### PR TITLE
Docs visual signature — candidate 1/3: full-arc hero (converging ghost-paths + scope axis)

### DIFF
--- a/website/VISUAL-SIGNATURE.md
+++ b/website/VISUAL-SIGNATURE.md
@@ -1,0 +1,174 @@
+# Agent AFK Docs — Visual Signature
+
+A subtle, **reusable** visual system layered onto the existing fumadocs docs
+site (docs.agentafk.com). It is **additive**: nothing about the brand palette,
+the "Handoff Arc" mark, the dark terminal aesthetic, the sidebar/TOC/search,
+the content, or the responsive/light-mode behavior was replaced. The signature
+is grown out of the identity that was already there.
+
+The page now quietly embodies one worldview, without ever stating it literally:
+
+> A small **signal** on the surface reveals hidden **depth** beneath it. You
+> descend into the real local complexity, find the structure that survives
+> contact with reality, **compress** repeated passes into an earned path, then
+> **rise** into something usable enough to live, build on, and share
+> (**embodiment**).
+
+Motion: **signal → depth → compression → rise → embodiment.**
+
+---
+
+## 1. What changed (concise)
+
+| File | Change |
+|------|--------|
+| `app/(docs)/signature.css` *(new)* | The whole reusable system: signature tokens + the three motifs as scoped CSS (field migration, contour dividers, artifact cards, elevated/deep field, signal-field motion + responsive + reduced-motion contracts). |
+| `components/visual/signal-field.tsx` *(new)* | `<SignalField>` — the hero motif. One self-contained inline SVG that renders the full motion (signal node → contour basin → converging ghost passes → one earned route rising to a warm arrival node), crossed by one crisp scope rule. No deps, no client JS. |
+| `components/visual/contour-divider.tsx` *(new)* | `<ContourDivider>` — a semantic `<hr>` rendered as a routed topographic transition instead of a flat rule. |
+| `app/(docs)/layout.tsx` | Imports `signature.css` after `docs-theme.css` (one line). |
+| `app/(docs)/[[...slug]]/page.tsx` | Registers `SignalField` + `ContourDivider` for MDX, and maps **all** `---` thematic breaks site-wide to `ContourDivider` (the `hr` component) so every page inherits the same hand. |
+| `content/docs/index.mdx` | Adds `<SignalField />` to the hero; wraps the primary "Get started" Cards in `.sig-cta` (warmest arrival card) and the closing CTA in `.elevated-field` (the most embodied zone). Content/links unchanged. |
+
+No new dependencies. Production build is green: all 28 pages prerender
+statically; `tsc --noEmit` passes; the only console errors at runtime are the
+pre-existing `@vercel/analytics` 404 in a keyless local server (unrelated).
+
+---
+
+## 2. The visual logic
+
+The brand already contained the seed of the whole idea. The **Handoff Arc**
+mark is a small orange "ping" sitting in the gap of a larger grey→green arc —
+i.e. *a small bright signal implying a larger structure handed off*. The
+signature simply takes that one glyph's logic and lets it govern the page:
+
+- The **ping orange** (`#f97316`/`#ffc2a1`/`#d65a0e`) becomes the *signal* and
+  the *warm embodiment* register.
+- The arc's **grey→green** (`#6f6f86`→`#5cb87f`) becomes the *cool descent →
+  structure-found* register.
+- The deep `#07070b` background is the *depth* everything sits over.
+
+Nothing is recolored. The motifs reuse those exact values as CSS variables
+(`--sig-warm`, `--sig-cool`, `--sig-mid`, …), so the new shapes read as the same
+hand as the mark.
+
+The composition follows the brief's default movement —
+**dense lower-left → compressed center → resolved upper-right** — and the
+emotional movement **cold depth → earned route → warm use**: discovery happens
+inward/cool/low-left; embodiment happens outward/warm/up-right.
+
+### Restraint
+
+Per the decision rule, only **three** recurring motifs are used (repetition
+with variation, not a collage of every available effect), and every one is
+tied back to the same law:
+
+1. **Signal field** — signal over depth (hero).
+2. **Earned path + scope rule** — compression into one route, crossed by one
+   ruthless line of measurement (hero, and the measure echoes at card scale).
+3. **Field migration** — cool/dense lower-left warming to upper-right, applied
+   to the whole shell, to section transitions, and to cards-as-artifacts.
+
+---
+
+## 3. Reusable tokens / components / utilities added
+
+### Components (`components/visual/`)
+- **`<SignalField seed?={n} />`** — the hero motif. Drop it at the top of any
+  page's hero region. `seed` deterministically perturbs the route + basin so
+  sibling pages feel related but not identical. Decorative: `aria-hidden`,
+  `pointer-events:none`, zero-height anchor (never displaces copy).
+- **`<ContourDivider />`** — an explicit routed-contour section break. Also wired
+  globally so plain MDX `---` becomes one automatically.
+
+### CSS custom properties (signature tokens, in `:root`)
+```
+--sig-warm / --sig-warm-soft / --sig-warm-deep   the signal / embodiment orange
+--sig-cool / --sig-mid                           the descent grey → structure green
+--sig-contour-op / --sig-field-op                low field opacities (never fights copy)
+--sig-ripple-dur / --sig-drift-dur               motion timing
+```
+
+### Utility classes (all scoped to `#nd-docs-layout` or opt-in)
+- **`.signal-field` / `.signal-field__svg`** — host + bleed geometry for the
+  hero SVG (incl. mobile recomposition + reduced-motion handling).
+- **`.contour-divider`** — section transition as a topographic crossing.
+- **`.deep-field`** — a reusable cool/dense "discovery" callout wrapper.
+- **`.elevated-field`** — a reusable warm/clear "embodiment" wrapper (CTA/arrival).
+- **`.sig-cta`** — marks the primary call's card(s) as the warmest arrival.
+- **Artifact cards** — fumadocs `[data-card]`s gain a cool threshold top-edge, a
+  carved lower-left contour recess, and a warm rise on hover/focus. Applied
+  automatically to every docs card; no per-card markup.
+
+These are intentionally generic so future pages can reach for `deep-field` /
+`elevated-field` / `<SignalField seed=…/>` and stay on-system.
+
+---
+
+## 4. How the page expresses the five beats
+
+- **Signal** — the small bright orange node at the hero's lower-left (the brand
+  ping), pulsing slowly. The visible symptom.
+- **Depth** — concentric contour rings + open basin arcs spread beneath and
+  *past the frame edges* around that node: the submerged system is far larger
+  than the signal. The whole docs shell also carries a cool, denser tint in its
+  lower-left corner.
+- **Compression** — several faint "ghost" traces (prior passes) converge into
+  **one** confident route. Iteration worn into a single path, not a drawn
+  swoosh.
+- **Rise** — that route climbs from the cool low-left, through the green
+  "structure-found" midtone, up toward the warm upper-right. Section dividers
+  and card thresholds carry the same cool→warm gradient at smaller scale.
+- **Embodiment** — the route resolves into a warm arrival node next to the
+  **"Get started"** card (`.sig-cta`, warm border + lit threshold), and the page
+  closes in an **`.elevated-field`** — the clearest, warmest, lowest-friction
+  zone, the strongest sense of arrival.
+
+The **one ruthless measure**: a crisp dashed scope-rule with a monospace
+`depth → signal` coordinate label crosses the organic hero field — living
+complexity crossed by clean judgment. The same "one precise edge" idea repeats
+as the cards' threshold top-line.
+
+---
+
+## 5. Accessibility, performance, responsiveness
+
+- **Reduced motion** — under `prefers-reduced-motion: reduce`, every animation
+  is disabled and frozen in a *resolved* end state (route fully drawn, node
+  steady). The composition is structural, so it still reads when static.
+  *(Verified: route `animation-name: none`, `stroke-dashoffset: 0`.)*
+- **Contrast** — all field art is low-opacity and sits **behind** content; the
+  AA text contrast already met by `docs-theme.css` is preserved in both themes.
+  *(Verified: hero body text ≈ `#e9e9f0` on dark, ≈ `#111118` on light.)*
+- **Mobile** — the signal field recomposes intentionally (shorter, narrower
+  bleed) rather than collapsing; **no horizontal overflow** at 375–390px.
+  *(Verified: `scrollWidth === clientWidth`.)*
+- **Semantics / a11y** — decorative SVG is `aria-hidden` + non-interactive;
+  dividers remain real `<hr>` thematic breaks; no DOM/landmark changes; search,
+  nav, TOC, and the brand mark are untouched.
+- **Performance** — pure CSS + inline SVG, no JS on the client for the motifs,
+  no new dependencies, no extra network requests. The field-migration backdrop
+  is a single `position: fixed` pseudo-element.
+
+---
+
+## 6. Tradeoffs, omissions, future extensions
+
+- **Only the hero carries the full motif.** By design (restraint / "not the
+  signature graphic again"). Inner pages inherit the *quiet* signals — the
+  field-migration backdrop, contour dividers, artifact cards — so they feel
+  governed by the same law without repeating the hero graphic. `<SignalField>`
+  is ready to drop into another page's hero (e.g. How It Works) with a different
+  `seed` if a second focal point is ever wanted.
+- **`hr` is globally remapped to `ContourDivider`.** High leverage (every `---`
+  on every page becomes on-system with zero per-file edits) and reversible (one
+  line in `page.tsx`). The element stays a semantic `<hr>`.
+- **Motifs deliberately *not* used:** glassmorphism, particle fields, generic
+  "AI glow", literal landscape art, and a recurring illustration/mascot — all on
+  the brief's avoid list. The scope rule is the single "crisp measure"; adding
+  more axes/scales risked tipping into poster territory.
+- **Future extensions:** (a) a `<ScopeRule>` component if pages want the measure
+  device standalone; (b) `seed`-varied `<SignalField>` on section landing pages;
+  (c) a `data-sig-register="deep|warm"` attribute on `<section>`s to let long
+  pages migrate cool→warm down the scroll; (d) an optional faint route in the
+  sidebar rail. None are needed for the system to read today.

--- a/website/app/(docs)/[[...slug]]/page.tsx
+++ b/website/app/(docs)/[[...slug]]/page.tsx
@@ -4,6 +4,8 @@ import { DocsPage, DocsBody, DocsDescription, DocsTitle } from 'fumadocs-ui/page
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import { Card, Cards } from 'fumadocs-ui/components/card';
 import { source } from '@/lib/source';
+import { SignalField } from '@/components/visual/signal-field';
+import { ContourDivider } from '@/components/visual/contour-divider';
 
 interface Props {
   params: Promise<{ slug?: string[] }>;
@@ -22,7 +24,21 @@ export default async function Page({ params }: Props) {
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>
-        <MDX components={{ ...defaultMdxComponents, Card, Cards }} />
+        <MDX
+          components={{
+            ...defaultMdxComponents,
+            Card,
+            Cards,
+            // Visual signature: the hero motif (signal -> depth -> compression
+            // -> rise -> embodiment), available to any page's MDX.
+            SignalField,
+            // Every thematic break (`---`) across the docs renders as a routed
+            // contour transition instead of a flat rule, so all pages inherit
+            // the same hand. ContourDivider is also usable explicitly in MDX.
+            hr: ContourDivider,
+            ContourDivider,
+          }}
+        />
       </DocsBody>
     </DocsPage>
   );

--- a/website/app/(docs)/layout.tsx
+++ b/website/app/(docs)/layout.tsx
@@ -4,6 +4,10 @@ import { RootProvider } from 'fumadocs-ui/provider/next';
 import { source } from '@/lib/source';
 import 'fumadocs-ui/style.css';
 import './docs-theme.css';
+// Visual signature — a reusable, additive system layered on top of the brand
+// theme (signal -> depth -> compression -> rise -> embodiment). Imported AFTER
+// docs-theme.css so its scoped overrides sit last in the cascade.
+import './signature.css';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (

--- a/website/app/(docs)/signature.css
+++ b/website/app/(docs)/signature.css
@@ -1,0 +1,413 @@
+/* ==========================================================================
+   Agent AFK Docs — Visual Signature
+   --------------------------------------------------------------------------
+   A small, reusable visual system layered ON TOP of the existing fumadocs
+   brand (see docs-theme.css). It is ADDITIVE: every rule is scoped to
+   #nd-docs-layout or to opt-in `.sig-*` classes / data-attributes, so it
+   never overrides content, sidebar, search, or the brand mark.
+
+   The worldview it encodes (never stated literally on the page):
+
+     A small SIGNAL on the surface reveals hidden DEPTH beneath it. You
+     descend into the real local complexity, find the structure that survives
+     contact with reality, COMPRESS repeated passes into an earned path, then
+     RISE into something usable enough to live, build on, and SHARE.
+
+     motion:  signal -> depth -> compression -> rise -> embodiment
+
+   Three recurring motifs carry it (repetition with variation, not collage):
+
+     1. SIGNAL FIELD  — a bright node over implied submerged structure
+                        (concentric rings + contour basin). See <SignalField>.
+     2. EARNED PATH   — braided traces converging into one confident route,
+                        crossed by ONE ruthless measuring line (scope rule).
+                        See <SignalField> (path + rule live in the same SVG).
+     3. FIELD MIGRATION — the page runs cool/dense at the lower-left and warms
+                        + lightens toward the upper-right. Section separators
+                        become routed contours; cards read as extracted
+                        artifacts; the closing CTA sits in the warmest light.
+
+   Palette continuity: the motifs reuse the brand-mark colours verbatim —
+   the orange "ping" (--sig-warm), the grey->green handoff arc
+   (--sig-cool / --sig-mid), the deep background (#07070b). Nothing is
+   recoloured; the signature is grown out of the mark that already exists.
+
+   Accessibility / performance:
+     - All decorative SVG is aria-hidden and pointer-events:none.
+     - Motion is opt-in and fully disabled under prefers-reduced-motion.
+     - No new dependencies; pure CSS + inline SVG.
+     - Backgrounds are low-opacity gradients behind content, so AA text
+       contrast (already met by docs-theme.css) is preserved.
+   ========================================================================== */
+
+/* --- Signature tokens ----------------------------------------------------- */
+/* Tied to the brand-mark gradients so depth/route/rise read as one family.
+   Defined on :root so the SVG components and the docs shell share them. */
+:root {
+  /* The signal: the brand "ping" orange — warmth, arrival, embodiment. */
+  --sig-warm:        #f97316;
+  --sig-warm-soft:   #ffc2a1;
+  --sig-warm-deep:   #d65a0e;
+
+  /* The route handoff: the brand arc grey -> green — descent into structure. */
+  --sig-cool:        #6f6f86;   /* cooler/greyer than text-faint: deep field */
+  --sig-mid:         #5cb87f;   /* arc green: structure found in the depth   */
+
+  /* Field opacities — kept low so nothing competes with copy. */
+  --sig-contour-op:  0.05;      /* contour line strength over deep bg        */
+  --sig-field-op:    0.07;      /* basin glow strength                        */
+
+  /* Motion (respects the site's existing easing vocabulary). */
+  --sig-ripple-dur:  7s;
+  --sig-drift-dur:   22s;
+}
+
+/* ==========================================================================
+   MOTIF 3 — FIELD MIGRATION (depth -> rise -> embodiment)
+   The docs shell carries a single, very subtle directional field: cooler and
+   denser toward the lower-left, warming + lightening toward the upper-right.
+   This is the "cold depth -> warm use" movement applied to the whole page,
+   not just the hero. Two stacked radial gradients (one cool basin anchored
+   lower-left, one warm rise anchored upper-right) are painted as a fixed,
+   non-scrolling backdrop BEHIND all docs content.
+   ========================================================================== */
+#nd-docs-layout {
+  position: relative;
+  isolation: isolate;
+}
+#nd-docs-layout::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    /* warm rise — upper-right, faint (embodiment) */
+    radial-gradient(
+      60% 55% at 88% 8%,
+      rgba(249, 115, 22, 0.06) 0%,
+      rgba(249, 115, 22, 0.018) 38%,
+      transparent 70%
+    ),
+    /* cool basin — lower-left, denser (descent / hidden depth) */
+    radial-gradient(
+      70% 65% at 6% 100%,
+      rgba(92, 184, 127, 0.055) 0%,
+      rgba(111, 111, 134, 0.05) 34%,
+      transparent 72%
+    );
+  /* Let the deep base bg show through; this only tints the corners. */
+}
+
+/* Light theme: the same migration, dialed down so it never muddies the
+   high-contrast light reading surface. */
+:root:not(.dark) #nd-docs-layout::before {
+  background:
+    radial-gradient(60% 55% at 88% 8%,
+      rgba(232, 104, 42, 0.05) 0%, rgba(232, 104, 42, 0.015) 38%, transparent 70%),
+    radial-gradient(70% 65% at 6% 100%,
+      rgba(92, 184, 127, 0.06) 0%, rgba(111, 111, 134, 0.045) 34%, transparent 72%);
+}
+
+/* ==========================================================================
+   CONTOUR DIVIDER — section transitions as routed contours, not flat rules.
+   Opt-in via <hr class="contour-divider" /> (or the MDX `---` rule when the
+   page sets data-sig-contours). A topographic line: a faint baseline with a
+   single channel dipping through it and a small node marking the crossing —
+   "a threshold in the field", echoing the signal-over-depth motif at small
+   scale. Drawn with an inline SVG data-URI mask so it needs no extra markup.
+   ========================================================================== */
+#nd-docs-layout .contour-divider,
+#nd-docs-layout hr.contour-divider {
+  position: relative;
+  height: 22px;
+  border: 0;
+  margin: 2.6em 0;
+  background: transparent;
+  overflow: visible;
+}
+#nd-docs-layout .contour-divider::before {
+  /* Three stacked contour traces of decreasing opacity = layered depth. */
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    radial-gradient(circle at center, color-mix(in srgb, var(--sig-warm) 70%, transparent) 0 1.4px, transparent 1.8px),
+    repeating-linear-gradient(90deg, transparent 0 6px, transparent 6px);
+  background-repeat: no-repeat, repeat;
+  background-position: 18% center, 0 0;
+}
+/* The routed line itself: a thin gradient stroke that fades cool->warm,
+   left (deep) to right (resolved). The node above sits at the channel mouth. */
+#nd-docs-layout .contour-divider::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 1px;
+  transform: translateY(-50%);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--sig-cool) 55%, transparent) 0%,
+    color-mix(in srgb, var(--sig-mid) 45%, transparent) 42%,
+    color-mix(in srgb, var(--sig-warm) 38%, transparent) 100%
+  );
+  /* A single channel dips through the line: mask a notch out of the middle. */
+  -webkit-mask: radial-gradient(8px 14px at 18% -6px, transparent 96%, #000 100%);
+          mask: radial-gradient(8px 14px at 18% -6px, transparent 96%, #000 100%);
+}
+
+/* ==========================================================================
+   ARTIFACT CARDS — fumadocs Cards read as extracted artifacts pulled from the
+   field, not floating rectangles. A carved recess (inset top shadow +
+   threshold top-edge highlight), and a warm RISE on hover (lifts toward the
+   embodiment register). Scoped to fumadocs' [data-card] so only docs cards
+   are touched; their existing layout/colour from docs-theme.css is preserved.
+   ========================================================================== */
+#nd-docs-layout [data-card] {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  transition:
+    transform var(--t-base, 180ms) var(--ease, ease),
+    border-color var(--t-base, 180ms) var(--ease, ease),
+    box-shadow var(--t-base, 180ms) var(--ease, ease);
+}
+/* Threshold marker: a precise top edge — the "one ruthless line of
+   measurement" repeated at card scale. Cool at rest. */
+#nd-docs-layout [data-card]::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--sig-mid) 55%, transparent) 22%,
+    color-mix(in srgb, var(--sig-warm) 60%, transparent) 100%
+  );
+  opacity: 0.5;
+  transition: opacity var(--t-base, 180ms) var(--ease, ease);
+  z-index: 1;
+}
+/* Carved recess: a faint contour glow seated in the lower-left corner of each
+   card — the artifact still carries a trace of the depth it came from. */
+#nd-docs-layout [data-card]::after {
+  content: '';
+  position: absolute;
+  left: -30%;
+  bottom: -40%;
+  width: 70%;
+  height: 80%;
+  background: radial-gradient(
+    circle at 30% 70%,
+    color-mix(in srgb, var(--sig-mid) 60%, transparent) 0%,
+    transparent 70%
+  );
+  opacity: 0.06;
+  transition: opacity var(--t-base, 180ms) var(--ease, ease);
+  z-index: -1;
+  pointer-events: none;
+}
+#nd-docs-layout [data-card]:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--sig-warm) 45%, var(--color-fd-border));
+  box-shadow:
+    0 6px 20px -10px rgba(0, 0, 0, 0.5),
+    0 0 0 1px color-mix(in srgb, var(--sig-warm) 12%, transparent);
+}
+#nd-docs-layout [data-card]:hover::before { opacity: 1; }
+#nd-docs-layout [data-card]:hover::after  { opacity: 0.13; }
+#nd-docs-layout [data-card]:focus-within {
+  border-color: color-mix(in srgb, var(--sig-warm) 45%, var(--color-fd-border));
+}
+
+/* The first <Cards> block on a page (the primary "Get started" call) sits in
+   warmer light — strongest sense of arrival. Opt-in via .sig-cta on a wrapper
+   or on the Card itself. */
+#nd-docs-layout .sig-cta[data-card],
+#nd-docs-layout .sig-cta [data-card] {
+  border-color: color-mix(in srgb, var(--sig-warm) 30%, var(--color-fd-border));
+}
+#nd-docs-layout .sig-cta[data-card]::before,
+#nd-docs-layout .sig-cta [data-card]::before {
+  opacity: 0.9;
+}
+#nd-docs-layout .sig-cta[data-card]::after,
+#nd-docs-layout .sig-cta [data-card]::after {
+  background: radial-gradient(circle at 30% 70%,
+    color-mix(in srgb, var(--sig-warm) 70%, transparent) 0%, transparent 70%);
+  opacity: 0.12;
+}
+
+/* ==========================================================================
+   ELEVATED FIELD — a reusable "embodiment zone" wrapper. The warmest, clearest
+   region: used for the closing CTA / arrival block. Opt-in via
+   <div class="elevated-field"> in MDX.
+   ========================================================================== */
+#nd-docs-layout .elevated-field {
+  position: relative;
+  border-radius: var(--radius-lg, 12px);
+  padding: 1.4rem 1.5rem;
+  margin: 2.2em 0 0.5em;
+  background:
+    radial-gradient(120% 140% at 100% 0%,
+      rgba(249, 115, 22, 0.07) 0%, transparent 55%),
+    var(--color-fd-card);
+  border: 1px solid color-mix(in srgb, var(--sig-warm) 22%, var(--color-fd-border));
+}
+#nd-docs-layout .elevated-field::before {
+  /* The measure crossing the warm field: a clean top rule with a tick. */
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 1.5rem;
+  right: 1.5rem;
+  height: 1px;
+  background: linear-gradient(90deg,
+    color-mix(in srgb, var(--sig-warm) 55%, transparent),
+    transparent 80%);
+  opacity: 0.7;
+}
+
+/* A reusable DEEP FIELD wrapper — the cool, dense, inward "discovery" register.
+   Opt-in; available for problem-framing / deep-dive callouts on any page. */
+#nd-docs-layout .deep-field {
+  position: relative;
+  border-radius: var(--radius-lg, 12px);
+  padding: 1.4rem 1.5rem;
+  margin: 2em 0;
+  background:
+    radial-gradient(120% 160% at 0% 100%,
+      rgba(92, 184, 127, 0.06) 0%,
+      rgba(111, 111, 134, 0.05) 38%,
+      transparent 70%),
+    var(--color-fd-card);
+  border: 1px solid var(--color-fd-border);
+}
+
+/* ==========================================================================
+   SIGNAL FIELD host — the wrapper the <SignalField> component renders into.
+   It is a zero-height, overflow-visible anchor placed at the top of the hero;
+   the SVG bleeds upward/outward behind the intro copy. Sized in the component;
+   here we own positioning + the reduced-motion + responsive contract so the
+   rules live with the rest of the system.
+   ========================================================================== */
+.signal-field {
+  position: relative;
+  display: block;
+  width: 100%;
+  /* The field reaches above its anchor (into the title region) and to the
+     right (toward the CTA), establishing the lower-left -> upper-right pull. */
+  height: 0;
+  pointer-events: none;
+  user-select: none;
+  z-index: 0;
+}
+.signal-field__svg {
+  position: absolute;
+  /* Bleed beyond the content column so the "submerged structure" extends past
+     the visible frame — the system is larger than what the page shows. */
+  left: -8%;
+  right: -8%;
+  bottom: -130px;
+  width: 116%;
+  height: 360px;
+  overflow: visible;
+}
+
+/* Animated primitives inside the SVG (classes applied to SVG elements). */
+.signal-field .sf-ripple {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: sf-ripple var(--sig-ripple-dur) var(--ease, ease-out) infinite;
+}
+.signal-field .sf-ripple--2 { animation-delay: calc(var(--sig-ripple-dur) / -3); }
+.signal-field .sf-ripple--3 { animation-delay: calc(var(--sig-ripple-dur) / -1.5); }
+
+.signal-field .sf-node {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: sf-pulse calc(var(--sig-ripple-dur) / 1.75) ease-in-out infinite;
+}
+
+/* The earned path draws itself once, then holds — iteration resolving into a
+   single confident route. dash length set in the component via pathLength. */
+.signal-field .sf-route {
+  stroke-dasharray: 1000;
+  stroke-dashoffset: 1000;
+  animation: sf-draw 2.6s var(--ease, ease) 0.2s forwards;
+}
+.signal-field .sf-route--ghost {
+  /* The faint prior passes: drawn, then settle to low opacity. */
+  opacity: 0;
+  animation: sf-ghost 2.6s var(--ease, ease) forwards;
+}
+
+@keyframes sf-ripple {
+  0%   { transform: scale(0.35); opacity: 0; }
+  18%  { opacity: var(--sig-field-op); }
+  100% { transform: scale(1.6); opacity: 0; }
+}
+@keyframes sf-pulse {
+  0%, 100% { opacity: 0.85; transform: scale(1); }
+  50%      { opacity: 1;    transform: scale(1.12); }
+}
+@keyframes sf-draw {
+  to { stroke-dashoffset: 0; }
+}
+@keyframes sf-ghost {
+  0%   { opacity: 0; stroke-dashoffset: 1000; }
+  60%  { opacity: 0.5; }
+  100% { opacity: 0.18; stroke-dashoffset: 0; }
+}
+
+/* Faint contour drift on the basin layer (background structure breathing). */
+.signal-field .sf-drift {
+  animation: sf-drift var(--sig-drift-dur) ease-in-out infinite alternate;
+  transform-box: fill-box;
+  transform-origin: center;
+}
+@keyframes sf-drift {
+  from { transform: translateX(-6px); }
+  to   { transform: translateX(6px); }
+}
+
+/* --- Responsive recomposition -------------------------------------------- */
+/* On small screens the field recomposes intentionally: it shrinks, pulls the
+   route to a vertical descent, and keeps the node/rings centred — never
+   collapsing into visual rubble or pushing copy around. */
+@media (max-width: 640px) {
+  .signal-field__svg {
+    left: -4%;
+    right: -4%;
+    width: 108%;
+    height: 230px;
+    bottom: -90px;
+  }
+}
+
+/* --- Reduced motion ------------------------------------------------------- */
+/* Honour the user's preference: freeze every animation in a resolved end
+   state (route fully drawn, node steady, ripples hidden). The composition
+   still reads — the signature is structural, not dependent on motion. */
+@media (prefers-reduced-motion: reduce) {
+  .signal-field .sf-ripple,
+  .signal-field .sf-node,
+  .signal-field .sf-drift {
+    animation: none;
+  }
+  .signal-field .sf-ripple { opacity: var(--sig-field-op); }
+  .signal-field .sf-route {
+    animation: none;
+    stroke-dashoffset: 0;
+  }
+  .signal-field .sf-route--ghost {
+    animation: none;
+    opacity: 0.18;
+    stroke-dashoffset: 0;
+  }
+}

