### PR TITLE
fix(worktree): propagate cwd to presence + executors so live worktrees aren't deleted mid-run

### DIFF
--- a/src/agent/awareness/presence.test.ts
+++ b/src/agent/awareness/presence.test.ts
@@ -102,6 +102,30 @@ describe('writePresenceFile + readPresenceFiles', () => {
   });
 });
 
+describe('updatePresenceCwd', () => {
+  it('updates the cwd field on an existing file, preserving every other field', async () => {
+    const { writePresenceFile, updatePresenceCwd, readPresenceFiles } = await getPresenceMod();
+    await writePresenceFile(mkInfo({ sessionId: 'cwd-update', cwd: '/launch/dir', actor: 'main' }));
+
+    // Simulate a born-named worktree being created mid-session.
+    await updatePresenceCwd('cwd-update', '/launch/dir/.afk-worktrees/afk-xyz');
+
+    const records = await readPresenceFiles();
+    expect(records).toHaveLength(1);
+    expect(records[0]!.cwd).toBe('/launch/dir/.afk-worktrees/afk-xyz');
+    // Read-modify-write must not drop the other fields.
+    expect(records[0]!.sessionId).toBe('cwd-update');
+    expect(records[0]!.actor).toBe('main');
+    expect(records[0]!.pid).toBe(process.pid);
+  });
+
+  it('is a no-op when no presence file exists (does not throw, creates nothing)', async () => {
+    const { updatePresenceCwd, readPresenceFiles } = await getPresenceMod();
+    await expect(updatePresenceCwd('ghost-session', '/some/where')).resolves.toBeUndefined();
+    expect(await readPresenceFiles()).toHaveLength(0);
+  });
+});
+
 describe('removePresenceFile', () => {
   it('deletes the file; subsequent readPresenceFiles omits it', async () => {
     const { writePresenceFile, removePresenceFile, readPresenceFiles } = await getPresenceMod();

--- a/src/agent/awareness/presence.ts
+++ b/src/agent/awareness/presence.ts
@@ -127,6 +127,29 @@ export async function setPresenceAfk(sessionId: string, afk: boolean): Promise<v
 }
 
 /**
+ * Update the `cwd` field on an existing presence file (best-effort,
+ * read-modify-write). Called from `AgentSession.setCwd` so a session's presence
+ * record tracks its CURRENT working directory after a mid-session cwd change —
+ * notably the born-named `afk -w` worktree, which is created on the first turn
+ * AFTER presence was written with the launch dir. Without this the worktree
+ * sweep's live-session guard (`isPathWithin(presence.cwd, worktreePath)`) never
+ * matches, so the sweep can reap the worktree out from under the running
+ * session. No-op when the file is absent (subagents never have one). Preserves
+ * every other field.
+ */
+export async function updatePresenceCwd(sessionId: string, cwd: string): Promise<void> {
+  try {
+    const filePath = presenceFilePath(sessionId);
+    const raw = await readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as PresenceFileInfo;
+    parsed.cwd = cwd;
+    await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf8');
+  } catch {
+    // Best-effort — presence is non-critical.
+  }
+}
+
+/**
  * Asynchronously delete a presence file by session ID.
  *
  * Safe to call even if the file does not exist (ENOENT is swallowed).

--- a/src/agent/daemon/scheduler.test.ts
+++ b/src/agent/daemon/scheduler.test.ts
@@ -9,10 +9,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { CronScheduler, daemonTraceLabel } from './scheduler.js';
+import { CronScheduler, daemonTraceLabel, resolveWorktreePruneRoot } from './scheduler.js';
 import { getTraceDir } from '../../paths.js';
 import type { AgentSession } from '../session/agent-session.js';
 import type { AgentConfig } from '../types.js';
+import type { ExecFileFn } from '../worktree-sweep.js';
 
 function makeTmpDir(): string {
   return mkdtempSync(join(tmpdir(), 'agent-afk-scheduler-'));
@@ -286,5 +287,40 @@ describe('daemonTraceLabel', () => {
     const label = daemonTraceLabel('///');
     expect(SAFE.test(label)).toBe(true);
     expect(label.startsWith('task-')).toBe(true);
+  });
+});
+
+describe('resolveWorktreePruneRoot', () => {
+  it('returns the explicit override without invoking git', async () => {
+    const mock = vi.fn();
+    const root = await resolveWorktreePruneRoot(mock as unknown as ExecFileFn, '/anywhere', '/pinned/repo');
+    expect(root).toBe('/pinned/repo');
+    expect(mock).not.toHaveBeenCalled();
+  });
+
+  it('discovers the repo root via git rev-parse when no override is set', async () => {
+    const mock = vi.fn().mockResolvedValue({ stdout: '/Users/me/proj\n', stderr: '' });
+    const root = await resolveWorktreePruneRoot(mock as unknown as ExecFileFn, '/Users/me/proj/sub', undefined);
+    expect(root).toBe('/Users/me/proj');
+    expect(mock).toHaveBeenCalledWith('git', ['rev-parse', '--show-toplevel'], { cwd: '/Users/me/proj/sub' });
+  });
+
+  it('returns null when cwd is not a git repo (rev-parse throws) — the daemon $HOME case', async () => {
+    const mock = vi.fn().mockRejectedValue(new Error('fatal: not a git repository'));
+    const root = await resolveWorktreePruneRoot(mock as unknown as ExecFileFn, '/Users/me', undefined);
+    expect(root).toBeNull();
+  });
+
+  it('returns null when git yields empty output', async () => {
+    const mock = vi.fn().mockResolvedValue({ stdout: '   \n', stderr: '' });
+    const root = await resolveWorktreePruneRoot(mock as unknown as ExecFileFn, '/x', undefined);
+    expect(root).toBeNull();
+  });
+
+  it('treats an empty-string override as unset and falls back to discovery', async () => {
+    const mock = vi.fn().mockResolvedValue({ stdout: '/repo\n', stderr: '' });
+    const root = await resolveWorktreePruneRoot(mock as unknown as ExecFileFn, '/repo/x', '');
+    expect(root).toBe('/repo');
+    expect(mock).toHaveBeenCalled();
   });
 });

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -29,6 +29,30 @@ import { getQueueDir } from '../../paths.js';
 // reuses the same node:child_process exec function on every tick; there is no
 // reason to re-resolve it dynamically inside the handler.
 const builtinPruneExecFile: ExecFileFn = promisify(execFileCallback) as ExecFileFn;
+
+/**
+ * Resolve the repo root for the builtin worktree-prune sweep. An explicit
+ * `override` (AFK_WORKTREE_SWEEP_ROOT) wins; otherwise discover the repo
+ * enclosing `cwd` via `git rev-parse --show-toplevel`. Returns `null` when the
+ * cwd is not inside a git repository — the daemon's cwd is frequently $HOME
+ * (launchd sets WorkingDirectory=homedir), so the caller skips gracefully
+ * instead of erroring `fatal: not a git repository` on every nightly run.
+ * Exported for unit testing with a stubbed execFile.
+ */
+export async function resolveWorktreePruneRoot(
+  execFile: ExecFileFn,
+  cwd: string,
+  override: string | undefined,
+): Promise<string | null> {
+  if (override !== undefined && override.length > 0) return override;
+  try {
+    const top = await execFile('git', ['rev-parse', '--show-toplevel'], { cwd });
+    const root = top.stdout.trim();
+    return root.length > 0 ? root : null;
+  } catch {
+    return null;
+  }
+}
 import type { ScheduledTask as CronTask } from 'node-cron';
 import { AgentSession } from '../session/agent-session.js';
 import { createDefaultHookRegistry } from '../default-hook-registry.js';
@@ -363,7 +387,26 @@ export class CronScheduler {
     };
 
     try {
-      const repoRoot = env.AFK_WORKTREE_SWEEP_ROOT ?? process.cwd();
+      const repoRoot = await resolveWorktreePruneRoot(
+        builtinPruneExecFile,
+        process.cwd(),
+        env.AFK_WORKTREE_SWEEP_ROOT,
+      );
+      if (repoRoot === null) {
+        // Daemon cwd is not inside a git repo (commonly $HOME under launchd).
+        // Skip rather than erroring on every tick; the per-repo REPL boot-prune
+        // still handles cleanup for repos the user actually works in.
+        const skipped: TelemetryRecord = {
+          ...baseRecord,
+          durationMs: this.now() - startTimeMs,
+          status: 'skipped',
+          responseExcerpt:
+            'worktree-prune skipped: daemon cwd is not inside a git repository ' +
+            '(set AFK_WORKTREE_SWEEP_ROOT to target a repo)',
+        };
+        this.writeTelemetry(skipped, task);
+        return skipped;
+      }
 
       const maxAgeDaysClean =
         parseInt(env.AFK_WORKTREE_MAX_AGE_CLEAN ?? '', 10) || 14;

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -24,6 +24,23 @@ import type { ExecFileFn } from '../worktree-sweep.js';
 import { IdleDetector } from './idle-detector.js';
 import { dequeueNext } from './queue-store.js';
 import { getQueueDir } from '../../paths.js';
+import type { ScheduledTask as CronTask } from 'node-cron';
+import { AgentSession } from '../session/agent-session.js';
+import { createDefaultHookRegistry } from '../default-hook-registry.js';
+import { loadHooksConfig } from '../hooks/config-loader.js';
+import { createDefaultTraceWriter } from '../trace/factory.js';
+import { MemoryStore, injectHotMemory } from '../memory/index.js';
+import type { AgentConfig } from '../types.js';
+import { getTelemetryPath } from '../../paths.js';
+import { redactInlineSecrets } from '../session/prompt-dump.js';
+import { ScheduledTask, validateScheduledTask } from './triggers.js';
+import {
+  DEFAULT_SESSIONSTART_COOLDOWN_MS,
+  defaultBriefsDir,
+  evaluateSessionStartGates,
+  type GateDecision,
+  type SessionStartSkipReason,
+} from './gates.js';
 
 // Promisified once at module scope — the daemon's builtin worktree-prune task
 // reuses the same node:child_process exec function on every tick; there is no
@@ -53,23 +70,6 @@ export async function resolveWorktreePruneRoot(
     return null;
   }
 }
-import type { ScheduledTask as CronTask } from 'node-cron';
-import { AgentSession } from '../session/agent-session.js';
-import { createDefaultHookRegistry } from '../default-hook-registry.js';
-import { loadHooksConfig } from '../hooks/config-loader.js';
-import { createDefaultTraceWriter } from '../trace/factory.js';
-import { MemoryStore, injectHotMemory } from '../memory/index.js';
-import type { AgentConfig } from '../types.js';
-import { getTelemetryPath } from '../../paths.js';
-import { redactInlineSecrets } from '../session/prompt-dump.js';
-import { ScheduledTask, validateScheduledTask } from './triggers.js';
-import {
-  DEFAULT_SESSIONSTART_COOLDOWN_MS,
-  defaultBriefsDir,
-  evaluateSessionStartGates,
-  type GateDecision,
-  type SessionStartSkipReason,
-} from './gates.js';
 
 /**
  * Build a charset-safe witness `sessionLabel` for a daemon tick, shaped

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -838,6 +838,13 @@ export class AnthropicDirectProvider implements ModelProvider {
           }
           this._currentCwd = newCwd;
 
+          // 1b. Re-anchor the forked sub-agent / skill executors so child tool
+          //     calls (the `agent` and skill tools) land in the new worktree
+          //     instead of the host's process.cwd(). Without this, a born-named
+          //     `afk -w` worktree leaves the executors frozen on the launch dir.
+          this.subagentExecutor?.setCwd(newCwd);
+          this.skillExecutor?.setCwd(newCwd);
+
           // 2. Rebuild system-prompt fragment with the new `# Environment` line.
           //    Build a fresh copy each invocation — splice mutates in place.
           //    Awareness identity fields (sessionId/surface/depth/maxDepth)

--- a/src/agent/session/agent-session.test.ts
+++ b/src/agent/session/agent-session.test.ts
@@ -25,8 +25,18 @@ import type {
 } from '@anthropic-ai/sdk/resources';
 import { AgentSession } from './agent-session.js';
 import { AnthropicDirectProvider, __setAnthropicClientFactory } from '../providers/anthropic-direct/index.js';
+import { updatePresenceCwd } from '../awareness/presence.js';
 
 vi.mock('../../utils/debug.js', () => ({ debugLog: vi.fn() }));
+
+// Spy on updatePresenceCwd while keeping every other presence export real (the
+// provider still writes/removes presence normally). Lets the setCwd→presence
+// wiring be asserted deterministically — updatePresenceCwd's own file behavior
+// is covered in presence.test.ts, so we only check it is invoked correctly.
+vi.mock('../awareness/presence.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../awareness/presence.js')>();
+  return { ...actual, updatePresenceCwd: vi.fn() };
+});
 
 // ---------------------------------------------------------------------------
 // Mock Anthropic client (same pattern as plan-mode-system-payload.test.ts)
@@ -158,6 +168,52 @@ describe('AgentSession.setCwd() — live session propagation (T19)', () => {
       expect(turn2System).toContain(NEW_CWD);
       expect(turn2System).not.toContain(OLD_CWD);
       expect(turn2System).toContain('Working directory');
+    } finally {
+      await session.close();
+    }
+  });
+
+  it('(T19-6) setCwd() re-writes the session presence file with the new cwd', async () => {
+    // Regression: a born-named `afk -w` worktree is created on turn 1, AFTER
+    // the presence file was written with the launch dir. If setCwd does not
+    // re-write presence.cwd, the worktree-sweep live-session guard never matches
+    // and the sweep deletes the worktree out from under the running session.
+    messagesCreateMock.mockImplementation(() => fromArray(makeTextStream('ok')));
+    vi.mocked(updatePresenceCwd).mockClear();
+
+    const provider = new AnthropicDirectProvider();
+    const session = new AgentSession({
+      model: 'claude-haiku-4-5',
+      apiKey: 'sk-ant-oat01-test',
+      cwd: OLD_CWD,
+      sessionId: 'sess-presence-cwd',
+      provider,
+    });
+    try {
+      session.setCwd(NEW_CWD);
+      expect(updatePresenceCwd).toHaveBeenCalledWith('sess-presence-cwd', NEW_CWD);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it('(T19-7) setCwd() does not touch presence when the session has no sessionId', async () => {
+    // The presence file is keyed by sessionId and only written for top-level
+    // sessions. A session without one (e.g. a sub-agent fork) must not attempt
+    // the presence re-write.
+    messagesCreateMock.mockImplementation(() => fromArray(makeTextStream('ok')));
+    vi.mocked(updatePresenceCwd).mockClear();
+
+    const provider = new AnthropicDirectProvider();
+    const session = new AgentSession({
+      model: 'claude-haiku-4-5',
+      apiKey: 'sk-ant-oat01-test',
+      cwd: OLD_CWD,
+      provider,
+    });
+    try {
+      session.setCwd(NEW_CWD);
+      expect(updatePresenceCwd).not.toHaveBeenCalled();
     } finally {
       await session.close();
     }

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -52,6 +52,7 @@ import type { ElicitationRequest } from '../types/sdk-types.js';
 import { env } from '../../config/env.js';
 import { resolveModelId } from './model-resolution.js';
 import { deriveOrigin, deriveActor } from './session-identity.js';
+import { updatePresenceCwd } from '../awareness/presence.js';
 import { setSlotBindings } from './model-slots.js';
 import { applySlotCredentials } from './slot-credentials.js';
 import {
@@ -754,7 +755,7 @@ export class AgentSession implements IAgentSession {
   /**
    * Update the working directory for the current session.
    *
-   * Two things happen atomically:
+   * Three things happen atomically:
    *   1. `config.cwd` is updated so future `reset()` calls rebuild the
    *      provider query with the correct path.
    *   2. `providerQuery.setCwd(cwd)` is called (when the query supports it)
@@ -765,7 +766,12 @@ export class AgentSession implements IAgentSession {
    *      cwd). The provider also splices its shared `readRoots`/`writeRoots`
    *      arrays in place so containment checks accept paths under the new
    *      cwd, and any `/allow-dir` grants accumulated under the old cwd
-   *      survive intact.
+   *      survive intact. The provider's `setCwd` ALSO re-anchors the forked
+   *      sub-agent / skill executors so child tool calls land in the new cwd.
+   *   3. The session's presence file is re-written with the new cwd (best-
+   *      effort, top-level sessions only). This keeps the worktree-sweep
+   *      live-session guard accurate after a born-named `afk -w` worktree is
+   *      created on turn 1, so the sweep never reaps an in-use worktree.
    *
    * `AnthropicDirectQuery` implements both the in-flight propagation and
    * the next-turn rebuild. Providers that don't implement the optional
@@ -781,6 +787,15 @@ export class AgentSession implements IAgentSession {
   setCwd(cwd: string): void {
     this.config = { ...this.config, cwd };
     this.providerQuery.setCwd?.(cwd);
+    // Keep the session's presence record pointing at the CURRENT cwd. A born-
+    // named `afk -w` worktree is created on turn 1, AFTER presence was written
+    // with the launch dir; without this update presence.cwd stays stale and the
+    // worktree sweep's live-session guard can't see that the worktree is in use,
+    // so it gets deleted mid-run. Fire-and-forget + self-guarding (no-op when no
+    // presence file exists, e.g. sub-agents); only top-level sessions key one.
+    if (this.config.sessionId !== undefined) {
+      void updatePresenceCwd(this.config.sessionId, cwd);
+    }
   }
 
   /**

--- a/src/agent/subagent.test.ts
+++ b/src/agent/subagent.test.ts
@@ -215,6 +215,22 @@ describe('SubagentManager', () => {
     expect((shared.lastConfig as unknown as Record<string, unknown>)['cwd']).toBeUndefined();
   });
 
+  // setCwd re-anchors forks mid-session. A born-named `afk -w` worktree is
+  // created on turn 1, AFTER the root manager was constructed in the launch
+  // dir; without re-anchoring, forked subagents keep inheriting the launch dir.
+  it('forkSubagent inherits the updated cwd after setCwd (mid-session re-anchor)', async () => {
+    shared.lastConfig = null;
+    const mgr = new SubagentManager({ cwd: '/tmp/launch/dir' });
+    mgr.setCwd('/tmp/launch/dir/.afk-worktrees/afk-xyz');
+    await mgr.forkSubagent({
+      parent: { sessionId: 'p' },
+      config: { model: 'sonnet' },
+    });
+    expect(shared.lastConfig).toEqual(
+      expect.objectContaining({ cwd: '/tmp/launch/dir/.afk-worktrees/afk-xyz' }),
+    );
+  });
+
   it('list() and get() track active handles', async () => {
     const mgr = new SubagentManager();
     const h = await mgr.forkSubagent({ parent: { sessionId: 'p' }, config: { model: 'sonnet' } });

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -217,7 +217,10 @@ export class SubagentManager {
   private readonly progressSink: SubagentProgressSink | undefined;
   private readonly parentApiKey: string | undefined;
   private readonly parentBaseUrl: string | undefined;
-  private readonly parentCwd: string | undefined;
+  // Mutable so AgentSession.setCwd can re-anchor forks after a born-named
+  // `afk -w` worktree is created mid-session. Read at fork time (forkSubagent),
+  // so updating it makes every subsequent fork inherit the new worktree cwd.
+  private parentCwd: string | undefined;
   private readonly abortGraph: AbortGraph;
   private readonly rootId: string;
   private readonly rootController: AbortController;
@@ -287,6 +290,17 @@ export class SubagentManager {
     cb: (usage: import('./subagent/result.js').SubagentTrace['usage'], costUsd: number | undefined) => void,
   ): void {
     this.onSubagentSucceededCb = cb;
+  }
+
+  /**
+   * Re-anchor the cwd inherited by future forks. Called (transitively, via the
+   * provider's `setCwd`) when the session's working directory changes — most
+   * importantly when a born-named `afk -w` worktree is created on turn 1, after
+   * this manager was constructed in the launch dir. Existing in-flight children
+   * are unaffected; only forks dispatched after this call inherit `cwd`.
+   */
+  setCwd(cwd: string): void {
+    this.parentCwd = cwd;
   }
 
   /**

--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -313,6 +313,48 @@ describe('SessionToolDispatcher', () => {
     });
   });
 
+  describe('setResolveBase — executor re-anchoring (openai-compatible worktree cwd fix)', () => {
+    // Regression: the openai-compatible provider's query.setCwd routes straight
+    // to dispatcher.setResolveBase. Before this, setResolveBase migrated the
+    // path roots but left the forked agent/skill executors frozen on the launch
+    // dir, so child tool calls in a born-named `afk -w` worktree ran against the
+    // host repo. setResolveBase must now re-anchor the executors it owns.
+    it('re-anchors subagent + skill executors to the new cwd on a real cwd change', () => {
+      const subagentExecutor = { execute: vi.fn(), setCwd: vi.fn() } as any;
+      const skillExecutor = { execute: vi.fn(), setCwd: vi.fn() } as any;
+      const dispatcher = makeDispatcher({
+        cwd: '/tmp/launch/dir',
+        subagentExecutor,
+        skillExecutor,
+      });
+
+      dispatcher.setResolveBase('/tmp/launch/dir/.afk-worktrees/afk-xyz');
+
+      expect(subagentExecutor.setCwd).toHaveBeenCalledWith('/tmp/launch/dir/.afk-worktrees/afk-xyz');
+      expect(skillExecutor.setCwd).toHaveBeenCalledWith('/tmp/launch/dir/.afk-worktrees/afk-xyz');
+    });
+
+    it('does not re-anchor when the cwd is unchanged (no-op guard)', () => {
+      const subagentExecutor = { execute: vi.fn(), setCwd: vi.fn() } as any;
+      const skillExecutor = { execute: vi.fn(), setCwd: vi.fn() } as any;
+      const dispatcher = makeDispatcher({
+        cwd: '/tmp/same/dir',
+        subagentExecutor,
+        skillExecutor,
+      });
+
+      dispatcher.setResolveBase('/tmp/same/dir'); // identical → early return
+
+      expect(subagentExecutor.setCwd).not.toHaveBeenCalled();
+      expect(skillExecutor.setCwd).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when no executors are configured (eval-run probe dispatcher)', () => {
+      const dispatcher = makeDispatcher({ cwd: '/tmp/launch/dir' });
+      expect(() => dispatcher.setResolveBase('/tmp/launch/dir/.afk-worktrees/afk-xyz')).not.toThrow();
+    });
+  });
+
   describe('defaultConcurrencyClassifier', () => {
     it('marks read-only tools as safe', () => {
       expect(defaultConcurrencyClassifier('read_file')).toBe(true);

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -352,6 +352,12 @@ export class SessionToolDispatcher implements ToolDispatcher {
    *   2. `_readRoots` / `_writeRoots` — any entry that equals the prior
    *      resolveBase is replaced in place with `newCwd`. Other grants
    *      (added via /allow-dir) are preserved.
+   *   3. The forked sub-agent / skill executors this dispatcher owns are
+   *      re-anchored via their `setCwd` so child `agent` / skill tool calls
+   *      land in `newCwd` (the worktree) instead of the host `process.cwd()`.
+   *      This is the openai-compatible provider's ONLY executor re-anchor hook
+   *      (its `query.setCwd` routes straight here); anthropic-direct re-anchors
+   *      the same instances again in `cwdDependentsFactory` (idempotent).
    *
    * Mutates in place. Callers must keep the same dispatcher reference; the
    * point of this method is that callers holding the dispatcher by reference
@@ -393,6 +399,16 @@ export class SessionToolDispatcher implements ToolDispatcher {
       if (!this._readRoots.includes(newCwd)) this._readRoots.push(newCwd);
       if (!this._writeRoots.includes(newCwd)) this._writeRoots.push(newCwd);
     }
+
+    // Re-anchor the forked executors this dispatcher dispatches to (item 3
+    // above) so child `agent` / skill tool calls follow the cwd change instead
+    // of staying frozen on the launch dir — the openai-compatible provider's
+    // only re-anchor path (anthropic-direct also does this in
+    // cwdDependentsFactory on the same instances). No-op when the executors are
+    // absent (sub-agents, the eval-run probe dispatcher); `setCwd` is
+    // idempotent, so the anthropic-direct double-set is harmless.
+    this.subagentExecutor?.setCwd(newCwd);
+    this.skillExecutor?.setCwd(newCwd);
   }
 
   private appendAuditLog(entry: {

--- a/src/agent/tools/skill-executor.test.ts
+++ b/src/agent/tools/skill-executor.test.ts
@@ -896,6 +896,57 @@ describe('SkillExecutor', () => {
       expect((capturedManager as unknown as { parentCwd: string | undefined }).parentCwd)
         .toBe('/tmp/wt/feat-x');
     });
+
+    // setCwd re-anchors mid-session: a born-named `afk -w` worktree is created
+    // on turn 1, after the SkillExecutor was constructed in the launch dir.
+    // Without re-anchoring, skill subagents keep resolving against the launch
+    // dir (host repo).
+    it('setCwd re-anchors the per-call SubagentManager for skill subagents', async () => {
+      registerSkill({
+        name: 'fork-skill-setcwd',
+        description: 'test',
+        context: 'fork',
+        handler: vi.fn(),
+      });
+
+      vi.spyOn(promptLoader, 'loadSkillPrompts').mockReturnValue({
+        'system.md': 'fake-system-prompt',
+      });
+
+      let capturedManager: SubagentManager | undefined;
+      vi.spyOn(SubagentManager.prototype, 'forkSubagent').mockImplementation(
+        function (this: SubagentManager) {
+          capturedManager = this;
+          return Promise.resolve({
+            id: 'h',
+            runToResult: vi.fn().mockResolvedValue({
+              status: 'succeeded',
+              message: { content: 'ok' },
+            }),
+            teardown: vi.fn().mockResolvedValue(undefined),
+          }) as any;
+        } as any,
+      );
+      vi.spyOn(SubagentManager.prototype, 'teardownAll').mockResolvedValue(undefined);
+
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'parent-123',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        defaultModel: 'sonnet',
+        cwd: '/tmp/launch/dir',
+      });
+
+      executor.setCwd('/tmp/launch/dir/.afk-worktrees/afk-xyz');
+
+      const result = await executor.execute(makeCall({ name: 'fork-skill-setcwd' }));
+
+      expect(result.isError).toBeUndefined();
+      expect((capturedManager as unknown as { parentCwd: string | undefined }).parentCwd)
+        .toBe('/tmp/launch/dir/.afk-worktrees/afk-xyz');
+    });
   });
 
   describe('resolveApiKeyForModel — per-model credential resolution (skill fork path)', () => {

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -216,8 +216,19 @@ function parseSkillInput(input: unknown): SkillInput {
 
 export class SkillExecutor {
   private pluginBodies: Map<string, PluginSkillBody> | null = null;
+  // Current worktree cwd. Seeded from ctx.cwd; updated by setCwd when the
+  // session's cwd changes (born-named `afk -w` worktree created on turn 1) so
+  // skill-forked sub-agents anchor to the worktree, not the host process.cwd().
+  private currentCwd: string | undefined;
 
-  constructor(private readonly ctx: SkillExecutorContext) {}
+  constructor(private readonly ctx: SkillExecutorContext) {
+    this.currentCwd = ctx.cwd;
+  }
+
+  /** Re-anchor the cwd used for skill-forked sub-agents after a cwd change. */
+  setCwd(cwd: string): void {
+    this.currentCwd = cwd;
+  }
 
   /**
    * Session-identity fields for telemetry rows (skill-invocations + routing).
@@ -375,7 +386,7 @@ export class SkillExecutor {
     writeSkillInvocation({
       skillName: skill.name,
       sessionId: this.ctx.parentSession.sessionId,
-      cwd: this.ctx.cwd,
+      cwd: this.currentCwd,
       model: skill.model ?? this.ctx.defaultModel,
       ...this.sessionIdentity(),
     });
@@ -544,7 +555,7 @@ export class SkillExecutor {
       // dispatches its own `agent` calls (grandchild forks), the manager's
       // forkSubagent injects cwd into the grandchild's config. Mirrors
       // subagent-executor.ts:294.
-      ...(this.ctx.cwd !== undefined ? { cwd: this.ctx.cwd } : {}),
+      ...(this.currentCwd !== undefined ? { cwd: this.currentCwd } : {}),
     });
     const childExecutor = new SubagentExecutor({
       subagentManager: childManager,
@@ -570,7 +581,7 @@ export class SkillExecutor {
       maxDepth,
       // Forward cwd so the grandchild executor's own childManager (when it
       // recursively constructs one for great-grandchild forks) is also cwd-anchored.
-      ...(this.ctx.cwd !== undefined ? { cwd: this.ctx.cwd } : {}),
+      ...(this.currentCwd !== undefined ? { cwd: this.currentCwd } : {}),
       // Invariant: background dispatch requires the registry to be present
       // in every SubagentExecutor in the chain — root → skill-forked child →
       // skill-forked grandchild. Without forwarding, a plugin skill's
@@ -665,7 +676,7 @@ export class SkillExecutor {
     writeSkillInvocation({
       skillName: skill.name,
       sessionId: this.ctx.parentSession.sessionId,
-      cwd: this.ctx.cwd,
+      cwd: this.currentCwd,
       model: typeof skillChildModel === 'string' ? skillChildModel : undefined,
       ...this.sessionIdentity(),
     });
@@ -680,7 +691,7 @@ export class SkillExecutor {
       // forwarding here is what gives the skill subagent's bash/grep/file
       // tools the worktree anchor. Without it, every `/diagnose`, `/mint`,
       // etc. run their first-tier subagents against the host repo.
-      ...(this.ctx.cwd !== undefined ? { cwd: this.ctx.cwd } : {}),
+      ...(this.currentCwd !== undefined ? { cwd: this.currentCwd } : {}),
     });
 
     // Thread traceWriter into the child's AgentConfig so its tool_use, hook,
@@ -960,7 +971,7 @@ export class SkillExecutor {
     writeSkillInvocation({
       skillName: skillName,
       sessionId: this.ctx.parentSession.sessionId,
-      cwd: this.ctx.cwd,
+      cwd: this.currentCwd,
       model: typeof pluginChildModel === 'string' ? pluginChildModel : undefined,
       ...this.sessionIdentity(),
     });
@@ -972,7 +983,7 @@ export class SkillExecutor {
       ...(this.ctx.traceWriter !== undefined ? { traceWriter: this.ctx.traceWriter } : {}),
       progressSink: getCurrentSink(),
       // Worktree isolation — same rationale as executeForkedRegistrySkill above.
-      ...(this.ctx.cwd !== undefined ? { cwd: this.ctx.cwd } : {}),
+      ...(this.currentCwd !== undefined ? { cwd: this.currentCwd } : {}),
     });
 
     // PLUGIN_ROOT is injected here so shell commands in the plugin SKILL.md

--- a/src/agent/tools/subagent-executor.test.ts
+++ b/src/agent/tools/subagent-executor.test.ts
@@ -1227,6 +1227,50 @@ describe('SubagentExecutor', () => {
       //     holds for arbitrary depth up to maxDepth.
       expect(capturedChildExecutorCtx!.cwd).toBe('/tmp/wt/feat-x');
     });
+
+    // setCwd re-anchors mid-session (born-named `afk -w` worktree on turn 1):
+    //   (1) the root manager (depth-1 forks) is re-anchored via manager.setCwd
+    //   (2) the depth-2+ childManager built in execute() uses the new cwd
+    it('setCwd re-anchors the root manager and depth-2+ child managers', async () => {
+      let capturedChildExecutorCtx: SubagentExecutorContext | undefined;
+
+      const handle = mockHandle();
+      const manager = {
+        forkSubagent: vi.fn().mockResolvedValue(handle),
+        teardownAll: vi.fn().mockResolvedValue(undefined),
+        setCwd: vi.fn(),
+      };
+
+      const factory = vi.fn().mockImplementation(({ childExecutor }: { childExecutor: SubagentExecutor }) => {
+        capturedChildExecutorCtx = (childExecutor as any).ctx as SubagentExecutorContext;
+        return { name: 'p', query: vi.fn() };
+      });
+
+      const exec = new SubagentExecutor({
+        subagentManager: manager as any,
+        parentSession: {
+          sessionId: 'root',
+          getInputStreamRef: vi.fn(),
+          abortSignal: new AbortController().signal,
+        },
+        defaultConfig: { apiKey: 'k', systemPrompt: 'sp' },
+        childProviderFactory: factory,
+        depth: 0,
+        maxDepth: DEFAULT_MAX_NESTING_DEPTH,
+        cwd: '/tmp/launch/dir',
+      });
+
+      exec.setCwd('/tmp/launch/dir/.afk-worktrees/afk-xyz');
+
+      // (1) depth-1 forks: the root manager was re-anchored.
+      expect(manager.setCwd).toHaveBeenCalledWith('/tmp/launch/dir/.afk-worktrees/afk-xyz');
+
+      // (2) depth-2+ forks: the child manager + executor built in execute() use it.
+      await exec.execute(makeCall());
+      const childManager = capturedChildExecutorCtx!.subagentManager as unknown as { parentCwd: string | undefined };
+      expect(childManager.parentCwd).toBe('/tmp/launch/dir/.afk-worktrees/afk-xyz');
+      expect(capturedChildExecutorCtx!.cwd).toBe('/tmp/launch/dir/.afk-worktrees/afk-xyz');
+    });
   });
 
   // ISSUE H3: agentType fallback chain — all three legs.

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -416,7 +416,25 @@ function buildFailurePayload(args: {
 }
 
 export class SubagentExecutor implements SubagentControl {
-  constructor(private readonly ctx: SubagentExecutorContext) {}
+  // Current worktree cwd. Seeded from ctx.cwd; updated by setCwd when the
+  // session's cwd changes (born-named `afk -w` worktree created on turn 1).
+  // Read when building the depth-2+ child manager/executor below.
+  private currentCwd: string | undefined;
+
+  constructor(private readonly ctx: SubagentExecutorContext) {
+    this.currentCwd = ctx.cwd;
+  }
+
+  /**
+   * Re-anchor the cwd used for forked sub-agents after a mid-session cwd change.
+   * Updates the depth-2+ anchor (this.currentCwd) AND the root manager that
+   * dispatches depth-1 forks, so the whole `agent`-tool tree follows the new
+   * worktree instead of falling back to the host's process.cwd().
+   */
+  setCwd(cwd: string): void {
+    this.currentCwd = cwd;
+    this.ctx.subagentManager.setCwd(cwd);
+  }
 
   /**
    * In-flight foreground subagents that can be promoted to background, keyed
@@ -596,7 +614,7 @@ export class SubagentExecutor implements SubagentControl {
       // bash/grep/read_file fall back to process.cwd() (host repo).
       childManager = new SubagentManager({
         parentAbortSignal: call.signal,
-        ...(this.ctx.cwd !== undefined ? { cwd: this.ctx.cwd } : {}),
+        ...(this.currentCwd !== undefined ? { cwd: this.currentCwd } : {}),
       });
       childParentSession = createStubParentSession(call.signal) as ReturnType<typeof createStubParentSession> & { sessionId: string | undefined };
       const childExecutor = new SubagentExecutor({
@@ -619,7 +637,7 @@ export class SubagentExecutor implements SubagentControl {
         // Forward cwd so the depth-1 child executor, when it constructs
         // ITS own childManager for depth-3+ forks, also receives cwd. The
         // chain holds for arbitrary depth up to maxDepth.
-        ...(this.ctx.cwd !== undefined ? { cwd: this.ctx.cwd } : {}),
+        ...(this.currentCwd !== undefined ? { cwd: this.currentCwd } : {}),
         // Propagate read-only constraints so depth ≥ 2 forks (this depth-1
         // child calling the `agent` tool) keep the same tool allowlist and
         // bash gate that the originating read-only skill imposed.

--- a/src/agent/worktree-sweep.test.ts
+++ b/src/agent/worktree-sweep.test.ts
@@ -1330,4 +1330,85 @@ describe('dead-owner — live-session protection', () => {
     expect(deadOwnerCandidates).toHaveLength(1);
     expect(result.removed).toContain(worktreePath);
   });
+
+  it('end-to-end: REAL updatePresenceCwd flips the verdict from reap to spare', async () => {
+    // Closes the seam the unit tests leave open: presence.test.ts covers the
+    // updatePresenceCwd file round-trip in isolation, and agent-session.test.ts
+    // asserts setCwd→updatePresenceCwd via a MOCK. Neither proves the on-disk
+    // record updatePresenceCwd writes is consumed by the sweep's live-session
+    // guard. This composes the REAL updatePresenceCwd write with the REAL
+    // readPresenceFiles reader the daemon sweep uses by default.
+    //
+    // The worktree's creator pid is DEAD (and the meta is fresh, so it is not
+    // 'unknown'), so the presence.cwd path is the ONLY thing that can spare it —
+    // exactly the born-named `afk -w` scenario. dryRun keeps the worktree on
+    // disk across both phases so the verdict flip is attributable solely to the
+    // cwd write. AFK_HOME is set to repoRoot in beforeEach, so the real presence
+    // dir is isolated to this test's tmpdir.
+    const { writePresenceFile, updatePresenceCwd, readPresenceFiles } = await import('./awareness/presence.js');
+
+    const deadOwnerPid = findDeadPid();
+    const worktreePath = join(afkWorktreesDir, 'afk-e2e-presence-wt');
+    await fs.mkdir(worktreePath, { recursive: true });
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({
+        owner: 'interactive',
+        pid: deadOwnerPid,
+        createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+        baseSha: 'base123',
+        baseBranch: 'main',
+      }),
+    );
+
+    const mainBlock = worktreeBlock({ path: repoRoot, head: 'base123' });
+    const wtBlock = worktreeBlock({
+      path: worktreePath,
+      head: 'base123',
+      branch: 'refs/heads/afk/e2e-presence-wt',
+    });
+    const porcelainOut = `${mainBlock}\n\n${wtBlock}\n`;
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) return { stdout: porcelainOut, stderr: '' };
+      if (args.includes('status') && args.includes('--porcelain')) return { stdout: '', stderr: '' };
+      if (args.includes('rev-list') && args.includes('--count')) return { stdout: '0\n', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+    // dryRun:true keeps the worktree on disk so the same fixture is swept twice.
+    // readPresence is the production default (readPresenceFiles), passed
+    // explicitly so the intent — exercise the real on-disk read path — is clear.
+    const sweepOpts = {
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: true,
+      telemetryPath: telemetryFile,
+      readPresence: readPresenceFiles,
+    };
+
+    // Turn 0: a live session writes presence with the LAUNCH dir. The born-named
+    // worktree does not exist yet, so presence.cwd points at the host repo.
+    const sessionId = 'e2e-presence-cwd';
+    await writePresenceFile({
+      sessionId,
+      surface: 'cli',
+      cwd: repoRoot, // stale launch dir, NOT the worktree
+      startedAt: new Date().toISOString(),
+      model: { provider: 'anthropic-direct', name: 'test-model' },
+      workspace: { branch: null, headSha: null, dirty: null, dirtyCount: null, remoteUrl: null },
+      pid: process.pid, // alive — this test process
+    });
+
+    // Phase 1 (pre-fix state): stale presence.cwd → guard can't match → reaped.
+    const before = await runSweep(sweepOpts);
+    expect(before.candidates.filter((c) => c.verdict === 'dead-owner')).toHaveLength(1);
+
+    // Turn 1: the worktree is created and setCwd fires updatePresenceCwd.
+    await updatePresenceCwd(sessionId, worktreePath);
+
+    // Phase 2 (fixed state): presence.cwd now inside the worktree → spared.
+    const after = await runSweep(sweepOpts);
+    expect(after.candidates.filter((c) => c.verdict === 'dead-owner')).toHaveLength(0);
+    expect(after.removed).not.toContain(worktreePath);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes two user-facing bugs with `afk --worktree` (auto-named / deferred path) plus a related daemon bug, all rooted in cwd state not propagating after a worktree is created mid-session.

On the default `afk -w` path (no explicit branch), the session, its sub-agent/skill executors, and its presence file are all constructed in the **launch dir** *before* the worktree exists. The worktree is created on turn 1 via `session.setCwd()`. Previously `setCwd` updated `config.cwd` + the provider dispatcher/read-roots but **not** the presence file or the executor cwds, causing:

1. **Worktrees deleted mid-run.** The presence file kept pointing at the launch dir, so the worktree-sweep live-session guard (`isPathWithin(presence.cwd, worktreePath)`) never matched. A clean worktree was then reaped as `empty`/`dead-owner` — including by the boot-prune that runs on every `afk` startup — deleting it out from under the running session (symptom: `spawn /bin/sh ENOENT` on every subsequent shell call).
2. **Sub-agents/skills running in the wrong directory.** The executor cwds were frozen at construction; only the fragile process-global `process.chdir` kept tools in the worktree, which breaks under nesting/concurrency and entirely once the worktree is deleted.

Real-run evidence on the author's machine: **53 of 1318 stored sessions** recorded the `spawn /bin/sh ENOENT` + `.afk-worktrees` signature, most recent the day this was written.

The eager path (`afk -w <branch>`, `AFK_WORKTREE_AUTONAME=0`, or no credential) was already correct and is unaffected.

## Changes

**Part 1 — presence follows cwd** (`95c31d7`)
- Add `updatePresenceCwd(sessionId, cwd)` to `presence.ts` (mirrors `setPresenceAfk`: read-modify-write, no-op when absent).
- `AgentSession.setCwd` now calls it (top-level sessions only; self-guarding for sub-agents).

**Part 2 — propagate setCwd to the executors** (`fec6a73`)
- `SubagentManager.parentCwd` is no longer `readonly`; add `setCwd()`.
- `SubagentExecutor` / `SkillExecutor` hold a mutable `currentCwd` (seeded from `ctx.cwd`) read at fork time; add `setCwd()`. `SubagentExecutor.setCwd` also re-anchors the root manager so depth-1 `agent` forks follow.
- The provider's existing `cwdDependentsFactory` (the `setCwd` choke point) now calls `subagentExecutor?.setCwd` + `skillExecutor?.setCwd`. No new cross-layer references; all changes inside `src/agent/`.

**Part 3 — daemon worktree-prune skips gracefully** (`9e96e80`, separate but related)
- The builtin nightly prune used `repoRoot = AFK_WORKTREE_SWEEP_ROOT ?? process.cwd()`; under launchd the daemon cwd is `$HOME` (not a git repo), so it failed with `fatal: not a git repository` every run (10/10 errors in telemetry) and pruned nothing.
- Extract `resolveWorktreePruneRoot(execFile, cwd, override)`: explicit `AFK_WORKTREE_SWEEP_ROOT` still wins; otherwise discover the repo via `git rev-parse --show-toplevel`, returning `null` when not in a repo so the task emits `status:'skipped'` instead of erroring. Per-repo cleanup is still handled by the REPL boot-prune.

## Tests

12 new tests, all green:
- `presence.test.ts`: `updatePresenceCwd` updates cwd / preserves fields / no-ops when absent.
- `agent-session.test.ts`: T19-6 (setCwd invokes the presence re-write) + T19-7 (no-op without a sessionId).
- `subagent.test.ts` / `subagent-executor.test.ts` / `skill-executor.test.ts`: setCwd re-anchors forks (root manager + depth-2+ child managers).
- `scheduler.test.ts`: `resolveWorktreePruneRoot` — override wins, rev-parse discovery, `null` on non-repo ($HOME case), `null` on empty output, empty override falls back.

## Verification

- `pnpm lint` (tsc --noEmit, strict): clean.
- `pnpm exec vitest run` (full suite): **9761 passed, 2 failed, 12 skipped**. The 2 failures (`config.test.ts:538` model-slot defaults, `anthropic-direct.test.ts:1070` compact model-id) reproduce **identically on clean `origin/main`** with these changes absent — they are pre-existing, local-env-only (global `afk.config.json` MLX slot-bleed + a model-registry date mismatch) and unrelated to this diff. Zero new failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
