### PR TITLE
test(compose): strengthen per-node credential resolution coverage (port afk-workshop#643)

### DIFF
--- a/src/agent/tools/compose-executor.test.ts
+++ b/src/agent/tools/compose-executor.test.ts
@@ -1431,16 +1431,22 @@ describe('ComposeExecutor', () => {
       expect(dagOpts.nodes[0].apiKey).toBe('session-anthropic-token');
     });
 
-    it('falls back to ctx.apiKey when no resolver is injected (backward compat)', async () => {
-      // Pre-fix behavior: no resolver → node inherits ctx.apiKey verbatim.
+    it('falls back to ctx.apiKey when no resolver is injected and providers differ (cross-provider no-resolver else arm, backward compat only — production always injects a resolver)', async () => {
+      // Exercises the genuine else arm: cross-provider (OpenAI parent, Anthropic
+      // node) with no resolver. nodeIsOpenAI=false, preserveParentApiKey=false
+      // (different providers) → falls to `else` → no resolver → ctx.apiKey.
+      // Note: without a resolver, production would forward the wrong credential
+      // (OpenAI key to an Anthropic node). This path exists for backward compat
+      // only; callers should always inject resolveApiKeyForModel.
       mockRunSubagentDAG.mockResolvedValue({ outputs: { a: 'ok' }, failed: [], skipped: [] });
       const executor = new ComposeExecutor(makeContext({
+        defaultModel: 'gpt-4o',
         apiKey: 'legacy-key',
         // no resolveApiKeyForModel
       }));
 
       await executor.execute(makeCall({
-        nodes: [{ id: 'a', prompt: 'task a' }],
+        nodes: [{ id: 'a', prompt: 'task a', model: 'sonnet' }],
       }));
 
       const dagOpts = mockRunSubagentDAG.mock.calls[0][0];
@@ -1494,6 +1500,26 @@ describe('ComposeExecutor', () => {
 
       expect(result.isError).toBeFalsy();
       expect(mockRunSubagentDAG).toHaveBeenCalledOnce();
+      const dagOpts = mockRunSubagentDAG.mock.calls[0][0];
+      expect(dagOpts.nodes[0].apiKey).toBe('anthropic-key-from-env');
+    });
+
+    it('injects no node apiKey when the resolver returns undefined for a cross-provider node (forkSubagent applies the parentApiKey fallback)', async () => {
+      // OpenAI-routed parent, Anthropic node, but the resolver finds NO Anthropic
+      // credential. The executor forwards no per-node apiKey; SubagentManager.forkSubagent
+      // then applies `config.apiKey || parentApiKey` — the same fallback the agent/skill
+      // paths use (verified parity; exercised in subagent.test.ts, out of scope here).
+      const resolveApiKeyForModel = vi.fn(() => undefined);
+      mockRunSubagentDAG.mockResolvedValue({ outputs: { a: 'ok' }, failed: [], skipped: [] });
+      const executor = new ComposeExecutor(makeContext({
+        defaultModel: 'gpt-4o',
+        apiKey: 'openai-key',
+        resolveApiKeyForModel,
+      }));
+      await executor.execute(makeCall({ nodes: [{ id: 'a', prompt: 'task a', model: 'sonnet' }] }));
+      expect(resolveApiKeyForModel).toHaveBeenCalledWith('sonnet');
+      const dagOpts = mockRunSubagentDAG.mock.calls[0][0];
+      expect(dagOpts.nodes[0].apiKey).toBeUndefined();
     });
   });
 });

--- a/src/agent/tools/compose-executor.ts
+++ b/src/agent/tools/compose-executor.ts
@@ -547,6 +547,8 @@ export class ComposeExecutor {
         );
         const nodeIsOpenAI = nodeProvider === 'openai-compatible';
         const preserveParentApiKey = this.ctx.apiKey !== undefined && nodeProvider === parentProvider;
+        // preserveParentApiKey is dead for OpenAI-routed nodes — the `nodeIsOpenAI ? undefined`
+        // branch short-circuits before it is ever read.
         // Resolve per-node credential by the node's own model when a resolver
         // is injected (fixes: Anthropic node starves under OpenAI-keyed parent).
         // Same-provider nodes keep an explicit parent/session apiKey so


### PR DESCRIPTION
## Port of afk-workshop#643 → agent-afk (moat-scrubbed; not a 1:1 copy)

**Source:** private `afk-workshop#643` — *"fix(agent): resolve compose node credentials by node model."*

**The production fix is already on `agent-afk` main — public led it.** A content diff of
private-final vs. public-HEAD shows the per-node credential logic from #643 (the
`resolveApiKeyForModel` context field, the `nodeIsOpenAI`/`preserveParentApiKey` ternary, the
keyless-guard relaxation, all five surface wirings, and the `SubagentDAGNode.apiKey` field)
already exists here. The **only** remaining delta is the test/comment hardening below — hence
this is a `test:` change, not a `fix:` (no production behavior changes).

### Ported (public-safe)
- `src/agent/tools/compose-executor.ts` — one clarifying comment, **no logic change**: notes
  `preserveParentApiKey` is dead for OpenAI-routed nodes (`nodeIsOpenAI ? undefined`
  short-circuits first).
- `src/agent/tools/compose-executor.test.ts` — three test improvements:
  - retarget the no-resolver test to the genuine **cross-provider else arm** (it previously
    traversed the same-provider `preserveParentApiKey` branch);
  - strengthen the keyless-parent test to assert the resolved key reaches the node;
  - add coverage for the **resolver-returns-`undefined` cross-provider** path (executor forwards
    no node apiKey → `forkSubagent` applies the `config.apiKey || parentApiKey` fallback — parity
    with the agent/skill paths).

### Dropped (and why)
- `src/cli/commands/{chat,daemon,interactive/bootstrap}.ts`, `src/telegram.ts` — #643's 2-line
  wiring per file is **already present** on public; their remaining differences are pre-existing
  repo divergence, not part of this fix → not ported.
- `src/agent/dag-subagent.ts` — already **identical** on public → nothing to port.
- `src/threads/create-session-factory.ts` — `src/threads*` is a moat-private surface, **absent**
  from public → dropped.

### Verification (all clean)
- `pnpm install --frozen-lockfile` ✓ · `pnpm lint` (tsc --noEmit) ✓ · `pnpm build` + `build:dist` ✓
- `vitest run compose-executor.test.ts` → **78/78** ✓ · `fix:pins:check` → no drift ✓
- Deterministic moat guard (tree + `dist/`) → **✅ MOAT GUARD CLEAN**
- Independent adversarial moat audit → **CLEAN** (added lines, file scope, tree structure, dist)

**Please do not merge automatically — left for human review.**
