### PR TITLE
feat(skills): enforce tools: allowlist in plugin-skill dispatch (#108)

### DIFF
--- a/src/agent/plugins/tool-injector.test.ts
+++ b/src/agent/plugins/tool-injector.test.ts
@@ -395,4 +395,72 @@ description: No body
       expect(extractPluginName('/some/random/path/plugin-name')).toBe('plugin-name');
     });
   });
+
+  describe('tools: frontmatter allowlist parsing', () => {
+    function writeSkillFile(dir: string, frontmatter: string): void {
+      const fs = require('fs');
+      fs.mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, 'SKILL.md'),
+        `---\nname: allowlist-test\ndescription: A test skill\n${frontmatter}---\nContent`,
+      );
+    }
+
+    it('parses comma-separated tools: field', () => {
+      const skillDir = join(tmpDir, 'skills', 'comma-sep');
+      writeSkillFile(skillDir, 'tools: read_file, grep, glob\n');
+      const skills = extractPluginSkills(tmpDir);
+      expect(skills[0]!.allowedTools).toEqual(['read_file', 'grep', 'glob']);
+    });
+
+    it('parses bracket-array tools: field', () => {
+      const skillDir = join(tmpDir, 'skills', 'bracket-arr');
+      writeSkillFile(skillDir, 'tools: [read_file, grep]\n');
+      const skills = extractPluginSkills(tmpDir);
+      expect(skills[0]!.allowedTools).toEqual(['read_file', 'grep']);
+    });
+
+    it('silently drops unknown tool names', () => {
+      const skillDir = join(tmpDir, 'skills', 'unknown-tools');
+      writeSkillFile(skillDir, 'tools: read_file, not_a_tool, grep\n');
+      const skills = extractPluginSkills(tmpDir);
+      expect(skills[0]!.allowedTools).toEqual(['read_file', 'grep']);
+    });
+
+    it('deduplicates repeated tool names', () => {
+      const skillDir = join(tmpDir, 'skills', 'dedup-tools');
+      writeSkillFile(skillDir, 'tools: read_file, read_file, grep\n');
+      const skills = extractPluginSkills(tmpDir);
+      expect(skills[0]!.allowedTools).toEqual(['read_file', 'grep']);
+    });
+
+    it('omits allowedTools when all names are unknown', () => {
+      const skillDir = join(tmpDir, 'skills', 'all-unknown');
+      writeSkillFile(skillDir, 'tools: not_a_tool\n');
+      const skills = extractPluginSkills(tmpDir);
+      expect(skills[0]!.allowedTools).toBeUndefined();
+    });
+
+    it('omits allowedTools when tools: field is absent', () => {
+      const skillDir = join(tmpDir, 'skills', 'no-tools-field');
+      writeSkillFile(skillDir, '');
+      const skills = extractPluginSkills(tmpDir);
+      expect(skills[0]!.allowedTools).toBeUndefined();
+    });
+
+    it('tools: and read-only: true coexist; both are parsed into metadata', () => {
+      const skillDir = join(tmpDir, 'skills', 'coexist');
+      writeSkillFile(skillDir, 'tools: read_file\nread-only: true\n');
+      const skills = extractPluginSkills(tmpDir);
+      expect(skills[0]!.allowedTools).toEqual(['read_file']);
+      expect(skills[0]!.readOnly).toBe(true);
+    });
+
+    it('handles quoted values', () => {
+      const skillDir = join(tmpDir, 'skills', 'quoted');
+      writeSkillFile(skillDir, 'tools: "read_file, grep"\n');
+      const skills = extractPluginSkills(tmpDir);
+      expect(skills[0]!.allowedTools).toEqual(['read_file', 'grep']);
+    });
+  });
 });

--- a/src/agent/plugins/tool-injector.ts
+++ b/src/agent/plugins/tool-injector.ts
@@ -13,6 +13,8 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
 import type { AnthropicToolDef } from '../providers/anthropic-direct/types.js';
 import type { SdkPluginConfig } from '../types/sdk-types.js';
+import { BUILTIN_TOOL_NAMES } from '../tools/schemas.js';
+import { debugLog } from '../../utils/debug.js';
 
 /**
  * Metadata extracted from a skill's SKILL.md frontmatter, plus the body.
@@ -37,6 +39,14 @@ export interface PluginSkillMetadata {
    * dispatcher's `readOnlyBash` gate.
    */
   readOnly?: boolean;
