### PR TITLE
feat(ask-question): surface-answerability clause + BLOCKED-artifact convention

### DIFF
--- a/src/agent/routing-directive.ts
+++ b/src/agent/routing-directive.ts
@@ -57,6 +57,17 @@ Default to acting autonomously. \`ask_question\` is a last resort, not a first m
 
 Before you ask, you MUST exhaust the tools you have: read the files, check git, search the codebase and docs, inspect runtime state. If any tool can get you the answer, use the tool — never ask the operator for something you can discover yourself. When a wrong guess would be cheap or reversible, make a reasonable assumption, proceed, and state the assumption instead of asking.
 
+**Answerability — a question only helps if a human will actually answer it:**
+
+\`surface\` (from \`get_runtime_state\`, view \`"self"\`) is a partial signal, not a guarantee:
+- \`daemon\`, or any session started by a scheduler, cron job, or another agent, has no human watching — never block on \`ask_question\` here.
+- \`cli\` is ambiguous: the interactive REPL and the Telegram bot can reach a human, but one-shot \`chat\` runs and sub-agent forks report the same \`cli\` and have no elicitation handler — there \`ask_question\` returns \`{ action: 'decline' }\` instantly.
+- Even when a handler exists, the operator is usually away, so a blocking question can stall until the turn aborts.
+
+So treat \`ask_question\` as best-effort: a \`decline\` or \`cancel\` result means "no answer is coming," not a failure to abort the task on. When you cannot be sure a human will answer, instead of asking:
+1. **Proceed on a stated assumption** — pick the most reasonable interpretation, act on it, and record the assumption in your Done/Blocked terminal state for async review.
+2. **Emit a Blocked artifact** — if no safe assumption exists and proceeding would be irreversible, end the turn with a **Blocked** terminal state naming exactly what the operator must supply before the next run.
+
 Reserve \`ask_question\` for the narrow set of things no tool can resolve: a genuinely ambiguous requirement whose readings lead to materially different work, a decision with significant or irreversible consequences, or context that lives only in the operator's head (a preference, a secret, an external constraint):
 
 - Question types: \`text\` (open-ended), \`confirm\` (yes/no), \`choice\` (single pick from list), \`multi_choice\` (multi-pick), \`number\` (numeric with optional bounds). When \`allow_custom: true\`, the result may include \`custom_value\` instead of \`value\` — check \`content.custom_value !== undefined\` to detect a free-form answer.

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -641,6 +641,22 @@ export const askQuestionTool: AnthropicToolDef = {
     'materially different work, a decision with significant or irreversible consequences, or context that exists ' +
     "only in the operator's head (a preference, a secret, an external constraint). " +
     '\n\n' +
+    'ANSWERABILITY — a question only helps if a human will answer it:\n' +
+    '`surface` (from `get_runtime_state`, view "self") is a partial signal, not a guarantee:\n' +
+    '- `daemon`, or any session started by a scheduler, cron, or another agent: no human is\n' +
+    '  watching — never block on a question here.\n' +
+    '- `cli` is AMBIGUOUS: the interactive REPL and Telegram bot reach a human, but one-shot `chat`\n' +
+    '  runs and sub-agent forks report the same `cli` with no elicitation handler — there the call\n' +
+    "  returns `{ action: 'decline' }` instantly.\n" +
+    '- Even when a handler exists, the operator is usually away, so a blocking question may stall\n' +
+    '  until the turn aborts.\n' +
+    'Treat this tool as best-effort: a `decline` or `cancel` result means "no answer is coming," not\n' +
+    'a failure to abort the task on. When you cannot be sure a human will answer, instead of asking:\n' +
+    '1. Proceed on a stated assumption — pick the most reasonable interpretation, act, and record the\n' +
+    '   assumption in your Done/Blocked terminal state for async review.\n' +
+    '2. Emit a Blocked artifact — if no safe assumption exists and proceeding is irreversible, end\n' +
+    '   with a **Blocked** terminal state naming exactly what the operator must supply.\n' +
+    '\n' +
     'Question types:\n' +
     '- `text` (default): free-form text answer. Use for open-ended questions.\n' +
     '- `confirm`: yes/no question. Returns `{ action: "accept", value: true|false }`.\n' +


### PR DESCRIPTION
## Source

Ported from **afk-workshop#777** (private canonical repo). This is a **moat-scrubbed port**, not a 1:1 copy — the public commit history shares no ancestry with the private repo, so the change was applied via diff + 3-way merge rather than cherry-pick.

## What

Tightens the `ask_question` tool contract — in both the tool description (`src/agent/tools/schemas.ts`) and `ROUTING_DIRECTIVE` (`src/agent/routing-directive.ts`) — with an **answerability** clause and a **Blocked-artifact** fallback convention.

## Why

Telemetry flagged `ask_question:timeout` co-occurring with run aborts across ~16 sessions: the agent pauses for human input on a surface where no answer arrives, and the run aborts. The prior contract said "ask is a last resort / prefer assumptions" but gave no guidance on *surface answerability* or on handling a no-answer result.

## What the contract now says

`surface` (from `get_runtime_state`, view `"self"`) is a **partial signal, not a guarantee**:
- `daemon` / scheduler / cron / agent-started → no human watching; never block on `ask_question`.
- `cli` is **ambiguous** — the interactive REPL and Telegram bot reach a human, but one-shot `chat` and sub-agent forks report the same `cli` with no elicitation handler (instant `{action:'decline'}`).
- Even with a handler, the operator is usually away, so a blocking ask can stall until the turn aborts.

A `decline`/`cancel` result means "no answer is coming," **not** a failure to abort on → **proceed on a stated assumption** or **emit a Blocked artifact**.

## Ported (public-safe)

- `src/agent/routing-directive.ts` — `+11` lines: bolded "Answerability" sub-section inserted between the last-resort preamble and the question-type list.
- `src/agent/tools/schemas.ts` — `+16` lines: an `ANSWERABILITY` block added to the `ask_question` tool description string.

Net: additive prose only (`+27` lines, `0` deletions). No TypeScript type changes, no new exports, no test changes. The 3-way merge preserved a public-only sentence in `routing-directive.ts` (the `allow_custom`/`custom_value` note on the question-type bullet) that does not exist in the private source.

## Dropped (and why)

**Nothing dropped.** Both touched files exist in public, both hunks classified PUBLIC-SAFE by moat triage, and the added lines contain no moat vocabulary. The private PR's commit-message reference to `forge-friction` (telemetry origin) is KEEP-listed public vocabulary and is git metadata, not ported content.

## Verification

- `pnpm install --frozen-lockfile` ✓ · `pnpm fix:pins:check` ✓ (all pins up to date) · `pnpm lint` (tsc --noEmit, strict) ✓
- `pnpm test` ✓ — **9099 passed, 12 skipped** (483 files)
- `pnpm build` ✓ · `pnpm build:dist` ✓ (`dist/` built, 0 files scrubbed)
- **MOAT GUARD CLEAN** — deterministic HARD-denylist + structural scan over tree + built `dist/`: 0 hits.
- **Adversarial audit CLEAN** — independent sub-agent re-derived the moat search from scratch (tree + `dist/`): no moat found, high confidence.

## Do not merge automatically

Left for human review.
