### PR TITLE
fix(tui): stop double-spacing markdown blocks in REPL/chat output

### DIFF
--- a/docs/tui-rhythm.md
+++ b/docs/tui-rhythm.md
@@ -66,6 +66,23 @@ for (const line of lines) compositor.commitAbove(line);
 compositor.commitAbove('');  // ← trailing blank
 ```
 
+## How the markdown renderer participates
+
+`renderMarkdownToTerminal` (`formatter.ts`) is the source of assistant
+prose. To keep it contract-clean for both the streaming REPL path and the
+non-streamed paths (`afk chat`, `/transcript`, `/attach`):
+
+- **Every block token emits exactly one trailing `\n`** (a line terminator,
+  not a blank line) and **no leading blank**. The one blank line between
+  blocks comes solely from marked's `space` token (one source blank line →
+  one `\n`). Emitting `\n\n` from a block token *and* relying on the `space`
+  token double-spaced every boundary in non-streamed rendering; a leading
+  `\n` on headings produced a double blank before every heading in the REPL.
+- `formatBlockForCommit` (`markdown-stream-format.ts`) strips **both** leading
+  and trailing blank lines before `commitBlock` re-adds the single trailing
+  blank — so a model emitting 3+ newlines between sections can't smuggle a
+  leading blank into scrollback.
+
 ## Tests
 
 `src/cli/_lib/rhythm-contract.test.ts` exercises the major emission

--- a/src/cli/formatter.test.ts
+++ b/src/cli/formatter.test.ts
@@ -592,4 +592,52 @@ describe('renderMarkdownToTerminal', () => {
       expect(stripped).toMatch(/amplifies\n/);
     });
   });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Block-spacing rhythm — see docs/tui-rhythm.md. Every block token emits a
+  // single trailing '\n' and no leading blank; marked's `space` token supplies
+  // the one blank line between blocks. Regression guard for the
+  // "double blank between paragraphs / leading blank before headings" bug.
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('block spacing rhythm', () => {
+    // Longest run of consecutive blank lines in the rendered output.
+    const maxBlankRun = (s: string): number => {
+      let max = 0;
+      let run = 0;
+      for (const line of stripAnsi(s).split('\n')) {
+        if (line.trim() === '') {
+          run++;
+          max = Math.max(max, run);
+        } else {
+          run = 0;
+        }
+      }
+      return max;
+    };
+
+    it('separates consecutive paragraphs by exactly one blank line (no double blanks)', () => {
+      const out = renderMarkdownToTerminal('First paragraph.\n\nSecond paragraph.\n\nThird paragraph.\n');
+      expect(maxBlankRun(out)).toBeLessThanOrEqual(1);
+      expect(stripAnsi(out)).toMatch(/First paragraph\.\n\nSecond paragraph\.\n\nThird paragraph\./);
+    });
+
+    it('a heading does not emit a leading blank line', () => {
+      const out = renderMarkdownToTerminal('# Title\n\nBody.\n');
+      expect(out).not.toMatch(/^\n/);
+      expect(stripAnsi(out).split('\n')[0]).toContain('Title');
+    });
+
+    it('mixed blocks (paragraph, list, code, heading) never stack blank lines', () => {
+      const md = [
+        'Lead in.', '', '## Section', '', '- one', '- two', '',
+        '```sh', 'afk login', '```', '', 'Closing line.', '',
+      ].join('\n');
+      expect(maxBlankRun(renderMarkdownToTerminal(md))).toBeLessThanOrEqual(1);
+    });
+
+    it('collapses 3+ source newlines between paragraphs to a single blank line', () => {
+      const out = renderMarkdownToTerminal('Above.\n\n\n\nBelow.\n');
+      expect(maxBlankRun(out)).toBeLessThanOrEqual(1);
+    });
+  });
 });

--- a/src/cli/formatter.test.ts
+++ b/src/cli/formatter.test.ts
@@ -639,5 +639,13 @@ describe('renderMarkdownToTerminal', () => {
       const out = renderMarkdownToTerminal('Above.\n\n\n\nBelow.\n');
       expect(maxBlankRun(out)).toBeLessThanOrEqual(1);
     });
+
+    it('an empty code block does not double-space the following blank line', () => {
+      // The empty-fence loud-fail placeholder is a block token too: it must own
+      // exactly one trailing '\n' like every other block. Guards the formatter
+      // empty-code branch against re-introducing '\n\n'.
+      const out = renderMarkdownToTerminal('Intro.\n\n```bash\n```\n\nOutro.\n');
+      expect(maxBlankRun(out)).toBeLessThanOrEqual(1);
+    });
   });
 });

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -172,7 +172,13 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           // command instead of assuming it rendered fine.
           if (code.text.trim() === '') {
             const label = code.lang ? `(empty ${code.lang} block)` : '(empty code block)';
-            return palette.dim(`│ ${label}`) + '\n\n';
+            // One trailing '\n' (line terminator), not '\n\n' — the same block
+            // rhythm invariant as the non-empty branch below and the heading /
+            // paragraph cases above (docs/tui-rhythm.md): every block token owns
+            // exactly one trailing newline; the inter-block blank comes solely
+            // from marked's `space` token. Emitting '\n\n' here double-spaced the
+            // gap after an empty fence in the non-streamed render paths.
+            return palette.dim(`│ ${label}`) + '\n';
           }
           const highlighted = highlightCode(code.text, lang);
           const bodyLines = highlighted.split('\n');

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -141,13 +141,25 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           // H1 → brand (warm orange, bold) — top-level identity tone.
           // H2 → palette.heading (bold white) — strong but neutral.
           // H3+ → bold (terminal default weight, no hue).
-          if (heading.depth === 1) return palette.brand.bold('\n' + headingText + '\n');
-          if (heading.depth === 2) return palette.heading('\n' + headingText + '\n');
-          return palette.bold('\n' + headingText + '\n');
+          // Invariant (TUI rhythm contract, docs/tui-rhythm.md): every block
+          // token emits exactly ONE trailing '\n' (a line terminator, not a
+          // blank line) and NO leading blank. Blank-line separation between
+          // blocks comes solely from marked's `space` token (one source blank
+          // line → one '\n'). A leading '\n' here would stack with the
+          // predecessor block's separation into a double blank — and in the
+          // streaming commit path it survives `formatBlockForCommit` (which
+          // strips trailing newlines) as a leading blank before the heading.
+          if (heading.depth === 1) return palette.brand.bold(headingText) + '\n';
+          if (heading.depth === 2) return palette.heading(headingText) + '\n';
+          return palette.bold(headingText) + '\n';
         }
         case 'paragraph': {
+          // One trailing '\n' (line terminator), not '\n\n'. marked already
+          // emits a `space` token for the source blank line that follows a
+          // paragraph; adding a second '\n' here double-spaced every block
+          // boundary in non-streamed rendering. See the heading invariant above.
           const para = token as Tokens.Paragraph;
-          return renderInline(para.tokens as Tokens.Generic[]) + '\n\n';
+          return renderInline(para.tokens as Tokens.Generic[]) + '\n';
         }
         case 'code': {
           const code = token as Tokens.Code;

--- a/src/cli/markdown-stream-format.test.ts
+++ b/src/cli/markdown-stream-format.test.ts
@@ -3,7 +3,11 @@ import {
   isInOpenTable,
   isInOpenCodeFence,
   formatPendingBuffer,
+  formatBlockForCommit,
 } from './markdown-stream-format.js';
+
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+const stripAnsi = (s: string): string => s.replace(ANSI_RE, '');
 
 /**
  * Tests for the pure formatting helpers behind StreamingMarkdownRenderer.
@@ -105,5 +109,29 @@ describe('formatPendingBuffer', () => {
 describe('isInOpenCodeFence (precedence sanity)', () => {
   it('is true for an unclosed fence even when it contains table-like rows', () => {
     expect(isInOpenCodeFence('```\n|---|---|\n')).toBe(true);
