### PR TITLE
fix(worktree): re-anchor compose DAG nodes on cwd change

### DIFF
--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -838,12 +838,14 @@ export class AnthropicDirectProvider implements ModelProvider {
           }
           this._currentCwd = newCwd;
 
-          // 1b. Re-anchor the forked sub-agent / skill executors so child tool
-          //     calls (the `agent` and skill tools) land in the new worktree
-          //     instead of the host's process.cwd(). Without this, a born-named
-          //     `afk -w` worktree leaves the executors frozen on the launch dir.
+          // 1b. Re-anchor the forked sub-agent / skill / compose executors so
+          //     child tool calls (the `agent`, skill, and compose tools) land in
+          //     the new worktree instead of the host's process.cwd(). Without
+          //     this, a born-named `afk -w` worktree leaves the executors frozen
+          //     on the launch dir.
           this.subagentExecutor?.setCwd(newCwd);
           this.skillExecutor?.setCwd(newCwd);
+          this.composeExecutor?.setCwd(newCwd);
 
           // 2. Rebuild system-prompt fragment with the new `# Environment` line.
           //    Build a fresh copy each invocation — splice mutates in place.

--- a/src/agent/tools/compose-executor.test.ts
+++ b/src/agent/tools/compose-executor.test.ts
@@ -20,6 +20,7 @@ interface CapturedManagerOpts {
   progressSink?: SubagentProgressSink;
   apiKey?: string;
   parentAbortSignal?: AbortSignal;
+  cwd?: string;
 }
 let lastManagerOpts: CapturedManagerOpts | undefined;
 
@@ -997,6 +998,39 @@ describe('ComposeExecutor', () => {
       }));
 
       expect(result.isError).toBeFalsy();
+    });
+  });
+
+  describe('cwd re-anchoring', () => {
+    it('seeds ctx.cwd into the SubagentManager so DAG nodes anchor to the worktree', async () => {
+      mockRunSubagentDAG.mockResolvedValue({ outputs: { a: 'ok' }, failed: [], skipped: [] });
+      const executor = new ComposeExecutor(makeContext({ cwd: '/tmp/worktree-abc' }));
+
+      await executor.execute(makeCall({ nodes: [{ id: 'a', prompt: 'task a' }] }));
+
+      expect(lastManagerOpts?.cwd).toBe('/tmp/worktree-abc');
+    });
+
+    it('omits cwd when ctx.cwd is undefined (falls back to process.cwd())', async () => {
+      mockRunSubagentDAG.mockResolvedValue({ outputs: { a: 'ok' }, failed: [], skipped: [] });
+      const executor = new ComposeExecutor(makeContext());
+
+      await executor.execute(makeCall({ nodes: [{ id: 'a', prompt: 'task a' }] }));
+
+      expect(lastManagerOpts?.cwd).toBeUndefined();
+    });
+
+    it('setCwd() re-anchors the cwd passed to the SubagentManager on the next execute', async () => {
+      // Mirrors the born-named `afk -w` worktree flow: executor is constructed
+      // with the launch dir, then re-anchored to the worktree on turn 1 before
+      // the first compose call forks any DAG node.
+      mockRunSubagentDAG.mockResolvedValue({ outputs: { a: 'ok' }, failed: [], skipped: [] });
+      const executor = new ComposeExecutor(makeContext({ cwd: '/tmp/launch-dir' }));
+
+      executor.setCwd('/tmp/born-named-worktree');
+      await executor.execute(makeCall({ nodes: [{ id: 'a', prompt: 'task a' }] }));
+
+      expect(lastManagerOpts?.cwd).toBe('/tmp/born-named-worktree');
     });
   });
 

