### PR TITLE
fix(ci): make auto-release push atomic to prevent orphaned tags

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -139,19 +139,39 @@ jobs:
           pnpm version "${{ steps.bump.outputs.next }}" --no-git-tag-version
           node scripts/generate-changelog.mjs "${{ steps.bump.outputs.next }}"
 
-      - name: Commit, tag, and push
+      - name: Commit, tag, and push (atomic + rebase-retry)
         if: steps.bump.outputs.release == 'true'
         run: |
           set -euo pipefail
           NEXT="${{ steps.bump.outputs.next }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json CHANGELOG.md
-          git commit -m "chore(release): v${NEXT}"
-          git tag -a "v${NEXT}" -m "v${NEXT}"
-          # Pushed with the default GITHUB_TOKEN. This deliberately does NOT
-          # re-trigger publish.yml (anti-recursion) — we publish inline below.
-          git push origin HEAD:main --follow-tags
+
+          # Invariant: the branch update and the tag must land together or not
+          # at all. The prior `git push --follow-tags` pushed refs independently,
+          # so a concurrent PR merge that turned the branch push into a
+          # non-fast-forward still let the TAG land — orphaning vX.Y.Z on the
+          # remote and deadlocking every later run at `git tag -a` ("tag already
+          # exists"). `--atomic` closes that gap; on rejection we re-sync to the
+          # new main tip, re-apply the bump + changelog, and retry. The push uses
+          # the default GITHUB_TOKEN, which by design does NOT re-trigger
+          # publish.yml (anti-recursion) — we publish inline below.
+          for attempt in 1 2 3; do
+            git add package.json CHANGELOG.md
+            git commit -m "chore(release): v${NEXT}"
+            git tag -a "v${NEXT}" -m "v${NEXT}"
+            if git push --atomic origin "HEAD:main" "refs/tags/v${NEXT}"; then
+              exit 0
+            fi
+            echo "::warning::Release push rejected (attempt ${attempt}/3); re-syncing to origin/main and re-applying the bump."
+            git tag -d "v${NEXT}"
+            git fetch origin main
+            git reset --hard origin/main
+            pnpm version "${NEXT}" --no-git-tag-version
+            node scripts/generate-changelog.mjs "${NEXT}"
+          done
+          echo "::error::Release push failed after 3 attempts — persistent contention on main. Re-run this job once main settles."
+          exit 1
 
       # Inline publish: the working tree already holds the bumped package.json +
       # fresh dist, and prepublishOnly rebuilds the tarball, so publish directly.


### PR DESCRIPTION
## Why

Auto-release has failed on **every** merge to `main` since PR #18 (5 consecutive runs). Root cause is a non-atomic push that left an orphaned `v3.85.0` tag, deadlocking the pipeline.

### Failure chain
1. **Trigger** ([run 27078807146](https://github.com/griffinwork40/agent-afk/actions/runs/27078807146), PR #18 `feat:` → `3.85.0`): the job created the release commit + tag and ran `git push origin HEAD:main --follow-tags`. A concurrent PR merge had advanced `main`, so the **branch push was rejected (non-fast-forward)** — but because `--follow-tags` pushes refs independently, the **tag `v3.85.0` landed anyway**, pointing at an orphaned commit. Exit 1.
2. **Deadlock** (4 later runs): `package.json` was still `3.84.1` (bump never landed) and the orphaned tag is unreachable from `main`, so every run recomputed `3.85.0` and died at `git tag -a` → `fatal: tag 'v3.85.0' already exists` (exit 128).

Verified: `v3.85.0` was **never published to npm** (latest = `3.84.1`) and **no GitHub Release** exists for it.

## What

- Replace the non-atomic push with `git push --atomic origin HEAD:main refs/tags/vX.Y.Z` — branch + tag land together or not at all, so a rejected branch push can never leak a tag again.
- Add a **3-attempt rebase-retry**: on rejection, re-sync to the new `main` tip, re-apply the bump (`pnpm version`) + regenerate the changelog (idempotent — `includeHash: true` dedups), and retry. After 3 attempts it fails cleanly with no orphaned state.

## Remediation already applied out-of-band

- Deleted the orphaned remote tag `v3.85.0` (it pointed to `e28a1a0`; nothing referenced it) — this unblocked the deadlock immediately.

## Effect of merging

Because the `v3.84.1..HEAD` range already contains `feat:` commits, **merging this PR will cut and publish `v3.85.0`** with the fixed workflow — clearing the backlog (feat + 4 fixes) and validating the atomic path live.

## Validation

- `python3 yaml.safe_load` → YAML OK
- `bash -n` on the extracted script → SYNTAX OK
- `prepublishOnly` runs `clean && build:dist`, so the retry path's `dist/` is always rebuilt at publish time.
