### PR TITLE
chore: remove resolved BACK-PORT GAP comment for shadow-verify

### DIFF
--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -80,8 +80,6 @@ const PINNED_HASHES = {
   // escape sequences that parseSkillMetadata (tool-injector.ts) renders
   // literally — replaced with a literal ≥ and unquoted terms so the
   // model-facing description is clean.
-  // BACK-PORT GAP: the same enhancement should land in the upstream example-plugin
-  // shadow-verify skill (drift test is skipped here — example-plugin not co-located).
   // Hash re-bumped during PR #187 review: the Merge section now enumerates the
   // new UNVERIFIED-COMPOSITION / UNVERIFIED-ECHO-CHAMBER verdict states — prose-
   // consistency fix only; no behavior change to the composition-axis guard.


### PR DESCRIPTION
## Summary

Removes the `BACK-PORT GAP` comment for shadow-verify in `bundled.test.ts` once the enhancement lands in the upstream example-plugin.

> ⏸️ **Draft — blocked on the back-port.** The back-port (griffinwork40/awa-private#56) is **not yet merged** and tracking issue #71 is still open, so this comment still flags a live gap. Held as draft to prevent premature merge; mark ready-for-review once #56 lands, at which point the deletion is correct.

## Changes

- Remove the 2-line BACK-PORT GAP comment (L83-84) that flagged the missing composition-axis guard / evidence_base taxonomy in the upstream copy

## Refs

- Back-port PR (must merge first): griffinwork40/awa-private#56
- Closes #71 — once the back-port lands and this merges as the agent-afk-side cleanup
