### PR TITLE
feat(docs): add a reusable visual signature to the docs site

### DIFF
--- a/website/app/(docs)/[[...slug]]/page.tsx
+++ b/website/app/(docs)/[[...slug]]/page.tsx
@@ -4,6 +4,7 @@ import { DocsPage, DocsBody, DocsDescription, DocsTitle } from 'fumadocs-ui/page
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import { Card, Cards } from 'fumadocs-ui/components/card';
 import { source } from '@/lib/source';
+import { Signature } from '@/components/signature';
 
 interface Props {
   params: Promise<{ slug?: string[] }>;
@@ -22,7 +23,7 @@ export default async function Page({ params }: Props) {
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>
-        <MDX components={{ ...defaultMdxComponents, Card, Cards }} />
+        <MDX components={{ ...defaultMdxComponents, Card, Cards, Signature }} />
       </DocsBody>
     </DocsPage>
   );

--- a/website/app/(docs)/docs-theme.css
+++ b/website/app/(docs)/docs-theme.css
@@ -78,11 +78,36 @@
   --color-fd-accent-foreground:  #c0501a;   /* darker orange for text on light bg */
 }
 
-/* --- Sidebar / docs background ------------------------------------------ */
-/* fumadocs-ui uses --color-fd-background for the page and sidebar.
-   Ensure the sidebar rail matches the deep dark bg. */
+/* --- Sidebar / docs background + the signature field -------------------- */
+/* fumadocs-ui uses --color-fd-background for the page and sidebar. We keep
+   that solid base colour and paint the signature field ON it as background
+   layers (no extra DOM, no z-index gymnastics): content surfaces — cards,
+   code blocks — carry their own opaque bg and sit cleanly above the field.
+
+   deep-field  : a cool depth pocket biased to the lower-left (descent) that
+                 resolves into a faint warm node upper-right (rise). This is
+                 the quiet cold→warm migration that governs EVERY page.
+   signal-field: three faint concentric rings around that warm node — a small
+                 signal implying a far larger submerged structure.
+
+   background-attachment:fixed turns the field into a stable ground the content
+   scrolls over (cartographic, not a hero gradient). Switched to scroll on
+   touch/coarse pointers below, where fixed attachment is janky. */
 #nd-docs-layout {
   background-color: var(--color-fd-background);
+  background-image:
+    /* signal-field — concentric rings around the upper-right node */
+    radial-gradient(circle at var(--sig-origin-x) var(--sig-origin-y),
+      transparent 178px, rgb(var(--sig-ring) / calc(var(--sig-ring-a) * 0.55)) 179px 180px, transparent 181px),
+    radial-gradient(circle at var(--sig-origin-x) var(--sig-origin-y),
+      transparent 116px, rgb(var(--sig-ring) / calc(var(--sig-ring-a) * 0.8)) 117px 118px, transparent 119px),
+    radial-gradient(circle at var(--sig-origin-x) var(--sig-origin-y),
+      transparent 64px, rgb(var(--sig-ring) / var(--sig-ring-a)) 65px 66px, transparent 67px),
+    /* deep-field — warm rise (upper-right) over cool depth (lower-left) */
+    radial-gradient(120% 80% at 92% -8%, rgb(var(--sig-warm) / var(--sig-warm-a)), transparent 60%),
+    radial-gradient(125% 120% at 4% 108%, rgb(var(--sig-depth) / var(--sig-depth-a)), transparent 62%);
+  background-attachment: fixed;
+  background-repeat: no-repeat;
 }
 
 /* --- Typography: inherit the site's mono font for code blocks ----------- */
