### PR TITLE
feat(permissions): make bypassPermissions real — disable path containment + add /bypass, flag, config key

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Aliases: `afk c` → `chat`, `afk i` → `interactive`, `afk s` → `status`.
 
 The one prompt you may hit is **path approval**: when a file tool (read/write/edit/list/glob/grep) targets a path *outside* the session's working directory, `afk` asks before allowing it. Pre-authorize paths with `/allow-dir <path>` (or answer "persist" at the prompt to remember them across sessions).
 
-To turn path approval off entirely — letting the agent read and write **anywhere** with no prompt — enable **bypass mode** with `/bypass` in the REPL. The status line shows `⚠ BYPASS` while it is active. This is the equivalent of `--dangerously-skip-permissions`; use it only on a machine and account you trust. `afk daemon` runs in bypass mode by default (no human to prompt). Bypass does not change `ask_question` — that is the model choosing to ask you something, a separate axis.
+To turn path approval off entirely — letting the agent read and write **anywhere** with no prompt — enable **bypass mode** any of three ways: `/bypass` in the REPL (the status line shows `⚠ BYPASS`), the `--dangerously-skip-permissions` flag on `afk`/`afk chat`, or `"permissionMode": "bypassPermissions"` in `afk.config.json`. This is the equivalent of Claude Code's `--dangerously-skip-permissions`; use it only on a machine and account you trust. `afk daemon` runs in bypass mode by default (no human to prompt). Bypass does not change `ask_question` — that is the model choosing to ask you something, a separate axis.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,11 @@ Aliases: `afk c` → `chat`, `afk i` → `interactive`, `afk s` → `status`.
 
 ## A note on permissions
 
-`afk` runs with **full permissions** by default: no per-tool prompts. Claude can run bash, read and write files, fetch URLs, and call MCP servers without asking each time. This is intentional — `afk` is built for unattended work, where a permission prompt with no human in front of it is just a wedged session.
+`afk` does not prompt before each tool call — there is no per-tool approval flow. Claude runs bash, reads and writes files, fetches URLs, and calls MCP servers without asking each time. This is intentional — `afk` is built for unattended work, where a permission prompt with no human in front of it is just a wedged session.
 
-Use `afk` on a machine and account you trust. Override per-session with `--permission-mode` if you want stricter behavior.
+The one prompt you may hit is **path approval**: when a file tool (read/write/edit/list/glob/grep) targets a path *outside* the session's working directory, `afk` asks before allowing it. Pre-authorize paths with `/allow-dir <path>` (or answer "persist" at the prompt to remember them across sessions).
+
+To turn path approval off entirely — letting the agent read and write **anywhere** with no prompt — enable **bypass mode** with `/bypass` in the REPL. The status line shows `⚠ BYPASS` while it is active. This is the equivalent of `--dangerously-skip-permissions`; use it only on a machine and account you trust. `afk daemon` runs in bypass mode by default (no human to prompt). Bypass does not change `ask_question` — that is the model choosing to ask you something, a separate axis.
 
 ## Troubleshooting
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,11 +120,14 @@ Markers never leak back into stored history — `cache-policy.ts` clones-and-sta
 
 ## Bypass permissions
 
-By default, the Claude Agent SDK asks for permission before executing tools like bash, file ops, web requests, etc. **`agent-afk` enables `bypassPermissions: true`** which:
+By default, `agent-afk` runs in permission mode `'default'`: tools execute without a per-tool approval prompt, but a file tool touching a path **outside the session's granted roots** triggers a path-approval prompt (and out-of-root access stays contained until granted). There is no per-tool "allow this bash command?" flow.
 
-- Skips all permission prompts
+**Bypass mode** (`permissionMode: 'bypassPermissions'`) disables path containment and the path-approval prompt entirely — filesystem tools may read/write any path with no confirmation:
+
+- Skips path-approval prompts; disables out-of-root containment
 - Allows fully automated workflows
