### PR TITLE
feat(skills): flip default skill execution from fork to load

### DIFF
--- a/docs/skill-load-mode.md
+++ b/docs/skill-load-mode.md
@@ -2,6 +2,21 @@
 
 Status: implemented (v1). Scope-frozen 2026-06-01.
 
+> **Amendment 2026-06 — load-by-default for frontmatter skills.** The default
+> execution mode for **plugin** SKILL.md skills and **user/project disk**
+> skills (`~/.afk/skills/`, `<cwd>/.afk/skills/`) flipped from `fork` → `load`:
+> a frontmatter skill now runs in-context unless it explicitly declares
+> `context: fork`. Built-in TS registry skills are unaffected — they still
+> default to `inline` (their handler is the orchestrator). Bundled skills that
+> must return an **epistemically independent** result, or keep heavy
+> intermediate work out of the main context, are pinned to `context: fork`
+> (`research`, `ground-state`, `shadow-verify`, `review`, `simplify`,
+> `refactor`, `ship`, `spec`). Skills that orchestrate *from* the current agent
+> and feed their result back into the caller's decision stay `load`
+> (`gather`, `parallelize`, `devils-advocate`), as do the zero-dispatch
+> **guard** skills (`ground-claim`, `intent-lock`). See the "Defaults" section
+> below.
+
 ## Why this exists
 
 agent-afk runs on the raw Messages API, not the Claude Code harness. The
@@ -16,9 +31,11 @@ disclosure).
 
 | Mode | Mechanic | Context | Analogue |
 |------|----------|---------|----------|
-| `inline` (default) | run the TS `handler` in-process | current process | orchestrator skills (mint, forge, diagnose, audit-fit, score) |
-| `fork` | fork a subagent with `prompts/system.md` as its system prompt | **isolated** child | Claude Code `Agent`/`Task` (delegation) |
+| `inline` | run the TS `handler` in-process | current process | orchestrator skills (mint, forge, diagnose, audit-fit, score) |
+| `fork` | fork a subagent with `prompts/system.md` / SKILL.md body as its system prompt | **isolated** child | Claude Code `Agent`/`Task` (delegation) |
 | `load` | return `prompts/system.md` / SKILL.md body as the tool result; the **current** agent executes it with its existing tools | **current** session | Claude Code inline Skill (progressive disclosure) |
