### PR TITLE
refactor(cli): centralize committed-band CUP+EL escape into eraseAndPaintRow

### DIFF
--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -14,6 +14,7 @@
  */
 
 import type { LogUpdateFn, CompositorScrollRegionGuard } from './terminal-compositor.types.js';
+import { eraseAndPaintRow } from './terminal-compositor.types.js';
 import { hardWrapToWidth } from './wrap.js';
 import { capBandModel, decideCommitMode } from './commit-mode.js';
 
@@ -360,7 +361,7 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
           for (let start = 0; start < genuineOverflow; start += chunkMax) {
             const chunk = overflowRun.slice(start, Math.min(start + chunkMax, genuineOverflow));
             const topWrite = chunk
-              .map((l, i) => `\x1b[${anchorFloor + i};1H\x1b[2K${l ?? ''}`)
+              .map((l, i) => eraseAndPaintRow(anchorFloor + i, l))
               .join('');
             self.stdout.write(`${topWrite}\x1b[${rows};1H${'\n'.repeat(chunk.length)}`);
           }
@@ -470,7 +471,7 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
       for (let i = 0; i < paintedCount; i++) {
         const row = bandTop + i;
         if (row >= newTopRow) break; // Never overwrite the live frame.
-        out += `\x1b[${row};1H\x1b[2K${model[model.length - paintedCount + i] ?? ''}`;
+        out += eraseAndPaintRow(row, model[model.length - paintedCount + i]);
       }
       if (out.length > 0) {
         writeWithGuard(() => {
@@ -572,13 +573,13 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
         if (oldBandTop > 0 && oldBandTop < bandTop) {
           const eraseFloor = Math.max(postScrollFloor, oldBandTop);
           for (let r = eraseFloor; r < bandTop; r++) {
-            out += `\x1b[${r};1H\x1b[2K`;
+            out += eraseAndPaintRow(r);
           }
         }
         for (let i = 0; i < capped.length; i++) {
           const row = bandTop + i;
           if (row >= newTopRow) break; // Never overwrite the live frame.
-          out += `\x1b[${row};1H\x1b[2K${capped[i] ?? ''}`;
+          out += eraseAndPaintRow(row, capped[i]);
         }
       } else {
         // Overflow (block taller than the above-frame region): Phase 1 already
@@ -597,7 +598,7 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
         for (let i = startIdx; i < textLines.length; i++) {
           const row = anchorFloor + (i - startIdx);
           if (row >= newTopRow) break;
-          out += `\x1b[${row};1H\x1b[2K${textLines[i] ?? ''}`;
+          out += eraseAndPaintRow(row, textLines[i]);
         }
       }
       if (out.length > 0) {

--- a/src/cli/terminal-compositor.committed-band-repin.ts
+++ b/src/cli/terminal-compositor.committed-band-repin.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CommittedBandHost } from './terminal-compositor.committed-band-commit.js';
+import { eraseAndPaintRow } from './terminal-compositor.types.js';
 
 /**
  * Physically erase the pre-resize on-screen footprint snapshotted by the
@@ -35,7 +36,7 @@ export function flushResizeGhostErase(self: CommittedBandHost): void {
   // scroll region is never triggered.
   let out = '';
   for (let r = top; r <= bottom; r++) {
-    out += `\x1b[${r};1H\x1b[2K`;
+    out += eraseAndPaintRow(r);
   }
   try {
     self.stdout.write(out);
@@ -98,10 +99,10 @@ export function repositionCommittedBand(
   // Erase rows the block vacated when it slid DOWN (the former gap), down to —
   // but not including — its new top.
   for (let r = Math.max(floor, self.committedBandTopRow); r < newTop; r++) {
-    out += `\x1b[${r};1H\x1b[2K`;
+    out += eraseAndPaintRow(r);
   }
   for (let i = 0; i < paint.length; i++) {
-    out += `\x1b[${newTop + i};1H\x1b[2K${paint[i] ?? ''}`;
+    out += eraseAndPaintRow(newTop + i, paint[i]);
   }
   // Re-park the cursor where CupFrameRenderer.render() left it (the frame's
   // bottom content row) so the band write does not displace it.

--- a/src/cli/terminal-compositor.frame-preserve.ts
+++ b/src/cli/terminal-compositor.frame-preserve.ts
@@ -9,6 +9,7 @@
  */
 
 import type { FrameHost } from './terminal-compositor.frame.js';
+import { eraseAndPaintRow } from './terminal-compositor.types.js';
 
 /**
  * Preserve rows that the next compositor frame is about to cover.
@@ -58,10 +59,10 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
     // follows repaints its own (lower) footprint; survivors sit above it.
     let out = '';
     for (let r = Math.max(1, self.committedBandTopRow); r <= self.committedBandBottomRow; r++) {
-      out += `\x1b[${r};1H\x1b[2K`;
+      out += eraseAndPaintRow(r);
     }
     for (let i = 0; i < bandLen; i++) {
-      out += `\x1b[${1 + i};1H\x1b[2K${self.committedBand[i] ?? ''}`;
+      out += eraseAndPaintRow(1 + i, self.committedBand[i]);
     }
     try {
       self.stdout.write(out);

--- a/src/cli/terminal-compositor.lifecycle.ts
+++ b/src/cli/terminal-compositor.lifecycle.ts
@@ -18,6 +18,7 @@ import type {
   KeyInfo,
   LogUpdateFn,
 } from './terminal-compositor.types.js';
+import { eraseAndPaintRow } from './terminal-compositor.types.js';
 import * as InputDispatch from './terminal-compositor.input-dispatch.js';
 import type { KeyDispatchHost } from './terminal-compositor.input-dispatch.js';
 
@@ -399,7 +400,7 @@ function flushPendingCommittedBand(self: LifecycleHost): void {
     for (let start = 0; start < pending.length; start += chunkMax) {
       const chunk = pending.slice(start, Math.min(start + chunkMax, pending.length));
       const topWrite = chunk
-        .map((l, i) => `\x1b[${anchorFloor + i};1H\x1b[2K${l ?? ''}`)
+        .map((l, i) => eraseAndPaintRow(anchorFloor + i, l))
         .join('');
       self.stdout.write(`${topWrite}\x1b[${rows};1H${'\n'.repeat(chunk.length)}`);
     }

--- a/src/cli/terminal-compositor.types.ts
+++ b/src/cli/terminal-compositor.types.ts
@@ -76,6 +76,23 @@ export function formatElapsed(startedAt: number): string {
 }
 
 /**
+ * Absolute-position erase-and-paint of one terminal row, returned as a string
+ * for accumulation into a batched write (never written directly here).
+ *
+ * Emits CUP (`\x1b[{row};1H` — cursor to column 1 of `row`) then EL
+ * (`\x1b[2K` — erase entire line), then `line`. Omitting `line` (or passing
+ * `undefined`) erases the row and writes nothing — the bare-erase form.
+ *
+ * Invariant: emits NO `\n`, so callers that rely on CUP+EL writes never
+ * triggering the DECSTBM scroll region stay correct. Shared by the
+ * committed-band commit/repin and frame-preserve render paths, which batch
+ * these into one `out` string before a single `stdout.write`.
+ */
+export function eraseAndPaintRow(row: number, line?: string): string {
+  return `\x1b[${row};1H\x1b[2K${line ?? ''}`;
+}
+
+/**
  * Format a loading tip into the dim 💡 row that sits beneath the spinner.
  *
  * The literal `Tip:` label is load-bearing, not decoration: most tips are


### PR DESCRIPTION
## What

Extracts the duplicated absolute-position cursor erase-and-paint escape sequence — `` `\x1b[${row};1H\x1b[2K${line ?? ''}` `` (CUP to `row`/col-1 + EL erase-line + optional content) — into a single documented helper `eraseAndPaintRow(row, line?)` in `terminal-compositor.types.ts` (the existing leaf module for pure, side-effect-free helpers — no circular-import risk).

The sequence was hand-written at **11 sites across 4 modules**:

| Module | Sites |
|---|---|
| `terminal-compositor.committed-band-commit.ts` | 5 |
| `terminal-compositor.committed-band-repin.ts` | 3 |
| `terminal-compositor.frame-preserve.ts` | 2 |
| `terminal-compositor.lifecycle.ts` | 1 |

## Why

- A change to the erase/paint primitive previously had to be replicated across 11 copies.
- The load-bearing invariant — *emits no `\n`, so the DECSTBM scroll region is never triggered* — lived only in scattered call-site comments. It is now documented once, on the helper.
- The erase-only sites are exactly the `line === undefined` case, so one helper cleanly covers both shapes (bare-erase and erase-then-paint).

## Behavior preservation

Output bytes are **identical** at every call site — this is a pure de-duplication, no observable behavior change. The intentionally *different* relative-position variant `` `\x1b[2K${l}` `` (EL with no CUP, joined with `\n`) in `committed-band-commit.ts` is deliberately left untouched.

- ✅ `pnpm lint` (`tsc --noEmit`, strict) — clean
- ✅ `terminal-compositor` suite — **288/288 green**, unchanged from the pre-change baseline
- ✅ Full suite — **zero new failures**. The 2 failing files (`config.test.ts`, `anthropic-direct.test.ts`) are a pre-existing model-registry test drift on `main`, confirmed failing identically on a clean checkout with these changes stashed.

## Deferred (intentionally out of scope)

A read-only `/simplify` discovery pass flagged two larger items that are **not** included here, on Sandi-Metz grounds (duplication is cheaper than the wrong abstraction):

1. **Per-module `*Host` interface field duplication** — the ~10 `*Host` interfaces re-declare overlapping fields, but each is documented in-code as the *"narrowest state slice"* its module touches. Collapsing them into a shared base would erode that intentional precision.
2. **`commitAbove` banner / non-banner dual path** — unifying the two branch trees would require introducing a flag parameter.

Both are left as potential follow-ups.

## Diff

5 files, **+32 / −11**. The net `+21` is the helper's invariant-documenting comment; the duplication factor drops **11 → 1**.

---
🤖 Generated with agent-afk (`/simplify` → behavior-preserving apply).
