### PR TITLE
fix(browser): unblock native browser tools in the bundled ESM binary

### DIFF
--- a/src/agent/tools/handlers/browser-act.ts
+++ b/src/agent/tools/handlers/browser-act.ts
@@ -29,7 +29,7 @@ import { env } from '../../../config/env.js';
 // helpers (truncateTargetText, hashSelector) are imported and called so the
 // logic is in place for when browser_event emission is wired.
 
-const PLAYWRIGHT_MISSING_HINTS = ['Cannot find package', 'ERR_MODULE_NOT_FOUND'];
+import { isPlaywrightMissing, playwrightMissingHint } from './playwright-hints.js';
 
 const VALID_ACTIONS: readonly ActAction[] = [
   'click', 'fill', 'press', 'select', 'hover', 'scroll_to', 'wait_for',
@@ -200,13 +200,8 @@ export function createBrowserActHandler(opts: BrowserHandlerOptions = {}): ToolH
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (PLAYWRIGHT_MISSING_HINTS.some((hint) => msg.includes(hint))) {
-        return {
-          content:
-            'browser tools require the optional `playwright` peer dependency. ' +
-            'Install via: pnpm add playwright. Or pick a different tool.',
-          isError: true,
-        };
+      if (isPlaywrightMissing(msg)) {
+        return { content: playwrightMissingHint(msg), isError: true };
       }
       return { content: `browser_act failed to get provider: ${msg}`, isError: true };
     }

--- a/src/agent/tools/handlers/browser-close.ts
+++ b/src/agent/tools/handlers/browser-close.ts
@@ -17,7 +17,7 @@ import { env } from '../../../config/env.js';
 // History: browser_event witness emission is a no-op in this handler.
 // See browser-open.ts for the full rationale.
 
-const PLAYWRIGHT_MISSING_HINTS = ['Cannot find package', 'ERR_MODULE_NOT_FOUND'];
+import { isPlaywrightMissing, playwrightMissingHint } from './playwright-hints.js';
 
 export function createBrowserCloseHandler(opts: BrowserHandlerOptions = {}): ToolHandler {
   return async (_input, signal) => {
@@ -46,13 +46,8 @@ export function createBrowserCloseHandler(opts: BrowserHandlerOptions = {}): Too
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (PLAYWRIGHT_MISSING_HINTS.some((hint) => msg.includes(hint))) {
-        return {
-          content:
-            'browser tools require the optional `playwright` peer dependency. ' +
-            'Install via: pnpm add playwright. Or pick a different tool.',
-          isError: true,
-        };
+      if (isPlaywrightMissing(msg)) {
+        return { content: playwrightMissingHint(msg), isError: true };
       }
       return { content: `browser_close failed to get provider: ${msg}`, isError: true };
     }

--- a/src/agent/tools/handlers/browser-observe.ts
+++ b/src/agent/tools/handlers/browser-observe.ts
@@ -23,7 +23,7 @@ import { env } from '../../../config/env.js';
 // dispatcher already emits surrounding tool_call events; browser_event
 // wiring is deferred to a follow-up PR.
 
-const PLAYWRIGHT_MISSING_HINTS = ['Cannot find package', 'ERR_MODULE_NOT_FOUND'];
+import { isPlaywrightMissing, playwrightMissingHint } from './playwright-hints.js';
 
 interface ParsedObserveInput {
   screenshot?: boolean;
@@ -103,13 +103,8 @@ export function createBrowserObserveHandler(opts: BrowserHandlerOptions = {}): T
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (PLAYWRIGHT_MISSING_HINTS.some((hint) => msg.includes(hint))) {
-        return {
-          content:
-            'browser tools require the optional `playwright` peer dependency. ' +
-            'Install via: pnpm add playwright. Or pick a different tool.',
-          isError: true,
-        };
+      if (isPlaywrightMissing(msg)) {
+        return { content: playwrightMissingHint(msg), isError: true };
       }
       return { content: `browser_observe failed to get provider: ${msg}`, isError: true };
     }

--- a/src/agent/tools/handlers/browser-open.ts
+++ b/src/agent/tools/handlers/browser-open.ts
@@ -28,7 +28,7 @@ import { env } from '../../../config/env.js';
 // semantic layer. Until then, browser_event emission lives in the dispatcher
 // tier, not in these handlers. See design doc: design-native-browser-control.
 
-const PLAYWRIGHT_MISSING_HINTS = ['Cannot find package', 'ERR_MODULE_NOT_FOUND'];
+import { isPlaywrightMissing, playwrightMissingHint } from './playwright-hints.js';
 
 type WaitForOption = 'load' | 'domcontentloaded' | 'networkidle';
 
@@ -130,13 +130,8 @@ export function createBrowserOpenHandler(opts: BrowserHandlerOptions = {}): Tool
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (PLAYWRIGHT_MISSING_HINTS.some((hint) => msg.includes(hint))) {
-        return {
-          content:
-            'browser tools require the optional `playwright` peer dependency. ' +
-            'Install via: pnpm add playwright. Or pick a different tool.',
-          isError: true,
-        };
+      if (isPlaywrightMissing(msg)) {
+        return { content: playwrightMissingHint(msg), isError: true };
       }
       return { content: `browser_open failed to get provider: ${msg}`, isError: true };
     }

--- a/src/agent/tools/handlers/browser-screenshot.ts
+++ b/src/agent/tools/handlers/browser-screenshot.ts
@@ -24,7 +24,7 @@ import { env } from '../../../config/env.js';
 // History: browser_event witness emission is a no-op in this handler.
 // See browser-open.ts for the full rationale.
 
-const PLAYWRIGHT_MISSING_HINTS = ['Cannot find package', 'ERR_MODULE_NOT_FOUND'];
+import { isPlaywrightMissing, playwrightMissingHint } from './playwright-hints.js';
 
 const VALID_TARGET_KINDS = ['semantic', 'element_id', 'selector'] as const;
 
@@ -128,13 +128,8 @@ export function createBrowserScreenshotHandler(opts: BrowserHandlerOptions = {})
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (PLAYWRIGHT_MISSING_HINTS.some((hint) => msg.includes(hint))) {
-        return {
-          content:
-            'browser tools require the optional `playwright` peer dependency. ' +
-            'Install via: pnpm add playwright. Or pick a different tool.',
-          isError: true,
-        };
+      if (isPlaywrightMissing(msg)) {
+        return { content: playwrightMissingHint(msg), isError: true };
       }
       return { content: `browser_screenshot failed to get provider: ${msg}`, isError: true };
     }

--- a/src/agent/tools/handlers/playwright-hints.test.ts
+++ b/src/agent/tools/handlers/playwright-hints.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PLAYWRIGHT_MISSING_HINTS,
+  isPlaywrightMissing,
+  playwrightMissingHint,
+} from './playwright-hints.js';
+
+describe('isPlaywrightMissing', () => {
+  it('matches the package-not-installed signatures', () => {
+    expect(isPlaywrightMissing('Cannot find package playwright')).toBe(true);
+    expect(isPlaywrightMissing('Error [ERR_MODULE_NOT_FOUND]: ...')).toBe(true);
+  });
+
+  it("matches the chromium-binary-missing signature", () => {
+    expect(
+      isPlaywrightMissing("browserType.launch: Executable doesn't exist at /path/chrome"),
+    ).toBe(true);
+  });
+
+  it('does not match unrelated provider errors', () => {
+    expect(isPlaywrightMissing('provider init failed')).toBe(false);
+    expect(isPlaywrightMissing('net::ERR_NAME_NOT_RESOLVED')).toBe(false);
+  });
+
+  it('exposes all three hint substrings', () => {
+    expect(PLAYWRIGHT_MISSING_HINTS).toContain('Cannot find package');
+    expect(PLAYWRIGHT_MISSING_HINTS).toContain('ERR_MODULE_NOT_FOUND');
+    expect(PLAYWRIGHT_MISSING_HINTS).toContain("Executable doesn't exist");
+  });
+});
+
+describe('playwrightMissingHint', () => {
+  it('tells the user to install the package when it is absent', () => {
+    const hint = playwrightMissingHint('Cannot find package playwright');
+    expect(hint).toMatch(/pnpm add playwright/);
+  });
+
+  it('tells the user to install chromium when only the binary is missing', () => {
+    const hint = playwrightMissingHint("Executable doesn't exist at /ms-playwright/chromium/chrome");
+    expect(hint).toMatch(/pnpm exec playwright install chromium/);
+    // Must NOT mis-direct the user to reinstall a package that is already present.
+    expect(hint).not.toMatch(/pnpm add playwright/);
+  });
+});

--- a/src/agent/tools/handlers/playwright-hints.ts
+++ b/src/agent/tools/handlers/playwright-hints.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared Playwright-availability detection + install-hint messaging for the
+ * `browser_*` tool handlers.
+ *
+ * Two distinct failure modes are surfaced with DIFFERENT remedies:
+ *   - the `playwright` package is not installed → `pnpm add playwright`
+ *   - the package is present but the chromium browser binary was never
+ *     downloaded → `pnpm exec playwright install chromium`
+ *
+ * History: the chromium-missing hint ("Executable doesn't exist") lived in
+ * web-scrape.ts but was absent from the five browser_* handlers, so a user who
+ * had `playwright` installed but no chromium binary got an opaque
+ * `... failed to get provider: Executable doesn't exist at ...` error with no
+ * remedy. The hint list was also copy-pasted into all five handlers, so any fix
+ * had to land in five places. Centralizing both the substrings and the message
+ * here keeps them from drifting apart again.
+ *
+ * @module agent/tools/handlers/playwright-hints
+ */
+
+// Substrings in a thrown error message that indicate the optional Playwright
+// peer dependency — or its chromium browser binary — is unavailable.
+export const PLAYWRIGHT_MISSING_HINTS = [
+  'Cannot find package',
+  'ERR_MODULE_NOT_FOUND',
+  "Executable doesn't exist",
+] as const;
+
+/** True when `msg` indicates Playwright (the package or its chromium binary) is missing. */
+export function isPlaywrightMissing(msg: string): boolean {
+  return PLAYWRIGHT_MISSING_HINTS.some((hint) => msg.includes(hint));
+}
+
+/**
+ * Returns the install hint appropriate to which half of the dependency is
+ * absent. Assumes `isPlaywrightMissing(msg)` already returned true.
+ */
+export function playwrightMissingHint(msg: string): string {
+  if (msg.includes("Executable doesn't exist")) {
+    // Package is installed; the chromium browser binary was never downloaded.
+    return (
+      'browser tools require the Playwright chromium binary. ' +
+      'Install via: pnpm exec playwright install chromium.'
+    );
+  }
+  // The `playwright` package itself is not installed.
+  return (
+    'browser tools require the optional `playwright` peer dependency. ' +
+    'Install via: pnpm add playwright (then pnpm exec playwright install chromium). ' +
+    'Or pick a different tool.'
+  );
+}

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -9,6 +9,7 @@
  * @module browser/config
  */
 
+import { readFileSync } from 'node:fs';
 import { join } from 'path';
 import { env as defaultEnv } from '../config/env.js';
 import { getAfkConfigDir } from '../paths.js';
@@ -124,11 +125,15 @@ function parseBooleanEnv(raw: string | undefined): boolean {
 function defaultReadFileSync(path: string): string | undefined {
   // Contract: returns the file contents as a string, or undefined when the
   // file does not exist. Throws for any error other than ENOENT.
+  //
+  // Invariant: must use the static `node:fs` import, never a runtime
+  // require('fs'). The published binary is bundled to ESM (build-dist.mjs sets
+  // format:'esm'), where esbuild replaces a runtime require() with a shim that
+  // throws `Dynamic require of "fs" is not supported`. That shim is what
+  // previously made every browser_* tool fail at provider construction, since
+  // loadBrowserConfig() runs on the first getBrowserProvider() call.
   try {
-    // Use synchronous Node built-in — this function is called once at startup.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const fs = require('fs') as typeof import('fs');
-    return fs.readFileSync(path, 'utf8');
+    return readFileSync(path, 'utf8');
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
     throw err;

--- a/src/browser/playwright/launcher.ts
+++ b/src/browser/playwright/launcher.ts
@@ -22,17 +22,29 @@ import type { BrowserConfig } from '../types.js';
 // Version resolution
 // ---------------------------------------------------------------------------
 
-// Contract: resolve once at module load time. A missing / malformed
-// package.json falls back to 'unknown' without crashing the process.
+// In bundled (esbuild) builds, `__AFK_VERSION__` is replaced at compile time
+// via esbuild's `define` option (see scripts/build-dist.mjs). Declared here so
+// tsc accepts the reference; it is undefined in dev/tsx/vitest runs.
+declare const __AFK_VERSION__: string | undefined;
+
+// Contract: resolve once at module load time. Falls back to 'unknown' without
+// crashing the process.
 function resolveAFKVersion(): string {
+  // Build-time injected literal — the source of truth in the published binary,
+  // where this module is bundled into dist/cli.mjs and import.meta.dirname
+  // points at dist/, so the relative package.json walk below would miss.
   try {
-    // import.meta.dirname is Node ≥20 ESM. The package.json is three
-    // directories above src/browser/playwright/.
-    const pkgPath = path.resolve(
-      // The cast is safe: we target Node ≥20 where import.meta.dirname exists.
-      import.meta.dirname,
-      '../../../package.json',
-    );
+    if (typeof __AFK_VERSION__ === 'string' && __AFK_VERSION__.length > 0) {
+      return __AFK_VERSION__;
+    }
+  } catch {
+    // ReferenceError where the define wasn't applied (dev/tsx) — fall through.
+  }
+
+  // Dev fallback (tsx / vitest): import.meta.dirname is the real source dir,
+  // and the package.json is three directories above src/browser/playwright/.
+  try {
+    const pkgPath = path.resolve(import.meta.dirname, '../../../package.json');
     const raw = fs.readFileSync(pkgPath, 'utf8');
     const parsed = JSON.parse(raw) as { version?: unknown };
     return typeof parsed['version'] === 'string' ? parsed['version'] : 'unknown';

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -289,14 +289,6 @@ export interface ScreenshotResult {
   height: number;
 }
 
-export interface ScreenshotResult {
-  /** Absolute path under ~/.afk/state/witness/<sid>/browser/screenshots/. */
-  path: string;
-  bytes: number;
-  width: number;
-  height: number;
-}
-
 export interface ExtractResult {
   /** Conforms to the input `schema`. */
   data: unknown;


### PR DESCRIPTION
## Summary
- **Unblocks all browser tools.** `src/browser/config.ts` read its config via a runtime `require('fs')`. The published binary is bundled to ESM (`scripts/build-dist.mjs` → `format:'esm'`), where esbuild rewrites that require into a shim that throws `Dynamic require of "fs" is not supported`. Since `loadBrowserConfig()` runs on the first `getBrowserProvider()` call, **every** `browser_*` tool died at provider construction in the published binary — while passing under tsx/vitest (which don't bundle). Fixed with a static `import { readFileSync } from 'node:fs'`.
- **Better playwright/chromium errors + DRY.** Centralized the Playwright-missing detection and install hint (previously copy-pasted across all 5 handlers) into `playwright-hints.ts`, and added the chromium-binary-missing signature (`"Executable doesn't exist"`) that `web_scrape` already had. A user with playwright installed but no chromium now gets `pnpm exec playwright install chromium` guidance instead of an opaque error.
- **Correct version in UA.** Resolve the launcher version from the build-injected `__AFK_VERSION__`; the prior `import.meta.dirname` walk resolved outside the package in the bundle, so the browser User-Agent was always `agent-afk/unknown`.
- **Cleanup.** Removed a duplicate `ScreenshotResult` interface declaration.

Net diff: +141 / -61 across 10 files (2 new: the shared hints module + its test).

## Test results
- `pnpm test` (full suite): **8561 passed**, 12 skipped, **2 failed**.
  - The 2 failures (`provider.test.ts` auth-diagnose, `openai-compatible/query.test.ts` auth-failure-path) are **pre-existing and environment-dependent** — this machine has ChatGPT-OAuth creds that the *no-auth* tests assume are absent. **Proven** by stashing this change and re-running on the clean base (de58a93): the same 2 fail. Both live in files disjoint from this diff (browser-only); this change introduces zero new failures. Expected green in CI's clean environment.
- `pnpm test` (browser scope): **369 passed** (15 files), incl. new `playwright-hints.test.ts`.
- `pnpm lint` (`tsc --noEmit`, strict): **pass**.
- Live e2e (faithful ESM bundle of `getBrowserProvider().open()`): opened `https://example.com` → `title="Example Domain"`, clean shutdown. Rebuilt `dist/cli.mjs` has **0** dynamic-require shims and `resolveAFKVersion()` returns the real version literal.

## Verification
Independent read-only adversarial verifier re-derived the 3 load-bearing claims from the diff alone — all **CONFIRM**, no contradictions:
- **Claim 1 (require→import unblocks tools):** CONFIRM — `build-dist.mjs:94` `format:'esm'`; `config.ts` now static `node:fs` import; `registry.ts` → `loadBrowserConfig()` on the `getBrowserProvider()` path.
- **Claim 2 (chromium hint gap + 5x dup):** CONFIRM — shared module includes all three hint strings incl. `"Executable doesn't exist"`; all 5 handlers import the helpers.
- **Claim 3 (version 'unknown' in bundle):** CONFIRM — `build-dist.mjs:103` defines `__AFK_VERSION__`; launcher prefers it before the `import.meta.dirname` fallback.

## Out of scope (deferred follow-ups)
- `AFK_SESSION_ID` silently falls back to `'default'` → subagents without a propagated id share one browser context (needs a design decision).
- `open()` double-throw can mask the original navigation error.
- An `audit:require` guard (grep `src/` for `require(` outside tests), sibling to `audit:sdk`/`audit:env`, to prevent this bug class from recurring.
