### PR TITLE
feat(permissions): elicit user approval for restricted-path tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ auto-release workflow to deduplicate commits across successive runs.
 ## [Unreleased]
 
 ### Added
-- Path-approval elicitation: when a typed file tool (`read_file`, `write_file`, `edit_file`, `list_directory`, `glob`, `grep`) targets a path outside the session's granted roots, a `PreToolUse` hook prompts the user via the `ElicitationRouter` with a 4-choice form (once / session / persist / deny). Bash invocations that reference restricted paths or use interpreter eval flags (`python -c`, `node -e`, `sh -c`) are hard-blocked and the model is directed to the typed-file-tool surface instead.
+- Path-approval elicitation: when a typed file tool (`read_file`, `write_file`, `edit_file`, `list_directory`, `glob`, `grep`) targets a path outside the session's granted roots, a `PreToolUse` hook prompts the user via the `ElicitationRouter` with a 4-choice form (once / session / persist / deny). Bash invocations that reference restricted paths or use interpreter eval flags (`python -c`, `node -e`, `sh -c`) are hard-blocked and the model is directed to the typed-file-tool surface instead. **Scope:** restricted-path prompts are currently wired for **Anthropic providers only** — OpenAI-compatible (GPT/Codex) sessions run path-approval fail-open for now (the interpreter-eval denylist still applies on every surface); tracked in #166.
 - `AFK_DISABLE_BASH_INTERPRETER_GUARD` env var — lifts only the bash interpreter-eval denylist while keeping the rest of path-approval enabled
 - `AFK_DISABLE_PATH_APPROVAL=1` env var — escape hatch to skip path-approval and bash-restriction hooks entirely for headless flows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Added
+- Path-approval elicitation: when a typed file tool (`read_file`, `write_file`, `edit_file`, `list_directory`, `glob`, `grep`) targets a path outside the session's granted roots, a `PreToolUse` hook prompts the user via the `ElicitationRouter` with a 4-choice form (once / session / persist / deny). Bash invocations that reference restricted paths or use interpreter eval flags (`python -c`, `node -e`, `sh -c`) are hard-blocked and the model is directed to the typed-file-tool surface instead.
+- `AFK_DISABLE_BASH_INTERPRETER_GUARD` env var — lifts only the bash interpreter-eval denylist while keeping the rest of path-approval enabled
+- `AFK_DISABLE_PATH_APPROVAL=1` env var — escape hatch to skip path-approval and bash-restriction hooks entirely for headless flows
+
+### Changed
+- path-approval: the bash interpreter-eval denylist (on by default on every surface including headless) can now be lifted with the granular `AFK_DISABLE_BASH_INTERPRETER_GUARD=1` instead of only the all-or-nothing `AFK_DISABLE_PATH_APPROVAL=1`
+
 ## [4.6.2] - 2026-06-15
 
 ### Changed

--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -173,6 +173,24 @@
       "category": "misc"
     },
     {
+      "name": "AFK_DISABLE_BASH_INTERPRETER_GUARD",
+      "description": "Skip ONLY the bash interpreter-eval denylist (python -c, node -e, sh -c, ...) when set to 1, leaving the rest of path-approval intact. Use for headless flows (CI, daemon) whose automation legitimately runs interpreter one-liners but should still keep path-approval enabled. The restricted-root substring check is unaffected. Default: guard enabled. To disable all path-approval + bash restriction instead, use AFK_DISABLE_PATH_APPROVAL=1.",
+      "type": "boolean",
+      "required": false,
+      "default": "0",
+      "example": "1",
+      "category": "process"
+    },
+    {
+      "name": "AFK_DISABLE_PATH_APPROVAL",
+      "description": "Skip the path-approval + bash-restriction hooks entirely when set to 1. Use for headless flows that need wide-open file access (CI scripts, batch jobs). Default: hooks enabled.",
+      "type": "boolean",
+      "required": false,
+      "default": "0",
+      "example": "1",
+      "category": "process"
+    },
+    {
       "name": "AFK_DISABLE_PROMPT_CACHE",
       "description": "Disable Anthropic prompt caching when set to 1/true/yes/on. Unset = caching enabled.",
       "type": "boolean",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -13,6 +13,8 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_COMPACT_KEEP_LAST_TURNS` | number |  |  | `6` | Number of recent turns the compactor keeps verbatim during /compact. Default tuned in compact-handler.ts. |
 | `AFK_COMPACT_MODEL` | string |  |  | `claude-haiku-4-5` | Override the model used by the /compact summarizer. Falls back to a cheap default (haiku-class). |
 | `AFK_DEFAULT_SUBAGENT_MODEL` | string |  |  | `sonnet` | Override the default model used when a subagent is dispatched without an explicit model. |
+| `AFK_DISABLE_BASH_INTERPRETER_GUARD` | boolean |  | `0` | `1` | Skip ONLY the bash interpreter-eval denylist (python -c, node -e, sh -c, ...) when set to 1, leaving the rest of path-approval intact. |
+| `AFK_DISABLE_PATH_APPROVAL` | boolean |  | `0` | `1` | Skip the path-approval + bash-restriction hooks entirely when set to 1. Use for headless flows that need wide-open file access. |
 | `AFK_DISABLE_PROMPT_CACHE` | boolean |  | `0` | `1` | Disable Anthropic prompt caching when set to 1/true/yes/on. Unset = caching enabled. |
 | `AFK_EFFORT` | string |  |  | `medium` | Effort hint guiding adaptive-thinking depth, forwarded as Anthropic output_config.effort (model-gated; ignored where unsupported). Accepts low \| medium \| high \| xhigh \| max. |
 | `AFK_LOCAL_BASE_URL` | string |  |  | `http://127.0.0.1:8080` | Base URL for a self-hosted Anthropic-compatible server. When set, routes traffic away from api.anthropic.com. |

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**108 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**110 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 
@@ -13,8 +13,6 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_COMPACT_KEEP_LAST_TURNS` | number |  |  | `6` | Number of recent turns the compactor keeps verbatim during /compact. Default tuned in compact-handler.ts. |
 | `AFK_COMPACT_MODEL` | string |  |  | `claude-haiku-4-5` | Override the model used by the /compact summarizer. Falls back to a cheap default (haiku-class). |
 | `AFK_DEFAULT_SUBAGENT_MODEL` | string |  |  | `sonnet` | Override the default model used when a subagent is dispatched without an explicit model. |
-| `AFK_DISABLE_BASH_INTERPRETER_GUARD` | boolean |  | `0` | `1` | Skip ONLY the bash interpreter-eval denylist (python -c, node -e, sh -c, ...) when set to 1, leaving the rest of path-approval intact. |
-| `AFK_DISABLE_PATH_APPROVAL` | boolean |  | `0` | `1` | Skip the path-approval + bash-restriction hooks entirely when set to 1. Use for headless flows that need wide-open file access. |
 | `AFK_DISABLE_PROMPT_CACHE` | boolean |  | `0` | `1` | Disable Anthropic prompt caching when set to 1/true/yes/on. Unset = caching enabled. |
 | `AFK_EFFORT` | string |  |  | `medium` | Effort hint guiding adaptive-thinking depth, forwarded as Anthropic output_config.effort (model-gated; ignored where unsupported). Accepts low \| medium \| high \| xhigh \| max. |
 | `AFK_LOCAL_BASE_URL` | string |  |  | `http://127.0.0.1:8080` | Base URL for a self-hosted Anthropic-compatible server. When set, routes traffic away from api.anthropic.com. |
@@ -147,6 +145,8 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 
 | Name | Type | Required | Default | Example | Description |
 |------|------|----------|---------|---------|-------------|
+| `AFK_DISABLE_BASH_INTERPRETER_GUARD` | boolean |  | `0` | `1` | Skip ONLY the bash interpreter-eval denylist (python -c, node -e, sh -c, ...) when set to 1, leaving the rest of path-approval intact. Use for headless flows (CI, daemon) whose automation legitimately runs interpreter one-liners but should still keep path-approval enabled. The restricted-root substring check is unaffected. Default: guard enabled. To disable all path-approval + bash restriction instead, use AFK_DISABLE_PATH_APPROVAL=1. |
+| `AFK_DISABLE_PATH_APPROVAL` | boolean |  | `0` | `1` | Skip the path-approval + bash-restriction hooks entirely when set to 1. Use for headless flows that need wide-open file access (CI scripts, batch jobs). Default: hooks enabled. |
 | `AFK_SHELL_WRAPPER` | boolean |  |  | `1` | Set to 1 or true by the optional afk shell wrapper function (installed via `afk shell-init`). Signals that the parent shell has the wrapper active so the post-exit cd can fire. |
 | `AGENT_SURFACE` | string |  |  | `cli` | Internal surface marker propagated to subprocesses. Identifies which AFK surface (cli, telegram, daemon) spawned the process. |
 | `ASCIINEMA_REC` | boolean |  |  | `1` | Set to 1 by asciinema rec while a session is being recorded. Triggers capture-mode. |

--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -1,5 +1,5 @@
 /**
- * Factory for a `HookRegistry` pre-populated with the built-in
+ * Factory for a `HookRegistry` pre-populated with AFK's built-in
  * hook handlers. Entry points should use this instead of the bare
  * `createHookRegistry()` unless they explicitly want no built-ins.
  *
@@ -11,6 +11,13 @@ import { shadowVerifyNudge } from './shadow-verify-nudge.js';
 import { MemoryStore, createMemorySessionEndHook } from './memory/index.js';
 import { createPlanModeGate } from './plan-mode-gate.js';
 import { cleanupComposeSpills } from './tools/compose-executor.js';
+import { env } from '../config/env.js';
+import {
+  createPathApprovalHook,
+  type PathApprovalSurface,
+} from './tools/hooks/path-approval-hook.js';
+import { createBashRestrictionHook } from './tools/hooks/bash-restriction-hook.js';
+import type { GrantManager } from '../cli/slash/commands/allow-dir.js';
 import type { PermissionMode } from './types/sdk-types.js';
 import type { LoadedHooksConfig } from './hooks/config-loader.js';
 import { loadAndRegisterConfigHooks } from './hooks/config-bridge.js';
@@ -25,6 +32,24 @@ export interface SubagentCompleteInfo {
 export interface DefaultHookRegistryResult {
   registry: HookRegistry;
   memoryStore: MemoryStore;
+  /**
+   * Mutable ref the surface bootstrap MUST populate with the active provider
+   * (which implements {@link GrantManager}) after session construction. Path-
+   * approval + bash-restriction hooks dereference this on every PreToolUse;
+   * leaving it null makes the path-approval hook fail OPEN — it skips the
+   * elicitation prompt (the typed-file-tool handler's own resolveAndContain
+   * still enforces containment), and the bash hook's restricted-root substring
+   * check also fails open. (The bash interpreter denylist still hard-blocks
+   * regardless — it runs before the grant-manager gate. See the registration
+   * block below for the full per-surface breakdown.)
+   *
+   * Wiring pattern (see `src/cli/commands/interactive/bootstrap.ts:532`):
+   *   pathApprovalGrantRef.current = provider;
+   *
+   * The same ref drives `setAllowDirDispatcher(provider)` callers — both
+   * read the live provider grant API.
+   */
+  pathApprovalGrantRef: { current: GrantManager | undefined };
 }
 
 export function createDefaultHookRegistry(
@@ -34,6 +59,7 @@ export function createDefaultHookRegistry(
   getPermissionMode?: () => PermissionMode,
   hookConfig?: LoadedHooksConfig,
   agentOptions?: { cwd?: string; sessionId?: string },
+  getCwd?: () => string | undefined,
 ): DefaultHookRegistryResult {
   const registry = createHookRegistry();
   registry.register('SubagentStop', shadowVerifyNudge);
@@ -41,6 +67,70 @@ export function createDefaultHookRegistry(
   if (getPermissionMode !== undefined) {
     registry.register('PreToolUse', createPlanModeGate(getPermissionMode));
   }
+
+  // Path-approval + bash-restriction hooks. Both share a mutable grant-manager
+  // ref that the surface bootstrap populates after the provider exists.
+  // `AFK_DISABLE_PATH_APPROVAL=1` skips registration entirely — escape hatch
+  // for headless flows where wide-open access is desired (CI scripts, etc.).
+  //
+  // Invariant: registration order matters. Path-approval (typed file tools)
+  // runs BEFORE bash-restriction so the model gets the interactive prompt
+  // path first when both could apply (e.g. an edit_file followed by a bash
+  // grep against the same restricted root within one turn).
+  //
+  // Invariant: only the REPL and Telegram bootstraps wire
+  // `pathApprovalGrantRef.current` (see bootstrap.ts / telegram bot.start).
+  // Headless surfaces (afk chat, daemon, threads) register these hooks but
+  // never wire the ref, so on those surfaces:
+  //   - path-approval PreToolUse: fails open (no prompt; the typed-tool
+  //     handler's own resolveAndContain still enforces containment);
+  //   - bash restricted-root substring check: fails open (no backstop);
+  //   - bash interpreter denylist: STILL hard-blocks (it runs before the
+  //     grant-manager gate). Lift just this guard with
+  //     AFK_DISABLE_BASH_INTERPRETER_GUARD=1, or disable the whole feature
+  //     with AFK_DISABLE_PATH_APPROVAL=1.
+  const pathApprovalGrantRef: { current: GrantManager | undefined } = {
+    current: undefined,
+  };
+  const disabled = env.AFK_DISABLE_PATH_APPROVAL === '1';
+  if (!disabled) {
+    const pathApproval = createPathApprovalHook({
+      getGrantManager: () => pathApprovalGrantRef.current,
+      // Prefer an explicit getCwd callback (REPL/Telegram bootstrap thread a
+      // live `extras.cwd`); otherwise fall back to the static cwd carried in
+      // main's `agentOptions` (scheduler/chat/threads callers). Both feed the
+      // path-approval containment check's resolveBase.
+      getCwd: getCwd ?? (() => agentOptions?.cwd),
+      surface: mapSurface(surface),
+    });
+    registry.register(
+      'PreToolUse',
+      pathApproval.preToolUse,
+      // Longrunning: the hook awaits elicitationRouter.route(), which has no
+      // time-based deadline (it waits as long as the operator needs). Bypass
+      // the 30s per-handler deadline; the hook forwards the turn signal so
+      // session/turn teardown still cancels the pending prompt.
+      { longRunning: true },
+    );
+    // PostToolUse revokes "Once" grants after the call completes. Synchronous
+    // (no I/O, just Map/Set/Array mutations) — default timeout suffices.
+    registry.register('PostToolUse', pathApproval.postToolUse);
+    // SessionEnd safety net: revoke any "Once" grants whose PostToolUse never
+    // ran (e.g. the call's signal aborted before the revoke fired).
+    registry.register('SessionEnd', pathApproval.sessionEnd);
+    registry.register(
+      'PreToolUse',
+      createBashRestrictionHook({
+        getGrantManager: () => pathApprovalGrantRef.current,
+        // Granular escape: lift only the interpreter-eval denylist (which
+        // fires on every surface, incl. headless) without disabling the rest
+        // of path-approval. AFK_DISABLE_PATH_APPROVAL=1 already short-circuits
+        // the whole `if (!disabled)` block above, so this is the finer knob.
+        disableInterpreterGuard: env.AFK_DISABLE_BASH_INTERPRETER_GUARD === '1',
+      }),
+    );
+  }
+
   registry.register('SessionEnd', createMemorySessionEndHook(store, surface));
   // Clean up compose-truncation spill files when the session ends. Files
   // are written under <sessions>/<sessionId>/compose/<callId>/<nodeId>.txt
@@ -76,5 +166,16 @@ export function createDefaultHookRegistry(
     });
   }
 
-  return { registry, memoryStore: store };
+  return { registry, memoryStore: store, pathApprovalGrantRef };
+}
+
+/**
+ * Map the loose surface label threaded through {@link createDefaultHookRegistry}
+ * to the {@link PathApprovalSurface} discriminator stamped into persisted
+ * grants. Unknown labels fall through to `'unknown'`.
+ */
+function mapSurface(surface: string | undefined): PathApprovalSurface {
+  if (surface === 'telegram') return 'telegram';
+  if (surface === 'cli' || surface === 'repl') return 'repl';
+  return 'unknown';
 }

