### PR TITLE
feat(cli): trim /resume from startup welcome hint

### DIFF
--- a/src/cli/commands/interactive.test.ts
+++ b/src/cli/commands/interactive.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StreamingMarkdownRenderer } from '../markdown-stream.js';
 import { renderMarkdownToTerminal } from '../formatter.js';
 import { palette } from '../palette.js';
-import { formatToolResultLine, isAutonameEnabled, formatAutonameSkipReason } from './interactive.js';
+import { formatToolResultLine, isAutonameEnabled, formatAutonameSkipReason, startupHintLine } from './interactive.js';
 import type { ToolResultChunk } from '../../agent/types/message-types.js';
 import type { CliOptions } from './interactive/shared.js';
 import type { CliConfig } from '../config.js';
@@ -544,6 +544,25 @@ describe('interactive command - streaming logic', () => {
 
     it('renders unknown gracefully', () => {
       expect(formatAutonameSkipReason('unknown', undefined)).toBe('unknown reason');
+    });
+  });
+
+  describe('startupHintLine — first-session welcome hint', () => {
+    it('keeps the essential first-session controls', () => {
+      const hint = startupHintLine();
+      expect(hint).toContain('/help');
+      expect(hint).toContain('/model');
+      expect(hint).toContain('Esc to interrupt');
+      expect(hint).toContain('/exit to quit');
+    });
+
+    it('omits /resume — useless to a new user, redundant when resuming', () => {
+      expect(startupHintLine()).not.toContain('/resume');
+    });
+
+    it('stays compact (≤ 4 dot-separated items) so the busiest startup line is scannable', () => {
+      const items = startupHintLine().split(' · ');
+      expect(items.length).toBeLessThanOrEqual(4);
     });
   });
 

--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -131,6 +131,24 @@ export function isAutonameEnabled(options: CliOptions, config: CliConfig): boole
   return true;
 }
 
+/**
+ * The hint line rendered under the welcome banner at session startup.
+ *
+ * Kept deliberately short and first-session-oriented: it teaches the handful
+ * of controls a newcomer needs on day one (help, switching models, how to
+ * interrupt a turn, how to leave). `/resume` is intentionally NOT listed here —
+ * it does nothing for a brand-new user (no prior sessions exist to resume), and
+ * for a user who IS resuming it is redundant with the "Resuming … · N prior
+ * turns" metaLine the banner already shows. `/resume` stays fully discoverable
+ * via `/help` and the `--resume` / `--continue` launch flags, so trimming it
+ * from the busiest line of the startup screen costs no real capability.
+ *
+ * Pure + exported so the content is unit-testable without booting a session.
+ */
+export function startupHintLine(): string {
+  return '/help · /model · Esc to interrupt · /exit to quit';
+}
+
 export function registerInteractiveCommand(program: Command): void {
   program
     .command('interactive', { isDefault: true })
@@ -641,7 +659,7 @@ export function registerInteractiveCommand(program: Command): void {
           ...(worktreeHandle !== undefined ? { worktree: worktreeHandle.branch } : {}),
           cwd: worktreeCwd ?? process.cwd(),
           ...(resumeMeta !== undefined ? { metaLine: resumeMeta } : {}),
-          hintLine: '/help · /model · /resume · Esc to interrupt · /exit to quit',
+          hintLine: startupHintLine(),
         }));
         // Surface boot-time prune outcome AFTER the banner so it lives at the
         // same scrollback rank as the status line — close enough to be seen,


### PR DESCRIPTION
## Summary
- Trims `/resume` from the interactive startup welcome hint line:
  `/help · /model · /resume · Esc to interrupt · /exit to quit`
  → `/help · /model · Esc to interrupt · /exit to quit`.
- `/resume` is the weakest item on the busiest line of the welcome screen — it
  does nothing for a brand-new user (no prior sessions to resume) and is
  redundant when resuming (the banner metaLine already shows
  "Resuming … · N prior turns").
- Extracts the literal into an exported, unit-tested `startupHintLine()` helper
  (matches the existing `formatAutonameSkipReason` / `isAutonameEnabled` pattern
  in the same module), so the hint content is testable without booting a session.
- `/resume` stays fully discoverable via `/help` and the `--resume` /
  `--continue` launch flags — no capability removed.

## Test results
- `pnpm test` (vitest run): **8158 passed, 12 skipped, 0 failed** (439 files)
- `pnpm lint` (`tsc --noEmit`, strict): passed
- Added 3 unit tests for `startupHintLine()` (essentials present, `/resume`
  absent, ≤4 items).

## Verification
No adversarial verify requested and the diff is under the 100-line threshold
(41 changed lines) — Phase 6 skipped.

## Tradeoff
A returning power user who launches a *fresh* session loses the inline `/resume`
reminder on the startup screen. Accepted: the startup hint should optimize for
the first-time reader, and `/resume` remains in `/help` and as a launch flag.
The "smarter" alternative (show `/resume` only when prior sessions exist) was
rejected — detecting that requires `listSessions()`, which reads and parses
every session sidecar on disk on every launch, for a cosmetic hint.