### PR TITLE
feat(telemetry): native AFK skill-invocation JSONL writer

### DIFF
--- a/src/agent/telemetry/skill-invocation-writer.test.ts
+++ b/src/agent/telemetry/skill-invocation-writer.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the native AFK skill-invocation telemetry writer.
+ *
+ * Hermetic: every test that touches the filesystem uses a `mkdtempSync` dir
+ * so no writes ever reach the real `~/.afk/`. The `writeSkillInvocation`
+ * guard test additionally saves/restores `AFK_HOME` and asserts the file
+ * does NOT exist after calling under vitest — proving the guard suppresses
+ * real writes.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  buildSkillInvocationRow,
+  appendSkillInvocationTo,
+  writeSkillInvocation,
+} from './skill-invocation-writer.js';
+
+// ---------------------------------------------------------------------------
+// (a) buildSkillInvocationRow — pure, no I/O
+// ---------------------------------------------------------------------------
+
+describe('buildSkillInvocationRow', () => {
+  it('includes required fields: ts, surface, event, skill_name, source', () => {
+    const row = buildSkillInvocationRow({ skillName: 'mint' });
+
+    expect(row.ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(row.surface).toBe('afk');
+    expect(row.event).toBe('skill_invocation');
+    expect(row.skill_name).toBe('mint');
+    expect(row.source).toBe('native-runtime');
+  });
+
+  it('omits optional fields entirely when input is undefined (not null)', () => {
+    const row = buildSkillInvocationRow({ skillName: 'diagnose' });
+
+    // Assert the keys are absent, not null
+    expect(Object.prototype.hasOwnProperty.call(row, 'session_id')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(row, 'trace_id')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(row, 'cwd')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(row, 'model')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(row, 'command')).toBe(false);
+  });
+
+  it('includes optional fields when provided', () => {
+    const row = buildSkillInvocationRow({
+      skillName: 'ship',
+      sessionId: 'sess-abc',
+      traceId: 'trace-xyz',
+      cwd: '/tmp/myproject',
+      model: 'claude-sonnet-4-5',
+      command: '--verify',
+    });
+
+    expect(row.session_id).toBe('sess-abc');
+    expect(row.trace_id).toBe('trace-xyz');
+    expect(row.cwd).toBe('/tmp/myproject');
+    expect(row.model).toBe('claude-sonnet-4-5');
+    expect(row.command).toBe('--verify');
+  });
+
+  it('includes only the provided optional fields (partial subset)', () => {
+    const row = buildSkillInvocationRow({
+      skillName: 'gather',
+      sessionId: 'sess-123',
+      model: 'haiku',
+    });
+
+    expect(row.session_id).toBe('sess-123');
+    expect(row.model).toBe('haiku');
+    expect(Object.prototype.hasOwnProperty.call(row, 'trace_id')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(row, 'cwd')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(row, 'command')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) appendSkillInvocationTo — explicit dir, hermetic I/O
+// ---------------------------------------------------------------------------
+
+describe('appendSkillInvocationTo', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'afk-skill-inv-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('creates the file and writes a valid JSONL row', () => {
+    const row = buildSkillInvocationRow({
+      skillName: 'mint',
+      sessionId: 'sess-1',
+      model: 'sonnet',
+    });
+
+    appendSkillInvocationTo(tmp, row);
+
+    const filePath = join(tmp, 'skill-invocations.jsonl');
+    expect(existsSync(filePath)).toBe(true);
+
+    const raw = readFileSync(filePath, 'utf8');
+    const lines = raw.trim().split('\n').filter((l) => l !== '');
+    expect(lines).toHaveLength(1);
+
+    const parsed = JSON.parse(lines[0]!) as Record<string, unknown>;
+    expect(parsed['surface']).toBe('afk');
+    expect(parsed['event']).toBe('skill_invocation');
+    expect(parsed['skill_name']).toBe('mint');
+    expect(parsed['source']).toBe('native-runtime');
+    expect(parsed['session_id']).toBe('sess-1');
+    expect(parsed['model']).toBe('sonnet');
+  });
+
+  it('appends (two calls → two lines)', () => {
+    const row1 = buildSkillInvocationRow({ skillName: 'mint' });
+    const row2 = buildSkillInvocationRow({ skillName: 'ship' });
+
+    appendSkillInvocationTo(tmp, row1);
+    appendSkillInvocationTo(tmp, row2);
+
+    const raw = readFileSync(join(tmp, 'skill-invocations.jsonl'), 'utf8');
+    const lines = raw.trim().split('\n').filter((l) => l !== '');
+    expect(lines).toHaveLength(2);
+
+    const first = JSON.parse(lines[0]!) as Record<string, unknown>;
+    const second = JSON.parse(lines[1]!) as Record<string, unknown>;
+    expect(first['skill_name']).toBe('mint');
+    expect(second['skill_name']).toBe('ship');
+  });
+
+  it('does not throw when the dir is unwritable (e.g. parent is a file)', () => {
+    // Construct a path whose parent component is actually a file → mkdirSync
+    // will throw ENOTDIR, exercising the swallow-and-continue guarantee.
+    const fileAsDir = join(tmp, 'i-am-a-file');
+    // Write a regular file at the "dir" path
+    appendSkillInvocationTo(tmp, buildSkillInvocationRow({ skillName: 'probe' })); // warm up parent
+    const badFrameworkDir = join(tmp, 'skill-invocations.jsonl', 'nested');
+    // skill-invocations.jsonl is now a file; using it as a parent is ENOTDIR
+    const row = buildSkillInvocationRow({ skillName: 'test' });
+    expect(() => appendSkillInvocationTo(badFrameworkDir, row)).not.toThrow();
+    void fileAsDir; // suppress unused-var lint
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (c) writeSkillInvocation guard — must be a no-op under vitest
+// ---------------------------------------------------------------------------
+
+describe('writeSkillInvocation guard', () => {
+  const savedAfkHome = process.env['AFK_HOME'];
+
+  afterEach(() => {
+    // Restore AFK_HOME regardless of test outcome
+    if (savedAfkHome === undefined) {
+      delete process.env['AFK_HOME'];
+    } else {
+      process.env['AFK_HOME'] = savedAfkHome;
+    }
+  });
+
+  it('does NOT write to skill-invocations.jsonl when running under vitest', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'afk-guard-'));
+    try {
+      // Point AFK_HOME at the tmp dir so if the guard fails, the file lands
+      // there and our assertion catches it.
+      process.env['AFK_HOME'] = tmp;
+
+      writeSkillInvocation({ skillName: 'mint', sessionId: 'sess-guard-test' });
+
+      const filePath = join(tmp, 'agent-framework', 'skill-invocations.jsonl');
+      expect(existsSync(filePath)).toBe(false);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agent/telemetry/skill-invocation-writer.ts
+++ b/src/agent/telemetry/skill-invocation-writer.ts
@@ -1,0 +1,112 @@
+/**
+ * Native AFK skill-invocation telemetry writer.
+ *
+ * Appends one JSONL row per skill dispatch to
+ * `$AFK_HOME/agent-framework/skill-invocations.jsonl`, tagged
+ * `surface:"afk"` and `source:"native-runtime"` so rows interleave cleanly
+ * with plugin-written rows in the same file.
+ *
+ * Privacy: operational metadata only — skill name, session/trace IDs, cwd,
+ * model, and the dispatch command. No prompt content, tool inputs/outputs,
+ * model responses, stack traces, or credentials are written here.
+ *
+ * Three public exports with distinct responsibilities:
+ *   - `buildSkillInvocationRow` — pure, no I/O. Construct the row object.
+ *   - `appendSkillInvocationTo` — write to an *explicit* dir. No test guard.
+ *     Used by both the public writer and by hermetic tests that inject a
+ *     temp dir.
+ *   - `writeSkillInvocation` — public entry point wired into the executor.
+ *     No-ops under tests (VITEST / NODE_ENV=test) to prevent fixture runs
+ *     from polluting the real `~/.afk/agent-framework/` stream. Mirrors the
+ *     guard in `src/agent/routing-telemetry.ts:104`.
+ *
+ * @module agent/telemetry/skill-invocation-writer
+ */
+
+import { appendFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { env } from '../../config/env.js';
+import { getAgentFrameworkDir } from '../../paths.js';
+
+/** Input shape accepted by the public writer and `buildSkillInvocationRow`. */
+export interface SkillInvocationInput {
+  skillName: string;
+  sessionId?: string | undefined;
+  traceId?: string | undefined;
+  cwd?: string | undefined;
+  model?: string | undefined;
+  command?: string | undefined;
+}
+
+/** The persisted JSONL row shape. Optional fields are omitted (never `null`)
+ *  when their input counterpart is `undefined`, keeping the log compact. */
+export interface SkillInvocationRow {
+  ts: string;
+  surface: 'afk';
+  event: 'skill_invocation';
+  skill_name: string;
+  source: 'native-runtime';
+  session_id?: string;
+  trace_id?: string;
+  cwd?: string;
+  model?: string;
+  command?: string;
+}
+
+/**
+ * Build a `SkillInvocationRow` from the given input.
+ *
+ * Pure — performs no I/O. Optional fields are included via conditional spread
+ * so absent keys are never written as `null` to the JSONL stream.
+ */
+export function buildSkillInvocationRow(input: SkillInvocationInput): SkillInvocationRow {
+  return {
+    ts: new Date().toISOString(),
+    surface: 'afk',
+    event: 'skill_invocation',
+    skill_name: input.skillName,
+    source: 'native-runtime',
+    ...(input.sessionId !== undefined ? { session_id: input.sessionId } : {}),
+    ...(input.traceId !== undefined ? { trace_id: input.traceId } : {}),
+    ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
+    ...(input.model !== undefined ? { model: input.model } : {}),
+    ...(input.command !== undefined ? { command: input.command } : {}),
+  };
+}
+
+/**
+ * Write a built row into an explicit `frameworkDir`.
+ *
+ * No test guard — this function is also called by hermetic tests that inject
+ * a temp directory. The public `writeSkillInvocation` applies the guard
+ * before calling here.
+ *
+ * Best-effort: any filesystem error is swallowed so telemetry never breaks
+ * dispatch. Uses `appendFileSync` for POSIX `O_APPEND` atomicity (rows are
+ * well under PIPE_BUF). Mirrors `routing-telemetry.ts`'s approach.
+ */
+export function appendSkillInvocationTo(frameworkDir: string, row: SkillInvocationRow): void {
+  try {
+    mkdirSync(frameworkDir, { recursive: true });
+    appendFileSync(join(frameworkDir, 'skill-invocations.jsonl'), JSON.stringify(row) + '\n');
+  } catch {
+    // Swallow — telemetry failures must never propagate to dispatch callers.
+  }
+}
+
+/**
+ * Public entry point wired into `SkillExecutor`.
+ *
+ * No-op under Vitest / NODE_ENV=test — fixture dispatches must never pollute
+ * the real `~/.afk/agent-framework/skill-invocations.jsonl` stream. This is
+ * the same guard used in `src/agent/routing-telemetry.ts:104`.
+ *
+ * In production, resolves the real framework dir via `getAgentFrameworkDir()`
+ * (honours `$AFK_HOME`) and delegates to `appendSkillInvocationTo`.
+ */
+export function writeSkillInvocation(input: SkillInvocationInput): void {
+  // No-op under vitest — fixture dispatches must never pollute the real stream
+  // (see routing-telemetry.ts).
+  if (env.VITEST || env.NODE_ENV === 'test') return;
+  appendSkillInvocationTo(getAgentFrameworkDir(), buildSkillInvocationRow(input));
+}

--- a/src/agent/tools/skill-executor.test.ts
+++ b/src/agent/tools/skill-executor.test.ts
@@ -16,6 +16,14 @@ vi.mock('../auth/credential-resolver.js', () => ({
   loadOpenAICredential: vi.fn(() => undefined),
 }));
 
+// Mock writeSkillInvocation so the call-site wiring test can assert it was
+// called without performing real I/O (the guard would suppress writes under
+// vitest anyway, but mocking is cleaner for assertion purposes).
+const mockWriteSkillInvocation = vi.hoisted(() => vi.fn());
+vi.mock('../telemetry/skill-invocation-writer.js', () => ({
+  writeSkillInvocation: mockWriteSkillInvocation,
+}));
+
 import { SkillExecutor } from './skill-executor.js';
 import { registerSkill, _resetRegistry } from '../../skills/index.js';
 import { SubagentManager } from '../subagent.js';
@@ -2362,6 +2370,42 @@ describe('SkillExecutor', () => {
       expect(mockRunToResult).toHaveBeenCalledWith(
         'Run the plugin-no-args skill now, following the instructions in your system prompt.',
       );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // (d) skill-invocation-writer call-site wiring
+  // ---------------------------------------------------------------------------
+  describe('writeSkillInvocation wiring', () => {
+    beforeEach(() => {
+      mockWriteSkillInvocation.mockClear();
+    });
+
+    it('calls writeSkillInvocation once with correct skillName for an inline registry skill', async () => {
+      // mockWriteSkillInvocation is hoisted and mocked at file scope via
+      // vi.hoisted + vi.mock, so it is already in effect here.
+      const handler = vi.fn().mockResolvedValue('wired output');
+      registerSkill({
+        name: 'wired-skill',
+        description: 'Test wiring for writeSkillInvocation',
+        handler,
+      });
+
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'sess-wiring-test',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        defaultModel: 'sonnet',
+        cwd: '/tmp/test-cwd',
+      });
+
+      await executor.execute(makeCall({ name: 'wired-skill', arguments: 'test args' }));
+
+      expect(mockWriteSkillInvocation).toHaveBeenCalledOnce();
+      const callArg = mockWriteSkillInvocation.mock.calls[0][0] as { skillName: string };
+      expect(callArg.skillName).toBe('wired-skill');
     });
   });
 });

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -37,6 +37,7 @@ import { resolveCredentialForModel } from '../auth/credential-resolver.js';
 import { getCurrentSink } from '../_lib/skill-sink-channel.js';
 import { loadSkillPrompts } from '../../skills/_lib/prompt-loader.js';
 import { appendRoutingDecision } from '../routing-telemetry.js';
+import { writeSkillInvocation } from '../telemetry/skill-invocation-writer.js';
 import { isTrustedSkill } from '../_lib/trusted-skill-registry.js';
 import { emitTrustedSkillComplete, emitTrustedSkillStart } from '../_lib/trusted-skill-events.js';
 import { debugLog } from '../../utils/debug.js';
@@ -347,6 +348,12 @@ export class SkillExecutor {
     // without these two events the 5 inline skills (mint, forge, diagnose,
     // audit-fit, score) are invisible to operator usage queries.
     const depth = this.ctx.depth ?? 0;
+    writeSkillInvocation({
+      skillName: skill.name,
+      sessionId: this.ctx.parentSession.sessionId,
+      cwd: this.ctx.cwd,
+      model: skill.model ?? this.ctx.defaultModel,
+    });
     void appendRoutingDecision({
       event: 'skill.dispatched',
       requested_name: skill.name,
@@ -623,6 +630,13 @@ export class SkillExecutor {
         ? this.ctx.resolveApiKeyForModel(skillChildModel)
         : resolveCredentialForModel(skillChildModel),
       parentApiKey: this.ctx.apiKey,
+    });
+
+    writeSkillInvocation({
+      skillName: skill.name,
+      sessionId: this.ctx.parentSession.sessionId,
+      cwd: this.ctx.cwd,
+      model: typeof skillChildModel === 'string' ? skillChildModel : undefined,
     });
 
     const manager = new SubagentManager({
@@ -909,6 +923,13 @@ export class SkillExecutor {
         ? this.ctx.resolveApiKeyForModel(pluginChildModel)
         : resolveCredentialForModel(pluginChildModel),
       parentApiKey: this.ctx.apiKey,
+    });
+
+    writeSkillInvocation({
+      skillName: skillName,
+      sessionId: this.ctx.parentSession.sessionId,
+      cwd: this.ctx.cwd,
+      model: typeof pluginChildModel === 'string' ? pluginChildModel : undefined,
     });
 
     const manager = new SubagentManager({


### PR DESCRIPTION
## Source

Port of **afk-workshop#804** — https://github.com/griffinwork40/afk-workshop/pull/804

This is a moat-scrubbed port, not a 1:1 copy.

## Ported (all public-safe)

Native skill-invocation telemetry for the AFK runtime. Every native skill dispatch (inline registry, forked registry, plugin fork) appends one row to `$AFK_HOME/agent-framework/skill-invocations.jsonl`, tagged `surface:"afk"`, `source:"native-runtime"`.

- `src/agent/telemetry/skill-invocation-writer.ts` (new) — `buildSkillInvocationRow` (pure; optional fields omitted, never null), `appendSkillInvocationTo` (explicit-dir write, swallows errors), `writeSkillInvocation` (public entry, **no-ops under `env.VITEST || NODE_ENV==='test'`** — same guard as `routing-telemetry.ts`, so the executor's own test suite can't pollute the real telemetry file).
- `src/agent/telemetry/skill-invocation-writer.test.ts` (new, 8 tests).
- `src/agent/tools/skill-executor.ts` — import + 3 call sites.
- `src/agent/tools/skill-executor.test.ts` — `vi.mock` wiring test.

## Dropped

**Nothing dropped** — the entire change was public-safe (generic operational telemetry; no moat files, paths, or symbols touched). The only `forge` reference in the diff is a pre-existing context comment already present in this repo (KEEP-listed).

## Verification

- `pnpm install --frozen-lockfile` ✓ · `pnpm lint` (tsc) ✓ · `pnpm fix:pins:check` ✓ · `pnpm build` ✓ · `pnpm build:dist` ✓
- New tests pass (writer 8/8 + executor wiring test).
- Full suite: ported change introduces **zero** new failures (the only local failure, `config.test.ts:531` model-slot bindings, reproduces identically on clean HEAD and is a local-env artifact from a machine-level `AFK_MODEL`/config override — it passes in CI on a clean runner, as the source PR #804's Test gate confirmed).
- **Deterministic moat guard: ✅ CLEAN** (HARD denylist + structural markers, tree + built `dist/`).
- **Independent adversarial moat audit: MOAT-CLEAN** (re-derived from scratch; tree + dist).

Privacy: operational metadata only (skill name, session id, cwd, model) — no prompt content, tool IO, or credentials.

**Do not merge automatically** — for human review.
