### PR TITLE
fix(tui): commit content to scrollback in banner sessions (gap/dup/loss)

### DIFF
--- a/docs/scrollback.md
+++ b/docs/scrollback.md
@@ -340,6 +340,54 @@ only on the live viewport, never on scrollback).
   survivors belong at `[targetBottom - fit + 1, targetBottom]`, always above the
   frame top).
 
+### Banner case: the floor must follow the commit scroll
+
+The full-contiguous-run tracking + merge path above was originally gated on
+`anchorRow <= 1`, so it was **inert for every banner session** — i.e. every
+real interactive REPL, which prints the ASCII banner before arming and so runs
+with `anchorRow > 1`. Two things were wrong:
+
+1. **Stale gate.** The merge soundness check is the equality
+   `committedBandBottomRow === newTopRow - 1`, which is banner-agnostic (the
+   anchor-ceiling evict shifts `committedBandBottomRow` in lockstep with the
+   frame). The extra `anchorRow <= 1` term forced single-block tracking on
+   every banner commit, so a tall overlay collapsing after several commits
+   stranded the older blocks (blank gap), re-pinned only the last block
+   (duplication), and dropped untracked lines (lost commits).
+
+2. **Stale floor.** `commitAbove` Phase 1 scrolls the whole screen up — banner
+   included — but never lowered `anchorRow`. The above-frame room
+   (`frameTop - anchorRow`) therefore never grew, the band could only ever
+   track that fixed number of rows, and committed content piled up orphaned in
+   the now-vacated banner rows where the collapse erase later destroyed it.
+
+3. **Wrap-blind contiguity check.** Once the gate was lifted, the merge's
+   "whole block painted?" test (`newPainted === lineCount`) misfired: `lineCount`
+   is the WRAP-AWARE physical row count (`logUpdate.measure()`), while
+   `newPainted` is derived from the logical-line array `textLines.length`. The
+   two diverge whenever a block has a trailing blank line (`\n\n` → `split`
+   yields a trailing `""`) or a wrapped line — so the check failed on every
+   `\n\n`-terminated commit, re-suppressing the merge and stranding the prior
+   band as a single overwritten block (lost commits). The intent is "no lines
+   dropped to overflow", i.e. `newPainted === textLines.length`.
+
+**The fix** (`terminal-compositor.committed-band.ts`): (a) drop the `anchorRow
+<= 1` gate from both `canUseMergePath` and `contiguousPriorBand`; (b) decrement
+`anchorRow` by the rows Phase 1 scrolled — exactly as the evict path already
+does (`preserveRowsBeforeFrameRender`, `anchorRow -= deficit`), scoped to the
+`fitsAboveFrame` path (the overflow path still floors at the unchanged
+`anchorFloor` to avoid CUP-writing into the still-protected banner zone); and
+(c) compare the contiguity check against `textLines.length`, not the wrap-aware
+`lineCount`. As the banner scrolls into scrollback the floor drops to 1 and the
+path converges to the no-banner case. Phase 3 measures `maxRun` against the
+**post-scroll** floor.
+
+**Regression test.** `src/cli/terminal-compositor.banner-commit-gap.test.ts`
+drives 8–12 commits under a tall overlay with a banner (`anchorRow > 1`) across
+two terminal geometries, then collapses the overlay, and asserts every committed
+line appears in the `@xterm/headless` buffer exactly once and the viewport run is
+contiguous and hugging the frame.
+
 **Regression test.** `src/cli/terminal-compositor.scrollback-gap.test.ts` drives
 7 thought/tool commit pairs under a tall overlay at `extraRows=2`, replays
 through `@xterm/headless`, and asserts every committed line survives exactly once

