### PR TITLE
fix(subagent): make forked sub-agents non-interactive

### DIFF
--- a/src/agent/subagent.test.ts
+++ b/src/agent/subagent.test.ts
@@ -380,10 +380,11 @@ describe('SubagentManager', () => {
     });
   });
 
-  // External constraint: background subagents have no surface to serve
-  // elicitations. denyElicitations installs DENY_ELICITATION on the child
-  // config so the SDK auto-declines instead of stalling. Foreground
-  // subagents are unaffected.
+  // External constraint: a forked sub-agent has no human relationship of its
+  // own, so every fork is non-interactive by default — DENY_ELICITATION is
+  // installed on the child config so the SDK auto-declines MCP elicitations
+  // instead of routing them to the operator. A caller opts a fork back in with
+  // denyElicitations: false (then the parent's handler, if any, propagates).
   describe('denyElicitations / DENY_ELICITATION', () => {
     it('DENY_ELICITATION resolves to { action: "decline" } regardless of input', async () => {
       const { DENY_ELICITATION } = await import('./subagent.js');
@@ -407,7 +408,7 @@ describe('SubagentManager', () => {
       expect(shared.lastConfig?.onElicitation).toBe(DENY_ELICITATION);
     });
 
-    it('denyElicitations: false leaves onElicitation untouched (foreground default)', async () => {
+    it('denyElicitations: false (explicit opt-out) leaves onElicitation untouched', async () => {
       shared.lastConfig = null;
       const mgr = new SubagentManager();
       await mgr.forkSubagent({
@@ -415,7 +416,8 @@ describe('SubagentManager', () => {
         config: { model: 'sonnet' },
         denyElicitations: false,
       });
-      // No handler explicitly set on parent config → child receives none.
+      // Explicit opt-out: no DENY_ELICITATION installed. No handler on the
+      // parent config → child receives none.
       expect(shared.lastConfig?.onElicitation).toBeUndefined();
     });
 
@@ -435,18 +437,57 @@ describe('SubagentManager', () => {
       expect(shared.lastConfig?.onElicitation).toBe(DENY_ELICITATION);
     });
 
-    it('denyElicitations omitted: parent onElicitation propagates to child (transitive)', async () => {
+    it('denyElicitations omitted: DENY_ELICITATION installed by default (overrides parent handler)', async () => {
+      const { DENY_ELICITATION } = await import('./subagent.js');
       const parentHandler = vi.fn();
       shared.lastConfig = null;
       const mgr = new SubagentManager();
       await mgr.forkSubagent({
         parent: { sessionId: 'p' },
         config: { model: 'sonnet', onElicitation: parentHandler as any },
-        // denyElicitations omitted — inheritance via ...options.config spread
+        // denyElicitations omitted — forks now default to non-interactive, so
+        // DENY_ELICITATION is installed unless the caller opts out with false.
       });
-      // Transitive propagation: a bg grandparent's DENY_ELICITATION (or any
-      // other handler) flows through unless explicitly overridden.
+      // Default-deny: a fork is non-interactive by default, so even a
+      // parent-provided handler is overridden. The parent owns the operator
+      // relationship; the sub-agent reports findings back rather than eliciting.
+      expect(shared.lastConfig?.onElicitation).toBe(DENY_ELICITATION);
+    });
+
+    it('denyElicitations: false (opt-out) lets a parent onElicitation propagate to the child', async () => {
+      const parentHandler = vi.fn();
+      shared.lastConfig = null;
+      const mgr = new SubagentManager();
+      await mgr.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'sonnet', onElicitation: parentHandler as any },
+        denyElicitations: false,
+      });
+      // Explicit opt-out preserves transitive inheritance via the
+      // ...options.config spread (e.g. a parent that itself has a live surface).
       expect(shared.lastConfig?.onElicitation).toBe(parentHandler);
+    });
+
+    it('forked sub-agents are non-interactive by default (isNonInteractive omitted → true)', async () => {
+      shared.lastConfig = null;
+      const mgr = new SubagentManager();
+      await mgr.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'sonnet' },
+      });
+      // The provider strips `ask_question` from a non-interactive toolset, so a
+      // fork cannot prompt the operator via that tool either.
+      expect(shared.lastConfig?.isNonInteractive).toBe(true);
+    });
+
+    it('isNonInteractive: false on the fork config is respected (caller opt-in to interactive)', async () => {
+      shared.lastConfig = null;
+      const mgr = new SubagentManager();
+      await mgr.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'sonnet', isNonInteractive: false },
+      });
+      expect(shared.lastConfig?.isNonInteractive).toBe(false);
     });
   });
 

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -381,6 +381,15 @@ export class SubagentManager {
       abortSignal: childController.signal,
       apiKey: options.config.apiKey || this.parentApiKey,
       baseUrl: options.config.baseUrl ?? this.parentBaseUrl,
+      // External constraint: a forked sub-agent has no human relationship of its
+      // own — it returns findings (including Blocked/Asking) to its PARENT, which
+      // owns the operator surface. Mark every fork non-interactive by default so
+      // the provider strips `ask_question` from the child toolset; otherwise the
+      // child could call it and reach the REPL/Telegram human via the
+      // process-wide elicitation router, interleaved into the parent's turn with
+      // no attribution. A caller may opt a fork back in with
+      // `isNonInteractive: false`.
+      isNonInteractive: options.config.isNonInteractive ?? true,
       // Awareness metadata: surface parent identity + phase role into the
       // child's config so the get_runtime_state tool's `self` view can report
       // the topology fields. Caller-supplied values on options.config win on
@@ -411,12 +420,17 @@ export class SubagentManager {
         (this.parentCanUseTool !== undefined && options.config.canUseTool === undefined
           ? { canUseTool: this.parentCanUseTool }
           : undefined),
-      // External constraint: background subagents have no interactive surface —
-      // auto-decline prevents silent session hangs on MCP elicitation requests.
-      // When denyElicitations is true, override whatever the caller set.
-      // Otherwise the `...options.config` spread above already propagates any
-      // parent-configured handler (including DENY_ELICITATION) transitively.
-      ...(options.denyElicitations === true ? { onElicitation: DENY_ELICITATION } : {}),
+      // External constraint: close the MCP elicitation path too. A
+      // non-interactive sub-agent must not serve `onElicitation` to the
+      // operator, so deny by default (install DENY_ELICITATION) unless a caller
+      // explicitly opts back in with `denyElicitations: false` (no in-tree
+      // caller does). This unifies the three elicitation channels — ask_question
+      // (stripped via isNonInteractive above), path-approval (auto-denied via the
+      // parentSessionId guard in path-approval-hook.ts), and MCP onElicitation
+      // (here) — so every fork is uniformly non-interactive. When opted out, the
+      // `...options.config` spread above still propagates any parent-configured
+      // handler transitively.
+      ...(options.denyElicitations === false ? {} : { onElicitation: DENY_ELICITATION }),
       // Phase role enforcement: when phaseRole === 'read-only', construct a
       // provider whose permissions.allowedTools is restricted to
       // READ_ONLY_PHASE_TOOLS. This is the ONLY wiring that reaches the

--- a/src/agent/tools/hooks/path-approval-hook.test.ts
+++ b/src/agent/tools/hooks/path-approval-hook.test.ts
@@ -108,6 +108,60 @@ describe('createPathApprovalHook — typed-tool gating', () => {
   });
 });
 
