### PR TITLE
docs: lead positioning with authorship; drop control-plane framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 # Agent AFK
 
-> Run coding agents while you’re AFK.
->
-> Start a run in your terminal, walk away, and get pinged when Agent AFK finishes or needs you. Every step is saved as a readable trace, so you stay in control before anything ships.
+> **Claude Code decides how the agent behaves. Agent AFK lets you edit the rules.**
+
+**Agent AFK** is an open-source coding-agent harness you can actually change. Run long coding tasks while you're away, use any model, and edit the rules that decide what the agent can touch, when it stops, and how it proves the work.
+
+> Agent AFK isn't "smarter than Claude Code." It's *yours* in a way Claude Code can't be.
 
 [![npm version](https://img.shields.io/npm/v/agent-afk.svg)](https://www.npmjs.com/package/agent-afk)
 [![Node](https://img.shields.io/node/v/agent-afk.svg)](https://nodejs.org/)
+
+## Claude Code vs. Agent AFK
+
+| | Claude Code | Agent AFK |
+|---|---|---|
+| Harness | Closed binary | Apache-2.0, editable |
+| The loop | You configure *around* it | You edit *the loop* |
+| Behavior | Mostly fixed | Prompts, gates, routing, skills are code |
+| Result | A great default agent | An agent system you own |
+
+The model isn't the product — the loop is. Agent AFK hands you the loop as code: prompts, gates, routing, skills, traces, providers, terminal states. Edit any of them.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-afk",
   "version": "3.112.0",
-  "description": "Local-first control plane for long-running AI agent work — delegation, traces, resumable sessions, verification, and notifications.",
+  "description": "Open-source coding-agent harness you can actually change — own the loop (prompts, gates, routing, skills, terminal states), use any model, run long tasks while you're away.",
   "main": "dist/index.mjs",
   "type": "module",
   "bin": {


### PR DESCRIPTION
**Source:** afk-workshop#781 (private) — moat-scrubbed port, not a 1:1 copy.

Re-spins the public positioning from capability claims to **harness ownership**: Agent AFK's value is that the agent loop is open and editable, not that it is "smarter" than Claude Code (same-model comparisons tie).

**Ported (both public-safe):**
- `README.md` — new hero (*Claude Code decides how the agent behaves. Agent AFK lets you edit the rules.*) + a Claude Code vs Agent AFK contrast table + spine sentence. Hand-ported onto public's existing hero, since public's hero differed from private's and the patch context didn't apply 1:1.
- `package.json` — `description` drops "control plane" for "open-source coding-agent harness you can actually change."

**Dropped:** nothing — the source PR is docs/metadata only; no moat files or hunks.

**Verification (all clean):**
- Correctness gate green: `pnpm install --frozen-lockfile` + `lint` (tsc --noEmit) + `test` (9181 passed) + `build` + `build:dist`.
- Deterministic moat guard: `MOAT GUARD CLEAN` — zero HARD-denylist hits; diff scope = `README.md` + `package.json` only.
- Independent adversarial audit: clean.

Please review — do not auto-merge.
