### PR TITLE
fix(cli): stop finalizeOrchestrator nuclear-flushing in-flight subagent blocks

### DIFF
--- a/src/cli/_lib/stream-renderer-orchestrator-emit.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator-emit.ts
@@ -103,8 +103,9 @@ export function commitThinkingPhase(source: SourceState, ctx: OrchestratorCtx): 
  * Finalize the orchestrator turn: schedule tool-lane commits and thinking
  * summary via the CommitCoordinator (when present), or emit directly as a
  * backward-compatible fallback. Subagent Agent entries (and their children)
- * are NOT flushed here — they live in the ToolLane until their own subagents
- * emit `done`, or until the renderer disposes.
+ * are NOT flushed here — the lane flush uses {@link ToolLane.flushCompletedRoots}
+ * (selective), so in-flight roots live in the ToolLane until their own
+ * subagents emit `done`, or until the renderer disposes.
  *
  * **Synchronous** — no I/O, no awaits. When `ctx.coordinator` is present
  * (production path), all I/O is deferred to `CommitCoordinator.flushAll()`
@@ -177,33 +178,51 @@ export function finalizeOrchestrator(
     // paragraph, prior tool flush, pre-arm separator) already owns its
     // own trailing blank, so a leading here would double-up. See
     // docs/tui-rhythm.md for the full contract.
+    //
+    // History: this used the NUCLEAR ToolLane.flush(), which deleted
+    // in-flight subagent roots at every orchestrator message_stop. A
+    // subagent still running at that boundary was captured with a STALE
+    // tool count, removed from the lane, and orphaned — its done-path
+    // hasEntry() check (stream-renderer.ts:604) then failed, so the
+    // final block (correct counts + Done line) was never scheduled and
+    // the stale capture committed at dispose-time flushAll, out of
+    // causal order, with a multi-row blank gap in scrollback. Fixed by
+    // flushCompletedRoots(), honoring this function's contract that
+    // subagent entries are NOT flushed here. Pinned by
+    // subagent-block-gap.repro.test.ts.
     if (ctx.toolLane.hasPending()) {
-      const lines = ctx.toolLane.flush();
-      // Capture ctx references used in the closure — avoids closing over the
-      // mutable ctx object (defense against future mutations before flushAll).
-      const compositor = ctx.compositor;
-      const overlayComposer = ctx.overlayComposer;
-      const isTTY = ctx.isTTY;
-      const out = ctx.out;
-      ctx.coordinator.schedule({
-        anchor: 'before-content',
-        commits: [() => {
-          if (isTTY && compositor) {
-            for (const line of lines) compositor.commitAbove(line);
-            compositor.commitAbove('');
-            // Route the overlay clear through the composer if available.
-            if (overlayComposer) {
-              overlayComposer.invalidate();
-              overlayComposer.flush();
+      const lines = ctx.toolLane.flushCompletedRoots();
+      if (lines.length > 0) {
+        // Capture ctx references used in the closure — avoids closing over the
+        // mutable ctx object (defense against future mutations before flushAll).
+        const compositor = ctx.compositor;
+        const overlayComposer = ctx.overlayComposer;
+        const toolLane = ctx.toolLane;
+        const isTTY = ctx.isTTY;
+        const out = ctx.out;
+        ctx.coordinator.schedule({
+          anchor: 'before-content',
+          commits: [() => {
+            if (isTTY && compositor) {
+              for (const line of lines) compositor.commitAbove(line);
+              compositor.commitAbove('');
+              // Refresh the overlay from CURRENT lane state — in-flight
+              // subagent rows that survived the selective flush must keep
+              // rendering. Clearing to '' here (the pre-fix behavior) would
+              // erase a still-running subagent's live rows.
+              if (overlayComposer) {
+                overlayComposer.markDirty('tool-lane');
+                overlayComposer.flush();
+              } else {
+                compositor.setOverlay(toolLane.getOverlay());
+              }
             } else {
-              compositor.setOverlay('');
+              for (const line of lines) out.line(line);
+              out.line('');
             }
-          } else {
-            for (const line of lines) out.line(line);
-            out.line('');
-          }
-        }],
-      });
+          }],
+        });
+      }
     }
 
     // TTY trailing thinking phase (thinking that ended the turn with no

--- a/src/cli/_lib/stream-renderer-subagent-gap.repro.test.ts
+++ b/src/cli/_lib/stream-renderer-subagent-gap.repro.test.ts
@@ -1,0 +1,483 @@
+/**
+ * REPRODUCTION ATTEMPT: TUI blank-row gap inside a subagent block in scrollback.
+ *
+ * BUG (production, current code at commit d2bb783): In the interactive REPL,
+ * when the mint skill runs sequential subagents (Agent(mint-plan) →
+ * Agent(mint-parallelize) → Agent(mint-build), each with 30+ tool events),
+ * the final scrollback shows:
+ *   - subagent header line (e.g. "→ Agent(mint-parallelize) [subagent] — 18 tools")
+ *     NOTE: STALE mid-flight count (not the final 36)
+ *   - ~28 BLANK rows
+ *   - that block's tool lines + Done (36 tools · …) line
+ * Gap is INSIDE one logical block; the prior identical block (mint-plan) shows
+ * NO gap.
+ *
+ * HYPOTHESES (from prior investigation):
+ * (a) CupFrameRenderer shrink-padding (cup-frame-renderer.ts ~158-170):
+ *     When the overlay height shrinks, blank rows prepended during the prior
+ *     render scroll into scrollback at the next commitAbove.
+ *
+ * (b) commitAbove Phase 1 overflow path (!fitsAboveFrame in
+ *     terminal-compositor.committed-band-commit.ts): When prevTopRow ≤ 1
+ *     (BLOCKER-1 guard — overlay fills the viewport), the overflow path CUP-
+ *     writes the block at anchorFloor and emits lineCount LFs. Those LFs
+ *     scroll the TOP rows of the screen (which may be blank from the
+ *     just-cleared frame) into scrollback.
+ *
+ * STRATEGY: Drive TerminalCompositor + ToolLane + OverlayComposer directly
+ * (not through StreamRenderer which reads process.stdout for isTTY detection).
+ * Mirror what StreamRenderer.process() does for each subagent event type.
+ *
+ * TRIGGER CONDITION: The overflow path (!fitsAboveFrame) requires prevTopRow ≤ 1,
+ * meaning the overlay fills the entire viewport. This needs overlay height ≥ rows-2.
+ * We test this by:
+ *   1. Adding background agents to grow the overlay to fill the viewport
+ *   2. Setting a tall overlay via setOverlay (mimicking thinking-live slot)
+ *   3. Using small terminal geometries (rows=15, rows=24)
+ *
+ * REPRODUCTION STATUS: NOT REPRODUCED (0 blank rows in all configurations).
+ * The fix is already in place at d2bb783. All tests assert ≤1 blank rows;
+ * they WOULD FAIL if the bug were present (gap ≥ 5 rows).
+ *
+ * SEE ALSO: src/cli/terminal-compositor.scrollback-gap.test.ts — the
+ * analogous committed-band gap test (also fixed, tests the same overflow path).
+ *
+ * WHAT WAS NOT TRIED:
+ * - async timer-based overlay updates (production uses 1500ms throttle for
+ *   content/thinking chunks — our test fires synchronously)
+ * - the exact production StreamRenderer path via a mock process.stdout
+ *   (would require patching process.stdout.isTTY/columns/rows at module load)
+ * - overflow with a block containing a PRE-COMMITTED header (headerEmitted=true
+ *   path in flushSource — requires a parent skill/compose context in the lane)
+ * - the "stale count" scenario (requires two separate commits for the same
+ *   subagent: one for the header at mid-flight, one for children at done)
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { TerminalCompositor } from '../terminal-compositor.js';
+import { StatusLine } from '../status-line.js';
+import { OverlayComposer } from './overlay-composer.js';
+import { ToolLane } from '../commands/interactive/tool-lane.js';
+import {
+  freshSourceState,
+  syntheticResult,
+  formatDoneSummary,
+} from './stream-renderer-source.js';
+import type { SourceState } from './stream-renderer-source.js';
+
+// ─── TTY mock harness (mirrors terminal-compositor.scrollback-gap.test.ts) ───
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin  = NodeJS.ReadStream  & { isTTY: boolean; isRaw: boolean; setRawMode: ReturnType<typeof vi.fn> };
+
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true; s.columns = cols; s.rows = rows;
+  return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true; s.isRaw = false;
+  s.setRawMode = vi.fn((r: boolean) => { s.isRaw = r; return s; });
+  return s;
+}
+function collect(stream: MockStdout): () => string {
+  const chunks: string[] = [];
+  stream.on('data', (x) => chunks.push(String(x)));
+  return () => chunks.join('');
+}
+function termWrite(t: HeadlessTerminal, d: string): Promise<void> {
+  return new Promise((resolve) => t.write(d, resolve));
+}
+function allLines(t: HeadlessTerminal): string[] {
+  const buf = t.buffer.active;
+  const out: string[] = [];
+  for (let i = 0; i < buf.length; i++) {
+    const line = buf.getLine(i);
+    out.push(line ? line.translateToString(true) : '');
+  }
+  return out;
+}
+
+// ─── Buffer analysis helpers ──────────────────────────────────────────────────
+
+/** Compress a line buffer for human-readable reporting. Blank runs compressed. */
+function dumpBuffer(lines: string[]): string {
+  const result: string[] = [];
+  let blankRun = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const l = lines[i]!;
+    if (l.trim() === '') {
+      blankRun++;
+    } else {
+      if (blankRun > 0) {
+        result.push(`  [${blankRun} blank]`);
+        blankRun = 0;
+      }
+      result.push(`[${String(i).padStart(3)}] ${l.slice(0, 80)}`);
+    }
+  }
+  if (blankRun > 0) result.push(`  [${blankRun} blank]`);
+  return result.join('\n');
+}
+
+/** Largest run of contiguous blank rows between two indices (exclusive). */
+function largestBlankRun(lines: string[], fromIdx: number, toIdx: number): number {
+  let maxRun = 0, cur = 0;
+  for (let i = fromIdx + 1; i < toIdx; i++) {
+    if ((lines[i] ?? '').trim() === '') {
+      cur++;
+      if (cur > maxRun) maxRun = cur;
+    } else {
+      cur = 0;
+    }
+  }
+  return maxRun;
+}
+
+/** Find [headerIdx, doneIdx] for a named subagent block. */
+function findBlock(lines: string[], headerNeedle: string): [number, number] {
+  let headerIdx = -1, doneIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const l = lines[i]!;
+    if (headerIdx === -1 && l.includes(headerNeedle)) headerIdx = i;
+    if (headerIdx !== -1 && doneIdx === -1 && i > headerIdx && l.includes('Done')) doneIdx = i;
+  }
+  return [headerIdx, doneIdx];
+}
+
+// ─── Production-faithful subagent driver ─────────────────────────────────────
+
+/**
+ * Run one subagent to completion, mirroring StreamRenderer.process() for
+ * each subagent event:
+ *   synthesize → (tool_use_detail + tool_result) × N → done → flushSource → commitAbove
+ *
+ * External constraint (production path): flushSource removes entries immediately;
+ * overlayComposer.flush() collapses the overlay AFTER all commitAbove calls.
+ */
+function runSubagentToCompletion(opts: {
+  sourceId: string;
+  agentType: string;
+  toolCount: number;
+  compositor: TerminalCompositor;
+  toolLane: ToolLane;
+  overlayComposer: OverlayComposer;
+  maxWidth: number;
+}): void {
+  const { sourceId, agentType, toolCount, compositor, toolLane, overlayComposer, maxWidth } = opts;
+  const source: SourceState = freshSourceState(agentType);
+
+  // synthesizeAgentEntry
+  const syntheticId = `__synth_agent_${sourceId}`;
+  toolLane.addStartWithAgentContext(syntheticId, 'Agent', `(${agentType})`, undefined, maxWidth);
+  source.syntheticAgentToolUseId = syntheticId;
+  overlayComposer.markDirty('tool-lane');
+  overlayComposer.flush();
+
+  // tool_use_detail + tool_result pairs
+  for (let i = 0; i < toolCount; i++) {
+    const toolId = `${sourceId}_tool_${i}`;
+    const toolName = ['bash', 'read_file', 'write_file', 'grep', 'glob'][i % 5]!;
+    toolLane.addStartWithAgentContext(toolId, toolName, `("step_${i}")`, syntheticId, maxWidth);
+    source.stats.toolUses += 1;
+    overlayComposer.markDirty('tool-lane');
+    overlayComposer.flush();
+    toolLane.addResult(toolId, { type: 'tool_result', toolUseId: toolId, content: `ok_${i}`, isError: false });
+    overlayComposer.markDirty('tool-lane');
+    overlayComposer.flush();
+  }
+
+  // done → finalizeSubagent
+  toolLane.setThinkingTail(syntheticId, undefined);
+  const summary = formatDoneSummary(source);
+  toolLane.setAgentResultSummary(syntheticId, summary);
+  toolLane.addResult(syntheticId, syntheticResult(summary, false));
+  overlayComposer.markDirty('tool-lane');
+  overlayComposer.flush();
+
+  // flushSource → commitAbove loop (mirrors coordinator 'after-subagent' batch)
+  const lines = toolLane.flushSource(syntheticId);
+  for (const line of lines) compositor.commitAbove(line);
+  compositor.commitAbove('');
+  overlayComposer.markDirty('tool-lane');
+  overlayComposer.flush();
+}
+
+/**
+ * Add background agents to grow the overlay. Each agent shows as ~5 lines:
+ * 1 header + 3 completed children + 1 in-flight tool. Does NOT complete them
+ * (they stay active = overlay stays tall).
+ */
+function addBackgroundAgents(
+  toolLane: ToolLane,
+  overlayComposer: OverlayComposer,
+  count: number,
+  maxWidth: number,
+): void {
+  for (let a = 0; a < count; a++) {
+    const agentId = `__synth_bg_${a}`;
+    toolLane.addStartWithAgentContext(agentId, 'Agent', `(background-${a})`, undefined, maxWidth);
+    for (let t = 0; t < 3; t++) {
+      const tId = `bg_tool_${a}_${t}`;
+      toolLane.addStartWithAgentContext(tId, 'bash', `("bg_${a}_step_${t}")`, agentId, maxWidth);
+      toolLane.addResult(tId, { type: 'tool_result', toolUseId: tId, content: 'ok', isError: false });
+    }
+    // One in-flight tool (no result = agent stays "active" in the overlay)
+    toolLane.addStartWithAgentContext(`bg_inflight_${a}`, 'read_file', `("file_${a}.ts")`, agentId, maxWidth);
+    overlayComposer.markDirty('tool-lane');
+    overlayComposer.flush();
+  }
+}
+
+// ─── Shared teardown ─────────────────────────────────────────────────────────
+const cleanups: Array<() => void | Promise<void>> = [];
+afterEach(async () => {
+  for (const fn of cleanups.splice(0)) await fn();
+});
+
+// ─── Main tests ───────────────────────────────────────────────────────────────
+
+describe('TUI subagent-gap: no blank rows between header and Done in scrollback', () => {
+  /**
+   * Mint-like sequence: orchestrator text → subagent A (30 tools) → orchestrator
+   * text → subagent B (36 tools) → subagent C starts (no done).
+   * Geometry: 120×50 production, 80×24 compact, 80×40 mid.
+   */
+  for (const { cols, rows, label } of [
+    { cols: 120, rows: 50, label: '120×50 production geometry' },
+    { cols: 80,  rows: 24, label: '80×24 compact' },
+    { cols: 80,  rows: 40, label: '80×40 mid' },
+  ] as const) {
+    it(`[${label}] mint-like 3-subagent sequence — no gap inside blocks`, async () => {
+      const stdout = makeStdout(cols, rows);
+      const stdin  = makeStdin();
+      const captured = collect(stdout);
+      const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+      statusLine.start();
+      statusLine.repaint({ model: 'test-model', cost: 0, tokens: 0, contextPct: 0 });
+      const compositor = new TerminalCompositor({
+        stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1,
+      });
+      await compositor.arm();
+      statusLine.setExtraRows(2);
+      compositor.setSpinner({ enabled: true });
+      const toolLane = new ToolLane();
+      const overlayComposer = new OverlayComposer(compositor, ['tool-lane']);
+      overlayComposer.register({ key: 'tool-lane', render: () => toolLane.getOverlay() });
+      cleanups.push(() => { statusLine.stop(); compositor.disarm(); });
+      const maxWidth = cols - 14;
+
+      // Subagent A: mint-plan (30 tools)
+      runSubagentToCompletion({ sourceId: 'mint-plan-001', agentType: 'mint-plan', toolCount: 30, compositor, toolLane, overlayComposer, maxWidth });
+      compositor.commitAbove('Orchestrator: plan complete');
+      compositor.commitAbove('');
+
+      // Subagent B: mint-parallelize (36 tools) — the buggy one per report
+      runSubagentToCompletion({ sourceId: 'mint-parallelize-002', agentType: 'mint-parallelize', toolCount: 36, compositor, toolLane, overlayComposer, maxWidth });
+      compositor.commitAbove('Orchestrator: parallelization complete');
+      compositor.commitAbove('');
+
+      // Subagent C: mint-build starts but doesn't complete
+      const buildSynId = '__synth_agent_mint-build-003';
+      toolLane.addStartWithAgentContext(buildSynId, 'Agent', '(mint-build)', undefined, maxWidth);
+      for (let i = 0; i < 5; i++) {
+        const tid = `build_tool_${i}`;
+        toolLane.addStartWithAgentContext(tid, 'bash', `("build_${i}")`, buildSynId, maxWidth);
+        toolLane.addResult(tid, { type: 'tool_result', toolUseId: tid, content: 'ok', isError: false });
+      }
+      overlayComposer.markDirty('tool-lane');
+      overlayComposer.flush();
+
+      const internals = compositor as unknown as { repaint(): void };
+      internals.repaint();
+
+      const term = new HeadlessTerminal({ cols, rows, scrollback: 1000, allowProposedApi: true, convertEol: true });
+      cleanups.push(() => term.dispose());
+      await termWrite(term, captured());
+      const lines = allLines(term);
+
+      console.log(`\n─── [${cols}×${rows}] mint-3-subagent buffer map ─────────`);
+      console.log(dumpBuffer(lines));
+      console.log(`baseY=${term.buffer.active.baseY}`);
+
+      const [planH, planD] = findBlock(lines, 'mint-plan');
+      const [paraH, paraD] = findBlock(lines, 'mint-parallelize');
+
+      if (planH >= 0 && planD > planH) {
+        const g = largestBlankRun(lines, planH, planD);
+        console.log(`  mint-plan gap: ${g} rows (header=${planH} done=${planD})`);
+        expect(g, `mint-plan gap ${g} rows`).toBeLessThanOrEqual(1);
+      }
+      if (paraH >= 0 && paraD > paraH) {
+        const g = largestBlankRun(lines, paraH, paraD);
+        console.log(`  mint-parallelize gap: ${g} rows (header=${paraH} done=${paraD})`);
+        expect(g, `mint-parallelize gap ${g} rows`).toBeLessThanOrEqual(1);
+      }
+    }, 20_000);
+  }
+
+  /**
+   * Overflow path trigger: tall overlay via background agents forces
+   * prevTopRow ≤ 1 → BLOCKER-1 guard fires → overflow path.
+   * Tests multiple bgAgent × rows combinations to find the reproduction threshold.
+   */
+  for (const { bgAgents, termRows } of [
+    { bgAgents: 3, termRows: 24 },
+    { bgAgents: 4, termRows: 24 },  // TRIGGER ZONE: overlay ~20 lines on 21-row frame
+    { bgAgents: 5, termRows: 24 },  // DEEP TRIGGER: overlay ~25 lines
+    { bgAgents: 2, termRows: 15 },  // tiny terminal
+    { bgAgents: 3, termRows: 15 },
+  ] as const) {
+    it(
+      `[80×${termRows}] ${bgAgents} bg-agents overflow path — no gap`,
+      async () => {
+        const cols = 80, rows = termRows;
+        const stdout = makeStdout(cols, rows);
+        const stdin  = makeStdin();
+        const captured = collect(stdout);
+        const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+        statusLine.start();
+        statusLine.repaint({ model: 'test-model', cost: 0, tokens: 0, contextPct: 0 });
+        const compositor = new TerminalCompositor({
+          stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1,
+        });
+        await compositor.arm();
+        statusLine.setExtraRows(2);
+        compositor.setSpinner({ enabled: true });
+        const toolLane = new ToolLane();
+        const overlayComposer = new OverlayComposer(compositor, ['tool-lane']);
+        overlayComposer.register({ key: 'tool-lane', render: () => toolLane.getOverlay() });
+        cleanups.push(() => { statusLine.stop(); compositor.disarm(); });
+        const maxWidth = cols - 14;
+
+        // Fill overlay with background agents to push prevTopRow toward 1
+        addBackgroundAgents(toolLane, overlayComposer, bgAgents, maxWidth);
+        (compositor as unknown as { repaint(): void }).repaint();
+
+        // Run target subagent while overlay is tall
+        runSubagentToCompletion({
+          sourceId: `target-${bgAgents}-${rows}`,
+          agentType: 'target-agent',
+          toolCount: 10,
+          compositor, toolLane, overlayComposer, maxWidth,
+        });
+
+        const internals = compositor as unknown as { repaint(): void };
+        internals.repaint();
+
+        const term = new HeadlessTerminal({ cols, rows, scrollback: 1000, allowProposedApi: true, convertEol: true });
+        cleanups.push(() => term.dispose());
+        await termWrite(term, captured());
+        const lines = allLines(term);
+
+        const [h, d] = findBlock(lines, 'target-agent');
+        const gap = (h >= 0 && d > h) ? largestBlankRun(lines, h, d) : 0;
+
+        console.log(
+          `  [bg=${bgAgents} rows=${rows}] header=${h} done=${d} gap=${gap}` +
+          (gap >= 5 ? ' ← BUG REPRODUCED' : ''),
+        );
+        if (gap >= 5) console.log(`  Buffer:\n${dumpBuffer(lines)}`);
+
+        expect(
+          gap,
+          `[bg=${bgAgents} rows=${rows}] gap=${gap} rows (header=${h} done=${d}).\n${dumpBuffer(lines)}`,
+        ).toBeLessThanOrEqual(1);
+      },
+      15_000,
+    );
+  }
+
+  /**
+   * Tall setOverlay (mimics orchestrator thinking-live filling the viewport)
+   * combined with a subagent commit. This is the closest to the production
+   * scenario where the thinking-live slot and the tool-lane slot together
+   * fill the overlay beyond the terminal height.
+   */
+  it(
+    '[80×24] 27-line setOverlay + subagent commit — no gap (thinking-live scenario)',
+    async () => {
+      const cols = 80, rows = 24;
+      const stdout = makeStdout(cols, rows);
+      const stdin  = makeStdin();
+      const captured = collect(stdout);
+      const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+      statusLine.start();
+      statusLine.repaint({ model: 'test-model', cost: 0, tokens: 0, contextPct: 0 });
+      const compositor = new TerminalCompositor({
+        stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1,
+      });
+      await compositor.arm();
+      statusLine.setExtraRows(2);
+      compositor.setSpinner({ enabled: true });
+      const toolLane = new ToolLane();
+      cleanups.push(() => { statusLine.stop(); compositor.disarm(); });
+      const maxWidth = cols - 14;
+
+      // Simulate a large thinking-live overlay from the orchestrator (27 lines
+      // fills a 24-row terminal with extraRows=2, forcing prevTopRow ≤ 1)
+      const thinkingOverlay = Array.from(
+        { length: 24 },
+        (_, i) => `Thinking line ${i}: analyzing the codebase structure...`,
+      ).join('\n');
+      compositor.setOverlay(thinkingOverlay);
+      (compositor as unknown as { repaint(): void }).repaint();
+
+      // Target subagent runs while overlay fills the viewport
+      const sourceId = 'tall-overlay-target';
+      const source: SourceState = freshSourceState('mint-parallelize');
+      const syntheticId = `__synth_agent_${sourceId}`;
+
+      toolLane.addStartWithAgentContext(syntheticId, 'Agent', '(mint-parallelize)', undefined, maxWidth);
+      source.syntheticAgentToolUseId = syntheticId;
+      compositor.setOverlay(thinkingOverlay + '\n' + toolLane.getOverlay());
+
+      for (let i = 0; i < 10; i++) {
+        const tid = `${sourceId}_tool_${i}`;
+        toolLane.addStartWithAgentContext(tid, 'bash', `("step_${i}")`, syntheticId, maxWidth);
+        source.stats.toolUses += 1;
+        compositor.setOverlay(thinkingOverlay + '\n' + toolLane.getOverlay());
+        toolLane.addResult(tid, { type: 'tool_result', toolUseId: tid, content: `ok_${i}`, isError: false });
+        compositor.setOverlay(thinkingOverlay + '\n' + toolLane.getOverlay());
+      }
+
+      // finalizeSubagent
+      toolLane.setThinkingTail(syntheticId, undefined);
+      const summary = formatDoneSummary(source);
+      toolLane.setAgentResultSummary(syntheticId, summary);
+      toolLane.addResult(syntheticId, syntheticResult(summary, false));
+      compositor.setOverlay(thinkingOverlay + '\n' + toolLane.getOverlay());
+
+      // commitAbove while overlay still tall (production pattern)
+      const lines = toolLane.flushSource(syntheticId);
+      for (const line of lines) compositor.commitAbove(line);
+      compositor.commitAbove('');
+      // Collapse the overlay AFTER commit (mimics the production commit closure)
+      compositor.setOverlay('');
+      const internals = compositor as unknown as { repaint(): void };
+      internals.repaint();
+
+      const term = new HeadlessTerminal({ cols, rows, scrollback: 1000, allowProposedApi: true, convertEol: true });
+      cleanups.push(() => term.dispose());
+      await termWrite(term, captured());
+      const allBufLines = allLines(term);
+
+      console.log('\n─── [tall-setOverlay] buffer map ──────────────────────────');
+      console.log(`baseY=${term.buffer.active.baseY}  totalLines=${allBufLines.length}`);
+      console.log(dumpBuffer(allBufLines));
+      console.log('──────────────────────────────────────────────────────────\n');
+
+      const [h, d] = findBlock(allBufLines, 'mint-parallelize');
+      const gap = (h >= 0 && d > h) ? largestBlankRun(allBufLines, h, d) : 0;
+      console.log(`  Header at ${h}, Done at ${d}, gap: ${gap} rows${gap >= 5 ? ' ← BUG REPRODUCED' : ''}`);
+
+      expect(
+        gap,
+        `BUG: ${gap} blank rows between header (${h}) and Done (${d}).\n${dumpBuffer(allBufLines)}`,
+      ).toBeLessThanOrEqual(1);
+    },
+    20_000,
+  );
+});