@@ -208,4 +233,249 @@ a:hover > .afk-brand-mark {
 }
 :root:not(.dark) .afk-wordmark-afk {
   color: var(--color-fd-foreground);
+}
+
+/* ==========================================================================
+   SIGNATURE SYSTEM — earned-path, scope-rule, elevated-field
+   "signal → depth → compression → rise → embodiment."
+   All rules scoped to #nd-docs-layout so the system governs the docs chrome
+   and nothing leaks elsewhere. See globals.css for the --sig-* tokens.
+   ========================================================================== */
+
+/* --- earned-path: the hero Signature band ------------------------------- */
+/* The clearest single statement of the law. A slim, full-width band that sits
+   between the page lede and its content — the route opening into the page. */
+#nd-docs-layout .afk-signature {
+  margin: 0.25rem 0 2rem;
+  width: 100%;
+}
+#nd-docs-layout .afk-sig {
+  display: block;
+  width: 100%;
+  height: auto;
+  /* The band reads as a thin horizon, not a hero billboard. */
+  max-height: 132px;
+  overflow: visible;
+}
+/* The band paints at ~0.5x its viewBox, which would shrink 1px hairlines into
+   sub-pixel invisibility. Pin every stroke to device pixels so the measure,
+   traces and rings stay crisp at any width (and on mobile). */
+.afk-sig line,
+.afk-sig path,
+.afk-sig circle { vector-effect: non-scaling-stroke; }
+
+/* Field strokes — every colour traces back to a --sig-* token. The traces and
+   rings read at rest (not just under motion) so "repeated passes compressed
+   into one route" never collapses into a lone swoosh. */
+.afk-sig__trace path {
+  fill: none;
+  stroke: rgb(var(--sig-route-cold) / 0.4);
+  stroke-width: 1.1;
+}
+.afk-sig__route {
+  stroke-width: 2.25;
+  stroke-linecap: round;
+  opacity: 0.92;
+}
+.afk-sig__ring {
+  fill: none;
+  stroke: rgb(var(--sig-ring) / 0.62);
+  stroke-width: 1.1;
+}
+.afk-sig__signal .afk-sig__ring:nth-of-type(2) { stroke: rgb(var(--sig-ring) / 0.44); }
+.afk-sig__signal .afk-sig__ring:nth-of-type(3) { stroke: rgb(var(--sig-ring) / 0.28); }
+.afk-sig__ripple {
+  fill: none;
+  stroke: rgb(var(--sig-ring) / 0.45);
+  stroke-width: 1.1;
+  opacity: 0;            /* invisible at rest; only motion brings it to life */
+}
+.afk-sig__node--signal { fill: rgb(var(--sig-route-cold) / 0.9); }
+.afk-sig__node--warm   { fill: rgb(var(--sig-route-warm)); }
+.afk-sig__measure line { stroke: rgb(var(--sig-measure) / var(--sig-measure-a)); stroke-width: 1; }
+.afk-sig__threshold    { stroke: rgb(var(--sig-measure) / calc(var(--sig-measure-a) + 0.2)) !important; stroke-width: 1.4 !important; }
+.afk-sig__axis         { stroke: rgb(var(--sig-measure) / calc(var(--sig-measure-a) * 0.4)) !important; }
+.afk-sig__crosshair    { stroke: rgb(var(--sig-route-warm) / 0.6); stroke-width: 1; }
+
+/* --- earned-path: route dividers (hr) ----------------------------------- */
+/* A horizontal rule is reframed as a compressed band: a route that migrates
+   cold → green → warm left-to-right (rise), with one measure tick near the
+   resolved end. Replaces fumadocs' flat 1px border. */
+#nd-docs-layout .prose hr {
+  position: relative;
+  border: 0;
+  height: 1px;
+  margin: 2.75rem 0;
+  background-image: linear-gradient(
+    to right,
+    transparent 0%,
+    rgb(var(--sig-route-cold) / 0.45) 14%,
+    rgb(var(--sig-route-mid) / 0.5) 52%,
+    rgb(var(--sig-route-warm) / 0.55) 82%,
+    transparent 100%
+  );
+}
+#nd-docs-layout .prose hr::after {
+  /* measure tick — a threshold marker at the warm/resolve point */
+  content: "";
+  position: absolute;
+  top: -3px;
+  left: 82%;
+  width: 1px;
+  height: 7px;
+  background: rgb(var(--sig-route-warm) / 0.7);
+}
+
+/* --- scope-rule: cards as excavated artifacts --------------------------- */
+/* A feature card is reframed as an instrument pulled from the field: a
+   measured scope-rule down its leading edge, a faint excavated recess, and a
+   small coordinate tick in the corner. Discovery resolves (warms) on hover.
+
+   Invariant: scope to :not(.peer). Fumadocs reuses data-card on every heading
+   permalink anchor (<a data-card class="peer" href="#…">); .peer is unique to
+   those, so excluding it keeps the treatment on real feature cards only. */
+#nd-docs-layout [data-card]:not(.peer) {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  transition: transform var(--t-base, 180ms) var(--ease, ease),
+    border-color var(--t-base, 180ms) var(--ease, ease),
+    box-shadow var(--t-base, 180ms) var(--ease, ease);
+}
+/* scope-rule — the measured leading edge (the route passing through). */
+#nd-docs-layout [data-card]:not(.peer)::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 14%;
+  bottom: 14%;
+  width: 2px;
+  border-radius: 2px;
+  background: linear-gradient(
+    to bottom,
+    rgb(var(--sig-route-cold) / 0.5),
+    rgb(var(--sig-route-mid) / 0.55)
+  );
+  transition: background var(--t-base, 180ms) var(--ease, ease),
+    top var(--t-base, 180ms) var(--ease, ease),
+    bottom var(--t-base, 180ms) var(--ease, ease);
+}
+/* excavated recess + corner coordinate tick — a faint cool depth wash from the
+   leading edge, and a 7px right-angle tick top-right (cartographic cue). */
+#nd-docs-layout [data-card]:not(.peer)::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background:
+    linear-gradient(135deg, rgb(var(--sig-depth) / 0.1), transparent 38%),
+    linear-gradient(to right, rgb(var(--sig-measure) / 0.5) 7px, transparent 7px) top right / 7px 1px no-repeat,
+    linear-gradient(to bottom, rgb(var(--sig-measure) / 0.5) 7px, transparent 7px) top right / 1px 7px no-repeat;
+}
+#nd-docs-layout [data-card]:not(.peer):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 28px -16px rgb(var(--sig-depth) / 0.55);
+}
+#nd-docs-layout [data-card]:not(.peer):hover::before {
+  top: 8%;
+  bottom: 8%;
+  background: linear-gradient(
+    to bottom,
+    rgb(var(--sig-route-mid) / 0.6),
+    rgb(var(--sig-route-warm) / 0.7)
+  );
+}
+
+/* --- elevated-field: the embodied CTA ----------------------------------- */
+/* The primary action sits in the warmest, most-arrived zone: warm border, a
+   soft warm lift, a faint warm wash, and a leading edge that fully resolves to
+   the signal colour. This is where the page rises into use. Applied via
+   <Card className="elevated-field" …>. */
+#nd-docs-layout [data-card].elevated-field {
+  border-color: rgb(var(--sig-route-warm) / 0.45);
+  background:
+    radial-gradient(120% 140% at 100% 0%, rgb(var(--sig-route-warm) / 0.1), transparent 55%),
+    var(--color-fd-card);
+  box-shadow: 0 0 0 1px rgb(var(--sig-route-warm) / 0.12),
+    0 14px 40px -22px rgb(var(--sig-route-warm) / 0.5);
+}
+#nd-docs-layout [data-card].elevated-field::before {
+  top: 10%;
+  bottom: 10%;
+  width: 2.5px;
+  background: linear-gradient(
+    to bottom,
+    rgb(var(--sig-route-mid) / 0.6),
+    rgb(var(--sig-route-warm) / 0.95)
+  );
+}
+#nd-docs-layout [data-card].elevated-field:hover {
+  border-color: rgb(var(--sig-route-warm) / 0.65);
+  transform: translateY(-2px);
+  box-shadow: 0 0 0 1px rgb(var(--sig-route-warm) / 0.22),
+    0 18px 46px -20px rgb(var(--sig-route-warm) / 0.6);
+}
+
+/* --- motion: slow, earned, optional ------------------------------------- *
+   Default (no preference): the route draws in once, the signal ripples
+   expand slowly, the warm node breathes faintly. Everything also reads fully
+   formed without motion — reduced-motion users lose nothing structural. */
+@media (prefers-reduced-motion: no-preference) {
+  .afk-sig__route {
+    stroke-dasharray: 1600;
+    stroke-dashoffset: 1600;
+    animation: afk-sig-draw 1.8s var(--ease, ease) 0.15s forwards;
+  }
+  .afk-sig__ripple {
+    transform-box: fill-box;
+    transform-origin: center;
+    animation: afk-sig-ripple 6.5s ease-out infinite;
+  }
+  .afk-sig__ripple--2 { animation-delay: 3.25s; }
+  .afk-sig__node--warm {
+    transform-box: fill-box;
+    transform-origin: center;
+    animation: afk-sig-breathe 4.5s ease-in-out 1.9s infinite;
+  }
+  .afk-sig__glow {
+    transform-box: fill-box;
+    transform-origin: center;
+    animation: afk-sig-breathe 4.5s ease-in-out 1.9s infinite;
+  }
+}
+@keyframes afk-sig-draw {
+  to { stroke-dashoffset: 0; }
+}
+@keyframes afk-sig-ripple {
+  0%   { transform: scale(0.7); opacity: 0; }
+  18%  { opacity: 0.5; }
+  100% { transform: scale(3.4); opacity: 0; }
+}
+@keyframes afk-sig-breathe {
+  0%, 100% { transform: scale(1);    opacity: 1; }
+  50%      { transform: scale(1.14); opacity: 0.86; }
+}
+
+/* --- mobile: recompose, don't collapse ---------------------------------- */
+/* fixed background attachment is janky on touch — pin it to scroll and ease
+   the field's energy so it never competes with cramped mobile copy. */
+@media (hover: none), (pointer: coarse) {
+  #nd-docs-layout { background-attachment: scroll; }
+}
+@media (max-width: 640px) {
+  #nd-docs-layout {
+    /* drop the outermost signal ring and soften depth on small screens */
+    --sig-ring-a: 0.04;
+    --sig-depth-a: 0.1;
+  }
+  #nd-docs-layout .afk-signature { margin-bottom: 1.5rem; }
+  #nd-docs-layout .afk-sig { max-height: 96px; }
+  /* the band recomposes to its essential gesture: hide the finer measure
+     ticks and the long axis; keep the route, the signal, and the resolve. */
+  .afk-sig__measure line:not(:first-child),
+  .afk-sig__axis,
+  .afk-sig__crosshair { display: none; }
+  /* thinner scope-rule so it reads as accent, not bar, in narrow cards */
+  #nd-docs-layout [data-card]:not(.peer)::before { width: 1.5px; }
 }

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -62,6 +62,62 @@ html:not(.dark) {
   /* accent and glow stay orange — same brand in both themes */
 }
 
