### PR TITLE
feat(repl): Shift+Tab cycles permission modes (default → plan → bypass)

### DIFF
--- a/.afk/plans/shift-tab-permission-mode-cycle.md
+++ b/.afk/plans/shift-tab-permission-mode-cycle.md
@@ -1,0 +1,86 @@
+# Shift+Tab → cycle permission modes (3-mode ring)
+
+## Goal
+Make the REPL's **Shift+Tab** key cycle through permission modes instead of only
+toggling `plan ↔ default`.
+
+## Decision (chosen: option **a**, the safe 3-mode ring)
+Shift+Tab cycles a fixed ring **`default → plan → bypassPermissions → default`**.
+**AFK (`autonomous`) is deliberately excluded** from the keypress ring and stays
+on the `/afk` command. The one concession: if the session is *already* in
+`autonomous` (operator ran `/afk on`), Shift+Tab exits AFK cleanly (full
+teardown) and lands on `default` — so the key still does something sensible from
+AFK without ever *entering* it on a transient press.
+
+Built the **cheap way** (devils-advocate pragmatist): no extraction refactor of
+`afk-mode-toggle.ts`. `plan`/`bypass`/`default` are pure `setPermissionMode`
+flips; the AFK-exit case reuses the existing `toggleAfkMode(ctx, false)` helper.
+
+## Verified facts (shadow-verify, all CONFIRMED via independent re-derivation)
+- 4 modes: `default`, `plan`, `autonomous` (AFK), `bypassPermissions`. New
+  installs default to `bypassPermissions` (`config.ts:342` `DEFAULT_CLI_PERMISSION_MODE`).
+- Shift+Tab wired at exactly 2 call sites, both calling `togglePlanMode(ctx.slashCtx)`:
+  `surface-setup.ts:~103` (persistent compositor) and `loop-iteration.ts:~206`
+  (readLine fallback). `reader.ts`/`terminal-compositor*` only forward the callback.
+- `toggleAfkMode` (`afk-mode-toggle.ts`) owns AFK's enter/exit machinery
+  (push-budget reset, elicitation→ledger swap, abort-watcher start/stop,
+  presence on/off) — all gated on `(sessionId && swap && fallback)`. These live
+  ONLY there, not in `session.setPermissionMode` (`agent-session.ts:750`) nor in
+  any provider `setPermissionMode` (anthropic-direct/openai-compatible/router).
+  A raw `setPermissionMode('autonomous')` would leak the abort-watcher + strand presence.
+- `togglePlanMode` and `/bypass` are pure (setPermissionMode + stats mirror +
+  repaint + copy; no teardown).
+- `plan-mode-addendum.test.ts` asserts `'/plan off'` literal but does NOT snapshot
+  the `Shift+Tab` parenthetical — so rewording it stays green.
+- `buildPrompt` (`repl-loop-shared.ts:~59`) renders a marker for `plan` and
+  `autonomous` but NOT `bypassPermissions`.
+- `repl-loop-wiring.test.ts:64` + `loop-iteration.test.ts:73` both
+  `vi.mock('../../plan-mode-toggle.js')`. NUANCE: neither test actually *fires*
+  the `onShiftTab` handler (FakeInputSurface stores/ignores it), so repointing
+  won't break them — swapping the mock target is defensive (hermeticity).
+
+## Step-by-step changes
+1. **New `src/cli/permission-mode-cycle.ts`** — `PERMISSION_CYCLE =
+   ['default','plan','bypassPermissions']` + `cyclePermissionMode(ctx)`:
+   - `cur === 'autonomous'` → `await toggleAfkMode(ctx, false)` (clean exit to default); return.
+   - else `idx = indexOf(cur)`; `next = ring[(idx+1) % len]` (out-of-ring → idx -1 → default).
+   - `setPermissionMode(next)` + mirror `stats.permissionMode` + `repaintStatusLine()` + per-mode copy.
+   - On `setPermissionMode` rejection: leave `stats` unchanged, surface via `ctx.out.error` (mirrors `togglePlanMode` contract).
+2. **Repoint both `onShiftTab` handlers** (`surface-setup.ts`, `loop-iteration.ts`)
+   from `togglePlanMode(ctx.slashCtx)` → `cyclePermissionMode(ctx.slashCtx)`; update inline comments.
+3. **`buildPrompt`** (`repl-loop-shared.ts`) — add a `⚡ bypass` marker for prompt parity (status line already shows the chip).
+4. **Doc/tip/addendum updates** (no behavior):
+   - `loading-tips.ts:56` — "Shift+Tab cycles permission modes (default → plan → bypass)".
+   - `input/types.ts:71-73` — `onShiftTab` doc comment.
+   - `plan-mode-addendum.ts:49` — reword Shift+Tab parenthetical; KEEP `/plan off`.
+   - `slash/commands/plan.ts` — doc (47-49) + hint (102).
+   - `plan-mode-toggle.ts` — doc (13-14) + first-use tip (40).
+   - `CHANGELOG.md` — add entry.
+   - (`afk-mode-addendum.ts:46` "(or Shift+Tab) to restore default" stays accurate — AFK→Shift+Tab still lands on default.)
+5. **Tests**:
+   - New `permission-mode-cycle.test.ts` — ring advances default→plan→bypass→default; autonomous→`toggleAfkMode(false)`; out-of-ring→default; rejection leaves stats unchanged + errors.
+   - Swap `vi.mock('plan-mode-toggle.js')` → `vi.mock('permission-mode-cycle.js')` in `repl-loop-wiring.test.ts` + `loop-iteration.test.ts`.
+6. **Gates**: `pnpm lint` (strict tsc) + focused vitest (permission-mode-cycle, plan-mode-toggle, afk-mode-toggle, repl-loop-wiring, loop-iteration, plan-mode-addendum, status-line) + full suite.
+
+## Risks
+- **Lost "Shift+Tab exits plan" muscle memory / model desync.** From plan,
+  Shift+Tab now → bypass, not default. Mitigated: reword `plan-mode-addendum.ts`
+  (model-facing) + tips, keep `/plan off` for save-and-implement.
+- **Accidental bypass escalation** via stray double-press from default. Accepted:
+  bypass is already the new-install default, so it's not new exposure for most
+  users; the ring is forward-only and the status line + prompt marker show the mode.
+- **AFK churn** — eliminated by excluding AFK from the ring.
+
+## Alternatives considered (devils-advocate; dissent=true, user chose)
+- **O (original):** 4-mode ring + extract AFK helpers. Dropped — extraction
+  unnecessary (`toggleAfkMode` already takes a boolean); strictly dominated by P.
+- **P (pragmatist, strong):** 4-mode ring reusing existing toggles, no extraction.
+  Adopted its build approach; user chose 3-mode over its 4-mode for safety.
+- **R (paranoid, strong):** keep Shift+Tab=plan toggle + separate guarded key for
+  AFK/bypass; no wrap through bypass. Drove the decision to exclude AFK and pick
+  the safe ring. Repo evidence: `settable-keys.test.ts:95` names `permissionMode`
+  a "self-escalation vector"; AFK machinery non-idempotent; `surface-setup.ts:107-108`
+  calls Shift+Tab the "manual-takeover escape hatch."
+- **A (architect, medium):** unified `PermissionModeManager.transitionTo` for all
+  entry points. Deferred as YAGNI — only Shift+Tab needs cycling; revisit if a
+  second new caller (config restore, Telegram `/mode`) appears.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Changed
+- Shift+Tab now cycles permission modes (default → plan → bypass) instead of toggling plan mode on/off; AFK (autonomous) stays on `/afk` and, if active, Shift+Tab exits it cleanly to default
+
 ## [4.24.0] - 2026-06-20
 
 ### Added

