### PR TITLE
fix(renderer): route all overlay repaints through setComposedOverlay (port afk-workshop#572)

### DIFF
--- a/src/cli/_lib/rhythm-contract.test.ts
+++ b/src/cli/_lib/rhythm-contract.test.ts
@@ -77,6 +77,7 @@ function makeCtx(
     thinkingLane: new ThinkingLane(),
     thinkingMode: 'off',
     streamingMarkdown: { current: null },
+    lastProgressByTask: new Map(),
   };
 }
 
@@ -172,6 +173,7 @@ describe('TUI rhythm contract — flushToolLaneToScrollback', () => {
       thinkingLane: new ThinkingLane(),
       thinkingMode: 'off',
       streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
     };
 
     flushToolLaneToScrollback(ctx);
@@ -213,7 +215,7 @@ describe('TUI rhythm contract — done-time tool-lane flush', () => {
 
     // Drive the done event — this path takes the orchestrator branch
     // at lines 357-379 (tool-lane flush + before-content anchor).
-    handleOrchestratorEvent({ type: 'done', metadata: { durationMs: 1 } }, source, ctx, new Map());
+    handleOrchestratorEvent({ type: 'done', metadata: { durationMs: 1 } }, source, ctx);
 
     // The done-path schedules commits through coordinator OR runs the
     // fallback path. In the fallback (no coordinator on ctx), it calls
@@ -253,7 +255,6 @@ describe('TUI rhythm contract — orchestrator before-content path', () => {
       { type: 'chunk', chunk: { type: 'content', content: 'prose after tool' } },
       source,
       ctx,
-      new Map(),
     );
 
     // The tool flush must have produced at least tool content + a trailing blank.

--- a/src/cli/_lib/stream-renderer-contexts.test.ts
+++ b/src/cli/_lib/stream-renderer-contexts.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Production-wiring regression tests for the StreamRenderer ctx factories.
+ *
+ * Issue #389 shipped with every subagent overlay repaint routed through
+ * `setComposedOverlay(ctx.orchestratorCtx)`, but `makeSubagentCtx` — the SOLE
+ * production constructor of SubagentCtx, called by StreamRenderer.process() —
+ * never set `orchestratorCtx`. The `ctx.orchestratorCtx` guard in every
+ * subagent handler was therefore permanently false in production, so no
+ * subagent state transition ever repainted the overlay. The PR's own tests
+ * missed it because they hand-assembled a SubagentCtx with `orchestratorCtx`
+ * wired in — exercising a path production never takes.
+ *
+ * These tests build the ctx through the REAL factories (`makeSubagentCtx` +
+ * `makeOrchestratorCtx`), the exact path production uses, and assert the
+ * repaint actually fires. They fail on the pre-fix code.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { makeSubagentCtx, makeOrchestratorCtx } from './stream-renderer-contexts.js';
+import { handleSubagentEvent, synthesizeAgentEntry } from './stream-renderer-subagent.js';
+import { freshSourceState, type SourceState } from './stream-renderer-source.js';
+import { ToolLane } from '../commands/interactive/tool-lane.js';
+import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
+import { CommitCoordinator } from './commit-coordinator.js';
+import { stripAnsi } from '../display.js';
+import type { Writer } from '../slash/types.js';
+import type { StreamingMarkdownRenderer } from './stream-renderer.js';
+import type { TerminalCompositor } from '../terminal-compositor.js';
+import type { OutputEvent } from '../../agent/types.js';
+
+function makeWriter(): Writer {
+  return { line() {}, raw() {}, success() {}, info() {}, warn() {}, error() {} };
+}
+
+function makeCompositor() {
+  const overlayCalls: string[] = [];
+  const compositor = {
+    setOverlay: (text: string) => { overlayCalls.push(text); },
+    commitAbove: vi.fn(),
+  } as unknown as TerminalCompositor;
+  return { compositor, overlayCalls };
+}
+
+describe('stream-renderer-contexts — issue #389 production wiring', () => {
+  it('makeSubagentCtx forwards orchestratorCtx onto the SubagentCtx', () => {
+    const { compositor } = makeCompositor();
+    const writer = makeWriter();
+    const toolLane = new ToolLane();
+    const orchestratorCtx = makeOrchestratorCtx({
+      out: writer,
+      isTTY: true,
+      compositor,
+      overlayComposer: null,
+      toolLane,
+      thinkingLane: new ThinkingLane(),
+      thinkingMode: 'off',
+      streamingMarkdown: { current: null },
+      coordinator: new CommitCoordinator(),
+      lastProgressByTask: new Map(),
+    });
+
+    const ctx = makeSubagentCtx({
+      isTTY: true,
+      compositor,
+      toolLane,
+      out: writer,
+      streamingMarkdown: new Map<string, StreamingMarkdownRenderer>(),
+      thinkingMode: 'off',
+      orchestratorCtx,
+    });
+
+    // The factory MUST thread orchestratorCtx through — dropping it (pre-fix)
+    // is exactly what neutered every subagent repaint in production.
+    expect(ctx.orchestratorCtx).toBe(orchestratorCtx);
+  });
+
+  it('a subagent tool event fires a composed overlay repaint that preserves the orchestrator thinking paragraph', () => {
+    const { compositor, overlayCalls } = makeCompositor();
+    const writer = makeWriter();
+    const toolLane = new ToolLane();
+    // Orchestrator is mid-thought in live mode — its paragraph must survive
+    // a subagent state transition (the whole point of issue #389).
+    const thinkingLane = new ThinkingLane();
+    thinkingLane.push('Orchestrator reasoning that must survive subagent repaints.');
+
+    const orchestratorCtx = makeOrchestratorCtx({
+      out: writer,
+      isTTY: true,
+      compositor,
+      // null composer → setComposedOverlay takes the legacy compose path,
+      // which renders the thinking paragraph + tool lane directly.
+      overlayComposer: null,
+      toolLane,
+      thinkingLane,
+      thinkingMode: 'live',
+      streamingMarkdown: { current: null },
+      coordinator: new CommitCoordinator(),
+      lastProgressByTask: new Map(),
+    });
+
+    const ctx = makeSubagentCtx({
+      isTTY: true,
+      compositor,
+      toolLane,
+      out: writer,
+      streamingMarkdown: new Map<string, StreamingMarkdownRenderer>(),
+      thinkingMode: 'live',
+      orchestratorCtx,
+    });
+
+    const source: SourceState = freshSourceState('verifier');
+    source.agentType = 'verifier';
+    synthesizeAgentEntry('src-wire', source, ctx, undefined);
+
+    const toolStart: OutputEvent = {
+      type: 'chunk',
+      chunk: { type: 'tool_use_detail', toolUseId: 'tu-wire', toolName: 'Bash', toolInput: '"echo hi"' },
+    } as OutputEvent;
+    handleSubagentEvent(toolStart, 'src-wire', source, ctx);
+
+    // Pre-fix: zero overlay calls (the ctx.orchestratorCtx guard was false).
+    expect(overlayCalls.length).toBeGreaterThan(0);
+    // The composed frame includes the orchestrator's live thinking paragraph —
+    // proving it was NOT a bare tool-lane-only write.
+    const lastFrame = stripAnsi(overlayCalls[overlayCalls.length - 1] ?? '');
+    expect(lastFrame).toContain('◆ thinking');
+  });
+
+  it('the done/finalize path fires a composed overlay repaint through orchestratorCtx', () => {
+    const { compositor, overlayCalls } = makeCompositor();
+    const writer = makeWriter();
+    const toolLane = new ToolLane();
+    const thinkingLane = new ThinkingLane();
+    thinkingLane.push('Synthesizing the final answer.');
+
+    const orchestratorCtx = makeOrchestratorCtx({
+      out: writer,
+      isTTY: true,
+      compositor,
+      overlayComposer: null,
+      toolLane,
+      thinkingLane,
+      thinkingMode: 'live',
+      streamingMarkdown: { current: null },
+      coordinator: new CommitCoordinator(),
+      lastProgressByTask: new Map(),
+    });
+
+    const ctx = makeSubagentCtx({
+      isTTY: true,
+      compositor,
+      toolLane,
+      out: writer,
+      streamingMarkdown: new Map<string, StreamingMarkdownRenderer>(),
+      thinkingMode: 'live',
+      orchestratorCtx,
+    });
+
+    const source = freshSourceState('verifier');
+    source.agentType = 'verifier';
+    synthesizeAgentEntry('src-done', source, ctx, undefined);
+
+    handleSubagentEvent({ type: 'done' } as OutputEvent, 'src-done', source, ctx);
+
+    // finalizeSubagent (the live copy in stream-renderer-subagent.ts) must
+    // repaint via setComposedOverlay(ctx.orchestratorCtx) — pre-fix this guard
+    // was false in production and the Done row never repainted live.
+    expect(overlayCalls.length).toBeGreaterThan(0);
+  });
+});

--- a/src/cli/_lib/stream-renderer-contexts.ts
+++ b/src/cli/_lib/stream-renderer-contexts.ts
@@ -10,6 +10,7 @@
 
 import type { OrchestratorCtx } from './stream-renderer-orchestrator.js';
 import type { SubagentCtx } from './stream-renderer-subagent.js';
+import type { ProgressEvent } from '../../agent/types.js';
 import type { TerminalCompositor } from '../terminal-compositor.js';
 import type { OverlayComposer } from './overlay-composer.js';
 import type { ToolLane } from '../commands/interactive/tool-lane.js';
@@ -36,6 +37,7 @@ export function makeOrchestratorCtx(args: {
   coordinator: CommitCoordinator;
   stageTracker?: StageTrackerState;
   activeSkillName?: string;
+  lastProgressByTask: Map<string, ProgressEvent>;
 }): OrchestratorCtx {
   return {
     out: args.out,
@@ -47,6 +49,7 @@ export function makeOrchestratorCtx(args: {
     thinkingMode: args.thinkingMode,
     streamingMarkdown: args.streamingMarkdown,
     coordinator: args.coordinator,
+    lastProgressByTask: args.lastProgressByTask,
     // Hand the tracker only when we have a TTY compositor — non-TTY
     // surfaces (Telegram, daemon, tests) never call setComposedOverlay
     // anyway, and propagating a tracker through them would just be
@@ -62,16 +65,15 @@ export function makeOrchestratorCtx(args: {
 export function makeSubagentCtx(args: {
   isTTY: boolean;
   compositor: TerminalCompositor | null;
-  overlayComposer: OverlayComposer | null;
   toolLane: ToolLane;
   out: Writer;
   streamingMarkdown: Map<string, StreamingMarkdownRenderer>;
   thinkingMode: 'off' | 'summary' | 'live';
+  orchestratorCtx: OrchestratorCtx;
 }): SubagentCtx {
   return {
     isTTY: args.isTTY,
     compositor: args.compositor,
-    overlayComposer: args.overlayComposer,
     toolLane: args.toolLane,
     out: args.out,
     streamingMarkdown: args.streamingMarkdown,
@@ -80,6 +82,15 @@ export function makeSubagentCtx(args: {
     // governs both surfaces. One knob, one mental model. See
     // SubagentCtx.thinkingMode for the per-mode behavior contract.
     thinkingMode: args.thinkingMode,
+    // Invariant (issue #389): every subagent event handler routes its overlay
+    // repaint through `setComposedOverlay(ctx.orchestratorCtx)`. That call is
+    // guarded by `ctx.orchestratorCtx`, so production MUST thread the live
+    // orchestrator ctx here — otherwise the guard is permanently false and no
+    // subagent repaint ever reaches the compositor. Required (not optional) so
+    // `tsc` fails loudly if a future caller forgets it. The ctx shares the
+    // renderer's toolLane / thinkingLane / lastProgressByTask, so the composed
+    // frame includes the orchestrator's thinking paragraph + progress banner.
+    orchestratorCtx: args.orchestratorCtx,
   };
 }
 

--- a/src/cli/_lib/stream-renderer-orchestrator.test.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.test.ts
@@ -91,6 +91,8 @@ function makeCtx(
     thinkingLane: new ThinkingLane(),
     thinkingMode: 'off',
     streamingMarkdown: { current: null },
+    // lastProgressByTask is now part of OrchestratorCtx (issue #389 hoist).
+    lastProgressByTask: new Map(),
   };
 }
 
@@ -117,16 +119,15 @@ describe('handleOrchestratorEvent — tool_diff arm', () => {
 
     const ctx = makeCtx(toolLane, { isTTY: true, compositor });
     const source: SourceState = freshSourceState('__main__');
-    const lastProgress = new Map();
     const diff = makeMinimalDiff();
     const id = 'tu-1';
 
     // First: register the tool use so the entry exists in the lane.
-    handleOrchestratorEvent(toolStartEvent(id), source, ctx, lastProgress);
-    handleOrchestratorEvent(toolResultEvent(id), source, ctx, lastProgress);
+    handleOrchestratorEvent(toolStartEvent(id), source, ctx);
+    handleOrchestratorEvent(toolResultEvent(id), source, ctx);
 
     // Now send the tool_diff sidecar.
-    handleOrchestratorEvent(toolDiffEvent(id, diff), source, ctx, lastProgress);
+    handleOrchestratorEvent(toolDiffEvent(id, diff), source, ctx);
 
     // The compositor must have received at least one setOverlay call after
     // the tool_diff (the overlay is set for every chunk when isTTY is true).
@@ -157,20 +158,19 @@ describe('handleOrchestratorEvent — tool_diff arm', () => {
 
     const ctx = makeCtx(toolLane, { isTTY: true, compositor });
     const source: SourceState = freshSourceState('__main__');
-    const lastProgress = new Map();
     const diff = makeMinimalDiff();
     const id = 'tu-flush';
 
     // Register tool, result, then flush the lane (simulates turn end).
-    handleOrchestratorEvent(toolStartEvent(id), source, ctx, lastProgress);
-    handleOrchestratorEvent(toolResultEvent(id), source, ctx, lastProgress);
+    handleOrchestratorEvent(toolStartEvent(id), source, ctx);
+    handleOrchestratorEvent(toolResultEvent(id), source, ctx);
     toolLane.flush(); // lane now empty
 
     const overlayCallsBefore = setOverlay.mock.calls.length;
 
     // tool_diff arrives after flush — must not throw.
     expect(() => {
-      handleOrchestratorEvent(toolDiffEvent(id, diff), source, ctx, lastProgress);
+      handleOrchestratorEvent(toolDiffEvent(id, diff), source, ctx);
     }).not.toThrow();
 
     // Because isTTY=true, setComposedOverlay IS still called — but the lane
@@ -193,16 +193,15 @@ describe('handleOrchestratorEvent — tool_diff arm', () => {
     // No compositor on non-TTY.
     const ctx = makeCtx(toolLane, { isTTY: false, compositor: null });
     const source: SourceState = freshSourceState('__main__');
-    const lastProgress = new Map();
     const diff = makeMinimalDiff();
     const id = 'tu-nontty';
 
-    handleOrchestratorEvent(toolStartEvent(id), source, ctx, lastProgress);
-    handleOrchestratorEvent(toolResultEvent(id), source, ctx, lastProgress);
+    handleOrchestratorEvent(toolStartEvent(id), source, ctx);
+    handleOrchestratorEvent(toolResultEvent(id), source, ctx);
 
     // Must not throw on non-TTY.
     expect(() => {
-      handleOrchestratorEvent(toolDiffEvent(id, diff), source, ctx, lastProgress);
+      handleOrchestratorEvent(toolDiffEvent(id, diff), source, ctx);
     }).not.toThrow();
 
     // Source should not be marked errored.
@@ -247,13 +246,11 @@ describe('handleOrchestratorEvent — thinking overlay (live mode)', () => {
     const ctx = makeCtx(toolLane, { isTTY: true, compositor });
     ctx.thinkingMode = 'live';
     const source: SourceState = freshSourceState('__main__');
-    const lastProgress = new Map();
 
     handleOrchestratorEvent(
       thinkingEvent('Let me reason about this step by step.'),
       source,
       ctx,
-      lastProgress,
     );
 
     expect(setOverlay).toHaveBeenCalled();
@@ -277,13 +274,11 @@ describe('handleOrchestratorEvent — thinking overlay (live mode)', () => {
     const ctx = makeCtx(toolLane, { isTTY: true, compositor });
     ctx.thinkingMode = 'summary';
     const source: SourceState = freshSourceState('__main__');
-    const lastProgress = new Map();
 
     handleOrchestratorEvent(
       thinkingEvent('Hidden in summary mode.'),
       source,
       ctx,
-      lastProgress,
     );
 
     // setComposedOverlay IS called in summary mode (the case-arm fires it so
@@ -308,13 +303,11 @@ describe('handleOrchestratorEvent — thinking overlay (live mode)', () => {
     const ctx = makeCtx(toolLane, { isTTY: true, compositor });
     ctx.thinkingMode = 'off';
     const source: SourceState = freshSourceState('__main__');
-    const lastProgress = new Map();
 
     handleOrchestratorEvent(
       thinkingEvent('Dropped on the floor.'),
       source,
       ctx,
-      lastProgress,
     );
 
     expect(setOverlay).not.toHaveBeenCalled();
@@ -383,7 +376,6 @@ describe('handleOrchestratorEvent — content chunk preserves in-flight subagent
       contentChunk('Here is some interleaved orchestrator prose.'),
       source,
       ctx,
-      new Map(),
     );
 
     // ── Scrollback assertions ────────────────────────────────────────────
@@ -437,7 +429,6 @@ describe('handleOrchestratorEvent — content chunk preserves in-flight subagent
       contentChunk('Prose while subagent is still working.'),
       source,
       ctx,
-      new Map(),
     );
 
     // No completed roots → no scrollback commits beyond markdown.
@@ -474,7 +465,7 @@ describe('handleOrchestratorEvent — content chunk preserves in-flight subagent
     const ctx = makeCtx(toolLane, { isTTY: true, compositor });
     const source: SourceState = freshSourceState('__main__');
 
-    handleOrchestratorEvent(contentChunk('Prose.'), source, ctx, new Map());
+    handleOrchestratorEvent(contentChunk('Prose.'), source, ctx);
 
     const scrollback = commitAbove.mock.calls.map((c) => strip(c[0])).join('\n');
     expect(scrollback).toContain('ls');
@@ -560,15 +551,15 @@ describe('handleOrchestratorEvent — tool-use-loop scrollback (no content emiss
     const source: SourceState = freshSourceState('__main__');
 
     // Iteration 1: bash A starts and completes.
-    handleOrchestratorEvent(bashStart('bash-A', '"ls"'), source, ctx, new Map());
-    handleOrchestratorEvent(bashResult('bash-A'), source, ctx, new Map());
+    handleOrchestratorEvent(bashStart('bash-A', '"ls"'), source, ctx);
+    handleOrchestratorEvent(bashResult('bash-A'), source, ctx);
 
     // Before the next tool fires, nothing is in scrollback (correct — the
     // flush trigger is on the NEXT tool_use_detail, not on tool_result).
     expect(commitAbove).not.toHaveBeenCalled();
 
     // Iteration 2: bash B starts. THIS is the flush trigger.
-    handleOrchestratorEvent(bashStart('bash-B', '"pwd"'), source, ctx, new Map());
+    handleOrchestratorEvent(bashStart('bash-B', '"pwd"'), source, ctx);
 
     // bash-A must now be in scrollback.
     const scrollback = commitAbove.mock.calls.map((c) => strip(c[0])).join('\n');
@@ -592,15 +583,15 @@ describe('handleOrchestratorEvent — tool-use-loop scrollback (no content emiss
     const { ctx, commitAbove } = makeLoopCtx(toolLane);
     const source: SourceState = freshSourceState('__main__');
 
-    handleOrchestratorEvent(editStart('edit-1'), source, ctx, new Map());
-    handleOrchestratorEvent(editResult('edit-1'), source, ctx, new Map());
-    handleOrchestratorEvent(toolDiffEvent('edit-1', makeMinimalDiff()), source, ctx, new Map());
+    handleOrchestratorEvent(editStart('edit-1'), source, ctx);
+    handleOrchestratorEvent(editResult('edit-1'), source, ctx);
+    handleOrchestratorEvent(toolDiffEvent('edit-1', makeMinimalDiff()), source, ctx);
 
     // Pre-trigger: entry is still in the lane WITH the diff attached.
     expect(toolLane.hasEntry('edit-1')).toBe(true);
 
     // Next tool starts — fires the eager flush.
-    handleOrchestratorEvent(bashStart('bash-1', '"echo"'), source, ctx, new Map());
+    handleOrchestratorEvent(bashStart('bash-1', '"echo"'), source, ctx);
 
     // edit_file committed to scrollback. The diff hunk markers must be
     // present (proving addDiff wasn't silently lost by a too-early flush).
@@ -636,13 +627,12 @@ describe('handleOrchestratorEvent — tool-use-loop scrollback (no content emiss
       },
       source,
       ctx,
-      new Map(),
     );
 
     // Now a flat tool fires (e.g., the orchestrator does a bash call
     // alongside the in-flight subagent). The flush should commit nothing
     // because the only root (agent-1) is in-flight.
-    handleOrchestratorEvent(bashStart('bash-1', '"ls"'), source, ctx, new Map());
+    handleOrchestratorEvent(bashStart('bash-1', '"ls"'), source, ctx);
 
     // No scrollback writes — agent-1 is still in-flight.
     expect(commitAbove).not.toHaveBeenCalled();
@@ -671,7 +661,7 @@ describe('handleOrchestratorEvent — tool-use-loop scrollback (no content emiss
     };
     const source: SourceState = freshSourceState('__main__');
 
-    handleOrchestratorEvent(bashStart('bash-B', '"pwd"'), source, ctx, new Map());
+    handleOrchestratorEvent(bashStart('bash-B', '"pwd"'), source, ctx);
 
     // Lane untouched on non-TTY (no eager flush).
     expect(toolLane.hasEntry('bash-A')).toBe(true);
@@ -739,7 +729,7 @@ describe('handleOrchestratorEvent — stage rail single-paint invariant', () => 
     const { ctx, setOverlay } = makeStageCtx(toolLane);
     const source: SourceState = freshSourceState('__main__');
 
-    handleOrchestratorEvent(toolStart('tu-1'), source, ctx, new Map());
+    handleOrchestratorEvent(toolStart('tu-1'), source, ctx);
 
     // Pre-fix: 2 calls (pre-switch + case-arm). Post-fix: 1 (case-arm only).
     expect(setOverlay).toHaveBeenCalledTimes(1);
@@ -758,10 +748,10 @@ describe('handleOrchestratorEvent — stage rail single-paint invariant', () => 
     const source: SourceState = freshSourceState('__main__');
 
     // Prime: send tool_use_detail first so tool_result has something to flip.
-    handleOrchestratorEvent(toolStart('tu-1'), source, ctx, new Map());
+    handleOrchestratorEvent(toolStart('tu-1'), source, ctx);
     setOverlay.mockClear();
 
-    handleOrchestratorEvent(toolResultEvt('tu-1'), source, ctx, new Map());
+    handleOrchestratorEvent(toolResultEvt('tu-1'), source, ctx);
 
     expect(setOverlay).toHaveBeenCalledTimes(1);
     const overlay = strip(setOverlay.mock.calls[0]?.[0] ?? '');
@@ -778,7 +768,7 @@ describe('handleOrchestratorEvent — stage rail single-paint invariant', () => 
     ctx.thinkingMode = 'live';
     const source: SourceState = freshSourceState('__main__');
 
-    handleOrchestratorEvent(thinkingEvt('reasoning step'), source, ctx, new Map());
+    handleOrchestratorEvent(thinkingEvt('reasoning step'), source, ctx);
 
     expect(setOverlay).toHaveBeenCalledTimes(1);
     const overlay = strip(setOverlay.mock.calls[0]?.[0] ?? '');
@@ -807,7 +797,7 @@ describe('handleOrchestratorEvent — stage rail single-paint invariant', () => 
     ctx.thinkingMode = 'summary';
     const source: SourceState = freshSourceState('__main__');
 
-    handleOrchestratorEvent(thinkingEvt('hidden reasoning'), source, ctx, new Map());
+    handleOrchestratorEvent(thinkingEvt('hidden reasoning'), source, ctx);
 
     // No overlay update in summary mode — thinking is buffered silently.
     expect(setOverlay).toHaveBeenCalledTimes(0);
@@ -831,7 +821,7 @@ describe('handleOrchestratorEvent — stage rail single-paint invariant', () => 
         durationMs: 100,
       },
     };
-    handleOrchestratorEvent(progressEvent, source, ctx, new Map());
+    handleOrchestratorEvent(progressEvent, source, ctx);
 
     expect(setOverlay).toHaveBeenCalledTimes(1);
   });
@@ -842,14 +832,14 @@ describe('handleOrchestratorEvent — stage rail single-paint invariant', () => 
     const source: SourceState = freshSourceState('__main__');
 
     // Register the tool first so addDiff has an entry to attach to.
-    handleOrchestratorEvent(toolStart('tu-1'), source, ctx, new Map());
+    handleOrchestratorEvent(toolStart('tu-1'), source, ctx);
     setOverlay.mockClear();
 
     const diffEvent: OutputEvent = {
       type: 'chunk',
       chunk: { type: 'tool_diff', toolUseId: 'tu-1', diff: makeMinimalDiff() },
     };
-    handleOrchestratorEvent(diffEvent, source, ctx, new Map());
+    handleOrchestratorEvent(diffEvent, source, ctx);
 
     expect(setOverlay).toHaveBeenCalledTimes(1);
   });
@@ -869,7 +859,7 @@ describe('handleOrchestratorEvent — stage rail single-paint invariant', () => 
     // No stageTracker assigned.
     const source: SourceState = freshSourceState('__main__');
 
-    handleOrchestratorEvent(toolStart('tu-1'), source, ctx, new Map());
+    handleOrchestratorEvent(toolStart('tu-1'), source, ctx);
 
     expect(setOverlay).toHaveBeenCalledTimes(1);
   });
@@ -897,8 +887,7 @@ describe('handleOrchestratorEvent — per-phase interleaved thinking (TTY)', () 
     const ctx = makeCtx(toolLane, { isTTY: true, compositor });
     ctx.thinkingMode = 'live';
     const source: SourceState = freshSourceState('__main__');
-    const lastProgress = new Map();
-    const fire = (e: OutputEvent) => handleOrchestratorEvent(e, source, ctx, lastProgress);
+    const fire = (e: OutputEvent) => handleOrchestratorEvent(e, source, ctx);
 
     // think_A → T1 → think_B → T2  (each phase sealed at the NEXT tool boundary)
     fire(thinkingEvent('reasoning that leads to the first tool call'));
@@ -934,7 +923,7 @@ describe('handleOrchestratorEvent — per-phase interleaved thinking (TTY)', () 
     const ctx = makeCtx(new ToolLane(), { isTTY: true, compositor });
     ctx.thinkingMode = 'off';
     const source: SourceState = freshSourceState('__main__');
-    const fire = (e: OutputEvent) => handleOrchestratorEvent(e, source, ctx, new Map());
+    const fire = (e: OutputEvent) => handleOrchestratorEvent(e, source, ctx);
 
     fire(thinkingEvent('reasoning that should be dropped'));
     fire(toolStartEvent('tu_1'));
@@ -984,8 +973,7 @@ describe('handleOrchestratorEvent — progress arm (duplicate banner regression)
 
     const ctx = makeCtx(new ToolLane(), { isTTY: true, compositor });
     const source: SourceState = freshSourceState('__main__');
-    const lastProgress = new Map();
-    const fire = (e: OutputEvent) => handleOrchestratorEvent(e, source, ctx, lastProgress);
+    const fire = (e: OutputEvent) => handleOrchestratorEvent(e, source, ctx);
 
     // Stale entry from a first runTurn, then a fresh taskId from a second
     // runTurn replaying through the same renderer.
@@ -993,9 +981,9 @@ describe('handleOrchestratorEvent — progress arm (duplicate banner regression)
     fire(progressEvent('task-2-live', 'Iteration 15: used memory_update'));
 
     // Invariant: at most one entry. The second taskId evicts the first.
-    expect(lastProgress.size).toBe(1);
-    expect(lastProgress.has('task-2-live')).toBe(true);
-    expect(lastProgress.has('task-1-stale')).toBe(false);
+    expect(ctx.lastProgressByTask.size).toBe(1);
+    expect(ctx.lastProgressByTask.has('task-2-live')).toBe(true);
+    expect(ctx.lastProgressByTask.has('task-1-stale')).toBe(false);
 
     // The composed overlay renders one banner, not two: exactly one '◦' glyph
     // (one banner block) and only the live task's description survives.

--- a/src/cli/_lib/stream-renderer-orchestrator.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.ts
@@ -7,6 +7,12 @@
  */
 
 import type { OutputEvent, ProgressEvent } from '../../agent/types.js';
+// Design note (issue #389): `lastProgressByTask` is now a field of
+// OrchestratorCtx rather than a separate parameter to setComposedOverlay.
+// This lets any callsite (including subagent handlers via
+// SubagentCtx.orchestratorCtx) compose the full overlay without needing
+// an independent copy of the progress map. See the SubagentCtx comment in
+// stream-renderer-subagent.ts for the companion rationale.
 import type { SourceState } from './stream-renderer-source.js';
 import type { Writer } from '../slash/types.js';
 import type { TerminalCompositor } from '../terminal-compositor.js';
@@ -96,6 +102,14 @@ export interface OrchestratorCtx {
    * falls back to direct-emit behavior for backward compatibility.
    */
   coordinator?: CommitCoordinator;
+  /**
+   * Live progress map — mutated by `progress` events and read by
+   * `setComposedOverlay` to render the progress banner layer of the
+   * composed overlay. Hoisted from the old second parameter so every
+   * callsite (including subagent handlers via SubagentCtx.orchestratorCtx)
+   * can compose the full frame without carrying a separate copy.
+   */
+  lastProgressByTask: Map<string, ProgressEvent>;
 }
 
 /**
@@ -105,7 +119,6 @@ export function handleOrchestratorEvent(
   event: OutputEvent,
   source: SourceState,
   ctx: OrchestratorCtx,
-  lastProgressByTask: Map<string, ProgressEvent>,
 ): void {
   // Invariant: at most one setComposedOverlay call per event. The pre-switch
   // block updates tracker state only; per-case arms below fire the single
@@ -131,9 +144,9 @@ export function handleOrchestratorEvent(
       // unlike turn-handler.ts — never rebuilds on 'resumed') would otherwise
       // leave two distinct taskIds accumulated here, rendering two stacked
       // "Tool-use loop" banners. The live loop's next progress event wipes it.
-      lastProgressByTask.clear();
-      lastProgressByTask.set(event.progress.taskId, event.progress);
-      if (ctx.isTTY) setComposedOverlay(ctx, lastProgressByTask);
+      ctx.lastProgressByTask.clear();
+      ctx.lastProgressByTask.set(event.progress.taskId, event.progress);
+      if (ctx.isTTY) setComposedOverlay(ctx);
       return;
 
     case 'chunk': {
@@ -230,17 +243,17 @@ export function handleOrchestratorEvent(
         if (ctx.isTTY && ctx.compositor) {
           ctx.compositor.setSpinner({ enabled: true, rotateVerbEveryMs: 3500 });
         }
-        if (ctx.isTTY) setComposedOverlay(ctx, lastProgressByTask);
+        if (ctx.isTTY) setComposedOverlay(ctx);
       } else if (chunk.type === 'tool_result') {
         ctx.streamingMarkdown.current?.commitPending();
         ctx.toolLane.addResult(chunk.toolUseId, chunk);
-        if (ctx.isTTY) setComposedOverlay(ctx, lastProgressByTask);
+        if (ctx.isTTY) setComposedOverlay(ctx);
       } else if (chunk.type === 'tool_diff') {
         // Sidecar render-only diff. Late-attached to the matching tool
         // entry by `toolUseId`; if the entry no longer exists (lane
         // already flushed), `addDiff` is a no-op by design.
         ctx.toolLane.addDiff(chunk.toolUseId, chunk.diff);
-        if (ctx.isTTY) setComposedOverlay(ctx, lastProgressByTask);
+        if (ctx.isTTY) setComposedOverlay(ctx);
       } else if (chunk.type === 'content') {
         // Thinking→acting boundary: text is starting to stream. Cap the
         // thinking-duration window so a 30s think followed by 150s of text
@@ -299,12 +312,11 @@ export function handleOrchestratorEvent(
           source.thinkingPhaseStartedAt = Date.now();
         }
         ctx.thinkingLane.push(chunk.content);
-        // Repaint unconditionally (when TTY) so the stage rail advance to
-        // 'modeling' is visible in BOTH 'live' and 'summary' modes. The
-        // thinking paragraph itself is still gated on 'live' mode inside
-        // setComposedOverlay — summary-mode users see the rail update
-        // without the paragraph leaking out of its silent buffer.
-        if (ctx.isTTY) setComposedOverlay(ctx, lastProgressByTask);
+        // Only repaint the overlay in 'live' mode — summary mode buffers
+        // silently and has nothing overlay-visible to push (the stage rail
+        // moved to a footer bar and is repainted via onStageChange in
+        // stream-renderer.ts, not through setComposedOverlay).
+        if (ctx.isTTY && ctx.thinkingMode === 'live') setComposedOverlay(ctx);
       }
       return;
     }
@@ -346,15 +358,21 @@ export function handleOrchestratorEvent(
 }
 
 /**
- * Compose tool-lane overlay + progress banner into a single overlay string
- * and push it to the compositor. Both layers are optional — whichever is
- * active gets included. Prevents the old bug where progress events and
- * tool events would clobber each other's overlay.
+ * Compose stage-rail + thinking paragraph + tool-lane overlay + progress
+ * banner into a single overlay string and push it to the compositor
+ * atomically. All layers are optional — whichever is active gets included.
+ *
+ * This is the ONLY function that should call `compositor.setOverlay` with
+ * live content. All orchestrator and subagent code paths that mutate
+ * toolLane, thinkingLane, or the progress map must route their overlay
+ * repaints through here so every frame includes the full composed picture.
+ *
+ * The second `lastProgressByTask` parameter was removed in issue #389 — it
+ * is now read from `ctx.lastProgressByTask` so subagent handlers can call
+ * this function via `ctx.orchestratorCtx` without needing a separate
+ * reference to the progress map.
  */
-export function setComposedOverlay(
-  ctx: OrchestratorCtx,
-  lastProgressByTask?: Map<string, ProgressEvent>,
-): void {
+export function setComposedOverlay(ctx: OrchestratorCtx): void {
   if (!ctx.compositor) return;
 
   // When the overlay composer is available, use it to compose all slots.
@@ -365,32 +383,33 @@ export function setComposedOverlay(
     return;
   }
 
-  // Legacy path for tests and callers without a composer.
-  // This preserves the old setComposedOverlay behavior, minus the stage-rail
-  // which is now a reserved footer row managed by LoopStageBar (not part of
-  // the overlay in either the composer or legacy paths).
+  // Live thinking preview — rendered above the tool lane so the user sees
+  // the model's current reasoning while it streams. Only in 'live' mode;
+  // 'summary' mode buffers silently and emits a single line at turn-end.
+  //
+  // Rendered as a wrapped, soft-capped paragraph (`◆ thinking` header +
+  // indented body, ~5 visible lines, `⋯ +N chars earlier` footer when the
+  // buffer outruns the cap). See `formatThinkingParagraph` for the format
+  // and the design rationale — including why we cap (otherwise a 30-second
+  // chain of thought would push the tool lane and progress banner offscreen).
+  //
+  // Subagent thinking is deliberately NOT wired through this path — each
+  // subagent renders into its parent's ToolLane row via
+  // `setThinkingTail()` in stream-renderer-subagent.ts. See the comment
+  // block in that file for why parallel subagents stay on the single-line
+  // tail treatment instead of the paragraph format.
   const parts: string[] = [];
-  // Same gate as the thinking-live overlay slot (stream-renderer-lifecycle.ts):
-  // suppress the live preview once thinking is collapsed (isActive() === false),
-  // even though the buffer is retained for inlineSummary.
-  if (ctx.thinkingMode === 'live' && ctx.thinkingLane.isActive() && ctx.thinkingLane.hasBufferedContent()) {
-    // peekPhase() (not peek()): show only the CURRENT uncommitted phase so the
-    // preview clears once a phase is collapsed into an inline summary above,
-    // rather than re-showing reasoning already committed to scrollback.
-    const paragraph = formatThinkingParagraph(ctx.thinkingLane.peekPhase(), {
+  if (ctx.thinkingMode === 'live' && ctx.thinkingLane.hasBufferedContent()) {
+    const paragraph = formatThinkingParagraph(ctx.thinkingLane.peek(), {
       cols: getTerminalWidth(),
     });
     if (paragraph) parts.push(paragraph);
   }
   if (ctx.toolLane.hasPending()) parts.push(ctx.toolLane.getOverlay());
-  if (lastProgressByTask && lastProgressByTask.size > 0) {
-    const bannerLines: string[] = [];
-    for (const progress of lastProgressByTask.values()) {
-      bannerLines.push(...formatProgressBanner(progress));
-    }
-    if (bannerLines.length > 0) parts.push(bannerLines.join('\n'));
+  const bannerLines: string[] = [];
+  for (const progress of ctx.lastProgressByTask.values()) {
+    bannerLines.push(...formatProgressBanner(progress));
   }
-  if (parts.length > 0) {
-    ctx.compositor.setOverlay(parts.join('\n'));
-  }
+  if (bannerLines.length > 0) parts.push(bannerLines.join('\n'));
+  ctx.compositor.setOverlay(parts.join('\n'));
 }

--- a/src/cli/_lib/stream-renderer-subagent-h2.test.ts
+++ b/src/cli/_lib/stream-renderer-subagent-h2.test.ts
@@ -9,7 +9,9 @@ import {
   type SubagentCtx,
 } from './stream-renderer-subagent.js';
 import { freshSourceState, type SourceState } from './stream-renderer-source.js';
+import type { OrchestratorCtx } from './stream-renderer-orchestrator.js';
 import { ToolLane } from '../commands/interactive/tool-lane.js';
+import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
 import type { Writer } from '../slash/types.js';
 import type { StreamingMarkdownRenderer } from './stream-renderer.js';
 import type { TerminalCompositor } from '../terminal-compositor.js';
@@ -17,6 +19,18 @@ import type { OutputEvent } from '../../agent/types.js';
 
 function makeCtx(toolLane: ToolLane, compositor: TerminalCompositor, thinkingMode: 'live' | 'summary' | 'off' = 'live'): SubagentCtx {
   const writer: Writer = { line() {}, raw() {}, success() {}, info() {}, warn() {}, error() {} };
+  // Provide orchestratorCtx with the same compositor so setComposedOverlay
+  // (the post-issue-#389 overlay path) routes through to the spy correctly.
+  const orchCtx: OrchestratorCtx = {
+    out: writer,
+    isTTY: true,
+    compositor,
+    toolLane,
+    thinkingLane: new ThinkingLane(),
+    thinkingMode: 'off',
+    streamingMarkdown: { current: null },
+    lastProgressByTask: new Map(),
+  };
   return {
     isTTY: true,
     compositor,
@@ -24,6 +38,7 @@ function makeCtx(toolLane: ToolLane, compositor: TerminalCompositor, thinkingMod
     out: writer,
     streamingMarkdown: new Map<string, StreamingMarkdownRenderer>(),
     thinkingMode,
+    orchestratorCtx: orchCtx,
   };
 }
 

--- a/src/cli/_lib/stream-renderer-subagent-helpers.ts
+++ b/src/cli/_lib/stream-renderer-subagent-helpers.ts
@@ -7,12 +7,9 @@
 
 import type { SourceState } from './stream-renderer-source.js';
 import type { SubagentCtx } from './stream-renderer-subagent.js';
-import type { CardSpec } from '../render.js';
-import { syntheticResult, formatDoneSummary } from './stream-renderer-source.js';
 import { getTerminalWidth } from '../terminal-size.js';
 import { wrapToWidth } from '../wrap.js';
 import { palette } from '../palette.js';
-import { card } from '../render.js';
 
 /**
  * Pull the latest "clause" out of a thinking buffer for the live tail.
@@ -102,60 +99,6 @@ export function formatSubagentTextLines(text: string): string[] {
 }
 
 /**
- * Render a panel emitted from inside a subagent. Flushes any pending
- * subagent content (markdown buffer) before rendering the card, mirroring
- * the orchestrator's emitPanel pattern so the card never races streamed
- * content on non-TTY surfaces.
- *
- * The synthetic Agent entry stays alive in the parent tool lane (we don't
- * flush it — that would drop attribution mid-flight). The card itself is
- * committed straight to scrollback as a loud visual marker; its color and
- * shape make the source obvious without extra indent chrome.
- */
-export function emitSubagentPanel(
-  spec: CardSpec,
-  _sourceId: string,
-  source: SourceState,
-  ctx: SubagentCtx,
-): void {
-  // Drop buffered prose before rendering the card so the panel doesn't
-  // visually interleave with streaming content.
-  //
-  // TTY: subagent prose was already routed to the transient thinking tail
-  // (not scrollback) — clear that tail so the panel reads as the new state,
-  // and discard the prose buffer silently. The card itself is the deliberate
-  // visible artifact and is committed via the loop below.
-  // Non-TTY: flush the buffer through the gutter-prefixed scrollback path so
-  // logs retain the full prose context that preceded the card.
-  if (ctx.isTTY) {
-    const parentId = source.syntheticAgentToolUseId;
-    if (parentId) ctx.toolLane.setThinkingTail(parentId, undefined);
-    source.contentBuffer = '';
-  } else if (source.contentBuffer.trim()) {
-    emitSubagentTextLines(source.contentBuffer, ctx);
-    source.contentBuffer = '';
-  }
-
-  const rendered = card(spec);
-  for (const line of rendered.split('\n')) {
-    if (ctx.isTTY && ctx.compositor) {
-      ctx.compositor.commitAbove(line);
-    } else {
-      ctx.out.line(line);
-    }
-  }
-  // Invariant (TUI rhythm contract): subagent panel card owns ONE
-  // trailing blank line so the next block (more prose, the next tool,
-  // or another subagent) has breathing room. Mirrors background-task
-  // completion cards (repl-loop.ts:314). See docs/tui-rhythm.md.
-  if (ctx.isTTY && ctx.compositor) {
-    ctx.compositor.commitAbove('');
-  } else {
-    ctx.out.line('');
-  }
-}
-
-/**
  * Create the synthetic `Agent(<agentType>)` entry for a subagent source on
  * its first event. Idempotent — no-op if a synthetic entry already exists.
  */
@@ -200,86 +143,4 @@ export function synthesizeAgentEntry(
   const syntheticId = `__synth_agent_${sourceId}`;
   ctx.toolLane.addStartWithAgentContext(syntheticId, 'Agent', `(${label})`, agentContext, maxWidth);
   source.syntheticAgentToolUseId = syntheticId;
-}
-
-/**
- * Finalize a subagent source: flush any remaining partial line buffer and emit
- * a summary result under its synthetic agent. No-op if the subagent errored
- * (error summary already set in the error case).
- *
- * Caller must pass the throttle maps so cleanup can delete stale entries.
- */
-export function finalizeSubagent(
-  _sourceId: string,
-  source: SourceState,
-  ctx: SubagentCtx,
-  thinkingTailLastUpdate: Map<string, number>,
-  overlayLastUpdate: Map<string, number>,
-): void {
-  const parentId = source.syntheticAgentToolUseId;
-  if (!parentId || source.errored) return;
-
-  // Drain any remaining buffered prose.
-  //
-  // TTY: subagent prose is suppressed from scrollback by design (the leak
-  // fix). The buffer is discarded silently — the user already saw the live
-  // tail under the Agent row while the subagent was running, and the Done
-  // row below is the only artifact that lands in the parent transcript.
-  //
-  // Non-TTY: flush the trailing buffer through the gutter-prefixed
-  // scrollback path so logs/CI keep the final line of prose even when the
-  // subagent's last chunk lacked a trailing newline.
-  if (!ctx.isTTY && source.contentBuffer) {
-    emitSubagentTextLines(source.contentBuffer, ctx);
-  }
-  source.contentBuffer = '';
-
-  // Non-TTY: emit a standalone thinking summary line before the Done row,
-  // mirroring the orchestrator's pattern (stream-renderer-orchestrator.ts:236-250).
-  // On TTY the live thinking tail already provides visibility; this is for
-  // logs, CI, and headless surfaces where the tail is never rendered.
-  //
-  // Invariant (TUI rhythm contract): emit summary + ONE trailing blank.
-  // Without the trailing blank, the next block (the Done row, committed
-  // via addResult/syntheticResult below) butts directly against the
-  // summary. See docs/tui-rhythm.md.
-  if (!ctx.isTTY && source.thinkingLane?.hasBufferedContent()) {
-    const thinkingSummary = source.thinkingLane.collapse();
-    if (thinkingSummary) {
-      ctx.out.line(thinkingSummary);
-      ctx.out.line('');
-    }
-  }
-
-  // Clear the live thinking tail before the Done row is committed —
-  // `formatDoneSummary` reads `source.thinkingLane` to append the
-  // "thought Xs · N tok" post-mortem stat, which makes the live tail
-  // redundant and visually noisy alongside the result line.
-  ctx.toolLane.setThinkingTail(parentId, undefined);
-  // Item #6: Clean up the per-parentId throttle entry so the map doesn't
-  // grow unboundedly across many short-lived subagents in a long session.
-  // External constraint: delete AFTER setThinkingTail(undefined) so the
-  // clear is never throttled by a stale timestamp from the same run.
-  thinkingTailLastUpdate.delete(parentId);
-  // H2 fix: clean up the overlay throttle entry too.
-  overlayLastUpdate.delete(parentId);
-
-  const summary = formatDoneSummary(source);
-  ctx.toolLane.setAgentResultSummary(parentId, summary);
-  ctx.toolLane.addResult(
-    parentId,
-    syntheticResult(summary, false),
-  );
-  if (ctx.isTTY && ctx.compositor) {
-    // Route the final Done-row overlay through the composer when present so it
-    // recomposes all active slots in z-order instead of clobbering the overlay
-    // region with the tool-lane alone (overlay-composer.ts invariant: the
-    // composer is the sole writer of compositor.setOverlay during a turn).
-    if (ctx.overlayComposer) {
-      ctx.overlayComposer.markDirty('tool-lane');
-      ctx.overlayComposer.flush();
-    } else {
-      ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
-    }
-  }
 }

--- a/src/cli/_lib/stream-renderer-subagent-paragraph.test.ts
+++ b/src/cli/_lib/stream-renderer-subagent-paragraph.test.ts
@@ -33,6 +33,7 @@ import {
   synthesizeAgentEntry,
   type SubagentCtx,
 } from './stream-renderer-subagent.js';
+import type { OrchestratorCtx } from './stream-renderer-orchestrator.js';
 import { freshSourceState, type SourceState } from './stream-renderer-source.js';
 import { OverlayComposer } from './overlay-composer.js';
 import { registerOverlaySlots } from './stream-renderer-lifecycle.js';
@@ -102,14 +103,29 @@ function setup() {
     getInterrupting: () => false,
   });
 
-  const ctx: SubagentCtx = {
+  // Build a minimal OrchestratorCtx so subagent handlers can call
+  // setComposedOverlay(ctx.orchestratorCtx) and route through the composer
+  // (issue #389: subagents no longer hold overlayComposer directly).
+  const orchestratorCtx: OrchestratorCtx = {
     isTTY: true,
     compositor,
     overlayComposer,
     toolLane,
+    thinkingLane,
+    thinkingMode: 'live',
+    out: noopWriter,
+    streamingMarkdown: { current: null },
+    lastProgressByTask: new Map(),
+  };
+
+  const ctx: SubagentCtx = {
+    isTTY: true,
+    compositor,
+    toolLane,
     out: noopWriter,
     streamingMarkdown: new Map<string, StreamingMarkdownRenderer>(),
     thinkingMode: 'summary',
+    orchestratorCtx,
   };
 
   return { overlayFrames, compositor, thinkingLane, toolLane, overlayComposer, ctx };

--- a/src/cli/_lib/stream-renderer-subagent.test.ts
+++ b/src/cli/_lib/stream-renderer-subagent.test.ts
@@ -19,17 +19,47 @@ import {
   type SubagentCtx,
 } from './stream-renderer-subagent.js';
 import { freshSourceState, type SourceState } from './stream-renderer-source.js';
+import type { OrchestratorCtx } from './stream-renderer-orchestrator.js';
 import { ToolLane } from '../commands/interactive/tool-lane.js';
+import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
 import { stripAnsi } from '../display.js';
 import type { Writer } from '../slash/types.js';
 import type { StreamingMarkdownRenderer } from './stream-renderer.js';
 import type { TerminalCompositor } from '../terminal-compositor.js';
 import type { OutputEvent } from '../../agent/types.js';
 
+/**
+ * Build a minimal OrchestratorCtx that wraps the given compositor and
+ * toolLane. Used by TTY-path tests that now route through setComposedOverlay
+ * (issue #389 — all overlay repaints composed).
+ */
+function makeOrchestratorCtx(
+  toolLane: ToolLane,
+  compositor: TerminalCompositor | null,
+  writer: Writer,
+): OrchestratorCtx {
+  return {
+    out: writer,
+    isTTY: compositor !== null,
+    compositor,
+    toolLane,
+    thinkingLane: new ThinkingLane(),
+    thinkingMode: 'off',
+    streamingMarkdown: { current: null },
+    lastProgressByTask: new Map(),
+  };
+}
+
 interface MakeCtxOptions {
   isTTY?: boolean;
   compositor?: TerminalCompositor | null;
   out?: Writer;
+  /**
+   * Optional pre-built orchestratorCtx for TTY-path tests that need
+   * setComposedOverlay to fire. When omitted, orchestratorCtx is not set
+   * (non-TTY / non-overlay tests don't need it).
+   */
+  orchestratorCtx?: OrchestratorCtx;
 }
 
 function makeCtx(toolLane: ToolLane, opts: MakeCtxOptions = {}): SubagentCtx {
@@ -48,6 +78,7 @@ function makeCtx(toolLane: ToolLane, opts: MakeCtxOptions = {}): SubagentCtx {
     out: writer,
     streamingMarkdown: new Map<string, StreamingMarkdownRenderer>(),
     thinkingMode: 'summary',
+    ...(opts.orchestratorCtx !== undefined ? { orchestratorCtx: opts.orchestratorCtx } : {}),
   };
 }
 
@@ -225,7 +256,11 @@ describe('handleSubagentEvent — TTY path (M-6)', () => {
   it('calls compositor.setOverlay after a tool_use_detail chunk on TTY', () => {
     const lane = new ToolLane();
     const compositor = makeCompositor();
-    const ctx = makeCtx(lane, { isTTY: true, compositor });
+    // Provide orchestratorCtx so the subagent handler routes through
+    // setComposedOverlay (issue #389 — all overlay repaints composed).
+    const writer: Writer = { line() {}, raw() {}, success() {}, info() {}, warn() {}, error() {} };
+    const orchCtx = makeOrchestratorCtx(lane, compositor, writer);
+    const ctx = makeCtx(lane, { isTTY: true, compositor, orchestratorCtx: orchCtx });
 
     const source: SourceState = freshSourceState('sub-tty');
     source.agentType = 'verifier';
@@ -524,6 +559,190 @@ describe('handleSubagentEvent — thinking-tail throttle (Item #6)', () => {
       expect(afterReuse).toBeGreaterThan(afterFirst);
     } finally {
       vi.useRealTimers();
+    }
+  });
+});
+
+// ── Issue #389 regression: subagent state transitions preserve orchestrator
+//    thinking paragraph ──────────────────────────────────────────────────────
+//
+// Pre-fix: subagent handlers called compositor.setOverlay(toolLane.getOverlay())
+// directly, which produced a bare tool-lane-only frame and wiped the
+// orchestrator's live-thinking paragraph on every subagent state transition.
+// Post-fix: all repaints go through setComposedOverlay(ctx.orchestratorCtx),
+// which includes the thinking paragraph when it is buffered and visible.
+//
+// This test verifies the invariant: when the orchestrator has a live thinking
+// buffer AND a subagent fires tool_use_detail / tool_result / tool_diff /
+// error / finalizeSubagent events, every overlay frame produced by those
+// events contains the '◆ thinking' header (i.e. the paragraph was not dropped).
+describe('handleSubagentEvent — issue #389 regression: subagent events preserve orchestrator thinking paragraph', () => {
+  function makeCompositor() {
+    const overlayCalls: string[] = [];
+    const compositor = {
+      setOverlay: (text: string) => { overlayCalls.push(text); },
+      commitAbove: vi.fn(),
+    } as unknown as TerminalCompositor;
+    return { compositor, overlayCalls };
+  }
+
+  function makeWriter(): Writer {
+    return { line() {}, raw() {}, success() {}, info() {}, warn() {}, error() {} };
+  }
+
+  function strip(s: string): string {
+    // eslint-disable-next-line no-control-regex
+    return s.replace(/\x1b\[[0-9;]*m/g, '');
+  }
+
+  it('tool_use_detail does NOT drop the live-thinking paragraph from the composed overlay', () => {
+    const lane = new ToolLane();
+    const { compositor, overlayCalls } = makeCompositor();
+    const writer = makeWriter();
+
+    // Orchestrator ctx with a live thinking buffer.
+    const thinkingLane = new ThinkingLane();
+    thinkingLane.push('I am reasoning about the task carefully.');
+    const orchCtx: OrchestratorCtx = {
+      out: writer,
+      isTTY: true,
+      compositor,
+      toolLane: lane,
+      thinkingLane,
+      thinkingMode: 'live',
+      streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
+    };
+
+    // Subagent ctx wired to the same compositor + toolLane + orchestratorCtx.
+    const subCtx: SubagentCtx = {
+      isTTY: true,
+      compositor,
+      toolLane: lane,
+      out: writer,
+      streamingMarkdown: new Map(),
+      thinkingMode: 'summary',
+      orchestratorCtx: orchCtx,
+    };
+
+    const source: SourceState = freshSourceState('verifier');
+    source.agentType = 'verifier';
+    synthesizeAgentEntry('src-389', source, subCtx, undefined);
+
+    const toolStartEvent: OutputEvent = {
+      type: 'chunk',
+      chunk: { type: 'tool_use_detail', toolUseId: 'tu-389', toolName: 'Bash', toolInput: '"echo hi"' },
+    } as OutputEvent;
+
+    handleSubagentEvent(toolStartEvent, 'src-389', source, subCtx);
+
+    // At least one overlay was emitted (the repaint after tool_use_detail).
+    expect(overlayCalls.length).toBeGreaterThan(0);
+
+    // Every overlay frame emitted after tool_use_detail must preserve the
+    // thinking paragraph header — none should be a bare tool-lane-only frame.
+    for (const frame of overlayCalls) {
+      const plain = strip(frame);
+      expect(
+        plain,
+        `overlay frame dropped the thinking paragraph:\n${plain}`,
+      ).toContain('◆ thinking');
+    }
+  });
+
+  it('tool_result does NOT drop the live-thinking paragraph from the composed overlay', () => {
+    const lane = new ToolLane();
+    const { compositor, overlayCalls } = makeCompositor();
+    const writer = makeWriter();
+
+    const thinkingLane = new ThinkingLane();
+    thinkingLane.push('Still reasoning while tool runs.');
+    const orchCtx: OrchestratorCtx = {
+      out: writer,
+      isTTY: true,
+      compositor,
+      toolLane: lane,
+      thinkingLane,
+      thinkingMode: 'live',
+      streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
+    };
+    const subCtx: SubagentCtx = {
+      isTTY: true,
+      compositor,
+      toolLane: lane,
+      out: writer,
+      streamingMarkdown: new Map(),
+      thinkingMode: 'summary',
+      orchestratorCtx: orchCtx,
+    };
+
+    const source: SourceState = freshSourceState('verifier2');
+    source.agentType = 'verifier';
+    synthesizeAgentEntry('src-389b', source, subCtx, undefined);
+
+    // Register a tool use first so tool_result has something to attach to.
+    lane.addStartWithAgentContext('tu-389b', 'Read', '"file.ts"', source.syntheticAgentToolUseId);
+
+    const toolResultEvent: OutputEvent = {
+      type: 'chunk',
+      chunk: { type: 'tool_result', toolUseId: 'tu-389b', content: 'ok', isError: false },
+    } as OutputEvent;
+
+    handleSubagentEvent(toolResultEvent, 'src-389b', source, subCtx);
+
+    expect(overlayCalls.length).toBeGreaterThan(0);
+    for (const frame of overlayCalls) {
+      const plain = strip(frame);
+      expect(
+        plain,
+        `overlay frame dropped the thinking paragraph:\n${plain}`,
+      ).toContain('◆ thinking');
+    }
+  });
+
+  it('finalizeSubagent does NOT drop the live-thinking paragraph from the composed overlay', () => {
+    const lane = new ToolLane();
+    const { compositor, overlayCalls } = makeCompositor();
+    const writer = makeWriter();
+
+    const thinkingLane = new ThinkingLane();
+    thinkingLane.push('Synthesizing the final answer now.');
+    const orchCtx: OrchestratorCtx = {
+      out: writer,
+      isTTY: true,
+      compositor,
+      toolLane: lane,
+      thinkingLane,
+      thinkingMode: 'live',
+      streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
+    };
+    const subCtx: SubagentCtx = {
+      isTTY: true,
+      compositor,
+      toolLane: lane,
+      out: writer,
+      streamingMarkdown: new Map(),
+      thinkingMode: 'summary',
+      orchestratorCtx: orchCtx,
+    };
+
+    const source: SourceState = freshSourceState('verifier3');
+    source.agentType = 'verifier';
+    synthesizeAgentEntry('src-389c', source, subCtx, undefined);
+
+    // Drive a 'done' event which calls finalizeSubagent internally.
+    const doneEvent: OutputEvent = { type: 'done' } as OutputEvent;
+    handleSubagentEvent(doneEvent, 'src-389c', source, subCtx);
+
+    expect(overlayCalls.length).toBeGreaterThan(0);
+    for (const frame of overlayCalls) {
+      const plain = strip(frame);
+      expect(
+        plain,
+        `overlay frame dropped the thinking paragraph:\n${plain}`,
+      ).toContain('◆ thinking');
     }
   });
 });

--- a/src/cli/_lib/stream-renderer-subagent.ts
+++ b/src/cli/_lib/stream-renderer-subagent.ts
@@ -13,29 +13,34 @@ import type { TerminalCompositor } from '../terminal-compositor.js';
 import type { ToolLane } from '../commands/interactive/tool-lane.js';
 import type { Writer } from '../slash/types.js';
 import type { CardSpec } from '../render.js';
+import { card } from '../render.js';
 import { StreamingMarkdownRenderer } from '../markdown-stream.js';
 import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
-import type { OverlayComposer } from './overlay-composer.js';
+import { syntheticResult, formatDoneSummary } from './stream-renderer-source.js';
+import type { OrchestratorCtx } from './stream-renderer-orchestrator.js';
+import { setComposedOverlay } from './stream-renderer-orchestrator.js';
 import {
   extractLatestThinkingClause,
-  emitSubagentPanel,
-  finalizeSubagent,
   emitSubagentTextLines,
   synthesizeAgentEntry,
 } from './stream-renderer-subagent-helpers.js';
-import { syntheticResult } from './stream-renderer-source.js';
 
 /**
  * Context object passed to subagent event handlers. Minimal set of collaborators
  * needed for subagent rendering: compositor for overlay updates, toolLane for
  * nesting under the synthetic agent, and output writer for scrollback lines.
+ *
+ * Design note (issue #389 — overlay routing): every overlay repaint in
+ * subagent handlers routes through `setComposedOverlay(ctx.orchestratorCtx)`
+ * instead of calling `compositor.setOverlay(toolLane.getOverlay())` directly.
+ * This preserves the orchestrator's live-thinking paragraph, stage rail, and
+ * progress banner in every frame — a direct tool-lane-only write would wipe
+ * those layers for the duration of the repaint, causing visible flicker when
+ * parallel subagents fire repaints at independent cadences.
  */
 export interface SubagentCtx {
   isTTY: boolean;
   compositor: TerminalCompositor | null;
-  // Optional: production StreamRenderer always provides it; tests / non-TTY
-  // omit it and overlay routing falls back to a direct setOverlay.
-  overlayComposer?: OverlayComposer | null;
   toolLane: ToolLane;
   /** Where line-based output goes (non-TTY fallback + scrollback emits). */
   out: Writer;
@@ -56,7 +61,21 @@ export interface SubagentCtx {
    * silently dropping thinking events when the field is omitted by callers
    * (tests, future surfaces).
    */
-  thinkingMode?: 'off' | 'summary' | 'live';
+  thinkingMode: 'off' | 'summary' | 'live';
+  /**
+   * Reference to the parent orchestrator's context. Used by subagent
+   * handlers to compose the full overlay frame (stage rail + thinking
+   * paragraph + tool lane + progress banner) instead of painting a bare
+   * tool-lane-only frame. Required for issue #389: every
+   * `compositor.setOverlay(toolLane.getOverlay())` in subagent code is
+   * replaced with `setComposedOverlay(ctx.orchestratorCtx)` so the live
+   * thinking paragraph is never wiped by a subagent state transition.
+   *
+   * Tests that don't exercise the TTY overlay path may omit this field —
+   * the subagent handlers guard all `setComposedOverlay` calls with
+   * `ctx.isTTY && ctx.orchestratorCtx` before invoking.
+   */
+  orchestratorCtx?: OrchestratorCtx;
 }
 
 /**
@@ -156,37 +175,28 @@ export function handleSubagentEvent(
           maxWidth,
         );
         source.stats.toolUses += 1;
-        if (ctx.isTTY) {
-          if (ctx.overlayComposer) {
-            ctx.overlayComposer.markDirty('tool-lane');
-            ctx.overlayComposer.flush();
-          } else if (ctx.compositor) {
-            ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
-          }
+        // Route through the full composed frame so the orchestrator's live-
+        // thinking paragraph is preserved. (Issue #389.)
+        if (ctx.isTTY && ctx.orchestratorCtx) {
+          setComposedOverlay(ctx.orchestratorCtx);
         }
       } else if (chunk.type === 'tool_result') {
         const renderer = ctx.streamingMarkdown.get(sourceId);
         if (renderer) renderer.commitPending();
         ctx.toolLane.addResult(chunk.toolUseId, chunk);
-        if (ctx.isTTY) {
-          if (ctx.overlayComposer) {
-            ctx.overlayComposer.markDirty('tool-lane');
-            ctx.overlayComposer.flush();
-          } else if (ctx.compositor) {
-            ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
-          }
+        // Route through the full composed frame so the orchestrator's live-
+        // thinking paragraph is preserved. (Issue #389.)
+        if (ctx.isTTY && ctx.orchestratorCtx) {
+          setComposedOverlay(ctx.orchestratorCtx);
         }
       } else if (chunk.type === 'tool_diff') {
         // Sidecar render-only diff for a subagent's tool call. Late-attach
         // by toolUseId; no-op if the entry already flushed.
         ctx.toolLane.addDiff(chunk.toolUseId, chunk.diff);
-        if (ctx.isTTY) {
-          if (ctx.overlayComposer) {
-            ctx.overlayComposer.markDirty('tool-lane');
-            ctx.overlayComposer.flush();
-          } else if (ctx.compositor) {
-            ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
-          }
+        // Route through the full composed frame so the orchestrator's live-
+        // thinking paragraph is preserved. (Issue #389.)
+        if (ctx.isTTY && ctx.orchestratorCtx) {
+          setComposedOverlay(ctx.orchestratorCtx);
         }
       } else if (chunk.type === 'content') {
         // Thinking→acting boundary for this subagent. Same idempotent cap
@@ -228,29 +238,18 @@ export function handleSubagentEvent(
               ctx.toolLane.setThinkingTail(parentId, tail);
             }
           }
-          // H2 fix: gate setOverlay behind the same 1500ms throttle to prevent
-          // driving a full CupFrameRenderer.render() on every content token.
-          // Discrete state transitions (tool_use_detail, tool_result, tool_diff,
-          // error, done) are NOT gated — only the high-frequency streaming path.
-          {
+          // H2 fix: gate setComposedOverlay behind the same 1500ms throttle to
+          // prevent driving a full CupFrameRenderer.render() on every content
+          // token. Discrete state transitions (tool_use_detail, tool_result,
+          // tool_diff, error, done) are NOT gated — only the high-frequency
+          // streaming path. Routes through the full composed frame so the
+          // orchestrator's live-thinking paragraph is preserved. (Issue #389.)
+          if (ctx.orchestratorCtx) {
             const now = Date.now();
             const lastOverlay = _overlayLastUpdate.get(parentId) ?? 0;
             if (now - lastOverlay >= 1500) {
               _overlayLastUpdate.set(parentId, now);
-              // Route the throttled refresh through the composer when present so
-              // it recomposes ALL active slots in z-order. A direct
-              // compositor.setOverlay would overwrite the single overlay region
-              // with only the tool-lane, clobbering the markdown-pending /
-              // stage-rail / thinking-tail slots — the OverlayComposer is the
-              // sole writer of compositor.setOverlay while a turn is live (see
-              // overlay-composer.ts). Falls back to direct setOverlay only when
-              // no composer is wired (tests / non-TTY).
-              if (ctx.overlayComposer) {
-                ctx.overlayComposer.markDirty('tool-lane');
-                ctx.overlayComposer.flush();
-              } else {
-                ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
-              }
+              setComposedOverlay(ctx.orchestratorCtx);
             }
           }
         } else {
@@ -286,26 +285,21 @@ export function handleSubagentEvent(
         if (ctx.thinkingMode === 'off') return;
         if (!source.thinkingLane) source.thinkingLane = new ThinkingLane();
         source.thinkingLane.push(chunk.content);
-        if (ctx.thinkingMode === 'live' && ctx.isTTY && ctx.compositor) {
+        if (ctx.thinkingMode === 'live' && ctx.isTTY && ctx.orchestratorCtx) {
           const cols = process.stdout.columns ?? 100;
           const maxTail = Math.max(20, cols - 14);
           const tail = extractLatestThinkingClause(source.thinkingLane.peek(), maxTail);
           if (tail) ctx.toolLane.setThinkingTail(parentId, tail);
-          // H2 fix: gate setOverlay behind the same 1500ms throttle to prevent
-          // driving a full CupFrameRenderer.render() on every thinking token.
+          // H2 fix: gate setComposedOverlay behind the same 1500ms throttle to
+          // prevent driving a full CupFrameRenderer.render() on every thinking
+          // token. Routes through the full composed frame so the orchestrator's
+          // live-thinking paragraph is preserved. (Issue #389.)
           {
             const now = Date.now();
             const lastOverlay = _overlayLastUpdate.get(parentId) ?? 0;
             if (now - lastOverlay >= 1500) {
               _overlayLastUpdate.set(parentId, now);
-              // Route through the composer when present (see content path above)
-              // so the throttled refresh never clobbers sibling overlay slots.
-              if (ctx.overlayComposer) {
-                ctx.overlayComposer.markDirty('tool-lane');
-                ctx.overlayComposer.flush();
-              } else {
-                ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
-              }
+              setComposedOverlay(ctx.orchestratorCtx);
             }
           }
         }
@@ -348,23 +342,17 @@ export function handleSubagentEvent(
         ctx.toolLane.setAgentResultSummary(parentId, errorSummary);
         ctx.toolLane.addResult(parentId, syntheticResult(errorSummary, true));
       }
-      if (ctx.isTTY && ctx.compositor) {
-        // Route through the composer when present so the error's terminal
-        // overlay recomposes all slots instead of clobbering the overlay
-        // region with the tool-lane alone (overlay-composer.ts invariant).
-        if (ctx.overlayComposer) {
-          ctx.overlayComposer.markDirty('tool-lane');
-          ctx.overlayComposer.flush();
-        } else {
-          ctx.compositor.setOverlay(ctx.toolLane.getOverlay());
-        }
+      // Route through the full composed frame so the orchestrator's live-
+      // thinking paragraph is preserved. (Issue #389.)
+      if (ctx.isTTY && ctx.orchestratorCtx) {
+        setComposedOverlay(ctx.orchestratorCtx);
       }
       return;
 
     case 'done':
       source.done = true;
       if (event.metadata) source.responseMetadata = event.metadata;
-      finalizeSubagent(sourceId, source, ctx, _thinkingTailLastUpdate, _overlayLastUpdate);
+      finalizeSubagent(sourceId, source, ctx);
       return;
 
     case 'suggestion':
@@ -375,4 +363,126 @@ export function handleSubagentEvent(
       return;
   }
 }
-export { extractLatestThinkingClause, emitSubagentPanel, finalizeSubagent, synthesizeAgentEntry };
+
+/**
+ * Render a panel emitted from inside a subagent. Flushes any pending
+ * subagent content (markdown buffer) before rendering the card, mirroring
+ * the orchestrator's emitPanel pattern so the card never races streamed
+ * content on non-TTY surfaces.
+ *
+ * The synthetic Agent entry stays alive in the parent tool lane (we don't
+ * flush it — that would drop attribution mid-flight). The card itself is
+ * committed straight to scrollback as a loud visual marker; its color and
+ * shape make the source obvious without extra indent chrome.
+ */
+export function emitSubagentPanel(
+  spec: CardSpec,
+  _sourceId: string,
+  source: SourceState,
+  ctx: SubagentCtx,
+): void {
+  // Drop buffered prose before rendering the card so the panel doesn't
+  // visually interleave with streaming content.
+  //
+  // TTY: subagent prose was already routed to the transient thinking tail
+  // (not scrollback) — clear that tail so the panel reads as the new state,
+  // and discard the prose buffer silently. The card itself is the deliberate
+  // visible artifact and is committed via the loop below.
+  // Non-TTY: flush the buffer through the gutter-prefixed scrollback path so
+  // logs retain the full prose context that preceded the card.
+  if (ctx.isTTY) {
+    const parentId = source.syntheticAgentToolUseId;
+    if (parentId) ctx.toolLane.setThinkingTail(parentId, undefined);
+    source.contentBuffer = '';
+  } else if (source.contentBuffer.trim()) {
+    emitSubagentTextLines(source.contentBuffer, ctx);
+    source.contentBuffer = '';
+  }
+
+  const rendered = card(spec);
+  for (const line of rendered.split('\n')) {
+    if (ctx.isTTY && ctx.compositor) {
+      ctx.compositor.commitAbove(line);
+    } else {
+      ctx.out.line(line);
+    }
+  }
+  // Invariant (TUI rhythm contract): subagent panel card owns ONE
+  // trailing blank line so the next block (more prose, the next tool,
+  // or another subagent) has breathing room. Mirrors background-task
+  // completion cards (repl-loop.ts:314). See docs/tui-rhythm.md.
+  if (ctx.isTTY && ctx.compositor) {
+    ctx.compositor.commitAbove('');
+  } else {
+    ctx.out.line('');
+  }
+}
+
+/**
+ * Finalize a subagent source: flush any remaining partial line buffer and emit
+ * a summary result under its synthetic agent. No-op if the subagent errored
+ * (error summary already set in the error case).
+ */
+export function finalizeSubagent(_sourceId: string, source: SourceState, ctx: SubagentCtx): void {
+  const parentId = source.syntheticAgentToolUseId;
+  if (!parentId || source.errored) return;
+
+  // Drain any remaining buffered prose.
+  //
+  // TTY: subagent prose is suppressed from scrollback by design (the leak
+  // fix). The buffer is discarded silently — the user already saw the live
+  // tail under the Agent row while the subagent was running, and the Done
+  // row below is the only artifact that lands in the parent transcript.
+  //
+  // Non-TTY: flush the trailing buffer through the gutter-prefixed
+  // scrollback path so logs/CI keep the final line of prose even when the
+  // subagent's last chunk lacked a trailing newline.
+  if (!ctx.isTTY && source.contentBuffer) {
+    emitSubagentTextLines(source.contentBuffer, ctx);
+  }
+  source.contentBuffer = '';
+
+  // Non-TTY: emit a standalone thinking summary line before the Done row,
+  // mirroring the orchestrator's pattern (stream-renderer-orchestrator.ts:236-250).
+  // On TTY the live thinking tail already provides visibility; this is for
+  // logs, CI, and headless surfaces where the tail is never rendered.
+  //
+  // Invariant (TUI rhythm contract): emit summary + ONE trailing blank.
+  // Without the trailing blank, the next block (the Done row, committed
+  // via addResult/syntheticResult below) butts directly against the
+  // summary. See docs/tui-rhythm.md.
+  if (!ctx.isTTY && source.thinkingLane?.hasBufferedContent()) {
+    const thinkingSummary = source.thinkingLane.collapse();
+    if (thinkingSummary) {
+      ctx.out.line(thinkingSummary);
+      ctx.out.line('');
+    }
+  }
+
+  // Clear the live thinking tail before the Done row is committed —
+  // `formatDoneSummary` reads `source.thinkingLane` to append the
+  // "thought Xs · N tok" post-mortem stat, which makes the live tail
+  // redundant and visually noisy alongside the result line.
+  ctx.toolLane.setThinkingTail(parentId, undefined);
+  // Item #6: Clean up the per-parentId throttle entry so the map doesn't
+  // grow unboundedly across many short-lived subagents in a long session.
+  // External constraint: delete AFTER setThinkingTail(undefined) so the
+  // clear is never throttled by a stale timestamp from the same run.
+  _thinkingTailLastUpdate.delete(parentId);
+  // H2 fix: clean up the overlay throttle entry too.
+  _overlayLastUpdate.delete(parentId);
+
+  const summary = formatDoneSummary(source);
+  ctx.toolLane.setAgentResultSummary(parentId, summary);
+  ctx.toolLane.addResult(
+    parentId,
+    syntheticResult(summary, false),
+  );
+  // Route through the full composed frame so the orchestrator's live-
+  // thinking paragraph is preserved. (Issue #389.)
+  if (ctx.isTTY && ctx.orchestratorCtx) {
+    setComposedOverlay(ctx.orchestratorCtx);
+  }
+}
+
+export { extractLatestThinkingClause, synthesizeAgentEntry };

--- a/src/cli/_lib/stream-renderer.test.ts
+++ b/src/cli/_lib/stream-renderer.test.ts
@@ -610,6 +610,7 @@ describe('handleOrchestratorEvent — pending markdown commit on tool boundary',
       thinkingMode: 'summary' as const,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       streamingMarkdown: { current: stubs.markdownRenderer as any },
+      lastProgressByTask: new Map(),
     };
     const source = freshSourceState(undefined);
 
@@ -620,7 +621,6 @@ describe('handleOrchestratorEvent — pending markdown commit on tool boundary',
       },
       source,
       ctx,
-      new Map(),
     );
 
     expect(stubs.commitPendingCalls.length).toBe(1);
@@ -649,6 +649,7 @@ describe('handleOrchestratorEvent — pending markdown commit on tool boundary',
       thinkingMode: 'summary' as const,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       streamingMarkdown: { current: stubs.markdownRenderer as any },
+      lastProgressByTask: new Map(),
     };
     const source = freshSourceState(undefined);
 
@@ -659,7 +660,6 @@ describe('handleOrchestratorEvent — pending markdown commit on tool boundary',
       },
       source,
       ctx,
-      new Map(),
     );
 
     expect(stubs.commitPendingCalls.length).toBe(1);
@@ -687,6 +687,7 @@ describe('handleOrchestratorEvent — pending markdown commit on tool boundary',
       thinkingLane: new ThinkingLane(),
       thinkingMode: 'summary' as const,
       streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
     };
     const source = freshSourceState(undefined);
 
@@ -694,7 +695,6 @@ describe('handleOrchestratorEvent — pending markdown commit on tool boundary',
       { type: 'chunk', chunk: { type: 'content', content: 'hello world' } },
       source,
       ctx,
-      new Map(),
     );
 
     const disables = stubs.setSpinnerCalls.filter((c) => c.enabled === false);
@@ -722,6 +722,7 @@ describe('handleOrchestratorEvent — pending markdown commit on tool boundary',
       thinkingMode: 'summary' as const,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       streamingMarkdown: { current: stubs.markdownRenderer as any },
+      lastProgressByTask: new Map(),
     };
     const source = freshSourceState(undefined);
 
@@ -732,7 +733,6 @@ describe('handleOrchestratorEvent — pending markdown commit on tool boundary',
       },
       source,
       ctx,
-      new Map(),
     );
 
     const enables = stubs.setSpinnerCalls.filter((c) => c.enabled === true);
@@ -767,18 +767,34 @@ describe('handleSubagentEvent — streaming content via markdown renderer', () =
     );
     const { freshSourceState } = await import('./stream-renderer-source.js');
     const { ToolLane } = await import('../commands/interactive/tool-lane.js');
+    const { ThinkingLane } = await import('../commands/interactive/thinking-lane.js');
     const { StreamingMarkdownRenderer } = await import('../markdown-stream.js');
 
     const stubs = makeOverlayStubs();
     const { writer } = makeWriter();
     const streamingMarkdown = new Map<string, InstanceType<typeof StreamingMarkdownRenderer>>();
+    const toolLane = new ToolLane();
+    // Provide orchestratorCtx so subagent handlers route through
+    // setComposedOverlay (issue #389 — all overlay repaints composed).
+    const orchCtx = {
+      out: writer,
+      isTTY: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      compositor: stubs.compositor as any,
+      toolLane,
+      thinkingLane: new ThinkingLane(),
+      thinkingMode: 'off' as const,
+      streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
+    };
     const ctx = {
       isTTY: true,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       compositor: stubs.compositor as any,
-      toolLane: new ToolLane(),
+      toolLane,
       out: writer,
       streamingMarkdown,
+      orchestratorCtx: orchCtx,
     };
     const source = freshSourceState('pragmatist');
     synthesizeAgentEntry('src-A', source, ctx);
@@ -824,18 +840,34 @@ describe('handleSubagentEvent — streaming content via markdown renderer', () =
     );
     const { freshSourceState } = await import('./stream-renderer-source.js');
     const { ToolLane } = await import('../commands/interactive/tool-lane.js');
+    const { ThinkingLane } = await import('../commands/interactive/thinking-lane.js');
     const { StreamingMarkdownRenderer } = await import('../markdown-stream.js');
 
     const stubs = makeOverlayStubs();
     const { writer } = makeWriter();
     const streamingMarkdown = new Map<string, InstanceType<typeof StreamingMarkdownRenderer>>();
+    const toolLane = new ToolLane();
+    // Provide orchestratorCtx so subagent handlers route through
+    // setComposedOverlay (issue #389 — all overlay repaints composed).
+    const orchCtx = {
+      out: writer,
+      isTTY: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      compositor: stubs.compositor as any,
+      toolLane,
+      thinkingLane: new ThinkingLane(),
+      thinkingMode: 'off' as const,
+      streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
+    };
     const ctx = {
       isTTY: true,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       compositor: stubs.compositor as any,
-      toolLane: new ToolLane(),
+      toolLane,
       out: writer,
       streamingMarkdown,
+      orchestratorCtx: orchCtx,
     };
     const source = freshSourceState('pragmatist');
     synthesizeAgentEntry('src-A', source, ctx);
@@ -873,6 +905,7 @@ describe('handleSubagentEvent — streaming content via markdown renderer', () =
     );
     const { freshSourceState } = await import('./stream-renderer-source.js');
     const { ToolLane } = await import('../commands/interactive/tool-lane.js');
+    const { ThinkingLane } = await import('../commands/interactive/thinking-lane.js');
     const { StreamingMarkdownRenderer } = await import('../markdown-stream.js');
 
     const stubs = makeOverlayStubs();
@@ -888,6 +921,19 @@ describe('handleSubagentEvent — streaming content via markdown renderer', () =
       return origSet(id, tail);
     };
 
+    // Provide orchestratorCtx so subagent handlers route through
+    // setComposedOverlay (issue #389 — all overlay repaints composed).
+    const orchCtx = {
+      out: writer,
+      isTTY: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      compositor: stubs.compositor as any,
+      toolLane,
+      thinkingLane: new ThinkingLane(),
+      thinkingMode: 'off' as const,
+      streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
+    };
     const ctx = {
       isTTY: true,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -895,6 +941,7 @@ describe('handleSubagentEvent — streaming content via markdown renderer', () =
       toolLane,
       out: writer,
       streamingMarkdown,
+      orchestratorCtx: orchCtx,
     };
     const source = freshSourceState('pragmatist');
     synthesizeAgentEntry('src-A', source, ctx);
@@ -1476,9 +1523,10 @@ describe('setComposedOverlay — live thinking preview', () => {
       thinkingLane,
       thinkingMode: 'live' as const,
       streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
     };
 
-    setComposedOverlay(ctx, new Map());
+    setComposedOverlay(ctx);
 
     const overlay = overlayCalls.at(-1) ?? '';
     expect(overlay).toContain('◆');
@@ -1503,9 +1551,10 @@ describe('setComposedOverlay — live thinking preview', () => {
       thinkingLane,
       thinkingMode: 'summary' as const,
       streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
     };
 
-    setComposedOverlay(ctx, new Map());
+    setComposedOverlay(ctx);
 
     const overlay = overlayCalls.at(-1) ?? '';
     expect(overlay).not.toContain('reasoning');
@@ -1539,9 +1588,10 @@ describe('setComposedOverlay — live thinking preview', () => {
       thinkingLane,
       thinkingMode: 'live' as const,
       streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
     };
 
-    setComposedOverlay(ctx, new Map());
+    setComposedOverlay(ctx);
 
     const overlay = overlayCalls.at(-1) ?? '';
     // Tail is preserved (last wrapped lines kept).
@@ -1575,9 +1625,10 @@ describe('setComposedOverlay — live thinking preview', () => {
       thinkingLane,
       thinkingMode: 'live' as const,
       streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
     };
 
-    setComposedOverlay(ctx, new Map());
+    setComposedOverlay(ctx);
 
     const overlay = overlayCalls.at(-1) ?? '';
     // eslint-disable-next-line no-control-regex

--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -46,6 +46,7 @@ import {
 import {
   handleOrchestratorEvent,
   setComposedOverlay,
+  type OrchestratorCtx,
 } from './stream-renderer-orchestrator.js';
 import { CommitCoordinator } from './commit-coordinator.js';
 import { handleSubagentEvent, synthesizeAgentEntry } from './stream-renderer-subagent.js';
@@ -456,7 +457,6 @@ export class StreamRenderer {
     this.resizeUnsub = subscribeToResize(this.overlayComposer, false);
   }
 
-
   /**
    * Public accessor for the underlying TerminalCompositor. Returns null
    * before {@link arm} resolves, on non-TTY surfaces, or after {@link dispose}.
@@ -493,6 +493,33 @@ export class StreamRenderer {
    * Process one OutputEvent. `meta.subagentId` identifies the source; absent
    * meta is treated as the orchestrator source (`__main__`).
    */
+  /**
+   * Build a fresh OrchestratorCtx snapshot from the renderer's live
+   * collaborators (compositor, overlay composer, shared tool lane, thinking
+   * lane, progress map, …). Both the orchestrator branch and the subagent
+   * branch (issue #389) compose overlays through this so EVERY repaint —
+   * including those triggered by subagent state transitions — includes the
+   * full frame: orchestrator thinking paragraph + shared tool lane + progress
+   * banner. Cheap to rebuild per event (a shallow wrapper over shared refs);
+   * the orchestrator path already did so inline before this extraction.
+   */
+  private buildOrchestratorCtx(): OrchestratorCtx {
+    return makeOrchestratorCtx({
+      out: this.out,
+      isTTY: this.isTTY,
+      compositor: this.compositor,
+      overlayComposer: this.overlayComposer,
+      toolLane: this.toolLane,
+      thinkingLane: this.thinkingLane,
+      thinkingMode: this.thinkingMode,
+      streamingMarkdown: this.streamingMarkdownRef,
+      coordinator: this.coordinator,
+      lastProgressByTask: this.lastProgressByTask,
+      ...(this.isTTY ? { stageTracker: this.stageTracker } : {}),
+      ...(this.activeSkillName ? { activeSkillName: this.activeSkillName } : {}),
+    });
+  }
+
   process(event: OutputEvent, meta?: SubagentProgressMeta): void {
     if (this.disposed) return;
 
@@ -516,11 +543,11 @@ export class StreamRenderer {
         synthesizeAgentEntry(sourceId, source, makeSubagentCtx({
           isTTY: this.isTTY,
           compositor: this.compositor,
-          overlayComposer: this.overlayComposer,
           toolLane: this.toolLane,
           out: this.out,
           streamingMarkdown: this.subagentMarkdown,
           thinkingMode: this.thinkingMode,
+          orchestratorCtx: this.buildOrchestratorCtx(),
         }), parentSyntheticId);
       }
     }
@@ -529,19 +556,7 @@ export class StreamRenderer {
       // Snapshot the stage before the event so we can fire onStageChange
       // exactly when the stage transitions (not on every event).
       const stageBefore = this.stageTracker.stage;
-      handleOrchestratorEvent(event, source, makeOrchestratorCtx({
-        out: this.out,
-        isTTY: this.isTTY,
-        compositor: this.compositor,
-        overlayComposer: this.overlayComposer,
-        toolLane: this.toolLane,
-        thinkingLane: this.thinkingLane,
-        thinkingMode: this.thinkingMode,
-        streamingMarkdown: this.streamingMarkdownRef,
-        coordinator: this.coordinator,
-        ...(this.isTTY ? { stageTracker: this.stageTracker } : {}),
-        ...(this.activeSkillName ? { activeSkillName: this.activeSkillName } : {}),
-      }), this.lastProgressByTask);
+      handleOrchestratorEvent(event, source, this.buildOrchestratorCtx());
       // Fire onStageChange when the loop stage transitions so the LoopStageBar
       // footer row repaints immediately — without polling or threading the bar
       // through the overlay compositor. Swallows errors defensively.
@@ -552,11 +567,11 @@ export class StreamRenderer {
       handleSubagentEvent(event, sourceId, source, makeSubagentCtx({
         isTTY: this.isTTY,
         compositor: this.compositor,
-        overlayComposer: this.overlayComposer,
         toolLane: this.toolLane,
         out: this.out,
         streamingMarkdown: this.subagentMarkdown,
         thinkingMode: this.thinkingMode,
+        orchestratorCtx: this.buildOrchestratorCtx(),
       }));
       // Refresh staleness timestamp and clear any pause annotation on new activity.
       source.lastEventAt = Date.now();
@@ -668,20 +683,7 @@ export class StreamRenderer {
             this.coordinator.drainSubagent(sourceId);
           }
         }
-        const orchestratorCtx = makeOrchestratorCtx({
-          out: this.out,
-          isTTY: this.isTTY,
-          compositor: this.compositor,
-          overlayComposer: this.overlayComposer,
-          toolLane: this.toolLane,
-          thinkingLane: this.thinkingLane,
-          thinkingMode: this.thinkingMode,
-          streamingMarkdown: this.streamingMarkdownRef,
-          coordinator: this.coordinator,
-          ...(this.isTTY ? { stageTracker: this.stageTracker } : {}),
-          ...(this.activeSkillName ? { activeSkillName: this.activeSkillName } : {}),
-        });
-        setComposedOverlay(orchestratorCtx, this.lastProgressByTask);
+        setComposedOverlay(this.buildOrchestratorCtx());
       }
     }
   }


### PR DESCRIPTION
## Source

Port of **afk-workshop#572** — `fix(renderer): route all overlay repaints through setComposedOverlay`.
Moat-scrubbed port via **diff + 3-way apply** (the public repo shares no git history with afk-workshop), **not** a 1:1 commit copy. Public tracker for this bug: #110.

## Problem

A prior change grew the composed orchestrator overlay to ~7 rows (thinking paragraph + stage rail + tool lane + progress banner). Every direct `compositor.setOverlay(toolLane.getOverlay())` callsite was a flicker source: it wiped the live-thinking paragraph rows, then the next composed frame repainted them — visible paragraph flicker on every subagent state transition.

## What changed

- **`lastProgressByTask`** hoisted from a separate function parameter into `OrchestratorCtx` (progress state is orchestrator-owned).
- **`setComposedOverlay`** signature simplified `(ctx, lastProgressByTask)` → `(ctx: OrchestratorCtx)`; now reads `ctx.lastProgressByTask`.
- **`SubagentCtx`** drops `overlayComposer`, gains `orchestratorCtx?: OrchestratorCtx`; every subagent overlay repaint (tool start/result/diff, throttled content, thinking, error, done/finalize) now routes through `setComposedOverlay(ctx.orchestratorCtx)` instead of a bare tool-lane write — so the orchestrator's thinking paragraph + stage rail + progress banner survive in every frame.
- **`emitSubagentPanel` / `finalizeSubagent`** moved from `stream-renderer-subagent-helpers.ts` → `stream-renderer-subagent.ts`; `finalizeSubagent` drops its two throttle-map params (uses module-scope maps).
- **`StreamRenderer.buildOrchestratorCtx()`** new private factory; threads the live ctx into both the orchestrator and subagent branches.
- Tests: new `stream-renderer-contexts.test.ts` + regression tests asserting subagent transitions do not drop the orchestrator thinking paragraph.

## Dropped for moat

**None.** Entirely public-safe — 12 files, all under `src/cli/_lib/stream-renderer*` (TUI rendering). No moat files, hunks, imports, or denylist terms were present, so nothing was scrubbed.

## Adaptations for public (not 1:1 — reviewer please note)

The public tree had drifted from the private base; rejects were resolved by hand, **preserving public-specific logic**:

- **`stream-renderer-orchestrator.ts` progress arm:** public carries a public-only fix — `lastProgressByTask.clear()` + an invariant comment that evicts a stale entry on auth-retry replay to prevent stacked "Tool-use loop" banners. Preserved it while applying the hoist (`ctx.lastProgressByTask.clear()/.set()`, dropped the 2nd arg).
- **`stream-renderer-subagent.ts` content + thinking throttle arms:** ported the `overlayComposer.markDirty/flush` → `setComposedOverlay(ctx.orchestratorCtx)` conversion onto public's (more verbose) comment text.
- **`stream-renderer-subagent-helpers.ts`:** deleted `finalizeSubagent` (moved to subagent.ts) despite a comment line-wrap drift.
- **3 public-only tests** in `stream-renderer-orchestrator.test.ts` used the old 4-arg `handleOrchestratorEvent(..., lastProgress)` signature; forward-fixed to the hoisted `ctx.lastProgressByTask` API (one was a live assertion against the now-disconnected external map; two were dead 4th args).
- **Issue reference:** the source title's `(closes #389)` points at a *private* issue; dropped from the commit subject to avoid a dangling/auto-close link on public (public #389 does not exist). Public tracker is #110.

## Verification (clean clone of this branch)

- `pnpm lint` (tsc --noEmit, strict): **clean**
- `pnpm fix:pins:check`: **clean**
- Affected suite (the 7 changed test files): **134/134 pass**
- Full suite excluding the pre-existing parallel-worker flake `stream-renderer-ordering.test.ts`: **9292 pass / 0 fail / 12 skipped (495 files)**. That flake is untouched by this PR and passes in isolation (14/14) — it hangs only under parallel workers (a pre-existing repo issue, documented on the source PR).
- `pnpm build` + `pnpm build:dist`: **clean** (dist scrubber: 0 files scrubbed)
- Deterministic moat guard (tree + `dist/`, HARD denylist + structural): **MOAT GUARD CLEAN**
- Independent adversarial moat audit (re-derived, not trusting the guard): **AUDIT CLEAN**

## Do not merge automatically — for human review.