+/* --- Signature system tokens --------------------------------------------- *
+   "signal → depth → compression → rise → embodiment."
+
+   A reusable visual law layered onto the existing brand (it does NOT recolor
+   it): the orange "ping" of the Handoff Arc is the *signal*; the grey→green
+   arc is the *earned route*. These tokens extend that logic into a field +
+   route + measure system shared by every page.
+
+   Colours are stored as bare "R, G, B" triplets so each can be composed with
+   an arbitrary alpha via rgb(var(--sig-x) / <a>). Alphas/origins are separate
+   knobs so the field can be retuned per theme without touching the gradients.
+
+   Stage → token:
+     signal      --sig-signal / --sig-ring   (the small visible mark, ripples)
+     depth       --sig-depth                  (cool submerged structure, lower-left)
+     route       --sig-route-cold/mid/warm    (cold start → green route → warm use)
+     measure     --sig-measure                (the one ruthless structural line)
+     embodiment  --sig-warm                   (warm resolve, upper-right / CTA)            */
+:root {
+  /* Route gradient — mirrors the Handoff Arc: grey start → green route → warm.
+     NB: triplets are SPACE-separated so rgb(var(--x) / <a>) is valid modern
+     syntax. (Comma triplets + slash alpha is invalid and silently dropped.) */
+  --sig-route-cold: 138 138 160;   /* #8a8aa0  cold depth / start node      */
+  --sig-route-mid:   92 184 127;   /* #5cb87f  the resolved green route      */
+  --sig-route-warm: 249 115 22;    /* #f97316  warm signal / embodiment      */
+
+  /* Field tints (dark). Cool indigo depth, cool-steel ripples, warm resolve. */
+  --sig-depth:   92 104 168;       /* cool submerged structure (lower-left)  */
+  --sig-ring:   150 168 192;       /* concentric signal ripples              */
+  --sig-warm:   249 115 22;        /* warm rise (upper-right)                */
+  --sig-signal: 249 133 75;        /* the ping — == --color-accent           */
+  --sig-measure: 156 166 192;      /* the crisp measuring rule / ticks       */
+
+  /* Field intensity (dark) — kept low so text contrast is never touched. */
+  --sig-depth-a: 0.13;
+  --sig-ring-a:  0.05;
+  --sig-warm-a:  0.05;
+  --sig-measure-a: 0.55;
+
+  /* Signal origin — the small node the ripples radiate from (upper-right). */
+  --sig-origin-x: 86%;
+  --sig-origin-y: -2%;
+}
+
+/* Field retune for light mode: lower-energy, darker cool tints so faint rings
+   read on a near-white ground and never muddy the prose. Route stays branded. */
+html:not(.dark) {
+  --sig-depth:    96 108 156;
+  --sig-ring:     96 110 150;
+  --sig-measure:  96 108 150;
+  --sig-depth-a:  0.07;
+  --sig-ring-a:   0.06;
+  --sig-warm-a:   0.05;
+  --sig-measure-a: 0.46;
+}
+
 /* --- Minimal base --------------------------------------------------------- */
 *, *::before, *::after { box-sizing: border-box; }
 