+  });
+});
+
+// A committed block must own NEITHER a leading nor a trailing blank line: the
+// caller (commitBlock) re-adds exactly one trailing blank via
+// `commitAbove(trimmed + '\n\n')`. See docs/tui-rhythm.md.
+describe('formatBlockForCommit blank-line trimming', () => {
+  const WIDTH = 80;
+
+  it('strips leading blank lines (surplus newline from a 3+ newline section break)', () => {
+    const out = formatBlockForCommit('\n\nActual content.', '  ', WIDTH);
+    expect(stripAnsi(out).startsWith('\n')).toBe(false);
+    expect(stripAnsi(out)).toContain('Actual content.');
+  });
+
+  it('strips trailing blank lines', () => {
+    const out = formatBlockForCommit('Content.\n\n\n', '  ', WIDTH);
+    expect(out.endsWith('\n')).toBe(false);
+  });
+
+  it('a heading block carries no leading blank into scrollback', () => {
+    const out = formatBlockForCommit('## Done\n\n', '  ', WIDTH);
+    expect(stripAnsi(out).startsWith('\n')).toBe(false);
+    expect(stripAnsi(out)).toContain('Done');
   });
 });

--- a/src/cli/markdown-stream-format.ts
+++ b/src/cli/markdown-stream-format.ts
@@ -91,7 +91,15 @@ export function formatBlockForCommit(
   // like table borders mid-row.
   const wrapped = wrapToWidth(rendered, contentWidth);
   const indented = applyIndent(wrapped, indentStr);
-  const trimmed = indented.replace(/\n+$/, '');
+  // Strip BOTH leading and trailing blank lines. The caller (`commitBlock`)
+  // re-adds exactly one trailing blank via `commitAbove(trimmed + '\n\n')`, so
+  // a committed block must own neither — that is the TUI rhythm contract
+  // (docs/tui-rhythm.md: "every block owns one trailing blank, no emitter owns
+  // leading blanks"). Leading blanks reach here when a model emits 3+ newlines
+  // between sections: the streamer splits on the first '\n\n', leaving the
+  // surplus newline at the START of the next block. Without this strip it
+  // survives as a double blank in scrollback.
+  const trimmed = indented.replace(/^\n+/, '').replace(/\n+$/, '');
 
   return trimmed;
 }


