### PR TITLE
feat(cli): add /review --post {github,telegram} publishers

### DIFF
--- a/src/agent/gh.test.ts
+++ b/src/agent/gh.test.ts
@@ -6,7 +6,14 @@
 
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
-import { checkGhReady, createPr, GhError, _resetCacheForTest } from './gh.js';
+import {
+  checkGhReady,
+  createPr,
+  postPrComment,
+  resolveCurrentBranchPr,
+  GhError,
+  _resetCacheForTest,
+} from './gh.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -257,5 +264,70 @@ describe('checkGhReady — in-flight dedup (C5)', () => {
     // Because of in-flight dedup, execFn should have been called only twice
     // (once for `gh --version`, once for `gh auth status`) — not 4 times.
     expect(exec).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// postPrComment
+// ---------------------------------------------------------------------------
+
+describe('postPrComment', () => {
+  it('success — feeds body via stdin, returns trimmed comment URL', async () => {
+    const exec = vi
+      .fn()
+      .mockResolvedValue({ stdout: 'https://github.com/o/r/pull/5#issuecomment-1\n', stderr: '' });
+    const url = await postPrComment({ pr: '5', body: '## Review\n- nit: foo' }, exec);
+    expect(url).toBe('https://github.com/o/r/pull/5#issuecomment-1');
+    // PR selector present, --body-file - reads stdin, body passed as 3rd arg.
+    expect(exec).toHaveBeenCalledWith(
+      'gh',
+      ['pr', 'comment', '5', '--body-file', '-'],
+      '## Review\n- nit: foo',
+    );
+  });
+
+  it('empty pr selector — omits the ref so gh resolves the current branch PR', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: 'ok', stderr: '' });
+    await postPrComment({ pr: '', body: 'b' }, exec);
+    expect(exec).toHaveBeenCalledWith('gh', ['pr', 'comment', '--body-file', '-'], 'b');
+  });
+
+  it('unauthed stderr — throws GhError with kind: unauthed', async () => {
+    const exec = vi
+      .fn()
+      .mockRejectedValue({ stderr: 'authentication required: please log in', exitCode: 1 });
+    await expect(postPrComment({ pr: '5', body: 'b' }, exec)).rejects.toThrow(GhError);
+    await expect(postPrComment({ pr: '5', body: 'b' }, exec)).rejects.toMatchObject({
+      kind: 'unauthed',
+    });
+  });
+
+  it('timeout (killed) — throws GhError with kind: timeout', async () => {
+    const exec = vi.fn().mockRejectedValue({ killed: true, stderr: '' });
+    await expect(postPrComment({ pr: '5', body: 'b' }, exec)).rejects.toMatchObject({
+      kind: 'timeout',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveCurrentBranchPr
+// ---------------------------------------------------------------------------
+
+describe('resolveCurrentBranchPr', () => {
+  it('returns the trimmed PR number on success', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: '42\n', stderr: '' });
+    expect(await resolveCurrentBranchPr(exec)).toBe('42');
+    expect(exec).toHaveBeenCalledWith('gh', ['pr', 'view', '--json', 'number', '--jq', '.number']);
+  });
+
+  it('returns null when gh fails (no open PR for the branch)', async () => {
+    const exec = vi.fn().mockRejectedValue(new Error('no pull requests found'));
+    expect(await resolveCurrentBranchPr(exec)).toBeNull();
+  });
+
+  it('returns null when stdout is not a number', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: 'null\n', stderr: '' });
+    expect(await resolveCurrentBranchPr(exec)).toBeNull();
   });
 });

--- a/src/agent/gh.ts
+++ b/src/agent/gh.ts
@@ -2,17 +2,21 @@
  * GitHub CLI (`gh`) agent-layer utilities.
  *
  * Pure agent-layer: no Telegraf knowledge, no Telegram imports. Provides:
- *   - `GhError`         — typed error class for `gh` failures
- *   - `checkGhReady`    — probes `gh` presence and auth with a module-level TTL cache
- *   - `createPr`        — creates a GitHub PR via `gh pr create`, returns the PR URL
+ *   - `GhError`                — typed error class for `gh` failures
+ *   - `checkGhReady`           — probes `gh` presence and auth with a module-level TTL cache
+ *   - `createPr`               — creates a GitHub PR via `gh pr create`, returns the PR URL
+ *   - `postPrComment`          — posts a comment to a PR via `gh pr comment --body-file -` (stdin)
+ *   - `resolveCurrentBranchPr` — resolves the current branch's open PR number, or null
  *
- * All `gh` invocations use `execFile` (no shell) — branch refs and titles come
- * from the manifest, but argv isolation is the defence-in-depth.
+ * All `gh` invocations use `execFile` / `spawn` (no shell) — branch refs and
+ * titles come from the manifest, but argv isolation is the defence-in-depth.
+ * `postPrComment` feeds the body through stdin so arbitrary markdown (backticks,
+ * quotes, newlines) never has to survive argv-escaping or hit an argv length cap.
  *
  * @module agent/gh
  */
 
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
@@ -232,5 +236,137 @@ export async function createPr(opts: CreatePrOpts, execFn?: ExecFn): Promise<str
     const exitCode = e.exitCode ?? 1;
     const kind = classifyStderr(stderr, code, e.killed);
     throw new GhError(`gh pr create failed (${kind}): ${stderr.trim()}`, kind, exitCode, stderr);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// postPrComment — post a review/comment body to a PR via stdin
