### PR TITLE
fix(service): launchd daemon crash-loops (exit 127) — bake PATH into plist; + correct --trigger help

### DIFF
--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -212,7 +212,7 @@ export function registerDaemonCommand(program: Command): void {
     .option('--effort <level>', "Effort level: low|medium|high|xhigh|max")
     .option(
       '--trigger <mode>',
-      'Trigger mode: cron | sessionstart | both | pull. Defaults to cron.',
+      "Trigger mode: cron | sessionstart | both | pull. Defaults to 'cron' when --cron is set, else 'sessionstart'.",
     )
     .option(
       '--sessionstart-cooldown-ms <ms>',

--- a/src/service/launchd.test.ts
+++ b/src/service/launchd.test.ts
@@ -16,7 +16,7 @@
 
 import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // vi.hoisted: the mock fn must exist before vi.mock factories run
@@ -52,6 +52,7 @@ import {
   renderPlist,
   resolveAfkBinary,
   resolveProgramArguments,
+  resolveServicePath,
   SERVICE_NAMES,
   serviceStatus,
   uninstallService,
@@ -339,6 +340,30 @@ describe('resolveProgramArguments', () => {
   });
 });
 
+describe('resolveServicePath', () => {
+  it('prepends the installer node dir, then standard system bins', () => {
+    const parts = resolveServicePath('/Users/me/.nvm/versions/node/v24.11.0/bin/node').split(':');
+    // node dir first — so `#!/usr/bin/env node` resolves under launchd's
+    // minimal bootstrap PATH (the exit-127 daemon crash-loop fix).
+    expect(parts[0]).toBe('/Users/me/.nvm/versions/node/v24.11.0/bin');
+    for (const d of ['/usr/local/bin', '/opt/homebrew/bin', '/usr/bin', '/bin', '/usr/sbin', '/sbin']) {
+      expect(parts).toContain(d);
+    }
+  });
+
+  it('dedups the node dir when it already lives in a standard bin (Homebrew node)', () => {
+    const parts = resolveServicePath('/opt/homebrew/bin/node').split(':');
+    expect(parts[0]).toBe('/opt/homebrew/bin');
+    expect(parts.filter((d) => d === '/opt/homebrew/bin')).toHaveLength(1);
+  });
+
+  it('is non-empty and colon-joined', () => {
+    const p = resolveServicePath('/usr/local/bin/node');
+    expect(p.length).toBeGreaterThan(0);
+    expect(p).toContain(':');
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────────────
 // I/O-bearing surface: installService / uninstallService / serviceStatus.
 // Tests redirect HOME + AFK_HOME to a per-test tmpdir; child_process is
@@ -410,6 +435,23 @@ describe('install/uninstall/status I/O', () => {
       // Mask out the high bits so this passes under any umask.
       const mode = statSync(expectedPath).mode & 0o777;
       expect(mode).toBe(0o600);
+    });
+
+    it('injects EnvironmentVariables.PATH led by the installer node dir (launchd minimal-PATH fix)', () => {
+      // Regression for the exit-127 daemon crash-loop: launchd bootstraps a
+      // minimal PATH that excludes nvm/Homebrew node, so the afk shebang
+      // (`#!/usr/bin/env node`) could not resolve node. installService must
+      // bake an explicit PATH into every service plist.
+      mockExecFileSync.mockReturnValue('' as never);
+      const result = installService('telegram', { _entrypointExistsCheck: () => true });
+      expect(result.kind).toBe('installed');
+      if (result.kind !== 'installed') return;
+
+      const contents = readFileSync(result.plistPath, 'utf-8');
+      expect(contents).toContain('<key>EnvironmentVariables</key>');
+      expect(contents).toContain('<key>PATH</key>');
+      // The node interpreter running this test must be on the injected PATH.
+      expect(contents).toContain(dirname(process.execPath));
     });
 
     it('returns already-installed if plist exists, without invoking launchctl', () => {

--- a/src/service/launchd/install.ts
+++ b/src/service/launchd/install.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, unlinkSync, wr
 import { homedir } from 'os';
 import { dirname } from 'path';
 import { guiDomain, LAUNCHCTL_TIMEOUT_MS, labelFor, launchAgentsDir, plistPath, serviceLogPath, type ServiceName } from './paths.js';
-import { type PlistOptions, renderPlist, resolveWatchPaths, resolveProgramArguments } from './plist.js';
+import { type PlistOptions, renderPlist, resolveServicePath, resolveWatchPaths, resolveProgramArguments } from './plist.js';
 
 // ─────────────────────────────────────────────────────────────────────────
 // Install / uninstall I/O
@@ -78,6 +78,16 @@ export function installService(name: ServiceName, opts: InstallOptions = {}): In
   mkdirSync(launchAgentsDir(), { recursive: true });
   mkdirSync(dirname(logFile), { recursive: true });
 
+  // launchd's minimal bootstrap PATH excludes Homebrew and version-manager
+  // node installs, which crash-loops any service whose entrypoint resolves
+  // node via `#!/usr/bin/env node` (see resolveServicePath). Always inject an
+  // explicit PATH led by the installer's own node dir; caller-supplied env
+  // wins so an explicit `PATH` in opts.environment still overrides.
+  const environmentVariables: Record<string, string> = {
+    PATH: resolveServicePath(),
+    ...(opts.environment ?? {}),
+  };
+
   const plistOpts: PlistOptions = {
     label: labelFor(name),
     programArguments: args,
@@ -85,7 +95,7 @@ export function installService(name: ServiceName, opts: InstallOptions = {}): In
     standardOutPath: logFile,
     standardErrorPath: logFile,
     ...(watchPaths ? { watchPaths } : {}),
-    ...(opts.environment ? { environmentVariables: opts.environment } : {}),
+    environmentVariables,
   };
   const xml = renderPlist(plistOpts);
 

--- a/src/service/launchd/plist.ts
+++ b/src/service/launchd/plist.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'child_process';
 import { existsSync, realpathSync } from 'fs';
 import { homedir } from 'os';
-import { resolve } from 'path';
+import { delimiter, dirname, resolve } from 'path';
 import { resolveEntrypoint as resolveTelegramEntrypoint } from '../../telegram/manager.js';
 import { type ServiceName } from './paths.js';
 
@@ -27,8 +27,13 @@ export interface PlistOptions {
    */
   watchPaths?: string[];
   /**
-   * Extra env vars to inject. Keep small — the running process already
-   * inherits the user's login env via launchd's user-context bootstrap.
+   * Extra env vars to inject.
+   *
+   * // Invariant: a `gui/<uid>` launchd job does NOT inherit the user's
+   * // interactive-shell environment — it bootstraps with a minimal PATH
+   * // (/usr/bin:/bin:/usr/sbin:/sbin). Anything the service or its child
+   * // processes need on PATH (node via nvm/fnm/volta, Homebrew's git/gh)
+   * // must be set here explicitly. See {@link resolveServicePath}.
    */
   environmentVariables?: Record<string, string>;
 }
@@ -111,6 +116,55 @@ export function renderPlist(opts: PlistOptions): string {
   lines.push('</dict>');
   lines.push('</plist>');
   return lines.join('\n') + '\n';
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Environment resolution
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Standard system bin directories every launchd job should see, after the
+ * node dir. Homebrew (`/opt/homebrew/bin`, `/usr/local/bin`) is where the
+ * `afk` binary, `git`, and `gh` usually live — the daemon shells out to
+ * these from its spawned agent sessions.
+ */
+const BASE_SERVICE_PATH_DIRS: readonly string[] = [
+  '/usr/local/bin',
+  '/opt/homebrew/bin',
+  '/usr/bin',
+  '/bin',
+  '/usr/sbin',
+  '/sbin',
+];
+
+/**
+ * Build the `PATH` value a launchd service must run with.
+ *
+ * // Invariant: launchd bootstraps `gui/<uid>` jobs with a minimal PATH
+ * // (/usr/bin:/bin:/usr/sbin:/sbin) that excludes Homebrew and
+ * // version-manager (nvm/fnm/volta/asdf) node installs. The installed
+ * // `afk` binary's `#!/usr/bin/env node` shebang then fails to resolve
+ * // `node` → the job exits 127 and silently crash-loops under KeepAlive
+ * // (this is the exact failure the `daemon` service hit). We prepend
+ * // dirname(process.execPath) — the node interpreter running the
+ * // installer, guaranteed to contain a working `node` — then the standard
+ * // system bin dirs so the service's own child processes (git, gh, …)
+ * // resolve too. Dedup keeps first-wins order so a node living in a base
+ * // dir (e.g. Homebrew's) is listed exactly once, at the front.
+ *
+ * Pure: `execPath` is injectable for tests.
+ */
+export function resolveServicePath(execPath: string = process.execPath): string {
+  const nodeDir = dirname(execPath);
+  const seen = new Set<string>();
+  const dirs: string[] = [];
+  for (const d of [nodeDir, ...BASE_SERVICE_PATH_DIRS]) {
+    if (d.length > 0 && !seen.has(d)) {
+      seen.add(d);
+      dirs.push(d);
+    }
+  }
+  return dirs.join(delimiter);
 }
 
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Source
Ported from **`griffinwork40/afk-workshop#727`** (private): https://github.com/griffinwork40/afk-workshop/pull/727 — a moat-scrubbed port (nothing required scrubbing in this case; see Dropped).

## Problem
`afk service install daemon` produced a LaunchAgent that never ran: `afk service status daemon` reported **"Installed but not running, last exit status: 127"**, and the service log showed `env: node: No such file or directory` on a KeepAlive crash-loop.

## Root cause
launchd bootstraps `gui/<uid>` jobs with a **minimal PATH** (`/usr/bin:/bin:/usr/sbin:/sbin`) and does **not** inherit the user's interactive-shell env. The installed `afk` binary's shebang is `#!/usr/bin/env node`, so `env` can't find node when it lives in a Homebrew or version-manager (nvm/fnm/volta) dir → exit 127. The `daemon` service hit this (argv `[afk, daemon]` relies on PATH); `telegram` avoided it only because its argv is `[process.execPath, entry]` (absolute node). `EnvironmentVariables` existed in `PlistOptions` but was never populated.

## Ported (public-safe — all 4 files)
- **`src/service/launchd/plist.ts`** — new pure `resolveServicePath()` (prepends `dirname(process.execPath)`, then standard Homebrew/system bins; dedups, first-wins); corrected the misleading `environmentVariables` comment.
- **`src/service/launchd/install.ts`** — `installService` now injects `EnvironmentVariables.PATH` into every service plist (caller-supplied env still overrides).
- **`src/service/launchd.test.ts`** — +4 tests (`resolveServicePath` unit cases + an install-level assertion that the rendered plist carries `EnvironmentVariables/PATH`).
- **`src/cli/commands/daemon.ts`** — `--trigger` help now states it defaults to `sessionstart` (not `cron`), matching `resolveTriggerMode` + its tests.

## Dropped (and why)
**None.** Moat triage classified all 4 files PUBLIC-SAFE; the patch applied cleanly via 3-way (no rejects) and introduced no moat.

## Verification (in this public clone)
- **Gate green:** `pnpm install --frozen-lockfile` · `pnpm lint` · `env -u AFK_INTERNAL pnpm test` (**8159 passed / 12 skipped / 0 failed**) · `pnpm build` · `pnpm build:dist`.
- **✅ MOAT GUARD CLEAN** — deterministic denylist + structural grep over tree + built `dist/`.
- **Adversarial audit (independent re-derivation): CLEAN.**

**Do not merge automatically** — left for human review.
