### PR TITLE
fix(cli): collapse orchestrator progress map to one entry (kill duplicate "Tool-use loop" banner)

### DIFF
--- a/src/cli/_lib/stream-renderer-orchestrator.test.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.test.ts
@@ -944,3 +944,65 @@ describe('handleOrchestratorEvent — per-phase interleaved thinking (TTY)', () 
     expect(source.thinkingPhaseStartedAt).toBeUndefined();
   });
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// progress arm — at-most-one-entry invariant (duplicate banner regression)
+// ────────────────────────────────────────────────────────────────────────────
+
+function progressEvent(taskId: string, description: string): OutputEvent {
+  return {
+    type: 'progress',
+    progress: {
+      taskId,
+      description,
+      totalTokens: 1000,
+      toolUses: 1,
+      durationMs: 1000,
+    },
+  };
+}
+
+describe('handleOrchestratorEvent — progress arm (duplicate banner regression)', () => {
+  /**
+   * Two `progress` events with DIFFERENT taskIds — as produced when two
+   * runTurn invocations share one live renderer (a 401 auth-retry replay, or
+   * any retry on the skill-dispatch renderer, which never rebuilds on
+   * 'resumed'). loop.ts mints a fresh taskId per runTurn, so without the
+   * clear() the map would accumulate two entries and the overlay would render
+   * two stacked "◦ Tool-use loop" banners.
+   *
+   * Expect: lastProgressByTask holds EXACTLY ONE entry (the latest task), and
+   * the composed overlay renders EXACTLY ONE banner.
+   */
+  it('collapses two distinct-taskId progress events to a single map entry + one banner', () => {
+    const setOverlay = vi.fn<(overlay: string) => void>();
+    const compositor = {
+      setOverlay,
+      commitAbove: vi.fn(),
+      setSpinner: vi.fn(),
+    } as unknown as OrchestratorCtx['compositor'];
+
+    const ctx = makeCtx(new ToolLane(), { isTTY: true, compositor });
+    const source: SourceState = freshSourceState('__main__');
+    const lastProgress = new Map();
+    const fire = (e: OutputEvent) => handleOrchestratorEvent(e, source, ctx, lastProgress);
+
+    // Stale entry from a first runTurn, then a fresh taskId from a second
+    // runTurn replaying through the same renderer.
+    fire(progressEvent('task-1-stale', 'Iteration 6: used bash'));
+    fire(progressEvent('task-2-live', 'Iteration 15: used memory_update'));
+
+    // Invariant: at most one entry. The second taskId evicts the first.
+    expect(lastProgress.size).toBe(1);
+    expect(lastProgress.has('task-2-live')).toBe(true);
+    expect(lastProgress.has('task-1-stale')).toBe(false);
+
+    // The composed overlay renders one banner, not two: exactly one '◦' glyph
+    // (one banner block) and only the live task's description survives.
+    const lastOverlay = setOverlay.mock.calls.at(-1)?.[0] ?? '';
+    const bannerCount = (lastOverlay.match(/◦/g) ?? []).length;
+    expect(bannerCount).toBe(1);
+    expect(lastOverlay).toContain('Iteration 15: used memory_update');
+    expect(lastOverlay).not.toContain('Iteration 6: used bash');
+  });
+});

--- a/src/cli/_lib/stream-renderer-orchestrator.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.ts
@@ -119,6 +119,19 @@ export function handleOrchestratorEvent(
 
   switch (event.type) {
     case 'progress':
+      // Invariant: lastProgressByTask holds at most one entry. The orchestrator
+      // runs exactly one tool-use loop at a time, and subagent progress is
+      // firewalled to handleSubagentEvent (it carries a non-null subagentId and
+      // never reaches this map — see stream-renderer.ts isOrchestrator branch),
+      // so only the single live loop ever writes here. clear() before set()
+      // evicts a stale entry left by a SECOND runTurn invocation that shares
+      // this live renderer: loop.ts mints a fresh taskId per runTurn, and a
+      // retry that replays the turn without rebuilding the renderer (the 401
+      // auth-retry path; ANY retry on the skill-dispatch renderer, which —
+      // unlike turn-handler.ts — never rebuilds on 'resumed') would otherwise
+      // leave two distinct taskIds accumulated here, rendering two stacked
+      // "Tool-use loop" banners. The live loop's next progress event wipes it.
+      lastProgressByTask.clear();
       lastProgressByTask.set(event.progress.taskId, event.progress);
       if (ctx.isTTY) setComposedOverlay(ctx, lastProgressByTask);
       return;


### PR DESCRIPTION
## Ported from afk-workshop#725

**Source:** griffinwork40/afk-workshop#725 — https://github.com/griffinwork40/afk-workshop/pull/725

This is a **moat-scrubbed port** (diff + 3-way apply), not a 1:1 commit copy — the public repo shares no history with afk-workshop, so the change was reapplied rather than cherry-picked.

## Problem
The interactive REPL sometimes renders **two stacked `◦ Tool-use loop` banners** in one turn — e.g. a frozen `Iteration 6: used bash` alongside a live `Iteration 15: used memory_update`, each with its own token/time totals.

## Root cause
`StreamRenderer` keeps `lastProgressByTask: Map<taskId, ProgressEvent>` and the progress-banner overlay renders **one banner per entry**. The map is **never cleared**, and `loop.ts` mints a fresh `taskId` per `runTurn` invocation. When two `runTurn` invocations share one live renderer, two `taskId`s accumulate → two banners. Two `runTurn`s share a renderer when a retry replays the turn without rebuilding the renderer (the 401 auth-retry path; any retry on the skill-dispatch renderer, which — unlike `turn-handler.ts` — never rebuilds on `'resumed'`).

## Fix
Enforce the real invariant in `handleOrchestratorEvent`'s `progress` case: the orchestrator runs exactly one tool-use loop at a time, and subagent progress is firewalled to `handleSubagentEvent` (never touches this map), so `lastProgressByTask` holds **at most one entry**. `clear()` before `set()`; the live loop's next `progress` event wipes any stale entry.

## Ported changes (public-safe)
- `src/cli/_lib/stream-renderer-orchestrator.ts` (+13): an `// Invariant:` comment + `lastProgressByTask.clear()`.
- `src/cli/_lib/stream-renderer-orchestrator.test.ts` (+62): regression test — two `progress` events with distinct `taskId`s assert exactly one map entry and one rendered banner.

## Dropped (moat)
**None.** The source PR was triaged as entirely public-safe — no files or hunks were dropped.

## Verification
- **Correctness gate** green in a clean public clone: `pnpm install --frozen-lockfile`, `pnpm lint`, `pnpm test` (440 files, 8177 passed / 12 skipped / 0 failed, `AFK_INTERNAL` unset), `pnpm build`, `pnpm build:dist` — all exit 0.
- **Deterministic moat guard** over working tree + built `dist/`: `MOAT GUARD CLEAN`.
- **Independent adversarial moat audit** (re-derived from scratch, not trusting the deterministic guard): CLEAN, high confidence.

**Do not merge automatically** — left for human review.
