### PR TITLE
feat(prompt): layer operator config over an unconditional framework base

### DIFF
--- a/AFK.md
+++ b/AFK.md
@@ -73,21 +73,23 @@ The plugin surface writes to `~/.claude/agent-framework/` independently — no s
 
 ### System prompt discovery
 
-`loadConfig()` resolves `systemPrompt` in 4-tier precedence (highest wins):
+The base system prompt is **layered**: the framework prompt (`prompts/system-prompt.md`, inlined at publish-build) is the unconditional foundation; the resolved operator overlay is **appended** on top beneath an `# Operator configuration` header — never a replacement. `resolveBaseSystemPrompt()` (`src/cli/shared-helpers.ts`) layers them for every top-level surface (chat, REPL, Telegram, farm).
 
-| Tier | Source | `systemPromptSource` |
+`loadConfig()` resolves the **operator overlay** across three tiers (highest wins); `loadConfig().systemPrompt` is that overlay alone:
+
+| Tier | Overlay source | `loadConfig().systemPromptSource` |
 |------|--------|----------------------|
 | 1 | `AFK_SYSTEM_PROMPT` env | `env:AFK_SYSTEM_PROMPT` |
 | 2 | `afk.config.json` (cwd → `~/.afk/config/` → legacy) | `file:<abs>` |
 | 3 | `AFK.md` (cwd → `$AFK_HOME/`) | `afk-md:<abs>` |
-| 4 | None | `undefined` |
+| — | None | `undefined` |
 
-`AFK.md` is plain markdown, no frontmatter. Empty/whitespace → treated as absent. `systemPromptSource` threads into `AgentSession` for `--dump-prompt` provenance; never forwarded to the SDK.
+`AFK.md` is plain markdown, no frontmatter. Empty/whitespace → treated as absent. The framework base is always present regardless of overlay tier (this file, `AFK.md`, is itself a tier-3 overlay appended to the framework base). `--dump-prompt` reports a composed `systemPromptSource` (`framework`, `framework+afk-md:<path>`, …); never forwarded to the SDK as a preset. Every overlay appends — no full-replace escape hatch yet (a future `AFK_BASE_PROMPT=0` would add one).
 
 ## Conventions
 
 - **`tsconfig.json` is maximally strict**: `noUnusedLocals`, `noUnusedParameters`, `noUncheckedIndexedAccess`, `noPropertyAccessFromIndexSignature`. All code must pass `tsc --noEmit`.
-- The agent-afk system prompt is a raw string from config or file, sent to the Messages API as-is. No SDK preset is loaded.
+- The agent-afk system prompt is the framework base (`prompts/system-prompt.md`) with the operator overlay (env/config/AFK.md) appended, composed by `resolveBaseSystemPrompt()` and sent to the Messages API as a raw string. No SDK preset is loaded.
 - `AgentSession` constructor is **synchronous**; SDK lifecycle runs async via `initSdkLifecycle()` and surfaces through the provider event stream.
 - DAG executor (`src/agent/dag.ts`, 266 LOC) is fully implemented: layer-by-layer Kahn execution, per-node `AbortController`s, fail-fast with transitive skip, node-level timeouts.
 - **SDK dependency tracking**: every import from `@anthropic-ai/sdk` is in `.sdk-dependency.lock.json`. CI fails on unlocked new symbols. After adding an SDK import, run `pnpm audit:sdk:update-lock` and edit the new entry's `reason` field before commit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,16 +121,18 @@ grep -rn --include='*.ts' '^[[:space:]]*//' src/ \
 
 ### System Prompt Discovery
 
-`loadConfig()` resolves `systemPrompt` through a 4-tier precedence chain (highest wins):
+The base system prompt is **layered**: the framework prompt (`prompts/system-prompt.md`, inlined at publish-build) is the unconditional foundation, and the resolved operator overlay is **appended** on top beneath an `# Operator configuration` header — never a replacement. `resolveBaseSystemPrompt()` (`src/cli/shared-helpers.ts`) does the layering for every top-level surface (chat, REPL, Telegram, farm).
 
-| Tier | Source | `systemPromptSource` value |
+`loadConfig()` resolves the **operator overlay** across three tiers (highest wins); `loadConfig().systemPrompt` is that overlay alone:
+
+| Tier | Overlay source | `loadConfig().systemPromptSource` value |
 |------|--------|---------------------------|
 | 1 | `AFK_SYSTEM_PROMPT` env var | `"env:AFK_SYSTEM_PROMPT"` |
 | 2 | `afk.config.json` (`cwd` → `~/.afk/config/` → legacy) | `"file:<abs path>"` |
 | 3 | `AFK.md` (`cwd` → `$AFK_HOME/`) | `"afk-md:<abs path>"` |
-| 4 | None | `systemPromptSource` is `undefined` |
+| — | None | `systemPromptSource` is `undefined` |
 
