### PR TITLE
fix(plan-mode): enforce write-tool gate (config.hookRegistry was dropped by the dispatcher)

### DIFF
--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -300,6 +300,16 @@ export class AnthropicDirectProvider implements ModelProvider {
        * `get_runtime_state` against a dispatcher built without a source.
        */
       runtimeStateSource?: RuntimeStateSource;
+      /**
+       * Session-scoped hook registry sourced from `AgentConfig.hookRegistry`.
+       * Threaded here so `PreToolUse`/`PostToolUse` hooks (notably the
+       * plan-mode gate) fire on the per-query dispatcher. Production entry
+       * points construct the provider WITHOUT a constructor-time
+       * `hookRegistry` and supply the session registry on the query config
+       * instead, so falling back to `this.hookRegistry` when this is unset
+       * preserves any constructor-provided registry.
+       */
+      hookRegistry?: import('../../hooks.js').HookRegistry;
     },
   ): SessionToolDispatcher {
     const handlers = createBuiltinHandlers(permissionMode, opts?.cwd);
@@ -342,7 +352,12 @@ export class AnthropicDirectProvider implements ModelProvider {
       // Constraint (semantic invariant): MCP schemas appended AFTER builtins
       // so builtin tool names always take precedence in any overlap.
       schemas: [...this.schemas, ...mcpSchemas],
-      hookRegistry: this.hookRegistry,
+      // Prefer the session-scoped registry from the query config (the
+      // production path — see the opts.hookRegistry doc above); fall back to
+      // any constructor-provided registry. Without this, the plan-mode gate
+      // (the sole built-in PreToolUse hook) never reached the dispatcher and
+      // write tools ran unblocked in plan mode.
+      hookRegistry: opts?.hookRegistry ?? this.hookRegistry,
       // Union live MCP wire-names into the (statically-snapshotted) allowlist so
       // OAuth servers whose tools were discovered after construction are not
       // rejected by the gate while present in `schemas`/`handlers`. No-op when
@@ -632,6 +647,7 @@ export class AnthropicDirectProvider implements ModelProvider {
           parentSessionId: config.parentSessionId,
           traceWriter: config.traceWriter,
           runtimeStateSource,
+          hookRegistry: config.hookRegistry,
         });
 
     // External-dispatcher branch: the caller owns routing for whatever tools
@@ -839,6 +855,7 @@ export class AnthropicDirectProvider implements ModelProvider {
             parentSessionId: config.parentSessionId,
             traceWriter: config.traceWriter,
             runtimeStateSource,
+            hookRegistry: config.hookRegistry,
           });
           return { userSystem: newUserSystem, dispatcher: newDispatcher };
         };