--- a/website/components/visual/contour-divider.tsx
+++ b/website/components/visual/contour-divider.tsx
@@ -1,0 +1,20 @@
+/**
+ * ContourDivider — a section transition rendered as a routed contour line
+ * instead of a flat rule. Part of the Agent AFK docs visual signature: a
+ * threshold crossing in the field (a faint cool->warm trace with a single
+ * channel dipping through it and a node marking the crossing).
+ *
+ * It is a semantic <hr> (preserves the document outline / a11y meaning of a
+ * thematic break) carrying the `.contour-divider` class whose visuals live in
+ * signature.css. Drop <ContourDivider /> in MDX, or write a plain `---` rule
+ * and let the page opt in — this component is the explicit form.
+ *
+ * Purely decorative styling; the <hr> itself remains a real separator.
+ */
+export function ContourDivider({ className }: { className?: string }) {
+  return (
+    <hr className={className ? `contour-divider ${className}` : 'contour-divider'} aria-hidden="false" />
+  );
+}
+
+export default ContourDivider;

--- a/website/components/visual/signal-field.tsx
+++ b/website/components/visual/signal-field.tsx
@@ -1,0 +1,191 @@
+/**
+ * SignalField — the hero motif of the Agent AFK docs visual signature.
+ *
+ * Encodes, in one self-contained inline SVG, the full motion the signature is
+ * built around:
+ *
+ *   signal -> depth -> compression -> rise -> embodiment
+ *
+ *   - SIGNAL: a small bright node (the brand "ping" orange) at the lower-left,
+ *     the visible symptom on the surface.
+ *   - DEPTH:  concentric rings + a layered contour basin spreading beneath and
+ *     around the node — the submerged structure is far larger than the signal.
+ *     The basin lines bleed past the frame, implying the system continues
+ *     beyond what the page shows.
+ *   - COMPRESSION: several faint "ghost" traces (prior passes) on the left that
+ *     converge into ONE confident route — iteration worn into a single path.
+ *   - RISE / EMBODIMENT: that route climbs from the deep lower-left toward the
+ *     warm upper-right, resolving into a clear endpoint node near where the
+ *     page's "Get started" call sits.
+ *   - MEASURE: one crisp scope rule (axis tick + coordinate label) crosses the
+ *     organic field — "living complexity crossed by clean judgment."
+ *
+ * It is purely decorative: aria-hidden, pointer-events:none, and it occupies a
+ * zero-height anchor so it never displaces the hero copy. All motion lives in
+ * signature.css and is disabled under prefers-reduced-motion (the composition
+ * still reads when frozen). No client JS, no dependencies.
+ *
+ * Reusable: drop <SignalField /> at the top of any page's hero region. The
+ * `seed` prop nudges the route/basin so sibling pages can share the hand
+ * without repeating the identical graphic.
+ */
+
+export interface SignalFieldProps {
+  /**
+   * Small integer that perturbs the route + basin so different pages feel
+   * related but not identical (repetition with variation). Default 0.
+   */
+  seed?: number;
+  /** Optional extra className on the host wrapper. */
+  className?: string;
+}
+
+export function SignalField({ seed = 0, className }: SignalFieldProps) {
+  // Deterministic, tiny perturbations from the seed — keep the composition
+  // recognisably the same while letting it vary per page.
+  const jitter = ((seed % 5) - 2) * 4; // -8..8
+  const routeMidY = 96 + jitter;
+
+  // The earned route: faint ghost passes converge into one confident curve.
+  // Coordinate system: 0..640 x, 0..360 y. The node sits low-left (~96,250),
+  // the resolved endpoint rises high-right (~556,70).
+  const mainRoute = `M 96 250
+    C 150 232, 168 210, 214 ${routeMidY + 86}
+    S 300 150, 360 ${routeMidY + 44}
+    S 470 110, 556 70`;
+
+  // Ghost passes: same destination, scattered approaches that compress in.
+  const ghostRoutes = [
+    `M 96 250 C 168 250, 196 200, 250 188 S 360 168, 430 120 S 506 96, 556 70`,
+    `M 96 250 C 140 218, 200 224, 258 ${routeMidY + 70} S 348 132, 412 134 S 500 92, 556 70`,
+    `M 96 250 C 176 246, 150 184, 236 176 S 372 196, 440 132 S 520 102, 556 70`,
+  ];
+
+  return (
+    <div className={className ? `signal-field ${className}` : 'signal-field'} aria-hidden="true">
+      <svg
+        className="signal-field__svg"
+        viewBox="0 0 640 360"
+        fill="none"
+        preserveAspectRatio="xMidYMax meet"
+        role="presentation"
+        focusable="false"
+      >
+        <defs>
+          {/* Route gradient: cool/green (depth) -> warm orange (embodiment). */}
+          <linearGradient id="sf-route-grad" x1="96" y1="250" x2="556" y2="70" gradientUnits="userSpaceOnUse">
+            <stop offset="0%" stopColor="var(--sig-cool)" />
+            <stop offset="48%" stopColor="var(--sig-mid)" />
+            <stop offset="100%" stopColor="var(--sig-warm)" />
+          </linearGradient>
+
+          {/* Node glow — the brand ping. */}
+          <radialGradient id="sf-node-grad" cx="50%" cy="50%" r="50%">
+            <stop offset="0%" stopColor="var(--sig-warm-soft)" />
+            <stop offset="55%" stopColor="var(--sig-warm)" />
+            <stop offset="100%" stopColor="var(--sig-warm-deep)" />
+          </radialGradient>
+
+          {/* Basin contour stroke — cool, low opacity, the hidden structure. */}
+          <linearGradient id="sf-contour-grad" x1="0" y1="360" x2="640" y2="0" gradientUnits="userSpaceOnUse">
+            <stop offset="0%" stopColor="var(--sig-mid)" stopOpacity="0.5" />
+            <stop offset="60%" stopColor="var(--sig-cool)" stopOpacity="0.35" />
+            <stop offset="100%" stopColor="var(--sig-warm)" stopOpacity="0.22" />
+          </linearGradient>
+
+          {/* Soft mask so the whole field fades into the page edges — nothing
+              hard-clips, so it reads as "excavated", not pasted on. */}
+          <radialGradient id="sf-fade" cx="22%" cy="72%" r="85%">
+            <stop offset="0%" stopColor="#fff" stopOpacity="1" />
+            <stop offset="70%" stopColor="#fff" stopOpacity="0.65" />
+            <stop offset="100%" stopColor="#fff" stopOpacity="0" />
+          </radialGradient>
+          <mask id="sf-fade-mask">
+            <rect x="-40" y="-40" width="720" height="440" fill="url(#sf-fade)" />
+          </mask>
+        </defs>
+
+        <g mask="url(#sf-fade-mask)">
+          {/* ---- DEPTH: layered contour basin around/under the node -------- */}
+          {/* Concentric contour rings imply a pocket in the field; they drift
+              slowly (breathing structure). Centred on the signal node. */}
+          <g className="sf-drift" stroke="url(#sf-contour-grad)" fill="none">
+            <ellipse cx="120" cy="250" rx="64" ry="30" strokeWidth="1" opacity="0.5" />
+            <ellipse cx="120" cy="250" rx="118" ry="54" strokeWidth="1" opacity="0.36" />
+            <ellipse cx="120" cy="250" rx="182" ry="82" strokeWidth="1" opacity="0.24" />
+            <ellipse cx="120" cy="250" rx="252" ry="112" strokeWidth="1" opacity="0.15" />
+            <ellipse cx="120" cy="250" rx="330" ry="146" strokeWidth="1" opacity="0.09" />
+          </g>
+
+          {/* A few open contour arcs sweeping across the whole field — the
+              structure extends well beyond the local pocket. */}
+          <g stroke="url(#sf-contour-grad)" fill="none" opacity="0.5">
+            <path d="M -20 318 C 150 300, 300 312, 470 286 S 640 250, 700 268" strokeWidth="1" />
+            <path d="M -20 350 C 180 338, 320 348, 500 320 S 660 296, 700 308" strokeWidth="1" />
+          </g>
+
+          {/* ---- EXPANDING RIPPLES: the signal propagating outward --------- */}
+          <g stroke="var(--sig-warm)" fill="none">
+            <circle className="sf-ripple" cx="120" cy="250" r="40" strokeWidth="1.2" />
+            <circle className="sf-ripple sf-ripple--2" cx="120" cy="250" r="40" strokeWidth="1.2" />
+            <circle className="sf-ripple sf-ripple--3" cx="120" cy="250" r="40" strokeWidth="1.2" />
+          </g>
+
+          {/* ---- COMPRESSION: ghost passes converging into the route ------- */}
+          <g stroke="url(#sf-route-grad)" fill="none" strokeLinecap="round">
+            {ghostRoutes.map((d, i) => (
+              <path
+                key={i}
+                className="sf-route--ghost"
+                d={d}
+                strokeWidth="1"
+                style={{ animationDelay: `${0.15 * i}s` }}
+              />
+            ))}
+          </g>
+
+          {/* ---- THE EARNED PATH: one confident route, rising -------------- */}
+          <path
+            className="sf-route"
+            d={mainRoute}
+            stroke="url(#sf-route-grad)"
+            strokeWidth="2.25"
+            strokeLinecap="round"
+          />
+
+          {/* ---- MEASURE: one ruthless scope rule across the field --------- */}
+          {/* A crisp vertical axis tick with a coordinate label — clean
+              judgment laid over the organic field. Placed at the compression
+              midpoint where the route resolves. */}
+          <g stroke="var(--color-fd-muted-foreground, #9b9bae)" opacity="0.5">
+            <line x1="360" y1="40" x2="360" y2="300" strokeWidth="0.75" strokeDasharray="3 5" />
+            <line x1="354" y1="40" x2="366" y2="40" strokeWidth="0.75" />
+            <line x1="354" y1="300" x2="366" y2="300" strokeWidth="0.75" />
+          </g>
+          <text
+            x="370"
+            y="52"
+            fill="var(--color-fd-muted-foreground, #9b9bae)"
+            opacity="0.55"
+            fontSize="10"
+            fontFamily="var(--font-mono, ui-monospace, monospace)"
+            letterSpacing="0.06em"
+          >
+            depth → signal
+          </text>
+
+          {/* ---- THE SIGNAL + THE ARRIVAL nodes ---------------------------- */}
+          {/* Resolved endpoint (embodiment) — quiet, warm, up-right. */}
+          <circle cx="556" cy="70" r="4.5" fill="url(#sf-node-grad)" opacity="0.92" />
+          <circle cx="556" cy="70" r="9" fill="none" stroke="var(--sig-warm)" strokeWidth="0.75" opacity="0.4" />
+
+          {/* The signal node — the bright origin, pulsing. */}
+          <circle className="sf-node" cx="120" cy="250" r="6" fill="url(#sf-node-grad)" />
+          <circle cx="120" cy="250" r="11" fill="none" stroke="var(--sig-warm)" strokeWidth="1" opacity="0.45" />
+        </g>
+      </svg>
+    </div>
+  );
+}
+
+export default SignalField;

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -3,15 +3,21 @@ title: "Introduction"
 description: "A local AI agent runner — terminal, daemon, and Telegram, sharing one session."
 ---
 
