### PR TITLE
feat(cli): add --post/--post-pr headless publishing to afk chat

### DIFF
--- a/src/cli/commands/chat.post.test.ts
+++ b/src/cli/commands/chat.post.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tests for `afk chat --post <targets>` / `--post-pr <ref>` headless publishing.
+ *
+ * The publish stack (`runReviewPostPublish`) is mocked at the module boundary so
+ * these tests assert *invocation* — that the flag is parsed and the publisher is
+ * called with the right `targets` / `reviewText` / `prRefFromArgs` — not that the
+ * underlying gh/Telegram calls fire (those are covered by review-post.test.ts).
+ * The real `parsePostFlag` runs (via importOriginal) so target validation is
+ * exercised end-to-end.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Command } from 'commander';
+import type { OutputEvent } from '../../agent/types/session-types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function* makeStream(events: OutputEvent[]): AsyncIterable<OutputEvent> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+/** A fresh AgentSession mock implementation whose text turn returns `content`. */
+function sessionImpl(content: string) {
+  return () => ({
+    close: vi.fn().mockResolvedValue(undefined),
+    sendMessage: vi.fn().mockResolvedValue({ content, timestamp: new Date() }),
+    sendMessageStream: vi.fn().mockReturnValue(makeStream([{ type: 'done' }])),
+    getLastResponseMetadata: vi.fn().mockReturnValue(null),
+    getInputStreamRef: vi.fn().mockReturnValue({ pushUserMessage: vi.fn() }),
+    sessionId: 'mock-session-id',
+    abortSignal: new AbortController().signal,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mocks — hoisted above module imports.
+// ---------------------------------------------------------------------------
+
+vi.mock('../../agent/session.js', () => ({
+  AgentSession: vi.fn().mockImplementation(sessionImpl('pong')),
+}));
+
+vi.mock('../config.js', () => ({
+  loadConfig: vi.fn(() => ({ model: 'sonnet', maxTokens: 4096 })),
+}));
+
+vi.mock('../shared-helpers.js', () => ({
+  parseThinking: vi.fn(() => undefined),
+  parseEffort: vi.fn(() => undefined),
+  parseBudget: vi.fn(() => undefined),
+  parseMaxOutputTokens: vi.fn(() => undefined),
+  parseProvider: vi.fn(() => undefined),
+  getApiKey: vi.fn(() => 'test-key'),
+  getApiKeyForModel: vi.fn(() => 'test-key'),
+  getModel: vi.fn(() => 'sonnet'),
+  getThinking: vi.fn(() => undefined),
+  getEffort: vi.fn(() => undefined),
+  getMaxBudgetUsd: vi.fn(() => undefined),
+  getTaskBudget: vi.fn(() => undefined),
+  getMaxOutputTokens: vi.fn(() => undefined),
+  getDefaultSubagentModel: vi.fn(() => 'sonnet'),
+  loadSystemPrompt: vi.fn(() => undefined),
+  loadConfigSystemPrompt: vi.fn(() => undefined),
+  resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
+}));
+
+vi.mock('../../agent/routing-directive.js', () => ({
+  assembleSystemPrompt: vi.fn(() => undefined),
+}));
+
+vi.mock('../../agent/default-hook-registry.js', () => ({
+  createDefaultHookRegistry: vi.fn(() => ({ registry: {} })),
+}));
+
+vi.mock('../../agent/memory/index.js', () => ({
+  MemoryStore: vi.fn(() => ({ close: vi.fn() })),
+  injectHotMemory: (c: unknown) => c,
+  MEMORY_TOOL_NAMES: [],
+}));
+
+vi.mock('../../agent/subagent.js', () => ({
+  SubagentManager: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../../agent/tools/subagent-executor.js', () => ({
+  SubagentExecutor: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../../agent/tools/skill-executor.js', () => ({
+  SkillExecutor: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../../agent/tools/compose-executor.js', () => ({
+  ComposeExecutor: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../../agent/tools/nesting.js', () => ({
+  createChildProviderFactory: vi.fn(() => ({})),
+  createChildSkillExecutorFactory: vi.fn(() => ({})),
+}));
+
+vi.mock('../../agent/providers/anthropic-direct/index.js', () => ({
+  AnthropicDirectProvider: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('../../agent/tools/schemas.js', () => ({
+  BUILTIN_TOOL_NAMES: [],
+}));
+
+vi.mock('../../agent/trace/factory.js', () => ({
+  createDefaultTraceWriter: vi.fn(() => null),
+}));
+
+vi.mock('./interactive/progress-banner.js', () => ({
+  formatSubagentCompletion: vi.fn(() => ''),
+}));
+
+vi.mock('./interactive/worktree.js', () => ({
+  setupWorktree: vi.fn(),
+}));
+
+vi.mock('../errors/index.js', () => ({
+  handleCommandError: vi.fn((err: unknown): never => {
+    throw err instanceof Error ? err : new Error(String(err));
+  }),
+}));
+
+vi.mock('../resume-session.js', () => ({
+  resolveResumeTarget: vi.fn(() => undefined),
+  resumeConfigFor: vi.fn(() => ({})),
+}));
+
+vi.mock('../session-store.js', () => ({
+  saveSession: vi.fn(() => '/tmp/mock.json'),
+  findSession: vi.fn(() => undefined),
+}));
+
+vi.mock('../slash/session-stats.js', () => ({
+  createSessionStats: vi.fn(() => ({
+    totalTurns: 0,
+    totalCostUsd: 0,
+    totalTokens: 0,
+    totalDurationMs: 0,
+    sessionStartTime: Date.now(),
+    turnCosts: [],
+    turnTokens: [],
+    turns: [],
+    model: 'sonnet',
+    planMode: false,
+  })),
+  recordTurn: vi.fn(() => ({ user: '', assistant: '', timestamp: Date.now() })),
+}));
+
+// Partial mock: keep the REAL parsePostFlag (so target validation is exercised),
+// replace only the side-effecting publisher with a spy.
+vi.mock('../slash/_lib/review-post.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../slash/_lib/review-post.js')>();
+  return {
+    ...real,
+    runReviewPostPublish: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { AgentSession } from '../../agent/session.js';
+import { runReviewPostPublish } from '../slash/_lib/review-post.js';
+import { registerChatCommand } from './chat.js';
+
+const mockPublish = vi.mocked(runReviewPostPublish);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function runChat(...args: string[]): Promise<void> {
+  const program = new Command();
+  program.exitOverride();
+  registerChatCommand(program);
+  await program.parseAsync(['node', 'afk', 'chat', ...args]);
+}
+
+/** Capture stderr written during fn(). */
+async function captureStderr(fn: () => Promise<void>): Promise<string> {
+  const chunks: string[] = [];
+  const spy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk));
+    return true;
+  });
+  try {
+    await fn();
+  } catch {
+    /* ignore — we only want stderr */
+  } finally {
+    spy.mockRestore();
+  }
+  return chunks.join('');
+}
+
+/** Swallow stdout writes (and fire the write callback) so NDJSON paths don't hang. */
+async function captureStdout(fn: () => Promise<void>): Promise<string[]> {
+  const chunks: string[] = [];
+  const spy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((chunk: unknown, encoding?: unknown, cb?: unknown) => {
+      chunks.push(String(chunk));
+      const callback = typeof encoding === 'function' ? encoding : cb;
+      if (typeof callback === 'function') {
+        setImmediate(() => (callback as (err?: Error | null) => void)(null));
+      }
+      return true;
+    });
+  try {
+    await fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return chunks.join('').split('\n').filter((l) => l.trim().length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('afk chat — --post headless publishing', () => {
+  const originalIsTTY = process.stdin.isTTY;
+
+  beforeEach(() => {
+    vi.mocked(AgentSession).mockReset();
+    vi.mocked(AgentSession).mockImplementation(sessionImpl('pong'));
+    mockPublish.mockReset();
+    mockPublish.mockResolvedValue(undefined);
+    // Positional-message path: a literal arg is used regardless of TTY, but force
+    // non-TTY so an accidentally-omitted arg fails loudly instead of reading stdin.
+    // @ts-expect-error — overriding readonly-ish runtime prop for the test
+    process.stdin.isTTY = false;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    // @ts-expect-error — restore original
+    process.stdin.isTTY = originalIsTTY;
+    process.exitCode = undefined;
+  });
+
+  it('does not publish when --post is absent', async () => {
+    await runChat('hello', '--format', 'json');
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it('--post github calls the publisher with targets ["github"]', async () => {
+    await runChat('hello', '--post', 'github', '--format', 'json');
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ targets: ['github'] }),
+    );
+  });
+
+  it('--post telegram calls the publisher with targets ["telegram"]', async () => {
+    await runChat('hello', '--post', 'telegram', '--format', 'json');
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ targets: ['telegram'] }),
+    );
+  });
+
+  it('--post github,telegram calls the publisher with both targets', async () => {
+    await runChat('hello', '--post', 'github,telegram', '--format', 'json');
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ targets: ['github', 'telegram'] }),
+    );
+  });
+
+  it('--post with an unknown target warns and does not publish (exit not 1)', async () => {
+    const stderr = await captureStderr(() => runChat('hello', '--post', 'slack', '--format', 'json'));
+    expect(stderr).toMatch(/unknown --post target ignored: slack/);
+    expect(mockPublish).not.toHaveBeenCalled();
+    expect(process.exitCode).not.toBe(1);
+  });
+
+  it('--post-pr forwards the ref as prRefFromArgs', async () => {
+    await runChat('hello', '--post', 'github', '--post-pr', '123', '--format', 'json');
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ prRefFromArgs: '123' }),
+    );
+  });
+
+  it('prRefFromArgs is null when --post-pr is omitted', async () => {
+    await runChat('hello', '--post', 'github', '--format', 'json');
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ prRefFromArgs: null }),
+    );
+  });
+
+  it('passes the final assistant text as reviewText (text path)', async () => {
+    vi.mocked(AgentSession).mockImplementationOnce(sessionImpl('the full review output'));
+    await runChat('review it', '--post', 'github', '--format', 'json');
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ reviewText: 'the full review output' }),
+    );
+  });
+
+  it('publishes the accumulated text on the stream-json path', async () => {
+    vi.mocked(AgentSession).mockImplementationOnce(() => ({
+      close: vi.fn().mockResolvedValue(undefined),
+      sendMessage: vi.fn().mockResolvedValue({ content: 'unused', timestamp: new Date() }),
+      sendMessageStream: vi.fn().mockReturnValue(
+        makeStream([
+          { type: 'chunk', chunk: { type: 'content', content: 'streamed ' } },
+          { type: 'chunk', chunk: { type: 'content', content: 'output' } },
+          { type: 'done', metadata: undefined },
+        ] as OutputEvent[]),
+      ),
+      getLastResponseMetadata: vi.fn().mockReturnValue(null),
+      getInputStreamRef: vi.fn().mockReturnValue({ pushUserMessage: vi.fn() }),
+      sessionId: 'mock-session-id',
+      abortSignal: new AbortController().signal,
+    }));
+
+    await captureStdout(() => runChat('review it', '--format', 'stream-json', '--post', 'github'));
+
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ targets: ['github'], reviewText: 'streamed output' }),
+    );
+  });
+
+  it('is fail-soft: a throwing publisher does not flip the exit code', async () => {
+    mockPublish.mockReset();
+    mockPublish.mockRejectedValueOnce(new Error('post failed'));
+    const stderr = await captureStderr(() => runChat('hello', '--post', 'github', '--format', 'json'));
+    expect(stderr).toMatch(/\[--post\] publish failed: post failed/);
+    expect(process.exitCode).not.toBe(1);
+  });
+});

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -29,6 +29,8 @@ import { setupWorktree } from './interactive/worktree.js';
 import { resolveResumeTarget, resumeConfigFor } from '../resume-session.js';
 import { saveSession, findSession } from '../session-store.js';
 import { createSessionStats, recordTurn } from '../slash/session-stats.js';