--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -79,9 +79,12 @@ export function createDefaultHookRegistry(
   // grep against the same restricted root within one turn).
   //
   // Invariant: only the REPL and Telegram bootstraps wire
-  // `pathApprovalGrantRef.current` (see bootstrap.ts / telegram bot.start).
-  // Headless surfaces (afk chat, daemon, threads) register these hooks but
-  // never wire the ref, so on those surfaces:
+  // `pathApprovalGrantRef.current` (see bootstrap.ts / telegram bot.start) — and
+  // today ONLY when the active provider is AnthropicDirectProvider. OpenAI-
+  // compatible providers implement GrantManager but are not yet wired, so an
+  // OpenAI/Codex REPL or Telegram session also runs path-approval fail-open
+  // (tracked in #166). Headless surfaces (afk chat, daemon, threads) register
+  // these hooks but never wire the ref, so on those surfaces:
   //   - path-approval PreToolUse: fails open (no prompt; the typed-tool
   //     handler's own resolveAndContain still enforces containment);
   //   - bash restricted-root substring check: fails open (no backstop);

--- a/src/agent/hook-registry.ts
+++ b/src/agent/hook-registry.ts
@@ -24,6 +24,7 @@ import type {
   HookDecision,
   HookHandler,
   HookRegistry,
+  RegisterOptions,
 } from './hooks.js';
 
 /**
@@ -105,20 +106,36 @@ export class HookHandlerTimeoutError extends Error {
   }
 }
 
-class HookRegistryImpl implements HookRegistry {
-  private readonly handlers = new Map<HarnessHookEvent, HookHandler[]>();
+/**
+ * Internal wrapper threading per-handler registration options through dispatch.
+ * The public {@link HookRegistry.register} accepts a plain `HookHandler` and an
+ * optional {@link RegisterOptions}; we store both as one entry so the dispatch
+ * loop can decide whether to apply the timeout race per-handler.
+ */
+interface RegisteredHandler {
+  handler: HookHandler;
+  options: RegisterOptions;
+}
 
-  register(event: HarnessHookEvent, handler: HookHandler): () => void {
+class HookRegistryImpl implements HookRegistry {
+  private readonly handlers = new Map<HarnessHookEvent, RegisteredHandler[]>();
+
+  register(
+    event: HarnessHookEvent,
+    handler: HookHandler,
+    options: RegisterOptions = {},
+  ): () => void {
     let list = this.handlers.get(event);
     if (!list) {
       list = [];
       this.handlers.set(event, list);
     }
-    list.push(handler);
+    const entry: RegisteredHandler = { handler, options };
+    list.push(entry);
     return () => {
       const current = this.handlers.get(event);
       if (!current) return;
-      const idx = current.indexOf(handler);
+      const idx = current.indexOf(entry);
       if (idx >= 0) current.splice(idx, 1);
     };
   }
@@ -142,20 +159,33 @@ class HookRegistryImpl implements HookRegistry {
 
     let lastDecision: HookDecision = {};
 
-    for (const handler of snapshot) {
+    for (const entry of snapshot) {
       assertNotAborted(signal, context.event);
 
       let decision: HookDecision;
       try {
-        const handlerResult = handler(context);
+        // Forward the turn/dispatch signal as the second handler argument so
+        // longRunning handlers (e.g. path-approval awaiting an elicitation
+        // prompt) can cancel on session/turn teardown — `assertNotAborted`
+        // only gates BETWEEN handlers, not during a single in-flight await.
+        const handlerResult = entry.handler(context, signal);
         // External constraint: every handler must be bounded so a hung handler
         // cannot stall the dispatch loop. Callers can pass `Infinity` to opt
         // out explicitly (e.g. inside tests with fake timers), but the default
         // is the documented HOOK_HANDLER_TIMEOUT_MS ceiling.
-        decision =
-          handlerTimeoutMs > 0 && Number.isFinite(handlerTimeoutMs)
-            ? await withHandlerTimeout(handlerResult, handlerTimeoutMs, context.event)
-            : await handlerResult;
+        //
+        // `longRunning` opts out for handlers that legitimately await human
+        // input (e.g. path-approval calling elicitationRouter.route(), which
+        // waits indefinitely and relies on the forwarded `signal` for teardown
+        // rather than a timer). The opt-out is per-handler at registration
+        // time so a hung policy hook cannot mask it ad-hoc.
+        const applyTimeout =
+          !entry.options.longRunning &&
+          handlerTimeoutMs > 0 &&
+          Number.isFinite(handlerTimeoutMs);
+        decision = applyTimeout
+          ? await withHandlerTimeout(handlerResult, handlerTimeoutMs, context.event)
+          : await handlerResult;
       } catch (err) {
         if (err instanceof HookHandlerTimeoutError) {
           // Timeout: re-throw as-is so dispatchSubagentStop can catch it
@@ -185,11 +215,8 @@ class HookRegistryImpl implements HookRegistry {
         );
       }
 
-      // Accumulate non-blocking decisions so the caller can inspect them.
-      // Current contract: decisions are not merged. If multiple SubagentStop
-      // handlers return injectContext, the last handler's value wins and earlier
-      // values are dropped. This documents the existing behavior until a typed
-      // result envelope or explicit merge policy replaces it.
+      // Accumulate non-blocking decisions so the caller can inspect them
+      // (e.g., SubagentStop handlers that return injectContext).
       lastDecision = decision;
     }
 

--- a/src/agent/hooks-longrunning.test.ts
+++ b/src/agent/hooks-longrunning.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for the `longRunning` per-handler registration option added to
+ * {@link HookRegistry}.
+ *
+ * Invariant: a handler registered with `longRunning: true` does NOT race
+ * against the per-handler timeout. This is the load-bearing escape hatch
+ * for the path-approval hook, which awaits `elicitationRouter.route()`
+ * (a 5-minute human-input window) and would otherwise be killed by the
+ * default 30s timeout in the dispatch loop.
+ *
+ * The corresponding default-timeout behavior is already covered by
+ * `hooks.test.ts`. This file pins ONLY the new opt-out path.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { createHookRegistry } from './hooks.js';
+import type { HookHandler, SessionStartContext } from './hooks.js';
+
+function ctx(): SessionStartContext {
+  return { event: 'SessionStart', sessionId: 'sess-1' };
+}
+
+describe('HookRegistry — longRunning opt-out', () => {
+  it('longRunning handler is not killed by the per-handler timeout', async () => {
+    const registry = createHookRegistry();
+    // Handler resolves after 50ms — but we pass a 10ms timeout. Without
+    // `longRunning`, this would throw `HookHandlerTimeoutError`. With it,
+    // we expect the dispatch to wait the full 50ms.
+    const slow: HookHandler = async () => {
+      await new Promise((res) => setTimeout(res, 50));
+      return { reason: 'completed-after-timeout' };
+    };
+    registry.register('SessionStart', slow, { longRunning: true });
+
+    const decision = await registry.dispatch(ctx(), undefined, 10);
+    expect(decision.reason).toBe('completed-after-timeout');
+  });
+
+  it('default-registered handler IS killed by the timeout (sanity)', async () => {
+    const registry = createHookRegistry();
+    const slow: HookHandler = async () => {
+      await new Promise((res) => setTimeout(res, 50));
+      return {};
+    };
+    registry.register('SessionStart', slow);
+
+    await expect(registry.dispatch(ctx(), undefined, 10)).rejects.toMatchObject({
+      code: 'HOOK_HANDLER_TIMEOUT',
+    });
+  });
+
+  it('register returns an unsubscribe that removes the longRunning entry', async () => {
+    const registry = createHookRegistry();
+    const handler = vi.fn(async () => ({}));
+    const off = registry.register('SessionStart', handler, { longRunning: true });
+    expect(registry.count('SessionStart')).toBe(1);
+    off();
+    expect(registry.count('SessionStart')).toBe(0);
+    await registry.dispatch(ctx());
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('mixing longRunning and bounded handlers in one event works', async () => {
+    const registry = createHookRegistry();
+    const bounded = vi.fn<HookHandler>(async () => ({}));
+    const slow: HookHandler = async () => {
+      await new Promise((res) => setTimeout(res, 50));
+      return {};
+    };
+    registry.register('SessionStart', bounded);
+    registry.register('SessionStart', slow, { longRunning: true });
+
+    // 10ms timeout would kill the slow handler if it were bounded; here it
+    // shouldn't. The bounded one runs first.
+    const decision = await registry.dispatch(ctx(), undefined, 10);
+    expect(bounded).toHaveBeenCalledTimes(1);
+    expect(decision).toBeDefined();
+  });
+});

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -18,16 +18,10 @@
  * with the original error attached as `cause`. This prevents a bug in one
  * handler from silently skipping policy enforcement.
  *
- * **Context injection (SubagentStop only):** Foreground subagents hand their
- * final assistant output to the parent through the normal `agent` tool result;
- * `injectContext` is a separate hook-generated framework note, not text typed
- * by the human user. When a `SubagentStop` handler returns `injectContext`, the
- * dispatch result is propagated to the caller, which queues the context string
- * to the parent session's input stream for the parent's next turn. If the
- * parent is aborting, the injection is skipped. DAG/compose and background
- * paths are not guaranteed to inject (some intentionally leave this channel
- * dark), and multiple `injectContext` values do not merge today: hook dispatch
- * returns the last non-blocking decision. Other hook events ignore
+ * **Context injection (SubagentStop only):** When a `SubagentStop` handler
+ * returns `injectContext`, the dispatch result is propagated to the caller,
+ * which queues the context string to the parent session's input stream. If
+ * the parent is aborting, the injection is skipped. Other hook events ignore
  * `injectContext` entirely.
  *
  * @module agent/hooks
@@ -52,12 +46,9 @@ export interface HookDecision {
   /** Human-readable rationale for blocking or approving. */
   reason?: string;
   /**
-   * (SubagentStop only) Framework-generated context to inject into the parent
-   * session's next turn. This is not human-authored user text. Queued to the
-   * parent's input stream after dispatch completes; dropped if the parent is
-   * aborting. DAG/compose and background paths may intentionally not inject.
-   * Multiple injected contexts currently do not merge — the last non-blocking
-   * hook decision wins. Ignored for all other hook events.
+   * (SubagentStop only) Context to inject into the parent session's next turn.
+   * Queued to parent's input stream after dispatch completes. Dropped if parent is aborting.
+   * Ignored for all other hook events.
    */
   injectContext?: string;
 }
@@ -68,6 +59,14 @@ export type SubagentHookStatus = 'idle' | 'running' | 'succeeded' | 'failed' | '
 export interface SessionStartContext {
   event: 'SessionStart';
   sessionId?: string;
+  /**
+   * Parent session id when this SessionStart belongs to a forked subagent
+   * (set from {@link AgentConfig.parentSessionId}). Top-level sessions leave
+   * this undefined. Session-scoped SessionStart hooks (e.g. the pattern-card
+   * appearance writer) use it to skip subagents so per-session telemetry
+   * counts only top-level sessions.
+   */
+  parentSessionId?: string;
 }
 
 export interface SessionEndContext {
@@ -136,6 +135,13 @@ export interface PostToolUseContext {
   sessionId?: string;
   subagentId?: string;
   toolName: string;
+  /**
+   * Tool-call input passed through from {@link PreToolUseContext}. Carried
+   * verbatim so hooks that need to correlate Pre/PostToolUse for the same
+   * call (e.g. the path-approval hook's "Once" cleanup) can recompute the
+   * resolved path identically.
+   */
+  input?: unknown;
   output?: unknown;
 }
 
@@ -148,11 +154,36 @@ export type HookContext =
   | PreToolUseContext
   | PostToolUseContext;
 
-export type HookHandler = (context: HookContext) => HookDecision | Promise<HookDecision>;
+/**
+ * A hook handler. `signal` is the turn/dispatch {@link AbortSignal} forwarded
+ * by `dispatch()`; handlers that await human input (see `longRunning` below)
+ * MUST observe it so session/turn teardown can cancel the wait. Synchronous
+ * and short-lived handlers can ignore it.
+ */
+export type HookHandler = (
+  context: HookContext,
+  signal?: AbortSignal,
+) => HookDecision | Promise<HookDecision>;
+
+/**
+ * Per-handler registration options.
+ *
+ * `longRunning` opts the handler out of the per-handler timeout enforced by
+ * `dispatch()`. Use ONLY for handlers that legitimately need to await human
+ * input (e.g. the path-approval hook calling `elicitationRouter.route()`,
+ * which waits indefinitely for an operator who may be away from keyboard).
+ * The default 30s per-handler timeout exists to bound hung policy handlers —
+ * opting out of it means YOU own teardown: observe the turn `AbortSignal`
+ * (passed as the second handler argument) so session/turn abort can still
+ * cancel the wait. There is no time-based auto-decline.
+ */
+export interface RegisterOptions {
+  longRunning?: boolean;
+}
 
 export interface HookRegistry {
   /** Register a handler for an event. Returns an unsubscribe function. */
-  register(event: HarnessHookEvent, handler: HookHandler): () => void;
+  register(event: HarnessHookEvent, handler: HookHandler, options?: RegisterOptions): () => void;
   /**
    * Dispatch a context through the handlers registered for its event.
    * Throws {@link AbortError} if `signal` aborts before or during dispatch.

--- a/src/agent/hooks/config-bridge.test.ts
+++ b/src/agent/hooks/config-bridge.test.ts
@@ -341,6 +341,7 @@ describe('createDefaultHookRegistry integration', () => {
   let afkHome: string;
   let projectCwd: string;
   let originalAfkHome: string | undefined;
+  let originalDisablePathApproval: string | undefined;
 
   beforeEach(() => {
     afkHome = join(tmp, 'afk-home');
@@ -349,11 +350,19 @@ describe('createDefaultHookRegistry integration', () => {
     mkdirSync(projectCwd, { recursive: true });
     originalAfkHome = process.env['AFK_HOME'];
     process.env['AFK_HOME'] = afkHome;
+    // Disable path-approval hooks during these tests so they don't inflate
+    // PreToolUse counts and conflate the config-bridge assertion logic with
+    // the unrelated path-approval feature.
+    originalDisablePathApproval = process.env['AFK_DISABLE_PATH_APPROVAL'];
+    process.env['AFK_DISABLE_PATH_APPROVAL'] = '1';
   });
 
   afterEach(() => {
     if (originalAfkHome === undefined) delete process.env['AFK_HOME'];
     else process.env['AFK_HOME'] = originalAfkHome;
+    if (originalDisablePathApproval === undefined)
+      delete process.env['AFK_DISABLE_PATH_APPROVAL'];
+    else process.env['AFK_DISABLE_PATH_APPROVAL'] = originalDisablePathApproval;
   });
 
   it('createDefaultHookRegistry without hookConfig → 0 config hooks registered', () => {

--- a/src/agent/permissions-store.test.ts
+++ b/src/agent/permissions-store.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for the persisted path-approval grant store
+ * (`~/.afk/config/permissions.json`).
+ *
+ * Coverage:
+ *   - Empty/missing file → returns empty
+ *   - Corrupt file → returns empty (fail-soft, never throws)
+ *   - Append round-trip via temp dir
+ *   - ULID format (26 chars, sortable by time)
+ *   - Revoke by ID
+ *   - `allowedPathsForMode` honors expiresAt
+ */
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  allowedPathsForMode,
+  appendGrant,
+  generateUlid,
+  loadPermissionsFile,
+  revokeGrantById,
+  seedPersistedGrants,
+} from './permissions-store.js';
+
+let scratch: string;
+let storePath: string;
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), 'afk-permissions-test-'));
+  storePath = join(scratch, 'permissions.json');
+});
+
+describe('generateUlid', () => {
+  it('produces a 26-character string in the Crockford-base32 alphabet', () => {
+    const ulid = generateUlid();
+    expect(ulid).toHaveLength(26);
+    expect(ulid).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+  });
+
+  it('encodes the provided timestamp in the leading 10 chars', () => {
+    const t1 = generateUlid(0);
+    const t2 = generateUlid(Date.now());
+    // Lexicographic comparison on Crockford-base32 = numeric comparison
+    // when both have the same length, so t2 > t1.
+    expect(t2 > t1).toBe(true);
+  });
+});
+
+describe('loadPermissionsFile', () => {
+  it('returns an empty file when none exists', () => {
+    const file = loadPermissionsFile(storePath);
+    expect(file).toEqual({ version: 1, grants: [] });
+  });
+
+  it('returns an empty file on JSON parse error (fail-soft)', () => {
+    writeFileSync(storePath, '{ corrupt', 'utf8');
+    expect(loadPermissionsFile(storePath)).toEqual({ version: 1, grants: [] });
+  });
+
+  it('returns an empty file when version is wrong', () => {
+    writeFileSync(storePath, JSON.stringify({ version: 999, grants: [] }), 'utf8');
+    expect(loadPermissionsFile(storePath)).toEqual({ version: 1, grants: [] });
+  });
+
+  it('drops invalid grant entries silently', () => {
+    writeFileSync(
+      storePath,
+      JSON.stringify({
+        version: 1,
+        grants: [
+          { id: 'a', path: '/x', mode: 'read', decision: 'allow', grantedAt: 'now', source: 'manual' },
+          { id: 'b', path: '/y' /* missing mode */ },
+          'not-an-object',
+        ],
+      }),
+      'utf8',
+    );
+    const file = loadPermissionsFile(storePath);
+    expect(file.grants).toHaveLength(1);
+    expect(file.grants[0]?.path).toBe('/x');
+  });
+});
+
+describe('appendGrant', () => {
+  it('stamps ID + grantedAt and persists atomically', () => {
+    const grant = appendGrant(
+      {
+        path: '/Users/alice/.ssh',
+        mode: 'read',
+        decision: 'allow',
+        source: 'elicit:repl',
+        reason: 'test',
+      },
+      storePath,
+    );
+
+    expect(grant.id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(grant.grantedAt).toBeDefined();
+    expect(existsSync(storePath)).toBe(true);
+
+    // Reload from disk and verify the grant round-trips.
+    const reloaded = loadPermissionsFile(storePath);
+    expect(reloaded.grants).toHaveLength(1);
+    expect(reloaded.grants[0]?.path).toBe('/Users/alice/.ssh');
+  });
+
+  it('appends multiple grants in order', () => {
+    appendGrant(
+      { path: '/a', mode: 'read', decision: 'allow', source: 'manual' },
+      storePath,
+    );
+    appendGrant(
+      { path: '/b', mode: 'write', decision: 'allow', source: 'manual' },
+      storePath,
+    );
+    const file = loadPermissionsFile(storePath);
+    expect(file.grants.map((g) => g.path)).toEqual(['/a', '/b']);
+  });
+
+  it('produces JSON that is human-readable (pretty-printed)', () => {
+    appendGrant(
+      { path: '/a', mode: 'read', decision: 'allow', source: 'manual' },
+      storePath,
+    );
+    const raw = readFileSync(storePath, 'utf8');
+    // Two-space indent + grant body on its own line.
+    expect(raw).toContain('"version": 1');
+    expect(raw).toContain('"grants":');
+    expect(raw).toContain('\n');
+  });
+});
+
+describe('revokeGrantById', () => {
+  it('removes the matching grant and returns true', () => {
+    const a = appendGrant({ path: '/a', mode: 'read', decision: 'allow', source: 'manual' }, storePath);
+    const b = appendGrant({ path: '/b', mode: 'read', decision: 'allow', source: 'manual' }, storePath);
+
+    expect(revokeGrantById(a.id, storePath)).toBe(true);
+    const after = loadPermissionsFile(storePath);
+    expect(after.grants.map((g) => g.id)).toEqual([b.id]);
+  });
+
+  it('returns false when no record matches', () => {
+    appendGrant({ path: '/a', mode: 'read', decision: 'allow', source: 'manual' }, storePath);
+    expect(revokeGrantById('NONEXISTENT', storePath)).toBe(false);
+  });
+});
+
+describe('allowedPathsForMode', () => {
+  it('returns paths for the requested mode (read sees both read+write grants)', () => {
+    appendGrant({ path: '/r', mode: 'read', decision: 'allow', source: 'manual' }, storePath);
+    appendGrant({ path: '/w', mode: 'write', decision: 'allow', source: 'manual' }, storePath);
+    expect(allowedPathsForMode('read', storePath).sort()).toEqual(['/r', '/w']);
+    expect(allowedPathsForMode('write', storePath)).toEqual(['/w']);
+  });
+
+  it('filters out denied grants', () => {
+    appendGrant({ path: '/blocked', mode: 'read', decision: 'deny', source: 'manual' }, storePath);
+    expect(allowedPathsForMode('read', storePath)).toEqual([]);
+  });
+
+  it('respects expiresAt', () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const future = new Date(Date.now() + 60_000).toISOString();
+    appendGrant({
+      path: '/expired',
+      mode: 'read',
+      decision: 'allow',
+      source: 'manual',
+      expiresAt: past,
+    }, storePath);
+    appendGrant({
+      path: '/live',
+      mode: 'read',
+      decision: 'allow',
+      source: 'manual',
+      expiresAt: future,
+    }, storePath);
+
+    expect(allowedPathsForMode('read', storePath)).toEqual(['/live']);
+  });
+});
+
+describe('seedPersistedGrants', () => {
+  it('seeds read + write roots from persisted allow grants (F1 regression)', () => {
+    appendGrant({ path: '/r', mode: 'read', decision: 'allow', source: 'manual' }, storePath);
+    appendGrant({ path: '/w', mode: 'write', decision: 'allow', source: 'manual' }, storePath);
+
+    const reads: string[] = [];
+    const writes: string[] = [];
+    seedPersistedGrants(
+      { addReadRoot: (p) => reads.push(p), addWriteRoot: (p) => writes.push(p) },
+      storePath,
+    );
+
+    // read loop sees read+write grants (read ⊆ write); write loop only write grants.
+    expect(reads.sort()).toEqual(['/r', '/w']);
+    expect(writes).toEqual(['/w']);
+  });
+
+  it('is a no-op when the store is empty/absent', () => {
+    const reads: string[] = [];
+    const writes: string[] = [];
+    seedPersistedGrants(
+      { addReadRoot: (p) => reads.push(p), addWriteRoot: (p) => writes.push(p) },
+      storePath,
+    );
+    expect(reads).toEqual([]);
+    expect(writes).toEqual([]);
+  });
+});

--- a/src/agent/permissions-store.ts
+++ b/src/agent/permissions-store.ts
@@ -274,10 +274,17 @@ export function seedPersistedGrants(
  * concurrent reads never see a half-written JSON document.
  */
 function writeAtomic(filePath: string, contents: PermissionsFile): void {
-  mkdirSync(dirname(filePath), { recursive: true });
+  // Owner-only dir + file. permissions.json enumerates the operator-approved
+  // path prefixes; on a shared host a world-readable file would leak the
+  // workspace layout to other local users. mode is best-effort (masked by the
+  // process umask), but 0o600/0o700 carry no group/other bits, so any
+  // reasonable umask preserves them. mkdirSync's mode only applies when the
+  // directory is created, so an existing ~/.afk/config is left untouched.
+  mkdirSync(dirname(filePath), { recursive: true, mode: 0o700 });
   const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
-  writeFileSync(tmp, JSON.stringify(contents, null, 2) + '\n', 'utf8');
+  writeFileSync(tmp, JSON.stringify(contents, null, 2) + '\n', { encoding: 'utf8', mode: 0o600 });
   // fs.renameSync is atomic within a single filesystem on POSIX + NTFS;
-  // sufficient for our user-scope config file.
+  // sufficient for our user-scope config file. rename preserves the temp
+  // file's 0o600 mode.
   renameSync(tmp, filePath);
 }

--- a/src/agent/permissions-store.ts
+++ b/src/agent/permissions-store.ts
@@ -1,0 +1,283 @@
+/**
+ * Persisted path-access grants for the path-approval elicitation flow.
+ *
+ * # Schema
+ *
+ * Lives at `~/.afk/config/permissions.json` (policy, not runtime state).
+ * Designed for both machine round-tripping and `cat`-readable audit.
+ *
+ * ```json
+ * {
+ *   "version": 1,
+ *   "grants": [
+ *     {
+ *       "id": "01JBXR3K8N7Q9V4E2T6Y0W8A1F",
+ *       "path": "/Users/alice/Library/Application Support/Cursor/User",
+ *       "mode": "read",
+ *       "decision": "allow",
+ *       "grantedAt": "2026-05-25T15:30:00Z",
+ *       "source": "elicit:repl",
+ *       "reason": "Approved via inline prompt"
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * # Design notes
+ *
+ * - **Structured records, not Claude Code's stringly-typed `Read(path/**)` DSL.**
+ *   Each field has a single meaning. `mode` and `decision` are their own
+ *   columns, not encoded inside a string.
+ * - **Stable IDs.** Each grant carries a ULID so `afk permissions revoke <id>`
+ *   can target a specific record without parsing globs.
+ * - **Provenance.** `source` records which surface created the grant
+ *   (`elicit:repl`, `elicit:telegram`, `manual`); useful when auditing.
+ * - **TTL-ready.** `expiresAt` is reserved for a future "allow for the next
+ *   hour" feature. Not consumed today.
+ *
+ * # Threat model
+ *
+ * This file controls a non-adversarial policy boundary. A user with write
+ * access to `~/.afk/config/permissions.json` can already run arbitrary code
+ * in the same session, so file-level tamper protection is out of scope. The
+ * elicitation flow is the integrity boundary — only paths the user actually
+ * confirmed via prompt can be persisted here.
+ *
+ * @module agent/permissions-store
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+import { getPermissionsStorePath } from '../paths.js';
+
+export type GrantMode = 'read' | 'write';
+export type GrantDecision = 'allow' | 'deny';
+export type GrantSource = 'elicit:repl' | 'elicit:telegram' | 'manual';
+
+export interface PermissionGrant {
+  /** ULID — sortable, opaque, unique per grant. */
+  id: string;
+  /** Absolute filesystem path (or path prefix) the grant covers. */
+  path: string;
+  /** Whether this grant covers read-only or read+write access. */
+  mode: GrantMode;
+  /** `allow` adds to roots on load; `deny` is a future-reserved blocklist (no consumer today). */
+  decision: GrantDecision;
+  /** ISO-8601 timestamp of the elicitation accept. */
+  grantedAt: string;
+  /** Which surface produced the grant. */
+  source: GrantSource;
+  /** Free-form human-readable rationale. */
+  reason?: string;
+  /** Optional ISO-8601 expiry. Not consumed yet; reserved for "allow for 1h". */
+  expiresAt?: string;
+}
+
+export interface PermissionsFile {
+  version: 1;
+  grants: PermissionGrant[];
+}
+
+const EMPTY: PermissionsFile = { version: 1, grants: [] };
+
+/**
+ * Crockford-base32 ULID generator (no external dep).
+ *
+ * Contract: 26-character string, time-sortable, monotonic within a millisecond
+ * via random-tail increment (sufficient for human-driven grant creation rates).
+ * Not crypto-grade — these IDs are not secrets, they are revocation handles.
+ *
+ * Format: <10 chars time (ms since epoch, base32)><16 chars random (base32)>.
+ */
+const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+export function generateUlid(now: number = Date.now()): string {
+  // Time component — 10 chars, big-endian base32 of milliseconds.
+  let time = now;
+  const timeChars: string[] = new Array<string>(10).fill('0');
+  for (let i = 9; i >= 0; i--) {
+    timeChars[i] = CROCKFORD[time % 32]!;
+    time = Math.floor(time / 32);
+  }
+
+  // Randomness component — 16 chars from Math.random (sufficient for IDs;
+  // see contract note above).
+  const randChars: string[] = new Array<string>(16).fill('0');
+  for (let i = 0; i < 16; i++) {
+    randChars[i] = CROCKFORD[Math.floor(Math.random() * 32)]!;
+  }
+
+  return timeChars.join('') + randChars.join('');
+}
+
+/**
+ * Read the permissions file from disk. Returns an empty file on first run
+ * or on any read/parse error — never throws.
+ *
+ * Invariant: a corrupt file is treated as empty, NOT as a fail-closed reject.
+ * Fail-closed would leave users locked out of any path the model touched
+ * with no way to recover short of `rm`. The corruption is silent because the
+ * file is best-effort; rebuilding from elicitation prompts is the recovery
+ * path.
+ */
+export function loadPermissionsFile(
+  filePath: string = getPermissionsStorePath(),
+): PermissionsFile {
+  if (!existsSync(filePath)) return EMPTY;
+  try {
+    const raw = readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('version' in parsed) ||
+      (parsed as { version: unknown }).version !== 1 ||
+      !('grants' in parsed) ||
+      !Array.isArray((parsed as { grants: unknown }).grants)
+    ) {
+      return EMPTY;
+    }
+    const grants = (parsed as { grants: unknown[] }).grants.filter(isValidGrant);
+    return { version: 1, grants };
+  } catch (err) {
+    // Fail-soft (see the Invariant above): a read/parse failure returns empty
+    // rather than locking the user out. Surface it on stderr though — silent
+    // grant loss is hard to diagnose. The recovery path is re-approving via
+    // the elicitation prompt, which re-persists the grants.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[permissions] could not parse ${filePath} — treating as empty (persisted grants reset): ` +
+        (err instanceof Error ? err.message : String(err)),
+    );
+    return EMPTY;
+  }
+}
+
+function isValidGrant(value: unknown): value is PermissionGrant {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v['id'] === 'string' &&
+    typeof v['path'] === 'string' &&
+    (v['mode'] === 'read' || v['mode'] === 'write') &&
+    (v['decision'] === 'allow' || v['decision'] === 'deny') &&
+    typeof v['grantedAt'] === 'string' &&
+    typeof v['source'] === 'string'
+  );
+}
+
+/**
+ * Append a grant and persist atomically (write-temp + rename). Returns the
+ * grant after assignment of `id` and `grantedAt`.
+ *
+ * The caller passes the grant body without ID/timestamp; this function
+ * stamps both so the audit trail is consistent regardless of caller drift.
+ *
+ * Ordered-operation invariant: parent directory creation MUST precede the
+ * write to avoid ENOENT under a fresh `~/.afk/` tree. Constraint: file-system
+ * semantics — Node.js writeFileSync does not create parents.
+ */
+export function appendGrant(
+  body: Omit<PermissionGrant, 'id' | 'grantedAt'> & { grantedAt?: string },
+  filePath: string = getPermissionsStorePath(),
+): PermissionGrant {
+  const current = loadPermissionsFile(filePath);
+  const grant: PermissionGrant = {
+    id: generateUlid(),
+    grantedAt: body.grantedAt ?? new Date().toISOString(),
+    path: body.path,
+    mode: body.mode,
+    decision: body.decision,
+    source: body.source,
+    ...(body.reason !== undefined ? { reason: body.reason } : {}),
+    ...(body.expiresAt !== undefined ? { expiresAt: body.expiresAt } : {}),
+  };
+  const next: PermissionsFile = {
+    version: 1,
+    grants: [...current.grants, grant],
+  };
+  writeAtomic(filePath, next);
+  return grant;
+}
+
+/**
+ * Remove the grant matching `id`. Returns true on a successful removal,
+ * false if no record matched (caller can surface "no such grant").
+ */
+export function revokeGrantById(
+  id: string,
+  filePath: string = getPermissionsStorePath(),
+): boolean {
+  const current = loadPermissionsFile(filePath);
+  const next = current.grants.filter((g) => g.id !== id);
+  if (next.length === current.grants.length) return false;
+  writeAtomic(filePath, { version: 1, grants: next });
+  return true;
+}
+
+/**
+ * Return all `decision === 'allow'` grants for a given mode. Used at session
+ * bootstrap to seed `readRoots`/`writeRoots` with previously-persisted paths.
+ */
+export function allowedPathsForMode(
+  mode: GrantMode,
+  filePath: string = getPermissionsStorePath(),
+): string[] {
+  const file = loadPermissionsFile(filePath);
+  const now = Date.now();
+  return file.grants
+    .filter((g) => g.decision === 'allow')
+    .filter((g) => g.mode === mode || (mode === 'read' && g.mode === 'write'))
+    .filter((g) => {
+      // Honor expiresAt if set. Best-effort — comparing ISO strings via
+      // Date.parse is sufficient for hour-class TTLs.
+      if (g.expiresAt === undefined) return true;
+      const exp = Date.parse(g.expiresAt);
+      return Number.isFinite(exp) && exp > now;
+    })
+    .map((g) => g.path);
+}
+
+/**
+ * Seed a grant manager's read/write roots from the persisted `allow` grants in
+ * permissions.json. Call ONCE at interactive-session bootstrap, right after
+ * the grant manager is wired to the provider — this is what makes the
+ * `persist` elicitation choice actually deliver "future sessions inherit it".
+ *
+ * No-op when the file is absent or empty. `addReadRoot`/`addWriteRoot` are
+ * idempotent, so re-seeding (or overlap with the cwd root) is harmless. A
+ * write-mode grant is added to BOTH lists: `allowedPathsForMode('read')`
+ * includes write grants (read ⊆ write), and the write loop additionally pushes
+ * them into the write roots.
+ *
+ * The param is a structural subset of the `GrantManager` interface so this
+ * module (agent layer) needn't import it from the CLI layer.
+ */
+export function seedPersistedGrants(
+  grantManager: {
+    addReadRoot(absPath: string, source: 'slash' | 'tool'): void;
+    addWriteRoot(absPath: string, source: 'slash' | 'tool'): void;
+  },
+  filePath: string = getPermissionsStorePath(),
+): void {
+  for (const p of allowedPathsForMode('read', filePath)) {
+    grantManager.addReadRoot(p, 'tool');
+  }
+  for (const p of allowedPathsForMode('write', filePath)) {
+    grantManager.addWriteRoot(p, 'tool');
+  }
+}
+
+/**
+ * Atomic write: temp-file + rename. Mirrors the pattern used elsewhere in
+ * agent-afk for config files (`~/.afk/config/afk.config.json` etc.) so
+ * concurrent reads never see a half-written JSON document.
+ */
+function writeAtomic(filePath: string, contents: PermissionsFile): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  writeFileSync(tmp, JSON.stringify(contents, null, 2) + '\n', 'utf8');
+  // fs.renameSync is atomic within a single filesystem on POSIX + NTFS;
+  // sufficient for our user-scope config file.
+  renameSync(tmp, filePath);
+}

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -527,7 +527,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
       // PostToolUse hook fires for agent calls too.
       // Fire-and-forget: mirrors executeCore() — hook latency must not block
       // the tool result from being returned to the model on the critical path.
