### PR TITLE
feat(improve): add `cards list --regressed` observability view

### DIFF
--- a/src/cli/commands/improve.ts
+++ b/src/cli/commands/improve.ts
@@ -9,8 +9,10 @@
  *       Scan witness traces, run every registered detector, print a
  *       summary. Default is DRY-RUN; pass `--write` to persist cards.
  *
- *   afk improve cards list [--pattern] [--severity] [--status] [--json]
- *       Tabular listing of all cards on disk.
+ *   afk improve cards list [--pattern] [--severity] [--status] [--regressed] [--json]
+ *       Tabular listing of all cards on disk. `--regressed` narrows to
+ *       resolved/deferred cards that fired again after their latest triage
+ *       note (a read-side observability view; never changes status).
  *
  *   afk improve cards show <slug> [--json]
  *       Print one card.
@@ -81,7 +83,8 @@ import {
   disabledByDefaultDetectorNames,
   type DetectorOptions,
 } from '../../improve/scan/detectors/index.js';
-import { writeCard, listCards, getCard } from '../../improve/scan/card-writer.js';
+import { writeCard, listCards, getCard, listRegressedCards } from '../../improve/scan/card-writer.js';
+import type { RegressedCardEntry } from '../../improve/scan/card-writer.js';
 import { renderMarkdown } from '../../improve/scan/card-writer.js';
 import { triageCard, TriageError } from '../../improve/triage.js';
 import type { CardStatus } from '../../improve/schemas.js';