+  /**
+   * Enumerated tool allowlist from the `tools:` frontmatter field. When set,
+   * the forked subagent receives exactly this tool surface. Validated against
+   * BUILTIN_TOOL_NAMES at parse time; unknown names are silently dropped.
+   * Takes no effect when `readOnly: true` (RECON_ALLOWED_TOOLS takes precedence).
+   * Only applies to `context: fork` skills — loaded skills run in the caller's context.
+   */
+  allowedTools?: string[];
   /** Markdown content after the frontmatter closing `---`. */
   body?: string;
   /**
@@ -162,6 +172,27 @@ function parseSkillMetadata(skillPath: string): PluginSkillMetadata {
         // child's write tools.
         const raw = value.replace(/^["']|["']$/g, '').trim();
         if (raw === 'true') metadata.readOnly = true;
+      } else if (key === 'tools') {
+        // Parse both inline-string (`tools: read_file, grep`) and
+        // inline YAML sequence (`tools: [read_file, grep]`) forms.
+        // Block-form (`- read_file\n- grep`) is out of scope — the scanner
+        // does not support multi-line values.
+        const raw = value.replace(/^["']|["']$/g, '');
+        const stripped = raw.replace(/^\[|\]$/g, ''); // strip bracket-array wrapper
+        const tokens = stripped.split(',').map((t) => t.trim()).filter(Boolean);
+        const validSet = new Set(BUILTIN_TOOL_NAMES);
+        const filtered: string[] = [];
+        for (const token of tokens) {
+          if (validSet.has(token)) {
+            filtered.push(token);
+          } else {
+            debugLog(`[tool-injector] parseSkillMetadata: unknown tool name in tools: "${token}" — dropped`);
+          }
+        }
+        const deduped = [...new Set(filtered)];
+        if (deduped.length > 0) {
+          metadata.allowedTools = deduped;
+        }
       }
     }
 

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -221,6 +221,25 @@ export function buildReadOnlyReconProvider(model: AgentModelInput | undefined): 
 }
 
 /**
+ * Build a minimal provider with a custom tool allowlist for the depth-cap
+ * fallback path. Mirrors {@link buildReadOnlyReconProvider} but omits the
+ * `readOnlyBash` and `readOnlyMemory` flags — only tool-surface restriction.
+ * Used when a skill declares `tools:` (without `read-only: true`) and the
+ * provider factory is unavailable (depth cap or no factory configured).
+ */
+export function buildCustomAllowlistProvider(
+  model: AgentModelInput | undefined,
+  allowedTools: string[],
+): ModelProvider {
+  const permissions = { allowedTools: [...allowedTools] };
+  const route = providerForModel(typeof model === 'string' ? model : undefined);
+  if (route === 'openai-compatible') {
+    return new OpenAICompatibleProvider({ permissions });
+  }
+  return new AnthropicDirectProvider({ permissions });
+}
+
+/**
  * Build a depth-aware factory that produces a {@link SkillExecutor} for a
  * grandchild session at the given `depth`.
  *

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -461,12 +461,12 @@ describe('discoverPluginSkillBodies', () => {
     }
   });
 
-  function writeSkill(pluginPath: string, skillName: string, body: string): void {
+  function writeSkill(pluginPath: string, skillName: string, body: string, extraFrontmatter = ''): void {
     const dir = join(pluginPath, 'skills', skillName);
     mkdirSync(dir, { recursive: true });
     writeFileSync(
       join(dir, 'SKILL.md'),
-      `---\nname: ${skillName}\ndescription: A test skill\n---\n${body}\n`,
+      `---\nname: ${skillName}\ndescription: A test skill\n${extraFrontmatter}---\n${body}\n`,
     );
   }
 
@@ -510,6 +510,30 @@ describe('discoverPluginSkillBodies', () => {
   it('returns empty map when no plugins yield skills', () => {
     const bodies = discoverPluginSkillBodies([]);
     expect(bodies.size).toBe(0);
+  });
+
+  it('propagates allowedTools from PluginSkillMetadata when tools: is set', () => {
+    const pluginA = join(tmpDir, 'plugin-tools');
+    mkdirSync(pluginA, { recursive: true });
+    writeSkill(pluginA, 'tools-skill', '# Body', 'tools: read_file, grep\n');
+
+    const bodies = discoverPluginSkillBodies([{ type: 'local', path: pluginA }]);
+
+    const entry = bodies.get('tools-skill');
+    expect(entry).toBeDefined();
+    expect(entry?.allowedTools).toEqual(['read_file', 'grep']);
+  });
+
+  it('leaves allowedTools undefined when tools: is absent', () => {
+    const pluginA = join(tmpDir, 'plugin-no-tools');
+    mkdirSync(pluginA, { recursive: true });
+    writeSkill(pluginA, 'no-tools-skill', '# Body');
+
+    const bodies = discoverPluginSkillBodies([{ type: 'local', path: pluginA }]);
+
+    const entry = bodies.get('no-tools-skill');
+    expect(entry).toBeDefined();
+    expect(entry?.allowedTools).toBeUndefined();
   });
 });
 

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -186,6 +186,14 @@ export interface PluginSkillBody {
    * Absent → historical full-write fork.
    */
   readOnly?: boolean;
