### PR TITLE
feat(skills): flip gather + parallelize to context: load

### DIFF
--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -38,7 +38,12 @@ const PINNED_HASHES = {
   contract: '0b7febafec024e8dd4404f75e84d21ee72b1b1846d6e2610aaa82ba77f9d6f2d',
   'devils-advocate':
     '84275b097fa3ed270b0b71c87e2dad0366794fd7efc7a47d29abaa85da97f974',
-  gather: 'ec2964fb1f47970fffba6bafacb4dc4f0c76291a7cc0da92ff069a0a986decb4',
+  // gather + parallelize carry a bundled-only `context: load` frontmatter line
+  // (2026-06 skill-execution-mode work). `context` is an agent-afk-specific
+  // field; Claude Code upstream skills are natively inline/progressive-disclosure,
+  // so there is NO upstream counterpart to back-port — permanent bundled-only
+  // divergence (allowlisted in INTENTIONAL_DIFFS below). See docs/skill-load-mode.md.
+  gather: '26ef18dde7db7c313655b0fe3097f14966763298ff5a2fe643ccf18d0f6b29c0',
   'ground-claim':
     'd877c1e7de08ecb8788677f6a8f3b51f5d48cefefbf4019af2e37ac1484a95bb',
   'ground-state':
@@ -48,8 +53,9 @@ const PINNED_HASHES = {
   // commit message instead.
   'intent-lock':
     '7a466075e5a64c1145b97aa24b9a6990a3ee1dc818b93c158433e53d7416aef0',
+  // parallelize: bundled-only `context: load` added — see the gather note above.
   parallelize:
-    '74b1a7cf866d630dce0d33323663a8b818f149b5f4d4ef60feba1aeb3472e49b',
+    'be8b2a301fe35d86d96d4be6f8418bf497dd9050767a3837cf057d7d5a1cd719',
   // refactor is bundled-only (no upstream example-plugin counterpart); verbatim
   // copy of the user-scope /refactor at ~/.afk/skills/.
   refactor: '23ab4836653159deeafbca45e516af8d43e8c5275535613e36f7bcb2d77de64e',
@@ -148,12 +154,19 @@ const INTENTIONAL_DIFFS: Partial<Record<SkillName, RegExp[]>> = {
     // skill namespace on bundled vs upstream.
     /^\/contract$/,
     /\/agent-workflow-amplifiers:contract/,
+    // Bundled-only agent-afk execution-mode field (no upstream equivalent —
+    // Claude Code skills are natively inline). See docs/skill-load-mode.md.
+    /^context: load$/,
   ],
   'shadow-verify': [
     // Same structural divergence as devils-advocate.
     /^\/contract$/,
     /\/agent-workflow-amplifiers:contract/,
   ],
+
+  // gather: bundled-only `context: load` execution-mode field (no upstream
+  // equivalent — Claude Code skills are natively inline). See docs/skill-load-mode.md.
+  gather: [/^context: load$/],
 
   // research — 1-line divergence, #441 back-port gap:
   //   "if the research-agent is not available" (bundled) vs

--- a/src/bundled-plugins/awa-bundled/skills/gather/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/gather/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: gather
 description: "Parallel context-gathering for a code area. Use when you need to understand a module, feature, or subsystem and would otherwise read 3+ files sequentially — dispatches two agents in parallel to map structure and test coverage in one wave."
+context: load
 ---
 
 ## Dispatch protocol

--- a/src/bundled-plugins/awa-bundled/skills/parallelize/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/parallelize/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: parallelize
 description: "When finished creating the plan in plan mode, run /parallelize so Claude dispatches one planning agent to transform the current approach into a plan to orchestrate waves of parallel sub-agents."
+context: load
 ---
 
 ## Sub-agent contract


### PR DESCRIPTION
## Summary

Flip the two context-hungry bundled orchestration skills — `gather` and `parallelize` — to in-context (`context: load`) execution.

## Why

In `fork` mode a skill's forked sub-agent receives **only** `{ system prompt = SKILL.md body, first user message = the args string }` — **no conversation history**:
- `skill-executor.ts` passes the args string as the sole user message;
- `subagent.ts` never sets `resumeHistory`;
- the provider seeds messages only from `resumeHistory`, and the raw Messages API is stateless.

So a forked `gather`/`parallelize` knows only a lossy args string — not the files just discussed or the actual nuance of the task. `context: load` injects the body into the **current** agent, which holds the full conversation, so it authors richly-contextualized sub-agent prompts. `parallelize` is the sharpest case: it operates on "the current plan," which a forked planner cannot see.

## What changed

- `gather/SKILL.md`, `parallelize/SKILL.md`: add `context: load` (frontmatter only — the minimal flip).
- `bundled.test.ts`: bump the two pinned hashes; add `context: load` to `INTENTIONAL_DIFFS` for both. **Bundled-only** divergence — `context` is an agent-afk runtime field; the `example-plugin` upstream skills are natively inline, so there is nothing to back-port.

## Verification

- `bundled.test.ts`: 15 passed / 11 skipped (drift comparisons skip — `example-plugin` not co-located).
- `pnpm lint` (`tsc --noEmit`): clean.

See `docs/skill-load-mode.md` for the execution-mode model (`inline` / `fork` / `load`).
