### PR TITLE
fix(mcp): emit OAuth state param so Mintlify-style servers connect

### DIFF
--- a/src/agent/mcp/oauth.test.ts
+++ b/src/agent/mcp/oauth.test.ts
@@ -153,6 +153,53 @@ describe('KeychainOAuthProvider — discovery state', () => {
 });
 
 // ---------------------------------------------------------------------------
+// state (OAuth state parameter)
+// ---------------------------------------------------------------------------
+
+describe('KeychainOAuthProvider — state', () => {
+  it('returns a non-empty string', () => {
+    const provider = new KeychainOAuthProvider('srv', makeMemoryBackend());
+    const s = provider.state();
+    expect(typeof s).toBe('string');
+    expect(s.length).toBeGreaterThan(0);
+  });
+
+  it('is stable across repeated calls (persisted)', () => {
+    const provider = new KeychainOAuthProvider('srv', makeMemoryBackend());
+    expect(provider.state()).toBe(provider.state());
+  });
+
+  it('persists across provider instances sharing one backend', () => {
+    const store = { blob: undefined as string | undefined };
+    const first = new KeychainOAuthProvider('srv', makeMemoryBackend(store));
+    const generated = first.state();
+    const second = new KeychainOAuthProvider('srv', makeMemoryBackend(store));
+    expect(second.state()).toBe(generated);
+  });
+
+  it('scopes state per server name', () => {
+    const store = { blob: undefined as string | undefined };
+    const provA = new KeychainOAuthProvider('server-a', makeMemoryBackend(store));
+    const provB = new KeychainOAuthProvider('server-b', makeMemoryBackend(store));
+    expect(provA.state()).not.toBe(provB.state());
+  });
+
+  it('regenerates after invalidateCredentials("verifier")', () => {
+    const provider = new KeychainOAuthProvider('srv', makeMemoryBackend());
+    const before = provider.state();
+    provider.invalidateCredentials('verifier');
+    expect(provider.state()).not.toBe(before);
+  });
+
+  it('regenerates after invalidateCredentials("all")', () => {
+    const provider = new KeychainOAuthProvider('srv', makeMemoryBackend());
+    const before = provider.state();
+    provider.invalidateCredentials('all');
+    expect(provider.state()).not.toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // invalidateCredentials
 // ---------------------------------------------------------------------------
 

--- a/src/agent/mcp/oauth.ts
+++ b/src/agent/mcp/oauth.ts
@@ -35,6 +35,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { homedir, userInfo } from 'node:os';
 import { join, dirname } from 'node:path';
 
@@ -63,6 +64,8 @@ interface McpOAuthSlot {
   clientInfo?: OAuthClientInformationMixed;
   codeVerifier?: string;
   discoveryState?: OAuthDiscoveryState;
+  /** OAuth `state` parameter — see `KeychainOAuthProvider.state()`. */
+  state?: string;
 }
 
 /** Shape of the `mcpOAuth` top-level key in the credentials JSON. */
@@ -327,6 +330,29 @@ export class KeychainOAuthProvider implements OAuthClientProvider {
     return v;
   }
 
+  /**
+   * OAuth `state` parameter.
+   *
+   * `state` is only RECOMMENDED by OAuth 2.1 (PKCE already defends the code
+   * exchange against CSRF), so the SDK omits it from the authorization URL
+   * unless the provider supplies one. Some authorization servers nonetheless
+   * REQUIRE `state` and reject the authorize request with `invalid_request`
+   * when it is absent — Mintlify's admin MCP (`https://mcp.mintlify.com`) is
+   * one such server.
+   *
+   * We generate a random value once per server and persist it so repeated
+   * `state()` calls within a flow return the same value. The SDK does not
+   * validate the echoed value on the token exchange, so this exists purely to
+   * satisfy servers that mandate the parameter's presence.
+   */
+  state(): string {
+    const existing = this._readSlot().state;
+    if (existing) return existing;
+    const generated = randomUUID();
+    this._updateSlot((slot) => ({ ...slot, state: generated }));
+    return generated;
+  }
+
   saveDiscoveryState(state: OAuthDiscoveryState): void {
     this._updateSlot((slot) => ({ ...slot, discoveryState: state }));
   }
@@ -341,7 +367,12 @@ export class KeychainOAuthProvider implements OAuthClientProvider {
       const updated = { ...slot };
       if (scope === 'client') delete updated.clientInfo;
       if (scope === 'tokens') delete updated.tokens;
-      if (scope === 'verifier') delete updated.codeVerifier;
+      if (scope === 'verifier') {
+        // `state` and the PKCE verifier are both per-authorization-attempt
+        // artifacts — drop them together so a re-auth starts a clean flow.
+        delete updated.codeVerifier;
+        delete updated.state;
+      }
       if (scope === 'discovery') delete updated.discoveryState;
       return updated;
     });

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -45,7 +45,7 @@ import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { createBuiltinHandlers } from '../../tools/handlers/index.js';
 import { builtinToolSchemas, agentTool, skillTool, composeTool } from '../../tools/schemas.js';
 import { TOOL_SYSTEM_PROMPT_BASE, SLASH_COMMAND_ROUTING_PROMPT, BASH_PASSTHROUGH_PROMPT, MEMORY_SYSTEM_PROMPT, MEMORY_SYSTEM_PROMPT_READONLY } from '../../tools/system-prompt.js';
-import type { ToolPermissionConfig } from '../../tools/permissions.js';
+import { withMcpToolsAllowed, type ToolPermissionConfig } from '../../tools/permissions.js';
 import type { HookRegistry } from '../../hooks.js';
 import type { SubagentExecutor } from '../../tools/subagent-executor.js';
 import { maxOutputTokensFor } from '../../model-limits.js';
@@ -343,7 +343,13 @@ export class AnthropicDirectProvider implements ModelProvider {
       // so builtin tool names always take precedence in any overlap.
       schemas: [...this.schemas, ...mcpSchemas],
       hookRegistry: this.hookRegistry,
-      permissions: this.permissions,
+      // Union live MCP wire-names into the (statically-snapshotted) allowlist so
+      // OAuth servers whose tools were discovered after construction are not
+      // rejected by the gate while present in `schemas`/`handlers`. No-op when
+      // no mcpManager (e.g. restricted sub-agents) or no allowlist configured.
+      permissions: this.mcpManager
+        ? withMcpToolsAllowed(this.permissions, this.mcpManager.getMcpToolWireNames())
+        : this.permissions,
       subagentExecutor: this.subagentExecutor,
       skillExecutor: this.skillExecutor,
       composeExecutor: this.composeExecutor,

--- a/src/agent/providers/anthropic-direct/mcp-permission-refresh.test.ts
+++ b/src/agent/providers/anthropic-direct/mcp-permission-refresh.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Regression test for the OAuth-MCP permission-staleness bug.
+ *
+ * The permission allowlist is snapshotted ONCE at provider construction. When
+ * an OAuth-backed MCP server discovers its tools AFTER that snapshot, the tools
+ * appear in the dispatcher's `schemas`/`handlers` (read live each query) but are
+ * absent from the frozen allowlist — so the gate rejects every call with "not
+ * in the configured allowlist" even though the model can see the tool.
+ *
+ * The fix (`withMcpToolsAllowed`, applied in `buildDispatcher`) re-unions the
+ * live MCP wire-names into the allowlist at query time. This test drives a REAL
+ * `McpManager` (stdio fixture) through the REAL provider + dispatcher with a
+ * static allowlist that deliberately omits the MCP tool, and asserts:
+ *   1. the MCP tool now executes (no permission rejection), and
+ *   2. a non-MCP tool absent from the allowlist is STILL rejected (the union is
+ *      scoped to MCP tools — not a blanket open).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { ContentBlockParam, RawMessageStreamEvent } from '@anthropic-ai/sdk/resources';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { AnthropicDirectProvider, __setAnthropicClientFactory } from './index.js';
+import { McpManager } from '../../mcp/manager.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const FIXTURE = resolve(dirname(__filename), '../../mcp/__fixtures__/test-server.mjs');
+
+// --- Mock Anthropic Messages-API plumbing (mirrors read-only-memory.test.ts) --
+
+const messagesCreateMock = vi.fn();
+
+class MockAnthropic {
+  public messages: { create: typeof messagesCreateMock };
+  constructor() {
+    this.messages = { create: messagesCreateMock };
+  }
+}
+
+async function* singleInput(content: string): AsyncIterable<{ content: string }> {
+  yield { content };
+}
+
+async function* fromArray<T>(arr: T[]): AsyncIterable<T> {
+  for (const x of arr) yield x;
+}
+
+function makeTextStream(text: string): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_test',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-4-5-20250929',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 5,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '', citations: [] },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 4 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+function makeToolUseStream(
+  toolId: string,
+  toolName: string,
+  inputJson: string,
+): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_t',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-4-5-20250929',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 5,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'tool_use', id: toolId, name: toolName, input: {} },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: inputJson },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'tool_use', stop_sequence: null },
+      usage: { output_tokens: 9 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+async function drainQuery(query: AsyncIterable<unknown>): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for await (const _ev of query) {
+    // drain
+  }
+}
+
+/** Pull the tool_result block for `toolUseId` out of the follow-up request. */
+function toolResultText(toolUseId: string): { isError: boolean; text: string } {
+  const secondCall = messagesCreateMock.mock.calls[1]!;
+  const messages = (secondCall[0] as {
+    messages?: Array<{ role: string; content: ContentBlockParam[] | string }>;
+  }).messages;
+  const lastUser = [...(messages ?? [])].reverse().find((m) => m.role === 'user');
+  const blocks = Array.isArray(lastUser?.content) ? (lastUser!.content as ContentBlockParam[]) : [];
+  const toolResult = blocks.find(
+    (b) =>
+      (b as { type?: string }).type === 'tool_result' &&
+      (b as { tool_use_id?: string }).tool_use_id === toolUseId,
+  ) as { is_error?: boolean; content?: unknown } | undefined;
+  const content = toolResult?.content;
+  const text =
+    typeof content === 'string'
+      ? content
+      : Array.isArray(content)
+        ? (content as Array<{ text?: string }>).map((c) => c.text ?? '').join('')
+        : '';
+  return { isError: toolResult?.is_error === true, text };
+}
+
+describe('AnthropicDirectProvider — MCP permission allowlist refresh', () => {
+  let manager: McpManager | undefined;
+
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    __setAnthropicClientFactory(() => new MockAnthropic() as unknown as Anthropic);
+  });
+
+  afterEach(async () => {
+    if (manager) {
+      await manager.disconnectAll();
+      manager = undefined;
+    }
+    __setAnthropicClientFactory(null);
+  });
+
+  it(
+    'allows an MCP tool absent from the static allowlist (OAuth late-discovery regression)',
+    async () => {
+      manager = await McpManager.fromConfig({
+        srv: { type: 'stdio', command: process.execPath, args: [FIXTURE] },
+      });
+
+      // Static allowlist omits the MCP tool entirely — simulates the snapshot
+      // taken before the OAuth handshake discovered the server's tools.
+      const provider = new AnthropicDirectProvider({
+        permissions: { allowedTools: ['read_file'] },
+        mcpManager: manager,
+      });
+
+      let call = 0;
+      messagesCreateMock.mockImplementation(() => {
+        call++;
+        return call === 1
+          ? fromArray(makeToolUseStream('tu_echo', 'mcp__srv__echo', JSON.stringify({ text: 'hi via mcp' })))
+          : fromArray(makeTextStream('done'));
+      });
+
+      await drainQuery(
+        provider.query({
+          prompt: singleInput('echo something'),
+          config: { model: 'claude-sonnet-4-5-20250929', apiKey: 'sk-ant-oat01-test' },
+        }),
+      );
+
+      expect(messagesCreateMock).toHaveBeenCalledTimes(2);
+      const { isError, text } = toolResultText('tu_echo');
+      expect(text).not.toContain('not in the configured allowlist');
+      expect(isError).toBe(false);
+      expect(text).toContain('hi via mcp');
+    },
+    { timeout: 15_000 },
+  );
+
+  it(
+    'still rejects a non-MCP tool absent from the allowlist (union is scoped, not blanket)',
+    async () => {
+      manager = await McpManager.fromConfig({
+        srv: { type: 'stdio', command: process.execPath, args: [FIXTURE] },
+      });
+
+      const provider = new AnthropicDirectProvider({
+        permissions: { allowedTools: ['read_file'] },
+        mcpManager: manager,
+      });
+
+      let call = 0;
+      messagesCreateMock.mockImplementation(() => {
+        call++;
+        return call === 1
+          ? fromArray(makeToolUseStream('tu_write', 'write_file', JSON.stringify({ file_path: '/tmp/x', content: 'y' })))
+          : fromArray(makeTextStream('done'));
+      });
+
+      await drainQuery(
+        provider.query({
+          prompt: singleInput('write a file'),
+          config: { model: 'claude-sonnet-4-5-20250929', apiKey: 'sk-ant-oat01-test' },
+        }),
+      );
+
+      const { isError, text } = toolResultText('tu_write');
+      expect(isError).toBe(true);
+      expect(text).toContain('not in the configured allowlist');
+    },
+    { timeout: 15_000 },
+  );
+});

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -26,7 +26,7 @@ import type { HookRegistry } from '../../hooks.js';
 import type { SubagentExecutor } from '../../tools/subagent-executor.js';
 import type { SkillExecutor } from '../../tools/skill-executor.js';
 import type { ComposeExecutor } from '../../tools/compose-executor.js';
