### PR TITLE
docs(website): use `claude login` for the OAuth flow in quickstart

### DIFF
--- a/website/content/docs/quickstart.mdx
+++ b/website/content/docs/quickstart.mdx
@@ -6,7 +6,7 @@ description: "Install Agent AFK, set your API key, and run your first command in
 ## Prerequisites
 
 - **Node.js ≥ 22** — check with `node --version`
-- An **Anthropic API key** (or run `afk login` for browser-based OAuth)
+- An **Anthropic API key** (or run `claude login` for browser-based OAuth)
 
 ## Install
 
@@ -45,7 +45,7 @@ afk config env set ANTHROPIC_API_KEY   # prompts without echoing the value
 Or use the OAuth flow (no API key required — authenticates via `console.anthropic.com`):
 
 ```bash
-afk login
+claude login
 ```
 
 ## Smoke test


### PR DESCRIPTION
## What

The quickstart's OAuth-flow section told users to run `afk login` for the browser-based OAuth flow ("no API key required — authenticates via `console.anthropic.com`"). That command is wrong for this flow.

This changes the two OAuth-flow references in `website/content/docs/quickstart.mdx` to `claude login`:
- the **Prerequisites** note ("or run `claude login` for browser-based OAuth")
- the **OAuth flow** code block (the one in the screenshot)

## Why

- `afk login` (`src/cli/commands/login-command.ts` → `runAuthWizard` in `src/cli/auth-wizard.ts`) only **prompts for a token you paste** and saves it to `~/.afk/config/afk.env`. It never opens a browser and is not the "no API key required" flow.
- The browser-based OAuth flow that authenticates via `console.anthropic.com` is Claude Code's `claude login`, which writes the keychain entry AFK reads. The codebase already points users there everywhere else (`src/agent/auth/keychain.ts`, `src/cli/slash/commands/reauth.ts`, `src/cli/render/usage-limit-box.ts`, `src/cli/commands/interactive/turn-handler.ts`).

## Scope

Intentionally narrow. The `afk login` references in `api-keys.mdx`, `configuration/overview.mdx`, and `configuration/editing-config.mdx` are **left as-is** — they accurately describe the real token-saving wizard, and rewriting them to `claude login` would make correct docs wrong.