### PR TITLE
fix: unblock pre-auth CLI commands; require Node >= 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@
 npm install -g agent-afk
 ```
 
-Requires Node ≥ 20.
+Requires Node ≥ 22.
 
 Smoke test:
 
 ```bash
-afk chat "hello"
+afk --version    # confirm the install (works before login)
 afk doctor       # environment self-check
+afk login        # save an Anthropic API key or OAuth token
+afk chat "hello"
 ```
 
 ## What you can do with it

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@ Internal reference for working on `agent-afk` itself — building, testing, rele
 
 ## Prerequisites
 
-- **Node.js ≥ 20.0.0** (enforced by `package.json#engines`).
+- **Node.js ≥ 22.0.0** (enforced by `package.json#engines`). Node 20 is EOL and `better-sqlite3` ≥ 12.10 ships no prebuilt binaries for it — installs on Node 20 fall back to a node-gyp source build, which fails on machines without Python/build tools.
 - **pnpm** — the lockfile is pnpm-specific. `npm install` will desync it.
   - Fast path: `corepack enable` (bundled with Node ≥ 16.9), then use `pnpm` directly.
   - Or globally: `npm install -g pnpm@latest`.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "files": [
     "dist/",
+    "scripts/postinstall.mjs",
     "NOTICE"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "NOTICE"
   ],
   "scripts": {
-    "postinstall": "node scripts/postinstall.mjs || true",
+    "postinstall": "node dist/postinstall.mjs || node scripts/postinstall.mjs || true",
     "build": "tsc && node scripts/copy-prompts.js",
     "dev": "tsx watch src/cli/index.ts",
     "start": "node dist/cli/index.js",
@@ -63,7 +63,7 @@
     "url": "https://github.com/griffinwork40/agent-afk/issues"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",

--- a/src/cli/first-run.test.ts
+++ b/src/cli/first-run.test.ts
@@ -37,9 +37,40 @@ vi.mock('dotenv', () => ({
 import { loadCredential } from './config.js';
 import { runAuthWizard } from './auth-wizard.js';
 import { providerForModel } from '../agent/providers/index.js';
-import { runFirstRunDetector } from './index.js';
+import { runFirstRunDetector, needsCredentialGate } from './index.js';
+
+// Argv helper — tests pass explicit argv so vitest's own process.argv (test
+// file paths) can't be misread as a subcommand.
+const argvFor = (...args: string[]) => ['node', 'afk', ...args];
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('needsCredentialGate', () => {
+  it('never gates --version / -V / --help / -h', () => {
+    expect(needsCredentialGate(argvFor('--version'))).toBe(false);
+    expect(needsCredentialGate(argvFor('-V'))).toBe(false);
+    expect(needsCredentialGate(argvFor('--help'))).toBe(false);
+    expect(needsCredentialGate(argvFor('-h'))).toBe(false);
+    expect(needsCredentialGate(argvFor('chat', '--help'))).toBe(false);
+  });
+
+  it('does not gate pre-auth commands (login, doctor, config, status, …)', () => {
+    for (const cmd of ['login', 'doctor', 'config', 'status', 'plugin', 'completion', 'update']) {
+      expect(needsCredentialGate(argvFor(cmd))).toBe(false);
+    }
+  });
+
+  it('gates commands that need a credential', () => {
+    for (const cmd of ['chat', 'c', 'interactive', 'i', 'daemon', 'farm']) {
+      expect(needsCredentialGate(argvFor(cmd))).toBe(true);
+    }
+  });
+
+  it('gates bare invocation and program-flag-only invocation (REPL start)', () => {
+    expect(needsCredentialGate(argvFor())).toBe(true);
+    expect(needsCredentialGate(argvFor('--model', 'opus'))).toBe(true);
+  });
+});
 
 describe('runFirstRunDetector', () => {
   let stderrSpy: ReturnType<typeof vi.spyOn>;
@@ -67,7 +98,7 @@ describe('runFirstRunDetector', () => {
     vi.mocked(loadCredential).mockReturnValue('sk-ant-api03-existing-key');
     vi.mocked(providerForModel).mockReturnValue('anthropic-direct');
 
-    await runFirstRunDetector();
+    await runFirstRunDetector(argvFor());
 
     expect(runAuthWizard).not.toHaveBeenCalled();
     expect(exitSpy).not.toHaveBeenCalled();
@@ -78,7 +109,7 @@ describe('runFirstRunDetector', () => {
     vi.mocked(loadCredential).mockReturnValue(undefined);
     vi.mocked(providerForModel).mockReturnValue('openai-compatible');
 
-    await runFirstRunDetector();
+    await runFirstRunDetector(argvFor());
 
     expect(runAuthWizard).not.toHaveBeenCalled();
     expect(exitSpy).not.toHaveBeenCalled();
@@ -96,7 +127,7 @@ describe('runFirstRunDetector', () => {
       writable: true,
     });
 
-    await runFirstRunDetector();
+    await runFirstRunDetector(argvFor());
 
     expect(stderrSpy).toHaveBeenCalledWith(
       expect.stringContaining('No Anthropic credential found'),
@@ -117,7 +148,7 @@ describe('runFirstRunDetector', () => {
       writable: true,
     });
 
-    await runFirstRunDetector();
+    await runFirstRunDetector(argvFor());
 
     expect(runAuthWizard).toHaveBeenCalledOnce();
     expect(exitSpy).not.toHaveBeenCalled();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -135,13 +135,45 @@ Examples:
 );
 
 /**
+ * Commands that cannot do anything useful without an Anthropic credential.
+ * Everything else (login, doctor, --version, --help, config, …) must work
+ * pre-auth — a fresh install's first commands are exactly those.
+ */
+const AUTH_GATED_COMMANDS = new Set(['chat', 'c', 'interactive', 'i', 'daemon', 'farm']);
+
+/**
+ * Pure function. Decides whether the invoked command needs the credential
+ * gate. `--version`/`--help` never gate. A leading non-flag arg is the
+ * subcommand (commander convention); only AUTH_GATED_COMMANDS gate. No
+ * subcommand (bare `afk`, or program flags like `--model opus`) means the
+ * REPL is starting, which needs auth.
+ *
+ * Exported for unit testing.
+ */
+export function needsCredentialGate(argv: string[]): boolean {
+  const args = argv.slice(2);
+  if (args.some((a) => a === '--version' || a === '-V' || a === '--help' || a === '-h')) {
+    return false;
+  }
+  const first = args[0];
+  const sub = first && !first.startsWith('-') ? first : undefined;
+  if (sub === undefined) return true; // bare `afk` → REPL → needs auth
+  return AUTH_GATED_COMMANDS.has(sub);
+}
+
+/**
  * First-run detector. When no credential is present and the resolved provider
  * is anthropic-direct, offers an interactive wizard (TTY) or prints a helpful
  * error (non-TTY) instead of surfacing a cryptic provider error.
  *
+ * Only fires for commands that actually need a credential (see
+ * needsCredentialGate) — `afk --version`, `afk login`, `afk doctor` etc. must
+ * never be blocked by the gate they would be used to satisfy or diagnose.
+ *
  * Exported so it can be tested independently without running program.parse().
  */
-export async function runFirstRunDetector(): Promise<void> {
+export async function runFirstRunDetector(argv: string[] = process.argv): Promise<void> {
+  if (!needsCredentialGate(argv)) return;
   const credential = loadCredential();
   const provider = providerForModel(getModel() as string);
   if (!credential && provider === 'anthropic-direct') {


### PR DESCRIPTION
## Summary

Two fresh-install onboarding fixes:

- **Scope the first-run credential gate** to only commands that actually call the model. Previously the gate fired on *every* invocation, so `afk --version`, `afk login`, and `afk doctor` — the exact commands a credential-less fresh install runs first — were blocked by the very gate they exist to satisfy or diagnose. A new pure, unit-tested predicate `needsCredentialGate(argv)` (+ `AUTH_GATED_COMMANDS` = `chat`, `c`, `interactive`, `i`, `daemon`, `farm`) decides this; `--version`/`--help` and pre-auth commands always pass, bare `afk`/flag-only (REPL start) still gate.
- **Require Node ≥ 22.** Node 20 is EOL and `better-sqlite3` ≥ 12.10 ships no prebuilt binaries for it, forcing a node-gyp source build that fails on machines without Python/build tools. CI already runs exclusively on Node 22, so this aligns the declared `engines` floor with the only version actually tested. Updated `README.md` smoke-test sequence and `docs/development.md` rationale to match.
- **`postinstall` hardening:** prefer the built `dist/postinstall.mjs` (fall back to `scripts/postinstall.mjs`) so the published package runs the compiled hook.

## Test results

- `pnpm lint` (`tsc --noEmit`, strict): passed
- `pnpm test` (`vitest run`): **8155 passed, 12 skipped, 439 files** — including new `needsCredentialGate` coverage and updated `runFirstRunDetector` tests in `src/cli/first-run.test.ts`

Run against the final tree after rebasing onto `origin/main` (v3.84.0).

## Verification

No adversarial verify requested and diff is under the 100-line threshold (76 insertions / 11 deletions). Skipped.

## Out of scope

The credential-gate fix and the Node-floor bump are separable concerns bundled here as a single "fresh-install onboarding" PR per request; split on request.