-import type { ToolPermissionConfig } from '../../tools/permissions.js';
+import { withMcpToolsAllowed, type ToolPermissionConfig } from '../../tools/permissions.js';
 import type { ToolDispatcher } from '../anthropic-direct/tool-dispatcher.js';
 import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { createBuiltinHandlers } from '../../tools/handlers/index.js';
@@ -335,8 +335,18 @@ export class OpenAICompatibleProvider implements ModelProvider {
     };
     if (this.providerOpts.hookRegistry !== undefined)
       dispatcherOpts.hookRegistry = this.providerOpts.hookRegistry;
-    if (this.providerOpts.permissions !== undefined)
-      dispatcherOpts.permissions = this.providerOpts.permissions;
+    // Union live MCP wire-names into the (statically-snapshotted) allowlist so
+    // OAuth servers whose tools were discovered after construction are not
+    // rejected by the gate while present in `schemas`/`handlers`. No-op when no
+    // mcpManager (e.g. restricted sub-agents) or no allowlist configured.
+    const effectivePermissions = this.providerOpts.mcpManager
+      ? withMcpToolsAllowed(
+          this.providerOpts.permissions,
+          this.providerOpts.mcpManager.getMcpToolWireNames(),
+        )
+      : this.providerOpts.permissions;
+    if (effectivePermissions !== undefined)
+      dispatcherOpts.permissions = effectivePermissions;
     if (this.providerOpts.subagentExecutor !== undefined)
       dispatcherOpts.subagentExecutor = this.providerOpts.subagentExecutor;
     if (this.providerOpts.skillExecutor !== undefined)

