### PR TITLE
docs(website): fix Brave→Exa search key, document daemon --host, add /get-started

### DIFF
--- a/website/content/docs/configuration/api-keys.mdx
+++ b/website/content/docs/configuration/api-keys.mdx
@@ -126,15 +126,15 @@ separately via `AFK_TELEGRAM_ALLOWED_CHAT_IDS` (comma-separated). Run
 `afk telegram setup` for guided first-time onboarding.
 Source: `docs/env-registry.md` (Telegram section).
 
-## Brave Search (optional)
+## Exa Search (optional)
 
-The `web_scrape` tool's search mode requires a Brave Search API key:
+The `web_scrape` tool's search mode requires an Exa (exa.ai) API key:
 
 ```bash
-export BRAVE_SEARCH_API_KEY=...
+export EXA_API_KEY=...
 ```
 
-Free tier available at [brave.com/search/api](https://brave.com/search/api/).
+Free tier (20k requests/month) available at [exa.ai](https://exa.ai).
 When unset, search mode returns an actionable error; markdown and raw fetch
 modes work without it.
 

--- a/website/content/docs/configuration/environment-variables.mdx
+++ b/website/content/docs/configuration/environment-variables.mdx
@@ -11,9 +11,9 @@ All environment variables recognized by `agent-afk` are listed here, grouped by 
 | --- | --- | --- | --- |
 | `AFK_LOCAL_API_KEY` | string | Placeholder API key for local Anthropic-compatible servers (vllm-mlx, etc.). Set when AFK_LOCAL_BASE_URL is configured. | `local` |
 | `ANTHROPIC_API_KEY` | string | Anthropic API key. Tier-1 credential — overrides keychain OAuth and CLAUDE_CODE_OAUTH_TOKEN. | — |
-| `BRAVE_SEARCH_API_KEY` | string | Brave Search API subscription token, enabling web_scrape search mode. Free tier available at https://brave.com/search/api/. When unset, search mode returns an actionable error; markdown and raw modes are unaffected. | — |
 | `CLAUDE_CODE_OAUTH_TOKEN` | string | Claude Code OAuth token. Tier-2 credential — used when ANTHROPIC_API_KEY is unset; falls back to keychain. | — |
 | `CODEX_API_KEY` | string | Fallback OpenAI API key for the openai-compatible provider, read after OPENAI_API_KEY. Legacy name from the removed @openai/codex-sdk integration — prefer OPENAI_API_KEY. | — |
+| `EXA_API_KEY` | string | Exa (exa.ai) search API key, enabling web_scrape search mode. Free tier (20k requests/month) available at https://exa.ai. When unset, search mode returns an actionable error; markdown and raw modes are unaffected. | — |
 | `OPENAI_API_KEY` | string | OpenAI API key for the openai-compatible provider (gpt-*, o1*, o3*, o4* models). | — |
 
 
@@ -61,7 +61,7 @@ All environment variables recognized by `agent-afk` are listed here, grouped by 
 | Variable | Type | Description | Default |
 | --- | --- | --- | --- |
 | `AFK_AUTO_ROUTING` | boolean | Auto-route bare slash inputs to matching skills. Applies to interactive, chat, telegram, and daemon surfaces. | — |
-| `AFK_INTERNAL` | boolean | When set to exactly `1`, unlocks internal-audience skills (e.g. `/audit-fit`) in slash listings and `/help`. Gates surfacing only — it does not change what's accessible. | — |
+| `AFK_INTERNAL` | boolean | Tier gate. Unlocks only when set to the literal string `1` — other truthy values (`true`, `yes`) leave the tier locked. When unlocked, internal-audience skills (e.g. `/audit-fit`) become visible in slash listings, `/help`, and tab-complete. Gates surfacing only — not an access boundary; it does not change what's accessible. | — |
 
 
 ## Browser

--- a/website/content/docs/skills/built-in.mdx
+++ b/website/content/docs/skills/built-in.mdx
@@ -9,6 +9,22 @@ AFK includes a small set of skills out of the box. Each one works as a slash com
 
 These skills are visible to all users.
 
+### `/get-started`
+
+```
+/get-started
+```
+
+**Purpose:** Guided first-run onboarding — preflight checks, optional capability setup, and a route to your first task.
+
+**What it does:** Runs a preflight check (git repo, model provider, `AFK.md`, Exa/Telegram/service config), asks your name and gives a brief intro, detects importable Claude Code / Codex assets and offers `afk migrate`, then walks optional capability setup (Exa Search, Telegram via `/telegram-setup`, background service via `/service-setup`). Ends by recommending `/init` to generate project context and `/clear` to start fresh, then routes you to your first task.
+
+**Execution mode:** `load` — runs interactively in the current session (not a fork), so it can drive setup alongside you.
+
+**When to use:** When you're setting up AFK for the first time or asking how to get going. Triggers on `/get-started`, "how do I start", "set me up", or "onboard me". Best run in the interactive REPL.
+
+---
+
 ### `/mint`
 
 ```

--- a/website/content/docs/surfaces/daemon.mdx
+++ b/website/content/docs/surfaces/daemon.mdx
@@ -44,6 +44,8 @@ afk daemon \
 | `--effort <level>` | Effort level: `low` \| `medium` \| `high` \| `xhigh` \| `max` |
 | `--sessionstart-cooldown-ms <ms>` | Cooldown between sessionstart fires |
 | `--port <n>` | HTTP port for live schedule sync (default `7777`) |
+| `--host <address>` | Bind address for the control HTTP surface (default `127.0.0.1`, loopback only). Overrides `AFK_DAEMON_HOST`. **The control surface is unauthenticated** — bind a non-loopback address (e.g. `0.0.0.0`) only on a trusted or firewalled network. |
+| `--briefs-dir <path>` | Override the directory scanned for pending briefs (default `~/.afk/agent-framework/briefs`). |
 
 ## Testing a single tick
 
@@ -133,6 +135,7 @@ and will take effect on next start.
 | `AFK_DAEMON_TASK_ID` | Default task ID (overridden by `--task-id`) |
 | `AFK_TIMEOUT_MS` | Per-tick session timeout in milliseconds |
 | `AFK_DAEMON_CWD` | Working directory for daemon-spawned sessions |
+| `AFK_DAEMON_HOST` | Bind address for the control HTTP surface (default `127.0.0.1`, loopback only). Overridden by `--host`. |
 | `AFK_SESSIONSTART_COOLDOWN_MS` | Cooldown between sessionstart fires |
 
 ## State and logs


### PR DESCRIPTION
## Summary

A scoping audit of the newly-added docs website (v4.0.1) surfaced content-accuracy gaps against the shipping code. This PR fixes the verified high-priority items.

| Fix | File(s) | Source of truth |
|-----|---------|-----------------|
| **Search key Brave→Exa** — `BRAVE_SEARCH_API_KEY` is fictional; the real key is `EXA_API_KEY` (search backend was switched Brave→Exa). Fixed in the env-var reference **and** a second stale section in the api-keys guide. | `configuration/environment-variables.mdx`, `configuration/api-keys.mdx` | `src/config/env.ts:434` |
| **Daemon `--host`** flag + its UNAUTHENTICATED / non-loopback **security warning**, plus `--briefs-dir` and `AFK_DAEMON_HOST` on the daemon env table. | `surfaces/daemon.mdx` | `src/cli/commands/daemon.ts:212,234,255` |
| **Add `/get-started`** — public, load-mode onboarding skill that ships and is user-visible but was undocumented. | `skills/built-in.mdx` | `src/skills/get-started/index.ts:50` |
| **`AFK_INTERNAL`** — clarify it unlocks only on the literal `1` (`true`/`yes` leave the tier locked). | `configuration/environment-variables.mdx` | `src/config/env.ts:677` |

## Verification

- `next build` compiles all **27 static pages** with no MDX or type errors.
- `grep -rin brave website/content/` → **zero** matches remain.
- Diff is content-only: +25 / −6 across 4 MDX files (no build artifacts).

## Not included (deferred)

Lower-priority scope items left for a follow-up pass: hardcoded model-slot defaults that will drift (`model-slots.mdx`), bare-`codex` alias in README, underscore-prefix model variants missing from the routing table, and thin coverage of the Elicitation Router / AbortGraph semantics.
