### PR TITLE
feat(cli): restyle bypass indicator as a "full-power" badge, not a caution

### DIFF
--- a/src/cli/palette.ts
+++ b/src/cli/palette.ts
@@ -49,6 +49,8 @@ export const palette = {
   warning: chalk.yellow,
   /** Plan tone — magenta hex, used for PLAN card border + title chip. */
   plan: chalk.hex('#9F7CE0'),
+  /** Bypass tone — electric synthwave pink, bold, used for the `⚡ BYPASS` status-line chip + `/bypass` toggle (bypassPermissions mode). Deliberately reads as a "full-power / turbo unlocked" badge, NOT a caution: bypass is the default CLI mode now, so the indicator should inform at a glance without alarming. Warm-pink pairs with brand orange (sunset/synthwave) yet stays distinct from it and from plan lavender, so the chip never reads as the model name or plan mode. */
+  bypass: chalk.bold.hex('#FF6AC1'),
   /** Meta tone — bright-black, used for per-turn stats, dim hints, diff hunk headers, "other"/"planning" tool fallbacks, and the neutral "interrupted" verdict. */
   meta: chalk.blackBright,
   /** Info tone — sky blue, used for ℹ-prefixed ambient notices, status cards, and daemon banners. Owns the ambient-notice channel exclusively. */

--- a/src/cli/slash/commands/bypass.test.ts
+++ b/src/cli/slash/commands/bypass.test.ts
@@ -23,18 +23,24 @@ function makeCtx(mode: PermissionMode): {
     stats: { permissionMode: mode },
     session: { current: { setPermissionMode } },
     ui: { repaintStatusLine: repaint },
-    out: { success: vi.fn(), error: vi.fn() },
+    // `line` carries the ON notice (a cool "full-power" badge, not a red alarm);
+    // `success` carries the OFF notice; `error` only fires on a toggle failure.
+    out: { line: vi.fn(), success: vi.fn(), error: vi.fn() },
   } as unknown as SlashContext;
   return { ctx, setPermissionMode, repaint };
 }
 
 describe('/bypass command', () => {
-  it('/bypass on from default → enters bypassPermissions, mirrors stats, repaints, continues', async () => {
+  it('/bypass on from default → enters bypassPermissions, mirrors stats, repaints, surfaces ON notice via line, continues', async () => {
     const { ctx, setPermissionMode, repaint } = makeCtx('default');
     const result = await bypassCmd.handler(ctx, 'on');
     expect(setPermissionMode).toHaveBeenCalledWith('bypassPermissions');
     expect(ctx.stats.permissionMode).toBe('bypassPermissions');
     expect(repaint).toHaveBeenCalled();
+    // ON notice routes through the plain line channel (not error/✗) so it reads
+    // as a "full-power" badge rather than a red alarm.
+    expect((ctx.out.line as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+    expect((ctx.out.error as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
     expect(result).toBe('continue');
   });
 

--- a/src/cli/slash/commands/bypass.ts
+++ b/src/cli/slash/commands/bypass.ts
@@ -29,15 +29,15 @@ import { palette } from '../../palette.js';
 import type { SlashCommand, SlashContext, SlashResult } from '../types.js';
 
 const ON_NOTICE =
-  palette.warning('⚠ bypass mode ON') +
+  palette.bypass('⚡ BYPASS ON') +
   palette.dim(
-    ' — path-approval prompts OFF; the agent can read/write ANY path on this ' +
-    'machine with no confirmation. Run /bypass off to restore containment. ' +
-    '(Does not affect ask_question.)',
+    ' — full-power mode: path-approval prompts OFF; the agent can read/write ANY ' +
+    'path on this machine with no confirmation. Run /bypass off to restore ' +
+    'containment. (Does not affect ask_question.)',
   );
 
 const OFF_NOTICE =
-  palette.success('○ bypass mode OFF') +
+  palette.success('○ BYPASS OFF') +
   palette.dim(' — default permissions restored (path containment + prompts back on)');
 
 export const bypassCmd: SlashCommand = {
@@ -70,9 +70,11 @@ export const bypassCmd: SlashCommand = {
       await ctx.session.current.setPermissionMode(desired ? 'bypassPermissions' : 'default');
       ctx.stats.permissionMode = desired ? 'bypassPermissions' : 'default';
       ctx.ui.repaintStatusLine();
-      // Use the error channel for the ON notice so the warning is visually
-      // prominent (it is a high-consequence, easy-to-forget mode).
-      if (desired) ctx.out.error(ON_NOTICE);
+      // ON notice goes through the plain line channel (not error/✗) so it reads
+      // as a cool "full-power" badge rather than a red alarm — bypass is the
+      // default mode, so the indicator informs without alarming. The dim text
+      // still spells out exactly what bypass does, so nothing is hidden.
+      if (desired) ctx.out.line(ON_NOTICE);
       else ctx.out.success(OFF_NOTICE);
     } catch (err) {
       ctx.out.error(

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -30,7 +30,8 @@ export interface StatusLineFields {
   /**
    * Current REPL permission mode. Renders a never-dropped indicator: `● plan`
    * (plan mode, warning tone), `◐ AFK` (autonomous/AFK mode, info tone), or
-   * `⚠ BYPASS` (bypassPermissions, warning tone). `'default'` renders none.
+   * `⚡ BYPASS` (bypassPermissions, bypass tone — a cool "full-power" badge, not
+   * a caution glyph, since bypass is the default mode). `'default'` renders none.
    */
   permissionMode?: PermissionMode;
   /**
@@ -367,7 +368,7 @@ export class StatusLine {
     } else if (f.permissionMode === 'autonomous') {
       parts.push({ text: palette.info('◐ AFK') }); // never drop
     } else if (f.permissionMode === 'bypassPermissions') {
-      parts.push({ text: palette.warning('⚠ BYPASS') }); // never drop
+      parts.push({ text: palette.bypass('⚡ BYPASS') }); // never drop
     }
 
     if (f.contextPct !== undefined) {


### PR DESCRIPTION
## What

Make the `bypassPermissions` indicator look like an intentional **full-power badge** instead of a cautionary warning — without hiding any information.

`bypassPermissions` is the default CLI permission mode now, so the old `⚠ BYPASS` (caution triangle + warning-yellow) showed up on *every* session and read as "something is wrong" when nothing is.

## Before / After

```
status line
BEFORE:  ~ · opus_1m · ⚠ BYPASS · [▓▓▓░░░] 42% · 423.3k/1m   (warning-yellow)
AFTER:   ~ · opus_1m · ⚡ BYPASS · [▓▓▓░░░] 42% · 423.3k/1m   (bold synthwave-pink)

/bypass toggle
ON  before:  ✗ ⚠ bypass mode ON — path-approval prompts OFF; …   (red error channel)
ON  after:   ⚡ BYPASS ON — full-power mode: path-approval prompts OFF; …   (plain line, pink)
OFF after:   ✓ ○ BYPASS OFF — default permissions restored …   (unchanged, green)
```

## Changes

- **`src/cli/palette.ts`** — new `palette.bypass` tone: `chalk.bold.hex('#FF6AC1')`. Chosen to stay distinct from the brand-orange model name and plan-mode lavender so the chip still pops and reads as its own thing.
- **`src/cli/status-line.ts`** — chip `⚠ BYPASS` (warning) → `⚡ BYPASS` (bypass tone); doc comment updated.
- **`src/cli/slash/commands/bypass.ts`** — `/bypass on` notice → `⚡ BYPASS ON` routed through the plain line channel instead of the red `✗` error channel; full explanatory text kept verbatim so nothing is hidden. OFF-notice casing aligned.
- **`src/cli/slash/commands/bypass.test.ts`** — mock now stubs the `line` channel; added assertion that the ON notice routes through `line` (not `error`).

## Why pink, not orange

The model name already renders brand-orange, so an orange badge would blend into it. Warm pink sits next to the orange as a sunset/synthwave pairing while staying clearly separate.

## Information preserved

The label (`BYPASS`) and the full "what it does" explanation are unchanged — this only moves the *tone* from cautionary to cool. People still know they're in bypass and exactly what that means.

## Testing

- `pnpm lint` (strict `tsc --noEmit`) — clean.
- `pnpm exec vitest run src/cli/status-line.test.ts src/cli/slash/commands/bypass.test.ts` — **45/45 pass**.
- Full-suite `better-sqlite3` failures seen locally are environmental (fresh worktree; pnpm skipped the native build script — "Could not locate the bindings file"), single root cause, all sqlite-backed, unrelated to this CLI-palette change.

## Easy follow-up tweaks

- Color is one line in `palette.ts` (`#FF6AC1`) — e.g. electric violet `#8B5CF6`.
- Glyph is one char in `status-line.ts` (`⚡`). Note `⚡` is emoji-class: terminals that force-color emoji won't tint the bolt itself — swap to a monochrome glyph (`✦`, `◆`) for guaranteed pink everywhere.
