### PR TITLE
feat(improve): add closure-anomaly guardrail + eval-run contract (abort subtype)

### DIFF
--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -24,6 +24,7 @@ import { DEFAULT_SESSION_TIMEOUT_MS, RESET_DRAIN_TIMEOUT_MS, withTimeout } from 
 import { dispatchSessionEnd, dispatchSessionStart } from './hooks-dispatch.js';
 import { HookBlockedError } from '../../utils/errors.js';
 import { classifyClosureReason } from './closure-reason.js';
+import { buildClosureGuidance } from './closure-guidance.js';
 import type {
   AccountInfo,
   AgentConfig,
@@ -931,12 +932,18 @@ export class AgentSession implements IAgentSession {
     if (this.sessionRunningTokens.cacheCreation > 0)
       finalTokens.cacheCreation = this.sessionRunningTokens.cacheCreation;
 
+    // closure-anomaly guardrail: attach an actionable recovery hint for an
+    // anomalous reason so the closure event names not just WHY it ended but
+    // what to do next. Null (benign / not-yet-covered reasons) → field omitted.
+    const guidance = buildClosureGuidance(reasonValue);
+
     await emitClosure(writer, {
       reason: reasonValue,
       finalTurnCount: this.turnCount,
       finalCostUsd: this.sessionRunningCostUsd,
       finalTokens,
       ...(this.lastStopReason !== undefined ? { lastStopReason: this.lastStopReason } : {}),
+      ...(guidance !== null ? { guidance } : {}),
     });
   }
 

--- a/src/agent/session/closure-guidance.test.ts
+++ b/src/agent/session/closure-guidance.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for the `closure-anomaly` guardrail — {@link buildClosureGuidance}.
+ *
+ * Pure function: maps a {@link ClosureReason} to an actionable recovery hint
+ * (abort subtype) or `null` (benign closes + anomalous reasons not yet
+ * covered). The wiring onto the closure trace event is covered in
+ * `trace/closure.test.ts`; the eval-run contract is covered in
+ * `improve/eval-run/contracts.test.ts`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ClosureReason } from '../trace/index.js';
+import { buildClosureGuidance, CLOSURE_ABORT_RECOVERY_HINT } from './closure-guidance.js';
+
+describe('buildClosureGuidance', () => {
+  it('returns the canonical recovery hint for an abort closure', () => {
+    expect(buildClosureGuidance('abort')).toBe(CLOSURE_ABORT_RECOVERY_HINT);
+    expect(CLOSURE_ABORT_RECOVERY_HINT.trim().length).toBeGreaterThan(0);
+  });
+
+  it('the abort hint names a concrete recovery action', () => {
+    expect(buildClosureGuidance('abort')).toMatch(/\b(resume|re-run|rerun|retry)\b/i);
+  });
+
+  it('the abort hint points at the real recovery command (afk --resume)', () => {
+    expect(CLOSURE_ABORT_RECOVERY_HINT).toMatch(/afk --resume/);
+  });
+
+  it('returns null for benign closes — no false-positive guidance', () => {
+    expect(buildClosureGuidance('model_end_turn')).toBeNull();
+    expect(buildClosureGuidance('truncated')).toBeNull();
+  });
+
+  it('returns null for anomalous reasons not yet covered (deferred subtypes)', () => {
+    const deferred: ClosureReason[] = [
+      'timeout',
+      'budget_exceeded',
+      'hook_blocked',
+      'iteration_cap',
+      'max_turns_exceeded',
+    ];
+    for (const reason of deferred) {
+      expect(buildClosureGuidance(reason), `reason=${reason}`).toBeNull();
+    }
+  });
+
+  it('is pure — repeated calls return the identical value', () => {
+    expect(buildClosureGuidance('abort')).toBe(buildClosureGuidance('abort'));
+  });
+});

