### PR TITLE
fix(cli): re-pin committed band on overlay collapse to kill the blank-space gap

### DIFF
--- a/src/cli/terminal-compositor.commit-collapse-wrap-gap.test.ts
+++ b/src/cli/terminal-compositor.commit-collapse-wrap-gap.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression (big-gap.txt): the "massive blank space". A long streamed line is
+ * committed while a tall overlay (status footer + spinner + streaming preview)
+ * FILLS the viewport, then the overlay collapses. The committed line must be
+ * re-pinned hugging the live frame on collapse — not dropped, leaving a run of
+ * ~N shrink-pad blank rows between the transcript and the frame.
+ *
+ * Root cause: when the frame fills the viewport (desiredTopRow ≤ 1) commitAbove
+ * had nowhere to paint the block (newTopRow ≤ 1) and DROPPED it from the band
+ * (clearCommittedBand) — the block lived only in scrollback. On collapse
+ * repositionCommittedBand found an empty band and re-pinned nothing, so
+ * CupFrameRenderer's shrink-pad blank rows stayed blank (the gap). The wrap-
+ * blind logical line count (a7ace49 / #39 follow-up) compounded it by under-
+ * scrolling the wrapped block.
+ *
+ * Fix: commitAbove PARKS the block in `coveredBand` instead of dropping it;
+ * repositionCommittedBand PROMOTES it back adjacent to the frame on collapse.
+ * commitAbove's lineCount is now physical (wrap-aware) so the scroll/anchor math
+ * matches the wrapped screen.
+ *
+ * HARD GATE: pre-fix the committed WRAPMARK line is ABSENT from the collapsed
+ * viewport (dropped) and a tall blank gap sits above the frame. Post-fix the
+ * line is present, single-copy, and hugs the frame.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { StatusLine } from './status-line.js';
+import { LoopStageBar } from './commands/interactive/loop-stage.js';
+
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin = NodeJS.ReadStream & { isTTY: boolean; isRaw: boolean; setRawMode: ReturnType<typeof vi.fn> };
+
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true; s.columns = cols; s.rows = rows; return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true; s.isRaw = false; s.setRawMode = vi.fn((r: boolean) => { s.isRaw = r; return s; }); return s;
+}
+function collect(stream: MockStdout): () => string { const c: string[] = []; stream.on('data', (x) => c.push(String(x))); return () => c.join(''); }
+function termWrite(t: HeadlessTerminal, d: string): Promise<void> { return new Promise((r) => t.write(d, r)); }
+function lines(t: HeadlessTerminal): string[] {
+  const b = t.buffer.active; const o: string[] = [];
+  for (let i = 0; i < b.length; i++) { const l = b.getLine(i); if (l) o.push(l.translateToString(true)); }
+  return o;
+}
+function wireFooter(stdout: MockStdout): { statusLine: StatusLine; loopStageBar: LoopStageBar } {
+  const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+  statusLine.start();
+  statusLine.repaint({ model: 'STATUSMODELXYZ', cost: 0, tokens: 0, contextPct: 0 });
+  const loopStageBar = new LoopStageBar({ getExtraRows: () => statusLine.getExtraRows(), stream: stdout });
+  loopStageBar.setRowCountChangeHandler(() => statusLine.setExtraRows(1));
+  statusLine.setAfterScrollRestore(() => loopStageBar.redraw());
+  loopStageBar.start();
+  return { statusLine, loopStageBar };
+}
+
+const COLS = 120, ROWS = 24;
+const SPINNER_RE = /[\u2800-\u28ff]/; // braille spinner glyph row (the live frame)
+
+describe('commit-under-full-overlay → collapse gap regression (big-gap.txt)', () => {
+  it('re-pins the committed wrapping line hugging the frame after the overlay collapses', async () => {
+    const stdout = makeStdout(COLS, ROWS);
+    const stdin = makeStdin();
+    const all = collect(stdout);
+    const { statusLine, loopStageBar } = wireFooter(stdout);
+
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1 });
+    await c.arm();
+    const internals = c as unknown as { repaint(): void };
+
+    c.setSpinner({ enabled: true });
+    // Prior transcript already committed.
+    c.commitAbove('PRIOR_TRANSCRIPT_LINE\n');
+    // A tall overlay (streaming preview) fills the viewport — desiredTopRow ≤ 1.
+    c.setOverlay(Array.from({ length: ROWS - 1 }, (_, i) => `streaming preview row ${i}`).join('\n'));
+    // The model commits a long assistant line WHILE the overlay fills the screen.
+    // One logical line that soft-wraps to 2 physical rows (the capture's shape).
+    c.commitAbove('WRAPMARK_assistant_line_' + 'x'.repeat(COLS + 25) + '\n');
+    // Overlay collapses back to idle (turn settles, preview clears).
+    c.setOverlay('');
+    internals.repaint();
+    internals.repaint();
+
+    const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 400, allowProposedApi: true, convertEol: true });
+    await termWrite(term, all());
+    const ls = lines(term);
+    const vStart = Math.max(0, ls.length - ROWS);
+    const view = ls.slice(vStart);
+    const dump = view.map((l, i) => `[${String(vStart + i).padStart(2)}] ${JSON.stringify(l.slice(0, 56))}`).join('\n');
+
+    const markerIdxs = view
+      .map((l, i) => (l.includes('WRAPMARK_assistant_line_') ? i : -1))
+      .filter((i) => i >= 0);
+    const frameIdx = view.findIndex((l) => SPINNER_RE.test(l));
+
+    expect(frameIdx, `frame (spinner) not found in viewport:\n${dump}`).toBeGreaterThanOrEqual(0);
+
+    // (a) PRESENT + SINGLE-COPY: the committed line survives the collapse exactly
+    //     once. Pre-fix it is dropped (0 occurrences) — the gap bug.
+    expect(
+      markerIdxs.length,
+      `committed line must appear exactly once after collapse (0 = dropped/gap bug, >1 = duplicate):\n${dump}`,
+    ).toBe(1);
+
+    // (b) HUGS THE FRAME: the committed line sits immediately above the live
+    //     frame — no blank gap between transcript and frame. (markerIdx is the
+    //     line's first physical row; its soft-wrap continuation is the row just
+    //     below, so the frame is ≤2 rows under the marker.)
+    const markerIdx = markerIdxs[0]!;
+    expect(
+      frameIdx - markerIdx,
+      `committed line does not hug the frame (marker=${markerIdx}, frame=${frameIdx}) — blank gap between:\n${dump}`,
+    ).toBeLessThanOrEqual(2);
+    expect(markerIdx, `committed line should be above the frame:\n${dump}`).toBeLessThan(frameIdx);
+
+    // Single status row still holds (no double-statusline regression).
+    expect(ls.filter((l) => l.includes('STATUSMODELXYZ')).length, `status row not single:\n${dump}`).toBe(1);
+
+    term.dispose(); loopStageBar.stop(); statusLine.stop(); c.disarm();
+  }, 15_000);
+});

