### PR TITLE
fix(openai-compatible): stop local-model subagent dispatch from hanging

### DIFF
--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -566,6 +566,40 @@ describe('OpenAICompatibleQuery — lifecycle', () => {
     expect(remaining.length).toBeLessThan(100);
   });
 
+  it('emits a terminal turn.completed when interrupted mid-stream (no hang)', async () => {
+    // Regression: an abort during the stream made runIteration return null and
+    // runTurn return WITHOUT a terminal event. The persistent stream consumer
+    // (agent-session.ts:sendMessageStreamInternal) breaks its providerIterator
+    // loop only on a terminal output ('done' from turn.completed, or 'error'),
+    // so a missing turn.completed strands it on a next() that never resolves —
+    // the "esc to interrupt" hang. The abort path must now yield turn.completed.
+    pendingChunks = Array.from({ length: 100 }, (_, i) => ({
+      choices: [{ delta: { content: `chunk${i}` } }],
+    }));
+    const controlled = makeControlledPromptStream();
+    const q = buildQueryFromConfig(baseConfig(), controlled.stream);
+    const iter = q[Symbol.asyncIterator]();
+    controlled.send('long task');
+
+    const initEv = await iter.next();
+    expect(initEv.value).toMatchObject({ type: 'session.init' });
+    await iter.next(); // delta 0
+    await iter.next(); // delta 1
+
+    await q.interrupt();
+    controlled.end();
+
+    const remaining: ProviderEvent[] = [];
+    let ev: IteratorResult<ProviderEvent>;
+    do {
+      ev = await iter.next();
+      if (!ev.done) remaining.push(ev.value);
+    } while (!ev.done);
+
+    // The terminal event must be present so the consumer unblocks.
+    expect(remaining.some((e) => e.type === 'turn.completed')).toBe(true);
+  });
+
   it('close() stops the loop cleanly even with no input pending', async () => {
     const controlled = makeControlledPromptStream();
     const q = buildQueryFromConfig(baseConfig(), controlled.stream);

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -331,13 +331,23 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     for (let iter = 0; iter < MAX_TOOL_ITERATIONS; iter++) {
       if (controller.signal.aborted) {
         if (this.abortController === controller) this.abortController = null;
+        yield* this.finishTurn(accumulatedUsage, turnStartTime);
         return;
       }
 
       const result = yield* this.runIteration(controller);
       if (result === null) {
-        // Stream errored or aborted — events were already yielded; bail.
+        // runIteration bailed: either an abort/close (no event was yielded) or
+        // a real stream error (an `error` event was already yielded). Mirror
+        // anthropic-direct/loop.ts:410-432 — on abort/close emit a terminal
+        // `turn.completed` so the persistent stream consumer
+        // (agent-session.ts:sendMessageStreamInternal) unblocks its turn loop;
+        // on a real stream error the already-yielded `error` event is itself
+        // terminal, so skip turn.completed to avoid double-advancing turn state.
         if (this.abortController === controller) this.abortController = null;
+        if (controller.signal.aborted || this.closed) {
+          yield* this.finishTurn(accumulatedUsage, turnStartTime);
+        }
         return;
       }
 
@@ -384,6 +394,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
 
       if (controller.signal.aborted) {
         if (this.abortController === controller) this.abortController = null;
+        yield* this.finishTurn(accumulatedUsage, turnStartTime);
         return;
       }
     }
@@ -401,17 +412,36 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       this.priorTurns.push(assistantTurn);
     }
 
-    // Capture for getContextUsage() before yielding turn.completed — matches
-    // the timing in anthropic-direct/query.ts:292 where lastUsage is set on
-    // the turn.completed handler. Doing it here (vs. in [Symbol.asyncIterator])
-    // means the field is correct even if the outer consumer breaks early.
-    this.lastUsage = accumulatedUsage;
-
     yield {
       type: 'assistant.message',
       text: finalAssistantText,
       sessionId: this.initSessionId,
     };
+    yield* this.finishTurn(accumulatedUsage, turnStartTime);
+  }
+
+  /**
+   * Invariant: `runTurn` MUST funnel every non-error exit through here so a
+   * single terminal `turn.completed` is emitted for the turn. The persistent
+   * stream consumer (agent-session.ts:sendMessageStreamInternal) breaks its
+   * `providerIterator.next()` loop only on a terminal output (`turn.completed`
+   * → 'done', or `error`). Because the provider's top-level generator loops
+   * back to await the next prompt after a turn rather than returning, a
+   * `runTurn` exit with no terminal event strands the consumer on a `next()`
+   * that never resolves — the permanent "esc to interrupt" hang observed on
+   * local OpenAI-shim models that stall or get interrupted mid-stream. Real
+   * stream errors are the one exception: their already-yielded `error` event
+   * is itself terminal (mirrors anthropic-direct/loop.ts:410-423).
+   *
+   * `lastUsage` is set here (before the yield) so getContextUsage() reads the
+   * correct value even if the outer consumer breaks early — matching the timing
+   * in anthropic-direct/query.ts where lastUsage is set on turn.completed.
+   */
+  private *finishTurn(
+    accumulatedUsage: ProviderUsage,
+    turnStartTime: number,
+  ): Generator<ProviderEvent> {
+    this.lastUsage = accumulatedUsage;
     yield {
       type: 'turn.completed',
       usage: { ...accumulatedUsage, durationMs: Date.now() - turnStartTime },
@@ -609,6 +639,20 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     }
 
     const accumulated = finalizedToolCalls(state);
+    // Invariant: every dispatched tool call MUST carry a non-empty id, and the
+    // SAME id must appear on BOTH the assistant turn's `tool_calls[]` and each
+    // matching tool-result message's `tool_call_id` — OpenAI rejects a
+    // tool_call_id with no corresponding assistant tool_calls[] entry (HTTP
+    // 400). Local OpenAI-shim runners (MLX, llama.cpp) sometimes stream
+    // tool_calls with an empty or absent id. Mint one synthetic id HERE, once,
+    // so both downstream builders observe the same value:
+    // accumulatedToolCallsToToolCalls (→ tool-result tool_call_id) and
+    // assistantMessageWithToolCalls (→ assistant tool_calls[].id) below.
+    // Generating it independently in each builder would desync the pair and
+    // reintroduce the 400.
+    for (const c of accumulated) {
+      if (c.id.length === 0) c.id = randomUUID();
+    }
     const { calls, parseErrors } = accumulatedToolCallsToToolCalls(accumulated, signal);
 
     // Emit tool.use.start BEFORE dispatching, matching anthropic-direct.

--- a/src/agent/providers/openai-compatible/tool-dispatch.test.ts
+++ b/src/agent/providers/openai-compatible/tool-dispatch.test.ts
@@ -243,6 +243,63 @@ describe('OpenAICompatibleQuery — tool dispatch (slice 3)', () => {
     }
   });
 
