### PR TITLE
Docs visual signature — candidate 3/3: ambient basin + left-gutter scope-rule

### DIFF
--- a/website/VISUAL-SIGNATURE.md
+++ b/website/VISUAL-SIGNATURE.md
@@ -1,0 +1,192 @@
+# Visual Signature — Agent AFK docs
+
+A small, reusable visual layer added to the docs site (Next.js 15 + fumadocs)
+that encodes one worldview into the page without changing a single word of copy,
+a single link, or the existing brand identity:
+
+> **A small signal on the surface reveals hidden depth beneath it. You descend
+> into the real local complexity, find the structure that survives contact with
+> reality, compress repeated passes into an earned path, then rise into something
+> usable enough to live, build on, and share.**
+>
+> signal → depth → compression → rise → embodiment
+
+It is **additive and discovered, not decorative**. Nothing was recoloured,
+restructured, or removed; the signature is layered behind and around the
+existing fumadocs prose, nav, search, TOC, and the "Handoff Arc" brand mark.
+
+---
+
+## 1. What changed (files)
+
+| File | Change |
+|------|--------|
+| `app/(docs)/signature.css` | **New.** The whole visual system: tokens, named utility classes, keyframes, reduced-motion + responsive recomposition. ~490 lines, fully commented. |
+| `app/(docs)/_components/signature.tsx` | **New.** Five tiny presentational React wrappers + one inline topographic SVG (data-URI). No copy, no interactivity, no hooks. The `_` prefix makes it a Next.js private folder (never routed). |
+| `app/(docs)/layout.tsx` | +1 import (`./signature.css`) so the layer loads after the brand theme. |
+| `app/(docs)/[[...slug]]/page.tsx` | Mounts `<SignatureField />` (ambient backdrop) once per page; registers the five wrappers in the MDX component map so any `.mdx` page can use them. |
+| `content/docs/index.mdx` | The intro/hero wrapped in the signature wrappers. **All text and links unchanged**; two `---`/separators upgraded to `<Threshold />`. |
+
+No new dependencies. No build-system changes. No content edits.
+
+---
+
+## 2. The visual logic
+
+### The brand mark was already the Rosetta Stone
+
+The existing "Handoff Arc" glyph (`public/brand-mark.svg`) **already travels the
+whole arc**: a cool **grey endpoint node** → a routed **green arc** → a warm
+**orange "ping"** breaking through the gap. That is *signal → route →
+embodiment* compressed into one logo. The signature does not invent a new
+language; it **expands that single glyph's DNA** into the page's composition,
+backgrounds, section flow, and motion. Different pages feel like they came from
+the same hand because they inherit the same node→route→ping logic the logo
+already carries.
+
+The brand palette is reused verbatim — brand orange `#f9854b`, arc-green
+`#5cb87f`, structural grey — only *repositioned* along the depth→rise axis. The
+deep, cool basins are derived from the existing `--color-bg` family; the warm
+arrival light from `--color-accent`. Nothing is recoloured.
+
+### The compositional law: dense lower-left → resolved upper-right
+
+The brief's "dense lower-left → resolved upper-right" is expressed as **light,
+not layout** (so it never fights fumadocs' grid or mobile reflow). The ambient
+`deep-field` gathers a cool basin in the lower-left (where descent begins) and
+lets a faint warm wash rise toward the upper-right (where embodiment lives).
+The reader's eye starts deep and is drawn up-and-right along the route toward
+the CTA.
+
+### Three motifs, repeated with variation — not a collage
+
+Per the decision rule, only the **smallest coherent set** of motifs is used:
+
+1. **Signal over depth** — a small bright node with expanding concentric ripples,
+   sitting above a vast, faintly-contoured submerged field. The signal is small;
+   the implied system is enormous.
+2. **The earned path + one ruthless measure** — a thin left-gutter device that
+   pairs an organic *route* (cool→green→warm, the discovered path) with a crisp
+   *scope-rule* (a measured axis, ticks, and a single warm threshold marker).
+   "Organic depth + one ruthless line of measurement."
+3. **Rise into embodiment** — a warmer, lighter, more open *elevated-field* for
+   the CTA and the page's arrival zone, with a lit threshold edge brightening
+   outward (toward action).
+
+These three recur — in the hero, between sections (the `Threshold`), and inside
+feature cards (the `extract-field` route-edge) — so the whole page feels
+*governed by the same law* rather than sprinkled with effects.
+
+---
+
+## 3. Reusable tokens / components / utilities
+
+### CSS custom properties (in `signature.css`)
+Named after the motion so the system reads as its own worldview. All derived
+from existing brand tokens; light-theme overrides included.
+
+| Group | Tokens |
+|-------|--------|
+| Depth (cool, submerged) | `--afk-depth-1`, `--afk-depth-2`, `--afk-depth-line`, `--afk-depth-line-2` |
+| Signal (the bright node + ripple) | `--afk-signal`, `--afk-signal-ring`, `--afk-signal-glow` |
+| Route (the arc gradient) | `--afk-route-cool`, `--afk-route-mid`, `--afk-route-warm` |
+| Measure (the ruthless line) | `--afk-rule`, `--afk-rule-tick`, `--afk-rule-mark` |
+| Embodiment (warm arrival) | `--afk-warm-wash`, `--afk-warm-edge` |
+| Motion timing | `--afk-rise`, `--afk-t-ripple`, `--afk-t-drift` |
+
+### Utility classes
+| Class | Role |
+|-------|------|
+| `.afk-deep-field` | Page-wide ambient basin (cool lower-left → warm upper-right). |
+| `.afk-contour-layer` | Faint drifting topographic contours (inline SVG). |
+| `.afk-signal-field` | Hero wrapper: ripple + node behind content. |
+| `.afk-route` / `.afk-scope-rule` | Left-gutter earned-path + measured axis with marker. |
+| `.afk-scope-rule--inline` | Standalone measure you can attach to any heading/block. |
+| `.afk-elevated-field` | Warm arrival surface (CTA), lit threshold edge. |
+| `.afk-extract-field` | Wraps card grids; gives each card a carved recess + route-edge. |
+| `.afk-threshold` | A section transition that is a contour shift, not a generic `<hr>`. |
+
+### React components (in `_components/signature.tsx`)
+`<SignatureField />`, `<SignalField>`, `<ExtractField>`, `<ElevatedField>`,
+`<Threshold />`. All are pure presentational shells (server components, no
+hooks, `aria-hidden` decorative layers). Registered in the MDX map, so **any**
+docs page can adopt the system, not just the homepage.
+
+---
+
+## 4. How the page expresses each stage
+
+- **Signal** — the hero's small pulsing node + concentric ripples; the warm tick
+  on the scope-rule marking where the route first breaks the surface. A visible
+  symptom above a much larger hidden system.
+- **Depth** — the cool `deep-field` basin and faint topographic `contour-layer`
+  beneath everything; cards carry a cool recess pooling in their lower-left —
+  each artifact still remembers the depth it came from. Depth is honoured as
+  beautiful structure, not an ugly "before" state.
+- **Compression** — the `earned-path`: repeated cool→green lines converging into
+  one confident warm route, crossed by the ruthless `scope-rule`. Iteration
+  becoming a single leveraged path.
+- **Rise** — the warm/cool migration: cool discovery lower-left resolving to warm
+  use upper-right; the `Threshold` separators migrate cool→warm left-to-right;
+  card route-edges light from cool to warm on hover (the signal travelling).
+- **Embodiment** — the `elevated-field` CTA: the warmest, most open, lowest-
+  friction zone, with a lit threshold edge — cold depth fully risen into warm,
+  usable action.
+
+The emotional movement is **cold depth → earned route → warm use**, exactly as
+the brief asks — discovery inward, embodiment outward.
+
+---
+
+## 5. Accessibility, performance, responsiveness
+
+- **A11y** — every signature layer is `aria-hidden="true"` and
+  `pointer-events: none`; no new landmarks, no focus traps, no tab stops. Copy
+  contrast is untouched (fields sit behind content at low opacity). Verified in
+  both dark and light themes (near-black text on light bg stays well above AA).
+- **Reduced motion** — `@media (prefers-reduced-motion: reduce)` freezes *all*
+  animation while keeping the full composition intact (the node, rings, route,
+  and warm rise are meaningful at rest — they settle to a calm mid-state, no
+  layout shift, nothing disappears).
+- **Performance** — pure CSS gradients/masks + one ~670-byte inline SVG data-URI.
+  No images, no extra requests, no JS, no libraries. `will-change` only on the
+  single drifting layer.
+- **Responsive recomposition** — at ≤768px the left-gutter route shrinks and the
+  signal field tucks behind the heading; at ≤480px the absolute route is dropped
+  entirely (no gutter) and the signal-field + inline measure carry the identity.
+  Cards stack to one column. It **recomposes intentionally, never collapses into
+  rubble** (verified at 420px).
+
+All states above were rendered and visually verified (dark, light, hover, mobile).
+
+---
+
+## 6. Tradeoffs, omissions, future extensions
+
+**Tradeoffs**
+- The signature is intentionally *quiet*. It rewards a second look rather than
+  shouting — chosen deliberately over a louder hero, because this is a docs site
+  with an existing strong identity, and the brief says adapt, don't overwrite.
+- The motifs lean on fumadocs' `[data-card]` and `#nd-docs-layout` hooks. These
+  are the **versioned, officially-supported** selectors (per fumadocs'
+  customize-ui guide); we deliberately avoid structural selectors (`> div`) that
+  could break on upgrade. If fumadocs ever renames `[data-card]`, the
+  `extract-field`/`elevated-field` card treatments degrade gracefully to plain
+  cards (the wrappers still render; only the card-specific polish drops).
+
+**Omissions (by the decision rule — not every idea was used)**
+- No field-distortion / parallax-on-scroll. Scroll-linked motion would need JS
+  and risks competing with copy; the static composition already reads.
+- The signature is applied fully to the homepage hero; other pages currently get
+  only the ambient `deep-field` + `contour-layer`. This is intentional restraint
+  — the wrappers are wired into the MDX map so any page *can* opt in.
+
+**Future extensions**
+- Add `<SignalField>` to other high-intent pages (Quickstart hero, How-It-Works
+  opening) for a stronger cross-page through-line.
+- A `<ScopeRule>` MDX component using `.afk-scope-rule--inline` to annotate key
+  headings as measured thresholds.
+- A faint scroll-progress reveal on the `earned-path` (gated behind
+  `prefers-reduced-motion`) so the route "draws in" as the reader descends.
+- Promote the tokens into `globals.css` if the standalone marketing site
+  (agentafk.com, separate repo) wants to share the same signal→rise language.

--- a/website/app/(docs)/[[...slug]]/page.tsx
+++ b/website/app/(docs)/[[...slug]]/page.tsx
@@ -4,6 +4,13 @@ import { DocsPage, DocsBody, DocsDescription, DocsTitle } from 'fumadocs-ui/page
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import { Card, Cards } from 'fumadocs-ui/components/card';
 import { source } from '@/lib/source';
+import {
+  SignatureField,
+  SignalField,
+  ExtractField,
+  ElevatedField,
+  Threshold,
+} from '../_components/signature';
 
 interface Props {
   params: Promise<{ slug?: string[] }>;
@@ -19,10 +26,25 @@ export default async function Page({ params }: Props) {
 
   return (
     <DocsPage toc={page.data.toc} full={false}>
+      {/* Ambient signature backdrop — the submerged topographic field that
+          sits behind every docs page (deep-field + drifting contour-layer).
+          Pure presentation, aria-hidden, pointer-events:none. */}
+      <SignatureField />
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>
-        <MDX components={{ ...defaultMdxComponents, Card, Cards }} />
+        <MDX
+          components={{
+            ...defaultMdxComponents,
+            Card,
+            Cards,
+            // Signature wrappers, available to any MDX page.
+            SignalField,
+            ExtractField,
+            ElevatedField,
+            Threshold,
+          }}
+        />
       </DocsBody>
     </DocsPage>
   );

--- a/website/app/(docs)/_components/signature.tsx
+++ b/website/app/(docs)/_components/signature.tsx
@@ -1,0 +1,88 @@
+/* ==========================================================================
+   Agent AFK Docs — Visual Signature components
+   --------------------------------------------------------------------------
+   Reusable React wrappers that mount the signature system into MDX content.
+   They carry NO copy and NO interactivity — they are pure presentational
+   shells around existing prose, so content, links, search and a11y are
+   untouched. All visual weight lives in signature.css; these components only
+   place the named layers (deep-field, contour-layer, signal-field, route,
+   elevated-field, extract-field, threshold) around the right content.
+
+   Because they render no semantic landmarks of their own, they are safe to
+   drop into any docs page. The field layers are aria-hidden + pointer-events
+   none, so screen readers and keyboard users never encounter them.
+   ========================================================================== */
+import type { ReactNode } from 'react';
+
+/* Lightweight topographic contour as an inline SVG data URI. Concentric,
+   slightly irregular rings imply terrain basins/pockets rather than a perfect
+   bullseye — "topology, not decoration." Stroke colours are baked from the
+   brand DNA (arc-green + structural grey) at low alpha so it reads as faint
+   carved relief. Kept tiny (no runtime cost, no extra request).
+
+   Invariant: this string is a valid, URL-encoded SVG — keep the encoding of
+   '#', '<', '>' and quotes intact when editing or the background-image drops. */
+const CONTOUR_SVG = `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='600' height='600' viewBox='0 0 600 600'%3E%3Cg fill='none' stroke-width='1'%3E%3Cg stroke='%235cb87f' stroke-opacity='0.16'%3E%3Cpath d='M120 540 C 220 470, 250 360, 200 280 C 150 200, 60 190, 30 120'/%3E%3Cpath d='M170 560 C 290 480, 330 350, 280 250 C 235 160, 120 150, 90 70'/%3E%3Cpath d='M70 520 C 150 470, 175 380, 140 310 C 105 240, 30 235, 5 175'/%3E%3C/g%3E%3Cg stroke='%237c7c94' stroke-opacity='0.12'%3E%3Cpath d='M230 575 C 360 500, 415 360, 360 250 C 312 155, 180 150, 150 60'/%3E%3Cpath d='M300 585 C 440 510, 500 350, 445 235 C 398 135, 250 130, 225 40'/%3E%3C/g%3E%3Ccircle cx='150' cy='430' r='4' fill='%23f9854b' fill-opacity='0.30' stroke='none'/%3E%3C/g%3E%3C/svg%3E`;
+
+/**
+ * SignatureField — the page-wide ambient backdrop.
+ * Mounts the deep-field (cool basin lower-left -> warm rise upper-right) and
+ * the drifting contour-layer once per page, behind all content. Render it
+ * once near the top of a docs page; everything else paints over it.
+ */
+export function SignatureField() {
+  return (
+    <>
+      <div className="afk-deep-field" aria-hidden="true" />
+      <div
+        className="afk-contour-layer"
+        aria-hidden="true"
+        style={{ backgroundImage: `url("${CONTOUR_SVG}")` }}
+      />
+    </>
+  );
+}
+
+/**
+ * SignalField — the hero opening: a small bright signal over implied depth.
+ * Wraps the intro block. Adds the ripple/node field (law #1) and the left-edge
+ * earned-path + scope-rule (laws #3 + #5) behind the children. Children render
+ * normally on top, so the hero copy and its CTA are unchanged.
+ */
+export function SignalField({ children }: { children: ReactNode }) {
+  return (
+    <div className="afk-signal-field">
+      {/* the discovered route + its one ruthless measure, in the left gutter */}
+      <div className="afk-route" aria-hidden="true">
+        <div className="afk-scope-rule" />
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/**
+ * ExtractField — wraps a group of feature cards so each reads like an artifact
+ * extracted from the same deeper system (carved recess + route edge on hover),
+ * instead of a pile of disconnected boxes. Purely a styling scope.
+ */
+export function ExtractField({ children }: { children: ReactNode }) {
+  return <div className="afk-extract-field">{children}</div>;
+}
+
+/**
+ * ElevatedField — the warm arrival surface for the CTA / "Get started" zone.
+ * The most embodied part of the page: warmer light + a lit threshold edge.
+ */
+export function ElevatedField({ children }: { children: ReactNode }) {
+  return <div className="afk-elevated-field">{children}</div>;
+}
+
+/**
+ * Threshold — a section transition that is a contour shift, not a generic rule.
+ * Cool -> warm migration with a single measured tick at the crossing. Use in
+ * place of an <hr> between major zones. Decorative, so aria-hidden.
+ */
+export function Threshold() {
+  return <hr className="afk-threshold" aria-hidden="true" />;
+}

--- a/website/app/(docs)/layout.tsx
+++ b/website/app/(docs)/layout.tsx
@@ -4,6 +4,7 @@ import { RootProvider } from 'fumadocs-ui/provider/next';
 import { source } from '@/lib/source';
 import 'fumadocs-ui/style.css';
 import './docs-theme.css';
+import './signature.css';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (

--- a/website/app/(docs)/layout.tsx
+++ b/website/app/(docs)/layout.tsx
@@ -58,16 +58,8 @@ export default function Layout({ children }: { children: ReactNode }) {
           // the docs home — clicking the logo returns to the main site.
           url: 'https://agentafk.com',
         }}
-        // Nav links: the landing page (agentafk.com) and the GitHub repo.
-        // These docs are served at the docs.agentafk.com subdomain, so link
-        // back out to the main site; githubUrl renders Fumadocs' built-in
-        // GitHub icon button (no extra icon import needed).
-        links={[
-          {
-            text: 'agentafk.com',
-            url: 'https://agentafk.com',
-          },
-        ]}
+        // Nav: GitHub repo button only (the external agentafk.com sidebar link
+        // was removed per request). githubUrl renders Fumadocs' GitHub icon button.
         githubUrl="https://github.com/griffinwork40/agent-afk"
         sidebar={{
           defaultOpenLevel: 1,

--- a/website/app/(docs)/signature.css
+++ b/website/app/(docs)/signature.css
@@ -1,0 +1,496 @@
+/* ==========================================================================
+   Agent AFK Docs — Visual Signature System
+   --------------------------------------------------------------------------
+   A small reusable layer that encodes one worldview into the docs shell:
+
+     signal -> depth -> compression -> rise -> embodiment
+
+   It is NOT decoration. Every token below maps to a stage of that motion and
+   reuses the brand mark's own DNA — the "Handoff Arc" glyph already travels
+   from a cool grey node, through a green routed arc, to a warm orange ping.
+   This file expands that single glyph's logic into the page's composition.
+
+   Design constraints honoured here:
+     - Additive only. Scoped under #nd-docs-layout / dedicated .afk-* classes,
+       so fumadocs prose, nav, search, TOC and the brand mark are untouched.
+     - Targets only versioned fumadocs hooks (#nd-docs-layout) + our own
+       classes — never structural selectors fumadocs may change.
+     - Reuses existing brand tokens (globals.css / docs-theme.css). No recolor.
+     - All motion is gated behind prefers-reduced-motion. Text contrast and
+       responsive behaviour are preserved; the field sits behind content at
+       low opacity and recomposes (not collapses) on small screens.
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Signature tokens
+   --------------------------------------------------------------------------
+   Named after the motion so the system reads like its own worldview. Cool
+   tones bias toward DEPTH (discovery, inward); the warm brand orange biases
+   toward EMBODIMENT (action, outward). Derived from existing brand tokens —
+   nothing is recoloured, only positioned along the signal->rise axis.        */
+:root {
+  /* Depth — cool, dense, submerged. The hidden structure beneath the signal. */
+  --afk-depth-1:        #0a0a12;          /* deepest basin                     */
+  --afk-depth-2:        #0c1018;          /* cool shadow, faint blue cast      */
+  --afk-depth-line:     rgba(120, 188, 144, 0.10);  /* contour ink (arc-green) */
+  --afk-depth-line-2:   rgba(124, 124, 148, 0.07);  /* faint structural grey   */
+
+  /* Signal — the small bright node + its ripple. Brand orange, ping-derived. */
+  --afk-signal:         rgba(249, 133, 75, 0.55);    /* node core             */
+  --afk-signal-ring:    rgba(249, 133, 75, 0.18);    /* expanding ripple      */
+  --afk-signal-glow:    rgba(249, 133, 75, 0.10);    /* ambient haze          */
+
+  /* Route — the earned path. The arc gradient: grey -> green -> orange.       */
+  --afk-route-cool:     #6e7a86;          /* origin (the grey endpoint node)   */
+  --afk-route-mid:      #5cb87f;           /* the green arc                     */
+  --afk-route-warm:     #f9854b;           /* arrival (the warm ping)           */
+
+  /* Measure — the one ruthless line. Crisp, neutral, high-legibility.         */
+  --afk-rule:           rgba(155, 155, 174, 0.30);   /* axis / scope line     */
+  --afk-rule-tick:      rgba(155, 155, 174, 0.55);   /* threshold ticks       */
+  --afk-rule-mark:      var(--color-accent);          /* the active marker     */
+
+  /* Embodiment — warm, open, elevated. The arrival surface.                   */
+  --afk-warm-wash:      rgba(249, 133, 75, 0.06);    /* faint warm light      */
+  --afk-warm-edge:      rgba(249, 133, 75, 0.30);    /* lit threshold edge    */
+
+  /* Motion timing — slow, geological. Discovery is patient.                   */
+  --afk-rise:           cubic-bezier(0.16, 0.84, 0.30, 1);
+  --afk-t-ripple:       7s;
+  --afk-t-drift:        24s;
+}
+
+/* Light theme: depth basins lighten so the field reads as paper relief rather
+   than a dark void, while the route + warm tokens keep the same brand hue.    */
+:root:not(.dark) {
+  --afk-depth-1:        #eef0f2;
+  --afk-depth-2:        #e7eaee;
+  --afk-depth-line:     rgba(92, 184, 127, 0.16);
+  --afk-depth-line-2:   rgba(90, 90, 114, 0.10);
+  --afk-signal:         rgba(232, 104, 42, 0.55);
+  --afk-signal-ring:    rgba(232, 104, 42, 0.16);
+  --afk-signal-glow:    rgba(232, 104, 42, 0.08);
+  --afk-rule:           rgba(90, 90, 114, 0.30);
+  --afk-rule-tick:      rgba(90, 90, 114, 0.55);
+  --afk-warm-wash:      rgba(232, 104, 42, 0.05);
+  --afk-warm-edge:      rgba(232, 104, 42, 0.28);
+}
+
+/* --------------------------------------------------------------------------
+   2. deep-field — the page-wide submerged backdrop
+   --------------------------------------------------------------------------
+   A fixed, behind-everything topographic field. It implies a vast structure
+   beneath the docs: cool basins gathered in the lower-left (where descent
+   begins) resolving toward a warmer, lighter, more open upper-right (where
+   embodiment lives). This is the compositional law from the brief —
+   "dense lower-left -> resolved upper-right" — expressed as light, not layout.
+
+   It is purely ambient: pointer-events:none, very low opacity, sits at z -1
+   behind the fumadocs grid so prose contrast is never affected.              */
+#nd-docs-layout {
+  position: relative;
+  isolation: isolate;            /* keep the field's stacking local           */
+}
+
+.afk-deep-field {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  /* Composite three intentions:
+     (a) a cool, dense basin anchored lower-left  — descent
+     (b) a faint warm rise toward upper-right     — embodiment
+     (c) a near-black vignette floor              — the depth below depth     */
+  background:
+    radial-gradient(
+      120% 90% at 8% 100%,
+      var(--afk-depth-2) 0%,
+      transparent 55%
+    ),
+    radial-gradient(
+      90% 80% at 100% 0%,
+      var(--afk-warm-wash) 0%,
+      transparent 45%
+    ),
+    radial-gradient(
+      140% 120% at 50% 120%,
+      var(--afk-depth-1) 0%,
+      transparent 60%
+    );
+  opacity: 0.9;
+}
+
+/* contour-layer — faint topographic rings carved into the depth. An inline
+   SVG (set via background-image data URI on the element) draws concentric
+   contour pockets, so the field reads as *terrain with structure* rather than
+   a flat gradient. Drifts almost imperceptibly. The SVG itself lives on the
+   element's style (see SignatureField.tsx) so the stroke colour can inherit
+   theme tokens; here we own only its placement + motion.                     */
+.afk-contour-layer {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-repeat: no-repeat;
+  background-position: -6% 110%;     /* anchored lower-left, like the basin   */
+  background-size: 75vmax 75vmax;
+  opacity: 0.5;
+  will-change: transform;
+  animation: afk-contour-drift var(--afk-t-drift) ease-in-out infinite alternate;
+}
+
+@keyframes afk-contour-drift {
+  from { transform: translate3d(0, 0, 0) scale(1); }
+  to   { transform: translate3d(2.2%, -1.6%, 0) scale(1.04); }
+}
+
+/* --------------------------------------------------------------------------
+   3. signal-field — the hero's small-signal-over-vast-depth opening
+   --------------------------------------------------------------------------
+   Wraps the top of a page (the intro / hero). A single bright NODE sits at the
+   origin of the route; concentric RIPPLES expand from it (the visible signal)
+   while the surrounding darkened field implies the submerged system. The node
+   is small; the implied structure is large. This is the clearest statement of
+   law #1.                                                                     */
+.afk-signal-field {
+  position: relative;
+  isolation: isolate;
+}
+
+/* The ripple stack: two expanding rings + an ambient glow, painted behind the
+   hero content. Positioned to the lower-left of the heading so the eye starts
+   deep and is drawn up-and-right along the route toward the CTA.             */
+.afk-signal-field::before {
+  content: "";
+  position: absolute;
+  /* anchor near the lower-left of the hero block                            */
+  left: -2.2rem;
+  top: 1.2rem;
+  width: 16rem;
+  height: 16rem;
+  pointer-events: none;
+  z-index: -1;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at center, var(--afk-signal-glow) 0%, transparent 62%);
+  /* concentric signal rings drawn as hard-stop radial bands                  */
+  -webkit-mask: radial-gradient(circle, #000 99%, transparent 100%);
+          mask: radial-gradient(circle, #000 99%, transparent 100%);
+  background-image:
+    radial-gradient(circle at center, transparent 0 24%, var(--afk-signal-ring) 24% 25%, transparent 25%),
+    radial-gradient(circle at center, transparent 0 44%, var(--afk-signal-ring) 44% 45%, transparent 45%),
+    radial-gradient(circle at center, transparent 0 66%, var(--afk-signal-ring) 66% 67%, transparent 67%),
+    radial-gradient(circle at center, var(--afk-signal-glow) 0%, transparent 62%);
+  animation: afk-ripple var(--afk-t-ripple) var(--afk-rise) infinite;
+}
+
+/* The node itself — the small bright point the rings emanate from. */
+.afk-signal-field::after {
+  content: "";
+  position: absolute;
+  left: calc(-2.2rem + 8rem - 4px);   /* centre of the ripple field          */
+  top: calc(1.2rem + 8rem - 4px);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: -1;
+  background: var(--afk-signal);
+  box-shadow: 0 0 12px 2px var(--afk-signal-ring);
+  animation: afk-node-pulse var(--afk-t-ripple) var(--afk-rise) infinite;
+}
+
+@keyframes afk-ripple {
+  0%   { transform: scale(0.82); opacity: 0.35; }
+  50%  { opacity: 0.85; }
+  100% { transform: scale(1.06); opacity: 0; }
+}
+
+@keyframes afk-node-pulse {
+  0%, 100% { opacity: 0.55; transform: scale(1); }
+  50%      { opacity: 1;    transform: scale(1.18); }
+}
+
+/* --------------------------------------------------------------------------
+   4. earned-path + scope-rule — the route and the one ruthless measure
+   --------------------------------------------------------------------------
+   A thin vertical device pinned to the left of the hero. It pairs:
+     - earned-path : a braided trace of repeated lines converging into one
+                     confident route (iteration -> compression -> a path).
+     - scope-rule  : a crisp measured axis with threshold ticks and an active
+                     marker — the clean judgment crossing the organic field.
+   Together they read as "a route the system had to discover," measured.      */
+.afk-route {
+  position: absolute;
+  left: -1.75rem;
+  top: 0.25rem;
+  bottom: -0.5rem;
+  width: 1.25rem;
+  pointer-events: none;
+  z-index: -1;
+}
+
+/* The scope-rule: a hairline axis with evenly measured ticks. The single warm
+   marker sits near the TOP (arrival), echoing the route resolving upward.    */
+.afk-scope-rule {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    var(--afk-rule) 12%,
+    var(--afk-rule) 88%,
+    transparent 100%
+  );
+}
+/* Measured ticks: a repeating gradient of short horizontal marks. */
+.afk-scope-rule::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 6%;
+  bottom: 6%;
+  width: 6px;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    var(--afk-rule-tick) 0 1px,
+    transparent 1px 1.05rem
+  );
+}
+/* The active threshold marker — the moment the route breaks the surface. */
+.afk-scope-rule::after {
+  content: "";
+  position: absolute;
+  left: -2px;
+  top: 9%;
+  width: 9px;
+  height: 1px;
+  background: var(--afk-rule-mark);
+  box-shadow: 0 0 6px var(--afk-signal);
+}
+
+/* As a standalone reusable utility, the scope-rule can also annotate any block
+   (e.g. a section heading) when used directly on an element edge.            */
+.afk-scope-rule--inline {
+  position: relative;
+  padding-left: 1rem;
+}
+.afk-scope-rule--inline::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.15em;
+  bottom: 0.15em;
+  width: 2px;
+  border-radius: 2px;
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    var(--afk-route-cool) 0%,
+    var(--afk-route-mid) 55%,
+    var(--afk-route-warm) 100%
+  );
+}
+
+/* --------------------------------------------------------------------------
+   5. elevated-field — the warm arrival surface (embodiment)
+   --------------------------------------------------------------------------
+   Applied to the CTA / "Get started" zone: the most embodied part of the page.
+   Warmer light, a lit threshold edge along the top (the surface broken into),
+   and the least visual friction. This is where cold depth has fully risen
+   into warm use. Reusable on any card or block meant to feel like arrival.   */
+.afk-elevated-field {
+  position: relative;
+  border-radius: var(--radius-lg);
+  background:
+    radial-gradient(120% 140% at 100% 0%, var(--afk-warm-wash) 0%, transparent 55%),
+    linear-gradient(180deg, var(--afk-warm-wash) 0%, transparent 40%);
+  isolation: isolate;
+}
+/* The lit threshold edge: a warm top hairline that brightens toward the right
+   (outward, the action side).                                                */
+.afk-elevated-field::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 1px;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--afk-route-mid) 20%,
+    var(--afk-warm-edge) 100%
+  );
+  pointer-events: none;
+}
+
+/* Give the embodiment card's contents a touch more breathing room so it reads
+   as "open" relative to the denser sections above. Scoped to our wrapper so it
+   only affects the arrival zone, not all cards.                              */
+.afk-elevated-field [data-card] {
+  background:
+    linear-gradient(180deg, rgba(249, 133, 75, 0.04) 0%, transparent 60%),
+    var(--color-fd-card);
+  border-color: color-mix(in srgb, var(--color-fd-border) 70%, var(--afk-route-warm) 30%);
+  transition: border-color var(--t-base, 180ms) var(--afk-rise),
+              box-shadow var(--t-base, 180ms) var(--afk-rise),
+              transform var(--t-base, 180ms) var(--afk-rise);
+}
+.afk-elevated-field [data-card]:hover {
+  border-color: var(--afk-warm-edge);
+  box-shadow: 0 0 0 1px var(--afk-warm-wash), 0 8px 30px -12px var(--afk-signal-ring);
+}
+
+/* --------------------------------------------------------------------------
+   6. afk-extract — feature cards as artifacts pulled from the field
+   --------------------------------------------------------------------------
+   The brief warns against "a pile of disconnected cards." We don't restructure
+   fumadocs Cards (that would risk a11y/content); instead we give them a quiet
+   shared treatment so each reads like a resolved form extracted from the same
+   deeper system: a faint cool inner-shadow recess + a warm left-edge that
+   lights on hover, echoing the route. Applied via a wrapper class so it only
+   touches cards we opt in, and degrades to plain cards if unstyled.          */
+.afk-extract-field [data-card] {
+  position: relative;
+  overflow: hidden;
+  transition: border-color var(--t-base, 180ms) var(--afk-rise),
+              transform var(--t-base, 180ms) var(--afk-rise),
+              box-shadow var(--t-base, 180ms) var(--afk-rise);
+}
+/* The carved recess: a faint cool gradient pooling in the lower-left of each
+   card — the artifact still carries the depth it came from.                  */
+.afk-extract-field [data-card]::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background: radial-gradient(
+    90% 90% at 0% 100%,
+    var(--afk-depth-line-2) 0%,
+    transparent 55%
+  );
+  opacity: 0.9;
+}
+/* The route edge: a thin left band that lights from cool to warm on hover —
+   the signal travelling the path. */
+.afk-extract-field [data-card]::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  z-index: 1;
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    var(--afk-route-cool) 0%,
+    var(--afk-route-mid) 100%
+  );
+  opacity: 0.45;
+  transition: opacity var(--t-base, 180ms) var(--afk-rise),
+              background var(--t-base, 180ms) var(--afk-rise);
+}
+.afk-extract-field [data-card]:hover {
+  transform: translateY(-2px);
+}
+.afk-extract-field [data-card]:hover::before {
+  opacity: 1;
+  background: linear-gradient(
+    to bottom,
+    var(--afk-route-mid) 0%,
+    var(--afk-route-warm) 100%
+  );
+}
+/* keep card text above the recess */
+.afk-extract-field [data-card] > * { position: relative; z-index: 1; }
+
+/* --------------------------------------------------------------------------
+   7. afk-threshold — a section transition that is a contour shift, not a rule
+   --------------------------------------------------------------------------
+   A reusable replacement for a generic <hr>. Reads as a measured threshold
+   crossing the field: a hairline that migrates cool -> warm left-to-right with
+   a single tick at the crossing point. Use sparingly between major zones.    */
+.afk-threshold {
+  position: relative;
+  height: 1px;
+  margin: 2.5rem 0;
+  border: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--afk-route-cool) 18%,
+    var(--afk-route-mid) 52%,
+    var(--afk-warm-edge) 86%,
+    transparent 100%
+  );
+  opacity: 0.6;
+}
+.afk-threshold::before {
+  content: "";
+  position: absolute;
+  left: 52%;
+  top: -3px;
+  width: 1px;
+  height: 7px;
+  pointer-events: none;
+  background: var(--afk-rule-mark);
+  box-shadow: 0 0 6px var(--afk-signal);
+}
+
+/* --------------------------------------------------------------------------
+   8. Reduced motion — discovery still holds its shape, it just stops moving
+   --------------------------------------------------------------------------
+   The field is meaningful at rest: the node, rings, route and warm rise are
+   all static compositions. Under reduced-motion we freeze every animation but
+   keep the full visual system intact (no layout shift, no disappearance).    */
+@media (prefers-reduced-motion: reduce) {
+  .afk-contour-layer,
+  .afk-signal-field::before,
+  .afk-signal-field::after {
+    animation: none !important;
+  }
+  /* settle the ripple to a calm, legible mid-state rather than mid-transition */
+  .afk-signal-field::before { transform: scale(0.96); opacity: 0.6; }
+  .afk-signal-field::after  { opacity: 0.7; transform: none; }
+}
+
+/* --------------------------------------------------------------------------
+   9. Responsive recomposition — recompose, don't collapse
+   --------------------------------------------------------------------------
+   On narrow screens the left-margin route/scope devices have no gutter to live
+   in, so they recompose into the flow rather than overflowing: the route hugs
+   the content's left edge and the signal field shrinks and tucks behind the
+   heading. The deep-field + contour stay (they're ambient and full-bleed).   */
+@media (max-width: 768px) {
+  .afk-route {
+    left: -0.85rem;
+    width: 0.85rem;
+  }
+  .afk-signal-field::before {
+    left: -1rem;
+    top: 0.5rem;
+    width: 11rem;
+    height: 11rem;
+  }
+  .afk-signal-field::after {
+    left: calc(-1rem + 5.5rem - 4px);
+    top: calc(0.5rem + 5.5rem - 4px);
+  }
+  .afk-contour-layer {
+    background-size: 110vmax 110vmax;
+    opacity: 0.4;
+  }
+}
+
+/* Very small screens: drop the absolute route entirely (no gutter at all) and
+   let the inline scope-rule carry the measure motif instead.                 */
+@media (max-width: 480px) {
+  .afk-route { display: none; }
+}

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -40,6 +40,8 @@ Every surface shares the same context, memory, and tools — so work started in 
 </Cards>
 </ExtractField>
 
