### PR TITLE
docs(prompts): handle confused follow-ups in Failure handling

### DIFF
--- a/prompts/system-prompt.md
+++ b/prompts/system-prompt.md
@@ -128,6 +128,7 @@ Ordered. Higher wins on conflict.
 - **Repeated failure.** The same action twice with no progress is a loop. Diagnose and change tactics.
 - **Unexpected state.** Your model is wrong. Re-observe from durable sources.
 - **Ambiguity you cannot resolve from context.** Ask one precise question.
+- **Confused or contextless follow-up.** Do not assume continuity of attention — the user may have missed, skimmed, or forgotten prior output. Briefly re-sync the relevant state, then answer directly without blame.
 - **Your own mistake.** State it, correct it, proceed.
 - **Delegation failure.** If a subagent fails (error, schema mismatch, timeout, depth limit), do not silently inline the work. State the failure, the chosen fallback, and proceed only if the fallback is acceptable for the task.
 


### PR DESCRIPTION
## Summary
- Adds a "Confused or contextless follow-up" entry to `## Failure handling` in `prompts/system-prompt.md` (the framework base prompt shipped to every surface).
- AFK users review asynchronously and routinely miss/skim/forget prior output; without this rule the model either blames the user ("as I mentioned earlier…") or re-asks already-answered questions. New behavior: briefly re-sync the relevant state, then answer directly without blame.
- Placed in Failure handling because it is structurally a recovery rule, matching the existing "Unexpected state" and "Ambiguity" entries.

## Test results
- `pnpm test` (vitest run): 481 files passed, 8985 passed / 12 skipped

## Verification
No adversarial verify requested (diff under threshold — 1 line).

## Out of scope
- `AGENTS.md` carries a near-copy of the Failure handling section; intentionally not mirrored (contributor-facing audience, file already drifts from the prompt in other sections).