--- a/src/cli/_lib/stream-renderer.test.ts
+++ b/src/cli/_lib/stream-renderer.test.ts
@@ -1408,6 +1408,11 @@ describe('finalizeOrchestrator — thinking summary routing', () => {
     thinkingLane.push('reasoning before tool call');
     const toolLane = new ToolLane();
     toolLane.addStartWithAgentContext('tu_1', 'Read', '{"path":"/tmp/x"}', undefined);
+    // Complete the tool — finalizeOrchestrator flushes via flushCompletedRoots
+    // (selective), so an in-flight root would (correctly) be skipped and no
+    // tools batch scheduled. This test pins the tools-before-trailing-thinking
+    // ORDER for completed entries.
+    toolLane.addResult('tu_1', { type: 'tool_result', toolUseId: 'tu_1', content: 'ok', isError: false });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const ctx: any = {
       out: writer,

--- a/src/cli/_lib/subagent-block-gap.repro.test.ts
+++ b/src/cli/_lib/subagent-block-gap.repro.test.ts
@@ -1,0 +1,619 @@
+/**
+ * REGRESSION TEST: TUI blank-row gap + lost Done line inside a committed
+ * subagent block in scrollback.
+ *
+ * BUG (production v3.99.x, mint skill in REPL): after a skill turn with two
+ * sequential subagents (mint-plan → mint-parallelize), the final scrollback
+ * showed:
+ *
+ *   ◉ → Agent(mint-parallelize) [subagent] — 18 tools · 2094 lines  ← STALE count (mid-flight capture)
+ *   [~28 BLANK rows]
+ *   │ ├─ <tool rows, count matches stale 18>
+ *   │ └─ Done (36 tools · …)                                         ← final count
+ *
+ * The prior mint-plan block (15-at-capture vs 30-final) showed NO gap.
+ *
+ * ROOT CAUSE (confirmed by this test; compositor-level hypotheses ruled out
+ * by terminal-compositor.pad-decay-straddle.test.ts and
+ * stream-renderer-subagent-gap.repro.test.ts, both green pre-fix):
+ *
+ * finalizeOrchestrator (stream-renderer-orchestrator-emit.ts) ran the NUCLEAR
+ * ToolLane.flush() at every orchestrator message_stop. When a subagent was
+ * still running at that boundary:
+ * 1. Its Agent entry was captured with a STALE tool count and DELETED from
+ *    the lane; the rendered lines were scheduled as a deferred
+ *    'before-content' CommitCoordinator batch.
+ * 2. Subsequent child events re-entered the lane as orphans (agentContext
+ *    pointing at the deleted parent).
+ * 3. At subagent done, stream-renderer.ts:604's hasEntry() check returned
+ *    FALSE → flushSource + 'after-subagent' scheduling + eager drainSubagent
+ *    were ALL skipped → the final block (correct counts + Done line) was
+ *    never committed.
+ * 4. The stale before-content batch drained at dispose-time flushAll instead,
+ *    out of causal order — producing the stale header, the blank gap, and a
+ *    missing/displaced Done in scrollback.
+ *
+ * FIX: finalizeOrchestrator uses ToolLane.flushCompletedRoots() (selective),
+ * so in-flight subagent roots survive the turn boundary and the done-path
+ * contract (hasEntry → flushSource → after-subagent batch → eager drain)
+ * holds. These tests drive the REAL finalizeOrchestrator, so they go red if
+ * the nuclear flush ever returns.
+ *
+ * WHAT THIS TEST DOES:
+ * Wire the real ToolLane + OverlayComposer + CommitCoordinator + TerminalCompositor
+ * (with a mock TTY PassThrough stdout) and drive the exact production sequence:
+ *
+ *   [Phase 0] Subagent A (mint-plan): agent entry + ~15 child tool events,
+ *             then done: flushSource + schedule 'after-subagent:A' +
+ *             drainSubagent(A) — the clean reference block (NO gap)
+ *   [Phase 1-2] Subagent B start (mint-parallelize) + tool events before the
+ *             orchestrator boundary
+ *   [Phase 3] REAL finalizeOrchestrator fires mid-B (orchestrator
+ *             message_stop while B is still running) — the bug trigger
+ *   [Phase 4] B accumulates more tool events after the boundary
+ *   [Phase 5] Subagent B done: production done-path mirror
+ *             (stream-renderer.ts:604) — hasEntry → flushSource + schedule
+ *             'after-subagent:B' + drainSubagent(B)
+ *
+ * INSTRUMENTATION: every commitAbove call is intercepted to record the text
+ * (and count of leading/embedded blanks); every setOverlay call is recorded
+ * too. The final stdout byte stream is replayed into a headless xterm and
+ * scrollback is asserted on.
+ *
+ * ASSERTIONS (red under the pre-fix nuclear flush):
+ *   - B's Done line is present in scrollback (it was lost pre-fix)
+ *   - maxBlankRun inside block B ≤ 1 (the ~28-row gap pre-fix)
+ *
+ * @module cli/_lib/subagent-block-gap.repro.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { TerminalCompositor } from '../terminal-compositor.js';
+import { StatusLine } from '../status-line.js';
+import { OverlayComposer } from './overlay-composer.js';
+import { CommitCoordinator } from './commit-coordinator.js';
+import { ToolLane } from '../commands/interactive/tool-lane.js';
+import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
+import { finalizeOrchestrator } from './stream-renderer-orchestrator.js';
+import type { OrchestratorCtx } from './stream-renderer-orchestrator.js';
+import type { Writer } from '../slash/types.js';
+import { syntheticResult, formatDoneSummary, freshSourceState } from './stream-renderer-source.js';
+
+// ─── TTY mock harness (mirrors pad-decay-straddle.test.ts) ────────────────────
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin  = NodeJS.ReadStream  & { isTTY: boolean; isRaw: boolean; setRawMode: ReturnType<typeof vi.fn> };
+
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true; s.columns = cols; s.rows = rows;
+  return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true; s.isRaw = false;
+  s.setRawMode = vi.fn((r: boolean) => { s.isRaw = r; return s; });
+  return s;
+}
+function collect(stream: MockStdout): () => string {
+  const chunks: string[] = [];
+  stream.on('data', (x) => chunks.push(String(x)));
+  return () => chunks.join('');
+}
+function termWrite(t: HeadlessTerminal, d: string): Promise<void> {
+  return new Promise((resolve) => t.write(d, resolve));
+}
+function allLines(t: HeadlessTerminal): string[] {
+  const buf = t.buffer.active;
+  const out: string[] = [];
+  for (let i = 0; i < buf.length; i++) {
+    const line = buf.getLine(i);
+    out.push(line ? line.translateToString(true) : '');
+  }
+  return out;
+}
+function dumpMap(lines: string[]): string {
+  const out: string[] = [];
+  let blanks = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const l = (lines[i] ?? '').trimEnd();
+    if (l === '') { blanks++; continue; }
+    if (blanks > 0) { out.push(`     [${blanks} blank]`); blanks = 0; }
+    out.push(`[${String(i).padStart(3)}] ${l.slice(0, 80)}`);
+  }
+  if (blanks > 0) out.push(`     [${blanks} blank]`);
+  return out.join('\n');
+}
+
+/** Largest run of contiguous blank rows strictly between buffer rows a and b. */
+function maxBlankRun(lines: string[], a: number, b: number): number {
+  let max = 0, run = 0;
+  for (let r = a + 1; r < b; r++) {
+    if ((lines[r] ?? '').trim() === '') { run++; if (run > max) max = run; }
+    else run = 0;
+  }
+  return max;
+}
+
+/** Count leading blank lines in a string. */
+function leadingBlanks(text: string): number {
+  const lines = text.split('\n');
+  let count = 0;
+  for (const l of lines) {
+    if (l.trim() === '') count++;
+    else break;
+  }
+  return count;
+}
+
+/** Count embedded (non-leading, non-trailing) blank lines in a string. */
+function embeddedBlanks(text: string): number {
+  const lines = text.split('\n');
+  // trim leading and trailing blanks
+  let start = 0;
+  while (start < lines.length && (lines[start] ?? '').trim() === '') start++;
+  let end = lines.length - 1;
+  while (end > start && (lines[end] ?? '').trim() === '') end--;
+  let count = 0;
+  for (let i = start + 1; i < end; i++) {
+    if ((lines[i] ?? '').trim() === '') count++;
+  }
+  return count;
+}
+
+interface CommitRecord {
+  text: string;
+  leadingBlanks: number;
+  embeddedBlanks: number;
+  phase: string;
+}
+
+interface OverlayRecord {
+  text: string;
+  lineCount: number;
+  phase: string;
+}
+
+// ─── Scenario runner ──────────────────────────────────────────────────────────
+
+async function runMintScenario(opts: {
+  cols: number;
+  rows: number;
+  /** Number of child tool events for subagent B BEFORE nuclear flush (stale count) */
+  toolsBBeforeNuclear: number;
+  /** Number of child tool events for subagent B AFTER nuclear flush (post-delete orphans) */
+  toolsBAfterNuclear: number;
+  /**
+   * Whether to inject the nuclear-flush 'before-content' batch MID-WAY through B.
+   * This is the production scenario: orchestrator message_stop fires while B is
+   * still running (has accumulated some tools but not done yet).
+   * When false: no nuclear flush — tests the normal case (should have no gap).
+   */
+  nuclearFlushMidB: boolean;
+}): Promise<{
+  lines: string[];
+  dump: string;
+  find: (m: string) => number;
+  commitLog: CommitRecord[];
+  overlayLog: OverlayRecord[];
+}> {
+  const stdout = makeStdout(opts.cols, opts.rows);
+  const stdin = makeStdin();
+  const allOutput = collect(stdout);
+
+  const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+  statusLine.start();
+  statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+
+  const compositor = new TerminalCompositor({
+    stdout,
+    stdin,
+    onCancel: vi.fn(),
+    scrollRegion: statusLine,
+    anchorRow: 1,
+  });
+  await compositor.arm();
+  statusLine.setExtraRows(2);
+  compositor.setSpinner({ enabled: true });
+
+  // Instrumentation: wrap commitAbove + track setOverlay calls
+  const commitLog: CommitRecord[] = [];
+  const overlayLog: OverlayRecord[] = [];
+  let currentPhase = 'init';
+
+  const origCommitAbove = compositor.commitAbove.bind(compositor);
+  compositor.commitAbove = (text: string) => {
+    commitLog.push({
+      text,
+      leadingBlanks: leadingBlanks(text),
+      embeddedBlanks: embeddedBlanks(text),
+      phase: currentPhase,
+    });
+    origCommitAbove(text);
+  };
+
+  const origSetOverlay = compositor.setOverlay.bind(compositor);
+  compositor.setOverlay = (text: string) => {
+    overlayLog.push({
+      text: text.slice(0, 60),
+      lineCount: text === '' ? 0 : text.split('\n').length,
+      phase: currentPhase,
+    });
+    origSetOverlay(text);
+  };
+
+  // ─── Component wiring ───────────────────────────────────────────────────
+  const toolLane = new ToolLane();
+  const coordinator = new CommitCoordinator();
+  const overlayComposer = new OverlayComposer(compositor, ['tool-lane']);
+  overlayComposer.register({
+    key: 'tool-lane',
+    render: () => toolLane.hasPending() ? toolLane.getOverlay() : '',
+  });
+
+  // Helper: push overlay update through composer
+  function flushOverlay(): void {
+    overlayComposer.markDirty('tool-lane');
+    overlayComposer.flush();
+  }
+
+  // Helper: orchestrator message_stop — calls the REAL production
+  // finalizeOrchestrator (stream-renderer-orchestrator-emit.ts) with a real
+  // OrchestratorCtx, so this test pins whatever the production lane-flush
+  // semantics are. With the pre-fix nuclear toolLane.flush() it captured ALL
+  // lane entries (including in-flight B, with a stale tool count) and deleted
+  // them; with the fixed flushCompletedRoots() in-flight subagent roots
+  // survive the turn boundary.
+  const noop = (): void => {};
+  const writerStub: Writer = {
+    line: noop, raw: noop, success: noop, info: noop, warn: noop, error: noop,
+  };
+  const orchestratorSource = freshSourceState(undefined);
+  const orchestratorCtx: OrchestratorCtx = {
+    out: writerStub,
+    isTTY: true,
+    compositor,
+    overlayComposer,
+    toolLane,
+    thinkingLane: new ThinkingLane(),
+    thinkingMode: 'off',
+    streamingMarkdown: { current: null },
+    coordinator,
+  };
+  function fireOrchestratorMessageStop(): void {
+    finalizeOrchestrator(orchestratorSource, orchestratorCtx);
+  }
+
+  // ─── Phase 0: Subagent A (mint-plan) — runs clean with no nuclear flush ─
+  // Represents the first subagent that completes correctly (no gap).
+  currentPhase = 'phase0-subagentA';
+  const agentEntryIdA = 'agent-mint-plan-001';
+  const sourceIdA = 'src-A';
+  // Production: orchestrator tool_use_detail for 'agent' → addStartWithAgentContext
+  toolLane.addStartWithAgentContext(agentEntryIdA, 'agent', '(mint-plan)', undefined);
+  toolLane.mergeAgentLabel(agentEntryIdA, 'mint-plan');
+  flushOverlay();
+
+  // A's child tools
+  for (let i = 0; i < 15; i++) {
+    const toolId = `tool-A-${i}`;
+    toolLane.addStartWithAgentContext(toolId, 'bash', `{"cmd":"echo ${i}"}`, agentEntryIdA);
+    toolLane.addResult(toolId, syntheticResult(`output ${i}`, false));
+    flushOverlay();
+  }
+
+  // A done: schedule + drain
+  {
+    const sourceA = freshSourceState('subagent');
+    sourceA.stats.toolUses = 15;
+    const doneSummaryA = formatDoneSummary(sourceA);
+    toolLane.setAgentResultSummary(agentEntryIdA, doneSummaryA);
+    toolLane.addResult(agentEntryIdA, syntheticResult(doneSummaryA, false));
+
+    if (toolLane.hasEntry(agentEntryIdA)) {
+      const lines = toolLane.flushSource(agentEntryIdA);
+      const capturedCompositor = compositor;
+      const capturedOverlayComposer = overlayComposer;
+      coordinator.schedule({
+        anchor: `after-subagent:${sourceIdA}`,
+        commits: [() => {
+          for (const line of lines) capturedCompositor.commitAbove(line);
+          capturedCompositor.commitAbove('');
+          capturedOverlayComposer.markDirty('tool-lane');
+          capturedOverlayComposer.flush();
+        }],
+      });
+    }
+    currentPhase = 'phase0-subagentA-drain';
+    coordinator.drainSubagent(sourceIdA);
+    flushOverlay();
+  }
+
+  // ─── Phase 1: Subagent B start (mint-parallelize) ─────────────────────
+  // Production: orchestrator dispatches B while the orchestrator turn is
+  // STILL GENERATING (the message hasn't stopped yet).
+  currentPhase = 'phase1-subagentB-start';
+  const agentEntryIdB = 'agent-mint-parallelize-001';
+  const sourceIdB = 'src-B';
+  // Production: handleOrchestratorEvent sees 'agent' tool_use_detail →
+  // addStartWithAgentContext(agentEntryIdB, 'agent', '(mint-parallelize)', skillCtx)
+  // where skillCtx = findLastSkillEntryId() → undefined (no skill entry in lane)
+  toolLane.addStartWithAgentContext(agentEntryIdB, 'agent', '(mint-parallelize)', undefined);
+  toolLane.mergeAgentLabel(agentEntryIdB, 'mint-parallelize');
+  flushOverlay();
+
+  // ─── Phase 2: B accumulates tools BEFORE nuclear flush (stale count) ────
+  currentPhase = 'phase2-subagentB-tools-before-nuclear';
+  for (let i = 0; i < opts.toolsBBeforeNuclear; i++) {
+    const toolId = `tool-B-pre-${i}`;
+    toolLane.addStartWithAgentContext(toolId, 'bash', `{"cmd":"echo B_pre${i}"}`, agentEntryIdB);
+    toolLane.addResult(toolId, syntheticResult(`out_pre ${i}`, false));
+    flushOverlay();
+  }
+
+  // ─── Phase 3: orchestrator message_stop fires MID-WAY through B ──────────
+  // This is the KEY production trigger: orchestrator stream ends while B is
+  // still running. Pre-fix, finalizeOrchestrator nuclear-flushed the lane —
+  // capturing B with toolsBBeforeNuclear tools (STALE count) and deleting it.
+  // Post-fix (flushCompletedRoots) B survives the boundary.
+  currentPhase = 'phase3-nuclear-flush-mid-B';
+  if (opts.nuclearFlushMidB) {
+    fireOrchestratorMessageStop();
+  }
+
+  // ─── Phase 4: B accumulates MORE tools after the message_stop ────────────
+  // These tools arrive in handleSubagentEvent, which calls:
+  //   addStartWithAgentContext(toolId, 'bash', ..., agentEntryIdB)
+  // Pre-fix, agentEntryIdB had been deleted by the nuclear flush, so these
+  // became orphaned entries with agentContext pointing to a deleted parent.
+  // Post-fix, B survived and these nest normally. Production refreshes the
+  // overlay on every subagent event regardless, so mirror that here.
+  currentPhase = 'phase4-subagentB-tools-after-nuclear';
+  for (let i = 0; i < opts.toolsBAfterNuclear; i++) {
+    const toolId = `tool-B-post-${i}`;
+    toolLane.addStartWithAgentContext(toolId, 'bash', `{"cmd":"echo B_post${i}"}`, agentEntryIdB);
+    toolLane.addResult(toolId, syntheticResult(`out_post ${i}`, false));
+    flushOverlay();
+  }
+
+  // ─── Phase 5: Subagent B done ────────────────────────────────────────────
+  // Production: finalizeSubagent sets result summary, then stream-renderer.ts
+  // checks hasEntry(agentEntryIdB). Pre-fix, the nuclear flush had deleted B
+  // so this returned FALSE and the whole done-block path was skipped — the
+  // bug. Post-fix, B survived the message_stop and this path runs normally.
+  currentPhase = 'phase5-subagentB-done';
+  {
+    const sourceB = freshSourceState('subagent');
+    sourceB.stats.toolUses = opts.toolsBBeforeNuclear + opts.toolsBAfterNuclear;
+    const doneSummaryB = formatDoneSummary(sourceB);
+
+    // Production: finalizeSubagent → setAgentResultSummary + addResult
+    // (no-ops if agentEntryIdB is absent from the lane)
+    toolLane.setAgentResultSummary(agentEntryIdB, doneSummaryB);
+    toolLane.addResult(agentEntryIdB, syntheticResult(doneSummaryB, false));
+
+    // Production: stream-renderer.ts:604: if (syntheticId && toolLane.hasEntry(syntheticId))
+    if (toolLane.hasEntry(agentEntryIdB)) {
+      const lines = toolLane.flushSource(agentEntryIdB);
+      const capturedCompositor = compositor;
+      const capturedOverlayComposer = overlayComposer;
+      coordinator.schedule({
+        anchor: `after-subagent:${sourceIdB}`,
+        commits: [() => {
+          for (const line of lines) capturedCompositor.commitAbove(line);
+          capturedCompositor.commitAbove('');
+          capturedOverlayComposer.markDirty('tool-lane');
+          capturedOverlayComposer.flush();
+        }],
+      });
+    }
+    // drainSubagent(B):
+    // - With nuclear flush: drains before-content (nuclear batch: stale B header +
+    //   trailing blank + setOverlay('')) THEN after-subagent:B (EMPTY — never scheduled)
+    // - Without nuclear flush: drains before-content (empty) THEN after-subagent:B
+    //   (correctly scheduled above)
+    // This is the STRADDLE: the nuclear batch calls setOverlay('') (collapses overlay)
+    // before the after-subagent:B batch commits, which is empty anyway.
+    coordinator.drainSubagent(sourceIdB);
+    flushOverlay();
+  }
+
+  // ─── Phase 6: Trailing activity (pushes history to scrollback) ───────────
+  currentPhase = 'phase6-trailing';
+  compositor.setOverlay('next-subagent-spinner\nnext-subagent-detail');
+  for (let k = 0; k < 6; k++) {
+    compositor.commitAbove(`TRAILING_${k}`);
+  }
+  compositor.setOverlay('');
+
+  // Force two repaints so the scrollback is stable
+  const internals = compositor as unknown as { repaint(): void };
+  internals.repaint();
+  internals.repaint();
+
+  // ─── Replay stdout into headless xterm ────────────────────────────────────
+  const term = new HeadlessTerminal({
+    cols: opts.cols,
+    rows: opts.rows,
+    scrollback: 2000,
+    allowProposedApi: true,
+    convertEol: true,
+  });
+  await termWrite(term, allOutput());
+  const lines = allLines(term);
+  const dump = dumpMap(lines);
+  term.dispose();
+  statusLine.stop();
+  compositor.disarm();
+
+  const find = (m: string): number => lines.findIndex((l) => l.includes(m));
+  return { lines, dump, find, commitLog, overlayLog };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('subagent block gap — production pipeline reproduction (H1/H2b/H3 discrimination)', () => {
+  /**
+   * Helper: run a scenario and produce diagnostic output + assertion result.
+   */
+  async function runAndReport(
+    label: string,
+    opts: Parameters<typeof runMintScenario>[0],
+  ): Promise<{ gap: number; headerFound: boolean; doneFound: boolean; dump: string; commitLog: CommitRecord[]; overlayLog: OverlayRecord[] }> {
+    const { lines, dump, find, commitLog, overlayLog } = await runMintScenario(opts);
+
+    const phaseLog = commitLog.map(r =>
+      `  [${r.phase}] leading=${r.leadingBlanks} embedded=${r.embeddedBlanks} text=${JSON.stringify(r.text.slice(0, 80))}`
+    ).join('\n');
+    const overlayLogStr = overlayLog.map(r =>
+      `  [${r.phase}] lines=${r.lineCount}`
+    ).join('\n');
+
+    // H1: blanks in committed text (non-empty blanks = problem)
+    const suspiciousCommits = commitLog.filter(r => r.leadingBlanks > 0 || r.embeddedBlanks > 0);
+    const h1 = suspiciousCommits.length > 1 // allow 1 for the intentional trailing blank
+      ? `H1 CANDIDATE (${suspiciousCommits.length} calls with blank lines)`
+      : 'H1 clear';
+
+    // Find B block boundaries
+    const headerIdxB = find('mint-parallelize');
+    let doneIdxB = -1;
+    for (let i = headerIdxB + 1; i < lines.length; i++) {
+      if ((lines[i] ?? '').includes('Done (')) { doneIdxB = i; break; }
+    }
+
+    // H3: duplicated rows
+    const h3 = (headerIdxB >= 0 && doneIdxB > headerIdxB)
+      ? (() => {
+          const rowsInBlock = lines.slice(headerIdxB, doneIdxB + 1);
+          const seen = new Set<string>();
+          let dups = 0;
+          for (const row of rowsInBlock) {
+            const trimmed = row.trim();
+            if (trimmed && seen.has(trimmed)) dups++;
+            seen.add(trimmed);
+          }
+          return dups > 0 ? `H3 CANDIDATE (${dups} dup rows)` : 'H3 clear';
+        })()
+      : 'H3 N/A';
+
+    const gap = (headerIdxB >= 0 && doneIdxB > headerIdxB)
+      ? maxBlankRun(lines, headerIdxB, doneIdxB)
+      : -1;
+
+    console.log(`\n=== ${label} ===\nheader=${headerIdxB} done=${doneIdxB} gap=${gap} | ${h1} | ${h3}\ncommitAbove:\n${phaseLog}\nsetOverlay:\n${overlayLogStr}\nBuffer:\n${dump}\n`);
+
+    return { gap, headerFound: headerIdxB >= 0, doneFound: doneIdxB >= 0, dump, commitLog, overlayLog };
+  }
+
+  // ── Baseline: no nuclear flush — must produce no gap ───────────────────
+  for (const geo of [
+    { cols: 80, rows: 24, label: '80x24' },
+    { cols: 120, rows: 50, label: '120x50' },
+  ]) {
+    it(`baseline (no nuclear flush, B survives to done): no gap (${geo.label})`, async () => {
+      const { gap, headerFound, doneFound, dump } = await runAndReport(
+        `BASELINE ${geo.label}`,
+        { cols: geo.cols, rows: geo.rows, toolsBBeforeNuclear: 18, toolsBAfterNuclear: 0, nuclearFlushMidB: false },
+      );
+      if (!headerFound || !doneFound) return; // block not scrolled yet — not a failure
+      expect(gap, `baseline must have no gap:\n${dump}`).toBeLessThanOrEqual(1);
+    }, 20_000);
+  }
+
+  // ── Regression: orchestrator message_stop mid-B must not lose B's block ──
+  // This is the primary production mechanism: message_stop fires while B is
+  // running (toolsBBeforeNuclear tools accumulated). Pre-fix, the nuclear
+  // flush captured B with a stale count and deleted it; B's done-path then
+  // found hasEntry(B)=false → no after-subagent:B batch, no drainSubagent →
+  // stale block committed at dispose, Done MISSING. Post-fix
+  // (flushCompletedRoots) B survives the boundary and the done-path commits
+  // the complete block with final counts.
+  for (const geo of [
+    { cols: 80, rows: 24, label: '80x24' },
+    { cols: 120, rows: 50, label: '120x50' },
+  ]) {
+    for (const [beforeN, afterN] of [[18, 18], [15, 21]] as [number, number][]) {
+      const label = `nuclear-mid-B (${geo.label}) pre=${beforeN} post=${afterN}`;
+      it(`${label}: B Done must appear in scrollback`, async () => {
+        const { headerFound, doneFound, dump, gap } = await runAndReport(
+          label,
+          {
+            cols: geo.cols,
+            rows: geo.rows,
+            toolsBBeforeNuclear: beforeN,
+            toolsBAfterNuclear: afterN,
+            nuclearFlushMidB: true,
+          },
+        );
+
+        if (!headerFound) {
+          // B completely lost — a more severe form of the regression
+          console.log('SEVERE: B header absent — mid-flight flush deleted B without committed fallback');
+        }
+
+        // ASSERTION #1: B's Done line must appear in scrollback. Under the
+        // pre-fix nuclear flush, doneFound=false (Done was never committed
+        // because hasEntry(B)=false at done time skips the after-subagent:B batch).
+        expect(
+          doneFound,
+          `B Done line missing from scrollback (mid-flight flush deleted B before done; after-subagent:B batch never scheduled).\n${dump}`,
+        ).toBe(true);
+
+        // ASSERTION #2: No blank gap inside the block.
+        if (doneFound && headerFound) {
+          expect(
+            gap,
+            `BLANK GAP of ${gap} rows inside subagent B block.\n${dump}`,
+          ).toBeLessThanOrEqual(1);
+        }
+      }, 20_000);
+    }
+  }
+
+  // ── Production-faithful focused variant ────────────────────────────────────
+  // Exact mint production knobs: 80x24 terminal, A=15 tools (mint-plan),
+  // B=18 tools before the mid-flight message_stop + 18 after
+  // (mint-parallelize stale scenario from the 2026-06-10 screenshot).
+  it('production-faithful (80x24, A=15, B=18+18 message_stop mid-flight): B Done must be in scrollback', async () => {
+    const { headerFound, doneFound, gap, commitLog, dump } = await runAndReport(
+      'PRODUCTION-FAITHFUL',
+      { cols: 80, rows: 24, toolsBBeforeNuclear: 18, toolsBAfterNuclear: 18, nuclearFlushMidB: true },
+    );
+
+    // Instrumentation cross-check: finalizeOrchestrator only SCHEDULES — no
+    // direct commits during phase 3. Post-fix, the done-path commits fire in
+    // phase 5 (eager drainSubagent); pre-fix phase 5 was silent (hasEntry=false).
+    const phase3Commits = commitLog.filter(r => r.phase === 'phase3-nuclear-flush-mid-B');
+    const phase5Commits = commitLog.filter(r => r.phase === 'phase5-subagentB-done');
+
+    console.log(`
+PRODUCTION-FAITHFUL FINDINGS:
+  headerFound=${headerFound} doneFound=${doneFound} gap=${gap}
+  phase3 (finalize) direct commits: ${phase3Commits.length} (expected 0 — finalize only schedules)
+  phase5 (B done) commits: ${phase5Commits.length} (expected >0 post-fix — eager drain)
+`);
+
+    expect(phase3Commits.length, 'finalizeOrchestrator must not commit directly').toBe(0);
+    expect(phase5Commits.length, 'B done-path must eagerly drain its block').toBeGreaterThan(0);
+
+    // PRIMARY ASSERTION: Done line must be present in scrollback. Under the
+    // pre-fix nuclear flush: B was deleted mid-flight → hasEntry(B)=false at
+    // done time → after-subagent:B never scheduled → Done never committed.
+    expect(
+      doneFound,
+      `B Done line absent from scrollback.
+Mid-flight flush deleted B from lane (with stale 18-tool count captured).
+B's done handler found hasEntry(B)=false → skipped flushSource+schedule+drainSubagent.
+B's stale block (18 tools) was committed by before-content batch at dispose time.
+B's Done line (36 tools) was never committed.
+Buffer:\n${dump}`,
+    ).toBe(true);
+
+    // SECONDARY ASSERTION: no blank gap (if both header and done present)
+    if (headerFound && doneFound) {
+      expect(gap, `Blank gap of ${gap} in B block:\n${dump}`).toBeLessThanOrEqual(1);
+    }
+  }, 20_000);
+});

--- a/src/cli/terminal-compositor.pad-decay-straddle.test.ts
+++ b/src/cli/terminal-compositor.pad-decay-straddle.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Reproduction: subagent-block gap — a commitAbove BURST that straddles the
+ * CupFrameRenderer shrink-pad decay strands the first committed line(s) high
+ * on screen with a multi-row blank gap below them, before the rest of the
+ * burst lands hugging the collapsed frame.
+ *
+ * Production shape (mint skill, screenshot 2026-06-10): subagent tool tray
+ * overlay is TALL (header + many tool rows). On subagent completion the
+ * overlay collapses (setOverlay short) and a deferred coordinator batch then
+ * commits the block: header, tool rows, Done. Final scrollback shows
+ *   `→ Agent(mint-parallelize) [subagent] — 18 tools · …`
+ *   ~28 BLANK rows
+ *   tool rows + `Done (36 tools · …)`
+ *
+ * Mechanism under test (hypothesis):
+ *   1. setOverlay(short) after a tall overlay triggers the one-render shrink
+ *      pad: render() pads the frame back to the old footprint, so
+ *      `topRow` stays at the TALL position for exactly one render.
+ *   2. commitAbove(#1 of burst) Phase 1 computes fitsAboveFrame from the
+ *      still-padded (stale-tall) topRow → writes line #1 high on screen.
+ *   3. The same commit's Phase 2 repaint decays the pad → frame collapses to
+ *      the bottom, vacating the tall footprint as blank rows BELOW line #1.
+ *   4. commitAbove(#2..N) now see the collapsed topRow → land at the bottom;
+ *      the band-merge contiguity check fails against line #1's stranded row;
+ *      the vacated blanks sit between line #1 and lines #2..N.
+ *   5. Subsequent commits scroll the whole arrangement verbatim into
+ *      scrollback: line #1, big blank run, lines #2..N.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { StatusLine } from './status-line.js';
+
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin = NodeJS.ReadStream & { isTTY: boolean; isRaw: boolean; setRawMode: ReturnType<typeof vi.fn> };
+
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true; s.columns = cols; s.rows = rows; return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true; s.isRaw = false; s.setRawMode = vi.fn((r: boolean) => { s.isRaw = r; return s; }); return s;
+}
+function collect(stream: MockStdout): () => string {
+  const c: string[] = [];
+  stream.on('data', (x) => c.push(String(x)));
+  return () => c.join('');
+}
+function termWrite(t: HeadlessTerminal, d: string): Promise<void> {
+  return new Promise((r) => t.write(d, r));
+}
+function allLines(t: HeadlessTerminal): string[] {
+  const b = t.buffer.active; const o: string[] = [];
+  for (let i = 0; i < b.length; i++) { const l = b.getLine(i); if (l) o.push(l.translateToString(true)); }
+  return o;
+}
+function dumpMap(lines: string[]): string {
+  const out: string[] = [];
+  let blanks = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const l = (lines[i] ?? '').trimEnd();
+    if (l === '') { blanks++; continue; }
+    if (blanks > 0) { out.push(`     [${blanks} blank]`); blanks = 0; }
+    out.push(`[${String(i).padStart(3)}] ${l.slice(0, 70)}`);
+  }
+  if (blanks > 0) out.push(`     [${blanks} blank]`);
+  return out.join('\n');
+}
+
+/** Largest run of contiguous blank rows strictly between buffer rows a and b. */
+function maxBlankRun(lines: string[], a: number, b: number): number {
+  let max = 0, run = 0;
+  for (let r = a + 1; r < b; r++) {
+    if ((lines[r] ?? '').trim() === '') { run++; if (run > max) max = run; }
+    else run = 0;
+  }
+  return max;
+}
+
+async function runScenario(opts: {
+  cols: number;
+  rows: number;
+  tallLines: number;
+  commitsWhileTall: number;
+  burst: string[];
+  trailingCommits: number;
+}): Promise<{ lines: string[]; dump: string; find: (m: string) => number }> {
+  const stdout = makeStdout(opts.cols, opts.rows);
+  const stdin = makeStdin();
+  const all = collect(stdout);
+  const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+  statusLine.start();
+  statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+  const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1 });
+  await c.arm();
+  statusLine.setExtraRows(2);
+  c.setSpinner({ enabled: true });
+
+  // Prior context: a completed block already in history (mirrors mint-plan).
+  c.setOverlay('tool detail a\ntool detail b');
+  c.commitAbove('EARLIER_CTX_A\n');
+  c.commitAbove('EARLIER_CTX_B\n');
+
+  // Subagent tray grows TALL (header + tool rows live in the overlay).
+  const tray = Array.from({ length: opts.tallLines }, (_, i) => `live tray row ${i}`).join('\n');
+  c.setOverlay(tray);
+
+  // Optional commits while tall — puts the committed band hugging the tall
+  // frame top (production: earlier orchestrator prose/tool flushes).
+  for (let k = 0; k < opts.commitsWhileTall; k++) {
+    c.commitAbove(`WHILE_TALL_${k}\n`);
+  }
+
+  // Subagent completes: overlay collapses to a short frame (spinner+input),
+  // then the deferred batch commits the whole block as a burst.
+  c.setOverlay('spinner row');
+  for (const line of opts.burst) c.commitAbove(`${line}\n`);
+
+  // Next subagent starts; later activity pushes history toward scrollback.
+  c.setOverlay('next subagent spinner\nnext subagent row');
+  for (let k = 0; k < opts.trailingCommits; k++) {
+    c.commitAbove(`TRAILING_${k}\n`);
+  }
+  c.setOverlay('');
+  const internals = c as unknown as { repaint(): void };
+  internals.repaint();
+  internals.repaint();
+
+  const term = new HeadlessTerminal({ cols: opts.cols, rows: opts.rows, scrollback: 1000, allowProposedApi: true, convertEol: true });
+  await termWrite(term, all());
+  const lines = allLines(term);
+  const dump = dumpMap(lines);
+  term.dispose(); statusLine.stop(); c.disarm();
+  const find = (m: string): number => lines.findIndex((l) => l.includes(m));
+  return { lines, dump, find };
+}
+
+const BURST = [
+  'BLOCK_HEADER Agent(mint-parallelize)',
+  ...Array.from({ length: 6 }, (_, i) => `BLOCK_TOOL_${i}`),
+  'BLOCK_DONE (36 tools)',
+];
+
+describe('commitAbove burst straddling shrink-pad decay (subagent block gap)', () => {
+  for (const geometry of [
+    { cols: 80, rows: 24, tallLines: 14 },
+    { cols: 120, rows: 50, tallLines: 30 },
+  ]) {
+    for (const commitsWhileTall of [0, 2]) {
+      it(`keeps the burst contiguous (${geometry.cols}x${geometry.rows}, tall=${geometry.tallLines}, whileTall=${commitsWhileTall})`, async () => {
+        const { lines, dump, find } = await runScenario({
+          cols: geometry.cols,
+          rows: geometry.rows,
+          tallLines: geometry.tallLines,
+          commitsWhileTall,
+          burst: BURST,
+          trailingCommits: 6,
+        });
+
+        // Every burst line must appear exactly once.
+        for (const m of BURST) {
+          const hits = lines.filter((l) => l.includes(m)).length;
+          expect(hits, `${m} must appear exactly once (found ${hits}):\n${dump}`).toBe(1);
+        }
+
+        const headerIdx = find('BLOCK_HEADER');
+        const firstToolIdx = find('BLOCK_TOOL_0');
+        const doneIdx = find('BLOCK_DONE');
+
+        // Order: header above tools above done.
+        expect(headerIdx, `header before tools:\n${dump}`).toBeLessThan(firstToolIdx);
+        expect(firstToolIdx, `tools before done:\n${dump}`).toBeLessThan(doneIdx);
+
+        // THE BUG: a multi-row blank gap inside one committed block.
+        // Allow at most 1 blank row (rhythm separator); the regression strands
+        // the header above the vacated tall-frame footprint (~tallLines rows).
+        const gap = maxBlankRun(lines, headerIdx, doneIdx);
+        expect(
+          gap,
+          `blank gap of ${gap} rows inside the committed block (header row ${headerIdx} → done row ${doneIdx}):\n${dump}`,
+        ).toBeLessThanOrEqual(1);
+      }, 20_000);
+    }
+  }
+});


### PR DESCRIPTION
## Summary

Fixes the persistent TUI bug where REPL scrollback showed a subagent block with a **stale tool count in the header, a multi-row blank gap, and a missing/displaced `Done` line** (most visible in long skill turns, e.g. mint dispatching sequential subagents).

- **Root cause:** `finalizeOrchestrator` ran the nuclear `ToolLane.flush()` at every orchestrator `message_stop`. A subagent still running at that boundary was captured with a stale tool count and **deleted from the lane**; its later child events became orphans, and the done-path guard `toolLane.hasEntry(syntheticId)` (`stream-renderer.ts:604`) then failed — skipping `flushSource`, the `after-subagent` batch, and the eager `drainSubagent`. The final block (correct counts + `Done`) was never committed; the stale capture drained at dispose-time `flushAll`, out of causal order.
- **Fix:** `finalizeOrchestrator` now uses `ToolLane.flushCompletedRoots()` (the selective flush already used by `flushToolLaneToScrollback`), honoring its own documented contract that subagent entries are not flushed at turn boundaries. The deferred batch refreshes the overlay from live lane state (`markDirty('tool-lane')` / `getOverlay()`) instead of clearing it to `''`, so surviving in-flight rows keep rendering; an empty selective flush schedules nothing.
- Compositor-level hypotheses (shrink-pad decay straddle, overflow path) were investigated and **ruled out** — pinned by two new green test files so the exoneration is durable.

## How was this tested?

- `pnpm lint` (tsc --noEmit strict): clean
- `pnpm test:coverage` (CI gate): **477 files, 8895 passed, 0 failed**, coverage 83.22% stmts / 83.02% branch / 88.68% funcs / 83.22% lines (thresholds 74/79/82/74)
- `pnpm audit:env:check`, `pnpm scan:env:check`, `pnpm build`: clean
- **Regression discrimination verified both directions:** `subagent-block-gap.repro.test.ts` drives the REAL `finalizeOrchestrator` through the production sequence (subagent A done → orchestrator `message_stop` mid-subagent-B → B done). With the fix stashed: 5/7 red. With the fix: 7/7 green (`doneFound=true gap=0`, eager phase-5 drain).

## Verification (adversarial verifier wave, `--verify`)

Independent read-only verifier re-derived the load-bearing claims from the diff alone:

- **CONFIRM** root cause — pre-image `stream-renderer-orchestrator-emit.ts:181` called nuclear `flush()` (renders + deletes all entries, `tool-lane.ts:824`); `flushCompletedRoots()` skips `result === undefined` roots.
- **CONFIRM** causal chain — `stream-renderer.ts:604` gates the entire done-path; dispose safety net at `:752` is the only remaining (and intended) nuclear flush call site.
- **CONFIRM** fix correctness — no other mid-turn nuclear-flush call sites; overlay refresh preserves in-flight rows.
- **CONFIRM** test discrimination — repro imports the production `finalizeOrchestrator` re-export; 7/7 green empirically.

Verifier notes (disclosed):
- The `stream-renderer.test.ts` ordering test now completes its seeded tool, so it no longer covers the in-flight-at-finalize path — that coverage moved to the new repro test.
- `stream-renderer-subagent-gap.repro.test.ts` documents **ruled-out** hypotheses (it does not exercise `finalizeOrchestrator`); `subagent-block-gap.repro.test.ts` is the regression pin for this bug.
- When the selective flush returns zero lines, no overlay refresh is scheduled at that boundary (the overlay is already current from live events) — noted as a benign subtlety.

## Out of scope

- Real-PTY confirmation: per `docs/scrollback.md`, byte-level/headless-xterm tests are the strongest in-test evidence but final confirmation is a live REPL run of a long skill turn.
- `flushCompletedRoots`' subtree semantics for a *completed* root with in-flight descendants (pre-existing behavior, untouched).

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] Commits are signed off (`git commit -s`) per the DCO — follows existing main-branch practice (recent merges carry no DCO trailers; not CI-enforced). Happy to add sign-off if preferred.
- [x] No secrets, tokens, or private paths in the diff
