### PR TITLE
feat(facets): AFK-native SessionFacet substrate (port afk-workshop#779)

### DIFF
--- a/src/agent/facets/derive.test.ts
+++ b/src/agent/facets/derive.test.ts
@@ -1,0 +1,330 @@
+import { describe, it, expect } from 'vitest';
+import { deriveSessionFacet } from './derive.js';
+import { SessionFacetSchema, type StoredSessionInput } from './schema.js';
+
+function richSession(): StoredSessionInput {
+  return {
+    sessionId: 'sess-123',
+    name: 'add-user-auth-flow',
+    model: 'opus',
+    startedAt: 1_000_000,
+    savedAt: 1_000_000 + 5 * 60_000, // +5 min
+    totalTurns: 2,
+    totalCostUsd: 0,
+    totalTokens: 100,
+    totalDurationMs: 5 * 60_000,
+    turns: [
+      {
+        user: '/deploy the auth service',
+        assistant: 'Done — deployed.',
+        timestamp: 1,
+        toolEvents: [
+          { toolName: 'read_file', toolUseId: 'a', input: JSON.stringify({ file_path: '/src/a.ts' }) },
+          { toolName: 'write_file', toolUseId: 'b', input: JSON.stringify({ file_path: '/src/b.ts', content: 'x' }) },
+          { toolName: 'edit_file', toolUseId: 'c', input: JSON.stringify({ file_path: '/src/a.ts' }) },
+          { toolName: 'bash', toolUseId: 'd', input: JSON.stringify({ command: 'git commit -m "x"' }) },
+          { toolName: 'bash', toolUseId: 'e', input: JSON.stringify({ command: 'ls' }), isError: true },
+          { toolName: 'agent', toolUseId: 'f', input: JSON.stringify({ id_prefix: 'verify', prompt: '…' }) },
+          { toolName: 'skill', toolUseId: 'g', input: JSON.stringify({ name: 'review', arguments: '' }) },
+          { toolName: 'compose', toolUseId: 'h', input: JSON.stringify({ nodes: [] }) },
+        ],
+      },
+      {
+        user: 'thanks',
+        assistant: 'You are welcome.',
+        timestamp: 2,
+        toolEvents: [{ toolName: 'read_file', toolUseId: 'i', input: JSON.stringify({ file_path: '/src/b.ts' }) }],
+      },
+    ],
+  };
+}
+
+describe('deriveSessionFacet', () => {
+  it('produces a schema-valid facet', () => {
+    const facet = deriveSessionFacet(richSession());
+    expect(SessionFacetSchema.safeParse(facet).success).toBe(true);
+    expect(facet.facet_version).toBe(1);
+    expect(facet.derived_from).toBe('afk-session');
+  });
+
+  it('derives identity and timestamps', () => {
+    const facet = deriveSessionFacet(richSession());
+    expect(facet.session_id).toBe('sess-123');
+    expect(facet.source).toBe('cli'); // undefined source → cli
+    expect(facet.model).toBe('opus');
+    expect(facet.duration_minutes).toBe(5);
+    expect(facet.start_time).toBe(new Date(1_000_000).toISOString());
+  });
+
+  it('aggregates tool counts and errors mechanically', () => {
+    const facet = deriveSessionFacet(richSession());
+    expect(facet.tool_counts).toEqual({
+      read_file: 2,
+      write_file: 1,
+      edit_file: 1,
+      bash: 2,
+      agent: 1,
+      skill: 1,
+      compose: 1,
+    });
+    expect(facet.tool_errors).toBe(1);
+    expect(facet.tool_error_categories).toEqual({ bash: 1 });
+    expect(facet.friction_counts).toEqual({ bash: 1 });
+    expect(facet.friction_detail).toBe('1 tool error(s): bash×1');
+  });
+
+  it('reconstructs subagent invocations and stamps not_persisted', () => {
+    const facet = deriveSessionFacet(richSession());
+    expect(facet.subagent_persistence).toBe('not_persisted');
+    expect(facet.subagents).toEqual([
+      { tool: 'agent', label: 'verify' },
+      { tool: 'skill', label: 'review' },
+      { tool: 'compose', label: 'compose' },
+    ]);
+    expect(facet.skills).toEqual(['review']);
+  });
+
+  it('extracts slash commands and counts messages', () => {
+    const facet = deriveSessionFacet(richSession());
+    expect(facet.commands).toEqual(['deploy']);
+    expect(facet.total_turns).toBe(2);
+    expect(facet.user_message_count).toBe(2);
+    expect(facet.assistant_message_count).toBe(2);
+  });
+
+  it('derives world changes and evidence pointers', () => {
+    const facet = deriveSessionFacet(richSession());
+    expect(facet.world_changes).toEqual({
+      files_written: 1,
+      files_edited: 1,
+      bash_commands: 2,
+      commits: 1,
+      mutated: true,
+    });
+    expect(facet.evidence_pointers).toEqual(['/src/a.ts', '/src/b.ts']);
+  });
+
+  it('classifies outcome and semantic fields for a completed session', () => {
+    const facet = deriveSessionFacet(richSession());
+    expect(facet.outcome).toBe('fully_achieved');
+    expect(facet.primary_success).toBe('You are welcome.');
+    expect(facet.session_type).toBe('slash_command');
+    expect(facet.goal_categories).toEqual({ slash_command: 1 });
+    expect(facet.underlying_goal).toBe('/deploy the auth service');
+    expect(facet.brief_summary).toContain('add user auth flow');
+    expect(facet.brief_summary).toContain('You are welcome.');
+    expect(facet.decisions).toEqual([]);
+  });
+
+  it('uses an injected clock for deterministic derived_at', () => {
+    const facet = deriveSessionFacet(richSession(), { derivedAt: new Date(0) });
+    expect(facet.derived_at).toBe('1970-01-01T00:00:00.000Z');
+  });
+
+  it('appends the source session path to evidence when provided', () => {
+    const facet = deriveSessionFacet(richSession(), { sourceSessionPath: '/sessions/sess-123.json' });
+    expect(facet.evidence_pointers).toEqual(['/src/a.ts', '/src/b.ts', '/sessions/sess-123.json']);
+    expect(facet.source_session_path).toBe('/sessions/sess-123.json');
+  });
+
+  it('treats a zero-turn session as aborted with empty friction', () => {
+    const facet = deriveSessionFacet({
+      sessionId: 'empty-1',
+      model: 'haiku',
+      startedAt: 0,
+      savedAt: 0,
+      totalTurns: 0,
+      turns: [],
+    });
+    expect(facet.outcome).toBe('aborted');
+    expect(facet.primary_success).toBe('none');
+    expect(facet.friction_detail).toBe('');
+    expect(facet.friction_counts).toEqual({});
+    expect(facet.tool_errors).toBe(0);
+    expect(facet.brief_summary).toBe('empty session');
+    expect(facet.session_type).toBe('task');
+  });
+
+  it('marks a session with no completed assistant reply as partially_achieved', () => {
+    const facet = deriveSessionFacet({
+      sessionId: 'partial-1',
+      model: 'sonnet',
+      startedAt: 0,
+      savedAt: 0,
+      totalTurns: 1,
+      turns: [{ user: 'hi', assistant: '', timestamp: 1 }],
+    });
+    expect(facet.outcome).toBe('partially_achieved');
+    expect(facet.primary_success).toBe('hi');
+    expect(facet.assistant_message_count).toBe(0);
+  });
+
+  it('survives malformed tool input without throwing', () => {
+    const facet = deriveSessionFacet({
+      sessionId: 'bad-input',
+      model: 'opus',
+      startedAt: 0,
+      savedAt: 60_000,
+      totalTurns: 1,
+      turns: [
+        {
+          user: 'go',
+          assistant: 'ok',
+          timestamp: 1,
+          toolEvents: [
+            { toolName: 'bash', toolUseId: 'x', input: 'not-json-at-all' },
+            { toolName: 'write_file', toolUseId: 'y' }, // no input field
+          ],
+        },
+      ],
+    });
+    expect(facet.tool_counts).toEqual({ bash: 1, write_file: 1 });
+    expect(facet.world_changes.files_written).toBe(1);
+    expect(facet.world_changes.commits).toBe(0);
+    expect(facet.evidence_pointers).toEqual([]);
+  });
+
+  it('prefers inputRaw over the summarized input for exact field extraction', () => {
+    // `input` is the summarized hint a provider emits (NOT valid JSON for field
+    // extraction); `inputRaw` carries the exact whitelisted fields. Derivation
+    // must read inputRaw — if the wire dropped it, the non-JSON `input` fallback
+    // would extract nothing and these assertions would fail.
+    const facet = deriveSessionFacet({
+      sessionId: 'raw-precedence',
+      model: 'opus',
+      startedAt: 0,
+      savedAt: 60_000,
+      totalTurns: 1,
+      turns: [
+        {
+          user: 'go',
+          assistant: 'ok',
+          timestamp: 1,
+          toolEvents: [
+            { toolName: 'bash', toolUseId: 'a', input: ' git commit', inputRaw: JSON.stringify({ command: 'git commit -m "x"' }) },
+            { toolName: 'write_file', toolUseId: 'b', input: ' /src/a.ts', inputRaw: JSON.stringify({ file_path: '/src/a.ts' }) },
+          ],
+        },
+      ],
+    });
+    expect(facet.world_changes.commits).toBe(1);
+    expect(facet.world_changes.bash_commands).toBe(1);
+    expect(facet.world_changes.files_written).toBe(1);
+    expect(facet.evidence_pointers).toEqual(['/src/a.ts']);
+  });
+
+  it('counts a real git commit but excludes git commit-tree', () => {
+    const facet = deriveSessionFacet({
+      sessionId: 'commit-re',
+      model: 'opus',
+      startedAt: 0,
+      savedAt: 60_000,
+      totalTurns: 1,
+      turns: [
+        {
+          user: 'go',
+          assistant: 'ok',
+          timestamp: 1,
+          toolEvents: [
+            { toolName: 'bash', toolUseId: '1', inputRaw: JSON.stringify({ command: 'git commit -m "real"' }) },
+            { toolName: 'bash', toolUseId: '2', inputRaw: JSON.stringify({ command: 'git commit-tree HEAD' }) },
+          ],
+        },
+      ],
+    });
+    expect(facet.world_changes.commits).toBe(1);
+  });
+
+  it('detects a commit from the summarized input when inputRaw omits command', () => {
+    // Post-fix sidecars do NOT persist the raw bash `command` (secret-at-rest),
+    // so commit detection falls back to the summarized first-line `input`
+    // (leading space, as summarizeToolInput emits it).
+    const facet = deriveSessionFacet({
+      sessionId: 'summarized-commit',
+      model: 'opus',
+      startedAt: 0,
+      savedAt: 60_000,
+      totalTurns: 1,
+      turns: [
+        {
+          user: 'go',
+          assistant: 'ok',
+          timestamp: 1,
+          toolEvents: [
+            { toolName: 'bash', toolUseId: '1', input: ' git commit -m "real"' },
+            { toolName: 'bash', toolUseId: '2', input: ' git commit-tree HEAD' },
+          ],
+        },
+      ],
+    });
+    expect(facet.world_changes.commits).toBe(1);
+    expect(facet.world_changes.bash_commands).toBe(2);
+  });
+
+  it('collapses the duplicate placeholder+real tool events the recorder persists', () => {
+    // The Anthropic streaming pipeline records TWO ToolEvent entries per tool
+    // call under one toolUseId: an early placeholder (input ' …', no result)
+    // pushed during streaming, then the real post-stream entry (summarized
+    // input + result). Both land in turns[].toolEvents. Mechanical counts must
+    // collapse them by toolUseId — counting each tool ONCE, not twice.
+    const facet = deriveSessionFacet({
+      sessionId: 'dup-events',
+      model: 'opus',
+      startedAt: 0,
+      savedAt: 60_000,
+      totalTurns: 1,
+      turns: [
+        {
+          user: 'go',
+          assistant: 'ok',
+          timestamp: 1,
+          toolEvents: [
+            // placeholders (emitted first, during streaming — no inputRaw, no result)
+            { toolName: 'bash', toolUseId: 'tu_1', input: ' …' },
+            { toolName: 'write_file', toolUseId: 'tu_2', input: ' …' },
+            { toolName: 'bash', toolUseId: 'tu_3', input: ' …' },
+            // real entries (emitted post-stream, SAME ids, with summary + result)
+            { toolName: 'bash', toolUseId: 'tu_1', input: ' git commit -m "x"', isError: false },
+            {
+              toolName: 'write_file',
+              toolUseId: 'tu_2',
+              input: ' /src/a.ts',
+              inputRaw: JSON.stringify({ file_path: '/src/a.ts' }),
+              isError: false,
+            },
+            { toolName: 'bash', toolUseId: 'tu_3', input: ' ls', isError: false },
+          ],
+        },
+      ],
+    });
+    // Without dedup these would be {bash: 4, write_file: 2}.
+    expect(facet.tool_counts).toEqual({ bash: 2, write_file: 1 });
+    expect(facet.world_changes.bash_commands).toBe(2);
+    expect(facet.world_changes.files_written).toBe(1);
+    expect(facet.world_changes.commits).toBe(1);
+    expect(facet.evidence_pointers).toEqual(['/src/a.ts']);
+  });
+
+  it('counts events without a toolUseId individually (cannot be paired)', () => {
+    // Defensive: events lacking a toolUseId can't be deduped, so each must count.
+    const facet = deriveSessionFacet({
+      sessionId: 'no-id',
+      model: 'opus',
+      startedAt: 0,
+      savedAt: 60_000,
+      totalTurns: 1,
+      turns: [
+        {
+          user: 'go',
+          assistant: 'ok',
+          timestamp: 1,
+          toolEvents: [
+            { toolName: 'read_file', input: JSON.stringify({ file_path: '/a.ts' }) },
+            { toolName: 'read_file', input: JSON.stringify({ file_path: '/b.ts' }) },
+          ],
+        },
+      ],
+    });
+    expect(facet.tool_counts).toEqual({ read_file: 2 });
+  });
+});

--- a/src/agent/facets/derive.ts
+++ b/src/agent/facets/derive.ts
@@ -1,0 +1,270 @@
+/**
+ * deriveSessionFacet — pure function: StoredSessionInput → validated SessionFacet.
+ *
+ * No I/O, no clock reads unless injected (see DeriveOptions.derivedAt) — so it
+ * is deterministic and trivially testable. The store layer (store.ts) handles
+ * disk reads, caching, and staleness.
+ *
+ * Derivation tiers:
+ *   - MECHANICAL (exact): tool_counts, tool_errors/categories, world_changes,
+ *     durations, message counts, subagent invocations, evidence pointers.
+ *   - SEMANTIC (heuristic, v1): underlying_goal (= first prompt, capped),
+ *     goal_categories, session_type, brief_summary, outcome, primary_success.
+ *     `decisions` is intentionally empty in v1 — it needs an LLM digest pass.
+ */
+
+import { basename } from 'path';
+import {
+  FACET_VERSION,
+  SessionFacetSchema,
+  type FacetOutcome,
+  type SessionFacet,
+  type StoredSessionInput,
+  type SubagentInvocation,
+  type ToolEventInput,
+} from './schema.js';
+
+export interface DeriveOptions {
+  /** Absolute path of the source session sidecar (recorded for provenance). */
+  sourceSessionPath?: string;
+  /** mtime (ms) of the source sidecar — used by the store for staleness. */
+  sourceSessionMtimeMs?: number;
+  /** Injectable clock for deterministic tests. Defaults to `new Date()`. */
+  derivedAt?: Date;
+}
+
+const SUBAGENT_TOOLS = new Set(['agent', 'compose', 'skill']);
+const FILE_TOOLS = new Set(['read_file', 'write_file', 'edit_file']);
+const GOAL_CAP = 1000;
+const SUMMARY_CAP = 240;
+const EVIDENCE_CAP = 50;
+// `(?![\w-])` rejects `git commit-tree` / `git commits` (a trailing word char or
+// hyphen) while still matching `git commit`, `git commit -m …`, `git commit;`.
+const COMMIT_RE = /\bgit\s+commit(?![\w-])/;
+const SLASH_CMD_RE = /^\s*\/([a-zA-Z][\w-]*)/;
+
+/** Parse a stringified tool input to an object, swallowing malformed JSON. */
+function parseInput(input: string | undefined): Record<string, unknown> | undefined {
+  if (!input) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(input);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+/** Collapse whitespace and cap length for single-line summary fields. */
+function oneLine(text: string, cap: number): string {
+  const flat = text.replace(/\s+/g, ' ').trim();
+  return flat.length > cap ? `${flat.slice(0, cap - 1)}…` : flat;
+}
+
+function humanizeName(name: string): string {
+  return name.replace(/[-_]+/g, ' ').trim();
+}
+
+function classifySessionType(firstPrompt: string, source: string): string {
+  if (SLASH_CMD_RE.test(firstPrompt)) return 'slash_command';
+  if (source === 'telegram') return 'chat';
+  return 'task';
+}
+
+/**
+ * Invariant: the recorder persists TWO ToolEvent entries per tool call under one
+ * toolUseId — an early placeholder emitted at content_block_start (translate.ts:
+ * input ' …', no inputRaw, no result) and the real entry emitted post-stream
+ * (loop.ts: summarized input + result). Both are pushed to the turn's toolEvents
+ * array (turn-handler.ts / background.ts), so counting raw events double-counts
+ * every tool. The real entry is always emitted AFTER its placeholder, so a
+ * last-write-wins Map keyed by toolUseId keeps the real one; Map iteration order
+ * preserves each id's first-seen position (call order). Events without a
+ * toolUseId cannot be paired and are kept individually.
+ */
+function dedupeToolEvents(events: ToolEventInput[]): ToolEventInput[] {
+  const byId = new Map<string, ToolEventInput>();
+  const noId: ToolEventInput[] = [];
+  for (const ev of events) {
+    if (ev.toolUseId === undefined) noId.push(ev);
+    else byId.set(ev.toolUseId, ev); // last write wins → real entry supersedes placeholder
+  }
+  return [...byId.values(), ...noId];
+}
+
+export function deriveSessionFacet(
+  session: StoredSessionInput,
+  options: DeriveOptions = {},
+): SessionFacet {
+  const turns = session.turns ?? [];
+  const allEvents: ToolEventInput[] = dedupeToolEvents(turns.flatMap((t) => t.toolEvents ?? []));
+
+  // --- mechanical: tool + error aggregation ---
+  const toolCounts: Record<string, number> = {};
+  const toolErrorCategories: Record<string, number> = {};
+  const subagents: SubagentInvocation[] = [];
+  const skills: string[] = [];
+  const evidencePaths: string[] = [];
+  let toolErrors = 0;
+  let filesWritten = 0;
+  let filesEdited = 0;
+  let bashCommands = 0;
+  let commits = 0;
+
+  for (const ev of allEvents) {
+    const name = ev.toolName;
+    toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+
+    if (ev.isError === true) {
+      toolErrors += 1;
+      toolErrorCategories[name] = (toolErrorCategories[name] ?? 0) + 1;
+    }
+
+    // Prefer inputRaw (full JSON, populated for sessions recorded after this fix) over
+    // input (summarized string). For older sidecars without inputRaw, parseInput falls
+    // back to input — which will still return undefined for summarized strings, preserving
+    // the pre-fix behaviour rather than crashing.
+    const parsed = parseInput(ev.inputRaw ?? ev.input);
+
+    if (name === 'write_file') filesWritten += 1;
+    if (name === 'edit_file') filesEdited += 1;
+    if (name === 'bash') {
+      bashCommands += 1;
+      // Commit detection reads the parsed `command` when present (older sidecars
+      // written before the secret-at-rest fix) and otherwise falls back to the
+      // summarized `input` (≤80-char first line). The raw `command` is no longer
+      // persisted to inputRaw — it can carry inline secrets verbatim — so for
+      // current sidecars detection runs against the truncated summary, which
+      // still catches a leading `git commit`. See raw-input.ts.
+      const cmd = asString(parsed?.['command']) ?? ev.input;
+      if (cmd && COMMIT_RE.test(cmd)) commits += 1;
+    }
+
+    if (FILE_TOOLS.has(name)) {
+      const fp = asString(parsed?.['file_path']);
+      if (fp && !evidencePaths.includes(fp) && evidencePaths.length < EVIDENCE_CAP) {
+        evidencePaths.push(fp);
+      }
+    }
+
+    if (SUBAGENT_TOOLS.has(name)) {
+      let label: string | undefined;
+      if (name === 'skill') {
+        label = asString(parsed?.['name']);
+        if (label && !skills.includes(label)) skills.push(label);
+      } else if (name === 'agent') {
+        label = asString(parsed?.['id_prefix']);
+      } else {
+        label = 'compose';
+      }
+      subagents.push(label ? { tool: name, label } : { tool: name });
+    }
+  }
+
+  // --- semantic (heuristic) ---
+  const firstPrompt = turns[0]?.user ?? '';
+  const source = session.source ?? 'cli';
+  const sessionType = classifySessionType(firstPrompt, source);
+
+  const commands: string[] = [];
+  for (const t of turns) {
+    const m = SLASH_CMD_RE.exec(t.user ?? '');
+    const cmd = m?.[1];
+    if (cmd && !commands.includes(cmd)) commands.push(cmd);
+  }
+
+  const userMessageCount = turns.filter((t) => (t.user ?? '').trim().length > 0).length;
+  const assistantMessageCount = turns.filter((t) => (t.assistant ?? '').trim().length > 0).length;
+
+  const lastAssistant = [...turns].reverse().find((t) => (t.assistant ?? '').trim().length > 0)?.assistant ?? '';
+
+  let outcome: FacetOutcome;
+  if (turns.length === 0) outcome = 'aborted';
+  else if (lastAssistant.trim().length === 0) outcome = 'partially_achieved';
+  else outcome = 'fully_achieved';
+
+  // Skip-gate semantics (consumers compare primary_success === 'none' and read
+  // friction_detail non-emptiness): 'none' for non-completing sessions.
+  const succeeded = outcome === 'fully_achieved' || outcome === 'partially_achieved';
+  const primarySuccess = succeeded
+    ? oneLine(lastAssistant || firstPrompt || sessionType, 160) || sessionType
+    : 'none';
+
+  const frictionDetail =
+    toolErrors > 0
+      ? `${toolErrors} tool error(s): ${Object.entries(toolErrorCategories)
+          .map(([k, v]) => `${k}×${v}`)
+          .join(', ')}`
+      : '';
+
+  const summaryHead = session.name ? humanizeName(session.name) : oneLine(firstPrompt, 80);
+  const summaryTail = oneLine(lastAssistant || firstPrompt, SUMMARY_CAP);
+  const briefSummary = oneLine(summaryHead ? `${summaryHead} — ${summaryTail}` : summaryTail, 400) || 'empty session';
+
+  const sessionId =
+    session.sessionId ??
+    (options.sourceSessionPath ? basename(options.sourceSessionPath, '.json') : 'unknown');
+
+  const durationMs =
+    session.totalDurationMs && session.totalDurationMs > 0
+      ? session.totalDurationMs
+      : Math.max(0, session.savedAt - session.startedAt);
+
+  const evidencePointers = options.sourceSessionPath
+    ? [...evidencePaths, options.sourceSessionPath]
+    : evidencePaths;
+
+  const facet: SessionFacet = {
+    facet_version: FACET_VERSION,
+    session_id: sessionId,
+    source: source === 'telegram' ? 'telegram' : 'cli',
+    model: session.model,
+    derived_at: (options.derivedAt ?? new Date()).toISOString(),
+    derived_from: 'afk-session',
+    source_session_path: options.sourceSessionPath ?? '',
+    source_session_mtime_ms: options.sourceSessionMtimeMs ?? session.savedAt,
+    subagent_persistence: 'not_persisted',
+
+    start_time: new Date(session.startedAt).toISOString(),
+    end_time: new Date(session.savedAt).toISOString(),
+    duration_minutes: Number((durationMs / 60000).toFixed(2)),
+
+    underlying_goal: firstPrompt.slice(0, GOAL_CAP),
+    first_prompt: firstPrompt.slice(0, GOAL_CAP),
+    goal_categories: { [sessionType]: 1 },
+    session_type: sessionType,
+    brief_summary: briefSummary,
+
+    total_turns: turns.length,
+    user_message_count: userMessageCount,
+    assistant_message_count: assistantMessageCount,
+    tool_counts: toolCounts,
+    commands,
+    skills,
+    subagents,
+
+    tool_errors: toolErrors,
+    tool_error_categories: toolErrorCategories,
+    friction_counts: { ...toolErrorCategories },
+    friction_detail: frictionDetail,
+
+    outcome,
+    primary_success: primarySuccess,
+    world_changes: {
+      files_written: filesWritten,
+      files_edited: filesEdited,
+      bash_commands: bashCommands,
+      commits,
+      mutated: filesWritten > 0 || filesEdited > 0 || commits > 0,
+    },
+
+    decisions: [],
+    evidence_pointers: evidencePointers,
+  };
+
+  // Validate on the way out so callers can rely on a well-formed facet.
+  return SessionFacetSchema.parse(facet);
+}

--- a/src/agent/facets/index.ts
+++ b/src/agent/facets/index.ts
@@ -1,0 +1,40 @@
+/**
+ * src/agent/facets — AFK-native session facets.
+ *
+ * A SessionFacet is a structured, consumer-facing projection of a persisted
+ * session, derived lazily and cached on disk. Consumers (evals, debug views,
+ * improvement loops) depend on this public surface — never on the raw
+ * session-store shape.
+ *
+ * Public API:
+ *   - deriveSessionFacet(session, opts) — pure session → facet
+ *   - getOrDeriveFacet(id, opts)        — lazy read-through cache
+ *   - loadStoredSession(id, dir)        — validated session loader
+ *   - listSessionIds(opts)             — enumerate persisted sessions
+ *   - SessionFacet / schema exports
+ */
+
+export {
+  FACET_VERSION,
+  SessionFacetSchema,
+  StoredSessionInputSchema,
+  FacetOutcomeSchema,
+  SubagentPersistenceSchema,
+  SubagentInvocationSchema,
+  WorldChangesSchema,
+  type SessionFacet,
+  type StoredSessionInput,
+  type ToolEventInput,
+  type FacetOutcome,
+  type SubagentInvocation,
+  type WorldChanges,
+} from './schema.js';
+
+export { deriveSessionFacet, type DeriveOptions } from './derive.js';
+
+export {
+  getOrDeriveFacet,
+  loadStoredSession,
+  listSessionIds,
+  type FacetStoreOptions,
+} from './store.js';

--- a/src/agent/facets/raw-input.test.ts
+++ b/src/agent/facets/raw-input.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { extractRawToolInput, RAW_INPUT_FIELDS, RAW_INPUT_FIELD_CAP } from './raw-input.js';
+
+describe('extractRawToolInput', () => {
+  it('keeps exactly the whitelisted scalar fields derivation reads', () => {
+    const raw = extractRawToolInput({
+      command: 'git commit -m "x"',
+      file_path: '/src/a.ts',
+      name: 'review',
+      id_prefix: 'verify',
+    });
+    expect(raw).toBeDefined();
+    // `command` is intentionally excluded (secret-at-rest risk); the rest are kept.
+    expect(JSON.parse(raw as string)).toEqual({
+      file_path: '/src/a.ts',
+      name: 'review',
+      id_prefix: 'verify',
+    });
+    // The whitelist is the documented contract — `command` is not in it.
+    expect([...RAW_INPUT_FIELDS]).toEqual(['file_path', 'name', 'id_prefix']);
+  });
+
+  it('drops large/sensitive fields (command, content, new_string, old_string, value)', () => {
+    const raw = extractRawToolInput({
+      file_path: '/src/secret.ts',
+      command: 'curl -H "Authorization: Bearer sk-leaked-bash-secret" https://api.example.com',
+      content: 'API_KEY=sk-supersecret-value',
+      new_string: 'token = "sk-leaked-edit"',
+      old_string: 'previous',
+      value: 'hunter2-password',
+    });
+    expect(JSON.parse(raw as string)).toEqual({ file_path: '/src/secret.ts' });
+    // Secrets carried by the dropped fields — including a bash `command` — never reach the serialized form.
+    expect(raw).not.toContain('sk-leaked-bash-secret');
+    expect(raw).not.toContain('sk-supersecret');
+    expect(raw).not.toContain('sk-leaked-edit');
+    expect(raw).not.toContain('hunter2-password');
+  });
+
+  it('caps a pathologically large field value', () => {
+    const huge = 'x'.repeat(RAW_INPUT_FIELD_CAP + 5_000);
+    const raw = extractRawToolInput({ file_path: huge });
+    const parsed = JSON.parse(raw as string) as { file_path: string };
+    expect(parsed.file_path.length).toBe(RAW_INPUT_FIELD_CAP);
+  });
+
+  it('returns undefined when no whitelisted field is present', () => {
+    expect(extractRawToolInput({ content: 'x', value: 'y' })).toBeUndefined();
+    expect(extractRawToolInput({})).toBeUndefined();
+  });
+
+  it('returns undefined for non-object inputs', () => {
+    expect(extractRawToolInput('not-an-object')).toBeUndefined();
+    expect(extractRawToolInput(null)).toBeUndefined();
+    expect(extractRawToolInput(undefined)).toBeUndefined();
+    expect(extractRawToolInput(42)).toBeUndefined();
+  });
+});

--- a/src/agent/facets/raw-input.ts
+++ b/src/agent/facets/raw-input.ts
@@ -1,0 +1,60 @@
+/**
+ * Raw tool-input whitelist for facet derivation.
+ *
+ * The provider hot loop (anthropic-direct/loop.ts, openai-compatible/query.ts)
+ * stamps a `toolInputRaw` field onto each tool-use event so facet derivation
+ * (derive.ts) can extract the exact tool-input fields the summarized `input`
+ * string loses. The whitelist holds ONLY non-sensitive scalar identifiers:
+ *   - file_path  → read/write/edit evidence pointers
+ *   - name       → skill label
+ *   - id_prefix  → agent (subagent) label
+ *
+ * `command` is deliberately NOT whitelisted. A bash command is the single
+ * highest inline-secret risk of any tool input (`export TOKEN=…`,
+ * `curl -H "Authorization: Bearer …"`, `psql "postgres://user:pass@…"`), and
+ * persisting it verbatim to the on-disk session sidecar would defeat the point
+ * of this whitelist. derive.ts's only use of `command` is git-commit detection,
+ * which runs against the already-truncated summarized `input` (≤80-char first
+ * line) instead — so no full command is ever persisted. (Sidecars written
+ * before this fix may still carry `command` in inputRaw; derive.ts reads it
+ * there for backward-compat, but nothing writes it anymore.)
+ *
+ * Persisting the FULL raw input would write large and/or sensitive fields
+ * verbatim to the sidecar on every tool call — write_file `content`, edit_file
+ * `new_string`/`old_string`, browser_act `value`, and bash `command` — for zero
+ * derivation benefit. `extractRawToolInput` projects the input down to the
+ * whitelisted fields above and caps each, bounding sidecar growth and shrinking
+ * the secret-at-rest surface.
+ *
+ * Invariant: RAW_INPUT_FIELDS must hold only non-sensitive scalar fields that
+ * derive.ts reads AND that are safe to persist verbatim. This module is the
+ * single source of that contract — never add a secret-bearing field (notably
+ * `command`); add a field only when derive.ts consumes it and it cannot leak.
+ */
+
+/** The exact non-sensitive scalar fields facet derivation reads from a tool input. */
+export const RAW_INPUT_FIELDS = ['file_path', 'name', 'id_prefix'] as const;
+
+/** Per-field character cap — a pathologically large field value is truncated. */
+export const RAW_INPUT_FIELD_CAP = 4096;
+
+/**
+ * Project a tool input down to the whitelisted scalar fields facet derivation
+ * consumes, JSON-serialized. Returns `undefined` when the input is not an
+ * object or carries none of the relevant fields, so callers store nothing
+ * rather than an empty `{}`. String fields are capped at RAW_INPUT_FIELD_CAP.
+ */
+export function extractRawToolInput(input: unknown): string | undefined {
+  if (!input || typeof input !== 'object') return undefined;
+  const obj = input as Record<string, unknown>;
+  const picked: Record<string, unknown> = {};
+  for (const key of RAW_INPUT_FIELDS) {
+    const value = obj[key];
+    if (value === undefined) continue;
+    picked[key] =
+      typeof value === 'string' && value.length > RAW_INPUT_FIELD_CAP
+        ? value.slice(0, RAW_INPUT_FIELD_CAP)
+        : value;
+  }
+  return Object.keys(picked).length > 0 ? JSON.stringify(picked) : undefined;
+}

--- a/src/agent/facets/schema.ts
+++ b/src/agent/facets/schema.ts
@@ -1,0 +1,168 @@
+/**
+ * SessionFacet — the canonical, consumer-facing projection of an AFK session.
+ *
+ * A facet is a structured summary derived from a persisted `StoredSession`
+ * (~/.afk/state/sessions/<id>.json). Downstream consumers (evals, debug views,
+ * improvement loops) read facets instead of raw session
+ * internals, so the session-store shape can evolve without breaking them.
+ *
+ * Two schemas live here:
+ *   - StoredSessionInputSchema — the SUBSET of the persisted session this
+ *     module reads. Defined locally (not imported from src/cli/session-store)
+ *     to honour the layering invariant: src/agent/ must never import src/cli/.
+ *     `.passthrough()` keeps unknown fields rather than stripping them.
+ *   - SessionFacetSchema — the derived, validated output object.
+ *
+ * Field tiers (see derive.ts): MECHANICAL fields (tool_counts, tool_errors,
+ * durations, world_changes) are computed exactly from the session; SEMANTIC
+ * fields (goal_categories, brief_summary, outcome, primary_success) are
+ * heuristic in v1 and enrichable later by an LLM digest pass — kept honest,
+ * never fabricated.
+ */
+
+import { z } from 'zod';
+
+/** Bump when the facet shape or derivation changes — invalidates caches. */
+export const FACET_VERSION = 1;
+
+// ---------------------------------------------------------------------------
+// Input: the subset of StoredSession the deriver reads (local, layering-safe)
+// ---------------------------------------------------------------------------
+
+export const ToolEventInputSchema = z
+  .object({
+    toolName: z.string(),
+    toolUseId: z.string().optional(),
+    input: z.string().optional(),
+    /** Raw JSON-serialized tool input — populated by the CLI session writer for exact field extraction. */
+    inputRaw: z.string().optional(),
+    result: z.string().optional(),
+    isError: z.boolean().optional(),
+  })
+  .passthrough();
+
+export const TurnInputSchema = z
+  .object({
+    user: z.string().default(''),
+    assistant: z.string().default(''),
+    timestamp: z.number().optional(),
+    toolEvents: z.array(ToolEventInputSchema).optional(),
+  })
+  .passthrough();
+
+export const StoredSessionInputSchema = z
+  .object({
+    sessionId: z.string().optional(),
+    name: z.string().optional(),
+    source: z.enum(['cli', 'telegram']).optional(),
+    telegramChatId: z.number().optional(),
+    model: z.string(),
+    startedAt: z.number(),
+    savedAt: z.number(),
+    totalTurns: z.number(),
+    totalCostUsd: z.number().optional(),
+    totalTokens: z.number().optional(),
+    totalDurationMs: z.number().optional(),
+    turns: z.array(TurnInputSchema).default([]),
+    forkedFrom: z.string().optional(),
+    forkedAt: z.number().optional(),
+  })
+  .passthrough();
+
+export type StoredSessionInput = z.infer<typeof StoredSessionInputSchema>;
+export type ToolEventInput = z.infer<typeof ToolEventInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Output: the derived SessionFacet
+// ---------------------------------------------------------------------------
+
+export const FacetOutcomeSchema = z.enum([
+  'fully_achieved',
+  'partially_achieved',
+  'not_achieved',
+  'aborted',
+]);
+export type FacetOutcome = z.infer<typeof FacetOutcomeSchema>;
+
+/**
+ * Whether the transcripts of any subagents this session spawned are separately
+ * persisted. In AFK they are NOT (forked subagent sessions never call
+ * saveSession), so facets reconstruct subagent *invocations* from the parent's
+ * tool events and stamp this 'not_persisted'. See derive.ts.
+ */
+export const SubagentPersistenceSchema = z.enum([
+  'not_persisted',
+  'persisted',
+  'unknown',
+]);
+
+export const SubagentInvocationSchema = z.object({
+  /** Dispatch tool: 'agent' | 'compose' | 'skill'. */
+  tool: z.string(),
+  /** Best-effort label: id_prefix (agent), skill name (skill), or 'compose'. */
+  label: z.string().optional(),
+});
+
+export const WorldChangesSchema = z.object({
+  files_written: z.number().int(),
+  files_edited: z.number().int(),
+  bash_commands: z.number().int(),
+  commits: z.number().int(),
+  /** True if the session performed any state-mutating action. */
+  mutated: z.boolean(),
+});
+
+export const SessionFacetSchema = z
+  .object({
+    // provenance & identity
+    facet_version: z.number().int(),
+    session_id: z.string(),
+    source: z.enum(['cli', 'telegram', 'unknown']),
+    model: z.string(),
+    derived_at: z.string(),
+    derived_from: z.literal('afk-session'),
+    source_session_path: z.string(),
+    source_session_mtime_ms: z.number(),
+    subagent_persistence: SubagentPersistenceSchema,
+
+    // timestamps
+    start_time: z.string(),
+    end_time: z.string(),
+    duration_minutes: z.number(),
+
+    // goal / ask
+    underlying_goal: z.string(),
+    first_prompt: z.string(),
+    goal_categories: z.record(z.string(), z.number()),
+    session_type: z.string(),
+    brief_summary: z.string(),
+
+    // activity: tools / commands / skills / subagents
+    total_turns: z.number().int(),
+    user_message_count: z.number().int(),
+    assistant_message_count: z.number().int(),
+    tool_counts: z.record(z.string(), z.number()),
+    commands: z.array(z.string()),
+    skills: z.array(z.string()),
+    subagents: z.array(SubagentInvocationSchema),
+
+    // errors / friction
+    tool_errors: z.number().int(),
+    tool_error_categories: z.record(z.string(), z.number()),
+    friction_counts: z.record(z.string(), z.number()),
+    friction_detail: z.string(),
+
+    // outcome / world changes
+    outcome: FacetOutcomeSchema,
+    primary_success: z.string(),
+    world_changes: WorldChangesSchema,
+
+    // decisions / evidence (v1-thin; semantic-enrichable)
+    decisions: z.array(z.string()),
+    evidence_pointers: z.array(z.string()),
+  })
+  .passthrough();
+
+export type SessionFacet = z.infer<typeof SessionFacetSchema>;
+export type SubagentInvocation = z.infer<typeof SubagentInvocationSchema>;
+export type WorldChanges = z.infer<typeof WorldChangesSchema>;

--- a/src/agent/facets/store.test.ts
+++ b/src/agent/facets/store.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { getOrDeriveFacet, listSessionIds, loadStoredSession } from './store.js';
+import type { StoredSessionInput } from './schema.js';
+
+let sessionsDir: string;
+let cacheDir: string;
+
+function sampleSession(id: string, overrides: Partial<StoredSessionInput> = {}): StoredSessionInput {
+  return {
+    sessionId: id,
+    name: 'sample-session',
+    model: 'opus',
+    startedAt: 1_000_000,
+    savedAt: 1_000_000 + 60_000,
+    totalTurns: 1,
+    totalCostUsd: 0,
+    totalTokens: 10,
+    totalDurationMs: 60_000,
+    turns: [
+      {
+        user: 'do the thing',
+        assistant: 'done',
+        timestamp: 1,
+        toolEvents: [{ toolName: 'bash', toolUseId: 'a', input: JSON.stringify({ command: 'ls' }) }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function writeSession(id: string, session: StoredSessionInput): string {
+  const path = join(sessionsDir, `${id}.json`);
+  writeFileSync(path, JSON.stringify(session), 'utf8');
+  return path;
+}
+
+function readCache(id: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(cacheDir, `${id}.json`), 'utf8')) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  sessionsDir = mkdtempSync(join(tmpdir(), 'afk-facet-sessions-'));
+  cacheDir = mkdtempSync(join(tmpdir(), 'afk-facet-cache-'));
+});
+
+afterEach(() => {
+  rmSync(sessionsDir, { recursive: true, force: true });
+  rmSync(cacheDir, { recursive: true, force: true });
+});
+
+describe('getOrDeriveFacet', () => {
+  it('derives and writes a cache entry on first read', () => {
+    writeSession('sess-a', sampleSession('sess-a'));
+    const facet = getOrDeriveFacet('sess-a', { sessionsDir, cacheDir });
+    expect(facet).toBeDefined();
+    expect(facet?.session_id).toBe('sess-a');
+    expect(existsSync(join(cacheDir, 'sess-a.json'))).toBe(true);
+  });
+
+  it('returns undefined for a missing session', () => {
+    expect(getOrDeriveFacet('does-not-exist', { sessionsDir, cacheDir })).toBeUndefined();
+  });
+
+  it('returns the cached facet without rewriting an unchanged session', () => {
+    writeSession('sess-b', sampleSession('sess-b'));
+    getOrDeriveFacet('sess-b', { sessionsDir, cacheDir });
+
+    // Tag the cache with a passthrough sentinel; a rewrite would erase it.
+    const cached = readCache('sess-b');
+    cached['_sentinel'] = 'keep';
+    writeFileSync(join(cacheDir, 'sess-b.json'), JSON.stringify(cached), 'utf8');
+
+    const second = getOrDeriveFacet('sess-b', { sessionsDir, cacheDir });
+    expect((second as Record<string, unknown>)['_sentinel']).toBe('keep');
+    expect(readCache('sess-b')['_sentinel']).toBe('keep');
+  });
+
+  it('re-derives when the session sidecar changes (staleness)', () => {
+    const path = writeSession('sess-c', sampleSession('sess-c'));
+    getOrDeriveFacet('sess-c', { sessionsDir, cacheDir });
+
+    const cached = readCache('sess-c');
+    cached['_sentinel'] = 'keep';
+    writeFileSync(join(cacheDir, 'sess-c.json'), JSON.stringify(cached), 'utf8');
+
+    // Bump the session mtime into the future to force a stale read.
+    const future = new Date(Date.now() + 100_000);
+    utimesSync(path, future, future);
+
+    const second = getOrDeriveFacet('sess-c', { sessionsDir, cacheDir });
+    expect(second).toBeDefined();
+    expect((second as Record<string, unknown>)['_sentinel']).toBeUndefined();
+    expect(readCache('sess-c')['_sentinel']).toBeUndefined();
+  });
+
+  it('force re-derives even when the cache is fresh', () => {
+    writeSession('sess-d', sampleSession('sess-d'));
+    getOrDeriveFacet('sess-d', { sessionsDir, cacheDir });
+
+    const cached = readCache('sess-d');
+    cached['_sentinel'] = 'keep';
+    writeFileSync(join(cacheDir, 'sess-d.json'), JSON.stringify(cached), 'utf8');
+
+    getOrDeriveFacet('sess-d', { sessionsDir, cacheDir, force: true });
+    expect(readCache('sess-d')['_sentinel']).toBeUndefined();
+  });
+});
+
+describe('loadStoredSession', () => {
+  it('returns undefined on corrupt JSON', () => {
+    writeFileSync(join(sessionsDir, 'broken.json'), 'not json {{{', 'utf8');
+    expect(loadStoredSession('broken', sessionsDir)).toBeUndefined();
+  });
+
+  it('loads and validates a well-formed session', () => {
+    writeSession('sess-e', sampleSession('sess-e'));
+    const loaded = loadStoredSession('sess-e', sessionsDir);
+    expect(loaded?.sessionId).toBe('sess-e');
+    expect(loaded?.turns).toHaveLength(1);
+  });
+});
+
+describe('listSessionIds', () => {
+  it('enumerates session sidecar ids', () => {
+    writeSession('sess-f', sampleSession('sess-f'));
+    writeSession('sess-g', sampleSession('sess-g'));
+    const ids = listSessionIds({ sessionsDir });
+    expect(ids.sort()).toEqual(['sess-f', 'sess-g']);
+  });
+
+  it('returns an empty array for a missing directory', () => {
+    expect(listSessionIds({ sessionsDir: join(sessionsDir, 'nope') })).toEqual([]);
+  });
+});

--- a/src/agent/facets/store.ts
+++ b/src/agent/facets/store.ts
@@ -1,0 +1,132 @@
+/**
+ * Facet store — lazy derive-on-read with a write-through disk cache.
+ *
+ * `getOrDeriveFacet(id)` returns the cached facet when it is still fresh
+ * (same FACET_VERSION and derived from the current session sidecar), otherwise
+ * it loads the session, derives a facet, writes it through to the cache, and
+ * returns it. Repeated reads of an unchanged session never rewrite the cache.
+ *
+ * Layering: this module reads session JSON directly via getSessionsDir() and
+ * validates it with the LOCAL StoredSessionInputSchema — it does NOT import
+ * the session-store loader from src/cli/ (src/agent must not depend on src/cli).
+ *
+ * All directory inputs are injectable so tests can point at temp dirs without
+ * touching $AFK_HOME.
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, writeFileSync } from 'fs';
+import { basename, dirname, join } from 'path';
+import { getFacetCacheDir, getSessionsDir, validateSessionId } from '../../paths.js';
+import { deriveSessionFacet } from './derive.js';
+import {
+  FACET_VERSION,
+  SessionFacetSchema,
+  StoredSessionInputSchema,
+  type SessionFacet,
+  type StoredSessionInput,
+} from './schema.js';
+
+export interface FacetStoreOptions {
+  /** Override the session sidecar directory (default: getSessionsDir()). */
+  sessionsDir?: string;
+  /** Override the facet cache directory (default: getFacetCacheDir()). */
+  cacheDir?: string;
+  /** Re-derive and rewrite even when a fresh cache entry exists. */
+  force?: boolean;
+}
+
+function sessionPathFor(sessionId: string, sessionsDir: string): string {
+  validateSessionId(sessionId);
+  return join(sessionsDir, `${sessionId}.json`);
+}
+
+function cachePathFor(sessionId: string, cacheDir: string): string {
+  validateSessionId(sessionId);
+  return join(cacheDir, `${sessionId}.json`);
+}
+
+/** Load + validate a persisted session sidecar. Returns undefined on miss/corruption. */
+export function loadStoredSession(
+  sessionId: string,
+  sessionsDir: string = getSessionsDir(),
+): StoredSessionInput | undefined {
+  const path = sessionPathFor(sessionId, sessionsDir);
+  if (!existsSync(path)) return undefined;
+  try {
+    const raw: unknown = JSON.parse(readFileSync(path, 'utf8'));
+    const parsed = StoredSessionInputSchema.safeParse(raw);
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readCachedFacet(cachePath: string): SessionFacet | undefined {
+  if (!existsSync(cachePath)) return undefined;
+  try {
+    const raw: unknown = JSON.parse(readFileSync(cachePath, 'utf8'));
+    const parsed = SessionFacetSchema.safeParse(raw);
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeFacet(cachePath: string, facet: SessionFacet): void {
+  mkdirSync(dirname(cachePath), { recursive: true });
+  // Atomic write: serialize to a sibling temp file then rename into place, so a
+  // crash mid-write can never leave a torn cache file (rename is atomic on the
+  // same filesystem). The .pid suffix avoids collisions between concurrent writers.
+  const tmpPath = `${cachePath}.${process.pid}.tmp`;
+  writeFileSync(tmpPath, `${JSON.stringify(facet, null, 2)}\n`, 'utf8');
+  renameSync(tmpPath, cachePath);
+}
+
+/**
+ * A cached facet is fresh iff it was produced by the current FACET_VERSION and
+ * the session sidecar has not been modified since the facet was derived.
+ */
+function isFresh(cached: SessionFacet, sessionMtimeMs: number): boolean {
+  return cached.facet_version === FACET_VERSION && cached.source_session_mtime_ms === sessionMtimeMs;
+}
+
+/**
+ * Return the facet for `sessionId`, deriving + caching on a miss or when the
+ * cache is stale. Returns undefined if the session sidecar does not exist.
+ */
+export function getOrDeriveFacet(
+  sessionId: string,
+  options: FacetStoreOptions = {},
+): SessionFacet | undefined {
+  const sessionsDir = options.sessionsDir ?? getSessionsDir();
+  const cacheDir = options.cacheDir ?? getFacetCacheDir();
+  const sessionPath = sessionPathFor(sessionId, sessionsDir);
+  if (!existsSync(sessionPath)) return undefined;
+
+  const sessionMtimeMs = statSync(sessionPath).mtimeMs;
+  const cachePath = cachePathFor(sessionId, cacheDir);
+
+  if (!options.force) {
+    const cached = readCachedFacet(cachePath);
+    if (cached && isFresh(cached, sessionMtimeMs)) return cached;
+  }
+
+  const session = loadStoredSession(sessionId, sessionsDir);
+  if (!session) return undefined;
+
+  const facet = deriveSessionFacet(session, {
+    sourceSessionPath: sessionPath,
+    sourceSessionMtimeMs: sessionMtimeMs,
+  });
+  writeFacet(cachePath, facet);
+  return facet;
+}
+
+/** List all persisted session ids (sidecar filenames, sans `.json`). */
+export function listSessionIds(options: Pick<FacetStoreOptions, 'sessionsDir'> = {}): string[] {
+  const sessionsDir = options.sessionsDir ?? getSessionsDir();
+  if (!existsSync(sessionsDir)) return [];
+  return readdirSync(sessionsDir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => basename(f, '.json'));
+}

--- a/src/agent/provider.ts
+++ b/src/agent/provider.ts
@@ -120,6 +120,8 @@ export type ProviderEvent =
       toolUseId: string;
       toolName: string;
       toolInput: string;
+      /** Raw JSON-serialized tool input object — used by facet derivation for exact field extraction. */
+      toolInputRaw?: string;
       sessionId?: string;
     }
   | {

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -49,6 +49,7 @@ import {
 } from './cache-policy.js';
 import { translateMessageStream } from './translate.js';
 import { emitToolCall, emitSessionPhase } from '../../trace/emit.js';
+import { extractRawToolInput } from '../../facets/raw-input.js';
 import { env } from '../../../config/env.js';
 
 /**
@@ -545,6 +546,7 @@ export async function* runTurn(
         toolUseId: block.id,
         toolName: block.name,
         toolInput: summarizeToolInput(block.name, block.input),
+        toolInputRaw: extractRawToolInput(block.input),
         sessionId: input.ctx.sessionId,
       };
     }

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -46,6 +46,7 @@ import { sumProviderUsage } from '../../usage.js';
 import { contextLimitFor } from '../../model-limits.js';
 import { resolveModelId } from '../../session/model-resolution.js';
 import { collectSkillEntries } from '../../tools/skill-bridge.js';
+import { extractRawToolInput } from '../../facets/raw-input.js';
 import { debugLog } from '../../../utils/debug.js';
 import {
   resolveOpenAIAuth,
@@ -662,6 +663,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
         toolUseId: call.id,
         toolName: call.name,
         toolInput: summarizeToolInput(call.name, call.input),
+        toolInputRaw: extractRawToolInput(call.input),
         sessionId: this.initSessionId,
       };
     }

--- a/src/agent/session/stream-consumer.ts
+++ b/src/agent/session/stream-consumer.ts
@@ -327,6 +327,7 @@ export function transformProviderEvent(
           toolUseId: event.toolUseId,
           toolName: event.toolName,
           toolInput: event.toolInput,
+          toolInputRaw: event.toolInputRaw,
         },
       };
 

--- a/src/agent/types/message-types.ts
+++ b/src/agent/types/message-types.ts
@@ -69,6 +69,8 @@ export interface ToolUseDetailChunk {
   toolUseId: string;
   toolName: string;
   toolInput: string;
+  /** Raw JSON-serialized tool input object — used by facet derivation for exact field extraction. */
+  toolInputRaw?: string;
   metadata?: Record<string, unknown>;
 }
 

--- a/src/cli/commands/interactive/background.ts
+++ b/src/cli/commands/interactive/background.ts
@@ -177,7 +177,7 @@ export function detachStreamToBackground(
           responseText += event.chunk.content;
         } else if (event.type === 'chunk' && event.chunk.type === 'tool_use_detail') {
           const c = event.chunk;
-          const te: ToolEvent = { toolName: c.toolName, toolUseId: c.toolUseId, input: c.toolInput };
+          const te: ToolEvent = { toolName: c.toolName, toolUseId: c.toolUseId, input: c.toolInput, ...(c.toolInputRaw !== undefined && { inputRaw: c.toolInputRaw }) };
           pendingTools.set(c.toolUseId, te);
           toolEvents.push(te);
         } else if (event.type === 'chunk' && event.chunk.type === 'tool_result') {

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -326,7 +326,7 @@ export async function runTurn(
 
         if (event.type === 'chunk' && event.chunk.type === 'tool_use_detail') {
           const c = event.chunk;
-          const te: ToolEvent = { toolName: c.toolName, toolUseId: c.toolUseId, input: c.toolInput };
+          const te: ToolEvent = { toolName: c.toolName, toolUseId: c.toolUseId, input: c.toolInput, ...(c.toolInputRaw !== undefined && { inputRaw: c.toolInputRaw }) };
           pendingTools.set(c.toolUseId, te);
           toolEvents.push(te);
         } else if (event.type === 'chunk' && event.chunk.type === 'tool_result') {

--- a/src/cli/slash/types.ts
+++ b/src/cli/slash/types.ts
@@ -28,6 +28,8 @@ export interface ToolEvent {
   toolName: string;
   toolUseId: string;
   input: string;
+  /** Raw JSON-serialized tool input object — populated for facet derivation (exact field extraction). */
+  inputRaw?: string;
   result?: string;
   isError?: boolean;
 }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -74,6 +74,18 @@ export function getBriefsDir(): string {
   return join(getAgentFrameworkDir(), 'briefs');
 }
 
+/**
+ * Directory for cached SessionFacet JSON sidecars (one per session id).
+ *
+ * Facets are a lazily-derived, consumer-facing projection of a persisted
+ * session (see src/agent/facets/). They live under the agent-framework
+ * telemetry tier in $AFK_HOME — NOT under a Claude-Code-style `usage-data/`
+ * path, which has no precedent here.
+ */
+export function getFacetCacheDir(): string {
+  return join(getAgentFrameworkDir(), 'facets');
+}
+
 export function getSkillsDir(): string {
   return join(getAfkHome(), 'skills');
 }


### PR DESCRIPTION
## Source
Port of **afk-workshop#779** — "feat(facets): AFK-native SessionFacet substrate"
(private: https://github.com/griffinwork40/afk-workshop/pull/779)

This is a **moat-scrubbed port**, not a 1:1 copy. The repos share no history, so it was applied via diff + 3-way, not cherry-pick.

## Ported (17 files — all public-safe)
New `src/agent/facets/` module — a lazily-derived, disk-cached, consumer-facing `SessionFacet` projection of a persisted session:
- `schema.ts` — Zod schemas (StoredSessionInput subset + SessionFacet output)
- `derive.ts` — pure `deriveSessionFacet(session)` (mechanical tool/world-change aggregation + v1-heuristic semantic fields)
- `store.ts` — `getOrDeriveFacet` lazy derive-on-read with a write-through atomic cache
- `raw-input.ts` — whitelist (`file_path`/`name`/`id_prefix`) for exact field extraction (deliberately excludes `command` — secret-at-rest)
- `index.ts` + 3 test files (derive/store/raw-input)

Additive plumbing (all **optional** fields — backward compatible):
- `toolInputRaw?`/`inputRaw?` threaded through `provider.ts`, `providers/anthropic-direct/loop.ts`, `providers/openai-compatible/query.ts`, `session/stream-consumer.ts`, `types/message-types.ts`, `cli/commands/interactive/{background,turn-handler}.ts`, `cli/slash/types.ts`
- new `getFacetCacheDir()` in `src/paths.ts`

## Scrubbed / adapted (no files dropped)
No file was excluded; all moat scrubs were comment-level:
- **`src/paths.ts`** — rewrote the `getFacetCacheDir()` doc comment to drop private moat vocabulary. The private diff anchored on `getCeilingLedgerDir` (a moat function absent from public), so the new function was placed after `getBriefsDir` instead. No functional change.
- **`src/agent/facets/schema.ts` + `index.ts`** — genericized consumer-list comments, removing private-only skill names (`/harvest`, `/distill` are not public skills) → "evals, debug views, improvement loops".
- **`loop.ts` / `query.ts`** — public's `summarizeToolInput(name, input)` has diverged from private's `summarizeToolInput(input)`; the `toolInputRaw` field was hand-resolved onto public's call style (import + field present and correct).

## Verification (all green)
- `pnpm install --frozen-lockfile` ✓ · `pnpm lint` (tsc strict) ✓ · `pnpm test` ✓ **488 files, 9176 passed / 12 skipped / 0 failed** · `pnpm build` ✓ · `pnpm build:dist` ✓ · `pnpm fix:pins:check` ✓ (no drift)
- **Deterministic moat guard: CLEAN** (tree + built `dist/`; HARD denylist + structural markers + eval schemas + merge markers)
- **Adversarial moat audit (independent sub-agent, re-derived from scratch): CLEAN** — zero denylist hits, scrubs verified residue-free, paraphrase net caught only legitimate public vocabulary

## ⚠️ Do not merge automatically — leave for human review.
