### PR TITLE
fix(cli): harvest argument-hint flags so /review --post completes

### DIFF
--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -66,7 +66,7 @@ const PINNED_HASHES = {
   // copy of the user-scope /refactor at ~/.afk/skills/.
   refactor: '9cb84710ddf2cf63e1a648460a64656d3f4a9aae8e21753b031556070740c51e',
   research: '10692d77e392cedce928f66cb5dec27dbc2066f48cfc33047820f56506da762a',
-  review: '581a1068ea9e47b4309b3fbf2701ad8ec1de1fb7b5b171bb8b607395fe290033',
+  review: '31a17d8c3bace684b7fce22588d54ce3e95462acdf397fc1673f3590192e0944',
   'shadow-verify':
     '9b1ea7db65485f849ae6dfb9a6f69a102d7ccc6e5230b561dc76ef8c666475f8',
   ship: '95f6410600af55fa9fa0312a48d3eebb37ef18ca98dd73ccba840b7136f83b69',
@@ -272,6 +272,15 @@ const INTENTIONAL_DIFFS: Partial<Record<SkillName, RegExp[]>> = {
     // (Already carried `context: fork` before the flip; allowlisted here for
     // the co-located drift comparison.) See devils-advocate note.
     /^context: fork$/,
+    // argument-hint divergence — bundled-only `--post {github,telegram}` flag.
+    // `/review --post` is an agent-afk dispatch-layer publishing feature (PR #35,
+    // 7830a0f) handled in src/cli/slash/plugin-skills.ts; the upstream
+    // example-plugin review skill has NO --post publisher, so its argument-hint
+    // omits the flag. Anchored on the stable line prefix so it removes the
+    // argument-hint line from BOTH sides (bundled w/ --post, upstream w/o),
+    // leaving the rest of the line guarded. No upstream back-port applies —
+    // the feature does not exist there. (bundled.test.ts workflow option 4.)
+    /^argument-hint: "\[diff\|pr-url\|pr-number/,
   ],
 
   // ground-state — TWO bundled-only frontmatter lines, both allowlisted:

--- a/src/bundled-plugins/awa-bundled/skills/review/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review
 description: "Dispatches parallel dimension agents across a diff, PR (URL or number), commit SHA, branch, staged changes, or patch file — covering security, correctness, api-compat, test-coverage, and perf-observability — synthesizes findings by severity, and emits a merge recommendation. Use when changes are ready for review before merge. Read-only: this skill analyzes and reports only — it never edits files, commits, pushes, comments on a PR, or modifies the PR description."
-argument-hint: "[diff|pr-url|pr-number|commit-sha|branch|--staged|--head] [--light] [--change-type hotfix|feature|refactor|dep-bump|new-service]"
+argument-hint: "[diff|pr-url|pr-number|commit-sha|branch|--staged|--head] [--light] [--change-type hotfix|feature|refactor|dep-bump|new-service] [--post github|telegram]"
 context: fork
 ---
 

--- a/src/cli/slash/_lib/flag-harvest.ts
+++ b/src/cli/slash/_lib/flag-harvest.ts
@@ -106,13 +106,25 @@ export function parseSkillMd(content: string): ParsedSkillMd {
 }
 
 /**
- * One-shot helper: harvest flags from a SKILL.md document. Frontmatter wins;
- * falls back to body extraction. Empty array if neither produced anything.
+ * One-shot helper: harvest flags from a SKILL.md document.
+ *
+ * Precedence (highest first):
+ *   1. An explicit frontmatter `flags:` list — the unambiguous, author-declared
+ *      set. Wins outright when present.
+ *   2. Otherwise, the union of flags scanned from the `argument-hint` frontmatter
+ *      field AND the body. `argument-hint` is a standard Claude Code /
+ *      agentskills.io-compatible field that declares the CLI surface, so flags
+ *      written there (e.g. `[--post github|telegram]`) complete in the REPL
+ *      dropdown without a proprietary `flags:` field. The body is still scanned
+ *      as a legacy fallback for skills that mention flags only in prose.
+ *
+ * Empty array if none produced anything.
  */
 export function harvestFlagsFromSkillMd(content: string): string[] {
   const parsed = parseSkillMd(content);
   if (parsed.frontmatterFlags && parsed.frontmatterFlags.length > 0) {
     return parsed.frontmatterFlags;
   }
-  return extractFlagsFromBody(parsed.body);
+  const argHint = parsed.frontmatter?.['argument-hint'] ?? '';
+  return extractFlagsFromBody(`${argHint}\n${parsed.body}`);
 }

--- a/src/cli/slash/plugin-skills-harvest.test.ts
+++ b/src/cli/slash/plugin-skills-harvest.test.ts
@@ -133,6 +133,65 @@ flags: [--x, --y]
     expect(result.get('inline-flags')).toEqual(['--x', '--y']);
   });
 
