### PR TITLE
fix(cli): make TerminalCompositor wrap-aware so soft-wrapped frame lines don't clobber committed text

### DIFF
--- a/src/cli/cup-frame-renderer.ts
+++ b/src/cli/cup-frame-renderer.ts
@@ -80,6 +80,46 @@ export class CupFrameRenderer {
   }
 
   /**
+   * Wrap `content` to `width` exactly as render() does — {trim:false,
+   * hard:true, wordWrap:false} with a guaranteed trailing newline for
+   * consistent normalization — and return the physical (post-wrap) visible
+   * lines, trailing empty element(s) dropped. Shared by render() and measure()
+   * so the physical row count can never drift between them.
+   */
+  private static wrapToPhysicalLines(content: string, width: number): string[] {
+    const raw = content.endsWith('\n') ? content : `${content}\n`;
+    const wrapped = wrapAnsi(raw, width, { trim: false, hard: true, wordWrap: false });
+    const allLines = wrapped.split('\n');
+    while (allLines.length > 0 && allLines[allLines.length - 1] === '') {
+      allLines.pop();
+    }
+    return allLines;
+  }
+
+  /**
+   * Predict the physical top row the next `render(content, targetBottomRow)`
+   * will use, WITHOUT rendering or mutating tracked state. CupFrameRenderer
+   * hard-wraps at `stream.columns`, so a frame line wider than the terminal
+   * occupies >1 physical row. Callers (TerminalCompositor repaint /
+   * repaintPickerFrame) use this to size committed-band eviction + re-pin
+   * against the PHYSICAL frame footprint; the logical line count under-counts
+   * whenever a line soft-wraps and re-pins the band INSIDE the frame, where the
+   * next render's erase pass clobbers it (review #592).
+   *
+   * Returns the raw (wrapped, pre-shrink-padding) top: shrink padding is a
+   * transient one-render artifact handled inside render(), and the band is
+   * pinned against the real content top — `bottomRow - rawLineCount + 1`. In
+   * the common case where nothing wraps this equals the logical line count, so
+   * callers see byte-identical geometry.
+   */
+  measure(content: string, targetBottomRow: number): { topRow: number; lineCount: number } {
+    const width = this.stream.columns ?? 80;
+    const rawLineCount = Math.max(1, CupFrameRenderer.wrapToPhysicalLines(content, width).length);
+    const bottomRow = Math.max(1, targetBottomRow);
+    return { topRow: Math.max(1, bottomRow - rawLineCount + 1), lineCount: rawLineCount };
+  }
+
+  /**
    * Render `content` so that the last content line sits at `targetBottomRow`.
    * Lines are positioned with CUP escapes — no `\n` is written for line
    * transitions, so the DECSTBM scroll region is never triggered.
@@ -94,18 +134,9 @@ export class CupFrameRenderer {
     const width = this.stream.columns ?? 80;
     const useSyncOutput = this.stream.isTTY === true;
 
-    // Wrap exactly as log-update did: {trim: false, hard: true, wordWrap: false}
-    // plus a guaranteed trailing newline so wrap-ansi normalises consistently.
-    const raw = content.endsWith('\n') ? content : `${content}\n`;
-    const wrapped = wrapAnsi(raw, width, { trim: false, hard: true, wordWrap: false });
-
-    // Split into lines. The trailing `\n` from wrapping produces a final empty
-    // element — drop it so `lineCount` reflects visible lines only.
-    const allLines = wrapped.split('\n');
-    // Drop trailing empty element(s) from the normalized trailing newline.
-    while (allLines.length > 0 && allLines[allLines.length - 1] === '') {
-      allLines.pop();
-    }
+    // Wrap via the shared helper measure() also uses, so the physical row count
+    // repaint() predicted (via measure) matches what we actually render here.
+    const allLines = CupFrameRenderer.wrapToPhysicalLines(content, width);
     const rawLineCount = Math.max(1, allLines.length);
 
     // Invariant (bottom-anchored shrink coverage): when raw content shrinks

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -1218,15 +1218,25 @@ export class TerminalCompositor {
     // shifts up by the same number of rows because the pre-arm content has
     // moved upward in the viewport — re-running this branch on the next
     // repaint with the same lineCount finds no deficit.
-    const lineCount = frameLines.length;
-    const desiredTopRow = Math.max(1, targetBottomRow - lineCount + 1);
+    const frame = frameLines.join('\n');
+    // Wrap-aware top row: CupFrameRenderer hard-wraps at stdout.columns, so a
+    // frame line wider than the terminal occupies >1 physical row. Sizing the
+    // committed-band eviction/re-pin off the LOGICAL line count
+    // (frameLines.length) under-counts in that case and re-pins the band INSIDE
+    // the physical frame footprint, where the next render's erase pass clobbers
+    // it (review #592). measure() returns the physical top render() will use; it
+    // equals the logical count whenever nothing wraps. Stubs without measure()
+    // fall back to the logical count.
+    const desiredTopRow = this.logUpdate.measure
+      ? this.logUpdate.measure(frame, targetBottomRow).topRow
+      : Math.max(1, targetBottomRow - frameLines.length + 1);
     this.preserveRowsBeforeFrameRender(desiredTopRow);
     // Capture the renderer's current top BEFORE render(): it is the first row
     // its erase pass will clear, which repositionCommittedBand() uses to detect
     // whether the render wiped the band (the collapse render, whose stale-tall
     // top erases down through it).
     const preRenderFrameTop = this.logUpdate.topRow ?? 0;
-    this.logUpdate.render(frameLines.join('\n'), targetBottomRow);
+    this.logUpdate.render(frame, targetBottomRow);
     this.repositionCommittedBand(desiredTopRow, preRenderFrameTop, targetBottomRow);
   }
 
@@ -1439,11 +1449,16 @@ export class TerminalCompositor {
     // rawLineCount=1). Skip the render — nothing to draw on screen.
     if (frameLines.length === 0) return;
     const targetBottomRow = Math.max(1, (this.stdout.rows ?? 24) - 1 - extraRows);
-    const lineCount = frameLines.length;
-    const desiredTopRow = Math.max(1, targetBottomRow - lineCount + 1);
+    const frame = frameLines.join('\n');
+    // Wrap-aware top row — CupFrameRenderer hard-wraps at stdout.columns; sizing
+    // the band off the logical line count re-pins it inside a soft-wrapped frame
+    // (review #592). See repaint() for the full rationale.
+    const desiredTopRow = this.logUpdate.measure
+      ? this.logUpdate.measure(frame, targetBottomRow).topRow
+      : Math.max(1, targetBottomRow - frameLines.length + 1);
     this.preserveRowsBeforeFrameRender(desiredTopRow);
     const preRenderFrameTop = this.logUpdate.topRow ?? 0;
-    this.logUpdate.render(frameLines.join('\n'), targetBottomRow);
+    this.logUpdate.render(frame, targetBottomRow);
     this.repositionCommittedBand(desiredTopRow, preRenderFrameTop, targetBottomRow);
   }
 

--- a/src/cli/terminal-compositor.types.ts
+++ b/src/cli/terminal-compositor.types.ts
@@ -39,6 +39,16 @@ export interface LogUpdateFn {
    * coordinates.
    */
   resetGeometry?: () => void;
