### PR TITLE
feat(cli): render MCP form enum/boolean fields as arrow-key selector

### DIFF
--- a/src/cli/elicitation-repl.test.ts
+++ b/src/cli/elicitation-repl.test.ts
@@ -1768,3 +1768,149 @@ describe('allow_custom — TTY multi-selector path (renderMultiSelector)', () =>
     expect(result.content?.['value']).toEqual(['alpha', 'beta']);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Form mode — picker path (enum / boolean fields + pickFromList, TTY surfaces)
+// ---------------------------------------------------------------------------
+//
+// When a pickFromList dep is wired (armed compositor / interactive TTY), an
+// `enum` or `boolean` form field is rendered as the arrow-key PickerController
+// overlay — the same component the ask_question choice prompts use — instead
+// of a typed `> ` readLine prompt. This is what makes the path-approval prompt
+// (a single enum field) a keyboard selector. Without the dep (non-TTY/daemon/
+// tests), the typed path remains the fallback.
+describe('form mode — picker path (enum/boolean)', () => {
+  // Mirrors the path-approval hook's form: one required enum field.
+  function pathApprovalForm(): ElicitationRequest {
+    return formRequest(
+      {
+        choice: {
+          type: 'string',
+          title: 'Choose one',
+          enum: ['once', 'session', 'persist', 'deny'],
+          description: "'once' allows this single call only. 'session' allows this path until the session ends.",
+        },
+      },
+      ['choice'],
+    );
+  }
+
+  it('enum field + pickFromList: renders a selector and returns the picked value (no typed prompt)', async () => {
+    const lines: string[] = [];
+    const readLine = vi.fn();
+    const pickFromList = vi.fn().mockResolvedValueOnce(['session']);
+    const handler = makeReplElicitationHandler({
+      readLine,
+      writer: { line: (t = '') => lines.push(t) },
+      pendingCount: () => 0,
+      pickFromList,
+    });
+
+    const result = await handler(pathApprovalForm(), { signal: NO_SIGNAL });
+
+    expect(result.action).toBe('accept');
+    expect(result.content?.['choice']).toBe('session');
+    // Selector was used, NOT the typed readLine prompt.
+    expect(pickFromList).toHaveBeenCalledTimes(1);
+    expect(readLine).not.toHaveBeenCalled();
+    const call = pickFromList.mock.calls[0]?.[0];
+    expect(call?.options).toEqual(['once', 'session', 'persist', 'deny']);
+    expect(call?.multi).toBe(false);
+    // Result echo persists in scrollback.
+    expect(lines.some((l) => l.includes('\u2713') && l.includes('session'))).toBe(true);
+  });
+
+  it('enum field WITHOUT pickFromList: falls back to the typed readLine path', async () => {
+    const readLine = vi.fn().mockResolvedValueOnce('persist');
+    const handler = makeReplElicitationHandler({
+      readLine,
+      writer: { line: vi.fn() },
+      pendingCount: () => 0,
+      // no pickFromList → typed fallback
+    });
+
+    const result = await handler(pathApprovalForm(), { signal: NO_SIGNAL });
+
+    expect(result.action).toBe('accept');
+    expect(result.content?.['choice']).toBe('persist');
+    expect(readLine).toHaveBeenCalledTimes(1);
+  });
+
+  it('enum field + pickFromList: null result (Esc/Ctrl+C) maps to cancel', async () => {
+    const pickFromList = vi.fn().mockResolvedValueOnce(null);
+    const handler = makeReplElicitationHandler({
+      readLine: vi.fn(),
+      writer: { line: vi.fn() },
+      pendingCount: () => 0,
+      pickFromList,
+    });
+
+    const result = await handler(pathApprovalForm(), { signal: NO_SIGNAL });
+    expect(result.action).toBe('cancel');
+  });
+
+  it('number-typed enum + pickFromList: preserves the original numeric type', async () => {
+    const pickFromList = vi.fn().mockResolvedValueOnce(['2']);
+    const handler = makeReplElicitationHandler({
+      readLine: vi.fn(),
+      writer: { line: vi.fn() },
+      pendingCount: () => 0,
+      pickFromList,
+    });
+
+    const result = await handler(
+      formRequest({ n: { type: 'number', enum: [1, 2, 3] } }, ['n']),
+      { signal: NO_SIGNAL },
+    );
+
+    expect(result.action).toBe('accept');
+    // Selector returns the display string '2'; resolver maps it back to the
+    // original numeric enum entry.
+    expect(result.content?.['n']).toBe(2);
+  });
+
+  it('boolean field + pickFromList: Yes/No selector maps to true/false', async () => {
+    const pickFromList = vi.fn().mockResolvedValueOnce(['No']);
+    const handler = makeReplElicitationHandler({
+      readLine: vi.fn(),
+      writer: { line: vi.fn() },
+      pendingCount: () => 0,
+      pickFromList,
+    });
+
+    const result = await handler(
+      formRequest({ enabled: { type: 'boolean', description: 'Enabled?' } }, ['enabled']),
+      { signal: NO_SIGNAL },
+    );
+
+    expect(result.action).toBe('accept');
+    expect(result.content?.['enabled']).toBe(false);
+    expect(pickFromList.mock.calls[0]?.[0]?.options).toEqual(['Yes', 'No']);
+  });
+
+  it('optional enum field + pickFromList: choosing the skip sentinel omits the field', async () => {
+    // The skip sentinel is the last option for an OPTIONAL field.
+    const pickFromList = vi.fn().mockImplementationOnce(async (opts: { options: readonly string[] }) => {
+      const sentinel = opts.options[opts.options.length - 1];
+      return [sentinel];
+    });
+    const handler = makeReplElicitationHandler({
+      readLine: vi.fn(),
+      writer: { line: vi.fn() },
+      pendingCount: () => 0,
+      pickFromList,
+    });
+
+    // `mode` optional (not in required[]).
+    const result = await handler(
+      formRequest({ mode: { type: 'string', enum: ['fast', 'slow'] } }),
+      { signal: NO_SIGNAL },
+    );
+
+    expect(result.action).toBe('accept');
+    // Skipped optional field is omitted from content (no default declared).
+    expect(result.content && 'mode' in result.content).toBe(false);
+    // Sentinel was appended after the real options.
+    expect(pickFromList.mock.calls[0]?.[0]?.options.length).toBe(3);
+  });
+});

--- a/src/cli/elicitation-repl.ts
+++ b/src/cli/elicitation-repl.ts
@@ -190,6 +190,77 @@ function renderFormHeader(
   writer.line();
 }
 
+/** Sentinel option appended to OPTIONAL enum/boolean pickers so the selector
+ *  can express "leave unset" — mirrors the typed path's empty→default skip. */
+const FORM_SKIP_SENTINEL = '\u2014 skip (optional) \u2014';
+
+/**
+ * Render an `enum` / `boolean` form field as an arrow-key picker — the same
+ * `PickerController` overlay the `ask_question` choice path uses — instead of a
+ * typed `readLine` prompt. Only reached when a `pickFromList` dep is wired
+ * (TTY/REPL); the typed path in {@link promptField} remains the non-TTY /
+ * daemon / test fallback.
+ *
+ * Returns a {@link FieldOutcome}:
+ *   - `{ tag: 'value', value }` on confirm (enum values map back to their
+ *     ORIGINAL typed entry so number/boolean enums preserve their type);
+ *   - `{ tag: 'value', value: fieldDef.default }` when an optional field's skip
+ *     sentinel is chosen (caller omits `undefined`);
+ *   - `{ tag: 'cancel' }` on Esc / Ctrl+C / abort (picker resolves `null`).
+ */
+async function pickFormField(
+  fieldDef: FieldDef,
+  isRequired: boolean,
+  label: string,
+  displayKey: string,
+  pickFromList: NonNullable<ReplElicitationDeps['pickFromList']>,
+  writer: ReplElicitationDeps['writer'],
+  signal: AbortSignal,
+): Promise<FieldOutcome> {
+  // Build the option labels + a resolver from display-string back to the
+  // declared field value. Enum first (takes precedence over `type`), matching
+  // the typed path's type-hint ordering.
+  let baseLabels: string[];
+  let resolveValue: (picked: string) => unknown;
+  if (fieldDef.enum !== undefined) {
+    const enumValues = fieldDef.enum.slice(0, MAX_ENUM_VALUES);
+    baseLabels = enumValues.map((v) => sanitizeSchemaString(String(v), 64));
+    resolveValue = (picked: string): unknown => {
+      const idx = baseLabels.indexOf(picked);
+      return idx >= 0 ? enumValues[idx] : picked;
+    };
+  } else {
+    // boolean
+    baseLabels = ['Yes', 'No'];
+    resolveValue = (picked: string): unknown => picked === 'Yes';
+  }
+
+  const options = isRequired ? baseLabels : [...baseLabels, FORM_SKIP_SENTINEL];
+  // The field label (enum `description` carries the per-choice guidance for
+  // path-approval) renders INSIDE the picker frame and vanishes on confirm;
+  // server + message stay in scrollback via the unchanged renderFormHeader.
+  const header = [palette.bold('  ? ' + label), ''];
+
+  let selected: readonly string[] | null;
+  try {
+    selected = await pickFromList({ header, options, multi: false, signal });
+  } catch {
+    return { tag: 'cancel' };
+  }
+  if (signal.aborted) return { tag: 'cancel' };
+  if (selected === null) return { tag: 'cancel' };
+  const picked = selected[0];
+  if (picked === undefined) return { tag: 'cancel' };
+  if (!isRequired && picked === FORM_SKIP_SENTINEL) {
+    // Optional skip → declared default (caller omits undefined). Mirrors the
+    // typed path's empty-input branch.
+    return { tag: 'value', value: fieldDef.default };
+  }
+  // Single-line echo into scrollback (picker frame already vanished on confirm).
+  writer.line(palette.dim('  \u2713 ') + palette.brand(`${displayKey}: ${sanitizeSchemaString(picked, 128)}`));
+  return { tag: 'value', value: resolveValue(picked) };
+}
+
 async function promptField(
   fieldKey: string,
   fieldDef: FieldDef,
@@ -197,6 +268,7 @@ async function promptField(
   readLine: ReplElicitationDeps['readLine'],
   writer: ReplElicitationDeps['writer'],
   signal: AbortSignal,
+  pickFromList?: ReplElicitationDeps['pickFromList'],
 ): Promise<FieldOutcome> {
   // M-3a: detect an abort fired between fields (after the previous promptField
   // resolved but before this one starts) before printing any label or blocking
@@ -212,6 +284,16 @@ async function promptField(
   // fieldKey is also reflected to the terminal; sanitise for display, but
   // keep the original key for content[] assignment downstream.
   const displayKey = sanitizeSchemaString(fieldKey, 64);
+
+  // Arrow-key selector path for enum / boolean fields when a picker is wired
+  // (TTY/REPL surfaces). Routes the same PickerController overlay the
+  // ask_question choice prompts use, so the path-approval prompt (a single
+  // enum field) becomes a keyboard selector instead of a typed entry. Falls
+  // through to the typed readLine loop below on non-TTY surfaces (daemon,
+  // pipes, tests) where pickFromList is undefined.
+  if (pickFromList && (fieldDef.enum !== undefined || fieldType === 'boolean')) {
+    return pickFormField(fieldDef, isRequired, label, displayKey, pickFromList, writer, signal);
+  }
 
   // Build type-hint string and emit unknown-type warning (once, before loop)
   let typeHint: string;
@@ -968,6 +1050,7 @@ export function makeReplElicitationHandler(
             deps.readLine,
             deps.writer,
             signal,
+            deps.pickFromList,
           );
           if (outcome.tag === 'cancel') return CANCEL;
           if (outcome.tag === 'decline') return DECLINE;


### PR DESCRIPTION
## Summary
- MCP **form** elicitations (`request.mode === 'form'`) now render `enum` and `boolean` fields through the existing **arrow-key picker** (`pickFromList` → `PickerController` overlay) instead of a typed `readLine` prompt.
- This directly fixes the PR #202 **path-approval** prompt ("⚠ MCP form elicitation" — `once | session | persist | deny`): operators now **select** with ↑/↓/Enter instead of **typing** the option string.
- Reuses the component already wired for `ask_question` choice prompts (`surface-setup.ts`) — the form path simply never passed `pickFromList` into `promptField`. **No new TUI machinery.**
- New `pickFormField()` helper: enum picks map back to their **original typed value** (numeric/boolean enums keep their type); booleans → Yes/No; optional fields get a "— skip (optional) —" sentinel.
- **Backward-compatible:** the typed `readLine` path remains the fallback whenever `pickFromList` is absent (non-TTY / daemon / pipes / tests), gated on the dep being wired — so headless surfaces and all existing form-mode tests are unchanged.

## Test results
- `pnpm lint` (tsc --noEmit, strict): **clean**.
- `pnpm test -- src/cli/elicitation-repl.test.ts`: **96 passed** (90 existing + 6 new: enum→picker, enum-without-picker→typed fallback, picker-cancel, numeric-enum type preservation, boolean Yes/No, optional skip sentinel).
- Cluster sweep `render/` + `input/` + elicitation + afk-mode-toggle: **641 passed (25 files)**, no regressions.
- ⚠️ Full `pnpm test` showed **2 unrelated failures locally** (`config.test.ts`, `anthropic-direct.test.ts` — model-slot / haiku-id resolution). They are a **local-environment artifact** (user-global model config leaking into `loadConfig()` during the suite), **not** caused by this diff (which touches only `elicitation-repl.*`). Confirmed benign: `main`'s CI is green for the identical model code (CI run for `bde30c2` = success), and the PR's clean-env CI will exercise the real gate.

## Verification
Adversarial verifier wave (read-only, diff > 100 lines) independently re-derived the load-bearing claims from source:
- **CLAIM 1 — enum/boolean route to the picker, `pickFromList` threaded to `promptField`: CONFIRM** (branch in `promptField`; dep forwarded from the form loop).
- **CLAIM 2 — typed `readLine` fallback when `pickFromList` is undefined: CONFIRM** (branch gated on truthy `pickFromList`).
- **CLAIM 3 — enum→original typed value, boolean→true/false, optional→skip-sentinel→default: CONFIRM** (`pickFormField` resolver via `enumValues[indexOf]`).

Disclosed minor risks (none blocking):
1. **Sentinel collision** — an enum value literally equal to "— skip (optional) —" on an *optional* field would be treated as skip. Pathological; no guard (mirrors the existing `CUSTOM_ANSWER_SENTINEL` approach).
2. **Silent truncation on the picker path** — `MAX_ENUM_VALUES=256` slices the option list; the "enum truncated" warning currently fires only on the typed path.
3. **Echo uses the display label** (not the resolved value) — intended (shows what the user picked).

## Out of scope
- `renderFormHeader` still prints "Type :decline or :cancel at any prompt to exit," which is inaccurate for the picker path (Esc cancels) — minor cosmetic follow-up.
- Broader component-based settings/forms TUI — an incremental arc on the same `PickerController` substrate, not required here.
- The complementary granted-roots seeding (reduces how *often* path-approval fires) is tracked separately.