### PR TITLE
feat(skills): composition-boundary guard for shadow-verify & devils-advocate

### DIFF
--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -37,7 +37,7 @@ const __dirname = dirname(__filename);
 const PINNED_HASHES = {
   contract: '748eaf01deda592913f463b23c81a6be3a89ae3b316f31f531a8488dc5bc1a7c',
   'devils-advocate':
-    'a86982c9d8e2ec65e409f92b2715f551c4d6861b08bb10ac5e20e1e6f1717efa',
+    '3e7f65b240ef3a9530efba2b71ea9912c6d53e43d69a551612f1c4b8b31fd1c6',
   // gather + parallelize carry a bundled-only `context: load` frontmatter line
   // (2026-06 skill-execution-mode work). `context` is an agent-afk-specific
   // field; Claude Code upstream skills are natively inline/progressive-disclosure,
@@ -80,7 +80,7 @@ const PINNED_HASHES = {
   // BACK-PORT GAP: the same enhancement should land in the upstream example-plugin
   // shadow-verify skill (drift test is skipped here — example-plugin not co-located).
   'shadow-verify':
-    '07aeb4724877001351de868012d796841fb3b9596e0086cd4b302a17c183c977',
+    'fafc8db3bf78aa41aa406416d968f8af8aba764eb4ffd9ecb1c77d232819a6ab',
   // Hash bumped 2026-06: Phase 4 (commit) + Phase 8 (PR) switched from the
   // `--body "$(cat <<'EOF' … EOF)"` heredoc-in-command-substitution antipattern
   // to the file-based form (`git commit -F` / `gh pr create --body-file`). The

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -36,8 +36,11 @@ const __dirname = dirname(__filename);
 // developer to look at both copies.
 const PINNED_HASHES = {
   contract: '748eaf01deda592913f463b23c81a6be3a89ae3b316f31f531a8488dc5bc1a7c',
+  // Hash re-bumped during PR #187 review: the Merge section now routes the
+  // second convergence condition (≥2 critics agree on the same alternative) to
+  // Wave 3.5 — prose-consistency fix only; no behavior change to the guard.
   'devils-advocate':
-    '3e7f65b240ef3a9530efba2b71ea9912c6d53e43d69a551612f1c4b8b31fd1c6',
+    '8a729f40297e43f33aa84f80c66f21c9a46fd8b610727601f4e13dc597be633b',
   // gather + parallelize carry a bundled-only `context: load` frontmatter line
   // (2026-06 skill-execution-mode work). `context` is an agent-afk-specific
   // field; Claude Code upstream skills are natively inline/progressive-disclosure,
@@ -79,8 +82,11 @@ const PINNED_HASHES = {
   // model-facing description is clean.
   // BACK-PORT GAP: the same enhancement should land in the upstream example-plugin
   // shadow-verify skill (drift test is skipped here — example-plugin not co-located).
+  // Hash re-bumped during PR #187 review: the Merge section now enumerates the
+  // new UNVERIFIED-COMPOSITION / UNVERIFIED-ECHO-CHAMBER verdict states — prose-
+  // consistency fix only; no behavior change to the composition-axis guard.
   'shadow-verify':
-    'fafc8db3bf78aa41aa406416d968f8af8aba764eb4ffd9ecb1c77d232819a6ab',
+    '9a9f7f2d0482f4258036e4b204113f37f3b44e1b390d6ddaaf97f13e7b4cd858',
   // Hash bumped 2026-06: Phase 4 (commit) + Phase 8 (PR) switched from the
   // `--body "$(cat <<'EOF' … EOF)"` heredoc-in-command-substitution antipattern
   // to the file-based form (`git commit -F` / `gh pr create --body-file`). The

--- a/src/bundled-plugins/awa-bundled/skills/devils-advocate/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/devils-advocate/SKILL.md
@@ -34,7 +34,7 @@ Until the verifier returns `CONFIRMED`, the convergent recommendation is a **can
 **Scope guard:** skip when the proposal is purely local with no composition surface, or is anchored to an external referent that survives independently of the system. Fires once per convergent verdict, not per critic.
 
 **Merge + surface:**
-- Recommendation = `original` → the proposal survived critique; proceed with it.
+- Recommendation = `original` → the proposal survived critique; proceed with it — **unless ≥2 critics converged on the same alternative** (the second convergence condition above), in which case run Wave 3.5 first and, on `OVERRIDE`, re-rank before acting.
 - Recommendation ≠ `original`, `dissent = false` → synthesis found a better path; run Wave 3.5, then surface the alternative with rationale (on `OVERRIDE`, re-rank first) before acting.
 - `dissent = true` → present the matrix to the user; do not act. Confidence is low.
 

--- a/src/bundled-plugins/awa-bundled/skills/devils-advocate/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/devils-advocate/SKILL.md
@@ -23,9 +23,19 @@ When a proposal — a plan, fix, decomposition, scoping, or named recommendation
 3. Recommend ONE top choice with a one-paragraph rationale.
 4. Flag `dissent = true` when ≥2 critics returned `strong` alternatives disagreeing with the recommendation — signals the synthesizer is overruling well-argued dissent, so confidence is low. Include a `dissent_note` summarizing the strongest counter-argument.
 
+**Wave 3.5 — Composition-boundary check (fires on convergence):**
+Critics that converge may all have evaluated the proposal in artifact-isolation — none read the boundaries where it composes with siblings. A convergent verdict reached in isolation can be confidently wrong (e.g., critics agree on a UI glyph asserting visual continuity, but none saw that parallel-branch flushes reorder it). When the synthesis recommendation is **convergent** — recommendation ≠ original with `dissent = false`, OR ≥2 critics returned the same alternative — dispatch ONE context-injection verifier (same research-agent base) BEFORE surfacing:
+1. Its job is NOT to re-evaluate the proposal in isolation. It reads the 3 nearest composition boundaries — upstream caller, downstream consumer, and the render/event/state pipeline that interleaves the proposal's target with siblings.
+2. For each boundary: does the recommendation survive when the boundary varies? Check **temporal interleaving** (can flushes / parallel branches / sibling completions reorder it?), **state threading** (does it assume a point-of-use state upstream can break?), **adjacency assumptions** (does it presume render-tree / scrollback / call-graph adjacency that isn't load-bearing under recomposition?).
+3. Returns `CONFIRMED` only if the recommendation survives all three; otherwise `OVERRIDE: <specific boundary condition that breaks it>`.
+
+Until the verifier returns `CONFIRMED`, the convergent recommendation is a **candidate**, not a recommendation. On `OVERRIDE`, fold the named condition into the matrix and re-rank.
+
+**Scope guard:** skip when the proposal is purely local with no composition surface, or is anchored to an external referent that survives independently of the system. Fires once per convergent verdict, not per critic.
+
 **Merge + surface:**
 - Recommendation = `original` → the proposal survived critique; proceed with it.
-- Recommendation ≠ `original`, `dissent = false` → synthesis found a better path; surface the alternative with rationale before acting.
+- Recommendation ≠ `original`, `dissent = false` → synthesis found a better path; run Wave 3.5, then surface the alternative with rationale (on `OVERRIDE`, re-rank first) before acting.
 - `dissent = true` → present the matrix to the user; do not act. Confidence is low.
 
 **When to invoke:**

--- a/src/bundled-plugins/awa-bundled/skills/shadow-verify/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/shadow-verify/SKILL.md
@@ -18,6 +18,7 @@ When a sub-agent (or wave) returns investigation findings, code-review conclusio
 - `CONFIRMED` → surface the claim as validated.
 - `REFUTED` → replace the claim with the verifier's corrected finding, annotated `[was: confident, now: refuted]`, and show it alongside the original with evidence. Do not act until the conflict is resolved.
 - `UNVERIFIABLE` → surface with a `[needs-human-review]` tag rather than passing it through silently.
+- `UNVERIFIED-COMPOSITION` / `UNVERIFIED-ECHO-CHAMBER` (from the composition-axis guard below) → surface with a `[needs-human-review]` tag naming the missed boundary; do not pass through as validated.
 
 Bound the loop: at most 3 verification rounds per session. Claims still unresolved after 3 rounds are escalated to the user, never silently dropped.
 

--- a/src/bundled-plugins/awa-bundled/skills/shadow-verify/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/shadow-verify/SKILL.md
@@ -12,7 +12,7 @@ When a sub-agent (or wave) returns investigation findings, code-review conclusio
 **Wave 2 — Adversarial verifiers (parallel, independent):**
 1. Extract 2–3 concrete, re-checkable claims from the returned report (e.g., "X function is unused", "file Y exceeds 300 lines", "PR targets main", "no tests cover Z").
 2. Dispatch one shadow sub-agent per claim, in parallel. Each receives ONLY the claim + the user's original goal — never the original agent's reasoning or cited evidence. **Default to `subagent_type: "research-agent"` (mechanically locked to Read/Grep/Glob/WebFetch/WebSearch — cannot Edit/commit/push).** If the claim requires Bash to verify (running a failing test, `gh pr view`, `git log origin/...`), fall back to a Bash-capable subagent type with `isolation: "worktree"` and prepend this prefix to the prompt: *"Verifier sub-agent — do not Edit, Write, commit, push, `gh pr create`, or `curl`. Return findings only."*
-3. Each verifier re-derives the verdict independently using tool calls only — never re-reading the original report's reasoning. Returns `{claim, verifier_verdict, evidence_pointer}`, where `verifier_verdict` is one of `CONFIRMED`, `REFUTED`, or `UNVERIFIABLE`. On `REFUTED`, the verifier also emits a corrected finding.
+3. Each verifier re-derives the verdict independently using tool calls only — never re-reading the original report's reasoning. Returns `{claim, verifier_verdict, evidence_pointer, evidence_base}`, where `verifier_verdict` is one of `CONFIRMED`, `REFUTED`, or `UNVERIFIABLE`, and `evidence_base` is `independent-rederivation` (read primary sources *outside* the cited artifact's boundary) or `artifact-internal` (re-read only the cited file/region). On `REFUTED`, the verifier also emits a corrected finding.
 
 **Merge:**
 - `CONFIRMED` → surface the claim as validated.
@@ -20,6 +20,14 @@ When a sub-agent (or wave) returns investigation findings, code-review conclusio
 - `UNVERIFIABLE` → surface with a `[needs-human-review]` tag rather than passing it through silently.
 
 Bound the loop: at most 3 verification rounds per session. Claims still unresolved after 3 rounds are escalated to the user, never silently dropped.
+
+**Composition-axis guard (echo-chamber check):**
+A verifier that re-derives a claim by re-reading the *same* file/region the original sub-agent cited has confirmed the citation, not the claim — it can be blind to composition-boundary failures (temporal interleaving, state threading, render/event-pipeline ordering, scrollback/call-graph adjacency) that only manifest outside the artifact's boundary. Before accepting a `CONFIRMED`:
+1. Read each verifier's `evidence_base`.
+2. For any **artifact-internal `CONFIRMED`**, require one composition-boundary read (≥1 upstream caller + ≥1 downstream consumer, plus the pipeline that interleaves the artifact with siblings) before merging. If a missed boundary surfaces, downgrade to `UNVERIFIED-COMPOSITION` and tag `[needs-human-review]`.
+3. **Echo-chamber guard:** if ≥2 verifiers cite the *same* in-repo artifact as primary evidence with no external referent, flag `UNVERIFIED-ECHO-CHAMBER` regardless of verdict and require one verifier to read outside that artifact's boundary.
+
+**Scope guard:** skip the composition check when the claim cites an external referent (RFC, spec, threat model, upstream-API contract) that survives independently of the repo, or when the artifact is purely local with no composition surface. Runs once per artifact, not on every cite.
 
 **When to invoke:**
 Any time sub-agent output will drive user decisions, file edits, commits, external side-effects, or is the basis of a user-facing summary. Treat **high-confidence language as a trigger in its own right**: when a review/audit sub-agent asserts a claim with markers like "confident", "certain", "clearly", "obviously", "must be", or a stated probability ≥ 80%, verify it as if it were decision-driving regardless of stakes. Confidence is a trigger, not a verdict.


### PR DESCRIPTION
## What

Adds a **composition-boundary guard** to the two parallel-verification skills, closing a shared blind spot: a verdict reached by re-reading the *same* local artifact can be confidently wrong about failures that only manifest where the artifact composes with its neighbors (temporal interleaving, state threading, render/event-pipeline ordering, scrollback/call-graph adjacency).

- **shadow-verify** — verifiers now report `evidence_base` (`independent-rederivation` vs `artifact-internal`). An `artifact-internal` `CONFIRMED` must do a composition-boundary read (≥1 upstream caller + ≥1 downstream consumer) before merge, else downgrades to `UNVERIFIED-COMPOSITION`. New **echo-chamber guard**: ≥2 verifiers citing the same in-repo artifact with no external referent → `UNVERIFIED-ECHO-CHAMBER`.
- **devils-advocate** — new **Wave 3.5** fires on *convergent* verdicts (recommendation ≠ original w/ `dissent=false`, or ≥2 critics agreeing): one context-injection verifier reads the 3 nearest composition boundaries and returns `CONFIRMED`/`OVERRIDE` before the recommendation surfaces.

Both carry scope guards (skip on external-referent-anchored or purely-local artifacts; fire once per artifact/verdict, not per cite). `dissent` already guards *disagreement*; this guards false *convergence*.

## Scope / safety

- Docs-only change to two bundled `SKILL.md` files + regenerated hash pins (`bundled.test.ts`).
- Existing public adaptations preserved (frontmatter `context:` keys, de-escaped descriptions, the inline `skip-when` guidance that avoids dangling skill references).
- `pnpm fix:pins:check` clean; `bundled.test.ts` passes (15/15).

Do not merge automatically — for review.