### PR TITLE
fix(browser): default the 'afk' CLI surface to headless (no more web_scrape window flashes)

### DIFF
--- a/docs/browser-control.md
+++ b/docs/browser-control.md
@@ -30,8 +30,8 @@ afk
 ```
 
 The agent will issue `browser_open` → `browser_observe` → … under the hood.
-A real Chromium window opens (headed by default in REPL — the operator
-watches the work).
+The browser runs **headless by default**; set `AFK_BROWSER_HEADLESS=0` to open a
+real Chromium window and watch the agent work.
 
 ---
 
@@ -85,8 +85,10 @@ Environment variables override the defaults. All are optional.
 | `AFK_BROWSER_CONFIG`           | (none)           | Absolute path to a JSON file overriding env-derived config  |
 | `AFK_SESSION_ID`               | `default`        | Override the per-session BrowserContext key                 |
 
-\* Headless `on` for daemon / subagent / telegram surfaces;
-headed for repl / interactive / cli (so an operator can watch the agent).
+\* Headless by default on every AFK surface — the CLI runs as surface `afk`,
+which is headless so background work (including `web_scrape`'s render
+escalation) never pops a visible window. Set `AFK_BROWSER_HEADLESS=0` to force
+headed, e.g. to watch the agent drive a real Chromium window in the REPL.
 
 ### Domain policy
 

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -25,7 +25,11 @@ function withFile(content: string): (path: string) => string | undefined {
 // ---------------------------------------------------------------------------
 
 describe('loadBrowserConfig — headless default per surface', () => {
-  const headlessSurfaces = ['daemon', 'subagent', 'telegram'] as const;
+  // 'afk' is the surface string the CLI sets for the whole process
+  // (src/cli/index.ts), so it must default to headless — otherwise web_scrape's
+  // render escalation opens visible Chromium windows. See the regression test
+  // below.
+  const headlessSurfaces = ['daemon', 'subagent', 'telegram', 'afk'] as const;
   const headedSurfaces = ['repl', 'interactive', 'cli'] as const;
 
   for (const surface of headlessSurfaces) {
@@ -49,6 +53,25 @@ describe('loadBrowserConfig — headless default per surface', () => {
 
   it('unknown surface string → headless: false (headed default)', () => {
     const cfg = loadBrowserConfig({ surface: 'something-exotic', env: makeEnv(), readFileSync: noFile });
+    expect(cfg.headless).toBe(false);
+  });
+
+  // Regression: the CLI entrypoint sets AGENT_SURFACE='afk' for the whole
+  // process, so 'afk' — not 'cli'/'repl'/'interactive' — is the surface every
+  // run actually reports. Before this was added to HEADLESS_SURFACES, 'afk'
+  // fell through to the headed default and web_scrape's render escalation
+  // launched a VISIBLE Chromium window (many at once under parallel scrapes).
+  it("surface='afk' (the real default CLI surface) → headless: true", () => {
+    const cfg = loadBrowserConfig({ surface: 'afk', env: makeEnv(), readFileSync: noFile });
+    expect(cfg.headless).toBe(true);
+  });
+
+  it("surface='afk' with AFK_BROWSER_HEADLESS=0 → headless: false (env opt-in to headed)", () => {
+    const cfg = loadBrowserConfig({
+      surface: 'afk',
+      env: makeEnv({ AFK_BROWSER_HEADLESS: '0' }),
+      readFileSync: noFile,
+    });
     expect(cfg.headless).toBe(false);
   });
 });

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -64,7 +64,15 @@ function matchesGlob(host: string, pattern: string): boolean {
 // Headless default
 // ---------------------------------------------------------------------------
 
-const HEADLESS_SURFACES = new Set(['daemon', 'subagent', 'telegram']);
+// Invariant: 'afk' is the surface string the CLI entrypoint sets for the whole
+// process (src/cli/index.ts defaults AGENT_SURFACE to 'afk'), so it is the
+// surface every chat/REPL/one-shot run actually reports. It MUST be in this
+// set: without it, resolveHeadlessDefault() falls through to its headed default
+// and every browser launch — including web_scrape's render escalation — opens a
+// visible Chromium window (many at once under parallel scrapes). The
+// 'repl'/'interactive'/'cli' names below are never emitted at runtime; headed
+// is opt-in via AFK_BROWSER_HEADLESS=0 (checked first, above surface).
+const HEADLESS_SURFACES = new Set(['daemon', 'subagent', 'telegram', 'afk']);
 const HEADED_SURFACES = new Set(['repl', 'interactive', 'cli']);
 
 function resolveHeadlessDefault(


### PR DESCRIPTION
## Summary

Fixes a bug where invoking `web_scrape` pops a **visible Chromium window** (and one per call under parallel scrapes).

**Root cause.** The CLI entrypoint sets `AGENT_SURFACE='afk'` for the whole process (`src/cli/index.ts`), so `'afk'` — not `'cli'`/`'repl'`/`'interactive'` — is the surface every run actually reports. But `'afk'` was absent from `HEADLESS_SURFACES` (`src/browser/config.ts`), so `resolveHeadlessDefault()` fell through to its headed default (`return false`). Every browser launch on the default surface — including `web_scrape`'s render escalation (`renderViaBrowser` → shared `getBrowserProvider()` → `chromium.launch({ headless: false })`) — opened a real window. Each `renderHtml()` creates its own `BrowserContext`, so N parallel scrapes = N windows. (The `web_scrape` docstring already says it escalates to a *"headless render"*, so the headed behavior contradicted the code's own stated intent.)

**Fix.** Add `'afk'` to `HEADLESS_SURFACES`. The default AFK surface is now headless — matching the away-from-keyboard premise and the documented render contract. Headed stays opt-in via `AFK_BROWSER_HEADLESS=0` (checked *before* surface detection in `resolveHeadlessDefault`, so the override is unaffected).

**Behavior change to note:** interactive `browser_open`/`browser_act` on the CLI also become headless by default (they share the surface/provider). The previously-documented "headed for repl/interactive/cli" default never actually triggered — the runtime surface is always `'afk'` — and watching the browser is preserved as an opt-in via `AFK_BROWSER_HEADLESS=0`. Docs updated accordingly.

## How was this tested?

- `pnpm lint` → exit 0
- `pnpm test -- src/browser/config.test.ts` → 50/50 pass (added: `surface='afk'` → headless, and `surface='afk'` + `AFK_BROWSER_HEADLESS=0` → headed)
- `pnpm build`, `pnpm scan:env:check`, `pnpm audit:sdk:check`, `pnpm audit:env:check` → all pass
- Full `pnpm test:coverage`: only 2 failures, both **pre-existing and environment-specific** (local `~/.afk` model config bleeding into `src/cli/config.test.ts` + `anthropic-direct.test.ts`) — proven identical with this branch's changes stashed on clean HEAD. Neither imports browser config.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (browser suite; the 2 unrelated failures are pre-existing/env-specific — green in CI)
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] No secrets, tokens, or private paths in the diff
