### PR TITLE
fix(cli): anchor flat-leaf tool roots with col-0 ◉ beside a nesting root

### DIFF
--- a/src/cli/commands/interactive/tool-lane-root-anchor.test.ts
+++ b/src/cli/commands/interactive/tool-lane-root-anchor.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression: flat-leaf ROOT tools (main-session calls, agentContext=undefined)
+ * dispatched alongside a NESTING root (skill / Agent / compose) must anchor
+ * their own col-0 ◉ turn-root marker in the LIVE OVERLAY.
+ *
+ * The reported bug (screenshot shape): a subagent block renders with a `│`
+ * spine at col 0 and connectors at col 2; three main-session `read_file` calls
+ * dispatched afterward rendered at a bare 2-space lead, placing their `●` glyph
+ * at col 2 — directly under the subagent's connector column with NOTHING in
+ * col 0. The eye read them as severed / orphaned nodes that "fell out" of the
+ * subagent tree.
+ *
+ * Fix: when the overlay mixes a NESTING root with flat-leaf roots, the flat
+ * roots anchor col-0 with ◉ (the same marker the dispatch head uses). The
+ * `│ → ◉` transition at col 0 is an honest "spine ended, new root begins"
+ * signal. A pure flat-leaf turn keeps the clean 2-space lead — no spine to
+ * collide with, so the marker would be gratuitous.
+ */
+import { describe, it, expect } from 'vitest';
+import { ToolLane } from './tool-lane.js';
+import { stripAnsi } from '../../display.js';
+import type { ToolResultChunk } from '../../../agent/types/message-types.js';
+
+function makeResult(content: string, isError = false): ToolResultChunk {
+  return { type: 'tool_result', toolUseId: 'unused', content, isError };
+}
+
+describe('flat-leaf root anchoring (turn-root ◉ when mixed with a NESTING root)', () => {
+  it('overlay: flat read_file roots anchor col-0 ◉ when a subagent block is present', () => {
+    const lane = new ToolLane();
+    // NESTING root (skill) with a completed child → renders a spine in the overlay.
+    lane.addStartWithAgentContext('skill', 'skill', '(hero-migration)', undefined);
+    lane.addStartWithAgentContext('mem', 'memory_search', '("landing page")', 'skill');
+    lane.addResult('mem', makeResult('1 result'));
+    // Main-session flat-leaf roots dispatched AFTER the subagent block.
+    lane.addStartWithAgentContext('r1', 'read_file', '("Terminal.tsx")', undefined);
+    lane.addStartWithAgentContext('r2', 'read_file', '("Hero.tsx")', undefined);
+
+    const rows = stripAnsi(lane.getOverlay()).split('\n');
+    const readRows = rows.filter((l) => l.includes('read_file'));
+    expect(readRows.length, `dump:\n${rows.join('\n')}`).toBe(2);
+    for (const row of readRows) {
+      // Anchored: row begins with the turn-root marker at col 0, NOT a blank lead.
+      expect(
+        row.startsWith('◉ '),
+        `read_file root not ◉-anchored:\n${JSON.stringify(row)}\nfull:\n${rows.join('\n')}`,
+      ).toBe(true);
+    }
+
+    // Sanity: the subagent's child still carries the `│` spine at col 0, so the
+    // `│ → ◉` transition the fix relies on is actually present.
+    const memRow = rows.find((l) => l.includes('memory_search'))!;
+    expect(memRow[0], `subagent child should carry a col-0 spine\n${rows.join('\n')}`).toBe('│');
+  });
+
+  it('overlay: a single flat read_file root anchors ◉ alongside an Agent dispatch', () => {
+    const lane = new ToolLane();
+    lane.addStartWithAgentContext('agent', 'Agent', '(researcher)', undefined);
+    lane.addStartWithAgentContext('grep', 'grep', '("pattern")', 'agent');
+    lane.addStartWithAgentContext('r1', 'read_file', '("Hero.tsx")', undefined);
+
+    const rows = stripAnsi(lane.getOverlay()).split('\n');
+    const readRow = rows.find((l) => l.includes('read_file'))!;
+    expect(readRow, `dump:\n${rows.join('\n')}`).toBeDefined();
+    expect(readRow.startsWith('◉ '), `read_file root not ◉-anchored:\n${JSON.stringify(readRow)}`).toBe(true);
+  });
+
+  it('overlay: flat read_file roots keep the clean 2-space lead when NO subagent present', () => {
+    const lane = new ToolLane();
+    lane.addStartWithAgentContext('r1', 'read_file', '("a.ts")', undefined);
+    lane.addStartWithAgentContext('r2', 'read_file', '("b.ts")', undefined);
+    lane.addResult('r1', makeResult('10 lines'));
+
+    const rows = stripAnsi(lane.getOverlay()).split('\n');
+    const readRows = rows.filter((l) => l.includes('read_file'));
+    expect(readRows.length, `dump:\n${rows.join('\n')}`).toBe(2);
+    for (const row of readRows) {
+      expect(
+        row.startsWith('◉ '),
+        `clean flat-only turn should NOT anchor ◉:\n${JSON.stringify(row)}`,
+      ).toBe(false);
+      expect(
+        row.startsWith('  '),
+        `clean flat root should keep the 2-space lead:\n${JSON.stringify(row)}`,
+      ).toBe(true);
+    }
+  });
+});

