### PR TITLE
fix(tui): StatusLine stop() clears the pre-SIGWINCH row during the resize debounce window

### DIFF
--- a/src/cli/status-line.test.ts
+++ b/src/cli/status-line.test.ts
@@ -440,6 +440,36 @@ describe('StatusLine resize handling', () => {
     status.stop();
   });
 
+  it('stop() during debounce window clears the pre-SIGWINCH row, not the new-geometry row', () => {
+    // Race: SIGWINCH fires (preResizePaintedRow=24, lastPaintedRow=null), then a
+    // mid-window repaint() seeds lastPaintedRow=30. stop() must erase row 24
+    // (preResizePaintedRow), NOT row 30 (lastPaintedRow after the mid-window repaint).
+    vi.useFakeTimers();
+    const stream = mockStream({ isTTY: true, rows: 24 });
+    const status = new StatusLine({
+      stream: stream as unknown as NodeJS.WriteStream,
+      throttleMs: 0,
+    });
+    status.start();
+    status.repaint({ model: 'sonnet' }); // lastPaintedRow=24
+
+    // SIGWINCH: preResizePaintedRow=24, lastPaintedRow=null.
+    stream.rows = 30;
+    process.stdout.emit('resize');
+
+    // Mid-window repaint seeds lastPaintedRow=30.
+    status.repaint({ model: 'sonnet' });
+
+    stream.writes.length = 0;
+    status.stop();
+    const out = lastJoined(stream);
+
+    // Must erase the true pre-SIGWINCH row (24).
+    expect(out).toContain('\x1b[24;1H');
+    // Must NOT erase the new-geometry row (30) — sharp: fails on buggy code.
+    expect(out).not.toContain('\x1b[30;1H');
+  });
+
   it('does not emit an invalid 1;0 scroll region when the terminal has one row', () => {
     const stream = mockStream({ isTTY: true, rows: 1 });
     const status = new StatusLine({

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -314,7 +314,11 @@ export class StatusLine {
     }
     const rows = this.currentRows();
     this.stream.write('\x1b[s');
-    this.stream.write(`\x1b[${this.lastPaintedRow ?? this.paintRow(rows)};1H`);
+    // Symmetric with onResize(): prefer preResizePaintedRow so a mid-debounce
+    // repaint() that re-seeded lastPaintedRow to the new geometry doesn't cause
+    // stop() to erase the wrong (new-geometry) row.
+    const rowToErase = this.preResizePaintedRow ?? this.lastPaintedRow ?? this.paintRow(rows);
+    this.stream.write(`\x1b[${rowToErase};1H`);
     this.stream.write('\x1b[2K');
     // Reset scroll region to full.
     this.stream.write('\x1b[r');


### PR DESCRIPTION
## Source

Ported from **afk-workshop#719** (private) — `fix(tui): reset StatusLine + BackgroundStatusBar geometry on SIGWINCH to stop ghost rows`. This is a **moat-scrubbed, partial port**, not a 1:1 copy.

## Context — most of #719 is already public

The core of #719 (the `ResizeBus.subscribeImmediate` geometry reset for `StatusLine` + `BackgroundStatusBar`) already landed publicly via **#174**, and the post-review StatusLine race-window coverage + BackgroundStatusBar old-row-erase fix landed via the #174 review follow-up (`bc67d4ef`). This PR ports the **one remaining gap**: a low-severity `StatusLine.stop()` fix from #719's own review pass that public still lacks.

## Ported

- **`src/cli/status-line.ts`** — `stop()` now clears `preResizePaintedRow ?? lastPaintedRow ?? paintRow(rows)`, symmetric with `onResize()`. Without this, a `stop()` landing inside the 150ms SIGWINCH debounce window — after a mid-window `repaint()` re-seeded `lastPaintedRow` to the new geometry — erases the wrong (new-geometry) row, leaving the pre-resize row stranded. (Public's `stop()` was byte-identical to the pre-fix private version.)
- **`src/cli/status-line.test.ts`** — one regression test: `stop()` during the debounce window clears the pre-SIGWINCH row, not the new-geometry row. It is sharp (fails on the pre-fix code).

## Dropped (and why)

- The companion **onResize race test** from #719 — public already has an equivalent (`'clears the PRE-resize row, not a mid-window repaint row…'`, added via the #174 review cycle). Porting it would duplicate coverage.
- The **R3 unsub-test sharpening** (a NIT on `background-status-bar.test.ts`) — public's bg-bar test diverged via `bc67d4ef` (added R4/R5 old-row-erase tests); the NIT is marginal and would land on diverged code. Left for a separate pass if wanted.

## Verification

- `pnpm install --frozen-lockfile` ✓ · `pnpm lint` ✓ · `pnpm test -- src/cli/status-line.test.ts` ✓ (36 passed, incl. the new test) · `pnpm build` + `pnpm build:dist` ✓
- Deterministic moat guard: **✅ MOAT GUARD CLEAN** (tree + `dist/`)
- Independent adversarial moat audit: **CLEAN**

**Do not merge automatically — left for human review.**
