### PR TITLE
fix(cli): render non-empty fenced code blocks not preceded by a blank line

### DIFF
--- a/src/cli/markdown-stream-fence-boundary.test.ts
+++ b/src/cli/markdown-stream-fence-boundary.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { StreamingMarkdownRenderer } from './markdown-stream.js';
+import { findBlockBoundary } from './markdown-stream-format.js';
+
+// Strip ANSI for readable assertions.
+const stripAnsi = (s: string): string =>
+  // eslint-disable-next-line no-control-regex
+  s.replace(/\u001b\[[0-9;]*m/g, '');
+
+function renderNonTTY(chunks: string[]): string {
+  const r = new StreamingMarkdownRenderer({ indent: '' });
+  for (const c of chunks) r.push(c);
+  return stripAnsi(r.getCommittedOutput());
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Regression: a NON-EMPTY fenced code block that is NOT preceded by a blank
+// line (the opening fence directly follows a paragraph, e.g. "run:\n```\ncmd")
+// used to render as TWO "(empty code block)" placeholders sandwiching the body
+// as a stray paragraph. Root cause: findBlockBoundary's closing-fence regex
+// could not distinguish an opening fence from a closing one, so it committed
+// the block at the OPENER — orphaning the never-closed fence (→ empty block)
+// and leaving body + closer to form a second block (→ paragraph + empty block).
+// Fix: parity-aware scan commits only at a fence that CLOSES an open block.
+// ──────────────────────────────────────────────────────────────────────────
+describe('non-empty fence not preceded by a blank line', () => {
+  it('findBlockBoundary defers past the opening fence to the closing fence', () => {
+    const text = 'To extract it, run:\n```\n/harvest abc123\n```\n';
+    // Boundary must land at the END of the block (after the closing fence),
+    // not at index 24 (right after the opening fence).
+    expect(findBlockBoundary(text)).toBe(text.length);
+  });
+
+  it('renders the command body, not "(empty code block)" (single push)', () => {
+    const out = renderNonTTY(['To extract it, run:\n```\n/harvest abc123\n```\n']);
+    expect(out).toContain('/harvest abc123');
+    expect(out).not.toContain('(empty code block)');
+  });
+
+  it('renders the command body, not "(empty code block)" (chunked across fence)', () => {
+    const out = renderNonTTY(['To extract it, run:\n```\n', '/harvest abc123\n```\n']);
+    expect(out).toContain('/harvest abc123');
+    expect(out).not.toContain('(empty code block)');
+  });
+
+  it('control: a fence WITH a preceding blank line still renders the body', () => {
+    const out = renderNonTTY(['To extract it, run:\n\n```\n/harvest abc123\n```\n']);
+    expect(out).toContain('/harvest abc123');
+    expect(out).not.toContain('(empty code block)');
+  });
+
+  it('a genuinely empty fence still loud-fails with the placeholder', () => {
+    const out = renderNonTTY(['Heads up:\n```\n```\n']);
+    expect(out).toContain('(empty code block)');
+  });
+});

--- a/src/cli/markdown-stream-format.ts
+++ b/src/cli/markdown-stream-format.ts
@@ -180,11 +180,34 @@ export function findBlockBoundary(text: string): number {
     }
   }
 
-  // Check for closing fenced code fence (``` or ~~~ on its own line)
-  // Pattern: newline, optional spaces, fence marker, optional spaces, newline
-  const closeCodeFenceMatch = text.match(/\n[ \t]*(?:```|~~~)[ \t]*\n/);
-  if (closeCodeFenceMatch && closeCodeFenceMatch.index !== undefined) {
-    return closeCodeFenceMatch.index + closeCodeFenceMatch[0].length;
+  // Commit at a CLOSING fenced code fence (``` or ~~~ on its own line).
+  // Pattern: newline, optional spaces, BARE fence marker, optional spaces,
+  // newline. (A fence with a language tag — `\n```bash\n` — never matches, so
+  // only bare fence lines are candidates here.)
+  //
+  // Invariant: this regex cannot tell an OPENING fence from a CLOSING one — a
+  // bare opener that directly follows non-blank text (e.g. "run:\n```\nbody")
+  // is also a "\n```\n" line. Committing at the opener would slice it into the
+  // previous block, where marked re-lexes the orphaned, never-closed fence as
+  // an empty code block ("(empty code block)") and the body becomes a stray
+  // paragraph — the exact "non-empty fence renders as two empty blocks" render
+  // bug. So scan every candidate fence line and commit only at the first one
+  // whose prefix (up to and including that fence) has EVEN fence parity, i.e.
+  // closes an open block. An opener leaves odd parity → defer past it to its
+  // matching closer; if none has arrived yet, return -1 so the whole fence
+  // stays pending until the closer streams in (or flush() commits the tail).
+  const fenceLineRe = /\n[ \t]*(?:```|~~~)[ \t]*\n/g;
+  let fence: RegExpExecArray | null;
+  while ((fence = fenceLineRe.exec(text)) !== null) {
+    const endIdx = fence.index + fence[0].length;
+    if (!isInOpenCodeFence(text.slice(0, endIdx))) {
+      return endIdx; // even parity → this fence closed a block; commit here
+    }
+    // Odd parity → this is an opener. Advance past its leading '\n' (not its
+    // whole match) so an immediately-adjacent closer can reuse the shared
+    // newline (e.g. the empty fence "```\n```\n"). m.index+1 > lastIndex
+    // guarantees forward progress, so the loop always terminates.
+    fenceLineRe.lastIndex = fence.index + 1;
   }
 
   return -1;


### PR DESCRIPTION
## What

The streaming REPL renderer rendered a real fenced command as **two `(empty code block)` placeholders** sandwiching the command body as a stray paragraph:

```
To extract it, run:
│ (empty code block)
/harvest ee668524-…
│ (empty code block)
```

## Root cause

`findBlockBoundary()` in `src/cli/markdown-stream-format.ts` decides where the streaming renderer cuts committed blocks. Its closing-fence detector — a regex matching a newline, optional spaces, a bare fence marker, optional spaces, newline — **cannot distinguish an opening fence from a closing one**; it matches any bare fence-only line.

When a **bare** fence (no language tag) directly follows non-blank text with a single newline (`run:` + newline + opening fence + body), and the closing fence has not streamed in yet, the streamer commits the block **at the opener**. `marked` then re-lexes the orphaned, never-closed fence as an empty code block → `(empty code block)`; the body becomes a stray paragraph; the eventual closing fence renders as a *second* empty placeholder.

**Streaming-only:** the non-streamed `renderMarkdownToTerminal` always handled this input correctly — which is why every `formatter.ts` test passed and the defect was invisible to the suite. A fence *with* a preceding blank line, or *with* a language tag, never triggered it.

## Fix

Parity-aware scan: walk candidate fence lines and commit only at one whose prefix has **even** fence parity (`isInOpenCodeFence` false ⇒ it closed a block). Defer past openers (odd parity) until the matching closer arrives — or to `flush()` for the tail. The empty-fence loud-fail placeholder is preserved.

## Verification

- **New regression test** `src/cli/markdown-stream-fence-boundary.test.ts` (5 cases): boundary index, single-push, chunked-across-fence, blank-line control, empty-fence loud-fail.
- **Blast-radius suites green (334 tests):** `markdown-stream-format` + `formatter` + all `stream-renderer*` + the new test.
- **Full suite:** 9753 passed / 12 skipped. The 3 failures are unrelated and pre-existing/environmental, confirmed by baselining against clean `main`:
  - `anthropic-direct.test.ts` (compact model-ID) — reproduces on clean `main`.
  - `config.test.ts` (MLX bleed) — passes in isolation; order-dependent test-isolation artifact.
  - `trace/writer.test.ts` (subprocess exit) — passes on a checkout with `node_modules`; local worktree-env artifact only.
- `tsc --noEmit`: clean.
