### PR TITLE
fix(cli): verdict card 'cut off bottom' — render closing border in tight frames + ASCII-safe affordances

### DIFF
--- a/src/cli/commands/interactive/verdict-card.ts
+++ b/src/cli/commands/interactive/verdict-card.ts
@@ -34,28 +34,34 @@ interface KindStyle {
   affordance: string;
 }
 
+// Invariant: affordance strings must be ASCII-only (no em-dash `—`, en-dash,
+// `…`, `·`, or other East-Asian-Width "Ambiguous" glyphs). The affordance row
+// is padded to the full card width; `string-width` counts an ambiguous glyph
+// as 1 column, but terminals/fonts that render it as 2 push the row 1 column
+// past the right border, wrapping the trailing `│` and breaking the box. Use
+// ASCII `-` for dashes. (Chip glyphs ✓/⊘/?/⏸ are NOT ambiguous — verified.)
 const STYLES: Record<TerminalKind, KindStyle> = {
   done: {
     color: palette.success,
     chip: '✓ Done',
-    affordance: 'Objective satisfied — review evidence and close.',
+    affordance: 'Objective satisfied - review evidence and close.',
   },
   blocked: {
     color: palette.error,
     chip: '⊘ Blocked',
-    affordance: 'External dependency — unblock above to resume.',
+    affordance: 'External dependency - unblock above to resume.',
   },
   asking: {
     color: palette.warning,
     chip: '? Asking',
-    affordance: 'Waiting on you — answer above to continue.',
+    affordance: 'Waiting on you - answer above to continue.',
   },
   interrupted: {
     // Neutral terminal state — see verdict-ledger.ts for rationale. Meta
     // grey conveys "this happened, low salience," not "informational event."
     color: palette.meta,
     chip: '⏸ Interrupted',
-    affordance: 'Halted with state preserved — resume when ready.',
+    affordance: 'Halted with state preserved - resume when ready.',
   },
 };
 

