### PR TITLE
feat(plugin-skills): honor `tools:` frontmatter as enforced allowlist (port afk-workshop#571)

### DIFF
--- a/src/agent/plugins/tool-injector.test.ts
+++ b/src/agent/plugins/tool-injector.test.ts
@@ -7,9 +7,11 @@
  *  - Convert skills to tool definitions
  *  - Handle missing or malformed SKILL.md files
  *  - Extract plugin name from path
+ *  - tools: frontmatter parsing (comma-separated + YAML list)
+ *  - Legacy alias normalisation (Read→read_file, Edit→edit_file, etc.)
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, writeFileSync, rmdirSync } from 'fs';
 import { join } from 'path';
 import {
@@ -17,6 +19,8 @@ import {
   extractPluginTools,
   extractAllPluginTools,
   extractPluginName,
+  normalizeToolToken,
+  parseToolsField,
 } from './tool-injector.js';
 
 describe('plugin tool injector', () => {
@@ -393,6 +397,204 @@ description: No body
 
     it('should use last component when no cache in path', () => {
       expect(extractPluginName('/some/random/path/plugin-name')).toBe('plugin-name');
+    });
+  });
+
+  // ─── tools: frontmatter parsing ─────────────────────────────────────────
+
+  describe('normalizeToolToken', () => {
+    const knownTools = new Set([
+      'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep',
+      'list_directory', 'web_scrape', 'agent', 'skill',
+    ]);
+
+    it('passes through AFK canonical names unchanged', () => {
+      expect(normalizeToolToken('read_file', knownTools)).toBe('read_file');
+      expect(normalizeToolToken('edit_file', knownTools)).toBe('edit_file');
+      expect(normalizeToolToken('bash', knownTools)).toBe('bash');
+    });
+
+    it('maps legacy Claude Code aliases case-insensitively', () => {
+      expect(normalizeToolToken('Read', knownTools)).toBe('read_file');
+      expect(normalizeToolToken('Edit', knownTools)).toBe('edit_file');
+      expect(normalizeToolToken('Write', knownTools)).toBe('write_file');
+      expect(normalizeToolToken('Bash', knownTools)).toBe('bash');
+      expect(normalizeToolToken('Grep', knownTools)).toBe('grep');
+      expect(normalizeToolToken('Glob', knownTools)).toBe('glob');
+    });
+
+    it('maps WebFetch and WebSearch to web_scrape', () => {
+      expect(normalizeToolToken('WebFetch', knownTools)).toBe('web_scrape');
+      expect(normalizeToolToken('WebSearch', knownTools)).toBe('web_scrape');
+      expect(normalizeToolToken('webfetch', knownTools)).toBe('web_scrape');
+    });
+
+    it('returns undefined for unknown tokens', () => {
+      expect(normalizeToolToken('NonExistentTool', knownTools)).toBeUndefined();
+      expect(normalizeToolToken('', knownTools)).toBeUndefined();
+    });
+
+    it('is case-insensitive for legacy aliases', () => {
+      expect(normalizeToolToken('READ', knownTools)).toBe('read_file');
+      expect(normalizeToolToken('EDIT', knownTools)).toBe('edit_file');
+      expect(normalizeToolToken('grep', knownTools)).toBe('grep');
+    });
+  });
+
+  describe('parseToolsField', () => {
+    it('parses comma-separated inline form', () => {
+      expect(parseToolsField('Read, Grep, Glob', [])).toEqual(['Read', 'Grep', 'Glob']);
+    });
+
+    it('parses comma-separated without spaces', () => {
+      expect(parseToolsField('Read,Grep,Glob', [])).toEqual(['Read', 'Grep', 'Glob']);
+    });
+
+    it('parses single-item inline form', () => {
+      expect(parseToolsField('read_file', [])).toEqual(['read_file']);
+    });
+
+    it('returns empty array for blank inline value with no YAML list', () => {
+      expect(parseToolsField('', [])).toEqual([]);
+    });
+
+    it('parses YAML list form when inline value is blank', () => {
+      const remainingLines = ['  - Read', '  - Grep', '  - Glob'];
+      expect(parseToolsField('', remainingLines)).toEqual(['Read', 'Grep', 'Glob']);
+    });
+
+    it('stops consuming YAML list at first non-list line', () => {
+      const remainingLines = ['  - Read', '  - Grep', 'description: something'];
+      expect(parseToolsField('', remainingLines)).toEqual(['Read', 'Grep']);
+    });
+  });
+
+  describe('extractPluginSkills — tools: frontmatter', () => {
+    const knownTools = new Set([
+      'bash', 'read_file', 'write_file', 'edit_file', 'glob', 'grep',
+      'list_directory', 'web_scrape', 'agent', 'skill',
+    ]);
+
+    it('parses comma-separated tools: field into allowedTools', () => {
+      const skillDir = join(tmpDir, 'skills');
+      const fs = require('fs');
+      fs.mkdirSync(skillDir, { recursive: true });
+      writeFileSync(join(skillDir, 'SKILL.md'), [
+        '---',
+        'name: research-agent',
+        'description: Read-only research skill',
+        'tools: Read, Grep, Glob',
+        '---',
+        'Research the codebase.',
+      ].join('\n'));
+
+      const skills = extractPluginSkills(tmpDir, knownTools);
+      expect(skills).toHaveLength(1);
+      expect(skills[0]!.allowedTools).toEqual(['read_file', 'grep', 'glob']);
+    });
+
+    it('parses YAML list tools: field into allowedTools', () => {
+      const skillDir = join(tmpDir, 'skills');
+      const fs = require('fs');
+      fs.mkdirSync(skillDir, { recursive: true });
+      writeFileSync(join(skillDir, 'SKILL.md'), [
+        '---',
+        'name: list-skill',
+        'description: Uses YAML list syntax',
+        'tools:',
+        '  - read_file',
+        '  - grep',
+        '  - glob',
+        '  - list_directory',
+        '---',
+        'Run the skill.',
+      ].join('\n'));
+
+      const skills = extractPluginSkills(tmpDir, knownTools);
+      expect(skills).toHaveLength(1);
+      expect(skills[0]!.allowedTools).toEqual(['read_file', 'grep', 'glob', 'list_directory']);
+    });
+
+    it('leaves allowedTools undefined when tools: is absent', () => {
+      const skillDir = join(tmpDir, 'skills');
+      const fs = require('fs');
+      fs.mkdirSync(skillDir, { recursive: true });
+      writeFileSync(join(skillDir, 'SKILL.md'), [
+        '---',
+        'name: no-tools-field',
+        'description: No tools restriction',
+        '---',
+        'Do things.',
+      ].join('\n'));
+
+      const skills = extractPluginSkills(tmpDir, knownTools);
+      expect(skills).toHaveLength(1);
+      expect(skills[0]!.allowedTools).toBeUndefined();
+    });
+
+    it('drops unknown tokens and warns to stderr', () => {
+      const skillDir = join(tmpDir, 'skills');
+      const fs = require('fs');
+      fs.mkdirSync(skillDir, { recursive: true });
+      writeFileSync(join(skillDir, 'SKILL.md'), [
+        '---',
+        'name: partial-tools',
+        'description: Some unknown tokens',
+        'tools: Read, UnknownTool, grep',
+        '---',
+        'Body.',
+      ].join('\n'));
+
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const skills = extractPluginSkills(tmpDir, knownTools);
+      stderrSpy.mockRestore();
+
+      expect(skills).toHaveLength(1);
+      // read_file and grep should be kept; UnknownTool dropped
+      expect(skills[0]!.allowedTools).toEqual(['read_file', 'grep']);
+    });
+
+    it('deduplicates repeated tools (e.g. WebFetch + WebSearch both → web_scrape)', () => {
+      const skillDir = join(tmpDir, 'skills');
+      const fs = require('fs');
+      fs.mkdirSync(skillDir, { recursive: true });
+      writeFileSync(join(skillDir, 'SKILL.md'), [
+        '---',
+        'name: dedup-skill',
+        'description: Dedup test',
+        'tools: WebFetch, WebSearch, web_scrape',
+        '---',
+        'Body.',
+      ].join('\n'));
+
+      const skills = extractPluginSkills(tmpDir, knownTools);
+      expect(skills).toHaveLength(1);
+      // All three map to web_scrape — should appear exactly once
+      expect(skills[0]!.allowedTools).toEqual(['web_scrape']);
+    });
+
+    it('sets allowedTools to [] (fail-closed) when all tokens are unknown', () => {
+      const skillDir = join(tmpDir, 'skills');
+      const fs = require('fs');
+      fs.mkdirSync(skillDir, { recursive: true });
+      writeFileSync(join(skillDir, 'SKILL.md'), [
+        '---',
+        'name: all-unknown',
+        'description: All unknown tokens',
+        'tools: Foo, Bar, Baz',
+        '---',
+        'Body.',
+      ].join('\n'));
+
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      const skills = extractPluginSkills(tmpDir, knownTools);
+      stderrSpy.mockRestore();
+
+      expect(skills).toHaveLength(1);
+      // Fail-closed invariant: when `tools:` is PRESENT but all tokens are unknown,
+      // allowedTools is [] (not undefined). This blocks all tools rather than
+      // silently falling through to the full CHILD_ALLOWED_TOOLS surface.
+      expect(skills[0]!.allowedTools).toEqual([]);
     });
   });
 });

