### PR TITLE
docs(tui): formalize TUI invariants discipline with regression tests

### DIFF
--- a/docs/tui-invariants.md
+++ b/docs/tui-invariants.md
@@ -1,0 +1,104 @@
+# TUI Invariants
+
+The agent-afk TUI is built on three protocols whose contracts are governed by sources outside the source file you're editing: the VT/xterm spec (DECSTBM, CUP), `log-update`'s internal line tracker, and the compositor's lifecycle phases. Bugs in this subsystem are almost never raw-ANSI leaks or shared-state races. They are **invariant violations inside centralized owners** — and they recur because the external constraint isn't named at the call site, so the next author can't see it.
+
+This doc names the three risk-site classes, the comment shape they require, and the existing embodiments already in the codebase.
+
+## The pattern
+
+1. **Name the externally-governed constraint.** What invariant does the call site depend on that isn't visible in the surrounding code? (e.g., "`CSI r` homes cursor to (1,1)", "log-update's first frame anchors at current cursor row", "`disposed` flag must be set synchronously before any await")
+2. **Emit the constraint as a code comment, not just in reasoning.** Future authors read the call site, not your PR description.
+3. **For matched teardown/setup pairs, write teardown above setup in source order.** The inverse must be visible from the setup line.
+4. **No optimistic rendering** — never emit a UI update before its dependent write has a confirmed result.
+
+Source: pattern card `agents-fail-ordered-sequences-when-constraint-is-externally-governed`.
+
+## Risk-site classes
+
+### 1. DECSTBM scroll-region operations
+
+**Protocol owner:** VT100/xterm spec — `CSI {top};{bottom}r` sets the scroll region AND unconditionally homes the cursor to `(1,1)`.
+
+**Invariant:** Every DECSTBM emit must either (a) be bracketed by `\x1b[s`/`\x1b[u` save/restore, or (b) carry a comment explaining why cursor-home is intentional at this site.
+
+**Recurrence vector:** Author sets a scroll region to wrap an unrelated write, forgets the cursor moves to (1,1), the next thing rendered clobbers content at the top of the screen.
+
+### 2. log-update calls
+
+**Protocol owner:** `node_modules/log-update/index.js:230` — the first `render()` call writes at the **current cursor row** with no preceding cursor movement. All subsequent repaints anchor relative to that first frame.
+
+**Invariant:** Before the first `log-update.render()` of a session, the cursor must be at the row you want the overlay to anchor to (typically `stdout.rows - 1`). After `log-update.clear()`, call `log-update.done()` to restore cursor visibility — `clear()` alone leaves the cursor hidden.
+
+**Recurrence vector:** A status-line setup or banner-print bracketed its writes with save/restore but left the cursor mid-screen; log-update's first frame anchors there; the overlay is stranded at the wrong row for the rest of the session.
+
+### 3. Lifecycle-dependent state resets
+
+**Protocol owner:** Internal — the compositor and stream renderer have phase transitions (`armed`/`disposed`, `streaming`/`idle`, owned/borrowed) whose invariants are enforced by ordering rather than types.
+
+**Invariant:** Setting the lifecycle flag must happen **synchronously before any `await`** that could let an interval timer, resize handler, or other deferred callback re-enter the object. Borrow-dispose sequences must use per-step `try/catch` so a throw in one step doesn't skip the others. Teardown is written above setup in source order.
+
+**Recurrence vector:** Author adds an `await` between two cleanup steps; an 80ms timer fires in the gap and mutates state the next step assumes is quiescent; the safety-net cleanup then clobbers the timer's writes.
+
+## Comment shape
+
+```ts
+// External constraint (<protocol name>): <invariant in one to three sentences>.
+//
+// <Optional: why this site needs the constraint, what breaks without it,
+// citation to the spec / library source / commit that established the rule>.
+```
+
+Grep the prefix `External constraint` to find every site. The labelled form `External constraint (<protocol>):` is preferred and dominant; a few older sites use the bare `External constraint:` form, so grep the **unparenthesised** prefix to catch both. New protocol invariants extend the catalog by grep, not by re-deriving the rule.
+
+## Existing embodiments
+
+Each site below already carries an `External constraint` comment. **Cite them by grep anchor, never by line number.** Filenames and line numbers drift across refactors — `commitAbove` may live in `terminal-compositor.committed-band.ts` or `terminal-compositor.committed-band-commit.ts`; SIGWINCH/drain handling in `terminal-compositor.ts` or `terminal-compositor.lifecycle.ts` — so the searchable comment text is the only stable anchor. Every anchor below was verified to resolve in the current tree.
+
+### DECSTBM scroll-region
+
+| Site | Grep anchor |
+|---|---|
+| `commitAbove()` band write | `External constraint (DECSTBM contract): when a StatusLine is active` |
+| readline `onSubmit` echo | `External constraint (DECSTBM contract): the StatusLine reserves` |
+| `StatusLine.withFullScrollRegion()` | `External constraint (VT100/DECSTBM contract)` |
+| `StatusLine` DECSTBM cursor-home rule | `External constraint (DEC VT spec)` |
+
+### Lifecycle / ordered-operation sequences
+
+| Site | Grep anchor |
+|---|---|
+| skill-borrow `onCancel` capture | `External constraint (ordered-operation sequence): we MUST capture` |
+| `commitPending` before `drainSubagent` | `External constraint (pattern card: ordered-sequences governed by` |
+| dedup-tail flush after `disarm()` | `External constraint (pattern card: ordered-sequences): this MUST run` |
+| SIGWINCH geometry reset | `External constraint (terminal resize semantics): SIGWINCH` |
+| teardown drain ordering | `External constraint (drain ordering): disable bracketed-paste BEFORE` |
+
+Bare-form sites (no parenthesised label — find them with the unparenthesised `External constraint` grep): the streaming→idle ordering in `setInputMode` (`→ 'idle'` … `onSubmit` MUST fire first), the `Ctrl+L` clear-screen ordering in `input/reader.ts`, and the `CommitCoordinator` "this call MUST come before any cleanup" rule in `stream-renderer.ts`.
+
+### Tested, not yet annotated
+
+Two invariants the regression tests in this PR (`describe('TerminalCompositor — protocol invariants')`) guard, but which do **not** yet carry an `External constraint` comment at the call site — add one on next touch:
+
+- **`arm()` first-frame CUP anchor.** `arm()` now drives a `CupFrameRenderer` (not `log-update`); it still writes an explicit CUP to the bottom row before the first repaint, but the rationale lives only in the test. *(Test: "writes CUP to bottom row before the first repaint".)*
+- **`disarm()` cursor-visibility restore.** The `clear()` → `done()` sequence carries an explanatory inline comment but not the `External constraint` tag. *(Test: "calls logUpdate.done() after logUpdate.clear()".)*
+
+## Checklist for new TUI code
+
+When touching `src/cli/terminal-compositor.ts`, `src/cli/_lib/stream-renderer*.ts`, `src/cli/input/`, or any file that calls log-update / writes ANSI escapes / manages a compositor lifecycle, answer before merging:
+
+- [ ] Does this site depend on a contract from outside the source file? (VT spec, `log-update` source, lifecycle phase invariant)
+- [ ] If yes, is the contract named in an `// External constraint (...)` comment at the call site?
+- [ ] If this is a teardown/setup pair, does teardown appear above setup in source order?
+- [ ] Is the inverse operation reachable from the setup line by reading downward in the same function?
+- [ ] If this site mutates state during an `await`, is there a re-entrancy guard (flag, `disposed`, `committing`) checked synchronously?
+
+## What this is not
+
+- **Not an ESLint rule.** The 2025 audit confirmed every historical bug in this subsystem was a semantic protocol violation **inside** a centralized owner, not a raw-ESC leak outside one. Linting `\x1b` byte literals would flag the correct fixes as violations while catching none of the actual bugs.
+- **Not a refactor brief.** `docs/rendering-architecture-desired.md` proposes the state-machine refactor for the entry lifecycle. This doc is the discipline for the call sites we already have, until and unless that refactor lands.
+- **Not a runtime check.** A `withSavedCursor()` helper or a runtime cursor-position assertion would also work — and may be worth adding alongside. This doc is the cheaper first move.
+- **Not a requirement for every commit.** Most TUI work doesn't touch a risk-site class. The checklist applies when you're inside one of the three protocols above.
+
+## Recurrence record
+
+When a new TUI bug ships and traces back to an unnamed invariant, add the site to the **Existing embodiments** table above as part of the fix PR — as a **grep anchor (the searchable comment text), never a line number**. Line numbers rot on the next refactor; the comment text is stable across line drift. The table is the load-bearing artifact — it converts a one-time fix into searchable institutional memory.

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -4814,3 +4814,160 @@ describe('TerminalCompositor — content-following placement', () => {
     c.disarm();
   });
 });
