### PR TITLE
feat(permissions): default to bypass mode for new installs

### DIFF
--- a/.afk/plans/default-permission-mode-bypass.md
+++ b/.afk/plans/default-permission-mode-bypass.md
@@ -1,0 +1,47 @@
+# Default permission mode → bypass (for new installs, changeable, sticky)
+
+## Goal
+Make `bypassPermissions` the default permission mode for the human-driven CLI
+surfaces. A fresh install (no `permissionMode` in `afk.config.json`) runs
+`afk chat` / `afk interactive` in bypass — path containment + the path-approval
+prompt are off — and stays that way every session until the operator changes it.
+Keep it changeable everywhere it already is, and add a sanctioned config-set path.
+
+## History that constrains this
+`git` comments reference "the default flip in C2 (from 'bypassPermissions' to
+'default')" — bypass *was* the session-layer default and was deliberately
+flipped to `'default'` for safety. The daemon (`scheduler.ts:442`) and Telegram
+(`telegram.ts:348,391`) explicitly depend on the post-C2 `'default'`
+session-layer fallback. So the re-flip must NOT touch the deep session layer —
+only the CLI config-resolution layer.
+
+## Layered default model (precise)
+- `afk chat`, `afk interactive` (REPL): **bypassPermissions** (NEW) — both read
+  `loadConfig().permissionMode`.
+- Telegram: **default** (unchanged) — omits `permissionMode`; hook-enforced.
+- Daemon: **bypassPermissions** (unchanged) — set explicitly.
+- Library `new AgentSession(...)` + subagents inheriting nothing: **default**
+  (unchanged) — deep `?? 'default'` fallback in `session-setup.ts:48`.
+
+## Changes
+1. `src/cli/config.ts`
+   - Add `export const DEFAULT_CLI_PERMISSION_MODE: PermissionMode = 'bypassPermissions'`.
+   - `loadConfig()` merge: `permissionMode: merged.permissionMode ?? DEFAULT_CLI_PERMISSION_MODE`
+     (was a conditional spread that left it undefined).
+   - Add `export function resolveCliPermissionMode()` — reads
+     `loadJsonConfig().config.permissionMode ?? DEFAULT_CLI_PERMISSION_MODE`
+     (no throw risk; for display surfaces).
+2. `src/config/settable-keys.ts` — add `permissionMode` to `CONFIG_KEY_SPECS`
+   (tier `human`, type `enum`: default|plan|autonomous|bypassPermissions). Human-tier
+   ⇒ `afk config set` works; the `config_set` agent tool is refused (no self-escalation).
+3. Honest displays (drop hardcoded bypass-on; read resolved mode):
+   - `src/cli/commands/status.ts` (JSON `bypass` + `permissionMode`; text panel).
+   - `src/cli/commands/config-command.ts` (JSON `bypass` + `permissionMode`; text line).
+   - `src/cli/slash/commands/config-doctor.ts` (`bypass perms` line).
+4. Help/docs accuracy: `chat.ts` + `interactive.ts` flag help; README.md
+   "A note on permissions"; docs/architecture.md "Bypass permissions"; docs/reference.md.
+5. Tests: config default + override; permissionMode settable-key tier/validation;
+   display reflects mode.
+
+## Verification
+`pnpm lint` clean; `pnpm test` green (only the 2 known pre-existing env fails).

--- a/README.md
+++ b/README.md
@@ -155,9 +155,14 @@ Aliases: `afk c` → `chat`, `afk i` → `interactive`, `afk s` → `status`.
 
 `afk` does not prompt before each tool call — there is no per-tool approval flow. Claude runs bash, reads and writes files, fetches URLs, and calls MCP servers without asking each time. This is intentional — `afk` is built for unattended work, where a permission prompt with no human in front of it is just a wedged session.
 
-The one prompt you may hit is **path approval**: when a file tool (read/write/edit/list/glob/grep) targets a path *outside* the session's working directory, `afk` asks before allowing it. Pre-authorize paths with `/allow-dir <path>` (or answer "persist" at the prompt to remember them across sessions).
+**New installs default to bypass mode.** `afk chat` and `afk interactive` start in `permissionMode: "bypassPermissions"` when `afk.config.json` sets none — the agent reads and writes **anywhere** with no path-approval prompt. This is the equivalent of Claude Code's `--dangerously-skip-permissions`, on by default; use `afk` only on a machine and account you trust. Bypass does not change `ask_question` — that is the model choosing to ask you something, a separate axis.
 
