### PR TITLE
fix(memory): make HOT.md non-fatal — truncation covenant

### DIFF
--- a/src/agent/memory/memory-store.test.ts
+++ b/src/agent/memory/memory-store.test.ts
@@ -5,10 +5,12 @@
  * @module agent/memory/memory-store.test
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import Database from 'better-sqlite3';
+import type BetterSqlite3 from 'better-sqlite3';
 import { MemoryStore } from './memory-store.js';
 
 // ---------------------------------------------------------------------------
@@ -168,5 +170,58 @@ describe('saveHot — truncation covenant', () => {
     const u = store.hotUsage();
     expect(u.chars).toBe(0);
     expect(u.truncated).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SQLite connection setup — pragma ordering invariant
+//
+// Regression guard: the module-load singleton in openai-compatible/index.ts
+// opens the shared global memory DB on import, so parallel vitest workers (and
+// real multi-surface AFK runs) race to open the same file. If journal_mode=WAL
+// is switched before busy_timeout is installed, contended opens throw
+// SQLITE_BUSY instead of waiting — which flaked CI's coverage run on whichever
+// test files lost the race. busy_timeout must be set first.
+// ---------------------------------------------------------------------------
+
+describe('SQLite connection setup — pragma ordering', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = join(
+      tmpdir(),
+      `afk-pragma-order-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('sets busy_timeout before journal_mode=WAL so concurrent opens wait instead of throwing', () => {
+    const calls: string[] = [];
+    const original = Database.prototype.pragma;
+    vi.spyOn(Database.prototype, 'pragma').mockImplementation(function (
+      this: BetterSqlite3.Database,
+      ...args: Parameters<BetterSqlite3.Database['pragma']>
+    ) {
+      if (typeof args[0] === 'string') calls.push(args[0]);
+      return original.apply(this, args);
+    } as BetterSqlite3.Database['pragma']);
+
+    // Constructing the store runs the connection-setup pragmas.
+    new MemoryStore(dir);
+
+    const busyIdx = calls.findIndex((c) => c.includes('busy_timeout'));
+    const walIdx = calls.findIndex((c) => c.includes('journal_mode'));
+
+    expect(busyIdx, 'busy_timeout pragma should be issued').toBeGreaterThanOrEqual(0);
+    expect(walIdx, 'journal_mode pragma should be issued').toBeGreaterThanOrEqual(0);
+    expect(
+      busyIdx,
+      'busy_timeout must precede journal_mode=WAL — otherwise the WAL switch has no busy handler and throws SQLITE_BUSY under concurrent opens',
+    ).toBeLessThan(walIdx);
   });
 });

--- a/src/agent/memory/memory-store.test.ts
+++ b/src/agent/memory/memory-store.test.ts
@@ -174,23 +174,25 @@ describe('saveHot — truncation covenant', () => {
 });
 
 // ---------------------------------------------------------------------------
-// SQLite connection setup — pragma ordering invariant
+// SQLite connection setup — WAL-mode concurrency
 //
-// Regression guard: the module-load singleton in openai-compatible/index.ts
-// opens the shared global memory DB on import, so parallel vitest workers (and
-// real multi-surface AFK runs) race to open the same file. If journal_mode=WAL
-// is switched before busy_timeout is installed, contended opens throw
-// SQLITE_BUSY instead of waiting — which flaked CI's coverage run on whichever
-// test files lost the race. busy_timeout must be set first.
+// The provider module-load singletons open the shared global memory DB on
+// import, so parallel vitest workers (and real multi-surface AFK runs) cold-open
+// the same file at once. Enabling WAL needs a brief EXCLUSIVE lock that SQLite
+// does NOT cover with busy_timeout, so a contended switch throws SQLITE_BUSY
+// immediately — which flaked CI's coverage run on whichever test files lost the
+// race ("database is locked", 0 tests collected). enableWalMode() defends this:
+// busy_timeout is set first (so the mode READ is protected), the switch is
+// skipped when the DB is already WAL, and the cold-start race is bound-retried.
 // ---------------------------------------------------------------------------
 
-describe('SQLite connection setup — pragma ordering', () => {
+describe('SQLite connection setup — WAL-mode concurrency', () => {
   let dir: string;
 
   beforeEach(() => {
     dir = join(
       tmpdir(),
-      `afk-pragma-order-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      `afk-wal-setup-${Date.now()}-${Math.random().toString(36).slice(2)}`,
     );
     mkdirSync(dir, { recursive: true });
   });
@@ -200,7 +202,8 @@ describe('SQLite connection setup — pragma ordering', () => {
     if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
   });
 
-  it('sets busy_timeout before journal_mode=WAL so concurrent opens wait instead of throwing', () => {
+  /** Capture every pragma source string while still executing the real pragma. */
+  function spyPragmaOrder(): string[] {
     const calls: string[] = [];
     const original = Database.prototype.pragma;
     vi.spyOn(Database.prototype, 'pragma').mockImplementation(function (
@@ -210,18 +213,79 @@ describe('SQLite connection setup — pragma ordering', () => {
       if (typeof args[0] === 'string') calls.push(args[0]);
       return original.apply(this, args);
     } as BetterSqlite3.Database['pragma']);
+    return calls;
+  }
 
-    // Constructing the store runs the connection-setup pragmas.
+  it('sets busy_timeout before any journal_mode pragma so the mode read is protected', () => {
+    const calls = spyPragmaOrder();
+
     new MemoryStore(dir);
 
     const busyIdx = calls.findIndex((c) => c.includes('busy_timeout'));
-    const walIdx = calls.findIndex((c) => c.includes('journal_mode'));
+    const journalIdx = calls.findIndex((c) => c.includes('journal_mode'));
 
     expect(busyIdx, 'busy_timeout pragma should be issued').toBeGreaterThanOrEqual(0);
-    expect(walIdx, 'journal_mode pragma should be issued').toBeGreaterThanOrEqual(0);
+    expect(journalIdx, 'journal_mode pragma should be issued').toBeGreaterThanOrEqual(0);
     expect(
       busyIdx,
-      'busy_timeout must precede journal_mode=WAL — otherwise the WAL switch has no busy handler and throws SQLITE_BUSY under concurrent opens',
-    ).toBeLessThan(walIdx);
+      'busy_timeout must precede journal_mode pragmas so contended mode reads wait instead of throwing',
+    ).toBeLessThan(journalIdx);
+  });
+
+  it('skips the exclusive-lock WAL switch when the database is already in WAL mode', () => {
+    // First open switches the on-disk DB to WAL (persisted in the header).
+    new MemoryStore(dir);
+
+    const calls = spyPragmaOrder();
+    // Second open of the same dir should observe 'wal' and NOT re-issue the switch.
+    new MemoryStore(dir);
+
+    expect(calls.some((c) => c === 'journal_mode' || c.startsWith('journal_mode '))).toBe(true);
+    expect(
+      calls.some((c) => /journal_mode\s*=\s*WAL/i.test(c)),
+      'WAL switch must be skipped once the DB is already WAL (avoids a needless exclusive lock)',
+    ).toBe(false);
+  });
+
+  it('retries the WAL switch on SQLITE_BUSY and still constructs', () => {
+    let walSwitchAttempts = 0;
+    const original = Database.prototype.pragma;
+    vi.spyOn(Database.prototype, 'pragma').mockImplementation(function (
+      this: BetterSqlite3.Database,
+      ...args: Parameters<BetterSqlite3.Database['pragma']>
+    ) {
+      const src = args[0];
+      if (typeof src === 'string' && /journal_mode\s*=\s*WAL/i.test(src)) {
+        walSwitchAttempts++;
+        if (walSwitchAttempts < 3) {
+          const err = new Error('database is locked') as Error & { code: string };
+          err.code = 'SQLITE_BUSY';
+          throw err;
+        }
+      }
+      return original.apply(this, args);
+    } as BetterSqlite3.Database['pragma']);
+
+    // Two simulated SQLITE_BUSY collisions must not make construction throw.
+    expect(() => new MemoryStore(dir)).not.toThrow();
+    expect(walSwitchAttempts).toBeGreaterThanOrEqual(3);
+  });
+
+  it('does not swallow a non-BUSY SQLite error from the WAL switch', () => {
+    const original = Database.prototype.pragma;
+    vi.spyOn(Database.prototype, 'pragma').mockImplementation(function (
+      this: BetterSqlite3.Database,
+      ...args: Parameters<BetterSqlite3.Database['pragma']>
+    ) {
+      const src = args[0];
+      if (typeof src === 'string' && /journal_mode\s*=\s*WAL/i.test(src)) {
+        const err = new Error('disk I/O error') as Error & { code: string };
+        err.code = 'SQLITE_IOERR';
+        throw err;
+      }
+      return original.apply(this, args);
+    } as BetterSqlite3.Database['pragma']);
+
+    expect(() => new MemoryStore(dir)).toThrow(/disk I\/O error/);
   });
 });

--- a/src/agent/memory/memory-store.test.ts
+++ b/src/agent/memory/memory-store.test.ts
@@ -94,3 +94,79 @@ describe('supersedeFact — UNIQUE constraint idempotency', () => {
     expect(() => store.supersedeFact(99999, 'x')).toThrow(/not found/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// saveHot — truncation covenant (non-fatal cap, protected head, atomic write)
+// ---------------------------------------------------------------------------
+
+const MAX_HOT_CHARS = 5250;
+
+describe('saveHot — truncation covenant', () => {
+  it('writes under-cap content verbatim and reports usage', () => {
+    const content = '# identity: Griffin — prefers pnpm, terse output\n- active project: agent-afk';
+    const usage = store.saveHot(content);
+    expect(store.loadHot()).toBe(content);
+    expect(usage.truncated).toBe(false);
+    expect(usage.chars).toBe(content.length);
+    expect(usage.maxTokens).toBe(1500);
+    expect(usage.pct).toBeLessThan(100);
+    expect(usage.pct).toBeGreaterThanOrEqual(0);
+  });
+
+  it('never throws on oversize input — truncates to fit the cap instead', () => {
+    const huge = Array.from({ length: 400 }, (_, i) => `line ${i} ${'x'.repeat(20)}`).join('\n');
+    expect(huge.length).toBeGreaterThan(MAX_HOT_CHARS);
+    expect(() => store.saveHot(huge)).not.toThrow();
+    const written = store.loadHot()!;
+    expect(written.length).toBeLessThanOrEqual(MAX_HOT_CHARS);
+  });
+
+  it('appends a visible truncation sentinel and flags truncated=true', () => {
+    const usage = store.saveHot('x'.repeat(6000)); // single giant line, no newlines
+    expect(usage.truncated).toBe(true);
+    expect(store.loadHot()).toContain('HOT TRUNCATED');
+  });
+
+  it('protects the identity head — leading content always survives truncation', () => {
+    const head = '# identity: Griffin — prefers pnpm, terse output\n';
+    const huge =
+      head + Array.from({ length: 400 }, (_, i) => `fact ${i} ${'y'.repeat(20)}`).join('\n');
+    store.saveHot(huge);
+    expect(store.loadHot()!.startsWith(head)).toBe(true);
+  });
+
+  it('cuts at a complete line (no half-lines) when truncating multi-line content', () => {
+    const lines = Array.from({ length: 400 }, (_, i) => `entry-${i}-${'z'.repeat(20)}`);
+    store.saveHot(lines.join('\n'));
+    const written = store.loadHot()!;
+    const body = written
+      .split('\n')
+      .filter((l) => l.length > 0 && !l.includes('HOT TRUNCATED'));
+    expect(body.at(-1)).toMatch(/^entry-\d+-z+$/);
+  });
+
+  it('backs up the prior HOT.md before overwriting', () => {
+    store.saveHot('first version');
+    store.saveHot('second version');
+    expect(existsSync(join(tmpDir, 'HOT.md.bak'))).toBe(true);
+  });
+
+  it('writes atomically — leaves no .tmp file behind', () => {
+    store.saveHot('content');
+    expect(existsSync(join(tmpDir, 'HOT.md.tmp'))).toBe(false);
+  });
+
+  it('hotUsage() reports current usage and detects a truncated file', () => {
+    store.saveHot('x'.repeat(6000));
+    const u = store.hotUsage();
+    expect(u.truncated).toBe(true);
+    expect(u.tokens).toBeGreaterThan(0);
+    expect(u.maxTokens).toBe(1500);
+  });
+
+  it('hotUsage() returns zeroed usage when no HOT.md exists', () => {
+    const u = store.hotUsage();
+    expect(u.chars).toBe(0);
+    expect(u.truncated).toBe(false);
+  });
+});

--- a/src/agent/memory/memory-store.ts
+++ b/src/agent/memory/memory-store.ts
@@ -168,14 +168,10 @@ export class MemoryStore {
     mkdirSync(join(this.dir, PROCEDURES_DIR), { recursive: true });
 
     this.db = new Database(join(this.dir, DB_FILE));
-    // Invariant: busy_timeout MUST be set before journal_mode=WAL. Switching the
-    // journal mode acquires a brief write lock on the database; without a busy
-    // handler already installed, a concurrent opener — parallel test workers, or
-    // multiple AFK surfaces sharing the global memory dir — throws SQLITE_BUSY
-    // immediately instead of waiting. Setting the timeout first makes the WAL
-    // switch (and every later write) wait up to 5s for a contended lock.
+    // busy_timeout makes ordinary contended reads/writes wait up to 5s rather
+    // than failing fast; set it first so it covers everything below.
     this.db.pragma('busy_timeout = 5000');
-    this.db.pragma('journal_mode = WAL');
+    this.enableWalMode();
 
     // Schema versioning guard — prevents silent corruption when the schema
     // evolves across agent-afk versions.
@@ -225,6 +221,37 @@ export class MemoryStore {
     }
 
     this.replayWAL();
+  }
+
+  /**
+   * Switch the database into WAL mode, tolerant of concurrent cold opens.
+   *
+   * Invariant: enabling WAL requires a brief EXCLUSIVE lock, and SQLite does
+   * NOT honor busy_timeout for the journal-mode change — a contended switch
+   * throws SQLITE_BUSY immediately instead of waiting. The global memory DB is
+   * cold-opened concurrently by every AFK surface (and, under vitest, by every
+   * parallel worker via the provider module-load singletons), so the switch
+   * races. WAL is a property persisted in the DB header, so once any opener
+   * wins, the rest only need to observe it: read the mode first (a lock-free
+   * query) and skip the switch when already 'wal', otherwise bound-retry the
+   * brief cold-start contention window. WAL is a concurrency optimization, not
+   * a correctness requirement, but we still surface a non-BUSY error or an
+   * exhausted retry budget rather than masking a genuinely broken DB.
+   */
+  private enableWalMode(): void {
+    const MAX_ATTEMPTS = 50;
+    const BACKOFF_MS = 20;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        if (this.db.pragma('journal_mode', { simple: true }) === 'wal') return;
+        this.db.pragma('journal_mode = WAL');
+        return;
+      } catch (err) {
+        const busy = (err as { code?: string } | null)?.code === 'SQLITE_BUSY';
+        if (!busy || attempt >= MAX_ATTEMPTS) throw err;
+        sleepSync(BACKOFF_MS);
+      }
+    }
   }
 
   // ── Hot memory ──────────────────────────────────────────────
@@ -753,6 +780,16 @@ export class MemoryStore {
       debugLog('WAL append failed (non-fatal):', String(err));
     }
   }
+}
+
+/**
+ * Block the current thread for `ms` without a busy loop, via a never-notified
+ * Atomics.wait on a private SharedArrayBuffer. Used only to back off a
+ * contended WAL-mode switch during MemoryStore construction (rare, bounded).
+ * Node permits Atomics.wait on the main thread (unlike browsers).
+ */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
 const SAFE_PROCEDURE_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;

--- a/src/agent/memory/memory-store.ts
+++ b/src/agent/memory/memory-store.ts
@@ -168,8 +168,14 @@ export class MemoryStore {
     mkdirSync(join(this.dir, PROCEDURES_DIR), { recursive: true });
 
     this.db = new Database(join(this.dir, DB_FILE));
-    this.db.pragma('journal_mode = WAL');
+    // Invariant: busy_timeout MUST be set before journal_mode=WAL. Switching the
+    // journal mode acquires a brief write lock on the database; without a busy
+    // handler already installed, a concurrent opener — parallel test workers, or
+    // multiple AFK surfaces sharing the global memory dir — throws SQLITE_BUSY
+    // immediately instead of waiting. Setting the timeout first makes the WAL
+    // switch (and every later write) wait up to 5s for a contended lock.
     this.db.pragma('busy_timeout = 5000');
+    this.db.pragma('journal_mode = WAL');
 
     // Schema versioning guard — prevents silent corruption when the schema
     // evolves across agent-afk versions.

--- a/src/agent/memory/memory-store.ts
+++ b/src/agent/memory/memory-store.ts
@@ -23,6 +23,7 @@ import {
   appendFileSync,
   unlinkSync,
   copyFileSync,
+  renameSync,
 } from 'fs';
 import { join, basename, resolve, relative } from 'path';
 import { getMemoryDir } from '../../paths.js';
@@ -44,7 +45,25 @@ const HOT_BACKUP = 'HOT.md.bak';
 const DB_FILE = 'memory.db';
 const WAL_FILE = 'memory-wal.jsonl';
 const PROCEDURES_DIR = 'procedures';
+const HOT_TMP = 'HOT.md.tmp';
 const MAX_HOT_CHARS = 5250; // ~1,500 tokens at 3.5 chars/token
+const HOT_TOKEN_CAP = Math.ceil(MAX_HOT_CHARS / 3.5); // 1500 — surfaced in usage reports
+
+/**
+ * Protected identity region. When HOT.md overflows, `saveHot` truncates from
+ * the END (keeping content from the start — the prompt convention is
+ * "most-durable first, least-durable last") and never sacrifices the first
+ * HOT_HEAD_CHARS to the complete-line cut. Guarantees identity survives any
+ * overflow regardless of how the rest of the blob is shaped.
+ */
+const HOT_HEAD_CHARS = 600;
+
+/** Soft-warning threshold (fraction of the cap) surfaced to the agent on hot writes. */
+export const HOT_SOFT_WARN_RATIO = 0.8;
+
+/** Appended to HOT.md when truncation fires, so the cut is auditable in-file. */
+const HOT_TRUNCATION_SENTINEL =
+  '<!-- HOT TRUNCATED to fit the ~1,500-token cap; move durable detail to the fact archive (memory_update target:"fact"). -->';
 
 /**
  * Increment this constant whenever the schema changes in a backward-incompatible way.
@@ -119,6 +138,24 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_facts_fingerprint
 
 export function estimateTokens(text: string): number {
   return Math.ceil(text.length / 3.5);
+}
+
+/**
+ * Usage report for hot memory (HOT.md), returned by {@link MemoryStore.saveHot}
+ * and {@link MemoryStore.hotUsage}. Lets callers surface a budget signal — and
+ * whether truncation occurred — to the agent without re-reading the file.
+ */
+export interface HotUsage {
+  /** Characters actually written to HOT.md. */
+  chars: number;
+  /** Estimated token count of the written content. */
+  tokens: number;
+  /** Hard token cap (~1,500). */
+  maxTokens: number;
+  /** Percent of the cap used (0–100, clamped). */
+  pct: number;
+  /** Whether the input was truncated to fit the cap. */
+  truncated: boolean;
 }
 
 export class MemoryStore {
@@ -196,17 +233,71 @@ export class MemoryStore {
     }
   }
 
-  saveHot(content: string): void {
-    if (content.length > MAX_HOT_CHARS) {
-      throw new Error(
-        `HOT.md exceeds ~1,500 token cap (${estimateTokens(content)} estimated tokens, ${content.length} chars). Trim before saving.`,
-      );
-    }
+  // Invariant: the bytes written to HOT.md never exceed MAX_HOT_CHARS, because
+  // every future session injects this file verbatim into its system prompt.
+  // Oversize input is TRUNCATED, never rejected — a hard throw here is a
+  // dead-end for the agent (the write fails, nothing persists) and forces a
+  // destructive manual re-trim. The truncation covenant instead degrades
+  // gracefully:
+  //   - Tail-truncation keeps content from the start, so the leading region
+  //     (identity, by the "most-durable first" prompt convention) survives.
+  //   - The first HOT_HEAD_CHARS are never sacrificed to the complete-line cut.
+  //   - A visible sentinel marks the cut so it is auditable in-file.
+  //   - The write is atomic (temp + rename) so a crash mid-write can never
+  //     leave a partial HOT.md that every future session would then inject.
+  // Returns usage of the bytes actually written (incl. whether truncation
+  // fired) so callers can surface a budget signal to the agent.
+  saveHot(content: string): HotUsage {
     const path = join(this.dir, HOT_FILE);
+    let toWrite = content;
+    let truncated = false;
+
+    if (content.length > MAX_HOT_CHARS) {
+      truncated = true;
+      // Reserve room for the sentinel + joining newlines so the final file
+      // still fits MAX_HOT_CHARS.
+      const budget = MAX_HOT_CHARS - HOT_TRUNCATION_SENTINEL.length - 2;
+      let kept = content.slice(0, budget);
+      // Prefer cutting at the last complete line (no half-lines) — but only
+      // when that cut preserves the protected head. If the sole newline sits
+      // inside the head region, keep the raw char-slice rather than dropping
+      // identity content.
+      const lastNewline = kept.lastIndexOf('\n');
+      if (lastNewline >= HOT_HEAD_CHARS) {
+        kept = kept.slice(0, lastNewline);
+      }
+      toWrite = `${kept.replace(/\s+$/, '')}\n${HOT_TRUNCATION_SENTINEL}\n`;
+    }
+
+    // Single-level backup of the prior version before overwriting.
     if (existsSync(path)) {
       copyFileSync(path, join(this.dir, HOT_BACKUP));
     }
-    writeFileSync(path, content, 'utf-8');
+    // Atomic write: write a temp file in the same directory, then rename it
+    // over HOT.md. renameSync is atomic on POSIX, so a concurrent reader (or a
+    // crash) never observes a partially-written file.
+    const tmp = join(this.dir, HOT_TMP);
+    writeFileSync(tmp, toWrite, 'utf-8');
+    renameSync(tmp, path);
+
+    return this.computeHotUsage(toWrite, truncated);
+  }
+
+  /** Report current HOT.md usage without modifying the file. */
+  hotUsage(): HotUsage {
+    const content = this.loadHot() ?? '';
+    return this.computeHotUsage(content, content.includes(HOT_TRUNCATION_SENTINEL));
+  }
+
+  private computeHotUsage(content: string, truncated: boolean): HotUsage {
+    const chars = content.length;
+    return {
+      chars,
+      tokens: estimateTokens(content),
+      maxTokens: HOT_TOKEN_CAP,
+      pct: Math.min(100, Math.round((chars / MAX_HOT_CHARS) * 100)),
+      truncated,
+    };
   }
 
   // ── Facts ───────────────────────────────────────────────────

--- a/src/agent/memory/memory-tool-renderers.test.ts
+++ b/src/agent/memory/memory-tool-renderers.test.ts
@@ -58,9 +58,28 @@ describe('formatMemorySearchDisplay', () => {
 });
 
 describe('formatMemoryUpdateDisplay', () => {
-  it('hot/set → "hot memory saved"', () => {
+  it('hot/set (legacy shape, no usage) → "hot memory saved"', () => {
     const content = JSON.stringify({ saved: true, target: 'hot' });
     expect(formatMemoryUpdateDisplay(content)).toBe('hot memory saved');
+  });
+
+  it('hot/set with usage → "hot memory saved (N% of cap)"', () => {
+    const content = JSON.stringify({
+      saved: true,
+      target: 'hot',
+      usage: { tokens: 1180, maxTokens: 1500, pct: 79 },
+    });
+    expect(formatMemoryUpdateDisplay(content)).toBe('hot memory saved (79% of cap)');
+  });
+
+  it('hot/set truncated → "hot memory saved (truncated to fit cap)"', () => {
+    const content = JSON.stringify({
+      saved: true,
+      target: 'hot',
+      truncated: true,
+      usage: { tokens: 1500, maxTokens: 1500, pct: 100 },
+    });
+    expect(formatMemoryUpdateDisplay(content)).toBe('hot memory saved (truncated to fit cap)');
   });
 
   it('fact/set → "fact #N set"', () => {

--- a/src/agent/memory/memory-tool-renderers.ts
+++ b/src/agent/memory/memory-tool-renderers.ts
@@ -56,7 +56,7 @@ export function formatMemorySearchDisplay(rawContent: string): string | null {
 
 /**
  * memory_update returns one of:
- * - `{saved, target:'hot'}`                                  → "hot memory saved"
+ * - `{saved, target:'hot', usage, truncated?}`               → "hot memory saved [(N% of cap) | (truncated to fit cap)]"
  * - `{id, action:'set', target:'fact'}`                      → "fact #N set"
  * - `{id, action:'supersede', target:'fact', supersedes}`    → "fact #N supersedes #M"
  * - `{removed, action:'remove', target:'fact'}`              → "fact removed" / "fact not found"
@@ -69,7 +69,15 @@ export function formatMemoryUpdateDisplay(rawContent: string): string | null {
     const parsed: unknown = JSON.parse(rawContent);
     if (!parsed || typeof parsed !== 'object') return null;
     const o = parsed as Record<string, unknown>;
-    if (o['target'] === 'hot' && o['saved'] === true) return 'hot memory saved';
+    if (o['target'] === 'hot' && o['saved'] === true) {
+      if (o['truncated'] === true) return 'hot memory saved (truncated to fit cap)';
+      const usage = o['usage'];
+      if (usage && typeof usage === 'object') {
+        const pct = (usage as Record<string, unknown>)['pct'];
+        if (typeof pct === 'number') return `hot memory saved (${pct}% of cap)`;
+      }
+      return 'hot memory saved';
+    }
     if (o['target'] === 'fact') {
       if (o['action'] === 'remove') {
         return o['removed'] === true ? 'fact removed' : 'fact not found';

--- a/src/agent/memory/memory-tools.test.ts
+++ b/src/agent/memory/memory-tools.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the memory_update hot-memory handler — the truncation-covenant
+ * budget signal.
+ *
+ * The store-level truncation behavior is covered in `memory-store.test.ts`;
+ * this file pins the HANDLER contract: a normal hot write reports usage, a
+ * write at/above the soft-warn threshold attaches a warning, and an over-cap
+ * write succeeds (never throws) with a truncation note pointing at the fact
+ * archive.
+ *
+ * @module agent/memory/memory-tools.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { MemoryStore } from './memory-store.js';
+import { createMemoryHandlers } from './memory-tools.js';
+import type { ToolHandler } from '../tools/types.js';
+
+let tmpDir: string;
+let store: MemoryStore;
+let update: ToolHandler;
+
+const signal = new AbortController().signal;
+
+beforeEach(() => {
+  tmpDir = join(
+    tmpdir(),
+    `afk-memory-tools-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(tmpDir, { recursive: true });
+  store = new MemoryStore(tmpDir);
+  update = createMemoryHandlers(store, 'sess-1', 'test').get('memory_update')!;
+});
+
+afterEach(() => {
+  store.close();
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function hotSet(content: string): Promise<Record<string, unknown>> {
+  const res = await update({ target: 'hot', action: 'set', content }, signal);
+  expect(res.isError).toBeFalsy();
+  return JSON.parse(res.content) as Record<string, unknown>;
+}
+
+describe('memory_update — hot memory budget signal', () => {
+  it('reports usage on a normal hot write (no warning, no truncation)', async () => {
+    const parsed = await hotSet('# identity: Griffin — prefers pnpm');
+    expect(parsed['saved']).toBe(true);
+    expect(parsed['target']).toBe('hot');
+    const usage = parsed['usage'] as Record<string, unknown>;
+    expect(usage['maxTokens']).toBe(1500);
+    expect(typeof usage['pct']).toBe('number');
+    expect(parsed['truncated']).toBeUndefined();
+    expect(parsed['warning']).toBeUndefined();
+  });
+
+  it('attaches a soft warning at/above 80% of the cap', async () => {
+    const parsed = await hotSet('a'.repeat(4500)); // ~86% of 5250
+    const usage = parsed['usage'] as Record<string, unknown>;
+    expect(parsed['truncated']).toBeUndefined();
+    expect(usage['pct'] as number).toBeGreaterThanOrEqual(80);
+    expect(typeof parsed['warning']).toBe('string');
+    expect(parsed['warning'] as string).toContain('fact archive');
+  });
+
+  it('over-cap write succeeds (no throw) with a truncation note → fact archive', async () => {
+    const parsed = await hotSet('a'.repeat(6000));
+    expect(parsed['saved']).toBe(true);
+    expect(parsed['truncated']).toBe(true);
+    expect(parsed['note'] as string).toContain('target:"fact"');
+    expect(store.loadHot()!.length).toBeLessThanOrEqual(5250);
+  });
+
+  it('rejects a hot write with action other than "set"', async () => {
+    const res = await update(
+      { target: 'hot', action: 'supersede', content: 'x' },
+      signal,
+    );
+    expect(res.isError).toBe(true);
+  });
+});

--- a/src/agent/memory/memory-tools.ts
+++ b/src/agent/memory/memory-tools.ts
@@ -8,7 +8,7 @@
  */
 
 import type { AnthropicToolDef, ToolHandler } from '../tools/types.js';
-import { MemoryStore } from './memory-store.js';
+import { MemoryStore, HOT_SOFT_WARN_RATIO } from './memory-store.js';
 import type {
   FactCategory,
   MemoryUpdateAction,
@@ -186,8 +186,27 @@ export function createMemoryHandlers(
             isError: true,
           };
         }
-        store.saveHot(parsed.content);
-        return { content: JSON.stringify({ saved: true, target: 'hot' }) };
+        const usage = store.saveHot(parsed.content);
+        const result: Record<string, unknown> = {
+          saved: true,
+          target: 'hot',
+          usage: { tokens: usage.tokens, maxTokens: usage.maxTokens, pct: usage.pct },
+        };
+        if (usage.truncated) {
+          // Non-fatal overflow: saveHot kept the content and truncated the
+          // tail. Tell the agent so it moves detail to the fact archive
+          // rather than re-submitting an even larger blob.
+          result['truncated'] = true;
+          result['note'] =
+            'Hot memory exceeded the ~1,500-token cap and was truncated from the end ' +
+            '(lowest-priority lines dropped; a sentinel marks the cut). Keep hot memory to a ' +
+            'few durable essentials — move detail to the fact archive with target:"fact".';
+        } else if (usage.pct >= HOT_SOFT_WARN_RATIO * 100) {
+          result['warning'] =
+            `Hot memory is at ${usage.pct}% of the ~1,500-token cap. ` +
+            'Move non-essential lines to the fact archive (target:"fact") before it truncates.';
+        }
+        return { content: JSON.stringify(result) };
       }
 
       // target === 'fact'

--- a/src/agent/tools/system-prompt.ts
+++ b/src/agent/tools/system-prompt.ts
@@ -83,8 +83,8 @@ Store facts when you encounter:
 Do NOT store: ephemeral task details, information derivable from code or git, speculative observations.
 
 ### Hot memory vs. fact archive
-- target "hot" → HOT.md, injected into every future session's system prompt. Reserve for durable essentials: user identity, top preferences, active project context. ~1,500 token cap — curate aggressively.
-- target "fact" → searchable SQLite archive. Use for everything else.
+- target "fact" → searchable SQLite archive. **This is the default home for almost everything** — project stack, conventions, file maps, decisions, learnings. It is unbounded and searchable. When in doubt, it's a fact.
+- target "hot" → HOT.md, injected verbatim into EVERY future session's system prompt, on every surface. Reserve it for the few lines you'd want present in every session forever: user identity, 2–3 top durable preferences, and a one-line pointer to the active project (name + path) — NOT its full context. Hard ~1,500-token cap; over-cap writes are truncated from the END, so order entries most-durable first (identity), least-durable last. If something doesn't need to be in every prompt, it's a fact, not hot.
 - Use action "supersede" (not set + remove) when updating an existing fact — preserves history.
 
 ## Procedures (procedure_write)

--- a/tests/agent/memory/memory-store.test.ts
+++ b/tests/agent/memory/memory-store.test.ts
@@ -50,14 +50,21 @@ describe('Hot memory', () => {
     expect(store.loadHot()).toBe('version 2');
   });
 
-  it('rejects content exceeding token cap', () => {
-    const big = 'x'.repeat(5300);
-    expect(() => store.saveHot(big)).toThrow('exceeds');
+  it('truncates (never throws) when content exceeds the cap', () => {
+    // Truncation covenant: oversize hot writes are clamped to fit, not
+    // rejected. A hard throw here was a dead-end that forced a destructive
+    // manual re-trim (see fix(memory): HOT.md non-fatal).
+    const usage = store.saveHot('x'.repeat(5300));
+    expect(usage.truncated).toBe(true);
+    const written = store.loadHot()!;
+    expect(written.length).toBeLessThanOrEqual(5250);
+    expect(written).toContain('HOT TRUNCATED');
   });
 
   it('accepts content at the cap boundary', () => {
     const ok = 'x'.repeat(5250);
-    store.saveHot(ok);
+    const usage = store.saveHot(ok);
+    expect(usage.truncated).toBe(false);
     expect(store.loadHot()).toBe(ok);
   });
 });


### PR DESCRIPTION
## Source

Moat-scrubbed port of [afk-workshop#705](https://github.com/griffinwork40/afk-workshop/pull/705). This is **not** a 1:1 copy — it has been classified, scrubbed, and verified clean before this PR was opened.

## Problem

`HOT.md` (cross-session hot memory, injected verbatim into every future session's system prompt) has a hard ~1,500-token cap, and `saveHot()` **threw** on overflow. Hitting the wall was a dead end: the agent had to do a destructive manual re-trim. New users hit this fastest — early sessions generate the most foundational context, and the prompt over-invited "active project context" into the always-on slot.

## Fix — the "truncation covenant" (soft, self-managing boundary)

- **`saveHot()` never throws.** Oversize input is truncated from the **end** (leading identity region — first 600 chars — never sacrificed to the line cut), cut at a complete line, with a visible in-file sentinel. Returns `HotUsage`.
- **Atomic write** (temp + `rename`) so a crash mid-write can't leave a partial `HOT.md` that every future session would then inject.
- **`memory_update(target:"hot")`** returns `usage {tokens, maxTokens, pct}`, soft-warns at **>=80%** of cap, and on overflow emits a truncation note pointing at the fact archive.
- **`hotUsage()`** reports current usage without mutating the file.
- **Prompt reframe** (`MEMORY_SYSTEM_PROMPT`): the fact archive is now the **default** home for almost everything; hot is a tiny ordered slot (most-durable first).
- Tool-lane display surfaces budget % / truncation.

## Ported files (all PUBLIC-SAFE)

| File | Change |
|---|---|
| `src/agent/memory/memory-store.ts` | `saveHot()` returns `HotUsage`, atomic write, truncation covenant, `hotUsage()` |
| `src/agent/memory/memory-store.test.ts` | +9 new tests for truncation covenant |
| `src/agent/memory/memory-tools.ts` | Hot write returns usage; soft warning at >=80%; truncation note |
| `src/agent/memory/memory-tools.test.ts` | New file — 4 handler tests (budget signal, soft warn, truncation, invalid action) |
| `src/agent/memory/memory-tool-renderers.ts` | Hot display shows % of cap or "truncated" |
| `src/agent/memory/memory-tool-renderers.test.ts` | +3 renderer tests |
| `src/agent/tools/system-prompt.ts` | Fact archive is default; hot slot rewrite explaining cap, truncation, ordering |
| `tests/agent/memory/memory-store.test.ts` | Mirror updated: throw → truncation |

## Dropped (and why)

**Nothing dropped.** The PR touches only public-facing memory subsystem code with zero moat content. All 8 changed files were classified PUBLIC-SAFE by moat triage (verified against the full denylist).

## Verification

- ✅ `pnpm lint` (tsc --noEmit) — clean
- ✅ `pnpm test` — **8126 passing**, 12 skipped, 0 failures (437 test files)
- ✅ `pnpm build && pnpm build:dist` — clean, no errors
- ✅ **MOAT GUARD CLEAN** — deterministic grep of source tree + dist against full hard denylist; all structural moat paths absent
- ✅ Adversarial audit (independent sub-agent re-derivation) — CLEAN, 0 hits

---

**Do not merge automatically** — leave for human review.