### PR TITLE
shadow-verify: skip adversarial re-derivation on text-terminal sessions

### DIFF
--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -68,7 +68,7 @@ const PINNED_HASHES = {
   research: '10692d77e392cedce928f66cb5dec27dbc2066f48cfc33047820f56506da762a',
   review: '31a17d8c3bace684b7fce22588d54ce3e95462acdf397fc1673f3590192e0944',
   'shadow-verify':
-    '9b1ea7db65485f849ae6dfb9a6f69a102d7ccc6e5230b561dc76ef8c666475f8',
+    '58afb3387766498a7b4321bac56196a2654e0bca1153e2c0f7d66154e2fa8705',
   ship: '95f6410600af55fa9fa0312a48d3eebb37ef18ca98dd73ccba840b7136f83b69',
   // simplify is bundled-only (no upstream example-plugin counterpart).
   simplify:

--- a/src/bundled-plugins/awa-bundled/skills/shadow-verify/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/shadow-verify/SKILL.md
@@ -22,7 +22,7 @@ When a sub-agent (or wave) returns investigation findings, code-review conclusio
 Any time sub-agent output will drive user decisions, file edits, commits, external side-effects, or is the basis of a user-facing summary.
 
 **Skip when:**
-Sub-agent ran inside an orchestrator skill that already verifies (`resolve`, `diagnose`, `appmap`); sub-agent returned explicit failure; work was purely exploratory and no decision follows.
+Sub-agent ran inside an orchestrator skill that already verifies (`resolve`, `diagnose`, `appmap`); sub-agent returned explicit failure; work was purely exploratory and no decision follows; or the session is **text-terminal** — a pure explanation, architecture walkthrough, onboarding Q&A, or capability map that names no mutated artifact (file/PR/commit/test), where there are no re-checkable state claims for adversarial verifiers to re-derive (assess coverage, coherence, and citation density instead of dispatching re-derivation sub-agents).
 
 ## Appendix: verification methods by domain (non-binding)
 


### PR DESCRIPTION
## What

Adds one `Skip when` clause to the bundled `shadow-verify`: route **text-terminal** sessions (pure explanation, architecture walkthrough, onboarding Q&A, capability map — anything that names no mutated artifact like a file/PR/commit/test) away from adversarial re-derivation. Those sessions have **no re-checkable state claims** for verifiers to re-derive, so assess coverage / coherence / citation-density instead of dispatching re-derivation sub-agents.

## Why

A skill-generation run re-discovered the text-terminal verification pattern and proposed bolting a whole synthesis-depth *arc* onto shadow-verify. That would duplicate existing explanation-verification tooling, so the clean, non-duplicative delta is this single routing note — behavior-only, no new machinery.

## Changes

- `skills/shadow-verify/SKILL.md`: +1 `Skip when` clause (self-contained wording).
- `bundled.test.ts`: bump `PINNED_HASHES['shadow-verify']` for the edited file (the pinned-hash test is the CI gate).

One-line behavioral change; fully reversible.