### PR TITLE
feat(improve): add eval-run, the first deterministic eval-case validation stage

### DIFF
--- a/src/agent/tools/skill-depth-message.ts
+++ b/src/agent/tools/skill-depth-message.ts
@@ -1,0 +1,37 @@
+/**
+ * Skill-tool max-nesting-depth refusal message.
+ *
+ * Extracted as a pure, dependency-free module so two consumers share one
+ * source of truth:
+ *
+ *   1. {@link SkillExecutor.execute} returns it when a `skill` call lands at or
+ *      beyond the nesting-depth limit — the runtime guardrail.
+ *   2. `afk improve eval-run` asserts the recovery hint is present without
+ *      importing the heavy skill-executor module graph or firing its routing
+ *      telemetry as a side effect.
+ *
+ * History: the refusal originally inlined a bare "not available at depth N"
+ * string. PR #80 expanded it with an actionable recovery hint (work inline
+ * instead of delegating) after telemetry showed sessions stalling at the depth
+ * wall. Keeping the hint here — beside the message it belongs to — makes its
+ * presence a checkable contract rather than a string literal buried in a
+ * thousand-line executor.
+ *
+ * @module agent/tools/skill-depth-message
+ */
+
+/**
+ * The actionable recovery clause appended to the skill max-depth refusal.
+ * Exported so the eval-run validator can assert its presence directly.
+ */
+export const SKILL_MAX_DEPTH_RECOVERY_HINT =
+  'You are too deeply nested to delegate further — perform the work inline with your own tools instead of calling skill/agent/compose.';
+
+/**
+ * Build the full refusal message returned by the `skill` tool when invoked at
+ * or beyond {@link DEFAULT_MAX_NESTING_DEPTH}. Always carries
+ * {@link SKILL_MAX_DEPTH_RECOVERY_HINT}.
+ */
+export function buildSkillMaxDepthRefusal(depth: number, maxDepth: number): string {
+  return `Skill tool not available at nesting depth ${depth} (max ${maxDepth}). ${SKILL_MAX_DEPTH_RECOVERY_HINT}`;
+}

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -30,6 +30,7 @@ import {
   type ChildProviderFactoryArgs,
 } from './nesting.js';
 import { SubagentExecutor } from './subagent-executor.js';
+import { buildSkillMaxDepthRefusal } from './skill-depth-message.js';
 import { applyParentCredentialFallback } from './child-credential.js';
 import { resolveCredentialForModel } from '../auth/credential-resolver.js';
 import { getCurrentSink } from '../_lib/skill-sink-channel.js';
@@ -225,7 +226,7 @@ export class SkillExecutor {
         requested_name: requestedName,
       }).catch(() => {});
       return {
-        content: `Skill tool not available at nesting depth ${depth} (max ${maxDepth}). You are too deeply nested to delegate further — perform the work inline with your own tools instead of calling skill/agent/compose.`,
+        content: buildSkillMaxDepthRefusal(depth, maxDepth),
         isError: true,
       };
     }

--- a/src/cli/commands/improve.ts
+++ b/src/cli/commands/improve.ts
@@ -47,11 +47,20 @@
  *   afk improve eval-cases show <id> [--json]
  *       Print one eval-case (markdown view by default).
  *
- * Sprint 3 scope explicitly EXCLUDES: LLM-mode proposals, plan, apply,
- * validate, eval-run (the runner), eval-link (the proposal back-fill),
- * branch creation, git operations, and PR publishing. Those are reserved
- * for later sprints behind explicit flags with hard-coded forbidden-path
- * guardrails.
+ *   afk improve eval-run <evalCaseIdOrCardSlug> [--id <override>] [--json]
+ *                                               [--no-write]
+ *       Run the smallest deterministic validation contract for an eval-case's
+ *       pattern against the live codebase, and persist an EvalRun result under
+ *       `eval-runs/<id>.{json,md}`. Re-verifies the eval-case's committed
+ *       fixture checksum. NO LLM calls; NO patch/apply; NO fixture replay
+ *       through the detector (that broader runner is reserved for a later
+ *       sprint — see EvalRunSchema). The arg may be an eval-case id OR a card
+ *       slug (the most recent eval-case for that card is run).
+ *
+ * Scope explicitly EXCLUDES: LLM-mode proposals, plan, apply, patch, fixture
+ * replay through the detector, eval-link (the proposal back-fill), branch
+ * creation, git operations, and PR publishing. Those are reserved for later
+ * sprints behind explicit flags with hard-coded forbidden-path guardrails.
  *
  * @module cli/commands/improve
  */
@@ -89,11 +98,19 @@ import {
   buildEvalCase,
   generateEvalCaseId,
   getEvalCase,
+  getEvalCasesForCard,
   listEvalCases,
   renderEvalCaseMarkdown,
   writeEvalCase,
 } from '../../improve/eval-gen/writer.js';
-import type { EvalCaseStatus, FailurePattern } from '../../improve/schemas.js';
+import {
+  generateEvalRunId,
+  renderEvalRunMarkdown,
+  runEvalCase,
+  writeEvalRun,
+} from '../../improve/eval-run/runner.js';
+import { knownContractIds } from '../../improve/eval-run/contracts.js';
+import type { EvalCase, EvalCaseStatus, EvalRun, FailurePattern } from '../../improve/schemas.js';
 
 const VALID_STATUSES: readonly CardStatus[] = ['open', 'deferred', 'resolved'];
 const VALID_EVAL_STATUSES: readonly EvalCaseStatus[] = [
@@ -119,6 +136,7 @@ export function registerImproveCommand(program: Command): void {
   registerProposalsSubcommand(improve);
   registerEvalGenSubcommand(improve);
   registerEvalCasesSubcommand(improve);
+  registerEvalRunSubcommand(improve);
 }
 
 // ---------------------------------------------------------------------------
@@ -796,6 +814,114 @@ function registerEvalCasesSubcommand(improve: Command): void {
         handleCommandError(err);
       }
     });
