### PR TITLE
fix(telegram): defer version-drift exit while a session is mid-turn

### DIFF
--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -418,8 +418,20 @@ async function main() {
         const diskVersion = pkg.version ?? 'unknown';
         const result = checkVersionDrift(DAEMON_VERSION, diskVersion);
         if (result.drift) {
-          console.log(`⚠️ ${result.message}`);
-          process.exit(0);
+          // Invariant: never exit mid-turn. The drift-exit hands the chat off to
+          // a freshly-installed binary via launchd KeepAlive, but exiting while a
+          // session is streaming severs the in-flight turn (plus its queued
+          // messages and sub-agent dispatch). The relaunched process starts cold
+          // and cannot resume it — the user sees "An unexpected error occurred"
+          // and the conversation does not continue. Defer the upgrade until every
+          // session is idle; the next stats tick (≤5 min) re-checks and exits then.
+          const busy = bot.getBusySessionCount();
+          if (busy > 0) {
+            console.log(`⚠️ ${result.message} — deferred: ${busy} active session(s) mid-turn.`);
+          } else {
+            console.log(`⚠️ ${result.message}`);
+            process.exit(0);
+          }
         }
       } catch {
         console.warn('⚠️ [daemon] Could not re-read package.json for version drift check — skipping.');

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -322,6 +322,15 @@ export class TelegramBot {
   }
 
   /**
+   * Number of sessions currently mid-turn (streaming / processing / compacting).
+   * The version-drift watchdog consults this to avoid exiting under an active
+   * conversation — see startBot() in src/telegram.ts.
+   */
+  getBusySessionCount(): number {
+    return this.sessionManager.getBusySessionCount();
+  }
+
+  /**
    * Test-facing handler methods (delegates to handlers module)
    * These are used by tests to invoke handlers directly without starting the bot
    */

--- a/src/telegram/session-manager.test.ts
+++ b/src/telegram/session-manager.test.ts
@@ -473,6 +473,29 @@ describe('SessionManager', () => {
       await manager.getSession(67890);
       expect(manager.getChatCount()).toBe(2);
     });
+
+    test('getBusySessionCount counts only non-idle, non-closed sessions', async () => {
+      // Idle sessions do not count as busy.
+      const s1 = (await manager.getSession(12345)) as MockAgentSession;
+      const s2 = (await manager.getSession(67890)) as MockAgentSession;
+      expect(manager.getSessionCount()).toBe(2);
+      expect(manager.getBusySessionCount()).toBe(0);
+
+      // A streaming session counts as busy; the idle one does not.
+      s1.state = 'streaming';
+      expect(manager.getBusySessionCount()).toBe(1);
+
+      // Other mid-turn states count too.
+      s2.state = 'processing';
+      expect(manager.getBusySessionCount()).toBe(2);
+      s2.state = 'compacting';
+      expect(manager.getBusySessionCount()).toBe(2);
+
+      // Returning to idle / closed drops them from the busy count.
+      s1.state = 'idle';
+      s2.state = 'closed';
+      expect(manager.getBusySessionCount()).toBe(0);
+    });
   });
 
   describe('closeAll', () => {

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -613,4 +613,24 @@ export class SessionManager {
   getChatCount(): number {
     return this.sessionData.size;
   }
+
+  /**
+   * Count sessions that are mid-turn (not idle and not closed).
+   *
+   * Used by the version-drift watchdog to defer the upgrade-exit while a
+   * conversation is in flight. A session in 'processing' / 'streaming' /
+   * 'compacting' is actively producing output (or rewriting history); exiting
+   * the process under it kills the turn, its queued messages, and any
+   * sub-agent dispatch — none of which the relaunched binary can resume.
+   *
+   * Fail-safe: any non-idle, non-closed state counts as busy, so a future
+   * SessionState variant defaults to "defer the exit" rather than "kill it".
+   */
+  getBusySessionCount(): number {
+    let busy = 0;
+    for (const session of this.sessions.values()) {
+      if (session.state !== 'idle' && session.state !== 'closed') busy++;
+    }
+    return busy;
+  }
 }


### PR DESCRIPTION
## Summary
- Fixes the Telegram bot killing itself **mid-conversation** whenever a new version is published while a chat is active.
- The version-drift watchdog (`src/telegram.ts`, 5-min `setInterval`) called `process.exit(0)` the instant a newer version landed on disk, with **no check for active sessions**. Under launchd `KeepAlive` the bot relaunched cold mid-stream — severing the in-flight turn, its queued messages, and any sub-agent dispatch. The user saw "An unexpected error occurred" / "An internal error occurred", and the relaunched (context-less) process could not continue the conversation.
- The exit is now guarded on `bot.getBusySessionCount()`: it only exits when **no session is mid-turn**, deferring the self-upgrade to the next idle tick.

## Test results
- `vitest run` (full suite): **8985 passed, 12 skipped, 481 files — exit 0**.
- `tsc --noEmit` (strict): clean.
- New unit test: `getBusySessionCount counts only non-idle, non-closed sessions` (covers idle / streaming / processing / compacting / closed).

## Verification (`--verify` adversarial wave)
An independent read-only verifier re-derived the 3 load-bearing claims from the diff + source (high confidence):
- **Root cause — CONFIRM:** pre-fix `process.exit(0)` fired with zero session-state guard (`git diff HEAD~1 -- src/telegram.ts`).
- **The fix — CONFIRM:** exit now gated on `busy === 0`; `busy > 0` logs "deferred" and does not exit (`src/telegram.ts:428–433`).
- **The counter — CONFIRM:** `getBusySessionCount()` counts `state !== 'idle' && !== 'closed'` over `SessionState = idle|processing|streaming|compacting|closed`; bot delegates to it (`session-manager.ts:629`, `session-types.ts:30`, `bot.ts:329`).

## Known tradeoff / follow-up (out of scope)
- **Deferral while busy:** a session stuck in `processing`/`streaming` (hung sub-agent, leaked session) would block self-upgrades indefinitely — there is no max-deferral / forced-close escape hatch. Accepted tradeoff: *never interrupt a live turn* > eager self-upgrade; the realistic case finishes in minutes. A bounded "force-upgrade after N deferrals" or stuck-session watchdog is a reasonable follow-up.
- This fix eliminates the **self-inflicted version kill only**. Any other mid-turn process death (OOM, SIGTERM, crash) still cannot resume the in-flight turn — true turn-state replay is a larger, separate change.