### PR TITLE
fix(worktree): don't reap a dead-owner worktree hosting a live session

### DIFF
--- a/src/agent/worktree-sweep.test.ts
+++ b/src/agent/worktree-sweep.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { runSweep } from './worktree-sweep.js';
 import type { ExecFileFn } from './worktree-sweep.js';
+import type { PresenceRecord } from './awareness/presence.js';
 
 type ExecResult = { stdout: string; stderr: string };
 type ExecCall = { file: string; args: string[]; opts?: { cwd?: string } };
@@ -81,9 +82,12 @@ let repoRoot: string;
 let afkWorktreesDir: string;
 let telemetryFile: string;
 let lockFile: string;
+let prevAfkHome: string | undefined;
 
 beforeEach(async () => {
   repoRoot = realpathSync(mkdtempSync(join(tmpdir(), 'afk-sweep-test-')));
+  prevAfkHome = process.env['AFK_HOME'];
+  process.env['AFK_HOME'] = repoRoot;
   afkWorktreesDir = join(repoRoot, '.afk-worktrees');
   await fs.mkdir(afkWorktreesDir, { recursive: true });
   telemetryFile = join(repoRoot, 'fake-telemetry.jsonl');
@@ -102,6 +106,8 @@ afterEach(() => {
   try {
     rmSync(repoRoot, { recursive: true, force: true });
   } catch { /* ignore */ }
+  if (prevAfkHome === undefined) delete process.env['AFK_HOME'];
+  else process.env['AFK_HOME'] = prevAfkHome;
   vi.restoreAllMocks();
 });
 
@@ -1147,5 +1153,181 @@ describe('dead-owner', () => {
     expect(result.removed).not.toContain(worktreePath);
     const activeCandidates = result.candidates.filter((c) => c.verdict === 'active');
     expect(activeCandidates).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. dead-owner — live-session protection
+// ---------------------------------------------------------------------------
+
+describe('dead-owner — live-session protection', () => {
+  /**
+   * Helper to find a PID that is guaranteed not to exist.
+   */
+  function findDeadPid(): number {
+    for (let pid = 999_999; pid > 90_000; pid -= 1_117) {
+      try {
+        process.kill(pid, 0);
+        // Process exists — not safe to use as "dead"
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'ESRCH') return pid;
+      }
+    }
+    throw new Error('Could not find a dead PID for test setup');
+  }
+
+  it('does NOT reap a dead-owner worktree while a live session occupies it', async () => {
+    const deadPid = findDeadPid();
+    const worktreePath = join(afkWorktreesDir, 'afk-live-session-wt');
+    await fs.mkdir(worktreePath, { recursive: true });
+
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({
+        owner: 'interactive',
+        pid: deadPid,
+        createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+        baseSha: 'base123',
+        baseBranch: 'main',
+      }),
+    );
+
+    const mainBlock = worktreeBlock({ path: repoRoot, head: 'base123' });
+    const wtBlock = worktreeBlock({
+      path: worktreePath,
+      head: 'base123',
+      branch: 'refs/heads/afk/live-session-wt',
+    });
+    const porcelainOut = `${mainBlock}\n\n${wtBlock}\n`;
+
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: porcelainOut, stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' }; // clean
+      }
+      if (args.includes('rev-list') && args.includes('--count')) {
+        return { stdout: '0\n', stderr: '' }; // no commits ahead
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+      readPresence: async () => [{ pid: process.pid, cwd: worktreePath } as unknown as PresenceRecord],
+    });
+
+    const deadOwnerCandidates = result.candidates.filter((c) => c.verdict === 'dead-owner');
+    expect(deadOwnerCandidates).toHaveLength(0);
+    expect(result.removed).not.toContain(worktreePath);
+  });
+
+  it('still reaps when the presence file is stale (its pid is dead)', async () => {
+    const deadPid = findDeadPid();
+    const stalePid = findDeadPid();
+    const worktreePath = join(afkWorktreesDir, 'afk-stale-presence-wt');
+    await fs.mkdir(worktreePath, { recursive: true });
+
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({
+        owner: 'interactive',
+        pid: deadPid,
+        createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+        baseSha: 'base123',
+        baseBranch: 'main',
+      }),
+    );
+
+    const mainBlock = worktreeBlock({ path: repoRoot, head: 'base123' });
+    const wtBlock = worktreeBlock({
+      path: worktreePath,
+      head: 'base123',
+      branch: 'refs/heads/afk/stale-presence-wt',
+    });
+    const porcelainOut = `${mainBlock}\n\n${wtBlock}\n`;
+
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: porcelainOut, stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' }; // clean
+      }
+      if (args.includes('rev-list') && args.includes('--count')) {
+        return { stdout: '0\n', stderr: '' }; // no commits ahead
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+      readPresence: async () => [{ pid: stalePid, cwd: worktreePath } as unknown as PresenceRecord],
+    });
+
+    const deadOwnerCandidates = result.candidates.filter((c) => c.verdict === 'dead-owner');
+    expect(deadOwnerCandidates).toHaveLength(1);
+    expect(result.removed).toContain(worktreePath);
+  });
+
+  it('still reaps when the live session cwd is outside the worktree', async () => {
+    const deadPid = findDeadPid();
+    const worktreePath = join(afkWorktreesDir, 'afk-outside-cwd-wt');
+    await fs.mkdir(worktreePath, { recursive: true });
+
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({
+        owner: 'interactive',
+        pid: deadPid,
+        createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+        baseSha: 'base123',
+        baseBranch: 'main',
+      }),
+    );
+
+    const mainBlock = worktreeBlock({ path: repoRoot, head: 'base123' });
+    const wtBlock = worktreeBlock({
+      path: worktreePath,
+      head: 'base123',
+      branch: 'refs/heads/afk/outside-cwd-wt',
+    });
+    const porcelainOut = `${mainBlock}\n\n${wtBlock}\n`;
+
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: porcelainOut, stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' }; // clean
+      }
+      if (args.includes('rev-list') && args.includes('--count')) {
+        return { stdout: '0\n', stderr: '' }; // no commits ahead
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+      readPresence: async () => [{ pid: process.pid, cwd: join(repoRoot, 'somewhere-else') } as unknown as PresenceRecord],
+    });
+
+    const deadOwnerCandidates = result.candidates.filter((c) => c.verdict === 'dead-owner');
+    expect(deadOwnerCandidates).toHaveLength(1);
+    expect(result.removed).toContain(worktreePath);
   });
 });

