### PR TITLE
fix(cli): stop streaming markdown tables leaving ghost rows in the live overlay

### DIFF
--- a/src/cli/markdown-stream-format.test.ts
+++ b/src/cli/markdown-stream-format.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isInOpenTable,
+  isInOpenCodeFence,
+  formatPendingBuffer,
+} from './markdown-stream-format.js';
+
+/**
+ * Tests for the pure formatting helpers behind StreamingMarkdownRenderer.
+ *
+ * Focus: the streaming-table placeholder guard. A markdown table has no
+ * internal blank line, so the whole (growing) table accumulates in the pending
+ * buffer and was painted into the live overlay every chunk. Once the table
+ * exceeds the viewport height, the overlay's absolute-cursor erase can no
+ * longer reclaim rows that scrolled into scrollback, leaving ghost tail rows
+ * beside the final committed table. `formatPendingBuffer` now substitutes a
+ * fixed-height placeholder for an in-progress table, mirroring the existing
+ * open-code-fence guard.
+ */
+
+describe('isInOpenTable', () => {
+  it('detects a basic GFM delimiter row', () => {
+    expect(isInOpenTable('| A | B |\n|---|---|\n| 1 | 2 |')).toBe(true);
+  });
+
+  it('detects an alignment delimiter row (colons)', () => {
+    expect(isInOpenTable('| L | C | R |\n| :--- | :--: | ---: |')).toBe(true);
+  });
+
+  it('detects a delimiter even before the first data row arrives', () => {
+    // Mid-stream: header + delimiter present, rows still streaming.
+    expect(isInOpenTable('| Col A | Col B |\n|-------|-------|\n')).toBe(true);
+  });
+
+  it('detects a no-outer-pipe delimiter row', () => {
+    expect(isInOpenTable('A | B\n--- | ---\n1 | 2')).toBe(true);
+  });
+
+  it('returns false for a horizontal rule (no pipe)', () => {
+    expect(isInOpenTable('above\n\n---\n\nbelow')).toBe(false);
+  });
+
+  it('returns false for prose containing a stray pipe (no dash-only row)', () => {
+    expect(isInOpenTable('run `a | b` to pipe output')).toBe(false);
+  });
+
+  it('returns false for a setext underline', () => {
+    expect(isInOpenTable('Heading\n=======')).toBe(false);
+  });
+
+  it('returns false for empty / whitespace buffers', () => {
+    expect(isInOpenTable('')).toBe(false);
+    expect(isInOpenTable('   \n  \n')).toBe(false);
+  });
+
+  it('returns false for a table header row alone (no delimiter yet)', () => {
+    // A lone `| a | b |` is a paragraph until the delimiter row arrives — and
+    // a single short line never overflows the viewport, so no guard needed.
+    expect(isInOpenTable('| just | a | row |')).toBe(false);
+  });
+});
+
+describe('formatPendingBuffer', () => {
+  const WIDTH = 80;
+
+  it('renders a compact placeholder for an in-progress table, not the table', () => {
+    const tall = ['| Col A | Col B |', '|-------|-------|']
+      .concat(Array.from({ length: 40 }, (_, i) => `| row ${i} | value ${i} |`))
+      .join('\n');
+
+    const out = formatPendingBuffer(tall, WIDTH, true);
+
+    expect(out).toContain('streaming table');
+    // The actual table rows / borders must never reach the ephemeral overlay.
+    expect(out).not.toContain('value 39');
+    expect(out).not.toContain('│');
+    // Placeholder is fixed-height regardless of table size (no ghost source).
+    const nonEmptyLines = out.split('\n').filter((l) => l.trim().length > 0);
+    expect(nonEmptyLines.length).toBeLessThanOrEqual(2);
+  });
+
+  it('still renders the open-code-fence placeholder (precedence over table)', () => {
+    // A fenced block whose body looks table-ish must be treated as code, not a
+    // table — the code-fence guard is checked first.
+    const out = formatPendingBuffer('```\n|---|---|\n| a | b |', WIDTH, true);
+    expect(out).toContain('streaming code');
+    expect(out).not.toContain('streaming table');
+  });
+
+  it('renders plain prose normally (no placeholder)', () => {
+    const out = formatPendingBuffer('hello world', WIDTH, true);
+    expect(out).toContain('hello world');
+    expect(out).not.toContain('streaming');
+  });
+
+  it('returns empty string when shouldRender is false', () => {
+    expect(formatPendingBuffer('| A |\n|---|\n| 1 |', WIDTH, false)).toBe('');
+  });
+
+  it('returns empty string for a whitespace-only buffer', () => {
+    expect(formatPendingBuffer('   ', WIDTH, true)).toBe('');
+  });
+});
+
+describe('isInOpenCodeFence (precedence sanity)', () => {
+  it('is true for an unclosed fence even when it contains table-like rows', () => {
+    expect(isInOpenCodeFence('```\n|---|---|\n')).toBe(true);
+  });
+});

