### PR TITLE
fix(openai-compatible): thread max_tokens into streaming request body (issue #125)

### DIFF
--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -551,6 +551,82 @@ describe('OpenAICompatibleQuery — text streaming', () => {
       { role: 'user', content: 'next q' },
     ]);
   });
+
+  // ---- streaming max_tokens (issue #125) --------------------------------
+
+  it('includes max_tokens on the Chat Completions streaming path (default config)', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'ok' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ];
+    const q = buildQueryFromConfig(baseConfig({ model: 'gpt-4o-mini' }), singleInput('hi'));
+    await collect(q);
+    const body = createCalls[0]!.args as Record<string, unknown>;
+    expect(body).toHaveProperty('max_tokens');
+    // Default output ceiling for gpt-4o-mini is 64k.
+    expect(body.max_tokens).toBe(64000);
+  });
+
+  it('honours config.maxOutputTokens on the Chat Completions streaming path', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'ok' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ];
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'gpt-4o-mini', maxOutputTokens: 2048 }),
+      singleInput('hi'),
+    );
+    await collect(q);
+    const body = createCalls[0]!.args as Record<string, unknown>;
+    expect(body).toHaveProperty('max_tokens');
+    expect(body.max_tokens).toBe(2048);
+  });
+
+  it('uses max_completion_tokens for o-series models on Chat Completions', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'ok' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ];
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'o3-mini' }),
+      singleInput('hi'),
+    );
+    await collect(q);
+    const body = createCalls[0]!.args as Record<string, unknown>;
+    expect(body).toHaveProperty('max_completion_tokens');
+    expect(body).not.toHaveProperty('max_tokens');
+  });
+
+  it('uses max_completion_tokens for o-series with custom maxOutputTokens', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'ok' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ];
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'o3-mini', maxOutputTokens: 4096 }),
+      singleInput('hi'),
+    );
+    await collect(q);
+    const body = createCalls[0]!.args as Record<string, unknown>;
+    expect(body).toHaveProperty('max_completion_tokens');
+    expect(body.max_completion_tokens).toBe(4096);
+    expect(body).not.toHaveProperty('max_tokens');
+  });
+
+  it('strips provider/ prefix before o-series detection (OpenRouter-style)', async () => {
+    pendingChunks = [
+      { choices: [{ delta: { content: 'ok' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ];
+    const q = buildQueryFromConfig(
+      baseConfig({ model: 'openai/o3-mini' }),
+      singleInput('hi'),
+    );
+    await collect(q);
+    const body = createCalls[0]!.args as Record<string, unknown>;
+    expect(body).toHaveProperty('max_completion_tokens');
+    expect(body).not.toHaveProperty('max_tokens');
+  });
 });
 
 describe('OpenAICompatibleQuery — model-slot resolution in request body', () => {

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -43,7 +43,7 @@ import type {
   ProviderUsage,
 } from '../../provider.js';
 import { sumProviderUsage } from '../../usage.js';
-import { contextLimitFor } from '../../model-limits.js';
+import { contextLimitFor, maxOutputTokensFor } from '../../model-limits.js';
 import { resolveModelId } from '../../session/model-resolution.js';
 import { collectSkillEntries } from '../../tools/skill-bridge.js';
 import { extractRawToolInput } from '../../facets/raw-input.js';
@@ -105,6 +105,41 @@ export type OpenAIClientFactory = (opts: {
 let clientFactory: OpenAIClientFactory | null = null;
 export function __setOpenAIClientFactory(factory: OpenAIClientFactory | null): void {
   clientFactory = factory;
+}
+
+/**
+ * Resolve the streaming output-token cap for the OpenAI API.
+ *
+ * Mirrors the o-series field-selection logic in `oneshot.ts:91–96`:
+ * o-series reasoning models (o1/o3/o4…) reject `max_tokens` and require
+ * `max_completion_tokens`; everything else (chat models, local shims)
+ * wants `max_tokens`.  Strips any `provider/` prefix (OpenRouter-style ids)
+ * before the regex check so `openai/o3` is treated the same as `o3`.
+ *
+ * Returns `undefined` when no cap is configured, so shims that reject the
+ * field simply don't see it on the wire.
+ */
+function resolveStreamingMaxTokens(
+  model: string,
+  configMaxOutput: number | undefined,
+): Record<string, number> | undefined {
+  // Strip any `provider/` prefix (OpenRouter-style ids) before the o-series
+  // regex — mirrors oneshot.ts:93.
+  const bareModel = model.includes('/') ? model.slice(model.lastIndexOf('/') + 1) : model;
+  const isOSeries = /^o[0-9]/.test(bareModel);
+
+  // Resolve the effective cap: honour config.maxOutputTokens when finite+positive,
+  // otherwise fall back to the model's output ceiling (matching Anthropic's
+  // resolveMaxTokens).  Uses maxOutputTokensFor (output ceiling), not
+  // contextLimitFor (context window), because the cap bounds *output*, not
+  // the full context window.
+  const ceiling = maxOutputTokensFor(model);
+  const effectiveMax =
+    typeof configMaxOutput === 'number' && Number.isFinite(configMaxOutput) && configMaxOutput > 0
+      ? Math.floor(configMaxOutput)
+      : ceiling;
+
+  return isOSeries ? { max_completion_tokens: effectiveMax } : { max_tokens: effectiveMax };
 }
 
 /** Construction options. */
@@ -551,6 +586,18 @@ export class OpenAICompatibleQuery implements ProviderQuery {
         input: req.input,
         stream: true,
       };
+      // Thread the output-token cap into the streaming request so callers can
+      // bound output length (parity with Anthropic's always-forwarded
+      // max_tokens).  Reuses the o-series field-selection logic from
+      // oneshot.ts:91–96.
+      const maxTokensField = resolveStreamingMaxTokens(
+        this.currentModel,
+        this.opts.config.maxOutputTokens,
+      );
+      if (maxTokensField !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        Object.assign(requestBody, maxTokensField);
+      }
       // The private ChatGPT backend (subscription path) has two hard
       // requirements the public Responses API does not: a non-empty
       // `instructions`, and `store: false`. Scope both to that path so the
@@ -591,6 +638,18 @@ export class OpenAICompatibleQuery implements ProviderQuery {
         stream: true,
         stream_options: { include_usage: true },
       };
+      // Thread the output-token cap into the streaming request so callers can
+      // bound output length (parity with Anthropic's always-forwarded
+      // max_tokens).  Reuses the o-series field-selection logic from
+      // oneshot.ts:91–96.
+      const maxTokensField = resolveStreamingMaxTokens(
+        this.currentModel,
+        this.opts.config.maxOutputTokens,
+      );
+      if (maxTokensField !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        Object.assign(requestBody, maxTokensField);
+      }
       // Only attach `tools` when the dispatcher actually has any — empty
       // arrays make some providers reject the request.
       if (this.openAITools && this.openAITools.length > 0) {

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -116,13 +116,13 @@ export function __setOpenAIClientFactory(factory: OpenAIClientFactory | null): v
  * wants `max_tokens`.  Strips any `provider/` prefix (OpenRouter-style ids)
  * before the regex check so `openai/o3` is treated the same as `o3`.
  *
- * Returns `undefined` when no cap is configured, so shims that reject the
- * field simply don't see it on the wire.
+ * Always returns an object containing the resolved cap; uses the model's
+ * output ceiling as a fallback so the field is always present on the wire.
  */
 function resolveStreamingMaxTokens(
   model: string,
   configMaxOutput: number | undefined,
-): Record<string, number> | undefined {
+): Record<string, number> {
   // Strip any `provider/` prefix (OpenRouter-style ids) before the o-series
   // regex — mirrors oneshot.ts:93.
   const bareModel = model.includes('/') ? model.slice(model.lastIndexOf('/') + 1) : model;
@@ -590,14 +590,11 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       // bound output length (parity with Anthropic's always-forwarded
       // max_tokens).  Reuses the o-series field-selection logic from
       // oneshot.ts:91–96.
-      const maxTokensField = resolveStreamingMaxTokens(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      Object.assign(requestBody, resolveStreamingMaxTokens(
         this.currentModel,
         this.opts.config.maxOutputTokens,
-      );
-      if (maxTokensField !== undefined) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        Object.assign(requestBody, maxTokensField);
-      }
+      ));
       // The private ChatGPT backend (subscription path) has two hard
       // requirements the public Responses API does not: a non-empty
       // `instructions`, and `store: false`. Scope both to that path so the
@@ -642,14 +639,11 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       // bound output length (parity with Anthropic's always-forwarded
       // max_tokens).  Reuses the o-series field-selection logic from
       // oneshot.ts:91–96.
-      const maxTokensField = resolveStreamingMaxTokens(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      Object.assign(requestBody, resolveStreamingMaxTokens(
         this.currentModel,
         this.opts.config.maxOutputTokens,
-      );
-      if (maxTokensField !== undefined) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        Object.assign(requestBody, maxTokensField);
-      }
+      ));
       // Only attach `tools` when the dispatcher actually has any — empty
       // arrays make some providers reject the request.
       if (this.openAITools && this.openAITools.length > 0) {


### PR DESCRIPTION
## Problem

The OpenAI-compatible provider's streaming path omitted any output-token cap, so normal turns relied on the upstream server's default.  The non-streaming `complete()` path correctly set `max_tokens`/`max_completion_tokens`, but the streaming `runIteration()` did not.

## Fix

- Adds `resolveStreamingMaxTokens()` that reuses the o-series field-selection logic from `oneshot.ts:91–96` (`max_tokens` for chat/local shims, `max_completion_tokens` for o-series).
- Threads the resolved cap into **both** the Chat Completions and Responses API streaming request bodies.
- Falls back to `maxOutputTokensFor()` (output ceiling, not context window) when `config.maxOutputTokens` is unset, matching Anthropic's `resolveMaxTokens()` behaviour.
- Strips `provider/` prefix (OpenRouter-style ids) before o-series detection.

## Tests

5 new unit tests in `query.test.ts`:
1. Default config includes `max_tokens` on Chat Completions streaming
2. Custom `maxOutputTokens` is honoured on Chat Completions streaming
3. o-series models get `max_completion_tokens` (not `max_tokens`)
4. o-series with custom `maxOutputTokens` uses `max_completion_tokens`
5. `provider/` prefix stripping before o-series detection (OpenRouter-style)

All 193 openai-compatible tests pass (42 in query.test.ts, 193 total).