### PR TITLE
fix(tui): reset StatusLine + BackgroundStatusBar geometry on SIGWINCH to stop ghost rows

### DIFF
--- a/src/cli/background-status-bar.test.ts
+++ b/src/cli/background-status-bar.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { BackgroundStatusBar } from './background-status-bar.js';
 import type {
@@ -6,6 +6,7 @@ import type {
   BackgroundJob,
   BackgroundRegistryEvents,
 } from '../agent/background-registry.js';
+import { __flushResizeBusForTests } from './terminal-size.js';
 
 // ---------------------------------------------------------------------------
 // Minimal fake BackgroundAgentRegistry for testing — extends the same
@@ -529,5 +530,128 @@ describe('BackgroundStatusBar', () => {
     expect(writes).not.toMatch(/\x1b\[\d+;1H/);
 
     bar.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resize-immediate channel tests
+// ---------------------------------------------------------------------------
+
+describe('BackgroundStatusBar resize-immediate channel', () => {
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // R1. resetGeometry() is called synchronously on resize — rowCount is 0
+  //     BEFORE the debounced channel fires.
+  // -------------------------------------------------------------------------
+  it('rowCount is 0 immediately after resize, before debounced channel fires', () => {
+    const mockStream = makeMockStream();
+    const registry = new FakeRegistry();
+    const bar = new BackgroundStatusBar(registry as unknown as BackgroundAgentRegistry, {
+      stream: mockStream,
+      throttleMs: 0,
+    });
+    const rowHandler = vi.fn();
+    bar.setRowCountChangeHandler(rowHandler);
+    bar.start();
+
+    // Seed two running jobs so rowCount is set to 2.
+    registry.fireStarted(makeJob('j1'));
+    registry.fireStarted(makeJob('j2'));
+    rowHandler.mockClear();
+
+    // Emit resize — the immediate channel fires resetGeometry() synchronously.
+    // The debounced channel (and thus repaint()) has NOT yet fired.
+    process.stdout.emit('resize');
+
+    // rowCount must now be 0 (invalidated by resetGeometry on immediate channel).
+    // We assert this indirectly: if the spinner were to tick NOW (before the
+    // debounce fires), it must see rowCount === 0 and skip repaint().
+    // Directly inspect by triggering scheduleRepaint via a registry event.
+    // At this point rowCount=0, so repaint() should recompute from scratch.
+    // First flush the debounced resize: row count re-seeds.
+    (mockStream.write as ReturnType<typeof vi.fn>).mockClear();
+    __flushResizeBusForTests();
+
+    // After the debounced channel fires repaint(), rowHandler should be called
+    // (newRowCount 2 !== 0 → equality guard trips, rowCountChange fires).
+    expect(rowHandler).toHaveBeenCalledWith(2);
+
+    bar.stop();
+  });
+
+  // -------------------------------------------------------------------------
+  // R2. Spinner tick BETWEEN SIGWINCH and debounced repaint sees rowCount === 0
+  //     and emits NO write() calls.
+  // -------------------------------------------------------------------------
+  it('spinner tick after SIGWINCH but before debounced repaint emits no writes', () => {
+    // Use a throttleMs that makes the spinner interval deterministic: 100ms.
+    const mockStream = makeMockStream();
+    const registry = new FakeRegistry();
+    const bar = new BackgroundStatusBar(registry as unknown as BackgroundAgentRegistry, {
+      stream: mockStream,
+      throttleMs: 100,
+    });
+    bar.start();
+
+    // Seed a running job so rowCount > 0.
+    registry.fireStarted(makeJob('j1'));
+
+    // Clear writes from initial paint.
+    (mockStream.write as ReturnType<typeof vi.fn>).mockClear();
+
+    // Emit resize — immediate channel resets rowCount to 0 synchronously.
+    process.stdout.emit('resize');
+
+    // Advance time by 100ms — spinner tick fires (interval = max(100, 50) = 100ms).
+    // The debounce timer (150ms) has NOT yet elapsed.
+    vi.advanceTimersByTime(100);
+
+    // The spinner tick must NOT have produced any writes: rowCount === 0.
+    const writesAfterSpinner = (mockStream.write as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(writesAfterSpinner).toBe(0);
+
+    // Now advance past the debounce (50ms more → 150ms total).
+    vi.advanceTimersByTime(50);
+
+    // After debounced repaint, writes should resume (rowCount re-seeded to 1).
+    const writesAfterDebounce = (mockStream.write as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(writesAfterDebounce).toBeGreaterThan(0);
+
+    bar.stop();
+  });
+
+  // -------------------------------------------------------------------------
+  // R3. stop() unsubscribes the immediate channel — no resetGeometry() after stop.
+  // -------------------------------------------------------------------------
+  it('stop() unsubscribes immediate channel — resize after stop does not affect rowCount', () => {
+    const mockStream = makeMockStream();
+    const registry = new FakeRegistry();
+    const bar = new BackgroundStatusBar(registry as unknown as BackgroundAgentRegistry, {
+      stream: mockStream,
+      throttleMs: 0,
+    });
+    const rowHandler = vi.fn();
+    bar.setRowCountChangeHandler(rowHandler);
+    bar.start();
+
+    registry.fireStarted(makeJob('j1'));
+    bar.stop();
+    rowHandler.mockClear();
+
+    // Emit resize after stop — should be a complete no-op.
+    process.stdout.emit('resize');
+    vi.advanceTimersByTime(150);
+
+    // rowHandler must not be called after stop.
+    expect(rowHandler).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/background-status-bar.test.ts
+++ b/src/cli/background-status-bar.test.ts
@@ -654,4 +654,83 @@ describe('BackgroundStatusBar resize-immediate channel', () => {
     // rowHandler must not be called after stop.
     expect(rowHandler).not.toHaveBeenCalled();
   });
+
+  // -------------------------------------------------------------------------
+  // R4. On terminal EXPAND, the rows painted at the OLD start-row address are
+  //     erased on the recovery repaint, so they do not strand as a ghost stripe
+  //     (PR #174 review finding 2). The old address is snapshotted from the
+  //     STORED lastPaintStartRow — not recomputed from the new stream.rows.
+  // -------------------------------------------------------------------------
+  it('erases pre-resize rows at their old address on terminal expand', () => {
+    const mockStream = makeMockStream();
+    const registry = new FakeRegistry();
+    const bar = new BackgroundStatusBar(registry as unknown as BackgroundAgentRegistry, {
+      stream: mockStream,
+      throttleMs: 0,
+    });
+    bar.start();
+
+    // Paint 1 running job at rows=24 → startRow = max(1, 24 - 1 - 0) = 23.
+    registry.fireStarted(makeJob('j1'));
+    (mockStream.write as ReturnType<typeof vi.fn>).mockClear();
+
+    // Expand the terminal to 30 rows, then fire SIGWINCH. The immediate channel
+    // snapshots the OLD painted address (startRow 23, rowCount 1).
+    Object.defineProperty(mockStream, 'rows', { value: 30, configurable: true });
+    process.stdout.emit('resize');
+
+    // Debounced repaint: new startRow = max(1, 30 - 1 - 0) = 29. The recovery
+    // repaint must erase the stranded old row 23 BEFORE painting the new row 29.
+    __flushResizeBusForTests();
+
+    const writes = (mockStream.write as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .join('');
+
+    // Old row 23 was addressed for erase.
+    expect(writes).toContain('\x1b[23;1H');
+    // New content painted at row 29.
+    expect(writes).toContain('\x1b[29;1H');
+    // The old-row erase precedes the new-row paint.
+    expect(writes.indexOf('\x1b[23;1H')).toBeLessThan(writes.indexOf('\x1b[29;1H'));
+
+    bar.stop();
+  });
+
+  // -------------------------------------------------------------------------
+  // R5. On terminal SHRINK, the old rows are now below the viewport; addressing
+  //     them would clamp onto the status-line row, so they are skipped. The bar
+  //     must NOT emit a cursor-move to the (now off-screen) old start-row.
+  // -------------------------------------------------------------------------
+  it('does not erase off-screen old rows on terminal shrink', () => {
+    const mockStream = makeMockStream();
+    Object.defineProperty(mockStream, 'rows', { value: 30, configurable: true });
+    const registry = new FakeRegistry();
+    const bar = new BackgroundStatusBar(registry as unknown as BackgroundAgentRegistry, {
+      stream: mockStream,
+      throttleMs: 0,
+    });
+    bar.start();
+
+    // Paint 1 running job at rows=30 → startRow = max(1, 30 - 1 - 0) = 29.
+    registry.fireStarted(makeJob('j1'));
+    (mockStream.write as ReturnType<typeof vi.fn>).mockClear();
+
+    // Shrink to 24 rows, then fire SIGWINCH. Old address (29) is now below the
+    // 24-row viewport and must be skipped (not clamped onto the status line).
+    Object.defineProperty(mockStream, 'rows', { value: 24, configurable: true });
+    process.stdout.emit('resize');
+    __flushResizeBusForTests();
+
+    const writes = (mockStream.write as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .join('');
+
+    // The off-screen old row 29 must NOT be addressed.
+    expect(writes).not.toContain('\x1b[29;1H');
+    // New content paints at the new startRow = max(1, 24 - 1 - 0) = 23.
+    expect(writes).toContain('\x1b[23;1H');
+
+    bar.stop();
+  });
 });

--- a/src/cli/background-status-bar.ts
+++ b/src/cli/background-status-bar.ts
@@ -46,6 +46,18 @@ export class BackgroundStatusBar {
   private registryStartedHandler: ((job: BackgroundJob) => void) | null = null;
   private registrySettledHandler: ((job: BackgroundJob) => void) | null = null;
   private rowCount = 0;
+  // The start-row address used by the most recent paint. Stored at paint time so
+  // resetGeometry() can snapshot the TRUE pre-SIGWINCH address: clearRows()
+  // recomputes startRow from the live stream.rows, but by the time a resize
+  // handler runs stream.rows is already the NEW height, so only a stored address
+  // can still point at the old rows. Mirrors StatusLine.lastPaintedRow.
+  private lastPaintStartRow = 0;
+  // Pre-resize snapshot captured by resetGeometry() on the immediate channel and
+  // consumed by the next repaint() (via clearPreResizeRows()) to erase rows
+  // stranded at the old address. null = no resize-erase pending. Mirrors
+  // StatusLine.preResizePaintedRow.
+  private preResizeStartRow: number | null = null;
+  private preResizeRowCount: number | null = null;
   private onRowCountChange?: (rows: number) => void;
   private readonly getAdjacentRows: () => number;
 
@@ -146,15 +158,34 @@ export class BackgroundStatusBar {
     //      terminal but skips clearRows() because newRowCount === this.rowCount,
     //      so the old content sits at the old startRow while new content is
     //      written at the new startRow — a visible stripe artifact.
-    // Zeroing rowCount here forces the equality guard to trip on the very next
-    // repaint() regardless of item-count, allowing clearRows() to run before
-    // any painting with the new geometry.  Zeroing lastRepaint ensures the
-    // throttle gate in scheduleRepaint() is open, so the immediate-next call
-    // (from the spinner or from a registry event) actually executes repaint()
-    // and re-seizes the correct coordinates.
-    // This must execute on the IMMEDIATE channel (ResizeBus.subscribeImmediate)
-    // so it lands synchronously inside the 'resize' event, before the 150ms
-    // debounce window opens and any spinner tick can observe stale state.
+    // resetGeometry() does three things, all synchronously inside the 'resize'
+    // event (the IMMEDIATE channel, ResizeBus.subscribeImmediate) so they land
+    // before the 150ms debounce window opens and any spinner tick observes stale
+    // state:
+    //   1. Snapshot the pre-SIGWINCH paint address (lastPaintStartRow + rowCount)
+    //      into preResize{StartRow,RowCount}.  This is the ONLY moment the true
+    //      old address is still recoverable: stream.rows has already flipped to
+    //      the new height, so clearRows() — which recomputes startRow from
+    //      stream.rows — can no longer reach the old rows.  The next repaint()
+    //      consumes the snapshot via clearPreResizeRows() to erase rows stranded
+    //      at the old address (failure mode 2 / EXPAND above).  Mirrors
+    //      StatusLine's preResizePaintedRow snapshot.
+    //   2. Zero rowCount.  This does NOT make clearRows() run on the next
+    //      repaint() — the `if (this.rowCount > 0)` guard there sees 0 and skips
+    //      it; the explicit old-row erase is clearPreResizeRows() (point 1).
+    //      Zeroing rowCount instead buys two things: (a) the spinner's
+    //      `if (rowCount > 0)` guard suppresses mid-window repaints that would
+    //      paint against stale geometry; (b) it forces the
+    //      `newRowCount !== this.rowCount` equality guard to trip on the next
+    //      repaint() so rowCount is re-seeded and onRowCountChange fires the
+    //      correct new count.
+    //   3. Zero lastRepaint so the throttle gate in scheduleRepaint() is open and
+    //      the immediate-next call (spinner or registry event) actually executes
+    //      repaint() and re-seizes the correct coordinates.
+    if (this.rowCount > 0) {
+      this.preResizeStartRow = this.lastPaintStartRow;
+      this.preResizeRowCount = this.rowCount;
+    }
     this.rowCount = 0;
     this.lastRepaint = 0;
   }
@@ -201,6 +232,13 @@ export class BackgroundStatusBar {
     // leakage when totalRows ≤ 1 (no paintable rows → early return below).
     const newRowCount = Math.max(0, Math.min(items.length, totalRows - 1 - adjacentRows));
 
+    // Invariant: erase rows stranded at the pre-resize address (set by
+    // resetGeometry() on SIGWINCH) BEFORE re-seeding geometry or hitting the
+    // early newRowCount===0 return below — otherwise an EXPAND leaves the old
+    // rows as a ghost stripe (clearRows() cannot reach them; see
+    // resetGeometry()). No-op on every non-resize repaint.
+    this.clearPreResizeRows();
+
     if (newRowCount !== this.rowCount) {
       if (this.rowCount > 0) this.clearRows();
       this.rowCount = newRowCount;
@@ -211,6 +249,7 @@ export class BackgroundStatusBar {
 
     // Start row is offset above adjacent painter rows and the status line.
     const startRow = Math.max(1, totalRows - newRowCount - adjacentRows);
+    this.lastPaintStartRow = startRow;
 
     this.stream.write('\x1b[s');
     for (let i = 0; i < newRowCount; i++) {
@@ -235,6 +274,45 @@ export class BackgroundStatusBar {
     this.stream.write('\x1b[s');
     for (let i = 0; i < visibleCount; i++) {
       this.stream.write(`\x1b[${startRow + i};1H`);
+      this.stream.write('\x1b[2K');
+    }
+    this.stream.write('\x1b[u');
+  }
+
+  /**
+   * Erase the rows the bar painted at its PRE-resize address — captured by
+   * resetGeometry() into preResize{StartRow,RowCount} on the immediate resize
+   * channel, before SIGWINCH-updated stream.rows made the old address
+   * unrecomputable. Called once at the top of the first repaint() after a
+   * resize; a no-op otherwise.
+   *
+   * Contract: only erases addresses still on-screen in the NEW geometry. On
+   * EXPAND the old (higher) rows would otherwise strand as ghosts, so they are
+   * erased; on SHRINK the old rows are now below the viewport, where a
+   * cursor-move would clamp onto the status-line row — so they are skipped (the
+   * terminal reflows them into scrollback, exactly as the pre-existing
+   * zero-rowCount path already relied on). Mirrors StatusLine.onResize()'s
+   * preResizePaintedRow erase, adapted for the bar's multi-row, relocating
+   * start-row.
+   */
+  private clearPreResizeRows(): void {
+    const startRow = this.preResizeStartRow;
+    const rowCount = this.preResizeRowCount;
+    this.preResizeStartRow = null;
+    this.preResizeRowCount = null;
+    if (startRow === null || rowCount === null || !this.stream.isTTY) return;
+    const totalRows = this.stream.rows ?? 24;
+    // Only the old rows still on-screen in the NEW geometry (see Contract).
+    // Skipping off-screen rows on SHRINK also avoids leaking a bare s/u pair.
+    const rows: number[] = [];
+    for (let i = 0; i < rowCount; i++) {
+      const row = startRow + i;
+      if (row <= totalRows) rows.push(row);
+    }
+    if (rows.length === 0) return;
+    this.stream.write('\x1b[s');
+    for (const row of rows) {
+      this.stream.write(`\x1b[${row};1H`);
       this.stream.write('\x1b[2K');
     }
     this.stream.write('\x1b[u');

--- a/src/cli/background-status-bar.ts
+++ b/src/cli/background-status-bar.ts
@@ -42,6 +42,7 @@ export class BackgroundStatusBar {
   private spinnerIndex = 0;
   private spinnerInterval: ReturnType<typeof setInterval> | null = null;
   private resizeUnsub: (() => void) | null = null;
+  private resizeImmediateUnsub: (() => void) | null = null;
   private registryStartedHandler: ((job: BackgroundJob) => void) | null = null;
   private registrySettledHandler: ((job: BackgroundJob) => void) | null = null;
   private rowCount = 0;
@@ -78,8 +79,17 @@ export class BackgroundStatusBar {
     }
 
     this.resizeUnsub = ResizeBus.subscribe(() => this.repaint());
+    this.resizeImmediateUnsub = ResizeBus.subscribeImmediate(() => this.resetGeometry());
 
     this.spinnerInterval = setInterval(() => {
+      // Invariant: resetGeometry() zeroes this.rowCount synchronously inside
+      // the 'resize' event (via ResizeBus.subscribeImmediate), which fires
+      // BEFORE any macrotask (including this setInterval callback) can execute.
+      // Therefore, if a SIGWINCH fires between two spinner ticks, this.rowCount
+      // is guaranteed to be 0 by the time this callback runs — the `> 0` guard
+      // correctly suppresses the repaint until the debounced ResizeBus.subscribe
+      // channel fires repaint() and re-seizes the correct row count and
+      // start-row address against the new terminal geometry.
       this.spinnerIndex = (this.spinnerIndex + 1) % SPINNER_FRAMES.length;
       if (this.rowCount > 0) this.repaint();
     }, Math.max(this.throttleMs, 50));
@@ -103,6 +113,10 @@ export class BackgroundStatusBar {
       this.resizeUnsub();
       this.resizeUnsub = null;
     }
+    if (this.resizeImmediateUnsub) {
+      this.resizeImmediateUnsub();
+      this.resizeImmediateUnsub = null;
+    }
     if (this.spinnerInterval) {
       clearInterval(this.spinnerInterval);
       this.spinnerInterval = null;
@@ -113,6 +127,36 @@ export class BackgroundStatusBar {
       this.rowCount = 0;
       this.onRowCountChange?.(0);
     }
+  }
+
+  private resetGeometry(): void {
+    // Invariant: 'stale' means `this.rowCount` was computed against the
+    // pre-SIGWINCH terminal height and therefore encodes both (a) how many rows
+    // were physically written at the OLD start-row address and (b) the old
+    // equality baseline used by the `newRowCount !== this.rowCount` guard in
+    // repaint().  After SIGWINCH, `stream.rows` has already changed, but the
+    // 150ms-debounced ResizeBus.subscribe channel has NOT yet fired, so any
+    // repaint() call in that window (typically from the spinner at ≤150ms
+    // interval) evaluates newRowCount against the NEW terminal height and
+    // compares it with the OLD this.rowCount.  Two failure modes follow:
+    //   1. SHRINK: the equality guard may not trip, leaving the old rows
+    //      uncleaned; clearRows() would CUP to addresses now outside the
+    //      visible viewport, producing ghost rows in the scrollback.
+    //   2. EXPAND: repaint() computes a new startRow against the larger
+    //      terminal but skips clearRows() because newRowCount === this.rowCount,
+    //      so the old content sits at the old startRow while new content is
+    //      written at the new startRow — a visible stripe artifact.
+    // Zeroing rowCount here forces the equality guard to trip on the very next
+    // repaint() regardless of item-count, allowing clearRows() to run before
+    // any painting with the new geometry.  Zeroing lastRepaint ensures the
+    // throttle gate in scheduleRepaint() is open, so the immediate-next call
+    // (from the spinner or from a registry event) actually executes repaint()
+    // and re-seizes the correct coordinates.
+    // This must execute on the IMMEDIATE channel (ResizeBus.subscribeImmediate)
+    // so it lands synchronously inside the 'resize' event, before the 150ms
+    // debounce window opens and any spinner tick can observe stale state.
+    this.rowCount = 0;
+    this.lastRepaint = 0;
   }
 
   private scheduleRepaint(): void {

--- a/src/cli/status-line.test.ts
+++ b/src/cli/status-line.test.ts
@@ -402,6 +402,44 @@ describe('StatusLine resize handling', () => {
     status.stop();
   });
 
+  it('clears the PRE-resize row, not a mid-window repaint row, when a repaint lands between resize and debounce', () => {
+    // Race that preResizePaintedRow guards: a repaint() (e.g. a streaming token)
+    // arrives in the 150ms debounce window AFTER SIGWINCH but BEFORE the
+    // debounced onResize(). The mid-window repaint mutates lastPaintedRow to the
+    // NEW row; without the immediate-channel snapshot, onResize() would read that
+    // new row, decide old===new, and skip the stale-row clear — leaving a ghost.
+    vi.useFakeTimers();
+    const stream = mockStream({ isTTY: true, rows: 24 });
+    const status = new StatusLine({
+      stream: stream as unknown as NodeJS.WriteStream,
+      throttleMs: 0,
+    });
+    status.start();
+    // Paint at rows=24 → lastPaintedRow = 24.
+    status.repaint({ model: 'sonnet' });
+    stream.writes.length = 0;
+
+    // SIGWINCH → grow to 30. The IMMEDIATE channel snapshots preResizePaintedRow=24
+    // and nulls lastPaintedRow, synchronously, before the debounced onResize().
+    stream.rows = 30;
+    process.stdout.emit('resize');
+
+    // Mid-window repaint lands before the debounce: paints at row 30 and sets
+    // lastPaintedRow = 30 (the value that would corrupt the old-row reference).
+    status.repaint({ model: 'opus' });
+
+    // Flush the debounced channel → onResize() fires.
+    vi.advanceTimersByTime(150);
+
+    const out = lastJoined(stream);
+    // onResize() must clear the TRUE pre-resize row (24), NOT the mid-window row.
+    expect(out).toContain('\x1b[24;1H');
+    expect(out).toContain('\x1b[2K');
+    // New scroll region for the 30-row terminal is armed.
+    expect(out).toContain('\x1b[1;29r');
+    status.stop();
+  });
+
   it('does not emit an invalid 1;0 scroll region when the terminal has one row', () => {
     const stream = mockStream({ isTTY: true, rows: 1 });
     const status = new StatusLine({

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -53,7 +53,10 @@ export class StatusLine {
   private lastRepaint = 0;
   private lastFields: StatusLineFields | null = null;
   private resizeUnsub: (() => void) | null = null;
+  private resizeImmediateUnsub: (() => void) | null = null;
   private lastPaintedRow: number | null = null;
+  /** Captures lastPaintedRow at SIGWINCH time for onResize() to use as the stale-row target. */
+  private preResizePaintedRow: number | null = null;
   private extraRows = 0;
   private afterScrollRestore: (() => void) | null = null;
 
@@ -82,16 +85,58 @@ export class StatusLine {
       this.resizeUnsub = ResizeBus.subscribe(() => {
         this.onResize();
       });
+      this.resizeImmediateUnsub = ResizeBus.subscribeImmediate(() => this.resetGeometry());
     }
+  }
+
+  private resetGeometry(): void {
+    // Invariant: capturing `lastPaintedRow` into `preResizePaintedRow` BEFORE
+    // nulling it is critical to preserve the stale-row-clear capability of
+    // onResize() while also preventing mid-window repaint() calls from
+    // corrupting the stale-row reference.
+    //
+    // The race this method prevents:
+    //   SIGWINCH fires → stream.rows changes to newRows.
+    //   A repaint(fields) call arrives in the 150ms debounce window (e.g. from a
+    //   streaming token event).  repaint() writes to paintRow(newRows) and sets
+    //   lastPaintedRow = paintRow(newRows).
+    //   When onResize() finally fires, it reads lastPaintedRow = paintRow(newRows)
+    //   and (correctly) sees that lastPaintedRow === paintRow(newRows), so it
+    //   emits NO clear for the old row.  The pre-SIGWINCH content at
+    //   paintRow(oldRows) is never erased — a visible stale-row artifact remains.
+    //
+    // By snapshotting lastPaintedRow → preResizePaintedRow here and nulling
+    // lastPaintedRow synchronously, we achieve two goals simultaneously:
+    //   1. onResize() reads preResizePaintedRow (the true pre-SIGWINCH row)
+    //      for the old-row clear, immune to any mid-window repaint() mutation
+    //      of lastPaintedRow.
+    //   2. Mid-window repaint() writes to the new paintRow and seeds
+    //      lastPaintedRow = paintRow(newRows).  Because lastPaintedRow was
+    //      nulled, the mid-window repaint runs unconditionally (throttle gate
+    //      open via lastRepaint=0) and does not attempt to clear a stale row
+    //      on its own — onResize() will handle that.
+    //
+    // This must execute on the IMMEDIATE channel (ResizeBus.subscribeImmediate)
+    // so the snapshot is taken synchronously inside the 'resize' event, before
+    // any macrotask (streaming event, spinner tick) can mutate lastPaintedRow.
+    this.preResizePaintedRow = this.lastPaintedRow;
+    this.lastPaintedRow = null;
+    this.lastRepaint = 0;
   }
 
   /** Re-anchor DECSTBM when the terminal height changes, then repaint. */
   private onResize(): void {
     if (!this.started || !this.enabled) return;
     const rows = this.currentRows();
+    // Use preResizePaintedRow (set by resetGeometry() on the immediate channel)
+    // as the authoritative old-row reference.  lastPaintedRow may have been
+    // updated by a mid-window repaint() call and therefore already reflects the
+    // new geometry — using it here would skip the necessary old-row clear.
+    const rowToErase = this.preResizePaintedRow ?? this.lastPaintedRow;
+    this.preResizePaintedRow = null;
     this.stream.write('\x1b[s');
-    if (this.lastPaintedRow !== null && this.lastPaintedRow !== this.paintRow(rows)) {
-      this.stream.write(`\x1b[${this.lastPaintedRow};1H`);
+    if (rowToErase !== null && rowToErase !== this.paintRow(rows)) {
+      this.stream.write(`\x1b[${rowToErase};1H`);
       this.stream.write('\x1b[2K');
     }
     this.writeScrollRegion(rows);
@@ -259,6 +304,10 @@ export class StatusLine {
       this.resizeUnsub();
       this.resizeUnsub = null;
     }
+    if (this.resizeImmediateUnsub !== null) {
+      this.resizeImmediateUnsub();
+      this.resizeImmediateUnsub = null;
+    }
     if (!this.started || !this.enabled) {
       this.started = false;
       return;
@@ -273,6 +322,7 @@ export class StatusLine {
     this.started = false;
     this.lastRepaint = 0;
     this.lastPaintedRow = null;
+    this.preResizePaintedRow = null;
   }
 
   private formatLine(f: StatusLineFields): string {


### PR DESCRIPTION
## Source
Port of **afk-workshop#719** — https://github.com/griffinwork40/afk-workshop/pull/719
*Moat-scrubbed port, not a 1:1 copy.* Cross-repo (no shared history) → applied via diff + 3-way, then adapted to public structure.

**What it fixes:** on `SIGWINCH`, both `StatusLine` and `BackgroundStatusBar` now reset their geometry **synchronously inside the resize event** (via the existing non-debounced `ResizeBus.subscribeImmediate` channel), before any spinner tick or streaming repaint in the 150 ms debounce window can paint against stale row coordinates — eliminating ghost/stripe rows on terminal resize.

## Ported
- `src/cli/status-line.ts` — `resetGeometry()` on the immediate channel snapshots `lastPaintedRow → preResizePaintedRow` and nulls it; `onResize()` erases the true pre-SIGWINCH row via `preResizePaintedRow ?? lastPaintedRow`; both channels torn down in `stop()`.
- `src/cli/background-status-bar.ts` — `resetGeometry()` zeroes `rowCount`/`lastRepaint` so the spinner `if (rowCount > 0)` guard suppresses mid-window paints until the debounced channel re-seeds geometry; immediate-channel subscribe/unsubscribe wired in `start()`/`stop()`.
- `src/cli/background-status-bar.test.ts` — 3 new tests (R1/R2/R3) covering the reset-on-resize, spinner-suppression-during-debounce, and stop()-teardown behaviors.

## Adapted for public structure (NOT moat drops)
Public's `BackgroundStatusBar` is a registry-only variant — constructor `(registry?, opts?)`, and `BackgroundTaskManager` (`src/cli/commands/interactive/background.ts`) does not exist in public. The private PR was written against the manager-integrated variant, so:
- Dropped the unused `private updateHandler` field (no `updateHandler` in public's bg-bar).
- Adapted the 3 new tests from `new BackgroundStatusBar(manager, registry, …)` to public's `new BackgroundStatusBar(registry, …)`; removed the `BackgroundTaskManager` import/usage from the new test block (the existing public tests already use the `FakeRegistry` + `registry.fireStarted` pattern these now follow).
- One stale comment `from a manager event` → `from a registry event` (manager is private-only).

The fix logic itself is ported faithfully.

## Dropped (moat)
**None.** The diff contains no moat content — it is pure TUI/ANSI resize logic. (`subscribeImmediate` + `__flushResizeBusForTests` already exist in public's `terminal-size.ts`, so no prerequisite port was needed.)

## Verification
- **lint** (`tsc --noEmit`, strict): ✅ pass
- **build** + **build:dist**: ✅ pass (build:dist scrub: 0 files scrubbed)
- **hash pins** (`fix:pins:check`): ✅ all up to date
- **tests**: all port-scoped suites green — `status-line.test.ts` (34), `background-status-bar.test.ts` (19, incl. the 3 new), `status-line-context.test.ts` (7). The full suite shows one failure in `config.test.ts:531`, which is a **pre-existing host-environment config-isolation issue** (`loadConfig()` reading the local machine's real `~/.afk/config` model binding) — it reproduces identically on pristine `main` with this change stashed, and passes in clean CI. **Unrelated to this port.**
- **Deterministic moat guard** (tree + `dist/`): ✅ `MOAT GUARD CLEAN`
- **Adversarial moat audit** (independent re-derivation): ✅ CLEAN

## ⚠️ Do not merge automatically — leave for human review.
