### PR TITLE
fix(cli): correct ESC soft-stop notice (drop dead-end /resume hint)

### DIFF
--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -464,8 +464,13 @@ export async function runTurn(
     // commit the turn as completed — visible-success-with-silent-stop,
     // exactly the failure mode the soft-stop UX exists to prevent.
     // The SDK's server-side session store preserves the response even
-    // when we skip local recordTurn; the user can resume with /resume
-    // or --resume <id>.
+    // when we skip local recordTurn; the REPL session stays live, so the
+    // user continues simply by sending the next message — no resume needed.
+    // (/resume and --resume operate on *other* /saved sessions, not the
+    // live one that was just soft-stopped, so they must NOT be advertised
+    // here; doing so sent users down a dead-end. See the onSoftStop doc in
+    // terminal-compositor.types.ts: "next Enter starts a new turn in the
+    // same session.")
     if (softStopRequested) {
       const write = completionWriter ? completionWriter.fn : console.log;
       // Invariant (TUI rhythm contract): the soft-stop notice owns ONE
@@ -473,7 +478,7 @@ export async function runTurn(
       // or tool block) already emitted its own trailing blank, so a
       // leading blank here would double-up. See docs/tui-rhythm.md.
       write(palette.warning('⏸ Stopped — work so far kept.') +
-        palette.dim('  Use /resume or --resume to continue.'));
+        palette.dim('  Send a message to continue.'));
       write('');
     }
 


### PR DESCRIPTION
## Problem

After an ESC soft-stop, the REPL printed:

> ⏸ Stopped — work so far kept.  **Use /resume or --resume to continue.**

But that guidance is a dead end. After ESC the REPL session stays **live** — the turn loop keeps running and the user continues simply by sending their next message. Neither command continues the just-stopped session:

- `/resume` lists/swaps to *other* `/save`d sessions, and explicitly **guards against** resuming into the live session (`Already on session …`).
- `--resume <id>` is a launch flag that relaunches a *fresh process*.

So users following the hint were sent somewhere that could not continue their current work.

## Fix

`src/cli/commands/interactive/turn-handler.ts` (the sole emitter of this notice):

- Notice suffix → `Send a message to continue.`
- Rewrote the stale `Invariant:` comment that had propagated the wrong mental model, recording *why* `/resume`/`--resume` must not be advertised here and cross-referencing the `onSoftStop` doc in `terminal-compositor.types.ts`, which already documents the truth: *"next Enter starts a new turn in the same session."*

The skill-dispatch soft-stop path (`run-skill-dispatch-turn.ts`) prints no such notice — it just breaks — so this was the only occurrence.

## Verification

- `pnpm lint` (tsc --noEmit, strict) — clean
- `pnpm test -- src/cli/commands/interactive/turn-handler.test.ts` — 37/37 pass
- No test pinned the old string, so nothing else changed

No behavior change beyond the user-facing string.
