### PR TITLE
Document subagent injectContext handoff contract

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ Both providers emit a normalized `ProviderEvent` stream consumed by `src/agent/s
 
 ## Cross-cutting subsystems
 
-- **Hooks** (`src/agent/hooks.ts`, `hook-registry.ts`) — SessionStart/End, SubagentStart/Stop, PreToolUse/PostToolUse. Sequential; `decision: 'block'` short-circuits. SubagentStop supports `injectContext` for parent-session context injection.
+- **Hooks** (`src/agent/hooks.ts`, `hook-registry.ts`) — SessionStart/End, SubagentStart/Stop, PreToolUse/PostToolUse. Sequential; `decision: 'block'` short-circuits. Foreground subagent final output returns through the normal `agent` tool result. Separately, `SubagentStop` supports `injectContext`: a hook-generated framework note (not human-authored user text) queued into the parent input stream for the next parent turn. Injection is skipped when the parent is aborting, is not guaranteed on DAG/compose or background paths, and multiple injected contexts currently do not merge (last non-blocking hook decision wins).
 - **SubagentManager** (`src/agent/subagent.ts`) — Forks child `AgentSession`s with permission bubbling, transitive abort via `AbortGraph`, optional Zod output schemas.
 - **AbortGraph** (`src/agent/abort-graph.ts`) — Tree of `AbortController`s. Parent abort cascades down; child abort notifies up (never auto-aborts parent). Abort beats hook decisions.
 - **Elicitation Router** (`src/agent/elicitation-router.ts`) — Module-scope handler bridging SDK elicitations to REPL/Telegram/iMessage surfaces.

--- a/src/agent/dag-subagent.test.ts
+++ b/src/agent/dag-subagent.test.ts
@@ -90,6 +90,27 @@ describe('runSubagentDAG', () => {
     expect(handles[0]!.teardown).toHaveBeenCalled();
   });
 
+  it('forks nodes with parent session identity only, so compose/DAG cannot inject context', async () => {
+    pushHandle('hello');
+    const manager = managerFromQueue();
+
+    await runSubagentDAG({
+      manager,
+      parentSession: makeParent(),
+      nodes: [{ id: 'A', systemPrompt: 's', promptBuilder: () => 'p' }],
+      edges: [],
+    });
+
+    const fork = manager.forkSubagent as unknown as ReturnType<typeof vi.fn>;
+    const forkOptions = fork.mock.calls[0]![0];
+
+    // Current contract: compose/DAG nodes intentionally receive no parent input
+    // stream ref. Their final output returns through DAG outputs/tool results;
+    // SubagentStop.injectContext cannot enqueue hidden parent turns here.
+    expect(forkOptions.parent).toEqual({ sessionId: 'test-parent' });
+    expect(forkOptions.parent.getInputStreamRef).toBeUndefined();
+  });
+
   it('two-node chain: output of first feeds promptBuilder of second', async () => {
     pushHandle('first-output');
     pushHandle('second-output');

--- a/src/agent/hook-registry.ts
+++ b/src/agent/hook-registry.ts
@@ -185,8 +185,11 @@ class HookRegistryImpl implements HookRegistry {
         );
       }
 
-      // Accumulate non-blocking decisions so the caller can inspect them
-      // (e.g., SubagentStop handlers that return injectContext).
+      // Accumulate non-blocking decisions so the caller can inspect them.
+      // Current contract: decisions are not merged. If multiple SubagentStop
+      // handlers return injectContext, the last handler's value wins and earlier
+      // values are dropped. This documents the existing behavior until a typed
+      // result envelope or explicit merge policy replaces it.
       lastDecision = decision;
     }
 

--- a/src/agent/hooks-integration.test.ts
+++ b/src/agent/hooks-integration.test.ts
@@ -261,7 +261,7 @@ describe('SubagentManager — hook integration', () => {
 
     const messages = parentSession.getMockInputStreamMessages();
     expect(messages).toHaveLength(1);
-    expect(messages[0]).toMatch(/^shadow-verify nudge:/);
+    expect(messages[0]).toMatch(/^\[framework-generated context: shadow-verify nudge\]/);
     expect(messages[0]).toContain('/shadow-verify');
   });
 
@@ -309,7 +309,7 @@ describe('SubagentManager — hook integration', () => {
 
     const messages = parentSession.getMockInputStreamMessages();
     expect(messages).toHaveLength(1);
-    expect(messages[0]).toMatch(/^shadow-verify nudge:/);
+    expect(messages[0]).toMatch(/^\[framework-generated context: shadow-verify nudge\]/);
   });
 
   it('stays silent when neither config, manager, nor parent supplies a registry', async () => {

--- a/src/agent/hooks.test.ts
+++ b/src/agent/hooks.test.ts
@@ -267,6 +267,29 @@ describe('dispatchSubagentStop — return value', () => {
     });
   });
 
+  it('keeps the last injectContext when multiple stop hooks return one', async () => {
+    const registry = createHookRegistry();
+
+    registry.register('SubagentStop', async () => ({
+      injectContext: 'first framework note',
+    }));
+    registry.register('SubagentStop', async () => ({
+      injectContext: 'second framework note',
+    }));
+
+    const decision = await dispatchSubagentStop(registry, {
+      event: 'SubagentStop',
+      subagentId: 'sub-1',
+      status: 'succeeded',
+    });
+
+    // Current contract: hook decisions are not merged. The last non-blocking
+    // SubagentStop decision is the only one the parent injection path sees.
+    expect(decision).toEqual({
+      injectContext: 'second framework note',
+    });
+  });
+
   it('returns empty object when no handlers registered', async () => {
     const registry = createHookRegistry();
 

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -18,10 +18,16 @@
  * with the original error attached as `cause`. This prevents a bug in one
  * handler from silently skipping policy enforcement.
  *
- * **Context injection (SubagentStop only):** When a `SubagentStop` handler
- * returns `injectContext`, the dispatch result is propagated to the caller,
- * which queues the context string to the parent session's input stream. If
- * the parent is aborting, the injection is skipped. Other hook events ignore
+ * **Context injection (SubagentStop only):** Foreground subagents hand their
+ * final assistant output to the parent through the normal `agent` tool result;
+ * `injectContext` is a separate hook-generated framework note, not text typed
+ * by the human user. When a `SubagentStop` handler returns `injectContext`, the
+ * dispatch result is propagated to the caller, which queues the context string
+ * to the parent session's input stream for the parent's next turn. If the
+ * parent is aborting, the injection is skipped. DAG/compose and background
+ * paths are not guaranteed to inject (some intentionally leave this channel
+ * dark), and multiple `injectContext` values do not merge today: hook dispatch
+ * returns the last non-blocking decision. Other hook events ignore
  * `injectContext` entirely.
  *
  * @module agent/hooks
@@ -46,9 +52,12 @@ export interface HookDecision {
   /** Human-readable rationale for blocking or approving. */
   reason?: string;
   /**
-   * (SubagentStop only) Context to inject into the parent session's next turn.
-   * Queued to parent's input stream after dispatch completes. Dropped if parent is aborting.
-   * Ignored for all other hook events.
+   * (SubagentStop only) Framework-generated context to inject into the parent
+   * session's next turn. This is not human-authored user text. Queued to the
+   * parent's input stream after dispatch completes; dropped if the parent is
+   * aborting. DAG/compose and background paths may intentionally not inject.
+   * Multiple injected contexts currently do not merge — the last non-blocking
+   * hook decision wins. Ignored for all other hook events.
    */
   injectContext?: string;
 }

--- a/src/agent/session/input-iterable.test.ts
+++ b/src/agent/session/input-iterable.test.ts
@@ -54,6 +54,22 @@ describe('QueryInputStream', () => {
       expect(result.value.sessionId).toBeUndefined();
     });
 
+    it('preserves ordering between queued parent input and injected framework context', async () => {
+      const stream = new QueryInputStream(() => 'parent-session');
+      const iter = stream.createIterable()[Symbol.asyncIterator]();
+
+      stream.pushUserMessage('human-authored parent message');
+      stream.pushUserMessage('[framework-generated context: injected note]');
+
+      const first = await iter.next();
+      const second = await iter.next();
+
+      expect(first.value.content).toBe('human-authored parent message');
+      expect(second.value.content).toBe('[framework-generated context: injected note]');
+      expect(first.value.sessionId).toBe('parent-session');
+      expect(second.value.sessionId).toBe('parent-session');
+    });
+
     it('sets sessionId when getter returns a value', async () => {
       const stream = new QueryInputStream(() => 'my-session');
       stream.pushUserMessage('msg');

--- a/src/agent/shadow-verify-nudge.test.ts
+++ b/src/agent/shadow-verify-nudge.test.ts
@@ -105,7 +105,7 @@ describe('shadowVerifyNudge', () => {
       'lorem ipsum '.repeat(60);
     const result = shadowVerifyNudge(stopCtx(output));
     expect(result.injectContext).toBeDefined();
-    expect(result.injectContext).toMatch(/^shadow-verify nudge:/);
+    expect(result.injectContext).toMatch(/^\[framework-generated context: shadow-verify nudge\]/);
     expect(result.injectContext).toContain('/shadow-verify');
   });
 

--- a/src/agent/shadow-verify-nudge.ts
+++ b/src/agent/shadow-verify-nudge.ts
@@ -59,7 +59,7 @@ const VERIFIER_SIGNATURES: RegExp[] = [
 ];
 
 const CONTEXT_MESSAGE =
-  'shadow-verify nudge:\n\n' +
+  '[framework-generated context: shadow-verify nudge]\n\n' +
   'The sub-agent that just finished returned output that reads like ' +
   '**decision-driving findings** (verdicts, recommendations, audit ' +
   'conclusions, or claim-style results that could drive file edits, ' +

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -458,11 +458,15 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
       this.traceWriter ? { traceWriter: this.traceWriter } : {},
     );
 
-    // Inject context into parent if handler provided it and parent ref exists.
-    // Abort precedence: if the parent's abortSignal was provided AND is set,
-    // skip injection — the parent's query loop will unwind before it can
-    // consume the message. Matches the abort-graph invariant that abort is
-    // terminal for side effects. Injection failures are logged, not propagated.
+    // Invariant: SubagentStop.injectContext is a framework-generated next-turn
+    // note, not the foreground subagent result and not human-authored text. The
+    // final subagent answer has already returned through the `agent` tool result;
+    // this side-channel queues only supplemental hook context for the parent's
+    // next input-stream read. Abort precedence: if the parent's abortSignal was
+    // provided AND is set, skip injection — the parent's query loop will unwind
+    // before it can consume the message. Matches the abort-graph invariant that
+    // abort is terminal for side effects. Injection failures are logged, not
+    // propagated.
     if (decision.injectContext && this.parentInputStreamRef) {
       if (this.parentAbortSignal?.aborted) {
         debugLog(


### PR DESCRIPTION
## Summary
- document the current SubagentStop.injectContext contract and foreground result handoff
- label the shadow-verify injected nudge as framework-generated context
- add focused tests for last-wins hook context, parent-input ordering, and DAG no-injection wiring

## Verification
- pnpm test -- src/agent/hooks.test.ts src/agent/hooks-integration.test.ts src/agent/session/input-iterable.test.ts src/agent/dag-subagent.test.ts src/agent/shadow-verify-nudge.test.ts
- pnpm lint