--- a/src/agent/providers/anthropic-direct/plan-mode-gate-wiring.test.ts
+++ b/src/agent/providers/anthropic-direct/plan-mode-gate-wiring.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Regression test for plan-mode GATE wiring (the enforcement half).
+ *
+ * `plan-mode-system-payload.test.ts` covers the POSTURE half — the system
+ * prompt addendum the model sees. This file covers the ENFORCEMENT half: when
+ * a session is in `'plan'` permission mode, a write-class tool such as
+ * `edit_file` must be REFUSED by the plan-mode gate before its handler runs.
+ *
+ * The gate is a `PreToolUse` hook. It reaches the per-query
+ * `SessionToolDispatcher` only if the provider threads the session's hook
+ * registry into the dispatcher. Production entry points (REPL/chat/daemon/
+ * telegram) construct the provider WITHOUT a constructor-time `hookRegistry`
+ * and instead pass the session-scoped registry on `AgentConfig.hookRegistry`
+ * (consumed by `provider.query({ config })`). This test mirrors that exact
+ * shape — `new AnthropicDirectProvider()` (no constructor registry) + a
+ * registry supplied on the query config — so a regression that drops
+ * `config.hookRegistry` on the dispatcher path is caught here.
+ *
+ * Observation point: the `tool.output` ProviderEvent. A gate block surfaces as
+ * `isError: true` with a "plan mode … refused" / "blocked by PreToolUse hook"
+ * message; an un-gated call instead runs the real `edit_file` handler.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { RawMessageStreamEvent } from '@anthropic-ai/sdk/resources';
+import type { ProviderEvent } from '../provider.js';
+import { AnthropicDirectProvider, __setAnthropicClientFactory } from './index.js';
+import { createHookRegistry, type HookRegistry } from '../../hooks.js';
+import { createPlanModeGate } from '../../plan-mode-gate.js';
+
+// --- Mock Anthropic Messages-API plumbing (mirrors plan-mode-system-payload.test.ts) ---
+
+const messagesCreateMock = vi.fn();
+
+class MockAnthropic {
+  public messages: { create: typeof messagesCreateMock };
+  constructor() {
+    this.messages = { create: messagesCreateMock };
+  }
+}
+
+function installFactory(): void {
+  __setAnthropicClientFactory(() => new MockAnthropic() as unknown as Anthropic);
+}
+
+async function* singleInput(content: string): AsyncIterable<{ content: string }> {
+  yield { content };
+}
+
+async function* fromArray<T>(arr: T[]): AsyncIterable<T> {
+  for (const x of arr) yield x;
+}
+
+async function collect(query: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  for await (const ev of query) out.push(ev);
+  return out;
+}
+
+function makeToolUseStream(
+  toolId: string,
+  toolName: string,
+  inputJson: string,
+): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_t',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-4-5-20250929',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 7,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'tool_use', id: toolId, name: toolName, input: {} },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: inputJson },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'tool_use', stop_sequence: null },
+      usage: { output_tokens: 9 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+function makeTextStream(text: string): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_done',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-4-5-20250929',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 5,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '', citations: [] },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 4 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+/** Registry carrying ONLY the plan-mode gate, in the requested mode. */
+function planGateRegistry(mode: 'plan' | 'default'): HookRegistry {
+  const registry = createHookRegistry();
+  registry.register('PreToolUse', createPlanModeGate(() => mode));
+  return registry;
+}
+
+const EDIT_FILE_INPUT = JSON.stringify({
+  file_path: '/tmp/afk-plan-mode-gate-wiring-nonexistent.txt',
+  old_string: 'a',
+  new_string: 'b',
+});
+
+function toolOutputOf(events: ProviderEvent[]): { content: string; isError?: boolean } {
+  const ev = events.find((e) => e.type === 'tool.output');
+  if (!ev || ev.type !== 'tool.output') {
+    throw new Error('expected a tool.output event');
+  }
+  return { content: ev.content, ...(ev.isError !== undefined ? { isError: ev.isError } : {}) };
+}
+
+describe('AnthropicDirectProvider — plan-mode gate reaches the dispatcher via config.hookRegistry', () => {
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    installFactory();
+    let callIdx = 0;
+    messagesCreateMock.mockImplementation(() => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        return fromArray(makeToolUseStream('toolu_edit', 'edit_file', EDIT_FILE_INPUT));
+      }
+      return fromArray(makeTextStream('done'));
+    });
+  });
+
+  it('BLOCKS edit_file for a top-level session in plan mode', async () => {
+    // Provider constructed WITHOUT a hookRegistry — exactly how bootstrap.ts,
+    // chat.ts, daemon.ts, and telegram.ts build it. The gate must still fire
+    // because the session-scoped registry is supplied on the query config.
+    const provider = new AnthropicDirectProvider({
+      permissions: { allowedTools: ['edit_file'] },
+    });
+    const query = provider.query({
+      prompt: singleInput('edit the file'),
+      config: {
+        model: 'claude-sonnet-4-5-20250929',
+        apiKey: 'sk-ant-oat01-test',
+        permissionMode: 'plan',
+        hookRegistry: planGateRegistry('plan'),
+      },
+    });
+
+    const events = await collect(query);
+    const out = toolOutputOf(events);
+
+    expect(out.isError).toBe(true);
+    expect(out.content).toContain('plan mode');
+    expect(out.content).toContain('edit_file');
+  });
+
+  it('does NOT block edit_file for a forked subagent in plan mode (parentSessionId self-skip)', async () => {
+    // A subagent inherits the parent registry but its tool calls are task
+    // output, not main-conversation mutations — the gate self-skips when
+    // parentSessionId is set. This guards against the fix over-blocking.
+    const provider = new AnthropicDirectProvider({
+      permissions: { allowedTools: ['edit_file'] },
+    });
+    const query = provider.query({
+      prompt: singleInput('edit the file'),
+      config: {
+        model: 'claude-sonnet-4-5-20250929',
+        apiKey: 'sk-ant-oat01-test',
+        permissionMode: 'plan',
+        parentSessionId: 'parent-session-123',
+        hookRegistry: planGateRegistry('plan'),
+      },
+    });
+
+    const events = await collect(query);
+    const out = toolOutputOf(events);
+
+    // The gate did not fire — whatever the handler returned, it is NOT the
+    // plan-mode refusal.
+    expect(out.content).not.toContain('plan mode');
+    expect(out.content).not.toContain('blocked by PreToolUse hook');
+  });
+
+  it('does NOT block edit_file when the session is in default mode', async () => {
+    const provider = new AnthropicDirectProvider({
+      permissions: { allowedTools: ['edit_file'] },
+    });
+    const query = provider.query({
+      prompt: singleInput('edit the file'),
+      config: {
+        model: 'claude-sonnet-4-5-20250929',
+        apiKey: 'sk-ant-oat01-test',
+        permissionMode: 'default',
+        hookRegistry: planGateRegistry('default'),
+      },
+    });
+
+    const events = await collect(query);
+    const out = toolOutputOf(events);
+
+    expect(out.content).not.toContain('plan mode');
+    expect(out.content).not.toContain('blocked by PreToolUse hook');
+  });
+});

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -205,6 +205,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
           runtimeStateSource,
           ...(config.isSkillDispatch ? { isSkillDispatch: true } : {}),
           ...(config.isNonInteractive ? { isNonInteractive: true } : {}),
