### PR TITLE
feat(repl): inline ghost-text tab autocomplete for mid-sentence skill names

### DIFF
--- a/src/cli/input/reader.ts
+++ b/src/cli/input/reader.ts
@@ -16,7 +16,7 @@
 import { emitKeypressEventsImmediateEscape } from './emit-keypress.js';
 import * as ansiEscapes from 'ansi-escapes';
 import stringWidth from 'string-width';
-import { list as listSlashCommands } from '../slash/registry.js';
+import { list as listSlashCommands, aliasEntries } from '../slash/registry.js';
 import { stripAnsi } from '../display.js';
 import { acquireStdinClaim } from './stdin-claim.js';
 import { InputCore, type InputCoreState } from '../input-core.js';
@@ -787,7 +787,34 @@ export async function readWithAutocompleteTty(
         }
 
         if (key?.name === 'tab') {
-          if (ac.dropdownOpen) applySelection();
+          if (ac.dropdownOpen) {
+            applySelection();
+          } else {
+            // Ghost-accept for mid-sentence skill token (non-compositor path).
+            // Mirrors the source (c) logic in getDeterministicGhost (suggest.ts).
+            // The compositor path handles its own ghost-accept via applyGhostAccept();
+            // this branch covers reader.ts-only surfaces (non-TTY fallback).
+            const upToCursor = input.buffer.slice(0, input.cursor);
+            const ghostMatch = /\s+\/([A-Za-z][A-Za-z0-9_:-]*)$/.exec(upToCursor);
+            if (ghostMatch) {
+              const partial = ghostMatch[1]!;
+              const slashPartial = '/' + partial;
+              const allNames = [
+                ...listSlashCommands().map(c => c.name),
+                ...aliasEntries().map(e => e.alias),
+              ];
+              const bestMatch = allNames
+                .filter(n => n.startsWith(slashPartial))
+                .sort((a, b) => a.localeCompare(b))[0];
+              if (bestMatch) {
+                const afterCursor = input.buffer.slice(input.cursor);
+                const start = input.cursor - slashPartial.length;
+                const replacement = bestMatch + (afterCursor.startsWith(' ') ? '' : ' ');
+                input = InputCore.replaceRange(input, { start, end: input.cursor }, replacement);
+                repaint();
+              }
+            }
+          }
           return;
         }
 

--- a/src/cli/input/suggest.test.ts
+++ b/src/cli/input/suggest.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createSuggestEngine, pickModel, stripGhostControlChars } from './suggest.js';
 import type { SuggestContext } from './suggest.js';
 import type { ModelProvider } from '../../agent/provider.js';
+import { register as registerSlashCommand, resetRegistry as resetSlashRegistry } from '../slash/registry.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -91,6 +92,72 @@ describe('getDeterministicGhost', () => {
     });
     const ghost = engine.getDeterministicGhost('/compact', ctx);
     expect(ghost).toBeNull();
+  });
+
+  describe('source (c): mid-sentence skill name prefix-match', () => {
+    beforeEach(() => { resetSlashRegistry(); });
+    afterEach(() => { resetSlashRegistry(); });
+
+    it('T1: ghost fires mid-sentence for a registered canonical command', () => {
+      registerSlashCommand({ name: '/forge', summary: 'test', handler: async () => 'continue' });
+      const engine = createSuggestEngine();
+      const ctx = makeCtx({ getDropdownTopCandidate: () => null, getHistory: () => [] });
+      expect(engine.getDeterministicGhost('can you run /fo', ctx)).toBe('can you run /forge');
+    });
+
+    it('T2: first-token /partial does NOT fire (no preceding whitespace)', () => {
+      registerSlashCommand({ name: '/forge', summary: 'test', handler: async () => 'continue' });
+      const engine = createSuggestEngine();
+      const ctx = makeCtx({ getDropdownTopCandidate: () => null, getHistory: () => [] });
+      // "/fo" at the start of the buffer — no preceding \s+ — must return null
+      expect(engine.getDeterministicGhost('/fo', ctx)).toBeNull();
+    });
+
+    it('T3: returns null when no registered command matches the partial', () => {
+      registerSlashCommand({ name: '/forge', summary: 'test', handler: async () => 'continue' });
+      const engine = createSuggestEngine();
+      const ctx = makeCtx({ getDropdownTopCandidate: () => null, getHistory: () => [] });
+      expect(engine.getDeterministicGhost('please use /zzz', ctx)).toBeNull();
+    });
+
+    it('T4: multiple prefix matches → lexicographically first wins', () => {
+      registerSlashCommand({ name: '/forge', summary: 'test', handler: async () => 'continue' });
+      registerSlashCommand({ name: '/fork', summary: 'test', handler: async () => 'continue' });
+      const engine = createSuggestEngine();
+      const ctx = makeCtx({ getDropdownTopCandidate: () => null, getHistory: () => [] });
+      // '/forge' < '/fork' lexicographically
+      expect(engine.getDeterministicGhost('use /for', ctx)).toBe('use /forge');
+    });
+
+    it('T5: aliases are prefix-match candidates', () => {
+      registerSlashCommand({ name: '/exit', summary: 'test', aliases: ['/quit'], handler: async () => 'continue' });
+      const engine = createSuggestEngine();
+      const ctx = makeCtx({ getDropdownTopCandidate: () => null, getHistory: () => [] });
+      expect(engine.getDeterministicGhost('try /qu', ctx)).toBe('try /quit');
+    });
+
+    it('T6: source (c) fires after source (a) falls through (candidate does not prefix-match buffer)', () => {
+      registerSlashCommand({ name: '/forge', summary: 'test', handler: async () => 'continue' });
+      const engine = createSuggestEngine();
+      // Dropdown returns '/forge' only for the exact buffer 'use /fo' — source (a)
+      // checks dropdownCandidate.startsWith(buffer). '/forge' does NOT startsWith
+      // 'use /fo', so source (a) misses and source (c) fires: returns 'use /forge'.
+      const ctx = makeCtx({
+        getDropdownTopCandidate: (buf) => buf === 'use /fo' ? '/forge' : null,
+        getHistory: () => [],
+      });
+      const result = engine.getDeterministicGhost('use /fo', ctx);
+      // Source (a) misses (candidate '/forge' doesn't startsWith 'use /fo').
+      // Source (c) fires and returns 'use /forge'.
+      expect(result).toBe('use /forge');
+    });
+
+    it('T7: partial with colons and underscores matches registered command', () => {
+      registerSlashCommand({ name: '/my:skill', summary: 'test', handler: async () => 'continue' });
+      const engine = createSuggestEngine();
+      const ctx = makeCtx({ getDropdownTopCandidate: () => null, getHistory: () => [] });
+      expect(engine.getDeterministicGhost('invoke /my:sk', ctx)).toBe('invoke /my:skill');
+    });
   });
 });
 

