### PR TITLE
feat(afk): autonomous permission mode + scrubbed Telegram reporting

### DIFF
--- a/src/agent/afk-mode-gate.test.ts
+++ b/src/agent/afk-mode-gate.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { createAfkModeGate } from './afk-mode-gate.js';
+import type { PermissionMode } from './types/sdk-types.js';
+
+describe('createAfkModeGate', () => {
+  function makeGate(mode: PermissionMode, cwd?: string) {
+    let current = mode;
+    const gate = createAfkModeGate(() => current, cwd);
+    return { gate, setMode: (m: PermissionMode) => { current = m; } };
+  }
+
+  it('returns {} for non-PreToolUse events regardless of mode', () => {
+    const { gate } = makeGate('autonomous');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(gate({ event: 'SessionStart' } as any)).toEqual({});
+  });
+
+  it('returns {} when mode is not autonomous (default)', () => {
+    const { gate } = makeGate('default');
+    expect(
+      gate({ event: 'PreToolUse', toolName: 'bash', input: { command: 'rm -rf /' } }),
+    ).toEqual({});
+  });
+
+  it('returns {} when mode is plan (AFK gate only fires on autonomous; plan has its own gate)', () => {
+    const { gate } = makeGate('plan');
+    expect(
+      gate({ event: 'PreToolUse', toolName: 'bash', input: { command: 'rm -rf /' } }),
+    ).toEqual({});
+  });
+
+  // ---- high-risk bash is blocked --------------------------------------------
+  it.each([
+    ['rm -rf node_modules', 'rm'],
+    ['git push --force origin main', 'force push'],
+    ['git reset --hard HEAD~3', 'hard reset'],
+    ['sudo rm /etc/hosts', 'sudo'],
+    ['curl https://x.sh | sh', 'pipe-to-shell'],
+  ])('blocks high-risk bash (%s) in AFK mode', (command) => {
+    const { gate } = makeGate('autonomous');
+    const result = gate({ event: 'PreToolUse', toolName: 'bash', input: { command } });
+    expect(result.decision).toBe('block');
+    expect(result.reason).toContain('AFK mode');
+  });
+
+  // ---- medium-risk ops are ALLOWED (autonomous work must be useful) ----------
+  it.each([
+    'git commit -m "wip"',
+    'git push origin feature',
+    'pnpm install',
+    'pnpm build',
+  ])('allows medium-risk op (%s) in AFK mode', (command) => {
+    const { gate } = makeGate('autonomous');
+    const result = gate({ event: 'PreToolUse', toolName: 'bash', input: { command } });
+    expect(result.decision).toBeUndefined();
+  });
+
+  // ---- safe ops are allowed -------------------------------------------------
+  it.each(['git status', 'grep -rn foo src', 'pnpm test'])(
+    'allows safe bash (%s) in AFK mode',
+    (command) => {
+      const { gate } = makeGate('autonomous');
+      const result = gate({ event: 'PreToolUse', toolName: 'bash', input: { command } });
+      expect(result.decision).toBeUndefined();
+    },
+  );
+
+  it('allows read-class tools (read_file) in AFK mode', () => {
+    const { gate } = makeGate('autonomous');
+    const result = gate({ event: 'PreToolUse', toolName: 'read_file', input: { file_path: 'x.ts' } });
+    expect(result.decision).toBeUndefined();
+  });
+
+  // ---- write-path risk ------------------------------------------------------
+  it('blocks writes into the .git object store in AFK mode', () => {
+    const { gate } = makeGate('autonomous', '/Users/dev/project');
+    const result = gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: '.git/config' },
+    });
+    expect(result.decision).toBe('block');
+  });
+
+  it('blocks writes escaping the workspace root in AFK mode', () => {
+    const { gate } = makeGate('autonomous', '/Users/dev/project');
+    const result = gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: '/etc/cron.d/evil' },
+    });
+    expect(result.decision).toBe('block');
+  });
+
+  it('allows an in-workspace write in AFK mode (reversible, useful work)', () => {
+    const { gate } = makeGate('autonomous', '/Users/dev/project');
+    const result = gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: 'src/feature.ts' },
+    });
+    expect(result.decision).toBeUndefined();
+  });
+
+  // ---- send_telegram is the channel: always exempt --------------------------
+  it('never blocks send_telegram in AFK mode (it is the operator channel)', () => {
+    const { gate } = makeGate('autonomous');
+    const result = gate({
+      event: 'PreToolUse',
+      toolName: 'send_telegram',
+      input: { message: 'Asking: should I deploy?' },
+    });
+    expect(result.decision).toBeUndefined();
+  });
+
+  // ---- KEY DIVERGENCE from plan gate: applies tree-wide (no subagent skip) ---
+  it('STILL blocks high-risk subagent tool calls in AFK mode (parentSessionId set)', () => {
+    // Unlike the plan-mode gate, AFK mode is a safety ceiling: an unwatched
+    // subagent running rm -rf is exactly the risk. It must be blocked too.
+    const { gate } = makeGate('autonomous');
+    const result = gate({
+      event: 'PreToolUse',
+      toolName: 'bash',
+      input: { command: 'rm -rf /' },
+      parentSessionId: 'parent-session-123',
+    });
+    expect(result.decision).toBe('block');
+  });
+
+  it('allows medium-risk subagent ops in AFK mode (skill worktree commits keep working)', () => {
+    const { gate } = makeGate('autonomous');
+    const result = gate({
+      event: 'PreToolUse',
+      toolName: 'bash',
+      input: { command: 'git commit -m "skill output"' },
+      parentSessionId: 'parent-session-123',
+    });
+    expect(result.decision).toBeUndefined();
+  });
+
+  it('getter-at-call-time: gate respects mode changes after construction', () => {
+    const { gate, setMode } = makeGate('autonomous');
+    expect(
+      gate({ event: 'PreToolUse', toolName: 'bash', input: { command: 'rm -rf x' } }).decision,
+    ).toBe('block');
+    setMode('default');
+    expect(
+      gate({ event: 'PreToolUse', toolName: 'bash', input: { command: 'rm -rf x' } }).decision,
+    ).toBeUndefined();
+  });
+});

--- a/src/agent/afk-mode-gate.ts
+++ b/src/agent/afk-mode-gate.ts
@@ -1,0 +1,88 @@
+/**
+ * AFK-mode gate hook factory.
+ *
+ * Returns a `HookHandler` that blocks high-risk / irreversible tool calls when
+ * the session is in `'autonomous'` (AFK) mode. The handler reads the current
+ * mode at call time (not at construction time), so toggling the mode
+ * mid-session is reflected immediately without reconstructing the registry.
+ *
+ * Why a mechanical gate at all: AFK mode raises the agent's autonomy precisely
+ * when no human is watching. The posture addendum
+ * ({@link module:agent/providers/anthropic-direct/afk-mode-addendum}) asks the
+ * model to stop at one-way doors, but posture text is not a safety mechanism.
+ * This gate is the enforcement half — it refuses the irreversible/destructive
+ * operations that must never run unattended on a model's say-so.
+ *
+ * Policy: the single source of truth for "how dangerous is this op" is
+ * {@link classifyRisk} (`risk-classifier.ts`) — the same taxonomy the status
+ * line and audit log use. AFK mode blocks anything it rates `'high'`:
+ *   - destructive/irreversible bash (`rm`, `sudo`, `git push --force`,
+ *     `git reset --hard`, `mkfs`/`dd`/`diskutil`, pipe-to-shell, `eval`,
+ *     `chmod`/`chown`)
+ *   - writes that escape the workspace, hit the write-denylist (`~/.ssh`,
+ *     `/etc`, …), or target the `.git` object store
+ * `'medium'` ops (normal `git push`/`git commit`, installs, builds, file moves)
+ * and `'safe'` ops (reads, tests, lint) are ALLOWED — autonomous work has to be
+ * useful, and these are reversible enough to run unattended.
+ *
+ * `send_telegram` is ALWAYS exempt: it is the operator's channel in AFK mode,
+ * and the posture explicitly relies on it to surface Asking states.
+ *
+ * Deliberate divergence from the plan-mode gate: this gate does NOT skip
+ * forked subagents (`context.parentSessionId`). Plan mode is a main-session
+ * conversation affordance, so its gate exempts subagents. AFK mode is a SAFETY
+ * ceiling — an unwatched subagent running `rm -rf` is exactly the risk the gate
+ * exists to stop — so the ceiling applies tree-wide. Medium ops (e.g. a skill's
+ * worktree commit) stay allowed, so this does not break skill flows; only
+ * high-risk ops are refused, in the parent and in every child alike.
+ *
+ * Like the plan-mode gate, the bash classification is a best-effort honesty
+ * guardrail, not a sandbox: bash is Turing-complete, so obfuscated writes can
+ * slip through. It catches the destructive shapes a cooperative model naturally
+ * emits and surfaces refusal so the operator can take over.
+ *
+ * @module agent/afk-mode-gate
+ */
+
+import type { HookContext, HookDecision } from './hooks.js';
+import type { PermissionMode } from './types/sdk-types.js';
+import { classifyRisk } from './risk-classifier.js';
+
+export function createAfkModeGate(
+  getMode: () => PermissionMode,
+  cwd?: string,
+): (context: HookContext) => HookDecision {
+  return function afkModeGate(context: HookContext): HookDecision {
+    if (context.event !== 'PreToolUse') return {};
+    // No subagent guard, on purpose: the safety ceiling applies tree-wide.
+    if (getMode() !== 'autonomous') return {};
+
+    const { toolName } = context;
+
+    // The operator's channel is never blocked — the posture relies on it to
+    // surface Asking states from an unattended run.
+    if (toolName === 'send_telegram') return {};
+
+    // Single source of truth for risk. `workspaceRoot` is set to the session
+    // cwd so writes that escape it are flagged `high` (classifyRisk's workspace
+    // boundary rule); falling back to process.cwd() when unknown.
+    const root = cwd ?? process.cwd();
+    const risk = classifyRisk(toolName, context.input, {
+      cwd: root,
+      workspaceRoot: root,
+    });
+
+    if (risk === 'high') {
+      return {
+        decision: 'block',
+        reason:
+          `AFK mode: ${toolName} is refused — this op is high-risk or ` +
+          `irreversible, and AFK mode runs autonomously without a human ` +
+          `watching. Push an Asking summary to Telegram (send_telegram) and ` +
+          `stop, or have the operator run /afk off and take over.`,
+      };
+    }
+
+    return {};
+  };
+}

--- a/src/agent/awareness/runtime-source.ts
+++ b/src/agent/awareness/runtime-source.ts
@@ -136,9 +136,12 @@ function bucketPermissionMode(raw: string): 'elevated' | 'default' {
     case 'auto':
       return 'elevated';
     default:
-      // `default`, `plan`, and any unrecognised value fall through here.
-      // Plan mode is restrictive, not elevated — the model observes its
-      // restrictions through real-time tool denials, not through this field.
+      // `default`, `plan`, `autonomous` (AFK), and any unrecognised value fall
+      // through here. Plan and AFK modes are RESTRICTIVE, not elevated — AFK
+      // adds a high-risk-op gate on top of default, it does not bypass
+      // permissions. The model observes those restrictions through real-time
+      // tool denials and its system-prompt posture addendum, not through this
+      // coarse anti-injection field (which exists to hide bypass/auto-accept).
       return 'default';
   }
 }

--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -10,6 +10,7 @@ import { createHookRegistry, type HookRegistry } from './hooks.js';
 import { shadowVerifyNudge } from './shadow-verify-nudge.js';
 import { MemoryStore, createMemorySessionEndHook } from './memory/index.js';
 import { createPlanModeGate } from './plan-mode-gate.js';
+import { createAfkModeGate } from './afk-mode-gate.js';
 import { cleanupComposeSpills } from './tools/compose-executor.js';
 import type { PermissionMode } from './types/sdk-types.js';
 import type { LoadedHooksConfig } from './hooks/config-loader.js';
