### PR TITLE
feat(forge): surface pending briefs nudge on AFK interactive sessions

### DIFF
--- a/src/agent/routing-directive.test.ts
+++ b/src/agent/routing-directive.test.ts
@@ -11,7 +11,11 @@
  * motivated this fix.
  */
 
-import { describe, it, expect } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, it, expect, afterEach } from 'vitest';
 
 import { parseTerminalState } from '../cli/commands/interactive/terminal-state.js';
 
@@ -19,6 +23,7 @@ import {
   END_OF_TURN_DIRECTIVE,
   ROUTING_DIRECTIVE,
   assembleSystemPrompt,
+  pendingBriefContext,
 } from './routing-directive.js';
 
 const BASE = 'You are a careful assistant.';
@@ -121,6 +126,55 @@ describe('assembleSystemPrompt', () => {
       // Three sections → at least two `\n\n` separators.
       const separators = (out!.match(/\n\n/g) ?? []).length;
       expect(separators).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('briefContext parameter', () => {
+    const BRIEF_CTX = '[forge: 1 pending skill brief]\n\nRun /forge to process.';
+
+    it('injects briefContext before end-of-turn on the repl surface', () => {
+      const out = assembleSystemPrompt(BASE, false, 'repl', BRIEF_CTX);
+      expect(out).toContain(BRIEF_CTX);
+      expect(out).toContain(END_OF_TURN_DIRECTIVE);
+      // brief context must precede end-of-turn
+      expect(out!.indexOf(BRIEF_CTX)).toBeLessThan(out!.indexOf(END_OF_TURN_DIRECTIVE));
+    });
+
+    it('injects briefContext before end-of-turn on the telegram surface', () => {
+      const out = assembleSystemPrompt(BASE, false, 'telegram', BRIEF_CTX);
+      expect(out).toContain(BRIEF_CTX);
+      expect(out!.indexOf(BRIEF_CTX)).toBeLessThan(out!.indexOf(END_OF_TURN_DIRECTIVE));
+    });
+
+    it('does NOT inject briefContext on one-shot surface', () => {
+      const out = assembleSystemPrompt(BASE, false, 'one-shot', BRIEF_CTX);
+      expect(out).not.toContain(BRIEF_CTX);
+    });
+
+    it('does NOT inject briefContext on subagent surface', () => {
+      const out = assembleSystemPrompt(BASE, false, 'subagent', BRIEF_CTX);
+      expect(out).not.toContain(BRIEF_CTX);
+    });
+
+    it('orders sections as: base, routing, brief-context, end-of-turn', () => {
+      const out = assembleSystemPrompt(BASE, true, 'repl', BRIEF_CTX);
+      expect(out).toBeDefined();
+      const baseIdx = out!.indexOf(BASE);
+      const routingIdx = out!.indexOf(ROUTING_DIRECTIVE);
+      const briefIdx = out!.indexOf(BRIEF_CTX);
+      const endIdx = out!.indexOf(END_OF_TURN_DIRECTIVE);
+      expect(baseIdx).toBeLessThan(routingIdx);
+      expect(routingIdx).toBeLessThan(briefIdx);
+      expect(briefIdx).toBeLessThan(endIdx);
+    });
+
+    it('skips brief injection when briefContext is undefined (backward compat)', () => {
+      const withBrief = assembleSystemPrompt(BASE, false, 'repl', BRIEF_CTX);
+      const withoutBrief = assembleSystemPrompt(BASE, false, 'repl');
+      expect(withBrief).toContain(BRIEF_CTX);
+      expect(withoutBrief).not.toContain(BRIEF_CTX);
+      // Without brief, the output still contains end-of-turn
+      expect(withoutBrief).toContain(END_OF_TURN_DIRECTIVE);
     });
   });
 
@@ -250,5 +304,90 @@ describe('assembleSystemPrompt', () => {
       expect(verdict?.kind).toBe('interrupted');
       expect(verdict?.whatWasInProgress).toContain('migration');
     });
+  });
+});
+
+describe('pendingBriefContext', () => {
+  let tmpDir: string | null = null;
+
+  afterEach(() => {
+    if (tmpDir !== null) {
+      rmSync(tmpDir, { recursive: true, force: true });
+      tmpDir = null;
+    }
+  });
+
+  it('returns undefined when the briefs directory does not exist', () => {
+    expect(pendingBriefContext('/nonexistent/path/briefs-xyz')).toBeUndefined();
+  });
+
+  it('returns undefined when the briefs directory is empty', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
+    expect(pendingBriefContext(tmpDir)).toBeUndefined();
+  });
+
+  it('returns undefined when only non-.md files are present', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
+    writeFileSync(join(tmpDir, 'not-a-brief.txt'), 'hello');
+    writeFileSync(join(tmpDir, 'README'), 'hello');
+    expect(pendingBriefContext(tmpDir)).toBeUndefined();
+  });
+
+  it('returns undefined when only subdirectories are present', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
+    mkdirSync(join(tmpDir, 'consumed'));
+    mkdirSync(join(tmpDir, 'consumed', 'old-brief.md')); // dir named .md
+    expect(pendingBriefContext(tmpDir)).toBeUndefined();
+  });
+
+  it('returns singular nudge for one brief', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
+    writeFileSync(join(tmpDir, 'my-skill.md'), '# brief');
+    const ctx = pendingBriefContext(tmpDir);
+    expect(ctx).toBeDefined();
+    expect(ctx).toContain('[forge: 1 pending skill brief]');
+    expect(ctx).toContain('1 skill brief');
+    expect(ctx).toContain('my-skill.md');
+    expect(ctx).toContain('/forge');
+  });
+
+  it('returns plural nudge for multiple briefs', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
+    writeFileSync(join(tmpDir, 'alpha.md'), '');
+    writeFileSync(join(tmpDir, 'beta.md'), '');
+    const ctx = pendingBriefContext(tmpDir);
+    expect(ctx).toBeDefined();
+    expect(ctx).toContain('[forge: 2 pending skill briefs]');
+    expect(ctx).toContain('2 skill briefs');
+  });
+
+  it('lists up to 3 brief names in the preview', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
+    for (const name of ['a.md', 'b.md', 'c.md']) {
+      writeFileSync(join(tmpDir, name), '');
+    }
+    const ctx = pendingBriefContext(tmpDir);
+    expect(ctx).toBeDefined();
+    expect(ctx).toContain('a.md, b.md, c.md');
+    expect(ctx).not.toContain('+');
+  });
+
+  it('truncates preview to 3 with "+N more" for larger sets', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
+    for (const name of ['a.md', 'b.md', 'c.md', 'd.md', 'e.md']) {
+      writeFileSync(join(tmpDir, name), '');
+    }
+    const ctx = pendingBriefContext(tmpDir);
+    expect(ctx).toBeDefined();
+    expect(ctx).toContain('[forge: 5 pending skill briefs]');
+    expect(ctx).toContain('+2 more');
+  });
+
+  it('ignores .md files inside subdirectories (consumed/, failed/)', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
+    mkdirSync(join(tmpDir, 'consumed'));
+    writeFileSync(join(tmpDir, 'consumed', 'archived.md'), '');
+    // No top-level .md files → should return undefined
+    expect(pendingBriefContext(tmpDir)).toBeUndefined();
   });
 });

