### PR TITLE
feat(models): add Claude Fable 5 (claude-fable-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 Optional, in order of usefulness:
 
 ```bash
-# Pick a model — opus | sonnet | haiku (Anthropic) or codex (OpenAI)
+# Pick a model — opus | sonnet | haiku | fable (Anthropic) or codex (OpenAI)
 AFK_MODEL=sonnet
 
 # Enable the Telegram bot + send_telegram tool
@@ -87,6 +87,7 @@ afk chat "refactor this" --model codex
 
 | Model | Best for |
 |---|---|
+| `fable` | Most capable — Claude Fable 5 (Mythos-class), hardest reasoning + long-horizon agentic work (1M context) |
 | `opus` | Complex reasoning, multi-step planning, long contexts |
 | `sonnet` | Day-to-day default — balanced speed and capability |
 | `haiku` | Fast, cheap, one-shots |

--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -251,7 +251,7 @@
     },
     {
       "name": "AFK_MODEL",
-      "description": "Default model for agent turns. Accepts slot names (small, medium, large), legacy aliases (opus, sonnet, haiku), or full model IDs.",
+      "description": "Default model for agent turns. Accepts slot names (small, medium, large), legacy aliases (opus, sonnet, haiku), the fixed-id fable alias (Claude Fable 5), or full model IDs.",
       "type": "string",
       "required": false,
       "default": "sonnet",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -19,7 +19,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_MAX_BUDGET_USD` | number |  | `5.00` | `10.00` | Per-turn USD budget ceiling. Aborts the turn when projected spend would exceed this. |
 | `AFK_MAX_OUTPUT_TOKENS` | number |  |  | `8192` | Cap on output tokens per turn. Falls back to provider default when unset. |
 | `AFK_MAX_TOKENS` | number |  | `4096` | `8192` | Cap on total tokens per turn (input + output). Default 4096. |
-| `AFK_MODEL` | string |  | `sonnet` | `claude-opus-4-5` | Default model for agent turns. Accepts slot names (small, medium, large), legacy aliases (opus, sonnet, haiku), or full model IDs. |
+| `AFK_MODEL` | string |  | `sonnet` | `claude-opus-4-5` | Default model for agent turns. Accepts slot names (small, medium, large), legacy aliases (opus, sonnet, haiku), the fixed-id `fable` alias (Claude Fable 5), or full model IDs. |
 | `AFK_MODEL_LARGE` | string |  |  | `claude-opus-4-8` | Bind the "large" capability tier (most capable) to a model id/alias. Overrides afk.config.json models.large. |
 | `AFK_MODEL_LARGE_API_KEY` | string |  |  |  | Per-slot API key for the "large" tier (Stage 2). Overrides global credentials for this tier only. |
 | `AFK_MODEL_LARGE_BASE_URL` | string |  |  | `http://localhost:8080/v1` | Per-slot endpoint base URL for the "large" tier (Stage 2). Anthropic Messages base or OpenAI-compatible base per the tier provider. |

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -19,7 +19,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_MAX_BUDGET_USD` | number |  | `5.00` | `10.00` | Per-turn USD budget ceiling. Aborts the turn when projected spend would exceed this. |
 | `AFK_MAX_OUTPUT_TOKENS` | number |  |  | `8192` | Cap on output tokens per turn. Falls back to provider default when unset. |
 | `AFK_MAX_TOKENS` | number |  | `4096` | `8192` | Cap on total tokens per turn (input + output). Default 4096. |
-| `AFK_MODEL` | string |  | `sonnet` | `claude-opus-4-5` | Default model for agent turns. Accepts slot names (small, medium, large), legacy aliases (opus, sonnet, haiku), the fixed-id `fable` alias (Claude Fable 5), or full model IDs. |
+| `AFK_MODEL` | string |  | `sonnet` | `claude-opus-4-5` | Default model for agent turns. Accepts slot names (small, medium, large), legacy aliases (opus, sonnet, haiku), the fixed-id fable alias (Claude Fable 5), or full model IDs. |
 | `AFK_MODEL_LARGE` | string |  |  | `claude-opus-4-8` | Bind the "large" capability tier (most capable) to a model id/alias. Overrides afk.config.json models.large. |
 | `AFK_MODEL_LARGE_API_KEY` | string |  |  |  | Per-slot API key for the "large" tier (Stage 2). Overrides global credentials for this tier only. |
 | `AFK_MODEL_LARGE_BASE_URL` | string |  |  | `http://localhost:8080/v1` | Per-slot endpoint base URL for the "large" tier (Stage 2). Anthropic Messages base or OpenAI-compatible base per the tier provider. |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -48,7 +48,7 @@ All commands support `--format json` where machine-readable output makes sense (
 ### Per-session overrides
 
 ```
---model <name>            # opus | sonnet | haiku | codex
+--model <name>            # opus | sonnet | haiku | fable | codex
 --thinking <on|off|N>     # extended thinking budget
 --max-output-tokens <n>
 --temperature <n>
@@ -111,7 +111,8 @@ Implementation: `src/cli/slash/index.ts` (`registerAll()`), individual command m
 `agent-afk` speaks to two providers through a single abstraction (`src/agent/providers/`):
 
 **Anthropic (direct)** — default. Selects from:
-- **opus** — most capable, for complex tasks
+- **fable** — most capable (Claude Fable 5, Mythos-class) — hardest reasoning + long-horizon agentic work; 1M context
+- **opus** — most capable Opus-tier, for complex tasks
 - **sonnet** — balanced performance and speed (default)
 - **haiku** — fastest, best for simple tasks
 
@@ -178,7 +179,7 @@ The setup wizard prompts for the token and the chat IDs allowed to interact with
 **Bot commands:**
 - `/start` — welcome
 - `/reset` — clear conversation
-- `/model opus|sonnet|haiku` — switch model
+- `/model opus|sonnet|haiku|fable` — switch model
 
 Send any other message to chat. The bot has full tool access via bypass mode.
 

--- a/src/agent/model-limits.ts
+++ b/src/agent/model-limits.ts
@@ -30,6 +30,7 @@ export const MODEL_MAX_OUTPUT_TOKENS: Record<string, number> = {
   sonnet: 64_000,
   sonnet_1m: 64_000,
   haiku: 64_000,
+  fable: 128_000,
   'claude-opus-4-8': 128_000,
   // 'claude-opus-4-7' removed — retired model; MODEL_MAP.opus now points to
   // claude-opus-4-8. Kept here as a comment so git blame reveals the removal.
@@ -37,6 +38,8 @@ export const MODEL_MAX_OUTPUT_TOKENS: Record<string, number> = {
   // 2026-05-28.)
   'claude-sonnet-4-6': 64_000,
   'claude-haiku-4-5-20251001': 64_000,
+  // Claude Fable 5 (Mythos-class, GA 2026-06-09): 128k max output.
+  'claude-fable-5': 128_000,
 } as const;
 
 const DEFAULT_MAX_OUTPUT = 64_000;
@@ -84,6 +87,12 @@ export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   sonnet: 200_000,
   sonnet_1m: 1_000_000,
   haiku: 200_000,
+  // Claude Fable 5 ships a 1M-token context window natively (no `_1m` opt-in,
+  // unlike opus/sonnet whose base window is 200k). Keyed by both the `fable`
+  // alias and the `claude-fable-5` wire id so lookups hit either side of the
+  // alias boundary.
+  fable: 1_000_000,
+  'claude-fable-5': 1_000_000,
   // OpenAI flagship + cost-tier models (windows per OpenAI platform docs
   // as of 2026-Q1). Listed here so the openai-compatible provider's
   // getContextUsage() returns an accurate percentage instead of the

--- a/src/agent/providers/routing.test.ts
+++ b/src/agent/providers/routing.test.ts
@@ -61,6 +61,7 @@ describe('providerForModel', () => {
       'sonnet',
       'sonnet_1m',
       'haiku',
+      'fable',
       'auto',
     ])('routes short alias %s to anthropic', (alias) => {
       expect(providerForModel(alias)).toBe('anthropic-direct');
@@ -71,6 +72,7 @@ describe('providerForModel', () => {
       'claude-sonnet-4-6',
       'claude-haiku-4-5-20251001',
       'claude-sonnet-4',
+      'claude-fable-5',
     ])('routes full Claude id %s to anthropic', (id) => {
       expect(providerForModel(id)).toBe('anthropic-direct');
     });
@@ -408,8 +410,10 @@ describe('createChildProviderFactory — child provider routing', () => {
     'opus',
     'opus_1m',
     'haiku',
+    'fable',
     'claude-opus-4-8',
     'claude-sonnet-4-6',
+    'claude-fable-5',
   ])('routes Claude id %s to AnthropicDirectProvider', (model) => {
     const factory = createChildProviderFactory();
     const provider = factory({ childExecutor, childSkillExecutor, model });
@@ -548,8 +552,10 @@ describe('getDefaultSubagentModel — parent-aware fallback', () => {
     'opus',
     'opus_1m',
     'haiku',
+    'fable',
     'claude-opus-4-8',
     'claude-sonnet-4-6',
+    'claude-fable-5',
   ])('defaults to "sonnet" for Claude parent %s (preserves cost-mgmt intent)', (parent) => {
     expect(getDefaultSubagentModel(parent)).toBe('sonnet');
   });

--- a/src/agent/session/model-resolution.ts
+++ b/src/agent/session/model-resolution.ts
@@ -9,7 +9,7 @@
  */
 
 import type { AgentModelInput, ClaudeModel } from '../types.js';
-import { DEFAULT_SLOT_BINDINGS, resolveModelInput } from './model-slots.js';
+import { CLAUDE_FABLE_5_ID, DEFAULT_SLOT_BINDINGS, resolveModelInput } from './model-slots.js';
 
 /**
  * Canonical short-alias → full model-ID mapping for the built-in Claude
@@ -22,6 +22,9 @@ import { DEFAULT_SLOT_BINDINGS, resolveModelInput } from './model-slots.js';
  * Note: actual model selection now flows through the slot resolver
  * ({@link resolveModelId} → `resolveModelInput`), which honors user rebindings
  * of these aliases. `MODEL_MAP` reflects only the *default* bindings.
+ *
+ * The `fable` entry is a fixed-id alias (`DIRECT_MODEL_ALIASES`), not a tier —
+ * it names one concrete model above the opus/large slot and is never rebound.
  */
 export const MODEL_MAP: Readonly<Record<ClaudeModel, string>> = {
   opus: DEFAULT_SLOT_BINDINGS.large.id,
@@ -29,6 +32,10 @@ export const MODEL_MAP: Readonly<Record<ClaudeModel, string>> = {
   sonnet: DEFAULT_SLOT_BINDINGS.medium.id,
   sonnet_1m: DEFAULT_SLOT_BINDINGS.medium.id,
   haiku: DEFAULT_SLOT_BINDINGS.small.id,
+  // Fixed-id alias (above the large/opus tier — not a slot). Derived from the
+  // canonical id in model-slots.ts so the alias table cannot drift from the
+  // direct-alias resolver.
+  fable: CLAUDE_FABLE_5_ID,
 };
 
 export function isValidModel(model: string): model is ClaudeModel {

--- a/src/agent/session/model-slots.test.ts
+++ b/src/agent/session/model-slots.test.ts
@@ -5,8 +5,10 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  CLAUDE_FABLE_5_ID,
   computeSlotBindings,
   DEFAULT_SLOT_BINDINGS,
+  DIRECT_MODEL_ALIASES,
   getSlotBindings,
   parseModelsConfig,
   resetSlotBindings,
@@ -95,6 +97,39 @@ describe('resolveModelInput', () => {
     expect(resolveModelInput('mlx-community/Qwen3-32B-4bit')).toBe('mlx-community/Qwen3-32B-4bit');
     expect(resolveModelInput('auto')).toBe('auto');
     expect(resolveModelInput(undefined)).toBeUndefined();
+  });
+});
+
+describe('Claude Fable 5 fixed-id alias', () => {
+  it('exposes the canonical wire id via the direct-alias table', () => {
+    expect(CLAUDE_FABLE_5_ID).toBe('claude-fable-5');
+    expect(DIRECT_MODEL_ALIASES['fable']).toBe('claude-fable-5');
+  });
+
+  it('resolves the `fable` alias straight to claude-fable-5 (case-insensitive)', () => {
+    expect(resolveModelInput('fable')).toBe('claude-fable-5');
+    expect(resolveModelInput('FABLE')).toBe('claude-fable-5');
+    expect(resolveModelInput('  Fable  ')).toBe('claude-fable-5');
+    expect(resolveBinding('fable')).toEqual({ id: 'claude-fable-5' });
+  });
+
+  it('is NOT a capability tier — slotForInput never matches it', () => {
+    // fable sits above the large/opus slot, so it has no tier of its own.
+    expect(slotForInput('fable')).toBeUndefined();
+  });
+
+  it('stays pinned to claude-fable-5 regardless of slot rebindings', () => {
+    // The direct alias bypasses slot bindings entirely: rebinding every tier to
+    // an OpenAI id must not drag `fable` off claude-fable-5.
+    const rebound = makeSlots({ small: 'gpt-4o-mini', medium: 'gpt-4o', large: 'gpt-4o' });
+    expect(resolveModelInput('fable', rebound)).toBe('claude-fable-5');
+  });
+
+  it('reports the 1M context window and 128k max output', () => {
+    expect(contextLimitFor('fable')).toBe(1_000_000);
+    expect(contextLimitFor('claude-fable-5')).toBe(1_000_000);
+    expect(maxOutputTokensFor('fable')).toBe(128_000);
+    expect(maxOutputTokensFor('claude-fable-5')).toBe(128_000);
   });
 });
 

--- a/src/agent/session/model-slots.ts
+++ b/src/agent/session/model-slots.ts
@@ -105,6 +105,23 @@ const LEGACY_ALIAS_TO_SLOT: Readonly<Record<string, SlotName>> = {
  */
 export const AUTO_SENTINEL = 'auto';
 
+/** Claude Fable 5 wire id — Anthropic's most-capable widely-released model. */
+export const CLAUDE_FABLE_5_ID = 'claude-fable-5';
+
+/**
+ * Fixed-id model aliases that are NOT capability tiers. Unlike the slot aliases
+ * (`small`/`medium`/`large`) and the legacy tier aliases (`haiku`/`sonnet`/
+ * `opus`), these name one concrete pinned model and are never rebound by user
+ * slot config. `fable` → Claude Fable 5 (`claude-fable-5`), the Mythos-class
+ * model GA'd 2026-06-09; it sits above the `large`/opus tier and so has no slot
+ * of its own — keeping it a direct alias means adding it does not displace any
+ * existing tier binding. Consulted by {@link resolveBinding} after slot
+ * resolution and before the raw-id passthrough.
+ */
+export const DIRECT_MODEL_ALIASES: Readonly<Record<string, string>> = {
+  fable: CLAUDE_FABLE_5_ID,
+};
+
 /**
  * Process-global resolved bindings, installed by `loadConfig()` via
  * {@link setSlotBindings}. `undefined` until installed; callers fall back to
@@ -237,6 +254,10 @@ export function resolveBinding(
   if (input === undefined) return { id: '' };
   const slot = slotForInput(input, bindings);
   if (slot) return bindings[slot];
+  // Fixed-id aliases (e.g. `fable` → claude-fable-5) are not tiers, so they
+  // bypass slot bindings and resolve straight to their pinned wire id.
+  const directId = DIRECT_MODEL_ALIASES[input.trim().toLowerCase()];
+  if (directId) return { id: directId };
   return { id: input };
 }
 

--- a/src/agent/types/model-types.ts
+++ b/src/agent/types/model-types.ts
@@ -3,8 +3,16 @@
  * @module agent/types/model-types
  */
 
-/** Supported Claude model variants */
-export type ClaudeModel = 'opus' | 'opus_1m' | 'sonnet' | 'sonnet_1m' | 'haiku';
+/**
+ * Supported Claude model variants.
+ *
+ * `opus`/`sonnet`/`haiku` (+ the `*_1m` context variants) are the legacy tier
+ * aliases that resolve through the small/medium/large slots. `fable` is a
+ * fixed-id alias for Claude Fable 5 (`claude-fable-5`) — Anthropic's most
+ * capable widely-released model — which sits above the opus tier and resolves
+ * directly to its pinned wire id rather than through a slot.
+ */
+export type ClaudeModel = 'opus' | 'opus_1m' | 'sonnet' | 'sonnet_1m' | 'haiku' | 'fable';
 
 /**
  * Supported runtime model inputs. Short aliases are mapped to full Claude

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -67,8 +67,12 @@ const PINNED_HASHES = {
   refactor: '9cb84710ddf2cf63e1a648460a64656d3f4a9aae8e21753b031556070740c51e',
   research: '10692d77e392cedce928f66cb5dec27dbc2066f48cfc33047820f56506da762a',
   review: '31a17d8c3bace684b7fce22588d54ce3e95462acdf397fc1673f3590192e0944',
+  // Hash bumped 2026-06-09: reconciles the SKILL.md edit landed in #57
+  // ("skip adversarial re-derivation on text-terminal sessions"), which changed
+  // the bundled copy but did not bump this pin — leaving the snapshot test red
+  // on main. The behavior change is intentional; this records the new content.
   'shadow-verify':
-    '9b1ea7db65485f849ae6dfb9a6f69a102d7ccc6e5230b561dc76ef8c666475f8',
+    '58afb3387766498a7b4321bac56196a2654e0bca1153e2c0f7d66154e2fa8705',
   // Hash bumped 2026-06: Phase 4 (commit) + Phase 8 (PR) switched from the
   // `--body "$(cat <<'EOF' … EOF)"` heredoc-in-command-substitution antipattern
   // to the file-based form (`git commit -F` / `gh pr create --body-file`). The

--- a/src/cli/commands/completion.ts
+++ b/src/cli/commands/completion.ts
@@ -14,7 +14,7 @@ const SUBCOMMANDS = [
 
 const PLUGIN_SUBCOMMANDS = ['install', 'update', 'list', 'remove', 'enable', 'disable'] as const;
 
-const MODEL_VALUES = ['sonnet', 'opus', 'haiku'] as const;
+const MODEL_VALUES = ['sonnet', 'opus', 'haiku', 'fable'] as const;
 
 const FORMAT_VALUES = ['json', 'text'] as const;
 

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -78,6 +78,7 @@ describe('Config Loader', () => {
       expect(isValidModel('sonnet')).toBe(true);
       expect(isValidModel('sonnet_1m')).toBe(true);
       expect(isValidModel('haiku')).toBe(true);
+      expect(isValidModel('fable')).toBe(true);
     });
 
     it('should reject invalid model names', () => {
@@ -94,6 +95,7 @@ describe('Config Loader', () => {
       expect(getModelId('sonnet')).toBe('claude-sonnet-4-6');
       expect(getModelId('sonnet_1m')).toBe('claude-sonnet-4-6');
       expect(getModelId('haiku')).toBe('claude-haiku-4-5-20251001');
+      expect(getModelId('fable')).toBe('claude-fable-5');
     });
   });
 

--- a/src/cli/model-limits.test.ts
+++ b/src/cli/model-limits.test.ts
@@ -19,6 +19,16 @@ describe('model-limits', () => {
     expect(contextLimitFor('sonnet_1m')).toBe(1_000_000);
   });
 
+  it('declares the 1M context window for Claude Fable 5 (alias + wire id)', () => {
+    // Fable 5 ships 1M natively (no `_1m` opt-in). Both the `fable` alias and
+    // the `claude-fable-5` wire id must report the full window, not the 200k
+    // Anthropic fallback.
+    expect(MODEL_CONTEXT_LIMITS['fable']).toBe(1_000_000);
+    expect(MODEL_CONTEXT_LIMITS['claude-fable-5']).toBe(1_000_000);
+    expect(contextLimitFor('fable')).toBe(1_000_000);
+    expect(contextLimitFor('claude-fable-5')).toBe(1_000_000);
+  });
+
   it('contextLimitFor falls back to 200k for unknown Anthropic-style models', () => {
     expect(contextLimitFor('claude-xyz' as unknown as 'opus')).toBe(200_000);
     expect(contextLimitFor('')).toBe(200_000);

--- a/src/cli/slash/commands/info.ts
+++ b/src/cli/slash/commands/info.ts
@@ -17,7 +17,7 @@ import type { SlashCommand } from '../types.js';
 import type { AgentModelInput } from '../../../agent/types.js';
 
 /** Display hint only — not used for validation. Full model IDs (org/model) are also accepted. */
-const MODEL_ALIASES_HINT = ['small', 'medium', 'large', 'opus', 'opus_1m', 'sonnet', 'sonnet_1m', 'haiku'] as const;
+const MODEL_ALIASES_HINT = ['small', 'medium', 'large', 'opus', 'opus_1m', 'sonnet', 'sonnet_1m', 'haiku', 'fable'] as const;
 
 const costCmd: SlashCommand = {
   name: '/cost',
@@ -218,7 +218,7 @@ const resetCmd: SlashCommand = {
 
 const modelCmd: SlashCommand = {
   name: '/model',
-  usage: '/model <small|medium|large|opus|sonnet|haiku|org/model>',
+  usage: '/model <small|medium|large|opus|sonnet|haiku|fable|org/model>',
   summary: 'Switch the active model mid-session',
   hint: 'Switch the capability tier (small/medium/large — or your configured names) or pass a full model id. Upgrade to large for a hard problem, downshift to small for cheap iteration — context carries over. Also accepts HuggingFace-style ids (e.g. mlx-community/Qwen3-30B-A3B-4bit).',
   async handler(ctx, args) {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -166,7 +166,7 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
   },
   {
     name: 'AFK_MODEL',
-    description: 'Default model for agent turns. Accepts slot names (small, medium, large), legacy aliases (opus, sonnet, haiku), or full model IDs.',
+    description: 'Default model for agent turns. Accepts slot names (small, medium, large), legacy aliases (opus, sonnet, haiku), the fixed-id fable alias (Claude Fable 5), or full model IDs.',
     type: 'string',
     required: false,
     default: 'sonnet',

--- a/src/telegram/handlers/commands.ts
+++ b/src/telegram/handlers/commands.ts
@@ -28,7 +28,7 @@ import { formatResumeCommand } from '../../cli/resume-command.js';
 type LogFn = (...args: unknown[]) => void;
 
 /** Canonical short aliases accepted by /model and the inline keyboard. */
-export const MODEL_ALIASES_HINT = ['small', 'medium', 'large', 'opus', 'opus_1m', 'sonnet', 'sonnet_1m', 'haiku'] as const;
+export const MODEL_ALIASES_HINT = ['small', 'medium', 'large', 'opus', 'opus_1m', 'sonnet', 'sonnet_1m', 'haiku', 'fable'] as const;
 
 /**
  * Handle /clear command (SDK /clear - clear conversation history)


### PR DESCRIPTION
## What

Adds **Claude Fable 5** (`claude-fable-5`) — Anthropic's most capable widely-released model (Mythos-class, GA 2026-06-09; 1M context, 128k max output, adaptive thinking always on) — to agent-afk as a first-class, selectable model.

**Additive only — no current Claude models are removed.** `opus` (4.8) / `sonnet` (4.6) / `haiku` (4.5) and all their aliases (`opus_1m`, `sonnet_1m`) are untouched.

## Design

Fable 5 sits *above* the existing `large`/opus tier. Rather than rebinding a capability slot (which would silently change existing behavior), it is exposed as a **fixed-id alias** `fable` that resolves directly to the `claude-fable-5` wire id, independent of the `small`/`medium`/`large` slot bindings:

- New `DIRECT_MODEL_ALIASES` table in `model-slots.ts`, consulted in `resolveBinding` *after* slot resolution and *before* the raw-id passthrough.
- Consequence: `fable` is **never rebound** by user slot config — it always names one concrete model. (Test covers this invariant.)

Users can select it three ways, all working end-to-end: `afk -m fable` / `afk -m claude-fable-5`, `AFK_MODEL=fable`, or `/model fable` (REPL / Telegram).

## Changes

| Area | File | Change |
|---|---|---|
| Resolution | `agent/session/model-slots.ts` | `CLAUDE_FABLE_5_ID` + `DIRECT_MODEL_ALIASES`; resolve fixed-id alias in `resolveBinding` |
| Alias map | `agent/session/model-resolution.ts` | `MODEL_MAP.fable` (derived from canonical id → no drift; also locks `fable` to anthropic-direct via `CLAUDE_SHORT_ALIASES`) |
| Type | `agent/types/model-types.ts` | extend `ClaudeModel` union with `fable` |
| Limits | `agent/model-limits.ts` | **1M** context + **128k** output for `fable` and `claude-fable-5` (previously fell back to wrong 200k / 64k defaults) |
| Discoverability | `cli/slash/commands/info.ts`, `telegram/handlers/commands.ts`, `cli/commands/completion.ts` | add `fable` to `/model` hints + shell completion |
| Docs | `README.md`, `docs/reference.md`, `src/config/env.ts` → regenerated `docs/env-registry.{md,json}` | list `fable` in model tables |

**Routing needs no change:** `claude-fable-5` already matches the `claude-` prefix (Tier 2) → `anthropic-direct`.

## Tests

- Extended canonical suites: `routing.test.ts` (alias + wire id + child-provider + subagent-default), `model-slots.test.ts`, `model-limits.test.ts`, `config.test.ts`.
- New focused `Claude Fable 5 fixed-id alias` describe block: alias resolution (case-insensitive), the never-rebound-by-slots invariant, and the 1M/128k limits.

## CI gates (all green locally — `pnpm test:coverage`, the exact CI command)

- `pnpm lint` (strict `tsc --noEmit`) ✅
- `pnpm scan:env:check` ✅
- `pnpm audit:sdk:check` ✅ (no new SDK symbols)
- `pnpm test:coverage` → **460 files / 8604 passed**, 12 skipped, **0 failed**; coverage 82.93% stmts / 83.02% branches / 88.18% funcs / 82.93% lines (all above the 74/79/82/74 thresholds).

## Two follow-up fixes included (separate commits)

1. **`fix(docs): regenerate env-registry from env.ts`** — the initial Fable 5 commit hand-edited the *generated* `docs/env-registry.md`, which the `scan:env:check` gate flags as drift. Moved the `fable` mention into the `AFK_MODEL` description in `src/config/env.ts` and regenerated.
2. **`fix(test): bump shadow-verify bundled pinned hash to reconcile #57`** — this snapshot test has been red on `main` since #57 edited `shadow-verify/SKILL.md` without bumping its pin (the forcing function the test header documents). Unrelated to Fable 5, but it blocks CI on every PR off this main; bumped the pin to the committed content's hash so the guard goes green.
