### PR TITLE
feat(afk): bidirectional remote control over Telegram (answer elicitations + remote /abort)

### DIFF
--- a/docs/afk-remote-control.md
+++ b/docs/afk-remote-control.md
@@ -1,0 +1,239 @@
+# AFK Remote Control — Bidirectional Telegram Handoff
+
+**Status:** Implemented (iterations 1–4 committed; docs iteration 5).  
+**Feature branch:** `afk/20260617-201405-0b2298`  
+**Design record:** `.afk/plans/afk-telegram-bidirectional.md`
+
+---
+
+## What It Is
+
+Normally the AFK Telegram integration is **outbound only**: when you step away from
+the REPL (`/afk on`) the agent's output streams to your phone, but if the agent asks a
+question the session hangs waiting for a keyboard reply. Returning to the computer just
+to answer one question defeats the point of AFK mode.
+
+**Bidirectional AFK** closes that loop. With a running Telegram daemon (`afk telegram
+start`), you can **answer the agent's questions, redirect it, or abort its turn entirely
+— from your phone, mid-flight, in the same session.** When you return to the computer
+and type `/afk off`, interaction returns to the keyboard seamlessly.
+
+---
+
+## End-to-End Flow
+
+```
+REPL process (afk i)                  Telegram daemon (afk telegram start)
+─────────────────────                  ──────────────────────────────────────
+/afk on
+  → swap elicitation handler
+    to makeLedgerChannelHandler        (auto-subscribe loop fires every 30 s)
+  → mark presence afk=true    ──────→  sees surface=cli, afk=true, sessionId
+  → start abort-watcher tail          → watchManager.start(sessionId, chatId)
+
+Agent turn begins.
+Agent calls ask_question / MCP elicit.
+  → elicitationRouter.route()
+  → ledgerChannelHandler fires:
+    1. Open ledger tail (fromStart:false,
+       before emit — no reply can be missed)
+    2. Emit `elicitation` record to
+       ~/.afk/state/sessions/<id>/events.jsonl
+    3. Race:
+         a. verified ledger reply       ledger tail sees `elicitation` record
+         b. stdin keyboard fallback   → renders question to your phone
+         c. outer turn abort           (inline keyboard for choice/confirm,
+                                         text prompt for free text)
+                                      You tap/type your answer on the phone.
+                                      Daemon writes HMAC-signed
+                                      `elicitation_response` → ledger file.
+
+       REPL tail sees new record ←────────────────────────────────────────
+       verifies HMAC
+       resolves with result
+       cancels losers (stdin, tail)
+
+Agent sees the answer; continues.
+
+/afk off
+  → restore stdin handler
+  → stop abort-watcher tail
+  → clear presence afk marker
+
+Back at the keyboard.
+```
+
+### Remote abort
+
+```
+You: /abort (Telegram)
+  Daemon looks up getWatched(chatId) → sessionId
+  Reads session key from ~/.afk/state/sessions/<id>/session.key
+  Signs: HMAC-SHA256(key, "abort_request\0<sessionId>\0<nonce>")
+  Writes `abort_request` record to ledger
+
+  REPL abort-watcher tail sees record
+  verifyAbortRequest(key, sessionId, nonce, hmac) → true
+  fires session AbortGraph
+  session aborts cleanly
+```
+
+If the REPL has no AFK key (the operator never typed `/afk on` in this session),
+the daemon replies with a helpful message and does NOT write an unsigned abort.
+
+---
+
+## Ledger-as-Channel Design
+
+The REPL (`afk i`) and the Telegram daemon (`afk telegram start`) are **separate OS
+processes**. They share no memory, no sockets, and no new IPC primitive. Communication
+flows **only through the per-session ledger file**:
+
+```
+~/.afk/state/sessions/<id>/events.jsonl   ← append-only NDJSON
+```
+
+This file already exists for every top-level `AgentSession` (the REPL's `/watch`
+feature reads it for outbound streaming). The bidirectional channel adds three new
+record kinds to the open union in `src/agent/session-ledger.ts`:
+
+| Kind | Writer | Reader |
+|---|---|---|
+| `elicitation` | REPL (`makeLedgerChannelHandler`) | Daemon (`_run` in `watch.ts`) |
+| `elicitation_response` | Daemon (`SessionLedgerWriter`) | REPL (ledger tail) |
+| `abort_request` | Daemon (`bot.ts` `/abort` command) | REPL (abort-watcher tail) |
+
+The ledger is append-only NDJSON with torn-line skipping (`parseRecord`). Two
+concurrent appenders (REPL + daemon) do not corrupt each other.
+
+---
+
+## Per-Session HMAC — Threat Model
+
+When `/afk on` is first typed, the REPL writes a 32-byte random key to:
+
+```
+~/.afk/state/sessions/<id>/session.key  (mode 0600)
+```
+
+Every `elicitation_response` and `abort_request` record written by the daemon carries
+an HMAC-SHA256 tag over `(recordKind, sessionId, correlator, payload)` using this key.
+The REPL verifies the tag before acting; an unverified record is **silently ignored —
+never actioned**.
+
+**What this protects:**
+- Accidental cross-session bleed (a reply from session A cannot resolve session B).
+- Stray or buggy writers (a process that appends a raw `abort_request` without the key
+  cannot abort your session).
+
+**What this does NOT protect:**
+- A malicious *same-user* process that reads the 0600 key. Such a process already holds
+  the user's OS privileges — this is out of scope.
+
+**Telegram ingress** stays gated by the existing `AFK_TELEGRAM_ALLOWED_CHAT_IDS`
+allowlist, unchanged.
+
+---
+
+## The AFK Safety Gate Is Non-Overridable
+
+`src/agent/afk-mode-gate.ts` enforces which tool calls are permitted in autonomous
+mode. A remote phone reply is **an input to the agent's reasoning** — it answers a
+question and the agent re-evaluates its next action against the gate. The gate is
+**never bypassed** by a Telegram reply. This is scope-lock Invariant #1 and is tested
+separately in `src/agent/afk-mode-gate.test.ts`.
+
+---
+
+## Five Hard Invariants
+
+These are frozen in `.afk/plans/afk-telegram-bidirectional.scope.lock.md` and
+enforced by tests:
+
+1. **AFK gate non-overridable.** `afk-mode-gate.ts` has no Telegram override path;
+   remote replies feed the agent's next reasoning step, never bypass the gate.
+2. **Daemon is the sole Telegraf poller.** The REPL never constructs a `Telegraf`
+   instance or calls `getUpdates`. A second poller would cause Telegram 409 Conflict.
+   Enforced by `src/cli/afk-no-telegraf-poller.test.ts`.
+3. **Additive channel.** The stdin keyboard fallback is always live alongside the
+   phone. If the daemon is not running, the keyboard still works. No daemon-liveness
+   dependency, no `bot.pid` gating.
+4. **HMAC-gated writes.** `elicitation_response` and `abort_request` are acted upon
+   **only** after successful per-session HMAC verification. Key-absent → ledger branch
+   disabled; the safe degrade is keyboard-only.
+5. **Ledger-only IPC.** The only cross-process hop is the session ledger file. No
+   sockets, pipes, or new IPC primitives.
+
+---
+
+## Key Source Files
+
+| File | Role |
+|---|---|
+| `src/agent/afk-channel.ts` | Per-session HMAC helpers (`ensureSessionKey`, `signElicitationResponse`, `verifyAbortRequest`, …) |
+| `src/agent/afk-ledger-channel.ts` | `makeLedgerChannelHandler` (REPL phone+keyboard race) + `makeAbortWatcher` |
+| `src/agent/session-ledger.ts` | Append-only NDJSON ledger; `tailLedger`, `SessionLedgerWriter`, `LedgerRecord` union |
+| `src/cli/afk-mode-toggle.ts` | `/afk on/off` swap logic — installs the ledger channel, starts abort-watcher, sets presence marker |
+| `src/cli/commands/interactive/surface-setup.ts` | Pre-builds stdin handler + exposes `swapElicitationHandler` callback |
+| `src/agent/elicitation-router.ts` | Module-scope router; `install()` swap is the only coupling point |
+| `src/telegram/watch.ts` | Daemon `SessionWatchManager._run` — intercepts `elicitation` records and triggers write-back |
+| `src/telegram/bot.ts` | Daemon lifecycle, `/abort` command, presence auto-subscribe loop |
+| `src/telegram/handlers/message.ts` | `ledgerOriginatedPendingChats` bypass for the `state==='idle'` guard |
+| `src/telegram/elicitation-handler.ts` | `makeTelegramElicitationHandler` — reused to render questions to the phone |
+
+---
+
+## Known Limitations / Future Work
+
+These were deferred because the scope-lock budget was exhausted at iteration 4. Each
+needs a separate focused change.
+
+### (a) Daemon writer fd leak (low severity, slow)
+
+When the daemon writes back an `elicitation_response` or `abort_request`, it creates a
+`new SessionLedgerWriter(sessionId)` to perform the one append. This writer **must not
+be `close()`d** — calling `close()` would write a spurious `closed` record into the
+REPL's ledger, which would terminate the REPL's `tailLedger` loop and break subsequent
+questions in the same session.
+
+As a result, the fd created by the writer lives until GC reclaims the object. For a
+single-session interaction this is invisible. For a very long-lived daemon that serves
+many sessions over many hours, it is a slow fd leak.
+
+**Proper fix:** add a one-shot `appendAndClose` path to `SessionLedgerWriter` (or to
+the `session-ledger.ts` module) that writes the record and closes the underlying stream
+without emitting a `closed` record. Requires a small change in `src/agent/session-ledger.ts`
+(currently OUT OF SCOPE per scope.lock — file is frozen from Phase 1).
+
+### (b) Auto-subscribe stops a manually `/watch`'d non-AFK session
+
+The auto-subscribe tick (every 30 s) calls `watchManager.start(sessionId, chatId)` for
+any `surface=cli, afk=true` session. On the next tick, if the user had manually
+`/watch`'d a different (non-AFK) session in the same chat, the auto-subscribe call can
+replace it with the AFK session's watch, silently stopping the manual one.
+
+**Proper fix:** track whether a current watch was started manually (`/watch` command)
+vs. automatically (auto-subscribe) and skip the auto-start when a manual watch is
+active.
+
+### (c) `bot.action` handlers accumulate per watch cycle
+
+Each time `SessionWatchManager._run` arms a new `bot.action` handler (for
+inline-keyboard callback confirmations), the handler is appended to Telegraf's internal
+middleware stack and is never removed, even after the watch ends. Over many watch
+cycles the stack grows unboundedly.
+
+**Proper fix:** expose a handler-removal API from Telegraf (or use a delegating
+middleware that is registered once and routes by run ID) so each watch cycle can clean
+up after itself.
+
+### (d) Inline-keyboard elicitation not yet end-to-end tested
+
+`choice` and `confirm` elicitation types render as Telegram inline keyboards (via
+`makeTelegramElicitationHandler`). The `ledgerOriginated: true` path through
+`elicitation-handler.ts` and `message.ts` is code-reviewed and unit-tested but has not
+been exercised in an end-to-end integration test with a real Telegram bot.
+
+**Proper fix:** add an integration / live test that fires a `confirm`-type elicitation
+through the full chain (REPL ledger emit → daemon render → callback query → signed
+write-back → REPL resolve).

