### PR TITLE
feat(browser): return browser_screenshot as a model-visible image

### DIFF
--- a/src/agent/providers/anthropic-direct/loop.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.test.ts
@@ -415,6 +415,67 @@ describe('loop.ts runTurn', () => {
     }
   });
 
+  // A ToolResult carrying `image` (e.g. browser_screenshot) must be emitted as
+  // an image content block + text block in the model-facing tool_result.
+  it('emits a tool image as an image content block in the tool_result', async () => {
+    let callIdx = 0;
+    const client = makeClient(() => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        return fromArray(makeToolUseStream('toolu_shot', 'browser_screenshot', '{}'));
+      }
+      return fromArray(makeTextStream('done'));
+    });
+
+    const dispatcher = makeDispatcher(async () => ({
+      content: '{"path":"/x.png","width":1280,"height":800}',
+      image: { mediaType: 'image/png' as const, data: 'QUJDREVG' },
+    }));
+
+    const messages: MessageParam[] = [{ role: 'user', content: 'shot' }];
+    const abortController = new AbortController();
+
+    await collect(
+      runTurn({
+        client,
+        messages,
+        system: null,
+        tools: [{ name: 'browser_screenshot', input_schema: { type: 'object' } }],
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 1024,
+        headers: {},
+        signal: abortController.signal,
+        ctx,
+      }),
+    );
+
+    // Locate the user turn carrying tool_result blocks (runTurn appends it).
+    const toolResultTurn = messages.find(
+      (m) =>
+        m.role === 'user' &&
+        Array.isArray(m.content) &&
+        m.content.some(
+          (b) => typeof b === 'object' && b !== null && (b as { type?: string }).type === 'tool_result',
+        ),
+    );
+    expect(toolResultTurn).toBeDefined();
+
+    const blocks = toolResultTurn!.content as Array<{ type: string; content: unknown }>;
+    const trBlock = blocks.find((b) => b.type === 'tool_result')!;
+    // content is an array: [image block, text block] — not a bare string.
+    expect(Array.isArray(trBlock.content)).toBe(true);
+    const parts = trBlock.content as Array<Record<string, unknown>>;
+    expect(parts[0]).toMatchObject({
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'QUJDREVG' },
+    });
+    expect(parts[1]).toMatchObject({
+      type: 'text',
+      text: '{"path":"/x.png","width":1280,"height":800}',
+    });
+  });
+
   // covers lines 255-263: batch dispatch with executeBatch
   it('uses executeBatch when provided on the dispatcher', async () => {
     let callIdx = 0;

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -643,12 +643,33 @@ export async function* runTurn(
       // Destructure only the model-facing fields so `result.render` is
       // structurally unreachable at this call site — not merely excluded by
       // convention. This makes the isolation load-bearing rather than
-      // documentation-only.
-      const { content: resultContent, isError: resultIsError } = result;
+      // documentation-only. `image` is the ONE structured field that IS
+      // model-facing: when set it becomes an `image` content block alongside
+      // the text. `render` remains excluded.
+      const { content: resultContent, isError: resultIsError, image: resultImage } = result;
+      // When a tool returns an image (e.g. browser_screenshot), emit it as an
+      // image block followed by the text summary. The handler keeps the text
+      // non-empty so providers that drop the image still see useful context.
+      const toolResultContent: ToolResultBlockParam['content'] =
+        resultImage !== undefined
+          ? [
+              {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  media_type: resultImage.mediaType,
+                  data: resultImage.data,
+                },
+              },
+              ...(resultContent.length > 0
+                ? [{ type: 'text' as const, text: resultContent }]
+                : []),
+            ]
+          : resultContent;
       toolResultBlocks.push({
         type: 'tool_result',
         tool_use_id: call.id,
-        content: resultContent,
+        content: toolResultContent,
         ...(resultIsError === true ? { is_error: true } : {}),
       });
     }

--- a/src/agent/providers/anthropic-direct/types.ts
+++ b/src/agent/providers/anthropic-direct/types.ts
@@ -103,6 +103,23 @@ export interface ToolResult {
    * Never forwarded to the model — render-only metadata.
    */
   testResult?: import('../../tools/handlers/test-runner-detector.js').TestResult;
+  /**
+   * Optional image to surface to the model as part of the `tool_result`.
+   *
+   * Unlike `render` (deliberately kept OUT of the model-facing block), `image`
+   * IS model-facing: the anthropic-direct loop emits it as an `image` content
+   * block alongside the `content` text. Set by tools that produce pixels the
+   * model should read visually (e.g. browser_screenshot).
+   *
+   * `data` is base64-encoded raw bytes (no `data:` URI prefix). Providers that
+   * cannot represent images in a tool result (OpenAI `role:'tool'`) ignore
+   * this field and degrade to text-only — so `content` must still carry a
+   * useful textual summary (path, dimensions) on its own.
+   */
+  image?: {
+    mediaType: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
+    data: string;
+  };
 }
 
 /**

--- a/src/agent/providers/openai-compatible/loop.ts
+++ b/src/agent/providers/openai-compatible/loop.ts
@@ -147,6 +147,11 @@ export interface OpenAIToolResultMessage {
 export function toolResultsToMessages(
   results: readonly { call: ToolCall; result: ToolResult }[],
 ): OpenAIToolResultMessage[] {
+  // NOTE: `result.image` (set by e.g. browser_screenshot) is intentionally
+  // dropped here. The OpenAI Chat Completions `role:'tool'` message cannot
+  // carry image content — images must ride a separate `role:'user'` message.
+  // We degrade to text-only; `content` still carries the path/dimensions
+  // summary. Proper vision support for tool-result images is a future follow-up.
   return results.map(({ call, result }) => ({
     role: 'tool',
     tool_call_id: call.id,

--- a/src/agent/tools/handlers/browser-screenshot.test.ts
+++ b/src/agent/tools/handlers/browser-screenshot.test.ts
@@ -195,6 +195,66 @@ describe('browser_screenshot handler — happy path', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Dimension guard (Anthropic 8000px vision limit)
+// ---------------------------------------------------------------------------
+
+describe('browser_screenshot handler — dimension guard', () => {
+  it('drops the image (text-only) when height exceeds 8000px, without erroring', async () => {
+    // A tall full_page screenshot: well under the 5 MiB byte cap, but its
+    // pixel height blows past Anthropic's 8000px limit — attaching it would
+    // 400 the request and poison message history.
+    const result = makeScreenshotResult({ width: 1280, height: 20000, dataBase64: 'QUJDREVG' });
+    const provider = makeProvider({ screenshot: vi.fn().mockResolvedValue(result) });
+    const handler = createBrowserScreenshotHandler({ getBrowserProvider: vi.fn().mockResolvedValue(provider) });
+
+    const r = await handler({ full_page: true }, makeSignal());
+
+    // Graceful text-only degradation — NOT an error.
+    expect(r.isError).toBeUndefined();
+    expect(r.image).toBeUndefined();
+    // The model still gets dimensions + a legible reason, and never the base64.
+    const parsed = JSON.parse(r.content as string) as { width: number; height: number; imageOmitted?: string };
+    expect(parsed.width).toBe(1280);
+    expect(parsed.height).toBe(20000);
+    expect(parsed.imageOmitted).toMatch(/8000px model-vision limit/);
+    expect(r.content).not.toContain('QUJDREVG');
+  });
+
+  it('drops the image when width exceeds 8000px', async () => {
+    const result = makeScreenshotResult({ width: 9000, height: 800 });
+    const provider = makeProvider({ screenshot: vi.fn().mockResolvedValue(result) });
+    const handler = createBrowserScreenshotHandler({ getBrowserProvider: vi.fn().mockResolvedValue(provider) });
+
+    const r = await handler({}, makeSignal());
+
+    expect(r.isError).toBeUndefined();
+    expect(r.image).toBeUndefined();
+  });
+
+  it('attaches the image at exactly 8000x8000 (boundary is inclusive)', async () => {
+    const result = makeScreenshotResult({ width: 8000, height: 8000, dataBase64: 'QUJDREVG' });
+    const provider = makeProvider({ screenshot: vi.fn().mockResolvedValue(result) });
+    const handler = createBrowserScreenshotHandler({ getBrowserProvider: vi.fn().mockResolvedValue(provider) });
+
+    const r = await handler({ full_page: true }, makeSignal());
+
+    expect(r.isError).toBeUndefined();
+    expect(r.image).toEqual({ mediaType: 'image/png', data: 'QUJDREVG' });
+  });
+
+  it('drops the image one pixel over the limit (8001px)', async () => {
+    const result = makeScreenshotResult({ width: 8001, height: 800 });
+    const provider = makeProvider({ screenshot: vi.fn().mockResolvedValue(result) });
+    const handler = createBrowserScreenshotHandler({ getBrowserProvider: vi.fn().mockResolvedValue(provider) });
+
+    const r = await handler({ full_page: true }, makeSignal());
+
+    expect(r.isError).toBeUndefined();
+    expect(r.image).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Provider errors
 // ---------------------------------------------------------------------------
 

--- a/src/agent/tools/handlers/browser-screenshot.test.ts
+++ b/src/agent/tools/handlers/browser-screenshot.test.ts
@@ -24,6 +24,10 @@ function makeScreenshotResult(overrides: Partial<ScreenshotResult> = {}): Screen
     bytes: 42000,
     width: 1280,
     height: 800,
+    // 1x1 transparent PNG — realistic base64 the provider would return.
+    dataBase64:
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+    mediaType: 'image/png',
     ...overrides,
   };
 }
@@ -118,7 +122,7 @@ describe('browser_screenshot handler — happy path', () => {
     provider = makeProvider();
   });
 
-  it('returns JSON screenshot result', async () => {
+  it('returns JSON screenshot metadata with no base64 in the text content', async () => {
     const result = makeScreenshotResult({ bytes: 99000, width: 1920, height: 1080 });
     vi.mocked(provider.screenshot).mockResolvedValue(result);
 
@@ -130,6 +134,24 @@ describe('browser_screenshot handler — happy path', () => {
     expect(parsed.bytes).toBe(99000);
     expect(parsed.width).toBe(1920);
     expect(parsed.height).toBe(1080);
+    // The base64 payload + its key must NEVER appear in the text the model
+    // reads — it rides on the `image` field instead.
+    expect(r.content).not.toContain('dataBase64');
+    expect(r.content).not.toContain(result.dataBase64);
+  });
+
+  it('surfaces the screenshot as a model-visible image block', async () => {
+    const result = makeScreenshotResult({ dataBase64: 'QUJDREVG', mediaType: 'image/png' });
+    vi.mocked(provider.screenshot).mockResolvedValue(result);
+
+    const handler = createBrowserScreenshotHandler({ getBrowserProvider: vi.fn().mockResolvedValue(provider) });
+    const r = await handler({}, makeSignal());
+
+    expect(r.isError).toBeUndefined();
+    // Pixels ride on the `image` field; the anthropic-direct loop emits it as
+    // an image content block alongside the text metadata.
+    expect(r.image).toEqual({ mediaType: 'image/png', data: 'QUJDREVG' });
+    expect(r.content).not.toContain('QUJDREVG');
   });
 
   it('passes fullPage through to provider.screenshot', async () => {

--- a/src/agent/tools/handlers/browser-screenshot.ts
+++ b/src/agent/tools/handlers/browser-screenshot.ts
@@ -28,6 +28,12 @@ import { isPlaywrightMissing, playwrightMissingHint } from './playwright-hints.j
 
 const VALID_TARGET_KINDS = ['semantic', 'element_id', 'selector'] as const;
 
+// Invariant: Anthropic's vision API hard-rejects any image whose width OR
+// height exceeds 8000px (docs: "Build with Claude › Vision › General limits").
+// This is a pixel ceiling independent of byte size — enforced here, not in the
+// provider, because the provider is model-agnostic and this is a model limit.
+const MAX_IMAGE_DIMENSION = 8000;
+
 interface ParsedScreenshotInput {
   target?: Target;
   fullPage?: boolean;
@@ -146,6 +152,24 @@ export function createBrowserScreenshotHandler(opts: BrowserHandlerOptions = {})
       // image content block; the text carries only the metadata so providers
       // that can't render tool-result images still get the path/dimensions.
       const { dataBase64, mediaType, ...meta } = screenshotResult;
+      // Dimension guard. A full_page screenshot of a tall page can stay under
+      // the 5 MiB sidecar byte cap yet exceed Anthropic's 8000px pixel limit.
+      // Attaching it would 400 the request AND leave a poison image block in
+      // message history that re-fails every subsequent turn. So degrade to
+      // text-only (omit `image`) — NOT an error: the model still gets the path,
+      // byte size, dimensions, and a reason, mirroring the byte-cap fallback.
+      if (meta.width > MAX_IMAGE_DIMENSION || meta.height > MAX_IMAGE_DIMENSION) {
+        return {
+          content: JSON.stringify(
+            {
+              ...meta,
+              imageOmitted: `dimensions ${meta.width}x${meta.height}px exceed the ${MAX_IMAGE_DIMENSION}px model-vision limit; the PNG was saved to the sidecar path but not attached. Use full_page:false (viewport) or target a specific element for a model-visible image.`,
+            },
+            null,
+            2,
+          ),
+        };
+      }
       return {
         content: JSON.stringify(meta, null, 2),
         image: { mediaType, data: dataBase64 },

--- a/src/agent/tools/handlers/browser-screenshot.ts
+++ b/src/agent/tools/handlers/browser-screenshot.ts
@@ -140,7 +140,16 @@ export function createBrowserScreenshotHandler(opts: BrowserHandlerOptions = {})
         target: parsed.target,
         fullPage: parsed.fullPage,
       });
-      return { content: JSON.stringify(screenshotResult, null, 2) };
+      // Keep the base64 image bytes OUT of the text content — `dataBase64` is
+      // megabytes of base64 the model must never see as text. The pixels ride
+      // on the `image` field, which the anthropic-direct provider emits as an
+      // image content block; the text carries only the metadata so providers
+      // that can't render tool-result images still get the path/dimensions.
+      const { dataBase64, mediaType, ...meta } = screenshotResult;
+      return {
+        content: JSON.stringify(meta, null, 2),
+        image: { mediaType, data: dataBase64 },
+      };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       return { content: `browser_screenshot failed: ${msg}`, isError: true };

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -901,11 +901,15 @@ export const browserScreenshotTool: AnthropicToolDef = {
   category: 'browser',
   concurrencySafe: true,
   description:
-    'Capture a PNG screenshot of the current page (or a specific element). Returns ' +
-    '`{ path, bytes, width, height }` as JSON. The PNG is written as a sidecar under ' +
-    '`~/.afk/state/witness/<sessionId>/browser/screenshots/` and referenced from the ' +
-    'corresponding witness trace event. Use after a `browser_act` to visually ' +
-    'confirm the result, or to inspect an element that\'s hard to describe in text.',
+    'Capture a PNG screenshot of the current page (or a specific element) and return ' +
+    'it as a viewable image attached to the tool result — you can read it directly. ' +
+    'Call this whenever you need to SEE the page (visual layout, rendering, charts, ' +
+    'or anything hard to read from DOM text). The text portion of the result is ' +
+    '`{ path, bytes, width, height }` as JSON; the same PNG is also written as a sidecar ' +
+    'under `~/.afk/state/witness/<sessionId>/browser/screenshots/` and referenced from ' +
+    'the witness trace event. Use after a `browser_act` to visually confirm the result, ' +
+    'or to inspect an element that\'s hard to describe in text. (Image return works on ' +
+    'Anthropic models; OpenAI-compatible providers receive the text metadata only.)',
   input_schema: {
     type: 'object',
     properties: {

--- a/src/browser/playwright/index.test.ts
+++ b/src/browser/playwright/index.test.ts
@@ -607,6 +607,21 @@ describe('describe()', () => {
 // extract() tests
 // ---------------------------------------------------------------------------
 
+describe('screenshot()', () => {
+  it('returns metadata plus base64-encoded PNG bytes for the model', async () => {
+    const provider = makeProvider();
+    const result = await provider.screenshot({ sessionId: 'sess1' });
+
+    expect(result.path).toBe('/fake/screenshot.png');
+    expect(result.bytes).toBe(100);
+    expect(result.width).toBe(1280);
+    expect(result.height).toBe(800);
+    // dataBase64 is the base64 encoding of the raw PNG buffer the page returned.
+    expect(result.dataBase64).toBe(Buffer.from('PNG').toString('base64'));
+    expect(result.mediaType).toBe('image/png');
+  });
+});
+
 describe('extract()', () => {
   it('throws Error with Phase 1 not-implemented message', async () => {
     const provider = makeProvider();

--- a/src/browser/playwright/index.ts
+++ b/src/browser/playwright/index.ts
@@ -430,9 +430,12 @@ export class PlaywrightProvider implements BrowserProvider {
       bytes,
       width,
       height,
-      // Raw PNG bytes for the model to read visually. The 5 MiB sidecar cap
-      // in writeScreenshotSidecar() (called above) already bounded `buf`, so
-      // the encoded payload stays within reason for the Messages API.
+      // Raw PNG bytes for the model to read visually. The 5 MiB sidecar cap in
+      // writeScreenshotSidecar() (called above) already bounded `buf` — under
+      // the direct Messages API's 10 MB base64 ceiling (note: Bedrock/Vertex
+      // cap tighter at 5 MB base64). The orthogonal 8000px pixel limit is
+      // enforced in the browser_screenshot handler, which falls back to
+      // text-only when width/height exceed it: bytes bounded here, pixels there.
       dataBase64: buf.toString('base64'),
       mediaType: 'image/png',
     };

--- a/src/browser/playwright/index.ts
+++ b/src/browser/playwright/index.ts
@@ -425,7 +425,17 @@ export class PlaywrightProvider implements BrowserProvider {
       height = vp?.height ?? 0;
     }
 
-    return { path, bytes, width, height };
+    return {
+      path,
+      bytes,
+      width,
+      height,
+      // Raw PNG bytes for the model to read visually. The 5 MiB sidecar cap
+      // in writeScreenshotSidecar() (called above) already bounded `buf`, so
+      // the encoded payload stays within reason for the Messages API.
+      dataBase64: buf.toString('base64'),
+      mediaType: 'image/png',
+    };
   }
 
   // -------------------------------------------------------------------------

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -287,6 +287,18 @@ export interface ScreenshotResult {
   bytes: number;
   width: number;
   height: number;
+  /**
+   * Base64-encoded raw image bytes (no `data:` URI prefix). Carried
+   * separately from the witness sidecar so the tool handler can hand the
+   * pixels to the model as an image content block.
+   *
+   * Invariant: NEVER embed this in any text/JSON the model sees — it is
+   * megabytes of base64. The `browser_screenshot` handler maps it onto
+   * `ToolResult.image` and keeps it out of `content`.
+   */
+  dataBase64: string;
+  /** Media type of `dataBase64`. Playwright captures PNG. */
+  mediaType: 'image/png';
 }
 
 export interface ExtractResult {


### PR DESCRIPTION
## Problem

`browser_screenshot` was **write-only**: it persisted a PNG sidecar under the witness dir and returned only `{ path, bytes, width, height }` JSON. The model never received the pixels, so it would give up on visual tasks — literally: *"I can't visually read screenshots (they're saved for you, not returned to me)."*

The Anthropic Messages API already supports image blocks inside `tool_result.content`; the harness just never built one.

## Change

- **`ToolResult.image`** (optional) added in `anthropic-direct/types.ts` — the one structured field that IS model-facing (unlike `render`, which is deliberately kept out of the model block).
- **anthropic-direct loop** (`loop.ts`): when `image` is set, the `tool_result` content becomes an `[image, text]` block array instead of a bare string. Built via the existing `ToolResultBlockParam` union — **no new SDK symbol**, audit lock untouched.
- **`ScreenshotResult`** carries base64 PNG bytes; `PlaywrightProvider.screenshot()` encodes the buffer it already captured (bounded by the existing 5 MiB sidecar cap).
- **Handler** maps it onto `ToolResult.image` and keeps the base64 **out** of the text content (else megabytes of base64 would hit the model's context).
- **Tool description** updated so the model knows it now receives a viewable image.

## Scope / known limits

- **OpenAI-compatible providers**: `role:'tool'` messages can't carry images, so they **degrade to text-only** (path + dimensions). Documented inline; proper vision support (synthetic `role:'user'` image message) is a follow-up.
- **MCP image results** are still stubbed at `mcp/client.ts` — a related but separate gap, intentionally out of scope here.
- Always-on error screenshots (`browser_open/observe/act`) stay sidecar-only by design — only the explicit `browser_screenshot` tool returns a model-visible image, to avoid burning image tokens on every error.

## Verification

- `pnpm lint` (tsc strict) — clean
- `pnpm audit:sdk:check` — "Lock matches current imports"
- `pnpm test` — **8794 passed, 12 skipped, 0 failed** (469 files)
- **+3 tests**: handler image-mapping + base64-exclusion; loop image-content-block construction; provider base64 return.

Part 1 of 2 in the browser-tooling rework. Part 2 (attach to the user's real Chrome profile via Chrome 144 `--autoConnect`, no extension) follows on a separate branch.