--- a/src/agent/providers/anthropic-direct/plan-mode-addendum.ts
+++ b/src/agent/providers/anthropic-direct/plan-mode-addendum.ts
@@ -46,7 +46,7 @@ export const PLAN_MODE_ADDENDUM_TEXT = [
   '  - `devils-advocate` — generate alternatives and rank them before committing',
   '  - `shadow-verify` — independently re-derive load-bearing claims',
   '',
-  'Do not declare readiness silently. When the plan is ready, state: chosen approach, risks named, and alternatives considered. The user will then exit plan mode with `/plan off`, which has you save this plan to a file and implement it (Shift+Tab exits without implementing) — so keep the plan concrete and complete enough to act on directly.',
+  'Do not declare readiness silently. When the plan is ready, state: chosen approach, risks named, and alternatives considered. The user will then exit plan mode with `/plan off`, which has you save this plan to a file and implement it (Shift+Tab instead advances the permission-mode ring without saving or implementing) — so keep the plan concrete and complete enough to act on directly.',
 ].join('\n');
 
 /**

--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -70,7 +70,7 @@ vi.mock('./verdict-ledger.js', () => ({
 vi.mock('../../slash/commands/sh.js', () => ({ setShellPassthrough: vi.fn() }));
 vi.mock('../../debug-banner.js', () => ({ renderDebugBanner: () => '' }));
 vi.mock('../../../utils/debug.js', () => ({ isDebugEnabled: () => false, debugLog: () => {} }));
-vi.mock('../../plan-mode-toggle.js', () => ({ togglePlanMode: vi.fn(async () => {}) }));
+vi.mock('../../permission-mode-cycle.js', () => ({ cyclePermissionMode: vi.fn(async () => {}) }));
 
 // Shell-passthrough mock — `dispatch` routes to the hoisted spy so the
 // shell-branch test can assert it was invoked; drain methods are inert.

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -13,7 +13,7 @@ import { renderDebugBanner } from '../../debug-banner.js';
 import { isDebugEnabled, debugLog } from '../../../utils/debug.js';
 import { env } from '../../../config/env.js';
 import { palette } from '../../palette.js';
-import { togglePlanMode } from '../../plan-mode-toggle.js';
+import { cyclePermissionMode } from '../../permission-mode-cycle.js';
 import {
   autoRegisterPluginPassthroughs,
   getPluginShadowingNoticeLines,
@@ -204,11 +204,12 @@ export async function runInputLoop(
           promptFn: () => buildPrompt(ctx.stats.model, ctx.stats.permissionMode),
           onSigint: sigintHandler,
           onShiftTab: () => {
-            // Shift+Tab is the keyboard speed lane: a raw plan-mode flip with
-            // no seeded turn. It exits plan mode WITHOUT saving or implementing
-            // the plan — the manual-takeover escape hatch. (`/plan off`, by
-            // contrast, flips and then seeds a save-and-implement turn.)
-            togglePlanMode(ctx.slashCtx).catch(() => {});
+            // Shift+Tab is the keyboard speed lane: it advances the permission-
+            // mode ring default → plan → bypass → default (AFK is excluded —
+            // it stays on /afk; if already in AFK, Shift+Tab exits it to
+            // default). No seeded turn. (`/plan off`, by contrast, exits plan
+            // and seeds a save-and-implement turn.)
+            cyclePermissionMode(ctx.slashCtx).catch(() => {});
             ctx.statusLine.rearm();
           },
         });

--- a/src/cli/commands/interactive/repl-loop-shared.ts
+++ b/src/cli/commands/interactive/repl-loop-shared.ts
@@ -61,6 +61,7 @@ export function buildPrompt(model: string, mode: PermissionMode): string {
   const marker =
     mode === 'plan' ? palette.warning(' ● plan') :
     mode === 'autonomous' ? palette.info(' ◐ AFK') :
+    mode === 'bypassPermissions' ? palette.bypass(' ⚡ bypass') :
     '';
   return base + marker + palette.dim('  › ');
 }

--- a/src/cli/commands/interactive/repl-loop-wiring.test.ts
+++ b/src/cli/commands/interactive/repl-loop-wiring.test.ts
@@ -61,8 +61,8 @@ vi.mock('./verdict-ledger.js', () => ({
 }));
 vi.mock('../../debug-banner.js', () => ({ renderDebugBanner: () => '' }));
 vi.mock('../../../utils/debug.js', () => ({ isDebugEnabled: () => false }));
-vi.mock('../../plan-mode-toggle.js', () => ({
-  togglePlanMode: vi.fn(async () => {}),
+vi.mock('../../permission-mode-cycle.js', () => ({
+  cyclePermissionMode: vi.fn(async () => {}),
 }));
 
 // Fake TerminalCompositor for the completionWriter idle-wiring test.

--- a/src/cli/commands/interactive/repl-loop-wiring.test.ts
+++ b/src/cli/commands/interactive/repl-loop-wiring.test.ts
@@ -520,3 +520,46 @@ describe('runReplLoop — AFK_SUGGEST_GHOST: ghost-text master toggle', () => {
     expect(armOpts2.suggest!.getContext().llmEnabled()).toBe(false);
   });
 });
+
+/**
+ * Regression test — Shift+Tab routes to the permission-mode cycle (PR #225).
+ *
+ * `setupSurface` hands the persistent compositor an `onShiftTab` closure that
+ * must call `cyclePermissionMode(ctx.slashCtx)` — the default → plan → bypass
+ * ring — NOT the historical `togglePlanMode`. The unit suite covers the cycle
+ * itself; this test covers the WIRING end-to-end by firing the real closure
+ * captured off `armCompositor`. Before PR #225 the keypress→handler wiring had
+ * no test at all (the fake input surface stored `onShiftTab` but never invoked
+ * it), so a silent repoint regression would have gone unnoticed.
+ */
+describe('runReplLoop — Shift+Tab wired to cyclePermissionMode (persistent compositor)', () => {
+  it('the armCompositor onShiftTab closure invokes cyclePermissionMode(ctx.slashCtx) and rearms the status line', async () => {
+    const cycleMod = await import('../../permission-mode-cycle.js');
+    const cycleSpy = vi.mocked(cycleMod.cyclePermissionMode);
+    cycleSpy.mockClear();
+
+    const ctx = makeMinimalCtx(new BackgroundAgentRegistry({}));
+    const turnState: TurnState = {
+      turnInFlight: false,
+      lastSigintAt: 0,
+      activeCompositor: null,
+    } as TurnState;
+
+    await runReplLoop(ctx, makeTranscript() as never, turnState, vi.fn());
+
+    // The closure is installed during bootstrap (armCompositor) but never fired
+    // by the loop itself — so the cycle has NOT run yet.
+    expect(cycleSpy).not.toHaveBeenCalled();
+
+    const armOpts = fakeCompositorState.lastArmOpts as { onShiftTab?: () => void };
+    expect(typeof armOpts.onShiftTab).toBe('function');
+
+    // Fire the captured handler — this exercises the REAL surface-setup.ts
+    // closure, not a re-implementation.
+    armOpts.onShiftTab!();
+
+    expect(cycleSpy).toHaveBeenCalledTimes(1);
+    expect(cycleSpy).toHaveBeenCalledWith(ctx.slashCtx);
+    expect(ctx.statusLine.rearm).toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/interactive/surface-setup.ts
+++ b/src/cli/commands/interactive/surface-setup.ts
@@ -6,7 +6,7 @@ import { runPicker } from '../../render/picker.js';
 import { runTextInput } from '../../render/text-input.js';
 import { debugLog } from '../../../utils/debug.js';
 import { env } from '../../../config/env.js';
-import { togglePlanMode } from '../../plan-mode-toggle.js';
+import { cyclePermissionMode } from '../../permission-mode-cycle.js';
 import type { InteractiveCtx } from './shared.js';
 import { formatStatusFields } from './shared.js';
 import type { TranscriptHandle } from './transcript.js';
@@ -103,10 +103,10 @@ export async function setupSurface(
     onShiftTab: () => {
       // Replicated from the user-turn onShiftTab handler below — the
       // persistent compositor uses ONE onShiftTab across both phases
-      // (plan-mode toggle is REPL-global, not turn-scoped). Shift+Tab is a
-      // raw flip with no seeded turn: the "exit plan mode without saving or
-      // implementing" escape hatch (cf. `/plan off`, which saves + implements).
-      togglePlanMode(ctx.slashCtx).catch(() => {});
+      // (the permission-mode cycle is REPL-global, not turn-scoped). Shift+Tab
+      // advances the ring default → plan → bypass → default (AFK stays on
+      // /afk); cf. `/plan off`, which saves the plan + implements it.
+      cyclePermissionMode(ctx.slashCtx).catch(() => {});
       ctx.statusLine.rearm();
     },
     // StatusLine doubles as DECSTBM scroll-region guard so commitAbove

--- a/src/cli/input/types.ts
+++ b/src/cli/input/types.ts
@@ -69,8 +69,8 @@ export interface ReadWithAutocompleteOpts {
   initialBuffer?: string;
   /**
    * Invoked when the user presses Shift+Tab (sequence `\x1b[Z` or
-   * `{ shift: true, name: 'tab' }`). Used by the REPL to toggle plan mode
-   * without requiring the user to type a slash command.
+   * `{ shift: true, name: 'tab' }`). Used by the REPL to cycle permission
+   * modes (default → plan → bypass) without typing a slash command.
    *
    * Only fires on the TTY path — non-TTY input never generates keypresses.
    */

--- a/src/cli/loading-tips.ts
+++ b/src/cli/loading-tips.ts
@@ -53,7 +53,7 @@ const STATIC_TIPS: readonly LoadingTip[] = [
   },
   {
     id: 'kbd:shift-tab',
-    text: 'Shift+Tab toggles plan mode (write tools refused) without leaving the prompt.',
+    text: 'Shift+Tab cycles permission modes: default → plan → bypass (AFK stays on /afk).',
     source: 'static',
   },
   {

--- a/src/cli/permission-mode-cycle.test.ts
+++ b/src/cli/permission-mode-cycle.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for the Shift+Tab permission-mode cycle.
+ *
+ * `cyclePermissionMode` advances the ring default → plan → bypassPermissions →
+ * default. AFK (`autonomous`) is excluded from the ring: if the session is
+ * already in autonomous, the cycle exits it via `toggleAfkMode(ctx, false)`
+ * (mocked here) rather than stepping to a ring mode — never entering AFK on a
+ * keypress. plan/bypass/default transitions are pure setPermissionMode flips
+ * with the same rejection contract as togglePlanMode (leave stats unchanged +
+ * surface error).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { cyclePermissionMode, PERMISSION_CYCLE } from './permission-mode-cycle.js';
+import { toggleAfkMode } from './afk-mode-toggle.js';
+import type { SessionStats, SlashContext } from './slash/types.js';
+
+// AFK's heavy enter/exit machinery is out of scope here — stub the helper so we
+// can assert the cycle DELEGATES the autonomous-exit to it (rather than firing a
+// raw setPermissionMode that would leak the abort-watcher / strand presence).
+vi.mock('./afk-mode-toggle.js', () => ({
+  toggleAfkMode: vi.fn(async () => {}),
+}));
+
+function makeStats(overrides: Partial<SessionStats> = {}): SessionStats {
+  return {
+    totalTurns: 0,
+    totalCostUsd: 0,
+    totalTokens: 0,
+    totalDurationMs: 0,
+    sessionStartTime: Date.now(),
+    turnCosts: [],
+    turnTokens: [],
+    turns: [],
+    model: 'sonnet',
+    permissionMode: 'default',
+    ...overrides,
+  };
+}
+
+interface FakeSession {
+  setPermissionMode: ReturnType<typeof vi.fn>;
+}
+
+function makeCtx(opts: {
+  stats: SessionStats;
+  setPermissionMode?: ReturnType<typeof vi.fn>;
+}): { ctx: SlashContext; sess: FakeSession; lines: string[] } {
+  const lines: string[] = [];
+  const sess: FakeSession = {
+    setPermissionMode: opts.setPermissionMode ?? vi.fn().mockResolvedValue(undefined),
+  };
+  const ctx: SlashContext = {
+    session: { current: sess } as unknown as SlashContext['session'],
+    stats: opts.stats,
+    out: {
+      line: (t = '') => lines.push(t),
+      raw: (t) => lines.push(t),
+      success: (t) => lines.push(`SUCCESS:${t}`),
+      info: (t) => lines.push(`INFO:${t}`),
+      warn: (t) => lines.push(`WARN:${t}`),
+      error: (t) => lines.push(`ERROR:${t}`),
+    },
+    ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
+  };
+  return { ctx, sess, lines };
+}
+
+describe('cyclePermissionMode', () => {
+  beforeEach(() => {
+    vi.mocked(toggleAfkMode).mockClear();
+  });
+
+  it('ring constant excludes autonomous (AFK stays on /afk)', () => {
+    expect(PERMISSION_CYCLE).toEqual(['default', 'plan', 'bypassPermissions']);
+    expect(PERMISSION_CYCLE as readonly string[]).not.toContain('autonomous');
+  });
+
+  it('default → plan and emits plan ON copy', async () => {
+    const stats = makeStats({ permissionMode: 'default' });
+    const { ctx, sess, lines } = makeCtx({ stats });
+
+    await cyclePermissionMode(ctx);
+
+    expect(sess.setPermissionMode).toHaveBeenCalledWith('plan');
+    expect(stats.permissionMode).toBe('plan');
+    expect(ctx.ui.repaintStatusLine).toHaveBeenCalled();
+    expect(lines.join('\n').toLowerCase()).toContain('plan mode on');
+  });
+
+  it('plan → bypassPermissions and emits bypass copy', async () => {
+    const stats = makeStats({ permissionMode: 'plan' });
+    const { ctx, sess, lines } = makeCtx({ stats });
+
+    await cyclePermissionMode(ctx);
+
+    expect(sess.setPermissionMode).toHaveBeenCalledWith('bypassPermissions');
+    expect(stats.permissionMode).toBe('bypassPermissions');
+    expect(lines.join('\n').toLowerCase()).toContain('bypass on');
+  });
+
+  it('bypassPermissions → default (wraps) and emits default copy', async () => {
+    const stats = makeStats({ permissionMode: 'bypassPermissions' });
+    const { ctx, sess, lines } = makeCtx({ stats });
+
+    await cyclePermissionMode(ctx);
+
+    expect(sess.setPermissionMode).toHaveBeenCalledWith('default');
+    expect(stats.permissionMode).toBe('default');
+    expect(lines.join('\n').toLowerCase()).toContain('default');
+  });
+
+  it('autonomous (AFK) → exits via toggleAfkMode(ctx, false), never a raw setPermissionMode', async () => {
+    const stats = makeStats({ permissionMode: 'autonomous' });
+    const { ctx, sess } = makeCtx({ stats });
+
+    await cyclePermissionMode(ctx);
+
+    expect(toggleAfkMode).toHaveBeenCalledWith(ctx, false);
+    expect(sess.setPermissionMode).not.toHaveBeenCalled();
+  });
+
+  it('out-of-ring mode (e.g. acceptEdits) falls back to default', async () => {
+    const stats = makeStats({ permissionMode: 'acceptEdits' });
+    const { ctx, sess } = makeCtx({ stats });
+
+    await cyclePermissionMode(ctx);
+
+    expect(sess.setPermissionMode).toHaveBeenCalledWith('default');
+    expect(stats.permissionMode).toBe('default');
+    expect(toggleAfkMode).not.toHaveBeenCalled();
+  });
+
+  it('leaves permissionMode unchanged and surfaces an error when setPermissionMode rejects', async () => {
+    // Mirrors togglePlanMode's failure contract: a provider query-handle
+    // rejection must NOT advance stats.permissionMode (the prompt/status line
+    // read it back).
+    const setPermissionMode = vi.fn().mockRejectedValue(new Error('boom'));
+    const stats = makeStats({ permissionMode: 'default' });
+    const { ctx, lines } = makeCtx({ stats, setPermissionMode });
+
+    await cyclePermissionMode(ctx);
+
+    expect(setPermissionMode).toHaveBeenCalledWith('plan');
+    expect(stats.permissionMode).toBe('default');
+    expect(lines.some((l) => l.startsWith('ERROR:'))).toBe(true);
+  });
+});

--- a/src/cli/permission-mode-cycle.test.ts
+++ b/src/cli/permission-mode-cycle.test.ts
@@ -96,6 +96,7 @@ describe('cyclePermissionMode', () => {
 
     expect(sess.setPermissionMode).toHaveBeenCalledWith('bypassPermissions');
     expect(stats.permissionMode).toBe('bypassPermissions');
+    expect(ctx.ui.repaintStatusLine).toHaveBeenCalled();
     expect(lines.join('\n').toLowerCase()).toContain('bypass on');
   });
 
@@ -107,7 +108,16 @@ describe('cyclePermissionMode', () => {
 
     expect(sess.setPermissionMode).toHaveBeenCalledWith('default');
     expect(stats.permissionMode).toBe('default');
-    expect(lines.join('\n').toLowerCase()).toContain('default');
+    expect(ctx.ui.repaintStatusLine).toHaveBeenCalled();
+    // Wrapping out of bypass is a pure ring step — it must NOT touch the AFK
+    // teardown helper (that path is reserved for `autonomous`).
+    expect(toggleAfkMode).not.toHaveBeenCalled();
+    // Pin the distinctive default-landing copy ("… approval prompts restored."),
+    // not merely the substring "default" (which also appears in the marker glyph
+    // and would match almost any output).
+    const out = lines.join('\n').toLowerCase();
+    expect(out).toContain('default');
+    expect(out).toContain('restored');
   });
 
   it('autonomous (AFK) → exits via toggleAfkMode(ctx, false), never a raw setPermissionMode', async () => {

--- a/src/cli/permission-mode-cycle.ts
+++ b/src/cli/permission-mode-cycle.ts
@@ -1,0 +1,103 @@
+/**
+ * Shift+Tab permission-mode cycle for the REPL.
+ *
+ * `cyclePermissionMode` advances the session through a fixed ring of three
+ * permission modes — `default → plan → bypassPermissions → default` — one step
+ * per Shift+Tab press. It is the keyboard speed-lane that replaces the historical
+ * Shift+Tab plan-toggle: instead of flipping `plan ↔ default`, it walks the ring.
+ * Both onShiftTab handlers (the persistent compositor in `surface-setup.ts` and
+ * the readLine fallback in `loop-iteration.ts`) call this.
+ *
+ * Invariant: AFK (`autonomous`) is deliberately NOT in the ring. Entering AFK
+ * runs heavy, non-idempotent machinery — Telegram push-budget reset, swapping the
+ * elicitation handler to the ledger channel, starting an abort-watcher, setting a
+ * presence marker (all in `toggleAfkMode`) — that must not fire on a transient
+ * keypress pass-through. AFK stays on the `/afk` command. The one concession: if
+ * the session is ALREADY in `autonomous` (the operator ran `/afk on`), Shift+Tab
+ * exits AFK via `toggleAfkMode(ctx, false)` — which runs the full teardown — and
+ * lands on `default`. So the key does something sensible from AFK without ever
+ * ENTERING it; the next press resumes the ring at `default → plan`.
+ *
+ * Contract: `plan`/`bypass`/`default` transitions are pure `setPermissionMode`
+ * flips. The plan-mode gate and the bypass allow-all are keyed off
+ * `permissionMode` alone with no enter/exit machinery, so the ring sets the mode
+ * directly, mirrors `stats.permissionMode` (the value the prompt + status line +
+ * gate getters read), repaints, and emits per-mode copy. On a `setPermissionMode`
+ * rejection (provider query handle closing/torn down) `stats.permissionMode` is
+ * left unchanged and the error is surfaced — mirroring `togglePlanMode`'s
+ * failure contract.
+ */
+
+import { toggleAfkMode } from './afk-mode-toggle.js';
+import { palette } from './palette.js';
+import type { SlashContext } from './slash/types.js';
+
+/**
+ * The Shift+Tab ring. `autonomous` (AFK) is intentionally excluded — see the
+ * module-level invariant. Order is load-bearing: `default → plan` preserves the
+ * historical "first press from the prompt enters plan" muscle memory, and the
+ * wrap `bypassPermissions → default` keeps the cycle forward-only.
+ */
+export const PERMISSION_CYCLE = ['default', 'plan', 'bypassPermissions'] as const;
+
+type CycleMode = (typeof PERMISSION_CYCLE)[number];
+
+/** Emit the one-line status copy for the mode the ring just landed on. */
+function emitCycleCopy(ctx: SlashContext, mode: CycleMode): void {
+  switch (mode) {
+    case 'plan':
+      ctx.out.success(
+        palette.warning('● plan mode ON') +
+          palette.dim(' — writes refused; read-only bash runs, mutating bash blocked.'),
+      );
+      return;
+    case 'bypassPermissions':
+      // Plain line (not the ✓ channel) so bypass reads as a cool "full-power"
+      // badge rather than a red alarm — matches the `/bypass` ON notice.
+      ctx.out.line(
+        palette.bypass('⚡ BYPASS ON') +
+          palette.dim(
+            ' — path-approval prompts + containment OFF; read/write any path. ' +
+              '(Does not affect ask_question.)',
+          ),
+      );
+      return;
+    case 'default':
+      ctx.out.success(
+        palette.success('○ default') +
+          palette.dim(' — path containment + approval prompts restored.'),
+      );
+      return;
+  }
+}
+
+/**
+ * Advance one step through the permission-mode ring. See module doc for the
+ * AFK-exit concession and the failure contract.
+ */
+export async function cyclePermissionMode(ctx: SlashContext): Promise<void> {
+  const cur = ctx.stats.permissionMode;
+
+  // AFK is not a ring stop. If we are in it (operator ran `/afk on`), exit
+  // cleanly via the helper that runs the teardown, landing on `default`.
+  if (cur === 'autonomous') {
+    await toggleAfkMode(ctx, false);
+    return;
+  }
+
+  const idx = PERMISSION_CYCLE.indexOf(cur as CycleMode);
+  // idx === -1 for any out-of-ring mode (acceptEdits/dontAsk/auto) → (−1+1)=0 →
+  // start at `default`. The modulo wraps `bypassPermissions` (last) → `default`.
+  const next = PERMISSION_CYCLE[(idx + 1) % PERMISSION_CYCLE.length] ?? 'default';
+
+  try {
+    await ctx.session.current.setPermissionMode(next);
+    ctx.stats.permissionMode = next;
+    ctx.ui.repaintStatusLine();
+    emitCycleCopy(ctx, next);
+  } catch (err) {
+    ctx.out.error(
+      `Could not switch permission mode: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/src/cli/plan-mode-toggle.ts
+++ b/src/cli/plan-mode-toggle.ts
@@ -1,17 +1,16 @@
 /**
  * Shared toggle helper for plan mode.
  *
- * `togglePlanMode` is used by the /plan slash command and the Shift+Tab
- * keybinding in the REPL input loop. Both paths emit identical copy and
- * update the same stats/status-line plumbing. It flips the session permission
- * mode (`'plan'` <-> `'default'`) and mirrors the result onto
- * `stats.permissionMode` — the value the REPL prompt and status line read.
+ * `togglePlanMode` is used by the `/plan` slash command. (Shift+Tab no longer
+ * calls it directly — it routes through `cyclePermissionMode` in
+ * `permission-mode-cycle.ts`, which advances the ring default → plan → bypass.)
+ * It flips the session permission mode (`'plan'` <-> `'default'`) and mirrors the
+ * result onto `stats.permissionMode` — the value the REPL prompt and status
+ * line read.
  *
- * Exit semantics differ by entry point and live in the callers, not here:
- *   - `/plan off` (slash command) flips to default, then seeds a turn that
- *     saves the plan to a file and implements it (see `slash/commands/plan.ts`).
- *   - Shift+Tab calls this helper raw — a bare flip with no seeded turn, the
- *     "exit without implementing" escape hatch.
+ * Exit semantics live in the caller, not here: `/plan off` flips to default,
+ * then seeds a turn that saves the plan to a file and implements it (see
+ * `slash/commands/plan.ts`).
  *
  * If `setPermissionMode` rejects (e.g. the provider's query handle is closing
  * or already torn down), `stats.permissionMode` is left unchanged and the
@@ -37,7 +36,7 @@ export async function togglePlanMode(
     if (next) {
       const tip = hasShownFirstUseTip
         ? ''
-        : palette.dim(' /plan off saves the plan + implements; Shift+Tab just exits.');
+        : palette.dim(' /plan off saves the plan + implements; Shift+Tab cycles to the next mode.');
       if (!hasShownFirstUseTip) hasShownFirstUseTip = true;
       ctx.out.success(
         palette.warning('● plan mode ON') +

--- a/src/cli/slash/commands/plan.ts
+++ b/src/cli/slash/commands/plan.ts
@@ -44,9 +44,10 @@
  * seeded: seeding one while writes are still refused would only produce a
  * wall of gate refusals.
  *
- * Escape hatch: Shift+Tab from the REPL performs a raw `togglePlanMode` flip
- * with no seeded turn — exit plan mode WITHOUT saving or implementing. Use it
- * to take manual control after planning.
+ * Escape hatch: Shift+Tab from the REPL advances the permission-mode ring
+ * (default → plan → bypass) with no seeded turn — it does NOT save or implement.
+ * From plan mode it steps to bypass; use it to drop planning and take manual
+ * control. (Cycle lives in `permission-mode-cycle.ts`.)
  *
  * Scope: plan mode is a REPL-only conversation affordance. Other surfaces
  * (Telegram) never enter plan mode (their sessions are constructed with
@@ -99,7 +100,7 @@ export const planCmd: SlashCommand = {
   name: '/plan',
   usage: '/plan [on|off|<prompt>]',
   summary: 'Toggle plan mode; /plan off saves the plan to a file then implements it',
-  hint: 'Think through an approach without changing anything — write tools and state-mutating bash are refused until you exit; read-only investigation runs. /plan off saves the plan + implements it; Shift+Tab exits without implementing.',
+  hint: 'Think through an approach without changing anything — write tools and state-mutating bash are refused until you exit; read-only investigation runs. /plan off saves the plan + implements it; Shift+Tab cycles to the next mode without implementing.',
   async handler(ctx, args): Promise<SlashResult> {
     const arg = args.trim();
     const argLower = arg.toLowerCase();


### PR DESCRIPTION
## Summary
- Shift+Tab in the REPL now cycles permission modes `default → plan → bypassPermissions → default` instead of only toggling plan↔default — every keyboard-reachable mode is one press apart.
- **AFK (`autonomous`) is deliberately excluded** from the keypress ring. Its enter/exit machinery (Telegram push-budget reset, elicitation→ledger swap, abort-watcher, presence marker) is too heavy to fire on a transient pass-through. It stays on `/afk`; if the session is already in AFK, Shift+Tab exits it cleanly to `default` via `toggleAfkMode` (full teardown).
- `plan`/`bypass`/`default` are pure `setPermissionMode` flips; the autonomous-exit case reuses the existing `toggleAfkMode` helper, so no teardown leaks and no extraction refactor was needed.
- Reworded the model-facing plan-mode addendum, the loading tip, `/plan` docs, and `plan-mode-toggle` comments that described the old "Shift+Tab exits plan" semantics; added a `⚡ bypass` prompt marker for parity with the status line.

## Why this design (3-mode, AFK excluded)
A `/shadow-verify` pass confirmed AFK's machinery lives only in `toggleAfkMode` (a raw `setPermissionMode('autonomous')` would leak the abort-watcher / strand presence). A `/devils-advocate` pass surfaced the safety case for keeping AFK off an unguarded single keypress (`permissionMode` is a documented self-escalation vector; AFK side-effects are non-idempotent). The 3-mode ring meets the goal — fast keyboard mode-switching — without that risk; AFK remains on `/afk`. Full rationale + alternatives in `.afk/plans/shift-tab-permission-mode-cycle.md`.

## Test results
- `pnpm lint` (tsc --noEmit, strict): clean.
- Targeted vitest (permission-mode-cycle, plan-mode-toggle, afk-mode-toggle, repl-loop-wiring, loop-iteration, plan-mode-addendum, status-line): **87 passed**.
- Full suite (`vitest run`): **9777 passed, 12 skipped, 2 failed**. The 2 failures are pre-existing and unrelated — model-id string mismatches (`claude-haiku-4-5` vs `…-20251001`) in `src/cli/config.test.ts:538` and `src/agent/providers/anthropic-direct.test.ts:1070`; neither file is touched by this PR.

## Verification
Adversarial read-only verifier re-derived the load-bearing claims from the diff: **CONFIRMED** — (1) both `onShiftTab` handlers repointed to `cyclePermissionMode` with no dangling `togglePlanMode` import (passes `noUnusedLocals`); (2) ring math correct, AFK delegates to `toggleAfkMode(ctx, false)`, unknown current-mode falls back to `default` with no off-by-one and no `undefined` index access under `noUncheckedIndexedAccess`; (3) neither pre-existing-failing file (`config.ts`, `anthropic-direct.ts`) is in the diff.