--- a/website/components/signature.tsx
+++ b/website/components/signature.tsx
@@ -1,0 +1,104 @@
+/**
+ * Signature — the page's visual law, rendered once as a slim hero band.
+ *
+ * Encodes "signal → depth → compression → rise → embodiment" left-to-right:
+ *   signal      a small node (upper-left) with concentric ripples — a faint
+ *               mark on the surface implying structure beneath it.
+ *   depth       several braided traces fan down into the cool lower band —
+ *               the real local complexity you descend into.
+ *   compression those repeated passes converge toward one threshold and
+ *               compress into a single confident route.
+ *   rise        that earned route climbs to the upper-right.
+ *   embodiment  it resolves into a warm node — the "ping", work made usable.
+ * One crisp measuring rule crosses the whole field (organic depth + one
+ * ruthless line of measurement).
+ *
+ * Pure SVG, no client JS, no dependencies. Decorative → aria-hidden. All
+ * colour comes from --sig-* tokens (composes with the brand, never recolours
+ * it); all motion lives in docs-theme.css under prefers-reduced-motion, so a
+ * reduced-motion reader sees the fully-formed, static composition.
+ *
+ * Gradient ids are namespaced by `idPrefix` so multiple instances on one page
+ * never collide (the same footgun documented on public/brand-mark.svg).
+ */
+export function Signature({ idPrefix = 'afkSig' }: { idPrefix?: string }) {
+  const routeGrad = `${idPrefix}-route`;
+  const ping = `${idPrefix}-ping`;
+
+  return (
+    <figure className="afk-signature not-prose" aria-hidden="true">
+      <svg
+        className="afk-sig"
+        viewBox="0 0 1200 180"
+        width="1200"
+        height="180"
+        role="presentation"
+        preserveAspectRatio="xMidYMid meet"
+      >
+        <defs>
+          {/* The earned route: cold start → green route → warm use. */}
+          <linearGradient id={routeGrad} x1="150" y1="120" x2="1058" y2="52" gradientUnits="userSpaceOnUse">
+            <stop offset="0%" style={{ stopColor: 'rgb(var(--sig-route-cold))' }} />
+            <stop offset="52%" style={{ stopColor: 'rgb(var(--sig-route-mid))' }} />
+            <stop offset="100%" style={{ stopColor: 'rgb(var(--sig-route-warm))' }} />
+          </linearGradient>
+          {/* The ping — warm resolve at the route's end. */}
+          <radialGradient id={ping} cx="50%" cy="50%" r="50%">
+            <stop offset="0%" style={{ stopColor: 'rgb(var(--sig-route-warm))', stopOpacity: 0.9 }} />
+            <stop offset="60%" style={{ stopColor: 'rgb(var(--sig-route-warm))', stopOpacity: 0.5 }} />
+            <stop offset="100%" style={{ stopColor: 'rgb(var(--sig-route-warm))', stopOpacity: 0 }} />
+          </radialGradient>
+        </defs>
+
+        {/* ── measure: one crisp rule crossing the organic field ───────────── */}
+        <g className="afk-sig__measure">
+          <line x1="80" y1="158" x2="1120" y2="158" />
+          {/* interval ticks */}
+          <line x1="150" y1="153" x2="150" y2="158" />
+          <line x1="340" y1="153" x2="340" y2="158" />
+          <line x1="530" y1="153" x2="530" y2="158" />
+          <line x1="884" y1="153" x2="884" y2="158" />
+          <line x1="1058" y1="153" x2="1058" y2="158" />
+          {/* threshold marker at the compression point — a longer tick + a
+              faint vertical guide where many passes resolve into one route. */}
+          <line className="afk-sig__threshold" x1="706" y1="146" x2="706" y2="162" />
+          <line className="afk-sig__axis" x1="706" y1="40" x2="706" y2="146" />
+        </g>
+
+        {/* ── depth: braided passes fanning through the cool lower band ─────── */}
+        <g className="afk-sig__trace">
+          <path d="M150 78 C 280 122, 470 140, 706 114" />
+          <path d="M150 112 C 300 150, 480 156, 706 118" />
+          <path d="M150 96 C 290 140, 470 150, 706 116" />
+        </g>
+
+        {/* ── compression → rise: the single earned route to the warm node ──── */}
+        <path
+          className="afk-sig__route"
+          d="M150 96 C 300 140, 480 150, 706 115 C 852 92, 952 70, 1058 52"
+          fill="none"
+          stroke={`url(#${routeGrad})`}
+        />
+
+        {/* ── signal: a small mark, ripples implying hidden depth (upper-left) ─ */}
+        <g className="afk-sig__signal">
+          <circle className="afk-sig__ring" cx="132" cy="60" r="14" />
+          <circle className="afk-sig__ring" cx="132" cy="60" r="26" />
+          <circle className="afk-sig__ring" cx="132" cy="60" r="40" />
+          <circle className="afk-sig__ripple" cx="132" cy="60" r="14" />
+          <circle className="afk-sig__ripple afk-sig__ripple--2" cx="132" cy="60" r="14" />
+          <circle className="afk-sig__node afk-sig__node--signal" cx="132" cy="60" r="3.5" />
+        </g>
+
+        {/* ── embodiment: the route lands as a warm ping (upper-right) ──────── */}
+        <g className="afk-sig__embodiment">
+          <circle className="afk-sig__glow" cx="1058" cy="52" r="17" fill={`url(#${ping})`} />
+          <circle className="afk-sig__node afk-sig__node--warm" cx="1058" cy="52" r="4.5" />
+          {/* a precise crosshair — measure meeting the resolved point */}
+          <line className="afk-sig__crosshair" x1="1058" y1="38" x2="1058" y2="46" />
+          <line className="afk-sig__crosshair" x1="1058" y1="58" x2="1058" y2="66" />
+        </g>
+      </svg>
+    </figure>
+  );
+}

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -3,6 +3,8 @@ title: "Introduction"
 description: "A local AI agent runner — terminal, daemon, and Telegram, sharing one session."
 ---
 
