### PR TITLE
feat(build): add fix:pins hash-pin regen + check

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "audit:env:list": "tsx scripts/audit-env-access.ts --list",
     "scan:env": "tsx scripts/render-env-registry.ts",
     "scan:env:check": "tsx scripts/render-env-registry.ts --check",
+    "fix:pins": "tsx scripts/update-hash-pins.ts",
+    "fix:pins:check": "tsx scripts/update-hash-pins.ts --check",
     "stats:tools": "tsx scripts/count-tool-calls.ts",
     "clean": "rm -rf dist",
     "build:dist": "node scripts/build-dist.mjs",

--- a/scripts/update-hash-pins.ts
+++ b/scripts/update-hash-pins.ts
@@ -1,0 +1,214 @@
+#!/usr/bin/env tsx
+/**
+ * Recompute SHA-256 hash pins for vendored and bundled skill files.
+ *
+ * Two test files hard-code pinned hashes that guard against undocumented edits:
+ *
+ *   src/skills/_agents/vendored.test.ts     — 3 vendored agent prompt files
+ *   src/bundled-plugins/awa-bundled/bundled.test.ts — 14 bundled SKILL.md files
+ *
+ * Both compute hashes as: createHash('sha256').update(rawContent).digest('hex')
+ * with NO normalization applied before hashing.
+ *
+ * Usage:
+ *   pnpm fix:pins             # recompute and rewrite stale pins in both test files
+ *   pnpm fix:pins:check       # exit nonzero if any pin would change (CI gate)
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const isCheck = process.argv.includes('--check');
+
+// ── Hash helper ────────────────────────────────────────────────────────────────
+
+function computeHash(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+// ── Target file definitions ────────────────────────────────────────────────────
+
+interface PinTarget {
+  /** Absolute path to the test file containing PINNED_HASHES */
+  testFile: string;
+  /** Map from pin key to absolute path of the source file to hash */
+  pins: Record<string, string>;
+}
+
+// vendored.test.ts: hashes src/skills/_agents/prompts/<name>.md
+// Path logic from test: join(__dirname, '../../../src/skills/_agents/prompts', `${name}.md`)
+// where test __dirname = src/skills/_agents — so paths resolve from repo root as below.
+const vendoredPromptsDir = join(repoRoot, 'src/skills/_agents/prompts');
+const vendoredTarget: PinTarget = {
+  testFile: join(repoRoot, 'src/skills/_agents/vendored.test.ts'),
+  pins: {
+    'research-agent': join(vendoredPromptsDir, 'research-agent.md'),
+    contract: join(vendoredPromptsDir, 'contract.md'),
+    'git-investigator': join(vendoredPromptsDir, 'git-investigator.md'),
+  },
+};
+
+// bundled.test.ts: hashes src/bundled-plugins/awa-bundled/skills/<name>/SKILL.md
+// Path logic from test: join(__dirname, 'skills', name, 'SKILL.md')
+// where test __dirname = src/bundled-plugins/awa-bundled
+const bundledSkillsDir = join(repoRoot, 'src/bundled-plugins/awa-bundled/skills');
+const bundledTarget: PinTarget = {
+  testFile: join(repoRoot, 'src/bundled-plugins/awa-bundled/bundled.test.ts'),
+  pins: {
+    contract: join(bundledSkillsDir, 'contract/SKILL.md'),
+    'devils-advocate': join(bundledSkillsDir, 'devils-advocate/SKILL.md'),
+    gather: join(bundledSkillsDir, 'gather/SKILL.md'),
+    'ground-claim': join(bundledSkillsDir, 'ground-claim/SKILL.md'),
+    'ground-state': join(bundledSkillsDir, 'ground-state/SKILL.md'),
+    'intent-lock': join(bundledSkillsDir, 'intent-lock/SKILL.md'),
+    parallelize: join(bundledSkillsDir, 'parallelize/SKILL.md'),
+    refactor: join(bundledSkillsDir, 'refactor/SKILL.md'),
+    research: join(bundledSkillsDir, 'research/SKILL.md'),
+    review: join(bundledSkillsDir, 'review/SKILL.md'),
+    'shadow-verify': join(bundledSkillsDir, 'shadow-verify/SKILL.md'),
+    ship: join(bundledSkillsDir, 'ship/SKILL.md'),
+    simplify: join(bundledSkillsDir, 'simplify/SKILL.md'),
+    spec: join(bundledSkillsDir, 'spec/SKILL.md'),
+  },
+};
+
+const TARGETS: PinTarget[] = [vendoredTarget, bundledTarget];
+
+// ── PINNED_HASHES block rewriter ───────────────────────────────────────────────
+//
+// Invariant: The rewrite must only change hex string values for known keys and
+// must not disturb surrounding comments, key order, indentation, quoting style,
+// or the `as const` suffix. We locate the block by its open/close boundaries
+// and replace each hash literal with a targeted regex that matches only the
+// 64-char hex string value for that exact key.
+//
+// The regex for each key handles both single-line style:
+//   contract: 'abc123...',
+// and wrapped style (value on the next line):
+//   'devils-advocate':
+//     'abc123...',
+// Both patterns end with either a trailing comma or the closing `}`.
+// We replace only the 64-char hex string in the value position.
+
+function rewritePins(
+  source: string,
+  pins: Record<string, string>,
+  newHashes: Record<string, string>,
+): string {
+  let result = source;
+
+  for (const key of Object.keys(pins)) {
+    const newHash = newHashes[key];
+    if (newHash === undefined) continue;
+
+    // Escape the key for use in a regex (hyphens need escaping in char classes
+    // but are safe in a character sequence — the only special chars in our keys
+    // are hyphens, which are literal outside character classes).
+    const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+    // Match the key (quoted or bare) followed by an optional colon+whitespace
+    // on the same line, then optionally a newline+whitespace (wrapped style),
+    // then a 64-char hex string in single quotes.
+    //
+    // Group 1: everything from the key through the opening quote of the hash
+    // Group 2: the 64-char hex value (the only thing we replace)
+    // Group 3: the closing quote (and optional trailing comma)
+    const pattern = new RegExp(
+      `('${escapedKey}'|${escapedKey})` +   // key: quoted or bare
+      `(:[^']*?')`                          + // colon + optional whitespace/newline + opening quote
+      `([0-9a-f]{64})`                      + // current 64-char hex hash (group 3)
+      `('[,]?)`,                              // closing quote + optional comma
+      'g',
+    );
+
+    result = result.replace(pattern, (_match, keyPart, middle, _oldHash, tail) => {
+      return `${keyPart}${middle}${newHash}${tail}`;
+    });
+  }
+
+  return result;
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+interface StalePin {
+  testFile: string;
+  key: string;
+  sourceFile: string;
+  currentHash: string;
+  freshHash: string;
+}
+
+const stalePins: StalePin[] = [];
+
+for (const target of TARGETS) {
+  const source = readFileSync(target.testFile, 'utf8');
+  const newHashes: Record<string, string> = {};
+
+  // Compute fresh hash for every key
+  for (const [key, srcPath] of Object.entries(target.pins)) {
+    const content = readFileSync(srcPath, 'utf8');
+    newHashes[key] = computeHash(content);
+  }
+
+  // Extract current pinned hashes from the test file by finding each key's value
+  for (const [key, srcPath] of Object.entries(target.pins)) {
+    const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(
+      `(?:'${escapedKey}'|${escapedKey})` +
+      `:[^']*?'` +
+      `([0-9a-f]{64})` +
+      `'`,
+    );
+    const match = pattern.exec(source);
+    const currentHash = match?.[1] ?? '';
+    const freshHash = newHashes[key] ?? '';
+
+    if (currentHash !== freshHash) {
+      stalePins.push({
+        testFile: target.testFile.replace(repoRoot + '/', ''),
+        key,
+        sourceFile: srcPath.replace(repoRoot + '/', ''),
+        currentHash,
+        freshHash,
+      });
+    }
+  }
+
+  // In write mode, rewrite the test file if any pins changed for this target
+  if (!isCheck) {
+    const rewritten = rewritePins(source, target.pins, newHashes);
+    if (rewritten !== source) {
+      writeFileSync(target.testFile, rewritten, 'utf8');
+      console.log(`Updated pins in ${target.testFile.replace(repoRoot + '/', '')}`);
+    }
+  }
+}
+
+// ── Report results ─────────────────────────────────────────────────────────────
+
+if (stalePins.length === 0) {
+  console.log('All hash pins are up to date.');
+  process.exit(0);
+} else if (isCheck) {
+  console.error(`${stalePins.length} stale hash pin(s) found:\n`);
+  for (const pin of stalePins) {
+    console.error(`  [${pin.testFile}] key: ${pin.key}`);
+    console.error(`    source file : ${pin.sourceFile}`);
+    console.error(`    pinned hash : ${pin.currentHash}`);
+    console.error(`    actual hash : ${pin.freshHash}`);
+    console.error('');
+  }
+  console.error('Run `pnpm fix:pins` to regenerate.');
+  process.exit(1);
+} else {
+  // Write mode: already rewrote above — just summarise what changed
+  for (const pin of stalePins) {
+    console.log(`  [${pin.testFile}] ${pin.key}: ${pin.currentHash.slice(0, 12)}… → ${pin.freshHash.slice(0, 12)}…`);
+  }
+}


### PR DESCRIPTION
## Source
Moat-scrubbed port of **afk-workshop#756** — https://github.com/griffinwork40/afk-workshop/pull/756
This is a sanitized port, **not** a 1:1 copy (see Dropped below).

## What
Adds `pnpm fix:pins` (regenerate) and `pnpm fix:pins:check` (CI gate), backed by a new `scripts/update-hash-pins.ts`.

## Why
The SHA-256 pins for vendored agent prompts (`src/skills/_agents/vendored.test.ts`) and bundled `SKILL.md` files (`src/bundled-plugins/awa-bundled/bundled.test.ts`) previously had to be updated by hand-copying hex whenever a prompt or skill doc changed — the recurring "the pin" test breakage. This automates detect + regen.

## What it does
- `pnpm fix:pins` — recompute the SHA-256 of every pinned file and rewrite the `PINNED_HASHES` blocks in place (handles both single-line and wrapped hex styles).
- `pnpm fix:pins:check` — recompute and exit 1 (naming each stale pin) if any pin is out of date. Intended to sit in CI next to `scan:env:check`.
- Hashes the raw UTF-8 file bytes exactly as the tests do (no normalization), so regenerated pins match the test computation.

## Ported
- `package.json` — two script entries (`fix:pins`, `fix:pins:check`), inserted after `scan:env:check`.
- `scripts/update-hash-pins.ts` — new standalone tsx script. Pins **3 vendored prompts** (`research-agent`, `contract`, `git-investigator`) + **14 bundled SKILL.md** files — exactly the sets the public test files pin.

## Dropped (and why)
- **`qualify` vendored pin** — the source PR pinned a 4th vendored prompt, `src/skills/_agents/prompts/qualify.md`. That file is private-only and does not exist in this repo, so the pin (and the script's header comment "4 vendored agent prompt files" → "3") was removed. One illustrative regex-example comment that used `qualify:` was changed to `contract:` (a real public bare key).

## Verification
- `pnpm install --frozen-lockfile` ✅ · `pnpm lint` (tsc --noEmit strict) ✅
- `pnpm test` — **8709 passed**, 12 skipped, 465 files ✅
- `pnpm build` ✅ · `pnpm build:dist` ✅
- Functional: `fix:pins:check` reports "All hash pins are up to date" on a clean tree; drift simulation (corrupt → detect exit 1 → `fix:pins` regen → restore) verified.
- Moat guard (tree + built `dist/`): **CLEAN** — zero hard-denylist hits, no structural moat.
- Independent adversarial audit: **CLEAN** — all 17 pin paths resolve, key sets match the public test files, no `qualify` reference remains.

**Please do not merge automatically — leaving for human review.**