--- a/src/agent/routing-directive.ts
+++ b/src/agent/routing-directive.ts
@@ -21,6 +21,9 @@
  * @module agent/routing-directive
  */
 
+import { existsSync, readdirSync } from 'node:fs';
+import { getBriefsDir } from '../paths.js';
+
 export const ROUTING_DIRECTIVE = `[skill-routing: active]
 
 Route recurring work through registered skills instead of rolling ad-hoc solutions:
@@ -139,14 +142,59 @@ const SURFACES_WITH_END_OF_TURN: ReadonlySet<PromptSurface> = new Set([
   'telegram',
 ]);
 
+/**
+ * Returns a nudge string when there are pending skill briefs awaiting `/forge`,
+ * or `undefined` when the briefs directory is absent or empty.
+ *
+ * The TS implementation injects via `assembleSystemPrompt` (system-prompt layer)
+ * rather than a SessionStart hook because AFK's `dispatchSessionStart` is
+ * trace-only — `injectContext` from SessionStart hooks is never forwarded to
+ * the model.
+ *
+ * @param briefsDir - Override the briefs directory (defaults to
+ *   `getBriefsDir()`). Exists primarily for testing so callers can point at a
+ *   temp dir without touching the real `~/.afk/agent-framework/briefs/`.
+ */
+export function pendingBriefContext(briefsDir?: string): string | undefined {
+  const dir = briefsDir ?? getBriefsDir();
+  let briefs: string[];
+  try {
+    if (!existsSync(dir)) return undefined;
+    briefs = readdirSync(dir, { withFileTypes: true })
+      .filter((e) => e.isFile() && e.name.endsWith('.md'))
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    return undefined;
+  }
+  if (briefs.length === 0) return undefined;
+
+  const count = briefs.length;
+  const noun = count === 1 ? 'brief' : 'briefs';
+  let preview = briefs.slice(0, 3).join(', ');
+  if (count > 3) preview += `, +${count - 3} more`;
+
+  return (
+    `[forge: ${count} pending skill ${noun}]\n\n` +
+    `${count} skill ${noun} from \`/forge-friction\` awaiting generation in ` +
+    `\`${dir}/\`: ${preview}\n\n` +
+    `Run \`/forge\` to process (it will pick up the pending briefs ` +
+    `automatically). Ignore if the user is mid-task on something else.`
+  );
+}
+
 export function assembleSystemPrompt(
   base: string | undefined,
   autoRouting: boolean,
   surface: PromptSurface = 'one-shot',
+  briefContext?: string,
 ): string | undefined {
   if (!base) return base;
   const parts: string[] = [base];
   if (autoRouting) parts.push(ROUTING_DIRECTIVE);
-  if (SURFACES_WITH_END_OF_TURN.has(surface)) parts.push(END_OF_TURN_DIRECTIVE);
+  if (SURFACES_WITH_END_OF_TURN.has(surface)) {
+    if (briefContext !== undefined) parts.push(briefContext);
+    parts.push(END_OF_TURN_DIRECTIVE);
+  }
   return parts.join('\n\n');
 }

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -15,7 +15,7 @@ import {
   getMaxOutputTokens, getDefaultSubagentModel, resolveBaseSystemPrompt,
 } from '../../shared-helpers.js';
 import { loadConfig } from '../../config.js';
