### PR TITLE
fix(cli): clamp diff body lines to terminal width in nested tool-lane paths

### DIFF
--- a/src/cli/commands/interactive/tool-lane-render-agent.ts
+++ b/src/cli/commands/interactive/tool-lane-render-agent.ts
@@ -10,7 +10,7 @@ import {
   shortenPaths,
 } from './tool-lane-format.js';
 import type { ToolEntry, Entry } from './tool-lane-render.js';
-import { getGlyphs } from './tool-lane-render.js';
+import { getGlyphs, clampLineToTerminal } from './tool-lane-render.js';
 import { renderFlushChildren } from './tool-lane-render-children.js';
 
 /**
@@ -199,6 +199,11 @@ function renderGroupedRootTools(
   homeDir?: string,
 ): string[] {
   const lines: string[] = [];
+  // Read once per call: diff body lines below are clamped to this width so
+  // long file content never soft-wraps to column 0 in scrollback (orphaning
+  // its continuation past the indent). Mirrors the clamp on every other
+  // diff-emission path; see tool-lane-render-children.ts.
+  const cols = getTerminalWidth();
   for (const toolName of groupOrder) {
     const entries = groups.get(toolName)!;
     if (entries.length === 1) {
@@ -210,7 +215,7 @@ function renderGroupedRootTools(
           // the outcome line (2 for the row indent, 2 more to clear the
           // tool-name column visually).
           for (const line of formatDiffBlock(e.diff, 'flush', '    ')) {
-            lines.push(line);
+            lines.push(clampLineToTerminal(line, cols));
           }
         }
       } else {
@@ -242,7 +247,7 @@ function renderGroupedRootTools(
           lines.push('    ' + palette.dim(`── ${label} ──`));
         }
         for (const line of formatDiffBlock(e.diff!, 'flush', '    ')) {
-          lines.push(line);
+          lines.push(clampLineToTerminal(line, cols));
         }
       }
     }

--- a/src/cli/commands/interactive/tool-lane-render-children.ts
+++ b/src/cli/commands/interactive/tool-lane-render-children.ts
@@ -264,8 +264,18 @@ function renderOverlayChildren(
           // since the connector itself is 3 cells (`├─ ` / `╰─ `) — the diff
           // hangs visually past it without claiming a sibling slot.
           const diffIndent = indentColored + (isLast ? g.spineClosed : palette.dim(g.spine)) + '  ';
+          // Clamp each diff body line to terminal width. Diff lines are
+          // model-controlled (file content) and routinely exceed `cols`;
+          // without clamping the terminal soft-wraps the overflow to column 0
+          // with no spine gutter, orphaning a flush-left continuation between
+          // siblings (the same orphan-wrap bug every other row-producing path
+          // here guards against). In the live overlay an unclamped wrap also
+          // desyncs the compositor's logical-line row accounting from
+          // log-update's wrap-aware count, making the block flicker on each
+          // repaint. Mirrors the clamp on the root-overlay diff path in
+          // tool-lane.ts.
           for (const line of formatDiffBlock(child.diff, 'overlay', diffIndent)) {
-            lines.push(line);
+            lines.push(clampLineToTerminal(line, cols));
           }
         }
       } else {
@@ -425,8 +435,13 @@ function renderFlushChildren(
           // the overlay path: continue (or close) this child's spine column,
           // then 2 cells past the connector.
           const diffIndent = indentColored + (isLast ? g.spineClosed : palette.dim(g.spine)) + '  ';
+          // Clamp each diff body line to terminal width — see the matching
+          // note on the overlay diff path above. Scrollback is append-only:
+          // an unclamped line that soft-wraps to column 0 orphans its
+          // continuation past the spine gutter permanently, with no repaint
+          // able to repair it.
           for (const line of formatDiffBlock(child.diff, 'flush', diffIndent)) {
-            lines.push(line);
+            lines.push(clampLineToTerminal(line, cols));
           }
         }
       } else {

--- a/src/cli/commands/interactive/tool-lane.test.ts
+++ b/src/cli/commands/interactive/tool-lane.test.ts
@@ -548,6 +548,107 @@ describe('ToolLane.upsertTextChild / removeTextChildrenUnder', () => {
         ).toBeLessThanOrEqual(cols);
       }
     });
+
+    /**
+     * Regression for the "weird wrapping in the diff" + "write_file text comes
+     * and goes" report: a diff body line under a subagent child (rendered via
+     * renderOverlayChildren, NOT the root-entry path) was pushed RAW with no
+     * clampLineToTerminal. A long line of file content then soft-wrapped to
+     * column 0 with no `│` spine gutter, orphaning the continuation between
+     * sibling rows. In the live overlay the same overflow also desyncs the
+     * compositor's logical-line row accounting (frameLines.length, which
+     * assumes 1 line = 1 visual row) from log-update's wrap-aware count,
+     * making the block flicker ("comes and goes") on every repaint.
+     *
+     * The width assertion is the proxy for both symptoms: if every emitted
+     * line fits within `cols`, the terminal never soft-wraps, so there is no
+     * orphaned continuation AND no row-count desync.
+     */
+    it('overlay diff under a subagent child fits within terminal width (no orphan-wrap / flicker)', () => {
+      const lane = new ToolLane();
+      const cols = process.stdout.columns ?? 88;
+      lane.addStartWithAgentContext('synth-A', 'Agent', '(skill-diagnose)', undefined);
+      lane.addStartWithAgentContext('edit-1', 'edit_file', ' verification-prompt.md', 'synth-A');
+      lane.addResult('edit-1', makeResult('Edited verification-prompt.md'));
+      // A diff whose body line is far wider than 88 cols — the failure shape
+      // from the screenshot ("- You are testing a hypothesis … propo" wrapped
+      // to "sed fix resolves the failure." at column 0).
+      lane.addDiff('edit-1', {
+        addedLines: 1,
+        removedLines: 1,
+        hunks: [{
+          oldStart: 1, oldLines: 1, newStart: 1, newLines: 1,
+          lines: [
+            { kind: '-', text: 'You are testing a hypothesis in an isolated worktree to determine if a proposed fix resolves the failure.' },
+            { kind: '+', text: 'You are performing a **static code-reading assessment** of a proposed fix in an isolated worktree to determine whether it would resolve the failure.' },
+          ],
+        }],
+      });
+
+      const overlay = lane.getOverlay();
+      // Sanity: the diff actually rendered (so this test can fail loudly if a
+      // future refactor stops emitting the block).
+      expect(stripAnsi(overlay)).toContain('across 1 hunk');
+      for (const line of overlay.split('\n')) {
+        expect(
+          displayWidth(stripAnsi(line)),
+          `overlay diff line exceeds terminal width (${cols}): ${JSON.stringify(line)}`,
+        ).toBeLessThanOrEqual(cols);
+      }
+    });
+
+    it('scrollback (flush) diff under a subagent child fits within terminal width', () => {
+      const lane = new ToolLane();
+      const cols = process.stdout.columns ?? 88;
+      lane.addStartWithAgentContext('synth-A', 'Agent', '(skill-diagnose)', undefined);
+      lane.addStartWithAgentContext('edit-1', 'edit_file', ' verification-prompt.md', 'synth-A');
+      lane.addResult('edit-1', makeResult('Edited verification-prompt.md'));
+      lane.addDiff('edit-1', {
+        addedLines: 1,
+        removedLines: 0,
+        hunks: [{
+          oldStart: 1, oldLines: 0, newStart: 1, newLines: 1,
+          lines: [
+            { kind: '+', text: 'A reproducer command or failing test that demonstrates the regression before the fix is applied and passes cleanly afterward.' },
+          ],
+        }],
+      });
+
+      const flushed = lane.flush().join('\n');
+      for (const line of flushed.split('\n')) {
+        expect(
+          displayWidth(stripAnsi(line)),
+          `flush diff line exceeds terminal width (${cols}): ${JSON.stringify(line)}`,
+        ).toBeLessThanOrEqual(cols);
+      }
+    });
+
+    it('scrollback (flush) diff under a grouped write_file ×2 fits within terminal width', () => {
+      const lane = new ToolLane();
+      const cols = process.stdout.columns ?? 88;
+      // Two root-level write_file calls → renderGroupedRootTools path.
+      lane.addStart('tu_a', 'write_file', '(a.ts)');
+      lane.addStart('tu_b', 'write_file', '(b.ts)');
+      lane.addResult('tu_a', makeResult('Wrote a.ts'));
+      lane.addResult('tu_b', makeResult('Wrote b.ts'));
+      const longLine = 'const veryLongIdentifierForTheRegressionTest = someModule.callWithAReallyLongArgumentListThatExceedsEightyEightColumns(alpha, beta, gamma);';
+      lane.addDiff('tu_a', {
+        addedLines: 1, removedLines: 0,
+        hunks: [{ oldStart: 1, oldLines: 0, newStart: 1, newLines: 1, lines: [{ kind: '+', text: longLine }] }],
+      });
+      lane.addDiff('tu_b', {
+        addedLines: 1, removedLines: 0,
+        hunks: [{ oldStart: 1, oldLines: 0, newStart: 1, newLines: 1, lines: [{ kind: '+', text: longLine }] }],
+      });
+
+      const flushed = lane.flush().join('\n');
+      for (const line of flushed.split('\n')) {
+        expect(
+          displayWidth(stripAnsi(line)),
+          `grouped flush diff line exceeds terminal width (${cols}): ${JSON.stringify(line)}`,
+        ).toBeLessThanOrEqual(cols);
+      }
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Long diff body lines in nested overlay-child and flush-child rendering paths were not clamped to terminal width, causing soft-wrap to column 0 with no tree-spine gutter (orphaned continuation lines)
- The resulting mismatch between the compositor's logical-line row count and log-update's wrap-aware count caused the diff block to flicker ("text comes and goes")
- The root-overlay path already applied `clampLineToTerminal`; this fix adds the same guard to the 4 remaining paths in `tool-lane-render-children.ts` (overlay-child + flush-child diff) and `tool-lane-render-agent.ts` (grouped-root single + multi diff), plus imports `clampLineToTerminal` and reads `getTerminalWidth()` per-call in the agent file

## Test results

- `pnpm lint` (tsc --noEmit strict): clean
- `pnpm test` (vitest): **8135 passed, 12 skipped** — the 3 new regression tests in `tool-lane.test.ts` pass; all 146 existing tool-lane tests + 117 tool-lane-format tests + 981 interactive/_lib tests pass
- Pre-existing failures (2): `bundled.test.ts` pinned-hash snapshot mismatches for `contract` and `review` bundled skills — confirmed present on the base commit before this patch (not a regression)
- New tests were verified to **FAIL** against the unfixed source (expected line width 133 ≤ 88) and **pass** with the fix applied

## Verification

No adversarial verify requested (diff under 100-line threshold — 126 insertions, 5 deletions, all in one coherent fix domain).

## Out of scope

Stale pinned-hash failures in `bundled.test.ts` are pre-existing and unrelated to this patch.