--- a/src/cli/terminal-compositor.committed-band.ts
+++ b/src/cli/terminal-compositor.committed-band.ts
@@ -30,6 +30,9 @@ export interface CommittedBandHost {
   committedBand: string[];
   committedBandTopRow: number;
   committedBandBottomRow: number;
+  /** Most-recent committed block covered by a full-viewport frame, awaiting
+   *  re-pin on the next collapse (see {@link repositionCommittedBand}). */
+  coveredBand: string[];
   /** Re-entrancy guard: suppresses a repaint during the clear→write window. */
   committing: boolean;
   /** Suppresses the shrink re-pin (repositionCommittedBand) for a commit. */
@@ -103,7 +106,20 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   const rows = Math.max(1, self.stdout.rows ?? 24);
   const stripped = text.endsWith('\n') ? text.slice(0, -1) : text;
   const newlineCount = (stripped.match(/\n/g)?.length ?? 0);
-  const lineCount = Math.max(1, newlineCount + 1);
+  const logicalLineCount = Math.max(1, newlineCount + 1);
+  // Physical (wrap-aware) row count. A committed line wider than the terminal
+  // soft-wraps to >1 physical row, so the LOGICAL count (newlines+1) under-counts
+  // the rows the block actually occupies. That under-count made Phase 1 scroll too
+  // few rows (LF×lineCount) — stranding wrapped overflow rows on screen — and
+  // mis-sized fitsAboveFrame / bandOverflow. Mirror the frame side (a7ace49 / #39),
+  // which derives its geometry from CupFrameRenderer.measure()'s physical row count
+  // via the shared wrapToPhysicalLines helper; reuse the same measure() here so the
+  // band and frame can't drift. (a7ace49 flagged this site as the tracked follow-up:
+  // "commitAbove()'s lineCount is still logical — a separate wrap-blind site.")
+  // Logical fallback for stubs without measure().
+  const lineCount = self.logUpdate.measure
+    ? Math.max(1, self.logUpdate.measure(stripped, rows).lineCount)
+    : logicalLineCount;
   const textLines = stripped.split('\n');
 
   // Decide where the committed text is written so it lands in scrollback
@@ -364,13 +380,28 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
       self.committedBand = capped;
       self.committedBandBottomRow = newTopRow - 1;
       self.committedBandTopRow = bandTop;
+      // An on-screen band is now authoritative — any previously covered block is
+      // stale (this commit supersedes it).
+      self.coveredBand = [];
     } else {
       clearCommittedBand(self);
     }
   } else {
-    // No above-frame area (frame fills the viewport, or nothing rendered yet):
-    // the committed text lives only in scrollback — nothing to re-pin.
+    // No above-frame area: the frame fills the viewport (newTopRow ≤ 1) or
+    // nothing has rendered yet. The block is already in scrollback (Phase 1's
+    // overflow archive). Rather than DROP it, PARK it in coveredBand so the
+    // moment the overlay collapses repositionCommittedBand re-pins it adjacent
+    // to the frame — without this the band is empty on collapse and
+    // CupFrameRenderer shrink-pads blank rows nothing refills (the "massive
+    // blank gap" in big-gap.txt). Cap to the viewport height; the re-pin caps
+    // again to the real above-frame room. clearCommittedBand() resets coveredBand
+    // first, so set it AFTER. (newTopRow ≤ 1 ⇒ nothing rendered yet has no block
+    // to park — textLines is the just-committed content either way.)
     clearCommittedBand(self);
+    if (newTopRow <= 1 && textLines.length > 0) {
+      const cap = Math.max(1, rows - 1);
+      self.coveredBand = textLines.length > cap ? textLines.slice(textLines.length - cap) : textLines;
+    }
   }
   self.commitInFlight = false;
   self.debugLog('commitAbove:phase3:done');
