### PR TITLE
fix(cli): prevent table cut-off from row-count off-by-one and width overshoot

### DIFF
--- a/src/cli/formatter.test.ts
+++ b/src/cli/formatter.test.ts
@@ -137,6 +137,39 @@ describe('renderMarkdownToTerminal', () => {
     });
 
     /**
+     * Width-budget hard ceiling (the "clipped table + blank gap" regression).
+     *
+     * Per-column Math.round in the proportional shrink can under-reduce —
+     * round-down error accumulates across columns — leaving every rendered
+     * row 1+ col WIDER than maxWidth. formatBlockForCommit then re-wraps the
+     * committed block at contentWidth with word-wrap, splitting each
+     * over-wide row at its last space into a fragment + orphan '│' line.
+     * The inflated physical line count desyncs the compositor's row
+     * accounting, which clips the table's tail rows and emits a blank gap.
+     *
+     * 5 equal columns at maxWidth 25 is a concrete rounding-overshoot case:
+     * pre-fix it rendered 26-wide rows and the re-wrap inflated 6 lines → 8.
+     */
+    it('never renders a table line wider than maxWidth (rounding overshoot)', () => {
+      const sample = [
+        '| AAAA | BBBB | CCCC | DDDD | EEEE |',
+        '|------|------|------|------|------|',
+        '| aaaa | bbbb | cccc | dddd | eeee |',
+        '',
+      ].join('\n');
+      const maxWidth = 25;
+      const out = renderMarkdownToTerminal(sample, { maxWidth });
+      const lines = stripAnsi(out).split('\n').filter((l) => l.length > 0);
+      for (const line of lines) {
+        expect(stringWidth(line)).toBeLessThanOrEqual(maxWidth);
+      }
+      // The commit-time second wrap pass must be a no-op for table content —
+      // no orphan '│' fragments, no physical line-count inflation.
+      const rewrapped = wrapToWidth(out, maxWidth);
+      expect(rewrapped.split('\n').length).toBe(out.split('\n').length);
+    });
+
+    /**
      * Inter-row separator contract.
      *
      * A thin `├─┼─┤` line is inserted between every pair of data rows

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -307,6 +307,29 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
                 const reducible = Math.max(0, constrained[i]! - minColWidth);
                 constrained[i] = Math.max(minColWidth, constrained[i]! - Math.round(reducible * ratio));
               }
+              // Invariant: sum(constrained) must not exceed availableContentWidth.
+              // Per-column Math.round above can under-reduce (round-down error
+              // accumulates across columns), leaving rows 1+ col wider than
+              // maxWidth. Downstream, formatBlockForCommit re-wraps committed
+              // output at contentWidth with word-wrap: a row even 1 col over
+              // splits at its last space into a fragment + orphan '│' line,
+              // inflating the physical line count and corrupting the
+              // compositor's row accounting (clipped table tails + blank gaps
+              // in the REPL). Trim the widest reducible column until the total
+              // fits so rendered rows never exceed the budget.
+              let constrainedTotal = constrained.reduce((sum, w) => sum + w, 0);
+              while (constrainedTotal > availableContentWidth) {
+                let widest = -1;
+                for (let i = 0; i < constrained.length; i++) {
+                  if (constrained[i]! > minColWidth &&
+                      (widest === -1 || constrained[i]! > constrained[widest]!)) {
+                    widest = i;
+                  }
+                }
+                if (widest === -1) break; // nothing left above minColWidth
+                constrained[widest] = constrained[widest]! - 1;
+                constrainedTotal -= 1;
+              }
             }
             for (let i = 0; i < constrained.length; i++) {
               widths[i] = constrained[i] ?? widths[i] ?? 0;

--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -121,6 +121,21 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     ? Math.max(1, self.logUpdate.measure(stripped, rows).lineCount)
     : logicalLineCount;
   const textLines = stripped.split('\n');
+  // Mirror the trailing-blank removal wrapToPhysicalLines applies inside measure():
+  // commitBlock passes `trimmed + '\n\n'`; after stripping one '\n' the stripped
+  // string still ends with '\n', making split('\n') produce a trailing '' that
+  // makes textLines.length > lineCount by 1. In the exact-fit scenario (block
+  // height === aboveFrameRoom), this off-by-one makes newPainted=lineCount
+  // (capped by maxRun=lineCount) but textLines.length=lineCount+1, so the
+  // tail-slice slice(textLines.length - newPainted) starts at index 1 — DROPPING
+  // the table's top border — and paints the trailing '' into the bottom screen
+  // slot instead. Removing trailing '' here aligns textLines.length with lineCount.
+  //
+  // Guard: keep at least one element so commitAbove('') still paints a blank
+  // separator row (the stream-renderer subagent-done path relies on this). This
+  // mirrors measure()'s Math.max(1, wrapToPhysicalLines(...).length) clamp — an
+  // empty content still counts as 1 physical line for row accounting.
+  while (textLines.length > 1 && textLines[textLines.length - 1] === '') textLines.pop();
 
   // Decide where the committed text is written so it lands in scrollback
   // EXACTLY ONCE. Capture the live frame's top row BEFORE clear() resets it:
@@ -345,13 +360,13 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
       const newLines = textLines.slice(textLines.length - newPainted);
       // "Whole block painted" = newPainted === textLines.length (no lines
       // dropped to overflow). Compare against textLines.length, NOT lineCount:
-      // lineCount is the WRAP-AWARE physical row count (measure()), which
-      // diverges from the logical-line array length whenever a block has a
-      // trailing blank line (`\n\n` → split yields a trailing "") or a wrapped
-      // line. Using lineCount here wrongly failed the contiguity check on every
-      // `\n\n`-terminated commit, suppressing the merge and stranding the prior
-      // band as a single overwritten block (lost commits) — the splice
-      // regression. newPainted is itself derived from textLines.length.
+      // lineCount is the WRAP-AWARE physical row count (measure()), which can
+      // diverge from the logical-line array length when a line is wider than
+      // the terminal and wraps to >1 physical row. newPainted is itself derived
+      // from textLines.length, so comparing back to textLines.length keeps the
+      // check self-consistent regardless of wrap-induced divergence.
+      // Note: the prior `\n\n`-trailing-blank divergence (textLines.length =
+      // lineCount+1) is eliminated by the trailing-'' pop above.
       const wholeBlockPainted = newPainted === textLines.length;
       const contiguousPriorBand =
         fitsAboveFrame &&

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -854,6 +854,52 @@ describe('TerminalCompositor', () => {
       expect(outWith).toMatch(/\x1b\[22;1H\x1b\[2KB/);
     });
 
+    it('double-newline-terminated commit paints ALL rows including the top border (no trailing-empty slot waste)', async () => {
+      // Regression (table-cutoff): commitBlock always passes `trimmed + '\n\n'`
+      // to commitAbove. After stripping one trailing '\n', `stripped` ends with
+      // '\n', so `stripped.split('\n')` produces a trailing '' — making
+      // textLines.length = lineCount+1 (measure() via wrapToPhysicalLines pops
+      // trailing '' before counting). In the exact-fit scenario (block height
+      // === aboveFrameRoom), the tail-slice `textLines.slice(textLines.length -
+      // newPainted)` starts at index 1 (not 0), silently dropping the FIRST row
+      // (e.g. a table's top border) and painting the trailing '' into the last
+      // screen slot instead. Fix: pop trailing '' from textLines before Phase 3,
+      // mirroring the wrapToPhysicalLines normalization, with a length>1 guard so
+      // commitAbove('') still paints a blank separator row.
+      //
+      // Scenario: 22-row frame is used (rows=24, idle frame=1 row, newTopRow=23,
+      // maxRun=22). We commit a block with exactly 22 real content lines plus the
+      // mandatory commitBlock '\n\n' terminator → `'\n\n'`-terminated, 22 content
+      // lines + trailing '' in textLines (before fix). With fix the top-border
+      // row (LINE_00) is painted at the topmost slot (row 1).
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+      await c.arm();
+      writes.clear();
+      // Build 22-line block. commitBlock calls commitAbove(trimmed + '\n\n');
+      // we simulate that by appending '\n\n' ourselves. After the single-'\n'
+      // strip in commitAbove: stripped = 'LINE_00\n…\nLINE_21\n' → split produces
+      // ['LINE_00',…,'LINE_21',''] (23 elements, 22 real).
+      const lines = Array.from({ length: 22 }, (_, i) => `LINE_${String(i).padStart(2, '0')}`);
+      c.commitAbove(lines.join('\n') + '\n\n');
+      const out = writes.all();
+      // All 22 lines must appear in Phase 3 CUP writes (rows 1–22).
+      // The critical invariant: LINE_00 (top border / first row) must be present.
+      expect(out).toContain('LINE_00');
+      // LINE_21 (last row) must land immediately above the frame (row 22).
+      expect(out).toMatch(/\x1b\[22;1H\x1b\[2KLINE_21/);
+      // LINE_00 (first row) must land at row 1 (the topmost available slot).
+      expect(out).toMatch(/\x1b\[1;1H\x1b\[2KLINE_00/);
+      // The blank trailing '' must NOT appear as a CUP-painted row occupying
+      // one of the 22 above-frame slots (it would displace LINE_00 in the
+      // unfixed code). Verify each LINE_NN is at the expected row (1..22).
+      for (let i = 0; i < 22; i++) {
+        const row = i + 1;
+        const label = `LINE_${String(i).padStart(2, '0')}`;
+        const rowPattern = new RegExp(`\\x1b\\[${row};1H\\x1b\\[2K${label}`);
+        expect(out, `${label} must be at row ${row}`).toMatch(rowPattern);
+      }
+    });
+
     it('empty commit (compositor.commitAbove("")) places a blank row above the frame', async () => {
       // Used by the stream-renderer subagent-done path to insert a blank
       // separator line above the live frame. Phase 3 CUP-writes a blank


### PR DESCRIPTION
## Problem

Markdown tables in the REPL sometimes rendered cut off: missing top/bottom borders, a large blank gap mid-table, and clipped tail rows. "Sometimes" because it required specific column-width ratios × terminal width.

## Root cause (two interacting bugs, found via /diagnose)

**Bug A — off-by-one in committed-band row accounting** (`terminal-compositor.committed-band-commit.ts`)
Blocks commit as `trimmed + '\n\n'`, but `commitAbove` stripped only one trailing newline, leaving a trailing `''` in `textLines`. The phantom row made `textLines.length` permanently 1 greater than the measured physical row count. On exact-fit commits this dropped the table's top border, painted a blank bottom row, broke the band-merge check, and fired eviction one row early.

**Bug B — column-shrink width overshoot + commit-time re-wrap** (`formatter.ts`)
Over-wide tables shrink columns proportionally using per-column `Math.round`; accumulated round-down error could yield rendered rows 1+ cols **wider** than the budget. `formatBlockForCommit` then re-wrapped the block at `contentWidth`, word-splitting each over-wide row into a fragment + an orphan `│` line — inflating a 13-row table to ~21 physical lines, desyncing compositor row math (`bandOverflow` emitted the blank gap), and clipping the tail.

## Fix

- **Compositor:** pop the trailing `''` from `textLines`, guarded so intentional blank-separator commits still work.
- **Formatter:** trim-to-fit pass after proportional shrink guarantees no row exceeds `maxWidth`, making the commit-time re-wrap a provable no-op.

## Verification

- Regression test: exact-fit commit paints all rows including top border (compositor)
- Regression test: 5-col rounding-overshoot case stays within budget, no line inflation (formatter)
- Pre-fix repro rendered 26-wide rows in a 25 budget and inflated 6→8 lines; post-fix exactly 25 / no inflation
- `pnpm lint` clean; full suite green (8986 passed, 12 pre-existing skips)
