### PR TITLE
feat(tui): OSC 8 hyperlinks on tool-lane file paths — clickable without layout change

### DIFF
--- a/src/cli/commands/interactive/tool-lane-format-args.ts
+++ b/src/cli/commands/interactive/tool-lane-format-args.ts
@@ -5,6 +5,7 @@ import {
   styleForToolName,
 } from '../../tool-category.js';
 import { truncateDisplayWidth, displayWidth } from '../../display.js';
+import { fileHyperlink, hyperlinksEnabled } from '../../hyperlink.js';
 import { sanitizeLabel } from './tool-lane-format-sanitize.js';
 
 /**
@@ -35,9 +36,29 @@ export function shortenPaths(text: string): string {
   return result;
 }
 
-/** Collapse absolute paths with 3+ segments to their basename. */
+/**
+ * Collapse absolute paths with 3+ segments to their basename.
+ *
+ * When the terminal supports OSC 8 hyperlinks, the collapsed basename is
+ * emitted as a clickable link targeting the full original path as a
+ * `file://` URL — the display text (and therefore layout, wrapping, and
+ * truncation budgets) is byte-identical in width to the plain basename
+ * because OSC sequences are zero display columns. Cmd+click in VS Code /
+ * Cursor / iTerm2 / WezTerm / kitty / Ghostty opens the full path even
+ * though only the basename is shown.
+ *
+ * Injection safety: the regex match comes from toolInput that was already
+ * ANSI-stripped at storage time (tool-lane.ts addStart), and
+ * `fileHyperlink` percent-encodes the URI via `pathToFileURL`, so path
+ * content cannot smuggle escape bytes into the emitted sequence. We emit
+ * the only OSC 8 in the pipeline — model-controlled escapes never survive
+ * to this point.
+ */
 function collapseFsPaths(text: string): string {
-  return text.replace(/\/(?:[^/\s,)]+\/){2,}([^/\s,)]+)/g, '$1');
+  const linkify = hyperlinksEnabled();
+  return text.replace(/\/(?:[^/\s,)]+\/){2,}([^/\s,)]+)/g, (fullPath, basename: string) =>
+    linkify ? fileHyperlink(basename, fullPath) : basename,
+  );
 }
 
 /**

--- a/src/cli/commands/interactive/tool-lane-format.test.ts
+++ b/src/cli/commands/interactive/tool-lane-format.test.ts
@@ -6,7 +6,7 @@
  * Pure-function tests; no ToolLane / no terminal state.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import {
   summarizeToolArgs,
   formatOutcome,
@@ -19,7 +19,8 @@ import {
   MAX_OVERLAY_DIFF_LINES,
   FLUSH_DIFF_LINES_DEFAULT,
 } from './tool-lane-format.js';
-import { stripAnsi } from '../../display.js';
+import { resetHyperlinksEnabledForTest } from '../../hyperlink.js';
+import { stripAnsi, displayWidth } from '../../display.js';
 import type { ToolResultChunk } from '../../../agent/types/message-types.js';
 import type { DiffPayload } from '../../../utils/diff.js';
 
@@ -592,6 +593,82 @@ describe('shortenPaths — URL-safety + fs-path collapsing', () => {
     expect(shortenPaths('see https://x.com/a/b/c then /Users/me/proj/src/y.ts')).toBe(
       'see https://x.com/a/b/c then y.ts',
     );
+  });
+});
+
+describe('shortenPaths — OSC 8 hyperlink emission', () => {
+  afterEach(() => resetHyperlinksEnabledForTest());
+
+  it('emits no escapes when hyperlinks are disabled (non-TTY default)', () => {
+    resetHyperlinksEnabledForTest(false);
+    expect(shortenPaths('/Users/me/proj/src/x.ts')).toBe('x.ts');
+  });
+
+  it('wraps the collapsed basename in a file:// link to the full path when enabled', () => {
+    resetHyperlinksEnabledForTest(true);
+    const out = shortenPaths('/Users/me/proj/src/x.ts');
+    expect(stripAnsi(out)).toBe('x.ts');
+    expect(out).toContain('\x1b]8;;file:///Users/me/proj/src/x.ts\x1b\\');
+    expect(out).toContain('\x1b]8;;\x1b\\'); // close sequence present
+  });
+
+  it('zero-width invariant: linked output measures identical to plain output', () => {
+    resetHyperlinksEnabledForTest(true);
+    const linked = shortenPaths('git -C /Users/me/proj/agent-afk log');
+    resetHyperlinksEnabledForTest(false);
+    const plain = shortenPaths('git -C /Users/me/proj/agent-afk log');
+    expect(displayWidth(linked)).toBe(displayWidth(plain));
+    expect(stripAnsi(linked)).toBe(plain);
+  });
+
+  it('does not linkify URLs or short paths', () => {
+    resetHyperlinksEnabledForTest(true);
+    expect(shortenPaths(' https://example.com/docs/api/reference')).toBe(
+      ' https://example.com/docs/api/reference',
+    );
+    expect(shortenPaths('/tmp/file.ts')).toBe('/tmp/file.ts');
+  });
+
+  it('percent-encodes spaces in the link target', () => {
+    resetHyperlinksEnabledForTest(true);
+    const out = shortenPaths('/Users/me/My\u00a0Project/src/x.ts');
+    // Path with non-break space segment still produces an encoded URI and
+    // an intact visible basename.
+    expect(stripAnsi(out)).toContain('x.ts');
+  });
+
+  it('formatToolLine keeps the link intact through width budgeting', () => {
+    resetHyperlinksEnabledForTest(true);
+    const out = formatToolLine('read_file(/Users/me/proj/src/index.ts)', 80);
+    expect(stripAnsi(out)).toContain('index.ts');
+    expect(out).toContain('file:///Users/me/proj/src/index.ts');
+    // Balanced open/close: no link bleed past the row.
+    const opens = (out.match(/\x1b\]8;;file[^\x1b]*\x1b\\/g) ?? []).length;
+    const closes = (out.match(/\x1b\]8;;\x1b\\/g) ?? []).length;
+    expect(opens).toBe(closes);
+  });
+});
+
+describe('formatOutcome — persistedPath hyperlink', () => {
+  afterEach(() => resetHyperlinksEnabledForTest());
+
+  it('links the ~-shortened display path to the absolute path when enabled', () => {
+    resetHyperlinksEnabledForTest(true);
+    const out = formatOutcome(
+      makeResult({ persistedPath: '/home/u/.afk/state/out.txt' }),
+      '/home/u',
+    );
+    expect(stripAnsi(out)).toContain('saved → ~/.afk/state/out.txt');
+    expect(out).toContain('file:///home/u/.afk/state/out.txt');
+  });
+
+  it('renders plain text when disabled', () => {
+    resetHyperlinksEnabledForTest(false);
+    const out = formatOutcome(
+      makeResult({ persistedPath: '/home/u/.afk/state/out.txt' }),
+      '/home/u',
+    );
+    expect(out).not.toContain(']8;;');
   });
 });
 

--- a/src/cli/commands/interactive/tool-lane-format.ts
+++ b/src/cli/commands/interactive/tool-lane-format.ts
@@ -1,6 +1,7 @@
 import type { ToolResultChunk } from '../../../agent/types/message-types.js';
 import { env } from '../../../config/env.js';
 import { palette } from '../../palette.js';
+import { fileHyperlink, hyperlinksEnabled } from '../../hyperlink.js';
 import { categorizeTool } from '../../tool-category.js';
 import { sanitizeLabel, sanitizeTextParagraph } from './tool-lane-format-sanitize.js';
 
@@ -96,7 +97,15 @@ export function formatOutcome(
     const displayPath = chunk.persistedPath.startsWith(effectiveHomeDir)
       ? '~' + chunk.persistedPath.slice(effectiveHomeDir.length)
       : chunk.persistedPath;
-    return resultColor(`saved → ${displayPath}`);
+    // OSC 8 hyperlink: keep the compact `~/…` display text but link to the
+    // full absolute path so the saved file is Cmd+clickable in supporting
+    // terminals. fileHyperlink percent-encodes the URI; zero display width
+    // so layout is unchanged. Color wrapping the link is safe — SGR and
+    // OSC 8 sequences nest independently.
+    const linked = hyperlinksEnabled()
+      ? fileHyperlink(displayPath, chunk.persistedPath)
+      : displayPath;
+    return resultColor(`saved → ${linked}`);
   }
   if (chunk.lineCount !== undefined && chunk.lineCount > 1) {
     return resultColor(`${chunk.lineCount} ${outcomeNoun(toolName, chunk.lineCount)}`);

--- a/src/cli/commands/interactive/tool-lane-render-agent.ts
+++ b/src/cli/commands/interactive/tool-lane-render-agent.ts
@@ -243,7 +243,14 @@ function renderGroupedRootTools(
       const needSeparators = entriesWithDiffs.length > 1;
       for (const e of entriesWithDiffs) {
         if (needSeparators) {
-          const label = sanitizeLabel(shortenPaths(e.toolInput).trim() || e.toolInput.trim());
+          // Order is load-bearing: sanitizeLabel BEFORE shortenPaths.
+          // shortenPaths emits OSC 8 hyperlink escapes (the one sanctioned
+          // escape producer in the lane); sanitizeLabel strips ALL ANSI, so
+          // running it after would kill the link. Sanitizing first is
+          // equally safe — toolInput is the injection surface, and it is
+          // fully scrubbed before linkification adds our own escapes.
+          const sanitized = sanitizeLabel(e.toolInput);
+          const label = shortenPaths(sanitized).trim() || sanitized.trim();
           lines.push('    ' + palette.dim(`── ${label} ──`));
         }
         for (const line of formatDiffBlock(e.diff!, 'flush', '    ')) {
@@ -261,7 +268,10 @@ function formatGroupedToolResults(
   homeDir?: string,
 ): string {
   const { color, glyph } = styleForToolName(toolName);
-  const targets = entries.map((e) => sanitizeLabel(shortenPaths(e.toolInput).trim()));
+  // sanitizeLabel before shortenPaths — same ordering rationale as the
+  // diff-separator labels above (shortenPaths emits OSC 8 hyperlinks that
+  // sanitizeLabel would strip).
+  const targets = entries.map((e) => shortenPaths(sanitizeLabel(e.toolInput)).trim());
   const header =
     color(glyph + ' ') +
     color.bold(toolName) +

--- a/src/cli/display.test.ts
+++ b/src/cli/display.test.ts
@@ -20,6 +20,40 @@ describe('display utilities', () => {
     expect(scrubbed).not.toContain('\x1b');
   });
 
+  describe('truncateDisplayWidth — OSC 8 hyperlink bleed guard', () => {
+    const OSC8_CLOSE = '\x1b]8;;\x1b\\';
+    const link = (text: string, url: string) => `\x1b]8;;${url}\x1b\\${text}${OSC8_CLOSE}`;
+
+    it('re-closes a hyperlink span when the cut lands inside it', () => {
+      // `prefix ` (7 cols) + linked `long-basename.ts` — truncating at 12
+      // keeps the OSC 8 open but drops the original close. Without the
+      // bleed guard, everything rendered after this string joins the link.
+      const text = 'prefix ' + link('long-basename.ts', 'file:///a/b/long-basename.ts');
+      const out = truncateDisplayWidth(text, 12);
+      const opens = (out.match(/\x1b\]8;;[^\x1b]+\x1b\\/g) ?? []).length;
+      const closes = (out.match(/\x1b\]8;;\x1b\\/g) ?? []).length;
+      expect(opens).toBe(1);
+      expect(closes).toBe(1);
+      // Close must come after the ellipsis (remnant stays clickable) and
+      // before the SGR reset tail.
+      expect(out.indexOf(OSC8_CLOSE)).toBeGreaterThan(out.indexOf('…'));
+    });
+
+    it('does not add a spurious close when the link was fully consumed before the cut', () => {
+      const text = link('x.ts', 'file:///a/b/x.ts') + ' trailing-text-that-overflows';
+      const out = truncateDisplayWidth(text, 10);
+      // One close from the intact link; no extra appended.
+      const closes = (out.match(/\x1b\]8;;\x1b\\/g) ?? []).length;
+      expect(closes).toBe(1);
+    });
+
+    it('zero-width invariant: linked and plain text truncate to identical visible output', () => {
+      const plain = 'read x.ts now';
+      const linked = 'read ' + link('x.ts', 'file:///a/b/x.ts') + ' now';
+      expect(stripAnsi(truncateDisplayWidth(linked, 8))).toBe(truncateDisplayWidth(plain, 8));
+    });
+  });
+
   it('steps grapheme boundaries across emoji and combining sequences', () => {
     expect(previousGraphemeIndex('🙂a', '🙂a'.length)).toBe(2);
     expect(previousGraphemeIndex('éa', 'éa'.length)).toBe(2);

--- a/src/cli/display.ts
+++ b/src/cli/display.ts
@@ -96,6 +96,14 @@ export function padDisplay(
   return padDisplayRight(text, width);
 }
 
+// OSC 8 hyperlink tokens: `ESC ] 8 ; params ; URI (BEL|ST)`. An OPEN has a
+// non-empty URI; a CLOSE has an empty one (`ESC ]8;;ST`). Truncation must
+// track open/close state — see truncateDisplayWidth below.
+const OSC8_TOKEN_RE = /^\x1b\]8;[^;\x07\x1b]*;(.*?)(?:\x07|\x1b\\)$/s;
+
+/** OSC 8 close sequence (ST-terminated) — ends the current hyperlink span. */
+const OSC8_CLOSE = '\x1b]8;;\x1b\\';
+
 export function truncateDisplayWidth(
   text: string,
   maxWidth: number,
@@ -109,11 +117,20 @@ export function truncateDisplayWidth(
   let width = 0;
   let out = '';
   let sawAnsi = false;
+  let openHyperlink = false;
 
   for (const token of tokenizeAnsi(text)) {
     if (token.type === 'ansi') {
       out += token.value;
       sawAnsi = true;
+      // Track OSC 8 open/close state: if the truncation cut lands between a
+      // hyperlink's open and close sequences, the dropped close would leave
+      // the link span unterminated and everything rendered AFTER this string
+      // (padding, the next lane row, …) would become part of the link
+      // ("link bleed"). The trailing `\x1b[0m` SGR reset does NOT close an
+      // OSC 8 span — only `ESC ]8;;ST` does — so we re-close explicitly.
+      const osc8 = OSC8_TOKEN_RE.exec(token.value);
+      if (osc8) openHyperlink = (osc8[1] ?? '').length > 0;
       continue;
     }
     const nextWidth = width + displayWidth(token.value);
@@ -122,7 +139,9 @@ export function truncateDisplayWidth(
     width = nextWidth;
   }
 
-  return out + ellipsis + (sawAnsi ? '\x1b[0m' : '');
+  // Ellipsis goes INSIDE a still-open link span so the truncated remnant
+  // stays clickable end-to-end, then the span is closed before the reset.
+  return out + ellipsis + (openHyperlink ? OSC8_CLOSE : '') + (sawAnsi ? '\x1b[0m' : '');
 }
 
 function clampIndex(index: number, length: number): number {

--- a/src/cli/hyperlink.test.ts
+++ b/src/cli/hyperlink.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  hyperlink,
+  fileHyperlink,
+  supportsHyperlinks,
+  hyperlinksEnabled,
+  resetHyperlinksEnabledForTest,
+  OSC8_CLOSE,
+} from './hyperlink.js';
+import { stripAnsi, displayWidth } from './display.js';
+
+afterEach(() => resetHyperlinksEnabledForTest());
+
+describe('hyperlink', () => {
+  it('wraps text in an ST-terminated OSC 8 open/close pair', () => {
+    const out = hyperlink('x.ts', 'file:///tmp/x.ts');
+    expect(out).toBe('\x1b]8;;file:///tmp/x.ts\x1b\\x.ts\x1b]8;;\x1b\\');
+  });
+
+  it('is zero display width beyond the visible text', () => {
+    const out = hyperlink('x.ts', 'file:///Users/me/proj/src/x.ts');
+    expect(displayWidth(out)).toBe(displayWidth('x.ts'));
+  });
+
+  it('stripAnsi removes the escapes and leaves the visible text', () => {
+    const out = hyperlink('x.ts', 'file:///tmp/x.ts');
+    expect(stripAnsi(out)).toBe('x.ts');
+  });
+});
+
+describe('fileHyperlink', () => {
+  it('targets the absolute path as a file:// URL', () => {
+    const out = fileHyperlink('x.ts', '/Users/me/proj/src/x.ts');
+    expect(out).toContain('file:///Users/me/proj/src/x.ts');
+    expect(stripAnsi(out)).toBe('x.ts');
+  });
+
+  it('percent-encodes spaces, unicode, and control bytes in the URI', () => {
+    const out = fileHyperlink('y.ts', '/tmp/a b/x\x07y.ts');
+    expect(out).toContain('file:///tmp/a%20b/x%07y.ts');
+    // The raw BEL byte must never appear in the emitted sequence.
+    expect(out).not.toContain('\x07');
+  });
+
+  it('resolves relative input against cwd (pathToFileURL semantics) without throwing', () => {
+    // pathToFileURL never throws on string input (relative paths resolve
+    // against cwd; lone surrogates are replacement-char-encoded), so the
+    // fail-open catch in fileHyperlink is purely defensive. Document the
+    // observable behavior: relative input still yields a valid clickable
+    // link with intact visible text.
+    const out = fileHyperlink('b.ts', 'a/b.ts');
+    expect(stripAnsi(out)).toBe('b.ts');
+    expect(out).toContain('file://');
+  });
+});
+
+describe('supportsHyperlinks', () => {
+  it('FORCE_HYPERLINK=1 force-enables even without a TTY', () => {
+    expect(supportsHyperlinks({ FORCE_HYPERLINK: '1' }, false)).toBe(true);
+  });
+
+  it('FORCE_HYPERLINK=0 / false force-disables even on a supported terminal', () => {
+    expect(supportsHyperlinks({ FORCE_HYPERLINK: '0', TERM_PROGRAM: 'vscode' }, true)).toBe(false);
+    expect(supportsHyperlinks({ FORCE_HYPERLINK: 'false', TERM_PROGRAM: 'vscode' }, true)).toBe(
+      false,
+    );
+  });
+
+  it('disabled when stdout is not a TTY', () => {
+    expect(supportsHyperlinks({ TERM_PROGRAM: 'vscode' }, false)).toBe(false);
+  });
+
+  it('disabled in CI', () => {
+    expect(supportsHyperlinks({ TERM_PROGRAM: 'vscode', CI: 'true' }, true)).toBe(false);
+  });
+
+  it.each([
+    ['vscode (covers Cursor)', { TERM_PROGRAM: 'vscode' }],
+    ['iTerm2', { TERM_PROGRAM: 'iTerm.app' }],
+    ['WezTerm', { WEZTERM_PANE: '1' }],
+    ['kitty', { KITTY_WINDOW_ID: '1' }],
+    ['Ghostty', { TERM: 'xterm-ghostty' }],
+    ['Windows Terminal', { WT_SESSION: 'x' }],
+    ['Konsole', { KONSOLE_DBUS_SERVICE: 'x' }],
+    ['Alacritty', { TERM: 'alacritty' }],
+  ] as const)('enabled on %s', (_name, env) => {
+    expect(supportsHyperlinks(env, true)).toBe(true);
+  });
+
+  it.each([
+    ['Apple Terminal', { TERM_PROGRAM: 'Apple_Terminal' }],
+    ['Hyper', { TERM_PROGRAM: 'Hyper' }],
+    ['tmux (passthrough not configured)', { TMUX: '/tmp/tmux-1000/default,123,0' }],
+    ['unknown terminal', {}],
+  ] as const)('disabled on %s', (_name, env) => {
+    expect(supportsHyperlinks(env, true)).toBe(false);
+  });
+
+  it('gates VTE family on VTE_VERSION >= 0.50', () => {
+    expect(supportsHyperlinks({ GNOME_TERMINAL_SCREEN: 'x', VTE_VERSION: '5202' }, true)).toBe(
+      true,
+    );
+    expect(supportsHyperlinks({ GNOME_TERMINAL_SCREEN: 'x', VTE_VERSION: '4205' }, true)).toBe(
+      false,
+    );
+    // No advertised version: allow (gnome-terminal sets the screen var
+    // and any modern release supports OSC 8).
+    expect(supportsHyperlinks({ GNOME_TERMINAL_SCREEN: 'x' }, true)).toBe(true);
+  });
+});
+
+describe('hyperlinksEnabled cache seam', () => {
+  it('resetHyperlinksEnabledForTest pins the value', () => {
+    resetHyperlinksEnabledForTest(true);
+    expect(hyperlinksEnabled()).toBe(true);
+    resetHyperlinksEnabledForTest(false);
+    expect(hyperlinksEnabled()).toBe(false);
+  });
+});
+
+describe('OSC8_CLOSE', () => {
+  it('is the ST-terminated empty-URI close sequence', () => {
+    expect(OSC8_CLOSE).toBe('\x1b]8;;\x1b\\');
+  });
+});

--- a/src/cli/hyperlink.ts
+++ b/src/cli/hyperlink.ts
@@ -1,0 +1,136 @@
+/**
+ * OSC 8 terminal hyperlink support.
+ *
+ * Lets the tool lane keep its compact display text (`x.ts`) while making it
+ * a real clickable link whose target is the full absolute `file://` path —
+ * dissolving the "clickable paths vs. clean layout" trade-off. The escape
+ * sequences are zero display width (`string-width` skips OSC), so emitting
+ * a hyperlink never changes wrapping, truncation budgets, or alignment.
+ *
+ * Wire format (ST-terminated; BEL also valid but ST is the modern form):
+ *
+ *   ESC ] 8 ; params ; URI ST  <visible text>  ESC ] 8 ; ; ST
+ *
+ * Capability detection is conservative-allowlist: only terminals known to
+ * render OSC 8 as clickable links get the escapes. Unsupported terminals
+ * would *usually* ignore them gracefully, but Apple Terminal and old VTEs
+ * can show garbage, and tmux requires passthrough config — so unknowns get
+ * plain text. Degradation is purely cosmetic (the short path, exactly as
+ * today).
+ *
+ * env-access note: this module reads terminal-capability vars (TERM_PROGRAM,
+ * TMUX, FORCE_HYPERLINK, …) via an injectable `NodeJS.ProcessEnv` parameter
+ * defaulting to `process.env` — the same injectable-test-seam pattern as
+ * `src/cli/terminal-spawn/`. The audit script skips default-param seams, and
+ * these OS-level / community-convention vars (FORCE_HYPERLINK mirrors
+ * FORCE_COLOR's convention but is read here, not via `env.X`) are outside
+ * the AFK domain and intentionally not in ENV_REGISTRY.
+ */
+
+import { pathToFileURL } from 'node:url';
+import { detectTerminal } from './terminal-spawn/detect.js';
+
+/** OSC 8 close sequence — ends the most recent hyperlink span. */
+export const OSC8_CLOSE = '\x1b]8;;\x1b\\';
+
+/**
+ * Terminals (by `detectTerminal` kind) known to render OSC 8 hyperlinks.
+ *
+ * Included: iTerm2 (≥3.1), WezTerm, kitty, VS Code (≥1.72 — also covers
+ * Cursor, which reports TERM_PROGRAM=vscode), Ghostty, Windows Terminal
+ * (≥1.4), Konsole, GNOME/VTE family (≥0.50 — VTE_VERSION-gated below),
+ * Alacritty (≥0.11).
+ *
+ * Excluded: Apple Terminal (no support), Hyper (plugin-dependent),
+ * tmux (requires user passthrough config; the host terminal is hidden),
+ * unknown.
+ */
+const HYPERLINK_TERMINALS = new Set([
+  'iterm2',
+  'wezterm',
+  'kitty',
+  'vscode',
+  'ghostty',
+  'windows-terminal',
+  'konsole',
+  'gnome-terminal',
+  'alacritty',
+]);
+
+/** Minimum VTE_VERSION with OSC 8 support (0.50.0 → "5000"). */
+const VTE_MIN_VERSION = 5000;
+
+/**
+ * Pure capability check. Order:
+ *  1. FORCE_HYPERLINK — explicit override both ways (`0`/`false` disables,
+ *     any other non-empty value enables). Mirrors the FORCE_COLOR convention
+ *     and the `supports-hyperlinks` npm package.
+ *  2. Not a TTY, or CI set → off (piped output / log collectors).
+ *  3. Terminal allowlist via detectTerminal; VTE family additionally
+ *     version-gated.
+ */
+export function supportsHyperlinks(
+  env: NodeJS.ProcessEnv = process.env,
+  isTTY: boolean = process.stdout.isTTY === true,
+): boolean {
+  const force = env['FORCE_HYPERLINK'];
+  if (force !== undefined && force.length > 0) {
+    return force !== '0' && force.toLowerCase() !== 'false';
+  }
+  if (!isTTY) return false;
+  if (env['CI'] !== undefined && env['CI'].length > 0) return false;
+
+  const kind = detectTerminal(env);
+  if (!HYPERLINK_TERMINALS.has(kind)) return false;
+  // VTE family: detectTerminal returns 'gnome-terminal' for both the real
+  // gnome-terminal (GNOME_TERMINAL_SCREEN) and the generic VTE_VERSION
+  // catch-all (Tilix, XFCE4, …). Gate both on a modern-enough VTE when the
+  // version is advertised.
+  if (kind === 'gnome-terminal' && env['VTE_VERSION'] !== undefined) {
+    const vte = Number.parseInt(env['VTE_VERSION'], 10);
+    if (!Number.isFinite(vte) || vte < VTE_MIN_VERSION) return false;
+  }
+  return true;
+}
+
+let cached: boolean | undefined;
+
+/**
+ * Cached process-level capability check. Detection is a pure function of
+ * env + stdout TTY-ness, neither of which changes mid-process, so we
+ * evaluate once on first use.
+ */
+export function hyperlinksEnabled(): boolean {
+  if (cached === undefined) cached = supportsHyperlinks();
+  return cached;
+}
+
+/** Test seam: clear (or pin) the cached capability result. */
+export function resetHyperlinksEnabledForTest(value?: boolean): void {
+  cached = value;
+}
+
+/**
+ * Wrap `text` in an OSC 8 hyperlink pointing at `url`. The caller is
+ * responsible for ensuring `url` contains no raw control bytes — use
+ * {@link fileHyperlink} for filesystem paths, which percent-encodes via
+ * `pathToFileURL`.
+ */
+export function hyperlink(text: string, url: string): string {
+  return `\x1b]8;;${url}\x1b\\${text}${OSC8_CLOSE}`;
+}
+
+/**
+ * Wrap `text` in a hyperlink targeting an absolute filesystem path as a
+ * `file://` URL. `pathToFileURL` percent-encodes spaces, unicode, and any
+ * control bytes, so adversarial path content cannot smuggle escape
+ * sequences through the URI portion. Fail-open: if URL conversion throws
+ * (relative path, malformed input), returns `text` unchanged.
+ */
+export function fileHyperlink(text: string, absolutePath: string): string {
+  try {
+    return hyperlink(text, pathToFileURL(absolutePath).href);
+  } catch {
+    return text;
+  }
+}


### PR DESCRIPTION
## What

File paths in the interactive tool lane are now **Cmd+clickable** without changing the layout at all. Collapsed basenames (`x.ts`) and `saved → ~/...` outcome paths are emitted as OSC 8 terminal hyperlinks whose target is the full absolute path as a percent-encoded `file://` URL.

The escape sequences are zero display width, so wrapping, truncation budgets, and alignment are byte-identical to the previous plain-text rendering. This dissolves the "clickable full paths vs. clean layout" trade-off instead of balancing it.

## How

- **`src/cli/hyperlink.ts`** (new): `hyperlink` / `fileHyperlink` emitters + `supportsHyperlinks` capability check reusing `detectTerminal()`. Conservative allowlist: VS Code/Cursor, iTerm2, WezTerm, kitty, Ghostty, Windows Terminal, Konsole, Alacritty, VTE ≥ 0.50. Plain text for non-TTY, CI, Apple Terminal, Hyper, tmux, unknown. `FORCE_HYPERLINK` overrides both ways (mirrors `FORCE_COLOR` convention). Cached per-process with a test seam.
- **`truncateDisplayWidth` bleed guard** (`display.ts`): tracks OSC 8 open/close state during tokenization and re-closes a link span severed by the truncation cut. The trailing `\x1b[0m` SGR reset does **not** terminate an OSC 8 span — without this, everything rendered after a mid-link cut would join the link. The ellipsis lands *inside* the span so a truncated path remnant stays clickable to the full target.
- **`collapseFsPaths`** (`tool-lane-format-args.ts`): wraps each collapsed basename in a link to the original absolute path when the terminal supports it. URLs and short (<3-segment) paths untouched, exactly as before.
- **`formatOutcome`** (`tool-lane-format.ts`): the `~`-shortened `persistedPath` display links to the absolute target.
- **Ordering fix** (`tool-lane-render-agent.ts`): `sanitizeLabel` now runs **before** `shortenPaths` at both call sites — sanitization strips ALL ANSI and would have killed the link just emitted. Comments at both sites document the load-bearing order.

## Injection safety

The lane's threat model (LLM-controlled toolInput smuggling escapes) is preserved:

- toolInput is ANSI-stripped at storage time (`tool-lane.ts addStart`) and/or `sanitizeLabel`-scrubbed **before** linkification — we are the only escape producer in the pipeline.
- The link URI is percent-encoded via `pathToFileURL`, so path content (BEL, spaces, unicode) cannot carry raw control bytes into the emitted sequence.
- `stripAnsi` / `sanitizeLabel` already cover OSC 8, so every existing scrub surface removes these links cleanly where links don't belong.

## Testing

- `src/cli/hyperlink.test.ts` (25 tests): emission shape, zero-width invariant, percent-encoding, full capability matrix (per-terminal enable/disable, FORCE_HYPERLINK, CI, non-TTY, VTE version gate).
- `display.test.ts`: truncation bleed guard — severed span is re-closed, no spurious close when the link is fully consumed, linked/plain text truncate to identical visible output.
- `tool-lane-format.test.ts`: `shortenPaths` link round-trips, width invariants, URL/short-path non-linkification, `formatOutcome` persistedPath links, `formatToolLine` open/close balance through width budgeting.
- Full suite: **8689 passed / 462 files**, `tsc --noEmit` clean, `pnpm audit:env:check` clean.
- Smoke render: `read_file(/…/src/cli/display.ts)` → visible `● read_file(display.ts)`, width 23, full `file:///` target embedded.

## Not covered

- Diff-block file headers (`tool-lane-format-diff.ts`) don't render paths directly today — no change needed.
- Manual Cmd+click verification in a live terminal (Cursor/iTerm2) is recommended before merge; degradation on unsupported terminals is plain text, i.e. exactly today's rendering.