+  it('mints a synthetic id for an empty-id tool call and keeps assistant/tool-result ids matched', async () => {
+    // Regression: local MLX/llama.cpp shims sometimes stream tool_calls with no
+    // id. The provider must mint ONE synthetic id and use it on BOTH the
+    // assistant turn's tool_calls[].id and the tool-result tool_call_id —
+    // generating it independently in each builder would desync the pair and
+    // produce a request OpenAI/strict shims reject with HTTP 400.
+    const fixture = makeDispatcher();
+    scriptedTurns = [
+      {
+        chunks: [
+          {
+            // NOTE: no `id` field on the tool call — the empty-id case.
+            choices: [
+              { delta: { tool_calls: [{ index: 0, type: 'function', function: { name: 'echo', arguments: '{"msg":"hi"}' } }] } },
+            ],
+          },
+          { choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+        ],
+      },
+      {
+        chunks: [
+          { choices: [{ delta: { content: 'done' } }] },
+          { choices: [{ delta: {}, finish_reason: 'stop' }] },
+        ],
+      },
+    ];
+
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'sk-test', source: 'config', last4: 'test' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'sid-empty-id',
+      promptStream: singleInput('please echo hi'),
+      config: baseConfig(),
+      toolDispatcher: fixture.dispatcher,
+    });
+
+    await collect(q);
+
+    // The call was dispatched (not dropped) despite the empty id.
+    expect(fixture.handlerCalls).toEqual([{ name: 'echo', input: { msg: 'hi' } }]);
+
+    // The SECOND request must carry a well-formed assistant tool_calls turn and
+    // a matching tool-result message: same id, non-empty.
+    expect(createCalls.length).toBe(2);
+    const secondMessages = createCalls[1]!.args.messages as Array<Record<string, unknown>>;
+    const assistantToolTurn = secondMessages.find(
+      (m) => m['role'] === 'assistant' && Array.isArray(m['tool_calls']),
+    );
+    const toolResult = secondMessages.find((m) => m['role'] === 'tool');
+    expect(assistantToolTurn).toBeDefined();
+    expect(toolResult).toBeDefined();
+    const assistantId = (assistantToolTurn!['tool_calls'] as Array<{ id: string }>)[0]!.id;
+    const resultId = toolResult!['tool_call_id'] as string;
+    expect(assistantId.length).toBeGreaterThan(0);
+    expect(resultId).toBe(assistantId);
+  });
+
   // Cross-provider parity: the openai-compatible `summarizeToolInput` is a
   // separate copy of the anthropic-direct helper (they must render identically
   // — see the docstring on each). This guards the skill-label behavior against