-      this.firePostToolUse(call.name, result.content, call.signal);
+      this.firePostToolUse(call.name, result.content, call.signal, call.input);
       return result;
     }
 
@@ -548,14 +548,14 @@ export class SessionToolDispatcher implements ToolDispatcher {
       }
       // Fire-and-forget: mirrors executeCore() — hook + trace-write latency
       // must not add to per-tool round-trip time on the single-call path.
-      this.firePostToolUse(call.name, result.content, call.signal);
+      this.firePostToolUse(call.name, result.content, call.signal, call.input);
       return result;
     }
 
     // 3c. Compose tool — DAG-based parallel subagent dispatch
     if (call.name === 'compose') {
       const result = await this.executeCompose(call);
-      this.firePostToolUse(call.name, result.content, call.signal);
+      this.firePostToolUse(call.name, result.content, call.signal, call.input);
       return result;
     }
 
@@ -580,7 +580,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
     // 6. PostToolUse hook — fire-and-forget to align with executeCore().
     // Errors are caught inside firePostToolUse (.catch(() => {})), so
     // hook failures never surface as tool errors (same behaviour as before).
-    this.firePostToolUse(call.name, result.content, call.signal);
+    this.firePostToolUse(call.name, result.content, call.signal, call.input);
 
     return result;
   }
@@ -758,7 +758,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
         const message = err instanceof Error ? err.message : String(err);
         result = { content: `Agent tool error: ${message}`, isError: true };
       }
-      this.firePostToolUse(call.name, result.content, call.signal);
+      this.firePostToolUse(call.name, result.content, call.signal, call.input);
       return result;
     }
 
@@ -777,14 +777,14 @@ export class SessionToolDispatcher implements ToolDispatcher {
         const message = err instanceof Error ? err.message : String(err);
         result = { content: `Skill tool error: ${message}`, isError: true };
       }
-      this.firePostToolUse(call.name, result.content, call.signal);
+      this.firePostToolUse(call.name, result.content, call.signal, call.input);
       return result;
     }
 
     // Compose tool — DAG-based parallel subagent dispatch
     if (call.name === 'compose') {
       const result = await this.executeCompose(call);
-      this.firePostToolUse(call.name, result.content, call.signal);
+      this.firePostToolUse(call.name, result.content, call.signal, call.input);
       return result;
     }
 
@@ -805,7 +805,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
       result = { content: `Tool execution error: ${message}`, isError: true };
     }
 
-    this.firePostToolUse(call.name, result.content, call.signal);
+    this.firePostToolUse(call.name, result.content, call.signal, call.input);
     return result;
   }
 