--- a/src/agent/tools/compose-executor.ts
+++ b/src/agent/tools/compose-executor.ts
@@ -86,6 +86,16 @@ export interface ComposeExecutorContext {
    * system prompt and no tool context.
    */
   systemPrompt: string;
+  /**
+   * Working directory inherited by every compose DAG node. Seeded into the
+   * SubagentManager so forked nodes anchor to the session's worktree instead
+   * of the host's `process.cwd()`. Re-anchored mid-session via
+   * {@link ComposeExecutor.setCwd} (born-named `afk -w` worktree created on
+   * turn 1). Mirrors the SubagentExecutor / SkillExecutor cwd convention.
+   * Optional: when absent, nodes fall back to `process.cwd()` (pre-fix
+   * behavior).
+   */
+  cwd?: string;
 }
 
 interface ComposeNodeInput {
@@ -432,7 +442,26 @@ function formatTruncationWarning(t: TruncationEvent): string {
 }
 
 export class ComposeExecutor {
-  constructor(private readonly ctx: ComposeExecutorContext) {}
+  // Current worktree cwd. Seeded from ctx.cwd; updated by setCwd when the
+  // session's cwd changes (born-named `afk -w` worktree created on turn 1) so
+  // compose DAG nodes anchor to the worktree, not the host's process.cwd().
+  // Mirrors the SubagentExecutor / SkillExecutor re-anchor convention.
+  private currentCwd: string | undefined;
+
+  constructor(private readonly ctx: ComposeExecutorContext) {
+    this.currentCwd = ctx.cwd;
+  }
+
+  /**
+   * Re-anchor the cwd inherited by compose DAG nodes after a mid-session cwd
+   * change. Forks dispatched after this call inherit the new worktree instead
+   * of the launch dir. Wired from `dispatcher.setResolveBase()` and
+   * anthropic-direct's `cwdDependentsFactory`, mirroring the sub-agent / skill
+   * executors. Only affects nodes spawned after the call.
+   */
+  setCwd(cwd: string): void {
+    this.currentCwd = cwd;
+  }
 
   async execute(call: ToolCall): Promise<ToolResult> {
     if (call.signal.aborted) {
@@ -516,6 +545,10 @@ export class ComposeExecutor {
       apiKey: this.ctx.apiKey,
       progressSink: chainedSink,
       ...(this.ctx.baseUrl !== undefined ? { baseUrl: this.ctx.baseUrl } : {}),
+      // Anchor every forked DAG node to the session's worktree (re-anchored via
+      // setCwd). Without this the manager's parentCwd is undefined and nodes
+      // fall back to the host's process.cwd() (subagent.ts fork fallback).
+      ...(this.currentCwd !== undefined ? { cwd: this.currentCwd } : {}),
     });
 
     const startedAt = Date.now();

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -401,14 +401,15 @@ export class SessionToolDispatcher implements ToolDispatcher {
     }
 
     // Re-anchor the forked executors this dispatcher dispatches to (item 3
-    // above) so child `agent` / skill tool calls follow the cwd change instead
-    // of staying frozen on the launch dir — the openai-compatible provider's
-    // only re-anchor path (anthropic-direct also does this in
-    // cwdDependentsFactory on the same instances). No-op when the executors are
-    // absent (sub-agents, the eval-run probe dispatcher); `setCwd` is
-    // idempotent, so the anthropic-direct double-set is harmless.
+    // above) so child `agent` / skill / compose tool calls follow the cwd
+    // change instead of staying frozen on the launch dir — the
+    // openai-compatible provider's only re-anchor path (anthropic-direct also
+    // does this in cwdDependentsFactory on the same instances). No-op when the
+    // executors are absent (sub-agents, the eval-run probe dispatcher); `setCwd`
+    // is idempotent, so the anthropic-direct double-set is harmless.
     this.subagentExecutor?.setCwd(newCwd);
     this.skillExecutor?.setCwd(newCwd);
+    this.composeExecutor?.setCwd(newCwd);
   }
 
   private appendAuditLog(entry: {

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -536,6 +536,8 @@ export function registerChatCommand(program: Command): void {
           // Per-model credential resolver — mirrors #640 for the compose fork-path.
           resolveApiKeyForModel: getApiKeyForModel,
           ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
+          // Anchor DAG nodes to the worktree (re-anchored via composeExecutor.setCwd).
+          ...(worktreeCwd !== undefined ? { cwd: worktreeCwd } : {}),
           systemPrompt: basePrompt ?? '',
         });
 

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -153,6 +153,8 @@ export function buildDaemonSessionFactory(
       // Per-model credential resolver — mirrors #640 for the compose fork-path.
       resolveApiKeyForModel: getApiKeyForModel,
       ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
+      // Anchor DAG nodes to the worktree (re-anchored via composeExecutor.setCwd).
+      ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
       systemPrompt: '',
     });
 

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -363,6 +363,8 @@ export async function bootstrapSession(
     // Per-model credential resolver — mirrors #640 for the compose fork-path.
     resolveApiKeyForModel: getApiKeyForModel,
     ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
+    // Anchor DAG nodes to the worktree (re-anchored via composeExecutor.setCwd).
+    ...(extras?.cwd !== undefined ? { cwd: extras.cwd } : {}),
     systemPrompt: basePrompt ?? '',
   });
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -320,6 +320,8 @@ async function main() {
           // Per-model credential resolver — mirrors #640 for the compose fork-path.
           resolveApiKeyForModel: getApiKeyForModel,
           ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
+          // Anchor DAG nodes to the worktree (re-anchored via composeExecutor.setCwd).
+          ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
           systemPrompt: layeredBasePrompt ?? '',
         });
 