--- a/src/agent/plugins/tool-injector.ts
+++ b/src/agent/plugins/tool-injector.ts
@@ -13,6 +13,8 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
 import type { AnthropicToolDef } from '../providers/anthropic-direct/types.js';
 import type { SdkPluginConfig } from '../types/sdk-types.js';
+import { BUILTIN_TOOL_NAMES } from '../tools/schemas.js';
+import { AWARENESS_TOOL_NAMES } from '../awareness/index.js';
 
 /**
  * Metadata extracted from a skill's SKILL.md frontmatter, plus the body.
@@ -21,6 +23,16 @@ export interface PluginSkillMetadata {
   name?: string;
   description?: string;
   argumentHint?: string;
+  /**
+   * Resolved tool allowlist parsed from the `tools:` frontmatter field.
+   *
+   * When present, only the listed tools are permitted for subagents dispatched
+   * by this skill. Names are normalized to AFK canonical form (e.g. `Read` →
+   * `read_file`, `Edit` → `edit_file`). Unknown tokens are dropped with a
+   * stderr warning. When absent, the default `CHILD_ALLOWED_TOOLS` surface
+   * applies unchanged (backward-compatible).
+   */
+  allowedTools?: string[];
   /**
    * Execution mode from the `context:` frontmatter field. The skill forks a
    * subagent ONLY when this is `'fork'`; absent/`'load'`/other values load the
@@ -50,13 +62,138 @@ export interface PluginSkillMetadata {
 }
 
 /**
+ * Canonical mapping from legacy Claude Code tool aliases (case-insensitive)
+ * to AFK tool names.
+ *
+ * Invariant: all values must be members of `BUILTIN_TOOL_NAMES` or the
+ * orchestration tools (`agent`, `skill`). Entries map both the raw form and
+ * a lowercase form so the lookup can be done on `.toLowerCase()` input.
+ */
+const LEGACY_TOOL_ALIASES: Record<string, string> = {
+  read: 'read_file',
+  edit: 'edit_file',
+  write: 'write_file',
+  bash: 'bash',
+  grep: 'grep',
+  glob: 'glob',
+  ls: 'list_directory',
+  list: 'list_directory',
+  webfetch: 'web_scrape',
+  websearch: 'web_scrape',
+  webbrowse: 'web_scrape',
+};
+
+/**
+ * Normalize a raw frontmatter tool token to its canonical AFK name.
+ *
+ * 1. Strips surrounding whitespace.
+ * 2. Tries the token as-is (already lowercase AFK names like `read_file` pass through).
+ * 3. Falls back to the legacy alias map (case-insensitive).
+ * 4. Returns `undefined` when the token is unrecognised — callers drop it and
+ *    emit a warning rather than rejecting the whole skill.
+ *
+ * @param token  Raw tool token from frontmatter (e.g. `"Read"`, `"edit_file"`)
+ * @param knownToolNames  Set of all valid tool names at normalisation time
+ */
+export function normalizeToolToken(
+  token: string,
+  knownToolNames: ReadonlySet<string>,
+): string | undefined {
+  const trimmed = token.trim();
+  if (trimmed.length === 0) return undefined;
+
+  // Direct match (AFK canonical names are already lowercase with underscores)
+  if (knownToolNames.has(trimmed)) return trimmed;
+
+  // Legacy alias lookup (case-insensitive)
+  const alias = LEGACY_TOOL_ALIASES[trimmed.toLowerCase()];
+  if (alias !== undefined && knownToolNames.has(alias)) return alias;
+
+  return undefined;
+}
+
+/**
+ * Parse a `tools:` frontmatter value into a list of raw tokens.
+ *
+ * Accepts two formats:
+ * - Inline comma-separated string: `tools: Read, Grep, Glob`
+ * - YAML sequence (one item per line, each prefixed with `- `):
+ *   ```yaml
+ *   tools:
+ *     - Read
+ *     - Grep
+ *   ```
+ *
+ * Returns an empty array when the value is blank.
+ *
+ * @param inlineValue  The text after `tools:` on the same line (may be empty)
+ * @param remainingLines  Lines following the `tools:` key in the frontmatter
+ * @returns  Raw token strings (not yet normalised or validated)
+ */
+/**
+ * Strip surrounding single or double quotes from a token.
+ * Handles `"Read"` → `Read` and `'Read'` → `Read`.
+ */
+function stripQuotes(token: string): string {
+  const t = token.trim();
+  if (
+    (t.startsWith('"') && t.endsWith('"')) ||
+    (t.startsWith("'") && t.endsWith("'"))
+  ) {
+    return t.slice(1, -1).trim();
+  }
+  return t;
+}
+
+export function parseToolsField(
+  inlineValue: string,
+  remainingLines: string[],
+): string[] {
+  const trimmedInline = inlineValue.trim();
+
+  if (trimmedInline.length > 0) {
+    // YAML flow-sequence form: `tools: [Read, Grep, Glob]`
+    if (trimmedInline.startsWith('[') && trimmedInline.endsWith(']')) {
+      const inner = trimmedInline.slice(1, -1);
+      return inner
+        .split(',')
+        .map((t) => stripQuotes(t))
+        .filter((t) => t.length > 0);
+    }
+    // Comma-separated inline form: `tools: Read, Grep, Glob`
+    // Also handles quoted-string form: `tools: "Read, Grep"`
+    const unquoted = stripQuotes(trimmedInline);
+    return unquoted.split(',').map((t) => stripQuotes(t)).filter((t) => t.length > 0);
+  }
+
+  // YAML sequence form — consume leading lines that start with `- `
+  const tokens: string[] = [];
+  for (const line of remainingLines) {
+    const stripped = line.trim();
+    if (stripped.startsWith('- ')) {
+      tokens.push(stripQuotes(stripped.slice(2)));
+    } else {
+      // First non-list-item line ends the sequence
+      break;
+    }
+  }
+  return tokens;
+}
+
+/**
  * Discover all SKILL.md files in a plugin directory and extract their metadata.
  * Recursively searches the plugin tree for SKILL.md files that have YAML frontmatter.
  *
  * @param pluginPath - Absolute path to the plugin directory
+ * @param knownToolNames - Optional set of valid tool names for `tools:` normalisation.
+ *   When omitted the full built-in + orchestration set is used by default (lazy-loaded
+ *   to avoid a hard circular-import cycle at module-load time).
  * @returns Array of discovered skill metadata
  */