+  /**
+   * Enumerated tool allowlist parsed from SKILL.md `tools:` frontmatter.
+   * Forwarded from {@link PluginSkillMetadata.allowedTools} by
+   * {@link discoverPluginSkillBodies}. When set and the skill has
+   * `context: fork`, the forked child's provider receives exactly this
+   * tool surface. Absent → full {@link CHILD_ALLOWED_TOOLS} (backward-compat).
+   */
+  allowedTools?: string[];
 }
 
 /**
@@ -227,6 +235,7 @@ export function discoverPluginSkillBodies(
           pluginPath: plugin.path,
           ...(skill.context !== undefined ? { context: skill.context } : {}),
           ...(skill.readOnly === true ? { readOnly: true } : {}),
+          ...(skill.allowedTools !== undefined ? { allowedTools: skill.allowedTools } : {}),
         });
       }
     }

--- a/src/agent/tools/skill-executor.test.ts
+++ b/src/agent/tools/skill-executor.test.ts
@@ -1761,6 +1761,178 @@ describe('SkillExecutor', () => {
     });
   });
 
+  describe('tools: frontmatter allowlist enforcement', () => {
+    function captureForkConfig(): { mockForkSubagent: ReturnType<typeof vi.fn> } {
+      const mockForkSubagent = vi.fn().mockResolvedValue({
+        runToResult: vi.fn().mockResolvedValue({
+          status: 'succeeded',
+          message: { content: 'ok' },
+        }),
+        teardown: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.spyOn(SubagentManager.prototype, 'forkSubagent').mockImplementation(mockForkSubagent);
+      vi.spyOn(SubagentManager.prototype, 'teardownAll').mockResolvedValue(undefined);
+      return { mockForkSubagent };
+    }
+
+    it('passes custom allowedTools to the factory for a plugin skill with tools: field', async () => {
+      const { mockForkSubagent } = captureForkConfig();
+      const childProviderFactory = vi.fn().mockReturnValue({ name: 'sentinel' });
+
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'p',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        pluginConfigs: undefined,
+        childProviderFactory: childProviderFactory as never,
+      });
+
+      // Stub a plugin skill body with a custom tools: allowlist.
+      const body: PluginSkillBody = {
+        body: 'fake plugin body',
+        pluginPath: '/fake/plugin',
+        context: 'fork',
+        allowedTools: ['read_file', 'grep', 'glob'],
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (executor as any).pluginBodies = new Map([['tools-skill', body]]);
+
+      await executor.execute(makeCall({ name: 'tools-skill', arguments: 'go' }));
+
+      expect(mockForkSubagent).toHaveBeenCalledOnce();
+      const factoryArgs = childProviderFactory.mock.calls[0]?.[0];
+      expect(factoryArgs?.allowedTools).toEqual(['read_file', 'grep', 'glob']);
+      // Not a read-only skill — no bash gate.
+      expect(factoryArgs?.readOnlyBash).toBeUndefined();
+    });
+
+    it('does NOT set allowedTools when tools: is absent', async () => {
+      captureForkConfig();
+      const childProviderFactory = vi.fn().mockReturnValue({ name: 'sentinel' });
+
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'p',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        pluginConfigs: undefined,
+        childProviderFactory: childProviderFactory as never,
+      });
+
+      const body: PluginSkillBody = {
+        body: 'fake plugin body',
+        pluginPath: '/fake/plugin',
+        context: 'fork',
+        // allowedTools intentionally absent
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (executor as any).pluginBodies = new Map([['no-tools-field', body]]);
+
+      await executor.execute(makeCall({ name: 'no-tools-field' }));
+
+      const factoryArgs = childProviderFactory.mock.calls[0]?.[0];
+      // No custom allowlist — factory falls back to CHILD_ALLOWED_TOOLS (full write surface).
+      expect(factoryArgs?.allowedTools).toBeUndefined();
+    });
+
+    it('read-only: true takes precedence over tools:', async () => {
+      captureForkConfig();
+      const childProviderFactory = vi.fn().mockReturnValue({ name: 'sentinel' });
+
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'p',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        pluginConfigs: undefined,
+        childProviderFactory: childProviderFactory as never,
+      });
+
+      // Skill has BOTH readOnly: true and allowedTools: [...]; readOnly wins.
+      const body: PluginSkillBody = {
+        body: 'fake plugin body',
+        pluginPath: '/fake/plugin',
+        context: 'fork',
+        readOnly: true,
+        allowedTools: ['read_file'],
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (executor as any).pluginBodies = new Map([['readonly-wins', body]]);
+
+      await executor.execute(makeCall({ name: 'readonly-wins' }));
+
+      const factoryArgs = childProviderFactory.mock.calls[0]?.[0];
+      // read-only takes precedence: factory receives RECON allowlist, not the custom one.
+      expect(factoryArgs?.allowedTools).toEqual([...RECON_ALLOWED_TOOLS]);
+      expect(factoryArgs?.readOnlyBash).toBe(true);
+    });
+
+    it('depth-cap fallback: custom allowedTools applied when no factory', async () => {
+      const { mockForkSubagent } = captureForkConfig();
+      // No childProviderFactory — depth-cap fallback path.
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'p',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        // childProviderFactory intentionally omitted.
+      });
+
+      const body: PluginSkillBody = {
+        body: 'fake plugin body',
+        pluginPath: '/fake/plugin',
+        context: 'fork',
+        allowedTools: ['read_file', 'grep'],
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (executor as any).pluginBodies = new Map([['custom-fallback', body]]);
+
+      await executor.execute(makeCall({ name: 'custom-fallback' }));
+
+      const forkCall = mockForkSubagent.mock.calls[0]?.[0];
+      // A provider IS set (the custom allowlist fallback).
+      expect(forkCall?.config?.provider).toBeDefined();
+      const provider = forkCall?.config?.provider;
+      const allowedTools: string[] | undefined = (provider as any)?.permissions?.allowedTools;
+      expect(allowedTools, 'provider must have an allowedTools list').toBeDefined();
+      expect(allowedTools).toEqual(['read_file', 'grep']);
+      // Not a read-only skill — no bash gate (provider stores false, not true).
+      expect((provider as any)?.readOnlyBash).not.toBe(true);
+    });
+
+    it('depth-cap fallback: normal skill (no tools:) gets no provider', async () => {
+      const { mockForkSubagent } = captureForkConfig();
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'p',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        // childProviderFactory intentionally omitted.
+      });
+
+      const body: PluginSkillBody = {
+        body: 'fake plugin body',
+        pluginPath: '/fake/plugin',
+        context: 'fork',
+        // No readOnly, no allowedTools.
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (executor as any).pluginBodies = new Map([['normal-fallback', body]]);
+
+      await executor.execute(makeCall({ name: 'normal-fallback' }));
+
+      const forkCall = mockForkSubagent.mock.calls[0]?.[0];
+      // Proves the `else if` guard works: no tools: and no readOnly → no provider.
+      expect(forkCall?.config?.provider).toBeUndefined();
+    });
+  });
+
   describe('ctx.dispatchSkill', () => {
     // dispatchSkill is the in-handler callback that re-enters SkillExecutor.execute
     // so built-in TS handlers can reach plugin-only skills (e.g. shadow-verify).

--- a/src/agent/tools/skill-executor.test.ts
+++ b/src/agent/tools/skill-executor.test.ts
@@ -1804,6 +1804,9 @@ describe('SkillExecutor', () => {
       expect(mockForkSubagent).toHaveBeenCalledOnce();
       const factoryArgs = childProviderFactory.mock.calls[0]?.[0];
       expect(factoryArgs?.allowedTools).toEqual(['read_file', 'grep', 'glob']);
+      // Materialized copy, NOT the skill body's array — guards against a
+      // shared-reference alias bleeding across sibling forks.
+      expect(factoryArgs?.allowedTools).not.toBe(body.allowedTools);
       // Not a read-only skill — no bash gate.
       expect(factoryArgs?.readOnlyBash).toBeUndefined();
     });
@@ -1930,6 +1933,95 @@ describe('SkillExecutor', () => {
       const forkCall = mockForkSubagent.mock.calls[0]?.[0];
       // Proves the `else if` guard works: no tools: and no readOnly → no provider.
       expect(forkCall?.config?.provider).toBeUndefined();
+    });
+
+    it('propagates the custom allowlist into the SubagentExecutor for depth-2 agent fan-out', async () => {
+      // Regression: a tools:-restricted skill that includes `agent` could fan
+      // out to a grandchild that silently received the full CHILD_ALLOWED_TOOLS
+      // surface — buildForkedChildConfig forwarded allowedTools into the child
+      // SubagentExecutor only on the read-only path. The custom tools: path must
+      // forward its allowlist too so the grandchild stays gated.
+      captureForkConfig();
+
+      const capturedCtorArgs: ConstructorParameters<typeof SubagentExecutorModule.SubagentExecutor>[] = [];
+      const OriginalSubagentExecutor = SubagentExecutorModule.SubagentExecutor;
+      vi.spyOn(SubagentExecutorModule, 'SubagentExecutor').mockImplementation(
+        (...args: ConstructorParameters<typeof SubagentExecutorModule.SubagentExecutor>) => {
+          capturedCtorArgs.push(args);
+          return new OriginalSubagentExecutor(...args);
+        },
+      );
+
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'p',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        defaultModel: 'sonnet',
+        childProviderFactory: vi.fn().mockReturnValue({ name: 'sentinel' }) as never,
+      });
+
+      const body: PluginSkillBody = {
+        body: 'fake plugin body',
+        pluginPath: '/fake/plugin',
+        context: 'fork',
+        allowedTools: ['read_file', 'grep', 'agent'],
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (executor as any).pluginBodies = new Map([['fanout-skill', body]]);
+
+      await executor.execute(makeCall({ name: 'fanout-skill', arguments: 'go' }));
+
+      expect(capturedCtorArgs.length).toBeGreaterThan(0);
+      const ctorOpts = capturedCtorArgs[0]?.[0];
+      // The child SubagentExecutor must carry the custom allowlist so a depth-2
+      // `agent` dispatch keeps the enumerated surface instead of widening.
+      expect(ctorOpts?.allowedTools).toEqual(['read_file', 'grep', 'agent']);
+      // Fresh copy — not the skill body's array (no shared-reference alias).
+      expect(ctorOpts?.allowedTools).not.toBe(body.allowedTools);
+      // Custom tools: does not gate bash (only read-only does).
+      expect(ctorOpts?.readOnlyBash).toBeUndefined();
+    });
+
+    it('does NOT propagate an allowlist into the SubagentExecutor for a normal skill', async () => {
+      // Back-compat guard: a skill with no tools: and no read-only must leave
+      // the child SubagentExecutor's allowedTools unset so grandchild fan-out
+      // keeps the full default surface.
+      captureForkConfig();
+
+      const capturedCtorArgs: ConstructorParameters<typeof SubagentExecutorModule.SubagentExecutor>[] = [];
+      const OriginalSubagentExecutor = SubagentExecutorModule.SubagentExecutor;
+      vi.spyOn(SubagentExecutorModule, 'SubagentExecutor').mockImplementation(
+        (...args: ConstructorParameters<typeof SubagentExecutorModule.SubagentExecutor>) => {
+          capturedCtorArgs.push(args);
+          return new OriginalSubagentExecutor(...args);
+        },
+      );
+
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'p',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        defaultModel: 'sonnet',
+        childProviderFactory: vi.fn().mockReturnValue({ name: 'sentinel' }) as never,
+      });
+
+      const body: PluginSkillBody = {
+        body: 'fake plugin body',
+        pluginPath: '/fake/plugin',
+        context: 'fork',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (executor as any).pluginBodies = new Map([['normal-fanout', body]]);
+
+      await executor.execute(makeCall({ name: 'normal-fanout' }));
+
+      expect(capturedCtorArgs.length).toBeGreaterThan(0);
+      const ctorOpts = capturedCtorArgs[0]?.[0];
+      expect(ctorOpts?.allowedTools).toBeUndefined();
     });
   });
 

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -520,12 +520,22 @@ export class SkillExecutor {
       ...(this.ctx.backgroundRegistry !== undefined
         ? { backgroundRegistry: this.ctx.backgroundRegistry }
         : {}),
-      // Propagate read-only constraints into the SubagentExecutor that will
+      // Propagate tool-surface constraints into the SubagentExecutor that will
       // handle `agent` tool calls from this skill-forked child. Without this,
       // a depth-2 fan-out (`ground-state → agent → depth-2`) loses the
       // allowlist — the grandchild SubagentExecutor's `childProviderFactory`
       // call omits allowedTools/readOnlyBash and falls back to CHILD_ALLOWED_TOOLS.
       ...(readOnly ? { allowedTools: [...RECON_ALLOWED_TOOLS], readOnlyBash: true as const } : {}),
+      // Custom `tools:` allowlist (non-read-only): forward the enumerated
+      // surface so a depth-2 `agent` fan-out from a tools:-restricted skill
+      // child keeps the same allowlist instead of silently widening back to
+      // CHILD_ALLOWED_TOOLS at the grandchild. No bash gate — custom tools:
+      // does not gate bash (only read-only does). Mutually exclusive with the
+      // read-only spread above. A fresh copy is materialized so sibling
+      // grandchild executors never alias the skill body's array.
+      ...(!readOnly && customAllowedTools !== undefined
+        ? { allowedTools: [...customAllowedTools] }
+        : {}),
     });
     const childSkillExecutor = this.ctx.childSkillExecutorFactory
       ? this.ctx.childSkillExecutorFactory(depth + 1, maxDepth, signal)
@@ -545,8 +555,13 @@ export class SkillExecutor {
       // bash (git status/log/diff for dirty-tree detection).
       ...(readOnly ? { allowedTools: [...RECON_ALLOWED_TOOLS], readOnlyBash: true } : {}),
       // Custom tools: allowlist from `tools:` frontmatter. Only applied when
-      // not read-only (read-only takes precedence via the RECON allowlist above).
-      ...(!readOnly && customAllowedTools !== undefined ? { allowedTools: customAllowedTools } : {}),
+      // not read-only (read-only takes precedence via the RECON allowlist
+      // above). Materialize a fresh copy (mirrors buildReadOnlyReconProvider /
+      // buildCustomAllowlistProvider) so the provider never aliases the skill
+      // body's array — runtime/test mutation can't bleed across sibling forks.
+      ...(!readOnly && customAllowedTools !== undefined
+        ? { allowedTools: [...customAllowedTools] }
+        : {}),
     });
 
     return { childConfig, childManager };

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_READ_ONLY_SKILLS,
   RECON_ALLOWED_TOOLS,
   buildReadOnlyReconProvider,
+  buildCustomAllowlistProvider,
   createStubParentSession,
   type ChildProviderFactoryArgs,
 } from './nesting.js';
@@ -275,6 +276,7 @@ export class SkillExecutor {
           parsed.arguments,
           call,
           readOnly,
+          pluginSkill.allowedTools,
         );
       }
       // Default: in-context LOAD (2026-06 load-by-default flip). No readOnly —
@@ -453,6 +455,10 @@ export class SkillExecutor {
     // RECON tool allowlist (no write_file/edit_file) and the mutating-bash
     // gate — on BOTH the factory path and the depth-cap/no-factory fallback.
     readOnly = false,
+    // Enumerated tool allowlist from the `tools:` frontmatter field. When set
+    // and readOnly is false, the forked child receives exactly this tool surface.
+    // Ignored when readOnly is true (RECON_ALLOWED_TOOLS takes precedence).
+    customAllowedTools?: string[],
   ): { childConfig: AgentConfig; childManager: SubagentManager | undefined } {
     const depth = this.ctx.depth ?? 0;
     const maxDepth = this.ctx.maxDepth ?? DEFAULT_MAX_NESTING_DEPTH;
@@ -466,6 +472,8 @@ export class SkillExecutor {
       // is possible at the cap anyway, so the missing executors are harmless).
       if (readOnly) {
         childConfig.provider = buildReadOnlyReconProvider(childConfig.model);
+      } else if (customAllowedTools !== undefined && customAllowedTools.length > 0) {
+        childConfig.provider = buildCustomAllowlistProvider(childConfig.model, customAllowedTools);
       }
       return { childConfig, childManager: undefined };
     }
@@ -536,6 +544,9 @@ export class SkillExecutor {
       // keeps `agent`/`skill` (so surveyor fan-out still works) and read-only
       // bash (git status/log/diff for dirty-tree detection).
       ...(readOnly ? { allowedTools: [...RECON_ALLOWED_TOOLS], readOnlyBash: true } : {}),
+      // Custom tools: allowlist from `tools:` frontmatter. Only applied when
+      // not read-only (read-only takes precedence via the RECON allowlist above).
+      ...(!readOnly && customAllowedTools !== undefined ? { allowedTools: customAllowedTools } : {}),
     });
 
     return { childConfig, childManager };
@@ -857,6 +868,9 @@ export class SkillExecutor {
     // Read-only enforcement flag, computed at the call site from the plugin
     // body's `readOnly` frontmatter OR DEFAULT_READ_ONLY_SKILLS membership.
     readOnly = false,
+    // Enumerated tool allowlist from the `tools:` frontmatter field. When set
+    // and readOnly is false, the forked child receives exactly this tool surface.
+    customAllowedTools?: string[],
   ): Promise<ToolResult> {
     if (call.signal.aborted) {
       return { content: 'Skill call aborted', isError: true };
@@ -909,6 +923,7 @@ export class SkillExecutor {
       } as AgentConfig,
       call.signal,
       readOnly,
+      customAllowedTools,
     );
 
     // Invariant: same trace-sealing rule as executeForkedRegistrySkill above.


### PR DESCRIPTION
Implements the enforcement infrastructure requested in #108.

## Summary
Plugin skills (`SKILL.md`) can now declare a `tools:` YAML frontmatter field to mechanically restrict their forked subagent to an enumerated tool surface. Calling any unlisted tool produces the standard `checkToolPermission` rejection at the provider layer — the same path already proven by `read-only: true`.

- **Parse** — `parseSkillMetadata` reads `tools:` (comma-separated *or* `[bracket, array]` form), validates each entry against `BUILTIN_TOOL_NAMES`, deduplicates, and debug-logs dropped unknown names.
- **Propagate** — `PluginSkillMetadata` / `PluginSkillBody` gain `allowedTools?: string[]`; `discoverPluginSkillBodies` forwards it.
- **Enforce** — `buildForkedChildConfig` threads a `customAllowedTools` param into both the provider-factory path and the depth-cap fallback (`buildCustomAllowlistProvider`); the allowlist is also propagated into the child `SubagentExecutor` so depth-2 `agent` fan-out stays gated.
- **Precedence / back-compat** — `read-only: true` wins over `tools:` (maps to `RECON_ALLOWED_TOOLS`); skills with no `tools:` field are unchanged (full `CHILD_ALLOWED_TOOLS`).

## Test results
- `pnpm exec tsc --noEmit` (strict): **0 errors**
- `pnpm test`: **9127 passed**, 12 skipped, **0 failed** (484 files)
- +17 tests: frontmatter parsing, bridge propagation, factory/fallback enforcement, precedence, and grandchild-propagation regressions.

## Verification
An adversarial read-only verifier independently re-derived the load-bearing claims from the diff and **CONFIRMED all three**: (1) a `tools:` skill's provider is constructed with exactly that allowlist and `edit_file` is denied; (2) skills with no `tools:` field keep the full default surface; (3) `read-only: true` takes precedence. It additionally flagged two latent gaps beyond the original acceptance criteria, both now **fixed** in the second commit (each mirrors a convention the read-only path already follows):

- **Shared-reference** — the factory path passed the allowlist array by reference; now materialized as a per-call copy (`[...customAllowedTools]`), matching `buildReadOnlyReconProvider` / `buildCustomAllowlistProvider`.
- **Grandchild escape** — the custom allowlist was not propagated into the child `SubagentExecutor`, so a `tools:`-restricted skill that includes `agent` could spawn an unconstrained grandchild. Now forwarded (no bash gate — custom `tools:` does not gate bash, only `read-only` does), covered by two new regression tests.

## Out of scope (per spec)
- Adding `tools:` frontmatter to existing bundled skills (separate follow-up).
- Output-schema enforcement for `/ground-state` — tracked as #109.

Closes #108
