### PR TITLE
fix(skills): ship uses --body-file/-F instead of heredoc-in-$()

### DIFF
--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -69,7 +69,16 @@ const PINNED_HASHES = {
   review: '31a17d8c3bace684b7fce22588d54ce3e95462acdf397fc1673f3590192e0944',
   'shadow-verify':
     '9b1ea7db65485f849ae6dfb9a6f69a102d7ccc6e5230b561dc76ef8c666475f8',
-  ship: '95f6410600af55fa9fa0312a48d3eebb37ef18ca98dd73ccba840b7136f83b69',
+  // Hash bumped 2026-06: Phase 4 (commit) + Phase 8 (PR) switched from the
+  // `--body "$(cat <<'EOF' … EOF)"` heredoc-in-command-substitution antipattern
+  // to the file-based form (`git commit -F` / `gh pr create --body-file`). The
+  // heredoc tripped whenever a commit/PR body contained backticks, `$(`, or
+  // quotes (markdown bodies almost always do) — the shell parsed them before
+  // git/gh ran, failing the call or recording a mangled/truncated body. The
+  // file-based form matches the safe convention already used in src/agent/gh.ts.
+  // BACK-PORT GAP: the same fix should land in the upstream example-plugin /ship
+  // skill (drift test is skipped here — example-plugin not co-located).
+  ship: 'e778f20e30cb24edd04e2fa25b939c21db2b49b95ad0e0076be0e49dae8a34a3',
   // simplify is bundled-only (no upstream example-plugin counterpart).
   simplify:
     'f9c9e93b1263ed782b5703b6f30fd981908b0af1fa219d0124405a318ff2756e',

--- a/src/bundled-plugins/awa-bundled/skills/ship/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/ship/SKILL.md
@@ -58,16 +58,16 @@ Read the cumulative diff: `git diff --stat origin/<default>...HEAD` + full `git 
 Before committing, review the **file list** to stage — don't sweep in untracked config/scratch/secret files. Print the draft message + file list to the user as info-only output, then **immediately** invoke Phase 4. **This is not a gate. Do not ask "does this look good?" Do not wait for approval.** The user surface is one continuous turn: draft → commit → push → PR URL.
 
 **Phase 4 — Commit.**
-Stage only the confirmed files. Commit via HEREDOC to preserve formatting:
+Stage only the confirmed files, then write the commit message to a temp file with your file-writing tool — **NOT** a shell heredoc — and commit with `-F`:
 
 ```
-git commit -m "$(cat <<'EOF'
-<subject>
-
-<body>
-EOF
-)"
+# 1. Write the subject + body to a temp file (e.g. .git/COMMIT_BODY.txt) using
+#    your file-writing tool. The content never passes through the shell.
+# 2. Commit from that file:
+git commit -F .git/COMMIT_BODY.txt
 ```
+
+Going through a file keeps backticks, `$(...)`, and quotes in the message literal. **Never** assemble the message inline as `git commit -m "$(cat <<'EOF' … EOF)"` — a backtick or `$(` in the body is parsed by the shell *before* `git` runs, so the commit fails or records a mangled message. `.git/` is never staged, so the temp file can't sneak into the commit (in a linked worktree `.git` is a file, not a dir — write to the path printed by `git rev-parse --git-dir` instead).
 
 Never `--amend` (creates a new commit each time). Never bypass hooks (`--no-verify`).
 
@@ -108,16 +108,20 @@ Structure:
 ```
 
 **Phase 8 — Open PR.**
+Write the PR body (from Phase 7) to a temp file with your file-writing tool — **NOT** a shell heredoc — then pass it with `--body-file`:
+
 ```
+# 1. Write the Phase 7 PR body to a temp file (e.g. .git/PR_BODY.md) using your
+#    file-writing tool. The body never passes through the shell.
+# 2. Open the PR from that file:
 gh pr create \
   --title "<subject line of the commit>" \
-  --body "$(cat <<'EOF'
-<PR body from Phase 7>
-EOF
-)" \
+  --body-file .git/PR_BODY.md \
   --base <default-branch> \
   [--draft]
 ```
+
+PR bodies are markdown: they routinely carry backticks (inline code), `$(...)`, and quotes. **Never** inline the body as `--body "$(cat <<'EOF' … EOF)"` — the shell parses backticks/`$(` inside the command substitution before `gh` ever runs, so the call fails (or worse, opens the PR with a truncated/garbled body and you don't notice). `--body-file` reads the file verbatim: no shell quoting, no escaping. Only `--title` stays inline — keep it a single plain line with no backticks.
 
 Return the PR URL to the user. Done.
 


### PR DESCRIPTION
## Summary

The `/ship` skill (`src/bundled-plugins/awa-bundled/skills/ship/SKILL.md`) prescribed the heredoc-in-command-substitution pattern in two phases:

- **Phase 8 (PR):** `gh pr create --body "$(cat <<'EOF' … EOF)"`
- **Phase 4 (commit):** `git commit -m "$(cat <<'EOF' … EOF)"`

Markdown commit/PR bodies almost always contain backticks (inline code), `$(`, or quotes. The shell parses those *inside* the `$(...)` command substitution **before** `git`/`gh` ever runs — so the call fails outright, or (worse) records a mangled/truncated body that goes unnoticed. This kept biting the agent-driven `/ship` path.

This PR switches both phases to the file-based form, which reads the file verbatim with no shell quoting:

- Phase 4 → write the message to a temp file, then `git commit -F <file>`
- Phase 8 → write the body to a temp file, then `gh pr create --body-file <file>`

Both now match the safe convention already used in `src/agent/gh.ts` (which posts PR comments via `--body-file -` through `execFile`, never a shell). Only `--title` stays inline (a single plain line, no backticks). The new prose also documents the worktree caveat: in a linked worktree `.git` is a file, not a dir, so write to the path printed by `git rev-parse --git-dir`.

## Changes

- `src/bundled-plugins/awa-bundled/skills/ship/SKILL.md` — Phase 4 + Phase 8 rewritten to the file-based form, with an explicit "Never inline as `$(cat <<'EOF' …)`" prohibition explaining why.
- `src/bundled-plugins/awa-bundled/bundled.test.ts` — bumped the pinned ship hash (`95f641…` → `e778f2…`) with a documented reason + back-port-gap note.

## Test results

- `vitest run src/bundled-plugins/awa-bundled/bundled.test.ts`: 15 passed, 11 skipped. The 11 skips are the namespace-drift comparisons, which skip when `example-plugin` isn't co-located (standalone clone / worktree) — expected.
- `tsc --noEmit`: clean (exit 0).

## Verification

This PR was opened with the new path itself — `gh pr create --body-file` reading this very body (full of backticks and `$()`), and the underlying commit was made with `git commit -F`. Both bodies recorded the special characters literally, which is the exact failure the old heredoc produced.

## Out of scope / follow-up

- **Back-port gap:** the same fix should land in the upstream `example-plugin/ship` skill. The bundled drift test can't catch this here because `example-plugin` isn't co-located. Flagged in the commit message and the hash-bump comment for cross-repo reconciliation.
