### PR TITLE
docs(website): use main-site favicon and link out to landing page + GitHub

### DIFF
--- a/website/app/(docs)/docs-theme.css
+++ b/website/app/(docs)/docs-theme.css
@@ -176,3 +176,17 @@
 #nd-docs-layout figure.shiki .line {
   line-height: 1.5;
 }
+
+/* --- Brand mark glow: match agentafk.com's navbar glyph --------------------
+   The nav "Handoff Arc" glyph (inline SVG in the DocsLayout title) carries a
+   soft orange glow at rest and a stronger glow on hover — the same treatment
+   as the main site's .Navbar_brandMark. The hover rule targets the glyph as a
+   direct child of Fumadocs' title link. */
+.afk-brand-mark {
+  filter: drop-shadow(0 0 12px rgba(249, 133, 75, 0.14));
+  transition: filter 0.2s ease, transform 0.2s ease;
+}
+a:hover > .afk-brand-mark {
+  filter: drop-shadow(0 0 16px rgba(249, 115, 22, 0.32))
+          drop-shadow(0 0 8px rgba(249, 115, 22, 0.22));
+}

--- a/website/app/(docs)/docs-theme.css
+++ b/website/app/(docs)/docs-theme.css
@@ -190,3 +190,22 @@ a:hover > .afk-brand-mark {
   filter: drop-shadow(0 0 16px rgba(249, 115, 22, 0.32))
           drop-shadow(0 0 8px rgba(249, 115, 22, 0.22));
 }
+
+/* Wordmark colours. Dark (the default, and agentafk.com's only mode) matches
+   the main site exactly: "agent" in light grey (500), "afk" in white (700).
+   The docs also expose an optional light theme — remap there so the wordmark
+   stays legible (white-on-light would vanish) while keeping "afk" emphasised. */
+.afk-wordmark-agent {
+  font-weight: 500;
+  color: #e9e9f0;
+}
+.afk-wordmark-afk {
+  font-weight: 700;
+  color: #ffffff;
+}
+:root:not(.dark) .afk-wordmark-agent {
+  color: var(--color-fd-muted-foreground);
+}
+:root:not(.dark) .afk-wordmark-afk {
+  color: var(--color-fd-foreground);
+}

--- a/website/app/(docs)/layout.tsx
+++ b/website/app/(docs)/layout.tsx
@@ -72,8 +72,8 @@ export default function Layout({ children }: { children: ReactNode }) {
                   alignItems: 'baseline',
                 }}
               >
-                <span style={{ fontWeight: 500, color: '#e9e9f0' }}>agent</span>
-                <span style={{ fontWeight: 700, color: '#ffffff' }}>afk</span>
+                <span className="afk-wordmark-agent">agent</span>
+                <span className="afk-wordmark-afk">afk</span>
               </span>
             </>
           ),