+
+// ─── Protocol invariants ─────────────────────────────────────────────────────
+//
+// These tests guard the externally-governed contracts catalogued in
+// docs/tui-invariants.md. Each test names the historical bug it prevents from
+// recurring. If you find yourself disabling one of these, you are also opting
+// out of the invariant — confirm in the PR description that the contract has
+// genuinely changed at the protocol level (VT spec, log-update source) before
+// merging.
+
+describe('TerminalCompositor — protocol invariants', () => {
+  let stdout: MockStdout;
+  let stdin: MockStdin;
+  let writes: ReturnType<typeof collectWrites>;
+
+  beforeEach(() => {
+    stdout = makeMockStdout();
+    stdin = makeMockStdin();
+    writes = collectWrites(stdout);
+  });
+
+  describe('arm() — log-update anchor protocol', () => {
+    it('writes CUP to bottom row before the first repaint', async () => {
+      // External constraint (log-update anchor protocol): the FIRST log-update
+      // render writes at the current cursor row with no preceding cursor
+      // movement; all subsequent repaints anchor relative to that row.
+      //
+      // Prevents recurrence of ce1dcfe: without the explicit CUP to
+      // (rows-1, 1), the overlay anchors wherever the welcome banner +
+      // status-line save/restore left the cursor (mid-screen) — producing
+      // a frame split where the overlay paints at the top and input
+      // drifts to the bottom.
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+      await c.arm();
+      const out = writes.all();
+      const anchorRow = (stdout.rows ?? 24) - 1;
+      const expectedCUP = `\x1b[${anchorRow};1H`;
+      const cupIdx = out.indexOf(expectedCUP);
+      expect(cupIdx).toBeGreaterThanOrEqual(0);
+      // CUP must precede any log-update frame content. The first frame
+      // includes the input-row caret render. We assert the CUP appears
+      // within the first 64 bytes of arm()'s output to keep the test
+      // robust against minor preamble changes (e.g. raw-mode setup
+      // sequences) without losing the "comes first" guarantee.
+      expect(cupIdx).toBeLessThan(64);
+    });
+
+    it('skips the CUP write when stdout is not a TTY', async () => {
+      // Negative complement: non-TTY surfaces (pipes, CI) have no cursor
+      // to position. Writing the CUP would inject literal escape bytes
+      // into piped output — visible garbage in logs.
+      const nonTTY = makeMockStdout(false);
+      const nonTTYWrites = collectWrites(nonTTY);
+      const c = new TerminalCompositor({
+        stdout: nonTTY,
+        stdin,
+        onCancel: vi.fn(),
+      });
+      await c.arm();
+      // No CUP escape should appear (the regex matches `\x1b[<n>;1H`).
+      expect(nonTTYWrites.all()).not.toMatch(/\x1b\[\d+;1H/);
+    });
+  });
+
+  describe('commitAbove() — DECSTBM contract', () => {
+    it('routes the newline write through withFullScrollRegion when scrollRegion is provided', async () => {
+      // External constraint (DECSTBM contract): when a status line is active,
+      // the bottom row is reserved via a persistent scroll region. A raw `\n`
+      // at the bottom of that sub-region triggers a sub-region scroll and the
+      // displaced top line silently exits without entering scrollback.
+      //
+      // Prevents recurrence of f962403-family bugs: removing the
+      // withFullScrollRegion guard would resurface "tool-lane lines vanish
+      // into the void" the moment the status line is active.
+      const scrollRegion = {
+        withFullScrollRegion: vi.fn(<T,>(fn: () => T): T => fn()),
+        // getExtraRows is part of the CompositorScrollRegionGuard contract:
+        // arm()→repaint() reads it to keep the frame above any reserved
+        // status-bar rows. A mock that omits it throws on arm(); 0 means
+        // "no reserved rows", isolating this test to the routing invariant.
+        getExtraRows: vi.fn(() => 0),
+      };
+      const c = new TerminalCompositor({
+        stdout,
+        stdin,
+        onCancel: vi.fn(),
+        scrollRegion,
+      });
+      await c.arm();
+      writes.clear();
+      c.commitAbove('COMMITTED_BLOCK');
+
+      // The guard-call is the load-bearing assertion: removing
+      // `writeWithGuard(...)` from commitAbove would make this fail
+      // immediately, regardless of how the inner write is shaped.
+      expect(scrollRegion.withFullScrollRegion).toHaveBeenCalled();
+      // Content reaches stdout. Armed-path commitAbove (CommittedBand.commitAbove)
+      // positions the cursor at the row above the frame and erases the line
+      // before writing the block, so the committed text appears as
+      // `CUP-to-row → EL (\x1b[2K) → text`. We pin that exact positioned
+      // shape rather than a bare substring so the test fails if the block
+      // ever stops being placed via the centralized cursor-positioned write.
+      const out = writes.all();
+      expect(out).toContain('COMMITTED_BLOCK');
+      expect(out).toMatch(/\x1b\[\d+;1H\x1b\[2KCOMMITTED_BLOCK/);
+    });
+
+    it('writes directly without invoking the guard when scrollRegion is absent', async () => {
+      // Negative complement: callers without an active status line shouldn't
+      // pay for indirection; the bare write still commits to scrollback
+      // because no DECSTBM is in effect.
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+      await c.arm();
+      writes.clear();
+      c.commitAbove('NO_GUARD_BLOCK');
+      // Same positioned emission shape as the guarded path — armed
+      // commitAbove writes `CUP-to-row → EL (\x1b[2K) → text`. The only
+      // difference from the guarded case is that withFullScrollRegion is
+      // never invoked (asserted implicitly: no scrollRegion was provided).
+      const out = writes.all();
+      expect(out).toContain('NO_GUARD_BLOCK');
+      expect(out).toMatch(/\x1b\[\d+;1H\x1b\[2KNO_GUARD_BLOCK/);
+    });
+  });
+
+  describe('disarm() — cursor visibility restore', () => {
+    it('calls logUpdate.done() after logUpdate.clear() so the cursor stays visible', async () => {
+      // External constraint (cliCursor visibility): log-update hides the
+      // cursor on every render() when showCursor is false (the default).
+      // Only done() calls cliCursor.show(); clear() alone leaves the cursor
+      // hidden, leaking that state for the rest of the session.
+      //
+      // Prevents recurrence of "cursor stays invisible after a turn ends"
+      // by asserting the (clear, done) sequence is intact.
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+      await c.arm();
+
+      const internals = c as unknown as {
+        logUpdate: { clear: () => void; done: () => void };
+      };
+      const calls: string[] = [];
+      const originalClear = internals.logUpdate.clear.bind(internals.logUpdate);
+      const originalDone = internals.logUpdate.done.bind(internals.logUpdate);
+      internals.logUpdate.clear = () => {
+        calls.push('clear');
+        originalClear();
+      };
+      internals.logUpdate.done = () => {
+        calls.push('done');
+        originalDone();
+      };
+
+      c.disarm();
+      expect(calls).toEqual(['clear', 'done']);
+    });
+  });
+});


### PR DESCRIPTION
## Ported from afk-workshop#454 (moat-scrubbed)

**Source:** griffinwork40/afk-workshop#454 — _"docs(tui): formalize TUI invariants discipline with regression tests"_
This is a **moat-scrubbed port** (private → public), not a 1:1 copy.

### Ported (public-safe)
- **`docs/tui-invariants.md`** (new, +104) — names the three externally-governed TUI risk-site classes (DECSTBM scroll-region ops, `log-update` anchoring, lifecycle-dependent state resets), the `External constraint (...)` comment shape, a grep-anchor catalog of existing embodiments, and a checklist for new TUI code.
- **`src/cli/terminal-compositor.test.ts`** (+157) — a `describe('TerminalCompositor — protocol invariants')` block with 5 regression tests guarding: `arm()` bottom-row CUP anchoring (+ non-TTY skip), `commitAbove()` DECSTBM scroll-region routing (guarded + unguarded), and `disarm()` cursor-visibility restore (`clear()` → `done()`).

### Modified during scrub (softened, not dropped)
- The doc's two **dual-tree** passages — which explicitly contrasted the private (`afk-workshop`) and public (`agent-afk`) tree file layouts — were softened to tree-agnostic language (_"filenames and line numbers drift across refactors … cite grep anchors, not line numbers"_). The concrete (public-real) filename examples and the grep-anchor rationale are preserved; this removes private-repo file-layout disclosure and reads correctly for public contributors who have only one tree.

### Dropped
- Nothing fully dropped — no moat files or hunks were present in this PR.

### Verification
- **Correctness gate (green):** `lint` ✓ · `test` → 498 files / **9354 passed / 0 failed** ✓ · `build` ✓ · `build:dist` ✓ · `fix:pins:check` clean ✓. The 5 new tests pass against the public tree.
  - _Note:_ one `config.test.ts` model-slot-binding assertion fails **only** when leaked `AFK_*` session env vars are present (the runner's env reads them via `loadConfig`); it passes cleanly in a hermetic env. Unrelated to this docs+test change.
- **Deterministic moat guard:** `✅ MOAT GUARD CLEAN` (tree + dist; HARD denylist + structural markers + merge markers).
- **Adversarial audit (independent re-derivation):** CLEAN-TO-PUBLISH (high confidence). "pattern card" confirmed pre-existing public vocabulary (`AFK.md`, `CLAUDE.md`, `docs/scrollback.md`, source); "afk-workshop" absent from ported files; cited SHAs `ce1dcfe`/`f962403` already in public `CHANGELOG.md`; all doc grep anchors resolve in the public tree.

### Flagged for reviewer (BORDERLINE)
- The softened dual-tree phrasing was the only borderline item — confirm you're comfortable with it. (Repo names + "pattern card" + the cited SHAs are already publicly disclosed.)

**⚠️ Do not merge automatically — human review required.** The `docs(tui):` prefix is intentionally non-releasable; merging will not trigger a version bump (correct for a docs + test change).