+  /**
+   * Optional method exposed by CupFrameRenderer. Predicts the physical top row
+   * the next `render(content, targetBottomRow)` will use (after hard-wrapping
+   * at `stdout.columns`), without rendering or mutating tracked state. Used by
+   * `repaint()`/`repaintPickerFrame()` to size committed-band eviction + re-pin
+   * against the PHYSICAL frame footprint rather than the logical line count,
+   * which under-counts whenever a frame line soft-wraps (review #592). Absent on
+   * test stubs — callers fall back to the logical line count.
+   */
+  measure?: (content: string, targetBottomRow: number) => { topRow: number; lineCount: number };
 }
 
 export interface KeyInfo {

--- a/src/cli/terminal-compositor.wrap-gap.test.ts
+++ b/src/cli/terminal-compositor.wrap-gap.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Regression: committed content must stay intact and adjacent to the live frame
+ * when an overlay line is WIDER than the terminal and soft-wraps to ≥2 physical
+ * rows ("weird gap + missing/overlapping text" on long streamed messages).
+ *
+ * Root cause (review #592 follow-up): TerminalCompositor.repaint() computed the
+ * frame's `desiredTopRow` from the LOGICAL line count (`frameLines.length`),
+ * but CupFrameRenderer.render() positions the frame at the PHYSICAL top after
+ * wrapAnsi(hard:true) at stdout.columns. When any frame line wraps, physical >
+ * logical, so preserveRowsBeforeFrameRender (eviction) and repositionCommittedBand
+ * (re-pin) operate on the wrong rows — the committed band lands inside the
+ * physical frame footprint and is clobbered by the next render's erase pass,
+ * opening a blank gap and dropping committed text.
+ *
+ * Trigger: src/cli/wrap.ts wrapToWidth uses hard:false (a long unbreakable token
+ * — URL, inline-code span, file:line ref — is NOT broken and overruns the width),
+ * while CupFrameRenderer wraps hard:true and splits it. The two row counts then
+ * diverge.
+ *
+ * HARD CORRECTNESS GATE: RED on the wrap-blind code (committed marker is dropped
+ * or a multi-row blank gap opens above the overlay), GREEN once repaint() derives
+ * desiredTopRow from the physical (wrapped) row count.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { TerminalCompositor } from './terminal-compositor.js';
+
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin = NodeJS.ReadStream & { isTTY: boolean; isRaw: boolean; setRawMode: ReturnType<typeof vi.fn> };
+
+function makeMockStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true;
+  s.columns = cols;
+  s.rows = rows;
+  return s;
+}
+function makeMockStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true;
+  s.isRaw = false;
+  s.setRawMode = vi.fn((raw: boolean) => {
+    s.isRaw = raw;
+    return s;
+  });
+  return s;
+}
+function collectWrites(stream: MockStdout): { all: () => string } {
+  const chunks: string[] = [];
+  stream.on('data', (c: unknown) => chunks.push(String(c)));
+  return { all: () => chunks.join('') };
+}
+function makeScrollRegion(stdout: MockStdout) {
+  return {
+    withFullScrollRegion<T>(fn: () => T): T {
+      stdout.write('\x1b[s');
+      stdout.write('\x1b[r');
+      stdout.write('\x1b[u');
+      try {
+        return fn();
+      } finally {
+        const rows = stdout.rows;
+        stdout.write('\x1b[s');
+        stdout.write(`\x1b[1;${rows}r`);
+        stdout.write('\x1b[u');
+      }
+    },
+    getExtraRows(): number {
+      return 0;
+    },
+  };
+}
+function termWriteSync(term: HeadlessTerminal, data: string): Promise<void> {
+  return new Promise((resolve) => term.write(data, resolve));
+}
+function allLines(term: HeadlessTerminal): string[] {
+  const buf = term.buffer.active;
+  const result: string[] = [];
+  for (let i = 0; i < buf.length; i++) {
+    const line = buf.getLine(i);
+    if (line != null) result.push(line.translateToString(true));
+  }
+  return result;
+}
+
+const COLS = 80;
+const ROWS = 24;
+const MARKER = 'COMMITTED_MARKER_LINE';
+
+describe('repaint wrap-blindness regression', () => {
+  it('keeps committed content intact + adjacent when an overlay line soft-wraps', async () => {
+    const stdout = makeMockStdout(COLS, ROWS);
+    const stdin = makeMockStdin();
+    const writes = collectWrites(stdout);
+    const scrollRegion = makeScrollRegion(stdout);
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), scrollRegion, anchorRow: 1 });
+    await c.arm();
+
+    const term = new HeadlessTerminal({
+      cols: COLS,
+      rows: ROWS,
+      scrollback: 400,
+      allowProposedApi: true,
+      convertEol: true,
+    });
+
+    // 1) Commit a recognizable marker block — lands in the band just above the
+    //    idle input frame.
+    c.commitAbove(`${MARKER}\n`);
+
+    // 2) An overlay arrives whose lines exceed the terminal width. Each long line
+    //    soft-wraps to 2 physical rows. The compositor's LOGICAL count (4) is one
+    //    short of the PHYSICAL count (7) per long line → desiredTopRow is wrong.
+    const long = 'WRAPME_' + 'x'.repeat(COLS + 25); // > COLS → wraps to 2 rows
+    const overlay = ['short head', long, long, 'short tail'].join('\n');
+    c.setOverlay(overlay);
+
+    // 3) A spinner tick / further repaint (the second repaint the streamer fires
+    //    as content lands). This is where the wrong desiredTopRow re-pins the
+    //    band into the physical frame and the erase pass clobbers it.
+    const internals = c as unknown as { repaint(): void };
+    internals.repaint();
+    internals.repaint();
+
+    await termWriteSync(term, writes.all());
+    const lines = allLines(term);
+    const dump = lines.map((l, i) => `[${String(i).padStart(2)}] ${JSON.stringify(l)}`).join('\n');
+
+    const markerIdx = lines.findIndex((l) => l.includes(MARKER));
+    const headIdx = lines.findIndex((l) => l.includes('short head'));
+    const tailIdx = lines.findIndex((l) => l.includes('short tail'));
+
+    // (a) The committed marker must survive — exactly one copy, not clobbered.
+    expect(lines.filter((l) => l.includes(MARKER)).length, `marker dropped or duplicated:\n${dump}`).toBe(1);
+
+    // (b) Overlay content intact.
+    expect(headIdx, `overlay head missing:\n${dump}`).toBeGreaterThanOrEqual(0);
+    expect(tailIdx, `overlay tail missing:\n${dump}`).toBeGreaterThanOrEqual(0);
+
+    // (c) DISCRIMINATING: the committed marker sits strictly ABOVE the overlay
+    //     block. The wrap-blind bug re-pins it INSIDE the physical frame (below
+    //     the overlay's first line), interleaving committed + streamed content.
+    expect(
+      markerIdx,
+      `committed marker is interleaved INSIDE the overlay (marker=${markerIdx}, head=${headIdx}):\n${dump}`,
+    ).toBeLessThan(headIdx);
+
+    term.dispose();
+    c.disarm();
+  }, 15_000);
+});