--- a/src/cli/terminal-compositor.banner-commit-gap.test.ts
+++ b/src/cli/terminal-compositor.banner-commit-gap.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Regression (banner case): the interactive REPL prints an ASCII banner before
+ * arming, so the compositor runs with anchorRow > 1 (hasBanner = true). Every
+ * OTHER gap/scrollback regression test uses anchorRow: 1, so the banner path
+ * was uncovered — and broken: `commitAbove` gated its full-contiguous-run
+ * tracking + merge on `anchorRow <= 1`, and never lowered `anchorRow` when its
+ * Phase-1 scroll pushed the banner into scrollback. The floor went stale, the
+ * band could only ever track `frameTop - anchorRow` rows, committed content
+ * piled up orphaned in the vacated banner rows, and a tall overlay collapsing
+ * after several commits stranded the older blocks (blank gap), re-pinned a
+ * partial band (duplication), and dropped untracked lines that never reached
+ * scrollback (lost commits) — the reported "stuff isn't getting committed to
+ * the scrollback" bug.
+ *
+ * Fix (terminal-compositor.committed-band.ts): drop the `anchorRow <= 1` gate
+ * (the `committedBandBottomRow === newTopRow - 1` equality is the real, banner-
+ * agnostic contiguity guard) and decrement `anchorRow` by the rows Phase 1
+ * scrolls, exactly as the evict path does — so the floor follows the banner
+ * into scrollback and the band tracks the whole visible run.
+ *
+ * Parameterized over two geometries to prove the fix is not tuned to one size.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { StatusLine } from './status-line.js';
+import { LoopStageBar } from './commands/interactive/loop-stage.js';
+
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin = NodeJS.ReadStream & { isTTY: boolean; isRaw: boolean; setRawMode: ReturnType<typeof vi.fn> };
+
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true; s.columns = cols; s.rows = rows; return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true; s.isRaw = false; s.setRawMode = vi.fn((r: boolean) => { s.isRaw = r; return s; }); return s;
+}
+function collect(stream: MockStdout): () => string { const c: string[] = []; stream.on('data', (x) => c.push(String(x))); return () => c.join(''); }
+function termWrite(t: HeadlessTerminal, d: string): Promise<void> { return new Promise((r) => t.write(d, r)); }
+function lines(t: HeadlessTerminal): string[] {
+  const b = t.buffer.active; const o: string[] = [];
+  for (let i = 0; i < b.length; i++) { const l = b.getLine(i); if (l) o.push(l.translateToString(true)); }
+  return o;
+}
+
+const SPINNER_RE = /[\u2800-\u28ff]/;
+const COMMITTED_RE = /TOOL_OUTPUT_\d|memory_search|bash x37|Done \(114/;
+
+function wireFooter(stdout: MockStdout): { statusLine: StatusLine; loopStageBar: LoopStageBar } {
+  const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+  statusLine.start();
+  statusLine.repaint({ model: 'STATUSMODELXYZ', cost: 0, tokens: 0, contextPct: 0 });
+  const loopStageBar = new LoopStageBar({ getExtraRows: () => statusLine.getExtraRows(), stream: stdout });
+  loopStageBar.setRowCountChangeHandler(() => statusLine.setExtraRows(1));
+  statusLine.setAfterScrollRestore(() => loopStageBar.redraw());
+  loopStageBar.start();
+  return { statusLine, loopStageBar };
+}
+
+interface Geometry { name: string; cols: number; rows: number; bannerRows: number; overlayRows: number; commits: number }
+
+const GEOMETRIES: Geometry[] = [
+  { name: '24-row terminal, 8-row banner', cols: 80, rows: 24, bannerRows: 8, overlayRows: 10, commits: 8 },
+  { name: '50-row terminal, 12-row banner (real AFK banner)', cols: 100, rows: 50, bannerRows: 12, overlayRows: 22, commits: 12 },
+];
+
+describe('banner commit→collapse gap (anchorRow > 1, real footer)', () => {
+  for (const g of GEOMETRIES) {
+    it(`does not lose committed content and keeps the viewport run contiguous — ${g.name}`, async () => {
+      const stdout = makeStdout(g.cols, g.rows);
+      const stdin = makeStdin();
+      const all = collect(stdout);
+
+      // Print a banner BEFORE arming, exactly like the interactive surface. The
+      // compositor protects rows 1..anchorRow-1; anchorRow is the first row below.
+      for (let i = 0; i < g.bannerRows; i++) stdout.write(`BANNER_LINE_${i}\n`);
+
+      const { statusLine, loopStageBar } = wireFooter(stdout);
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: g.bannerRows + 1 });
+      await c.arm();
+      const internals = c as unknown as { repaint(): void };
+
+      // Subagent run: a tall overlay is up while tool outputs commit one by one,
+      // then a multi-line rollup commits and the overlay collapses to idle.
+      const committedBlocks: string[] = [];
+      c.setSpinner({ enabled: true });
+      for (let k = 0; k < g.commits; k++) {
+        c.setOverlay(Array.from({ length: g.overlayRows }, (_, i) => `stream ${k}.${i}`).join('\n'));
+        const block = `TOOL_OUTPUT_${k}`;
+        committedBlocks.push(block);
+        c.commitAbove(`${block}\n`);
+      }
+      for (const line of ['memory_search — done', 'bash x37 — done', 'Done (114 tools)']) committedBlocks.push(line);
+      c.commitAbove('memory_search — done\nbash x37 — done\nDone (114 tools)\n');
+      c.setOverlay('');
+      internals.repaint();
+      internals.repaint();
+
+      const term = new HeadlessTerminal({ cols: g.cols, rows: g.rows, scrollback: 800, allowProposedApi: true, convertEol: true });
+      await termWrite(term, all());
+      const ls = lines(term);
+      const fullDump = ls.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l)}`).join('\n');
+
+      // Exact whole-line match: substring matching would conflate "TOOL_OUTPUT_1"
+      // with "TOOL_OUTPUT_10"/"_11". translateToString(true) right-trims, and the
+      // committed lines are written left-aligned, so a trimmed === is exact.
+      const occurrences = (block: string): number => ls.filter((l) => l.trim() === block).length;
+      // (1) DURABILITY: every committed block survives EXACTLY once in the buffer
+      // (scrollback + viewport). Zero = the "not committed to scrollback" bug.
+      // (2) NO DUPLICATES: more than one = the garbled/doubled-row symptom. The
+      // single-copy invariant means exactly one copy reaches the terminal.
+      for (const block of committedBlocks) {
+        const count = occurrences(block);
+        expect(count, `committed block "${block}" should appear EXACTLY once, saw ${count}×:\n${fullDump}`).toBe(1);
+      }
+
+      // (3) CONTIGUITY: the committed lines visible in the viewport hug the
+      // frame with no massive blank gap between them and the live frame.
+      const vStart = Math.max(0, ls.length - g.rows);
+      const view = ls.slice(vStart);
+      const dump = view.map((l, i) => `[${String(vStart + i).padStart(2)}] ${JSON.stringify(l)}`).join('\n');
+      const frameIdx = view.findIndex((l) => SPINNER_RE.test(l));
+      expect(frameIdx, `frame (spinner) not found in viewport:\n${dump}`).toBeGreaterThanOrEqual(0);
+      const committedIdxs = view
+        .map((l, i) => (COMMITTED_RE.test(l) ? i : -1))
+        .filter((i) => i >= 0);
+      expect(committedIdxs.length, `no committed lines in viewport:\n${dump}`).toBeGreaterThan(0);
+      const min = committedIdxs[0]!;
+      const max = committedIdxs[committedIdxs.length - 1]!;
+      expect(
+        max - min + 1,
+        `committed lines NOT contiguous (gap bug): span=${max - min + 1}, count=${committedIdxs.length}:\n${dump}`,
+      ).toBe(committedIdxs.length);
+      expect(frameIdx - max, `committed run does not hug the frame (bottom=${max}, frame=${frameIdx}):\n${dump}`).toBe(1);
+      // The most-recent committed line is the rollup tail, adjacent to the frame.
+      expect(view[max], `rollup tail not adjacent to frame:\n${dump}`).toContain('Done (114 tools)');
+      // Footer status row remains single (no double-statusline under the heavy scenario).
+      expect(ls.filter((l) => l.includes('STATUSMODELXYZ')).length, `status row not single:\n${fullDump}`).toBe(1);
+
+      term.dispose(); loopStageBar.stop(); statusLine.stop(); c.disarm();
+    }, 15_000);
+  }
+});

--- a/src/cli/terminal-compositor.committed-band.ts
+++ b/src/cli/terminal-compositor.committed-band.ts
@@ -158,6 +158,10 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   // that is already ending; the next commit re-arms it. No try/finally needed.
   self.commitInFlight = true;
   self.committing = true;
+  // Rows Phase 1 scrolls into scrollback this commit (set inside the guard).
+  // The whole screen — banner included — scrolls up by this many rows, so the
+  // anchor floor must drop to match (see the decrement after the finally).
+  let scrolledRows = 0;
   try {
     self.logUpdate.clear(extraRows);
     writeWithGuard(() => {
@@ -221,7 +225,7 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
       // behavior), which scrolls the old band rows into scrollback before
       // Phase 3 paints over them. Also safe when committedBand is empty
       // (nothing to lose) regardless of anchorRow.
-      const canUseMergePath = fitsAboveFrame && (self.anchorRow ?? 1) <= 1;
+      const canUseMergePath = fitsAboveFrame;
       const effectiveFrameTop =
         canUseMergePath && self.committedBand.length > 0 && self.committedBandBottomRow > 0
           ? Math.max(frameTop, self.committedBandBottomRow + 1)
@@ -232,6 +236,11 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
       const bandOverflow = canUseMergePath
         ? Math.max(0, self.committedBand.length + lineCount - aboveFrameRoom)
         : lineCount;
+      // Record the rows the fitsAboveFrame path scrolls so the anchor floor can
+      // follow (see the decrement after the finally). Scoped to fitsAboveFrame:
+      // the overflow path archives the whole block to scrollback and floors
+      // Phase 3 at the unchanged anchorFloor to avoid clobbering the banner.
+      scrolledRows = fitsAboveFrame ? bandOverflow : 0;
       self.debugLog('commitAbove:phase1', { lineCount, fitsAboveFrame, bandOverflow });
       if (fitsAboveFrame) {
         if (bandOverflow > 0) {
@@ -253,6 +262,17 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   } finally {
     self.committing = false;
     self.debugLog('commitAbove:finally');
+  }
+  // Invariant (floor follows the scroll): Phase 1 scrolled `scrolledRows` rows
+  // off the top of the screen. The banner occupying rows [1, anchorRow-1]
+  // scrolled up with everything else, so the protected ceiling shrinks by the
+  // same amount — exactly as the evict path in preserveRowsBeforeFrameRender
+  // does (anchorRow -= deficit). Without this the floor goes stale, the
+  // above-frame room never grows, committed content orphans in the vacated
+  // banner rows, and a later overlay collapse loses it. Clamp at 1; once the
+  // banner is fully in scrollback the path matches the no-banner case.
+  if (scrolledRows > 0 && self.anchorRow !== undefined && self.anchorRow > 1) {
+    self.anchorRow = Math.max(1, self.anchorRow - scrolledRows);
   }
   // Mark that a commit has happened this arm cycle so growthDeficit in
   // repaint() knows there is transcript content above the frame to protect.
@@ -308,7 +328,12 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     // ceiling evict could have shifted the tracked bottom). Otherwise (frame
     // resized between commits, anchor-ceiling evict, or the overflow
     // !fitsAboveFrame path) fall back to single-block tracking.
-    const maxRun = Math.max(0, newTopRow - anchorFloor);
+    // Measure room against the POST-scroll floor: the anchorRow decrement above
+    // lowered the ceiling by `scrolledRows`, so the newly-vacated banner rows
+    // are now legitimately available to the band. Using the stale pre-scroll
+    // anchorFloor would keep maxRun pinned and re-trigger the cap-to-one-row bug.
+    const postScrollFloor = Math.max(self.anchorRow ?? 1, 1);
+    const maxRun = Math.max(0, newTopRow - postScrollFloor);
     const newPainted = Math.min(textLines.length, maxRun);
     if (newPainted > 0) {
       // Tail-slice (not head): when the block is taller than the above-frame
@@ -318,10 +343,19 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
       // bottom left boxes rendered un-closed. In the fits path newPainted ===
       // lineCount, so this is the whole array (no behavior change there).
       const newLines = textLines.slice(textLines.length - newPainted);
+      // "Whole block painted" = newPainted === textLines.length (no lines
+      // dropped to overflow). Compare against textLines.length, NOT lineCount:
+      // lineCount is the WRAP-AWARE physical row count (measure()), which
+      // diverges from the logical-line array length whenever a block has a
+      // trailing blank line (`\n\n` → split yields a trailing "") or a wrapped
+      // line. Using lineCount here wrongly failed the contiguity check on every
+      // `\n\n`-terminated commit, suppressing the merge and stranding the prior
+      // band as a single overwritten block (lost commits) — the splice
+      // regression. newPainted is itself derived from textLines.length.
+      const wholeBlockPainted = newPainted === textLines.length;
       const contiguousPriorBand =
         fitsAboveFrame &&
-        newPainted === lineCount &&
-        (self.anchorRow ?? 1) <= 1 &&
+        wholeBlockPainted &&
         self.committedBand.length > 0 &&
         self.committedBandBottomRow === newTopRow - 1;
       const run = contiguousPriorBand ? [...self.committedBand, ...newLines] : newLines;

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -1157,12 +1157,13 @@ describe('TerminalCompositor', () => {
       // banner rows either.
       //
       // With anchorRow=10, a 1-line commit, and rows=24 (idle 1-line frame):
-      //   fitsAboveFrame = true → Phase 1 scroll-only at row 24
+      //   fitsAboveFrame = true, empty band, 13 rows of above-frame room →
+      //     bandOverflow = max(0, 0 + 1 - 13) = 0 → Phase 1 emits NO scroll
       //   Phase 2 repaint → topRow=23
       //   Phase 3 textStartRow = max(10, 23-1) = 22 → text at row 22
       //
-      // The bottom-margin scroll (Phase 1) fires, and text appears at row 22
-      // (inside the frame zone, NOT in the banner zone rows 1..9).
+      // The committed line appears at row 22 (inside the frame zone, NOT the
+      // banner zone rows 1..9) and is NOT written into the banner.
       stdout.rows = 24;
       const c = new TerminalCompositor({
         stdout, stdin, onCancel: vi.fn(), promptText: '> ',
@@ -1181,9 +1182,13 @@ describe('TerminalCompositor', () => {
       expect(out).not.toContain(`\x1b[1;1H${paddedEcho}`);
       // Phase 3 writes the single copy above the live frame (row 22).
       expect(out).toContain(`\x1b[22;1H\x1b[2K${paddedEcho}`);
-      // The bottom-margin scroll still fires — Phase 1's scrollback push
-      // is preserved via LF-only scrolls.
-      expect(out).toContain('\x1b[24;1H\n');
+      // The FIRST commit into an empty band with ample above-frame room is
+      // scroll-free (bandOverflow=0) — identical to the no-anchor single-copy
+      // path. The banner no longer forces a spurious lineCount scroll on every
+      // commit; that quirk left the floor stale and orphaned committed content
+      // in the vacated banner rows — see terminal-compositor.banner-commit-gap.test.ts.
+      // The single copy enters scrollback later via evict-on-growth / the next commit.
+      expect(out).not.toMatch(/\x1b\[24;1H\n/);
     });
 
     it('commitAbove Phase 3 always lands at row newTopRow-1 regardless of anchorRow (single-copy path)', async () => {


### PR DESCRIPTION
**Source:** [afk-workshop#758](https://github.com/griffinwork40/afk-workshop/pull/758) — moat-scrubbed, **re-derived** port (not a 1:1 copy; see below).

## Problem
In interactive sessions, committed output (tool results, finalized text) **was not reliably committed to scrollback**. After a tall overlay (streaming + several tool commits) collapsed to idle, the viewport showed a **large blank gap**, **duplicated rows**, and **lost commits**. Reproduces on `main` — see the new test.

## Root cause
The REPL prints the ASCII banner before arming the compositor, so production always runs with `anchorRow > 1` (`hasBanner`). The banner path was uncovered and broken in `commitAbove`:
1. **Stale gate** — full-contiguous-run tracking + merge were gated on `(anchorRow ?? 1) <= 1`, inert for every real session → band tracked only the last block → collapse stranded older blocks (gap) and re-pinned a partial band (duplication).
2. **Stale floor** — Phase 1 scrolls the whole screen (banner included) into scrollback but never lowered `anchorRow`; the above-frame room never grew, so content orphaned in the vacated banner rows where the collapse erase destroyed it (lost commits).
3. **Wrap-blind contiguity check** *(public-specific)* — once the gate was lifted, `newPainted === lineCount` misfired because `lineCount` is the wrap-aware physical count (`measure()`) while `newPainted` derives from `textLines.length`; they diverge on `\n\n`-terminated commits, re-suppressing the merge.

## Fix (`terminal-compositor.committed-band.ts`)
- Drop the `anchorRow <= 1` gate from `canUseMergePath` and `contiguousPriorBand` (the `committedBandBottomRow === newTopRow-1` equality is the real, banner-agnostic guard).
- Decrement `anchorRow` by the rows Phase 1 scrolled (**`fitsAboveFrame` path only**), so the floor follows the banner into scrollback; Phase 3 measures `maxRun` against the post-scroll floor.
- Compare the contiguity check against `textLines.length`, not the wrap-aware `lineCount`.

## Adapted for public (why this is not a 1:1 port)
Public's `committed-band.ts` has **diverged** from the private source — it carries a `coveredBand` park/promote mechanism, a wrap-aware `lineCount` (`measure()`-based), and a "cut-off bottom" tail-slice in the overflow path that the private version lacks. The fix was **re-derived against public's version**: the overflow branch and `coveredBand` logic are **kept unchanged**, and item (3) above is a public-only addition the private PR did not need. No private-source logic was force-ported.

## Dropped
Nothing. The change touches only core TUI files; no moat content was present to scrub.

## Verification
- New `terminal-compositor.banner-commit-gap.test.ts` (2 geometries: 24-row/8-line banner, 50-row/12-line banner) — fails on `main`, passes after; asserts every committed line appears exactly once and the viewport run is contiguous hugging the frame.
- Full suite: **8734 passed, 0 failed, 12 skipped** (`env -u AFK_INTERNAL pnpm test`). `pnpm lint` clean. `pnpm build` + `pnpm build:dist` clean.
- Moat: deterministic guard **CLEAN** (tree + built `dist/`); independent adversarial audit **CLEAN**.

**Do not merge automatically — for human review.**