### PR TITLE
feat(web)!: switch web_scrape search backend from Brave to Exa

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,11 +36,11 @@ CLAUDE_MODEL=sonnet
 # AFK_TELEGRAM_ALLOWED_CHAT_IDS=123456789,-100987654321
 
 # Web search (optional - for web_scrape search mode)
-# Brave Search API subscription token. Free tier at https://brave.com/search/api/.
+# Exa (exa.ai) search API key. Free tier (20k requests/month) at https://exa.ai.
 # Without it, web_scrape search mode returns a clear error; markdown and raw
 # modes work with no key. (markdown's render fallback needs the Playwright
 # chromium binary: `pnpm exec playwright install chromium`.)
-# BRAVE_SEARCH_API_KEY=BSA...your-token-here...
+# EXA_API_KEY=your-exa-api-key-here
 
 # Optional: Base URL and auth token (if using an Anthropic-compatible proxy)
 # NOTE: This only works with proxies that speak Anthropic's /v1/messages API.

--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -695,14 +695,6 @@
       "category": "process"
     },
     {
-      "name": "BRAVE_SEARCH_API_KEY",
-      "description": "Brave Search API subscription token, enabling web_scrape search mode. Free tier available at https://brave.com/search/api/. When unset, search mode returns an actionable error; markdown and raw modes are unaffected.",
-      "type": "string",
-      "required": false,
-      "category": "auth",
-      "secret": true
-    },
-    {
       "name": "CI",
       "description": "Standard CI-detection convention. Auto-set by GitHub Actions, CircleCI, etc. Used to switch off TTY-only UX.",
       "type": "string",
@@ -740,6 +732,14 @@
       "type": "string",
       "required": false,
       "category": "debug"
+    },
+    {
+      "name": "EXA_API_KEY",
+      "description": "Exa (exa.ai) search API key, enabling web_scrape search mode. Free tier (20k requests/month) available at https://exa.ai. When unset, search mode returns an actionable error; markdown and raw modes are unaffected.",
+      "type": "string",
+      "required": false,
+      "category": "auth",
+      "secret": true
     },
     {
       "name": "FORCE_COLOR",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -50,9 +50,9 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 |------|------|----------|---------|---------|-------------|
 | `AFK_LOCAL_API_KEY` | string |  | `local` | `local` | Placeholder API key for local Anthropic-compatible servers (vllm-mlx, etc.). Set when AFK_LOCAL_BASE_URL is configured. |
 | `ANTHROPIC_API_KEY` | string |  |  |  | Anthropic API key. Tier-1 credential — overrides keychain OAuth and CLAUDE_CODE_OAUTH_TOKEN. |
-| `BRAVE_SEARCH_API_KEY` | string |  |  |  | Brave Search API subscription token, enabling web_scrape search mode. Free tier available at https://brave.com/search/api/. When unset, search mode returns an actionable error; markdown and raw modes are unaffected. |
 | `CLAUDE_CODE_OAUTH_TOKEN` | string |  |  |  | Claude Code OAuth token. Tier-2 credential — used when ANTHROPIC_API_KEY is unset; falls back to keychain. |
 | `CODEX_API_KEY` | string |  |  |  | Fallback OpenAI API key for the openai-compatible provider, read after OPENAI_API_KEY. Legacy name from the removed @openai/codex-sdk integration — prefer OPENAI_API_KEY. |
+| `EXA_API_KEY` | string |  |  |  | Exa (exa.ai) search API key, enabling web_scrape search mode. Free tier (20k requests/month) available at https://exa.ai. When unset, search mode returns an actionable error; markdown and raw modes are unaffected. |
 | `OPENAI_API_KEY` | string |  |  |  | OpenAI API key for the openai-compatible provider (gpt-*, o1*, o3*, o4* models). |
 
 ## Telegram

--- a/src/agent/tool-category.ts
+++ b/src/agent/tool-category.ts
@@ -102,7 +102,7 @@ const WEB_TOOLS = new Set([
   // send_telegram is an outbound HTTP call to a third-party API —
   // same conceptual shape as a web fetch, so it shares the web bucket.
   'send_telegram',
-  // agent-afk's native web tool (local Readability/Turndown scrape + Brave search, plus raw GET).
+  // agent-afk's native web tool (local Readability/Turndown scrape + Exa search, plus raw GET).
   'web_scrape',
 ]);
 const BROWSER_TOOLS = new Set([

--- a/src/agent/tools/handlers/web-scrape.test.ts
+++ b/src/agent/tools/handlers/web-scrape.test.ts
@@ -44,15 +44,15 @@ function richArticleHtml(marker = 'main article content'): string {
     `<footer>Copyright</footer></body></html>`;
 }
 
-/** A Brave Search JSON response object. */
-function braveResponse(results: Array<{ title?: string; url?: string; description?: string }>): Response {
+/** An Exa Search JSON response object. */
+function exaResponse(results: Array<{ title?: string | null; url?: string; highlights?: string[] }>): Response {
   return {
     ok: true,
     status: 200,
     statusText: 'OK',
     headers: new Headers({ 'content-type': 'application/json' }),
-    json: async (): Promise<unknown> => ({ web: { results } }),
-    text: async (): Promise<string> => JSON.stringify({ web: { results } }),
+    json: async (): Promise<unknown> => ({ results }),
+    text: async (): Promise<string> => JSON.stringify({ results }),
   } as unknown as Response;
 }
 
@@ -221,41 +221,43 @@ describe('web_scrape handler — raw mode', () => {
   });
 });
 
-describe('web_scrape handler — search mode (Brave)', () => {
-  it('queries Brave with the subscription token and formats ranked results', async () => {
+describe('web_scrape handler — search mode (Exa)', () => {
+  it('queries Exa with the api key and formats ranked results', async () => {
     let seenUrl = '';
-    let seenToken: string | null = null;
+    let seenKey: string | null = null;
+    let seenBody: { query?: string } = {};
     const fetchFn = vi.fn(async (input: Parameters<FetchFn>[0], init?: Parameters<FetchFn>[1]) => {
       seenUrl = String(input);
-      seenToken = new Headers(init?.headers).get('x-subscription-token');
-      return braveResponse([
-        { title: 'Result 1', description: 'desc 1', url: 'https://r1.example' },
-        { title: 'Result 2', description: 'desc 2', url: 'https://r2.example' },
+      seenKey = new Headers(init?.headers).get('x-api-key');
+      seenBody = JSON.parse(String(init?.body)) as { query?: string };
+      return exaResponse([
+        { title: 'Result 1', highlights: ['desc 1'], url: 'https://r1.example' },
+        { title: 'Result 2', highlights: ['desc 2'], url: 'https://r2.example' },
       ]);
     }) as unknown as FetchFn;
-    const handler = createWebScrapeHandler({ fetchFn, env: { BRAVE_SEARCH_API_KEY: 'brave-secret' } });
+    const handler = createWebScrapeHandler({ fetchFn, env: { EXA_API_KEY: 'exa-secret' } });
 
     const r = await handler({ mode: 'search', query: 'playwright scraping' }, signal());
     expect(r.isError).toBeUndefined();
-    expect(seenUrl).toContain('api.search.brave.com');
-    expect(seenUrl).toContain('q=playwright+scraping');
-    expect(seenToken).toBe('brave-secret');
+    expect(seenUrl).toContain('api.exa.ai/search');
+    expect(seenBody.query).toBe('playwright scraping');
+    expect(seenKey).toBe('exa-secret');
     expect(r.content).toMatch(/# Search results for "playwright scraping"/);
     expect(r.content).toMatch(/## 1\. Result 1/);
     expect(r.content).toMatch(/https:\/\/r1\.example/);
     expect(r.content).toMatch(/## 2\. Result 2/);
   });
 
-  it('returns a clear error (and makes no request) when BRAVE_SEARCH_API_KEY is unset', async () => {
+  it('returns a clear error (and makes no request) when EXA_API_KEY is unset', async () => {
     const fetchFn = vi.fn(async () => makeResponse({ body: '' })) as unknown as FetchFn;
     const handler = createWebScrapeHandler({ fetchFn, env: {} });
     const r = await handler({ mode: 'search', query: 'whatever' }, signal());
     expect(r.isError).toBe(true);
-    expect(r.content).toMatch(/BRAVE_SEARCH_API_KEY/);
+    expect(r.content).toMatch(/EXA_API_KEY/);
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
-  it('surfaces a Brave HTTP error', async () => {
+  it('surfaces an Exa HTTP error', async () => {
     const fetchFn = vi.fn(async () => ({
       ok: false,
       status: 422,
@@ -264,16 +266,16 @@ describe('web_scrape handler — search mode (Brave)', () => {
       text: async (): Promise<string> => 'quota exceeded',
       json: async (): Promise<unknown> => ({}),
     } as unknown as Response)) as unknown as FetchFn;
-    const handler = createWebScrapeHandler({ fetchFn, env: { BRAVE_SEARCH_API_KEY: 'k' } });
+    const handler = createWebScrapeHandler({ fetchFn, env: { EXA_API_KEY: 'k' } });
     const r = await handler({ mode: 'search', query: 'q' }, signal());
     expect(r.isError).toBe(true);
-    expect(r.content).toMatch(/search error \(brave\)/);
+    expect(r.content).toMatch(/search error \(exa\)/);
     expect(r.content).toMatch(/422/);
   });
 
   it('handles an empty result set without throwing', async () => {
-    const fetchFn = vi.fn(async () => braveResponse([])) as unknown as FetchFn;
-    const handler = createWebScrapeHandler({ fetchFn, env: { BRAVE_SEARCH_API_KEY: 'k' } });
+    const fetchFn = vi.fn(async () => exaResponse([])) as unknown as FetchFn;
+    const handler = createWebScrapeHandler({ fetchFn, env: { EXA_API_KEY: 'k' } });
     const r = await handler({ mode: 'search', query: 'no hits' }, signal());
     expect(r.isError).toBeUndefined();
     expect(r.content).toMatch(/no results/);

--- a/src/agent/tools/handlers/web-scrape.ts
+++ b/src/agent/tools/handlers/web-scrape.ts
@@ -13,8 +13,8 @@
  *   - `raw`: GET <url> directly. No transformation — caller gets whatever the
  *     origin serves (HTML, JSON, plain text, …). No auth.
  *   - `search`: query a web-search backend and return ranked results as
- *     markdown. v1 supports Brave Search (`BRAVE_SEARCH_API_KEY`); the backend
- *     interface is pluggable (DuckDuckGo / SearXNG / Tavily can be added
+ *     markdown. Ships Exa Search (`EXA_API_KEY`); the backend interface is
+ *     pluggable (Brave / DuckDuckGo / SearXNG / Tavily can be added
  *     later). When no backend is configured the handler returns a clear,
  *     actionable error. See `src/web/search.ts`.
  *
@@ -263,9 +263,9 @@ export function createWebScrapeHandler(opts: WebScrapeOptions = {}): ToolHandler
         }
       }
 
-      // ---- search mode: pluggable backend (Brave in v1) ---------------------
+      // ---- search mode: pluggable backend (Exa) -----------------------------
       const backend = resolveSearchBackend({
-        braveApiKey: env['BRAVE_SEARCH_API_KEY'],
+        exaApiKey: env['EXA_API_KEY'],
         fetchFn,
       });
       if ('error' in backend) {

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -256,7 +256,7 @@ export const webScrapeTool: AnthropicToolDef = {
     'No API key required.\n' +
     '- `search`: runs a web search and returns ranked markdown results. Use when ' +
     'you need to FIND a URL, not read one. Provide `query` instead of `url`. ' +
-    'Requires `BRAVE_SEARCH_API_KEY` (free tier at https://brave.com/search/api/); ' +
+    'Requires `EXA_API_KEY` (free tier at https://exa.ai); ' +
     'the handler returns a clear error if it is unset.\n\n' +
     'Outputs are capped at `max_bytes` UTF-8 bytes (default 1MB, ceiling 10MB) ' +
     'and the request is aborted after `timeout_ms` (default 30000, ceiling 120000).',

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -431,8 +431,8 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     category: 'model',
   },
   {
-    name: 'BRAVE_SEARCH_API_KEY',
-    description: 'Brave Search API subscription token, enabling web_scrape search mode. Free tier available at https://brave.com/search/api/. When unset, search mode returns an actionable error; markdown and raw modes are unaffected.',
+    name: 'EXA_API_KEY',
+    description: 'Exa (exa.ai) search API key, enabling web_scrape search mode. Free tier (20k requests/month) available at https://exa.ai. When unset, search mode returns an actionable error; markdown and raw modes are unaffected.',
     type: 'string',
     required: false,
     category: 'auth',
@@ -1062,7 +1062,7 @@ export const env = {
   get AFK_OPENAI_USE_RESPONSES(): string | undefined { return process.env['AFK_OPENAI_USE_RESPONSES']; },
   get AFK_OPENAI_CHATGPT_OAUTH(): string | undefined { return process.env['AFK_OPENAI_CHATGPT_OAUTH']; },
   get AFK_PROVIDER(): string | undefined { return process.env['AFK_PROVIDER']; },
-  get BRAVE_SEARCH_API_KEY(): string | undefined { return process.env['BRAVE_SEARCH_API_KEY']; },
+  get EXA_API_KEY(): string | undefined { return process.env['EXA_API_KEY']; },
 
   // Telegram
   get TELEGRAM_BOT_TOKEN(): string | undefined { return process.env['TELEGRAM_BOT_TOKEN']; },

--- a/src/skills/get-started/index.ts
+++ b/src/skills/get-started/index.ts
@@ -49,7 +49,7 @@ async function handler(): Promise<unknown> {
 export const getStartedSkill: SkillMetadata = {
   name: 'get-started',
   description:
-    'Guided first-run onboarding for AFK. Runs a preflight check (git repo, model provider, AFK.md, Brave/Telegram/service config), asks the user their name and gives a brief intro, detects importable Claude Code / Codex assets and offers `afk migrate`, walks optional capability setup (Brave Search, Telegram via /telegram-setup, background service via /service-setup), then recommends /init to generate project context and /clear to start fresh — ending by routing the user to their first task. Runs interactively in the current session.',
+    'Guided first-run onboarding for AFK. Runs a preflight check (git repo, model provider, AFK.md, Exa/Telegram/service config), asks the user their name and gives a brief intro, detects importable Claude Code / Codex assets and offers `afk migrate`, walks optional capability setup (Exa Search, Telegram via /telegram-setup, background service via /service-setup), then recommends /init to generate project context and /clear to start fresh — ending by routing the user to their first task. Runs interactively in the current session.',
   handler,
   context: 'load',
   audience: 'public',

--- a/src/skills/get-started/prompts/system.md
+++ b/src/skills/get-started/prompts/system.md
@@ -22,7 +22,7 @@ afk doctor -f json
 git rev-parse --is-inside-work-tree
 ```
 
-Also check whether `AFK.md` exists in the current directory. Build a short status list: model provider (API key) ✓/✗, git repo ✓/✗, AFK.md present ✓/✗, and from the doctor JSON: Telegram, importable Claude Code/Codex assets. Brave Search = is `BRAVE_SEARCH_API_KEY` set in the environment.
+Also check whether `AFK.md` exists in the current directory. Build a short status list: model provider (API key) ✓/✗, git repo ✓/✗, AFK.md present ✓/✗, and from the doctor JSON: Telegram, importable Claude Code/Codex assets. Exa Search = is `EXA_API_KEY` set in the environment.
 
 **Idempotency:** if AFK.md already exists AND a model provider is configured AND (Telegram is configured or the user clearly isn't new), say so in one line — "Looks like AFK is already set up here." — and skip straight to Step 6 (first job). Don't re-run the full flow.
 
@@ -39,7 +39,7 @@ Then give a 4–6 line intro, e.g.:
 **3a. Migrate existing tooling.** If the doctor preflight flagged importable Claude Code / Codex assets, run `afk migrate --dry-run` (read-only preview — safe, no prompt) and summarize what it found (plugins / skills / MCP servers). Then `ask_question` (type `confirm`): "Import these into AFK?" On yes, run `afk migrate -y` (add `--mcp` only if they explicitly want MCP servers, which auto-run commands on connect). If nothing is importable, skip this silently.
 
 **3b. Optional capabilities.** Offer only the ones not already configured:
-- **Brave Search** (web research/grounding): if `BRAVE_SEARCH_API_KEY` is unset, tell them to set it in `~/.afk/config/afk.env`; offer to explain how.
+- **Exa Search** (web research/grounding): if `EXA_API_KEY` is unset, tell them to set it in `~/.afk/config/afk.env`; offer to explain how.
 - **Telegram** (drive/monitor AFK from your phone): if unconfigured, dispatch the `skill` tool with `/telegram-setup`.
 - **Background service** (always-on bot/daemon): **macOS only** — first check the platform (e.g. `uname` → `Darwin`). If not macOS, skip and say service mode is macOS-only today. On macOS, if they want it, dispatch the `skill` tool with `/service-setup`.
 

--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -11,11 +11,11 @@ export { extractReadableMarkdown, THIN_CONTENT_CHARS } from './extract.js';
 export { scrapeToMarkdown } from './scrape.js';
 export type { ScrapeOptions, ScrapeResult } from './scrape.js';
 export {
-  createBraveSearchBackend,
+  createExaSearchBackend,
   resolveSearchBackend,
   formatSearchResults,
 } from './search.js';
-export type { BraveBackendOptions, ResolveSearchOptions } from './search.js';
+export type { ExaBackendOptions, ResolveSearchOptions } from './search.js';
 export type {
   ExtractedContent,
   FetchFn,

--- a/src/web/search.test.ts
+++ b/src/web/search.test.ts
@@ -1,30 +1,31 @@
 /**
  * Unit tests for the search backends (src/web/search.ts).
  *
- * Strategy: inject `fetchFn` so no real Brave API call is made. Cover the
- * Brave request shape, result mapping/markup-stripping, HTTP error surfacing,
- * the no-key resolution error, and markdown formatting.
+ * Strategy: inject `fetchFn` so no real Exa API call is made. Cover the
+ * Exa request shape (POST + x-api-key + JSON body), result mapping (highlights
+ * → description), HTTP error surfacing, the no-key resolution error, and
+ * markdown formatting.
  */
 
 import { describe, it, expect, vi } from 'vitest';
 import {
-  createBraveSearchBackend,
+  createExaSearchBackend,
   resolveSearchBackend,
   formatSearchResults,
 } from './search.js';
 
-function braveOk(results: Array<{ title?: string; url?: string; description?: string }>): Response {
+function exaOk(results: Array<{ title?: string | null; url?: string; highlights?: string[] }>): Response {
   return {
     ok: true,
     status: 200,
     statusText: 'OK',
     headers: new Headers({ 'content-type': 'application/json' }),
-    json: async (): Promise<unknown> => ({ web: { results } }),
-    text: async (): Promise<string> => JSON.stringify({ web: { results } }),
+    json: async (): Promise<unknown> => ({ results }),
+    text: async (): Promise<string> => JSON.stringify({ results }),
   } as unknown as Response;
 }
 
-function braveErr(status: number, body = ''): Response {
+function exaErr(status: number, body = ''): Response {
   return {
     ok: false,
     status,
@@ -37,79 +38,92 @@ function braveErr(status: number, body = ''): Response {
 
 const signal = (): AbortSignal => new AbortController().signal;
 
-describe('createBraveSearchBackend — request shape', () => {
-  it('hits the Brave endpoint with the query, count, and subscription token', async () => {
+interface ExaRequestBody {
+  query?: string;
+  type?: string;
+  numResults?: number;
+  contents?: { highlights?: unknown };
+}
+
+describe('createExaSearchBackend — request shape', () => {
+  it('POSTs to the Exa endpoint with the api key, query, numResults, type, and highlights', async () => {
     let seenUrl = '';
-    let seenToken: string | null = null;
+    let seenMethod: string | undefined;
+    let seenKey: string | null = null;
+    let seenBody: ExaRequestBody = {};
     const fetchFn = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       seenUrl = String(input);
-      const headers = new Headers(init?.headers);
-      seenToken = headers.get('x-subscription-token');
-      return braveOk([{ title: 'T', url: 'https://e.com', description: 'D' }]);
+      seenMethod = init?.method;
+      seenKey = new Headers(init?.headers).get('x-api-key');
+      seenBody = JSON.parse(String(init?.body)) as ExaRequestBody;
+      return exaOk([{ title: 'T', url: 'https://e.com', highlights: ['D'] }]);
     });
 
-    const backend = createBraveSearchBackend({ apiKey: 'brave-secret', fetchFn: fetchFn as unknown as typeof fetch });
+    const backend = createExaSearchBackend({ apiKey: 'exa-secret', fetchFn: fetchFn as unknown as typeof fetch });
     await backend.search('hello world', { limit: 5, timeoutMs: 5000, signal: signal() });
 
-    expect(seenUrl).toContain('api.search.brave.com/res/v1/web/search');
-    expect(seenUrl).toContain('q=hello+world');
-    expect(seenUrl).toContain('count=5');
-    expect(seenToken).toBe('brave-secret');
-    expect(backend.name).toBe('brave');
+    expect(seenUrl).toBe('https://api.exa.ai/search');
+    expect(seenMethod).toBe('POST');
+    expect(seenKey).toBe('exa-secret');
+    expect(seenBody.query).toBe('hello world');
+    expect(seenBody.numResults).toBe(5);
+    expect(seenBody.type).toBe('auto');
+    expect(seenBody.contents?.highlights).toBeTruthy();
+    expect(backend.name).toBe('exa');
   });
 
-  it('clamps count to Brave max of 20', async () => {
-    let seenUrl = '';
-    const fetchFn = vi.fn(async (input: string | URL | Request) => {
-      seenUrl = String(input);
-      return braveOk([]);
+  it('clamps numResults to the Exa max of 10', async () => {
+    let seenBody: ExaRequestBody = {};
+    const fetchFn = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      seenBody = JSON.parse(String(init?.body)) as ExaRequestBody;
+      return exaOk([]);
     });
-    const backend = createBraveSearchBackend({ apiKey: 'k', fetchFn: fetchFn as unknown as typeof fetch });
+    const backend = createExaSearchBackend({ apiKey: 'k', fetchFn: fetchFn as unknown as typeof fetch });
     await backend.search('q', { limit: 100, timeoutMs: 5000, signal: signal() });
-    expect(seenUrl).toContain('count=20');
+    expect(seenBody.numResults).toBe(10);
   });
 });
 
-describe('createBraveSearchBackend — result mapping', () => {
-  it('maps results and strips highlight markup + entities from snippets', async () => {
+describe('createExaSearchBackend — result mapping', () => {
+  it('maps highlights[0] to description and falls back for a null title', async () => {
     const fetchFn = vi.fn(async () =>
-      braveOk([
-        { title: 'First <strong>hit</strong>', url: 'https://a.com', description: 'A &amp; B <strong>x</strong>' },
-        { title: 'Second', url: 'https://b.com', description: 'plain' },
+      exaOk([
+        { title: 'First hit', url: 'https://a.com', highlights: ['snippet A', 'snippet A2'] },
+        { title: null, url: 'https://b.com', highlights: [] },
       ]),
     );
-    const backend = createBraveSearchBackend({ apiKey: 'k', fetchFn: fetchFn as unknown as typeof fetch });
+    const backend = createExaSearchBackend({ apiKey: 'k', fetchFn: fetchFn as unknown as typeof fetch });
     const results = await backend.search('q', { limit: 10, timeoutMs: 5000, signal: signal() });
 
     expect(results).toHaveLength(2);
-    expect(results[0]).toEqual({ title: 'First hit', url: 'https://a.com', description: 'A & B x' });
-    expect(results[1]?.title).toBe('Second');
+    expect(results[0]).toEqual({ title: 'First hit', url: 'https://a.com', description: 'snippet A' });
+    expect(results[1]).toEqual({ title: '(untitled)', url: 'https://b.com', description: '' });
   });
 
   it('drops results with no URL and applies the limit', async () => {
     const fetchFn = vi.fn(async () =>
-      braveOk([
-        { title: 'has url', url: 'https://a.com', description: '' },
-        { title: 'no url', description: 'orphan' },
+      exaOk([
+        { title: 'has url', url: 'https://a.com', highlights: [] },
+        { title: 'no url', highlights: ['orphan'] },
       ]),
     );
-    const backend = createBraveSearchBackend({ apiKey: 'k', fetchFn: fetchFn as unknown as typeof fetch });
+    const backend = createExaSearchBackend({ apiKey: 'k', fetchFn: fetchFn as unknown as typeof fetch });
     const results = await backend.search('q', { limit: 10, timeoutMs: 5000, signal: signal() });
     expect(results).toHaveLength(1);
     expect(results[0]?.url).toBe('https://a.com');
   });
 
   it('surfaces an HTTP error with status and body snippet', async () => {
-    const fetchFn = vi.fn(async () => braveErr(422, 'quota exceeded'));
-    const backend = createBraveSearchBackend({ apiKey: 'k', fetchFn: fetchFn as unknown as typeof fetch });
+    const fetchFn = vi.fn(async () => exaErr(422, 'quota exceeded'));
+    const backend = createExaSearchBackend({ apiKey: 'k', fetchFn: fetchFn as unknown as typeof fetch });
     await expect(
       backend.search('q', { limit: 10, timeoutMs: 5000, signal: signal() }),
-    ).rejects.toThrow(/Brave Search HTTP 422.*quota exceeded/);
+    ).rejects.toThrow(/Exa Search HTTP 422.*quota exceeded/);
   });
 
   it('sanitizes control characters from HTTP error bodies before throwing', async () => {
-    const fetchFn = vi.fn(async () => braveErr(500, 'bad\x1b[31mred\x1b[0m\nbody\x07'));
-    const backend = createBraveSearchBackend({ apiKey: 'k', fetchFn: fetchFn as unknown as typeof fetch });
+    const fetchFn = vi.fn(async () => exaErr(500, 'bad\x1b[31mred\x1b[0m\nbody\x07'));
+    const backend = createExaSearchBackend({ apiKey: 'k', fetchFn: fetchFn as unknown as typeof fetch });
 
     let message = '';
     try {
@@ -118,7 +132,7 @@ describe('createBraveSearchBackend — result mapping', () => {
       message = err instanceof Error ? err.message : String(err);
     }
 
-    expect(message).toContain('Brave Search HTTP 500 Error: badred body');
+    expect(message).toContain('Exa Search HTTP 500 Error: badred body');
     expect(message).not.toContain('\x1b');
     expect(message).not.toContain('\n');
     expect(message).not.toContain('\x07');
@@ -126,20 +140,20 @@ describe('createBraveSearchBackend — result mapping', () => {
 });
 
 describe('resolveSearchBackend', () => {
-  it('returns a Brave backend when a key is present', () => {
-    const resolved = resolveSearchBackend({ braveApiKey: 'k' });
+  it('returns an Exa backend when a key is present', () => {
+    const resolved = resolveSearchBackend({ exaApiKey: 'k' });
     expect('error' in resolved).toBe(false);
-    expect((resolved as { name: string }).name).toBe('brave');
+    expect((resolved as { name: string }).name).toBe('exa');
   });
 
   it('returns an actionable error when no key is configured', () => {
-    const resolved = resolveSearchBackend({ braveApiKey: undefined });
+    const resolved = resolveSearchBackend({ exaApiKey: undefined });
     expect('error' in resolved).toBe(true);
-    expect((resolved as { error: string }).error).toMatch(/BRAVE_SEARCH_API_KEY/);
+    expect((resolved as { error: string }).error).toMatch(/EXA_API_KEY/);
   });
 
   it('treats a blank key as unconfigured', () => {
-    const resolved = resolveSearchBackend({ braveApiKey: '   ' });
+    const resolved = resolveSearchBackend({ exaApiKey: '   ' });
     expect('error' in resolved).toBe(true);
   });
 });

--- a/src/web/search.ts
+++ b/src/web/search.ts
@@ -1,14 +1,14 @@
 /**
  * Web-search backends for `web_scrape` search mode.
  *
- * v1 ships exactly one backend — Brave Search — behind a `SearchBackend`
- * interface so DuckDuckGo / SearXNG / Tavily / SerpAPI can be added later
+ * Ships one backend — Exa (exa.ai) — behind a `SearchBackend` interface so
+ * other engines (Brave / Tavily / SearXNG / SerpAPI) can be added later
  * without touching the handler. The handler calls `resolveSearchBackend()`
  * to pick a backend from available credentials; when none is configured it
  * receives a clear, actionable error instead of a failed request.
  *
- * Deliberate non-goal for v1: search-engine scraping (DuckDuckGo HTML, etc.).
- * It is brittle and bot-blocked; we require a real search API key instead.
+ * Deliberate non-goal: search-engine scraping (DuckDuckGo HTML, etc.). It is
+ * brittle and bot-blocked; we require a real search API key instead.
  *
  * @module web/search
  */
@@ -16,62 +16,56 @@
 import type { FetchFn, SearchBackend, SearchResult } from './types.js';
 import { sanitizeForDisplay } from '../utils/terminal-sanitize.js';
 
-const BRAVE_ENDPOINT = 'https://api.search.brave.com/res/v1/web/search';
-/** Brave caps `count` at 20 per request. */
-const BRAVE_MAX_COUNT = 20;
+const EXA_ENDPOINT = 'https://api.exa.ai/search';
+/** Exa's free/basic plans cap `numResults` at 10. */
+const EXA_MAX_RESULTS = 10;
 
-interface BraveWebResult {
-  title?: string;
+/** One result from Exa's `/search` response. `contents` fields are optional. */
+interface ExaSearchResult {
+  title?: string | null;
   url?: string;
-  description?: string;
+  /** Present when `contents.highlights` is requested — query-relevant snippets. */
+  highlights?: string[];
 }
 
-interface BraveResponse {
-  web?: { results?: BraveWebResult[] };
+interface ExaResponse {
+  results?: ExaSearchResult[];
 }
 
-/** Strip Brave's `<strong>`-highlighted snippet markup and collapse spaces. */
-function stripMarkup(s: string): string {
-  return s
-    .replace(/<[^>]*>/g, '')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-export interface BraveBackendOptions {
+export interface ExaBackendOptions {
   apiKey: string;
   /** Override for tests. Defaults to `globalThis.fetch`. */
   fetchFn?: FetchFn;
 }
 
 /**
- * Construct a Brave Search backend bound to an API key.
+ * Construct an Exa Search backend bound to an API key.
  *
- * Brave's REST API returns JSON directly (no browser needed), making search
+ * Exa's REST API returns JSON directly (no browser needed), making search
  * robust and deterministic — the opposite of scraping a search-results page.
+ * We request `contents.highlights` so each result carries a query-relevant
+ * snippet for the `description` field; Exa highlights are plain text, so no
+ * markup stripping is needed.
  */
-export function createBraveSearchBackend(opts: BraveBackendOptions): SearchBackend {
+export function createExaSearchBackend(opts: ExaBackendOptions): SearchBackend {
   const fetchFn = opts.fetchFn ?? globalThis.fetch;
   return {
-    name: 'brave',
+    name: 'exa',
     async search(query, { limit, signal }): Promise<SearchResult[]> {
-      const url = new URL(BRAVE_ENDPOINT);
-      url.searchParams.set('q', query);
-      url.searchParams.set('count', String(Math.min(Math.max(limit, 1), BRAVE_MAX_COUNT)));
-
-      const res = await fetchFn(url.toString(), {
-        method: 'GET',
+      const res = await fetchFn(EXA_ENDPOINT, {
+        method: 'POST',
         headers: {
+          'Content-Type': 'application/json',
           Accept: 'application/json',
-          'Accept-Encoding': 'gzip',
-          'X-Subscription-Token': opts.apiKey,
+          'x-api-key': opts.apiKey,
           'User-Agent': 'agent-afk/web_scrape',
         },
+        body: JSON.stringify({
+          query,
+          type: 'auto',
+          numResults: Math.min(Math.max(limit, 1), EXA_MAX_RESULTS),
+          contents: { highlights: { numSentences: 3, highlightsPerUrl: 1 } },
+        }),
         signal,
       });
 
@@ -85,25 +79,25 @@ export function createBraveSearchBackend(opts: BraveBackendOptions): SearchBacke
           // Ignore — proceed with status only.
         }
         const statusText = res.statusText ? ` ${res.statusText}` : '';
-        throw new Error(`Brave Search HTTP ${res.status}${statusText}${detail}`);
+        throw new Error(`Exa Search HTTP ${res.status}${statusText}${detail}`);
       }
 
-      let json: BraveResponse;
+      let json: ExaResponse;
       try {
-        json = (await res.json()) as BraveResponse;
+        json = (await res.json()) as ExaResponse;
       } catch (err) {
         throw new Error(
-          `Brave Search response was not JSON: ${err instanceof Error ? err.message : String(err)}`,
+          `Exa Search response was not JSON: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
 
-      const results = json.web?.results ?? [];
+      const results = json.results ?? [];
       return results
         .slice(0, limit)
         .map((r) => ({
-          title: stripMarkup(r.title ?? '') || '(untitled)',
+          title: (r.title ?? '').trim() || '(untitled)',
           url: r.url ?? '',
-          description: stripMarkup(r.description ?? ''),
+          description: (r.highlights?.[0] ?? '').trim(),
         }))
         .filter((r) => r.url.length > 0);
     },
@@ -111,8 +105,8 @@ export function createBraveSearchBackend(opts: BraveBackendOptions): SearchBacke
 }
 
 export interface ResolveSearchOptions {
-  /** Brave API key (from BRAVE_SEARCH_API_KEY), if present. */
-  braveApiKey?: string | undefined;
+  /** Exa API key (from EXA_API_KEY), if present. */
+  exaApiKey?: string | undefined;
   /** Override for tests. */
   fetchFn?: FetchFn;
 }
@@ -121,21 +115,21 @@ export interface ResolveSearchOptions {
  * Pick a search backend from available credentials.
  *
  * Resolution order (extend here as backends are added):
- *   1. Brave — when `braveApiKey` is set.
- *   …  (future: SearXNG instance URL, Tavily key, …)
+ *   1. Exa — when `exaApiKey` is set.
+ *   …  (future: Brave key, SearXNG instance URL, Tavily key, …)
  *
  * Returns `{ error }` with an actionable message when nothing is configured,
  * so the handler surfaces a `ToolResult { isError: true }` rather than making
  * a doomed request.
  */
 export function resolveSearchBackend(opts: ResolveSearchOptions): SearchBackend | { error: string } {
-  if (opts.braveApiKey !== undefined && opts.braveApiKey.trim() !== '') {
-    return createBraveSearchBackend({ apiKey: opts.braveApiKey, fetchFn: opts.fetchFn });
+  if (opts.exaApiKey !== undefined && opts.exaApiKey.trim() !== '') {
+    return createExaSearchBackend({ apiKey: opts.exaApiKey, fetchFn: opts.fetchFn });
   }
   return {
     error:
-      'web_scrape search mode requires a search backend. Set BRAVE_SEARCH_API_KEY ' +
-      '(free tier at https://brave.com/search/api/) to enable it. ' +
+      'web_scrape search mode requires a search backend. Set EXA_API_KEY ' +
+      '(free tier at https://exa.ai) to enable it. ' +
       'Use mode: "markdown" to read a known URL, or mode: "raw" for a direct fetch.',
   };
 }

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -71,13 +71,13 @@ export interface SearchResult {
 /**
  * A pluggable web-search backend.
  *
- * v1 ships exactly one implementation: Brave (`./search.ts`). The interface
- * exists so DuckDuckGo / SearXNG / Tavily / SerpAPI backends can be added
+ * Ships one implementation: Exa (`./search.ts`). The interface exists so
+ * Brave / DuckDuckGo / SearXNG / Tavily / SerpAPI backends can be added
  * later without touching the handler — it resolves a backend and calls
  * `search()`.
  */
 export interface SearchBackend {
-  /** Backend identifier, e.g. `'brave'`. Surfaced in error messages. */
+  /** Backend identifier, e.g. `'exa'`. Surfaced in error messages. */
   readonly name: string;
   /**
    * Run a query and return ranked results.


### PR DESCRIPTION
## Summary
- Swap the `web_scrape` tool's search backend from **Brave Search → Exa (exa.ai)**. The pre-built pluggable `SearchBackend` seam made this a contained swap: the interface, `SearchResult` shape, `formatSearchResults()`, and handler dispatch are unchanged — only the backend implementation and the env var differ.
- New backend issues `POST https://api.exa.ai/search` with header `x-api-key`, body `{query, type:"auto", numResults<=10, contents.highlights}`. Maps `highlights[0] -> description`, nullable `title -> "(untitled)"`, filters empty URLs.
- Implemented with **raw `fetch` (not `exa-js`)** to preserve the injected `fetchFn` test seam and add zero runtime dependencies.
- **BREAKING:** search mode now requires `EXA_API_KEY`; `BRAVE_SEARCH_API_KEY` is no longer read. The no-key error and `/get-started` onboarding name the new variable. Exa's free tier is far more generous (20k req/mo vs Brave's ~2k).

## Test results
- `pnpm lint` (tsc --noEmit, strict): **passed**
- `pnpm test` (full suite): **490 files, 9205 passed, 12 skipped, 0 failed**
- `pnpm build` (tsc + copy-prompts): **passed**
- `pnpm scan:env:check` (CI gate): **in sync** (107 vars)
- `pnpm audit:sdk:check` (CI gate): **OK** (no new SDK symbols)

## Verification
Adversarial verifier wave (read-only; claims re-derived from the diff alone): **SHIP-SAFE**.
- Correct Exa request + response mapping — **CONFIRM** (`src/web/search.ts:56-70, 96-100`)
- Clean swap behind unchanged seam — **CONFIRM** (`src/web/types.ts`, handler dispatch in `web-scrape.ts`)
- BREAKING change complete, no dangling Brave read — **CONFIRM** (`grep brave src/` -> 4 comment-only hits listing Brave as a *future* backend; zero wired reads, zero Brave endpoint strings)

## Touched files (13)
- **Core:** `src/web/search.ts` (Brave->Exa backend), `src/web/index.ts` (exports), `src/web/types.ts` (doc comments)
- **Wiring:** `src/agent/tools/handlers/web-scrape.ts`, `src/agent/tools/schemas.ts`, `src/config/env.ts`, `src/agent/tool-category.ts`
- **Onboarding:** `src/skills/get-started/{index.ts, prompts/system.md}`
- **Tests:** `src/web/search.test.ts`, `src/agent/tools/handlers/web-scrape.test.ts`
- **Generated:** `docs/env-registry.{json,md}` (via `pnpm scan:env`)

## Out of scope / follow-ups
- **Not probed against a live `EXA_API_KEY`** — request/response shape is from Exa's docs; the parser is defensive (`?? []`, optional fields). A real round-trip would confirm end-to-end.
- **Migration:** existing users with only `BRAVE_SEARCH_API_KEY` lose search until they set `EXA_API_KEY` (the error message states the requirement). No automatic Brave-key detection/hint was added.