+// ---------------------------------------------------------------------------
+
+/**
+ * Exec function that feeds `input` to the child's stdin and captures stdout —
+ * the shape required for `gh pr comment <ref> --body-file -`, where `-` reads
+ * the body from stdin. Injectable so tests never spawn a real `gh`.
+ */
+export type ExecWithInputFn = (
+  file: string,
+  args: string[],
+  input: string,
+) => Promise<{ stdout: string; stderr: string }>;
+
+/** Error shape `classifyStderr` reads — attached to rejections below. */
+interface ExecError extends Error {
+  stderr?: string;
+  exitCode?: number;
+  code?: string;
+  killed?: boolean;
+}
+
+/**
+ * Default stdin-feeding exec via `spawn` (no shell). Applies the same 20 s
+ * hard timeout as `defaultExecFn`; on timeout the child is SIGTERM'd and the
+ * rejection carries `killed: true` so `classifyStderr` maps it to `'timeout'`.
+ */
+function defaultExecWithInput(
+  file: string,
+  args: string[],
+  input: string,
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(file, args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    let killedByTimeout = false;
+
+    const timer = setTimeout(() => {
+      killedByTimeout = true;
+      child.kill('SIGTERM');
+    }, EXEC_TIMEOUT_MS);
+
+    child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      clearTimeout(timer);
+      reject(Object.assign(new Error(err.message), {
+        ...(err.code !== undefined ? { code: err.code } : {}),
+        stderr,
+      }) as ExecError);
+    });
+
+    child.on('close', (code: number | null) => {
+      clearTimeout(timer);
+      if (killedByTimeout) {
+        reject(Object.assign(new Error(`${file} timed out`), { killed: true, stderr }) as ExecError);
+        return;
+      }
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+      reject(Object.assign(new Error(`${file} exited ${code ?? 'null'}`), {
+        exitCode: code ?? 1,
+        stderr,
+      }) as ExecError);
+    });
+
+    // EPIPE guard: if `gh` exits before draining stdin, the write errors — the
+    // close/error handler owns the real outcome, so swallow the stdin error.
+    child.stdin?.on('error', () => { /* ignore */ });
+    child.stdin?.end(input);
+  });
+}
+
+export interface PostPrCommentOpts {
+  /**
+   * PR selector forwarded to `gh pr comment`: a number, a full PR URL, or a
+   * branch name. Empty string → `gh` resolves the current branch's PR.
+   */
+  pr: string;
+  /** Comment body (markdown). Sent via stdin, so any content is safe. */
+  body: string;
+}
+
+/**
+ * Post a comment to a GitHub PR via `gh pr comment <ref> --body-file -`,
+ * feeding the body through stdin. Returns the created comment URL (trimmed,
+ * may be empty if `gh` prints nothing). Throws `GhError` on failure with a
+ * discriminated `kind`.
+ */
+export async function postPrComment(
+  opts: PostPrCommentOpts,
+  execFn?: ExecWithInputFn,
+): Promise<string> {
+  const exec = execFn ?? defaultExecWithInput;
+  const args = ['pr', 'comment'];
+  const ref = opts.pr.trim();
+  if (ref) args.push(ref);
+  args.push('--body-file', '-');
+
+  try {
+    const { stdout } = await exec('gh', args, opts.body);
+    return stdout.trim();
+  } catch (err: unknown) {
+    const e = err as ExecError;
+    const stderr = e.stderr ?? '';
+    const kind = classifyStderr(stderr, e.code, e.killed);
+    throw new GhError(`gh pr comment failed (${kind}): ${stderr.trim()}`, kind, e.exitCode ?? 1, stderr);
+  }
+}
+
+/**
+ * Resolve the open PR number for the current branch via
+ * `gh pr view --json number`. Returns the number as a string, or `null` when
+ * there is no open PR for the branch (or `gh` fails) — never throws. Used to
+ * give `--post github` a target when the review ran against a local diff.
+ */
+export async function resolveCurrentBranchPr(execFn?: ExecFn): Promise<string | null> {
+  const exec = execFn ?? defaultExecFn;
+  try {
+    const { stdout } = await exec('gh', ['pr', 'view', '--json', 'number', '--jq', '.number']);
+    const n = stdout.trim();
+    return /^\d+$/.test(n) ? n : null;
+  } catch {
+    return null;
   }
 }

