### PR TITLE
fix(improve): exclude ask_question elicitation declines from tool-failure-density

### DIFF
--- a/src/agent/tools/handlers/ask-question.test.ts
+++ b/src/agent/tools/handlers/ask-question.test.ts
@@ -99,6 +99,9 @@ describe('ask_question handler — decline when no handler', () => {
     // M3: decline/cancel are hard stops — the agent must see isError: true so it
     // halts rather than treating the refusal as a valid answer.
     expect(result.isError).toBe(true);
+    // The decline is tagged so tool-failure-density excludes it: an unanswered
+    // question on a non-interactive/AFK surface is an expected outcome, not a fault.
+    expect(result.failureClass).toBe('elicitation-declined');
     const parsed = JSON.parse(result.content as string) as ElicitationResult;
     expect(parsed.action).toBe('decline');
   });
@@ -151,8 +154,35 @@ describe('ask_question handler — handler installed', () => {
 
     const result = await askQuestionHandler({ question: 'confirm?' }, NO_SIGNAL);
     expect(result.isError).toBeUndefined();
+    // A successful answer is never tagged as a failure.
+    expect(result.failureClass).toBeUndefined();
     const parsed = JSON.parse(result.content as string) as ElicitationResult;
     expect(parsed.action).toBe('accept');
+  });
+
+  it('tags cancel result with isError + failureClass: elicitation-declined', async () => {
+    elicitationRouter.install(vi.fn().mockResolvedValue({ action: 'cancel' } as ElicitationResult));
+
+    const result = await askQuestionHandler({ question: 'still there?' }, NO_SIGNAL);
+    // cancel (operator dismissed the prompt) is a hard stop like decline, and is
+    // excluded from tool-failure-density via the failureClass tag.
+    expect(result.isError).toBe(true);
+    expect(result.failureClass).toBe('elicitation-declined');
+    const parsed = JSON.parse(result.content as string) as ElicitationResult;
+    expect(parsed.action).toBe('cancel');
+  });
+
+  it('does NOT tag skip result as a failure (optional question skipped is a success)', async () => {
+    elicitationRouter.install(vi.fn().mockResolvedValue({ action: 'skip' } as ElicitationResult));
+
+    const result = await askQuestionHandler(
+      { question: 'optional?', allow_skip: true },
+      NO_SIGNAL,
+    );
+    expect(result.isError).toBeUndefined();
+    expect(result.failureClass).toBeUndefined();
+    const parsed = JSON.parse(result.content as string) as ElicitationResult;
+    expect(parsed.action).toBe('skip');
   });
 
   it('passes origin: "agent" in the routed request', async () => {

--- a/src/agent/tools/handlers/ask-question.ts
+++ b/src/agent/tools/handlers/ask-question.ts
@@ -133,6 +133,16 @@ export const askQuestionHandler: ToolHandler = async (input, signal) => {
   // documents this distinction: "skip (optional question skipped)" is a
   // listed action, while "After a `cancel` or `decline`, stop and tell the
   // user what information you need" only fires for the two error actions.
+  //
+  // The `isError: true` is preserved (the model must still stop on a decline),
+  // but it is tagged `failureClass: 'elicitation-declined'` so the
+  // tool-failure-density detector excludes it: an unanswered question on a
+  // non-interactive or AFK surface is an expected outcome, not a tool fault.
+  // Without the tag these land as `unclassified` failures and manufacture a
+  // false-positive `tool-failure-ask-question` card.
   const declined = result.action === 'decline' || result.action === 'cancel';
-  return { content: JSON.stringify(result), ...(declined && { isError: true }) };
+  return {
+    content: JSON.stringify(result),
+    ...(declined && { isError: true, failureClass: 'elicitation-declined' as const }),
+  };
 };

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -62,6 +62,7 @@ export const TOOL_FAILURE_CLASSES = [
   'permission-denied',
   'hook-block',
   'abort',
+  'elicitation-declined',
 ] as const;
 
 /**
@@ -70,15 +71,20 @@ export const TOOL_FAILURE_CLASSES = [
  * pre-classification default — a handler bug, malformed input, etc.).
  *
  * Set at the site that produced the error:
- *   - `policy-refusal`    — browser handler refused nav (domain allowlist). NOT a bug.
- *   - `timeout`           — browser navigation/action exceeded its deadline.
- *   - `permission-denied` — permission gate or read-only-skill bash gate denied the call.
- *   - `hook-block`        — a PreToolUse hook returned `decision: 'block'`.
- *   - `abort`             — the call's AbortSignal was already fired.
+ *   - `policy-refusal`       — browser handler refused nav (domain allowlist). NOT a bug.
+ *   - `timeout`              — browser navigation/action exceeded its deadline.
+ *   - `permission-denied`    — permission gate or read-only-skill bash gate denied the call.
+ *   - `hook-block`           — a PreToolUse hook returned `decision: 'block'`.
+ *   - `abort`                — the call's AbortSignal was already fired.
+ *   - `elicitation-declined` — `ask_question` returned `decline` (no handler / surface
+ *                              cannot reach a human) or `cancel` (operator dismissed the
+ *                              prompt). An unanswered question is an expected outcome on a
+ *                              non-interactive or AFK surface, NOT a tool fault.
  *
  * The `tool-failure-density` detector treats `policy-refusal`, `permission-denied`,
- * `hook-block`, and `abort` as "the system correctly said no" — excluded from
- * failure stats entirely — while `timeout` and unclassified failures still count.
+ * `hook-block`, `abort`, and `elicitation-declined` as "the system correctly said no" —
+ * excluded from failure stats entirely — while `timeout` and unclassified failures still
+ * count.
  */
 export type ToolFailureClass = (typeof TOOL_FAILURE_CLASSES)[number];
 

--- a/src/improve/scan/detectors/tool-failure-density.test.ts
+++ b/src/improve/scan/detectors/tool-failure-density.test.ts
@@ -431,7 +431,13 @@ describe('detectToolFailureDensity — circuit-breaker exclusion', () => {
 });
 
 describe('detectToolFailureDensity — failureClass exclusion', () => {
-  for (const cls of ['policy-refusal', 'permission-denied', 'hook-block', 'abort']) {
+  for (const cls of [
+    'policy-refusal',
+    'permission-denied',
+    'hook-block',
+    'abort',
+    'elicitation-declined',
+  ]) {
     it(`does NOT produce a card when all failures are class '${cls}'`, () => {
       resetSeq();
       // 8 isError failures, all "system said no" — must produce zero cards.
@@ -471,6 +477,41 @@ describe('detectToolFailureDensity — failureClass exclusion', () => {
     expect(r.detail['totalCalls']).toBe(5);
     expect(r.detail['failureCount']).toBe(3);
     expect(r.detail['excludedByClass']).toEqual({ 'policy-refusal': 6 });
+  });
+
+  it('regression: ask_question AFK declines do not manufacture a card (the reported bug)', () => {
+    resetSeq();
+    // The real-world shape that produced the false-positive `tool-failure-ask-question`
+    // card: 12 elicitation declines/cancels (operator AFK on an interactive surface) out
+    // of 36 ask_question calls. Pre-fix this read as 12/36 = 33% "failure" → high card.
+    // Post-fix the 12 declines are excluded from BOTH numerator and denominator,
+    // leaving 0 real failures / 24 calls → no card.
+    const lines: string[] = [];
+    for (let i = 0; i < 12; i++) {
+      lines.push(
+        ...toolPair(`d-${i}`, 'ask_question', { isError: true, failureClass: 'elicitation-declined' }),
+      );
+    }
+    for (let i = 0; i < 24; i++) lines.push(...toolPair(`ok-${i}`, 'ask_question'));
+    expect(detectToolFailureDensity([makeSession('s1', lines)])).toEqual([]);
+  });
+
+  it('excludes elicitation declines from BOTH numerator and denominator but still fires on real faults', () => {
+    resetSeq();
+    // 3 real (unclassified) failures + 5 elicitation declines + 1 success.
+    // Real denominator = 3 + 1 = 4; rate = 3/4 = 75% → fires with count 3, total 4.
+    const lines: string[] = [];
+    for (let i = 0; i < 3; i++) lines.push(...toolPair(`f-${i}`, 'ask_question', { isError: true }));
+    for (let i = 0; i < 5; i++) {
+      lines.push(
+        ...toolPair(`d-${i}`, 'ask_question', { isError: true, failureClass: 'elicitation-declined' }),
+      );
+    }
+    lines.push(...toolPair('ok-0', 'ask_question'));
+    const r = detectToolFailureDensity([makeSession('s1', lines)])[0]!;
+    expect(r.detail['totalCalls']).toBe(4);
+    expect(r.detail['failureCount']).toBe(3);
+    expect(r.detail['excludedByClass']).toEqual({ 'elicitation-declined': 5 });
   });
 
   it("counts 'timeout' as a real failure (not excluded) and surfaces it in the breakdown", () => {

--- a/src/improve/scan/detectors/tool-failure-density.ts
+++ b/src/improve/scan/detectors/tool-failure-density.ts
@@ -38,13 +38,15 @@
  * ## Caveats
  *
  *   - "Failure" means `isError: true` returned by the dispatcher. The trace
- *     payload now carries a coarse `failureClass` (set at the dispatcher gates
- *     and browser handlers — see {@link ToolFailureClass}). This detector uses
- *     it to EXCLUDE "the system correctly said no" results (policy refusal,
- *     permission denial, hook block, abort) from both the failure count and the
- *     call total — see {@link EXCLUDED_FAILURE_CLASSES}. Failures with no class
- *     (older traces, handler throws, malformed input) still count, preserving
- *     back-compat. The per-class `failureClassBreakdown` and `excludedByClass`
+ *     payload now carries a coarse `failureClass` (set at the dispatcher gates,
+ *     the browser handlers, and the ask_question handler — see
+ *     {@link ToolFailureClass}). This detector uses it to EXCLUDE "the system
+ *     correctly said no / the human did not answer" results (policy refusal,
+ *     permission denial, hook block, abort, elicitation decline) from both the
+ *     failure count and the call total — see {@link EXCLUDED_FAILURE_CLASSES}.
+ *     Failures with no class (older traces, handler throws, malformed input)
+ *     still count, preserving back-compat. The per-class
+ *     `failureClassBreakdown` and `excludedByClass`
  *     are surfaced in the card detail so a reviewer can see the mix.
  *   - `timeout` is classified but NOT excluded — a high timeout rate can be a
  *     real signal — so it still counts toward the rate, just visibly.
@@ -60,12 +62,15 @@ import type { SessionRead } from '../reader.js';
 import type { ToolFailureClass } from '../../../agent/trace/types.js';
 
 /**
- * Failure classes that mean "the system correctly said no", not "the tool
- * failed". A domain-policy refusal, a permission denial, a PreToolUse hook
- * block, or an aborted call all return `isError: true` so the model sees the
- * refusal — but counting them as tool failures inflated the signal and
- * manufactured false-positive cards (e.g. `browser_open` looking 50% broken
- * when half its calls were policy refusals working exactly as designed).
+ * Failure classes that mean "the system correctly said no" or "the human did
+ * not answer", not "the tool failed". A domain-policy refusal, a permission
+ * denial, a PreToolUse hook block, an aborted call, or an `ask_question`
+ * decline/cancel all return `isError: true` so the model sees the outcome —
+ * but counting them as tool failures inflated the signal and manufactured
+ * false-positive cards (e.g. `browser_open` looking 50% broken when half its
+ * calls were policy refusals working exactly as designed, or `ask_question`
+ * looking 33% broken when the operator was simply AFK on an interactive
+ * surface).
  *
  * Results in this set are excluded from BOTH the failure count and the call
  * total. `timeout` is deliberately NOT excluded — a high timeout rate can be a
@@ -81,6 +86,7 @@ const EXCLUDED_FAILURE_CLASSES: ReadonlySet<ToolFailureClass> = new Set([
   'permission-denied',
   'hook-block',
   'abort',
+  'elicitation-declined',
 ]);
 
 /** Minimum absolute failure count for a tool before a card fires. */


### PR DESCRIPTION
## What

Adds a new `elicitation-declined` `ToolFailureClass` and tags `ask_question` decline/cancel results with it so the `tool-failure-density` detector stops counting them as real tool failures.

## Why

An unanswered question on a non-interactive or AFK surface — no elicitation handler installed (sub-agent fork, one-shot `chat`, daemon), or the operator dismissed/ignored the prompt — returns `isError: true` so the model halts. That's an **expected outcome, not a tool fault.** Untagged, these landed as `unclassified` failures and manufactured a false-positive high-severity `tool-failure-ask-question` card (the reported 12/36 = 33% "failure rate," which triage had already deferred as a non-defect).

This is the same false-positive class that previously put `browser_open` policy-refusals and circuit-breaker synthetic errors behind exclusions.

## Change

- **`src/agent/trace/types.ts`** — add `elicitation-declined` to the canonical `TOOL_FAILURE_CLASSES` tuple (the Zod enum in `events.ts` derives from it automatically).
- **`src/agent/tools/handlers/ask-question.ts`** — tag `decline`/`cancel` with `failureClass: 'elicitation-declined'`. **`isError: true` is preserved** — the model still stops on a decline (the documented "M3 hard stop" contract); only the detector's accounting changes.
- **`src/improve/scan/detectors/tool-failure-density.ts`** — add the class to `EXCLUDED_FAILURE_CLASSES` (excluded from both numerator and denominator, like the other "system said no" classes).

`timeout` and compose DAG-node failures are deliberately **not** touched. Back-compat preserved: pre-fix traces carry no class and still count, so the exclusion is forward-looking.

## Verification

- `pnpm lint` clean (strict `tsc --noEmit`).
- Targeted + blast-radius tests green (detector, ask-question handler, trace events/schema, dispatcher, writer).
- Full suite: 9380 pass (one unrelated pre-existing failure in `config.test.ts` from local model-slot env leakage; passes when those env vars are unset).
- **End-to-end via the `improve scan` CLI**: a synthetic 12-decline/24-success `ask_question` session fires `tool-failure-ask-question [high]` when untagged and produces **zero cards** when tagged — the only difference being the new `failureClass`.

Tests added: extend the detector's `failureClass`-exclusion loop to cover the new class; explicit `ask_question` 12/36 regression + numerator/denominator tests; ask-question handler `cancel`/`skip` + accept-negative assertions.

Do not merge automatically — leaving for review.
