### PR TITLE
fix(awareness): recompute git workspace state per read instead of freezing at session start

### DIFF
--- a/src/agent/awareness/runtime-source.test.ts
+++ b/src/agent/awareness/runtime-source.test.ts
@@ -4,10 +4,19 @@
  * MCP tools by server correctly.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { buildRuntimeStateSource } from './runtime-source.js';
+import { gatherWorkspace } from './workspace-source.js';
 import type { AnthropicToolDef } from '../tools/types.js';
-import type { RuntimeSubagents } from './types.js';
+import type { RuntimeSubagents, RuntimeWorkspace } from './types.js';
+
+// `getWorkspace()` delegates to the real `gatherWorkspace`, which spawns git
+// subprocesses against the test's cwd — nondeterministic and slow. Mock it so
+// the tests can assert the *call discipline* (fresh per read vs. frozen at
+// construction) deterministically, without depending on a real repo.
+vi.mock('./workspace-source.js', () => ({
+  gatherWorkspace: vi.fn(),
+}));
 
 // --- Fixture builders --------------------------------------------------------
 
@@ -225,5 +234,54 @@ describe('buildRuntimeStateSource.getSubagents', () => {
   it('returns empty result shape when no subagent executor is wired', () => {
     const src = buildRuntimeStateSource(defaultDeps());
     expect(src.getSubagents()).toEqual({ active: [], backgroundJobs: [] });
+  });
+});
+
+// --- getWorkspace ------------------------------------------------------------
+
+describe('buildRuntimeStateSource.getWorkspace', () => {
+  const ws = (dirtyCount: number): RuntimeWorkspace => ({
+    branch: 'main',
+    headSha: 'abc1234',
+    dirty: dirtyCount > 0,
+    dirtyCount,
+    remoteUrl: 'git@github.com:acme/repo.git',
+  });
+
+  beforeEach(() => {
+    vi.mocked(gatherWorkspace).mockReset();
+  });
+
+  it('recomputes workspace state on every call — not frozen at construction', () => {
+    // Regression guard: getWorkspace() previously returned a single
+    // construction-time snapshot, so the model saw a stale dirtyCount no matter
+    // how many files changed mid-session. It must now pull fresh on each read,
+    // mirroring the live getTools()/getSubagents() accessors.
+    vi.mocked(gatherWorkspace)
+      .mockReturnValueOnce(ws(0)) // clean at first orientation
+      .mockReturnValueOnce(ws(3)); // 3 files written since
+
+    const src = buildRuntimeStateSource(defaultDeps());
+
+    expect(src.getWorkspace().dirtyCount).toBe(0);
+    // The frozen implementation would still report 0 here — this is the line
+    // that fails against the pre-unfreeze code.
+    expect(src.getWorkspace().dirtyCount).toBe(3);
+    expect(vi.mocked(gatherWorkspace)).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not gather eagerly at construction (no spawn until first read)', () => {
+    vi.mocked(gatherWorkspace).mockReturnValue(ws(0));
+    buildRuntimeStateSource(defaultDeps());
+    // The old code spawned 4 git processes at construction even if no one ever
+    // read the workspace. The unfrozen version is lazy.
+    expect(vi.mocked(gatherWorkspace)).not.toHaveBeenCalled();
+  });
+
+  it('passes deps.cwd through to gatherWorkspace on each read', () => {
+    vi.mocked(gatherWorkspace).mockReturnValue(ws(0));
+    const src = buildRuntimeStateSource({ ...defaultDeps(), cwd: '/custom/work' });
+    src.getWorkspace();
+    expect(vi.mocked(gatherWorkspace)).toHaveBeenCalledWith('/custom/work');
   });
 });

--- a/src/agent/awareness/runtime-source.ts
+++ b/src/agent/awareness/runtime-source.ts
@@ -4,7 +4,7 @@
  * Shared by both `anthropic-direct` and `openai-compatible` providers so the
  * resulting snapshot shape is provider-agnostic. The provider supplies live
  * accessors (lambdas), not snapshots, so subsequent `get_runtime_state` calls
- * see up-to-date subagent and MCP tool counts.
+ * see up-to-date subagent counts, MCP tool counts, and git workspace state.
  *
  * @module agent/awareness/runtime-source
  */