+<SignalField />
+
 Built on the Anthropic SDK, Agent AFK runs outside Claude Code as its own process — a full agentic runtime you own completely. Hand it long or multi-step work and check in asynchronously: it delegates the work and leaves the judgment to you.
 
 ```bash
 npm install -g agent-afk
 ```
 
+<div className="sig-cta">
+
 <Cards>
   <Card title="Get started →" href="/quickstart" description="Install, set your API key, and run your first command in under two minutes." />
 </Cards>
+
+</div>
 
 ## Who it's for
 
@@ -56,4 +62,8 @@ Agent AFK keeps all state under `~/.afk/` — sessions, memory, plugins, logs, d
 
 ---
 
+<div className="elevated-field">
+
 Ready to go deeper? Start with the [Quickstart](/quickstart), then see [How It Works](/how-it-works).
+
+</div>


### PR DESCRIPTION
**Farm-generated candidate 1 of 3** for the "subtle, reusable visual signature" brief on the docs site (docs.agentafk.com).

These three PRs (`website/visual-signature-1`, `-2`, `-3`) are **mutually-exclusive alternatives** produced by parallel [`afk farm`](https://github.com/griffinwork40/agent-afk) branches off `main@da072af`. Open them side by side (and compare deploy previews) to pick one — or cherry-pick ideas across them. **Opened as draft** for visual review.

### Approach
Tells the whole signature arc in one hero SVG: an orange signal node + expanding ripples over layered depth ellipses, **three faint "ghost" routes converging into one drawn path**, crossed by a dashed vertical scope axis labeled `depth → signal`.

**Motifs (3 — within the brief's "≤3" rule):**
- **signal-field** — bright node + radial ripple rings over descending-opacity depth ellipses
- **earned-path + scope-rule** — three ghost traces resolve into one animated route, crossed by a dashed measured axis
- **field-migration backdrop** — fixed radial gradient behind content (cool lower-left → warm upper-right)

### Signature arc (signal → depth → compression → rise → embodiment)
- **signal** — `sf-pulse` node + staggered `sf-ripple` rings
- **depth** — five concentric ellipses + slow `sf-drift` sway
- **compression** — ghost paths fade and settle into one `sf-draw` route *(the strongest "compression" beat of the three candidates)*
- **rise** — route climbs lower-left → upper-right on a cool→warm gradient
- **embodiment** — `.elevated-field` warm wrapper around the closing CTA

### Shared properties (all three candidates)
- **Additive only**, scoped **entirely to `website/`** (verified — nothing outside it changed)
- `prefers-reduced-motion` honored · mobile breakpoint present · **no new dependencies**

### Reviewer-flagged risks for this candidate
- The `[data-card]` hover transition (180ms) is **not** wrapped in the reduced-motion guard (minor).
- Inline-SVG gradient IDs are unscoped — placing `<SignalField/>` twice on one page would break the second instance's fills (it's used once today).
- Leans on `color-mix()` (modern browsers; degrades to the untinted border token).
- **Content integrity: clean** — no existing copy or links changed.

Full rationale lives in `website/VISUAL-SIGNATURE.md` on this branch.

---
🌾 Generated by `afk farm` (slug `20260615T183126-farm-task-evolve-the-agent-afk-d-65b4`). Sibling candidates: branches `website/visual-signature-2` and `website/visual-signature-3`.
