### PR TITLE
fix(providers): strip ask_question on non-interactive surfaces

### DIFF
--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -441,6 +441,13 @@ export class CronScheduler {
       // break scheduled tasks that depend on tool execution.
       permissionMode: 'bypassPermissions',
       hookRegistry: registry,
+      // Scheduler/cron sessions are headless (no human at the keyboard): strip
+      // ask_question so a scheduled task never stalls on an unanswerable prompt.
+      // The daemon session factory also forces this after its own config spread;
+      // set it here as the base for the no-factory fallback (standalone
+      // scheduler / tests). Placed before the sessionConfig spread so an
+      // operator escape-hatch could still override it, mirroring permissionMode.
+      isNonInteractive: true,
       // Trace writer placed before sessionConfig so an operator-supplied
       // sessionConfig.traceWriter still wins (escape-hatch parity with
       // permissionMode).

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -651,11 +651,18 @@ export class AnthropicDirectProvider implements ModelProvider {
     // confused model into calling terminal_font_size(<n>) instead of running the
     // skill). Gated on isSkillDispatch; pairs with the SLASH_COMMAND_ROUTING_PROMPT
     // omission below. Verified safe: no bundled/registry/user skill calls either tool.
+    // Non-interactive surfaces (daemon, scheduler/cron, one-shot `afk chat`)
+    // install no elicitation handler, so `ask_question` can only auto-decline
+    // (elicitation-router.ts). Strip it so the model proceeds on an assumption
+    // or emits Blocked rather than burning a turn on an unanswerable prompt.
+    // Narrower than the skill-dispatch strip: `terminal_font_size` is retained.
     const toolDefs = config.isSkillDispatch
       ? baseToolDefs.filter(
           (t) => t.name !== 'ask_question' && t.name !== 'terminal_font_size',
         )
-      : baseToolDefs;
+      : config.isNonInteractive
+        ? baseToolDefs.filter((t) => t.name !== 'ask_question')
+        : baseToolDefs;
 
     // Build skill manifest for system prompt injection. The manifest lists
     // available skills so the model knows what the `skill` tool can invoke.

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -204,6 +204,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
           ...(config.traceWriter !== undefined ? { traceWriter: config.traceWriter } : {}),
           runtimeStateSource,
           ...(config.isSkillDispatch ? { isSkillDispatch: true } : {}),
+          ...(config.isNonInteractive ? { isNonInteractive: true } : {}),
         });
 
     const buildOpts: {
@@ -289,6 +290,13 @@ export class OpenAICompatibleProvider implements ModelProvider {
        * AnthropicDirectProvider.
        */
       isSkillDispatch?: boolean;
+      /**
+       * When true, this is a non-interactive surface (daemon, scheduler/cron,
+       * one-shot chat) where no human answers elicitations. Strip `ask_question`
+       * only (not `terminal_font_size`). Parity with the `config.isNonInteractive`
+       * toolDefs filter in AnthropicDirectProvider.
+       */
+      isNonInteractive?: boolean;
     },
   ): SessionToolDispatcher {
     const handlers = createBuiltinHandlers(permissionMode, opts.cwd);
@@ -325,7 +333,9 @@ export class OpenAICompatibleProvider implements ModelProvider {
       ? this.schemas.filter(
           (t) => t.name !== 'ask_question' && t.name !== 'terminal_font_size',
         )
-      : this.schemas;
+      : opts.isNonInteractive
+        ? this.schemas.filter((t) => t.name !== 'ask_question')
+        : this.schemas;
 
     const dispatcherOpts: ConstructorParameters<typeof SessionToolDispatcher>[0] = {
       handlers,

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -1284,6 +1284,57 @@ describe('OpenAICompatibleProvider — skill-dispatch ask_question suppression',
 });
 
 // --------------------------------------------------------------------------
+// OpenAICompatibleProvider — ask_question stripped on non-interactive surfaces
+// --------------------------------------------------------------------------
+// Parity with AnthropicDirectProvider: daemon / scheduler / one-shot chat
+// install no elicitation handler, so ask_question can only auto-decline.
+// buildDispatcher strips it when config.isNonInteractive is true. Narrower than
+// the skill-dispatch strip — terminal_font_size is RETAINED here.
+
+describe('OpenAICompatibleProvider — non-interactive surface ask_question suppression', () => {
+  /** Collect tool names from an OpenAI-format `tools[]` request payload. */
+  function openAIToolNames(toolsArg: unknown): string[] {
+    if (!Array.isArray(toolsArg)) return [];
+    return (toolsArg as Array<{ function?: { name?: unknown } }>)
+      .map((t) => (typeof t.function?.name === 'string' ? t.function.name : ''))
+      .filter((n): n is string => n.length > 0);
+  }
+
+  // A single clean text turn so the query terminates after one create() call.
+  function stubOneTextTurn(): void {
+    pendingChunks = [
+      {
+        choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    ];
+  }
+
+  it('non-interactive session (isNonInteractive=true): ask_question is STRIPPED', async () => {
+    stubOneTextTurn();
+    const provider = new OpenAICompatibleProvider();
+    const q = provider.query({
+      prompt: singleInput('Summarize the open PRs and proceed.'),
+      config: {
+        model: 'gpt-4o-mini',
+        apiKey: 'sk-test-key',
+        isNonInteractive: true,
+      } as AgentConfig,
+    });
+    await collect(q);
+
+    expect(createCalls).toHaveLength(1);
+    const toolNames = openAIToolNames((createCalls[0]!.args as { tools?: unknown }).tools);
+    // No human can answer on a headless surface, so the escape hatch is gone…
+    expect(toolNames).not.toContain('ask_question');
+    // …but this strip is NARROWER than skill-dispatch: terminal_font_size stays.
+    expect(toolNames).toContain('terminal_font_size');
+    expect(toolNames).toContain('read_file');
+    expect(toolNames).toContain('bash');
+  });
+});
+
+// --------------------------------------------------------------------------
 // OpenAICompatibleProvider — terminal_font_size stripped for skill-dispatch sub-agents
 // --------------------------------------------------------------------------
 // Parity with AnthropicDirectProvider: a bare numeric skill arg (e.g. /review 621)

--- a/src/agent/tools/skill-dispatch-routing.test.ts
+++ b/src/agent/tools/skill-dispatch-routing.test.ts
@@ -308,6 +308,47 @@ describe('AnthropicDirectProvider — skill-dispatch ask_question suppression', 
 });
 
 // --------------------------------------------------------------------------
+// AnthropicDirectProvider — ask_question stripped on non-interactive surfaces
+// --------------------------------------------------------------------------
+// Daemon, scheduler/cron, and one-shot `afk chat` install no elicitation
+// handler, so ask_question can only auto-decline. Stripping it pre-emptively
+// stops the model burning a turn on an unanswerable prompt. Narrower than the
+// skill-dispatch strip: terminal_font_size is RETAINED here.
+
+describe('AnthropicDirectProvider — non-interactive surface ask_question suppression', () => {
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    installFactory();
+    messagesCreateMock.mockImplementation(() => fromArray(makeTextStream('ok')));
+  });
+
+  it('non-interactive session (isNonInteractive=true): ask_question is STRIPPED', async () => {
+    const provider = new AnthropicDirectProvider();
+    const query = provider.query({
+      prompt: singleInput('Summarize the open PRs and proceed.'),
+      config: {
+        model: 'claude-haiku-4-5',
+        apiKey: 'sk-ant-oat01-test',
+        isNonInteractive: true,
+      },
+    });
+
+    await drainQuery(query);
+
+    const firstCall = messagesCreateMock.mock.calls[0]!;
+    const toolNames = extractToolNames((firstCall[0] as { tools?: unknown }).tools);
+    // No human can answer on a headless surface, so the escape hatch is gone…
+    expect(toolNames).not.toContain('ask_question');
+    // …but this strip is NARROWER than skill-dispatch: terminal_font_size stays,
+    // and the rest of the toolset is intact (precise filtering, not blanket).
+    expect(toolNames).toContain('terminal_font_size');
+    expect(toolNames).toContain('read_file');
+    expect(toolNames).toContain('bash');
+  });
+});
+
+// --------------------------------------------------------------------------
 // AnthropicDirectProvider — terminal_font_size stripped for skill-dispatch sub-agents
 // --------------------------------------------------------------------------
 // A bare numeric skill arg (e.g. /review 621) can lure a confused model into

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -412,6 +412,31 @@ export interface AgentConfig {
   isSkillDispatch?: boolean;
 
   /**
+   * When true, the session runs on a non-interactive surface where no human is
+   * available to answer an `ask_question` elicitation — the daemon, a
+   * scheduler/cron-launched task, or a one-shot `afk chat` invocation. On these
+   * surfaces no elicitation handler is installed (see `elicitation-router.ts`),
+   * so an `ask_question` call can only auto-decline; offering the tool merely
+   * lets the model burn a turn calling something that structurally cannot
+   * succeed. Providers therefore strip `ask_question` from the assembled
+   * toolset, forcing the model to proceed on a stated assumption or emit a
+   * Blocked terminal state instead.
+   *
+   * Parallels the structural `ask_question` strip already applied for
+   * skill-dispatch sub-agents (`isSkillDispatch`), but is intentionally
+   * narrower: ONLY `ask_question` is removed — `terminal_font_size` is retained
+   * (its skill-dispatch-specific numeric-arg lure does not apply here).
+   *
+   * Interactive surfaces (REPL, Telegram) leave this unset so a human can still
+   * be asked even when away-from-keyboard. Foreground/background sub-agent
+   * elicitation policy is governed separately by `denyElicitations` in
+   * `subagent.ts` and is deliberately NOT changed by this flag.
+   *
+   * Default: `false`.
+   */
+  isNonInteractive?: boolean;
+
+  /**
    * Opt-in automatic compaction. When the context window fills past the
    * configured threshold, `compact()` fires automatically at the next idle
    * turn boundary (no tool call in flight, not already compacting).

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -556,6 +556,10 @@ export function registerChatCommand(program: Command): void {
           // (anti-leak invariant, credential-resolver.ts).
           apiKey: getApiKeyForModel(sessionModel),
           maxTurns: parseInt(options.maxTurns, 10),
+          // One-shot `afk chat` is headless: no REPL/Telegram elicitation
+          // handler is installed, so ask_question can only auto-decline. Strip
+          // it so the model proceeds on an assumption instead of wasting a turn.
+          isNonInteractive: true,
           hookRegistry: createDefaultHookRegistry((info) => {
             console.log(formatSubagentCompletion(info));
           }, 'cli', sharedMemoryStore, undefined, loadHooksConfig({ cwd: worktreeCwd }), { cwd: worktreeCwd }).registry,

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -175,6 +175,11 @@ export function buildDaemonSessionFactory(
     return new AgentSession(injectHotMemory({
       ...config,
       provider,
+      // Daemon sessions are headless: no human watches to answer ask_question.
+      // Stamped after `...config` so it is forced regardless of caller config;
+      // this is the production chokepoint the scheduler routes every task
+      // through, so it also covers scheduler/cron-spawned sessions.
+      isNonInteractive: true,
     }));
   };
 }


### PR DESCRIPTION
## What

Adds `AgentConfig.isNonInteractive` and makes both providers strip the
`ask_question` tool from the assembled toolset when it is set. Wires it on the
three headless top-level surfaces: one-shot `afk chat`, the daemon session
factory, and the scheduler fallback config.

This mirrors the existing structural `ask_question` strip for skill-dispatch
sub-agents (`isSkillDispatch`) and rides the exact same rails — `AgentSession`
forwards `this.config` directly to `provider.query({ config })`
(`agent-session.ts:199,211`), so no new plumbing is required.

## Why

Session telemetry surfaced 17 sessions ending in `tool_error:ask_question:timeout`.
The deeper finding: the friction guards for this (the advisory `/ask-gate` skill,
plus prose in the routing directive) are *opt-in* — they only help if the model
chooses to invoke/heed them, so they under-fire exactly under task momentum. The
runtime already has the deterministic primitive (the provider tool-strip used for
skill-dispatch); this PR extends it to the case where the surface itself
guarantees no human can answer.

## Important nuance (what this does and does not fix)

Recon showed these headless surfaces install **no** elicitation handler
(`elicitation-router.ts:86-88`), so `ask_question` there already **auto-declines**
— it does not hang. So this change is best understood as:

- **Hygiene + deterministic contract:** don't offer a tool that structurally
  cannot succeed; stop the model burning a turn calling it and handling a decline.
- **Infrastructure:** establishes the `isNonInteractive` signal that future work
  can build on.

It is **not** a fix for the timeout source itself. Those 17 timeouts almost
certainly originate on **interactive** surfaces (REPL/Telegram) where a human is
genuinely away-from-keyboard, and possibly from foreground sub-agents that inherit
the parent's module-scope elicitation handler.

## Deliberately out of scope (with rationale)

- **Interactive surfaces (REPL/Telegram):** left untouched. A human *can* answer
  there (just slowly). Stripping `ask_question` would remove a legitimate
  capability and change core interactive behavior — a product-policy call, not a
  bug fix.
- **Foreground sub-agent elicitation:** `subagent.ts:414-419` has a deliberate
  `denyElicitations`/`DENY_ELICITATION` mechanism that auto-declines only for
  *background* sub-agents, intentionally leaving foreground forks able to elicit.
  Blanket-stripping all sub-agents would silently override that maintainer
  decision, so this PR does not touch `subagent.ts`.

## Scope

- Narrow strip: only `ask_question` is removed. `terminal_font_size` is **retained**
  (its skill-dispatch-specific numeric-arg lure does not apply here).
- Surfaces wired: `afk chat` (one-shot), daemon factory (production chokepoint the
  scheduler routes through), scheduler fallback config (standalone/tests).

## Test plan

- `pnpm lint` (tsc --noEmit, strict): clean.
- `pnpm test`: **495 files, 9302 passed, 12 skipped, 0 failed.**
- New tests (both providers): a non-interactive session strips `ask_question` while
  retaining `terminal_font_size`, `read_file`, and `bash` — asserting the strip is
  precise, not a blanket removal.

## Possible follow-ups (not in this PR)

- Decide policy for `ask_question` on interactive surfaces under sustained AFK
  (turn-timeout handling vs. strip).
- Revisit foreground sub-agent elicitation (the `denyElicitations` foreground/
  background split).
- Consider other headless entry points (e.g. threads/farm) if they prove headless.
