### PR TITLE
feat(skills): redesign /skills listing + detail UX (phase 1)

### DIFF
--- a/src/cli/slash-commands.test.ts
+++ b/src/cli/slash-commands.test.ts
@@ -666,7 +666,7 @@ describe('plugin-skills bridge', () => {
     expect(uniqueRes.handled).toBe(true);
   });
 
-  it('/skills after init renders main rows + alt continuation rows for shadowed plugins', async () => {
+  it('/skills after init surfaces shadowed plugins as inline "↳ also:" alternatives', async () => {
     const sess = fakeSession({
       supportedCommands: vi.fn().mockResolvedValue([
         { name: 'mint', description: 'One-prompt feature delivery', argumentHint: '' },
@@ -680,10 +680,13 @@ describe('plugin-skills bridge', () => {
     // Vendored mains still appear with their slash forms.
     expect(joined).toContain('/mint');
     expect(joined).toContain('/diagnose');
-    // Plugin alt rows surface the namespaced fallback + plugin description.
+    // Shadowed plugin collisions surface inline as compact "↳ also:" references
+    // to the namespaced fallback form — visible by default, not hidden.
+    expect(joined).toContain('↳ also:');
     expect(joined).toContain('/plugin:mint');
-    expect(joined).toContain('One-prompt feature delivery');
-    expect(joined).toContain('plugin alt');
+    expect(joined).toContain('/plugin:diagnose');
+    // The old raw "(plugin alt)" badge + duplicated alt description are gone.
+    expect(joined).not.toContain('plugin alt');
   });
 
   it('registerPluginSkills() handles SDK errors gracefully and returns null', async () => {

--- a/src/cli/slash/plugin-skills-listing.test.ts
+++ b/src/cli/slash/plugin-skills-listing.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the redesigned `/skills` listing + detail UX (Phase 1).
+ *
+ * Covers the behavior changes shipped in the listing redesign:
+ *   - descriptions WRAP (via wrapToWidth) instead of clipping at 80 chars,
+ *   - built-in skills render in their own top block,
+ *   - a human-friendly source legend replaces raw `(user)`/`(plugin)` badges,
+ *   - shadowed/alias forms surface inline as `↳ also:` lines (not hidden),
+ *   - `/skills <name>` renders an enriched detail card with an Alternatives
+ *     section,
+ *   - `/skills --all` (a leading-dash token) renders the listing, not a 404,
+ *   - narrow terminals don't throw.
+ *
+ * Assertions strip ANSI so they pin TEXT, not color codes.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { _resetRegistry, registerSkill } from '../../skills/index.js';
+import { resetRegistry } from './registry.js';
+import { initialSkillsCmd } from './plugin-skills.js';
+import { stripAnsi } from '../display.js';
+import type { SlashContext } from './types.js';
+
+function makeCtx(): { ctx: SlashContext; lines: string[] } {
+  const lines: string[] = [];
+  const ctx: SlashContext = {
+    session: { current: {} } as unknown as SlashContext['session'],
+    stats: {
+      totalTurns: 0,
+      totalCostUsd: 0,
+      totalTokens: 0,
+      totalDurationMs: 0,
+      sessionStartTime: Date.now(),
+      turnCosts: [],
+      turnTokens: [],
+      turns: [],
+      model: 'sonnet',
+      planMode: false,
+    },
+    out: {
+      line: (t = '') => lines.push(t),
+      raw: (t) => lines.push(t),
+      success: (t) => lines.push(`SUCCESS:${t}`),
+      info: (t) => lines.push(`INFO:${t}`),
+      warn: (t) => lines.push(`WARN:${t}`),
+      error: (t) => lines.push(`ERROR:${t}`),
+    },
+    ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
+  };
+  return { ctx, lines };
+}
+
+/** Force a terminal width for width-dependent rendering. Restored in afterEach. */
+function setColumns(n: number): void {
+  Object.defineProperty(process.stdout, 'columns', {
+    value: n,
+    configurable: true,
+    writable: true,
+  });
+}
+
+const LONG_DESC =
+  'Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu ' +
+  'xi omicron pi rho sigma tau upsilon phi chi psi omega final-sentinel-word';
+
+describe('/skills listing UX (Phase 1)', () => {
+  const origColumns = process.stdout.columns;
+
+  beforeEach(() => {
+    resetRegistry();
+    _resetRegistry();
+    vi.unstubAllEnvs();
+    vi.stubEnv('AFK_INTERNAL', undefined as unknown as string);
+
+    // A vendored (built-in) skill + a colliding user-scope alias, plus a
+    // second vendored skill with a long description for the wrapping test.
+    registerSkill({
+      name: 'mint',
+      description: 'Deliver a feature end-to-end in one ship-ready pass.',
+      whenToUse: 'When a novel multi-day feature genuinely benefits from a spec.',
+      flags: ['--continue'],
+      handler: async () => 'ok',
+    });
+    registerSkill({
+      name: 'user:mint',
+      description: 'A user-scope mint override.',
+      origin: 'user',
+      handler: async () => 'ok',
+    });
+    registerSkill({
+      name: 'wrapme',
+      description: LONG_DESC,
+      handler: async () => 'ok',
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    setColumns(origColumns as number);
+  });
+
+  it('renders a built-in block header with built-in skills under it', async () => {
+    const { ctx, lines } = makeCtx();
+    await initialSkillsCmd.handler(ctx, '');
+    const out = stripAnsi(lines.join('\n'));
+
+    expect(out).toContain('Skills');
+    expect(out).toContain('Built-in');
+    expect(out).toContain('/mint');
+    expect(out).toContain('/wrapme');
+  });
+
+  it('shows a friendly source legend (no raw "(user)"/"(plugin)" badges)', async () => {
+    const { ctx, lines } = makeCtx();
+    await initialSkillsCmd.handler(ctx, '');
+    const out = stripAnsi(lines.join('\n'));
+
+    expect(out).toContain('built-in');
+    expect(out).toContain('user');
+    expect(out).toContain('/skills <name> for details');
+    // The old raw badge formatting must be gone.
+    expect(out).not.toContain('(user)');
+    expect(out).not.toContain('(plugin alt)');
+  });
+
+  it('wraps long descriptions instead of clipping them at 80 chars', async () => {
+    setColumns(50);
+    const { ctx, lines } = makeCtx();
+    await initialSkillsCmd.handler(ctx, '');
+    const out = stripAnsi(lines.join('\n'));
+
+    // The last word survives (clipping would have dropped it) and no ellipsis
+    // truncation marker appears.
+    expect(out).toContain('final-sentinel-word');
+    expect(out).not.toContain('…');
+  });
+
+  it('surfaces shadowed/alias forms inline as "↳ also:" (not hidden)', async () => {
+    const { ctx, lines } = makeCtx();
+    await initialSkillsCmd.handler(ctx, '');
+    const out = stripAnsi(lines.join('\n'));
+
+    expect(out).toContain('↳ also:');
+    expect(out).toContain('/user:mint');
+  });
+
+  it('detail card shows description, when-to-use, flags, source, alternatives', async () => {
+    const { ctx, lines } = makeCtx();
+    await initialSkillsCmd.handler(ctx, 'mint');
+    const out = stripAnsi(lines.join('\n'));
+
+    expect(out).toContain('/mint');
+    expect(out).toContain('Deliver a feature end-to-end');
+    expect(out).toContain('When to use');
+    expect(out).toContain('novel multi-day feature');
+    expect(out).toContain('Flags');
+    expect(out).toContain('--continue');
+    expect(out).toContain('Source');
+    expect(out).toContain('built-in');
+    expect(out).toContain('Alternatives');
+    expect(out).toContain('/user:mint');
+    expect(out).toContain('shadowed by /mint');
+  });
+
+  it('detail for an unknown skill suggests running /skills', async () => {
+    const { ctx, lines } = makeCtx();
+    await initialSkillsCmd.handler(ctx, 'does-not-exist');
+    const out = stripAnsi(lines.join('\n'));
+
+    expect(out).toMatch(/no skill found/i);
+    expect(out).toContain('Run /skills');
+  });
+
+  it('treats a leading-dash arg (--all) as the listing, not a 404 lookup', async () => {
+    const { ctx, lines } = makeCtx();
+    await initialSkillsCmd.handler(ctx, '--all');
+    const out = stripAnsi(lines.join('\n'));
+
+    expect(out).toContain('Skills');
+    expect(out).not.toMatch(/no skill found/i);
+  });
+
+  it('does not throw in a very narrow terminal', async () => {
+    setColumns(20);
+    const { ctx } = makeCtx();
+    await expect(initialSkillsCmd.handler(ctx, '')).resolves.toBe('continue');
+  });
+});

--- a/src/cli/slash/plugin-skills.ts
+++ b/src/cli/slash/plugin-skills.ts
@@ -49,6 +49,9 @@ import { getMarketplaceCacheDir } from '../../paths.js';
 import { listSkills, getSkill, isSkillVisible, listVisibleSkills, type SkillMetadata } from '../../skills/index.js';
 import { palette } from '../palette.js';
 import { divider } from '../render.js';
+import { wrapToWidth } from '../wrap.js';
+import { getTerminalWidth } from '../terminal-size.js';
+import { padDisplayRight, displayWidth } from '../display.js';
 import { registerPluginAgents } from './plugin-agents.js';
 import { registerOrReplace, register } from './registry.js';
 import {
@@ -315,6 +318,9 @@ export function makeForwardHandler(skill: DiscoveredSkill, flags?: readonly stri
   };
 }
 
+/** Where a listing row's skill came from. Drives the friendly source label. */
+type SkillSource = 'builtin' | 'user' | 'project' | 'plugin';
+
 /** A row in the unified `/skills` listing. */
 interface ListingRow {
   /** Slash form for tab-completion / invocation, e.g. `/mint` or `/example-plugin:mint`. */
@@ -322,13 +328,20 @@ interface ListingRow {
   /** Display form preferred when present, e.g. `/mint <idea>` or `/forge [--brief]`. */
   display: string;
   description: string;
-  /** Source label rendered as a dim badge. Vendored is unlabeled. */
-  sourceLabel?: 'user' | 'plugin';
+  /** Origin of the skill — surfaced as a friendly source label, never a raw badge. */
+  source: SkillSource;
 }
 
 interface ListingGroup {
   main: ListingRow;
   alts: ListingRow[];
+}
+
+/** Map a registry skill's `origin` (absent = vendored) to a listing source. */
+function registryOriginToSource(origin: SkillMetadata['origin']): SkillSource {
+  if (origin === 'user') return 'user';
+  if (origin === 'project') return 'project';
+  return 'builtin';
 }
 
 function buildListingGroups(plugins: DiscoveredSkill[], internalUnlocked: boolean): Map<string, ListingGroup> {
@@ -344,22 +357,22 @@ function buildListingGroups(plugins: DiscoveredSkill[], internalUnlocked: boolea
     }
   };
 
-  // Pass 1: registry skills. Vendored + user — vendored has no badge,
-  // user gets the (user) badge. Names already account for collision
-  // (user-skills.ts shifts colliding names to `user:<name>`).
+  // Pass 1: registry skills (vendored + user + project). Names already account
+  // for collision (user-skills.ts shifts colliding names to `<origin>:<name>`),
+  // so a `user:mint` lands as an alt under the vendored `mint` via addRow's
+  // bare-name keying.
   for (const name of listVisibleSkills(internalUnlocked)) {
     const skill = getSkill(name);
     const slashName = `/${name}`;
     const display = skill.argumentHint
       ? `${slashName} ${skill.argumentHint}`
       : slashName;
-    const row: ListingRow = {
+    addRow({
       slashName,
       display,
       description: skill.description,
-    };
-    if (skill.origin === 'user') row.sourceLabel = 'user';
-    addRow(row);
+      source: registryOriginToSource(skill.origin),
+    });
   }
 
   // Pass 2: plugin skills. Group by bare name so a colliding plugin entry
@@ -380,44 +393,74 @@ function buildListingGroups(plugins: DiscoveredSkill[], internalUnlocked: boolea
       slashName,
       display,
       description: skill.description,
-      sourceLabel: 'plugin',
+      source: 'plugin',
     });
   }
 
   return groups;
 }
 
-function truncateDescription(text: string, max = 80): string {
-  const dot = text.indexOf('. ');
-  const firstSentence = dot >= 0 ? text.slice(0, dot + 1) : text;
-  const base = firstSentence.length <= max ? firstSentence : text;
-  if (base.length <= max) return base;
-  return base.slice(0, max - 1) + '…';
+/** Human-friendly source label — replaces the old raw `(user)`/`(plugin)` badges. */
+function friendlySource(source: SkillSource): string {
+  switch (source) {
+    case 'builtin':
+      return 'built-in';
+    case 'user':
+      return 'user';
+    case 'project':
+      return 'project';
+    case 'plugin':
+      return 'plugin';
+  }
 }
 
-function renderListingGroup(ctx: SlashContext, group: ListingGroup, displayWidth: number): void {
-  const main = group.main;
-  const displayCell = palette.warning(main.display.padEnd(displayWidth));
-  const badge = main.sourceLabel ? palette.dim(`(${main.sourceLabel}) `) : '';
-  ctx.out.line(`  ${displayCell} ${badge}${palette.dim(truncateDescription(main.description))}`);
+/** Sort comparator: alphabetical by bare skill name. */
+function byBareName(a: ListingGroup, b: ListingGroup): number {
+  const an = bareName(a.main.slashName.replace(/^\//, ''));
+  const bn = bareName(b.main.slashName.replace(/^\//, ''));
+  return an.localeCompare(bn);
+}
 
-  for (const alt of group.alts) {
-    const altCell = palette.warning(alt.display.padEnd(Math.max(0, displayWidth - 4)));
-    const altBadge = alt.sourceLabel
-      ? palette.dim(`(${alt.sourceLabel} alt) `)
-      : palette.dim('(alt) ');
-    ctx.out.line(
-      `    ${palette.dim('└')} ${altCell} ${altBadge}${palette.dim(truncateDescription(alt.description))}`,
-    );
+/**
+ * Render one skill as a wrapped two-column row: padded name on the left, the
+ * word-wrapped description on the right (continuation lines hang under the
+ * description column). When a name is too wide for the gutter it takes its own
+ * line. Shadowed/alternative forms render as a dim `↳ also:` continuation line
+ * — visible by default, never hidden behind a flag.
+ */
+function renderGroupRows(
+  ctx: SlashContext,
+  group: ListingGroup,
+  nameW: number,
+  descW: number,
+): void {
+  const { main, alts } = group;
+  const wrapped = wrapToWidth(main.description, descW).split('\n');
+
+  if (displayWidth(main.display) > nameW - 1) {
+    // Name too wide for the gutter — give it its own line, hang the description.
+    ctx.out.line('  ' + palette.warning(main.display));
+    for (const line of wrapped) {
+      ctx.out.line('  ' + ' '.repeat(nameW) + palette.dim(line));
+    }
+  } else {
+    const paddedName = padDisplayRight(palette.warning(main.display), nameW);
+    ctx.out.line('  ' + paddedName + palette.dim(wrapped[0] ?? ''));
+    for (const extra of wrapped.slice(1)) {
+      ctx.out.line('  ' + ' '.repeat(nameW) + palette.dim(extra));
+    }
+  }
+
+  if (alts.length > 0) {
+    const altForms = alts.map((a) => a.slashName).join(', ');
+    for (const altLine of wrapToWidth(`↳ also: ${altForms}`, descW).split('\n')) {
+      ctx.out.line('  ' + ' '.repeat(nameW) + palette.dim(altLine));
+    }
   }
 }
 
 function renderUnifiedListing(ctx: SlashContext, plugins: DiscoveredSkill[], internalUnlocked: boolean): void {
   const groups = buildListingGroups(plugins, internalUnlocked);
-  const total = Array.from(groups.values()).reduce(
-    (n, g) => n + 1 + g.alts.length,
-    0,
-  );
 
   ctx.out.line();
   if (groups.size === 0) {
@@ -426,24 +469,51 @@ function renderUnifiedListing(ctx: SlashContext, plugins: DiscoveredSkill[], int
     return;
   }
 
-  ctx.out.line(palette.bold('Skills') + palette.dim(`  (${total} loaded)`));
-  ctx.out.line(divider());
+  const allGroups = Array.from(groups.values());
+  const altCount = allGroups.reduce((n, g) => n + g.alts.length, 0);
 
-  // Compute the maximum width for the display column so everything aligns.
-  const sortedKeys = Array.from(groups.keys()).sort();
-  const maxDisplay =
-    sortedKeys.reduce((m, k) => {
-      const g = groups.get(k)!;
-      return Math.max(m, g.main.display.length);
-    }, 0) + 2;
+  // Built-in skills carry the richest metadata and are the modal starting
+  // point, so they get their own block at the top. Everything else (user,
+  // project, plugin) follows in a second block. Within each, alphabetical.
+  const builtinGroups = allGroups.filter((g) => g.main.source === 'builtin').sort(byBareName);
+  const otherGroups = allGroups.filter((g) => g.main.source !== 'builtin').sort(byBareName);
 
-  for (const key of sortedKeys) {
-    renderListingGroup(ctx, groups.get(key)!, maxDisplay);
+  // Column widths mirror the help-table layout: name column capped at ~45% of
+  // the terminal, the rest for the wrapped description. Width-aware so narrow
+  // terminals stay readable.
+  const termW = Math.max(20, getTerminalWidth());
+  const maxDisplay = allGroups.reduce((m, g) => Math.max(m, displayWidth(g.main.display)), 0);
+  const nameW = Math.min(maxDisplay + 2, Math.max(10, Math.floor((termW - 2) * 0.45)));
+  const descW = Math.max(12, termW - 2 - nameW);
+
+  // Header + a one-line source legend listing only the sources actually present.
+  ctx.out.line(palette.bold('Skills') + palette.dim(`  (${allGroups.length})`));
+  const present = new Set(allGroups.map((g) => g.main.source));
+  const legend = (['builtin', 'user', 'project', 'plugin'] as const)
+    .filter((s) => present.has(s))
+    .map(friendlySource)
+    .join(' · ');
+  ctx.out.line(palette.dim(`  ${legend} — /skills <name> for details`));
+
+  if (builtinGroups.length > 0) {
+    ctx.out.line();
+    ctx.out.line(divider('Built-in'));
+    for (const g of builtinGroups) renderGroupRows(ctx, g, nameW, descW);
+  }
+  if (otherGroups.length > 0) {
+    ctx.out.line();
+    ctx.out.line(builtinGroups.length > 0 ? divider('Plugins & user skills') : divider());
+    for (const g of otherGroups) renderGroupRows(ctx, g, nameW, descW);
   }
 
   ctx.out.line();
-  ctx.out.line(palette.dim('  Tip: /skills <name> for full details on a skill.'));
-  ctx.out.line(palette.dim('  Source: vendored (no badge), (user), (plugin). Shadowed entries listed under their winner.'));
+  ctx.out.line(
+    palette.dim(
+      altCount > 0
+        ? '  Tip: ↳ also lines show alternative (shadowed) forms · /skills <name> for full details'
+        : '  Tip: /skills <name> for full details on a skill',
+    ),
+  );
   ctx.out.line();
 }
 
@@ -457,6 +527,31 @@ function tryGetRegistrySkill(
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Collect the shadowed/alternative forms of a bare skill name — namespaced
+ * registry collisions (`user:`/`project:`) plus shadowed plugin entries. These
+ * are surfaced (not hidden) so a user always knows an alternative exists.
+ */
+function collectAlternatives(
+  bare: string,
+  internalUnlocked: boolean,
+): Array<{ slash: string; source: SkillSource }> {
+  const alternatives: Array<{ slash: string; source: SkillSource }> = [];
+
+  for (const name of listVisibleSkills(internalUnlocked)) {
+    if (name.includes(':') && bareName(name) === bare) {
+      const source = registryOriginToSource(getSkill(name).origin);
+      alternatives.push({ slash: `/${name}`, source });
+    }
+  }
+  for (const collision of state.collisions) {
+    if (collision.bare === bare) {
+      alternatives.push({ slash: collision.altSlash, source: 'plugin' });
+    }
+  }
+  return alternatives;
 }
 
 function renderSkillDetail(
@@ -475,6 +570,7 @@ function renderSkillDetail(
   if (!registrySkill && !pluginSkill) {
     ctx.out.line();
     ctx.out.line(palette.dim(`  No skill found matching "${cleaned}".`));
+    ctx.out.line(palette.dim('  Run /skills to see everything available.'));
     ctx.out.line();
     return;
   }
@@ -483,31 +579,56 @@ function renderSkillDetail(
   const description = registrySkill?.description ?? pluginSkill!.description;
   const hint = registrySkill?.argumentHint ?? pluginSkill?.argumentHint;
   const displayName = hint ? `/${name} ${hint}` : `/${name}`;
-  const origin = registrySkill
-    ? registrySkill.origin ?? 'builtin'
+  const source: SkillSource = registrySkill
+    ? registryOriginToSource(registrySkill.origin)
     : 'plugin';
+
+  // Wrap the body to the terminal width (capped) so long descriptions read as
+  // paragraphs instead of one runaway line.
+  const termW = Math.max(20, getTerminalWidth());
+  const bodyW = Math.max(20, Math.min(termW - 2, 100));
 
   ctx.out.line();
   ctx.out.line(`  ${palette.warning(displayName)}`);
   ctx.out.line();
-  ctx.out.line(`  ${description}`);
-
-  if (registrySkill?.whenToUse) {
-    ctx.out.line();
-    ctx.out.line(`  ${palette.bold('When to use:')}`);
-    ctx.out.line(`  ${palette.dim(registrySkill.whenToUse)}`);
+  for (const line of wrapToWidth(description, bodyW).split('\n')) {
+    ctx.out.line(`  ${line}`);
   }
 
-  const flags = registrySkill?.flags;
-  const pluginFlags = harvestPluginSkillFlags().get(cleaned);
-  const allFlags = flags ?? pluginFlags;
-  if (allFlags && allFlags.length > 0) {
+  // "When to use": structured field for vendored skills; for plugin/user skills
+  // fall back to plucking a "Use when…" sentence out of the description. Skip
+  // when it would merely echo the description verbatim.
+  const whenToUse = registrySkill?.whenToUse ?? extractHintFromDescription(description);
+  if (whenToUse && whenToUse !== description.trim()) {
     ctx.out.line();
-    ctx.out.line(`  ${palette.bold('Flags:')} ${palette.dim(allFlags.join(', '))}`);
+    ctx.out.line(`  ${palette.bold('When to use')}`);
+    for (const line of wrapToWidth(whenToUse, bodyW).split('\n')) {
+      ctx.out.line(`  ${palette.dim(line)}`);
+    }
+  }
+
+  const flags = registrySkill?.flags ?? harvestPluginSkillFlags().get(cleaned);
+  if (flags && flags.length > 0) {
+    ctx.out.line();
+    ctx.out.line(`  ${palette.bold('Flags')}  ${palette.dim(flags.join(', '))}`);
   }
 
   ctx.out.line();
-  ctx.out.line(`  ${palette.bold('Source:')} ${palette.dim(origin)}`);
+  ctx.out.line(`  ${palette.bold('Source')}  ${palette.dim(friendlySource(source))}`);
+
+  const alternatives = collectAlternatives(name, internalUnlocked);
+  if (alternatives.length > 0) {
+    ctx.out.line();
+    ctx.out.line(`  ${palette.bold('Alternatives')}`);
+    for (const alt of alternatives) {
+      ctx.out.line(
+        `  ${palette.dim('↳')} ${palette.warning(alt.slash)} ${palette.dim(
+          `(${friendlySource(alt.source)} — shadowed by /${name})`,
+        )}`,
+      );
+    }
+  }
+
   ctx.out.line();
 }
 
@@ -525,8 +646,11 @@ export const initialSkillsCmd: SlashCommand = {
   hint: 'When you want to browse every skill the session can dispatch — pass a name for full details on one.',
   async handler(ctx, args) {
     const internalUnlocked = env.AFK_INTERNAL === '1';
-    if (args.trim()) {
-      renderSkillDetail(ctx, args.trim(), [], internalUnlocked);
+    const trimmed = args.trim();
+    // A leading-dash token (e.g. `--all`) is reserved for future verbose modes;
+    // for now it just renders the full listing rather than 404 as a skill name.
+    if (trimmed && !trimmed.startsWith('-')) {
+      renderSkillDetail(ctx, trimmed, [], internalUnlocked);
     } else {
       renderUnifiedListing(ctx, [], internalUnlocked);
     }
@@ -544,8 +668,11 @@ function makeDynamicSkillsCmd(plugins: DiscoveredSkill[]): SlashCommand {
     hint: 'When you want to browse every skill the session can dispatch — pass a name for full details on one.',
     async handler(ctx, args) {
       const internalUnlocked = env.AFK_INTERNAL === '1';
-      if (args.trim()) {
-        renderSkillDetail(ctx, args.trim(), plugins, internalUnlocked);
+      const trimmed = args.trim();
+      // A leading-dash token (e.g. `--all`) is reserved for future verbose
+      // modes; for now it renders the full listing rather than 404 as a name.
+      if (trimmed && !trimmed.startsWith('-')) {
+        renderSkillDetail(ctx, trimmed, plugins, internalUnlocked);
       } else {
         renderUnifiedListing(ctx, plugins, internalUnlocked);
       }


### PR DESCRIPTION
## Summary

Redesigns the `/skills` slash-command listing + detail UX. The previous output was a dense alphabetical registry dump — descriptions clipped at 80 chars, raw `(user)`/`(plugin)` badges, and shadowed name-collisions nested as cryptic `└ (plugin alt)` sub-rows. This makes it readable and task-oriented.

**Phase 1 of 2.** Job-to-be-done grouping is intentionally deferred to a follow-up (see below).

## What changed

- **Wrapped descriptions** (`wrapToWidth` + `getTerminalWidth`) with hanging indent, instead of clipping at 80 chars — width-aware, readable in narrow terminals.
- **Built-in skills block on top** (richest metadata, modal entry point); user/project/plugin follow in a second block. Alphabetical within each.
- **Friendly source legend** (`built-in · user · plugin — /skills <name> for details`) replaces raw `(user)`/`(plugin)` badges.
- **Shadowed/alias forms surfaced inline** as dim `↳ also: /plugin:mint` references — visible by default, never hidden or silently dropped.
- **Enriched `/skills <name>` detail card**: wrapped body, when-to-use (structured field, or a "Use when…" sentence extracted from plugin descriptions), flags, friendly source label, and an explicit **Alternatives** section explaining shadowed forms.
- Leading-dash args (e.g. `/skills --all`) render the listing instead of 404-ing as a skill name (reserved for a future verbose mode).

All logic stays in `src/cli/slash/plugin-skills.ts` and reuses existing render primitives (`wrapToWidth`, `getTerminalWidth`, `padDisplayRight`, `divider`). No new dependencies; no change to skill resolution.

## Preview

```
Skills  (4)
  built-in · user — /skills <name> for details

── Built-in ─────────────────────────────────────────────────
  /diagnose <bug>  Parallel root-cause analysis for bugs and failing tests.
  /mint <idea>     Deliver a feature or refactor end-to-end — spec, research,
                   build, verify — in one ship-ready pass. Use when a novel
                   multi-day feature genuinely benefits from a written spec.
                   ↳ also: /user:mint

── Plugins & user skills ────────────────────────────────────
  /onboard         Onboards any session to an unfamiliar repository.
  /review <pr>     Dispatches parallel dimension agents across a diff or PR …

  Tip: ↳ also lines show alternative (shadowed) forms · /skills <name> for full details
```

## Design note (why no grouping yet)

A devils-advocate critique (3 independent lenses) unanimously rejected the originally-planned render-time categorizer (curated name→category map + keyword heuristic): it infers at render time what should be authored at the source, misclassifies the plugin long-tail, and the fixed taxonomy rots as plugins evolve. Reliable job-to-be-done grouping needs a **source-authored `category` field**, which is scoped as Phase 2.

**Phase 2 follow-up: #12.**

## Testing

- `pnpm lint` (strict `tsc --noEmit`) — clean.
- New `src/cli/slash/plugin-skills-listing.test.ts` — 8 cases (wrapping vs clip, built-in block, legend, inline shadows, detail card, unknown-skill, `--all` routing, narrow-terminal safety).
- Updated the shadowed-plugin assertion in `slash-commands.test.ts` to the new inline-alternatives UX (old test pinned the removed `(plugin alt)` chrome).
- **Full suite: 439 files, 8148 passed, 12 skipped, 0 failed.**
