### PR TITLE
fix(cli): correct prerelease version compare + debounce auto-update re-trigger

### DIFF
--- a/src/cli/update-checker.test.ts
+++ b/src/cli/update-checker.test.ts
@@ -80,6 +80,7 @@ function buildFakeHttp(
 
 import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'fs';
 import { spawn } from 'child_process';
+import { getVersion } from './version.js';
 import {
   checkForUpdates,
   printUpdateBanner,
@@ -94,7 +95,9 @@ const mockWriteFileSync = vi.mocked(writeFileSync);
 const mockExistsSync = vi.mocked(existsSync);
 const mockUnlinkSync = vi.mocked(unlinkSync);
 const mockSpawn = vi.mocked(spawn);
+const mockGetVersion = vi.mocked(getVersion);
 const pendingFile = join(FAKE_CACHE_DIR, 'pending-update.json');
+const ONE_HOUR_MS = 60 * 60 * 1000;
 
 describe('update-checker', () => {
   let stderrSpy: ReturnType<typeof vi.spyOn>;
@@ -103,6 +106,9 @@ describe('update-checker', () => {
     vi.clearAllMocks();
     stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockExistsSync.mockReturnValue(true);
+    // clearAllMocks() does not reset implementations set via mockReturnValue,
+    // so re-pin the default here to stop per-test prerelease overrides leaking.
+    mockGetVersion.mockReturnValue('1.10.1');
     delete process.env['NO_UPDATE_NOTIFIER'];
     delete process.env['CI'];
   });
@@ -179,6 +185,45 @@ describe('update-checker', () => {
       checkForUpdates('notify');
       expect(mockSpawn).not.toHaveBeenCalled();
     });
+
+    // --- prerelease ordering (exercises the private isNewerVersion) ---------
+    // Before the fix, Number() on a "-beta"/"-rc" suffix produced NaN segments
+    // whose comparisons are always false, so these two cases returned the wrong
+    // boolean (a running prerelease never saw its release; a release wrongly
+    // "updated" to a prerelease).
+
+    it('treats the final release as newer than a running prerelease', () => {
+      mockGetVersion.mockReturnValue('1.10.1-beta.1');
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ latestVersion: '1.10.1', checkedAt: Date.now() }),
+      );
+
+      expect(checkForUpdates('notify')).toEqual({
+        currentVersion: '1.10.1-beta.1',
+        latestVersion: '1.10.1',
+      });
+    });
+
+    it('does not offer a prerelease as an update over the running release', () => {
+      mockGetVersion.mockReturnValue('1.10.1');
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ latestVersion: '1.10.1-beta.5', checkedAt: Date.now() }),
+      );
+
+      expect(checkForUpdates('notify')).toBeNull();
+    });
+
+    it('compares numeric cores when a prerelease suffix is present', () => {
+      mockGetVersion.mockReturnValue('1.10.1-rc.1');
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ latestVersion: '1.11.0', checkedAt: Date.now() }),
+      );
+
+      expect(checkForUpdates('notify')).toEqual({
+        currentVersion: '1.10.1-rc.1',
+        latestVersion: '1.11.0',
+      });
+    });
   });
 
   describe('printUpdateBanner', () => {
@@ -193,6 +238,7 @@ describe('update-checker', () => {
 
   describe('triggerAutoUpdate', () => {
     it('spawns npm install and writes pending marker', () => {
+      mockExistsSync.mockReturnValue(false); // no in-flight marker
       triggerAutoUpdate('1.11.0');
 
       expect(mockWriteFileSync).toHaveBeenCalledWith(
@@ -213,8 +259,16 @@ describe('update-checker', () => {
     });
 
     it('accepts pre-release versions', () => {
+      mockExistsSync.mockReturnValue(false); // no in-flight marker
       triggerAutoUpdate('2.0.0-beta.1');
       expect(mockSpawn).toHaveBeenCalled();
+    });
+
+    it('does not re-trigger when a pending marker already exists (install in flight)', () => {
+      mockExistsSync.mockReturnValue(true); // marker on disk → install in flight
+      triggerAutoUpdate('1.11.0');
+      expect(mockSpawn).not.toHaveBeenCalled();
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
     });
   });
 
@@ -254,14 +308,31 @@ describe('update-checker', () => {
       expect(output).toContain('Updated to agent-afk v1.10.1');
     });
 
-    it('clears marker without message when version does not match', () => {
+    it('keeps a fresh non-matching marker (install still in flight)', () => {
       mockReadFileSync.mockReturnValue(
         JSON.stringify({ targetVersion: '1.11.0', triggeredAt: Date.now() }),
       );
 
       checkPendingUpdate();
 
-      expect(mockUnlinkSync).toHaveBeenCalled();
+      // The install hasn't landed yet; the marker must survive so that
+      // triggerAutoUpdate() debounces and does not spawn a second install.
+      expect(mockUnlinkSync).not.toHaveBeenCalled();
+      const output = stderrSpy.mock.calls.map((c) => c[0]).join('');
+      expect(output).not.toContain('Updated');
+    });
+
+    it('clears a stale non-matching marker (install never completed)', () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          targetVersion: '1.11.0',
+          triggeredAt: Date.now() - ONE_HOUR_MS - 60_000, // older than PENDING_TTL_MS
+        }),
+      );
+
+      checkPendingUpdate();
+
+      expect(mockUnlinkSync).toHaveBeenCalledWith(pendingFile);
       const output = stderrSpy.mock.calls.map((c) => c[0]).join('');
       expect(output).not.toContain('Updated');
     });

--- a/src/cli/update-checker.ts
+++ b/src/cli/update-checker.ts
@@ -25,6 +25,13 @@ interface PendingUpdate {
 }
 
 const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
+/**
+ * How long a pending-update marker is trusted to mean "an install is still in
+ * flight." Within this window `triggerAutoUpdate()` refuses to spawn a second
+ * `npm install`; past it the marker is treated as stale (the install crashed
+ * or was killed) and cleared so a fresh attempt can run.
+ */
+const PENDING_TTL_MS = 60 * 60 * 1000;
 const CACHE_FILE = 'update-check.json';
 const PENDING_FILE = 'pending-update.json';
 
@@ -44,8 +51,17 @@ function ensureCacheDir(): void {
 }
 
 function isNewerVersion(current: string, latest: string): boolean {
-  const c = current.split('.').map(Number);
-  const l = latest.split('.').map(Number);
+  // Compare only the numeric "core" (major.minor.patch). A prerelease
+  // (`-beta.1`) or build-metadata (`+sha`) suffix would otherwise produce
+  // NaN segments via Number(), and NaN comparisons are always false — so a
+  // running prerelease never saw its own final release as "newer".
+  const core = (v: string): string => v.split(/[-+]/, 1)[0] ?? v;
+  // Prerelease is denoted by a `-` suffix per semver; build metadata (`+`)
+  // does NOT lower precedence, so it must not count here.
+  const isPrerelease = (v: string): boolean => v.includes('-');
+
+  const c = core(current).split('.').map(Number);
+  const l = core(latest).split('.').map(Number);
   const len = Math.max(c.length, l.length);
   for (let i = 0; i < len; i++) {
     const cv = c[i] ?? 0;
@@ -53,7 +69,11 @@ function isNewerVersion(current: string, latest: string): boolean {
     if (lv > cv) return true;
     if (lv < cv) return false;
   }
-  return false;
+  // Equal numeric cores: a final release outranks its own prerelease
+  // (so the running 4.7.5-beta.1 treats 4.7.5 as an available update).
+  // Prerelease-to-prerelease ordering is intentionally not handled — npm's
+  // `latest` dist-tag does not serve prereleases.
+  return isPrerelease(current) && !isPrerelease(latest);
 }
 
 function readCache(): UpdateCache | null {
@@ -247,6 +267,12 @@ export function fetchLatestVersion(
 
 export function triggerAutoUpdate(latestVersion: string): void {
   if (!SEMVER_RE.test(latestVersion)) return;
+  // Debounce: a marker on disk means a prior install is still in flight (or
+  // finished but not yet announced). Spawning a second `npm install -g` over
+  // it races two installs against the same global package. checkPendingUpdate()
+  // owns clearing the marker — on success, or once it is older than
+  // PENDING_TTL_MS — at which point a fresh trigger is allowed through.
+  if (existsSync(pendingPath())) return;
   try {
     writePendingUpdateMarker(latestVersion);
     const child = spawn('npm', ['install', '-g', `agent-afk@${latestVersion}`], {
@@ -263,15 +289,26 @@ export function checkPendingUpdate(): void {
   try {
     const raw = readFileSync(pendingPath(), 'utf-8');
     const pending = JSON.parse(raw) as PendingUpdate;
-    if (typeof pending.targetVersion === 'string') {
-      const current = getVersion();
+    if (typeof pending.targetVersion !== 'string') return;
+
+    const current = getVersion();
+    if (current === pending.targetVersion) {
+      // Install landed: announce once, then clear the marker.
       unlinkSync(pendingPath());
-      if (current === pending.targetVersion) {
-        const green = '\x1b[32m';
-        const bold = '\x1b[1m';
-        const reset = '\x1b[0m';
-        process.stderr.write(`${green}${bold}Updated to agent-afk v${current}${reset}\n`);
-      }
+      const green = '\x1b[32m';
+      const bold = '\x1b[1m';
+      const reset = '\x1b[0m';
+      process.stderr.write(`${green}${bold}Updated to agent-afk v${current}${reset}\n`);
+      return;
+    }
+
+    // Version still doesn't match the target. Either the background install is
+    // genuinely in flight — keep the marker so triggerAutoUpdate() debounces —
+    // or it never completed and the marker is stale, in which case clear it so
+    // a fresh auto-update can be triggered.
+    const triggeredAt = typeof pending.triggeredAt === 'number' ? pending.triggeredAt : 0;
+    if (Date.now() - triggeredAt > PENDING_TTL_MS) {
+      unlinkSync(pendingPath());
     }
   } catch {
     // no pending update or corrupt file — ignore


### PR DESCRIPTION
**Source:** [afk-workshop#801](https://github.com/griffinwork40/afk-workshop/pull/801) — moat-scrubbed port via diff + 3-way apply (the public repo shares no history with afk-workshop, so this is not a cherry-pick). In this case nothing required scrubbing: the change is core-CLI only and carries no moat.

## Ported
- **`src/cli/update-checker.ts`**
  - Fix `isNewerVersion`: compare numeric semver **cores** by stripping any `-prerelease`/`+build` suffix before `Number()`. Previously `Number('1.10.1-beta')` produced `NaN`, whose comparisons are always false, so a running prerelease never detected its own final release (and a release could wrongly "update" to a prerelease). On equal cores, a final release now outranks its prerelease (`return isPrerelease(current) && !isPrerelease(latest)`).
  - Add `PENDING_TTL_MS` (1h) auto-update **debounce**: `triggerAutoUpdate()` skips spawning a second `npm install -g` when a pending marker already exists; `checkPendingUpdate()` keeps a *fresh* non-matching marker (install still in flight) but clears a *stale* one (older than the TTL → install crashed) so a fresh attempt can run.
- **`src/cli/update-checker.test.ts`** — tests for prerelease ordering, the debounce guard, and fresh-vs-stale marker handling.

## Dropped (and why)
- **Nothing.** The PR touches only core-CLI files that already exist in public; no moat files or hunks were present to drop.

## Verification (on the ported tree at this branch)
- `pnpm install --frozen-lockfile` ✅ · `pnpm lint` (`tsc --noEmit`) ✅ · `pnpm fix:pins:check` ✅ (hash pins up to date) · `pnpm build` ✅ · `pnpm build:dist` ✅
- `pnpm test`: **9381 passed / 12 skipped / 0 failed** (full suite, clean env). Ported file in isolation: **33/33 pass**.
- **Moat guard: CLEAN** — deterministic grep of the tree **and built `dist/`** for the full HARD denylist + structural markers returned 0 hits.
- **Adversarial moat audit: MOAT-CLEAN** — independent re-derivation over tree + dist.

**Do not merge automatically — left for human review.**