@@ -830,12 +830,18 @@ export class SessionToolDispatcher implements ToolDispatcher {
    * completion. Routes through `dispatchPostToolUse` so the
    * witness-layer `hook_decision` event lands automatically.
    */
-  private firePostToolUse(toolName: string, output: string, signal: AbortSignal): void {
+  private firePostToolUse(
+    toolName: string,
+    output: string,
+    signal: AbortSignal,
+    input?: unknown,
+  ): void {
     if (!this.hookRegistry) return;
     const postCtx: PostToolUseContext = {
       event: 'PostToolUse',
       toolName,
       output,
+      ...(input !== undefined ? { input } : {}),
     };
     void dispatchPostToolUse(this.hookRegistry, postCtx, {
       signal,

--- a/src/agent/tools/handlers/_cwd-utils.test.ts
+++ b/src/agent/tools/handlers/_cwd-utils.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the path containment helpers used by all filesystem handlers
+ * AND the path-approval PreToolUse hook.
+ *
+ * The two functions MUST agree on what "contained" means: `resolveAndContain`
+ * throws when out-of-bounds, `wouldBeRestricted` returns `restricted: true`
+ * on the SAME inputs. Drift would mean the hook prompts for paths the
+ * handler then accepts (over-prompting) or skips paths the handler then
+ * rejects (silent containment failure).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveAndContain, wouldBeRestricted } from './_cwd-utils.js';
+import type { ToolHandlerContext } from '../types.js';
+
+const BASE = '/tmp/repo';
+const OUTSIDE = '/etc/passwd';
+const INSIDE = '/tmp/repo/src/foo.ts';
+
+function ctx(overrides: Partial<ToolHandlerContext> = {}): ToolHandlerContext {
+  return {
+    cwd: BASE,
+    resolveBase: BASE,
+    readRoots: [BASE],
+    writeRoots: [BASE],
+    ...overrides,
+  };
+}
+
+describe('resolveAndContain', () => {
+  it('returns the absolute path for inputs inside the resolveBase', () => {
+    expect(resolveAndContain(INSIDE, ctx())).toBe(INSIDE);
+    expect(resolveAndContain('src/foo.ts', ctx())).toBe(INSIDE);
+  });
+
+  it('throws when path falls outside every allowed root', () => {
+    expect(() => resolveAndContain(OUTSIDE, ctx())).toThrow(/outside the allowed/);
+  });
+
+  it('falls through to abs (no enforcement) when no resolveBase set', () => {
+    expect(
+      resolveAndContain(OUTSIDE, {
+        cwd: undefined,
+        resolveBase: undefined,
+        readRoots: undefined,
+        writeRoots: undefined,
+      } as ToolHandlerContext),
+    ).toBe(OUTSIDE);
+  });
+
+  it('accepts paths inside an extra granted root', () => {
+    const extra = '/tmp/other';
+    expect(
+      resolveAndContain('/tmp/other/secrets.json', ctx({ readRoots: [BASE, extra] })),
+    ).toBe('/tmp/other/secrets.json');
+  });
+
+  it('throws on writes to a read-only path', () => {
+    expect(() =>
+      resolveAndContain('/tmp/other/x.txt', ctx({ readRoots: [BASE, '/tmp/other'] }), 'write'),
+    ).toThrow(/outside the allowed write roots/);
+  });
+});
+
+describe('wouldBeRestricted', () => {
+  it('agrees with resolveAndContain for inside paths (restricted=false)', () => {
+    const verdict = wouldBeRestricted(INSIDE, ctx());
+    expect(verdict.restricted).toBe(false);
+    expect(verdict.resolved).toBe(INSIDE);
+  });
+
+  it('agrees with resolveAndContain for outside paths (restricted=true)', () => {
+    const verdict = wouldBeRestricted(OUTSIDE, ctx());
+    expect(verdict.restricted).toBe(true);
+    expect(verdict.resolved).toBe(OUTSIDE);
+    expect(verdict.roots).toContain(BASE);
+  });
+
+  it('returns restricted=false when no resolveBase (enforcement disabled)', () => {
+    const verdict = wouldBeRestricted(OUTSIDE, {
+      cwd: undefined,
+      resolveBase: undefined,
+      readRoots: undefined,
+      writeRoots: undefined,
+    } as ToolHandlerContext);
+    expect(verdict.restricted).toBe(false);
+  });
+
+  it('distinguishes read vs write containment', () => {
+    const c = ctx({ readRoots: [BASE, '/tmp/extra'], writeRoots: [BASE] });
+    expect(wouldBeRestricted('/tmp/extra/x.txt', c, 'read').restricted).toBe(false);
+    expect(wouldBeRestricted('/tmp/extra/x.txt', c, 'write').restricted).toBe(true);
+  });
+
+  it('resolves relative paths against resolveBase', () => {
+    const verdict = wouldBeRestricted('src/foo.ts', ctx());
+    expect(verdict.restricted).toBe(false);
+    expect(verdict.resolved).toBe(INSIDE);
+  });
+
+  it('does not throw when restricted (key contract: returns instead of throws)', () => {
+    expect(() => wouldBeRestricted(OUTSIDE, ctx())).not.toThrow();
+  });
+});

--- a/src/agent/tools/handlers/_cwd-utils.ts
+++ b/src/agent/tools/handlers/_cwd-utils.ts
@@ -60,3 +60,53 @@ export function resolveAndContain(
   const noun = mode === 'read' ? 'read roots' : 'write roots';
   throw new Error(`Path \`${inputPath}\` is outside the allowed ${noun} [${rootList}].`);
 }
+
+/**
+ * Non-throwing variant of {@link resolveAndContain}: returns the resolution
+ * verdict instead of throwing on a containment failure. Used by the
+ * path-approval PreToolUse hook to decide whether to prompt the user BEFORE
+ * the handler's resolveAndContain throws.
+ *
+ * Contract:
+ * - `resolved` is always the absolute path that `resolveAndContain` would
+ *   produce. Callers can pass it straight to `addReadRoot/addWriteRoot` on
+ *   the grant manager after an approval prompt.
+ * - `restricted: false` means the path is contained within at least one
+ *   allowed root (or no `resolveBase` is set, which disables enforcement).
+ * - `restricted: true` means EVERY root rejected the path; the caller should
+ *   either elicit user approval or block.
+ *
+ * Mirrors `resolveAndContain`'s logic exactly — duplicating ~10 LOC is cheaper
+ * than restructuring the throwing variant around a result object, and the
+ * unit test suite pins both functions to the same containment semantics.
+ */
+export function wouldBeRestricted(
+  inputPath: string,
+  context: ToolHandlerContext | undefined,
+  mode: 'read' | 'write' = 'read',
+): { restricted: boolean; resolved: string; roots: string[] } {
+  const resolveBase = context?.resolveBase ?? context?.cwd;
+
+  const abs = path.isAbsolute(inputPath)
+    ? inputPath
+    : path.resolve(resolveBase ?? process.cwd(), inputPath);
+
+  if (resolveBase === undefined) {
+    // No containment enforcement — never restricted.
+    return { restricted: false, resolved: abs, roots: [] };
+  }
+
+  const roots: string[] =
+    mode === 'read'
+      ? (context?.readRoots ?? [resolveBase])
+      : (context?.writeRoots ?? [resolveBase]);
+
+  for (const root of roots) {
+    const rel = path.relative(root, abs);
+    if (!rel.startsWith('..')) {
+      return { restricted: false, resolved: abs, roots };
+    }
+  }
+
+  return { restricted: true, resolved: abs, roots };
+}

--- a/src/agent/tools/hooks/bash-restriction-hook.test.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.test.ts
@@ -79,6 +79,32 @@ describe('createBashRestrictionHook — interpreter denylist', () => {
     // `python3 script.py` is fine — not running code from the command line.
     expect(hook(ctx('python3 script.py')).decision).not.toBe('block');
   });
+
+  it('blocks version-qualified interpreters (python3.10 -c, python3.11 -c)', () => {
+    // Regression: `python3.10` previously slipped past the denylist because the
+    // pattern only listed `python`/`python3` with no version suffix.
+    expect(hook(ctx('python3.10 -c "import os"')).decision).toBe('block');
+    expect(hook(ctx('python3.11 -c "1+1"')).decision).toBe('block');
+  });
+
+  it('blocks combined eval-flag clusters (python -ec, bash -lc, perl -ne)', () => {
+    // Regression: combined short-flag clusters (`-ec`, `-lc`) previously evaded
+    // the `-[cCeE](\s|$)` pattern, which required the eval letter immediately
+    // after the dash.
+    expect(hook(ctx('python -ec "x"')).decision).toBe('block');
+    expect(hook(ctx('bash -lc "rm x"')).decision).toBe('block');
+    expect(hook(ctx('perl -ne "print"')).decision).toBe('block');
+  });
+
+  it('does NOT block common non-eval interpreter flags (no FP from flag widening)', () => {
+    // Widening the flag match to clusters must not catch version/module/warn
+    // flags that contain no eval letter at the cluster end.
+    expect(hook(ctx('python --version')).decision).not.toBe('block');
+    expect(hook(ctx('python -V')).decision).not.toBe('block');
+    expect(hook(ctx('python -m mymod')).decision).not.toBe('block');
+    expect(hook(ctx('python -W error script.py')).decision).not.toBe('block');
+    expect(hook(ctx('node -v')).decision).not.toBe('block');
+  });
 });
 
 describe('createBashRestrictionHook — interpreter guard opt-out (AFK_DISABLE_BASH_INTERPRETER_GUARD)', () => {
@@ -164,6 +190,21 @@ describe('createBashRestrictionHook — restricted-root substring', () => {
     // using $HOME or ~. Both get normalized and matched.
     expect(hook(ctx('cat $HOME/.ssh/id_rsa')).decision).toBe('block');
     expect(hook(ctx('cat ~/.ssh/id_rsa')).decision).toBe('block');
+  });
+
+  it('normalizes the ${HOME} brace form before checking', () => {
+    // Regression: `${HOME}` (brace form) previously slipped past the $HOME
+    // normalization (which only matched the bare `$HOME` form) and bypassed
+    // the restricted-path substring check. Single-quoted so JS does not
+    // interpolate — the hook receives the literal `${HOME}`.
+    const decision = hook(ctx('cat ${HOME}/.ssh/id_rsa'));
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toMatch(/restricted path/);
+  });
+
+  it('does NOT mangle unrelated $HOME-prefixed vars ($HOMEDIR)', () => {
+    // `$HOME\b` boundary: `$HOMEDIR` must not be partially expanded.
+    expect(hook(ctx('echo $HOMEDIR')).decision).not.toBe('block');
   });
 });
 

--- a/src/agent/tools/hooks/bash-restriction-hook.test.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for `createBashRestrictionHook` — pre-tool-use gate that hard-blocks
+ * bash invocations referencing restricted paths or evaluating interpreter
+ * code.
+ *
+ * Threat-model invariant pinned by these tests:
+ *   - Substring match catches the cat /restricted/path case we observed.
+ *   - The interpreter denylist catches python -c, node -e, ruby -e, sh -c.
+ *   - Variable-assembled bypasses are EXPLICITLY out of scope — see
+ *     `bash-restriction-hook.ts` module header. The "documented bypass"
+ *     test pins that behavior.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createBashRestrictionHook } from './bash-restriction-hook.js';
+import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
+import type { PreToolUseContext } from '../../hooks.js';
+import { homedir } from 'os';
+
+function mockGrants(): GrantManager {
+  return {
+    addReadRoot: () => {},
+    addWriteRoot: () => {},
+    revokeRoot: () => {},
+    getGrants() {
+      return { resolveBase: '/tmp/repo', readRoots: ['/tmp/repo'], writeRoots: ['/tmp/repo'] };
+    },
+  };
+}
+
+function ctx(command: unknown): PreToolUseContext {
+  return { event: 'PreToolUse', toolName: 'bash', input: { command } };
+}
+
+describe('createBashRestrictionHook — interpreter denylist', () => {
+  const hook = createBashRestrictionHook({ getGrantManager: mockGrants });
+
+  it('blocks python -c', () => {
+    const decision = hook(ctx('python -c "import os; print(os.uname())"'));
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toContain('Interpreter');
+  });
+
+  it('blocks python3 -c', () => {
+    expect(hook(ctx('python3 -c "1+1"')).decision).toBe('block');
+  });
+
+  it('blocks node -e', () => {
+    expect(hook(ctx('node -e "console.log(1)"')).decision).toBe('block');
+  });
+
+  it('blocks ruby -e', () => {
+    expect(hook(ctx('ruby -e "puts 1"')).decision).toBe('block');
+  });
+
+  it('blocks osascript -e', () => {
+    expect(hook(ctx('osascript -e \'tell app "Finder" to quit\'')).decision).toBe('block');
+  });
+
+  it('blocks sh -c, bash -c, zsh -c, fish -c', () => {
+    expect(hook(ctx('sh -c "rm x"')).decision).toBe('block');
+    expect(hook(ctx('bash -c "rm x"')).decision).toBe('block');
+    expect(hook(ctx('zsh -c "rm x"')).decision).toBe('block');
+    expect(hook(ctx('fish -c "rm x"')).decision).toBe('block');
+  });
+
+  it('block message names typed file tools as the proper escape', () => {
+    const decision = hook(ctx('python -c "open(\\"/etc/passwd\\").read()"'));
+    expect(decision.reason).toMatch(/read_file|write_file|edit_file/);
+  });
+
+  it('does NOT block paths that just CONTAIN the interpreter name', () => {
+    // `which python3` shouldn't match the denylist (python3 NOT followed by -c/-e).
+    expect(hook(ctx('which python3')).decision).not.toBe('block');
+    expect(hook(ctx('cat /usr/local/bin/python3-config')).decision).not.toBe('block');
+  });
+
+  it('does NOT block interpreter run without eval flag', () => {
+    // `python3 script.py` is fine — not running code from the command line.
+    expect(hook(ctx('python3 script.py')).decision).not.toBe('block');
+  });
+});
+
+describe('createBashRestrictionHook — interpreter guard opt-out (AFK_DISABLE_BASH_INTERPRETER_GUARD)', () => {
+  it('skips the interpreter denylist when disableInterpreterGuard is true', () => {
+    const hook = createBashRestrictionHook({
+      getGrantManager: mockGrants,
+      disableInterpreterGuard: true,
+    });
+    expect(hook(ctx('python -c "1+1"')).decision).not.toBe('block');
+    expect(hook(ctx('sh -c "echo hi"')).decision).not.toBe('block');
+    expect(hook(ctx('node -e "console.log(1)"')).decision).not.toBe('block');
+  });
+
+  it('opting out does NOT weaken the restricted-root substring check', () => {
+    // The granular escape lifts ONLY the interpreter denylist — a bash command
+    // that literally references a restricted path must still be blocked.
+    const hook = createBashRestrictionHook({
+      getGrantManager: mockGrants,
+      disableInterpreterGuard: true,
+    });
+    const decision = hook(ctx(`cat ${homedir()}/.ssh/id_rsa`));
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toMatch(/restricted path/);
+  });
+
+  it('guard is active by default when the option is omitted', () => {
+    const hook = createBashRestrictionHook({ getGrantManager: mockGrants });
+    expect(hook(ctx('python -c "1+1"')).decision).toBe('block');
+  });
+});
+
+describe('createBashRestrictionHook — restricted-root substring', () => {
+  const hook = createBashRestrictionHook({ getGrantManager: mockGrants });
+  const home = homedir();
+
+  it('blocks `cat ~/.ssh/...`', () => {
+    const decision = hook(ctx(`cat ${home}/.ssh/id_rsa`));
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toMatch(/restricted path/);
+  });
+
+  it('blocks `cat ~/.aws/credentials`', () => {
+    const decision = hook(ctx(`cat ${home}/.aws/credentials`));
+    expect(decision.decision).toBe('block');
+  });
+
+  it('block reason names the restricted prefix', () => {
+    const decision = hook(ctx(`grep secret ${home}/.gnupg/keys`));
+    expect(decision.reason).toContain('.gnupg');
+  });
+
+  it('normalizes ~ to HOME before checking', () => {
+    const decision = hook(ctx('cat ~/.ssh/id_rsa'));
+    expect(decision.decision).toBe('block');
+  });
+
+  it('does NOT block ordinary commands', () => {
+    expect(hook(ctx('ls')).decision).not.toBe('block');
+    expect(hook(ctx('git status')).decision).not.toBe('block');
+    expect(hook(ctx('pnpm test')).decision).not.toBe('block');
+    expect(hook(ctx('which git')).decision).not.toBe('block');
+  });
+
+  it('DOCUMENTED BYPASS: variable assembly slips through (threat-model invariant)', () => {
+    // This test PINS the documented invariant: this hook is for accidental
+    // access prevention, NOT adversarial containment. Variable-assembled
+    // paths and interpreter denylist evasion are EXPLICIT non-goals.
+    // If this test ever starts failing because someone "fixed" the bypass,
+    // do NOT extend the parser — refer back to the threat-model invariant
+    // in the module header and either accept the new behavior or escalate
+    // to OS-level sandboxing.
+    //
+    // Why this slips: we normalize `$HOME` and `~`, but `H=$HOME; cat $H/...`
+    // assigns the value to `$H` first. The substring check sees only the
+    // text "cat $H/.ssh/id_rsa", which doesn't contain any restricted prefix
+    // literally.
+    const decision = hook(ctx('H=$HOME; cat $H/.ssh/id_rsa'));
+    expect(decision.decision).not.toBe('block');
+  });
+
+  it('the straightforward $HOME / ~ form IS caught (counterpoint to bypass)', () => {
+    // The non-adversarial accident case — model directly writes the path
+    // using $HOME or ~. Both get normalized and matched.
+    expect(hook(ctx('cat $HOME/.ssh/id_rsa')).decision).toBe('block');
+    expect(hook(ctx('cat ~/.ssh/id_rsa')).decision).toBe('block');
+  });
+});
+
+describe('createBashRestrictionHook — grant containment direction (F4 regression)', () => {
+  const home = homedir();
+  const appSupport = `${home}/Library/Application Support`;
+
+  function grantsWith(extraReadRoot: string): GrantManager {
+    return {
+      addReadRoot: () => {},
+      addWriteRoot: () => {},
+      revokeRoot: () => {},
+      getGrants() {
+        return {
+          resolveBase: '/tmp/repo',
+          readRoots: ['/tmp/repo', extraReadRoot],
+          writeRoots: ['/tmp/repo'],
+        };
+      },
+    };
+  }
+
+  it('granting a NARROW subdir does NOT un-gate the sensitive parent or its siblings', () => {
+    // Regression: before the fix `path.relative(candidate, granted)` matched a
+    // granted CHILD and dropped the whole parent candidate. Granting only the
+    // Cursor config dir must leave the rest of Application Support restricted.
+    const hook = createBashRestrictionHook({
+      getGrantManager: () => grantsWith(`${appSupport}/Cursor/User`),
+    });
+    const decision = hook(ctx(`cat "${appSupport}/Firefox/Profiles/logins.json"`));
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toContain('Application Support');
+  });
+
+  it('granting the candidate itself (or an ancestor) DOES drop it from restriction', () => {
+    // User granted ALL of Application Support → a path under it is not blocked.
+    const hook = createBashRestrictionHook({
+      getGrantManager: () => grantsWith(appSupport),
+    });
+    const decision = hook(ctx(`cat "${appSupport}/Cursor/User/settings.json"`));
+    expect(decision.decision).not.toBe('block');
+  });
+});
+
+describe('createBashRestrictionHook — wiring failsafes', () => {
+  it('fails open when grant manager is undefined (bootstrap race)', () => {
+    const hook = createBashRestrictionHook({ getGrantManager: () => undefined });
+    const decision = hook(ctx(`cat ${homedir()}/.ssh/id_rsa`));
+    // Substring check is gated by grant manager — when unwired, fail open.
+    expect(decision.decision).not.toBe('block');
+  });
+
+  it('does NOT block on non-bash tools', () => {
+    const hook = createBashRestrictionHook({ getGrantManager: mockGrants });
+    expect(hook({ event: 'PreToolUse', toolName: 'read_file', input: { file_path: '/etc/passwd' } }).decision).not.toBe('block');
+  });
+});

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -47,10 +47,19 @@ import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
 import type { HookContext, HookDecision } from '../../hooks.js';
 
 /**
- * Interpreter denylist regex. Matches `<interpreter> -<flag>` where flag is
- * the eval-from-string variant (`-c`/`-C`/`-e`/`-E`) common across shells
- * and scripting languages. Anchored with `\b` so a path containing the
- * literal `python3` (e.g. `/usr/local/bin/python3-config`) does not match.
+ * Interpreter denylist regex. Matches `<interpreter> -<flag>` where flag is a
+ * short-option cluster ending in the eval-from-string variant (`-c`/`-C`/`-e`/
+ * `-E`), INCLUDING combined clusters like `-ec` or `bash -lc`. The interpreter
+ * name allows a version suffix (`python[0-9.]*` → matches `python`, `python3`,
+ * `python3.10`) so version-qualified binaries are not a bypass. A mandatory
+ * whitespace between interpreter and flag means a path containing the literal
+ * `python3` (e.g. `/usr/local/bin/python3-config`) still does not match.
+ *
+ * Known residuals, accepted per the non-adversarial threat model (module
+ * header): an interpreter name inside a quoted argument (`echo "python -c"`)
+ * still matches (a tolerated false positive), and a SEPARATE intervening flag
+ * (`bash --login -c`, `python -B -c`) is not caught. Do NOT grow this into a
+ * shell parser to close those — escalate to OS-level sandboxing instead.
  *
  * Note: this is a hard-block — no elicitation — because:
  *   (a) the user cannot reasonably audit an arbitrary shell-script string
@@ -63,7 +72,7 @@ import type { HookContext, HookDecision } from '../../hooks.js';
  * not to evaluate code on the user's behalf.
  */
 const INTERPRETER_DENYLIST =
-  /\b(python|python3|node|ruby|perl|osascript|sh|bash|zsh|fish|tclsh|lua)\s+-[cCeE](\s|$)/;
+  /\b(python[0-9.]*|node|ruby|perl|osascript|sh|bash|zsh|fish|tclsh|lua)\s+-[A-Za-z]*[cCeE](\s|$)/;
 
 export interface BashRestrictionHookOptions {
   /**
@@ -140,12 +149,13 @@ export function createBashRestrictionHook(opts: BashRestrictionHookOptions) {
     const restrictedSubstrings = deriveRestrictedSubstrings(grants);
     if (restrictedSubstrings.length === 0) return {};
 
-    // Normalize `~` and `$HOME` in the command to the real home dir for the
-    // substring match. This catches the obvious-shell-idiom case without
-    // pretending to be a real parser.
+    // Normalize `~`, `$HOME`, and `${HOME}` in the command to the real home
+    // dir for the substring match. This catches the obvious-shell-idiom cases
+    // without pretending to be a real parser. The `$HOME\b` boundary avoids
+    // mangling unrelated vars like `$HOMEDIR`; `${HOME}` covers the brace form.
     const home = homedir();
     const normalized = command
-      .replace(/\$HOME/g, home)
+      .replace(/\$\{HOME\}|\$HOME\b/g, home)
       .replace(/(^|[\s/=:])~(?=$|[/\s])/g, `$1${home}`);
 
     for (const sub of restrictedSubstrings) {

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -1,0 +1,221 @@
+/**
+ * PreToolUse hook that blocks bash invocations referencing restricted paths
+ * or evaluating arbitrary code via interpreter `-c`/`-e` flags.
+ *
+ * # Invariant — threat model (load-bearing)
+ *
+ * This hook prevents ACCIDENTAL access to sensitive paths by a non-adversarial
+ * model. It is NOT a security boundary against an actively adversarial model.
+ *
+ * Bash is Turing-complete and any string-based filter has known bypasses:
+ *   - Variable assembly:        `H=$HOME; cat $H/.ssh/id_rsa`
+ *   - Brace expansion:          `cat /etc/{passwd,shadow}`
+ *   - Process substitution:     `cat <(echo /etc/passwd)`
+ *   - File descriptor tricks:   `exec 3</etc/passwd; cat <&3`
+ *   - Interpreter scripts:      `python -c "open('/etc/passwd').read()"`
+ *
+ * The interpreter denylist below closes the most obvious adjacent bypass
+ * (interpreter scripts). The rest are accepted as residual risk for the
+ * accidental-prevention threat model.
+ *
+ * For adversarial containment, run agent-afk inside an OS-level sandbox:
+ *   - macOS:  `sandbox-exec` (note: deprecated in newer Xcode releases)
+ *   - Linux:  Landlock or seccomp via systemd, bubblewrap, firejail
+ *   - Docker: drop --cap-add and mount only the workspace
+ *
+ * # What this hook does
+ *
+ * 1. Reads the bash `command` string from the tool input.
+ * 2. If the command matches the interpreter denylist (`python -c`, `node -e`,
+ *    `ruby -e`, `osascript -e`, `sh -c`, `bash -c`, `zsh -c`, `fish -c`),
+ *    block with redirect guidance.
+ * 3. If the command contains a literal substring referencing a restricted
+ *    root (any path NOT inside the session's grant lists), block with
+ *    redirect guidance pointing the model at typed file tools.
+ *
+ * The block reason is **structured** — the model sees "use read_file /
+ * write_file / edit_file, they support per-call approval" — so it routes
+ * back to the prompt-able surface instead of looking for another escape
+ * hatch.
+ *
+ * @module agent/tools/hooks/bash-restriction-hook
+ */
+
+import { homedir } from 'os';
+import path from 'path';
+import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
+import type { HookContext, HookDecision } from '../../hooks.js';
+
+/**
+ * Interpreter denylist regex. Matches `<interpreter> -<flag>` where flag is
+ * the eval-from-string variant (`-c`/`-C`/`-e`/`-E`) common across shells
+ * and scripting languages. Anchored with `\b` so a path containing the
+ * literal `python3` (e.g. `/usr/local/bin/python3-config`) does not match.
+ *
+ * Note: this is a hard-block — no elicitation — because:
+ *   (a) the user cannot reasonably audit an arbitrary shell-script string
+ *       inside a prompt; clicking [Allow] would be a reflex, not a
+ *       considered decision (the architect's "training-wheels" critique);
+ *   (b) the model can almost always re-route via typed tools instead.
+ *
+ * If the user genuinely needs to run an interpreter script, they can do it
+ * outside the agent. The agent's escape hatch is to ask the user explicitly,
+ * not to evaluate code on the user's behalf.
+ */
+const INTERPRETER_DENYLIST =
+  /\b(python|python3|node|ruby|perl|osascript|sh|bash|zsh|fish|tclsh|lua)\s+-[cCeE](\s|$)/;
+
+export interface BashRestrictionHookOptions {
+  /**
+   * Returns the active grant manager (provider). Used to read the current
+   * grant snapshot so the substring check knows which paths are trusted.
+   * Returns undefined during the bootstrap race; in that case the hook
+   * fails open (no bash restriction) because blocking on bootstrap would
+   * leave the user unable to recover.
+   */
+  getGrantManager: () => GrantManager | undefined;
+  /**
+   * When true, skip the interpreter-eval denylist (check 1 below). The
+   * restricted-root substring check (check 2) is unaffected. Wired from
+   * `AFK_DISABLE_BASH_INTERPRETER_GUARD=1` so an operator whose headless
+   * automation legitimately runs `python -c` / `sh -c` one-liners can lift
+   * just the interpreter block without disabling all of path-approval
+   * (`AFK_DISABLE_PATH_APPROVAL=1`). Default false (guard active).
+   */
+  disableInterpreterGuard?: boolean;
+}
+
+/**
+ * Factory. Returns a synchronous `HookHandler` — bash restriction is
+ * regex-based with no I/O, so we do not need the longRunning escape.
+ */
+export function createBashRestrictionHook(opts: BashRestrictionHookOptions) {
+  return (context: HookContext): HookDecision => {
+    if (context.event !== 'PreToolUse') return {};
+    if (context.toolName !== 'bash') return {};
+
+    const input = context.input as Record<string, unknown> | undefined;
+    const command = typeof input?.['command'] === 'string' ? input['command'] : '';
+    if (!command) return {};
+
+    // 1. Interpreter denylist — hard block. Fires before the grant-manager
+    // gate below, so by default it applies on every surface — including
+    // headless ones (afk chat, daemon, threads) where no grant manager is
+    // wired. On those surfaces there is no interactive approval path, so the
+    // "use typed file tools" advice is only actionable interactively. The
+    // granular escape is AFK_DISABLE_BASH_INTERPRETER_GUARD=1 (lifts only this
+    // check, threaded in as `disableInterpreterGuard`); AFK_DISABLE_PATH_APPROVAL=1
+    // disables the whole feature.
+    if (!opts.disableInterpreterGuard && INTERPRETER_DENYLIST.test(command)) {
+      return {
+        decision: 'block',
+        reason:
+          'Interpreter-with-eval flags (python -c, node -e, ruby -e, sh -c, ...) are blocked by ' +
+          'the path-approval policy. On interactive surfaces, use the typed file tools (read_file, ' +
+          'write_file, edit_file) which support per-call user approval, or ask the user to run the ' +
+          'script themselves. To lift this block — e.g. headless automation that legitimately runs ' +
+          'interpreter one-liners — set AFK_DISABLE_BASH_INTERPRETER_GUARD=1, or disable all of ' +
+          'path-approval with AFK_DISABLE_PATH_APPROVAL=1.',
+      };
+    }
+
+    // 2. Restricted-root substring check.
+    // Only fires when a grant manager is wired (during bootstrap race we
+    // fail open). The check is intentionally crude: literal `command.includes`
+    // against every "restricted directory" we can derive. False positives
+    // (echo "see ~/.ssh/config") block the bash call and ask the model to
+    // explain what it was doing, which is acceptable for the accidental
+    // threat model.
+    //
+    // Invariant: on headless surfaces (afk chat, daemon, threads) the grant
+    // manager is NEVER wired, so this substring check always fails open here —
+    // bash referencing a restricted path is NOT blocked on headless (bash has
+    // no resolveAndContain backstop like the typed file tools do). Accepted
+    // residual risk under the non-adversarial threat model (see module header);
+    // for stricter headless containment use an OS-level sandbox. The
+    // interpreter denylist (check 1) is unaffected — it fires regardless.
+    const grantManager = opts.getGrantManager();
+    if (!grantManager) return {};
+    const grants = grantManager.getGrants();
+    const restrictedSubstrings = deriveRestrictedSubstrings(grants);
+    if (restrictedSubstrings.length === 0) return {};
+
+    // Normalize `~` and `$HOME` in the command to the real home dir for the
+    // substring match. This catches the obvious-shell-idiom case without
+    // pretending to be a real parser.
+    const home = homedir();
+    const normalized = command
+      .replace(/\$HOME/g, home)
+      .replace(/(^|[\s/=:])~(?=$|[/\s])/g, `$1${home}`);
+
+    for (const sub of restrictedSubstrings) {
+      if (normalized.includes(sub)) {
+        return {
+          decision: 'block',
+          reason:
+            `Bash command references a restricted path (${sub}). ` +
+            'For sensitive paths, use read_file / write_file / edit_file — ' +
+            'those tools support per-call user approval via an inline prompt. ' +
+            'If you genuinely need a shell command for this path, ask the user ' +
+            'to grant it via `/allow-dir <path>` first.',
+        };
+      }
+    }
+
+    return {};
+  };
+}
+
+/**
+ * Derive a set of sensitive-path substrings to scan bash commands for.
+ *
+ * Heuristic: we want to block paths the user has NOT explicitly granted that
+ * are likely to contain sensitive material. We do NOT want to block every
+ * path outside the cwd — that would break `ls /etc`, `which git`, etc.
+ *
+ * The current allow-listed sensitive prefixes are common high-signal targets:
+ * SSH keys, GPG, AWS, browser profiles, password stores, environment files.
+ * Each is included only when the user's resolveBase is NOT already inside it
+ * (so a user working in `~/.ssh` doesn't self-block).
+ */
+function deriveRestrictedSubstrings(grants: {
+  resolveBase: string | undefined;
+  readRoots: string[];
+  writeRoots: string[];
+}): string[] {
+  const home = homedir();
+  const candidates = [
+    path.join(home, '.ssh'),
+    path.join(home, '.gnupg'),
+    path.join(home, '.aws'),
+    path.join(home, '.config', 'gh'),
+    path.join(home, '.netrc'),
+    path.join(home, 'Library', 'Application Support'),
+    path.join(home, '.password-store'),
+    '/etc/shadow',
+    '/etc/sudoers',
+    '/private/etc/sudoers',
+  ];
+
+  const granted = new Set([
+    ...(grants.resolveBase !== undefined ? [grants.resolveBase] : []),
+    ...grants.readRoots,
+    ...grants.writeRoots,
+  ]);
+
+  // Filter: drop a candidate only when the user has actually granted access
+  // to ALL of it — i.e. a granted root IS the candidate or is an ANCESTOR of
+  // it. Containment direction matters: `path.relative(g, c)` not starting
+  // with `..` means c is at-or-inside g (g covers c). Using the candidate as
+  // the `from` arg (the prior bug) instead matched when g was a CHILD of c,
+  // so granting a narrow subdir (e.g. ~/Library/Application Support/Cursor/User)
+  // wrongly un-gated the whole sensitive parent (~/Library/Application Support)
+  // and every sibling app dir under it.
+  return candidates.filter((c) => {
+    for (const g of granted) {
+      const rel = path.relative(g, c);
+      if (rel === '' || !rel.startsWith('..')) return false;
+    }
+    return true;
+  });
+}

--- a/src/agent/tools/hooks/path-approval-hook.test.ts
+++ b/src/agent/tools/hooks/path-approval-hook.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Tests for `createPathApprovalHook` — typed file-tool gate that prompts
+ * the user via `elicitationRouter` and translates the answer into grant
+ * mutations + hook decisions.
+ *
+ * Coverage:
+ *   - Typed file tools fire the prompt; other tools (bash) do not.
+ *   - Paths inside the granted roots do NOT prompt.
+ *   - `once` adds + records for post-cleanup; PostToolUse revokes.
+ *   - `session` adds and caches; second call to same path does not re-prompt.
+ *   - `persist` calls appendGrant.
+ *   - `deny` returns block.
+ *   - Cancel/decline → block with reason.
+ *   - Concurrent calls to the same path dedupe (single prompt).
+ *   - Failing-open when grant manager is not wired.
+ */
+
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { elicitationRouter } from '../../elicitation-router.js';
+import { createPathApprovalHook } from './path-approval-hook.js';
+import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
+import type { PreToolUseContext, PostToolUseContext } from '../../hooks.js';
+import * as permissionsStore from '../../permissions-store.js';
+
+const BASE = '/tmp/repo';
+
+function makeMockGrantManager(initial?: {
+  readRoots?: string[];
+  writeRoots?: string[];
+}): GrantManager & {
+  _readRoots: string[];
+  _writeRoots: string[];
+  _events: Array<{ op: string; path: string }>;
+} {
+  const readRoots = initial?.readRoots?.slice() ?? [BASE];
+  const writeRoots = initial?.writeRoots?.slice() ?? [BASE];
+  const events: Array<{ op: string; path: string }> = [];
+
+  return {
+    _readRoots: readRoots,
+    _writeRoots: writeRoots,
+    _events: events,
+    addReadRoot(p) {
+      if (!readRoots.includes(p)) readRoots.push(p);
+      events.push({ op: 'addRead', path: p });
+    },
+    addWriteRoot(p) {
+      if (!readRoots.includes(p)) readRoots.push(p);
+      if (!writeRoots.includes(p)) writeRoots.push(p);
+      events.push({ op: 'addWrite', path: p });
+    },
+    revokeRoot(p) {
+      const rIdx = readRoots.indexOf(p);
+      if (rIdx !== -1) readRoots.splice(rIdx, 1);
+      const wIdx = writeRoots.indexOf(p);
+      if (wIdx !== -1) writeRoots.splice(wIdx, 1);
+      events.push({ op: 'revoke', path: p });
+    },
+    getGrants() {
+      return { resolveBase: BASE, readRoots: readRoots.slice(), writeRoots: writeRoots.slice() };
+    },
+  };
+}
+
+function preCtx(toolName: string, input: unknown): PreToolUseContext {
+  return { event: 'PreToolUse', toolName, input, sessionId: 'sess-1' };
+}
+
+function postCtx(toolName: string, input: unknown): PostToolUseContext {
+  return { event: 'PostToolUse', toolName, input, sessionId: 'sess-1' };
+}
+
+beforeEach(() => {
+  elicitationRouter.uninstall();
+  vi.restoreAllMocks();
+});
+
+describe('createPathApprovalHook — typed-tool gating', () => {
+  it('does not prompt for tools outside the typed-file-tool set (e.g. bash)', async () => {
+    elicitationRouter.install(async () => ({ action: 'accept', content: { choice: 'once' } }));
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse(preCtx('bash', { command: 'ls' }));
+    expect(decision).toEqual({});
+    expect(mgr._events).toHaveLength(0);
+  });
+
+  it('does not prompt for inside-cwd paths', async () => {
+    const handler = vi.fn(async () => ({ action: 'accept', content: { choice: 'once' } }));
+    elicitationRouter.install(handler);
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse(
+      preCtx('read_file', { file_path: '/tmp/repo/src/foo.ts' }),
+    );
+    expect(decision).toEqual({});
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe('createPathApprovalHook — outcome mapping', () => {
+  it('once: allows the call, records for post-cleanup; PostToolUse revokes', async () => {
+    elicitationRouter.install(async () => ({ action: 'accept', content: { choice: 'once' } }));
+    const mgr = makeMockGrantManager();
+    const { preToolUse, postToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse(
+      preCtx('read_file', { file_path: '/etc/hosts' }),
+    );
+    expect(decision).toEqual({});
+    expect(mgr._readRoots).toContain('/etc/hosts');
+
+    // PostToolUse should revoke the once-grant.
+    postToolUse(postCtx('read_file', { file_path: '/etc/hosts' }));
+    expect(mgr._readRoots).not.toContain('/etc/hosts');
+    expect(mgr._events.map((e) => e.op)).toEqual(['addRead', 'revoke']);
+  });
+
+  it('session: adds to readRoots and caches; second call does not re-prompt', async () => {
+    const handler = vi.fn(async () => ({ action: 'accept', content: { choice: 'session' } }));
+    elicitationRouter.install(handler);
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    await preToolUse(preCtx('read_file', { file_path: '/etc/hosts' }));
+    await preToolUse(preCtx('read_file', { file_path: '/etc/hosts' }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(mgr._readRoots).toContain('/etc/hosts');
+  });
+
+  it('persist: calls appendGrant + adds to readRoots', async () => {
+    const append = vi.spyOn(permissionsStore, 'appendGrant').mockImplementation(((body: unknown) => {
+      return { ...(body as object), id: 'fake-ulid', grantedAt: 'now' };
+    }) as never);
+    elicitationRouter.install(async () => ({ action: 'accept', content: { choice: 'persist' } }));
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'telegram',
+    });
+
+    const decision = await preToolUse(
+      preCtx('write_file', { file_path: '/etc/hosts', content: 'x' }),
+    );
+
+    expect(decision).toEqual({});
+    expect(mgr._writeRoots).toContain('/etc/hosts');
+    expect(append).toHaveBeenCalledTimes(1);
+    expect(append.mock.calls[0]?.[0]).toMatchObject({
+      path: '/etc/hosts',
+      mode: 'write',
+      decision: 'allow',
+      source: 'elicit:telegram',
+    });
+  });
+
+  it('deny: returns block with descriptive reason', async () => {
+    elicitationRouter.install(async () => ({ action: 'accept', content: { choice: 'deny' } }));
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse(
+      preCtx('read_file', { file_path: '/etc/hosts' }),
+    );
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toContain('/etc/hosts');
+    expect(mgr._events).toHaveLength(0);
+  });
+
+  it('decline → block', async () => {
+    elicitationRouter.install(async () => ({ action: 'decline' }));
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+    const decision = await preToolUse(preCtx('read_file', { file_path: '/etc/hosts' }));
+    expect(decision.decision).toBe('block');
+  });
+
+  it('cancel → block with cancel-specific message', async () => {
+    elicitationRouter.install(async () => ({ action: 'cancel' }));
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+    const decision = await preToolUse(preCtx('read_file', { file_path: '/etc/hosts' }));
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toContain('cancelled');
+  });
+});
+
+describe('createPathApprovalHook — concurrency dedup', () => {
+  it('two concurrent calls to the same path produce one prompt', async () => {
+    let resolveHandler: (() => void) | undefined;
+    const handler = vi.fn(() =>
+      new Promise<{ action: 'accept'; content: { choice: string } }>((res) => {
+        resolveHandler = () => res({ action: 'accept', content: { choice: 'session' } });
+      }),
+    );
+    elicitationRouter.install(handler as never);
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    // Fire two concurrent calls for the SAME path.
+    const a = preToolUse(preCtx('read_file', { file_path: '/etc/hosts' }));
+    const b = preToolUse(preCtx('read_file', { file_path: '/etc/hosts' }));
+
+    // Flush microtasks so the elicitation-router's serial queue fires the
+    // handler (which sets resolveHandler) before we try to call it.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Resolve the single in-flight prompt.
+    resolveHandler?.();
+    await Promise.all([a, b]);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createPathApprovalHook — turn-signal cancellation (F2 regression)', () => {
+  it('forwards the turn signal so an abort cancels a pending prompt (no infinite hang)', async () => {
+    // Handler mirrors the real REPL/Telegram handlers: it settles ONLY when
+    // its signal aborts. Pre-fix the hook passed a throwaway signal, so this
+    // prompt would hang forever and the test would time out.
+    const handler = (_req: unknown, opts: { signal: AbortSignal }) =>
+      new Promise((resolve) => {
+        opts.signal.addEventListener('abort', () => resolve({ action: 'decline' }), {
+          once: true,
+        });
+      });
+    elicitationRouter.install(handler as never);
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const controller = new AbortController();
+    const pending = preToolUse(
+      preCtx('read_file', { file_path: '/etc/hosts' }),
+      controller.signal,
+    );
+    // Let the router enqueue and start awaiting the handler, then abort.
+    await Promise.resolve();
+    await Promise.resolve();
+    controller.abort();
+
+    const decision = await pending;
+    expect(decision.decision).toBe('block'); // router returns decline on abort → block
+    expect(mgr._readRoots).not.toContain('/etc/hosts');
+  });
+});
+
+describe('createPathApprovalHook — SessionEnd once-grant sweep (F3 regression)', () => {
+  it('revokes a once-grant whose PostToolUse never ran (abort safety net)', async () => {
+    elicitationRouter.install(async () => ({ action: 'accept', content: { choice: 'once' } }));
+    const mgr = makeMockGrantManager();
+    const { preToolUse, sessionEnd } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    // Approve "once" — root added + recorded for cleanup.
+    await preToolUse(preCtx('read_file', { file_path: '/etc/hosts' }));
+    expect(mgr._readRoots).toContain('/etc/hosts');
+
+    // PostToolUse never fires (the call's signal aborted). Without the sweep
+    // the once-grant would leak into a full-session grant. SessionEnd cleans it.
+    sessionEnd({ event: 'SessionEnd', sessionId: 'sess-1' });
+    expect(mgr._readRoots).not.toContain('/etc/hosts');
+    expect(mgr._events.map((e) => e.op)).toEqual(['addRead', 'revoke']);
+  });
+
+  it('is a no-op when no once-grants are outstanding', () => {
+    const mgr = makeMockGrantManager();
+    const { sessionEnd } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+    sessionEnd({ event: 'SessionEnd', sessionId: 'sess-1' });
+    expect(mgr._events).toHaveLength(0);
+  });
+});
+
+describe('createPathApprovalHook — failsafe behavior', () => {
+  it('fails open when no grant manager is wired (headless surfaces)', async () => {
+    elicitationRouter.install(async () => ({ action: 'accept', content: { choice: 'deny' } }));
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => undefined,
+      getCwd: () => BASE,
+      surface: 'unknown',
+    });
+
+    const decision = await preToolUse(preCtx('read_file', { file_path: '/etc/hosts' }));
+    // No grant manager → no pre-check; the handler's own resolveAndContain
+    // will enforce containment as it does today.
+    expect(decision).toEqual({});
+  });
+});

--- a/src/agent/tools/hooks/path-approval-hook.test.ts
+++ b/src/agent/tools/hooks/path-approval-hook.test.ts
@@ -174,6 +174,29 @@ describe('createPathApprovalHook — outcome mapping', () => {
     });
   });
 
+  it('persist: second call to the same path does not re-prompt', async () => {
+    // C10 coverage gap: the persist path populates sessionApproved + adds the
+    // root, so a second call to the same path must NOT re-prompt — parity with
+    // the `session` test above (which had this assertion; persist did not).
+    vi.spyOn(permissionsStore, 'appendGrant').mockImplementation(((body: unknown) => {
+      return { ...(body as object), id: 'fake-ulid', grantedAt: 'now' };
+    }) as never);
+    const handler = vi.fn(async () => ({ action: 'accept', content: { choice: 'persist' } }));
+    elicitationRouter.install(handler);
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    await preToolUse(preCtx('write_file', { file_path: '/etc/hosts', content: 'x' }));
+    await preToolUse(preCtx('write_file', { file_path: '/etc/hosts', content: 'y' }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(mgr._writeRoots).toContain('/etc/hosts');
+  });
+
   it('deny: returns block with descriptive reason', async () => {
     elicitationRouter.install(async () => ({ action: 'accept', content: { choice: 'deny' } }));
     const mgr = makeMockGrantManager();
@@ -214,6 +237,55 @@ describe('createPathApprovalHook — outcome mapping', () => {
     const decision = await preToolUse(preCtx('read_file', { file_path: '/etc/hosts' }));
     expect(decision.decision).toBe('block');
     expect(decision.reason).toContain('cancelled');
+  });
+});
+
+describe('createPathApprovalHook — list_directory / glob path extraction', () => {
+  it('prompts for list_directory targeting an outside-root path', async () => {
+    const handler = vi.fn(async () => ({ action: 'accept', content: { choice: 'once' } }));
+    elicitationRouter.install(handler);
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse(preCtx('list_directory', { path: '/etc' }));
+    expect(decision).toEqual({});
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(mgr._readRoots).toContain('/etc');
+  });
+
+  it('prompts for glob targeting an outside-root path', async () => {
+    const handler = vi.fn(async () => ({ action: 'accept', content: { choice: 'once' } }));
+    elicitationRouter.install(handler);
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse(preCtx('glob', { path: '/etc', pattern: '*.conf' }));
+    expect(decision).toEqual({});
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(mgr._readRoots).toContain('/etc');
+  });
+
+  it('does NOT prompt for glob without a path arg (defaults to trusted cwd)', async () => {
+    const handler = vi.fn(async () => ({ action: 'accept', content: { choice: 'once' } }));
+    elicitationRouter.install(handler);
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse(preCtx('glob', { pattern: '*.ts' }));
+    expect(decision).toEqual({});
+    expect(handler).not.toHaveBeenCalled();
   });
 });
 
@@ -331,5 +403,23 @@ describe('createPathApprovalHook — failsafe behavior', () => {
     // No grant manager → no pre-check; the handler's own resolveAndContain
     // will enforce containment as it does today.
     expect(decision).toEqual({});
+  });
+
+  it('fails CLOSED when a grant manager is wired but no elicitation handler is installed', async () => {
+    // Security-critical: beforeEach uninstalls the router and we do NOT
+    // reinstall. With a wired grant manager the pre-check runs and routes;
+    // the router auto-declines when no handler exists, which MUST map to block
+    // (never silently allow an outside-root path because the prompt surface is
+    // missing).
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse(preCtx('read_file', { file_path: '/etc/hosts' }));
+    expect(decision.decision).toBe('block');
+    expect(mgr._events).toHaveLength(0); // no grant mutation on a blocked path
   });
 });

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -1,0 +1,468 @@
+/**
+ * Path-approval hooks: PreToolUse + PostToolUse.
+ *
+ * Intercepts typed file-tool calls (`read_file`, `write_file`, `edit_file`,
+ * `list_directory`, `glob`, `grep`) targeting paths outside the session's
+ * granted roots and elicits user approval before allowing them through.
+ *
+ * # Invariant — threat model
+ *
+ * This hook prevents ACCIDENTAL access to sensitive paths by a non-adversarial
+ * model. It is NOT a security boundary against an actively adversarial
+ * model. The hook only inspects typed file tools; bash invocations are gated
+ * separately by `bash-restriction-hook.ts` (with much narrower scope, since
+ * bash is Turing-complete and any string-based filter has known bypasses:
+ * interpreter scripts, variable assembly, /proc/self/fd, brace expansion,
+ * process substitution). For adversarial containment, run agent-afk inside
+ * an OS-level sandbox: macOS `sandbox-exec` or Linux Landlock/seccomp.
+ *
+ * # Flow
+ *
+ * On a `PreToolUse` event whose tool is one of the typed file tools AND whose
+ * resolved path falls outside every granted root:
+ *
+ *   1. Check the in-process "always for this session" allow-cache — if the
+ *      path is in there, fall through without prompting.
+ *   2. Otherwise, deduplicate against any in-flight request for the same
+ *      `(tool, path)` pair — concurrent prompts collapse to one.
+ *   3. Call `elicitationRouter.route()` with a 4-option form:
+ *        [once] [session] [persist] [deny]
+ *   4. Map the response:
+ *        once     → grantManager.addReadRoot + record in `onceApprovedPaths`
+ *                   (the paired PostToolUse hook revokes after the call).
+ *        session  → grantManager.addReadRoot/addWriteRoot (in-memory only)
+ *        persist  → grantManager.addReadRoot + appendGrant() to disk
+ *        deny     → return { decision: 'block', reason: ... }
+ *   5. On no installed handler / timeout / decline / cancel: block.
+ *
+ * # Wiring
+ *
+ * The PreToolUse handler is registered with `longRunning: true` so the 30s
+ * per-handler timeout in the dispatch loop is bypassed — `elicitationRouter`
+ * enforces its own 5-minute timeout. The PostToolUse handler is synchronous
+ * (only revokes a root from an in-process set) and runs under the default
+ * timeout.
+ *
+ * @module agent/tools/hooks/path-approval-hook
+ */
+
+import { elicitationRouter } from '../../elicitation-router.js';
+import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
+import { wouldBeRestricted } from '../handlers/_cwd-utils.js';
+import { appendGrant } from '../../permissions-store.js';
+import type { HookContext, HookDecision, HookHandler } from '../../hooks.js';
+
+/** Tools subject to per-call path approval. Bash is gated separately. */
+const TYPED_FILE_TOOLS = new Set([
+  'read_file',
+  'write_file',
+  'edit_file',
+  'list_directory',
+  'glob',
+  'grep',
+]);
+
+/** Tools that write — used to pick read-vs-write containment + grant mode. */
+const WRITE_TOOLS = new Set(['write_file', 'edit_file']);
+
+/** Surface label threaded into the persisted grant for audit. */
+export type PathApprovalSurface = 'repl' | 'telegram' | 'unknown';
+
+export interface PathApprovalHookOptions {
+  /**
+   * Returns the active grant manager (provider instance) or undefined if not
+   * yet wired (e.g. session bootstrap is racing with the first tool call).
+   * When undefined, the hook fails open (skip approval) so headless/one-shot
+   * surfaces without a wire-up step keep working with the existing handler
+   * `resolveAndContain` enforcement.
+   */
+  getGrantManager: () => GrantManager | undefined;
+  /**
+   * Returns the current cwd / resolveBase used by the dispatcher. Required to
+   * mirror the handler's `resolveAndContain` semantics; without it, the hook
+   * cannot reproduce the same containment verdict the handler will reach.
+   */
+  getCwd: () => string | undefined;
+  /**
+   * Surface label baked into persisted grants so the audit trail shows
+   * provenance (`elicit:repl` vs. `elicit:telegram`). Static per session.
+   */
+  surface: PathApprovalSurface;
+}
+
+/** Shared closure state between the Pre/Post hooks. */
+interface PathApprovalState {
+  /** Set of `<mode>:<resolvedPath>` keys approved for the whole session. */
+  sessionApproved: Set<string>;
+  /**
+   * Map of `<mode>:<resolvedPath>` → resolvedPath for paths approved
+   * "Once". On PostToolUse, the corresponding root is revoked from the
+   * grant manager and the key removed.
+   */
+  onceApproved: Map<string, { resolvedPath: string; mode: 'read' | 'write' }>;
+  /** In-flight elicitations — dedupes concurrent prompts for the same path. */
+  inFlight: Map<string, Promise<HookDecision>>;
+}
+
+export interface PathApprovalHookHandlers {
+  /** Register at PreToolUse with `{ longRunning: true }`. */
+  preToolUse: HookHandler;
+  /** Register at PostToolUse (default options). */
+  postToolUse: HookHandler;
+  /**
+   * Register at SessionEnd. Revokes any "Once" grants still outstanding —
+   * the safety net for the case where PostToolUse never ran (e.g. the tool
+   * call's signal aborted, so `dispatchPostToolUse` short-circuited before
+   * the revoke). Without this, an aborted-mid-call "Once" grant would leak
+   * into a full-session grant.
+   */
+  sessionEnd: HookHandler;
+}
+
+function pathApprovalKey(mode: 'read' | 'write', resolvedPath: string): string {
+  return `${mode}:${resolvedPath}`;
+}
+
+/**
+ * Factory. Returns a `{ preToolUse, postToolUse, sessionEnd }` triple closing
+ * over shared cache + in-flight state. Register `preToolUse` with
+ * `{ longRunning: true }` so the dispatcher does not race the elicitation
+ * prompt against its 30s per-handler timeout. `postToolUse` and `sessionEnd`
+ * use default options.
+ */
+export function createPathApprovalHook(
+  opts: PathApprovalHookOptions,
+): PathApprovalHookHandlers {
+  const state: PathApprovalState = {
+    sessionApproved: new Set<string>(),
+    onceApproved: new Map<string, { resolvedPath: string; mode: 'read' | 'write' }>(),
+    inFlight: new Map<string, Promise<HookDecision>>(),
+  };
+
+  // Forward the turn/dispatch `signal` (second handler arg) into the impl so a
+  // pending elicitation prompt is cancelled on session/turn teardown.
+  const preToolUse: HookHandler = async (context, signal) =>
+    preToolUseImpl(opts, state, context, signal);
+  const postToolUse: HookHandler = (context) => postToolUseImpl(opts, state, context);
+  const sessionEnd: HookHandler = (context) => sessionEndImpl(opts, state, context);
+
+  return { preToolUse, postToolUse, sessionEnd };
+}
+
+async function preToolUseImpl(
+  opts: PathApprovalHookOptions,
+  state: PathApprovalState,
+  context: HookContext,
+  signal?: AbortSignal,
+): Promise<HookDecision> {
+  if (context.event !== 'PreToolUse') return {};
+  if (!TYPED_FILE_TOOLS.has(context.toolName)) return {};
+
+  const input = context.input as Record<string, unknown> | undefined;
+  if (!input) return {};
+  const candidate = extractCandidatePath(context.toolName, input);
+  if (candidate === undefined) return {};
+
+  const mode: 'read' | 'write' = WRITE_TOOLS.has(context.toolName)
+    ? 'write'
+    : 'read';
+
+  // Reproduce the handler's containment check. cwd / readRoots / writeRoots
+  // are sampled from the grant manager using the same fresh-snapshot pattern
+  // the dispatcher uses on every handler call.
+  const grantManager = opts.getGrantManager();
+  if (!grantManager) {
+    // Failsafe — no wired grant manager (headless, one-shot, daemon). Skip
+    // the approval pre-check and let the handler's own resolveAndContain
+    // enforce containment as it does today. Documented in module header.
+    return {};
+  }
+  const grants = grantManager.getGrants();
+  const cwd = opts.getCwd();
+  const result = wouldBeRestricted(
+    candidate,
+    {
+      cwd,
+      resolveBase: grants.resolveBase ?? cwd,
+      readRoots: grants.readRoots,
+      writeRoots: grants.writeRoots,
+    },
+    mode,
+  );
+  if (!result.restricted) return {};
+
+  // In-session approval cache short-circuits the prompt.
+  const key = pathApprovalKey(mode, result.resolved);
+  if (state.sessionApproved.has(key)) return {};
+
+  // Dedupe concurrent prompts: if the model fires three reads of the same
+  // path in one turn, we want ONE elicitation, not three. Subsequent
+  // callers await the same promise and inherit its decision.
+  const existing = state.inFlight.get(key);
+  if (existing) return existing;
+
+  const promptPromise = promptForApproval({
+    toolName: context.toolName,
+    resolvedPath: result.resolved,
+    mode,
+    grantManager,
+    state,
+    surface: opts.surface,
+    ...(signal !== undefined ? { signal } : {}),
+  });
+  state.inFlight.set(key, promptPromise);
+  try {
+    return await promptPromise;
+  } finally {
+    state.inFlight.delete(key);
+  }
+}
+
+function postToolUseImpl(
+  opts: PathApprovalHookOptions,
+  state: PathApprovalState,
+  context: HookContext,
+): HookDecision {
+  if (context.event !== 'PostToolUse') return {};
+  if (!TYPED_FILE_TOOLS.has(context.toolName)) return {};
+
+  const input = context.input as Record<string, unknown> | undefined;
+  if (!input) return {};
+  const candidate = extractCandidatePath(context.toolName, input);
+  if (candidate === undefined) return {};
+  const mode: 'read' | 'write' = WRITE_TOOLS.has(context.toolName)
+    ? 'write'
+    : 'read';
+
+  const grantManager = opts.getGrantManager();
+  if (!grantManager) return {};
+  const grants = grantManager.getGrants();
+  const cwd = opts.getCwd();
+  // Recompute resolved path with the same logic preToolUseImpl used. Cheaper
+  // and more robust than threading the original through PreToolUseContext.
+  const { resolved } = wouldBeRestricted(
+    candidate,
+    {
+      cwd,
+      resolveBase: grants.resolveBase ?? cwd,
+      readRoots: grants.readRoots,
+      writeRoots: grants.writeRoots,
+    },
+    mode,
+  );
+
+  const key = pathApprovalKey(mode, resolved);
+  const onceEntry = state.onceApproved.get(key);
+  if (!onceEntry) return {};
+
+  // Revoke the temporary grant. Ordered-operation invariant: revoke MUST
+  // happen before we delete from `onceApproved` so a concurrent PreToolUse
+  // for the same path observes a consistent state (either still approved-
+  // once OR fully revoked, never the in-between window where the once entry
+  // is gone but the grant root persists).
+  //
+  // TODO(once-dedup-race): two concurrent identical reads share one in-flight
+  // "Once" prompt (see `state.inFlight` dedup in preToolUseImpl); this revoke
+  // can fire after the first call completes but before a second concurrent
+  // call's resolveAndContain runs, making the second call fail. Low impact
+  // today (PostToolUse is fire-and-forget async, so by the time it runs the
+  // concurrent handler has already passed containment). A deterministic fix
+  // would ref-count Once grants per key and revoke only when the count hits 0.
+  grantManager.revokeRoot(onceEntry.resolvedPath, 'tool');
+  state.onceApproved.delete(key);
+  return {};
+}
+
+/**
+ * SessionEnd safety net: revoke any "Once" grants still outstanding. Covers
+ * the case where PostToolUse never ran for a once-approved call — e.g. the
+ * call's signal aborted, so `dispatchPostToolUse` short-circuited on
+ * `assertNotAborted` before reaching the revoke. Without this, an aborted-
+ * mid-call "Once" grant silently survives as a full-session grant.
+ *
+ * `revokeRoot` is idempotent (no-op when the root is already gone), so a
+ * double-revoke (PostToolUse already ran, then this sweep) is harmless.
+ */
+function sessionEndImpl(
+  opts: PathApprovalHookOptions,
+  state: PathApprovalState,
+  context: HookContext,
+): HookDecision {
+  if (context.event !== 'SessionEnd') return {};
+  const grantManager = opts.getGrantManager();
+  if (grantManager) {
+    for (const { resolvedPath } of state.onceApproved.values()) {
+      grantManager.revokeRoot(resolvedPath, 'tool');
+    }
+  }
+  state.onceApproved.clear();
+  return {};
+}
+
+/**
+ * Extract the path argument from a typed file-tool input. Returns undefined
+ * when no path is present (e.g. glob without explicit `path`, which falls
+ * back to cwd and is therefore inside the resolveBase).
+ */
+function extractCandidatePath(
+  toolName: string,
+  input: Record<string, unknown>,
+): string | undefined {
+  // read_file / write_file / edit_file all use `file_path`.
+  if (
+    toolName === 'read_file' ||
+    toolName === 'write_file' ||
+    toolName === 'edit_file'
+  ) {
+    const p = input['file_path'];
+    return typeof p === 'string' ? p : undefined;
+  }
+  // list_directory uses `path`.
+  if (toolName === 'list_directory') {
+    const p = input['path'];
+    return typeof p === 'string' ? p : undefined;
+  }
+  // glob/grep — `path` is optional. When absent, the handler uses cwd which
+  // is trusted; return undefined so we skip the prompt.
+  if (toolName === 'glob' || toolName === 'grep') {
+    const p = input['path'];
+    return typeof p === 'string' ? p : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Issue the elicitation prompt and translate the response into a hook
+ * decision + grant mutation.
+ */
+async function promptForApproval(args: {
+  toolName: string;
+  resolvedPath: string;
+  mode: 'read' | 'write';
+  grantManager: GrantManager;
+  state: PathApprovalState;
+  surface: PathApprovalSurface;
+  /** Turn/dispatch abort signal — cancels the pending prompt on teardown. */
+  signal?: AbortSignal;
+}): Promise<HookDecision> {
+  const { toolName, resolvedPath, mode, grantManager, state, surface, signal } = args;
+
+  const message =
+    `Tool \`${toolName}\` wants to ${mode === 'write' ? 'WRITE to' : 'read'} a path ` +
+    `outside this session's granted roots:\n\n  ${resolvedPath}\n\n` +
+    `Choose how to handle this and future requests for this path.`;
+
+  // Form-mode elicitation with a single enum field, four choices. The REPL
+  // and Telegram handlers know how to render this (REPL: numbered prompt;
+  // Telegram: inline keyboard).
+  const result = await elicitationRouter.route(
+    {
+      serverName: 'agent-afk',
+      message,
+      mode: 'form',
+      title: 'Path access approval',
+      requestedSchema: {
+        type: 'object',
+        properties: {
+          choice: {
+            type: 'string',
+            title: 'Choose one',
+            enum: ['once', 'session', 'persist', 'deny'],
+            description:
+              "'once' allows this single call only. 'session' allows this path until the session ends. " +
+              "'persist' writes a grant to ~/.afk/config/permissions.json so future sessions inherit it. " +
+              "'deny' blocks this call and returns an error to the model.",
+          },
+        },
+        required: ['choice'],
+      },
+    },
+    // The elicitation router has NO time-based deadline — a path-approval
+    // prompt waits as long as the operator needs (the 5-min auto-decline was
+    // deliberately removed; it cut off AFK operators who stepped away). The
+    // hook's `longRunning` flag prevents the registry's 30s timeout from
+    // firing, so the ONLY unblock-on-teardown path is the turn/dispatch
+    // signal forwarded here. Falling back to a never-aborting signal (no
+    // forwarded signal) preserves prior behavior for surfaces/tests that
+    // dispatch without one.
+    { signal: signal ?? new AbortController().signal },
+  );
+
+  if (result.action !== 'accept') {
+    return {
+      decision: 'block',
+      reason:
+        result.action === 'cancel'
+          ? `User cancelled the access prompt for ${resolvedPath}`
+          : `User denied access to ${resolvedPath}`,
+    };
+  }
+
+  const choice = String(result.content?.['choice'] ?? '').toLowerCase();
+  const key = pathApprovalKey(mode, resolvedPath);
+
+  switch (choice) {
+    case 'once':
+      // Add to grant lists so resolveAndContain passes, AND record in the
+      // once-approved map so the PostToolUse hook revokes after the call.
+      // Invariant: addReadRoot/addWriteRoot must precede the onceApproved
+      // map write so an interleaved PostToolUse cannot revoke before the
+      // pre-handler check sees the grant. Ordered-operation invariant per
+      // AFK.md.
+      if (mode === 'write') {
+        grantManager.addWriteRoot(resolvedPath, 'tool');
+      } else {
+        grantManager.addReadRoot(resolvedPath, 'tool');
+      }
+      state.onceApproved.set(key, { resolvedPath, mode });
+      return {};
+
+    case 'session':
+      // Mutate the in-memory grant lists (no persistence). Also cache the
+      // (mode, path) key so subsequent calls in the same session don't
+      // re-prompt even if the model passes the path through a different
+      // tool that resolves to the same absolute.
+      if (mode === 'write') {
+        grantManager.addWriteRoot(resolvedPath, 'tool');
+      } else {
+        grantManager.addReadRoot(resolvedPath, 'tool');
+      }
+      state.sessionApproved.add(key);
+      return {};
+
+    case 'persist':
+      // Same as session, plus write to ~/.afk/config/permissions.json.
+      if (mode === 'write') {
+        grantManager.addWriteRoot(resolvedPath, 'tool');
+      } else {
+        grantManager.addReadRoot(resolvedPath, 'tool');
+      }
+      state.sessionApproved.add(key);
+      try {
+        appendGrant({
+          path: resolvedPath,
+          mode,
+          decision: 'allow',
+          source: surface === 'telegram' ? 'elicit:telegram' : 'elicit:repl',
+          reason: `Approved via ${surface} prompt for ${toolName}`,
+        });
+      } catch (err) {
+        // Persistence is best-effort. We still honor the in-session grant —
+        // the user already approved. Log to stderr; the dispatcher has no
+        // structured logger here.
+        // eslint-disable-next-line no-console
+        console.error(
+          `path-approval: failed to persist grant for ${resolvedPath}:`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+      return {};
+
+    case 'deny':
+    default:
+      return {
+        decision: 'block',
+        reason: `User denied access to ${resolvedPath}`,
+      };
+  }
+}

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -748,8 +748,15 @@ export async function bootstrapSession(
   //
   // We wire once here and do not rewire on /model swaps: directory grants are a
   // session-level concept (not per-model), and a Claude→GPT→Claude swap reuses
-  // the cached Claude instance with its grants intact. Only AnthropicDirectProvider
-  // implements the GrantManager interface; other providers are no-ops.
+  // the cached Claude instance with its grants intact.
+  //
+  // Scope (tracked in #166): path-approval is currently wired ONLY for
+  // AnthropicDirectProvider. OpenAICompatibleProvider ALSO implements the
+  // GrantManager interface, but is not wired here yet — so an OpenAI-compatible
+  // REPL session runs path-approval FAIL-OPEN: no restricted-path prompts (the
+  // typed-tool handler's own resolveAndContain still enforces containment, and
+  // the bash interpreter denylist still hard-blocks). Widening this gate to a
+  // GrantManager duck-type is #166.
   if (startupProvider instanceof AnthropicDirectProvider) {
     setAllowDirDispatcher(startupProvider);
     pathApprovalGrantRef.current = startupProvider;

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -57,6 +57,7 @@ import { emitSessionPhase } from '../../../agent/trace/emit.js';
 import { palette } from '../../palette.js';
 import { performResumeSwap, resumeConfigFor } from './resume-swap.js';
 import { reseedStatsFromStored } from './shared.js';
+import { seedPersistedGrants } from '../../../agent/permissions-store.js';
 
 /**
  * Dependencies for constructing a fresh `AgentSession`. Captures everything
@@ -515,14 +516,17 @@ export async function bootstrapSession(
   // Stable hookRegistry shared across sessions (including swaps).
   // The hook callbacks close over `stats` and `completionWriter` which are
   // also stable, so the new session gets the same routing without re-wiring.
-  const hookRegistry = createDefaultHookRegistry(
+  const hookRegistryBundle = createDefaultHookRegistry(
     (info) => { completionWriter.fn(formatSubagentCompletion(info)); },
     'cli',
     sharedMemoryStore,
     () => (stats.planMode ? 'plan' : 'default'),
     loadHooksConfig({ cwd: extras?.cwd }),
     { cwd: extras?.cwd },
-  ).registry;
+    () => extras?.cwd ?? process.cwd(),
+  );
+  const hookRegistry = hookRegistryBundle.registry;
+  const pathApprovalGrantRef = hookRegistryBundle.pathApprovalGrantRef;
 
   // Capture deps needed by both the initial build and the swap closure.
   const sharedDeps: BuildAgentSessionDeps = {
@@ -748,6 +752,8 @@ export async function bootstrapSession(
   // implements the GrantManager interface; other providers are no-ops.
   if (startupProvider instanceof AnthropicDirectProvider) {
     setAllowDirDispatcher(startupProvider);
+    pathApprovalGrantRef.current = startupProvider;
+    seedPersistedGrants(startupProvider);
   }
 
   const rl = readline.createInterface({

--- a/src/cli/interactive-lifecycle.test.ts
+++ b/src/cli/interactive-lifecycle.test.ts
@@ -32,7 +32,14 @@ describe('interactive bootstrap status line hooks', () => {
       },
     }));
     vi.doMock('../agent/default-hook-registry.js', () => ({
-      createDefaultHookRegistry: vi.fn(() => ({ registry: {}, memoryStore: { close: vi.fn() } })),
+      createDefaultHookRegistry: vi.fn(() => ({
+        registry: {},
+        memoryStore: { close: vi.fn() },
+        // Real factory always returns this ref (default-hook-registry.ts:72,125);
+        // bootstrap.ts:601 writes `.current` once the provider exists, so the mock
+        // must include it or the assignment throws "Cannot set properties of undefined".
+        pathApprovalGrantRef: { current: undefined },
+      })),
     }));
     vi.doMock('../agent/memory/index.js', () => ({
       MemoryStore: vi.fn(() => ({ close: vi.fn() })),
@@ -181,7 +188,15 @@ describe('interactive bootstrap — P1: suggestBaseUrl mirrors openaiBaseUrl', (
       },
     }));
     vi.doMock('../agent/default-hook-registry.js', () => ({
-      createDefaultHookRegistry: vi.fn(() => ({ registry: {}, memoryStore: { close: vi.fn() } })),
+      createDefaultHookRegistry: vi.fn(() => ({
+        registry: {},
+        memoryStore: { close: vi.fn() },
+        // Real factory always returns this ref (default-hook-registry.ts);
+        // bootstrap.ts writes `.current` once the provider exists, so the mock
+        // must include it or the assignment throws "Cannot set properties of
+        // undefined". Mirrors the status-line test mock above.
+        pathApprovalGrantRef: { current: undefined },
+      })),
     }));
     vi.doMock('../agent/memory/index.js', () => ({
       MemoryStore: vi.fn(() => ({ close: vi.fn() })),

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -131,6 +131,31 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     category: 'debug',
   },
   {
+    name: 'AFK_DISABLE_BASH_INTERPRETER_GUARD',
+    description:
+      'Skip ONLY the bash interpreter-eval denylist (python -c, node -e, sh -c, ...) when set to 1, ' +
+      'leaving the rest of path-approval intact. Use for headless flows (CI, daemon) whose ' +
+      'automation legitimately runs interpreter one-liners but should still keep path-approval ' +
+      'enabled. The restricted-root substring check is unaffected. Default: guard enabled. To ' +
+      'disable all path-approval + bash restriction instead, use AFK_DISABLE_PATH_APPROVAL=1.',
+    type: 'boolean',
+    required: false,
+    default: '0',
+    example: '1',
+    category: 'process',
+  },
+  {
+    name: 'AFK_DISABLE_PATH_APPROVAL',
+    description:
+      'Skip the path-approval + bash-restriction hooks entirely when set to 1. Use for headless ' +
+      'flows that need wide-open file access (CI scripts, batch jobs). Default: hooks enabled.',
+    type: 'boolean',
+    required: false,
+    default: '0',
+    example: '1',
+    category: 'process',
+  },
+  {
     name: 'AFK_DISABLE_PROMPT_CACHE',
     description: 'Disable Anthropic prompt caching when set to 1/true/yes/on. Unset = caching enabled.',
     type: 'boolean',
@@ -1030,6 +1055,8 @@ export const env = {
   get AFK_COMPACT_MODEL(): string | undefined { return process.env['AFK_COMPACT_MODEL']; },
   get AFK_DEFAULT_SUBAGENT_MODEL(): string | undefined { return process.env['AFK_DEFAULT_SUBAGENT_MODEL']; },
   get AFK_DIAGNOSE_BASELINE(): string | undefined { return process.env['AFK_DIAGNOSE_BASELINE']; },
+  get AFK_DISABLE_BASH_INTERPRETER_GUARD(): string | undefined { return process.env['AFK_DISABLE_BASH_INTERPRETER_GUARD']; },
+  get AFK_DISABLE_PATH_APPROVAL(): string | undefined { return process.env['AFK_DISABLE_PATH_APPROVAL']; },
   get AFK_DISABLE_PROMPT_CACHE(): string | undefined { return process.env['AFK_DISABLE_PROMPT_CACHE']; },
   get AFK_EFFORT(): string | undefined { return process.env['AFK_EFFORT']; },
   get AFK_MAX_BUDGET_USD(): string | undefined { return process.env['AFK_MAX_BUDGET_USD']; },

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -311,6 +311,17 @@ export function getSettingsPath(): string {
 }
 
 /**
+ * Persisted user-approved path-access grants written by the path-approval
+ * elicitation flow when the user selects [Always — persist]. See
+ * `src/agent/permissions-store.ts` for the schema. Lives under
+ * `~/.afk/config/` rather than `state/` because it's policy (dotfile-syncable)
+ * not runtime data.
+ */
+export function getPermissionsStorePath(): string {
+  return join(getAfkConfigDir(), 'permissions.json');
+}
+
+/**
  * Path to the project-local AFK settings file (`<cwd>/.afk/settings.json`).
  *
  * Accepts an explicit `cwd` so tests can inject a temp directory without

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -387,6 +387,13 @@ async function main() {
         ...(codexSessionCwd !== undefined && codexSessionCwd.length > 0
           ? { cwd: codexSessionCwd }
           : {}),
+        // Scope (tracked in #166): unlike the Anthropic branch above, the
+        // Codex/OpenAI path does NOT wire `pathApprovalGrantRef.current` or call
+        // seedPersistedGrants — it has no explicit provider handle to wire (the
+        // session constructs the provider internally). So path-approval runs
+        // FAIL-OPEN for OpenAI-compatible Telegram sessions: no restricted-path
+        // prompts (the bash interpreter denylist still hard-blocks). This is a
+        // known, documented limitation — not an accidental `.registry` chain.
         hookRegistry: createDefaultHookRegistry(
           undefined,
           'telegram',

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -36,6 +36,7 @@ import { validateBotToken } from './telegram/setup-wizard.js';
 import { AgentSession } from './agent/session.js';
 import { constructTelegramSession } from './telegram/construct-session.js';
 import { createDefaultHookRegistry } from './agent/default-hook-registry.js';
+import { seedPersistedGrants } from './agent/permissions-store.js';
 import { loadHooksConfig } from './agent/hooks/config-loader.js';
 import { MemoryStore } from './agent/memory/index.js';
 import { providerForModel, AnthropicDirectProvider } from './agent/providers/index.js';
@@ -347,14 +348,20 @@ async function main() {
           // configured worktree (AFK_TELEGRAM_CWD or sessionConfig.cwd).
           ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
           provider: directProvider,
-          hookRegistry: createDefaultHookRegistry(
-            undefined,
-            'telegram',
-            sharedMemoryStore,
-            undefined,
-            loadHooksConfig(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
-            { cwd: sessionCwd !== undefined && sessionCwd.length > 0 ? sessionCwd : undefined },
-          ).registry,
+          hookRegistry: (() => {
+            const telegramHookBundle = createDefaultHookRegistry(
+              undefined,
+              'telegram',
+              sharedMemoryStore,
+              undefined,
+              loadHooksConfig(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
+              { cwd: sessionCwd !== undefined && sessionCwd.length > 0 ? sessionCwd : undefined },
+              () => sessionCwd,
+            );
+            telegramHookBundle.pathApprovalGrantRef.current = directProvider;
+            seedPersistedGrants(directProvider);
+            return telegramHookBundle.registry;
+          })(),
         });
         boundSession = session;
         return session;

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -14,8 +14,11 @@ import { handleFarmCallback } from './handlers/farm-callbacks.js';
 import { MessageHandler } from './handlers/message.js';
 import { createAllowlistMiddleware } from './allowlist.js';
 import { FARM_CALLBACK_PREFIX } from './farm-callback-data.js';
-import { ELICITATION_CALLBACK_PREFIX } from './elicitation-callback-data.js';
 import { makeTelegramElicitationHandler } from './elicitation-handler.js';
+import {
+  createTelegramElicitationHandler,
+  composeTelegramElicitation,
+} from './elicitation-telegram.js';
 import { elicitationRouter } from '../agent/elicitation-router.js';
 import { SessionWatchManager, resolveWatchTarget, listWatchableSessions } from './watch.js';
 import { splitLongMessage } from './formatter.js';
@@ -228,24 +231,30 @@ export class TelegramBot {
     this.log('Loading sessions...');
     await this.sessionManager.loadSessions();
 
-    // Install the Telegram elicitation handler so ask_question calls from
-    // the agent are routed to the first allowed Telegram chat. This covers
-    // the common single-operator case; multi-chat support would require
-    // per-session handler installation.
+    // Wire elicitation prompts to Telegram. TWO systems share the router:
+    //   - ask_question (agent questions) → makeTelegramElicitationHandler
+    //     (afk:e: inline buttons + typed replies via messageHandler).
+    //   - path-approval + MCP form/url   → createTelegramElicitationHandler
+    //     (afk:pa: enum keyboard).
+    // They MUST be composed into a SINGLE installed handler: elicitationRouter
+    // .install is last-wins, so installing both separately clobbers the first.
+    // composeTelegramElicitation routes by request kind. Each factory registers
+    // its own DISJOINT bot.action prefix (afk:e:<digit>: vs afk:pa:), so taps
+    // never cross-route.
     const chatIds = [...this.options.allowedChatIds];
     if (chatIds.length > 0) {
       const primaryChatId = chatIds[0]!;
-      const elicitCallbackRe = new RegExp(`^${escapeRegExp(ELICITATION_CALLBACK_PREFIX)}`);
-      elicitationRouter.install(
-        makeTelegramElicitationHandler(this.messageHandler, this.bot, primaryChatId),
+      const askHandler = makeTelegramElicitationHandler(
+        this.messageHandler,
+        this.bot,
+        primaryChatId,
       );
-      // Register the elicitation action handler
-      this.bot.action(elicitCallbackRe, async (ctx) => {
-        // answerCbQuery is handled inside makeTelegramElicitationHandler's
-        // per-button action callbacks; this outer handler is a safety net
-        // in case the inner one wasn't registered yet.
-        await ctx.answerCbQuery().catch(() => {});
-      });
+      const formHandler = createTelegramElicitationHandler(
+        this.bot,
+        new Set(this.options.allowedChatIds),
+        (...args) => this.log('[elicitation]', ...args),
+      );
+      elicitationRouter.install(composeTelegramElicitation(askHandler, formHandler));
     }
 
     this.log('Starting bot...');

--- a/src/telegram/elicitation-telegram.test.ts
+++ b/src/telegram/elicitation-telegram.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Tests for the Telegram-backed elicitation handler — inline-keyboard
+ * prompt for path-approval + MCP elicitations.
+ *
+ * Covers:
+ *   - Sends the message + inline keyboard to every allowlisted chat.
+ *   - Callback resolves the pending promise with the chosen enum value.
+ *   - Out-of-band (stale ULID) callbacks ack with "no longer active" and do
+ *     NOT resolve any pending promise.
+ *   - Unknown choice → answerCbQuery says so + does not resolve.
+ *   - Abort signal aborts the pending promise as decline.
+ *   - Form-mode requests with a 4-value enum render as 2×2 keyboard.
+ */
+
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import {
+  createTelegramElicitationHandler,
+  composeTelegramElicitation,
+  _resetPendingForTests,
+  ELICITATION_CALLBACK_PREFIX,
+} from './elicitation-telegram.js';
+import { ELICITATION_CALLBACK_PREFIX as ASK_QUESTION_PREFIX } from './elicitation-callback-data.js';
+import type { ElicitationHandler } from '../agent/elicitation-router.js';
+import type { ElicitationRequest, ElicitationResult } from '../agent/types/sdk-types.js';
+
+interface SentMessage {
+  chatId: number;
+  text: string;
+  reply_markup?: unknown;
+}
+
+function makeStubBot(): {
+  bot: any;
+  sent: SentMessage[];
+  actionRegex?: RegExp;
+  actionHandler?: (ctx: any) => Promise<void>;
+} {
+  const sent: SentMessage[] = [];
+  let actionRegex: RegExp | undefined;
+  let actionHandler: ((ctx: any) => Promise<void>) | undefined;
+  const bot: any = {
+    telegram: {
+      sendMessage: async (chatId: number, text: string, opts: Record<string, unknown>) => {
+        sent.push({ chatId, text, reply_markup: opts['reply_markup'] });
+      },
+    },
+    action: (re: RegExp, handler: (ctx: any) => Promise<void>) => {
+      actionRegex = re;
+      actionHandler = handler;
+    },
+  };
+  return {
+    bot,
+    sent,
+    get actionRegex() { return actionRegex; },
+    get actionHandler() { return actionHandler; },
+  } as any;
+}
+
+function pathApprovalRequest(): ElicitationRequest {
+  return {
+    serverName: 'agent-afk',
+    message: 'Tool `read_file` wants to read /etc/hosts',
+    mode: 'form',
+    title: 'Path access approval',
+    requestedSchema: {
+      type: 'object',
+      properties: {
+        choice: {
+          type: 'string',
+          enum: ['once', 'session', 'persist', 'deny'],
+        },
+      },
+      required: ['choice'],
+    },
+  };
+}
+
+beforeEach(() => {
+  _resetPendingForTests();
+});
+
+describe('createTelegramElicitationHandler — broadcast', () => {
+  it('sends one message per allowlisted chat with a 2x2 keyboard for 4-enum', async () => {
+    const stub = makeStubBot();
+    const handler = createTelegramElicitationHandler(stub.bot, new Set([111, 222]));
+    const controller = new AbortController();
+
+    const p = handler(pathApprovalRequest(), { signal: controller.signal });
+
+    // Give the microtask queue a chance to fire the broadcast.
+    await new Promise((r) => setImmediate(r));
+
+    expect(stub.sent).toHaveLength(2);
+    expect(stub.sent.map((m) => m.chatId).sort()).toEqual([111, 222]);
+
+    // 2x2 inline keyboard.
+    const markup = stub.sent[0]?.reply_markup as
+      | { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> }
+      | undefined;
+    expect(markup?.inline_keyboard).toHaveLength(2);
+    expect(markup?.inline_keyboard[0]).toHaveLength(2);
+    expect(markup?.inline_keyboard[1]).toHaveLength(2);
+
+    // Buttons reference the path-approval enum values.
+    const callbacks = markup?.inline_keyboard.flat().map((b) => b.callback_data) ?? [];
+    expect(callbacks.every((c) => c.startsWith(ELICITATION_CALLBACK_PREFIX))).toBe(true);
+    expect(callbacks.some((c) => c.endsWith(':once'))).toBe(true);
+    expect(callbacks.some((c) => c.endsWith(':session'))).toBe(true);
+    expect(callbacks.some((c) => c.endsWith(':persist'))).toBe(true);
+    expect(callbacks.some((c) => c.endsWith(':deny'))).toBe(true);
+
+    // Abort to GC the pending entry so the test doesn't leak.
+    controller.abort();
+    await p;
+  });
+});
+
+describe('createTelegramElicitationHandler — callback resolution', () => {
+  it('callback resolves the promise with the chosen enum value', async () => {
+    const stub = makeStubBot();
+    const handler = createTelegramElicitationHandler(stub.bot, new Set([111]));
+    const controller = new AbortController();
+
+    const promise = handler(pathApprovalRequest(), { signal: controller.signal });
+    await new Promise((r) => setImmediate(r));
+
+    // Extract the ULID from the first button's callback_data.
+    const markup = stub.sent[0]?.reply_markup as { inline_keyboard: Array<Array<{ callback_data: string }>> };
+    const sampleCb = markup.inline_keyboard[0]?.[0]?.callback_data;
+    expect(sampleCb).toBeDefined();
+    const ulid = sampleCb!.slice(ELICITATION_CALLBACK_PREFIX.length).split(':')[0]!;
+
+    // Fire the simulated tap.
+    const answerCbQuery = vi.fn(async () => {});
+    await stub.actionHandler?.({
+      callbackQuery: { data: `${ELICITATION_CALLBACK_PREFIX}${ulid}:session` },
+      answerCbQuery,
+    });
+
+    const result = await promise;
+    expect(result.action).toBe('accept');
+    expect(result.content?.['choice']).toBe('session');
+    expect(answerCbQuery).toHaveBeenCalled();
+  });
+
+  it('stale ULID callback does not resolve any pending promise', async () => {
+    const stub = makeStubBot();
+    createTelegramElicitationHandler(stub.bot, new Set([111]));
+
+    const answerCbQuery = vi.fn(async () => {});
+    await stub.actionHandler?.({
+      callbackQuery: { data: `${ELICITATION_CALLBACK_PREFIX}NONEXISTENT26CHARSULID01234:session` },
+      answerCbQuery,
+    });
+
+    expect(answerCbQuery).toHaveBeenCalledWith(expect.stringMatching(/no longer active/i));
+  });
+
+  it('unknown choice (not in enum) replies with "Unknown choice"', async () => {
+    const stub = makeStubBot();
+    const handler = createTelegramElicitationHandler(stub.bot, new Set([111]));
+    const controller = new AbortController();
+    const promise = handler(pathApprovalRequest(), { signal: controller.signal });
+    await new Promise((r) => setImmediate(r));
+
+    const markup = stub.sent[0]?.reply_markup as { inline_keyboard: Array<Array<{ callback_data: string }>> };
+    const ulid = markup.inline_keyboard[0]?.[0]?.callback_data!
+      .slice(ELICITATION_CALLBACK_PREFIX.length)
+      .split(':')[0]!;
+
+    const answerCbQuery = vi.fn(async () => {});
+    await stub.actionHandler?.({
+      callbackQuery: { data: `${ELICITATION_CALLBACK_PREFIX}${ulid}:rogue_choice` },
+      answerCbQuery,
+    });
+
+    expect(answerCbQuery).toHaveBeenCalledWith('Unknown choice');
+
+    // Abort so the test doesn't leak the pending promise.
+    controller.abort();
+    await promise;
+  });
+});
+
+describe('createTelegramElicitationHandler — abort path', () => {
+  it('abort signal resolves the pending promise as decline', async () => {
+    const stub = makeStubBot();
+    const handler = createTelegramElicitationHandler(stub.bot, new Set([111]));
+    const controller = new AbortController();
+
+    const promise = handler(pathApprovalRequest(), { signal: controller.signal });
+    await new Promise((r) => setImmediate(r));
+
+    controller.abort();
+    const result = await promise;
+    expect(result.action).toBe('decline');
+  });
+
+  it('pre-aborted signal returns decline without sending any message', async () => {
+    const stub = makeStubBot();
+    const handler = createTelegramElicitationHandler(stub.bot, new Set([111]));
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await handler(pathApprovalRequest(), { signal: controller.signal });
+    expect(result.action).toBe('decline');
+    expect(stub.sent).toHaveLength(0);
+  });
+});
+
+/**
+ * Regression for PR #477 review findings B1 + B2: the path-approval and
+ * ask_question Telegram elicitation systems must COEXIST.
+ *   - B1: composeTelegramElicitation routes BOTH request kinds through one
+ *     installed handler, so neither clobbers the other on
+ *     elicitationRouter.install (last-wins). Routed by `request.type`:
+ *     set → ask_question (old afk:e: handler); absent → form/url (new afk:pa:).
+ *   - B2: the two callback prefixes are DISJOINT, so the new handler's
+ *     bot.action matcher can never intercept an ask_question button tap.
+ */
+describe('elicitation coexistence (PR #477 B1/B2)', () => {
+  it('B1: composeTelegramElicitation routes ask_question (type set) to the ask handler', async () => {
+    const calls: string[] = [];
+    const askHandler: ElicitationHandler = async () => {
+      calls.push('ask');
+      return { action: 'accept', content: { value: 'beta' } } as ElicitationResult;
+    };
+    const formHandler: ElicitationHandler = async () => {
+      calls.push('form');
+      return { action: 'accept', content: { choice: 'once' } } as ElicitationResult;
+    };
+    const composed = composeTelegramElicitation(askHandler, formHandler);
+
+    const req: ElicitationRequest = {
+      serverName: 'agent-afk',
+      message: 'Pick one',
+      type: 'choice',
+      choices: ['alpha', 'beta'],
+    };
+    const result = await composed(req, { signal: new AbortController().signal });
+    expect(calls).toEqual(['ask']);
+    expect(result.content?.['value']).toBe('beta');
+  });
+
+  it('B1: composeTelegramElicitation routes form/path-approval (no type) to the form handler', async () => {
+    const calls: string[] = [];
+    const askHandler: ElicitationHandler = async () => {
+      calls.push('ask');
+      return { action: 'accept' } as ElicitationResult;
+    };
+    const formHandler: ElicitationHandler = async () => {
+      calls.push('form');
+      return { action: 'accept', content: { choice: 'once' } } as ElicitationResult;
+    };
+    const composed = composeTelegramElicitation(askHandler, formHandler);
+
+    // Path-approval request: mode 'form', NO `type` field.
+    const result = await composed(pathApprovalRequest(), { signal: new AbortController().signal });
+    expect(calls).toEqual(['form']);
+    expect(result.content?.['choice']).toBe('once');
+  });
+
+  it('B2: the two callback prefixes are disjoint (no cross-interception)', () => {
+    // The new handler registers bot.action(/^afk:pa:/); the old one registers
+    // /^afk:e:\d+:.+$/. A tap on either must match exactly one.
+    const askTap = `${ASK_QUESTION_PREFIX}0:elic-deadbeef`; // afk:e:0:...
+    const paTap = `${ELICITATION_CALLBACK_PREFIX}01ARZ3NDEKTSV4RRFFQ69G5FAV:once`; // afk:pa:<ulid>:once
+
+    const paMatcher = new RegExp(`^${ELICITATION_CALLBACK_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);
+    const askMatcher = /^afk:e:\d+:.+$/;
+
+    // New (path-approval) matcher must NOT swallow ask_question taps.
+    expect(paMatcher.test(askTap)).toBe(false);
+    expect(paMatcher.test(paTap)).toBe(true);
+    // Old (ask_question) matcher must NOT swallow path-approval taps.
+    expect(askMatcher.test(paTap)).toBe(false);
+    expect(askMatcher.test(askTap)).toBe(true);
+    // And the constants themselves differ.
+    expect(ELICITATION_CALLBACK_PREFIX).not.toBe(ASK_QUESTION_PREFIX);
+  });
+});

--- a/src/telegram/elicitation-telegram.ts
+++ b/src/telegram/elicitation-telegram.ts
@@ -1,0 +1,331 @@
+/**
+ * Telegram-backed elicitation handler.
+ *
+ * Routes MCP elicitations + path-approval prompts to the Telegram chat with
+ * an inline keyboard. Resolves the `ElicitationResult` promise when the user
+ * taps a button.
+ *
+ * # Wire format
+ *
+ * Inline buttons carry `callback_data` of the form
+ *
+ *   `afk:pa:<ulid>:<choice>`
+ *
+ * where `<ulid>` uniquely identifies the elicitation request and `<choice>`
+ * is the enum value (e.g. `once` / `session` / `persist` / `deny`).
+ * The ULID prefix is mandatory so two elicitations fired in the same chat
+ * (e.g. by concurrent subagents) don't have their callbacks aliased.
+ *
+ * Invariant: this prefix (`afk:pa:`) is deliberately DISJOINT from the
+ * `ask_question` handler's `afk:e:<digit>:<id>` format (see
+ * `elicitation-callback-data.ts`). Both handlers register a `bot.action` on
+ * the same Telegraf instance; disjoint prefixes guarantee a tap routes to
+ * exactly one handler. Sharing a prefix (the pre-fix bug) made the broader
+ * `^afk:e:` matcher swallow ask_question taps and reply "no longer active".
+ *
+ * # Threat model
+ *
+ * Allowlist guarding is the bot's middleware concern (every chat ID in
+ * `AFK_TELEGRAM_ALLOWED_CHAT_IDS` is trusted). By the time a callback
+ * reaches us we know the tap came from the user. We still
+ * defensively dispatch by the in-process pending-request map — an out-of-
+ * band callback (e.g. a copied URL pasted manually) hits a request that
+ * has already resolved and gets a "stale" reply.
+ *
+ * # Lifecycle
+ *
+ * Each elicitation request:
+ *   1. Generates a fresh ULID and stores `{ resolve, enumValues }` in a
+ *      module-scope Map keyed by ULID.
+ *   2. Sends the message + inline keyboard to every allowlisted chat ID.
+ *   3. Awaits the first callback that matches the ULID.
+ *   4. Calls `ctx.answerCbQuery()` and resolves the promise.
+ *   5. The pending entry is GC'd when EITHER the callback resolves it OR the
+ *      request's AbortSignal fires (session/turn teardown). The elicitation
+ *      router has NO time-based deadline — the prior 5-minute ceiling was
+ *      removed (it cut off operators who stepped away), so abort is the only
+ *      non-resolution cleanup path.
+ *
+ * @module telegram/elicitation-telegram
+ */
+
+import type { Telegraf, Context } from 'telegraf';
+import type { InlineKeyboardMarkup } from 'telegraf/types';
+import { generateUlid } from '../agent/permissions-store.js';
+import type {
+  ElicitationHandler,
+} from '../agent/elicitation-router.js';
+import type {
+  ElicitationRequest,
+  ElicitationResult,
+} from '../agent/types/sdk-types.js';
+
+/**
+ * Prefix for path-approval / MCP elicitation callbacks. DISTINCT from the
+ * `ask_question` handler's `afk:e:` prefix (`elicitation-callback-data.ts`)
+ * so the two `bot.action` matchers never cross-route — see the module header.
+ */
+export const ELICITATION_CALLBACK_PREFIX = 'afk:pa:';
+
+/** Maximum bytes for inline-keyboard callback_data (Telegram limit is 64). */
+const MAX_CALLBACK_DATA_BYTES = 64;
+
+interface PendingElicitation {
+  resolve: (result: ElicitationResult) => void;
+  enumValues: string[];
+}
+
+/**
+ * Module-scope pending-request map. Keyed by the ULID embedded in each
+ * callback_data. Lives at module scope (not per-bot) so the singleton
+ * `elicitationRouter.install(...)` can register a handler that closes over
+ * it without needing to thread state through every call site.
+ */
+const pending = new Map<string, PendingElicitation>();
+
+/**
+ * Install a callback handler on the Telegraf instance that resolves
+ * elicitation buttons. Must be called BEFORE `bot.launch()` so the action
+ * regex is registered ahead of the first incoming update.
+ *
+ * Returns an `ElicitationHandler` that callers pass to
+ * `elicitationRouter.install(...)`.
+ */
+export function createTelegramElicitationHandler(
+  bot: Telegraf,
+  chatIds: Set<number>,
+  log: (...args: unknown[]) => void = () => {},
+): ElicitationHandler {
+  // Register the action handler exactly once per bot. Bots in tests may
+  // reuse the same Telegraf instance across handler factories; guard
+  // against double-registration by stashing a flag on the bot object.
+  // (`as { _elicitationRegistered?: boolean }` because Telegraf is plain JS
+  // and accepts ad-hoc property assignment.)
+  const botAny = bot as Telegraf & { _elicitationRegistered?: boolean };
+  if (!botAny._elicitationRegistered) {
+    const actionRe = new RegExp(`^${escapeRegExp(ELICITATION_CALLBACK_PREFIX)}`);
+    bot.action(actionRe, async (ctx) => handleElicitationCallback(ctx, log));
+    botAny._elicitationRegistered = true;
+  }
+
+  return async (request, options) => {
+    if (options.signal.aborted) {
+      return { action: 'decline' };
+    }
+    return new Promise<ElicitationResult>((resolve) => {
+      const ulid = generateUlid();
+      const enumValues = extractEnumValues(request);
+      pending.set(ulid, {
+        resolve,
+        enumValues,
+      });
+
+      const text = formatRequest(request);
+      const keyboard = buildKeyboard(ulid, enumValues);
+
+      // Send to every allowlisted chat. The first callback resolves; later
+      // taps from other chats hit the "stale" path.
+      const sends = Array.from(chatIds).map(async (chatId) => {
+        try {
+          await bot.telegram.sendMessage(chatId, text, {
+            reply_markup: keyboard,
+          });
+        } catch (err) {
+          log('[elicitation] sendMessage failed:', err);
+        }
+      });
+      // Fire-and-forget: we don't await the sends. If they all fail, the
+      // promise stays pending until the request's AbortSignal fires (session/
+      // turn teardown) and the abort listener below resolves DECLINE + GCs the
+      // entry. The router has no time-based deadline, so abort is the cleanup
+      // path. Acceptable degraded behavior.
+      void Promise.all(sends);
+
+      // Abort wiring — if the outer signal fires (e.g. session torn down),
+      // we resolve as decline and GC the pending entry.
+      options.signal.addEventListener(
+        'abort',
+        () => {
+          const entry = pending.get(ulid);
+          if (!entry) return;
+          pending.delete(ulid);
+          entry.resolve({ action: 'decline' });
+        },
+        { once: true },
+      );
+    });
+  };
+}
+
+async function handleElicitationCallback(
+  ctx: Context,
+  log: (...args: unknown[]) => void,
+): Promise<void> {
+  // Telegraf threads the callback_data on `ctx.callbackQuery.data`.
+  const cb = (ctx.callbackQuery as { data?: string } | undefined)?.data;
+  if (typeof cb !== 'string' || !cb.startsWith(ELICITATION_CALLBACK_PREFIX)) {
+    await ctx.answerCbQuery('Unknown callback').catch(() => {});
+    return;
+  }
+  const tail = cb.slice(ELICITATION_CALLBACK_PREFIX.length);
+  const sepIdx = tail.indexOf(':');
+  if (sepIdx <= 0 || sepIdx === tail.length - 1) {
+    await ctx.answerCbQuery('Malformed callback').catch(() => {});
+    return;
+  }
+  const ulid = tail.slice(0, sepIdx);
+  const choice = tail.slice(sepIdx + 1);
+
+  const entry = pending.get(ulid);
+  if (!entry) {
+    // Stale or never-existed — most often a duplicate tap after the first
+    // resolved, or a tap on a prompt whose request was aborted (session/turn
+    // teardown GC'd the entry). Answer the spinner so the user UI doesn't hang.
+    await ctx.answerCbQuery('This prompt is no longer active.').catch(() => {});
+    return;
+  }
+  if (!entry.enumValues.includes(choice)) {
+    log('[elicitation] callback choice not in enum:', choice, entry.enumValues);
+    await ctx.answerCbQuery('Unknown choice').catch(() => {});
+    return;
+  }
+
+  // Resolve the pending promise. Per the MCP elicitation spec, accept
+  // carries `content` keyed by the schema property — we use 'choice' as a
+  // stable convention since path-approval emits a single enum field.
+  pending.delete(ulid);
+  entry.resolve({
+    action: 'accept',
+    content: { choice },
+  });
+
+  // Acknowledge the button tap so Telegram clears the spinner. The button
+  // ack message is what the user sees as a brief toast.
+  await ctx.answerCbQuery(`Recorded: ${choice}`).catch((err: unknown) => {
+    log('[elicitation] answerCbQuery failed:', err);
+  });
+}
+
+/**
+ * Pull the `enum` array off the requestedSchema's first property. For path
+ * approval this is `['once', 'session', 'persist', 'deny']`. Falls back to
+ * accept/decline for non-form requests (URL mode).
+ */
+function extractEnumValues(req: ElicitationRequest): string[] {
+  if (req.mode !== 'form') return ['accept', 'decline'];
+  const schema = req.requestedSchema;
+  if (typeof schema !== 'object' || schema === null) return ['accept', 'decline'];
+  const props = (schema as Record<string, unknown>)['properties'];
+  if (typeof props !== 'object' || props === null) return ['accept', 'decline'];
+  const firstKey = Object.keys(props as Record<string, unknown>)[0];
+  if (firstKey === undefined) return ['accept', 'decline'];
+  const field = (props as Record<string, unknown>)[firstKey];
+  if (typeof field !== 'object' || field === null) return ['accept', 'decline'];
+  const enumArr = (field as Record<string, unknown>)['enum'];
+  if (!Array.isArray(enumArr)) return ['accept', 'decline'];
+  return enumArr.map(String);
+}
+
+function formatRequest(req: ElicitationRequest): string {
+  const parts: string[] = [];
+  // Plain text — `sendMessage` is sent without `parse_mode`, so Markdown
+  // syntax would render literally. The body carries filesystem paths
+  // (underscores, brackets) that would also break a Markdown/HTML parser, so
+  // emitting plain text is the correct (and safe) choice here.
+  if (req.title) parts.push(req.title);
+  parts.push(req.message);
+  // Telegram has a 4096-char body limit. Truncate defensively (path strings
+  // can be long; we don't want to fail-silent on send).
+  const joined = parts.join('\n\n');
+  return joined.length > 4000 ? joined.slice(0, 3997) + '...' : joined;
+}
+
+function buildKeyboard(ulid: string, choices: string[]): InlineKeyboardMarkup {
+  // Truncate any choice that would exceed the 64-byte callback_data ceiling
+  // once the prefix + ulid + separator are included. ULID is 26 bytes
+  // + 'afk:pa:' (7 bytes) + ':' (1 byte) = 34 bytes of overhead, leaving
+  // 30 bytes for the choice — comfortable for the path-approval enums.
+  const overhead = ELICITATION_CALLBACK_PREFIX.length + ulid.length + 1;
+  const room = MAX_CALLBACK_DATA_BYTES - overhead;
+  const buttons = choices.map((choice) => {
+    const safe = choice.length <= room ? choice : choice.slice(0, room);
+    return {
+      text: labelFor(safe),
+      callback_data: `${ELICITATION_CALLBACK_PREFIX}${ulid}:${safe}`,
+    };
+  });
+
+  // Layout: 2x2 if 4 buttons (path approval), single column otherwise.
+  if (buttons.length === 4) {
+    return {
+      inline_keyboard: [
+        [buttons[0]!, buttons[1]!],
+        [buttons[2]!, buttons[3]!],
+      ],
+    };
+  }
+  return { inline_keyboard: buttons.map((b) => [b]) };
+}
+
+/**
+ * Human-friendly labels for known enum values. Falls through to title-case
+ * for unknowns (so future enums get a reasonable default rendering).
+ */
+function labelFor(choice: string): string {
+  switch (choice) {
+    case 'once':
+      return '✅ Once';
+    case 'session':
+      return '🔁 Session';
+    case 'persist':
+      return '💾 Always';
+    case 'deny':
+      return '❌ Deny';
+    case 'accept':
+      return '✅ Accept';
+    case 'decline':
+      return '❌ Decline';
+    default:
+      return choice.charAt(0).toUpperCase() + choice.slice(1);
+  }
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Compose the two Telegram elicitation handlers into ONE dispatcher for
+ * `elicitationRouter.install`. Routes by request kind:
+ *   - `request.type` set → agent-originated `ask_question` (confirm / choice /
+ *     text / number / multi_choice) → `askHandler` (the `afk:e:` handler in
+ *     `elicitation-handler.ts`: inline buttons + typed replies).
+ *   - otherwise (`mode:'form'|'url'`, no `type`) → path-approval / MCP
+ *     elicitation → `formHandler` (this module's `afk:pa:` enum keyboard).
+ *
+ * Invariant: install the COMPOSED handler exactly once. `elicitationRouter
+ * .install` is last-wins (`this.handler = handler`), so installing the two
+ * handlers separately silently clobbers the first — the PR #477 bug this
+ * fixes (the path-approval install was overwritten by the ask_question install
+ * inside `bot.start()`). Both underlying factories still register their own
+ * disjoint `bot.action` (`afk:e:<digit>:` vs `afk:pa:`), so button taps never
+ * cross-route. `request.type` is the discriminant because `ask_question`
+ * always sets it (ask-question.ts) and form/url elicitations never do.
+ */
+export function composeTelegramElicitation(
+  askHandler: ElicitationHandler,
+  formHandler: ElicitationHandler,
+): ElicitationHandler {
+  return (request, options) =>
+    request.type !== undefined
+      ? askHandler(request, options)
+      : formHandler(request, options);
+}
+
+/**
+ * Test-only: clear the pending map. Production never needs this — entries
+ * are GC'd via resolve() or abort, never leaked.
+ */
+export function _resetPendingForTests(): void {
+  pending.clear();
+}


### PR DESCRIPTION
## Source
Port of [afk-workshop#477](https://github.com/griffinwork40/afk-workshop/pull/477). This is a moat-scrubbed port, not a 1:1 copy.

## What

When a typed file tool (`read_file`, `write_file`, `edit_file`, `list_directory`, `glob`, `grep`) targets a path outside the session's granted roots, a new `PreToolUse` hook prompts the user via the existing `ElicitationRouter` with a 4-choice form:

| Choice | Behavior |
|---|---|
| **once** | Allow this single call (`PostToolUse` revokes the grant) |
| **session** | `addReadRoot` / `addWriteRoot` for the dispatcher lifetime |
| **persist** | session + write to `~/.afk/config/permissions.json` |
| **deny** | block; model sees a structured `"user denied access to X"` error |

Bash invocations are gated separately by `bash-restriction-hook.ts` — hard-block on interpreter `-c`/`-e` flags (`python -c`, `node -e`, `ruby -e`, `sh -c`, …) and on literal restricted-root substrings (`~/.ssh`, `~/.aws`, `~/.gnupg`, `/etc/sudoers`, …).

## Ported (all 25 files, all PUBLIC-SAFE)

**New files:**
- `src/agent/permissions-store.ts` + test — JSON-backed grant store with ULID IDs
- `src/agent/hooks-longrunning.test.ts` — tests for `longRunning` timeout opt-out
- `src/agent/tools/handlers/_cwd-utils.test.ts`
- `src/agent/tools/hooks/bash-restriction-hook.ts` + test — interpreter denylist + restricted-root substring guard
- `src/agent/tools/hooks/path-approval-hook.ts` + test — PreToolUse/PostToolUse/SessionEnd hooks
- `src/telegram/elicitation-telegram.ts` + test — Telegram 2×2 inline keyboard with ULID callbacks

**Modified files:**
- `src/agent/hooks.ts` — `PostToolUseContext.input?`, `RegisterOptions`, signal forwarded to handlers
- `src/agent/hook-registry.ts` — `longRunning?: boolean` opt-out from 30s handler timeout
- `src/agent/default-hook-registry.ts` — registers path-approval + bash-restriction hooks, exposes `pathApprovalGrantRef`
- `src/agent/tools/dispatcher.ts` — passes `call.input` to all `firePostToolUse` callsites
- `src/cli/commands/interactive/bootstrap.ts` — wires `pathApprovalGrantRef` + `seedPersistedGrants`
- `src/telegram.ts` + `src/telegram/bot.ts` — composes Telegram elicitation handlers (ask_question + path-approval) into single installed handler
- `src/paths.ts` — adds `getPermissionsStorePath()`
- `src/config/env.ts` — adds `AFK_DISABLE_PATH_APPROVAL` + `AFK_DISABLE_BASH_INTERPRETER_GUARD`
- `docs/env-registry.json` + `docs/env-registry.md` — documents the two new env vars
- `CHANGELOG.md` — unreleased entry

## Dropped (and why)

- `src/agent/pattern-cards/appearance-writer.ts` and its SessionStart hook registration — this module does not exist in public; the hook writes pattern-card telemetry to a private pipeline. The related comment mentioning `awa-private` was also dropped.
- `agent-atlas` reference in `default-hook-registry.ts` JSDoc — scrubbed to `AFK's built-in` (was the private internal name).
- `getCeilingLedgerDir()` in `paths.ts` and the `ceiling-ledger/` directory listing — these reference the forge-gate evaluation store, which is moat.
- Unrelated private-branch cleanup (repeat circuit breaker removal, provider factory refactoring, MCP import-sources removal) — these diverged from public and would break public-only consumers. The public versions of the affected files were restored and only the PR-specific additions were applied surgically.

## Verification

- ✅ `pnpm lint` (tsc --noEmit strict) — clean
- ✅ `pnpm test` — 501 test files, 9376 tests passed (12 skipped, 0 failed)
- ✅ `pnpm build` — clean
- ✅ `MOAT GUARD CLEAN` — deterministic grep over src/ + dist/ found zero denylist hits
- ✅ Adversarial audit — independent sub-agent re-derived all 21 denylist terms and all structural checks from scratch; confirmed CLEAN

**Do not merge automatically — leave for human review.**