### PR TITLE
feat(prompt): diagnostic-goal handling + commit-gate terminal-state invariant (port afk-workshop#808)

### DIFF
--- a/prompts/system-prompt.md
+++ b/prompts/system-prompt.md
@@ -101,6 +101,14 @@ When diagnosing and fixing code:
 - Ask only when the options differ materially in risk, user-facing behavior, irreversible or external effects, or long-term product direction.
 - Credential-sensitive means: exposing, rotating, persisting, transmitting, deleting, or altering credential sources. Passing an existing credential through an internal context is not credential-sensitive when the fix is reversible, additive, and testable.
 
+## Diagnostic-goal handling
+
+A goal phrased as a question — "why does X keep happening", "how come Y", "what causes Z" — asks for an explanation, not (only) a patch. The failure mode is silent substitution: reframing the diagnostic question into an implementation task, shipping a fix, and reporting success while the original "why" goes unanswered.
+
+- **Classify the goal before acting.** Diagnostic (interrogative: why / how come / what causes / why does X keep happening) versus imperative (fix / add / change / build). When the goal is diagnostic, the primary deliverable is the answer; a fix is secondary and follows from the diagnosis.
+- **Answer first.** Produce the root cause or explanation as an explicit artifact before writing any fix. For recurring behavior ("keeps happening"), inspect prior run outputs and artifacts before reading source — the signal is usually in the outputs, not the code.
+- **Surface reframes.** If you decide to implement rather than only explain, say so explicitly and tie the fix back to the diagnosed cause. Never report a diagnostic goal as satisfied when only a substituted implementation task was completed.
+
 ## Skill routing hints
 
 These skills fire automatically at specific points in the task lifecycle. Check each condition before the relevant phase begins.

--- a/src/agent/routing-directive.test.ts
+++ b/src/agent/routing-directive.test.ts
@@ -231,6 +231,18 @@ describe('assembleSystemPrompt', () => {
       expect(END_OF_TURN_DIRECTIVE).toContain('**Asking**');
       expect(END_OF_TURN_DIRECTIVE).toContain('**Interrupted**');
     });
+
+    it('carries the uncommitted-mutation guard in the Done block', () => {
+      // Regression guard for the commit-gate invariant (pattern card
+      // "world_changed && commits=0 leaves work in an unrecoverable
+      // intermediate state"). A Done state that claims clean completion while
+      // files were mutated but never committed is the failure this prevents.
+      // The check is self-observed: the agent reasons from its own in-turn
+      // tool history, because world_changes telemetry (facets/derive.ts) is
+      // computed post-session and is not visible to the model at turn-end.
+      expect(END_OF_TURN_DIRECTIVE).toMatch(/git commit/);
+      expect(END_OF_TURN_DIRECTIVE).toMatch(/uncommitted/i);
+    });
   });
 
   describe('end-to-end contract with parseTerminalState', () => {

--- a/src/agent/routing-directive.ts
+++ b/src/agent/routing-directive.ts
@@ -107,6 +107,7 @@ Every turn must end in one externally identifiable terminal state. AFK users nee
 - Evidence that exists, named by a durable location (file path, commit SHA, trace path, test output, or memory key) — never transcript-only
 - What changed in the world
 - Anything still pending or deferred, with why
+- If files were written or edited but no \`git commit\` ran, say so explicitly — name the uncommitted paths and why (e.g. awaiting review); do not imply clean completion while the work sits uncommitted in the worktree.
 
 **Blocked**
 - What blocks


### PR DESCRIPTION
## Source

Port of **afk-workshop#808** — `feat(prompt): diagnostic-goal handling + commit-gate terminal-state invariant` (private repo). This is a moat-scrubbed port, not a 1:1 copy; the public mirror has unrelated history, so it was applied via diff + 3-way, not cherry-pick.

Source PR: https://github.com/griffinwork40/afk-workshop/pull/808

## Ported (public-safe — all 3 hunks, +21/-0)

- **`prompts/system-prompt.md`** (+8): new `## Diagnostic-goal handling` section — classify interrogative ("why does X keep happening") vs imperative goals; answer/diagnose before patching; read prior run outputs before source; surface any explain→implement reframe. Guards the silent goal-substitution failure mode.
- **`src/agent/routing-directive.ts`** (+1): commit-gate bullet in the `END_OF_TURN_DIRECTIVE` **Done** block — if files were written/edited but no `git commit` ran, the Done state must say so explicitly rather than imply clean completion.
- **`src/agent/routing-directive.test.ts`** (+12): regression test pinning the commit-gate guard (`/git commit/` + `/uncommitted/i`) in `END_OF_TURN_DIRECTIVE`.

## Adapted during port (intent preserved, no clobber)

The `routing-directive.ts` hunk did **not** apply cleanly: public's `END_OF_TURN_DIRECTIVE` has independently evolved (enhanced evidence bullet "named by a durable location … never transcript-only", plus "Write each bullet as a single sentence"). The commit-gate bullet was hand-inserted **after** the existing Done bullets to preserve public's enhancements rather than overwrite them.

## Dropped (and why)

- The source commit **message** carried pattern-card provenance with internal scores/session-id (`(27/35)`, session `a415ba3a`, card filenames). This is **not** carried into the public commit — only the verbatim file changes are ported.
- No source **file content** required scrubbing. The only moat-adjacent token in the diff is "pattern card" in a test comment, which is **already-disclosed public vocabulary** (`AFK.md`, `CLAUDE.md`, `docs/tui-invariants.md`, `src/cli/…`) and carries no score/session-id/denylist term → kept. The referenced `src/agent/facets/derive.ts` already exists in this repo.

## Verification

- `pnpm lint` (tsc --noEmit, strict) ✅
- `pnpm fix:pins:check` → "All hash pins are up to date" ✅
- `pnpm build` ✅ · `pnpm build:dist` ✅ (`system-prompt.md` inlined; build-scrub reported `0 files scrubbed`)
- Ported test file `routing-directive.test.ts` → **38/38 pass** (incl. the new commit-gate guard, verified against public's already-evolved directive).
- **Deterministic moat guard (tree + built `dist/`): MOAT GUARD CLEAN** — zero HARD-denylist hits, no structural moat paths, no merge-conflict markers.
- **Independent adversarial audit: AUDIT CLEAN** — re-derived from scratch (did not trust the deterministic guard); confirmed all hunks clean and that "pattern card" / `facets/derive.ts` are already-public references.

## ⚠️ Pre-existing baseline failures — NOT introduced by this port

A full `pnpm test` run shows **2 failures**, both **proven identical on clean public HEAD (v4.11.2)** via `git stash` + rerun, in files this port does **not** touch and that are unrelated to prompt handling:

- `src/cli/config.test.ts > Config Loader > model slots > defaults to the built-in tier bindings when no models block is present`
- `src/agent/providers/anthropic-direct.test.ts > compact() …` — `expected 'claude-haiku-4-5' to be 'claude-haiku-4-5-20251001'` (model-id alias drift)

These are baseline issues for a maintainer to address separately. They are flagged here for full transparency and do **not** reflect a regression from this 21-line, prompt-only change.

## Do not merge automatically

Maintainer-reviewed port. Please confirm the diff and the baseline-failure note before merging.
