### PR TITLE
fix(cli): repaint REPL prompt on fresh interactive session

### DIFF
--- a/src/cli/input/input-surface.test.ts
+++ b/src/cli/input/input-surface.test.ts
@@ -258,6 +258,52 @@ describe('InputSurface', () => {
       // The pending Promise must have been rejected by dispose().
       await expect(readPromise).rejects.toThrow('disposed');
     });
+
+    it('readLine repaints the prompt before blocking even when already idle (regression: fresh-session prompt invisible until first keypress)', async () => {
+      // Regression: on a fresh `afk interactive` session, armCompositor()
+      // paints the prompt (streaming→idle repaint), then footer subsystems
+      // (loop-stage bar, bg bar) bump StatusLine.extraRows and overwrite the
+      // prompt row. The first readLine() then calls setInputMode('idle') on an
+      // ALREADY-idle compositor — a no-op for the repaint, because the
+      // `prev !== mode` guard (terminal-compositor.ts) suppresses idle→idle
+      // repaints — so the prompt stayed invisible until the user's first
+      // keypress triggered a repaint. readLine() must repaint explicitly so
+      // the prompt shows up immediately. We assert the surface-level invariant
+      // ("readLine paints the prompt before blocking") rather than a specific
+      // call count, so the test stays green under either fix shape.
+      const stdout = makeMockStdout();
+      const stdin = makeMockStdin();
+      const surface = new InputSurface({ rl: makeRl(), history: makeHistory() });
+
+      await surface.armCompositor({
+        promptFn: () => 'afk › ',
+        onCancel: () => {},
+        stdout,
+        stdin,
+      });
+      const compositor = surface.getCompositor()!;
+      expect(compositor).not.toBeNull();
+      // armCompositor leaves the compositor in idle mode — so the readLine
+      // below exercises the idle→idle (no mode change) path exactly.
+      expect(compositor.getInputMode()).toBe('idle');
+
+      // Spy AFTER arm so we measure only the readLine-triggered repaint, not
+      // armCompositor's own streaming→idle paint. vi.spyOn calls through, so
+      // the real prompt still renders.
+      const repaintSpy = vi.spyOn(compositor, 'repaint');
+
+      // Start readLine but do NOT submit — it blocks waiting for Enter. The
+      // act of calling readLine (idle→idle setInputMode, no queue) must paint
+      // the prompt at least once before blocking. Pre-fix this was zero.
+      const readPromise = surface.readLine({ promptFn: () => 'afk › ' });
+
+      expect(repaintSpy).toHaveBeenCalled();
+
+      // Cleanup: dispose rejects the in-flight readLine promise.
+      repaintSpy.mockRestore();
+      await surface.dispose();
+      await expect(readPromise).rejects.toThrow('disposed');
+    });
   });
 
   /**

--- a/src/cli/input/input-surface.ts
+++ b/src/cli/input/input-surface.ts
@@ -460,9 +460,19 @@ export class InputSurface {
         //      invariant — any → idle with queued + handler — fires
         //      the synthesized submission immediately so the queued
         //      payload auto-submits as the next turn (option (b)).
-        //   2. If we're already in idle with no queue, this is a
-        //      no-op aside from the repaint and we wait for an Enter.
+        //   2. If we're already in idle with no queue it records the
+        //      mode but does NOT repaint (the prev!==mode guard at
+        //      terminal-compositor.ts suppresses idle→idle repaints).
         compositor.setInputMode('idle');
+        // Invariant: the prompt must be on-screen before we block for
+        // input. setInputMode('idle') above does not repaint on an
+        // idle→idle transition (see (2)), and footer subsystems
+        // (loop-stage bar, bg bar) bump extraRows AFTER armCompositor's
+        // initial paint — overwriting the prompt row. Repaint here so a
+        // fresh interactive session shows the prompt immediately rather
+        // than only after the first keypress. Idle repaint is one cheap
+        // frame; redundant if the prompt was already correctly drawn.
+        compositor.repaint();
       });
     }
     // Non-TTY fallback: delegate to the existing reader.


### PR DESCRIPTION
## Summary
- Fixes the REPL prompt being invisible on a fresh `afk interactive` session until the user's first keypress (the prompt line `afk (model) ›` only appeared after typing began).
- **Root cause:** `armCompositor()` paints the prompt while `StatusLine.extraRows = 0`, then `loopStageBar.start()` bumps `extraRows` to 1 and paints the stage bar over the prompt's row. The first `readLine()` then calls `compositor.setInputMode('idle')` on an *already-idle* compositor — a no-op for the repaint, because the `if (prev !== mode) this.repaint()` guard in `TerminalCompositor` (terminal-compositor.ts) suppresses idle→idle repaints. `CupFrameRenderer` has no content-diffing, so that guard exists to avoid redundant writes. Net effect: nothing repainted the displaced prompt until the first keypress triggered `dispatchKey → repaint`.
- **Fix:** `readLine()` in `src/cli/input/input-surface.ts` now calls `compositor.repaint()` explicitly after `setInputMode('idle')`, so the prompt is drawn before the compositor blocks for input.
- Chosen over broadening the compositor's `setInputMode` guard: the surface-local fix doesn't touch the shared mode-transition guard (which `resumeInput`/`suspendInput` idempotency tests depend on), keeping blast radius minimal. The previously-inaccurate "no-op aside from the repaint" comment is corrected.

## Test results
- `pnpm lint` (tsc --noEmit, strict): **passed**.
- `pnpm test` (vitest run): **439 files, 8152 passed, 12 skipped, 0 failures**.
- New regression test `input-surface.test.ts › "readLine repaints the prompt before blocking even when already idle"`: confirmed to **FAIL without the fix** ("expected repaint to be called at least once") and **PASS with it**.

## Verification
No adversarial verifier wave requested (diff is +58/-2, under the 100-line threshold). The root cause was independently re-derived from source before the fix landed — the originating `/diagnose` run's premise checks came back inconclusive, so the mechanism was confirmed by direct reads of `input-surface.ts`, `terminal-compositor.ts`, and `repl-loop.ts` rather than trusting the auto-fix.
