### PR TITLE
refactor(tui): extract getBuffer/resetState/applyEdit from compositor host

### DIFF
--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -50,6 +50,8 @@ export interface KeyDispatchHost {
   applyEdit(next: InputCoreState): boolean;
   /** Recompute autocomplete dropdown state for the current buffer. */
   updateAutocomplete(): void;
+  /** Refresh the active ghost suggestion for the current buffer (Tier-1 sync + Tier-2 async kick-off). */
+  updateGhost(): void;
   /** Apply the highlighted dropdown candidate; false when the dropdown is closed/empty. */
   applyDropdownSelection(): boolean;
   /** Accept the active ghost text; false when no ghost is showing. */
@@ -102,6 +104,32 @@ export interface KeyDispatchHost {
   readonly onBackground?: () => void;
   readonly onShiftTab?: () => void;
   readonly onSubmit?: (payload: SubmissionPayload) => void;
+}
+
+/**
+ * Apply a pure InputCore transition. If the state reference changed, clear the
+ * queued flag, refresh autocomplete + ghost, and repaint; otherwise it's a
+ * no-op (e.g. moveLeft at 0). Returns whether the state reference changed.
+ */
+export function applyEdit(self: KeyDispatchHost, next: InputCoreState): boolean {
+  if (next === self.input) return false;
+  self.input = next;
+  self.queued = false;
+  // During a bracketed-paste burst, suppress per-character work —
+  // a 10KB paste would otherwise trigger 10K log-update frames AND
+  // 10K detectTrigger scans. The paste end marker (`\x1b[201~`)
+  // runs maybeTruncatePaste + one final repaint, which also picks
+  // up any autocomplete state from the final buffer. Mirrors the
+  // `pasting` guard in reader.ts and keeps multi-KB pastes responsive.
+  if (self.pasting) return true;
+  self.updateAutocomplete();
+  // Ghost-text update: synchronous Tier-1 check + async Tier-2 kick-off.
+  // Paste bursts already returned early above (the `if (self.pasting)`
+  // guard), so this per-character ghost refresh never fires mid-paste —
+  // it would be stale by paste end anyway.
+  self.updateGhost();
+  self.repaint();
+  return true;
 }
 
 export function dispatchKey(self: KeyDispatchHost, char: string | undefined, key: KeyInfo): void {

--- a/src/cli/terminal-compositor.paste.ts
+++ b/src/cli/terminal-compositor.paste.ts
@@ -86,6 +86,32 @@ export function expandPastePlaceholders(self: PasteHost, buffer: string): string
 }
 
 /**
+ * Narrowest slice for {@link getBuffer}: the {@link PasteHost} fields
+ * `expandPastePlaceholders` reads, plus the `queued` flag.
+ */
+export interface BufferSnapshotHost extends PasteHost {
+  /** Whether the buffer is queued for submission on the next idle transition. */
+  readonly queued: boolean;
+}
+
+/**
+ * Snapshot the live buffer as submission-shaped text + the queued flag.
+ *
+ * Expands any `[Pasted text #N +M lines]` placeholders back to their original
+ * content so callers reading this snapshot see submission-shaped text (what the
+ * model will receive), not placeholder tokens. Primarily used by tests;
+ * production submit paths read `input.buffer` directly so expansion and registry
+ * clear happen in the same atomic operation.
+ *
+ * CAUTION: do not call after submit fires — pasteRegistry is cleared before the
+ * handler so placeholders would pass through unexpanded. For the raw buffer with
+ * placeholders intact, read `input.buffer` directly.
+ */
+export function getBuffer(self: BufferSnapshotHost): { text: string; queued: boolean } {
+  return { text: expandPastePlaceholders(self, self.input.buffer), queued: self.queued };
+}
+
+/**
  * After a bracketed paste ends, check whether the pasted span is
  * large enough to warrant collapsing into a `[Pasted text #N +M lines]`
  * placeholder. The original content is stashed in pasteRegistry and

--- a/src/cli/terminal-compositor.reset.ts
+++ b/src/cli/terminal-compositor.reset.ts
@@ -1,0 +1,113 @@
+/**
+ * State reset — `resetState`, extracted from terminal-compositor.ts
+ * (free-functions-on-host pattern; see sibling lifecycle/frame/paste modules).
+ * The class owns all state; this function clears the narrow {@link ResetStateHost}
+ * slice passed as `self` back to its armed-cycle defaults. Called by
+ * {@link ./terminal-compositor.lifecycle.ts | Lifecycle.disarm} AND by internal
+ * state-resets that keep the suggest engine alive. No behavior change — the body
+ * is a byte-for-byte move with `this.` rewritten to `self.`.
+ */
+
+import { InputCore, type InputCoreState } from './input-core.js';
+import type { AutocompleteState } from './input/autocomplete-state.js';
+import type { ImageAttachment } from './input/attachments.js';
+import type { CompositorInputMode, PickerController } from './terminal-compositor.types.js';
+
+/**
+ * Narrowest TerminalCompositor state slice {@link resetState} clears. Spans the
+ * overlay / input / paste / committed-band / resize fields that must return to
+ * armed-cycle defaults between disarm and rearm. `pasteRegistry` and
+ * `autocompleteState` keep a readonly reference (mutated in place via
+ * `.clear()` / `.reset()`); `clearCommittedBand` is the class delegator this
+ * function calls back into. Field semantics are documented authoritatively on
+ * the class declarations in terminal-compositor.ts; this is a structural mirror.
+ */
+export interface ResetStateHost {
+  clearCommittedBand(): void;
+
+  overlay: string;
+  input: InputCoreState;
+  queued: boolean;
+  canceled: boolean;
+  backgrounded: boolean;
+  softStopped: boolean;
+  activeGhost: string | null;
+  anchorRow: number | undefined;
+  hasCommitted: boolean;
+  commitInFlight: boolean;
+  pendingResizeErase: { top: number; bottom: number } | null;
+  lastKnownRows: number;
+  pickerController: PickerController | null;
+  inputMode: CompositorInputMode;
+  attachments: ImageAttachment[];
+  pasting: boolean;
+  pasteStartBufferLen: number;
+  pasteStartCursor: number;
+  readonly pasteRegistry: Map<string, string>;
+  clipboardFailureMsg: string | null;
+  readonly autocompleteState?: AutocompleteState;
+  resizeUnsub: (() => void) | null;
+  resizeImmediateUnsub: (() => void) | null;
+}
+
+export function resetState(self: ResetStateHost): void {
+  self.overlay = '';
+  self.input = InputCore.seed('');
+  self.queued = false;
+  self.canceled = false;
+  self.backgrounded = false;
+  self.softStopped = false;
+  // Clear active ghost — stale suggestions must not survive a disarm/rearm
+  // cycle. The engine itself is NOT disposed here (only in disarm) since
+  // resetState() is called by both disarm() AND internal state-resets that
+  // keep the engine alive (e.g. idle→streaming transition after submit).
+  self.activeGhost = null;
+  // Clear the working anchor — `repaint()` may have shifted it up during
+  // eviction (e.g. declared 15 → working 11 after pushing 4 rows into
+  // scrollback). The shifted value is per-cycle state; leaving it set
+  // across disarm/rearm would silently under-protect the declared ceiling
+  // on the next arm. `arm()` re-seeds from `declaredAnchorRow`.
+  self.anchorRow = undefined;
+  // Reset commit-presence flag so growthDeficit in repaint() does not fire
+  // on the new arm cycle until a commit actually happens.
+  self.hasCommitted = false;
+  // Drop any retained above-frame committed block + the in-flight commit guard
+  // so a fresh arm cycle never re-pins stale transcript from the previous one.
+  self.clearCommittedBand();
+  self.commitInFlight = false;
+  // Drop resize ghost-erase state — a pending erase or stale row count from
+  // the previous arm cycle must not leak into the next one (the first repaint
+  // of a fresh arm re-seeds lastKnownRows before any resize can be detected).
+  self.pendingResizeErase = null;
+  self.lastKnownRows = 0;
+  // Drop any active picker — a disarm during a picker would leave
+  // the controller's resolve callback orphaned. The runPicker abort
+  // path normally exits the picker first; this is defence-in-depth
+  // for a hard disarm (process termination, swap path).
+  self.pickerController = null;
+  self.inputMode = 'streaming';
+  // Reset attachment + paste state — between full disarm/rearm cycles
+  // (skill dispatchers, tests) we must not carry stale clipboard
+  // artifacts into the next session.
+  self.attachments = [];
+  self.pasting = false;
+  self.pasteStartBufferLen = 0;
+  self.pasteStartCursor = 0;
+  self.pasteRegistry.clear();
+  self.clipboardFailureMsg = null;
+  // clipboardInFlight is NOT reset — an in-flight osascript probe is
+  // tied to a Promise that will resolve/reject independently. Setting
+  // the flag to false here would allow a new probe to spawn while the
+  // old one's `.finally` is pending, defeating the guard.
+  // Reset shared autocomplete state so stale dropdown chrome from this
+  // agent turn does not leak into the next user-turn read.
+  self.autocompleteState?.reset();
+  if (self.resizeUnsub) {
+    self.resizeUnsub();
+    self.resizeUnsub = null;
+  }
+  if (self.resizeImmediateUnsub) {
+    self.resizeImmediateUnsub();
+    self.resizeImmediateUnsub = null;
+  }
+}

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -40,7 +40,9 @@ import * as Render from './terminal-compositor.render.js';
 import * as CommittedBand from './terminal-compositor.committed-band.js';
 import * as Frame from './terminal-compositor.frame.js';
 import * as InputMode from './terminal-compositor.input-mode.js';
+import * as InputDispatch from './terminal-compositor.input-dispatch.js';
 import * as Lifecycle from './terminal-compositor.lifecycle.js';
+import * as Reset from './terminal-compositor.reset.js';
 
 // Re-export public types so existing importers of './terminal-compositor.js'
 // continue to work without any import-path changes.
@@ -646,21 +648,13 @@ export class TerminalCompositor {
     CommittedBand.repositionCommittedBand(this, desiredTopRow, preRenderFrameTop, targetBottomRow);
   }
 
+  /**
+   * Snapshot the current buffer as submission-shaped text + the queued flag.
+   * Body extracted to terminal-compositor.paste.ts — see {@link Paste.getBuffer}
+   * for the placeholder-expansion semantics and the post-submit caution.
+   */
   getBuffer(): { text: string; queued: boolean } {
-    // Expand any `[Pasted text #N +M lines]` placeholders back to
-    // their original content so callers reading this snapshot see
-    // submission-shaped text (what the model will receive), not
-    // placeholder tokens. Primarily used by tests; production submit
-    // paths read this.input.buffer directly so expansion and registry
-    // clear happen in the same atomic operation.
-    //
-    // CAUTION: do not call getBuffer() after submit fires — pasteRegistry
-    // is cleared before the handler so placeholders would pass through
-    // unexpanded. For the raw buffer with placeholders intact, read
-    // this.input.buffer directly.
-    //
-    // No-op fast path when no truncation happened in this compose window.
-    return { text: Paste.expandPastePlaceholders(this, this.input.buffer), queued: this.queued };
+    return Paste.getBuffer(this);
   }
 
   /**
@@ -695,8 +689,9 @@ export class TerminalCompositor {
    * Update the active ghost text for the current buffer state. Body extracted
    * to terminal-compositor.autocomplete.ts — see {@link Autocomplete.updateGhost}
    * for the keystroke-path and stale-async-guard invariants.
+   * @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost).
    */
-  private updateGhost(): void {
+  updateGhost(): void {
     Autocomplete.updateGhost(this);
   }
 
@@ -728,94 +723,27 @@ export class TerminalCompositor {
     Frame.repaint(this);
   }
 
-  /** @internal Relaxed from `private` for the lifecycle module (LifecycleHost). */
+  /**
+   * Reset all per-cycle state back to its armed-cycle defaults (overlay, input,
+   * paste/attachment, committed-band, resize ghost-erase, picker). Body extracted
+   * to terminal-compositor.reset.ts — see {@link Reset.resetState} for the
+   * per-field disarm/rearm invariants (working-anchor clear, ghost-not-engine,
+   * and the clipboardInFlight + committed-band carve-outs).
+   * @internal Relaxed from `private` for the lifecycle module (LifecycleHost).
+   */
   resetState(): void {
-    this.overlay = '';
-    this.input = InputCore.seed('');
-    this.queued = false;
-    this.canceled = false;
-    this.backgrounded = false;
-    this.softStopped = false;
-    // Clear active ghost — stale suggestions must not survive a disarm/rearm
-    // cycle. The engine itself is NOT disposed here (only in disarm) since
-    // resetState() is called by both disarm() AND internal state-resets that
-    // keep the engine alive (e.g. idle→streaming transition after submit).
-    this.activeGhost = null;
-    // Clear the working anchor — `repaint()` may have shifted it up during
-    // eviction (e.g. declared 15 → working 11 after pushing 4 rows into
-    // scrollback). The shifted value is per-cycle state; leaving it set
-    // across disarm/rearm would silently under-protect the declared ceiling
-    // on the next arm. `arm()` re-seeds from `declaredAnchorRow`.
-    this.anchorRow = undefined;
-    // Reset commit-presence flag so growthDeficit in repaint() does not fire
-    // on the new arm cycle until a commit actually happens.
-    this.hasCommitted = false;
-    // Drop any retained above-frame committed block + the in-flight commit guard
-    // so a fresh arm cycle never re-pins stale transcript from the previous one.
-    this.clearCommittedBand();
-    this.commitInFlight = false;
-    // Drop resize ghost-erase state — a pending erase or stale row count from
-    // the previous arm cycle must not leak into the next one (the first repaint
-    // of a fresh arm re-seeds lastKnownRows before any resize can be detected).
-    this.pendingResizeErase = null;
-    this.lastKnownRows = 0;
-    // Drop any active picker — a disarm during a picker would leave
-    // the controller's resolve callback orphaned. The runPicker abort
-    // path normally exits the picker first; this is defence-in-depth
-    // for a hard disarm (process termination, swap path).
-    this.pickerController = null;
-    this.inputMode = 'streaming';
-    // Reset attachment + paste state — between full disarm/rearm cycles
-    // (skill dispatchers, tests) we must not carry stale clipboard
-    // artifacts into the next session.
-    this.attachments = [];
-    this.pasting = false;
-    this.pasteStartBufferLen = 0;
-    this.pasteStartCursor = 0;
-    this.pasteRegistry.clear();
-    this.clipboardFailureMsg = null;
-    // clipboardInFlight is NOT reset — an in-flight osascript probe is
-    // tied to a Promise that will resolve/reject independently. Setting
-    // the flag to false here would allow a new probe to spawn while the
-    // old one's `.finally` is pending, defeating the guard.
-    // Reset shared autocomplete state so stale dropdown chrome from this
-    // agent turn does not leak into the next user-turn read.
-    this.autocompleteState?.reset();
-    if (this.resizeUnsub) {
-      this.resizeUnsub();
-      this.resizeUnsub = null;
-    }
-    if (this.resizeImmediateUnsub) {
-      this.resizeImmediateUnsub();
-      this.resizeImmediateUnsub = null;
-    }
+    Reset.resetState(this);
   }
 
   /**
-   * Apply a pure InputCore transition. If the state reference changed, clear
-   * the queued flag, refresh the autocomplete state, and repaint; otherwise
-   * it's a no-op (e.g. moveLeft at 0).
+   * Apply a pure InputCore transition (clears queued, refreshes autocomplete +
+   * ghost, repaints; no-op when the state reference is unchanged). Body extracted
+   * to terminal-compositor.input-dispatch.ts — see {@link InputDispatch.applyEdit}
+   * for the bracketed-paste per-character suppression guard.
    * @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost).
    */
   applyEdit(next: InputCoreState): boolean {
-    if (next === this.input) return false;
-    this.input = next;
-    this.queued = false;
-    // During a bracketed-paste burst, suppress per-character work —
-    // a 10KB paste would otherwise trigger 10K log-update frames AND
-    // 10K detectTrigger scans. The paste end marker (`\x1b[201~`)
-    // runs maybeTruncatePaste + one final repaint, which also picks
-    // up any autocomplete state from the final buffer. Mirrors the
-    // `pasting` guard in reader.ts and keeps multi-KB pastes responsive.
-    if (this.pasting) return true;
-    this.updateAutocomplete();
-    // Ghost-text update: synchronous Tier-1 check + async Tier-2 kick-off.
-    // Paste bursts already returned early above (the `if (this.pasting)`
-    // guard), so this per-character ghost refresh never fires mid-paste —
-    // it would be stale by paste end anyway.
-    this.updateGhost();
-    this.repaint();
-    return true;
+    return InputDispatch.applyEdit(this, next);
   }
 
   /**


### PR DESCRIPTION
## What

Continues the `terminal-compositor.ts` host slim-down using the established **free-functions-on-host** pattern. Three logic-bearing methods move to sibling modules, each taking a narrow structural `*Host` interface; the host keeps thin delegators.

| Method | Moved to | Host interface |
|---|---|---|
| `getBuffer` | `terminal-compositor.paste.ts` | new `BufferSnapshotHost extends PasteHost` |
| `resetState` | **new** `terminal-compositor.reset.ts` | new `ResetStateHost` |
| `applyEdit` | `terminal-compositor.input-dispatch.ts` | reuses `KeyDispatchHost` |

For `applyEdit`, `updateGhost` is relaxed from `private` and added to `KeyDispatchHost` (its only caller besides the host delegator) so the free function can call back into it — mirroring the existing `updateAutocomplete` relaxation.

**Host: 843 → 771 LOC.**

## Behavior preservation

Bodies are byte-for-byte moves with `this.` → `self.`; every `Invariant:`/`History:` comment travels with its body. The host's public API is unchanged (signatures identical; `resetState`/`updateGhost` remain `@internal`).

## Deliberate scope decisions

- **Did not** extract the trivial `setOverlay` setter — cross-file indirection outweighs the ~6 LOC saved.
- **Did not** compress the field-block docs. Those comments are load-bearing (bracketed-paste state machine, `pasteRegistry` nonce rationale, anchor-eviction invariants, and per-field `@internal Relaxed from private for <module>` provenance). Compressing them trades documentation for cosmetic LOC, against the repo's "false-shrink is a regression" convention. All meaningful method *logic* is now out of the host; the remaining 771 LOC is constructor + field declarations + thin delegators.

## Verification

- `tsc --noEmit` — clean
- `vitest run src/cli` — **3831/3831 pass** (273 compositor across 17 files)
- Cut fresh off `origin/main` (v4.6.0).