--- a/src/agent/session/closure-guidance.ts
+++ b/src/agent/session/closure-guidance.ts
@@ -1,0 +1,53 @@
+/**
+ * Actionable recovery guidance for anomalous {@link ClosureReason}s.
+ *
+ * The runtime classifies WHY a session/subagent ended (`closure-reason.ts`)
+ * and emits that reason on the `closure` trace event. But knowing the reason
+ * is not the same as knowing what to DO about it: an AFK operator reviewing a
+ * trace after the fact sees `abort` with no next step. This module is the
+ * guardrail for the `closure-anomaly` failure pattern — it maps an anomalous
+ * closure reason to a short, concrete recovery hint that `emitClosure`
+ * attaches to the closure event and `afk trace` renders.
+ *
+ * Mirrors the `subagent-block` guardrail (`skill-depth-message.ts`): a pure,
+ * deterministic builder, wired at one production site and exercised directly
+ * by an `afk improve eval-run` contract (no LLM, no network).
+ *
+ * Scope — first concrete subtype only: only `abort` carries guidance today.
+ * The detector flags six anomalous reasons; covering all six in one change
+ * would couple the fix to six distinct recovery stories. The rest (timeout,
+ * budget_exceeded, hook_blocked, iteration_cap, max_turns_exceeded) each get
+ * their own hint in a follow-up. Benign reasons (model_end_turn, truncated)
+ * never carry guidance — a clean close needs no recovery action.
+ *
+ * @module agent/session/closure-guidance
+ */
+
+import type { ClosureReason } from '../trace/index.js';
+
+/**
+ * Recovery hint for an `abort` closure. Names a concrete next action: AFK
+ * preserves the transcript + witness trace on abort, so an interrupted
+ * session can be resumed rather than restarted from scratch.
+ */
+export const CLOSURE_ABORT_RECOVERY_HINT =
+  'Session ended via abort before reaching a terminal state. The transcript and ' +
+  'witness trace are preserved — resume with `afk --resume <sessionId>` to continue ' +
+  'from saved state, or re-run the task if the interruption was intentional.';
+
+/**
+ * Map a closure reason to an actionable recovery hint, or `null` when no
+ * guidance applies (benign closes, and anomalous reasons not yet covered).
+ *
+ * Pure and deterministic: no I/O, no clock, no randomness — safe to call from
+ * the hot closure-emission path and to exercise directly from an eval-run
+ * contract.
+ */
+export function buildClosureGuidance(reason: ClosureReason): string | null {
+  switch (reason) {
+    case 'abort':
+      return CLOSURE_ABORT_RECOVERY_HINT;
+    default:
+      return null;
+  }
+}

--- a/src/agent/trace/closure.test.ts
+++ b/src/agent/trace/closure.test.ts
@@ -25,6 +25,7 @@ import type { AgentConfig, OutputEvent } from '../types.js';
 import { createMockProvider, type MockProviderHandle } from '../__fixtures__/mock-provider.js';
 import { InMemoryTraceWriter } from './writer.js';
 import { BudgetExceededError, TimeoutError } from '../../utils/errors.js';
