### PR TITLE
fix(repl): reserve final column in echo path to fix prompt tripling

### DIFF
--- a/src/cli/input-box.test.ts
+++ b/src/cli/input-box.test.ts
@@ -488,9 +488,11 @@ describe('formatSubmittedEcho', () => {
         terminalWidth,
       }),
     );
-    // No prompt prefix; the buffer ends at the terminal edge.
+    // No prompt prefix; the buffer ends one column short of the terminal's
+    // final column (last-column safety — a glyph in the physical last column
+    // triggers DECAWM deferred-wrap ghosting/tripling on real terminals).
     expect(out.endsWith(buffer)).toBe(true);
-    expect(out).toBe('▶ ' + ' '.repeat(terminalWidth - buffer.length - 2) + buffer);
+    expect(out).toBe('▶ ' + ' '.repeat(terminalWidth - 1 - buffer.length - 2) + buffer);
   });
 
   it('renders a right-edge bar card for multi-line buffers', () => {

--- a/src/cli/input/echo.test.ts
+++ b/src/cli/input/echo.test.ts
@@ -33,17 +33,20 @@ describe('formatSubmittedEcho', () => {
     expect(result).toBe('afk › hello');
   });
 
-  it('short single-line buffer right-pads with leading spaces so content ends at right edge', async () => {
+  it('short single-line buffer right-pads so content ends at cols-1 (last-column safety)', async () => {
     const fn = await importEcho();
     const buffer = 'hi';
     const terminalWidth = 80;
     const result = strip(
       fn({ buffer, promptText: 'afk › ', isTTY: true, terminalWidth }),
     );
-    // No prompt prefix in the echo; pad + buffer should equal terminalWidth wide.
+    // No prompt prefix in the echo; content ends ONE column short of the
+    // terminal's final column. A printable glyph in the physical last column
+    // triggers DECAWM deferred-wrap ghosting/tripling on real terminals — see
+    // the last-column-safety invariant in echo.ts (mirrors render/card.ts).
     expect(result.endsWith(buffer)).toBe(true);
-    expect(stringWidth(result)).toBe(terminalWidth);
-    expect(result).toBe('▶ ' + ' '.repeat(terminalWidth - stringWidth(buffer) - 2) + buffer);
+    expect(stringWidth(result)).toBe(terminalWidth - 1);
+    expect(result).toBe('▶ ' + ' '.repeat(terminalWidth - 1 - stringWidth(buffer) - 2) + buffer);
   });
 
   it('card path: every content line ends flush right with the cyan bar', async () => {
@@ -142,8 +145,9 @@ describe('formatSubmittedEcho', () => {
       expect(lines).toHaveLength(2);
       expect(lines[0]!.endsWith('hi')).toBe(true);
       expect(lines[1]!.endsWith(summary)).toBe(true);
-      // Summary is flush-right against the terminal edge.
-      expect(stringWidth(lines[1]!)).toBe(terminalWidth);
+      // Summary is right-aligned, ending at cols-1 (last-column safety — a
+      // glyph in the physical final column triggers DECAWM wrap ghosting).
+      expect(stringWidth(lines[1]!)).toBe(terminalWidth - 1);
     });
 
     it('TTY card path: summary appears below the card, right-aligned', async () => {
@@ -159,10 +163,10 @@ describe('formatSubmittedEcho', () => {
       });
       const stripped = strip(result);
       const lines = stripped.split('\n');
-      // Last line is the summary, flush-right.
+      // Last line is the summary, right-aligned to cols-1 (last-column safety).
       const lastLine = lines[lines.length - 1]!;
       expect(lastLine.endsWith(summary)).toBe(true);
-      expect(stringWidth(lastLine)).toBe(terminalWidth);
+      expect(stringWidth(lastLine)).toBe(terminalWidth - 1);
       // The card's right-edge bar is still present on the content rows.
       // cardLines = all lines except the trailing summary line.
       const cardLines = lines.slice(0, -1);

--- a/src/cli/input/echo.ts
+++ b/src/cli/input/echo.ts
@@ -76,12 +76,25 @@ export function formatSubmittedEcho(opts: {
 
   let primary: string;
   if (!isMultiLine && !isLong) {
-    // Right-pad with leading spaces so the buffer ends at the terminal edge.
+    // Right-pad with leading spaces so the buffer ends near the terminal edge.
     // Prepend a ▶ glyph (2 visible columns) so the user's own message has a
     // distinctive left shoulder in scrollback — replaces the two leading spaces.
     const GLYPH = palette.user('▶') + ' '; // 2 visible columns: glyph + space
     const GLYPH_W = 2;
-    const pad = Math.max(0, cols - bufferW - GLYPH_W);
+    // Invariant (last-column safety): the echoed content ends at column
+    // `cols - 1` at most — never the terminal's final column. A printable
+    // glyph in the last column leaves many emulators (iTerm2/Ghostty/Kitty/
+    // WezTerm) in the DECAWM deferred-wrap state; when the compositor later
+    // CUP-repositions for the committed-band repaint — and skill/slash turns
+    // fire extra repaints (arm→streaming, dispose→idle) — those terminals
+    // flush the pending wrap inconsistently and the committed row drops or
+    // triples in scrollback (the "user prompt echoed 3×" report). xterm
+    // handles the boundary cleanly, so this never surfaces in the
+    // @xterm/headless harness — only on real terminals. The card path
+    // (render/card.ts `rightEdge = cols - 1`) reserves this column the same
+    // way; this inline path is its sibling and must match or the bug returns.
+    const rightEdge = cols - 1;
+    const pad = Math.max(0, rightEdge - bufferW - GLYPH_W);
     primary = GLYPH + ' '.repeat(pad) + buffer;
   } else {
     primary = card({ kind: 'user', body: buffer });
@@ -93,8 +106,11 @@ export function formatSubmittedEcho(opts: {
 
   // Right-align the dim summary line. `palette.dim` wraps in ANSI escapes
   // (zero-width); pad based on the visible width of the raw summary string.
+  // Reserve the final column for the same last-column-safety reason as the
+  // primary echo above — a glyph in the last column triggers the DECAWM
+  // deferred-wrap tripling/drop on real terminals.
   const summaryW = stringWidth(summary);
-  const summaryPad = Math.max(0, cols - summaryW);
+  const summaryPad = Math.max(0, cols - 1 - summaryW);
   const summaryLine = ' '.repeat(summaryPad) + palette.dim(summary);
   return primary + '\n' + summaryLine;
 }


### PR DESCRIPTION
## Summary

- Fixes the "user prompt echoed 3×" tripling bug in the REPL submitted-echo path.
- The echo path right-padded content to the terminal's **physical final column** (`cols`). A printable glyph in that column leaves iTerm2 / Ghostty / Kitty / WezTerm in the DECAWM deferred-wrap state; skill/slash turns fire extra committed-band repaints (arm→streaming, dispose→idle), the pending wrap flushes inconsistently, and the committed row drops or **triples** in scrollback.
- Fix reserves the final column (`rightEdge = cols - 1`) in **both** the primary echo pad and the attachment-summary pad in `src/cli/input/echo.ts` — mirroring `render/card.ts`, which already guards this way (commit `23200c2`). This is the inline-echo sibling of that earlier card-path fix.
- Tests in `echo.test.ts` and `input-box.test.ts` are updated to assert the `cols - 1` invariant so the guard cannot silently regress.

## Test results

- `pnpm test` (vitest run, full suite): **474 files passed (474), 8863 passed | 12 skipped** — green (~79s).
- `pnpm lint` (`tsc --noEmit`, strict): **exit 0** — green.

## Verification

No adversarial verify requested (diff is 35 lines, under the 100-line threshold).

**Known caveat (documented invariant):** `@xterm/headless` handles the DECAWM last-column boundary cleanly, so this bug is **invisible in the test harness** — "all tests pass" does not by itself reproduce the failure. Confidence is grounded instead in the fix mirroring the previously-validated card-path guard (`render/card.ts`, commit `23200c2`): the updated tests now encode the `cols - 1` invariant so any future full-`cols` write trips the assertions.