+  it('harvests flags from the argument-hint frontmatter field', () => {
+    // argument-hint is the standard Claude Code / agentskills.io-compatible
+    // field for declaring the CLI surface. Flags written there must complete
+    // in the dropdown without a proprietary `flags:` field. Regression guard
+    // for /review --post (PR #35), which lived only in the dispatch layer.
+    mkdirSync(join(tmpRoot, 'plugins', 'test-plugin', 'skills', 'review'), { recursive: true });
+    writeFileSync(
+      join(tmpRoot, 'plugins', 'test-plugin', 'skills', 'review', 'SKILL.md'),
+      `---
+name: review
+description: Review changes
+argument-hint: "[--staged|--head] [--post github|telegram]"
+---
+
+# Review skill body with no flag mentions.
+`,
+    );
+
+    const result = harvestPluginSkillFlags(tmpRoot);
+    expect(result.get('review')).toEqual(['--head', '--post', '--staged']); // sorted
+  });
+
+  it('unions argument-hint flags with body flags (no frontmatter flags:)', () => {
+    mkdirSync(join(tmpRoot, 'plugins', 'test-plugin', 'skills', 'merged'), { recursive: true });
+    writeFileSync(
+      join(tmpRoot, 'plugins', 'test-plugin', 'skills', 'merged', 'SKILL.md'),
+      `---
+name: merged
+description: Test skill
+argument-hint: "[--post github|telegram]"
+---
+
+Add --verify to trigger the extra wave.
+`,
+    );
+
+    const result = harvestPluginSkillFlags(tmpRoot);
+    expect(result.get('merged')).toEqual(['--post', '--verify']); // argHint ∪ body, sorted
+  });
+
+  it('frontmatter flags: still wins over argument-hint', () => {
+    mkdirSync(join(tmpRoot, 'plugins', 'test-plugin', 'skills', 'explicit'), { recursive: true });
+    writeFileSync(
+      join(tmpRoot, 'plugins', 'test-plugin', 'skills', 'explicit', 'SKILL.md'),
+      `---
+name: explicit
+description: Test skill
+flags: [--only-this]
+argument-hint: "[--ignored-hint]"
+---
+
+Body mentions --also-ignored.
+`,
+    );
+
+    const result = harvestPluginSkillFlags(tmpRoot);
+    expect(result.get('explicit')).toEqual(['--only-this']);
+  });
+
   it('parses block-form frontmatter flags', () => {
     mkdirSync(join(tmpRoot, 'plugins', 'test-plugin', 'skills', 'block-flags'), {
       recursive: true,

--- a/src/cli/slash/plugin-skills.ts
+++ b/src/cli/slash/plugin-skills.ts
@@ -45,7 +45,7 @@ import {
   formatPluginVersion,
   type InstalledPlugin,
 } from '../../agent/plugins/inventory.js';
-import { getMarketplaceCacheDir } from '../../paths.js';
+import { getMarketplaceCacheDir, getBundledPluginsDir } from '../../paths.js';
 import { listSkills, getSkill, isSkillVisible, listVisibleSkills, type SkillMetadata } from '../../skills/index.js';
 import { palette } from '../palette.js';
 import { divider } from '../render.js';
@@ -54,11 +54,7 @@ import { getTerminalWidth } from '../terminal-size.js';
 import { padDisplayRight, displayWidth } from '../display.js';
 import { registerPluginAgents } from './plugin-agents.js';
 import { registerOrReplace, register } from './registry.js';
-import {
-  extractFlagsFromBody,
-  parseSkillMd,
-  type ParsedSkillMd,
-} from './_lib/flag-harvest.js';
+import { harvestFlagsFromSkillMd } from './_lib/flag-harvest.js';
 import { runSkillDispatchTurn } from './_lib/run-skill-dispatch-turn.js';
 import { parsePostFlag, runReviewPostPublish, type PostTarget } from './_lib/review-post.js';
 import { parsePrRef } from './preflight/review-pr.js';
@@ -164,11 +160,7 @@ export function harvestPluginSkillFlags(cacheRoot?: string): Map<string, string[
       const skillName = pathParts[pathParts.length - 2];
       if (!skillName) continue;
 
-      const parsed: ParsedSkillMd = parseSkillMd(content);
-      const flags =
-        parsed.frontmatterFlags && parsed.frontmatterFlags.length > 0
-          ? parsed.frontmatterFlags
-          : extractFlagsFromBody(parsed.body);
+      const flags = harvestFlagsFromSkillMd(content);
 
       if (flags.length === 0) continue;
 
@@ -180,6 +172,27 @@ export function harvestPluginSkillFlags(cacheRoot?: string): Map<string, string[
 
   walk(root, 0);
   return result;
+}
+
+/**
+ * Harvest flags from BOTH the marketplace cache AND the bundled-plugins dir,
+ * merging per-skill (union, deduped, sorted).
+ *
+ * Why both: `session.supportedCommands()` surfaces bundled skills (e.g. the
+ * `awa-bundled` /review), but a plugin skill's flags live only in its SKILL.md
+ * and the plain `harvestPluginSkillFlags()` walks only the cache. Without the
+ * bundled-dir pass, a bundled-only skill gets NO flag completion in the
+ * dropdown even though its argument-hint declares flags. Walking both keeps the
+ * completion set consistent regardless of whether a skill is installed
+ * (cache) or shipped (bundled).
+ */
+function harvestAllPluginSkillFlags(): Map<string, string[]> {
+  const merged = harvestPluginSkillFlags();
+  for (const [name, flags] of harvestPluginSkillFlags(getBundledPluginsDir())) {
+    const existing = merged.get(name) ?? [];
+    merged.set(name, Array.from(new Set([...existing, ...flags])).sort());
+  }
+  return merged;
 }
 
 /**
@@ -651,7 +664,7 @@ function renderSkillDetail(
     }
   }
 
-  const flags = registrySkill?.flags ?? harvestPluginSkillFlags().get(cleaned);
+  const flags = registrySkill?.flags ?? harvestAllPluginSkillFlags().get(cleaned);
   if (flags && flags.length > 0) {
     ctx.out.line();
     ctx.out.line(`  ${palette.bold('Flags')}  ${palette.dim(flags.join(', '))}`);
@@ -757,7 +770,7 @@ export async function registerPluginSkills(
     ...(c.argumentHint ? { argumentHint: c.argumentHint } : {}),
   }));
 
-  const harvestedFlags = harvestPluginSkillFlags();
+  const harvestedFlags = harvestAllPluginSkillFlags();
   // Reserved names = registry skills that are ACTUALLY VISIBLE at the
   // current tier. Internal-tier skills (forge, audit-fit) that are hidden
   // by the audience gate don't reserve their slash — otherwise a plugin


### PR DESCRIPTION
## Summary

Fixes the REPL slash-command dropdown never offering `/review --post`. The cause was two-layered: `--post` (added in #35 at the dispatch layer only) was absent from the review `SKILL.md`, **and** the flag harvester only body-scraped the marketplace cache — it never read the `argument-hint` frontmatter field and never walked the bundled-plugins dir, so bundled-only skills got no flag completion at all.

- **`flag-harvest.ts`** — `harvestFlagsFromSkillMd` now unions flags from the standard `argument-hint` field with body-scraped flags (explicit frontmatter `flags:` still wins). Chosen over a proprietary `flags:` key for **agentskills.io / Claude Code compatibility** — neither spec defines a `flags` field, whereas `argument-hint` is a recognized Claude Code frontmatter field (autocomplete hint).
- **`plugin-skills.ts`** — collapsed the duplicated precedence logic into the shared helper; added `harvestAllPluginSkillFlags()` which merges the marketplace cache **and** the bundled-plugins dir; both consumer sites use it.
- **`review/SKILL.md`** — added `[--post github|telegram]` to `argument-hint`.
- **`bundled.test.ts`** — bumped the `review` pinned hash + documented an `INTENTIONAL_DIFFS['review']` allowlist (`--post` is agent-afk-only; no upstream example-plugin counterpart, so it is a legitimately bundled-only divergence).
- Side win: `--light` / `--change-type` (previously argument-hint-only) now complete too.

## Test results

- `pnpm lint` (tsc --noEmit, strict): **pass**
- `pnpm test`: **8544 passed | 12 skipped | 2 failed** (456 files). The 2 failures are **pre-existing and unrelated** — see Verification.
- Targeted: `plugin-skills-harvest.test.ts` (incl. 3 new argument-hint tests), `bundled.test.ts`, and the slash/skills/plugin suites — all green.
- End-to-end: harvesting the real bundled `review/SKILL.md` returns `--post`.

## Verification

Adversarial verification ran via `/shadow-verify` — 3 independent verifiers, each given only the claim (not the implementation reasoning):

- **Fix surfaces `--post` end-to-end** — AGREE. Traced `SKILL.md` -> harvester -> trigger detection -> candidate filter; confirmed `pnpm build` copies the bundled `SKILL.md` into `dist/`.
- **agentskills.io / Claude Code compatibility** — AGREE. Fresh fetch of both specs: neither defines a `flags` field; `argument-hint` is a documented Claude Code field.
- **No regression / test integrity** — AGREE. `flags:` precedence preserved; the review pinned hash matches the file byte-for-byte; the only suite failures are pre-existing.

**Pre-existing failures (NOT introduced here):** `src/agent/providers/openai-compatible/query.test.ts` (auth-failure path) and `src/cli/commands/provider.test.ts` (`buildProviderAuthDiagnose`). Both are env-dependent (no `OPENAI_API_KEY`), fail identically on the clean base (`git stash` -> both still fail), and have zero import link to the flag-harvest / slash layer this PR touches.

## Out of scope

- The installed `awa-private` plugin copy (private repo) still lacks `--post` in its argument-hint — a separate parity port if the private mirror should match.
- Residual body-scrape noise: `/review` still surfaces `--json` / `--no-heading` from shell examples in the SKILL.md body (pre-existing). Fully de-noising would require making `argument-hint` authoritative, which would drop `--verify` (body-only) — deferred.
