### PR TITLE
Port afk-workshop#689: feat(cli): process-wide stdin-claim guard (phantom-turn root-cause fix)

### DIFF
--- a/src/__test-utils__/stdin-claim-reset.ts
+++ b/src/__test-utils__/stdin-claim-reset.ts
@@ -1,0 +1,11 @@
+// Global test setup: the stdin-claim guard (src/cli/input/stdin-claim.ts) is a
+// process-wide singleton. Vitest isolates module state per test FILE, but within
+// a file multiple tests may arm a TerminalCompositor / reader that acquires the
+// claim. Reset it before every test so an un-disarmed claim in one test cannot
+// leak into the next (e.g. autocomplete-state.test.ts arms without disarm).
+import { beforeEach } from 'vitest';
+import { __resetStdinClaimForTests } from '../cli/input/stdin-claim.js';
+
+beforeEach(() => {
+  __resetStdinClaimForTests();
+});

--- a/src/cli/commands/interactive/repl-loop.ts
+++ b/src/cli/commands/interactive/repl-loop.ts
@@ -330,6 +330,7 @@ export async function runReplLoop(
   // Invariant: install the REPL elicitation handler AFTER armCompositor
   // resolves so it routes through the persistent compositor's onSubmit
   // path (single stdin consumer) rather than through `rl.question()`.
+  // (also enforced structurally by StdinClaim — see src/cli/input/stdin-claim.ts)
   //
   // External constraint (single-consumer stdin): when the TerminalCompositor
   // is armed, it owns a raw-mode `keypress` listener on process.stdin and

--- a/src/cli/input/reader.ts
+++ b/src/cli/input/reader.ts
@@ -18,6 +18,7 @@ import * as ansiEscapes from 'ansi-escapes';
 import stringWidth from 'string-width';
 import { list as listSlashCommands } from '../slash/registry.js';
 import { stripAnsi } from '../display.js';
+import { acquireStdinClaim } from './stdin-claim.js';
 import { InputCore, type InputCoreState } from '../input-core.js';
 import { colorizeInputBuffer, type SlashRegistryView } from '../input-highlight.js';
 import { describeAttachmentSummary, renderStatusLine, type ImageAttachment } from './attachments.js';
@@ -49,9 +50,18 @@ export async function readWithAutocompleteTty(
   // mode; entering raw mode again would double-set and confuse restoration.
   // In practice this guard never fires (compositor is always disarmed between
   // turns), but it is correct-by-default for future call sites.
-  const rawMode: RawModeHandle = opts.compositor?.isArmed()
+  const compositorArmed = opts.compositor?.isArmed() ?? false;
+  const rawMode: RawModeHandle = compositorArmed
     ? { restore: () => {} }
     : enterRawMode(stdin, stdout);
+
+  // Stdin claim: acquire here so the single-consumer stdin invariant is
+  // structurally enforced (see src/cli/input/stdin-claim.ts). Skip when the
+  // compositor is already armed — it holds its own claim and this reader is
+  // acting as a subordinate consumer under the compositor's keypress handler.
+  const stdinClaim = compositorArmed
+    ? null
+    : acquireStdinClaim('reader.readWithAutocomplete');
 
   // Bottom-row reservation: increment extraRows by 1 so the DECSTBM scroll
   // region leaves space for the composer prompt. Captured + restored in the
@@ -856,5 +866,8 @@ export async function readWithAutocompleteTty(
     // Idempotent — also called from any abort path inside the keypress
     // handler so the terminal is restored exactly once.
     rawMode.restore();
+    // Release the stdin claim after restoring raw mode so the TTY is in a
+    // consistent state before the next acquirer can proceed.
+    stdinClaim?.release();
   }
 }

--- a/src/cli/input/stdin-claim.test.ts
+++ b/src/cli/input/stdin-claim.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the StdinClaim module.
+ *
+ * Pins the single-consumer stdin invariant:
+ *  - Only one claim may be held at a time.
+ *  - Release is idempotent.
+ *  - withStdinClaim releases even when fn throws.
+ *  - currentStdinClaimHolder() tracks state correctly.
+ *  - __resetStdinClaimForTests() allows test isolation.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetStdinClaimForTests,
+  acquireStdinClaim,
+  currentStdinClaimHolder,
+  withStdinClaim,
+} from './stdin-claim.js';
+
+// ─── Test isolation ───────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  __resetStdinClaimForTests();
+});
+
+// ─── Core invariants ─────────────────────────────────────────────────────────
+
+describe('acquireStdinClaim', () => {
+  it('acquire → release → re-acquire with a different name succeeds', () => {
+    const h = acquireStdinClaim('a');
+    h.release();
+    // Should not throw:
+    const h2 = acquireStdinClaim('b');
+    h2.release();
+  });
+
+  it('acquire while already held throws, naming both holders', () => {
+    acquireStdinClaim('a');
+    expect(() => acquireStdinClaim('b')).toThrowError(/\ba\b/);
+    expect(() => {
+      __resetStdinClaimForTests();
+      acquireStdinClaim('first-holder');
+      acquireStdinClaim('second-holder');
+    }).toThrowError(/second-holder/);
+  });
+
+  it('release is idempotent — second call is a no-op', () => {
+    const h = acquireStdinClaim('a');
+    h.release();
+    // Second release must not throw and must not corrupt state.
+    expect(() => h.release()).not.toThrow();
+    // State should be free so we can re-acquire.
+    const h2 = acquireStdinClaim('b');
+    h2.release();
+  });
+
+  it('re-acquiring with the same name after release succeeds', () => {
+    const h1 = acquireStdinClaim('x');
+    h1.release();
+    const h2 = acquireStdinClaim('x');
+    h2.release();
+    expect(currentStdinClaimHolder()).toBeNull();
+  });
+});
+
+describe('currentStdinClaimHolder', () => {
+  it('returns the holder name while held', () => {
+    const h = acquireStdinClaim('my-holder');
+    expect(currentStdinClaimHolder()).toBe('my-holder');
+    h.release();
+  });
+
+  it('returns null after release', () => {
+    const h = acquireStdinClaim('x');
+    h.release();
+    expect(currentStdinClaimHolder()).toBeNull();
+  });
+});
+
+describe('withStdinClaim', () => {
+  it('releases even when fn throws', async () => {
+    await expect(
+      withStdinClaim('a', () => {
+        throw new Error('fn-error');
+      }),
+    ).rejects.toThrow('fn-error');
+    // Claim must be free after fn threw.
+    expect(currentStdinClaimHolder()).toBeNull();
+  });
+
+  it('releases after fn resolves normally', async () => {
+    const result = await withStdinClaim('a', () => 42);
+    expect(result).toBe(42);
+    expect(currentStdinClaimHolder()).toBeNull();
+  });
+
+  it('releases when async fn rejects', async () => {
+    await expect(
+      withStdinClaim('async-holder', async () => {
+        await Promise.resolve();
+        throw new Error('async-error');
+      }),
+    ).rejects.toThrow('async-error');
+    expect(currentStdinClaimHolder()).toBeNull();
+  });
+});
+
+describe('__resetStdinClaimForTests', () => {
+  it('clears state regardless of prior acquisitions', () => {
+    acquireStdinClaim('held');
+    expect(currentStdinClaimHolder()).toBe('held');
+    __resetStdinClaimForTests();
+    expect(currentStdinClaimHolder()).toBeNull();
+    // After reset, a fresh acquire works.
+    const h = acquireStdinClaim('after-reset');
+    expect(currentStdinClaimHolder()).toBe('after-reset');
+    h.release();
+  });
+});
+
+// ─── Error message content ────────────────────────────────────────────────────
+
+describe('conflict error message', () => {
+  it('names both the current holder and the requested holder', () => {
+    acquireStdinClaim('alpha');
+    let caughtMsg = '';
+    try {
+      acquireStdinClaim('beta');
+    } catch (e) {
+      caughtMsg = e instanceof Error ? e.message : String(e);
+    }
+    expect(caughtMsg).toContain('alpha');
+    expect(caughtMsg).toContain('beta');
+  });
+});

