### PR TITLE
feat(diagnose): inject measured reproducer baseline into the read-only verifier [Step 1]

### DIFF
--- a/src/skills/diagnose.test.ts
+++ b/src/skills/diagnose.test.ts
@@ -13,6 +13,9 @@ import {
   classifyAndExtract,
   fixSpansMultipleFiles,
   computeOutcome,
+  runReproducerBaseline,
+  buildVerifierUserPrompt,
+  type BaselineResult,
   type DiagnosisResult,
   type Hypothesis,
   type VerificationResult,
@@ -815,4 +818,228 @@ describe('Diagnose Skill', () => {
     });
   });
 
+});
+
+// =============================================================================
+// runReproducerBaseline — injectable-exec seam tests (no real processes)
+// =============================================================================
+
+/**
+ * Build a fake exec function that the tests inject at the `exec` parameter of
+ * runReproducerBaseline.  All shapes that promisify(execFile) can resolve or
+ * reject are modelled here.
+ */
+type ExecResult = { stdout: string; stderr: string };
+type FakeExec = (
+  file: string,
+  args: string[],
+  opts: object,
+) => Promise<ExecResult>;
+
+function fakeExecSuccess(stdout: string, stderr = ''): FakeExec {
+  return async () => ({ stdout, stderr });
+}
+
+function fakeExecFailure(opts: {
+  code?: number | null;
+  stdout?: string;
+  stderr?: string;
+  killed?: boolean;
+  signal?: string;
+}): FakeExec {
+  return async () => {
+    const err = Object.assign(new Error('process error'), {
+      code: opts.code ?? 1,
+      stdout: opts.stdout ?? '',
+      stderr: opts.stderr ?? '',
+      killed: opts.killed ?? false,
+      signal: opts.signal,
+    });
+    throw err;
+  };
+}
+
+describe('runReproducerBaseline', () => {
+  const CWD = '/fake/repo';
+
+  afterEach(() => {
+    // Restore env after each test that mutates it.
+    delete process.env['AFK_DIAGNOSE_BASELINE'];
+  });
+
+  it('captures non-zero exit code into exitCode without throwing', async () => {
+    const exec = fakeExecFailure({ code: 1, stdout: 'test output', stderr: 'error line' });
+    const result = await runReproducerBaseline('npm test', CWD, exec as never);
+
+    expect(result.skipped).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('test output');
+    expect(result.stderr).toBe('error line');
+    expect(result.timedOut).toBe(false);
+  });
+
+  it('captures zero exit (reproducer passed on current code)', async () => {
+    const exec = fakeExecSuccess('all tests passed', '');
+    const result = await runReproducerBaseline('npm test', CWD, exec as never);
+
+    expect(result.skipped).toBe(false);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('all tests passed');
+    expect(result.stderr).toBe('');
+    expect(result.timedOut).toBe(false);
+  });
+
+  it('sets timedOut when killed === true', async () => {
+    const exec = fakeExecFailure({ code: null, stdout: 'partial', stderr: '', killed: true });
+    const result = await runReproducerBaseline('npm test', CWD, exec as never);
+
+    expect(result.timedOut).toBe(true);
+    expect(result.stdout).toBe('partial');
+  });
+
+  it('sets timedOut when signal is SIGTERM', async () => {
+    const exec = fakeExecFailure({ code: null, stdout: '', stderr: '', killed: false, signal: 'SIGTERM' });
+    const result = await runReproducerBaseline('npm test', CWD, exec as never);
+
+    expect(result.timedOut).toBe(true);
+  });
+
+  it('truncates stdout to last 4000 chars with marker', async () => {
+    const big = 'A'.repeat(5000);
+    const exec = fakeExecFailure({ code: 1, stdout: big, stderr: '' });
+    const result = await runReproducerBaseline('npm test', CWD, exec as never);
+
+    expect(result.stdout.length).toBeLessThanOrEqual(4000 + '...[truncated]\n'.length);
+    expect(result.stdout.startsWith('...[truncated]\n')).toBe(true);
+    // Tail characters must be preserved
+    expect(result.stdout.endsWith('A'.repeat(100))).toBe(true);
+  });
+
+  it('truncates stderr to last 4000 chars with marker', async () => {
+    const big = 'E'.repeat(5000);
+    const exec = fakeExecFailure({ code: 1, stdout: '', stderr: big });
+    const result = await runReproducerBaseline('npm test', CWD, exec as never);
+
+    expect(result.stderr.startsWith('...[truncated]\n')).toBe(true);
+  });
+
+  it('does not truncate output under the limit', async () => {
+    const short = 'X'.repeat(100);
+    const exec = fakeExecSuccess(short, 'err');
+    const result = await runReproducerBaseline('npm test', CWD, exec as never);
+
+    expect(result.stdout).toBe(short);
+  });
+
+  it('skips when command is empty string', async () => {
+    const exec = vi.fn() as unknown as FakeExec;
+    const result = await runReproducerBaseline('', CWD, exec as never);
+
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toContain('no reproducer command detected');
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('skips when AFK_DIAGNOSE_BASELINE=0 is set', async () => {
+    process.env['AFK_DIAGNOSE_BASELINE'] = '0';
+    const exec = vi.fn() as unknown as FakeExec;
+    const result = await runReproducerBaseline('npm test', CWD, exec as never);
+
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toContain('AFK_DIAGNOSE_BASELINE=0');
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('does NOT skip when AFK_DIAGNOSE_BASELINE is unset (default enabled)', async () => {
+    delete process.env['AFK_DIAGNOSE_BASELINE'];
+    const exec = fakeExecSuccess('ok', '');
+    const result = await runReproducerBaseline('npm test', CWD, exec as never);
+
+    expect(result.skipped).toBe(false);
+  });
+});
+
+// =============================================================================
+// buildVerifierUserPrompt
+// =============================================================================
+
+function skippedBaseline(reason = 'no reproducer command detected'): BaselineResult {
+  return { skipped: true, reason, exitCode: null, stdout: '', stderr: '', timedOut: false };
+}
+
+function measuredBaseline(overrides: Partial<BaselineResult> = {}): BaselineResult {
+  return {
+    skipped: false,
+    exitCode: 1,
+    stdout: 'test output',
+    stderr: 'error line',
+    timedOut: false,
+    ...overrides,
+  };
+}
+
+describe('buildVerifierUserPrompt', () => {
+  const hyp = {
+    id: 'h1',
+    claim: 'Type mismatch',
+    location: 'src/foo.ts:42',
+    proposed_fix: 'Change to number',
+  };
+
+  it('includes the BASELINE block when not skipped', () => {
+    const baseline = measuredBaseline({ exitCode: 1, stdout: 'FAIL', stderr: '' });
+    const prompt = buildVerifierUserPrompt(hyp, 'npm test', '/wt/path', baseline);
+
+    expect(prompt).toContain('BASELINE');
+    expect(prompt).toContain('exit code: 1');
+    expect(prompt).toContain('$ npm test');
+    expect(prompt).toContain('FAIL');
+  });
+
+  it('includes "(not run: …)" form when skipped', () => {
+    const baseline = skippedBaseline('no reproducer command detected');
+    const prompt = buildVerifierUserPrompt(hyp, 'npm test', '/wt/path', baseline);
+
+    expect(prompt).toContain('BASELINE');
+    expect(prompt).toContain('(not run: no reproducer command detected)');
+    expect(prompt).not.toContain('exit code:');
+  });
+
+  it('appends TIMED OUT note when timedOut is true', () => {
+    const baseline = measuredBaseline({ exitCode: null, timedOut: true });
+    const prompt = buildVerifierUserPrompt(hyp, 'npm test', '/wt/path', baseline);
+
+    expect(prompt).toContain('TIMED OUT');
+  });
+
+  it('includes guidance to set stance: blocks when exit code is 0', () => {
+    const baseline = measuredBaseline({ exitCode: 0 });
+    const prompt = buildVerifierUserPrompt(hyp, 'npm test', '/wt/path', baseline);
+
+    expect(prompt).toContain('exit code: 0');
+    expect(prompt).toMatch(/stance.*blocks/i);
+  });
+
+  it('does not include stance:blocks guidance when exit code is non-zero', () => {
+    const baseline = measuredBaseline({ exitCode: 1 });
+    const prompt = buildVerifierUserPrompt(hyp, 'npm test', '/wt/path', baseline);
+
+    expect(prompt).not.toMatch(/stance.*blocks/i);
+  });
+
+  it('includes the worktree path', () => {
+    const baseline = skippedBaseline();
+    const prompt = buildVerifierUserPrompt(hyp, 'npm test', '/isolated/worktree', baseline);
+
+    expect(prompt).toContain('/isolated/worktree');
+  });
+
+  it('includes hypothesis fields', () => {
+    const baseline = skippedBaseline();
+    const prompt = buildVerifierUserPrompt(hyp, 'npm test', '/wt', baseline);
+
+    expect(prompt).toContain('Type mismatch');
+    expect(prompt).toContain('src/foo.ts:42');
+    expect(prompt).toContain('Change to number');
+  });
 });

--- a/src/skills/diagnose/index.ts
+++ b/src/skills/diagnose/index.ts
@@ -160,6 +160,175 @@ export function parseShadowVerifyOutput(raw: string): Verification[] {
 
 const execFile = promisify(execFileCallback);
 
+// ---------------------------------------------------------------------------
+// Baseline reproducer execution
+// ---------------------------------------------------------------------------
+
+/**
+ * The result of running the reproducer command ONCE on the current/unfixed
+ * code at the repo root — before any worktree is created.
+ */
+export interface BaselineResult {
+  skipped: boolean;
+  reason?: string;
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+/**
+ * Truncate a string to its LAST `maxLen` characters, prefixing with a marker
+ * when truncation occurred.  Test failures surface at the end of output.
+ */
+function tailTruncate(s: string, maxLen: number): string {
+  if (s.length <= maxLen) return s;
+  return `...[truncated]\n${s.slice(s.length - maxLen)}`;
+}
+
+/**
+ * Run the detected reproducer command ONCE on the current/unfixed code and
+ * return the measured result as ground truth for the verifier.
+ *
+ * @param command  The raw shell command string extracted by detectReproducer.
+ * @param cwd      MUST be parsedInput.repoPath (the real repo root, which has
+ *                 node_modules). Worktrees lack gitignored deps.
+ * @param exec     Injectable execFile shim — defaults to the module-level
+ *                 promisified execFile so tests can fake it without spawning
+ *                 real processes.
+ *
+ * // Invariant: The parent (orchestrator TS code) executes the SINGLE detected
+ * // reproducer command — NOT a model-chosen command — directly at the repo
+ * // root. This is bounded and faithful to what the developer would run by
+ * // hand, but a true execution sandbox (container / network-egress isolation)
+ * // is tracked as a separate follow-up. The kill switch
+ * // AFK_DIAGNOSE_BASELINE=0 disables execution entirely for environments
+ * // where running untrusted commands at session time is unacceptable.
+ */
+export async function runReproducerBaseline(
+  command: string,
+  cwd: string,
+  exec: typeof execFile = execFile,
+): Promise<BaselineResult> {
+  const TRUNCATE_LEN = 4000;
+
+  // Kill switch: opt out of baseline execution.
+  if (process.env['AFK_DIAGNOSE_BASELINE'] === '0') {
+    return {
+      skipped: true,
+      reason: 'disabled via AFK_DIAGNOSE_BASELINE=0',
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+    };
+  }
+
+  // Guard: don't run if there's no command.
+  if (!command || !command.trim()) {
+    return {
+      skipped: true,
+      reason: 'no reproducer command detected',
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+    };
+  }
+
+  try {
+    // Run via shell so the full reproducer string (pipes, env vars, etc.) works.
+    const result = await exec('/bin/sh', ['-c', command], {
+      cwd,
+      timeout: 120_000,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    // Zero-exit path — reproducer passed on current code.
+    return {
+      skipped: false,
+      exitCode: 0,
+      stdout: tailTruncate(result.stdout, TRUNCATE_LEN),
+      stderr: tailTruncate(result.stderr, TRUNCATE_LEN),
+      timedOut: false,
+    };
+  } catch (err: unknown) {
+    // promisified execFile rejects on non-zero exit — that IS the expected
+    // baseline case (failing test/reproducer on unfixed code). Read the
+    // structured error properties rather than treating this as a real error.
+    const e = err as {
+      code?: number | string | null;
+      stdout?: string;
+      stderr?: string;
+      killed?: boolean;
+      signal?: string;
+    };
+    const timedOut = e.killed === true || e.signal === 'SIGTERM';
+    const exitCode = typeof e.code === 'number' ? e.code : null;
+    return {
+      skipped: false,
+      exitCode,
+      stdout: tailTruncate(e.stdout ?? '', TRUNCATE_LEN),
+      stderr: tailTruncate(e.stderr ?? '', TRUNCATE_LEN),
+      timedOut,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Verifier prompt construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the user prompt sent to the read-only verifier subagent.
+ * Exported for unit testing.
+ */
+export function buildVerifierUserPrompt(
+  hypothesis: { id: string; claim: string; location?: string; proposed_fix?: string },
+  reproducer: string,
+  worktreePath: string,
+  baseline: BaselineResult,
+): string {
+  const baselineBlock = buildBaselineBlock(baseline, reproducer);
+  return (
+    `Test this hypothesis:\n\n` +
+    `Claim: ${hypothesis.claim}\n` +
+    `Location: ${hypothesis.location ?? 'unknown'}\n` +
+    `Proposed fix: ${hypothesis.proposed_fix ?? 'unknown'}\n` +
+    `Reproducer: ${reproducer}\n\n` +
+    `Working directory (isolated): ${worktreePath}\n\n` +
+    baselineBlock
+  );
+}
+
+/**
+ * Render the BASELINE block appended to the verifier prompt.
+ */
+function buildBaselineBlock(baseline: BaselineResult, reproducer: string): string {
+  const lines: string[] = [
+    'BASELINE (measured by the orchestrator on the CURRENT/unfixed code at the repo root — ground truth you MUST NOT contradict):',
+  ];
+  if (baseline.skipped) {
+    lines.push(`(not run: ${baseline.reason ?? 'unknown reason'})`);
+  } else {
+    lines.push(`$ ${reproducer}`);
+    lines.push(
+      `exit code: ${baseline.exitCode ?? 'unknown'}${baseline.timedOut ? ' (TIMED OUT)' : ''}`,
+    );
+    lines.push('stdout (tail):');
+    lines.push(baseline.stdout || '(empty)');
+    lines.push('stderr (tail):');
+    lines.push(baseline.stderr || '(empty)');
+    if (baseline.exitCode === 0) {
+      lines.push(
+        'NOTE: The reproducer PASSED on the current (unfixed) code (exit 0). ' +
+          'The failure may not reproduce or the reproducer may be wrong — set ' +
+          '`stance: "blocks"` and lower confidence.',
+      );
+    }
+  }
+  return lines.join('\n');
+}
+
 /**
  * Schema for a single hypothesis.
  *
@@ -662,6 +831,37 @@ async function handler(
 
   // Phase 4: Test hypotheses in isolated worktrees
   const reproduceCommand = reproducer || parsedInput.failure;
+
+  // Run the reproducer ONCE at the repo root (which has node_modules) to get
+  // a ground-truth baseline BEFORE any worktree is created.  Only run when a
+  // real shell command was detected via detectReproducer — never run prose
+  // failure descriptions.  The baseline is NON-FATAL: any error degrades to
+  // skipped rather than crashing the skill.
+  let baseline: BaselineResult;
+  if (reproducer) {
+    try {
+      baseline = await runReproducerBaseline(reproducer, parsedInput.repoPath);
+    } catch (baselineErr) {
+      baseline = {
+        skipped: true,
+        reason: `baseline execution error: ${baselineErr instanceof Error ? baselineErr.message : String(baselineErr)}`,
+        exitCode: null,
+        stdout: '',
+        stderr: '',
+        timedOut: false,
+      };
+    }
+  } else {
+    baseline = {
+      skipped: true,
+      reason: 'no reproducer command detected',
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+    };
+  }
+
   const verificationPromises = hypotheses_to_test.map((hypothesis) =>
     testHypothesisInWorktree(
       hypothesis,
@@ -671,6 +871,7 @@ async function handler(
       verifyPrompt,
       manager,
       skillCallId,
+      baseline,
     ),
   );
 
@@ -922,6 +1123,7 @@ async function testHypothesisInWorktree(
   // rather than orphaning at root. Optional — `undefined` preserves legacy
   // (raw session UUID → render-at-root) behavior.
   skillCallId?: string,
+  baseline?: BaselineResult,
 ): Promise<VerificationResult> {
   const worktreePath = join(tmpdir(), `diagnose-hyp-${hypothesis.id}-${Date.now()}`);
   let verifierHandle: SubagentHandle<VerificationResult> | undefined;
@@ -965,12 +1167,15 @@ async function testHypothesisInWorktree(
       ...(skillCallId ? { parentId: skillCallId } : {}),
     });
 
-    const userPrompt = `Test this hypothesis:\n\n` +
-      `Claim: ${hypothesis.claim}\n` +
-      `Location: ${hypothesis.location || 'unknown'}\n` +
-      `Proposed fix: ${hypothesis.proposed_fix || 'unknown'}\n` +
-      `Reproducer: ${reproducer}\n\n` +
-      `Working directory (isolated): ${worktreePath}`;
+    const effectiveBaseline: BaselineResult = baseline ?? {
+      skipped: true,
+      reason: 'baseline not computed',
+      exitCode: null,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+    };
+    const userPrompt = buildVerifierUserPrompt(hypothesis, reproducer, worktreePath, effectiveBaseline);
 
     const verificationResult = await verifierHandle.runToResult(userPrompt);
 

--- a/src/skills/diagnose/prompts/verify.md
+++ b/src/skills/diagnose/prompts/verify.md
@@ -58,3 +58,14 @@ OMIT `signal` when the assessment was inconclusive (e.g., the relevant code
 could not be located). Do not invent a stance to fill the slot.
 
 IMPORTANT: You are working in an isolated worktree with read-only restrictions. Edit, Write, and Bash tools are disabled — your verdict is a static code-reading prediction, not an executed test result. If reading alone cannot determine the outcome, set `stance: "blocks"` and reduce confidence.
+
+## BASELINE block
+
+Your prompt will include a **BASELINE** block measured by the orchestrator (the deterministic parent process) by running the reproducer ONCE on the current/unfixed code at the repo root — before any worktree was created. Treat this as ground truth:
+
+- Use the baseline exit code and output to anchor your `predicted_pass` prediction and `confidence`.
+- If the baseline shows exit code 0 (the reproducer PASSED on the current/unfixed code), the failure may not reproduce or the reproducer may be wrong — set `stance: "blocks"` and lower confidence.
+- If the baseline shows a non-zero exit code, the failure reproduces as expected — your assessment of whether the proposed fix would make it pass is the core question.
+- If the baseline was not run (shown as "(not run: …)"), proceed with code reading alone and note the reduced certainty in `confidence`.
+
+You MUST NOT contradict what the baseline reports. The baseline is measured fact; your code-reading assessment builds on top of it.


### PR DESCRIPTION
## What this does

The diagnose skill forks a read-only verifier subagent (Bash/Edit/Write denied via `createVerifierCanUseTool`) into an isolated git worktree to assess each hypothesis fix. Previously the verifier's `predicted_pass` verdict was a static code-reading guess with no empirical anchor.

This PR gives the verdict a real anchor by having the **deterministic parent** (the orchestrator TS code) run the reproducer **once** on the current/unfixed code and inject the measured result into each verifier's prompt as ground truth.

**The verifier stays read-only** — `createVerifierCanUseTool` is unchanged.

### Run-at-repo-root rationale

The baseline runs at `parsedInput.repoPath` (the real repo root), NOT in a worktree. Worktrees lack gitignored dependencies (e.g. `node_modules`), so running the test suite there would produce meaningless results. The baseline measures the CURRENT/unfixed code, which lives at the repo root.

### Security posture

- Only the **single detected** shell command (from `detectReproducer`) is run — not a model-chosen command.
- Kill switch: `AFK_DIAGNOSE_BASELINE=0` disables execution entirely for environments where running commands at session time is unacceptable.
- `cwd` is always `parsedInput.repoPath`; never a worktree path.
- `createVerifierCanUseTool()` is **unchanged** — Edit/Write/Bash/Agent/Task remain denied.
- A true execution sandbox (container / network-egress isolation) is tracked as a separate follow-up.

### New exports (unit-tested at the injected-exec seam)

- `runReproducerBaseline(command, cwd, exec?)` — injectable `exec` param so tests fake it without spawning real processes
- `buildVerifierUserPrompt(hypothesis, reproducer, worktreePath, baseline)` — pure function, unit-testable

### verify.md

Added a BASELINE block section instructing the verifier to treat the injected measurement as ground truth, use exit code + output to anchor `predicted_pass` and `confidence`, and set `stance: "blocks"` if exit code is 0 (reproducer passed on unfixed code).

### No schema change

`VerificationResultSchema` is unchanged. The model folds the baseline into the existing `predicted_pass`, `confidence`, `verification_log`, and `signal` fields.

## Depends on / stacks on

- **PR #8** (`fix/diagnose-verifier-honest-labeling`) — honest labeling of the verifier as read-only/prediction-based. This PR base-branches off that work; it should be merged first.

## Step 1 of 2

**Step 2** (structured-patch schema + post-fix execution in the worktree) is a separate future PR.