### PR TITLE
feat(improve): classify tool failures; exclude "system said no" from failure-density

### DIFF
--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -618,6 +618,7 @@ export async function* runTurn(
         truncated,
         durationMs,
         ...(result.circuitBreaker === true ? { circuitBreaker: true } : {}),
+        ...(result.failureClass ? { failureClass: result.failureClass } : {}),
       });
 
       yield {

--- a/src/agent/providers/anthropic-direct/types.ts
+++ b/src/agent/providers/anthropic-direct/types.ts
@@ -17,6 +17,7 @@ import type {
   Usage,
 } from '@anthropic-ai/sdk/resources';
 import type { ProviderEvent, ProviderUsage } from '../../provider.js';
+import type { ToolFailureClass } from '../../trace/types.js';
 
 /**
  * Auth mode is selected by token shape. OAuth-mode tokens (`sk-ant-oat01-*`)
@@ -95,6 +96,15 @@ export interface ToolResult {
   /** True when this result is a synthetic repeat-loop circuit-breaker block,
    *  not a real tool outcome — lets trace consumers exclude it from failure stats. */
   circuitBreaker?: boolean;
+  /**
+   * Coarse classification of WHY this result is an error, set by the site that
+   * produced it (dispatcher gate or tool handler). Carried through to the
+   * `tool_call` completed trace event so failure-density detection can
+   * distinguish "the system correctly said no" (policy/permission/hook/abort)
+   * from a real tool fault. Absent on success and unclassified failures.
+   * See {@link import('../../trace/types.js').ToolFailureClass}.
+   */
+  failureClass?: ToolFailureClass;
   render?: RenderHints;
   /**
    * Structured test-runner result parsed from bash output by

--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -80,6 +80,7 @@ describe('SessionToolDispatcher', () => {
     const result = await dispatcher.execute(makeCall({ signal: controller.signal }));
     expect(result.isError).toBe(true);
     expect(result.content).toContain('aborted');
+    expect(result.failureClass).toBe('abort');
   });
 
   it('exposes toolDefs from schemas', () => {
@@ -95,6 +96,7 @@ describe('SessionToolDispatcher', () => {
       const result = await dispatcher.execute(makeCall());
       expect(result.isError).toBe(true);
       expect(result.content).toContain('not in the configured allowlist');
+      expect(result.failureClass).toBe('permission-denied');
     });
 
     it('allows tool in allowlist', async () => {
@@ -127,6 +129,7 @@ describe('SessionToolDispatcher', () => {
       const result = await dispatcher.execute(makeCall());
       expect(result.isError).toBe(true);
       expect(result.content).toContain('blocked by PreToolUse hook');
+      expect(result.failureClass).toBe('hook-block');
     });
 
     it('PreToolUse approve allows execution', async () => {
@@ -194,6 +197,7 @@ describe('SessionToolDispatcher', () => {
       const result = await dispatcher.execute(bashCall('git commit -m x'));
       expect(result.isError).toBe(true);
       expect(result.content).toContain('read-only skill may not run mutating commands');
+      expect(result.failureClass).toBe('permission-denied');
     });
 
     it('lets a read-only bash command through the gate when readOnlyBash is true', async () => {

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -419,6 +419,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
         `(${verdict.reason ?? 'mutation detected'}). Allowed: read-only recon ` +
         `(git status/log/diff, ls, cat, find, grep).`,
       isError: true,
+      failureClass: 'permission-denied',
     };
   }
 
@@ -456,7 +457,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
 
   async execute(call: ToolCall): Promise<ToolResult> {
     if (call.signal.aborted) {
-      return { content: 'Tool call aborted', isError: true };
+      return { content: 'Tool call aborted', isError: true, failureClass: 'abort' };
     }
 
     // 1. PreToolUse hook — can block. Routed through dispatchPreToolUse
@@ -480,6 +481,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
           return {
             content: `Tool "${call.name}" blocked by PreToolUse hook: ${err.message}`,
             isError: true,
+            failureClass: 'hook-block',
           };
         }
         throw err;
@@ -492,6 +494,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
       return {
         content: permResult.reason ?? `Tool "${call.name}" is not permitted`,
         isError: true,
+        failureClass: 'permission-denied',
       };
     }
 
@@ -604,7 +607,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
       const call = calls[i]!;
 
       if (call.signal.aborted) {
-        results[i] = { content: 'Tool call aborted', isError: true };
+        results[i] = { content: 'Tool call aborted', isError: true, failureClass: 'abort' };
         blocked.add(i);
         continue;
       }
@@ -628,6 +631,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
             results[i] = {
               content: `Tool "${call.name}" blocked by PreToolUse hook: ${err.message}`,
               isError: true,
+              failureClass: 'hook-block',
             };
             blocked.add(i);
             continue;
@@ -641,6 +645,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
         results[i] = {
           content: permResult.reason ?? `Tool "${call.name}" is not permitted`,
           isError: true,
+          failureClass: 'permission-denied',
         };
         blocked.add(i);
         continue;
@@ -694,7 +699,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
             const { call, originalIndex } = executableCalls[batchIdx]!;
             if (call.signal.aborted) {
               return {
-                result: { content: 'Tool call aborted', isError: true } as ToolResult,
+                result: { content: 'Tool call aborted', isError: true, failureClass: 'abort' } as ToolResult,
                 originalIndex,
               };
             }
@@ -721,7 +726,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
         for (const batchIdx of batch.indices) {
           const { call, originalIndex } = executableCalls[batchIdx]!;
           if (call.signal.aborted) {
-            results[originalIndex] = { content: 'Tool call aborted', isError: true };
+            results[originalIndex] = { content: 'Tool call aborted', isError: true, failureClass: 'abort' };
             continue;
           }
           results[originalIndex] = await this.executeCore(call);

--- a/src/agent/tools/handlers/browser-act.test.ts
+++ b/src/agent/tools/handlers/browser-act.test.ts
@@ -262,6 +262,7 @@ describe('browser_act handler — blocked_by_policy', () => {
     expect(r.isError).toBe(true);
     expect(r.content).toMatch(/blocked/);
     expect(r.content).toMatch(/navigation refused/);
+    expect(r.failureClass).toBe('policy-refusal');
   });
 });
 
@@ -277,6 +278,18 @@ describe('browser_act handler — provider errors', () => {
     const r = await handler({ action: 'click', target: { kind: 'semantic', text: 'Btn' } }, makeSignal());
     expect(r.isError).toBe(true);
     expect(r.content).toMatch(/element not found/);
+    expect(r.failureClass).toBeUndefined();
+  });
+
+  it("tags an action timeout as failureClass 'timeout'", async () => {
+    const timeoutErr = new Error('locator.click: Timeout 10000ms exceeded.');
+    timeoutErr.name = 'TimeoutError';
+    const provider = makeProvider({ act: vi.fn().mockRejectedValue(timeoutErr) });
+    const handler = createBrowserActHandler({ getBrowserProvider: vi.fn().mockResolvedValue(provider) });
+
+    const r = await handler({ action: 'click', target: { kind: 'semantic', text: 'Btn' } }, makeSignal());
+    expect(r.isError).toBe(true);
+    expect(r.failureClass).toBe('timeout');
   });
 
   it('returns playwright install hint when error contains Cannot find package', async () => {
@@ -304,6 +317,7 @@ describe('browser_act handler — abort signal', () => {
     );
     expect(r.isError).toBe(true);
     expect(r.content).toMatch(/aborted/);
+    expect(r.failureClass).toBe('abort');
     expect(getBrowserProvider).not.toHaveBeenCalled();
   });
 });

--- a/src/agent/tools/handlers/browser-act.ts
+++ b/src/agent/tools/handlers/browser-act.ts
@@ -29,7 +29,11 @@ import { env } from '../../../config/env.js';
 // helpers (truncateTargetText, hashSelector) are imported and called so the
 // logic is in place for when browser_event emission is wired.
 
-import { isPlaywrightMissing, playwrightMissingHint } from './playwright-hints.js';
+import {
+  browserTimeoutFailureClass,
+  isPlaywrightMissing,
+  playwrightMissingHint,
+} from './playwright-hints.js';
 
 const VALID_ACTIONS: readonly ActAction[] = [
   'click', 'fill', 'press', 'select', 'hover', 'scroll_to', 'wait_for',
@@ -170,7 +174,7 @@ export function createBrowserActHandler(opts: BrowserHandlerOptions = {}): ToolH
     if (signal.aborted) {
       const reason = signal.reason;
       const msg = reason instanceof Error ? reason.message : String(reason ?? 'aborted');
-      return { content: `browser_act aborted: ${msg}`, isError: true };
+      return { content: `browser_act aborted: ${msg}`, isError: true, failureClass: 'abort' };
     }
 
     const parsed = parseInput(input);
@@ -227,6 +231,7 @@ export function createBrowserActHandler(opts: BrowserHandlerOptions = {}): ToolH
           return {
             content: `browser_act blocked: ${result.reason}`,
             isError: true,
+            failureClass: 'policy-refusal',
           };
         }
       }
@@ -235,7 +240,12 @@ export function createBrowserActHandler(opts: BrowserHandlerOptions = {}): ToolH
       return { content: JSON.stringify(result, null, 2) };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      return { content: `browser_act failed: ${msg}`, isError: true };
+      const failureClass = browserTimeoutFailureClass(err);
+      return {
+        content: `browser_act failed: ${msg}`,
+        isError: true,
+        ...(failureClass ? { failureClass } : {}),
+      };
     }
   };
 }

--- a/src/agent/tools/handlers/browser-open.test.ts
+++ b/src/agent/tools/handlers/browser-open.test.ts
@@ -202,6 +202,8 @@ describe('browser_open handler — blocked_by_policy', () => {
     expect(r.isError).toBe(true);
     expect(r.content).toMatch(/blocked/);
     expect(r.content).toMatch(/domain not allowed/);
+    // Tagged so the failure-density detector excludes it as a refusal, not a fault.
+    expect(r.failureClass).toBe('policy-refusal');
   });
 });
 
@@ -218,6 +220,20 @@ describe('browser_open handler — provider errors', () => {
     const r = await handler({ url: 'https://example.com' }, makeSignal());
     expect(r.isError).toBe(true);
     expect(r.content).toMatch(/browser crashed/);
+    // A generic crash is left unclassified → still counts as a real failure.
+    expect(r.failureClass).toBeUndefined();
+  });
+
+  it("tags a navigation timeout as failureClass 'timeout'", async () => {
+    const timeoutErr = new Error('page.goto: Timeout 30000ms exceeded.');
+    timeoutErr.name = 'TimeoutError';
+    const provider = makeProvider({ open: vi.fn().mockRejectedValue(timeoutErr) });
+    const getBrowserProvider = vi.fn().mockResolvedValue(provider);
+    const handler = createBrowserOpenHandler({ getBrowserProvider });
+
+    const r = await handler({ url: 'https://slow.example.com' }, makeSignal());
+    expect(r.isError).toBe(true);
+    expect(r.failureClass).toBe('timeout');
   });
 
   it('returns isError when getBrowserProvider throws', async () => {
@@ -260,6 +276,7 @@ describe('browser_open handler — abort signal', () => {
     const r = await handler({ url: 'https://example.com' }, makeSignal(true));
     expect(r.isError).toBe(true);
     expect(r.content).toMatch(/aborted/);
+    expect(r.failureClass).toBe('abort');
     // Provider was never called
     expect(getBrowserProvider).not.toHaveBeenCalled();
   });

--- a/src/agent/tools/handlers/browser-open.ts
+++ b/src/agent/tools/handlers/browser-open.ts
@@ -28,7 +28,11 @@ import { env } from '../../../config/env.js';
 // semantic layer. Until then, browser_event emission lives in the dispatcher
 // tier, not in these handlers. See design doc: design-native-browser-control.
 
-import { isPlaywrightMissing, playwrightMissingHint } from './playwright-hints.js';
+import {
+  browserTimeoutFailureClass,
+  isPlaywrightMissing,
+  playwrightMissingHint,
+} from './playwright-hints.js';
 
 type WaitForOption = 'load' | 'domcontentloaded' | 'networkidle';
 
@@ -104,7 +108,7 @@ export function createBrowserOpenHandler(opts: BrowserHandlerOptions = {}): Tool
     if (signal.aborted) {
       const reason = signal.reason;
       const msg = reason instanceof Error ? reason.message : String(reason ?? 'aborted');
-      return { content: `browser_open aborted: ${msg}`, isError: true };
+      return { content: `browser_open aborted: ${msg}`, isError: true, failureClass: 'abort' };
     }
 
     const parsed = parseInput(input);
@@ -149,6 +153,7 @@ export function createBrowserOpenHandler(opts: BrowserHandlerOptions = {}): Tool
         return {
           content: `browser_open blocked: ${result.reason}`,
           isError: true,
+          failureClass: 'policy-refusal',
         };
       }
 
@@ -156,7 +161,12 @@ export function createBrowserOpenHandler(opts: BrowserHandlerOptions = {}): Tool
       return { content: JSON.stringify(result, null, 2) };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      return { content: `browser_open failed: ${msg}`, isError: true };
+      const failureClass = browserTimeoutFailureClass(err);
+      return {
+        content: `browser_open failed: ${msg}`,
+        isError: true,
+        ...(failureClass ? { failureClass } : {}),
+      };
     }
   };
 }

--- a/src/agent/tools/handlers/playwright-hints.test.ts
+++ b/src/agent/tools/handlers/playwright-hints.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   PLAYWRIGHT_MISSING_HINTS,
+  browserTimeoutFailureClass,
   isPlaywrightMissing,
   playwrightMissingHint,
 } from './playwright-hints.js';
@@ -40,5 +41,27 @@ describe('playwrightMissingHint', () => {
     expect(hint).toMatch(/pnpm exec playwright install chromium/);
     // Must NOT mis-direct the user to reinstall a package that is already present.
     expect(hint).not.toMatch(/pnpm add playwright/);
+  });
+});
+
+describe('browserTimeoutFailureClass', () => {
+  it("classifies a Playwright TimeoutError (by name) as 'timeout'", () => {
+    const err = new Error('page.goto: Timeout 30000ms exceeded.');
+    err.name = 'TimeoutError';
+    expect(browserTimeoutFailureClass(err)).toBe('timeout');
+  });
+
+  it("classifies the timeout message shape as 'timeout' even without the name", () => {
+    expect(browserTimeoutFailureClass(new Error('Timeout 30000ms exceeded.'))).toBe('timeout');
+    expect(browserTimeoutFailureClass(new Error('locator.click: Timeout 5000 ms exceeded'))).toBe(
+      'timeout',
+    );
+  });
+
+  it('returns undefined for non-timeout errors (left unclassified → still a real failure)', () => {
+    expect(browserTimeoutFailureClass(new Error('net::ERR_NAME_NOT_RESOLVED'))).toBeUndefined();
+    expect(browserTimeoutFailureClass(new Error('boom'))).toBeUndefined();
+    expect(browserTimeoutFailureClass('a plain string')).toBeUndefined();
+    expect(browserTimeoutFailureClass(undefined)).toBeUndefined();
   });
 });

--- a/src/agent/tools/handlers/playwright-hints.ts
+++ b/src/agent/tools/handlers/playwright-hints.ts
@@ -18,6 +18,24 @@
  * @module agent/tools/handlers/playwright-hints
  */
 
+import type { ToolFailureClass } from '../../trace/types.js';
+
+/**
+ * Classify a thrown browser error as a navigation/action timeout, for the
+ * `failureClass` field on the tool result. Playwright raises a `TimeoutError`
+ * (`name === 'TimeoutError'`) from `page.goto` and locator waits; the message
+ * regex is a defensive fallback for errors that lost their prototype across a
+ * boundary. Returns `'timeout'` for timeouts, `undefined` otherwise — an
+ * unclassified browser failure still counts as a real failure downstream, so
+ * this only ever DEMOTES a timeout out of the "real fault" bucket, never
+ * promotes a genuine error into a benign class.
+ */
+export function browserTimeoutFailureClass(err: unknown): ToolFailureClass | undefined {
+  if (err instanceof Error && err.name === 'TimeoutError') return 'timeout';
+  const msg = err instanceof Error ? err.message : String(err);
+  return /Timeout\s+\d+\s*ms exceeded/i.test(msg) ? 'timeout' : undefined;
+}
+
 // Substrings in a thrown error message that indicate the optional Playwright
 // peer dependency — or its chromium browser binary — is unavailable.
 export const PLAYWRIGHT_MISSING_HINTS = [

--- a/src/agent/trace/events.test.ts
+++ b/src/agent/trace/events.test.ts
@@ -49,6 +49,38 @@ describe('tool_call payload', () => {
     ).not.toThrow();
   });
 
+  it('accepts completed phase with a valid failureClass', () => {
+    for (const failureClass of ['policy-refusal', 'timeout', 'permission-denied', 'hook-block', 'abort']) {
+      expect(() =>
+        ToolCallPayloadSchema.parse({
+          phase: 'completed',
+          toolUseId: 't1',
+          name: 'browser_open',
+          resultBytes: 64,
+          isError: true,
+          truncated: false,
+          durationMs: 5,
+          failureClass,
+        }),
+      ).not.toThrow();
+    }
+  });
+
+  it('rejects an unknown failureClass', () => {
+    expect(() =>
+      ToolCallPayloadSchema.parse({
+        phase: 'completed',
+        toolUseId: 't1',
+        name: 'bash',
+        resultBytes: 0,
+        isError: true,
+        truncated: false,
+        durationMs: 1,
+        failureClass: 'made-up-class',
+      }),
+    ).toThrow();
+  });
+
   it('rejects unknown phase', () => {
     expect(() =>
       ToolCallPayloadSchema.parse({

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -17,6 +17,7 @@
  */
 
 import { z } from 'zod';
+import { TOOL_FAILURE_CLASSES } from './types.js';
 
 // ---------------------------------------------------------------------------
 // tool_call
@@ -30,6 +31,11 @@ export const ToolCallStartedPayloadSchema = z.object({
   subagentId: z.string().optional(),
 });
 
+/** Mirrors {@link import('./types.js').ToolFailureClass}. The literal tuple is
+ *  imported from `types.ts` (the canonical source) so the validator and the TS
+ *  type cannot drift. */
+export const ToolFailureClassSchema = z.enum(TOOL_FAILURE_CLASSES);
+
 export const ToolCallCompletedPayloadSchema = z.object({
   phase: z.literal('completed'),
   toolUseId: z.string(),
@@ -40,6 +46,8 @@ export const ToolCallCompletedPayloadSchema = z.object({
   durationMs: z.number().nonnegative(),
   /** Set when the event was produced by the repeat-loop circuit breaker. */
   circuitBreaker: z.boolean().optional(),
+  /** Coarse failure classification when `isError` is true. Absent otherwise. */
+  failureClass: ToolFailureClassSchema.optional(),
   subagentId: z.string().optional(),
 });
 

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -50,6 +50,38 @@ export interface ToolCallStartedPayload {
   subagentId?: string;
 }
 
+// Invariant: this is the canonical source of truth for the failure-class
+// vocabulary. `src/agent/trace/events.ts` imports this exact tuple to build
+// the Zod `z.enum`, so the runtime validator and the TS type can never drift.
+// Order is not load-bearing. Every value is set at a specific dispatcher or
+// handler site (see ToolFailureClass JSDoc) and consumed by
+// `src/improve/scan/detectors/tool-failure-density.ts`.
+export const TOOL_FAILURE_CLASSES = [
+  'policy-refusal',
+  'timeout',
+  'permission-denied',
+  'hook-block',
+  'abort',
+] as const;
+
+/**
+ * Coarse classification of WHY a tool returned `isError: true`. Optional and
+ * additive: a result with no `failureClass` is an unclassified failure (the
+ * pre-classification default — a handler bug, malformed input, etc.).
+ *
+ * Set at the site that produced the error:
+ *   - `policy-refusal`    — browser handler refused nav (domain allowlist). NOT a bug.
+ *   - `timeout`           — browser navigation/action exceeded its deadline.
+ *   - `permission-denied` — permission gate or read-only-skill bash gate denied the call.
+ *   - `hook-block`        — a PreToolUse hook returned `decision: 'block'`.
+ *   - `abort`             — the call's AbortSignal was already fired.
+ *
+ * The `tool-failure-density` detector treats `policy-refusal`, `permission-denied`,
+ * `hook-block`, and `abort` as "the system correctly said no" — excluded from
+ * failure stats entirely — while `timeout` and unclassified failures still count.
+ */
+export type ToolFailureClass = (typeof TOOL_FAILURE_CLASSES)[number];
+
 export interface ToolCallCompletedPayload {
   phase: 'completed';
   toolUseId: string;
@@ -63,6 +95,9 @@ export interface ToolCallCompletedPayload {
   /** True when this completed event was produced by the repeat-loop circuit breaker,
    *  not by a real tool dispatch — lets detectors exclude it from failure stats. */
   circuitBreaker?: boolean;
+  /** Coarse failure classification when `isError` is true. Absent on success
+   *  and on unclassified failures. See {@link ToolFailureClass}. */
+  failureClass?: ToolFailureClass;
   subagentId?: string;
 }
 

--- a/src/improve/scan/detectors/tool-failure-density.test.ts
+++ b/src/improve/scan/detectors/tool-failure-density.test.ts
@@ -48,6 +48,7 @@ function toolPair(
     durationMs?: number;
     resultBytes?: number;
     circuitBreaker?: boolean;
+    failureClass?: string;
   } = {},
 ): string[] {
   const started = JSON.stringify({
@@ -66,6 +67,7 @@ function toolPair(
     durationMs: opts.durationMs ?? 50,
   };
   if (opts.circuitBreaker === true) completedPayload['circuitBreaker'] = true;
+  if (opts.failureClass !== undefined) completedPayload['failureClass'] = opts.failureClass;
   const completed = JSON.stringify({
     ts: new Date(1_700_000_000_000 + seqCounter * 1000).toISOString(),
     seq: seqCounter++,
@@ -425,5 +427,103 @@ describe('detectToolFailureDensity — circuit-breaker exclusion', () => {
     expect(results).toHaveLength(1);
     expect(results[0]?.detail['totalCalls']).toBe(5);
     expect(results[0]?.detail['failureCount']).toBe(3);
+  });
+});
+
+describe('detectToolFailureDensity — failureClass exclusion', () => {
+  for (const cls of ['policy-refusal', 'permission-denied', 'hook-block', 'abort']) {
+    it(`does NOT produce a card when all failures are class '${cls}'`, () => {
+      resetSeq();
+      // 8 isError failures, all "system said no" — must produce zero cards.
+      const lines: string[] = [];
+      for (let i = 0; i < 8; i++) {
+        lines.push(...toolPair(`x-${i}`, 'browser_open', { isError: true, failureClass: cls }));
+      }
+      expect(detectToolFailureDensity([makeSession('s1', lines)])).toEqual([]);
+    });
+  }
+
+  it('regression: browser_open policy refusals do not manufacture a card (the reported bug)', () => {
+    resetSeq();
+    // The real-world shape: 10 policy refusals + 4 successes + 0 real faults.
+    // Pre-fix this read as 10/14 = 71% "failure" → high-severity card.
+    // Post-fix the 10 refusals are excluded from BOTH numerator and denominator,
+    // leaving 0 failures / 4 calls → no card.
+    const lines: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      lines.push(...toolPair(`p-${i}`, 'browser_open', { isError: true, failureClass: 'policy-refusal' }));
+    }
+    for (let i = 0; i < 4; i++) lines.push(...toolPair(`ok-${i}`, 'browser_open'));
+    expect(detectToolFailureDensity([makeSession('s1', lines)])).toEqual([]);
+  });
+
+  it('excludes refusals from BOTH numerator and denominator but still fires on real faults', () => {
+    resetSeq();
+    // 3 real (unclassified) failures + 6 policy refusals + 2 successes.
+    // Real denominator = 3 + 2 = 5; rate = 3/5 = 60% → fires with count 3, total 5.
+    const lines: string[] = [];
+    for (let i = 0; i < 3; i++) lines.push(...toolPair(`f-${i}`, 'browser_open', { isError: true }));
+    for (let i = 0; i < 6; i++) {
+      lines.push(...toolPair(`p-${i}`, 'browser_open', { isError: true, failureClass: 'policy-refusal' }));
+    }
+    for (let i = 0; i < 2; i++) lines.push(...toolPair(`ok-${i}`, 'browser_open'));
+    const r = detectToolFailureDensity([makeSession('s1', lines)])[0]!;
+    expect(r.detail['totalCalls']).toBe(5);
+    expect(r.detail['failureCount']).toBe(3);
+    expect(r.detail['excludedByClass']).toEqual({ 'policy-refusal': 6 });
+  });
+
+  it("counts 'timeout' as a real failure (not excluded) and surfaces it in the breakdown", () => {
+    resetSeq();
+    // 4 timeouts out of 4 calls → 100% → fires. timeout is NOT excluded.
+    const lines: string[] = [];
+    for (let i = 0; i < 4; i++) {
+      lines.push(...toolPair(`t-${i}`, 'browser_open', { isError: true, failureClass: 'timeout' }));
+    }
+    const r = detectToolFailureDensity([makeSession('s1', lines)])[0]!;
+    expect(r.detail['failureCount']).toBe(4);
+    expect(r.detail['totalCalls']).toBe(4);
+    expect(r.detail['failureClassBreakdown']).toEqual({ timeout: 4 });
+  });
+
+  it('reports a mixed failureClassBreakdown including unclassified failures', () => {
+    resetSeq();
+    // 2 timeout + 3 unclassified faults = 5 failures / 5 calls.
+    const lines: string[] = [];
+    for (let i = 0; i < 2; i++) {
+      lines.push(...toolPair(`t-${i}`, 'web_scrape', { isError: true, failureClass: 'timeout' }));
+    }
+    for (let i = 0; i < 3; i++) lines.push(...toolPair(`u-${i}`, 'web_scrape', { isError: true }));
+    const r = detectToolFailureDensity([makeSession('s1', lines)])[0]!;
+    expect(r.detail['failureClassBreakdown']).toEqual({ timeout: 2, unclassified: 3 });
+  });
+
+  it('back-compat: failures with NO failureClass count exactly as before', () => {
+    resetSeq();
+    // Mirrors the pre-failureClass world: 3 unclassified failures / 6 → fires.
+    const lines = [
+      ...toolPair('a', 'Bash', { isError: true }),
+      ...toolPair('b', 'Bash', { isError: true }),
+      ...toolPair('c', 'Bash', { isError: true }),
+      ...toolPair('d', 'Bash'),
+      ...toolPair('e', 'Bash'),
+      ...toolPair('f', 'Bash'),
+    ];
+    const r = detectToolFailureDensity([makeSession('s1', lines)])[0]!;
+    expect(r.detail['totalCalls']).toBe(6);
+    expect(r.detail['failureCount']).toBe(3);
+    expect(r.detail['failureClassBreakdown']).toEqual({ unclassified: 3 });
+    expect(r.detail['excludedByClass']).toEqual({});
+  });
+
+  it('annotates evidence rows with the failure class', () => {
+    resetSeq();
+    const lines = [
+      ...toolPair('t1', 'browser_open', { isError: true, failureClass: 'timeout' }),
+      ...toolPair('t2', 'browser_open', { isError: true, failureClass: 'timeout' }),
+      ...toolPair('t3', 'browser_open', { isError: true, failureClass: 'timeout' }),
+    ];
+    const r = detectToolFailureDensity([makeSession('s1', lines)])[0]!;
+    expect(r.evidence[0]?.annotation).toContain('class=timeout');
   });
 });

--- a/src/improve/scan/detectors/tool-failure-density.ts
+++ b/src/improve/scan/detectors/tool-failure-density.ts
@@ -37,22 +37,51 @@
  *
  * ## Caveats
  *
- *   - "Failure" means `isError: true` returned by the dispatcher. This
- *     conflates several distinct root causes — hook block, permission
- *     denied, handler throw, unknown tool — which the trace payload does
- *     NOT distinguish. The card surfaces the raw bytes count and duration
- *     so a reviewer can disambiguate from evidence excerpts; future
- *     versions may key on a richer failure-class field if the dispatcher
- *     starts emitting one.
- *   - Tools that return `isError: true` as a *signal* to the LLM (e.g.
- *     intentional "no results" responses) will inflate the rate. Reviewers
- *     can suppress via card status: 'deferred'.
+ *   - "Failure" means `isError: true` returned by the dispatcher. The trace
+ *     payload now carries a coarse `failureClass` (set at the dispatcher gates
+ *     and browser handlers — see {@link ToolFailureClass}). This detector uses
+ *     it to EXCLUDE "the system correctly said no" results (policy refusal,
+ *     permission denial, hook block, abort) from both the failure count and the
+ *     call total — see {@link EXCLUDED_FAILURE_CLASSES}. Failures with no class
+ *     (older traces, handler throws, malformed input) still count, preserving
+ *     back-compat. The per-class `failureClassBreakdown` and `excludedByClass`
+ *     are surfaced in the card detail so a reviewer can see the mix.
+ *   - `timeout` is classified but NOT excluded — a high timeout rate can be a
+ *     real signal — so it still counts toward the rate, just visibly.
+ *   - Tools that return `isError: true` as an unclassified *signal* to the LLM
+ *     (e.g. intentional "no results" responses) will still inflate the rate.
+ *     Reviewers can suppress via card status: 'deferred'.
  *
  * @module improve/scan/detectors/tool-failure-density
  */
 
 import type { DetectorResult, FailureEvidence, Severity } from '../../schemas.js';
 import type { SessionRead } from '../reader.js';
+import type { ToolFailureClass } from '../../../agent/trace/types.js';
+
+/**
+ * Failure classes that mean "the system correctly said no", not "the tool
+ * failed". A domain-policy refusal, a permission denial, a PreToolUse hook
+ * block, or an aborted call all return `isError: true` so the model sees the
+ * refusal — but counting them as tool failures inflated the signal and
+ * manufactured false-positive cards (e.g. `browser_open` looking 50% broken
+ * when half its calls were policy refusals working exactly as designed).
+ *
+ * Results in this set are excluded from BOTH the failure count and the call
+ * total. `timeout` is deliberately NOT excluded — a high timeout rate can be a
+ * real problem (too-tight a deadline, a systematically slow target) — but it IS
+ * surfaced in the per-class breakdown so a reviewer can judge.
+ *
+ * Back-compat: traces written before the `failureClass` field existed carry no
+ * class, so historical failures are never excluded — they count exactly as they
+ * did before. Only post-upgrade traces benefit.
+ */
+const EXCLUDED_FAILURE_CLASSES: ReadonlySet<ToolFailureClass> = new Set([
+  'policy-refusal',
+  'permission-denied',
+  'hook-block',
+  'abort',
+]);
 
 /** Minimum absolute failure count for a tool before a card fires. */
 export const DEFAULT_TOOL_FAILURE_MIN_FAILURES = 3;
@@ -81,6 +110,8 @@ interface FailureSighting {
   resultBytes: number;
   durationMs: number;
   truncated: boolean;
+  /** Coarse failure class from the trace event, when present. */
+  failureClass?: ToolFailureClass;
 }
 
 /** Aggregated stats per tool name across all sessions. */
@@ -92,6 +123,9 @@ interface ToolStats {
   affectedSessions: Set<string>;
   /** How many failures were also truncated (often signals a separate bug). */
   truncatedFailureCount: number;
+  /** Count of results excluded as "system said no" (see EXCLUDED_FAILURE_CLASSES),
+   *  keyed by class. Surfaced in the card detail for transparency. */
+  excludedByClass: Map<ToolFailureClass, number>;
 }
 
 /**
@@ -121,7 +155,18 @@ export function detectToolFailureDensity(
       if (ev.payload.phase !== 'completed') continue;
       // Skip synthetic circuit-breaker blocks — not real tool outcomes.
       if (ev.payload.circuitBreaker === true) continue;
+
       const stats = getOrInit(byTool, ev.payload.name);
+      const failureClass = ev.payload.failureClass;
+
+      // "System said no" — exclude from BOTH numerator and denominator so a
+      // policy/permission/hook/abort refusal can never manufacture a card.
+      // Recorded separately for reviewer transparency.
+      if (failureClass !== undefined && EXCLUDED_FAILURE_CLASSES.has(failureClass)) {
+        stats.excludedByClass.set(failureClass, (stats.excludedByClass.get(failureClass) ?? 0) + 1);
+        continue;
+      }
+
       stats.totalCalls += 1;
       if (ev.payload.isError) {
         stats.failures.push({
@@ -132,6 +177,7 @@ export function detectToolFailureDensity(
           resultBytes: ev.payload.resultBytes,
           durationMs: ev.payload.durationMs,
           truncated: ev.payload.truncated,
+          ...(failureClass !== undefined ? { failureClass } : {}),
         });
         stats.affectedSessions.add(session.sessionId);
         if (ev.payload.truncated) stats.truncatedFailureCount += 1;
@@ -160,6 +206,7 @@ function getOrInit(map: Map<string, ToolStats>, toolName: string): ToolStats {
       failures: [],
       affectedSessions: new Set<string>(),
       truncatedFailureCount: 0,
+      excludedByClass: new Map<ToolFailureClass, number>(),
     };
     map.set(toolName, stats);
   }
@@ -176,11 +223,22 @@ function buildResult(stats: ToolStats, rate: number): DetectorResult {
     tracePath: f.relativeTracePath,
     eventIndices: [f.seq],
     excerpt: clampExcerpt(f.rawLine),
-    annotation: `isError=true · resultBytes=${f.resultBytes} · durationMs=${f.durationMs}${f.truncated ? ' · truncated' : ''}`,
+    annotation: `isError=true${f.failureClass ? ` · class=${f.failureClass}` : ''} · resultBytes=${f.resultBytes} · durationMs=${f.durationMs}${f.truncated ? ' · truncated' : ''}`,
   }));
 
   const totalDuration = stats.failures.reduce((acc, f) => acc + f.durationMs, 0);
   const avgFailureDurationMs = totalDuration / stats.failures.length;
+
+  // Per-class breakdown of the COUNTED failures (unclassified = no failureClass,
+  // e.g. a handler throw or malformed input — the pre-classification default).
+  const failureClassBreakdown: Record<string, number> = {};
+  for (const f of stats.failures) {
+    const key = f.failureClass ?? 'unclassified';
+    failureClassBreakdown[key] = (failureClassBreakdown[key] ?? 0) + 1;
+  }
+  // Refusals excluded from the stats entirely, for reviewer transparency.
+  const excludedByClass: Record<string, number> = {};
+  for (const [cls, n] of stats.excludedByClass) excludedByClass[cls] = n;
 
   return {
     slug,
@@ -190,7 +248,7 @@ function buildResult(stats: ToolStats, rate: number): DetectorResult {
     observedAt,
     evidence,
     detail: {
-      detector: 'tool-failure-density@v1',
+      detector: 'tool-failure-density@v2',
       toolName: stats.toolName,
       totalCalls: stats.totalCalls,
       failureCount: stats.failures.length,
@@ -198,6 +256,8 @@ function buildResult(stats: ToolStats, rate: number): DetectorResult {
       affectedSessionCount: stats.affectedSessions.size,
       truncatedFailureCount: stats.truncatedFailureCount,
       avgFailureDurationMs: round2(avgFailureDurationMs),
+      failureClassBreakdown,
+      excludedByClass,
       sessionIds: Array.from(stats.affectedSessions),
       seqs: stats.failures.map((f) => f.seq),
     },


### PR DESCRIPTION
## Problem

The `tool-failure-density` detector (`afk improve scan`) counts every `isError: true` tool result as a **failure**. But many `isError` results are the system working *exactly as designed*:

- a browser navigation refused by the domain allowlist (`blocked_by_policy`),
- a permission gate / read-only-bash gate denial,
- a `PreToolUse` hook block,
- an aborted call.

These inflated the failure rate and manufactured **high-severity false-positive cards**. Concrete case that prompted this: the `tool-failure-browser-open` card read `browser_open` as **11/22 (50%) broken** when, on inspection of the witness traces, the failures were **~10 `blocked_by_policy`** (the allowlist working) **+ 8 nav timeouts** (remote sites) **+ 2 one-off env issues** — zero actual handler bugs.

## Fix

Add an optional `failureClass` discriminator to the `tool_call` *completed* trace event, set at the site that produced the error:

| Site | Class |
|------|-------|
| dispatcher abort gate | `abort` |
| `PreToolUse` hook block | `hook-block` |
| permission gate + read-only-bash gate | `permission-denied` |
| `browser_open` / `browser_act` allowlist refusal | `policy-refusal` |
| `browser_open` / `browser_act` nav/action timeout | `timeout` |

The detector now **excludes** `policy-refusal` / `permission-denied` / `hook-block` / `abort` from **both** the failure count and the call total — so a refusal can never manufacture a card. `timeout` still **counts** (a high timeout rate can be a real problem) but is surfaced in a new per-class `failureClassBreakdown` in the card detail, alongside an `excludedByClass` tally for transparency. Detector `detail.detector` bumped to `tool-failure-density@v2`.

## Design notes

- **Single source of truth.** `TOOL_FAILURE_CLASSES` is defined once in `trace/types.ts`; `events.ts` imports it to build the Zod enum, so the validator and the TS type cannot drift.
- **Back-compat.** The field is optional. Traces written before it existed carry no class and count exactly as before — only post-upgrade traces benefit. No retroactive change to historical cards.
- **No new SDK surface.** No new `@anthropic-ai/sdk` symbols; `audit:sdk:check` passes.

## Scope boundaries (deliberate)

- Only the **browser** handlers tag `policy-refusal`/`timeout`. Subagent/skill/compose errors and browser `ambiguous_target` stay **unclassified** (still counted as real failures) — classifying those is a separate refinement.
- Tool-failure telemetry is emitted only by the **anthropic-direct** provider loop today (the OpenAI-compatible loop emits no `tool_call` events) — pre-existing, out of scope here.

## Verification

- `pnpm test` — **9055 pass / 12 skip**, 0 fail (full suite).
- `pnpm lint` (`tsc --noEmit`, strict) — clean.
- `pnpm audit:sdk:check` — clean.
- `pnpm build` — clean.
- **+17 new tests**: detector exclusion for each class + the `browser_open` policy-refusal regression case + `timeout` counted/surfaced + back-compat; Zod schema accept/reject; dispatcher gate tagging (abort/hook/permission); browser handler policy/timeout/abort tagging; the `browserTimeoutFailureClass` helper.