+describe('createPathApprovalHook — sub-agent auto-deny (PR1)', () => {
+  // A forked sub-agent (parentSessionId set) must never prompt the operator for
+  // out-of-root access — the prompt would surface on the parent's handler with
+  // no attribution. The hook auto-denies instead; the sub-agent reports the
+  // path requirement back to its parent.
+  it('blocks an out-of-root path for a forked sub-agent without prompting', async () => {
+    const handler = vi.fn(async () => ({ action: 'accept', content: { choice: 'session' } }));
+    elicitationRouter.install(handler);
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse({
+      event: 'PreToolUse',
+      toolName: 'read_file',
+      input: { file_path: '/etc/hosts' },
+      sessionId: 'child-1',
+      parentSessionId: 'parent-1',
+    });
+
+    expect(decision.decision).toBe('block');
+    // Never routed to the operator, never granted.
+    expect(handler).not.toHaveBeenCalled();
+    expect(mgr._events).toHaveLength(0);
+  });
+
+  it('leaves inherited in-root access untouched for a sub-agent (no prompt, no block)', async () => {
+    const handler = vi.fn(async () => ({ action: 'accept', content: { choice: 'session' } }));
+    elicitationRouter.install(handler);
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    // In-root path: the `!restricted` check returns {} BEFORE the sub-agent
+    // guard, so paths the parent already grants stay accessible to the child.
+    const decision = await preToolUse({
+      event: 'PreToolUse',
+      toolName: 'read_file',
+      input: { file_path: '/tmp/repo/src/foo.ts' },
+      sessionId: 'child-1',
+      parentSessionId: 'parent-1',
+    });
+
+    expect(decision).toEqual({});
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
 describe('createPathApprovalHook — outcome mapping', () => {
   it('once: allows the call, records for post-cleanup; PostToolUse revokes', async () => {
     elicitationRouter.install(async () => ({ action: 'accept', content: { choice: 'once' } }));

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -21,6 +21,10 @@
  * On a `PreToolUse` event whose tool is one of the typed file tools AND whose
  * resolved path falls outside every granted root:
  *
+ *   0. If the call originates inside a forked sub-agent (`parentSessionId`
+ *      set), block immediately — sub-agents never prompt the operator; they
+ *      report the out-of-root path requirement back to their parent, which
+ *      owns the surface and can grant access.
  *   1. Check the in-process "always for this session" allow-cache — if the
  *      path is in there, fall through without prompting.
  *   2. Otherwise, deduplicate against any in-flight request for the same
@@ -203,6 +207,30 @@ async function preToolUseImpl(
     mode,
   );
   if (!result.restricted) return {};
+
+  // A forked sub-agent has no human relationship of its own and must not prompt
+  // the operator for out-of-root access — the prompt would surface on the
+  // parent's REPL/Telegram handler (the elicitation router is process-wide),
+  // interleaved into the parent's turn with no attribution. Auto-deny instead.
+  // The sub-agent inherits the parent's grants (this hook and its grant-manager
+  // closure are shared via the inherited registry), so any path the parent
+  // already approved still passes the `!restricted` check above; only a
+  // genuinely NEW out-of-root path reaches here, and the sub-agent reports the
+  // requirement back to its parent, which owns the surface and can grant it.
+  // Mirrors the `parentSessionId` self-skip used by the memory + plan-mode hooks.
+  if (context.parentSessionId !== undefined) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[path-approval] surface=${opts.surface} tool=${context.toolName} path=${result.resolved} outcome=subagent-autodeny`,
+    );
+    return {
+      decision: 'block',
+      reason:
+        `Sub-agents cannot access paths outside the session's granted roots ` +
+        `(${result.resolved}). Report this path requirement to the parent ` +
+        `session, which owns the operator surface and can grant access.`,
+    };
+  }
 
   // In-session approval cache short-circuits the prompt.
   const key = pathApprovalKey(mode, result.resolved);

--- a/src/agent/tools/subagent-executor.test.ts
+++ b/src/agent/tools/subagent-executor.test.ts
@@ -1487,25 +1487,28 @@ describe('SubagentExecutor', () => {
       );
     });
 
-    it('mode: "foreground" passes denyElicitations: false to forkSubagent', async () => {
+    it('mode: "foreground" passes denyElicitations: true to forkSubagent', async () => {
       const handle = mockHandle();
       mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
 
       await executor.execute(
         makeCall({ input: { prompt: 'p', mode: 'foreground' } }),
       );
+      // Foreground forks are non-interactive too: a sub-agent reports
+      // Blocked/Asking to its parent rather than eliciting the operator via the
+      // process-wide router. Both modes now deny MCP elicitation.
       expect(mockSubagentMgr.forkSubagent).toHaveBeenCalledWith(
-        expect.objectContaining({ denyElicitations: false }),
+        expect.objectContaining({ denyElicitations: true }),
       );
     });
 
-    it('mode omitted (default foreground) passes denyElicitations: false to forkSubagent', async () => {
+    it('mode omitted (default foreground) passes denyElicitations: true to forkSubagent', async () => {
       const handle = mockHandle();
       mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
 
       await executor.execute(makeCall({ input: { prompt: 'p' } }));
       expect(mockSubagentMgr.forkSubagent).toHaveBeenCalledWith(
-        expect.objectContaining({ denyElicitations: false }),
+        expect.objectContaining({ denyElicitations: true }),
       );
     });
 

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -644,10 +644,14 @@ export class SubagentExecutor implements SubagentControl {
         agentType: (parsed.id_prefix && parsed.id_prefix !== 'agent-tool')
           ? stripEscapeSequences(parsed.id_prefix).replace(/[\r\n]+/g, ' ').trim() || 'agent'
           : stripEscapeSequences(parsed.prompt).replace(/[\r\n]+/g, ' ').slice(0, 40).trim() || 'agent',
-        // External constraint: background subagents have no interactive surface
-        // to serve elicitation prompts — auto-decline prevents silent hangs.
-        // Foreground subagents continue to route through the default handler.
-        denyElicitations: parsed.mode === 'background',
+        // A forked sub-agent has no human relationship of its own: it returns
+        // findings (including Blocked/Asking) to its PARENT, which owns the
+        // operator surface. Deny MCP elicitation for BOTH foreground and
+        // background forks — together with the isNonInteractive default in
+        // subagent.ts this makes every sub-agent uniformly non-interactive.
+        // (Previously only background denied; foreground leaked elicitations to
+        // the REPL/Telegram human via the process-wide elicitation router.)
+        denyElicitations: true,
       });
       // Backfill: give the depth-1 child executor a real parentId so any
       // depth-2 forks it spawns carry handle.id as their parentId.

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -428,9 +428,11 @@ export interface AgentConfig {
    * (its skill-dispatch-specific numeric-arg lure does not apply here).
    *
    * Interactive surfaces (REPL, Telegram) leave this unset so a human can still
-   * be asked even when away-from-keyboard. Foreground/background sub-agent
-   * elicitation policy is governed separately by `denyElicitations` in
-   * `subagent.ts` and is deliberately NOT changed by this flag.
+   * be asked even when away-from-keyboard. Forked sub-agents default this to
+   * `true` (see `subagent.ts`): a sub-agent has no human relationship of its own
+   * and must return Blocked/Asking findings to its parent rather than eliciting
+   * the operator directly. Callers may override a fork with
+   * `isNonInteractive: false`.
    *
    * Default: `false`.
    */


### PR DESCRIPTION
## Problem

A forked sub-agent shares the **process-wide** elicitation router with its parent. So a child that calls `ask_question`, trips the path-approval hook, or receives an MCP elicitation reaches the operator at the **parent's** REPL/Telegram surface — interleaved into the parent's turn with no attribution. Foreground forks did this by design (`denyElicitations: false`), and `ask_question` + path-approval leaked for **both** foreground and background.

A sub-agent has no human relationship of its own; it should return Blocked/Asking findings to its **parent**, which owns the operator surface.

## Change

Make every fork non-interactive at a single chokepoint, plus close the three elicitation channels:

- **`subagent.ts`** child config: default `isNonInteractive: true` (the provider then strips `ask_question`) and default `onElicitation: DENY_ELICITATION`. A caller may opt a fork back in with `isNonInteractive: false` / `denyElicitations: false`.
- **`subagent-executor.ts`**: `denyElicitations: true` for **both** modes (was background-only). *Behavior change:* foreground forks no longer route MCP elicitations to the operator.
- **`path-approval-hook.ts`**: auto-deny out-of-root access when `context.parentSessionId` is set. Sub-agents inherit the parent's grants, so only a **genuinely new** out-of-root path blocks; the child reports the requirement to its parent. Mirrors the `parentSessionId` self-skip already used by the memory + plan-mode hooks.
- **`config-types.ts`**: updated the now-stale `isNonInteractive` doc.

## Why it's safe (no flow depends on foreground-sub-agent elicitation)

- Skill-dispatch forks **already** strip `ask_question` via `isSkillDispatch` (mint, diagnose, all skill phases) — this only closes the `agent`-tool foreground gap.
- DAG/farm/compose/skill-phase forks had **no** `denyElicitations` guard at all — making all forks deny is a latent-silent-hang **fix**, not a regression.
- `get-started` (the only `ask_question`-heavy skill) runs in-context (`load`), never forked, and already self-guards on non-interactive surfaces.

## Verification

- `pnpm lint` clean.
- 126 tests pass across the 3 affected files (incl. new fork-default `isNonInteractive` + path-approval sub-agent auto-deny coverage); 75 provider strip-mechanism tests pass.
- Note: the full `pnpm test` is currently unreliable in my local env due to a pre-existing `memory.db` schema v3 vs build v2 mismatch (unrelated to this change); CI runs against a clean state dir.

First of two PRs. Follow-up: make `bypassPermissions` actually suppress path-approval prompts (grant-all).