### PR TITLE
feat(trace): record root-session model in witness traces

### DIFF
--- a/src/agent/providers/anthropic-direct/loop.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.test.ts
@@ -1312,9 +1312,11 @@ describe('loop.ts runTurn — witness-layer tool_call emission', () => {
     );
     // Single text-stream turn => exactly one model API call => one TTFB.
     expect(ttfb).toHaveLength(1);
-    const payload = ttfb[0]!.payload as { durationMs?: number };
+    const payload = ttfb[0]!.payload as { durationMs?: number; resolvedModel?: string };
     expect(payload.durationMs).toBeTypeOf('number');
     expect(payload.durationMs).toBeGreaterThanOrEqual(0);
+    // model_ttfb carries the resolved wire id for THIS call (input.model).
+    expect(payload.resolvedModel).toBe('claude-test');
   });
 
   it('records isError=true and truncated=true based on tool result content', async () => {

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -318,6 +318,11 @@ export async function* runTurn(
           void emitSessionPhase(input.traceWriter, {
             phase: 'model_ttfb',
             durationMs: Date.now() - requestStartedAt,
+            // Resolved wire id for THIS call — captures mid-session model
+            // overrides/switches that differ from the session default recorded
+            // on session_init_start. `input.model` is already the resolved id
+            // passed to the Messages API (see params.model above).
+            resolvedModel: input.model,
           });
         }
         if (env.AFK_TELEGRAM_TRACE) console.log('[loop] translate yielded:', out.kind, out.kind === 'event' ? out.event.type : '');

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -138,8 +138,17 @@ export class AgentSession implements IAgentSession {
     });
 
     // Witness layer: mark the start of provider/SDK initialization so
-    // downstream tooling can compute the session_init phase duration.
-    void emitSessionPhase(config.traceWriter, { phase: 'session_init_start' });
+    // downstream tooling can compute the session_init phase duration. This is
+    // ALSO the root session's model-provenance anchor: emitted unconditionally
+    // here in the constructor (earliest event, provider-agnostic) so every
+    // trace names its root model even with zero subagents and zero completed
+    // API calls. `model` = operator-typed alias; `resolvedModel` = wire id.
+    const configuredModel = String(config.model);
+    void emitSessionPhase(config.traceWriter, {
+      phase: 'session_init_start',
+      model: configuredModel,
+      resolvedModel: resolveModelId(config.model) ?? configuredModel,
+    });
 
     this.initSdkLifecycle();
   }

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -362,6 +362,11 @@ export const SessionPhasePayloadSchema = z.object({
   phase: SessionPhaseNameSchema,
   durationMs: z.number().nonnegative().optional(),
   metadata: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()])).optional(),
+  // Model provenance — see SessionPhasePayload JSDoc in types.ts. `model` is
+  // the operator-typed alias, `resolvedModel` the wire id. Both optional:
+  // present on session_init_start; resolvedModel also on model_ttfb.
+  model: z.string().optional(),
+  resolvedModel: z.string().optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/trace/integration.test.ts
+++ b/src/agent/trace/integration.test.ts
@@ -139,4 +139,51 @@ describe('AgentSession + witness-layer wiring', () => {
       angry.seal = origSeal;
     });
   });
