### PR TITLE
feat(continuity): durable session event ledger + Telegram /watch live-tail

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -381,6 +381,14 @@
       "category": "browser"
     },
     {
+      "name": "AFK_SESSION_LEDGER_DISABLED",
+      "description": "Disable the per-session durable event ledger (state/sessions/<id>/events.jsonl). Set to 1 to skip ledger writes; live cross-surface watching (e.g. the Telegram /watch command) will report no activity for sessions started while disabled.",
+      "type": "boolean",
+      "required": false,
+      "example": "1",
+      "category": "debug"
+    },
+    {
       "name": "AFK_SESSIONSTART_COOLDOWN_MS",
       "description": "Cooldown in milliseconds between SessionStart trigger fires in the daemon. Prevents thundering-herd on rapid restarts.",
       "type": "number",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**104 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**105 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 
@@ -131,6 +131,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_DEBUG_CLIPBOARD` | boolean |  |  |  | Debug bracketed-paste and image-paste handling in the interactive REPL. |
 | `AFK_DEBUG_COMPOSITOR` | boolean |  |  |  | Gate compositor phase-boundary traces to stderr; any truthy value enables. |
 | `AFK_DUMP_PROMPT` | string |  |  | `/tmp/afk-prompt.txt` | Write the resolved system prompt to a file at startup. Accepts a path or 1 for default location. |
+| `AFK_SESSION_LEDGER_DISABLED` | boolean |  |  | `1` | Disable the per-session durable event ledger (state/sessions/<id>/events.jsonl). Set to 1 to skip ledger writes; live cross-surface watching (e.g. the Telegram /watch command) will report no activity for sessions started while disabled. |
 | `AFK_SKILL_STREAM_VERBOSE` | boolean |  |  |  | Verbose streaming output when a skill is dispatched. Logs sub-agent setup, intermediate events, and final result. |
 | `AFK_TELEGRAM_TRACE` | boolean |  |  | `1` | Set to 1 to dump raw bridge traffic between the agent and the Telegram bot — debugging only. |
 | `AFK_TRACE_DISABLED` | boolean |  |  | `1` | Disable the agent trace subsystem entirely. Set to 1 to skip trace file writes. |

--- a/src/agent/session-ledger.test.ts
+++ b/src/agent/session-ledger.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for the per-session durable event ledger.
+ *
+ * Uses a temp AFK_HOME per suite run so no real ~/.afk/state is touched
+ * (same pattern as bg-job-log.test.ts — env must be set before import).
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-ledger-test-'));
+process.env['AFK_HOME'] = tmpDir;
+
+// Import after env is set so path helpers resolve into the temp dir.
+import {
+  SessionLedgerWriter,
+  projectOutputEvent,
+  readLedger,
+  tailLedger,
+  ledgerExists,
+  type LedgerRecord,
+} from './session-ledger.js';
+import { getSessionLedgerPath, isSafeLedgerSessionId } from '../paths.js';
+import type { OutputEvent } from './types/session-types.js';
+
+let seq = 0;
+function freshId(): string {
+  return `ledger-test-${Date.now()}-${seq++}`;
+}
+
+async function collect(gen: AsyncGenerator<LedgerRecord>): Promise<LedgerRecord[]> {
+  const out: LedgerRecord[] = [];
+  for await (const r of gen) out.push(r);
+  return out;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ---------------------------------------------------------------------------
+// projectOutputEvent
+// ---------------------------------------------------------------------------
+
+describe('projectOutputEvent', () => {
+  it('projects assistant messages', () => {
+    const event: OutputEvent = {
+      type: 'message',
+      message: { role: 'assistant', content: 'hello world', timestamp: new Date() },
+    };
+    expect(projectOutputEvent(event)).toEqual({ kind: 'assistant', text: 'hello world' });
+  });
+
+  it('skips user-role message events (recorded separately via recordUser)', () => {
+    const event: OutputEvent = {
+      type: 'message',
+      message: { role: 'user', content: 'hi', timestamp: new Date() },
+    };
+    expect(projectOutputEvent(event)).toBeNull();
+  });
+
+  it('skips content deltas and progress (projection, not transcript)', () => {
+    expect(
+      projectOutputEvent({
+        type: 'chunk',
+        chunk: { type: 'content', content: 'tok' },
+      }),
+    ).toBeNull();
+    expect(
+      projectOutputEvent({
+        type: 'progress',
+        progress: {
+          taskId: 't1',
+          description: 'd',
+          totalTokens: 1,
+          toolUses: 0,
+          durationMs: 5,
+        },
+      }),
+    ).toBeNull();
+    expect(projectOutputEvent({ type: 'stream_retry' })).toBeNull();
+  });
+
+  it('projects tool starts with a capped input preview', () => {
+    const event: OutputEvent = {
+      type: 'chunk',
+      chunk: {
+        type: 'tool_use_detail',
+        toolUseId: 'tu1',
+        toolName: 'bash',
+        toolInput: 'x'.repeat(1000),
+      },
+    };
+    const payload = projectOutputEvent(event);
+    expect(payload).toMatchObject({ kind: 'tool', toolName: 'bash' });
+    if (payload?.kind === 'tool') {
+      expect(payload.input.length).toBeLessThan(500);
+      expect(payload.input).toContain('[truncated]');
+    }
+  });
+
+  it('projects failed tool results but skips successful ones', () => {
+    const failed: OutputEvent = {
+      type: 'chunk',
+      chunk: { type: 'tool_result', toolUseId: 'tu1', content: 'boom', isError: true },
+    };
+    expect(projectOutputEvent(failed)).toEqual({ kind: 'tool_error', content: 'boom' });
+
+    const ok: OutputEvent = {
+      type: 'chunk',
+      chunk: { type: 'tool_result', toolUseId: 'tu2', content: 'fine' },
+    };
+    expect(projectOutputEvent(ok)).toBeNull();
+  });
+
+  it('projects done with cost and duration when present', () => {
+    const event: OutputEvent = {
+      type: 'done',
+      metadata: { totalCostUsd: 0.0123, durationMs: 4200 },
+    };
+    expect(projectOutputEvent(event)).toEqual({ kind: 'done', costUsd: 0.0123, durationMs: 4200 });
+    expect(projectOutputEvent({ type: 'done' })).toEqual({ kind: 'done' });
+  });
+
+  it('projects errors as message strings', () => {
+    const payload = projectOutputEvent({ type: 'error', error: new Error('nope') });
+    expect(payload).toEqual({ kind: 'error', message: 'nope' });
+  });
+
+  it('projects paused/resumed', () => {
+    const resetsAt = new Date('2026-06-10T00:00:00Z');
+    expect(
+      projectOutputEvent({ type: 'paused', reason: 'usage-limit', resetsAt }),
+    ).toEqual({ kind: 'paused', resetsAt: resetsAt.toISOString() });
+    expect(projectOutputEvent({ type: 'resumed', hotSwapped: false })).toEqual({ kind: 'resumed' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Writer + reader round trip
+// ---------------------------------------------------------------------------
+
+describe('SessionLedgerWriter', () => {
+  it('writes records and round-trips through readLedger', async () => {
+    const id = freshId();
+    const writer = new SessionLedgerWriter(id);
+    expect(writer.active).toBe(true);
+
+    writer.record({ kind: 'meta', sessionId: id, model: 'sonnet' });
+    writer.recordUser('do the thing');
+    writer.recordEvent({
+      type: 'message',
+      message: { role: 'assistant', content: 'done!', timestamp: new Date() },
+    });
+    await writer.close('close');
+
+    const records = await collect(readLedger(id));
+    expect(records.map((r) => r.kind)).toEqual(['meta', 'user', 'assistant', 'closed']);
+    expect(records.every((r) => r.v === 1 && typeof r.ts === 'number')).toBe(true);
+    const closed = records[3];
+    expect(closed).toMatchObject({ kind: 'closed', reason: 'close' });
+  });
+
+  it('recordEvent no-ops for skipped event types (no file created)', async () => {
+    const id = freshId();
+    const writer = new SessionLedgerWriter(id);
+    writer.recordEvent({ type: 'chunk', chunk: { type: 'content', content: 'tok' } });
+    // No ledger-worthy record yet → lazy stream not opened → no events.jsonl.
+    expect(fs.existsSync(getSessionLedgerPath(id))).toBe(false);
+    await writer.close();
+    // close() writes the terminal record, which opens the stream.
+    expect(await ledgerExists(id)).toBe(true);
+  });
+
+  it('rejects unsafe session ids without throwing', () => {
+    const writer = new SessionLedgerWriter('../../evil');
+    expect(writer.active).toBe(false);
+    // Recording must be a silent no-op.
+    writer.record({ kind: 'user', text: 'x' });
+  });
+
+  it('close is idempotent and writes a single closed record', async () => {
+    const id = freshId();
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('hi');
+    await writer.close('close');
+    await writer.close('close');
+    const records = await collect(readLedger(id));
+    expect(records.filter((r) => r.kind === 'closed')).toHaveLength(1);
+  });
+
+  it('skips malformed lines on read', async () => {
+    const id = freshId();
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('first');
+    await writer.close();
+    fs.appendFileSync(getSessionLedgerPath(id), 'not-json\n{"v":2,"ts":1,"kind":"user","text":"wrong-version"}\n');
+    const records = await collect(readLedger(id));
+    expect(records.map((r) => r.kind)).toEqual(['user', 'closed']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSafeLedgerSessionId
+// ---------------------------------------------------------------------------
+
+describe('isSafeLedgerSessionId', () => {
+  it('accepts uuids and slugs', () => {
+    expect(isSafeLedgerSessionId('0806444d-1234-5678-9abc-def012345678')).toBe(true);
+    expect(isSafeLedgerSessionId('my-session_2')).toBe(true);
+  });
+  it('rejects traversal, separators, and empties', () => {
+    expect(isSafeLedgerSessionId('../../etc/passwd')).toBe(false);
+    expect(isSafeLedgerSessionId('a/b')).toBe(false);
+    expect(isSafeLedgerSessionId('')).toBe(false);
+    expect(isSafeLedgerSessionId('x'.repeat(129))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tailLedger
+// ---------------------------------------------------------------------------
+
+describe('tailLedger', () => {
+  it('replays history with fromStart and stops at the closed record', async () => {
+    const id = freshId();
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('one');
+    writer.recordUser('two');
+    await writer.close('close');
+
+    const records = await collect(tailLedger(id, { fromStart: true }));
+    expect(records.map((r) => r.kind)).toEqual(['user', 'user', 'closed']);
+  });
+
+  it('yields records appended after the tail started', async () => {
+    const id = freshId();
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('pre-existing');
+    // Give the lazy stream a beat to flush the first line.
+    await sleep(50);
+
+    const seen: LedgerRecord[] = [];
+    const done = (async () => {
+      for await (const rec of tailLedger(id)) {
+        seen.push(rec);
+      }
+    })();
+
+    await sleep(100);
+    writer.recordUser('live-one');
+    await sleep(400);
+    await writer.close('close');
+    await done;
+
+    // Started at end-of-file: must NOT include 'pre-existing'.
+    expect(seen.some((r) => r.kind === 'user' && 'text' in r && r.text === 'pre-existing')).toBe(false);
+    expect(seen.some((r) => r.kind === 'user' && 'text' in r && r.text === 'live-one')).toBe(true);
+    expect(seen.at(-1)?.kind).toBe('closed');
+  });
+
+  it('terminates when the abort signal fires', async () => {
+    const id = freshId();
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('hello');
+    await sleep(50);
+
+    const abort = new AbortController();
+    const tailPromise = collect(tailLedger(id, { signal: abort.signal }));
+    await sleep(100);
+    abort.abort();
+    const records = await tailPromise;
+    // No closed record was written — abort alone must end the generator.
+    expect(records.every((r) => r.kind !== 'closed')).toBe(true);
+    await writer.close();
+  });
+
+  it('returns immediately for unsafe ids', async () => {
+    const records = await collect(tailLedger('../escape'));
+    expect(records).toEqual([]);
+  });
+});

--- a/src/agent/session-ledger.ts
+++ b/src/agent/session-ledger.ts
@@ -1,0 +1,417 @@
+/**
+ * Per-session durable event ledger.
+ *
+ * Every top-level `AgentSession` appends a filtered projection of its
+ * `OutputEvent` stream to `~/.afk/state/sessions/<sessionId>/events.jsonl`.
+ * Any other process (the Telegram bot's `/watch`, a future `afk attach`)
+ * can tail that file to observe the session live — cross-surface visibility
+ * without a shared process, HTTP server, or new daemon dependency.
+ *
+ * Design (mirrors `bg-job-log.ts`, the proven JSONL writer/tailer pattern):
+ *   - Writer uses a lazy append stream — sessions that never produce a
+ *     ledger-worthy event leave no file.
+ *   - Disk errors are caught and suppressed on the write path: a session
+ *     must never fail because the ledger directory is unwritable.
+ *   - The ledger is a PROJECTION, not a transcript: per-token text/thinking
+ *     deltas, progress events, suggestions, and panel payloads are skipped.
+ *     What lands: user turns, full assistant messages, tool starts, failed
+ *     tool results, turn completions, errors, pause/resume, and a terminal
+ *     `closed` record. This keeps files compact and phone-renderable.
+ *   - `tailLedger` polls (250ms) with `fs.watch` as wakeup, yielding records
+ *     until the consumer aborts or a `closed` record is read.
+ *
+ * @module agent/session-ledger
+ */
+
+import * as fs from 'node:fs';
+import * as fsp from 'node:fs/promises';
+import * as readline from 'node:readline';
+import { getSessionLedgerDir, getSessionLedgerPath, isSafeLedgerSessionId } from '../paths.js';
+import type { OutputEvent } from './types/session-types.js';
+
+// ---------------------------------------------------------------------------
+// Record schema
+// ---------------------------------------------------------------------------
+
+/** One JSONL line in a session ledger. `v` is the schema version. */
+export type LedgerRecord = { v: 1; ts: number } & LedgerPayload;
+
+export type LedgerPayload =
+  /** Session-level metadata, written once when the ledger opens. */
+  | { kind: 'meta'; sessionId: string; model: string; cwd?: string; surface?: string }
+  /** A user turn entering the session (summary text, never raw blocks). */
+  | { kind: 'user'; text: string }
+  /** A complete assistant message. */
+  | { kind: 'assistant'; text: string }
+  /** A tool invocation starting. `input` is a preview, capped at source. */
+  | { kind: 'tool'; toolName: string; input: string }
+  /** A failed tool result (successful results are skipped — too chatty). */
+  | { kind: 'tool_error'; toolName?: string; content: string }
+  /** Turn completed. Cost/duration when the provider reported them. */
+  | { kind: 'done'; costUsd?: number; durationMs?: number }
+  /** Stream-level error. Message only — Error objects don't survive JSON. */
+  | { kind: 'error'; message: string }
+  /** Provider paused on a usage limit. */
+  | { kind: 'paused'; resetsAt?: string }
+  /** Provider resumed after a usage-limit pause. */
+  | { kind: 'resumed' }
+  /** Terminal record: the hosting process closed the session. */
+  | { kind: 'closed'; reason?: string };
+
+/** Cap stored user/assistant text so a pasted file can't bloat the ledger. */
+const MAX_TEXT_LEN = 8_000;
+/** Cap stored tool-input previews. */
+const MAX_TOOL_INPUT_LEN = 400;
+
+function clip(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}… [truncated]` : text;
+}
+
+/**
+ * Project an `OutputEvent` onto a ledger payload, or `null` for events the
+ * ledger intentionally skips (deltas, progress, suggestions, panels,
+ * stream-retry markers).
+ */
+export function projectOutputEvent(event: OutputEvent): LedgerPayload | null {
+  switch (event.type) {
+    case 'message':
+      if (event.message.role !== 'assistant' || !event.message.content) return null;
+      return { kind: 'assistant', text: clip(event.message.content, MAX_TEXT_LEN) };
+    case 'chunk': {
+      const chunk = event.chunk;
+      if (chunk.type === 'tool_use_detail') {
+        return {
+          kind: 'tool',
+          toolName: chunk.toolName,
+          input: clip(chunk.toolInput, MAX_TOOL_INPUT_LEN),
+        };
+      }
+      if (chunk.type === 'tool_result' && chunk.isError === true) {
+        return { kind: 'tool_error', content: clip(chunk.content, MAX_TOOL_INPUT_LEN) };
+      }
+      return null;
+    }
+    case 'done': {
+      const cost = event.metadata?.totalCostUsd;
+      const duration = event.metadata?.durationMs;
+      return {
+        kind: 'done',
+        ...(typeof cost === 'number' ? { costUsd: cost } : {}),
+        ...(typeof duration === 'number' ? { durationMs: duration } : {}),
+      };
+    }
+    case 'error':
+      return { kind: 'error', message: event.error.message };
+    case 'paused':
+      return {
+        kind: 'paused',
+        ...(event.resetsAt ? { resetsAt: event.resetsAt.toISOString() } : {}),
+      };
+    case 'resumed':
+      return { kind: 'resumed' };
+    default:
+      // progress | suggestion | stream_retry | panel — intentionally skipped.
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Writer
+// ---------------------------------------------------------------------------
+
+/**
+ * Append-only ledger writer for one session. Same error posture as
+ * `BgJobLogWriter`: all I/O failures are logged to stderr and swallowed.
+ */
+export class SessionLedgerWriter {
+  private readonly sessionId: string;
+  private readonly ledgerPath: string;
+  private stream: fs.WriteStream | null = null;
+  private errored = false;
+  private closed = false;
+  private streamReady = false;
+  private pendingLines: string[] = [];
+  private readyPromise: Promise<void> | null = null;
+  private readyResolve: (() => void) | null = null;
+
+  constructor(sessionId: string) {
+    this.sessionId = sessionId;
+    if (!isSafeLedgerSessionId(sessionId)) {
+      // Never throw from the session hot path — an exotic provider-issued id
+      // just disables the ledger for this session.
+      this.errored = true;
+      this.ledgerPath = '';
+      return;
+    }
+    this.ledgerPath = getSessionLedgerPath(sessionId);
+    try {
+      fs.mkdirSync(getSessionLedgerDir(sessionId), { recursive: true });
+    } catch (e) {
+      process.stderr.write(`[afk] session-ledger: mkdir failed for ${sessionId}: ${String(e)}\n`);
+      this.errored = true;
+    }
+  }
+
+  /** Whether this writer can accept records. */
+  get active(): boolean {
+    return !this.errored && !this.closed;
+  }
+
+  /** Append a payload as a timestamped JSONL record. Fire-and-forget. */
+  record(payload: LedgerPayload): void {
+    if (this.errored || this.closed) return;
+    const rec: LedgerRecord = { v: 1, ts: Date.now(), ...payload };
+    const line = JSON.stringify(rec) + '\n';
+    if (!this.stream) {
+      this.pendingLines.push(line);
+      this._openStream();
+      return;
+    }
+    if (!this.streamReady) {
+      this.pendingLines.push(line);
+      return;
+    }
+    this._writeLine(line);
+  }
+
+  /** Project and append an OutputEvent. No-ops for skipped event types. */
+  recordEvent(event: OutputEvent): void {
+    const payload = projectOutputEvent(event);
+    if (payload) this.record(payload);
+  }
+
+  /** Record a user turn entering the session. */
+  recordUser(text: string): void {
+    this.record({ kind: 'user', text: clip(text, MAX_TEXT_LEN) });
+  }
+
+  private _openStream(): void {
+    if (this.stream) return;
+    this.readyPromise = new Promise<void>((resolve) => {
+      this.readyResolve = resolve;
+    });
+    try {
+      const s = fs.createWriteStream(this.ledgerPath, { flags: 'a', encoding: 'utf8', mode: 0o600 });
+      this.stream = s;
+      s.once('open', () => {
+        this.streamReady = true;
+        for (const line of this.pendingLines) this._writeLine(line);
+        this.pendingLines = [];
+        this.readyResolve?.();
+        this.readyResolve = null;
+      });
+      s.once('error', (err) => {
+        process.stderr.write(`[afk] session-ledger: stream error for ${this.sessionId}: ${String(err)}\n`);
+        this.errored = true;
+        this.pendingLines = [];
+        this.readyResolve?.();
+        this.readyResolve = null;
+      });
+    } catch (e) {
+      process.stderr.write(`[afk] session-ledger: createWriteStream failed for ${this.sessionId}: ${String(e)}\n`);
+      this.errored = true;
+      this.pendingLines = [];
+      this.readyResolve?.();
+      this.readyResolve = null;
+    }
+  }
+
+  private _writeLine(line: string): void {
+    if (!this.stream || this.errored) return;
+    try {
+      this.stream.write(line, (err) => {
+        if (err) {
+          process.stderr.write(`[afk] session-ledger: write error for ${this.sessionId}: ${String(err)}\n`);
+          this.errored = true;
+        }
+      });
+    } catch (e) {
+      process.stderr.write(`[afk] session-ledger: write threw for ${this.sessionId}: ${String(e)}\n`);
+      this.errored = true;
+    }
+  }
+
+  /**
+   * Write the terminal `closed` record, flush, and close the stream.
+   * Idempotent — safe to call from both `close()` and `reset()` paths.
+   */
+  async close(reason?: string): Promise<void> {
+    if (this.closed) return;
+    this.record({ kind: 'closed', ...(reason !== undefined ? { reason } : {}) });
+    this.closed = true;
+    if (this.readyPromise) await this.readyPromise;
+    return new Promise<void>((resolve) => {
+      if (!this.stream) {
+        resolve();
+        return;
+      }
+      this.stream.end(() => resolve());
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reader
+// ---------------------------------------------------------------------------
+
+/** Parse one ledger line; returns null for blank/malformed lines. */
+function parseRecord(line: string): LedgerRecord | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed) as LedgerRecord;
+    if (parsed.v !== 1 || typeof parsed.ts !== 'number' || typeof parsed.kind !== 'string') {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Whether a ledger file exists for the given session id. */
+export async function ledgerExists(sessionId: string): Promise<boolean> {
+  if (!isSafeLedgerSessionId(sessionId)) return false;
+  try {
+    await fsp.access(getSessionLedgerPath(sessionId));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Read all records from a session ledger (ENOENT → zero records). */
+export async function* readLedger(sessionId: string): AsyncGenerator<LedgerRecord> {
+  if (!isSafeLedgerSessionId(sessionId)) return;
+  let fd: fsp.FileHandle;
+  try {
+    fd = await fsp.open(getSessionLedgerPath(sessionId), 'r');
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw e;
+  }
+  try {
+    const rl = readline.createInterface({
+      input: fd.createReadStream({ encoding: 'utf8' }),
+      crlfDelay: Infinity,
+    });
+    for await (const line of rl) {
+      const rec = parseRecord(line);
+      if (rec) yield rec;
+    }
+  } finally {
+    await fd.close();
+  }
+}
+
+const POLL_INTERVAL_MS = 250;
+
+/**
+ * Tail a session ledger — for live following from another process.
+ *
+ * - `fromStart: true` replays existing records first; otherwise starts at
+ *   the current end of file (or 0 if the file doesn't exist yet).
+ * - Yields until a `closed` record is read or `signal` aborts.
+ * - `fs.watch` on the ledger directory is the wakeup; a 250ms poll is the
+ *   fallback — on macOS watch events are coalesced/dropped under load, so
+ *   the poll floor is load-bearing, not belt-and-braces.
+ */
+export async function* tailLedger(
+  sessionId: string,
+  opts?: { fromStart?: boolean; signal?: AbortSignal },
+): AsyncGenerator<LedgerRecord> {
+  if (!isSafeLedgerSessionId(sessionId)) return;
+  const ledgerPath = getSessionLedgerPath(sessionId);
+  const ledgerDir = getSessionLedgerDir(sessionId);
+  const { fromStart = false, signal } = opts ?? {};
+
+  let fileOffset = 0;
+  let buffer = '';
+  let sawClosed = false;
+
+  async function* readNewRecords(): AsyncGenerator<LedgerRecord> {
+    let fd: fsp.FileHandle | null = null;
+    try {
+      fd = await fsp.open(ledgerPath, 'r');
+      const stat = await fd.stat();
+      if (stat.size <= fileOffset) return;
+      const toRead = stat.size - fileOffset;
+      const readBuf = Buffer.allocUnsafe(toRead);
+      const { bytesRead } = await fd.read(readBuf, 0, toRead, fileOffset);
+      if (bytesRead === 0) return;
+      fileOffset += bytesRead;
+      buffer += readBuf.toString('utf8', 0, bytesRead);
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        const rec = parseRecord(line);
+        if (!rec) continue;
+        if (rec.kind === 'closed') sawClosed = true;
+        yield rec;
+        if (sawClosed) return;
+      }
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+        process.stderr.write(`[afk] session-ledger: tail read error for ${sessionId}: ${String(e)}\n`);
+      }
+    } finally {
+      if (fd) await fd.close().catch(() => { /* ignore */ });
+    }
+  }
+
+  if (!fromStart) {
+    try {
+      const stat = await fsp.stat(ledgerPath);
+      fileOffset = stat.size;
+    } catch {
+      // File doesn't exist yet — start from 0 and wait for it to appear.
+    }
+  } else {
+    yield* readNewRecords();
+    if (sawClosed) return;
+  }
+
+  let watcher: fs.FSWatcher | null = null;
+  let watcherChange: (() => void) | null = null;
+
+  const waitForChange = (): Promise<void> =>
+    new Promise<void>((resolve) => {
+      const pollTimer = setTimeout(() => {
+        watcherChange = null;
+        resolve();
+      }, POLL_INTERVAL_MS);
+      watcherChange = () => {
+        clearTimeout(pollTimer);
+        watcherChange = null;
+        resolve();
+      };
+      signal?.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(pollTimer);
+          watcherChange = null;
+          resolve();
+        },
+        { once: true },
+      );
+    });
+
+  try {
+    // Watch the parent dir, not the file — the file may not exist yet.
+    watcher = fs.watch(ledgerDir, { persistent: false }, () => {
+      watcherChange?.();
+    });
+  } catch {
+    // Pure polling fallback.
+  }
+
+  try {
+    while (!signal?.aborted && !sawClosed) {
+      await waitForChange();
+      if (signal?.aborted) break;
+      yield* readNewRecords();
+    }
+  } finally {
+    watcher?.close();
+  }
+}

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -46,6 +46,8 @@ import type {
   SlashCommand,
 } from '../types.js';
 import { QueryInputStream } from './input-iterable.js';
+import { SessionLedgerWriter } from '../session-ledger.js';
+import { env } from '../../config/env.js';
 import { resolveModelId } from './model-resolution.js';
 import { setSlotBindings } from './model-slots.js';
 import { applySlotCredentials } from './slot-credentials.js';
@@ -114,6 +116,16 @@ export class AgentSession implements IAgentSession {
   } = { input: 0, output: 0, cacheRead: 0, cacheCreation: 0 };
   /** Cumulative USD cost rolled up from completed subagents. */
   private subagentRunningCostUsd = 0;
+  /**
+   * Durable per-session event ledger (`~/.afk/state/sessions/<id>/events.jsonl`).
+   * Created lazily on the first turn once the provider has issued a session id.
+   * Top-level sessions only — subagents are observable via the bg-job log and
+   * witness traces; mirroring them here would multiply files per session.
+   * Null when disabled (env opt-out), gated off (subagent), or after close.
+   */
+  private ledger: SessionLedgerWriter | null = null;
+  /** Set true once ledger creation has been attempted (success or not). */
+  private ledgerInitAttempted = false;
 
   constructor(config: AgentConfig) {
     this.config = config;
@@ -459,6 +471,12 @@ export class AgentSession implements IAgentSession {
     this.conversationHistory.push(userMessage);
     this.inputStream.pushUserMessage(content);
 
+    // Durable ledger: initialization is deferred to here (not the
+    // constructor) because the provider-issued session id only exists after
+    // `session.init` — which `initPromise` above has just drained.
+    this.ensureLedger();
+    this.ledger?.recordUser(historySummary);
+
     const deps = this.buildTransformDeps();
 
     try {
@@ -470,6 +488,7 @@ export class AgentSession implements IAgentSession {
 
         if (output) {
           if (output.type === 'done') this.turnCount++;
+          this.ledger?.recordEvent(output);
           yield output;
           if (output.type === 'done' || output.type === 'error') break;
         }
@@ -477,6 +496,51 @@ export class AgentSession implements IAgentSession {
     } finally {
       if (this.currentState === 'streaming') this.currentState = 'idle';
     }
+  }
+
+  /**
+   * Create the session ledger writer on first use.
+   *
+   * Gates (all must pass):
+   *   - top-level session (subagents: `depth`/`parentSessionId` set at fork);
+   *   - `AFK_SESSION_LEDGER_DISABLED` is not `'1'`;
+   *   - the provider has issued a session id.
+   *
+   * One attempt per lifecycle: if the id is unavailable or unsafe the first
+   * time, the session simply runs unledgered — never throws, never retries
+   * per-event (the `ledgerInitAttempted` latch keeps the hot path cheap).
+   */
+  private ensureLedger(): void {
+    if (this.ledgerInitAttempted) return;
+    this.ledgerInitAttempted = true;
+    if (this.config.depth !== undefined || this.config.parentSessionId !== undefined) return;
+    if (env.AFK_SESSION_LEDGER_DISABLED === '1') return;
+    const id = this.sessionId;
+    if (!id) return;
+    const writer = new SessionLedgerWriter(id);
+    if (!writer.active) return;
+    this.ledger = writer;
+    const meta = this.getSessionMetadata();
+    writer.record({
+      kind: 'meta',
+      sessionId: id,
+      model: meta.model ?? String(this.config.model),
+      ...(meta.cwd !== undefined ? { cwd: meta.cwd } : {}),
+    });
+  }
+
+  /**
+   * Seal the ledger with a terminal record and flush. Idempotent.
+   * `close()`/`reset()` await the returned promise so tailers see the
+   * terminal record before teardown completes; the abort path
+   * fire-and-forgets it (abort handlers cannot block on disk I/O).
+   */
+  private sealLedger(reason: string): Promise<void> {
+    const ledger = this.ledger;
+    if (!ledger) return Promise.resolve();
+    this.ledger = null;
+    this.ledgerInitAttempted = false;
+    return ledger.close(reason);
   }
 
   private summarizeContentBlocks(blocks: ContentBlockParam[]): string {
@@ -547,6 +611,7 @@ export class AgentSession implements IAgentSession {
     }
 
     await this.dispatchSessionEndOnce('reset');
+    await this.sealLedger('reset');
 
     try {
       await this.providerQuery.close();
@@ -597,6 +662,7 @@ export class AgentSession implements IAgentSession {
   }
 
   private async onAbort(): Promise<void> {
+    void this.sealLedger('abort');
     try {
       await this.providerQuery.interrupt();
     } catch {
@@ -777,6 +843,7 @@ export class AgentSession implements IAgentSession {
   async close(): Promise<void> {
     if (this.currentState === 'closed') return;
     this.currentState = 'closed';
+    await this.sealLedger('close');
     if (!this.abortController.signal.aborted) {
       this.abortController.abort('closed');
     }

--- a/src/agent/session/session-ledger-integration.test.ts
+++ b/src/agent/session/session-ledger-integration.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Integration: AgentSession × session ledger.
+ *
+ * Verifies the full chain — a turn through a (mock) provider lands user /
+ * assistant / done records in ~/.afk/state/sessions/<id>/events.jsonl, and
+ * close() seals the file with a terminal record. Also verifies the gates:
+ * subagent configs and the env opt-out produce no ledger.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-ledger-int-test-'));
+process.env['AFK_HOME'] = tmpDir;
+
+import { AgentSession } from './agent-session.js';
+import { createMockProvider } from '../__fixtures__/mock-provider.js';
+import { readLedger, type LedgerRecord } from '../session-ledger.js';
+import { getSessionLedgerPath } from '../../paths.js';
+
+async function collect(sessionId: string): Promise<LedgerRecord[]> {
+  const out: LedgerRecord[] = [];
+  for await (const r of readLedger(sessionId)) out.push(r);
+  return out;
+}
+
+async function drainTurn(session: AgentSession, text: string): Promise<void> {
+  for await (const event of session.sendMessageStream(text)) {
+    if (event.type === 'done' || event.type === 'error') break;
+  }
+}
+
+describe('AgentSession ledger integration', () => {
+  it('writes meta/user/assistant/done records for a turn and seals on close', async () => {
+    const sessionId = `ledger-int-${Date.now()}-a`;
+    const provider = createMockProvider({ sessionId });
+    const session = new AgentSession({ model: 'sonnet', provider });
+
+    await drainTurn(session, 'hello ledger');
+    await session.close();
+
+    const records = await collect(sessionId);
+    const kinds = records.map((r) => r.kind);
+    expect(kinds[0]).toBe('meta');
+    expect(kinds).toContain('user');
+    expect(kinds).toContain('assistant');
+    expect(kinds).toContain('done');
+    expect(kinds.at(-1)).toBe('closed');
+
+    const user = records.find((r) => r.kind === 'user');
+    expect(user).toMatchObject({ kind: 'user', text: 'hello ledger' });
+    const assistant = records.find((r) => r.kind === 'assistant');
+    expect(assistant).toMatchObject({ kind: 'assistant', text: 'Echo: hello ledger' });
+    const closed = records.at(-1);
+    expect(closed).toMatchObject({ kind: 'closed', reason: 'close' });
+  });
+
+  it('does not write a ledger for subagent sessions', async () => {
+    const sessionId = `ledger-int-${Date.now()}-sub`;
+    const provider = createMockProvider({ sessionId });
+    const session = new AgentSession({
+      model: 'sonnet',
+      provider,
+      depth: 1,
+      parentSessionId: 'parent-123',
+    });
+
+    await drainTurn(session, 'child work');
+    await session.close();
+
+    expect(fs.existsSync(getSessionLedgerPath(sessionId))).toBe(false);
+  });
+
+  it('honors AFK_SESSION_LEDGER_DISABLED=1', async () => {
+    process.env['AFK_SESSION_LEDGER_DISABLED'] = '1';
+    try {
+      const sessionId = `ledger-int-${Date.now()}-off`;
+      const provider = createMockProvider({ sessionId });
+      const session = new AgentSession({ model: 'sonnet', provider });
+      await drainTurn(session, 'silent');
+      await session.close();
+      expect(fs.existsSync(getSessionLedgerPath(sessionId))).toBe(false);
+    } finally {
+      delete process.env['AFK_SESSION_LEDGER_DISABLED'];
+    }
+  });
+
+  it('seals the ledger on reset and starts a fresh one for the next cycle', async () => {
+    const sessionId = `ledger-int-${Date.now()}-reset`;
+    const provider = createMockProvider({ sessionId });
+    const session = new AgentSession({ model: 'sonnet', provider });
+
+    await drainTurn(session, 'before reset');
+    await session.reset();
+
+    let records = await collect(sessionId);
+    expect(records.at(-1)).toMatchObject({ kind: 'closed', reason: 'reset' });
+
+    // Mock provider reuses the same session id, so the post-reset cycle
+    // appends to the same file after the closed record (a fresh provider
+    // would issue a new id and a new file).
+    await drainTurn(session, 'after reset');
+    await session.close();
+
+    records = await collect(sessionId);
+    const closedIdx = records.findIndex((r) => r.kind === 'closed');
+    const after = records.slice(closedIdx + 1);
+    expect(after.some((r) => r.kind === 'user' && 'text' in r && r.text === 'after reset')).toBe(true);
+    expect(after.at(-1)).toMatchObject({ kind: 'closed', reason: 'close' });
+  });
+});

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -754,6 +754,17 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     category: 'debug',
   },
   {
+    name: 'AFK_SESSION_LEDGER_DISABLED',
+    description:
+      'Disable the per-session durable event ledger (state/sessions/<id>/events.jsonl). ' +
+      'Set to 1 to skip ledger writes; live cross-surface watching (e.g. the Telegram ' +
+      '/watch command) will report no activity for sessions started while disabled.',
+    type: 'boolean',
+    required: false,
+    example: '1',
+    category: 'debug',
+  },
+  {
     name: 'DEBUG',
     description: 'Standard Node `debug`-package convention. When set to 1, enables verbose logging in several modules alongside AFK_DEBUG.',
     type: 'string',
@@ -1093,6 +1104,7 @@ export const env = {
   get AFK_DEBUG_CLIPBOARD(): string | undefined { return process.env['AFK_DEBUG_CLIPBOARD']; },
   get AFK_DEBUG_COMPOSITOR(): string | undefined { return process.env['AFK_DEBUG_COMPOSITOR']; },
   get AFK_TRACE_DISABLED(): string | undefined { return process.env['AFK_TRACE_DISABLED']; },
+  get AFK_SESSION_LEDGER_DISABLED(): string | undefined { return process.env['AFK_SESSION_LEDGER_DISABLED']; },
   get DEBUG(): string | undefined { return process.env['DEBUG']; },
   get AGENT_AFK_ASCII(): string | undefined { return process.env['AGENT_AFK_ASCII']; },
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -399,6 +399,50 @@ export function getBgJobMeta(jobId: string): string {
   return join(getBgJobDir(jobId), 'meta.json');
 }
 
+// ---------------------------------------------------------------------------
+// Session event-ledger paths
+// ---------------------------------------------------------------------------
+
+/**
+ * Session ids flow into ledger paths from provider-issued identifiers AND
+ * from caller-supplied CLI/Telegram arguments (`afk attach <id>`, `/watch
+ * <id>`), so the same traversal defense as bg job ids applies. UUIDs and
+ * slugified names both fit the charset.
+ */
+const LEDGER_SESSION_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+const LEDGER_SESSION_ID_MAX_LEN = 128;
+
+/** Non-throwing safety check for session ids used in ledger paths. */
+export function isSafeLedgerSessionId(sessionId: string): boolean {
+  return (
+    typeof sessionId === 'string' &&
+    sessionId.length > 0 &&
+    sessionId.length <= LEDGER_SESSION_ID_MAX_LEN &&
+    LEDGER_SESSION_ID_PATTERN.test(sessionId)
+  );
+}
+
+/**
+ * Per-session ledger directory: `~/.afk/state/sessions/<sessionId>/`.
+ * Shares the sessions dir with sidecar `<id>.json` files and mint-state
+ * subdirs — the ledger adds `events.jsonl` inside the per-id subdir.
+ * @throws if `sessionId` fails {@link isSafeLedgerSessionId}.
+ */
+export function getSessionLedgerDir(sessionId: string): string {
+  if (!isSafeLedgerSessionId(sessionId)) {
+    throw new Error(`Invalid session id for ledger path: ${JSON.stringify(sessionId)}`);
+  }
+  return join(getSessionsDir(), sessionId);
+}
+
+/**
+ * Append-only JSONL event ledger for a session.
+ * @throws if `sessionId` fails {@link isSafeLedgerSessionId}.
+ */
+export function getSessionLedgerPath(sessionId: string): string {
+  return join(getSessionLedgerDir(sessionId), 'events.jsonl');
+}
+
 /**
  * Path to the MCP server-status file.
  *

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -17,6 +17,8 @@ import { FARM_CALLBACK_PREFIX } from './farm-callback-data.js';
 import { ELICITATION_CALLBACK_PREFIX } from './elicitation-callback-data.js';
 import { makeTelegramElicitationHandler } from './elicitation-handler.js';
 import { elicitationRouter } from '../agent/elicitation-router.js';
+import { SessionWatchManager, resolveWatchTarget, listWatchableSessions } from './watch.js';
+import { splitLongMessage } from './formatter.js';
 
 /**
  * Bot configuration options
@@ -46,6 +48,7 @@ export class TelegramBot {
   private running = false;
   private registeredCommandChats = new Set<number>();
   private messageHandler: MessageHandler;
+  private watchManager: SessionWatchManager;
 
   constructor(options: BotOptions) {
     this.options = options;
@@ -57,6 +60,7 @@ export class TelegramBot {
       this.registeredCommandChats,
       this.log.bind(this)
     );
+    this.watchManager = new SessionWatchManager(this.log.bind(this));
 
     this.setupHandlers();
   }
@@ -115,6 +119,51 @@ export class TelegramBot {
     this.bot.command('name', (ctx) =>
       handleName(ctx, this.sessionManager, this.log.bind(this))
     );
+    // /watch <session> — live-tail another surface's session ledger into
+    // this chat. /watch with no arg lists watchable sessions. The ledger is
+    // written by every top-level AgentSession (CLI REPL, daemon, one-shot),
+    // so this is the CLI→Telegram half of cross-surface continuity.
+    this.bot.command('watch', async (ctx) => {
+      const chatId = ctx.chat?.id;
+      if (!chatId) {
+        await ctx.reply(formatError('Could not identify chat'));
+        return;
+      }
+      const text = (ctx.message && 'text' in ctx.message ? ctx.message.text : '') ?? '';
+      const arg = text.split(/\s+/).slice(1).join(' ').trim();
+      try {
+        if (!arg) {
+          await ctx.reply(await listWatchableSessions());
+          return;
+        }
+        const sessionId = await resolveWatchTarget(arg);
+        if (!sessionId) {
+          await ctx.reply(
+            `No session ledger found for "${arg}". Use /watch with no argument to list watchable sessions.`,
+          );
+          return;
+        }
+        const send = async (msg: string): Promise<void> => {
+          for (const part of splitLongMessage(msg)) {
+            await ctx.telegram.sendMessage(chatId, part);
+          }
+        };
+        this.watchManager.start(chatId, sessionId, send);
+        await ctx.reply(`📡 Watching ${sessionId} — new activity will stream here. /unwatch to stop.`);
+      } catch (error) {
+        this.log('Watch error:', error);
+        await ctx.reply(formatError(error as Error));
+      }
+    });
+    this.bot.command('unwatch', async (ctx) => {
+      const chatId = ctx.chat?.id;
+      if (!chatId) {
+        await ctx.reply(formatError('Could not identify chat'));
+        return;
+      }
+      const stopped = this.watchManager.stop(chatId);
+      await ctx.reply(stopped ? `Stopped watching ${stopped}.` : 'Not watching anything.');
+    });
 
     this.bot.on('text', (ctx) => this.messageHandler.handle(ctx));
 
@@ -212,6 +261,8 @@ export class TelegramBot {
       { command: 'model', description: 'Switch Claude model (opus/sonnet/haiku)' },
       { command: 'cd', description: 'Show or change session working directory' },
       { command: 'name', description: 'Show or set the session name' },
+      { command: 'watch', description: 'Live-tail a CLI session from this chat' },
+      { command: 'unwatch', description: 'Stop watching a session' },
     ]);
 
     this.running = true;
@@ -241,6 +292,9 @@ export class TelegramBot {
 
     this.log('Uninstalling elicitation handler...');
     elicitationRouter.uninstall();
+
+    this.log('Stopping session watches...');
+    await this.watchManager.stopAll();
 
     this.log('Closing sessions...');
     await this.sessionManager.closeAll();

--- a/src/telegram/formatter.ts
+++ b/src/telegram/formatter.ts
@@ -260,6 +260,8 @@ export function formatHelp(sdkCommands?: string[]): string {
     '  /model      — Switch Claude model',
     '  /cd         — Change working directory',
     '  /name       — Show or set the session name',
+    '  /watch      — Live-tail a CLI session from this chat',
+    '  /unwatch    — Stop watching a session',
     '',
     'Also works from the CLI.',
   ];

--- a/src/telegram/watch.test.ts
+++ b/src/telegram/watch.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Tests for Telegram session watching (/watch, /unwatch).
+ *
+ * Uses a temp AFK_HOME so ledgers and session sidecars live in a temp dir
+ * (env must be set before importing modules that resolve paths).
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-watch-test-'));
+process.env['AFK_HOME'] = tmpDir;
+
+import { SessionWatchManager, renderLedgerRecord, resolveWatchTarget } from './watch.js';
+import { SessionLedgerWriter, type LedgerRecord } from '../agent/session-ledger.js';
+import { getSessionsDir } from '../paths.js';
+
+let seq = 0;
+function freshId(): string {
+  return `watch-test-${Date.now()}-${seq++}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function rec(payload: Omit<LedgerRecord, 'v' | 'ts'>): LedgerRecord {
+  return { v: 1, ts: 1718000000000, ...payload } as LedgerRecord;
+}
+
+// ---------------------------------------------------------------------------
+// renderLedgerRecord
+// ---------------------------------------------------------------------------
+
+describe('renderLedgerRecord', () => {
+  it('renders each record kind compactly', () => {
+    expect(renderLedgerRecord(rec({ kind: 'meta', sessionId: 's1', model: 'sonnet', cwd: '/x' })))
+      .toContain('s1');
+    expect(renderLedgerRecord(rec({ kind: 'user', text: 'hi there' }))).toBe('👤 hi there');
+    expect(renderLedgerRecord(rec({ kind: 'assistant', text: 'sure' }))).toBe('🤖 sure');
+    expect(renderLedgerRecord(rec({ kind: 'tool', toolName: 'bash', input: 'ls' }))).toBe('🔧 bash(ls)');
+    expect(renderLedgerRecord(rec({ kind: 'tool_error', content: 'ENOENT' }))).toContain('ENOENT');
+    expect(renderLedgerRecord(rec({ kind: 'done', costUsd: 0.01, durationMs: 1500 })))
+      .toBe('✅ turn done (1.5s, $0.0100)');
+    expect(renderLedgerRecord(rec({ kind: 'done' }))).toBe('✅ turn done');
+    expect(renderLedgerRecord(rec({ kind: 'error', message: 'boom' }))).toContain('boom');
+    expect(renderLedgerRecord(rec({ kind: 'paused' }))).toContain('paused');
+    expect(renderLedgerRecord(rec({ kind: 'resumed' }))).toBe('▶️ resumed');
+    expect(renderLedgerRecord(rec({ kind: 'closed', reason: 'close' }))).toContain('closed');
+  });
+
+  it('collapses whitespace and clips long text', () => {
+    const text = `line1\nline2\t${'x'.repeat(2000)}`;
+    const rendered = renderLedgerRecord(rec({ kind: 'assistant', text }));
+    expect(rendered).not.toContain('\n');
+    expect(rendered!.length).toBeLessThan(800);
+    expect(rendered).toContain('…');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveWatchTarget
+// ---------------------------------------------------------------------------
+
+describe('resolveWatchTarget', () => {
+  it('resolves a raw session id that has a ledger', async () => {
+    const id = freshId();
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('x');
+    await writer.close();
+    expect(await resolveWatchTarget(id)).toBe(id);
+  });
+
+  it('resolves a session-store name to its SDK session id', async () => {
+    const sdkId = freshId();
+    const writer = new SessionLedgerWriter(sdkId);
+    writer.recordUser('x');
+    await writer.close();
+
+    // Write a session-store sidecar pointing at the SDK id.
+    const sidecar = {
+      sessionId: sdkId,
+      name: 'my-named-session',
+      model: 'sonnet',
+      startedAt: Date.now(),
+      savedAt: Date.now(),
+      totalTurns: 1,
+      totalCostUsd: 0,
+      totalTokens: { input: 0, output: 0 },
+      totalDurationMs: 0,
+      turns: [],
+    };
+    fs.mkdirSync(getSessionsDir(), { recursive: true });
+    fs.writeFileSync(
+      path.join(getSessionsDir(), `${sdkId}.json`),
+      JSON.stringify(sidecar),
+    );
+
+    expect(await resolveWatchTarget('my-named-session')).toBe(sdkId);
+  });
+
+  it('returns null for unknown targets and traversal attempts', async () => {
+    expect(await resolveWatchTarget('definitely-not-a-session')).toBeNull();
+    expect(await resolveWatchTarget('../../etc/passwd')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SessionWatchManager
+// ---------------------------------------------------------------------------
+
+describe('SessionWatchManager', () => {
+  it('streams batched records to the send fn and ends on closed', async () => {
+    const id = freshId();
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('pre');
+    await sleep(50);
+
+    const sent: string[] = [];
+    const manager = new SessionWatchManager();
+    manager.start(7, id, async (text) => {
+      sent.push(text);
+    });
+    expect(manager.watching(7)).toBe(id);
+
+    await sleep(100);
+    writer.recordUser('hello from CLI');
+    writer.recordEvent({
+      type: 'message',
+      message: { role: 'assistant', content: 'on it', timestamp: new Date() },
+    });
+    await sleep(300);
+    await writer.close('close');
+    await sleep(600);
+
+    const all = sent.join('\n');
+    expect(all).toContain('👤 hello from CLI');
+    expect(all).toContain('🤖 on it');
+    expect(all).toContain('watch ended');
+    // Watch ended → registry cleaned up.
+    expect(manager.watching(7)).toBeUndefined();
+    // Batching: the user+assistant records (written within one debounce
+    // window) must arrive in a single message, not one send per record.
+    expect(sent.some((m) => m.includes('hello from CLI') && m.includes('on it'))).toBe(true);
+  });
+
+  it('stop aborts the tail and reports the watched id', async () => {
+    const id = freshId();
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('x');
+    await sleep(50);
+
+    const manager = new SessionWatchManager();
+    manager.start(9, id, async () => {});
+    expect(manager.stop(9)).toBe(id);
+    expect(manager.watching(9)).toBeUndefined();
+    expect(manager.stop(9)).toBeUndefined();
+    await writer.close();
+  });
+
+  it('starting a new watch replaces the previous one', async () => {
+    const idA = freshId();
+    const idB = freshId();
+    const wA = new SessionLedgerWriter(idA);
+    const wB = new SessionLedgerWriter(idB);
+    wA.recordUser('a');
+    wB.recordUser('b');
+    await sleep(50);
+
+    const manager = new SessionWatchManager();
+    manager.start(11, idA, async () => {});
+    manager.start(11, idB, async () => {});
+    expect(manager.watching(11)).toBe(idB);
+    await manager.stopAll();
+    expect(manager.watching(11)).toBeUndefined();
+    await wA.close();
+    await wB.close();
+  });
+
+  it('send failures do not kill the watch', async () => {
+    const id = freshId();
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('x');
+    await sleep(50);
+
+    const sent: string[] = [];
+    let failNext = true;
+    const manager = new SessionWatchManager();
+    manager.start(13, id, async (text) => {
+      if (failNext) {
+        failNext = false;
+        throw new Error('telegram 429');
+      }
+      sent.push(text);
+    });
+
+    await sleep(100);
+    writer.recordUser('first-batch');
+    // Wait past the debounce window so the first batch flushes (and throws)
+    // before the second batch is written.
+    await sleep(1_800);
+    writer.recordUser('second-batch');
+    await sleep(300);
+    await writer.close('close');
+    await sleep(600);
+
+    // First batch send threw; later batches must still be delivered.
+    expect(sent.join('\n')).toContain('second-batch');
+  });
+});

--- a/src/telegram/watch.ts
+++ b/src/telegram/watch.ts
@@ -1,0 +1,235 @@
+/**
+ * Live session watching for the Telegram bot.
+ *
+ * `/watch <session>` tails another process's durable event ledger
+ * (`~/.afk/state/sessions/<id>/events.jsonl`, written by every top-level
+ * `AgentSession`) and relays a compact rendering of each record to the chat.
+ * This is the cross-surface AFK loop: start work in the CLI REPL, walk away,
+ * watch it stream to your phone — no shared process, no daemon required.
+ *
+ * Design:
+ *   - One active watch per chat (starting a new one replaces the old).
+ *   - Records are batched on a short debounce window before sending, so a
+ *     burst of tool events becomes one Telegram message instead of N rate-
+ *     limited sends.
+ *   - The tail ends when the watched session writes its terminal `closed`
+ *     record, when the user sends `/unwatch`, or when the bot shuts down.
+ *   - Watch targets resolve through the same store as CLI `--resume`:
+ *     sidecar id, SDK session id, or human session name (`/name`).
+ *
+ * @module telegram/watch
+ */
+
+import { tailLedger, ledgerExists, type LedgerRecord } from '../agent/session-ledger.js';
+import { findSession, listSessions } from '../cli/session-store.js';
+import { readPresenceFiles } from '../agent/awareness/presence.js';
+
+type SendFn = (text: string) => Promise<void>;
+type LogFn = (...args: unknown[]) => void;
+
+/** Debounce window for batching ledger records into one Telegram message. */
+const FLUSH_INTERVAL_MS = 1_500;
+/** Max characters of a user/assistant text shown per record. */
+const WATCH_TEXT_PREVIEW = 700;
+/** Max characters of a tool input preview shown per record. */
+const WATCH_TOOL_PREVIEW = 160;
+
+function preview(text: string, max: number): string {
+  const flat = text.replace(/\s+/g, ' ').trim();
+  return flat.length > max ? `${flat.slice(0, max)}…` : flat;
+}
+
+/** Render one ledger record as a compact plain-text line (or null to skip). */
+export function renderLedgerRecord(rec: LedgerRecord): string | null {
+  switch (rec.kind) {
+    case 'meta':
+      return `📡 Watching session ${rec.sessionId}\nmodel: ${rec.model}${rec.cwd ? `\ncwd: ${rec.cwd}` : ''}`;
+    case 'user':
+      return `👤 ${preview(rec.text, WATCH_TEXT_PREVIEW)}`;
+    case 'assistant':
+      return `🤖 ${preview(rec.text, WATCH_TEXT_PREVIEW)}`;
+    case 'tool':
+      return `🔧 ${rec.toolName}(${preview(rec.input, WATCH_TOOL_PREVIEW)})`;
+    case 'tool_error':
+      return `⚠️ tool failed: ${preview(rec.content, WATCH_TOOL_PREVIEW)}`;
+    case 'done': {
+      const parts: string[] = [];
+      if (typeof rec.durationMs === 'number') parts.push(`${(rec.durationMs / 1000).toFixed(1)}s`);
+      if (typeof rec.costUsd === 'number') parts.push(`$${rec.costUsd.toFixed(4)}`);
+      return `✅ turn done${parts.length ? ` (${parts.join(', ')})` : ''}`;
+    }
+    case 'error':
+      return `❌ error: ${preview(rec.message, WATCH_TOOL_PREVIEW)}`;
+    case 'paused':
+      return `⏸️ paused on usage limit${rec.resetsAt ? ` (resets ${rec.resetsAt})` : ''}`;
+    case 'resumed':
+      return '▶️ resumed';
+    case 'closed':
+      return `🏁 session closed${rec.reason ? ` (${rec.reason})` : ''} — watch ended`;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Resolve a user-supplied watch target to a ledger session id.
+ *
+ * Resolution order:
+ *   1. Session-store lookup (sidecar id / SDK id / name / unique name
+ *      prefix) — the same path CLI `--resume` uses. The sidecar's SDK
+ *      `sessionId` is the ledger key.
+ *   2. Raw id with an existing ledger file (covers sessions that have not
+ *      persisted a sidecar yet).
+ *
+ * Returns null when nothing matches.
+ */
+export async function resolveWatchTarget(input: string): Promise<string | null> {
+  const found = findSession(input);
+  if (found?.data.sessionId && (await ledgerExists(found.data.sessionId))) {
+    return found.data.sessionId;
+  }
+  if (await ledgerExists(input)) return input;
+  return null;
+}
+
+/**
+ * Build the `/watch` no-argument listing: live sessions first (presence
+ * files), then the most recent saved sessions that have ledgers.
+ */
+export async function listWatchableSessions(): Promise<string> {
+  const lines: string[] = [];
+
+  const presence = await readPresenceFiles();
+  const live = presence.filter((p) => p.surface !== 'telegram');
+  if (live.length > 0) {
+    lines.push('🟢 Live sessions:');
+    for (const p of live) {
+      lines.push(`  ${p.sessionId}  (${p.surface}, ${p.cwd})`);
+    }
+  }
+
+  const saved = listSessions()
+    .filter((s) => s.source !== 'telegram')
+    .slice(0, 8);
+  const withLedger: string[] = [];
+  for (const s of saved) {
+    if (s.sessionId && (await ledgerExists(s.sessionId))) {
+      withLedger.push(`  ${s.name ?? s.id}  (${s.model})`);
+    }
+  }
+  if (withLedger.length > 0) {
+    if (lines.length > 0) lines.push('');
+    lines.push('💾 Recent sessions with activity logs:', ...withLedger);
+  }
+
+  if (lines.length === 0) {
+    return 'No watchable sessions found. Start one with `afk i` on your machine, then /watch <session-id-or-name>.';
+  }
+  lines.push('', 'Watch one with /watch <session-id-or-name>.');
+  return lines.join('\n');
+}
+
+interface ActiveWatch {
+  sessionId: string;
+  abort: AbortController;
+  finished: Promise<void>;
+}
+
+/**
+ * Per-chat watch registry. Owns the tail loops and their teardown.
+ */
+export class SessionWatchManager {
+  private readonly watches = new Map<number, ActiveWatch>();
+  private readonly log: LogFn;
+
+  constructor(log: LogFn = () => {}) {
+    this.log = log;
+  }
+
+  /** The session id this chat is watching, if any. */
+  watching(chatId: number): string | undefined {
+    return this.watches.get(chatId)?.sessionId;
+  }
+
+  /**
+   * Start watching `sessionId` for `chatId`, replacing any existing watch.
+   * `send` delivers rendered batches to the chat; failures are logged and
+   * the watch continues (a transient Telegram error must not kill the tail).
+   */
+  start(chatId: number, sessionId: string, send: SendFn): void {
+    this.stop(chatId);
+    const abort = new AbortController();
+    const finished = this._run(chatId, sessionId, send, abort.signal).catch((err) => {
+      this.log('watch loop error:', err);
+    });
+    this.watches.set(chatId, { sessionId, abort, finished });
+  }
+
+  /** Stop the chat's active watch. Returns the watched id, if there was one. */
+  stop(chatId: number): string | undefined {
+    const active = this.watches.get(chatId);
+    if (!active) return undefined;
+    this.watches.delete(chatId);
+    active.abort.abort();
+    return active.sessionId;
+  }
+
+  /** Tear down all watches (bot shutdown). */
+  async stopAll(): Promise<void> {
+    const all = [...this.watches.values()];
+    this.watches.clear();
+    for (const w of all) w.abort.abort();
+    await Promise.allSettled(all.map((w) => w.finished));
+  }
+
+  private async _run(
+    chatId: number,
+    sessionId: string,
+    send: SendFn,
+    signal: AbortSignal,
+  ): Promise<void> {
+    let batch: string[] = [];
+    let flushTimer: NodeJS.Timeout | null = null;
+    let sending = Promise.resolve();
+
+    const flush = (): void => {
+      flushTimer = null;
+      if (batch.length === 0) return;
+      const text = batch.join('\n');
+      batch = [];
+      // Serialize sends so batches arrive in order even when Telegram is slow.
+      sending = sending
+        .then(() => send(text))
+        .catch((err) => this.log('watch send error:', err));
+    };
+
+    try {
+      for await (const rec of tailLedger(sessionId, { signal })) {
+        const line = renderLedgerRecord(rec);
+        if (!line) continue;
+        batch.push(line);
+        if (rec.kind === 'closed') {
+          flush();
+          break;
+        }
+        if (!flushTimer) {
+          flushTimer = setTimeout(flush, FLUSH_INTERVAL_MS);
+          // Don't hold the process open for a pending flush.
+          flushTimer.unref?.();
+        }
+      }
+      // Tail ended (closed record or abort) — deliver anything still queued.
+      if (flushTimer) clearTimeout(flushTimer);
+      flush();
+      await sending;
+    } finally {
+      if (flushTimer) clearTimeout(flushTimer);
+      // Only delete if we're still the registered watch (a replacement may
+      // have been installed by a newer start()).
+      const current = this.watches.get(chatId);
+      if (current && current.sessionId === sessionId && current.abort.signal === signal) {
+        this.watches.delete(chatId);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Stage 1 of cross-surface session continuity: a **durable per-session event ledger** plus a **Telegram `/watch` live-tail**. Start agent work in the CLI REPL, walk away, and watch it stream to your phone — no daemon required, no process-topology change.

- Every top-level `AgentSession` appends a compact projection of its `OutputEvent` stream to `~/.afk/state/sessions/<sessionId>/events.jsonl`
- New Telegram commands: `/watch <session-id-or-name>` (live-tail into the chat), `/watch` (list watchable sessions), `/unwatch`
- Watch targets resolve through the same store as CLI `--resume`: sidecar id, SDK session id, `/name` slug, or unique name prefix

## Why this design

The obvious alternative — a gateway daemon owning all sessions (OpenClaw/Hermes pattern) — was put through an adversarial design review and rejected for this stage:

- A reduced gateway would have **deferred elicitation routing**, meaning approvals wouldn't work from the phone — hollowing out the exact AFK promise it exists to serve
- It converts the currently-optional daemon into a **mandatory single point of failure**
- The ledger solves the observation half **in-process**, keeps both surfaces independently operational, and leaves a clean upgrade path (a future daemon can own the ledger writer and expose it over SSE)

Stage 2 (turn-injection records → steer from phone) and stage 3 (elicitation records → approve from phone) are deliberate follow-ups, gated on stage-1 usage.

## How

**Ledger** (`src/agent/session-ledger.ts`) — mirrors the proven `BgJobLogWriter`/`BgJobLogReader` pattern:
- Projection, not transcript: user turns, assistant messages, tool starts, **failed** tool results, turn completions (cost/duration), errors, pause/resume, terminal `closed` record. Token deltas/progress/panels skipped — files stay compact and phone-renderable
- Lazy append stream, `0600` mode, all disk errors suppressed (a session must never fail because the ledger is unwritable)
- `tailLedger()`: `fs.watch` wakeup + 250ms poll floor (load-bearing on macOS where watch events coalesce), partial-line buffering, ends on `closed` or `AbortSignal`
- Session ids validated against a traversal-safe charset before any path use

**AgentSession wiring** (`src/agent/session/agent-session.ts`):
- Initializes lazily on the first turn (provider-issued session id only exists after `session.init`)
- Top-level sessions only (subagents gated off); opt-out via `AFK_SESSION_LEDGER_DISABLED=1`
- `close()`/`reset()` await the terminal-record flush so tailers observe the seal; abort path fire-and-forgets

**Telegram** (`src/telegram/watch.ts`):
- Debounce-batched (1.5s) record delivery — a burst of tool events becomes one message, not N rate-limited sends; sends serialized; failed sends logged, watch continues
- One watch per chat; bot shutdown tears all watches down

## Verification

- `pnpm lint` (tsc strict) ✅
- `pnpm test:coverage` — 464 files, 8685 passed, thresholds met ✅
- `pnpm scan:env:check` ✅ (new env var registered, docs regenerated)
- `pnpm audit:sdk:check` ✅ (no new SDK symbols)
- `pnpm build` ✅
- 32 new tests: projection unit tests, writer/reader round-trip, tail semantics (replay, live-append, abort, traversal rejection), AgentSession integration via mock provider (turn → records → seal; subagent + env gates; reset re-cycle), watch manager (batching, replacement, send-failure tolerance, target resolution)

## Try it

```bash
# Terminal: start any REPL session
afk i

# Phone (Telegram bot):
/watch            # list watchable sessions
/watch <id>       # live-tail it
/unwatch
```
