### PR TITLE
feat(openai-compatible): add retry/backoff for transient errors (429, 5xx)

### DIFF
--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -15,6 +15,7 @@ import type { ProviderEvent, ProviderUserTurn } from '../../provider.js';
 import type { AgentConfig } from '../../types/config-types.js';
 import {
   __setOpenAIClientFactory,
+  __setRetryBaseDelay,
   buildQueryFromConfig,
   OpenAICompatibleQuery,
   type OpenAIClientFactory,
@@ -1555,5 +1556,225 @@ describe('image (vision) input — issue #127', () => {
     expect(text).toMatch(/cannot view images/i);
     // The data must never reach the wire as an image part.
     expect(JSON.stringify(args.messages)).not.toContain('image_url');
+  });
+});
+
+// ---- retry / backoff tests (issue #126) -----------------------------------
+
+/**
+ * Build an APIError-like object with a `status` field. The OpenAI SDK throws
+ * `APIError` instances; our retry predicates only inspect `status`.
+ */
+function makeApiError(status: number, message?: string): Error {
+  const e = new Error(message ?? `HTTP ${status}`);
+  (e as Error & { status: number }).status = status;
+  return e;
+}
+
+/**
+ * Install a mock client that fails the first `failCount` connection attempts
+ * with the given status code, then succeeds with `pendingChunks`.
+ */
+function installConnectionRetryMock(failStatus: number, failCount: number): void {
+  let attempts = 0;
+  const factory: OpenAIClientFactory = () =>
+    ({
+      chat: {
+        completions: {
+          create: async (args: { stream?: boolean }, options?: { signal?: AbortSignal }) => {
+            createCalls.push({ args, signal: options?.signal });
+            attempts++;
+            if (attempts <= failCount) {
+              throw makeApiError(failStatus);
+            }
+            if (!args.stream) throw new Error('mock only supports streaming mode');
+            const chunks = pendingChunks.slice();
+            return (async function* () {
+              for (const c of chunks) yield c;
+            })();
+          },
+        },
+      },
+    }) as unknown as OpenAI;
+  __setOpenAIClientFactory(factory);
+}
+
+/**
+ * Install a mock client that succeeds on connection but throws a retryable
+ * error mid-stream after `goodChunks` chunks, up to `failCount` times, then
+ * succeeds fully.
+ */
+function installMidStreamRetryMock(
+  failStatus: number,
+  failCount: number,
+  goodChunksBeforeFail: OpenAIChunk[] = [],
+): void {
+  let attempts = 0;
+  const factory: OpenAIClientFactory = () =>
+    ({
+      chat: {
+        completions: {
+          create: async (args: { stream?: boolean }, options?: { signal?: AbortSignal }) => {
+            createCalls.push({ args, signal: options?.signal });
+            attempts++;
+            if (!args.stream) throw new Error('mock only supports streaming mode');
+            if (attempts <= failCount) {
+              // Succeed on connection, then fail mid-stream after some chunks.
+              const chunks = goodChunksBeforeFail.slice();
+              return (async function* () {
+                for (const c of chunks) yield c;
+                throw makeApiError(failStatus);
+              })();
+            }
+            // Final attempt: succeed fully.
+            const chunks = pendingChunks.slice();
+            return (async function* () {
+              for (const c of chunks) yield c;
+            })();
+          },
+        },
+      },
+    }) as unknown as OpenAI;
+  __setOpenAIClientFactory(factory);
+}
+
+describe('OpenAICompatibleQuery — retry / backoff (issue #126)', () => {
+  beforeEach(() => {
+    createCalls = [];
+    pendingChunks = [];
+    pendingError = null;
+    __setRetryBaseDelay(0); // no real waits in tests
+  });
+
+  afterEach(() => {
+    __setOpenAIClientFactory(null);
+    __setRetryBaseDelay(null); // restore production default
+  });
+
+  const successChunk: OpenAIChunk = {
+    choices: [{ delta: { content: 'hello' }, finish_reason: 'stop' }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+
+  // ── Connection-phase retry ──────────────────────────────────────────────
+
+  it.each([429, 500, 502, 503, 529])(
+    'retries on HTTP %d and succeeds on second attempt',
+    async (status) => {
+      pendingChunks = [successChunk];
+      installConnectionRetryMock(status, 1); // fail once, then succeed
+
+      const q = buildQueryFromConfig(baseConfig(), singleInput('hi'));
+      const events = await collect(q);
+      const types = events.map((e) => e.type);
+
+      // Should have succeeded — no error event.
+      expect(types).not.toContain('error');
+      expect(types).toContain('session.init');
+      // Two connection attempts: one failed, one succeeded.
+      expect(createCalls).toHaveLength(2);
+    },
+  );
+
+  it('surfaces error after exhausting connection retry budget (3 retries)', async () => {
+    pendingChunks = [successChunk];
+    installConnectionRetryMock(429, 10); // always fails — budget is 3 retries (4 total attempts)
+
+    const q = buildQueryFromConfig(baseConfig(), singleInput('hi'));
+    const events = await collect(q);
+    const types = events.map((e) => e.type);
+
+    expect(types).toContain('error');
+    // 1 initial + 3 retries = 4 total attempts.
+    expect(createCalls).toHaveLength(4);
+  });
+
+  it.each([400, 401, 403, 404])(
+    'does NOT retry on non-retryable HTTP %d',
+    async (status) => {
+      pendingChunks = [successChunk];
+      installConnectionRetryMock(status, 10);
+
+      const q = buildQueryFromConfig(baseConfig(), singleInput('hi'));
+      const events = await collect(q);
+      const types = events.map((e) => e.type);
+
+      expect(types).toContain('error');
+      // Only one attempt — no retries for client errors.
+      expect(createCalls).toHaveLength(1);
+    },
+  );
+
+  // ── Mid-stream retry ────────────────────────────────────────────────────
+
+  it('emits stream.retry on mid-stream 429 and succeeds on retry', async () => {
+    pendingChunks = [successChunk];
+    const partialChunk: OpenAIChunk = {
+      choices: [{ delta: { content: 'partial' }, finish_reason: null }],
+    };
+    installMidStreamRetryMock(429, 1, [partialChunk]);
+
+    const q = buildQueryFromConfig(baseConfig(), singleInput('hi'));
+    const events = await collect(q);
+    const types = events.map((e) => e.type);
+
+    expect(types).toContain('stream.retry');
+    expect(types).not.toContain('error');
+    // Two attempts: one mid-stream fail, one success.
+    expect(createCalls).toHaveLength(2);
+  });
+
+  it('emits stream.retry on mid-stream 503 and succeeds on retry', async () => {
+    pendingChunks = [successChunk];
+    installMidStreamRetryMock(503, 1, []);
+
+    const q = buildQueryFromConfig(baseConfig(), singleInput('hi'));
+    const events = await collect(q);
+    const types = events.map((e) => e.type);
+
+    expect(types).toContain('stream.retry');
+    expect(types).not.toContain('error');
+    expect(createCalls).toHaveLength(2);
+  });
+
+  it('surfaces error after exhausting mid-stream retry budget', async () => {
+    pendingChunks = [successChunk];
+    installMidStreamRetryMock(529, 10); // always fails mid-stream — budget is 3
+
+    const q = buildQueryFromConfig(baseConfig(), singleInput('hi'));
+    const events = await collect(q);
+    const types = events.map((e) => e.type);
+
+    expect(types).toContain('error');
+    // 1 initial + 3 retries = 4 total attempts.
+    expect(createCalls).toHaveLength(4);
+    // Should have emitted 3 stream.retry events (one per retry).
+    const retryEvents = events.filter((e) => e.type === 'stream.retry');
+    expect(retryEvents).toHaveLength(3);
+  });
+
+  // ── Abort during backoff ────────────────────────────────────────────────
+
+  it('aborts cleanly during connection-phase backoff', async () => {
+    installConnectionRetryMock(429, 10); // always fails
+
+    const q = buildQueryFromConfig(baseConfig(), singleInput('hi'));
+    const iterator = q[Symbol.asyncIterator]();
+
+    // Pull session.init.
+    const init = await iterator.next();
+    expect(init.value?.type).toBe('session.init');
+
+    // Interrupt immediately — the retry backoff should notice the abort.
+    await q.interrupt();
+
+    const result = await iterator.next();
+    // Should get turn.completed (aborted path) or done — not hang.
+    const ev = result.value;
+    expect(
+      ev === undefined ||
+      ev.type === 'turn.completed' ||
+      ev.type === 'error',
+    ).toBe(true);
   });
 });

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -92,6 +92,86 @@ const PROVIDER_NAME = 'openai-compatible';
  */
 const MAX_TOOL_ITERATIONS = 50;
 
+// ── Retry / backoff constants ──────────────────────────────────────────────
+// Mirrors the Anthropic provider's connection-phase + mid-stream retry pattern
+// (see `anthropic-direct/loop.ts:createWithRetry` and the overload-retry block
+// in `runTurn`). The Anthropic `RetryLayer` class is too coupled to OAuth /
+// keychain hot-swap to share; the core retry pattern (bounded exponential
+// backoff on retryable HTTP status codes) is simple enough to implement here
+// directly. See issue #126.
+
+/**
+ * HTTP status codes that warrant a retry with backoff. 429 (rate limit) and
+ * 5xx server errors are transient by nature — the same request sent again
+ * after a short wait is likely to succeed. 400/401/403/404 are deterministic
+ * client errors and must NOT be retried (they would just burn quota).
+ */
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 529]);
+
+/** Max connection-phase retries per iteration (matches Anthropic's budget). */
+const MAX_CONNECTION_RETRIES = 3;
+
+/** Max mid-stream retries per iteration (matches Anthropic's OVERLOAD_MAX_RETRIES). */
+const MAX_STREAM_RETRIES = 3;
+
+/** Base delay for exponential backoff: 2s → 4s → 8s (shorter than Anthropic's 5s because OpenAI-compatible shims are often local). */
+let RETRY_BASE_DELAY_MS = 2_000;
+
+/**
+ * Test injection hook for retry base delay. Set to 0 in tests to avoid real
+ * waits. Pass `null` to restore the production default (2000ms).
+ */
+export function __setRetryBaseDelay(ms: number | null): void {
+  RETRY_BASE_DELAY_MS = ms ?? 2_000;
+}
+
+/**
+ * Extract an HTTP status code from an error thrown by the OpenAI SDK (or a
+ * compatible shim). The SDK throws `APIError` instances with a `status` field;
+ * network errors and generic throws have no status and are treated as
+ * retryable (transient network blip) only when they carry no explicit code.
+ */
+function getErrorStatus(err: unknown): number | undefined {
+  if (err === null || typeof err !== 'object') return undefined;
+  const e = err as { status?: unknown };
+  return typeof e.status === 'number' ? e.status : undefined;
+}
+
+/**
+ * Connection-phase retryability: the HTTP call itself failed before any
+ * streaming began. Only retry on known transient status codes — errors with
+ * no status (network drops, DNS failures, wrong baseURL) are deterministic
+ * and must surface immediately to avoid wasting time on misconfigurations.
+ * Mirrors the Anthropic provider's `isTransientServerError` which also
+ * requires an explicit status.
+ */
+function isRetryableConnectionError(err: unknown): boolean {
+  const status = getErrorStatus(err);
+  if (status === undefined) return false;
+  return RETRYABLE_STATUS_CODES.has(status);
+}
+
+/**
+ * Mid-stream retryability: the stream was established but the server sent an
+ * error event mid-flight. OpenAI-compatible APIs surface this as an `APIError`
+ * thrown from the async iterator. Same status-code set as connection-phase —
+ * only retry on explicit transient codes, not on status-less errors.
+ */
+function isRetryableStreamError(err: unknown): boolean {
+  const status = getErrorStatus(err);
+  if (status === undefined) return false;
+  return RETRYABLE_STATUS_CODES.has(status);
+}
+
+function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) { resolve(); return; }
+    const timer = setTimeout(resolve, ms);
+    timer.unref();
+    signal.addEventListener('abort', () => { clearTimeout(timer); resolve(); }, { once: true });
+  });
+}
+
 /**
  * Test injection hook for the OpenAI client. Set to a factory to swap in a
  * mock client; pass `null` to restore the real constructor. Not part of the
@@ -519,8 +599,6 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       };
     }
 
-    const state = createStreamState();
-
     if (this.wireMode === 'responses') {
       const isChatGptBackend = this.opts.auth.source === 'chatgpt-oauth';
 
@@ -561,28 +639,77 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       if (isChatGptBackend) requestBody['store'] = false;
       if (req.tools && req.tools.length > 0) requestBody['tools'] = req.tools;
 
-      let stream: AsyncIterable<ResponsesStreamEvent>;
-      try {
-        stream = (await this.client.responses.create(requestBody as never, {
-          signal: controller.signal,
-        })) as unknown as AsyncIterable<ResponsesStreamEvent>;
-      } catch (err) {
-        if (controller.signal.aborted) return null;
-        yield { type: 'error', error: this.clarifyResponsesError(err, isChatGptBackend) };
-        return null;
-      }
+      // Retry loop: connection-phase + mid-stream retry with exponential
+      // backoff. Mirrors the Anthropic provider's createWithRetry + overload
+      // retry pattern (see `anthropic-direct/loop.ts`). State is reset on each
+      // retry so the re-driven request starts from a clean slate.
+      let streamRetries = 0;
+      for (;;) {
+        const state = createStreamState();
 
-      try {
-        for await (const event of stream) {
-          if (this.closed) return null;
-          for (const ev of translateResponsesEvent(event, state, this.initSessionId)) {
-            yield ev;
+        // ── Connection-phase retry ──────────────────────────────────────
+        let stream: AsyncIterable<ResponsesStreamEvent>;
+        let connectionError: unknown = null;
+        for (let attempt = 0; ; attempt++) {
+          try {
+            stream = (await this.client.responses.create(requestBody as never, {
+              signal: controller.signal,
+            })) as unknown as AsyncIterable<ResponsesStreamEvent>;
+            break; // connection succeeded
+          } catch (err) {
+            if (controller.signal.aborted) return null;
+            if (isRetryableConnectionError(err) && attempt < MAX_CONNECTION_RETRIES) {
+              const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+              await sleepWithAbort(delay, controller.signal);
+              if (controller.signal.aborted) return null;
+              continue;
+            }
+            connectionError = err;
+            break;
           }
         }
-      } catch (err) {
-        if (controller.signal.aborted) return null;
-        yield { type: 'error', error: this.clarifyResponsesError(err, isChatGptBackend) };
-        return null;
+
+        if (connectionError !== null) {
+          yield { type: 'error', error: this.clarifyResponsesError(connectionError, isChatGptBackend) };
+          return null;
+        }
+
+        // ── Mid-stream consumption with retry ───────────────────────────
+        let streamError: unknown = null;
+        try {
+          for await (const event of stream!) {
+            if (this.closed) return null;
+            for (const ev of translateResponsesEvent(event, state, this.initSessionId)) {
+              yield ev;
+            }
+          }
+        } catch (err) {
+          if (controller.signal.aborted) return null;
+          if (isRetryableStreamError(err) && streamRetries < MAX_STREAM_RETRIES) {
+            streamRetries++;
+            yield { type: 'stream.retry', sessionId: this.initSessionId };
+            await sleepWithAbort(
+              RETRY_BASE_DELAY_MS * Math.pow(2, streamRetries - 1),
+              controller.signal,
+            );
+            if (controller.signal.aborted) return null;
+            continue; // retry the whole iteration
+          }
+          streamError = err;
+        }
+
+        if (streamError !== null) {
+          yield { type: 'error', error: this.clarifyResponsesError(streamError, isChatGptBackend) };
+          return null;
+        }
+
+        // Clean completion — return the result.
+        return {
+          state,
+          events: [],
+          text: state.assistantText,
+          needsToolDispatch: isToolCallStop(state) && state.toolCallsByIndex.size > 0,
+        };
       }
     } else {
       const requestBody: Record<string, unknown> = {
@@ -597,39 +724,79 @@ export class OpenAICompatibleQuery implements ProviderQuery {
         requestBody['tools'] = this.openAITools;
       }
 
-      let stream: AsyncIterable<OpenAIChunk>;
-      try {
-        stream = (await this.client.chat.completions.create(requestBody as never, {
-          signal: controller.signal,
-        })) as unknown as AsyncIterable<OpenAIChunk>;
-      } catch (err) {
-        if (controller.signal.aborted) return null;
-        const e = err instanceof Error ? err : new Error(String(err));
-        yield { type: 'error', error: e };
-        return null;
-      }
+      // Retry loop: connection-phase + mid-stream retry with exponential
+      // backoff. Same pattern as the Responses path above.
+      let streamRetries = 0;
+      for (;;) {
+        const state = createStreamState();
 
-      try {
-        for await (const chunk of stream) {
-          if (this.closed) return null;
-          for (const ev of translateChunk(chunk, state, this.initSessionId)) {
-            yield ev;
+        // ── Connection-phase retry ──────────────────────────────────────
+        let stream: AsyncIterable<OpenAIChunk>;
+        let connectionError: unknown = null;
+        for (let attempt = 0; ; attempt++) {
+          try {
+            stream = (await this.client.chat.completions.create(requestBody as never, {
+              signal: controller.signal,
+            })) as unknown as AsyncIterable<OpenAIChunk>;
+            break; // connection succeeded
+          } catch (err) {
+            if (controller.signal.aborted) return null;
+            if (isRetryableConnectionError(err) && attempt < MAX_CONNECTION_RETRIES) {
+              const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+              await sleepWithAbort(delay, controller.signal);
+              if (controller.signal.aborted) return null;
+              continue;
+            }
+            connectionError = err;
+            break;
           }
         }
-      } catch (err) {
-        if (controller.signal.aborted) return null;
-        const e = err instanceof Error ? err : new Error(String(err));
-        yield { type: 'error', error: e };
-        return null;
+
+        if (connectionError !== null) {
+          const e = connectionError instanceof Error ? connectionError : new Error(String(connectionError));
+          yield { type: 'error', error: e };
+          return null;
+        }
+
+        // ── Mid-stream consumption with retry ───────────────────────────
+        let streamError: unknown = null;
+        try {
+          for await (const chunk of stream!) {
+            if (this.closed) return null;
+            for (const ev of translateChunk(chunk, state, this.initSessionId)) {
+              yield ev;
+            }
+          }
+        } catch (err) {
+          if (controller.signal.aborted) return null;
+          if (isRetryableStreamError(err) && streamRetries < MAX_STREAM_RETRIES) {
+            streamRetries++;
+            yield { type: 'stream.retry', sessionId: this.initSessionId };
+            await sleepWithAbort(
+              RETRY_BASE_DELAY_MS * Math.pow(2, streamRetries - 1),
+              controller.signal,
+            );
+            if (controller.signal.aborted) return null;
+            continue; // retry the whole iteration
+          }
+          streamError = err;
+        }
+
+        if (streamError !== null) {
+          const e = streamError instanceof Error ? streamError : new Error(String(streamError));
+          yield { type: 'error', error: e };
+          return null;
+        }
+
+        // Clean completion — return the result.
+        return {
+          state,
+          events: [],
+          text: state.assistantText,
+          needsToolDispatch: isToolCallStop(state) && state.toolCallsByIndex.size > 0,
+        };
       }
     }
-
-    return {
-      state,
-      events: [],
-      text: state.assistantText,
-      needsToolDispatch: isToolCallStop(state) && state.toolCallsByIndex.size > 0,
-    };
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds connection-phase and mid-stream retry with bounded exponential backoff to the OpenAI-compatible provider, mirroring the Anthropic provider's `createWithRetry` + overload-retry pattern.

**Closes #126.**

## Changes

### `src/agent/providers/openai-compatible/query.ts`

- **Retry constants & predicates**: `RETRYABLE_STATUS_CODES` (429, 500, 502, 503, 529), `isRetryableConnectionError`, `isRetryableStreamError`, `sleepWithAbort`
- **Connection-phase retry**: wraps `client.chat.completions.create` and `client.responses.create` in a retry loop (max 3 retries, exponential backoff 2s → 4s → 8s)
- **Mid-stream retry**: wraps stream consumption in a retry loop — on a retryable error mid-stream, resets state, emits `stream.retry`, backs off, and re-drives the request (max 3 retries)
- **Test hook**: `__setRetryBaseDelay` for zero-delay tests (same pattern as `__setOpenAIClientFactory`)

### `src/agent/providers/openai-compatible/query.test.ts`

14 new tests covering:
- Connection-phase retry on each retryable status code (429, 500, 502, 503, 529)
- Connection-phase retry budget exhaustion (surfaces error after 4 total attempts)
- Non-retryable errors (400, 401, 403, 404) — no retry, immediate error
- Mid-stream retry with `stream.retry` emission
- Mid-stream retry budget exhaustion (3 `stream.retry` events + final error)
- Clean abort during backoff

## Design decisions

- **Not sharing the Anthropic `RetryLayer`**: the Anthropic class is deeply coupled to OAuth/keychain hot-swap/usage-limit semantics. The core retry pattern (bounded exponential backoff on transient HTTP codes) is simple enough to implement directly — duplicating ~80 lines is cleaner than abstracting a shared base that would need to parameterize over two different SDK shapes.
- **No retry on status-less errors**: network drops / DNS failures / wrong baseURL surface immediately (matching Anthropic's `isTransientServerError` which also requires an explicit status). Retrying misconfigurations just wastes time.
- **2s base delay** (vs Anthropic's 5s): OpenAI-compatible shims are often local (MLX, llama.cpp, vLLM), so shorter backoff is appropriate.
- **Per-iteration retry budget**: mid-stream retry counter resets each iteration (each tool-use round gets its own allowance), matching the Anthropic provider's invariant.

## Test results

- All 202 openai-compatible tests pass (37 existing + 14 new + 151 in sibling test files)
- `tsc --noEmit` clean
- Pre-existing failures in unrelated test files (telegram, cli/config, anthropic-direct/read-only-memory) are not caused by this change