-- Designed for CLI/scripting and unattended daemon work
+- Enable with `/bypass` in the REPL (status line shows `⚠ BYPASS`); the `afk daemon` sets it directly for unattended work
+- Does **not** affect `ask_question` (the model asking you a question is a separate axis)
 
 This is intentional — `agent-afk` is built for unattended work, where a permission prompt with no human in front of it just wedges the session. Use on a machine and account you trust.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -68,6 +68,7 @@ All commands support `--format json` where machine-readable output makes sense (
 --max-turns <n>           # safety rail (default 100)
 --max-budget-usd <n>
 --task-budget <tokens>
+--dangerously-skip-permissions  # bypass mode: skip path-approval prompts (read/write anywhere)
 --no-update-check         # suppress startup update check
 --dump-prompt <path>      # write resolved system prompt to file (provenance included)
 ```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -68,7 +68,6 @@ All commands support `--format json` where machine-readable output makes sense (
 --max-turns <n>           # safety rail (default 100)
 --max-budget-usd <n>
 --task-budget <tokens>
---permission-mode <mode>  # default | acceptEdits | bypassPermissions | plan
 --no-update-check         # suppress startup update check
 --dump-prompt <path>      # write resolved system prompt to file (provenance included)
 ```
@@ -194,7 +193,7 @@ The setup wizard prompts for the token and the chat IDs allowed to interact with
 - `/reset` — clear conversation
 - `/model local|small|medium|large|opus|sonnet|haiku|fable` — switch model
 
-Send any other message to chat. The bot has full tool access via bypass mode.
+Send any other message to chat. The bot runs in the default permission mode — tools execute without per-tool prompts, and file access outside the working directory stays contained.
 
 **Background-service helpers:**
 

--- a/src/agent/providers/anthropic-direct/bypass-live-toggle.test.ts
+++ b/src/agent/providers/anthropic-direct/bypass-live-toggle.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Regression test for the live `/bypass` (permission-mode) toggle.
+ *
+ * The reported bug: starting a session in `bypassPermissions` (via
+ * `--dangerously-skip-permissions`, the `permissionMode` config key, or the
+ * daemon) and then turning bypass OFF mid-session left the agent effectively
+ * unrestricted while the UI badge cleared — i.e. `/bypass off` failed UNSAFE.
+ *
+ * Root cause: `setPermissionMode()` updated only the system-prompt mode field,
+ * never the two fields that actually gate enforcement:
+ *   1. the provider's `_currentPermissionMode` — read by `getGrants().allowAll`,
+ *      which the path-approval hook consults; and
+ *   2. the live dispatcher's `_allowAll` — read per call by the file-tool
+ *      handler containment chain (`resolveAndContain` / `wouldBeRestricted`).
+ *
+ * These tests assert BOTH reads flip together on every `setPermissionMode`
+ * call, in both directions, within a single session (no model swap).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { AnthropicDirectProvider, __setAnthropicClientFactory } from './index.js';
+
+/** A stub client whose message stream is immediately done — no network. */
+function emptyStreamClient() {
+  return () =>
+    ({
+      messages: {
+        stream: () => ({
+          [Symbol.asyncIterator]() {
+            return { next: async () => ({ done: true, value: undefined }) };
+          },
+        }),
+      },
+    }) as unknown as InstanceType<typeof import('@anthropic-ai/sdk').default>;
+}
+
+/**
+ * Test-only read of the LIVE dispatcher's bypass flag — the file-tool
+ * containment source. The handler context reads the same `_allowAll` field, so
+ * the dispatcher's `getGrants().allowAll` is a faithful proxy for whether file
+ * tools are contained.
+ */
+function liveDispatcherAllowAll(q: unknown): boolean {
+  return (
+    q as { state: { toolDispatcher: { getGrants(): { allowAll: boolean } } } }
+  ).state.toolDispatcher.getGrants().allowAll;
+}
+
+describe('AnthropicDirectProvider — live /bypass toggle changes effective enforcement', () => {
+  afterEach(() => __setAnthropicClientFactory(undefined));
+
+  it('setPermissionMode flips BOTH enforcement reads live; /bypass off fails CLOSED', async () => {
+    __setAnthropicClientFactory(emptyStreamClient());
+    const provider = new AnthropicDirectProvider();
+    const baseDir = mkdtempSync(path.join(tmpdir(), 'bypass-live-'));
+    try {
+      // Start bypassed — mirrors --dangerously-skip-permissions / config / daemon.
+      const q = provider.query({
+        prompt: 'noop',
+        config: {
+          apiKey: 'sk-test',
+          cwd: baseDir,
+          permissionMode: 'bypassPermissions',
+        } as unknown as Parameters<typeof provider.query>[0]['config'],
+      });
+      // Drain one event so the SDK lifecycle is fully spun up (buildDispatcher
+      // and _currentPermissionMode are already set synchronously by query()).
+      await q[Symbol.asyncIterator]().next();
+
+      // Both enforcement sources see bypass at construction.
+      expect(provider.getGrants().allowAll).toBe(true); // path-approval hook
+      expect(liveDispatcherAllowAll(q)).toBe(true); // file-tool containment
+
+      // THE reported bug: /bypass off must actually restore containment.
+      // Pre-fix both reads stayed `true` (agent unrestricted, badge safe).
+      await q.setPermissionMode('default');
+      expect(provider.getGrants().allowAll).toBe(false);
+      expect(liveDispatcherAllowAll(q)).toBe(false);
+
+      // /bypass on from default enables bypass live — no model swap required.
+      await q.setPermissionMode('bypassPermissions');
+      expect(provider.getGrants().allowAll).toBe(true);
+      expect(liveDispatcherAllowAll(q)).toBe(true);
+
+      // No non-bypass mode ever enables allowAll.
+      for (const mode of ['default', 'plan', 'autonomous']) {
+        await q.setPermissionMode(mode);
+        expect(provider.getGrants().allowAll, `provider:${mode}`).toBe(false);
+        expect(liveDispatcherAllowAll(q), `dispatcher:${mode}`).toBe(false);
+      }
+
+      await q.close?.();
+    } finally {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+
+  it('starts contained by default and /bypass on lifts containment without a restart', async () => {
+    __setAnthropicClientFactory(emptyStreamClient());
+    const provider = new AnthropicDirectProvider();
+    const baseDir = mkdtempSync(path.join(tmpdir(), 'bypass-live-'));
+    try {
+      const q = provider.query({
+        prompt: 'noop',
+        config: {
+          apiKey: 'sk-test',
+          cwd: baseDir,
+        } as unknown as Parameters<typeof provider.query>[0]['config'],
+      });
+      await q[Symbol.asyncIterator]().next();
+
+      // Default mode: contained.
+      expect(provider.getGrants().allowAll).toBe(false);
+      expect(liveDispatcherAllowAll(q)).toBe(false);
+
+      // Live enable.
+      await q.setPermissionMode('bypassPermissions');
+      expect(provider.getGrants().allowAll).toBe(true);
+      expect(liveDispatcherAllowAll(q)).toBe(true);
+
+      await q.close?.();
+    } finally {
+      rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -191,6 +191,12 @@ export class AnthropicDirectProvider implements ModelProvider {
   private _sharedReadRoots: string[] | undefined;
   /** Mutable write-root list — same shared-reference pattern as `_sharedReadRoots`. */
   private _sharedWriteRoots: string[] | undefined;
+  /**
+   * The session's current permission mode, refreshed on each `query()`. Read by
+   * `getGrants()` so the path-approval hook sees `allowAll` in bypassPermissions
+   * mode (the per-query dispatcher gets the same signal via `buildDispatcher`).
+   */
+  private _currentPermissionMode = 'default';
   /** The first cwd ever seen by ensureSharedRoots — non-revocable, mirrors the dispatcher-level guard. */
   private _initialResolveBase: string | undefined;
   /**
@@ -355,6 +361,9 @@ export class AnthropicDirectProvider implements ModelProvider {
     const mcpSchemas = this._mcpToolsCache ?? [];
     return new SessionToolDispatcher({
       handlers,
+      // Bypass mode: when the session runs in bypassPermissions, every per-call
+      // ToolHandlerContext carries allowAll:true so path containment is disabled.
+      allowAll: permissionMode === 'bypassPermissions',
       // Constraint (semantic invariant): MCP schemas appended AFTER builtins
       // so builtin tool names always take precedence in any overlap.
       schemas: [...this.schemas, ...mcpSchemas],
@@ -492,11 +501,12 @@ export class AnthropicDirectProvider implements ModelProvider {
     this.appendProviderAuditLog({ action: 'revoke', path: p, source, sessionId });
   }
 
-  getGrants(): { resolveBase: string | undefined; readRoots: string[]; writeRoots: string[] } {
+  getGrants(): { resolveBase: string | undefined; readRoots: string[]; writeRoots: string[]; allowAll: boolean } {
     return {
       resolveBase: this._initialResolveBase,
       readRoots: this._sharedReadRoots?.slice() ?? [],
       writeRoots: this._sharedWriteRoots?.slice() ?? [],
+      allowAll: this._currentPermissionMode === 'bypassPermissions',
     };
   }
 
@@ -566,6 +576,9 @@ export class AnthropicDirectProvider implements ModelProvider {
     // external dispatcher, use it as-is — external callers own their own
     // lifecycle.
     const permissionMode = config.permissionMode ?? 'default';
+    // Track for getGrants() so the path-approval hook's allowAll stays in sync
+    // with the per-query dispatcher's (both derive from this mode).
+    this._currentPermissionMode = permissionMode;
 
     // Initialise the shared root arrays on first query. Subsequent queries
     // reuse the same array references so /allow-dir grants survive across turns.

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -868,7 +868,10 @@ export class AnthropicDirectProvider implements ModelProvider {
           //    will continue to reference the original `queryDispatcher` — an
           //    accepted minor staleness window for Phase 1 (worktree rename
           //    rarely coincides with mid-session MCP tool refresh).
-          const newDispatcher = this.buildDispatcher(permissionMode, {
+          // Use the LIVE permission mode (not the captured construction-time
+          // `permissionMode`) so a `/cd` after a `/bypass` toggle rebuilds the
+          // dispatcher with the current allowAll, never reverting the toggle.
+          const newDispatcher = this.buildDispatcher(this._currentPermissionMode, {
             cwd: newCwd,
             readRoots: this._sharedReadRoots,
             writeRoots: this._sharedWriteRoots,
@@ -920,6 +923,13 @@ export class AnthropicDirectProvider implements ModelProvider {
         ? { autoResumeOnUsageLimit: config.autoResumeOnUsageLimit }
         : {}),
       ...(cwdDependentsFactory !== undefined ? { cwdDependentsFactory } : {}),
+      // Path-approval half of the live `/bypass` toggle: keep the provider's
+      // `_currentPermissionMode` (read by getGrants().allowAll) in sync with
+      // the query handle's mode. The file-tool half is the dispatcher's
+      // setAllowAll(), flipped inside the same setPermissionMode call.
+      onPermissionMode: (mode: string) => {
+        this._currentPermissionMode = mode;
+      },
       ...(this.mcpManager !== undefined ? { mcpManager: this.mcpManager } : {}),
       ...(resolveAutoCompactThreshold(config.autoCompact) !== undefined
         ? { autoCompactThreshold: resolveAutoCompactThreshold(config.autoCompact) }

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -151,6 +151,14 @@ export interface AnthropicDirectQueryOptions {
    */
   cwdDependentsFactory?: (cwd: string) => { userSystem: string; dispatcher: ToolDispatcher };
   /**
+   * Provider callback invoked by `setPermissionMode()` to update the
+   * provider-level `_currentPermissionMode` — the field the path-approval hook
+   * reads via the provider's `getGrants().allowAll`. This is the path-approval
+   * half of a live `/bypass` toggle; the file-tool half is the dispatcher's
+   * `setAllowAll()`. Supplied by `AnthropicDirectProvider.query()`.
+   */
+  onPermissionMode?: (mode: string) => void;
+  /**
    * Optional MCP manager — used by `session.init` and `mcpServerStatus()`
    * to surface live MCP server status to the REPL (`/mcp`), the Telegram
    * bridge, and the daemon's state file. The query itself does NOT call
@@ -225,6 +233,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
    */
   private readonly retry: RetryLayer;
   private readonly cwdDependentsFactory?: (cwd: string) => { userSystem: string; dispatcher: ToolDispatcher };
+  private readonly onPermissionMode?: (mode: string) => void;
   private readonly mcpManager?: import('../../mcp/index.js').McpManager;
 
   constructor(opts: AnthropicDirectQueryOptions) {
@@ -238,6 +247,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
     if (opts.baseUrl !== undefined) this.baseUrl = opts.baseUrl;
     this.traceWriter = opts.traceWriter;
     this.cwdDependentsFactory = opts.cwdDependentsFactory;
+    this.onPermissionMode = opts.onPermissionMode;
     this.mcpManager = opts.mcpManager;
     this.retry = new RetryLayer({
       client: opts.client,
@@ -464,7 +474,19 @@ export class AnthropicDirectQuery implements ProviderQuery {
   }
 
   async setPermissionMode(mode: string): Promise<void> {
+    // The plan/AFK system-prompt addendum reads this on the next composeSystem.
     this.state.currentPermissionMode = mode;
+    // Live enforcement spans two reads fed by two separate fields — keep both
+    // in sync or a live `/bypass` toggle silently fails (and `/bypass off`
+    // fails UNSAFE: badge clears while the agent stays unrestricted):
+    //  1. File-tool path containment reads the dispatcher's `allowAll` fresh
+    //     per call, so flip it in place — effective on the next tool call.
+    const bypass = mode === 'bypassPermissions';
+    this.state.toolDispatcher.setAllowAll?.(bypass);
+    //  2. The path-approval hook reads the PROVIDER's getGrants().allowAll (a
+    //     different field, `_currentPermissionMode`); update it via the
+    //     provider-supplied callback.
+    this.onPermissionMode?.(mode);
   }
 
   /**

--- a/src/agent/providers/anthropic-direct/types.ts
+++ b/src/agent/providers/anthropic-direct/types.ts
@@ -383,6 +383,16 @@ export interface ToolDispatcherLike {
    * implementation.
    */
   setResolveBase?(cwd: string): void;
+  /**
+   * Optional in-place bypass (`allowAll`) update. Called by a provider query
+   * handle's `setPermissionMode()` so a live `/bypass` toggle changes effective
+   * file-tool path containment mid-session. The dispatcher reads `allowAll`
+   * fresh per call (via its `handlerContext` getter), so flipping it here takes
+   * effect on the NEXT tool call — no dispatcher swap needed. Dispatchers that
+   * own their own permission model can omit this.
+   * See `SessionToolDispatcher.setAllowAll` for the canonical implementation.
+   */
+  setAllowAll?(allow: boolean): void;
 }
 
 /**

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -219,6 +219,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
     const buildOpts: {
       baseURL?: string;
       toolDispatcher?: ToolDispatcher;
+      onPermissionMode?: (mode: string) => void;
       mcpManager?: import('../../mcp/index.js').McpManager;
     } = {};
     // Per-slot / per-session baseURL (`config.openaiBaseUrl`, set by
@@ -228,6 +229,12 @@ export class OpenAICompatibleProvider implements ModelProvider {
     const effectiveBaseURL = config.openaiBaseUrl ?? this.providerOpts.baseURL;
     if (effectiveBaseURL !== undefined) buildOpts.baseURL = effectiveBaseURL;
     buildOpts.toolDispatcher = dispatcher;
+    // Path-approval half of the live `/bypass` toggle: keep the provider's
+    // `_currentPermissionMode` (read by getGrants().allowAll) in sync with the
+    // query handle's mode. File-tool half is the dispatcher's setAllowAll().
+    buildOpts.onPermissionMode = (mode: string) => {
+      this._currentPermissionMode = mode;
+    };
     if (this.providerOpts.mcpManager !== undefined) buildOpts.mcpManager = this.providerOpts.mcpManager;
 
     // Phase 2 — Presence file lifecycle (top-level sessions only).

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -116,6 +116,11 @@ export class OpenAICompatibleProvider implements ModelProvider {
    */
   private _sharedReadRoots: string[] | undefined;
   private _sharedWriteRoots: string[] | undefined;
+  /**
+   * Current permission mode, refreshed per `query()` — read by `getGrants()` so
+   * the path-approval hook's `allowAll` matches the per-query dispatcher's.
+   */
+  private _currentPermissionMode = 'default';
   private _initialResolveBase: string | undefined;
   /**
    * Presence-registration guard — same semantics as
@@ -149,6 +154,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
   query(args: ProviderQueryArgs): ProviderQuery {
     const config = args.config;
     const permissionMode = config.permissionMode ?? 'default';
+    this._currentPermissionMode = permissionMode;
 
     // Lazily init the shared root arrays (mirrors AnthropicDirectProvider).
     this.ensureSharedRoots(config.cwd);
@@ -389,6 +395,8 @@ export class OpenAICompatibleProvider implements ModelProvider {
     // the provider's construction-time flag so a read-only skill's forked
     // OpenAI-routed child also blocks mutating shell commands.
     if (this.providerOpts.readOnlyBash === true) dispatcherOpts.readOnlyBash = true;
+    // Bypass mode: disable path containment for every per-call context.
+    dispatcherOpts.allowAll = permissionMode === 'bypassPermissions';
 
     return new SessionToolDispatcher(dispatcherOpts);
   }
@@ -442,11 +450,12 @@ export class OpenAICompatibleProvider implements ModelProvider {
     this.appendProviderAuditLog({ action: 'revoke', path: p, source, sessionId });
   }
 
-  getGrants(): { resolveBase: string | undefined; readRoots: string[]; writeRoots: string[] } {
+  getGrants(): { resolveBase: string | undefined; readRoots: string[]; writeRoots: string[]; allowAll: boolean } {
     return {
       resolveBase: this._initialResolveBase,
       readRoots: this._sharedReadRoots?.slice() ?? [],
       writeRoots: this._sharedWriteRoots?.slice() ?? [],
+      allowAll: this._currentPermissionMode === 'bypassPermissions',
     };
   }
 

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -244,6 +244,14 @@ export interface OpenAICompatibleQueryOptions {
    * and the shared handler set all just work.
    */
   toolDispatcher?: ToolDispatcher;
+  /**
+   * Provider callback invoked by `setPermissionMode()` to update the
+   * provider-level `_currentPermissionMode` — the field the path-approval hook
+   * reads via the provider's `getGrants().allowAll`. The path-approval half of
+   * a live `/bypass` toggle (the file-tool half is the dispatcher's
+   * `setAllowAll()`). Supplied by `OpenAICompatibleProvider.query()`.
+   */
+  onPermissionMode?: (mode: string) => void;
   /** Optional MCP manager — populates `session.init` and `mcpServerStatus()`. */
   mcpManager?: import('../../mcp/index.js').McpManager;
   /**
@@ -317,6 +325,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
   private readonly opts: OpenAICompatibleQueryOptions;
   private readonly initSessionId: string;
   private readonly toolDispatcher: ToolDispatcher | undefined;
+  private readonly onPermissionMode?: (mode: string) => void;
   /** Pre-computed tool catalog — recomputed only if dispatcher.toolDefs changes (it doesn't today). */
   private readonly openAITools: OpenAIFunctionTool[] | undefined;
   /** Which wire this session speaks: Chat Completions (default) or Responses. */
@@ -349,6 +358,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     this.currentModel = opts.model;
     this.currentPermissionMode = normalizePermissionMode(opts.config.permissionMode);
     this.toolDispatcher = opts.toolDispatcher;
+    this.onPermissionMode = opts.onPermissionMode;
 
     // Pre-compute the OpenAI tool catalog once. Only `SessionToolDispatcher`
     // (and not the structural `ToolDispatcher` minimal interface) exposes
@@ -1088,6 +1098,13 @@ export class OpenAICompatibleQuery implements ProviderQuery {
 
   async setPermissionMode(mode: string): Promise<void> {
     this.currentPermissionMode = normalizePermissionMode(mode);
+    // Live enforcement, two fields kept in sync (else `/bypass off` fails
+    // UNSAFE — badge clears while the agent stays unrestricted):
+    //  1. file-tool containment ← dispatcher's allowAll (read fresh per call).
+    const bypass = this.currentPermissionMode === 'bypassPermissions';
+    this.toolDispatcher?.setAllowAll?.(bypass);
+    //  2. path-approval hook ← provider's _currentPermissionMode (callback).
+    this.onPermissionMode?.(this.currentPermissionMode);
   }
 
   setCwd(cwd: string): void {
@@ -1260,6 +1277,7 @@ export function buildQueryFromConfig(
   options: {
     baseURL?: string;
     toolDispatcher?: ToolDispatcher;
+    onPermissionMode?: (mode: string) => void;
     mcpManager?: import('../../mcp/index.js').McpManager;
     useResponsesApi?: boolean;
     /**
@@ -1291,6 +1309,7 @@ export function buildQueryFromConfig(
   };
   if (options.baseURL !== undefined) opts.baseURL = options.baseURL;
   if (options.toolDispatcher !== undefined) opts.toolDispatcher = options.toolDispatcher;
+  if (options.onPermissionMode !== undefined) opts.onPermissionMode = options.onPermissionMode;
   if (options.mcpManager !== undefined) opts.mcpManager = options.mcpManager;
   if (options.useResponsesApi !== undefined) opts.useResponsesApi = options.useResponsesApi;
   return new OpenAICompatibleQuery(opts);

--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -52,6 +52,28 @@ describe('SessionToolDispatcher', () => {
     expect(result.isError).toBeUndefined();
   });
 
+  describe('setAllowAll (live /bypass toggle — file-tool containment half)', () => {
+    it('flips getGrants().allowAll in place, both directions', () => {
+      const d = makeDispatcher();
+      expect(d.getGrants().allowAll).toBe(false);
+      // `/bypass on`: takes effect immediately (read fresh per call via the
+      // handlerContext getter — no dispatcher rebuild needed).
+      d.setAllowAll(true);
+      expect(d.getGrants().allowAll).toBe(true);
+      // `/bypass off`: must restore containment (fail-closed) — the direction
+      // that previously failed UNSAFE because the field was never updated.
+      d.setAllowAll(false);
+      expect(d.getGrants().allowAll).toBe(false);
+    });
+
+    it('can toggle off a construction-time bypass', () => {
+      const d = makeDispatcher({ allowAll: true });
+      expect(d.getGrants().allowAll).toBe(true);
+      d.setAllowAll(false);
+      expect(d.getGrants().allowAll).toBe(false);
+    });
+  });
+
   it('returns isError for unknown tool', async () => {
     const dispatcher = makeDispatcher({
       permissions: { allowedTools: ['echo', 'nonexistent'] },

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -150,6 +150,12 @@ export interface SessionToolDispatcherOptions {
    */
   writeRoots?: string[];
   /**
+   * When true, the per-call `ToolHandlerContext` carries `allowAll: true`,
+   * disabling ALL path containment (bypassPermissions mode). Derived by the
+   * provider's `buildDispatcher` from the session permission mode.
+   */
+  allowAll?: boolean;
+  /**
    * Extra environment variables surfaced on every `ToolHandlerContext.env`.
    * Consumed by the Bash handler to inject `PLUGIN_ROOT` (and any future
    * per-session overrides) without mutating `process.env`. Captured by
@@ -208,6 +214,8 @@ export class SessionToolDispatcher implements ToolDispatcher {
   private readonly _readRoots: string[];
   /** Mutable write-root list. Mutated in place by `addWriteRoot`/`revokeRoot`/`setResolveBase`. */
   private readonly _writeRoots: string[];
+  /** When true, all path containment is bypassed (bypassPermissions mode). */
+  private readonly _allowAll: boolean;
   /** Optional per-session env injected into the Bash handler's spawn env. */
   private readonly _env: Record<string, string> | undefined;
   private readonly sessionId: string | undefined;
@@ -238,6 +246,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
     this.parentSessionId = opts.parentSessionId;
     this.traceWriter = opts.traceWriter;
     this.readOnlyBash = opts.readOnlyBash === true;
+    this._allowAll = opts.allowAll === true;
 
     // When caller passes arrays by reference (provider sharing pattern), use
     // them directly so mutations are visible without rebuilding. Otherwise
@@ -257,6 +266,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
       resolveBase: this.resolveBase,
       readRoots: this._readRoots.slice(),
       writeRoots: this._writeRoots.slice(),
+      ...(this._allowAll ? { allowAll: true } : {}),
       ...(this._env !== undefined ? { env: this._env } : {}),
     };
   }
@@ -310,11 +320,12 @@ export class SessionToolDispatcher implements ToolDispatcher {
   }
 
   /** Returns a snapshot of current grant state (for /allow-dir display). */
-  getGrants(): { resolveBase: string | undefined; readRoots: string[]; writeRoots: string[] } {
+  getGrants(): { resolveBase: string | undefined; readRoots: string[]; writeRoots: string[]; allowAll: boolean } {
     return {
       resolveBase: this.resolveBase,
       readRoots: this._readRoots.slice(),
       writeRoots: this._writeRoots.slice(),
+      allowAll: this._allowAll,
     };
   }
 

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -214,8 +214,12 @@ export class SessionToolDispatcher implements ToolDispatcher {
   private readonly _readRoots: string[];
   /** Mutable write-root list. Mutated in place by `addWriteRoot`/`revokeRoot`/`setResolveBase`. */
   private readonly _writeRoots: string[];
-  /** When true, all path containment is bypassed (bypassPermissions mode). */
-  private readonly _allowAll: boolean;
+  /**
+   * When true, all path containment is bypassed (bypassPermissions mode).
+   * Mutable so a live `/bypass` toggle can flip it mid-session via
+   * `setAllowAll()` — read fresh per call by the `handlerContext` getter.
+   */
+  private _allowAll: boolean;
   /** Optional per-session env injected into the Bash handler's spawn env. */
   private readonly _env: Record<string, string> | undefined;
   private readonly sessionId: string | undefined;
@@ -327,6 +331,18 @@ export class SessionToolDispatcher implements ToolDispatcher {
       writeRoots: this._writeRoots.slice(),
       allowAll: this._allowAll,
     };
+  }
+
+  /**
+   * Flip the bypass (`allowAll`) flag in place. Mutates rather than rebuilding
+   * so callers holding this dispatcher by reference (e.g. `loop.ts` captured
+   * `runInput.toolDispatcher` for an in-flight turn) see the new value on their
+   * next `handlerContext`/`getGrants()` read. This is the file-tool half of a
+   * live `/bypass` toggle; the path-approval-hook half is the provider's
+   * `_currentPermissionMode` (see the query handle's `setPermissionMode`).
+   */
+  setAllowAll(allow: boolean): void {
+    this._allowAll = allow;
   }
 
   /**

--- a/src/agent/tools/handlers/_cwd-utils.test.ts
+++ b/src/agent/tools/handlers/_cwd-utils.test.ts
@@ -110,6 +110,29 @@ describe('wouldBeRestricted', () => {
 // Symlink containment tests (H1 security fix)
 // ---------------------------------------------------------------------------
 
+describe('allowAll bypass (bypassPermissions mode)', () => {
+  // External invariant: both functions MUST agree under allowAll too —
+  // resolveAndContain admits the path (no throw), wouldBeRestricted reports
+  // not-restricted — so the path-approval hook skips its prompt for exactly the
+  // paths the handler will then accept.
+  it('resolveAndContain admits an out-of-root path when allowAll is set', () => {
+    expect(resolveAndContain(OUTSIDE, ctx({ allowAll: true }))).toBe(OUTSIDE);
+    expect(resolveAndContain(OUTSIDE, ctx({ allowAll: true }), 'write')).toBe(OUTSIDE);
+  });
+
+  it('wouldBeRestricted reports not-restricted for an out-of-root path when allowAll is set', () => {
+    const r = wouldBeRestricted(OUTSIDE, ctx({ allowAll: true }));
+    expect(r.restricted).toBe(false);
+    expect(r.resolved).toBe(OUTSIDE);
+    expect(wouldBeRestricted(OUTSIDE, ctx({ allowAll: true }), 'write').restricted).toBe(false);
+  });
+
+  it('allowAll does not disturb in-root resolution (relative paths still anchor to resolveBase)', () => {
+    expect(resolveAndContain('src/foo.ts', ctx({ allowAll: true }))).toBe(INSIDE);
+    expect(wouldBeRestricted(INSIDE, ctx({ allowAll: true })).restricted).toBe(false);
+  });
+});
+
 describe('symlink containment', () => {
   // Track tmp dirs created per test so afterEach can clean them up.
   const tmps: string[] = [];

--- a/src/agent/tools/handlers/_cwd-utils.ts
+++ b/src/agent/tools/handlers/_cwd-utils.ts
@@ -86,6 +86,13 @@ export function resolveAndContain(
     ? inputPath
     : path.resolve(resolveBase ?? process.cwd(), inputPath);
 
+  // Bypass mode: the session runs in `bypassPermissions`, which disables all
+  // path containment. Admit any path (no throw). This is the same switch the
+  // path-approval hook consults to skip its prompt, so the two stay in sync.
+  if (context?.allowAll === true) {
+    return abs;
+  }
+
   // No base set — no containment enforcement.
   if (resolveBase === undefined) {
     return abs;
@@ -145,6 +152,12 @@ export function wouldBeRestricted(
   const abs = path.isAbsolute(inputPath)
     ? inputPath
     : path.resolve(resolveBase ?? process.cwd(), inputPath);
+
+  // Bypass mode (bypassPermissions): never restricted, so the path-approval
+  // hook does not prompt. Mirrors the short-circuit in `resolveAndContain`.
+  if (context?.allowAll === true) {
+    return { restricted: false, resolved: abs, roots: [] };
+  }
 
   if (resolveBase === undefined) {
     // No containment enforcement — never restricted.

--- a/src/agent/tools/hooks/path-approval-hook.test.ts
+++ b/src/agent/tools/hooks/path-approval-hook.test.ts
@@ -217,6 +217,29 @@ describe('createPathApprovalHook — outcome mapping', () => {
   });
 });
 
+describe('createPathApprovalHook — allowAll bypass (bypassPermissions, PR2)', () => {
+  // When the provider reports allowAll (session in bypassPermissions), the hook
+  // must NOT prompt for out-of-root paths — wouldBeRestricted returns
+  // not-restricted, mirroring the handler's resolveAndContain which also admits
+  // the path. This is what makes "bypass" actually skip the approval prompt.
+  it('does not prompt for an out-of-root path when grants.allowAll is true', async () => {
+    const handler = vi.fn(async () => ({ action: 'accept', content: { choice: 'session' } }));
+    elicitationRouter.install(handler);
+    const mgr = makeMockGrantManager();
+    const bypassMgr = { ...mgr, getGrants: () => ({ ...mgr.getGrants(), allowAll: true }) };
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => bypassMgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse(preCtx('read_file', { file_path: '/etc/hosts' }));
+    expect(decision).toEqual({});
+    expect(handler).not.toHaveBeenCalled();
+    expect(mgr._events).toHaveLength(0);
+  });
+});
+
 describe('createPathApprovalHook — concurrency dedup', () => {
   it('two concurrent calls to the same path produce one prompt', async () => {
     let resolveHandler: (() => void) | undefined;

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -199,9 +199,13 @@ async function preToolUseImpl(
       resolveBase: grants.resolveBase ?? cwd,
       readRoots: grants.readRoots,
       writeRoots: grants.writeRoots,
+      ...(grants.allowAll === true ? { allowAll: true } : {}),
     },
     mode,
   );
+  // Bypass mode: `allowAll` makes wouldBeRestricted return not-restricted, so
+  // this returns {} here — no prompt. (Belt-and-suspenders with the explicit
+  // flag pass-through above.)
   if (!result.restricted) return {};
 
   // In-session approval cache short-circuits the prompt.

--- a/src/agent/tools/types.ts
+++ b/src/agent/tools/types.ts
@@ -66,6 +66,14 @@ export interface ToolHandlerContext {
    * future handler needs env-aware behavior, it can read this same key.
    */
   env?: Record<string, string>;
+  /**
+   * When true, ALL path containment is bypassed: `resolveAndContain` and
+   * `wouldBeRestricted` admit any path. Set by the dispatcher when the session
+   * runs in `bypassPermissions` mode. This is the single switch that makes
+   * "bypass" actually skip the path-approval prompt AND the handler containment
+   * throw. Default (unset) enforces containment against the granted roots.
+   */
+  allowAll?: boolean;
 }
 
 /**

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -151,6 +151,7 @@ export function registerChatCommand(program: Command): void {
     .option('--session-id <uuid>', 'Assign a specific UUID to this session (creates new; errors if already exists)')
     .option('--post <targets>', 'Headless publish of the final assistant message: github, telegram, or github,telegram')
     .option('--post-pr <ref>', 'PR number, URL, or branch for --post github (defaults to the current-branch PR)')
+    .option('--dangerously-skip-permissions', 'Bypass mode: skip path-approval prompts; the agent may read/write ANY path with no confirmation (permissionMode=bypassPermissions). Does not affect ask_question.')
     .action(async (rawMessage: string | undefined, options: {
       model: AgentModelInput;
       stream: boolean;
@@ -170,6 +171,7 @@ export function registerChatCommand(program: Command): void {
       sessionId?: string;
       post?: string;
       postPr?: string;
+      dangerouslySkipPermissions?: boolean;
     }) => {
       // -----------------------------------------------------------------------
       // Mutual-exclusion checks for session flags (before spinner so errors
@@ -575,6 +577,15 @@ export function registerChatCommand(program: Command): void {
           // handler is installed, so ask_question can only auto-decline. Strip
           // it so the model proceeds on an assumption instead of wasting a turn.
           isNonInteractive: true,
+          // Bypass mode: --dangerously-skip-permissions wins; else the
+          // afk.config.json `permissionMode` key (validated in loadConfig).
+          // Omitted entirely when neither is set so the session defaults to
+          // 'default' at the session layer.
+          ...(options.dangerouslySkipPermissions
+            ? { permissionMode: 'bypassPermissions' as const }
+            : cliConfig.permissionMode !== undefined
+              ? { permissionMode: cliConfig.permissionMode }
+              : {}),
           hookRegistry: createDefaultHookRegistry((info) => {
             console.log(formatSubagentCompletion(info));
           }, 'cli', sharedMemoryStore, undefined, loadHooksConfig({ cwd: worktreeCwd }), { cwd: worktreeCwd }).registry,

--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -185,6 +185,7 @@ export function registerInteractiveCommand(program: Command): void {
     )
     .option('--provider <name>', "Provider to use: anthropic|anthropic-direct|openai|openai-compatible. Default: auto-selected by model")
     .option('--dump-prompt [path]', 'Dump resolved SDK prompt+options+provenance to file (default: ~/.afk/logs/prompt-dump-<ISO>.json) or "stderr"')
+    .option('--dangerously-skip-permissions', 'Start in bypass mode: skip path-approval prompts; the agent may read/write ANY path with no confirmation. Toggle live with /bypass. Does not affect ask_question.')
     .option(
       '--mcp-config <path>',
       'Path to an additional MCP config file (highest priority — merges over ~/.afk/config/mcp.json, project-local .mcp.json, and plugin-contributed configs). File format identical to mcp.json.',

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -2,6 +2,7 @@ import * as readline from 'node:readline';
 import { elicitationRouter } from '../../../agent/elicitation-router.js';
 import { makeReplElicitationHandler } from '../../elicitation-repl.js';
 import { AgentSession } from '../../../agent/session.js';
+import type { PermissionMode } from '../../../agent/types/sdk-types.js';
 import { unconfiguredSlotError } from '../../../agent/session/model-slots.js';
 import { createDefaultHookRegistry } from '../../../agent/default-hook-registry.js';
 import { loadHooksConfig } from '../../../agent/hooks/config-loader.js';
@@ -85,6 +86,8 @@ interface BuildAgentSessionDeps {
   cwd: string | undefined;
   maxTurns: number;
   autoResumeOnUsageLimit: boolean | undefined;
+  /** Initial session permission mode (e.g. 'bypassPermissions'). Omit for 'default'. */
+  permissionMode?: PermissionMode;
   baseUrl?: string;
 }
 
@@ -108,6 +111,7 @@ export function buildAgentSession(deps: BuildAgentSessionDeps): AgentSession {
     apiKey: getApiKeyForModel(deps.model),
     maxTurns: deps.maxTurns,
     hookRegistry: deps.hookRegistry,
+    ...(deps.permissionMode !== undefined ? { permissionMode: deps.permissionMode } : {}),
     ...(deps.systemPrompt !== undefined ? { systemPrompt: deps.systemPrompt } : {}),
     ...(deps.systemPromptSource !== undefined ? { systemPromptSource: deps.systemPromptSource } : {}),
     ...(deps.thinking !== undefined ? { thinking: deps.thinking } : {}),
@@ -499,6 +503,16 @@ export async function bootstrapSession(
   if (resumeTarget?.stored) {
     reseedStatsFromStored(stats, resumeTarget.stored, resumeTarget.resumeId);
   }
+  // Initial permission mode: --dangerously-skip-permissions wins, else the
+  // afk.config.json `permissionMode` key (validated in loadConfig). Stamped on
+  // stats so the status-line badge + the plan/AFK/bypass gate getters reflect it
+  // from turn 1; the session is constructed with the same value via sharedDeps.
+  const initialPermissionMode = options.dangerouslySkipPermissions
+    ? ('bypassPermissions' as const)
+    : cliConfig.permissionMode;
+  if (initialPermissionMode !== undefined) {
+    stats.permissionMode = initialPermissionMode;
+  }
   // Stamp the effective working directory on stats so the status line can
   // render it. We capture the same cwd the provider will see: the explicit
   // `extras.cwd` override (e.g. from `--worktree`) when present, else
@@ -562,6 +576,7 @@ export async function bootstrapSession(
     cwd: extras?.cwd,
     maxTurns: parseInt(options.maxTurns, 10),
     autoResumeOnUsageLimit: cliConfig.autoResumeOnUsageLimit,
+    ...(initialPermissionMode !== undefined ? { permissionMode: initialPermissionMode } : {}),
   };
 
   const session = buildAgentSession(sharedDeps);
@@ -668,6 +683,10 @@ export async function bootstrapSession(
         ...sharedDeps,
         model: t.stored?.model ?? sharedDeps.model,
         resumeConfig: resumeConfigFor(t),
+        // Preserve the LIVE permission mode across a model swap (e.g. the user
+        // toggled /bypass after startup) rather than resetting to the initial
+        // config value carried in sharedDeps.
+        permissionMode: stats.permissionMode,
       }),
     });
   };

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -229,6 +229,11 @@ export interface CliOptions {
   continue?: boolean;
   debug?: boolean;
   /**
+   * `--dangerously-skip-permissions` — start the session in `'bypassPermissions'`
+   * (skip path-approval prompts; read/write anywhere). Toggle live with /bypass.
+   */
+  dangerouslySkipPermissions?: boolean;
+  /**
    * `--worktree [branch]` flag. `true` when the flag was passed without a value
    * (auto-named branch). String when the user supplied a branch name.
    * `undefined` when the flag was not passed.

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -12,6 +12,7 @@ import {
 } from '../agent/session/model-slots.js';
 import { providerForModel, type BundledProviderName } from '../agent/providers/index.js';
 import type { AgentModelInput } from '../agent/types.js';
+import type { PermissionMode } from '../agent/types/sdk-types.js';
 import {
   getAfkHome,
   getEnvConfigPath,
@@ -87,6 +88,13 @@ export interface CliConfig {
    * prompt-dump debug feature; not forwarded to the SDK.
    */
   systemPromptSource?: string;
+  /**
+   * Session permission mode. Sourced from afk.config.json `permissionMode`.
+   * `'bypassPermissions'` disables path containment + the path-approval prompt
+   * (the agent reads/writes anywhere). Defaults to `'default'` at the session
+   * layer when unset. Validated on load — invalid strings are ignored.
+   */
+  permissionMode?: PermissionMode;
   autoRouting?: AutoRoutingConfig;
   /**
    * Daemon defaults sourced from afk.config.json. Stays `undefined` when
@@ -252,6 +260,8 @@ interface ConfigFileSchema {
   maxTokens?: number;
   temperature?: number;
   systemPrompt?: string;
+  /** Session permission mode (validated on load): default | plan | autonomous | bypassPermissions. */
+  permissionMode?: string;
   autoRouting?: {
     interactive?: boolean;
     chat?: boolean;
@@ -607,6 +617,15 @@ function loadJsonConfig(): {
           config.systemPrompt = json.systemPrompt;
         }
 
+        if (typeof json.permissionMode === 'string') {
+          // Validate against the known modes; ignore garbage so a typo can't
+          // silently land the session in an unexpected (or dangerous) mode.
+          const pm = json.permissionMode;
+          if (pm === 'default' || pm === 'plan' || pm === 'autonomous' || pm === 'bypassPermissions') {
+            config.permissionMode = pm;
+          }
+        }
+
         if (json.autoRouting && typeof json.autoRouting === 'object') {
           const ar: AutoRoutingConfig = {};
           if (typeof json.autoRouting.interactive === 'boolean') ar.interactive = json.autoRouting.interactive;
@@ -865,6 +884,7 @@ export function loadConfig(overrides?: Partial<CliConfig>): CliConfig {
     ...(merged.openaiBaseUrl !== undefined ? { openaiBaseUrl: merged.openaiBaseUrl } : {}),
     ...(merged.systemPrompt !== undefined ? { systemPrompt: merged.systemPrompt } : {}),
     ...(systemPromptSource !== undefined ? { systemPromptSource } : {}),
+    ...(merged.permissionMode !== undefined ? { permissionMode: merged.permissionMode } : {}),
     ...(merged.autoRouting !== undefined ? { autoRouting: merged.autoRouting } : {}),
     ...(merged.daemon !== undefined ? { daemon: merged.daemon } : {}),
     ...(merged.telegram !== undefined ? { telegram: merged.telegram } : {}),

--- a/src/cli/slash/commands/allow-dir.ts
+++ b/src/cli/slash/commands/allow-dir.ts
@@ -27,7 +27,7 @@ export interface GrantManager {
   addReadRoot(absPath: string, source: 'slash' | 'tool', sessionId?: string): void;
   addWriteRoot(absPath: string, source: 'slash' | 'tool', sessionId?: string): void;
   revokeRoot(absPath: string, source: 'slash' | 'tool', sessionId?: string): void;
-  getGrants(): { resolveBase: string | undefined; readRoots: string[]; writeRoots: string[] };
+  getGrants(): { resolveBase: string | undefined; readRoots: string[]; writeRoots: string[]; allowAll?: boolean };
 }
 
 let grantManagerRef: GrantManager | undefined;

--- a/src/cli/slash/commands/bypass.test.ts
+++ b/src/cli/slash/commands/bypass.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the /bypass slash command.
+ *
+ * /bypass toggles the session into/out of `'bypassPermissions'` — it resolves
+ * on/off/bare-toggle intent against the current permissionMode, flips it via
+ * session.setPermissionMode, mirrors stats.permissionMode, and repaints. These
+ * tests verify dispatch + no-op suppression + the mutual-exclusivity replace.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { bypassCmd } from './bypass.js';
+import type { PermissionMode } from '../../../agent/types/sdk-types.js';
+import type { SlashContext } from '../types.js';
+
+function makeCtx(mode: PermissionMode): {
+  ctx: SlashContext;
+  setPermissionMode: ReturnType<typeof vi.fn>;
+  repaint: ReturnType<typeof vi.fn>;
+} {
+  const setPermissionMode = vi.fn().mockResolvedValue(undefined);
+  const repaint = vi.fn();
+  const ctx = {
+    stats: { permissionMode: mode },
+    session: { current: { setPermissionMode } },
+    ui: { repaintStatusLine: repaint },
+    out: { success: vi.fn(), error: vi.fn() },
+  } as unknown as SlashContext;
+  return { ctx, setPermissionMode, repaint };
+}
+
+describe('/bypass command', () => {
+  it('/bypass on from default → enters bypassPermissions, mirrors stats, repaints, continues', async () => {
+    const { ctx, setPermissionMode, repaint } = makeCtx('default');
+    const result = await bypassCmd.handler(ctx, 'on');
+    expect(setPermissionMode).toHaveBeenCalledWith('bypassPermissions');
+    expect(ctx.stats.permissionMode).toBe('bypassPermissions');
+    expect(repaint).toHaveBeenCalled();
+    expect(result).toBe('continue');
+  });
+
+  it('/bypass off from bypassPermissions → restores default', async () => {
+    const { ctx, setPermissionMode } = makeCtx('bypassPermissions');
+    await bypassCmd.handler(ctx, 'off');
+    expect(setPermissionMode).toHaveBeenCalledWith('default');
+    expect(ctx.stats.permissionMode).toBe('default');
+  });
+
+  it('bare /bypass from default → toggles ON', async () => {
+    const { ctx, setPermissionMode } = makeCtx('default');
+    await bypassCmd.handler(ctx, '');
+    expect(setPermissionMode).toHaveBeenCalledWith('bypassPermissions');
+  });
+
+  it('bare /bypass from bypassPermissions → toggles OFF', async () => {
+    const { ctx, setPermissionMode } = makeCtx('bypassPermissions');
+    await bypassCmd.handler(ctx, '');
+    expect(setPermissionMode).toHaveBeenCalledWith('default');
+  });
+
+  it('/bypass on when already bypassPermissions → no-op (does not call setPermissionMode)', async () => {
+    const { ctx, setPermissionMode } = makeCtx('bypassPermissions');
+    const result = await bypassCmd.handler(ctx, 'on');
+    expect(setPermissionMode).not.toHaveBeenCalled();
+    expect(result).toBe('continue');
+  });
+
+  it('/bypass off when already default → no-op flip (no setPermissionMode), surfaces OFF notice', async () => {
+    const { ctx, setPermissionMode } = makeCtx('default');
+    await bypassCmd.handler(ctx, 'off');
+    expect(setPermissionMode).not.toHaveBeenCalled();
+    expect((ctx.out.success as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+  });
+
+  it('/bypass on from plan (mutual exclusivity) → replaces plan with bypassPermissions', async () => {
+    const { ctx, setPermissionMode } = makeCtx('plan');
+    await bypassCmd.handler(ctx, 'on');
+    expect(setPermissionMode).toHaveBeenCalledWith('bypassPermissions');
+    expect(ctx.stats.permissionMode).toBe('bypassPermissions');
+  });
+
+  it('leaves stats.permissionMode unchanged if setPermissionMode rejects', async () => {
+    const { ctx, setPermissionMode } = makeCtx('default');
+    setPermissionMode.mockRejectedValueOnce(new Error('session closing'));
+    await bypassCmd.handler(ctx, 'on');
+    expect(ctx.stats.permissionMode).toBe('default');
+    expect((ctx.out.error as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+  });
+});

--- a/src/cli/slash/commands/bypass.ts
+++ b/src/cli/slash/commands/bypass.ts
@@ -1,0 +1,84 @@
+/**
+ * /bypass — toggle bypassPermissions mode (DANGEROUS).
+ *
+ * Usage:
+ *   /bypass            — toggle bypass mode on/off
+ *   /bypass on         — enter bypass mode
+ *   /bypass off        — exit bypass mode
+ *
+ * Bypass mode is the permission mode `'bypassPermissions'`. It disables the
+ * path-approval prompt AND the handler's path-containment check: filesystem
+ * tools (read_file/write_file/edit_file/list_directory/glob/grep) may touch ANY
+ * path with no confirmation. This is the agent-afk equivalent of Claude Code's
+ * `--dangerously-skip-permissions`.
+ *
+ * It does NOT suppress `ask_question` — that is the model choosing to ask you a
+ * substantive question, a different axis from path permission. If you want the
+ * agent to ask less, adjust posture in AFK.md, not here.
+ *
+ * Mutual exclusivity: bypass, AFK (`'autonomous'`), and plan (`'plan'`) share
+ * the single `permissionMode` field, so `/bypass on` from any of them replaces
+ * the mode. `/bypass off` restores `'default'` (containment + prompts back on).
+ *
+ * Scope: a REPL affordance. Other surfaces enable bypass via the
+ * `--dangerously-skip-permissions` flag or the `permissionMode` config key.
+ * The daemon sets it directly (no human to prompt).
+ */
+
+import { palette } from '../../palette.js';
+import type { SlashCommand, SlashContext, SlashResult } from '../types.js';
+
+const ON_NOTICE =
+  palette.warning('⚠ bypass mode ON') +
+  palette.dim(
+    ' — path-approval prompts OFF; the agent can read/write ANY path on this ' +
+    'machine with no confirmation. Run /bypass off to restore containment. ' +
+    '(Does not affect ask_question.)',
+  );
+
+const OFF_NOTICE =
+  palette.success('○ bypass mode OFF') +
+  palette.dim(' — default permissions restored (path containment + prompts back on)');
+
+export const bypassCmd: SlashCommand = {
+  name: '/bypass',
+  usage: '/bypass [on|off]',
+  summary: 'Toggle bypass mode — skip path-approval prompts (DANGEROUS: read/write anywhere)',
+  hint:
+    'Disable path-approval prompts AND path containment for filesystem tools — ' +
+    'the agent can touch any path with no confirmation. The agent-afk equivalent ' +
+    'of --dangerously-skip-permissions. Does not affect ask_question. /bypass off restores containment.',
+  async handler(ctx: SlashContext, args: string): Promise<SlashResult> {
+    const argLower = args.trim().toLowerCase();
+    const isOn = ctx.stats.permissionMode === 'bypassPermissions';
+    const desired =
+      argLower === 'on' ? true :
+      argLower === 'off' ? false :
+      !isOn;
+
+    if (desired && isOn) {
+      // Already on — suppress the no-op success line for ergonomics.
+      return 'continue';
+    }
+    if (!desired && !isOn) {
+      // Already off — surface the affordance with a no-op toggle.
+      ctx.out.success(OFF_NOTICE);
+      return 'continue';
+    }
+
+    try {
+      await ctx.session.current.setPermissionMode(desired ? 'bypassPermissions' : 'default');
+      ctx.stats.permissionMode = desired ? 'bypassPermissions' : 'default';
+      ctx.ui.repaintStatusLine();
+      // Use the error channel for the ON notice so the warning is visually
+      // prominent (it is a high-consequence, easy-to-forget mode).
+      if (desired) ctx.out.error(ON_NOTICE);
+      else ctx.out.success(OFF_NOTICE);
+    } catch (err) {
+      ctx.out.error(
+        `Could not toggle bypass mode: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return 'continue';
+  },
+};

--- a/src/cli/slash/index.ts
+++ b/src/cli/slash/index.ts
@@ -11,6 +11,7 @@ import { coreCommands } from './commands/core.js';
 import { infoCommands } from './commands/info.js';
 import { planCmd } from './commands/plan.js';
 import { afkCmd } from './commands/afk.js';
+import { bypassCmd } from './commands/bypass.js';
 import { todoCmd } from './commands/todo.js';
 import { saveCmd } from './commands/save.js';
 import { nameCmd } from './commands/name.js';
@@ -40,6 +41,7 @@ export function registerAll(): void {
   for (const cmd of infoCommands) register(cmd);
   register(planCmd);
   register(afkCmd);
+  register(bypassCmd);
   register(todoCmd);
   register(saveCmd);
   register(nameCmd);

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -29,8 +29,8 @@ export interface StatusLineFields {
   contextSparkline?: string;
   /**
    * Current REPL permission mode. Renders a never-dropped indicator: `● plan`
-   * (plan mode, warning tone) or `◐ AFK` (autonomous/AFK mode, info tone).
-   * `'default'` and other modes render no indicator.
+   * (plan mode, warning tone), `◐ AFK` (autonomous/AFK mode, info tone), or
+   * `⚠ BYPASS` (bypassPermissions, warning tone). `'default'` renders none.
    */
   permissionMode?: PermissionMode;
   /**
@@ -366,6 +366,8 @@ export class StatusLine {
       parts.push({ text: palette.warning('● plan') }); // never drop
     } else if (f.permissionMode === 'autonomous') {
       parts.push({ text: palette.info('◐ AFK') }); // never drop
+    } else if (f.permissionMode === 'bypassPermissions') {
+      parts.push({ text: palette.warning('⚠ BYPASS') }); // never drop
     }
 
     if (f.contextPct !== undefined) {


### PR DESCRIPTION
## Problem

Two issues, surfaced from a user report ("everything says permissions default to bypass but I always get prompts in the CLI"):

1. **`bypassPermissions` was near-inert.** There is no per-tool approval flow in agent-afk; the only runtime effect of bypass was a `console.warn` in the bash handler and a `get_runtime_state` label. It did **not** suppress the path-approval prompt (the prompt users actually hit).
2. **No way to enable it interactively, and stale docs.** Bypass was only set by the daemon (hard-coded); docs claimed bypass-by-default and advertised an unwired `--permission-mode` flag.

## What this does

Makes `bypassPermissions` actually disable path containment + the path-approval prompt, and adds three ways to turn it on.

**Core mechanism** (`b320187`): an `allowAll` switch threaded from the session permission mode through the single containment chokepoint.
- `_cwd-utils.ts`: `resolveAndContain` + `wouldBeRestricted` short-circuit on `context.allowAll` — both the handler's containment throw AND the path-approval prompt vanish together (they share this code, so they stay in sync).
- `SessionToolDispatcher`: `allowAll` opt → per-call context + `getGrants()`, sampled fresh per call (a live toggle takes effect next tool call).
- Both providers' `buildDispatcher` derive `allowAll = permissionMode === 'bypassPermissions'` and track `_currentPermissionMode` so the provider's `getGrants()` — read by the path-approval hook — stays in sync with the dispatcher.

**`/bypass` REPL toggle + badge** (`35c392b`): `/bypass [on|off]` flips the live permission mode (mutually exclusive with `/plan` and `/afk`); a never-dropped `⚠ BYPASS` status-line badge keeps a dangerous mode visible.

**Config key + CLI flag** (`2de4171`): `"permissionMode": "bypassPermissions"` in `afk.config.json` (validated on load — invalid strings ignored) and `--dangerously-skip-permissions` on `afk`/`afk chat` + `afk interactive`. Resolution is flag > config > default; threaded into the `AgentSession` construction on both surfaces. The model-swap closure preserves the live mode (a `/bypass` toggle survives a mid-session model swap).

**Docs** (`44067ca`): corrected the stale bypass-by-default claims (README, architecture.md), removed the unwired `--permission-mode` flag line, fixed the false Telegram "full tool access via bypass" claim, and documented the three enablement paths.

## Notes / caveats

- Bypass quiets **path-approval**, not `ask_question` — that's the model choosing to ask you something, a separate axis. Documented in `/bypass` help + README.
- Already active for the `afk daemon` (which sets `bypassPermissions`): it removes the out-of-root auto-deny that previously blocked the daemon.
- `AFK_DISABLE_PATH_APPROVAL=1` remains the process/CI escape hatch; `bypassPermissions` is the clean per-session user mode.

## Verification

- `pnpm lint` clean (rebased onto current `main`).
- Targeted tests pass: `_cwd-utils`, `path-approval-hook`, `/bypass`, `dispatcher` (110 tests), plus config loading (the lone config.test failure is a pre-existing MLX slot-binding env artifact, unrelated).
- Full `pnpm test` is unreliable in my local env due to a pre-existing `memory.db` schema v3 vs build v2 mismatch (not introduced here); CI runs against a clean state dir.

Pairs with #218 (forked sub-agents non-interactive). Independent of it.