### PR TITLE
fix(website): make docs search work (add /api/search + export structuredData)

### DIFF
--- a/website/app/api/search/route.ts
+++ b/website/app/api/search/route.ts
@@ -1,0 +1,13 @@
+import { createFromSource } from 'fumadocs-core/search/server';
+import { source } from '@/lib/source';
+
+// Contract: Fumadocs' RootProvider enables the search dialog by default
+// (search.enabled defaults to true), and the default dialog issues
+// GET /api/search?query=... via fumadocs-core's fetch client. Without this
+// route handler that request 404s and the dialog silently returns no results
+// ("search does nothing"). createFromSource builds an in-memory Orama index
+// from the same loader the pages use (@/lib/source), keeping the index in sync
+// with the rendered docs. This is the canonical server-search wiring; it relies
+// on a Node runtime (the site already uses next.config redirects()/headers(),
+// which are incompatible with output: 'export').
+export const { GET } = createFromSource(source);

--- a/website/source.config.ts
+++ b/website/source.config.ts
@@ -2,6 +2,20 @@ import { defineDocs, defineConfig } from 'fumadocs-mdx/config';
 
 export const docs = defineDocs({
   dir: 'content/docs',
+  docs: {
+    // Invariant: search depends on each compiled MDX module exporting
+    // `structuredData`. remarkStructure (the default MDX preset) populates
+    // `vfile.data.structuredData`, but with the installed fumadocs-mdx@14 +
+    // fumadocs-core@15 pairing the export step does not emit it automatically
+    // (core 15's remarkStructure ignores the `exportAs` hint fumadocs-mdx
+    // passes). Listing it in `postprocess.valueToExport` re-exports that vfile
+    // data as a real module export, so `page.data.structuredData` is defined at
+    // build time (no runtime filesystem reads) and `createFromSource` can build
+    // the search index. Drop this once the two packages are realigned.
+    postprocess: {
+      valueToExport: ['structuredData'],
+    },
+  },
 });
 
 export default defineConfig();


### PR DESCRIPTION
## Problem

Search on the docs site does nothing — you can open the dialog and type, but no results ever appear.

## Root cause (verified, not guessed)

The docs site is a **Fumadocs** app. `RootProvider` enables the search dialog by default (`search.enabled` defaults to `true`), and the default dialog issues `GET /api/search?query=…` via `fumadocs-core`'s fetch client.

Two things were broken:

1. **No search route handler existed.** `app/api/search/route.ts` was never created, so every query hit a non-existent route → 404 → empty results.
2. **Even with the route, `createFromSource` 500s** with `Cannot find structured data from page`. The compiled MDX modules only export `default / frontmatter / toc` — **`structuredData` is never emitted**. With the installed `fumadocs-mdx@14.0.4` + `fumadocs-core@15.8.5` pairing, `remarkStructure` populates `vfile.data.structuredData` but the export step doesn't emit it automatically (core 15's `remarkStructure` ignores the `exportAs` hint `fumadocs-mdx` passes). All 23 pages had `page.data.structuredData === undefined`.

## Fix

- **`app/api/search/route.ts`** — canonical `export const { GET } = createFromSource(source)` to serve the index. (`next.config` already uses `redirects()`/`headers()`, which are incompatible with `output: 'export'`, so the dynamic route handler is correct.)
- **`source.config.ts`** — add `docs.postprocess.valueToExport: ['structuredData']`. `remarkStructure` already computes the data; this re-exports it as a real module export, so `page.data.structuredData` is defined **at build time** (no runtime filesystem reads → safe in serverless/static-server deploys).

Both files carry an inline comment explaining the contract and a note to drop the `valueToExport` workaround once the two fumadocs packages are realigned.

## Verification

End-to-end against a live server (dev, `next build`, and `next start`):

- ✅ `next build` succeeds; `/api/search` emitted as `ƒ (Dynamic)`.
- ✅ All **23 pages** index cleanly (`badCount: 0`).
- ✅ `GET /api/search?query=…` returns **200** with highlighted matches, heading deep-links, and breadcrumbs for: `daemon`, `telegram`, `worktree`, `subagent`, `mcp`.
- ✅ `npm run typecheck` passes.

## Notes

Stacked on top of `afk-port/pr-784` (the docs-site port) — base branch is `afk-port/pr-784`, not `main`.