-import { assembleSystemPrompt } from '../../../agent/routing-directive.js';
+import { assembleSystemPrompt, pendingBriefContext } from '../../../agent/routing-directive.js';
 import { StatusLine } from '../../status-line.js';
 import { registerAll } from '../../slash/index.js';
 import { setAllowDirDispatcher } from '../../slash/commands/allow-dir.js';
@@ -156,7 +156,7 @@ export async function bootstrapSession(
   const { prompt: basePrompt, source: systemPromptSource } = resolveBaseSystemPrompt();
   const cliConfig = loadConfig();
   const autoRouting = cliConfig.autoRouting?.interactive ?? true;
-  const systemPrompt = assembleSystemPrompt(basePrompt, autoRouting, 'repl');
+  const systemPrompt = assembleSystemPrompt(basePrompt, autoRouting, 'repl', pendingBriefContext());
 
   // Wire Agent tool by creating SubagentExecutor first.
   // The executor needs the session's methods, so we use a deferred parent proxy

--- a/src/cli/commands/interactive/repl-loop-wiring.test.ts
+++ b/src/cli/commands/interactive/repl-loop-wiring.test.ts
@@ -501,8 +501,13 @@ describe('runReplLoop — completionWriter wired to persistent compositor.commit
 describe('runReplLoop — P2 regression: AFK_SUGGEST_ENABLED parsed as boolean', () => {
   async function captureLlmEnabled(value: string | undefined): Promise<boolean> {
     const prev = process.env.AFK_SUGGEST_ENABLED;
+    const prevGhost = process.env.AFK_SUGGEST_GHOST;
     if (value === undefined) delete process.env.AFK_SUGGEST_ENABLED;
     else process.env.AFK_SUGGEST_ENABLED = value;
+    // This test isolates the Tier-2 LLM gate. The ghost-text master toggle must
+    // stay enabled, regardless of the caller's shell environment, so the
+    // compositor wires the suggest block whose llmEnabled() closure we inspect.
+    delete process.env.AFK_SUGGEST_GHOST;
     try {
       const ctx = makeMinimalCtx(new BackgroundAgentRegistry({}));
       const turnState: TurnState = {
@@ -522,6 +527,8 @@ describe('runReplLoop — P2 regression: AFK_SUGGEST_ENABLED parsed as boolean',
     } finally {
       if (prev === undefined) delete process.env.AFK_SUGGEST_ENABLED;
       else process.env.AFK_SUGGEST_ENABLED = prev;
+      if (prevGhost === undefined) delete process.env.AFK_SUGGEST_GHOST;
+      else process.env.AFK_SUGGEST_GHOST = prevGhost;
     }
   }
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -42,7 +42,7 @@ import { providerForModel, AnthropicDirectProvider } from './agent/providers/ind
 import { detectAuthMode } from './agent/providers/anthropic-direct/auth.js';
 import { loadConfig, loadCredential } from './cli/config.js';
 import { getEnvConfigPath } from './paths.js';
-import { assembleSystemPrompt } from './agent/routing-directive.js';
+import { assembleSystemPrompt, pendingBriefContext } from './agent/routing-directive.js';
 import { resolveModelId } from './agent/session/model-resolution.js';
 import { getDefaultSubagentModel, getMaxOutputTokens, getApiKeyForModel, loadSystemPrompt, composeSystemPrompt } from './cli/shared-helpers.js';
 import type { AgentConfig, AgentModelInput } from './agent/types.js';
@@ -330,7 +330,7 @@ async function main() {
         const rawPromptInner = layeredBasePrompt;
         const telegramAutoRoutingInner = config.autoRouting?.telegram ?? false;
         const systemPromptInner = typeof rawPromptInner === 'string'
-          ? assembleSystemPrompt(rawPromptInner, telegramAutoRoutingInner, 'telegram')
+          ? assembleSystemPrompt(rawPromptInner, telegramAutoRoutingInner, 'telegram', pendingBriefContext())
           : rawPromptInner;
 
         // permissionMode is intentionally omitted here: AgentSession defaults
@@ -363,7 +363,7 @@ async function main() {
       const rawPrompt = layeredBasePrompt;
       const telegramAutoRouting = config.autoRouting?.telegram ?? false;
       const systemPrompt = typeof rawPrompt === 'string'
-        ? assembleSystemPrompt(rawPrompt, telegramAutoRouting, 'telegram')
+        ? assembleSystemPrompt(rawPrompt, telegramAutoRouting, 'telegram', pendingBriefContext())
         : rawPrompt;
       // Codex branch: same cwd resolution as the Anthropic branch above.
       const codexSessionCwd = sessionConfig.cwd ?? telegramCwd;


### PR DESCRIPTION
## Source

Moat-scrubbed port of private PR griffinwork40/afk-workshop#789: https://github.com/griffinwork40/afk-workshop/pull/789

This is not a 1:1 copy; private-only wording was scrubbed before porting.

## Ported

- `src/agent/routing-directive.ts`
  - Adds `pendingBriefContext(briefsDir?)` to scan the AFK briefs directory for top-level `.md` files and produce a `/forge` nudge.
  - Extends `assembleSystemPrompt` with optional `briefContext`, injected only for interactive surfaces before the end-of-turn directive.
- `src/cli/commands/interactive/bootstrap.ts`
  - Passes `pendingBriefContext()` into REPL system-prompt assembly.
- `src/telegram.ts`
  - Passes `pendingBriefContext()` into both Telegram session construction paths.
- `src/agent/routing-directive.test.ts`
  - Adds coverage for brief-context injection and pending-brief filesystem cases.
- `src/cli/commands/interactive/repl-loop-wiring.test.ts`
  - Forward-fixes an environment-sensitive public test by isolating `AFK_SUGGEST_GHOST` while checking the `AFK_SUGGEST_ENABLED` LLM gate.

## Dropped / scrubbed

- Scrubbed one private plugin reference from `src/agent/routing-directive.ts` JSDoc:
  - Dropped: `awa-private`
  - Replacement: generic TS implementation wording.

No files or hunks were dropped as moat-only.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm fix:pins`
- `pnpm fix:pins:check`
- `pnpm lint`
- `env -u AFK_INTERNAL pnpm test`
- `pnpm build`
- `pnpm build:dist`
- Deterministic moat guard: `✅ MOAT GUARD CLEAN`
- Adversarial audit: clean; no hard-denylist or structural moat leaks found in tree or `dist/`.

## Merge note

Do not merge automatically; leave for human review.
