### PR TITLE
fix(trace): seal orphaned witness traces on abnormal process exit

### DIFF
--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -386,6 +386,7 @@ export const SessionSealedPayloadSchema = z.object({
   finalCostUsd: z.number().nonnegative(),
   finalTurnCount: z.number().int().nonnegative(),
   closedAt: z.string().datetime(),
+  incomplete: z.boolean().optional(),
   subagentCount: z.number().int().nonnegative().optional(),
   subagentTokens: z
     .object({

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -563,6 +563,18 @@ export interface SessionSealedPayload {
   finalTurnCount: number;
   /** ISO-8601. When known, mirrors the closure event's wall-clock. */
   closedAt: string;
+  /**
+   * True when this seal was written by the synchronous process-exit
+   * backstop ({@link NdjsonTraceWriter}) rather than by a normal
+   * `AgentSession.close()`. Signals that the process exited abnormally —
+   * crash, early-EOF before the REPL's close handler attached, or a
+   * `process.exit()` that bypassed cleanup — so the session never reached
+   * a clean terminal classification. `status` is `'failed'` and the
+   * `final*` counters are last-known-from-the-writer (0 when the session
+   * had no completed turns), NOT a reconstructed total. Omitted on every
+   * normal seal.
+   */
+  incomplete?: boolean;
   /** Number of subagent forks that reached `succeeded` status this session. */
   subagentCount?: number;
   /**

--- a/src/agent/trace/writer.test.ts
+++ b/src/agent/trace/writer.test.ts
@@ -13,7 +13,7 @@
 
 import { mkdtemp, readdir, readFile, rm } from 'fs/promises';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -168,6 +168,101 @@ describe('NdjsonTraceWriter', () => {
     expect(events).toHaveLength(1);
     expect(events.some((e) => e.kind === 'session_sealed')).toBe(false);
   });
+
+  // ---------------------------------------------------------------------------
+  // Process-exit seal backstop: a trace that emitted events but never sealed
+  // (crash / early-EOF / process.exit bypassing close()) must not be orphaned.
+  // ---------------------------------------------------------------------------
+
+  it('sealOnProcessExit() seals an unsealed trace as failed + incomplete', async () => {
+    const writer = new NdjsonTraceWriter({ traceDir });
+    await writer.write({
+      kind: 'session_phase',
+      payload: { phase: 'session_init_done', durationMs: 10 },
+    });
+    // Simulate the synchronous exit-handler path (no close()/seal() ran).
+    writer.sealOnProcessExit();
+
+    const events = await readTrace(writer.getTracePath());
+    const seals = events.filter((e) => e.kind === 'session_sealed');
+    expect(seals).toHaveLength(1);
+    const seal = seals[0];
+    if (seal?.kind !== 'session_sealed') throw new Error('unreachable');
+    expect(seal.payload.status).toBe('failed');
+    expect(seal.payload.incomplete).toBe(true);
+    expect(seal.seq).toBe(1); // continues the monotonic seq after the phase event
+  });
+
+  it('sealOnProcessExit() is a no-op after a normal seal() (no double seal)', async () => {
+    const writer = new NdjsonTraceWriter({ traceDir });
+    await writer.write({
+      kind: 'session_phase',
+      payload: { phase: 'session_init_done', durationMs: 10 },
+    });
+    await writer.seal({
+      status: 'succeeded',
+      finalCostUsd: 0.01,
+      finalTurnCount: 1,
+      closedAt: new Date().toISOString(),
+    });
+    writer.sealOnProcessExit(); // must not append a second seal
+
+    const events = await readTrace(writer.getTracePath());
+    const seals = events.filter((e) => e.kind === 'session_sealed');
+    expect(seals).toHaveLength(1);
+    const seal = seals[0];
+    if (seal?.kind !== 'session_sealed') throw new Error('unreachable');
+    expect(seal.payload.status).toBe('succeeded');
+    expect(seal.payload.incomplete).toBeUndefined();
+  });
+
+  it('sealOnProcessExit() is a no-op when nothing was written (no orphan file)', async () => {
+    const writer = new NdjsonTraceWriter({ traceDir });
+    // Never opened the file — must neither throw nor create a trace.
+    expect(() => writer.sealOnProcessExit()).not.toThrow();
+    await expect(readFile(writer.getTracePath(), 'utf8')).rejects.toThrow();
+  });
+
+  it('process-exit backstop seals a real crashed subprocess (end-to-end wiring)', async () => {
+    const { spawnSync } = await import('node:child_process');
+    const { fileURLToPath } = await import('node:url');
+    const { writeFile: writeFileAsync } = await import('node:fs/promises');
+    const here = dirname(fileURLToPath(import.meta.url));
+    const writerSrc = join(here, 'writer.ts');
+    const tsxBin = join(here, '..', '..', '..', 'node_modules', '.bin', 'tsx');
+
+    // Child: open a writer, write one event (flushed), then throw uncaught.
+    // The throw must escape with no handler so Node fires 'exit' and the
+    // module-level backstop seals the trace synchronously.
+    const childPath = join(traceDir, 'crash-child.mts');
+    await writeFileAsync(
+      childPath,
+      [
+        `import { NdjsonTraceWriter } from ${JSON.stringify(writerSrc)};`,
+        `const w = new NdjsonTraceWriter({ traceDir: process.env.CHILD_TRACE_DIR });`,
+        `await w.write({ kind: 'session_phase', payload: { phase: 'session_init_done', durationMs: 7 } });`,
+        `setTimeout(() => { throw new Error('simulated uncaught crash'); }, 5);`,
+      ].join('\n'),
+      'utf8',
+    );
+
+    const childTraceDir = join(traceDir, 'child-trace');
+    const res = spawnSync(tsxBin, [childPath], {
+      env: { ...process.env, CHILD_TRACE_DIR: childTraceDir },
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+    expect(res.status).toBe(1); // crashed (uncaught exception)
+
+    const events = await readTrace(join(childTraceDir, 'trace.jsonl'));
+    // Phase event landed, then the backstop appended the terminal seal.
+    expect(events.some((e) => e.kind === 'session_phase')).toBe(true);
+    const seal = events.find((e) => e.kind === 'session_sealed');
+    expect(seal).toBeDefined();
+    if (seal?.kind !== 'session_sealed') throw new Error('expected session_sealed');
+    expect(seal.payload.status).toBe('failed');
+    expect(seal.payload.incomplete).toBe(true);
+  }, 35_000);
 
   it('compaction event writes a sidecar with sha256 + size and embeds the reference', async () => {
     const writer = new NdjsonTraceWriter({ traceDir });

--- a/src/agent/trace/writer.ts
+++ b/src/agent/trace/writer.ts
@@ -39,6 +39,7 @@
  */
 
 import { createHash } from 'crypto';
+import { appendFileSync } from 'fs';
 import { mkdir, open, writeFile } from 'fs/promises';
 import type { FileHandle } from 'fs/promises';
 import { join } from 'path';
@@ -96,6 +97,40 @@ export interface NdjsonTraceWriterOptions {
  *     opens the file. This avoids cluttering `~/.afk/state/witness/`
  *     with empty directories for sessions that never emit.
  */
+// ---------------------------------------------------------------------------
+// Synchronous process-exit seal backstop.
+//
+// History: witness traces were frequently left UNSEALED (no `session_sealed`
+// record) whenever the process exited WITHOUT running `AgentSession.close()` —
+// an uncaught exception mid-turn, an early stdin-EOF that raced the REPL's
+// readline 'close' handler before it attached, or a `process.exit()` that
+// bypassed cleanup. A reader cannot distinguish such an orphaned trace from a
+// still-live session, so failures masquerade as "still running" or are simply
+// lost. See docs analysis 2026-06-16 (sibling of the SIGHUP fix).
+//
+// `seal()` is async (appendFile + fsync) and so cannot run from a
+// `process.on('exit')` handler, which must be synchronous. Instead each live
+// NdjsonTraceWriter registers itself here (on first file open) and a single
+// shared exit handler synchronously appends a terminal `session_sealed`
+// record for any writer that emitted events but never sealed. Node fires
+// 'exit' on uncaught exceptions (empirically verified), explicit
+// `process.exit()`, and normal event-loop drain — i.e. every *catchable*
+// termination. SIGKILL is uncatchable and a trace killed that way stays
+// genuinely unsealed (nothing in-process can help).
+// ---------------------------------------------------------------------------
+const liveTraceWriters = new Set<NdjsonTraceWriter>();
+let exitBackstopInstalled = false;
+
+function ensureExitBackstop(): void {
+  if (exitBackstopInstalled) return;
+  exitBackstopInstalled = true;
+  process.on('exit', () => {
+    for (const w of liveTraceWriters) {
+      w.sealOnProcessExit();
+    }
+  });
+}
+
 export class NdjsonTraceWriter implements TraceWriter {
   private readonly traceDir: string;
   private readonly tracePath: string;
@@ -184,13 +219,62 @@ export class NdjsonTraceWriter implements TraceWriter {
     // even across processes (we only have one here, but defense in
     // depth is cheap).
     this.fh = await open(this.tracePath, 'a');
+    // Register with the process-exit backstop now that a real on-disk file
+    // exists: if the process dies before seal() runs, the exit handler
+    // synchronously seals this trace instead of orphaning it.
+    liveTraceWriters.add(this);
+    ensureExitBackstop();
   }
 
   private async closeHandle(): Promise<void> {
+    // De-register from the exit backstop first: a closed/sealed writer must
+    // not be touched by the synchronous exit handler.
+    liveTraceWriters.delete(this);
     if (!this.fh) return;
     const fh = this.fh;
     this.fh = null;
     await fh.close();
+  }
+
+  /**
+   * Synchronous terminal seal for the process-exit backstop — see the
+   * module-level comment above the class. Appends a `session_sealed`
+   * record with `status: 'failed'` and `incomplete: true` iff this writer
+   * emitted at least one event but never sealed. No-op once sealed (the
+   * normal `seal()` already ran) or when nothing was written (no orphaned
+   * file to seal). Runs inside a `process.on('exit')` handler, so it MUST
+   * be fully synchronous and MUST NOT throw.
+   */
+  sealOnProcessExit(): void {
+    if (this.sealed || this.seq === 0) return;
+    this.sealed = true;
+    liveTraceWriters.delete(this);
+    try {
+      const persisted: TraceEvent = {
+        ts: new Date().toISOString(),
+        seq: this.seq++,
+        kind: 'session_sealed',
+        payload: {
+          status: 'failed',
+          finalCostUsd: 0,
+          finalTurnCount: 0,
+          closedAt: new Date().toISOString(),
+          incomplete: true,
+        },
+      };
+      // Synchronous append: the async `fh`/queue cannot be awaited from an
+      // exit handler. O_APPEND keeps this ordered even though the async file
+      // handle may still be open — the OS closes it as the process dies.
+      appendFileSync(this.tracePath, `${JSON.stringify(persisted)}\n`);
+    } catch {
+      /* exit handler: swallow — a broken seal must never block process exit */
+    }
+    // Release the async handle. At a real process exit the OS reclaims it
+    // anyway; doing it here keeps a directly-invoked call (and tests) from
+    // leaking a FileHandle to GC. Fire-and-forget — cannot await in 'exit'.
+    const fh = this.fh;
+    this.fh = null;
+    if (fh) void fh.close().catch(() => {});
   }
 
   private async appendLine(event: TraceEvent): Promise<void> {


### PR DESCRIPTION
## What happened (witness trace `c490bddb-b4fb-4551-89b3-033a09bb28c5`)

A `qwen3.7-plus` REPL session emitted 5 events and then **stopped at `session_init_done`** — no `closure`, no `session_sealed`. The trace is **orphaned/unsealed**: a reader cannot tell whether the session is still running, crashed, or exited.

```
seq3 hook_decision     SessionStart
seq4 session_phase     session_init_done durationMs=224
<EOF — no closure, no session_sealed>
```

This is a **different and worse** failure than #167. #167 fixes a session that *reaches* `close()` but mis-seals (succeeded instead of failed). This one **never reaches `close()`**, so no terminal record is written at all.

## This is systemic, not model-specific

A survey of recent witness traces found unsealed traces are common and happen with **valid models (`opus_1m`) too**, terminating at every lifecycle stage: `bootstrap_done`, `session_init_done`, `model_ttfb`, `tool_call started`. The common factor is the **process exiting without running `AgentSession.close()`** (which is what writes the seal).

## Root cause

The seal is written by `AgentSession.close()` → `dispatchSessionEndOnce()` → `writer.seal()`. The interactive REPL only reaches `close()` via `ctx.rl.on('close')` or its SIGINT/SIGTERM/SIGHUP handlers (`src/cli/commands/interactive.ts`). Several exit routes bypass all of them:

- **Uncaught exception / unhandled rejection mid-turn** — the REPL has no process-level crash handler (only the daemon does, and even that just pushes Telegram + `process.exit(1)` — it does **not** seal).
- **Early stdin-EOF race** — if `rl` emits `'close'` before its seal handler is attached (~`interactive.ts:712`, after an `await initTranscript()`), the seal callback never registers. Reproducible with piped input.
- **Any `process.exit()` that skips cleanup.**

`SIGKILL` is uncatchable and out of scope.

## Fix — synchronous process-exit seal backstop

A single, surface-agnostic backstop in `NdjsonTraceWriter`:

- Each writer registers itself when its trace file is first opened; a **single shared `process.on('exit')` handler** synchronously appends a terminal `session_sealed { status: 'failed', incomplete: true }` for any writer that emitted events but never sealed.
- `seal()` is async (`appendFile` + `fsync`) and can't run in an exit handler, so the backstop uses `appendFileSync`.
- **Node fires `'exit'` on uncaught exceptions (empirically verified in this work), explicit `process.exit()`, and event-loop drain** — every *catchable* termination. The backstop therefore covers the crash gap, the EOF race, and stray `process.exit()` uniformly, in one place.
- The normal `close()` path `await`s `seal()` **before** `process.exit`, so the backstop cleanly **skips already-sealed traces** (no double seal). It also no-ops when nothing was written (no orphan file).

New optional **`incomplete`** flag on `SessionSealedPayload` (type + Zod schema) marks a backstop-written seal so readers can distinguish it from a normally-classified seal. The `final*` counters are `0` — the writer cannot reconstruct session totals from an exit handler; the `incomplete: true` marker says so explicitly.

### Result for the reported trace
`c490bddb` would now end with `session_sealed { status: 'failed', incomplete: true }` instead of dangling at `session_init_done` — a clear "this session terminated abnormally without completing" signal.

## Tests
- `writer.test.ts`: 3 unit cases — backstop writes `failed` + `incomplete`; no-op after a normal `seal()`; no-op when nothing was written.
- **Real subprocess crash test**: spawns a node process (via `tsx`) that writes one event then throws uncaught, and asserts the on-disk trace is sealed `incomplete: true` end-to-end — proving the `process.on('exit')` wiring.

`tsc --noEmit` clean. `src/agent/trace/` + `src/agent/session/` suites: **335 passed**.

## Scope notes
- This PR addresses the **observability** defect (orphaned traces). It does **not** add REPL `uncaughtException` handlers or fix the `rl.on('close')` registration race — the backstop makes both non-fatal for sealing, and they're worth a separate hardening pass.
- Separately, an unrecognized model id like `qwen3.7-plus` falls through `providerForModel()` routing to `anthropic-direct` with no warning (no `AFK_OPENAI_BASE_URL` set). That misconfiguration-silence is a distinct follow-up (also noted on #167).

Related: #167.
