### PR TITLE
feat(plan-mode): gate bash by mutation, not a substring denylist

### DIFF
--- a/src/agent/plan-mode-gate.test.ts
+++ b/src/agent/plan-mode-gate.test.ts
@@ -34,7 +34,24 @@ describe('createPlanModeGate', () => {
     expect(result.reason).toContain('edit_file');
   });
 
-  it('blocks bash with git commit in plan mode', () => {
+  // Bash is mutation-gated in plan mode via the shared `classifyBashCommand`
+  // classifier (tools/readonly-bash.ts): read-only recon passes, state-mutating
+  // commands are refused. These tests exercise the REAL classifier through the
+  // gate (no mock), so they double as an integration check that the gate wires
+  // to it. The file/memory write-tool gate above is the separate, hard
+  // no-mutation guarantee.
+  it('blocks state-mutating bash (rm) in plan mode', () => {
+    const { gate } = makeGate('plan');
+    const result = gate({
+      event: 'PreToolUse',
+      toolName: 'bash',
+      input: { command: 'rm file.txt' },
+    });
+    expect(result.decision).toBe('block');
+    expect(result.reason).toContain('state-mutating');
+  });
+
+  it('blocks state-mutating bash (git commit) in plan mode', () => {
     const { gate } = makeGate('plan');
     const result = gate({
       event: 'PreToolUse',
@@ -44,14 +61,27 @@ describe('createPlanModeGate', () => {
     expect(result.decision).toBe('block');
   });
 
-  it('blocks bash with rm in plan mode', () => {
+  it('blocks output redirection to a file in plan mode', () => {
     const { gate } = makeGate('plan');
     const result = gate({
       event: 'PreToolUse',
       toolName: 'bash',
-      input: { command: 'rm file.txt' },
+      input: { command: 'echo hello > out.txt' },
     });
     expect(result.decision).toBe('block');
+  });
+
+  it('allows chained read-only bash (git status && git log) in plan mode', () => {
+    // Regression guard for the friction the old substring denylist caused: it
+    // listed ` && `, so every chained command was refused — even when both
+    // halves were read-only. The classifier parses properly and allows this.
+    const { gate } = makeGate('plan');
+    const result = gate({
+      event: 'PreToolUse',
+      toolName: 'bash',
+      input: { command: 'git status && git log --oneline -5' },
+    });
+    expect(result.decision).toBeUndefined();
   });
 
   it('allows read-only bash (git status) in plan mode', () => {
@@ -60,6 +90,16 @@ describe('createPlanModeGate', () => {
       event: 'PreToolUse',
       toolName: 'bash',
       input: { command: 'git status' },
+    });
+    expect(result.decision).toBeUndefined();
+  });
+
+  it('allows read-only bash (grep) in plan mode', () => {
+    const { gate } = makeGate('plan');
+    const result = gate({
+      event: 'PreToolUse',
+      toolName: 'bash',
+      input: { command: 'grep -rn foo src' },
     });
     expect(result.decision).toBeUndefined();
   });

--- a/src/agent/plan-mode-gate.ts
+++ b/src/agent/plan-mode-gate.ts
@@ -1,26 +1,30 @@
 /**
  * Plan-mode gate hook factory.
  *
- * Returns a `HookHandler` that blocks write-class tool calls when the session
+ * Returns a `HookHandler` that blocks state-mutating tool calls when the session
  * is in 'plan' mode. The handler reads the current mode at call time (not at
  * construction time), so toggling the mode mid-session is reflected immediately
  * without reconstructing the registry.
  *
  * Blocked operations:
  *   - Any tool categorized as `'write'` by `tool-category.ts` — always blocked
- *     in plan mode. This covers `write_file`, `edit_file`, `memory_update`, and
- *     `procedure_write` (the last two previously fell through and allowed plan
- *     mode to mutate persistent memory — now fixed).
- *   - `bash` — blocked when the command matches a write-intent denylist.
- *     Unknown/read-only bash commands pass through.
+ *     in plan mode. Covers `write_file`, `edit_file`, `memory_update`,
+ *     `procedure_write`, `config_set`, and `terminal_font_size`: the tools that
+ *     persist state to disk or memory. This is the meaningful, non-bypassable
+ *     no-mutation guarantee.
+ *   - `bash` — blocked when `classifyBashCommand` (`tools/readonly-bash.ts`)
+ *     judges the command state-mutating; read-only recon (`git status/log/diff`,
+ *     `ls`, `cat`, `grep`, `find`, and chains thereof) passes through. This is
+ *     the SAME best-effort classifier that gates read-only skill phases (the
+ *     dispatcher's `readOnlyBash` path), so the mutation rules live in one place
+ *     and the two consumers cannot drift apart.
  *
- * This gate is a best-effort honesty primitive, not a security boundary.
- * Interpreter-mediated writes (`python -c`, `node -e`, `curl -o`, `wget -O`,
- * heredocs, `dd`, `truncate`, etc.) are not caught. The denylist is
- * substring-matched against the raw command string and is intentionally
- * conservative: it catches the common write-intent shapes a model would
- * naturally emit in plan mode, and surfaces refusal so the user can choose
- * to exit plan mode rather than silently allowing the side-effect.
+ * The bash check is an honesty guardrail, NOT a security boundary. Because bash
+ * is Turing-complete, no classifier is exhaustive — obfuscated writes
+ * (`eval "$(printf …)"`, `sh -c "…"`) slip through, as `readonly-bash.ts` itself
+ * documents. It catches the mutation shapes a cooperative model naturally emits
+ * while planning and surfaces refusal so the user can `/plan off` rather than
+ * silently allow the side-effect.
  *
  * @module agent/plan-mode-gate
  */
@@ -28,29 +32,7 @@
 import type { HookContext, HookDecision } from './hooks.js';
 import type { PermissionMode } from './types/sdk-types.js';
 import { categorizeTool } from './tool-category.js';
-
-const BASH_DENYLIST = [
-  'git commit',
-  'git push',
-  'git reset',
-  'rm ',
-  'mv ',
-  'mkdir',
-  'touch',
-  'chmod',
-  'chown',
-  'cp ',
-  'tee ',
-  ' > ',
-  ' >> ',
-  'npm install',
-  'pnpm install',
-  'pip install',
-  'apt ',
-  'apt-get ',
-  'brew install',
-  ' && ',
-];
+import { classifyBashCommand } from './tools/readonly-bash.js';
 
 export function createPlanModeGate(
   getMode: () => PermissionMode,
@@ -68,10 +50,8 @@ export function createPlanModeGate(
     const { toolName } = context;
 
     // External constraint (semantic invariant): any tool categorized as 'write'
-    // persists state to disk. Block all of them, not just file-write tools.
-    // Previously only write_file and edit_file were blocked; memory_update and
-    // procedure_write now blocked too (bug fix — plan mode must not allow
-    // persistent-memory mutation).
+    // persists state to disk or memory. Block all of them — write_file,
+    // edit_file, memory_update, procedure_write, config_set, terminal_font_size.
     if (categorizeTool(toolName) === 'write') {
       return {
         decision: 'block',
@@ -79,17 +59,23 @@ export function createPlanModeGate(
       };
     }
 
+    // `bash` is mutation-gated, not blanket-refused: read-only recon runs,
+    // state-mutating commands are refused. Reuses the same best-effort
+    // classifier as the read-only skill phases (single source of mutation
+    // rules). Best-effort, not a sandbox — see the module header.
     if (toolName === 'bash') {
       const cmd =
         typeof context.input === 'object' && context.input !== null
           ? String((context.input as Record<string, unknown>)['command'] ?? '')
           : '';
-      const denied = BASH_DENYLIST.some((p) => cmd.includes(p));
-      if (denied) {
+      const verdict = classifyBashCommand(cmd);
+      if (verdict.mutating) {
         return {
           decision: 'block',
           reason:
-            'plan mode: write-intent bash is refused. Use /plan off or rephrase as a read-only command.',
+            `plan mode: bash refused — command looks state-mutating ` +
+            `(${verdict.reason ?? 'mutation detected'}). Read-only investigation ` +
+            `(git status/log/diff, ls, cat, grep, find) is allowed. Use /plan off to act.`,
         };
       }
     }

--- a/src/agent/providers/anthropic-direct/plan-mode-addendum.test.ts
+++ b/src/agent/providers/anthropic-direct/plan-mode-addendum.test.ts
@@ -54,9 +54,11 @@ describe('plan-mode-addendum', () => {
       expect(PLAN_MODE_ADDENDUM_TEXT.toLowerCase()).toContain('plan mode');
     });
 
-    it('names the write-class tools that are refused', () => {
-      // Regression guard: if the gate's denylist changes, this should change
-      // in lockstep so the model is told the truth about what is refused.
+    it('names file/memory write tools refused and describes bash mutation-gating', () => {
+      // Regression guard: the addendum must tell the model the truth about what
+      // the hook gate refuses. File/memory write tools are refused; bash is
+      // mutation-gated — read-only recon runs, state-mutating bash is refused
+      // via classifyBashCommand. Keep this in lockstep with plan-mode-gate.ts.
       expect(PLAN_MODE_ADDENDUM_TEXT).toContain('write_file');
       expect(PLAN_MODE_ADDENDUM_TEXT).toContain('edit_file');
       expect(PLAN_MODE_ADDENDUM_TEXT.toLowerCase()).toContain('bash');

--- a/src/agent/providers/anthropic-direct/plan-mode-addendum.ts
+++ b/src/agent/providers/anthropic-direct/plan-mode-addendum.ts
@@ -29,8 +29,9 @@ import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
 export const PLAN_MODE_ADDENDUM_TEXT = [
   '## Plan mode is active',
   '',
-  'Write-class tools (`write_file`, `edit_file`, write-intent `bash`) are refused at the hook layer.',
-  'The user has asked you to plan, not yet to act. Treat this turn as planning work.',
+  'File and memory write tools (`write_file`, `edit_file`, `memory_update`, `procedure_write`) are refused at the hook layer.',
+  '`bash` runs for read-only investigation (git status/log/diff, ls, cat, grep, find — chained or not); state-mutating bash (file writes, rm, installs, commits, pushes) is refused while planning. The user has asked you to plan, not yet to act — exit plan mode to make changes.',
+  'Treat this turn as planning work.',
   '',
   'Traverse the shape that matches the work — skip steps the terrain already covers, do not skip steps the terrain hides:',
   '',

--- a/src/agent/risk-classifier.ts
+++ b/src/agent/risk-classifier.ts
@@ -5,10 +5,9 @@
  * operator-facing UI (status line, permission prompts) and the audit log.
  * Does NOT wire to `permissions.onAsk` — that is Stream C's job.
  *
- * The rule table mirrors the philosophy of BASH_DENYLIST in
- * `src/agent/plan-mode-gate.ts`: substring-matching against the raw command
- * string is intentionally conservative. We catch the shapes a model
- * naturally emits; we do not attempt to parse shell syntax comprehensively.
+ * The bash rule table uses substring-matching against the raw command string
+ * and is intentionally conservative: we catch the shapes a model naturally
+ * emits; we do not attempt to parse shell syntax comprehensively.
  *
  * BUILTIN_WRITE_DENYLIST from `src/agent/tools/handlers/write-denylist.ts`
  * is reused for the write_file / edit_file path-based risk check so the

--- a/src/cli/loading-tips.ts
+++ b/src/cli/loading-tips.ts
@@ -53,7 +53,7 @@ const STATIC_TIPS: readonly LoadingTip[] = [
   },
   {
     id: 'kbd:shift-tab',
-    text: 'Shift+Tab toggles plan mode (no file writes) without leaving the prompt.',
+    text: 'Shift+Tab toggles plan mode (write tools refused) without leaving the prompt.',
     source: 'static',
   },
   {

--- a/src/cli/plan-mode-toggle.ts
+++ b/src/cli/plan-mode-toggle.ts
@@ -41,7 +41,7 @@ export async function togglePlanMode(
       if (!hasShownFirstUseTip) hasShownFirstUseTip = true;
       ctx.out.success(
         palette.warning('● plan mode ON') +
-        palette.dim(' — write_file, edit_file, and write-intent bash are refused.') +
+        palette.dim(' — writes are refused; read-only bash runs, mutating bash is blocked.') +
         tip,
       );
     } else {

--- a/src/cli/slash/commands/plan.ts
+++ b/src/cli/slash/commands/plan.ts
@@ -9,13 +9,17 @@
  *   /plan <free text>        — enter plan mode and pre-fill the prompt with
  *                              <free text> for immediate submission
  *
- * Enforcement: in plan mode, write_file, edit_file, memory_update,
- * procedure_write, and write-intent bash are refused by the plan-mode gate
- * hook (`src/agent/plan-mode-gate.ts`). This is hook-level refusal in
- * agent-afk's own harness — the model is not lied to about which permission
- * mode it is in, and there is no upstream permission-mode layer being relied
- * on. (agent-afk talks to the Anthropic Messages API directly via
- * `@anthropic-ai/sdk`; it does not use `@anthropic-ai/claude-agent-sdk`.)
+ * Enforcement: in plan mode, write_file, edit_file, memory_update, and
+ * procedure_write are refused by the plan-mode gate hook
+ * (`src/agent/plan-mode-gate.ts`). `bash` is mutation-gated rather than blanket-
+ * refused: read-only recon (git status/log/diff, ls, cat, grep, find) runs,
+ * while state-mutating commands are refused via the shared `classifyBashCommand`
+ * classifier (best-effort, not a security boundary — the same classifier that
+ * gates read-only skill phases). This is hook-level refusal in agent-afk's own
+ * harness — the model is not lied to about which permission mode it is in, and
+ * there is no upstream permission-mode layer being relied on. (agent-afk talks
+ * to the Anthropic Messages API directly via `@anthropic-ai/sdk`; it does not
+ * use `@anthropic-ai/claude-agent-sdk`.)
  *
  * Posture: the `anthropic-direct` provider appends a planning-topology
  * addendum to the system prompt whenever permissionMode === 'plan', so the
@@ -95,7 +99,7 @@ export const planCmd: SlashCommand = {
   name: '/plan',
   usage: '/plan [on|off|<prompt>]',
   summary: 'Toggle plan mode; /plan off saves the plan to a file then implements it',
-  hint: 'Think through an approach without touching files — writes are refused until you exit. /plan off saves the plan + implements it; Shift+Tab exits without implementing.',
+  hint: 'Think through an approach without changing anything — write tools and state-mutating bash are refused until you exit; read-only investigation runs. /plan off saves the plan + implements it; Shift+Tab exits without implementing.',
   async handler(ctx, args): Promise<SlashResult> {
     const arg = args.trim();
     const argLower = arg.toLowerCase();


### PR DESCRIPTION
## Summary

Plan mode previously gated `bash` with a crude substring `BASH_DENYLIST`. Its ` && ` entry refused *every* chained command — even read-only `git status && git log` — and it was trivially bypassed (interpreter writes, heredocs), so it added friction without real enforcement.

This replaces it with the existing **`classifyBashCommand`** mutation classifier (the same best-effort classifier that already gates read-only skill phases):

- **Read-only recon flows** in plan mode: `git status/log/diff`, `ls`, `cat`, `grep`, `find`, and chains thereof.
- **State-mutating bash is refused**: `rm`, `>`/`>>`, `cp`/`mv`/`mkdir`/`touch`/`tee`, `git commit/push/reset`, package installs, `sed -i`, interpreter file-writes, etc.
- **One source of mutation rules** — no second denylist to drift from the skill-phase path.
- The hard file/memory write-tool gate (`write_file`, `edit_file`, `memory_update`, `procedure_write`, `config_set`, `terminal_font_size`) is **unchanged**. The bash check reads the mode at call-time, so live Shift+Tab toggling needs no extra wiring.

Honest framing kept throughout: best-effort, **not** a security boundary (bash is Turing-complete) — stated in the gate header and the block reason. The approach was vetted with a devils-advocate wave (alternatives considered: OS read-only sandbox, dispatcher `readOnlyBash`-path reuse, do-nothing) which ranked it top with no dissent.

## Test results

- `pnpm test`: **504 files, 9404 passed, 12 skipped**, exit 0 (clean env).
- `pnpm lint` (`tsc --noEmit`, strict): clean.
- Gate suite (16 tests) exercises the *real* classifier through the gate (integration-level), incl. regression guards that `git status && git log` passes and `rm` / `echo > file` / `git commit` block.

## Verification (`--verify` adversarial wave)

Independent read-only verifier re-derived the load-bearing claims from source:

- Read-only bash allowed (`git status`, chained reads, `grep`): **CONFIRM**
- Mutating bash blocked (`rm`, redirect, `git commit`): **CONFIRM**
- Additive — write-tool gate intact, mode read at call-time, subagent bypass preserved: **CONFIRM**
- False-positive risk: **LOW** (CMD_START anchoring + `stripDataStrings` cover `cat install.md`, `grep "rm "`, `git log`).
- Import cycle: **none** (`readonly-bash.ts` imports nothing).
- Bottom line: safe to merge as-is.

## Out of scope

- Plan-mode bash now blocks **all** known mutations, not strictly file edits — so `git push`/installs are also refused while planning (judged correct for a planning phase). A stricter "files-only" mode is a possible future `--strict-files` toggle, not in this PR.
- Noticed but not fixed here: `src/cli/config.test.ts` has a test-isolation gap — its env cleanup list omits `AFK_MODEL_LOCAL*`, so the full suite reports a spurious failure on a machine that exports those vars (CI is unaffected). Separate concern.