--- a/website/app/(docs)/layout.tsx
+++ b/website/app/(docs)/layout.tsx
@@ -20,48 +20,24 @@ export default function Layout({ children }: { children: ReactNode }) {
           title: (
             // Brand lockup mirrors agentafk.com's navbar: the "Handoff Arc"
             // glyph + the sans wordmark "agent" (light grey, 500) / "afk"
-            // (white, 700). The glyph and wordmark are direct children of
-            // Fumadocs' title link so the hover-glow rule in docs-theme.css
-            // (a:hover > .afk-brand-mark) can target the glyph.
+            // (white, 700). The glyph is a standalone SVG file referenced via
+            // <img> (not inlined): Fumadocs renders the title in several nav
+            // slots, and an inline SVG would duplicate its gradient ids across
+            // those copies — the browser then resolves url(#arc)/url(#ping) to
+            // the first (hidden) copy and the arc/ping fills drop out. A file
+            // scopes the gradient ids to its own document, so every copy paints.
+            // The <img> and wordmark are direct children of Fumadocs' title
+            // link so docs-theme.css's `a:hover > .afk-brand-mark` glow applies.
             <>
-              <svg
+              {/* eslint-disable-next-line @next/next/no-img-element -- static 32px brand glyph; next/image adds no value */}
+              <img
                 className="afk-brand-mark"
-                viewBox="0 0 64 64"
+                src="/brand-mark.svg"
+                alt=""
+                aria-hidden="true"
                 width={32}
                 height={32}
-                role="img"
-                aria-label="Agent AFK"
-              >
-                <defs>
-                  <linearGradient
-                    id="afk-nav-arc"
-                    x1="14"
-                    y1="48"
-                    x2="50"
-                    y2="48"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop offset="0%" stopColor="#8a8aa0" />
-                    <stop offset="50%" stopColor="#74bc90" />
-                    <stop offset="100%" stopColor="#5cb87f" />
-                  </linearGradient>
-                  <radialGradient id="afk-nav-ping" cx="50%" cy="50%" r="50%">
-                    <stop offset="0%" stopColor="#ffc2a1" />
-                    <stop offset="55%" stopColor="#f97316" />
-                    <stop offset="100%" stopColor="#d65a0e" />
-                  </radialGradient>
-                </defs>
-                <path
-                  d="M 14 48 A 24 24 0 1 1 50 48"
-                  fill="none"
-                  stroke="url(#afk-nav-arc)"
-                  strokeWidth="7"
-                  strokeLinecap="round"
-                />
-                <circle cx="14" cy="48" r="4.5" fill="#8a8aa0" />
-                <circle cx="50" cy="48" r="4.5" fill="#5cb87f" />
-                <circle cx="32" cy="56" r="5" fill="url(#afk-nav-ping)" />
-              </svg>
+              />
               <span
                 style={{
                   fontFamily:

--- a/website/app/(docs)/layout.tsx
+++ b/website/app/(docs)/layout.tsx
@@ -23,8 +23,21 @@ export default function Layout({ children }: { children: ReactNode }) {
               <span style={{ color: 'var(--color-accent, #f9854b)' }}>afk</span>
             </span>
           ),
-          url: '/',
+          // Brand wordmark links out to the landing page (agentafk.com), not
+          // the docs home — clicking the logo returns to the main site.
+          url: 'https://agentafk.com',
         }}
+        // Nav links: the landing page (agentafk.com) and the GitHub repo.
+        // These docs are served at the docs.agentafk.com subdomain, so link
+        // back out to the main site; githubUrl renders Fumadocs' built-in
+        // GitHub icon button (no extra icon import needed).
+        links={[
+          {
+            text: 'agentafk.com',
+            url: 'https://agentafk.com',
+          },
+        ]}
+        githubUrl="https://github.com/griffinwork40/agent-afk"
         sidebar={{
           defaultOpenLevel: 1,
         }}

--- a/website/app/(docs)/layout.tsx
+++ b/website/app/(docs)/layout.tsx
@@ -18,10 +18,64 @@ export default function Layout({ children }: { children: ReactNode }) {
         tree={source.getPageTree()}
         nav={{
           title: (
-            <span style={{ fontFamily: 'var(--font-jbm, monospace)', fontWeight: 600 }}>
-              <span style={{ color: 'var(--color-text, #e9e9f0)' }}>agent</span>
-              <span style={{ color: 'var(--color-accent, #f9854b)' }}>afk</span>
-            </span>
+            // Brand lockup mirrors agentafk.com's navbar: the "Handoff Arc"
+            // glyph + the sans wordmark "agent" (light grey, 500) / "afk"
+            // (white, 700). The glyph and wordmark are direct children of
+            // Fumadocs' title link so the hover-glow rule in docs-theme.css
+            // (a:hover > .afk-brand-mark) can target the glyph.
+            <>
+              <svg
+                className="afk-brand-mark"
+                viewBox="0 0 64 64"
+                width={32}
+                height={32}
+                role="img"
+                aria-label="Agent AFK"
+              >
+                <defs>
+                  <linearGradient
+                    id="afk-nav-arc"
+                    x1="14"
+                    y1="48"
+                    x2="50"
+                    y2="48"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop offset="0%" stopColor="#8a8aa0" />
+                    <stop offset="50%" stopColor="#74bc90" />
+                    <stop offset="100%" stopColor="#5cb87f" />
+                  </linearGradient>
+                  <radialGradient id="afk-nav-ping" cx="50%" cy="50%" r="50%">
+                    <stop offset="0%" stopColor="#ffc2a1" />
+                    <stop offset="55%" stopColor="#f97316" />
+                    <stop offset="100%" stopColor="#d65a0e" />
+                  </radialGradient>
+                </defs>
+                <path
+                  d="M 14 48 A 24 24 0 1 1 50 48"
+                  fill="none"
+                  stroke="url(#afk-nav-arc)"
+                  strokeWidth="7"
+                  strokeLinecap="round"
+                />
+                <circle cx="14" cy="48" r="4.5" fill="#8a8aa0" />
+                <circle cx="50" cy="48" r="4.5" fill="#5cb87f" />
+                <circle cx="32" cy="56" r="5" fill="url(#afk-nav-ping)" />
+              </svg>
+              <span
+                style={{
+                  fontFamily:
+                    '-apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif',
+                  fontSize: '19px',
+                  letterSpacing: '-0.01em',
+                  display: 'inline-flex',
+                  alignItems: 'baseline',
+                }}
+              >
+                <span style={{ fontWeight: 500, color: '#e9e9f0' }}>agent</span>
+                <span style={{ fontWeight: 700, color: '#ffffff' }}>afk</span>
+              </span>
+            </>
           ),
           // Brand wordmark links out to the landing page (agentafk.com), not
           // the docs home — clicking the logo returns to the main site.

--- a/website/app/layout.tsx
+++ b/website/app/layout.tsx
@@ -19,6 +19,13 @@ const jetbrainsMono = localFont({
 export const metadata: Metadata = {
   title: 'Agent AFK Docs',
   description: 'Documentation for Agent AFK',
+  // Favicon: the same "Handoff Arc" mark used on the main site (agentafk.com).
+  // SVG primary icon (served from public/favicon.svg) plus the Safari
+  // pinned-tab mask-icon reusing the same SVG in the brand orange.
+  icons: {
+    icon: [{ url: '/favicon.svg', type: 'image/svg+xml' }],
+    other: [{ rel: 'mask-icon', url: '/favicon.svg', color: '#f97316' }],
+  },
 };
 
 export default function RootLayout({

--- a/website/public/brand-mark.svg
+++ b/website/public/brand-mark.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Agent AFK — navbar brand glyph ("Handoff Arc"), transparent variant.
+  Matches the inline mark in agentafk.com's navbar: gradient arc, two
+  endpoint nodes, and the orange "ping" in the gap. Served as a standalone
+  file (referenced via <img>) so its gradient ids stay scoped to this
+  document — the docs nav renders the title in several places, and inlining
+  the SVG would collide duplicate gradient ids and drop the arc/ping fills.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Agent AFK">
+  <defs>
+    <linearGradient id="arc" x1="14" y1="48" x2="50" y2="48" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#8a8aa0"/>
+      <stop offset="50%" stop-color="#74bc90"/>
+      <stop offset="100%" stop-color="#5cb87f"/>
+    </linearGradient>
+    <radialGradient id="ping" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ffc2a1"/>
+      <stop offset="55%" stop-color="#f97316"/>
+      <stop offset="100%" stop-color="#d65a0e"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Arc: endpoints (14,48) -> (50,48), r=24, large-arc, clockwise (90° gap at bottom) -->
+  <path d="M 14 48 A 24 24 0 1 1 50 48"
+        fill="none"
+        stroke="url(#arc)"
+        stroke-width="7"
+        stroke-linecap="round"/>
+
+  <!-- Endpoint nodes -->
+  <circle cx="14" cy="48" r="4.5" fill="#8a8aa0"/>
+  <circle cx="50" cy="48" r="4.5" fill="#5cb87f"/>
+
+  <!-- Ping in the gap, on the imagined completed circle -->
+  <circle cx="32" cy="56" r="5" fill="url(#ping)"/>
+</svg>

--- a/website/public/favicon.svg
+++ b/website/public/favicon.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Agent AFK — favicon variant (Handoff Arc)
+
+  Differences from mark.svg:
+    - Dark rounded tile background so the mark sits well on light browser
+      chrome too (Safari tabs, light-mode taskbars).
+    - Endpoint nodes dropped — at 16px they'd merge into the arc's rounded
+      caps and just look like blobs. The arc + ping carry the identity alone.
+    - Specular highlight dropped from the ping for the same reason.
+    - Arc stroke thickened proportionally so it survives sub-pixel rendering.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Agent AFK">
+  <defs>
+    <linearGradient id="g" x1="14" y1="48" x2="50" y2="48" gradientUnits="userSpaceOnUse">
+      <stop offset="0%"   stop-color="#8a8aa0"/>
+      <stop offset="50%"  stop-color="#74bc90"/>
+      <stop offset="100%" stop-color="#5cb87f"/>
+    </linearGradient>
+    <radialGradient id="ping" cx="50%" cy="50%" r="50%">
+      <stop offset="0%"   stop-color="#ffc2a1"/>
+      <stop offset="55%"  stop-color="#f97316"/>
+      <stop offset="100%" stop-color="#d65a0e"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Dark rounded tile, so the mark reads on any background -->
+  <rect width="64" height="64" rx="14" ry="14" fill="#07070b"/>
+
+  <!-- Arc: same geometry as mark.svg, scaled to 64-viewBox.
+       Endpoints (14,48) → (50,48), r=24, large-arc, clockwise → 90° gap at bottom. -->
+  <path d="M 14 48 A 24 24 0 1 1 50 48"
+        fill="none"
+        stroke="url(#g)"
+        stroke-width="7"
+        stroke-linecap="round"/>
+
+  <!-- Ping in the gap, on the imagined completed circle (y = 48 + sqrt(24² - 18²) ≈ 63.8) -->
+  <circle cx="32" cy="56" r="5" fill="url(#ping)"/>
+</svg>


### PR DESCRIPTION
## Summary

Aligns the docs site (`website/`, served at docs.agentafk.com) with the main site's branding and adds outbound links.

- **Favicon** — the docs site had **no** favicon configured. Adds the same "Handoff Arc" `favicon.svg` used on agentafk.com and wires it as the SVG icon + Safari pinned-tab `mask-icon` (brand orange `#f97316`) in the docs root metadata.
- **Nav links** — adds an `agentafk.com` link and the GitHub repository link (via Fumadocs `githubUrl`) to the docs header.
- **Header logo** — points the top-left `agentafk` wordmark at the landing page (`https://agentafk.com`) instead of the docs home.

## How was this tested?

`website/` is a standalone Next.js (Fumadocs) sub-project with its own toolchain — it is **not** covered by the root `pnpm lint` / `pnpm test`. Verified with the website's own gates:

- `npm run typecheck` (`tsc --noEmit`) → **pass**
- `npm run build` (`next build`) → **pass**, all 28 pages prerendered
- Inspected the generated `<head>`: emits `<link rel="icon" href="/favicon.svg" type="image/svg+xml">` and `<link rel="mask-icon" href="/favicon.svg" color="#f97316">`; the header wordmark renders as `<a href="https://agentafk.com" …>`.

## Checklist

- [ ] `pnpm lint` passes — *N/A: change is confined to `website/` (separate sub-project with its own tsconfig); root lint does not cover it. Ran the website's `npm run typecheck` instead → pass.*
- [ ] `pnpm test` passes — *N/A: no code covered by the root vitest suite changed. Verified via the website's `npm run build` → pass.*
- [x] Commits are signed off (`git commit -s`) per the DCO
- [x] No secrets, tokens, or private paths in the diff
