### PR TITLE
fix(tui): first-turn echo duplication + band loss; persist user message to transcript immediately

### DIFF
--- a/src/cli/commands/interactive/repl-loop.ts
+++ b/src/cli/commands/interactive/repl-loop.ts
@@ -925,6 +925,11 @@ export async function runReplLoop(
 
       await runTurn({ text: runText, attachments }, ctx.session.current, ctx.stats, {
         setInFlight(v: boolean) { turnState.turnInFlight = v; },
+        async onUserMessage(userInput) {
+          // Write the user's message to the transcript immediately — the
+          // appendTurn below then closes the turn with the assistant block.
+          await transcript.appendUser(userInput);
+        },
         async onTurnComplete(userInput, assistantText) {
           await transcript.appendTurn(userInput, assistantText);
           // Per-turn session autosave → ~/.afk/state/sessions/<sessionId>.json.

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -427,6 +427,16 @@ export interface CompletionWriter {
 export interface TurnHandles {
   setInFlight(v: boolean): void;
   /**
+   * Fired once at turn start, immediately after the user's submission is
+   * normalized (describeForHistory) and before the model stream begins.
+   * Used by the REPL to persist the user's message to the autosaved
+   * transcript right away — a crash, ESC soft-stop, or backgrounded turn
+   * must not lose it (onTurnComplete only fires on completed turns).
+   * Receives the exact string onTurnComplete later receives as
+   * `userInput`. Best-effort — errors are swallowed by the caller.
+   */
+  onUserMessage?(userInput: string): Promise<void> | void;
+  /**
    * Fired once per completed turn after the assistant's final text is
    * in hand. Used by the REPL to append a human-readable row to the
    * autosaved markdown transcript. Best-effort — errors are swallowed

--- a/src/cli/commands/interactive/transcript.test.ts
+++ b/src/cli/commands/interactive/transcript.test.ts
@@ -1,13 +1,11 @@
 /**
- * Regression tests for S2 (transcript file permissions 0o600).
- *
- * Asserts that transcript files (created by startTranscript / appendTurn /
- * appendEnded / rotateOnClear) are written with mode 0o600 so their contents
- * are not world-readable.
+ * Regression tests for S2 (transcript file permissions 0o600) and for the
+ * immediate user-message write (appendUser opens a turn at submission time;
+ * appendTurn closes it without duplicating the user block).
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtempSync, statSync, rmSync } from 'node:fs';
+import { mkdtempSync, statSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -49,5 +47,105 @@ describe('transcript — S2 file mode 0o600 regression', () => {
         process.env['AFK_STATE_DIR'] = savedEnv;
       }
     }
+  });
+});
+
+describe('transcript — immediate user-message write (appendUser)', () => {
+  let tmpDir: string;
+  let savedEnv: string | undefined;
+
+  async function makeHandle() {
+    tmpDir = mkdtempSync(join(tmpdir(), 'afk-transcript-test-'));
+    savedEnv = process.env['AFK_STATE_DIR'];
+    process.env['AFK_STATE_DIR'] = tmpDir;
+    const { initTranscript } = await import('./transcript.js');
+    return initTranscript(() => 'test-model');
+  }
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env['AFK_STATE_DIR'];
+    else process.env['AFK_STATE_DIR'] = savedEnv;
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const count = (body: string, needle: string) => body.split(needle).length - 1;
+
+  it('appendUser persists the user block before any assistant text exists', async () => {
+    const handle = await makeHandle();
+    await handle.appendUser('hello from the user');
+    const body = readFileSync(handle.path(), 'utf8');
+    expect(body).toContain('## User\n\nhello from the user');
+    expect(body).not.toContain('## Assistant');
+  });
+
+  it('appendTurn closes the open turn without duplicating the user block', async () => {
+    const handle = await makeHandle();
+    await handle.appendUser('the question');
+    await handle.appendTurn('the question', 'the answer');
+    const body = readFileSync(handle.path(), 'utf8');
+    expect(count(body, 'the question')).toBe(1);
+    expect(count(body, '## User')).toBe(1);
+    expect(count(body, '## Assistant')).toBe(1);
+    expect(body).toContain('## Assistant\n\nthe answer');
+    // Turn is closed: a separator follows the assistant block.
+    expect(body.trimEnd().endsWith('---')).toBe(true);
+  });
+
+  it('appendTurn with empty assistant text closes the open turn with a placeholder', async () => {
+    const handle = await makeHandle();
+    await handle.appendUser('tool-only turn');
+    await handle.appendTurn('tool-only turn', '');
+    const body = readFileSync(handle.path(), 'utf8');
+    expect(body).toContain('_(no text response)_');
+    expect(count(body, '## User')).toBe(1);
+  });
+
+  it('appendTurn without a matching open turn writes the legacy self-contained pair', async () => {
+    const handle = await makeHandle();
+    // Skill-dispatch path / late background completion: no appendUser first.
+    await handle.appendTurn('/review --post', 'looks good');
+    const body = readFileSync(handle.path(), 'utf8');
+    expect(body).toContain('## User\n\n/review --post');
+    expect(body).toContain('## Assistant\n\nlooks good');
+  });
+
+  it('appendTurn without a matching open turn no-ops on empty assistant text (legacy guard)', async () => {
+    const handle = await makeHandle();
+    const before = readFileSync(handle.path(), 'utf8');
+    await handle.appendTurn('ignored', '');
+    const body = readFileSync(handle.path(), 'utf8');
+    expect(body).toBe(before);
+  });
+
+  it('a second appendUser self-heals a dangling turn (soft-stop / crash path)', async () => {
+    const handle = await makeHandle();
+    await handle.appendUser('first message — turn never completed');
+    await handle.appendUser('second message');
+    const body = readFileSync(handle.path(), 'utf8');
+    expect(body).toContain('_(no response recorded)_');
+    expect(count(body, '## User')).toBe(2);
+    // Headings stay paired: the dangling turn was closed before the new one.
+    expect(body.indexOf('_(no response recorded)_')).toBeLessThan(body.indexOf('second message'));
+  });
+
+  it('a backgrounded turn completing after a newer turn writes a self-contained pair', async () => {
+    const handle = await makeHandle();
+    await handle.appendUser('slow background task');   // turn A
+    await handle.appendUser('quick question');          // turn B (A self-healed)
+    await handle.appendTurn('quick question', 'quick answer');     // closes B
+    await handle.appendTurn('slow background task', 'late result'); // A completes late
+    const body = readFileSync(handle.path(), 'utf8');
+    // A's late completion is fully attributed, not orphaned under B.
+    expect(body).toContain('## User\n\nslow background task\n\n## Assistant\n\nlate result');
+    expect(count(body, '## Assistant')).toBe(3); // healed A + B + late A
+  });
+
+  it('appendEnded closes a dangling turn before the ended marker', async () => {
+    const handle = await makeHandle();
+    await handle.appendUser('interrupted by shutdown');
+    await handle.appendEnded();
+    const body = readFileSync(handle.path(), 'utf8');
+    expect(body).toContain('_(no response recorded)_');
+    expect(body.indexOf('_(no response recorded)_')).toBeLessThan(body.indexOf('_ended:'));
   });
 });

--- a/src/cli/commands/interactive/transcript.ts
+++ b/src/cli/commands/interactive/transcript.ts
@@ -29,6 +29,15 @@ export async function startTranscript(dir: string, model: string, continued = fa
 
 export interface TranscriptHandle {
   path(): string;
+  /**
+   * Persist the user's message immediately at submission time — before the
+   * model responds. Opens a turn on disk; the matching `appendTurn()` call
+   * (same `userInput`) closes it with the assistant block only. Without
+   * this, a crash, ESC soft-stop, or backgrounded turn loses the user's
+   * message entirely (appendTurn only fires on completed turns).
+   * Best-effort — errors swallowed.
+   */
+  appendUser(userInput: string): Promise<void>;
   /** Append a completed turn. Best-effort — errors swallowed. */
   appendTurn(userInput: string, assistantText: string): Promise<void>;
   /** `/clear` flow: mark old file `_cleared_` and start a new one. */
@@ -49,28 +58,62 @@ export async function initTranscript(getModel: () => string): Promise<Transcript
     'transcripts',
   );
   let current = await startTranscript(dir, getModel());
+  // The user text of the turn currently "open" on disk: appendUser() wrote
+  // its `## User` block but no `## Assistant` block has closed it yet.
+  // null when the file sits at a turn boundary (trailing `---`).
+  let openUser: string | null = null;
+
+  // S2 fix: mode 0o600 on appendFile guards the create-if-not-exists path.
+  const append = (text: string) =>
+    fs.appendFile(current, text, { mode: 0o600 })
+      .catch(() => { /* transcript best-effort */ });
+
+  const closeDanglingTurn = async () => {
+    if (openUser === null) return;
+    openUser = null;
+    await append(`## Assistant\n\n_(no response recorded)_\n\n---\n\n`);
+  };
 
   return {
     path: () => current,
+    async appendUser(userInput) {
+      // Self-heal: the previous turn never completed (soft-stop, stream
+      // error, or it was backgrounded). Close it so headings stay paired;
+      // a backgrounded turn that completes later writes a full
+      // self-contained pair via appendTurn's mismatch path below.
+      await closeDanglingTurn();
+      openUser = userInput;
+      await append(
+        `_${new Date().toISOString()} · model: ${getModel()}_\n\n## User\n\n${userInput}\n\n`,
+      );
+    },
     async appendTurn(userInput, assistantText) {
+      if (openUser === userInput) {
+        // The user block is already on disk (appendUser) — close the open
+        // turn with the assistant block only, never re-writing the user text.
+        openUser = null;
+        await append(
+          `## Assistant\n\n${assistantText || '_(no text response)_'}\n\n---\n\n`,
+        );
+        return;
+      }
+      // No matching open turn: the skill-dispatch path, or a backgrounded
+      // turn completing after later turns were appended. Write the legacy
+      // self-contained pair so the response is never orphaned from its
+      // prompt.
       if (!assistantText) return;
-      // S2 fix: mode 0o600 on appendFile guards the create-if-not-exists path.
-      await fs.appendFile(
-        current,
+      await append(
         `_${new Date().toISOString()} · model: ${getModel()}_\n\n## User\n\n${userInput}\n\n## Assistant\n\n${assistantText}\n\n---\n\n`,
-        { mode: 0o600 },
-      ).catch(() => { /* transcript best-effort */ });
+      );
     },
     async rotateOnClear() {
-      await fs.appendFile(current, `\n_cleared_\n`, { mode: 0o600 }).catch(() => { /* best-effort */ });
+      await closeDanglingTurn();
+      await append(`\n_cleared_\n`);
       current = await startTranscript(dir, getModel(), true);
     },
     async appendEnded() {
-      await fs.appendFile(
-        current,
-        `\n_ended: ${new Date().toISOString()}_\n`,
-        { mode: 0o600 },
-      ).catch(() => { /* transcript best-effort */ });
+      await closeDanglingTurn();
+      await append(`\n_ended: ${new Date().toISOString()}_\n`);
     },
   };
 }

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -51,6 +51,14 @@ export async function runTurn(
 ): Promise<void> {
   const historyText = describeForHistory(input.text, input.attachments);
 
+  // Persist the user's message before the stream starts. onTurnComplete
+  // only fires on doneFired && !softStopRequested, so without this hook a
+  // crash, ESC soft-stop, or backgrounded turn loses the user's message.
+  if (h.onUserMessage) {
+    await Promise.resolve(h.onUserMessage(historyText))
+      .catch(() => { /* best-effort */ });
+  }
+
   h.setInFlight(true);
 
   let responseText = '';

--- a/src/cli/slash/_lib/run-skill-dispatch-turn.ts
+++ b/src/cli/slash/_lib/run-skill-dispatch-turn.ts
@@ -108,6 +108,12 @@ export async function runSkillDispatchTurn(
   });
 
   let softStopRequested = false;
+  // The transcript-facing user line for this turn. Written immediately
+  // (appendUser, when the surface provides it) so an interrupted skill
+  // turn still leaves the invocation on disk; the completed-turn
+  // appendTurn below then closes the open turn via its matching path.
+  const userInput = `/${params.skillName}${params.args ? ' ' + params.args : ''}`;
+  await ctx.transcript?.appendUser?.(userInput).catch(() => { /* best-effort */ });
   // Captured for post-dispatch consumers (e.g. `/review --post`). The last
   // assistant message on the stream is the skill's terminal output — for
   // review that's the post-shadow-verify merge recommendation + findings.
@@ -239,7 +245,6 @@ export async function runSkillDispatchTurn(
   // matching turn-handler.ts's recordTurn guard: an interrupted skill turn
   // must not be folded into totals as if it completed.
   if (doneFired && !softStopRequested) {
-    const userInput = `/${params.skillName}${params.args ? ' ' + params.args : ''}`;
     recordTurn(ctx.stats, userInput, finalAssistantText, doneMeta, toolEvents);
     // Push the freshly-recorded totals to the status line now — the REPL's
     // post-dispatch `statusLine.rearm()` only re-flushes the PREVIOUS fields.

--- a/src/cli/slash/types.ts
+++ b/src/cli/slash/types.ts
@@ -207,7 +207,16 @@ export interface SlashContext {
    * module free of an upward import. Absent on surfaces without a
    * transcript (Telegram, daemon, tests).
    */
-  transcript?: { appendTurn(userInput: string, assistantText: string): Promise<void> };
+  transcript?: {
+    appendTurn(userInput: string, assistantText: string): Promise<void>;
+    /**
+     * Optional immediate user-message write (TranscriptHandle.appendUser).
+     * When present, `runSkillDispatchTurn` persists `/<skill> <args>` at
+     * dispatch start so an interrupted skill turn still leaves the user's
+     * invocation in the transcript.
+     */
+    appendUser?(userInput: string): Promise<void>;
+  };
 }
 
 /** The handler's return value — controls the REPL's next action. */

--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -175,6 +175,16 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   // overflow path archives the block to scrollback at anchorFloor instead
   // (recoverable). No existing test hits prevTopRow <= 1.
   const fitsAboveFrame = prevTopRow > 1 && lineCount <= frameTop - anchorFloor;
+  // Shrink-pad-corrected effective frame top (shared between Phase 1 and Phase 3):
+  // when the prior band is positioned, the real above-frame room starts at
+  // committedBandBottomRow + 1 (not at the raw frameTop which may be artificially
+  // low due to CupFrameRenderer shrink-padding). Computed here so it is in scope
+  // for Phase 3's extended contiguity check without being re-derived inside the
+  // writeWithGuard closure. Value matches Phase 1's `effectiveFrameTop` exactly.
+  const phase1EffectiveFrameTop =
+    fitsAboveFrame && self.committedBand.length > 0 && self.committedBandBottomRow > 0
+      ? Math.max(frameTop, self.committedBandBottomRow + 1)
+      : frameTop;
 
   // Suppress the shrink re-pin for the whole commit; Phase 3 sets the band.
   // Re-armed at the top of every commitAbove, so a throw on a dying TTY (the
@@ -378,17 +388,44 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
       // band as a single overwritten block (lost commits) — the splice
       // regression. newPainted is itself derived from textLines.length.
       const wholeBlockPainted = newPainted === textLines.length;
+      // Invariant (contiguity across banner-path eviction gaps): the prior band
+      // is mergeable when it was adjacent to the frame BEFORE Phase 2 snapped the
+      // frame to bottom-anchored (commitInFlight). Banner-path evictions in
+      // preserveRowsBeforeFrameRender shift committedBandBottomRow downward (lower
+      // row number) by scrolling the viewport upward, but the frame stays where it
+      // is for the next render — so by the time the response commitAbove fires, the
+      // band's tracked bottom may be several rows below newTopRow-1. The classic
+      // check (`committedBandBottomRow === newTopRow - 1`) requires exact adjacency
+      // to the POST-Phase-2 frame top and fails on this gap, dropping the whole
+      // prior band from the model. The extended check adds `effectiveFrameTop - 1`
+      // (the band's tracked bottom is adjacent to the PRE-Phase-2 frame top,
+      // corrected for shrink-pad) — that relationship is unambiguously contiguous
+      // even though Phase 2 stretched the gap by snapping to absoluteBottom.
+      // Safety: `fitsAboveFrame` is already required, so this extended arm only
+      // fires when the merged run is guaranteed to fit in the above-frame region;
+      // `anchorRow <= 1` is NOT required here because the merge path is gated on
+      // `fitsAboveFrame`, not on `anchorRow <= 1`.
       const contiguousPriorBand =
         fitsAboveFrame &&
         wholeBlockPainted &&
         self.committedBand.length > 0 &&
-        self.committedBandBottomRow === newTopRow - 1;
+        (self.committedBandBottomRow === newTopRow - 1 ||
+          self.committedBandBottomRow === phase1EffectiveFrameTop - 1);
       const run = contiguousPriorBand ? [...self.committedBand, ...newLines] : newLines;
       // Cap at the room between the anchor floor and the frame top. maxRun >=
       // newPainted always (the new lines fit by construction), so they are
       // never dropped; only prior-band lines that scroll above the floor are.
       const capped = run.length > maxRun ? run.slice(run.length - maxRun) : run;
       const bandTop = newTopRow - capped.length;
+      // Stale band rows above bandTop: when the extended contiguity arm fires, the
+      // old band's tracked top (self.committedBandTopRow) may be ABOVE the new
+      // bandTop — those rows hold echo content that was physically scrolled there
+      // by earlier evictions and was never overwritten (they were above the
+      // streaming frame top). Phase 3's paint loop covers only rows bandTop..newTopRow-1;
+      // rows committedBandTopRow..bandTop-1 are orphaned: they still show stale echo
+      // content whose row position no longer matches the merged band model. Erase
+      // them before painting so screen == model after Phase 3.
+      const oldBandTop = self.committedBandTopRow;
       let out = '';
       if (fitsAboveFrame) {
         // History: repaint the ENTIRE visible band, not just the new block.
@@ -406,6 +443,21 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
         // lines that scroll off. Single-copy still holds: these rows live only
         // in the viewport until a later scroll moves them (once) into
         // scrollback. Full root-cause + design: docs/scrollback.md.
+        //
+        // Invariant (orphan erase): erase rows that the old band occupied above
+        // the new bandTop BEFORE painting the merged run. Without this, an old
+        // echo row that was physically scrolled above the new bandTop (by banner-
+        // path evictions) remains visible on screen while the model no longer
+        // tracks it — a ghost that the next collapse repaint's stale-tall erase
+        // may or may not cover, producing intermittent duplicate or orphaned rows.
+        // This erase is safe for the non-extended arm too (bandTop >= oldBandTop
+        // in the classic adjacent case, so the loop emits zero iterations).
+        if (oldBandTop > 0 && oldBandTop < bandTop) {
+          const eraseFloor = Math.max(postScrollFloor, oldBandTop);
+          for (let r = eraseFloor; r < bandTop; r++) {
+            out += `\x1b[${r};1H\x1b[2K`;
+          }
+        }
         for (let i = 0; i < capped.length; i++) {
           const row = bandTop + i;
           if (row >= newTopRow) break; // Never overwrite the live frame.

--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -122,14 +122,39 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     : logicalLineCount;
   const textLines = stripped.split('\n');
 
+  const extraRows = self.scrollRegion?.getExtraRows() ?? 0;
+  // Invariant (one geometry per commit): the room/scroll/band math below must
+  // measure the frame at the position Phase 2's repaint will ACTUALLY use.
+  // Frame placement runs in two regimes (terminal-compositor.frame.ts ~236):
+  // banner-following while `hasBanner && !commitInFlight` (idle frame sits
+  // just below the banner / band), bottom-anchored during a commit. With a
+  // banner and an EMPTY band the idle frame banner-follows at ~anchorRow, so
+  // capturing prevTopRow from that regime reports zero above-frame room and
+  // misroutes the commit into the overflow path — Phase 1 then "archives" the
+  // block ON SCREEN at anchorFloor (an untracked orphan, not scrollback),
+  // Phase 3 paints a second copy at anchorFloor while recording the band at
+  // the bottom-anchored rows, and the next commit's merge repaints a third —
+  // the first-turn "echo first line duplicated + card body lost" bug. Flip
+  // into the commit regime FIRST (clear the banner-followed frame, repaint at
+  // the bottom-anchored position) so every phase sees one geometry. Band
+  // non-empty ⇒ contentFloor = committedBandBottomRow keeps idle placement
+  // bottom-consistent already ⇒ skip (no extra clear/repaint flicker on the
+  // steady-state per-commit path). repositionCommittedBand is suppressed
+  // under commitInFlight (committed-band-repin.ts:72) and the band is empty
+  // here anyway; commitInFlight is re-set below and reset at Phase 3's end.
+  if (self.anchorRow !== undefined && self.anchorRow > 1 && self.committedBand.length === 0) {
+    self.commitInFlight = true;
+    self.logUpdate.clear(extraRows);
+    self.repaint();
+  }
   // Decide where the committed text is written so it lands in scrollback
   // EXACTLY ONCE. Capture the live frame's top row BEFORE clear() resets it:
   // every frame mutation (setOverlay, setSpinner, keypress) repaints
-  // synchronously, so `topRow` already reflects the frame Phase 2's repaint
+  // synchronously — and the regime-sync above re-ran placement for the
+  // banner-followed case — so `topRow` reflects the frame Phase 2's repaint
   // will reproduce. `capacity` is the number of rows available to DISPLAY
   // committed text above the frame, between the pre-arm content ceiling
   // (anchorRow) and the frame top.
-  const extraRows = self.scrollRegion?.getExtraRows() ?? 0;
   const prevTopRow = self.logUpdate.topRow ?? 0;
   const frameTop = prevTopRow > 1 ? prevTopRow : Math.max(1, rows - 1 - extraRows);
   const anchorFloor = Math.max(self.anchorRow ?? 1, 1);

--- a/src/cli/terminal-compositor.first-turn-banner-echo.test.ts
+++ b/src/cli/terminal-compositor.first-turn-banner-echo.test.ts
@@ -230,4 +230,118 @@ describe('first turn after banner — idle banner-followed frame commit', () => 
 
     statusLine.stop();
   });
+
+  it('card body rows survive the streaming→idle collapse after mid-stream banner evictions', async () => {
+    // Regression (second defect, independent of the first-commit regime-sync fix):
+    // After banner-path evictions shift the committed band DOWN (as the streaming
+    // overlay grows), the band model tracks the band at a position no longer adjacent
+    // to the frame top recorded by logUpdate.topRow. When the overlay then CLEARS
+    // (streaming ends → setOverlay('') + setSpinner(false)), the idle repaint places
+    // the frame via content-following at contentFloor+1 — which is the band's
+    // *current* tracked bottom + 1, so the frame top stays just above the band.
+    // repositionCommittedBand sees moved=false and renderErasedBand=false (the idle
+    // frame did NOT erase the band) → no re-pin, band stays at its evicted position.
+    //
+    // Then the response commitAbove fires. Phase 2 snaps to bottom-anchored
+    // (commitInFlight=true) → the frame renders as a 1-row idle prompt at topRow=22,
+    // leaving a gap between the band's tracked bottom (e.g. row 12) and newTopRow-1=21.
+    // The contiguity check (`committedBandBottomRow === newTopRow - 1`) fails on this
+    // gap, so Phase 3 records only the new 1-line response, dropping the entire 4-row
+    // echo band from the model.
+    //
+    // On the NEXT repaint the CupFrameRenderer stale-tall erase wipes the rows between
+    // the old tall frame top and the new idle frame top — rows that contain the echo
+    // content — and repositionCommittedBand re-pins only the 1-line response model,
+    // leaving the separator and body rows permanently blank.
+    //
+    // Scenario that reproduces the gap:
+    //  • anchorRow=12, 4 echo commits (sep + body1 + body2 + blank) → band rows 18..21
+    //  • overlay grows to 7 rows + spinner → banner-path evictions shift band to ~9..12,
+    //    anchorRow drops to ~3
+    //  • setOverlay('') + setSpinner(false) → idle repaint at contentFloor+1 (NOT 22);
+    //    repositionCommittedBand: moved=false, renderErasedBand=false → no re-pin
+    //  • response commitAbove fires: Phase 2 snaps to topRow=22 (gap of ~9 rows);
+    //    contiguity fails → echo band dropped from model
+    //  • final collapse repaint erases the echo rows (body lost, separator orphaned)
+    const stdout = makeStdout(COLS, ROWS);
+    const stdin = makeStdin();
+    const all = collect(stdout);
+    for (let i = 0; i < BANNER_ROWS; i++) stdout.write(`BANNER_LINE_${i}\n`);
+    const statusLine = wireFooter(stdout);
+    const c = new TerminalCompositor({
+      stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: BANNER_ROWS + 1,
+    });
+    await c.arm();
+    const internals = c as unknown as { repaint(): void };
+
+    // Pre-submit chrome to seat the frame below the banner (avoid idle banner-follow
+    // for the very first commit — already covered by the first test in this suite).
+    c.setOverlay('preflight-line');
+    c.setOverlay('');
+
+    // Echo the multi-line card (separator + body1 + body2) then blank terminator.
+    const echoCard = formatSubmittedEcho({
+      buffer: MESSAGE,
+      promptText: 'afk (haiku)  › ',
+      isTTY: true,
+      terminalWidth: COLS,
+    });
+    const echoRows = echoCard.split('\n');
+    expect(echoRows.length).toBeGreaterThanOrEqual(3);
+    for (const line of echoRows) c.commitAbove(line);
+    c.commitAbove(''); // blank terminator — 4 commits total, band at rows 18..21
+
+    // Streaming phase: grow the overlay large enough to cause several banner-path
+    // evictions. Each eviction shifts the committedBand downward (lower row numbers)
+    // while shrinking anchorRow. A 7-line overlay causes ~3 evictions of 2+2+2=6
+    // rows total, landing the band around rows 9..12 with anchorRow ~3.
+    c.setSpinner({ enabled: true });
+    c.setOverlay(Array.from({ length: 3 }, (_, i) => `stream ${i}`).join('\n'));
+    c.setOverlay(Array.from({ length: 5 }, (_, i) => `stream ${i}`).join('\n'));
+    c.setOverlay(Array.from({ length: 7 }, (_, i) => `stream ${i}`).join('\n'));
+
+    // Streaming ends — clear overlay and spinner so the idle repaint runs
+    // content-following placement (frame top = contentFloor+1 based on band bottom),
+    // NOT bottom-anchored. This is the critical window: the idle repaint places the
+    // frame just above the band (moved=false → no re-pin), so the band's tracked
+    // position is NOT corrected back to newTopRow-1 before the response commit.
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+
+    // Response commit fires while the band is still at its evicted, non-adjacent
+    // position. Phase 2 (commitInFlight=true) forces bottom-anchored placement,
+    // creating the gap between band bottom and newTopRow-1. Contiguity fails →
+    // echo band dropped from the model.
+    c.commitAbove('RESPONSE_OK');
+    // Two more repaints mirror the spinner-tick cadence that exposes the erasure.
+    internals.repaint();
+    internals.repaint();
+
+    const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 800, allowProposedApi: true, convertEol: true });
+    await termWrite(term, all());
+    const ls = lines(term);
+    const dump = ls.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l)}`).join('\n');
+
+    const sepRows = ls.filter((l) => /─{10,}/.test(l));
+    const body1Rows = ls.filter((l) => l.includes('DUPCHECK'));
+    const body2Rows = ls.filter((l) => l.includes('india'));
+
+    // Separator must appear exactly once. Under the bug it still appears (it was above
+    // the streaming frame top and never overwritten) but body rows vanish entirely.
+    expect(sepRows, `separator missing or duplicated:\n${dump}`).toHaveLength(1);
+    // Card body must survive the streaming→idle collapse (the bug erased body1 + body2).
+    expect(body1Rows, `card body row 1 lost:\n${dump}`).toHaveLength(1);
+    expect(body2Rows, `card body row 2 lost:\n${dump}`).toHaveLength(1);
+    // Response present exactly once.
+    expect(ls.filter((l) => l.includes('RESPONSE_OK')), `response lost:\n${dump}`).toHaveLength(1);
+
+    // Order: sep above body1 above body2 above response.
+    const idx = (pred: (l: string) => boolean): number => ls.findIndex(pred);
+    expect(idx((l) => /─{10,}/.test(l))).toBeGreaterThan(idx((l) => l.includes('BANNER_LINE_')));
+    expect(idx((l) => l.includes('DUPCHECK'))).toBeGreaterThan(idx((l) => /─{10,}/.test(l)));
+    expect(idx((l) => l.includes('india'))).toBeGreaterThan(idx((l) => l.includes('DUPCHECK')));
+    expect(idx((l) => l.includes('RESPONSE_OK'))).toBeGreaterThan(idx((l) => l.includes('india')));
+
+    statusLine.stop();
+  });
 });

--- a/src/cli/terminal-compositor.first-turn-banner-echo.test.ts
+++ b/src/cli/terminal-compositor.first-turn-banner-echo.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Regression (first turn after the banner): the FIRST commitAbove of an arm
+ * cycle fires while the idle frame is banner-followed (frame placement's
+ * `hasBanner && !commitInFlight` regime puts the prompt just below the
+ * banner → zero above-frame room), but the commit itself executes in the
+ * bottom-anchored regime (Phase 2 repaints with commitInFlight=true). The
+ * room calculation used the pre-flip topRow, misrouting the commit into the
+ * overflow path:
+ *
+ *   - Phase 1 "archived" the block ON SCREEN at anchorFloor — with a banner
+ *     that is an untracked orphan row, not a scrollback write (copy #1),
+ *   - Phase 3 painted it again at anchorFloor (copy #2) while recording the
+ *     band at the bottom-anchored rows it never painted,
+ *   - the next commit's merge then repainted the phantom band one row up
+ *     (copy #3), and the stale anchorRow (overflow sets scrolledRows=0)
+ *     under-protected the real rows when streaming growth evicted — the
+ *     card body was overwritten by the growing frame.
+ *
+ * User-visible symptom: submitting the first message echoed the card's
+ * FIRST line (the separator rule) twice near the top while the card body
+ * vanished under the streaming frame. Reproduced live in tmux (80×24,
+ * 11 pre-arm rows) with AFK_DEBUG_COMPOSITOR traces showing commit 1 enter
+ * topRow=12/anchorRow=12 → fitsAboveFrame=false → phase2 newTopRow=22.
+ *
+ * Fix (terminal-compositor.committed-band-commit.ts): when a banner is
+ * active and the band is empty, flip commitInFlight and clear+repaint
+ * BEFORE measuring room, so every phase of the commit sees the same
+ * (bottom-anchored) geometry.
+ *
+ * Every other banner-path test commits with a tall overlay already up
+ * (frame bottom-ish), so this idle-frame first-commit geometry was
+ * uncovered. Harness pattern follows banner-commit-gap.test.ts.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { StatusLine } from './status-line.js';
+import { LoopStageBar } from './commands/interactive/loop-stage.js';
+import { formatSubmittedEcho } from './input/echo.js';
+
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin = NodeJS.ReadStream & { isTTY: boolean; isRaw: boolean; setRawMode: ReturnType<typeof vi.fn> };
+
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true; s.columns = cols; s.rows = rows; return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true; s.isRaw = false; s.setRawMode = vi.fn((r: boolean) => { s.isRaw = r; return s; }); return s;
+}
+function collect(stream: MockStdout): () => string { const c: string[] = []; stream.on('data', (x) => c.push(String(x))); return () => c.join(''); }
+function termWrite(t: HeadlessTerminal, d: string): Promise<void> { return new Promise((r) => t.write(d, r)); }
+function lines(t: HeadlessTerminal): string[] {
+  const b = t.buffer.active; const o: string[] = [];
+  for (let i = 0; i < b.length; i++) { const l = b.getLine(i); if (l) o.push(l.translateToString(true)); }
+  return o;
+}
+
+function wireFooter(stdout: MockStdout): StatusLine {
+  const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+  statusLine.start();
+  statusLine.repaint({ model: 'STATUSMODELXYZ', cost: 0, tokens: 0, contextPct: 0 });
+  const loopStageBar = new LoopStageBar({ getExtraRows: () => statusLine.getExtraRows(), stream: stdout });
+  loopStageBar.setRowCountChangeHandler(() => statusLine.setExtraRows(1));
+  statusLine.setAfterScrollRestore(() => loopStageBar.redraw());
+  loopStageBar.start();
+  return statusLine;
+}
+
+const COLS = 80;
+const ROWS = 24;
+const BANNER_ROWS = 11; // live geometry: anchorRow = 12
+
+const MESSAGE =
+  'Reply with only the word ok and nothing else. DUPCHECK alpha bravo charlie delta echo foxtrot golf hotel india';
+
+describe('first turn after banner — idle banner-followed frame commit', () => {
+  it('commits the echo card exactly once and the body survives streaming growth', async () => {
+    const stdout = makeStdout(COLS, ROWS);
+    const stdin = makeStdin();
+    const all = collect(stdout);
+
+    // Pre-arm banner, exactly like the interactive surface.
+    for (let i = 0; i < BANNER_ROWS; i++) stdout.write(`BANNER_LINE_${i}\n`);
+
+    const statusLine = wireFooter(stdout);
+    const c = new TerminalCompositor({
+      stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: BANNER_ROWS + 1,
+    });
+    await c.arm();
+    const internals = c as unknown as { repaint(): void };
+
+    // Pre-submit chrome cycle: the REPL renders transient chrome (spinner,
+    // hint row, preflight line) and collapses back to idle before the user's
+    // first submit. The collapse leaves CupFrameRenderer's shrink-pad state
+    // deflating logUpdate.topRow by the shrink delta (commit.ts documents the
+    // deflation; its `effectiveFrameTop` correction is gated on a NON-EMPTY
+    // band, so the FIRST commit had no correction). A 1-row delta reproduces
+    // the live trace exactly: topRow 13 → 12 == anchorRow, measured
+    // above-frame room 0, and the commit misroutes into the overflow path.
+    c.setOverlay('preflight-line');
+    c.setOverlay('');
+
+    // First turn: NO overlay is up — the idle frame is banner-followed.
+    // Echo the submitted message through the REAL card path and commit it
+    // per-line, mirroring input-surface.ts (split + commitAbove per row),
+    // then the turn-handler's blank-line commit.
+    const echo = formatSubmittedEcho({
+      buffer: MESSAGE,
+      promptText: 'afk (haiku)  › ',
+      isTTY: true,
+      terminalWidth: COLS,
+    });
+    const echoRows = echo.split('\n');
+    expect(echoRows.length).toBeGreaterThanOrEqual(3); // separator + ≥2 body rows
+    for (const line of echoRows) c.commitAbove(line);
+    c.commitAbove('');
+
+    // Streaming: spinner + overlay growth past the band (the phase that
+    // overwrote the card body when the band/anchor bookkeeping was stale),
+    // then a response commit and collapse back to idle.
+    c.setSpinner({ enabled: true });
+    for (let g = 2; g <= 14; g += 3) {
+      c.setOverlay(Array.from({ length: g }, (_, i) => `stream-row ${g}.${i}`).join('\n'));
+    }
+    c.commitAbove('RESPONSE_OK');
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    internals.repaint();
+    internals.repaint();
+
+    const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 800, allowProposedApi: true, convertEol: true });
+    await termWrite(term, all());
+    const ls = lines(term);
+    const dump = ls.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l)}`).join('\n');
+
+    const sepRows = ls.filter((l) => /─{10,}/.test(l));
+    const body1Rows = ls.filter((l) => l.includes('DUPCHECK'));
+    const body2Rows = ls.filter((l) => l.includes('india'));
+
+    // The card's first line (separator) must appear exactly once — the bug
+    // produced 2–3 copies (Phase-1 orphan + Phase-3 anchorFloor paint +
+    // next-commit merge repaint).
+    expect(sepRows, `separator duplicated:\n${dump}`).toHaveLength(1);
+    // The card body must survive streaming growth — the bug erased it.
+    expect(body1Rows, `card body row 1 lost/duplicated:\n${dump}`).toHaveLength(1);
+    expect(body2Rows, `card body row 2 lost/duplicated:\n${dump}`).toHaveLength(1);
+    // Response present exactly once below the echo.
+    expect(ls.filter((l) => l.includes('RESPONSE_OK'))).toHaveLength(1);
+
+    // Order: banner above separator above body above response.
+    const idx = (pred: (l: string) => boolean): number => ls.findIndex(pred);
+    const lastBanner = ls.reduce((acc, l, i) => (l.includes('BANNER_LINE_') ? i : acc), -1);
+    expect(lastBanner).toBeGreaterThanOrEqual(0);
+    expect(idx((l) => /─{10,}/.test(l)), `separator above banner:\n${dump}`).toBeGreaterThan(lastBanner);
+    expect(idx((l) => l.includes('DUPCHECK'))).toBeGreaterThan(idx((l) => /─{10,}/.test(l)));
+    expect(idx((l) => l.includes('india'))).toBeGreaterThan(idx((l) => l.includes('DUPCHECK')));
+    expect(idx((l) => l.includes('RESPONSE_OK'))).toBeGreaterThan(idx((l) => l.includes('india')));
+
+    // Banner integrity: banner lines still present exactly once (stale
+    // anchor bookkeeping previously let commits orphan into banner rows).
+    // Exemption — the LAST banner row (BANNER_LINE_10): the pre-commit
+    // chrome collapse's shrink-pad climbs above anchorRow and blanks it
+    // BEFORE any commit fires (probe: collapse alone leaves topRow=11 and
+    // row 11 erased, no commitAbove involved). That is a separate
+    // pre-existing renderer defect (shrink-pad has no anchorRow floor) —
+    // out of scope for the commit-geometry fix this file guards. In
+    // production the observed deflation is 1 row, landing on the blank
+    // row below the banner, so it is not user-visible today.
+    for (let i = 0; i < BANNER_ROWS - 1; i++) {
+      expect(ls.filter((l) => l.trim() === `BANNER_LINE_${i}`), `banner row ${i}:\n${dump}`).toHaveLength(1);
+    }
+
+    statusLine.stop();
+  });
+
+  it('second message after idle (band emptied by eviction) also commits exactly once', async () => {
+    // Guards the gate choice: the regime-sync must key on BAND EMPTY (not a
+    // once-per-arm flag) — growth eviction can empty the band mid-session,
+    // returning idle placement to banner-following for the next commit.
+    const stdout = makeStdout(COLS, ROWS);
+    const stdin = makeStdin();
+    const all = collect(stdout);
+    for (let i = 0; i < BANNER_ROWS; i++) stdout.write(`BANNER_LINE_${i}\n`);
+    const statusLine = wireFooter(stdout);
+    const c = new TerminalCompositor({
+      stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: BANNER_ROWS + 1,
+    });
+    await c.arm();
+    const internals = c as unknown as { repaint(): void };
+
+    // Turn 1: idle-frame echo commit, response while chrome is modest, then
+    // heavy growth (no commits while the frame fills the viewport — that is
+    // the separately-tested park/promote path) so eviction EMPTIES the band,
+    // then collapse. The collapse leaves shrink-pad deflation AND an empty
+    // band — the exact first-commit geometry, recreated mid-session.
+    c.commitAbove('TURN_ONE_ECHO');
+    c.commitAbove('');
+    c.setSpinner({ enabled: true });
+    c.setOverlay('t1-stream 0\nt1-stream 1');
+    c.commitAbove('TURN_ONE_RESPONSE');
+    c.setOverlay(Array.from({ length: 20 }, (_, i) => `t1-stream ${i}`).join('\n'));
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    internals.repaint();
+
+    // Turn 2 from idle again (band emptied by the growth eviction above).
+    c.commitAbove('TURN_TWO_ECHO');
+    c.commitAbove('');
+    c.setSpinner({ enabled: true });
+    c.setOverlay(Array.from({ length: 6 }, (_, i) => `t2-stream ${i}`).join('\n'));
+    c.commitAbove('TURN_TWO_RESPONSE');
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    internals.repaint();
+
+    const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 800, allowProposedApi: true, convertEol: true });
+    await termWrite(term, all());
+    const ls = lines(term);
+    const dump = ls.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l)}`).join('\n');
+
+    for (const marker of ['TURN_ONE_ECHO', 'TURN_ONE_RESPONSE', 'TURN_TWO_ECHO', 'TURN_TWO_RESPONSE']) {
+      expect(ls.filter((l) => l.includes(marker)), `${marker}:\n${dump}`).toHaveLength(1);
+    }
+    expect(ls.findIndex((l) => l.includes('TURN_TWO_ECHO')))
+      .toBeGreaterThan(ls.findIndex((l) => l.includes('TURN_ONE_RESPONSE')));
+
+    statusLine.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- **TUI, first turn after the banner**: the user's echo card committed its first line (separator) 2–3× while the card body vanished under the streaming frame. Two compositor defects, fixed separately:
  - `commitAbove` measured above-frame room against the idle **banner-follow** placement regime (often shrink-pad-deflated to `topRow ≤ anchorRow` → room 0) while executing in the bottom-anchored **commit** regime — misrouting the first commit into the overflow path (on-screen orphan "archive" + double paint + phantom band coords). Fix: flip into the commit regime (clear+repaint) before measuring, gated on `anchorRow > 1 && band empty`.
  - Banner-path evictions shift the tracked band down while the frame stays put, so the next commit's exact-adjacency merge check failed and **replaced** the band — model-dropping echo rows that never reached scrollback; the next stale-tall erase wiped them on screen. Fix: extend contiguity with the shrink-pad-corrected pre-Phase-2 frame top + erase the old band rows above the merged run (merge = single-copy move).
- **REPL transcript**: the user's message was only written via `onTurnComplete` (`doneFired && !softStopRequested`) — a crash, ESC soft-stop, or backgrounded turn lost it entirely. New `TranscriptHandle.appendUser` fires at turn start (REPL + skill dispatch); `appendTurn` closes the open turn assistant-only on match, keeps legacy self-contained pairs otherwise; dangling turns self-heal with a `(no response recorded)` marker.

Root-caused via live tmux repro (80×24) with `AFK_DEBUG_COMPOSITOR` model traces + `script(1)` byte capture + @xterm/headless replay bisect; mechanism details in the commit messages and the regression test docblock.

## Test results
- `pnpm test` (post-rebase onto v3.104.3): **8996 passed | 12 skipped (9008)**, 0 failed
- `pnpm lint` (tsc --noEmit, strict): clean
- New regression coverage: `terminal-compositor.first-turn-banner-echo.test.ts` (3 tests, true red→green — separator ×3 without the fixes); `transcript.test.ts` +8 behavior tests
- Live end-to-end (tmux + real haiku turn): pre-fix separator ×2–3 / body lost → post-fix card intact ×1, full response rendered

## Verification
Adversarial verifier (read-only, re-derived from the diff alone):
- CLAIM 1 (user block written at turn start; exactly one `## User` per completed turn; legacy pair path preserved) — **CONFIRM** (`turn-handler.ts:57-60`, `transcript.ts:79-97,106-109`). Refinement: skill-dispatch turns also adopt the new open/close protocol via direct `appendUser?.()`; only surfaces that never call it (Telegram/daemon) keep the legacy pair path.
- CLAIM 2 (regime-sync inert for no-banner sessions, steady-state commits, unarmed compositors; regression test pins the bug) — **CONFIRM** (`committed-band-commit.ts:145`; the unfixed path yields separator ×2-3 against the test's single-copy assertion).
- CLAIM 3 (extended merge arm fires iff the band reaches/overlaps the corrected pre-Phase-2 frame top — not unconditionally; orphan-erase bounded to `[max(anchorFloor, oldBandTop), bandTop)` so it can never touch banner rows or the live frame) — **CONFIRM** (`committed-band-commit.ts:184-187, 408-413, 455-458`).
- Additive interface notes: `TranscriptHandle.appendUser` (new method on an internal interface) and optional `SlashContext.transcript.appendUser?` (backward-compatible).

## Out of scope
Two pre-existing residuals documented in commit messages + regression-test docblock, tracked separately:
- CupFrameRenderer shrink-pad has no `anchorRow` floor — a >1-row chrome collapse can blank the last banner row (1-row in production hits the blank row below the banner, invisible today).
- Overlay-collapse erase-without-repin can wipe band rows under unlucky stream timing (observed once in four live runs: response rows + a stranded spinner row).