+
+  describe('session_init_start — root model provenance', () => {
+    it('records the configured alias + resolved wire id', async () => {
+      const session = new AgentSession(config); // model: 'sonnet'
+      await session.waitForInitialization();
+      await session.close();
+
+      const initStarts = writer.events.filter(
+        (e) => e.kind === 'session_phase' && e.payload.phase === 'session_init_start',
+      );
+      expect(initStarts).toHaveLength(1);
+      const ev = initStarts[0];
+      if (ev?.kind !== 'session_phase') throw new Error('unreachable');
+      expect(ev.payload.model).toBe('sonnet');
+      // Alias 'sonnet' expands to a non-empty full wire id (not the alias).
+      expect(typeof ev.payload.resolvedModel).toBe('string');
+      expect(ev.payload.resolvedModel!.length).toBeGreaterThan(0);
+      expect(ev.payload.resolvedModel).not.toBe('sonnet');
+    });
+
+    it('is the FIRST event in the trace (earliest, provider-agnostic anchor)', async () => {
+      const session = new AgentSession(config);
+      await session.waitForInitialization();
+      await session.close();
+
+      const first = writer.events[0];
+      expect(first?.kind).toBe('session_phase');
+      if (first?.kind !== 'session_phase') throw new Error('unreachable');
+      expect(first.seq).toBe(0);
+      expect(first.payload.phase).toBe('session_init_start');
+      expect(first.payload.model).toBe('sonnet');
+    });
+
+    it('passes a raw (non-alias) model through unchanged: model === resolvedModel', async () => {
+      const rawConfig = { ...config, model: 'gpt-4o' };
+      const session = new AgentSession(rawConfig);
+      await session.waitForInitialization();
+      await session.close();
+
+      const initStart = writer.events.find(
+        (e) => e.kind === 'session_phase' && e.payload.phase === 'session_init_start',
+      );
+      if (initStart?.kind !== 'session_phase') throw new Error('unreachable');
+      expect(initStart.payload.model).toBe('gpt-4o');
+      expect(initStart.payload.resolvedModel).toBe('gpt-4o');
+    });
+  });
 });

--- a/src/agent/trace/session-phase.test.ts
+++ b/src/agent/trace/session-phase.test.ts
@@ -47,6 +47,26 @@ describe('session_phase payload schema — acceptance', () => {
     ).not.toThrow();
   });
 
