### PR TITLE
fix(tui): ESC soft-stop cancels on first press, no post-cancel lag

### DIFF
--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -506,19 +506,32 @@ export function registerInteractiveCommand(program: Command): void {
           return;
         }
         if (turnState.turnInFlight) {
-          ctx.session.current.interrupt().catch(() => { /* swallow during teardown */ });
+          // First Ctrl+C during a turn = ESC soft-stop: stop cleanly, keep
+          // completed work, and preserve the typed draft (the compositor no
+          // longer auto-queues it on Ctrl+C). requestSoftStop sets
+          // softStopRequested + interrupts, so the turn handler renders the
+          // "⏸ Stopped — work so far kept" notice and skips recordTurn exactly
+          // as ESC does. Falls back to a bare interrupt when no soft-stop
+          // handler is published (non-REPL turn, or a gap between turns).
+          if (turnState.requestSoftStop) {
+            turnState.requestSoftStop();
+          } else {
+            ctx.session.current.interrupt().catch(() => { /* swallow during teardown */ });
+          }
           turnState.lastSigintAt = now;
           // Surface a live "interrupting…" affordance in the overlay. The
           // renderer owns the OverlayComposer; this notifier was published by
           // the turn handler at arm time (null between turns → no-op).
           turnState.notifyInterrupting?.(true);
-          // Route the interrupt notice through the active compositor's
-          // commitAbove when available — that path clears the live overlay,
-          // writes the line into scrollback, and repaints the overlay
-          // below, so the notice survives subsequent log-update clears.
-          // A bare console.log races the still-armed compositor's
-          // spinner-tick repaints and can be erased before the user sees it.
-          const msg = '\n' + palette.warning('⚠ Interrupted. Press Ctrl+C again to exit.');
+          // The "⏸ Stopped — work so far kept" notice prints from the turn
+          // handler (the soft-stop path). Here we add ONLY the exit affordance:
+          // a second Ctrl+C within SIGINT_EXIT_WINDOW_MS quits. Route it
+          // through the active compositor's commitAbove when available — that
+          // path clears the live overlay, writes the line into scrollback, and
+          // repaints the overlay below, so the notice survives subsequent
+          // log-update clears. A bare console.log races the still-armed
+          // compositor's spinner-tick repaints and can be erased first.
+          const msg = '\n' + palette.info('ℹ ') + 'Press Ctrl+C again to exit.';
           const c = turnState.activeCompositor;
           if (c && c.isArmed()) {
             try { c.commitAbove(msg); } catch { console.log(msg); }

--- a/src/cli/commands/interactive/repl-loop-wiring.test.ts
+++ b/src/cli/commands/interactive/repl-loop-wiring.test.ts
@@ -298,6 +298,43 @@ describe('runReplLoop — skill-dispatch handles wired onto slashCtx', () => {
     expect(captured.transcriptIsHandle).toBe(true);
   });
 
+  it('setSoftStopHandler publishes the soft-stop closure to turnState.requestSoftStop (and clears it)', async () => {
+    // Ctrl+C-once == ESC: the SIGINT handler (interactive.ts) fires the SAME
+    // soft-stop closure ESC does. That closure must be published to turnState
+    // so handleSigint can reach it mid-turn — and cleared between turns so a
+    // between-turn Ctrl+C falls back to a plain interrupt rather than firing a
+    // stale closure.
+    const backgroundRegistry = new BackgroundAgentRegistry({});
+    const ctx = makeMinimalCtx(backgroundRegistry);
+    const transcript = makeTranscript();
+
+    const turnState: TurnState = {
+      turnInFlight: false,
+      lastSigintAt: 0,
+      activeCompositor: null,
+    } as TurnState;
+
+    const handler = (): void => {};
+    const captured = {
+      afterInstall: undefined as unknown,
+      afterClear: undefined as unknown,
+    };
+
+    const slashMod = await import('../../slash/registry.js');
+    vi.mocked(slashMod.dispatch).mockImplementationOnce(async () => {
+      ctx.slashCtx.setSoftStopHandler?.(handler);
+      captured.afterInstall = turnState.requestSoftStop;
+      ctx.slashCtx.setSoftStopHandler?.(null);
+      captured.afterClear = turnState.requestSoftStop;
+      return { handled: true, result: 'exit' as const };
+    });
+
+    await runReplLoop(ctx, transcript as never, turnState, vi.fn());
+
+    expect(captured.afterInstall).toBe(handler);
+    expect(captured.afterClear).toBeNull();
+  });
+
   it('slashCtx.onContextProgress refreshes the sampler and repaints the status line', async () => {
     const backgroundRegistry = new BackgroundAgentRegistry({});
     const ctx = makeMinimalCtx(backgroundRegistry);

--- a/src/cli/commands/interactive/repl-loop.ts
+++ b/src/cli/commands/interactive/repl-loop.ts
@@ -88,6 +88,16 @@ export interface TurnState {
    * handler calls it on Ctrl+C mid-turn. Null between turns.
    */
   notifyInterrupting?: ((active: boolean) => void) | null;
+  /**
+   * In-turn soft-stop trigger — the SAME closure ESC fires
+   * (sets the turn's `softStopRequested` + interrupts the session). The
+   * SIGINT handler calls it on the FIRST Ctrl+C during a turn so Ctrl+C
+   * stops as gracefully as ESC (keeps completed work, preserves the draft)
+   * rather than a bare interrupt. Published whenever a soft-stop handler is
+   * installed (normal turn or /skill dispatch) and cleared (null) between
+   * turns. Null → the SIGINT handler falls back to a plain interrupt.
+   */
+  requestSoftStop?: (() => void) | null;
 }
 
 async function runFirstTurnHookIfNeeded(ctx: InteractiveCtx, text: string): Promise<void> {
@@ -433,12 +443,22 @@ export async function runReplLoop(
     ctx.completionWriter.fn = writeIdle;
     ctx.completionWriter.idleFn = writeIdle;
   }
-  // Expose the surface's setSoftStopHandler so `runSkillDispatchTurn`
-  // can install its per-dispatch closure (same wiring as TurnHandles.
-  // setSoftStopHandler line ~583). Without this, ESC during a /skill
-  // turn is silently dropped at the compositor's onSoftStop because
-  // the surface's softStopHandler ref stays null.
-  ctx.slashCtx.setSoftStopHandler = (handler) => surface.setSoftStopHandler(handler);
+  // Install a per-turn soft-stop handler on the surface (so ESC works) AND
+  // publish it to turnState so the SIGINT handler can fire the SAME soft-stop
+  // on the first Ctrl+C of a turn (Ctrl+C-once == ESC). Both the normal-turn
+  // host hook and the /skill dispatch path route through here, so a single
+  // helper keeps the surface ref and the turnState ref in lockstep — including
+  // the teardown call (handler === null) that clears both between turns.
+  const installSoftStop = (handler: (() => void) | null): void => {
+    surface.setSoftStopHandler(handler);
+    turnState.requestSoftStop = handler;
+  };
+  // Expose setSoftStopHandler so `runSkillDispatchTurn` can install its
+  // per-dispatch closure (same wiring as TurnHandles.setSoftStopHandler
+  // below). Without this, ESC during a /skill turn is silently dropped at
+  // the compositor's onSoftStop because the surface's softStopHandler ref
+  // stays null.
+  ctx.slashCtx.setSoftStopHandler = installSoftStop;
   // Mirror the TurnHandles.onStageChange / onContextProgress wiring (see the
   // runTurn handles object below) onto SlashContext so skill-dispatch turns
   // (`/review`, `/mint`, plugin skills) drive the SAME footer rails as normal
@@ -975,7 +995,7 @@ export async function runReplLoop(
         // set*Handler calls are benign mutations of null refs).
         getCompositor: () => surface.getCompositor(),
         setBackgroundHandler: (handler) => surface.setBackgroundHandler(handler),
-        setSoftStopHandler: (handler) => surface.setSoftStopHandler(handler),
+        setSoftStopHandler: installSoftStop,
         async onContextProgress() {
           await ctx.contextSampler.refresh();
           ctx.statusLine.repaint(formatStatusFields(ctx.stats, ctx.contextSampler));

--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -1006,8 +1006,12 @@ describe('runTurn — ESC soft-stop', () => {
 
     // Post-fix (Bug 2 fixed): softStopRequested=true → notice IS shown,
     // doneFired && !softStopRequested is false → onTurnComplete NOT called.
-    // session.interrupt() was not called (ESC fired after stream ended, no break).
-    expect(session.interrupt).not.toHaveBeenCalled();
+    // Immediate-interrupt fix: the soft-stop handler now calls
+    // session.interrupt() synchronously on ESC, so it fires exactly once
+    // even when ESC lands after the stream ended — a harmless idempotent
+    // no-op in production (AgentSession.interrupt() returns early once the
+    // session state has left streaming/processing).
+    expect(session.interrupt).toHaveBeenCalledTimes(1);
     expect(onTurnComplete).not.toHaveBeenCalled();
   });
 
@@ -1071,8 +1075,10 @@ describe('runTurn — ESC soft-stop', () => {
     expect(writerCalls.some((line) => line.includes('Stopped'))).toBe(true);
     // Turn is NOT recorded.
     expect(onTurnComplete).not.toHaveBeenCalled();
-    // interrupt() not called (ESC after stream, no in-flight events to break on).
-    expect(session.interrupt).not.toHaveBeenCalled();
+    // Immediate-interrupt fix: the soft-stop handler calls interrupt()
+    // synchronously on ESC, so it fires exactly once even after the stream
+    // ended — a harmless idempotent no-op in production.
+    expect(session.interrupt).toHaveBeenCalledTimes(1);
   });
 
   // ---------------------------------------------------------------------------

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -199,7 +199,22 @@ export async function runTurn(
     // guard. By wiring the handler first, any ESC that arrives during or
     // after arm() correctly sets softStopRequested=true.
     if (h.setSoftStopHandler) {
-      h.setSoftStopHandler(() => { softStopRequested = true; });
+      h.setSoftStopHandler(() => {
+        softStopRequested = true;
+        // Fire interrupt() synchronously on ESC instead of waiting for the
+        // for-await loop below to observe `softStopRequested`. During a long
+        // tool call the loop is blocked awaiting the stream's next event, so a
+        // deferred interrupt would not fire until another token arrived —
+        // making ESC look dead for seconds (the "ESC does nothing" symptom).
+        // interrupt() is idempotent (AgentSession returns early once state
+        // leaves streaming/processing), so the loop's break-path interrupt
+        // below remains a safe no-op.
+        session.interrupt().catch((err) => {
+          if (isDebugEnabled()) {
+            console.error('  ' + palette.error('soft-stop session.interrupt() failed:'), err);
+          }
+        });
+      });
     }
 
     await armAndWire();
@@ -244,24 +259,22 @@ export async function runTurn(
         // tool-call flush into session state. Reverse order (flush
         // then halt) risks writing partial state to disk — the stream
         // may still be delivering tool_result chunks, so tool events
-        // accumulated so far would be incomplete. By halting first
-        // (session.interrupt() stops the pump), the event loop drains
-        // to quiescence before the post-stream block records completed
-        // tool events via recordTurn. This ordering is externally
-        // governed by the event-loop boundary between the HTTP stream
-        // pump and the state writer in turn-handler.ts.
+        // accumulated so far would be incomplete. The soft-stop handler
+        // (installed above) calls session.interrupt() synchronously on
+        // ESC, so the pump is already halting before this loop breaks and
+        // before the post-stream recordTurn runs. This ordering is
+        // externally governed by the event-loop boundary between the HTTP
+        // stream pump and the state writer in turn-handler.ts.
         //
-        // Implementation: interrupt is called here (inside the stream
-        // loop) so it fires as early as possible on the next iteration
-        // after softStopRequested is set. The stream's async iterator
-        // then terminates naturally (no throw), and the post-stream
-        // block below detects doneFired===false to render the notice.
+        // Implementation: interrupt fires in the handler, NOT here — if it
+        // were deferred to this for-await, a long-running tool call (during
+        // which this loop is blocked awaiting the next event) would not halt
+        // until the next token arrived, making ESC look dead for seconds
+        // (the "ESC does nothing" bug). Here we only break: interrupt() was
+        // already initiated in the handler, the stream's async iterator
+        // terminates naturally (no throw), and the post-stream block detects
+        // softStopRequested to render the notice and suppress recordTurn.
         if (softStopRequested) {
-          session.interrupt().catch((err) => {
-            if (isDebugEnabled()) {
-              console.error('  ' + palette.error('soft-stop session.interrupt() failed:'), err);
-            }
-          });
           break;
         }
 

--- a/src/cli/slash/_lib/run-skill-dispatch-turn.ts
+++ b/src/cli/slash/_lib/run-skill-dispatch-turn.ts
@@ -129,7 +129,16 @@ export async function runSkillDispatchTurn(
     // /skill turn is silently dropped at the compositor's onSoftStop →
     // InputSurface.softStopHandler?.() no-op (the gap PR #546 called
     // out as a deferred follow-up). Cleared in finally.
-    ctx.setSoftStopHandler?.(() => { softStopRequested = true; });
+    ctx.setSoftStopHandler?.(() => {
+      softStopRequested = true;
+      // Fire interrupt() synchronously on ESC rather than deferring to the
+      // for-await loop's `softStopRequested` check — during a long tool call
+      // the loop is blocked awaiting the next stream event, so a deferred
+      // interrupt leaves ESC unresponsive until another token arrives.
+      // interrupt() is idempotent, so the loop's break-path interrupt is a
+      // safe no-op.
+      ctx.session.current.interrupt().catch(() => { /* best effort */ });
+    });
 
     // Preflight runs inside the armed renderer so the spinner is visible
     // during any I/O. Failure isolation matches `runPreflight`'s own
@@ -161,14 +170,16 @@ export async function runSkillDispatchTurn(
     await runWithSink(renderer.sink, async () => {
       for await (const event of ctx.session.current.sendMessageStream(message)) {
         // Invariant: soft-stop halt MUST fire before the event is sinked
-        // into the renderer. Mirrors turn-handler.ts ~line 225 — the
-        // event-loop boundary between the HTTP stream pump and the
-        // renderer state writer is what makes this ordering load-bearing.
-        // session.interrupt() terminates the stream's async iterator
-        // naturally (no throw); the break exits the for-await cleanly
-        // and the finally block disposes the renderer.
+        // into the renderer. Mirrors turn-handler.ts — the event-loop
+        // boundary between the HTTP stream pump and the renderer state
+        // writer is what makes this ordering load-bearing. The soft-stop
+        // handler (installed above) calls interrupt() synchronously on ESC,
+        // so the pump is already halting before this break; deferring it to
+        // this loop would leave ESC unresponsive while a long tool call
+        // blocks the await. Here we only break: interrupt() was already
+        // initiated, the stream's async iterator terminates naturally (no
+        // throw), and the finally block disposes the renderer.
         if (softStopRequested) {
-          ctx.session.current.interrupt().catch(() => { /* best effort */ });
           break;
         }
         // Capture the latest assistant message text BEFORE sinking — read-only,

--- a/src/cli/terminal-compositor.committed-band-single-copy.test.ts
+++ b/src/cli/terminal-compositor.committed-band-single-copy.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Regression tests for the "triplicate echo" TUI rendering analysis.
+ *
+ * ## Investigation summary
+ * A user reported their submitted REPL message renders 3 times. The prior
+ * investigation produced RED tests claiming `repositionCommittedBand` causes
+ * visible duplication. This test file is the corrected GREEN version after
+ * a byte-stream analysis confirmed the duplication is BENIGN.
+ *
+ * ## Verdict: BENIGN same-row repaint (NOT visible duplication)
+ *
+ * Byte-stream evidence from the critical window (setOverlay('') → setInputMode('idle')):
+ *
+ *   setOverlay('') render:
+ *     row21+EL:"" | row22+EL:"" | row23+EL:"" |   ← padded erase of prior tall frame
+ *     row21+EL:"" | row22+EL:"" | row23+EL:"> msg two [queued]"  ← new frame
+ *   repositionCommittedBand (band moves from row20 → row22):
+ *     row20+EL:"" | row21+EL:"" | row22+EL:"ECHO:msg one"        ← CORRECT PLACEMENT
+ *
+ *   setInputMode('idle') render:
+ *     row21+EL:"" | row22+EL:"" | row23+EL:""                    ← padded erase (previous
+ *                                                                     lineCount=3 still active)
+ *     row23+EL:"> msg two [queued]"                               ← new 1-row frame
+ *   repositionCommittedBand (same position, band was erased by padded erase):
+ *     row22+EL:"ECHO:msg one"                                     ← RE-PAINT to same row
+ *
+ * The band content at row 22 is the ONLY un-erased copy at the end of the
+ * critical window. Row 20 was erased before row 22 was painted. Row 22 is
+ * re-painted (not left blank) after the drain-guard render's padded erase.
+ * This is two sequential writes to the same row, not two simultaneously
+ * visible copies at different rows.
+ *
+ * ## Why the drain-guard repaint happens
+ * CupFrameRenderer's shrink-padding: after a tall-frame → short-frame transition,
+ * `previousLineCount` stays at the padded height for one render cycle, causing
+ * the erase pass to cover the band row. `renderErasedBand=true` fires, and
+ * `repositionCommittedBand` correctly repaints the band. The NEXT render uses
+ * the unpadded height and no longer covers the band row — the loop terminates
+ * after exactly 1 extra repaint.
+ *
+ * ## What the tests assert
+ * These tests verify the CORRECT invariant: at the end of any critical window,
+ * the band content exists at exactly ONE un-erased row on screen — no
+ * simultaneously visible copies at multiple rows. The number of sequential
+ * same-row repaints is not asserted (that's a performance/flicker concern, not
+ * a correctness concern per the byte-stream analysis).
+ *
+ * File: src/cli/terminal-compositor.committed-band-repin.ts
+ *
+ * @see terminal-compositor.committed-band-repin.ts:66-133 (repositionCommittedBand)
+ * @see terminal-compositor.frame.ts:272-274 (preRenderFrameTop capture + call)
+ * @see cup-frame-renderer.ts:152-170 (shrink-padding logic)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { __resetStdinClaimForTests } from './input/stdin-claim.js';
+import * as Repin from './terminal-compositor.committed-band-repin.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+type MockStdout = NodeJS.WriteStream & {
+  isTTY: boolean;
+  columns: number;
+  rows: number;
+};
+type MockStdin = NodeJS.ReadStream & {
+  isTTY: boolean;
+  isRaw: boolean;
+  setRawMode: ReturnType<typeof vi.fn>;
+};
+
+function makeMockStdout(): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true;
+  s.columns = 80;
+  s.rows = 24;
+  return s;
+}
+
+function makeMockStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true;
+  s.isRaw = false;
+  s.setRawMode = vi.fn((raw: boolean) => {
+    s.isRaw = raw;
+    return s;
+  });
+  return s;
+}
+
+function collectWrites(stream: MockStdout): { all: () => string } {
+  const chunks: string[] = [];
+  stream.on('data', (c: unknown) => chunks.push(String(c)));
+  return { all: () => chunks.join('') };
+}
+
+/**
+ * Parse the CUP+EL byte stream and return the last write to each row within
+ * the given segment. A row's "last write" is either:
+ *   - 'echo' if the final CUP+EL to that row contains echo content
+ *   - 'blank' if the final CUP+EL to that row left it empty/erased
+ */
+function lastWritePerRow(segment: string, echoMarker: string): Map<number, 'echo' | 'blank'> {
+  const result = new Map<number, 'echo' | 'blank'>();
+  // Match: ESC [ <row> ; 1 H ESC [ 2 K <content>
+  const re = /\x1b\[(\d+);1H\x1b\[2K([^\x1b]*)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(segment)) !== null) {
+    const row = parseInt(m[1]!);
+    const content = (m[2] ?? '').trim();
+    result.set(row, content.includes(echoMarker) ? 'echo' : 'blank');
+  }
+  return result;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  __resetStdinClaimForTests();
+});
+
+describe('triplicate-echo: committed-band single-copy invariant (GREEN regression)', () => {
+  /**
+   * CORE INVARIANT: at the end of the dispose→readLine critical window, the
+   * committed echo content exists at EXACTLY ONE un-erased row on screen.
+   * No row that previously held echo content retains it un-erased while a
+   * different row also holds it un-erased (no simultaneous multi-row duplication).
+   *
+   * The band may be sequentially re-painted on the same row (drain-guard churn),
+   * but the FINAL state has one un-erased copy. This is verified by inspecting
+   * the last write to each row in the critical window's byte stream.
+   */
+  it('band content ends at exactly one un-erased row after dispose→readLine', async () => {
+    const stdout = makeMockStdout();
+    const stdin = makeMockStdin();
+    const writes = collectWrites(stdout);
+
+    const c = new TerminalCompositor({
+      stdout,
+      stdin,
+      onCancel: vi.fn(),
+      onSoftStop: vi.fn(),
+      promptText: '> ',
+    });
+    await c.arm();
+
+    const ECHO_T1 = 'ECHO_T1:turn one message';
+
+    // ── Turn 1: establish committed band ──────────────────────────────────
+    c.setInputMode('idle');
+    c.setInputMode('streaming');
+    c.setOverlay('Turn 1 streaming output');
+
+    for (const ch of 'turn one message') {
+      stdin.emit('keypress', ch, { name: ch, sequence: ch });
+    }
+    stdin.emit('keypress', undefined, { name: 'escape' });
+    stdin.emit('keypress', undefined, { name: 'return' });
+
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    c.setInputMode('idle');
+
+    c.setOnSubmit((_p) => {
+      c.commitAbove(ECHO_T1);
+    });
+    c.setInputMode('idle');
+    c.repaint();
+    stdin.emit('keypress', undefined, { name: 'return' });
+
+    // ── Turn 2 arm ────────────────────────────────────────────────────────
+    c.setOnSubmit(null);
+    c.setInputMode('streaming');
+    c.setOverlay('Turn 2 streaming output');
+
+    for (const ch of 'turn two') {
+      stdin.emit('keypress', ch, { name: ch, sequence: ch });
+    }
+
+    // ── Critical window: capture byte stream ──────────────────────────────
+    const windowStart = writes.all().length;
+
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');        // frame shrinks → band moves → repin writes
+    c.setInputMode('idle'); // drain guard → repaint → repin may re-write same row
+
+    const windowEnd = writes.all().length;
+    const segment = writes.all().slice(windowStart, windowEnd);
+
+    // Analyze: find the last write to each row in the window.
+    const ECHO_MARKER = 'ECHO_T1'; // substring of the committed echo text
+    const rowStates = lastWritePerRow(segment, ECHO_MARKER);
+
+    // Count rows whose FINAL state is un-erased echo content.
+    const unErasedEchoRows = [...rowStates.entries()]
+      .filter(([_, state]) => state === 'echo')
+      .map(([row]) => row);
+
+    console.log(`[window byte analysis] row final states:`,
+      [...rowStates.entries()].map(([r, s]) => `row${r}:${s}`).join(' '));
+    console.log(`[un-erased echo rows at window end]: ${JSON.stringify(unErasedEchoRows)}`);
+
+    // INVARIANT: at the end of the critical window, echo content is un-erased
+    // at EXACTLY ONE row. Sequential same-row repaints are fine; simultaneous
+    // multi-row duplication is the correctness bug to prevent.
+    expect(unErasedEchoRows.length).toBe(1);
+
+    c.disarm();
+  });
+
+  /**
+   * ORDERING INVARIANT: within each repositionCommittedBand write,
+   * the old band position is erased BEFORE the new position is painted.
+   * This ensures the old row is never left un-erased while the new row
+   * is simultaneously painted.
+   *
+   * Verified by inspecting the byte ordering within each repin write:
+   * old-row erase must precede new-row content write.
+   */
+  it('each repositionCommittedBand write erases old rows before painting new ones', async () => {
+    const stdout = makeMockStdout();
+    const stdin = makeMockStdin();
+    const writes = collectWrites(stdout);
+
+    const origRepin = Repin.repositionCommittedBand;
+    // Capture the byte range of each repositionCommittedBand write.
+    const repinSegments: string[] = [];
+    vi.spyOn(Repin, 'repositionCommittedBand').mockImplementation(
+      function (self: Parameters<typeof Repin.repositionCommittedBand>[0], desiredTopRow, preRenderFrameTop, targetBottomRow) {
+        const before = writes.all().length;
+        origRepin(self, desiredTopRow, preRenderFrameTop, targetBottomRow);
+        const after = writes.all().length;
+        if (after > before) {
+          repinSegments.push(writes.all().slice(before, after));
+        }
+      },
+    );
+
+    const c = new TerminalCompositor({
+      stdout,
+      stdin,
+      onCancel: vi.fn(),
+      onSoftStop: vi.fn(),
+      promptText: '> ',
+    });
+    await c.arm();
+
+    // Turn 1
+    c.setInputMode('idle');
+    c.setInputMode('streaming');
+    c.setOverlay('Turn 1 output');
+    for (const ch of 'msg one') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+    stdin.emit('keypress', undefined, { name: 'escape' });
+    stdin.emit('keypress', undefined, { name: 'return' });
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    c.setInputMode('idle');
+    c.setOnSubmit((_p) => { c.commitAbove('ECHO:msg one'); });
+    c.setInputMode('idle');
+    c.repaint();
+    stdin.emit('keypress', undefined, { name: 'return' });
+    repinSegments.length = 0; // reset
+
+    // Turn 2 grow → shrink
+    c.setOnSubmit(null);
+    c.setInputMode('streaming');
+    c.setOverlay('Turn 2 output');
+    for (const ch of 'msg two') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+    stdin.emit('keypress', undefined, { name: 'escape' });
+    stdin.emit('keypress', undefined, { name: 'return' });
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    c.setInputMode('idle');
+
+    // For each repin write, verify: within that write, if there's an erase
+    // of an old row AND a paint of a new row, the erase comes first.
+    for (const seg of repinSegments) {
+      // Find all CUP+EL operations and their byte offsets.
+      const ops: Array<{offset: number; row: number; content: string}> = [];
+      const re = /\x1b\[(\d+);1H\x1b\[2K([^\x1b]*)/g;
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(seg)) !== null) {
+        ops.push({ offset: m.index, row: parseInt(m[1]!), content: (m[2] ?? '').trim() });
+      }
+      // Find the echo-content write.
+      const echoOp = ops.find(o => o.content.includes('ECHO') || o.content.includes('msg one'));
+      if (!echoOp) continue;
+      // Find any erase-only writes that precede the echo write.
+      const erasesBefore = ops.filter(o => o.offset < echoOp.offset && o.content === '');
+      const erasesAfter = ops.filter(o => o.offset > echoOp.offset && o.content === '');
+      // The echo write must be last (or near-last) — no BLANK write to the echo row after it.
+      const blankedAfterEcho = erasesAfter.filter(o => o.row === echoOp.row);
+      expect(blankedAfterEcho.length).toBe(0);
+
+      console.log(`[repin segment] ops: ${ops.map(o => `row${o.row}:${o.content.slice(0,20) || '[blank]'}`).join(' → ')}`);
+    }
+
+    c.disarm();
+  });
+
+  /**
+   * STABLE-BAND REGRESSION: after the frame geometry settles (unpadded), the
+   * committed band row must NOT be erased or lost on subsequent repaints.
+   * Verifies that the shrink-padding drain window terminates correctly and
+   * doesn't permanently corrupt the band.
+   */
+  it('committed band survives the drain window and remains visible on subsequent repaints', async () => {
+    const stdout = makeMockStdout();
+    const stdin = makeMockStdin();
+    const writes = collectWrites(stdout);
+
+    const c = new TerminalCompositor({
+      stdout,
+      stdin,
+      onCancel: vi.fn(),
+      onSoftStop: vi.fn(),
+      promptText: '> ',
+    });
+    await c.arm();
+
+    // Establish committed band.
+    c.setInputMode('idle');
+    c.setInputMode('streaming');
+    c.setOverlay('Streaming output');
+    for (const ch of 'hello') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+    stdin.emit('keypress', undefined, { name: 'escape' });
+    stdin.emit('keypress', undefined, { name: 'return' });
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    c.setInputMode('idle');
+    c.setOnSubmit((_p) => { c.commitAbove('COMMITTED_ECHO'); });
+    c.setInputMode('idle');
+    c.repaint();
+    stdin.emit('keypress', undefined, { name: 'return' });
+
+    // Grow frame (overlay).
+    c.setInputMode('streaming');
+    c.setOverlay('New overlay');
+
+    // Shrink frame (clear overlay).
+    c.setOverlay('');
+
+    // Drain window: fire several consecutive repaints.
+    for (let i = 0; i < 5; i++) {
+      c.repaint();
+    }
+
+    // Capture final byte stream and verify the band's FINAL state is un-erased.
+    const ECHO_MARKER = 'COMMITTED_ECHO';
+    const allBytes = writes.all();
+    const rowStates = lastWritePerRow(allBytes, ECHO_MARKER);
+    const unErasedEchoRows = [...rowStates.entries()]
+      .filter(([_, state]) => state === 'echo')
+      .map(([row]) => row);
+
+    console.log(`[after 5 repaints] un-erased echo rows: ${JSON.stringify(unErasedEchoRows)}`);
+
+    // The band must still be visible (at least one row with un-erased echo content).
+    expect(unErasedEchoRows.length).toBeGreaterThanOrEqual(1);
+
+    // The band must be at exactly ONE row (no duplication).
+    expect(unErasedEchoRows.length).toBe(1);
+
+    c.disarm();
+  });
+});

--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -246,12 +246,20 @@ function handleEscape(self: KeyDispatchHost, key: KeyInfo): boolean {
   // never marks the turn as hard-aborted (no `canceled = true`).
   if (ac?.dropdownOpen) {
     // Dismiss dropdown and record the suppression signature so it
-    // stays closed until the buffer changes.
+    // stays closed until the buffer changes. Do NOT `return` here:
+    // ghost-text autocomplete repopulates `dropdownOpen` on nearly every
+    // keystroke, so while the agent streams the dropdown is almost always
+    // open at the moment the user hits ESC to stop it. Returning early
+    // swallowed that ESC and forced a second press to reach the soft-stop
+    // path below — the "double-press to cancel" bug. Falling through lets a
+    // single ESC both dismiss the dropdown AND fire soft-stop in streaming
+    // mode; the idle-mode guard on the next line still keeps ESC a pure
+    // UI-dismissal when not streaming, and the `softStopped` once-only guard
+    // still prevents a second ESC from re-firing onSoftStop.
     ac.suppressedSignature = `${self.input.cursor}:${self.input.buffer}`;
     ac.dropdownOpen = false;
     ac.candidates = [];
     self.repaint();
-    return true;
   }
   if (self.inputMode === 'idle') return true;
   // Soft-stop: once-only per turn. Second ESC while streaming is

--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -230,20 +230,19 @@ function handleEscape(self: KeyDispatchHost, key: KeyInfo): boolean {
   const ac = self.autocompleteState;
   // ESC: close dropdown if open. In streaming mode, fire soft-stop
   // (once-only per turn via `softStopped` guard) — ESC is the
-  // user-recoverable stop that preserves already-completed work,
-  // distinct from Ctrl+C (hard-abort via `canceled` flag below).
-  // In idle mode, ESC is reserved for UI dismissal only.
+  // user-recoverable stop that preserves already-completed work. In
+  // idle mode, ESC is reserved for UI dismissal only.
   //
-  // Invariant: soft-stop is NOT the `onCancel` path. `onCancel`
-  // sets `canceled = true` and is consumed by the Ctrl+C branch. ESC
-  // routes to `onSoftStop` without touching `canceled`, so the turn
-  // ends cleanly (no "canceled" state on the compositor) and the
-  // queued-buffer flush at the next idle transition operates normally
-  // on the next turn. This distinction is externally governed by the
-  // caller contract in InputSurface.armCompositor — the `onCancel`
-  // handler there calls `session.interrupt()` which kills the stream;
-  // `onSoftStop` calls the same underlying interrupt but the compositor
-  // never marks the turn as hard-aborted (no `canceled = true`).
+  // ESC vs Ctrl+C: both now stop a turn gracefully (Ctrl+C routes to
+  // onCancel → handleSigint, whose in-turn branch triggers the SAME
+  // soft-stop as ESC), but they reach it by different paths and Ctrl+C
+  // additionally arms the "press again to exit" window so a second
+  // Ctrl+C quits. ESC routes straight to `onSoftStop`; it does NOT arm
+  // the exit window and does NOT touch `canceled`, so a lone ESC never
+  // edges the REPL toward quitting. The `canceled` flag is only the
+  // compositor's once-only guard for the Ctrl+C branch below; it is not
+  // read by the turn handler (soft-stop vs completed-turn is decided by
+  // the turn handler's `softStopRequested`, which BOTH paths now set).
   if (ac?.dropdownOpen) {
     // Dismiss dropdown and record the suppression signature so it
     // stays closed until the buffer changes. Do NOT `return` here:
@@ -286,13 +285,18 @@ function handleEscape(self: KeyDispatchHost, key: KeyInfo): boolean {
 }
 
 function handleInterrupt(self: KeyDispatchHost, key: KeyInfo): boolean {
-  // Ctrl+C → cancel/sigint, always (regardless of dropdown state).
-  //   - Idle mode: pure sigint trigger — no buffer queue, no
-  //     once-only guard. The surface installs handleSigint here so
-  //     repeated Ctrl+C presses follow the "interrupt → press again
-  //     to quit" affordance.
-  //   - Streaming mode: legacy — set canceled (once-only) + queue
-  //     buffer + fire onCancel (which interrupts the session).
+  // Ctrl+C → onCancel (= the REPL's handleSigint), in any mode. The
+  // first/second-press dispatch lives in handleSigint:
+  //   - 1st Ctrl+C during a turn = ESC soft-stop (stop cleanly, keep
+  //     work, preserve the draft); 2nd within the exit window quits.
+  //   - In idle, 1st arms the exit window, 2nd quits.
+  // We deliberately do NOT auto-queue the buffer here (parity with ESC
+  // soft-stop, handleEscape): a graceful stop must leave a typed-but-
+  // unconfirmed buffer as an editable draft (queued stays as-is), not
+  // fling it as a turn the user never submitted. `canceled` stays a
+  // once-only guard so a flurry of presses inside ONE streaming turn
+  // fires onCancel once; the second quit-press arrives in idle (the
+  // turn ends on interrupt) where the guard does not apply.
   if (key?.ctrl && key?.name === 'c') {
     if (self.inputMode === 'idle') {
       if (self.onCancel) self.onCancel();
@@ -300,10 +304,6 @@ function handleInterrupt(self: KeyDispatchHost, key: KeyInfo): boolean {
     }
     if (self.canceled) return true;
     self.canceled = true;
-    if (self.input.buffer.length > 0 && !self.queued) {
-      self.queued = true;
-      self.repaint();
-    }
     if (self.onCancel) self.onCancel();
     return true;
   }

--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -265,19 +265,21 @@ function handleEscape(self: KeyDispatchHost, key: KeyInfo): boolean {
   // Soft-stop: once-only per turn. Second ESC while streaming is
   // a no-op — the stream is already halting.
   if (self.softStopped) return true;
-  // Preserve a typed-but-not-yet-submitted buffer as queued so the
-  // soft-stop auto-submits it on the next turn — parity with the
-  // pre-soft-stop ESC path (which queued the buffer before firing
-  // onCancel) and with the Ctrl+C branch below. External constraint:
-  // the idle-transition flush (setInputMode → idle) requires
-  // `queued === true` to fire onSubmit; without this, a message typed
-  // while the agent was streaming is silently dropped on ESC. An
-  // already-[queued] buffer (user pressed Enter) is left untouched —
-  // the `!self.queued` guard makes this idempotent.
-  if (self.input.buffer.length > 0 && !self.queued) {
-    self.queued = true;
-    self.repaint();
-  }
+  // Contract: ESC soft-stop does NOT touch the buffer's queued state.
+  // Enter is the ONLY queue trigger. So:
+  //   - queued === true  (user pressed Enter): left untouched. It
+  //     auto-submits as the next turn via the idle-transition flush
+  //     (setInputMode → idle), since that branch fires on `queued`.
+  //   - queued === false (user only TYPED, no Enter): stays an editable
+  //     draft. The text is NOT dropped — setInputMode no longer
+  //     de-queues and never clears the buffer, so the typed characters
+  //     persist into the idle input row and simply wait for an explicit
+  //     Enter. This is the "ESC with nothing queued leaves what I typed
+  //     in the input field" behavior.
+  // We deliberately do NOT auto-queue a typed-but-unconfirmed buffer
+  // here: queuing it would fling it as a turn the user never submitted.
+  // (Ctrl+C keeps the legacy auto-queue in handleInterrupt below —
+  // hard-abort has intentionally different semantics.)
   self.softStopped = true;
   if (self.onSoftStop) self.onSoftStop();
   return true;

--- a/src/cli/terminal-compositor.input-mode.ts
+++ b/src/cli/terminal-compositor.input-mode.ts
@@ -178,53 +178,37 @@ export function setInputMode(self: InputModeHost, mode: CompositorInputMode): vo
     self.repaint();
     return;
   }
-  // Invariant: a buffer queued during or after an ESC soft-stop MUST NOT
-  // auto-flush as a phantom next turn, AND `softStopped` MUST be cleared at
-  // this first →idle transition (NOT left to persist until the next arm).
-  // `softStopped` is set only by ESC, and its ONLY function is the once-only
-  // ESC guard during streaming (handleEscape ~line 1937); in idle, ESC
-  // returns early (line ~1920) before that guard, so a lingering value has
-  // no legitimate effect. We clear the queued FLAG here (buffer text +
-  // attachments preserved) so the post-ESC draft stays visible + editable in
-  // the idle input row and waits for an explicit Enter instead of
-  // auto-submitting — a stream interruption should preserve in-progress
-  // input, not fling it as a turn the user never confirmed. This fires at
-  // the dispose→idle transition (streaming→idle).
+  // ESC soft-stop, → idle: clear the once-only `softStopped` guard (bounding
+  // its lifetime to the stopped turn) and FALL THROUGH to the queued-flush
+  // branch below. We deliberately do NOT de-queue.
   //
-  // Why clear softStopped HERE (the fix): if it persists into the idle
-  // period, it poisons the user's NEXT message. After an EMPTY-buffer ESC
-  // (the common "just stop the agent" case) `queued` stays false, so the old
-  // `&& this.queued` guard never fired and softStopped survived the dispose.
-  // The user then types a new message in the brief inter-readLine window
-  // (onSubmit not yet installed → Enter queues it); the following
-  // readLine→idle would re-enter this guard (softStopped && queued both
-  // true) and SILENTLY DE-QUEUE the message — it "looks like it sends" but
-  // no turn starts, and the user must send again (a per-stop off-by-one that
-  // reads as session-wide lag). Dropping the `&& this.queued` condition and
-  // resetting softStopped here bounds its lifetime to the stopped turn, so
-  // idle-window submissions flush normally via the branch below.
+  // Behavior (Bug B fix): a message the user typed + Entered during the ESC
+  // interrupt window AUTO-SUBMITS as the next turn — identical to normal
+  // mid-turn type-ahead — matching the user's intent ("I stopped the agent,
+  // typed a message, hit Enter: send it"). The prior design de-queued the
+  // buffer to an editable draft that required a SECOND explicit Enter, which
+  // read as "looks like it sends but no turn starts, and I have to send again."
   //
-  // Without this guard at all: session.interrupt() is deferred to the next
-  // stream event (turn-handler.ts:236 / run-skill-dispatch-turn.ts:143), so
-  // the compositor stays in streaming mode for a network-latency window. An
-  // Enter pressed in that window queues the buffer; the widened any→idle
-  // flush below then auto-fires it as an unconfirmed turn, and every message
-  // the user types during THAT turn queues in turn — a perpetual
-  // input-lag-of-one (each message submits one turn late) for the rest of
-  // the session. See terminal-compositor.test.ts soft-stop drain tests.
+  // Why this is safe now: the soft-stop handler fires session.interrupt()
+  // SYNCHRONOUSLY on ESC (turn-handler.ts / run-skill-dispatch-turn.ts), so
+  // the stream halts promptly. The "perpetual input-lag-of-one" this branch
+  // previously guarded against came from the OLD deferred-interrupt window —
+  // the compositor lingered in streaming mode for a network round-trip, so
+  // every Enter queued instead of submitting and each message landed one turn
+  // late. With the synchronous interrupt that window is gone, so auto-flushing
+  // the queued buffer is just normal sequential-turn submission, not a phantom
+  // unconfirmed turn.
   //
-  // ESC-only: Ctrl+C intentionally uses the legacy path — handleInterrupt
-  // (~line 1937) queues the buffer and fires onCancel; the widened any→idle
-  // flush below auto-submits it as the next turn. ESC preserves the draft
-  // for explicit (manual) submission; Ctrl+C auto-submits it. (see handleInterrupt ~line 1937-1957)
+  // `softStopped` is set only by ESC; its remaining roles are the second-ESC
+  // no-op (handleEscape) and the idle→streaming reset above. Clearing it here
+  // keeps an EMPTY-buffer ESC from leaving it armed into the idle period.
   if (mode === 'idle' && self.softStopped) {
-    self.queued = false;
     self.softStopped = false;
-    // Always repaint: the `[queued]` glyph must clear even on an
-    // idle→idle transition (the flush branch below repaints
-    // unconditionally for the same reason).
-    self.repaint();
-    return;
+    // No early return: fall through so a queued buffer flushes via the branch
+    // below when onSubmit is installed (readLine→idle), or — at the
+    // dispose→idle transition where onSubmit is still null — stays queued for
+    // the next readLine→idle to flush. The streaming→idle repaint at the
+    // bottom of this function clears/refreshes the frame either way.
   }
   // → idle with queued buffer + handler: flush. Widened from
   // streaming→idle to any→idle to cover the inter-readLine race

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -1300,11 +1300,10 @@ describe('TerminalCompositor', () => {
       for (const ch of 'wait') stdin.emit('keypress', ch, { name: ch, sequence: ch });
       expect(c.getBuffer()).toEqual({ text: 'wait', queued: false });
       // ESC soft-stop must mark the typed buffer queued so it survives the
-      // turn boundary (text is not dropped). Note: this is the state IMMEDIATELY
-      // after ESC; the queued flag is later cleared at the dispose→idle
-      // transition by the soft-stop drain guard (setInputMode) so the draft is
-      // preserved for EXPLICIT submission rather than auto-fired as a phantom
-      // turn — see the 'soft-stop drain' describe block below.
+      // turn boundary (text is not dropped). The queued flag is PRESERVED
+      // across the dispose→idle transition (Bug B fix: no de-queue) so the
+      // message auto-submits as the next turn at the following readLine→idle
+      // flush — see the 'soft-stop drain' describe block below.
       stdin.emit('keypress', undefined, { name: 'escape' });
       expect(onSoftStop).toHaveBeenCalledTimes(1);
       expect(c.getBuffer()).toEqual({ text: 'wait', queued: true });
@@ -1409,9 +1408,9 @@ describe('TerminalCompositor', () => {
     // ── Soft-stop drain (regression: ESC → perpetual input-lag-of-one) ──────
     //
     // Reported bug: after ESC (soft-stop), the user's next typed+Enter'd
-    // message appears to do nothing; the SUBSEQUENT message then submits the
-    // FIRST one, and every following Enter submits the PREVIOUS buffer — a
-    // perpetual off-by-one for the rest of the session.
+    // message appeared to do nothing — "it looks like it sends but no turn
+    // starts; I have to send a follow-up for it to respond to the first one,"
+    // then lag for the rest of the session.
     //
     // Root cause (two layers, both now fixed):
     //   1. session.interrupt() USED to be deferred to the next stream event,
@@ -1420,18 +1419,19 @@ describe('TerminalCompositor', () => {
     //      SYNCHRONOUSLY on ESC (turn-handler.ts / run-skill-dispatch-turn.ts),
     //      so the turn settles immediately and that window is closed at the
     //      source rather than merely survived.
-    //   2. Even within any residual window, an Enter hit the streaming queue
-    //      branch (queued=true, not fired); dispose() flipped to idle with
-    //      onSubmit still null → no flush → the buffer survived queued, and the
-    //      next readLine's widened any→idle flush auto-fired it as a phantom
-    //      turn the user never confirmed → perpetual off-by-one.
+    //   2. setInputMode's soft-stop guard USED to DE-QUEUE a buffer queued
+    //      during/after ESC — clearing the queued flag and holding the text as
+    //      an editable draft that needed a SECOND explicit Enter. That IS the
+    //      "looks like it sends but no turn starts" symptom: the user pressed
+    //      Enter, saw the echo, but no turn began.
     //
-    // Fix (defense-in-depth): setInputMode's soft-stop drain guard clears the
-    // queued FLAG (text preserved) on the first →idle transition while
-    // `softStopped` is true, so the buffer is held as an editable idle draft
-    // requiring an explicit Enter instead of auto-firing. With the synchronous
-    // interrupt above, this guard is now belt-and-suspenders rather than the
-    // sole defense.
+    // Fix (Bug B): the soft-stop guard NO LONGER de-queues. It clears the
+    // once-only `softStopped` flag (bounding its lifetime) and falls through,
+    // so a queued buffer — whether Entered during the interrupt window or
+    // preserved by handleEscape — AUTO-SUBMITS as the next turn via the widened
+    // any→idle flush, exactly like normal mid-turn type-ahead. Safe because the
+    // synchronous interrupt (layer 1) closes the window that would otherwise
+    // pile queued buffers into a perpetual off-by-one.
     //
     // Each test mirrors the production turn boundary using only the public
     // compositor API:
@@ -1440,7 +1440,7 @@ describe('TerminalCompositor', () => {
     //   readLine       → setOnSubmit(h) then setInputMode('idle')  [input-surface.ts:438,448]
     //   next turn arm  → setInputMode('streaming')         [stream-renderer.ts:352]
     describe('soft-stop drain', () => {
-      it('does NOT auto-flush a buffer typed during the interrupt window (no phantom turn)', async () => {
+      it('auto-flushes a buffer typed+Entered during the interrupt window as the next turn', async () => {
         const onSoftStop = vi.fn();
         const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop });
         await c.arm();
@@ -1458,23 +1458,18 @@ describe('TerminalCompositor', () => {
         stdin.emit('keypress', undefined, { name: 'return' });
         expect(c.getBuffer()).toEqual({ text: 'redirect', queued: true });
 
-        // dispose() flips to idle. The drain guard clears the queued flag but
-        // KEEPS the draft text — no flush (onSubmit is null here anyway).
+        // dispose() flips to idle. The soft-stop guard clears softStopped but
+        // PRESERVES the queued buffer (Bug B: no de-queue). onSubmit is null
+        // here, so no flush yet — the buffer stays queued for the next readLine.
         c.setInputMode('idle');
-        expect(c.getBuffer()).toEqual({ text: 'redirect', queued: false });
+        expect(c.getBuffer()).toEqual({ text: 'redirect', queued: true });
 
-        // readLine: install handler + setInputMode('idle'). The buffer must
-        // NOT auto-fire — softStopped is still true so the drain guard short-
-        // circuits the widened flush. The draft waits for an explicit Enter.
+        // readLine: install handler + setInputMode('idle'). softStopped was
+        // cleared at dispose, so the widened any→idle flush AUTO-SUBMITS the
+        // queued message as the next turn — no second Enter, no phantom lag.
         const onSubmit = vi.fn();
         c.setOnSubmit(onSubmit);
         c.setInputMode('idle');
-        expect(onSubmit).not.toHaveBeenCalled();
-        expect(c.getBuffer()).toEqual({ text: 'redirect', queued: false });
-
-        // Explicit Enter (idle + handler) submits the preserved draft exactly
-        // once, with its clean text.
-        stdin.emit('keypress', undefined, { name: 'return' });
         expect(onSubmit).toHaveBeenCalledTimes(1);
         expect(onSubmit).toHaveBeenCalledWith({ text: 'redirect', attachments: [] });
         expect(c.getBuffer()).toEqual({ text: '', queued: false });
@@ -1488,30 +1483,28 @@ describe('TerminalCompositor', () => {
         const submitTurn = (label: string): ReturnType<typeof vi.fn> => {
           // Turn arm.
           c.setInputMode('streaming');
-          // ESC mid-stream, then type a message + Enter during the drain.
+          // ESC mid-stream, then type a message + Enter during the interrupt window.
           stdin.emit('keypress', undefined, { name: 'escape' });
           for (const ch of label) stdin.emit('keypress', ch, { name: ch, sequence: ch });
           stdin.emit('keypress', undefined, { name: 'return' });
-          // dispose → idle (drain guard clears queued, preserves text).
-          c.setInputMode('idle');
-          // No stale text from a prior turn must remain: the buffer holds ONLY
+          // dispose → idle: softStopped cleared, queued buffer PRESERVED (no
+          // de-queue). No stale text from a prior turn: the buffer holds ONLY
           // this turn's message (regression: 'alphabeta' contamination).
-          expect(c.getBuffer()).toEqual({ text: label, queued: false });
-          // readLine: must NOT auto-fire.
+          c.setInputMode('idle');
+          expect(c.getBuffer()).toEqual({ text: label, queued: true });
+          // readLine: installing the handler + setInputMode('idle') AUTO-SUBMITS
+          // this turn's message exactly once — no second Enter, no off-by-one.
           const onSubmit = vi.fn();
           c.setOnSubmit(onSubmit);
           c.setInputMode('idle');
-          expect(onSubmit).not.toHaveBeenCalled();
-          // Explicit Enter fires exactly this message, exactly once.
-          stdin.emit('keypress', undefined, { name: 'return' });
           expect(onSubmit).toHaveBeenCalledTimes(1);
           expect(onSubmit).toHaveBeenCalledWith({ text: label, attachments: [] });
           c.setOnSubmit(null);
           return onSubmit;
         };
 
-        // Three sequential ESC-interrupted turns: each submits its OWN message
-        // on its OWN explicit Enter — no off-by-one, no accumulated stale text.
+        // Three sequential ESC-interrupted turns: each auto-submits its OWN
+        // message exactly once — no off-by-one, no accumulated stale text.
         submitTurn('alpha');
         submitTurn('beta');
         submitTurn('gamma');
@@ -1542,20 +1535,20 @@ describe('TerminalCompositor', () => {
         expect(onSubmit).toHaveBeenCalledWith({ text: 'ahead', attachments: [] });
       });
 
-      it('keeps the preserved draft editable in idle before explicit submission', async () => {
-        // Closes a coverage gap: after the drain guard preserves a draft, the
-        // user can keep editing it in idle mode; the eventual submission is the
-        // EDITED text, and editing leaves queued=false (no stale auto-flush).
+      it('keeps a typed-but-unconfirmed (no Enter) interrupt-window buffer editable in idle', async () => {
+        // A buffer typed during the interrupt window but NOT Entered stays
+        // queued=false, so it is preserved as an editable idle draft; the user
+        // can keep editing and the eventual submission is the EDITED text. Only
+        // a typed+Entered (or ESC-preserved) buffer auto-submits — see above.
         const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
         await c.arm();
         c.setInputMode('idle');
         c.setInputMode('streaming');
 
-        // ESC, then a partial message + Enter during the interrupt window.
+        // ESC (empty buffer), then a partial message WITHOUT Enter.
         stdin.emit('keypress', undefined, { name: 'escape' });
         for (const ch of 'redirec') stdin.emit('keypress', ch, { name: ch, sequence: ch });
-        stdin.emit('keypress', undefined, { name: 'return' });
-        c.setInputMode('idle'); // dispose → drain guard clears queued, keeps 'redirec'
+        c.setInputMode('idle'); // dispose → softStopped cleared; queued stays false
         expect(c.getBuffer()).toEqual({ text: 'redirec', queued: false });
 
         // readLine: handler installed, no auto-fire.
@@ -1574,30 +1567,32 @@ describe('TerminalCompositor', () => {
         expect(onSubmit).toHaveBeenCalledWith({ text: 'redirect more', attachments: [] });
       });
 
-      it('preserves a pre-ESC typed draft for explicit submission (not auto-fired)', async () => {
+      it('auto-submits a pre-ESC typed draft as the next turn (ESC-preserved buffer)', async () => {
         const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
         await c.arm();
         c.setInputMode('idle');
         c.setInputMode('streaming');
 
-        // Type a draft WITHOUT Enter, then ESC — the ESC handler marks it
-        // queued so the text survives the turn boundary.
+        // Type a draft WITHOUT Enter, then ESC — handleEscape marks it queued
+        // so the text survives the turn boundary AND auto-submits next turn
+        // (matches handleEscape's documented intent: "auto-submits it on the
+        // next turn — parity with the Ctrl+C branch").
         for (const ch of 'wait') stdin.emit('keypress', ch, { name: ch, sequence: ch });
         stdin.emit('keypress', undefined, { name: 'escape' });
         expect(c.getBuffer()).toEqual({ text: 'wait', queued: true });
 
-        // dispose → idle: drain guard clears the queued flag, keeps the draft.
+        // dispose → idle: softStopped cleared, queued buffer PRESERVED (no de-queue).
         c.setInputMode('idle');
-        expect(c.getBuffer()).toEqual({ text: 'wait', queued: false });
+        expect(c.getBuffer()).toEqual({ text: 'wait', queued: true });
 
-        // readLine: no auto-fire; the draft waits for an explicit Enter.
+        // readLine: the widened any→idle flush AUTO-SUBMITS the ESC-preserved
+        // buffer as the next turn — no explicit Enter needed.
         const onSubmit = vi.fn();
         c.setOnSubmit(onSubmit);
         c.setInputMode('idle');
-        expect(onSubmit).not.toHaveBeenCalled();
-        stdin.emit('keypress', undefined, { name: 'return' });
         expect(onSubmit).toHaveBeenCalledTimes(1);
         expect(onSubmit).toHaveBeenCalledWith({ text: 'wait', attachments: [] });
+        expect(c.getBuffer()).toEqual({ text: '', queued: false });
       });
 
       it('flushes a message typed in the idle window AFTER an empty-buffer ESC (no dropped message)', async () => {

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -1288,25 +1288,39 @@ describe('TerminalCompositor', () => {
       expect(onSoftStop).toHaveBeenCalledTimes(1);
     });
 
-    it('ESC preserves a typed-but-unsubmitted buffer as queued (regression: msg dropped on soft-stop)', async () => {
-      // Regression: the ESC soft-stop refactor (e4f9cd06) dropped the
-      // queued=true preservation the prior ESC path had. A message typed
-      // while the agent streamed was then silently lost on ESC because the
-      // next idle-transition flush requires queued===true to fire onSubmit.
+    it('ESC leaves a typed-but-unsubmitted buffer as an editable draft (queued stays false)', async () => {
+      // ESC does NOT queue a buffer the user only typed (never Entered).
+      // The text is preserved — setInputMode no longer de-queues and never
+      // clears the buffer — but queued stays false, so the next
+      // idle-transition flush does NOT auto-submit it. The user keeps
+      // editing and submits with an explicit Enter when ready. (Only an
+      // Enter-confirmed buffer auto-submits on ESC — see the idempotent
+      // test below and the 'soft-stop drain' block.)
       const onSoftStop = vi.fn();
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop });
       await c.arm();
       // Type a message mid-stream WITHOUT pressing Enter (queued stays false).
       for (const ch of 'wait') stdin.emit('keypress', ch, { name: ch, sequence: ch });
       expect(c.getBuffer()).toEqual({ text: 'wait', queued: false });
-      // ESC soft-stop must mark the typed buffer queued so it survives the
-      // turn boundary (text is not dropped). The queued flag is PRESERVED
-      // across the dispose→idle transition (Bug B fix: no de-queue) so the
-      // message auto-submits as the next turn at the following readLine→idle
-      // flush — see the 'soft-stop drain' describe block below.
       stdin.emit('keypress', undefined, { name: 'escape' });
       expect(onSoftStop).toHaveBeenCalledTimes(1);
-      expect(c.getBuffer()).toEqual({ text: 'wait', queued: true });
+      // Text preserved, but NOT queued — stays a draft for explicit submission.
+      expect(c.getBuffer()).toEqual({ text: 'wait', queued: false });
+    });
+
+    it('second ESC with a typed-but-unqueued draft is a no-op and does not disturb the draft', async () => {
+      // The once-only `softStopped` guard must hold even when a typed draft is
+      // present: a second ESC fires neither onSoftStop again nor any queue
+      // mutation, and the preserved draft is left exactly as typed.
+      const onSoftStop = vi.fn();
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop });
+      await c.arm();
+      for (const ch of 'wait') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+      stdin.emit('keypress', undefined, { name: 'escape' });
+      stdin.emit('keypress', undefined, { name: 'escape' });
+      expect(onSoftStop).toHaveBeenCalledTimes(1);
+      // Draft untouched across both presses — still typed, still not queued.
+      expect(c.getBuffer()).toEqual({ text: 'wait', queued: false });
     });
 
     it('ESC leaves an already-[queued] buffer queued (idempotent)', async () => {
@@ -1427,11 +1441,14 @@ describe('TerminalCompositor', () => {
     //
     // Fix (Bug B): the soft-stop guard NO LONGER de-queues. It clears the
     // once-only `softStopped` flag (bounding its lifetime) and falls through,
-    // so a queued buffer — whether Entered during the interrupt window or
-    // preserved by handleEscape — AUTO-SUBMITS as the next turn via the widened
-    // any→idle flush, exactly like normal mid-turn type-ahead. Safe because the
-    // synchronous interrupt (layer 1) closes the window that would otherwise
-    // pile queued buffers into a perpetual off-by-one.
+    // so an Enter-confirmed (queued) buffer AUTO-SUBMITS as the next turn via
+    // the widened any→idle flush, exactly like normal mid-turn type-ahead. A
+    // buffer the user only TYPED (never Entered) stays queued=false and is
+    // preserved as an editable draft — ESC does not auto-queue it (see
+    // handleEscape), matching "ESC with nothing queued keeps what I typed in
+    // the input field." Safe because the synchronous interrupt (layer 1) closes
+    // the window that would otherwise pile queued buffers into a perpetual
+    // off-by-one.
     //
     // Each test mirrors the production turn boundary using only the public
     // compositor API:
@@ -1539,7 +1556,7 @@ describe('TerminalCompositor', () => {
         // A buffer typed during the interrupt window but NOT Entered stays
         // queued=false, so it is preserved as an editable idle draft; the user
         // can keep editing and the eventual submission is the EDITED text. Only
-        // a typed+Entered (or ESC-preserved) buffer auto-submits — see above.
+        // a typed+Entered buffer auto-submits — see above.
         const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
         await c.arm();
         c.setInputMode('idle');
@@ -1567,32 +1584,37 @@ describe('TerminalCompositor', () => {
         expect(onSubmit).toHaveBeenCalledWith({ text: 'redirect more', attachments: [] });
       });
 
-      it('auto-submits a pre-ESC typed draft as the next turn (ESC-preserved buffer)', async () => {
+      it('keeps a pre-ESC typed draft (no Enter) editable in idle — does NOT auto-submit', async () => {
+        // Symmetric to the typed-AFTER-ESC case above: a buffer the user typed
+        // BEFORE pressing ESC, without Enter, is also preserved as an editable
+        // draft (queued=false). ESC no longer auto-queues it, so it waits for an
+        // explicit Enter instead of being flung as an unconfirmed turn. This is
+        // the "ESC with nothing queued leaves what I typed in the input" case.
         const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
         await c.arm();
         c.setInputMode('idle');
         c.setInputMode('streaming');
 
-        // Type a draft WITHOUT Enter, then ESC — handleEscape marks it queued
-        // so the text survives the turn boundary AND auto-submits next turn
-        // (matches handleEscape's documented intent: "auto-submits it on the
-        // next turn — parity with the Ctrl+C branch").
+        // Type a draft WITHOUT Enter, then ESC. handleEscape does NOT queue it.
         for (const ch of 'wait') stdin.emit('keypress', ch, { name: ch, sequence: ch });
         stdin.emit('keypress', undefined, { name: 'escape' });
-        expect(c.getBuffer()).toEqual({ text: 'wait', queued: true });
+        expect(c.getBuffer()).toEqual({ text: 'wait', queued: false });
 
-        // dispose → idle: softStopped cleared, queued buffer PRESERVED (no de-queue).
+        // dispose → idle: softStopped cleared, buffer preserved, still not queued.
         c.setInputMode('idle');
-        expect(c.getBuffer()).toEqual({ text: 'wait', queued: true });
+        expect(c.getBuffer()).toEqual({ text: 'wait', queued: false });
 
-        // readLine: the widened any→idle flush AUTO-SUBMITS the ESC-preserved
-        // buffer as the next turn — no explicit Enter needed.
+        // readLine: handler installed — NO auto-fire (queued is false).
         const onSubmit = vi.fn();
         c.setOnSubmit(onSubmit);
         c.setInputMode('idle');
+        expect(onSubmit).not.toHaveBeenCalled();
+        expect(c.getBuffer()).toEqual({ text: 'wait', queued: false });
+
+        // Explicit Enter submits the preserved draft, exactly once.
+        stdin.emit('keypress', undefined, { name: 'return' });
         expect(onSubmit).toHaveBeenCalledTimes(1);
         expect(onSubmit).toHaveBeenCalledWith({ text: 'wait', attachments: [] });
-        expect(c.getBuffer()).toEqual({ text: '', queued: false });
       });
 
       it('flushes a message typed in the idle window AFTER an empty-buffer ESC (no dropped message)', async () => {

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -1332,6 +1332,72 @@ describe('TerminalCompositor', () => {
       expect(c.getBuffer()).toEqual({ text: '', queued: false });
     });
 
+    // ── h1 regression: ESC with an open autocomplete dropdown ──────────────
+    //
+    // Bug: while the agent streamed, ghost-text / slash autocomplete frequently
+    // left `dropdownOpen === true`. handleEscape's dropdown-dismiss branch
+    // returned EARLY, so the first ESC closed the dropdown but never reached
+    // the soft-stop path — the user had to press ESC TWICE to stop the agent
+    // ("double-press to cancel"). Fix (input-dispatch.ts): the dropdown-dismiss
+    // branch no longer returns; it falls through so a single ESC both closes
+    // the dropdown AND fires onSoftStop in streaming mode, while the idle-mode
+    // guard on the next line keeps ESC a pure UI-dismissal between turns.
+    it('single ESC fires onSoftStop AND dismisses an open dropdown mid-stream (h1)', async () => {
+      resetSlashRegistry();
+      registerSlashCommand({
+        name: '/render-test',
+        summary: 'Stub to open the slash dropdown',
+        handler: async () => ({ kind: 'noop' as const }),
+      });
+      try {
+        const ac = createAutocompleteState();
+        const onSoftStop = vi.fn();
+        const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop, autocompleteState: ac });
+        await c.arm();
+        c.setInputMode('streaming'); // a turn is live
+
+        // Type '/' → updateAutocomplete opens the slash dropdown (earned via a
+        // real keystroke, not mutation) — mirrors ghost-text open mid-stream.
+        stdin.emit('keypress', '/', { name: '/', sequence: '/' });
+        expect(ac.dropdownOpen).toBe(true);
+
+        // A SINGLE ESC must both dismiss the dropdown AND fire soft-stop —
+        // pre-fix this required two presses.
+        stdin.emit('keypress', undefined, { name: 'escape' });
+        expect(ac.dropdownOpen).toBe(false);
+        expect(onSoftStop).toHaveBeenCalledTimes(1);
+      } finally {
+        resetSlashRegistry();
+      }
+    });
+
+    it('ESC with an open dropdown stays a pure UI-dismissal in idle mode — no soft-stop (h1)', async () => {
+      resetSlashRegistry();
+      registerSlashCommand({
+        name: '/render-test',
+        summary: 'Stub to open the slash dropdown',
+        handler: async () => ({ kind: 'noop' as const }),
+      });
+      try {
+        const ac = createAutocompleteState();
+        const onSoftStop = vi.fn();
+        const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop, autocompleteState: ac });
+        await c.arm();
+        c.setInputMode('idle'); // between turns — NOT streaming
+
+        stdin.emit('keypress', '/', { name: '/', sequence: '/' });
+        expect(ac.dropdownOpen).toBe(true);
+
+        // ESC dismisses the dropdown, but the idle-mode guard suppresses
+        // soft-stop (no live turn to stop). The fall-through must not change this.
+        stdin.emit('keypress', undefined, { name: 'escape' });
+        expect(ac.dropdownOpen).toBe(false);
+        expect(onSoftStop).not.toHaveBeenCalled();
+      } finally {
+        resetSlashRegistry();
+      }
+    });
+
     it('Ctrl+C triggers onCancel', async () => {
       const onCancel = vi.fn();
       const c = new TerminalCompositor({ stdout, stdin, onCancel });
@@ -1347,19 +1413,25 @@ describe('TerminalCompositor', () => {
     // FIRST one, and every following Enter submits the PREVIOUS buffer — a
     // perpetual off-by-one for the rest of the session.
     //
-    // Root cause: session.interrupt() is deferred to the next stream event
-    // (turn-handler.ts:236), so the compositor stays in streaming mode for a
-    // network-latency window after ESC. An Enter pressed in that window hits
-    // the streaming queue branch (queued=true, not fired). dispose() flips to
-    // idle with onSubmit still null → no flush → the buffer survives queued.
-    // The next readLine's widened any→idle flush then auto-fires it as a
-    // phantom turn the user never confirmed; messages typed during that turn
-    // queue in turn → perpetual lag.
+    // Root cause (two layers, both now fixed):
+    //   1. session.interrupt() USED to be deferred to the next stream event,
+    //      so the compositor lingered in streaming mode for a network-latency
+    //      window after ESC. The soft-stop handler now calls interrupt()
+    //      SYNCHRONOUSLY on ESC (turn-handler.ts / run-skill-dispatch-turn.ts),
+    //      so the turn settles immediately and that window is closed at the
+    //      source rather than merely survived.
+    //   2. Even within any residual window, an Enter hit the streaming queue
+    //      branch (queued=true, not fired); dispose() flipped to idle with
+    //      onSubmit still null → no flush → the buffer survived queued, and the
+    //      next readLine's widened any→idle flush auto-fired it as a phantom
+    //      turn the user never confirmed → perpetual off-by-one.
     //
-    // Fix: setInputMode's soft-stop drain guard clears the queued FLAG (text
-    // preserved) on the first →idle transition while `softStopped` is true, so
-    // the buffer is held as an editable idle draft requiring an explicit Enter
-    // instead of auto-firing.
+    // Fix (defense-in-depth): setInputMode's soft-stop drain guard clears the
+    // queued FLAG (text preserved) on the first →idle transition while
+    // `softStopped` is true, so the buffer is held as an editable idle draft
+    // requiring an explicit Enter instead of auto-firing. With the synchronous
+    // interrupt above, this guard is now belt-and-suspenders rather than the
+    // sole defense.
     //
     // Each test mirrors the production turn boundary using only the public
     // compositor API:

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -1419,6 +1419,36 @@ describe('TerminalCompositor', () => {
       expect(onCancel).toHaveBeenCalledTimes(1);
     });
 
+    it('Ctrl+C does NOT auto-queue a typed-but-unconfirmed buffer (preserved as a draft, parity with ESC)', async () => {
+      // Ctrl+C is now a graceful soft-stop (the REPL handleSigint fires the
+      // same soft-stop ESC does). Like ESC, it must NOT auto-queue a buffer
+      // the user only typed (never Entered): the text stays an editable draft
+      // (queued=false) instead of being flung as a turn the user never
+      // submitted. onCancel still fires (handleSigint owns stop/exit dispatch).
+      const onCancel = vi.fn();
+      const c = new TerminalCompositor({ stdout, stdin, onCancel });
+      await c.arm();
+      for (const ch of 'wait') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+      expect(c.getBuffer()).toEqual({ text: 'wait', queued: false });
+      stdin.emit('keypress', undefined, { name: 'c', ctrl: true });
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      // Draft preserved, NOT auto-queued.
+      expect(c.getBuffer()).toEqual({ text: 'wait', queued: false });
+    });
+
+    it('a second Ctrl+C within one streaming turn is swallowed by the once-only guard', async () => {
+      // The compositor fires onCancel once per streaming turn; the SECOND
+      // quit-press lands in idle (the turn ends on the soft-stop interrupt),
+      // where handleSigint's exit-window check quits. This guard only stops a
+      // burst of presses INSIDE one turn from firing onCancel repeatedly.
+      const onCancel = vi.fn();
+      const c = new TerminalCompositor({ stdout, stdin, onCancel });
+      await c.arm();
+      stdin.emit('keypress', undefined, { name: 'c', ctrl: true });
+      stdin.emit('keypress', undefined, { name: 'c', ctrl: true });
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
     // ── Soft-stop drain (regression: ESC → perpetual input-lag-of-one) ──────
     //
     // Reported bug: after ESC (soft-stop), the user's next typed+Enter'd


### PR DESCRIPTION
## Summary

Fixes ESC-to-cancel (REPL soft-stop), which had **three compounding root causes** that together made cancellation unreliable, dropped the user's next message, and degraded the rest of the session:

- **Double-press to cancel.** `handleEscape`'s dropdown-dismiss branch `return`ed early, so the first ESC was swallowed whenever the autocomplete dropdown was open — which it almost always is mid-stream (ghost-text repopulates on nearly every keystroke). ESC now falls through to the soft-stop path after dismissing the dropdown; the idle-mode and once-only guards still hold. (`src/cli/terminal-compositor.input-dispatch.ts`)
- **ESC unresponsive during long tool calls.** The soft-stop handler only set a flag; `session.interrupt()` was deferred into the stream `for-await` loop, so during a long tool call (loop blocked awaiting the next event) ESC did nothing until the next token arrived, and the compositor lingered in streaming mode. `interrupt()` now fires synchronously in the handler (it is idempotent — `AgentSession.interrupt()` early-returns once state leaves `streaming`/`processing`), and the loop just `break`s. The same fix is applied to the `/skill` dispatch turn path (`src/cli/slash/_lib/run-skill-dispatch-turn.ts`).
- **"Looks like it sends but no turn starts" (the session-wide lag).** The `setInputMode` soft-stop drain guard *de-queued* a message the user typed + Entered during the ESC interrupt window — clearing the queued flag and holding the text as a draft that required a **second** explicit Enter. That is the user's exact report: "I send a message, it looks like it sends, but the agent's turn doesn't start; I have to send a follow-up for it to respond to the first one." The guard no longer de-queues: a queued buffer now **auto-submits** as the next turn, identical to normal mid-turn type-ahead. Safe specifically because of the synchronous-interrupt fix above, which closes the deferred-interrupt window that previously could pile queued buffers into a perpetual off-by-one. (`src/cli/terminal-compositor.input-mode.ts`)

> An earlier pass concluded this third case needed no change (the drain guard "already handled it"). A follow-up `/diagnose` re-derived it from the user's report and confirmed the de-queue **was** the dropped-message symptom; reversing it to auto-submit is the fix. The 5 soft-stop tests that pinned the old draft-preservation semantics were updated to assert auto-submit (a typed-but-**not**-Entered interrupt-window buffer still stays an editable draft).

## Update — commit `c42cd1c`: only **Enter-confirmed** buffers auto-submit on ESC

Resolves the "Known follow-up" below. After the auto-submit reversal, a buffer the user had only **typed** (never pressed Enter) and then ESC'd was *also* being flung as an unconfirmed turn — because `handleEscape` auto-queued any non-empty buffer. `handleEscape` no longer touches the `queued` flag: **Enter is the only queue trigger.** The ESC soft-stop contract is now:

| While the agent streams… | ESC result |
|---|---|
| Typed **+ Enter** (queued) | Queued message **auto-submits** as the next turn |
| Typed, **no Enter** (nothing queued) | Text **stays in the input field** as an editable draft; waits for an explicit Enter |
| **Empty** input | Just stops the agent |

The typed-but-unconfirmed text is **not dropped**: `setInputMode` no longer de-queues and never clears the buffer when `queued === false` (it is cleared *only* in the `queued && onSubmit` flush branch), so the characters persist into the idle input row. `Ctrl+C` (hard-abort) intentionally keeps its legacy auto-queue — unchanged, documented in the `handleEscape` comment. (`src/cli/terminal-compositor.input-dispatch.ts`)

Tests: the typed-but-unsubmitted ESC assertion flipped to `queued: false`; the pre-ESC-typed-draft test rewritten to assert preserve-not-auto-submit (symmetric to the existing typed-*after*-ESC case); added a double-ESC-with-typed-draft no-op guard. An independent read-only `/review` traced the no-dropped-message claim through `setInputMode` and returned **MERGE** (no critical/high findings).

## Update — commit `1191272`: Ctrl+C once = ESC soft-stop, twice = exit

Unifies the two interrupt keys. A single Ctrl+C during a turn now stops as gracefully as ESC (keeps completed work, preserves the typed draft); a second Ctrl+C within the existing exit window quits. Previously the first Ctrl+C was a bare interrupt that auto-queued the buffer and showed "⚠ Interrupted", diverging from ESC's soft-stop.

| Key | Result |
|---|---|
| **Ctrl+C** during a turn | Soft-stop — identical to ESC: stop cleanly, keep work, preserve the typed draft. Shows "⏸ Stopped — work so far kept…" + "ℹ Press Ctrl+C again to exit." |
| **Ctrl+C again** (within `SIGINT_EXIT_WINDOW_MS`) | Exits the REPL |
| **Ctrl+C** in idle | Arms "press again to quit"; second press exits (unchanged) |
| **ESC** | Unchanged — still does **not** arm the exit window |

How: `handleSigint`'s in-turn branch now fires the **same** soft-stop closure ESC uses (`turnState.requestSoftStop` → `softStopRequested` + interrupt), so the turn handler renders "⏸ Stopped — work so far kept" and skips `recordTurn` exactly as ESC does (falls back to a bare interrupt if no handler is published). The compositor's Ctrl+C branch no longer auto-queues a typed-but-unconfirmed buffer (parity with ESC); the once-only `canceled` guard stays as an accidental-double-tap safety. The exit-window logic (2nd press → `rl.close`) is unchanged. `requestSoftStop` is published via an `installSoftStop` helper wired at **both** soft-stop install sites (normal turn + `/skill` dispatch) and cleared between turns.

Tests: +compositor (Ctrl+C preserves a typed-but-unconfirmed draft; a second in-turn press is swallowed by the once-only guard) and +repl-loop-wiring (`setSoftStopHandler` publishes/clears `turnState.requestSoftStop`). `handleSigint` is an inline closure (not directly unit-tested) — its seams are covered (the soft-stop closure is the ESC-tested one; the exit-window path is unchanged) but the end-to-end once/twice timing is best confirmed in a live TTY.

## Triple-echo render — investigated, no rendering change

The user also reported their submitted message rendering 3× (two truncated copies at the top + one full copy). Byte-stream analysis of `repositionCommittedBand` proved its shrink-pad re-paint is **benign** — a same-row sequential write (`blank → echo → blank → echo`) that ends at exactly one un-erased row, **not** visible duplication at multiple rows. A speculative fix there broke 7 band-repin regression tests, confirming the re-paint is load-bearing. The visible triplication was an artifact of the old **de-queue → preserve → re-submit** transition dance (extra repaints + a second echo commit) that the auto-submit fix removes. Added `src/cli/terminal-compositor.committed-band-single-copy.test.ts` (3 tests, byte-stream verified) as a regression guard for the single-copy invariant.

## Test results

- `pnpm lint` (`tsc --noEmit`, strict): **pass**
- `pnpm test` (committed suite, at `1191272`): **469 files, 8783 passed, 12 skipped, 0 failures**
- Regression coverage: single ESC with an open dropdown fires soft-stop **and** dismisses it; idle-mode ESC stays a pure UI-dismissal; an Enter-confirmed ESC buffer auto-submits while a typed-but-unconfirmed one stays an editable draft (typed-before-ESC and typed-after-ESC both covered); double-ESC with a typed draft is a no-op that leaves the draft intact; Ctrl+C preserves a typed-but-unconfirmed draft (no auto-queue) and a second in-turn Ctrl+C is swallowed by the once-only guard; `setSoftStopHandler` publishes/clears `turnState.requestSoftStop`; committed-band single-copy invariant (3 byte-stream tests).

## Verification

Adversarial verifier wave (`--verify`) independently re-derived the load-bearing claims from the diff/source alone:

- **CLAIM 1 — CONFIRM:** dropdown branch no longer returns early; idle + `softStopped` guards still hold (`input-dispatch.ts:247–282`).
- **CLAIM 2 — CONFIRM:** `interrupt()` is idempotent (`agent-session.ts:567`); `softStopRequested` is written only in the handler, so the removed loop-interrupt was provably redundant (`turn-handler.ts:203`, `run-skill-dispatch-turn.ts:133`).
- **CLAIM 3 — CONFIRM:** post-stream `recordTurn`/notice block unchanged; normal (no-ESC) turns unaffected (`turn-handler.ts:469–481`).
- **CLAIM 4 (auto-submit) — covered by suite:** the soft-stop drain branch clears `softStopped` and falls through to the widened any→idle flush; full suite + lint green.
- **OVERALL: SHIP.**

## Notes

> ⚠️ This PR targets the **public mirror** (`griffinwork40/agent-afk`). Under the two-repo model, canonical dev lives in the private `afk-workshop` and the public mirror is re-sanitized from it on refresh. To avoid this fix being clobbered on the next refresh, it should also land in `afk-workshop` (e.g. via the port workflow). All commits are **moat-clean** — TUI/REPL code only (`input-dispatch.ts`, `input-mode.ts`, `turn-handler.ts`, `run-skill-dispatch-turn.ts`, `interactive.ts`, `repl-loop.ts` + tests), no forge/qualify/eval/threads content.

> ~~Known follow-up (low priority): with the auto-submit reversal, a buffer typed **without** Enter and then ESC'd also auto-submits... If only Enter-confirmed buffers should auto-submit, that's a one-line `handleEscape` change.~~ **✅ Resolved in `c42cd1c`** — see the *Update* section above; only Enter-confirmed buffers auto-submit, typed-but-unconfirmed buffers stay editable drafts.
>
> Still pending: triplication-gone should be confirmed in a live TTY — the headless harness can't reproduce real frame-stranding/flush timing.


