### PR TITLE
feat(prompts): require durable, citation-backed evidence in terminal states

### DIFF
--- a/src/agent/routing-directive.ts
+++ b/src/agent/routing-directive.ts
@@ -100,11 +100,11 @@ Reserve \`ask_question\` for the narrow set of things no tool can resolve: a gen
  */
 export const END_OF_TURN_DIRECTIVE = `[end-of-turn protocol]
 
-Every turn must end in one externally identifiable terminal state. AFK users need inspectable artifacts, not ceremony.
+Every turn must end in one externally identifiable terminal state. AFK users need inspectable artifacts, not ceremony. Write each bullet as a single sentence.
 
 **Done**
 - What was done
-- Evidence that exists
+- Evidence that exists, named by a durable location (file path, commit SHA, trace path, test output, or memory key) — never transcript-only
 - What changed in the world
 - Anything still pending or deferred, with why
 

--- a/src/skills/mint/prompts/build.md
+++ b/src/skills/mint/prompts/build.md
@@ -38,7 +38,7 @@ Respond with a single fenced JSON code block and no prose outside it. The JSON m
   "tests_passed": true,
   "build_passed": true,
   "verification_passed": true,
-  "notes": "Concise summary of what was built, what verification ran, and any issues or decisions."
+  "notes": "Built the X module. Ran `pnpm test -- src/x.test.ts` → 12 passed, exit 0. Ran `pnpm lint` → exit 0. Ran `pnpm build` → exit 0."
 }
 ```
 
@@ -46,6 +46,6 @@ Field semantics:
 - `status` — `"PASS"` if implementation is complete and all tests pass; `"FAIL"` otherwise.
 - `status_reason` — short reason when `FAIL`; omit when `PASS`.
 - `files_changed` — every file you created or modified, as repo-relative paths.
-- `tests_passed` — did all specified tests pass?
-- `build_passed` / `verification_passed` — optional booleans for projects with a build step or extra verification commands; omit when not applicable.
-- `notes` — human-readable summary that the next phase will read. Keep it concise.
+- `tests_passed` — did all specified tests pass? Set `true` ONLY if `notes` records the exact test command you ran and its observed result (exit code, pass/fail count, or a relevant output excerpt); if you did not run them or cannot cite the result, set `false`.
+- `build_passed` / `verification_passed` — optional booleans for projects with a build step or extra verification commands; omit when not applicable. Same rule: set `true` ONLY when `notes` records the exact command and its observed result.
+- `notes` — human-readable summary that the next phase will read; keep it concise, but it MUST quote the exact command(s) run and their observed results (exit code, pass count, or output excerpt) backing every `*_passed: true` you set.


### PR DESCRIPTION
## What
Two prompt-hardening edits that push agent self-reports toward verifiable, durable evidence:

- **`src/agent/routing-directive.ts`** — the `Done` terminal state's *Evidence* bullet must now name a **durable location** (file path, commit SHA, trace path, test output, or memory key), never transcript-only; each bullet is written as a single sentence.
- **`src/skills/mint/prompts/build.md`** — `tests_passed` / `build_passed` may be reported `true` **only when `notes` cites the exact command run and its observed result** (exit code / pass count / output excerpt). Anti-hallucination for the build phase's self-report.

## Why
Terminal-state and build-phase self-reports could previously claim success backed by transcript-only or unsubstantiated evidence. Requiring a durable, citable artifact makes async review (the core AFK use case) trustworthy and curbs fabricated "tests passed" claims.

## Provenance
Salvaged from a stale local worktree (`afk/audit-prompts-parallel`) whose base had drifted ~283 files behind `main`; the hunks were re-applied cleanly onto current `main`. The branch's third hunk (`diagnose/verify.md` read-only honesty) was intentionally dropped — already superseded by main's own version.

## Verification
- `vitest run src/agent/routing-directive.test.ts src/cli/commands/interactive/terminal-state.test.ts` → **60 passed**. Assertions reference the directive constant by identifier (`toContain(END_OF_TURN_DIRECTIVE)`), so the wording change is safe.
- `tsc --noEmit` → clean (exit 0). The TS edit is string-literal content only.
