### PR TITLE
perf(renderer): tail-slice thinking buffer before normalize + wrap

### DIFF
--- a/src/cli/commands/interactive/thinking-paragraph.test.ts
+++ b/src/cli/commands/interactive/thinking-paragraph.test.ts
@@ -11,6 +11,14 @@
  *   (e) MIN_BODY_WIDTH floor on narrow terminals (no per-glyph breaks).
  *   (f) Internal whitespace (newlines, runs of spaces) collapsed to single spaces.
  *   (g) Custom `maxLines` honored.
+ *   (h) Perf bound — content (issue #23): on a 100 KB buffer the visible body is
+ *       the exact most-recent prose suffix and the footer totals every dropped
+ *       char (head-slice included). Byte-identical wrap to the old full-buffer
+ *       algorithm is deliberately NOT asserted — greedy-wrap phase makes it
+ *       unachievable with bounded work; see the test body.
+ *   (i) Perf bound — cost: the visible body is independent of everything before
+ *       the tail budget — the observable proof that the O(N) normalize+wrap only
+ *       ever touches a bounded tail, not the full buffer.
  *
  * Assertions look at the ANSI-stripped string so the structure (line count,
  * presence of header/footer text) is testable without coupling to chalk's
@@ -22,6 +30,32 @@
 import { describe, it, expect } from 'vitest';
 import { stripAnsi } from '../../display.js';
 import { formatThinkingParagraph } from './thinking-paragraph.js';
+
+/**
+ * Deterministic single-spaced prose with VARIED word lengths (1–11 chars).
+ * Single spacing (no whitespace runs, no leading/trailing space) is what makes
+ * the footer-accounting assertions in (h) exact. Seeded LCG → reproducible.
+ */
+function buildProse(targetLen: number): string {
+  let seed = 0x2545f4914f6cdd1d % 0x7fffffff;
+  const rand = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+  const words: string[] = [];
+  let total = 0;
+  while (total < targetLen) {
+    const len = 1 + Math.floor(rand() * 11);
+    const w = String.fromCharCode(97 + Math.floor(rand() * 26)).repeat(len);
+    words.push(w);
+    total += w.length + 1;
+  }
+  return words.join(' ');
+}
+
+/** Body lines = everything between the header and the optional footer. */
+function bodyOf(out: string): string[] {
+  const lines = stripAnsi(out).split('\n').slice(1);
+  if (lines.length && /chars earlier$/.test(lines[lines.length - 1] ?? '')) lines.pop();
+  return lines;
+}
 
 describe('formatThinkingParagraph', () => {
   it('(a) returns empty string for an empty buffer', () => {
@@ -109,5 +143,58 @@ describe('formatThinkingParagraph', () => {
     const out = formatThinkingParagraph('anything', { cols: 80 });
     const plain = stripAnsi(out);
     expect(plain.split('\n')[0]).toContain('◆ thinking');
+  });
+
+  it('(h) 100 KB buffer: visible body is the exact most-recent prose + footer totals all dropped chars', () => {
+    // Acceptance (issue #23). Byte-identical equality with the old full-buffer
+    // wrap is NOT a sound invariant: greedy word-wrap line breaks depend on the
+    // start offset, so a bounded tail-slice can land the *top* visible line a
+    // word or two off the full wrap, and no finite tail budget fixes every
+    // input (re-sync took 62 wrapped lines at cols:120 for this very buffer).
+    // What IS guaranteed — and is what users actually care about — is asserted
+    // here: the rendered reasoning is the true most-recent suffix of the CoT
+    // (nothing fabricated or skipped), and the `⋯ +N` footer accounts for every
+    // earlier char, including the head sliced off before wrapping (issue #23's
+    // 4th acceptance bullet). Both hold exactly for single-spaced prose at any
+    // width, independent of wrap phase.
+    const buffer = buildProse(100 * 1024);
+    expect(buffer.length).toBeGreaterThan(100 * 1024 - 12);
+    for (const cols of [42, 80, 120, 200]) {
+      const plain = stripAnsi(formatThinkingParagraph(buffer, { cols, maxLines: 5 })).split('\n');
+      const footerMatch = (plain[plain.length - 1] ?? '').match(/\+(\d+) chars earlier$/);
+      expect(footerMatch, `cols=${cols} renders a truncation footer`).not.toBeNull();
+      const droppedChars = Number(footerMatch![1]);
+      const body = plain.slice(1, -1).map((l) => l.replace(/^ {2}/, ''));
+      expect(body, `cols=${cols} caps at maxLines`).toHaveLength(5);
+
+      // De-wrapping the body (join lines with the single space wrap-ansi trimmed
+      // at each break) reconstructs an exact, contiguous suffix of the buffer.
+      const visibleProse = body.join(' ');
+      expect(buffer.endsWith(visibleProse), `cols=${cols} body is most-recent suffix`).toBe(true);
+
+      // Everything before the visible region was dropped. For single-spaced
+      // prose that is `len - visibleProse - 1` (the 1 = the space separating the
+      // dropped region from the visible region). This equals what the
+      // un-truncated algorithm would report for the same visible region, and
+      // would be off by ~the whole buffer if the pre-slice head weren't folded in.
+      expect(droppedChars, `cols=${cols} footer totals all dropped chars`).toBe(
+        buffer.length - visibleProse.length - 1,
+      );
+    }
+  });
+
+  it('(i) visible body is independent of buffer length before the tail budget (O(maxLines·bodyWidth) bound)', () => {
+    // The expensive normalize+wrap must only ever see a bounded tail. Two
+    // buffers that share an identical suffix longer than the tail budget
+    // (maxLines·bodyWidth·4 = 5·40·4 = 800 at cols:42) must produce the SAME
+    // visible body regardless of how much precedes it — the observable proof
+    // that work does not scale with total buffer length. Footers differ (they
+    // count the dropped head), so only the body is compared.
+    const sharedSuffix = buildProse(4000); // ≫ 800-char tail budget
+    const opts = { cols: 42, maxLines: 5 };
+    const small = formatThinkingParagraph('lead in. ' + sharedSuffix, opts);
+    const huge = formatThinkingParagraph(buildProse(200 * 1024) + ' ' + sharedSuffix, opts);
+    expect(bodyOf(huge)).toEqual(bodyOf(small));
+    expect(bodyOf(small)).toHaveLength(5);
   });
 });

--- a/src/cli/commands/interactive/thinking-paragraph.ts
+++ b/src/cli/commands/interactive/thinking-paragraph.ts
@@ -40,6 +40,17 @@ const DEFAULT_MAX_BODY_LINES = 5;
  * mangling them into single-letter slivers.
  */
 const MIN_BODY_WIDTH = 16;
+/**
+ * Burn-in factor for the input tail-slice. The renderer only ever shows
+ * `maxLines × bodyWidth` codepoints, but greedy word-wrap breaks depend on
+ * where the text starts — so the first few wrapped lines of a tail-slice can
+ * be out of phase with the full-buffer wrap. Slicing a tail ~4× larger than
+ * the visible region drops ~3×maxLines leading lines, giving the breaks room
+ * to re-synchronize before the surviving `maxLines`. For natural prose they
+ * re-sync within a line or two; uniform tokens tuned to `bodyWidth` are the
+ * pathological exception, where the footer count becomes approximate.
+ */
+const TAIL_MULTIPLIER = 4;
 
 export interface ThinkingParagraphOptions {
   /** Terminal width in columns. */
@@ -65,22 +76,43 @@ export interface ThinkingParagraphOptions {
  *
  * Tail-scroll semantics: the most recent `maxLines` wrapped lines survive;
  * older lines drop off the top. The footer reports how many characters of
- * wrapped body content were dropped, NOT a line count, because users care
- * about how much reasoning they didn't see.
+ * earlier content were dropped, NOT a line count, because users care about
+ * how much reasoning they didn't see. That total spans both the lines wrapped
+ * here and dropped, and the buffer head sliced off before wrapping (see the
+ * TAIL_MULTIPLIER bound) — for single-spaced prose the two agree exactly with
+ * the un-truncated count; whitespace-heavy CoT makes it an approximation.
  */
 export function formatThinkingParagraph(
   buffer: string,
   opts: ThinkingParagraphOptions,
 ): string {
+  const maxLines = opts.maxLines ?? DEFAULT_MAX_BODY_LINES;
+  const bodyWidth = Math.max(MIN_BODY_WIDTH, opts.cols - INDENT.length);
+
+  // Bound the per-repaint work *before* the O(N) normalize + wrap. This runs
+  // on every thinking-chunk (~50 Hz) and the wrapped output is then sliced to
+  // the last `maxLines` lines — so wrapping the full multi-KB CoT only to throw
+  // almost all of it away is pure waste that scales with turn length. Cap the
+  // input to a generous tail (see TAIL_MULTIPLIER); cost becomes
+  // O(maxLines · bodyWidth), independent of total CoT length. The chars sliced
+  // off the head — plus any whitespace the tail now leads with, which the
+  // normalize() below would silently trim — are folded into `droppedChars` so
+  // the `⋯ +N chars earlier` footer still totals the full pre-visible content.
+  const tailBudget = maxLines * bodyWidth * TAIL_MULTIPLIER;
+  let tail = buffer;
+  let preSliceDropped = 0;
+  if (buffer.length > tailBudget) {
+    tail = buffer.slice(-tailBudget);
+    const leadingTailWs = tail.length - tail.replace(/^\s+/, '').length;
+    preSliceDropped = buffer.length - tail.length + leadingTailWs;
+  }
+
   // Collapse all internal whitespace (including newlines) to single spaces.
   // CoT often has paragraph breaks the model used as natural pauses; in a
   // 5-line overlay those breaks don't add information and they shorten the
   // effective visible body. wrap-ansi will reflow at the body width below.
-  const normalized = buffer.replace(/\s+/g, ' ').trim();
+  const normalized = tail.replace(/\s+/g, ' ').trim();
   if (!normalized) return '';
-
-  const maxLines = opts.maxLines ?? DEFAULT_MAX_BODY_LINES;
-  const bodyWidth = Math.max(MIN_BODY_WIDTH, opts.cols - INDENT.length);
 
   // Wrap with `trim: true` (not the project-default `wrapToWidth`, which
   // uses `trim: false`). The default leaves whitespace at line breaks
@@ -96,12 +128,13 @@ export function formatThinkingParagraph(
   const allLines = wrapped.split('\n');
 
   let visible = allLines;
-  let droppedChars = 0;
+  let droppedChars = preSliceDropped;
   if (allLines.length > maxLines) {
     const dropped = allLines.slice(0, allLines.length - maxLines);
     // Sum the wrapped-line lengths, plus 1 per join to account for the
-    // spaces that would have separated them in the underlying prose.
-    droppedChars = dropped.reduce((sum, l, i) => sum + l.length + (i > 0 ? 1 : 0), 0);
+    // spaces that would have separated them in the underlying prose. Added
+    // to `preSliceDropped` (the head we never wrapped) for the full total.
+    droppedChars += dropped.reduce((sum, l, i) => sum + l.length + (i > 0 ? 1 : 0), 0);
     visible = allLines.slice(-maxLines);
   }
 


### PR DESCRIPTION
Closes #23.

## Problem

`formatThinkingParagraph` (`src/cli/commands/interactive/thinking-paragraph.ts`) renders the live-thinking overlay on **every** thinking-chunk repaint (~50 Hz). On each call it normalized (`buffer.replace(/\s+/g, ' ').trim()`) and `wrapAnsi`'d the **entire** accumulated CoT buffer, then sliced the wrapped output down to the last ~5 lines — throwing away almost all of the work. At an 8–10 KB steady-state buffer that's ~O(N) regex + wrap per repaint (~15 MB/min of string work), scaling with turn length.

## Fix

Slice a bounded tail of the buffer **before** normalize + wrap:

```ts
const tailBudget = maxLines * bodyWidth * TAIL_MULTIPLIER; // ×4
if (buffer.length > tailBudget) {
  tail = buffer.slice(-tailBudget);
  const leadingTailWs = tail.length - tail.replace(/^\s+/, '').length;
  preSliceDropped = buffer.length - tail.length + leadingTailWs;
}
```

Cost becomes **O(maxLines · bodyWidth)**, independent of total CoT length. The chars sliced off the head — plus any whitespace the tail then leads with (which `normalize()` would otherwise silently trim and undercount) — are folded into `droppedChars`, so the `⋯ +N chars earlier` footer still totals the full pre-visible content.

## Acceptance criteria

- [x] `formatThinkingParagraph` runtime is O(maxLines · bodyWidth), not O(buffer length) — proved by test (i): the visible body is identical for two buffers sharing a suffix longer than the tail budget but differing massively in total length.
- [x] Existing `thinking-paragraph.test.ts` cases still pass (tests a–g, unchanged).
- [x] New test on a 100 KB buffer with `maxLines: 5` — see note below.
- [x] `droppedChars` footer accounts for the pre-slice drop.

## Note on "same visible body + footer as the un-truncated version"

Byte-identical equality with the old full-buffer wrap is **not a sound invariant**, so it is deliberately not asserted. Greedy word-wrap line breaks depend on where the text starts, so a bounded tail-slice can land the **top** visible line a word or two off the full wrap — and **no finite tail budget fixes every input**. Empirically, re-sync needed **62 wrapped lines** at `cols:120` for the test buffer (and uniform tokens tuned to the wrap width never re-sync). This matches the issue's own "conservative but not proven" caveat on the ×4 multiplier.

Instead, the 100 KB test asserts the guarantees that **do** hold exactly at any width, independent of wrap phase — and are what users actually care about:

- the visible body de-wraps to the **exact most-recent prose suffix** of the buffer (nothing fabricated or skipped);
- the footer count equals `len − visibleProse − 1` — i.e. it totals **every** dropped char including the pre-slice head (it would be off by ~the whole buffer if the head weren't folded in).

Verified exact at cols ∈ {42, 80, 120, 200}.

## Out of scope

The UTF-16-vs-display-column footer bug the original review flagged on the same field is intentionally left out: changing the char-counting basis would alter the footer number and is orthogonal to this perf fix.

## Testing

- `pnpm test -- src/cli/commands/interactive/thinking-paragraph.test.ts` → 10 passed (8 existing + 2 new)
- Full suite: **484 files, 9142 passed, 12 skipped**
- `pnpm lint` (tsc --noEmit, strict) clean