### PR DESCRIPTION
## What

Fixes the excessive vertical whitespace in AFK's terminal output (reported: *"the spacing is rlly bad"*). Markdown blocks were separated by **two** blank lines instead of one, and **every heading** got a double blank line before it in the REPL.

## Root cause

`renderMarkdownToTerminal` (`src/cli/formatter.ts`) was internally inconsistent:

| Block token | Trailing emitted |
|---|---|
| `paragraph` | `\n\n` ❌ |
| `heading` | leading `\n` + `\n\n` ❌ |
| `list` / `code` / `blockquote` / `table` / `hr` | `\n` ✅ |

On top of that, marked inserts a `space` token (`\n`) for each source blank line. The block-token `\n\n` and the `space` `\n` **stacked**:

- **Non-streamed paths** (`afk chat`, `/transcript`, `/attach`) render the whole message at once → two blank lines between every block (`A\n\nB\n\nC` → `A · · B · · C`).
- The **streaming REPL** path masks the trailing double (it strips trailing newlines per block, then re-adds exactly one), but a heading's **leading** `\n` slipped past `formatBlockForCommit` (which only stripped *trailing*) → a double blank before every heading. That is the gap visible above the `Done` heading and section breaks in the onboarding output screenshots.

Both violate the documented contract in `docs/tui-rhythm.md`:

> Every emitted block owns exactly one trailing blank line. No emitter owns leading blanks.

## Fix

1. **`formatter.ts`** — normalize every block token to emit exactly one trailing `\n` and no leading blank. Blank-line separation now comes solely from marked's `space` token (one source blank line → one blank line). `paragraph` → `+ '\n'`; `heading` drops the leading `\n`.
2. **`markdown-stream-format.ts`** — `formatBlockForCommit` now strips **both** leading and trailing blank lines (was trailing-only), so a model emitting 3+ newlines between sections cannot smuggle a leading blank into scrollback.

## Before / after (rendered, `·` = blank line)

```
"First.\n\nSecond.\n\nThird."   (non-streamed)
BEFORE: First · · Second · · Third
AFTER:  First · Second · Third

streaming commit of an onboarding message — consecutive-blank runs
BEFORE: [1,1,1,1,2,1,...]   <- double blank before the heading
AFTER:  [1,1,1,1,1,1,...]   <- every gap is exactly one blank
```

## Testing

- `pnpm lint` (tsc --noEmit) — clean
- **Full suite green**: 486 files, 9164 tests passed, 12 skipped — no snapshot drift
- Added regression tests:
  - `formatter.test.ts` — paragraph/heading/mixed-block spacing, 3+ newline collapse, no leading blank before headings
  - `markdown-stream-format.test.ts` — `formatBlockForCommit` strips leading & trailing blanks
- Updated `docs/tui-rhythm.md` to document the markdown renderer's participation in the contract

## Scope / risk

Pure rendering change; no change to content. Existing heading/hr/blockquote tests (which assert single trailing newlines and "not glued") remain green. Low blast radius — verified by the full suite passing unchanged.