--- a/src/agent/providers/openai-compatible/translate.test.ts
+++ b/src/agent/providers/openai-compatible/translate.test.ts
@@ -195,6 +195,40 @@ describe('translateChunk — tool calls', () => {
     ]);
     expect(isToolCallStop(state)).toBe(false);
   });
+
+  it('isToolCallStop is false when finish_reason="stop" even with accumulated tool calls (MLX shim quirk)', () => {
+    // Regression: local MLX/llama.cpp shims sometimes stream partial tool_calls
+    // AND then send finish_reason:'stop'. The explicit stop is authoritative —
+    // honoring the size>0 fallback would dispatch a half-built call and poison
+    // history with a bad tool_call_id (→ HTTP 400 on the next request).
+    const { state } = collect([
+      {
+        choices: [
+          { delta: { tool_calls: [{ index: 0, id: 'call_x', function: { name: 'bash' } }] } },
+        ],
+      },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(state.toolCallsByIndex.size).toBe(1);
+    expect(state.finishReason).toBe('stop');
+    expect(isToolCallStop(state)).toBe(false);
+  });
+
+  it('isToolCallStop is false when finish_reason missing and an accumulated call has an empty id', () => {
+    // An empty/absent id means the call cannot round-trip (the assistant
+    // tool_calls[].id ↔ tool-result tool_call_id linkage would break), so it is
+    // not a real tool stop in the no-finish_reason fallback path.
+    const { state } = collect([
+      {
+        choices: [
+          { delta: { tool_calls: [{ index: 0, function: { name: 'bash', arguments: '{}' } }] } },
+        ],
+      },
+    ]);
+    expect(state.toolCallsByIndex.size).toBe(1);
+    expect(state.finishReason).toBeNull();
+    expect(isToolCallStop(state)).toBe(false);
+  });
 });
 
 describe('translateChunk — robustness', () => {

--- a/src/agent/providers/openai-compatible/translate.ts
+++ b/src/agent/providers/openai-compatible/translate.ts
@@ -217,7 +217,19 @@ export function finalizedToolCalls(state: StreamState): AccumulatedToolCall[] {
  */
 export function isToolCallStop(state: StreamState): boolean {
   if (state.finishReason === 'tool_calls' || state.finishReason === 'function_call') return true;
-  // Defensive: some providers emit no finish_reason but include tool_calls.
-  // If we accumulated any tool calls, treat as tool stop.
-  return state.toolCallsByIndex.size > 0;
+  // An explicit non-tool finish_reason ('stop', 'length', 'content_filter', …)
+  // is authoritative: the model ended the turn for THAT reason, not to call a
+  // tool. Some local MLX/llama.cpp shims wrongly send finish_reason:'stop'
+  // while also streaming partial tool_calls; honoring the size>0 fallback there
+  // dispatches a half-built (often empty-id) call, which poisons history with
+  // an empty tool_call_id and gets the next request rejected with HTTP 400.
+  if (state.finishReason !== null) return false;
+  // Defensive fallback ONLY when the provider sent no finish_reason at all
+  // (some OpenAI-compatible endpoints omit it): treat as a tool stop only if
+  // every accumulated call is complete enough to round-trip — non-empty id AND
+  // name. A partial or empty call is not a real tool stop.
+  if (state.toolCallsByIndex.size === 0) return false;
+  return [...state.toolCallsByIndex.values()].every(
+    (c) => c.id.length > 0 && c.name.length > 0,
+  );
 }


### PR DESCRIPTION
## Summary

Fixes a hang where local OpenAI-shim models (MLX, llama.cpp) stall the REPL indefinitely when a turn stalls, is interrupted, or emits a malformed tool call — the "esc to interrupt" hang. The trigger was a weak local model that narrated a subagent dispatch but never emitted a `tool_calls` response; that degenerate turn then hit missing guardrails in the openai-compatible provider and stalled instead of failing cleanly.

- **h3 (hang).** `runTurn` returned on abort/null without emitting a terminal `turn.completed`. The provider's top-level generator is *persistent* (it loops back to await the next prompt rather than returning), and the consumer (`agent-session.ts:sendMessageStreamInternal`) breaks its `providerIterator.next()` loop only on a terminal output (`turn.completed` → 'done', or 'error') — so an exit with no terminal event stranded it on a `next()` that never resolves. Every non-error exit now funnels through a new `finishTurn()` helper; a *real stream error* still skips `turn.completed` because its already-yielded `error` event is itself terminal (mirrors `anthropic-direct/loop.ts`).
- **h4 (HTTP 400 loop feeding the hang).** `isToolCallStop()` honored a `size > 0` fallback even when `finish_reason` was an explicit non-tool reason (`'stop'`). MLX shims that stream partial `tool_calls` + `finish_reason:'stop'` therefore dispatched half-built, often empty-id calls; an empty `tool_call_id` poisoned message history and strict shims rejected the next request with HTTP 400 — back into the h3 hang. Now: honor an explicit `finish_reason`; in the no-`finish_reason` fallback require complete calls (non-empty id **and** name); and mint **one** synthetic id at the single shared source so the assistant turn's `tool_calls[].id` and each tool-result `tool_call_id` stay matched (independent minting in two builders would desync the pair and reintroduce the 400).

## Test results

- `pnpm lint` (`tsc --noEmit`): clean
- `pnpm test`: **8853 passed**, 12 skipped, 0 failures (473 files) — run on the rebased tree (base v3.98.0, so it includes #86's closure / abort-subtype logic that my abort→`turn.completed` change now coexists with)
- +4 regression tests: `isToolCallStop` stop-with-toolcalls and empty-id cases; empty-id roundtrip keeps assistant ↔ tool-result ids matched; interrupt mid-stream emits `turn.completed`

## Verification

Adversarial verifier wave (diff 191 lines > 100-line threshold) — independent re-derivation from the diff + source, with no access to the PR's own reasoning:

- **h3 terminal-event contract — CONFIRM.** Consumer breaks only on 'done'/'error' (`agent-session.ts:494`); all in-loop abort/null paths emit `finishTurn`; the real-stream-error path correctly skips it; `turn.completed` → 'done' confirmed (`stream-consumer.ts`).
- **h4 `isToolCallStop` — CONFIRM.** Explicit non-tool `finish_reason` → false; no-`finish_reason` fallback requires every call complete.
- **h4 id matching — CONFIRM.** The same mutated `accumulated` array feeds both builders (`accumulatedToolCallsToToolCalls` and `assistantMessageWithToolCalls`); no independent `randomUUID()` mint that would desync the ids.

No CONTRADICT findings.

## Out of scope / known edges

- **h2 (deferred).** `runIteration`'s stream `for await` loop has no wall-clock timeout (the OpenAI SDK timeout covers response headers only), so a stalled shim can still block. Needs a timeout-policy decision; tracked separately.
- **Pre-turn abort.** The immediate `pendingAbortReason` path (`query.ts:299`) still returns without a terminal event. Pre-existing, narrow, and self-heals on the next message.
- **`isToolCallStop` fallback.** If a provider sends no `finish_reason` AND a mix of complete/incomplete calls, dispatch is skipped (text-only turn, no error surfaced) — strictly safer than the prior HTTP 400, but silent.
