### PR TITLE
refactor(cli): parse chat --post value directly via parsePostTargets

### DIFF
--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -29,7 +29,7 @@ import { setupWorktree } from './interactive/worktree.js';
 import { resolveResumeTarget, resumeConfigFor } from '../resume-session.js';
 import { saveSession, findSession } from '../session-store.js';
 import { createSessionStats, recordTurn } from '../slash/session-stats.js';
-import { runReviewPostPublish, parsePostFlag, type PostTarget } from '../slash/_lib/review-post.js';
+import { runReviewPostPublish, parsePostTargets, type PostTarget } from '../slash/_lib/review-post.js';
 import type { Writer } from '../slash/types.js';
 
 /** Loose UUID format check: 8-4-4-4-12 hex groups separated by dashes. */
@@ -200,14 +200,14 @@ export function registerChatCommand(program: Command): void {
 
       // -----------------------------------------------------------------------
       // Parse --post targets up front so an unknown target warns before any
-      // agent/network work. Reuses the REPL's parsePostFlag (which is string-in)
-      // by reconstructing the flag string from the Commander value; the actual
-      // publish runs after the turn completes (see maybePublish below). An
+      // agent/network work. parsePostTargets classifies the bare Commander value
+      // directly — no synthetic "--post …" flag string to reconstruct and re-parse;
+      // the actual publish runs after the turn completes (see maybePublish below). An
       // all-unknown value yields zero targets → a no-op, not a hard error.
       // -----------------------------------------------------------------------
       const postTargets: PostTarget[] = [];
       if (options.post !== undefined) {
-        const parsedPost = parsePostFlag(`--post ${options.post}`);
+        const parsedPost = parsePostTargets(options.post);
         postTargets.push(...parsedPost.targets);
         for (const unknownTarget of parsedPost.unknown) {
           process.stderr.write(

--- a/src/cli/slash/_lib/review-post.test.ts
+++ b/src/cli/slash/_lib/review-post.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect, vi } from 'vitest';
 import type { Writer } from '../types.js';
 import {
   parsePostFlag,
+  parsePostTargets,
   chunkText,
   buildGithubBody,
   summarizeForTelegram,
@@ -111,6 +112,41 @@ describe('parsePostFlag', () => {
   it('preserves a PR URL as the review target', () => {
     const r = parsePostFlag('https://github.com/o/r/pull/12 --post github');
     expect(r.cleanedArgs).toBe('https://github.com/o/r/pull/12');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parsePostTargets — bare-value classifier (CLI `chat --post` path)
+// ---------------------------------------------------------------------------
+
+describe('parsePostTargets', () => {
+  it('classifies a single target', () => {
+    expect(parsePostTargets('github')).toEqual({ targets: ['github'], unknown: [] });
+  });
+
+  it('classifies a comma list and dedupes', () => {
+    expect(parsePostTargets('github,telegram,github')).toEqual({
+      targets: ['github', 'telegram'],
+      unknown: [],
+    });
+  });
+
+  it('collects unknown targets without throwing', () => {
+    expect(parsePostTargets('github,slack')).toEqual({
+      targets: ['github'],
+      unknown: ['slack'],
+    });
+  });
+
+  it('trims whitespace and ignores empty members', () => {
+    expect(parsePostTargets(' github , , telegram ')).toEqual({
+      targets: ['github', 'telegram'],
+      unknown: [],
+    });
+  });
+
+  it('returns empty arrays for an empty value', () => {
+    expect(parsePostTargets('')).toEqual({ targets: [], unknown: [] });
   });
 });
 

--- a/src/cli/slash/_lib/review-post.ts
+++ b/src/cli/slash/_lib/review-post.ts
@@ -70,15 +70,7 @@ export function parsePostFlag(args: string): ParsedPostFlag {
   const unknown: string[] = [];
 
   for (const m of args.matchAll(POST_FLAG_RE)) {
-    const raw = m[1] ?? '';
-    for (const part of raw.split(',').map((s) => s.trim()).filter(Boolean)) {
-      if (VALID_TARGETS.has(part)) {
-        const t = part as PostTarget;
-        if (!targets.includes(t)) targets.push(t);
-      } else {
-        unknown.push(part);
-      }
-    }
+    classifyPostTargets(m[1] ?? '', targets, unknown);
   }
 
   const cleanedArgs = args
@@ -89,6 +81,39 @@ export function parsePostFlag(args: string): ParsedPostFlag {
     .trim();
 
   return { targets, cleanedArgs, unknown };
+}
+
+/**
+ * Classify one raw comma-separated target list (e.g. `github,telegram`) into
+ * recognized `targets` (deduped, in encounter order) and `unknown` tokens,
+ * accumulating into the caller-provided arrays. Shared by `parsePostFlag`
+ * (which may see several `--post` tokens in one arg string) and
+ * `parsePostTargets` (which receives a single already-parsed value).
+ */
+function classifyPostTargets(raw: string, targets: PostTarget[], unknown: string[]): void {
+  for (const part of raw.split(',').map((s) => s.trim()).filter(Boolean)) {
+    if (VALID_TARGETS.has(part)) {
+      const t = part as PostTarget;
+      if (!targets.includes(t)) targets.push(t);
+    } else {
+      unknown.push(part);
+    }
+  }
+}
+
+/**
+ * Classify an already-parsed `--post` value — the raw string Commander hands
+ * back for `chat --post <value>` (e.g. `github` or `github,telegram`). Unlike
+ * `parsePostFlag`, this takes the bare value directly, so the CLI path no longer
+ * reconstructs a synthetic `--post …` flag string just to re-parse it. The REPL
+ * keeps using `parsePostFlag` because it must also strip the token out of a
+ * larger review-args string.
+ */
+export function parsePostTargets(value: string): { targets: PostTarget[]; unknown: string[] } {
+  const targets: PostTarget[] = [];
+  const unknown: string[] = [];
+  classifyPostTargets(value, targets, unknown);
+  return { targets, unknown };
 }
 
 /**


### PR DESCRIPTION
## What

`afk chat --post` parsed its target value by reconstructing a synthetic `--post <value>` flag string and feeding it to `parsePostFlag` — a regex-based, string-in parser built for the REPL, where it must strip the `--post` token out of a larger review-args string. On the CLI path Commander has already parsed the bare value, so the round-trip (serialize → regex back out) was avoidable.

## Change

- Extract the shared target classification into a private `classifyPostTargets(raw, targets, unknown)` helper in `review-post.ts`.
- Add a first-class `parsePostTargets(value)` that classifies the bare value directly and returns `{ targets, unknown }`.
- `chat.ts` now calls `parsePostTargets(options.post)` instead of `parsePostFlag(\`--post ${options.post}\`)`.
- `parsePostFlag` is unchanged and still backs the REPL path (which must strip the token from a larger args string).

## Verification

- `pnpm lint` (`tsc --noEmit`) — clean.
- `pnpm test` — **481 files / 8992 tests pass**, 12 skipped, 0 failures.
- +5 unit tests for `parsePostTargets` (single / comma+dedupe / unknown / whitespace / empty).
- The existing `chat.post.test.ts` (10 tests) passes unchanged against the new parse path.

## Risk

Behavior-preserving refactor; no user-facing change. `--post` target semantics (dedupe, unknown-warns-not-errors, empty → no-op) are identical and covered by tests.
