### PR TITLE
feat(onboarding): add /get-started skill + harden /init detection

### DIFF
--- a/src/cli/slash/commands/init.ts
+++ b/src/cli/slash/commands/init.ts
@@ -69,6 +69,27 @@ An AFK.md already exists at \`${afkMdPath}\`. Read it first — then update it w
 A CLAUDE.md exists at \`${claudeMdPath}\`. Read it and incorporate relevant context (commands, conventions, architecture) into the AFK.md. Don't duplicate — adapt.`;
     }
 
+    // Other agent-instruction sources — detect programmatically and incorporate,
+    // mirroring the CLAUDE.md branch. Covers the tools a migrating user typically
+    // arrives from. `.cursor/rules` is a directory of *.mdc files in modern
+    // Cursor; `.cursorrules` is the legacy single-file form. `.clinerules` may be
+    // a file or a directory. Previously AGENTS.md was only a hint in the static
+    // prompt (no existsSync gate) and Cursor/Cline rules weren't handled at all.
+    const otherAgentSources: ReadonlyArray<{ rel: string; label: string }> = [
+      { rel: 'AGENTS.md', label: 'AGENTS.md (Codex / OpenAI)' },
+      { rel: '.cursor/rules', label: 'Cursor rules directory' },
+      { rel: '.cursorrules', label: 'Cursor rules (legacy single file)' },
+      { rel: '.clinerules', label: 'Cline rules' },
+    ];
+    const detectedOther = otherAgentSources.filter((s) =>
+      existsSync(resolve(process.cwd(), s.rel)),
+    );
+    if (detectedOther.length > 0) {
+      const list = detectedOther.map((s) => `\`${s.rel}\` (${s.label})`).join(', ');
+      instruction += `\n\n## Other agent instructions detected
+These existing agent-instruction sources were found: ${list}. Read each and incorporate relevant context (commands, conventions, architecture, do's and don'ts) into the AFK.md. Adapt — don't duplicate. If a source is a directory, read the files inside it.`;
+    }
+
     if (args.trim()) {
       const cleaned = args.replace('--force', '').trim();
       if (cleaned) {

--- a/src/skills/all.ts
+++ b/src/skills/all.ts
@@ -8,6 +8,7 @@
 
 import './audit-fit/index.js';
 import './diagnose/index.js';
+import './get-started/index.js';
 import './mint/index.js';
 import './service-setup/index.js';
 import './telegram-setup/index.js';

--- a/src/skills/get-started/index.test.ts
+++ b/src/skills/get-started/index.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Registration + metadata tests for the `get-started` onboarding skill.
+ *
+ * Unlike the sibling `telegram-setup` / `service-setup` fork skills, this one
+ * is `context: 'load'` — it must run in the CURRENT session so it can ask the
+ * user, recommend slash commands, dispatch setup sub-skills, and leave state in
+ * the caller's context. We assert the metadata contract + that the prompt body
+ * encodes the load-bearing steps of the flow; the interactive flow itself is
+ * model behavior and not deterministically testable.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { getSkill, listSkills } from '../index.js';
+import { loadSkillPrompts } from '../_lib/prompt-loader.js';
+
+// Import for registration side-effect.
+import './index.js';
+
+describe('get-started skill registration', () => {
+  test('is registered with name "get-started"', () => {
+    expect(listSkills()).toContain('get-started');
+  });
+
+  test('is a public, load-mode skill (the linchpin: runs in the current session, not a fork)', () => {
+    const skill = getSkill('get-started');
+    expect(skill.context).toBe('load');
+    expect(skill.audience).toBe('public');
+    expect(skill.description.length).toBeGreaterThan(40);
+    expect(skill.whenToUse).toBeTruthy();
+  });
+
+  test('handler throws if ever called (load skills never invoke it)', async () => {
+    const skill = getSkill('get-started');
+    await expect(skill.handler({})).rejects.toThrow(/load skill/i);
+  });
+});
+
+describe('get-started prompt body', () => {
+  test('resolves a non-empty system.md', () => {
+    const prompts = loadSkillPrompts('get-started');
+    expect((prompts['system.md'] ?? '').length).toBeGreaterThan(500);
+  });
+
+  test('encodes the load-bearing flow steps', () => {
+    const body = loadSkillPrompts('get-started')['system.md'] ?? '';
+
+    // Surface gate — don't ask on non-interactive surfaces.
+    expect(body).toContain('get_runtime_state');
+    // Preflight via the doctor JSON mode + an explicit git check.
+    expect(body).toContain('afk doctor -f json');
+    expect(body).toContain('git rev-parse');
+    // Name persisted to hot memory (survives /clear).
+    expect(body).toContain('memory_update');
+    // Migration via the non-interactive flag paths only (never interactive `afk migrate`).
+    expect(body).toContain('afk migrate --dry-run');
+    expect(body).toContain('afk migrate -y');
+    // Capability setup delegates to the existing setup sub-skills.
+    expect(body).toContain('/telegram-setup');
+    expect(body).toContain('/service-setup');
+    // Project context (/init) MUST be recommended before the save point (/clear).
+    const initIdx = body.indexOf('/init');
+    const clearIdx = body.indexOf('/clear');
+    expect(initIdx).toBeGreaterThan(-1);
+    expect(clearIdx).toBeGreaterThan(-1);
+    expect(initIdx).toBeLessThan(clearIdx);
+  });
+});

--- a/src/skills/get-started/index.ts
+++ b/src/skills/get-started/index.ts
@@ -1,0 +1,60 @@
+/**
+ * /get-started skill — guided first-run onboarding for AFK.
+ *
+ * Takes a brand-new user from cold install to their first useful action as a
+ * boot sequence (a state machine, not a feature menu):
+ *
+ *   preflight → name + intro → toolbox (migrate + capabilities) →
+ *   project context (/init) → save point (/clear) → first job
+ *
+ * ## Why `context: 'load'` (not `fork` like telegram-setup / service-setup)
+ * Onboarding must run in the CURRENT session so the agent can ask the user's
+ * name, hold a conversation, recommend slash commands the user then runs
+ * (`/init`, `/clear`), dispatch the existing setup sub-skills, and leave its
+ * state (name in hot memory, a warm context) in the caller's window. A forked
+ * subagent would discard that context and can't drive the REPL. Per the
+ * fork-vs-load rule in docs/skill-load-mode.md: this skill orchestrates *from*
+ * the current agent and its output lands in the caller's context → `load`.
+ *
+ * Built-in registry skills default to `inline`, so `context: 'load'` is
+ * declared explicitly. The body lives at `prompts/system.md`; the SkillExecutor
+ * load branch returns it (after `$ARGUMENT(S)` substitution) wrapped in an
+ * execute-now framing header, and the current agent carries it out with its
+ * existing tools (ask_question, bash, skill, memory_update).
+ *
+ * This skill never handles secrets directly — Telegram token setup is delegated
+ * to `/telegram-setup` (which has the token-discipline contract). Cross-tool
+ * asset import is delegated to `afk migrate` via its non-interactive flag paths
+ * (`--dry-run` / `-y`) to avoid the readline conflict with the REPL.
+ *
+ * @module skills/get-started
+ */
+
+import { registerSkill, type SkillMetadata } from '../index.js';
+
+/**
+ * No-op handler. `context: 'load'` routes invocations through
+ * {@link SkillExecutor.executeLoadedRegistrySkill}, which returns
+ * `prompts/system.md` as the tool result without ever calling this handler.
+ * Kept only because the registry's type requires one; throws to surface a
+ * routing bug loudly rather than silently returning nothing.
+ */
+async function handler(): Promise<unknown> {
+  throw new Error(
+    'get-started is a load skill; its handler should never be called directly. ' +
+      'Invoke via the `skill` tool or `/get-started` slash command.',
+  );
+}
+
+export const getStartedSkill: SkillMetadata = {
+  name: 'get-started',
+  description:
+    'Guided first-run onboarding for AFK. Runs a preflight check (git repo, model provider, AFK.md, Brave/Telegram/service config), asks the user their name and gives a brief intro, detects importable Claude Code / Codex assets and offers `afk migrate`, walks optional capability setup (Brave Search, Telegram via /telegram-setup, background service via /service-setup), then recommends /init to generate project context and /clear to start fresh — ending by routing the user to their first task. Runs interactively in the current session.',
+  handler,
+  context: 'load',
+  audience: 'public',
+  whenToUse:
+    "When someone is setting up AFK for the first time or asks how to get going — triggers on `/get-started`, 'how do I start', 'set me up', 'onboard me', or a fresh install with no AFK.md and unconfigured capabilities. Best run in the interactive REPL.",
+};
+
+registerSkill(getStartedSkill);

--- a/src/skills/get-started/prompts/system.md
+++ b/src/skills/get-started/prompts/system.md
@@ -1,0 +1,87 @@
+You are running first-time setup for AFK (Agent AFK) with a new user. Walk them from a cold install to their first useful task as a guided boot sequence. Be terse and operational — confirm each step in one line, don't narrate. Use `✓` / `✗` and code fences for commands. `$ARGUMENTS` may carry an initial hint (a name or a goal); use it if present.
+
+## Hard rules
+
+1. **You cannot run slash commands for the user.** You *recommend* `/init` and `/clear` and the user types them. You MAY dispatch the `skill` tool for `/telegram-setup` and `/service-setup` yourself (they are setup sub-skills).
+2. **Never touch the Telegram token.** All Telegram setup goes through `/telegram-setup`. Do not read `~/.afk/config/afk.env`.
+3. **Never shell into interactive `afk migrate` or `afk telegram setup`** — their stdin prompts conflict with the REPL. Use only the non-interactive paths below (`afk migrate --dry-run`, `afk migrate -y`).
+4. **One question at a time** via `ask_question`. Keep moving; don't loop waiting.
+
+## Step 0 — Surface gate
+
+Call `get_runtime_state` (view `self`). If the surface is NOT interactive (daemon, one-shot `chat`, or a sub-agent — where `ask_question` will be declined), do NOT ask anything: print the setup checklist below as plain text and stop. Only continue the interactive flow on the REPL or Telegram.
+
+> Setup checklist: 1) set `ANTHROPIC_API_KEY`  2) `afk migrate` to import Claude Code/Codex tooling  3) `afk telegram setup` for push  4) `/init` to generate AFK.md  5) `/clear` then start working.
+
+## Step 1 — Preflight
+
+Run these and read the results (don't dump raw JSON at the user — summarize):
+
+```
+afk doctor -f json
+git rev-parse --is-inside-work-tree
+```
+
+Also check whether `AFK.md` exists in the current directory. Build a short status list: model provider (API key) ✓/✗, git repo ✓/✗, AFK.md present ✓/✗, and from the doctor JSON: Telegram, importable Claude Code/Codex assets. Brave Search = is `BRAVE_SEARCH_API_KEY` set in the environment.
+
+**Idempotency:** if AFK.md already exists AND a model provider is configured AND (Telegram is configured or the user clearly isn't new), say so in one line — "Looks like AFK is already set up here." — and skip straight to Step 6 (first job). Don't re-run the full flow.
+
+## Step 2 — Name + intro
+
+Ask once with `ask_question` (type `text`): **"What should I call you?"** (skip if `$ARGUMENTS` already gave a name). When they answer, offer to remember it: call `memory_update` with `target: hot`, a short identity line (e.g. "User's name is <name>."). Hot memory survives `/clear` and is present in every future session.
+
+Then give a 4–6 line intro, e.g.:
+
+> AFK lets you hand work to an agent, step away, and come back to an inspectable trace. It can improve a repo, research, automate recurring jobs, run unattended as a background service, and report to you over Telegram. You drive it from this REPL or async from your phone.
+
+## Step 3 — Toolbox (bring + connect capabilities)
+
+**3a. Migrate existing tooling.** If the doctor preflight flagged importable Claude Code / Codex assets, run `afk migrate --dry-run` (read-only preview — safe, no prompt) and summarize what it found (plugins / skills / MCP servers). Then `ask_question` (type `confirm`): "Import these into AFK?" On yes, run `afk migrate -y` (add `--mcp` only if they explicitly want MCP servers, which auto-run commands on connect). If nothing is importable, skip this silently.
+
+**3b. Optional capabilities.** Offer only the ones not already configured:
+- **Brave Search** (web research/grounding): if `BRAVE_SEARCH_API_KEY` is unset, tell them to set it in `~/.afk/config/afk.env`; offer to explain how.
+- **Telegram** (drive/monitor AFK from your phone): if unconfigured, dispatch the `skill` tool with `/telegram-setup`.
+- **Background service** (always-on bot/daemon): **macOS only** — first check the platform (e.g. `uname` → `Darwin`). If not macOS, skip and say service mode is macOS-only today. On macOS, if they want it, dispatch the `skill` tool with `/service-setup`.
+
+Don't push all three — suggest based on what they said they want. Re-check the relevant signal after each so you can confirm ✓.
+
+## Step 4 — Project context (/init)
+
+If no `AFK.md` exists (or it's stale), recommend it:
+
+> Next, set up this project's context so every AFK session here understands it. Run:
+> ```
+> /init
+> ```
+> That scans the repo and writes an `AFK.md` (it also picks up any existing CLAUDE.md / AGENTS.md / .cursor/rules). Reply when it's done.
+
+You can't run `/init` yourself — wait for them to run it.
+
+## Step 5 — Save point (/clear)
+
+After `/init`, recommend a fresh window — this is the natural save point:
+
+> `AFK.md` is saved (and persists, along with what I remembered about you). For a clean context window, run:
+> ```
+> /clear
+> ```
+
+`/clear` MUST be last and user-run — it wipes this session. Don't recommend it before `/init`.
+
+## Step 6 — First job
+
+End on a useful action, not on setup. Ask with `ask_question` (type `choice`): **"What do you want AFK to do first?"** Offer, conditionally:
+- Improve this repo → `afk improve` (or describe the change and I'll do it)
+- Research something → `/research`
+- Review a diff / PR → `/review`
+- Integrate an external API → `/integrate` *(only list if that skill is available)*
+- Automate a recurring job → `/automate` *(only list if that skill is available)*
+- Nothing yet — just finish setup
+
+Only list `/integrate` and `/automate` if they're actually registered (they aren't bundled with AFK — they're operator-installed). If unsure, omit them and mention the user can install them later.
+
+Route to the choice and hand off. Done.
+
+## Tone
+
+Operational and warm, not corporate. This is one-time setup; the user wants it done, then to start working. Don't re-explain AFK after the Step 2 intro.


### PR DESCRIPTION
## Summary
- Adds `/get-started`, a guided first-run onboarding skill — a boot sequence (preflight → name + intro → migrate/capability setup → `/init` → `/clear` → first job) that ends on a useful action instead of a setup menu. Fills the gap where new users had no discoverable on-ramp.
- Built as a `context: 'load'` skill (the first built-in registry load skill) so it runs in the **current** session — required to ask the user's name, recommend slash commands, and dispatch the existing `/telegram-setup` & `/service-setup` sub-skills. A fork would discard that context and can't drive the REPL.
- Reuses existing surfaces rather than reimplementing: drives `afk migrate` via its **non-interactive** flags (sidesteps the REPL readline conflict), persists the user's name to **hot memory** (survives `/clear`), and gates the macOS-only service step.
- Hardens `/init` to programmatically detect `AGENTS.md`, `.cursor/rules`, `.cursorrules`, and `.clinerules` (previously only `CLAUDE.md`), making the "import existing instructions" step reliable across the tools migrating users arrive from.

## Test results
- `pnpm lint` (`tsc --noEmit`, strict): clean (exit 0)
- `pnpm test` (full suite): **485 files, 9145 passed, 12 skipped, 0 failed**
- `pnpm build`: clean — prompt copied into `dist/`, skill registered in `dist/skills/all.js`
- New tests: `src/skills/get-started/index.test.ts` (5 tests, pass)

## Verification (`--verify` adversarial wave)
A read-only verifier independently re-derived the PR's load-bearing claims from the diff/files alone:
- **CONFIRM** — `/get-started` is `context:'load'` + `audience:'public'`, registered in the barrel, auto-exposed as `/get-started` (`index.ts:62-63`, `all.ts:11`, `builtin-skills.ts:46`).
- **CONFIRM** — `/init` now `existsSync`-detects `AGENTS.md`/`.cursor/rules`/`.cursorrules`/`.clinerules`, additively (CLAUDE.md branch untouched) (`init.ts:80-84`).
- **CONFIRM** — prompt body uses non-interactive `afk migrate --dry-run`/`-y` only, gates service-setup to macOS, orders `/init` before `/clear` (`prompts/system.md`).

No CONTRADICT / REFINE.

## Notes
- Branch is 5 commits behind `origin/main`, but those commits touch only `interactive/*`, `CHANGELOG`, and `package.json` — zero overlap with this PR's files; merges cleanly.
- The design plan lives at `.afk/plans/implement-get-started-skill.md` (intentionally **not** committed — planning artifact, not source).

## Out of scope (deferred — see plan)
- REPL first-run discoverability nudge (needs an explicit `onboarded` marker; `/get-started` is already discoverable via `/help` + the skill manifest).
- First-run auto-trigger; non-macOS service mode.