+}
+
+// ---------------------------------------------------------------------------
+// eval-run (deterministic guardrail validation)
+// ---------------------------------------------------------------------------
+
+function registerEvalRunSubcommand(improve: Command): void {
+  improve
+    .command('eval-run <evalCaseIdOrCardSlug>')
+    .description(
+      'Run the smallest deterministic validation contract for an eval-case\'s pattern.\n' +
+        `  Validates guardrails (no LLM, no patch/apply). Known contracts: ${knownContractIds().join(', ')}.`,
+    )
+    .option('--id <override>', 'Override the auto-generated eval-run id')
+    .option('--json', 'Emit the eval-run JSON to stdout (still writes to disk)', false)
+    .option('--no-write', 'Run and render without persisting to disk (preview mode)')
+    .action(
+      async (
+        arg: string,
+        opts: { id?: string; json: boolean; write: boolean },
+      ) => {
+        try {
+          // 1. Resolve the eval-case: try an exact eval-case id first, then
+          //    fall back to treating the arg as a card slug (most recent
+          //    eval-case for that card wins — listEvalCases sorts newest first).
+          let evalCase: EvalCase | undefined = getEvalCase(arg);
+          if (!evalCase) {
+            const forCard = getEvalCasesForCard(arg);
+            evalCase = forCard[0];
+          }
+          if (!evalCase) {
+            console.error(
+              `No eval-case found for '${arg}'. Pass an eval-case id ` +
+                `(see 'afk improve eval-cases list') or a card slug with at least ` +
+                `one generated eval-case ('afk improve eval-gen <slug>').`,
+            );
+            process.exit(1);
+          }
+
+          // 2. Run the contract.
+          const evalRunId = opts.id ?? generateEvalRunId(evalCase.cardSlug);
+          const evalRun = await runEvalCase(evalCase, { evalRunId });
+
+          // 3. Preview branch: render without persisting.
+          if (opts.write === false) {
+            if (opts.json) {
+              console.log(JSON.stringify(evalRun, null, 2));
+            } else {
+              console.log('(preview — not persisted; remove --no-write to save)');
+              console.log('');
+              console.log(renderEvalRunMarkdown(evalRun));
+            }
+            applyEvalRunExit(evalRun.status);
+            return;
+          }
+
+          // 4. Persist.
+          const outcome = writeEvalRun(evalRun);
+
+          if (opts.json) {
+            console.log(JSON.stringify({ ...evalRun, _paths: outcome }, null, 2));
+            applyEvalRunExit(evalRun.status);
+            return;
+          }
+
+          printEvalRunSummary(evalRun, outcome.jsonPath, outcome.markdownPath);
+          applyEvalRunExit(evalRun.status);
+        } catch (err) {
+          handleCommandError(err);
+        }
+      },
+    );
+}
+
+function printEvalRunSummary(evalRun: EvalRun, jsonPath: string, markdownPath: string): void {
+  const passed = evalRun.checks.filter((c) => c.status === 'pass').length;
+  const failed = evalRun.checks.filter((c) => c.status === 'fail').length;
+  const skipped = evalRun.checks.filter((c) => c.status === 'skipped').length;
+
+  console.log(`Ran eval-run: ${evalRun.evalRunId}  [${evalRun.status.toUpperCase()}]`);
+  console.log(`  json: ${jsonPath}`);
+  console.log(`  md:   ${markdownPath}`);
+  console.log(
+    `  eval-case: ${evalRun.evalCaseId} · card: ${evalRun.cardSlug} · ` +
+      `pattern: ${evalRun.patternId} · contract: ${evalRun.contract ?? '(none)'}`,
+  );
+  console.log(
+    `  checks: ${passed} passed${failed ? `, ${failed} failed` : ''}${skipped ? `, ${skipped} skipped` : ''} (${evalRun.checks.length} total)`,
+  );
+  for (const c of evalRun.checks) {
+    const glyph = c.status === 'pass' ? '✓' : c.status === 'fail' ? '✗' : '–';
+    console.log(`    ${glyph} ${c.name}`);
+  }
+  for (const n of evalRun.notes) {
+    console.log(`  note: ${n.text}`);
+  }
+}
+
+/**
+ * Set a non-zero exit code when the run found a regression, so the command is
+ * usable as a CI / scripting gate (`afk improve eval-run X && …`). `pass` and
+ * `unsupported` exit 0 (no regression detected); `fail`/`error` exit 1. Uses
+ * `process.exitCode` rather than `process.exit()` so buffered stdout flushes.
+ */
+function applyEvalRunExit(status: EvalRun['status']): void {
+  if (status === 'fail' || status === 'error') {
+    process.exitCode = 1;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/improve/eval-run/contracts.test.ts
+++ b/src/improve/eval-run/contracts.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for `improve/eval-run/contracts.ts`.
+ *
+ * These exercise the REAL guardrails (the live dispatcher, the live skill
+ * depth-message builder, the live detector registry) — so a regression in any
+ * guardrail surfaces here as a failing check, exactly as it would in a real
+ * `afk improve eval-run`. No disk I/O, no AFK_HOME isolation needed.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  knownContractIds,
+  makeCheck,
+  resolveContract,
+  snapshot,
+  supportedContractPatterns,
+} from './contracts.js';
+import { REPEAT_CIRCUIT_BREAKER_THRESHOLD } from '../../agent/tools/dispatcher.js';
+import { SKILL_MAX_DEPTH_RECOVERY_HINT } from '../../agent/tools/skill-depth-message.js';
+
+// ---------------------------------------------------------------------------
+// Registry resolution
+// ---------------------------------------------------------------------------
+
+describe('resolveContract', () => {
+  it('maps each PR-80 pattern to its contract', () => {
+    expect(resolveContract('repeated-tool-use')?.id).toBe('repeat-loop-circuit-breaker');
+    expect(resolveContract('subagent-block')?.id).toBe('skill-max-depth-recovery-hint');
+    expect(resolveContract('tool-failure-density')?.id).toBe('tool-failure-density-enabled');
+  });
+
+  it('returns undefined for a pattern with no deterministic contract', () => {
+    expect(resolveContract('closure-anomaly')).toBeUndefined();
+  });
+
+  it('supportedContractPatterns / knownContractIds enumerate the registry', () => {
+    expect(supportedContractPatterns()).toEqual([
+      'repeated-tool-use',
+      'subagent-block',
+      'tool-failure-density',
+    ]);
+    expect(knownContractIds()).toEqual([
+      'repeat-loop-circuit-breaker',
+      'skill-max-depth-recovery-hint',
+      'tool-failure-density-enabled',
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// makeCheck / snapshot helpers
+// ---------------------------------------------------------------------------
+
+describe('makeCheck / snapshot', () => {
+  it('derives pass/fail status from the boolean', () => {
+    expect(makeCheck({ name: 'a', description: 'd', pass: true, expected: 'x', actual: 'x' }).status).toBe('pass');
+    expect(makeCheck({ name: 'a', description: 'd', pass: false, expected: 'x', actual: 'y' }).status).toBe('fail');
+  });
+
+  it('honours an explicit status override', () => {
+    const c = makeCheck({ name: 'a', description: 'd', pass: true, expected: '', actual: '', status: 'skipped' });
+    expect(c.status).toBe('skipped');
+  });
+
+  it('snapshot collapses whitespace and bounds length', () => {
+    expect(snapshot('a\n  b\t c')).toBe('a b c');
+    const long = 'x'.repeat(1000);
+    const s = snapshot(long);
+    expect(s.length).toBeLessThanOrEqual(400);
+    expect(s.endsWith('…')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract: repeat-loop circuit breaker (exercises the real dispatcher)
+// ---------------------------------------------------------------------------
+
+describe('repeat-loop-circuit-breaker contract', () => {
+  it('all checks pass against the live circuit breaker', async () => {
+    const contract = resolveContract('repeated-tool-use');
+    expect(contract).toBeDefined();
+    const result = await contract!.run();
+
+    expect(result.checks).toHaveLength(4);
+    for (const c of result.checks) {
+      expect(c.status, `${c.name}: expected=${c.expected} actual=${c.actual}`).toBe('pass');
+    }
+
+    const names = result.checks.map((c) => c.name);
+    expect(names).toEqual([
+      'executes-below-threshold',
+      'trips-at-threshold',
+      'breaker-message-is-actionable',
+      'resets-on-different-input',
+    ]);
+  });
+
+  it('records the live threshold as evidence', async () => {
+    const result = await resolveContract('repeated-tool-use')!.run();
+    const thresholdEvidence = result.evidence.find((e) =>
+      e.ref.includes('REPEAT_CIRCUIT_BREAKER_THRESHOLD'),
+    );
+    expect(thresholdEvidence?.detail).toBe(String(REPEAT_CIRCUIT_BREAKER_THRESHOLD));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract: skill max-depth recovery hint
+// ---------------------------------------------------------------------------
+
+describe('skill-max-depth-recovery-hint contract', () => {
+  it('all checks pass against the live refusal builder', async () => {
+    const result = await resolveContract('subagent-block')!.run();
+    expect(result.checks.map((c) => c.name)).toEqual([
+      'refusal-states-depth',
+      'recovery-hint-present',
+      'hint-directs-inline-work',
+    ]);
+    for (const c of result.checks) {
+      expect(c.status, `${c.name}: ${c.actual}`).toBe('pass');
+    }
+  });
+
+  it('evidence references the shared message builder and carries the hint', async () => {
+    const result = await resolveContract('subagent-block')!.run();
+    const builderEvidence = result.evidence.find((e) => e.ref.includes('buildSkillMaxDepthRefusal'));
+    expect(builderEvidence).toBeDefined();
+    expect(builderEvidence!.detail).toContain(SKILL_MAX_DEPTH_RECOVERY_HINT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract: tool-failure-density enabled by default
+// ---------------------------------------------------------------------------
+
+describe('tool-failure-density-enabled contract', () => {
+  it('all checks pass — the detector is enabled by default', async () => {
+    const result = await resolveContract('tool-failure-density')!.run();
+    expect(result.checks.map((c) => c.name)).toEqual(['in-default-enabled-set', 'not-opt-in']);
+    for (const c of result.checks) {
+      expect(c.status, `${c.name}: ${c.actual}`).toBe('pass');
+    }
+    const evidence = result.evidence.find((e) => e.ref.includes('enabledByDefault'));
+    expect(evidence?.detail).toBe('true');
+  });
+});

--- a/src/improve/eval-run/contracts.ts
+++ b/src/improve/eval-run/contracts.ts
@@ -1,0 +1,335 @@
+/**
+ * Deterministic validation contracts for `afk improve eval-run`.
+ *
+ * Each contract is the **smallest deterministic check** that a guardrail
+ * associated with one {@link FailurePattern} is present and behaving. A
+ * contract runs entirely in-process: no LLM, no network, no patch/apply, and
+ * no I/O side effects (the circuit-breaker probe builds a throwaway dispatcher
+ * with no trace writer / hooks; the others read constants and pure helpers).
+ *
+ * ## Why guardrail-presence, not fixture replay
+ *
+ * An eval-case's own assertion is `pattern-absent`: replay the committed
+ * fixture through the detector after the fix lands and expect zero findings.
+ * That broader replay capability is reserved for a later sprint. This runner
+ * validates the *fix* instead — the guardrail the pattern maps to:
+ *
+ *   - `repeated-tool-use`    → the repeat-loop circuit breaker (PR #80).
+ *   - `subagent-block`       → the skill max-depth recovery hint (PR #80).
+ *   - `tool-failure-density` → that detector being enabled by default (PR #80).
+ *
+ * Patterns with no registered contract (e.g. `closure-anomaly`) resolve to
+ * `undefined`; the runner records an `unsupported` result rather than failing.
+ *
+ * ## Adding a contract
+ *
+ *   1. Implement `async function run(): Promise<ContractProbeResult>`.
+ *   2. Append an {@link EvalContract} entry keyed on its `patternId`.
+ *   3. Exercise the REAL guardrail (import the production symbol) so a
+ *      regression in the guardrail is caught here — never re-implement it.
+ *
+ * @module improve/eval-run/contracts
+ */
+
+import {
+  REPEAT_CIRCUIT_BREAKER_THRESHOLD,
+  SessionToolDispatcher,
+} from '../../agent/tools/dispatcher.js';
+import type { ToolCall, ToolHandler, ToolResult } from '../../agent/tools/types.js';
+import {
+  SKILL_MAX_DEPTH_RECOVERY_HINT,
+  buildSkillMaxDepthRefusal,
+} from '../../agent/tools/skill-depth-message.js';
+import {
+  defaultEnabledDetectorNames,
+  disabledByDefaultDetectorNames,
+} from '../scan/detectors/index.js';
+import type { EvalCheck, EvalCheckStatus, EvalRunEvidenceRef, FailurePattern } from '../schemas.js';
+
+// ---------------------------------------------------------------------------
+// Contract surface
+// ---------------------------------------------------------------------------
+
+export interface ContractProbeResult {
+  checks: EvalCheck[];
+  evidence: EvalRunEvidenceRef[];
+}
+
+export interface EvalContract {
+  /** Stable id, written to the eval-run's `contract` field. */
+  id: string;
+  /** The pattern whose guardrail this contract validates. */
+  patternId: FailurePattern;
+  /** One-line human description. */
+  title: string;
+  /** Run the deterministic probe. Pure modulo throwaway in-memory objects. */
+  run: () => Promise<ContractProbeResult>;
+}
+
+/** Cap on `expected`/`actual`/`detail` snapshots so artifacts stay readable. */
+const SNAPSHOT_MAX = 400;
+
+/** Trim a value for an artifact snapshot — single line, bounded length. */
+export function snapshot(value: unknown): string {
+  const s = typeof value === 'string' ? value : String(value);
+  const oneLine = s.replace(/\s+/g, ' ').trim();
+  return oneLine.length > SNAPSHOT_MAX ? oneLine.slice(0, SNAPSHOT_MAX - 1) + '…' : oneLine;
+}
+
+/** Build a check record. `pass` is the boolean the assertion evaluated to. */
+export function makeCheck(args: {
+  name: string;
+  description: string;
+  pass: boolean;
+  expected: string;
+  actual: string;
+  /** Force a non-pass/fail status (e.g. `'skipped'`). Overrides `pass`. */
+  status?: EvalCheckStatus;
+}): EvalCheck {
+  return {
+    name: args.name,
+    description: args.description,
+    status: args.status ?? (args.pass ? 'pass' : 'fail'),
+    expected: snapshot(args.expected),
+    actual: snapshot(args.actual),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Contract: repeated-tool-use → repeat-loop circuit breaker (PR #80)
+// ---------------------------------------------------------------------------
+
+const PROBE_TOOL = 'eval_run_probe_tool';
+
+/**
+ * Exercise the real {@link SessionToolDispatcher} repeat-loop circuit breaker.
+ *
+ * Builds a throwaway dispatcher (no hooks, no permissions allowlist beyond the
+ * probe tool, no trace writer → zero side effects), fires the same call with
+ * byte-identical input, and asserts the documented threshold behavior:
+ *   - the first THRESHOLD-1 identical calls execute,
+ *   - call #THRESHOLD is short-circuited with `circuitBreaker: true`,
+ *   - the breaker counts CONSECUTIVE calls (a different input resets it).
+ */
+async function runRepeatLoopCircuitBreaker(): Promise<ContractProbeResult> {
+  const threshold = REPEAT_CIRCUIT_BREAKER_THRESHOLD;
+  let handlerCalls = 0;
+  const handler: ToolHandler = async () => {
+    handlerCalls += 1;
+    return { content: 'probe-ok' };
+  };
+  const dispatcher = new SessionToolDispatcher({
+    handlers: new Map<string, ToolHandler>([[PROBE_TOOL, handler]]),
+    schemas: [],
+    permissions: { allowedTools: [PROBE_TOOL] },
+  });
+
+  const signal = new AbortController().signal;
+  const makeCall = (input: unknown): ToolCall => ({
+    id: 'eval-run-probe',
+    name: PROBE_TOOL,
+    input,
+    signal,
+  });
+  const identical = { probe: 'byte-identical-input' };
+
+  const below: ToolResult[] = [];
+  for (let i = 0; i < threshold - 1; i++) {
+    below.push(await dispatcher.execute(makeCall(identical)));
+  }
+  const handlerAfterBelow = handlerCalls;
+  const tripped = await dispatcher.execute(makeCall(identical));
+  const handlerAfterTrip = handlerCalls;
+  const afterReset = await dispatcher.execute(makeCall({ probe: 'a-different-input' }));
+
+  const belowAllClean = below.every((r) => r.isError !== true && r.circuitBreaker !== true);
+
+  const checks: EvalCheck[] = [
+    makeCheck({
+      name: 'executes-below-threshold',
+      description: `First ${threshold - 1} byte-identical calls execute without tripping`,
+      pass: belowAllClean && handlerAfterBelow === threshold - 1,
+      expected: `${threshold - 1} clean executions; handler runs ${threshold - 1}×`,
+      actual: `${below.filter((r) => r.isError !== true).length} clean; handler ran ${handlerAfterBelow}×`,
+    }),
+    makeCheck({
+      name: 'trips-at-threshold',
+      description: `Call #${threshold} is short-circuited with isError + circuitBreaker, handler skipped`,
+      pass:
+        tripped.isError === true &&
+        tripped.circuitBreaker === true &&
+        handlerAfterTrip === handlerAfterBelow,
+      expected: 'isError=true, circuitBreaker=true, handler not re-run',
+      actual: `isError=${tripped.isError ?? false}, circuitBreaker=${tripped.circuitBreaker ?? false}, handler ran ${handlerAfterTrip}×`,
+    }),
+    makeCheck({
+      name: 'breaker-message-is-actionable',
+      description: 'The synthetic block names the looping tool and reads as a stop nudge',
+      pass: /circuit breaker/i.test(tripped.content) && tripped.content.includes(PROBE_TOOL),
+      expected: `mentions "circuit breaker" and the tool name "${PROBE_TOOL}"`,
+      actual: tripped.content,
+    }),
+    makeCheck({
+      name: 'resets-on-different-input',
+      description: 'A different-input call after a trip resets the consecutive counter and executes',
+      pass: afterReset.isError !== true && afterReset.circuitBreaker !== true && handlerCalls === handlerAfterTrip + 1,
+      expected: 'executes (no breaker), handler runs once more',
+      actual: `isError=${afterReset.isError ?? false}, circuitBreaker=${afterReset.circuitBreaker ?? false}, handler ran ${handlerCalls}×`,
+    }),
+  ];
+
+  const evidence: EvalRunEvidenceRef[] = [
+    {
+      kind: 'config-value',
+      ref: 'src/agent/tools/dispatcher.ts#REPEAT_CIRCUIT_BREAKER_THRESHOLD',
+      detail: String(threshold),
+    },
+    {
+      kind: 'observed-behavior',
+      ref: 'SessionToolDispatcher.execute',
+      detail: `handler ran ${handlerAfterTrip}× across ${threshold} byte-identical calls; call #${threshold} short-circuited (circuitBreaker=${tripped.circuitBreaker ?? false})`,
+    },
+  ];
+
+  return { checks, evidence };
+}
+
+// ---------------------------------------------------------------------------
+// Contract: subagent-block → skill max-depth recovery hint (PR #80)
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert the skill-tool max-depth refusal carries the actionable recovery
+ * hint. Validates the same builder {@link SkillExecutor.execute} returns, so a
+ * regression that drops the hint is caught — without firing the executor's
+ * `delegation.skipped` routing telemetry as a side effect.
+ */
+async function runSkillMaxDepthRecoveryHint(): Promise<ContractProbeResult> {
+  const depth = 3;
+  const maxDepth = 3;
+  const message = buildSkillMaxDepthRefusal(depth, maxDepth);
+
+  const checks: EvalCheck[] = [
+    makeCheck({
+      name: 'refusal-states-depth',
+      description: 'Refusal reports the depth that was hit and the max',
+      pass: message.includes(`nesting depth ${depth} (max ${maxDepth})`),
+      expected: `mentions "nesting depth ${depth} (max ${maxDepth})"`,
+      actual: message,
+    }),
+    makeCheck({
+      name: 'recovery-hint-present',
+      description: 'Refusal carries the recovery hint clause',
+      pass: message.includes(SKILL_MAX_DEPTH_RECOVERY_HINT),
+      expected: 'contains SKILL_MAX_DEPTH_RECOVERY_HINT',
+      actual: message,
+    }),
+    makeCheck({
+      name: 'hint-directs-inline-work',
+      description: 'Hint tells the model to work inline instead of delegating further',
+      pass:
+        /perform the work inline/i.test(SKILL_MAX_DEPTH_RECOVERY_HINT) &&
+        /skill\/agent\/compose/i.test(SKILL_MAX_DEPTH_RECOVERY_HINT),
+      expected: 'hint mentions "perform the work inline" and "skill/agent/compose"',
+      actual: SKILL_MAX_DEPTH_RECOVERY_HINT,
+    }),
+  ];
+
+  const evidence: EvalRunEvidenceRef[] = [
+    {
+      kind: 'source-symbol',
+      ref: 'src/agent/tools/skill-depth-message.ts#buildSkillMaxDepthRefusal',
+      detail: message,
+    },
+    {
+      kind: 'source-symbol',
+      ref: 'src/agent/tools/skill-executor.ts (execute: depth >= maxDepth branch)',
+      detail: 'returns buildSkillMaxDepthRefusal(depth, maxDepth)',
+    },
+  ];
+
+  return { checks, evidence };
+}
+
+// ---------------------------------------------------------------------------
+// Contract: tool-failure-density → enabled by default (PR #80)
+// ---------------------------------------------------------------------------
+
+const TFD_DETECTOR = 'tool-failure-density';
+
+/**
+ * Assert the `tool-failure-density` detector runs in a default `afk improve
+ * scan` (no `--only` / `--include-disabled`). Validates the live detector
+ * registry — a regression flipping it back to opt-in is caught.
+ */
+async function runToolFailureDensityEnabled(): Promise<ContractProbeResult> {
+  const enabled = defaultEnabledDetectorNames();
+  const disabled = disabledByDefaultDetectorNames();
+
+  const checks: EvalCheck[] = [
+    makeCheck({
+      name: 'in-default-enabled-set',
+      description: `${TFD_DETECTOR} runs in a default scan`,
+      pass: enabled.includes(TFD_DETECTOR),
+      expected: `defaultEnabledDetectorNames() includes "${TFD_DETECTOR}"`,
+      actual: `[${enabled.join(', ')}]`,
+    }),
+    makeCheck({
+      name: 'not-opt-in',
+      description: `${TFD_DETECTOR} is not in the disabled-by-default set`,
+      pass: !disabled.includes(TFD_DETECTOR),
+      expected: `disabledByDefaultDetectorNames() excludes "${TFD_DETECTOR}"`,
+      actual: `[${disabled.join(', ')}]`,
+    }),
+  ];
+
+  const evidence: EvalRunEvidenceRef[] = [
+    {
+      kind: 'config-value',
+      ref: "DETECTOR_REGISTRY['tool-failure-density'].enabledByDefault",
+      detail: String(enabled.includes(TFD_DETECTOR)),
+    },
+  ];
+
+  return { checks, evidence };
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const CONTRACTS: readonly EvalContract[] = Object.freeze([
+  {
+    id: 'repeat-loop-circuit-breaker',
+    patternId: 'repeated-tool-use',
+    title: 'Repeat-loop circuit breaker trips at the consecutive-identical threshold',
+    run: runRepeatLoopCircuitBreaker,
+  },
+  {
+    id: 'skill-max-depth-recovery-hint',
+    patternId: 'subagent-block',
+    title: 'Skill max-depth refusal carries an actionable recovery hint',
+    run: runSkillMaxDepthRecoveryHint,
+  },
+  {
+    id: 'tool-failure-density-enabled',
+    patternId: 'tool-failure-density',
+    title: 'tool-failure-density detector is enabled by default',
+    run: runToolFailureDensityEnabled,
+  },
+] satisfies EvalContract[]);
+
+/** Resolve the validation contract for a pattern, or `undefined` if none. */
+export function resolveContract(patternId: FailurePattern): EvalContract | undefined {
+  return CONTRACTS.find((c) => c.patternId === patternId);
+}
+
+/** Patterns that currently have a deterministic validation contract. */
+export function supportedContractPatterns(): readonly FailurePattern[] {
+  return CONTRACTS.map((c) => c.patternId);
+}
+
+/** All registered contract ids (for `--help` text and diagnostics). */
+export function knownContractIds(): readonly string[] {
+  return CONTRACTS.map((c) => c.id);
+}

--- a/src/improve/eval-run/runner.test.ts
+++ b/src/improve/eval-run/runner.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Tests for `improve/eval-run/runner.ts`.
+ *
+ * Coverage:
+ *   - generateEvalRunId: `-run-` infix format + injection seams + bad suffix.
+ *   - runEvalCase: fixture-integrity grounding (pass / mismatch / missing);
+ *     status aggregation + precedence (pass / fail / unsupported); injected
+ *     clock → deterministic durationMs; honours the resolveFixtureAbsPath seam.
+ *   - writeEvalRun: JSON + md atomic write + .index.jsonl append; round-trips
+ *     through getEvalRun / listEvalRuns.
+ *   - renderEvalRunMarkdown: sections, disclaimer, pipe-escaping in cells.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+import {
+  EVAL_RUN_RUNNER_VERSION,
+  generateEvalRunId,
+  getEvalRun,
+  listEvalRuns,
+  renderEvalRunMarkdown,
+  runEvalCase,
+  writeEvalRun,
+} from './runner.js';
+import { sha256Bytes } from '../eval-gen/replay-fixture.js';
+import { EvalCaseSchema, type EvalCase, type FailurePattern } from '../schemas.js';
+import {
+  getEvalRunJsonPath,
+  getEvalRunMarkdownPath,
+  getEvalRunsDir,
+  getEvalRunsIndexPath,
+} from '../paths.js';
+
+// ---------------------------------------------------------------------------
+// Filesystem fixture
+// ---------------------------------------------------------------------------
+
+let originalAfkHome: string | undefined;
+let tempHome: string;
+
+beforeEach(() => {
+  originalAfkHome = process.env['AFK_HOME'];
+  tempHome = mkdtemp();
+  process.env['AFK_HOME'] = tempHome;
+});
+
+afterEach(() => {
+  if (originalAfkHome === undefined) delete process.env['AFK_HOME'];
+  else process.env['AFK_HOME'] = originalAfkHome;
+  rmSync(tempHome, { recursive: true, force: true });
+});
+
+function mkdtemp(): string {
+  const { mkdtempSync } = require('fs');
+  return mkdtempSync(join(tmpdir(), 'afk-evalrun-test-'));
+}
+
+const FIXED_NOW = () => new Date('2026-06-11T12:00:00.000Z');
+const DEFAULT_FIXTURE_BYTES = Buffer.from('{"seq":0,"kind":"tool_call"}\n');
+
+/**
+ * Build a schema-valid EvalCase and (by default) write its fixture under the
+ * temp AFK_HOME so the default resolver finds it. `sliceSha256` is computed
+ * from the bytes written so fixture-integrity passes unless tampered.
+ */
+function makeEvalCase(opts: {
+  evalCaseId?: string;
+  cardSlug?: string;
+  pattern?: FailurePattern;
+  fixtureBytes?: Buffer;
+  writeFixture?: boolean;
+} = {}): EvalCase {
+  const cardSlug = opts.cardSlug ?? 'repeated-tool-grep-abc123';
+  const evalCaseId = opts.evalCaseId ?? `${cardSlug}-eval-20260611-ab12cd`;
+  const pattern = opts.pattern ?? 'repeated-tool-use';
+  const fixtureBytes = opts.fixtureBytes ?? DEFAULT_FIXTURE_BYTES;
+  const fixturePath = `agent-framework/improve/eval-cases/${evalCaseId}.fixture.jsonl`;
+
+  if (opts.writeFixture !== false) {
+    const abs = join(tempHome, fixturePath);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, fixtureBytes);
+  }
+
+  const evalCase: EvalCase = {
+    schemaVersion: 1,
+    evalCaseId,
+    cardSlug,
+    proposalId: null,
+    title: `Replay [pattern-absent]: ${pattern} (through seq 0)`,
+    createdAt: '2026-06-11T11:00:00.000Z',
+    kind: 'replay',
+    replay: {
+      sourceSessionId: 'sess-a',
+      sourceTracePath: 'state/witness/sess-a/trace.jsonl',
+      fixturePath,
+      evidenceRowIndex: 0,
+      evidenceEventIndices: [0],
+      sliceLineRange: { startLine: 1, endLine: 1 },
+      sliceLineCount: 1,
+      sliceSha256: sha256Bytes(fixtureBytes),
+    },
+    assertion: {
+      kind: 'pattern-absent',
+      patternId: pattern,
+      detectorVersion: `${pattern}@v1`,
+      rationale: 'test rationale',
+    },
+    provenance: {
+      detectorAtGeneration: `${pattern}@v1`,
+      fingerprintAtGeneration: null,
+      cardOccurrenceCountAtGeneration: 1,
+      cardLastSeenAtGeneration: '2026-06-11T11:00:00.000Z',
+      generatedBy: 'replay-fixture',
+    },
+    status: 'draft',
+    notes: [],
+  };
+  return EvalCaseSchema.parse(evalCase);
+}
+
+// ---------------------------------------------------------------------------
+// generateEvalRunId
+// ---------------------------------------------------------------------------
+
+describe('generateEvalRunId', () => {
+  it('uses the -run- infix and a yyyymmdd-6hex suffix', () => {
+    const id = generateEvalRunId('repeated-tool-grep-abc123', {
+      now: FIXED_NOW,
+      randomSuffix: () => '7e1a09',
+    });
+    expect(id).toBe('repeated-tool-grep-abc123-run-20260611-7e1a09');
+    expect(id).toMatch(/^[a-z0-9][a-z0-9-]*$/);
+  });
+
+  it('throws on a non-hex suffix', () => {
+    expect(() => generateEvalRunId('slug', { randomSuffix: () => 'ZZZ' })).toThrow(/6 lowercase hex/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runEvalCase
+// ---------------------------------------------------------------------------
+
+describe('runEvalCase', () => {
+  const baseCtx = {
+    evalRunId: 'repeated-tool-grep-abc123-run-20260611-7e1a09',
+    now: FIXED_NOW,
+    clockMs: stubClock([1000, 1042]),
+  };
+
+  it('passes for a supported pattern with an intact fixture', async () => {
+    const run = await runEvalCase(makeEvalCase({ pattern: 'repeated-tool-use' }), { ...baseCtx, clockMs: stubClock([1000, 1042]) });
+
+    expect(run.status).toBe('pass');
+    expect(run.contract).toBe('repeat-loop-circuit-breaker');
+    expect(run.patternId).toBe('repeated-tool-use');
+    expect(run.durationMs).toBe(42);
+    expect(run.createdAt).toBe('2026-06-11T12:00:00.000Z');
+    expect(run.runner).toEqual({ version: EVAL_RUN_RUNNER_VERSION, mode: 'deterministic' });
+
+    // fixture-integrity is always the first check.
+    expect(run.checks[0]?.name).toBe('fixture-integrity');
+    expect(run.checks[0]?.status).toBe('pass');
+    // ...followed by the 4 circuit-breaker checks, all passing.
+    expect(run.checks.every((c) => c.status === 'pass')).toBe(true);
+    expect(run.checks).toHaveLength(5);
+  });
+
+  it('fails when the committed fixture no longer matches its sha256', async () => {
+    const evalCase = makeEvalCase({ pattern: 'repeated-tool-use' });
+    // Tamper: overwrite the fixture on disk with different bytes.
+    const abs = join(tempHome, evalCase.replay.fixturePath);
+    writeFileSync(abs, Buffer.from('{"seq":0,"tampered":true}\n'));
+
+    const run = await runEvalCase(evalCase, { ...baseCtx, clockMs: stubClock([1, 2]) });
+
+    expect(run.status).toBe('fail');
+    const fixtureCheck = run.checks.find((c) => c.name === 'fixture-integrity');
+    expect(fixtureCheck?.status).toBe('fail');
+    // The guardrail checks themselves still pass — only the fixture is corrupt.
+    expect(run.checks.filter((c) => c.name !== 'fixture-integrity').every((c) => c.status === 'pass')).toBe(true);
+  });
+
+  it('fails when the committed fixture is missing', async () => {
+    const evalCase = makeEvalCase({ pattern: 'repeated-tool-use', writeFixture: false });
+    const run = await runEvalCase(evalCase, { ...baseCtx, clockMs: stubClock([1, 2]) });
+    expect(run.status).toBe('fail');
+    const fixtureCheck = run.checks.find((c) => c.name === 'fixture-integrity');
+    expect(fixtureCheck?.status).toBe('fail');
+    expect(fixtureCheck?.actual).toContain('not found');
+  });
+
+  it('reports unsupported for a pattern with no registered contract', async () => {
+    const run = await runEvalCase(makeEvalCase({ pattern: 'closure-anomaly' }), { ...baseCtx, clockMs: stubClock([1, 2]) });
+    expect(run.status).toBe('unsupported');
+    expect(run.contract).toBeNull();
+    // Only the fixture check ran (it passed); no contract checks.
+    expect(run.checks).toHaveLength(1);
+    expect(run.checks[0]?.name).toBe('fixture-integrity');
+    expect(run.notes.some((n) => /No deterministic validation contract/.test(n.text))).toBe(true);
+  });
+
+  it('a failed check beats unsupported (corrupt fixture on an unsupported pattern)', async () => {
+    const evalCase = makeEvalCase({ pattern: 'closure-anomaly', writeFixture: false });
+    const run = await runEvalCase(evalCase, { ...baseCtx, clockMs: stubClock([1, 2]) });
+    expect(run.status).toBe('fail');
+  });
+
+  it('validates the subagent-block (skill depth hint) contract end to end', async () => {
+    const run = await runEvalCase(makeEvalCase({ pattern: 'subagent-block' }), { ...baseCtx, clockMs: stubClock([1, 2]) });
+    expect(run.status).toBe('pass');
+    expect(run.contract).toBe('skill-max-depth-recovery-hint');
+    expect(run.checks.some((c) => c.name === 'recovery-hint-present' && c.status === 'pass')).toBe(true);
+  });
+
+  it('honours the resolveFixtureAbsPath seam', async () => {
+    const evalCase = makeEvalCase({ pattern: 'tool-failure-density', writeFixture: false });
+    // Write the fixture somewhere the default resolver would NOT look.
+    const customAbs = join(tempHome, 'custom', 'elsewhere.jsonl');
+    mkdirSync(dirname(customAbs), { recursive: true });
+    writeFileSync(customAbs, DEFAULT_FIXTURE_BYTES);
+
+    const run = await runEvalCase(evalCase, {
+      ...baseCtx,
+      clockMs: stubClock([1, 2]),
+      resolveFixtureAbsPath: () => customAbs,
+    });
+    expect(run.status).toBe('pass');
+    expect(run.checks.find((c) => c.name === 'fixture-integrity')?.status).toBe('pass');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeEvalRun + read helpers
+// ---------------------------------------------------------------------------
+
+describe('writeEvalRun / getEvalRun / listEvalRuns', () => {
+  it('writes JSON + md + index, and round-trips through getEvalRun', async () => {
+    const run = await runEvalCase(makeEvalCase(), {
+      evalRunId: 'repeated-tool-grep-abc123-run-20260611-aaa111',
+      now: FIXED_NOW,
+      clockMs: stubClock([0, 3]),
+    });
+    const outcome = writeEvalRun(run);
+
+    expect(outcome.jsonPath).toBe(getEvalRunJsonPath(run.evalRunId));
+    expect(outcome.markdownPath).toBe(getEvalRunMarkdownPath(run.evalRunId));
+    expect(existsSync(getEvalRunsDir())).toBe(true);
+    expect(existsSync(outcome.jsonPath)).toBe(true);
+    expect(existsSync(outcome.markdownPath)).toBe(true);
+
+    const reread = getEvalRun(run.evalRunId);
+    expect(reread).toEqual(run);
+
+    // Index has exactly one created event for this run.
+    const indexLines = readFileSync(getEvalRunsIndexPath(), 'utf-8').trim().split('\n');
+    expect(indexLines).toHaveLength(1);
+    const event = JSON.parse(indexLines[0]!);
+    expect(event.event).toBe('created');
+    expect(event.evalRunId).toBe(run.evalRunId);
+    expect(event.status).toBe('pass');
+  });
+
+  it('lists runs newest-first', async () => {
+    const older = await runEvalCase(makeEvalCase(), {
+      evalRunId: 'slug-run-20260611-000001',
+      now: () => new Date('2026-06-11T10:00:00.000Z'),
+      clockMs: stubClock([0, 1]),
+    });
+    const newer = await runEvalCase(makeEvalCase(), {
+      evalRunId: 'slug-run-20260611-000002',
+      now: () => new Date('2026-06-11T11:00:00.000Z'),
+      clockMs: stubClock([0, 1]),
+    });
+    writeEvalRun(older);
+    writeEvalRun(newer);
+
+    const entries = listEvalRuns();
+    expect(entries.map((e) => e.evalRunId)).toEqual([newer.evalRunId, older.evalRunId]);
+    expect(entries[0]?.status).toBe('pass');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderEvalRunMarkdown
+// ---------------------------------------------------------------------------
+
+describe('renderEvalRunMarkdown', () => {
+  it('renders the header, disclaimer, checks table, and evidence', async () => {
+    const run = await runEvalCase(makeEvalCase({ pattern: 'repeated-tool-use' }), {
+      evalRunId: 'repeated-tool-grep-abc123-run-20260611-7e1a09',
+      now: FIXED_NOW,
+      clockMs: stubClock([0, 7]),
+    });
+    const md = renderEvalRunMarkdown(run);
+
+    expect(md).toContain('# repeated-tool-grep-abc123-run-20260611-7e1a09 — `eval-run` — `pass`');
+    expect(md).toContain('does');
+    expect(md).toContain('NOT replay the fixture through the detector');
+    expect(md).toContain('## Result: ✓ PASS');
+    expect(md).toContain('| Check | Status | Expected | Actual |');
+    expect(md).toContain('fixture-integrity');
+    expect(md).toContain('REPEAT_CIRCUIT_BREAKER_THRESHOLD');
+    expect(md).toContain(`\`${EVAL_RUN_RUNNER_VERSION}\``);
+  });
+
+  it('escapes pipes in table cells so the markdown table stays valid', async () => {
+    const run = await runEvalCase(makeEvalCase({ pattern: 'tool-failure-density' }), {
+      evalRunId: 'slug-run-20260611-bbbbbb',
+      now: FIXED_NOW,
+      clockMs: stubClock([0, 1]),
+    });
+    const md = renderEvalRunMarkdown(run);
+    // tool-failure-density actual cells contain a "[a, b]" detector list — no
+    // raw pipes there, but the escaping helper must never leak an unescaped
+    // pipe into a cell. Assert every checks-table row has the right column count.
+    const rows = md.split('\n').filter((l) => l.startsWith('| ') && !l.startsWith('| Check') && !l.startsWith('|---'));
+    for (const row of rows) {
+      // 4 columns → 5 pipe delimiters (escaped pipes are \\| and don't count).
+      const delimiters = row.replace(/\\\|/g, '').split('|').length - 1;
+      expect(delimiters).toBe(5);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** A monotonic clock stub that yields the given values, then repeats the last. */
+function stubClock(values: number[]): () => number {
+  let i = 0;
+  return () => values[Math.min(i++, values.length - 1)]!;
+}

--- a/src/improve/eval-run/runner.ts
+++ b/src/improve/eval-run/runner.ts
@@ -1,0 +1,466 @@
+/**
+ * Eval-run runner.
+ *
+ * Loads an {@link EvalCase}, executes the smallest deterministic validation
+ * contract registered for its `assertion.patternId` (see
+ * {@link ./contracts}), re-verifies the eval-case's committed fixture
+ * checksum, aggregates a top-line {@link EvalRunStatus}, and persists the
+ * result triple:
+ *
+ *   <evalRunId>.json   EvalRun result (the artifact)
+ *   <evalRunId>.md     human-friendly rendered view
+ *   .index.jsonl       append-only event log (best-effort)
+ *
+ * ## What this runner does NOT do
+ *
+ * No LLM. No patch/apply. No git. No fixture *replay* through the detector —
+ * the eval-case's own `pattern-absent` assertion remains the full contract;
+ * this runner validates the guardrail the pattern maps to instead. The
+ * boundary is documented on {@link EvalRunSchema}.
+ *
+ * ## Eval-run ID format
+ *
+ *   `<cardSlug>-run-<yyyymmdd>-<6hex>`
+ *
+ * The `-run-` infix keeps the four improve artifact kinds mechanically
+ * distinguishable by name alone:
+ *   cards      `repeated-tool-grep-ac8317edd609`
+ *   proposals  `repeated-tool-grep-ac8317edd609-20260524-ab12cd`
+ *   eval-cases `repeated-tool-grep-ac8317edd609-eval-20260524-9c4d2f`
+ *   eval-runs  `repeated-tool-grep-ac8317edd609-run-20260611-7e1a09`
+ *
+ * @module improve/eval-run/runner
+ */
+
+import { randomBytes } from 'crypto';
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import {
+  EvalRunIndexEventSchema,
+  EvalRunSchema,
+  type EvalCase,
+  type EvalCheck,
+  type EvalRun,
+  type EvalRunEvidenceRef,
+  type EvalRunIndexEvent,
+  type EvalRunStatus,
+  type TriageNote,
+} from '../schemas.js';
+import {
+  getEvalRunJsonPath,
+  getEvalRunMarkdownPath,
+  getEvalRunsDir,
+  getEvalRunsIndexPath,
+} from '../paths.js';
+import { getAfkHome } from '../../paths.js';
+import { sha256Bytes } from '../eval-gen/replay-fixture.js';
+import type { IdContext } from '../eval-gen/writer.js';
+import { makeCheck, resolveContract, snapshot, supportedContractPatterns } from './contracts.js';
+
+/** Runner identity stamped into every result. */
+export const EVAL_RUN_RUNNER_VERSION = 'eval-run@v1';
+
+// ---------------------------------------------------------------------------
+// ID generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an eval-run id from a card slug: `<cardSlug>-run-<yyyymmdd>-<6hex>`.
+ * Matches `^[a-z0-9][a-z0-9-]*$` so long as `cardSlug` already does.
+ */
+export function generateEvalRunId(cardSlug: string, ctx: IdContext = {}): string {
+  const now = (ctx.now ?? (() => new Date()))();
+  const yyyymmdd = formatYyyymmdd(now);
+  const suffix =
+    ctx.randomSuffix !== undefined ? ctx.randomSuffix() : randomBytes(3).toString('hex');
+  if (!/^[0-9a-f]{6}$/.test(suffix)) {
+    throw new Error(`generateEvalRunId: randomSuffix must be 6 lowercase hex chars (got '${suffix}')`);
+  }
+  return `${cardSlug}-run-${yyyymmdd}-${suffix}`;
+}
+
+function formatYyyymmdd(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}${m}${day}`;
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+export interface RunEvalCaseContext {
+  /** Pre-generated id. Tests inject; the CLI uses {@link generateEvalRunId}. */
+  evalRunId: string;
+  /** Override timestamp source. Defaults to `new Date()`. */
+  now?: () => Date;
+  /** Monotonic clock for `durationMs`. Defaults to `Date.now`. */
+  clockMs?: () => number;
+  /**
+   * Resolve the absolute path of the eval-case's committed fixture from its
+   * AFK-relative `replay.fixturePath`. Defaults to `join(getAfkHome(), p)`.
+   * Tests inject for isolation.
+   */
+  resolveFixtureAbsPath?: (relativeFixturePath: string) => string;
+}
+
+/**
+ * Execute the validation contract for an eval-case and return an
+ * {@link EvalRun}. Pure modulo the fixture read; performs NO disk writes —
+ * the caller persists via {@link writeEvalRun}.
+ *
+ * Status precedence (highest wins): `error` > `fail` > `unsupported` > `pass`.
+ * A failed check (including a fixture-integrity mismatch) forces `fail` even
+ * when the pattern has no contract — a corrupt fixture is a real failure.
+ */
+export async function runEvalCase(evalCase: EvalCase, ctx: RunEvalCaseContext): Promise<EvalRun> {
+  const now = (ctx.now ?? (() => new Date()))();
+  const nowIso = now.toISOString();
+  const clock = ctx.clockMs ?? (() => Date.now());
+  const t0 = clock();
+
+  const checks: EvalCheck[] = [];
+  const evidence: EvalRunEvidenceRef[] = [];
+  const notes: TriageNote[] = [];
+
+  // 1. Fixture integrity — ground the run in the eval-case's durable artifact.
+  const fixture = checkFixtureIntegrity(evalCase, ctx);
+  checks.push(fixture.check);
+  if (fixture.evidence) evidence.push(fixture.evidence);
+
+  // 2. Run the pattern's validation contract (if one is registered).
+  const contract = resolveContract(evalCase.assertion.patternId);
+  let contractId: string | null = null;
+  let contractThrew = false;
+
+  if (!contract) {
+    notes.push({
+      at: nowIso,
+      text:
+        `No deterministic validation contract is registered for pattern ` +
+        `'${evalCase.assertion.patternId}'. Supported: ${supportedContractPatterns().join(', ')}.`,
+    });
+  } else {
+    contractId = contract.id;
+    try {
+      const probe = await contract.run();
+      checks.push(...probe.checks);
+      evidence.push(...probe.evidence);
+    } catch (err) {
+      contractThrew = true;
+      const message = err instanceof Error ? err.message : String(err);
+      notes.push({
+        at: nowIso,
+        text: `Contract '${contract.id}' threw during execution: ${snapshot(message)}`,
+      });
+    }
+  }
+
+  const status = decideStatus({ hasContract: contract !== undefined, contractThrew, checks });
+  const durationMs = Math.max(0, Math.round(clock() - t0));
+
+  const evalRun: EvalRun = {
+    schemaVersion: 1,
+    evalRunId: ctx.evalRunId,
+    evalCaseId: evalCase.evalCaseId,
+    cardSlug: evalCase.cardSlug,
+    patternId: evalCase.assertion.patternId,
+    contract: contractId,
+    status,
+    createdAt: nowIso,
+    durationMs,
+    checks,
+    evidence,
+    runner: { version: EVAL_RUN_RUNNER_VERSION, mode: 'deterministic' },
+    notes,
+  };
+
+  // Validate up-front so the caller never persists a malformed object.
+  EvalRunSchema.parse(evalRun);
+  return evalRun;
+}
+
+function decideStatus(args: {
+  hasContract: boolean;
+  contractThrew: boolean;
+  checks: EvalCheck[];
+}): EvalRunStatus {
+  if (args.contractThrew) return 'error';
+  if (args.checks.some((c) => c.status === 'fail')) return 'fail';
+  if (!args.hasContract) return 'unsupported';
+  return 'pass';
+}
+
+interface FixtureCheckResult {
+  check: EvalCheck;
+  evidence?: EvalRunEvidenceRef;
+}
+
+/**
+ * Re-verify the eval-case's committed fixture: hash the bytes on disk and
+ * compare to `replay.sliceSha256`. A missing or mismatched fixture is a
+ * `fail` — the eval-case's durable contract is broken. The fixture writer
+ * (`eval-gen`) performs the inverse check at write time; this is the
+ * read-time half the schema documents.
+ */
+function checkFixtureIntegrity(evalCase: EvalCase, ctx: RunEvalCaseContext): FixtureCheckResult {
+  const resolve = ctx.resolveFixtureAbsPath ?? ((p: string) => join(getAfkHome(), p));
+  const abs = resolve(evalCase.replay.fixturePath);
+  const expectedSha = evalCase.replay.sliceSha256;
+  const name = 'fixture-integrity';
+  const description = "Committed replay fixture exists and matches the eval-case's recorded sha256";
+
+  if (!existsSync(abs)) {
+    return {
+      check: makeCheck({
+        name,
+        description,
+        pass: false,
+        expected: `fixture present at ${evalCase.replay.fixturePath}`,
+        actual: 'fixture file not found on disk',
+      }),
+    };
+  }
+
+  let actualSha: string;
+  try {
+    actualSha = sha256Bytes(readFileSync(abs));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      check: makeCheck({
+        name,
+        description,
+        pass: false,
+        expected: `readable fixture (${expectedSha})`,
+        actual: `read error: ${snapshot(message)}`,
+      }),
+    };
+  }
+
+  const ok = actualSha === expectedSha;
+  return {
+    check: makeCheck({
+      name,
+      description,
+      pass: ok,
+      expected: expectedSha,
+      actual: actualSha,
+    }),
+    evidence: {
+      kind: 'fixture',
+      ref: evalCase.replay.fixturePath,
+      detail: `sha256 ${ok ? 'match' : 'MISMATCH'} (${evalCase.replay.sliceLineCount} lines)`,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Persist
+// ---------------------------------------------------------------------------
+
+export interface WriteEvalRunOutcome {
+  evalRunId: string;
+  jsonPath: string;
+  markdownPath: string;
+}
+
+/** Persist an eval-run: JSON + markdown (atomic) + `.index.jsonl` append. */
+export function writeEvalRun(evalRun: EvalRun): WriteEvalRunOutcome {
+  const validated = EvalRunSchema.parse(evalRun);
+
+  const dir = getEvalRunsDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+  const jsonPath = getEvalRunJsonPath(validated.evalRunId);
+  const mdPath = getEvalRunMarkdownPath(validated.evalRunId);
+
+  atomicWriteJson(jsonPath, validated);
+  atomicWriteText(mdPath, renderEvalRunMarkdown(validated));
+
+  appendIndex({
+    timestamp: new Date().toISOString(),
+    event: 'created',
+    evalRunId: validated.evalRunId,
+    evalCaseId: validated.evalCaseId,
+    cardSlug: validated.cardSlug,
+    patternId: validated.patternId,
+    contract: validated.contract,
+    status: validated.status,
+  });
+
+  return { evalRunId: validated.evalRunId, jsonPath, markdownPath: mdPath };
+}
+
+// ---------------------------------------------------------------------------
+// Markdown renderer
+// ---------------------------------------------------------------------------
+
+const STATUS_GLYPH: Record<EvalRunStatus, string> = {
+  pass: '✓ PASS',
+  fail: '✗ FAIL',
+  unsupported: '– UNSUPPORTED',
+  error: '⚠ ERROR',
+};
+
+const CHECK_GLYPH: Record<EvalCheck['status'], string> = {
+  pass: '✓',
+  fail: '✗',
+  skipped: '–',
+};
+
+export function renderEvalRunMarkdown(run: EvalRun): string {
+  const passed = run.checks.filter((c) => c.status === 'pass').length;
+  const failed = run.checks.filter((c) => c.status === 'fail').length;
+  const skipped = run.checks.filter((c) => c.status === 'skipped').length;
+
+  const out: string[] = [];
+  out.push(`# ${run.evalRunId} — \`eval-run\` — \`${run.status}\``);
+  out.push('');
+  out.push(`Deterministic guardrail validation of eval-case \`${run.evalCaseId}\`.`);
+  out.push('');
+  out.push(
+    `**Eval-case:** \`${run.evalCaseId}\` · **Card:** \`${run.cardSlug}\` · ` +
+      `**Pattern:** \`${run.patternId}\` · **Contract:** ${run.contract ? `\`${run.contract}\`` : '_(none)_'} · ` +
+      `**Created:** ${run.createdAt} · **Duration:** ${run.durationMs}ms`,
+  );
+  out.push('');
+
+  out.push('> **What this is.** A narrow, deterministic check that the guardrail');
+  out.push(`> mapped to pattern \`${run.patternId}\` is present and behaving. It does`);
+  out.push('> NOT replay the fixture through the detector — that broader capability');
+  out.push("> is reserved for a later sprint. The eval-case's own `pattern-absent`");
+  out.push('> assertion remains the full contract.');
+  out.push('');
+
+  out.push(`## Result: ${STATUS_GLYPH[run.status]}  (${passed}/${run.checks.length} checks passed${failed ? `, ${failed} failed` : ''}${skipped ? `, ${skipped} skipped` : ''})`);
+  out.push('');
+
+  out.push('## Checks');
+  out.push('');
+  if (run.checks.length === 0) {
+    out.push('_(none)_');
+  } else {
+    out.push('| Check | Status | Expected | Actual |');
+    out.push('|---|---|---|---|');
+    for (const c of run.checks) {
+      out.push(`| ${cell(c.name)} | ${CHECK_GLYPH[c.status]} ${c.status} | ${cell(c.expected)} | ${cell(c.actual)} |`);
+    }
+  }
+  out.push('');
+
+  out.push('## Evidence');
+  out.push('');
+  if (run.evidence.length === 0) {
+    out.push('_(none)_');
+  } else {
+    for (const e of run.evidence) {
+      out.push(`- **[${e.kind}]** \`${e.ref}\` — ${e.detail}`);
+    }
+  }
+  out.push('');
+
+  out.push('## Runner');
+  out.push('');
+  out.push(`- **Version:** \`${run.runner.version}\` · **Mode:** \`${run.runner.mode}\``);
+  out.push('');
+
+  out.push('## Notes');
+  out.push('');
+  if (run.notes.length === 0) {
+    out.push('_(none)_');
+  } else {
+    for (const n of run.notes) out.push(`- _${n.at}_ — ${n.text}`);
+  }
+  out.push('');
+
+  return out.join('\n');
+}
+
+/** Escape a value for a markdown table cell (pipes + newlines). */
+function cell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+// ---------------------------------------------------------------------------
+// Read-side helpers
+// ---------------------------------------------------------------------------
+
+export interface EvalRunListEntry {
+  evalRunId: string;
+  evalCaseId: string;
+  cardSlug: string;
+  patternId: EvalRun['patternId'];
+  contract: string | null;
+  status: EvalRunStatus;
+  createdAt: string;
+}
+
+export function listEvalRuns(): EvalRunListEntry[] {
+  const dir = getEvalRunsDir();
+  if (!existsSync(dir)) return [];
+  const entries: EvalRunListEntry[] = [];
+  for (const fileName of readdirSync(dir)) {
+    if (!fileName.endsWith('.json')) continue;
+    if (fileName.startsWith('.')) continue;
+    const run = readEvalRunIfExists(join(dir, fileName));
+    if (!run) continue;
+    entries.push({
+      evalRunId: run.evalRunId,
+      evalCaseId: run.evalCaseId,
+      cardSlug: run.cardSlug,
+      patternId: run.patternId,
+      contract: run.contract,
+      status: run.status,
+      createdAt: run.createdAt,
+    });
+  }
+  entries.sort((a, b) => {
+    if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? 1 : -1;
+    return a.evalRunId < b.evalRunId ? -1 : 1;
+  });
+  return entries;
+}
+
+export function getEvalRun(evalRunId: string): EvalRun | undefined {
+  return readEvalRunIfExists(getEvalRunJsonPath(evalRunId));
+}
+
+function readEvalRunIfExists(path: string): EvalRun | undefined {
+  if (!existsSync(path)) return undefined;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8'));
+    const validated = EvalRunSchema.safeParse(parsed);
+    return validated.success ? validated.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Index append + atomic writes (matching eval-gen writer conventions)
+// ---------------------------------------------------------------------------
+
+function appendIndex(event: EvalRunIndexEvent): void {
+  const validated = EvalRunIndexEventSchema.parse(event);
+  const dir = getEvalRunsDir();
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  try {
+    writeFileSync(getEvalRunsIndexPath(), JSON.stringify(validated) + '\n', { flag: 'a' });
+  } catch {
+    // Best-effort, matching the card / proposal / eval-case writers.
+  }
+}
+
+function atomicWriteJson(path: string, data: unknown): void {
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2));
+  renameSync(tmp, path);
+}
+
+function atomicWriteText(path: string, text: string): void {
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, text);
+  renameSync(tmp, path);
+}

--- a/src/improve/paths.ts
+++ b/src/improve/paths.ts
@@ -13,16 +13,19 @@
  *       .index.jsonl                  append-only event log
  *       <proposal-id>.json            ImprovementProposal artifact
  *       <proposal-id>.md              human-friendly rendered view
- *     eval-cases/                     [Sprint 3 — this commit]
+ *     eval-cases/                     [Sprint 3]
  *       .index.jsonl                  append-only event log
  *       <eval-case-id>.json           EvalCase artifact (the contract)
  *       <eval-case-id>.fixture.jsonl  byte-identical slice of the source trace
  *       <eval-case-id>.md             human-friendly rendered view
+ *     eval-runs/                      [this commit — the eval-run validator]
+ *       .index.jsonl                  append-only event log
+ *       <eval-run-id>.json            EvalRun result artifact
+ *       <eval-run-id>.md              human-friendly rendered view
  *
- * Future phases will add improve-runs/, reports/, and improve-telemetry.jsonl
- * under the same root. Those are intentionally absent — this module only
- * resolves what is read or written by `scan`, `cards`, `propose`, and
- * `eval-gen`.
+ * Future phases will add reports/ and improve-telemetry.jsonl under the same
+ * root. Those are intentionally absent — this module only resolves what is
+ * read or written by `scan`, `cards`, `propose`, `eval-gen`, and `eval-run`.
  *
  * The trace source is read-only from `$AFK_HOME/state/witness/<id>/trace.jsonl`
  * (see {@link getTraceDir} in src/paths.ts). The improve pipeline never
@@ -124,4 +127,28 @@ export function getEvalCaseFixturePath(evalCaseId: string): string {
 /** Resolve `<eval-case-id>.md`. No I/O. */
 export function getEvalCaseMarkdownPath(evalCaseId: string): string {
   return join(getEvalCasesDir(), `${evalCaseId}.md`);
+}
+
+// ---------------------------------------------------------------------------
+// Eval runs (the eval-run validator)
+// ---------------------------------------------------------------------------
+
+/** Directory holding `<eval-run-id>.json` + `<eval-run-id>.md` run results. */
+export function getEvalRunsDir(): string {
+  return join(getImproveRoot(), 'eval-runs');
+}
+
+/** Append-only event log for the eval-runs directory. */
+export function getEvalRunsIndexPath(): string {
+  return join(getEvalRunsDir(), '.index.jsonl');
+}
+
+/** Resolve `<eval-run-id>.json`. No I/O. */
+export function getEvalRunJsonPath(evalRunId: string): string {
+  return join(getEvalRunsDir(), `${evalRunId}.json`);
+}
+
+/** Resolve `<eval-run-id>.md`. No I/O. */
+export function getEvalRunMarkdownPath(evalRunId: string): string {
+  return join(getEvalRunsDir(), `${evalRunId}.md`);
 }

--- a/src/improve/schemas.ts
+++ b/src/improve/schemas.ts
@@ -507,6 +507,123 @@ export const EvalCaseIndexEventSchema = z.object({
 export type EvalCaseIndexEvent = z.infer<typeof EvalCaseIndexEventSchema>;
 
 // ---------------------------------------------------------------------------
+// EvalRun — the eval-run validator's result artifact
+// ---------------------------------------------------------------------------
+
+/**
+ * **An eval-run is the RESULT of validating an eval-case's pattern against the
+ * live codebase — not a fixture replay.**
+ *
+ * `afk improve eval-run <evalCaseId|cardSlug>` loads an existing eval-case,
+ * looks up the smallest deterministic validation contract registered for its
+ * `assertion.patternId`, executes it in-process (no LLM, no patch/apply, no
+ * git), and writes one of these to `eval-runs/<evalRunId>.json` with a sibling
+ * `<evalRunId>.md`.
+ *
+ * **Scope boundary.** This narrow runner does NOT replay the committed fixture
+ * through the detector and assert {@link EvalAssertionSchema} (`pattern-absent`)
+ * holds — that broader capability is reserved for a later sprint. It instead
+ * exercises the guardrail the pattern maps to (e.g. the repeat-loop circuit
+ * breaker for `repeated-tool-use`) and re-verifies the eval-case's own fixture
+ * checksum. The two are complementary: a passing eval-run is evidence the fix
+ * that makes the pattern absent is present and behaving; the eval-case's
+ * `pattern-absent` assertion remains the full contract.
+ *
+ * **Never merged.** Each `eval-run` call writes a fresh `evalRunId`.
+ */
+
+/** One deterministic assertion executed by a validation contract. */
+export const EvalCheckStatusSchema = z.enum(['pass', 'fail', 'skipped']);
+export type EvalCheckStatus = z.infer<typeof EvalCheckStatusSchema>;
+
+/**
+ * A single check the runner asserted. `expected`/`actual` are human-readable
+ * snapshots (not machine values) so a reviewer reading the JSON or markdown
+ * can see WHY a check passed or failed without re-running anything.
+ */
+export const EvalCheckSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1),
+  status: EvalCheckStatusSchema,
+  expected: z.string(),
+  actual: z.string(),
+});
+export type EvalCheck = z.infer<typeof EvalCheckSchema>;
+
+/**
+ * A pointer a human can follow to confirm a check independently:
+ *   - `config-value`      — a constant / registry flag (e.g. a threshold).
+ *   - `observed-behavior` — a result the runner produced by exercising code.
+ *   - `source-symbol`     — a function / symbol the contract validated.
+ *   - `fixture`           — the eval-case's committed replay fixture.
+ */
+export const EvalRunEvidenceKindSchema = z.enum([
+  'config-value',
+  'observed-behavior',
+  'source-symbol',
+  'fixture',
+]);
+export type EvalRunEvidenceKind = z.infer<typeof EvalRunEvidenceKindSchema>;
+
+export const EvalRunEvidenceRefSchema = z.object({
+  kind: EvalRunEvidenceKindSchema,
+  /** A symbol path, file ref, or registry key — stable enough to grep for. */
+  ref: z.string().min(1),
+  detail: z.string(),
+});
+export type EvalRunEvidenceRef = z.infer<typeof EvalRunEvidenceRefSchema>;
+
+/**
+ * Top-line run outcome:
+ *   - `pass`        — a contract ran and every check passed.
+ *   - `fail`        — a contract ran and at least one check failed.
+ *   - `unsupported` — no deterministic contract is registered for the pattern.
+ *   - `error`       — the contract threw unexpectedly mid-run.
+ */
+export const EvalRunStatusSchema = z.enum(['pass', 'fail', 'unsupported', 'error']);
+export type EvalRunStatus = z.infer<typeof EvalRunStatusSchema>;
+
+export const EvalRunSchema = z.object({
+  schemaVersion: z.literal(1),
+  evalRunId: z
+    .string()
+    .regex(/^[a-z0-9][a-z0-9-]*$/, 'evalRunId must be lowercase alphanumeric with hyphens'),
+  /** The eval-case this run validated. */
+  evalCaseId: z.string().min(1),
+  /** Denormalized from the eval-case for at-a-glance filtering. */
+  cardSlug: z.string().min(1),
+  /** The pattern whose guardrail was validated (from the eval-case assertion). */
+  patternId: FailurePatternSchema,
+  /** Id of the contract that ran; `null` when the pattern is `unsupported`. */
+  contract: z.string().min(1).nullable(),
+  status: EvalRunStatusSchema,
+  createdAt: z.string().datetime(),
+  /** Wall-clock runtime of the run in milliseconds. */
+  durationMs: z.number().int().nonnegative(),
+  checks: z.array(EvalCheckSchema),
+  evidence: z.array(EvalRunEvidenceRefSchema),
+  runner: z.object({
+    version: z.string().min(1),
+    mode: z.literal('deterministic'),
+  }),
+  notes: z.array(TriageNoteSchema).default([]),
+});
+export type EvalRun = z.infer<typeof EvalRunSchema>;
+
+/** Append-only event log entry for the eval-runs directory. */
+export const EvalRunIndexEventSchema = z.object({
+  timestamp: z.string().datetime(),
+  event: z.literal('created'),
+  evalRunId: z.string(),
+  evalCaseId: z.string(),
+  cardSlug: z.string(),
+  patternId: FailurePatternSchema,
+  contract: z.string().nullable(),
+  status: EvalRunStatusSchema,
+});
+export type EvalRunIndexEvent = z.infer<typeof EvalRunIndexEventSchema>;
+
+// ---------------------------------------------------------------------------
 // Canonical forbidden-path globs (Sprint 2)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds `afk improve eval-run <evalCaseIdOrCardSlug>`, the first deterministic validation stage for improve eval-cases.

This stage:
- resolves an eval-case by eval-case id or card slug (most recent eval-case wins for a slug)
- verifies the committed fixture's checksum integrity
- runs the registered guardrail contract for the eval-case's pattern
- writes eval-run JSON + Markdown artifacts under `agent-framework/improve/eval-runs/`
- supports `pass` / `fail` / `unsupported` — **no LLM, patch/apply, git, or detector replay**

It intentionally does **not** replay fixtures through detectors yet. That remains the next stage.

## Contracts

Keyed by `FailurePattern` in `src/improve/eval-run/contracts.ts`; each exercises the real PR #80 guardrail rather than re-implementing it:

| Pattern | Contract | What it validates |
|---|---|---|
| `repeated-tool-use` | `repeat-loop-circuit-breaker` | A throwaway `SessionToolDispatcher` (no traceWriter/hooks → side-effect-free) trips at `REPEAT_CIRCUIT_BREAKER_THRESHOLD`, skips the handler on the tripped call, and resets on a different input |
| `subagent-block` | `skill-max-depth-recovery-hint` | The skill max-depth refusal carries the actionable recovery hint |
| `tool-failure-density` | `tool-failure-density-enabled` | The detector is in `defaultEnabledDetectorNames()` (not opt-in) |

Unmapped patterns (e.g. `closure-anomaly`) resolve to `unsupported` rather than failing. Every run also re-verifies the eval-case's committed fixture `sha256` — the read-time half of the integrity contract documented on `EvalReplaySchema`.

## Status precedence & CLI

`error` > `fail` > `unsupported` > `pass`; any failed check (including a fixture-integrity mismatch) forces `fail`. The CLI exits non-zero on `fail`/`error` so `afk improve eval-run X` is usable as a CI gate. Run ids use the `<cardSlug>-run-<yyyymmdd>-<6hex>` form, keeping the four improve artifact kinds (cards / proposals / eval-cases / eval-runs) mechanically distinguishable by name.

## Notable refactor

Extracts the skill max-depth refusal string into a pure, dependency-free module `src/agent/tools/skill-depth-message.ts` shared by `SkillExecutor` and the validator, so the contract can assert hint presence without importing the heavy skill-executor module graph or firing its `delegation.skipped` routing telemetry as a side effect.

## Scope explicitly excluded

Fixture replay through detectors, LLM/patch/apply, eval-link back-fill, git operations, and PR publishing — reserved for later stages.

## Test plan

- `pnpm lint` (tsc --noEmit strict): clean
- New tests: 24 (`contracts.test.ts` 11 + `runner.test.ts` 13)
- Full suite: **8815 passed, 12 skipped, 0 failures**; no regressions in the refactored `skill-executor` / `dispatcher` suites
- `pnpm build` (tsc emit + prompt copy): clean
- End-to-end CLI smoke: by-id, by-card-slug, `--json`, `--no-write`, `unsupported`→exit 0, tampered-fixture→`fail`/exit 1, not-found→exit 1
- No `@anthropic-ai/sdk` imports added (`audit:sdk:check` unaffected)