-export function extractPluginSkills(pluginPath: string): PluginSkillMetadata[] {
+export function extractPluginSkills(
+  pluginPath: string,
+  knownToolNames?: ReadonlySet<string>,
+): PluginSkillMetadata[] {
   const skills: PluginSkillMetadata[] = [];
 
   function walkDirectory(dir: string, depth: number = 0): void {
@@ -82,7 +219,7 @@ export function extractPluginSkills(pluginPath: string): PluginSkillMetadata[] {
       }
 
       if (stat.isFile() && name === 'SKILL.md') {
-        const metadata = parseSkillMetadata(fullPath);
+        const metadata = parseSkillMetadata(fullPath, knownToolNames);
         if (metadata.name) {
           skills.push(metadata);
         }
@@ -105,13 +242,26 @@ export function extractPluginSkills(pluginPath: string): PluginSkillMetadata[] {
  * name: skill-name
  * description: Brief description of the skill
  * argumentHint: "[optional arguments]"
+ * tools: Read, Grep, Glob
  * ---
  * ```
  *
+ * The `tools:` field may alternatively use YAML list syntax:
+ * ```yaml
+ * tools:
+ *   - Read
+ *   - Grep
+ * ```
+ *
  * @param skillPath - Absolute path to the SKILL.md file
+ * @param knownToolNames - Set of valid AFK tool names used for normalisation.
+ *   When omitted, `resolveKnownToolNames()` is called lazily.
  * @returns Extracted metadata (returns `{ name: undefined }` if parsing fails)
  */
-function parseSkillMetadata(skillPath: string): PluginSkillMetadata {
+function parseSkillMetadata(
+  skillPath: string,
+  knownToolNames?: ReadonlySet<string>,
+): PluginSkillMetadata {
   try {
     const content = readFileSync(skillPath, 'utf-8');
 
@@ -130,7 +280,8 @@ function parseSkillMetadata(skillPath: string): PluginSkillMetadata {
     const metadata: PluginSkillMetadata = {};
 
     const lines = frontmatterText.split('\n');
-    for (const line of lines) {
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
       if (!line) continue;
 
       const colonIdx = line.indexOf(':');
@@ -145,6 +296,36 @@ function parseSkillMetadata(skillPath: string): PluginSkillMetadata {
         metadata.description = value.replace(/^["']|["']$/g, '');
       } else if (key === 'argumentHint') {
         metadata.argumentHint = value.replace(/^["']|["']$/g, '');
+      } else if (key === 'tools') {
+        // Collect the lines after this one to handle YAML list form
+        const remainingLines = lines.slice(i + 1);
+        const rawTokens = parseToolsField(value, remainingLines);
+        // Invariant: when `tools:` is PRESENT, we ALWAYS assign allowedTools — even
+        // if the result is an empty array. This is the fail-closed contract: a
+        // present-but-unparseable `tools:` MUST NOT silently fall through to the
+        // full CHILD_ALLOWED_TOOLS surface. allowedTools = [] blocks all tools.
+        // Absent `tools:` (branch never entered) → allowedTools stays undefined →
+        // full CHILD_ALLOWED_TOOLS applies (backward compat unchanged).
+        const resolved = resolveKnownToolNames(knownToolNames);
+        const normalized: string[] = [];
+        for (const token of rawTokens) {
+          const canonical = normalizeToolToken(token, resolved);
+          if (canonical !== undefined) {
+            if (!normalized.includes(canonical)) {
+              normalized.push(canonical);
+            }
+          } else {
+            process.stderr.write(
+              `[afk] plugin skill at ${skillPath}: unknown tool "${token}" in \`tools:\` frontmatter — ignored\n`,
+            );
+          }
+        }
+        if (normalized.length === 0 && rawTokens.length > 0) {
+          process.stderr.write(
+            `[afk] plugin skill at ${skillPath}: \`tools:\` declared but no valid tools resolved — subagent will be blocked from all tools\n`,
+          );
+        }
+        metadata.allowedTools = normalized;
       } else if (key === 'audience') {
         // Only accept the two well-known values — anything else is dropped
         // (and the skill defaults to public) so a typo can't accidentally
@@ -173,6 +354,26 @@ function parseSkillMetadata(skillPath: string): PluginSkillMetadata {
   } catch {
     return {};
   }
+}
+
+/**
+ * Return the effective set of known tool names for `tools:` token normalisation.
+ *
+ * When the caller provides an explicit set (tests, custom surfaces) it is used
+ * as-is. Otherwise `BUILTIN_TOOL_NAMES` (statically imported from schemas.ts)
+ * plus the orchestration tool names are used as the default.
+ */
+function resolveKnownToolNames(
+  provided?: ReadonlySet<string>,
+): ReadonlySet<string> {
+  if (provided !== undefined) return provided;
+  // 'memory_search' and 'get_runtime_state' (via AWARENESS_TOOL_NAMES) are in
+  // CHILD_ALLOWED_TOOLS but NOT in BUILTIN_TOOL_NAMES — skills that list them
+  // must be able to resolve them. 'memory_update' and 'procedure_write' are
+  // intentionally excluded (blast-radius too large for unsupervised writes).
+  // 'compose' is excluded from CHILD_ALLOWED_TOOLS (unbounded fan-out) and is
+  // not grantable to child sessions — accepting it produces a phantom allowlist entry.
+  return new Set([...BUILTIN_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, 'memory_search', 'agent', 'skill']);
 }
 
 /**

--- a/src/agent/tools/nesting.test.ts
+++ b/src/agent/tools/nesting.test.ts
@@ -3,6 +3,7 @@ import {
   CHILD_ALLOWED_TOOLS,
   RECON_ALLOWED_TOOLS,
   DEFAULT_READ_ONLY_SKILLS,
+  buildSkillRestrictedProvider,
 } from './nesting.js';
 import { checkToolPermission } from './permissions.js';
 
@@ -31,6 +32,81 @@ describe('CHILD_ALLOWED_TOOLS', () => {
   it("does NOT include 'compose'", () => {
     // compose is excluded to prevent unbounded DAG fan-out from child nodes.
     expect(CHILD_ALLOWED_TOOLS).not.toContain('compose');
+  });
+});
+
+describe('buildSkillRestrictedProvider', () => {
+  it('returns a provider without throwing for a valid allowedTools list', () => {
+    const provider = buildSkillRestrictedProvider(['read_file', 'grep', 'glob'], 'sonnet');
+    expect(provider).toBeDefined();
+    expect(typeof provider.query).toBe('function');
+  });
+
+  it('returns a provider for undefined model (falls back to Anthropic)', () => {
+    const provider = buildSkillRestrictedProvider(['read_file'], undefined);
+    expect(provider).toBeDefined();
+  });
+
+  it('returns a provider for an OpenAI-routed model', () => {
+    const provider = buildSkillRestrictedProvider(['read_file', 'bash'], 'gpt-4o');
+    expect(provider).toBeDefined();
+    expect(typeof provider.query).toBe('function');
+  });
+
+  it('enforces the allowlist via checkToolPermission on the provider permissions', () => {
+    // This test verifies the structural guarantee: permissions.allowedTools is
+    // exactly what was passed in, so the dispatcher will block disallowed tools.
+    const allowedTools = ['read_file', 'grep', 'glob', 'list_directory'];
+    // We can't call provider.query() without an API key, but we CAN verify
+    // that checkToolPermission with the same allowedTools list correctly
+    // allows/blocks tools — which is what the provider passes to the dispatcher.
+    const config = { allowedTools };
+    expect(checkToolPermission('read_file', config).allowed).toBe(true);
+    expect(checkToolPermission('grep', config).allowed).toBe(true);
+    expect(checkToolPermission('edit_file', config).allowed).toBe(false);
+    expect(checkToolPermission('write_file', config).allowed).toBe(false);
+    expect(checkToolPermission('bash', config).allowed).toBe(false);
+  });
+
+  it('does NOT include CHILD_ALLOWED_TOOLS write tools when a narrow list is given', () => {
+    // Regression guard: a skill declaring `tools: read_file, grep` must NOT
+    // silently inherit edit_file / write_file from CHILD_ALLOWED_TOOLS.
+    const narrowList = ['read_file', 'grep'];
+    const config = { allowedTools: narrowList };
+    expect(checkToolPermission('edit_file', config).allowed).toBe(false);
+    expect(checkToolPermission('write_file', config).allowed).toBe(false);
+    // But the declared tools are allowed
+    expect(checkToolPermission('read_file', config).allowed).toBe(true);
+    expect(checkToolPermission('grep', config).allowed).toBe(true);
+  });
+
+  it('blocks ALL tools when called with an empty allowlist (fail-closed enforcement)', () => {
+    // M3: end-to-end enforcement test — proves the gate fires.
+    //
+    // Invariant: buildSkillRestrictedProvider([]) produces a provider whose
+    // permissions.allowedTools = [] which causes checkToolPermission to deny
+    // every tool. This is the fail-closed contract: a SKILL.md `tools:` field
+    // that resolves to zero valid tools MUST block everything, not silently grant
+    // full CHILD_ALLOWED_TOOLS access.
+    //
+    // We drive the enforcement through checkToolPermission with the same
+    // allowedTools list the provider would pass to the dispatcher — the
+    // same seam used by the existing 'enforces the allowlist via checkToolPermission'
+    // test above, and the cleanest no-network path available.
+    const provider = buildSkillRestrictedProvider([], 'sonnet');
+    expect(provider).toBeDefined();
+
+    // The provider passes { allowedTools: [] } to the dispatcher via its
+    // permissions field. Verify that checkToolPermission correctly blocks
+    // every tool when the list is empty.
+    const config = { allowedTools: [] as string[] };
+    expect(checkToolPermission('read_file', config).allowed).toBe(false);
+    expect(checkToolPermission('grep', config).allowed).toBe(false);
+    expect(checkToolPermission('edit_file', config).allowed).toBe(false);
+    expect(checkToolPermission('bash', config).allowed).toBe(false);
+    expect(checkToolPermission('write_file', config).allowed).toBe(false);
+    expect(checkToolPermission('agent', config).allowed).toBe(false);
+    expect(checkToolPermission('skill', config).allowed).toBe(false);
   });
 });
 

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -298,6 +298,31 @@ export function createChildSkillExecutorFactory(
 export type PhaseRole = 'read-only' | 'read-write';
 
 /**
+ * Build a provider whose `permissions.allowedTools` is restricted to the
+ * explicit `allowedTools` list parsed from a plugin SKILL.md `tools:` field.
+ *
+ * Invariant: this is the ONLY path that connects a SKILL.md `tools:` frontmatter
+ * list to the dispatcher's permission gate. Setting `AgentConfig.tools.allowedTools`
+ * directly is NOT equivalent — that field is read only by `emitSubagentLifecycle`
+ * for telemetry and does not reach the dispatcher.
+ *
+ * @see {@link buildPhaseRestrictedProvider} for the analogous read-only-phase path.
+ * @see `SkillExecutor.executePluginSkill` for the caller wiring.
+ */
+export function buildSkillRestrictedProvider(
+  allowedTools: string[],
+  model: AgentModelInput | undefined,
+): ModelProvider {
+  // Materialise once per fork so runtime array mutations don't bleed across siblings.
+  const permissions = { allowedTools: [...allowedTools] };
+  const route = providerForModel(typeof model === 'string' ? model : undefined);
+  if (route === 'openai-compatible') {
+    return new OpenAICompatibleProvider({ permissions });
+  }
+  return new AnthropicDirectProvider({ permissions });
+}
+
+/**
  * Build a provider whose `permissions.allowedTools` is restricted to
  * `READ_ONLY_PHASE_TOOLS`. Routed by model: OpenAI-compatible models get an
  * `OpenAICompatibleProvider`; everything else falls back to

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -511,6 +511,51 @@ describe('discoverPluginSkillBodies', () => {
     const bodies = discoverPluginSkillBodies([]);
     expect(bodies.size).toBe(0);
   });
+
+  it('propagates allowedTools from tools: frontmatter field', () => {
+    const pluginA = join(tmpDir, 'plugin-a');
+    mkdirSync(pluginA, { recursive: true });
+    const dir = join(pluginA, 'skills', 'read-skill');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'SKILL.md'),
+      [
+        '---',
+        'name: read-skill',
+        'description: Read-only research skill',
+        'tools: read_file, grep, glob',
+        '---',
+        'Research the codebase.',
+      ].join('\n'),
+    );
+
+    const bodies = discoverPluginSkillBodies([{ type: 'local', path: pluginA }]);
+    const entry = bodies.get('read-skill');
+    expect(entry).toBeDefined();
+    expect(entry?.allowedTools).toEqual(['read_file', 'grep', 'glob']);
+  });
+
+  it('leaves allowedTools undefined when tools: is absent', () => {
+    const pluginA = join(tmpDir, 'plugin-a');
+    mkdirSync(pluginA, { recursive: true });
+    const dir = join(pluginA, 'skills', 'full-skill');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'SKILL.md'),
+      [
+        '---',
+        'name: full-skill',
+        'description: Full-access skill',
+        '---',
+        'Do anything.',
+      ].join('\n'),
+    );
+
+    const bodies = discoverPluginSkillBodies([{ type: 'local', path: pluginA }]);
+    const entry = bodies.get('full-skill');
+    expect(entry).toBeDefined();
+    expect(entry?.allowedTools).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -168,10 +168,17 @@ export function collectSkillEntries(
  * `pluginPath` is used by `executePluginSkill` to inject `PLUGIN_ROOT`
  * into the forked subagent's tool-handler context, so shell commands in
  * the body that reference `${PLUGIN_ROOT}/...` resolve correctly.
+ *
+ * `allowedTools` is the resolved tool allowlist from the SKILL.md `tools:`
+ * frontmatter field. When present, `executePluginSkill` must restrict the
+ * forked subagent's provider to this set only. When absent, the default
+ * `CHILD_ALLOWED_TOOLS` surface applies (backward-compatible).
  */
 export interface PluginSkillBody {
   body: string;
   pluginPath: string;
+  /** Resolved AFK-canonical tool names from the `tools:` frontmatter field, or undefined. */
+  allowedTools?: string[];
   /**
    * Execution mode from SKILL.md frontmatter `context:`. The executor forks a
    * subagent ONLY when this is `'fork'`; undefined/`'load'`/other values load
@@ -225,6 +232,7 @@ export function discoverPluginSkillBodies(
         bodies.set(skill.name, {
           body: skill.body,
           pluginPath: plugin.path,
+          ...(skill.allowedTools !== undefined ? { allowedTools: skill.allowedTools } : {}),
           ...(skill.context !== undefined ? { context: skill.context } : {}),
           ...(skill.readOnly === true ? { readOnly: true } : {}),
         });

--- a/src/agent/tools/skill-executor.test.ts
+++ b/src/agent/tools/skill-executor.test.ts
@@ -21,6 +21,7 @@ import { registerSkill, _resetRegistry } from '../../skills/index.js';
 import { SubagentManager } from '../subagent.js';
 import * as SubagentExecutorModule from './subagent-executor.js';
 import * as promptLoader from '../../skills/_lib/prompt-loader.js';
+import * as nestingModule from './nesting.js';
 import {
   onTrustedSkillComplete,
   offTrustedSkillComplete,
@@ -743,7 +744,7 @@ describe('SkillExecutor', () => {
       expect(result.content).toContain('skill was cancelled');
     });
 
-    it('passes a named "Run the <name> skill" directive when no arguments provided', async () => {
+    it('should pass empty string as user message when no arguments provided', async () => {
       registerSkill({
         name: 'fork-no-args',
         description: 'test',
@@ -780,9 +781,7 @@ describe('SkillExecutor', () => {
 
       await executor.execute(makeCall({ name: 'fork-no-args' }));
 
-      expect(mockRunToResult).toHaveBeenCalledWith(
-        'Run the fork-no-args skill now, following the instructions in your system prompt.',
-      );
+      expect(mockRunToResult).toHaveBeenCalledWith('Run the fork-no-args skill now, following the instructions in your system prompt.');
     });
 
     it('should pass arguments as user message when provided', async () => {
@@ -1679,6 +1678,48 @@ describe('SkillExecutor', () => {
       expect(factoryArgs?.readOnlyBash).toBe(true);
     });
 
+    it('read-only + tools: intersection of tools list with RECON_ALLOWED_TOOLS, readOnlyBash still true', async () => {
+      // B1 regression path: a plugin skill with BOTH read-only: true AND a
+      // tools: allowlist must produce a child whose effective allowedTools is
+      // the intersection of the tools list with RECON_ALLOWED_TOOLS, and
+      // readOnlyBash must remain true.  Previously the post-fork
+      // buildSkillRestrictedProvider override would drop readOnlyBash.
+      captureForkConfig();
+      const childProviderFactory = vi.fn().mockReturnValue({ name: 'sentinel' });
+
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'p',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        pluginConfigs: undefined,
+        childProviderFactory: childProviderFactory as never,
+      });
+
+      // tools: list includes both RECON-allowed and non-RECON (write_file)
+      // tokens. The intersection must keep only the RECON-allowed ones.
+      const body: PluginSkillBody = {
+        body: 'fake plugin body',
+        pluginPath: '/fake/plugin',
+        // Since the 2026-06 load-by-default flip, a plugin skill forks (and thus
+        // gets the tools/RECON allowlist) only when it declares context: fork.
+        context: 'fork',
+        readOnly: true,
+        allowedTools: ['read_file', 'bash', 'write_file'],
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (executor as any).pluginBodies = new Map([['recon-tools-plugin', body]]);
+
+      await executor.execute(makeCall({ name: 'recon-tools-plugin' }));
+
+      const factoryArgs = childProviderFactory.mock.calls[0]?.[0];
+      // Only RECON-allowed tokens survive the intersection.
+      expect(factoryArgs?.allowedTools).toEqual(['read_file', 'bash']);
+      // readOnlyBash must still be true — the bash gate is not dropped.
+      expect(factoryArgs?.readOnlyBash).toBe(true);
+    });
+
     it('with NO factory, a read-only skill still gets a recon provider (fallback path)', async () => {
       const { mockForkSubagent } = captureForkConfig();
       // No childProviderFactory configured → the no-factory branch of
@@ -1998,6 +2039,184 @@ describe('SkillExecutor', () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toContain('plugin was cancelled');
+    });
+  });
+
+  // ─── tools: allowlist propagation ────────────────────────────────────────
+
+  describe('plugin skill tools: allowlist enforcement', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('calls buildSkillRestrictedProvider when allowedTools is present on the skill body', async () => {
+      vi.spyOn(SubagentManager.prototype, 'forkSubagent').mockResolvedValue({
+        runToResult: vi.fn().mockResolvedValue({
+          status: 'succeeded',
+          message: { content: 'restricted output' },
+        }),
+        teardown: vi.fn().mockResolvedValue(undefined),
+      } as never);
+      vi.spyOn(SubagentManager.prototype, 'teardownAll').mockResolvedValue(undefined);
+
+      const buildRestrictedSpy = vi.spyOn(nestingModule, 'buildSkillRestrictedProvider');
+
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'test',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        defaultModel: 'sonnet',
+      });
+
+      // Inject a PluginSkillBody with allowedTools
+      const skillBody: PluginSkillBody = {
+        body: 'You are a read-only research assistant.',
+        pluginPath: '/fake/plugin',
+        // context: fork — required to reach the fork path post load-by-default flip.
+        context: 'fork',
+        allowedTools: ['read_file', 'grep', 'glob', 'list_directory'],
+      };
+      (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies =
+        new Map([['restricted-skill', skillBody]]);
+
+      const result = await executor.execute(makeCall({ name: 'restricted-skill' }));
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toBe('restricted output');
+      expect(buildRestrictedSpy).toHaveBeenCalledWith(
+        ['read_file', 'grep', 'glob', 'list_directory'],
+        'sonnet',
+      );
+    });
+
+    it('uses buildReadOnlyReconProvider (NOT buildSkillRestrictedProvider) for a read-only skill at the depth cap', async () => {
+      // Regression guard for the cap-path readOnlyBash fail-open: a read-only
+      // plugin skill forked without a childProviderFactory (the depth-cap / no-
+      // factory branch) must get a provider that preserves the mutating-bash
+      // gate. buildReadOnlyReconProvider carries readOnlyBash + readOnlyMemory +
+      // RECON; buildSkillRestrictedProvider does not. So the readOnly branch must
+      // win even when a tools: list is also declared — otherwise `bash` (a builtin
+      // gated by readOnlyBash, not routed through an executor) re-opens at the cap.
+      vi.spyOn(SubagentManager.prototype, 'forkSubagent').mockResolvedValue({
+        runToResult: vi.fn().mockResolvedValue({
+          status: 'succeeded',
+          message: { content: 'recon output' },
+        }),
+        teardown: vi.fn().mockResolvedValue(undefined),
+      } as never);
+      vi.spyOn(SubagentManager.prototype, 'teardownAll').mockResolvedValue(undefined);
+
+      const reconSpy = vi.spyOn(nestingModule, 'buildReadOnlyReconProvider');
+      const restrictedSpy = vi.spyOn(nestingModule, 'buildSkillRestrictedProvider');
+
+      // No childProviderFactory on the executor → buildForkedChildConfig takes
+      // the depth-cap / no-factory branch.
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'test',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        defaultModel: 'sonnet',
+      });
+
+      // Read-only skill that ALSO declares a tools: list including bash/write_file.
+      const skillBody: PluginSkillBody = {
+        body: 'You are a read-only auditor.',
+        pluginPath: '/fake/plugin',
+        // context: fork — required to reach the fork path post load-by-default flip.
+        context: 'fork',
+        readOnly: true,
+        allowedTools: ['read_file', 'bash', 'write_file'],
+      };
+      (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies =
+        new Map([['recon-skill', skillBody]]);
+
+      const result = await executor.execute(makeCall({ name: 'recon-skill' }));
+
+      expect(result.isError).toBeUndefined();
+      // readOnly wins: the recon provider (which keeps readOnlyBash) is used, and
+      // the bare restricted provider that would drop the bash gate is NOT.
+      expect(reconSpy).toHaveBeenCalledWith('sonnet');
+      expect(restrictedSpy).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call buildSkillRestrictedProvider when allowedTools is absent', async () => {
+      vi.spyOn(SubagentManager.prototype, 'forkSubagent').mockResolvedValue({
+        runToResult: vi.fn().mockResolvedValue({
+          status: 'succeeded',
+          message: { content: 'full-access output' },
+        }),
+        teardown: vi.fn().mockResolvedValue(undefined),
+      } as never);
+      vi.spyOn(SubagentManager.prototype, 'teardownAll').mockResolvedValue(undefined);
+
+      const buildRestrictedSpy = vi.spyOn(nestingModule, 'buildSkillRestrictedProvider');
+
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'test',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+      });
+
+      // Inject a PluginSkillBody WITHOUT allowedTools (backward-compatible path)
+      const skillBody: PluginSkillBody = {
+        body: 'Do anything.',
+        pluginPath: '/fake/plugin',
+        // context: fork so the skill actually forks (load-by-default since 2026-06);
+        // otherwise this test would pass vacuously via the in-context load path.
+        context: 'fork',
+      };
+      (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies =
+        new Map([['unrestricted-skill', skillBody]]);
+
+      await executor.execute(makeCall({ name: 'unrestricted-skill' }));
+
+      // buildSkillRestrictedProvider must NOT be called for unrestricted skills
+      expect(buildRestrictedSpy).not.toHaveBeenCalled();
+    });
+
+    it('passes the allowedTools list through to buildSkillRestrictedProvider verbatim', async () => {
+      vi.spyOn(SubagentManager.prototype, 'forkSubagent').mockResolvedValue({
+        runToResult: vi.fn().mockResolvedValue({
+          status: 'succeeded',
+          message: { content: 'ok' },
+        }),
+        teardown: vi.fn().mockResolvedValue(undefined),
+      } as never);
+      vi.spyOn(SubagentManager.prototype, 'teardownAll').mockResolvedValue(undefined);
+
+      const buildRestrictedSpy = vi.spyOn(nestingModule, 'buildSkillRestrictedProvider');
+
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'test',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+      });
+
+      const narrowList = ['read_file', 'grep'];
+      const skillBody: PluginSkillBody = {
+        body: 'Read-only body.',
+        pluginPath: '/p',
+        // context: fork — required to reach the fork path post load-by-default flip.
+        context: 'fork',
+        allowedTools: narrowList,
+      };
+      (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies =
+        new Map([['narrow-skill', skillBody]]);
+
+      await executor.execute(makeCall({ name: 'narrow-skill' }));
+
+      expect(buildRestrictedSpy).toHaveBeenCalledWith(
+        ['read_file', 'grep'],
+        'sonnet',
+      );
     });
   });
 

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -27,6 +27,7 @@ import {
   RECON_ALLOWED_TOOLS,
   buildReadOnlyReconProvider,
   createStubParentSession,
+  buildSkillRestrictedProvider,
   type ChildProviderFactoryArgs,
 } from './nesting.js';
 import { SubagentExecutor } from './subagent-executor.js';
@@ -275,6 +276,7 @@ export class SkillExecutor {
           parsed.arguments,
           call,
           readOnly,
+          pluginSkill.allowedTools,
         );
       }
       // Default: in-context LOAD (2026-06 load-by-default flip). No readOnly —
@@ -453,19 +455,50 @@ export class SkillExecutor {
     // RECON tool allowlist (no write_file/edit_file) and the mutating-bash
     // gate — on BOTH the factory path and the depth-cap/no-factory fallback.
     readOnly = false,
+    // Plugin SKILL.md `tools:` allowlist. When set, restricts the child to this
+    // exact tool set (single source of truth — no post-fork provider override).
+    // Undefined for the registry path (executeForkedRegistrySkill), which must
+    // stay unchanged.
+    allowedTools?: string[],
   ): { childConfig: AgentConfig; childManager: SubagentManager | undefined } {
     const depth = this.ctx.depth ?? 0;
     const maxDepth = this.ctx.maxDepth ?? DEFAULT_MAX_NESTING_DEPTH;
     const childConfig: AgentConfig = { ...baseConfig };
 
+    // Invariant (single source of truth for effective allowlist):
+    //   readOnly && allowedTools  → intersection(allowedTools, RECON_ALLOWED_TOOLS) + readOnlyBash
+    //   readOnly && !allowedTools → RECON_ALLOWED_TOOLS + readOnlyBash  (unchanged)
+    //   !readOnly && allowedTools → allowedTools, no readOnlyBash
+    //   !readOnly && !allowedTools → no override (factory default CHILD_ALLOWED_TOOLS)
+    // This keeps subagentExecutor/skillExecutor/readOnlyMemory/readOnlyBash intact
+    // through the factory — the previous post-fork buildSkillRestrictedProvider
+    // override is gone from executePluginSkill.
+    const effectiveAllowed: string[] | undefined =
+      readOnly && allowedTools !== undefined
+        ? allowedTools.filter((t) => (RECON_ALLOWED_TOOLS as readonly string[]).includes(t))
+        : readOnly
+          ? [...RECON_ALLOWED_TOOLS]
+          : allowedTools;
+    const effectiveReadOnlyBash = readOnly;
+
     if (!this.ctx.childProviderFactory || depth >= maxDepth) {
-      // Depth-cap / no-factory fallback. The child would otherwise inherit the
-      // bare provider singleton with the full write surface and no bash gate,
-      // silently defeating read-only enforcement. Build an explicit read-only
-      // recon provider so the constraint holds even here (no agent/skill fan-out
-      // is possible at the cap anyway, so the missing executors are harmless).
+      // Depth-cap / no-factory fallback. At the cap no executors are possible,
+      // so missing subagentExecutor/skillExecutor is harmless — but readOnlyBash
+      // and readOnlyMemory still matter: `bash` is a builtin gated by the
+      // dispatcher's readOnlyBash classifier, NOT routed through an executor, so
+      // dropping that gate here would re-open mutating bash even at the cap.
       if (readOnly) {
+        // readOnly (with OR without a tools: list): buildReadOnlyReconProvider
+        // carries readOnlyBash + readOnlyMemory + RECON_ALLOWED_TOOLS. The
+        // tools: intersection (effectiveAllowed) is a subset of RECON, so RECON
+        // is a safe read-only superset and — crucially — the mutating-bash gate
+        // is preserved. This closes the cap-path readOnlyBash fail-open for a
+        // `read-only: true` + `tools: bash` skill forked at the depth cap.
         childConfig.provider = buildReadOnlyReconProvider(childConfig.model);
+      } else if (effectiveAllowed !== undefined) {
+        // Non-readOnly tools: allowlist at the cap. Restrict to the declared
+        // tools (no readOnlyBash — the skill did not declare read-only).
+        childConfig.provider = buildSkillRestrictedProvider(effectiveAllowed, childConfig.model);
       }
       return { childConfig, childManager: undefined };
     }
@@ -512,12 +545,12 @@ export class SkillExecutor {
       ...(this.ctx.backgroundRegistry !== undefined
         ? { backgroundRegistry: this.ctx.backgroundRegistry }
         : {}),
-      // Propagate read-only constraints into the SubagentExecutor that will
-      // handle `agent` tool calls from this skill-forked child. Without this,
-      // a depth-2 fan-out (`ground-state → agent → depth-2`) loses the
-      // allowlist — the grandchild SubagentExecutor's `childProviderFactory`
-      // call omits allowedTools/readOnlyBash and falls back to CHILD_ALLOWED_TOOLS.
-      ...(readOnly ? { allowedTools: [...RECON_ALLOWED_TOOLS], readOnlyBash: true as const } : {}),
+      // Propagate effective allowlist into the grandchild SubagentExecutor so
+      // depth-2 fan-out (skill → agent → depth-2) inherits the same constraints.
+      // Without this, the grandchild's childProviderFactory call omits
+      // allowedTools/readOnlyBash and falls back to CHILD_ALLOWED_TOOLS.
+      ...(effectiveAllowed !== undefined ? { allowedTools: effectiveAllowed } : {}),
+      ...(effectiveReadOnlyBash ? { readOnlyBash: true as const } : {}),
     });
     const childSkillExecutor = this.ctx.childSkillExecutorFactory
       ? this.ctx.childSkillExecutorFactory(depth + 1, maxDepth, signal)
@@ -527,15 +560,17 @@ export class SkillExecutor {
     // skill-forked child inherits the legacy hardcoded
     // AnthropicDirectProvider — meaning an OpenAI-routed parent silently
     // dispatches every skill subagent to api.anthropic.com.
+    //
+    // Invariant: effective allowlist and readOnlyBash are passed through the
+    // factory — keeping subagentExecutor, skillExecutor, readOnlyMemory, and
+    // readOnlyBash intact in the resulting provider. No post-fork provider
+    // override; this is the single source of truth for the child's permissions.
     childConfig.provider = this.ctx.childProviderFactory({
       childExecutor,
       ...(childSkillExecutor !== undefined ? { childSkillExecutor } : {}),
       ...(childConfig.model !== undefined ? { model: childConfig.model } : {}),
-      // Read-only enforcement: hand the factory the RECON allowlist (strips
-      // write_file/edit_file) and turn on the mutating-bash gate. The child
-      // keeps `agent`/`skill` (so surveyor fan-out still works) and read-only
-      // bash (git status/log/diff for dirty-tree detection).
-      ...(readOnly ? { allowedTools: [...RECON_ALLOWED_TOOLS], readOnlyBash: true } : {}),
+      ...(effectiveAllowed !== undefined ? { allowedTools: effectiveAllowed } : {}),
+      ...(effectiveReadOnlyBash ? { readOnlyBash: true } : {}),
     });
 
     return { childConfig, childManager };
@@ -857,6 +892,7 @@ export class SkillExecutor {
     // Read-only enforcement flag, computed at the call site from the plugin
     // body's `readOnly` frontmatter OR DEFAULT_READ_ONLY_SKILLS membership.
     readOnly = false,
+    allowedTools?: string[],
   ): Promise<ToolResult> {
     if (call.signal.aborted) {
       return { content: 'Skill call aborted', isError: true };
@@ -894,21 +930,32 @@ export class SkillExecutor {
     // traceWriter on childConfig is what makes the fork visible in the
     // witness trace — SubagentManager.forkSubagent reads it off
     // options.config, not off the manager. Mirror in executeForkedRegistrySkill.
+    const baseAgentConfig: AgentConfig = {
+      model: pluginChildModel,
+      // Invariant: $ARGUMENT/$ARGUMENTS placeholders in the SKILL.md body are
+      // substituted with the caller-supplied args before the fork is configured,
+      // matching slash-command semantics SKILL.md authors expect.
+      systemPrompt: this.substituteSkillArgs(body, args),
+      env: { PLUGIN_ROOT: pluginPath },
+      // Invariant: skill-dispatch sub-agents must not inherit the
+      // SLASH_COMMAND_ROUTING_PROMPT paragraph. They receive a "Run the <name>
+      // skill" directive with no <command-name> tag, so the routing instruction
+      // (which keys off that tag) would push them to ask "which skill?" instead
+      // of engaging with their SKILL.md body.
+      isSkillDispatch: true,
+      ...(this.ctx.traceWriter !== undefined ? { traceWriter: this.ctx.traceWriter } : {}),
+    } as AgentConfig;
+
+    // Invariant (single source of truth): allowedTools is threaded into
+    // buildForkedChildConfig so the factory-built provider keeps
+    // subagentExecutor / skillExecutor / readOnlyMemory / readOnlyBash intact
+    // while applying the correct effective allowlist. No post-fork provider
+    // override — buildForkedChildConfig is the only place permissions are set.
     const { childConfig, childManager } = this.buildForkedChildConfig(
-      {
-        model: pluginChildModel,
-        systemPrompt: this.substituteSkillArgs(body, args),
-        env: { PLUGIN_ROOT: pluginPath },
-        // Invariant: skill-dispatch sub-agents must not inherit the
-        // SLASH_COMMAND_ROUTING_PROMPT paragraph. They receive a "Run the
-        // <name> skill" directive with no <command-name> tag, so the routing
-        // instruction (which keys off that tag) would push them to ask
-        // "which skill?" instead of engaging with their SKILL.md body.
-        isSkillDispatch: true,
-        ...(this.ctx.traceWriter !== undefined ? { traceWriter: this.ctx.traceWriter } : {}),
-      } as AgentConfig,
+      baseAgentConfig,
       call.signal,
       readOnly,
+      allowedTools,
     );
 
     // Invariant: same trace-sealing rule as executeForkedRegistrySkill above.


### PR DESCRIPTION
## Source

Port of **afk-workshop#571** — *feat(plugin-skills): honor `tools:` frontmatter as enforced allowlist*.
Closes the private issue afk-workshop#352.

This is a verified moat-scrubbed port. Nothing required scrubbing (the PR is pure core-agent infrastructure), but the diff is **not byte-identical** to the private PR — see "Port adaptations" below.

## What it does

Parses the `tools:` SKILL.md frontmatter field into an enforced tool allowlist for **plugin-dispatched subagents** (the fork path):

- Accepts comma-separated (`tools: Read, Grep`), YAML list, and flow-sequence (`[Read, Grep]`) forms; legacy Claude Code aliases (`Read`→`read_file`, `Edit`→`edit_file`, `WebFetch`/`WebSearch`→`web_scrape`, …) normalize case-insensitively to AFK canonical names.
- Unknown tokens are dropped with a stderr warning.
- **Fail-closed:** when `tools:` is present but resolves to zero valid tools, `allowedTools = []` — which blocks *every* tool (verified: `checkToolPermission` treats `[]` as block-all, not allow-all). When `tools:` is absent, `allowedTools` stays `undefined` and the default `CHILD_ALLOWED_TOOLS` surface applies (backward-compatible).
- The allowlist is the **single source of truth**, threaded through `buildForkedChildConfig` into the child provider's `permissions.allowedTools` (no post-fork provider override). For `read-only` skills it intersects with `RECON_ALLOWED_TOOLS` and preserves the `readOnlyBash` gate.

## Ported (all 8 files — entirely public-safe)

- `src/agent/plugins/tool-injector.ts` (+ test) — `parseToolsField`, `normalizeToolToken`, `resolveKnownToolNames`, `allowedTools` metadata field.
- `src/agent/tools/nesting.ts` (+ test) — `buildSkillRestrictedProvider`.
- `src/agent/tools/skill-bridge.ts` (+ test) — `allowedTools` on `PluginSkillBody`, propagation in `discoverPluginSkillBodies`.
- `src/agent/tools/skill-executor.ts` (+ test) — `allowedTools` threading through `buildForkedChildConfig` / `executePluginSkill`; effective-allowlist invariant.

## Dropped

**None.** The triage classified all 8 files PUBLIC-SAFE; no moat files, hunks, terms, or imports were present to drop.

## Port adaptations (why the diff differs from the private PR)

1. **Re-anchored 3 doc-comment hunks** (`tool-injector.ts`, `skill-bridge.ts`, `skill-executor.ts`) — public has a newer `context:` JSDoc than the private pre-image, so the `allowedTools` field/JSDoc insertions were applied by hand to port the intent.
2. **Added `context: 'fork'` to 5 test fixtures** in `skill-executor.test.ts`. Public defaults plugin skills to **LOAD** (the 2026-06 load-by-default flip); private at the PR base still forked by default. The PR's fork-path tests therefore had to opt into fork explicitly to exercise the allowlist threading — the same pattern the 37 existing public fork-path tests already use. (One test, `does NOT call buildSkillRestrictedProvider when allowedTools is absent`, was passing *vacuously* via the load path and now forks meaningfully.)

## Verification

- `pnpm install --frozen-lockfile && pnpm lint && env -u AFK_INTERNAL pnpm test && pnpm build && pnpm build:dist` — **all green** (484 test files, 9140 passed, 12 skipped, 0 failed).
- `pnpm fix:pins:check` — all hash pins up to date.
- **Deterministic moat guard** (tree + built `dist/`) — `MOAT GUARD CLEAN`.
- **Independent adversarial moat audit** — `CLEAN` (re-derived; did not trust the deterministic guard).

## Do not merge automatically — left for human review.
