### PR TITLE
fix(tui): surface the skill name in the tool lane

### DIFF
--- a/src/agent/providers/anthropic-direct/loop.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.test.ts
@@ -1093,6 +1093,58 @@ describe('loop.ts runTurn', () => {
       expect(loopEmittedStart.toolInput).toContain('test pattern');
     }
   });
+
+  // Regression: skill dispatch must surface WHICH skill in the tool lane.
+  // The skill tool's input is `{ name, arguments }` — none of the
+  // file_path/command/query fields match, so summarizeToolInput used to
+  // return '' and the lane rendered a bare `skill [skill]` with no hint of
+  // which skill ran. The fix returns the paren-wrapped skill name so the
+  // lane renders `skill(diagnose)`.
+  it('summarizeToolInput surfaces the skill name as a paren-wrapped label for skill dispatch', async () => {
+    let callIdx = 0;
+    const client = makeClient(() => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        return fromArray(
+          makeToolUseStream('toolu_s', 'skill', '{"name":"diagnose","arguments":"flaky test"}'),
+        );
+      }
+      return fromArray(makeTextStream('Done'));
+    });
+
+    const dispatcher = makeDispatcher(() => Promise.resolve({ content: 'ok' }));
+    const messages: MessageParam[] = [{ role: 'user', content: 'diagnose this' }];
+    const abortController = new AbortController();
+
+    const events = await collect(
+      runTurn({
+        client,
+        messages,
+        system: null,
+        tools: [{ name: 'skill', input_schema: { type: 'object' } }],
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 1024,
+        headers: {},
+        signal: abortController.signal,
+        ctx,
+      }),
+    );
+
+    // Loop emits tool.use.start with the summarized label; translate emits ' …'.
+    const loopEmittedStart = events.find(
+      (e) => e.type === 'tool.use.start' && e.toolInput !== ' …',
+    );
+    expect(loopEmittedStart).toBeDefined();
+    if (loopEmittedStart?.type === 'tool.use.start') {
+      // Paren-wrapped so the renderer treats it as a promoted dispatch label
+      // (matching `Agent(<label>)`), not a leaf-tool ` arg` suffix.
+      expect(loopEmittedStart.toolInput).toBe('(diagnose)');
+      // The skill `arguments` field is intentionally NOT echoed — the name
+      // alone identifies which skill ran, matching the Agent(label) form.
+      expect(loopEmittedStart.toolInput).not.toContain('flaky test');
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -148,9 +148,24 @@ async function createWithRetry(
   }
 }
 
-function summarizeToolInput(input: unknown): string {
+function summarizeToolInput(toolName: string, input: unknown): string {
   if (!input || typeof input !== 'object') return '';
   const obj = input as Record<string, unknown>;
+  // Skill dispatch: the `name` field IS the skill being invoked (diagnose,
+  // review, mint, …). Surface it as a paren-wrapped label so the tool lane
+  // renders `skill(diagnose)` instead of a bare `skill [skill]` — matching the
+  // `Agent(<label>)` dispatch convention and the paren-wrap signal the overflow
+  // renderer keys on (cli/commands/interactive/tool-lane-render-grouping-overflow.ts).
+  // Unlike `agent`, a skill's label is fully known from the tool input, so it
+  // needs no deferred mergeAgentLabel promotion — and it MUST be surfaced here
+  // because load-mode skills never fork a child Agent row to carry the name.
+  if (toolName === 'skill' || toolName === 'Skill') {
+    const skillName = obj['name'];
+    if (typeof skillName === 'string' && skillName.length > 0) {
+      return `(${skillName.length > 60 ? skillName.slice(0, 59) + '…' : skillName})`;
+    }
+    return '';
+  }
   const path = obj['file_path'] ?? obj['path'] ?? obj['filePath'];
   if (typeof path === 'string') return ' ' + path;
   const cmd = obj['command'] ?? obj['cmd'];
@@ -524,7 +539,7 @@ export async function* runTurn(
         type: 'tool.use.start',
         toolUseId: block.id,
         toolName: block.name,
-        toolInput: summarizeToolInput(block.input),
+        toolInput: summarizeToolInput(block.name, block.input),
         sessionId: input.ctx.sessionId,
       };
     }

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -617,7 +617,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
         type: 'tool.use.start',
         toolUseId: call.id,
         toolName: call.name,
-        toolInput: summarizeToolInput(call.input),
+        toolInput: summarizeToolInput(call.name, call.input),
         sessionId: this.initSessionId,
       };
     }
