### PR TITLE
fix(web/search): sanitize Brave error body before embedding

### DIFF
--- a/src/web/search.test.ts
+++ b/src/web/search.test.ts
@@ -106,6 +106,23 @@ describe('createBraveSearchBackend — result mapping', () => {
       backend.search('q', { limit: 10, timeoutMs: 5000, signal: signal() }),
     ).rejects.toThrow(/Brave Search HTTP 422.*quota exceeded/);
   });
+
+  it('sanitizes control characters from HTTP error bodies before throwing', async () => {
+    const fetchFn = vi.fn(async () => braveErr(500, 'bad\x1b[31mred\x1b[0m\nbody\x07'));
+    const backend = createBraveSearchBackend({ apiKey: 'k', fetchFn: fetchFn as unknown as typeof fetch });
+
+    let message = '';
+    try {
+      await backend.search('q', { limit: 10, timeoutMs: 5000, signal: signal() });
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(message).toContain('Brave Search HTTP 500 Error: badred body');
+    expect(message).not.toContain('\x1b');
+    expect(message).not.toContain('\n');
+    expect(message).not.toContain('\x07');
+  });
 });
 
 describe('resolveSearchBackend', () => {

--- a/src/web/search.ts
+++ b/src/web/search.ts
@@ -14,6 +14,7 @@
  */
 
 import type { FetchFn, SearchBackend, SearchResult } from './types.js';
+import { sanitizeForDisplay } from '../utils/terminal-sanitize.js';
 
 const BRAVE_ENDPOINT = 'https://api.search.brave.com/res/v1/web/search';
 /** Brave caps `count` at 20 per request. */
@@ -78,7 +79,8 @@ export function createBraveSearchBackend(opts: BraveBackendOptions): SearchBacke
         let detail = '';
         try {
           const body = await res.text();
-          if (body) detail = `: ${body.length > 200 ? body.slice(0, 200) + '…' : body}`;
+          const clean = sanitizeForDisplay(body);
+          if (clean) detail = `: ${clean.length > 200 ? clean.slice(0, 200) + '…' : clean}`;
         } catch {
           // Ignore — proceed with status only.
         }


### PR DESCRIPTION
Closes #22.

## Problem
On a non-OK Brave Search response, `createBraveSearchBackend` embeds the raw response body verbatim into the thrown `Error` message. The body is length-capped (200 chars) but **not sanitized** — a misbehaving or hostile search endpoint could inject ANSI escape / control sequences that then land in model context and terminal output.

`src/web/search.ts` (HTTP-error branch):
```ts
const body = await res.text();
if (body) detail = `: ${body.length > 200 ? body.slice(0, 200) + '…' : body}`;
```

## Fix
Route the body through the project's canonical terminal-display sanitizer, `sanitizeForDisplay()` from `src/utils/terminal-sanitize.ts` — already the documented security boundary for strings reaching the terminal — before length-capping. This strips escape sequences and neutralizes C0/DEL/C1 control bytes (the issue suggested a hand-rolled `replace(/[\x00-\x1f\x7f]/g, ' ')`; reusing the existing helper is stronger and consistent with the rest of the codebase, as the issue itself noted).

```ts
const clean = sanitizeForDisplay(body);
if (clean) detail = `: ${clean.length > 200 ? clean.slice(0, 200) + '…' : clean}`;
```

## Validation
- Added a regression test asserting control/escape sequences in an error body are stripped from the thrown message.
- `npx vitest run src/web/search.test.ts` → **11 passed**.
- `npm run lint` (`tsc --noEmit`) → clean.

Behavior for benign bodies (e.g. `quota exceeded`) is unchanged; existing tests still pass.
