### PR TITLE
feat(browser): drive the user's real Chrome via chrome-devtools-mcp (afk browser connect)

### DIFF
--- a/docs/browser-real-chrome.md
+++ b/docs/browser-real-chrome.md
@@ -1,0 +1,83 @@
+# Driving your real Chrome (`afk browser connect`)
+
+agent-afk can drive your **real, logged-in Chrome profile** — the one with your
+existing sessions and cookies — so the agent can act on sites you're already
+signed into. It does this by wiring Google's
+[`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp)
+into agent-afk's MCP client.
+
+## Quick start
+
+```bash
+afk browser connect          # writes the MCP server entry + prints setup steps
+```
+
+Then, one time, in Chrome:
+
+1. Open `chrome://inspect/#remote-debugging` and **enable** remote debugging.
+2. The first time the agent drives Chrome, click **Allow** on the prompt.
+3. Chrome shows a *"being controlled by automated test software"* banner while a
+   session is active. That's expected.
+
+The agent now has `mcp__chrome-devtools__*` tools (`navigate_page`, `click`,
+`fill`, `take_snapshot`, `take_screenshot`, …) operating on your real profile.
+Run `/mcp` in the REPL to confirm the server connected.
+
+Undo with:
+
+```bash
+afk browser disconnect
+```
+
+## Why an MCP server instead of a native provider
+
+agent-afk's native `browser_*` tools use Playwright, which **cannot** attach to
+your real default profile:
+
+- **Chrome 136+** refuses `--remote-debugging-port` on the default user-data-dir
+  (an anti-cookie-theft change), so Playwright's `connectOverCDP` has nothing to
+  attach to there.
+- **Chrome M144's** sanctioned `--autoConnect` consent flow needs Puppeteer's
+  `handleDevToolsAsPage` connection option, which Playwright lacks
+  ([microsoft/playwright#40027](https://github.com/microsoft/playwright/issues/40027)).
+
+`chrome-devtools-mcp` vendors Puppeteer and implements the `--autoConnect` flow,
+so wiring it in is the supported path. agent-afk's native `browser_*` tools
+remain for throwaway/headless automation that doesn't need your real logins.
+
+## Requirements & security
+
+- **Chrome ≥ 144** (the `connect` command warns if it detects an older version).
+- The consent flow is **intentionally human-gated** and cannot be bypassed: you
+  enable it once at `chrome://inspect`, then approve each session. This is a
+  Chrome security boundary, not an agent-afk limitation.
+- While connected, the agent can read and act on **anything in your logged-in
+  profile** — only connect when you want it acting as you.
+
+## What `connect` writes
+
+It adds (idempotently, preserving any existing servers) a `chrome-devtools`
+entry to `~/.afk/config/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["chrome-devtools-mcp@latest", "--autoConnect"]
+    }
+  }
+}
+```
+
+Pass `--channel beta|canary|dev` to target a non-stable Chrome channel's
+profile.
+
+## Known limitation
+
+`chrome-devtools-mcp`'s `take_screenshot` returns an image, but agent-afk's MCP
+bridge currently text-stubs image results, so those screenshots aren't yet
+visible to the model. Its `take_snapshot` (a text accessibility tree) is the
+primary automation surface and works today. Making MCP-returned screenshots
+model-visible (reusing the `browser_screenshot` image plumbing) is a planned
+follow-up.

--- a/src/cli/commands/browser.test.ts
+++ b/src/cli/commands/browser.test.ts
@@ -97,4 +97,9 @@ describe('readMcpConfigFile / writeMcpConfigFileAtomic', () => {
     writeFileSync(path, '[]', 'utf-8');
     expect(() => readMcpConfigFile(path)).toThrow(/must be a JSON object/);
   });
+
+  it('throws when mcpServers is an array (never silently drops the entry)', () => {
+    writeFileSync(path, JSON.stringify({ mcpServers: [] }), 'utf-8');
+    expect(() => readMcpConfigFile(path)).toThrow(/must be a JSON object, not an array/);
+  });
 });

--- a/src/cli/commands/browser.test.ts
+++ b/src/cli/commands/browser.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for `afk browser` config helpers (chrome-devtools-mcp wiring).
+ *
+ * The interactive command output + Chrome-version detection are not unit-tested
+ * (they're stdout/UX and env-dependent); the testable core is the config
+ * read/merge/write contract, which must be atomic, idempotent, and must never
+ * clobber a hand-edited mcp.json.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  buildChromeDevtoolsEntry,
+  readMcpConfigFile,
+  writeMcpConfigFileAtomic,
+  CHROME_DEVTOOLS_SERVER_NAME,
+} from './browser.js';
+
+describe('buildChromeDevtoolsEntry', () => {
+  it('defaults to npx + --autoConnect on the stable channel', () => {
+    expect(buildChromeDevtoolsEntry()).toEqual({
+      command: 'npx',
+      args: ['chrome-devtools-mcp@latest', '--autoConnect'],
+    });
+  });
+
+  it('appends --channel for a non-stable channel', () => {
+    expect(buildChromeDevtoolsEntry('canary')).toEqual({
+      command: 'npx',
+      args: ['chrome-devtools-mcp@latest', '--autoConnect', '--channel', 'canary'],
+    });
+  });
+});
+
+describe('readMcpConfigFile / writeMcpConfigFileAtomic', () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'afk-mcp-'));
+    path = join(dir, 'mcp.json');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns an empty server map when the file is absent', () => {
+    expect(readMcpConfigFile(path)).toEqual({ mcpServers: {} });
+  });
+
+  it('round-trips a written config', () => {
+    const cfg = { mcpServers: { [CHROME_DEVTOOLS_SERVER_NAME]: buildChromeDevtoolsEntry() } };
+    writeMcpConfigFileAtomic(path, cfg);
+    expect(existsSync(path)).toBe(true);
+    // Trailing newline for POSIX-friendliness, valid JSON otherwise.
+    expect(readFileSync(path, 'utf-8').endsWith('\n')).toBe(true);
+    expect(readMcpConfigFile(path)).toEqual(cfg);
+  });
+
+  it('preserves existing servers when adding chrome-devtools', () => {
+    writeFileSync(path, JSON.stringify({ mcpServers: { other: { command: 'cat' } } }), 'utf-8');
+    const cfg = readMcpConfigFile(path);
+    cfg.mcpServers![CHROME_DEVTOOLS_SERVER_NAME] = buildChromeDevtoolsEntry();
+    writeMcpConfigFileAtomic(path, cfg);
+
+    const reread = readMcpConfigFile(path);
+    expect(reread.mcpServers!['other']).toEqual({ command: 'cat' });
+    expect(reread.mcpServers![CHROME_DEVTOOLS_SERVER_NAME]).toEqual(buildChromeDevtoolsEntry());
+  });
+
+  it('is idempotent: re-adding the same entry produces an identical file', () => {
+    const cfg1 = readMcpConfigFile(path);
+    cfg1.mcpServers![CHROME_DEVTOOLS_SERVER_NAME] = buildChromeDevtoolsEntry();
+    writeMcpConfigFileAtomic(path, cfg1);
+    const first = readFileSync(path, 'utf-8');
+
+    const cfg2 = readMcpConfigFile(path);
+    cfg2.mcpServers![CHROME_DEVTOOLS_SERVER_NAME] = buildChromeDevtoolsEntry();
+    writeMcpConfigFileAtomic(path, cfg2);
+    expect(readFileSync(path, 'utf-8')).toBe(first);
+  });
+
+  it('normalizes a file missing mcpServers to an empty map', () => {
+    writeFileSync(path, JSON.stringify({ someOtherKey: true }), 'utf-8');
+    expect(readMcpConfigFile(path).mcpServers).toEqual({});
+  });
+
+  it('throws a clear error on malformed JSON (never clobbers)', () => {
+    writeFileSync(path, '{ not valid', 'utf-8');
+    expect(() => readMcpConfigFile(path)).toThrow(/not valid JSON/);
+  });
+
+  it('throws when the top-level value is not an object', () => {
+    writeFileSync(path, '[]', 'utf-8');
+    expect(() => readMcpConfigFile(path)).toThrow(/must be a JSON object/);
+  });
+});