--- a/src/cli/input/stdin-claim.ts
+++ b/src/cli/input/stdin-claim.ts
@@ -1,0 +1,120 @@
+/**
+ * Invariant: process.stdin has exactly one active consumer at a time.
+ *
+ * When the TerminalCompositor is armed it owns a raw-mode keypress listener
+ * on process.stdin and consumes every keystroke into its internal input
+ * buffer. A parallel consumer — such as `rl.question()` on a `terminal:
+ * false` readline interface, or `readWithAutocompleteTty`'s own keypress
+ * loop — ALSO receives every keystroke. This dual-consumption produces the
+ * PR #511 phantom-turn bug: both consumers resolve, the answer fills the
+ * compositor input buffer with `queued = true`, and the next
+ * `surface.readLine()` idle-flush fires the stale buffer as an unsolicited
+ * user turn.
+ *
+ * This module promotes that invariant from a comment to a type. Callers
+ * that consume stdin in a conflicting way must acquire a StdinClaimHandle
+ * before doing so. An attempt to acquire while another holder is active
+ * throws immediately, naming both holders so the conflict is immediately
+ * diagnosable.
+ *
+ * ## Holders
+ *  - TerminalCompositor.arm()        — acquires 'TerminalCompositor.arm'
+ *  - readWithAutocompleteTty         — acquires 'reader.readWithAutocomplete'
+ *  - telegram setup-wizard prompt()  — acquires via withStdinClaim(...)
+ *
+ * ## Non-TTY paths
+ * Non-TTY code paths (CI, piped input, daemons) that do not attach a stdin
+ * listener are exempt; callers gate the acquire behind `process.stdin.isTTY`
+ * or simply use `withStdinClaim` knowing the hold is brief and releases in
+ * `finally`.
+ *
+ * ## Test isolation
+ * Call `__resetStdinClaimForTests()` in `beforeEach` to start each test
+ * with a clean singleton — prevents cross-test state leaks.
+ */
+
+// ─── Module-private singleton state ──────────────────────────────────────────
+// Invariant: only one StdinClaimHandle may be live at any time. All
+// acquires/releases funnel through this single mutable reference so there
+// is no race between concurrent callers (Node.js is single-threaded; the
+// check-then-set is atomic within a synchronous turn).
+
+let currentHolder: { name: string; handle: StdinClaimHandle } | null = null;
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+/** Opaque token returned by {@link acquireStdinClaim}. Call `.release()` when done. */
+export interface StdinClaimHandle {
+  /** Idempotent — second call is a no-op. */
+  release(): void;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Acquire the process-wide stdin claim under `holderName`.
+ *
+ * @throws {Error} if another claim is already held — the error message
+ *   names both the current holder and the requested holder so the
+ *   conflict is immediately diagnosable.
+ */
+export function acquireStdinClaim(holderName: string): StdinClaimHandle {
+  if (currentHolder !== null) {
+    throw new Error(
+      `stdin claim conflict: '${currentHolder.name}' already holds the claim, ` +
+        `'${holderName}' cannot acquire it concurrently.`,
+    );
+  }
+
+  // Build the handle before assigning currentHolder so a reentrant
+  // acquireStdinClaim() inside the constructor (hypothetical, but
+  // defensive) observes currentHolder === null and throws correctly.
+  let released = false;
+  const handle: StdinClaimHandle = {
+    release(): void {
+      if (released) return; // idempotent
+      released = true;
+      // Only clear the global if this handle is still the current one.
+      // A __resetStdinClaimForTests() call may have already cleared it.
+      if (currentHolder?.handle === handle) {
+        currentHolder = null;
+      }
+    },
+  };
+
+  currentHolder = { name: holderName, handle };
+  return handle;
+}
+
+/**
+ * Acquire the claim, run `fn`, then release in a `finally` block.
+ * The release runs even when `fn` throws.
+ */
+export async function withStdinClaim<T>(
+  holderName: string,
+  fn: () => Promise<T> | T,
+): Promise<T> {
+  const handle = acquireStdinClaim(holderName);
+  try {
+    return await fn();
+  } finally {
+    handle.release();
+  }
+}
+
+/**
+ * Return the name of the current stdin claim holder, or `null` if the
+ * claim is free. Intended for diagnostics and tests.
+ */
+export function currentStdinClaimHolder(): string | null {
+  return currentHolder?.name ?? null;
+}
+
+/**
+ * Forcibly clear the singleton state. Call this in `beforeEach` to
+ * prevent cross-test contamination. Must not be called from production
+ * code paths.
+ */
+export function __resetStdinClaimForTests(): void {
+  currentHolder = null;
+}

--- a/src/cli/terminal-compositor.splice.test.ts
+++ b/src/cli/terminal-compositor.splice.test.ts
@@ -158,7 +158,7 @@ describe('commitAbove Phase 1 multi-line splice regression', () => {
   let writes: ReturnType<typeof collectWrites>;
   let compositor: TerminalCompositor;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     stdout = makeMockStdout(COLS, ROWS);
     stdin = makeMockStdin();
     writes = collectWrites(stdout);
@@ -169,8 +169,9 @@ describe('commitAbove Phase 1 multi-line splice regression', () => {
       onCancel: vi.fn(),
       scrollRegion,
     });
-    await compositor.arm();
-    writes; // capture clears happen inside each test
+    // NOTE: do NOT arm here — tests that create their own compositor would
+    // conflict with the shared claim. The one test that uses this shared
+    // compositor arms it explicitly; afterEach's disarm() is idempotent.
   });
 
   afterEach(() => {
@@ -180,6 +181,7 @@ describe('commitAbove Phase 1 multi-line splice regression', () => {
   it(
     'no rendered line carries a splice after committing a shorter multi-line block over a longer one',
     async () => {
+      await compositor.arm();
       // External constraint (ONLCR): the real TTY converts bare \n to \r\n in
       // output mode. @xterm/headless must mirror this with convertEol:true so
       // the LF-based cursor positioning in Phase 1 lands at column 1 on each

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -16,6 +16,14 @@ import { TerminalCompositor } from './terminal-compositor.js';
 import { CupFrameRenderer } from './cup-frame-renderer.js';
 import { createAutocompleteState } from './input/autocomplete-state.js';
 import { register as registerSlashCommand, resetRegistry as resetSlashRegistry } from './slash/registry.js';
+import { __resetStdinClaimForTests, currentStdinClaimHolder } from './input/stdin-claim.js';
+
+// Module-level beforeEach: reset the stdin-claim singleton before every test
+// regardless of which describe block it lives in. This prevents claim leaks
+// when a test calls arm() without a corresponding disarm() in its teardown.
+beforeEach(() => {
+  __resetStdinClaimForTests();
+});
 
 type MockStdout = NodeJS.WriteStream & {
   isTTY: boolean;
@@ -74,6 +82,8 @@ describe('TerminalCompositor', () => {
     stdout = makeMockStdout();
     stdin = makeMockStdin();
     writes = collectWrites(stdout);
+    // Reset the process-wide StdinClaim singleton so each test starts clean.
+    __resetStdinClaimForTests();
   });
 
   describe('arm/disarm lifecycle', () => {
@@ -132,6 +142,27 @@ describe('TerminalCompositor', () => {
       c.disarm();
       expect(clearSpy).toHaveBeenCalledTimes(1);
       expect(doneSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('arm() acquires the stdin claim under TerminalCompositor.arm', async () => {
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+      expect(currentStdinClaimHolder()).toBeNull();
+      await c.arm();
+      expect(currentStdinClaimHolder()).toBe('TerminalCompositor.arm');
+      c.disarm();
+      expect(currentStdinClaimHolder()).toBeNull();
+    });
+
+    it('arm() throws a conflict error if another holder already holds the claim', async () => {
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+      // Manually acquire before arm() to simulate a concurrent consumer.
+      const { acquireStdinClaim } = await import('./input/stdin-claim.js');
+      const handle = acquireStdinClaim('test-interloper');
+      try {
+        await expect(c.arm()).rejects.toThrow('stdin claim conflict');
+      } finally {
+        handle.release();
+      }
     });
   });
 

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -26,6 +26,10 @@ import type { IHistoryRing } from './input/types.js';
 import { renderStatusLine, type ImageAttachment } from './input/attachments.js';
 import { SpinnerController } from './input/spinner.js';
 import {
+  acquireStdinClaim,
+  type StdinClaimHandle,
+} from './input/stdin-claim.js';
+import {
   type CompositorInputMode,
   type CompositorScrollRegionGuard,
   type KeyInfo,
@@ -218,6 +222,8 @@ export class TerminalCompositor {
   /** @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost). */
   backgrounded = false;
   private wasRaw = false;
+  /** Held while armed; released on disarm(). */
+  private stdinClaim: StdinClaimHandle | null = null;
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   logUpdate: LogUpdateFn | null = null;
 
@@ -752,6 +758,11 @@ export class TerminalCompositor {
     // the helper with the same value, so it wins regardless of order.
     emitKeypressEventsImmediateEscape(this.stdin);
 
+    // Acquire the process-wide stdin claim immediately before attaching the
+    // keypress listener so the invariant is upheld: only one stdin consumer
+    // may be live at a time. Released in disarm().
+    this.stdinClaim = acquireStdinClaim('TerminalCompositor.arm');
+
     this.handleKeypress = (char, key) => this.dispatchKey(char, key);
     this.stdin.on('keypress', this.handleKeypress);
 
@@ -910,6 +921,13 @@ export class TerminalCompositor {
       } catch {
         /* noop */
       }
+    }
+
+    // Release the stdin claim before marking as unarmed so a subscriber
+    // that checks isArmed() inside an acquire call sees the correct state.
+    if (this.stdinClaim) {
+      this.stdinClaim.release();
+      this.stdinClaim = null;
     }
 
     this.armed = false;

--- a/src/telegram/setup-wizard.ts
+++ b/src/telegram/setup-wizard.ts
@@ -21,6 +21,7 @@ import chalk from 'chalk';
 import { upsertEnvVar } from '../utils/envFile.js';
 import { getEnvConfigPath } from '../paths.js';
 import { env } from '../config/env.js';
+import { withStdinClaim } from '../cli/input/stdin-claim.js';
 
 const TELEGRAM_API = 'https://api.telegram.org';
 
@@ -216,12 +217,14 @@ export async function pollForChats(
 /** Prompt for stdin input. */
 function prompt(question: string): Promise<string> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise((resolve) => {
-    rl.question(question, (answer) => {
-      rl.close();
-      resolve(answer.trim());
-    });
-  });
+  return withStdinClaim('telegram.setup-wizard', () =>
+    new Promise<string>((resolve) => {
+      rl.question(question, (answer) => {
+        rl.close();
+        resolve(answer.trim());
+      });
+    }),
+  );
 }
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    setupFiles: ['./src/__test-utils__/stdin-claim-reset.ts'],
     // testTimeout: bumped from vitest default 5000ms to 15000ms.
     // Many CLI/bootstrap tests do `await import('./bootstrap.js')` (directly or
     // via vi.doMock setup) and the transitive import graph can exceed 5s under


### PR DESCRIPTION
## Source

Ported from **afk-workshop#689** — https://github.com/griffinwork40/afk-workshop/pull/689

> This is a **moat-scrubbed port**, not a 1:1 copy. It was applied via diff + 3-way merge (the public repo is a squashed snapshot with no shared history, so cross-repo cherry-pick is impossible). Triage classified every hunk as PUBLIC-SAFE; nothing was dropped.

## What

Introduces a **process-wide stdin-claim singleton** enforcing the invariant *"`process.stdin` has exactly one active consumer at a time"* as a runtime guard.

**Root cause (phantom turns):** when `TerminalCompositor` holds a raw-mode `keypress` listener, a parallel `rl.question()` consumer receives the same keystrokes. Both resolve — `rl` fills its buffer, `queued=true`, and the next idle-flush fires as an **unsolicited agent turn**.

**Fix:** `acquireStdinClaim(name)` throws immediately if another holder is live, naming both parties. `TerminalCompositor.arm/disarm`, the autocomplete TTY reader, and the Telegram setup-wizard now acquire/release the claim structurally.

## Ported (all 10 files — none dropped)

| File | Change |
|------|--------|
| `src/cli/input/stdin-claim.ts` | **new** — singleton: `acquireStdinClaim` / `withStdinClaim` / `currentStdinClaimHolder` / `__resetStdinClaimForTests` |
| `src/cli/input/stdin-claim.test.ts` | **new** — 11 unit tests (acquire/release/conflict/with/reset) |
| `src/__test-utils__/stdin-claim-reset.ts` | **new** — global `beforeEach` claim reset (wired via `vitest.config.ts`) |
| `src/cli/terminal-compositor.ts` | `arm()` acquires the claim; `disarm()` releases it |
| `src/cli/terminal-compositor.test.ts` | +2 arm/disarm claim-lifecycle tests + module-level reset |
| `src/cli/terminal-compositor.splice.test.ts` | de-share `arm()` in `beforeEach` to avoid claim conflicts |
| `src/cli/input/reader.ts` | `readWithAutocompleteTty` acquires the claim when the compositor is not armed |
| `src/telegram/setup-wizard.ts` | `prompt()` wraps `rl.question()` in `withStdinClaim()` |
| `src/cli/commands/interactive/repl-loop.ts` | +1 comment cross-referencing the guard |
| `vitest.config.ts` | register the global stdin-claim reset setup file |

## Dropped (and why)

**Nothing.** Moat triage classified all 10 hunks PUBLIC-SAFE — the change is a self-contained CLI/TUI/Telegram guard with no moat files, imports, or vocabulary.

## Verification

- ✅ **Correctness gate** (in a fresh public checkout): `pnpm install --frozen-lockfile` · `pnpm lint` (strict `tsc --noEmit`) · `pnpm test` (**440 files, 8176 passed, 12 skipped**) · `pnpm build` · `pnpm build:dist` — all green.
- ✅ **Deterministic moat guard** over tree + built `dist/`: `MOAT GUARD CLEAN` (zero HARD-denylist hits, zero structural-moat paths, no merge markers).
- ✅ **Adversarial audit** (independent sub-agent, re-derived from scratch over tree + `dist/`): **CLEAN**, high confidence.

## Notes

- A `#511` reference in `stdin-claim.ts` is **intentionally kept** — it is a plain code comment (no auto-link), consistent with the pre-existing public reference in `src/cli/render/picker.ts`. It exposes no private information.

> ⚠️ **Do not merge automatically** — left for human review.
