### PR TITLE
docs: sync docs website with v4.9–v4.22; add permissions page

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -3,10 +3,10 @@
   "vars": [
     {
       "name": "AFK_ALLOW_PROJECT_MCP",
-      "description": "Allow loading MCP configuration from <cwd>/.mcp.json. Disabled by default — opt-in to mitigate config-injection risks.",
+      "description": "Controls auto-loading of MCP configuration from <cwd>/.mcp.json. Auto-loaded by default — set to 0 to disable (mitigates config-injection risk in shared/CI environments).",
       "type": "boolean",
       "required": false,
-      "example": "1",
+      "example": "0",
       "category": "mcp"
     },
     {

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -107,7 +107,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 
 | Name | Type | Required | Default | Example | Description |
 |------|------|----------|---------|---------|-------------|
-| `AFK_ALLOW_PROJECT_MCP` | boolean |  |  | `1` | Allow loading MCP configuration from <cwd>/.mcp.json. Disabled by default — opt-in to mitigate config-injection risks. |
+| `AFK_ALLOW_PROJECT_MCP` | boolean |  |  | `0` | Controls auto-loading of MCP configuration from <cwd>/.mcp.json. Auto-loaded by default — set to 0 to disable (mitigates config-injection risk in shared/CI environments). |
 
 ## Routing
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -731,10 +731,10 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
   // ── MCP ───────────────────────────────────────────────────────────────────
   {
     name: 'AFK_ALLOW_PROJECT_MCP',
-    description: 'Allow loading MCP configuration from <cwd>/.mcp.json. Disabled by default — opt-in to mitigate config-injection risks.',
+    description: 'Controls auto-loading of MCP configuration from <cwd>/.mcp.json. Auto-loaded by default — set to 0 to disable (mitigates config-injection risk in shared/CI environments).',
     type: 'boolean',
     required: false,
-    example: '1',
+    example: '0',
     category: 'mcp',
   },
 

--- a/website/content/docs/configuration/browser.mdx
+++ b/website/content/docs/configuration/browser.mdx
@@ -71,7 +71,7 @@ All browser environment variables are optional.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AFK_BROWSER_HEADLESS` | surface-aware | `1` forces headless; `0` forces headed. Default is headed for REPL, headless for daemon/subagent/telegram. |
+| `AFK_BROWSER_HEADLESS` | surface-aware | `1` forces headless; `0` forces headed. Default is headed for the interactive REPL, headless for the `daemon`, `subagent`, `telegram`, and `afk` surfaces. |
 | `AFK_BROWSER_ALLOWED_DOMAINS` | (empty — permissive) | Comma-separated host globs. Non-matching navigation is blocked. |
 | `AFK_BROWSER_BLOCKED_DOMAINS` | (empty) | Comma-separated host globs. Matching navigation is blocked regardless of the allowlist. |
 | `AFK_BROWSER_DOM_SNAPSHOTS` | off | `1` writes a gzipped DOM snapshot per `browser_act` to `~/.afk/state/witness/<sid>/browser/dom-snapshots/`. |

--- a/website/content/docs/configuration/environment-variables.mdx
+++ b/website/content/docs/configuration/environment-variables.mdx
@@ -27,7 +27,7 @@ All environment variables recognized by `agent-afk` are listed here, grouped by 
 | `AFK_DISABLE_PROMPT_CACHE` | boolean | Disable Anthropic prompt caching when set to 1/true/yes/on. Unset = caching enabled. | `0` |
 | `AFK_EFFORT` | string | Effort hint guiding adaptive-thinking depth, forwarded as Anthropic output_config.effort (model-gated; ignored where unsupported). Accepts low \| medium \| high \| xhigh \| max. | — |
 | `AFK_LOCAL_BASE_URL` | string | Base URL for a self-hosted Anthropic-compatible server. When set, routes traffic away from api.anthropic.com. | — |
-| `AFK_MAX_BUDGET_USD` | number | Per-turn USD budget ceiling. Aborts the turn when projected spend would exceed this. | `5.00` |
+| `AFK_MAX_BUDGET_USD` | number | Cumulative USD budget ceiling for the session. Aborts the turn when the running cost crosses this. | `5.00` |
 | `AFK_MAX_OUTPUT_TOKENS` | number | Cap on output tokens per turn. Falls back to provider default when unset. | — |
 | `AFK_MAX_TOKENS` | number | Cap on total tokens per turn (input + output). Default 4096. | `4096` |
 | `AFK_MODEL` | string | Default model for agent turns. Accepts slot names (local, small, medium, large), legacy aliases (opus, sonnet, haiku), the fixed-id fable alias (Claude Fable 5), or full model IDs. | `sonnet` |
@@ -56,6 +56,7 @@ All environment variables recognized by `agent-afk` are listed here, grouped by 
 | `AFK_TEMPERATURE` | number | Numeric temperature override for model sampling. Provider default if unset. | — |
 | `AFK_THINKING` | string | Extended-thinking mode. Accepts adaptive \| disabled \| enabled:&lt;N&gt; \| enabled:max. Defaults to the model-appropriate mode when unset (adaptive on current models). | `adaptive` |
 | `AFK_TIMEOUT_MS` | number | Per-turn timeout in milliseconds. Provider/SDK default if unset. | — |
+| `AFK_VISION_MODELS` | string | Comma-separated override for image (vision) capability detection on the openai-compatible provider. Each token force-enables a model id by exact or substring match; prefix with `!` to force-disable. Built-in detection already covers gpt-4o/4.1/5.x, o1/o3/o4-mini, Claude, and common VL families. | — |
 | `CLAUDE_MODEL` | string | Legacy alias for AFK_MODEL — supported for back-compat with pre-AFK_* deployments. | — |
 
 
@@ -84,7 +85,7 @@ All environment variables recognized by `agent-afk` are listed here, grouped by 
 
 | Variable | Type | Description | Default |
 | --- | --- | --- | --- |
-| `AFK_ALLOW_PROJECT_MCP` | boolean | Allow loading MCP configuration from &lt;cwd&gt;/.mcp.json. Disabled by default — opt-in to mitigate config-injection risks. | — |
+| `AFK_ALLOW_PROJECT_MCP` | boolean | Controls auto-loading of MCP configuration from &lt;cwd&gt;/.mcp.json. Auto-loaded by default — set to `0` to disable (mitigates config-injection risk in shared/CI environments). | auto-load |
 
 
 ## Daemon
@@ -137,8 +138,13 @@ All environment variables recognized by `agent-afk` are listed here, grouped by 
 
 ## Process
 
+These three tune the path-approval and bash-restriction hooks — see [Permissions](/configuration/permissions).
+
 | Variable | Type | Description | Default |
 | --- | --- | --- | --- |
+| `AFK_DISABLE_BASH_INTERPRETER_GUARD` | boolean | Skip only the bash interpreter-eval denylist (`python -c`, `node -e`, `sh -c`, ...) on interactive surfaces, leaving the rest of path-approval intact. The restricted-root check is unaffected. Wins over AFK_FORCE_BASH_INTERPRETER_GUARD. | `0` |
+| `AFK_DISABLE_PATH_APPROVAL` | boolean | Skip the path-approval + bash-restriction hooks entirely — wide-open file access for headless flows that need it (CI scripts, batch jobs). | `0` |
+| `AFK_FORCE_BASH_INTERPRETER_GUARD` | boolean | Apply the bash interpreter-eval denylist even on headless surfaces (afk chat, daemon), where it otherwise fails open. Overridden by AFK_DISABLE_BASH_INTERPRETER_GUARD. | `0` |
 | `AFK_SHELL_WRAPPER` | boolean | Set to 1 or true by the optional afk shell wrapper function (installed via `afk shell-init`). Signals that the parent shell has the wrapper active so the post-exit cd can fire. | — |
 | `AGENT_SURFACE` | string | Internal surface marker propagated to subprocesses. Identifies which AFK surface (cli, telegram, daemon) spawned the process. | — |
 | `ASCIINEMA_REC` | boolean | Set to 1 by asciinema rec while a session is being recorded. Triggers capture-mode. | — |

--- a/website/content/docs/configuration/meta.json
+++ b/website/content/docs/configuration/meta.json
@@ -1,1 +1,1 @@
-{"title":"Configuration","pages":["overview","editing-config","api-keys","models-providers","model-slots","afk-md","browser","environment-variables"]}
+{"title":"Configuration","pages":["overview","editing-config","permissions","api-keys","models-providers","model-slots","afk-md","browser","environment-variables"]}

--- a/website/content/docs/configuration/models-providers.mdx
+++ b/website/content/docs/configuration/models-providers.mdx
@@ -138,6 +138,25 @@ export AFK_EFFORT=medium          # low | medium | high | xhigh | max
 as an effort hint (model-gated; ignored where unsupported). Both can also be
 set per-call with `--thinking` and `--effort` flags.
 
+**OpenAI o-series reasoning effort.** For o-series models (`o1`, `o3`, `o3-mini`,
+`o4`, and `provider/o*` IDs), `AFK_EFFORT` maps to the OpenAI `reasoning_effort`
+parameter: `low` → `low`, `medium` → `medium`, and `high`/`xhigh`/`max` → `high`.
+The value is sent on the Chat Completions request (or as `reasoning.effort` on the
+Responses API). It is omitted entirely when `AFK_EFFORT` is unset or the model is
+not o-series.
+
+## Reliability and retries
+
+The openai-compatible provider retries transient failures automatically. Requests
+that fail with `429`, `500`, `502`, `503`, or `529` are retried up to three times
+with exponential backoff (2s → 4s → 8s); both the initial connection and a dropped
+stream get their own retry budget. Non-transient statuses (`400`, `401`, `403`,
+`404`) are surfaced immediately without retrying.
+
+Output-token caps are threaded into the streaming request body: `AFK_MAX_OUTPUT_TOKENS`
+(or the resolved per-model default) is sent as `max_tokens`, or as `max_completion_tokens`
+for o-series models that require it.
+
 ## Debug: what provider is active?
 
 ```bash

--- a/website/content/docs/configuration/permissions.mdx
+++ b/website/content/docs/configuration/permissions.mdx
@@ -1,0 +1,178 @@
+---
+title: "Permissions"
+description: "How agent-afk contains tool access: the default path-approval prompt, bash restrictions, bypass mode, autonomous mode, and the env vars that tune them."
+---
+
+`agent-afk` does **not** prompt before each tool call — there is no per-tool "allow this
+bash command?" flow. The agent runs bash, reads and writes files, fetches URLs, and calls MCP
+servers without asking each time. This is intentional: AFK is built for unattended work, where a
+permission prompt with no human in front of it just wedges the session.
+
+The one boundary it does enforce by default is **path containment**: a file tool that reaches
+*outside* the session's working directory asks for approval before it runs. Everything else about
+permissions is a knob layered on top of that.
+
+## Permission modes
+
+A session runs in one permission mode, set by the `permissionMode` key in `afk.config.json`
+(or the `--dangerously-skip-permissions` flag, which forces `bypassPermissions`).
+
+| Mode | Behavior | Set by |
+|---|---|---|
+| `default` | Path containment + path-approval prompts for out-of-root file access. No per-tool flow. | REPL and Telegram default |
+| `plan` | Read-only investigation; write-class tools are blocked until you approve a plan. | `/plan` in the REPL |
+| `autonomous` | Default containment **plus** a risk gate that blocks high-risk actions, and a remote channel so you can answer prompts from Telegram. | `/afk` in the REPL |
+| `bypassPermissions` | Disables containment and path approval entirely — read/write any path with no prompt. | `/bypass`, `--dangerously-skip-permissions`, or `afk daemon` |
+
+The interactive default is `default`, **not** bypass. Plan and autonomous modes are mutually
+exclusive with each other (they share the one mode field).
+
+## Path-access approval
+
+In `default` mode, six typed file tools are contained to the session's **granted roots**:
+
+```
+read_file   write_file   edit_file   list_directory   glob   grep
+```
+
+The initial granted root is the session's working directory (the `cwd` of the first turn). A tool
+that targets a path *inside* a granted root runs with no prompt. A tool that targets a path
+*outside* every granted root pauses and asks:
+
+| Choice | Effect |
+|---|---|
+| **Once** | Allow this one call; the grant is revoked immediately afterward. |
+| **Session** | Add the path to the granted roots for the rest of this session (in memory only). |
+| **Persist** | Like Session, and also write the grant to disk so future sessions skip the prompt. |
+| **Deny** | Block the call. |
+
+The prompt is delivered through the active elicitation surface — inline in the REPL, or pushed to
+your phone over Telegram.
+
+### Pre-authorizing paths with `/allow-dir`
+
+Rather than wait for a prompt, pre-authorize a directory in the REPL:
+
+```
+/allow-dir ~/Projects/shared-lib       # grant read+write for this session
+/allow-dir --revoke ~/Projects/shared-lib   # revoke a previously granted root
+```
+
+The session's initial working directory is a non-revocable base — `/allow-dir --revoke` cannot
+strip it.
+
+### Persisted grants
+
+Choosing **Persist** (or answering an out-of-root prompt with "persist") records the grant to:
+
+```
+~/.afk/config/permissions.json
+```
+
+Persisted `allow` grants are replayed at the start of every future interactive session, so a path
+you trust once stays trusted. A write-mode grant implies read access (write ⊇ read). The file is
+read fail-soft: if it is missing or corrupt, AFK treats it as empty grants rather than locking you
+out.
+
+<Callout type="info">
+Forked **subagents cannot answer a path prompt** — they have no operator surface of their own. An
+out-of-root access in a subagent is auto-denied with a message telling the subagent to surface the
+requirement to its parent. Pre-authorize the path in the parent (or run in bypass) if a subagent
+needs wider access. See [Subagents](/guides/subagents).
+</Callout>
+
+## Bash restrictions
+
+Alongside path approval, a bash-restriction hook hard-blocks two classes of command on interactive
+surfaces (REPL, Telegram) — no prompt, just a refusal that routes the model back to the typed file
+tools:
+
+- **Interpreter one-liners** — `python -c`, `python3 -c`, `node -e`, `ruby -e`, `perl -e`,
+  `osascript -e`, `sh -c`, `bash -c`, `zsh -c`, `fish -c`, `lua -e`, and the like. These are an
+  easy way to bypass path containment, so they are blocked; the model is told to use `read_file` /
+  `write_file` / `edit_file` (which carry their own per-call approval) instead.
+- **Restricted roots** — commands referencing sensitive paths such as `~/.ssh`, `~/.gnupg`,
+  `~/.aws`, `~/.config/gh`, `~/.netrc`, `~/.password-store`, `~/Library/Application Support`,
+  `/etc/shadow`, and `/etc/sudoers`. A restricted path is allowed only when a granted root already
+  covers it.
+
+On **headless** surfaces (`afk chat`, `afk daemon`) the interpreter denylist *fails open* by
+default — no grant manager is wired, so legitimate automation running `python -c` is not
+hard-blocked with no recourse. Opt headless flows back into the denylist with
+`AFK_FORCE_BASH_INTERPRETER_GUARD=1`.
+
+## Bypass mode
+
+Bypass mode (`permissionMode: 'bypassPermissions'`) turns the containment off entirely: filesystem
+tools may read and write **any** path with no confirmation, and the path-approval prompt never
+fires.
+
+```
+/bypass        # enable bypass for the current REPL session
+/bypass off    # return to default mode
+```
+
+While bypass is active the status line shows a `⚠ BYPASS` badge. From the command line, the
+equivalent is the `--dangerously-skip-permissions` flag on both `afk i` and `afk chat`:
+
+```bash
+afk chat "migrate the schema" --dangerously-skip-permissions
+```
+
+<Callout type="warn">
+Bypass lets the agent read and write anywhere on the machine with no prompt. Use it only on a
+machine and account you trust. To keep changes contained while still running unprompted, prefer an
+isolated git worktree (`afk i -w`) over bypass.
+</Callout>
+
+`afk daemon` runs in bypass mode by default — there is no human present to answer a prompt, so a
+path-approval dialog would simply wedge the run. Bypass does **not** affect `ask_question`: the
+model choosing to ask you something is a separate axis from filesystem containment.
+
+## Autonomous mode & remote supervision
+
+`/afk` puts an interactive session into `autonomous` mode, designed for "start it at the keyboard,
+walk away, supervise from your phone":
+
+```
+/afk        # enable autonomous mode
+/afk off    # return to default mode
+```
+
+Three things switch on together:
+
+- **Posture** — a system-prompt addendum tells the model to act autonomously on reversible work and
+  stop at one-way doors.
+- **Risk gate** — a PreToolUse hook classifies each tool call and blocks high-risk actions
+  (destructive bash, writes escaping the workspace) while allowing safe and medium-risk ones. The
+  gate applies to the whole session tree, including subagents. `send_telegram` is always allowed.
+- **Remote channel** — elicitations and a remote `/abort` are bridged through a per-session ledger,
+  so a watching Telegram daemon can answer a prompt or stop the run from your phone. Ledger records
+  are signed with a per-session HMAC key (`~/.afk/state/sessions/<id>/session.key`, mode `0600`)
+  and verified before the REPL acts on them. The keyboard remains live alongside the remote
+  channel — there is no dependency on the daemon being up.
+
+## Surface defaults
+
+| Surface | Default mode | Notes |
+|---|---|---|
+| REPL (`afk i`) | `default` | Out-of-root file access prompts inline; `/bypass` to disable containment. |
+| Telegram bot | `default` | Same as the REPL; prompts are pushed to your chat. |
+| `afk chat` | `default` | Non-interactive — out-of-root access can't be approved, so it is denied; pass `--dangerously-skip-permissions` for wide-open access. |
+| `afk daemon` | `bypassPermissions` | Unattended; containment off so no prompt can wedge the run. |
+
+## Environment variables
+
+| Variable | Effect | Default |
+|---|---|---|
+| `AFK_DISABLE_PATH_APPROVAL` | `1` skips **both** the path-approval and bash-restriction hooks entirely — wide-open file access for headless flows that need it. | `0` (hooks on) |
+| `AFK_DISABLE_BASH_INTERPRETER_GUARD` | `1` skips only the interpreter-eval denylist; the restricted-root check stays active. Wins over the force flag. | `0` (denylist on for interactive) |
+| `AFK_FORCE_BASH_INTERPRETER_GUARD` | `1` forces the interpreter denylist on even on headless surfaces, where it otherwise fails open. | `0` (headless fails open) |
+| `AFK_WRITE_DENYLIST` | Comma-separated path globs the `write_file` tool always refuses, regardless of mode (including bypass). | — |
+
+## See also
+
+- [Editing Configuration](/configuration/editing-config) — config sensitivity tiers; why
+  credentials and safety keys are human-only.
+- [Unattended Runs](/guides/unattended-runs) — running the daemon and Telegram supervision safely.
+- [Subagents](/guides/subagents) — why forked subagents auto-deny out-of-root access.

--- a/website/content/docs/configuration/permissions.mdx
+++ b/website/content/docs/configuration/permissions.mdx
@@ -83,14 +83,15 @@ needs wider access. See [Subagents](/guides/subagents).
 
 ## Bash restrictions
 
-Alongside path approval, a bash-restriction hook hard-blocks two classes of command on interactive
-surfaces (REPL, Telegram) — no prompt, just a refusal that routes the model back to the typed file
-tools:
+Alongside path approval, a bash-restriction hook blocks two classes of command by default on
+interactive surfaces (REPL, Telegram) — no prompt, just a refusal that routes the model back to the
+typed file tools:
 
 - **Interpreter one-liners** — `python -c`, `python3 -c`, `node -e`, `ruby -e`, `perl -e`,
   `osascript -e`, `sh -c`, `bash -c`, `zsh -c`, `fish -c`, `lua -e`, and the like. These are an
   easy way to bypass path containment, so they are blocked; the model is told to use `read_file` /
-  `write_file` / `edit_file` (which carry their own per-call approval) instead.
+  `write_file` / `edit_file` (which carry their own per-call approval) instead. Lift just this
+  denylist with `AFK_DISABLE_BASH_INTERPRETER_GUARD=1`.
 - **Restricted roots** — commands referencing sensitive paths such as `~/.ssh`, `~/.gnupg`,
   `~/.aws`, `~/.config/gh`, `~/.netrc`, `~/.password-store`, `~/Library/Application Support`,
   `/etc/shadow`, and `/etc/sudoers`. A restricted path is allowed only when a granted root already

--- a/website/content/docs/guides/mcp-plugins.mdx
+++ b/website/content/docs/guides/mcp-plugins.mdx
@@ -109,6 +109,14 @@ In the REPL:
 
 `/mcp auth` reads pending OAuth consent URLs from `~/.afk/state/mcp/server-status.json`. When an MCP server requests OAuth consent (e.g., Supabase re-auth), the REPL prints the server name, message, and URL, then prompts `Continue? [y/N]`.
 
+### Interactive server prompts
+
+Some MCP servers request input mid-session through an elicitation form. On the REPL these render
+inline, and fields with a fixed set of values — `enum` fields and booleans — appear as an
+**arrow-key selector** rather than a free-text prompt (optional fields include a "skip" choice). On
+non-TTY surfaces (daemon, piped input) AFK falls back to a typed prompt. Type `:decline` or
+`:cancel` at any prompt to exit the form.
+
 ### Server failures
 
 Non-fatal by default: a server that fails to connect is reported as a warning and skipped. Mark a server `alwaysLoad: true` in the config to make its failure abort session startup:

--- a/website/content/docs/guides/subagents.mdx
+++ b/website/content/docs/guides/subagents.mdx
@@ -9,6 +9,21 @@ Agent AFK can fork child sessions — subagents — that run isolated tasks in p
 
 Subagents are child sessions that run independently. Each inherits permissions from the parent and runs the same tool surface. What it does not inherit is context — every subagent starts with zero prior conversation.
 
+### Subagents are non-interactive
+
+A forked subagent has no operator surface of its own — it returns findings to its parent, which
+owns the human relationship. So subagents run **non-interactive** by default:
+
+- The `ask_question` tool is stripped from a subagent's toolset entirely — it cannot block on the
+  operator. It must proceed on a stated assumption or return a **Blocked** / **Asking** result to
+  the parent.
+- A path-approval prompt (file access outside the granted roots) is auto-denied rather than
+  surfaced — pre-authorize the path in the parent or run in [bypass mode](/configuration/permissions).
+- MCP elicitations are auto-declined.
+
+The parent session decides what to do with a subagent's Blocked/Asking result — including
+re-dispatching with wider grants or asking you directly.
+
 **Always include in a subagent brief:**
 - Objective
 - Relevant file paths and constraints
@@ -66,7 +81,7 @@ In the REPL, background subagent jobs are surfaced through the `/bgsub` namespac
 /bgsub:join <jobId>    # wait for and return the result
 ```
 
-The status bar at the bottom of the REPL shows running background task counts. `/bg` and `/tasks` also list active background work.
+The status bar at the bottom of the REPL shows running background task counts.
 
 Source: `src/cli/background-status-bar.ts`, `src/cli/commands/interactive/background.js`.
 

--- a/website/content/docs/how-it-works.mdx
+++ b/website/content/docs/how-it-works.mdx
@@ -109,12 +109,18 @@ All AFK state lives under `~/.afk/` — independent of `~/.claude/`:
 
 You can delete `~/.claude/` entirely and Agent AFK still runs.
 
-## Bypass permissions
+## Permissions
 
-By default, Agent AFK enables bypass permissions: no per-tool prompts. The model can run bash,
-read and write files, fetch URLs, and call MCP servers without asking each time. This is intentional
-— `afk` is built for unattended work, where a permission prompt with no human present wedges the
-session.
+Agent AFK does not prompt before each tool call — there is no per-tool approval flow. The model
+runs bash, reads and writes files, fetches URLs, and calls MCP servers without asking each time.
+This is intentional: `afk` is built for unattended work, where a permission prompt with no human
+present wedges the session.
+
+The one boundary enforced in the interactive default mode is **path containment**: a file tool
+reaching *outside* the session's working directory triggers a one-time approval prompt before it
+runs. Bypass mode (`/bypass`, or `--dangerously-skip-permissions`) turns containment off entirely;
+the `afk daemon` runs in bypass by default. See [Permissions](/configuration/permissions) for the
+full model — path approval, bash restrictions, autonomous mode, and the env-var knobs.
 
 Use `afk` on a machine and account you trust. To keep a session's changes contained, run it in an isolated git worktree — your main checkout stays untouched, and the worktree is removed automatically on a clean exit:
 

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -63,7 +63,7 @@ Agent AFK ships blast-radius controls — the guardrails that keep unattended ru
 
 - **Cost guardrails** — `AFK_MAX_BUDGET_USD` (or `--max-budget-usd` on `afk chat`) aborts a turn that would breach the cost ceiling.
 - **Turn limits** — `--max-turns` caps total turns (`afk chat` defaults to 10, `afk i` to 100), preventing runaway sessions.
-- **Bypass permissions** — by default tool calls run without per-tool approval prompts, which is intentional for unattended work.
+- **Path-access approval** — there are no per-tool prompts, but in the default mode a file tool reaching outside the working directory asks before it runs. [Bypass mode](/configuration/permissions) turns containment off for fully unattended work.
 - **Worktree isolation** — `--worktree` creates a git worktree for the session; on clean exit it is removed automatically.
 
 ## Local-first, no phone-home

--- a/website/content/docs/surfaces/repl.mdx
+++ b/website/content/docs/surfaces/repl.mdx
@@ -57,6 +57,16 @@ Type `/` in the REPL to see available commands. Typos are caught automatically �
 | `/limits` | Show rate-limit and budget state |
 | `/debug` | Toggle verbose debug output |
 
+### Permissions
+
+| Command | Description |
+|---|---|
+| `/allow-dir <path>` | Pre-authorize a directory for file tools (`--revoke <path>` to remove a grant) |
+| `/bypass` | Disable path containment entirely (`/bypass off` to restore); shows a `⚠ BYPASS` badge |
+| `/afk` | Enter autonomous mode — risk-gated, with remote answer/abort over Telegram (`/afk off` to exit) |
+
+See [Permissions](/configuration/permissions) for the full model behind these commands.
+
 ### Planning and state
 
 | Command | Description |
@@ -113,6 +123,32 @@ The REPL streams model output token-by-token with markdown rendering. Tool calls
 collapsible lane entries showing the tool name, arguments, and result. Extended thinking renders
 as a summary lane (or live, depending on `--thinking-ui`).
 
+## Type-ahead and queueing
+
+You don't have to wait for the agent to finish a turn before typing your next message. Press
+**Enter** on a non-empty buffer while a turn is in flight and the message is **queued** — the input
+clears so you can draft the next one. The input line shows `[queued]` for one pending message or
+`[N queued]` for several.
+
+Queued messages drain in order (FIFO), one per completed turn. To revise the message you most
+recently queued, press **↑** (Up arrow) on an empty buffer: the last queued message pops back into
+the input as an editable draft (non-destructive). **Backspace does not dequeue** — committed
+type-ahead is only ever recalled for editing with ↑, never silently discarded.
+
+## Usage limits
+
+When your Claude subscription hits its hourly limit mid-session, the REPL shows a usage-limit
+notice rather than failing the turn. By default AFK **auto-resumes** when the limit resets — you
+don't need to retype anything. The notice also lists the actions you can take right now:
+
+- **Switch model** — type `/model <name>` then Enter to continue on a different model.
+- **Switch account** — run `claude login` in any terminal; the session resumes automatically.
+- **Stop waiting** — press **Esc**.
+
+Set `autoResumeOnUsageLimit: false` in `afk.config.json` to opt out of automatic resume (the
+notice then prompts you to resend, switch to API-key billing, or re-auth). The `/limits` command
+shows current rate-limit and budget state at any time.
+
 ## Worktree isolation
 
 `-w` / `--worktree` creates a git worktree for the session. Every bash command and file operation
@@ -146,3 +182,7 @@ startup:
 afk i --resume <session-id>
 afk i --continue              # most recent session in cwd
 ```
+
+`/resume` lists sessions saved from the **current working directory** first — so the picker in a
+project shows that project's sessions, not every session on the machine. When no session was saved
+from the current directory, it falls back to listing all saved sessions.

--- a/website/content/docs/surfaces/telegram.mdx
+++ b/website/content/docs/surfaces/telegram.mdx
@@ -69,8 +69,9 @@ Inside Telegram, the bot recognizes:
 | `/reset` | Clear conversation history and start fresh |
 | `/model opus` | Switch the active model (`opus`, `sonnet`, `haiku`, `fable`) |
 
-Any other message is sent to the session as a regular turn. The bot has full tool access via
-bypass mode — same as the REPL.
+Any other message is sent to the session as a regular turn. The bot runs in the **default**
+permission mode — tools execute without per-tool prompts, and file access outside the working
+directory stays contained, the same as the REPL. See [Permissions](/configuration/permissions).
 
 ## Managing the bot process
 


### PR DESCRIPTION
## Summary

The docs website (`website/content/docs/`) was last synced at **v4.8.1**; HEAD is **v4.22.0**. This refreshes it across everything shipped in between, with every claim verified against code at file:line.

- **New page** `configuration/permissions.mdx` (+ nav wire-in): the permission model end-to-end — path-access approval (6 file tools, granted roots, once/session/persist/deny, `permissions.json`), bash restrictions, bypass mode (`/bypass`, `--dangerously-skip-permissions`), autonomous `/afk` mode + remote supervision, and the env-var knobs.
- **Safety-accuracy fix:** the site claimed bypass-permissions was **on by default**. The interactive default is permission mode `'default'` (path containment + path-approval active); bypass is opt-in, and only the daemon runs bypass. Corrected in `how-it-works.mdx`, `index.mdx`, and `surfaces/telegram.mdx` ("full tool access via bypass mode" → runs in `'default'`). Framing mirrors the merged repo-docs correction in `bed6aa3`.
- **REPL** (`surfaces/repl.mdx`): `/bypass`, `/afk`, `/allow-dir`; type-ahead queueing (Enter to queue, `[N queued]`, ↑ to recall/edit, Backspace does not dequeue); `/resume` cwd-scoping; usage-limit notice (auto-resume + `/model` + `claude login` + Esc — an informational box, **not** an interactive picker).
- **Providers** (`models-providers.mdx`): o-series `reasoning_effort` mapping; retry/backoff (429/500/502/503/529, 3 retries, 2s→4s→8s); `max_tokens`/`max_completion_tokens` threading.
- **Misc:** `browser.mdx` — `afk` surface is headless by default; `guides/subagents.mdx` — forked subagents are non-interactive (`ask_question` stripped, path/MCP elicitations auto-denied) + removed stale phantom `/bg` `/tasks`; `guides/mcp-plugins.mdx` — interactive enum/boolean arrow-key selector.
- **Env reference** (`environment-variables.mdx`): added `AFK_DISABLE_PATH_APPROVAL`, `AFK_DISABLE_BASH_INTERPRETER_GUARD`, `AFK_FORCE_BASH_INTERPRETER_GUARD`, `AFK_VISION_MODELS`; fixed `AFK_MAX_BUDGET_USD` (per-turn → **cumulative-session**) and `AFK_ALLOW_PROJECT_MCP` (Disabled-by-default → **auto-loaded-by-default**, verified at `config-loader.ts:342`). The `AFK_ALLOW_PROJECT_MCP` fix is also applied at source in `src/config/env.ts`, with `docs/env-registry.{json,md}` regenerated (`pnpm scan:env:check` in sync).

## Test results

- `pnpm lint` (`tsc --noEmit`, strict): **pass**
- website `npm run typecheck` + `npm run build`: **pass** (30 static pages; `permissions.mdx` rendered)
- `pnpm scan:env:check`: **in sync** (114 vars)
- `pnpm test` (vitest): **9741 passed / 12 skipped / 2 failed**. The 2 failures are pre-existing, environment-dependent (local model-slot config + compact-model resolution bleeding into `src/cli/config.test.ts` and `src/agent/providers/anthropic-direct.test.ts`); neither touches files in this diff (docs MDX + the `AFK_ALLOW_PROJECT_MCP` description string + generated registry).

## Verification

`--verify` ran an adversarial read-only verifier that re-derived 10 load-bearing claims from source. **8 CONFIRM, 2 REFINE, 0 CONTRADICT:**

- CONFIRM: REPL default = `'default'` (`bootstrap.ts:511`); Telegram = `'default'` (`session-manager.ts:321`); daemon = `bypassPermissions` (`scheduler.ts:442`); project `.mcp.json` auto-loads unless `AFK_ALLOW_PROJECT_MCP='0'` (`config-loader.ts:342`); `AFK_MAX_BUDGET_USD` cumulative (`env.ts:195`); retry codes + o-series effort mapping (`openai-compatible/query.ts:109,285`); subagents non-interactive strip `ask_question` (`subagent.ts:392`); `afk` surface headless (`browser/config.ts:67`).
- REFINE (claim 4): "granted roots" is a user-facing term; the code uses `readRoots`/`writeRoots` — kept, defined inline as "the session's working directory."
- REFINE (claim 5): "hard-blocks" was tightened to "blocks … by default" + an inline pointer to `AFK_DISABLE_BASH_INTERPRETER_GUARD=1` (commit `792d3af`).

## Out of scope

- The two pre-existing failing tests above (environmental; unrelated to this diff).
- Repo-side Markdown docs (`docs/`, `README.md`) — this PR targets the docs website; the only source touch is the verified `AFK_ALLOW_PROJECT_MCP` description fix that keeps the env registry honest.