### PR TITLE
chore: add .mailmap to re-attribute afk-port port commit

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,10 @@
+# .mailmap — canonicalizes commit-author identities for `git shortlog`, `git log --use-mailmap`,
+# and GitHub's contributor graph (GitHub honors .mailmap; no history rewrite required).
+#
+# Format:  Proper Name <proper@email>  Commit Name <commit@email>
+#
+# A cross-repo port (commit b1aaf8ad, port of afk-workshop#571) was committed under a synthetic
+# identity, `afk-port <noreply@users.noreply.github.com>`, which maps to no GitHub account. That
+# produced a phantom "noreply" contributor and dropped the real author. Re-attribute it to the
+# actual author. (The afk-port skill was fixed to preserve the source PR author going forward.)
+Griffin Long <griffinwork40@gmail.com> afk-port <noreply@users.noreply.github.com>


### PR DESCRIPTION
## What

Adds a `.mailmap` that re-attributes one mis-authored commit so the contributor graph is correct.

## Why

Commit `b1aaf8ad` (a cross-repo port of `afk-workshop#571`) was committed under a **synthetic identity**:

```
afk-port <noreply@users.noreply.github.com>
```

That email is not a valid GitHub address — per-user no-reply addresses are `<id>+<login>@users.noreply.github.com`, and the generic one is `noreply@github.com`. `noreply@users.noreply.github.com` maps to **no account**, so GitHub takes the local-part `noreply` as a display name and renders a **phantom "noreply" contributor**. The same defect dropped the real author of the source PR (Griffin Long).

## Fix

```
Griffin Long <griffinwork40@gmail.com> afk-port <noreply@users.noreply.github.com>
```

GitHub honors `.mailmap` in the contributor graph and `git shortlog`/`git log --use-mailmap` — **no history rewrite required**.

## Verification

```
$ git log -1 --format='raw:    %an <%ae>' b1aaf8ad
raw:    afk-port <noreply@users.noreply.github.com>
$ git log -1 --format='mapped: %aN <%aE>' b1aaf8ad
mapped: Griffin Long <griffinwork40@gmail.com>
$ git check-mailmap "afk-port <noreply@users.noreply.github.com>"
Griffin Long <griffinwork40@gmail.com>
```

## Root-cause fix (separate, private repo)

This `.mailmap` repairs the already-published commit. The underlying cause — the `afk-port` skill not preserving the source PR author — is fixed in the private `awa-private` plugin repo (`fix(afk-port): preserve source PR author on port commits`), which now commits ports with `--author` + a `Co-authored-by:` trailer and aborts rather than using a synthetic identity.

`chore:`-prefixed so it is intentionally non-releasable.
