### PR TITLE
refactor(anthropic-direct): extract pure param resolvers into resolve-params.ts

### DIFF
--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -23,9 +23,7 @@ import path from 'path';
 import { appendFileSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
 import Anthropic from '@anthropic-ai/sdk';
-import type { MessageParam, ThinkingConfigParam } from '@anthropic-ai/sdk/resources';
-import type { AgentConfig, ResumeHistoryTurn } from '../../types/config-types.js';
-import type { EffortLevel, ThinkingConfig } from '../../types/sdk-types.js';
+import type { AgentConfig } from '../../types/config-types.js';
 import type {
   ModelProvider,
   ProviderQuery,
@@ -40,6 +38,16 @@ import {
 import { oneShotCompletion, type OneShotInput } from './oneshot.js';
 import { refreshClaudeCodeOauthToken } from '../../auth/keychain.js';
 import { AnthropicDirectQuery } from './query.js';
+import {
+  resolveAutoCompactThreshold,
+  resolveEffort,
+  resolveMaxTokens,
+  resolveThinkingParam,
+  resumeHistoryToMessages,
+} from './resolve-params.js';
+// Re-export the pure param resolvers extracted to ./resolve-params.ts (issue
+// #103) so the historical `from './index.js'` import path stays valid.
+export { resolveEffort, resolveMaxTokens, resolveThinkingParam } from './resolve-params.js';
 import type { ToolDispatcher } from './tool-dispatcher.js';
 import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { createBuiltinHandlers } from '../../tools/handlers/index.js';
@@ -49,7 +57,6 @@ import { withMcpToolsAllowed, type ToolPermissionConfig } from '../../tools/perm
 import type { HookRegistry } from '../../hooks.js';
 import { resolveSessionHookRegistry } from '../../hooks.js';
 import type { SubagentExecutor } from '../../tools/subagent-executor.js';
-import { maxOutputTokensFor } from '../../model-limits.js';
 import type { SkillExecutor } from '../../tools/skill-executor.js';
 import type { ComposeExecutor } from '../../tools/compose-executor.js';
 import type { TraceWriter } from '../../trace/index.js';
@@ -72,9 +79,6 @@ import {
 
 const PROVIDER_NAME = 'anthropic-direct';
 const DEFAULT_MODEL = 'claude-sonnet-4-5-20250929';
-
-/** Match opus-4.7 and later opus 4.x families that require adaptive thinking + summarized display. */
-const isOpus47Plus = (model: string): boolean => /opus-4-(7|[89])/.test(model);
 
 /** Test/factory hook: lets tests inject a stub Anthropic client.
  *
@@ -923,205 +927,6 @@ function resolveUserSystem(sp: AgentConfig['systemPrompt']): string | null {
     return append && append.length > 0 ? append : null;
   }
   return null;
-}
-
-const DEFAULT_AUTO_COMPACT_THRESHOLD = 0.9;
-
-/**
- * Resolve `AgentConfig.autoCompact` to a numeric threshold fraction, or
- * `undefined` when auto-compaction is disabled.
- *
- * - `false` or `undefined` → disabled (`undefined` returned).
- * - `true` → default threshold (0.90).
- * - `{ threshold: n }` → custom fraction; clamped to (0, 1) exclusive.
- *   Out-of-range values are silently treated as disabled.
- */
-function resolveAutoCompactThreshold(
-  autoCompact: AgentConfig['autoCompact'],
-): number | undefined {
-  if (autoCompact === undefined || autoCompact === false) return undefined;
-  if (autoCompact === true) return DEFAULT_AUTO_COMPACT_THRESHOLD;
-  const t = autoCompact.threshold;
-  if (typeof t !== 'number' || !Number.isFinite(t) || t <= 0 || t >= 1) {
-    return undefined;
-  }
-  return t;
-}
-
-/**
- * Module-scope dedupe for budget-clamp warnings, keyed so a single
- * misconfiguration warns once per process rather than once per turn.
- */
-const warnedTokenClamps = new Set<string>();
-
-/**
- * Fraction of `max_tokens` reserved for the visible reply when thinking is
- * explicitly enabled. Thinking tokens share the output budget on the Messages
- * API, so without a reserve the thinking budget can consume nearly all of
- * `max_tokens` and starve the final answer (a budget of `maxTokens - 1` leaves
- * one token for the reply). 0.25 keeps at least a quarter of the budget for the
- * reply while leaving the bulk for reasoning.
- */
-const THINKING_OUTPUT_RESERVE_FRACTION = 0.25;
-
-/**
- * Resolve the effective Messages-API `max_tokens`, clamped to the model's
- * documented output ceiling (`maxOutputTokensFor`).
- *
- * - A finite, positive `config.maxOutputTokens` is used as-is when it fits the
- *   ceiling and clamped down (with a one-time warning) when it exceeds it.
- *   Without the clamp an over-large value reaches the wire verbatim and the
- *   API rejects the request with HTTP 400.
- * - Any non-finite or non-positive value — including the
- *   `Number.POSITIVE_INFINITY` "model max" sentinel that `parseMaxOutputTokens`
- *   emits for `--max-output-tokens max` — falls back to the model ceiling.
- *
- * Exported for unit testing; the production caller is the query builder above.
- */
-export function resolveMaxTokens(config: AgentConfig, model: string): number {
-  const ceiling = maxOutputTokensFor(model);
-  const v = config.maxOutputTokens;
-  if (typeof v === 'number' && Number.isFinite(v) && v > 0) {
-    const requested = Math.floor(v);
-    if (requested > ceiling) {
-      const key = `max:${model}:${requested}`;
-      if (!warnedTokenClamps.has(key)) {
-        warnedTokenClamps.add(key);
-        console.warn(
-          `[afk] maxOutputTokens ${requested} exceeds the ${model} output ceiling (${ceiling}); clamping to ${ceiling}.`,
-        );
-      }
-      return ceiling;
-    }
-    return requested;
-  }
-  return ceiling;
-}
-
-function resumeHistoryToMessages(history: ResumeHistoryTurn[] | undefined): MessageParam[] | undefined {
-  if (!history || history.length === 0) return undefined;
-  const messages: MessageParam[] = [];
-  for (const turn of history) {
-    if (turn.user.length > 0) {
-      messages.push({ role: 'user', content: turn.user });
-    }
-    if (turn.assistant.length > 0) {
-      messages.push({ role: 'assistant', content: turn.assistant });
-    }
-  }
-  return messages.length > 0 ? messages : undefined;
-}
-
-/**
- * Translate our internal {@link ThinkingConfig} into the Anthropic SDK wire
- * shape, applying model-specific fixups.
- *
- * Fixups for `claude-opus-4-7-*` and `claude-opus-4-8-*` (the `opus-4.7+`
- * family — `isOpus47Plus` matches `4-7`, `4-8`, `4-9`):
- *  - `{type: 'enabled'}` is rejected by the API; auto-route to `'adaptive'`.
- *    Callers that explicitly request `enabled` on Opus 4.7+ get adaptive
- *    behaviour with a console warning so the misconfiguration is visible.
- *  - `display: 'summarized'` is always injected on adaptive/enabled configs.
- *    On 4.7+ the default display mode is `'omitted'` (thinking blocks are
- *    produced server-side but stripped before delivery), so this field is
- *    *required* to surface visible reasoning.  On earlier models it is
- *    harmless — the server already defaults to visible delivery.
- */
-export function resolveThinkingParam(
-  tc: ThinkingConfig,
-  maxTokens: number,
-  model?: string,
-): ThinkingConfigParam {
-  switch (tc.type) {
-    case 'adaptive':
-      // Cast: the SDK ThinkingConfigAdaptive shape doesn't declare `display`
-      // yet, but the server honours it.  We use a type assertion to avoid
-      // pulling in a beta-SDK type across the module boundary.
-      return { type: 'adaptive', display: 'summarized' } as ThinkingConfigParam;
-
-    case 'disabled':
-      return { type: 'disabled' };
-
-    case 'enabled': {
-      if (typeof model === 'string' && isOpus47Plus(model)) {
-        // Opus 4.7 does not accept {type:'enabled'}; silently promote to adaptive.
-        return { type: 'adaptive', display: 'summarized' } as ThinkingConfigParam;
-      }
-      // Thinking tokens share the `max_tokens` budget, so reserve a slice for
-      // the visible reply and cap the thinking budget to fit. The cap applies
-      // to caller-supplied budgets too — an oversized explicit budget is
-      // clamped (with a one-time warning) rather than honoured blindly.
-      // `budget_tokens` must satisfy 1024 <= budget < max_tokens; when the
-      // reserve cannot be honoured (very small max_tokens) the upper bound
-      // wins so the request still clears the `< max_tokens` constraint.
-      const reserve = Math.floor(maxTokens * THINKING_OUTPUT_RESERVE_FRACTION);
-      const maxBudget = Math.max(1024, maxTokens - 1 - reserve);
-      const explicit =
-        tc.budgetTokens !== undefined && Number.isFinite(tc.budgetTokens)
-          ? Math.floor(tc.budgetTokens)
-          : undefined;
-      const budget = Math.min(Math.max(explicit ?? maxBudget, 1024), maxBudget);
-      if (explicit !== undefined && explicit > maxBudget) {
-        const key = `think:${model ?? 'default'}:${explicit}:${maxTokens}`;
-        if (!warnedTokenClamps.has(key)) {
-          warnedTokenClamps.add(key);
-          console.warn(
-            `[afk] thinking budgetTokens ${explicit} leaves too little of max_tokens ${maxTokens} for the reply; clamping to ${maxBudget}.`,
-          );
-        }
-      }
-      return {
-        type: 'enabled',
-        budget_tokens: budget,
-        display: 'summarized',
-      } as ThinkingConfigParam;
-    }
-  }
-}
-
-/**
- * Resolve the effective effort level for a request.
- *
- * Rules:
- *  1. An explicit `config.effort` always wins — callers can always override
- *     (including on Haiku, which will then fail loudly rather than silently
- *     ignore).
- *  2. For `opus-4-6`, `opus-4-7`, `opus-4-8`, `sonnet-4-6`, and `sonnet-4-7`
- *     (current and recent of each non-Haiku Claude 4 family), default to
- *     `'max'` when no effort is supplied. Empirically (scripts/probe-effort-
- *     thinking.mjs on opus-4-7) `max` produces ~10× the thinking-token depth
- *     vs the server default; the same lever applies on sonnet-4-6/opus-4-6.
- *     On opus-4-8 the server default flipped to `high`, so retaining `max`
- *     here preserves the high-thinking-depth experience users had on 4.7.
- *  3. Older 4-x variants (4-1, 4-5) and every Haiku reject
- *     `output_config.effort` with HTTP 400 — auto-default is skipped so
- *     non-effort requests on those models stay byte-equal to before.
- *  4. 3.x / legacy / unknown ids: omit. Matches Claude Code's
- *     `modelSupportsEffort()` allowlist behavior.
- *
- * `'xhigh'` is accepted by the API but empirically sits between `'high'`
- * and `'max'` on opus-4-7, so it is NOT the auto-default. (Anthropic's
- * 4.8 docs recommend `xhigh` for coding/agentic work; consider re-tuning
- * after baselining cost/latency on 4.8.)
- *
- * The returned value is forwarded as `output_config.effort` in the wire
- * request.  When `undefined`, no `output_config` field is sent.
- */
-export function resolveEffort(
-  callerEffort: EffortLevel | undefined,
-  model: string,
-): EffortLevel | undefined {
-  if (callerEffort !== undefined) return callerEffort;
-  const m = model.toLowerCase();
-  // Production-verified allowlist: only `4-6` and `4-7` opus/sonnet variants
-  // accept `output_config.effort` (probed scripts/probe-effort-{all-models,
-  // older}.mjs against the OAuth identity). Earlier minor versions — 4-1,
-  // 4-5 sonnet, 4-5 opus, and every Haiku — return HTTP 400
-  // "This model does not support the effort parameter." Caller-supplied
-  // effort still flows through unchanged so explicit overrides fail loudly
-  // rather than silently ignoring, but auto-default is gated tightly.
-  if (/(claude-)?(opus|sonnet)-4-[678]/.test(m)) return 'max';
-  return undefined;
 }
 
 /**

--- a/src/agent/providers/anthropic-direct/resolve-effort.test.ts
+++ b/src/agent/providers/anthropic-direct/resolve-effort.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { resolveEffort, resolveMaxTokens, resolveThinkingParam } from './index.js';
+import { resolveEffort, resolveMaxTokens, resolveThinkingParam } from './resolve-params.js';
 import { maxOutputTokensFor } from '../../model-limits.js';
 import type { AgentConfig } from '../../types/config-types.js';
 import type { ThinkingConfig } from '../../types/sdk-types.js';

--- a/src/agent/providers/anthropic-direct/resolve-params.ts
+++ b/src/agent/providers/anthropic-direct/resolve-params.ts
@@ -1,0 +1,220 @@
+/**
+ * Pure parameter-resolution helpers for the anthropic-direct provider.
+ *
+ * These functions are stateless and carry zero dependency on the
+ * {@link AnthropicDirectProvider} instance — extracted from `index.ts`
+ * (issue #103) to shrink the provider file and isolate independently testable
+ * logic. `index.ts` re-imports all of them and re-exports `resolveMaxTokens`,
+ * `resolveThinkingParam`, and `resolveEffort` so the historical
+ * `from './index.js'` import path stays valid for existing callers.
+ *
+ * @module agent/providers/anthropic-direct/resolve-params
+ */
+
+import type { MessageParam, ThinkingConfigParam } from '@anthropic-ai/sdk/resources';
+import type { AgentConfig, ResumeHistoryTurn } from '../../types/config-types.js';
+import type { EffortLevel, ThinkingConfig } from '../../types/sdk-types.js';
+import { maxOutputTokensFor } from '../../model-limits.js';
+
+/** Match opus-4.7 and later opus 4.x families that require adaptive thinking + summarized display. */
+const isOpus47Plus = (model: string): boolean => /opus-4-(7|[89])/.test(model);
+
+const DEFAULT_AUTO_COMPACT_THRESHOLD = 0.9;
+
+/**
+ * Resolve `AgentConfig.autoCompact` to a numeric threshold fraction, or
+ * `undefined` when auto-compaction is disabled.
+ *
+ * - `false` or `undefined` → disabled (`undefined` returned).
+ * - `true` → default threshold (0.90).
+ * - `{ threshold: n }` → custom fraction; clamped to (0, 1) exclusive.
+ *   Out-of-range values are silently treated as disabled.
+ */
+export function resolveAutoCompactThreshold(
+  autoCompact: AgentConfig['autoCompact'],
+): number | undefined {
+  if (autoCompact === undefined || autoCompact === false) return undefined;
+  if (autoCompact === true) return DEFAULT_AUTO_COMPACT_THRESHOLD;
+  const t = autoCompact.threshold;
+  if (typeof t !== 'number' || !Number.isFinite(t) || t <= 0 || t >= 1) {
+    return undefined;
+  }
+  return t;
+}
+
+/**
+ * Module-scope dedupe for budget-clamp warnings, keyed so a single
+ * misconfiguration warns once per process rather than once per turn.
+ */
+const warnedTokenClamps = new Set<string>();
+
+/**
+ * Fraction of `max_tokens` reserved for the visible reply when thinking is
+ * explicitly enabled. Thinking tokens share the output budget on the Messages
+ * API, so without a reserve the thinking budget can consume nearly all of
+ * `max_tokens` and starve the final answer (a budget of `maxTokens - 1` leaves
+ * one token for the reply). 0.25 keeps at least a quarter of the budget for the
+ * reply while leaving the bulk for reasoning.
+ */
+const THINKING_OUTPUT_RESERVE_FRACTION = 0.25;
+
+/**
+ * Resolve the effective Messages-API `max_tokens`, clamped to the model's
+ * documented output ceiling (`maxOutputTokensFor`).
+ *
+ * - A finite, positive `config.maxOutputTokens` is used as-is when it fits the
+ *   ceiling and clamped down (with a one-time warning) when it exceeds it.
+ *   Without the clamp an over-large value reaches the wire verbatim and the
+ *   API rejects the request with HTTP 400.
+ * - Any non-finite or non-positive value — including the
+ *   `Number.POSITIVE_INFINITY` "model max" sentinel that `parseMaxOutputTokens`
+ *   emits for `--max-output-tokens max` — falls back to the model ceiling.
+ *
+ * Exported for unit testing; the production caller is the query builder in
+ * `index.ts`.
+ */
+export function resolveMaxTokens(config: AgentConfig, model: string): number {
+  const ceiling = maxOutputTokensFor(model);
+  const v = config.maxOutputTokens;
+  if (typeof v === 'number' && Number.isFinite(v) && v > 0) {
+    const requested = Math.floor(v);
+    if (requested > ceiling) {
+      const key = `max:${model}:${requested}`;
+      if (!warnedTokenClamps.has(key)) {
+        warnedTokenClamps.add(key);
+        console.warn(
+          `[afk] maxOutputTokens ${requested} exceeds the ${model} output ceiling (${ceiling}); clamping to ${ceiling}.`,
+        );
+      }
+      return ceiling;
+    }
+    return requested;
+  }
+  return ceiling;
+}
+
+export function resumeHistoryToMessages(history: ResumeHistoryTurn[] | undefined): MessageParam[] | undefined {
+  if (!history || history.length === 0) return undefined;
+  const messages: MessageParam[] = [];
+  for (const turn of history) {
+    if (turn.user.length > 0) {
+      messages.push({ role: 'user', content: turn.user });
+    }
+    if (turn.assistant.length > 0) {
+      messages.push({ role: 'assistant', content: turn.assistant });
+    }
+  }
+  return messages.length > 0 ? messages : undefined;
+}
+
+/**
+ * Translate our internal {@link ThinkingConfig} into the Anthropic SDK wire
+ * shape, applying model-specific fixups.
+ *
+ * Fixups for `claude-opus-4-7-*` and `claude-opus-4-8-*` (the `opus-4.7+`
+ * family — `isOpus47Plus` matches `4-7`, `4-8`, `4-9`):
+ *  - `{type: 'enabled'}` is rejected by the API; auto-route to `'adaptive'`.
+ *    Callers that explicitly request `enabled` on Opus 4.7+ get adaptive
+ *    behaviour with a console warning so the misconfiguration is visible.
+ *  - `display: 'summarized'` is always injected on adaptive/enabled configs.
+ *    On 4.7+ the default display mode is `'omitted'` (thinking blocks are
+ *    produced server-side but stripped before delivery), so this field is
+ *    *required* to surface visible reasoning.  On earlier models it is
+ *    harmless — the server already defaults to visible delivery.
+ */
+export function resolveThinkingParam(
+  tc: ThinkingConfig,
+  maxTokens: number,
+  model?: string,
+): ThinkingConfigParam {
+  switch (tc.type) {
+    case 'adaptive':
+      // Cast: the SDK ThinkingConfigAdaptive shape doesn't declare `display`
+      // yet, but the server honours it.  We use a type assertion to avoid
+      // pulling in a beta-SDK type across the module boundary.
+      return { type: 'adaptive', display: 'summarized' } as ThinkingConfigParam;
+
+    case 'disabled':
+      return { type: 'disabled' };
+
+    case 'enabled': {
+      if (typeof model === 'string' && isOpus47Plus(model)) {
+        // Opus 4.7 does not accept {type:'enabled'}; silently promote to adaptive.
+        return { type: 'adaptive', display: 'summarized' } as ThinkingConfigParam;
+      }
+      // Thinking tokens share the `max_tokens` budget, so reserve a slice for
+      // the visible reply and cap the thinking budget to fit. The cap applies
+      // to caller-supplied budgets too — an oversized explicit budget is
+      // clamped (with a one-time warning) rather than honoured blindly.
+      // `budget_tokens` must satisfy 1024 <= budget < max_tokens; when the
+      // reserve cannot be honoured (very small max_tokens) the upper bound
+      // wins so the request still clears the `< max_tokens` constraint.
+      const reserve = Math.floor(maxTokens * THINKING_OUTPUT_RESERVE_FRACTION);
+      const maxBudget = Math.max(1024, maxTokens - 1 - reserve);
+      const explicit =
+        tc.budgetTokens !== undefined && Number.isFinite(tc.budgetTokens)
+          ? Math.floor(tc.budgetTokens)
+          : undefined;
+      const budget = Math.min(Math.max(explicit ?? maxBudget, 1024), maxBudget);
+      if (explicit !== undefined && explicit > maxBudget) {
+        const key = `think:${model ?? 'default'}:${explicit}:${maxTokens}`;
+        if (!warnedTokenClamps.has(key)) {
+          warnedTokenClamps.add(key);
+          console.warn(
+            `[afk] thinking budgetTokens ${explicit} leaves too little of max_tokens ${maxTokens} for the reply; clamping to ${maxBudget}.`,
+          );
+        }
+      }
+      return {
+        type: 'enabled',
+        budget_tokens: budget,
+        display: 'summarized',
+      } as ThinkingConfigParam;
+    }
+  }
+}
+
+/**
+ * Resolve the effective effort level for a request.
+ *
+ * Rules:
+ *  1. An explicit `config.effort` always wins — callers can always override
+ *     (including on Haiku, which will then fail loudly rather than silently
+ *     ignore).
+ *  2. For `opus-4-6`, `opus-4-7`, `opus-4-8`, `sonnet-4-6`, and `sonnet-4-7`
+ *     (current and recent of each non-Haiku Claude 4 family), default to
+ *     `'max'` when no effort is supplied. Empirically (scripts/probe-effort-
+ *     thinking.mjs on opus-4-7) `max` produces ~10× the thinking-token depth
+ *     vs the server default; the same lever applies on sonnet-4-6/opus-4-6.
+ *     On opus-4-8 the server default flipped to `high`, so retaining `max`
+ *     here preserves the high-thinking-depth experience users had on 4.7.
+ *  3. Older 4-x variants (4-1, 4-5) and every Haiku reject
+ *     `output_config.effort` with HTTP 400 — auto-default is skipped so
+ *     non-effort requests on those models stay byte-equal to before.
+ *  4. 3.x / legacy / unknown ids: omit. Matches Claude Code's
+ *     `modelSupportsEffort()` allowlist behavior.
+ *
+ * `'xhigh'` is accepted by the API but empirically sits between `'high'`
+ * and `'max'` on opus-4-7, so it is NOT the auto-default. (Anthropic's
+ * 4.8 docs recommend `xhigh` for coding/agentic work; consider re-tuning
+ * after baselining cost/latency on 4.8.)
+ *
+ * The returned value is forwarded as `output_config.effort` in the wire
+ * request.  When `undefined`, no `output_config` field is sent.
+ */
+export function resolveEffort(
+  callerEffort: EffortLevel | undefined,
+  model: string,
+): EffortLevel | undefined {
+  if (callerEffort !== undefined) return callerEffort;
+  const m = model.toLowerCase();
+  // Production-verified allowlist: only `4-6` and `4-7` opus/sonnet variants
+  // accept `output_config.effort` (probed scripts/probe-effort-{all-models,
+  // older}.mjs against the OAuth identity). Earlier minor versions — 4-1,
+  // 4-5 sonnet, 4-5 opus, and every Haiku — return HTTP 400
+  // "This model does not support the effort parameter." Caller-supplied
+  // effort still flows through unchanged so explicit overrides fail loudly
+  // rather than silently ignoring, but auto-default is gated tightly.
+  if (/(claude-)?(opus|sonnet)-4-[678]/.test(m)) return 'max';
+  return undefined;
+}


### PR DESCRIPTION
Closes #103.

## What

Extracts the cluster of stateless, instance-independent parameter resolvers out of `src/agent/providers/anthropic-direct/index.ts` (1,135 LOC) into a focused new module `resolve-params.ts`, shrinking the provider file by ~195 lines and isolating independently testable pure logic.

**Moved to `resolve-params.ts`:**

| Symbol | Was exported? | Now |
|---|---|---|
| `resolveAutoCompactThreshold` | no | exported |
| `resolveMaxTokens` | yes | exported |
| `resumeHistoryToMessages` | no | exported |
| `resolveThinkingParam` | yes | exported |
| `resolveEffort` | yes | exported |
| `warnedTokenClamps` | (private) | private — moved to preserve per-process warn-once dedupe shared by `resolveMaxTokens` + `resolveThinkingParam` |

Supporting privates the above depend on also move so the new module has **no back-import from `index.ts`** (avoids a circular dependency): `isOpus47Plus` (used only by `resolveThinkingParam`), `DEFAULT_AUTO_COMPACT_THRESHOLD`, `THINKING_OUTPUT_RESERVE_FRACTION`.

## Import-path stability

`index.ts` re-imports all five resolvers for internal use and **re-exports** `resolveMaxTokens` / `resolveThinkingParam` / `resolveEffort` so the historical `from './index.js'` path stays valid for any external caller. The one dependent test, `resolve-effort.test.ts`, is repointed at `./resolve-params.js` (the issue-named `anthropic-direct.test.ts` does not import these symbols — verified).

## Verification

- ✅ `pnpm lint` (`tsc --noEmit`, strict) — pass
- ✅ `pnpm audit:sdk:check` — pass ("Lock matches current imports"). The moved `@anthropic-ai/sdk/resources` type imports (`MessageParam`, `ThinkingConfigParam`) are not in `TRACKED_PACKAGES`, and the audit keys on `(package, symbol)` tuples, not files — so moving them is a no-op for the lock.
- ✅ `resolve-effort.test.ts` — 22/22 pass
- ✅ Full suite — `2 failed | 9545 passed | 12 skipped`. **Both failures are pre-existing on the base commit** (`compact()` model-alias `claude-haiku-4-5` vs `claude-haiku-4-5-20251001`, and `config.test.ts` "defaults to the built-in tier bindings"), confirmed by re-running them with these changes stashed. Neither touches the extracted pure resolvers.

## Acceptance criteria

- [x] The 5 functions + `warnedTokenClamps` live in `resolve-params.ts`
- [x] `index.ts` re-imports them; the 3 public ones stay exported (re-exported to keep import paths stable)
- [x] Dependent test import paths updated
- [x] `pnpm lint` passes
- [x] `pnpm test -- src/agent/providers/anthropic-direct.test.ts` — resolver logic passes; the 1 remaining failure is pre-existing & unrelated (see above)
- [x] `pnpm audit:sdk:check` still passes