--- a/src/cli/input/suggest.ts
+++ b/src/cli/input/suggest.ts
@@ -8,6 +8,7 @@
  *     prefix of a known entry. Sources in priority order:
  *       (a) the top dropdown candidate exposed by `ctx.getDropdownTopCandidate`
  *       (b) the most-recent history entry that starts with `buffer`
+ *       (c) mid-sentence skill name prefix-match against the slash registry
  *     Returns the FULL candidate string; the caller renders the suffix as ghost
  *     text. Never returns a string equal to buffer.
  *
@@ -26,6 +27,7 @@
 import { providerForModel, resolveProvider, type ProviderRouteHints } from '../../agent/providers/index.js';
 import type { ModelProvider } from '../../agent/provider.js';
 import { env } from '../../config/env.js';
+import { list as listSlashCommands, aliasEntries } from '../slash/registry.js';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -269,6 +271,18 @@ export function createSuggestEngine(opts: SuggestEngineOptions = {}): SuggestEng
     cache.set(key, value);
   }
 
+  /**
+   * Tier 1 deterministic ghost resolver.
+   *
+   * Sources in priority order:
+   *   (a) the top dropdown candidate exposed by `ctx.getDropdownTopCandidate`
+   *   (b) the most-recent history entry that starts with `buffer`
+   *   (c) mid-sentence skill name prefix-match against the slash registry —
+   *       fires only when a `/partial` token is preceded by whitespace (i.e.,
+   *       it is NOT the first token in the buffer).
+   *
+   * Returns the FULL candidate string or null when no source matches.
+   */
   function getDeterministicGhost(buffer: string, ctx: SuggestContext): string | null {
     if (buffer.length === 0) return null;
 
@@ -287,6 +301,27 @@ export function createSuggestEngine(opts: SuggestEngineOptions = {}): SuggestEng
     for (const entry of history) {
       if (entry.startsWith(buffer) && entry.length > buffer.length) {
         return entry;
+      }
+    }
+
+    // (c) Mid-sentence skill name prefix-match
+    // Fires only when the /partial token is preceded by at least one whitespace
+    // character — i.e., NOT the first token in the buffer. The \s+ guard is the
+    // sole first-token filter: "/fo" does not match; "run /fo" does.
+    const midSentenceMatch = /\s+\/([A-Za-z][A-Za-z0-9_:-]*)$/.exec(buffer);
+    if (midSentenceMatch) {
+      const partial = midSentenceMatch[1]!; // e.g. "fo" from "can you run /fo"
+      const slashPartial = '/' + partial;   // e.g. "/fo"
+      const canonicalNames = listSlashCommands().map(cmd => cmd.name);
+      const aliasNames = aliasEntries().map(e => e.alias);
+      const allNames = [...canonicalNames, ...aliasNames];
+      const match = allNames
+        .filter(name => name.startsWith(slashPartial))
+        .sort((a, b) => a.localeCompare(b))[0];
+      if (match) {
+        // Return the full buffer with the partial /token replaced by the full skill name.
+        const prefixEnd = buffer.length - slashPartial.length;
+        return buffer.slice(0, prefixEnd) + match;
       }
     }
 

--- a/src/cli/terminal-compositor.ghost.test.ts
+++ b/src/cli/terminal-compositor.ghost.test.ts
@@ -502,6 +502,48 @@ describe('TerminalCompositor ghost text', () => {
     expect(engine.disposeCalled).toBe(true);
   });
 
+  // ── Mid-sentence skill ghost (source c wiring) ───────────────────────────────
+
+  it('mid-sentence skill ghost: dim suffix renders for /partial token', async () => {
+    // Engine returns 'use /forge' for any buffer — simulates source (c) matching
+    // 'use /fo' and returning the full buffer with the completed skill name.
+    const engine = makeEngine({ tier1Result: 'use /forge' });
+    const c = new TerminalCompositor({
+      stdout, stdin,
+      suggest: { engine, getContext: makeCtx },
+    });
+    await c.arm();
+    writes.clear();
+
+    for (const ch of 'use /fo') {
+      stdin.emit('keypress', ch, { name: ch, sequence: ch });
+    }
+
+    const out = writes.all();
+    // Ghost suffix 'rge' must appear in the render output.
+    expect(out).toContain('rge');
+    c.disarm();
+  });
+
+  it('Tab accepts mid-sentence skill ghost: buffer becomes full skill name', async () => {
+    // Engine returns 'use /forge' as the tier1 ghost for any buffer.
+    const engine = makeEngine({ tier1Result: 'use /forge' });
+    const c = new TerminalCompositor({
+      stdout, stdin,
+      suggest: { engine, getContext: makeCtx },
+    });
+    await c.arm();
+
+    for (const ch of 'use /fo') {
+      stdin.emit('keypress', ch, { name: ch, sequence: ch });
+    }
+    expect(c.getBuffer().text).toBe('use /fo');
+
+    stdin.emit('keypress', undefined, { name: 'tab' });
+    expect(c.getBuffer().text).toBe('use /forge');
+    c.disarm();
+  });
+
   it('engine.dispose() is NOT called when compositor is disarmed without being armed (no-op path)', () => {
     // When disarm() is called on an unarmed compositor, the early-return path
     // calls resetState() but does NOT dispose the engine — the engine was never


### PR DESCRIPTION
## Summary
- Adds inline **ghost-text** autocomplete for `/skill-name` tokens typed **mid-sentence** (preceded by at least one other token) in the REPL — e.g. `can you run /fo` ghosts `rge`, completing to `/forge`. Tab or → accepts; Escape dismisses.
- **No menu, no dropdown** — pure inline ghost text, by design. The existing first-token slash dropdown is completely untouched.
- Implemented as **source (c)** in the existing `getDeterministicGhost` Tier-1 resolver (`suggest.ts`) — additive, behind a `\s+/` first-token guard. Reads the live slash registry (canonical names + aliases via `listSlashCommands()` / `aliasEntries()`), returns the lexicographically-first prefix match. No new `Trigger` kind, no compositor render-path changes.
- `reader.ts` Tab handler extended to accept the ghost via `InputCore.replaceRange` on the non-compositor code path (the compositor path already routes Tab → `applyGhostAccept()`).

## Test results
- `vitest run src/cli/input/suggest.test.ts`: **43 passed** (7 new: mid-sentence fires, first-token guard, no-match null, multi-match lex-first, aliases, priority fall-through, colon/underscore names)
- `vitest run src/cli/terminal-compositor.ghost.test.ts`: **17 passed** (2 new: ghost suffix renders dim, Tab accept completes buffer)
- Full suite (`pnpm test:coverage`): **8883 passed, 12 skipped, 0 failed** — coverage above all floors (stmts 83 / branches 83 / funcs 89 / lines 83; floors 74/79/82/74)
- `tsc --noEmit` clean, `lint` clean

## Verification
Adversarial verifier re-derived the load-bearing claims from the diff alone (read-only, did not consult the commit reasoning):
- **First-token guard — CONFIRM.** `suggest.ts` regex requires preceding whitespace, so a bare `/fo` never gets a source (c) ghost; the first-token dropdown path is never duplicated. Directly asserted by test T2.
- **Priority subordination — CONFIRM.** `getDeterministicGhost` is strictly sequential with early returns; source (c) is only reached when sources (a) dropdown-candidate and (b) history-prefix both miss.
- **No menu / no new trigger — CONFIRM.** `trigger.ts` unmodified; source (c) returns a plain string and never sets `dropdownOpen` or mutates candidates.
- **Bugs:** none. Buffer-slice replacement verified off-by-one-free.
- Confidence: high. Not exercised at the unit layer: display-layer suffix rendering of source (c)'s full-buffer return — covered separately by the two compositor wiring tests.

## Out of scope
- Telegram surface, `@file`/`--flag` completions, fuzzy matching, and the LLM (Tier 2) ghost path — all unchanged by design.

---
🤖 Generated via `/mint` → `/ship` (agent-afk).
