### PR TITLE
fix(tui): route subagent overlay refreshes through OverlayComposer

### DIFF
--- a/src/cli/_lib/stream-renderer-subagent-helpers.ts
+++ b/src/cli/_lib/stream-renderer-subagent-helpers.ts
@@ -271,6 +271,15 @@ export function finalizeSubagent(
     syntheticResult(summary, false),
   );
   if (ctx.isTTY && ctx.compositor) {
-    ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
+    // Route the final Done-row overlay through the composer when present so it
+    // recomposes all active slots in z-order instead of clobbering the overlay
+    // region with the tool-lane alone (overlay-composer.ts invariant: the
+    // composer is the sole writer of compositor.setOverlay during a turn).
+    if (ctx.overlayComposer) {
+      ctx.overlayComposer.markDirty('tool-lane');
+      ctx.overlayComposer.flush();
+    } else {
+      ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
+    }
   }
 }

--- a/src/cli/_lib/stream-renderer-subagent.ts
+++ b/src/cli/_lib/stream-renderer-subagent.ts
@@ -237,7 +237,20 @@ export function handleSubagentEvent(
             const lastOverlay = _overlayLastUpdate.get(parentId) ?? 0;
             if (now - lastOverlay >= 1500) {
               _overlayLastUpdate.set(parentId, now);
-              ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
+              // Route the throttled refresh through the composer when present so
+              // it recomposes ALL active slots in z-order. A direct
+              // compositor.setOverlay would overwrite the single overlay region
+              // with only the tool-lane, clobbering the markdown-pending /
+              // stage-rail / thinking-tail slots — the OverlayComposer is the
+              // sole writer of compositor.setOverlay while a turn is live (see
+              // overlay-composer.ts). Falls back to direct setOverlay only when
+              // no composer is wired (tests / non-TTY).
+              if (ctx.overlayComposer) {
+                ctx.overlayComposer.markDirty('tool-lane');
+                ctx.overlayComposer.flush();
+              } else {
+                ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
+              }
             }
           }
         } else {
@@ -285,7 +298,14 @@ export function handleSubagentEvent(
             const lastOverlay = _overlayLastUpdate.get(parentId) ?? 0;
             if (now - lastOverlay >= 1500) {
               _overlayLastUpdate.set(parentId, now);
-              ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
+              // Route through the composer when present (see content path above)
+              // so the throttled refresh never clobbers sibling overlay slots.
+              if (ctx.overlayComposer) {
+                ctx.overlayComposer.markDirty('tool-lane');
+                ctx.overlayComposer.flush();
+              } else {
+                ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
+              }
             }
           }
         }
@@ -329,7 +349,15 @@ export function handleSubagentEvent(
         ctx.toolLane.addResult(parentId, syntheticResult(errorSummary, true));
       }
       if (ctx.isTTY && ctx.compositor) {
-        ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
+        // Route through the composer when present so the error's terminal
+        // overlay recomposes all slots instead of clobbering the overlay
+        // region with the tool-lane alone (overlay-composer.ts invariant).
+        if (ctx.overlayComposer) {
+          ctx.overlayComposer.markDirty('tool-lane');
+          ctx.overlayComposer.flush();
+        } else {
+          ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
+        }
       }
       return;
 


### PR DESCRIPTION
## Problem

A regression made the interactive TUI render incorrectly — overlay content scrambled and interleaved across the screen during agent turns. Because AFK's core workflow is subagent delegation (`/diagnose`, `/mint`, `/review`, etc. all spawn subagents), it surfaced broadly as "a lot of stuff rendering fucky."

## Root cause

`OverlayComposer` (`src/cli/_lib/overlay-composer.ts`) is, by its own documented contract, **the sole writer of `compositor.setOverlay()` while a turn is live** — it composes all active slots (tool-lane, markdown-pending, stage-rail, thinking-tail) in a fixed z-order and pushes them in exactly one `setOverlay` call.

Four paths in the subagent renderer violated that invariant by calling `ctx.compositor.setOverlay(ctx.toolLane.getOverlay())` **directly**, with no composer guard:

- content-chunk throttle (`stream-renderer-subagent.ts`)
- thinking-chunk throttle (`stream-renderer-subagent.ts`)
- error path (`stream-renderer-subagent.ts`)
- `finalizeSubagent` Done-row (`stream-renderer-subagent-helpers.ts`)

A direct `setOverlay` overwrites the entire overlay region with **only** the tool-lane content, clobbering the composer's other slots. In production TTY both `compositor` and `overlayComposer` are non-null, so these fired on every subagent content chunk (throttled ~1500ms), every thinking token in live mode, every subagent error, and every subagent completion.

## Fix

Route all four paths through the composer when present (`markDirty('tool-lane')` + `flush()`), falling back to direct `setOverlay` only for tests/non-TTY — matching the already-correct discrete `tool_use_detail` / `tool_result` / `tool_diff` paths in the same file. The 1500ms H2 throttle is preserved; the flush is composed instead of clobbering.

## Scope

Audited all ~20 `setOverlay` call sites: every other one is already composer-aware (composer branch first, direct `setOverlay` only as an `else` fallback), including the orchestrator paths and `setComposedOverlay`'s legacy/test fallback. These four were the only genuine bypasses.

## Verification

- `tsc --noEmit` (strict) — clean
- `src/cli/_lib/` — 283 tests pass (incl. `overlay-composer`, `stream-renderer-subagent`, and the **H2 throttle tests**: `setOverlay` still fires ≤1× per 1500ms window)
- `src/cli/commands/interactive/` + `markdown-stream` — 784 tests pass