+  it('accepts model + resolvedModel on session_init_start (provenance anchor)', () => {
+    expect(() =>
+      SessionPhasePayloadSchema.parse({
+        phase: 'session_init_start',
+        model: 'sonnet',
+        resolvedModel: 'claude-sonnet-4-5-20250929',
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts resolvedModel alone on model_ttfb', () => {
+    expect(() =>
+      SessionPhasePayloadSchema.parse({
+        phase: 'model_ttfb',
+        durationMs: 640,
+        resolvedModel: 'claude-test',
+      }),
+    ).not.toThrow();
+  });
+
   it('accepts all phase names', () => {
     const phases: Array<string> = [
       'session_init_start',

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -453,12 +453,21 @@ export interface BrowserEventPayload {
 }
 
 // ---------------------------------------------------------------------------
-// session_phase — per-session latency waterfall markers.
+// Invariant: session_phase — per-session latency waterfall markers AND the
+// root session's model-provenance anchor.
 //
 // Most phases emit a `*_start`/`*_done` pair bracketing the phase; together
 // they form a latency waterfall without changing operational behavior.
 // `model_ttfb` is the exception: a single event per model API call carrying
 // time-to-first-byte in `durationMs`.
+//
+// Model provenance: `session_init_start` carries the session's `model` (the
+// operator-typed alias) and `resolvedModel` (the wire id). It is emitted in
+// the AgentSession constructor — provider-agnostic and the earliest event —
+// so EVERY trace is self-identifying about its root model even with no
+// subagents and no completed API call. `model_ttfb` additionally carries the
+// `resolvedModel` for THAT call, capturing mid-session overrides/switches.
+// (Child forks already record their model on `subagent_lifecycle.started`.)
 //
 // Chronological: bootstrap → session_init → mcp_connect → mcp_server (per
 // server) → loop (per turn); model_ttfb fires per model call inside a turn.
@@ -492,6 +501,21 @@ export interface SessionPhasePayload {
   durationMs?: number;
   /** Phase-specific diagnostic context (e.g. MCP server count on connect). */
   metadata?: Record<string, string | number | boolean>;
+  /**
+   * Operator-typed model identifier as configured for the session (e.g.
+   * `"sonnet"`, `"gpt-4o"`, `"mlx-community/…"`). Set on `session_init_start`
+   * — the always-emitted, provider-agnostic attribution anchor — so a trace
+   * names its root model even with zero subagents and zero completed calls.
+   */
+  model?: string;
+  /**
+   * Resolved wire model id the provider actually calls (e.g.
+   * `"claude-sonnet-4-…"`). Set on `session_init_start` (the session default,
+   * via `resolveModelId`) and on each `model_ttfb` (the id for THAT call —
+   * captures mid-session model overrides/switches). Equals `model` when no
+   * alias expansion applies (most non-Claude / raw ids).
+   */
+  resolvedModel?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/commands/trace.test.ts
+++ b/src/cli/commands/trace.test.ts
@@ -130,6 +130,52 @@ describe('formatTrace — default human view', () => {
   });
 });
 
+describe('formatTrace — root model provenance header', () => {
+  const initStart = (model: string, resolvedModel: string): EventObj => ({
+    ts: '2026-06-05T12:30:00.000Z',
+    seq: 0,
+    kind: 'session_phase',
+    payload: { phase: 'session_init_start', model, resolvedModel },
+  });
+  const seal: EventObj = {
+    ts: '2026-06-05T12:35:00.500Z',
+    seq: 1,
+    kind: 'session_sealed',
+    payload: { status: 'succeeded', finalCostUsd: 0, finalTurnCount: 0, closedAt: '2026-06-05T12:35:00.500Z' },
+  };
+
+  it('renders a Model line with alias → resolved when they differ', () => {
+    const out = formatTrace(
+      's',
+      '/p',
+      parseTrace(toJsonl([initStart('sonnet', 'claude-sonnet-4-5-20250929'), seal])),
+    );
+    expect(out).toContain('Model  sonnet → claude-sonnet-4-5-20250929');
+  });
+
+  it('renders the model once (no arrow) when alias === resolved (raw passthrough)', () => {
+    const out = formatTrace('s', '/p', parseTrace(toJsonl([initStart('gpt-4o', 'gpt-4o'), seal])));
+    expect(out).toContain('Model  gpt-4o');
+    expect(out).not.toContain('gpt-4o → gpt-4o');
+  });
+
+  it('omits the Model line when no session_init_start carries a model', () => {
+    // sampleEvents() has no session_init_start → no provenance to show.
+    const out = formatTrace('s', '/p', parseTrace(toJsonl(sampleEvents())));
+    expect(out).not.toContain('Model  ');
+  });
+
+  it('--all surfaces the model on the session_init_start phase line', () => {
+    const out = formatTrace(
+      's',
+      '/p',
+      parseTrace(toJsonl([initStart('sonnet', 'claude-sonnet-4-5-20250929'), seal])),
+      { showAll: true },
+    );
+    expect(out).toMatch(/session_init_start.*sonnet/);
+  });
+});
+
 describe('formatTrace — flags and edge cases', () => {
   it('--all surfaces latency phases and paired tool starts', () => {
     const out = formatTrace('s', '/p', parseTrace(toJsonl(sampleEvents())), { showAll: true });

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -356,7 +356,11 @@ function renderEvent(event: TraceEvent, ctx: RenderContext): string | null {
       if (!ctx.showAll) return null; // latency waterfall — low signal by default
       const p = event.payload;
       const dur = p.durationMs !== undefined ? `  ${fmtDuration(p.durationMs)}` : '';
-      return line('phase', `${p.phase}${dur}`);
+      // Prefer the operator alias (session_init_start); fall back to the
+      // resolved wire id (model_ttfb carries only that).
+      const modelStr = p.model ?? p.resolvedModel;
+      const modelBit = modelStr !== undefined ? `  ${modelStr}` : '';
+      return line('phase', `${p.phase}${dur}${modelBit}`);
     }
 
     case 'session_sealed': {
@@ -389,6 +393,10 @@ interface TraceSummary {
   blocks: number;
   sealStatus: string | null;
   finalCostUsd: number | null;
+  /** Operator-typed model for the root session (from session_init_start). */
+  model: string | null;
+  /** Resolved wire id for the root session, when it differs from `model`. */
+  resolvedModel: string | null;
 }
 
 function summarize(events: TraceEvent[]): TraceSummary {
@@ -399,6 +407,8 @@ function summarize(events: TraceEvent[]): TraceSummary {
   let blocks = 0;
   let sealStatus: string | null = null;
   let finalCostUsd: number | null = null;
+  let model: string | null = null;
+  let resolvedModel: string | null = null;
 
   for (const e of events) {
     switch (e.kind) {
@@ -406,6 +416,16 @@ function summarize(events: TraceEvent[]): TraceSummary {
         if (e.payload.phase === 'completed') {
           toolCalls++;
           if (e.payload.isError) toolErrors++;
+        }
+        break;
+      case 'session_phase':
+        // Root-session model provenance lives on session_init_start (the
+        // earliest, always-emitted phase). First occurrence wins.
+        if (e.payload.phase === 'session_init_start') {
+          if (model === null && e.payload.model !== undefined) model = e.payload.model;
+          if (resolvedModel === null && e.payload.resolvedModel !== undefined) {
+            resolvedModel = e.payload.resolvedModel;
+          }
         }
         break;
       case 'subagent_lifecycle':
@@ -438,6 +458,8 @@ function summarize(events: TraceEvent[]): TraceSummary {
     blocks,
     sealStatus,
     finalCostUsd,
+    model,
+    resolvedModel,
   };
 }
 
@@ -481,6 +503,13 @@ export function formatTrace(
   const out: string[] = [];
   out.push(`Trace  ${sessionId}`);
   out.push(`File   ${tracePath}`);
+  if (summary.model !== null) {
+    const resolvedBit =
+      summary.resolvedModel !== null && summary.resolvedModel !== summary.model
+        ? ` → ${summary.resolvedModel}`
+        : '';
+    out.push(`Model  ${summary.model}${resolvedBit}`);
+  }
   out.push(
     `       ${status} · ${summary.total} events · ${summary.toolCalls} tool calls` +
       ` (${summary.toolErrors} err) · ${summary.subagents} subagents · ${summary.claims} claims` +


### PR DESCRIPTION
## Summary
- Records the **root session's model** in its own witness trace. Previously only forked subagents (`subagent_lifecycle.started.model`) and background jobs carried model identity, so a top-level trace — especially one with no subagents — was unattributable to any model. This breaks cost attribution and "which model produced this trace" forensics, which matters for a deliberately multi-provider tool (Anthropic + OpenAI-compatible + local `org/model` runners, with per-call overrides).
- Anchors provenance on `session_init_start`, emitted in the `AgentSession` constructor: earliest event, provider-agnostic, fires unconditionally — so every trace self-identifies even with zero subagents and zero completed API calls (covers crashed/early-abort traces too).
- Adds two optional fields to the shared `SessionPhasePayload`: `model` (operator alias, e.g. `sonnet`) + `resolvedModel` (wire id, e.g. `claude-sonnet-4-...`). `model_ttfb` additionally carries `resolvedModel` per call, capturing mid-session model overrides/switches.
- `afk trace` surfaces the model in the always-shown summary header (`Model  sonnet -> claude-...`), so attribution is visible without `--all` (`session_phase` events are low-signal/hidden by default).

## Design
Chose additive optional fields on an existing event over a new `session_started` event kind — validated via an adversarial design critique against three alternatives (the filename-encoding alternative was rejected because local `org/model` ids contain `/`, which breaks filenames). Honors the "no new event type" convention: the `TraceEventKind` taxonomy and the SDK dependency lock are untouched. Both the hand-written TS interface (`trace/types.ts`) and the Zod schema (`trace/events.ts`) were updated — writes reject at the boundary otherwise.

## Test results
- `tsc --noEmit`: clean
- `vitest run` (full suite): **8863 passed, 12 skipped, 0 failures** (473 files)
- affected files re-confirmed during ship: 138 passed (integration, session-phase, startup-phases, loop, trace)
- `audit:sdk:check`: OK (no new `@anthropic-ai/sdk` imports)
- 9 new/extended tests: real-`AgentSession` records alias+resolved on `seq:0`; raw model passes through unchanged (`model === resolvedModel`); `model_ttfb` carries the resolved id; renderer shows the header with/without the arrow; Zod accepts the new fields.

## Verification
Adversarial verifier wave (diff > 100 lines) independently re-derived the load-bearing claims from the diff alone:
- Root model on `session_init_start` (alias + resolved, constructor-emitted): **CONFIRM** (`agent-session.ts:148-151`)
- `model_ttfb` carries the resolved wire id: **CONFIRM** (`loop.ts:322`)
- Renderer surfaces model in the always-shown header: **CONFIRM** (`trace.ts:503-509`)
- TS interface <-> Zod schema parity: no gap; no exact-payload test breakage.
