### PR TITLE
refactor(provider): promote hookRegistry into the dispatcher contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Audit env-registry docs (docs/env-registry.{json,md} in sync with src/config/env.ts)
         run: pnpm scan:env:check
 
+      - name: Audit SDK dependency surface (no unlocked @anthropic-ai/sdk imports)
+        run: pnpm audit:sdk:check
+
       - name: Build
         run: pnpm build
 

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -179,3 +179,22 @@ export interface HookRegistry {
 export function createHookRegistry(): HookRegistry {
   return createHookRegistryImpl();
 }
+
+/**
+ * Resolve the hook registry a provider threads into its per-query dispatcher.
+ * Precedence: the query-scoped session registry (`AgentConfig.hookRegistry`,
+ * supplied per `provider.query({ config })` — the production path) wins over a
+ * constructor-time registry (legacy / test convenience). `undefined` only when
+ * neither is set.
+ *
+ * Single canonical merge point for every provider — do not re-implement the
+ * precedence inline. `SessionToolDispatcherOptions.hookRegistry` is a required
+ * key, so building a dispatcher without threading this result is a compile
+ * error (the c6892c6 plan-mode write-gate regression, made structural).
+ */
+export function resolveSessionHookRegistry(
+  queryScoped: HookRegistry | undefined,
+  constructorScoped: HookRegistry | undefined,
+): HookRegistry | undefined {
+  return queryScoped ?? constructorScoped;
+}

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -47,6 +47,7 @@ import { builtinToolSchemas, agentTool, skillTool, composeTool } from '../../too
 import { TOOL_SYSTEM_PROMPT_BASE, SLASH_COMMAND_ROUTING_PROMPT, BASH_PASSTHROUGH_PROMPT, MEMORY_SYSTEM_PROMPT, MEMORY_SYSTEM_PROMPT_READONLY } from '../../tools/system-prompt.js';
 import { withMcpToolsAllowed, type ToolPermissionConfig } from '../../tools/permissions.js';
 import type { HookRegistry } from '../../hooks.js';
+import { resolveSessionHookRegistry } from '../../hooks.js';
 import type { SubagentExecutor } from '../../tools/subagent-executor.js';
 import { maxOutputTokensFor } from '../../model-limits.js';
 import type { SkillExecutor } from '../../tools/skill-executor.js';
@@ -352,12 +353,11 @@ export class AnthropicDirectProvider implements ModelProvider {
       // Constraint (semantic invariant): MCP schemas appended AFTER builtins
       // so builtin tool names always take precedence in any overlap.
       schemas: [...this.schemas, ...mcpSchemas],
-      // Prefer the session-scoped registry from the query config (the
-      // production path — see the opts.hookRegistry doc above); fall back to
-      // any constructor-provided registry. Without this, the plan-mode gate
-      // (the sole built-in PreToolUse hook) never reached the dispatcher and
-      // write tools ran unblocked in plan mode.
-      hookRegistry: opts?.hookRegistry ?? this.hookRegistry,
+      // Session hook registry via the one canonical resolver (query-scoped
+      // config registry wins over any constructor-provided one). Without this
+      // the plan-mode gate (the sole built-in PreToolUse hook) never reached
+      // the dispatcher and write tools ran unblocked in plan mode (c6892c6).
+      hookRegistry: resolveSessionHookRegistry(opts?.hookRegistry, this.hookRegistry),
       // Union live MCP wire-names into the (statically-snapshotted) allowlist so
       // OAuth servers whose tools were discovered after construction are not
       // rejected by the gate while present in `schemas`/`handlers`. No-op when

--- a/src/agent/providers/hook-registry-contract.test.ts
+++ b/src/agent/providers/hook-registry-contract.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Provider CONTRACT test — the session-scoped hook registry must reach the
+ * dispatcher across EVERY provider.
+ *
+ * Invariant under test: a provider built WITHOUT a constructor-time
+ * `hookRegistry` (the production shape — REPL/chat/daemon/telegram) must still
+ * fire `PreToolUse` gates supplied on `AgentConfig.hookRegistry`. The canonical
+ * example is the plan-mode write gate: in `'plan'` mode a write-class tool
+ * (`edit_file`) must be REFUSED before its handler runs.
+ *
+ * This is the cross-provider regression guard for c6892c6 (`config.hookRegistry`
+ * dropped on the internal dispatcher path → write tools ran unblocked in plan
+ * mode). The per-provider wiring tests
+ * (`anthropic-direct/plan-mode-gate-wiring.test.ts` and the plan-mode block in
+ * `openai-compatible/query.test.ts`) each cover one backend; this file asserts
+ * the SAME invariant uniformly. Adding a new `ModelProvider` = add one
+ * `ProviderContractCase` to `PROVIDER_CASES`, and the contract is enforced for
+ * it automatically.
+ *
+ * Structural backstop: `resolveSessionHookRegistry` is the one canonical merge
+ * point both providers use, and `SessionToolDispatcherOptions.hookRegistry` is a
+ * required key — so a provider that forgets to thread the registry is a compile
+ * error, not a silent runtime gap. The runtime tests below prove the wiring is
+ * not just present but correct.
+ *
+ * No `@anthropic-ai/sdk` / `openai` imports: mock backends are plain objects,
+ * keeping this test out of the SDK dependency-lock surface.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { ModelProvider, ProviderEvent, ProviderUserTurn } from '../provider.js';
+import type { AgentConfig } from '../types/config-types.js';
+import { createHookRegistry, resolveSessionHookRegistry, type HookRegistry } from '../hooks.js';
+import { createPlanModeGate } from '../plan-mode-gate.js';
+import { AnthropicDirectProvider, __setAnthropicClientFactory } from './anthropic-direct/index.js';
+import { OpenAICompatibleProvider, __setOpenAIClientFactory } from './openai-compatible/index.js';
+import type { OpenAIChunk } from './openai-compatible/translate.js';
+
+// --- shared fixtures -------------------------------------------------------
+
+/** Targets a path that does not exist: if the gate does NOT fire, the real
+ *  edit_file handler runs and returns a "not found" error — never the
+ *  plan-mode refusal — so the negative assertions stay unambiguous. */
+const EDIT_FILE_INPUT = JSON.stringify({
+  file_path: '/tmp/afk-hook-registry-contract-nonexistent.txt',
+  old_string: 'a',
+  new_string: 'b',
+});
+
+/** A registry carrying ONLY the plan-mode gate, in the requested mode. */
+function planGateRegistry(mode: 'plan' | 'default'): HookRegistry {
+  const registry = createHookRegistry();
+  registry.register('PreToolUse', createPlanModeGate(() => mode));
+  return registry;
+}
+
+async function* singleInput(content: string): AsyncIterable<ProviderUserTurn> {
+  yield { content };
+}
+
+async function* fromArray<T>(arr: T[]): AsyncIterable<T> {
+  for (const x of arr) yield x;
+}
+
+async function collect(query: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  for await (const ev of query) out.push(ev);
+  return out;
+}
+
+function toolOutputOf(events: ProviderEvent[]): { content: string; isError?: boolean } {
+  const ev = events.find((e) => e.type === 'tool.output');
+  if (!ev || ev.type !== 'tool.output') throw new Error('expected a tool.output event');
+  return { content: ev.content, ...(ev.isError !== undefined ? { isError: ev.isError } : {}) };
+}
+
+// --- provider adapters -----------------------------------------------------
+
+interface ProviderContractCase {
+  readonly name: string;
+  /** Install a mock backend that emits an `edit_file` tool call, then a text turn. */
+  installEditThenDone(): void;
+  /** Tear down the mock backend client factory. */
+  resetClient(): void;
+  /** Construct the provider WITHOUT a constructor-time registry, allowing `edit_file`. */
+  makeProvider(): ModelProvider;
+  /** Build a query config in the given mode (+ optional parent session / registry). */
+  makeConfig(opts: {
+    permissionMode: 'plan' | 'default';
+    parentSessionId?: string;
+    hookRegistry?: HookRegistry;
+  }): AgentConfig;
+}
+
+// ---- Anthropic adapter (plain-object Messages-API stream) ----
+
+const anthropicMessagesCreate = vi.fn();
+
+function anthropicEvent(obj: Record<string, unknown>): unknown {
+  return obj;
+}
+
+function anthropicToolUseStream(toolId: string, toolName: string, inputJson: string): unknown[] {
+  const usage = {
+    input_tokens: 7,
+    output_tokens: 0,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+    server_tool_use: null,
+    service_tier: null,
+  };
+  return [
+    anthropicEvent({
+      type: 'message_start',
+      message: {
+        id: 'msg_t',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-4-5-20250929',
+        stop_reason: null,
+        stop_sequence: null,
+        usage,
+      },
+    }),
+    anthropicEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'tool_use', id: toolId, name: toolName, input: {} },
+    }),
+    anthropicEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: inputJson },
+    }),
+    anthropicEvent({ type: 'content_block_stop', index: 0 }),
+    anthropicEvent({
+      type: 'message_delta',
+      delta: { stop_reason: 'tool_use', stop_sequence: null },
+      usage: { output_tokens: 9 },
+    }),
+    anthropicEvent({ type: 'message_stop' }),
+  ];
+}
+
+function anthropicTextStream(text: string): unknown[] {
+  return [
+    anthropicEvent({
+      type: 'message_start',
+      message: {
+        id: 'msg_done',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-4-5-20250929',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 5,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    }),
+    anthropicEvent({
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '', citations: [] },
+    }),
+    anthropicEvent({
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text },
+    }),
+    anthropicEvent({ type: 'content_block_stop', index: 0 }),
+    anthropicEvent({
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 4 },
+    }),
+    anthropicEvent({ type: 'message_stop' }),
+  ];
+}
+
+const anthropicCase: ProviderContractCase = {
+  name: 'AnthropicDirectProvider',
+  installEditThenDone() {
+    anthropicMessagesCreate.mockReset();
+    let callIdx = 0;
+    anthropicMessagesCreate.mockImplementation(() => {
+      callIdx += 1;
+      return callIdx === 1
+        ? fromArray(anthropicToolUseStream('toolu_edit', 'edit_file', EDIT_FILE_INPUT))
+        : fromArray(anthropicTextStream('done'));
+    });
+    const mockClient = { messages: { create: anthropicMessagesCreate } };
+    __setAnthropicClientFactory(
+      (() => mockClient) as unknown as Parameters<typeof __setAnthropicClientFactory>[0],
+    );
+  },
+  resetClient() {
+    __setAnthropicClientFactory(null);
+    anthropicMessagesCreate.mockReset();
+  },
+  makeProvider() {
+    return new AnthropicDirectProvider({ permissions: { allowedTools: ['edit_file'] } });
+  },
+  makeConfig({ permissionMode, parentSessionId, hookRegistry }) {
+    return {
+      model: 'claude-sonnet-4-5-20250929',
+      apiKey: 'sk-ant-oat01-test',
+      permissionMode,
+      ...(parentSessionId !== undefined ? { parentSessionId } : {}),
+      ...(hookRegistry !== undefined ? { hookRegistry } : {}),
+    } as AgentConfig;
+  },
+};
+
+// ---- OpenAI-compatible adapter (plain-object Chat-Completions stream) ----
+
+let openaiScript: Array<{ chunks: OpenAIChunk[] }> = [];
+let openaiTurnIndex = 0;
+
+function installOpenAIScriptedClient(): void {
+  openaiTurnIndex = 0;
+  const mockClient = {
+    chat: {
+      completions: {
+        create: async (args: { stream?: boolean }) => {
+          if (!args.stream) throw new Error('contract mock only supports streaming');
+          const turn = openaiScript[openaiTurnIndex++];
+          if (!turn) throw new Error(`openai scripted turn ${openaiTurnIndex - 1} not defined`);
+          const chunks = turn.chunks.slice();
+          return (async function* () {
+            for (const c of chunks) yield c;
+          })();
+        },
+      },
+    },
+  };
+  __setOpenAIClientFactory(
+    (() => mockClient) as unknown as Parameters<typeof __setOpenAIClientFactory>[0],
+  );
+}
+
+const openaiCase: ProviderContractCase = {
+  name: 'OpenAICompatibleProvider',
+  installEditThenDone() {
+    openaiScript = [
+      {
+        chunks: [
+          {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'call_edit',
+                      type: 'function',
+                      function: { name: 'edit_file', arguments: EDIT_FILE_INPUT },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+            usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+          },
+        ] as unknown as OpenAIChunk[],
+      },
+      {
+        chunks: [
+          {
+            choices: [{ delta: { content: 'done' }, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 10, completion_tokens: 1, total_tokens: 11 },
+          },
+        ] as unknown as OpenAIChunk[],
+      },
+    ];
+    installOpenAIScriptedClient();
+  },
+  resetClient() {
+    __setOpenAIClientFactory(null);
+    openaiScript = [];
+    openaiTurnIndex = 0;
+  },
+  makeProvider() {
+    return new OpenAICompatibleProvider({ permissions: { allowedTools: ['edit_file'] } });
+  },
+  makeConfig({ permissionMode, parentSessionId, hookRegistry }) {
+    return {
+      model: 'gpt-4o-mini',
+      apiKey: 'sk-test-key',
+      permissionMode,
+      ...(parentSessionId !== undefined ? { parentSessionId } : {}),
+      ...(hookRegistry !== undefined ? { hookRegistry } : {}),
+    } as AgentConfig;
+  },
+};
+
+const PROVIDER_CASES: ProviderContractCase[] = [anthropicCase, openaiCase];
+
+// --- the contract ----------------------------------------------------------
+
+describe('canonical hook-registry resolver', () => {
+  const a = createHookRegistry();
+  const b = createHookRegistry();
+
+  it('prefers the query-scoped (config) registry over the constructor-scoped one', () => {
+    expect(resolveSessionHookRegistry(a, b)).toBe(a);
+  });
+
+  it('falls back to the constructor-scoped registry when the query one is absent', () => {
+    expect(resolveSessionHookRegistry(undefined, b)).toBe(b);
+  });
+
+  it('returns undefined when neither is set', () => {
+    expect(resolveSessionHookRegistry(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe.each(PROVIDER_CASES)(
+  'provider contract: $name threads config.hookRegistry to the dispatcher',
+  (providerCase) => {
+    beforeEach(() => {
+      providerCase.installEditThenDone();
+    });
+
+    afterEach(() => {
+      providerCase.resetClient();
+    });
+
+    it('BLOCKS edit_file in plan mode (gate supplied on config.hookRegistry)', async () => {
+      const provider = providerCase.makeProvider();
+      const query = provider.query({
+        prompt: singleInput('edit the file'),
+        config: providerCase.makeConfig({
+          permissionMode: 'plan',
+          hookRegistry: planGateRegistry('plan'),
+        }),
+      });
+
+      const out = toolOutputOf(await collect(query));
+
+      // The session registry reached the dispatcher and the gate fired.
+      expect(out.isError).toBe(true);
+      expect(out.content).toContain('plan mode');
+    });
+
+    it('does NOT block edit_file in default mode', async () => {
+      const provider = providerCase.makeProvider();
+      const query = provider.query({
+        prompt: singleInput('edit the file'),
+        config: providerCase.makeConfig({
+          permissionMode: 'default',
+          hookRegistry: planGateRegistry('default'),
+        }),
+      });
+
+      const out = toolOutputOf(await collect(query));
+
+      expect(out.content).not.toContain('plan mode');
+      expect(out.content).not.toContain('blocked by PreToolUse hook');
+    });
+
+    it('does NOT block edit_file for a forked subagent (parentSessionId self-skip)', async () => {
+      const provider = providerCase.makeProvider();
+      const query = provider.query({
+        prompt: singleInput('edit the file'),
+        config: providerCase.makeConfig({
+          permissionMode: 'plan',
+          parentSessionId: 'parent-session-123',
+          hookRegistry: planGateRegistry('plan'),
+        }),
+      });
+
+      const out = toolOutputOf(await collect(query));
+
+      // The registry is still threaded — the gate just self-skips for subagents,
+      // proving the wiring is present without over-blocking task output.
+      expect(out.content).not.toContain('plan mode');
+      expect(out.content).not.toContain('blocked by PreToolUse hook');
+    });
+  },
+);

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -23,6 +23,7 @@ import type {
   ProviderCompleteArgs,
 } from '../../provider.js';
 import type { HookRegistry } from '../../hooks.js';
+import { resolveSessionHookRegistry } from '../../hooks.js';
 import type { SubagentExecutor } from '../../tools/subagent-executor.js';
 import type { SkillExecutor } from '../../tools/skill-executor.js';
 import type { ComposeExecutor } from '../../tools/compose-executor.js';
@@ -350,14 +351,12 @@ export class OpenAICompatibleProvider implements ModelProvider {
       // Constraint (semantic invariant): MCP schemas appended AFTER builtins
       // so builtin tool names always take precedence in any overlap.
       schemas: [...baseSchemas, ...mcpSchemas],
+      // Session hook registry via the one canonical resolver (query-scoped
+      // config registry wins over any constructor-provided one). Mirrors
+      // AnthropicDirectProvider; the required key on the dispatcher options
+      // makes a silent drop (c6892c6) a compile error.
+      hookRegistry: resolveSessionHookRegistry(opts.hookRegistry, this.providerOpts.hookRegistry),
     };
-    // Prefer the session-scoped registry from the query config (production
-    // path); fall back to any constructor-provided registry. Without this the
-    // plan-mode gate (the sole built-in PreToolUse hook) never reached the
-    // dispatcher and write tools ran unblocked in plan mode.
-    const effectiveHookRegistry = opts.hookRegistry ?? this.providerOpts.hookRegistry;
-    if (effectiveHookRegistry !== undefined)
-      dispatcherOpts.hookRegistry = effectiveHookRegistry;
     // Union live MCP wire-names into the (statically-snapshotted) allowlist so
     // OAuth servers whose tools were discovered after construction are not
     // rejected by the gate while present in `schemas`/`handlers`. No-op when no

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -122,7 +122,14 @@ function partitionIntoBatches(
 export interface SessionToolDispatcherOptions {
   handlers: Map<string, ToolHandler>;
   schemas: AnthropicToolDef[];
-  hookRegistry?: HookRegistry;
+  /**
+   * Session hook registry. REQUIRED KEY (value-nullable): every dispatcher
+   * construction must explicitly thread the registry or `undefined`. When this
+   * was optional, provider code could silently drop `config.hookRegistry`,
+   * disabling the plan-mode write gate (c6892c6). Resolve via
+   * `resolveSessionHookRegistry` — never re-implement the precedence.
+   */
+  hookRegistry: HookRegistry | undefined;
   permissions?: ToolPermissionConfig;
   subagentExecutor?: SubagentExecutor;
   skillExecutor?: SkillExecutor;

--- a/src/improve/eval-run/contracts.ts
+++ b/src/improve/eval-run/contracts.ts
@@ -127,6 +127,9 @@ async function runRepeatLoopCircuitBreaker(): Promise<ContractProbeResult> {
   const dispatcher = new SessionToolDispatcher({
     handlers: new Map<string, ToolHandler>([[PROBE_TOOL, handler]]),
     schemas: [],
+    // Deliberately hook-less probe dispatcher — declared explicitly now that
+    // hookRegistry is a required key on the dispatcher options.
+    hookRegistry: undefined,
     permissions: { allowedTools: [PROBE_TOOL] },
   });
 


### PR DESCRIPTION
## Summary

Make AFK's session hook registry **structural instead of convention-wired**, closing the highest-leverage instance of a broader theme: safety/protocol guards that exist but are enforced only by convention. Direct structural follow-up to #170 — which fixed the *symptom* (`config.hookRegistry` dropped by the dispatcher → plan-mode write-gate never fired), while this fixes the *gap that let it happen*.

- **`hookRegistry` is now a required key** on `SessionToolDispatcherOptions` (`HookRegistry | undefined`, not optional). A dispatcher construction that fails to thread it is a **compile error**, not a silent runtime gap — so the `c6892c6` bug class cannot recur unnoticed.
- **One canonical merge path.** `resolveSessionHookRegistry()` is the single merge point (query-scoped `config` registry wins over a constructor-time one). Both providers call it; the two divergent inline `?? this.hookRegistry` merges are deleted.
- **Cross-provider contract test** (`hook-registry-contract.test.ts`, parametrized over both providers): asserts the plan-mode write-gate fires through the provider boundary, self-skips for subagents, and stays silent in default mode. Adding a provider = adding one adapter.
- **SDK audit now enforced in CI.** Wired `pnpm audit:sdk:check` into `ci.yml` — the `.sdk-dependency.lock.json` guard existed but was never run, so an unlocked `@anthropic-ai/sdk` import could merge unnoticed.

No behavior change (the resolver returns the same value the inline merges did).

## Test results

- `pnpm test` (vitest, full suite): **9348 passed / 12 skipped / 1 failed (9361)**. The lone failure is a **pre-existing, environment-specific leak** in `src/cli/config.test.ts` — `loadConfig()` reads the developer's real `~/.afk/config` local-model slot instead of the mocked empty config. It reproduces on clean `main` and is unrelated to this diff (which touches zero config files).
- `pnpm lint` (`tsc --noEmit`, strict): **pass (exit 0)**.
- `pnpm audit:sdk:check`: **pass** (lock matches current imports).

## Verification (`--verify` adversarial wave)

An independent read-only verifier re-derived the load-bearing claims from the diff alone (not from commit messages):

- **Required-key contract — CONFIRM.** `dispatcher.ts:132` declares `hookRegistry: HookRegistry | undefined` (non-optional); omission fails to compile.
- **Single canonical merge — CONFIRM.** Both providers call `resolveSessionHookRegistry()` (`anthropic-direct/index.ts:360`, `openai-compatible/index.ts:358`); no inline `?? this.hookRegistry` merge remains on the dispatcher path. (The `openai-compatible/index.ts:209` spread is a *subagent* options object, not a dispatcher merge.)
- **Gate fires through provider boundary — CONFIRM (refined).** `hook-registry-contract.test.ts:337-357` asserts real block behavior (`isError === true`, content contains "plan mode") end-to-end. Refinement: it reads the event-stream `isError`/`content` rather than the internal `decision: 'block'` object — a behavioral check, not plumbing-only. Not a blocker.

No CONTRADICT. Verifier confidence 90%; its only open gap (lint not independently run) is closed — lint passed in this session.

## Out of scope

- Broader "guard exists but doesn't bite" sweep: **signal-block** was verified to be *honestly* deferred v0 passive-observation infra (docs accurate, adoption real) — **not a gap**, no change; **`fix:pins:check`** absent from CI is **not a gap** — the same hash-pin invariant is already enforced by `vendored.test.ts`/`bundled.test.ts` under `test:coverage`.
- The pre-existing `config.test.ts` env-leak (separate fix).