### PR TITLE
fix(skills): inherit default subagent model

### DIFF
--- a/src/skills/audit-fit/index.ts
+++ b/src/skills/audit-fit/index.ts
@@ -294,6 +294,7 @@ async function handler(
   // not because dispatch would break. The tier gate is surfacing-only by
   // design; dispatch via getSkill()/the skill tool stays available.
   const apiKey = ctx?.apiKey;
+  const subagentModel = ctx?.defaultSubagentModel ?? ctx?.defaultModel ?? 'sonnet';
   // Tool-use ID of the `skill` ToolCall that invoked this handler. Forwarded
   // as `parentId` to every forkSubagent call so the parallel inspector
   // `Agent(...)` rows nest under THIS skill's tool-lane entry both in the
@@ -385,7 +386,7 @@ async function handler(
         manager.forkSubagent({
           parent: { sessionId },
           config: {
-            model: 'sonnet',
+            model: subagentModel,
             systemPrompt: `${researchAgent.systemPrompt}\n\n${cfg.prompt}`,
             canUseTool: createCanUseTool(),
           },

--- a/src/skills/diagnose/index.ts
+++ b/src/skills/diagnose/index.ts
@@ -27,7 +27,7 @@ import { SubagentManager } from '../../agent/subagent.js';
 import type { SubagentHandle } from '../../agent/subagent/handle.js';
 import { runWave } from '../../agent/subagent/wave.js';
 import { describeFailure } from '../../agent/subagent/result.js';
-import type { IAgentSession } from '../../agent/types.js';
+import type { AgentModelInput, IAgentSession } from '../../agent/types.js';
 import type { CanUseTool } from '../../agent/types/sdk-types.js';
 import { researchAgent } from '../_agents/research-agent.js';
 import { gitInvestigator } from '../_agents/git-investigator.js';
@@ -575,6 +575,7 @@ async function handler(
   ctx?: SkillExecutionContext,
 ): Promise<DiagnosisResult> {
   const apiKey = ctx?.apiKey;
+  const subagentModel = ctx?.defaultSubagentModel ?? ctx?.defaultModel ?? 'sonnet';
   // Parse input — accept both structured object and plain string (from slash commands)
   const parsedInput = (() => {
     if (typeof input === 'string') {
@@ -677,7 +678,7 @@ async function handler(
   const codebaseHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {
-      model: 'sonnet',
+      model: subagentModel,
       systemPrompt: codebaseResearchPrompt,
       canUseTool: createReadOnlyCanUseTool(),
     },
@@ -692,10 +693,15 @@ async function handler(
   const gitHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {
-      model: 'sonnet',
+      model: subagentModel,
       systemPrompt: gitResearchPrompt,
       cwd: parsedInput.repoPath,
-      agents: { 'git-investigator': toAgentDefinition(gitInvestigator) },
+      agents: {
+        'git-investigator': {
+          ...toAgentDefinition(gitInvestigator),
+          model: subagentModel,
+        },
+      },
       canUseTool: createGitOrchestratorCanUseTool(),
     },
     idPrefix: 'diagnose-git-research',
@@ -729,7 +735,7 @@ async function handler(
   const hypothesisHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {
-      model: 'sonnet',
+      model: subagentModel,
       systemPrompt: `${systemPrompt}\n\n${hypothesisPrompt}`,
       canUseTool: createReadOnlyCanUseTool(),
     },
@@ -873,6 +879,7 @@ async function handler(
       manager,
       skillCallId,
       baseline,
+      subagentModel,
     ),
   );
 
@@ -1125,6 +1132,7 @@ async function testHypothesisInWorktree(
   // (raw session UUID → render-at-root) behavior.
   skillCallId?: string,
   baseline?: BaselineResult,
+  subagentModel: AgentModelInput = 'sonnet',
 ): Promise<VerificationResult> {
   const worktreePath = join(tmpdir(), `diagnose-hyp-${hypothesis.id}-${Date.now()}`);
   let verifierHandle: SubagentHandle<VerificationResult> | undefined;
@@ -1159,7 +1167,7 @@ async function testHypothesisInWorktree(
     verifierHandle = await manager.forkSubagent({
       parent: { sessionId: parentSessionId },
       config: {
-        model: 'sonnet',
+        model: subagentModel,
         systemPrompt: `${verifyPrompt}\n\nYou are testing in an isolated worktree at: ${worktreePath}`,
         canUseTool: createVerifierCanUseTool(),
       },

--- a/src/skills/mint/_phases/build.ts
+++ b/src/skills/mint/_phases/build.ts
@@ -8,6 +8,7 @@ import { SubagentManager } from '../../../agent/subagent.js';
 import { describeFailure } from '../../../agent/subagent/result.js';
 import { getApiKey } from '../../../cli/shared-helpers.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
+import type { AgentModelInput } from '../../../agent/types.js';
 import { emitCard } from '../../_lib/emit-card.js';
 
 const BuildOutputSchema = z.object({
@@ -34,6 +35,7 @@ export async function runBuildPhase(
   // Mint skill's ToolCall id — anchors the forked subagent under the mint
   // skill's tool-lane entry. See skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
+  defaultSubagentModel: AgentModelInput = 'sonnet',
 ): Promise<BuildResult> {
   const prompts = loadSkillPrompts('mint');
   const buildPrompt = prompts['build.md'];
@@ -51,7 +53,7 @@ export async function runBuildPhase(
   const buildHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {
-      model: 'sonnet',
+      model: defaultSubagentModel,
       systemPrompt: buildPrompt,
       apiKey: getApiKey(),
     },

--- a/src/skills/mint/_phases/heal.ts
+++ b/src/skills/mint/_phases/heal.ts
@@ -5,7 +5,7 @@
  */
 
 import { getSkill } from '../../index.js';
-import type { IAgentSession } from '../../../agent/types.js';
+import type { AgentModelInput, IAgentSession } from '../../../agent/types.js';
 import { SubagentManager } from '../../../agent/subagent.js';
 import { describeFailure } from '../../../agent/subagent/result.js';
 import { getApiKey } from '../../../cli/shared-helpers.js';
@@ -24,6 +24,7 @@ export async function runHealPhase(
   // verify subagents under the mint skill's tool-lane entry. See
   // skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
+  defaultSubagentModel: AgentModelInput = 'sonnet',
 ): Promise<{
   healed: boolean;
   newHealIterations: number;
@@ -100,7 +101,7 @@ export async function runHealPhase(
     const healHandle = await manager.forkSubagent({
       parent: { sessionId: parentSession.sessionId },
       config: {
-        model: 'sonnet',
+        model: defaultSubagentModel,
         systemPrompt: healPrompt,
         apiKey: getApiKey(),
       },
@@ -149,6 +150,7 @@ export async function runHealPhase(
       parentSession.sessionId,
       parentSession.cwd,
       skillCallId,
+      defaultSubagentModel,
     );
 
     return {

--- a/src/skills/mint/_phases/parallelize-dispatch.ts
+++ b/src/skills/mint/_phases/parallelize-dispatch.ts
@@ -18,7 +18,7 @@ import { getSkill } from '../../index.js';
 import { discoverPluginSkillBodies } from '../../../agent/tools/skill-bridge.js';
 import { SubagentManager } from '../../../agent/subagent.js';
 import { getApiKey } from '../../../cli/shared-helpers.js';
-import type { IAgentSession } from '../../../agent/types.js';
+import type { AgentModelInput, IAgentSession } from '../../../agent/types.js';
 
 export type ParallelizeDispatchResult =
   | { kind: 'skipped'; reason: 'too-few-files' | 'skill-body-missing' }
@@ -56,6 +56,7 @@ export async function runParallelizeDispatch(
   // Mint skill's ToolCall id — anchors the parallelize subagent under the
   // mint skill's tool-lane entry. See skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
+  defaultSubagentModel: AgentModelInput = 'sonnet',
 ): Promise<ParallelizeDispatchResult> {
   const fileCount = countFileReferences(plan);
 
@@ -117,7 +118,7 @@ export async function runParallelizeDispatch(
         // surfaces lifecycle to the user.
         parent: { sessionId: parentSession.sessionId },
         config: {
-          model: 'sonnet',
+          model: defaultSubagentModel,
           systemPrompt: skill.body,
           env: { PLUGIN_ROOT: skill.pluginPath },
         },

--- a/src/skills/mint/_phases/plan.ts
+++ b/src/skills/mint/_phases/plan.ts
@@ -7,6 +7,7 @@ import { SubagentManager } from '../../../agent/subagent.js';
 import { describeFailure } from '../../../agent/subagent/result.js';
 import { getApiKey } from '../../../cli/shared-helpers.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
+import type { AgentModelInput } from '../../../agent/types.js';
 
 export async function runPlanPhase(
   spec: string,
@@ -16,6 +17,7 @@ export async function runPlanPhase(
   // Mint skill's ToolCall id — anchors the forked subagent under the mint
   // skill's tool-lane entry. See skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
+  defaultSubagentModel: AgentModelInput = 'sonnet',
 ): Promise<string> {
   const prompts = loadSkillPrompts('mint');
   const planPrompt = prompts['plan.md'];
@@ -31,7 +33,7 @@ export async function runPlanPhase(
   const planHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {
-      model: 'sonnet',
+      model: defaultSubagentModel,
       systemPrompt: planPrompt,
       apiKey: getApiKey(),
     },

--- a/src/skills/mint/_phases/research.ts
+++ b/src/skills/mint/_phases/research.ts
@@ -7,6 +7,7 @@ import { SubagentManager } from '../../../agent/subagent.js';
 import { describeFailure } from '../../../agent/subagent/result.js';
 import { getApiKey } from '../../../cli/shared-helpers.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
+import type { AgentModelInput } from '../../../agent/types.js';
 
 export async function runResearchPhase(
   spec: string,
@@ -16,6 +17,7 @@ export async function runResearchPhase(
   // under the mint skill's tool-lane entry so the live overlay AND scrollback
   // block both nest correctly. See skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
+  defaultSubagentModel: AgentModelInput = 'sonnet',
 ): Promise<string> {
   const prompts = loadSkillPrompts('mint');
   const researchPrompt = prompts['research.md'];
@@ -31,7 +33,7 @@ export async function runResearchPhase(
   const researchHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {
-      model: 'sonnet',
+      model: defaultSubagentModel,
       systemPrompt: researchPrompt,
       apiKey: getApiKey(),
     },

--- a/src/skills/mint/_phases/ship.ts
+++ b/src/skills/mint/_phases/ship.ts
@@ -7,6 +7,7 @@ import { SubagentManager } from '../../../agent/subagent.js';
 import { describeFailure } from '../../../agent/subagent/result.js';
 import { getApiKey } from '../../../cli/shared-helpers.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
+import type { AgentModelInput } from '../../../agent/types.js';
 import { emitCard } from '../../_lib/emit-card.js';
 import type { MintState } from '../index.js';
 
@@ -17,6 +18,7 @@ export async function runShipPhase(
   // Mint skill's ToolCall id — anchors the ship subagent under the mint
   // skill's tool-lane entry. See skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
+  defaultSubagentModel: AgentModelInput = 'sonnet',
 ): Promise<string> {
   const prompts = loadSkillPrompts('mint');
   const shipPrompt = prompts['ship.md'];
@@ -33,7 +35,7 @@ export async function runShipPhase(
   const shipHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {
-      model: 'sonnet',
+      model: defaultSubagentModel,
       systemPrompt: shipPrompt,
       apiKey: getApiKey(),
     },

--- a/src/skills/mint/_phases/spec.ts
+++ b/src/skills/mint/_phases/spec.ts
@@ -7,6 +7,7 @@ import { SubagentManager } from '../../../agent/subagent.js';
 import { describeFailure } from '../../../agent/subagent/result.js';
 import { getApiKey } from '../../../cli/shared-helpers.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
+import type { AgentModelInput } from '../../../agent/types.js';
 
 export async function runSpecPhase(
   idea: string,
@@ -15,6 +16,7 @@ export async function runSpecPhase(
   // Mint skill's ToolCall id. When present, anchors the forked subagent
   // under the mint skill's tool-lane entry — see runResearchPhase / skills/index.ts.
   skillCallId?: string,
+  defaultSubagentModel: AgentModelInput = 'sonnet',
 ): Promise<string> {
   const prompts = loadSkillPrompts('mint');
   const specPrompt = prompts['spec.md'];
@@ -33,7 +35,7 @@ export async function runSpecPhase(
   const specHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {
-      model: 'sonnet',
+      model: defaultSubagentModel,
       systemPrompt: specPrompt,
       apiKey: getApiKey(),
     },

--- a/src/skills/mint/_phases/verify.ts
+++ b/src/skills/mint/_phases/verify.ts
@@ -10,6 +10,7 @@ import { getApiKey } from '../../../cli/shared-helpers.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import { emitCard } from '../../_lib/emit-card.js';
 import type { BuildResult } from './build.js';
+import type { AgentModelInput } from '../../../agent/types.js';
 
 const VerifyModeOutputSchema = z.object({
   status: z.enum(['PASS', 'FAIL']),
@@ -35,6 +36,7 @@ async function forkVerifyMode(
   // Mint skill's ToolCall id — anchors the parallel verify-mode subagent
   // under the mint skill's tool-lane entry. See skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
+  defaultSubagentModel: AgentModelInput = 'sonnet',
 ): Promise<{ passed: boolean; issues?: string[] }> {
   // Propagate parent worktree — verify subagents run tests/lint/grep in
   // the right working tree.
@@ -44,7 +46,7 @@ async function forkVerifyMode(
   const verifyHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {
-      model: 'sonnet',
+      model: defaultSubagentModel,
       systemPrompt: verifyPrompt,
       apiKey: getApiKey(),
     },
@@ -93,6 +95,7 @@ export async function runVerifyPhase(
   // Mint skill's ToolCall id — anchors every parallel verify-mode subagent
   // under the mint skill's tool-lane entry. See skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
+  defaultSubagentModel: AgentModelInput = 'sonnet',
 ): Promise<VerifyResult> {
   const prompts = loadSkillPrompts('mint');
   const verifyPrompt = prompts['verify.md'];
@@ -103,9 +106,9 @@ export async function runVerifyPhase(
 
   // Run test, lint, and design-review in parallel
   const [testResult, lintResult, designResult] = await Promise.all([
-    forkVerifyMode('test', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId),
-    forkVerifyMode('lint', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId),
-    forkVerifyMode('design-review', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId),
+    forkVerifyMode('test', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel),
+    forkVerifyMode('lint', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel),
+    forkVerifyMode('design-review', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel),
   ]);
 
   const allIssues: string[] = [];

--- a/src/skills/mint/index.ts
+++ b/src/skills/mint/index.ts
@@ -17,7 +17,7 @@
  */
 
 import { registerSkill, type SkillExecutionContext, type SkillMetadata } from '../index.js';
-import type { IAgentSession } from '../../agent/types.js';
+import type { AgentModelInput, IAgentSession } from '../../agent/types.js';
 import { runSpecPhase } from './_phases/spec.js';
 import { runResearchPhase } from './_phases/research.js';
 import { runPlanPhase } from './_phases/plan.js';
@@ -172,6 +172,7 @@ async function runPhasesAfterSpec(
   // a lane entry by the renderer's parentId resolver — see
   // stream-renderer.ts:262-280, and skills/index.ts SkillExecutionContext.callId).
   skillCallId?: string,
+  defaultSubagentModel: AgentModelInput = 'sonnet',
 ): Promise<MintResult> {
   if (!parentSession.sessionId) {
     throw new Error('runPhasesAfterSpec requires parentSession.sessionId');
@@ -184,11 +185,11 @@ async function runPhasesAfterSpec(
   const parentCwd = parentSession.cwd;
   try {
     state.currentPhase = 'research';
-    state.research = await runResearchPhase(state.spec!, parentSessionId, parentCwd, skillCallId);
+    state.research = await runResearchPhase(state.spec!, parentSessionId, parentCwd, skillCallId, defaultSubagentModel);
     appendHistory(state, 'research', state.research);
 
     state.currentPhase = 'plan';
-    state.plan = await runPlanPhase(state.spec!, state.research, parentSessionId, parentCwd, skillCallId);
+    state.plan = await runPlanPhase(state.spec!, state.research, parentSessionId, parentCwd, skillCallId, defaultSubagentModel);
     appendHistory(state, 'plan', state.plan);
 
     state.currentPhase = 'parallelize';
@@ -196,6 +197,7 @@ async function runPhasesAfterSpec(
       state.plan,
       parentSession,
       skillCallId,
+      defaultSubagentModel,
     );
     if (parallelizeResult.kind === 'plan') {
       state.waveOrchestrationPlan = parallelizeResult.plan;
@@ -242,6 +244,7 @@ async function runPhasesAfterSpec(
       parentSessionId,
       parentCwd,
       skillCallId,
+      defaultSubagentModel,
     );
     appendHistory(state, 'build', JSON.stringify(state.buildResults));
 
@@ -252,6 +255,7 @@ async function runPhasesAfterSpec(
       parentSessionId,
       parentCwd,
       skillCallId,
+      defaultSubagentModel,
     );
     appendHistory(state, 'verify', JSON.stringify(state.verifyResults));
 
@@ -270,6 +274,7 @@ async function runPhasesAfterSpec(
         state.healIterations,
         parentSession,
         skillCallId,
+        defaultSubagentModel,
       );
       state.healIterations = healResult.newHealIterations;
       state.verifyResults = healResult.newVerifyResults;
@@ -293,7 +298,7 @@ async function runPhasesAfterSpec(
     }
 
     state.currentPhase = 'ship';
-    const artifact = await runShipPhase(state, parentSessionId, parentCwd, skillCallId);
+    const artifact = await runShipPhase(state, parentSessionId, parentCwd, skillCallId, defaultSubagentModel);
     appendHistory(state, 'ship', artifact);
 
     return { completed: true, artifact, state };
@@ -330,6 +335,7 @@ async function handler(
   // tool-lane entry in both the live overlay and the committed scrollback
   // block. See skills/index.ts SkillExecutionContext.callId.
   const skillCallId = ctx?.callId;
+  const defaultSubagentModel = ctx?.defaultSubagentModel ?? ctx?.defaultModel ?? 'sonnet';
 
   // Resume path — caller-supplied resumeFrom wins; otherwise reload the last
   // paused state for this session from disk.
@@ -340,7 +346,7 @@ async function handler(
         'mint: no paused spec found for this session to continue. Run /mint <idea> first, then /mint --continue approved.',
       );
     }
-    const result = await runPhasesAfterSpec(resumeState, parentSession, skillCallId);
+    const result = await runPhasesAfterSpec(resumeState, parentSession, skillCallId, defaultSubagentModel);
     return finalizeAfterSpec(parentSessionId, result);
   }
 
@@ -361,7 +367,7 @@ async function handler(
   };
 
   try {
-    state.spec = await runSpecPhase(mintInput.idea, parentSessionId, parentSession.cwd, skillCallId);
+    state.spec = await runSpecPhase(mintInput.idea, parentSessionId, parentSession.cwd, skillCallId, defaultSubagentModel);
     appendHistory(state, 'spec', state.spec);
   } catch (err) {
     throw new Error(`mint failed at spec: ${err}`);
@@ -380,7 +386,7 @@ async function handler(
     return pausedResult;
   }
 
-  const result = await runPhasesAfterSpec(state, parentSession, skillCallId);
+  const result = await runPhasesAfterSpec(state, parentSession, skillCallId, defaultSubagentModel);
   return finalizeAfterSpec(parentSessionId, result);
 }
 

--- a/src/skills/user-skills.test.ts
+++ b/src/skills/user-skills.test.ts
@@ -494,6 +494,37 @@ You process PDF files. Scripts are in \${SKILL_ROOT}/scripts/.
     expect(callArgs?.config?.env?.['SKILL_ROOT']).toBe(dir);
   });
 
+  it('uses SkillExecutionContext.defaultSubagentModel for forked user skills', async () => {
+    const skillName = 'model-aware';
+    const dir = join(skillsDir, skillName);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'SKILL.md'),
+      `---
+name: ${skillName}
+description: Uses the inherited subagent model
+context: fork
+---
+
+You run on the configured child model.
+`,
+    );
+
+    scanAndRegisterUserSkills();
+    const skill = getSkill(skillName);
+
+    await skill.handler('run', undefined, {
+      defaultModel: 'opus',
+      defaultSubagentModel: 'haiku',
+    });
+
+    expect(mockForkSubagent).toHaveBeenCalledOnce();
+    const callArgs = mockForkSubagent.mock.calls[0]?.[0] as {
+      config?: { model?: string };
+    };
+    expect(callArgs?.config?.model).toBe('haiku');
+  });
+
   it('SKILL_ROOT resolves to the correct absolute directory path', async () => {
     const skillName = 'data-analysis';
     const dir = join(skillsDir, skillName);

--- a/src/skills/user-skills.ts
+++ b/src/skills/user-skills.ts
@@ -144,6 +144,8 @@ function makeUserSkillHandler(parsed: ParsedSkillMd): SkillMetadata['handler'] {
     parentSession?: IAgentSession,
     ctx?: SkillExecutionContext,
   ) => {
+    const subagentModel = ctx?.defaultSubagentModel ?? ctx?.defaultModel ?? 'sonnet';
+
     // Invariant: name the skill explicitly — a bare "Run the skill." is
     // ambiguous and lets the sub-agent ask the operator "which skill?" instead
     // of executing its own SKILL.md body. Mirrors skill-executor.ts.
@@ -172,7 +174,7 @@ function makeUserSkillHandler(parsed: ParsedSkillMd): SkillMetadata['handler'] {
         abortSignal: parentSession?.abortSignal,
       },
       config: {
-        model: 'sonnet',
+        model: subagentModel,
         systemPrompt: parsed.body,
         env: { SKILL_ROOT: parsed.dir },
         // Invariant: like the plugin/registry dispatch paths in


### PR DESCRIPTION
## Summary
- Route /diagnose and /audit-fit inline skill forks through SkillExecutionContext defaultSubagentModel/defaultModel fallback instead of hardcoded sonnet
- Thread the inherited subagent model through /mint phases and forked user SKILL.md handlers
- Add regression coverage for user skill fork model inheritance

## Verification
- pnpm lint
- pnpm test -- src/skills/user-skills.test.ts src/agent/tools/skill-executor.test.ts
- pnpm test -- src/skills