### PR TITLE
fix(session): seal provider-error turns as failed, not silent success

### DIFF
--- a/src/agent/__fixtures__/mock-provider.ts
+++ b/src/agent/__fixtures__/mock-provider.ts
@@ -85,6 +85,21 @@ export function createMockProvider(opts: MockProviderOptions = {}): MockProvider
 
             if (abortController.signal.aborted) return;
 
+            // Test affordance (mirrors the 'slow' marker above): a turn whose
+            // content contains 'provider-error' yields a terminal `error`
+            // event — exactly what the real providers emit on an HTTP / auth /
+            // stream failure — instead of the normal assistant.message +
+            // turn.completed pair. No turn.completed is emitted, so turnCount
+            // stays put and no usage is accumulated.
+            if (userContent.includes('provider-error')) {
+              yield {
+                type: 'error',
+                error: new Error('mock provider stream failure'),
+              } satisfies ProviderEvent;
+              abortController = null;
+              continue;
+            }
+
             yield {
               type: 'assistant.message',
               text: `Echo: ${userContent}`,

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -102,6 +102,18 @@ export class AgentSession implements IAgentSession {
   private maxTurnsHit = false;
   private hookBlocked = false;
   /**
+   * True when the provider emitted a terminal `error` event (an HTTP / auth /
+   * stream failure) as the session's last turn outcome. Set at the two
+   * error-observation sites — `pullInitialization` (init-phase error) and
+   * `sendMessageStreamInternal` (per-turn error) — and cleared by a subsequent
+   * completed turn so it reflects the FINAL turn's result, not any error
+   * earlier in the session. Read by `deriveClosureReason` (→ `abort`) and
+   * `deriveSealStatus` (→ `failed`) so a provider failure on an otherwise-clean
+   * `close()` is not sealed as a silent `succeeded` / `model_end_turn`. Reset
+   * by `reset()`.
+   */
+  private sawProviderError = false;
+  /**
    * Wall-clock timestamp captured at construction — used to compute the
    * `session_init_done` phase duration and the `session_init_start` emit.
    */
@@ -225,6 +237,7 @@ export class AgentSession implements IAgentSession {
     this.lastStopReason = undefined;
     this.maxTurnsHit = false;
     this.hookBlocked = false;
+    this.sawProviderError = false;
     this.sessionEndDispatched = false;
     this.currentState = 'idle';
     this.subagentCompletedCount = 0;
@@ -277,6 +290,10 @@ export class AgentSession implements IAgentSession {
           return;
         }
         if (output && output.type === 'error') {
+          // Terminal-cause flag: an init-phase provider error must not seal as
+          // a clean close. The eventual close()/reset() reads this so the trace
+          // reports `abort`/`failed` rather than a silent `model_end_turn`.
+          this.sawProviderError = true;
           return;
         }
       }
@@ -497,7 +514,18 @@ export class AgentSession implements IAgentSession {
         const output = transformProviderEvent(event, deps);
 
         if (output) {
-          if (output.type === 'done') this.turnCount++;
+          if (output.type === 'done') {
+            this.turnCount++;
+            // A completed turn clears a prior turn's provider error so the seal
+            // status reflects the FINAL turn's outcome (e.g. a turn that errored
+            // and was then retried successfully is not sealed as `failed`).
+            this.sawProviderError = false;
+          } else if (output.type === 'error') {
+            // Terminal-cause flag: a per-turn provider error (HTTP / auth /
+            // stream failure) must flip the eventual clean close from a silent
+            // `succeeded` / `model_end_turn` to `failed` / `abort`.
+            this.sawProviderError = true;
+          }
           this.ledger?.recordEvent(output);
           yield output;
           if (output.type === 'done' || output.type === 'error') break;
@@ -979,6 +1007,7 @@ export class AgentSession implements IAgentSession {
       hookBlocked: this.hookBlocked,
       abort,
       lastStopReason: this.lastStopReason,
+      sawProviderError: this.sawProviderError,
     });
   }
 
@@ -1079,6 +1108,12 @@ export class AgentSession implements IAgentSession {
     // as cancelled.
     const signal = this.abortController.signal;
     if (signal.aborted && signal.reason !== 'closed') return 'cancelled';
+    // A provider error (HTTP / auth / stream failure) that ended the final
+    // turn is a failure even when the surface then closed the session cleanly.
+    // Checked AFTER the abort branch so a genuine cancel/budget/timeout (which
+    // also emits an error event) keeps its more-specific `cancelled` status.
+    // Without this, a 0-turn/0-token error run seals as a silent `succeeded`.
+    if (this.sawProviderError) return 'failed';
     return 'succeeded';
   }
 

--- a/src/agent/session/closure-reason.test.ts
+++ b/src/agent/session/closure-reason.test.ts
@@ -16,6 +16,7 @@ const base: ClosureReasonInputs = {
   hookBlocked: false,
   abort: null,
   lastStopReason: undefined,
+  sawProviderError: false,
 };
 
 describe('isTruncationStopReason', () => {
@@ -87,5 +88,28 @@ describe('classifyClosureReason', () => {
     expect(
       classifyClosureReason({ ...base, abort: 'timeout', lastStopReason: 'max_tokens' }),
     ).toBe('timeout');
+  });
+
+  it('maps a provider error event on an otherwise-clean close to abort', () => {
+    // The silent-success regression: a turn ended in a provider `error` event
+    // but the surface closed the session cleanly (dispatchReason='close',
+    // no abort signal). Must NOT fall through to model_end_turn.
+    expect(classifyClosureReason({ ...base, sawProviderError: true })).toBe('abort');
+  });
+
+  it('a classified abort signal outranks a provider error event', () => {
+    // A genuine budget/timeout abort also emits an error event; the more
+    // specific abort classification wins.
+    expect(
+      classifyClosureReason({ ...base, sawProviderError: true, abort: 'budget_exceeded' }),
+    ).toBe('budget_exceeded');
+  });
+
+  it('a provider error event outranks a truncation stop reason', () => {
+    // A later errored turn is the terminal cause even if an earlier turn was
+    // truncated (lastStopReason carries the truncated turn's stop reason).
+    expect(
+      classifyClosureReason({ ...base, sawProviderError: true, lastStopReason: 'max_tokens' }),
+    ).toBe('abort');
   });
 });

--- a/src/agent/session/closure-reason.ts
+++ b/src/agent/session/closure-reason.ts
@@ -18,10 +18,15 @@
  *     Preserves the prior behaviour where an init-time error outranks the
  *     abort-signal classification below.
  *  4. a classified abort signal → `budget_exceeded` | `timeout` | `abort`.
- *  5. a truncation stop reason (`max_tokens` / `length`) on an otherwise clean
+ *  5. `sawProviderError` → `abort` — the provider emitted a terminal `error`
+ *     event (HTTP / auth / stream failure) as the session's last turn outcome,
+ *     yet the surface then closed the session cleanly (`dispatchReason` is
+ *     `'close'`/`'reset'`, no abort signal). Without this a provider failure on
+ *     an otherwise-clean close is silently sealed as `model_end_turn`.
+ *  6. a truncation stop reason (`max_tokens` / `length`) on an otherwise clean
  *     close → `truncated` — the model's final turn was cut off by the
  *     output-token ceiling, previously indistinguishable from a clean end.
- *  6. otherwise → `model_end_turn`.
+ *  7. otherwise → `model_end_turn`.
  *
  * `iteration_cap` is intentionally NOT produced here: nothing sets a tool-use
  * loop cap in production yet (`DEFAULT_MAX_TOOL_USE_ITERATIONS = 0`), so it is
@@ -57,6 +62,16 @@ export interface ClosureReasonInputs {
   abort: 'budget_exceeded' | 'timeout' | 'abort' | null;
   /** The provider's last `stop_reason` / `finish_reason`, if any. */
   lastStopReason: string | undefined;
+  /**
+   * True when the provider emitted a terminal `error` event (an HTTP / auth /
+   * stream failure that ended a turn or init without a completed turn) as the
+   * session's most recent turn outcome. Set at the error-observation sites in
+   * `AgentSession` and cleared by a subsequent completed turn, so it reflects
+   * whether the LAST turn ended in an error — not whether any turn ever did.
+   * Surfaces as `abort` so a provider failure on an otherwise-clean close is
+   * not misclassified as `model_end_turn`.
+   */
+  sawProviderError: boolean;
 }
 
 /**
@@ -68,6 +83,7 @@ export function classifyClosureReason(i: ClosureReasonInputs): ClosureReason {
   if (i.hookBlocked) return 'hook_blocked';
   if (i.dispatchReason === 'error') return 'abort';
   if (i.abort !== null) return i.abort;
+  if (i.sawProviderError) return 'abort';
   if (isTruncationStopReason(i.lastStopReason)) return 'truncated';
   return 'model_end_turn';
 }

--- a/src/agent/trace/closure.test.ts
+++ b/src/agent/trace/closure.test.ts
@@ -189,6 +189,61 @@ describe('AgentSession + closure trace event', () => {
     expect(ev.payload.lastStopReason).toBe('end_turn');
   });
 
+  // Regression: a provider `error` event (HTTP / auth / stream failure) that
+  // ends a turn must not be sealed as a silent success. Before the fix, a turn
+  // that errored — then a clean close() — produced closure.reason=model_end_turn
+  // and session_sealed.status=succeeded with 0 turns / 0 tokens / $0 (the exact
+  // signature of witness trace 78a71c64…: a ~36s mimo-v2.5 run sealed succeeded
+  // having produced nothing). See closure-reason.ts precedence rule 5.
+  it('seals failed + reason=abort when a turn ends in a provider error before a clean close', async () => {
+    const session = new AgentSession(config);
+    await session.waitForInitialization();
+
+    const collect = async (gen: AsyncIterable<OutputEvent>): Promise<OutputEvent[]> => {
+      const out: OutputEvent[] = [];
+      for await (const ev of gen) out.push(ev);
+      return out;
+    };
+    // The 'provider-error' marker makes the mock yield a terminal `error`
+    // event with no turn.completed — turnCount stays 0, no usage accrues.
+    const events = await collect(session.sendMessageStream('trigger provider-error'));
+    expect(events.some((e) => e.type === 'error')).toBe(true);
+
+    await session.close();
+
+    const closure = writer.events.find((e) => e.kind === 'closure');
+    if (closure?.kind !== 'closure') throw new Error('expected closure');
+    expect(closure.payload.reason).toBe('abort');
+    expect(closure.payload.finalTurnCount).toBe(0);
+
+    const seal = writer.events.find((e) => e.kind === 'session_sealed');
+    if (seal?.kind !== 'session_sealed') throw new Error('expected session_sealed');
+    expect(seal.payload.status).toBe('failed');
+  });
+
+  it('a successful turn after an errored turn clears the flag — seals succeeded', async () => {
+    const session = new AgentSession(config);
+    await session.waitForInitialization();
+
+    const drain = async (gen: AsyncIterable<OutputEvent>): Promise<void> => {
+      for await (const _ of gen) void _;
+    };
+    await drain(session.sendMessageStream('trigger provider-error'));
+    // A subsequent completed turn must clear the prior error so the seal
+    // reflects the FINAL turn's outcome, not a recovered-from failure.
+    await drain(session.sendMessageStream('recover'));
+
+    await session.close();
+
+    const closure = writer.events.find((e) => e.kind === 'closure');
+    if (closure?.kind !== 'closure') throw new Error('expected closure');
+    expect(closure.payload.reason).toBe('model_end_turn');
+
+    const seal = writer.events.find((e) => e.kind === 'session_sealed');
+    if (seal?.kind !== 'session_sealed') throw new Error('expected session_sealed');
+    expect(seal.payload.status).toBe('succeeded');
+  });
+
   it('is idempotent — repeated close() calls do not write multiple closure records', async () => {
     const session = new AgentSession(config);
     await session.waitForInitialization();


### PR DESCRIPTION
## What happened (witness trace `78a71c64-e05e-4e93-b3fe-b77e5112d429`)

A session ran for ~36s with model `mimo-v2.5`, produced **0 turns / 0 tokens / $0**, then was sealed as **`status: "succeeded"`** with `closure.reason: "model_end_turn"`:

```
seq4 session_phase  session_init_done durationMs=239
seq5 closure        reason=model_end_turn finalTurnCount=0 finalCostUsd=0 finalTokens={}   (~35.8s later)
seq6 session_sealed status=succeeded finalTurnCount=0
```

This is the "silence looks like success" failure mode: the model call failed (HTTP/auth/stream error after 36s), yet the trace recorded a clean success.

## Root cause

The OpenAI-compatible provider correctly emits a terminal `{ type: 'error' }` event on auth/stream/HTTP failure (`src/agent/providers/openai-compatible/query.ts`). But the session harness **never recorded that an error occurred**:

- `sendMessageStreamInternal` (per-turn loop) yielded the `error` OutputEvent and broke the loop — but only `done` events incremented `turnCount`, and nothing flagged the error. (`src/agent/session/agent-session.ts`)
- `pullInitialization` (init phase) did a bare `return` on an `error` event.

So when the surface later called `close()`:
- `deriveSealStatus('close')` → reason is not `'error'`, signal not aborted → **`'succeeded'`**
- `classifyClosureReason(...)` → fell through every guard → **`'model_end_turn'`**

A provider failure left zero trace in the terminal classification.

## Fix

Add a `sawProviderError` terminal-cause flag, following the existing `maxTurnsHit` / `hookBlocked` pattern (set at origin, read by `deriveClosureReason`):

- **Set** at both error-observation sites — `pullInitialization` (init-phase) and `sendMessageStreamInternal` (per-turn).
- **Cleared** by a subsequent completed turn, so it reflects the **final** turn's outcome (a turn that errored and was then retried successfully is *not* sealed failed).
- **Read** by `classifyClosureReason` → `abort` (ranked *below* a classified abort signal, so genuine budget/timeout cancels keep their more-specific status) and `deriveSealStatus` → `failed` (checked *after* the `cancelled` branch, for the same reason).

Net behavior change: a turn that ends in a provider error followed by an otherwise-clean `close()`/`reset()` now seals `failed` / `abort` instead of a silent `succeeded` / `model_end_turn`. **No other path changes** — clean sessions, budget/timeout cancels, hook-blocks, max-turns, and truncation all classify exactly as before.

### Deliberately *not* included (scope)
- **Blanket zero-turn to failed guard.** Rejected: it would false-fail a legitimate empty session (open REPL, quit without typing). The provider-error flag is the precise signal.
- **Warning when an unrecognized model id (`mimo-v2.5`) silently falls through `providerForModel()` routing tiers.** Real, but a separate concern (model misconfiguration vs. error classification) — worth a follow-up.

## Tests
- `closure-reason.test.ts`: 3 unit cases covering the new precedence (provider error → `abort`; abort signal outranks it; it outranks truncation).
- `closure.test.ts`: 2 end-to-end regressions driving a real `AgentSession` — (1) error turn → `close()` seals `failed`/`abort`; (2) error turn then successful turn → seals `succeeded`/`model_end_turn`.
- New `provider-error` marker in the mock provider fixture (mirrors the existing `slow` marker).

Full suite: **9329 passed**, 12 skipped. The single failing `src/cli/config.test.ts` case is **pre-existing on the clean baseline** (test-isolation bug reading the real `~/.afk` config) and unrelated to this diff. `tsc --noEmit` clean.
