### PR TITLE
fix(cli): resolve session credential by session model, not env default

### DIFF
--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -520,7 +520,15 @@ export function registerChatCommand(program: Command): void {
         // the AgentSession.
         session = new AgentSession(injectHotMemory({
           model: sessionModel,
-          apiKey,
+          // Resolve the credential for the ACTUAL session model, not the
+          // env-derived default (`getApiKey()` keys off AFK_MODEL/CLAUDE_MODEL).
+          // Without this, `--model gpt-5.5` while CLAUDE_MODEL is a Claude id
+          // injects the Anthropic OAuth token into the OpenAI provider, which
+          // (a) leaks sk-ant-… to api.openai.com and (b) shadows Codex ChatGPT
+          // OAuth (resolveOpenAIAuth treats a non-empty config key as Tier 1).
+          // getApiKeyForModel routes via providerForModel → correct family
+          // (anti-leak invariant, credential-resolver.ts).
+          apiKey: getApiKeyForModel(sessionModel),
           maxTurns: parseInt(options.maxTurns, 10),
           hookRegistry: createDefaultHookRegistry((info) => {
             console.log(formatSubagentCompletion(info));

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -85,7 +85,13 @@ interface BuildAgentSessionDeps {
 export function buildAgentSession(deps: BuildAgentSessionDeps): AgentSession {
   return new AgentSession(injectHotMemory({
     model: deps.model,
-    apiKey: getApiKey(),
+    // Resolve the credential for the ACTUAL session model, not the env-derived
+    // default. `getApiKey()` keys off AFK_MODEL/CLAUDE_MODEL, so launching
+    // `afk -m gpt-5.5` while CLAUDE_MODEL is a Claude id would inject the
+    // Anthropic OAuth token into the OpenAI provider — leaking sk-ant-… to
+    // OpenAI and shadowing Codex ChatGPT OAuth. getApiKeyForModel routes via
+    // providerForModel → the correct family (anti-leak invariant).
+    apiKey: getApiKeyForModel(deps.model),
     maxTurns: deps.maxTurns,
     hookRegistry: deps.hookRegistry,
     ...(deps.systemPrompt !== undefined ? { systemPrompt: deps.systemPrompt } : {}),


### PR DESCRIPTION
## Summary

Fixes a credential cross-leak in the top-level CLI surfaces: the AgentSession was always handed `getApiKey()` as its `apiKey`, but `getApiKey()` resolves the credential from `env.AFK_MODEL ?? env.CLAUDE_MODEL` — the **environment** model — not the `--model` flag / actual session model.

When `CLAUDE_MODEL` is a Claude id (the common default) but the session runs an OpenAI-routed model (`afk chat --model gpt-5.5`, `afk -m gpt-5.5`), the Anthropic OAuth token (`sk-ant-…`) was passed to the OpenAI provider as `config.apiKey`, which:

1. **Transmits the Anthropic credential to `api.openai.com`** (rejected with 401, but it leaves the machine).
2. **Shadows Codex ChatGPT OAuth** — `resolveOpenAIAuth` treats any non-empty config key as Tier 1 (`'config'`) and early-returns, so the `~/.codex/auth.json` OAuth tier is never reached. This is why `--model gpt-5.5` 404'd / 401'd even with a valid Codex OAuth token present.

## Changes

- `src/cli/commands/chat.ts` (one-shot): session `apiKey` → `getApiKeyForModel(sessionModel)`.
- `src/cli/commands/interactive/bootstrap.ts` (REPL): `buildAgentSession` `apiKey` → `getApiKeyForModel(deps.model)`.

Both route through `providerForModel` → the correct credential family (the PR #640 anti-leak resolver in `credential-resolver.ts`).

## Non-regression

- **Anthropic:** for a Claude session model, `getApiKeyForModel(claudeModel)` returns the same credential `getApiKey()` did. Default Claude usage unchanged.
- **OpenAI with no key:** returns `undefined`, so `resolveOpenAIAuth` falls through to Codex ChatGPT OAuth.

## Verification

| Check | Result |
|---|---|
| `pnpm build` | ✅ |
| `pnpm lint` (strict tsc) | ✅ |
| `pnpm test` (credential-resolver, child-credential, provider-switch, routing) | ✅ 118 tests |
| Live `afk chat --model gpt-5.5` via Codex OAuth | ✅ no `sk-ant` leak, no 401 |

## Scope notes / follow-ups (not in this PR)

- **Compose path:** `ComposeExecutor` still forwards a single `ctx.apiKey` per node regardless of node model — separate fix (afk-workshop #643, being ported).
- **Manager-level fallback** (`subagent.ts` `config.apiKey || parentApiKey`): keyless OpenAI children under a Claude-resolved parent key can still be re-injected the parent token (#548-class, deferred by #640/#643).
- **ProviderRouter not wired in REPL:** mid-session `/model` cannot cross provider families (separate).