-To turn path approval off entirely — letting the agent read and write **anywhere** with no prompt — enable **bypass mode** any of three ways: `/bypass` in the REPL (the status line shows `⚠ BYPASS`), the `--dangerously-skip-permissions` flag on `afk`/`afk chat`, or `"permissionMode": "bypassPermissions"` in `afk.config.json`. This is the equivalent of Claude Code's `--dangerously-skip-permissions`; use it only on a machine and account you trust. `afk daemon` runs in bypass mode by default (no human to prompt). Bypass does not change `ask_question` — that is the model choosing to ask you something, a separate axis.
+**To re-enable path containment**, set the mode back any of these ways:
+
+- Persistently: `afk config set permissionMode default` (or `plan`), or `"permissionMode": "default"` in `afk.config.json`. It stays that way until you change it again.
+- For one session: `/bypass off` in the REPL (the status line clears `⚠ BYPASS`).
+
+With containment on (`default`), a file tool (read/write/edit/list/glob/grep) targeting a path *outside* the session's working directory triggers a **path-approval** prompt; pre-authorize paths with `/allow-dir <path>` (or answer "persist" at the prompt to remember them across sessions). Toggle bypass live anytime with `/bypass`. `afk daemon` always runs in bypass (no human to prompt); **Telegram** sessions stay contained (`default`) and rely on hook-based enforcement.
 
 ## Troubleshooting
 

--- a/afk.config.json.example
+++ b/afk.config.json.example
@@ -3,6 +3,14 @@
   "maxTokens": 4096,
   "temperature": 1.0,
   "systemPrompt": "You are a helpful AI assistant.",
