### PR TITLE
feat(website): add Vercel Web Analytics

### DIFF
--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
+import { Analytics } from '@vercel/analytics/next';
 import './globals.css';
 
 // JetBrains Mono (variable, latin subset) — vendored under app/fonts/ (OFL-1.1,
@@ -27,7 +28,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className={jetbrainsMono.variable} suppressHydrationWarning>
-      <body>{children}</body>
+      <body>{children}<Analytics /></body>
     </html>
   );
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@types/mdx": "2.0.14",
+        "@vercel/analytics": "^2.0.1",
         "fumadocs-core": "15.8.5",
         "fumadocs-mdx": "14.0.4",
         "fumadocs-ui": "15.8.5",
@@ -2116,14 +2117,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.29",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
       "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2134,7 +2135,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -2151,6 +2152,48 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.17.0",
@@ -2364,7 +2407,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/website/package.json
+++ b/website/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@types/mdx": "2.0.14",
+    "@vercel/analytics": "^2.0.1",
     "fumadocs-core": "15.8.5",
     "fumadocs-mdx": "14.0.4",
     "fumadocs-ui": "15.8.5",


### PR DESCRIPTION
## What

Adds [Vercel Web Analytics](https://vercel.com/docs/analytics) to the Agent AFK documentation website to collect privacy-friendly, aggregated traffic insights.

## How

- `npm install @vercel/analytics` — adds `@vercel/analytics@2.0.1` (MIT) to `website/package.json` and updates `website/package-lock.json`
- Mounts `<Analytics />` in `website/app/layout.tsx` (Next.js 15 App Router root layout), via the canonical `@vercel/analytics/next` subpath export, immediately after `{children}` inside `<body>`

**Diff of `layout.tsx`** (two-line change):
```diff
+import { Analytics } from '@vercel/analytics/next';
 ...
-      <body>{children}</body>
+      <body>{children}<Analytics /></body>
```

## Verification

| Check | Result |
|-------|--------|
| `npm run typecheck` | Pre-existing failures only (3 errors in `[[...slug]]/page.tsx` and `lib/source.ts`, identical on `main` baseline). **Zero new errors** introduced by this change. |
| `npm run build` | ✅ **Pass** — 27 static pages generated, compiled successfully. |

## Note for deploy

Web Analytics must also be **enabled in the Vercel dashboard** for the project before data will flow. This is an account/dashboard action outside this PR:
> Vercel Dashboard → Project → Analytics tab → Enable

No other configuration is required; the `<Analytics />` component auto-discovers the Vercel environment.