### PR TITLE
feat(openai-compatible): forward reasoning_effort for o-series models

### DIFF
--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -600,6 +600,163 @@ describe('OpenAICompatibleQuery — model-slot resolution in request body', () =
   });
 });
 
+describe('OpenAICompatibleQuery — reasoning_effort for o-series models', () => {
+  it('forwards reasoning_effort for o-series models when effort is set', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'ok' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ];
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'o3', effort: 'high' }),
+      singleInput('hi'),
+    );
+    await collect(q);
+    expect(createCalls).toHaveLength(1);
+    const args = createCalls[0]!.args as Record<string, unknown>;
+    expect(args['reasoning_effort']).toBe('high');
+  });
+
+  it('does NOT forward reasoning_effort for non-o-series models', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'ok' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ];
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'gpt-4o', effort: 'high' }),
+      singleInput('hi'),
+    );
+    await collect(q);
+    const args = createCalls[0]!.args as Record<string, unknown>;
+    expect(args['reasoning_effort']).toBeUndefined();
+  });
+
+  it('does NOT forward reasoning_effort when effort is undefined', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'ok' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ];
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'o3' }),
+      singleInput('hi'),
+    );
+    await collect(q);
+    const args = createCalls[0]!.args as Record<string, unknown>;
+    expect(args['reasoning_effort']).toBeUndefined();
+  });
+
+  it('maps xhigh to high for OpenAI', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'ok' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ];
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'o4-mini', effort: 'xhigh' }),
+      singleInput('hi'),
+    );
+    await collect(q);
+    const args = createCalls[0]!.args as Record<string, unknown>;
+    expect(args['reasoning_effort']).toBe('high');
+  });
+
+  it('maps max to high for OpenAI', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'ok' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ];
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'o1', effort: 'max' }),
+      singleInput('hi'),
+    );
+    await collect(q);
+    const args = createCalls[0]!.args as Record<string, unknown>;
+    expect(args['reasoning_effort']).toBe('high');
+  });
+
+  it('handles OpenRouter-style prefixed model ids (e.g. openai/o3)', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'ok' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ];
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'openai/o3', effort: 'medium' }),
+      singleInput('hi'),
+    );
+    await collect(q);
+    const args = createCalls[0]!.args as Record<string, unknown>;
+    expect(args['reasoning_effort']).toBe('medium');
+  });
+
+  it('forwards reasoning.effort on the Responses API path for o-series models', async () => {
+    // Install a mock that also supports the Responses API
+    const responsesFactory: OpenAIClientFactory = () =>
+      ({
+        chat: {
+          completions: {
+            create: async () => { throw new Error('should not be called'); },
+          },
+        },
+        responses: {
+          create: async (args: Record<string, unknown>) => {
+            createCalls.push({ args });
+            const gen = (async function* () {
+              yield { type: 'response.output_text.delta', delta: 'ok' };
+              yield { type: 'response.completed', response: { usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } } };
+            })();
+            return gen;
+          },
+        },
+      }) as unknown as OpenAI;
+    __setOpenAIClientFactory(responsesFactory);
+
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'o3', effort: 'low' }),
+      singleInput('hi'),
+      { useResponsesApi: true },
+    );
+    await collect(q);
+    expect(createCalls).toHaveLength(1);
+    const args = createCalls[0]!.args as Record<string, unknown>;
+    expect(args['reasoning']).toEqual({ effort: 'low' });
+
+    // Restore the default mock for subsequent tests
+    installMockClient();
+  });
+
+  it('does NOT forward reasoning.effort on the Responses API path for non-o-series models', async () => {
+    const responsesFactory: OpenAIClientFactory = () =>
+      ({
+        chat: {
+          completions: {
+            create: async () => { throw new Error('should not be called'); },
+          },
+        },
+        responses: {
+          create: async (args: Record<string, unknown>) => {
+            createCalls.push({ args });
+            const gen = (async function* () {
+              yield { type: 'response.output_text.delta', delta: 'ok' };
+              yield { type: 'response.completed', response: { usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } } };
+            })();
+            return gen;
+          },
+        },
+      }) as unknown as OpenAI;
+    __setOpenAIClientFactory(responsesFactory);
+
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'gpt-4o', effort: 'high' }),
+      singleInput('hi'),
+      { useResponsesApi: true },
+    );
+    await collect(q);
+    const args = createCalls[0]!.args as Record<string, unknown>;
+    expect(args['reasoning']).toBeUndefined();
+
+    // Restore the default mock
+    installMockClient();
+  });
+});
+
 describe('OpenAICompatibleQuery — auth failure path', () => {
   it('emits session.init then error when no auth is resolvable', async () => {
     // Use hermetic auth deps so this test is isolated from the host machine's

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -19,8 +19,6 @@
  * Things deliberately deferred:
  *   - File checkpointing / rewindFiles (deferred — `canRewind: false`)
  *   - Compact (provider opts out by leaving `compact` undefined)
- *   - Reasoning effort knob for o-series (will be wired when AgentConfig
- *     `effort` flows through cleanly)
  *
  * @module agent/providers/openai-compatible/query
  */
@@ -28,6 +26,7 @@
 import OpenAI from 'openai';
 import { randomUUID } from 'node:crypto';
 import type { AgentConfig } from '../../types/config-types.js';
+import type { EffortLevel } from '../../types/sdk-types.js';
 import type {
   ProviderQuery,
   ProviderEvent,
@@ -142,6 +141,49 @@ export interface OpenAICompatibleQueryOptions {
 
 function normalizePermissionMode(mode: string | undefined): string {
   return mode ?? 'default';
+}
+
+/**
+ * Detect OpenAI o-series reasoning models (o1, o3, o4, and their variants).
+ * Strips any `provider/` prefix (OpenRouter-style ids) before matching.
+ * Mirrors the detection in `oneshot.ts` for the `max_completion_tokens` switch.
+ */
+export function isOSeriesModel(model: string): boolean {
+  const bareModel = model.includes('/') ? model.slice(model.lastIndexOf('/') + 1) : model;
+  return /^o[0-9]/.test(bareModel);
+}
+
+/**
+ * Map AFK's `EffortLevel` to OpenAI's `reasoning_effort` values.
+ * OpenAI accepts `low`, `medium`, `high`. AFK's `xhigh` and `max` are
+ * Anthropic-specific and map to `high` for OpenAI.
+ */
+export function mapEffortForOpenAI(effort: EffortLevel): 'low' | 'medium' | 'high' {
+  switch (effort) {
+    case 'low':
+      return 'low';
+    case 'medium':
+      return 'medium';
+    case 'high':
+    case 'xhigh':
+    case 'max':
+      return 'high';
+  }
+}
+
+/**
+ * Resolve the `reasoning_effort` to send for a given model + effort config.
+ * Returns `undefined` when effort should not be forwarded (non-o-series model
+ * or no effort configured). Callers attach the result to the request body
+ * under `reasoning_effort` (Chat Completions) or `reasoning.effort` (Responses).
+ */
+export function resolveReasoningEffort(
+  effort: EffortLevel | undefined,
+  model: string,
+): 'low' | 'medium' | 'high' | undefined {
+  if (effort === undefined) return undefined;
+  if (!isOSeriesModel(model)) return undefined;
+  return mapEffortForOpenAI(effort);
 }
 
 /** Internal record used to drive the per-turn iteration loop. */
@@ -560,6 +602,12 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       if (instructions !== undefined) requestBody['instructions'] = instructions;
       if (isChatGptBackend) requestBody['store'] = false;
       if (req.tools && req.tools.length > 0) requestBody['tools'] = req.tools;
+      // Forward reasoning effort for o-series models on the Responses API.
+      // Uses the `reasoning: { effort }` shape per OpenAI's Responses API spec.
+      const responsesEffort = resolveReasoningEffort(this.opts.config.effort, this.currentModel);
+      if (responsesEffort !== undefined) {
+        requestBody['reasoning'] = { effort: responsesEffort };
+      }
 
       let stream: AsyncIterable<ResponsesStreamEvent>;
       try {
@@ -595,6 +643,12 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       // arrays make some providers reject the request.
       if (this.openAITools && this.openAITools.length > 0) {
         requestBody['tools'] = this.openAITools;
+      }
+      // Forward reasoning effort for o-series models on Chat Completions.
+      // Uses the `reasoning_effort` field per OpenAI's Chat Completions API spec.
+      const chatEffort = resolveReasoningEffort(this.opts.config.effort, this.currentModel);
+      if (chatEffort !== undefined) {
+        requestBody['reasoning_effort'] = chatEffort;
       }
 
       let stream: AsyncIterable<OpenAIChunk>;


### PR DESCRIPTION
## Summary

Closes #128.

The `openai-compatible` provider never sent `reasoning_effort` for o-series reasoning models (o1/o3/o4), so reasoning depth could not be controlled from AFK config. The `anthropic-direct` provider already forwarded effort via `output_config.effort`.

## Changes

### `src/agent/providers/openai-compatible/query.ts`
- **`isOSeriesModel(model)`** — detects o-series models via `/^o[0-9]/` after stripping `provider/` prefixes (OpenRouter-style ids like `openai/o3`)
- **`mapEffortForOpenAI(effort)`** — maps AFK `EffortLevel` → OpenAI values (`low`/`medium`/`high`); `xhigh` and `max` collapse to `high`
- **`resolveReasoningEffort(effort, model)`** — combines both: returns the mapped effort only for o-series models with effort configured
- **Chat Completions path**: attaches `reasoning_effort` to the request body
- **Responses API path**: attaches `reasoning: { effort }` to the request body
- Removed the deferred-features comment about reasoning effort (it is now wired)

### `src/agent/providers/openai-compatible/query.test.ts`
8 new tests:
- ✅ Forwards `reasoning_effort` for o-series models when effort is set
- ✅ Does NOT forward for non-o-series models (e.g. gpt-4o)
- ✅ Does NOT forward when effort is undefined
- ✅ Maps `xhigh` → `high`
- ✅ Maps `max` → `high`
- ✅ Handles OpenRouter-style prefixed model ids (`openai/o3`)
- ✅ Forwards `reasoning.effort` on the Responses API path
- ✅ Does NOT forward on Responses API for non-o-series models

## Test results
- `tsc --noEmit`: ✅ clean
- `vitest run src/agent/providers/openai-compatible/`: ✅ 196/196 passed (including 8 new)