### PR TITLE
feat(cli): scope /resume session list to current working directory

### DIFF
--- a/src/cli/session-store.test.ts
+++ b/src/cli/session-store.test.ts
@@ -404,4 +404,23 @@ describe('session-store — naming', () => {
     // Resolving by sidecar id and SDK id still works.
     expect(findSession('sdk-legacy')?.data.sessionId).toBe('sdk-legacy');
   });
+
+  it('persists cwd when set on stats', () => {
+    const stats = createSessionStats('sonnet');
+    stats.cwd = '/proj/foo';
+    recordTurn(stats, 'work here', 'done', { sessionId: 'sdk-cwd-test' });
+    const path = saveSession(stats);
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+    expect(raw['cwd']).toBe('/proj/foo');
+    const entry = listSessions().find((e) => e.sessionId === 'sdk-cwd-test');
+    expect(entry?.cwd).toBe('/proj/foo');
+  });
+
+  it('does not write cwd key when absent from stats', () => {
+    const stats = createSessionStats('sonnet');
+    recordTurn(stats, 'no cwd', 'done', { sessionId: 'sdk-no-cwd' });
+    const path = saveSession(stats);
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+    expect('cwd' in raw).toBe(false);
+  });
 });

--- a/src/cli/session-store.ts
+++ b/src/cli/session-store.ts
@@ -42,6 +42,10 @@ export interface StoredSession {
   forkedFrom?: string;
   /** Wall-clock time the fork was created (set by /fork). */
   forkedAt?: number;
+  /** Effective working directory when the session was started. Used by /resume
+   * to filter the list to sessions from the current directory. Absent on
+   * legacy sidecars — those surface only in the global fallback view. */
+  cwd?: string;
 }
 
 export interface SessionListEntry {
@@ -55,6 +59,7 @@ export interface SessionListEntry {
   savedAt: number;
   totalTurns: number;
   totalCostUsd: number;
+  cwd?: string;
 }
 
 export interface FoundSession {
@@ -124,6 +129,7 @@ export function saveSession(stats: SessionStats, overrideId?: string): string {
     ...(stats.name ? { name: stats.name } : {}),
     ...(stats.source ? { source: stats.source } : {}),
     ...(stats.telegramChatId !== undefined ? { telegramChatId: stats.telegramChatId } : {}),
+    ...(stats.cwd ? { cwd: stats.cwd } : {}),
     model: stats.model,
     startedAt: stats.sessionStartTime,
     savedAt: Date.now(),
@@ -278,6 +284,7 @@ export function listSessions(): SessionListEntry[] {
         savedAt: loaded.savedAt,
         totalTurns: loaded.totalTurns,
         totalCostUsd: loaded.totalCostUsd,
+        cwd: loaded.cwd,
       });
     } catch {
       // skip corrupted files

--- a/src/cli/slash/commands/resume.test.ts
+++ b/src/cli/slash/commands/resume.test.ts
@@ -129,3 +129,58 @@ describe('/resume — C2 same-session guard', () => {
     expect(lines.some((l) => /WARN:.*No saved session/i.test(l))).toBe(true);
   });
 });
