### PR TITLE
feat(cli): make usage-limit pause actionable at the keyboard

### DIFF
--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -475,6 +475,8 @@ export async function runInputLoop(
         getCompositor: () => surface.getCompositor(),
         setBackgroundHandler: (handler) => surface.setBackgroundHandler(handler),
         setSoftStopHandler: installSoftStop,
+        setPausedState: (paused) => surface.setPausedState(paused),
+        setPauseInterruptHandler: (handler) => surface.setPauseInterruptHandler(handler),
         async onContextProgress() {
           await ctx.contextSampler.refresh();
           ctx.statusLine.repaint(formatStatusFields(ctx.stats, ctx.contextSampler));

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -564,6 +564,27 @@ export interface TurnHandles {
    */
   setSoftStopHandler?(handler: (() => void) | null): void;
   /**
+   * Toggle the compositor's `paused` flag for the duration of a usage-limit
+   * pause (set true on the `paused` provider event, false on `resumed` / turn
+   * end). While true, a submitted line fires the pause-interrupt handler below
+   * instead of merely queuing — ending the auto-resume wait so the queued
+   * command runs as the next turn.
+   *
+   * Wired by the REPL to `surface.setPausedState(...)`. Absent on non-REPL
+   * callers and a no-op on non-TTY surfaces — the turn handler treats this as
+   * a no-op when undefined.
+   */
+  setPausedState?(paused: boolean): void;
+  /**
+   * Install/clear the per-turn pause-interrupt handler on the surface's
+   * persistent compositor. The turn handler sets a `session.interrupt()`
+   * closure at turn start and clears it (`null`) at turn end.
+   *
+   * Wired by the REPL to `surface.setPauseInterruptHandler(...)`. Absent on
+   * non-REPL callers and non-TTY surfaces — treated as a no-op when undefined.
+   */
+  setPauseInterruptHandler?(handler: (() => void) | null): void;
+  /**
    * Fired mid-turn on tool_result events so the REPL can refresh the
    * context sampler and repaint the status line with live context usage.
    * The turn handler throttles calls internally (min interval) — callers

--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -510,6 +510,374 @@ describe('runTurn — pause-interrupt (submit during usage-limit pause)', () => 
   });
 });
 
+// ---------------------------------------------------------------------------
+// Helpers for the picker tests (C — interactive usage-limit picker)
+// ---------------------------------------------------------------------------
+
+import type { PickerController } from '../../terminal-compositor.js';
+
+/**
+ * Minimal fake compositor that implements the PickerHost interface used by
+ * `runPicker` and the subset of `TerminalCompositor` called by `runTurn`
+ * (only `commitAbove` is needed besides the picker surface).
+ */
+function makeFakeCompositor() {
+  let controller: PickerController | null = null;
+  let enteredCount = 0;
+  let exitedCount = 0;
+
+  const comp = {
+    // PickerHost surface
+    enterPickerMode(c: PickerController): void {
+      controller = c;
+      enteredCount++;
+    },
+    exitPickerMode(): void {
+      controller = null;
+      exitedCount++;
+    },
+    repaintPicker(): void { /* no-op in unit tests */ },
+
+    // Called by runTurn at line 229 (blank separator before the stream event)
+    commitAbove(_line: string): void { /* swallow */ },
+
+    // Test-only accessors
+    get capturedController(): PickerController | null { return controller; },
+    get enteredCount(): number { return enteredCount; },
+    get exitedCount(): number { return exitedCount; },
+
+    /** Simulate the user selecting item at index `idx` by dispatching Return. */
+    selectIndex(idx: number): void {
+      if (!controller) throw new Error('No active picker controller');
+      // Navigate to the desired index by pressing Down from index 0.
+      for (let i = 0; i < idx; i++) {
+        controller.onKey(undefined, { name: 'down' });
+      }
+      controller.onKey(undefined, { name: 'return' });
+    },
+
+    /** Simulate pressing Esc in the picker. */
+    pressEscape(): void {
+      if (!controller) throw new Error('No active picker controller');
+      controller.onKey(undefined, { name: 'escape' });
+    },
+  };
+  return comp;
+}
+
+describe('runTurn — usage-limit picker (C)', () => {
+  // The interactive picker is shown when:
+  //   - A TTY compositor is armed (getCompositor returns non-null)
+  //   - The paused event has autoResume === true
+  // On autoResume=false or non-TTY, the passive card path is kept unchanged.
+  //
+  // The picker uses runPicker (src/cli/render/picker.ts) which drives
+  // enterPickerMode / exitPickerMode on the compositor. Selections are
+  // simulated by calling the captured PickerController's onKey method.
+
+  it('shows picker when borrowedCompositor is present and autoResume is true', async () => {
+    const comp = makeFakeCompositor();
+
+    // Stream: paused (autoResume=true) then the user picks "keep waiting" via
+    // the picker, then the auto-resume fires and the turn completes normally.
+    let capturedController: PickerController | null = null;
+    const session = {
+      sessionId: 'mock',
+      sendMessageStream: async function* () {
+        yield { type: 'paused', reason: 'usage-limit', autoResume: true } as const;
+        // Let the microtask queue flush so runPicker can install the controller
+        // via enterPickerMode before we inspect it.
+        await Promise.resolve();
+        // Capture the controller so we can simulate a selection.
+        capturedController = comp.capturedController;
+        // Simulate: user selects "Keep waiting" (index 0).
+        if (capturedController) {
+          capturedController.onKey(undefined, { name: 'return' });
+        }
+        yield { type: 'resumed', hotSwapped: false } as const;
+        yield { type: 'chunk', chunk: { type: 'content', content: 'done' } } as const;
+        yield { type: 'done', metadata: { durationMs: 5 } } as const;
+      },
+      interrupt: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AgentSession;
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { h: base, onTurnComplete } = makeHandles();
+    const h: TurnHandles = {
+      ...base,
+      getCompositor: () => comp as unknown as import('../../terminal-compositor.js').TerminalCompositor,
+    };
+    const stats = makeStats();
+
+    await runTurn({ text: 'q', attachments: [] }, session, stats, h);
+
+    // Picker was entered at least once.
+    expect(comp.enteredCount).toBeGreaterThanOrEqual(1);
+    // "Keep waiting" → no interrupt, turn completes normally.
+    expect(session.interrupt).not.toHaveBeenCalled();
+    expect(onTurnComplete).toHaveBeenCalledTimes(1);
+    expect(stats.totalTurns).toBe(1);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('suppresses the passive "Usage paused" card when the picker is shown (no double-render)', async () => {
+    // Mutual exclusivity: when the interactive picker is shown (TTY +
+    // autoResume), the passive bordered card must NOT also render — otherwise
+    // the user sees the same options twice (prose card + menu). The card's
+    // ' Usage paused ' chip is unique to usageLimitBox(); the picker header
+    // says "Usage limit reached" instead, so the chip is a clean discriminator.
+    const comp = makeFakeCompositor();
+    const session = {
+      sessionId: 'mock',
+      sendMessageStream: async function* () {
+        yield {
+          type: 'paused',
+          reason: 'usage-limit',
+          resetsAt: new Date('2025-01-01T00:00:00Z'),
+          autoResume: true,
+        } as const;
+        await Promise.resolve();
+        comp.capturedController?.onKey(undefined, { name: 'return' }); // keep waiting
+        yield { type: 'resumed', hotSwapped: false } as const;
+        yield { type: 'done', metadata: { durationMs: 5 } } as const;
+      },
+      interrupt: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AgentSession;
+
+    const logged: string[] = [];
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logged.push(args.map(String).join(' '));
+    });
+    const { h: base } = makeHandles();
+    const h: TurnHandles = {
+      ...base,
+      getCompositor: () => comp as unknown as import('../../terminal-compositor.js').TerminalCompositor,
+    };
+
+    await runTurn({ text: 'q', attachments: [] }, session, makeStats(), h);
+
+    expect(comp.enteredCount).toBeGreaterThanOrEqual(1);
+    // The passive card chip must be absent — the picker replaced it.
+    expect(logged.some((l) => l.includes('Usage paused'))).toBe(false);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does NOT show picker when autoResume is false (passive card path)', async () => {
+    const comp = makeFakeCompositor();
+
+    const events: OutputEvent[] = [
+      { type: 'paused', reason: 'usage-limit', autoResume: false },
+      // Stream ends without resumed (manual-retry path).
+    ];
+
+    const session = streamFrom(events);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { h: base } = makeHandles();
+    const h: TurnHandles = {
+      ...base,
+      getCompositor: () => comp as unknown as import('../../terminal-compositor.js').TerminalCompositor,
+    };
+    const stats = makeStats();
+
+    await runTurn({ text: 'q', attachments: [] }, session, stats, h);
+
+    // No picker should be shown for autoResume=false.
+    expect(comp.enteredCount).toBe(0);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does NOT show picker when compositor is null (non-TTY path)', async () => {
+    const events: OutputEvent[] = [
+      { type: 'paused', reason: 'usage-limit', autoResume: true },
+    ];
+
+    const session = streamFrom(events);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    // getCompositor returns null → non-TTY path; passive card only.
+    const { h: base } = makeHandles();
+    const h: TurnHandles = { ...base, getCompositor: () => null };
+    const stats = makeStats();
+
+    await runTurn({ text: 'q', attachments: [] }, session, stats, h);
+
+    // No picker error; passive card path silently completes.
+    expect(stats.totalTurns).toBe(0); // no done event
+
+    consoleSpy.mockRestore();
+  });
+
+  it('"keep waiting" selection leaves paused=true so B\'s Enter-during-pause still works', async () => {
+    // B-coexistence guard: after "keep waiting", compositor.paused must stay
+    // true so a subsequent Enter fires the pause-interrupt handler normally.
+    const comp = makeFakeCompositor();
+    const setPausedState = vi.fn();
+
+    const session = {
+      sessionId: 'mock',
+      sendMessageStream: async function* () {
+        yield { type: 'paused', reason: 'usage-limit', autoResume: true } as const;
+        await Promise.resolve();
+        // Simulate "keep waiting" (index 0, press Enter immediately).
+        const ctrl = comp.capturedController;
+        if (ctrl) ctrl.onKey(undefined, { name: 'return' });
+        // After "keep waiting", the picker exits. The stream then auto-resumes.
+        yield { type: 'resumed', hotSwapped: false } as const;
+        yield { type: 'chunk', chunk: { type: 'content', content: 'answer' } } as const;
+        yield { type: 'done', metadata: { durationMs: 5 } } as const;
+      },
+      interrupt: vi.fn().mockResolvedValue(undefined),
+    } as unknown as AgentSession;
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { h: base } = makeHandles();
+    const h: TurnHandles = {
+      ...base,
+      setPausedState,
+      getCompositor: () => comp as unknown as import('../../terminal-compositor.js').TerminalCompositor,
+    };
+    const stats = makeStats();
+
+    await runTurn({ text: 'q', attachments: [] }, session, stats, h);
+
+    // setPausedState(true) on paused event, then (false) on resumed, then
+    // (false) again in finally. The key assertion: true is set (pause is live)
+    // and false is set on resumed (not on picker dismiss — "keep waiting"
+    // must not clear the flag).
+    expect(setPausedState).toHaveBeenCalledWith(true);
+    // No interrupt fired — auto-resume completed normally.
+    expect(session.interrupt).not.toHaveBeenCalled();
+    expect(stats.totalTurns).toBe(1);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('"stop waiting" selection triggers interrupt and suppresses recordTurn', async () => {
+    const comp = makeFakeCompositor();
+    const interrupt = vi.fn().mockResolvedValue(undefined);
+
+    const session = {
+      sessionId: 'mock',
+      sendMessageStream: async function* () {
+        yield { type: 'paused', reason: 'usage-limit', autoResume: true } as const;
+        await Promise.resolve();
+        // Simulate "stop waiting" (index 2).
+        const ctrl = comp.capturedController;
+        if (ctrl) {
+          // Navigate down twice to reach index 2, then confirm.
+          ctrl.onKey(undefined, { name: 'down' });
+          ctrl.onKey(undefined, { name: 'down' });
+          ctrl.onKey(undefined, { name: 'return' });
+        }
+        // After interrupt(), the stream should end. Yield a late event to prove
+        // the break guard drops it.
+        yield { type: 'chunk', chunk: { type: 'content', content: 'LATE' } } as const;
+        yield { type: 'done', metadata: { durationMs: 5 } } as const;
+      },
+      interrupt,
+    } as unknown as AgentSession;
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { h: base, onTurnComplete } = makeHandles();
+    const h: TurnHandles = {
+      ...base,
+      getCompositor: () => comp as unknown as import('../../terminal-compositor.js').TerminalCompositor,
+    };
+    const stats = makeStats();
+
+    await runTurn({ text: 'q', attachments: [] }, session, stats, h);
+
+    // interrupt was called by the picker selection.
+    expect(interrupt).toHaveBeenCalled();
+    // Turn suppressed — late events after the picker selection are dropped.
+    expect(onTurnComplete).not.toHaveBeenCalled();
+    expect(stats.totalTurns).toBe(0);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('"switch model" selection triggers interrupt, prints hint, suppresses recordTurn', async () => {
+    const comp = makeFakeCompositor();
+    const interrupt = vi.fn().mockResolvedValue(undefined);
+
+    const session = {
+      sessionId: 'mock',
+      sendMessageStream: async function* () {
+        yield { type: 'paused', reason: 'usage-limit', autoResume: true } as const;
+        await Promise.resolve();
+        // Simulate "switch model / provider" (index 1).
+        const ctrl = comp.capturedController;
+        if (ctrl) {
+          ctrl.onKey(undefined, { name: 'down' });
+          ctrl.onKey(undefined, { name: 'return' });
+        }
+        yield { type: 'chunk', chunk: { type: 'content', content: 'LATE' } } as const;
+        yield { type: 'done', metadata: { durationMs: 5 } } as const;
+      },
+      interrupt,
+    } as unknown as AgentSession;
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { h: base, onTurnComplete } = makeHandles();
+    const h: TurnHandles = {
+      ...base,
+      getCompositor: () => comp as unknown as import('../../terminal-compositor.js').TerminalCompositor,
+    };
+    const stats = makeStats();
+
+    await runTurn({ text: 'q', attachments: [] }, session, stats, h);
+
+    // interrupt was called.
+    expect(interrupt).toHaveBeenCalled();
+    // /model hint was printed.
+    const wrote = consoleSpy.mock.calls.flat().join('\n');
+    expect(wrote).toContain('/model');
+    // Turn suppressed.
+    expect(onTurnComplete).not.toHaveBeenCalled();
+    expect(stats.totalTurns).toBe(0);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('picker is torn down (abort) when auto-resume fires before the user picks', async () => {
+    // Race: auto-resume arrives while the picker is still open.
+    // The resumed handler aborts the picker so it exits cleanly.
+    const comp = makeFakeCompositor();
+
+    const events: OutputEvent[] = [
+      { type: 'paused', reason: 'usage-limit', autoResume: true },
+      // No explicit picker selection — the stream resumes before user acts.
+      { type: 'resumed', hotSwapped: false },
+      { type: 'chunk', chunk: { type: 'content', content: 'auto-answered' } },
+      { type: 'done', metadata: { durationMs: 5 } },
+    ];
+
+    const session = streamFrom(events);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { h: base, onTurnComplete } = makeHandles();
+    const h: TurnHandles = {
+      ...base,
+      getCompositor: () => comp as unknown as import('../../terminal-compositor.js').TerminalCompositor,
+    };
+    const stats = makeStats();
+
+    await runTurn({ text: 'q', attachments: [] }, session, stats, h);
+
+    // The turn completed normally (auto-resume won the race).
+    expect(onTurnComplete).toHaveBeenCalledTimes(1);
+    expect(stats.totalTurns).toBe(1);
+    // No interrupt fired.
+    expect(session.interrupt).not.toHaveBeenCalled();
+    // Picker was entered and then exited (aborted by resumed).
+    expect(comp.enteredCount).toBeGreaterThanOrEqual(1);
+    expect(comp.exitedCount).toBeGreaterThanOrEqual(1);
+
+    consoleSpy.mockRestore();
+  });
+});
+
 describe('runTurn — ghost spinner regression', () => {
   it('emits the blank separator line before arm, not after', async () => {
     // Regression: a console.log() between arm() and the first stream event

--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -418,6 +418,98 @@ describe('runTurn — usage-limit pause/resume', () => {
   });
 });
 
+describe('runTurn — pause-interrupt (submit during usage-limit pause)', () => {
+  // When the user submits a line while the turn is parked in a usage-limit
+  // pause, the compositor's Enter path queues the buffer AND fires the
+  // installed pause-interrupt handler. That handler ends the auto-resume wait
+  // (session.interrupt) so the queued buffer flushes as the next turn at the
+  // next readLine. The turn ends WITHOUT a done event, so recordTurn /
+  // onTurnComplete are suppressed — mirroring the ESC soft-stop path.
+  //
+  // Non-TTY in vitest means the compositor stays null, so the Enter→queue→fire
+  // chain itself is covered by the terminal-compositor unit tests. Here we
+  // assert the turn-handler WIRING contract: paused toggles the compositor
+  // paused flag, the handler fires interrupt + suppresses the turn, and both
+  // the flag and the handler ref are cleared on teardown.
+
+  it('fires interrupt, suppresses recordTurn, and clears paused state when a line is submitted mid-pause', async () => {
+    let capturedHandler: (() => void) | null = null;
+    const setPauseInterruptHandler = vi.fn((fn: (() => void) | null) => {
+      capturedHandler = fn;
+    });
+    const setPausedState = vi.fn();
+    const interrupt = vi.fn().mockResolvedValue(undefined);
+
+    const session = {
+      sessionId: 'mock',
+      sendMessageStream: async function* () {
+        yield { type: 'paused', reason: 'usage-limit', autoResume: true };
+        // Simulate the user typing a line + Enter during the pause: the
+        // compositor queues the buffer and fires the pause-interrupt handler.
+        capturedHandler?.();
+        // The auto-resume wait is now aborted; in the live flow the stream
+        // ends here. Yield one more event to prove the break guard drops it
+        // (it must NOT accumulate into the recorded turn).
+        yield { type: 'chunk', chunk: { type: 'content', content: 'LATE' } };
+        yield { type: 'done', metadata: { durationMs: 5 } };
+      },
+      interrupt,
+    } as unknown as AgentSession;
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { h: base, onTurnComplete } = makeHandles();
+    const h: TurnHandles = { ...base, setPausedState, setPauseInterruptHandler };
+    const stats = makeStats();
+
+    await runTurn({ text: 'q', attachments: [] }, session, stats, h);
+
+    // paused → setPausedState(true); finally → setPausedState(false).
+    expect(setPausedState).toHaveBeenCalledWith(true);
+    expect(setPausedState).toHaveBeenLastCalledWith(false);
+    // The handler ended the wait via session.interrupt().
+    expect(interrupt).toHaveBeenCalled();
+    // The "ending wait" notice was written (distinct from the ESC stop notice).
+    const wrote = consoleSpy.mock.calls.flat().join('\n');
+    expect(wrote).toContain('Ending wait');
+    // Turn suppressed: no recordTurn (totalTurns stays 0), no onTurnComplete —
+    // the LATE chunk after the interrupt was dropped by the break guard.
+    expect(stats.totalTurns).toBe(0);
+    expect(onTurnComplete).not.toHaveBeenCalled();
+    // The handler ref is cleared on teardown so it can't fire between turns.
+    expect(setPauseInterruptHandler).toHaveBeenLastCalledWith(null);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('clears the paused flag on resumed so a line typed during the replay queues normally', async () => {
+    // Auto-resume succeeds (no user interrupt): the paused flag must flip back
+    // to false on `resumed` so type-ahead during the replayed turn queues
+    // (normal behavior) instead of firing the pause-interrupt.
+    const setPausedState = vi.fn();
+    const setPauseInterruptHandler = vi.fn();
+    const events: OutputEvent[] = [
+      { type: 'paused', reason: 'usage-limit', autoResume: true },
+      { type: 'resumed', hotSwapped: false },
+      { type: 'chunk', chunk: { type: 'content', content: 'answer' } },
+      { type: 'done', metadata: { durationMs: 10 } },
+    ];
+
+    const session = streamFrom(events);
+    const { h: base, onTurnComplete } = makeHandles();
+    const h: TurnHandles = { ...base, setPausedState, setPauseInterruptHandler };
+    const stats = makeStats();
+
+    await runTurn({ text: 'q', attachments: [] }, session, stats, h);
+
+    // true on paused, false on resumed (and again on finally).
+    expect(setPausedState).toHaveBeenNthCalledWith(1, true);
+    expect(setPausedState).toHaveBeenNthCalledWith(2, false);
+    // No interrupt fired; the turn completed normally via the replay.
+    expect(onTurnComplete).toHaveBeenCalledTimes(1);
+    expect(stats.totalTurns).toBe(1);
+  });
+});
+
 describe('runTurn — ghost spinner regression', () => {
   it('emits the blank separator line before arm, not after', async () => {
     // Regression: a console.log() between arm() and the first stream event

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -71,6 +71,11 @@ export async function runTurn(
   let doneFired = false;
   let doneMeta: ResponseMetadata | undefined;
   let softStopRequested = false;
+  // Set when the user submits a line DURING a usage-limit pause: the
+  // pause-interrupt handler (installed below) ends the auto-resume wait so the
+  // queued buffer flushes as the next turn. Like softStopRequested, it ends the
+  // turn without a `done` event, so recordTurn is naturally skipped.
+  let pauseInterruptRequested = false;
   let lastContextProgressMs = 0;
   const CONTEXT_PROGRESS_MIN_INTERVAL_MS = 15_000;
   const toolEvents: ToolEvent[] = [];
@@ -242,6 +247,23 @@ export async function runTurn(
       });
     }
 
+    // Install the per-turn pause-interrupt handler. When the user submits a
+    // line while the turn is parked in a usage-limit pause (compositor
+    // `paused === true`, toggled by setPausedState on the paused/resumed events
+    // below), end the auto-resume wait so the just-queued buffer flushes as the
+    // next turn. Mirrors the ESC soft-stop interrupt; session.interrupt() is
+    // idempotent, so a double Enter during the pause is a safe no-op.
+    if (h.setPauseInterruptHandler) {
+      h.setPauseInterruptHandler(() => {
+        pauseInterruptRequested = true;
+        session.interrupt().catch((err) => {
+          if (isDebugEnabled()) {
+            console.error('  ' + palette.error('pause-interrupt session.interrupt() failed:'), err);
+          }
+        });
+      });
+    }
+
     await armAndWire();
 
     // Install the per-turn Ctrl+B handler on the surface's persistent
@@ -300,7 +322,7 @@ export async function runTurn(
         // already initiated in the handler, the stream's async iterator
         // terminates naturally (no throw), and the post-stream block detects
         // softStopRequested to render the notice and suppress recordTurn.
-        if (softStopRequested) {
+        if (softStopRequested || pauseInterruptRequested) {
           break;
         }
 
@@ -354,6 +376,10 @@ export async function runTurn(
         }
 
         if (event.type === 'paused') {
+          // Mark the compositor paused so a submitted line ends the wait (via
+          // the pause-interrupt handler + input-dispatch Enter path) instead of
+          // sitting queued behind the auto-resume. Cleared on resumed / finally.
+          h.setPausedState?.(true);
           // Disarm before raw console output so the card doesn't tear the
           // live overlay. Auto-resume path continues — the provider is now
           // waiting; the stream will deliver a 'resumed' event when ready,
@@ -369,6 +395,10 @@ export async function runTurn(
         }
 
         if (event.type === 'resumed') {
+          // Pause is over (auto-resume / hot-swap). Clear the paused flag so a
+          // line typed during the replayed turn queues normally (type-ahead)
+          // rather than firing the pause-interrupt.
+          h.setPausedState?.(false);
           // External constraint: the retry layer replays the ENTIRE turn
           // after this event (retry-layer.ts: `yield* turnWithAuthRetry`),
           // re-streaming all content + tool calls from scratch. We must:
@@ -481,7 +511,17 @@ export async function runTurn(
       write('');
     }
 
-    if (doneFired && !softStopRequested) {
+    // Pause-interrupt: the user submitted a line during a usage-limit pause to
+    // end the wait. The queued buffer flushes as the next turn at the next
+    // readLine (idle-transition flush). Gentle note, distinct from ESC's stop.
+    if (pauseInterruptRequested) {
+      const write = completionWriter ? completionWriter.fn : console.log;
+      // Owns one trailing blank (TUI rhythm contract — see docs/tui-rhythm.md).
+      write(palette.dim('▶ Ending wait — running your next command…'));
+      write('');
+    }
+
+    if (doneFired && !softStopRequested && !pauseInterruptRequested) {
       recordTurn(stats, historyText, responseText, doneMeta, toolEvents);
 
       if (h.onTurnComplete) {
@@ -593,6 +633,11 @@ export async function runTurn(
     // presses are a no-op (compositor mode gate already drops them in
     // idle; this is a defense-in-depth clear).
     h.setSoftStopHandler?.(null);
+    // Clear the pause flag + pause-interrupt handler so a line submitted
+    // between turns queues normally (type-ahead) instead of firing the
+    // interrupt against a no-longer-paused turn.
+    h.setPausedState?.(false);
+    h.setPauseInterruptHandler?.(null);
     h.setInFlight(false);
     h.rearmStatus?.();
   }

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -467,6 +467,14 @@ export async function runTurn(
                   console.error('  ' + palette.error('picker pause-interrupt session.interrupt() failed:'), err);
                 }
               });
+            }).catch((err) => {
+              // Defensive: runPicker never rejects, but the .then() body calls
+              // completionWriter.fn (→ compositor.commitAbove), which can throw
+              // mid-teardown. Swallow outside debug so a throw here can't surface
+              // as an unhandled rejection (the REPL has no process-level handler).
+              if (isDebugEnabled()) {
+                console.error('  ' + palette.error('picker promise rejected:'), err);
+              }
             });
           } else {
             // Passive card — the only surface when no interactive picker applies

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -10,6 +10,7 @@ import { palette } from '../../palette.js';
 import { isDebugEnabled } from '../../../utils/debug.js';
 import { formatDuration, formatCost, formatTokens } from '../../format-utils.js';
 import { usageLimitBox } from '../../render.js';
+import { runPicker } from '../../render/picker.js';
 import { classifyError, presentError } from '../../errors/index.js';
 import { contextLimitFor } from '../../model-limits.js';
 import {
@@ -76,6 +77,14 @@ export async function runTurn(
   // queued buffer flushes as the next turn. Like softStopRequested, it ends the
   // turn without a `done` event, so recordTurn is naturally skipped.
   let pauseInterruptRequested = false;
+  // AbortController for the interactive usage-limit picker (C). Created when
+  // the picker is shown (TTY + autoResume=true); aborted on resumed / pause-
+  // interrupt / turn-end so the picker tears down cleanly on every exit path.
+  // Stored in an object (not a bare `let`) so TypeScript's control-flow
+  // narrowing does not collapse the type to `never` in the finally block after
+  // the async .then() assignment — a synchronous read in finally always sees
+  // the latest write even though the assignment happens in a microtask.
+  const pickerRef: { abort: AbortController | null } = { abort: null };
   let lastContextProgressMs = 0;
   const CONTEXT_PROGRESS_MIN_INTERVAL_MS = 15_000;
   const toolEvents: ToolEvent[] = [];
@@ -385,12 +394,91 @@ export async function runTurn(
           // waiting; the stream will deliver a 'resumed' event when ready,
           // at which point we rebuild a fresh renderer for the replayed turn.
           await disposeRendererOnce();
-          (completionWriter ?? { fn: console.log }).fn(usageLimitBox({
-            reason: event.reason,
-            ...(event.resetsAt !== undefined ? { resetsAt: event.resetsAt } : {}),
-            ...(event.accountId !== undefined ? { accountId: event.accountId } : {}),
-            ...(event.autoResume !== undefined ? { autoResume: event.autoResume } : {}),
-          }));
+
+          // Invariant: the interactive picker REPLACES the passive card when a
+          // TTY compositor is armed (borrowedCompositor != null) AND the
+          // provider will auto-resume (autoResume === true) — i.e. there is a
+          // live wait to make a decision about. The two are mutually exclusive:
+          // showing both would duplicate the same options (prose card + menu).
+          // Non-TTY surfaces and autoResume=false fall through to the passive
+          // card, which is the only possible surface there.
+          if (borrowedCompositor && event.autoResume === true) {
+            const ac = new AbortController();
+            pickerRef.abort = ac;
+
+            const resetsAtStr = event.resetsAt
+              ? event.resetsAt.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+              : null;
+            // Option labels are referenced both here and in the .then() match
+            // below — keep them as consts so the definition and the match can
+            // never drift apart.
+            const keepLabel = resetsAtStr
+              ? `Keep waiting — auto-resumes at ${resetsAtStr}`
+              : 'Keep waiting — auto-resume in progress';
+            const switchModelLabel = 'Switch model / provider  (type /model after)';
+            const stopLabel = 'Stop waiting';
+
+            // Contract: the picker header carries the context the passive card
+            // would have shown (limit + reset time) plus the out-of-band
+            // account-switch tip — "switch account" is NOT a selectable option
+            // because it happens via `claude login` in another terminal during
+            // the wait, which the keychain hot-swap picks up automatically.
+            // Options are ordered by increasing disruption so the safe default
+            // (keep waiting) is first and pre-selected.
+            const header = [
+              palette.warning('  ⏳ Usage limit reached.') +
+                (resetsAtStr ? palette.dim(`  Auto-resumes at ${resetsAtStr}.`) : ''),
+              palette.dim('  Tip: run `claude login` in another terminal to switch account — this turn resumes on it automatically.'),
+              '',
+            ];
+
+            void runPicker(borrowedCompositor, {
+              header,
+              options: [keepLabel, switchModelLabel, stopLabel],
+              signal: ac.signal,
+              initialIndex: 0,
+            }).then((result) => {
+              // Picker resolved — null means aborted (resumed/turn-end tore it
+              // down); any result means the user made an explicit choice.
+              pickerRef.abort = null;
+              if (!result) return; // aborted — no action needed
+
+              const choice = result[0];
+              if (choice === undefined || choice === keepLabel) {
+                // Keep waiting (or a defensive undefined): the auto-resume path
+                // continues unchanged; B's Enter-during-pause path stays live.
+                return;
+              }
+
+              // Switch model / Stop waiting: end the wait via the pause-interrupt
+              // path (same mechanism as B's Enter-during-pause). session.interrupt()
+              // ends the stream; pauseInterruptRequested breaks the for-await loop
+              // so recordTurn is skipped and the queued buffer flushes next turn.
+              pauseInterruptRequested = true;
+              if (choice === switchModelLabel) {
+                // Cannot pre-fill the input buffer (no public buffer-set API on
+                // the compositor), so guide with a printed hint instead.
+                (completionWriter ?? { fn: console.log }).fn(
+                  palette.dim('  Hint: type /model <name> to switch, then send your message again.'),
+                );
+              }
+              session.interrupt().catch((err) => {
+                if (isDebugEnabled()) {
+                  console.error('  ' + palette.error('picker pause-interrupt session.interrupt() failed:'), err);
+                }
+              });
+            });
+          } else {
+            // Passive card — the only surface when no interactive picker applies
+            // (non-TTY, or autoResume=false where there is no wait to decide on).
+            (completionWriter ?? { fn: console.log }).fn(usageLimitBox({
+              reason: event.reason,
+              ...(event.resetsAt !== undefined ? { resetsAt: event.resetsAt } : {}),
+              ...(event.accountId !== undefined ? { accountId: event.accountId } : {}),
+              ...(event.autoResume !== undefined ? { autoResume: event.autoResume } : {}),
+            }));
+          }
+
           continue;
         }
 
@@ -399,6 +487,10 @@ export async function runTurn(
           // line typed during the replayed turn queues normally (type-ahead)
           // rather than firing the pause-interrupt.
           h.setPausedState?.(false);
+          // Tear down the picker if it's still open — the wait resolved
+          // without user intervention (auto-resume / hot-swap won the race).
+          pickerRef.abort?.abort();
+          pickerRef.abort = null;
           // External constraint: the retry layer replays the ENTIRE turn
           // after this event (retry-layer.ts: `yield* turnWithAuthRetry`),
           // re-streaming all content + tool calls from scratch. We must:
@@ -638,6 +730,11 @@ export async function runTurn(
     // interrupt against a no-longer-paused turn.
     h.setPausedState?.(false);
     h.setPauseInterruptHandler?.(null);
+    // Abort the usage-limit picker if still open (e.g. turn ended via error
+    // or soft-stop before the user made a choice). Idempotent — safe to call
+    // even when the picker already resolved or was never shown.
+    pickerRef.abort?.abort();
+    pickerRef.abort = null;
     h.setInFlight(false);
     h.rearmStatus?.();
   }

--- a/src/cli/input/input-surface.ts
+++ b/src/cli/input/input-surface.ts
@@ -223,6 +223,15 @@ export class InputSurface {
   private softStopHandler: (() => void) | null = null;
 
   /**
+   * Mutable pause-interrupt handler ref. The compositor's `onPauseInterrupt`
+   * closure dereferences this when the user submits a line during a
+   * usage-limit pause (compositor `paused === true`), so the per-turn
+   * `turn-handler.ts` can install its `session.interrupt()` closure without
+   * reconstructing the compositor. Cleared (null) between turns.
+   */
+  private pauseInterruptHandler: (() => void) | null = null;
+
+  /**
    * Reject callback for the currently-pending readLine Promise (if any).
    * Set inside `readLine()` before the compositor path blocks, and
    * cleared once the Promise settles. Used by `dispose()` to abort any
@@ -285,6 +294,10 @@ export class InputSurface {
       // so per-turn swaps via this.backgroundHandler take effect
       // immediately.
       onBackground: () => { this.backgroundHandler?.(); },
+      // Pause-interrupt handler is mutable — close over the surface's ref so
+      // the per-turn turn-handler swap takes effect immediately. Fires when
+      // the user submits a line during a usage-limit pause.
+      onPauseInterrupt: () => { this.pauseInterruptHandler?.(); },
       ...(opts.onShiftTab ? { onShiftTab: opts.onShiftTab } : {}),
       history: this.history,
       autocompleteState: this.autocompleteState,
@@ -326,6 +339,7 @@ export class InputSurface {
     this.armedStdout = null;
     this.backgroundHandler = null;
     this.softStopHandler = null;
+    this.pauseInterruptHandler = null;
   }
 
   /**
@@ -357,6 +371,26 @@ export class InputSurface {
    */
   setSoftStopHandler(handler: (() => void) | null): void {
     this.softStopHandler = handler;
+  }
+
+  /**
+   * Install or clear the per-turn pause-interrupt handler. The compositor's
+   * `onPauseInterrupt` closure dereferences this ref, so swapping it here
+   * takes effect immediately without reconstructing the compositor. Wired by
+   * the REPL to the turn handler's `session.interrupt()` closure; cleared at
+   * turn end. No-op (benign null-ref mutation) when no compositor is armed.
+   */
+  setPauseInterruptHandler(handler: (() => void) | null): void {
+    this.pauseInterruptHandler = handler;
+  }
+
+  /**
+   * Toggle the compositor's `paused` flag — set true while a usage-limit
+   * pause is parked so a submitted line fires {@link setPauseInterruptHandler}.
+   * No-op when no compositor is armed (non-TTY).
+   */
+  setPausedState(paused: boolean): void {
+    if (this.compositor) this.compositor.paused = paused;
   }
 
   /**

--- a/src/cli/render.test.ts
+++ b/src/cli/render.test.ts
@@ -619,13 +619,20 @@ describe('usageLimitBox', () => {
     expect(out).not.toContain("I'll auto-resume when the limit resets");
   });
 
-  it('keeps the API-key + claude-login escape hatches in both modes', () => {
+  it('advertises mode-appropriate escape hatches (live auto-resume card vs manual)', () => {
     const autoOn = strip(usageLimitBox({ reason: 'usage-limit', autoResume: true }));
     const autoOff = strip(usageLimitBox({ reason: 'usage-limit', autoResume: false }));
-    for (const out of [autoOn, autoOff]) {
-      expect(out).toContain('ANTHROPIC_API_KEY');
-      expect(out).toContain('claude login');
-    }
+    // `claude login` is picked up live by the keychain hot-swap in BOTH modes.
+    expect(autoOn).toContain('claude login');
+    expect(autoOff).toContain('claude login');
+    // Live (auto-resume) card: actionable in-pause escapes; the misleading
+    // env-var bullet is dropped because the running turn never re-reads env.
+    expect(autoOn).toContain('/model');
+    expect(autoOn).toContain('Press Esc to stop waiting');
+    expect(autoOn).not.toContain('ANTHROPIC_API_KEY');
+    // Manual (autoResume:false) card keeps the API-key billing hint — there the
+    // user genuinely starts a fresh send after the reset, so a new env var applies.
+    expect(autoOff).toContain('ANTHROPIC_API_KEY');
   });
 
   it('includes the reset time when resetsAt is provided', () => {

--- a/src/cli/render/usage-limit-box.test.ts
+++ b/src/cli/render/usage-limit-box.test.ts
@@ -37,11 +37,19 @@ describe('usageLimitBox', () => {
     expect(rows[rows.length - 1]?.endsWith('╯')).toBe(true);
   });
 
-  it('usage-limit reason shows the auto-resume copy by default', () => {
+  it('usage-limit reason shows the auto-resume copy + actionable escapes by default', () => {
     const out = strip(usageLimitBox({ reason: 'usage-limit' }));
     expect(out).toContain("You've hit your Claude subscription limit");
     expect(out).toContain('auto-resume when the limit resets');
-    expect(out).toContain('ANTHROPIC_API_KEY');
+    // A: the live card advertises the real at-keyboard escapes.
+    expect(out).toContain('/model');
+    expect(out).toContain('claude login');
+    expect(out).toContain('Press Esc to stop waiting');
+    // A: the misleading "export ANTHROPIC_API_KEY" bullet was dropped from the
+    // live auto-resume card — the running turn never re-reads env, and the
+    // keychain hot-swap watches only the OAuth token (env helps future sessions
+    // only). The manual (autoResume:false) branch keeps it (covered below).
+    expect(out).not.toContain('ANTHROPIC_API_KEY');
   });
 
   it('autoResume:false swaps in the manual "send the message again" copy', () => {

--- a/src/cli/render/usage-limit-box.ts
+++ b/src/cli/render/usage-limit-box.ts
@@ -63,9 +63,19 @@ export function usageLimitBox(opts: {
       // channels promise the same behavior.
       bodyLines.push("I'll auto-resume when the limit resets — no need to retype.");
       bodyLines.push('');
-      bodyLines.push('Other options:');
-      bodyLines.push('  \u2022 Switch to API-key billing: export ANTHROPIC_API_KEY=...');
-      bodyLines.push('  \u2022 Log into another account in any terminal: claude login');
+      // Discoverable at-keyboard escapes. The model switch + Esc are honored
+      // mid-pause: a submitted line ends the wait via the compositor's
+      // pause-interrupt and runs as the next turn (see
+      // terminal-compositor.input-dispatch.ts + turn-handler.ts). The
+      // `claude login` path is picked up live by the keychain hot-swap in
+      // usage-limit.ts. The former `export ANTHROPIC_API_KEY` bullet was
+      // dropped here: the running process already captured its credential and
+      // the hot-swap watches only the keychain OAuth token, so a new env var
+      // in another terminal does nothing for THIS turn (future sessions only).
+      bodyLines.push('Or act now:');
+      bodyLines.push('  \u2022 Switch model — type  /model <name>  then press Enter');
+      bodyLines.push('  \u2022 Switch account — run  claude login  in any terminal (resumes automatically)');
+      bodyLines.push('  \u2022 Press Esc to stop waiting');
     } else {
       bodyLines.push('Options:');
       bodyLines.push('  \u2022 Wait, then send the message again.');

--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -97,11 +97,15 @@ export interface KeyDispatchHost {
   canceled: boolean;
   /** Once-only guard for Ctrl+B background in streaming mode. */
   backgrounded: boolean;
+  /** True while the turn is parked in a usage-limit pause — see {@link TerminalCompositor.paused}. */
+  paused: boolean;
 
   /** Per-turn handlers (read + invoked; the class owns reassignment between turns). */
   readonly onCancel?: () => void;
   readonly onSoftStop?: () => void;
   readonly onBackground?: () => void;
+  /** Submitted-line-during-pause handler — see {@link TerminalCompositorOptions.onPauseInterrupt}. */
+  readonly onPauseInterrupt?: () => void;
   readonly onShiftTab?: () => void;
   readonly onSubmit?: (payload: SubmissionPayload) => void;
 }
@@ -559,6 +563,16 @@ function handleEnter(self: KeyDispatchHost, key: KeyInfo, sequence: string): boo
     self.queued = true;
     self.repaint();
   }
+  // Usage-limit pause escape: while the turn is parked waiting for auto-resume
+  // (the loop is suspended in `await runTurn`), a queued line would otherwise
+  // sit stranded behind the wait. Fire the pause-interrupt so the wait ends
+  // (handler calls session.interrupt) and the buffer we just queued flushes as
+  // the NEXT turn via the idle-transition flush — the same path ESC uses.
+  // Ordering: queue is set ABOVE, then we interrupt (teardown-before-setup), so
+  // the next readLine()'s setInputMode('idle') dispatches the buffer. Reached
+  // only past the empty-buffer suppression above, so there is always content to
+  // run; idempotent if the user presses Enter twice (interrupt is idempotent).
+  if (self.paused && self.onPauseInterrupt) self.onPauseInterrupt();
   return true;
 }
 

--- a/src/cli/terminal-compositor.reset.ts
+++ b/src/cli/terminal-compositor.reset.ts
@@ -31,6 +31,7 @@ export interface ResetStateHost {
   canceled: boolean;
   backgrounded: boolean;
   softStopped: boolean;
+  paused: boolean;
   activeGhost: string | null;
   anchorRow: number | undefined;
   hasCommitted: boolean;
@@ -57,6 +58,7 @@ export function resetState(self: ResetStateHost): void {
   self.canceled = false;
   self.backgrounded = false;
   self.softStopped = false;
+  self.paused = false;
   // Clear active ghost — stale suggestions must not survive a disarm/rearm
   // cycle. The engine itself is NOT disposed here (only in disarm) since
   // resetState() is called by both disarm() AND internal state-resets that

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -1437,6 +1437,55 @@ describe('TerminalCompositor', () => {
       expect(c.getBuffer()).toEqual({ text: '', queued: false });
     });
 
+    // ── Usage-limit pause: Enter ends the wait AND queues (B) ──────────────
+    //
+    // While a turn is parked in a usage-limit pause, the compositor's `paused`
+    // flag is set. A submitted line must still queue (so it flushes as the next
+    // turn) AND fire onPauseInterrupt (so the turn handler ends the auto-resume
+    // wait via session.interrupt). This is the one-gesture escape: type
+    // `/model <name>` + Enter during the pause → on the new provider next turn.
+    it('Enter during a usage-limit pause fires onPauseInterrupt and still queues the buffer', async () => {
+      const onPauseInterrupt = vi.fn();
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onPauseInterrupt });
+      await c.arm();
+      c.paused = true;
+      for (const ch of 'hi') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+      stdin.emit('keypress', undefined, { name: 'return' });
+      expect(onPauseInterrupt).toHaveBeenCalledTimes(1);
+      // Buffer stays queued so the next readLine's idle-flush dispatches it.
+      expect(c.getBuffer()).toEqual({ text: 'hi', queued: true });
+      c.disarm();
+    });
+
+    // Regression guard: when NOT paused, Enter is plain type-ahead — it queues
+    // but must NOT fire onPauseInterrupt (else normal mid-stream typing would
+    // spuriously interrupt the turn).
+    it('Enter when NOT paused does not fire onPauseInterrupt (normal type-ahead queue)', async () => {
+      const onPauseInterrupt = vi.fn();
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onPauseInterrupt });
+      await c.arm();
+      // paused defaults to false.
+      for (const ch of 'hi') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+      stdin.emit('keypress', undefined, { name: 'return' });
+      expect(onPauseInterrupt).not.toHaveBeenCalled();
+      expect(c.getBuffer()).toEqual({ text: 'hi', queued: true });
+      c.disarm();
+    });
+
+    // An empty-buffer Enter during a pause is suppressed (nothing to submit), so
+    // it must not fire the pause-interrupt either — a stray Enter shouldn't kill
+    // the wait when the user has typed nothing.
+    it('Enter on an empty buffer during a pause does not fire onPauseInterrupt', async () => {
+      const onPauseInterrupt = vi.fn();
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onPauseInterrupt });
+      await c.arm();
+      c.paused = true;
+      stdin.emit('keypress', undefined, { name: 'return' });
+      expect(onPauseInterrupt).not.toHaveBeenCalled();
+      expect(c.getBuffer()).toEqual({ text: '', queued: false });
+      c.disarm();
+    });
+
     // ── h1 regression: ESC with an open autocomplete dropdown ──────────────
     //
     // Bug: while the agent streamed, ghost-text / slash autocomplete frequently

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -81,6 +81,14 @@ export class TerminalCompositor {
   softStopped = false;
   /** @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost). */
   onBackground?: () => void;
+  /**
+   * Per-turn pause-interrupt handler — see
+   * {@link TerminalCompositorOptions.onPauseInterrupt}. Invoked when the user
+   * submits a line while {@link paused} is true; ends the usage-limit wait so
+   * the queued buffer flushes as the next turn.
+   * @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost).
+   */
+  onPauseInterrupt?: () => void;
   /** @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost). */
   onShiftTab?: () => void;
   /**
@@ -223,6 +231,15 @@ export class TerminalCompositor {
   canceled = false;
   /** @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost). */
   backgrounded = false;
+  /**
+   * True while the current turn is parked in a usage-limit pause (set by the
+   * turn handler on the `paused` provider event, cleared on `resumed` / turn
+   * end). While set, a submitted line in {@link handleEnter} additionally
+   * fires {@link onPauseInterrupt} so the queued buffer is not stranded behind
+   * the auto-resume wait. Reset in `resetState()` (defence-in-depth).
+   * @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost).
+   */
+  paused = false;
   /** @internal Relaxed from `private` for the lifecycle module (LifecycleHost). */
   wasRaw = false;
   /** Held while armed; released on disarm().
@@ -362,6 +379,7 @@ export class TerminalCompositor {
     this.onCancel = opts.onCancel;
     this.onSoftStop = opts.onSoftStop;
     this.onBackground = opts.onBackground;
+    this.onPauseInterrupt = opts.onPauseInterrupt;
     this.onShiftTab = opts.onShiftTab;
     // Normalize promptText to a function: string → constant closure;
     // function → use as-is; falsy → dim-chevron fallback.

--- a/src/cli/terminal-compositor.types.ts
+++ b/src/cli/terminal-compositor.types.ts
@@ -272,6 +272,15 @@ export interface TerminalCompositorOptions {
   onSoftStop?: () => void;
   onBackground?: () => void;
   /**
+   * Fires when the user submits a line WHILE the turn is parked in a
+   * usage-limit pause (`paused === true`). Distinct from `onSoftStop` so the
+   * gentle "ending the wait" copy stays separate from the ESC stop notice.
+   * The handler ends the provider's auto-resume wait (caller calls
+   * `session.interrupt()`); the just-queued buffer then flushes as the next
+   * turn via the same idle-transition path ESC uses. No-op outside a pause.
+   */
+  onPauseInterrupt?: () => void;
+  /**
    * Fires on Shift+Tab. Replaces the historical reader.ts onShiftTab
    * binding (plan-mode toggle) so the persistent compositor offers
    * the same gesture across both idle and streaming phases.


### PR DESCRIPTION
## Problem

When a Claude OAuth subscription usage limit (HTTP 429) is hit mid-turn, the anthropic provider parks the turn in an auto-resume pause (`autoResumeOnUsageLimit ?? true`) and waits for the limit to reset or a keychain account hot-swap. That default is correct for the away-from-keyboard case — but the **at-keyboard** user had no discoverable way to act *now*:

- A line typed during the pause only sets `queued = true` (type-ahead); it does **not** dispatch until the next `readLine()` after the turn ends. So a user who types `/model gpt-5.5` to escape the wait sees it silently do nothing — stranded behind the very wait they are trying to escape.
- The "Usage paused" card never mentioned `/model` (provider switching is now first-class) or `Ctrl+C`/`Esc`, and it advertised `export ANTHROPIC_API_KEY=…` — which is **misleading mid-pause**: the running process already captured its credential, and the hot-swap watches only the keychain OAuth token, so a new env var does nothing for the parked turn.

## Change (A + B + C)

**A — Box copy (`usage-limit-box.ts`).** Advertise the real escape hatches: switch model/provider via `/model`, switch account via `claude login` (picked up live by the existing keychain hot-swap), or `Esc` to stop waiting. Drop the misleading live `ANTHROPIC_API_KEY` bullet.

**B — Enter-during-pause = interrupt + flush.** Reuse the existing ESC soft-stop machinery. A new `paused` compositor flag (toggled by `setPausedState` on the `paused`/`resumed` events in the turn handler) makes a submitted line *during the pause* fire a new `onPauseInterrupt` handler that ends the auto-resume wait via `session.interrupt()`. The just-queued buffer then flushes as the next turn at the next `readLine()`. Type `/model gpt-5.5` + Enter during a pause and you land on the new provider — one gesture. Normal-streaming type-ahead queuing is unchanged.

**C — Interactive picker.** On a TTY with `autoResume === true`, show an arrow-key picker (via the existing `enterPickerMode`/`runPicker` infra) *in place of* the passive card — the two are **mutually exclusive**, so the options never render twice:

```
⏳ Usage limit reached.  Auto-resumes at HH:MM.
Tip: run `claude login` in another terminal to switch account — this turn resumes on it automatically.

▸ Keep waiting — auto-resumes at HH:MM        [default]
  Switch model / provider  (type /model after)
  Stop waiting
```

- **Keep waiting** (default / Esc): no-op — auto-resume + B's Enter-during-pause both stay live with `paused === true`.
- **Switch model / Stop waiting**: end the wait via B's pause-interrupt path (`session.interrupt()`); "switch model" also prints a `/model <name>` hint (no buffer pre-fill — the compositor exposes no public buffer-set API).
- "Switch account" is an out-of-band action (`claude login` during the wait → hot-swap), so it lives as a header tip rather than a menu row.
- Non-TTY surfaces and `autoResume === false` keep the existing passive card path unchanged.

Auto-resume + background keychain hot-swap are left **fully intact** — this is purely additive agency for the watching user.

## Why reuse the ESC path (B and C)

ESC already aborts the pause today (the soft-stop handler stays live through the wait and calls `session.interrupt()`). B and C both point the same proven teardown at new triggers (an Enter-during-pause; a picker selection), gated on the `paused` flag so only the pause changes behavior. The interrupt ends the turn without a `done` event, so `recordTurn`/`onTurnComplete` are naturally suppressed — same as soft-stop. The picker's `AbortController` is aborted on `resumed`, soft-stop/error, and in `finally`, so `exitPickerMode` fires exactly once on every exit path.

## Tests

- **terminal-compositor (+3):** Enter+`paused` fires `onPauseInterrupt` **and** queues; Enter+not-`paused` only queues (type-ahead regression guard); plus `paused` reset coverage.
- **turn-handler (+10):** paused→interrupt→suppressed turn; `resumed` clears the flag; picker shown on TTY+autoResume; **card suppressed when picker shows** (mutual-exclusivity guard); keep-waiting leaves `paused === true` so B still works; switch-model / stop-waiting fire the interrupt; auto-resume race teardown; non-TTY and `autoResume=false` keep the passive path.
- **box copy:** assertions updated; the misleading `ANTHROPIC_API_KEY` bullet asserted absent from the live card.
- `pnpm lint` (strict `tsc --noEmit`): clean. Affected suites all green (terminal-compositor, turn-handler, picker, usage-limit-box, render).

## Scope / follow-ups

- CLI only (`src/cli/`). **Telegram parity** for the pause-interrupt is a tracked follow-up, not in this PR (the picker is TTY-specific; Telegram would interrupt the paused turn on a new inbound message instead).