@@ -872,9 +872,21 @@ function defaultClientFactory(opts: {
  * helper in anthropic-direct/loop.ts so `tool.use.start` events render
  * identically across providers.
  */
-function summarizeToolInput(input: unknown): string {
+function summarizeToolInput(toolName: string, input: unknown): string {
   if (!input || typeof input !== 'object') return '';
   const obj = input as Record<string, unknown>;
+  // Skill dispatch: the `name` field IS the skill being invoked (diagnose,
+  // review, mint, …). Surface it as a paren-wrapped label so the tool lane
+  // renders `skill(diagnose)` instead of a bare `skill [skill]`. Mirrors the
+  // anthropic-direct helper exactly so labels render identically across
+  // providers — see the rationale comment in anthropic-direct/loop.ts.
+  if (toolName === 'skill' || toolName === 'Skill') {
+    const skillName = obj['name'];
+    if (typeof skillName === 'string' && skillName.length > 0) {
+      return `(${skillName.length > 60 ? skillName.slice(0, 59) + '…' : skillName})`;
+    }
+    return '';
+  }
   const path = obj['file_path'] ?? obj['path'] ?? obj['filePath'];
   if (typeof path === 'string') return ' ' + path;
   const cmd = obj['command'] ?? obj['cmd'];

--- a/src/agent/providers/openai-compatible/tool-dispatch.test.ts
+++ b/src/agent/providers/openai-compatible/tool-dispatch.test.ts
@@ -243,6 +243,73 @@ describe('OpenAICompatibleQuery — tool dispatch (slice 3)', () => {
     }
   });
 
+  // Cross-provider parity: the openai-compatible `summarizeToolInput` is a
+  // separate copy of the anthropic-direct helper (they must render identically
+  // — see the docstring on each). This guards the skill-label behavior against
+  // drift between the two copies: a skill dispatch must surface the skill name
+  // as a paren-wrapped label in tool.use.start so the tool lane shows
+  // `skill(diagnose)` rather than a bare `skill [skill]`.
+  it('surfaces the skill name as a paren-wrapped label in tool.use.start', async () => {
+    const fixture = makeDispatcher();
+
+    // Turn 1: model dispatches the skill tool. Turn 2: final text so the
+    // query terminates. The skill handler is unregistered in the fixture, but
+    // tool.use.start fires BEFORE dispatch (query.ts), so the label is emitted
+    // regardless of whether the dispatch itself succeeds.
+    scriptedTurns = [
+      {
+        chunks: [
+          {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'call_skill',
+                      type: 'function',
+                      function: { name: 'skill', arguments: '{"name":"diagnose","arguments":"flaky test"}' },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+            usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+          },
+        ],
+      },
+      {
+        chunks: [
+          { choices: [{ delta: { content: 'done' } }] },
+          {
+            choices: [{ delta: {}, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 5, completion_tokens: 1, total_tokens: 6 },
+          },
+        ],
+      },
+    ];
+
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'sk-test', source: 'config', last4: 'test' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'sid-skill',
+      promptStream: singleInput('diagnose this'),
+      config: baseConfig(),
+      toolDispatcher: fixture.dispatcher,
+    });
+
+    const events = await collect(q);
+    const start = events.find((e) => e.type === 'tool.use.start');
+    expect(start?.type).toBe('tool.use.start');
+    if (start?.type === 'tool.use.start') {
+      expect(start.toolName).toBe('skill');
+      expect(start.toolInput).toBe('(diagnose)');
+    }
+  });
+
   it("includes the tool catalog as 'tools' in the request", async () => {
     const fixture = makeDispatcher();
     scriptedTurns = [

--- a/src/cli/commands/interactive/tool-lane-render-grouping-overflow.ts
+++ b/src/cli/commands/interactive/tool-lane-render-grouping-overflow.ts
@@ -118,11 +118,14 @@ const LABEL_DISPLAY_MAX = 60;
  *
  * Why the paren-wrap shape check matters: between the early `tool.use.start`
  * fire (`translate.ts` emits `' …'`) and the post-stream `tool.use.start`
- * (`loop.ts` emits `summarizeToolInput(input)`, which returns `''` for
- * dispatch tools), and the subsequent `mergeAgentLabel`/`Agent(<label>)`
- * synthesis, dispatch entries carry placeholder `toolInput` values that
- * MUST NOT be rendered as labels. Paren-wrapped `(label)` is the protocol
- * signal that the entry has been promoted to its labeled form.
+ * (`loop.ts` emits `summarizeToolInput(name, input)`, which returns `''` for
+ * `agent`/`compose` whose label is only known after dispatch), and the
+ * subsequent `mergeAgentLabel`/`Agent(<label>)` synthesis, those dispatch
+ * entries carry placeholder `toolInput` values that MUST NOT be rendered as
+ * labels. Paren-wrapped `(label)` is the protocol signal that the entry has
+ * been promoted to its labeled form. (`skill` is the exception: its label is
+ * the input's `name` field, so `summarizeToolInput` returns the paren-wrapped
+ * `(skillname)` directly — already promoted, no deferred merge needed.)
  *
  * Only called with real tool / grouped siblings (never overflow or
  * resultSummary synthetics) — those are added AFTER the overflow is computed.


### PR DESCRIPTION
## Problem

When a skill is dispatched, the REPL tool lane rendered a bare `◆ skill [skill]` with no indication of **which** skill ran:

```
◎ ◆ skill [skill]
```

## Root cause

`summarizeToolInput` (the provider-layer helper that produces the `tool.use.start` label) only extracted `file_path` / `command` / `query` / `pattern` / `url` / `description`. A skill call's input is `{ name, arguments }` — none of those keys match, so it returned `''`.

Unlike `agent` (which gets relabeled to `Agent(<label>)` later via `mergeAgentLabel` from its forked subagent), `skill` lives in `SKILL_TOOLS`, not `SUBAGENT_TOOLS`, so its row is never relabeled. And load-mode skills (the plugin default since 2026-06) don't even fork a child row to carry the name — so the bare `skill` placeholder stuck permanently.

## Fix

Teach `summarizeToolInput` (in **both** providers — they are deliberate mirrors) to recognize the `skill` / `Skill` tool and return the skill name as a **paren-wrapped label** `(diagnose)`. The tool lane now renders:

```
◆ skill(diagnose) [skill]
```

The paren-wrap form is intentional: it matches the existing `Agent(<label>)` dispatch convention and the paren-wrap signal the overflow renderer keys on (so a collapsed wave of skills shows `… +3 more: diagnose, review, mint` instead of a generic `… +3 skill`).

## Changed files

- `src/agent/providers/anthropic-direct/loop.ts` — skill branch + thread `block.name` into the call
- `src/agent/providers/openai-compatible/query.ts` — identical mirror + thread `call.name`
- `src/cli/commands/interactive/tool-lane-render-grouping-overflow.ts` — corrected a now-stale comment claiming `summarizeToolInput` returns `''` for *all* dispatch tools
- Regression tests: anthropic-direct (`loop.test.ts`) + a cross-provider parity test (`tool-dispatch.test.ts`) guarding the two helper copies against drift

## Verification

- Full suite: **8565 passed**, 12 skipped, 0 failures
- `tsc --noEmit` (strict): clean
- `pnpm audit:sdk:check`: OK (no new SDK symbols)
- Standalone render check: `skill(diagnose)` → `◆ skill(diagnose) [skill]`; empty-name input still falls back to `◆ skill [skill]`; `bash`/leaf tools unchanged

## Notes

- Scope is tight to `skill`. `agent`/`compose` keep their existing `mergeAgentLabel` path untouched; `create_schedule` (which also has a `name` field) is unaffected because the branch gates on the tool name, not a generic `name` lookup.
- Telegram surfaces it too (same `toolInput`): `◦ skill (diagnose)`.
- In fork-mode skills the name now appears on both the parent row (`skill(diagnose)`) and its nested `Agent(diagnose)` child — mildly redundant but it reads honestly as "the skill tool dispatched the diagnose skill, running as this agent." Load-mode skills (no child) gain the name where they previously had none.