@@ -40,6 +41,14 @@ export function createDefaultHookRegistry(
   const store = memoryStore ?? new MemoryStore();
   if (getPermissionMode !== undefined) {
     registry.register('PreToolUse', createPlanModeGate(getPermissionMode));
+    // AFK-mode safety ceiling. Reads the same mode getter; AFK ('autonomous')
+    // and plan are mutually exclusive permission modes, so at most one of the
+    // two gates ever fires for a given tool call. Unlike the plan gate, this
+    // one applies tree-wide (no subagent exemption) — see afk-mode-gate.ts.
+    registry.register(
+      'PreToolUse',
+      createAfkModeGate(getPermissionMode, agentOptions?.cwd),
+    );
   }
   registry.register('SessionEnd', createMemorySessionEndHook(store, surface));
   // Clean up compose-truncation spill files when the session ends. Files

--- a/src/agent/providers/anthropic-direct/afk-mode-addendum.test.ts
+++ b/src/agent/providers/anthropic-direct/afk-mode-addendum.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for `afk-mode-addendum.ts`.
+ *
+ * Verifies the pure builder activates only for `'autonomous'` mode and that
+ * the addendum text encodes the bounded-autonomy posture (regression guard
+ * against accidental message drift toward unchecked "YOLO" autonomy).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  AFK_MODE_ADDENDUM_TEXT,
+  buildAfkModeAddendumBlock,
+} from './afk-mode-addendum.js';
+
+describe('afk-mode-addendum', () => {
+  describe('buildAfkModeAddendumBlock', () => {
+    it('returns null for default mode', () => {
+      expect(buildAfkModeAddendumBlock('default')).toBeNull();
+    });
+
+    it('returns null for undefined mode', () => {
+      expect(buildAfkModeAddendumBlock(undefined)).toBeNull();
+    });
+
+    it('returns null for plan mode (mutually exclusive — plan has its own addendum)', () => {
+      expect(buildAfkModeAddendumBlock('plan')).toBeNull();
+    });
+
+    it('returns null for other permission modes', () => {
+      expect(buildAfkModeAddendumBlock('bypassPermissions')).toBeNull();
+      expect(buildAfkModeAddendumBlock('acceptEdits')).toBeNull();
+      expect(buildAfkModeAddendumBlock('')).toBeNull();
+    });
+
+    it('returns a text block when mode is exactly "autonomous"', () => {
+      const block = buildAfkModeAddendumBlock('autonomous');
+      expect(block).not.toBeNull();
+      expect(block).toMatchObject({ type: 'text', text: AFK_MODE_ADDENDUM_TEXT });
+    });
+
+    it('does not stamp cache_control on its own block', () => {
+      const block = buildAfkModeAddendumBlock('autonomous');
+      expect(block).not.toBeNull();
+      expect(block as { cache_control?: unknown }).not.toHaveProperty('cache_control');
+    });
+
+    it('is case-sensitive — "Autonomous" does not activate', () => {
+      expect(buildAfkModeAddendumBlock('Autonomous')).toBeNull();
+      expect(buildAfkModeAddendumBlock('AUTONOMOUS')).toBeNull();
+    });
+  });
+
+  describe('AFK_MODE_ADDENDUM_TEXT', () => {
+    it('declares AFK mode is active', () => {
+      expect(AFK_MODE_ADDENDUM_TEXT.toLowerCase()).toContain('afk mode');
+    });
+
+    it('names Telegram + send_telegram as the operator channel', () => {
+      expect(AFK_MODE_ADDENDUM_TEXT).toContain('Telegram');
+      expect(AFK_MODE_ADDENDUM_TEXT).toContain('send_telegram');
+    });
+
+    it('encodes bounded autonomy — proceed on reversible, stop at one-way doors', () => {
+      // Regression guard: the posture must remain BOUNDED. If these markers
+      // drift the addendum risks becoming an unchecked-autonomy ("YOLO")
+      // directive, which is the exact failure mode the mechanical gate + this
+      // text are designed to prevent.
+      const text = AFK_MODE_ADDENDUM_TEXT.toLowerCase();
+      expect(text).toContain('reversible');
+      expect(text).toMatch(/irreversible|one-way door/);
+      expect(text).toContain('asking');
+    });
+
+    it('defers to the mechanical gate (posture is not the safety mechanism)', () => {
+      expect(AFK_MODE_ADDENDUM_TEXT.toLowerCase()).toContain('gate');
+    });
+
+    it('directs the model to report terminal state at end of turn', () => {
+      expect(AFK_MODE_ADDENDUM_TEXT.toLowerCase()).toContain('terminal state');
+    });
+
+    it('names /afk off as the exit affordance', () => {
+      expect(AFK_MODE_ADDENDUM_TEXT).toContain('/afk off');
+    });
+  });
+});

--- a/src/agent/providers/anthropic-direct/afk-mode-addendum.ts
+++ b/src/agent/providers/anthropic-direct/afk-mode-addendum.ts
@@ -1,0 +1,59 @@
+/**
+ * AFK-mode system-prompt addendum.
+ *
+ * When the session is in `'autonomous'` permission mode (AFK mode), this module
+ * supplies a single text block that the provider's `composeSystem()` appends to
+ * the system payload. The addendum is the *posture* half of AFK mode — its
+ * companion is the hook-layer refusal in {@link module:agent/afk-mode-gate},
+ * which is the *enforcement* half (the mechanical safety ceiling).
+ *
+ * Design notes:
+ *  - The posture is **bounded autonomy, not YOLO.** It tells the model to act
+ *    on reversible work without waiting, but to STOP at one-way doors
+ *    (irreversible / external / genuinely ambiguous forks) and surface an
+ *    Asking summary to Telegram instead of guessing. The text explicitly defers
+ *    to the gate: the model is told a mechanical layer refuses high-risk ops
+ *    regardless of what it decides, so it should not treat the posture as a
+ *    licence to bypass safety.
+ *  - The channel to the operator is Telegram via the `send_telegram` tool —
+ *    `send_telegram` is the one outbound op the gate never blocks.
+ *  - The block carries no `cache_control` of its own — `withSystemBreakpoint`
+ *    in `cache-policy.ts` floats the breakpoint to whichever block is last, so
+ *    toggling AFK mode busts the cache once (correct) and same-mode turns hit
+ *    cleanly. This mirrors the plan-mode addendum's cache behaviour exactly.
+ *  - AFK mode and plan mode are mutually exclusive permission modes, so at most
+ *    one of the two addenda is ever appended in a turn.
+ *
+ * @module agent/providers/anthropic-direct/afk-mode-addendum
+ */
+
+import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
+
+export const AFK_MODE_ADDENDUM_TEXT = [
+  '## AFK mode is active',
+  '',
+  'The operator is away from keyboard. Your channel to them is Telegram via the `send_telegram` tool — not this transcript, which no one is watching live. At the end of each turn, push your terminal state (Done / Blocked / Asking) to Telegram so the operator can review asynchronously.',
+  '',
+  'Posture — bounded autonomy, not unchecked action:',
+  '  - Proceed autonomously on reversible work. Do not stop to confirm actions you are already authorized to take and can undo (edits, reads, tests, local commits, non-force pushes, installs).',
+  '  - At a one-way door — anything irreversible, externally visible, credential- or payment-touching, or where multiple readings lead to materially different work — do NOT guess. Push a concise Asking summary to Telegram naming the decision and your recommended default, then stop and end the turn in the Asking state.',
+  '  - A mechanical gate refuses high-risk and irreversible operations at the hook layer regardless of this text. Treat a gate refusal as a signal to surface the decision to the operator, not an obstacle to work around.',
+  '',
+  'Communication discipline:',
+  '  - Batch updates. Send a Telegram message at terminal state (and at a genuinely blocking fork), not a play-by-play — the operator gets a push notification for every message.',
+  '  - Keep pushes short and scannable: what happened, what changed, what (if anything) you need. Never paste raw tool output, logs, secrets, or full file contents into a push.',
+  '',
+  'Exit: the operator returns and runs `/afk off` (or Shift+Tab) to restore default permissions and terminal-channel interaction.',
+].join('\n');
+
+/**
+ * Returns the addendum block when the session is in `'autonomous'` (AFK) mode,
+ * else `null`. The block is a plain text content block with no `cache_control`
+ * stamp (the breakpoint stamper handles cache markers).
+ */
+export function buildAfkModeAddendumBlock(
+  mode: string | undefined,
+): ContentBlockParam | null {
+  if (mode !== 'autonomous') return null;
+  return { type: 'text', text: AFK_MODE_ADDENDUM_TEXT };
+}

--- a/src/agent/providers/anthropic-direct/plan-mode-system-payload.test.ts
+++ b/src/agent/providers/anthropic-direct/plan-mode-system-payload.test.ts
@@ -25,6 +25,7 @@ import {
   __setAnthropicClientFactory,
 } from './index.js';
 import { PLAN_MODE_ADDENDUM_TEXT } from './plan-mode-addendum.js';
+import { AFK_MODE_ADDENDUM_TEXT } from './afk-mode-addendum.js';
 
 // --- Mock Anthropic Messages-API plumbing (mirrors query-auth-retry.test.ts) ---
 