+
+describe('/resume — no-arg CWD filtering', () => {
+  it('shows only sessions matching ctx.stats.cwd', async () => {
+    // Save two sessions in different directories.
+    const statsA = createSessionStats('sonnet');
+    statsA.cwd = '/proj/foo';
+    recordTurn(statsA, 'foo work', 'done', { sessionId: 'sdk-cwd-a', totalCostUsd: 0.01, durationMs: 10, usage: { input_tokens: 5, output_tokens: 5 } });
+    statsA.name = 'session-foo';
+    saveSession(statsA);
+
+    const statsB = createSessionStats('sonnet');
+    statsB.cwd = '/proj/bar';
+    recordTurn(statsB, 'bar work', 'done', { sessionId: 'sdk-cwd-b', totalCostUsd: 0.01, durationMs: 10, usage: { input_tokens: 5, output_tokens: 5 } });
+    statsB.name = 'session-bar';
+    saveSession(statsB);
+
+    const { ctx, lines } = makeCtx(undefined);
+    ctx.stats.cwd = '/proj/foo';
+    await resumeCmd.handler(ctx, '');
+
+    const allText = lines.join('\n');
+    expect(allText).toContain('session-foo');
+    expect(allText).not.toContain('session-bar');
+  });
+
+  it('falls back to global list with distinct header when no local sessions', async () => {
+    const statsB = createSessionStats('sonnet');
+    statsB.cwd = '/proj/bar';
+    recordTurn(statsB, 'bar work', 'done', { sessionId: 'sdk-fallback', totalCostUsd: 0.01, durationMs: 10, usage: { input_tokens: 5, output_tokens: 5 } });
+    statsB.name = 'session-bar-only';
+    saveSession(statsB);
+
+    const { ctx, lines } = makeCtx(undefined);
+    ctx.stats.cwd = '/proj/unrelated';
+    await resumeCmd.handler(ctx, '');
+
+    const allText = lines.join('\n');
+    expect(allText).toMatch(/Saved sessions — all \(none in this directory\)/);
+    expect(allText).toContain('session-bar-only');
+  });
+
+  it('explicit target path ignores cwd entirely', async () => {
+    const statsC = createSessionStats('sonnet');
+    statsC.cwd = '/proj/bar';
+    recordTurn(statsC, 'some work', 'done', { sessionId: 'sdk-explicit', totalCostUsd: 0.01, durationMs: 10, usage: { input_tokens: 5, output_tokens: 5 } });
+    const path = saveSession(statsC);
+    const sidecarId = path.split('/').pop()!.replace(/\.json$/, '');
+
+    const { ctx, requestResumeSpy } = makeCtx('sdk-other');
+    ctx.stats.cwd = '/proj/other';
+    await resumeCmd.handler(ctx, sidecarId);
+
+    expect(requestResumeSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/src/cli/slash/commands/resume.ts
+++ b/src/cli/slash/commands/resume.ts
@@ -105,10 +105,17 @@ export const resumeCmd: SlashCommand = {
       ctx.out.info('No saved sessions found.  Use /save first.');
       return 'continue';
     }
+    const currentCwd = ctx.stats.cwd ?? process.cwd();
+    const localEntries = entries.filter((e) => e.cwd === currentCwd);
+    const isFiltered = localEntries.length > 0;
+    const displayEntries = isFiltered ? localEntries : entries;
+    const header = isFiltered
+      ? palette.bold(`Saved sessions  (${displayEntries.length})`)
+      : palette.bold(`Saved sessions — all (none in this directory)`);
     ctx.out.line();
-    ctx.out.line(palette.bold(`Saved sessions  (${entries.length})`));
+    ctx.out.line(header);
     ctx.out.line(divider());
-    for (const e of entries.slice(0, 20)) {
+    for (const e of displayEntries.slice(0, 20)) {
       const when = fmtWhen(e.savedAt);
       const model = palette.brand(e.model.padEnd(7));
       const turns = palette.meta(`${e.totalTurns} turn${e.totalTurns === 1 ? '' : 's'}`.padEnd(9));


### PR DESCRIPTION
## Summary

When `/resume` is invoked with **no argument** in the interactive REPL, the session list now shows only sessions that were started in the **current working directory** — keeping the picker scoped to the project at hand instead of dumping every session across the machine.

- If no sessions match the current directory, it **falls back to the full global list** with a distinct header (`Saved sessions — all (none in this directory)`), so the command is never silently empty.
- Explicit `/resume <id>` targeting is **unchanged** — it still resolves globally by id/name/prefix, ignoring cwd.

## Changes

- `src/cli/session-store.ts` — add optional `cwd?: string` to `StoredSession` + `SessionListEntry`; write `stats.cwd` into the `saveSession()` sidecar payload (conditional spread, mirroring the existing `source` field); surface `cwd` in `listSessions()`.
- `src/cli/slash/commands/resume.ts` — no-arg branch filters entries by `ctx.stats.cwd ?? process.cwd()`; renders a fallback header when nothing matches. Explicit-target path untouched.
- Tests — 2 new in `session-store.test.ts` (cwd persisted when set / absent when unset), 3 new in `resume.test.ts` (filtered view, fallback header, explicit-target ignores cwd).

## Backward compatibility

`cwd` is optional. Legacy sidecars written before this change have no `cwd` field, so `e.cwd === currentCwd` is `false` — they are excluded from the filtered view and surface only in the global fallback. No migration, no schema bump, no new imports. The `listSessions()` validation guard is unchanged.

## Verification

- `pnpm lint` (tsc --noEmit, strict) — 0 errors
- Targeted tests `session-store.test.ts` + `resume.test.ts` — 40 passed (incl. 5 new)
- Adversarial diff review — verdict SHIP; correctness, backward-compat, and regression checks all pass.

## Known minor items (non-blocking, optional follow-up)

- The fallback header omits a total count, while the normal filtered header shows `(N)`; the global list can exceed the 20-row display cap, so the user can't see how many are truncated in the fallback case.
- No test exercises the `ctx.stats.cwd === undefined` branch (the `process.cwd()` fallback); the behavior works but that branch is uncovered.

## Design note

The fallback-to-global-when-empty behavior (vs. showing a literal empty list) is a deliberate choice for usability. Easy to flip to strict-empty if preferred.