+<Threshold />
+
 ## Key capabilities
 
 <ExtractField>
@@ -52,6 +54,8 @@ Every surface shares the same context, memory, and tools — so work started in 
   <Card title="Unattended guardrails" href="/guides/unattended-runs" description="Cost ceilings, turn limits, and worktree isolation keep long unattended runs in bounds." />
 </Cards>
 </ExtractField>
+
+<Threshold />
 
 ## Safety & verification controls
 

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -3,15 +3,21 @@ title: "Introduction"
 description: "A local AI agent runner — terminal, daemon, and Telegram, sharing one session."
 ---
 
+<SignalField>
+
 Built on the Anthropic SDK, Agent AFK runs outside Claude Code as its own process — a full agentic runtime you own completely. Hand it long or multi-step work and check in asynchronously: it delegates the work and leaves the judgment to you.
 
 ```bash
 npm install -g agent-afk
 ```
 
+<ElevatedField>
 <Cards>
   <Card title="Get started →" href="/quickstart" description="Install, set your API key, and run your first command in under two minutes." />
 </Cards>
+</ElevatedField>
+
+</SignalField>
 
 ## Who it's for
 
@@ -19,19 +25,24 @@ npm install -g agent-afk
 - **Engineers** running headless, CI-adjacent workflows that need model reasoning, bash access, and subagent orchestration without a human in the loop.
 - **Anyone** who wants Telegram supervision — a phone ping the moment work lands in a terminal (finished) state — without standing up a server.
 