+<Signature />
+
 Built on the Anthropic SDK, Agent AFK runs outside Claude Code as its own process — a full agentic runtime you own completely. Hand it long or multi-step work and check in asynchronously: it delegates the work and leaves the judgment to you.
 
 ```bash
@@ -10,7 +12,7 @@ npm install -g agent-afk
 ```
 
 <Cards>
-  <Card title="Get started →" href="/quickstart" description="Install, set your API key, and run your first command in under two minutes." />
+  <Card className="elevated-field" title="Get started →" href="/quickstart" description="Install, set your API key, and run your first command in under two minutes." />
 </Cards>
 
 ## Who it's for


### PR DESCRIPTION
## Summary

Adds a subtle, reusable visual signature to the docs site (`website/`, docs.agentafk.com) that quietly embodies one worldview — **signal → depth → compression → rise → embodiment** — without a logo/mascot, without changing copy, IA, or the install/quickstart conversion path.

It *extends the existing Handoff-Arc brand logic* rather than overlaying a new one: the orange "ping" is the **signal**, the grey→green arc is the **earned route**. Three named motifs carry the law, repeated with variation so pages feel governed by one hand:

- **`deep-field` + `signal-field`** — a faint fixed page background: cool depth biased lower-left resolving to a warm node + concentric signal rings upper-right (signal over depth, on every page).
- **`earned-path` + `scope-rule`** — a slim SSR SVG hero band on the home (braided traces compressing into one route that rises into a warm "ping", crossed by one crisp measure), plus route-migrating `hr` dividers and feature cards reframed as excavated artifacts (scope-rule edge + corner tick).
- **`elevated-field`** — the "Get started" CTA gets the warmest, most-arrived treatment (rise → embodiment).