@@ -320,6 +323,55 @@ function registerScanSubcommand(improve: Command): void {
 // cards (group)
 // ---------------------------------------------------------------------------
 
+/**
+ * Render the `cards list --regressed` view: resolved/deferred cards that kept
+ * firing after their latest triage note. Read-only — surfaces an observability
+ * signal, never changes status. Composes with --pattern/--severity/--status.
+ */
+function renderRegressedList(opts: {
+  pattern?: string;
+  severity?: string;
+  status?: string;
+  json: boolean;
+}): void {
+  let rows: RegressedCardEntry[] = listRegressedCards();
+  if (opts.pattern) rows = rows.filter((e) => e.pattern === opts.pattern);
+  if (opts.severity) rows = rows.filter((e) => e.severity === opts.severity);
+  if (opts.status) rows = rows.filter((e) => e.status === opts.status);
+
+  if (opts.json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  if (rows.length === 0) {
+    console.log(
+      'No regressed cards found (no resolved/deferred card has fired since its latest triage note).',
+    );
+    return;
+  }
+
+  const header =
+    'SLUG                                              | PATTERN              | SEV    | STATUS    | N    | LAST SEEN                | LATEST NOTE';
+  const sep = '-'.repeat(header.length);
+  console.log(`${rows.length} regressed card(s): triaged, then fired again afterwards.`);
+  console.log(header);
+  console.log(sep);
+  for (const e of rows) {
+    console.log(
+      [
+        e.slug.padEnd(50).slice(0, 50),
+        e.pattern.padEnd(20),
+        e.severity.padEnd(6),
+        e.status.padEnd(9),
+        String(e.occurrenceCount).padEnd(4),
+        e.lastSeen.padEnd(24),
+        e.latestNoteAt,
+      ].join(' | '),
+    );
+  }
+}
+
 function registerCardsSubcommand(improve: Command): void {
   const cards = improve
     .command('cards')
@@ -331,15 +383,26 @@ function registerCardsSubcommand(improve: Command): void {
     .option('--pattern <name>', 'Filter by pattern name')
     .option('--severity <level>', 'Filter by severity: low | medium | high')
     .option('--status <state>', 'Filter by status: open | deferred | resolved')
+    .option(
+      '--regressed',
+      'Only show resolved/deferred cards that fired again after their latest triage note',
+      false,
+    )
     .option('--json', 'Emit JSON instead of a table', false)
     .action(
       (opts: {
         pattern?: string;
         severity?: string;
         status?: string;
+        regressed: boolean;
         json: boolean;
       }) => {
         try {
+          if (opts.regressed) {
+            renderRegressedList(opts);
+            return;
+          }
+
           let entries = listCards();
           if (opts.pattern) entries = entries.filter((e) => e.pattern === opts.pattern);
           if (opts.severity) entries = entries.filter((e) => e.severity === opts.severity);

--- a/src/improve/scan/card-writer.test.ts
+++ b/src/improve/scan/card-writer.test.ts
@@ -22,12 +22,17 @@ import { tmpdir } from 'os';
 import type { DetectorResult, FailureCard } from '../schemas.js';
 import {
   getCard,
+  isRegressed,
+  latestNoteAt,
   listCards,
+  listRegressedCards,
   mergeCard,
   readCardIfExists,
   renderMarkdown,
+  selectRegressed,
   writeCard,
 } from './card-writer.js';
+import { triageCard } from '../triage.js';
 import { getFailureCardJsonPath, getFailureCardsIndexPath } from '../paths.js';
 
 // ---------------------------------------------------------------------------
@@ -289,5 +294,257 @@ describe('renderMarkdown', () => {
     const md = renderMarkdown(card);
     expect(md).toContain('confirmed');
     expect(md).not.toContain('Phase 1A does not write notes');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regressed-card selection (pure)
+// ---------------------------------------------------------------------------
+
+function makeCard(overrides: Partial<FailureCard> = {}): FailureCard {
+  return {
+    schemaVersion: 1,
+    slug: 'tool-failure-memory-search',
+    title: 'memory_search failing repeatedly',
+    pattern: 'repeated-tool-use',
+    severity: 'medium',
+    status: 'resolved',
+    firstSeen: '2026-05-01T10:00:00.000Z',
+    lastSeen: '2026-06-10T10:00:00.000Z',
+    occurrenceCount: 5,
+    evidence: [
+      {
+        sessionId: 'sess-A',
+        tracePath: 'state/witness/sess-A/trace.jsonl',
+        eventIndices: [1],
+        excerpt: '{"kind":"tool_call"}',
+      },
+    ],
+    detail: { detector: 'test' },
+    notes: [{ at: '2026-06-01T10:00:00.000Z', text: 'resolved as expected' }],
+    ...overrides,
+  };
+}
+
+describe('latestNoteAt (pure)', () => {
+  it('returns undefined for a card with no notes', () => {
+    expect(latestNoteAt(makeCard({ notes: [] }))).toBeUndefined();
+  });
+
+  it('returns the only note timestamp', () => {
+    expect(latestNoteAt(makeCard({ notes: [{ at: '2026-06-01T10:00:00.000Z', text: 'x' }] }))).toBe(
+      '2026-06-01T10:00:00.000Z',
+    );
+  });
+
+  it('returns the MAX timestamp regardless of on-disk note order', () => {
+    const card = makeCard({
+      notes: [
+        { at: '2026-06-05T10:00:00.000Z', text: 'later' },
+        { at: '2026-06-01T10:00:00.000Z', text: 'earlier' },
+        { at: '2026-06-03T10:00:00.000Z', text: 'middle' },
+      ],
+    });
+    expect(latestNoteAt(card)).toBe('2026-06-05T10:00:00.000Z');
+  });
+});
+
+describe('isRegressed (pure)', () => {
+  it('is true when resolved + note + lastSeen strictly after latest note', () => {
+    expect(
+      isRegressed(
+        makeCard({
+          status: 'resolved',
+          notes: [{ at: '2026-06-01T10:00:00.000Z', text: 'fixed' }],
+          lastSeen: '2026-06-10T10:00:00.000Z',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is true for a deferred card that fired again', () => {
+    expect(
+      isRegressed(
+        makeCard({
+          status: 'deferred',
+          notes: [{ at: '2026-06-01T10:00:00.000Z', text: 'later' }],
+          lastSeen: '2026-06-10T10:00:00.000Z',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is false for an open card even if it fired after a note (status gate)', () => {
+    expect(
+      isRegressed(
+        makeCard({
+          status: 'open',
+          notes: [{ at: '2026-06-01T10:00:00.000Z', text: 'n' }],
+          lastSeen: '2026-06-10T10:00:00.000Z',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('is false for a resolved card with no triage notes (note gate)', () => {
+    expect(isRegressed(makeCard({ status: 'resolved', notes: [] }))).toBe(false);
+  });
+
+  it('is false when lastSeen equals the latest note (must be STRICTLY later)', () => {
+    expect(
+      isRegressed(
+        makeCard({
+          notes: [{ at: '2026-06-10T10:00:00.000Z', text: 'n' }],
+          lastSeen: '2026-06-10T10:00:00.000Z',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('is false when lastSeen predates the note (fixed and quiet)', () => {
+    expect(
+      isRegressed(
+        makeCard({
+          notes: [{ at: '2026-06-10T10:00:00.000Z', text: 'n' }],
+          lastSeen: '2026-06-01T10:00:00.000Z',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('measures against the LATEST note, not an earlier one', () => {
+    // lastSeen sits after the first note but before the most recent note → not regressed.
+    expect(
+      isRegressed(
+        makeCard({
+          notes: [
+            { at: '2026-06-01T10:00:00.000Z', text: 'first' },
+            { at: '2026-06-20T10:00:00.000Z', text: 'second' },
+          ],
+          lastSeen: '2026-06-10T10:00:00.000Z',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('ignores an unparseable lastSeen (conservative not-regressed)', () => {
+    expect(
+      isRegressed(
+        makeCard({
+          notes: [{ at: '2026-06-01T10:00:00.000Z', text: 'n' }],
+          lastSeen: 'not-a-date',
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('selectRegressed (pure)', () => {
+  it('returns [] for an empty input', () => {
+    expect(selectRegressed([])).toEqual([]);
+  });
+
+  it('keeps only regressed cards and projects the expected fields', () => {
+    const regressed = makeCard({
+      slug: 'regressed-one',
+      status: 'resolved',
+      severity: 'high',
+      occurrenceCount: 9,
+      notes: [{ at: '2026-06-01T10:00:00.000Z', text: 'fixed' }],
+      lastSeen: '2026-06-10T10:00:00.000Z',
+    });
+    const quiet = makeCard({
+      slug: 'quiet-resolved',
+      notes: [{ at: '2026-06-10T10:00:00.000Z', text: 'fixed' }],
+      lastSeen: '2026-06-01T10:00:00.000Z',
+    });
+    const open = makeCard({ slug: 'still-open', status: 'open', notes: [] });
+
+    const out = selectRegressed([regressed, quiet, open]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({
+      slug: 'regressed-one',
+      pattern: 'repeated-tool-use',
+      severity: 'high',
+      status: 'resolved',
+      occurrenceCount: 9,
+      lastSeen: '2026-06-10T10:00:00.000Z',
+      latestNoteAt: '2026-06-01T10:00:00.000Z',
+    });
+  });
+
+  it('sorts by lastSeen descending, then slug', () => {
+    const a = makeCard({
+      slug: 'aaa',
+      notes: [{ at: '2026-06-01T10:00:00.000Z', text: 'n' }],
+      lastSeen: '2026-06-09T10:00:00.000Z',
+    });
+    const b = makeCard({
+      slug: 'bbb',
+      notes: [{ at: '2026-06-01T10:00:00.000Z', text: 'n' }],
+      lastSeen: '2026-06-12T10:00:00.000Z',
+    });
+    const c = makeCard({
+      slug: 'ccc',
+      notes: [{ at: '2026-06-01T10:00:00.000Z', text: 'n' }],
+      lastSeen: '2026-06-12T10:00:00.000Z',
+    });
+    const out = selectRegressed([a, b, c]).map((e) => e.slug);
+    // b and c share lastSeen → tie broken by slug ascending; a is older → last.
+    expect(out).toEqual(['bbb', 'ccc', 'aaa']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listRegressedCards (round-trip): proves the real scan-merge + triage path
+// feeds the regression view WITHOUT changing merge semantics.
+// ---------------------------------------------------------------------------
+
+describe('listRegressedCards (round-trip)', () => {
+  it('returns empty when no cards exist', () => {
+    expect(listRegressedCards()).toEqual([]);
+  });
+
+  it('flags a card that re-fired after being resolved, but not a quiet one', () => {
+    // Card 1: detected, resolved with a note, then detected AGAIN later → regressed.
+    writeCard(makeDetection({ slug: 'repeated-tool-grep-aaaaaaaaaaaa', observedAt: '2026-05-20T10:00:00.000Z' }));
+    triageCard('repeated-tool-grep-aaaaaaaaaaaa', {
+      status: 'resolved',
+      note: 'fixed in commit X',
+      now: () => new Date('2026-05-21T10:00:00.000Z'),
+    });
+    // Re-detection with a NEW session + later observedAt advances lastSeen past the note.
+    writeCard(
+      makeDetection({
+        slug: 'repeated-tool-grep-aaaaaaaaaaaa',
+        observedAt: '2026-05-25T10:00:00.000Z',
+        evidence: [
+          {
+            sessionId: 'sess-Z',
+            tracePath: 'state/witness/sess-Z/trace.jsonl',
+            eventIndices: [3, 5, 7, 9],
+            excerpt: 'recurred',
+          },
+        ],
+      }),
+    );
+
+    // Card 2: detected, resolved with a note, and never fired again → quiet.
+    writeCard(makeDetection({ slug: 'repeated-tool-grep-bbbbbbbbbbbb', observedAt: '2026-05-20T10:00:00.000Z' }));
+    triageCard('repeated-tool-grep-bbbbbbbbbbbb', {
+      status: 'resolved',
+      note: 'expected behavior',
+      now: () => new Date('2026-05-26T10:00:00.000Z'),
+    });
+
+    // Card 1's status must still be 'resolved' (merge preserves it — not auto-reopened).
+    expect(getCard('repeated-tool-grep-aaaaaaaaaaaa')?.status).toBe('resolved');
+
+    const regressed = listRegressedCards();
+    expect(regressed).toHaveLength(1);
+    expect(regressed[0]?.slug).toBe('repeated-tool-grep-aaaaaaaaaaaa');
+    expect(regressed[0]?.status).toBe('resolved');
+    expect(regressed[0]?.latestNoteAt).toBe('2026-05-21T10:00:00.000Z');
+    expect(regressed[0]?.lastSeen).toBe('2026-05-25T10:00:00.000Z');
   });
 });

--- a/src/improve/scan/card-writer.ts
+++ b/src/improve/scan/card-writer.ts
@@ -381,3 +381,110 @@ export function listCards(): CardListEntry[] {
 export function getCard(slug: string): FailureCard | undefined {
   return readCardIfExists(getFailureCardJsonPath(slug));
 }
+
+// ---------------------------------------------------------------------------
+// Regressed-card selection — read-side observability view
+//
+// Invariant: regression is a READ-SIDE signal only. None of the helpers below
+// mutate a card, change its status, or touch scan merge semantics. A regressed
+// card stays exactly as triaged on disk; we merely surface that it kept firing
+// after a human closed/deferred it. This deliberately does NOT auto-reopen,
+// because most `resolved` cards are resolved-as-expected (Ctrl+C aborts,
+// network noise) and recur by design — auto-reopen would re-spam them.
+// ---------------------------------------------------------------------------
+
+/** Projection returned for a regressed card. Derived on read; never persisted. */
+export interface RegressedCardEntry {
+  slug: string;
+  pattern: FailureCard['pattern'];
+  severity: FailureCard['severity'];
+  status: FailureCard['status'];
+  /** Union evidence count (`occurrenceCount`) at time of read. */
+  occurrenceCount: number;
+  lastSeen: string;
+  /** The most recent triage-note timestamp the recurrence is measured against. */
+  latestNoteAt: string;
+}
+
+/**
+ * Most recent triage-note timestamp on a card, or undefined when it has no
+ * notes. Notes are not guaranteed ordered on disk, so take the max rather than
+ * the last element. Pure; no I/O.
+ */
+export function latestNoteAt(card: FailureCard): string | undefined {
+  let max: string | undefined;
+  for (const note of card.notes) {
+    if (max === undefined || Date.parse(note.at) > Date.parse(max)) max = note.at;
+  }
+  return max;
+}
+
+/**
+ * A card is "regressed" when a human triaged it but it kept firing afterwards:
+ *   - status is `resolved` or `deferred`, AND
+ *   - it has at least one triage note, AND
+ *   - `lastSeen` is strictly later than the latest triage note.
+ *
+ * Pure predicate; no I/O; never mutates. Timestamps are compared as epoch
+ * millis (not lexically) so any RFC3339 offset form compares correctly; an
+ * unparseable timestamp is treated as not-regressed (conservative).
+ */
+export function isRegressed(card: FailureCard): boolean {
+  if (card.status !== 'resolved' && card.status !== 'deferred') return false;
+  const noteAt = latestNoteAt(card);
+  if (noteAt === undefined) return false;
+  const last = Date.parse(card.lastSeen);
+  const note = Date.parse(noteAt);
+  if (Number.isNaN(last) || Number.isNaN(note)) return false;
+  return last > note;
+}
+
+/**
+ * Filter + project the regressed cards from a list, most-recent recurrence
+ * first (then slug for stable ordering). Pure (no I/O) so the selection logic
+ * is unit-testable without the filesystem.
+ */
+export function selectRegressed(cards: FailureCard[]): RegressedCardEntry[] {
+  const out: RegressedCardEntry[] = [];
+  for (const card of cards) {
+    if (!isRegressed(card)) continue;
+    const latest = latestNoteAt(card);
+    // isRegressed guarantees a note exists; this guard satisfies the type
+    // checker and stays defensive without an assertion.
+    if (latest === undefined) continue;
+    out.push({
+      slug: card.slug,
+      pattern: card.pattern,
+      severity: card.severity,
+      status: card.status,
+      occurrenceCount: card.occurrenceCount,
+      lastSeen: card.lastSeen,
+      latestNoteAt: latest,
+    });
+  }
+  out.sort((a, b) => {
+    if (a.lastSeen !== b.lastSeen) return a.lastSeen < b.lastSeen ? 1 : -1;
+    return a.slug < b.slug ? -1 : 1;
+  });
+  return out;
+}
+
+/**
+ * Read every card from disk and return the regressed subset. Mirrors
+ * {@link listCards}, but reads full cards because the regression check needs
+ * `notes`, which {@link CardListEntry} omits. Missing dir → empty; corrupt
+ * cards are skipped (same policy as listCards).
+ */
+export function listRegressedCards(): RegressedCardEntry[] {
+  const dir = getFailureCardsDir();
+  if (!existsSync(dir)) return [];
+  const cards: FailureCard[] = [];
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith('.json')) continue;
+    if (name.startsWith('.')) continue;
+    const card = readCardIfExists(join(dir, name));
+    if (!card) continue;
+    cards.push(card);
+  }
+  return selectRegressed(cards);
+}


### PR DESCRIPTION
## Summary
- Adds `afk improve cards list --regressed` — a **read-side** view that surfaces resolved/deferred failure cards whose `lastSeen` is later than their latest triage note (fixes that silently regressed, or deferrals that got worse).
- **Why:** scan merges by slug and *preserves* `status` (this is correct — most resolved cards are resolved-as-expected/noise and recur by design; auto-reopening would re-spam them). The gap was observability: no way to see "triaged, then fired again" without re-introducing ticket spam. This closes that gap **without** changing merge semantics.
- A card is **regressed** iff: status is `resolved` or `deferred`, AND it has ≥1 triage note, AND `lastSeen` is strictly later than the latest note timestamp.
- Pure, unit-tested helpers `latestNoteAt` / `isRegressed` / `selectRegressed` + disk reader `listRegressedCards` (`card-writer.ts`); `--regressed` flag + `renderRegressedList` wired into `cards list` (`improve.ts`), composing with `--pattern` / `--severity` / `--status` / `--json`.
- **Non-goals (by design):** no scan/merge-semantics change, no schema fields added, no auto-reopen. Read-only throughout.

## Test results
- `pnpm test` (full vitest suite): **9794 passed / 12 skipped / 2 failed**. The 2 failures — `src/agent/providers/anthropic-direct.test.ts` (compact() haiku model-id) and `src/cli/config.test.ts` (DEFAULT_SLOT_BINDINGS) — are **pre-existing and unrelated**: they reproduce on a clean checkout in isolation and live in files disjoint from this change.
- `npx vitest run src/improve/scan/card-writer.test.ts`: **31/31 passed** — 14 new (pure `latestNoteAt`/`isRegressed`/`selectRegressed` + a filesystem round-trip that proves `status` is preserved across re-detection).
- `pnpm lint` (`tsc --noEmit`, strict): clean.

## Verification (`--verify` adversarial wave)
An independent read-only verifier re-derived the load-bearing claims from the diff alone — all **CONFIRM**:
- `mergeCard` is absent from the diff; `status` / `notes` preserved verbatim (`card-writer.ts:145-193`).
- Every new symbol is a pure read / console output — no card mutation or disk write; the round-trip test asserts `status` stays `resolved` after re-detection.
- `FailureCardSchema` unchanged; `RegressedCardEntry` is a derived view interface, never persisted.
- `isRegressed`: strict `>`, max-of-notes, and status+note gates all correct.
- Default `cards list` output is unchanged when `--regressed` is absent (early-return gate).

## Example
Run against a real local improve store, `--regressed` surfaced 9 cards — including `tool-failure-browser-open` (resolved, then re-fired = candidate regression) and `closure-anomaly-abort` (resolved, recurs by design). The latter is exactly the "resolved-as-expected" case that a future optional `resolution: fixed|expected` field would suppress, and illustrates why auto-reopen was deliberately avoided.

## Note for maintainer
Developed on the public mirror. Per the snapshot-sync workflow, this should also be ported to the private `afk-workshop` canonical so it survives the next public re-sync.