@@ -380,6 +411,12 @@ export function clearCommittedBand(self: CommittedBandHost): void {
   self.committedBand = [];
   self.committedBandTopRow = 0;
   self.committedBandBottomRow = 0;
+  // Drop any covered-but-retained content too: every clear path (disarm, /clear,
+  // resetCommittedBand, fits-path empties) means there is no longer a band to
+  // re-pin, so a stale coveredBand must not resurrect old transcript on the next
+  // shrink. Sites that intentionally PARK content in coveredBand set it AFTER
+  // calling this (commitAbove's full-viewport branch).
+  self.coveredBand = [];
 }
 
 /**
@@ -464,9 +501,27 @@ export function repositionCommittedBand(
   preRenderFrameTop: number,
   targetBottomRow: number,
 ): void {
-  if (self.commitInFlight || !self.logUpdate || self.committedBand.length === 0) return;
+  if (self.commitInFlight || !self.logUpdate) return;
   const floor = Math.max(self.anchorRow ?? 1, 1);
   const targetBottom = desiredTopRow - 1;
+  // Promote covered content the moment the frame shrinks enough to show it. A
+  // full-viewport frame (newTopRow ≤ 1) parked the most-recent block in
+  // coveredBand (commitAbove) instead of dropping it; re-pin it now adjacent to
+  // the new frame top so the collapse shows it hugging the frame rather than a
+  // run of shrink-pad blank rows (the "massive blank gap"). While the frame
+  // still fills the viewport (targetBottom < floor) this is a no-op and the
+  // block stays parked. The block is already in scrollback (Phase 1 archive), so
+  // the only cost of the re-pin is an off-screen scrollback copy (no-gap default).
+  if (self.committedBand.length === 0 && self.coveredBand.length > 0 && targetBottom >= floor) {
+    self.committedBand = self.coveredBand;
+    self.coveredBand = [];
+    // Treat the promoted band as having occupied the just-erased covered frame
+    // footprint so renderErasedBand fires and it paints at the position the fit
+    // math computes below (committedBandTopRow = 1 also makes `moved` true).
+    self.committedBandTopRow = 1;
+    self.committedBandBottomRow = Math.max(1, preRenderFrameTop, targetBottom);
+  }
+  if (self.committedBand.length === 0) return;
   // On upward growth (targetBottom < committedBandBottomRow) the band must be
   // re-pinned above the NEW frame top: preserveRowsBeforeFrameRender either
   // left the whole band in place (it fits) or already scrolled the overflow

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -275,6 +275,17 @@ export class TerminalCompositor {
   committedBandTopRow = 0;
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   committedBandBottomRow = 0;
+  // Content COVERED by a full-viewport frame (desiredTopRow ≤ 1) rather than
+  // displayed: when the overlay fills the screen there is no above-frame row to
+  // show the committed band, but the overlay is transient. Stashing the most-
+  // recent committed block here (instead of dropping it) lets
+  // repositionCommittedBand re-pin it adjacent to the frame the moment the
+  // overlay collapses — otherwise the band is empty on collapse and
+  // CupFrameRenderer shrink-pads blank rows that nothing refills (the "massive
+  // blank gap"). Invalidated whenever an on-screen band is (re-)established or
+  // the band is reset (clearCommittedBand). See repositionCommittedBand().
+  /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
+  coveredBand: string[] = [];
 
   // Resize ghost-erase state. On SIGWINCH the immediate handler snapshots the
   // pre-resize on-screen footprint of the compositor (old live-frame rows +


### PR DESCRIPTION
## Summary

Fixes the **"massive blank space"** in the interactive REPL (reported from `big-gap.txt`): when a long streamed line is committed while a tall overlay (status footer + spinner + streaming preview) **fills the viewport**, then the overlay collapses, ~19 blank rows opened between the transcript and the live frame and the committed line vanished.

**Root cause** — a committed-band wrap/eviction gap, the half left behind by #39 (a7ace49):

- When the frame fills the viewport (`desiredTopRow <= 1` => `newTopRow <= 1` in `commitAbove`), there is no above-frame row to paint the block, so `commitAbove` **dropped it** from the band (`clearCommittedBand`) — it lived only in scrollback.
- On collapse, `repositionCommittedBand` found an **empty band** and re-pinned nothing, so `CupFrameRenderer`'s shrink-pad left blank rows that nothing refilled — the gap.
- The wrap-blind **logical** line count compounded it (a committed line wider than the terminal under-counts its physical rows).

**Fix:**

1. `commitAbove` now **PARKS** the most-recent block in a new `coveredBand` (capped to the viewport) instead of dropping it when the frame fills the viewport; `repositionCommittedBand` **PROMOTES** it back adjacent to the frame the moment the overlay collapses (`targetBottom >= floor`). The block is already in scrollback (Phase-1 archive), so the only cost of the re-pin is an off-screen scrollback copy (no-gap default). `coveredBand` is invalidated whenever an on-screen band is (re-)established or the band is reset (`clearCommittedBand` clears it), so a stale block can never resurrect old transcript.
2. `commitAbove`'s `lineCount` is now **wrap-aware** (physical rows via `CupFrameRenderer.measure()`, the same shared helper the frame side uses) — the follow-up #39's commit message explicitly tracked: *"commitAbove()'s lineCount is still logical — a separate wrap-blind site, tracked for a follow-up."*

## How was this tested?

- **New regression test** `terminal-compositor.commit-collapse-wrap-gap.test.ts` (`@xterm/headless`, real `StatusLine` + `LoopStageBar` footer wiring): commits a wrapping line under a viewport-filling overlay, collapses it, and asserts the line is **present, single-copy, and hugging the frame**. Verified **RED on baseline** (line absent — the gap bug) then **GREEN** with the fix.
- `pnpm lint` (`tsc --noEmit`) — **clean**.
- Full `terminal-compositor` + `cup-frame-renderer` suite — **272 pass** (271 prior + the new test), including the `shrink-gap` / `wrap-gap` / `multi-commit-gap` / `footer-ghost` / `splice` / `resize-ghost` / `clear-band-reset` regressions.
- Full `pnpm test`: 8542 pass, **2 failures in `src/cli/commands/provider.test.ts` + `src/agent/providers/openai-compatible/query.test.ts` that are PRE-EXISTING and unrelated** (provider/auth resolution) — confirmed failing identically on `main` (`109a815`) with this branch stashed. No rendering code imports those paths.

### Scope note

Deliberately scoped to the captured gap + the #39 follow-up. An unrelated overflow-path Phase-3 anchor desync I noticed turned out to be byte-identical in all reachable states (the overflow frame can't shrink mid-`commitAbove`), so it's left out to keep the diff motivated.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (except 2 pre-existing, unrelated provider/auth failures present on `main`)
- [x] Commits are signed off (`git commit -s`) per the DCO
- [x] No secrets, tokens, or private paths in the diff