@@ -73,18 +73,13 @@ export interface RuntimeSourceDeps {
  * those exposed as live accessors. For Phase 1 this is fine — identity fields
  * (`sessionId`, `depth`, `parentSessionId`, etc.) do not change mid-session.
  *
- * Phase 2: `getWorkspace()` returns the git baseline captured once via
- * `gatherWorkspace(deps.cwd)` at construction time. Git state changes rarely
- * and the model only needs orientation — a session-start snapshot is enough.
- * Callers that need a fresher snapshot should construct a new source.
+ * `getWorkspace()` recomputes git workspace state on every call via
+ * `gatherWorkspace(deps.cwd)`, mirroring the live `getTools()`/`getSubagents()`
+ * accessors. This costs 4 `spawnSync` git calls per invocation, but means the
+ * model sees the *current* dirty-file count / HEAD / branch when it orients,
+ * not a frozen session-start snapshot that silently goes stale as files change.
  */
 export function buildRuntimeStateSource(deps: RuntimeSourceDeps): RuntimeStateSource {
-  // Gather the workspace baseline once, synchronously, at construction time.
-  // `gatherWorkspace` runs 4 spawnSync git calls but the result is stable for
-  // the session lifetime. Caching it here means every `get_runtime_state`
-  // call returns the same object without re-spawning.
-  const workspace: RuntimeWorkspace = gatherWorkspace(deps.cwd);
-
   return {
     getSelf(): RuntimeSelf {
       return {
@@ -112,7 +107,10 @@ export function buildRuntimeStateSource(deps: RuntimeSourceDeps): RuntimeStateSo
       return deps.getSubagents();
     },
     getWorkspace(): RuntimeWorkspace {
-      return workspace;
+      // Live: recompute per call so the snapshot reflects edits made since
+      // session start — the agent's own writes AND concurrent external writers.
+      // Cost: 4 spawnSync git calls per call (see gatherWorkspace).
+      return gatherWorkspace(deps.cwd);
     },
   };
 }

--- a/src/agent/awareness/workspace-source.ts
+++ b/src/agent/awareness/workspace-source.ts
@@ -1,10 +1,11 @@
 /**
  * Workspace baseline gatherer (Phase 2).
  *
- * Captures git state via synchronous child-process calls at session-start
- * time. The result is cached by the caller — `gatherWorkspace` itself is
- * stateless and always performs 4 `spawnSync` calls (branch, SHA, status,
- * remote). Callers who need the result more than once should cache it.
+ * Captures git state via synchronous child-process calls. `gatherWorkspace`
+ * itself is stateless and always performs 4 `spawnSync` calls (branch, SHA,
+ * status, remote); whether to cache the result or call it fresh for liveness
+ * is the caller's choice (see `runtime-source.ts`, which calls it per-read so
+ * the model sees current state).
  *
  * Design:
  *   - Uses `spawnSync` rather than `execSync` to avoid shell injection on
@@ -63,8 +64,10 @@ function gitOutput(cwd: string, args: string[]): string | null {
  * Individual field nullability is finer-grained: `branch` being null while
  * `headSha` is set indicates a detached HEAD.
  *
- * Callers MUST cache the returned object — this function performs 4
- * synchronous process spawns on every call.
+ * This function performs 4 synchronous process spawns on every call. Callers
+ * that need only a one-time baseline should cache the result; callers that need
+ * liveness (e.g. `get_runtime_state` reflecting the current dirty state) call
+ * it fresh each time and accept the per-call spawn cost.
  */
 export function gatherWorkspace(cwd: string): RuntimeWorkspace {
   // Verify this is a git repo first — avoids running 3 more commands when it's not.


### PR DESCRIPTION
## What

`getWorkspace()` in the runtime awareness source cached a single
`gatherWorkspace(cwd)` snapshot taken at construction time, so
`get_runtime_state { view: "workspace" }` reported the **session-start** git
state (dirtyCount / HEAD / branch) no matter how much changed mid-session.

This makes it a live accessor — recomputing on every read — matching the
sibling `getTools()` / `getSubagents()` accessors right beside it. The model
now sees current workspace state when it orients, instead of a frozen snapshot
that silently goes stale as files change (its own edits and concurrent external
writers).

## Why

The workspace fields are the one part of the runtime snapshot that drifts during
a session. Freezing them meant the orientation tool returned stale-but-
authoritative data — the worst failure mode for a tool whose job is situational
awareness.

## Changes

- `runtime-source.ts` — `getWorkspace()` calls `gatherWorkspace(deps.cwd)` per
  read; drop the eager construction-time gather and the now-false caching
  comments.
- `workspace-source.ts` — doc reflects caller-choice caching vs. liveness.
- `runtime-source.test.ts` — regression tests: fresh-per-read, lazy (no eager
  spawn at construction), and cwd passthrough.

## Cost

4 `spawnSync` git calls per `getWorkspace()` read (previously: 4 once at
construction). Acceptable for an orientation tool; a turn-boundary-only /
dirty-count-only refresh is a possible follow-up if per-read cost matters.

## Verification

- `pnpm lint` (tsc --noEmit, strict) — clean
- `pnpm test -- src/agent/awareness/` — 78/78 pass
- Regression guard proven: the new tests fail against the pre-change frozen
  code and pass after.
