### PR TITLE
ci: add docs site typecheck + build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,32 @@ jobs:
           path: coverage/
           retention-days: 14
 
+  # The docs site under website/ is a standalone npm app (Fumadocs/Next.js)
+  # with its own tsconfig and dependency tree — not part of the root pnpm
+  # workspace. This job catches TypeScript errors and broken Next.js builds
+  # that would otherwise land silently on main. See issue #144.
+  docs:
+    name: Docs Site (typecheck + build)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: cd website && npm ci
+
+      - name: Typecheck
+        run: cd website && npm run typecheck
+
+      - name: Build
+        run: cd website && npm run build
+
   # Exercise the publish-path esbuild bundle on every PR so prompt-inlining
   # regressions, externalised-dep mistakes, or shebang/permission bugs are
   # caught before `prepublishOnly` fires at release time.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: website/package-lock.json
 
       - name: Install dependencies
         run: cd website && npm ci


### PR DESCRIPTION
## Summary

Add a new `docs` CI job that exercises the standalone docs site under `website/` on every PR and push to `main`.

## Problem

The docs site is a separate npm app (Fumadocs/Next.js) with its own `tsconfig.json`, `package.json`, and dependency tree — not part of the root pnpm workspace. A TypeScript error or broken Next.js build in `website/` would land silently on `main`.

## Changes

New CI job that runs:
1. `cd website && npm ci` — install deps from the docs site's own `package-lock.json`
2. `npm run typecheck` — `tsc --noEmit`
3. `npm run build` — full Next.js production build (catches MDX/config issues too)

Verified locally: both typecheck and build pass cleanly.

Fixes #144