### PR TITLE
fix(openai-compatible): crash on null-content tool-call turns (non-vision models)

### DIFF
--- a/src/agent/providers/openai-compatible/messages.test.ts
+++ b/src/agent/providers/openai-compatible/messages.test.ts
@@ -225,4 +225,47 @@ describe('buildMessages', () => {
     });
     expect(m[0]!.content).toEqual(parts);
   });
+
+  // Regression: a tool-only assistant turn carries `content: null` (see
+  // loop.ts:assistantMessageWithToolCalls). On a non-vision model the
+  // down-convert map used to send that null into flattenOpenAIParts, whose
+  // `for…of` threw "X is not iterable" and crashed the second iteration of
+  // every tool-using turn. null/string content must pass through untouched;
+  // only array (multimodal) content is flattened.
+  it('does not crash on null content (tool-call assistant turn) under vision:false', () => {
+    // `content: null` is the real tool-call assistant shape; the type omits
+    // null (production casts via `as unknown as OpenAIMessage`), so cast here.
+    const toolCallTurn = {
+      role: 'assistant',
+      content: null,
+      tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'read_file', arguments: '{}' } }],
+    } as never;
+    const parts: OpenAIContentPart[] = [
+      { type: 'text', text: 'look' },
+      { type: 'image_url', image_url: { url: 'data:image/png;base64,xx' } },
+    ];
+    let m!: ReturnType<typeof buildMessages>;
+    expect(() => {
+      m = buildMessages({
+        config: baseConfig(),
+        priorTurns: [
+          toolCallTurn,
+          { role: 'tool', content: 'file contents', tool_call_id: 'call_1' },
+          { role: 'assistant', content: parts }, // array → still flattened
+        ],
+        currentUserText: 'continue',
+        vision: false,
+      });
+    }).not.toThrow();
+    // null content preserved untouched (OpenAI requires null on tool-call turns).
+    expect(m[0]!.content).toBeNull();
+    expect((m[0] as { tool_calls?: unknown[] }).tool_calls).toHaveLength(1);
+    // tool-result string preserved.
+    expect(m[1]!.content).toBe('file contents');
+    // array (multimodal) content still down-converted to text.
+    expect(typeof m[2]!.content).toBe('string');
+    expect(m[2]!.content).toMatch(/cannot view images/i);
+    // current user turn intact.
+    expect(m[3]).toEqual({ role: 'user', content: 'continue' });
+  });
 });

--- a/src/agent/providers/openai-compatible/messages.ts
+++ b/src/agent/providers/openai-compatible/messages.ts
@@ -246,8 +246,22 @@ export function buildMessages(args: {
   }
 
   if (args.vision === false) {
+    // Only ARRAY content (the multimodal vision shape: text + image_url parts)
+    // needs down-converting to text for a non-vision endpoint. String content
+    // is already text, and `null` content — which an assistant tool-call turn
+    // legitimately carries (see `assistantMessageWithToolCalls`, whose
+    // `content` is `null` on a tool-only turn) — must pass through untouched.
+    //
+    // Regression: the previous `typeof m.content === 'string' ? m : …` guard
+    // sent that `null` into `flattenOpenAIParts`, whose `for (const part of
+    // content)` threw `TypeError: <x> is not iterable` and crashed the SECOND
+    // iteration of every tool-using turn on a non-vision model (the model's
+    // tool-only assistant turn lands in `priorTurns` with `content: null`,
+    // then the next request rebuild hits this map). `OpenAIMessage.content`'s
+    // type omits `null`, so the `as unknown as OpenAIMessage` casts at the
+    // priorTurns push sites hid the gap from the compiler.
     return messages.map((m) =>
-      typeof m.content === 'string' ? m : { ...m, content: flattenOpenAIParts(m.content) },
+      Array.isArray(m.content) ? { ...m, content: flattenOpenAIParts(m.content) } : m,
     );
   }
 


### PR DESCRIPTION
## The actual error

```
TypeError: e is not iterable
    at Hj  (cli.mjs)                     ← flattenOpenAIParts: `for (const part of content)`
    at <arrow>                           ← buildMessages map callback
    at Array.map (<anonymous>)
    at Mk  (cli.mjs)                     ← buildMessages
    at Vc.runIteration → runTurn → [Symbol.asyncIterator]   ← OpenAICompatibleQuery
```

This uncaught `TypeError` in the **OpenAI-compatible provider** is what crashes the turn. It's the root cause behind the orphaned witness trace in #168 (the trace dies mid-turn and never seals) — the *disease*; #167 and #168 are defense-in-depth that make such failures observable.

## Root cause

A tool-only assistant turn is recorded with **`content: null`** — OpenAI's required shape for a tool-call message (`loop.ts` `assistantMessageWithToolCalls`: `content: accumulatedText.length > 0 ? accumulatedText : null`). It's pushed to `priorTurns`. On the **next** `runIteration`, `buildMessages` rebuilds the request and, for a **non-vision** model (`vision === false`), ran:

```ts
messages.map((m) =>
  typeof m.content === 'string' ? m : { ...m, content: flattenOpenAIParts(m.content) })
```

`null` is not a string → it called `flattenOpenAIParts(null)`, whose `for (const part of content)` throws on a non-iterable → `TypeError: ... is not iterable`.

Why it was invisible to the compiler: `OpenAIMessage.content` is typed `string | OpenAIContentPart[]` (no `null`), and the `priorTurns` push sites cast via `as unknown as OpenAIMessage`, hiding the real `null` shape.

### Why "I keep getting it"
Only the **non-vision** path is affected — the vision path returns messages untouched. So:
- Vision models (gpt-4o, Claude) → never hit it.
- **Local / text-only OpenAI-compatible models that use tools** → hit it on the **second iteration of every tool-using turn** (the first tool-only assistant turn lands in history with `content: null`, then the next request rebuild crashes).

That's the exact profile of the reported sessions (local model + tool calls like `read_file`).

## Fix

Down-convert **only array** (multimodal) content; pass `string` and `null` through untouched:

```ts
messages.map((m) =>
  Array.isArray(m.content) ? { ...m, content: flattenOpenAIParts(m.content) } : m)
```

- **array** → the only shape that can carry image parts needing flattening for a non-vision endpoint (the original intent).
- **string** → already text, pass through.
- **null** → the tool-call-turn marker OpenAI requires; must survive verbatim.

One-line behavioral change; the existing "down-converts image parts when non-vision" test still passes (array path unchanged).

## Test

New regression in `messages.test.ts`: `buildMessages({ vision: false })` with history = `[ tool-call assistant (content: null), tool result (string), assistant (image array), user text ]` — no longer throws, **preserves the `null`** and its `tool_calls`, preserves the tool-result string, and **still flattens the image array** to the graceful text notice.

`tsc --noEmit` clean. Full `src/agent/providers/openai-compatible/` suite: **186 passed**.

## Relationship to #167 / #168
This is the **root crash**. #168 seals the orphaned trace this crash produced (observability backstop); #167 fixes the complementary close-path mis-seal. All three are independent (different files) and can merge in any order.