+
+Defaults differ by skill kind — see the [Defaults](#defaults) section.
 
 ## How `load` works
 
@@ -50,18 +67,86 @@ registerSkill({
 // requires src/skills/my-skill/prompts/system.md
 ```
 
-Plugin (`SKILL.md` frontmatter):
+Plugin / user / project disk (`SKILL.md` frontmatter) — `load` is the default,
+so the `context:` line is optional:
 
 ```markdown
 ---
 name: my-skill
 description: …
-context: load
+# context: load   # optional — load is the default for frontmatter skills
 ---
-Your in-context operating procedure. May reference $ARGUMENTS.
+Your in-context operating procedure. May reference $ARGUMENTS and ${SKILL_ROOT}
+(disk skills) / ${PLUGIN_ROOT} (plugin skills), expanded in-place before load.
 ```
 
-When `context` is omitted, plugin skills keep their historical behavior (fork).
+To opt a frontmatter skill into delegation, declare `context: fork` explicitly:
+
+```markdown
+---
+name: my-heavy-skill
+description: …
+context: fork
+---
+Body becomes the forked sub-agent's system prompt; runs in an isolated context.
+```
+
+## Defaults
+
+The default execution mode depends on how the skill is defined:
+
+| Skill kind | Source | Default when `context:` absent |
+|------------|--------|--------------------------------|
+| Built-in TS registry | `registerSkill({ … })` in `src/skills/` | `inline` (handler is the orchestrator) |
+| Plugin | `~/.afk/plugins/*/SKILL.md` | **`load`** (since 2026-06) |
+| User / project disk | `~/.afk/skills/`, `<cwd>/.afk/skills/` | **`load`** (since 2026-06) |
+
+Rule for frontmatter skills (plugin + disk): **fork iff `context: fork`**;
+everything else (absent, `load`, or an unrecognized value) loads in-context.
+Built-in TS skills are unchanged — they still default to `inline`, and only
+opt into `fork`/`load` explicitly.
+
+Disk skills resolve their load body from the SKILL.md content (not the built-in
+`prompts/system.md` convention), threaded through `SkillMetadata.loadBody`;
+`${SKILL_ROOT}` is expanded to the skill's directory in-place at registration,
+because load mode runs in the current agent (no subagent env injection).
+
+Bundled skills shipped under `awa-bundled/` pinned to `context: fork`:
+`research`, `ground-state`, `shadow-verify`, `review`, `simplify`, `refactor`,
+`ship`, `spec`. These either return an **epistemically independent** result the
+caller's reasoning must not contaminate (`shadow-verify`, `review`), or run
+heavy multi-phase / high-volume work whose intermediate noise must stay out of
+the main context (`research`, `ground-state`, `refactor`, `ship`, `simplify`,
+`spec`).
+
+Bundled skills that stay `load`: `gather`, `parallelize`, `devils-advocate`,
+`contract`, `ground-claim`, `intent-lock`. These orchestrate *from* the current
+agent and feed their result back into the caller's decision, or are pure
+in-context guards.
+
+### Choosing fork vs load (the rule that matters)
+
+Do **not** use "does it dispatch sub-agents?" as the test — that is the crude
+rule that mis-pinned `devils-advocate` and the guards. Ask instead:
+
+- **Independence:** must the *result* be free of the caller's reasoning/bias?
+  → `fork` (`shadow-verify`, `review`). Note: a skill can dispatch its own
+  independent sub-agents *and still be `load`* — `devils-advocate` and
+  `parallelize` fan out parallel waves, but the current agent orchestrates and
+  the critics/synthesizer stay isolated as sub-agents either way, so `fork`
+  would only add an orchestration layer, not independence.
+- **Context hygiene:** would the intermediate work (voluminous reads, failed
+  hypotheses, multi-phase logs) blow or pollute the caller's window? → `fork`
+  (`research`, `ground-state`, `refactor`, `ship`).
+- **Otherwise** — the skill advises, enriches, orchestrates, or guards the
+  *current* turn, and its output is meant to land in the caller's context →
+  `load` (`gather`, `parallelize`, `devils-advocate`, `ground-claim`,
+  `intent-lock`). A zero-dispatch guard is ALWAYS `load`: a forked guard returns
+  a digest about a context it cannot see, producing a false safety signal.
+
+A 2026-06 /devils-advocate review (and a follow-up user review of that review)
+moved `ground-claim`, `intent-lock`, and `devils-advocate` itself from the
+initial fork pin to `load`.
 
 ## When to use which mode
 
@@ -90,8 +175,14 @@ discriminator; tests.
 
 ## Notes / invariants
 
-- Default stays `'inline'`; the five inline TS skills and the fork path are
-  untouched. `load` is strictly opt-in.
+- **Built-in TS registry skills** still default to `'inline'`; the five inline
+  TS skills (mint, forge, diagnose, audit-fit, score) and the fork path are
+  untouched.
+- **Frontmatter skills** (plugin + user/project disk) default to `'load'` since
+  the 2026-06 amendment: fork iff `context: fork`. Isolation-critical bundled
+  skills are pinned to `context: fork` (see [Defaults](#defaults)); third-party
+  plugins and disk skills that omit `context:` now load in-context. Authors of
+  fan-out / heavy orchestration skills MUST set `context: fork` explicitly.
 - The `execute()` depth guard applies to `load` too (conservative): a load
   dispatch at `depth >= maxDepth` is refused even though load does not deepen
   nesting. Revisit if it proves limiting.

--- a/src/agent/plugins/tool-injector.ts
+++ b/src/agent/plugins/tool-injector.ts
@@ -22,10 +22,10 @@ export interface PluginSkillMetadata {
   description?: string;
   argumentHint?: string;
   /**
-   * Execution mode from the `context:` frontmatter field. When `'load'`, the
-   * skill body is loaded into the current session instead of forking a
-   * subagent (see docs/skill-load-mode.md). Absent/other values keep the
-   * historical fork behavior.
+   * Execution mode from the `context:` frontmatter field. The skill forks a
+   * subagent ONLY when this is `'fork'`; absent/`'load'`/other values load the
+   * body into the current session (the default since 2026-06; see
+   * docs/skill-load-mode.md).
    */
   context?: string;
   /** Markdown content after the frontmatter closing `---`. */

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -151,9 +151,10 @@ export interface PluginSkillBody {
   body: string;
   pluginPath: string;
   /**
-   * Execution mode from SKILL.md frontmatter `context:`. When `'load'`, the
-   * executor loads the body into the current session instead of forking a
-   * subagent (see docs/skill-load-mode.md). Undefined → historical fork path.
+   * Execution mode from SKILL.md frontmatter `context:`. The executor forks a
+   * subagent ONLY when this is `'fork'`; undefined/`'load'`/other values load
+   * the body into the current session (the default since 2026-06; see
+   * docs/skill-load-mode.md).
    */
   context?: string;
 }

--- a/src/agent/tools/skill-executor.test.ts
+++ b/src/agent/tools/skill-executor.test.ts
@@ -1125,7 +1125,7 @@ describe('SkillExecutor', () => {
         },
       });
       (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies =
-        new Map([[skillName, { body: 'plugin body text', pluginPath: '/fake/plugin' }]]);
+        new Map([[skillName, { body: 'plugin body text', pluginPath: '/fake/plugin', context: 'fork' }]]);
       return { executor, teardown };
     }
 
@@ -1163,7 +1163,7 @@ describe('SkillExecutor', () => {
         },
       });
       (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies =
-        new Map([['plugin-throw', { body: 'plugin body', pluginPath: '/fake/plugin' }]]);
+        new Map([['plugin-throw', { body: 'plugin body', pluginPath: '/fake/plugin', context: 'fork' }]]);
 
       const result = await executor.execute(makeCall({ name: 'plugin-throw' }));
       expect(result.isError).toBe(true);
@@ -1213,7 +1213,7 @@ describe('SkillExecutor', () => {
       // Pre-populate the cache so `getPluginSkillBody` returns a body for
       // our synthetic name without invoking `discoverPluginSkillBodies`.
       (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies =
-        new Map([['nest-pin-plugin', { body: 'plugin-body-text', pluginPath: '/fake/plugin' }]]);
+        new Map([['nest-pin-plugin', { body: 'plugin-body-text', pluginPath: '/fake/plugin', context: 'fork' }]]);
 
       await executor.execute(makeCall({ name: 'nest-pin-plugin' }));
 
@@ -1285,7 +1285,7 @@ describe('SkillExecutor', () => {
 
       // Stub the plugin body lookup so executePluginSkill is reached.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (executor as any).pluginBodies = new Map([['nested', { body: 'fake plugin body', pluginPath: '/fake/plugin' }]]);
+      (executor as any).pluginBodies = new Map([['nested', { body: 'fake plugin body', pluginPath: '/fake/plugin', context: 'fork' }]]);
 
       await executor.execute(makeCall({ name: 'nested', arguments: 'go' }));
 
@@ -1348,7 +1348,7 @@ describe('SkillExecutor', () => {
       });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (executor as any).pluginBodies = new Map([['no-factory', { body: 'body', pluginPath: '/fake/plugin' }]]);
+      (executor as any).pluginBodies = new Map([['no-factory', { body: 'body', pluginPath: '/fake/plugin', context: 'fork' }]]);
 
       await executor.execute(makeCall({ name: 'no-factory' }));
 
@@ -1372,7 +1372,7 @@ describe('SkillExecutor', () => {
       });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (executor as any).pluginBodies = new Map([['deep', { body: 'body', pluginPath: '/fake/plugin' }]]);
+      (executor as any).pluginBodies = new Map([['deep', { body: 'body', pluginPath: '/fake/plugin', context: 'fork' }]]);
 
       await executor.execute(makeCall({ name: 'deep' }));
 
@@ -1740,7 +1740,7 @@ describe('SkillExecutor', () => {
       });
 
       (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies =
-        new Map([['plugin-cancelled-partial', { body: 'plugin-body', pluginPath: '/fake/plugin' }]]);
+        new Map([['plugin-cancelled-partial', { body: 'plugin-body', pluginPath: '/fake/plugin', context: 'fork' }]]);
 
       const result = await executor.execute(makeCall({ name: 'plugin-cancelled-partial' }));
 
@@ -1768,7 +1768,7 @@ describe('SkillExecutor', () => {
       });
 
       (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies =
-        new Map([['plugin-cancelled-no-partial', { body: 'plugin-body', pluginPath: '/fake/plugin' }]]);
+        new Map([['plugin-cancelled-no-partial', { body: 'plugin-body', pluginPath: '/fake/plugin', context: 'fork' }]]);
 
       const result = await executor.execute(makeCall({ name: 'plugin-cancelled-no-partial' }));
 
@@ -1808,7 +1808,7 @@ describe('SkillExecutor', () => {
       });
 
       (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies =
-        new Map([[skillName, { body, pluginPath: '/fake/plugin' }]]);
+        new Map([[skillName, { body, pluginPath: '/fake/plugin', context: 'fork' }]]);
 
       return { executor, mockForkSubagent };
     }
@@ -1912,7 +1912,7 @@ describe('SkillExecutor', () => {
         },
       });
       (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies =
-        new Map([['plugin-no-args', { body, pluginPath: '/fake/plugin' }]]);
+        new Map([['plugin-no-args', { body, pluginPath: '/fake/plugin', context: 'fork' }]]);
 
       await executor.execute(makeCall({ name: 'plugin-no-args' }));
 

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -247,26 +247,30 @@ export class SkillExecutor {
       // getSkill throws on not-found — fall through to plugin lookup.
     }
 
-    // 2. Try plugin skills (SKILL.md body → subagent dispatch, or in-context
-    //    load when the SKILL.md frontmatter declares `context: load`).
+    // 2. Try plugin skills (SKILL.md body). Default is in-context LOAD; a
+    //    plugin skill forks a subagent ONLY when its frontmatter explicitly
+    //    declares `context: fork`. (History: the default was fork until
+    //    2026-06; flipped to load so authored skills act in-context by
+    //    default. Isolation-critical bundled skills are pinned to
+    //    `context: fork`. See docs/skill-load-mode.md.)
     const pluginSkill = this.getPluginSkillBody(parsed.name);
     if (pluginSkill) {
-      if (pluginSkill.context === 'load') {
-        const bodyWithRoot = pluginSkill.body.replace(
-          /\$\{?PLUGIN_ROOT\}?/g,
-          () => pluginSkill.pluginPath,
-        );
-        return this.executeLoadedPluginSkill(
+      if (pluginSkill.context === 'fork') {
+        return await this.executePluginSkill(
           parsed.name,
-          bodyWithRoot,
+          pluginSkill.body,
+          pluginSkill.pluginPath,
           parsed.arguments,
           call,
         );
       }
-      return await this.executePluginSkill(
+      const bodyWithRoot = pluginSkill.body.replace(
+        /\$\{?PLUGIN_ROOT\}?/g,
+        () => pluginSkill.pluginPath,
+      );
+      return this.executeLoadedPluginSkill(
         parsed.name,
-        pluginSkill.body,
-        pluginSkill.pluginPath,
+        bodyWithRoot,
         parsed.arguments,
         call,
       );
@@ -291,6 +295,7 @@ export class SkillExecutor {
       name: string;
       context?: 'inline' | 'fork' | 'load';
       model?: string;
+      loadBody?: string;
     },
     args: string | undefined,
     call: ToolCall,
@@ -702,13 +707,17 @@ export class SkillExecutor {
   }
 
   /**
-   * Load path for a registry skill (`context: 'load'`). Resolves
-   * `prompts/system.md` (same convention as the fork path), substitutes args,
-   * and returns the framed body for in-context execution. Never forks and
-   * never calls the skill's `handler`.
+   * Load path for a registry skill (`context: 'load'`). Resolves the body in
+   * priority order:
+   *   1. `skill.loadBody` — set by disk-scanned user/project skills, whose
+   *      body is the SKILL.md content (not the built-in prompts/ convention).
+   *      `${SKILL_ROOT}` is already expanded by the registrant.
+   *   2. `loadSkillPrompts(name)['system.md']` — the built-in convention.
+   * Substitutes `$ARGUMENT(S)` and returns the framed body for in-context
+   * execution. Never forks and never calls the skill's `handler`.
    */
   private executeLoadedRegistrySkill(
-    skill: { name: string; model?: string },
+    skill: { name: string; model?: string; loadBody?: string },
     args: string | undefined,
     call: ToolCall,
   ): ToolResult {
@@ -717,19 +726,23 @@ export class SkillExecutor {
     }
     const startMs = Date.now();
     let body: string;
-    try {
-      const prompts = loadSkillPrompts(skill.name);
-      const system = prompts['system.md'];
-      if (!system) {
-        return {
-          content: `Skill "${skill.name}" has context: "load" but no prompts/system.md found`,
-          isError: true,
-        };
+    if (skill.loadBody !== undefined) {
+      body = skill.loadBody;
+    } else {
+      try {
+        const prompts = loadSkillPrompts(skill.name);
+        const system = prompts['system.md'];
+        if (!system) {
+          return {
+            content: `Skill "${skill.name}" has context: "load" but no prompts/system.md found`,
+            isError: true,
+          };
+        }
+        body = system;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: `Failed to load skill prompts: ${message}`, isError: true };
       }
-      body = system;
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      return { content: `Failed to load skill prompts: ${message}`, isError: true };
     }
     const substituted = this.substituteSkillArgs(body, args);
     this.emitLoadTelemetry(skill.name, substituted.length, Date.now() - startMs, skill.model);

--- a/src/agent/tools/skill-load-mode.test.ts
+++ b/src/agent/tools/skill-load-mode.test.ts
@@ -9,7 +9,8 @@
  *   - the framed body + arg echo reach the model as the tool result;
  *   - `$ARGUMENT(S)` substitution applies;
  *   - SKILL.md frontmatter `context: load` flows end-to-end to the executor;
- *   - plugin skills WITHOUT `context: load` keep the historical fork path.
+ *   - plugin skills default to LOAD (since 2026-06); they fork ONLY when the
+ *     frontmatter explicitly declares `context: fork`.
  *
  * See docs/skill-load-mode.md.
  */
@@ -170,7 +171,22 @@ describe('context: load — plugin skills', () => {
     expect(mockFork).not.toHaveBeenCalled();
   });
 
-  it('regression: a plugin skill WITHOUT context: load still forks a subagent', async () => {
+  it('a plugin skill WITHOUT a context field now LOADS in-context (default flipped 2026-06)', async () => {
+    const mockFork = spyNoFork();
+    const executor = makeExecutor();
+    setPluginBodies(executor, [
+      ['plugin-default', { body: 'DEFAULT-BODY for $ARGUMENTS', pluginPath: '/fake' }],
+    ]);
+
+    const result = await executor.execute(makeCall({ name: 'plugin-default', arguments: 'task-y' }));
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toContain('DEFAULT-BODY for task-y');
+    expect(result.content).toContain('loaded into your current context');
+    expect(mockFork).not.toHaveBeenCalled();
+  });
+
+  it('a plugin skill with context: fork still forks a subagent (explicit opt-in)', async () => {
     const mockFork = vi.fn().mockResolvedValue({
       runToResult: vi.fn().mockResolvedValue({ status: 'succeeded', message: { content: 'forked' } }),
       teardown: vi.fn().mockResolvedValue(undefined),
@@ -180,7 +196,7 @@ describe('context: load — plugin skills', () => {
 
     const executor = makeExecutor();
     setPluginBodies(executor, [
-      ['plugin-fork', { body: 'historical fork body', pluginPath: '/fake' }],
+      ['plugin-fork', { body: 'fork body', pluginPath: '/fake', context: 'fork' }],
     ]);
 
     const result = await executor.execute(makeCall({ name: 'plugin-fork' }));
@@ -240,7 +256,10 @@ describe('context: load — SKILL.md frontmatter parsing (end-to-end)', () => {
     }
   });
 
-  it('leaves context undefined when frontmatter omits it (fork default preserved)', () => {
+  it('parser leaves context undefined when frontmatter omits it (executor applies the load default)', () => {
+    // The PARSER stays neutral: an omitted `context:` yields `undefined`. The
+    // load-vs-fork default is applied downstream by SkillExecutor.execute()
+    // (undefined → load since 2026-06), NOT baked in at parse time.
     const dir = mkdtempSync(join(tmpdir(), 'afk-load-fm-'));
     try {
       const skillDir = join(dir, 'skills', 'demo2');

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -35,9 +35,9 @@ const __dirname = dirname(__filename);
 // test cannot prevent that on its own — but the hash-bump moment forces the
 // developer to look at both copies.
 const PINNED_HASHES = {
-  contract: '0b7febafec024e8dd4404f75e84d21ee72b1b1846d6e2610aaa82ba77f9d6f2d',
+  contract: '748eaf01deda592913f463b23c81a6be3a89ae3b316f31f531a8488dc5bc1a7c',
   'devils-advocate':
-    '84275b097fa3ed270b0b71c87e2dad0366794fd7efc7a47d29abaa85da97f974',
+    'a86982c9d8e2ec65e409f92b2715f551c4d6861b08bb10ac5e20e1e6f1717efa',
   // gather + parallelize carry a bundled-only `context: load` frontmatter line
   // (2026-06 skill-execution-mode work). `context` is an agent-afk-specific
   // field; Claude Code upstream skills are natively inline/progressive-disclosure,
@@ -45,29 +45,29 @@ const PINNED_HASHES = {
   // divergence (allowlisted in INTENTIONAL_DIFFS below). See docs/skill-load-mode.md.
   gather: '26ef18dde7db7c313655b0fe3097f14966763298ff5a2fe643ccf18d0f6b29c0',
   'ground-claim':
-    'd877c1e7de08ecb8788677f6a8f3b51f5d48cefefbf4019af2e37ac1484a95bb',
+    '1fe26f35fe858932ba1a42e5c2d4927e3b404a7b7995680b37b3e84a63912b72',
   'ground-state':
-    'ae4c167296e96b640a54cd4cd317e5810894cffff6dac3c022b1433dff003105',
+    '92c40063ac3492d49b7cc2fdaaf3090552cde3f949de53a0fe5820e08b7d75b5',
   // intent-lock is bundled-only (no upstream counterpart).
   // Hash bumps need no parallel PR — document the change in the
   // commit message instead.
   'intent-lock':
-    '7a466075e5a64c1145b97aa24b9a6990a3ee1dc818b93c158433e53d7416aef0',
+    'a0844035c011205eaab9b61e793c4dbe32a48eea0f84ae9fa7b7b4a59e801066',
   // parallelize: bundled-only `context: load` added — see the gather note above.
   parallelize:
     'be8b2a301fe35d86d96d4be6f8418bf497dd9050767a3837cf057d7d5a1cd719',
   // refactor is bundled-only (no upstream example-plugin counterpart); verbatim
   // copy of the user-scope /refactor at ~/.afk/skills/.
-  refactor: '23ab4836653159deeafbca45e516af8d43e8c5275535613e36f7bcb2d77de64e',
-  research: '0d04d0a05891ed1b63679e5a0237b743364a6165731a8f694c5584ed7661505f',
-  review: '816ea27cf665be23c67cf887d639d40e1435954f80ceeb43740bcd7f39c205e7',
+  refactor: '9cb84710ddf2cf63e1a648460a64656d3f4a9aae8e21753b031556070740c51e',
+  research: '10692d77e392cedce928f66cb5dec27dbc2066f48cfc33047820f56506da762a',
+  review: '581a1068ea9e47b4309b3fbf2701ad8ec1de1fb7b5b171bb8b607395fe290033',
   'shadow-verify':
-    '8bce741e55be049a196ed6c71efd0acd271f272a8e2202917c3f1243b875eb33',
-  ship: '4b9a0e40372c36f953ad6d37347e1682950c9825ca5e312fae4e9b320cde975f',
+    '9b1ea7db65485f849ae6dfb9a6f69a102d7ccc6e5230b561dc76ef8c666475f8',
+  ship: '95f6410600af55fa9fa0312a48d3eebb37ef18ca98dd73ccba840b7136f83b69',
   // simplify is bundled-only (no upstream example-plugin counterpart).
   simplify:
-    'b863890eead7011c90d4f93b65e5a1533c8f88292728ec771f8b128e9535d996',
-  spec: 'c08f3b4fbe1f585b1e8354a000e0d2d3a48455ad322c7a27112d509aa9698fe7',
+    'f9c9e93b1263ed782b5703b6f30fd981908b0af1fa219d0124405a318ff2756e',
+  spec: '167e7cbb84de5b716efa11bb9f20a6e4b940f6f9a6d1812a7fbd735dae4f67dd',
 } as const;
 
 type SkillName = keyof typeof PINNED_HASHES;
@@ -148,6 +148,14 @@ const INTENTIONAL_DIFFS: Partial<Record<SkillName, RegExp[]>> = {
     /^\/contract$/,
     // Upstream side: /agent-workflow-amplifiers:contract invocation.
     /\/agent-workflow-amplifiers:contract/,
+    // Bundled-only agent-afk execution-mode field. LOAD (not fork): the current
+    // agent orchestrates the critic wave and the advisory recommendation feeds
+    // ITS OWN decision (structurally identical to /parallelize). The critics +
+    // synthesizer stay independent as dispatched sub-agents either way, so fork
+    // adds an orchestration layer without adding independence. (Moved fork→load
+    // by user review, 2026-06.) Claude Code skills are natively inline → no
+    // upstream counterpart. See docs/skill-load-mode.md.
+    /^context: load$/,
   ],
   parallelize: [
     // Same structural divergence as devils-advocate — different contract
@@ -162,6 +170,10 @@ const INTENTIONAL_DIFFS: Partial<Record<SkillName, RegExp[]>> = {
     // Same structural divergence as devils-advocate.
     /^\/contract$/,
     /\/agent-workflow-amplifiers:contract/,
+    // Bundled-only `context: fork` pin — independence of the verifier wave
+    // requires an isolated context, so it must keep forking after the
+    // load-by-default flip. See devils-advocate note.
+    /^context: fork$/,
   ],
 
   // gather: bundled-only `context: load` execution-mode field (no upstream
@@ -179,6 +191,10 @@ const INTENTIONAL_DIFFS: Partial<Record<SkillName, RegExp[]>> = {
   research: [
     /if the research-agent is not available/,
     /if the private plugin is not installed/,
+    // Bundled-only `context: fork` pin — research fans out parallel
+    // context-gathering sub-agents and must keep that work in an isolated
+    // context after the load-by-default flip. See devils-advocate note.
+    /^context: fork$/,
   ],
 
   // ship — 3 divergences, all #441 back-port gaps:
@@ -221,6 +237,10 @@ const INTENTIONAL_DIFFS: Partial<Record<SkillName, RegExp[]>> = {
     /then proceed immediately to commit\. Do not wait for approval\./,
     // Bullet ordering divergence (3 above).
     /\*\*Never\*\* `git push origin main` \(or `master`\)\. Pushing the feature branch is the only allowed form\./,
+    // Bundled-only `context: fork` pin — /ship is a heavy multi-phase release
+    // orchestrator kept in an isolated context after the load-by-default flip.
+    // See devils-advocate note.
+    /^context: fork$/,
   ],
 
   // review — namespace-only divergence (back-port landed; #441 closed):
@@ -241,7 +261,27 @@ const INTENTIONAL_DIFFS: Partial<Record<SkillName, RegExp[]>> = {
     /^\/contract$/,
     // Upstream side: /agent-workflow-amplifiers:contract invocation.
     /\/agent-workflow-amplifiers:contract/,
+    // Bundled-only `context: fork` pin — review dispatches parallel dimension
+    // agents and must keep that work isolated after the load-by-default flip.
+    // (Already carried `context: fork` before the flip; allowlisted here for
+    // the co-located drift comparison.) See devils-advocate note.
+    /^context: fork$/,
   ],
+
+  // ground-state, spec: bundled-only `context: fork` pins added in the 2026-06
+  // load-by-default flip so these orchestration skills keep forking. No other
+  // divergence from upstream. See devils-advocate note.
+  'ground-state': [/^context: fork$/],
+  spec: [/^context: fork$/],
+
+  // ground-claim: bundled-only `context: load` field. Unlike the fork-pinned
+  // skills, ground-claim dispatches NO sub-agents — it is a pre-answer guard
+  // that must run in the caller's context to see the reasoning it grounds
+  // (a forked guard cannot inspect the parent's accumulated context). A
+  // /devils-advocate review (2026-06) flagged the original fork pin as a
+  // semantic error and moved it to load. Claude Code skills are natively
+  // inline → no upstream counterpart. See docs/skill-load-mode.md.
+  'ground-claim': [/^context: load$/],
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/src/bundled-plugins/awa-bundled/skills/devils-advocate/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/devils-advocate/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: devils-advocate
 description: "Adversarially critique a proposal by generating alternatives. Dispatches 3 parallel critics (pragmatist, paranoid, architect lenses) — each invents one alternative approach — then a synthesis step ranks all 4 options and recommends the top choice. Use when a plan, fix, scoping, decomposition, or named recommendation will drive decisions and you want structured alternative-generation before committing. Complements /shadow-verify — that skill re-derives factual claims; this one critiques whether the chosen approach itself is best."
+context: load
 ---
 
 ## Sub-agent contract

--- a/src/bundled-plugins/awa-bundled/skills/ground-claim/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/ground-claim/SKILL.md
@@ -2,6 +2,7 @@
 name: ground-claim
 description: "Use when the user asks a meta-capability question about a system/framework/repo ('what does X enable', 'what can this do', 'list the capabilities'). Forces file-read grounding with path:line citations before answering; tags any unverifiable claim as [UNVERIFIED]."
 argument-hint: "<the meta-capability question>"
+context: load
 ---
 
 ## Trigger

--- a/src/bundled-plugins/awa-bundled/skills/ground-state/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/ground-state/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ground-state
 description: "Before starting any non-trivial implementation (multi-file edits, new features, config changes, anything that writes), dispatch a parallel pre-flight reconnaissance wave to triangulate git state, project infrastructure, and prior-session memory. Produces a 5-line ground-truth snapshot that grounds the implementation and catches wrong-branch edits, assumed-no-CI, stale origin, and missed memory context before the first edit."
+context: fork
 ---
 
 ## Sub-agent contract

--- a/src/bundled-plugins/awa-bundled/skills/intent-lock/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/intent-lock/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: intent-lock
 description: "Fires before multi-step work when the user's request contains ambiguous referents ('the text', 'her Y'), characterizations of unverified entities ('the meeting is substantive'), or identity assumptions (which contact = the user). Emits a one-sentence interpretation lock for fast async correction; escalates to Asking only when interpretation gates an irreversible action AND multiple plausible reads exist."
+context: load
 ---
 
 ## When to invoke

--- a/src/bundled-plugins/awa-bundled/skills/refactor/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/refactor/SKILL.md
@@ -7,6 +7,7 @@ failure_modes:
   - dependency blindness
   - false completeness
   - premature execution
+context: fork
 ---
 
 ## Sub-agent contract

--- a/src/bundled-plugins/awa-bundled/skills/research/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/research/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: research
 description: "Dispatches two sub-agents in parallel to gather external and local context for the current task."
+context: fork
 ---
 
 ## Sub-agent contract

--- a/src/bundled-plugins/awa-bundled/skills/shadow-verify/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/shadow-verify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: shadow-verify
 description: "Dispatch a parallel adversarial verifier wave after any high-stakes sub-agent investigation (code reviews, audits, findings reports, large refactors). Shadow verifiers independently re-derive 2–3 key claims from scratch and flag disagreements before the user acts. Use when sub-agent output will drive decisions, file changes, commits, or external side-effects."
+context: fork
 ---
 
 ## Sub-agent contract

--- a/src/bundled-plugins/awa-bundled/skills/ship/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/ship/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ship
 description: "Release pipeline for already-done local work. Dispatches /ground-state pre-flight, runs the project test suite, drafts a commit message, pushes, and opens a PR with a structured verification summary. Use when local changes are ready to hand off to review — e.g. 'ship this', 'push and open a PR', 'release this work'. Add --verify to trigger an adversarial verifier wave on the diff before a human reads the PR."
+context: fork
 ---
 
 ## Sub-agent contract

--- a/src/bundled-plugins/awa-bundled/skills/simplify/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/simplify/SKILL.md
@@ -2,6 +2,7 @@
 name: simplify
 description: "Discovers incidental complexity, duplication, and dead code in a codebase and produces a ranked, behavior-preserving reduction plan — optionally applying safe changes. Dispatches four parallel read-only discovery lenses (clone detection, dead code, complexity hotspots, wrong abstraction), synthesizes into a prioritized reduction plan, and gates apply mode behind /refactor and a hard test check."
 argument-hint: "[target] [--apply] [--all]"
+context: fork
 ---
 
 ## Sub-agent contract

--- a/src/bundled-plugins/awa-bundled/skills/spec/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/spec/SKILL.md
@@ -2,6 +2,7 @@
 name: spec
 description: "Takes a loose idea and transforms it into a structured, actionable spec ready for implementation. Use when the user passes an idea, feature request, or problem description that needs scoping before building."
 argument-hint: "<idea or feature request>"
+context: fork
 ---
 
 ## Triage: bugs route to /diagnose

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -84,11 +84,25 @@ export interface SkillMetadata {
    * - `'inline'` — call the handler directly in-process (TS orchestrators).
    * - `'fork'` — route through a subagent fork using the skill's
    *   `prompts/system.md` (delegation; isolated child context).
-   * - `'load'` — load `prompts/system.md` into the CURRENT session as the tool
-   *   result; the calling agent executes it with its existing tools
-   *   (progressive disclosure; no fork). See docs/skill-load-mode.md.
+   * - `'load'` — load `prompts/system.md` (or {@link loadBody}, when set) into
+   *   the CURRENT session as the tool result; the calling agent executes it
+   *   with its existing tools (progressive disclosure; no fork). See
+   *   docs/skill-load-mode.md.
    */
   context?: 'inline' | 'fork' | 'load';
+  /**
+   * In-context body for `context: 'load'` skills whose body does NOT live at
+   * the built-in `src/skills/<name>/prompts/system.md` convention — i.e.
+   * disk-scanned user/project skills, whose body is the SKILL.md content.
+   *
+   * When set, {@link SkillExecutor.executeLoadedRegistrySkill} returns this
+   * string (after `$ARGUMENT(S)` substitution) instead of calling
+   * `loadSkillPrompts(name)`. Built-in load skills leave it unset and keep
+   * resolving their body from the prompts/ directory. `${SKILL_ROOT}` /
+   * `$SKILL_ROOT` placeholders MUST already be expanded by the registrant,
+   * because load mode runs in the current agent (no subagent env injection).
+   */
+  loadBody?: string;
   /** Where the skill came from. Absent or 'builtin' = vendored TS skill; 'user' = scanned from ~/.afk/skills/; 'project' = scanned from <cwd>/.afk/skills/. Plugin skills don't enter this registry. */
   origin?: 'builtin' | 'user' | 'project';
   /** Long-form CLI flags this skill accepts (e.g. ['--auto', '--ship']). Surfaces in tab completion and `/help`. */

--- a/src/skills/user-skills.test.ts
+++ b/src/skills/user-skills.test.ts
@@ -443,9 +443,13 @@ Body.
 
 // ---------------------------------------------------------------------------
 // Fix A — SKILL_ROOT injection into forked subagent env
+//
+// These fixtures use `context: fork` because SKILL_ROOT-as-subagent-env only
+// applies to the fork path (the handler injects it). Load-mode skills expand
+// `${SKILL_ROOT}` in-place into the body instead — covered separately below.
 // ---------------------------------------------------------------------------
 
-describe('SKILL_ROOT injection (Fix A)', () => {
+describe('SKILL_ROOT injection (Fix A — fork path)', () => {
   beforeEach(() => {
     _resetRegistry();
     mkdirSync(skillsDir, { recursive: true });
@@ -470,6 +474,7 @@ describe('SKILL_ROOT injection (Fix A)', () => {
       `---
 name: ${skillName}
 description: Processes PDF files
+context: fork
 ---
 
 You process PDF files. Scripts are in \${SKILL_ROOT}/scripts/.
@@ -498,6 +503,7 @@ You process PDF files. Scripts are in \${SKILL_ROOT}/scripts/.
       `---
 name: ${skillName}
 description: Runs data analysis
+context: fork
 ---
 
 You analyze data.
@@ -517,5 +523,88 @@ You analyze data.
     expect(skillRoot.endsWith(skillName)).toBe(true);
     // Must be absolute (starts with /).
     expect(skillRoot.startsWith('/')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// context: load default (2026-06 load-by-default flip)
+//
+// Disk skills now honor the SKILL.md `context:` field with the same default as
+// plugin skills: in-context LOAD unless `context: fork` is explicit. Load mode
+// is wired by setting `context: 'load'` + `loadBody` (with `${SKILL_ROOT}`
+// expanded in-place) on the registered metadata, so the SkillExecutor's load
+// path returns the body to the current agent instead of forking.
+// ---------------------------------------------------------------------------
+
+describe('context: load default', () => {
+  beforeEach(() => {
+    _resetRegistry();
+    mkdirSync(skillsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // cleanup best-effort
+    }
+  });
+
+  function writeSkill(name: string, frontmatterExtra: string, body: string): string {
+    const dir = join(skillsDir, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'SKILL.md'),
+      `---\nname: ${name}\ndescription: a ${name} skill${frontmatterExtra}\n---\n\n${body}\n`,
+    );
+    return dir;
+  }
+
+  it('a SKILL.md WITHOUT a context field registers as load (context=load + loadBody)', () => {
+    writeSkill('leaf-skill', '', 'Do the leaf thing.');
+    scanAndRegisterUserSkills();
+    const skill = getSkill('leaf-skill');
+    expect(skill.context).toBe('load');
+    expect(skill.loadBody).toContain('Do the leaf thing.');
+  });
+
+  it('context: load is honored explicitly', () => {
+    writeSkill('explicit-load', '\ncontext: load', 'Loaded body.');
+    scanAndRegisterUserSkills();
+    const skill = getSkill('explicit-load');
+    expect(skill.context).toBe('load');
+    expect(skill.loadBody).toContain('Loaded body.');
+  });
+
+  it('context: fork leaves context unset (routes to the forking handler) and sets no loadBody', () => {
+    writeSkill('forker', '\ncontext: fork', 'Forked body.');
+    scanAndRegisterUserSkills();
+    const skill = getSkill('forker');
+    // Fork disk skills stay on the inline→handler path; the executor's own
+    // fork branch expects prompts/system.md, which disk skills do not have.
+    expect(skill.context).toBeUndefined();
+    expect(skill.loadBody).toBeUndefined();
+  });
+
+  it('expands ${SKILL_ROOT} and $SKILL_ROOT in the load body to the absolute skill dir', () => {
+    const dir = writeSkill(
+      'rooted',
+      '',
+      'Run "${SKILL_ROOT}/scripts/go.sh" then $SKILL_ROOT/bin/x.',
+    );
+    scanAndRegisterUserSkills();
+    const skill = getSkill('rooted');
+    expect(skill.loadBody).toContain(`"${dir}/scripts/go.sh"`);
+    expect(skill.loadBody).toContain(`${dir}/bin/x`);
+    expect(skill.loadBody).not.toContain('$SKILL_ROOT');
+    expect(skill.loadBody).not.toContain('${SKILL_ROOT}');
+  });
+
+  it('an unknown context value (typo) falls through to the load default', () => {
+    writeSkill('typoed', '\ncontext: lod', 'Body.');
+    scanAndRegisterUserSkills();
+    const skill = getSkill('typoed');
+    expect(skill.context).toBe('load');
+    expect(skill.loadBody).toContain('Body.');
   });
 });

--- a/src/skills/user-skills.ts
+++ b/src/skills/user-skills.ts
@@ -2,9 +2,17 @@
  * Disk-based skill scanner.
  *
  * Discovers SKILL.md files under a given directory, parses their YAML
- * frontmatter, and registers each as a skill whose handler dispatches a
- * subagent with the SKILL.md body as the system prompt and the user's
- * input as the first message.
+ * frontmatter, and registers each as a skill.
+ *
+ * Execution mode follows the SKILL.md `context:` frontmatter field, with the
+ * same default as plugin skills (skill-executor.ts): in-context **load**
+ * unless the author explicitly opts into `context: fork`.
+ *   - default / `context: load` → the SKILL.md body is returned as the tool
+ *     result and the CURRENT agent carries it out with its existing tools
+ *     (progressive disclosure; `${SKILL_ROOT}` expanded in-place). No fork.
+ *   - `context: fork` → the handler dispatches a subagent with the SKILL.md
+ *     body as the system prompt and the user's input as the first message
+ *     (delegation; isolated child context).
  *
  * Two scopes use this scanner:
  *   - **User-scope** (`~/.afk/skills/`) — global user skills.
@@ -42,6 +50,12 @@ interface ParsedSkillMd {
   body: string;
   /** Absolute path of the skill's root directory (e.g. `~/.afk/skills/<name>/`). */
   dir: string;
+  /**
+   * Execution mode from the `context:` frontmatter field. Only the three
+   * well-known values are accepted; anything else (typo, omitted) is left
+   * `undefined` and treated as the default (load) by the registrant.
+   */
+  context?: 'inline' | 'fork' | 'load';
 }
 
 /**
@@ -115,6 +129,12 @@ function parseUserSkillMd(content: string, dirname: string): ParsedSkillMd | nul
   const out: ParsedSkillMd = { name, description, body, dir: '' };
   if (argumentHint && argumentHint.length > 0) out.argumentHint = argumentHint;
   if (flags.length > 0) out.flags = flags;
+  // Only accept the three well-known modes; an unknown value (typo) falls
+  // through to the default (load) rather than silently mis-routing.
+  const rawContext = parsed.frontmatter['context'];
+  if (rawContext === 'inline' || rawContext === 'fork' || rawContext === 'load') {
+    out.context = rawContext;
+  }
   return out;
 }
 
@@ -258,6 +278,21 @@ export function scanSkillsFromDir(
     };
     if (parsed.argumentHint) meta.argumentHint = parsed.argumentHint;
     if (parsed.flags && parsed.flags.length > 0) meta.flags = parsed.flags;
+    // Default to in-context LOAD; fork only when `context: fork` is explicit
+    // (symmetric with the plugin-skill default in skill-executor.ts). In load
+    // mode we set `context: 'load'` + `loadBody` so the executor's load path
+    // returns the body to the current agent instead of invoking the (forking)
+    // handler. In fork mode we leave `context` unset so the registry executor
+    // falls through to the handler, which forks via makeUserSkillHandler — the
+    // disk-skill body is NOT at the built-in prompts/system.md path the
+    // executor's own fork branch expects, so we must keep using the handler.
+    if (parsed.context !== 'fork') {
+      meta.context = 'load';
+      // SKILL_ROOT is expanded in-place here, not via subagent env, because
+      // load mode runs in the CURRENT agent. Mirrors the PLUGIN_ROOT expansion
+      // in skill-executor.ts's plugin load path.
+      meta.loadBody = parsed.body.replace(/\$\{?SKILL_ROOT\}?/g, () => parsed.dir);
+    }
     registerSkill(meta);
     count++;
   }


### PR DESCRIPTION
## Summary

- **Flips the skill execution default from fork to load.** Previously, disk-scanned user/project skills and plugin skills defaulted to subagent dispatch (fork); authors opted in to in-context execution with `context: load`. That's the wrong default for the majority of authored skills, which are prompts meant to run in-context.
- **`context: fork` is now the explicit opt-in** for subagent isolation. Plugin skills (skill-executor.ts) and disk-scanned skills (user-skills.ts) both fall through to the load path unless `context: fork` is declared.
- **`loadBody` added to `SkillMetadata`** so the load path returns the SKILL.md body (with `$SKILL_ROOT` expanded in-place) for disk-scanned skills, instead of falling back to the built-in `prompts/system.md` convention.
- **Disk-scanned skills now parse `context:`** at all (it was previously ignored — they always forked).

## Bundled-skill allocation

Which bundled skills opt into `context: fork`, and which stay `load`. The split was refined by a `/devils-advocate` review of the allocation (and a follow-up review of that review):

**`context: fork` (7)** — keep heavy/high-volume work out of the caller's context, or must return an epistemically independent result:
`ground-state`, `research`, `shadow-verify`, `refactor`, `ship`, `simplify`, `spec`. (`review` was already fork prior to this PR.)

**`context: load` (3, moved here from the initial fork pin)**:
- `devils-advocate` — orchestrates its critic wave *from the current agent*; the critics + synthesizer stay isolated subagents either way, so fork would add an orchestration layer without adding independence (structurally identical to `parallelize`, which is load).
- `ground-claim`, `intent-lock` — zero-dispatch **guards**. A forked guard returns a digest about a context it cannot see — a false safety signal — so a guard must run in the caller's context.

(`gather`, `parallelize`, `contract` were already `load` and are unchanged.)

## Test results

- `pnpm test` (vitest run): **438 test files, 8140 tests passed, 12 skipped, 0 failures**
- `pnpm lint` (tsc --noEmit, strict): clean
- Also fixes a **pre-existing** `bundled.test.ts` pinned-hash drift on `contract` + `review` (their committed content had diverged from the pinned hashes in earlier HEAD commits that forgot to bump them).

## Verification

Adversarial verifier wave dispatched (diff: 390 insertions, 78 deletions). Note: the wave's original Claim 3 spot-checked only 3 fork skills and missed that `devils-advocate`/`ground-claim`/`intent-lock` had been moved to `load`; corrected here. Final committed allocation verified directly against the committed tree:

- **Plugin default = load, `context: fork` is opt-in**: CONFIRM (`skill-executor.ts` — `pluginSkill.context === 'fork'` guards the fork path; load is the fallthrough)
- **Disk skills default to load with `loadBody` + `$SKILL_ROOT` expansion**: CONFIRM (`user-skills.ts` — `if (parsed.context !== 'fork')` sets `meta.context = 'load'` + `meta.loadBody`)
- **Bundled allocation**: CONFIRM (all 14 bundled SKILL.md context fields read directly from the committed tree — fork: ground-state, research, shadow-verify, refactor, ship, simplify, spec, review; load: devils-advocate, ground-claim, intent-lock, gather, parallelize, contract)