--- a/src/cli/markdown-stream-format.ts
+++ b/src/cli/markdown-stream-format.ts
@@ -46,6 +46,14 @@ export function formatPendingBuffer(
 
   if (isInOpenCodeFence(buffer)) {
     pendingRender = '\n▍ streaming code…\n';
+  } else if (isInOpenTable(buffer)) {
+    // A streaming table has no internal blank line, so the whole (growing)
+    // table stays in the pending buffer until a trailing blank line commits
+    // it. Painting that growing table into the live overlay every chunk leaves
+    // ghost rows once it exceeds the viewport height — so substitute a
+    // fixed-height placeholder here, exactly as the open-code-fence path does.
+    // The full table still renders once at commit via formatBlockForCommit.
+    pendingRender = '\n▍ streaming table…\n';
   } else {
     pendingRender = renderTextBlock(buffer, contentWidth);
   }
@@ -117,6 +125,35 @@ export function isInOpenCodeFence(text: string): boolean {
   const tildeFences = (text.match(/^~~~[^\n]*$/gm) ?? []).length;
   // Odd count for either family means an unclosed fence
   return backtickFences % 2 === 1 || tildeFences % 2 === 1;
+}
+
+/**
+ * Detect whether the pending buffer contains an in-progress GFM table,
+ * identified by its delimiter row (e.g. `|---|:--:|`) — a line composed only
+ * of pipes, dashes, optional alignment colons, and spaces.
+ *
+ * Mirrors {@link isInOpenCodeFence}: when this is true, `formatPendingBuffer`
+ * renders a compact placeholder instead of the growing table, because a table
+ * taller than the viewport leaves un-clearable ghost rows in the live overlay
+ * (the absolute-cursor erase in CupFrameRenderer cannot reclaim rows that have
+ * scrolled past the top of the viewport into scrollback).
+ *
+ * Requiring BOTH a pipe and a dash excludes horizontal rules (`---`, no pipe),
+ * setext underlines, and prose lines that merely contain a stray pipe.
+ */
+export function isInOpenTable(text: string): boolean {
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (
+      line.length >= 3 &&
+      line.includes('|') &&
+      line.includes('-') &&
+      /^[|:\- ]+$/.test(line)
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/src/cli/markdown-stream.test.ts
+++ b/src/cli/markdown-stream.test.ts
@@ -637,6 +637,65 @@ describe('StreamingMarkdownRenderer', () => {
 
       expect(writes.join('')).toContain('legacy');
     });
+
+    it('streams a table as a compact overlay placeholder, then commits it exactly once', async () => {
+      // Regression (the "ghost table rows" bug): a streaming markdown table has
+      // no internal blank line, so the whole growing table accumulated in the
+      // pending buffer and was painted into the live overlay every chunk. Once
+      // taller than the viewport, rows scrolled into scrollback where the
+      // overlay's absolute-cursor erase could not reclaim them — leaving ghost
+      // tail rows beside the final committed table. The fix paints a
+      // fixed-height placeholder for an in-progress table, so the overlay never
+      // grows past the viewport. The full table still commits once.
+      const prevCols = process.stdout.columns;
+      Object.defineProperty(process.stdout, 'columns', { value: 200, configurable: true });
+      vi.useFakeTimers();
+      try {
+        const { stub, overlayCalls, commitAboveCalls } = makeStubCompositor();
+        const ttyStream = new PassThrough();
+        (ttyStream as any).isTTY = true;
+
+        renderer = new StreamingMarkdownRenderer({
+          out: ttyStream,
+          throttleMs: 10,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          compositor: stub as any,
+        });
+
+        // Stream a table (header + delimiter + many rows) with NO trailing
+        // blank line, so it stays in the pending buffer the whole time.
+        renderer.push('| Col A | Col B |\n');
+        renderer.push('|-------|-------|\n');
+        for (let i = 0; i < 12; i++) {
+          renderer.push(`| ROW_${i} | value ${i} |\n`);
+          vi.advanceTimersByTime(20);
+          await vi.runAllTimersAsync();
+        }
+
+        // The live overlay only ever shows the compact placeholder…
+        expect(overlayCalls.length).toBeGreaterThan(0);
+        expect(overlayCalls.some((s) => s.includes('streaming table'))).toBe(true);
+        // …never the growing table rows (the un-clearable ghost source).
+        expect(overlayCalls.some((s) => s.includes('ROW_11'))).toBe(false);
+        for (const call of overlayCalls) {
+          const nonEmpty = call.split('\n').filter((l) => l.trim().length > 0);
+          expect(nonEmpty.length).toBeLessThanOrEqual(2);
+        }
+
+        // Close the block → the full table commits to scrollback exactly once.
+        vi.useRealTimers();
+        renderer.push('\n\n');
+        await renderer.flush();
+
+        const committed = commitAboveCalls.join('\n');
+        expect(committed).toContain('ROW_0');
+        expect(committed).toContain('ROW_11');
+        expect((committed.match(/ROW_11\b/g) ?? []).length).toBe(1);
+      } finally {
+        vi.useRealTimers();
+        Object.defineProperty(process.stdout, 'columns', { value: prevCols, configurable: true });
+      }
+    });
   });
 
   describe('resize handling', () => {


### PR DESCRIPTION
## Why does this always happen to the tables?

Because a markdown **table is the one multi-line block with no internal `\n\n` boundary.** The streaming renderer commits blocks at paragraph breaks and keeps the in-progress tail block in an **ephemeral live overlay** that it repaints on every chunk. Prose and lists hit a `\n\n` and commit quickly; a table's rows are consecutive single-`\n` lines, so the *entire growing table* sits in the pending buffer and is re-rendered into the overlay every chunk until a trailing blank line finally commits it.

Once that growing table exceeds the terminal viewport height, the overlay's clear can't keep up: `CupFrameRenderer` erases by **absolute cursor row** (`cup(row) + ERASE_LINE`), so rows that have scrolled past the top of the viewport into scrollback are unreachable. They stay on screen as **ghost tail rows** next to the final committed table — exactly the duplicated bottom-rows artifact in the report.

## Root cause (verified against source)

`formatPendingBuffer` (`src/cli/markdown-stream-format.ts`) already special-cases an **open code fence** — it renders a compact `▍ streaming code…` placeholder precisely to avoid painting tall content into the overlay. Tables had no equivalent guard, so they fell through to a full `renderTextBlock`.

- `push()` keeps the whole table in `this.buffer` (no `\n\n` → `findBlockBoundary` returns `-1`).
- Each chunk → `scheduleRepaint()` → `renderPending()` → `formatPendingBuffer()` → full table painted into the overlay.
- Overflowed rows scroll into un-clearable scrollback → ghosts.

The commit path itself is correct — `push()` slices the buffer *before* `commitBlock`, and `flush()` clears the overlay *before* committing — so committed output was never the problem; the **live preview** was.

## Fix

Mirror the open-code-fence guard: add `isInOpenTable()` (detects a GFM delimiter row) and, when the pending buffer contains an in-progress table, render a fixed-height `▍ streaming table…` placeholder instead of the growing table. The full table still renders **once** at commit via `formatBlockForCommit` — committed scrollback is byte-for-byte unchanged. The overlay can no longer outgrow the viewport, so no ghost rows.

Net: a guard branch + a small pure detector. No behavior change to committed output, code, prose, or lists.

## Tests

- `src/cli/markdown-stream-format.test.ts` (new) — `isInOpenTable` truth table (delimiter rows, alignment colons, no-outer-pipe rows; rejects HRs, setext underlines, stray-pipe prose, lone header rows) + `formatPendingBuffer` placeholder behavior, including **code-fence precedence over table**.
- `src/cli/markdown-stream.test.ts` — end-to-end regression: streams a tall table through the compositor and asserts the overlay only ever shows the placeholder (never the rows, ≤2 lines tall), then that committed scrollback contains the table **exactly once**.

The regression test was verified to **fail without the fix** (overlay renders the full table → `ROW_11` leaks into the overlay and the placeholder is absent).

## Verification

- `pnpm lint` ✓
- `pnpm build` ✓
- `pnpm test` ✓ (452 files, 8344 passed, 12 skipped)
- `pnpm audit:env:check` / `pnpm scan:env:check` ✓

🤖 Diagnosed and fixed via `/diagnose`.
