### PR TITLE
fix(repl): render user echo as a true chat bubble; label spinner tips

### DIFF
--- a/src/cli/loading-tips.test.ts
+++ b/src/cli/loading-tips.test.ts
@@ -317,9 +317,12 @@ describe('formatTipRow', () => {
     expect(row.startsWith('  💡 Tip: /agentify')).toBe(true);
   });
 
-  it('truncates to one visual line with a trailing ellipsis', () => {
+  it('truncates to one visual line with a single trailing ellipsis', () => {
     const row = strip(formatTipRow('x'.repeat(500), 40));
     expect(row.endsWith('…')).toBe(true);
+    // Exactly one trailing ellipsis — guards the '……' regression where
+    // truncateDisplayWidth's own ellipsis was compounded by a manual '…' append.
+    expect(row.match(/…+$/)?.[0]).toBe('…');
     expect(row.length).toBeLessThanOrEqual(40);
   });
 

--- a/src/cli/loading-tips.test.ts
+++ b/src/cli/loading-tips.test.ts
@@ -22,6 +22,7 @@ import {
   _resetSeenTipsForTesting,
   type LoadingTip,
 } from './loading-tips.js';
+import { formatTipRow } from './terminal-compositor.types.js';
 
 // Harvest stubs — vi.mock has to be hoisted, so use the standard pattern.
 vi.mock('./slash/registry.js', () => ({
@@ -301,5 +302,23 @@ describe('selectTip', () => {
   it('respects the custom warmupMs override', () => {
     expect(selectTip(pool, { startedAt: 0, now: 2_000, warmupMs: 5_000 })).toBeNull();
     expect(selectTip(pool, { startedAt: 0, now: 6_000, warmupMs: 5_000 })).not.toBeNull();
+  });
+});
+
+describe('formatTipRow', () => {
+  const strip = (s: string): string => s.replace(/\x1B\[[0-9;]*m/g, '');
+
+  it('labels the row with "Tip:" so skill hints are not misread as routing', () => {
+    // A harvested skill tip looks like `/agentify — Use when…`. Without the
+    // label, rendering it under the spinner right after the user typed a
+    // DIFFERENT slash command reads as "the agent rerouted my command".
+    const row = strip(formatTipRow('/agentify — Use when the user wants to delegate', 120));
+    expect(row.startsWith('  💡 Tip: /agentify')).toBe(true);
+  });
+
+  it('truncates to one visual line with a trailing ellipsis', () => {
+    const row = strip(formatTipRow('x'.repeat(500), 40));
+    expect(row.endsWith('…')).toBe(true);
+    expect(row.length).toBeLessThanOrEqual(40);
   });
 });

--- a/src/cli/loading-tips.test.ts
+++ b/src/cli/loading-tips.test.ts
@@ -16,6 +16,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import stringWidth from 'string-width';
 import {
   buildTipPool,
   selectTip,
@@ -320,5 +321,14 @@ describe('formatTipRow', () => {
     const row = strip(formatTipRow('x'.repeat(500), 40));
     expect(row.endsWith('…')).toBe(true);
     expect(row.length).toBeLessThanOrEqual(40);
+  });
+
+  it('truncates by display width, not char count (wide CJK glyphs)', () => {
+    // 30 CJK chars = 60 display columns but only 30 JS chars. Char-count
+    // truncation would keep ~29 of them (≈58 cols) and overflow a 40-col
+    // terminal; display-width truncation must keep the row ≤ cols.
+    const row = strip(formatTipRow('漢'.repeat(30), 40));
+    expect(row.endsWith('…')).toBe(true);
+    expect(stringWidth(row)).toBeLessThanOrEqual(40);
   });
 });

--- a/src/cli/loading-tips.ts
+++ b/src/cli/loading-tips.ts
@@ -25,7 +25,7 @@
  *      reproducible.
  *
  * Tips are plain text — no ANSI inside the body, no second sentence. The
- * compositor wraps them with the dim 💡 prefix.
+ * compositor wraps them with the dim `💡 Tip:` prefix.
  */
 
 import { list as listSlashCommands } from './slash/registry.js';

--- a/src/cli/render.test.ts
+++ b/src/cli/render.test.ts
@@ -468,7 +468,7 @@ describe('card', () => {
     Object.defineProperty(process.stdout, 'columns', { value: 80, configurable: true });
   });
 
-  it('user kind wraps long lines and right-aligns each row against the bar', () => {
+  it('user kind wraps long lines and terminates every row at the bar', () => {
     Object.defineProperty(process.stdout, 'columns', { value: 30, configurable: true });
     const out = strip(card({ kind: 'user', body: 'word '.repeat(15).trim() }));
     const rows = out.split('\n');
@@ -531,7 +531,7 @@ describe('card', () => {
 
   it('user kind wrapped lines all end flush right at the bar', () => {
     Object.defineProperty(process.stdout, 'columns', { value: 40, configurable: true });
-    // Body long enough to wrap. innerW = max(20, 40 - 4) = 36.
+    // Body long enough to wrap. innerW = max(20, min(36, floor(40*0.75), 100)) = 30.
     const body = 'word '.repeat(10).trim(); // 49 visible chars → wraps
     const out = strip(card({ kind: 'user', body }));
     const lines = out.split('\n');
@@ -546,6 +546,48 @@ describe('card', () => {
       expect(line.length).toBeLessThanOrEqual(40);
     }
     Object.defineProperty(process.stdout, 'columns', { value: 80, configurable: true });
+  });
+
+  // ── chat-bubble block tests (straight left edge, capped width) ─────────────
+
+  it('user kind: wrapped rows share a straight left edge (block, not per-row right-align)', () => {
+    Object.defineProperty(process.stdout, 'columns', { value: 80, configurable: true });
+    // Rows wrap at differing natural widths; per-row right-alignment would
+    // produce ragged indents. The bubble pads every row to the widest one.
+    const body = 'word '.repeat(30).trim();
+    const out = strip(card({ kind: 'user', body }));
+    const [, ...contentLines] = out.split('\n');
+    expect(contentLines.length).toBeGreaterThan(1);
+    const indents = contentLines.map((l) => l.length - l.trimStart().length);
+    expect(new Set(indents).size).toBe(1);
+    // A left gutter remains — the bubble must not span the full row.
+    expect(indents[0]).toBeGreaterThan(0);
+  });
+
+  it('user kind: bubble width is capped at 75% of the terminal', () => {
+    Object.defineProperty(process.stdout, 'columns', { value: 80, configurable: true });
+    const body = 'word '.repeat(40).trim();
+    const out = strip(card({ kind: 'user', body }));
+    const [, ...contentLines] = out.split('\n');
+    // innerW = floor(80 * 0.75) = 60 → content + ' │' ≤ 62; rows are pinned
+    // at rightEdge = 79, so the left gutter is at least 79 - 62 = 17 cols.
+    for (const line of contentLines) {
+      expect(line.length - line.trimStart().length).toBeGreaterThanOrEqual(17);
+    }
+  });
+
+  it('user kind: separator spans the bubble and shares its left edge', () => {
+    Object.defineProperty(process.stdout, 'columns', { value: 80, configurable: true });
+    const body = 'word '.repeat(30).trim();
+    const out = strip(card({ kind: 'user', body }));
+    const [sep, ...contentLines] = out.split('\n');
+    const sepIndent = sep!.length - sep!.trimStart().length;
+    const rowIndent = contentLines[0]!.length - contentLines[0]!.trimStart().length;
+    // Top rule starts exactly above the bubble's left edge and reaches the
+    // bar column — it reads as the bubble's top border.
+    expect(sepIndent).toBe(rowIndent);
+    expect(sep!.trimEnd().endsWith('─')).toBe(true);
+    expect(sep!.trimEnd().length).toBe(contentLines[0]!.length);
   });
 });
 

--- a/src/cli/render/card.ts
+++ b/src/cli/render/card.ts
@@ -28,8 +28,9 @@ const MAX_USER_CARD_ROWS = (() => {
  * - `status`      — blue.    A status or state report.
  * - `checkpoint`  — green.   A successful step / phase rollup.
  * - `diagnosis`   — yellow.  A diagnosis, problem, or warning.
- * - `user`        — cyan.    A user message echo (left-bar variant; no
- *                            top/bottom border or title chip).
+ * - `user`        — cyan.    A user message echo (right-positioned chat
+ *                            bubble: dim top rule + cyan right bar; no
+ *                            full border or title chip).
  */
 export type CardKind = 'plan' | 'status' | 'checkpoint' | 'diagnosis' | 'user';
 
@@ -78,11 +79,11 @@ const CARD_DEFAULT_TITLE: Record<Exclude<CardKind, 'user'>, string> = {
  * same shape vocabulary as {@link errorBox}: a colored border with a bold
  * title chip in the top bar and 2-space inner padding.
  *
- * The `user` kind is a thin, right-aligned variant — content is flushed to
- * the right edge of the terminal with a single cyan bar (`│`) on the far
- * right, no top/bottom border. Used for echoing user input in the REPL,
- * mirroring the chat-bubble convention where the speaker's own messages
- * sit on the right.
+ * The `user` kind is a thin chat-bubble variant — a width-capped block of
+ * left-aligned text positioned against the right edge of the terminal,
+ * closed by a single cyan bar (`│`) on the far right and a dim top rule.
+ * Used for echoing user input in the REPL, mirroring the chat-bubble
+ * convention where the speaker's own messages sit on the right.
  *
  * @param spec - Card specification.
  * @returns Multi-line string ready to write to stdout.
@@ -99,13 +100,19 @@ export function card(spec: CardSpec): string {
 }
 
 function renderUserCard(bodyLines: string[]): string {
-  // Right-aligned chat-bubble layout: each body line is wrapped to fit within
-  // the available width, then padded on the LEFT so the content + ' │' suffix
-  // sits flush against the right edge of the terminal. `cols - 4` leaves 2
-  // cols of breathing room on the left and reserves 2 cols on the right for
-  // the ' │' suffix.
+  // Chat-bubble layout: the bubble BLOCK is positioned against the right
+  // edge of the terminal, but the text INSIDE it stays left-aligned —
+  // mirroring how iMessage/WhatsApp render the speaker's own messages.
+  // Two width rules make it read as a bubble instead of misaligned text:
+  //
+  //   1. Bubble width is capped at 75% of the terminal (and at 100, the
+  //      bordered-card ceiling) so a left gutter always remains. A bubble
+  //      spanning the whole row is indistinguishable from plain output.
+  //   2. Every row is padded to the width of the WIDEST row, giving the
+  //      bubble a straight left edge. Per-row right-alignment (the prior
+  //      layout) produced a ragged left edge that read as broken wrapping.
   const cols = getTerminalWidth();
-  const innerW = Math.max(20, cols - 4);
+  const innerW = Math.max(20, Math.min(cols - 4, Math.floor(cols * 0.75), 100));
   const wrapped: string[] = [];
   for (const line of bodyLines) {
     wrapped.push(...wrapToWidth(renderCardLine(line), innerW).split('\n'));
@@ -146,27 +153,37 @@ function renderUserCard(bodyLines: string[]): string {
   // width.
   const rightEdge = cols - 1;
 
-  // Separator row is built after capping — does not count against MAX_USER_CARD_ROWS.
-  // Spans up to 30 visible columns right-aligned to rightEdge, matching the
-  // existing divider glyph vocabulary. Width formula guarantees row ≤ cols-1.
-  const sepW = Math.min(30, Math.max(1, rightEdge));
+  // Bubble block width: the widest visible row, clamped so content + ' │'
+  // still honors the last-column-safety ceiling. Rows wider than the clamp
+  // (unbreakable tokens that survive wrapToWidth(hard:false)) are truncated
+  // below, landing exactly at blockW.
+  const blockW = Math.min(
+    Math.max(0, ...displayRows.map((l) => displayWidth(l))),
+    Math.max(0, rightEdge - 2),
+  );
+
+  // Separator row is built after capping — does not count against
+  // MAX_USER_CARD_ROWS. It doubles as the bubble's top edge: spans the
+  // bubble's footprint (content + ' │' = blockW + 2) starting at the
+  // bubble's left edge. Floor of 12 keeps it legible for one-word bubbles;
+  // the rightEdge clamp preserves the last-column-safety invariant.
+  const sepW = Math.min(Math.max(1, rightEdge), Math.max(12, blockW + 2));
   const sepPad = Math.max(0, rightEdge - sepW);
   const separatorRow = ' '.repeat(sepPad) + palette.dim('─'.repeat(sepW));
 
+  // Common left edge for every row; the bar lands at rightEdge on every row.
+  const leadingSpace = Math.max(0, rightEdge - blockW - 2);
   const contentRows = displayRows
     .map((line) => {
       // Defensive clamp: an unbreakable token wider than innerW survives
       // wrapToWidth(hard:false) intact, so a row could otherwise exceed
-      // rightEdge. Truncate (ANSI/hyperlink-aware) so content + ' │' ≤ rightEdge.
+      // blockW. Truncate (ANSI/hyperlink-aware) so content fits the block.
       const content =
-        displayWidth(line) + 2 > rightEdge
-          ? truncateDisplayWidth(line, Math.max(0, rightEdge - 2))
-          : line;
-      const lineW = displayWidth(content);
-      // `rightEdge - lineW - 2` reserves 2 cols for the trailing ' │'. Clamp to
-      // 0 so a line at the width ceiling still renders without negative pad.
-      const leadingSpace = Math.max(0, rightEdge - lineW - 2);
-      return ' '.repeat(leadingSpace) + content + ' ' + bar;
+        displayWidth(line) > blockW ? truncateDisplayWidth(line, blockW) : line;
+      // Interior pad fills the gap between this row's text and the bar
+      // column, keeping the text left-aligned within the bubble.
+      const interiorPad = Math.max(0, blockW - displayWidth(content));
+      return ' '.repeat(leadingSpace) + content + ' '.repeat(interiorPad) + ' ' + bar;
     })
     .join('\n');
   return separatorRow + '\n' + contentRows;

--- a/src/cli/terminal-compositor.types.ts
+++ b/src/cli/terminal-compositor.types.ts
@@ -8,6 +8,7 @@
  */
 
 import { palette } from './palette.js';
+import { displayWidth, truncateDisplayWidth } from './display.js';
 import type { LoadingTip } from './loading-tips.js';
 import type { ImageAttachment } from './input/attachments.js';
 import type { AutocompleteState } from './input/autocomplete-state.js';
@@ -88,16 +89,20 @@ export function formatElapsed(startedAt: number): string {
  * `cols` is the terminal width — we truncate to fit on one visual line so
  * the tip never wraps and steals a viewport row that log-update can't
  * cleanly reclaim on the next paint. The prefix budget is "  💡 Tip: "
- * (10 cols — `prefix.length` happens to equal its display width since the
- * bulb is width-2 and length-2); 1 more col is reserved for the trailing
- * "…" when truncation kicks in.
+ * (10 visible cols); 1 more col is reserved for the trailing "…" when
+ * truncation kicks in. Budget and truncation are measured in DISPLAY
+ * columns (not JS chars) so wide glyphs (CJK, emoji) in a tip body cannot
+ * overflow the row — char-count truncation would under-truncate them 2:1.
  */
 export function formatTipRow(text: string, cols: number): string {
   const prefix = '  💡 Tip: ';
-  // Reserve 4 cols of prefix chrome and 1 col for the truncation marker so
-  // the rendered line always fits in `cols` regardless of body length.
-  const bodyBudget = Math.max(8, cols - prefix.length - 1);
-  const body = text.length > bodyBudget ? text.slice(0, bodyBudget - 1) + '…' : text;
+  // Reserve the prefix chrome and 1 col for the truncation marker so the
+  // rendered line always fits in `cols` regardless of body length.
+  const bodyBudget = Math.max(8, cols - displayWidth(prefix) - 1);
+  const body =
+    displayWidth(text) > bodyBudget
+      ? truncateDisplayWidth(text, Math.max(0, bodyBudget - 1)) + '…'
+      : text;
   return palette.dim(prefix + body);
 }
 

--- a/src/cli/terminal-compositor.types.ts
+++ b/src/cli/terminal-compositor.types.ts
@@ -77,14 +77,23 @@ export function formatElapsed(startedAt: number): string {
 /**
  * Format a loading tip into the dim 💡 row that sits beneath the spinner.
  *
+ * The literal `Tip:` label is load-bearing, not decoration: most tips are
+ * harvested skill hints shaped like `/agentify — Use when …`, and without
+ * the label a tip rendered mid-turn reads as the agent announcing it is
+ * routing to that skill (e.g. the user types `/automate` and immediately
+ * sees `💡 /agentify — Use when…`). `Tip:` marks the row as ambient
+ * guidance, decoupled from the in-flight turn. The {@link LoadingTip}
+ * contract has always promised this prefix; the implementation drifted.
+ *
  * `cols` is the terminal width — we truncate to fit on one visual line so
  * the tip never wraps and steals a viewport row that log-update can't
- * cleanly reclaim on the next paint. The 4-col prefix budget is "  💡 "
- * (two leading spaces, the bulb, one trailing space); 2 more cols are
- * reserved for the trailing "…" when truncation kicks in.
+ * cleanly reclaim on the next paint. The prefix budget is "  💡 Tip: "
+ * (10 cols — `prefix.length` happens to equal its display width since the
+ * bulb is width-2 and length-2); 1 more col is reserved for the trailing
+ * "…" when truncation kicks in.
  */
 export function formatTipRow(text: string, cols: number): string {
-  const prefix = '  💡 ';
+  const prefix = '  💡 Tip: ';
   // Reserve 4 cols of prefix chrome and 1 col for the truncation marker so
   // the rendered line always fits in `cols` regardless of body length.
   const bodyBudget = Math.max(8, cols - prefix.length - 1);

--- a/src/cli/terminal-compositor.types.ts
+++ b/src/cli/terminal-compositor.types.ts
@@ -101,7 +101,7 @@ export function formatTipRow(text: string, cols: number): string {
   const bodyBudget = Math.max(8, cols - displayWidth(prefix) - 1);
   const body =
     displayWidth(text) > bodyBudget
-      ? truncateDisplayWidth(text, Math.max(0, bodyBudget - 1)) + '…'
+      ? truncateDisplayWidth(text, Math.max(0, bodyBudget - 1), '') + '…'
       : text;
   return palette.dim(prefix + body);
 }


### PR DESCRIPTION
## Summary
- REPL user-message echo now renders as a true right-positioned chat bubble: width capped at 75% of the terminal (≤100 cols), text left-aligned within a common block (straight left edge), dim top rule spanning the bubble as its top edge. Previously each wrapped row was right-aligned independently at near-full width — a ragged left edge that read as broken wrapping, not a bubble.
- Spinner tip row now carries the `Tip:` label the `LoadingTip` contract documents (`💡 Tip: /agentify — Use when…`), so a harvested skill hint rendered mid-turn can't be misread as the agent rerouting the user's command.
- Tip-row truncation hardened to display-width measurement (adversarial-verify finding): wide glyphs (CJK/emoji) in a tip body could previously overflow the one-line budget ~2:1.

## Test results
- `pnpm lint` (tsc --noEmit, strict): passed
- `pnpm scan:env:check`: passed (107 vars in sync)
- `pnpm test:coverage` (CI gate, hard thresholds): 483 files — 9105 passed | 12 skipped, exit 0

## Verification
Adversarial verifier (read-only sub-agent) independently re-derived the load-bearing claims from the diff:
- **Last-column safety preserved** (no printable glyph in the terminal's final column): CONFIRM — every content row sums to exactly `cols-1` (`(rightEdge−blockW−2) + blockW + 2`); `blockW` clamped to `rightEdge−2`; separator ≤ `rightEdge`.
- **Width math closes incl. truncation branch** (ANSI/OSC-8-aware `truncateDisplayWidth`): CONFIRM.
- **Tip row stays one visual line**: REFINE — char-count truncation could overflow on wide glyphs; **resolved in this PR** (display-width truncation + CJK regression test, commit 2b34060).
- **No collateral behavior change** (bordered card kinds, non-TTY echo, single-line inline echo): CONFIRM.
- Other risks reviewed: no remaining consumers of the old fixed-30 separator width; card-path echo height flows through the compositor's physical `measure()`, so the added geometry self-corrects.

## Out of scope
- `visualRowCount` (src/cli/input/echo.ts) intentionally serves only the inline non-card path; card-path geometry is measured physically by the compositor.