--- a/src/agent/tools/permissions.test.ts
+++ b/src/agent/tools/permissions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { checkToolPermission } from './permissions.js';
+import { checkToolPermission, withMcpToolsAllowed } from './permissions.js';
 
 describe('checkToolPermission', () => {
   it('allows all tools when no config provided', () => {
@@ -28,5 +28,53 @@ describe('checkToolPermission', () => {
     const config = { allowedTools: ['bash'] };
     expect(checkToolPermission('bash', config).allowed).toBe(true);
     expect(checkToolPermission('read_file', config).allowed).toBe(false);
+  });
+});
+
+describe('withMcpToolsAllowed', () => {
+  it('returns undefined unchanged (no allowlist → all tools allowed)', () => {
+    expect(withMcpToolsAllowed(undefined, ['mcp__srv__echo'])).toBeUndefined();
+  });
+
+  it('returns base unchanged when allowedTools is absent', () => {
+    const base = {} as { allowedTools?: string[] };
+    expect(withMcpToolsAllowed(base, ['mcp__srv__echo'])).toBe(base);
+  });
+
+  it('returns base unchanged (same reference) when no MCP names', () => {
+    const base = { allowedTools: ['read_file'] };
+    expect(withMcpToolsAllowed(base, [])).toBe(base);
+  });
+
+  it('returns base unchanged (same reference) when every MCP name already present', () => {
+    const base = { allowedTools: ['read_file', 'mcp__srv__echo'] };
+    expect(withMcpToolsAllowed(base, ['mcp__srv__echo'])).toBe(base);
+  });
+
+  it('unions missing MCP names into a NEW config without mutating base', () => {
+    const base = { allowedTools: ['read_file'] };
+    const result = withMcpToolsAllowed(base, ['mcp__srv__echo', 'mcp__srv__boom']);
+    expect(result).not.toBe(base);
+    expect(base.allowedTools).toEqual(['read_file']); // base untouched
+    expect(result?.allowedTools).toEqual(['read_file', 'mcp__srv__echo', 'mcp__srv__boom']);
+  });
+
+  it('deduplicates when some MCP names already present', () => {
+    const base = { allowedTools: ['read_file', 'mcp__srv__echo'] };
+    const result = withMcpToolsAllowed(base, ['mcp__srv__echo', 'mcp__srv__boom']);
+    expect(result?.allowedTools).toEqual(['read_file', 'mcp__srv__echo', 'mcp__srv__boom']);
+  });
+
+  it('the unioned allowlist makes a previously-rejected MCP tool pass the gate', () => {
+    // Reproduces the bug: a static allowlist that omits an MCP tool rejects it;
+    // after unioning the live wire-name the gate allows it — while non-MCP
+    // tools stay denied (the union is scoped, not a blanket open).
+    const stale = { allowedTools: ['read_file'] };
+    expect(checkToolPermission('mcp__srv__echo', stale).allowed).toBe(false);
+
+    const refreshed = withMcpToolsAllowed(stale, ['mcp__srv__echo']);
+    expect(checkToolPermission('mcp__srv__echo', refreshed).allowed).toBe(true);
+    expect(checkToolPermission('read_file', refreshed).allowed).toBe(true);
+    expect(checkToolPermission('write_file', refreshed).allowed).toBe(false);
   });
 });

--- a/src/agent/tools/permissions.ts
+++ b/src/agent/tools/permissions.ts
@@ -34,3 +34,41 @@ export function checkToolPermission(
   }
   return { allowed: true };
 }
+
+/**
+ * Union live MCP tool wire-names into a base permission allowlist.
+ *
+ * Invariant: the base allowlist is snapshotted ONCE at provider construction
+ * (see `cli/shared-helpers.ts:allowedToolsFor`). OAuth-backed MCP servers
+ * discover their tools asynchronously — the handshake completes AFTER that
+ * snapshot — so freshly-bridged tools land in the dispatcher's `schemas` and
+ * `handlers` (read live each query) but are absent from the frozen allowlist.
+ * The permission gate then rejects them with "not in the configured allowlist"
+ * even though the model can see them. Re-unioning the live wire-names at
+ * dispatcher-build time (every query) keeps the gate in lockstep with the
+ * registry without mutating the shared base config.
+ *
+ * Only the top-level provider receives an `mcpManager`; restricted sub-agent
+ * providers (recon / read-only / skill-scoped, built in `tools/nesting.ts`) do
+ * not, so this never widens a sub-agent's allowlist — no privilege escalation.
+ *
+ * Returns `base` unchanged (same reference) when there is no allowlist
+ * (`undefined` → all tools allowed), when `mcpToolWireNames` is empty, or when
+ * every wire-name is already present — avoiding needless allocation per query.
+ * Otherwise returns a NEW config; `base.allowedTools` is never mutated.
+ */
+export function withMcpToolsAllowed(
+  base: ToolPermissionConfig | undefined,
+  mcpToolWireNames: readonly string[],
+): ToolPermissionConfig | undefined {
+  if (!base?.allowedTools || mcpToolWireNames.length === 0) return base;
+  const merged = new Set(base.allowedTools);
+  let changed = false;
+  for (const name of mcpToolWireNames) {
+    if (!merged.has(name)) {
+      merged.add(name);
+      changed = true;
+    }
+  }
+  return changed ? { ...base, allowedTools: [...merged] } : base;
+}


### PR DESCRIPTION
## Summary

- Adds a `state()` method to `KeychainOAuthProvider` (`src/agent/mcp/oauth.ts`) so the MCP OAuth authorization URL now carries the `state` parameter.
- Fixes connection failures against OAuth authorization servers that **require** `state` — notably Mintlify's admin MCP (`https://mcp.mintlify.com`), which previously rejected AFK's authorize request with `{"error":"invalid_request","details":{"fieldErrors":{"state":["Required"]}}}`.
- Root cause: `@modelcontextprotocol/sdk` (`client/auth.js`) reads `provider.state?.()` and only appends `state` to the URL when the provider supplies one. `KeychainOAuthProvider` implemented no such method, so `state` was always omitted. `state` is only *RECOMMENDED* by OAuth 2.1 (PKCE already defends the code exchange against CSRF), which is why the SDK leaves it to the provider.

## Implementation notes

- `state()` returns a random `node:crypto` `randomUUID`, persisted per-server in the keychain slot (`McpOAuthSlot.state`) so repeated calls within one flow are stable.
- Regenerated when the `verifier` or `all` credential scopes are invalidated (paired with the PKCE verifier as a per-authorization-attempt artifact).
- The SDK does **not** validate the echoed `state` on the token exchange, so this is presence-only: a no-op for servers that don't require `state`, and just enough to satisfy those that do.

## Test results

- `pnpm lint` (`tsc --noEmit`, strict): **passed**
- `pnpm test` (`vitest run`, full suite): **9151 passed | 12 skipped across 485 files**, exit 0
- `pnpm build` (`tsc` + copy-prompts): **passed**; `state()` confirmed present in `dist/agent/mcp/oauth.js`
- New coverage: 6 unit tests in `src/agent/mcp/oauth.test.ts` (non-empty, stable/persisted, cross-instance persistence, per-server scoping, regeneration on both `verifier` and `all` invalidation)

## Verification

No adversarial verify requested (diff is 79 lines, under the 100-line threshold).

## Out of scope (follow-up)

- `/mcp auth` currently displays a **stripped** authorization URL: `writeOauthPending()` persists only `origin + pathname`, so the param-bearing URL reaches the user only via Telegram/stderr at connect time. Not addressed here — worth a separate change so `/mcp auth` surfaces a directly-usable URL.


---

## Follow-up fix — permission gate for late-discovered (OAuth) MCP tools (commit `066b836`)

The `state` fix above makes Mintlify **connect** and discover all its tools — but exposed a second, downstream bug: the tools connect yet are **not callable**. Every invocation is rejected with `Tool "mcp__mintlify__…" is not in the configured allowlist`.

**Root cause.** The tool permission allowlist is snapshotted **once** at provider construction (`cli/shared-helpers.ts:allowedToolsFor`, which appends `mcpManager.getMcpToolWireNames()`). OAuth servers finish their handshake and discover tools *asynchronously — after* that snapshot. The dispatcher reads MCP `schemas`/`handlers` live each query (so the model sees all the tools), but the permission object handed to the gate (`tools/dispatcher.ts:492`) stays frozen, missing the `mcp__…` names. `onToolsRefreshed` (`anthropic-direct/index.ts:262`) invalidated only the tool/handler caches — never the allowlist. Net: tool **visible + dispatchable but permission-rejected**.

**Fix.** Re-union the live MCP wire-names into the allowlist at `buildDispatcher()` time (every query) in **both** providers, via a shared pure helper `withMcpToolsAllowed()` (`tools/permissions.ts`). It allocates a new config only when names are actually missing — never mutates the base — and fires only when an `mcpManager` is present. Restricted sub-agent providers (recon / read-only / skill-scoped, built in `tools/nesting.ts`) never receive an `mcpManager`, so their allowlists are untouched: **no privilege escalation**.

**Tests (this commit).**
- `withMcpToolsAllowed` unit tests in `tools/permissions.test.ts` (undefined / empty / dedup / no-mutation-of-base / gate-passes-after-union).
- Provider-level regression in `anthropic-direct/mcp-permission-refresh.test.ts`: drives a **real** stdio MCP manager through the real provider + dispatcher with a static allowlist that omits the MCP tool — asserts the MCP tool now executes **and** a non-MCP tool (`write_file`) absent from the allowlist is still denied (the union is scoped, not a blanket open).
- Full suite green: **9160 passed | 12 skipped across 486 files**; `pnpm lint` clean; `pnpm audit:sdk:check` OK.