--- a/src/agent/afk-channel.test.ts
+++ b/src/agent/afk-channel.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the AFK remote-control channel auth (per-session HMAC).
+ *
+ * Uses a temp AFK_HOME per suite run so no real ~/.afk/state is touched
+ * (env must be set before importing the path-dependent module).
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-channel-test-'));
+process.env['AFK_HOME'] = tmpDir;
+
+import {
+  stableStringify,
+  ensureSessionKey,
+  readSessionKey,
+  signElicitationResponse,
+  verifyElicitationResponse,
+  signAbortRequest,
+  verifyAbortRequest,
+  freshChannelId,
+} from './afk-channel.js';
+import { getSessionKeyPath } from '../paths.js';
+import type { ElicitationResult } from './types/sdk-types.js';
+
+let seq = 0;
+function freshId(): string {
+  return `chan-test-${Date.now()}-${seq++}`;
+}
+
+describe('stableStringify', () => {
+  it('is insensitive to object key insertion order', () => {
+    expect(stableStringify({ a: 1, b: 2 })).toBe(stableStringify({ b: 2, a: 1 }));
+    expect(stableStringify({ x: { p: 1, q: 2 } })).toBe(stableStringify({ x: { q: 2, p: 1 } }));
+  });
+
+  it('preserves array order', () => {
+    expect(stableStringify([3, 1, 2])).toBe('[3,1,2]');
+  });
+});
+
+describe('session key management', () => {
+  it('creates a key on first use and returns the same key thereafter', () => {
+    const id = freshId();
+    const k1 = ensureSessionKey(id);
+    const k2 = ensureSessionKey(id);
+    expect(k1).toBeTruthy();
+    expect(k1).toBe(k2);
+    expect(k1).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('writes the key file with 0600 permissions', () => {
+    const id = freshId();
+    ensureSessionKey(id);
+    const mode = fs.statSync(getSessionKeyPath(id)).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('readSessionKey returns null when no key exists, the key once created', () => {
+    const id = freshId();
+    expect(readSessionKey(id)).toBeNull();
+    const created = ensureSessionKey(id);
+    expect(readSessionKey(id)).toBe(created);
+  });
+
+  it('returns null for an unsafe session id rather than throwing', () => {
+    expect(ensureSessionKey('../escape')).toBeNull();
+    expect(readSessionKey('../escape')).toBeNull();
+  });
+});
+
+describe('elicitation response signing', () => {
+  const result: ElicitationResult = { action: 'accept', content: { value: 'b' } };
+
+  it('round-trips: a signature verifies for the same key/session/reqId/result', () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    const sig = signElicitationResponse(key, id, 'r1', result);
+    expect(verifyElicitationResponse(key, id, 'r1', result, sig)).toBe(true);
+  });
+
+  it('is insensitive to result key order (stable canonicalization)', () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    const sig = signElicitationResponse(key, id, 'r1', {
+      action: 'accept',
+      content: { value: 'b', extra: 1 },
+    });
+    const reordered: ElicitationResult = { content: { extra: 1, value: 'b' }, action: 'accept' };
+    expect(verifyElicitationResponse(key, id, 'r1', reordered, sig)).toBe(true);
+  });
+
+  it('rejects a tampered result', () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    const sig = signElicitationResponse(key, id, 'r1', result);
+    const tampered: ElicitationResult = { action: 'accept', content: { value: 'EVIL' } };
+    expect(verifyElicitationResponse(key, id, 'r1', tampered, sig)).toBe(false);
+  });
+
+  it('rejects a wrong reqId, wrong session, and wrong key', () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    const sig = signElicitationResponse(key, id, 'r1', result);
+    expect(verifyElicitationResponse(key, id, 'r2', result, sig)).toBe(false);
+    expect(verifyElicitationResponse(key, 'other-session', 'r1', result, sig)).toBe(false);
+    expect(verifyElicitationResponse('00'.repeat(32), id, 'r1', result, sig)).toBe(false);
+  });
+
+  it('rejects a malformed signature without throwing', () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    expect(verifyElicitationResponse(key, id, 'r1', result, 'not-hex!!')).toBe(false);
+    expect(verifyElicitationResponse(key, id, 'r1', result, '')).toBe(false);
+  });
+});
+
+describe('abort request signing', () => {
+  it('round-trips and rejects tampering', () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    const nonce = freshChannelId();
+    const sig = signAbortRequest(key, id, nonce);
+    expect(verifyAbortRequest(key, id, nonce, sig)).toBe(true);
+    expect(verifyAbortRequest(key, id, 'other-nonce', sig)).toBe(false);
+    expect(verifyAbortRequest('11'.repeat(32), id, nonce, sig)).toBe(false);
+  });
+
+  it('a response signature does not verify as an abort (kind-bound canonical)', () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    const respSig = signElicitationResponse(key, id, 'r1', { action: 'accept' });
+    expect(verifyAbortRequest(key, id, 'r1', respSig)).toBe(false);
+  });
+});
+
+describe('freshChannelId', () => {
+  it('returns distinct 16-hex-char ids', () => {
+    const a = freshChannelId();
+    const b = freshChannelId();
+    expect(a).toMatch(/^[0-9a-f]{16}$/);
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/agent/afk-channel.ts
+++ b/src/agent/afk-channel.ts
@@ -109,6 +109,10 @@ function digestsEqual(a: string, b: string): boolean {
   if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length || a.length === 0) {
     return false;
   }
+  // Reject non-hex inputs explicitly: Buffer.from(_, 'hex') silently truncates
+  // at the first invalid nibble rather than throwing, so a malformed digest
+  // would otherwise slip past the try/catch and lean solely on the length guard.
+  if (!/^[0-9a-f]+$/i.test(a) || !/^[0-9a-f]+$/i.test(b)) return false;
   let bufA: Buffer;
   let bufB: Buffer;
   try {

--- a/src/agent/afk-channel.ts
+++ b/src/agent/afk-channel.ts
@@ -1,0 +1,179 @@
+/**
+ * AFK remote-control channel: per-session HMAC authentication for the
+ * cross-process elicitation/abort protocol carried over the session ledger.
+ *
+ * Invariant: records that drive the autonomous agent from another process —
+ * `elicitation_response` (an answer) and `abort_request` (a kill) — MUST be
+ * authenticated. The REPL session writes a random per-session key to
+ * `~/.afk/state/sessions/<id>/session.key` (0600) when it enters AFK mode; the
+ * Telegram daemon reads that key to sign any response/abort it writes back into
+ * the ledger, and the REPL verifies the signature before acting. A stray,
+ * buggy, or cross-session write therefore cannot resolve a question or abort a
+ * turn.
+ *
+ * Threat boundary (honest): this binds the channel against ACCIDENTAL
+ * cross-session bleed and stray writers. It is NOT a defense against a malicious
+ * SAME-USER process — that process can read the 0600 key, and it already holds
+ * the user's privileges. The Telegram ingress stays gated by the
+ * AFK_TELEGRAM_ALLOWED_CHAT_IDS allowlist; this layer protects the on-disk hop.
+ *
+ * Contract: the signed canonical form binds (recordKind, sessionId, correlator,
+ * payload) so a signature is valid only for one record kind, one session, and
+ * one request/nonce — replaying a response under a different reqId or session
+ * fails verification.
+ *
+ * @module agent/afk-channel
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { getSessionKeyPath } from '../paths.js';
+import type { ElicitationResult } from './types/sdk-types.js';
+
+/** Per-session key length. 32 bytes (256 bits) → 64 hex chars. */
+const KEY_BYTES = 32;
+/** Field separator for canonical signing input — NUL can't appear in our fields. */
+const SEP = '\u0000';
+
+/**
+ * Deterministic JSON: object keys sorted recursively so the HMAC input is
+ * stable regardless of property insertion order. Arrays keep their order.
+ */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(sortValue(value));
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortValue);
+  if (value !== null && typeof value === 'object') {
+    const src = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(src).sort()) out[key] = sortValue(src[key]);
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Read the per-session channel key, creating it if absent. Idempotent: the
+ * first caller writes a fresh random key (0600); later callers read the same
+ * bytes. Returns null only when the key can neither be read nor written (e.g.
+ * an invalid session id or an unwritable state dir) — callers treat null as
+ * "channel auth unavailable" and degrade (the keyboard fallback still works).
+ */
+export function ensureSessionKey(sessionId: string): string | null {
+  const existing = readSessionKey(sessionId);
+  if (existing) return existing;
+  let keyPath: string;
+  try {
+    keyPath = getSessionKeyPath(sessionId);
+  } catch {
+    return null;
+  }
+  try {
+    // The per-session dir may not exist yet (the ledger writer creates it
+    // lazily on first record); create it so the key write doesn't ENOENT.
+    fs.mkdirSync(path.dirname(keyPath), { recursive: true });
+    const key = randomBytes(KEY_BYTES).toString('hex');
+    fs.writeFileSync(keyPath, key + '\n', { mode: 0o600 });
+    return key;
+  } catch {
+    // Possible concurrent create — try one more read before giving up.
+    return readSessionKey(sessionId);
+  }
+}
+
+/** Read an existing per-session channel key (daemon side). Null if absent. */
+export function readSessionKey(sessionId: string): string | null {
+  let keyPath: string;
+  try {
+    keyPath = getSessionKeyPath(sessionId);
+  } catch {
+    return null;
+  }
+  try {
+    const key = fs.readFileSync(keyPath, 'utf8').trim();
+    return key.length > 0 ? key : null;
+  } catch {
+    return null;
+  }
+}
+
+function hmac(key: string, canonical: string): string {
+  return createHmac('sha256', key).update(canonical).digest('hex');
+}
+
+/** Timing-safe comparison of two hex digests. False on any length/parse mismatch. */
+function digestsEqual(a: string, b: string): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length || a.length === 0) {
+    return false;
+  }
+  let bufA: Buffer;
+  let bufB: Buffer;
+  try {
+    bufA = Buffer.from(a, 'hex');
+    bufB = Buffer.from(b, 'hex');
+  } catch {
+    return false;
+  }
+  if (bufA.length !== bufB.length || bufA.length === 0) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+// ---------------------------------------------------------------------------
+// elicitation_response
+// ---------------------------------------------------------------------------
+
+function responseCanonical(sessionId: string, reqId: string, result: ElicitationResult): string {
+  return ['elicitation_response', sessionId, reqId, stableStringify(result)].join(SEP);
+}
+
+/** Sign an elicitation response (daemon side, before writing it back). */
+export function signElicitationResponse(
+  key: string,
+  sessionId: string,
+  reqId: string,
+  result: ElicitationResult,
+): string {
+  return hmac(key, responseCanonical(sessionId, reqId, result));
+}
+
+/** Verify an elicitation response (REPL side, before resolving the question). */
+export function verifyElicitationResponse(
+  key: string,
+  sessionId: string,
+  reqId: string,
+  result: ElicitationResult,
+  sig: string,
+): boolean {
+  return digestsEqual(sig, signElicitationResponse(key, sessionId, reqId, result));
+}
+
+// ---------------------------------------------------------------------------
+// abort_request
+// ---------------------------------------------------------------------------
+
+function abortCanonical(sessionId: string, nonce: string): string {
+  return ['abort_request', sessionId, nonce].join(SEP);
+}
+
+/** Sign an abort request (daemon side). */
+export function signAbortRequest(key: string, sessionId: string, nonce: string): string {
+  return hmac(key, abortCanonical(sessionId, nonce));
+}
+
+/** Verify an abort request (REPL side, before firing the AbortGraph). */
+export function verifyAbortRequest(
+  key: string,
+  sessionId: string,
+  nonce: string,
+  sig: string,
+): boolean {
+  return digestsEqual(sig, signAbortRequest(key, sessionId, nonce));
+}
+
+/** Fresh random correlation id / nonce for channel records (hex). */
+export function freshChannelId(): string {
+  return randomBytes(8).toString('hex');
+}

--- a/src/agent/afk-ledger-channel.test.ts
+++ b/src/agent/afk-ledger-channel.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the REPL-side ledger ElicitationChannel handler.
+ *
+ * The load-bearing assertion is Invariant #4: an `elicitation_response` whose
+ * per-session HMAC does NOT verify is ignored — it can never resolve the
+ * question. The additive-racing behaviour (phone vs. keyboard vs. abort) is
+ * exercised in all four directions.
+ *
+ * Temp AFK_HOME set before import so no real ~/.afk/state is touched.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-ledgerchan-test-'));
+process.env['AFK_HOME'] = tmpDir;
+
+import { makeLedgerChannelHandler } from './afk-ledger-channel.js';
+import { SessionLedgerWriter } from './session-ledger.js';
+import { ensureSessionKey, signElicitationResponse } from './afk-channel.js';
+import type { ElicitationRequest, ElicitationResult } from './types/sdk-types.js';
+
+let seq = 0;
+function freshId(): string {
+  return `ledgerchan-${Date.now()}-${seq++}`;
+}
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+const REQUEST: ElicitationRequest = { serverName: 'agent', origin: 'agent', message: 'Proceed?' };
+/** A fallback that never resolves — so the ledger/abort branch decides. */
+const neverFallback = () => new Promise<ElicitationResult>(() => { /* pending forever */ });
+
+describe('makeLedgerChannelHandler', () => {
+  it('resolves from a VERIFIED ledger response (phone answers)', async () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    const writer = new SessionLedgerWriter(id);
+    const handler = makeLedgerChannelHandler({
+      sessionId: id,
+      key,
+      emitElicitation: (rec) => writer.record(rec),
+      fallback: neverFallback,
+      newReqId: () => 'rX',
+    });
+
+    const p = handler(REQUEST, { signal: new AbortController().signal });
+    await sleep(80);
+    const result: ElicitationResult = { action: 'accept', content: { value: 'yes' } };
+    const hmac = signElicitationResponse(key, id, 'rX', result);
+    writer.record({ kind: 'elicitation_response', reqId: 'rX', result, hmac });
+
+    await expect(p).resolves.toEqual(result);
+    await writer.close();
+  });
+
+  it('IGNORES a forged (bad-HMAC) response, then the keyboard fallback wins', async () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    const writer = new SessionLedgerWriter(id);
+    let resolveKbd!: (r: ElicitationResult) => void;
+    const kbdResult: ElicitationResult = { action: 'accept', content: { value: 'from-keyboard' } };
+    const handler = makeLedgerChannelHandler({
+      sessionId: id,
+      key,
+      emitElicitation: (rec) => writer.record(rec),
+      fallback: () => new Promise<ElicitationResult>((res) => { resolveKbd = res; }),
+      newReqId: () => 'rY',
+    });
+
+    const p = handler(REQUEST, { signal: new AbortController().signal });
+    await sleep(80);
+    // Daemon (or a stray writer) emits a FORGED response — wrong signature.
+    writer.record({
+      kind: 'elicitation_response',
+      reqId: 'rY',
+      result: { action: 'accept', content: { value: 'EVIL' } },
+      hmac: 'deadbeefdeadbeef',
+    });
+    await sleep(350); // give the tail time to see + reject it
+
+    // The forged reply must NOT have resolved the handler. Now the keyboard answers.
+    resolveKbd(kbdResult);
+    await expect(p).resolves.toEqual(kbdResult);
+    await writer.close();
+  });
+
+  it('resolves from the keyboard fallback when it answers first', async () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    const writer = new SessionLedgerWriter(id);
+    const kbdResult: ElicitationResult = { action: 'accept', content: { value: 'kbd' } };
+    const handler = makeLedgerChannelHandler({
+      sessionId: id,
+      key,
+      emitElicitation: (rec) => writer.record(rec),
+      fallback: async () => kbdResult,
+      newReqId: () => 'rZ',
+    });
+    await expect(handler(REQUEST, { signal: new AbortController().signal })).resolves.toEqual(kbdResult);
+    await writer.close();
+  });
+
+  it('declines on abort', async () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    const writer = new SessionLedgerWriter(id);
+    const ac = new AbortController();
+    const handler = makeLedgerChannelHandler({
+      sessionId: id,
+      key,
+      emitElicitation: (rec) => writer.record(rec),
+      fallback: neverFallback,
+      newReqId: () => 'rA',
+    });
+    const p = handler(REQUEST, { signal: ac.signal });
+    await sleep(50);
+    ac.abort();
+    await expect(p).resolves.toEqual({ action: 'decline' });
+    await writer.close();
+  });
+
+  it('declines immediately when the signal is already aborted', async () => {
+    const id = freshId();
+    const ac = new AbortController();
+    ac.abort();
+    const handler = makeLedgerChannelHandler({
+      sessionId: id,
+      key: ensureSessionKey(id)!,
+      emitElicitation: () => { throw new Error('should not emit when pre-aborted'); },
+      fallback: neverFallback,
+    });
+    await expect(handler(REQUEST, { signal: ac.signal })).resolves.toEqual({ action: 'decline' });
+  });
+
+  it('with no key, ignores even a validly-signed response (cannot verify) and uses the keyboard', async () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!; // a real key exists on disk...
+    const writer = new SessionLedgerWriter(id);
+    const kbdResult: ElicitationResult = { action: 'accept', content: { value: 'kbd-only' } };
+    let resolveKbd!: (r: ElicitationResult) => void;
+    const handler = makeLedgerChannelHandler({
+      sessionId: id,
+      key: null, // ...but the handler was given no key → ledger branch disabled
+      emitElicitation: (rec) => writer.record(rec),
+      fallback: () => new Promise<ElicitationResult>((res) => { resolveKbd = res; }),
+      newReqId: () => 'rN',
+    });
+    const p = handler(REQUEST, { signal: new AbortController().signal });
+    await sleep(60);
+    const result: ElicitationResult = { action: 'accept', content: { value: 'signed-but-ignored' } };
+    writer.record({
+      kind: 'elicitation_response',
+      reqId: 'rN',
+      result,
+      hmac: signElicitationResponse(key, id, 'rN', result),
+    });
+    await sleep(300);
+    resolveKbd(kbdResult);
+    await expect(p).resolves.toEqual(kbdResult);
+    await writer.close();
+  });
+});

--- a/src/agent/afk-ledger-channel.test.ts
+++ b/src/agent/afk-ledger-channel.test.ts
@@ -17,9 +17,9 @@ import * as path from 'node:path';
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-ledgerchan-test-'));
 process.env['AFK_HOME'] = tmpDir;
 
-import { makeLedgerChannelHandler } from './afk-ledger-channel.js';
+import { makeLedgerChannelHandler, makeAbortWatcher } from './afk-ledger-channel.js';
 import { SessionLedgerWriter } from './session-ledger.js';
-import { ensureSessionKey, signElicitationResponse } from './afk-channel.js';
+import { ensureSessionKey, signElicitationResponse, signAbortRequest } from './afk-channel.js';
 import type { ElicitationRequest, ElicitationResult } from './types/sdk-types.js';
 
 let seq = 0;
