### PR TITLE
fix(tui): keep multi-line blocks visible (band-hold) when committed under a tall overlay

### DIFF
--- a/docs/scrollback.md
+++ b/docs/scrollback.md
@@ -401,7 +401,129 @@ massive gap. (b) When content scrolled into scrollback during a tall phase and
 the frame later collapses, the bottom-anchored band can sit below the
 scrolled-off content with blank viewport rows between them. That live-viewport
 "boundary gap" is the bottom-anchored-frame design tension (the frame does not
-float up to meet sparse content) and is a separate, larger item.
+float up to meet sparse content) and is a separate, larger item — but see the
+band-hold fix below, which closes the most common manifestation.
+
+### Fixed: multi-line block committed under a tall overlay (the overflow path)
+
+**Symptom.** During a long turn (a tall "thought"/tool overlay up), the streamed
+"Done" report committed a markdown TABLE via `commitAbove`. The table rendered
+its header + `├──┼──┤` divider, then a large blank VOID swallowed the body rows,
+and later content (Evidence) resumed far below — and the table was DUPLICATED (a
+full copy in scrollback plus a truncated on-screen copy) with an orphan divider.
+The prose committed just before the table (`Diagnosis complete`, `What I
+diagnosed`) VANISHED entirely.
+
+**Root cause.** The `!fitsAboveFrame` OVERFLOW path (the one #645 left unchanged)
+fired whenever a block was taller than the room above the *current* frame —
+which, under a tall overlay, is only a few rows. That path was written for blocks
+genuinely taller than the SCREEN: it CUP-wrote the whole block at the anchor
+floor (clobbering the prior committed band) and scrolled the entire block into
+scrollback (Phase 1), then painted a truncated on-screen copy (Phase 3). So a
+10-line table committed under a 14-line overlay — which fits fine once the
+overlay collapses — was wrongly archived + truncated + the prior band was lost.
+
+**The fix (band-hold).** A block that overflows the *current* tall frame but fits
+the *collapsed* screen now takes a band-hold path instead of the archive path:
+the full committed run (prior band + new block) is kept in the `committedBand`
+MODEL, capped at `maxBandModel` (the rows that can ever show above a minimal
+frame). Only the bottom `room` lines that fit above the current frame are
+painted; the rest are "pending" — present in the model, not on screen, not in
+scrollback. Nothing is scrolled. When the overlay collapses, the existing
+`repositionCommittedBand()` (which keys off `committedBand.length`, not the
+painted span) materializes the WHOLE run contiguously adjacent to the frame.
+Once pending lines exist, subsequent commits route through band-hold too, so the
+fits-path's room-based `bandOverflow` never scrolls the unpainted rows as blanks.
+A block taller than `maxBandModel` committed with NO pending rows is genuinely
+off-screen and keeps the legacy archive path; the fits path and its exact scroll
+mechanics are untouched (the routing is additive). But once pending rows already
+exist — a streamed table/report grown past `maxBandModel` under a *sustained*
+tall overlay — the commit STAYS on band-hold even though the run now exceeds
+`maxBandModel` (review #649 P1). Routing such a commit to the fits path instead
+would emit room-based line-feeds that scroll the unpainted pending rows into
+scrollback as BLANKS while Phase 3's cap drops the real rows — losing most of the
+report. Band-hold Phase 1 instead archives the genuine overflow (the oldest rows
+beyond what the collapsed screen can hold, chunked by screen height so a run
+taller than the terminal still archives every row) to scrollback as REAL content,
+disjoint from the suffix Phase 3 keeps — no blanks, no drops, no duplicates. Under
+a transient overlay GROWTH between the commit and the collapse, evict-on-growth
+materializes + scrolls the band's overflow as real, contiguous content — so
+band-hold degrades gracefully to contiguous scrollback, never to the
+duplicate/void corruption.
+
+**Regression test.** `src/cli/terminal-compositor.overflow-gap.test.ts` commits a
+rendered markdown table under a 14-line overlay at `extraRows=2`, collapses, and
+asserts (via `@xterm/headless`): the table header appears exactly once, the whole
+table + surrounding prose are VISIBLE and intact in the viewport, there is no
+>=2-row blank void, and the run hugs the frame. It fails on the pre-fix code
+(header found twice + 14-row void) and passes after. A second case in the same
+file streams a multi-block report under a *sustained* 17-line overlay until the
+band-hold model fills `maxBandModel`, commits one more block (run →
+`maxBandModel`+2), collapses, and asserts every committed row is present exactly
+once across scrollback + viewport — covering the pending-row loss of review #649
+P1 (on the pre-fix code the oldest row is dropped entirely).
+
+### Fixed: lost table under a *full-viewport* overlay + the wrap-blind overlap (review #649 follow-ups)
+
+**Symptom.** A `/review` streamed a markdown TABLE under a tall subagent-tree
+overlay: the table rendered its header + `├──┼──┤` divider, then the body rows
+VANISHED, and the next section resumed below — even on the band-hold fix above.
+Separately and intermittently, a new `commitAbove` block "ate" the bottom line
+of the *previously* committed block. Three distinct defects, surfaced together.
+
+**1. Commit-time overlay sync (the trigger — `markdown-stream.ts`).**
+`StreamingMarkdownRenderer.push()` commits a completed block via `commitAbove`
+while the throttled (33 ms) overlay repaint has NOT yet re-rendered — so the
+`markdown-pending` overlay slot still shows the just-committed block. That stale,
+too-tall overlay pins the live frame to row 1 (`prevTopRow == 1`) at the exact
+moment of commit. Fix: `syncPendingOverlay()` re-composes the overlay from the
+post-slice buffer BEFORE `commitAbove` runs (mirroring what `flush()` already did
+via the `flushing` flag). With the block removed from the overlay first, the
+frame is no longer pinned to the top and the commit takes the normal band-hold
+path. **This is the load-bearing fix**; (2) and (3) are defense-in-depth.
+
+**2. Band-hold storage at `prevTopRow <= 1` (`commitAbove`).** If the overlay DOES
+still fill the viewport at commit time, the old code dropped the block:
+`useBandHold` was gated on `prevTopRow > 1`, and Phase 3's `if (newTopRow > 1)`
+guard fell through to `clearCommittedBand()` — losing the block from screen AND
+scrollback (the BLOCKER-1 comment documented exactly this and noted "no test hits
+prevTopRow <= 1"). Fix: band-hold ROUTING is decoupled from `prevTopRow > 1` (a
+block that fits the collapsed screen is HELD, not archived), and a Phase-3
+`newTopRow <= 1` branch stores the model FULLY PENDING with
+`committedBandBottomRow = collapsedFrameTop - 1`. `repositionCommittedBand()`
+paints it on collapse; the non-zero bottom row lets consecutive full-viewport
+commits MERGE (same geometry) so a multi-block report accumulates instead of
+keeping only the last block. `fitsAboveFrame` keeps its OWN `prevTopRow > 1`
+guard — the single-copy fits path genuinely needs a known frame top.
+
+**3. Wrap-aware line counting (`commitAbove`, the "eating the bottom" overlap).**
+`lineCount`/`textLines` were derived from the `\n` count alone — wrap-blind. A
+logical line wider than `cols` hard-wraps into ≥2 PHYSICAL rows in the terminal,
+but `commitAbove` positions/scrolls exactly one row per `textLines` entry. So
+Phase 1 scrolled too few lines and Phase 3 CUP-painted a wide line that the
+terminal then auto-wrapped over the next row — overwriting ("eating") the
+adjacent committed content. Fix: each logical line is split into its visual rows
+up front via `hardWrapToWidth` (a pure CHARACTER wrap that matches the terminal
+and preserves ANSI — `wrap.ts`); `lineCount` is the visual-row count. For lines
+that fit `cols` this is a no-op, so narrow content is unchanged. NOTE:
+`wrapToWidth` (word-wrap, `hard: false`) must NOT be used here — it does not split
+long unbreakable tokens, so it under-counts physical rows.
+
+**Regression tests.** `terminal-compositor.h1-prevtoprow.test.ts` (block held +
+painted on collapse at `prevTopRow==1`; multi-block accumulation; and the
+partial-shrink transition below), `terminal-compositor.wrap-overlap.test.ts` (a
+wide block's wrapped tail survives a following commit), and the H3 ordering case
+in `markdown-stream.test.ts` (every `commitAbove` is preceded by an overlay sync
+that no longer shows the committed block). Each fails on the pre-fix code and
+passes after.
+
+**Partial-shrink transition (covered).** The transition where a pending band
+stored at `prevTopRow <= 1` then sees the overlay PARTIALLY shrink on the *next*
+commit (rather than fully collapse) is handled by `repositionCommittedBand`
+re-pinning the pending model above the new frame top on the shrink — so the next
+commit satisfies `overflowPriorContiguous` and merges contiguously, and both
+blocks survive in commit order. Verified by the third case in
+`terminal-compositor.h1-prevtoprow.test.ts`.
 
 ## What is and isn't in scrollback after a commit
 

--- a/src/cli/_lib/testing/golden-rendering.test.ts
+++ b/src/cli/_lib/testing/golden-rendering.test.ts
@@ -207,14 +207,12 @@ describe('Golden rendering tests', () => {
     // Converted from it.fails: the single-copy commitAbove fix (WIP commit
     // e8b6d9f0) makes this assertion pass. Phase 1 now emits LF-only scrolls;
     // Phase 3 writes exactly one copy of the text above the live frame.
-    // A 150-char line with 80-col terminal → soft-wraps to 2 rows but the
-    // VirtualScreen sees exactly 150 'X' characters (1 copy), not 300 (2 copies
-    // from the old dual-write). Note: the compositor is wrap-blind (lineCount =
-    // newline-count = 1 for a single long line) — it opens only 1 scroll slot
-    // and writes the full 150-char string at row 22. The VirtualScreen counts
-    // all 'X' characters across scroll+viewport, so soft-wrapping at row 22-23
-    // still yields 150 total.
-    // TODO(review #592): compositor is wrap-blind — a soft-wrapping line opens 1 scroll slot but occupies 2 visual rows (potential 1-row drift). Track separately.
+    // A 150-char line with an 80-col terminal occupies 2 physical rows. The
+    // compositor is now WRAP-AWARE (PR #649 follow-up): hardWrapToWidth splits
+    // the logical line into its 2 visual rows up front, so lineCount == 2,
+    // Phase 1 scrolls the right count, and each row is painted once. The
+    // VirtualScreen sees exactly 150 'X' characters (1 copy), not 300 (the old
+    // dual-write) — and no longer carries the prior wrap-blind 1-row drift.
     it('long text wraps correctly and appears in scrollback', async () => {
       const stdout = makeMockStdout();
       const stdin = makeMockStdin();
@@ -235,12 +233,11 @@ describe('Golden rendering tests', () => {
       const allText = vscreen.screenText();
       const xCount = (allText.match(/X/g) ?? []).length;
 
-      // RED on current code: commitAbove is wrap-blind (lineCount = newline
-      // count = 1, ignoring the soft-wrap to 2 rows) AND its 3-phase dance
-      // paints the text twice (phase-1 scrolls it to scrollback, phase-3
-      // re-paints it above the live frame) → the VirtualScreen sees 300 X's.
-      // GREEN after Wave 2 Track B: wrap-aware ScrollbackCommitter + single
-      // paint → exactly 150.
+      // A historical dual-write bug painted the text twice (phase-1 to
+      // scrollback + phase-3 above the frame) → 300 X's; the single-copy commit
+      // fixed that. The later wrap-blindness (counting the 150-char line as 1
+      // row) is fixed too (PR #649 follow-up: wrap-aware lineCount), so the line
+      // is split into 2 correctly-counted rows and painted once → exactly 150.
       expect(xCount).toBe(150);
     });
   });

--- a/src/cli/commit-mode.test.ts
+++ b/src/cli/commit-mode.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { decideCommitMode, capBandModel, type CommitModeInput } from './commit-mode.js';
+
+/**
+ * Pure-logic coverage for the commitAbove routing decision — no terminal,
+ * headless or otherwise. Shared geometry mirrors the production overflow-gap
+ * scenario: a 24-row terminal with a 2-row status footer and the content
+ * ceiling at row 1 → overflowTargetBottom = 24-1-2 = 21, maxBandModel = 21-1 = 20.
+ */
+function base(overrides: Partial<CommitModeInput> = {}): CommitModeInput {
+  return {
+    prevTopRow: 10,
+    frameTop: 10,
+    anchorFloor: 1,
+    anchorRow: 1,
+    lineCount: 2,
+    textLines: ['line-a', 'line-b'],
+    rows: 24,
+    extraRows: 2,
+    committedBand: [],
+    committedBandBottomRow: 0,
+    ...overrides,
+  };
+}
+
+describe('decideCommitMode', () => {
+  it('derives maxBandModel/overflowTargetBottom from rows, extraRows, anchorFloor', () => {
+    const m = decideCommitMode(base());
+    expect(m.overflowTargetBottom).toBe(21);
+    expect(m.maxBandModel).toBe(20);
+  });
+
+  it('fits path: a small block under a known (prevTopRow>1) frame', () => {
+    const m = decideCommitMode(base({ prevTopRow: 10, frameTop: 10, lineCount: 2 }));
+    expect(m.fitsAboveFrame).toBe(true);
+    expect(m.useBandHold).toBe(false);
+  });
+
+  it('BLOCKER-1 guard: fitsAboveFrame is false when prevTopRow<=1 (frame fills the viewport)', () => {
+    // Caller passes the fallback frameTop (max(1, rows-1-extraRows)=21) when prevTopRow<=1.
+    const m = decideCommitMode(base({ prevTopRow: 1, frameTop: 21, lineCount: 2 }));
+    expect(m.fitsAboveFrame).toBe(false);
+  });
+
+  it('H1 (review #649): a small block committed at prevTopRow<=1 is HELD, not dropped', () => {
+    // Band-hold routing is deliberately NOT gated on prevTopRow>1: the block
+    // fits the collapsed screen, so it must be held and painted on collapse.
+    const m = decideCommitMode(base({ prevTopRow: 1, frameTop: 21, lineCount: 2 }));
+    expect(m.fitsAboveFrame).toBe(false);
+    expect(m.useBandHold).toBe(true);
+  });
+
+  it('band-hold: overflows the current tall-frame room but fits the collapsed screen', () => {
+    // frameTop=3 → only room=2 above the frame; a 5-line block does not fit now
+    // but 5 <= maxBandModel(20) fits once the overlay collapses.
+    const m = decideCommitMode(
+      base({ prevTopRow: 3, frameTop: 3, lineCount: 5, textLines: ['1', '2', '3', '4', '5'] }),
+    );
+    expect(m.fitsAboveFrame).toBe(false);
+    expect(m.useBandHold).toBe(true);
+    expect(m.overflowRun).toHaveLength(5);
+  });
+
+  it('legacy overflow: a block taller than the collapsed screen (no pending band) takes neither flag', () => {
+    const tall = Array.from({ length: 25 }, (_, i) => `row${i}`);
+    const m = decideCommitMode(base({ prevTopRow: 3, frameTop: 3, lineCount: 25, textLines: tall }));
+    expect(m.fitsAboveFrame).toBe(false);
+    expect(m.useBandHold).toBe(false); // → caller falls through to the legacy archive path
+  });
+
+  it('review #649 P1: overflowHasPending forces band-hold even when the merged run exceeds maxBandModel', () => {
+    // A full pending band (20 rows) contiguous with a tall frame (frameTop=2,
+    // room=1) plus a 2-row commit → merged run = 22 > maxBandModel = 20. The
+    // override keeps useBandHold true so Phase 1 archives the genuine overflow
+    // as REAL content instead of the fits path scrolling unpainted blanks.
+    const band = Array.from({ length: 20 }, (_, i) => `band${i}`);
+    const m = decideCommitMode(
+      base({
+        prevTopRow: 2,
+        frameTop: 2,
+        lineCount: 2,
+        textLines: ['new-a', 'new-b'],
+        committedBand: band,
+        committedBandBottomRow: 1, // === frameTop - 1 → contiguous
+      }),
+    );
+    expect(m.overflowPriorContiguous).toBe(true);
+    expect(m.overflowHasPending).toBe(true);
+    expect(m.overflowRun).toHaveLength(22);
+    expect(m.overflowRun.length > m.maxBandModel).toBe(true);
+    expect(m.useBandHold).toBe(true); // without the override this would be false
+  });
+
+  it('merges the prior band into the run only when verifiably contiguous', () => {
+    const band = ['x', 'y'];
+    const merged = decideCommitMode(
+      base({
+        prevTopRow: 3,
+        frameTop: 3,
+        lineCount: 2,
+        textLines: ['a', 'b'],
+        committedBand: band,
+        committedBandBottomRow: 2, // === frameTop - 1
+      }),
+    );
+    expect(merged.overflowPriorContiguous).toBe(true);
+    expect(merged.overflowRun).toEqual(['x', 'y', 'a', 'b']);
+
+    const split = decideCommitMode(
+      base({
+        prevTopRow: 3,
+        frameTop: 3,
+        lineCount: 2,
+        textLines: ['a', 'b'],
+        committedBand: band,
+        committedBandBottomRow: 99, // !== frameTop - 1 → not contiguous
+      }),
+    );
+    expect(split.overflowPriorContiguous).toBe(false);
+    expect(split.overflowRun).toEqual(['a', 'b']);
+  });
+
+  it('does not merge when anchorRow>1 (a mid-commit anchor-evict could have moved the band)', () => {
+    const m = decideCommitMode(
+      base({
+        prevTopRow: 3,
+        frameTop: 3,
+        lineCount: 2,
+        textLines: ['a', 'b'],
+        anchorRow: 2,
+        committedBand: ['x', 'y'],
+        committedBandBottomRow: 2,
+      }),
+    );
+    expect(m.overflowPriorContiguous).toBe(false);
+    expect(m.overflowRun).toEqual(['a', 'b']);
+  });
+});
+
+describe('capBandModel', () => {
+  it('keeps the newest `max` rows when the run is over cap', () => {
+    expect(capBandModel(['a', 'b', 'c', 'd'], 2)).toEqual(['c', 'd']);
+  });
+
+  it('returns the run unchanged (same reference) when it already fits', () => {
+    const run = ['a', 'b'];
+    expect(capBandModel(run, 5)).toBe(run);
+  });
+
+  it('handles an empty run', () => {
+    expect(capBandModel([], 3)).toEqual([]);
+  });
+
+  it('max=0 drops the whole run', () => {
+    expect(capBandModel(['a', 'b'], 0)).toEqual([]);
+  });
+});

--- a/src/cli/commit-mode.ts
+++ b/src/cli/commit-mode.ts
@@ -1,0 +1,143 @@
+/**
+ * Pure routing/geometry helpers for `TerminalCompositor.commitAbove`.
+ *
+ * Extracted so the band-hold routing decision and the band-model cap can be
+ * unit-tested WITHOUT driving a real (or `@xterm/headless`) terminal: no side
+ * effects, no `this`, every input is a scalar or array and every result is a
+ * plain value. The escape-sequence emission and frame state stay in
+ * `terminal-compositor.ts`; only the "what should this commit do" arithmetic
+ * lives here. Full root cause + design: docs/scrollback.md and the regression
+ * suites terminal-compositor.overflow-gap.test.ts / .h1-prevtoprow.test.ts.
+ */
+
+/** Everything `decideCommitMode` needs, lifted out of the compositor's state. */
+export interface CommitModeInput {
+  /** Live frame top row captured BEFORE clear() (`logUpdate.topRow ?? 0`). */
+  prevTopRow: number;
+  /** Effective frame top: `prevTopRow > 1 ? prevTopRow : max(1, rows-1-extraRows)`. */
+  frameTop: number;
+  /** Content ceiling above which nothing is painted (`max(anchorRow ?? 1, 1)`). */
+  anchorFloor: number;
+  /** Raw anchor row (`anchorRow ?? 1`) — gates band-merge soundness (must be ≤1). */
+  anchorRow: number;
+  /** Physical-row count of the block being committed (wrap-aware). */
+  lineCount: number;
+  /** The block's visual rows (already hard-wrapped to the terminal width). */
+  textLines: string[];
+  /** Terminal height in rows. */
+  rows: number;
+  /** Reserved status-line rows below the frame. */
+  extraRows: number;
+  /** Current on-screen committed band model. */
+  committedBand: string[];
+  /** Tracked bottom row of the committed band (0 when unset). */
+  committedBandBottomRow: number;
+}
+
+/** The routing decision + the geometry the caller's phases consume. */
+export interface CommitMode {
+  /** Single-copy fits path: block fits `[anchorFloor, frameTop)` and the frame top is known. */
+  fitsAboveFrame: boolean;
+  /** Above-frame rows currently available to paint into. */
+  room: number;
+  /** Bottom row a collapsed-frame band can occupy. */
+  overflowTargetBottom: number;
+  /** Max band-model rows that can ever show above a minimal frame. */
+  maxBandModel: number;
+  /** Prior band verifiably contiguous with the frame top (safe to merge). */
+  overflowPriorContiguous: boolean;
+  /** Prior band + new lines (merged when contiguous, else just the new lines). */
+  overflowRun: string[];
+  /** Prior band carries rows never painted on screen because the held overlay left only `room` rows visible. */
+  overflowHasPending: boolean;
+  /** Route this commit through the band-hold path (hold in the model; don't archive + truncate). */
+  useBandHold: boolean;
+}
+
+/**
+ * Decide how a `commitAbove` block is routed: the single-copy fits path, the
+ * band-hold path, or (by returning neither flag) the legacy overflow archive.
+ *
+ * `fitsAboveFrame` — the block fits `[anchorFloor, frameTop)`, so Phase 1
+ * scrolls only the band overflow and Phase 3 paints the one copy. Gated on
+ * `prevTopRow > 1` (BLOCKER-1, review #592): only then is the real frame top
+ * known. When `prevTopRow <= 1` the live frame already fills the viewport, so
+ * the `frameTop` fallback would overestimate the above-frame room — the fits
+ * path genuinely needs a known frame top.
+ *
+ * `useBandHold` — keep a block that overflows the CURRENT (tall) frame but
+ * fits the COLLAPSED screen in the band model rather than archiving it to
+ * scrollback + painting a truncated on-screen copy (the legacy overflow path's
+ * duplicate header + orphan divider + blank "void"). Two ways to enter:
+ *
+ *  • `overflowRun.length <= maxBandModel && !fitsAboveFrame` — the merged run
+ *    still fits a collapsed screen but not the current room. Band-hold routing
+ *    is deliberately NOT gated on `prevTopRow > 1` (H1, review #649): when
+ *    `prevTopRow <= 1` the block is HELD in the model and painted by
+ *    repositionCommittedBand() on collapse, NOT dropped down the overflow path.
+ *
+ *  • `overflowHasPending` — once the prior band carries PENDING rows (rows in
+ *    the model never painted because the held overlay left only `room` visible),
+ *    the commit MUST stay on band-hold even when the merged run exceeds
+ *    maxBandModel (review #649 P1). The fits path scrolls from
+ *    `committedBand.length`, which counts those pending rows; routing there
+ *    would scroll unpainted blanks into scrollback while Phase 3's cap drops the
+ *    real rows. Band-hold Phase 1 instead archives the genuine overflow (the
+ *    oldest rows beyond what the collapsed screen holds) as REAL content.
+ *
+ * A block taller than the collapsed screen with no pending rows
+ * (`overflowRun.length > maxBandModel`, `!overflowHasPending`) takes neither
+ * flag and falls through to the legacy overflow archive (recoverable).
+ *
+ * `overflowRun` merges the prior band into the new lines only when verifiably
+ * contiguous with the frame top (`overflowPriorContiguous`) — otherwise a
+ * resize / anchor-evict moved it and adjacency cannot be assumed.
+ */
+export function decideCommitMode(input: CommitModeInput): CommitMode {
+  const {
+    prevTopRow,
+    frameTop,
+    anchorFloor,
+    anchorRow,
+    lineCount,
+    textLines,
+    rows,
+    extraRows,
+    committedBand,
+    committedBandBottomRow,
+  } = input;
+
+  const fitsAboveFrame = prevTopRow > 1 && lineCount <= frameTop - anchorFloor;
+
+  const room = Math.max(0, frameTop - anchorFloor);
+  const overflowTargetBottom = Math.max(1, rows - 1 - extraRows);
+  const maxBandModel = Math.max(0, overflowTargetBottom - anchorFloor);
+  const overflowPriorContiguous =
+    committedBand.length > 0 && anchorRow <= 1 && committedBandBottomRow === frameTop - 1;
+  const overflowRun = overflowPriorContiguous ? [...committedBand, ...textLines] : textLines;
+  const overflowHasPending = overflowPriorContiguous && committedBand.length > room;
+  const useBandHold =
+    overflowHasPending || (overflowRun.length <= maxBandModel && !fitsAboveFrame);
+
+  return {
+    fitsAboveFrame,
+    room,
+    overflowTargetBottom,
+    maxBandModel,
+    overflowPriorContiguous,
+    overflowRun,
+    overflowHasPending,
+    useBandHold,
+  };
+}
+
+/**
+ * Cap a band-hold run to its newest `max` rows — the rows that can ever show
+ * above a minimal (collapsed) frame. A run longer than `max` keeps its suffix
+ * (the most-recent rows); the older prefix is dropped here because the caller's
+ * Phase-1 band-hold branch has already archived those rows to scrollback as
+ * real content. Returns the run unchanged when it already fits.
+ */
+export function capBandModel(run: string[], max: number): string[] {
+  return run.length > max ? run.slice(run.length - max) : run;
+}

--- a/src/cli/markdown-stream.test.ts
+++ b/src/cli/markdown-stream.test.ts
@@ -533,6 +533,59 @@ describe('StreamingMarkdownRenderer', () => {
       await renderer.flush();
     });
 
+    it('syncs the overlay (dropping the committed block) BEFORE each commitAbove (H3 prevTopRow==1 guard)', async () => {
+      // Regression (PR #649 follow-up): when push() commits a multi-line block
+      // mid-stream, commitAbove() must NOT fire while the overlay still renders
+      // that block. A stale, too-tall overlay pins the live frame to row 1
+      // (prevTopRow==1), routing the committed block down the legacy overflow
+      // path where the band-hold gate is suppressed and the block can be
+      // dropped from screen AND scrollback (the "lost table" symptom).
+      //
+      // Assert the ORDERING contract: every commitAbove is immediately preceded
+      // by a setOverlay whose content no longer contains the block being
+      // committed. Pre-fix the push() loop committed with no preceding overlay
+      // sync, so commitAbove saw the full block still in the overlay.
+      const events: Array<{ kind: 'overlay' | 'commit'; text: string }> = [];
+      const stub = {
+        setOverlay(text: string) { events.push({ kind: 'overlay', text }); },
+        commitAbove(text: string) { events.push({ kind: 'commit', text }); },
+        arm: async () => {},
+        disarm: () => {},
+        getBuffer: () => ({ text: '', queued: false }),
+        isArmed: () => true,
+      };
+      const ttyStream = new PassThrough();
+      (ttyStream as any).isTTY = true;
+      renderer = new StreamingMarkdownRenderer({
+        out: ttyStream,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        compositor: stub as any,
+      });
+
+      // A multi-line block (rendered-table shape: no internal blank line)
+      // followed by its paragraph boundary, then a second block — one push.
+      const tableBlock = 'ROW_ALPHA\nROW_BETA\nROW_GAMMA\nROW_DELTA';
+      renderer.push(`${tableBlock}\n\nTRAILING PROSE\n\n`);
+
+      const commitIdxs = events
+        .map((e, i) => (e.kind === 'commit' ? i : -1))
+        .filter((i) => i >= 0);
+      expect(commitIdxs.length, 'at least one block must have committed').toBeGreaterThanOrEqual(1);
+      for (const ci of commitIdxs) {
+        const prev = events[ci - 1];
+        expect(prev?.kind, `commitAbove at event ${ci} must be preceded by an overlay sync`).toBe('overlay');
+        // The synced overlay must not still show the lines being committed.
+        const committedText = events[ci]!.text;
+        for (const marker of ['ROW_ALPHA', 'ROW_BETA', 'ROW_GAMMA', 'ROW_DELTA']) {
+          if (committedText.includes(marker)) {
+            expect(prev!.text, `overlay before commit must not still show "${marker}"`).not.toContain(marker);
+          }
+        }
+      }
+
+      await renderer.flush();
+    });
+
     it('routes pending overlay through compositor.setOverlay on repaint', async () => {
       vi.useFakeTimers();
       const { stub, overlayCalls } = makeStubCompositor();

--- a/src/cli/markdown-stream.ts
+++ b/src/cli/markdown-stream.ts
@@ -176,6 +176,31 @@ export class StreamingMarkdownRenderer {
   }
 
   /**
+   * Invariant (commit-time overlay sync): re-compose the live overlay from the
+   * CURRENT buffer BEFORE a `commitAbove()` runs, so the overlay no longer shows
+   * the block being committed. Callers MUST remove the committed block from
+   * `this.buffer` first (push() slices it out; commitPending() empties it).
+   *
+   * Without this, the overlay still renders the just-committed block while
+   * `commitAbove` repaints the frame. A multi-line block (e.g. a rendered
+   * table) leaves the overlay tall enough to pin the live frame to row 1
+   * (`prevTopRow == 1`), which routes the committed block down the legacy
+   * overflow path — where the band-hold gate is suppressed and the block can be
+   * dropped from screen AND scrollback. flush() already does this refresh before
+   * its tail commit (via the `flushing` flag, which makes renderPending() empty);
+   * push()/commitPending() need the explicit call because they commit while
+   * `flushing` is false. See terminal-compositor.ts commitAbove (band-hold path).
+   */
+  private syncPendingOverlay(): void {
+    if (this.overlayComposer) {
+      this.overlayComposer.markDirty('markdown-pending');
+      this.overlayComposer.flush();
+    } else if (this.compositor) {
+      this.compositor.setOverlay(this.renderPending());
+    }
+  }
+
+  /**
    * Execute a single repaint of pending content
    */
   private async repaint(): Promise<void> {
@@ -223,6 +248,11 @@ export class StreamingMarkdownRenderer {
       // triggered by compositor.commitAbove() sees only the remaining
       // content, not the block that was just committed.
       this.buffer = this.buffer.slice(boundary);
+      // Re-compose the overlay from the now-sliced buffer BEFORE committing, so
+      // commitAbove() does not fire while the overlay still shows this block
+      // (which would pin the frame to row 1 and risk dropping a multi-line
+      // block via the overflow path). See syncPendingOverlay().
+      this.syncPendingOverlay();
       this.commitBlock(blockText);
 
       boundary = findBlockBoundary(this.buffer);
@@ -313,14 +343,13 @@ export class StreamingMarkdownRenderer {
    */
   commitPending(): void {
     if (!this.buffer.trim()) return;
-    this.commitBlock(this.buffer);
+    const pending = this.buffer;
+    // Empty the buffer and re-compose the overlay (now empty) BEFORE committing,
+    // so commitAbove() does not fire while the overlay still shows this block.
+    // See syncPendingOverlay() / push() for the rationale (prevTopRow==1 drop).
     this.buffer = '';
-    if (this.overlayComposer) {
-      this.overlayComposer.markDirty('markdown-pending');
-      this.overlayComposer.flush();
-    } else if (this.compositor) {
-      this.compositor.setOverlay('');
-    }
+    this.syncPendingOverlay();
+    this.commitBlock(pending);
   }
 
   /**

--- a/src/cli/terminal-compositor.commit-collapse-wrap-gap.test.ts
+++ b/src/cli/terminal-compositor.commit-collapse-wrap-gap.test.ts
@@ -13,10 +13,14 @@
  * blind logical line count (a7ace49 / #39 follow-up) compounded it by under-
  * scrolling the wrapped block.
  *
- * Fix: commitAbove PARKS the block in `coveredBand` instead of dropping it;
- * repositionCommittedBand PROMOTES it back adjacent to the frame on collapse.
- * commitAbove's lineCount is now physical (wrap-aware) so the scroll/anchor math
- * matches the wrapped screen.
+ * Fix (band-hold, review #649): when the frame fills the viewport (newTopRow
+ * <= 1) and the run fits the collapsed screen, commitAbove no longer DROPS the
+ * block — the H1 band-hold branch HOLDS the full run in `committedBand` (fully
+ * pending, nothing painted yet) and repositionCommittedBand PAINTS it adjacent
+ * to the frame on the next collapse. commitAbove's lineCount is physical
+ * (wrap-aware) so the scroll/anchor math matches the wrapped screen. (An earlier
+ * fix parked the block in a separate `coveredBand` field; band-hold superseded
+ * that path and the field was removed.)
  *
  * HARD GATE: pre-fix the committed WRAPMARK line is ABSENT from the collapsed
  * viewport (dropped) and a tall blank gap sits above the frame. Post-fix the

--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -32,6 +32,8 @@ export interface CommittedBandHost {
   committedBand: string[];
   committedBandTopRow: number;
   committedBandBottomRow: number;
+  /** How many of committedBand's rows (its bottom suffix) are painted on screen. */
+  committedBandPaintedRows: number;
   /** Re-entrancy guard: suppresses a repaint during the clear→write window. */
   committing: boolean;
   /** Suppresses the shrink re-pin (repositionCommittedBand) for a commit. */
@@ -478,6 +480,9 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
       self.committedBand = model;
       self.committedBandBottomRow = newTopRow - 1;
       self.committedBandTopRow = bandTop;
+      // Only the bottom `paintedCount` rows reached the terminal; the rest of
+      // the model is pending (painted by repositionCommittedBand on collapse).
+      self.committedBandPaintedRows = paintedCount;
     } else {
     const newPainted = Math.min(textLines.length, maxRun);
     if (newPainted > 0) {
@@ -603,6 +608,11 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
       self.committedBand = capped;
       self.committedBandBottomRow = newTopRow - 1;
       self.committedBandTopRow = bandTop;
+      // The whole `capped` run is materialized: the fits arm CUP-paints all of
+      // it above the frame; the overflow arm paints the tail that fits AND
+      // Phase 1 already archived the full block to scrollback. Either way no row
+      // of `capped` is unpainted-and-unarchived, so nothing is pending here.
+      self.committedBandPaintedRows = capped.length;
     } else {
       clearCommittedBand(self);
     }
@@ -618,6 +628,11 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     self.committedBand = model;
     self.committedBandBottomRow = Math.max(0, collapsedFrameTop - 1);
     self.committedBandTopRow = Math.max(anchorFloor, collapsedFrameTop - model.length);
+    // Nothing was painted to the terminal: the whole model is PENDING until
+    // repositionCommittedBand materializes it on collapse. If disarm() runs
+    // first (Ctrl-C / abort / exit mid-turn), it flushes this pending model to
+    // scrollback so the committed block is not lost from screen AND history.
+    self.committedBandPaintedRows = 0;
   } else {
     clearCommittedBand(self);
   }
@@ -629,6 +644,7 @@ export function clearCommittedBand(self: CommittedBandHost): void {
   self.committedBand = [];
   self.committedBandTopRow = 0;
   self.committedBandBottomRow = 0;
+  self.committedBandPaintedRows = 0;
 }
 
 /**

--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -14,6 +14,8 @@
  */
 
 import type { LogUpdateFn, CompositorScrollRegionGuard } from './terminal-compositor.types.js';
+import { hardWrapToWidth } from './wrap.js';
+import { capBandModel, decideCommitMode } from './commit-mode.js';
 
 /**
  * Narrowest TerminalCompositor state slice the committed-band functions touch.
@@ -30,9 +32,6 @@ export interface CommittedBandHost {
   committedBand: string[];
   committedBandTopRow: number;
   committedBandBottomRow: number;
-  /** Most-recent committed block covered by a full-viewport frame, awaiting
-   *  re-pin on the next collapse (see {@link repositionCommittedBand}). */
-  coveredBand: string[];
   /** Re-entrancy guard: suppresses a repaint during the clear→write window. */
   committing: boolean;
   /** Suppresses the shrink re-pin (repositionCommittedBand) for a commit. */
@@ -124,26 +123,20 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   // exactly fills the room keeps all its content and drops the separator, so the
   // newest content still sits against the frame). The length>1 guard keeps
   // `commitAbove('')` painting its single blank row (the subagent-done path).
-  const contentLines = stripped.split('\n');
+  const cols = Math.max(1, self.stdout.columns ?? 80);
+  const logicalLines = stripped.split('\n');
   let hasTrailingSeparator = false;
-  while (contentLines.length > 1 && contentLines[contentLines.length - 1] === '') {
-    contentLines.pop();
+  while (logicalLines.length > 1 && logicalLines[logicalLines.length - 1] === '') {
+    logicalLines.pop();
     hasTrailingSeparator = true;
   }
-  // Physical (wrap-aware) CONTENT row count. A committed line wider than the
-  // terminal soft-wraps to >1 physical row, so the LOGICAL count under-counts the
-  // rows the block actually occupies. That under-count made Phase 1 scroll too
-  // few rows — stranding wrapped overflow rows on screen — and mis-sized
-  // fitsAboveFrame / bandOverflow. Mirror the frame side (a7ace49 / #39), which
-  // derives its geometry from CupFrameRenderer.measure()'s physical row count via
-  // the shared wrapToPhysicalLines helper; reuse the same measure() here so the
-  // band and frame can't drift. measure() drops the trailing-blank row (its
-  // wrapToPhysicalLines pops trailing ''), so it already counts CONTENT only —
-  // matching contentLines. Logical fallback (contentLines.length) for stubs
-  // without measure().
-  const contentLineCount = self.logUpdate.measure
-    ? Math.max(1, self.logUpdate.measure(stripped, rows).lineCount)
-    : Math.max(1, contentLines.length);
+  // Wrap-aware physical CONTENT rows: a logical line wider than the terminal
+  // occupies >1 physical row. hardWrapToWidth (pure char wrap, ANSI-preserving,
+  // matches the terminal) makes commitAbove position/scroll/paint exactly one
+  // terminal row per array entry — so a wide line's wrapped tail is not "eaten"
+  // by the next commit's paint, and the band-hold row math is exact.
+  const contentLines = logicalLines.flatMap((l) => hardWrapToWidth(l, cols).split('\n'));
+  const contentLineCount = Math.max(1, contentLines.length);
 
   const extraRows = self.scrollRegion?.getExtraRows() ?? 0;
   // Invariant (one geometry per commit): the room/scroll/band math below must
@@ -228,6 +221,37 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     hasTrailingSeparator && fitsAboveFrame && contentLineCount < aboveFrameRoomForSeparator;
   const textLines = paintSeparator ? [...contentLines, ''] : contentLines;
   const lineCount = contentLineCount + (paintSeparator ? 1 : 0);
+
+  // Band-hold routing (pure, tested in commit-mode.test.ts): keep a block that
+  // overflows the CURRENT tall frame but fits the COLLAPSED screen in the band
+  // model instead of archiving+truncating it. Additive: useBandHold is a new
+  // route checked before the existing fits/overflow branches; the existing
+  // fitsAboveFrame computed above still governs separator + Phase-1/3 fits math.
+  //
+  // Band-hold model uses the separator-inclusive block. The rhythm separator is
+  // always counted in the band model's row budget — even when paintSeparator is
+  // false — because the collapsed frame will display the separator between blocks.
+  // This also lets decideCommitMode see the correct effective lineCount (including
+  // the separator) so a 1-content-line block with trailing separator counts as 2
+  // model rows, correctly routing it to band-hold when room=1.
+  const bandTextLines = hasTrailingSeparator ? [...contentLines, ''] : contentLines;
+  const bandLineCount = bandTextLines.length;
+  const {
+    useBandHold,
+    overflowRun,
+    maxBandModel,
+  } = decideCommitMode({
+    prevTopRow,
+    frameTop,
+    anchorFloor,
+    anchorRow: self.anchorRow ?? 1,
+    lineCount: bandLineCount,
+    textLines: bandTextLines,
+    rows,
+    extraRows,
+    committedBand: self.committedBand,
+    committedBandBottomRow: self.committedBandBottomRow,
+  });
 
   // Suppress the shrink re-pin for the whole commit; Phase 3 sets the band.
   // Re-armed at the top of every commitAbove, so a throw on a dying TTY (the
@@ -320,7 +344,26 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
       // Phase 3 at the unchanged anchorFloor to avoid clobbering the banner.
       scrolledRows = fitsAboveFrame ? bandOverflow : 0;
       self.debugLog('commitAbove:phase1', { lineCount, fitsAboveFrame, bandOverflow });
-      if (fitsAboveFrame) {
+      if (useBandHold) {
+        // Band-hold Phase 1: scroll NOTHING for the rows the model keeps (they
+        // are "pending" — painted by repositionCommittedBand on collapse). Only
+        // the genuine overflow (oldest rows beyond maxBandModel) is archived to
+        // scrollback as REAL content, via the proven top-write-then-scroll
+        // mechanism, chunked by screen height so a run taller than the terminal
+        // still archives every row. The archived prefix is disjoint from the
+        // suffix Phase 3 keeps — no duplication.
+        const genuineOverflow = Math.max(0, overflowRun.length - maxBandModel);
+        if (genuineOverflow > 0) {
+          const chunkMax = Math.max(1, rows - anchorFloor + 1);
+          for (let start = 0; start < genuineOverflow; start += chunkMax) {
+            const chunk = overflowRun.slice(start, Math.min(start + chunkMax, genuineOverflow));
+            const topWrite = chunk
+              .map((l, i) => `\x1b[${anchorFloor + i};1H\x1b[2K${l ?? ''}`)
+              .join('');
+            self.stdout.write(`${topWrite}\x1b[${rows};1H${'\n'.repeat(chunk.length)}`);
+          }
+        }
+      } else if (fitsAboveFrame) {
         if (bandOverflow > 0) {
           self.stdout.write(`\x1b[${rows};1H${'\n'.repeat(bandOverflow)}`);
         }
@@ -412,6 +455,30 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     // anchorFloor would keep maxRun pinned and re-trigger the cap-to-one-row bug.
     const postScrollFloor = Math.max(self.anchorRow ?? 1, 1);
     const maxRun = Math.max(0, newTopRow - postScrollFloor);
+    if (useBandHold) {
+      // Band-hold Phase 3: track the full committed run (capped at maxBandModel)
+      // as the band model, but paint only the bottom paintedCount rows that fit
+      // above the current frame. The rest are "pending" — in the model, not yet
+      // on screen, not in scrollback. repositionCommittedBand paints the whole
+      // model contiguously above the frame on the next shrink/collapse.
+      const model = capBandModel(overflowRun, maxBandModel);
+      const paintedCount = Math.min(model.length, maxRun);
+      const bandTop = newTopRow - paintedCount;
+      let out = '';
+      for (let i = 0; i < paintedCount; i++) {
+        const row = bandTop + i;
+        if (row >= newTopRow) break; // Never overwrite the live frame.
+        out += `\x1b[${row};1H\x1b[2K${model[model.length - paintedCount + i] ?? ''}`;
+      }
+      if (out.length > 0) {
+        writeWithGuard(() => {
+          self.stdout.write(out);
+        });
+      }
+      self.committedBand = model;
+      self.committedBandBottomRow = newTopRow - 1;
+      self.committedBandTopRow = bandTop;
+    } else {
     const newPainted = Math.min(textLines.length, maxRun);
     if (newPainted > 0) {
       // Tail-slice (not head): when the block is taller than the above-frame
@@ -536,28 +603,23 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
       self.committedBand = capped;
       self.committedBandBottomRow = newTopRow - 1;
       self.committedBandTopRow = bandTop;
-      // An on-screen band is now authoritative — any previously covered block is
-      // stale (this commit supersedes it).
-      self.coveredBand = [];
     } else {
       clearCommittedBand(self);
     }
+    } // end else (not useBandHold)
+  } else if (useBandHold) {
+    // Full-viewport frame (newTopRow <= 1): no above-frame row to paint now, but
+    // band-hold is active — the block fits the collapsed screen. Store the model
+    // FULLY PENDING; repositionCommittedBand paints it on the next shrink/collapse.
+    // committedBandBottomRow = collapsedFrameTop - 1 (NOT a 0 sentinel) lets a
+    // subsequent full-viewport commit satisfy overflowPriorContiguous and MERGE.
+    const model = capBandModel(overflowRun, maxBandModel);
+    const collapsedFrameTop = Math.max(1, rows - 1 - extraRows);
+    self.committedBand = model;
+    self.committedBandBottomRow = Math.max(0, collapsedFrameTop - 1);
+    self.committedBandTopRow = Math.max(anchorFloor, collapsedFrameTop - model.length);
   } else {
-    // No above-frame area: the frame fills the viewport (newTopRow ≤ 1) or
-    // nothing has rendered yet. The block is already in scrollback (Phase 1's
-    // overflow archive). Rather than DROP it, PARK it in coveredBand so the
-    // moment the overlay collapses repositionCommittedBand re-pins it adjacent
-    // to the frame — without this the band is empty on collapse and
-    // CupFrameRenderer shrink-pads blank rows nothing refills (the "massive
-    // blank gap" in big-gap.txt). Cap to the viewport height; the re-pin caps
-    // again to the real above-frame room. clearCommittedBand() resets coveredBand
-    // first, so set it AFTER. (newTopRow ≤ 1 ⇒ nothing rendered yet has no block
-    // to park — textLines is the just-committed content either way.)
     clearCommittedBand(self);
-    if (newTopRow <= 1 && textLines.length > 0) {
-      const cap = Math.max(1, rows - 1);
-      self.coveredBand = textLines.length > cap ? textLines.slice(textLines.length - cap) : textLines;
-    }
   }
   self.commitInFlight = false;
   self.debugLog('commitAbove:phase3:done');
@@ -567,12 +629,6 @@ export function clearCommittedBand(self: CommittedBandHost): void {
   self.committedBand = [];
   self.committedBandTopRow = 0;
   self.committedBandBottomRow = 0;
-  // Drop any covered-but-retained content too: every clear path (disarm, /clear,
-  // resetCommittedBand, fits-path empties) means there is no longer a band to
-  // re-pin, so a stale coveredBand must not resurrect old transcript on the next
-  // shrink. Sites that intentionally PARK content in coveredBand set it AFTER
-  // calling this (commitAbove's full-viewport branch).
-  self.coveredBand = [];
 }
 
 /**

--- a/src/cli/terminal-compositor.committed-band-repin.ts
+++ b/src/cli/terminal-compositor.committed-band-repin.ts
@@ -113,4 +113,9 @@ export function repositionCommittedBand(
   }
   self.committedBandTopRow = newTop;
   self.committedBandBottomRow = targetBottom;
+  // `fit` rows (the band's bottom suffix) are now materialized on screen — this
+  // is the collapse repaint that drains a fully-pending band-hold model. Record
+  // it so a subsequent disarm() does not re-flush already-painted rows into
+  // scrollback (which would duplicate them).
+  self.committedBandPaintedRows = fit;
 }

--- a/src/cli/terminal-compositor.committed-band-repin.ts
+++ b/src/cli/terminal-compositor.committed-band-repin.ts
@@ -72,23 +72,6 @@ export function repositionCommittedBand(
   if (self.commitInFlight || !self.logUpdate) return;
   const floor = Math.max(self.anchorRow ?? 1, 1);
   const targetBottom = desiredTopRow - 1;
-  // Promote covered content the moment the frame shrinks enough to show it. A
-  // full-viewport frame (newTopRow ≤ 1) parked the most-recent block in
-  // coveredBand (commitAbove) instead of dropping it; re-pin it now adjacent to
-  // the new frame top so the collapse shows it hugging the frame rather than a
-  // run of shrink-pad blank rows (the "massive blank gap"). While the frame
-  // still fills the viewport (targetBottom < floor) this is a no-op and the
-  // block stays parked. The block is already in scrollback (Phase 1 archive), so
-  // the only cost of the re-pin is an off-screen scrollback copy (no-gap default).
-  if (self.committedBand.length === 0 && self.coveredBand.length > 0 && targetBottom >= floor) {
-    self.committedBand = self.coveredBand;
-    self.coveredBand = [];
-    // Treat the promoted band as having occupied the just-erased covered frame
-    // footprint so renderErasedBand fires and it paints at the position the fit
-    // math computes below (committedBandTopRow = 1 also makes `moved` true).
-    self.committedBandTopRow = 1;
-    self.committedBandBottomRow = Math.max(1, preRenderFrameTop, targetBottom);
-  }
   if (self.committedBand.length === 0) return;
   // On upward growth (targetBottom < committedBandBottomRow) the band must be
   // re-pinned above the NEW frame top: preserveRowsBeforeFrameRender either

--- a/src/cli/terminal-compositor.disarm-pending-band.test.ts
+++ b/src/cli/terminal-compositor.disarm-pending-band.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Regression (PR #649 follow-up): a multi-line block committed via commitAbove()
+ * while the live overlay FILLS the viewport (prevTopRow == 1) is HELD in the
+ * committedBand model FULLY PENDING — stored with committedBandBottomRow =
+ * collapsedFrameTop-1, painted to NEITHER the terminal NOR scrollback, to be
+ * materialized later by repositionCommittedBand() on collapse
+ * (terminal-compositor.committed-band-commit.ts newTopRow<=1 storage branch).
+ *
+ * THE LOSS: if disarm() runs BEFORE that collapse-repaint — the user hits
+ * Ctrl-C / the turn aborts / the process exits mid-turn while the tall overlay
+ * is still up — disarm() does logUpdate.clear() + done() + resetState() and the
+ * model is discarded. Because the pending rows were never painted and never
+ * archived, the whole committed block (e.g. a streamed "Done" report or table)
+ * vanishes from screen AND scrollback. Pre-band-hold the legacy overflow path
+ * archived to scrollback, so the block survived in history.
+ *
+ * THE FIX: disarm() flushes the genuinely-unpainted band-model prefix to
+ * scrollback as REAL content BEFORE logUpdate.clear(), tracked via the
+ * committedBandPaintedRows field (0 for a fully-pending model). The NORMAL
+ * teardown — overlay collapsed first, so repositionCommittedBand already
+ * painted the band — must NOT re-emit those on-screen rows (that would
+ * duplicate them in scrollback). Both behaviors are asserted below.
+ *
+ * Test #1 ("disarm before collapse") FAILS on current code (rows absent, count
+ * 0) and passes after the fix. Test #2 ("normal collapse path") proves the fix
+ * does not duplicate already-painted rows.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import xterm from '@xterm/headless';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { StatusLine } from './status-line.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const HeadlessTerminal = (xterm as any).Terminal;
+
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin = NodeJS.ReadStream & { isTTY: boolean; isRaw: boolean; setRawMode: ReturnType<typeof vi.fn> };
+
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true; s.columns = cols; s.rows = rows; return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true; s.isRaw = false; s.setRawMode = vi.fn((r: boolean) => { s.isRaw = r; return s; }); return s;
+}
+function collect(stream: MockStdout): () => string {
+  const c: string[] = [];
+  stream.on('data', (x) => c.push(String(x)));
+  return () => c.join('');
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function termWrite(t: any, d: string): Promise<void> {
+  return new Promise((r) => t.write(d, () => r()));
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function allLines(t: any): string[] {
+  const b = t.buffer.active; const o: string[] = [];
+  for (let i = 0; i < b.length; i++) { const l = b.getLine(i); if (l) o.push(l.translateToString(true)); }
+  return o;
+}
+
+const COLS = 120, ROWS = 24;
+
+describe('disarm() before collapse: pending band-hold rows are preserved in scrollback', () => {
+  it('flushes a fully-pending committed block to scrollback when disarm() runs before the overlay collapses', async () => {
+    const stdout = makeStdout(COLS, ROWS);
+    const stdin = makeStdin();
+    const all = collect(stdout);
+    const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+    statusLine.start();
+    statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1 });
+    await c.arm();
+    statusLine.setExtraRows(2);
+    c.setSpinner({ enabled: true });
+
+    // A 22-line overlay + spinner + gap + input OVERFLOWS the 24-row viewport,
+    // pinning the frame top to row 1 → prevTopRow == 1 at commit time.
+    const tallOverlay = Array.from({ length: 22 }, (_, i) => `thinking ${i} — held overlay row keeping the frame at full height`).join('\n');
+
+    // A multi-line "Done report" block committed as ONE block under the overlay.
+    const reportRows = [
+      'DONE_HEADER unique marker row',
+      'DONE_LINE_A first body row',
+      'DONE_LINE_B second body row',
+      'DONE_LINE_C third body row',
+    ];
+    c.setOverlay(tallOverlay);
+    c.commitAbove(`${reportRows.join('\n')}\n\n`);
+
+    // Precondition: the block took the fully-pending storage branch — band model
+    // non-empty, bottom at collapsedFrameTop-1 (=rows-1-extraRows-1=20), and
+    // ZERO painted rows (nothing on screen, nothing in scrollback yet).
+    const internals = c as unknown as {
+      repaint(): void;
+      committedBand: string[];
+      committedBandBottomRow: number;
+      committedBandPaintedRows: number;
+    };
+    expect(internals.committedBand.length, 'band model must hold the committed block').toBeGreaterThan(0);
+    expect(internals.committedBandBottomRow, 'must be the fully-pending storage branch (collapsedFrameTop-1=20)').toBe(20);
+    expect(internals.committedBandPaintedRows, 'nothing painted yet — block is fully pending').toBe(0);
+
+    // The user aborts mid-turn: disarm() WITHOUT collapsing the overlay first.
+    // Pre-fix this discards the model and the block is lost from screen AND
+    // scrollback. Post-fix disarm() flushes the pending rows to scrollback.
+    statusLine.stop();
+    c.disarm();
+
+    const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 400, allowProposedApi: true, convertEol: true });
+    await termWrite(term, all());
+    const lines = allLines(term);
+    const dump = lines.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l.replace(/\s+$/, ''))}`).join('\n');
+
+    // Every committed row must survive EXACTLY ONCE across the whole buffer
+    // (scrollback). Pre-fix: every row absent (count 0) — the headline loss.
+    for (const row of reportRows) {
+      const marker = row.split(' ')[0]!; // DONE_HEADER / DONE_LINE_A / …
+      const hits = lines.filter((l) => l.includes(marker)).length;
+      expect(
+        hits,
+        `committed row "${marker}" must survive in scrollback after abort-before-collapse (found ${hits}):\n${dump}`,
+      ).toBe(1);
+    }
+
+    term.dispose(); c.disarm();
+  }, 15_000);
+
+  it('does NOT duplicate rows on the normal teardown (collapse → repaint → disarm)', async () => {
+    const stdout = makeStdout(COLS, ROWS);
+    const stdin = makeStdin();
+    const all = collect(stdout);
+    const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+    statusLine.start();
+    statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1 });
+    await c.arm();
+    statusLine.setExtraRows(2);
+    c.setSpinner({ enabled: true });
+
+    const tallOverlay = Array.from({ length: 22 }, (_, i) => `thinking ${i} — held overlay row keeping the frame at full height`).join('\n');
+    const reportRows = [
+      'NORM_HEADER unique marker row',
+      'NORM_LINE_A first body row',
+      'NORM_LINE_B second body row',
+      'NORM_LINE_C third body row',
+    ];
+    c.setOverlay(tallOverlay);
+    c.commitAbove(`${reportRows.join('\n')}\n\n`);
+
+    const internals = c as unknown as {
+      repaint(): void;
+      committedBand: string[];
+      committedBandPaintedRows: number;
+    };
+    expect(internals.committedBandPaintedRows, 'block starts fully pending').toBe(0);
+
+    // NORMAL path: the overlay collapses (turn ends → spinner stops, overlay
+    // clears). repositionCommittedBand paints the band on the collapse repaint —
+    // so committedBandPaintedRows becomes the full band length.
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    internals.repaint();
+    internals.repaint();
+    expect(
+      internals.committedBandPaintedRows,
+      'after collapse the band is fully painted on screen',
+    ).toBe(internals.committedBand.length);
+
+    // THEN disarm. The flush MUST be a no-op (painted === length): the rows are
+    // already on screen, so re-emitting them would DUPLICATE them in scrollback.
+    statusLine.stop();
+    c.disarm();
+
+    const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 400, allowProposedApi: true, convertEol: true });
+    await termWrite(term, all());
+    const lines = allLines(term);
+    const dump = lines.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l.replace(/\s+$/, ''))}`).join('\n');
+
+    // Each committed row present EXACTLY ONCE — not twice. A regression in the
+    // disarm flush (flushing already-painted rows) would make this 2.
+    for (const row of reportRows) {
+      const marker = row.split(' ')[0]!;
+      const hits = lines.filter((l) => l.includes(marker)).length;
+      expect(
+        hits,
+        `committed row "${marker}" must appear exactly once after normal collapse→disarm (found ${hits}):\n${dump}`,
+      ).toBe(1);
+    }
+
+    term.dispose(); c.disarm();
+  }, 15_000);
+});

--- a/src/cli/terminal-compositor.frame-preserve.ts
+++ b/src/cli/terminal-compositor.frame-preserve.ts
@@ -75,6 +75,11 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
     self.committedBand = self.committedBand.slice(overflow);
     self.committedBandTopRow = 1;
     self.committedBandBottomRow = room;
+    // The full band was re-painted top-aligned above before the scroll, so
+    // every surviving row is materialized on screen (and the evicted prefix is
+    // now in scrollback) — none are pending. Promote any previously-pending
+    // rows that this growth just materialized.
+    self.committedBandPaintedRows = self.committedBand.length;
     return;
   }
 
@@ -112,6 +117,12 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
       }
       if (self.committedBand.length === 0 || self.committedBandBottomRow < floor) {
         self.clearCommittedBand();
+      } else {
+        // Survivors were scrolled by the terminal as real on-screen rows (this
+        // path runs only after a banner-era commit painted them), so all are
+        // materialized — none pending. (A fully-pending band has no banner above
+        // it and cannot reach this branch; this keeps the invariant exact.)
+        self.committedBandPaintedRows = self.committedBand.length;
       }
     }
   }

--- a/src/cli/terminal-compositor.frame.ts
+++ b/src/cli/terminal-compositor.frame.ts
@@ -68,6 +68,7 @@ export interface FrameHost {
   committedBand: string[];
   committedBandTopRow: number;
   committedBandBottomRow: number;
+  committedBandPaintedRows: number;
   hasCommitted: boolean;
   anchorRow: number | undefined;
   lastKnownRows: number;

--- a/src/cli/terminal-compositor.h1-prevtoprow.test.ts
+++ b/src/cli/terminal-compositor.h1-prevtoprow.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Regression (PR #649 follow-up, H1): a multi-line block committed via
+ * commitAbove() while the live overlay FILLS the viewport (prevTopRow == 1)
+ * must be HELD in the band model and painted when the overlay collapses — NOT
+ * dropped down the legacy overflow path.
+ *
+ * Pre-fix: with prevTopRow == 1 the `useBandHold` gate (`prevTopRow > 1 && …`)
+ * and Phase 3's `if (newTopRow > 1)` guard both fail, so Phase 3 falls to
+ * `clearCommittedBand()` and the block is lost from screen AND scrollback. This
+ * is exactly the "lost table" the user saw when a /review streamed a table
+ * under a tall subagent-tree overlay (BLOCKER-1 comment at terminal-compositor.ts
+ * ~1040 documents the drop and notes "No existing test hits prevTopRow <= 1").
+ *
+ * The fix decouples band-hold routing from prevTopRow and adds a Phase 3
+ * newTopRow<=1 storage branch that holds the model "fully pending" with
+ * committedBandBottomRow = collapsedFrameTop - 1 (so consecutive full-overlay
+ * commits MERGE rather than replace).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import xterm from '@xterm/headless';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { StatusLine } from './status-line.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const HeadlessTerminal = (xterm as any).Terminal;
+
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin = NodeJS.ReadStream & { isTTY: boolean; isRaw: boolean; setRawMode: ReturnType<typeof vi.fn> };
+
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true; s.columns = cols; s.rows = rows; return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true; s.isRaw = false; s.setRawMode = vi.fn((r: boolean) => { s.isRaw = r; return s; }); return s;
+}
+function collect(stream: MockStdout): () => string {
+  const c: string[] = [];
+  stream.on('data', (x) => c.push(String(x)));
+  return () => c.join('');
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function termWrite(t: any, d: string): Promise<void> {
+  return new Promise((r) => t.write(d, () => r()));
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function allLines(t: any): string[] {
+  const b = t.buffer.active; const o: string[] = [];
+  for (let i = 0; i < b.length; i++) { const l = b.getLine(i); if (l) o.push(l.translateToString(true)); }
+  return o;
+}
+
+const COLS = 120, ROWS = 24;
+
+describe('commitAbove H1: multi-line block committed at prevTopRow==1 (full-viewport overlay)', () => {
+  it('holds a multi-line block in the band model and paints it on collapse (not dropped)', async () => {
+    const stdout = makeStdout(COLS, ROWS);
+    const stdin = makeStdin();
+    const all = collect(stdout);
+    const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+    statusLine.start();
+    statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1 });
+    await c.arm();
+    statusLine.setExtraRows(2);
+    c.setSpinner({ enabled: true });
+
+    // A 22-line overlay + spinner + gap + input OVERFLOWS the 24-row viewport,
+    // pinning the frame top to row 1 → prevTopRow == 1 at commit time.
+    const tallOverlay = Array.from({ length: 22 }, (_, i) => `thinking ${i} — held overlay row keeping the frame at full height`).join('\n');
+
+    // A multi-line "table" block (no internal blank line) with unique body
+    // markers, committed as ONE block while the overlay fills the viewport.
+    const tableRows = [
+      'TBL_HEADER unique marker row',
+      'TBL_ROW_A first body row',
+      'TBL_ROW_B second body row',
+      'TBL_ROW_C third body row',
+    ];
+    c.setOverlay(tallOverlay);
+    c.commitAbove(`${tableRows.join('\n')}\n\n`);
+
+    // Precondition (proves we exercised the prevTopRow<=1 / newTopRow<=1 storage
+    // branch): the band is non-empty and its bottom sits at collapsedFrameTop-1
+    // (= rows-1-extraRows-1 = 20), the sentinel the H1 branch sets — NOT the
+    // newTopRow-1 a normal (newTopRow>1) commit would set.
+    const internals = c as unknown as { repaint(): void; committedBand: string[]; committedBandBottomRow: number };
+    expect(internals.committedBand.length, 'band model must hold the committed block (not cleared)').toBeGreaterThan(0);
+    expect(internals.committedBandBottomRow, 'must have taken the H1 newTopRow<=1 storage branch (collapsedFrameTop-1=20)').toBe(20);
+
+    // Overlay collapses (turn ends → spinner stops, overlay clears).
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    internals.repaint();
+    internals.repaint();
+
+    const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 400, allowProposedApi: true, convertEol: true });
+    await termWrite(term, all());
+    const lines = allLines(term);
+    const dump = lines.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l.replace(/\s+$/, ''))}`).join('\n');
+
+    // Every committed row must be present EXACTLY ONCE across the whole buffer
+    // (it lives in the painted band after collapse). Pre-fix all rows vanished.
+    for (const row of tableRows) {
+      const marker = row.split(' ')[0]!; // TBL_HEADER / TBL_ROW_A / …
+      const hits = lines.filter((l) => l.includes(marker)).length;
+      expect(hits, `committed row "${marker}" must be present exactly once after collapse (found ${hits}):\n${dump}`).toBe(1);
+    }
+
+    // The body must be visible in the viewport (not stranded in scrollback).
+    const baseY = term.buffer.active.baseY;
+    const view = lines.slice(baseY);
+    for (const marker of ['TBL_HEADER', 'TBL_ROW_A', 'TBL_ROW_B', 'TBL_ROW_C']) {
+      const inView = view.filter((l) => l.includes(marker)).length;
+      expect(inView, `"${marker}" must be visible in the viewport after collapse:\n${dump}`).toBe(1);
+    }
+
+    term.dispose(); statusLine.stop(); c.disarm();
+  }, 15_000);
+
+  it('accumulates MULTIPLE blocks committed under a sustained full-viewport overlay (no drops)', async () => {
+    const stdout = makeStdout(COLS, ROWS);
+    const stdin = makeStdin();
+    const all = collect(stdout);
+    const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+    statusLine.start();
+    statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1 });
+    await c.arm();
+    statusLine.setExtraRows(2);
+    c.setSpinner({ enabled: true });
+
+    const tallOverlay = Array.from({ length: 22 }, (_, i) => `thinking ${i} — sustained tall overlay row`).join('\n');
+    const internals = c as unknown as { repaint(): void; committedBand: string[] };
+
+    // Stream several small blocks while the overlay stays full (prevTopRow==1).
+    // Total rows committed (5) stay within maxBandModel so none should archive
+    // to scrollback — all must accumulate in the band and survive collapse.
+    const markers = ['ACC_ONE', 'ACC_TWO', 'ACC_THREE', 'ACC_FOUR', 'ACC_FIVE'];
+    for (const m of markers) {
+      c.setOverlay(tallOverlay);
+      c.commitAbove(`${m} streamed block under full overlay\n\n`);
+    }
+
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    internals.repaint();
+    internals.repaint();
+
+    const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 400, allowProposedApi: true, convertEol: true });
+    await termWrite(term, all());
+    const lines = allLines(term);
+    const dump = lines.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l.replace(/\s+$/, ''))}`).join('\n');
+
+    // No committed block may be DROPPED: each marker present at least once
+    // somewhere in the buffer (painted band and/or scrollback), never zero.
+    for (const m of markers) {
+      const hits = lines.filter((l) => l.includes(m)).length;
+      expect(hits, `streamed block "${m}" must not be lost (found ${hits}):\n${dump}`).toBeGreaterThanOrEqual(1);
+      expect(hits, `streamed block "${m}" must not be duplicated (found ${hits})`).toBeLessThanOrEqual(1);
+    }
+
+    term.dispose(); statusLine.stop(); c.disarm();
+  }, 15_000);
+
+  it('survives a PARTIAL overlay shrink between commits (pending band at prevTopRow==1 → smaller overlay → next commit)', async () => {
+    // The residual transition: block A is stored FULLY PENDING at prevTopRow==1
+    // (committedBandBottomRow set to the collapsed frame top - 1). Then the
+    // overlay PARTIALLY shrinks (not a full collapse) so the frame top drops to
+    // a mid-screen row, and block B commits there. repositionCommittedBand must
+    // re-pin A's pending model above the new frame top on the shrink so that
+    // (a) A becomes visible and (b) B then merges contiguously with it — neither
+    // block dropped or duplicated.
+    const stdout = makeStdout(COLS, ROWS);
+    const stdin = makeStdin();
+    const all = collect(stdout);
+    const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+    statusLine.start();
+    statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1 });
+    await c.arm();
+    statusLine.setExtraRows(2);
+    c.setSpinner({ enabled: true });
+    const internals = c as unknown as { repaint(): void; committedBand: string[]; committedBandBottomRow: number };
+
+    // Block A committed under a FULL-viewport overlay → stored fully pending.
+    const fullOverlay = Array.from({ length: 22 }, (_, i) => `full overlay row ${i}`).join('\n');
+    const aRows = ['TRANS_ALPHA_1', 'TRANS_ALPHA_2', 'TRANS_ALPHA_3'];
+    c.setOverlay(fullOverlay);
+    c.commitAbove(`${aRows.join('\n')}\n\n`);
+    expect(internals.committedBandBottomRow, 'A must have taken the prevTopRow<=1 storage branch').toBe(20);
+
+    // PARTIAL shrink: overlay drops to 10 lines → frame top moves to a mid row
+    // (prevTopRow > 1, but the frame is NOT fully collapsed). Repaint so
+    // repositionCommittedBand re-pins A above the new frame top before B commits.
+    const smallOverlay = Array.from({ length: 10 }, (_, i) => `small overlay row ${i}`).join('\n');
+    c.setOverlay(smallOverlay);
+    internals.repaint();
+
+    // Block B committed under the SMALLER overlay (prevTopRow > 1 now).
+    const bRows = ['TRANS_BETA_1', 'TRANS_BETA_2'];
+    c.commitAbove(`${bRows.join('\n')}\n\n`);
+
+    // Full collapse.
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    internals.repaint();
+    internals.repaint();
+
+    const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 400, allowProposedApi: true, convertEol: true });
+    await termWrite(term, all());
+    const lines = allLines(term);
+    const dump = lines.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l.replace(/\s+$/, ''))}`).join('\n');
+
+    // Neither block A nor B may be dropped or duplicated across the buffer.
+    for (const m of [...aRows, ...bRows]) {
+      const hits = lines.filter((l) => l.includes(m)).length;
+      expect(hits, `block "${m}" must survive the partial-shrink transition exactly once (found ${hits}):\n${dump}`).toBe(1);
+    }
+
+    // Commit order preserved: A's last row sits above B's first row.
+    const aLast = lines.findIndex((l) => l.includes('TRANS_ALPHA_3'));
+    const bFirst = lines.findIndex((l) => l.includes('TRANS_BETA_1'));
+    expect(aLast, `A and B both present:\n${dump}`).toBeGreaterThanOrEqual(0);
+    expect(bFirst, `A and B both present:\n${dump}`).toBeGreaterThanOrEqual(0);
+    expect(aLast < bFirst, `A must sit above B (commit order):\n${dump}`).toBe(true);
+
+    term.dispose(); statusLine.stop(); c.disarm();
+  }, 15_000);
+});

--- a/src/cli/terminal-compositor.lifecycle.ts
+++ b/src/cli/terminal-compositor.lifecycle.ts
@@ -59,6 +59,9 @@ export interface LifecycleHost {
   pendingResizeErase: { top: number; bottom: number } | null;
   readonly committedBand: string[];
   readonly committedBandTopRow: number;
+  // Read by disarm() to flush genuinely-unpainted committed-band rows to
+  // scrollback before teardown. See committedBandPaintedRows on the class.
+  readonly committedBandPaintedRows: number;
 }
 
 /**
@@ -297,6 +300,21 @@ export function disarm(self: LifecycleHost): void {
     self.resizeImmediateUnsub = null;
   }
 
+  // External constraint (band-hold materialization ordering): a block committed
+  // under a full-viewport overlay is HELD in the committedBand model fully
+  // pending — never painted to the terminal, never archived to scrollback —
+  // until repositionCommittedBand materializes it when the overlay collapses
+  // (committed-band-commit.ts newTopRow<=1 storage branch). If disarm() runs
+  // FIRST (Ctrl-C / turn abort / mid-turn exit), logUpdate.clear() + resetState()
+  // below discard that model, losing the block from screen AND history. So the
+  // pending rows MUST be flushed to scrollback as real content BEFORE the clear
+  // — the inverse-before-teardown rule. The painted suffix is already on screen
+  // (repositionCommittedBand / Phase 3 painted it), so it is intentionally left
+  // untouched; re-emitting it would duplicate it in scrollback (HARD CONSTRAINT
+  // #1). Pending rows go to scrollback ONLY, never an on-screen truncated copy
+  // (HARD CONSTRAINT #2).
+  flushPendingCommittedBand(self);
+
   if (self.logUpdate) {
     try {
       self.logUpdate.clear(self.scrollRegion?.getExtraRows() ?? 0);
@@ -346,4 +364,53 @@ export function disarm(self: LifecycleHost): void {
   // buffer-identity guard in updateGhost's resolve handler will then
   // silently drop any result that arrives after this point.
   self.ghostEngine?.dispose();
+}
+
+/**
+ * Flush the genuinely-unpainted prefix of the committed band to scrollback as
+ * REAL content, so a disarm before repositionCommittedBand materializes a
+ * band-hold model does not lose the committed block from screen AND history.
+ *
+ * Pending rows are the PREFIX `committedBand[0 .. length - committedBandPaintedRows)`
+ * (every paint site materializes the BOTTOM suffix — see committedBandPaintedRows
+ * on the class). When all rows are painted (the common teardown: overlay
+ * collapsed → repositionCommittedBand painted everything → painted === length)
+ * this is a no-op and the on-screen rows are left exactly as they are — never
+ * re-emitted (HARD CONSTRAINT #1: no duplicate in scrollback).
+ *
+ * Mechanism: the proven top-write-then-scroll the band-hold Phase-1 archive
+ * uses (committed-band-commit.ts) — CUP+EL each pending row at the anchor floor,
+ * then a CUP to the physical bottom + `\n`×count to scroll them into history.
+ * Chunked by screen height so a pending run taller than the terminal still
+ * archives every row. Wrapped in `withFullScrollRegion` (no-op when no status
+ * line is started) so the `\n` produces a FULL-screen scroll that enters
+ * scrollback rather than a DECSTBM sub-region scroll that silently drops the
+ * displaced top line. Best-effort: a throwing stdout means the process is
+ * exiting anyway and the next teardown step tears us down.
+ */
+function flushPendingCommittedBand(self: LifecycleHost): void {
+  const pendingCount = self.committedBand.length - self.committedBandPaintedRows;
+  if (pendingCount <= 0) return;
+  const pending = self.committedBand.slice(0, pendingCount);
+  const rows = Math.max(1, self.stdout.rows ?? 24);
+  const anchorFloor = Math.max(self.anchorRow ?? 1, 1);
+  const write = (): void => {
+    const chunkMax = Math.max(1, rows - anchorFloor + 1);
+    for (let start = 0; start < pending.length; start += chunkMax) {
+      const chunk = pending.slice(start, Math.min(start + chunkMax, pending.length));
+      const topWrite = chunk
+        .map((l, i) => `\x1b[${anchorFloor + i};1H\x1b[2K${l ?? ''}`)
+        .join('');
+      self.stdout.write(`${topWrite}\x1b[${rows};1H${'\n'.repeat(chunk.length)}`);
+    }
+  };
+  try {
+    if (self.scrollRegion) {
+      self.scrollRegion.withFullScrollRegion(write);
+    } else {
+      write();
+    }
+  } catch {
+    /* stdout closed mid-flush (process exiting) — nothing more we can do */
+  }
 }

--- a/src/cli/terminal-compositor.overflow-gap.test.ts
+++ b/src/cli/terminal-compositor.overflow-gap.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Regression: a MULTI-LINE block (a rendered markdown table) committed via
+ * commitAbove() while a tall overlay is held up — and then the overlay collapses
+ * — must not (a) duplicate the block (one truncated on-screen copy + one full
+ * scrollback copy) nor (b) leave a multi-row blank gap between the committed
+ * content and the live frame in the final viewport.
+ *
+ * This is the !fitsAboveFrame OVERFLOW path (terminal-compositor.ts), which #645
+ * explicitly left unchanged ("the overflow path is unchanged", docs/scrollback.md).
+ * The screenshot symptom: a table renders its header + divider, then a large
+ * blank gap swallows the body rows, and later content (Evidence) resumes far
+ * below — plus the header appears twice.
+ *
+ * Pre-fix: header appears TWICE (full scrollback copy + truncated on-screen
+ * copy) and a multi-row blank gap opens above the band after collapse.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { StatusLine } from './status-line.js';
+import { renderMarkdownToTerminal } from './formatter.js';
+
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin = NodeJS.ReadStream & { isTTY: boolean; isRaw: boolean; setRawMode: ReturnType<typeof vi.fn> };
+
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true; s.columns = cols; s.rows = rows; return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true; s.isRaw = false; s.setRawMode = vi.fn((r: boolean) => { s.isRaw = r; return s; }); return s;
+}
+function collect(stream: MockStdout): () => string {
+  const c: string[] = [];
+  stream.on('data', (x) => c.push(String(x)));
+  return () => c.join('');
+}
+function termWrite(t: HeadlessTerminal, d: string): Promise<void> {
+  return new Promise((r) => t.write(d, r));
+}
+function allLines(t: HeadlessTerminal): string[] {
+  const b = t.buffer.active; const o: string[] = [];
+  for (let i = 0; i < b.length; i++) { const l = b.getLine(i); if (l) o.push(l.translateToString(true)); }
+  return o;
+}
+
+const COLS = 120, ROWS = 24;
+
+// A realistic diagnosis-summary markdown table (mirrors the screenshot columns).
+const TABLE_MD = [
+  '| # | Change | File | Nature |',
+  '|---|--------|------|--------|',
+  '| 1 | pass cwd to scheduler | scheduler.ts | behavior |',
+  '| 2 | load config from cwd | config-loader.ts | behavior |',
+  '| 3 | thread cwd through daemon | daemon.ts | plumbing |',
+].join('\n');
+
+describe('commitAbove overflow-path table gap regression (tall overlay, extraRows=2)', () => {
+  it('commits a multi-line table under a tall overlay without duplicate or blank gap', async () => {
+    const stdout = makeStdout(COLS, ROWS);
+    const stdin = makeStdin();
+    const all = collect(stdout);
+    const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+    statusLine.start();
+    statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1 });
+    await c.arm();
+    // Production footer: StatusLine + LoopStageBar + VerdictLedger → extraRows=2.
+    statusLine.setExtraRows(2);
+    c.setSpinner({ enabled: true });
+
+    const tableText = renderMarkdownToTerminal(TABLE_MD, { width: COLS });
+    const tableLineCount = tableText.replace(/\n$/, '').split('\n').length;
+
+    // A persistent tall overlay (heavy tool-lane / thinking activity) held up
+    // across every commit — the trigger for the overflow path.
+    const tallOverlay = Array.from({ length: 14 }, (_, i) => `thinking ${i} — dispatched subagent, verifying claim ${i}`).join('\n');
+
+    // Mirror the production "Done" report streamed as blocks while the overlay
+    // stays tall (markdown-stream commits each block as `text + '\n\n'`).
+    c.setOverlay(tallOverlay);
+    c.commitAbove('Diagnosis complete\n\n');
+    c.setOverlay(tallOverlay);
+    c.commitAbove('What I diagnosed: the TUI rendering defect in your screenshot.\n\n');
+    c.setOverlay(tallOverlay);
+    c.commitAbove(tableText.replace(/\n$/, '') + '\n\n');
+    c.setOverlay(tallOverlay);
+    c.commitAbove('Evidence (deterministic, reproduced): header + divider render, then a gap.\n\n');
+
+    // The overlay collapses (turn ends → spinner stops, overlay clears).
+    c.setOverlay('');
+    const internals = c as unknown as { repaint(): void };
+    internals.repaint();
+    internals.repaint();
+
+    const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 400, allowProposedApi: true, convertEol: true });
+    await termWrite(term, all());
+    const lines = allLines(term);
+    const dump = lines.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l.replace(/\s+$/, ''))}`).join('\n');
+
+    const SPINNER_RE = /[\u2800-\u28ff]/; // braille spinner glyphs
+    const baseY = term.buffer.active.baseY; // first viewport row index
+    const view = lines.slice(baseY);
+    const frameIdx = view.findIndex((l) => SPINNER_RE.test(l));
+    expect(frameIdx, `frame (spinner) not found in viewport:\n${dump}`).toBeGreaterThanOrEqual(0);
+
+    // (1) NO DUPLICATE: the table header ("Change" + "Nature") appears exactly
+    //     once across the whole buffer (scrollback + viewport). Pre-fix the
+    //     overflow path archived the block to scrollback AND painted a truncated
+    //     on-screen copy → the header showed up twice.
+    const headerHits = lines.map((l, i) => (l.includes('Change') && l.includes('Nature') ? i : -1)).filter((i) => i >= 0);
+    expect(
+      headerHits.length,
+      `table header must appear exactly once (found ${headerHits.length}); tableLineCount=${tableLineCount}:\n${dump}`,
+    ).toBe(1);
+
+    // (2) VISIBLE + INTACT: the report fits the collapsed screen, so the whole
+    //     table (header + all three body rows) must be present IN THE VIEWPORT —
+    //     not pushed to scrollback, not truncated. Pre-fix the body rows were
+    //     swallowed by the void / stranded in scrollback.
+    const wantInView = [
+      'Change', // header
+      'pass cwd to scheduler', // body 1
+      'load config from cwd', // body 2
+      'thread cwd through daemon', // body 3
+      'Diagnosis complete', // prose before the table
+      'Evidence (deterministic', // prose after the table
+    ];
+    for (const needle of wantInView) {
+      const inView = view.slice(0, frameIdx).filter((l) => l.includes(needle)).length;
+      expect(inView, `"${needle}" must appear exactly once in the viewport above the frame:\n${dump}`).toBe(1);
+    }
+
+    // (3) CONTIGUOUS, NO VOID: between the first non-blank content row and the
+    //     frame there must be no run of >= 2 consecutive blank rows (one blank is
+    //     the legit rhythm separator between committed blocks). This is the
+    //     screenshot's "massive void" between the header and the body rows.
+    const firstContent = view.findIndex((l) => l.trim() !== '');
+    let maxBlankRun = 0, cur = 0;
+    for (let i = Math.max(0, firstContent); i < frameIdx; i++) {
+      if ((view[i] ?? '').trim() === '') { cur++; maxBlankRun = Math.max(maxBlankRun, cur); }
+      else cur = 0;
+    }
+    expect(
+      maxBlankRun,
+      `blank gap of ${maxBlankRun} rows in viewport between content and frame (baseY=${baseY} frameIdx=${frameIdx} firstContent=${firstContent}):\n${dump}`,
+    ).toBeLessThanOrEqual(1);
+
+    // (4) HUGS THE FRAME: the committed run's last content row sits immediately
+    //     above the frame (the bottom-anchored "input pinned, content rises"
+    //     geometry), with at most the one rhythm-separator blank between them.
+    const lastContent = (() => { for (let i = frameIdx - 1; i >= 0; i--) if ((view[i] ?? '').trim() !== '') return i; return -1; })();
+    expect(
+      frameIdx - lastContent,
+      `committed run does not hug the frame (lastContent=${lastContent} frame=${frameIdx}):\n${dump}`,
+    ).toBeLessThanOrEqual(2);
+
+    term.dispose(); statusLine.stop(); c.disarm();
+  }, 15_000);
+});
+
+/**
+ * Regression (Codex PR #649 P1): the band-hold path must not lose committed
+ * rows when streaming commits push the run past `maxBandModel` while a tall
+ * overlay is still held up.
+ *
+ * Geometry (re-derived against running code, not the diff): ROWS=24,
+ * extraRows=2, anchorRow=1, a 17-line overlay held across every commit pins
+ * the frame top at row 2 → room=1 (one visible above-frame row) and
+ * maxBandModel=20. Committing one-content-line blocks (`"Rxx\n\n"` →
+ * ['Rxx',''] = 1 content + 1 rhythm-separator blank) grows the band-hold MODEL
+ * by 2 rows per commit; only the bottom 1 is painted (room=1), the rest are
+ * "pending" — in the model, never on screen, never in scrollback. After 10
+ * such commits the model holds exactly 20 rows = maxBandModel.
+ *
+ * The bug: an 11th commit makes `overflowRun.length` = 20 + 2 = 22 >
+ * maxBandModel=20, which on HEAD flips `useBandHold` to false EVEN THOUGH
+ * `overflowHasPending` is true. The fits path (fitsAboveFrame, since the new
+ * block fits room=1's first line) then computes its scroll count from
+ * `committedBand.length` (20) and emits ~20 line-feeds — but only 1 of those
+ * rows was ever painted, so ~19 BLANK rows scroll into scrollback while
+ * Phase 3's cap (`run.slice(-maxRun)`) drops the ~19 pending real rows on the
+ * false premise they reached scrollback. Most of the streamed report vanishes
+ * — exactly the lost-table symptom the fits-path comment at
+ * terminal-compositor.ts ~1216-1228 already documents for a different trigger.
+ *
+ * A run genuinely taller than the collapsed screen (overflowRun.length truly
+ * exceeds maxBandModel) is legitimately off-screen and SHOULD archive its
+ * OVERFLOW (the oldest rows) to scrollback — but it must archive REAL content,
+ * never blanks, and must not drop or duplicate rows. After the overlay
+ * collapses, every committed row must be present exactly once across the whole
+ * buffer (oldest in scrollback, the rest visible in the viewport), the header
+ * must appear exactly once, and the run must hug the frame with no >=2-row void.
+ *
+ * Isolation note: to test ONLY the band-hold cap/routing mechanism the finding
+ * names — and NOT the separate, pre-existing fact that maxBandModel can exceed
+ * the room a NON-minimal collapsed frame leaves (repositionCommittedBand paints
+ * but does not evict that excess) — the overlay collapse here also stops the
+ * spinner, leaving a 1-row collapsed frame so the above-frame room at collapse
+ * (20) equals maxBandModel (20). That keeps the assertion focused on the
+ * reported pending-row loss; the collapsed-frame-height gap is out of scope for
+ * this fix.
+ */
+describe('commitAbove band-hold cap (run exceeds maxBandModel while a tall overlay is held)', () => {
+  it('archives the genuine overflow to scrollback instead of stranding pending rows', async () => {
+    const stdout = makeStdout(COLS, ROWS);
+    const stdin = makeStdin();
+    const all = collect(stdout);
+    const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+    statusLine.start();
+    statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1 });
+    await c.arm();
+    statusLine.setExtraRows(2);
+    c.setSpinner({ enabled: true });
+
+    // 17-line overlay → frame top pinned at row 2 → room=1, maxBandModel=20.
+    // (overlay 17 + spinner 1 + gap 1 + input 1 = 20 frame rows;
+    //  desiredTopRow = max(1, (24-1-2) - 20 + 1) = 2.)
+    const tallOverlay = Array.from(
+      { length: 17 },
+      (_, i) => `thinking ${i} — held overlay row ${i} keeping the frame tall`,
+    ).join('\n');
+
+    // Stream a "report" as blocks while the overlay stays tall. Each block is
+    // committed with the trailing '\n\n' that markdown-stream uses per block,
+    // so a single-content-line block ("Rxx\n\n") contributes 2 MODEL rows
+    // (1 content + 1 rhythm-separator blank) and an N-line block contributes
+    // N+1. Unique Rxx labels let us assert NO row is lost or duplicated. The
+    // first block carries a "HEADER-MARKER" sentinel (the table-header
+    // single-copy invariant). One block is a contiguous 3-row "table" to mirror
+    // the screenshot's rendered table.
+    //
+    // We size the accumulation to leave the band-hold model at EXACTLY
+    // maxBandModel=20 rows BEFORE the transition commit, so the transition
+    // (+2 rows) makes overflowRun=22 > maxBandModel — the precise condition the
+    // finding names. Layout (model-row running total):
+    //   header (1+1)            → 2
+    //   4 prose (4×(1+1))       → 10
+    //   table  (3+1)            → 14
+    //   3 prose (3×(1+1))       → 20   ← model == maxBandModel
+    const internals = c as unknown as {
+      repaint(): void;
+      committedBand: string[];
+    };
+    const reportRows: string[] = [];
+    const commit = (s: string): void => {
+      c.setOverlay(tallOverlay); // re-arm the held overlay before each commit
+      c.commitAbove(s);
+    };
+    const prose = (label: string): void => {
+      const row = `${label} prose row of the streamed report`;
+      reportRows.push(row);
+      commit(`${row}\n\n`);
+    };
+    // Block 0: a header line (sentinel) — label R00.
+    reportRows.push('HEADER-MARKER R00 — Diagnosis summary');
+    commit('HEADER-MARKER R00 — Diagnosis summary\n\n');
+    // Blocks 1-4: prose rows R01..R04.
+    for (let i = 1; i <= 4; i++) prose(`R${String(i).padStart(2, '0')}`);
+    // Block 5: a contiguous 3-row "table" committed as ONE block (the
+    // screenshot's rendered table — header+divider+row arrive together).
+    const tableRows = [
+      'R05 | Change                | File             |',
+      'R06 |-----------------------|------------------|',
+      'R07 | pass cwd to scheduler | scheduler.ts     |',
+    ];
+    reportRows.push(...tableRows);
+    commit(`${tableRows.join('\n')}\n\n`);
+    // Blocks 6-8: prose rows R08..R10, bringing the model to exactly 20.
+    for (let i = 8; i <= 10; i++) prose(`R${String(i).padStart(2, '0')}`);
+
+    // Precondition (locks the geometry against drift): the band-hold model is
+    // now full at exactly maxBandModel=20, with only the bottom row painted
+    // (room=1) and the other 19 pending. If this ever changes the test's
+    // premise is invalid and the assertions below would silently stop covering
+    // the finding — so assert it explicitly.
+    expect(
+      internals.committedBand.length,
+      'precondition: band-hold model must be full at maxBandModel=20 before the transition commit',
+    ).toBe(20);
+
+    // The transition commit: one more block under the STILL-held overlay.
+    // overflowRun = 20 + 2 = 22 > maxBandModel=20. On HEAD this flips
+    // useBandHold false → the fits path scrolls ~19 unpainted (blank) rows into
+    // scrollback and drops the pending real rows (band collapses to just this
+    // line). With the fix the commit stays in band-hold and archives the
+    // genuine overflow (oldest rows) as real content to scrollback.
+    reportRows.push('TRANSITION-LINE the streaming commit after the band filled');
+    commit('TRANSITION-LINE the streaming commit after the band filled\n\n');
+
+    // The overlay collapses (turn ends → spinner stops, overlay clears). Stop
+    // the spinner so the collapsed frame is 1 row (input only): the above-frame
+    // room at collapse (20) then equals maxBandModel (20), isolating the
+    // band-hold cap mechanism from the separate collapsed-frame-height gap.
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    internals.repaint();
+    internals.repaint();
+
+    const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 400, allowProposedApi: true, convertEol: true });
+    await termWrite(term, all());
+    const lines = allLines(term);
+    const dump = lines.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l.replace(/\s+$/, ''))}`).join('\n');
+
+    // With the spinner stopped the collapsed frame is the single input row,
+    // which renders the `⎯` rule (U+23AF) — used as the frame anchor.
+    const FRAME_RE = /\u23af/; // the input row's horizontal-rule glyph
+    const baseY = term.buffer.active.baseY;
+    const view = lines.slice(baseY);
+    const frameIdx = view.findIndex((l) => FRAME_RE.test(l));
+    expect(frameIdx, `frame (input rule) not found in viewport:\n${dump}`).toBeGreaterThanOrEqual(0);
+
+    // (1) NO DATA LOSS / NO DUPLICATE: every committed report row carries a
+    //     unique R<dd> label (R00..R10) and must be present EXACTLY ONCE across
+    //     the whole buffer (scrollback + viewport) — oldest rows archived to
+    //     scrollback, the rest visible in the viewport. Pre-fix most rows vanish
+    //     (scrolled as blanks then dropped by the cap).
+    for (const row of reportRows) {
+      const m = row.match(/R\d\d/); // the unique R<dd> label
+      if (!m) continue; // the TRANSITION-LINE row has no Rxx label — covered below
+      const label = m[0];
+      const hits = lines.filter((l) => l.includes(label)).length;
+      expect(hits, `report row ${label} must be present exactly once across the whole buffer (found ${hits}):\n${dump}`).toBe(1);
+    }
+    const transHits = lines.filter((l) => l.includes('TRANSITION-LINE')).length;
+    expect(transHits, `the transition line must be present exactly once across the whole buffer (found ${transHits}):\n${dump}`).toBe(1);
+
+    // (2) NO DUPLICATE header: the sentinel appears exactly once buffer-wide.
+    const headerHits = lines.filter((l) => l.includes('HEADER-MARKER')).length;
+    expect(headerHits, `HEADER-MARKER must appear exactly once (found ${headerHits}):\n${dump}`).toBe(1);
+
+    // (3) VISIBLE + INTACT IN VIEWPORT: the newest rows (everything after the
+    //     oldest few that legitimately archive to scrollback) must be visible
+    //     above the frame. Assert the transition line and the last few report
+    //     rows appear in the viewport above the frame exactly once.
+    const wantInView = [
+      'TRANSITION-LINE',
+      'R10 prose',
+      'R09 prose',
+      'R07 | pass cwd to scheduler', // last table row
+    ];
+    for (const needle of wantInView) {
+      const inView = view.slice(0, frameIdx).filter((l) => l.includes(needle)).length;
+      expect(inView, `"${needle}" must appear exactly once in the viewport above the frame:\n${dump}`).toBe(1);
+    }
+
+    // (4) NO BLANK VOID: pre-fix ~19 BLANK rows were scrolled into scrollback in
+    //     place of real content. Assert no run of >= 2 consecutive blank rows
+    //     between the first non-blank row and the frame (one blank is the
+    //     per-block rhythm separator).
+    const firstContentAbs = lines.findIndex((l) => l.trim() !== '');
+    const frameAbs = baseY + frameIdx;
+    let maxBlankRun = 0, cur = 0;
+    for (let i = Math.max(0, firstContentAbs); i < frameAbs; i++) {
+      if ((lines[i] ?? '').trim() === '') { cur++; maxBlankRun = Math.max(maxBlankRun, cur); }
+      else cur = 0;
+    }
+    expect(
+      maxBlankRun,
+      `blank gap of ${maxBlankRun} rows between content and frame (firstContent=${firstContentAbs} frame=${frameAbs} baseY=${baseY}):\n${dump}`,
+    ).toBeLessThanOrEqual(1);
+
+    // (5) HUGS THE FRAME: the most-recent committed row (the transition line)
+    //     sits immediately above the frame, with at most one rhythm-separator
+    //     blank between them.
+    const lastContent = (() => { for (let i = frameIdx - 1; i >= 0; i--) if ((view[i] ?? '').trim() !== '') return i; return -1; })();
+    expect(
+      frameIdx - lastContent,
+      `committed run does not hug the frame (lastContent=${lastContent} frame=${frameIdx}):\n${dump}`,
+    ).toBeLessThanOrEqual(2);
+
+    term.dispose(); statusLine.stop(); c.disarm();
+  }, 15_000);
+});

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -284,6 +284,23 @@ export class TerminalCompositor {
   committedBandTopRow = 0;
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   committedBandBottomRow = 0;
+  // Invariant: committedBandPaintedRows counts how many of committedBand's rows
+  // are MATERIALIZED on the terminal right now — always the BOTTOM
+  // committedBandPaintedRows rows (nearest the frame), since every paint site
+  // (commitAbove Phase 3, repositionCommittedBand, preserveRowsBeforeFrameRender)
+  // CUP-paints the band's suffix. The complementary PREFIX
+  // committedBand.slice(0, length - committedBandPaintedRows) is PENDING: held
+  // only in this in-memory model, never written to the terminal and never
+  // archived to scrollback. The band-hold storage branch in commitAbove (taken
+  // when a block is committed under a full-viewport overlay, newTopRow <= 1)
+  // sets this to 0 — the whole block is pending until repositionCommittedBand
+  // paints it on collapse. disarm() reads this to flush only the genuinely
+  // unpainted prefix into scrollback before tearing down (the painted suffix is
+  // already on screen, so re-emitting it would duplicate it). Always satisfies
+  // 0 <= committedBandPaintedRows <= committedBand.length; reset to 0 by
+  // clearCommittedBand() and (transitively) resetState().
+  /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
+  committedBandPaintedRows = 0;
   // Resize ghost-erase state. On SIGWINCH the immediate handler snapshots the
   // pre-resize on-screen footprint of the compositor (old live-frame rows +
   // committed-band rows) into `pendingResizeErase`; the next repaint physically

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -284,18 +284,6 @@ export class TerminalCompositor {
   committedBandTopRow = 0;
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   committedBandBottomRow = 0;
-  // Content COVERED by a full-viewport frame (desiredTopRow ≤ 1) rather than
-  // displayed: when the overlay fills the screen there is no above-frame row to
-  // show the committed band, but the overlay is transient. Stashing the most-
-  // recent committed block here (instead of dropping it) lets
-  // repositionCommittedBand re-pin it adjacent to the frame the moment the
-  // overlay collapses — otherwise the band is empty on collapse and
-  // CupFrameRenderer shrink-pads blank rows that nothing refills (the "massive
-  // blank gap"). Invalidated whenever an on-screen band is (re-)established or
-  // the band is reset (clearCommittedBand). See repositionCommittedBand().
-  /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
-  coveredBand: string[] = [];
-
   // Resize ghost-erase state. On SIGWINCH the immediate handler snapshots the
   // pre-resize on-screen footprint of the compositor (old live-frame rows +
   // committed-band rows) into `pendingResizeErase`; the next repaint physically

--- a/src/cli/terminal-compositor.wrap-overlap.test.ts
+++ b/src/cli/terminal-compositor.wrap-overlap.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression (PR #649 follow-up, "eating the bottom"): when a committed block
+ * contains a logical line WIDER than the terminal, the terminal hard-wraps it
+ * into ≥2 physical rows. commitAbove() must count those physical rows so the
+ * NEXT commit is positioned below them — otherwise the next block is painted
+ * onto the prior block's wrapped tail, overwriting ("eating") it.
+ *
+ * Pre-fix: lineCount = newline-count (wrap-blind), so a wide single-line block
+ * counts as 1 row. Phase 1 scrolls 1 row and Phase 3 tracks 1 row; the next
+ * commit's paint lands on the wide line's wrapped 2nd row and clobbers it.
+ *
+ * Fix: hardWrapToWidth() splits each logical line into its visual rows up front
+ * (pure character wrap matching the terminal), so lineCount == physical rows.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { StatusLine } from './status-line.js';
+
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin = NodeJS.ReadStream & { isTTY: boolean; isRaw: boolean; setRawMode: ReturnType<typeof vi.fn> };
+
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true; s.columns = cols; s.rows = rows; return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true; s.isRaw = false; s.setRawMode = vi.fn((r: boolean) => { s.isRaw = r; return s; }); return s;
+}
+function collect(stream: MockStdout): () => string {
+  const c: string[] = [];
+  stream.on('data', (x) => c.push(String(x)));
+  return () => c.join('');
+}
+function termWrite(t: HeadlessTerminal, d: string): Promise<void> { return new Promise((r) => t.write(d, r)); }
+function allLines(t: HeadlessTerminal): string[] {
+  const b = t.buffer.active; const o: string[] = [];
+  for (let i = 0; i < b.length; i++) { const l = b.getLine(i); if (l) o.push(l.translateToString(true)); }
+  return o;
+}
+
+const COLS = 40, ROWS = 24;
+
+describe('commitAbove wrap-aware line counting ("eating the bottom" overlap)', () => {
+  it('does not let the next commit overwrite a wide block\'s wrapped tail', async () => {
+    const stdout = makeStdout(COLS, ROWS);
+    const stdin = makeStdin();
+    const all = collect(stdout);
+    const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+    statusLine.start();
+    statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1 });
+    await c.arm();
+    const internals = c as unknown as { repaint(): void };
+
+    // Block 1: ONE logical line of 55 chars on a 40-col terminal → wraps to 2
+    // physical rows: row A = 40 'X', row B = "WRAPTAIL_UNIQUE" (15 chars).
+    const wideLine = 'X'.repeat(COLS) + 'WRAPTAIL_UNIQUE';
+    expect(wideLine.length).toBe(COLS + 15);
+    c.commitAbove(`${wideLine}\n`);
+
+    // Block 2: a distinct one-line block committed immediately after.
+    c.commitAbove('SECONDBLOCK_UNIQUE\n');
+
+    internals.repaint();
+
+    const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 400, allowProposedApi: true, convertEol: true });
+    await termWrite(term, all());
+    const lines = allLines(term);
+    const dump = lines.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l.replace(/\s+$/, ''))}`).join('\n');
+
+    // The wide block's wrapped tail must SURVIVE — pre-fix the second block's
+    // paint landed on its row and overwrote it (0 occurrences).
+    const tailRows = lines.map((l, i) => (l.includes('WRAPTAIL_UNIQUE') ? i : -1)).filter((i) => i >= 0);
+    const secondRows = lines.map((l, i) => (l.includes('SECONDBLOCK_UNIQUE') ? i : -1)).filter((i) => i >= 0);
+    expect(tailRows.length, `wide block's wrapped tail must survive exactly once:\n${dump}`).toBe(1);
+    expect(secondRows.length, `second block must be present exactly once:\n${dump}`).toBe(1);
+
+    // No overlap: the two markers occupy DIFFERENT physical rows, and the wide
+    // block's tail sits ABOVE the second block (commit order preserved).
+    expect(tailRows[0], `tail and second block must not share a row:\n${dump}`).not.toBe(secondRows[0]);
+    expect(tailRows[0]! < secondRows[0]!, `wide block tail must sit above the later block:\n${dump}`).toBe(true);
+
+    // Sanity: the wide block's first physical row (40 X's) is still intact and
+    // sits immediately above its wrapped tail.
+    const headRow = tailRows[0]! - 1;
+    expect(lines[headRow]?.includes('X'.repeat(COLS)), `wide block head row (40 X) must precede the tail:\n${dump}`).toBe(true);
+
+    term.dispose(); statusLine.stop(); c.disarm();
+  }, 15_000);
+});