+import { CLOSURE_ABORT_RECOVERY_HINT } from '../session/closure-guidance.js';
 
 vi.mock('../../utils/debug.js', () => ({
   debugLog: vi.fn(),
@@ -87,6 +88,31 @@ describe('AgentSession + closure trace event', () => {
     const ev = writer.events.find((e) => e.kind === 'closure');
     if (ev?.kind !== 'closure') throw new Error('expected closure');
     expect(ev.payload.reason).toBe('abort');
+  });
+
+  // closure-anomaly guardrail wiring: emitClosure attaches the abort recovery
+  // hint to an abort closure, and omits guidance on a clean close.
+  it('attaches the abort recovery hint to an abort closure', async () => {
+    const session = new AgentSession(config);
+    await session.waitForInitialization();
+    session.abort('sigint');
+    await session.close();
+
+    const ev = writer.events.find((e) => e.kind === 'closure');
+    if (ev?.kind !== 'closure') throw new Error('expected closure');
+    expect(ev.payload.reason).toBe('abort');
+    expect(ev.payload.guidance).toBe(CLOSURE_ABORT_RECOVERY_HINT);
+  });
+
+  it('omits guidance on a clean model_end_turn closure', async () => {
+    const session = new AgentSession(config);
+    await session.waitForInitialization();
+    await session.close();
+
+    const ev = writer.events.find((e) => e.kind === 'closure');
+    if (ev?.kind !== 'closure') throw new Error('expected closure');
+    expect(ev.payload.reason).toBe('model_end_turn');
+    expect(ev.payload.guidance).toBeUndefined();
   });
 
   it('reason=budget_exceeded when signal carries a BudgetExceededError', async () => {

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -271,6 +271,10 @@ export const ClosurePayloadSchema = z.object({
     cacheCreation: z.number().int().nonnegative().optional(),
   }),
   lastStopReason: z.string().optional(),
+  // Actionable recovery hint for an anomalous closure (closure-anomaly
+  // guardrail, `session/closure-guidance.ts`). Optional + back-compat: older
+  // traces and benign closes simply omit it.
+  guidance: z.string().optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -329,6 +329,12 @@ export interface ClosurePayload {
   };
   /** Raw `stop_reason` from the provider, when available. */
   lastStopReason?: string;
+  /**
+   * Actionable recovery hint for an anomalous closure, attached by
+   * `emitClosure` via the `closure-anomaly` guardrail (`closure-guidance.ts`).
+   * Absent for benign closes and anomalous reasons not yet covered.
+   */
+  guidance?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -328,7 +328,8 @@ function renderEvent(event: TraceEvent, ctx: RenderContext): string | null {
 
     case 'closure': {
       const p = event.payload;
-      return line('closure', `${p.reason}  turns=${p.finalTurnCount}  ${fmtUsd(p.finalCostUsd)}`);
+      const guidance = p.guidance ? `  — ${truncate(p.guidance, 100)}` : '';
+      return line('closure', `${p.reason}  turns=${p.finalTurnCount}  ${fmtUsd(p.finalCostUsd)}${guidance}`);
     }
 
     case 'claim': {

--- a/src/improve/eval-run/contracts.test.ts
+++ b/src/improve/eval-run/contracts.test.ts
@@ -17,20 +17,24 @@ import {
 } from './contracts.js';
 import { REPEAT_CIRCUIT_BREAKER_THRESHOLD } from '../../agent/tools/dispatcher.js';
 import { SKILL_MAX_DEPTH_RECOVERY_HINT } from '../../agent/tools/skill-depth-message.js';
+import type { FailurePattern } from '../schemas.js';
 
 // ---------------------------------------------------------------------------
 // Registry resolution
 // ---------------------------------------------------------------------------
 
 describe('resolveContract', () => {
-  it('maps each PR-80 pattern to its contract', () => {
+  it('maps each registered pattern to its contract', () => {
     expect(resolveContract('repeated-tool-use')?.id).toBe('repeat-loop-circuit-breaker');
     expect(resolveContract('subagent-block')?.id).toBe('skill-max-depth-recovery-hint');
     expect(resolveContract('tool-failure-density')?.id).toBe('tool-failure-density-enabled');
+    expect(resolveContract('closure-anomaly')?.id).toBe('closure-abort-recovery-hint');
   });
 
-  it('returns undefined for a pattern with no deterministic contract', () => {
-    expect(resolveContract('closure-anomaly')).toBeUndefined();
+  it('returns undefined for an unregistered (future) pattern', () => {
+    // Every current FailurePattern now has a contract; a future pattern with
+    // none resolves to undefined → the runner records an `unsupported` result.
+    expect(resolveContract('abort-cascade' as FailurePattern)).toBeUndefined();
   });
 
   it('supportedContractPatterns / knownContractIds enumerate the registry', () => {
@@ -38,11 +42,13 @@ describe('resolveContract', () => {
       'repeated-tool-use',
       'subagent-block',
       'tool-failure-density',
+      'closure-anomaly',
     ]);
     expect(knownContractIds()).toEqual([
       'repeat-loop-circuit-breaker',
       'skill-max-depth-recovery-hint',
       'tool-failure-density-enabled',
+      'closure-abort-recovery-hint',
     ]);
   });
 });
@@ -142,5 +148,31 @@ describe('tool-failure-density-enabled contract', () => {
     }
     const evidence = result.evidence.find((e) => e.ref.includes('enabledByDefault'));
     expect(evidence?.detail).toBe('true');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Contract: closure-anomaly abort recovery hint
+// ---------------------------------------------------------------------------
+
+describe('closure-abort-recovery-hint contract', () => {
+  it('all checks pass against the live closure guardrail', async () => {
+    const result = await resolveContract('closure-anomaly')!.run();
+    expect(result.checks.map((c) => c.name)).toEqual([
+      'abort-closure-has-guidance',
+      'guidance-names-a-recovery-action',
+      'guidance-is-the-canonical-constant',
+      'benign-closure-has-no-guidance',
+    ]);
+    for (const c of result.checks) {
+      expect(c.status, `${c.name}: ${c.actual}`).toBe('pass');
+    }
+  });
+
+  it('evidence references the real guardrail builder', async () => {
+    const result = await resolveContract('closure-anomaly')!.run();
+    const builderEvidence = result.evidence.find((e) => e.ref.includes('buildClosureGuidance'));
+    expect(builderEvidence).toBeDefined();
+    expect(builderEvidence!.detail).toContain('afk --resume');
   });
 });

--- a/src/improve/eval-run/contracts.ts
+++ b/src/improve/eval-run/contracts.ts
@@ -17,9 +17,11 @@
  *   - `repeated-tool-use`    → the repeat-loop circuit breaker (PR #80).
  *   - `subagent-block`       → the skill max-depth recovery hint (PR #80).
  *   - `tool-failure-density` → that detector being enabled by default (PR #80).
+ *   - `closure-anomaly`      → the abort-closure recovery hint
+ *                              (`session/closure-guidance.ts`; abort subtype).
  *
- * Patterns with no registered contract (e.g. `closure-anomaly`) resolve to
- * `undefined`; the runner records an `unsupported` result rather than failing.
+ * Patterns with no registered contract resolve to `undefined`; the runner
+ * records an `unsupported` result rather than failing.
  *
  * ## Adding a contract
  *
@@ -40,6 +42,10 @@ import {
   SKILL_MAX_DEPTH_RECOVERY_HINT,
   buildSkillMaxDepthRefusal,
 } from '../../agent/tools/skill-depth-message.js';
+import {
+  CLOSURE_ABORT_RECOVERY_HINT,
+  buildClosureGuidance,
+} from '../../agent/session/closure-guidance.js';
 import {
   defaultEnabledDetectorNames,
   disabledByDefaultDetectorNames,
@@ -295,6 +301,72 @@ async function runToolFailureDensityEnabled(): Promise<ContractProbeResult> {
 }
 
 // ---------------------------------------------------------------------------
+// Contract: closure-anomaly → actionable recovery hint on abort closures
+// ---------------------------------------------------------------------------
+
+/**
+ * Assert the `closure-anomaly` guardrail maps an `abort` closure to an
+ * actionable recovery hint, and does NOT fabricate guidance for a benign
+ * close. Validates the same {@link buildClosureGuidance} the session's
+ * `emitClosure` wires onto the `closure` trace event — a regression that
+ * drops the hint (or starts emitting one on clean closes) is caught here.
+ *
+ * Scoped to the `abort` subtype: the only closure reason the guardrail covers
+ * today (see `closure-guidance.ts`). The contract validates the GUARDRAIL the
+ * pattern maps to, not a fixture replay — matching the other contracts.
+ */
+async function runClosureAnomalyRecoveryHint(): Promise<ContractProbeResult> {
+  const abortGuidance = buildClosureGuidance('abort');
+  const benignGuidance = buildClosureGuidance('model_end_turn');
+
+  const checks: EvalCheck[] = [
+    makeCheck({
+      name: 'abort-closure-has-guidance',
+      description: 'An abort closure maps to a non-empty recovery hint',
+      pass: typeof abortGuidance === 'string' && abortGuidance.trim().length > 0,
+      expected: 'non-empty guidance string for reason=abort',
+      actual: abortGuidance === null ? 'null (no guidance)' : snapshot(abortGuidance),
+    }),
+    makeCheck({
+      name: 'guidance-names-a-recovery-action',
+      description: 'The abort hint names a concrete next action (resume / re-run)',
+      pass: abortGuidance !== null && /\b(resume|re-run|rerun|retry)\b/i.test(abortGuidance),
+      expected: 'hint mentions resume / re-run',
+      actual: abortGuidance === null ? 'null' : snapshot(abortGuidance),
+    }),
+    makeCheck({
+      name: 'guidance-is-the-canonical-constant',
+      description: 'The wired hint is the exported CLOSURE_ABORT_RECOVERY_HINT (no drift)',
+      pass: abortGuidance === CLOSURE_ABORT_RECOVERY_HINT,
+      expected: 'buildClosureGuidance("abort") === CLOSURE_ABORT_RECOVERY_HINT',
+      actual: abortGuidance === null ? 'null' : snapshot(abortGuidance),
+    }),
+    makeCheck({
+      name: 'benign-closure-has-no-guidance',
+      description: 'A clean model_end_turn close carries no false-positive guidance',
+      pass: benignGuidance === null,
+      expected: 'null for reason=model_end_turn',
+      actual: benignGuidance === null ? 'null' : snapshot(benignGuidance),
+    }),
+  ];
+
+  const evidence: EvalRunEvidenceRef[] = [
+    {
+      kind: 'source-symbol',
+      ref: 'src/agent/session/closure-guidance.ts#buildClosureGuidance',
+      detail: abortGuidance === null ? 'null' : snapshot(abortGuidance),
+    },
+    {
+      kind: 'source-symbol',
+      ref: 'src/agent/session/agent-session.ts (emitClosure: attaches guidance to closure event)',
+      detail: 'buildClosureGuidance(reason) → closure payload .guidance',
+    },
+  ];
+
+  return { checks, evidence };
+}
+
+// ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
 
@@ -316,6 +388,12 @@ const CONTRACTS: readonly EvalContract[] = Object.freeze([
     patternId: 'tool-failure-density',
     title: 'tool-failure-density detector is enabled by default',
     run: runToolFailureDensityEnabled,
+  },
+  {
+    id: 'closure-abort-recovery-hint',
+    patternId: 'closure-anomaly',
+    title: 'Anomalous abort closure carries an actionable recovery hint',
+    run: runClosureAnomalyRecoveryHint,
   },
 ] satisfies EvalContract[]);
 

--- a/src/improve/eval-run/runner.test.ts
+++ b/src/improve/eval-run/runner.test.ts
@@ -16,6 +16,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { tmpdir } from 'os';
 import {
+  decideStatus,
   EVAL_RUN_RUNNER_VERSION,
   generateEvalRunId,
   getEvalRun,
@@ -24,6 +25,7 @@ import {
   runEvalCase,
   writeEvalRun,
 } from './runner.js';
+import { makeCheck } from './contracts.js';
 import { sha256Bytes } from '../eval-gen/replay-fixture.js';
 import { EvalCaseSchema, type EvalCase, type FailurePattern } from '../schemas.js';
 import {
@@ -141,6 +143,31 @@ describe('generateEvalRunId', () => {
 });
 
 // ---------------------------------------------------------------------------
+// decideStatus — status precedence (error > fail > unsupported > pass)
+// ---------------------------------------------------------------------------
+
+describe('decideStatus precedence', () => {
+  const passCheck = makeCheck({ name: 'p', description: 'd', pass: true, expected: '', actual: '' });
+  const failCheck = makeCheck({ name: 'f', description: 'd', pass: false, expected: '', actual: '' });
+
+  it('error beats fail (a contract threw)', () => {
+    expect(decideStatus({ hasContract: true, contractThrew: true, checks: [failCheck] })).toBe('error');
+  });
+
+  it('fail beats unsupported and pass (a failed check)', () => {
+    expect(decideStatus({ hasContract: false, contractThrew: false, checks: [failCheck] })).toBe('fail');
+  });
+
+  it('unsupported when no contract is registered and every check passes', () => {
+    expect(decideStatus({ hasContract: false, contractThrew: false, checks: [passCheck] })).toBe('unsupported');
+  });
+
+  it('pass when a contract ran and every check passed', () => {
+    expect(decideStatus({ hasContract: true, contractThrew: false, checks: [passCheck] })).toBe('pass');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // runEvalCase
 // ---------------------------------------------------------------------------
 
@@ -193,20 +220,21 @@ describe('runEvalCase', () => {
     expect(fixtureCheck?.actual).toContain('not found');
   });
 
-  it('reports unsupported for a pattern with no registered contract', async () => {
+  it('validates the closure-anomaly (abort recovery hint) contract end to end', async () => {
     const run = await runEvalCase(makeEvalCase({ pattern: 'closure-anomaly' }), { ...baseCtx, clockMs: stubClock([1, 2]) });
-    expect(run.status).toBe('unsupported');
-    expect(run.contract).toBeNull();
-    // Only the fixture check ran (it passed); no contract checks.
-    expect(run.checks).toHaveLength(1);
-    expect(run.checks[0]?.name).toBe('fixture-integrity');
-    expect(run.notes.some((n) => /No deterministic validation contract/.test(n.text))).toBe(true);
+    expect(run.status).toBe('pass');
+    expect(run.contract).toBe('closure-abort-recovery-hint');
+    expect(run.checks.some((c) => c.name === 'abort-closure-has-guidance' && c.status === 'pass')).toBe(true);
   });
 
-  it('a failed check beats unsupported (corrupt fixture on an unsupported pattern)', async () => {
+  it('a failed check beats a passing contract (corrupt fixture forces fail)', async () => {
+    // closure-anomaly now has a contract whose checks pass; a missing fixture
+    // must still force `fail` (fixture-integrity beats the passing contract).
     const evalCase = makeEvalCase({ pattern: 'closure-anomaly', writeFixture: false });
     const run = await runEvalCase(evalCase, { ...baseCtx, clockMs: stubClock([1, 2]) });
     expect(run.status).toBe('fail');
+    expect(run.checks.find((c) => c.name === 'fixture-integrity')?.status).toBe('fail');
+    expect(run.checks.filter((c) => c.name !== 'fixture-integrity').every((c) => c.status === 'pass')).toBe(true);
   });
 
   it('validates the subagent-block (skill depth hint) contract end to end', async () => {

--- a/src/improve/eval-run/runner.ts
+++ b/src/improve/eval-run/runner.ts
@@ -181,7 +181,16 @@ export async function runEvalCase(evalCase: EvalCase, ctx: RunEvalCaseContext): 
   return evalRun;
 }
 
-function decideStatus(args: {
+/**
+ * Aggregate a top-line {@link EvalRunStatus} from the run signals. Pure and
+ * exported for direct precedence testing: once every registered
+ * {@link FailurePattern} has a contract, `unsupported` is unreachable through
+ * {@link runEvalCase} (the eval-case/eval-run schemas reject unregistered
+ * patterns), so the `hasContract: false` branch is exercised here instead.
+ *
+ * Precedence (highest wins): `error` > `fail` > `unsupported` > `pass`.
+ */
+export function decideStatus(args: {
   hasContract: boolean;
   contractThrew: boolean;
   checks: EvalCheck[];


### PR DESCRIPTION
## Summary

- `afk improve eval-run` returned `UNSUPPORTED` for the `closure-anomaly` pattern because no guardrail existed to validate. This adds the smallest real guardrail + its eval-run contract, flipping `eval-run closure-anomaly-abort` from `UNSUPPORTED` → `PASS` (5/5).
- **Guardrail** (`src/agent/session/closure-guidance.ts`): `buildClosureGuidance(reason)` returns an actionable recovery hint for the `abort` closure subtype (resume via `afk --resume`), `null` for benign closes and not-yet-covered reasons. Pure + deterministic, mirroring the `subagent-block` guardrail (`skill-depth-message.ts`).
- **Wired** at one production site — `emitClosure` (`agent-session.ts`) attaches the hint to the `closure` trace event via a new optional `guidance` field (on both the `ClosurePayload` interface and the Zod `ClosurePayloadSchema`; backward-compatible), and `afk trace` renders it.
- **Contract** (`closure-abort-recovery-hint` in `eval-run/contracts.ts`): imports the real `buildClosureGuidance` (no duplicated logic) and asserts abort has guidance, it names a recovery action, it equals the canonical constant, and a benign close carries none.

## Test results

- `pnpm lint` (tsc --noEmit, strict): **pass**
- `pnpm test` (full suite, on identical changes pre-rebase): **8839 passed, 12 skipped, 0 failed**
- `pnpm test` (affected files, post-rebase onto current main): **99 passed** — closure-guidance unit, closure emit-wiring, events schema, eval-run contracts, runner precedence, trace render
- `npx tsx src/cli/index.ts improve eval-run closure-anomaly-abort`: **`[PASS]` 5/5**, contract `closure-abort-recovery-hint`

## Verification

Adversarial verifier wave (read-only sub-agent; re-derived the load-bearing claims from the diff alone):

- **Guardrail is wired into production, not dead code — CONFIRM.** `buildClosureGuidance` imported `agent-session.ts:27`, called in `emitClosure` `:935`, conditionally spread into the closure payload `:943`; `guidance?: string` present + optional on both `types.ts` and the Zod schema in `events.ts`.
- **`closure-anomaly` resolves a contract and passes — CONFIRM.** Registered in `CONTRACTS` (`contracts.ts`), `run()` imports the real builder (not a reimplementation), checks pass structurally; `resolveContract('closure-anomaly')` is non-undefined.
- **`unsupported` status preserved — REFINE (intentional, documented).** `decideStatus` still returns `unsupported` when no contract is registered, and is now exported + unit-tested for the full precedence ladder (`error > fail > unsupported > pass`). Subtle invariant: because all four `FailurePattern` enum values now have contracts, `unsupported` is structurally **unreachable through `runEvalCase`** (the eval-case/eval-run schemas reject unregistered patterns) — it survives only as a `decideStatus` unit-test target. This is documented in the runner JSDoc and is why the prior `closure-anomaly`-based unsupported integration test was converted to a positive e2e test.
- No vacuous checks (the contract compares the builder output against the exported constant, so drift fails); schema change is backward-compatible (`optional()` on both type and Zod).

## Out of scope

- Only the `abort` closure subtype carries guidance. The other five anomalous reasons (`timeout`, `budget_exceeded`, `hook_blocked`, `iteration_cap`, `max_turns_exceeded`) return `null` for now — each warrants its own recovery hint in a follow-up. This is the deliberate "smallest real first fix, one concrete subtype" scoping.