--- a/src/cli/commands/browser.ts
+++ b/src/cli/commands/browser.ts
@@ -82,6 +82,13 @@ export function readMcpConfigFile(path: string): McpConfigFile {
   }
 
   const cfg = parsed as McpConfigFile;
+  // An array passes `typeof === 'object'`, so guard it explicitly: a string-keyed
+  // assignment onto an array is silently dropped by JSON.stringify, which would make
+  // `connect` report success while persisting nothing. Refuse rather than clobber a
+  // hand-edited file (mirrors the top-level array check above).
+  if (Array.isArray(cfg.mcpServers)) {
+    throw new Error(`MCP config at ${path} has an invalid "mcpServers" (must be a JSON object, not an array).`);
+  }
   if (cfg.mcpServers === undefined || typeof cfg.mcpServers !== 'object' || cfg.mcpServers === null) {
     cfg.mcpServers = {};
   }

--- a/src/cli/commands/browser.ts
+++ b/src/cli/commands/browser.ts
@@ -1,0 +1,217 @@
+/**
+ * `afk browser` command group — connect the agent to the user's REAL Chrome.
+ *
+ * Subcommands:
+ *   afk browser connect      — wire Google's `chrome-devtools-mcp` (--autoConnect)
+ *                              into ~/.afk/config/mcp.json + print setup steps
+ *   afk browser disconnect   — remove the chrome-devtools server entry
+ *
+ * Why an MCP server and not a native browser provider:
+ *   Driving the user's real, logged-in default Chrome profile is impossible via
+ *   Playwright. Chrome 136+ refuses --remote-debugging-port on the default
+ *   profile, and Chrome M144's sanctioned `--autoConnect` consent flow needs
+ *   Puppeteer's `handleDevToolsAsPage` option, which Playwright lacks
+ *   (microsoft/playwright#40027). Google's `chrome-devtools-mcp` vendors
+ *   Puppeteer and implements exactly this flow, so we wire it in via the
+ *   existing MCP client rather than reimplementing it. The agent then drives
+ *   the real tab through `mcp__chrome-devtools__*` tools.
+ *
+ * Security model (intentionally human-gated — we cannot bypass it):
+ *   The user must enable remote debugging once at chrome://inspect, then click
+ *   "Allow" on a per-session prompt; Chrome shows a "being controlled" banner
+ *   while active. This command only writes config + prints the steps.
+ *
+ * @module cli/commands/browser
+ */
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { randomBytes } from 'crypto';
+import { palette } from '../palette.js';
+import { handleCommandError } from '../errors/index.js';
+import { getMcpConfigPath, type McpConfigFile } from '../../agent/mcp/config-loader.js';
+import type { McpServerConfig } from '../../agent/mcp/types.js';
+
+/** MCP server key written into mcpServers. Stable so connect/disconnect agree. */
+export const CHROME_DEVTOOLS_SERVER_NAME = 'chrome-devtools';
+
+const VALID_CHANNELS = ['stable', 'beta', 'canary', 'dev'] as const;
+type ChromeChannel = (typeof VALID_CHANNELS)[number];
+
+/**
+ * Build the mcpServers entry for chrome-devtools-mcp.
+ *
+ * Always runs via `npx …@latest --autoConnect`. A non-stable channel is
+ * appended as `--channel <channel>` so autoConnect attaches to that channel's
+ * running profile (autoConnect targets the channel's default user-data-dir).
+ */
+export function buildChromeDevtoolsEntry(channel: ChromeChannel = 'stable'): McpServerConfig {
+  const args = ['chrome-devtools-mcp@latest', '--autoConnect'];
+  if (channel !== 'stable') {
+    args.push('--channel', channel);
+  }
+  return { command: 'npx', args };
+}
+
+/**
+ * Read + normalize the user-global mcp.json. Returns `{ mcpServers: {} }` when
+ * absent. Throws a clear error on malformed JSON rather than clobbering a file
+ * the user may have hand-edited.
+ */
+export function readMcpConfigFile(path: string): McpConfigFile {
+  if (!existsSync(path)) return { mcpServers: {} };
+
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf-8');
+  } catch (err) {
+    throw new Error(`Failed to read MCP config at ${path}: ${(err as Error).message}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`MCP config at ${path} is not valid JSON. Fix or remove it, then retry.`);
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`MCP config at ${path} must be a JSON object.`);
+  }
+
+  const cfg = parsed as McpConfigFile;
+  if (cfg.mcpServers === undefined || typeof cfg.mcpServers !== 'object' || cfg.mcpServers === null) {
+    cfg.mcpServers = {};
+  }
+  return cfg;
+}
+
+/**
+ * Atomically persist mcp.json (temp-file + POSIX rename) so a crash mid-write
+ * never leaves a truncated config. Mirrors the pattern in schedule-store.ts.
+ */
+export function writeMcpConfigFileAtomic(path: string, cfg: McpConfigFile): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = join(dirname(path), `.mcp.json.${process.pid}.${randomBytes(4).toString('hex')}.tmp`);
+  writeFileSync(tmp, `${JSON.stringify(cfg, null, 2)}\n`, 'utf-8');
+  renameSync(tmp, path);
+}
+
+/**
+ * Best-effort detection of the installed Chrome major version, so `connect`
+ * can warn when autoConnect (Chrome ≥ 144) won't work. Returns null when no
+ * Chrome is found — a soft note, never a hard failure.
+ */
+function detectChromeMajorVersion(): number | null {
+  const candidates =
+    process.platform === 'darwin'
+      ? [
+          '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+          '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
+          '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+        ]
+      : ['google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser'];
+
+  for (const bin of candidates) {
+    try {
+      const out = execFileSync(bin, ['--version'], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeout: 5000,
+      });
+      const m = out.match(/(\d+)\.\d+\.\d+/);
+      if (m !== null && m[1] !== undefined) return parseInt(m[1], 10);
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return null;
+}
+
+function printSetupGuidance(): void {
+  const major = detectChromeMajorVersion();
+
+  console.log('');
+  console.log(chalk.bold('Drive your real Chrome — one-time setup:'));
+  if (major === null) {
+    console.log(palette.meta('  • Chrome not detected. autoConnect requires Chrome ≥ 144.'));
+  } else if (major < 144) {
+    console.log(chalk.yellow(`  • Detected Chrome ${major} — autoConnect requires ≥ 144. Please update Chrome.`));
+  } else {
+    console.log(palette.meta(`  • Detected Chrome ${major} ✓ (autoConnect needs ≥ 144)`));
+  }
+  console.log(palette.meta('  1. In Chrome, open chrome://inspect/#remote-debugging and enable it (one time).'));
+  console.log(palette.meta('  2. The first time the agent drives Chrome, click "Allow" on the prompt.'));
+  console.log(palette.meta('  3. Chrome shows a "being controlled by automated test software" banner while active.'));
+  console.log('');
+  console.log(palette.meta('The agent gains mcp__chrome-devtools__* tools (navigate, click, fill, take_snapshot, …)'));
+  console.log(palette.meta('driving your REAL, logged-in profile. Run `/mcp` in the REPL to confirm it connected.'));
+  console.log(palette.meta('Undo anytime with `afk browser disconnect`.'));
+}
+
+export function registerBrowserCommand(program: Command): void {
+  const browser = program
+    .command('browser')
+    .description('Connect the agent to your real Chrome browser (via Chrome DevTools MCP)');
+
+  browser
+    .command('connect')
+    .description('Wire chrome-devtools-mcp (--autoConnect) so the agent can drive your real, logged-in Chrome')
+    .option('--channel <channel>', `Chrome channel autoConnect targets (${VALID_CHANNELS.join('|')})`, 'stable')
+    .action((opts: { channel?: string }) => {
+      try {
+        const channel = (opts.channel ?? 'stable').toLowerCase();
+        if (!(VALID_CHANNELS as readonly string[]).includes(channel)) {
+          throw new Error(`--channel must be one of ${VALID_CHANNELS.join(', ')} (got "${opts.channel}")`);
+        }
+
+        const path = getMcpConfigPath();
+        const cfg = readMcpConfigFile(path);
+        if (cfg.mcpServers === undefined) cfg.mcpServers = {};
+
+        const entry = buildChromeDevtoolsEntry(channel as ChromeChannel);
+        const existing = cfg.mcpServers[CHROME_DEVTOOLS_SERVER_NAME];
+
+        if (existing !== undefined && JSON.stringify(existing) === JSON.stringify(entry)) {
+          console.log(chalk.green(`✓ "${CHROME_DEVTOOLS_SERVER_NAME}" already configured`));
+          console.log(palette.meta(`  Config: ${path}`));
+        } else {
+          cfg.mcpServers[CHROME_DEVTOOLS_SERVER_NAME] = entry;
+          writeMcpConfigFileAtomic(path, cfg);
+          const verb = existing === undefined ? 'Added' : 'Updated';
+          console.log(chalk.green(`✓ ${verb} "${CHROME_DEVTOOLS_SERVER_NAME}" MCP server`));
+          console.log(palette.meta(`  Config: ${path}`));
+          console.log(palette.meta(`  Runs:   npx ${entry.args?.join(' ') ?? ''}`));
+        }
+
+        printSetupGuidance();
+      } catch (err) {
+        handleCommandError(err);
+      }
+    });
+
+  browser
+    .command('disconnect')
+    .description('Remove the chrome-devtools server from your MCP config')
+    .action(() => {
+      try {
+        const path = getMcpConfigPath();
+        if (!existsSync(path)) {
+          console.log(chalk.yellow(`⚠ No MCP config at ${path} — nothing to remove.`));
+          return;
+        }
+        const cfg = readMcpConfigFile(path);
+        if (cfg.mcpServers === undefined || cfg.mcpServers[CHROME_DEVTOOLS_SERVER_NAME] === undefined) {
+          console.log(chalk.yellow(`⚠ "${CHROME_DEVTOOLS_SERVER_NAME}" is not configured — nothing to remove.`));
+          return;
+        }
+        delete cfg.mcpServers[CHROME_DEVTOOLS_SERVER_NAME];
+        writeMcpConfigFileAtomic(path, cfg);
+        console.log(chalk.green(`✓ Removed "${CHROME_DEVTOOLS_SERVER_NAME}" from ${path}`));
+      } catch (err) {
+        handleCommandError(err);
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -67,6 +67,7 @@ import { registerScheduleCommand } from './commands/schedule.js';
 import { registerBgCommand } from './commands/bg.js';
 import { registerTraceCommand } from './commands/trace.js';
 import { registerServiceCommand } from './commands/service.js';
+import { registerBrowserCommand } from './commands/browser.js';
 import { registerImproveCommand } from './commands/improve.js';
 import { registerShellInitCommand } from './commands/shell-init.js';
 import { setInteractiveUpdateNotices } from './commands/interactive.js';
@@ -117,6 +118,7 @@ registerScheduleCommand(program);
 registerBgCommand(program);
 registerTraceCommand(program);
 registerServiceCommand(program);
+registerBrowserCommand(program);
 registerImproveCommand(program);
 registerShellInitCommand(program);
 


### PR DESCRIPTION
## Goal

Let the agent drive the user's **real, logged-in Chrome profile** (existing sessions/cookies) — e.g. act on sites they're already signed into.

## Why this shape (not a native provider)

Per the probe in the planning thread: Playwright **cannot** attach to the real default profile. Chrome 136+ refuses `--remote-debugging-port` on the default user-data-dir, and Chrome M144's sanctioned `--autoConnect` consent flow needs Puppeteer's `handleDevToolsAsPage` option that Playwright lacks (`microsoft/playwright#40027`). Google's `chrome-devtools-mcp` vendors Puppeteer and implements exactly this flow — and agent-afk already has an MCP client. So this PR **wires `chrome-devtools-mcp` in** rather than reimplementing the handshake. The native `browser_*` (Playwright) tools stay for throwaway/headless automation.

## Change

New **`afk browser`** command group (`src/cli/commands/browser.ts`, registered in `cli/index.ts`):

- **`afk browser connect`** — idempotently merges a `chrome-devtools` entry (`npx chrome-devtools-mcp@latest --autoConnect`) into `~/.afk/config/mcp.json` (atomic temp-file + rename, never clobbers a hand-edited file), detects the local Chrome version (warns if < 144), and prints the one-time `chrome://inspect` + per-session "Allow" setup steps. `--channel beta|canary|dev` supported.
- **`afk browser disconnect`** — removes the entry.
- Docs: `docs/browser-real-chrome.md`.

The agent then gets `mcp__chrome-devtools__*` tools (`navigate_page`, `click`, `fill`, `take_snapshot`, `take_screenshot`, …) driving the real profile; `/mcp` confirms connection.

## Security model (intentionally human-gated)

The consent flow **cannot** be bypassed and this PR doesn't try: the user enables remote debugging once at `chrome://inspect`, approves each session, and Chrome shows a "being controlled by automated test software" banner. Requires Chrome ≥ 144.

## Verification

- `pnpm lint` (tsc strict) — clean
- `pnpm test` — **8800 passed, 12 skipped, 0 failed** (470 files); **+9** new unit tests (entry building, atomic round-trip, idempotent merge, preserves other servers, malformed-JSON safety).
- **End-to-end smoke** (against a throwaway `AFK_HOME`, no real config touched, no Chrome/npx spawned): `connect` writes the correct `mcp.json` + detects Chrome 149 ✓; re-run is idempotent ("already configured"); `disconnect` removes it.
- **Not automatable:** the live autoConnect → real-profile drive needs a human "Allow" click in Chrome ≥ 144 — verify manually with `afk browser connect` then ask the agent to drive a page.

## Known limitation / follow-up

`chrome-devtools-mcp`'s `take_screenshot` returns an image, but agent-afk's MCP bridge currently text-stubs image results (`mcp/client.ts`), so those screenshots aren't model-visible yet. Its text `take_snapshot` is the primary automation surface and works. Making MCP screenshots visible (reusing PR #82's `ToolResult.image` plumbing) is the planned PR 3 fast-follow.

Part 2 of the browser-tooling rework. Part 1 (model-visible `browser_screenshot`) is #82.
