### PR TITLE
test(renderer): lock that subagent transitions can't drop the thinking paragraph (#110)

### DIFF
--- a/src/cli/_lib/stream-renderer-subagent-paragraph.test.ts
+++ b/src/cli/_lib/stream-renderer-subagent-paragraph.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Regression test for issue #110 — "route all overlay repaints through the
+ * composer to stop paragraph flicker."
+ *
+ * Invariant under test: while the orchestrator's live thinking paragraph (the
+ * `'thinking-live'` overlay slot) is active, a SUBAGENT state transition
+ * (handleSubagentEvent: tool_use_detail / tool_result / done / error) must NOT
+ * drop the thinking paragraph from the next composed overlay frame.
+ *
+ * History (the bug this pins): before the OverlayComposer migration each
+ * subagent transition called `compositor.setOverlay(toolLane.getOverlay())`
+ * directly — emitting ONLY the tool lane and clobbering the multi-row thinking
+ * paragraph, producing flicker (the paragraph blanked on the subagent's
+ * repaint, then repainted on the next orchestrator-composed frame). Under
+ * parallel subagents firing repaints at independent cadences the blank/repaint
+ * cycle was continuous.
+ *
+ * The fix: every subagent callsite routes through
+ * `overlayComposer.markDirty('tool-lane') + flush()` when a composer is wired.
+ * `flush()` recomposes ALL active slots in z-order (overlay-composer.ts), so
+ * the `'thinking-live'` slot is preserved alongside the tool lane. This test
+ * pins that at the INTEGRATION level: it drives the real `handleSubagentEvent`
+ * against a real `OverlayComposer` wired through the production
+ * `registerOverlaySlots`. If a future change reverts a subagent callsite to a
+ * bare tool-lane `setOverlay`, the composed frame loses the `◆ thinking`
+ * header and these tests fail. The `control` test proves the assertion
+ * genuinely discriminates the fix from the pre-fix behavior.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  handleSubagentEvent,
+  synthesizeAgentEntry,
+  type SubagentCtx,
+} from './stream-renderer-subagent.js';
+import { freshSourceState, type SourceState } from './stream-renderer-source.js';
+import { OverlayComposer } from './overlay-composer.js';
+import { registerOverlaySlots } from './stream-renderer-lifecycle.js';
+import { ToolLane } from '../commands/interactive/tool-lane.js';
+import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
+import { createStageTracker } from '../commands/interactive/loop-stage.js';
+import { stripAnsi } from '../display.js';
+import type { Writer } from '../slash/types.js';
+import type { StreamingMarkdownRenderer } from './stream-renderer.js';
+import type { TerminalCompositor } from '../terminal-compositor.js';
+import type { OutputEvent } from '../../agent/types.js';
+
+/** The header `formatThinkingParagraph` always emits — a stable, glyph-only
+ *  marker that survives `stripAnsi` (the `◆` is a unicode char, not ANSI). */
+const PARAGRAPH_HEADER = '◆ thinking';
+
+/** Production z-order from stream-renderer.ts:427 (the constructor wiring). */
+const ORDER = [
+  'thinking-live',
+  'markdown-pending',
+  'tool-lane',
+  'progress-banner',
+  'interrupt',
+] as const;
+
+const noopWriter: Writer = {
+  line() {},
+  raw() {},
+  success() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+/**
+ * Wire a real OverlayComposer exactly as production does (registerOverlaySlots),
+ * with an ACTIVE orchestrator thinking paragraph and a shared tool lane. The
+ * composer's sink IS the (mock) compositor, so every frame the compositor
+ * receives is captured in `overlayFrames` — mirroring production where
+ * `new OverlayComposer(compositor, …)` makes the compositor the single sink.
+ */
+function setup() {
+  const overlayFrames: string[] = [];
+  const compositor = {
+    setOverlay: (t: string) => overlayFrames.push(t),
+    commitAbove: () => {},
+  } as unknown as TerminalCompositor;
+
+  // The orchestrator's live thinking lane drives the 'thinking-live' slot.
+  // A single non-whitespace push leaves it active + buffered, so
+  // formatThinkingParagraph(peekPhase()) renders a non-empty paragraph.
+  const thinkingLane = new ThinkingLane();
+  thinkingLane.push(
+    'Investigating why the overlay paragraph flickers under parallel subagents.',
+  );
+
+  const toolLane = new ToolLane();
+
+  const overlayComposer = new OverlayComposer(compositor, [...ORDER]);
+  registerOverlaySlots(overlayComposer, {
+    stageTracker: createStageTracker(),
+    thinkingMode: 'live',
+    thinkingLane,
+    streamingMarkdownRef: { current: null },
+    toolLane,
+    lastProgressByTask: new Map(),
+    getInterrupting: () => false,
+  });
+
+  const ctx: SubagentCtx = {
+    isTTY: true,
+    compositor,
+    overlayComposer,
+    toolLane,
+    out: noopWriter,
+    streamingMarkdown: new Map<string, StreamingMarkdownRenderer>(),
+    thinkingMode: 'summary',
+  };
+
+  return { overlayFrames, compositor, thinkingLane, toolLane, overlayComposer, ctx };
+}
+
+function chunkEvent(chunk: Record<string, unknown>): OutputEvent {
+  return { type: 'chunk', chunk } as unknown as OutputEvent;
+}
+
+describe('issue #110 — subagent transitions preserve the orchestrator thinking paragraph', () => {
+  it('keeps the thinking paragraph in every frame across tool_use_detail → tool_result → done', () => {
+    const { overlayFrames, thinkingLane, ctx } = setup();
+
+    // Precondition: the thinking-live slot is genuinely active and renderable.
+    expect(thinkingLane.isActive()).toBe(true);
+    expect(thinkingLane.hasBufferedContent()).toBe(true);
+
+    // A subagent appears under the orchestrator — synthesize its parent
+    // `Agent(...)` row in the shared tool lane (handleSubagentEvent early-
+    // returns without a syntheticAgentToolUseId).
+    const source: SourceState = freshSourceState('verifier');
+    synthesizeAgentEntry('sub-1', source, ctx, undefined);
+
+    const transitions: Array<{ label: string; event: OutputEvent }> = [
+      {
+        label: 'tool_use_detail',
+        event: chunkEvent({
+          type: 'tool_use_detail',
+          toolUseId: 't1',
+          toolName: 'bash',
+          toolInput: '("ls")',
+        }),
+      },
+      {
+        label: 'tool_result',
+        event: chunkEvent({
+          type: 'tool_result',
+          toolUseId: 't1',
+          content: 'ok',
+          isError: false,
+        }),
+      },
+      { label: 'done', event: { type: 'done' } as unknown as OutputEvent },
+    ];
+
+    for (const { label, event } of transitions) {
+      const before = overlayFrames.length;
+      handleSubagentEvent(event, 'sub-1', source, ctx);
+
+      // Each discrete transition is unthrottled → fires exactly one composed
+      // frame through the composer's single setOverlay sink.
+      expect(overlayFrames.length, `${label} produced no overlay frame`).toBeGreaterThan(before);
+
+      const frame = stripAnsi(overlayFrames.at(-1) ?? '');
+      expect(
+        frame,
+        `frame after subagent ${label} dropped the orchestrator thinking paragraph`,
+      ).toContain(PARAGRAPH_HEADER);
+    }
+
+    // Sanity: the subagent's tool actually composed into the same frame (it is
+    // a real composed overlay, not just the paragraph in isolation).
+    expect(stripAnsi(overlayFrames.at(-1) ?? '')).toContain('bash');
+  });
+
+  it('keeps the thinking paragraph when a subagent transition ends in error', () => {
+    const { overlayFrames, ctx } = setup();
+
+    const source: SourceState = freshSourceState('verifier');
+    synthesizeAgentEntry('sub-err', source, ctx, undefined);
+
+    handleSubagentEvent(
+      chunkEvent({ type: 'tool_use_detail', toolUseId: 'e1', toolName: 'bash', toolInput: '("boom")' }),
+      'sub-err',
+      source,
+      ctx,
+    );
+
+    const before = overlayFrames.length;
+    handleSubagentEvent(
+      { type: 'error', error: new Error('subagent blew up') } as unknown as OutputEvent,
+      'sub-err',
+      source,
+      ctx,
+    );
+
+    expect(overlayFrames.length, 'error produced no overlay frame').toBeGreaterThan(before);
+    expect(
+      stripAnsi(overlayFrames.at(-1) ?? ''),
+      'error frame dropped the orchestrator thinking paragraph',
+    ).toContain(PARAGRAPH_HEADER);
+  });
+
+  it('control: the pre-fix bare tool-lane overlay would NOT contain the paragraph', () => {
+    // Proves the assertion in the tests above is load-bearing: a bare
+    // `setOverlay(toolLane.getOverlay())` (the regression) emits only the tool
+    // lane, which never carries the `◆ thinking` header. So a passing
+    // assertion above can ONLY mean the composer recomposed the thinking slot.
+    const { toolLane, ctx } = setup();
+    const source: SourceState = freshSourceState('verifier');
+    synthesizeAgentEntry('sub-ctrl', source, ctx, undefined);
+    handleSubagentEvent(
+      chunkEvent({ type: 'tool_use_detail', toolUseId: 'c1', toolName: 'bash', toolInput: '("ls")' }),
+      'sub-ctrl',
+      source,
+      ctx,
+    );
+
+    const bareOverlay = stripAnsi(toolLane.getOverlay());
+    expect(bareOverlay).toContain('bash'); // the tool lane is non-empty…
+    expect(bareOverlay).not.toContain(PARAGRAPH_HEADER); // …but never carries the paragraph
+  });
+});


### PR DESCRIPTION
Closes #110.

## TL;DR

The paragraph-flicker fix #110 asks for **already landed** with the
`OverlayComposer` migration. This PR closes the one remaining **open**
acceptance item — the regression test — and records the audit confirming the
production routing is complete.

## What #110 was

Subagent state transitions (and a few orchestrator paths) called
`compositor.setOverlay(toolLane.getOverlay())` **directly**, emitting only the
tool lane and clobbering the orchestrator's multi-row live "thinking paragraph"
between composed frames → visible flicker, worst under parallel subagents
repainting at independent cadences. (The line numbers in the issue are stale —
they predate the `OverlayComposer` migration.)

## Why no production code change is needed

The `OverlayComposer` is now the **single writer** of `compositor.setOverlay`
during a live turn (`overlay-composer.ts`). Every non-test `setOverlay`
callsite is composer-guarded:

```
if (ctx.overlayComposer) { ctx.overlayComposer.markDirty('tool-lane'); ctx.overlayComposer.flush(); }
else if (ctx.compositor) { ctx.compositor.setOverlay(ctx.toolLane.getOverlay()); }   // no-composer fallback only
```

- `stream-renderer-subagent.ts` — tool_use_detail / tool_result / tool_diff / content / thinking / error paths
- `stream-renderer-subagent-helpers.ts` — `finalizeSubagent` (done row)
- `stream-renderer-orchestrator-emit.ts` — `flushToolLaneToScrollback` + the before-content commit
- `stream-renderer.ts` — after-subagent commit + dispose safety-net
- `markdown-stream.ts` / `markdown-stream-format.ts` — markdown-pending slot

`OverlayComposer.flush()` recomposes **all** active slots in z-order, and the
production composer registers `thinking-live` first
(`stream-renderer.ts:427` + `registerOverlaySlots` in
`stream-renderer-lifecycle.ts`). So `markDirty('tool-lane') + flush()` always
re-emits the thinking paragraph alongside the tool lane — no clobber, no
flicker. The bare `setOverlay(...)` calls only run when **no** composer is
wired (tests / non-TTY), where there is no flicker concern and the subagent ctx
lacks the orchestrator's thinking/progress state anyway.

## Acceptance criteria

- [x] No callsite clobbers the composed frame in production — all route through the composer; bare `setOverlay(toolLane.getOverlay())` is the no-composer fallback only.
- [x] Subagent thinking tail still renders in the ToolLane row (no behavior change) — `setThinkingTail` paths untouched.
- [x] Existing tests pass; **added** a test that subagent state transitions don't drop the orchestrator's thinking paragraph from the next overlay frame.
- [x] Explicit `setOverlay('')` clears audited: live-turn clears (`markdown-stream.ts`, `stream-renderer.ts` borrow-dispose) route through the composer; the only bare clears are the no-composer fallback and the idle `/clear` path (`bootstrap.ts`) — both intentional.

## The test (`stream-renderer-subagent-paragraph.test.ts`)

Integration-level, production-faithful:
1. Wires a real `OverlayComposer` via the production `registerOverlaySlots`, with an **active** orchestrator thinking paragraph + a shared `ToolLane`. The composer's sink is the (mock) compositor, so every captured frame is exactly what production would paint.
2. Drives the **real** `handleSubagentEvent` through `tool_use_detail → tool_result → done`, and separately through `tool_use_detail → error`.
3. Asserts every composed frame still contains the `◆ thinking` header.
4. **Control** test proves the assertion discriminates: a bare tool-lane overlay never carries the paragraph header.

**Mutation-tested:** reverting a subagent callsite to a bare
`setOverlay(toolLane.getOverlay())` fails the test with the exact
"dropped the orchestrator thinking paragraph" diagnostic.

## Verification

- New test: 3/3 green
- `src/cli/_lib/` suite: 307/307 green
- `pnpm lint` (tsc --noEmit, strict): clean