--- a/src/agent/worktree-sweep.ts
+++ b/src/agent/worktree-sweep.ts
@@ -7,10 +7,11 @@
  * @module agent/worktree-sweep
  */
 
-import { promises as fs, existsSync, createReadStream } from 'node:fs';
-import { join } from 'node:path';
+import { promises as fs, existsSync, createReadStream, realpathSync } from 'node:fs';
+import { join, relative, isAbsolute } from 'node:path';
 import { createInterface } from 'node:readline';
 import { getWorktreeSweepLockPath, getTelemetryPath } from '../paths.js';
+import { readPresenceFiles, type PresenceRecord } from './awareness/presence.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -116,6 +117,14 @@ export interface SweepOptions {
    * point of running on boot at all.
    */
   bypassSoftLaunch?: boolean;
+  /**
+   * Override the presence reader. Defaults to the real {@link readPresenceFiles}
+   * (scans ~/.afk/state/presence/). Injected by tests for hermeticity and to
+   * assert against a controlled set of live sessions. A worktree hosting a live
+   * session (a presence record whose pid is alive, whose cwd is within the
+   * worktree) is never reaped — even if the creator pid in meta is dead.
+   */
+  readPresence?: () => Promise<PresenceRecord[]>;
 }
 
 export interface SweepCandidateSummary {
@@ -178,6 +187,30 @@ function isProcessAlive(pid: number): boolean {
     if (code === 'EPERM') return true;
     return false;
   }
+}
+
+/**
+ * Resolve a path through symlinks, falling back to the raw path when it can't
+ * be resolved. macOS aliases /var → /private/var, so both the worktree path
+ * and a session cwd must be normalized before any containment check or the
+ * comparison silently fails.
+ */
+function realpathSafe(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+/**
+ * True when `child` is the same path as, or nested inside, `parent`. Both are
+ * realpath-normalized first. Used to decide whether a live session's cwd sits
+ * inside a candidate worktree.
+ */
+function isPathWithin(child: string, parent: string): boolean {
+  const rel = relative(realpathSafe(parent), realpathSafe(child));
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }
 
 // ---------------------------------------------------------------------------
@@ -439,6 +472,28 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
       }
     }
 
