### PR TITLE
fix(daemon): bind control HTTP surface to loopback by default

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -97,6 +97,13 @@
       "category": "daemon"
     },
     {
+      "name": "AFK_DAEMON_HOST",
+      "description": "Bind address for the daemon control HTTP surface. Defaults to 127.0.0.1 (loopback only). The control surface is unauthenticated, so bind a non-loopback address such as 0.0.0.0 only on a trusted or firewalled network. Overridden by the --host flag.",
+      "type": "string",
+      "required": false,
+      "category": "daemon"
+    },
+    {
       "name": "AFK_DAEMON_TASK",
       "description": "Default task description for the daemon. Falls back to afk.config.json daemon.task.",
       "type": "string",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**105 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**106 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 
@@ -81,6 +81,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | Name | Type | Required | Default | Example | Description |
 |------|------|----------|---------|---------|-------------|
 | `AFK_DAEMON_CWD` | string |  |  |  | Working directory used by the daemon process for spawned agent sessions. |
+| `AFK_DAEMON_HOST` | string |  |  |  | Bind address for the daemon control HTTP surface. Defaults to 127.0.0.1 (loopback only). The control surface is unauthenticated, so bind a non-loopback address such as 0.0.0.0 only on a trusted or firewalled network. Overridden by the --host flag. |
 | `AFK_DAEMON_TASK` | string |  |  |  | Default task description for the daemon. Falls back to afk.config.json daemon.task. |
 | `AFK_DAEMON_TASK_ID` | string |  |  |  | Task identifier the daemon uses to scope its state directory and telemetry. |
 | `AFK_SESSIONSTART_COOLDOWN_MS` | number |  |  |  | Cooldown in milliseconds between SessionStart trigger fires in the daemon. Prevents thundering-herd on rapid restarts. |

--- a/src/agent/daemon.test.ts
+++ b/src/agent/daemon.test.ts
@@ -905,6 +905,24 @@ describe('port file lifecycle', () => {
     expect(readFileSync(portFilePath(), 'utf-8')).toBe('65501');
   });
 
+  it('binds the control surface to loopback (127.0.0.1) by default', async () => {
+    const h = await startDaemon({ port: 0, writePortFile: false });
+    // Regression guard: the prior code omitted the host argument, so Node bound
+    // the unspecified address (all interfaces) — exposing the unauthenticated
+    // control surface to the local network. Loopback-by-default closes that.
+    // This assertion fails on the old behaviour (address would be '::'/'0.0.0.0').
+    expect(h.host).toBe('127.0.0.1');
+    await h.stop();
+  });
+
+  it('honors an explicit bind host option', async () => {
+    // Exercises the `options.host`-defined branch (the default test above
+    // covers the fallback branch). Loopback only — no external interface bind.
+    const h = await startDaemon({ port: 0, host: '127.0.0.1', writePortFile: false });
+    expect(h.host).toBe('127.0.0.1');
+    await h.stop();
+  });
+
   it('POST /tasks accepts cronExpression as an alias for cron', async () => {
     const h = await startDaemon({ port: 0, writePortFile: false });
     try {

--- a/src/agent/daemon.ts
+++ b/src/agent/daemon.ts
@@ -22,6 +22,18 @@ import { getDaemonStateDir } from '../paths.js';
 export interface DaemonOptions {
   /** Port for the HTTP control surface. Defaults to 7777. */
   port?: number;
+  /**
+   * Host/interface the HTTP control surface binds to. Defaults to
+   * '127.0.0.1' (loopback only).
+   *
+   * Invariant: the control surface is UNAUTHENTICATED and `POST /tasks`
+   * registers commands the daemon will execute via an agent session (which
+   * has shell access). Binding a non-loopback address therefore exposes
+   * arbitrary-command scheduling to anyone who can reach the port — so the
+   * default refuses off-host connections. Override only on a trusted or
+   * firewalled network.
+   */
+  host?: string;
   /** Tasks to register at startup. */
   tasks?: ScheduledTask[];
   /** Per-tick session config; flows through to `CronScheduler`. */
@@ -61,6 +73,8 @@ export interface DaemonOptions {
 
 export interface DaemonHandle {
   readonly port: number;
+  /** The address the control surface actually bound to (e.g. '127.0.0.1'). */
+  readonly host: string;
   readonly scheduler: CronScheduler;
   registerTask(task: ScheduledTask): void;
   unregisterTask(taskId: string): void;
@@ -75,6 +89,10 @@ export interface DaemonHandle {
 }
 
 const DEFAULT_PORT = 7777;
+// Invariant: loopback-only by default. The control surface is unauthenticated
+// (see DaemonOptions.host) — binding all interfaces would expose command
+// scheduling to the local network. Callers opt into a wider bind explicitly.
+const DEFAULT_HOST = '127.0.0.1';
 
 export async function startDaemon(options: DaemonOptions = {}): Promise<DaemonHandle> {
   const scheduler = new CronScheduler({
@@ -104,7 +122,11 @@ export async function startDaemon(options: DaemonOptions = {}): Promise<DaemonHa
   const portFilePath = join(getDaemonStateDir('default'), 'port');
 
   const server = createServer((req, res) => handleRequest(req, res, scheduler));
-  const port = await listen(server, options.port ?? DEFAULT_PORT);
+  const { port, address: host } = await listen(
+    server,
+    options.port ?? DEFAULT_PORT,
+    options.host ?? DEFAULT_HOST,
+  );
 
   // Write the port file so tool handlers can find the running daemon.
   if (writePortFile) {
@@ -118,6 +140,7 @@ export async function startDaemon(options: DaemonOptions = {}): Promise<DaemonHa
 
   return {
     port,
+    host,
     scheduler,
     registerTask(task) {
       scheduler.register(task);
@@ -280,14 +303,24 @@ async function handleRequestAsync(
   res.end(JSON.stringify({ error: 'not found' }));
 }
 
-function listen(server: Server, requestedPort: number): Promise<number> {
+function listen(
+  server: Server,
+  requestedPort: number,
+  host: string,
+): Promise<{ port: number; address: string }> {
   return new Promise((resolve, reject) => {
     server.once('error', reject);
-    server.listen(requestedPort, () => {
+    // Contract: passing `host` restricts the bind to that interface. Omitting
+    // it (the prior behaviour) made Node bind the unspecified address (all
+    // interfaces) — the vulnerability this argument closes.
+    server.listen(requestedPort, host, () => {
       server.removeListener('error', reject);
       const address = server.address();
-      if (typeof address === 'object' && address) resolve(address.port);
-      else resolve(requestedPort);
+      if (typeof address === 'object' && address) {
+        resolve({ port: address.port, address: address.address });
+      } else {
+        resolve({ port: requestedPort, address: host });
+      }
     });
   });
 }

--- a/src/cli/commands/daemon.test.ts
+++ b/src/cli/commands/daemon.test.ts
@@ -31,6 +31,7 @@ vi.mock('../config.js', () => ({
 vi.mock('../../agent/daemon.js', () => ({
   startDaemon: vi.fn(async () => ({
     port: 7777,
+    host: '127.0.0.1',
     scheduler: {},
     registerTask: vi.fn(),
     unregisterTask: vi.fn(),

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -11,11 +11,13 @@ import type { TaskCompletionDetails, TelemetryRecord } from '../../agent/daemon/
 import {
   COMPILED_DEFAULT_TASK,
   COMPILED_DEFAULT_TASK_ID,
+  resolveDaemonHost,
   resolveDaemonTimeoutMs,
   resolveDefaultTask,
   resolveDefaultTaskId,
   resolveSessionStartCooldownMs,
   resolveTriggerMode,
+  isLoopbackHost,
 } from '../daemon-options.js';
 import { loadConfig } from '../config.js';
 import type { AgentConfig, ThinkingConfig, EffortLevel, AgentModelInput } from '../../agent/types.js';
@@ -206,6 +208,10 @@ export function registerDaemonCommand(program: Command): void {
     .command('daemon')
     .description('Run agent-afk as a daemon that fires scheduled tasks (e.g. /forge-friction --auto)')
     .option('-p, --port <number>', 'Control HTTP port', '7777')
+    .option(
+      '--host <address>',
+      'Bind address for the control HTTP surface. Overrides AFK_DAEMON_HOST. Defaults to 127.0.0.1 (loopback only). The control surface is UNAUTHENTICATED — bind a non-loopback address (e.g. 0.0.0.0) only on a trusted or firewalled network.',
+    )
     .option('-t, --task <command>', `Command to fire on each tick (default: ${COMPILED_DEFAULT_TASK})`)
     .option('-c, --cron <expression>', 'Cron expression (e.g. "0 */6 * * *"). Required when --trigger includes cron.')
     .option('-i, --task-id <id>', `Task identifier (default: ${COMPILED_DEFAULT_TASK_ID})`)
@@ -229,7 +235,7 @@ export function registerDaemonCommand(program: Command): void {
       'Override directory scanned for pending briefs (defaults to ~/.afk/agent-framework/briefs).',
     )
     .option('--dump-prompt [path]', 'Dump resolved SDK prompt+options+provenance to file (default: ~/.afk/logs/prompt-dump-<ISO>.json) or "stderr"')
-    .action(async (options: { port: string; task?: string; cron?: string; taskId?: string; once: boolean; timeoutMs?: string; thinking?: string; effort?: string; trigger?: string; sessionstartCooldownMs?: string; briefsDir?: string; dumpPrompt?: string | boolean | undefined }) => {
+    .action(async (options: { port: string; host?: string; task?: string; cron?: string; taskId?: string; once: boolean; timeoutMs?: string; thinking?: string; effort?: string; trigger?: string; sessionstartCooldownMs?: string; briefsDir?: string; dumpPrompt?: string | boolean | undefined }) => {
       const port = parseInt(options.port, 10);
       if (Number.isNaN(port) || port <= 0) {
         handleCommandError(new Error(`Invalid port: ${options.port}`));
@@ -246,6 +252,7 @@ export function registerDaemonCommand(program: Command): void {
         env.AFK_DAEMON_TASK_ID,
         config.daemon?.taskId,
       );
+      const host = resolveDaemonHost(options.host, env.AFK_DAEMON_HOST);
 
       let timeoutMs: number | undefined;
       let cooldownMs: number | undefined;
@@ -367,6 +374,7 @@ export function registerDaemonCommand(program: Command): void {
       try {
         const handle = await startDaemon({
           port,
+          host,
           // Transient one-tick runs must not claim (and on exit delete) the
           // shared port-discovery file the service daemon's live-sync needs.
           ...(options.once ? { writePortFile: false } : {}),
@@ -406,7 +414,16 @@ export function registerDaemonCommand(program: Command): void {
           }
         }
 
-        console.log(palette.success(`✔ Daemon listening on http://localhost:${handle.port}`));
+        console.log(palette.success(`✔ Daemon listening on http://${handle.host}:${handle.port}`));
+        if (!isLoopbackHost(handle.host)) {
+          console.log(
+            palette.warning(
+              `⚠ Control surface bound to ${handle.host} (non-loopback) and is UNAUTHENTICATED — ` +
+                `anyone who can reach this port can schedule commands the daemon will run. ` +
+                `Ensure the port is firewalled / on a trusted network.`,
+            ),
+          );
+        }
         if (trigger === 'pull') {
           console.log(palette.success(`✔ Daemon in pull mode`));
           console.log(palette.dim(`  polling queue: ${getQueueDir()} every 30s`));

--- a/src/cli/daemon-options.test.ts
+++ b/src/cli/daemon-options.test.ts
@@ -5,6 +5,9 @@ import {
   resolveTriggerMode,
   resolveDefaultTask,
   resolveDefaultTaskId,
+  resolveDaemonHost,
+  isLoopbackHost,
+  DEFAULT_DAEMON_HOST,
   COMPILED_DEFAULT_TASK,
   COMPILED_DEFAULT_TASK_ID,
 } from './daemon-options.js';
@@ -201,5 +204,48 @@ describe('resolveDefaultTaskId', () => {
 
   it('frozen-default guard: COMPILED_DEFAULT_TASK_ID is "default"', () => {
     expect(COMPILED_DEFAULT_TASK_ID).toBe('default');
+  });
+});
+
+describe('resolveDaemonHost', () => {
+  it('defaults to loopback (127.0.0.1) when neither flag nor env is set', () => {
+    expect(resolveDaemonHost(undefined, undefined)).toBe('127.0.0.1');
+  });
+
+  it('security guard: DEFAULT_DAEMON_HOST is loopback', () => {
+    expect(DEFAULT_DAEMON_HOST).toBe('127.0.0.1');
+    expect(resolveDaemonHost(undefined, undefined)).toBe(DEFAULT_DAEMON_HOST);
+  });
+
+  it('treats empty / whitespace-only inputs as absent', () => {
+    expect(resolveDaemonHost('', '')).toBe('127.0.0.1');
+    expect(resolveDaemonHost('   ', undefined)).toBe('127.0.0.1');
+    expect(resolveDaemonHost(undefined, '   ')).toBe('127.0.0.1');
+  });
+
+  it('uses the env var when the flag is unset', () => {
+    expect(resolveDaemonHost(undefined, '0.0.0.0')).toBe('0.0.0.0');
+  });
+
+  it('flag takes precedence over env var', () => {
+    expect(resolveDaemonHost('192.168.1.10', '0.0.0.0')).toBe('192.168.1.10');
+  });
+
+  it('falls through to env when flag is whitespace-only', () => {
+    expect(resolveDaemonHost('  ', '0.0.0.0')).toBe('0.0.0.0');
+  });
+});
+
+describe('isLoopbackHost', () => {
+  it('recognises loopback literals (case / whitespace insensitive)', () => {
+    for (const h of ['127.0.0.1', 'localhost', '::1', 'LOCALHOST', '  127.0.0.1  ']) {
+      expect(isLoopbackHost(h)).toBe(true);
+    }
+  });
+
+  it('treats all-interfaces wildcards and LAN/hostnames as non-loopback', () => {
+    for (const h of ['0.0.0.0', '::', '192.168.1.10', '10.0.0.5', '0:0:0:0:0:0:0:0', 'example.com']) {
+      expect(isLoopbackHost(h)).toBe(false);
+    }
   });
 });

--- a/src/cli/daemon-options.ts
+++ b/src/cli/daemon-options.ts
@@ -154,3 +154,44 @@ export function resolveDefaultTaskId(
     COMPILED_DEFAULT_TASK_ID
   );
 }
+
+/**
+ * Compiled-in default daemon control-surface bind host. Loopback only.
+ *
+ * The HTTP control surface is unauthenticated and POST /tasks schedules
+ * commands the daemon executes, so the safe default is to refuse off-host
+ * connections. Override via --host / AFK_DAEMON_HOST only when remote control
+ * is genuinely needed (and the port is firewalled).
+ */
+export const DEFAULT_DAEMON_HOST = '127.0.0.1';
+
+/**
+ * Resolve the daemon control-surface bind host from (in precedence order):
+ *   1. `--host` flag value
+ *   2. `AFK_DAEMON_HOST` env var value
+ *   3. {@link DEFAULT_DAEMON_HOST} ('127.0.0.1') fallback
+ *
+ * Empty / whitespace-only inputs are treated as absent.
+ */
+export function resolveDaemonHost(
+  flagValue: string | undefined,
+  envValue: string | undefined,
+): string {
+  return (
+    presentOrUndefined(flagValue) ??
+    presentOrUndefined(envValue) ??
+    DEFAULT_DAEMON_HOST
+  );
+}
+
+/**
+ * True when `host` binds only the local machine (loopback). Used to decide
+ * whether to warn that the unauthenticated control surface is reachable from
+ * the network. Anything that is not a recognised loopback literal — including
+ * the all-interfaces wildcards '0.0.0.0' and '::' and any LAN IP/hostname — is
+ * treated as non-loopback (warn).
+ */
+export function isLoopbackHost(host: string): boolean {
+  const h = host.trim().toLowerCase();
+  return h === '127.0.0.1' || h === 'localhost' || h === '::1';
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -564,6 +564,13 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     category: 'daemon',
   },
   {
+    name: 'AFK_DAEMON_HOST',
+    description: 'Bind address for the daemon control HTTP surface. Defaults to 127.0.0.1 (loopback only). The control surface is unauthenticated, so bind a non-loopback address such as 0.0.0.0 only on a trusted or firewalled network. Overridden by the --host flag.',
+    type: 'string',
+    required: false,
+    category: 'daemon',
+  },
+  {
     name: 'AFK_SESSIONSTART_COOLDOWN_MS',
     description: 'Cooldown in milliseconds between SessionStart trigger fires in the daemon. Prevents thundering-herd on rapid restarts.',
     type: 'number',
@@ -1070,6 +1077,7 @@ export const env = {
   get AFK_DAEMON_CWD(): string | undefined { return process.env['AFK_DAEMON_CWD']; },
   get AFK_DAEMON_TASK(): string | undefined { return process.env['AFK_DAEMON_TASK']; },
   get AFK_DAEMON_TASK_ID(): string | undefined { return process.env['AFK_DAEMON_TASK_ID']; },
+  get AFK_DAEMON_HOST(): string | undefined { return process.env['AFK_DAEMON_HOST']; },
   get AFK_SESSIONSTART_COOLDOWN_MS(): string | undefined { return process.env['AFK_SESSIONSTART_COOLDOWN_MS']; },
 
   // Worktree


### PR DESCRIPTION
## Summary

The daemon's HTTP control surface bound to **all network interfaces** and is **unauthenticated**, so any host that could reach the port could schedule commands the daemon runs (effectively LAN-local RCE). This binds it to **loopback by default**, with an explicit opt-in for deliberate remote control.

## The issue (v3.103.0)

`src/agent/daemon.ts` called `server.listen(port, cb)` with **no host argument**, so Node bound the unspecified address (`::` / `0.0.0.0`, all interfaces). The control surface (`GET`/`POST`/`DELETE /tasks`) has **no auth**, and `POST /tasks` registers a command the daemon executes via an agent session (which has the bash tool). Net: anything that could reach `:7777` (same LAN/WiFi, or a server with the port open) could schedule arbitrary commands. The bind also contradicted the code's own comment asserting the path is "localhost-only".

Exposure is higher because the documented `service-setup` path runs the daemon 24/7 as a LaunchAgent.

## Fix

- **Bind `127.0.0.1` by default** (`DEFAULT_HOST`).
- **Opt-in override** for deliberate remote control via `--host <address>` or `AFK_DAEMON_HOST`.
- **Warn loudly** at startup when a non-loopback address is bound (the surface is still unauthenticated).
- Live-sync (`create_schedule` / `cancel_schedule`) is unaffected — that client already connects via `127.0.0.1`/`localhost`.

## Changes

| File | Change |
|------|--------|
| `src/agent/daemon.ts` | `DaemonOptions.host` (default `127.0.0.1`); `listen()` passes host + returns the bound address; `DaemonHandle.host` |
| `src/cli/daemon-options.ts` | `resolveDaemonHost()` (flag > env > `127.0.0.1`), `isLoopbackHost()` |
| `src/cli/commands/daemon.ts` | `--host` flag; reads `AFK_DAEMON_HOST`; non-loopback startup warning |
| `src/config/env.ts` + `docs/env-registry.{json,md}` | register `AFK_DAEMON_HOST` (docs regenerated via `pnpm scan:env`) |
| `src/agent/daemon.test.ts`, `src/cli/daemon-options.test.ts` | loopback-bind regression guard + resolver/loopback units |
| `src/cli/commands/daemon.test.ts` | mock handle updated to the new `host` contract |

## Compatibility

Backward-compatible for the default local-only use case. Behavior changes **only** for anyone who was (perhaps unknowingly) relying on reaching the daemon from another host — they now pass `--host 0.0.0.0` (or set `AFK_DAEMON_HOST`) explicitly, which the code comment indicates was never an intended configuration.

## Verification

- `pnpm lint` — clean
- `pnpm scan:env:check` — env docs in sync
- `pnpm audit:env:check` — 0 violations (`AFK_DAEMON_HOST` read only via the `env` getter)
- `pnpm test:coverage` — full suite green; adds a regression test that fails on the old all-interfaces bind