@@ -160,6 +160,112 @@ describe('makeLedgerChannelHandler', () => {
     await sleep(300);
     resolveKbd(kbdResult);
     await expect(p).resolves.toEqual(kbdResult);
+    await writer.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// makeAbortWatcher — criterion 4
+// ---------------------------------------------------------------------------
+
+describe('makeAbortWatcher (criterion 4)', () => {
+  it('fires onAbort ONLY on a VERIFIED abort_request, not on a forged one', async () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    const writer = new SessionLedgerWriter(id);
+    const abortReasons: string[] = [];
+
+    const watcher = makeAbortWatcher({
+      sessionId: id,
+      key,
+      onAbort: (reason) => abortReasons.push(reason),
+    });
+
+    await sleep(80);
+
+    // Write a FORGED abort_request (bad HMAC). Must be IGNORED.
+    writer.record({ kind: 'abort_request', nonce: 'bad-nonce', hmac: 'deadbeefdeadbeef' });
+    await sleep(200);
+    expect(abortReasons).toHaveLength(0);
+
+    // Write a VERIFIED abort_request. Must fire onAbort exactly once.
+    const nonce = 'valid-nonce-001';
+    const hmac = signAbortRequest(key, id, nonce);
+    writer.record({ kind: 'abort_request', nonce, hmac });
+    await sleep(200);
+
+    expect(abortReasons).toHaveLength(1);
+    expect(abortReasons[0]).toContain('abort');
+
+    watcher.stop();
+    await writer.close();
+  });
+
+  it('key=null → never calls onAbort, even for a validly-signed record', async () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!; // a real key exists on disk…
+    const writer = new SessionLedgerWriter(id);
+    const abortReasons: string[] = [];
+
+    // …but the watcher is given no key → ledger branch disabled.
+    const watcher = makeAbortWatcher({
+      sessionId: id,
+      key: null,
+      onAbort: (reason) => abortReasons.push(reason),
+    });
+
+    await sleep(60);
+    const nonce = 'valid-nonce-002';
+    const hmac = signAbortRequest(key, id, nonce);
+    writer.record({ kind: 'abort_request', nonce, hmac });
+    await sleep(300);
+
+    expect(abortReasons).toHaveLength(0);
+
+    watcher.stop();
+    await writer.close();
+  });
+
+  it('stop() ends the watcher — no further onAbort calls after stop', async () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    const writer = new SessionLedgerWriter(id);
+    const abortReasons: string[] = [];
+
+    const watcher = makeAbortWatcher({
+      sessionId: id,
+      key,
+      onAbort: (reason) => abortReasons.push(reason),
+    });
+
+    await sleep(60);
+    // Stop the watcher before any record arrives.
+    watcher.stop();
+    await sleep(60);
+
+    // A valid abort_request arrives AFTER stop → must NOT trigger onAbort.
+    const nonce = 'post-stop-nonce';
+    const hmac = signAbortRequest(key, id, nonce);
+    writer.record({ kind: 'abort_request', nonce, hmac });
+    await sleep(200);
+
+    expect(abortReasons).toHaveLength(0);
+
+    await writer.close();
+  });
+
+  it('stop() is idempotent — calling it multiple times does not throw', async () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    const writer = new SessionLedgerWriter(id);
+    const watcher = makeAbortWatcher({
+      sessionId: id,
+      key,
+      onAbort: () => {},
+    });
+    watcher.stop();
+    watcher.stop();
+    watcher.stop(); // must not throw
     await writer.close();
   });
 });

--- a/src/agent/afk-ledger-channel.ts
+++ b/src/agent/afk-ledger-channel.ts
@@ -50,8 +50,6 @@ export interface AbortWatcherDeps {
    * forwarded to the session AbortGraph.
    */
   onAbort: (reason: string) => void;
-  /** Nonce generator; injectable for tests. */
-  newAbortReason?: () => string;
 }
 
 /** Handle returned by {@link makeAbortWatcher} — call `stop()` to tear down. */

--- a/src/agent/afk-ledger-channel.ts
+++ b/src/agent/afk-ledger-channel.ts
@@ -1,5 +1,5 @@
 /**
- * AFK remote-control: REPL-side ledger ElicitationChannel.
+ * AFK remote-control: REPL-side ledger ElicitationChannel + abort-watcher.
  *
  * Invariant: in AFK mode the REPL swaps its stdin elicitation handler for the
  * one this factory returns. When the agent asks a question, the handler:
@@ -11,9 +11,10 @@
  *      whichever settles first, cancelling the losers via a child AbortSignal.
  *
  * Invariant (scope.lock #4): a ledger reply is acted on ONLY if its per-session
- * HMAC verifies. An unverified/forged `elicitation_response` is ignored, never
- * resolved. With no key the ledger branch is disabled and the handler degrades
- * to the keyboard fallback.
+ * HMAC verifies. An unverified/forged `elicitation_response` or `abort_request`
+ * is ignored, never resolved. With no key the ledger branch is disabled and the
+ * handler degrades to the keyboard fallback. The abort-watcher likewise ignores
+ * any record whose HMAC does not verify — a stray write cannot abort the session.
  *
  * Invariant (#3): the channel is ADDITIVE — the stdin `fallback` always races
  * alongside the phone, so the keyboard never stops working and there is no
@@ -26,11 +27,93 @@
  */
 
 import { tailLedger } from './session-ledger.js';
-import { verifyElicitationResponse, freshChannelId } from './afk-channel.js';
+import { verifyElicitationResponse, verifyAbortRequest, freshChannelId } from './afk-channel.js';
 import type { ElicitationHandler } from './elicitation-router.js';
 import type { ElicitationRequest, ElicitationResult } from './types/sdk-types.js';
 
 const DECLINE: ElicitationResult = { action: 'decline' };
+
+// ---------------------------------------------------------------------------
+// AbortWatcher
+// ---------------------------------------------------------------------------
+
+export interface AbortWatcherDeps {
+  /** Session id whose ledger to tail for abort_request records. */
+  sessionId: string;
+  /**
+   * Per-session HMAC key. When null the watcher is a no-op: we cannot verify
+   * any abort record, so we must never act on one (Invariant #4).
+   */
+  key: string | null;
+  /**
+   * Called ONLY when a VERIFIED abort_request arrives. The reason string is
+   * forwarded to the session AbortGraph.
+   */
+  onAbort: (reason: string) => void;
+  /** Nonce generator; injectable for tests. */
+  newAbortReason?: () => string;
+}
+
+/** Handle returned by {@link makeAbortWatcher} — call `stop()` to tear down. */
+export interface AbortWatcherHandle {
+  stop: () => void;
+}
+
+/**
+ * Start a background ledger tail that watches for `abort_request` records.
+ *
+ * Invariant (scope.lock #4): the REPL fires the AbortGraph ONLY on a
+ * HMAC-VERIFIED abort_request. An unverified record (bad HMAC, forged nonce,
+ * or cross-session write) is IGNORED, never actioned. With `key === null` the
+ * watcher exits immediately and the `onAbort` callback is NEVER called.
+ *
+ * Mirrors the robustness pattern of `makeLedgerChannelHandler`: a child
+ * AbortController bounds the tail loop; errors are caught and swallowed so a
+ * transient I/O failure cannot propagate to the caller.
+ *
+ * Contract: `stop()` may be called multiple times idempotently. After `stop()`,
+ * `onAbort` is guaranteed not to be called regardless of in-flight records.
+ */
+export function makeAbortWatcher(deps: AbortWatcherDeps): AbortWatcherHandle {
+  const { sessionId, key, onAbort } = deps;
+
+  // Invariant #4: if there is no key we cannot verify → never abort.
+  if (key === null) {
+    return { stop: () => { /* no-op */ } };
+  }
+
+  const child = new AbortController();
+
+  // Run the tail loop in the background. Errors are caught; the loop exits
+  // cleanly when the AbortController is aborted via stop().
+  void (async () => {
+    try {
+      for await (const rec of tailLedger(sessionId, {
+        fromStart: false,
+        signal: child.signal,
+      })) {
+        if (rec.kind !== 'abort_request') continue;
+        // Invariant #4: ONLY act on a VERIFIED abort_request. A forged or
+        // stray write with a bad HMAC is silently ignored — the session
+        // continues unaffected.
+        if (verifyAbortRequest(key, sessionId, rec.nonce, rec.hmac)) {
+          onAbort('remote abort via Telegram');
+          // One verified abort is enough — stop watching.
+          child.abort();
+          return;
+        }
+      }
+    } catch {
+      // Tail I/O error or deliberate abort — exit quietly.
+    }
+  })();
+
+  return {
+    stop: () => {
+      child.abort();
+    },
+  };
+}
 
 export interface LedgerChannelDeps {
   /** Session id whose ledger carries the channel (the REPL's own session). */

--- a/src/agent/afk-ledger-channel.ts
+++ b/src/agent/afk-ledger-channel.ts
@@ -1,0 +1,134 @@
+/**
+ * AFK remote-control: REPL-side ledger ElicitationChannel.
+ *
+ * Invariant: in AFK mode the REPL swaps its stdin elicitation handler for the
+ * one this factory returns. When the agent asks a question, the handler:
+ *   1. opens a tail on its OWN session ledger (at EOF, before emitting) looking
+ *      for a VERIFIED `elicitation_response` correlated by `reqId`;
+ *   2. emits an `elicitation` record (a watching Telegram daemon renders it to
+ *      the operator's phone);
+ *   3. races [verified ledger reply, stdin keyboard fallback, abort] and returns
+ *      whichever settles first, cancelling the losers via a child AbortSignal.
+ *
+ * Invariant (scope.lock #4): a ledger reply is acted on ONLY if its per-session
+ * HMAC verifies. An unverified/forged `elicitation_response` is ignored, never
+ * resolved. With no key the ledger branch is disabled and the handler degrades
+ * to the keyboard fallback.
+ *
+ * Invariant (#3): the channel is ADDITIVE — the stdin `fallback` always races
+ * alongside the phone, so the keyboard never stops working and there is no
+ * daemon-liveness dependency.
+ *
+ * Invariant (#5): the only cross-process hop is the ledger file; this module
+ * opens no socket and starts no poller.
+ *
+ * @module agent/afk-ledger-channel
+ */
+
+import { tailLedger } from './session-ledger.js';
+import { verifyElicitationResponse, freshChannelId } from './afk-channel.js';
+import type { ElicitationHandler } from './elicitation-router.js';
+import type { ElicitationRequest, ElicitationResult } from './types/sdk-types.js';
+
+const DECLINE: ElicitationResult = { action: 'decline' };
+
+export interface LedgerChannelDeps {
+  /** Session id whose ledger carries the channel (the REPL's own session). */
+  sessionId: string;
+  /**
+   * Per-session HMAC key (from `ensureSessionKey`). When null, the ledger reply
+   * branch is disabled (cannot verify → must ignore) and only the keyboard
+   * fallback + abort race — the safe degrade.
+   */
+  key: string | null;
+  /**
+   * Append the `elicitation` request record to the session's ledger. Injected
+   * so this module never owns a `SessionLedgerWriter` lifecycle — the caller
+   * passes its session writer's `record`, avoiding fd leaks and spurious
+   * `closed` records.
+   */
+  emitElicitation: (record: {
+    kind: 'elicitation';
+    reqId: string;
+    request: ElicitationRequest;
+  }) => void;
+  /** Keyboard fallback — the existing stdin elicitation handler. */
+  fallback: ElicitationHandler;
+  /** Correlation-id generator; injectable for tests. */
+  newReqId?: () => string;
+}
+
+/**
+ * Build the REPL-side ledger ElicitationChannel handler. See module docs.
+ */
+export function makeLedgerChannelHandler(deps: LedgerChannelDeps): ElicitationHandler {
+  const { sessionId, key, emitElicitation, fallback } = deps;
+  const newReqId = deps.newReqId ?? freshChannelId;
+
+  return function ledgerChannelHandler(
+    request: ElicitationRequest,
+    options: { signal: AbortSignal },
+  ): Promise<ElicitationResult> {
+    const outer = options.signal;
+    if (outer.aborted) return Promise.resolve(DECLINE);
+
+    const reqId = newReqId();
+
+    let settle!: (r: ElicitationResult) => void;
+    const winner = new Promise<ElicitationResult>((resolve) => {
+      settle = resolve;
+    });
+
+    // Child signal cancels the losing branches once a winner settles (or the
+    // outer turn aborts). It never auto-aborts the outer signal.
+    const child = new AbortController();
+    const onOuterAbort = (): void => {
+      child.abort();
+      settle(DECLINE);
+    };
+    outer.addEventListener('abort', onOuterAbort, { once: true });
+
+    // Ledger branch — only when we can verify (Invariant #4). Armed before the
+    // emit so the response can never be missed.
+    if (key) {
+      void (async () => {
+        try {
+          for await (const rec of tailLedger(sessionId, {
+            fromStart: false,
+            signal: child.signal,
+          })) {
+            if (rec.kind === 'elicitation_response' && rec.reqId === reqId) {
+              if (verifyElicitationResponse(key, sessionId, reqId, rec.result, rec.hmac)) {
+                settle(rec.result);
+                return;
+              }
+              // Unverified/forged response — ignore and keep waiting. This is
+              // the security boundary: a stray write cannot drive the agent.
+            }
+          }
+        } catch {
+          // Tail error → the ledger branch yields to fallback/abort.
+        }
+      })();
+    }
+
+    // Emit the question for a watching daemon to render (after the tail is armed).
+    try {
+      emitElicitation({ kind: 'elicitation', reqId, request });
+    } catch {
+      // If the emit fails the ledger branch is moot; fallback/abort still race.
+    }
+
+    // Keyboard fallback — always live (Invariant #3).
+    void Promise.resolve(fallback(request, { signal: child.signal }))
+      .then((r) => settle(r))
+      .catch(() => {
+        /* fallback failure yields to the ledger/abort branches */
+      });
+
+    return winner.finally(() => {
+      child.abort();
+      outer.removeEventListener('abort', onOuterAbort);
+    });
+  };
+}

--- a/src/agent/awareness/presence.ts
+++ b/src/agent/awareness/presence.ts
@@ -39,6 +39,16 @@ export interface PresenceFileInfo {
   model: { provider: string; name: string };
   workspace: RuntimeWorkspace;
   pid: number;
+  /**
+   * AFK remote-control marker (bidirectional Telegram). Set `true` by the REPL
+   * `/afk on` toggle and cleared on `/afk off` via {@link setPresenceAfk}. A
+   * watching Telegram daemon filters `readPresenceFiles()` on
+   * `surface === 'cli' && afk === true` to auto-discover sessions whose
+   * questions it should render to the operator's phone. Optional/additive:
+   * absent (treated as `false`) on sessions that never entered AFK mode and on
+   * every non-REPL surface.
+   */
+  afk?: boolean;
 }
 
 /** A presence record loaded from disk — same as PresenceFileInfo plus the file path. */
@@ -86,6 +96,25 @@ export async function writePresenceFile(info: PresenceFileInfo): Promise<void> {
     await writeFile(filePath, JSON.stringify(info, null, 2), 'utf8');
   } catch {
     // Best-effort — swallow silently.
+  }
+}
+
+/**
+ * Update the `afk` marker on an existing presence file (best-effort,
+ * read-modify-write). Used by the REPL `/afk` toggle so a watching Telegram
+ * daemon can discover AFK sessions via `readPresenceFiles()`. No-op when the
+ * presence file is absent or unreadable (presence is non-critical — the
+ * keyboard elicitation path works regardless). Preserves every other field.
+ */
+export async function setPresenceAfk(sessionId: string, afk: boolean): Promise<void> {
+  try {
+    const filePath = presenceFilePath(sessionId);
+    const raw = await readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as PresenceFileInfo;
+    parsed.afk = afk;
+    await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
+  } catch {
+    // Best-effort — presence is non-critical.
   }
 }
 

