### PR TITLE
test(auth): isolate no-auth tests from host credentials via AuthResolverDeps injection

### DIFF
--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -500,25 +500,32 @@ describe('OpenAICompatibleQuery — model-slot resolution in request body', () =
 
 describe('OpenAICompatibleQuery — auth failure path', () => {
   it('emits session.init then error when no auth is resolvable', async () => {
-    // Don't set apiKey on config; env is empty in test env; no codex auth.
-    const noAuthDeps = { OPENAI_API_KEY: process.env['OPENAI_API_KEY'] };
-    delete process.env['OPENAI_API_KEY'];
-    try {
-      const q = buildQueryFromConfig({ model: 'gpt-4o-mini' } as AgentConfig, singleInput('hi'));
-      const events = await collect(q);
-      expect(events[0]?.type).toBe('session.init');
-      expect(events[1]?.type).toBe('error');
-      if (events[1]?.type === 'error') {
-        // Diagnostic must say API key is required and reference env+codex paths
-        expect(events[1].error.message).toContain('OPENAI_API_KEY');
-      }
-      // Crucially: no wire call was made.
-      expect(createCalls).toHaveLength(0);
-    } finally {
-      if (noAuthDeps.OPENAI_API_KEY !== undefined) {
-        process.env['OPENAI_API_KEY'] = noAuthDeps.OPENAI_API_KEY;
-      }
+    // Use hermetic auth deps so this test is isolated from the host machine's
+    // real credentials. Without this, a developer whose ~/.codex/auth.json
+    // contains a ChatGPT OAuth bundle (and AFK_OPENAI_CHATGPT_OAUTH=1) will
+    // resolve a real access_token — bypassing the no-auth path entirely and
+    // sending the request on the Responses API wire. The mock only stubs
+    // chat.completions.create, so this.client.responses.create would crash
+    // with "Cannot read properties of undefined (reading 'create')".
+    const noAuthDeps = {
+      readEnv: (_key: string) => undefined, // suppress OPENAI_API_KEY, CODEX_API_KEY, AFK_OPENAI_CHATGPT_OAUTH
+      homedir: () => '/nonexistent-test-home',
+      readFile: (_path: string) => null, // no ~/.codex/auth.json
+    };
+    const q = buildQueryFromConfig(
+      { model: 'gpt-4o-mini' } as AgentConfig,
+      singleInput('hi'),
+      { authDeps: noAuthDeps },
+    );
+    const events = await collect(q);
+    expect(events[0]?.type).toBe('session.init');
+    expect(events[1]?.type).toBe('error');
+    if (events[1]?.type === 'error') {
+      // Diagnostic must say API key is required and reference env+codex paths
+      expect(events[1].error.message).toContain('OPENAI_API_KEY');
     }
+    // Crucially: no wire call was made.
+    expect(createCalls).toHaveLength(0);
   });
 
   it('emits a specific diagnostic when only ChatGPT OAuth is present', async () => {

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -51,6 +51,7 @@ import {
   resolveOpenAIAuth,
   formatAuthDiagnostic,
   type OpenAIAuthResolution,
+  type AuthResolverDeps,
 } from './auth.js';
 import { buildMessages, flattenUserContent, type OpenAIMessage } from './messages.js';
 import {
@@ -902,9 +903,15 @@ export function buildQueryFromConfig(
     toolDispatcher?: ToolDispatcher;
     mcpManager?: import('../../mcp/index.js').McpManager;
     useResponsesApi?: boolean;
+    /**
+     * Optional env + fs injection point forwarded to `resolveOpenAIAuth`.
+     * Tests pass a hermetic stub here to prevent reading real host credentials
+     * (e.g. `~/.codex/auth.json`) from the developer's machine.
+     */
+    authDeps?: AuthResolverDeps;
   } = {},
 ): OpenAICompatibleQuery {
-  const auth = resolveOpenAIAuth(config.apiKey);
+  const auth = resolveOpenAIAuth(config.apiKey, options.authDeps);
   const synthesizedSessionId =
     config.resume ?? `openai-pending-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   // Resolve model-slot aliases (small/medium/large, custom names, and the

--- a/src/cli/commands/provider.test.ts
+++ b/src/cli/commands/provider.test.ts
@@ -36,21 +36,28 @@ describe('buildProviderAuthDiagnose', () => {
   });
 
   it('returns nonzero exit code with actionable message when no auth resolves', () => {
-    // Force the codex auth path to miss by using a fake HOME — actually,
-    // simpler to assert behavior: when nothing's set and the test
-    // environment has no real codex auth that contains an api key, we
-    // either get no-usable-auth OR no-usable-auth-codex-oauth. Both are
-    // nonzero exit codes.
-    const r = buildProviderAuthDiagnose(undefined);
-    if (r.exitCode !== 0) {
-      // We're in a no-auth state — verify the message is actionable.
-      expect(r.message.toLowerCase()).toMatch(/openai_api_key|codex login/);
-    } else {
-      // Real codex CLI auth is present on this machine. Skip the
-      // actionability assertion; the source tag must still be one of the
-      // legitimate-auth values.
-      expect(['config', 'env', 'codex-cli']).toContain(r.source);
-    }
+    // Inject hermetic deps so this test is isolated from the host machine's
+    // real credentials. Without this, a developer whose ~/.codex/auth.json
+    // contains a ChatGPT OAuth bundle (and AFK_OPENAI_CHATGPT_OAUTH=1) would
+    // cause resolveOpenAIAuth to return source:'chatgpt-oauth' with a real
+    // access_token — making exitCode 0 and source outside the allowlist below.
+    const hermeticDeps = {
+      readEnv: (key: string) => {
+        // Expose only the env vars already cleared by beforeEach (OPENAI_API_KEY,
+        // CODEX_API_KEY) as absent, and explicitly suppress the OAuth opt-in flag.
+        if (key === 'OPENAI_API_KEY' || key === 'CODEX_API_KEY' || key === 'AFK_OPENAI_CHATGPT_OAUTH') {
+          return undefined;
+        }
+        return undefined;
+      },
+      homedir: () => '/nonexistent-test-home',
+      readFile: (_path: string) => null, // no ~/.codex/auth.json
+    };
+    const r = buildProviderAuthDiagnose(undefined, hermeticDeps);
+    // With no env vars and no filesystem auth the resolver must return
+    // no-usable-auth (exitCode 1) with an actionable message.
+    expect(r.exitCode).toBe(1);
+    expect(r.message.toLowerCase()).toMatch(/openai_api_key|codex login/);
   });
 
   it('never includes raw key material in the returned message', () => {

--- a/src/cli/commands/provider.ts
+++ b/src/cli/commands/provider.ts
@@ -18,16 +18,22 @@ import {
   resolveOpenAIAuth,
   formatAuthDiagnostic,
   type OpenAIAuthSource,
+  type AuthResolverDeps,
 } from '../../agent/providers/openai-compatible/auth.js';
 
 /**
  * Build the human-readable result of `afk provider auth diagnose`. Pure
  * function so it's trivially testable. Caller writes to stdout.
+ *
+ * @param explicitConfigKey - `AgentConfig.apiKey` override, if any.
+ * @param deps - Optional env + fs injection point (tests pass a hermetic stub
+ *   to avoid reading real host credentials from `~/.codex/auth.json`).
  */
 export function buildProviderAuthDiagnose(
   explicitConfigKey: string | undefined,
+  deps?: AuthResolverDeps,
 ): { source: OpenAIAuthSource; message: string; exitCode: number; last4?: string } {
-  const resolution = resolveOpenAIAuth(explicitConfigKey);
+  const resolution = resolveOpenAIAuth(explicitConfigKey, deps);
   const message = formatAuthDiagnostic(resolution);
   // Exit nonzero when there's no usable auth so this can drive shell
   // scripts ("ensure OpenAI is configured before running").


### PR DESCRIPTION
## Summary

Two unit tests failed on credentialed developer machines but passed in clean CI. Both tests intended to simulate a "no auth resolvable" scenario but leaked real host credentials, causing the wrong code path to execute.

## Root cause

The host machine has `~/.codex/auth.json` with `auth_mode: 'chatgpt'` (a ChatGPT OAuth bundle with a real `access_token`) **and** `AFK_OPENAI_CHATGPT_OAUTH=1` set in the environment. The `resolveOpenAIAuth` function (which accepts an injectable `AuthResolverDeps` for isolation) was called by both `buildProviderAuthDiagnose` and `buildQueryFromConfig` **without** any deps injection — so it fell through to the real filesystem and env, resolving `source: 'chatgpt-oauth'` with a live token.

- **`provider.test.ts` line 52**: The test's `else` branch (real auth present) asserted `source` against `['config','env','codex-cli']` — but `'chatgpt-oauth'` was never in that list, so the assertion failed.
- **`query.test.ts` line 513**: With `chatgpt-oauth` resolved, `wireMode` was set to `'responses'` and a real client was constructed. The test mock only stubs `chat.completions.create` — not `responses.create` — so calling `client.responses.create` threw `TypeError: Cannot read properties of undefined (reading 'create')` instead of the expected `OPENAI_API_KEY` diagnostic.

## Fix

Threaded the existing `AuthResolverDeps` injection point through two thin wrappers that previously had no way to receive it:

1. **`src/cli/commands/provider.ts`** — added optional `deps?: AuthResolverDeps` param to `buildProviderAuthDiagnose()`, forwarded to `resolveOpenAIAuth()`.
2. **`src/agent/providers/openai-compatible/query.ts`** — added optional `authDeps?: AuthResolverDeps` inside `buildQueryFromConfig()`'s options object, forwarded to `resolveOpenAIAuth()`.

Both production call sites pass no deps and continue resolving against the real environment. Tests now pass a hermetic stub: `readEnv → undefined`, `homedir → '/nonexistent-test-home'`, `readFile → null`. This guarantees the resolver returns `source: 'no-usable-auth'` regardless of what credentials exist on the host machine.

No assertion text was weakened; the `'chatgpt-oauth'` source was not added to any allowlist; no tests were skipped.

## Test results

```
pnpm lint              → tsc --noEmit (clean)
vitest run src/cli/commands src/agent/providers/openai-compatible
  → 49 test files, 1092 tests, 0 failures
```

Both previously failing tests now pass deterministically on a machine with real ChatGPT OAuth credentials configured.
