### PR TITLE
fix(session): emit honest closure reasons — truncated / hook_blocked / max_turns_exceeded (budget-governor Patch 2)

### DIFF
--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -22,6 +22,8 @@ import { resolveCredentialForModel } from '../auth/credential-resolver.js';
 import type { ProviderCompactResult, ProviderEvent, ProviderQuery } from '../provider.js';
 import { DEFAULT_SESSION_TIMEOUT_MS, RESET_DRAIN_TIMEOUT_MS, withTimeout } from '../timeout.js';
 import { dispatchSessionEnd, dispatchSessionStart } from './hooks-dispatch.js';
+import { HookBlockedError } from '../../utils/errors.js';
+import { classifyClosureReason } from './closure-reason.js';
 import type {
   AccountInfo,
   AgentConfig,
@@ -90,6 +92,12 @@ export class AgentSession implements IAgentSession {
    *  `tool_use_loop_capped`, `max_tokens`). Undefined when no turn
    *  completed in this session. */
   private lastStopReason: string | undefined;
+  /**
+   * Terminal-cause flags set at their origin sites so `deriveClosureReason`
+   * reports the specific reason instead of a generic abort. Reset by `reset()`.
+   */
+  private maxTurnsHit = false;
+  private hookBlocked = false;
   /**
    * Wall-clock timestamp captured at construction — used to compute the
    * `session_init_done` phase duration and the `session_init_start` emit.
@@ -193,6 +201,8 @@ export class AgentSession implements IAgentSession {
     this.sessionRunningCostUsd = 0;
     this.sessionRunningTokens = { input: 0, output: 0, cacheRead: 0, cacheCreation: 0 };
     this.lastStopReason = undefined;
+    this.maxTurnsHit = false;
+    this.hookBlocked = false;
     this.sessionEndDispatched = false;
     this.currentState = 'idle';
     this.subagentCompletedCount = 0;
@@ -250,6 +260,11 @@ export class AgentSession implements IAgentSession {
       }
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
+      // Origin signal for `hook_blocked`: a SessionStart hook that blocks
+      // throws HookBlockedError up through pullInitialization() to here.
+      if (error instanceof HookBlockedError) {
+        this.hookBlocked = true;
+      }
       if (!this.stateManager.isInitializationSettled()) {
         this.stateManager.rejectInitializationOnce(error);
       }
@@ -822,21 +837,16 @@ export class AgentSession implements IAgentSession {
 
   /**
    * Emit the `closure` trace event with the session's terminal
-   * classification. Maps the `dispatchSessionEndOnce` reason plus the
-   * abort signal's reason value into the {@link ClosureReason} enum.
+   * classification. Delegates the precedence rules to the pure
+   * {@link classifyClosureReason} (`./closure-reason.ts`), which maps the
+   * `dispatchSessionEndOnce` reason, the terminal-cause flags (`maxTurnsHit`,
+   * `hookBlocked`), the pre-classified abort reason, and the last provider
+   * stop reason into a {@link ClosureReason}.
    *
-   * Classification rules:
-   *  - `dispatchReason === 'error'` → `'abort'` (init-time error, treated
-   *    as a generic abort termination)
-   *  - aborted signal with `BudgetExceededError` reason → `'budget_exceeded'`
-   *  - aborted signal with a `TimeoutError` reason → `'timeout'`
-   *  - aborted signal otherwise (and `signal.reason !== 'closed'`)
-   *    → `'abort'`
-   *  - non-aborted normal close/reset → `'model_end_turn'`
-   *
-   * The other ClosureReason values (`iteration_cap`, `hook_blocked`,
-   * `max_turns_exceeded`) require explicit signaling from their origin
-   * sites and are deferred to a later commit.
+   * Wired reasons: `model_end_turn`, `truncated`, `abort`, `timeout`,
+   * `budget_exceeded`, `hook_blocked`, `max_turns_exceeded`. `iteration_cap`
+   * remains deferred — it is wired alongside the tool-use loop cap that
+   * produces it.
    */
   private async emitClosure(dispatchReason: string): Promise<void> {
     const writer = this.config.traceWriter;
@@ -864,23 +874,29 @@ export class AgentSession implements IAgentSession {
   }
 
   private deriveClosureReason(dispatchReason: string): import('../trace/index.js').ClosureReason {
-    if (dispatchReason === 'error') return 'abort';
+    // Pre-classify the abort-signal reason here (needs the concrete error
+    // classes); the precedence decision tree lives in the pure
+    // classifyClosureReason so it is unit-testable without a live session.
+    let abort: 'budget_exceeded' | 'timeout' | 'abort' | null = null;
     const signal = this.abortController.signal;
     if (signal.aborted && signal.reason !== 'closed') {
       const r = signal.reason;
-      if (r instanceof BudgetExceededError) return 'budget_exceeded';
-      if (r instanceof TimeoutError) return 'timeout';
-      // Some abort paths pass the error's message string rather than
-      // the error instance — match the well-known prefixes as a fallback
-      // so the classification stays accurate when the abort reason has
-      // been stringified upstream.
-      if (typeof r === 'string') {
-        if (r.startsWith('Budget ')) return 'budget_exceeded';
-        if (r.includes('timed out')) return 'timeout';
-      }
-      return 'abort';
+      if (r instanceof BudgetExceededError) abort = 'budget_exceeded';
+      else if (r instanceof TimeoutError) abort = 'timeout';
+      // Some abort paths pass the error's message string rather than the
+      // error instance — match the well-known prefixes as a fallback so the
+      // classification stays accurate when the abort reason was stringified.
+      else if (typeof r === 'string' && r.startsWith('Budget ')) abort = 'budget_exceeded';
+      else if (typeof r === 'string' && r.includes('timed out')) abort = 'timeout';
+      else abort = 'abort';
     }
-    return 'model_end_turn';
+    return classifyClosureReason({
+      dispatchReason,
+      maxTurnsHit: this.maxTurnsHit,
+      hookBlocked: this.hookBlocked,
+      abort,
+      lastStopReason: this.lastStopReason,
+    });
   }
 
   /**
@@ -992,6 +1008,9 @@ export class AgentSession implements IAgentSession {
       throw new Error('Cannot send message: session is busy');
     }
     if (this.config.maxTurns && this.turnCount >= this.config.maxTurns) {
+      // Origin signal for `max_turns_exceeded`: the throw below surfaces as a
+      // generic dispatch error, so flag the specific cause for the closure.
+      this.maxTurnsHit = true;
       throw new Error(`Maximum turns (${this.config.maxTurns}) exceeded`);
     }
   }

--- a/src/agent/session/closure-reason.test.ts
+++ b/src/agent/session/closure-reason.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for the pure closure-reason classifier extracted from
+ * AgentSession (`closure-reason.ts`). Covers the precedence rules in
+ * `classifyClosureReason` and the `isTruncationStopReason` predicate.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  classifyClosureReason,
+  isTruncationStopReason,
+  type ClosureReasonInputs,
+} from './closure-reason.js';
+
+const base: ClosureReasonInputs = {
+  dispatchReason: 'close',
+  maxTurnsHit: false,
+  hookBlocked: false,
+  abort: null,
+  lastStopReason: undefined,
+};
+
+describe('isTruncationStopReason', () => {
+  it('flags Anthropic max_tokens and OpenAI length', () => {
+    expect(isTruncationStopReason('max_tokens')).toBe(true);
+    expect(isTruncationStopReason('length')).toBe(true);
+  });
+
+  it('does not flag clean / tool / unknown stop reasons', () => {
+    expect(isTruncationStopReason('end_turn')).toBe(false);
+    expect(isTruncationStopReason('stop')).toBe(false);
+    expect(isTruncationStopReason('tool_use')).toBe(false);
+    expect(isTruncationStopReason(undefined)).toBe(false);
+  });
+});
+
+describe('classifyClosureReason', () => {
+  it('returns model_end_turn for a clean close', () => {
+    expect(classifyClosureReason(base)).toBe('model_end_turn');
+  });
+
+  it('reports truncated when the final turn hit the token ceiling', () => {
+    expect(classifyClosureReason({ ...base, lastStopReason: 'max_tokens' })).toBe('truncated');
+    expect(classifyClosureReason({ ...base, lastStopReason: 'length' })).toBe('truncated');
+  });
+
+  it('reports max_turns_exceeded with the highest precedence', () => {
+    expect(classifyClosureReason({ ...base, maxTurnsHit: true })).toBe('max_turns_exceeded');
+    // The turn-cap throw surfaces as a generic error/abort — the flag must win.
+    expect(
+      classifyClosureReason({ ...base, maxTurnsHit: true, dispatchReason: 'error' }),
+    ).toBe('max_turns_exceeded');
+    expect(classifyClosureReason({ ...base, maxTurnsHit: true, abort: 'abort' })).toBe(
+      'max_turns_exceeded',
+    );
+  });
+
+  it('reports hook_blocked when a SessionStart hook blocked', () => {
+    expect(
+      classifyClosureReason({ ...base, hookBlocked: true, dispatchReason: 'error' }),
+    ).toBe('hook_blocked');
+  });
+
+  it('prefers max_turns_exceeded over hook_blocked if both are set', () => {
+    expect(classifyClosureReason({ ...base, maxTurnsHit: true, hookBlocked: true })).toBe(
+      'max_turns_exceeded',
+    );
+  });
+
+  it('maps a generic init/runtime error to abort', () => {
+    expect(classifyClosureReason({ ...base, dispatchReason: 'error' })).toBe('abort');
+  });
+
+  it('preserves prior behavior: a generic error outranks the abort-signal class', () => {
+    // Pre-refactor order: dispatchReason==='error' returned 'abort' before
+    // inspecting the abort signal.
+    expect(
+      classifyClosureReason({ ...base, dispatchReason: 'error', abort: 'budget_exceeded' }),
+    ).toBe('abort');
+  });
+
+  it('maps classified abort signals when not a generic error', () => {
+    expect(classifyClosureReason({ ...base, abort: 'budget_exceeded' })).toBe('budget_exceeded');
+    expect(classifyClosureReason({ ...base, abort: 'timeout' })).toBe('timeout');
+    expect(classifyClosureReason({ ...base, abort: 'abort' })).toBe('abort');
+  });
+
+  it('an abort signal outranks a truncation stop reason', () => {
+    expect(
+      classifyClosureReason({ ...base, abort: 'timeout', lastStopReason: 'max_tokens' }),
+    ).toBe('timeout');
+  });
+});

--- a/src/agent/session/closure-reason.ts
+++ b/src/agent/session/closure-reason.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure closure-reason classification for {@link AgentSession}.
+ *
+ * Extracted from the session so the precedence rules can be unit-tested
+ * without constructing a live session + provider (mirrors the pure
+ * `shouldAutoCompact` helper). `AgentSession.deriveClosureReason` pre-classifies
+ * the abort-signal reason — which needs the concrete error classes — and
+ * delegates the decision tree to {@link classifyClosureReason}.
+ *
+ * Precedence (first match wins):
+ *  1. `maxTurnsHit`  → `max_turns_exceeded` — the per-session turn cap tripped
+ *     in `assertCanSend`. Checked first because the resulting throw surfaces as
+ *     a generic `'error'`/`'close'` dispatch reason that would otherwise mask
+ *     the specific cause.
+ *  2. `hookBlocked`  → `hook_blocked` — a SessionStart hook threw
+ *     `HookBlockedError` during init (same masking rationale).
+ *  3. `dispatchReason === 'error'` → `abort` — generic init/runtime error.
+ *     Preserves the prior behaviour where an init-time error outranks the
+ *     abort-signal classification below.
+ *  4. a classified abort signal → `budget_exceeded` | `timeout` | `abort`.
+ *  5. a truncation stop reason (`max_tokens` / `length`) on an otherwise clean
+ *     close → `truncated` — the model's final turn was cut off by the
+ *     output-token ceiling, previously indistinguishable from a clean end.
+ *  6. otherwise → `model_end_turn`.
+ *
+ * `iteration_cap` is intentionally NOT produced here: nothing sets a tool-use
+ * loop cap in production yet (`DEFAULT_MAX_TOOL_USE_ITERATIONS = 0`), so it is
+ * wired alongside the cap itself in a later patch.
+ *
+ * @module agent/session/closure-reason
+ */
+
+import type { ClosureReason } from '../trace/index.js';
+
+/**
+ * Provider stop reasons that mean the response was cut off by the output-token
+ * cap rather than completing naturally. Anthropic emits `'max_tokens'`;
+ * OpenAI-compatible providers emit `'length'`.
+ */
+export function isTruncationStopReason(stopReason: string | undefined): boolean {
+  return stopReason === 'max_tokens' || stopReason === 'length';
+}
+
+export interface ClosureReasonInputs {
+  /** The reason string passed to `dispatchSessionEndOnce` (close/reset/error). */
+  dispatchReason: string;
+  /** True when the per-session turn cap tripped in `assertCanSend`. */
+  maxTurnsHit: boolean;
+  /** True when a SessionStart hook threw `HookBlockedError` during init. */
+  hookBlocked: boolean;
+  /**
+   * The abort-signal reason pre-classified by the caller, or `null` when the
+   * session was not aborted (or aborted only with the benign `'closed'`
+   * reason). Keeps the `instanceof` error-class checks in the session, where
+   * the concrete error classes are in scope.
+   */
+  abort: 'budget_exceeded' | 'timeout' | 'abort' | null;
+  /** The provider's last `stop_reason` / `finish_reason`, if any. */
+  lastStopReason: string | undefined;
+}
+
+/**
+ * Map terminal session signals to a {@link ClosureReason}. Pure — see the
+ * module docstring for the precedence rules.
+ */
+export function classifyClosureReason(i: ClosureReasonInputs): ClosureReason {
+  if (i.maxTurnsHit) return 'max_turns_exceeded';
+  if (i.hookBlocked) return 'hook_blocked';
+  if (i.dispatchReason === 'error') return 'abort';
+  if (i.abort !== null) return i.abort;
+  if (isTruncationStopReason(i.lastStopReason)) return 'truncated';
+  return 'model_end_turn';
+}

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -249,6 +249,7 @@ export const CompactionPayloadPersistedSchema = z.object({
 
 export const ClosureReasonSchema = z.enum([
   'model_end_turn',
+  'truncated',
   'iteration_cap',
   'abort',
   'timeout',

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -304,6 +304,9 @@ export interface CompactionPayloadPersisted {
 
 export type ClosureReason =
   | 'model_end_turn'
+  // Model's final turn was cut off by the output-token ceiling
+  // (Anthropic `max_tokens` / OpenAI `length`), not a clean completion.
+  | 'truncated'
   | 'iteration_cap'
   | 'abort'
   | 'timeout'


### PR DESCRIPTION
## Summary

**Patch 2 of the budget-governor work** (`docs/audits/failure-geometry-audit.md`, shipped in #58). Makes the session's terminal classification honest.

**Problem.** `deriveClosureReason` only ever produced `model_end_turn` / `abort` / `budget_exceeded` / `timeout`. Empirically, across **3,376 on-disk traces only 2 of the 7 enum values ever fired** (`model_end_turn`, `abort`), and `max_tokens` truncation had **no representation at all** (0 captures). Distinct terminal causes collapsed into "completed" or "aborted", so you couldn't tell *why* a run actually ended.

**This PR wires the specific reasons from their origin sites:**
- **`truncated`** *(new `ClosureReason` value)* — the model's final turn was cut off by the output-token ceiling. Signal: last provider stop reason is `max_tokens` (Anthropic) or `length` (OpenAI). Added to the `ClosureReason` union and the `ClosureReasonSchema` Zod enum (kept in sync). *(audit F14, F15)*
- **`max_turns_exceeded`** — flagged where `assertCanSend` trips the per-session turn cap; the throw otherwise surfaces as a generic abort. *(audit F13)*
- **`hook_blocked`** — flagged in the init catch when a `SessionStart` hook throws `HookBlockedError` (verified: `dispatchSessionStart` re-throws it up through `pullInitialization`). *(audit F13)*

**Design.** The precedence decision tree is extracted into a pure, unit-tested `classifyClosureReason` (`src/agent/session/closure-reason.ts`), mirroring the existing `shouldAutoCompact` pattern. `deriveClosureReason` pre-classifies the abort-signal reason (which needs the concrete error classes in scope) and delegates the tree. **Prior classifications are preserved exactly** — e.g. a generic init-time error still outranks the abort-signal class.

## Deferred (per audit)
- **`iteration_cap`** → Patch 3. Nothing sets a tool-use loop cap in production yet (`DEFAULT_MAX_TOOL_USE_ITERATIONS = 0`), so it has nothing to fire it. It's wired alongside the cap that produces it — folding it in here would be dead code.

## Verification
- `pnpm lint` (tsc --noEmit strict) ✓
- `pnpm audit:env:check` ✓ (no new `process.env` reads) · `pnpm scan:env:check` ✓
- `pnpm build` ✓
- New: 11 classifier unit tests. Existing: session suite **108/108**, trace suite **191/191** — `truncated` addition kept type/schema in sync; no regression.

## Risk
Low and additive. The only behavioral change is in trace *classification* — sessions that previously logged `model_end_turn`/`abort` for a truncation, turn-cap, or SessionStart-block now log the specific reason. No runtime control-flow changes. Stacks cleanly on #58 (disjoint files).