+          ...(config.hookRegistry !== undefined ? { hookRegistry: config.hookRegistry } : {}),
         });
 
     const buildOpts: {
@@ -297,6 +298,13 @@ export class OpenAICompatibleProvider implements ModelProvider {
        * toolDefs filter in AnthropicDirectProvider.
        */
       isNonInteractive?: boolean;
+      /**
+       * Session-scoped hook registry from `AgentConfig.hookRegistry`. Threaded
+       * here so `PreToolUse`/`PostToolUse` hooks (notably the plan-mode gate)
+       * fire on the per-query dispatcher. Falls back to the constructor-time
+       * `providerOpts.hookRegistry` when unset. Mirrors AnthropicDirectProvider.
+       */
+      hookRegistry?: import('../../hooks.js').HookRegistry;
     },
   ): SessionToolDispatcher {
     const handlers = createBuiltinHandlers(permissionMode, opts.cwd);
@@ -343,8 +351,13 @@ export class OpenAICompatibleProvider implements ModelProvider {
       // so builtin tool names always take precedence in any overlap.
       schemas: [...baseSchemas, ...mcpSchemas],
     };
-    if (this.providerOpts.hookRegistry !== undefined)
-      dispatcherOpts.hookRegistry = this.providerOpts.hookRegistry;
+    // Prefer the session-scoped registry from the query config (production
+    // path); fall back to any constructor-provided registry. Without this the
+    // plan-mode gate (the sole built-in PreToolUse hook) never reached the
+    // dispatcher and write tools ran unblocked in plan mode.
+    const effectiveHookRegistry = opts.hookRegistry ?? this.providerOpts.hookRegistry;
+    if (effectiveHookRegistry !== undefined)
+      dispatcherOpts.hookRegistry = effectiveHookRegistry;
     // Union live MCP wire-names into the (statically-snapshotted) allowlist so
     // OAuth servers whose tools were discovered after construction are not
     // rejected by the gate while present in `schemas`/`handlers`. No-op when no

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -22,7 +22,8 @@ import {
 import { OpenAICompatibleProvider } from './index.js';
 import type { OpenAIChunk } from './translate.js';
 import { SessionToolDispatcher } from '../../tools/dispatcher.js';
-import { createHookRegistry } from '../../hooks.js';
+import { createHookRegistry, type HookRegistry } from '../../hooks.js';
+import { createPlanModeGate } from '../../plan-mode-gate.js';
 import type { AnthropicToolDef } from '../anthropic-direct/types.js';
 import type { ToolHandler } from '../../tools/types.js';
 import { PLAN_MODE_ADDENDUM_TEXT } from '../anthropic-direct/plan-mode-addendum.js';
@@ -311,6 +312,105 @@ describe('OpenAICompatibleProvider — readOnlyMemory option', () => {
     if (out?.type === 'tool.output') {
       expect(out.isError).toBe(true);
       expect(out.content).toMatch(/unknown tool|not permitted|not allowed|permission|allowlist/i);
+    }
+  });
+});
+
+describe('OpenAICompatibleProvider — plan-mode gate via config.hookRegistry', () => {
+  // Mirrors the anthropic-direct gate-wiring regression: a provider built
+  // WITHOUT a constructor-time hookRegistry (production shape) must still
+  // honor the plan-mode gate when the session registry arrives on the query
+  // config. Before the fix, `config.hookRegistry` was dropped on the internal
+  // dispatcher path and write tools ran unblocked in plan mode.
+  const EDIT_FILE_ARGS = JSON.stringify({
+    file_path: '/tmp/afk-openai-plan-gate-nonexistent.txt',
+    old_string: 'a',
+    new_string: 'b',
+  });
+
+  function scriptEditFileThenDone(): void {
+    installScriptedClient();
+    scriptedTurns = [
+      {
+        chunks: [
+          {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'call_edit',
+                      type: 'function',
+                      function: { name: 'edit_file', arguments: EDIT_FILE_ARGS },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+            usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+          },
+        ],
+      },
+      {
+        chunks: [
+          {
+            choices: [{ delta: { content: 'done' }, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 10, completion_tokens: 1, total_tokens: 11 },
+          },
+        ],
+      },
+    ];
+  }
+
+  function planGateRegistry(mode: 'plan' | 'default'): HookRegistry {
+    const registry = createHookRegistry();
+    registry.register('PreToolUse', createPlanModeGate(() => mode));
+    return registry;
+  }
+
+  it('BLOCKS edit_file for a top-level session in plan mode', async () => {
+    scriptEditFileThenDone();
+    const provider = new OpenAICompatibleProvider({
+      permissions: { allowedTools: ['edit_file'] },
+    });
+    const q = provider.query({
+      prompt: singleInput('edit the file'),
+      config: baseConfig({ permissionMode: 'plan', hookRegistry: planGateRegistry('plan') }),
+    });
+    const events = await collect(q);
+
+    const out = events.find((e) => e.type === 'tool.output');
+    expect(out?.type).toBe('tool.output');
+    if (out?.type === 'tool.output') {
+      expect(out.isError).toBe(true);
+      expect(out.content).toContain('plan mode');
+    }
+  });
+
+  it('does NOT block edit_file for a forked subagent in plan mode (parentSessionId self-skip)', async () => {
+    scriptEditFileThenDone();
+    const provider = new OpenAICompatibleProvider({
+      permissions: { allowedTools: ['edit_file'] },
+    });
+    const q = provider.query({
+      prompt: singleInput('edit the file'),
+      config: baseConfig({
+        permissionMode: 'plan',
+        parentSessionId: 'parent-session-123',
+        hookRegistry: planGateRegistry('plan'),
+      }),
+    });
+    const events = await collect(q);
+
+    const out = events.find((e) => e.type === 'tool.output');
+    expect(out?.type).toBe('tool.output');
+    if (out?.type === 'tool.output') {
+      expect(out.content).not.toContain('plan mode');
+      expect(out.content).not.toContain('blocked by PreToolUse hook');
     }
   });
 });


### PR DESCRIPTION
## Ported from private — afk-workshop#706

**Source:** afk-workshop#706 — `fix(plan-mode): enforce write-tool gate (config.hookRegistry was dropped by the dispatcher)`. Moat-scrubbed port via **diff + 3-way apply** (the repos share no history), not a 1:1 commit copy.

### What this fixes
In REPL **plan mode**, write tools (`edit_file`, `write_file`, write-intent `bash`) ran **unblocked**. The plan-mode gate is the only built-in `PreToolUse` hook; it is dispatched by the provider's per-query `SessionToolDispatcher`, which was built from the provider's **constructor-time** `this.hookRegistry` (always `undefined` in production) and **ignored `config.hookRegistry`** — the session-scoped field `AgentSession` actually populates. So the gate never reached the dispatcher and writes ran unblocked in plan mode. Session-lifecycle hooks (SessionStart/End/SubagentStop, e.g. the memory writer) were unaffected — they dispatch from a separate path.

### Fix
Thread `config.hookRegistry` into `buildDispatcher` in **both** providers, preferring it over any constructor-time registry:
- `AnthropicDirectProvider`: `hookRegistry: opts?.hookRegistry ?? this.hookRegistry` (threaded from both dispatcher-build sites — initial + the `setCwd` rebuild closure).
- `OpenAICompatibleProvider`: `effectiveHookRegistry = opts.hookRegistry ?? this.providerOpts.hookRegistry`.

**Subagents are unaffected:** `forkSubagent` sets `parentSessionId` on the child config and the gate self-skips when present, so a subagent's own writes (incl. to its worktree) are not gated.

### Ported (all PUBLIC-SAFE)
- `src/agent/providers/anthropic-direct/index.ts`
- `src/agent/providers/anthropic-direct/plan-mode-gate-wiring.test.ts` *(new)*
- `src/agent/providers/openai-compatible/index.ts`
- `src/agent/providers/openai-compatible/query.test.ts`

`+391 / -4` — matches the source PR.

### Dropped
**None.** All four files were PUBLIC-SAFE; no moat files or hunks existed in the source PR.

### Conflict-resolution note (public had drifted ahead of the private patch base)
The two `index.ts` files conflicted on 3-way apply because public carries logic the private base lacked. Resolved by **applying the fix while preserving public-only logic**:
- Public's `isNonInteractive` support (call-site spread + `opts` type field) — **kept**.
- Public's MCP wire-name allowlist union (`withMcpToolsAllowed(...)`) on `permissions` — **kept**.

The resulting `git diff` vs public `HEAD` is exactly the fix's `hookRegistry` plumbing; no public functionality was removed.

### Verification
- `pnpm lint` (strict `tsc --noEmit`): **clean**.
- Ported regression tests: **40/40 pass** — `plan-mode-gate-wiring.test.ts` (3) + the `plan-mode gate via config.hookRegistry` block in `query.test.ts`. Each covers: top-level session **blocked**, forked subagent **not blocked** (`parentSessionId` self-skip), default mode **not blocked** (anthropic).
- Full suite: **9335 pass / 12 skip / 1 fail**. The single failure (`src/cli/config.test.ts` -> "defaults to the built-in tier bindings when no models block is present") is **proven pre-existing**: it reproduces identically on pristine public `HEAD` with zero port changes (env-dependent test isolation — reads the host's real `~/.afk` config). Not a regression.
- `pnpm build` + `pnpm build:dist`: clean. `pnpm fix:pins:check`: all hash pins up to date.
- **Moat safety:** deterministic tree+`dist/` guard -> `MOAT GUARD CLEAN`; independent adversarial audit -> `MOAT-CLEAN`.

**Do not merge automatically — left for human review.**