--- a/src/agent/session-ledger.test.ts
+++ b/src/agent/session-ledger.test.ts
@@ -282,3 +282,54 @@ describe('tailLedger', () => {
     expect(records).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// AFK remote-control records (cross-process elicitation / abort protocol)
+// ---------------------------------------------------------------------------
+
+describe('AFK remote-control ledger records', () => {
+  it('round-trips an elicitation request through the ledger', async () => {
+    const id = freshId();
+    const writer = new SessionLedgerWriter(id);
+    writer.record({
+      kind: 'elicitation',
+      reqId: 'r1',
+      request: {
+        serverName: 'agent',
+        origin: 'agent',
+        type: 'choice',
+        message: 'Pick one',
+        choices: ['a', 'b'],
+      },
+    });
+    await writer.close();
+
+    const records = await collect(readLedger(id));
+    const elic = records.find((r) => r.kind === 'elicitation');
+    expect(elic).toBeDefined();
+    if (elic && elic.kind === 'elicitation') {
+      expect(elic.reqId).toBe('r1');
+      expect(elic.request.type).toBe('choice');
+      expect(elic.request.choices).toEqual(['a', 'b']);
+    }
+  });
+
+  it('round-trips a signed response and an abort request', async () => {
+    const id = freshId();
+    const writer = new SessionLedgerWriter(id);
+    writer.record({
+      kind: 'elicitation_response',
+      reqId: 'r1',
+      result: { action: 'accept', content: { value: 'b' } },
+      hmac: 'deadbeef',
+    });
+    writer.record({ kind: 'abort_request', nonce: 'n1', hmac: 'cafef00d' });
+    await writer.close();
+
+    const records = await collect(readLedger(id));
+    const resp = records.find((r) => r.kind === 'elicitation_response');
+    const abort = records.find((r) => r.kind === 'abort_request');
+    expect(resp && resp.kind === 'elicitation_response' && resp.result.action).toBe('accept');
+    expect(abort && abort.kind === 'abort_request' && abort.nonce).toBe('n1');
+  });
+});

--- a/src/agent/session-ledger.ts
+++ b/src/agent/session-ledger.ts
@@ -28,6 +28,7 @@ import * as fsp from 'node:fs/promises';
 import * as readline from 'node:readline';
 import { getSessionLedgerDir, getSessionLedgerPath, isSafeLedgerSessionId } from '../paths.js';
 import type { OutputEvent } from './types/session-types.js';
+import type { ElicitationRequest, ElicitationResult } from './types/sdk-types.js';
 
 // ---------------------------------------------------------------------------
 // Record schema
@@ -55,6 +56,19 @@ export type LedgerPayload =
   | { kind: 'paused'; resetsAt?: string }
   /** Provider resumed after a usage-limit pause. */
   | { kind: 'resumed' }
+  // Invariant: the three AFK remote-control records below carry the
+  // cross-process elicitation/abort protocol (REPL session <-> Telegram daemon)
+  // over the same ledger file. `elicitation` is written by the REPL when the
+  // agent asks a question while AFK; `elicitation_response` and `abort_request`
+  // are written BACK by the daemon and MUST carry a per-session HMAC (see
+  // afk-channel.ts) — the REPL refuses any whose signature does not verify, so a
+  // stray or cross-session write can never resolve a question or abort a turn.
+  /** AFK: the agent asked a question; `reqId` correlates the response. */
+  | { kind: 'elicitation'; reqId: string; request: ElicitationRequest }
+  /** AFK: an answer to a prior `elicitation`, signed by the daemon. */
+  | { kind: 'elicitation_response'; reqId: string; result: ElicitationResult; hmac: string }
+  /** AFK: a signed request to abort the running turn. */
+  | { kind: 'abort_request'; nonce: string; hmac: string }
   /** Terminal record: the hosting process closed the session. */
   | { kind: 'closed'; reason?: string };
 

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -48,6 +48,7 @@ import type {
 } from '../types.js';
 import { QueryInputStream } from './input-iterable.js';
 import { SessionLedgerWriter } from '../session-ledger.js';
+import type { ElicitationRequest } from '../types/sdk-types.js';
 import { env } from '../../config/env.js';
 import { resolveModelId } from './model-resolution.js';
 import { setSlotBindings } from './model-slots.js';
@@ -579,6 +580,23 @@ export class AgentSession implements IAgentSession {
     this.ledger = null;
     this.ledgerInitAttempted = false;
     return ledger.close(reason);
+  }
+
+  /**
+   * Append an AFK remote-control `elicitation` record to this session's own
+   * ledger. No-op when the session is unledgered (subagent, ledger disabled,
+   * or no provider session id yet) — the caller's keyboard fallback still
+   * works regardless (channel is additive, scope.lock invariant #3).
+   *
+   * Used by the REPL AFK ledger channel (`makeLedgerChannelHandler`'s injected
+   * `emitElicitation`): the handler must NOT own a second `SessionLedgerWriter`
+   * (fd leak / spurious `closed` record), so it appends through the session's
+   * lifecycle-managed writer here. A watching Telegram daemon renders the
+   * appended `elicitation` to the operator's phone. Additive: changes no
+   * existing path.
+   */
+  recordLedgerElicitation(reqId: string, request: ElicitationRequest): void {
+    this.ledger?.record({ kind: 'elicitation', reqId, request });
   }
 
   private summarizeContentBlocks(blocks: ContentBlockParam[]): string {

--- a/src/cli/afk-mode-toggle.test.ts
+++ b/src/cli/afk-mode-toggle.test.ts
@@ -27,8 +27,29 @@ vi.mock('./commands/interactive/afk-push.js', () => ({
   resetAfkPushBudget: () => resetAfkPushBudget(),
 }));
 
+// AFK ledger-channel collaborators — mocked so this stays a pure unit test of
+// toggleAfkMode's orchestration. The real ledger handler, HMAC key, and
+// presence writer are covered by their own suites (afk-ledger-channel.test.ts,
+// afk-channel.test.ts).
+const ensureSessionKey = vi.fn((_id: string): string | null => 'a'.repeat(64));
+vi.mock('../agent/afk-channel.js', () => ({
+  ensureSessionKey: (id: string) => ensureSessionKey(id),
+}));
+const ledgerHandlerSentinel: ElicitationHandler = () => Promise.resolve({ action: 'decline' });
+const makeLedgerChannelHandler = vi.fn(
+  (_deps: unknown): ElicitationHandler => ledgerHandlerSentinel,
+);
+vi.mock('../agent/afk-ledger-channel.js', () => ({
+  makeLedgerChannelHandler: (deps: unknown) => makeLedgerChannelHandler(deps),
+}));
+const setPresenceAfk = vi.fn();
+vi.mock('../agent/awareness/presence.js', () => ({
+  setPresenceAfk: (id: string, afk: boolean) => setPresenceAfk(id, afk),
+}));
+
 import { toggleAfkMode } from './afk-mode-toggle.js';
 import type { SessionStats, SlashContext } from './slash/types.js';
+import type { ElicitationHandler } from '../agent/elicitation-router.js';
 
 function makeStats(overrides: Partial<SessionStats> = {}): SessionStats {
   return {
@@ -49,11 +70,27 @@ function makeStats(overrides: Partial<SessionStats> = {}): SessionStats {
 function makeCtx(opts: {
   stats: SessionStats;
   setPermissionMode?: ReturnType<typeof vi.fn>;
-}): { ctx: SlashContext; sess: { setPermissionMode: ReturnType<typeof vi.fn> }; lines: string[] } {
+  sessionId?: string;
+  withChannel?: boolean;
+}): {
+  ctx: SlashContext;
+  sess: {
+    setPermissionMode: ReturnType<typeof vi.fn>;
+    sessionId: string | undefined;
+    recordLedgerElicitation: ReturnType<typeof vi.fn>;
+  };
+  lines: string[];
+  swapCalls: (ElicitationHandler | null)[];
+  stdinHandler: ElicitationHandler;
+} {
   const lines: string[] = [];
   const sess = {
     setPermissionMode: opts.setPermissionMode ?? vi.fn().mockResolvedValue(undefined),
+    sessionId: opts.sessionId,
+    recordLedgerElicitation: vi.fn(),
   };
+  const stdinHandler: ElicitationHandler = () => Promise.resolve({ action: 'decline' });
+  const swapCalls: (ElicitationHandler | null)[] = [];
   const ctx: SlashContext = {
     session: { current: sess } as unknown as SlashContext['session'],
     stats: opts.stats,
@@ -66,8 +103,16 @@ function makeCtx(opts: {
       error: (t) => lines.push(`ERROR:${t}`),
     },
     ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
+    ...(opts.withChannel
+      ? {
+          stdinElicitationHandler: stdinHandler,
+          swapElicitationHandler: (h: ElicitationHandler | null) => {
+            swapCalls.push(h);
+          },
+        }
+      : {}),
   };
-  return { ctx, sess, lines };
+  return { ctx, sess, lines, swapCalls, stdinHandler };
 }
 
 describe('toggleAfkMode', () => {
@@ -136,5 +181,108 @@ describe('toggleAfkMode', () => {
     expect(setPermissionMode).toHaveBeenCalledWith('autonomous');
     expect(stats.permissionMode).toBe('default');
     expect(lines.some((l) => l.startsWith('ERROR:'))).toBe(true);
+  });
+});
+
+describe('toggleAfkMode — AFK ledger channel wiring (scope.lock criterion 1)', () => {
+  beforeEach(() => {
+    mockToken = 'bot-token';
+    mockTargets = [123456];
+    resetAfkPushBudget.mockClear();
+    ensureSessionKey.mockClear();
+    makeLedgerChannelHandler.mockClear();
+    setPresenceAfk.mockClear();
+  });
+
+  it('on /afk on, swaps to the ledger channel handler and marks presence AFK', async () => {
+    const { ctx, sess, swapCalls, stdinHandler } = makeCtx({
+      stats: makeStats({ permissionMode: 'default' }),
+      sessionId: 's1',
+      withChannel: true,
+    });
+
+    await toggleAfkMode(ctx, true);
+
+    // Built the ledger handler against the right deps (live id + HMAC key +
+    // the keyboard fallback) ...
+    expect(makeLedgerChannelHandler).toHaveBeenCalledTimes(1);
+    expect(makeLedgerChannelHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 's1',
+        key: 'a'.repeat(64),
+        fallback: stdinHandler,
+        emitElicitation: expect.any(Function),
+      }),
+    );
+    // ... and installed THAT handler (not the stdin fallback).
+    expect(swapCalls).toHaveLength(1);
+    expect(swapCalls[0]).toBe(ledgerHandlerSentinel);
+    expect(swapCalls[0]).not.toBe(stdinHandler);
+    expect(setPresenceAfk).toHaveBeenCalledWith('s1', true);
+    expect(sess.setPermissionMode).toHaveBeenCalledWith('autonomous');
+  });
+
+  it('wires emitElicitation to append via the session ledger writer', async () => {
+    const { ctx, sess } = makeCtx({
+      stats: makeStats(),
+      sessionId: 's1',
+      withChannel: true,
+    });
+
+    await toggleAfkMode(ctx, true);
+
+    const firstCall = makeLedgerChannelHandler.mock.calls[0];
+    if (!firstCall) throw new Error('expected makeLedgerChannelHandler to be called');
+    const deps = firstCall[0] as {
+      emitElicitation: (r: { kind: 'elicitation'; reqId: string; request: unknown }) => void;
+    };
+    const request = { type: 'text', message: 'pick one' };
+    deps.emitElicitation({ kind: 'elicitation', reqId: 'r1', request });
+    expect(sess.recordLedgerElicitation).toHaveBeenCalledWith('r1', request);
+  });
+
+  it('on /afk off, restores stdin (null swap) and clears the AFK presence marker', async () => {
+    const { ctx, swapCalls } = makeCtx({
+      stats: makeStats({ permissionMode: 'autonomous' }),
+      sessionId: 's1',
+      withChannel: true,
+    });
+
+    await toggleAfkMode(ctx, false);
+
+    expect(swapCalls).toEqual([null]);
+    expect(setPresenceAfk).toHaveBeenCalledWith('s1', false);
+    expect(makeLedgerChannelHandler).not.toHaveBeenCalled();
+  });
+
+  it('degrades to keyboard-only when the provider session id is not yet known', async () => {
+    const { ctx, swapCalls } = makeCtx({
+      stats: makeStats({ permissionMode: 'default' }),
+      // no sessionId → e.g. /afk on before the first turn issued an id
+      withChannel: true,
+    });
+
+    await toggleAfkMode(ctx, true);
+
+    expect(makeLedgerChannelHandler).not.toHaveBeenCalled();
+    expect(swapCalls).toHaveLength(0);
+    expect(setPresenceAfk).not.toHaveBeenCalled();
+    // AFK still entered — channel is additive, the keyboard stays live.
+    expect(ctx.stats.permissionMode).toBe('autonomous');
+  });
+
+  it('no-ops the swap on a surface that exposes no channel (non-REPL)', async () => {
+    const { ctx, swapCalls } = makeCtx({
+      stats: makeStats(),
+      sessionId: 's1',
+      withChannel: false,
+    });
+
+    await toggleAfkMode(ctx, true);
+
+    expect(makeLedgerChannelHandler).not.toHaveBeenCalled();
+    expect(swapCalls).toHaveLength(0);
+    expect(setPresenceAfk).not.toHaveBeenCalled();
+    expect(ctx.stats.permissionMode).toBe('autonomous');
   });
 });

--- a/src/cli/afk-mode-toggle.test.ts
+++ b/src/cli/afk-mode-toggle.test.ts
@@ -39,8 +39,13 @@ const ledgerHandlerSentinel: ElicitationHandler = () => Promise.resolve({ action
 const makeLedgerChannelHandler = vi.fn(
   (_deps: unknown): ElicitationHandler => ledgerHandlerSentinel,
 );
+// Stub abort-watcher: returns a no-op handle; correctness tested in its own suite.
+const makeAbortWatcher = vi.fn(
+  (_deps: unknown): { stop: () => void } => ({ stop: () => {} }),
+);
 vi.mock('../agent/afk-ledger-channel.js', () => ({
   makeLedgerChannelHandler: (deps: unknown) => makeLedgerChannelHandler(deps),
+  makeAbortWatcher: (deps: unknown) => makeAbortWatcher(deps),
 }));
 const setPresenceAfk = vi.fn();
 vi.mock('../agent/awareness/presence.js', () => ({
@@ -191,6 +196,7 @@ describe('toggleAfkMode — AFK ledger channel wiring (scope.lock criterion 1)',
     resetAfkPushBudget.mockClear();
     ensureSessionKey.mockClear();
     makeLedgerChannelHandler.mockClear();
+    makeAbortWatcher.mockClear();
     setPresenceAfk.mockClear();
   });
 
@@ -284,5 +290,56 @@ describe('toggleAfkMode — AFK ledger channel wiring (scope.lock criterion 1)',
     expect(swapCalls).toHaveLength(0);
     expect(setPresenceAfk).not.toHaveBeenCalled();
     expect(ctx.stats.permissionMode).toBe('autonomous');
+  });
+
+  // Criterion 4: abort-watcher wiring
+  it('on /afk on, starts the abort-watcher bound to the same session and key', async () => {
+    const { ctx } = makeCtx({
+      stats: makeStats({ permissionMode: 'default' }),
+      sessionId: 's2',
+      withChannel: true,
+    });
+
+    await toggleAfkMode(ctx, true);
+
+    expect(makeAbortWatcher).toHaveBeenCalledTimes(1);
+    expect(makeAbortWatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 's2',
+        key: 'a'.repeat(64),
+        onAbort: expect.any(Function),
+      }),
+    );
+  });
+
+  it('on /afk off, stops the abort-watcher (stop() is called)', async () => {
+    // Turn ON first to install the watcher.
+    const { ctx } = makeCtx({
+      stats: makeStats({ permissionMode: 'default' }),
+      sessionId: 's3',
+      withChannel: true,
+    });
+    await toggleAfkMode(ctx, true);
+
+    const handle = makeAbortWatcher.mock.results[0]?.value as { stop: ReturnType<typeof vi.fn> } | undefined;
+    expect(handle).toBeDefined();
+    // The stub returns { stop: () => {} }; spy on it.
+    const stopSpy = vi.spyOn(handle!, 'stop');
+
+    // Now turn OFF.
+    await toggleAfkMode(ctx, false);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('abort-watcher is not started when no channel (non-REPL surface)', async () => {
+    const { ctx } = makeCtx({
+      stats: makeStats({ permissionMode: 'default' }),
+      sessionId: 's4',
+      withChannel: false,
+    });
+
+    await toggleAfkMode(ctx, true);
+
+    expect(makeAbortWatcher).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/afk-mode-toggle.ts
+++ b/src/cli/afk-mode-toggle.ts
@@ -27,6 +27,9 @@
 import { env } from '../config/env.js';
 import { resolveConfiguredNotifyTargets } from '../telegram/notify-routing.js';
 import { resetAfkPushBudget } from './commands/interactive/afk-push.js';
+import { ensureSessionKey } from '../agent/afk-channel.js';
+import { makeLedgerChannelHandler } from '../agent/afk-ledger-channel.js';
+import { setPresenceAfk } from '../agent/awareness/presence.js';
 import { palette } from './palette.js';
 import type { SlashContext } from './slash/types.js';
 
@@ -49,6 +52,27 @@ export async function toggleAfkMode(
     ctx.ui.repaintStatusLine();
     if (next) {
       resetAfkPushBudget();
+      // Bidirectional AFK (scope.lock criterion 1): swap the elicitation handler
+      // to the ledger channel so a watching Telegram daemon can answer the
+      // agent's questions from the operator's phone — racing the keyboard
+      // fallback (invariant #3). Built lazily here because the provider session
+      // id is known only after the first turn; if it is not yet available we
+      // skip the swap and stay keyboard-only (safe degrade). The channel is
+      // bound to the session captured at toggle time.
+      const sess = ctx.session.current;
+      const id = sess.sessionId;
+      const swap = ctx.swapElicitationHandler;
+      const fallback = ctx.stdinElicitationHandler;
+      if (id && swap && fallback) {
+        const ledgerHandler = makeLedgerChannelHandler({
+          sessionId: id,
+          key: ensureSessionKey(id),
+          emitElicitation: (rec) => sess.recordLedgerElicitation(rec.reqId, rec.request),
+          fallback,
+        });
+        swap(ledgerHandler);
+        void setPresenceAfk(id, true);
+      }
       ctx.out.success(
         palette.info('◐ AFK mode ON') +
         palette.dim(
@@ -64,6 +88,11 @@ export async function toggleAfkMode(
         );
       }
     } else {
+      // Restore the stdin elicitation handler (`null` → reinstall stdin) and
+      // clear the AFK presence marker so a watching daemon stops tracking.
+      ctx.swapElicitationHandler?.(null);
+      const id = ctx.session.current.sessionId;
+      if (id) void setPresenceAfk(id, false);
       ctx.out.success(
         palette.success('○ AFK mode OFF') + palette.dim(' — default permissions restored'),
       );

--- a/src/cli/afk-mode-toggle.ts
+++ b/src/cli/afk-mode-toggle.ts
@@ -28,10 +28,18 @@ import { env } from '../config/env.js';
 import { resolveConfiguredNotifyTargets } from '../telegram/notify-routing.js';
 import { resetAfkPushBudget } from './commands/interactive/afk-push.js';
 import { ensureSessionKey } from '../agent/afk-channel.js';
-import { makeLedgerChannelHandler } from '../agent/afk-ledger-channel.js';
+import { makeLedgerChannelHandler, makeAbortWatcher, type AbortWatcherHandle } from '../agent/afk-ledger-channel.js';
 import { setPresenceAfk } from '../agent/awareness/presence.js';
 import { palette } from './palette.js';
 import type { SlashContext } from './slash/types.js';
+
+// Module-level abort-watcher handle. One REPL = one AFK session at a time, so
+// a single handle is sufficient. Cleared on /afk off or when a new /afk on
+// replaces it (the old one is stopped first).
+//
+// Invariant: the handle is always stopped before being replaced so we never
+// leave orphaned tail loops running against old sessions.
+let _abortWatcherHandle: AbortWatcherHandle | null = null;
 
 /** True when Telegram outbound is fully configured (token + ≥1 chat target). */
 function isTelegramConfigured(): boolean {
@@ -64,13 +72,22 @@ export async function toggleAfkMode(
       const swap = ctx.swapElicitationHandler;
       const fallback = ctx.stdinElicitationHandler;
       if (id && swap && fallback) {
+        const key = ensureSessionKey(id);
         const ledgerHandler = makeLedgerChannelHandler({
           sessionId: id,
-          key: ensureSessionKey(id),
+          key,
           emitElicitation: (rec) => sess.recordLedgerElicitation(rec.reqId, rec.request),
           fallback,
         });
         swap(ledgerHandler);
+        // Start the abort-watcher (criterion 4). Stop any previous one first
+        // (idempotent guard — protects against rapid /afk on/on).
+        _abortWatcherHandle?.stop();
+        _abortWatcherHandle = makeAbortWatcher({
+          sessionId: id,
+          key,
+          onAbort: (reason) => sess.abort(reason),
+        });
         void setPresenceAfk(id, true);
       }
       ctx.out.success(
@@ -91,6 +108,9 @@ export async function toggleAfkMode(
       // Restore the stdin elicitation handler (`null` → reinstall stdin) and
       // clear the AFK presence marker so a watching daemon stops tracking.
       ctx.swapElicitationHandler?.(null);
+      // Stop the abort-watcher (best-effort; guarded against null).
+      _abortWatcherHandle?.stop();
+      _abortWatcherHandle = null;
       const id = ctx.session.current.sessionId;
       if (id) void setPresenceAfk(id, false);
       ctx.out.success(

--- a/src/cli/afk-no-telegraf-poller.test.ts
+++ b/src/cli/afk-no-telegraf-poller.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Invariant test: the REPL / CLI / AFK-channel code NEVER constructs a Telegraf
+ * poller in-process.
+ *
+ * Scope-lock Invariant #2 (from `.afk/plans/afk-telegram-bidirectional.scope.lock.md`):
+ *   "Daemon is the SOLE Telegram `getUpdates` poller; REPL NEVER constructs a
+ *   Telegraf/second poller (409)."
+ *
+ * Why this matters: Telegram's long-poll API rejects a second concurrent
+ * `getUpdates` consumer with HTTP 409 Conflict. If any REPL code path were to
+ * instantiate a `Telegraf` object and call `launch()`, every message to the bot
+ * would silently fail while the daemon is running. The bidirectional AFK channel
+ * deliberately routes ALL Telegram I/O through the daemon process
+ * (`src/telegram/`). The REPL communicates with the daemon only via the
+ * per-session ledger file — no socket, no second poller.
+ *
+ * The test scans every non-test TypeScript file under the REPL/agent AFK paths
+ * and asserts zero occurrences of:
+ *   - `from 'telegraf'` or `from "telegraf"` (telegraf runtime import)
+ *   - `new Telegraf(` (direct Telegraf instantiation)
+ *
+ * The scanned paths are:
+ *   src/cli/**\/*.ts       — all CLI source (REPL, slash commands, etc.)
+ *   src/agent/afk-ledger-channel.ts  — REPL-side ledger channel
+ *   src/agent/afk-channel.ts         — per-session HMAC helpers
+ *   src/agent/elicitation-router.ts  — module-scope elicitation router
+ *
+ * src/telegram/** is EXPLICITLY EXCLUDED: the daemon is the legitimate
+ * sole owner of Telegraf and this test must not flag it.
+ *
+ * The test is NON-VACUOUS: it asserts that the scanned-file count > 0, so a
+ * broken glob cannot produce a spurious pass.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/** Recursively collect *.ts files under `dir` (excluding *.test.ts). */
+function collectTs(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectTs(full));
+    } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// build the file list
+// ---------------------------------------------------------------------------
+
+const root = path.resolve(__dirname, '../..');
+
+// All CLI source files (REPL, slash commands, afk-mode-toggle, …)
+const cliFiles = collectTs(path.join(root, 'src/cli'));
+
+// Key agent-side AFK files that run in the REPL process.
+const agentAfkFiles = [
+  path.join(root, 'src/agent/afk-ledger-channel.ts'),
+  path.join(root, 'src/agent/afk-channel.ts'),
+  path.join(root, 'src/agent/elicitation-router.ts'),
+];
+
+const allFiles = [...cliFiles, ...agentAfkFiles];
+
+// ---------------------------------------------------------------------------
+// assertions
+// ---------------------------------------------------------------------------
+
+describe('scope-lock invariant #2: REPL code never imports Telegraf', () => {
+  it('has a non-empty file list to scan (guards against a broken glob)', () => {
+    // If this assertion fails, collectTs broke or the source tree moved.
+    expect(allFiles.length).toBeGreaterThan(0);
+    // Sanity-check: we should have at least the three agent AFK files.
+    expect(allFiles.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('no REPL/CLI/AFK-channel file imports from telegraf', () => {
+    const violations: string[] = [];
+    for (const file of allFiles) {
+      const content = fs.readFileSync(file, 'utf8');
+      if (/from ['"]telegraf['"]/.test(content)) {
+        violations.push(file);
+      }
+    }
+    if (violations.length > 0) {
+      throw new Error(
+        `Scope-lock invariant #2 violated — the following REPL/CLI files import from 'telegraf' ` +
+          `(a second Telegraf instance would cause Telegram 409 Conflict):\n` +
+          violations.map((f) => `  ${path.relative(root, f)}`).join('\n'),
+      );
+    }
+    expect(violations).toHaveLength(0);
+  });
+
+  it('no REPL/CLI/AFK-channel file constructs a Telegraf instance (new Telegraf)', () => {
+    const violations: string[] = [];
+    for (const file of allFiles) {
+      const content = fs.readFileSync(file, 'utf8');
+      if (/new Telegraf\(/.test(content)) {
+        violations.push(file);
+      }
+    }
+    if (violations.length > 0) {
+      throw new Error(
+        `Scope-lock invariant #2 violated — the following REPL/CLI files contain 'new Telegraf(' ` +
+          `(a second Telegraf instance would cause Telegram 409 Conflict):\n` +
+          violations.map((f) => `  ${path.relative(root, f)}`).join('\n'),
+      );
+    }
+    expect(violations).toHaveLength(0);
+  });
+
+  it('reports the number of files scanned (informational)', () => {
+    // This test always passes — its purpose is to make the scanned-file count
+    // visible in the test output so reviewers can confirm the scan is non-trivial.
+    const cliCount = cliFiles.length;
+    const agentCount = agentAfkFiles.length;
+    // Emit a human-readable summary via the assertion message.
+    expect({ cliFiles: cliCount, agentAfkFiles: agentCount, total: allFiles.length }).toMatchObject(
+      { total: expect.any(Number) },
+    );
+  });
+});

--- a/src/cli/commands/interactive/surface-setup.ts
+++ b/src/cli/commands/interactive/surface-setup.ts
@@ -198,7 +198,7 @@ export async function setupSurface(
   // back to the numbered-text path — preserving the pre-picker behaviour
   // for surfaces that can't render a live frame.
   const armedCompositor = surface.getCompositor();
-  elicitationRouter.install(makeReplElicitationHandler({
+  const stdinElicitationHandler = makeReplElicitationHandler({
     readLine: (prompt) =>
       surface.readLine({ promptFn: () => prompt }).then((r) => r.text),
     writer: {
@@ -222,7 +222,8 @@ export async function setupSurface(
       pickFromList: (opts) => runPicker(armedCompositor, opts),
       readTextOverlay: (opts) => runTextInput(armedCompositor, opts),
     } : {}),
-  }));
+  });
+  elicitationRouter.install(stdinElicitationHandler);
 
   // Stage 3e fix — wire the persistent compositor into the ReplRenderer
   // and SlashContext ONCE, here, immediately after the surface arms.
@@ -314,6 +315,18 @@ export async function setupSurface(
   // matching the normal-turn append at onTurnComplete in the loop. Without it,
   // skill-turn output is absent from the autosaved markdown transcript.
   ctx.slashCtx.transcript = transcript;
+
+  // AFK bidirectional Telegram (scope.lock criterion 1): expose the surface's
+  // stdin elicitation handler + a swap primitive so `/afk on` can install the
+  // ledger channel (racing a watching daemon's phone reply against this
+  // keyboard handler) and `/afk off` can restore stdin (`null` → reinstall the
+  // stdin handler). This is the authoritative wiring point — `/afk` is a slash
+  // command that only runs after this surface setup, so the bootstrap-time
+  // startup handler is always superseded here. The router captures its handler
+  // at enqueue time (elicitation-router.ts), so swapping mid-session is safe.
+  ctx.slashCtx.stdinElicitationHandler = stdinElicitationHandler;
+  ctx.slashCtx.swapElicitationHandler = (handler) =>
+    elicitationRouter.install(handler ?? stdinElicitationHandler);
 
   // Wire the armed surface into the elicitation handler's compositor ref so
   // ask_question suspend/resume can yield stdin raw-mode to rl.question.

--- a/src/cli/slash/types.ts
+++ b/src/cli/slash/types.ts
@@ -8,6 +8,7 @@
  */
 
 import type { SessionRef } from '../../agent/session-ref.js';
+import type { ElicitationHandler } from '../../agent/elicitation-router.js';
 import type { AgentModelInput } from '../../agent/types.js';
 import type { PermissionMode } from '../../agent/types/sdk-types.js';
 import type { TrustedSkillLedger } from '../trusted-skill-ledger.js';
@@ -227,6 +228,23 @@ export interface SlashContext {
      */
     appendUser?(userInput: string): Promise<void>;
   };
+  /**
+   * AFK bidirectional Telegram (scope.lock criterion 1). Swap the active
+   * elicitation handler: a non-null handler is installed (the AFK ledger
+   * channel, which races a watching daemon's phone reply against the keyboard);
+   * `null` restores the surface's default stdin handler. Wired in
+   * `surface-setup.ts` after the router install. Absent on surfaces without a
+   * swappable router (Telegram, daemon, tests) — `toggleAfkMode` no-ops the
+   * swap when absent (keyboard stays live; channel is additive, invariant #3).
+   */
+  swapElicitationHandler?: (handler: ElicitationHandler | null) => void;
+  /**
+   * The surface's default stdin elicitation handler — exposed so the AFK
+   * ledger channel can compose it as its always-live keyboard fallback
+   * (invariant #3). Wired alongside `swapElicitationHandler`; absent on
+   * surfaces that never install a stdin handler.
+   */
+  stdinElicitationHandler?: ElicitationHandler;
 }
 
 /** The handler's return value — controls the REPL's next action. */

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -513,6 +513,18 @@ export function getSessionLedgerPath(sessionId: string): string {
 }
 
 /**
+ * Per-session HMAC key for the AFK remote-control channel:
+ * `~/.afk/state/sessions/<sessionId>/session.key`. Written 0600 by the REPL
+ * when AFK mode is enabled; read by the Telegram daemon to sign the
+ * elicitation responses and abort requests it writes back into the session
+ * ledger, and re-verified by the REPL before it acts on them.
+ * @throws if `sessionId` fails {@link isSafeLedgerSessionId}.
+ */
+export function getSessionKeyPath(sessionId: string): string {
+  return join(getSessionLedgerDir(sessionId), 'session.key');
+}
+
+/**
  * Path to the MCP server-status file.
  *
  * Written by `KeychainOAuthProvider.redirectToAuthorization()` when an MCP

--- a/src/telegram/README.md
+++ b/src/telegram/README.md
@@ -171,6 +171,75 @@ Covered:
 - `setup-wizard.test.ts` — `getMe` validation, `getUpdates` parsing,
   poll-with-early-stop
 
+## Bidirectional AFK — daemon role
+
+When a REPL session runs `/afk on`, the daemon becomes the **phone-side half** of a
+bidirectional elicitation channel. The two processes communicate **only through the
+per-session ledger file** (`~/.afk/state/sessions/<id>/events.jsonl`) — no sockets,
+no shared memory, no second Telegram poller.
+
+### Auto-subscribe
+
+Every 30 seconds (configurable via `TelegramBot.AUTO_SUBSCRIBE_INTERVAL_MS`), the bot
+reads all presence files and automatically starts watching any session where
+`surface === 'cli' && afk === true`. No manual `/watch` is needed — stepping away with
+`/afk on` is enough.
+
+### Rendering elicitations to the phone
+
+When the daemon's `SessionWatchManager._run` tail sees an `elicitation` record, it
+invokes `makeTelegramElicitationHandler` (from `elicitation-handler.ts`) to render the
+question interactively:
+
+- **`text` / open-ended questions** — sends a plain message and waits for the next
+  text reply from the operator.
+- **`choice` / `confirm` questions** — renders Telegram inline-keyboard buttons; the
+  operator taps an option.
+
+The message-handler bypasses the `state === 'idle'` guard for ledger-originated
+elicitations via `ledgerOriginatedPendingChats` (a `Set<number>` in
+`handlers/message.ts`) so phone replies are delivered even though no `AgentSession` is
+running inside the daemon for this session.
+
+### Signed write-back
+
+After the operator answers, the daemon:
+
+1. Reads the per-session HMAC key from `~/.afk/state/sessions/<id>/session.key`
+   (written 0600 by the REPL on `/afk on`).
+2. Signs the response with `signElicitationResponse` (HMAC-SHA256 over
+   `recordKind‖sessionId‖reqId‖stableStringify(result)`).
+3. Appends a signed `elicitation_response` record to the ledger.
+
+The REPL verifies the HMAC before acting on the response. An unverified or stray write
+is silently ignored — it cannot drive the agent.
+
+### Remote abort
+
+`/abort` (sent to the bot while watching a session):
+
+1. Daemon looks up the currently-watched session via `watchManager.getWatched(chatId)`.
+2. Signs a `abort_request` record (HMAC over `recordKind‖sessionId‖nonce`).
+3. Appends it to the ledger.
+
+The REPL's `makeAbortWatcher` tail (running since `/afk on`) verifies the HMAC and
+fires the `AbortGraph` — aborting the session cleanly. An unsigned or cross-session
+abort record is ignored.
+
+### Security boundary
+
+The HMAC layer guards against **accidental cross-session bleed** and **stray writers**.
+It is NOT a defence against a malicious same-user process (which can read the 0600 key
+and already has the user's OS privileges). Telegram ingress remains gated by the
+existing `AFK_TELEGRAM_ALLOWED_CHAT_IDS` allowlist. The AFK safety gate
+(`afk-mode-gate.ts`) is **non-overridable** — a remote reply is an input to the
+agent's reasoning, never a gate bypass.
+
+For the full design, threat model, flow diagram, five hard invariants, and known
+limitations, see [`docs/afk-remote-control.md`](../../docs/afk-remote-control.md).
+
+---
+
 ## Design decisions
 
 1. **One session per chat.** Simpler than per-user; works for both

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -60,7 +60,10 @@ export class TelegramBot {
       this.registeredCommandChats,
       this.log.bind(this)
     );
-    this.watchManager = new SessionWatchManager(this.log.bind(this));
+    // Invariant: pass the SOLE Telegraf instance and the MessageHandler so
+    // _run can render elicitation records interactively. No second bot
+    // instance is created here — this.bot is the single getUpdates poller.
+    this.watchManager = new SessionWatchManager(this.log.bind(this), this.bot, this.messageHandler);
 
     this.setupHandlers();
   }

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -18,6 +18,9 @@ import { ELICITATION_CALLBACK_PREFIX } from './elicitation-callback-data.js';
 import { makeTelegramElicitationHandler } from './elicitation-handler.js';
 import { elicitationRouter } from '../agent/elicitation-router.js';
 import { SessionWatchManager, resolveWatchTarget, listWatchableSessions } from './watch.js';
+import { readPresenceFiles } from '../agent/awareness/presence.js';
+import { readSessionKey, signAbortRequest, freshChannelId } from '../agent/afk-channel.js';
+import { SessionLedgerWriter } from '../agent/session-ledger.js';
 import { splitLongMessage } from './formatter.js';
 
 /**
@@ -49,6 +52,10 @@ export class TelegramBot {
   private registeredCommandChats = new Set<number>();
   private messageHandler: MessageHandler;
   private watchManager: SessionWatchManager;
+  /** Interval handle for the AFK presence auto-subscribe loop. */
+  private autoSubscribeInterval: NodeJS.Timeout | null = null;
+  /** How often to poll presence files for new AFK cli sessions (ms). */
+  private static readonly AUTO_SUBSCRIBE_INTERVAL_MS = 5_000;
 
   constructor(options: BotOptions) {
     this.options = options;
@@ -168,6 +175,41 @@ export class TelegramBot {
       await ctx.reply(stopped ? `Stopped watching ${stopped}.` : 'Not watching anything.');
     });
 
+    // /abort — write a signed abort_request to the ledger of the watched
+    // session. The REPL's abort-watcher verifies the HMAC and fires the
+    // AbortGraph only on a valid record (Invariant #4). If the chat is not
+    // watching a session, or the session has no key, reply helpfully.
+    //
+    // Invariant #5: comms only via the ledger; no IPC.
+    // Invariant #4: the abort_request MUST be HMAC-signed; an unsigned one
+    // would be ignored by the REPL anyway.
+    this.bot.command('abort', async (ctx) => {
+      const chatId = ctx.chat?.id;
+      if (!chatId) {
+        await ctx.reply(formatError('Could not identify chat'));
+        return;
+      }
+      const sessionId = this.watchManager.getWatched(chatId);
+      if (!sessionId) {
+        await ctx.reply(
+          'Not watching any session. Use /watch <session-id> to watch a REPL session first, then /abort to stop it.',
+        );
+        return;
+      }
+      const key = readSessionKey(sessionId);
+      if (key === null) {
+        await ctx.reply(
+          'Session key not found — the REPL may not have enabled AFK mode (/afk on). Cannot send a verified abort.',
+        );
+        return;
+      }
+      // Invariant #4: sign the abort so the REPL verifies it before acting.
+      const nonce = freshChannelId();
+      const hmac = signAbortRequest(key, sessionId, nonce);
+      new SessionLedgerWriter(sessionId).record({ kind: 'abort_request', nonce, hmac });
+      await ctx.reply(`✋ Abort sent to session ${sessionId}.`);
+    });
+
     this.bot.on('text', (ctx) => this.messageHandler.handle(ctx));
 
     // Photo updates carry `message.photo[]` not `message.text` — they require
@@ -271,6 +313,13 @@ export class TelegramBot {
     this.running = true;
     this.log('Bot started successfully');
 
+    // Auto-subscribe: periodically discover AFK cli sessions and start
+    // watching them so the operator's phone receives agent questions without
+    // needing a manual /watch. Idempotent — already-watched sessions are not
+    // re-subscribed. The interval is cleared on stop() (Invariant #2: we
+    // only read presence files and call watchManager; no second Telegraf poller).
+    this.startAutoSubscribe();
+
     // Graceful shutdown handlers
     const shutdown = async (signal: string) => {
       this.log(`Received ${signal}, shutting down...`);
@@ -292,6 +341,9 @@ export class TelegramBot {
 
     this.log('Stopping bot...');
     this.running = false;
+
+    this.log('Stopping auto-subscribe loop...');
+    this.stopAutoSubscribe();
 
     this.log('Uninstalling elicitation handler...');
     elicitationRouter.uninstall();
@@ -371,6 +423,97 @@ export class TelegramBot {
 
   async handleModelSwitch(ctx: Context): Promise<void> {
     return handleModelSwitch(ctx, this.sessionManager, this.log.bind(this));
+  }
+
+  /**
+   * Start the presence auto-subscribe loop.
+   *
+   * Polls `readPresenceFiles()` every AUTO_SUBSCRIBE_INTERVAL_MS and calls
+   * `watchManager.start()` for any `surface === 'cli' && afk === true` session
+   * not already watched. Stops auto-watches whose `afk` flag cleared or whose
+   * presence file disappeared.
+   *
+   * Invariant #2: this loop only reads presence files and delegates to
+   * watchManager. It NEVER constructs a Telegraf instance or second poller.
+   *
+   * Idempotency: `watchManager.start()` replaces any existing watch for a chat
+   * only when the session id changes — if the same session is already watched,
+   * the `watching(chatId) === sessionId` guard skips the start call.
+   */
+  private startAutoSubscribe(): void {
+    if (this.autoSubscribeInterval !== null) return;
+    const tick = (): void => {
+      void this.runAutoSubscribeTick().catch((err) =>
+        this.log('auto-subscribe tick error:', err),
+      );
+    };
+    this.autoSubscribeInterval = setInterval(tick, TelegramBot.AUTO_SUBSCRIBE_INTERVAL_MS);
+    // Don't hold the process open solely for presence polling.
+    this.autoSubscribeInterval.unref?.();
+    // Run immediately so the first discovered session is picked up without a
+    // full interval delay.
+    tick();
+  }
+
+  private stopAutoSubscribe(): void {
+    if (this.autoSubscribeInterval !== null) {
+      clearInterval(this.autoSubscribeInterval);
+      this.autoSubscribeInterval = null;
+    }
+  }
+
+  /**
+   * One tick of the auto-subscribe loop. Reads presence files and starts
+   * (or stops) watches for AFK cli sessions.
+   *
+   * Contract: if `allowedChatIds` is empty there are no allowed chats to
+   * subscribe to — the tick exits early without scanning presence files.
+   */
+  private async runAutoSubscribeTick(): Promise<void> {
+    const chatIds = [...this.options.allowedChatIds];
+    if (chatIds.length === 0) return;
+
+    let presence: Awaited<ReturnType<typeof readPresenceFiles>>;
+    try {
+      presence = await readPresenceFiles();
+    } catch {
+      return; // presence dir unreadable — ignore silently
+    }
+
+    // Find all AFK cli sessions currently advertised in presence files.
+    const afkSessionIds = new Set(
+      presence
+        .filter((p) => p.surface === 'cli' && p.afk === true && p.sessionId)
+        .map((p) => p.sessionId),
+    );
+
+    // For each allowed chat, subscribe to newly-discovered AFK sessions and
+    // unsubscribe from sessions whose AFK flag cleared.
+    for (const chatId of chatIds) {
+      const watchedId = this.watchManager.getWatched(chatId);
+
+      if (watchedId !== undefined && !afkSessionIds.has(watchedId)) {
+        // The currently-watched session is no longer AFK — stop the auto-watch.
+        // (If the user manually /watched something, the same stop fires, which
+        // is correct: the AFK flag being cleared means the REPL is back.)
+        this.watchManager.stop(chatId);
+        this.log(`[auto-subscribe] stopped watch for ${watchedId} (afk cleared)`);
+      }
+
+      // Pick the first unsubscribed AFK session (in practice there is usually
+      // one REPL session per operator).
+      for (const sessionId of afkSessionIds) {
+        if (this.watchManager.watching(chatId) === sessionId) continue; // already watching
+        const send = async (msg: string): Promise<void> => {
+          for (const part of splitLongMessage(msg)) {
+            await this.bot.telegram.sendMessage(chatId, part);
+          }
+        };
+        this.watchManager.start(chatId, sessionId, send);
+        this.log(`[auto-subscribe] started watch for ${sessionId} on chat ${chatId}`);
+        break; // one session per chat at a time
+      }
+    }
   }
 
   /**

--- a/src/telegram/elicitation-handler.ts
+++ b/src/telegram/elicitation-handler.ts
@@ -71,12 +71,33 @@ function truncateLabel(label: string, maxBytes = 64): string {
  * @param messageHandler - The message handler instance (for `pendingElicitations`).
  * @param bot - The Telegraf bot instance (for `bot.action` registration).
  * @param chatId - The Telegram chat ID to send questions to.
+ * @param opts.ledgerOriginated - When true, every text-intercept entry also
+ *   registers the chatId in `messageHandler.ledgerOriginatedPendingChats` so
+ *   the message handler's idle-guard fires the resolver even with no active
+ *   AgentSession for this chat (the REPL session runs in a separate process).
  */
 export function makeTelegramElicitationHandler(
   messageHandler: MessageHandler,
   bot: Telegraf,
   chatId: number,
+  opts?: { ledgerOriginated?: boolean },
 ): ElicitationHandler {
+  // Contract: ledgerOriginated elicitations bypass the session-state guard in
+  // MessageHandler.handle() — the resolver fires on the next text reply
+  // regardless of whether an AgentSession exists for this chat.
+  const ledgerOriginated = opts?.ledgerOriginated ?? false;
+
+  // Helpers that keep pendingElicitations and ledgerOriginatedPendingChats in
+  // sync. All text-intercept registrations and deletions must use these instead
+  // of touching the maps directly, so the bypass set never drifts from reality.
+  function setPending(resolver: (text: string) => void): void {
+    messageHandler.pendingElicitations.set(chatId, resolver);
+    if (ledgerOriginated) messageHandler.ledgerOriginatedPendingChats.add(chatId);
+  }
+  function deletePending(): void {
+    messageHandler.pendingElicitations.delete(chatId);
+    if (ledgerOriginated) messageHandler.ledgerOriginatedPendingChats.delete(chatId);
+  }
   /**
    * H3: Single dispatch table for confirm/choice elicitations.
    * Keys are elicitation IDs; values are `(choiceIndex) => void` resolvers.
@@ -176,7 +197,7 @@ export function makeTelegramElicitationHandler(
           pendingChoiceElicitations.delete(elicitId);
           // Custom-entry abort: also drop the chatId-keyed text intercept so a
           // stale handler can't swallow the user's next message.
-          if (inCustomTextWait) messageHandler.pendingElicitations.delete(chatId);
+          if (inCustomTextWait) deletePending();
           resolve({ action: 'decline' });
         };
         options.signal.addEventListener('abort', onAbort, { once: true });
@@ -194,7 +215,7 @@ export function makeTelegramElicitationHandler(
             inCustomTextWait = true;
             bot.telegram.sendMessage(chatId, '✍️ Please type your custom answer:').catch(() => {});
             if (options.signal.aborted) { resolve({ action: 'decline' }); return; }
-            messageHandler.pendingElicitations.set(chatId, (text: string) => {
+            setPending((text: string) => {
               if (resolved) return;
               resolved = true;
               options.signal.removeEventListener('abort', onAbort);
@@ -248,7 +269,7 @@ export function makeTelegramElicitationHandler(
         if (messageHandler.pendingElicitations.has(chatId)) {
           console.warn('[elicitation-handler] abort: cleaning up stale pendingElicitation for chatId', chatId);
         }
-        messageHandler.pendingElicitations.delete(chatId);
+        deletePending();
         resolve({ action: 'decline' });
       };
       options.signal.addEventListener('abort', onAbort, { once: true });
@@ -284,7 +305,7 @@ export function makeTelegramElicitationHandler(
             // H1: abort guard — if abort fired between `resolved = false` and `.set()`,
             // the promise is already settled; skip re-registration to avoid a dangling intercept.
             if (options.signal.aborted) return;
-            messageHandler.pendingElicitations.set(chatId, handleText);
+            setPending(handleText);
             // H1: re-attach abort listener so abort during the next wait resolves the promise.
             options.signal.addEventListener('abort', onAbort, { once: true });
             return;
@@ -297,7 +318,7 @@ export function makeTelegramElicitationHandler(
             bot.telegram.sendMessage(chatId, '❌ Please enter a valid number.').catch(() => {});
             // H1: abort guard before re-registration.
             if (options.signal.aborted) return;
-            messageHandler.pendingElicitations.set(chatId, handleText);
+            setPending(handleText);
             // H1: re-attach abort listener for the next wait.
             options.signal.addEventListener('abort', onAbort, { once: true });
             return;
@@ -308,7 +329,7 @@ export function makeTelegramElicitationHandler(
             bot.telegram.sendMessage(chatId, `❌ Value must be ≥ ${request.min}.`).catch(() => {});
             // H1: abort guard before re-registration.
             if (options.signal.aborted) return;
-            messageHandler.pendingElicitations.set(chatId, handleText);
+            setPending(handleText);
             // H1: re-attach abort listener for the next wait.
             options.signal.addEventListener('abort', onAbort, { once: true });
             return;
@@ -319,7 +340,7 @@ export function makeTelegramElicitationHandler(
             bot.telegram.sendMessage(chatId, `❌ Value must be ≤ ${request.max}.`).catch(() => {});
             // H1: abort guard before re-registration.
             if (options.signal.aborted) return;
-            messageHandler.pendingElicitations.set(chatId, handleText);
+            setPending(handleText);
             // H1: re-attach abort listener for the next wait.
             options.signal.addEventListener('abort', onAbort, { once: true });
             return;
@@ -355,7 +376,7 @@ export function makeTelegramElicitationHandler(
               ).catch(() => {});
               // H1: abort guard before re-registration.
               if (options.signal.aborted) return;
-              messageHandler.pendingElicitations.set(chatId, handleText);
+              setPending(handleText);
               // H1: re-attach abort listener for the next wait.
               options.signal.addEventListener('abort', onAbort, { once: true });
               return;
@@ -373,7 +394,7 @@ export function makeTelegramElicitationHandler(
           bot.telegram.sendMessage(chatId, '❌ Please enter a response (or type :cancel to skip).').catch(() => {});
           // H1: abort guard before re-registration.
           if (options.signal.aborted) return;
-          messageHandler.pendingElicitations.set(chatId, handleText);
+          setPending(handleText);
           // H1: re-attach abort listener for the next wait.
           options.signal.addEventListener('abort', onAbort, { once: true });
           return;
@@ -382,7 +403,7 @@ export function makeTelegramElicitationHandler(
       }
 
       // Register intercept
-      messageHandler.pendingElicitations.set(chatId, handleText);
+      setPending(handleText);
 
       // Build prompt text
       let promptText = displayText;
@@ -419,7 +440,7 @@ export function makeTelegramElicitationHandler(
           // M6: log sendMessage failure so callers can diagnose silent declines
           // without a visible error (e.g., MarkdownV2 parse failure, network error).
           console.warn('[elicitation-handler] sendMessage failed; declining elicitation for chatId', chatId);
-          messageHandler.pendingElicitations.delete(chatId);
+          deletePending();
           resolve({ action: 'decline' });
         }
       });

--- a/src/telegram/handlers/message.test.ts
+++ b/src/telegram/handlers/message.test.ts
@@ -208,3 +208,119 @@ describe('MessageHandler queue-depth acknowledgment', () => {
     expect(replies[0]).not.toContain('#6');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Criterion 3 (C3): ledger-originated pending resolver bypass (idle-guard fix)
+// ---------------------------------------------------------------------------
+
+describe('MessageHandler.ledgerOriginatedPendingChats bypass (C3)', () => {
+  it('fires a ledger-originated pending resolver even with no active session (no session at all)', async () => {
+    // Simulate no session in the manager: getSessionIfExists returns undefined.
+    const sessionManager = {
+      getSession: vi.fn().mockResolvedValue({ state: 'idle' }),
+      getSessionIfExists: vi.fn().mockReturnValue(undefined),
+      resetSession: vi.fn(),
+    };
+    const bot = {
+      telegram: { sendMessage: vi.fn().mockResolvedValue({}) },
+      command: vi.fn(),
+      on: vi.fn(),
+    };
+    const handler = new MessageHandler(
+      bot as unknown as import('telegraf').Telegraf,
+      sessionManager as unknown as import('../session-manager.js').SessionManager,
+      new Set<number>(),
+      vi.fn(),
+    );
+
+    const chatId = 55;
+    const resolved: string[] = [];
+
+    // Pre-seed as ledger-originated (as makeTelegramElicitationHandler would do).
+    handler.pendingElicitations.set(chatId, (text) => resolved.push(text));
+    handler.ledgerOriginatedPendingChats.add(chatId);
+
+    const { ctx } = makeMessageCtx(chatId, 'ledger answer');
+    await handler.handle(ctx);
+
+    // Resolver must fire even though there is no active session.
+    expect(resolved).toEqual(['ledger answer']);
+    // Both maps must be cleaned up after consumption.
+    expect(handler.pendingElicitations.has(chatId)).toBe(false);
+    expect(handler.ledgerOriginatedPendingChats.has(chatId)).toBe(false);
+  });
+
+  it('fires a ledger-originated pending resolver even when session is idle', async () => {
+    // Session exists but is idle — session-local path would drop this as stale.
+    const sessionManager = {
+      getSession: vi.fn().mockResolvedValue({ state: 'idle' }),
+      getSessionIfExists: vi.fn().mockReturnValue({ state: 'idle' }),
+      resetSession: vi.fn(),
+    };
+    const bot = {
+      telegram: { sendMessage: vi.fn().mockResolvedValue({}) },
+      command: vi.fn(),
+      on: vi.fn(),
+    };
+    const handler = new MessageHandler(
+      bot as unknown as import('telegraf').Telegraf,
+      sessionManager as unknown as import('../session-manager.js').SessionManager,
+      new Set<number>(),
+      vi.fn(),
+    );
+
+    const chatId = 56;
+    const resolved: string[] = [];
+
+    handler.pendingElicitations.set(chatId, (text) => resolved.push(text));
+    handler.ledgerOriginatedPendingChats.add(chatId);
+
+    const { ctx } = makeMessageCtx(chatId, 'idle session answer');
+    await handler.handle(ctx);
+
+    expect(resolved).toEqual(['idle session answer']);
+    expect(handler.pendingElicitations.has(chatId)).toBe(false);
+    expect(handler.ledgerOriginatedPendingChats.has(chatId)).toBe(false);
+  });
+
+  it('still drops a genuinely stale session-local entry (no ledger-origin flag) when session is idle', async () => {
+    // Session exists but is idle — this simulates a session reset mid-elicitation.
+    const sessionManager = {
+      getSession: vi.fn().mockResolvedValue({ state: 'idle' }),
+      getSessionIfExists: vi.fn().mockReturnValue({ state: 'idle' }),
+      resetSession: vi.fn(),
+    };
+    const bot = {
+      telegram: { sendMessage: vi.fn().mockResolvedValue({}) },
+      command: vi.fn(),
+      on: vi.fn(),
+    };
+    const handler = new MessageHandler(
+      bot as unknown as import('telegraf').Telegraf,
+      sessionManager as unknown as import('../session-manager.js').SessionManager,
+      new Set<number>(),
+      vi.fn(),
+    );
+
+    const chatId = 57;
+    let resolverCalled = false;
+
+    // Pre-seed WITHOUT the ledger-origin flag (session-local, now stale).
+    handler.pendingElicitations.set(chatId, () => { resolverCalled = true; });
+    // ledgerOriginatedPendingChats NOT set — this is the stale-session path.
+
+    const { ctx } = makeMessageCtx(chatId, 'stale reply');
+    await handler.handle(ctx);
+
+    // Resolver must NOT fire — the stale-session guard must drop it.
+    expect(resolverCalled).toBe(false);
+    // The stale entry must be cleaned up.
+    expect(handler.pendingElicitations.has(chatId)).toBe(false);
+  });
+
+  it('ledgerOriginatedPendingChats is a public Set initialized to empty', () => {
+    const handler = makeHandler();
+    expect(handler.ledgerOriginatedPendingChats).toBeInstanceOf(Set);
+    expect(handler.ledgerOriginatedPendingChats.size).toBe(0);
+  });
+});

--- a/src/telegram/handlers/message.ts
+++ b/src/telegram/handlers/message.ts
@@ -119,6 +119,24 @@ export class MessageHandler {
    */
   public pendingElicitations = new Map<number, (text: string) => void>();
 
+  /**
+   * Chat IDs whose active pendingElicitations entry was registered by a
+   * ledger-originated (daemon-watch) elicitation rather than a session-local
+   * ask_question call.
+   *
+   * Invariant: the idle-guard in handle() must fire the resolver for these
+   * chats even when no AgentSession is active for the chat (the REPL session
+   * lives in a different process). Without this bypass, every phone reply to a
+   * ledger-originated elicitation is silently dropped because the guard sees
+   * no in-flight session and treats the pending entry as stale.
+   *
+   * Lifecycle: entries are added by makeTelegramElicitationHandler before it
+   * installs the resolver (via the ledgerOriginatedElicitation flag passed by
+   * the watch loop), and deleted when the resolver fires or is aborted — exactly
+   * mirroring the pendingElicitations Map lifecycle.
+   */
+  public ledgerOriginatedPendingChats = new Set<number>();
+
   constructor(
     bot: Telegraf,
     sessionManager: SessionManager,
@@ -340,16 +358,33 @@ export class MessageHandler {
     // session message queue. Intercept BEFORE the session.state check so
     // that elicitation replies are never swallowed by the busy-queue branch.
     //
-    // Guard: only route to the elicit resolver when the session is actually
-    // streaming/processing (i.e. genuinely awaiting a reply). If the session
-    // was reset (/clear) while an elicitation was in flight, the abort signal
-    // on the old AbortController never fires, leaving a stale entry in
-    // pendingElicitations that would silently eat the user's next message.
-    // Checking the live session state here catches that case: a freshly-created
-    // session is always 'idle', so we delete the stale entry and fall through
-    // to processOne instead of routing to a dead resolver.
+    // Guard: only route to the elicit resolver when the resolver is live.
+    // Two cases are distinguished:
+    //
+    //   1. Ledger-originated elicitation (daemon watching a REPL session):
+    //      the REPL session runs in a separate process, so this chat has NO
+    //      in-flight AgentSession. We must fire the resolver regardless of
+    //      session state — the ledgerOriginatedPendingChats set tracks these
+    //      so we can bypass the session-state check safely.
+    //
+    //   2. Session-local elicitation (ask_question from this chat's session):
+    //      the resolver is live only while the session is non-idle. If the
+    //      session was reset (/clear) while an elicitation was in flight, the
+    //      abort signal on the old AbortController never fires, leaving a stale
+    //      entry that would silently eat the user's next message. Checking the
+    //      live session state here catches that case: a freshly-created session
+    //      is always 'idle', so we delete the stale entry and fall through to
+    //      processOne instead of routing to a dead resolver.
     const elicitResolver = this.pendingElicitations.get(chatId);
     if (elicitResolver) {
+      // Case 1: ledger-originated bypass — fire resolver without session check.
+      if (this.ledgerOriginatedPendingChats.has(chatId)) {
+        this.pendingElicitations.delete(chatId);
+        this.ledgerOriginatedPendingChats.delete(chatId);
+        elicitResolver(messageText);
+        return;
+      }
+      // Case 2: session-local — fire only when the session is genuinely busy.
       const existingSession = this.sessionManager.getSessionIfExists(chatId);
       if (existingSession && existingSession.state !== 'idle') {
         this.pendingElicitations.delete(chatId);

--- a/src/telegram/watch.test.ts
+++ b/src/telegram/watch.test.ts
@@ -19,7 +19,10 @@ import { getSessionsDir } from '../paths.js';
 import {
   ensureSessionKey,
   readSessionKey,
+  signAbortRequest,
+  verifyAbortRequest,
   verifyElicitationResponse,
+  freshChannelId,
 } from '../agent/afk-channel.js';
 import type { ElicitationResult } from '../agent/types/sdk-types.js';
 import type { MessageHandler } from './handlers/message.js';
@@ -417,5 +420,63 @@ describe('SessionWatchManager — elicitation intercept + signed write-back (cri
       nonce: 'n1',
       hmac: 'abc',
     }))).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Criterion 4: getWatched() getter + daemon abort-record signing
+// ---------------------------------------------------------------------------
+
+describe('SessionWatchManager — getWatched (criterion 4)', () => {
+  it('getWatched returns the watched session id and undefined when not watching', async () => {
+    const id = freshId();
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('x');
+    await sleep(50);
+
+    const manager = new SessionWatchManager();
+    expect(manager.getWatched(20)).toBeUndefined();
+
+    manager.start(20, id, async () => {});
+    expect(manager.getWatched(20)).toBe(id);
+
+    manager.stop(20);
+    expect(manager.getWatched(20)).toBeUndefined();
+
+    await writer.close();
+  });
+});
+
+describe('Criterion 4: daemon /abort writes a HMAC-signed abort_request', () => {
+  it('a signed abort_request written like the daemon /abort handler does verifies correctly', () => {
+    // This test simulates what bot.ts /abort does: read the key, sign, and write.
+    // Verifying the record with the real verifyAbortRequest confirms the
+    // REPL abort-watcher would accept it (Invariant #4).
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    expect(key).toBeTruthy();
+
+    // Simulate the /abort command path: sign a nonce exactly as bot.ts does.
+    const nonce = freshChannelId();
+    const hmac = signAbortRequest(key, id, nonce);
+
+    // The record is what SessionLedgerWriter.record() would emit.
+    const record = { kind: 'abort_request' as const, nonce, hmac };
+
+    // The REPL abort-watcher calls verifyAbortRequest before acting.
+    const valid = verifyAbortRequest(key, id, record.nonce, record.hmac);
+    expect(valid).toBe(true);
+  });
+
+  it('an abort_request with a forged HMAC does NOT verify (REPL would ignore it)', () => {
+    const id = freshId();
+    const key = ensureSessionKey(id)!;
+    const nonce = freshChannelId();
+    // Daemon signs with a DIFFERENT key (simulating a cross-session stray write).
+    const wrongKey = ensureSessionKey(freshId())!;
+    const forgedHmac = signAbortRequest(wrongKey, id, nonce);
+
+    const valid = verifyAbortRequest(key, id, nonce, forgedHmac);
+    expect(valid).toBe(false);
   });
 });

--- a/src/telegram/watch.test.ts
+++ b/src/telegram/watch.test.ts
@@ -5,7 +5,7 @@
  * (env must be set before importing modules that resolve paths).
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import * as os from 'node:os';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -16,6 +16,13 @@ process.env['AFK_HOME'] = tmpDir;
 import { SessionWatchManager, renderLedgerRecord, resolveWatchTarget } from './watch.js';
 import { SessionLedgerWriter, type LedgerRecord } from '../agent/session-ledger.js';
 import { getSessionsDir } from '../paths.js';
+import {
+  ensureSessionKey,
+  readSessionKey,
+  verifyElicitationResponse,
+} from '../agent/afk-channel.js';
+import type { ElicitationResult } from '../agent/types/sdk-types.js';
+import type { MessageHandler } from './handlers/message.js';
 
 let seq = 0;
 function freshId(): string {
@@ -208,5 +215,207 @@ describe('SessionWatchManager', () => {
 
     // First batch send threw; later batches must still be delivered.
     expect(sent.join('\n')).toContain('second-batch');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Criterion 3: elicitation intercept + signed write-back (C1+C2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal stub of the Telegraf bot + MessageHandler sufficient for the
+ * elicitation path in _run. The bot stub only needs sendMessage (for the text
+ * prompt) and action registration (no-op here). The MessageHandler stub only
+ * needs pendingElicitations and ledgerOriginatedPendingChats maps plus enough
+ * surface for makeTelegramElicitationHandler to function.
+ */
+function makeElicitStubs(chatId: number) {
+  // Track the pending resolver installed by the elicitation handler.
+  const pendingElicitations = new Map<number, (text: string) => void>();
+  const ledgerOriginatedPendingChats = new Set<number>();
+
+  const sentMessages: string[] = [];
+  const bot = {
+    action: vi.fn(),
+    telegram: {
+      sendMessage: vi.fn().mockImplementation((_chatId: number, text: string) => {
+        sentMessages.push(text);
+        return Promise.resolve({ message_id: 1 });
+      }),
+    },
+  };
+
+  // A minimal MessageHandler-shaped object. We only need the two maps.
+  const messageHandler = {
+    pendingElicitations,
+    ledgerOriginatedPendingChats,
+  } as unknown as MessageHandler;
+
+  return { bot, messageHandler, sentMessages, pendingElicitations, ledgerOriginatedPendingChats, chatId };
+}
+
+describe('SessionWatchManager — elicitation intercept + signed write-back (criterion 3)', () => {
+  it('intercepts an elicitation record, renders via telegram handler, writes back a HMAC-signed response', async () => {
+    const id = freshId();
+    const chatId = 42;
+
+    // Write the REPL-side session key (normally written by /afk on).
+    const key = ensureSessionKey(id);
+    expect(key).toBeTruthy();
+
+    const { bot, messageHandler, pendingElicitations } = makeElicitStubs(chatId);
+
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('setup');
+    await sleep(50);
+
+    const sent: string[] = [];
+    const manager = new SessionWatchManager(
+      () => {},
+      bot as unknown as import('telegraf').Telegraf,
+      messageHandler,
+    );
+    manager.start(chatId, id, async (text) => { sent.push(text); });
+
+    await sleep(100);
+
+    // Write an elicitation record into the ledger (as the REPL would).
+    const reqId = 'req-123';
+    writer.record({
+      kind: 'elicitation',
+      reqId,
+      request: { type: 'text', message: 'What is your name?' },
+    });
+
+    // Give the tail loop time to process the record and install the interceptor.
+    await sleep(200);
+
+    // Simulate the operator typing an answer into Telegram (the message handler
+    // fires the resolver, which is what handle() would do when it sees a text).
+    const resolver = pendingElicitations.get(chatId);
+    expect(resolver).toBeDefined();
+    resolver!('Alice');
+
+    // Give _run time to receive the result and write back the response.
+    await sleep(200);
+
+    // The elicitation_response record must be in the ledger and HMAC-verified.
+    const ledgerPath = path.join(
+      tmpDir, 'state', 'sessions', id, 'events.jsonl',
+    );
+    const lines = fs.readFileSync(ledgerPath, 'utf8').trim().split('\n');
+    const responseRecord = lines
+      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
+      .find((r) => r?.kind === 'elicitation_response');
+
+    expect(responseRecord).toBeDefined();
+    expect(responseRecord.reqId).toBe(reqId);
+    const result: ElicitationResult = responseRecord.result;
+    expect(result.action).toBe('accept');
+
+    // Verify the HMAC using the real verifyElicitationResponse.
+    const readKey = readSessionKey(id);
+    expect(readKey).toBeTruthy();
+    const valid = verifyElicitationResponse(readKey!, id, reqId, result, responseRecord.hmac);
+    expect(valid).toBe(true);
+
+    await writer.close();
+    manager.stop(chatId);
+  });
+
+  it('skips the write-back when no session key is present', async () => {
+    const id = freshId();
+    const chatId = 43;
+    // Deliberately do NOT call ensureSessionKey — no key on disk.
+
+    const { bot, messageHandler, pendingElicitations } = makeElicitStubs(chatId);
+
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('setup');
+    await sleep(50);
+
+    const manager = new SessionWatchManager(
+      () => {},
+      bot as unknown as import('telegraf').Telegraf,
+      messageHandler,
+    );
+    manager.start(chatId, id, async () => {});
+
+    await sleep(100);
+
+    writer.record({
+      kind: 'elicitation',
+      reqId: 'req-no-key',
+      request: { type: 'text', message: 'Skip?' },
+    });
+
+    await sleep(200);
+
+    // Answer the pending resolver.
+    const resolver = pendingElicitations.get(chatId);
+    expect(resolver).toBeDefined();
+    resolver!('any answer');
+
+    await sleep(200);
+
+    // No elicitation_response should be in the ledger.
+    const ledgerPath = path.join(tmpDir, 'state', 'sessions', id, 'events.jsonl');
+    const lines = fs.readFileSync(ledgerPath, 'utf8').trim().split('\n');
+    const responseRecord = lines
+      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
+      .find((r) => r?.kind === 'elicitation_response');
+
+    expect(responseRecord).toBeUndefined();
+
+    await writer.close();
+    manager.stop(chatId);
+  });
+
+  it('still relays normal (non-elicitation) records as push lines', async () => {
+    const id = freshId();
+    const chatId = 44;
+
+    const { bot, messageHandler } = makeElicitStubs(chatId);
+
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('hello');
+    await sleep(50);
+
+    const sent: string[] = [];
+    const manager = new SessionWatchManager(
+      () => {},
+      bot as unknown as import('telegraf').Telegraf,
+      messageHandler,
+    );
+    manager.start(chatId, id, async (text) => { sent.push(text); });
+
+    await sleep(100);
+    writer.recordUser('normal record');
+    await sleep(300);
+    await writer.close();
+    await sleep(600);
+
+    expect(sent.join('\n')).toContain('normal record');
+
+    manager.stop(chatId);
+  });
+
+  it('renderLedgerRecord returns null for elicitation kinds (no push line)', () => {
+    expect(renderLedgerRecord(rec({
+      kind: 'elicitation',
+      reqId: 'r1',
+      request: { type: 'text', message: 'Q?' },
+    }))).toBeNull();
+    expect(renderLedgerRecord(rec({
+      kind: 'elicitation_response',
+      reqId: 'r1',
+      result: { action: 'accept', content: { value: 'A' } },
+      hmac: 'abc',
+    }))).toBeNull();
+    expect(renderLedgerRecord(rec({
+      kind: 'abort_request',
+      nonce: 'n1',
+      hmac: 'abc',
+    }))).toBeNull();
   });
 });

--- a/src/telegram/watch.ts
+++ b/src/telegram/watch.ts
@@ -167,6 +167,15 @@ export class SessionWatchManager {
   }
 
   /**
+   * The session id that `chatId` is currently watching, or undefined.
+   * Alias for {@link watching} — exposed under the name the `/abort` handler
+   * uses so the call site reads clearly.
+   */
+  getWatched(chatId: number): string | undefined {
+    return this.watches.get(chatId)?.sessionId;
+  }
+
+  /**
    * Start watching `sessionId` for `chatId`, replacing any existing watch.
    * `send` delivers rendered batches to the chat; failures are logged and
    * the watch continues (a transient Telegram error must not kill the tail).

--- a/src/telegram/watch.ts
+++ b/src/telegram/watch.ts
@@ -20,9 +20,13 @@
  * @module telegram/watch
  */
 
-import { tailLedger, ledgerExists, type LedgerRecord } from '../agent/session-ledger.js';
+import { tailLedger, ledgerExists, SessionLedgerWriter, type LedgerRecord } from '../agent/session-ledger.js';
 import { findSession, listSessions } from '../cli/session-store.js';
 import { readPresenceFiles } from '../agent/awareness/presence.js';
+import { readSessionKey, signElicitationResponse } from '../agent/afk-channel.js';
+import { makeTelegramElicitationHandler } from './elicitation-handler.js';
+import type { MessageHandler } from './handlers/message.js';
+import type { Telegraf } from 'telegraf';
 
 type SendFn = (text: string) => Promise<void>;
 type LogFn = (...args: unknown[]) => void;
@@ -135,15 +139,26 @@ interface ActiveWatch {
   finished: Promise<void>;
 }
 
+// Invariant: SessionWatchManager holds a reference to the daemon's SOLE Telegraf
+// instance and the MessageHandler. These are used only to render elicitation
+// records interactively via makeTelegramElicitationHandler — never to create a
+// second poller. bot and messageHandler may be undefined (e.g. in tests that do
+// not exercise the elicitation path) — the watch loop degrades gracefully by
+// skipping the write-back rather than throwing.
+
 /**
  * Per-chat watch registry. Owns the tail loops and their teardown.
  */
 export class SessionWatchManager {
   private readonly watches = new Map<number, ActiveWatch>();
   private readonly log: LogFn;
+  private readonly bot: Telegraf | undefined;
+  private readonly messageHandler: MessageHandler | undefined;
 
-  constructor(log: LogFn = () => {}) {
+  constructor(log: LogFn = () => {}, bot?: Telegraf, messageHandler?: MessageHandler) {
     this.log = log;
+    this.bot = bot;
+    this.messageHandler = messageHandler;
   }
 
   /** The session id this chat is watching, if any. */
@@ -192,6 +207,20 @@ export class SessionWatchManager {
     let flushTimer: NodeJS.Timeout | null = null;
     let sending = Promise.resolve();
 
+    // Contract: build a per-run elicitation handler only when bot + messageHandler
+    // are available (they are injected from bot.ts but absent in legacy tests).
+    // The handler is created lazily once and reused across multiple elicitation
+    // records in the same watch run so the wildcard bot.action dispatch table
+    // is only registered once.
+    // ledgerOriginated:true tells the handler to register the chatId in
+    // messageHandler.ledgerOriginatedPendingChats alongside pendingElicitations,
+    // so the message-handler idle-guard fires the resolver even with no active
+    // AgentSession for this chat (the REPL runs in a separate process).
+    const elicitHandler =
+      this.bot !== undefined && this.messageHandler !== undefined
+        ? makeTelegramElicitationHandler(this.messageHandler, this.bot, chatId, { ledgerOriginated: true })
+        : undefined;
+
     const flush = (): void => {
       flushTimer = null;
       if (batch.length === 0) return;
@@ -205,6 +234,44 @@ export class SessionWatchManager {
 
     try {
       for await (const rec of tailLedger(sessionId, { signal })) {
+        // Invariant: elicitation records are handled interactively — the phone
+        // renders the question and the signed response is written back to the
+        // ledger. They are NOT forwarded as push lines; the normal render path
+        // returns null for unknown kinds so elicitation/elicitation_response
+        // and abort_request records are already invisible to the push branch.
+        if (rec.kind === 'elicitation' && elicitHandler !== undefined) {
+          // Flush any accumulated push lines before blocking on the question
+          // so the operator sees prior context before the prompt appears.
+          if (flushTimer) clearTimeout(flushTimer);
+          flush();
+          await sending;
+
+          // Await the operator's answer (or abort). The per-run signal bounds
+          // the wait: if the user /unwatches or the bot shuts down, the abort
+          // propagates through the handler and we get { action: 'decline' }.
+          const result = await elicitHandler(rec.request, { signal });
+
+          // Invariant: write-back MUST be HMAC-signed (invariant #4). If the
+          // key is absent (REPL has not enabled AFK mode), skip silently — an
+          // unsigned elicitation_response would be ignored by the REPL anyway.
+          const key = readSessionKey(sessionId);
+          if (key !== null) {
+            const hmac = signElicitationResponse(key, sessionId, rec.reqId, result);
+            // A single-record writer is sufficient; we do not own the session
+            // lifecycle. The writer opens, appends, and can be GC'd.
+            new SessionLedgerWriter(sessionId).record({
+              kind: 'elicitation_response',
+              reqId: rec.reqId,
+              result,
+              hmac,
+            });
+          } else {
+            this.log('[watch] no session key for', sessionId, '— skipping elicitation write-back');
+          }
+          // Do not add a push line for elicitation records.
+          continue;
+        }
+
         const line = renderLedgerRecord(rec);
         if (!line) continue;
         batch.push(line);


### PR DESCRIPTION
## Summary

Adds **bidirectional AFK control over Telegram**: when you flip the REPL into AFK mode, a watching Telegram daemon can now *answer the agent's questions* and *abort a run* from your phone — not just receive read-only status. Built as an authenticated ledger channel so every remote action is cryptographically bound to its originating session.

Before this change, `/afk on` + a watching daemon was one-way (the phone saw output but couldn't act). Now the agent's elicitations (questions/confirmations) surface on Telegram and a signed reply races the local keyboard; a remote `/abort` can stop the run.

## How it works

- **Per-session HMAC** — each session derives a key (`randomBytes`, written `0o600`, never committed) used to sign/verify every remote action. Forged, unsigned, or cross-session records are ignored, never actioned.
- **Ledger channel** — remote intents are appended as signed ledger records; the REPL tails them and applies only those that verify against the live session key.
- **Verified-only side effects** — with `key === null` (no key on disk) no remote action ever fires, even for an otherwise well-formed record. Abort fires only after `verifyAbortRequest` passes (timing-safe compare).

## Commits (6, atop v4.15.0)

| Commit | What |
|---|---|
| `552cd01` | Ledger-channel foundation — record kinds + per-session HMAC |
| `4ab9ca2` | REPL ledger-channel elicitation handler (race verified-reply / keyboard / abort) |
| `d408f6c` | Wire `/afk` toggle → swap to ledger channel / restore stdin |
| `0cb884c` | Daemon renders elicitations → signed `elicitation_response` write-back + idle-guard fix |
| `d60342b` | Remote `/abort` (signed) + REPL abort-watcher + presence auto-subscribe |
| `004ed33` | No-second-poller invariant test + docs |

## Verification

- `pnpm lint` (tsc strict) — **exit 0**.
- Full suite — **9542 passed**, 12 skipped; the only 2 failures (`config.test.ts` local-model leak, `anthropic-direct.test.ts` haiku id drift) are **pre-existing/environmental**, confirmed identical via `git stash` against the clean base.
- Each iteration independently gated by a context-isolated **drift-check** (IN_SCOPE @0.96–0.98) and **adversarial shadow-verify** on every high-stakes claim (HMAC round-trip, no regression to the existing in-process Telegram elicitation path, single Telegram poller, verified-only abort, daemon always-signs).
- New: `src/cli/afk-no-telegraf-poller.test.ts` — invariant test proving no second Telegraf poller is ever constructed (~155 files scanned, non-vacuous).

## Deferred follow-ups (documented in `src/telegram/README.md`)

1. Daemon write-back `SessionLedgerWriter` fd lives until GC (can't `close()` — would emit a spurious `closed` truncating the REPL tail); fix = one-shot append.
2. Auto-subscribe stops a manually `/watch`'d non-AFK session on the next tick.
3. `bot.action` handler accumulation per watch cycle.
4. Inline-keyboard (choice/confirm) ledger elicitation not yet exercised end-to-end.

🤖 Generated with agent-afk