-`AFK.md` is plain Markdown with no frontmatter. Empty or whitespace-only files are treated as absent (tier 4). The `systemPromptSource` field is populated on `CliConfig` and threaded into `AgentSession` config for `--dump-prompt` provenance tracking; it is never forwarded to the SDK.
+`AFK.md` is plain Markdown with no frontmatter. Empty or whitespace-only files are treated as absent. The framework base is always present regardless of overlay tier. `--dump-prompt` reports a composed `systemPromptSource` (`"framework"`, `"framework+afk-md:<path>"`, …) and the full text in `options.system`; the composed prompt is never forwarded to the SDK as a preset. Every overlay appends — there is currently no full-replace escape hatch (a future `AFK_BASE_PROMPT=0` would add one).
 
 ## Ordered-operation sequences
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ AFK_TELEGRAM_ALLOWED_CHAT_IDS=12345678
 AFK_MAX_BUDGET_USD=5.00
 ```
 
-**Project-scoped system prompt.** Drop an `AFK.md` at your project root and `afk` reads it as the system prompt whenever you run from that directory. No frontmatter needed.
+**Project-scoped system prompt.** Drop an `AFK.md` at your project root and `afk` appends it to its built-in framework prompt whenever you run from that directory — your instructions layer on top of the base, they don't replace it. No frontmatter needed.
 
 **Check what resolved.** `afk config` dumps the live configuration. `afk doctor` validates keys, paths, and provider connectivity.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,23 +64,30 @@ The plugin surface writes to `~/.claude/agent-framework/` independently — no s
 
 ## System prompt discovery
 
-`loadConfig()` resolves `systemPrompt` in 4-tier precedence (highest wins):
+The base system prompt is **layered**. The framework prompt (`prompts/system-prompt.md`, inlined into the bundle at publish-build) is the unconditional foundation; the resolved operator overlay is **appended** on top of it beneath an `# Operator configuration` header — it never replaces the framework base. `resolveBaseSystemPrompt()` (`src/cli/shared-helpers.ts`) performs the layering for every top-level surface (one-shot `chat`, REPL, Telegram, farm), and `composeSystemPrompt()` is the pure compose primitive.
 
-| Tier | Source | `systemPromptSource` |
+`loadConfig()` resolves the **operator overlay** across three tiers (highest wins); `loadConfig().systemPrompt` is that overlay alone (unchanged — it does not include the framework base):
+
+| Tier | Overlay source | `loadConfig().systemPromptSource` |
 |------|--------|----------------------|
 | 1 | `AFK_SYSTEM_PROMPT` env | `env:AFK_SYSTEM_PROMPT` |
 | 2 | `afk.config.json` (cwd → `~/.afk/config/` → legacy) | `file:<abs>` |
 | 3 | `AFK.md` (cwd → `$AFK_HOME/`) | `afk-md:<abs>` |
-| 4 | None | `undefined` |
+| — | None | `undefined` |
 
-`AFK.md` is plain markdown, no frontmatter. Empty/whitespace → treated as absent. `systemPromptSource` threads into `AgentSession` for `--dump-prompt` provenance; never forwarded to the SDK.
+`AFK.md` is plain markdown, no frontmatter. Empty/whitespace → treated as absent. The framework base is always present regardless of overlay tier, so an absent overlay just means the model gets the framework prompt alone. The composed prompt is sent to the Messages API as a raw string (never as an SDK preset).
+
+> **Escape hatch (not yet implemented):** every overlay appends — there is currently no way to fully replace the framework base. A future opt-out (e.g. `AFK_BASE_PROMPT=0`) would restore clean-slate behavior; until then the framework base is unconditional.
 
 **Bootstrapping `AFK.md`:** run `/init` in the REPL to scan the current project and generate a tailored `AFK.md` at the repo root. Implementation: `src/cli/slash/commands/init.ts`.
 
-**Provenance tracking:** When using `--dump-prompt`, the `systemPromptSource` field in the dump shows which tier won:
-- `"env:AFK_SYSTEM_PROMPT"` — tier 1
-- `"file:/abs/path/afk.config.json"` — tier 2
-- `"afk-md:/abs/path/AFK.md"` — tier 3
+**Provenance tracking:** `--dump-prompt` reports a layered `systemPromptSource`, and the full composed text lands in the dump's `options.system` field:
+- `"framework"` — base only, no overlay configured
+- `"framework+env:AFK_SYSTEM_PROMPT"` — base + tier-1 overlay
+- `"framework+file:/abs/path/afk.config.json"` — base + tier-2 overlay
+- `"framework+afk-md:/abs/path/AFK.md"` — base + tier-3 overlay
+
+(`loadConfig().systemPromptSource` keeps its un-prefixed overlay-only value; the `framework+…` composition is applied by `resolveBaseSystemPrompt()` at the surface.)
 
 ## Prompt caching (anthropic-direct provider)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -86,7 +86,7 @@ Vendored agents under `src/skills/_agents/` must stay byte-equal to upstream —
 ## Conventions
 
 - **`tsconfig.json` is maximally strict**: `noUnusedLocals`, `noUnusedParameters`, `noUncheckedIndexedAccess`, `noPropertyAccessFromIndexSignature`. All code must pass `tsc --noEmit`.
