### PR TITLE
docs(positioning): control-plane reframe — README hero + npm metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Agent AFK
 
-> Works while you're away.
+> Delegate the work. Keep the judgment.
 >
-> Start a coding run before dinner. Agent AFK works locally, texts you when it's done or stuck, and leaves behind a PR, trace, and Telegram thread showing exactly what happened.
+> **Agent AFK** is a local-first control plane for long-running AI agent work. Hand off multi-session, headless tasks to parallel agents — then stay in control with traces you can read (`afk trace show`), resumable sessions, verification passes before anything ships, and a phone ping the moment work lands in a terminal state. Bring your own model.
 
 [![npm version](https://img.shields.io/npm/v/agent-afk.svg)](https://www.npmjs.com/package/agent-afk)
 [![Node](https://img.shields.io/node/v/agent-afk.svg)](https://nodejs.org/)
@@ -28,6 +28,7 @@ afk chat "hello"
 
 - **Chat from your terminal** — `afk chat "..."` for one-shot, `afk i` for a REPL with full tool access (Bash, file ops, web fetch, grep/glob, subagents).
 - **Hand long work off to a daemon** — `afk daemon` runs headless. Pair it with `send_telegram` and you get pings on your phone when work lands in a terminal state.
+- **Read the trace** — every run writes an append-only record of what the agent did. `afk trace show` prints it back as a human-readable receipt — tool calls, gate decisions, subagent lifecycles, cost — so you can audit a run without reaching for `jq`.
 - **Message Claude from Telegram** — `afk telegram setup` walks you through bot token + allowlist. After that you have a private chat surface backed by the same session manager as the REPL.
 - **Built-in orchestrators** — `/mint`, `/diagnose`, `/spec`, `/research`, `/ship`, `/review` dispatch subagent waves. `/mint` takes a feature idea and runs spec → research → plan → parallelize → build → verify → ship. `/diagnose` forks parallel root-cause hypotheses for failing tests and bugs.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-afk",
   "version": "3.87.0",
-  "description": "CLI tool for interacting with AI agents via multiple interfaces",
+  "description": "Local-first control plane for long-running AI agent work — delegation, traces, resumable sessions, verification, and notifications.",
   "main": "dist/index.mjs",
   "type": "module",
   "bin": {
@@ -47,11 +47,15 @@
     "release:dry": "node scripts/release.mjs --dry-run"
   },
   "keywords": [
-    "cli",
-    "ai",
-    "agent",
+    "ai-agent",
+    "agent-runtime",
+    "control-plane",
+    "orchestration",
+    "verification",
+    "local-first",
+    "mcp",
     "telegram",
-    "chatbot"
+    "cli"
   ],
   "author": "Griffin Long",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What

Reframes the public README + npm metadata from the "works while you're away" convenience framing to the **control-plane / trust-loop** positioning: **"Delegate the work. Keep the judgment."**

This is the **public-repo** half. The landing-site copy lives in the private dev repo and ships there.

## Changes (copy-only — no code change)

- **README.md** — new hero blockquote; adds a "Read the trace" bullet for `afk trace show`.
- **package.json** — `description` rewrite; `keywords` drop `chatbot`, add `control-plane` / `ai-agent` / `agent-runtime` / `verification` / `local-first` / `mcp` (npm search + the npm listing are the highest-leverage storefront surface).

## Merge ordering

The README references `afk trace show`. Make sure the trace-reader source port has landed in this repo before merging so the command exists for readers who try it.

## Verification

- `package.json` parses as valid JSON; `description` updated.
- Diff scanned for moat/denylist terms — clean.
