### PR TITLE
feat(daemon): push full redacted task response to Telegram

### DIFF
--- a/src/agent/daemon/scheduler.test.ts
+++ b/src/agent/daemon/scheduler.test.ts
@@ -5,7 +5,7 @@
  * AgentSession or filesystem path is ever touched.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -149,6 +149,42 @@ describe('CronScheduler telemetry — errorMessage redaction', () => {
     expect(record.status).toBe('success');
     expect(record.responseExcerpt).not.toContain(rawSecret);
     expect(record.responseExcerpt).toMatch(/REDACTED/);
+
+    await scheduler.stop();
+  });
+
+  it('passes full redacted response to completion callback without persisting it', async () => {
+    const rawSecret = 'sk-ant-api03-secretkeyABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdefghijklmnopqrstu';
+    const tail = 'TAIL_AFTER_EXCERPT';
+    const response = `${'x'.repeat(350)}${rawSecret}\n${tail}`;
+    const onTaskComplete = vi.fn();
+    const scheduler = new CronScheduler({
+      telemetryPath,
+      sessionFactory: () => makeSession({ response }),
+      onTaskComplete,
+    });
+
+    scheduler.register({
+      taskId: 'full-response-test',
+      command: 'query',
+      trigger: 'cron',
+      cronExpression: '* * * * *',
+    });
+
+    const record = await scheduler.tick('full-response-test');
+
+    expect(record.status).toBe('success');
+    expect(record.responseExcerpt).not.toContain(tail);
+    expect(onTaskComplete).toHaveBeenCalledOnce();
+    const [callbackRecord, details] = onTaskComplete.mock.calls[0]!;
+    expect(callbackRecord).toBe(record);
+    expect(details?.responseText).toContain(tail);
+    expect(details?.responseText).toContain('REDACTED');
+    expect(details?.responseText).not.toContain(rawSecret);
+
+    const line = readFileSync(telemetryPath, 'utf-8').trim();
+    expect(line).not.toContain(tail);
+    expect(line).not.toContain(rawSecret);
 
     await scheduler.stop();
   });

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -87,7 +87,7 @@ export interface SchedulerOptions {
    * notification failures never crash the scheduler. Used for out-of-band
    * notifications (Telegram push, webhooks, etc.).
    */
-  onTaskComplete?: (record: TelemetryRecord) => void | Promise<void>;
+  onTaskComplete?: (record: TelemetryRecord, details?: TaskCompletionDetails) => void | Promise<void>;
   /**
    * Poll interval (ms) for the pull-trigger queue. When > 0, `startPullLoop()`
    * will set up a `setInterval` that dequeues one task per tick when idle.
@@ -114,6 +114,11 @@ export interface TelemetryRecord {
   skipReason?: SessionStartSkipReason;
   /** Human-readable label from ScheduledTaskConfig, if available. */
   name?: string;
+}
+
+export interface TaskCompletionDetails {
+  /** Full successful task response for out-of-band notifications; not persisted to telemetry. */
+  responseText?: string;
 }
 
 interface RegisteredEntry {
@@ -296,13 +301,14 @@ export class CronScheduler {
       session = spawned.session;
       memoryStore = spawned.memoryStore;
       const response = await session.sendMessage(task.command);
+      const responseText = redactInlineSecrets(response.content);
       const record: TelemetryRecord = {
         ...baseRecord,
         durationMs: this.now() - startTimeMs,
         status: 'success',
-        responseExcerpt: redactInlineSecrets(response.content.slice(0, 280)),
+        responseExcerpt: responseText.slice(0, 280),
       };
-      this.writeTelemetry(record, task);
+      this.writeTelemetry(record, task, { responseText });
       return record;
     } catch (err) {
       const record: TelemetryRecord = {
@@ -461,10 +467,14 @@ export class CronScheduler {
     }
   }
 
-  private writeTelemetry(record: TelemetryRecord, task?: ScheduledTask): void {
+  private writeTelemetry(
+    record: TelemetryRecord,
+    task?: ScheduledTask,
+    details?: TaskCompletionDetails,
+  ): void {
     try {
       appendFileSync(this.telemetryPath(), `${JSON.stringify(record)}\n`, 'utf-8');
-      this.fireOnTaskComplete(record, task);
+      this.fireOnTaskComplete(record, task, details);
     } catch (err) {
       // Telemetry failure must not crash the daemon. Log to stderr and move on.
       const msg = err instanceof Error ? err.message : String(err);
@@ -473,7 +483,11 @@ export class CronScheduler {
     }
   }
 
-  private fireOnTaskComplete(record: TelemetryRecord, task?: ScheduledTask): void {
+  private fireOnTaskComplete(
+    record: TelemetryRecord,
+    task?: ScheduledTask,
+    details?: TaskCompletionDetails,
+  ): void {
     const cb = this.options.onTaskComplete;
     if (!cb) return;
     // notifyOn filter — only applies when the triggering task is known
@@ -485,7 +499,7 @@ export class CronScheduler {
     // Fire-and-forget. Notification callbacks must not block telemetry
     // writes or crash the scheduler — every error is swallowed and logged.
     try {
-      const result = cb(record);
+      const result = cb(record, details);
       if (result instanceof Promise) {
         void result.catch((err: unknown) => {
           const msg = err instanceof Error ? err.message : String(err);

--- a/src/cli/commands/daemon.test.ts
+++ b/src/cli/commands/daemon.test.ts
@@ -67,8 +67,9 @@ vi.mock('../errors/index.js', () => ({
 }));
 
 import { startDaemon } from '../../agent/daemon.js';
+import { pushIfConfigured } from '../../telegram/push.js';
 import { loadConfig } from '../config.js';
-import { registerDaemonCommand } from './daemon.js';
+import { formatTaskCompletion, registerDaemonCommand } from './daemon.js';
 import {
   resolveTriggerMode,
   resolveDefaultTask,
@@ -79,6 +80,7 @@ import {
 
 const mockStartDaemon = vi.mocked(startDaemon);
 const mockLoadConfig = vi.mocked(loadConfig);
+const mockPushIfConfigured = vi.mocked(pushIfConfigured);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -262,5 +264,47 @@ describe('afk daemon (CLI integration)', () => {
     const opts = mockStartDaemon.mock.calls[0]?.[0];
     const mainTask = opts?.tasks?.find((t) => t.taskId !== 'worktree-prune');
     expect(mainTask?.command).toBe('/flag-task');
+  });
+
+  it('formats full completion response text when callback details include it', () => {
+    const fullResponse = `${'a'.repeat(700)}\nfinal line`;
+    const formatted = formatTaskCompletion(
+      {
+        taskId: 'nightly',
+        command: 'run',
+        trigger: 'cron',
+        triggeredAt: new Date(0).toISOString(),
+        durationMs: 1200,
+        status: 'success',
+        responseExcerpt: 'short excerpt',
+      },
+      { responseText: fullResponse },
+    );
+
+    expect(formatted).toContain('daemon task: nightly (success)');
+    expect(formatted).toContain('final line');
+    expect(formatted).not.toContain('short excerpt');
+  });
+
+  it('forwards scheduler completion details to Telegram notification formatting', async () => {
+    await runDaemon();
+
+    const opts = mockStartDaemon.mock.calls[0]?.[0];
+    opts?.onTaskComplete?.(
+      {
+        taskId: 'nightly',
+        command: 'run',
+        trigger: 'cron',
+        triggeredAt: new Date(0).toISOString(),
+        durationMs: 1200,
+        status: 'success',
+        responseExcerpt: 'short excerpt',
+      },
+      { responseText: 'full daemon output' },
+    );
+
+    expect(mockPushIfConfigured).toHaveBeenCalledWith(
+      expect.stringContaining('full daemon output'),
+    );
   });
 });

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -7,7 +7,7 @@ import os from 'os';
 import { startDaemon } from '../../agent/daemon.js';
 import { getQueueDir } from '../../paths.js';
 import { pushIfConfigured } from '../../telegram/push.js';
-import type { TelemetryRecord } from '../../agent/daemon/scheduler.js';
+import type { TaskCompletionDetails, TelemetryRecord } from '../../agent/daemon/scheduler.js';
 import {
   COMPILED_DEFAULT_TASK,
   COMPILED_DEFAULT_TASK_ID,
@@ -179,7 +179,10 @@ export function buildDaemonSessionFactory(
  * Format a daemon telemetry record for an out-of-band notification
  * (e.g. Telegram push). Short, scannable, status-first.
  */
-function formatTaskCompletion(record: TelemetryRecord): string {
+export function formatTaskCompletion(
+  record: TelemetryRecord,
+  details: TaskCompletionDetails = {},
+): string {
   const icon =
     record.status === 'success' ? '✅' : record.status === 'skipped' ? '⏭️' : '❌';
   const durationSec = (record.durationMs / 1000).toFixed(1);
@@ -189,8 +192,9 @@ function formatTaskCompletion(record: TelemetryRecord): string {
   ];
   if (record.skipReason) lines.push(`skipReason=${record.skipReason}`);
   if (record.errorMessage) lines.push(`error: ${record.errorMessage.slice(0, 400)}`);
-  if (record.responseExcerpt) {
-    lines.push('', record.responseExcerpt.slice(0, 600));
+  const responseText = details.responseText ?? record.responseExcerpt;
+  if (responseText) {
+    lines.push('', responseText);
   }
   return lines.join('\n');
 }
@@ -375,8 +379,8 @@ export function registerDaemonCommand(program: Command): void {
           ...(options.briefsDir !== undefined ? { briefsDir: options.briefsDir } : {}),
           ...(trigger === 'pull' ? { pullPollIntervalMs: 30_000, queueDir: getQueueDir() } : {}),
           tasks,
-          onTaskComplete: (record: TelemetryRecord) => {
-            void pushIfConfigured(formatTaskCompletion(record)).catch(() => undefined);
+          onTaskComplete: (record: TelemetryRecord, details?: TaskCompletionDetails) => {
+            void pushIfConfigured(formatTaskCompletion(record, details)).catch(() => undefined);
           },
         });
 

--- a/src/telegram/push.test.ts
+++ b/src/telegram/push.test.ts
@@ -217,6 +217,22 @@ describe('pushIfConfigured', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(3);
   });
 
+  test('splits long text into Telegram-safe chunks', async () => {
+    process.env['TELEGRAM_BOT_TOKEN'] = 't';
+    process.env['AFK_TELEGRAM_ALLOWED_CHAT_IDS'] = '42';
+    const fetchImpl = makeFetchOk();
+    const text = 'x'.repeat(9000);
+
+    const result = await pushIfConfigured(text, { fetchImpl });
+
+    expect(result).toHaveLength(3);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    const calls = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const sent = calls.map((c) => JSON.parse(c[1].body).text as string);
+    expect(sent.every((chunk) => chunk.length <= 4096)).toBe(true);
+    expect(sent.join('')).toBe(text);
+  });
+
   test('forwards reply_markup to every chat when provided', async () => {
     process.env['TELEGRAM_BOT_TOKEN'] = 't';
     process.env['AFK_TELEGRAM_ALLOWED_CHAT_IDS'] = '111,222';
@@ -230,6 +246,28 @@ describe('pushIfConfigured', () => {
     for (const c of calls) {
       const body = JSON.parse(c[1].body);
       expect(body.reply_markup).toEqual(replyMarkup);
+    }
+  });
+
+  test('attaches reply_markup only to the first chunk per chat', async () => {
+    process.env['TELEGRAM_BOT_TOKEN'] = 't';
+    process.env['AFK_TELEGRAM_ALLOWED_CHAT_IDS'] = '111,222';
+    const fetchImpl = makeFetchOk();
+    const replyMarkup = {
+      inline_keyboard: [[{ text: 'Open', callback_data: 'afk:f:x:slug' }]],
+    };
+
+    await pushIfConfigured('x'.repeat(5000), { fetchImpl, replyMarkup });
+
+    const calls = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(4);
+    for (let i = 0; i < calls.length; i++) {
+      const body = JSON.parse(calls[i][1].body);
+      if (i === 0 || i === 2) {
+        expect(body.reply_markup).toEqual(replyMarkup);
+      } else {
+        expect(body.reply_markup).toBeUndefined();
+      }
     }
   });
 });

--- a/src/telegram/push.ts
+++ b/src/telegram/push.ts
@@ -16,6 +16,7 @@
 import type { InlineKeyboardMarkup } from 'telegraf/types';
 
 import { parseAllowedChatIds } from './allowlist.js';
+import { splitLongMessage } from './formatter.js';
 import { env } from '../config/env.js';
 
 const TELEGRAM_API_BASE = 'https://api.telegram.org';
@@ -108,8 +109,8 @@ export async function push(options: PushOptions): Promise<PushResult> {
 }
 
 /**
- * Push to every chat in `AFK_TELEGRAM_ALLOWED_CHAT_IDS`, but only if
- * `TELEGRAM_BOT_TOKEN` is also set. Returns `null` if unconfigured (so
+ * Push to every chat in `AFK_TELEGRAM_ALLOWED_CHAT_IDS`, splitting long text
+ * into sequential Telegram-safe messages. Returns `null` if unconfigured (so
  * callers don't need to gate every call site).
  */
 export async function pushIfConfigured(
@@ -125,16 +126,19 @@ export async function pushIfConfigured(
   const chatIds = parseAllowedChatIds(env.AFK_TELEGRAM_ALLOWED_CHAT_IDS);
   if (chatIds.size === 0) return null;
 
+  const chunks = splitLongMessage(text);
   const results: PushResult[] = [];
   for (const chatId of chatIds) {
-    results.push(await push({
-      token,
-      chatId,
-      text,
-      ...(opts.parseMode !== undefined ? { parseMode: opts.parseMode } : {}),
-      ...(opts.replyMarkup !== undefined ? { replyMarkup: opts.replyMarkup } : {}),
-      ...(opts.fetchImpl !== undefined ? { fetchImpl: opts.fetchImpl } : {}),
-    }));
+    for (let i = 0; i < chunks.length; i++) {
+      results.push(await push({
+        token,
+        chatId,
+        text: chunks[i] ?? '',
+        ...(opts.parseMode !== undefined ? { parseMode: opts.parseMode } : {}),
+        ...(opts.replyMarkup !== undefined && i === 0 ? { replyMarkup: opts.replyMarkup } : {}),
+        ...(opts.fetchImpl !== undefined ? { fetchImpl: opts.fetchImpl } : {}),
+      }));
+    }
   }
   return results;
 }


### PR DESCRIPTION
## Summary
- Daemon Telegram task-completion notifications now deliver the **full redacted response** instead of a 280-char excerpt. The full text flows out-of-band through a new `TaskCompletionDetails` channel on the `onTaskComplete` callback; telemetry persistence stays bounded to the short redacted excerpt — no JSONL log bloat, and a smaller persisted-secret surface.
- `pushIfConfigured` now splits long text into Telegram-safe chunks (≤4096 chars) via `splitLongMessage`, attaching the inline keyboard (`reply_markup`) to the **first chunk per chat only** so action buttons aren't duplicated across chunks.
- `formatTaskCompletion` is exported and prefers `details.responseText` over the excerpt when present.

## Test results
- `pnpm lint` (`tsc --noEmit`, strict): **passed**, 0 errors
- `pnpm test` (`vitest run`): **440 files, 8183 passed | 12 skipped, 0 failed** (58s)

## Verification
Adversarial verifier wave ran (read-only re-derivation from the diff alone; triggered because the diff exceeds 100 changed lines):
- **CLAIM 1 — full response reaches the callback, but only the ≤280-char redacted excerpt is persisted:** CONFIRM (`scheduler.ts:304–311` — redact → `slice(0,280)` into the record; full `responseText` passed out-of-band; full text never enters the persisted record).
- **CLAIM 2 — ≤4096-char chunking; `reply_markup` on first chunk only:** CONFIRM (`push.ts:128–141`; hard cap in `formatter.ts`; `i === 0` gating at `push.ts:138`).
- **CLAIM 3 — redact-then-slice; callback never receives unredacted secrets:** CONFIRM (`scheduler.ts:304` redacts `response.content` before any slice).
- **Overall: SAFE TO MERGE.** No contradictions.

## Out of scope (follow-up candidates, non-blocking)
- Empty-chunk edge: if `splitLongMessage` ever yields an empty trailing chunk, `pushIfConfigured` would send an empty Telegram message (`push.ts:136`). Low severity.
- `splitLongMessage`'s per-chunk `.trim()` can drop whitespace straddling a split boundary; the `sent.join('') === text` assertion in `push.test.ts` could be fragile on whitespace-heavy inputs. Not a security issue.