+<Threshold />
+
 ## Four surfaces, one session manager
 
 Every surface shares the same context, memory, and tools — so work started in one can be picked up in another.
 
+<ExtractField>
 <Cards>
   <Card title="One-Shot Chat" href="/surfaces/chat" description="afk chat — a single pipe-friendly turn that scripts well." />
   <Card title="Interactive REPL" href="/surfaces/repl" description="afk i — slash commands, plan mode, and streaming output." />
   <Card title="Daemon" href="/surfaces/daemon" description="afk daemon — a long-running, cron-friendly headless agent." />
   <Card title="Telegram Bot" href="/surfaces/telegram" description="afk telegram start — the same tools and memory, on your phone." />
 </Cards>
+</ExtractField>
 
 ## Key capabilities
 
+<ExtractField>
 <Cards>
   <Card title="Subagent orchestration" href="/guides/subagents" description="Run many subagents at once — independent tasks run in parallel, dependent ones wait their turn." />
   <Card title="Slash skills" href="/skills/overview" description="A registry of built-in slash commands plus auto-discovered SKILL.md plugins, with typo-tolerant command suggestions." />
@@ -40,6 +51,7 @@ Every surface shares the same context, memory, and tools — so work started in 
   <Card title="Telegram supervision" href="/surfaces/telegram" description="Get a phone ping when a scheduled task lands, then reply to drive the session from anywhere." />
   <Card title="Unattended guardrails" href="/guides/unattended-runs" description="Cost ceilings, turn limits, and worktree isolation keep long unattended runs in bounds." />
 </Cards>