+
+  // Permission mode for `afk chat` / `afk interactive`. Omit for the new-install
+  // default of "bypassPermissions": path containment + the path-approval prompt
+  // are OFF, so the agent reads/writes anywhere with no confirmation. Set
+  // "default" to re-enable containment (out-of-root file access prompts), or
+  // "plan" / "autonomous". Telegram + the daemon ignore this key (own posture).
+  // "permissionMode": "default",
+
   "daemon": {
     "task": "/forge-friction --auto",
     "taskId": "default"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,16 +120,27 @@ Markers never leak back into stored history — `cache-policy.ts` clones-and-sta
 
 ## Bypass permissions
 
-By default, `agent-afk` runs in permission mode `'default'`: tools execute without a per-tool approval prompt, but a file tool touching a path **outside the session's granted roots** triggers a path-approval prompt (and out-of-root access stays contained until granted). There is no per-tool "allow this bash command?" flow.
+Permission mode `'default'` runs tools without a per-tool approval prompt, but a file tool touching a path **outside the session's granted roots** triggers a path-approval prompt (and out-of-root access stays contained until granted). There is no per-tool "allow this bash command?" flow.
 
 **Bypass mode** (`permissionMode: 'bypassPermissions'`) disables path containment and the path-approval prompt entirely — filesystem tools may read/write any path with no confirmation:
 
 - Skips path-approval prompts; disables out-of-root containment
 - Allows fully automated workflows
-- Enable with `/bypass` in the REPL (status line shows `⚠ BYPASS`); the `afk daemon` sets it directly for unattended work
+- Enable with `/bypass` in the REPL (status line shows `⚠ BYPASS`)
 - Does **not** affect `ask_question` (the model asking you a question is a separate axis)
 
-This is intentional — `agent-afk` is built for unattended work, where a permission prompt with no human in front of it just wedges the session. Use on a machine and account you trust.
+### Default mode by surface
+
+The effective default is resolved per surface, not in one global constant:
+
+| Surface | Default mode | Where it's set |
+|---------|--------------|----------------|
+| `afk chat`, `afk interactive` (REPL) | **`bypassPermissions`** | `DEFAULT_CLI_PERMISSION_MODE` in `src/cli/config.ts` — the `loadConfig()` resolution layer that both surfaces read. An `afk.config.json` `permissionMode` key overrides it. |
+| Telegram | `default` | `src/telegram.ts` omits `permissionMode`; relies on hook-based enforcement + the operator's `allowedTools`. |
+| `afk daemon` | `bypassPermissions` | `src/agent/daemon/scheduler.ts` sets it explicitly (no human to prompt). |
+| Embedded `new AgentSession(...)` / subagents inheriting no mode | `default` | The session-layer `?? 'default'` fallback in `src/agent/session/session-setup.ts`. |
+
+So the **CLI surfaces are bypass-by-default for new installs** (built for unattended work, where a permission prompt with no human in front of it just wedges the session — use on a machine and account you trust), while Telegram, the embedding API, and uninitialised subagents stay contained. Change the CLI default with `afk config set permissionMode default` (persistent) or `/bypass` (live, one session).
 
 ### Default allowed tools
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -68,7 +68,7 @@ All commands support `--format json` where machine-readable output makes sense (
 --max-turns <n>           # safety rail (default 100)
 --max-budget-usd <n>
 --task-budget <tokens>
---dangerously-skip-permissions  # bypass mode: skip path-approval prompts (read/write anywhere)
+--dangerously-skip-permissions  # force bypass mode (already the CLI default for new installs); disable with `afk config set permissionMode default`
 --no-update-check         # suppress startup update check
 --dump-prompt <path>      # write resolved system prompt to file (provenance included)
 ```

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -151,7 +151,7 @@ export function registerChatCommand(program: Command): void {
     .option('--session-id <uuid>', 'Assign a specific UUID to this session (creates new; errors if already exists)')
     .option('--post <targets>', 'Headless publish of the final assistant message: github, telegram, or github,telegram')
     .option('--post-pr <ref>', 'PR number, URL, or branch for --post github (defaults to the current-branch PR)')
-    .option('--dangerously-skip-permissions', 'Bypass mode: skip path-approval prompts; the agent may read/write ANY path with no confirmation (permissionMode=bypassPermissions). Does not affect ask_question.')
+    .option('--dangerously-skip-permissions', 'Force bypass mode (already the default for new installs): skip path-approval prompts; read/write ANY path with no confirmation (permissionMode=bypassPermissions). Disable persistently with `afk config set permissionMode default`. Does not affect ask_question.')
     .action(async (rawMessage: string | undefined, options: {
       model: AgentModelInput;
       stream: boolean;
@@ -577,10 +577,11 @@ export function registerChatCommand(program: Command): void {
           // handler is installed, so ask_question can only auto-decline. Strip
           // it so the model proceeds on an assumption instead of wasting a turn.
           isNonInteractive: true,
-          // Bypass mode: --dangerously-skip-permissions wins; else the
-          // afk.config.json `permissionMode` key (validated in loadConfig).
-          // Omitted entirely when neither is set so the session defaults to
-          // 'default' at the session layer.
+          // Permission mode: --dangerously-skip-permissions forces bypass; else
+          // the resolved afk.config.json `permissionMode` (loadConfig now always
+          // returns one — DEFAULT_CLI_PERMISSION_MODE = bypass for new installs,
+          // overridable by the config key). Always defined, so chat never falls
+          // through to the session-layer 'default'.
           ...(options.dangerouslySkipPermissions
             ? { permissionMode: 'bypassPermissions' as const }
             : cliConfig.permissionMode !== undefined

--- a/src/cli/commands/config-command.ts
+++ b/src/cli/commands/config-command.ts
@@ -24,6 +24,7 @@ import { readFileSync } from 'fs';
 import { env } from '../../config/env.js';
 import { palette } from '../palette.js';
 import { providerForModel } from '../../agent/providers/index.js';
+import { resolveCliPermissionMode } from '../config.js';
 import { promptSecret } from '../../utils/prompt-secret.js';
 import { classifyEnvKey } from '../../config/settable-keys.js';
 import {
@@ -79,6 +80,11 @@ export function registerConfigCommand(program: Command): void {
           : 'CODEX_API_KEY'
         : null;
 
+      // Effective CLI permission mode (afk chat / interactive). New-install
+      // default is bypass; an afk.config.json `permissionMode` key overrides.
+      const permissionMode = resolveCliPermissionMode();
+      const bypassEnabled = permissionMode === 'bypassPermissions';
+
       if (options.format === 'json') {
         console.log(JSON.stringify({
           model,
@@ -89,7 +95,8 @@ export function registerConfigCommand(program: Command): void {
           },
           thinking: env.AFK_THINKING || null,
           effort: env.AFK_EFFORT || null,
-          bypass: true,
+          permissionMode,
+          bypass: bypassEnabled,
           raw_env: {
             AFK_MODEL: env.AFK_MODEL ?? null,
             AFK_THINKING: env.AFK_THINKING ?? null,
@@ -122,9 +129,14 @@ export function registerConfigCommand(program: Command): void {
         const effortVal = env.AFK_EFFORT || '(unset — SDK default)';
         console.log(`  Effort: ${palette.info(effortVal)}`);
 
-        console.log(`  Bypass Permissions: ${palette.warning('true (enabled)')}`);
+        console.log(
+          `  Permission Mode: ${bypassEnabled
+            ? palette.warning(`${permissionMode} (bypass — path containment off)`)
+            : palette.info(`${permissionMode} (path containment on)`)}`,
+        );
 
         console.log(palette.meta('\n  Edit config:'));
+        console.log(palette.meta('    afk config set permissionMode default  # re-enable path containment'));
         console.log(palette.meta('    afk config set <key> <value>      e.g. afk config set model opus'));
         console.log(palette.meta('    afk config env set <KEY> [value]  e.g. afk config env set AFK_EFFORT high'));
         console.log(palette.meta('    afk config get [key] / afk config env get [key]'));

--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -185,7 +185,7 @@ export function registerInteractiveCommand(program: Command): void {
     )
     .option('--provider <name>', "Provider to use: anthropic|anthropic-direct|openai|openai-compatible. Default: auto-selected by model")
     .option('--dump-prompt [path]', 'Dump resolved SDK prompt+options+provenance to file (default: ~/.afk/logs/prompt-dump-<ISO>.json) or "stderr"')
-    .option('--dangerously-skip-permissions', 'Start in bypass mode: skip path-approval prompts; the agent may read/write ANY path with no confirmation. Toggle live with /bypass. Does not affect ask_question.')
+    .option('--dangerously-skip-permissions', 'Force bypass mode (already the default for new installs): skip path-approval prompts; read/write ANY path with no confirmation. Toggle live with /bypass; disable persistently with `afk config set permissionMode default`. Does not affect ask_question.')
     .option(
       '--mcp-config <path>',
       'Path to an additional MCP config file (highest priority — merges over ~/.afk/config/mcp.json, project-local .mcp.json, and plugin-contributed configs). File format identical to mcp.json.',

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -504,9 +504,11 @@ export async function bootstrapSession(
     reseedStatsFromStored(stats, resumeTarget.stored, resumeTarget.resumeId);
   }
   // Initial permission mode: --dangerously-skip-permissions wins, else the
-  // afk.config.json `permissionMode` key (validated in loadConfig). Stamped on
-  // stats so the status-line badge + the plan/AFK/bypass gate getters reflect it
-  // from turn 1; the session is constructed with the same value via sharedDeps.
+  // resolved afk.config.json `permissionMode` (loadConfig now always returns one
+  // — DEFAULT_CLI_PERMISSION_MODE = bypass for new installs, overridable by the
+  // config key). Stamped on stats so the status-line badge + the plan/AFK/bypass
+  // gate getters reflect it from turn 1; the session is constructed with the same
+  // value via sharedDeps. The `!== undefined` guard is retained defensively.
   const initialPermissionMode = options.dangerouslySkipPermissions
     ? ('bypassPermissions' as const)
     : cliConfig.permissionMode;

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -6,6 +6,7 @@ import { AgentSession } from '../../agent/session.js';
 import { providerForModel } from '../../agent/providers/index.js';
 import { statusPanel } from '../render.js';
 import { getApiKeyForModel, getModel, getApiKey, getCodexApiKey } from '../shared-helpers.js';
+import { resolveCliPermissionMode } from '../config.js';
 
 export function registerStatusCommand(program: Command): void {
   program
@@ -35,6 +36,11 @@ export function registerStatusCommand(program: Command): void {
 
         spinner.succeed(`${provider} provider reachable`);
 
+        // Effective new-install/default permission mode for the CLI surfaces
+        // (afk chat / interactive). Read once; both output formats reflect it
+        // instead of hardcoding bypass-on.
+        const permissionMode = resolveCliPermissionMode();
+
         if (options.format === 'json') {
           const anthropicApiKey = getApiKey();
           const codexApiKey = getCodexApiKey();
@@ -63,9 +69,13 @@ export function registerStatusCommand(program: Command): void {
               },
             },
             model: String(model),
-            bypass: true,
+            permissionMode,
+            bypass: permissionMode === 'bypassPermissions',
           }, null, 2));
         } else {
+          const bypassRow = permissionMode === 'bypassPermissions'
+            ? { label: 'Permissions', value: 'Bypass — path containment off (read/write anywhere)', kind: 'warn' as const }
+            : { label: 'Permissions', value: `Contained — mode: ${permissionMode}`, kind: 'info' as const };
           console.log(
             '\n' +
               statusPanel('Agent AFK · Status', [
@@ -82,7 +92,7 @@ export function registerStatusCommand(program: Command): void {
                   kind: apiKey ? 'ok' : 'warn',
                 },
                 { label: 'Model', value: String(model), kind: 'info' },
-                { label: 'Bypass', value: 'Permissions disabled', kind: 'warn' },
+                bypassRow,
               ]) +
               '\n',
           );

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -6,7 +6,14 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { join } from 'path';
-import { loadConfig, isValidModel, getModelId, _resetConfigCache } from './config.js';
+import {
+  loadConfig,
+  isValidModel,
+  getModelId,
+  _resetConfigCache,
+  resolveCliPermissionMode,
+  DEFAULT_CLI_PERMISSION_MODE,
+} from './config.js';
 import {
   DEFAULT_SLOT_BINDINGS,
   getSlotBindings,
@@ -637,5 +644,74 @@ describe('loadConfig() — interactive.suggestGhost JSON integration', () => {
     });
     const config = loadConfig();
     expect(config.interactive?.suggestGhost).toBeUndefined();
+  });
+});
+
+describe('loadConfig() — permissionMode default (new-install bypass)', () => {
+  const mockedExistsSync = () => vi.mocked(fs.existsSync);
+  const mockedReadFileSync = () => vi.mocked(fs.readFileSync);
+  const cwdConfigJson = join(process.cwd(), 'afk.config.json');
+
+  // Isolate from the dev machine's real afk.config.json / AFK.md: only the
+  // cwd afk.config.json "exists", with the supplied JSON body.
+  function mockConfig(json: unknown): void {
+    mockedExistsSync().mockImplementation((p) => {
+      const s = String(p);
+      if (s === cwdConfigJson) return true;
+      if (s.endsWith('AFK.md') || s.endsWith('afk.config.json')) return false;
+      return realFsModule.__realExistsSync(p as fs.PathLike);
+    });
+    mockedReadFileSync().mockImplementation((p, ...args) => {
+      if (String(p) === cwdConfigJson) return JSON.stringify(json);
+      return (realFsModule.__realReadFileSync as Function)(p, ...args);
+    });
+  }
+
+  beforeEach(() => {
+    _resetConfigCache();
+    process.env.ANTHROPIC_API_KEY = 'test-api-key-12345';
+  });
+
+  afterEach(() => {
+    delete process.env.ANTHROPIC_API_KEY;
+    mockedExistsSync().mockImplementation(realFsModule.__realExistsSync);
+    mockedReadFileSync().mockImplementation(realFsModule.__realReadFileSync);
+    _resetConfigCache();
+  });
+
+  it('defaults to bypassPermissions when afk.config.json sets no permissionMode', () => {
+    mockConfig({});
+    expect(loadConfig().permissionMode).toBe('bypassPermissions');
+    // The exported constant is the single source of truth.
+    expect(DEFAULT_CLI_PERMISSION_MODE).toBe('bypassPermissions');
+    expect(loadConfig().permissionMode).toBe(DEFAULT_CLI_PERMISSION_MODE);
+  });
+
+  it('honors an explicit permissionMode: "default" (re-enable containment)', () => {
+    mockConfig({ permissionMode: 'default' });
+    expect(loadConfig().permissionMode).toBe('default');
+  });
+
+  it('honors an explicit permissionMode: "plan"', () => {
+    mockConfig({ permissionMode: 'plan' });
+    expect(loadConfig().permissionMode).toBe('plan');
+  });
+
+  it('falls back to the bypass default when permissionMode is garbage (invalid ignored)', () => {
+    mockConfig({ permissionMode: 'totally-not-a-mode' });
+    expect(loadConfig().permissionMode).toBe('bypassPermissions');
+  });
+
+  it('an explicit overrides.permissionMode still wins over the default', () => {
+    mockConfig({});
+    expect(loadConfig({ permissionMode: 'default' }).permissionMode).toBe('default');
+  });
+
+  it('resolveCliPermissionMode() returns the bypass default when unset, and the config value when set', () => {
+    mockConfig({});
+    expect(resolveCliPermissionMode()).toBe('bypassPermissions');
+    _resetConfigCache();
+    mockConfig({ permissionMode: 'plan' });
+    expect(resolveCliPermissionMode()).toBe('plan');
   });
 });

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -321,6 +321,26 @@ const DEFAULT_CONFIG: Omit<CliConfig, 'apiKey'> = {
   updatePolicy: 'notify',
 };
 
+/**
+ * Invariant: the CLI-surface default permission mode. When `afk.config.json`
+ * sets no `permissionMode`, the human-driven CLI surfaces (`afk chat` and
+ * `afk interactive`) start in `bypassPermissions` — path containment and the
+ * path-approval prompt are OFF, so the agent reads/writes anywhere with no
+ * confirmation. This is the new-install default and it persists every session
+ * until the operator changes it (`afk config set permissionMode default`, a
+ * `permissionMode` key in afk.config.json, `--dangerously-skip-permissions`, or
+ * the live `/bypass` toggle).
+ *
+ * Scope is deliberately narrow: this default lives at the loadConfig() layer,
+ * which only `afk chat` + `afk interactive` consume via `cliConfig.permissionMode`.
+ * The deeper session-layer fallback stays `'default'` (see
+ * `src/agent/session/session-setup.ts`) so Telegram (which omits permissionMode
+ * and relies on hook-based enforcement), embedded/library `AgentSession` use, and
+ * subagents that inherit no explicit mode all remain contained. The daemon sets
+ * `bypassPermissions` explicitly and is unaffected.
+ */
+export const DEFAULT_CLI_PERMISSION_MODE: PermissionMode = 'bypassPermissions';
+
 // Track if dotenv has been loaded to avoid reloading
 let dotenvLoaded = false;
 
@@ -839,6 +859,19 @@ export function loadTelegramConfig(): NonNullable<CliConfig['telegram']> {
   return loadJsonConfig().config.telegram ?? {};
 }
 
+/**
+ * Resolve the effective CLI permission mode for display / status surfaces:
+ * the afk.config.json `permissionMode` when set, else the new-install default
+ * (`DEFAULT_CLI_PERMISSION_MODE` = bypass). Reads the memoized JSON directly so
+ * it is side-effect-free and never throws on the `local-*`-model guard that the
+ * full `loadConfig` enforces — same rationale as `loadTelegramConfig`. This is
+ * the canonical answer to "what mode would a fresh `afk chat`/`afk i` run in?"
+ * and the single source the status displays read so they stop hardcoding bypass.
+ */
+export function resolveCliPermissionMode(): PermissionMode {
+  return loadJsonConfig().config.permissionMode ?? DEFAULT_CLI_PERMISSION_MODE;
+}
+
 export function loadConfig(overrides?: Partial<CliConfig>): CliConfig {
   const envConfig = loadEnvConfig();
   const { config: jsonConfig, sourcePath: jsonSourcePath, modelsPartial } = loadJsonConfig();
@@ -884,7 +917,9 @@ export function loadConfig(overrides?: Partial<CliConfig>): CliConfig {
     ...(merged.openaiBaseUrl !== undefined ? { openaiBaseUrl: merged.openaiBaseUrl } : {}),
     ...(merged.systemPrompt !== undefined ? { systemPrompt: merged.systemPrompt } : {}),
     ...(systemPromptSource !== undefined ? { systemPromptSource } : {}),
-    ...(merged.permissionMode !== undefined ? { permissionMode: merged.permissionMode } : {}),
+    // New-install default is bypass (DEFAULT_CLI_PERMISSION_MODE); an explicit
+    // afk.config.json / env / override `permissionMode` still wins.
+    permissionMode: merged.permissionMode ?? DEFAULT_CLI_PERMISSION_MODE,
     ...(merged.autoRouting !== undefined ? { autoRouting: merged.autoRouting } : {}),
     ...(merged.daemon !== undefined ? { daemon: merged.daemon } : {}),
     ...(merged.telegram !== undefined ? { telegram: merged.telegram } : {}),

--- a/src/cli/json-output.test.ts
+++ b/src/cli/json-output.test.ts
@@ -63,6 +63,8 @@ describe('CLI JSON output', () => {
       expect(parsed.providers.codex).toHaveProperty('source');
       expect(parsed).toHaveProperty('model');
       expect(parsed).toHaveProperty('bypass');
+      expect(parsed).toHaveProperty('permissionMode');
+      expect(typeof parsed.bypass).toBe('boolean');
     });
   });
 
@@ -95,6 +97,8 @@ describe('CLI JSON output', () => {
       expect(parsed).toHaveProperty('thinking');
       expect(parsed).toHaveProperty('effort');
       expect(parsed).toHaveProperty('bypass');
+      expect(parsed).toHaveProperty('permissionMode');
+      expect(typeof parsed.bypass).toBe('boolean');
       expect(parsed).toHaveProperty('raw_env');
       expect(parsed.raw_env).toHaveProperty('AFK_MODEL');
       expect(parsed.raw_env).toHaveProperty('AFK_THINKING');

--- a/src/cli/slash/commands/config-doctor.ts
+++ b/src/cli/slash/commands/config-doctor.ts
@@ -16,6 +16,7 @@ import { env } from '../../../config/env.js';
 import { palette } from '../../palette.js';
 import { divider } from '../../render.js';
 import { providerForModel } from '../../../agent/providers/index.js';
+import { resolveCliPermissionMode } from '../../config.js';
 import { runDoctorChecks } from '../../commands/doctor-checks.js';
 import type { SlashCommand } from '../types.js';
 
@@ -64,7 +65,12 @@ const configCmd: SlashCommand = {
     out.line(
       `  effort      ${env.AFK_EFFORT ? palette.info(env.AFK_EFFORT) : palette.dim('(unset — SDK default)')}`,
     );
-    out.line(`  bypass perms ${palette.warning('true (enabled)')}`);
+    const permissionMode = resolveCliPermissionMode();
+    out.line(
+      `  perm mode   ${permissionMode === 'bypassPermissions'
+        ? palette.warning(`${permissionMode} (bypass — containment off)`)
+        : palette.info(`${permissionMode} (containment on)`)}`,
+    );
 
     out.line();
     out.line(palette.bold('Environment variables'));

--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -144,6 +144,18 @@ describe('config mutation engine', () => {
       const r = setConfigValue('updatePolicy', 'auto', { filePath: jsonFile, allowHumanOnly: true });
       expect(r.class).toBe('human');
     });
+
+    it('permissionMode: the agent cannot escalate itself to bypass; the human CLI can set it', () => {
+      // config_set (agent tool) never passes allowHumanOnly → refused.
+      expect(() => setConfigValue('permissionMode', 'bypassPermissions', { filePath: jsonFile })).toThrow(
+        HumanOnlyKeyRefused,
+      );
+      // afk config set (human surface) opts in → allowed, validated, persisted.
+      const r = setConfigValue('permissionMode', 'default', { filePath: jsonFile, allowHumanOnly: true });
+      expect(r.class).toBe('human');
+      expect(r.value).toBe('default');
+      expect(JSON.parse(readFileSync(jsonFile, 'utf-8')).permissionMode).toBe('default');
+    });
   });
 
   describe('config: setConfigValue', () => {

--- a/src/config/settable-keys.test.ts
+++ b/src/config/settable-keys.test.ts
@@ -92,6 +92,7 @@ describe('classifyConfigKey / specs', () => {
     expect(classifyConfigKey('systemPrompt')).toBe('human');
     expect(classifyConfigKey('enableShellHooks')).toBe('human'); // trust gate — agent must not flip it
     expect(classifyConfigKey('hooks')).toBe('unknown'); // hooks intentionally not listed (no safe per-key validator)
+    expect(classifyConfigKey('permissionMode')).toBe('human'); // self-escalation vector — agent must not set bypass on itself
     expect(classifyConfigKey('interactive.worktreeBranchPrefix')).toBe('human');
     expect(classifyConfigKey('nonsense.key')).toBe('unknown');
   });
@@ -120,6 +121,15 @@ describe('coerceConfigValue', () => {
     const spec = getConfigKeySpec('updatePolicy')!;
     expect(coerceConfigValue(spec, 'auto')).toEqual({ ok: true, value: 'auto' });
     expect(coerceConfigValue(spec, 'sometimes').ok).toBe(false);
+  });
+  it('permissionMode enum accepts the four modes and rejects others', () => {
+    const spec = getConfigKeySpec('permissionMode')!;
+    expect(spec.tier).toBe('human');
+    expect(coerceConfigValue(spec, 'bypassPermissions')).toEqual({ ok: true, value: 'bypassPermissions' });
+    expect(coerceConfigValue(spec, 'default')).toEqual({ ok: true, value: 'default' });
+    expect(coerceConfigValue(spec, 'plan')).toEqual({ ok: true, value: 'plan' });
+    expect(coerceConfigValue(spec, 'autonomous')).toEqual({ ok: true, value: 'autonomous' });
+    expect(coerceConfigValue(spec, 'yolo').ok).toBe(false);
   });
   it('number arrays accept arrays and csv strings', () => {
     const spec = getConfigKeySpec('telegram.notify.targets')!;

--- a/src/config/settable-keys.ts
+++ b/src/config/settable-keys.ts
@@ -189,8 +189,9 @@ export interface ConfigKeySpec {
  * rewriting its own prompt is recursive-risk), `hooks` (could disable safety
  * hooks), `importFrom` (a trust grant), `daemon.*` (controls autonomous runs),
  * the worktree git-ref fields (CLI-flag-injection sensitive), `telegram.notify.*`
- * (redirecting outbound notifications is an exfiltration vector), and
- * `updatePolicy` (auto self-update is autonomous-code scope-widening).
+ * (redirecting outbound notifications is an exfiltration vector), `updatePolicy`
+ * (auto self-update is autonomous-code scope-widening), and `permissionMode`
+ * (the agent flipping itself to bypassPermissions is privilege escalation).
  */
 export const CONFIG_KEY_SPECS: readonly ConfigKeySpec[] = [
   { path: 'model', tier: 'agent', type: 'string', description: 'Default model id / alias.' },
@@ -216,6 +217,11 @@ export const CONFIG_KEY_SPECS: readonly ConfigKeySpec[] = [
 
   // Human-only (CLI with --allow gate; agent tool refuses).
   { path: 'systemPrompt', tier: 'human', type: 'string', description: 'Operator system-prompt overlay.' },
+  // Session permission mode. Default for new installs (when unset) is
+  // bypassPermissions — path containment + the approval prompt OFF. Human-tier:
+  // the agent must NOT be able to escalate its own permissions (set bypass) via
+  // config_set; only the human CLI (`afk config set permissionMode <mode>`) can.
+  { path: 'permissionMode', tier: 'human', type: 'enum', enumValues: ['default', 'plan', 'autonomous', 'bypassPermissions'], description: 'Session permission mode for afk chat/interactive (human-tier: privilege-escalation vector). Unset → bypassPermissions (new-install default); set `default` to re-enable path containment + the approval prompt.' },
   // enableShellHooks is the TRUST GATE that activates shell hooks at load time
   // (config-loader userGlobalEnabled). Even though the agent cannot define `hooks`,
   // it must not be able to flip the activation gate on its own config — human-only.


### PR DESCRIPTION
## What

Make `bypassPermissions` the **default permission mode** for the human-driven CLI surfaces (`afk chat`, `afk interactive`). A fresh install with no `permissionMode` in `afk.config.json` now starts in **bypass** — path containment and the path-approval prompt are off, the agent reads/writes anywhere — and **stays that way every session until the operator changes it**.

## Why

Requested: default mode = bypass, changeable wherever it's changeable, and for new installs it starts as bypass and remains that way unless the user changes it.

## Where the default lives (layered, by design)

The flip is applied at the `loadConfig()` resolution layer — `DEFAULT_CLI_PERMISSION_MODE` in `src/cli/config.ts` — the **only** layer `afk chat` + `afk interactive` read (via `cliConfig.permissionMode`). The deeper session-layer fallback intentionally **stays `default`**:

| Surface | Default | Note |
|---|---|---|
| `afk chat`, `afk interactive` | **`bypassPermissions`** (new) | overridable by the config key |
| Telegram | `default` (unchanged) | omits the key; hook-based enforcement |
| `afk daemon` | `bypassPermissions` (unchanged) | set explicitly |
| Embedded `new AgentSession(...)` / subagents inheriting nothing | `default` (unchanged) | `session-setup.ts` fallback |

This deliberately does **not** undo the "C2" session-layer hardening that the Telegram + daemon comments depend on — it only changes the CLI-config layer those surfaces don't read.

## Changeable (kept + added)

Still changeable via `--dangerously-skip-permissions`, the `afk.config.json` `permissionMode` key, and the live `/bypass` toggle. **New sanctioned path:** `permissionMode` is now a **human-tier enum** config key, so `afk config set permissionMode default` re-enables containment. Human-tier means the `config_set` agent tool is refused — the agent can't escalate its own permissions.

## Honest status display

`afk status`, `afk config`, and the `/config-doctor` slash command now read the **resolved** mode (`resolveCliPermissionMode()`) instead of hardcoding bypass-on (which had been stale since C2). The JSON outputs gain a `permissionMode` field; `bypass` is now a real boolean.

## Tests

- `loadConfig()`: defaults to bypass when unset, honors explicit `default`/`plan`, falls back on invalid, and respects an `overrides` value; plus `resolveCliPermissionMode()`.
- `permissionMode` settable key: human-tier classification + enum validation.
- `mutate`: agent (`config_set`) **refused**, human CLI **allowed** + persisted.
- `json-output`: status/config expose `permissionMode` + boolean `bypass`.

## Verification

- `pnpm lint` ✓
- `pnpm audit:sdk:check` ✓ (no new SDK symbols)
- Full suite: **9749 passed**, 12 skipped, **2 failed** — both pre-existing env-specific failures unrelated to this change (`config.test.ts` DEFAULT_SLOT_BINDINGS local-MLX bleed; `anthropic-direct.test.ts` compact model-id).

## Docs

README "A note on permissions", `docs/architecture.md` (per-surface default table), `docs/reference.md`, and `afk.config.json.example` updated to describe bypass-as-default and how to re-enable containment.
