### PR TITLE
fix(cli): stop the slash-command dropdown from erasing the welcome banner on the first message

### DIFF
--- a/src/cli/cup-frame-renderer.test.ts
+++ b/src/cli/cup-frame-renderer.test.ts
@@ -607,6 +607,41 @@ describe('CupFrameRenderer — no trailing-\\n scroll', () => {
     expect(countBareNewlines(out2)).toBe(0);
   });
 
+  it('clamps the shrink-pad to anchorFloor — never writes above a banner ceiling', () => {
+    // Regression: typing a slash command as the FIRST message opened the
+    // autocomplete dropdown (a tall frame); closing it (a large shrink) padded
+    // enough blank rows that newTopRow climbed above the welcome-banner ceiling,
+    // blanking the bottom of the goblin logo and opening a gap. With
+    // anchorFloor=12 (banner occupies rows 1..11), the padded top must never
+    // rise above row 12.
+    const stream = makeMockStream(true, 80, 24);
+    const allWrites = collectWrites(stream);
+    const renderer = new CupFrameRenderer(stream);
+
+    // Render 1: a 9-row "open dropdown" frame just below the banner,
+    // bottomRow=20 → occupies rows 12..20 (top pinned at the floor).
+    const dropdown = Array.from({ length: 9 }, (_, i) => `menu${i + 1}`).join('\n');
+    renderer.render(dropdown, 20, 12);
+    expect(renderer.topRow).toBe(12);
+    void allWrites();
+
+    // Render 2: dropdown closes → 2-row input frame at bottomRow=14. The raw
+    // shrink delta is 7, but the floor clamp caps the pad to 1 so newTopRow=12.
+    const chunks: string[] = [];
+    (stream as NodeJS.ReadWriteStream).on('data', (c: unknown) => chunks.push(String(c)));
+    renderer.render('input\n> ', 14, 12);
+    const out2 = chunks.join('');
+
+    // No CUP write may target any banner row (1..11).
+    for (let row = 1; row <= 11; row++) {
+      expect(out2, `must not touch banner row ${row}`).not.toContain(`\x1b[${row};1H`);
+    }
+    // Frame top stays at or below the floor; content is still bottom-pinned.
+    expect(renderer.topRow).toBeGreaterThanOrEqual(12);
+    expect(out2).toContain('input');
+    expect(countBareNewlines(out2)).toBe(0);
+  });
+
   it('does not pad on grow (larger frame than previous)', () => {
     const stream = makeMockStream(true, 80, 24);
     const allWrites = collectWrites(stream);

--- a/src/cli/cup-frame-renderer.ts
+++ b/src/cli/cup-frame-renderer.ts
@@ -33,6 +33,8 @@
  *     ≥ 2 lines, or at `targetBottomRow` itself for a 1-line frame.
  *   - Frames grow UPWARD as line count increases; the bottom is pinned.
  *   - `newTopRow = max(1, targetBottomRow - lineCount + 1)`.
+ *   - A supplied `anchorFloor` caps the shrink-pad so `newTopRow` never rises
+ *     above it — protecting a fixed banner that occupies rows 1..anchorFloor-1.
  */
 
 import wrapAnsi from 'wrap-ansi';
@@ -128,9 +130,15 @@ export class CupFrameRenderer {
    *   - `content` is the raw frame string (may contain ANSI codes).
    *   - `targetBottomRow` is 1-based; caller passes `rows - 1`.
    *   - If `targetBottomRow < 1`, defaults to 1.
+   *   - `anchorFloor` (optional, 1-based) is the first row this renderer may
+   *     write to or erase — the row just below a fixed banner (welcome logo /
+   *     update notice) the compositor armed with. The shrink-pad is clamped so
+   *     the padded frame top never climbs above it (see the shrink-pad block).
+   *     Defaults to 1 (whole screen writable) when omitted.
    */
-  render(content: string, targetBottomRow: number): void {
+  render(content: string, targetBottomRow: number, anchorFloor?: number): void {
     const bottomRow = Math.max(1, targetBottomRow);
+    const floor = Math.max(1, anchorFloor ?? 1);
     const width = this.stream.columns ?? 80;
     const useSyncOutput = this.stream.isTTY === true;
 
@@ -155,13 +163,23 @@ export class CupFrameRenderer {
     // to peak and never decreased — the live frame stayed locked at peak
     // height forever even when overlay content collapsed (user-reported
     // 'huge gap' between scrollback and live content).
-    const frameLines =
+    // Anchor-floor clamp: a large shrink (e.g. the slash-command autocomplete
+    // dropdown collapsing from ~9 rows back to the bare input) would otherwise
+    // prepend enough blank rows that newTopRow climbs ABOVE `floor`, blanking
+    // the banner rows above it (the bottom of the goblin logo) and opening a
+    // visible gap. Cap the pad so the padded frame top lands at or below
+    // `floor`:  newTopRow = bottomRow - (rawLineCount + pad) + 1 >= floor
+    //           => pad <= bottomRow - rawLineCount + 1 - floor
+    // When no banner is armed (floor === 1) maxPad is large and the pad is the
+    // full raw-to-raw delta — byte-identical to the pre-clamp behaviour.
+    const rawShrinkPad =
       this.previousRawLineCount > rawLineCount
-        ? [
-            ...Array<string>(this.previousRawLineCount - rawLineCount).fill(''),
-            ...allLines,
-          ]
-        : allLines;
+        ? this.previousRawLineCount - rawLineCount
+        : 0;
+    const maxPad = Math.max(0, bottomRow - rawLineCount + 1 - floor);
+    const shrinkPad = Math.min(rawShrinkPad, maxPad);
+    const frameLines =
+      shrinkPad > 0 ? [...Array<string>(shrinkPad).fill(''), ...allLines] : allLines;
 
     const lineCount = frameLines.length;
 

--- a/src/cli/terminal-compositor.first-turn-banner-echo.test.ts
+++ b/src/cli/terminal-compositor.first-turn-banner-echo.test.ts
@@ -160,17 +160,13 @@ describe('first turn after banner — idle banner-followed frame commit', () => 
     expect(idx((l) => l.includes('india'))).toBeGreaterThan(idx((l) => l.includes('DUPCHECK')));
     expect(idx((l) => l.includes('RESPONSE_OK'))).toBeGreaterThan(idx((l) => l.includes('india')));
 
-    // Banner integrity: banner lines still present exactly once (stale
-    // anchor bookkeeping previously let commits orphan into banner rows).
-    // Exemption — the LAST banner row (BANNER_LINE_10): the pre-commit
-    // chrome collapse's shrink-pad climbs above anchorRow and blanks it
-    // BEFORE any commit fires (probe: collapse alone leaves topRow=11 and
-    // row 11 erased, no commitAbove involved). That is a separate
-    // pre-existing renderer defect (shrink-pad has no anchorRow floor) —
-    // out of scope for the commit-geometry fix this file guards. In
-    // production the observed deflation is 1 row, landing on the blank
-    // row below the banner, so it is not user-visible today.
-    for (let i = 0; i < BANNER_ROWS - 1; i++) {
+    // Banner integrity: ALL banner lines present exactly once (stale anchor
+    // bookkeeping previously let commits orphan into banner rows). The LAST
+    // banner row (BANNER_LINE_10) is now covered too: CupFrameRenderer's
+    // `anchorFloor` param (threaded from self.anchorRow) caps the pre-commit
+    // chrome-collapse shrink-pad so it can no longer climb above anchorRow and
+    // blank that row (previously a known, exempted renderer defect).
+    for (let i = 0; i < BANNER_ROWS; i++) {
       expect(ls.filter((l) => l.trim() === `BANNER_LINE_${i}`), `banner row ${i}:\n${dump}`).toHaveLength(1);
     }
 

--- a/src/cli/terminal-compositor.frame.ts
+++ b/src/cli/terminal-compositor.frame.ts
@@ -271,7 +271,7 @@ export function repaint(self: FrameHost): void {
   // whether the render wiped the band (the collapse render, whose stale-tall
   // top erases down through it).
   const preRenderFrameTop = self.logUpdate.topRow ?? 0;
-  self.logUpdate.render(frame, targetBottomRow);
+  self.logUpdate.render(frame, targetBottomRow, self.anchorRow);
   self.repositionCommittedBand(desiredTopRow, preRenderFrameTop, targetBottomRow);
 }
 
@@ -340,6 +340,6 @@ function repaintPickerFrame(self: FrameHost): void {
     : Math.max(1, targetBottomRow - frameLines.length + 1);
   preserveRowsBeforeFrameRender(self, desiredTopRow);
   const preRenderFrameTop = self.logUpdate.topRow ?? 0;
-  self.logUpdate.render(frame, targetBottomRow);
+  self.logUpdate.render(frame, targetBottomRow, self.anchorRow);
   self.repositionCommittedBand(desiredTopRow, preRenderFrameTop, targetBottomRow);
 }

--- a/src/cli/terminal-compositor.types.ts
+++ b/src/cli/terminal-compositor.types.ts
@@ -18,7 +18,7 @@ import type { SuggestEngine, SuggestContext } from './input/suggest.js';
 export type { SuggestEngine, SuggestContext };
 
 export interface LogUpdateFn {
-  render: (content: string, targetBottomRow: number) => void;
+  render: (content: string, targetBottomRow: number, anchorFloor?: number) => void;
   clear: (extraRows?: number) => void;
   done: () => void;
   /**


### PR DESCRIPTION
## Symptom

Typing a slash command as the **very first message** of a REPL session: when the autocomplete menu opened/closed, the input frame jumped, a blank gap appeared, and the bottom of the welcome ("goblin") banner was erased. It did **not** reproduce on later messages.

## Root cause

`CupFrameRenderer`'s shrink-pad (`src/cli/cup-frame-renderer.ts`) prepends blank rows when a frame shrinks, but `newTopRow = max(1, …)` has **no `anchorRow` floor** — the renderer has no knowledge of the banner ceiling.

The dropdown inflates the live frame to ~9 physical rows (`MAX_DROPDOWN_ROWS = 6` + input/hint/gap). On the **first** message `committedBandBottomRow === 0`, so the content-following placement (`terminal-compositor.frame.ts`) pins the frame just below the banner (`contentFloor = anchorRow`). When the menu closes (9 → ~2 rows), the shrink-pad prepends the full `9−2` delta and `newTopRow` lands **above** `anchorRow`, blanking banner rows and opening the gap.

Concretely, with banner rows 1–11 (`anchorRow = 12`) and the menu collapsing to a 2-row frame at `bottomRow = 14`: old code → `newTopRow = 14−9+1 = 6` (blanks goblin rows 6–11).

Later messages are immune because a grown committed band pushes the frame to the bottom, retiring the banner-following regime (see the comment at `terminal-compositor.frame.ts:227-234`).

The scrollback-eviction path (`terminal-compositor.frame-preserve.ts`) is a **separate, by-design** graceful degradation for genuinely short terminals and is intentionally left unchanged.

## Fix

Thread the compositor's `anchorRow` into `CupFrameRenderer.render()` as an optional `anchorFloor`, and cap the shrink-pad so the padded frame top can never climb above it:

    pad <= bottomRow - rawLineCount + 1 - floor

- **No behaviour change when no banner is armed** — `floor` defaults to `1`, so `maxPad` is large and the pad equals the full raw-to-raw delta (byte-identical to before). All existing shrink-gap / chain-stability tests pass untouched.
- The `LogUpdateFn.render` signature gains an optional 3rd param — backward-compatible with the 2-param test stubs.
- The erase loop is transitively safe: once `newTopRow >= floor` every render, `previousTopRow` is always `>= floor`, so the erase pass never touches banner rows (and `anchorRow` only ever decreases via eviction, never invalidating this).

## Verification

- `pnpm lint` (tsc --noEmit, strict) — clean
- Full compositor sweep — **288 tests across 21 files** pass (shrink-gap, pad-decay-straddle, banner-commit-gap, first-turn-banner-echo, …)
- **Un-exempts** the previously-known-broken `BANNER_LINE_10` assertion in `terminal-compositor.first-turn-banner-echo.test.ts` — now asserts **all** banner rows survive, proving the fix end-to-end through the compositor.
- Adds a focused `CupFrameRenderer` regression test: the dropdown-collapse scenario emits **no CUP write to any banner row**.
- Root cause independently re-derived from source by three adversarial verifiers (CONFIRMED, 0.97–0.99) before any edit.

## Note for reviewers

`pnpm test` (full suite) shows **2 pre-existing, unrelated failures** in `src/agent/providers/anthropic-direct.test.ts` (a model-ID alias: `claude-haiku-4-5` vs `claude-haiku-4-5-20251001`). Verified present on the clean base (v4.9.1) by stashing this branch's changes — **not introduced by this PR**, and in a different subsystem (`src/agent/providers/` vs `src/cli/`).
