### PR TITLE
fix(marketplace): align REPL slash verbs with CLI (install / install-plugin)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -153,7 +153,7 @@ Plugin state (telemetry, ledger, briefs) writes to `~/.afk/agent-framework/` in 
 ### Marketplaces
 
 ```bash
-afk marketplace add <url>
+afk marketplace install <url>
 afk marketplace list
 afk marketplace remove <name>
 ```

--- a/src/agent/plugins-scanner.ts
+++ b/src/agent/plugins-scanner.ts
@@ -1,7 +1,7 @@
 /**
  * Local plugin discovery for AFK sessions.
  *
- * Marketplace-based install paths (`/plugin marketplace add …`) still hardcode
+ * Marketplace-based install paths (`/marketplace install …`) still hardcode
  * to `~/.claude/plugins/` upstream (anthropics/claude-code#15071), so AFK
  * cannot rely on Claude Code to populate its own plugin home. Instead, AFK
  * scans `~/.afk/plugins/` at session construction and passes every discovered

--- a/src/cli/slash/marketplace-browse.test.ts
+++ b/src/cli/slash/marketplace-browse.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Tests for the `/marketplace` slash command verb-alignment fix.
+ *
+ * Covers:
+ *   - New canonical `install` (marketplace) routing — 1 bare arg.
+ *   - New canonical `install-plugin` routing.
+ *   - Legacy `add` (deprecated alias) — warns, still installs marketplace.
+ *   - Legacy 2-arg `install` — warns, still installs plugin.
+ *   - Legacy colon-form `install` — warns, still installs plugin.
+ *   - Unknown-subcommand error path.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SlashContext, Writer } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Mock all external dependencies before importing the module under test.
+// ---------------------------------------------------------------------------
+
+vi.mock('../../agent/marketplaces/install.js', () => ({
+  installMarketplace: vi.fn(),
+}));
+
+vi.mock('../../agent/marketplaces/resolve.js', () => ({
+  installFromMarketplace: vi.fn(),
+  listMarketplacePlugins: vi.fn(),
+}));
+
+vi.mock('../../agent/marketplaces/remove.js', () => ({
+  removeMarketplace: vi.fn(),
+}));
+
+vi.mock('../../agent/marketplaces/update.js', () => ({
+  updateMarketplace: vi.fn(),
+}));
+
+vi.mock('../../agent/plugins/index-store.js', () => ({
+  readIndex: vi.fn().mockReturnValue({ marketplaces: {} }),
+}));
+
+vi.mock('./registry.js', () => ({
+  register: vi.fn(),
+}));
+
+import { installMarketplace } from '../../agent/marketplaces/install.js';
+import { installFromMarketplace } from '../../agent/marketplaces/resolve.js';
+import { registerMarketplaceCommands } from './marketplace-browse.js';
+import { register } from './registry.js';
+import type { SlashCommand } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeWriter(): Writer & { calls: Record<keyof Writer, string[]> } {
+  const calls: Record<keyof Writer, string[]> = {
+    line: [],
+    raw: [],
+    success: [],
+    info: [],
+    warn: [],
+    error: [],
+  };
+  return {
+    calls,
+    line: vi.fn((t?: string) => { calls.line.push(t ?? ''); }) as Writer['line'],
+    raw: vi.fn((t: string) => { calls.raw.push(t); }) as Writer['raw'],
+    success: vi.fn((t: string) => { calls.success.push(t); }) as Writer['success'],
+    info: vi.fn((t: string) => { calls.info.push(t); }) as Writer['info'],
+    warn: vi.fn((t: string) => { calls.warn.push(t); }) as Writer['warn'],
+    error: vi.fn((t: string) => { calls.error.push(t); }) as Writer['error'],
+  };
+}
+
+function makeCtx(out: Writer): SlashContext {
+  return {
+    out,
+    session: {} as SlashContext['session'],
+    stats: {
+      totalTurns: 0, totalCostUsd: 0, totalTokens: 0, totalDurationMs: 0,
+      sessionStartTime: 0, turnCosts: [], turnTokens: [], turns: [],
+      model: 'sonnet', planMode: false,
+    },
+    ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
+  };
+}
+
+/** Retrieve the `/marketplace` SlashCommand captured by the register mock. */
+function getMarketplaceCmd(): SlashCommand {
+  const registerMock = vi.mocked(register);
+  const calls = registerMock.mock.calls;
+  const cmd = calls.find(([c]) => c.name === '/marketplace')?.[0];
+  if (!cmd) throw new Error('Expected /marketplace to have been registered');
+  return cmd;
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Default happy-path stubs.
+  vi.mocked(installMarketplace).mockResolvedValue({
+    name: 'my-mp',
+    dir: '/path/my-mp',
+    plugins: ['plugA', 'plugB'],
+    entry: { source: 'https://example.com', sourceType: 'git', ref: 'main' },
+  } as unknown as Awaited<ReturnType<typeof installMarketplace>>);
+
+  vi.mocked(installFromMarketplace).mockResolvedValue({
+    key: 'my-mp:plugA',
+    dir: '/path/my-mp/plugA',
+  } as unknown as Awaited<ReturnType<typeof installFromMarketplace>>);
+
+  registerMarketplaceCommands();
+});
+
+// ---------------------------------------------------------------------------
+// Canonical: install (marketplace)
+// ---------------------------------------------------------------------------
+
+describe('/marketplace install <source> — canonical marketplace install', () => {
+  it('calls installMarketplace with the source', async () => {
+    const out = makeWriter();
+    const ctx = makeCtx(out);
+    const cmd = getMarketplaceCmd();
+
+    await cmd.handler(ctx, 'install https://example.com/my-mp');
+
+    expect(vi.mocked(installMarketplace)).toHaveBeenCalledWith(
+      'https://example.com/my-mp',
+      expect.objectContaining({}),
+    );
+    expect(vi.mocked(installFromMarketplace)).not.toHaveBeenCalled();
+  });
+
+  it('emits success message and next-step hint', async () => {
+    const out = makeWriter();
+    const cmd = getMarketplaceCmd();
+
+    await cmd.handler(makeCtx(out), 'install my-org/my-mp');
+
+    expect(out.calls.success.some(s => s.includes('my-mp'))).toBe(true);
+    expect(out.calls.line.some(l => l.includes('/marketplace plugins'))).toBe(true);
+  });
+
+  it('does NOT emit a deprecation warning', async () => {
+    const out = makeWriter();
+    await getMarketplaceCmd().handler(makeCtx(out), 'install my-org/my-mp');
+    expect(out.calls.warn).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Canonical: install-plugin
+// ---------------------------------------------------------------------------
+
+describe('/marketplace install-plugin — canonical plugin install', () => {
+  it('calls installFromMarketplace with marketplace and plugin', async () => {
+    const out = makeWriter();
+    const cmd = getMarketplaceCmd();
+
+    await cmd.handler(makeCtx(out), 'install-plugin my-mp plugA');
+
+    expect(vi.mocked(installFromMarketplace)).toHaveBeenCalledWith('my-mp', 'plugA');
+    expect(vi.mocked(installMarketplace)).not.toHaveBeenCalled();
+  });
+
+  it('emits success and /reload-plugins hint', async () => {
+    const out = makeWriter();
+    await getMarketplaceCmd().handler(makeCtx(out), 'install-plugin my-mp plugA');
+
+    expect(out.calls.success.some(s => s.includes('my-mp:plugA'))).toBe(true);
+    expect(out.calls.line.some(l => l.includes('/reload-plugins'))).toBe(true);
+  });
+
+  it('does NOT emit a deprecation warning', async () => {
+    const out = makeWriter();
+    await getMarketplaceCmd().handler(makeCtx(out), 'install-plugin my-mp plugA');
+    expect(out.calls.warn).toHaveLength(0);
+  });
+
+  it('shows usage error when marketplace or plugin is missing', async () => {
+    const out = makeWriter();
+    await getMarketplaceCmd().handler(makeCtx(out), 'install-plugin my-mp');
+    expect(out.calls.error.some(e => e.includes('install-plugin'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy: add (deprecated alias for marketplace install)
+// ---------------------------------------------------------------------------
+
+describe('/marketplace add — deprecated alias, still installs marketplace', () => {
+  it('warns about deprecation and points to `install`', async () => {
+    const out = makeWriter();
+    await getMarketplaceCmd().handler(makeCtx(out), 'add https://example.com/my-mp');
+
+    expect(out.calls.warn.some(w => w.includes('install'))).toBe(true);
+    expect(out.calls.warn.length).toBeGreaterThan(0);
+  });
+
+  it('still calls installMarketplace (same effect as install)', async () => {
+    const out = makeWriter();
+    await getMarketplaceCmd().handler(makeCtx(out), 'add https://example.com/my-mp');
+
+    expect(vi.mocked(installMarketplace)).toHaveBeenCalledWith(
+      'https://example.com/my-mp',
+      expect.objectContaining({}),
+    );
+  });
+
+  it('does NOT call installFromMarketplace', async () => {
+    const out = makeWriter();
+    await getMarketplaceCmd().handler(makeCtx(out), 'add https://example.com/my-mp');
+    expect(vi.mocked(installFromMarketplace)).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy: install <mp> <plugin> (2-arg form) — warns, still installs plugin
+// ---------------------------------------------------------------------------
+
+describe('/marketplace install <mp> <plugin> (2 args) — legacy plugin install with warning', () => {
+  it('warns about deprecation and points to `install-plugin`', async () => {
+    const out = makeWriter();
+    await getMarketplaceCmd().handler(makeCtx(out), 'install my-mp plugA');
+
+    expect(out.calls.warn.some(w => w.includes('install-plugin'))).toBe(true);
+  });
+
+  it('still calls installFromMarketplace with the correct args', async () => {
+    const out = makeWriter();
+    await getMarketplaceCmd().handler(makeCtx(out), 'install my-mp plugA');
+
+    expect(vi.mocked(installFromMarketplace)).toHaveBeenCalledWith('my-mp', 'plugA');
+    expect(vi.mocked(installMarketplace)).not.toHaveBeenCalled();
+  });
+
+  it('emits the /reload-plugins hint', async () => {
+    const out = makeWriter();
+    await getMarketplaceCmd().handler(makeCtx(out), 'install my-mp plugA');
+    expect(out.calls.line.some(l => l.includes('/reload-plugins'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy: install <mp>:<plugin> (colon form) — warns, still installs plugin
+// ---------------------------------------------------------------------------
+
+describe('/marketplace install <mp>:<plugin> (colon form) — legacy plugin install with warning', () => {
+  it('warns about deprecation', async () => {
+    const out = makeWriter();
+    await getMarketplaceCmd().handler(makeCtx(out), 'install my-mp:plugA');
+
+    expect(out.calls.warn.some(w => w.includes('install-plugin'))).toBe(true);
+  });
+
+  it('still calls installFromMarketplace correctly', async () => {
+    const out = makeWriter();
+    await getMarketplaceCmd().handler(makeCtx(out), 'install my-mp:plugA');
+
+    expect(vi.mocked(installFromMarketplace)).toHaveBeenCalledWith('my-mp', 'plugA');
+    expect(vi.mocked(installMarketplace)).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown subcommand
+// ---------------------------------------------------------------------------
+
+describe('/marketplace unknown-sub — error path', () => {
+  it('emits an error listing valid subcommands', async () => {
+    const out = makeWriter();
+    await getMarketplaceCmd().handler(makeCtx(out), 'frobnicate');
+
+    expect(out.calls.error.some(e => e.includes('frobnicate'))).toBe(true);
+  });
+
+  it('does not call installMarketplace or installFromMarketplace', async () => {
+    const out = makeWriter();
+    await getMarketplaceCmd().handler(makeCtx(out), 'frobnicate');
+
+    expect(vi.mocked(installMarketplace)).not.toHaveBeenCalled();
+    expect(vi.mocked(installFromMarketplace)).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/slash/marketplace-browse.ts
+++ b/src/cli/slash/marketplace-browse.ts
@@ -3,9 +3,26 @@
  *
  * Two commands registered:
  *   - `/marketplaces` — list installed marketplaces.
- *   - `/marketplace <subcommand>` — `add`, `plugins`, `install`, `remove`,
- *     `update`. Sub-dispatched on the first whitespace-delimited arg, with
- *     a `/help`-style usage hint when called bare.
+ *   - `/marketplace <subcommand>` — `install`, `install-plugin`, `plugins`,
+ *     `remove`, `update`, `list`. Sub-dispatched on the first
+ *     whitespace-delimited arg, with a `/help`-style usage hint when called
+ *     bare.
+ *
+ * Verb alignment with the CLI (`afk marketplace …`):
+ *   - `/marketplace install <source> [name]`        → install a marketplace
+ *   - `/marketplace install-plugin <mp> <plugin>`   → install a plugin from one
+ *   - `/marketplace list`                           → alias for /marketplaces
+ *
+ * Backward compatibility (deprecated aliases, emit a one-line warning):
+ *   - `/marketplace add <source>`                   → routes to install (warns)
+ *   - `/marketplace install <mp> <plugin>` (2 args) → routes to install-plugin (warns)
+ *   - `/marketplace install <mp>:<plugin>` (colon)  → routes to install-plugin (warns)
+ *
+ * Disambiguation for `/marketplace install`:
+ *   - 1 bare arg (no colon) → new canonical: install a marketplace.
+ *   - 2 args OR single arg with colon → legacy: install a plugin (warn → install-plugin).
+ *   This is safe because the 2-arg form was previously the only accepted form
+ *   and a single arg with no colon was a usage error.
  *
  * After installing a plugin from a marketplace, the user must run
  * `/reload-plugins` (in plugin-skills.ts) to refresh the active session's
@@ -29,7 +46,7 @@ import { readIndex } from '../../agent/plugins/index-store.js';
 import { register } from './registry.js';
 import type { SlashCommand, SlashContext, SlashResult } from './types.js';
 
-const SUBCOMMANDS = ['add', 'plugins', 'install', 'remove', 'update'] as const;
+const SUBCOMMANDS = ['install', 'install-plugin', 'plugins', 'remove', 'update', 'list', 'add'] as const;
 
 const marketplacesCmd: SlashCommand = {
   name: '/marketplaces',
@@ -42,8 +59,8 @@ const marketplacesCmd: SlashCommand = {
 
 const marketplaceCmd: SlashCommand = {
   name: '/marketplace',
-  summary: 'Manage plugin marketplaces (add | plugins | install | remove | update)',
-  usage: '/marketplace <add|plugins|install|remove|update> [args]',
+  summary: 'Manage plugin marketplaces (install | install-plugin | plugins | remove | update)',
+  usage: '/marketplace <install|install-plugin|plugins|remove|update|list> [args]',
   async handler(ctx, args) {
     const trimmed = args.trim();
     if (!trimmed) {
@@ -52,20 +69,25 @@ const marketplaceCmd: SlashCommand = {
     }
     const [sub, ...rest] = trimmed.split(/\s+/);
     if (!sub || !(SUBCOMMANDS as readonly string[]).includes(sub)) {
-      ctx.out.error(`Unknown subcommand "${sub ?? ''}". Try one of: ${SUBCOMMANDS.join(', ')}.`);
+      ctx.out.error(`Unknown subcommand "${sub ?? ''}". Try one of: install, install-plugin, plugins, remove, update.`);
       return 'continue';
     }
     switch (sub) {
-      case 'add':
-        return handleAdd(ctx, rest);
-      case 'plugins':
-        return handlePlugins(ctx, rest);
       case 'install':
         return handleInstall(ctx, rest);
+      case 'install-plugin':
+        return handleInstallPlugin(ctx, rest);
+      case 'plugins':
+        return handlePlugins(ctx, rest);
       case 'remove':
         return handleRemove(ctx, rest);
       case 'update':
         return handleUpdate(ctx, rest);
+      case 'list':
+        renderList(ctx);
+        return 'continue';
+      case 'add':
+        return handleAddDeprecated(ctx, rest);
       default:
         return 'continue';
     }
@@ -84,7 +106,7 @@ function renderList(ctx: SlashContext): void {
   if (entries.length === 0) {
     ctx.out.line(palette.dim('  No marketplaces installed.'));
     ctx.out.line(
-      palette.dim('  Try: /marketplace add anthropics/claude-plugins-official'),
+      palette.dim('  Try: /marketplace install anthropics/claude-plugins-official'),
     );
     ctx.out.line();
     return;
@@ -102,22 +124,24 @@ function renderList(ctx: SlashContext): void {
 function printUsage(ctx: SlashContext): void {
   ctx.out.line();
   ctx.out.line(palette.bold('/marketplace usage:'));
-  ctx.out.line(`  ${palette.brand('/marketplace add')} <git-url|owner/repo|local-path>`);
+  ctx.out.line(`  ${palette.brand('/marketplace install')} <git-url|owner/repo|local-path> [name]`);
+  ctx.out.line(`  ${palette.brand('/marketplace install-plugin')} <marketplace> <plugin>`);
   ctx.out.line(`  ${palette.brand('/marketplace plugins')} <marketplace>`);
-  ctx.out.line(`  ${palette.brand('/marketplace install')} <marketplace> <plugin>`);
   ctx.out.line(`  ${palette.brand('/marketplace remove')} <marketplace>`);
   ctx.out.line(`  ${palette.brand('/marketplace update')} [<marketplace>]`);
+  ctx.out.line(`  ${palette.brand('/marketplace list')}`);
   ctx.out.line();
 }
 
-async function handleAdd(ctx: SlashContext, rest: string[]): Promise<SlashResult> {
+/** Canonical: install a marketplace from a source URL / owner/repo / local path. */
+async function handleMarketplaceInstall(ctx: SlashContext, rest: string[]): Promise<SlashResult> {
   if (rest.length === 0) {
-    ctx.out.error('Usage: /marketplace add <source> [name]');
+    ctx.out.error('Usage: /marketplace install <source> [name]');
     return 'continue';
   }
   const [source, name, ...flagsRaw] = rest;
   if (!source) {
-    ctx.out.error('Usage: /marketplace add <source> [name]');
+    ctx.out.error('Usage: /marketplace install <source> [name]');
     return 'continue';
   }
   const opts = parseFlags(flagsRaw);
@@ -139,6 +163,95 @@ async function handleAdd(ctx: SlashContext, rest: string[]): Promise<SlashResult
     ctx.out.error(`Install failed: ${errorMsg(err)}`);
   }
   return 'continue';
+}
+
+/**
+ * Dispatch for `/marketplace install`:
+ * - 1 bare arg (no colon, or colon that looks like a URL scheme) → canonical marketplace install.
+ * - 2 args OR single `<mp>:<plugin>` colon form (not a URL scheme) → legacy plugin install (warn).
+ *
+ * // Invariant: A colon in a single arg is the legacy plugin-colon form ONLY when
+ * // it does not follow a known URL scheme prefix (https, http, git, ssh, file).
+ * // This lets `install https://example.com/my-mp` route to marketplace install
+ * // while `install my-mp:plugA` still routes to the legacy warn path.
+ */
+async function handleInstall(ctx: SlashContext, rest: string[]): Promise<SlashResult> {
+  // Colon form: `<mp>:<plugin>` — legacy plugin install.
+  // Exclude URL-scheme colons (https://, http://, git://, ssh://, file://).
+  if (rest.length === 1 && isColonPluginForm(rest[0])) {
+    return handleLegacyInstallPlugin(ctx, rest);
+  }
+  // Two positional args: `<mp> <plugin>` — legacy plugin install.
+  if (rest.length >= 2) {
+    return handleLegacyInstallPlugin(ctx, rest);
+  }
+  // Single bare arg (or URL): canonical marketplace install.
+  return handleMarketplaceInstall(ctx, rest);
+}
+
+/**
+ * Returns true when a single arg looks like the legacy `<marketplace>:<plugin>` colon
+ * form — i.e. contains a colon that is NOT a URL-scheme separator (https:, http:, etc.).
+ */
+function isColonPluginForm(arg: string | undefined): arg is string {
+  if (!arg || !arg.includes(':')) return false;
+  // URL schemes are word-only characters before the colon followed by `//`.
+  // If the arg matches a URL scheme pattern, it is a source URL, not mp:plugin.
+  return !/^[a-zA-Z][a-zA-Z0-9+\-.]*:\/\//.test(arg);
+}
+
+/**
+ * Legacy: `/marketplace install <mp> <plugin>` or `/marketplace install <mp>:<plugin>`.
+ * Emits a deprecation warning then routes to the plugin installer.
+ */
+async function handleLegacyInstallPlugin(ctx: SlashContext, rest: string[]): Promise<SlashResult> {
+  ctx.out.warn(
+    'Deprecated: use `/marketplace install-plugin <marketplace> <plugin>` instead.',
+  );
+  return doInstallPlugin(ctx, rest);
+}
+
+/** Canonical: `/marketplace install-plugin <marketplace> <plugin>`. */
+async function handleInstallPlugin(ctx: SlashContext, rest: string[]): Promise<SlashResult> {
+  return doInstallPlugin(ctx, rest);
+}
+
+/** Shared implementation for both the canonical and legacy plugin-install paths. */
+async function doInstallPlugin(ctx: SlashContext, rest: string[]): Promise<SlashResult> {
+  let marketplace: string | undefined;
+  let plugin: string | undefined;
+  // Accept either `<mp> <plugin>` or `<mp>:<plugin>`.
+  if (rest.length === 1 && rest[0]?.includes(':')) {
+    const parts = rest[0].split(':');
+    if (parts.length === 2) {
+      [marketplace, plugin] = parts;
+    }
+  } else {
+    [marketplace, plugin] = rest;
+  }
+  if (!marketplace || !plugin) {
+    ctx.out.error('Usage: /marketplace install-plugin <marketplace> <plugin>');
+    return 'continue';
+  }
+  ctx.out.info(`Installing ${marketplace}:${plugin}…`);
+  try {
+    const result = await installFromMarketplace(marketplace, plugin);
+    ctx.out.success(`Installed ${result.key}.`);
+    ctx.out.line(
+      palette.dim('  Run /reload-plugins to refresh this session\'s slash commands.'),
+    );
+  } catch (err) {
+    ctx.out.error(`Install failed: ${errorMsg(err)}`);
+  }
+  return 'continue';
+}
+
+/** Deprecated: `/marketplace add <source>` — routes to canonical marketplace install. */
+async function handleAddDeprecated(ctx: SlashContext, rest: string[]): Promise<SlashResult> {
+  ctx.out.warn(
+    'Deprecated: use `/marketplace install <source>` instead.',
+  );
+  return handleMarketplaceInstall(ctx, rest);
 }
 
 function handlePlugins(ctx: SlashContext, rest: string[]): SlashResult {
@@ -164,39 +277,10 @@ function handlePlugins(ctx: SlashContext, rest: string[]): SlashResult {
       );
     });
     ctx.out.line();
-    ctx.out.line(palette.dim(`  Install one: /marketplace install ${name} <plugin>`));
+    ctx.out.line(palette.dim(`  Install one: /marketplace install-plugin ${name} <plugin>`));
     ctx.out.line();
   } catch (err) {
     ctx.out.error(`List failed: ${errorMsg(err)}`);
-  }
-  return 'continue';
-}
-
-async function handleInstall(ctx: SlashContext, rest: string[]): Promise<SlashResult> {
-  let marketplace: string | undefined;
-  let plugin: string | undefined;
-  // Accept either `<mp> <plugin>` or `<mp>:<plugin>` for parity with the CLI.
-  if (rest.length === 1 && rest[0]?.includes(':')) {
-    const parts = rest[0].split(':');
-    if (parts.length === 2) {
-      [marketplace, plugin] = parts;
-    }
-  } else {
-    [marketplace, plugin] = rest;
-  }
-  if (!marketplace || !plugin) {
-    ctx.out.error('Usage: /marketplace install <marketplace> <plugin>');
-    return 'continue';
-  }
-  ctx.out.info(`Installing ${marketplace}:${plugin}…`);
-  try {
-    const result = await installFromMarketplace(marketplace, plugin);
-    ctx.out.success(`Installed ${result.key}.`);
-    ctx.out.line(
-      palette.dim('  Run /reload-plugins to refresh this session\'s slash commands.'),
-    );
-  } catch (err) {
-    ctx.out.error(`Install failed: ${errorMsg(err)}`);
   }
   return 'continue';
 }


### PR DESCRIPTION
## Ported from `afk-workshop#701`

Source: **griffinwork40/afk-workshop#701** — https://github.com/griffinwork40/afk-workshop/pull/701
Original title: `fix(marketplace): align REPL slash verbs with CLI (install / install-plugin)`

This is a moat-scrubbed port via diff + 3-way apply (the public repo shares no history with afk-workshop, so commits cannot be cherry-picked across). In this case the entire patch was classified PUBLIC-SAFE — **nothing needed scrubbing**.

### What this change does
Aligns the REPL `/marketplace` slash verbs with the `afk marketplace …` CLI:
- `install <source>` now installs a **marketplace** (was the plugin-install verb).
- New `install-plugin <marketplace> <plugin>` installs a plugin from a marketplace.
- New `list` (alias for `/marketplaces`).
- Deprecated aliases keep working with a one-line warning: `add` → install, 2-arg `install <mp> <plugin>` → install-plugin, colon-form `install <mp>:<plugin>` → install-plugin.
- URL-scheme-aware colon disambiguation (`isColonPluginForm`) decides marketplace-vs-plugin routing.

### Ported (all PUBLIC-SAFE)
- `docs/reference.md` — `afk marketplace add` → `afk marketplace install`
- `src/agent/plugins-scanner.ts` — doc-comment verb update
- `src/cli/slash/marketplace-browse.ts` — the dispatch/routing refactor (+131/-47)
- `src/cli/slash/marketplace-browse.test.ts` — new test file (+289), 17 tests

### Dropped (and why)
**None.** The moat triage classified every file and hunk PUBLIC-SAFE; no moat files, hunks, imports, or HARD-denylist terms were present in the source patch.

### Verification
- `pnpm install --frozen-lockfile` ✓
- `pnpm fix:pins:check` → "All hash pins are up to date." ✓
- `pnpm lint` (tsc --noEmit, strict) ✓
- `pnpm test` → **468 files, 8767 passed / 12 skipped** ✓ (ported file: 17/17 ✓)
- `pnpm build` ✓ · `pnpm build:dist` ✓ (`[scrub] 0 files scrubbed`)
- **Deterministic moat guard (tree + dist): `✅ MOAT GUARD CLEAN`**
- **Adversarial moat audit (independent re-derivation): CLEAN**

> **Do not merge automatically** — left for human review.
