### PR TITLE
test(tool-lane): cover extraDepth>=2 spine rendering (closes #20)

### DIFF
--- a/src/cli/commands/interactive/tool-lane.test.ts
+++ b/src/cli/commands/interactive/tool-lane.test.ts
@@ -2924,6 +2924,53 @@ describe('ToolLane.flushSource — nesting-aware indent', () => {
     expect(lane.hasEntry('outer-agent')).toBe(true);
   });
 
+  it('issue #20: extraDepth≥2 (outer-skill → inner-skill → agent → child-tool) emits 2-unit head + 3-unit child rows', () => {
+    // Coverage for the tool-lane-render flush-path formatters
+    // (formatAgentHeader / formatAgentChildren, which prepend `extraDepth`
+    // spine units) at extraDepth ≥ 2. The rest of the suite only exercised
+    // extraDepth 0 and 1; a miscount at depth ≥2 would otherwise slip past CI.
+    //
+    // Topology is the issue's exact shape — an outer skill spawns an inner
+    // skill, which spawns an Agent, which runs a leaf tool. flushSource is the
+    // live REPL's settle-subtree-to-scrollback path; with both skill ancestors
+    // still open, each LIVE ancestor prepends one spine unit, so the agent head
+    // lands at two units (`│ │ ◉ `) and its children at three (`│ │ │ …`).
+    const lane = new ToolLane();
+    lane.addStartWithAgentContext('outer-skill', 'skill', '(devils-advocate)', undefined);
+    lane.addStartWithAgentContext('inner-skill', 'skill', '(compete)', 'outer-skill');
+    lane.addStartWithAgentContext('agent', 'Agent', '(critic-pragmatist)', 'inner-skill');
+    lane.addStartWithAgentContext('child-tool', 'Read', '("x.ts")', 'agent');
+    lane.addResult('child-tool', makeResult('1 line'));
+    lane.setAgentResultSummary('agent', 'Done (1 tools)');
+    lane.addResult('agent', makeResult('done'));
+
+    // Two live ancestors → eager ancestor headers + agent block:
+    //   [0] outer-skill header (depth 0 → ◉ at col 0)
+    //   [1] inner-skill header (depth 1 → │ ◉)
+    //   [2] agent block (depth 2 → │ │ ◉ head, │ │ │ … children)
+    const flushed = lane.flushSource('agent');
+    expect(flushed).toHaveLength(3);
+
+    const block = stripAnsi(flushed[2]!);
+    const rows = block.split('\n');
+    const headRow = rows[0]!;
+    const childRow = rows.find((r) => r.includes('Read'));
+
+    // ask #3: agent head row = two leading spine units + agent glyph.
+    expect(headRow.startsWith('│ │ ◉ '), `head row: ${JSON.stringify(headRow)}`).toBe(true);
+
+    // ask #4: child-tool row = three leading spine units + branch connector.
+    expect(childRow, `child row missing in block:\n${block}`).toBeDefined();
+    expect(
+      /^│ │ │ [├╰]─/.test(childRow!),
+      `child row: ${JSON.stringify(childRow)}`,
+    ).toBe(true);
+
+    // Both skill ancestors survive the flush (only the agent subtree settled).
+    expect(lane.hasEntry('outer-skill')).toBe(true);
+    expect(lane.hasEntry('inner-skill')).toBe(true);
+  });
+
   it('dangling agentContext (parent already gone from lane) renders at root', () => {
     const lane = new ToolLane();
     // Subagent claims agentContext pointing at an id that does NOT exist


### PR DESCRIPTION
## Summary

Closes #20.

- Adds one vitest case to `tool-lane.test.ts` (in the `ToolLane.flushSource — nesting-aware indent` block) that exercises the tool-lane-render flush-path formatters at **extraDepth ≥ 2** — the rest of the suite only covered depth 0 and 1, so a spine-unit miscount at depth ≥2 would have slipped past CI.
- The fixture builds issue #20's exact topology — outer-skill → inner-skill → agent → child-tool — flushes via the live REPL `flushSource` path, and asserts:
  - **ask #3:** the agent head row starts with `│ │ ◉ ` (two leading spine units + agent glyph),
  - **ask #4:** the child-tool row matches `^│ │ │ [├╰]─` (three leading spine units + branch connector).
- The depth-2 **child-row** prefix assertion (ask #4) was the only genuinely uncovered sliver; asks #1–#3 were already satisfied by pre-existing tests (`grandchild subagent finishing inside Agent inside skill`, `tool-lane-nested-spine.test.ts`) that predate the issue. This PR closes the remaining gap and re-anchors all four asks against the issue's literal topology.

No production code changed — test-only, low-severity coverage hygiene (`good first issue`).

## Test results

- `pnpm test` (`vitest run`): **9110 passed | 12 skipped (9122)** across 484 files — exit 0.
- `pnpm lint` (`tsc --noEmit`, strict): exit 0.
- Targeted: the new `issue #20` case passes; full `tool-lane.test.ts` (148 tests) passes.

## Verification

No adversarial verify requested (diff is 47 lines, under the 100-line threshold and no `--verify` flag).