### PR DESCRIPTION
## Problem

Long streamed assistant messages render in the REPL with **extra blank vertical space and missing/overlapping committed text** — committed lines get interleaved into the live stream and wrapped rows go missing.

## Root cause

`repaint()` and `repaintPickerFrame()` computed the frame's `desiredTopRow` from the **logical** line count (`frameLines.length`), but `CupFrameRenderer.render()` positions the frame at the **physical** top after `wrapAnsi(hard:true)` at `stdout.columns`. When a frame line is wider than the terminal and soft-wraps — e.g. a long unbreakable token (URL, inline-code span, `file:line` reference), which `wrap.ts` leaves unbroken at `hard:false` — `physical > logical`, so `preserveRowsBeforeFrameRender` (eviction) and `repositionCommittedBand` (re-pin) operate on the wrong rows. The committed band is re-pinned **inside** the physical frame footprint, where the next render's erase pass clobbers it.

This is the wrap-blindness already flagged by `golden-rendering.test.ts` → `TODO(review #592)`.

## Fix

- Add `CupFrameRenderer.measure()` — predicts the physical top row `render()` will use, via a shared private `wrapToPhysicalLines()` helper so the two computations can't drift.
- Both repaint sites derive `desiredTopRow` from `measure()` (logical fallback for test stubs without `measure`).
- In the no-wrap case `measure()` returns the logical count, so existing geometry is **byte-identical** — only the wrapping case changes.

## Verification

- New regression `src/cli/terminal-compositor.wrap-gap.test.ts` (`@xterm/headless`) — **RED before, GREEN after**. Reproduces the exact symptom: committed marker interleaved inside the overlay, a wrapped row overwritten.
- **497** tests pass across the compositor / renderer / golden-rendering / markdown / stream-renderer suites.
- `tsc --noEmit` clean (strict).

## Scope / follow-up

- Touches `repaint()` + `repaintPickerFrame()`. `commitAbove()`'s `lineCount` in `terminal-compositor.committed-band.ts` is still logical — a separate, rarer wrap-blind site (committed blocks are pre-wrapped to `contentWidth < columns`), tracked for follow-up.
- A separate **frame-render extraction** PR (decomposing `terminal-compositor.ts`) will follow, stacked on this one.