### PR DESCRIPTION
## Summary

The `compose` tool's DAG nodes were forking into the host's `process.cwd()` instead of the session worktree — so every compose node ran its `bash`/`grep`/file tools in the **wrong directory** whenever the session cwd differed from the launch dir (most importantly the born-named `afk -w` worktree flow).

`ComposeExecutor` was missed by the PR #223 worktree re-anchor series (`fec6a73`, `d53b198`), which added `setCwd()` to `SubagentExecutor` and `SkillExecutor` and wired both into the two cwd re-anchor paths but left compose out of all three.

## Root cause

- `ComposeExecutor` builds its `SubagentManager` with **no `cwd`** → `parentCwd` is `undefined` → forked nodes fall back to `process.cwd()` (`subagent.ts:424-426`).
- `ComposeExecutorContext` had no `cwd` field and `ComposeExecutor` had no `setCwd()`, so it could never be re-anchored.
- Neither `dispatcher.setResolveBase()` (`dispatcher.ts:410-411`) nor anthropic-direct `cwdDependentsFactory` (`index.ts:845-846`) called `composeExecutor?.setCwd()` — even though both already hold a `composeExecutor` reference.
- The DAG nodes carry no per-node `cwd` and `dag.ts`/`dag-subagent.ts` inject none, so there was no masking path — the bug manifests end-to-end.

## Fix (mirrors `fec6a73` / `d53b198`)

- Add `cwd?` to `ComposeExecutorContext`, a `currentCwd` field + `setCwd()` to `ComposeExecutor`, and seed it into the `SubagentManager` constructor.
- Call `composeExecutor?.setCwd(newCwd)` in `dispatcher.setResolveBase()` (covers openai-compatible) **and** anthropic-direct `cwdDependentsFactory`.
- Thread `cwd` into the four `ComposeExecutor` instantiation sites: `chat.ts`, `interactive/bootstrap.ts`, `daemon.ts`, `telegram.ts`.

Additive and backward-compatible: when no cwd is supplied, behavior is unchanged (`process.cwd()` fallback). The `setCwd` calls are optional-chaining no-ops where the executor is absent.

## Tests

New `cwd re-anchoring` describe block in `compose-executor.test.ts`:
- `ctx.cwd` seeds the `SubagentManager`.
- absent `cwd` omits it (process.cwd() fallback preserved).
- `setCwd()` re-anchors the cwd passed to the manager on the next `execute()` (the `afk -w` turn-1 flow).

## Verification

- `pnpm lint` (tsc --noEmit, strict) — clean.
- `compose-executor.test.ts` (81) + `dispatcher.test.ts` (71) — 152 passed, 0 failed.
- Full suite: 9798 passed / 12 skipped; the **only** failure is the pre-existing `AFK_COMPACT_MODEL` env-leak in `anthropic-direct.test.ts` (unrelated to this change — passes with the env var cleared).
- `pnpm audit:sdk:check` — lock matches (no new SDK symbols).

🤖 Diagnosed via `/diagnose`, verified via `/shadow-verify` (3 independent verifiers, all CONFIRMED + composition-boundary check).