+import { runReviewPostPublish, parsePostFlag, type PostTarget } from '../slash/_lib/review-post.js';
+import type { Writer } from '../slash/types.js';
 
 /** Loose UUID format check: 8-4-4-4-12 hex groups separated by dashes. */
 function isUuidShaped(s: string): boolean {
@@ -146,6 +148,8 @@ export function registerChatCommand(program: Command): void {
     .option('--resume <id>', 'Resume a persisted session by id')
     .option('--continue', 'Continue the most recent persisted session in cwd')
     .option('--session-id <uuid>', 'Assign a specific UUID to this session (creates new; errors if already exists)')
+    .option('--post <targets>', 'Headless publish of the final assistant message: github, telegram, or github,telegram')
+    .option('--post-pr <ref>', 'PR number, URL, or branch for --post github (defaults to the current-branch PR)')
     .action(async (rawMessage: string | undefined, options: {
       model: AgentModelInput;
       stream: boolean;
@@ -163,6 +167,8 @@ export function registerChatCommand(program: Command): void {
       resume?: string;
       continue?: boolean;
       sessionId?: string;
+      post?: string;
+      postPr?: string;
     }) => {
       // -----------------------------------------------------------------------
       // Mutual-exclusion checks for session flags (before spinner so errors
@@ -189,6 +195,24 @@ export function registerChatCommand(program: Command): void {
           process.stderr.write(`Error: session already exists: ${options.sessionId} — use --resume to continue it\n`);
           process.exitCode = 1;
           return;
+        }
+      }
+
+      // -----------------------------------------------------------------------
+      // Parse --post targets up front so an unknown target warns before any
+      // agent/network work. Reuses the REPL's parsePostFlag (which is string-in)
+      // by reconstructing the flag string from the Commander value; the actual
+      // publish runs after the turn completes (see maybePublish below). An
+      // all-unknown value yields zero targets → a no-op, not a hard error.
+      // -----------------------------------------------------------------------
+      const postTargets: PostTarget[] = [];
+      if (options.post !== undefined) {
+        const parsedPost = parsePostFlag(`--post ${options.post}`);
+        postTargets.push(...parsedPost.targets);
+        for (const unknownTarget of parsedPost.unknown) {
+          process.stderr.write(
+            `Warning: unknown --post target ignored: ${unknownTarget} (expected github or telegram)\n`,
+          );
         }
       }
 
@@ -560,6 +584,37 @@ export function registerChatCommand(program: Command): void {
         spinner.text = 'Sending message...';
 
         // ---------------------------------------------------------------------------
+        // Optional --post publish. Reuses the REPL's runReviewPostPublish so the
+        // GitHub/Telegram posting logic (markers, chunking, gh/Telegram auth) is
+        // never duplicated. Fail-soft by contract AND by an extra inner try/catch:
+        // a publish failure writes to stderr and is swallowed so it can never flip
+        // the command's exit code or corrupt stdout (NDJSON stays clean — the
+        // Writer is stderr-backed). No-op when no targets were requested.
+        // ---------------------------------------------------------------------------
+        const maybePublish = async (reviewText: string, errored: boolean): Promise<void> => {
+          if (postTargets.length === 0 || errored) return;
+          const out: Writer = {
+            line: (t?: string) => { process.stderr.write(`${t ?? ''}\n`); },
+            raw: (t: string) => { process.stderr.write(t); },
+            success: (t: string) => { process.stderr.write(`✔ ${t}\n`); },
+            info: (t: string) => { process.stderr.write(`ℹ ${t}\n`); },
+            warn: (t: string) => { process.stderr.write(`⚠ ${t}\n`); },
+            error: (t: string) => { process.stderr.write(`✖ ${t}\n`); },
+          };
+          try {
+            await runReviewPostPublish(out, {
+              targets: postTargets,
+              reviewText,
+              prRefFromArgs: options.postPr ?? null,
+            });
+          } catch (err) {
+            process.stderr.write(
+              `[--post] publish failed: ${err instanceof Error ? err.message : String(err)}\n`,
+            );
+          }
+        };
+
+        // ---------------------------------------------------------------------------
         // stream-json path — emits raw OutputEvent NDJSON on stdout for headless
         // consumers. The spinner is stopped before entering the loop so its escape
         // sequences do not corrupt the NDJSON stream on stdout.
@@ -578,6 +633,7 @@ export function registerChatCommand(program: Command): void {
           spinner.stop();
 
           let streamAssistantText = '';
+          let streamErrored = false;
           const stream = session.sendMessageStream(message);
           for await (const event of stream) {
             await writeAndDrain(process.stdout, JSON.stringify(event, dateReplacer) + '\n');
@@ -594,10 +650,12 @@ export function registerChatCommand(program: Command): void {
             }
             if (event.type === 'error') {
               process.exitCode = 1;
+              streamErrored = true;
               break;
             }
           }
 
+          await maybePublish(streamAssistantText, streamErrored);
           return;
         }
 
@@ -653,6 +711,8 @@ export function registerChatCommand(program: Command): void {
           }
           console.log('');
         }
+
+        await maybePublish(response.content, false);
 
       } catch (error) {
         encounteredError = true;


### PR DESCRIPTION
## Source

Ported from **afk-workshop#769** — https://github.com/griffinwork40/afk-workshop/pull/769

This is a moat-scrubbed port from the private repo, not a 1:1 copy. (In this case the diff contained no private/moat content, so the ported change is functionally identical to the source.)

## What

Adds `--post <targets>` and `--post-pr <ref>` to `afk chat`, wiring the existing `runReviewPostPublish` into the headless path so scheduled / non-interactive runs can publish their final assistant message to GitHub PR comments and/or Telegram.

```sh
afk chat --model opus_1m --post github --post-pr <pr-url> "Run /review <pr-url> and end with the full review."
afk chat --post github,telegram "..."     # both targets
afk chat "..."                              # no --post → unchanged behavior
```

## Why

The `--post` publishing path (`runReviewPostPublish`) was wired **only** into the interactive REPL slash dispatcher. `afk chat` has no slash routing and the REPL cannot be driven headlessly (piping into `afk interactive` throws `ERR_USE_AFTER_CLOSE` or silently ignores the command), so a scheduled cron running reviews via `afk chat` had no way to use the native publishing. This closes that gap.

## Design

- Reuses `parsePostFlag` + `runReviewPostPublish` from `src/cli/slash/_lib/review-post.ts` — **no posting or validation logic duplicated**.
- `--post-pr` is needed because a cron's cwd may not be the target repo; omitted → falls back to `resolveCurrentBranchPr()`.
- **Fail-soft**: a publish failure writes to stderr and can never flip the exit code or corrupt stdout — NDJSON stays clean (the `Writer` is stderr-backed), and the publish call is wrapped in its own try/catch.
- Strict no-op when `--post` is absent; an unknown target (e.g. `--post slack`) warns and is skipped (exit stays 0).

## Ported

- `src/cli/commands/chat.ts` (+`--post`/`--post-pr` flags, `maybePublish` helper on both the text and stream-json paths)
- `src/cli/commands/chat.post.test.ts` (new — 10 cases: target parsing incl. comma-list + unknown, `--post-pr` forwarding/null fallback, reviewText capture on both paths, fail-soft isolation)

## Dropped (and why)

**Nothing.** The source diff touched only `src/cli/commands/` and contained no moat files, no moat-denylist terms, and no moat structural paths. The full source diff was ported as-is.

## Verification

- **Correctness gate (green):** `pnpm install --frozen-lockfile`, `pnpm lint` (tsc strict), `env -u AFK_INTERNAL pnpm test` (**481/481 files, 8974 passed + 12 skipped**), `pnpm build`, `pnpm build:dist` — all exit 0. Hash-pin check clean (no pinned files touched). Ported test file: 10/10.
- **Deterministic moat guard:** `✅ MOAT GUARD CLEAN` (HARD denylist + structural markers across tree + built `dist/`).
- **Adversarial audit:** independent sub-agent re-derived moat-cleanliness from scratch → `VERDICT: CLEAN`.

## Do not merge automatically

Left for human review.