--- a/src/cli/commands/interactive/tool-lane.ts
+++ b/src/cli/commands/interactive/tool-lane.ts
@@ -304,6 +304,27 @@ export class ToolLane {
       visibleRoots = rootEntries.filter((e) => !e.result || visibleDoneSet.has(e));
     }
 
+    // Invariant: when the overlay mixes a NESTING root (skill / Agent / compose
+    // — each anchors a col-0 ◉ turn-root marker and a descendant spine drawn at
+    // col 0 by renderOverlayChildren) with flat-leaf roots, the flat roots must
+    // ALSO anchor their own col-0 ◉. A flat leaf's bare 2-space lead places its
+    // `●` glyph at col 2 (the NESTING block's depth-1 connector column) with a
+    // BLANK col 0 — so a main-session read_file dispatched after a subagent
+    // renders directly below a `│` spine with nothing in col 0, reading as a
+    // severed / orphaned node that "fell out" of the subagent tree. Anchoring
+    // col 0 with ◉ turns the `│ → ◉` transition into an honest "spine ended,
+    // new root begins" signal, making every root unambiguously parallel to the
+    // dispatch head. A pure flat-leaf turn (no NESTING root) keeps the clean
+    // 2-space lead — there is no spine to collide with, so the marker would be
+    // gratuitous noise on the common case. Mirrors the "each root anchors its
+    // own col-0 ◉ / blank marker" note in tool-lane-render-children.ts. The
+    // scrollback commit path groups same-tool flat roots into one labeled
+    // `×N` line (renderGroupedRootTools), which is not orphan-prone, so it is
+    // intentionally left at the 2-space lead — only the live overlay renders
+    // flat roots as separate rows that can collide with a sibling spine.
+    const hasNestingRoot = visibleRoots.some((e) => NESTING_TOOLS.has(e.toolName));
+    const flatRootLead = hasNestingRoot ? palette.dim(g.turnRoot) : '  ';
+
     for (const entry of visibleRoots) {
       const children = childMap.get(entry.toolUseId);
 
@@ -434,7 +455,7 @@ export class ToolLane {
         }
       } else {
         if (entry.result) {
-          lines.push(clamp('  ' + entry.prefix + palette.dim(' — ') + doneGlyph(entry.result.isError) + ' ' + formatOutcome(entry.result, undefined, 60, entry.toolName)));
+          lines.push(clamp(flatRootLead + entry.prefix + palette.dim(' — ') + doneGlyph(entry.result.isError) + ' ' + formatOutcome(entry.result, undefined, 60, entry.toolName)));
           if (entry.diff && !entry.result.isError) {
             // Diff hangs under the outcome line, indented one level deeper
             // (4 spaces) so it visually attaches to this tool entry.
@@ -443,7 +464,7 @@ export class ToolLane {
             }
           }
         } else {
-          lines.push(clamp('  ' + entry.prefix + palette.dim(' …')));
+          lines.push(clamp(flatRootLead + entry.prefix + palette.dim(' …')));
           if (entry.thinkingTail) {
             // Childless Agent entries (a child just opened its thinking block
             // and hasn't yet emitted content or a tool_use) get the tail right


### PR DESCRIPTION
## Source

Port of **[afk-workshop#711](https://github.com/griffinwork40/afk-workshop/pull/711)** — moat-scrubbed, not a 1:1 copy.

## Summary

Fixes a visual bug in the live tool-lane overlay: a flat-leaf root (main-session `read_file`, etc.) dispatched after a subagent/skill/compose block rendered at a bare 2-space lead, placing its glyph in the nesting block's depth-1 connector column with a **blank col 0** — reading as a severed node that "fell out" of the subagent tree.

When the overlay mixes a **nesting root** (`skill` / `Agent` / `compose`) with flat-leaf roots, flat roots now anchor their own col-0 `◉` turn-root marker. The `│ → ◉` transition becomes an honest "spine ended, new root begins" signal. Pure flat-leaf turns (no nesting root) keep the clean 2-space lead.

## Ported

| File | Change |
|------|--------|
| `src/cli/commands/interactive/tool-lane.ts` | Modified — adds `hasNestingRoot` / `flatRootLead` guard (21 lines added, 2 changed) |
| `src/cli/commands/interactive/tool-lane-root-anchor.test.ts` | New — 3 regression tests (mixed-root anchoring, single-root-with-Agent, flat-only negative case) |

## Dropped

Nothing dropped — both files are public-safe with zero moat content. Moat triage confirmed: no HARD denylist terms, no structural moat, no private identifiers in any hunk.

## Verification

- **Lint (`tsc --noEmit`):** ✅ exit 0
- **Tests (`pnpm test`):** ✅ 437 files / 8115 passed / 12 skipped — all green including 3/3 new tests
- **Build (`pnpm build && pnpm build:dist`):** ✅ clean
- **Moat guard (4b):** ✅ `MOAT GUARD CLEAN`
- **Adversarial audit (4c):** ✅ independent sub-agent found zero moat in tree + dist

## Do not merge automatically

Leave for human review.