### PR TITLE
fix(telegram): force version-drift upgrade after N mid-turn deferrals

### DIFF
--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -29,7 +29,7 @@ import { existsSync, readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { env } from './config/env.js';
-import { checkVersionDrift } from './telegram/version-check.js';
+import { checkVersionDrift, decideVersionDriftAction } from './telegram/version-check.js';
 import { TelegramBot } from './telegram/bot.js';
 import { parseAllowedChatIds } from './telegram/allowlist.js';
 import { validateBotToken } from './telegram/setup-wizard.js';
@@ -406,6 +406,11 @@ async function main() {
     console.log('\n💬 Send any message to chat with the agent.');
     console.log('\n⏹️  Press Ctrl+C to stop the bot.');
 
+    // Consecutive version-drift deferrals across stats ticks. Held here (not in
+    // the watchdog function, which is pure) so it survives between ticks; reset
+    // to 0 by decideVersionDriftAction() whenever drift clears or we exit.
+    let driftDeferrals = 0;
+
     const statsInterval = setInterval(() => {
       const stats = bot.getStats();
       console.log(`\n📊 Stats: ${stats.activeSessions} active sessions, ${stats.totalChats} total chats`);
@@ -417,21 +422,33 @@ async function main() {
         const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version?: string };
         const diskVersion = pkg.version ?? 'unknown';
         const result = checkVersionDrift(DAEMON_VERSION, diskVersion);
-        if (result.drift) {
-          // Invariant: never exit mid-turn. The drift-exit hands the chat off to
-          // a freshly-installed binary via launchd KeepAlive, but exiting while a
-          // session is streaming severs the in-flight turn (plus its queued
-          // messages and sub-agent dispatch). The relaunched process starts cold
-          // and cannot resume it — the user sees "An unexpected error occurred"
-          // and the conversation does not continue. Defer the upgrade until every
-          // session is idle; the next stats tick (≤5 min) re-checks and exits then.
-          const busy = bot.getBusySessionCount();
-          if (busy > 0) {
-            console.log(`⚠️ ${result.message} — deferred: ${busy} active session(s) mid-turn.`);
-          } else {
-            console.log(`⚠️ ${result.message}`);
+
+        // Invariant: never exit mid-turn — but never defer forever either.
+        // The drift-exit hands the chat off to a freshly-installed binary via
+        // launchd KeepAlive; exiting while a session is streaming severs the
+        // in-flight turn (plus its queued messages and sub-agent dispatch), and
+        // the cold relaunch cannot resume it ("An unexpected error occurred").
+        // So defer while any session is mid-turn (PR #106). The bounded escape
+        // hatch: a session wedged in processing/streaming would otherwise defer
+        // the upgrade forever (stuck-busy livelock), so after MAX_DRIFT_DEFERRALS
+        // deferrals (~1h at this 5-min tick) force the exit anyway.
+        const busy = result.drift ? bot.getBusySessionCount() : 0;
+        const decision = decideVersionDriftAction({
+          drift: result,
+          busyCount: busy,
+          deferrals: driftDeferrals,
+        });
+        driftDeferrals = decision.deferrals;
+        switch (decision.action) {
+          case 'none':
+            break;
+          case 'defer':
+            if (decision.message !== undefined) console.log(`⚠️ ${decision.message}`);
+            break;
+          case 'exit':
+          case 'force-exit':
+            if (decision.message !== undefined) console.log(`⚠️ ${decision.message}`);
             process.exit(0);
-          }
         }
       } catch {
         console.warn('⚠️ [daemon] Could not re-read package.json for version drift check — skipping.');

--- a/src/telegram/version-check.test.ts
+++ b/src/telegram/version-check.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the Telegram daemon's version-drift watchdog.
+ *
+ * Covers both the drift detector (checkVersionDrift) and the exit/defer/
+ * force-exit decision (decideVersionDriftAction) — the latter is the bounded
+ * escape hatch for PR #106's mid-turn deferral (stuck-busy livelock guard).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  checkVersionDrift,
+  decideVersionDriftAction,
+  MAX_DRIFT_DEFERRALS,
+} from './version-check.js';
+
+describe('checkVersionDrift', () => {
+  it('reports no drift when versions match', () => {
+    expect(checkVersionDrift('3.104.3', '3.104.3')).toEqual({ drift: false });
+  });
+
+  it('reports drift with a message when versions differ', () => {
+    const result = checkVersionDrift('3.104.2', '3.104.3');
+    expect(result.drift).toBe(true);
+    expect(result.message).toContain('3.104.2');
+    expect(result.message).toContain('3.104.3');
+  });
+
+  it('treats unknown / empty versions as no drift (avoids spurious exits)', () => {
+    expect(checkVersionDrift('unknown', '3.104.3')).toEqual({ drift: false });
+    expect(checkVersionDrift('3.104.3', 'unknown')).toEqual({ drift: false });
+    expect(checkVersionDrift('', '3.104.3')).toEqual({ drift: false });
+    expect(checkVersionDrift('3.104.3', '')).toEqual({ drift: false });
+  });
+});
+
+describe('decideVersionDriftAction', () => {
+  const drift = checkVersionDrift('3.104.2', '3.104.3');
+  const noDrift = checkVersionDrift('3.104.3', '3.104.3');
+
+  it('returns "none" and resets the counter when there is no drift', () => {
+    const decision = decideVersionDriftAction({ drift: noDrift, busyCount: 3, deferrals: 7 });
+    expect(decision.action).toBe('none');
+    expect(decision.deferrals).toBe(0);
+    expect(decision.message).toBeUndefined();
+  });
+
+  it('exits cleanly when drift is present and no session is busy', () => {
+    const decision = decideVersionDriftAction({ drift, busyCount: 0, deferrals: 0 });
+    expect(decision.action).toBe('exit');
+    expect(decision.deferrals).toBe(0);
+    expect(decision.message).toBe(drift.message);
+  });
+
+  it('resets the deferral counter once the busy sessions drain (drift, busy=0)', () => {
+    // Came in with prior deferrals, but now nothing is busy → clean exit + reset.
+    const decision = decideVersionDriftAction({ drift, busyCount: 0, deferrals: 5 });
+    expect(decision.action).toBe('exit');
+    expect(decision.deferrals).toBe(0);
+  });
+
+  it('defers (not exits) while a session is mid-turn, below the cap', () => {
+    const decision = decideVersionDriftAction({ drift, busyCount: 2, deferrals: 0 });
+    expect(decision.action).toBe('defer');
+    expect(decision.deferrals).toBe(1);
+    expect(decision.message).toContain('deferred (1/');
+    expect(decision.message).toContain('2 active session');
+  });
+
+  it('increments the deferral counter on each consecutive busy tick', () => {
+    const first = decideVersionDriftAction({ drift, busyCount: 1, deferrals: 0 });
+    expect(first.action).toBe('defer');
+    expect(first.deferrals).toBe(1);
+
+    const second = decideVersionDriftAction({ drift, busyCount: 1, deferrals: first.deferrals });
+    expect(second.action).toBe('defer');
+    expect(second.deferrals).toBe(2);
+  });
+
+  it('force-exits once the deferral count reaches the cap (livelock escape)', () => {
+    const decision = decideVersionDriftAction({
+      drift,
+      busyCount: 1,
+      deferrals: MAX_DRIFT_DEFERRALS,
+    });
+    expect(decision.action).toBe('force-exit');
+    expect(decision.message).toContain('forcing upgrade');
+    expect(decision.message).toContain('interrupted');
+  });
+
+  it('honors a custom maxDeferrals: defers up to the cap, then force-exits', () => {
+    const maxDeferrals = 2;
+    // Tick 1: 0 → defer (1/2)
+    const t1 = decideVersionDriftAction({ drift, busyCount: 1, deferrals: 0, maxDeferrals });
+    expect(t1.action).toBe('defer');
+    expect(t1.deferrals).toBe(1);
+    expect(t1.message).toContain('(1/2)');
+
+    // Tick 2: 1 → defer (2/2)
+    const t2 = decideVersionDriftAction({ drift, busyCount: 1, deferrals: t1.deferrals, maxDeferrals });
+    expect(t2.action).toBe('defer');
+    expect(t2.deferrals).toBe(2);
+    expect(t2.message).toContain('(2/2)');
+
+    // Tick 3: 2 ≥ cap → force-exit
+    const t3 = decideVersionDriftAction({ drift, busyCount: 1, deferrals: t2.deferrals, maxDeferrals });
+    expect(t3.action).toBe('force-exit');
+    expect(t3.message).toContain('after 2 deferral(s)');
+  });
+
+  it('a single busy session is enough to defer; idle/closed drained → clean exit next tick', () => {
+    // Busy → defer.
+    const busyTick = decideVersionDriftAction({ drift, busyCount: 1, deferrals: 3 });
+    expect(busyTick.action).toBe('defer');
+    expect(busyTick.deferrals).toBe(4);
+
+    // Session goes idle before hitting the cap → clean exit, counter reset.
+    const drainedTick = decideVersionDriftAction({ drift, busyCount: 0, deferrals: busyTick.deferrals });
+    expect(drainedTick.action).toBe('exit');
+    expect(drainedTick.deferrals).toBe(0);
+  });
+
+  it('MAX_DRIFT_DEFERRALS is a positive, bounded grace window', () => {
+    // Sanity guard: a 0 or negative default would force-exit immediately and
+    // resurrect the very mid-turn kill PR #106 fixed.
+    expect(MAX_DRIFT_DEFERRALS).toBeGreaterThan(0);
+    expect(Number.isInteger(MAX_DRIFT_DEFERRALS)).toBe(true);
+  });
+});

--- a/src/telegram/version-check.ts
+++ b/src/telegram/version-check.ts
@@ -34,3 +34,94 @@ export function checkVersionDrift(
     message: `[daemon] Version mismatch: running ${spawnedVersion} but installed is ${diskVersion}. Exiting.`,
   };
 }
+
+/**
+ * Maximum number of consecutive stats-tick deferrals the version-drift
+ * watchdog tolerates before it force-exits under an active session.
+ *
+ * Invariant: this is the bounded escape hatch for the deferral added in PR #106.
+ * That fix defers the upgrade-exit while any session is mid-turn (exiting would
+ * sever the in-flight turn, its queued messages, and any sub-agent dispatch —
+ * the relaunched binary starts cold and cannot resume it). But a session wedged
+ * in `processing`/`streaming` (hung sub-agent, leaked session) would otherwise
+ * defer the upgrade *forever*: a stuck-busy livelock. After this many deferrals
+ * the watchdog forces the exit even though sessions still report busy. At the
+ * daemon's 5-min stats tick (300_000 ms) 12 deferrals ≈ 1 hour of grace — far
+ * longer than any legitimate turn (those finish in minutes) yet bounded for a
+ * wedged one. Tuned here, consumed by decideVersionDriftAction().
+ */
+export const MAX_DRIFT_DEFERRALS = 12;
+
+/** What the version-drift watchdog should do on a given stats tick. */
+export type VersionDriftAction = 'none' | 'exit' | 'defer' | 'force-exit';
+
+export interface VersionDriftDecisionInput {
+  /** Result of {@link checkVersionDrift} for this tick. */
+  drift: VersionDriftResult;
+  /** Sessions currently mid-turn (`SessionManager.getBusySessionCount()`). */
+  busyCount: number;
+  /** Consecutive deferrals accumulated so far — caller-held, fed back each tick. */
+  deferrals: number;
+  /** Force the exit once `deferrals` reaches this many. Defaults to {@link MAX_DRIFT_DEFERRALS}. */
+  maxDeferrals?: number;
+}
+
+export interface VersionDriftDecision {
+  /** Action the caller should take this tick. */
+  action: VersionDriftAction;
+  /** Updated consecutive-deferral count to carry into the next tick. */
+  deferrals: number;
+  /** Human-readable log line. Present for every action except `'none'`. */
+  message?: string;
+}
+
+/**
+ * Decide whether the daemon should exit, defer, or force-exit for a version
+ * drift this tick — the bounded escape hatch for PR #106's mid-turn deferral.
+ *
+ * Pure: holds no state. The caller persists `deferrals` across ticks and feeds
+ * it back in; the reset-to-0 (drift cleared, or cleared-to-exit) happens here so
+ * the caller never manages the counter directly.
+ *
+ *   - no drift                 → { action: 'none',       deferrals: 0 }
+ *   - drift, no busy session   → { action: 'exit',       deferrals: 0 }   clean handoff
+ *   - drift, busy, < cap       → { action: 'defer',      deferrals: n+1 } grace window
+ *   - drift, busy, ≥ cap       → { action: 'force-exit', deferrals: n }   livelock escape
+ *
+ * With the default cap, drift+busy defers on ticks 1..maxDeferrals (counter
+ * reaching maxDeferrals/maxDeferrals) and force-exits on the next busy tick.
+ */
+export function decideVersionDriftAction(
+  input: VersionDriftDecisionInput,
+): VersionDriftDecision {
+  const maxDeferrals = input.maxDeferrals ?? MAX_DRIFT_DEFERRALS;
+
+  if (!input.drift.drift) {
+    return { action: 'none', deferrals: 0 };
+  }
+
+  const base = input.drift.message ?? '[daemon] Version drift detected.';
+
+  // No session mid-turn: exit cleanly so the freshly-installed binary takes
+  // over. Reset the counter so a later drift starts its grace window fresh.
+  if (input.busyCount <= 0) {
+    return { action: 'exit', deferrals: 0, message: base };
+  }
+
+  // A session is mid-turn. Once the grace window is exhausted, force the exit to
+  // break the stuck-busy livelock; otherwise defer one more tick.
+  if (input.deferrals >= maxDeferrals) {
+    return {
+      action: 'force-exit',
+      deferrals: input.deferrals,
+      message: `${base} — forcing upgrade after ${input.deferrals} deferral(s): ${input.busyCount} session(s) still mid-turn (their turn will be interrupted).`,
+    };
+  }
+
+  const deferrals = input.deferrals + 1;
+  return {
+    action: 'defer',
+    deferrals,
+    message: `${base} — deferred (${deferrals}/${maxDeferrals}): ${input.busyCount} active session(s) mid-turn.`,
+  };
+}


### PR DESCRIPTION
## Summary
Adds the bounded force-upgrade escape hatch that PR #106 documented as a follow-up.

PR #106 fixed the Telegram bot killing itself mid-conversation on a version drift by deferring the upgrade-exit while any session is mid-turn. The `--verify` wave flagged a **stuck-busy livelock**: a session wedged in `processing`/`streaming` (hung sub-agent, leaked session) would defer the self-upgrade **indefinitely** — there was no forced-exit escape hatch. That was logged as an accepted tradeoff (*never interrupt a live turn* > eager self-upgrade) with a "force-upgrade after N deferrals" follow-up. **This PR is that follow-up.**

## What changed
- **`src/telegram/version-check.ts`** — new pure, unit-testable `decideVersionDriftAction()` returning one of `none | exit | defer | force-exit` given the drift result, the busy-session count, and the consecutive-deferral count. Adds `MAX_DRIFT_DEFERRALS = 12`.
- **`src/telegram.ts`** — the 5-min stats-tick watchdog now holds the cross-tick deferral counter and acts on the returned decision. After `MAX_DRIFT_DEFERRALS` consecutive deferrals (~1h at the 5-min tick) it forces the exit even under a busy session, breaking the livelock. Below the cap it behaves exactly as PR #106: defers while busy, exits cleanly when idle.

## Why 12 / ~1h
The realistic mid-turn case finishes in minutes; 12 deferrals (≈1 hour of grace) is far longer than any legitimate turn yet bounded for a wedged one. The force-exit is a last-resort livelock escape — it does interrupt the (almost-certainly-stuck) turn, which is the documented, accepted cost of not deferring forever.

## Counter semantics
| Tick state | Action | Counter |
|---|---|---|
| no drift | none | reset to 0 |
| drift, no busy session | exit cleanly | reset to 0 |
| drift, busy, below cap | defer (logs `deferred (n/12)`) | increment |
| drift, busy, at cap | force-exit (logs `forcing upgrade after 12 deferral(s)`) | — |

The counter resets to 0 the moment sessions drain or drift clears — a fresh drift starts its grace window over.

## Tests
- New `src/telegram/version-check.test.ts` (12 tests): drift detection + every decision branch, including a custom-cap trace (`defer 1/2 → 2/2 → force-exit`) and the drain-before-cap reset path. `version-check.ts` → **100% line coverage**.
- Full suite: `pnpm test:coverage` → **8997 passed, 12 skipped, exit 0** (hard coverage thresholds met).
- `pnpm lint` (`tsc --noEmit` strict): clean.

## Out of scope
True mid-turn turn-state replay (resuming an in-flight turn across any process death — OOM, SIGTERM, crash) remains a larger, separate change. This PR only adds the bounded escape from the self-inflicted deferral livelock.