+    // Invariant: a worktree hosting a LIVE top-level session must never be
+    // reaped, even when the creator pid in .afk-worktree-meta.json is dead —
+    // the creating process and the session actively working inside are
+    // frequently different (a resumed session, or a hand-recreated worktree).
+    // meta.pid alone misses this and the dead-owner verdict would reap an
+    // in-use worktree. Presence files are the authoritative "someone is working
+    // here now" signal: each live top-level session writes one with its own pid
+    // + cwd. We trust a record only when its pid is actually alive, so a crashed
+    // session's stale file cannot protect a worktree forever.
+    const presenceReader = options.readPresence ?? readPresenceFiles;
+    let liveSessionCwds: string[] = [];
+    try {
+      const presenceRecords = await presenceReader();
+      liveSessionCwds = presenceRecords
+        .filter((r) => typeof r.pid === 'number' && r.pid > 0 && isProcessAlive(r.pid))
+        .map((r) => r.cwd)
+        .filter((cwd): cwd is string => typeof cwd === 'string' && cwd.length > 0);
+    } catch {
+      // Presence is advisory + best-effort: on any read failure, fall back to
+      // the meta.pid liveness check alone (prior behavior).
+    }
+
     // Process registered worktrees (skip main/bare)
     let hasOrphanedRegistrations = false;
     const mainPath = parsed[0]?.path;
@@ -516,6 +571,15 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
         ageMs <= MAX_TRUSTED_PID_AGE_MS
       ) {
         ownerLiveness = isProcessAlive(meta.pid) ? 'alive' : 'dead';
+      }
+
+      // A live session working inside this worktree overrides a dead creator
+      // pid — never reap an actively-used worktree.
+      if (
+        ownerLiveness !== 'alive' &&
+        liveSessionCwds.some((cwd) => isPathWithin(cwd, entry.path))
+      ) {
+        ownerLiveness = 'alive';
       }
 
       const candidate: WorktreeCandidate = {


### PR DESCRIPTION
## Ported from private repo

**Source:** `afk-workshop#757` — https://github.com/griffinwork40/afk-workshop/pull/757

This is a moat-scrubbed port, not a 1:1 copy. The verification pipeline confirmed the change set is entirely public-safe (nothing was dropped — see below).

## What
Makes the worktree sweep skip any worktree that hosts a **live session**, instead of reaping it.

## The bug
The sweep's only liveness check is `isProcessAlive(meta.pid)` (`src/agent/worktree-sweep.ts`), where `meta.pid` is the worktree's **creator** pid — written once at creation and never refreshed. When the live session's pid differs from the creator (a resumed session, or a hand-recreated worktree), the creator pid reads *dead* → the `dead-owner` verdict fires on a clean tree (`!isDirty && commitsAhead === 0`) and `git worktree remove --force`s it.

`dead-owner` is checked **before** the age gates, so even a minutes-old, actively-used worktree is eligible. A read-only / clean session is the worst case — clean tree, 0 commits ahead → it matches the deletion criteria exactly.

## The fix
The presence subsystem (`src/agent/awareness/presence.ts`) already records each live top-level session's `pid` + `cwd` — the sweep just wasn't consulting it. Now, when computing `ownerLiveness`: if a **live** session (presence record whose pid is alive, so a crashed session's stale file can't protect forever) has its `cwd` within a candidate worktree, force `ownerLiveness = 'alive'`, structurally preventing `dead-owner`. The presence pid is the *current* session's, so it is strictly better than the never-refreshed creator pid.

The presence reader is dependency-injected (`SweepOptions.readPresence`, default `readPresenceFiles`) — matching the file's existing DI pattern (`execFile`, `lockPath`, `telemetryPath`) and keeping tests hermetic.

## Ported changes
- `src/agent/worktree-sweep.ts` (+66/−2): presence-reader DI, `realpathSafe`/`isPathWithin` helpers, live-session override of `ownerLiveness`.
- `src/agent/worktree-sweep.test.ts` (+182): 3 regression tests — (1) live session → not reaped; (2) stale presence (dead pid) → still reaped; (3) cwd outside worktree → still reaped.

## Dropped (and why)
**Nothing.** Moat triage classified both files as PUBLIC-SAFE; no moat files or hunks were excluded. The depended-on `awareness/presence.ts` already exists in this repo.

## Verification
- Correctness gate green: `pnpm install --frozen-lockfile`, `pnpm lint` (strict tsc), `pnpm test` (**465 files / 8735 passed, 12 skipped**), `pnpm build`, `pnpm build:dist`.
- Targeted `worktree-sweep.test.ts`: **26/26 pass**.
- Deterministic moat guard over tree + built `dist/`: **MOAT GUARD CLEAN**.
- Independent adversarial moat audit (re-derived from scratch): **CLEAN, high confidence**.

> Do not merge automatically — left for human review.
