### PR TITLE
fix(provider): resolve model alias in compact summarizer

### DIFF
--- a/src/agent/providers/anthropic-direct/query/compact-handler.ts
+++ b/src/agent/providers/anthropic-direct/query/compact-handler.ts
@@ -43,6 +43,7 @@ import {
   findCompactionBoundary,
 } from '../compact.js';
 import { emitCompaction } from '../../../trace/emit.js';
+import { resolveModelId } from '../../../session/model-resolution.js';
 import type { AnthropicClientLike } from '../types.js';
 import type { SessionState } from './session-state.js';
 import type { AbortCoordinator } from './abort-coordinator.js';
@@ -228,7 +229,14 @@ function readKeepLastN(): number {
 
 function readCompactModel(): string {
   const raw = env.AFK_COMPACT_MODEL;
-  if (raw !== undefined && raw.length > 0) return raw;
+  // Invariant: the Anthropic Messages API rejects short aliases like `'haiku'`
+  // (404 `model: <alias> not_found` under OAuth — see the note in oneshot.ts).
+  // Every other API path resolves the alias to a full model id via
+  // resolveModelId before messages.create (query.ts, oneshot.ts, index.ts);
+  // the compact summarizer must do the same, or a configured AFK_COMPACT_MODEL
+  // alias reaches the API raw and 404s mid-compaction. resolveModelId returns
+  // the full id for known aliases and passes anything else through unchanged.
+  if (raw !== undefined && raw.length > 0) return resolveModelId(raw) ?? raw;
   return DEFAULT_COMPACT_MODEL;
 }
 


### PR DESCRIPTION
## Summary

The compact/summarize path passed `AFK_COMPACT_MODEL` (or the default) to the Anthropic Messages API **verbatim**. A short alias like `haiku` is rejected with `404 "model: haiku not_found"` under OAuth (see the invariant in `oneshot.ts`) — so **live compaction was broken for any operator whose `AFK_COMPACT_MODEL` is a short alias**.

Every other API path already resolves the alias via `resolveModelId` before `messages.create` (`query.ts`, `oneshot.ts`, `index.ts`); `readCompactModel()` was the sole path missing it.

**Fix:** resolve the configured model via `resolveModelId` in `readCompactModel()`. `resolveModelId` returns the full id for known aliases and passes anything else through unchanged. This is also what the existing `compact()` test asserts — the failure surfaced because an operator's `AFK_COMPACT_MODEL=haiku` leaks into the vitest process.

One-file change: `src/agent/providers/anthropic-direct/query/compact-handler.ts` (+9/-1).

## How was this tested?

- `pnpm lint` (tsc --noEmit) — **passes** (exit 0)
- `pnpm test -- src/agent/providers/anthropic-direct/compact.test.ts` — **17/17 pass**
- Full `pnpm test` / coverage gate runs in CI.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (targeted compact suite 17/17 locally; full suite via CI)
- [ ] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md) — _commit was already pushed without `-s`; can amend + force-push if required_
- [x] No secrets, tokens, or private paths in the diff
