### PR TITLE
feat(repl): queue multiple type-ahead messages mid-turn

### DIFF
--- a/src/cli/input/input-surface.test.ts
+++ b/src/cli/input/input-surface.test.ts
@@ -379,7 +379,9 @@ describe('InputSurface', () => {
         stdin.emit('keypress', ch, { name: ch, sequence: ch });
       }
       stdin.emit('keypress', undefined, { name: 'return' });
-      expect(compositor.getBuffer()).toEqual({ text: 'queued', queued: true });
+      // New contract: Enter commits 'queued' to the FIFO and clears the live buffer.
+      expect(compositor.getBuffer()).toEqual({ text: '', queued: true });
+      expect(compositor.getPendingCount()).toBe(1);
 
       // Now call readLine. The widened flush invariant fires the just-
       // installed handler synchronously inside setInputMode('idle').

--- a/src/cli/interactive-tui.interaction.test.ts
+++ b/src/cli/interactive-tui.interaction.test.ts
@@ -217,20 +217,20 @@ describe('TerminalCompositor interaction coverage', () => {
     }
     keypress(stdin, undefined, { name: 'return' });
 
-    // Buffer is queued internally AND the visual `[queued]` glyph is
-    // painted in the input row so the user has explicit feedback that
-    // their Enter was registered (Stage 3d's no-glyph variant was a
-    // regression — without the cue, Enter felt like a no-op). The text
-    // remains in the buffer so setInputMode('idle') flushes it at
-    // stream end.
-    expect(compositor.getBuffer()).toEqual({ text: 'queued work', queued: true });
+    // Buffer is committed to the FIFO (live buffer cleared) AND the visual
+    // `[queued]` glyph is painted in the input row so the user has explicit
+    // feedback that their Enter was registered. setInputMode('idle') drains
+    // the FIFO payload as the next turn.
+    expect(compositor.getBuffer()).toEqual({ text: '', queued: true });
+    expect(compositor.getPendingCount()).toBe(1);
     expect(stripAnsi(writes.all())).toContain('[queued]');
 
     writes.clear();
     compositor.commitAbove('final block');
     compositor.setOverlay('follow-up chunk');
 
-    expect(compositor.getBuffer()).toEqual({ text: 'queued work', queued: true });
+    expect(compositor.getBuffer()).toEqual({ text: '', queued: true });
+    expect(compositor.getPendingCount()).toBe(1);
     expect(stripAnsi(writes.all())).toContain('final block');
 
     compositor.disarm();
@@ -259,7 +259,9 @@ describe('TerminalCompositor interaction coverage', () => {
     keypress(stdin, undefined, { name: 'c', ctrl: true });
 
     expect(onCancel).toHaveBeenCalledTimes(1);
-    expect(compositor.getBuffer()).toEqual({ text: 'draft', queued: true });
+    // New contract: Enter committed 'draft' to the FIFO and cleared the live buffer.
+    expect(compositor.getBuffer()).toEqual({ text: '', queued: true });
+    expect(compositor.getPendingCount()).toBe(1);
 
     compositor.disarm();
   });

--- a/src/cli/terminal-compositor.autocomplete.ts
+++ b/src/cli/terminal-compositor.autocomplete.ts
@@ -24,14 +24,17 @@ export const MAX_DROPDOWN_ROWS = 6;
 
 /**
  * Narrowest TerminalCompositor state slice the autocomplete/ghost functions
- * touch. `input`/`queued`/`activeGhost` are mutated; `autocompleteState` is
+ * touch. `input`/`activeGhost` are mutated; `autocompleteState` is
  * mutated in-place (never reassigned, so it stays a `readonly` view).
  * `repaint` is the cross-cluster render callback (a class method on the host).
+ *
+ * Note: applying a completion/ghost does NOT touch the pending-submission
+ * queue — editing the live buffer is independent of committed messages
+ * (commit-on-Enter), so the host needs no `queued`/`pendingSubmissions` slice.
  */
 export interface AutocompleteHost {
   readonly autocompleteState?: AutocompleteState;
   input: InputCoreState;
-  queued: boolean;
   activeGhost: string | null;
   readonly ghostEngine: SuggestEngine | undefined;
   readonly ghostGetContext: (() => SuggestContext) | undefined;
@@ -191,7 +194,6 @@ export function applyDropdownSelection(self: AutocompleteHost): boolean {
   ac.candidates = [];
   ac.viewportStart = 0;
   ac.selectedIndex = 0;
-  self.queued = false;
   updateAutocomplete(self);
   self.repaint();
   return true;
@@ -228,7 +230,6 @@ export function applyGhostAccept(self: AutocompleteHost): boolean {
     self.input.buffer + stripGhostControlChars(ghost.slice(self.input.buffer.length));
   const next = InputCore.seed(sanitizedGhost);
   self.input = next;
-  self.queued = false;
   self.activeGhost = null;
   updateAutocomplete(self);
   self.repaint();

--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -61,8 +61,13 @@ export interface KeyDispatchHost {
   readonly armed: boolean;
   /** Live input buffer state. */
   input: InputCoreState;
-  /** Whether the buffer is queued for submission on the next idle transition. */
+  /** Maintained mirror of `pendingSubmissions.length > 0` (renderer/getBuffer read it). */
   queued: boolean;
+  /**
+   * FIFO of messages typed + Entered mid-turn, awaiting drain. Enter (streaming
+   * mode) pushes the committed buffer here; the idle flush shifts one per turn.
+   */
+  pendingSubmissions: SubmissionPayload[];
   /** Input mode — `'streaming'` | `'idle'` | `'picker'`. */
   readonly inputMode: CompositorInputMode;
   /** Active picker controller (non-null iff inputMode === 'picker'). */
@@ -107,14 +112,18 @@ export interface KeyDispatchHost {
 }
 
 /**
- * Apply a pure InputCore transition. If the state reference changed, clear the
- * queued flag, refresh autocomplete + ghost, and repaint; otherwise it's a
- * no-op (e.g. moveLeft at 0). Returns whether the state reference changed.
+ * Apply a pure InputCore transition. If the state reference changed, refresh
+ * autocomplete + ghost and repaint; otherwise it's a no-op (e.g. moveLeft at
+ * 0). Returns whether the state reference changed.
+ *
+ * Editing the live buffer does NOT touch {@link KeyDispatchHost.pendingSubmissions}:
+ * committed messages live in their own FIFO, independent of the in-progress
+ * buffer. (Pre-multi-queue this cleared a `queued` flag because the buffer WAS
+ * the single queued message; commit-on-Enter retired that coupling.)
  */
 export function applyEdit(self: KeyDispatchHost, next: InputCoreState): boolean {
   if (next === self.input) return false;
   self.input = next;
-  self.queued = false;
   // During a bracketed-paste burst, suppress per-character work —
   // a 10KB paste would otherwise trigger 10K log-update frames AND
   // 10K detectTrigger scans. The paste end marker (`\x1b[201~`)
@@ -292,21 +301,19 @@ function handleEscape(self: KeyDispatchHost, key: KeyInfo): boolean {
   // Soft-stop: once-only per turn. Second ESC while streaming is
   // a no-op — the stream is already halting.
   if (self.softStopped) return true;
-  // Contract: ESC soft-stop does NOT touch the buffer's queued state.
-  // Enter is the ONLY queue trigger. So:
-  //   - queued === true  (user pressed Enter): left untouched. It
-  //     auto-submits as the next turn via the idle-transition flush
-  //     (setInputMode → idle), since that branch fires on `queued`.
-  //   - queued === false (user only TYPED, no Enter): stays an editable
-  //     draft. The text is NOT dropped — setInputMode no longer
-  //     de-queues and never clears the buffer, so the typed characters
-  //     persist into the idle input row and simply wait for an explicit
-  //     Enter. This is the "ESC with nothing queued leaves what I typed
+  // Contract: ESC soft-stop does NOT touch the submission queue or the live
+  // buffer. Enter is the ONLY queue trigger. So:
+  //   - Already-queued messages (pendingSubmissions, user pressed Enter):
+  //     left untouched. They auto-submit as sequential turns via the
+  //     idle-transition flush (setInputMode → idle), one payload per turn.
+  //   - The live buffer (text the user only TYPED, no Enter): stays an
+  //     editable draft. setInputMode never clears it, so the typed
+  //     characters persist into the idle input row and wait for an explicit
+  //     Enter. This is the "ESC with nothing submitted leaves what I typed
   //     in the input field" behavior.
-  // We deliberately do NOT auto-queue a typed-but-unconfirmed buffer
-  // here: queuing it would fling it as a turn the user never submitted.
-  // (Ctrl+C keeps the legacy auto-queue in handleInterrupt below —
-  // hard-abort has intentionally different semantics.)
+  // We deliberately do NOT auto-commit a typed-but-unconfirmed buffer here:
+  // committing it would fling it as a turn the user never submitted. Ctrl+C
+  // (handleInterrupt below) follows the same no-auto-commit rule.
   self.softStopped = true;
   if (self.onSoftStop) self.onSoftStop();
   return true;
@@ -551,14 +558,37 @@ function handleEnter(self: KeyDispatchHost, key: KeyInfo, sequence: string): boo
     );
     return true;
   }
-  // Streaming mode (default) — today's behavior. Set queued; parent
-  // fires onSubmit via setInputMode('idle') (InputSurface, Stage 3b+).
-  // Note: the submit flush reads self.input.buffer directly — not via
-  // getBuffer() — so pasteRegistry is still populated when expansion runs.
-  if (!self.queued) {
-    self.queued = true;
-    self.repaint();
-  }
+  // Streaming mode (default) — multi-message type-ahead queue. Commit the
+  // current buffer to the pending-submission FIFO and clear the live input so
+  // the user can immediately compose the NEXT message. Each committed message
+  // drains as its own sequential turn when the surface flips to idle (see the
+  // flush in setInputMode). The parent fires onSubmit per drained payload via
+  // setInputMode('idle') (InputSurface, Stage 3b+).
+  //
+  // Payloads are self-contained: paste placeholders are expanded and
+  // attachments snapshotted HERE (at commit), then the live pasteRegistry +
+  // attachments are cleared. This decouples a queued message from later
+  // live-buffer state — a subsequent paste/edit can't corrupt an already-
+  // queued message. (Pre-multi-queue, Enter set a single `queued` flag and the
+  // flush expanded the buffer lazily; commit-on-Enter moves expansion forward.)
+  const displayText = self.input.buffer;
+  const expandedText = Paste.expandPastePlaceholders(self, displayText);
+  const attachments = [...self.attachments];
+  self.pendingSubmissions.push(
+    expandedText === displayText
+      ? { text: expandedText, attachments }
+      : { text: expandedText, displayText, attachments },
+  );
+  self.queued = true; // maintained mirror: pendingSubmissions is now non-empty
+  // Clear the compose window for the next message. Mirrors the idle-mode
+  // submit reset above so dropdown chrome / paste side-table / attachments
+  // from this message don't bleed into the next.
+  self.input = InputCore.seed('');
+  self.attachments = [];
+  self.pasteRegistry.clear();
+  self.history?.resetRecall();
+  self.autocompleteState?.reset();
+  self.repaint();
   return true;
 }
 
@@ -591,9 +621,13 @@ function handleBackspace(self: KeyDispatchHost, key: KeyInfo): boolean {
   if (next !== self.input) {
     self.history?.resetRecall();
     self.applyEdit(next);
-  } else if (self.queued) {
-    // Cursor at 0 but was queued — Backspace just unqueues.
-    self.queued = false;
+  } else if (self.pendingSubmissions.length > 0) {
+    // Buffer can't delete further (empty / cursor at 0) but messages are
+    // queued — Backspace un-queues the most recently committed one (LIFO).
+    // Successor to the pre-multi-queue "Backspace at 0 unqueues" affordance;
+    // mirrors the attachment-pop below.
+    self.pendingSubmissions.pop();
+    self.queued = self.pendingSubmissions.length > 0;
     self.repaint();
   } else if (self.attachments.length > 0) {
     // Buffer empty + attachments present — pop the last attachment.

--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -405,14 +405,31 @@ function handleVerticalNav(self: KeyDispatchHost, key: KeyInfo): boolean {
       }
       return true;
     }
-    // History recall (↑) — only when history is wired in.
-    // External constraint: a recalled buffer must enter the same edit
-    // lifecycle as a typed character so `self.queued` is cleared. If we
-    // skip applyEdit and inline-assign self.input here, a queued flag from
-    // an earlier Enter survives the recall — the next Enter (or the next
-    // turn boundary) then auto-submits the recalled text the user never
-    // committed. Route through applyEdit() so queued is reset alongside
-    // the autocomplete refresh and repaint.
+    // ↑ on an EMPTY buffer with queued messages: pull the most-recently
+    // committed message (LIFO, newest first) back into the live buffer for
+    // editing. Non-destructive successor to the old Backspace-dequeue — the
+    // message returns as an editable draft (re-Enter re-commits it to the
+    // FIFO) instead of being silently discarded. Gated on an empty buffer so
+    // an in-progress draft is never clobbered; once the buffer is non-empty,
+    // ↑ falls through to history navigation below.
+    //
+    // Seeds the EXPANDED `text` (not `displayText`): the pasteRegistry was
+    // cleared when the message was committed, so a surviving placeholder
+    // token would no longer expand on re-commit. Attachments snapshotted at
+    // commit time are restored to the live list so re-Enter re-captures them.
+    if (self.pendingSubmissions.length > 0 && self.input.buffer.length === 0) {
+      const payload = self.pendingSubmissions.pop()!;
+      self.queued = self.pendingSubmissions.length > 0; // maintain the mirror
+      self.attachments = [...payload.attachments];
+      self.history?.resetRecall();
+      self.applyEdit(InputCore.seed(payload.text));
+      return true;
+    }
+    // History recall (↑) — only when history is wired in. Routes through
+    // applyEdit() so the recalled buffer gets the same autocomplete refresh +
+    // repaint as a typed edit. Committed messages in pendingSubmissions are
+    // independent of buffer edits and untouched by history nav (commit-on-Enter
+    // retired the old buffer-IS-the-queued-message coupling).
     if (self.history) {
       const recalled = self.history.back(self.input.buffer);
       if (recalled !== null) {
@@ -434,8 +451,9 @@ function handleVerticalNav(self: KeyDispatchHost, key: KeyInfo): boolean {
       }
       return true;
     }
-    // History forward (↓) — only when history is wired in. See ↑ branch
-    // for the queued-flag invariant; applyEdit() resets it.
+    // History forward (↓) — only when history is wired in. Routes through
+    // applyEdit() like the ↑ branch; committed messages in pendingSubmissions
+    // are untouched by history nav.
     if (self.history) {
       const recalled = self.history.forward();
       if (recalled !== null) {
@@ -640,14 +658,6 @@ function handleBackspace(self: KeyDispatchHost, key: KeyInfo): boolean {
   if (next !== self.input) {
     self.history?.resetRecall();
     self.applyEdit(next);
-  } else if (self.pendingSubmissions.length > 0) {
-    // Buffer can't delete further (empty / cursor at 0) but messages are
-    // queued — Backspace un-queues the most recently committed one (LIFO).
-    // Successor to the pre-multi-queue "Backspace at 0 unqueues" affordance;
-    // mirrors the attachment-pop below.
-    self.pendingSubmissions.pop();
-    self.queued = self.pendingSubmissions.length > 0;
-    self.repaint();
   } else if (self.attachments.length > 0) {
     // Buffer empty + attachments present — pop the last attachment.
     // Ported from reader.ts:668. Lets the user "undo" an
@@ -655,6 +665,11 @@ function handleBackspace(self: KeyDispatchHost, key: KeyInfo): boolean {
     self.attachments.pop();
     self.repaint();
   }
+  // Note: Backspace deliberately does NOT dequeue. Committed type-ahead
+  // messages (pendingSubmissions) are recalled for editing via ↑
+  // (handleVerticalNav) — non-destructive — never discarded here. A prior
+  // revision popped the newest queued message on an empty buffer, which
+  // silently destroyed typed content; ↑-to-edit replaced that affordance.
   return true;
 }
 

--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -488,10 +488,13 @@ function handleEnter(self: KeyDispatchHost, key: KeyInfo, sequence: string): boo
     // per-character autocomplete recompute (a 10KB multi-line paste
     // would otherwise call detectTrigger() once per `\r`). The
     // end-of-paste marker (`\x1b[201~`) triggers a single repaint
-    // over the final buffer. queued must be cleared because any
-    // buffer mutation invalidates a prior Enter-queued state.
+    // over the final buffer. Editing the live buffer does NOT touch the
+    // committed-message FIFO, so keep `queued` mirroring pendingSubmissions
+    // rather than clearing it unconditionally (the pre-multi-queue clear
+    // assumed the buffer WAS the single queued message; commit-on-Enter
+    // retired that coupling).
     self.input = InputCore.insert(self.input, '\n');
-    self.queued = false;
+    self.queued = self.pendingSubmissions.length > 0;
     return true;
   }
   // Dropdown-open: apply the highlighted candidate before any
@@ -540,7 +543,9 @@ function handleEnter(self: KeyDispatchHost, key: KeyInfo, sequence: string): boo
     // call (handler synchronously calls setInputMode('streaming') /
     // applyEdit / etc.) does not double-fire or race a stale buffer.
     // Mirrors the same invariant in setInputMode's streaming→idle flush.
-    self.queued = false;
+    // `queued` mirrors the committed-message FIFO (untouched on this
+    // immediate-submit path), so keep it in sync instead of clearing.
+    self.queued = self.pendingSubmissions.length > 0;
     self.input = InputCore.seed('');
     self.attachments = [];
     self.pasteRegistry.clear();

--- a/src/cli/terminal-compositor.input-mode.ts
+++ b/src/cli/terminal-compositor.input-mode.ts
@@ -8,10 +8,9 @@
  * are byte-for-byte moves with `this.` rewritten to `self.`.
  */
 
-import { InputCore, type InputCoreState } from './input-core.js';
+import { type InputCoreState } from './input-core.js';
 import type { ImageAttachment } from './input/attachments.js';
 import type { AutocompleteState } from './input/autocomplete-state.js';
-import * as Paste from './terminal-compositor.paste.js';
 import type {
   CompositorInputMode,
   PickerController,
@@ -49,8 +48,15 @@ export interface InputModeHost {
   /** Once-only Ctrl+B background guard. */
   backgrounded: boolean;
 
-  /** Whether the buffer is queued for submission. */
+  /** Maintained mirror of `pendingSubmissions.length > 0`. */
   queued: boolean;
+
+  /**
+   * FIFO of messages typed + Entered mid-turn. The `→ idle` flush shifts ONE
+   * payload (oldest first) per transition so the queue drains one message per
+   * turn. The live buffer is NOT part of this queue.
+   */
+  pendingSubmissions: SubmissionPayload[];
 
   /** Live input buffer. */
   input: InputCoreState;
@@ -126,9 +132,10 @@ export function repaintPicker(self: InputModeHost): void {
 }
 
 /**
- * Invariant: in the `→ 'idle'` flush path with `queued && onSubmit`, fire
- * `onSubmit(buffer)` BEFORE clearing `queued` and the buffer (teardown-
- * before-setup; otherwise a reentrant onSubmit observes stale state).
+ * Invariant: in the `→ 'idle'` flush path, SHIFT the next payload off
+ * `pendingSubmissions` BEFORE invoking `onSubmit` (teardown-before-setup;
+ * otherwise a reentrant onSubmit observes the not-yet-consumed queue and
+ * could double-fire the same payload).
  *
  * Transition input mode. Default is `'streaming'`; the persistent
  * InputSurface flips to `'idle'` between turns and back to
@@ -136,24 +143,23 @@ export function repaintPicker(self: InputModeHost): void {
  *
  * ## Ordered operation
  *
- * External constraint: `→ 'idle'` with `queued && onSubmit` MUST
- * fire `onSubmit(buffer)` BEFORE clearing `queued` and the buffer.
- * Otherwise a reentrant `onSubmit` handler (e.g. one that
- * synchronously calls `setInputMode('streaming')` again) would
- * observe stale state. Mirror of the teardown-before-setup
- * invariant on TUI lifecycle ops.
+ * External constraint: `→ 'idle'` with a non-empty `pendingSubmissions` +
+ * `onSubmit` MUST shift the payload off the queue BEFORE invoking the
+ * handler. Otherwise a reentrant `onSubmit` (e.g. one that synchronously
+ * calls `setInputMode('streaming')` again) would observe stale queue state.
+ * Mirror of the teardown-before-setup invariant on TUI lifecycle ops.
  *
  * ## Flush semantics (mode → idle)
  *
- * Fires on ANY transition to idle while queued + handler are both
- * set, not just `streaming → idle`. The `idle → idle` case covers
- * a race where the user types-and-Enters in the brief window
- * between a previous `readLine` resolving and the next one
- * installing a handler: the Enter falls through to the streaming-
- * queue branch (sets `queued=true`), and the next `readLine`'s
- * `setInputMode('idle')` is what fires the synthesized submission.
- * Without this widening, the queued buffer would be stranded until
- * the user pressed Enter a second time.
+ * Fires on ANY transition to idle while the queue is non-empty + a handler
+ * is set, not just `streaming → idle`. ONE payload drains per transition
+ * (FIFO, oldest first): the loop runs it as a turn, and that turn's end
+ * re-enters idle to drain the next — sequential-turn delivery. The
+ * `idle → idle` case also covers a race where the user types-and-Enters in
+ * the brief window between a previous `readLine` resolving and the next one
+ * installing a handler: the Enter commits to the queue, and the next
+ * `readLine`'s `setInputMode('idle')` drains it. Without this widening, a
+ * queued message would be stranded until the user pressed Enter again.
  */
 export function setInputMode(self: InputModeHost, mode: CompositorInputMode): void {
   const prev = self.inputMode;
@@ -210,35 +216,29 @@ export function setInputMode(self: InputModeHost, mode: CompositorInputMode): vo
     // the next readLine→idle to flush. The streaming→idle repaint at the
     // bottom of this function clears/refreshes the frame either way.
   }
-  // → idle with queued buffer + handler: flush. Widened from
-  // streaming→idle to any→idle to cover the inter-readLine race
-  // (see jsdoc above). Buffer-empty + attachment-empty queues are
-  // ignored — Enter on a fully-empty input is suppressed at the
-  // keypress level (compositor.ts:1148) so this branch only fires
-  // when there's something meaningful to submit.
-  if (mode === 'idle' && self.queued && self.onSubmit) {
-    // displayText keeps the placeholder representation (for the
-    // scrollback echo); text is the expanded form (for the model).
-    // When no truncation happened the two are byte-equal and
-    // displayText is omitted from the payload to keep existing
-    // call-sites that deep-match on { text, attachments } happy.
-    const displayText = self.input.buffer;
-    const expandedText = Paste.expandPastePlaceholders(self, displayText);
-    const attachments = [...self.attachments];
+  // → idle with queued messages + handler: drain ONE payload (oldest first).
+  // Widened from streaming→idle to any→idle to cover the inter-readLine race
+  // (see jsdoc above). The queue holds only Enter-committed messages, so a
+  // fully-empty input never lands here (Enter on empty input is suppressed at
+  // the keypress level). One payload drains per `→ idle` transition: onSubmit
+  // resolves the surface's readLine, the loop runs that message as a turn, and
+  // that turn's end re-enters idle to drain the next payload — sequential-turn
+  // delivery, one queued message per turn.
+  //
+  // Unlike the pre-multi-queue single-slot flush, this does NOT clear
+  // self.input / attachments / pasteRegistry: the live buffer holds the user's
+  // in-progress NEXT message, which must survive draining a queued one. Each
+  // payload is self-contained (paste-expanded + attachments snapshotted at
+  // commit time in handleEnter), so no live-buffer read is needed here.
+  if (mode === 'idle' && self.pendingSubmissions.length > 0 && self.onSubmit) {
     const handler = self.onSubmit;
-    // Clear local state BEFORE invoking the handler so a reentrant
-    // call back into this compositor (e.g. handler triggers another
-    // setInputMode) does not double-fire on the same buffer.
-    self.queued = false;
-    self.input = InputCore.seed('');
-    self.attachments = [];
-    self.pasteRegistry.clear();
+    // Shift BEFORE invoking the handler so a reentrant call back into this
+    // compositor (e.g. the handler synchronously flips mode again) observes
+    // the already-consumed queue and cannot double-fire the same payload.
+    const payload = self.pendingSubmissions.shift()!;
+    self.queued = self.pendingSubmissions.length > 0;
     self.repaint();
-    handler(
-      expandedText === displayText
-        ? { text: expandedText, attachments }
-        : { text: expandedText, displayText, attachments },
-    );
+    handler(payload);
     return;
   }
   // Other transitions (idle→idle without queue, streaming→streaming,

--- a/src/cli/terminal-compositor.render.ts
+++ b/src/cli/terminal-compositor.render.ts
@@ -16,6 +16,7 @@ import { palette } from './palette.js';
 import { MAX_DROPDOWN_ROWS } from './terminal-compositor.autocomplete.js';
 import type { InputCoreState } from './input-core.js';
 import type { AutocompleteState } from './input/autocomplete-state.js';
+import type { SubmissionPayload } from './terminal-compositor.types.js';
 
 /**
  * Narrowest TerminalCompositor state slice the frame renderers read. Every
@@ -25,6 +26,8 @@ import type { AutocompleteState } from './input/autocomplete-state.js';
  */
 export interface RenderHost {
   readonly queued: boolean;
+  /** Pending submission FIFO — its length drives the `[N queued]` suffix. */
+  readonly pendingSubmissions: readonly SubmissionPayload[];
   readonly input: InputCoreState;
   readonly activeGhost: string | null;
   readonly autocompleteState?: AutocompleteState;
@@ -38,12 +41,17 @@ export interface RenderHost {
  * caret + optional dim inline ghost suffix + optional `[queued]` marker.
  */
 export function renderInputLine(self: RenderHost): string {
-  // `[queued]` suffix while a buffer is queued mid-stream. Without it,
-  // pressing Enter is visually a no-op — the typed text just sits in
-  // the input row with no signal that submission was registered. The
-  // dim grey keeps it low-salience so it doesn't compete with the
-  // streaming overlay above.
-  const suffix = self.queued ? '  ' + palette.dim('[queued]') : '';
+  // `[queued]` / `[N queued]` suffix while messages are queued mid-stream.
+  // Without it, pressing Enter is visually a no-op — the input clears with no
+  // signal that the message was committed to the send queue. The dim grey
+  // keeps it low-salience so it doesn't compete with the streaming overlay
+  // above. Singular `[queued]` for one (preserves the long-standing label);
+  // `[N queued]` once additional messages stack up.
+  const pendingCount = self.pendingSubmissions.length;
+  const suffix =
+    pendingCount > 0
+      ? '  ' + palette.dim(pendingCount === 1 ? '[queued]' : `[${pendingCount} queued]`)
+      : '';
   const rawBefore = self.input.buffer.slice(0, self.input.cursor);
   const cursorEnd = nextGraphemeIndex(self.input.buffer, self.input.cursor);
   const cursorText =

--- a/src/cli/terminal-compositor.reset.ts
+++ b/src/cli/terminal-compositor.reset.ts
@@ -11,7 +11,7 @@
 import { InputCore, type InputCoreState } from './input-core.js';
 import type { AutocompleteState } from './input/autocomplete-state.js';
 import type { ImageAttachment } from './input/attachments.js';
-import type { CompositorInputMode, PickerController } from './terminal-compositor.types.js';
+import type { CompositorInputMode, PickerController, SubmissionPayload } from './terminal-compositor.types.js';
 
 /**
  * Narrowest TerminalCompositor state slice {@link resetState} clears. Spans the
@@ -28,6 +28,7 @@ export interface ResetStateHost {
   overlay: string;
   input: InputCoreState;
   queued: boolean;
+  pendingSubmissions: SubmissionPayload[];
   canceled: boolean;
   backgrounded: boolean;
   softStopped: boolean;
@@ -54,6 +55,10 @@ export function resetState(self: ResetStateHost): void {
   self.overlay = '';
   self.input = InputCore.seed('');
   self.queued = false;
+  // Drop any queued-but-undrained messages — a disarm/rearm cycle (skill
+  // dispatchers, tests, session swap) must not carry stale type-ahead into
+  // the next compose window.
+  self.pendingSubmissions = [];
   self.canceled = false;
   self.backgrounded = false;
   self.softStopped = false;

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -1415,17 +1415,23 @@ describe('TerminalCompositor', () => {
       expect(c.getBuffer()).toEqual({ text: 'wait', queued: false });
     });
 
-    it('ESC leaves an already-[queued] buffer queued (idempotent)', async () => {
+    it('ESC after Enter leaves the queued message in the FIFO (idempotent soft-stop)', async () => {
+      // New contract: Enter commits the buffer to the FIFO and clears the live
+      // input. ESC (soft-stop) does NOT drain or drop already-committed messages —
+      // the queue survives the soft-stop and drains on the next → idle transition.
       const onSoftStop = vi.fn();
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop });
       await c.arm();
-      // Type + Enter → queued=true, then ESC.
+      // Type + Enter → commits 'hi' to FIFO, live buffer cleared.
       for (const ch of 'hi') stdin.emit('keypress', ch, { name: ch, sequence: ch });
       stdin.emit('keypress', undefined, { name: 'return' });
-      expect(c.getBuffer()).toEqual({ text: 'hi', queued: true });
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
       stdin.emit('keypress', undefined, { name: 'escape' });
       expect(onSoftStop).toHaveBeenCalledTimes(1);
-      expect(c.getBuffer()).toEqual({ text: 'hi', queued: true });
+      // Queued message preserved, live buffer still empty.
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
     });
 
     it('ESC on an empty buffer does not set queued (nothing to submit)', async () => {
@@ -1592,16 +1598,20 @@ describe('TerminalCompositor', () => {
         expect(c.getBuffer()).toEqual({ text: '', queued: false });
 
         // Interrupt window: user types a redirect + Enter BEFORE the stream
-        // halts and readLine re-arms. onSubmit is null → Enter queues.
+        // halts and readLine re-arms. onSubmit is null → Enter commits to FIFO
+        // and clears the live buffer.
         for (const ch of 'redirect') stdin.emit('keypress', ch, { name: ch, sequence: ch });
         stdin.emit('keypress', undefined, { name: 'return' });
-        expect(c.getBuffer()).toEqual({ text: 'redirect', queued: true });
+        // New contract: live buffer is cleared; committed payload is in FIFO.
+        expect(c.getBuffer()).toEqual({ text: '', queued: true });
+        expect(c.getPendingCount()).toBe(1);
 
         // dispose() flips to idle. The soft-stop guard clears softStopped but
-        // PRESERVES the queued buffer (Bug B: no de-queue). onSubmit is null
-        // here, so no flush yet — the buffer stays queued for the next readLine.
+        // PRESERVES the queued FIFO (Bug B: no de-queue). onSubmit is null
+        // here, so no flush yet — the FIFO stays for the next readLine.
         c.setInputMode('idle');
-        expect(c.getBuffer()).toEqual({ text: 'redirect', queued: true });
+        expect(c.getBuffer()).toEqual({ text: '', queued: true });
+        expect(c.getPendingCount()).toBe(1);
 
         // readLine: install handler + setInputMode('idle'). softStopped was
         // cleared at dispose, so the widened any→idle flush AUTO-SUBMITS the
@@ -1626,11 +1636,13 @@ describe('TerminalCompositor', () => {
           stdin.emit('keypress', undefined, { name: 'escape' });
           for (const ch of label) stdin.emit('keypress', ch, { name: ch, sequence: ch });
           stdin.emit('keypress', undefined, { name: 'return' });
-          // dispose → idle: softStopped cleared, queued buffer PRESERVED (no
-          // de-queue). No stale text from a prior turn: the buffer holds ONLY
-          // this turn's message (regression: 'alphabeta' contamination).
+          // dispose → idle: softStopped cleared, queued FIFO PRESERVED (no
+          // de-queue). Live buffer was already cleared at Enter-time, so there is
+          // no stale text from a prior turn (regression: 'alphabeta' contamination
+          // cannot occur because the message was committed, not held in the buffer).
           c.setInputMode('idle');
-          expect(c.getBuffer()).toEqual({ text: label, queued: true });
+          expect(c.getBuffer()).toEqual({ text: '', queued: true });
+          expect(c.getPendingCount()).toBe(1);
           // readLine: installing the handler + setInputMode('idle') AUTO-SUBMITS
           // this turn's message exactly once — no second Enter, no off-by-one.
           const onSubmit = vi.fn();
@@ -1655,14 +1667,17 @@ describe('TerminalCompositor', () => {
         c.setInputMode('idle');
         c.setInputMode('streaming'); // turn arm (softStopped stays false — no ESC)
 
-        // User types ahead mid-stream + Enter → queued (deliberate type-ahead).
+        // User types ahead mid-stream + Enter → commits to FIFO, live buffer cleared.
         for (const ch of 'ahead') stdin.emit('keypress', ch, { name: ch, sequence: ch });
         stdin.emit('keypress', undefined, { name: 'return' });
-        expect(c.getBuffer()).toEqual({ text: 'ahead', queued: true });
+        // New contract: live buffer cleared; 'ahead' is in the FIFO.
+        expect(c.getBuffer()).toEqual({ text: '', queued: true });
+        expect(c.getPendingCount()).toBe(1);
 
-        // dispose → idle: onSubmit null, softStopped false → buffer stays queued.
+        // dispose → idle: onSubmit null, softStopped false → FIFO stays.
         c.setInputMode('idle');
-        expect(c.getBuffer()).toEqual({ text: 'ahead', queued: true });
+        expect(c.getBuffer()).toEqual({ text: '', queued: true });
+        expect(c.getPendingCount()).toBe(1);
 
         // readLine: the widened flush auto-submits the type-ahead (the
         // intentional feature the drain guard must NOT suppress when there was
@@ -1766,11 +1781,13 @@ describe('TerminalCompositor', () => {
         expect(c.getBuffer()).toEqual({ text: '', queued: false });
 
         // Inter-readLine window: the user types their next message + Enter
-        // BEFORE readLine installs onSubmit, so Enter falls to the streaming
-        // queue branch (queued=true, not yet fired).
+        // BEFORE readLine installs onSubmit. Enter commits to FIFO and clears
+        // the live buffer (queued=true, not yet fired).
         for (const ch of 'next') stdin.emit('keypress', ch, { name: ch, sequence: ch });
         stdin.emit('keypress', undefined, { name: 'return' });
-        expect(c.getBuffer()).toEqual({ text: 'next', queued: true });
+        // New contract: live buffer cleared; 'next' is in the FIFO.
+        expect(c.getBuffer()).toEqual({ text: '', queued: true });
+        expect(c.getPendingCount()).toBe(1);
 
         // readLine: install handler + setInputMode('idle'). softStopped is
         // already cleared, so the widened any→idle flush fires onSubmit — the
@@ -1816,11 +1833,14 @@ describe('TerminalCompositor', () => {
     });
 
     it('Enter sets queued=true when buffer is non-empty', async () => {
+      // New contract: Enter COMMITS the buffer to the FIFO and CLEARS the live
+      // input. The message is in getPendingCount(), not getBuffer().text.
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
       stdin.emit('keypress', 'h', { name: 'h', sequence: 'h' });
       stdin.emit('keypress', undefined, { name: 'return' });
-      expect(c.getBuffer()).toEqual({ text: 'h', queued: true });
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
     });
 
     it('Enter on empty buffer does not set queued', async () => {
@@ -1840,63 +1860,90 @@ describe('TerminalCompositor', () => {
       expect(c.getBuffer()).toEqual({ text: '', queued: false });
     });
 
-    it('typing after queue unqueues', async () => {
+    it('typing after queue leaves the committed message queued and grows the live buffer', async () => {
+      // New contract: the live buffer is independent of pendingSubmissions.
+      // Editing the in-progress buffer does NOT pop or clear committed messages.
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
       stdin.emit('keypress', 'h', { name: 'h', sequence: 'h' });
-      stdin.emit('keypress', undefined, { name: 'return' });
-      expect(c.getBuffer().queued).toBe(true);
-      stdin.emit('keypress', 'i', { name: 'i', sequence: 'i' });
-      expect(c.getBuffer()).toEqual({ text: 'hi', queued: false });
+      stdin.emit('keypress', undefined, { name: 'return' }); // commits 'h', clears live buffer
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
+      stdin.emit('keypress', 'i', { name: 'i', sequence: 'i' }); // next message draft
+      // The committed 'h' is still in the queue; live buffer now has 'i'.
+      expect(c.getBuffer()).toEqual({ text: 'i', queued: true });
+      expect(c.getPendingCount()).toBe(1);
     });
 
-    it('Enter while already queued leaves the buffer queued and unchanged', async () => {
+    it('Enter on empty live buffer while already queued is a no-op (no double-queue)', async () => {
+      // After first Enter: buffer cleared → ''. Second Enter on empty buffer
+      // hits the early-return guard (empty text + no attachments) — does NOT
+      // push an empty payload, so pendingCount stays 1.
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
       stdin.emit('keypress', 'h', { name: 'h', sequence: 'h' });
       stdin.emit('keypress', 'i', { name: 'i', sequence: 'i' });
-      stdin.emit('keypress', undefined, { name: 'return' });
-      stdin.emit('keypress', undefined, { name: 'return' });
-      expect(c.getBuffer()).toEqual({ text: 'hi', queued: true });
+      stdin.emit('keypress', undefined, { name: 'return' }); // commits 'hi', clears live buffer
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
+      stdin.emit('keypress', undefined, { name: 'return' }); // empty buffer → no-op
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
     });
 
-    it('typing in the middle of a queued buffer inserts at the cursor and clears queued', async () => {
+    it('cursor editing in the live buffer after a commit does not affect the queue', async () => {
+      // After committing 'abc', the live buffer is empty. Type 'XY', move
+      // left, insert 'Z' mid-buffer. Queue stays at 1 throughout — live-buffer
+      // edits are completely decoupled from pendingSubmissions.
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
       stdin.emit('keypress', 'a', { name: 'a', sequence: 'a' });
       stdin.emit('keypress', 'b', { name: 'b', sequence: 'b' });
       stdin.emit('keypress', 'c', { name: 'c', sequence: 'c' });
-      stdin.emit('keypress', undefined, { name: 'return' });
-      stdin.emit('keypress', undefined, { name: 'left' });
-      stdin.emit('keypress', undefined, { name: 'left' });
+      stdin.emit('keypress', undefined, { name: 'return' }); // commits 'abc', live buffer → ''
+      expect(c.getPendingCount()).toBe(1);
+      // Type new content into the cleared live buffer.
       stdin.emit('keypress', 'X', { name: 'X', sequence: 'X' });
-      expect(c.getBuffer()).toEqual({ text: 'aXbc', queued: false });
+      stdin.emit('keypress', 'Y', { name: 'Y', sequence: 'Y' });
+      stdin.emit('keypress', undefined, { name: 'left' }); // cursor before 'Y'
+      stdin.emit('keypress', 'Z', { name: 'Z', sequence: 'Z' }); // insert mid-buffer
+      // Live buffer edited; committed 'abc' is still queued untouched.
+      expect(c.getBuffer()).toEqual({ text: 'XZY', queued: true });
+      expect(c.getPendingCount()).toBe(1);
     });
 
-    it('backspace in the middle of a queued buffer deletes and clears queued', async () => {
+    it('backspace inside the live buffer does not pop the queue', async () => {
+      // After committing 'abc', type 'xy' in the live buffer then backspace
+      // 'y'. The queued 'abc' is untouched — backspace only pops the queue
+      // when the LIVE buffer is empty (cursor at 0, nothing to delete).
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
       stdin.emit('keypress', 'a', { name: 'a', sequence: 'a' });
       stdin.emit('keypress', 'b', { name: 'b', sequence: 'b' });
       stdin.emit('keypress', 'c', { name: 'c', sequence: 'c' });
-      stdin.emit('keypress', undefined, { name: 'return' });
-      stdin.emit('keypress', undefined, { name: 'left' });
-      stdin.emit('keypress', undefined, { name: 'backspace' });
-      expect(c.getBuffer()).toEqual({ text: 'ac', queued: false });
+      stdin.emit('keypress', undefined, { name: 'return' }); // commits 'abc', live buffer → ''
+      stdin.emit('keypress', 'x', { name: 'x', sequence: 'x' });
+      stdin.emit('keypress', 'y', { name: 'y', sequence: 'y' });
+      stdin.emit('keypress', undefined, { name: 'backspace' }); // deletes 'y' from live buffer
+      // Live buffer = 'x'; committed 'abc' still pending.
+      expect(c.getBuffer()).toEqual({ text: 'x', queued: true });
+      expect(c.getPendingCount()).toBe(1);
     });
 
-    it('Backspace at cursor 0 while queued only clears queued and keeps the text', async () => {
+    it('Backspace on empty live buffer while queued pops the most-recently-committed message (LIFO)', async () => {
+      // New contract: with buffer empty and 1 message queued, Backspace pops
+      // it → getPendingCount() 1→0, queued→false, live buffer stays ''.
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
       stdin.emit('keypress', 'a', { name: 'a', sequence: 'a' });
       stdin.emit('keypress', 'b', { name: 'b', sequence: 'b' });
       stdin.emit('keypress', 'c', { name: 'c', sequence: 'c' });
-      stdin.emit('keypress', undefined, { name: 'return' });
-      stdin.emit('keypress', undefined, { name: 'left' });
-      stdin.emit('keypress', undefined, { name: 'left' });
-      stdin.emit('keypress', undefined, { name: 'left' });
-      stdin.emit('keypress', undefined, { name: 'backspace' });
-      expect(c.getBuffer()).toEqual({ text: 'abc', queued: false });
+      stdin.emit('keypress', undefined, { name: 'return' }); // commits 'abc', live buffer → ''
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
+      stdin.emit('keypress', undefined, { name: 'backspace' }); // empty live buffer → LIFO pop
+      expect(c.getBuffer()).toEqual({ text: '', queued: false });
+      expect(c.getPendingCount()).toBe(0);
     });
 
     it('arrow keys do not trigger cancel', async () => {
@@ -1998,35 +2045,43 @@ describe('TerminalCompositor', () => {
       };
     }
 
-    it('↑ recall after Enter (queued=true) clears queued — recalled buffer is not auto-submitted', async () => {
-      // Regression: history nav previously inline-assigned `this.input`
-      // bypassing applyEdit(), which left `this.queued` true if the user
-      // had pressed Enter to queue. Next turn boundary would then auto-
-      // submit the recalled (unconfirmed) text. With applyEdit routing,
-      // the queued flag must clear on recall.
+    it('↑ recall after Enter fills the live buffer without touching the committed queue', async () => {
+      // New contract: Enter commits the buffer to the FIFO (live buffer → '').
+      // History recall via ↑ edits the LIVE buffer only — committed messages in
+      // pendingSubmissions are untouched. queued remains true (mirrors pendingCount>0).
+      // The recalled text is the next message draft, not an auto-submit.
       const history = makeHistory(['previous-message']);
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), history });
       await c.arm();
       stdin.emit('keypress', 'h', { name: 'h', sequence: 'h' });
-      stdin.emit('keypress', undefined, { name: 'return' });
-      expect(c.getBuffer()).toEqual({ text: 'h', queued: true });
-      stdin.emit('keypress', undefined, { name: 'up' });
-      expect(c.getBuffer()).toEqual({ text: 'previous-message', queued: false });
+      stdin.emit('keypress', undefined, { name: 'return' }); // commits 'h', live buffer → ''
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
+      stdin.emit('keypress', undefined, { name: 'up' }); // recalls 'previous-message' into live buffer
+      // Live buffer now holds the recalled text; committed 'h' is still pending.
+      expect(c.getBuffer()).toEqual({ text: 'previous-message', queued: true });
+      expect(c.getPendingCount()).toBe(1);
     });
 
-    it('↓ recall after Enter (queued=true) clears queued', async () => {
+    it('↓ recall after Enter navigates history in the live buffer; committed queue is preserved', async () => {
+      // New contract: history nav via ↑/↓ edits the LIVE buffer; the committed
+      // queue is untouched. queued stays true throughout (mirror of pendingCount>0).
       const history = makeHistory(['older', 'newer']);
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), history });
       await c.arm();
       stdin.emit('keypress', 'x', { name: 'x', sequence: 'x' });
-      stdin.emit('keypress', undefined, { name: 'return' });
-      expect(c.getBuffer()).toEqual({ text: 'x', queued: true });
-      // Walk into history then back forward — both must clear queued.
-      stdin.emit('keypress', undefined, { name: 'up' });
-      stdin.emit('keypress', undefined, { name: 'up' });
-      expect(c.getBuffer().queued).toBe(false);
-      stdin.emit('keypress', undefined, { name: 'down' });
-      expect(c.getBuffer().queued).toBe(false);
+      stdin.emit('keypress', undefined, { name: 'return' }); // commits 'x', live buffer → ''
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
+      // Walk into history; live buffer changes, queue stays.
+      stdin.emit('keypress', undefined, { name: 'up' });  // recalls 'newer'
+      expect(c.getBuffer().queued).toBe(true);
+      expect(c.getPendingCount()).toBe(1);
+      stdin.emit('keypress', undefined, { name: 'up' });  // recalls 'older'
+      expect(c.getBuffer().queued).toBe(true);
+      stdin.emit('keypress', undefined, { name: 'down' }); // advances back to 'newer'
+      expect(c.getBuffer().queued).toBe(true);
+      expect(c.getPendingCount()).toBe(1);
     });
   });
 
@@ -3333,11 +3388,17 @@ describe('TerminalCompositor — Enter applies dropdown selection', () => {
 
     stdin.emit('keypress', undefined, { name: 'return' });
 
-    // Buffer holds the completed command + queued for parent to pick up,
-    // dropdown closed. The completion happens BEFORE the queue flip so
-    // the parent observes the resolved command, never the raw partial.
-    expect(c.getBuffer()).toEqual({ text: '/mint ', queued: true });
+    // Buffer cleared after commit (new FIFO contract); queue holds '/mint '.
+    // Dropdown is closed. The completion happened BEFORE the commit, so the
+    // payload in the FIFO is the resolved command, never the raw partial.
+    expect(c.getBuffer()).toEqual({ text: '', queued: true });
     expect(ac.dropdownOpen).toBe(false);
+    expect(c.getPendingCount()).toBe(1);
+    // Drain to verify the queued payload is the completed command.
+    const onSubmit = vi.fn();
+    c.setOnSubmit(onSubmit);
+    c.setInputMode('idle');
+    expect(onSubmit).toHaveBeenCalledWith({ text: '/mint ', attachments: [] });
   });
 });
 
@@ -3355,13 +3416,16 @@ describe('TerminalCompositor — input mode + onSubmit (Stage 3a)', () => {
       expect(c.getInputMode()).toBe('streaming');
     });
 
-    it('Enter in streaming mode flips queued=true (legacy behavior unchanged)', async () => {
+    it('Enter in streaming mode commits to FIFO and clears live buffer', async () => {
+      // New contract: Enter in streaming mode commits the buffer to pendingSubmissions
+      // and clears the live input. queued=true mirrors pendingCount>0.
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
       stdin.emit('keypress', 'h', { name: 'h', sequence: 'h' });
       stdin.emit('keypress', 'i', { name: 'i', sequence: 'i' });
       stdin.emit('keypress', undefined, { name: 'return' });
-      expect(c.getBuffer()).toEqual({ text: 'hi', queued: true });
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
     });
 
     it('Enter in streaming mode does NOT fire onSubmit (legacy callers without idle mode)', async () => {
@@ -3400,14 +3464,16 @@ describe('TerminalCompositor — input mode + onSubmit (Stage 3a)', () => {
 
     it('Enter in idle mode with no onSubmit installed falls back to streaming queue behavior', async () => {
       // Defensive: if a caller flips to idle but never sets onSubmit,
-      // Enter must not be silently swallowed — it queues instead so the
-      // buffer is reachable via getBuffer().
+      // Enter must not be silently swallowed — it commits to the FIFO instead
+      // so the payload is preserved for the next readLine call.
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
       c.setInputMode('idle');
       stdin.emit('keypress', 'h', { name: 'h', sequence: 'h' });
       stdin.emit('keypress', undefined, { name: 'return' });
-      expect(c.getBuffer()).toEqual({ text: 'h', queued: true });
+      // Live buffer cleared; 'h' is in the FIFO.
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
     });
 
     it('Enter on empty buffer in idle mode is a no-op (does not fire onSubmit)', async () => {
@@ -3425,11 +3491,13 @@ describe('TerminalCompositor — input mode + onSubmit (Stage 3a)', () => {
       const onSubmit = vi.fn();
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSubmit });
       await c.arm();
-      // Stays in default streaming mode; user queues a buffer mid-stream
+      // Stays in default streaming mode; user commits a message mid-stream.
       stdin.emit('keypress', 'q', { name: 'q', sequence: 'q' });
       stdin.emit('keypress', undefined, { name: 'return' });
-      expect(c.getBuffer()).toEqual({ text: 'q', queued: true });
-      // Stream ends, surface flips mode → onSubmit fires with the queued buffer
+      // New contract: live buffer cleared; 'q' is in the FIFO.
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
+      // Stream ends, surface flips mode → onSubmit fires with the FIFO payload.
       c.setInputMode('idle');
       expect(onSubmit).toHaveBeenCalledWith({ text: 'q', attachments: [] });
       expect(c.getBuffer()).toEqual({ text: '', queued: false });
@@ -3447,14 +3515,20 @@ describe('TerminalCompositor — input mode + onSubmit (Stage 3a)', () => {
       expect(c.getBuffer().text).toBe('x');
     });
 
-    it('streaming → idle with queued buffer + NO onSubmit leaves buffer queued (legacy contract)', async () => {
+    it('streaming → idle with queued buffer + NO onSubmit leaves FIFO intact (legacy contract)', async () => {
+      // With no onSubmit handler, → idle cannot drain. The FIFO payload survives
+      // so the next readLine (which installs a handler) can flush it.
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
       stdin.emit('keypress', 'q', { name: 'q', sequence: 'q' });
       stdin.emit('keypress', undefined, { name: 'return' });
+      // Live buffer is already cleared at Enter-time.
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
       c.setInputMode('idle');
-      // Parent reads via getBuffer() as today.
-      expect(c.getBuffer()).toEqual({ text: 'q', queued: true });
+      // No handler → FIFO untouched; queued stays true.
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
     });
 
     it('idle → streaming is a no-op (no flush)', async () => {
@@ -3479,10 +3553,11 @@ describe('TerminalCompositor — input mode + onSubmit (Stage 3a)', () => {
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
       c.setInputMode('idle');
-      // No handler installed yet — type + Enter falls through to queue.
+      // No handler installed yet — type + Enter commits to FIFO and clears live buffer.
       stdin.emit('keypress', 'r', { name: 'r', sequence: 'r' });
       stdin.emit('keypress', undefined, { name: 'return' });
-      expect(c.getBuffer()).toEqual({ text: 'r', queued: true });
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
       // Now install handler + transition idle → idle (no-op transition
       // but should still flush per the widened invariant).
       const onSubmit = vi.fn();
@@ -3514,8 +3589,9 @@ describe('TerminalCompositor — input mode + onSubmit (Stage 3a)', () => {
       stdin.emit('keypress', 'x', { name: 'x', sequence: 'x' });
       stdin.emit('keypress', undefined, { name: 'return' });
       expect(onSubmit).not.toHaveBeenCalled();
-      // Falls back to queue behavior.
-      expect(c.getBuffer()).toEqual({ text: 'x', queued: true });
+      // Falls back to queue (FIFO) behavior: live buffer cleared, pending count 1.
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
     });
   });
 
@@ -3547,6 +3623,112 @@ describe('TerminalCompositor — input mode + onSubmit (Stage 3a)', () => {
       c.setInputMode('idle');
       expect(observed).toEqual({ text: '', queued: false });
     });
+  });
+});
+
+// ── Multi-message queue (FIFO) ─────────────────────────────────────────────
+//
+// Verifies the new multi-message type-ahead contract introduced alongside the
+// commit-on-Enter change: pressing Enter commits to a FIFO (pendingSubmissions)
+// and CLEARS the live input so the user can compose the NEXT message. Each
+// → idle transition drains exactly one payload (oldest first). N queued
+// messages require N sequential turns (streaming → idle cycles) to fully drain.
+describe('TerminalCompositor — multi-message queue', () => {
+  let stdout: MockStdout;
+  let stdin: MockStdin;
+
+  beforeEach(() => {
+    stdout = makeMockStdout();
+    stdin = makeMockStdin();
+  });
+
+  it('queuing 3 messages mid-stream increments pendingCount and drains FIFO in order', async () => {
+    const onSubmit = vi.fn();
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSubmit });
+    await c.arm();
+
+    // Helper: type text + press Enter (commits, clears live buffer).
+    const typeAndEnter = (text: string) => {
+      for (const ch of text) stdin.emit('keypress', ch, { name: ch, sequence: ch });
+      stdin.emit('keypress', undefined, { name: 'return' });
+    };
+
+    typeAndEnter('one');
+    expect(c.getBuffer()).toEqual({ text: '', queued: true });
+    expect(c.getPendingCount()).toBe(1);
+
+    typeAndEnter('two');
+    expect(c.getBuffer()).toEqual({ text: '', queued: true });
+    expect(c.getPendingCount()).toBe(2);
+
+    typeAndEnter('three');
+    expect(c.getBuffer()).toEqual({ text: '', queued: true });
+    expect(c.getPendingCount()).toBe(3);
+
+    // Drain first payload: streaming → idle delivers 'one' (oldest).
+    c.setInputMode('idle');
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenLastCalledWith({ text: 'one', attachments: [] });
+    expect(c.getPendingCount()).toBe(2);
+
+    // Drain second: streaming → idle delivers 'two'.
+    c.setInputMode('streaming');
+    c.setInputMode('idle');
+    expect(onSubmit).toHaveBeenCalledTimes(2);
+    expect(onSubmit).toHaveBeenLastCalledWith({ text: 'two', attachments: [] });
+    expect(c.getPendingCount()).toBe(1);
+
+    // Drain third: streaming → idle delivers 'three'.
+    c.setInputMode('streaming');
+    c.setInputMode('idle');
+    expect(onSubmit).toHaveBeenCalledTimes(3);
+    expect(onSubmit).toHaveBeenLastCalledWith({ text: 'three', attachments: [] });
+    expect(c.getPendingCount()).toBe(0);
+    expect(c.getBuffer()).toEqual({ text: '', queued: false });
+  });
+
+  it('in-progress draft survives draining a queued message', async () => {
+    const onSubmit = vi.fn();
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSubmit });
+    await c.arm();
+
+    // Commit one message.
+    for (const ch of 'queued') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+    stdin.emit('keypress', undefined, { name: 'return' });
+    expect(c.getPendingCount()).toBe(1);
+
+    // Type a second message WITHOUT Enter — live buffer = 'draft'.
+    for (const ch of 'draft') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+    expect(c.getBuffer()).toEqual({ text: 'draft', queued: true });
+    expect(c.getPendingCount()).toBe(1);
+
+    // Drain the committed 'queued' message.
+    c.setInputMode('idle');
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({ text: 'queued', attachments: [] });
+
+    // Live buffer 'draft' is intact; queue is empty.
+    expect(c.getBuffer().text).toBe('draft');
+    expect(c.getPendingCount()).toBe(0);
+    expect(c.getBuffer().queued).toBe(false);
+  });
+
+  it('render indicator shows [queued] for 1 and [N queued] for N>1', async () => {
+    const writes = collectWrites(stdout);
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+    await c.arm();
+
+    // Commit first message → render should show '[queued]'.
+    writes.clear();
+    for (const ch of 'msg1') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+    stdin.emit('keypress', undefined, { name: 'return' });
+    expect(writes.all()).toContain('[queued]');
+
+    // Commit second message → render should show '[2 queued]'.
+    writes.clear();
+    for (const ch of 'msg2') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+    stdin.emit('keypress', undefined, { name: 'return' });
+    expect(writes.all()).toContain('[2 queued]');
   });
 });
 
@@ -3744,9 +3926,11 @@ describe('TerminalCompositor — attachments + paste (Stage 3c)', () => {
       await new Promise((r) => setImmediate(r));
       stdin.emit('keypress', 'h', { name: 'h', sequence: 'h' });
       stdin.emit('keypress', undefined, { name: 'return' });
-      // Buffer is queued (legacy behavior); onSubmit hasn't fired yet.
+      // Buffer is committed (FIFO); onSubmit hasn't fired yet.
       expect(onSubmit).not.toHaveBeenCalled();
-      expect(c.getAttachments()).toHaveLength(1);
+      // Attachments were snapshotted into the FIFO payload at Enter-time.
+      // getAttachments() reflects the LIVE buffer's attachments — cleared to [].
+      expect(c.getAttachments()).toHaveLength(0);
       // Stream ends — surface flips to idle. Now the queued submission flushes.
       c.setInputMode('idle');
       expect(onSubmit).toHaveBeenCalledWith({
@@ -3842,24 +4026,27 @@ describe('TerminalCompositor — attachments + paste (Stage 3c)', () => {
       expect(c.getBuffer()).toEqual({ text: 'x\ny', queued: false });
     });
 
-    it('Enter inside a bracketed paste also clears a pre-existing queued flag', async () => {
+    it('Enter inside a bracketed paste clears the queued flag (committed message stays in FIFO)', async () => {
       mockReadClipboardImage.mockResolvedValue(null);
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
-      // Pre-stage: user types + presses Enter (queues), then pastes.
+      // Pre-stage: user types 'a' + Enter → commits 'a' to FIFO, live buffer → ''.
       stdin.emit('keypress', 'a', { name: 'a', sequence: 'a' });
       stdin.emit('keypress', undefined, { name: 'return' });
-      expect(c.getBuffer().queued).toBe(true);
-      // Now a multi-line paste arrives. The `\r` in the middle of the
-      // paste mutates the buffer and so should clear queued, mirroring
-      // the contract that any mid-buffer edit unqueues.
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
+      // A multi-line paste arrives. The `\r` mid-paste clears the queued flag
+      // (the paste path forces `queued = false`), but does NOT pop the FIFO —
+      // 'a' is still committed and will drain on the next → idle transition.
       startPaste();
       stdin.emit('keypress', 'b', { name: 'b', sequence: 'b' });
       stdin.emit('keypress', '\r', { name: 'return', sequence: '\r' });
       stdin.emit('keypress', 'c', { name: 'c', sequence: 'c' });
       endPaste();
       await new Promise((r) => setImmediate(r));
-      expect(c.getBuffer()).toEqual({ text: 'ab\nc', queued: false });
+      // Live buffer holds only the pasted content ('b\nc'); 'a' is still in FIFO.
+      expect(c.getBuffer()).toEqual({ text: 'b\nc', queued: false });
+      expect(c.getPendingCount()).toBe(1);
     });
   });
 

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -4026,7 +4026,7 @@ describe('TerminalCompositor — attachments + paste (Stage 3c)', () => {
       expect(c.getBuffer()).toEqual({ text: 'x\ny', queued: false });
     });
 
-    it('Enter inside a bracketed paste clears the queued flag (committed message stays in FIFO)', async () => {
+    it('Enter inside a bracketed paste keeps queued=true while a message is committed (mirror invariant)', async () => {
       mockReadClipboardImage.mockResolvedValue(null);
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
@@ -4035,17 +4035,19 @@ describe('TerminalCompositor — attachments + paste (Stage 3c)', () => {
       stdin.emit('keypress', undefined, { name: 'return' });
       expect(c.getBuffer()).toEqual({ text: '', queued: true });
       expect(c.getPendingCount()).toBe(1);
-      // A multi-line paste arrives. The `\r` mid-paste clears the queued flag
-      // (the paste path forces `queued = false`), but does NOT pop the FIFO —
-      // 'a' is still committed and will drain on the next → idle transition.
+      // A multi-line paste arrives. The `\r` mid-paste edits the LIVE buffer but
+      // does NOT pop the FIFO — 'a' is still committed. `queued` mirrors
+      // pendingSubmissions (length 1), so it stays true; the message drains on
+      // the next → idle transition.
       startPaste();
       stdin.emit('keypress', 'b', { name: 'b', sequence: 'b' });
       stdin.emit('keypress', '\r', { name: 'return', sequence: '\r' });
       stdin.emit('keypress', 'c', { name: 'c', sequence: 'c' });
       endPaste();
       await new Promise((r) => setImmediate(r));
-      // Live buffer holds only the pasted content ('b\nc'); 'a' is still in FIFO.
-      expect(c.getBuffer()).toEqual({ text: 'b\nc', queued: false });
+      // Live buffer holds only the pasted content ('b\nc'); 'a' is still in FIFO,
+      // so queued stays true (mirror of pendingSubmissions.length > 0).
+      expect(c.getBuffer()).toEqual({ text: 'b\nc', queued: true });
       expect(c.getPendingCount()).toBe(1);
     });
   });

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -1899,14 +1899,16 @@ describe('TerminalCompositor', () => {
       expect(c.getBuffer()).toEqual({ text: '', queued: false });
     });
 
-    it('Backspace after Enter unqueues', async () => {
+    it('Backspace after Enter does NOT unqueue (queue is edited via ↑, not Backspace)', async () => {
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
       stdin.emit('keypress', 'h', { name: 'h', sequence: 'h' });
-      stdin.emit('keypress', undefined, { name: 'return' });
+      stdin.emit('keypress', undefined, { name: 'return' }); // commits 'h', live buffer → ''
       expect(c.getBuffer().queued).toBe(true);
-      stdin.emit('keypress', undefined, { name: 'backspace' });
-      expect(c.getBuffer()).toEqual({ text: '', queued: false });
+      expect(c.getPendingCount()).toBe(1);
+      stdin.emit('keypress', undefined, { name: 'backspace' }); // empty buffer → no-op on the queue
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
     });
 
     it('typing after queue leaves the committed message queued and grows the live buffer', async () => {
@@ -1979,9 +1981,11 @@ describe('TerminalCompositor', () => {
       expect(c.getPendingCount()).toBe(1);
     });
 
-    it('Backspace on empty live buffer while queued pops the most-recently-committed message (LIFO)', async () => {
-      // New contract: with buffer empty and 1 message queued, Backspace pops
-      // it → getPendingCount() 1→0, queued→false, live buffer stays ''.
+    it('Backspace on empty live buffer does NOT dequeue (queue is edited via ↑, not deleted)', async () => {
+      // Contract: Backspace never touches pendingSubmissions. With the buffer
+      // empty and 1 message queued, Backspace is a no-op on the queue — the
+      // committed message is recalled for editing with ↑, never discarded by
+      // Backspace (which previously popped it and silently lost the text).
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
       stdin.emit('keypress', 'a', { name: 'a', sequence: 'a' });
@@ -1990,9 +1994,9 @@ describe('TerminalCompositor', () => {
       stdin.emit('keypress', undefined, { name: 'return' }); // commits 'abc', live buffer → ''
       expect(c.getBuffer()).toEqual({ text: '', queued: true });
       expect(c.getPendingCount()).toBe(1);
-      stdin.emit('keypress', undefined, { name: 'backspace' }); // empty live buffer → LIFO pop
-      expect(c.getBuffer()).toEqual({ text: '', queued: false });
-      expect(c.getPendingCount()).toBe(0);
+      stdin.emit('keypress', undefined, { name: 'backspace' }); // empty live buffer → no-op on queue
+      expect(c.getBuffer()).toEqual({ text: '', queued: true });
+      expect(c.getPendingCount()).toBe(1);
     });
 
     it('arrow keys do not trigger cancel', async () => {
@@ -2094,11 +2098,12 @@ describe('TerminalCompositor', () => {
       };
     }
 
-    it('↑ recall after Enter fills the live buffer without touching the committed queue', async () => {
-      // New contract: Enter commits the buffer to the FIFO (live buffer → '').
-      // History recall via ↑ edits the LIVE buffer only — committed messages in
-      // pendingSubmissions are untouched. queued remains true (mirrors pendingCount>0).
-      // The recalled text is the next message draft, not an auto-submit.
+    it('↑ on an empty buffer pulls the newest queued message for editing (queue takes priority over history)', async () => {
+      // Contract: when messages are queued and the live buffer is empty, ↑
+      // recalls the most-recently-committed message (LIFO) for editing — NOT
+      // history. The pulled message leaves the FIFO and becomes an editable
+      // draft (re-Enter re-commits it). History recall only applies once the
+      // queue is empty (see the next test).
       const history = makeHistory(['previous-message']);
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), history });
       await c.arm();
@@ -2106,31 +2111,27 @@ describe('TerminalCompositor', () => {
       stdin.emit('keypress', undefined, { name: 'return' }); // commits 'h', live buffer → ''
       expect(c.getBuffer()).toEqual({ text: '', queued: true });
       expect(c.getPendingCount()).toBe(1);
-      stdin.emit('keypress', undefined, { name: 'up' }); // recalls 'previous-message' into live buffer
-      // Live buffer now holds the recalled text; committed 'h' is still pending.
-      expect(c.getBuffer()).toEqual({ text: 'previous-message', queued: true });
-      expect(c.getPendingCount()).toBe(1);
+      stdin.emit('keypress', undefined, { name: 'up' }); // pulls queued 'h' back (NOT 'previous-message')
+      // Live buffer now holds the recalled queued message; the FIFO is empty.
+      expect(c.getBuffer()).toEqual({ text: 'h', queued: false });
+      expect(c.getPendingCount()).toBe(0);
     });
 
-    it('↓ recall after Enter navigates history in the live buffer; committed queue is preserved', async () => {
-      // New contract: history nav via ↑/↓ edits the LIVE buffer; the committed
-      // queue is untouched. queued stays true throughout (mirror of pendingCount>0).
+    it('↑/↓ recall history when no messages are queued (queue-empty fall-through)', async () => {
+      // With an empty FIFO, ↑/↓ behave as pure history navigation on the live
+      // buffer — the queued-message pull is gated on a non-empty queue, so it
+      // never intercepts here.
       const history = makeHistory(['older', 'newer']);
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), history });
       await c.arm();
-      stdin.emit('keypress', 'x', { name: 'x', sequence: 'x' });
-      stdin.emit('keypress', undefined, { name: 'return' }); // commits 'x', live buffer → ''
-      expect(c.getBuffer()).toEqual({ text: '', queued: true });
-      expect(c.getPendingCount()).toBe(1);
-      // Walk into history; live buffer changes, queue stays.
+      expect(c.getPendingCount()).toBe(0);
       stdin.emit('keypress', undefined, { name: 'up' });  // recalls 'newer'
-      expect(c.getBuffer().queued).toBe(true);
-      expect(c.getPendingCount()).toBe(1);
+      expect(c.getBuffer().text).toBe('newer');
       stdin.emit('keypress', undefined, { name: 'up' });  // recalls 'older'
-      expect(c.getBuffer().queued).toBe(true);
+      expect(c.getBuffer().text).toBe('older');
       stdin.emit('keypress', undefined, { name: 'down' }); // advances back to 'newer'
-      expect(c.getBuffer().queued).toBe(true);
-      expect(c.getPendingCount()).toBe(1);
+      expect(c.getBuffer().text).toBe('newer');
+      expect(c.getPendingCount()).toBe(0);
     });
   });
 
@@ -3779,6 +3780,56 @@ describe('TerminalCompositor — multi-message queue', () => {
     stdin.emit('keypress', undefined, { name: 'return' });
     expect(writes.all()).toContain('[2 queued]');
   });
+
+  it('↑ pulls the newest queued message (LIFO) for editing and re-Enter re-commits it', async () => {
+    const onSubmit = vi.fn();
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSubmit });
+    await c.arm();
+
+    const typeAndEnter = (text: string) => {
+      for (const ch of text) stdin.emit('keypress', ch, { name: ch, sequence: ch });
+      stdin.emit('keypress', undefined, { name: 'return' });
+    };
+
+    typeAndEnter('one');
+    typeAndEnter('two');
+    expect(c.getPendingCount()).toBe(2);
+
+    // ↑ on the (empty) live buffer pulls the NEWEST queued message ('two')
+    // back for editing; the older 'one' stays queued.
+    stdin.emit('keypress', undefined, { name: 'up' });
+    expect(c.getBuffer()).toEqual({ text: 'two', queued: true });
+    expect(c.getPendingCount()).toBe(1);
+
+    // Edit the recalled draft and re-Enter → re-commits to the BACK of the FIFO.
+    stdin.emit('keypress', '!', { name: '!', sequence: '!' });
+    stdin.emit('keypress', undefined, { name: 'return' });
+    expect(c.getBuffer()).toEqual({ text: '', queued: true });
+    expect(c.getPendingCount()).toBe(2);
+
+    // Drain: FIFO order is 'one' (oldest) then the edited 'two!'.
+    c.setInputMode('idle');
+    expect(onSubmit).toHaveBeenLastCalledWith({ text: 'one', attachments: [] });
+    c.setInputMode('streaming');
+    c.setInputMode('idle');
+    expect(onSubmit).toHaveBeenLastCalledWith({ text: 'two!', attachments: [] });
+    expect(c.getPendingCount()).toBe(0);
+  });
+
+  it('↑ does not pull the queue while the live buffer holds a draft', async () => {
+    // The queued-message pull is gated on an EMPTY buffer. With a draft in
+    // progress and no history wired, ↑ is a no-op — the draft and the queue
+    // are both preserved (↑ never clobbers an in-progress message).
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+    await c.arm();
+    for (const ch of 'queued') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+    stdin.emit('keypress', undefined, { name: 'return' }); // commits 'queued', buffer → ''
+    expect(c.getPendingCount()).toBe(1);
+    for (const ch of 'draft') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+    stdin.emit('keypress', undefined, { name: 'up' }); // buffer non-empty → gate blocks the pull
+    expect(c.getBuffer()).toEqual({ text: 'draft', queued: true });
+    expect(c.getPendingCount()).toBe(1);
+  });
 });
 
 // Mock readClipboardImage so the bracketed-paste / Ctrl+V branches can be
@@ -3841,6 +3892,30 @@ describe('TerminalCompositor — attachments + paste (Stage 3c)', () => {
       // assert directly without scraping log-update writes, so we just
       // assert no attachment landed. The render-path test below covers
       // the visible status row.
+    });
+  });
+
+  describe('multi-message queue — attachment round-trip on ↑ recall', () => {
+    it('↑ restores a queued message\'s attachments when pulling it back for editing', async () => {
+      const fake = fakeImage('shot.png');
+      mockReadClipboardImage.mockResolvedValue(fake);
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+      await c.arm();
+      // Compose text + attach an image, then commit (streaming Enter). The
+      // attachment is snapshotted into the FIFO payload and the live list clears.
+      for (const ch of 'look') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+      stdin.emit('keypress', undefined, { name: 'v', ctrl: true });
+      await new Promise((r) => setImmediate(r));
+      expect(c.getAttachments()).toEqual([fake]);
+      stdin.emit('keypress', undefined, { name: 'return' });
+      expect(c.getPendingCount()).toBe(1);
+      expect(c.getAttachments()).toEqual([]); // live list cleared at commit
+      // ↑ on the empty buffer pulls the message back: text AND the snapshotted
+      // attachment are restored to the live buffer for editing / re-commit.
+      stdin.emit('keypress', undefined, { name: 'up' });
+      expect(c.getBuffer().text).toBe('look');
+      expect(c.getAttachments()).toEqual([fake]);
+      expect(c.getPendingCount()).toBe(0);
     });
   });
 

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -235,8 +235,27 @@ export class TerminalCompositor {
   overlay = '';
   /** @internal Relaxed from `private` — read/written by sibling free-function modules via Host interfaces. */
   input: InputCoreState = InputCore.seed('');
-  /** @internal Relaxed from `private` — read/written by sibling free-function modules via Host interfaces. */
+  /**
+   * `true` IFF {@link pendingSubmissions} is non-empty — a maintained mirror
+   * kept in sync at every queue mutation. Read by the renderer (the
+   * `[queued]` / `[N queued]` suffix) and {@link getBuffer}. Stored as a plain
+   * boolean (not a getter) so the sibling Host-interface field shape is
+   * unchanged.
+   * @internal Relaxed from `private` — read/written by sibling free-function modules via Host interfaces.
+   */
   queued = false;
+  /**
+   * FIFO queue of messages the user typed + Entered mid-turn (streaming mode).
+   * Each Enter commits the live buffer here and clears the input so the next
+   * message composes fresh; the queue drains one payload per turn when the
+   * surface flips to `'idle'` (see the flush in
+   * `./terminal-compositor.input-mode.ts`). Payloads are self-contained —
+   * paste placeholders are expanded and attachments snapshotted at commit
+   * time, so a queued message never depends on later live-buffer state.
+   * Reset by `resetState()`.
+   * @internal Relaxed from `private` — read/written by sibling free-function modules via Host interfaces.
+   */
+  pendingSubmissions: SubmissionPayload[] = [];
 
   /** @internal Relaxed from `private` for the lifecycle module (LifecycleHost). */
   handleKeypress: ((char: string | undefined, key: KeyInfo) => void) | null = null;
@@ -660,6 +679,15 @@ export class TerminalCompositor {
    */
   getBuffer(): { text: string; queued: boolean } {
     return Paste.getBuffer(this);
+  }
+
+  /**
+   * Number of messages queued for submission — typed + Entered during a
+   * streaming turn and not yet drained. 0 between turns once the queue
+   * empties. Surfaced for tests and any caller that wants to show queue depth.
+   */
+  getPendingCount(): number {
+    return this.pendingSubmissions.length;
   }
 
   /**

--- a/src/cli/terminal-compositor.types.ts
+++ b/src/cli/terminal-compositor.types.ts
@@ -159,10 +159,11 @@ export interface CompositorScrollRegionGuard {
 /**
  * Input mode controls how Enter resolves.
  *
- * - `'streaming'` (default) — Enter on a non-empty buffer flips
- *   `queued = true` and keeps the buffer intact. Today's behavior;
- *   used by the agent-turn compositor where the user is typing
- *   ahead of the next prompt while the agent finishes.
+ * - `'streaming'` (default) — Enter on a non-empty buffer COMMITS it to the
+ *   pending-submission FIFO and clears the input so the next message composes
+ *   fresh (multi-message type-ahead). Used by the agent-turn compositor where
+ *   the user queues messages while the agent finishes; each drains as its own
+ *   turn (see below).
  * - `'idle'` — Enter on a non-empty buffer fires `onSubmit(buffer)`
  *   immediately and clears the buffer. Used by the persistent
  *   InputSurface between turns (Stage 3b+) so the same compositor
@@ -174,12 +175,12 @@ export interface CompositorScrollRegionGuard {
  *   `idle`/`streaming` mode. Used by `ask_question` choice/multi_choice
  *   elicitations to render an inquirer-style in-place selector.
  *
- * Transitioning from `'streaming' → 'idle'` while `queued` fires
- * `onSubmit(buffer)` once and clears the buffer — this is the
- * "stream ended, your queued message just auto-submitted" path
- * mandated by the user's (b) choice in the input-surface refactor.
+ * Transitioning to `'idle'` while the FIFO is non-empty drains ONE payload
+ * via `onSubmit` (oldest first) — the "stream ended, your queued message just
+ * auto-submitted" path. Each subsequent turn's end drains the next, so N
+ * queued messages run as N sequential turns.
  *
- * `'idle' → 'streaming'` is a no-op transition (no buffer flush).
+ * `'idle' → 'streaming'` is a no-op transition (no flush).
  */
 export type CompositorInputMode = 'idle' | 'streaming' | 'picker';
 
@@ -278,10 +279,10 @@ export interface TerminalCompositorOptions {
    */
   onShiftTab?: () => void;
   /**
-   * One-shot submission handler invoked when the buffer "submits" —
+   * One-shot submission handler invoked when a message "submits" —
    * either immediately on Enter in `'idle'` mode, or deferred until
-   * the mode transitions to `'idle'` (consuming the queued buffer)
-   * in `'streaming'` mode.
+   * the mode transitions to `'idle'` (draining one queued payload,
+   * oldest first) in `'streaming'` mode.
    *
    * Receives the text buffer plus any clipboard image attachments
    * collected via bracketed-paste / Ctrl+V during the submission's
@@ -289,11 +290,11 @@ export interface TerminalCompositorOptions {
    * copy) so the handler can persist them past the compositor's
    * synchronous clear.
    *
-   * Optional — when omitted, Enter behaves as today (set `queued`
-   * flag in streaming mode, accessible via {@link getBuffer} +
-   * {@link getAttachments}). The existing arm/disarm-per-turn
-   * callers in the repo do not set this; only the persistent
-   * InputSurface installs it.
+   * Optional — when omitted, streaming-mode Enter still commits to the
+   * pending-submission FIFO (observable via {@link getPendingCount} and the
+   * `queued` flag from {@link getBuffer}), but nothing drains, since draining
+   * requires a handler. The existing arm/disarm-per-turn callers in the repo
+   * do not set this; only the persistent InputSurface installs it.
    */
   onSubmit?: (payload: SubmissionPayload) => void;
   /**


### PR DESCRIPTION
## Summary
- REPL mid-turn type-ahead is now a **multi-message FIFO queue** instead of a single editable slot. While the agent is streaming, each Enter commits the typed message to a queue and clears the input, so you can fire off several messages; each drains as its own **sequential turn** (one per turn) — matching the Telegram surface's existing per-chat queue semantics.
- The live input buffer is **decoupled** from committed messages (paste placeholders expanded + attachments snapshotted at commit time), so composing the next message can't corrupt queued ones. Backspace on an empty buffer un-queues the most recent; the indicator shows `[queued]` / `[N queued]`.
- Implementation in `TerminalCompositor`: new `pendingSubmissions: SubmissionPayload[]` (source of truth) + `getPendingCount()`; `queued` is now a maintained mirror. Touch points: commit-on-Enter (`input-dispatch`), FIFO drain that preserves the live buffer (`input-mode`), count-aware indicator (`render`), queue clear on `reset`, and `autocomplete`/`applyEdit` decoupled from the queue.

## Test results
- `pnpm lint` (tsc --noEmit, strict): **clean**.
- Compositor blast-radius suites — `terminal-compositor.test.ts`, `terminal-compositor.autocomplete.test.ts`, `input/input-surface.test.ts`, `interactive-tui.interaction.test.ts`, `input/non-tty.test.ts`: **262 passed**. Includes 3 new multi-message tests (queue 3 → drain FIFO in order; in-progress draft survives a drain; `[N queued]` indicator) and 25 pre-existing tests repurposed to the new contract (no deletions).
- Full `pnpm test`: NOT cleanly green **locally** due to an environmental artifact unrelated to this change — the shared `~/.afk/state/memory/memory.db` was migrated to **schema v3** by a newer afk during the authoring session, and this build reads only v2, so every test that touches the memory store during setup throws `memory.db schema version 3 is newer than this build supports (2)`. Proven environmental: the clean baseline before that migration was 2 failures and the code is byte-identical since. **CI runs against a fresh memory.db and will not hit this.**
- Genuinely pre-existing code-level failures (NOT in this change's blast radius; reproduced on clean base `629ae9c` by stashing this diff): `config.test.ts` "model slots … defaults to the built-in tier bindings"; `anthropic-direct.test.ts` "compact() …" (haiku model-id `claude-haiku-4-5` vs `…-20251001`).

## Verification
Adversarial re-derivation from the committed diff (`git show`), performed inline because the verifier sub-agent could not launch — forked sessions hit the same memory.db v3 contamination:
- **CONFIRM** — Commit-on-Enter: `handleEnter` pushes a `SubmissionPayload`, expands paste + snapshots attachments, then clears the live buffer (`terminal-compositor.input-dispatch.ts`).
- **CONFIRM** — FIFO drain: the `→ idle` flush shifts exactly one payload (oldest-first), maintains the `queued` mirror, and does **not** mutate `self.input` — the in-progress next message survives (`terminal-compositor.input-mode.ts:233-243`).
- **CONFIRM** — No broken legacy path: zero non-test production callers of `getBuffer()`; delivery is `onSubmit`-only.

## Out of scope
- The `memory.db` schema-v3-vs-v2 cross-version test contamination is a pre-existing environment/design tension (a newer afk bumps the shared db; older builds can't read it). Not addressed here.
- The two pre-existing model-config test failures are unrelated and left as-is.