+</ExtractField>
 
 ## Safety & verification controls
 
@@ -54,6 +66,6 @@ Agent AFK ships blast-radius controls — the guardrails that keep unattended ru
 
 Agent AFK keeps all state under `~/.afk/` — sessions, memory, plugins, logs, daemon state. There is no analytics or remote telemetry: it never sends your prompts, code, or usage anywhere except directly to the model provider you configure. What telemetry exists is local JSONL you can read or delete.
 
----
+<Threshold />
 
 Ready to go deeper? Start with the [Quickstart](/quickstart), then see [How It Works](/how-it-works).


### PR DESCRIPTION
**Farm-generated candidate 3 of 3** for the "subtle, reusable visual signature" brief on the docs site (docs.agentafk.com).

These three PRs (`website/visual-signature-1`, `-2`, `-3`) are **mutually-exclusive alternatives** produced by parallel [`afk farm`](https://github.com/griffinwork40/agent-afk) branches off `main@da072af`. Open them side by side (and compare deploy previews) to pick one — or cherry-pick ideas across them. **Opened as draft** for visual review.

### Approach
The most **ambient** of the three: a fixed topographic "basin" backdrop (cool lower-left → warm upper-right) with a pulsing node + ripples in the hero, and a distinctive **left-gutter "scope-rule"** — a vertical measured axis with repeating ticks — as the measure motif. Warm elevated CTA.

**Motifs (3 — within the brief's "≤3" rule):**
- **signal-over-depth** — node + ripple rings over a multi-layer radial basin
- **earned-path / scope-rule** — left-gutter vertical hairline with repeating ticks + a warm threshold marker (the most restrained "measure" device of the three)
- **elevated arrival** — warm wash + lit top hairline on the CTA

### Signature arc (signal → depth → compression → rise → embodiment)
- **signal** — pulsing node + expanding ripple rings
- **depth** — fixed topographic SVG backdrop with a 24s drift
- **compression** — ⚠️ **not explicitly addressed** (routes converge but there's no many-to-one animation)
- **rise** — deep-field gradient shifts cool→warm lower-left → upper-right
- **embodiment** — `ElevatedField` CTA with a lit threshold edge

### Shared properties (all three candidates)
- **Additive** (swaps two `---` separators for a semantically-equivalent `<Threshold/>`); scoped **entirely to `website/`** (verified)
- `prefers-reduced-motion` honored · two mobile breakpoints · **no new dependencies**

### Reviewer-flagged risks for this candidate
- Largest CSS of the three (~496 lines).
- `will-change: transform` keeps a **persistent GPU compositor layer on every docs page** for a near-imperceptible drift — consider removing.
- Fixed full-viewport backdrop can add paint cost on iOS Safari for long pages.
- **Skips the "compression" beat** — the only candidate that drops one of the five.
- Leans on `color-mix()`; route is hidden below 480px (graceful).

Full rationale lives in `website/VISUAL-SIGNATURE.md` on this branch.

---
🌾 Generated by `afk farm` (slug `20260615T183126-farm-task-evolve-the-agent-afk-d-65b4`). Sibling candidates: branches `website/visual-signature-1` and `website/visual-signature-2`.