@@ -186,6 +187,49 @@ describe('AnthropicDirectQuery — plan-mode system payload', () => {
     // Spot-check the topology + skill names made it through.
     expect(text).toContain('ground-state');
     expect(text).toContain('devils-advocate');
+  });
+
+  it('includes the AFK addendum (and NOT the plan addendum) when permission mode is autonomous', async () => {
+    const provider = new AnthropicDirectProvider();
+    const query = provider.query({
+      prompt: singleInput('hello'),
+      config: {
+        model: 'claude-sonnet-4-5-20250929',
+        apiKey: 'sk-ant-oat01-test',
+        permissionMode: 'autonomous',
+      },
+    });
+
+    await drainQuery(query);
+
+    expect(messagesCreateMock).toHaveBeenCalled();
+    const firstCall = messagesCreateMock.mock.calls[0]!;
+    const systemArg = (firstCall[0] as { system?: unknown }).system;
+    const text = extractSystemText(systemArg);
+    expect(text).toContain(AFK_MODE_ADDENDUM_TEXT);
+    expect(text).toContain('AFK mode is active');
+    // Mutual exclusivity at the payload level: plan addendum must be absent.
+    expect(text).not.toContain(PLAN_MODE_ADDENDUM_TEXT);
+  });
+
+  it('omits the AFK addendum when permission mode is default', async () => {
+    const provider = new AnthropicDirectProvider();
+    const query = provider.query({
+      prompt: singleInput('hello'),
+      config: {
+        model: 'claude-sonnet-4-5-20250929',
+        apiKey: 'sk-ant-oat01-test',
+        permissionMode: 'default',
+      },
+    });
+
+    await drainQuery(query);
+
+    const firstCall = messagesCreateMock.mock.calls[0]!;
+    const systemArg = (firstCall[0] as { system?: unknown }).system;
+    const text = extractSystemText(systemArg);
+    expect(text).not.toContain('AFK mode is active');
+    expect(text).not.toContain(AFK_MODE_ADDENDUM_TEXT);
   });
 
   it('appends the addendum as the LAST system block (cache breakpoint position)', async () => {

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -52,6 +52,7 @@ import {
   withSystemBreakpoint,
 } from './cache-policy.js';
 import { buildPlanModeAddendumBlock } from './plan-mode-addendum.js';
+import { buildAfkModeAddendumBlock } from './afk-mode-addendum.js';
 import { collectSkillEntries } from '../../tools/skill-bridge.js';
 import { contextLimitFor } from '../../model-limits.js';
 import { resolveModelId } from '../../session/model-resolution.js';
@@ -434,11 +435,14 @@ export class AnthropicDirectQuery implements ProviderQuery {
     if (userSys && userSys.length > 0) {
       blocks.push({ type: 'text', text: userSys });
     }
-    // Plan-mode posture: appended as the *last* block so the cache
-    // breakpoint stamper lands on it. Toggling plan mode mid-session busts
-    // the cache exactly once (correct); same-mode turns hit cleanly.
+    // Plan-mode / AFK-mode posture: appended as the *last* block so the cache
+    // breakpoint stamper lands on it. Toggling mode mid-session busts the cache
+    // exactly once (correct); same-mode turns hit cleanly. The two modes are
+    // mutually exclusive permission-mode values, so at most one block is added.
     const planBlock = buildPlanModeAddendumBlock(this.state.currentPermissionMode);
     if (planBlock !== null) blocks.push(planBlock);
+    const afkBlock = buildAfkModeAddendumBlock(this.state.currentPermissionMode);
+    if (afkBlock !== null) blocks.push(afkBlock);
     if (blocks.length === 0) return null;
     if (!isCacheEnabled({ baseUrl: this.baseUrl })) return blocks;
     return withSystemBreakpoint(blocks, getCacheTtl());

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -81,6 +81,7 @@ import type { ToolDispatcher } from '../anthropic-direct/tool-dispatcher.js';
 import type { ToolResult } from '../anthropic-direct/types.js';
 import { contextWindowTokensUsed, buildContextUsageFields } from '../anthropic-direct/query/auto-compact.js';
 import { PLAN_MODE_ADDENDUM_TEXT } from '../anthropic-direct/plan-mode-addendum.js';
+import { AFK_MODE_ADDENDUM_TEXT } from '../anthropic-direct/afk-mode-addendum.js';
 
 const PROVIDER_NAME = 'openai-compatible';
 
@@ -511,12 +512,19 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       vision,
     });
 
-    // Inject plan-mode posture addendum so the model understands write refusals.
-    if (this.currentPermissionMode === 'plan' && messages[0]?.role === 'system') {
-      messages[0] = {
-        ...messages[0],
-        content: (messages[0].content as string) + '\n\n' + PLAN_MODE_ADDENDUM_TEXT,
-      };
+    // Inject plan-mode / AFK-mode posture addendum onto the system message.
+    // The two are mutually exclusive permission modes, so at most one applies.
+    if (messages[0]?.role === 'system') {
+      const addendum =
+        this.currentPermissionMode === 'plan' ? PLAN_MODE_ADDENDUM_TEXT :
+        this.currentPermissionMode === 'autonomous' ? AFK_MODE_ADDENDUM_TEXT :
+        null;
+      if (addendum !== null) {
+        messages[0] = {
+          ...messages[0],
+          content: (messages[0].content as string) + '\n\n' + addendum,
+        };
+      }
     }
 
     const state = createStreamState();

--- a/src/agent/types/sdk-types.ts
+++ b/src/agent/types/sdk-types.ts
@@ -19,7 +19,12 @@ export type PermissionMode =
   | 'bypassPermissions'
   | 'plan'
   | 'dontAsk'
-  | 'auto';
+  | 'auto'
+  // AFK mode: the operator is away-from-keyboard. The agent reports terminal
+  // state to Telegram and works autonomously on reversible operations, while a
+  // mechanical gate (`agent/afk-mode-gate.ts`) refuses high-risk/irreversible
+  // ops. agent-afk-local addition (not from the upstream SDK union).
+  | 'autonomous';
 
 export type SettingSource = 'user' | 'project' | 'local';
 

--- a/src/cli/afk-mode-toggle.test.ts
+++ b/src/cli/afk-mode-toggle.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for the AFK-mode toggle helper.
+ *
+ * `toggleAfkMode` flips the session permission mode ('autonomous' <-> 'default'),
+ * mirrors the result onto `stats.permissionMode`, resets the per-session push
+ * budget on turn-ON, and preflights Telegram config (warns but still enters AFK
+ * mode when unconfigured). Mirrors plan-mode-toggle's failure semantics: leave
+ * permissionMode unchanged on a setPermissionMode rejection.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mutable Telegram-config state the mocks read.
+let mockToken: string | undefined = 'bot-token';
+let mockTargets: number[] = [123456];
+
+vi.mock('../config/env.js', () => ({
+  get env() {
+    return { TELEGRAM_BOT_TOKEN: mockToken };
+  },
+}));
+vi.mock('../telegram/notify-routing.js', () => ({
+  resolveConfiguredNotifyTargets: () => mockTargets,
+}));
+const resetAfkPushBudget = vi.fn();
+vi.mock('./commands/interactive/afk-push.js', () => ({
+  resetAfkPushBudget: () => resetAfkPushBudget(),
+}));
+
+import { toggleAfkMode } from './afk-mode-toggle.js';
+import type { SessionStats, SlashContext } from './slash/types.js';
+
+function makeStats(overrides: Partial<SessionStats> = {}): SessionStats {
+  return {
+    totalTurns: 0,
+    totalCostUsd: 0,
+    totalTokens: 0,
+    totalDurationMs: 0,
+    sessionStartTime: Date.now(),
+    turnCosts: [],
+    turnTokens: [],
+    turns: [],
+    model: 'sonnet',
+    permissionMode: 'default',
+    ...overrides,
+  };
+}
+
+function makeCtx(opts: {
+  stats: SessionStats;
+  setPermissionMode?: ReturnType<typeof vi.fn>;
+}): { ctx: SlashContext; sess: { setPermissionMode: ReturnType<typeof vi.fn> }; lines: string[] } {
+  const lines: string[] = [];
+  const sess = {
+    setPermissionMode: opts.setPermissionMode ?? vi.fn().mockResolvedValue(undefined),
+  };
+  const ctx: SlashContext = {
+    session: { current: sess } as unknown as SlashContext['session'],
+    stats: opts.stats,
+    out: {
+      line: (t = '') => lines.push(t),
+      raw: (t) => lines.push(t),
+      success: (t) => lines.push(`SUCCESS:${t}`),
+      info: (t) => lines.push(`INFO:${t}`),
+      warn: (t) => lines.push(`WARN:${t}`),
+      error: (t) => lines.push(`ERROR:${t}`),
+    },
+    ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
+  };
+  return { ctx, sess, lines };
+}
+
+describe('toggleAfkMode', () => {
+  beforeEach(() => {
+    mockToken = 'bot-token';
+    mockTargets = [123456];
+    resetAfkPushBudget.mockClear();
+  });
+
+  it('flips default → autonomous and emits ON copy', async () => {
+    const stats = makeStats({ permissionMode: 'default' });
+    const { ctx, sess, lines } = makeCtx({ stats });
+
+    await toggleAfkMode(ctx, true);
+
+    expect(sess.setPermissionMode).toHaveBeenCalledWith('autonomous');
+    expect(stats.permissionMode).toBe('autonomous');
+    expect(lines.join('\n').toLowerCase()).toContain('afk mode on');
+  });
+
+  it('resets the per-session push budget on turn-ON', async () => {
+    const { ctx } = makeCtx({ stats: makeStats() });
+    await toggleAfkMode(ctx, true);
+    expect(resetAfkPushBudget).toHaveBeenCalledTimes(1);
+  });
+
+  it('flips autonomous → default and emits OFF copy', async () => {
+    const stats = makeStats({ permissionMode: 'autonomous' });
+    const { ctx, sess, lines } = makeCtx({ stats });
+
+    await toggleAfkMode(ctx, false);
+
+    expect(sess.setPermissionMode).toHaveBeenCalledWith('default');
+    expect(stats.permissionMode).toBe('default');
+    expect(lines.join('\n').toLowerCase()).toContain('afk mode off');
+  });
+
+  it('warns but STILL enters AFK mode when Telegram is unconfigured', async () => {
+    mockToken = undefined;
+    mockTargets = [];
+    const stats = makeStats({ permissionMode: 'default' });
+    const { ctx, lines } = makeCtx({ stats });
+
+    await toggleAfkMode(ctx, true);
+
+    // Mode still flips — gate + posture apply regardless of Telegram.
+    expect(stats.permissionMode).toBe('autonomous');
+    const joined = lines.join('\n').toLowerCase();
+    expect(joined).toContain('telegram is not configured');
+    expect(lines.some((l) => l.startsWith('ERROR:'))).toBe(true);
+  });
+
+  it('does NOT warn about Telegram when fully configured', async () => {
+    const { ctx, lines } = makeCtx({ stats: makeStats() });
+    await toggleAfkMode(ctx, true);
+    expect(lines.join('\n').toLowerCase()).not.toContain('telegram is not configured');
+  });
+
+  it('leaves permissionMode unchanged and surfaces an error when setPermissionMode rejects', async () => {
+    const setPermissionMode = vi.fn().mockRejectedValue(new Error('boom'));
+    const stats = makeStats({ permissionMode: 'default' });
+    const { ctx, lines } = makeCtx({ stats, setPermissionMode });
+
+    await toggleAfkMode(ctx, true);
+
+    expect(setPermissionMode).toHaveBeenCalledWith('autonomous');
+    expect(stats.permissionMode).toBe('default');
+    expect(lines.some((l) => l.startsWith('ERROR:'))).toBe(true);
+  });
+});

--- a/src/cli/afk-mode-toggle.ts
+++ b/src/cli/afk-mode-toggle.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared toggle helper for AFK mode.
+ *
+ * `toggleAfkMode` is used by the `/afk` slash command and the AFK keybinding in
+ * the REPL input loop. It flips the session permission mode
+ * (`'autonomous'` <-> `'default'`) and mirrors the result onto
+ * `stats.permissionMode` — the value the REPL prompt, status line, and the
+ * plan/AFK gate getters all read.
+ *
+ * AFK ('autonomous') and plan modes are mutually exclusive permission-mode
+ * values held in one field, so turning AFK on from plan mode (or vice versa)
+ * simply replaces the mode — there is no separate AFK boolean to keep in sync.
+ *
+ * On turn-ON this helper:
+ *   - resets the per-session Telegram push budget (each AFK session starts
+ *     fresh — see afk-push.ts), and
+ *   - preflights Telegram config: if `TELEGRAM_BOT_TOKEN` or the chat allowlist
+ *     is unset it warns (and points at /telegram-setup) but still enters AFK
+ *     mode. The posture addendum and the safety gate apply regardless; only the
+ *     outbound push silently no-ops until Telegram is configured.
+ *
+ * If `setPermissionMode` rejects (e.g. the provider's query handle is closing
+ * or already torn down), `stats.permissionMode` is left unchanged and the
+ * failure is surfaced via `ctx.out.error` so the caller can detect a no-op flip.
+ */
+
+import { env } from '../config/env.js';
+import { resolveConfiguredNotifyTargets } from '../telegram/notify-routing.js';
+import { resetAfkPushBudget } from './commands/interactive/afk-push.js';
+import { palette } from './palette.js';
+import type { SlashContext } from './slash/types.js';
+
+/** True when Telegram outbound is fully configured (token + ≥1 chat target). */
+function isTelegramConfigured(): boolean {
+  if (!env.TELEGRAM_BOT_TOKEN) return false;
+  return resolveConfiguredNotifyTargets().length > 0;
+}
+
+export async function toggleAfkMode(
+  ctx: SlashContext,
+  desired?: boolean,
+): Promise<void> {
+  const current = ctx.stats.permissionMode === 'autonomous';
+  const next = desired !== undefined ? desired : !current;
+
+  try {
+    await ctx.session.current.setPermissionMode(next ? 'autonomous' : 'default');
+    ctx.stats.permissionMode = next ? 'autonomous' : 'default';
+    ctx.ui.repaintStatusLine();
+    if (next) {
+      resetAfkPushBudget();
+      ctx.out.success(
+        palette.info('◐ AFK mode ON') +
+        palette.dim(
+          ' — autonomous on reversible work; high-risk/irreversible ops are ' +
+          'refused; terminal states report to Telegram.',
+        ),
+      );
+      if (!isTelegramConfigured()) {
+        ctx.out.error(
+          'Telegram is not configured, so AFK updates will not be delivered. ' +
+          'Run /telegram-setup to connect a chat. (AFK posture + safety gate ' +
+          'still apply.)',
+        );
+      }
+    } else {
+      ctx.out.success(
+        palette.success('○ AFK mode OFF') + palette.dim(' — default permissions restored'),
+      );
+    }
+  } catch (err) {
+    ctx.out.error(
+      `Could not toggle AFK mode: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/src/cli/commands/chat.post.test.ts
+++ b/src/cli/commands/chat.post.test.ts
@@ -150,7 +150,7 @@ vi.mock('../slash/session-stats.js', () => ({
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   })),
   recordTurn: vi.fn(() => ({ user: '', assistant: '', timestamp: Date.now() })),
 }));

--- a/src/cli/commands/chat.resume.test.ts
+++ b/src/cli/commands/chat.resume.test.ts
@@ -49,7 +49,7 @@ const mockCreateSessionStats = vi.fn(() => ({
   turnTokens: [] as Array<{ input: number; output: number; cache: number }>,
   turns: [] as import('../slash/types.js').TurnRecord[],
   model: 'sonnet' as import('../../agent/types.js').AgentModelInput,
-  planMode: false,
+  permissionMode: 'default',
 }));
 const mockRecordTurn = vi.fn(() => ({
   user: '',
@@ -226,7 +226,7 @@ describe('afk chat — --resume / --continue / --session-id', () => {
       turnTokens: [],
       turns: [],
       model: 'sonnet',
-      planMode: false,
+      permissionMode: 'default',
     });
     mockRecordTurn.mockReturnValue({ user: '', assistant: '', timestamp: Date.now() });
     // Reset stdin to non-TTY so message args work without stdin logic firing.
@@ -363,7 +363,7 @@ describe('afk chat — --resume / --continue / --session-id', () => {
       turnTokens: [] as Array<{ input: number; output: number; cache: number }>,
       turns: [] as import('../slash/types.js').TurnRecord[],
       model: 'sonnet' as const,
-      planMode: false,
+      permissionMode: 'default',
     };
     mockCreateSessionStats.mockReturnValue(statsObj);
     // Simulate recordTurn incrementing totalTurns
@@ -394,7 +394,7 @@ describe('afk chat — --resume / --continue / --session-id', () => {
       turnTokens: [] as Array<{ input: number; output: number; cache: number }>,
       turns: [] as import('../slash/types.js').TurnRecord[],
       model: 'sonnet' as const,
-      planMode: false,
+      permissionMode: 'default',
     };
     mockCreateSessionStats.mockReturnValue(statsObj);
     mockRecordTurn.mockImplementation(() => {
@@ -424,7 +424,7 @@ describe('afk chat — --resume / --continue / --session-id', () => {
       turnTokens: [] as Array<{ input: number; output: number; cache: number }>,
       turns: [] as import('../slash/types.js').TurnRecord[],
       model: 'sonnet' as const,
-      planMode: false,
+      permissionMode: 'default',
     };
     mockCreateSessionStats.mockReturnValue(statsObj);
     mockRecordTurn.mockImplementation(() => {

--- a/src/cli/commands/chat.stdin.test.ts
+++ b/src/cli/commands/chat.stdin.test.ts
@@ -142,7 +142,7 @@ vi.mock('../slash/session-stats.js', () => ({
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   })),
   recordTurn: vi.fn(() => ({ user: '', assistant: '', timestamp: Date.now() })),
 }));

--- a/src/cli/commands/interactive/afk-push.test.ts
+++ b/src/cli/commands/interactive/afk-push.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  formatTerminalStateForTelegram,
+  pushTerminalStateToTelegram,
+  resetAfkPushBudget,
+  afkPushCount,
+  MAX_PUSHES_PER_SESSION,
+} from './afk-push.js';
+import type { TerminalState } from './terminal-state.js';
+
+function done(extra: Partial<TerminalState> = {}): TerminalState {
+  return { kind: 'done', rawBody: '', ...extra };
+}
+
+describe('formatTerminalStateForTelegram', () => {
+  it('renders a kind label header for each terminal state', () => {
+    expect(formatTerminalStateForTelegram(done())).toContain('AFK');
+    expect(formatTerminalStateForTelegram(done()).toLowerCase()).toContain('done');
+    expect(
+      formatTerminalStateForTelegram({ kind: 'blocked', rawBody: '' }).toLowerCase(),
+    ).toContain('blocked');
+    expect(
+      formatTerminalStateForTelegram({ kind: 'asking', rawBody: '' }).toLowerCase(),
+    ).toContain('asking');
+  });
+
+  it('includes the structured fields for the state kind', () => {
+    const msg = formatTerminalStateForTelegram(
+      done({ whatWasDone: 'migrated the field', evidence: 'src/x.ts:10', deferred: 'phase 2' }),
+    );
+    expect(msg).toContain('migrated the field');
+    expect(msg).toContain('src/x.ts:10');
+    expect(msg).toContain('phase 2');
+  });
+
+  it('is an allowlist by construction — only fields for THIS kind appear', () => {
+    // A done verdict that also (nonsensically) carries blocked/asking fields:
+    // the formatter must ignore the off-kind fields entirely.
+    const msg = formatTerminalStateForTelegram(
+      done({
+        whatWasDone: 'the real summary',
+        whatBlocks: 'SHOULD-NOT-APPEAR-blocked',
+        question: 'SHOULD-NOT-APPEAR-question',
+      }),
+    );
+    expect(msg).toContain('the real summary');
+    expect(msg).not.toContain('SHOULD-NOT-APPEAR');
+  });
+
+  it('scrubs secrets that leaked into a structured field', () => {
+    const msg = formatTerminalStateForTelegram(
+      done({ whatWasDone: 'set key sk-ant-abcdefgh12345678 in config' }),
+    );
+    expect(msg).not.toContain('sk-ant-abcdefgh12345678');
+    expect(msg).toContain('REDACTED');
+  });
+
+  it('falls back to rawBody only when no structured field is present', () => {
+    expect(formatTerminalStateForTelegram(done({ rawBody: 'fallback body text' }))).toContain(
+      'fallback body text',
+    );
+  });
+});
+
+describe('pushTerminalStateToTelegram — rate limiting', () => {
+  beforeEach(() => resetAfkPushBudget());
+
+  it('calls the push impl with the formatted message', async () => {
+    const push = vi.fn().mockResolvedValue(null);
+    await pushTerminalStateToTelegram(done({ whatWasDone: 'hello' }), push);
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(String(push.mock.calls[0]?.[0])).toContain('hello');
+    expect(afkPushCount()).toBe(1);
+  });
+
+  it('stops pushing after the per-session cap and sends exactly one mute notice', async () => {
+    const push = vi.fn().mockResolvedValue(null);
+    // Exhaust the budget.
+    for (let i = 0; i < MAX_PUSHES_PER_SESSION; i++) {
+      await pushTerminalStateToTelegram(done({ whatWasDone: `turn ${i}` }), push);
+    }
+    expect(push).toHaveBeenCalledTimes(MAX_PUSHES_PER_SESSION);
+
+    // Next call: a single "muted" notice, not the verdict.
+    await pushTerminalStateToTelegram(done({ whatWasDone: 'over budget' }), push);
+    expect(push).toHaveBeenCalledTimes(MAX_PUSHES_PER_SESSION + 1);
+    expect(String(push.mock.calls[MAX_PUSHES_PER_SESSION]?.[0]).toLowerCase()).toContain('muted');
+
+    // Further calls: silent (no more pushes).
+    await pushTerminalStateToTelegram(done({ whatWasDone: 'still over' }), push);
+    expect(push).toHaveBeenCalledTimes(MAX_PUSHES_PER_SESSION + 1);
+  });
+
+  it('resetAfkPushBudget restores a fresh budget', async () => {
+    const push = vi.fn().mockResolvedValue(null);
+    for (let i = 0; i < MAX_PUSHES_PER_SESSION; i++) {
+      await pushTerminalStateToTelegram(done(), push);
+    }
+    resetAfkPushBudget();
+    expect(afkPushCount()).toBe(0);
+    await pushTerminalStateToTelegram(done({ whatWasDone: 'fresh' }), push);
+    expect(afkPushCount()).toBe(1);
+  });
+
+  it('is best-effort — a throwing push impl never propagates', async () => {
+    const push = vi.fn().mockRejectedValue(new Error('network down'));
+    await expect(
+      pushTerminalStateToTelegram(done({ whatWasDone: 'x' }), push),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/cli/commands/interactive/afk-push.ts
+++ b/src/cli/commands/interactive/afk-push.ts
@@ -1,0 +1,143 @@
+/**
+ * AFK-mode terminal-state push.
+ *
+ * In AFK mode (`permissionMode === 'autonomous'`) the operator is away from
+ * keyboard and the transcript is unwatched. At the end of each turn the REPL
+ * pushes the turn's parsed terminal state to Telegram so the operator can
+ * review asynchronously. This module owns the *formatting*, *scrubbing*, and
+ * *rate-limiting* of that push; the trigger lives in `turn-handler.ts`.
+ *
+ * Two safety properties, both required by design (see `.afk/plans/afk-mode.md`):
+ *
+ *   1. Allowlist by construction. The message is built ONLY from the structured
+ *      fields of the parsed {@link TerminalState} (the Done/Blocked/Asking/
+ *      Interrupted bullets the model emitted). Raw tool output, full turn text,
+ *      logs, and file contents never enter the payload because this formatter
+ *      never reads them — it only ever sees the parsed verdict struct.
+ *   2. Secondary secret scrub. Even the structured fields are passed through
+ *      `redactInlineSecrets` before sending, so an API key the model happened to
+ *      echo into a bullet is masked before it leaves the machine over HTTPS.
+ *
+ * Rate limiting: at most one push per turn (one terminal state per turn) plus a
+ * per-AFK-session cap (`MAX_PUSHES_PER_SESSION`). On hitting the cap a single
+ * "further pushes muted" notice is sent, then pushes stop until the budget is
+ * reset (the `/afk` toggle resets it whenever AFK mode is switched ON, so each
+ * AFK session gets a fresh budget).
+ *
+ * @module cli/commands/interactive/afk-push
+ */
+
+import { redactInlineSecrets } from '../../../agent/session/prompt-dump.js';
+import { pushIfConfigured } from '../../../telegram/push.js';
+import type { TerminalState, TerminalKind } from './terminal-state.js';
+
+/** Per-AFK-session push budget. Generous enough for a long autonomous run,
+ *  low enough to bound notification flood if the model loops. */
+export const MAX_PUSHES_PER_SESSION = 20;
+
+const KIND_LABEL: Record<TerminalKind, string> = {
+  done: '✅ Done',
+  blocked: '⛔ Blocked',
+  asking: '❓ Asking',
+  interrupted: '⏸️ Interrupted',
+};
+
+// Ordered (label, field) pairs per kind. Only these structured fields are ever
+// read — this is the allowlist. `rawBody` is a last-resort fallback used only
+// when none of the structured fields were parsed.
+const KIND_FIELDS: Record<TerminalKind, ReadonlyArray<readonly [string, keyof TerminalState]>> = {
+  done: [
+    ['', 'whatWasDone'],
+    ['Evidence', 'evidence'],
+    ['Pending', 'deferred'],
+  ],
+  blocked: [
+    ['Blocked by', 'whatBlocks'],
+    ['Unblock', 'unblockCondition'],
+    ['Done so far', 'alreadyDone'],
+  ],
+  asking: [
+    ['', 'question'],
+    ['Resolves', 'assumption'],
+    ['Then', 'followup'],
+  ],
+  interrupted: [
+    ['', 'whatWasInProgress'],
+    ['State saved', 'stateLocation'],
+    ['Resume needs', 'resumeRequires'],
+  ],
+};
+
+/**
+ * Format a parsed terminal state into a compact, scannable Telegram message
+ * built strictly from structured fields, then scrub secrets. Returns the
+ * ready-to-send string (the caller decides whether to send).
+ */
+export function formatTerminalStateForTelegram(state: TerminalState): string {
+  const header = `🤖 AFK · ${KIND_LABEL[state.kind]}`;
+  const lines: string[] = [];
+  for (const [label, field] of KIND_FIELDS[state.kind]) {
+    const value = state[field];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      lines.push(label ? `• ${label}: ${value.trim()}` : `• ${value.trim()}`);
+    }
+  }
+  // Fallback: nothing structured parsed, but the parser found a verdict block.
+  // Use the model's own terminal-state body (not tool output) as a last resort.
+  if (lines.length === 0 && state.rawBody.trim().length > 0) {
+    lines.push(state.rawBody.trim());
+  }
+
+  const body = lines.length > 0 ? lines.join('\n') : '(no detail)';
+  // Secondary scrub over the assembled message — masks any secret the model
+  // echoed into a bullet before it leaves the machine.
+  return redactInlineSecrets(`${header}\n${body}`);
+}
+
+// ---------------------------------------------------------------------------
+// Rate limiting (per AFK session)
+// ---------------------------------------------------------------------------
+
+let pushCount = 0;
+let mutedNoticeSent = false;
+
+/** Reset the per-session push budget. Called when AFK mode is toggled ON so
+ *  each AFK session starts with a fresh budget. */
+export function resetAfkPushBudget(): void {
+  pushCount = 0;
+  mutedNoticeSent = false;
+}
+
+/** Test/inspection helper: current push count this AFK session. */
+export function afkPushCount(): number {
+  return pushCount;
+}
+
+/**
+ * Push the terminal state to Telegram if under budget. No-ops silently when
+ * Telegram is unconfigured (`pushIfConfigured` returns null). On reaching the
+ * cap, sends one "muted" notice then stops. Best-effort — never throws.
+ *
+ * `pushImpl` is injectable for tests; defaults to `pushIfConfigured`.
+ */
+export async function pushTerminalStateToTelegram(
+  state: TerminalState,
+  pushImpl: typeof pushIfConfigured = pushIfConfigured,
+): Promise<void> {
+  try {
+    if (pushCount >= MAX_PUSHES_PER_SESSION) {
+      if (!mutedNoticeSent) {
+        mutedNoticeSent = true;
+        await pushImpl(
+          `🤖 AFK · reached ${MAX_PUSHES_PER_SESSION} updates this session — ` +
+          `further terminal-state pushes muted. Run /afk off then /afk on to resume.`,
+        );
+      }
+      return;
+    }
+    pushCount += 1;
+    await pushImpl(formatTerminalStateForTelegram(state));
+  } catch {
+    // Outbound notification is best-effort; never let it break the turn.
+  }
+}

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -527,7 +527,7 @@ export async function bootstrapSession(
     (info) => { completionWriter.fn(formatSubagentCompletion(info)); },
     'cli',
     sharedMemoryStore,
-    () => (stats.planMode ? 'plan' : 'default'),
+    () => stats.permissionMode,
     loadHooksConfig({ cwd: extras?.cwd }),
     { cwd: extras?.cwd },
   ).registry;

--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -124,7 +124,7 @@ function makeCtx(): InteractiveCtx {
     stats: {
       totalTurns: 0,
       model: 'sonnet',
-      planMode: false,
+      permissionMode: 'default',
       sessionId: 'mock',
     },
     statusLine: {
@@ -137,7 +137,7 @@ function makeCtx(): InteractiveCtx {
     contextSampler: { onTurn: vi.fn(async () => {}), getRatio: () => undefined, refresh: vi.fn(async () => {}) },
     completionWriter: { fn: vi.fn(), idleFn: vi.fn() },
     replRenderer: { writeLine: vi.fn(), setCompositor: vi.fn() },
-    slashCtx: { stats: { planMode: false } },
+    slashCtx: { stats: { permissionMode: 'default' } },
     rl: { close: vi.fn() },
     options: { thinkingUi: undefined },
     inputSurfaceRef: { current: null },

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -185,7 +185,7 @@ export async function runInputLoop(
         // readLine echo path so scrollback parity holds).
         const queued = seedBuffer;
         seedBuffer = undefined;
-        const prompt = buildPrompt(ctx.stats.model, ctx.stats.planMode);
+        const prompt = buildPrompt(ctx.stats.model, ctx.stats.permissionMode);
         const echo = formatSubmittedEcho({
           buffer: queued.text,
           promptText: prompt,
@@ -201,7 +201,7 @@ export async function runInputLoop(
         // on non-TTY surfaces. Shift+Tab and onSigint are wired ONCE at
         // armCompositor time (above) — no need to re-pass per-call.
         const result = await surface.readLine({
-          promptFn: () => buildPrompt(ctx.stats.model, ctx.stats.planMode),
+          promptFn: () => buildPrompt(ctx.stats.model, ctx.stats.permissionMode),
           onSigint: sigintHandler,
           onShiftTab: () => {
             // Shift+Tab is the keyboard speed lane: a raw plan-mode flip with
@@ -491,7 +491,7 @@ export async function runInputLoop(
         // by armCompositor and the renderer's borrow skips this branch
         // — passing them anyway is a defensive belt-and-suspenders for
         // surfaces that haven't armed (e.g. a future test path).
-        surface.toRunTurnRefs(buildPrompt(ctx.stats.model, ctx.stats.planMode)),
+        surface.toRunTurnRefs(buildPrompt(ctx.stats.model, ctx.stats.permissionMode)),
       );
     }
 }

--- a/src/cli/commands/interactive/repl-loop-shared.ts
+++ b/src/cli/commands/interactive/repl-loop-shared.ts
@@ -1,4 +1,5 @@
 import { palette } from '../../palette.js';
+import type { PermissionMode } from '../../../agent/types/sdk-types.js';
 
 /**
  * Cross-phase state + helpers shared by the repl-loop orchestrator and its
@@ -55,8 +56,11 @@ export interface TurnState {
   requestSoftStop?: (() => void) | null;
 }
 
-export function buildPrompt(model: string, planMode: boolean): string {
+export function buildPrompt(model: string, mode: PermissionMode): string {
   const base = palette.brand('afk') + palette.dim(` (${model})`);
-  const marker = planMode ? palette.warning(' ● plan') : '';
+  const marker =
+    mode === 'plan' ? palette.warning(' ● plan') :
+    mode === 'autonomous' ? palette.info(' ◐ AFK') :
+    '';
   return base + marker + palette.dim('  › ');
 }

--- a/src/cli/commands/interactive/repl-loop-wiring.test.ts
+++ b/src/cli/commands/interactive/repl-loop-wiring.test.ts
@@ -135,7 +135,7 @@ function makeMinimalCtx(backgroundRegistry: BackgroundAgentRegistry): Interactiv
       turnTokens: [],
       turns: [],
       model: 'sonnet',
-      planMode: false,
+      permissionMode: 'default',
       sessionId: 'mock',
     },
     statusLine: {
@@ -147,7 +147,7 @@ function makeMinimalCtx(backgroundRegistry: BackgroundAgentRegistry): Interactiv
     contextSampler: { onTurn: vi.fn(async () => {}), getRatio: () => undefined },
     completionWriter: { fn: () => {}, idleFn: () => {} },
     replRenderer: { writeLine: vi.fn(), setCompositor: vi.fn() },
-    slashCtx: { stats: { planMode: false } },
+    slashCtx: { stats: { permissionMode: 'default' } },
     rl: { close: vi.fn() },
     options: { thinkingUi: undefined },
     backgroundRegistry,

--- a/src/cli/commands/interactive/resume-swap.test.ts
+++ b/src/cli/commands/interactive/resume-swap.test.ts
@@ -43,7 +43,7 @@ function makeStats(overrides: Partial<SessionStats> = {}): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
     ...overrides,
   };
 }
@@ -505,22 +505,22 @@ describe('performResumeSwap — waitForInitialization rejection', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests — stats.planMode reset on swap (LOW-12b)
+// Tests — stats.permissionMode reset on swap (LOW-12b)
 // ---------------------------------------------------------------------------
 
-describe('performResumeSwap — stats.planMode reset', () => {
-  it('resets stats.planMode to false on successful swap with stored session', async () => {
+describe('performResumeSwap — stats.permissionMode reset', () => {
+  it('resets stats.permissionMode to default on successful swap with stored session', async () => {
     const { deps, stats } = buildDeps();
-    stats.planMode = true;
+    stats.permissionMode = 'plan';
     await performResumeSwap(makeTarget('t-plan', makeStoredSession()), deps);
-    expect(stats.planMode).toBe(false);
+    expect(stats.permissionMode).toBe('default');
   });
 
-  it('resets stats.planMode to false on successful swap with no stored session', async () => {
+  it('resets stats.permissionMode to default on successful swap with no stored session', async () => {
     const { deps, stats } = buildDeps();
-    stats.planMode = true;
+    stats.permissionMode = 'plan';
     await performResumeSwap(makeTarget('bare-id'), deps);
-    expect(stats.planMode).toBe(false);
+    expect(stats.permissionMode).toBe('default');
   });
 });
 
@@ -563,7 +563,7 @@ describe('reseedStatsFromStored wiring — shared helper', () => {
     const stats = {
       totalTurns: 0, totalCostUsd: 0, totalTokens: 0, totalDurationMs: 0,
       sessionStartTime: 0, turnCosts: [], turnTokens: [], turns: [],
-      model: 'sonnet' as const, planMode: false,
+      model: 'sonnet' as const, permissionMode: 'default',
     } as import('../../slash/types.js').SessionStats;
     const stored: import('../../session-store.js').StoredSession = {
       model: 'opus', totalTurns: 5, totalCostUsd: 1.5, totalTokens: 30000,

--- a/src/cli/commands/interactive/resume-swap.ts
+++ b/src/cli/commands/interactive/resume-swap.ts
@@ -180,12 +180,12 @@ export async function performResumeSwap(
     deps.stats.turnCosts = [];
     deps.stats.turnTokens = [];
   }
-  // Reset plan-mode state — the incoming session starts in default mode.
-  // planMode is user-controlled state that does NOT persist in StoredSession
-  // (by design: it's a per-session UI toggle, not a durable preference).
-  // Carrying it forward would cause the resumed session to inherit an
-  // unexpected permission mode from the outgoing session.
-  deps.stats.planMode = false;
+  // Reset permission mode — the incoming session starts in default mode.
+  // permissionMode (plan / AFK) is user-controlled state that does NOT persist
+  // in StoredSession (by design: it's a per-session UI toggle, not a durable
+  // preference). Carrying it forward would cause the resumed session to inherit
+  // an unexpected permission mode from the outgoing session.
+  deps.stats.permissionMode = 'default';
 
   // Step 8 — Update ctx.resumeTarget for potential banner helpers.
   // Wrapped in try/catch so a misbehaving onSwapped handler cannot abort the

--- a/src/cli/commands/interactive/shared.test.ts
+++ b/src/cli/commands/interactive/shared.test.ts
@@ -27,7 +27,7 @@ function makeStats(turns: TurnRecord[]): SessionStats {
     turnTokens: [],
     turns,
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -30,7 +30,7 @@ export type { ResumeSwapResult } from '../../slash/types.js';
  * consistently.
  *
  * Callers own any fields that are NOT derived from the stored payload
- * (e.g. `cwd`, `planMode`, `turnCosts`, `turnTokens` on initial bootstrap
+ * (e.g. `cwd`, `permissionMode`, `turnCosts`, `turnTokens` on initial bootstrap
  * may be managed differently).
  */
 export function reseedStatsFromStored(
@@ -645,7 +645,7 @@ export function formatStatusFields(stats: SessionStats, sampler?: ContextSampler
     contextLimit,
     contextUsedTokens,
     contextSparkline,
-    planMode: stats.planMode,
+    permissionMode: stats.permissionMode,
     ...(stats.cwd !== undefined ? { cwd: stats.cwd } : {}),
   };
 }

--- a/src/cli/commands/interactive/surface-setup.ts
+++ b/src/cli/commands/interactive/surface-setup.ts
@@ -93,7 +93,7 @@ export async function setupSurface(
   // The caller's try block wraps this call so a rejection from armCompositor
   // still reaches the finally and surface.dispose() cleans up raw-mode stdin.
   await surface.armCompositor({
-    promptFn: () => buildPrompt(ctx.stats.model, ctx.stats.planMode),
+    promptFn: () => buildPrompt(ctx.stats.model, ctx.stats.permissionMode),
     // Stable cancel handler for both idle (between turns) and streaming
     // (mid-turn). handleSigint internally dispatches on `turnInFlight`:
     //   - In flight: session.interrupt() + arm "press Ctrl+C again to exit".

--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -31,7 +31,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -24,6 +24,7 @@ import { ringBellIfEnabled } from '../../_lib/capture-mode.js';
 import { runWithSink } from '../../../agent/_lib/skill-sink-channel.js';
 import { parseTerminalState, type TerminalState } from './terminal-state.js';
 import { renderVerdictCard } from './verdict-card.js';
+import { pushTerminalStateToTelegram } from './afk-push.js';
 import { buildUserPayload } from '../../slash/_lib/user-payload.js';
 import { expandAtFileTokens } from './at-file-inject.js';
 
@@ -530,6 +531,13 @@ export async function runTurn(
         writeAbove('');
         if (h.onTerminalState) {
           try { h.onTerminalState(verdict); } catch { /* ledger update is best-effort */ }
+        }
+        // AFK mode: the operator is away and the transcript is unwatched, so
+        // surface the terminal state to them over Telegram. Scrubbed + rate-
+        // limited (afk-push.ts); no-ops when Telegram is unconfigured.
+        // Fire-and-forget — outbound notification must never block the turn.
+        if (stats.permissionMode === 'autonomous') {
+          void pushTerminalStateToTelegram(verdict);
         }
       }
 

--- a/src/cli/input/input-surface.ts
+++ b/src/cli/input/input-surface.ts
@@ -104,7 +104,7 @@ export interface InputSurfaceReadOpts {
  * autocomplete state as the between-turn reader.
  *
  * `promptText` is supplied per-turn by the caller (not stored on the
- * surface) because it depends on the current `model + planMode` at
+ * surface) because it depends on the current `model + permissionMode` at
  * turn start, and the StreamRenderer is reconstructed per-turn anyway
  * — the string's lifetime matches the renderer's.
  */
@@ -491,7 +491,7 @@ export class InputSurface {
   /**
    * Build the refs bag passed to `runTurn` via the `inputSurface`
    * parameter. The promptText is supplied by the caller because it
-   * depends on the current model + planMode at turn start.
+   * depends on the current model + permissionMode at turn start.
    */
   toRunTurnRefs(promptText: string): InputSurfaceRefs {
     return {

--- a/src/cli/interactive-lifecycle.test.ts
+++ b/src/cli/interactive-lifecycle.test.ts
@@ -78,7 +78,7 @@ describe('interactive bootstrap status line hooks', () => {
     expect(registerAll).toHaveBeenCalledTimes(1);
 
     ctx.stats.model = 'opus';
-    ctx.stats.planMode = true;
+    ctx.stats.permissionMode = 'plan';
     ctx.stats.totalCostUsd = 1.25;
     ctx.stats.totalTokens = 2048;
 
@@ -91,7 +91,7 @@ describe('interactive bootstrap status line hooks', () => {
       contextLimit: 200000,
       contextUsedTokens: undefined,
       contextSparkline: undefined,
-      planMode: true,
+      permissionMode: 'plan',
       cwd: process.cwd(),
     });
 
@@ -126,7 +126,7 @@ describe('interactive bootstrap status line hooks', () => {
       contextLimit: 200000,
       contextUsedTokens: undefined,
       contextSparkline: undefined,
-      planMode: true,
+      permissionMode: 'plan',
       cwd: process.cwd(),
     });
     const clearCall = stdoutWrite.mock.invocationCallOrder[
@@ -337,7 +337,7 @@ describe('interactive command exit teardown', () => {
           turnTokens: [{ input: 256, output: 256, cache: 0 }],
           turns: [],
           model: 'sonnet',
-          planMode: false,
+          permissionMode: 'default',
           sessionId: 'sdk-exit',
         },
         statusLine,
@@ -497,7 +497,7 @@ describe('interactive worktree flag', () => {
         turnTokens: [],
         turns: [],
         model: 'sonnet',
-        planMode: false,
+        permissionMode: 'default',
       },
       statusLine,
       slashCtx: {
@@ -668,7 +668,7 @@ describe('interactive worktree flag', () => {
           ],
           turns: [],
           model: 'claude-opus-4',
-          planMode: false,
+          permissionMode: 'default',
           sessionId: 'item8-test',
         },
         statusLine,
@@ -772,7 +772,7 @@ describe('interactive worktree flag', () => {
           turnTokens: [],
           turns: [],
           model: 'sonnet',
-          planMode: false,
+          permissionMode: 'default',
         },
         statusLine,
         slashCtx: {
@@ -896,7 +896,7 @@ describe('interactive signal-handler wiring (PR #486)', () => {
           turnTokens: [],
           turns: [],
           model: 'sonnet',
-          planMode: false,
+          permissionMode: 'default',
         },
         statusLine,
         slashCtx: { ui: { repaintStatusLine } } as never,

--- a/src/cli/plan-mode-toggle.test.ts
+++ b/src/cli/plan-mode-toggle.test.ts
@@ -2,11 +2,11 @@
  * Unit tests for the plan-mode toggle helper.
  *
  * `togglePlanMode` flips the session permission mode ('plan' <-> 'default'),
- * mirrors the result onto `stats.planMode`, and emits the ON/OFF copy. It is
+ * mirrors the result onto `stats.permissionMode`, and emits the ON/OFF copy. It is
  * the shared primitive behind both the /plan slash command and the Shift+Tab
  * keybinding. The exit-and-implement behavior lives in the slash command
  * (`slash/commands/plan.ts`), not here — this file covers the raw flip,
- * including its failure semantics (leave planMode unchanged on rejection).
+ * including its failure semantics (leave permissionMode unchanged on rejection).
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -24,7 +24,7 @@ function makeStats(overrides: Partial<SessionStats> = {}): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
     ...overrides,
   };
 }
@@ -59,52 +59,52 @@ function makeCtx(opts: {
 
 describe('togglePlanMode', () => {
   it('flips default → plan and emits ON copy', async () => {
-    const stats = makeStats({ planMode: false });
+    const stats = makeStats({ permissionMode: 'default' });
     const { ctx, sess, lines } = makeCtx({ stats });
 
     await togglePlanMode(ctx, true);
 
     expect(sess.setPermissionMode).toHaveBeenCalledWith('plan');
-    expect(stats.planMode).toBe(true);
+    expect(stats.permissionMode).toBe('plan');
     const joined = lines.join('\n').toLowerCase();
     expect(joined).toContain('plan mode on');
   });
 
   it('flips plan → default and emits OFF copy', async () => {
-    const stats = makeStats({ planMode: true });
+    const stats = makeStats({ permissionMode: 'plan' });
     const { ctx, sess, lines } = makeCtx({ stats });
 
     await togglePlanMode(ctx, false);
 
     expect(sess.setPermissionMode).toHaveBeenCalledWith('default');
-    expect(stats.planMode).toBe(false);
+    expect(stats.permissionMode).toBe('default');
     const joined = lines.join('\n').toLowerCase();
     expect(joined).toContain('plan mode off');
     expect(joined).toContain('default permissions restored');
   });
 
   it('toggles based on current mode when no explicit desired is passed', async () => {
-    const stats = makeStats({ planMode: true });
+    const stats = makeStats({ permissionMode: 'plan' });
     const { ctx, sess } = makeCtx({ stats });
 
     await togglePlanMode(ctx);
 
     expect(sess.setPermissionMode).toHaveBeenCalledWith('default');
-    expect(stats.planMode).toBe(false);
+    expect(stats.permissionMode).toBe('default');
   });
 
-  it('leaves planMode unchanged and surfaces an error when setPermissionMode rejects', async () => {
+  it('leaves permissionMode unchanged and surfaces an error when setPermissionMode rejects', async () => {
     // The provider's query handle can reject (closing or torn down). The
-    // helper must NOT advance stats.planMode — callers (e.g. /plan off) read
+    // helper must NOT advance stats.permissionMode — callers (e.g. /plan off) read
     // it back to decide whether to seed a follow-up turn.
     const setPermissionMode = vi.fn().mockRejectedValue(new Error('boom'));
-    const stats = makeStats({ planMode: true });
+    const stats = makeStats({ permissionMode: 'plan' });
     const { ctx, lines } = makeCtx({ stats, setPermissionMode });
 
     await togglePlanMode(ctx, false);
 
     expect(setPermissionMode).toHaveBeenCalledWith('default');
-    expect(stats.planMode).toBe(true);
+    expect(stats.permissionMode).toBe('plan');
     expect(lines.some((l) => l.startsWith('ERROR:'))).toBe(true);
   });
 });

--- a/src/cli/plan-mode-toggle.ts
+++ b/src/cli/plan-mode-toggle.ts
@@ -5,7 +5,7 @@
  * keybinding in the REPL input loop. Both paths emit identical copy and
  * update the same stats/status-line plumbing. It flips the session permission
  * mode (`'plan'` <-> `'default'`) and mirrors the result onto
- * `stats.planMode` — the value the REPL prompt and status line read.
+ * `stats.permissionMode` — the value the REPL prompt and status line read.
  *
  * Exit semantics differ by entry point and live in the callers, not here:
  *   - `/plan off` (slash command) flips to default, then seeds a turn that
@@ -14,8 +14,8 @@
  *     "exit without implementing" escape hatch.
  *
  * If `setPermissionMode` rejects (e.g. the provider's query handle is closing
- * or already torn down), `stats.planMode` is left unchanged and the failure is
- * surfaced via `ctx.out.error` so the caller can detect a no-op flip.
+ * or already torn down), `stats.permissionMode` is left unchanged and the
+ * failure is surfaced via `ctx.out.error` so the caller can detect a no-op flip.
  */
 
 import { palette } from './palette.js';
@@ -27,12 +27,12 @@ export async function togglePlanMode(
   ctx: SlashContext,
   desired?: boolean,
 ): Promise<void> {
-  const current = ctx.stats.planMode;
+  const current = ctx.stats.permissionMode === 'plan';
   const next = desired !== undefined ? desired : !current;
 
   try {
     await ctx.session.current.setPermissionMode(next ? 'plan' : 'default');
-    ctx.stats.planMode = next;
+    ctx.stats.permissionMode = next ? 'plan' : 'default';
     ctx.ui.repaintStatusLine();
     if (next) {
       const tip = hasShownFirstUseTip

--- a/src/cli/session-stats.test.ts
+++ b/src/cli/session-stats.test.ts
@@ -11,7 +11,7 @@ describe('session-stats', () => {
     expect(s.totalTurns).toBe(0);
     expect(s.totalCostUsd).toBe(0);
     expect(s.model).toBe('sonnet');
-    expect(s.planMode).toBe(false);
+    expect(s.permissionMode).toBe('default');
     expect(s.turns).toEqual([]);
     expect(s.sessionStartTime).toBeGreaterThan(0);
   });
@@ -231,9 +231,9 @@ describe('resetStats', () => {
     expect(s.turnTokens).toBe(tokensRef);
   });
 
-  it('drops sessionId but preserves model and planMode', () => {
+  it('drops sessionId but preserves model and permissionMode', () => {
     const s = createSessionStats('sonnet');
-    s.planMode = true;
+    s.permissionMode = 'plan';
     recordTurn(s, 'q', 'a', {
       totalCostUsd: 0,
       durationMs: 0,
@@ -244,7 +244,7 @@ describe('resetStats', () => {
     resetStats(s);
     expect(s.sessionId).toBeUndefined();
     expect(s.model).toBe('sonnet');
-    expect(s.planMode).toBe(true);
+    expect(s.permissionMode).toBe('plan');
   });
 
   it('drops the auto-derived name so the next conversation re-derives its own', () => {

--- a/src/cli/slash-commands.test.ts
+++ b/src/cli/slash-commands.test.ts
@@ -27,7 +27,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 
@@ -388,7 +388,7 @@ describe('/plan', () => {
     const { ctx } = makeCtx({ session: { current: sess } as unknown as SlashContext['session'] });
     await dispatch('/plan on', ctx);
     expect(sess.setPermissionMode).toHaveBeenCalledWith('plan');
-    expect(ctx.stats.planMode).toBe(true);
+    expect(ctx.stats.permissionMode).toBe('plan');
     expect(ctx.ui.repaintStatusLine).toHaveBeenCalledTimes(1);
   });
 
@@ -396,7 +396,7 @@ describe('/plan', () => {
     const sess = fakeSession();
     const { ctx } = makeCtx({ session: { current: sess } as unknown as SlashContext['session'] });
     const res = await dispatch('/plan', ctx);
-    expect(ctx.stats.planMode).toBe(true);
+    expect(ctx.stats.permissionMode).toBe('plan');
     expect(res.result).toBe('continue');
   });
 
@@ -406,20 +406,20 @@ describe('/plan', () => {
     const res = await dispatch('/plan list all files', ctx);
     expect(res.handled).toBe(true);
     expect(sess.setPermissionMode).toHaveBeenCalledWith('plan');
-    expect(ctx.stats.planMode).toBe(true);
+    expect(ctx.stats.permissionMode).toBe('plan');
     expect(res.result).toEqual({ kind: 'submit', message: 'list all files' });
   });
 
   it('/plan <free text> while already in plan mode returns submit without toggling off', async () => {
     const sess = fakeSession();
     const stats = makeStats();
-    stats.planMode = true;
+    stats.permissionMode = 'plan';
     const { ctx } = makeCtx({ session: { current: sess } as unknown as SlashContext['session'], stats });
     const res = await dispatch('/plan list all files', ctx);
     expect(res.handled).toBe(true);
     // setPermissionMode should NOT be called again (already in plan mode)
     expect(sess.setPermissionMode).not.toHaveBeenCalled();
-    expect(ctx.stats.planMode).toBe(true);
+    expect(ctx.stats.permissionMode).toBe('plan');
     expect(res.result).toEqual({ kind: 'submit', message: 'list all files' });
   });
 
@@ -449,7 +449,7 @@ describe('/plan', () => {
     it('/plan off while in plan mode flips to default FIRST, then seeds a save-and-implement turn', async () => {
       const sess = fakeSession();
       const stats = makeStats();
-      stats.planMode = true;
+      stats.permissionMode = 'plan';
       const { ctx } = makeCtx({ session: { current: sess } as unknown as SlashContext['session'], stats });
 
       const res = await dispatch('/plan off', ctx);
@@ -457,7 +457,7 @@ describe('/plan', () => {
       // The flip MUST happen before the turn so writes are permitted when the
       // seeded message runs (the model has to write the plan file + implement).
       expect(sess.setPermissionMode).toHaveBeenCalledWith('default');
-      expect(ctx.stats.planMode).toBe(false);
+      expect(ctx.stats.permissionMode).toBe('default');
 
       // A submit turn is seeded.
       expect(res.handled).toBe(true);
@@ -475,32 +475,32 @@ describe('/plan', () => {
     it('bare /plan while in plan mode also exits and seeds save-and-implement', async () => {
       const sess = fakeSession();
       const stats = makeStats();
-      stats.planMode = true;
+      stats.permissionMode = 'plan';
       const { ctx } = makeCtx({ session: { current: sess } as unknown as SlashContext['session'], stats });
 
       const res = await dispatch('/plan', ctx);
 
       expect(sess.setPermissionMode).toHaveBeenCalledWith('default');
-      expect(ctx.stats.planMode).toBe(false);
+      expect(ctx.stats.permissionMode).toBe('default');
       expect(submitKind(res)).toBe('submit');
       expect(submitMessage(res)).toContain('.afk/plans');
     });
 
     it('does NOT seed an implement turn when the flip fails (writes still refused)', async () => {
-      // If setPermissionMode rejects, togglePlanMode leaves planMode true and
+      // If setPermissionMode rejects, togglePlanMode leaves permissionMode plan and
       // surfaces an error. Seeding an implement turn while writes are refused
       // would only produce gate refusals — so the handler returns 'continue'.
       const sess = fakeSession({
         setPermissionMode: vi.fn().mockRejectedValue(new Error('handle closing')),
       });
       const stats = makeStats();
-      stats.planMode = true;
+      stats.permissionMode = 'plan';
       const { ctx } = makeCtx({ session: { current: sess } as unknown as SlashContext['session'], stats });
 
       const res = await dispatch('/plan off', ctx);
 
       expect(sess.setPermissionMode).toHaveBeenCalledWith('default');
-      expect(ctx.stats.planMode).toBe(true);
+      expect(ctx.stats.permissionMode).toBe('plan');
       expect(res.result).toBe('continue');
     });
 
@@ -511,7 +511,7 @@ describe('/plan', () => {
       // togglePlanMode sets 'default' — already default, harmless, emits OFF copy.
       // No submit turn: there is no plan to save when not in plan mode.
       expect(sess.setPermissionMode).toHaveBeenCalledWith('default');
-      expect(ctx.stats.planMode).toBe(false);
+      expect(ctx.stats.permissionMode).toBe('default');
       expect(res.result).toBe('continue');
     });
   });

--- a/src/cli/slash-registry.test.ts
+++ b/src/cli/slash-registry.test.ts
@@ -32,7 +32,7 @@ function fakeCtx(): SlashContext {
       turnTokens: [],
       turns: [],
       model: 'sonnet',
-      planMode: false,
+      permissionMode: 'default',
     },
     out: {
       line: (t = '') => lines.push(t),

--- a/src/cli/slash/_lib/run-skill-dispatch-turn.test.ts
+++ b/src/cli/slash/_lib/run-skill-dispatch-turn.test.ts
@@ -56,7 +56,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/slash/builtin-skills-streaming.test.ts
+++ b/src/cli/slash/builtin-skills-streaming.test.ts
@@ -28,7 +28,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/slash/builtin-skills.test.ts
+++ b/src/cli/slash/builtin-skills.test.ts
@@ -37,7 +37,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/slash/changelog.test.ts
+++ b/src/cli/slash/changelog.test.ts
@@ -31,7 +31,7 @@ function makeWriter(): Writer & { lines: string[] } {
 function makeCtx(writer: Writer): SlashContext {
   return {
     out: writer,
-    stats: { totalTurns: 0, totalCostUsd: 0, totalTokens: 0, totalDurationMs: 0, sessionStartTime: 0, turnCosts: [], turnTokens: [], turns: [], model: 'claude-opus' as const, planMode: false },
+    stats: { totalTurns: 0, totalCostUsd: 0, totalTokens: 0, totalDurationMs: 0, sessionStartTime: 0, turnCosts: [], turnTokens: [], turns: [], model: 'claude-opus' as const, permissionMode: 'default' },
     session: {} as never,
     ui: { clearScreen: () => {}, repaintStatusLine: () => {} },
   } as SlashContext;

--- a/src/cli/slash/commands/afk.test.ts
+++ b/src/cli/slash/commands/afk.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the /afk slash command.
+ *
+ * The command resolves on/off/bare-toggle intent against the current
+ * permissionMode and delegates the actual flip to `toggleAfkMode` (covered by
+ * afk-mode-toggle.test.ts). These tests verify dispatch + no-op suppression.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const toggleAfkMode = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../afk-mode-toggle.js', () => ({
+  toggleAfkMode: (...args: unknown[]) => toggleAfkMode(...args),
+}));
+
+import { afkCmd } from './afk.js';
+import type { PermissionMode } from '../../../agent/types/sdk-types.js';
+import type { SlashContext } from '../types.js';
+
+function ctxWithMode(mode: PermissionMode): SlashContext {
+  return { stats: { permissionMode: mode } } as unknown as SlashContext;
+}
+
+describe('/afk command', () => {
+  beforeEach(() => toggleAfkMode.mockClear());
+
+  it('/afk on from default → toggles ON, continues', async () => {
+    const ctx = ctxWithMode('default');
+    const result = await afkCmd.handler(ctx, 'on');
+    expect(toggleAfkMode).toHaveBeenCalledWith(ctx, true);
+    expect(result).toBe('continue');
+  });
+
+  it('/afk off from autonomous → toggles OFF, continues', async () => {
+    const ctx = ctxWithMode('autonomous');
+    const result = await afkCmd.handler(ctx, 'off');
+    expect(toggleAfkMode).toHaveBeenCalledWith(ctx, false);
+    expect(result).toBe('continue');
+  });
+
+  it('bare /afk from default → toggles ON', async () => {
+    const ctx = ctxWithMode('default');
+    await afkCmd.handler(ctx, '');
+    expect(toggleAfkMode).toHaveBeenCalledWith(ctx, true);
+  });
+
+  it('bare /afk from autonomous → toggles OFF', async () => {
+    const ctx = ctxWithMode('autonomous');
+    await afkCmd.handler(ctx, '');
+    expect(toggleAfkMode).toHaveBeenCalledWith(ctx, false);
+  });
+
+  it('/afk on when already autonomous → no-op (does not call toggle)', async () => {
+    const ctx = ctxWithMode('autonomous');
+    const result = await afkCmd.handler(ctx, 'on');
+    expect(toggleAfkMode).not.toHaveBeenCalled();
+    expect(result).toBe('continue');
+  });
+
+  it('entering AFK from plan mode replaces plan (toggles ON)', async () => {
+    const ctx = ctxWithMode('plan');
+    await afkCmd.handler(ctx, 'on');
+    expect(toggleAfkMode).toHaveBeenCalledWith(ctx, true);
+  });
+
+  it('exposes correct metadata', () => {
+    expect(afkCmd.name).toBe('/afk');
+    expect(afkCmd.usage).toContain('/afk');
+  });
+});

--- a/src/cli/slash/commands/afk.ts
+++ b/src/cli/slash/commands/afk.ts
@@ -1,0 +1,62 @@
+/**
+ * /afk — toggle AFK (away-from-keyboard) mode.
+ *
+ * Usage:
+ *   /afk            — toggle AFK mode on/off
+ *   /afk on         — enter AFK mode
+ *   /afk off        — exit AFK mode
+ *
+ * AFK mode is the permission mode `'autonomous'`. It is the orthogonal twin of
+ * plan mode: where plan mode restricts the agent (writes refused) so the user
+ * can think, AFK mode tells the agent the operator is AWAY and shifts its
+ * posture and channel accordingly:
+ *
+ *   - Posture (system-prompt addendum, `afk-mode-addendum.ts`): work
+ *     autonomously on reversible operations; stop at one-way doors and surface
+ *     an Asking summary to Telegram rather than guessing.
+ *   - Enforcement (hook gate, `afk-mode-gate.ts`): high-risk / irreversible
+ *     operations (rm, force-push, reset --hard, writes escaping the workspace,
+ *     …) are refused at the hook layer — tree-wide, including subagents —
+ *     because raised autonomy without a human watching needs a mechanical
+ *     ceiling, not just a prompt.
+ *   - Channel (turn-handler + `afk-push.ts`): each turn's terminal state is
+ *     pushed to Telegram, scrubbed and rate-limited, so the operator can review
+ *     asynchronously.
+ *
+ * Mutual exclusivity: AFK and plan share the single `permissionMode` field, so
+ * `/afk on` from plan mode replaces plan with autonomous (and vice versa).
+ *
+ * Unlike `/plan off`, `/afk off` seeds no follow-up turn — it simply restores
+ * default permissions. Scope: AFK mode is a REPL affordance; other surfaces
+ * (Telegram) construct sessions in `'default'` and have no toggle path.
+ */
+
+import { toggleAfkMode } from '../../afk-mode-toggle.js';
+import type { SlashCommand, SlashContext, SlashResult } from '../types.js';
+
+export const afkCmd: SlashCommand = {
+  name: '/afk',
+  usage: '/afk [on|off]',
+  summary: 'Toggle AFK mode — autonomous work + Telegram reporting while you are away',
+  hint: 'Tell the agent you are away from keyboard: it works autonomously on reversible operations, a safety gate refuses high-risk/irreversible ops, and each turn reports its terminal state to Telegram. /afk off restores default permissions.',
+  async handler(ctx: SlashContext, args: string): Promise<SlashResult> {
+    const argLower = args.trim().toLowerCase();
+    const desired =
+      argLower === 'on' ? true :
+      argLower === 'off' ? false :
+      ctx.stats.permissionMode !== 'autonomous';
+
+    if (desired && ctx.stats.permissionMode === 'autonomous') {
+      // Already on — suppress the no-op success line for ergonomics.
+      return 'continue';
+    }
+    if (!desired && ctx.stats.permissionMode !== 'autonomous') {
+      // Already off — surface the affordance with a no-op toggle.
+      await toggleAfkMode(ctx, false);
+      return 'continue';
+    }
+
+    await toggleAfkMode(ctx, desired);
+    return 'continue';
+  },
+};

--- a/src/cli/slash/commands/bgsub.test.ts
+++ b/src/cli/slash/commands/bgsub.test.ts
@@ -48,7 +48,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/slash/commands/config-doctor.test.ts
+++ b/src/cli/slash/commands/config-doctor.test.ts
@@ -33,7 +33,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/slash/commands/font-size.test.ts
+++ b/src/cli/slash/commands/font-size.test.ts
@@ -29,7 +29,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/slash/commands/keys.test.ts
+++ b/src/cli/slash/commands/keys.test.ts
@@ -25,7 +25,7 @@ function makeCtx(): { ctx: SlashContext; lines: string[] } {
       turnTokens: [],
       turns: [],
       model: 'sonnet',
-      planMode: false,
+      permissionMode: 'default',
     } satisfies SessionStats,
     out: {
       line: (t = ''): void => { lines.push(t); },

--- a/src/cli/slash/commands/name.test.ts
+++ b/src/cli/slash/commands/name.test.ts
@@ -37,7 +37,7 @@ function makeStats(overrides: Partial<SessionStats> = {}): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
     ...overrides,
   };
 }

--- a/src/cli/slash/commands/plan.ts
+++ b/src/cli/slash/commands/plan.ts
@@ -40,7 +40,7 @@
  *      mode, so the writes land.
  *
  * If the flip fails (a transient `setPermissionMode` rejection — surfaced by
- * `togglePlanMode`, which leaves `planMode` unchanged), no implement turn is
+ * `togglePlanMode`, which leaves `permissionMode` unchanged), no implement turn is
  * seeded: seeding one while writes are still refused would only produce a
  * wall of gate refusals.
  *
@@ -50,7 +50,7 @@
  *
  * Scope: plan mode is a REPL-only conversation affordance. Other surfaces
  * (Telegram) never enter plan mode (their sessions are constructed with
- * `planMode: false` and no toggle path), so this command's exit behavior is
+ * `permissionMode: 'default'` and no toggle path), so this command's exit behavior is
  * exercised only by the REPL's `{ kind: 'submit' }` consumer.
  */
 
@@ -82,9 +82,9 @@ export function buildPlanExitPrompt(plansDir: string): string {
  */
 async function exitAndImplement(ctx: SlashContext): Promise<SlashResult> {
   await togglePlanMode(ctx, false);
-  if (ctx.stats.planMode) {
+  if (ctx.stats.permissionMode === 'plan') {
     // Flip failed — togglePlanMode already surfaced the error and left
-    // planMode unchanged. Do NOT seed an implement turn while writes are
+    // permissionMode unchanged. Do NOT seed an implement turn while writes are
     // still refused; the model would only collect gate refusals.
     return 'continue';
   }
@@ -106,7 +106,7 @@ export const planCmd: SlashCommand = {
 
     // Free-text arg: enter plan mode unconditionally and submit as prompt.
     if (arg !== '' && argLower !== 'on' && argLower !== 'off') {
-      if (!ctx.stats.planMode) {
+      if (ctx.stats.permissionMode !== 'plan') {
         await togglePlanMode(ctx, true);
       }
       return { kind: 'submit', message: arg };
@@ -115,10 +115,10 @@ export const planCmd: SlashCommand = {
     const desired =
       argLower === 'on' ? true :
       argLower === 'off' ? false :
-      !ctx.stats.planMode;
+      ctx.stats.permissionMode !== 'plan';
 
     if (desired === true) {
-      if (ctx.stats.planMode) {
+      if (ctx.stats.permissionMode === 'plan') {
         // Already on — nothing to do. togglePlanMode would emit a no-op
         // success line; suppress it for ergonomics.
         return 'continue';
@@ -128,7 +128,7 @@ export const planCmd: SlashCommand = {
     }
 
     // desired === false
-    if (!ctx.stats.planMode) {
+    if (ctx.stats.permissionMode !== 'plan') {
       // Already off — toggle to surface the affordance (no-op on the gate).
       // No plan to save, so no implement turn is seeded.
       await togglePlanMode(ctx, false);

--- a/src/cli/slash/commands/resume.test.ts
+++ b/src/cli/slash/commands/resume.test.ts
@@ -47,7 +47,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/slash/commands/save.test.ts
+++ b/src/cli/slash/commands/save.test.ts
@@ -39,7 +39,7 @@ function makeStats(overrides: Partial<SessionStats> = {}): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
     ...overrides,
   };
 }

--- a/src/cli/slash/commands/sh.test.ts
+++ b/src/cli/slash/commands/sh.test.ts
@@ -23,7 +23,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/slash/commands/stats.test.ts
+++ b/src/cli/slash/commands/stats.test.ts
@@ -21,7 +21,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/slash/commands/worktree.test.ts
+++ b/src/cli/slash/commands/worktree.test.ts
@@ -39,7 +39,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/slash/core-compact.test.ts
+++ b/src/cli/slash/core-compact.test.ts
@@ -22,7 +22,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/slash/index.ts
+++ b/src/cli/slash/index.ts
@@ -10,6 +10,7 @@ import { register, registerIfAbsent, resetRegistry } from './registry.js';
 import { coreCommands } from './commands/core.js';
 import { infoCommands } from './commands/info.js';
 import { planCmd } from './commands/plan.js';
+import { afkCmd } from './commands/afk.js';
 import { todoCmd } from './commands/todo.js';
 import { saveCmd } from './commands/save.js';
 import { nameCmd } from './commands/name.js';
@@ -38,6 +39,7 @@ export function registerAll(): void {
   for (const cmd of coreCommands) register(cmd);
   for (const cmd of infoCommands) register(cmd);
   register(planCmd);
+  register(afkCmd);
   register(todoCmd);
   register(saveCmd);
   register(nameCmd);

--- a/src/cli/slash/marketplace-browse.test.ts
+++ b/src/cli/slash/marketplace-browse.test.ts
@@ -79,7 +79,7 @@ function makeCtx(out: Writer): SlashContext {
     stats: {
       totalTurns: 0, totalCostUsd: 0, totalTokens: 0, totalDurationMs: 0,
       sessionStartTime: 0, turnCosts: [], turnTokens: [], turns: [],
-      model: 'sonnet', planMode: false,
+      model: 'sonnet', permissionMode: 'default',
     },
     ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
   };

--- a/src/cli/slash/plugin-skills-audience.test.ts
+++ b/src/cli/slash/plugin-skills-audience.test.ts
@@ -29,7 +29,7 @@ function makeCtx(): { ctx: SlashContext; lines: string[] } {
       turnTokens: [],
       turns: [],
       model: 'sonnet',
-      planMode: false,
+      permissionMode: 'default',
     },
     out: {
       line: (t = '') => lines.push(t),

--- a/src/cli/slash/plugin-skills-dispatch.test.ts
+++ b/src/cli/slash/plugin-skills-dispatch.test.ts
@@ -213,7 +213,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/slash/plugin-skills-listing.test.ts
+++ b/src/cli/slash/plugin-skills-listing.test.ts
@@ -35,7 +35,7 @@ function makeCtx(): { ctx: SlashContext; lines: string[] } {
       turnTokens: [],
       turns: [],
       model: 'sonnet',
-      planMode: false,
+      permissionMode: 'default',
     },
     out: {
       line: (t = '') => lines.push(t),

--- a/src/cli/slash/plugin-skills-preflight.test.ts
+++ b/src/cli/slash/plugin-skills-preflight.test.ts
@@ -57,7 +57,7 @@ function makeStats(): SessionStats {
     turnTokens: [],
     turns: [],
     model: 'sonnet',
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 

--- a/src/cli/slash/session-stats.ts
+++ b/src/cli/slash/session-stats.ts
@@ -22,14 +22,14 @@ export function createSessionStats(model: AgentModelInput): SessionStats {
     turnTokens: [],
     turns: [],
     model,
-    planMode: false,
+    permissionMode: 'default',
   };
 }
 
 /**
  * Reset session counters in-place. Used by `/clear` after the SDK session
  * is rebuilt — the conversation is gone, so per-turn counters/history must
- * be zeroed too. Preserves user-controlled state (`model`, `planMode`)
+ * be zeroed too. Preserves user-controlled state (`model`, `permissionMode`)
  * and refreshes `sessionStartTime` so elapsed-time displays restart from
  * the clear, not from the original launch. Drops `sessionId` because the
  * rebuilt SDK session will issue a new one, and drops the auto-derived
@@ -51,7 +51,8 @@ export function resetStats(stats: SessionStats): void {
   // make the NEXT conversation's first turn persist a fresh sidecar under the
   // PREVIOUS conversation's name — a user-visible misattribution.
   delete stats.name;
-  // Preserve `planMode` (user-controlled state — the gate reads it live).
+  // Preserve `permissionMode` (user-controlled state — the plan/AFK gates read
+  // it live; `/clear` should not silently drop the operator out of AFK mode).
 }
 
 /**

--- a/src/cli/slash/types.ts
+++ b/src/cli/slash/types.ts
@@ -9,6 +9,7 @@
 
 import type { SessionRef } from '../../agent/session-ref.js';
 import type { AgentModelInput } from '../../agent/types.js';
+import type { PermissionMode } from '../../agent/types/sdk-types.js';
 import type { TrustedSkillLedger } from '../trusted-skill-ledger.js';
 import type { ImageAttachment } from '../input/attachments.js';
 import type { ResolvedResumeTarget } from '../resume-session.js';
@@ -72,8 +73,15 @@ export interface SessionStats {
    * initial session may carry any string the SDK/proxy accepts.
    */
   model: AgentModelInput;
-  /** Plan-mode toggle — when true, session uses 'plan' PermissionMode. */
-  planMode: boolean;
+  /**
+   * Current REPL permission mode — the single source of truth the prompt
+   * marker, status line, and the plan/AFK gate getters all read. `'plan'`
+   * gates writes (plan mode); `'autonomous'` is AFK mode (the operator is away
+   * — autonomous work + Telegram reporting, with a high-risk gate); `'default'`
+   * is normal interactive operation. Mutually exclusive by construction (one
+   * field), which is why AFK is not a separate boolean alongside plan.
+   */
+  permissionMode: PermissionMode;
   /** SDK session ID once initialized. Populated from ResponseMetadata. */
   sessionId?: string;
   /**

--- a/src/cli/status-line.test.ts
+++ b/src/cli/status-line.test.ts
@@ -360,7 +360,7 @@ describe('StatusLine resize handling', () => {
     });
     status.start();
     stream.writes.length = 0;
-    status.repaint({ model: 'sonnet', planMode: true });
+    status.repaint({ model: 'sonnet', permissionMode: 'plan' });
     const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
     expect(out).toContain('…');
     expect(out).not.toContain('\x1b');
@@ -797,7 +797,7 @@ describe('StatusLine narrow-terminal priority drop', () => {
     status.stop();
   });
 
-  it('with planMode: never drops plan indicator', () => {
+  it('with plan mode: never drops plan indicator', () => {
     stream.columns = 30;
     const status = new StatusLine({
       stream: stream as unknown as NodeJS.WriteStream,
@@ -810,10 +810,31 @@ describe('StatusLine narrow-terminal priority drop', () => {
       cwd: '/tmp',
       cost: 0.05,
       tokens: 1200,
-      planMode: true,
+      permissionMode: 'plan',
     });
     const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
     expect(out).toContain('● plan');
+    expect(out).not.toContain('tok');
+    status.stop();
+  });
+
+  it('with AFK mode: never drops the AFK indicator', () => {
+    stream.columns = 30;
+    const status = new StatusLine({
+      stream: stream as unknown as NodeJS.WriteStream,
+      throttleMs: 0,
+    });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({
+      model: 'sonnet',
+      cwd: '/tmp',
+      cost: 0.05,
+      tokens: 1200,
+      permissionMode: 'autonomous',
+    });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('◐ AFK');
     expect(out).not.toContain('tok');
     status.stop();
   });

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -12,6 +12,7 @@
  *   status.stop();   // before exit
  */
 
+import type { PermissionMode } from '../agent/types/sdk-types.js';
 import { truncateDisplayWidth, displayWidth } from './display.js';
 import { palette } from './palette.js';
 import { ResizeBus } from './terminal-size.js';
@@ -26,7 +27,12 @@ export interface StatusLineFields {
   contextLimit?: number;
   contextUsedTokens?: number;
   contextSparkline?: string;
-  planMode?: boolean;
+  /**
+   * Current REPL permission mode. Renders a never-dropped indicator: `● plan`
+   * (plan mode, warning tone) or `◐ AFK` (autonomous/AFK mode, info tone).
+   * `'default'` and other modes render no indicator.
+   */
+  permissionMode?: PermissionMode;
   /**
    * Effective working directory for the session. Rendered leftmost so that
    * right-edge truncation (which strips trailing parts first) preserves the
@@ -356,7 +362,11 @@ export class StatusLine {
     // it is emitted inline via completionWriter (see bootstrap.ts).
     parts.push({ text: palette.brand(f.model) }); // never drop
 
-    if (f.planMode) parts.push({ text: palette.warning('● plan') }); // never drop
+    if (f.permissionMode === 'plan') {
+      parts.push({ text: palette.warning('● plan') }); // never drop
+    } else if (f.permissionMode === 'autonomous') {
+      parts.push({ text: palette.info('◐ AFK') }); // never drop
+    }
 
     if (f.contextPct !== undefined) {
       const barOutput = formatContextBar({

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -298,9 +298,9 @@ export class SessionManager {
 
     // Map StoredSession → SessionStats.
     // Critical rename: stored.startedAt === SessionStats.sessionStartTime.
-    // Fields not persisted (turnCosts, turnTokens, planMode) are reconstructed
-    // as empty/default — they are runtime-only display helpers, not resumption
-    // data. The round-trip contract is: saveSession(hydrated) === the original
+    // Fields not persisted (turnCosts, turnTokens, permissionMode) are
+    // reconstructed as empty/default — they are runtime-only display helpers,
+    // not resumption data. The round-trip contract is: saveSession(hydrated) === the original
     // sidecar (modulo savedAt timestamp), so a post-hydration persist does NOT
     // fork a new file.
     const stats: SessionStats = {
@@ -318,7 +318,7 @@ export class SessionManager {
       // Runtime-only fields — reconstructed as empty defaults.
       turnCosts: [],
       turnTokens: [],
-      planMode: false,
+      permissionMode: 'default',
     };
     // Carry forward the per-chat cwd override if one was set via /cd.
     const chatCwd = this.sessionData.get(chatId)?.cwd;


### PR DESCRIPTION
## Summary

**AFK mode** — a new operating mode (`permissionMode: 'autonomous'`), the orthogonal twin of plan mode. Toggle with `/afk`; it tells the agent the operator is away-from-keyboard and shifts it to a **bounded-autonomy** posture that reports terminal states to Telegram and is bounded by a mechanical safety gate.

- **`/afk [on|off]`** command + a `◐ AFK` status-line indicator + prompt marker.
- **Bounded-autonomy system-prompt addendum** injected by both providers (anthropic-direct and openai-compatible) — proceed on reversible work, stop at one-way doors, defer to the gate (not unchecked autonomy).
- **Mechanical gate** (`afk-mode-gate.ts`): refuses high-risk / irreversible ops (`rm`, `git push --force`, `git reset --hard`, `sudo`, workspace-escape and `.git` writes) via the shared `classifyRisk` taxonomy — applied **tree-wide including subagents**; `send_telegram` is always exempt (it is the operator channel).
- **Scrubbed Telegram push**: built only from parsed terminal-state fields (allowlist by construction) + inline secret redaction + a per-session rate cap, so unattended runs never leak raw tool output.
- **Data model**: `SessionStats.planMode: boolean` migrated to a single `permissionMode: PermissionMode` field; `'autonomous'` added to the union — mutually exclusive with `plan`/`acceptEdits` by construction (one field, not a parallel boolean).

## Test results

- `pnpm lint` (tsc strict): **clean**
- `pnpm test`: **9466 passed**, 12 skipped, 2 failed — both **pre-existing on the base branch and unrelated** to this change (`config.test.ts` model-tier defaults; `anthropic-direct.test.ts` compact-summarizer model-ID alias `claude-haiku-4-5` vs dated suffix).
- `pnpm build`: **exit 0**
- **61 new tests** covering the gate (incl. tree-wide subagent gating + `send_telegram` exemption + the medium/safe allow path), the addendum (present iff `autonomous`), the scrubbed + rate-limited push, the toggle (incl. Telegram-unconfigured preflight), the `/afk` command, the status indicator, and provider system-payload injection.

## Verification

- An independent read-only reviewer re-derived the full changeset from the diff and confirmed it clean (high confidence).
- Behavior is backed by the 61 new tests above; full suite is green apart from the 2 pre-existing failures noted.

## Out of scope (deferred)

- Dedicated AFK keybinding chord — the `/afk` command + `◐ AFK` indicator deliver the UX for v1.
- Protected-branch push hardening knob (documented, default-off).
- Phase 2: Telegram → agent inbound round-trip (one-way reporting only for v1).

_Please review before merge._