Implementation is intentionally lightweight: CSS tokens + scoped rules + one dependency-free server component. Motion is gated by `prefers-reduced-motion` (reduced-motion readers see the fully-formed static composition). AA text contrast preserved in light and dark; the system recomposes (not collapses) on mobile.

## Test results

- `pnpm typecheck` (website): **pass** (`tsc --noEmit`, clean).
- `pnpm build` (website): **pass** — 28/28 static pages prerendered, **First Load JS unchanged at 103 kB** (the signature adds no client bundle).
- In-browser smoke (next dev): **0 console errors**; verified light + dark + content pages legible; band, dividers, card scope-rule, and elevated CTA all render.

> Scope note: `website/` is a self-contained npm sub-project (its own `package-lock.json`), separate from the pnpm root. Its gates are `typecheck` + `next build` — it has no vitest suite. The root runtime test suite is **out of scope**: this PR changes zero files under `src/`.

## Verification

Load-bearing claims re-derived mechanically from the diff (deterministic checks, not prose):

- **Confined to `website/`** — `git status` shows all 5 changed paths under `website/`. ✅ CONFIRM
- **Runtime untouched** — zero changes under `src/`. ✅ CONFIRM
- **Zero new dependencies** — no `package.json` / lockfile changes. ✅ CONFIRM
- **Zero new client JS** — the new `signature.tsx` is a pure server component (no `"use client"`); build confirms First Load JS is unchanged. ✅ CONFIRM
- **No heading-anchor leak** — card styling scoped to `[data-card]:not(.peer)` (Fumadocs reuses `data-card` on heading permalink anchors, which carry `.peer`). Verified clean in-browser. ✅ CONFIRM

## Files

- `website/app/globals.css` — `--sig-*` token system (dark + light).
- `website/app/(docs)/docs-theme.css` — the system, scoped to `#nd-docs-layout`.
- `website/components/signature.tsx` — new reusable SSR SVG band (aria-hidden, namespaced gradient ids).
- `website/app/(docs)/[[...slug]]/page.tsx` — registered `<Signature>` in the MDX map.
- `website/content/docs/index.mdx` — `<Signature />` at top of body; CTA tagged `elevated-field`.

Run `cd website && pnpm dev` to preview locally.