--- a/src/cli/slash/_lib/review-post.test.ts
+++ b/src/cli/slash/_lib/review-post.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Tests for src/cli/slash/_lib/review-post.ts
+ *
+ * Pure helpers (parse / chunk / build / summarize) plus the fail-soft
+ * orchestrator with fully-injected deps — no real `gh`, no real Telegram.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import type { Writer } from '../types.js';
+import {
+  parsePostFlag,
+  chunkText,
+  buildGithubBody,
+  summarizeForTelegram,
+  runReviewPostPublish,
+  REVIEW_MARKER,
+  type ReviewPostDeps,
+} from './review-post.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** A Writer that records every call so assertions can inspect output. */
+function mockWriter(): Writer & {
+  warns: string[];
+  successes: string[];
+  errors: string[];
+} {
+  const warns: string[] = [];
+  const successes: string[] = [];
+  const errors: string[] = [];
+  return {
+    line: () => {},
+    raw: () => {},
+    info: () => {},
+    warn: (t = '') => { warns.push(t); },
+    success: (t = '') => { successes.push(t); },
+    error: (t = '') => { errors.push(t); },
+    warns,
+    successes,
+    errors,
+  };
+}
+
+/** Default happy-path deps; override per-test. */
+function deps(overrides: Partial<ReviewPostDeps> = {}): Partial<ReviewPostDeps> {
+  return {
+    checkGhReady: vi.fn().mockResolvedValue({ ok: true }),
+    postPrComment: vi.fn().mockResolvedValue('https://github.com/o/r/pull/7#issuecomment-9'),
+    resolveCurrentBranchPr: vi.fn().mockResolvedValue('7'),
+    pushIfConfigured: vi.fn().mockResolvedValue([{ ok: true, status: 200 }]),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parsePostFlag
+// ---------------------------------------------------------------------------
+
+describe('parsePostFlag', () => {
+  it('extracts a single target and strips it from args', () => {
+    const r = parsePostFlag('277 --post github');
+    expect(r.targets).toEqual(['github']);
+    expect(r.cleanedArgs).toBe('277');
+    expect(r.unknown).toEqual([]);
+  });
+
+  it('supports the = form', () => {
+    expect(parsePostFlag('--post=telegram --staged').targets).toEqual(['telegram']);
+    expect(parsePostFlag('--post=telegram --staged').cleanedArgs).toBe('--staged');
+  });
+
+  it('supports comma lists', () => {
+    expect(parsePostFlag('--post github,telegram').targets).toEqual(['github', 'telegram']);
+  });
+
+  it('supports repeated flags and dedupes', () => {
+    expect(parsePostFlag('--post github --post github --post telegram').targets).toEqual([
+      'github',
+      'telegram',
+    ]);
+  });
+
+  it('collects unknown targets and leaves valid args intact', () => {
+    const r = parsePostFlag('--head --post slack');
+    expect(r.targets).toEqual([]);
+    expect(r.unknown).toEqual(['slack']);
+    expect(r.cleanedArgs).toBe('--head');
+  });
+
+  it('strips a dangling bare --post with no value', () => {
+    const r = parsePostFlag('277 --post');
+    expect(r.targets).toEqual([]);
+    expect(r.cleanedArgs).toBe('277');
+  });
+
+  it('is a no-op when --post is absent', () => {
+    const r = parsePostFlag('--staged --light');
+    expect(r.targets).toEqual([]);
+    expect(r.cleanedArgs).toBe('--staged --light');
+  });
+
+  it('leaves args verbatim (no trim/collapse) when --post is absent', () => {
+    // Guards the preflight rawArgs-verbatim contract (plugin-skills-preflight).
+    const r = parsePostFlag('  277 --verbose  ');
+    expect(r.cleanedArgs).toBe('  277 --verbose  ');
+  });
+
+  it('preserves a PR URL as the review target', () => {
+    const r = parsePostFlag('https://github.com/o/r/pull/12 --post github');
+    expect(r.cleanedArgs).toBe('https://github.com/o/r/pull/12');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chunkText
+// ---------------------------------------------------------------------------
+
+describe('chunkText', () => {
+  it('returns the text unchanged when within the limit', () => {
+    expect(chunkText('short', 4096)).toEqual(['short']);
+  });
+
+  it('splits on line boundaries', () => {
+    const text = 'aaaa\nbbbb\ncccc';
+    const chunks = chunkText(text, 9); // "aaaa\nbbbb" = 9 chars
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(9);
+    expect(chunks.join('\n')).toBe(text);
+  });
+
+  it('hard-splits a single line longer than the limit', () => {
+    const chunks = chunkText('x'.repeat(25), 10);
+    expect(chunks).toEqual(['xxxxxxxxxx', 'xxxxxxxxxx', 'xxxxx']);
+  });
+
+  it('never emits a chunk longer than the limit', () => {
+    const text = Array.from({ length: 50 }, (_, i) => `line ${i} ${'y'.repeat(i)}`).join('\n');
+    for (const c of chunkText(text, 40)) expect(c.length).toBeLessThanOrEqual(40);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildGithubBody
+// ---------------------------------------------------------------------------
+
+describe('buildGithubBody', () => {
+  it('prepends the marker and includes the review + footer', () => {
+    const body = buildGithubBody('  ## Findings\n- nit: foo  ');
+    expect(body.startsWith(REVIEW_MARKER)).toBe(true);
+    expect(body).toContain('## Findings');
+    expect(body).toContain('agent-afk /review --post github');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summarizeForTelegram
+// ---------------------------------------------------------------------------
+
+describe('summarizeForTelegram', () => {
+  it('detects DO NOT MERGE', () => {
+    expect(summarizeForTelegram('Decision: **DO NOT MERGE**')).toContain('DO NOT MERGE');
+  });
+
+  it('detects MERGE', () => {
+    const s = summarizeForTelegram('Decision: **MERGE**\nAll clear.');
+    expect(s).toContain('MERGE');
+    expect(s).not.toContain('DO NOT MERGE');
+  });
+
+  it('falls back to a neutral header when no decision token is present', () => {
+    expect(summarizeForTelegram('some prose with no verdict')).toContain('Review complete');
+  });
+
+  it('lifts high-signal finding lines with citations', () => {
+    const review = [
+      '## Summary',
+      'Decision: DO NOT MERGE',
+      '',
+      '- critical: SQL injection in src/db/query.ts:42',
+      '- nit: rename a variable',
+      '- high: missing auth check at src/api/handler.ts:88',
+    ].join('\n');
+    const s = summarizeForTelegram(review);
+    expect(s).toContain('src/db/query.ts:42');
+    expect(s).toContain('src/api/handler.ts:88');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runReviewPostPublish — orchestrator (fail-soft)
+// ---------------------------------------------------------------------------
+
+describe('runReviewPostPublish', () => {
+  it('warns and does nothing when the review text is empty', async () => {
+    const out = mockWriter();
+    const d = deps();
+    await runReviewPostPublish(out, { targets: ['github'], reviewText: '   ', prRefFromArgs: null }, d);
+    expect(out.warns.some((w) => /no review output/.test(w))).toBe(true);
+    expect(d.postPrComment).not.toHaveBeenCalled();
+  });
+
+  it('github: posts a marker-tagged comment to the PR ref from args', async () => {
+    const out = mockWriter();
+    const post = vi.fn().mockResolvedValue('https://github.com/o/r/pull/277#issuecomment-1');
+    const resolveCurrentBranchPr = vi.fn();
+    const d = deps({ postPrComment: post, resolveCurrentBranchPr });
+    await runReviewPostPublish(
+      out,
+      { targets: ['github'], reviewText: 'MERGE — looks good', prRefFromArgs: '277' },
+      d,
+    );
+    expect(post).toHaveBeenCalledTimes(1);
+    const arg = post.mock.calls[0]![0] as { pr: string; body: string };
+    expect(arg.pr).toBe('277');
+    expect(arg.body.startsWith(REVIEW_MARKER)).toBe(true);
+    // PR ref came from args, so no current-branch resolution needed.
+    expect(resolveCurrentBranchPr).not.toHaveBeenCalled();
+    expect(out.successes.some((s) => /PR #277/.test(s))).toBe(true);
+  });
+
+  it('github: resolves the current-branch PR when args carry no ref', async () => {
+    const out = mockWriter();
+    const resolve = vi.fn().mockResolvedValue('99');
+    const post = vi.fn().mockResolvedValue('');
+    const d = deps({ resolveCurrentBranchPr: resolve, postPrComment: post });
+    await runReviewPostPublish(out, { targets: ['github'], reviewText: 'MERGE', prRefFromArgs: null }, d);
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect((post.mock.calls[0]![0] as { pr: string }).pr).toBe('99');
+  });
+
+  it('github: skips (warns) when gh is not ready', async () => {
+    const out = mockWriter();
+    const post = vi.fn();
+    const d = deps({
+      checkGhReady: vi.fn().mockResolvedValue({ ok: false, hint: '`gh` is not authenticated — run: gh auth login' }),
+      postPrComment: post,
+    });
+    await runReviewPostPublish(out, { targets: ['github'], reviewText: 'MERGE', prRefFromArgs: '1' }, d);
+    expect(post).not.toHaveBeenCalled();
+    expect(out.warns.some((w) => /not authenticated/.test(w))).toBe(true);
+  });
+
+  it('github: skips (warns) when no PR ref and no current-branch PR', async () => {
+    const out = mockWriter();
+    const post = vi.fn();
+    const d = deps({ resolveCurrentBranchPr: vi.fn().mockResolvedValue(null), postPrComment: post });
+    await runReviewPostPublish(out, { targets: ['github'], reviewText: 'MERGE', prRefFromArgs: null }, d);
+    expect(post).not.toHaveBeenCalled();
+    expect(out.warns.some((w) => /no PR to comment on/.test(w))).toBe(true);
+  });
+
+  it('github: fail-soft — a thrown postPrComment is reported, not rethrown', async () => {
+    const out = mockWriter();
+    const d = deps({ postPrComment: vi.fn().mockRejectedValue(new Error('boom')) });
+    await expect(
+      runReviewPostPublish(out, { targets: ['github'], reviewText: 'MERGE', prRefFromArgs: '1' }, d),
+    ).resolves.toBeUndefined();
+    expect(out.warns.some((w) => /github failed: boom/.test(w))).toBe(true);
+  });
+
+  it('telegram: sends a summary and reports success', async () => {
+    const out = mockWriter();
+    const push = vi.fn().mockResolvedValue([{ ok: true, status: 200 }]);
+    const d = deps({ pushIfConfigured: push });
+    await runReviewPostPublish(
+      out,
+      { targets: ['telegram'], reviewText: 'DO NOT MERGE\n- critical: x at a/b.ts:1', prRefFromArgs: null },
+      d,
+    );
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(out.successes.some((s) => /Telegram/.test(s))).toBe(true);
+  });
+
+  it('telegram: skips (warns) when unconfigured (pushIfConfigured returns null)', async () => {
+    const out = mockWriter();
+    const d = deps({ pushIfConfigured: vi.fn().mockResolvedValue(null) });
+    await runReviewPostPublish(out, { targets: ['telegram'], reviewText: 'MERGE', prRefFromArgs: null }, d);
+    expect(out.warns.some((w) => /not configured/.test(w))).toBe(true);
+  });
+
+  it('telegram: fail-soft — a thrown push is reported, not rethrown', async () => {
+    const out = mockWriter();
+    const d = deps({ pushIfConfigured: vi.fn().mockRejectedValue(new Error('net down')) });
+    await expect(
+      runReviewPostPublish(out, { targets: ['telegram'], reviewText: 'MERGE', prRefFromArgs: null }, d),
+    ).resolves.toBeUndefined();
+    expect(out.warns.some((w) => /telegram failed: net down/.test(w))).toBe(true);
+  });
+
+  it('runs every requested target independently', async () => {
+    const out = mockWriter();
+    const post = vi.fn().mockResolvedValue('url');
+    const push = vi.fn().mockResolvedValue([{ ok: true, status: 200 }]);
+    const d = deps({ postPrComment: post, pushIfConfigured: push });
+    await runReviewPostPublish(
+      out,
+      { targets: ['github', 'telegram'], reviewText: 'MERGE', prRefFromArgs: '3' },
+      d,
+    );
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(push).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli/slash/_lib/review-post.ts
+++ b/src/cli/slash/_lib/review-post.ts
@@ -1,0 +1,289 @@
+/**
+ * `/review --post` publishing layer.
+ *
+ * Keeps the `review` skill itself read-only — its SKILL.md forbids any PR
+ * mutation (`gh pr comment`/`edit`/`merge`). The `--post` flag is parsed at the
+ * slash-dispatch layer; after the skill emits its final verified review, the
+ * captured output is published here as a deterministic, fail-soft side effect:
+ *
+ *   - github   → the full review markdown as a PR comment (`gh pr comment
+ *                --body-file -`), tagged with the `<!-- agent-afk-review -->`
+ *                marker so a future version can find-and-edit instead of append.
+ *   - telegram → a concise summary (decision + top findings), chunked to
+ *                Telegram's 4096-char per-message limit.
+ *
+ * Invariant: publishing NEVER throws and NEVER suppresses stdout. The review is
+ * already streamed to the terminal by the renderer before this runs; a failed
+ * post is reported via the writer and the review output stands untouched.
+ *
+ * Auth note: the review runs on the session's Claude credential; posting uses
+ * entirely separate, independently-configured auth — `gh`'s own login for
+ * github, and `TELEGRAM_BOT_TOKEN` for telegram. No credential is shared.
+ *
+ * @module cli/slash/_lib/review-post
+ */
+
+import type { Writer } from '../types.js';
+import {
+  checkGhReady,
+  postPrComment,
+  resolveCurrentBranchPr,
+} from '../../../agent/gh.js';
+import { pushIfConfigured } from '../../../telegram/push.js';
+
+export type PostTarget = 'github' | 'telegram';
+
+/** Telegram hard per-message limit. */
+const TELEGRAM_LIMIT = 4096;
+/** Marker embedded at the top of every posted GitHub comment. */
+export const REVIEW_MARKER = '<!-- agent-afk-review -->';
+
+const VALID_TARGETS: ReadonlySet<string> = new Set(['github', 'telegram']);
+// Matches `--post github`, `--post=github`, and `--post github,telegram`.
+const POST_FLAG_RE = /--post(?:=|\s+)([^\s]+)/g;
+
+export interface ParsedPostFlag {
+  /** Recognized targets, deduped, in encounter order. */
+  targets: PostTarget[];
+  /** Args with every `--post …` token (and any bare `--post`) removed. */
+  cleanedArgs: string;
+  /** Unrecognized target tokens, for the caller to warn about. */
+  unknown: string[];
+}
+
+/**
+ * Extract `--post <targets>` from a `/review` arg string. Supports
+ * `--post github`, `--post=telegram`, comma lists (`--post github,telegram`),
+ * and repeated flags. Leaves all other review args (`--staged`, a PR ref, …)
+ * intact in `cleanedArgs`.
+ */
+export function parsePostFlag(args: string): ParsedPostFlag {
+  // Verbatim passthrough when `--post` is absent: the preflight's rawArgs
+  // contract requires the review target string to reach the skill untouched
+  // (no trim/collapse). Only normalize whitespace when we actually remove a
+  // `--post …` token.
+  if (!/--post\b/.test(args)) {
+    return { targets: [], cleanedArgs: args, unknown: [] };
+  }
+
+  const targets: PostTarget[] = [];
+  const unknown: string[] = [];
+
+  for (const m of args.matchAll(POST_FLAG_RE)) {
+    const raw = m[1] ?? '';
+    for (const part of raw.split(',').map((s) => s.trim()).filter(Boolean)) {
+      if (VALID_TARGETS.has(part)) {
+        const t = part as PostTarget;
+        if (!targets.includes(t)) targets.push(t);
+      } else {
+        unknown.push(part);
+      }
+    }
+  }
+
+  const cleanedArgs = args
+    .replace(POST_FLAG_RE, ' ')
+    // Strip a dangling bare `--post` with no value.
+    .replace(/(^|\s)--post(?=\s|$)/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return { targets, cleanedArgs, unknown };
+}
+
+/**
+ * Split text into chunks no longer than `limit`, preferring line boundaries.
+ * A single line longer than `limit` is hard-split. Pure — page markers are the
+ * caller's job. Returns `[text]` unchanged when it already fits.
+ */
+export function chunkText(text: string, limit: number): string[] {
+  if (limit <= 0 || text.length <= limit) return [text];
+  const chunks: string[] = [];
+  let cur = '';
+  for (const line of text.split('\n')) {
+    if (line.length > limit) {
+      if (cur) {
+        chunks.push(cur);
+        cur = '';
+      }
+      for (let i = 0; i < line.length; i += limit) chunks.push(line.slice(i, i + limit));
+      continue;
+    }
+    if (cur.length + line.length + 1 > limit) {
+      if (cur) chunks.push(cur);
+      cur = line;
+    } else {
+      cur = cur ? `${cur}\n${line}` : line;
+    }
+  }
+  if (cur) chunks.push(cur);
+  return chunks;
+}
+
+/**
+ * Build the GitHub PR comment body: the marker line, the full review markdown,
+ * and a small provenance footer. The marker lets a future version find and edit
+ * the prior agent-afk comment instead of appending a new one.
+ */
+export function buildGithubBody(review: string): string {
+  return (
+    `${REVIEW_MARKER}\n\n${review.trim()}\n\n` +
+    '---\n_🤖 Posted by `agent-afk /review --post github`_'
+  );
+}
+
+/**
+ * Derive a concise Telegram summary from the full review markdown: the merge
+ * decision plus up to a handful of high-signal finding lines. Heuristic by
+ * design — the full review lives in the terminal and (when `--post github`) on
+ * the PR; this is the at-a-glance push. Plain text (no markdown), since the
+ * push is sent without a parse mode.
+ */
+export function summarizeForTelegram(review: string): string {
+  const text = review.trim();
+  const decision = /do not merge/i.test(text)
+    ? '🔴 DO NOT MERGE'
+    : /\bmerge\b/i.test(text)
+      ? '🟢 MERGE'
+      : 'ℹ️ Review complete';
+
+  // High-signal lines: a file:line citation paired with a severity word, or a
+  // markdown bullet/heading carrying a severity word. Capped to stay short.
+  const findingLines: string[] = [];
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const hasCitation = /[\w./-]+:\d+/.test(line);
+    const hasSeverity = /\b(critical|high|blocking|medium)\b/i.test(line);
+    const isBullet = /^([-*]\s|#{1,6}\s)/.test(line);
+    if ((hasCitation && hasSeverity) || (isBullet && hasSeverity)) {
+      findingLines.push(line.replace(/^([-*]+|#{1,6})\s*/, '• '));
+    }
+    if (findingLines.length >= 8) break;
+  }
+
+  const parts = [`agent-afk review — ${decision}`];
+  if (findingLines.length > 0) parts.push('', ...findingLines);
+  parts.push('', 'Full review in terminal / on the PR.');
+  return parts.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator (side-effecting, fail-soft)
+// ---------------------------------------------------------------------------
+
+export interface ReviewPostDeps {
+  checkGhReady: typeof checkGhReady;
+  postPrComment: typeof postPrComment;
+  resolveCurrentBranchPr: typeof resolveCurrentBranchPr;
+  pushIfConfigured: typeof pushIfConfigured;
+}
+
+const DEFAULT_DEPS: ReviewPostDeps = {
+  checkGhReady,
+  postPrComment,
+  resolveCurrentBranchPr,
+  pushIfConfigured,
+};
+
+export interface RunReviewPostParams {
+  targets: PostTarget[];
+  reviewText: string;
+  /** PR ref parsed from the review args (null when the target was local). */
+  prRefFromArgs: string | null;
+}
+
+/**
+ * Publish a completed review to the requested targets. Fail-soft: every target
+ * is attempted independently, all errors are reported via `out` and swallowed,
+ * and a missing/empty review is reported rather than thrown.
+ */
+export async function runReviewPostPublish(
+  out: Writer,
+  params: RunReviewPostParams,
+  deps: Partial<ReviewPostDeps> = {},
+): Promise<void> {
+  const d: ReviewPostDeps = { ...DEFAULT_DEPS, ...deps };
+  const review = (params.reviewText ?? '').trim();
+  if (!review) {
+    out.warn('/review --post: no review output was captured — nothing to post.');
+    return;
+  }
+  for (const target of params.targets) {
+    if (target === 'github') {
+      await publishGithub(out, review, params.prRefFromArgs, d);
+    } else {
+      await publishTelegram(out, review, d);
+    }
+  }
+}
+
+async function publishGithub(
+  out: Writer,
+  review: string,
+  prRefFromArgs: string | null,
+  d: ReviewPostDeps,
+): Promise<void> {
+  try {
+    const ready = await d.checkGhReady();
+    if (!ready.ok) {
+      out.warn(`/review --post github skipped: ${ready.hint}`);
+      return;
+    }
+    let pr = (prRefFromArgs ?? '').trim();
+    if (!pr) {
+      const resolved = await d.resolveCurrentBranchPr();
+      if (!resolved) {
+        out.warn(
+          '/review --post github skipped: no PR to comment on. The review target was not a ' +
+            'PR and the current branch has no open PR. Re-run with a PR number/URL, or open a PR first.',
+        );
+        return;
+      }
+      pr = resolved;
+    }
+    const url = await d.postPrComment({ pr, body: buildGithubBody(review) });
+    out.success(`/review posted to GitHub PR #${pr}${url ? ` — ${url}` : ''}`);
+  } catch (err) {
+    out.warn(
+      `/review --post github failed: ${err instanceof Error ? err.message : String(err)} ` +
+        '(the review output above is unaffected).',
+    );
+  }
+}
+
+async function publishTelegram(out: Writer, review: string, d: ReviewPostDeps): Promise<void> {
+  try {
+    const summary = summarizeForTelegram(review);
+    // Reserve room for an "(i/n)\n" page marker so prefixed chunks stay ≤ limit.
+    const PAGE_PREFIX_BUDGET = 12;
+    const chunks = chunkText(summary, TELEGRAM_LIMIT - PAGE_PREFIX_BUDGET);
+    const paged =
+      chunks.length > 1 ? chunks.map((c, i) => `(${i + 1}/${chunks.length})\n${c}`) : chunks;
+
+    let anySent = false;
+    for (const chunk of paged) {
+      const results = await d.pushIfConfigured(chunk);
+      if (results === null) {
+        out.warn(
+          '/review --post telegram skipped: Telegram is not configured ' +
+            '(TELEGRAM_BOT_TOKEN / AFK_TELEGRAM_ALLOWED_CHAT_IDS).',
+        );
+        return;
+      }
+      if (results.some((r) => r.ok)) anySent = true;
+    }
+    if (anySent) {
+      out.success(
+        `/review summary sent to Telegram${paged.length > 1 ? ` (${paged.length} messages)` : ''}.`,
+      );
+    } else {
+      out.warn('/review --post telegram failed: Telegram rejected all sends.');
+    }
+  } catch (err) {
+    out.warn(
+      `/review --post telegram failed: ${err instanceof Error ? err.message : String(err)} ` +
+        '(the review output above is unaffected).',
+    );
+  }
+}

--- a/src/cli/slash/_lib/run-skill-dispatch-turn.ts
+++ b/src/cli/slash/_lib/run-skill-dispatch-turn.ts
@@ -80,11 +80,16 @@ export interface RunSkillDispatchTurnParams {
  * expected to wrap this in their own try/catch for error reporting;
  * this helper only owns the renderer lifecycle (arm/finally-dispose)
  * and preflight failure isolation.
+ *
+ * Returns the text of the final assistant `message` event seen on the stream
+ * (`''` when none / when soft-stopped before any landed). Callers that don't
+ * need it simply ignore the return; `/review --post` consumes it to publish
+ * the verified review after the skill's terminal output.
  */
 export async function runSkillDispatchTurn(
   ctx: SlashContext,
   params: RunSkillDispatchTurnParams,
-): Promise<void> {
+): Promise<string> {
   const renderer = createSkillRenderer(ctx, {
     skillName: params.skillName,
     onCancel: () => {
@@ -93,6 +98,10 @@ export async function runSkillDispatchTurn(
   });
 
   let softStopRequested = false;
+  // Captured for post-dispatch consumers (e.g. `/review --post`). The last
+  // assistant message on the stream is the skill's terminal output — for
+  // review that's the post-shadow-verify merge recommendation + findings.
+  let finalAssistantText = '';
 
   try {
     await renderer.arm();
@@ -144,6 +153,12 @@ export async function runSkillDispatchTurn(
           ctx.session.current.interrupt().catch(() => { /* best effort */ });
           break;
         }
+        // Capture the latest assistant message text BEFORE sinking — read-only,
+        // never mutates the event, and only runs when soft-stop did not break
+        // above (so an interrupted skill yields no stale post-text).
+        if (event.type === 'message' && event.message.role === 'assistant') {
+          finalAssistantText = event.message.content;
+        }
         renderer.sink(event);
       }
     });
@@ -151,4 +166,6 @@ export async function runSkillDispatchTurn(
     ctx.setSoftStopHandler?.(null);
     await renderer.dispose();
   }
+
+  return finalAssistantText;
 }

--- a/src/cli/slash/plugin-skills.ts
+++ b/src/cli/slash/plugin-skills.ts
@@ -60,6 +60,8 @@ import {
   type ParsedSkillMd,
 } from './_lib/flag-harvest.js';
 import { runSkillDispatchTurn } from './_lib/run-skill-dispatch-turn.js';
+import { parsePostFlag, runReviewPostPublish, type PostTarget } from './_lib/review-post.js';
+import { parsePrRef } from './preflight/review-pr.js';
 import {
   runPreflight,
   getSkillPreflightDir,
@@ -238,6 +240,36 @@ export function makeForwardHandler(skill: DiscoveredSkill, flags?: readonly stri
       args: string,
       attachments?: readonly ImageAttachment[],
     ): Promise<SlashResult> {
+      // `/review --post <github|telegram>` — parsed here at the dispatch layer
+      // and stripped from the args BEFORE they reach the (read-only) review
+      // skill, so the skill never sees `--post` as a review target and never
+      // posts anything itself. Publishing happens after the verified output
+      // lands (see runReviewPostPublish, below). Gated on the bare name so the
+      // flag is review-only; every other plugin skill is unaffected.
+      const isReview = bareName(skill.name) === 'review';
+      let dispatchArgs = args;
+      let postTargets: PostTarget[] = [];
+      let prRefFromArgs: string | null = null;
+      if (isReview) {
+        const parsed = parsePostFlag(args);
+        postTargets = parsed.targets;
+        dispatchArgs = parsed.cleanedArgs;
+        for (const u of parsed.unknown) {
+          ctx.out.warn(`/review: unknown --post target "${u}" — expected "github" or "telegram".`);
+        }
+        if (postTargets.length === 0 && parsed.unknown.length === 0 && /--post\b/.test(args)) {
+          ctx.out.warn('/review: --post needs a target — try "--post github" or "--post telegram".');
+        }
+        // Reuse the preflight's PR-ref parser so `/review 277 --post github`
+        // comments on PR 277; a local-diff review (no PR ref) resolves the
+        // current branch's PR at publish time instead.
+        try {
+          prRefFromArgs = parsePrRef(dispatchArgs);
+        } catch {
+          prRefFromArgs = null;
+        }
+      }
+
       // Mirror makeImmediateHandler: build the 2-block skill-invocation payload
       // (breadcrumb + dispatch instruction) and stream it through the session,
       // rather than returning 'forward' and letting the REPL send raw '/skill'
@@ -258,10 +290,10 @@ export function makeForwardHandler(skill: DiscoveredSkill, flags?: readonly stri
       };
 
       try {
-        await runSkillDispatchTurn(ctx, {
+        const finalAssistantText = await runSkillDispatchTurn(ctx, {
           skillName: skill.name,
           skillMeta,
-          args,
+          args: dispatchArgs,
           attachments,
           // SkillPreflight — runtime-owned context gathering, runs inside
           // the armed renderer. Symmetric with makeImmediateHandler
@@ -284,7 +316,7 @@ export function makeForwardHandler(skill: DiscoveredSkill, flags?: readonly stri
               : skill.name;
             const inv: SkillInvocation = {
               skillName: bareSkillName,
-              rawArgs: args,
+              rawArgs: dispatchArgs,
               source: 'plugin',
               capabilities: { compose: true, subagents: true },
             };
@@ -307,6 +339,18 @@ export function makeForwardHandler(skill: DiscoveredSkill, flags?: readonly stri
             return preflightResult?.manifestBlock;
           },
         });
+
+        // Publish AFTER the verified review output lands. runReviewPostPublish
+        // is fail-soft — it never throws and never suppresses the stdout the
+        // renderer already streamed, so a posting failure can't be mistaken
+        // for a review failure in the catch below.
+        if (isReview && postTargets.length > 0) {
+          await runReviewPostPublish(ctx.out, {
+            targets: postTargets,
+            reviewText: finalAssistantText,
+            prRefFromArgs,
+          });
+        }
       } catch (err) {
         ctx.out.line();
         ctx.out.error(


### PR DESCRIPTION
## Source

Moat-scrubbed port of **afk-workshop#733** (private). This is a verified port, not a 1:1 copy.

Adds a `--post <github|telegram>` flag to `/review` that publishes the **verified** review output to a GitHub PR comment and/or Telegram. The review runs locally on existing Claude auth — no CI credential or metered key needed. `--post github,telegram` posts to both.

## Design — review skill stays read-only

The `review` skill prompt is **untouched** (it still forbids any PR mutation). `--post` is parsed at the slash **dispatch layer** (`plugin-skills.ts`, gated on the review skill) and stripped from the args before they reach the skill. Publishing happens *after* the verified output lands.

## Ported (all 6 files — all public-safe)

- `src/agent/gh.ts` — `postPrComment()` via `gh pr comment <ref> --body-file -` (body over stdin); `resolveCurrentBranchPr()`.
- `src/cli/slash/_lib/review-post.ts` (new) — pure helpers (`parsePostFlag`, `chunkText`, `buildGithubBody`, `summarizeForTelegram`, marker) + fail-soft orchestrator.
- `src/cli/slash/_lib/run-skill-dispatch-turn.ts` — returns the final assistant text (was `void`); read-only capture, after the soft-stop break.
- `src/cli/slash/plugin-skills.ts` — forward handler parses `--post`, publishes after success.
- `src/agent/gh.test.ts` (+8), `src/cli/slash/_lib/review-post.test.ts` (+28) — tests.

## Behavior

- **GitHub**: full review markdown as a PR comment, prefixed with `<!-- agent-afk-review -->`. PR ref from review args or the current branch's PR; skips cleanly if neither exists.
- **Telegram**: concise summary, chunked to 4096 with `(i/n)` markers.
- **Fail-soft**: posting never throws and never suppresses stdout. Auth: review uses Claude creds, `gh` uses its own login, Telegram uses `TELEGRAM_BOT_TOKEN` — no shared credential.

## Dropped (moat)

**None.** Triage classified all 6 files / all hunks PUBLIC-SAFE; the patch touched no moat files or terms.

## Verification (--to-public, fail-closed)

- Correctness gate green in the public tree: `pnpm install --frozen-lockfile` ✅, `pnpm lint` ✅, `env -u AFK_INTERNAL pnpm test` ✅ (442 files, 8227 passed / 12 skipped), `pnpm build` ✅, `pnpm build:dist` ✅.
- Deterministic moat guard (tree + built dist): **✅ MOAT GUARD CLEAN**.
- Independent adversarial audit: **CLEAN**.

Do not merge automatically — for human review.
