### PR TITLE
docs: document cross-session memory (README section + docs-site guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ afk chat "hello"
 - **Built-in orchestrators** — `/mint`, `/diagnose`, `/spec`, `/research`, `/ship`, `/review` dispatch subagent waves. `/mint` takes a feature idea and runs spec → research → plan → parallelize → build → verify → ship. `/diagnose` forks parallel root-cause hypotheses for failing tests and bugs.
 
 > **Agent AFK Pro:** Autonomous skill-generation (`/forge`) and the calibrated skill-qualification rubric (`/qualify`) are reserved for Agent AFK Pro and are not part of the open-source build.
-- **Cross-session memory** — Claude remembers preferences, decisions, and procedures across runs. Backed by SQLite at `~/.afk/agent-framework/memory/` plus a `HOT.md` that injects into every future session's system prompt.
+- **Cross-session memory** — Claude remembers preferences, decisions, and procedures across runs. See [Memory](#memory) below.
 - **Background subagent jobs** — dispatch a subagent with `mode:'background'`; `/bgsub` lists running and completed jobs, `/bgsub:join <id>` retrieves the result.
 
 ## Four surfaces, one session manager
@@ -81,6 +81,34 @@ AFK_MAX_BUDGET_USD=5.00
 **Project-scoped system prompt.** Drop an `AFK.md` at your project root and `afk` appends it to its built-in framework prompt whenever you run from that directory — your instructions layer on top of the base, they don't replace it. No frontmatter needed.
 
 **Check what resolved.** `afk config` dumps the live configuration. `afk doctor` validates keys, paths, and provider connectivity.
+
+## Memory
+
+Claude remembers things across sessions — preferences, decisions, conventions, and reusable procedures — without any manual setup. Memory is local-only and stored under `~/.afk/state/memory/`.
+
+**Two storage tiers:**
+
+- **Hot memory** (`~/.afk/state/memory/HOT.md`) — a small markdown file (≤ ~1,500 tokens) injected into every future session's system prompt automatically. Use it for the facts you want Claude to always carry: your name, working style, standing instructions. Capped at 5,250 characters; overflow is truncated with a sentinel comment.
+- **Fact archive** (`~/.afk/state/memory/memory.db`) — an unbounded SQLite store, full-text-searchable via FTS5. Facts are queried on demand with the `memory_search` tool; they don't bloat every prompt.
+
+**Fact categories** (set when writing to the archive):
+
+| Category | What to put here |
+|---|---|
+| `preference` | Working style, formatting, tool choices |
+| `convention` | Naming rules, file layout, team norms |
+| `decision` | Architecture choices and the reasoning behind them |
+| `learning` | Bugs found, lessons from past runs |
+
+**Tools available inside a session:**
+
+- `memory_search` — full-text search across facts and procedures (supports FTS5: `AND`, `OR`, `NOT`, `"exact phrase"`, `prefix*`).
+- `memory_update` — write or supersede a fact in the archive (`target: "fact"`) or overwrite hot memory (`target: "hot"`).
+- `procedure_write` — save a reusable step-by-step workflow as a named markdown file under `~/.afk/state/memory/procedures/`. Procedures are searchable via `memory_search`.
+
+Hot memory is injected at session start; `memory_search` is called explicitly during a run. The session-end hook logs each completed top-level session to the archive automatically — subagent sessions are excluded.
+
+All four surfaces (REPL, chat, daemon, Telegram) share the same store — memory written in one surface is available everywhere.
 
 ## Models
 

--- a/website/content/docs/guides/memory.mdx
+++ b/website/content/docs/guides/memory.mdx
@@ -1,0 +1,165 @@
+---
+title: "Cross-Session Memory"
+description: "How Agent AFK stores and retrieves facts, procedures, and hot context across sessions — automatically, locally, with no external service required."
+---
+
+Agent AFK maintains persistent memory across sessions automatically. Everything is stored locally in `~/.afk/state/memory/` — no cloud sync, no external service. Memory is available on every surface: the REPL, Telegram bot, CLI `chat`, and daemon sessions.
+
+## Two storage tiers
+
+Memory is split into two tiers with different purposes and access patterns:
+
+| Tier | File | Best for |
+|---|---|---|
+| **Hot memory** | `~/.afk/state/memory/HOT.md` | Identity, top preferences, active project pointer — things needed in every prompt |
+| **Fact archive** | `~/.afk/state/memory/memory.db` | Everything else: decisions, conventions, learnings, project details |
+
+### Hot memory (HOT.md)
+
+**Path:** `~/.afk/state/memory/HOT.md`
+
+Hot memory is injected verbatim into the system prompt of every session before any other context. It is the first thing AFK reads at the start of each turn.
+
+**Capacity:** The hard cap is **5,250 characters (~1,500 tokens)**. Content beyond this limit is truncated from the end — the last entries to be written are the first to be cut. The first 600 characters are never sacrificed; content is always preserved from the top down.
+
+**Atomic writes:** HOT.md is written atomically (write to a temp file, then rename). A backup copy is kept at `~/.afk/state/memory/HOT.md.bak` reflecting the previous state.
+
+**Best for:**
+- User identity (name, timezone, role)
+- 2–3 top durable preferences
+- A one-line pointer to the active project (name + path)
+
+<Callout type="info">
+HOT.md is injected into **every session on every surface**. Keep it short. Store project-specific conventions and detailed context in the fact archive instead — it is unbounded and searchable. If it doesn't need to be in every prompt forever, it's a fact, not hot.
+</Callout>
+
+### Fact archive (memory.db)
+
+**Path:** `~/.afk/state/memory/memory.db`
+
+The fact archive is a SQLite database with WAL mode enabled and FTS5 full-text search. It is unbounded — there is no size cap.
+
+Facts are searched using FTS5 match syntax, which supports:
+- `AND`, `OR`, `NOT` operators
+- `"exact phrase"` matching with quotes
+- `prefix*` prefix matching
+
+When updating an existing fact, use the **supersede** action rather than removing and re-adding. Supersede replaces the active fact while keeping the original in history for audit purposes.
+
+### Procedures
+
+**Path pattern:** `~/.afk/state/memory/procedures/<name>.md`
+
+Procedures are markdown files that describe reusable multi-step workflows. Each procedure is stored as a separate file with a kebab-case filename (e.g., `deploy-to-staging.md`).
+
+Procedures support optional frontmatter fields for metadata. They are searched by **substring match** (not FTS5), so simple keywords work reliably.
+
+## On-disk layout
+
+```
+~/.afk/state/memory/
+├── HOT.md
+├── HOT.md.bak
+├── memory.db
+└── procedures/
+```
+
+## Fact categories
+
+Every fact stored in the archive is tagged with one of four categories:
+
+| Category | What to store | Example |
+|---|---|---|
+| `preference` | User preferences, style choices, things to avoid | "I prefer TypeScript strict mode" |
+| `convention` | Non-obvious project conventions discovered during investigation | "This repo uses `pnpm` exclusively, not `npm`" |
+| `decision` | Key decisions with rationale, architectural choices | "Chose Zod over Yup because the team already uses it in the API layer" |
+| `learning` | Surprising findings from debugging or exploration | "WAL mode must be enabled before the first write or the DB ignores it" |
+
+## Memory tools
+
+Three tools manage memory:
+
+| Tool | Purpose |
+|---|---|
+| `memory_search` | Retrieve facts and procedures by relevance |
+| `memory_update` | Create, update, or remove facts and hot memory |
+| `procedure_write` | Save or overwrite a named procedure |
+
+### memory_search
+
+Searches the fact archive and procedures by relevance. Returns results ranked by match quality.
+
+**Parameters:**
+- `query` — FTS5 match string (required)
+- `category` — filter to one category: `preference`, `convention`, `decision`, or `learning` (optional)
+- `limit` — max results to return, default 10 (optional)
+- `since` — ISO date string; only return facts created after this date (optional)
+
+**FTS5 syntax examples:**
+
+```
+"exact phrase"           -- match the phrase literally
+TypeScript AND strict    -- both terms must appear
+deploy OR release        -- either term
+postgres NOT sqlite      -- exclude sqlite
+pnpm*                    -- prefix match (pnpm, pnpm-lock, etc.)
+```
+
+### memory_update
+
+Creates, updates, or removes entries in hot memory or the fact archive.
+
+**`target` values:**
+- `"fact"` — write to the searchable SQLite archive (default for almost everything)
+- `"hot"` — write to HOT.md (system prompt injection)
+
+**`action` values:**
+- `"set"` — create or overwrite
+- `"supersede"` — replace an existing fact while keeping its history; requires `supersedes: <id>`
+- `"remove"` — delete a fact by ID; requires `id: <id>`
+
+**`category`** is required when `target` is `"fact"`: one of `preference`, `convention`, `decision`, `learning`.
+
+Use `supersede` (not `remove` + `set`) when updating a fact that already exists. This preserves history and avoids duplicate entries.
+
+### procedure_write
+
+Saves or overwrites a reusable procedure.
+
+**Parameters:**
+- `name` — kebab-case filename without extension (e.g., `deploy-to-staging`). The tool writes to `~/.afk/state/memory/procedures/<name>.md`.
+- `content` — full markdown content of the procedure
+
+Procedures are searchable via `memory_search`. Use them for recurring multi-step workflows that you want available in future sessions.
+
+## Automatic lifecycle
+
+**Session start:** At the beginning of each session, AFK reads HOT.md and injects it into the system prompt. The model sees this content before processing the first user message.
+
+**During the session:** New facts, hot-memory updates, and procedures are written by the agent through the memory tools (`memory_update`, `procedure_write`) as it works — for example, when it discovers a preference, decision, or convention worth keeping for next time.
+
+**Session end:** A `SessionEnd` hook records the session itself in the archive (used for session history). It runs on every session end, independent of whether any facts were written during the session.
+
+**Subagent exclusion:** Only the top-level (coordinating) session can write memory. Subagents — sessions that carry a `parentSessionId` — are given the read-only `memory_search` tool, never `memory_update` or `procedure_write`, and the `SessionEnd` hook skips them entirely. This prevents parallel workers from polluting the store with duplicate or conflicting entries.
+
+## Relocating memory
+
+By default all memory files live under `~/.afk/state/memory/`. To move them to a different path, set the `AFK_STATE_DIR` environment variable:
+
+```bash
+export AFK_STATE_DIR=/path/to/shared/state
+```
+
+All memory files are then resolved under `<AFK_STATE_DIR>/memory/`. See [Environment Variables](/configuration/environment-variables) for the full list of path overrides.
+
+## Cross-surface sharing
+
+Because all memory lives on disk under `<AFK_STATE_DIR>/memory/`, it is automatically shared across all surfaces that point to the same `AFK_STATE_DIR`:
+
+- Interactive REPL (`afk interactive`)
+- Telegram bot
+- CLI `chat` (`afk chat "..."`)
+- Daemon sessions
+- Scheduled tasks
+
+Facts written in a Telegram session are visible in the next REPL session, and vice versa. For more on how surfaces differ and share state, see [How It Works](/how-it-works).

--- a/website/content/docs/guides/meta.json
+++ b/website/content/docs/guides/meta.json
@@ -1,1 +1,1 @@
-{"title":"Guides","pages":["unattended-runs","subagents","verification","mcp-plugins","worktrees","headless"]}
+{"title":"Guides","pages":["unattended-runs","subagents","verification","memory","mcp-plugins","worktrees","headless"]}


### PR DESCRIPTION
## Summary
- Adds a dedicated **Cross-Session Memory** guide to the docs site (`website/content/docs/guides/memory.mdx`) and wires it into the Guides nav.
- Complements the README Memory section already on this branch — the docs site previously had no standalone memory page.
- The guide covers both storage tiers (HOT.md + the SQLite fact archive), procedures, the four fact categories, the three memory tools and their parameter schemas, the automatic session lifecycle, `AFK_STATE_DIR` relocation, and cross-surface sharing.

## Test results
- **`fumadocs-mdx` compile** (website): passed — generated files, exit 0. Validates the new MDX compiles under the docs framework.
- **meta.json**: valid JSON; the `memory` nav entry was inserted.
- **MDX safety**: every `<…>` token (`<name>`, `<id>`, `<AFK_STATE_DIR>`) sits inside an inline code span; the single `<Callout>` is balanced; both internal links (`/configuration/environment-variables`, `/how-it-works`) resolve to existing pages.
- Root `vitest` not run: this is a docs-content-only change; the suite exercises CLI/agent code and would give zero signal (root deps are not installed in this worktree).

## Verification
An adversarial fact-check of the new page's technical claims was run against source **before commit**. It surfaced two real errors, both **fixed before publishing**:

1. **Memory paths were wrong by one directory level.** The page documented `~/.afk/state/HOT.md`, `~/.afk/state/memory.db`, `~/.afk/state/procedures/`, etc. The code resolves all memory files under a `memory/` subdirectory — `getMemoryDir()` = `join(getAfkStateDir(), 'memory')` (`src/paths.ts:230`), used as the store's base dir (`src/agent/memory/memory-store.ts:166`). Corrected every reference to `~/.afk/state/memory/…`. This now also matches `how-it-works.mdx:53`.
2. **The session-end lifecycle was mischaracterized.** The page claimed a hook "runs when a session completes with `outcome: "completed"`" and writes facts/hot/procedures. In reality the `SessionEnd` hook records a *session row* and fires on **every** session end (it hard-codes `'completed'`, it does not gate on outcome) — `src/agent/memory/memory-hooks.ts`. Facts/hot/procedures are written by the agent via the memory *tools* during the session. Rewrote that section. The subagent-exclusion claim (sessions with a `parentSessionId` are read-only and skipped by the hook) was **confirmed correct**.

Confirmed correct against source and left unchanged: the 5,250-char HOT cap (`MAX_HOT_CHARS`), the 600-char protected floor (`HOT_HEAD_CHARS`), truncate-from-end + atomic write + `.bak`, the WAL + FTS5 unbounded archive, procedures searched by substring (not FTS5), and the `memory_search` / `memory_update` parameter schemas.

## Out of scope
- Bringing the branch up to date with `main` (now at v4.6.1). The PR is `MERGEABLE`; GitHub merges `main` at merge time.