-- The agent-afk system prompt is a raw string from config or file. No SDK preset is loaded.
+- The agent-afk system prompt is the framework base (`prompts/system-prompt.md`) with the operator overlay (env/config/AFK.md) appended via `resolveBaseSystemPrompt()`, sent as a raw string. No SDK preset is loaded.
 - `AgentSession` constructor is **synchronous**; SDK lifecycle runs async via `initSdkLifecycle()` and surfaces through the provider event stream.
 - DAG executor (`src/agent/dag.ts`) is a Phase 2 stub — types exported but `runDAG` throws.
 - **SDK dependency tracking**: every import from `@anthropic-ai/sdk` is in `.sdk-dependency.lock.json`. CI fails on unlocked new symbols. After adding an SDK import, run `pnpm audit:sdk:update-lock` and edit the new entry's `reason` field before commit.

--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -369,7 +369,7 @@
     },
     {
       "name": "AFK_SYSTEM_PROMPT",
-      "description": "Raw system-prompt string. Tier-1 source (highest priority over afk.config.json and AFK.md).",
+      "description": "Raw operator-overlay prompt. Highest-priority overlay (over afk.config.json and AFK.md). Appended on top of the framework base (prompts/system-prompt.md) under an \"# Operator configuration\" header — it augments, never replaces, the base.",
       "type": "string",
       "required": false,
       "example": "You are a helpful agent.",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -26,7 +26,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_SUGGEST_ENABLED` | boolean |  |  |  | Enable the LLM-backed ghost-text suggestion tier in the interactive REPL. Set to 1/true/yes/on to activate. Off by default. |
 | `AFK_SUGGEST_GHOST` | boolean |  | `1` | `0` | Enable REPL ghost-text inline suggestions (Tier-1 history/dropdown + optional Tier-2 LLM). 1 = on (default), 0 = off. Set 0/false/off/no to disable all ghost text. Tier-2 LLM is separately gated by AFK_SUGGEST_ENABLED. |
 | `AFK_SUGGEST_MODEL` | string |  |  |  | Override the small model used for REPL ghost-text suggestions. Falls back to AFK_COMPACT_MODEL or haiku-class for anthropic, or the session model for other providers. |
-| `AFK_SYSTEM_PROMPT` | string |  |  | `You are a helpful agent.` | Raw system-prompt string. Tier-1 source (highest priority over afk.config.json and AFK.md). |
+| `AFK_SYSTEM_PROMPT` | string |  |  | `You are a helpful agent.` | Raw operator-overlay prompt. Highest-priority overlay (over afk.config.json and AFK.md). Appended on top of the framework base (prompts/system-prompt.md) under an "# Operator configuration" header — it augments, never replaces, the base. |
 | `AFK_TASK_BUDGET` | number |  | `100000` | `200000` | Per-task token budget ceiling. Aborts when cumulative usage would exceed it. |
 | `AFK_TEMPERATURE` | number |  |  | `0.7` | Numeric temperature override for model sampling. Provider default if unset. |
 | `AFK_THINKING` | string |  | `adaptive` | `adaptive` | Extended-thinking mode. Accepts adaptive \| disabled \| enabled:<N> \| enabled:max. Defaults to the model-appropriate mode when unset (adaptive on current models). |

--- a/src/agent/session/prompt-dump.ts
+++ b/src/agent/session/prompt-dump.ts
@@ -16,7 +16,11 @@ import { dirname } from 'path';
 export type PromptShape = 'string' | 'string[]' | 'preset' | 'undefined';
 
 export interface SystemPromptProvenance {
-  source: string; // e.g. "env:AFK_SYSTEM_PROMPT", "file:/abs/path", "afk-md:/abs/path/AFK.md", "none"
+  // e.g. "env:AFK_SYSTEM_PROMPT", "file:/abs/path", "afk-md:/abs/path/AFK.md", "none".
+  // Top-level surfaces layer the framework base under the operator overlay and
+  // report a composed value: "framework" (base only), "framework+afk-md:/path"
+  // (base + overlay), etc. See resolveBaseSystemPrompt() in cli/shared-helpers.ts.
+  source: string;
   shape: PromptShape;
   length?: number; // chars for string, joined length for string[], append length for preset
 }

--- a/src/cli/commands/chat.resume.test.ts
+++ b/src/cli/commands/chat.resume.test.ts
@@ -91,6 +91,7 @@ vi.mock('../shared-helpers.js', () => ({
   getDefaultSubagentModel: vi.fn(() => 'sonnet'),
   loadSystemPrompt: vi.fn(() => undefined),
   loadConfigSystemPrompt: vi.fn(() => undefined),
+  resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
 }));
 
 vi.mock('../../agent/routing-directive.js', () => ({

--- a/src/cli/commands/chat.stdin.test.ts
+++ b/src/cli/commands/chat.stdin.test.ts
@@ -57,6 +57,7 @@ vi.mock('../shared-helpers.js', () => ({
   getDefaultSubagentModel: vi.fn(() => 'sonnet'),
   loadSystemPrompt: vi.fn(() => undefined),
   loadConfigSystemPrompt: vi.fn(() => undefined),
+  resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
 }));
 
 vi.mock('../../agent/routing-directive.js', () => ({

--- a/src/cli/commands/chat.stream-json.test.ts
+++ b/src/cli/commands/chat.stream-json.test.ts
@@ -73,6 +73,7 @@ vi.mock('../shared-helpers.js', () => ({
   getDefaultSubagentModel: vi.fn(() => 'sonnet'),
   loadSystemPrompt: vi.fn(() => undefined),
   loadConfigSystemPrompt: vi.fn(() => undefined),
+  resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
 }));
 
 vi.mock('../../agent/routing-directive.js', () => ({

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -10,7 +10,7 @@ import { loadHooksConfig } from '../../agent/hooks/config-loader.js';
 import { MemoryStore, injectHotMemory } from '../../agent/memory/index.js';
 import type { AgentModelInput, ThinkingConfig, EffortLevel } from '../../agent/types.js';
 import { formatDuration, formatCost, formatTokens } from '../format-utils.js';
-import { parseThinking, parseEffort, parseBudget, parseMaxOutputTokens, parseProvider, getApiKey, getApiKeyForModel, getModel, getThinking, getEffort, getMaxBudgetUsd, getTaskBudget, getMaxOutputTokens, getDefaultSubagentModel, loadSystemPrompt, loadConfigSystemPrompt } from '../shared-helpers.js';
+import { parseThinking, parseEffort, parseBudget, parseMaxOutputTokens, parseProvider, getApiKey, getApiKeyForModel, getModel, getThinking, getEffort, getMaxBudgetUsd, getTaskBudget, getMaxOutputTokens, getDefaultSubagentModel, resolveBaseSystemPrompt } from '../shared-helpers.js';
 import { loadConfig } from '../config.js';
 import { assembleSystemPrompt } from '../../agent/routing-directive.js';
 import { renderMarkdownToTerminal } from '../formatter.js';
@@ -300,15 +300,13 @@ export function registerChatCommand(program: Command): void {
         }
 
         const apiKey = getApiKey();
-        // Dual-path system-prompt resolution: `basePrompt` is sourced via
-        // `loadConfigSystemPrompt`/`loadSystemPrompt` (string-only path), while
-        // `systemPromptSource` provenance comes from `loadConfig()`. Both walk the
-        // same 3-tier precedence (env → afk.config.json → AFK.md) in the same order,
-        // so in production they agree. Any future caller that invokes one without
-        // the other risks an orphaned source tag — keep them paired.
-        const basePrompt = loadConfigSystemPrompt() ?? loadSystemPrompt();
+        // System-prompt layering: the framework base (`prompts/system-prompt.md`)
+        // is unconditional; the operator overlay (env → afk.config.json → AFK.md)
+        // is appended on top via resolveBaseSystemPrompt(), never substituted for
+        // the base. `source` is the layered provenance string surfaced by
+        // --dump-prompt (`framework`, `framework+afk-md:/path`, …).
+        const { prompt: basePrompt, source: systemPromptSource } = resolveBaseSystemPrompt();
         const cliConfig = loadConfig();
-        const systemPromptSource = cliConfig.systemPromptSource;
         const autoRouting = cliConfig.autoRouting?.chat ?? false;
         const systemPrompt = assembleSystemPrompt(basePrompt, autoRouting, 'one-shot');
 

--- a/src/cli/commands/farm.ts
+++ b/src/cli/commands/farm.ts
@@ -14,7 +14,7 @@ import chalk from 'chalk';
 import { createFarm, setFarmMemoryFactId } from '../../agent/worktree.js';
 import { runSubagentDAG } from '../../agent/dag-subagent.js';
 import { SubagentManager } from '../../agent/subagent.js';
-import { loadSystemPrompt, loadConfigSystemPrompt, getModel } from '../shared-helpers.js';
+import { resolveBaseSystemPrompt, getModel } from '../shared-helpers.js';
 import {
   scoreBranch,
   writeScore,
@@ -324,7 +324,8 @@ export async function runFarm(opts: RunFarmOptions): Promise<void> {
 
   const baseSha = manifest.baseRef;
   const resolvedModel = model ?? (getModel() as string);
-  const systemPrompt = loadConfigSystemPrompt() ?? loadSystemPrompt() ?? '';
+  // Framework base (`prompts/system-prompt.md`) + operator overlay, layered.
+  const systemPrompt = resolveBaseSystemPrompt().prompt ?? '';
 
   // -- Build DAG nodes --
   const nodes: SubagentDAGNode[] = manifest.branches.map((b) => ({

--- a/src/cli/commands/interactive.resume.test.ts
+++ b/src/cli/commands/interactive.resume.test.ts
@@ -61,6 +61,7 @@ vi.mock('../shared-helpers.js', () => ({
   getMaxOutputTokens: vi.fn(() => undefined),
   loadSystemPrompt: vi.fn(() => undefined),
   loadConfigSystemPrompt: vi.fn(() => undefined),
+  resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
   parseThinking: vi.fn(() => undefined),
   parseEffort: vi.fn(() => undefined),
   parseMaxOutputTokens: vi.fn(() => undefined),

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -12,7 +12,7 @@ import type { HookRegistry } from '../../../agent/hooks.js';
 import type { TraceWriter } from '../../../agent/trace/index.js';
 import {
   parseThinking, parseEffort, parseMaxOutputTokens, parseProvider, getApiKey, getApiKeyForModel, getThinking, getEffort,
-  getMaxOutputTokens, getDefaultSubagentModel, loadSystemPrompt, loadConfigSystemPrompt,
+  getMaxOutputTokens, getDefaultSubagentModel, resolveBaseSystemPrompt,
 } from '../../shared-helpers.js';
 import { loadConfig } from '../../config.js';
 import { assembleSystemPrompt } from '../../../agent/routing-directive.js';
@@ -133,15 +133,13 @@ export async function bootstrapSession(
   effort = parseEffort(options.effort) ?? getEffort();
   maxOutputTokens = parseMaxOutputTokens(options.maxOutputTokens) ?? getMaxOutputTokens();
 
-  // Dual-path system-prompt resolution: `basePrompt` is sourced via
-  // `loadConfigSystemPrompt`/`loadSystemPrompt` (string-only path), while
-  // `systemPromptSource` provenance comes from `loadConfig()`. Both walk the
-  // same 3-tier precedence (env → afk.config.json → AFK.md) in the same order,
-  // so in production they agree. Any future caller that invokes one without
-  // the other risks an orphaned source tag — keep them paired.
-  const basePrompt = loadConfigSystemPrompt() ?? loadSystemPrompt();
+  // System-prompt layering: the framework base (`prompts/system-prompt.md`)
+  // is unconditional; the operator overlay (env → afk.config.json → AFK.md)
+  // is appended on top via resolveBaseSystemPrompt(), never substituted for
+  // the base. `source` is the layered provenance string surfaced by
+  // --dump-prompt (`framework`, `framework+afk-md:/path`, …).
+  const { prompt: basePrompt, source: systemPromptSource } = resolveBaseSystemPrompt();
   const cliConfig = loadConfig();
-  const systemPromptSource = cliConfig.systemPromptSource;
   const autoRouting = cliConfig.autoRouting?.interactive ?? true;
   const systemPrompt = assembleSystemPrompt(basePrompt, autoRouting, 'repl');
 

--- a/src/cli/interactive-lifecycle.test.ts
+++ b/src/cli/interactive-lifecycle.test.ts
@@ -55,6 +55,7 @@ describe('interactive bootstrap status line hooks', () => {
       findClaudeExecutable: vi.fn(() => '/usr/bin/claude'),
       loadSystemPrompt: vi.fn(() => undefined),
       loadConfigSystemPrompt: vi.fn(() => undefined),
+      resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
     }));
     vi.doMock('./status-line.js', () => ({
       StatusLine: vi.fn(() => statusLine),
@@ -203,6 +204,7 @@ describe('interactive bootstrap — P1: suggestBaseUrl mirrors openaiBaseUrl', (
       findClaudeExecutable: vi.fn(() => '/usr/bin/claude'),
       loadSystemPrompt: vi.fn(() => undefined),
       loadConfigSystemPrompt: vi.fn(() => undefined),
+      resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
     }));
     vi.doMock('./status-line.js', () => ({
       StatusLine: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), repaint: vi.fn() })),

--- a/src/cli/shared-helpers.test.ts
+++ b/src/cli/shared-helpers.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for system-prompt layering helpers.
+ *
+ * Invariant under test: the framework base (`prompts/system-prompt.md`) is the
+ * UNCONDITIONAL foundation; the operator overlay (AFK_SYSTEM_PROMPT →
+ * afk.config.json → AFK.md) is APPENDED on top, never substituted for the base.
+ * This is the inverse of the historical `overlay ?? framework` behavior, where
+ * any operator prompt replaced the framework base wholesale.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  OPERATOR_CONFIG_HEADER,
+  composeSystemPrompt,
+  resolveBaseSystemPrompt,
+} from './shared-helpers.js';
+import { loadConfig } from './config.js';
+
+// Mock the config module so loadConfig() (the overlay source) is controllable.
+// loadSystemPrompt() is an in-module call in shared-helpers and reads the real
+// prompts/system-prompt.md from the package tree — i.e. the framework base is
+// genuinely present in these tests, which is the production invariant.
+vi.mock('./config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./config.js')>();
+  return { ...actual, loadConfig: vi.fn() };
+});
+
+const FRAMEWORK = '# Agent AFK\n\nYou operate inside a runtime.';
+const OVERLAY = '# Project\n\nUse pnpm. Never touch main.';
+
+describe('composeSystemPrompt', () => {
+  it('appends the overlay beneath the operator-config header when both present', () => {
+    const out = composeSystemPrompt(FRAMEWORK, OVERLAY);
+    expect(out).toBeDefined();
+    const fwIdx = out!.indexOf(FRAMEWORK);
+    const headerIdx = out!.indexOf(OPERATOR_CONFIG_HEADER);
+    const ovIdx = out!.indexOf(OVERLAY);
+    expect(fwIdx).toBe(0);
+    expect(fwIdx).toBeLessThan(headerIdx);
+    expect(headerIdx).toBeLessThan(ovIdx);
+  });
+
+  it('does NOT let the overlay replace the framework base (regression guard)', () => {
+    const out = composeSystemPrompt(FRAMEWORK, OVERLAY);
+    expect(out).toContain(FRAMEWORK);
+    expect(out).toContain(OVERLAY);
+    expect(out).not.toBe(OVERLAY);
+  });
+
+  it('returns the framework unchanged when no overlay is present', () => {
+    expect(composeSystemPrompt(FRAMEWORK, undefined)).toBe(FRAMEWORK);
+    expect(composeSystemPrompt(FRAMEWORK, '')).toBe(FRAMEWORK);
+    expect(composeSystemPrompt(FRAMEWORK, '   \n  ')).toBe(FRAMEWORK);
+  });
+
+  it('returns the overlay alone when the framework is genuinely absent (dev/test edge)', () => {
+    expect(composeSystemPrompt(undefined, OVERLAY)).toBe(OVERLAY);
+    expect(composeSystemPrompt('', OVERLAY)).toBe(OVERLAY);
+  });
+
+  it('returns undefined when neither is present', () => {
+    expect(composeSystemPrompt(undefined, undefined)).toBeUndefined();
+    expect(composeSystemPrompt('', '')).toBeUndefined();
+    expect(composeSystemPrompt('  ', undefined)).toBeUndefined();
+  });
+
+  it('never emits a dangling header (header only appears with both parts)', () => {
+    expect(composeSystemPrompt(FRAMEWORK, undefined)).not.toContain(OPERATOR_CONFIG_HEADER);
+    expect(composeSystemPrompt(undefined, OVERLAY)).not.toContain(OPERATOR_CONFIG_HEADER);
+  });
+});
+
+describe('resolveBaseSystemPrompt', () => {
+  function fakeConfig(overlay: string | undefined, source: string | undefined) {
+    return {
+      model: 'sonnet',
+      maxTokens: 8192,
+      temperature: 1,
+      updatePolicy: 'prompt',
+      ...(overlay !== undefined ? { systemPrompt: overlay } : {}),
+      ...(source !== undefined ? { systemPromptSource: source } : {}),
+    } as unknown as ReturnType<typeof loadConfig>;
+  }
+
+  beforeEach(() => {
+    vi.mocked(loadConfig).mockReset();
+  });
+
+  it('layers framework + overlay and reports a composed source', () => {
+    vi.mocked(loadConfig).mockReturnValue(fakeConfig('Operator says hi', 'afk-md:/repo/AFK.md'));
+    const { prompt, source } = resolveBaseSystemPrompt();
+    expect(prompt).toBeDefined();
+    expect(prompt).toContain('Operator says hi');
+    expect(prompt).toContain(OPERATOR_CONFIG_HEADER);
+    // Framework base is present too — the operating posture is not replaced.
+    expect(prompt!.length).toBeGreaterThan('Operator says hi'.length + OPERATOR_CONFIG_HEADER.length);
+    expect(source).toBe('framework+afk-md:/repo/AFK.md');
+  });
+
+  it('reports source "framework" when no overlay is configured', () => {
+    vi.mocked(loadConfig).mockReturnValue(fakeConfig(undefined, undefined));
+    const { prompt, source } = resolveBaseSystemPrompt();
+    expect(prompt).toBeDefined();
+    expect(prompt).not.toContain(OPERATOR_CONFIG_HEADER);
+    expect(source).toBe('framework');
+  });
+
+  it('prefixes whatever overlay tier won (env example)', () => {
+    vi.mocked(loadConfig).mockReturnValue(fakeConfig('env override', 'env:AFK_SYSTEM_PROMPT'));
+    const { source } = resolveBaseSystemPrompt();
+    expect(source).toBe('framework+env:AFK_SYSTEM_PROMPT');
+  });
+});

--- a/src/cli/shared-helpers.ts
+++ b/src/cli/shared-helpers.ts
@@ -53,6 +53,73 @@ export function loadConfigSystemPrompt(): string | undefined {
 }
 
 /**
+ * Header inserted between the framework base prompt and the operator overlay.
+ *
+ * Invariant: only emitted when BOTH a framework base and an overlay are
+ * present (see {@link composeSystemPrompt}). The "above" reference therefore
+ * never dangles — it always points at the framework operating posture.
+ */
+export const OPERATOR_CONFIG_HEADER =
+  "# Operator configuration\n\n" +
+  "The instructions below come from this operator's configuration (AFK.md, " +
+  'afk.config.json, or AFK_SYSTEM_PROMPT). Treat them as refinements layered ' +
+  'on top of the operating posture above — follow them unless they conflict ' +
+  'with the Priorities or Constraints already stated.';
+
+/**
+ * Compose the final base system prompt from the unconditional framework base
+ * and the optional operator overlay.
+ *
+ * Contract: the framework base (`prompts/system-prompt.md`) is the foundation
+ * whenever present; the overlay is APPENDED beneath {@link OPERATOR_CONFIG_HEADER},
+ * never substituted for the base. Empty / whitespace-only inputs are treated
+ * as absent so a blank AFK.md or a missing prompt file never injects a
+ * dangling header or a leading newline.
+ *   - both present  → `${framework}\n\n${header}\n\n${overlay}`
+ *   - framework only → framework
+ *   - overlay only   → overlay (framework genuinely absent — dev/test edge)
+ *   - neither        → undefined
+ */
+export function composeSystemPrompt(
+  framework: string | undefined,
+  overlay: string | undefined,
+): string | undefined {
+  const fw = framework !== undefined && framework.trim().length > 0 ? framework : undefined;
+  const ov = overlay !== undefined && overlay.trim().length > 0 ? overlay : undefined;
+  if (fw === undefined) return ov;
+  if (ov === undefined) return fw;
+  return `${fw}\n\n${OPERATOR_CONFIG_HEADER}\n\n${ov}`;
+}
+
+/**
+ * Resolve the surface base system prompt: the unconditional framework base
+ * (`prompts/system-prompt.md`, inlined at publish-build) with the resolved
+ * operator overlay (`AFK_SYSTEM_PROMPT` → `afk.config.json` → `AFK.md`)
+ * appended on top. Used by every top-level surface (one-shot `chat`, REPL,
+ * Telegram, farm) so they share one layering rule.
+ *
+ * Returns the composed `prompt` plus a layered `source` string for
+ * `--dump-prompt` provenance: `framework+<overlaySource>` when both are
+ * present, `framework` when only the base is, `<overlaySource>` when only the
+ * overlay is (framework absent), or `none`. The plain overlay source remains
+ * available unchanged via `loadConfig().systemPromptSource`.
+ */
+export function resolveBaseSystemPrompt(): { prompt: string | undefined; source: string } {
+  const framework = loadSystemPrompt();
+  const cfg = loadConfig();
+  const overlay = cfg.systemPrompt;
+  const overlaySource = cfg.systemPromptSource;
+  const hasFw = framework !== undefined && framework.trim().length > 0;
+  const hasOv = overlay !== undefined && overlay.trim().length > 0;
+  let source: string;
+  if (hasFw && hasOv) source = `framework+${overlaySource ?? 'unknown'}`;
+  else if (hasFw) source = 'framework';
+  else if (hasOv) source = overlaySource ?? 'unknown';
+  else source = 'none';
+  return { prompt: composeSystemPrompt(framework, overlay), source };
+}
+
+/**
  * Get a provider-appropriate API key from the environment for the current
  * session's model.
  *

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -251,7 +251,7 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
   // ── System prompt ─────────────────────────────────────────────────────────
   {
     name: 'AFK_SYSTEM_PROMPT',
-    description: 'Raw system-prompt string. Tier-1 source (highest priority over afk.config.json and AFK.md).',
+    description: 'Raw operator-overlay prompt. Highest-priority overlay (over afk.config.json and AFK.md). Appended on top of the framework base (prompts/system-prompt.md) under an "# Operator configuration" header — it augments, never replaces, the base.',
     type: 'string',
     required: false,
     example: 'You are a helpful agent.',

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -44,7 +44,7 @@ import { loadConfig, loadCredential } from './cli/config.js';
 import { getEnvConfigPath } from './paths.js';
 import { assembleSystemPrompt } from './agent/routing-directive.js';
 import { resolveModelId } from './agent/session/model-resolution.js';
-import { getDefaultSubagentModel, getMaxOutputTokens, getApiKeyForModel } from './cli/shared-helpers.js';
+import { getDefaultSubagentModel, getMaxOutputTokens, getApiKeyForModel, loadSystemPrompt, composeSystemPrompt } from './cli/shared-helpers.js';
 import type { AgentConfig, AgentModelInput } from './agent/types.js';
 import { SubagentManager } from './agent/subagent.js';
 import { SubagentExecutor } from './agent/tools/subagent-executor.js';
@@ -75,6 +75,11 @@ async function main() {
     console.error('❌ Configuration error:', (error as Error).message);
     process.exit(1);
   }
+
+  // Framework base prompt (`prompts/system-prompt.md`, inlined at publish-build).
+  // Resolved once here and layered under the operator overlay per session below,
+  // so Telegram sessions carry the same unconditional base as chat / REPL.
+  const frameworkBase = loadSystemPrompt();
 
   const providerName = providerForModel(config.model as string);
 
@@ -211,6 +216,18 @@ async function main() {
         sessionProviderName === 'openai-compatible' || sessionProviderName === 'openai-codex';
       const maxOutputTokens = isCodex ? undefined : getMaxOutputTokens();
 
+      // System-prompt layering (mirrors chat.ts / bootstrap.ts): the framework
+      // base is unconditional; the operator overlay (per-chat sessionConfig
+      // override → afk.config.json / AFK.md / env via loadConfig) is appended
+      // on top, never substituted for the base. Shared by both the Anthropic
+      // and Codex branches below, and inherited by forked subagent / compose
+      // children so they carry the same base.
+      const overlayPrompt = sessionConfig.systemPrompt ?? config.systemPrompt;
+      const layeredBasePrompt = composeSystemPrompt(
+        frameworkBase,
+        typeof overlayPrompt === 'string' ? overlayPrompt : undefined,
+      );
+
       let directProvider;
       if (!isCodex) {
         let boundSession: AgentSession | undefined;
@@ -262,7 +279,7 @@ async function main() {
           parentSession: deferredParent,
           defaultConfig: {
             apiKey: telegramApiKey,
-            systemPrompt: sessionConfig.systemPrompt ?? config.systemPrompt,
+            systemPrompt: layeredBasePrompt,
             ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
           },
           defaultSubagentModel: getDefaultSubagentModel(sessionConfig.model),
@@ -286,18 +303,17 @@ async function main() {
           ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
         });
 
-        // Pass the raw base prompt (pre-assembly) so compose subagents do not
-        // inherit ROUTING_DIRECTIVE or TOOL_SYSTEM_PROMPT — keeping them as
-        // task workers that cannot spawn nested DAGs or recurse into skills.
-        // Mirrors the SubagentExecutor defaultConfig.systemPrompt convention.
-        const rawBasePrompt = sessionConfig.systemPrompt ?? config.systemPrompt;
+        // Compose subagents inherit the framework base + operator overlay
+        // (layeredBasePrompt) but NOT ROUTING_DIRECTIVE / TOOL_SYSTEM_PROMPT /
+        // end-of-turn — those are appended only by assembleSystemPrompt for the
+        // parent session. Keeps DAG workers from recursing into skills / nested DAGs.
         const composeExecutor = new ComposeExecutor({
           parentSession: deferredParent,
           defaultModel: sessionConfig.model,
           defaultSubagentModel: getDefaultSubagentModel(sessionConfig.model),
           apiKey: telegramApiKey,
           ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
-          systemPrompt: typeof rawBasePrompt === 'string' ? rawBasePrompt : '',
+          systemPrompt: layeredBasePrompt ?? '',
         });
 
         const allowedTools = [...BUILTIN_TOOL_NAMES, ...MEMORY_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, 'agent', 'skill', 'compose'];
@@ -309,7 +325,7 @@ async function main() {
         });
 
         // Bind after session creation so deferred parent proxy resolves.
-        const rawPromptInner = sessionConfig.systemPrompt ?? config.systemPrompt;
+        const rawPromptInner = layeredBasePrompt;
         const telegramAutoRoutingInner = config.autoRouting?.telegram ?? false;
         const systemPromptInner = typeof rawPromptInner === 'string'
           ? assembleSystemPrompt(rawPromptInner, telegramAutoRoutingInner, 'telegram')
@@ -342,7 +358,7 @@ async function main() {
         return session;
       }
 
-      const rawPrompt = sessionConfig.systemPrompt ?? config.systemPrompt;
+      const rawPrompt = layeredBasePrompt;
       const telegramAutoRouting = config.autoRouting?.telegram ?? false;
       const systemPrompt = typeof rawPrompt === 'string'
         ? assembleSystemPrompt(rawPrompt, telegramAutoRouting, 'telegram')


### PR DESCRIPTION
## Problem

`prompts/system-prompt.md` is the framework operating-posture prompt, but it was only a **fallback**: base resolution was `loadConfigSystemPrompt() ?? loadSystemPrompt()`, so any operator prompt (`AFK_SYSTEM_PROMPT` → `afk.config.json` → `AFK.md`) **replaced** the framework base wholesale. Running from a repo with an `AFK.md` (e.g. this repo) silently dropped the entire operating posture — surfaced via `--dump-prompt`, whose resolved `system` showed only the `AFK.md` content. The Telegram surface was worse: it never called `loadSystemPrompt()` at all, so it never carried the framework base.

## Change

Make the framework base **unconditional** and append the operator overlay **on top** of it, beneath an `# Operator configuration` header — augment, never replace.

- **New helpers** (`src/cli/shared-helpers.ts`): `composeSystemPrompt(framework, overlay)` (pure) + `resolveBaseSystemPrompt()` returning `{ prompt, source }`. `loadSystemPrompt()` left byte-identical so the publish-build inliner (`esbuild-plugin-inline-prompts.mjs` Pattern C) keeps matching.
- **All four top-level surfaces rewired** to the layered resolver: one-shot `chat`, REPL `bootstrap`, `farm`, and `telegram` (Telegram now includes the framework base it previously omitted). Subagent / compose / farm children inherit framework+overlay (they read the same `basePrompt`).
- **`--dump-prompt` provenance** is now truthful with no provider edit: surfaces thread a layered `source` (`framework`, `framework+afk-md:/path`, …) into the session. `loadConfig().systemPromptSource` keeps its overlay-only value, so `config.test.ts` is unaffected.
- **Docs** updated from the old "4-tier, highest-wins/replaces" model to the layered model: `docs/architecture.md`, `CLAUDE.md`, `AFK.md`, `README.md`, `docs/development.md`, and the `AFK_SYSTEM_PROMPT` env description.

### Design decisions
- **Uniform append**: all three overlay tiers (`AFK_SYSTEM_PROMPT`, `afk.config.json`, `AFK.md`) layer on top. This **changes the previously-documented full-override behavior of `AFK_SYSTEM_PROMPT`** — it now augments.
- **No full-replace escape hatch yet** — deferred. A future explicit opt-out (e.g. `AFK_BASE_PROMPT=0`) is the intended clean-slate path, not the old accidental replacement.
- Layering happens **at the surface**, not inside `loadConfig()`, so `config.systemPrompt` keeps meaning "the operator overlay" and existing `config.test.ts` / `routing-directive.test.ts` stay valid.

## Verification

- `pnpm lint` clean; `pnpm test` → **441 files, 8192 passed, 12 skipped, 0 failed**.
- New `src/cli/shared-helpers.test.ts` (9 tests) pins the invariant + a regression guard ("overlay does not replace framework").
- Manual check from a repo cwd with `AFK.md`: `source = framework+afk-md:/…/AFK.md`; composed base **19,236 chars** containing `You operate inside a runtime` (framework) → `# Operator configuration` → the `AFK.md` overlay. Previously the framework text was absent.