--- a/src/cli/terminal-compositor.committed-band.ts
+++ b/src/cli/terminal-compositor.committed-band.ts
@@ -295,7 +295,13 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     const maxRun = Math.max(0, newTopRow - anchorFloor);
     const newPainted = Math.min(textLines.length, maxRun);
     if (newPainted > 0) {
-      const newLines = textLines.slice(0, newPainted);
+      // Tail-slice (not head): when the block is taller than the above-frame
+      // room (overflow path, newPainted < lineCount), keep the LAST lines. A
+      // block's final line — e.g. a verdict card's closing border `╰──╯` and
+      // its affordance — must survive, not its opening line; dropping the
+      // bottom left boxes rendered un-closed. In the fits path newPainted ===
+      // lineCount, so this is the whole array (no behavior change there).
+      const newLines = textLines.slice(textLines.length - newPainted);
       const contiguousPriorBand =
         fitsAboveFrame &&
         newPainted === lineCount &&
@@ -332,11 +338,20 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
         }
       } else {
         // Overflow (block taller than the above-frame region): Phase 1 already
-        // archived the whole block to scrollback at anchorFloor; paint only
-        // the top lines that fit, anchored at the floor (legacy behavior).
-        const textStartRow = Math.max(anchorFloor, newTopRow - lineCount);
-        for (let i = 0; i < textLines.length; i++) {
-          const row = textStartRow + i;
+        // archived the whole block to scrollback at anchorFloor. Paint the
+        // BOTTOM lines that fit (anchored so the block's final line lands at
+        // newTopRow-1, immediately above the frame), matching scrollback
+        // semantics — newest content sits at the bottom; older lines scroll
+        // up into history. Top-anchoring instead dropped the block's last
+        // line, so a verdict card taller than the room above the live frame
+        // rendered with no closing border `╰──╯` (the "cut-off bottom" bug).
+        // The dropped top lines stay recoverable via the Phase-1 archive.
+        // `capped` (== these same tail lines, via the tail-slice above) is the
+        // band we track, so repositionCommittedBand repaints them on resize.
+        const room = Math.max(0, newTopRow - anchorFloor);
+        const startIdx = Math.max(0, textLines.length - room);
+        for (let i = startIdx; i < textLines.length; i++) {
+          const row = anchorFloor + (i - startIdx);
           if (row >= newTopRow) break;
           out += `\x1b[${row};1H\x1b[2K${textLines[i] ?? ''}`;
         }

--- a/src/cli/verdict-card-overflow.test.ts
+++ b/src/cli/verdict-card-overflow.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression: verdict-card "bottom border cut off" bugs.
+ *
+ * Two independent defects, both reported via a screenshot where a Done card
+ * rendered with its content + affordance visible but NO closing border `╰──╯`:
+ *
+ *  1. commitAbove's overflow path (block taller than the room above the live
+ *     frame) top-anchored its viewport paint and clipped the LAST line — so a
+ *     verdict card taller than the available rows above the tall REPL idle
+ *     frame lost its closing border. Fix: tail-slice + bottom-anchor the
+ *     overflow paint so the final line (closing border + affordance) survives;
+ *     older top lines scroll into the Phase-1 scrollback archive instead.
+ *     (src/cli/terminal-compositor.committed-band.ts)
+ *
+ *  2. Every affordance string contained an em-dash `—` (U+2014, East-Asian-Width
+ *     Ambiguous). string-width counts it 1, but ambiguous-wide terminals render
+ *     it 2, pushing the full-width affordance row 1 column past the box and
+ *     wrapping the trailing `│`. Fix: ASCII-only affordances.
+ *     (src/cli/commands/interactive/verdict-card.ts)
+ *
+ * This test drives the REAL renderVerdictCard + TerminalCompositor.commitAbove
+ * pipeline (mirroring turn-handler's card → blank → footer sequence) into a
+ * headless xterm and asserts the closing border survives in a tight frame.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import stringWidth from 'string-width';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { renderVerdictCard } from './commands/interactive/verdict-card.js';
+import type { TerminalState, TerminalKind } from './commands/interactive/terminal-state.js';
+
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+function makeMockStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true; s.columns = cols; s.rows = rows;
+  return s;
+}
+function makeMockStdin() {
+  const s = new PassThrough() as unknown as NodeJS.ReadStream & { isTTY: boolean; setRawMode: ReturnType<typeof vi.fn> };
+  s.isTTY = true;
+  (s as unknown as { setRawMode: ReturnType<typeof vi.fn> }).setRawMode = vi.fn(() => s);
+  return s;
+}
+function makeScrollRegion(stdout: MockStdout) {
+  return {
+    withFullScrollRegion<T>(fn: () => T): T {
+      stdout.write('\x1b[s'); stdout.write('\x1b[r'); stdout.write('\x1b[u');
+      try { return fn(); } finally {
+        stdout.write('\x1b[s'); stdout.write(`\x1b[1;${stdout.rows}r`); stdout.write('\x1b[u');
+      }
+    },
+    getExtraRows() { return 0; },
+  };
+}
+function allLines(term: HeadlessTerminal): string[] {
+  const buf = term.buffer.active; const out: string[] = [];
+  for (let i = 0; i < buf.length; i++) {
+    const line = buf.getLine(i);
+    if (line != null) out.push(line.translateToString(true));
+  }
+  return out;
+}
+
+const VERDICT: TerminalState = {
+  kind: 'done',
+  whatWasDone: 'Ran two parallel investigation lanes (CLI command handling + state storage), then verified the load-bearing claim directly in source.',
+  evidence: 'Architecture summary above, every structural claim cited to file:line; non-atomic write confirmed by reading saveSession (session-store.ts:117-142).',
+  deferred: 'The atomic-write fix is recommended, not applied (you asked for analysis). Say the word and I will implement it.',
+  rawBody: '',
+};
+
+// A tall idle frame like the real REPL: loop-stage bar + ledger + prompt + status.
+const TALL_IDLE_FRAME = [
+  '  \u25e6 Tool-use loop',
+  '    Iteration 3: used read_file \u00b7 3 tools \u00b7 4.4k tok',
+  'afk > observe  model  choose  act  update',
+  'ledger  done   (1 turn)',
+  '~/x \u00b7 opus_1m \u00b7 3%',
+].join('\n');
+
+async function renderTurnIntoXterm(cols: number, rows: number): Promise<string[]> {
+  const stdout = makeMockStdout(cols, rows);
+  const chunks: string[] = [];
+  stdout.on('data', (c: unknown) => chunks.push(String(c)));
+  const stdin = makeMockStdin();
+  const scrollRegion = makeScrollRegion(stdout);
+  const c = new TerminalCompositor({ stdout, stdin, scrollRegion: scrollRegion as never });
+  await c.arm();
+  // Prior streamed prose pushes the screen near-full so the card commits into
+  // tight room above the frame (forces commitAbove's overflow path).
+  for (let i = 0; i < 8; i++) c.commitAbove(`prior streamed assistant prose line ${i}`);
+  c.setOverlay(TALL_IDLE_FRAME);
+  // Mirror turn-handler.ts: card -> blank -> footer.
+  c.commitAbove(renderVerdictCard(VERDICT));
+  c.commitAbove('');
+  c.commitAbove('  \u25e6 3m 12s  \u00b7  7.3k tok');
+  c.commitAbove('');
+
+  const term = new HeadlessTerminal({ cols, rows, scrollback: 1000, allowProposedApi: true });
+  await new Promise<void>((resolve) => term.write(chunks.join(''), resolve));
+  return allLines(term);
+}
+
+describe('verdict card bottom border survives a tight frame (regression)', () => {
+  it('renders the closing border ╰──╯ even when the card is taller than the room above the live frame', async () => {
+    const lines = await renderTurnIntoXterm(80, 20);
+    const grid = lines.filter((l) => l.trim()).join('\n');
+    const hasTop = lines.some((l) => /╭─.*Done.*╮/.test(l));
+    const hasBottom = lines.some((l) => /╰─+╯/.test(l));
+    // The closing border is the load-bearing assertion — its absence is the
+    // reported "cut off on the bottom" bug.
+    expect(hasBottom, `bottom border ╰──╯ missing from rendered grid:\n${grid}`).toBe(true);
+    // The affordance (the actionable end-of-turn line) must remain visible.
+    expect(lines.some((l) => l.includes('Objective satisfied')), `affordance missing:\n${grid}`).toBe(true);
+    // Sanity: the box opened too (top border present somewhere).
+    expect(hasTop).toBe(true);
+  });
+});
+
+describe('verdict card affordances are ambiguous-width safe (regression)', () => {
+  it('affordance TEXT has no glyph that string-width measures differently in narrow vs wide mode', () => {
+    const kinds: TerminalKind[] = ['done', 'blocked', 'asking', 'interrupted'];
+    for (const kind of kinds) {
+      const card = renderVerdictCard({ kind, rawBody: 'x' } as TerminalState);
+      // Find the affordance row (the dim line just above the bottom border).
+      const affordanceRow = card.split('\n').find((l) => /satisfied|dependency|Waiting|Halted/.test(l));
+      expect(affordanceRow, `affordance row not found for ${kind}`).toBeTruthy();
+      // Strip ANSI SGR + box-drawing chrome (U+2500–U+257F: the `│` rails),
+      // leaving only the affordance TEXT. Box-drawing is itself EAW-ambiguous
+      // but structurally unavoidable; the regression is an ambiguous glyph in
+      // the TEXT (the em-dash), which overflows the full-width row and wraps
+      // the trailing `│` on ambiguous-wide terminals.
+      const text = affordanceRow!
+        .replace(/\x1b\[[0-9;]*m/g, '')
+        .replace(/[\u2500-\u257F]/g, '');
+      const narrow = stringWidth(text, { ambiguousIsNarrow: true });
+      const wide = stringWidth(text, { ambiguousIsNarrow: false });
+      expect(
+        wide,
+        `${kind} affordance text has ambiguous-width glyph(s): narrow=${narrow} wide=${wide} in ${JSON.stringify(text)}`,
+      ).toBe(narrow);
+    }
+  });
+});


### PR DESCRIPTION
## Symptom

The Done/verdict card rendered in the REPL with its content + affordance visible but **no closing border `╰──╯`** ("cut off on the bottom"), and on some terminals the affordance line lost its right rail.

## Root cause (two independent defects)

Diagnosed by driving the real `renderVerdictCard` + `TerminalCompositor.commitAbove` pipeline through `@xterm/headless`. A 2×2 (font width × frame room) isolated them: bottom-border loss tracks **room**; chrome wrap tracks **font**.

**1. Bottom border clipped — `commitAbove` overflow path (the headline).**
When a committed block is taller than the room above the live frame, `fitsAboveFrame` is false and the overflow Phase-3 paint was **top-anchored** (`textStartRow = max(anchorFloor, newTopRow - lineCount)`) with `if (row >= newTopRow) break` — so it painted the first `room` lines and **dropped the last**. The REPL idle frame is tall (loop-stage bar + ledger + prompt + status ≈ 7 rows), so a ~13-line verdict card overflows on shorter terminals and loses its closing border. (`src/cli/terminal-compositor.committed-band.ts`)

**2. Affordance wrap — EAW-ambiguous em-dash.**
All four affordance strings contained an em-dash `—` (U+2014, East-Asian-Width **Ambiguous**). The card sizes every line to exactly the terminal width via `string-width`, which counts `—` as 1 column; terminals/fonts that render it as 2 push the full-width affordance row one column past the box, wrapping the trailing `│`. (`src/cli/commands/interactive/verdict-card.ts`)

> Note: the chip glyphs `✓` / `⊘` / `?` / `⏸` are **not** EAW-ambiguous (verified), so the top border was unaffected.

## Fix

- **Overflow paint** now **tail-slices** the tracked band and **bottom-anchors** the viewport paint, so a block's final line (a card's closing border + affordance) stays visible adjacent to the frame; older top lines remain in the Phase-1 scrollback archive. This also matches normal scrollback semantics (newest content at the bottom, like `tail`).
- **Affordances** are now ASCII-only (`-` instead of `—`), with an invariant comment to prevent reintroduction of ambiguous-width glyphs.

## Verification

- New regression test `src/cli/verdict-card-overflow.test.ts` drives the real card + compositor through `@xterm/headless` in a tight-frame scenario. It **fails on pre-fix code** (bottom border missing) and **passes after** — confirmed by stashing only the `commitAbove` fix.
- Full suite green: **8185 passed / 0 failed** (12 skipped). All **267** terminal-compositor tests pass (no regression in the delicate path).
- `pnpm lint` (`tsc --noEmit`, strict) exit 0. `pnpm audit:sdk:check` OK.

## Out of scope (follow-up)

`commitAbove` remains **wrap-blind** (counts newlines, not physical rows), so ambiguous-width glyphs in *model-provided* card content can still wrap. A deeper, higher-risk fix would make `commitAbove` measure physical rows. Left for a separate change.