--- a/src/cli/wrap.ts
+++ b/src/cli/wrap.ts
@@ -26,3 +26,27 @@ export function wrapToWidth(text: string, width: number): string {
     wordWrap: true,
   });
 }
+
+/**
+ * Hard-wrap `text` to exactly `width` display columns by CHARACTER, matching a
+ * terminal's auto-wrap: long unbreakable tokens ARE split at the column
+ * boundary (no word awareness), and ANSI styling is preserved across rows.
+ *
+ * Use when the resulting row COUNT and per-row content must match what the
+ * terminal will physically render — e.g. cursor-addressed (CUP) painting and
+ * scroll-count math, where treating a wrapped line as a single row corrupts the
+ * layout. `wrapToWidth` (word-wrap, `hard: false`) does NOT split long tokens,
+ * so it under-counts physical rows and must not be used for that purpose.
+ *
+ * Non-finite or ≤0 `width` returns `text` unchanged.
+ */
+export function hardWrapToWidth(text: string, width: number): string {
+  if (!Number.isFinite(width) || width <= 0 || width === Number.POSITIVE_INFINITY) {
+    return text;
+  }
+  return wrapAnsi(text, Math.floor(width), {
+    hard: true,
+    trim: false,
+    wordWrap: false,
+  });
+}


### PR DESCRIPTION
**Source:** [afk-workshop#649](https://github.com/griffinwork40/afk-workshop/pull/649) — "fix(tui): keep multi-line blocks visible (band-hold) when committed under a tall overlay"

> ⚠️ **This is NOT a 1:1 port — it is a structural re-targeting + hand-integration onto public's evolved code.** Please read "How this differs from the private PR" before reviewing. Moat triage: nothing to scrub (pure TUI rendering).

## What it does
When a multi-line block (e.g. a streamed markdown table / "Done" report) is committed via `commitAbove` while a tall overlay is up, the old overflow path archived it to scrollback **and** painted a truncated on-screen copy — duplicate header, orphan `├──┼──┤` divider, a blank void swallowing the body, and prior prose vanishing. Band-hold instead keeps the full run in the `committedBand` model (capped at `maxBandModel`), paints only the rows that fit now, holds the rest pending, and `repositionCommittedBand` materializes the whole run contiguously on collapse. Genuine overflow (beyond the collapsed screen) is archived to scrollback as real content, chunked by screen height.

## Ported (all public-safe)
- New pure helpers: `src/cli/commit-mode.ts` (`decideCommitMode`, `capBandModel`) + `hardWrapToWidth` in `src/cli/wrap.ts`.
- Band-hold integrated into `src/cli/terminal-compositor.committed-band-commit.ts`: routing via `decideCommitMode`, a Phase-1 band-hold archive branch, Phase-3 band-hold branches (paint suffix / store-pending), and wrap-aware physical line counting. The superseded `coveredBand` park/promote is removed.
- `coveredBand` removed from `committed-band-repin.ts` and the field on `terminal-compositor.ts`.
- `markdown-stream.ts`: `syncPendingOverlay()` re-composes the overlay before each `commitAbove` (the load-bearing fix — keeps a stale tall overlay from pinning the frame to row 1).
- Regression tests: `commit-mode.test.ts`, `terminal-compositor.{overflow-gap,h1-prevtoprow,wrap-overlap}.test.ts`, plus updates to `golden-rendering`, `markdown-stream`, `commit-collapse-wrap-gap` tests.
- `docs/scrollback.md` design notes.

## Dropped (and why)
Nothing dropped for moat — the change carries none. One **intentional non-port**: I did **not** apply the private PR's tail→head flip of the legacy overflow paint. Public's tail-slice (which keeps a verdict card's closing `╰──╯` visible) is load-bearing for public's existing tests; band-hold subsumes the card-sized case instead, so the legacy overflow path stays untouched.

## How this differs from the private PR (reviewer: please read)
Private's `committed-band.ts` is monolithic; **public split it** into `committed-band-commit.ts` + `committed-band-repin.ts` (public #78) **and** carries committed-band fixes the private #649 base never had — separator/TUI-rhythm, `first-turn-banner-echo`, `pad-decay-straddle`, `banner-commit-gap`, `wrap-gap`, the extended-contiguity band merge, orphan-row erase, and `scrolledRows`/anchor-floor-follow. So the private diff did not apply. Band-hold was **re-implemented onto public's base, surgically + additively**:
- Band-hold is a **new route** checked before the existing fits/overflow branches; public's fits/overflow/separator/shrink-pad/contiguity machinery is left **unchanged**.
- `decideCommitMode` is fed a **separator-inclusive** `bandLineCount`/`bandTextLines`, so a held block keeps its trailing rhythm blank — the correct extension of public's rhythm contract into band-hold (validated by both the band-hold tests and public's separator/rhythm tests passing).

## ⚠️ One latent edge — NOT fixed, needs a real terminal
`scrolledRows = fitsAboveFrame ? bandOverflow : 0` in `committed-band-commit.ts`. If public's `fitsAboveFrame` **and** `useBandHold` are both true at once (narrow: a banner session + a non-contiguous existing band + a trailing separator + `room == contentLineCount` exactly), the anchor floor could decrement without a matching band-hold scroll (≤1-row floor drift). It is test-green and nearly unreachable, and I would not ship an unvalidated change to floor logic. Candidate fix to evaluate with a real terminal: `scrolledRows = useBandHold ? 0 : (fitsAboveFrame ? bandOverflow : 0)`.

## Verification
- `tsc --noEmit` clean · `pnpm build` ok · `pnpm build:dist` ok.
- Full suite: **9359 passed · 12 skipped · 1 failed**. The single failure (`config.test.ts` model-slot bindings) is **pre-existing and environment-local** — it fails identically on the unmodified baseline (the test reads local model config), and is unrelated to this change.
- Deterministic moat guard over tree + `dist/`: **CLEAN**. Independent adversarial moat audit: **CLEAN**.

## Follow-up (not in this PR)
Sync the reconciled band-hold back into private `afk-workshop` so the two repos' committed-band implementations converge (private has band-hold on the monolithic structure; this PR has it on the split structure with public's newer fixes).

---
**Please do not merge automatically — this needs human review**, especially the re-targeting and the `scrolledRows` edge note.
