### PR TITLE
fix(mint): add spec-compliance axis to design-review verify gate

### DIFF
--- a/src/skills/mint/prompts/verify.md
+++ b/src/skills/mint/prompts/verify.md
@@ -21,7 +21,14 @@ The orchestrator runs three modes in parallel: `test` and `lint` are **programma
 - Capture each lint/type error with file:line where possible.
 
 **If mode is `design-review`:**
-Evaluate the implementation diff across these dimensions and decide PASS/FAIL based on whether any dimension has a red (blocker):
+Evaluate the implementation diff on two axes — **spec compliance** (did it build what the plan specified?) and **code quality** (is the build any good?). A red on *either* axis is a FAIL.
+
+**Spec compliance — check this FIRST, against the Phase 3 plan's success criteria (in your input):**
+- **Completeness** — every success criterion / acceptance condition in the plan has a corresponding change in the diff. A criterion with no implementing change is a blocker.
+- **No scope creep** — nothing substantive was built beyond what the plan asked for. Unrequested features or behavior changes are a blocker (cite `file:line`).
+- If the plan carries **no explicit success criteria** to check against, do NOT silently treat the global constraints — or the diff's own apparent goals — as "the spec" and pass. Emit a blocker: `spec-compliance not assessable — plan lacks explicit success criteria`. A reviewer who invents the spec rubber-stamps everything.
+
+**Code quality — evaluate the implementation diff across these dimensions:**
 
 1. **Clean code** — no unnecessary duplication, no dead code, clear names, comments explain "why" not "what", no overbuilt abstractions.
 2. **Modularity** — single-responsibility files, clean module boundaries, clear public vs. private APIs.
@@ -31,7 +38,7 @@ Evaluate the implementation diff across these dimensions and decide PASS/FAIL ba
 6. **Intuitive design** — discoverable API, actionable error messages, consistent names.
 7. **Security hygiene** — no new secrets in code, safe input handling, no obvious vulnerabilities.
 
-A red on any dimension is a FAIL; yellows are nice-to-have and do not block.
+A red on the spec-compliance axis or any code-quality dimension is a FAIL; yellows are nice-to-have and do not block.
 
 ## Output
 


### PR DESCRIPTION
## Source
Moat-scrubbed port of **afk-workshop#802** (private canonical). Not a 1:1 copy — moat-only content is excluded by policy (none here).

## Ported
- `src/skills/mint/prompts/verify.md` — adds a **spec-compliance axis** to the `mint` design-review verify gate. Design-review now evaluates two axes: **spec compliance** (completeness + no scope-creep, checked first against the Phase 3 plan's success criteria) and the existing 7 code-quality dimensions. Includes an inoculation: when the plan has no explicit success criteria, the reviewer emits a blocker rather than silently treating global constraints as "the spec."

Rationale: closes the "reviewer rubber-stamps without the brief" failure mode — a design-review that scores only code quality can pass an implementation that is clean but does not build what was specified.

## Dropped (moat)
None — the entire diff is a single public-safe prose change to a public skill prompt.

## Verification
- `pnpm install --frozen-lockfile` ✓ · `pnpm lint` ✓ · `pnpm build` ✓ · `pnpm build:dist` ✓ · `pnpm fix:pins:check` ✓ (no pin drift)
- `mint.test.ts`: **53/53 pass**
- Full `pnpm test`: 9380 passed, 12 skipped, **1 failure unrelated to this change** — `src/cli/config.test.ts` is non-hermetic: its `beforeEach` env-reset list omits `AFK_MODEL_LOCAL*`, so on a dev box exporting those it reads local model config and `config.models` ≠ `DEFAULT_SLOT_BINDINGS`. Re-running with those vars unset → **38/38 pass** (green on clean/CI env). Pre-existing test-isolation bug, flagged separately; untouched by this PR.
- **MOAT GUARD CLEAN** (deterministic denylist + structural scan of tree + built dist/) and **independent adversarial moat audit: CLEAN**.

**Do not merge automatically — for human review.**
