### PR TITLE
fix: web_scrape failure logging (#24) + tar create/append gating (#6)

### DIFF
--- a/src/agent/tools/readonly-bash.test.ts
+++ b/src/agent/tools/readonly-bash.test.ts
@@ -434,6 +434,11 @@ describe('classifyBashCommand', () => {
       ['tar -xzf pkg.tar.gz', 'tar -xzf'],
       ['tar -xzf pkg.tar.gz -C /dst', 'tar -xzf -C'],
       ['tar xvzf file.tgz', 'tar xvzf'],
+      // create / append / update modes also write to disk
+      ['tar czf out.tar src/', 'tar czf (create)'],
+      ['tar cf a.tar f', 'tar cf (create, bare)'],
+      ['tar rf a.tar f', 'tar rf (append)'],
+      ['tar uf a.tar f', 'tar uf (update)'],
       ['unzip package.zip', 'unzip'],
       ['unzip -d /dst pkg.zip', 'unzip -d'],
       ['source ./setup.sh', 'source script'],
@@ -450,7 +455,9 @@ describe('classifyBashCommand', () => {
     const allowed: string[] = [
       'tar tf archive.tar',         // list only
       'tar -tzf pkg.tar.gz',        // list with gzip
+      'tar tvf a.tar',              // list verbose — still read-only
       'grep -rn "tar xzf" .',       // quoted search term
+      'grep "tar czf" notes.txt',   // quoted create term — not a real tar call
       'cat readme.txt',             // .txt not a source invocation
       'ls *.zip',                   // listing zips, not extracting
     ];

--- a/src/agent/tools/readonly-bash.ts
+++ b/src/agent/tools/readonly-bash.ts
@@ -148,11 +148,16 @@ const INSTALL_CMD = new RegExp(CMD_START + String.raw`install\b`, 'i');
 // isn't matched.
 const SOURCE_CMD = new RegExp(CMD_START + String.raw`(?:source\b|\.\s+\S)`, 'i');
 
-// ── archive extraction ─────────────────────────────────────────────────────
-// Archive extraction writes files to disk.  These run in STRIPPED_RULES so a
-// quoted grep search term like `grep "tar xzf"` isn't misread as a real invocation.
-// `tar … x …` — any tar flag set that includes `x` (extract mode).
-const TAR_EXTRACT = /\btar\b[^|;&]*\s-?[a-zA-Z]*x[a-zA-Z]*\b/i;
+// ── archive extraction / creation / append / update ───────────────────────
+// Archive creation (c), extraction (x), append (r), update (u), and
+// concatenate-archives (A) all write files or modify an archive on disk.
+// List mode (t) is read-only and intentionally not matched.
+// These run in STRIPPED_RULES so a quoted grep search term like
+// `grep "tar czf"` isn't misread as a real invocation.
+// The regex anchors to the first token immediately after `tar` — no skip-ahead —
+// to avoid false-positives on archive filenames that contain mode-flag letters
+// (e.g. `tar tf a.tar` would match `a` via the skip-ahead form with /i).
+const TAR_WRITE = /\btar\s+-?[a-zA-Z]*[cxruA][a-zA-Z]*\b/i;
 // `unzip` in command position.
 const UNZIP_CMD = new RegExp(CMD_START + String.raw`unzip\b`, 'i');
 // `cpio -i` (copy-in / extract) writes files; `cpio -o`/`-p` (copy-out / pass)
@@ -252,7 +257,7 @@ const STRIPPED_RULES: readonly MutationRule[] = [
   { re: PATCH_CMD, reason: 'patch (applies a diff to files)' },
   { re: INSTALL_CMD, reason: 'install (writes files)' },
   { re: SOURCE_CMD, reason: 'source/dot-source executes a script' },
-  { re: TAR_EXTRACT, reason: 'tar extract (writes files)' },
+  { re: TAR_WRITE, reason: 'tar create/extract/append/update (writes files/archive)' },
   { re: UNZIP_CMD, reason: 'unzip (writes files)' },
   { re: CPIO_EXTRACT, reason: 'cpio extract (-i mode writes files)' },
 ];

--- a/src/web/scrape.ts
+++ b/src/web/scrape.ts
@@ -22,6 +22,7 @@
 
 import { extractReadableMarkdown, THIN_CONTENT_CHARS } from './extract.js';
 import type { ExtractedContent, FetchFn, RenderFn, RenderedPage } from './types.js';
+import { debugLog } from '../utils/debug.js';
 
 /** Content-types we treat as HTML (run the extraction pipeline). */
 const HTMLISH_RE = /(text\/html|application\/xhtml\+xml)/i;
@@ -67,7 +68,8 @@ export interface ScrapeResult {
 function safeExtract(html: string, url: string): ExtractedContent {
   try {
     return extractReadableMarkdown(html, url);
-  } catch {
+  } catch (err) {
+    debugLog('[web/scrape] extraction failed', { url, err });
     return { title: '', markdown: '', textLength: 0, usedFallback: true };
   }
 }


### PR DESCRIPTION
Two independent "good first issue" hardening fixes, one commit each. Verified on a clean worktree branched off `main` (v3.98.1).

## fix(web): log silent extraction failures — Closes #24
`safeExtract` (`src/web/scrape.ts`) swallowed every exception with a bare `catch {}` and returned an empty sentinel with no telemetry, so a genuine extraction crash silently degraded scrape output to empty content. It now logs via `debugLog('[web/scrape] extraction failed', { url, err })` before returning. No behavior change on the success path.

## fix(readonly-bash): gate tar create/append/update — Closes #6
The tar classifier rule matched only extract mode (`x`); create (`c`), append (`r`), update (`u`), and concatenate (`A`) all write to disk but slipped through as read-only. Broadened to gate any mode flag except list-only `t`.

Implementation note: the matcher anchors the mode cluster to the first token after `tar` (`\btar\s+-?…`, no skip-ahead). With the `/i` flag, including `A` matches a lowercase `a`, so a skip-ahead form would false-positive on archive filenames (e.g. `tar tf a.tar`). Tests cover block (`czf`/`cf`/`rf`/`uf`) and allow (`tf`/`tvf`, quoted grep term). This stays best-effort defense-in-depth, not a security boundary — same posture as the original rule.

## Verification
- `pnpm lint` (tsc --noEmit): clean
- `pnpm test`: 473 files / 8859 tests passing, 12 skipped
