### PR TITLE
feat(cli): surface hidden REPL features in help, hints & banner

### DIFF
--- a/src/cli/commands/interactive.test.ts
+++ b/src/cli/commands/interactive.test.ts
@@ -556,13 +556,19 @@ describe('interactive command - streaming logic', () => {
       expect(hint).toContain('/exit to quit');
     });
 
+    it('surfaces discoverable features: @ file attach and Shift+Tab mode switch', () => {
+      const hint = startupHintLine();
+      expect(hint).toContain('@ for files');
+      expect(hint).toContain('Shift+Tab');
+    });
+
     it('omits /resume — useless to a new user, redundant when resuming', () => {
       expect(startupHintLine()).not.toContain('/resume');
     });
 
-    it('stays compact (≤ 4 dot-separated items) so the busiest startup line is scannable', () => {
+    it('stays compact (≤ 6 dot-separated items) so the busiest startup line is scannable', () => {
       const items = startupHintLine().split(' · ');
-      expect(items.length).toBeLessThanOrEqual(4);
+      expect(items.length).toBeLessThanOrEqual(6);
     });
   });
 

--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -146,7 +146,7 @@ export function isAutonameEnabled(options: CliOptions, config: CliConfig): boole
  * Pure + exported so the content is unit-testable without booting a session.
  */
 export function startupHintLine(): string {
-  return '/help · /model · Esc to interrupt · /exit to quit';
+  return '/help · /model · @ for files · Shift+Tab mode · Esc to interrupt · /exit to quit';
 }
 
 export function registerInteractiveCommand(program: Command): void {

--- a/src/cli/loading-tips.ts
+++ b/src/cli/loading-tips.ts
@@ -48,7 +48,7 @@ export interface LoadingTip {
 const STATIC_TIPS: readonly LoadingTip[] = [
   {
     id: 'kbd:ctrl-b',
-    text: 'Ctrl+B during a turn detaches it to the background so you can keep typing — find it later with /tasks.',
+    text: 'Ctrl+B during a turn detaches it to the background so you can keep typing — find it later with /bgsub.',
     source: 'static',
   },
   {

--- a/src/cli/slash/commands/allow-dir.ts
+++ b/src/cli/slash/commands/allow-dir.ts
@@ -41,6 +41,7 @@ export const allowDirCmd: SlashCommand = {
   name: '/allow-dir',
   summary: 'Manage per-session directory access grants for tool handlers',
   usage: '/allow-dir [--rw | --revoke] [<path>]',
+  hint: 'When the model needs read or write access to a directory outside the session root — grant it here without restarting.',
   flags: ['--rw', '--revoke'] as const,
 
   async handler(ctx, args) {

--- a/src/cli/slash/commands/bgsub.ts
+++ b/src/cli/slash/commands/bgsub.ts
@@ -142,6 +142,7 @@ export const bgsubCmd: SlashCommand = {
   name: '/bgsub',
   summary: 'List background subagent jobs',
   usage: '/bgsub [id]',
+  hint: 'When you want to check on background subagent jobs spawned with mode="background" during this session.',
   async handler(ctx, args) {
     const registry = ensureRegistry(ctx);
     if (!registry) return 'continue';
@@ -174,6 +175,7 @@ export const bgsubStatusCmd: SlashCommand = {
   name: '/bgsub:status',
   summary: 'Show one background job',
   usage: '/bgsub:status <id>',
+  hint: 'When you need the full detail view for one specific background job by its ID.',
   async handler(ctx, args) {
     const registry = ensureRegistry(ctx);
     if (!registry) return 'continue';
@@ -197,6 +199,7 @@ export const bgsubJoinCmd: SlashCommand = {
   name: '/bgsub:join',
   summary: 'Wait for a background subagent job and print its result',
   usage: '/bgsub:join <id>',
+  hint: 'When a background subagent has finished and you want to surface its result into the conversation.',
   async handler(ctx, args) {
     const registry = ensureRegistry(ctx);
     if (!registry) return 'continue';
@@ -287,6 +290,7 @@ export const bgsubCancelCmd: SlashCommand = {
   name: '/bgsub:cancel',
   summary: 'Cancel a running background subagent job',
   usage: '/bgsub:cancel <id>',
+  hint: 'When you want to abort a background subagent job that is still in progress.',
   async handler(ctx, args) {
     const registry = ensureRegistry(ctx);
     if (!registry) return 'continue';

--- a/src/cli/slash/commands/changelog.ts
+++ b/src/cli/slash/commands/changelog.ts
@@ -22,6 +22,7 @@ export const changelogCmd: SlashCommand = {
   name: '/changelog',
   usage: '/changelog [--dry-run]',
   summary: 'Generate CHANGELOG entries from commits since last tag',
+  hint: 'When you are preparing a release and want to auto-generate changelog entries from conventional commits.',
   async handler(ctx, args) {
     const dryRun = args.split(/\s+/).includes('--dry-run');
     const repoRoot = process.cwd();

--- a/src/cli/slash/commands/core.ts
+++ b/src/cli/slash/commands/core.ts
@@ -105,6 +105,7 @@ const helpCmd: SlashCommand = {
     }
     ctx.out.line();
     ctx.out.line(palette.dim('  Tip: Ctrl+C interrupts a running turn; a second press exits.'));
+    ctx.out.line(palette.dim('  Hidden: /keys for keybindings · @ to attach files · !cmd to run shell · Shift+Tab to change mode'));
     ctx.out.line();
     return 'continue';
   },

--- a/src/cli/slash/commands/keys.test.ts
+++ b/src/cli/slash/commands/keys.test.ts
@@ -55,6 +55,7 @@ describe('/keys slash command', () => {
     expect(body).toContain('Editing');
     expect(body).toContain('History');
     expect(body).toContain('Multi-line');
+    expect(body).toContain('Attach');
     expect(body).toContain('Misc');
   });
 
@@ -69,6 +70,15 @@ describe('/keys slash command', () => {
     expect(body).toContain('ctrl+l');
     expect(body).toContain('alt+b');
     expect(body).toContain('alt+f');
+  });
+
+  it('documents @ file attachment, ctrl+v paste, and ctrl+x remove', async () => {
+    const { ctx, lines } = makeCtx();
+    await keysCmd.handler(ctx, '');
+    const body = lines.join('\n');
+    expect(body).toContain('@<path>');
+    expect(body).toContain('ctrl+v');
+    expect(body).toContain('ctrl+x');
   });
 
   it('is registered in the global slash registry', () => {

--- a/src/cli/slash/commands/keys.ts
+++ b/src/cli/slash/commands/keys.ts
@@ -51,11 +51,17 @@ const BINDINGS: Array<{ group: string; rows: Array<[string, string]> }> = [
     ],
   },
   {
+    group: 'Attach',
+    rows: [
+      ['@<path>', 'Autocomplete and attach a file — type @ then start the path'],
+      ['ctrl+v', 'Paste image from clipboard (macOS: Cmd+V also works)'],
+      ['ctrl+x', 'Remove the last attached image from the prompt'],
+    ],
+  },
+  {
     group: 'Misc',
     rows: [
       ['ctrl+l', 'Clear screen and repaint'],
-      ['ctrl+v', 'Paste image from clipboard'],
-      ['ctrl+x', 'Remove last attached image'],
       ['ctrl+c', 'Interrupt running turn / exit (second press)'],
       ['ctrl+d', 'EOF / exit (when buffer is empty)'],
       ['tab', 'Accept autocomplete suggestion'],
@@ -67,6 +73,7 @@ const BINDINGS: Array<{ group: string; rows: Array<[string, string]> }> = [
 export const keysCmd: SlashCommand = {
   name: '/keys',
   summary: 'Show keybinding reference',
+  hint: 'When you want the full list of keyboard shortcuts available in the interactive REPL.',
   async handler(ctx) {
     ctx.out.line();
     ctx.out.line(palette.bold(palette.brand('Keybindings')));

--- a/src/cli/slash/commands/stats.ts
+++ b/src/cli/slash/commands/stats.ts
@@ -9,6 +9,7 @@ import type { SlashCommand } from '../types.js';
 export const statsCmd: SlashCommand = {
   name: '/stats',
   summary: 'Show session statistics including skill runs',
+  hint: 'When you want a summary of skill invocations, token usage, and cost for the current session.',
   async handler(ctx) {
     const ledger = ctx.ledger;
     if (!ledger) {

--- a/src/cli/slash/commands/worktree.ts
+++ b/src/cli/slash/commands/worktree.ts
@@ -303,6 +303,7 @@ export const worktreeCmd: SlashCommand = {
   name: '/worktree',
   summary: 'List or prune afk-managed git worktrees',
   usage: '/worktree list | /worktree prune [--apply] [--scope <interactive|diagnose|all>]',
+  hint: 'When you want to audit or clean up stale afk-managed git worktrees from past sessions.',
   async handler(ctx, args) {
     const trimmed = args.trim();
     if (trimmed.length === 0 || trimmed.startsWith('list')) {


### PR DESCRIPTION
Discoverability gaps found in a UX audit — several power features were only learnable by accident.

### Changes
- **Fix dead loading tip:** `/tasks` → `/bgsub` (the command was renamed; the old tip dead-ended at "Unknown command"). `src/cli/loading-tips.ts`
- **`/help` now lists hidden features:** `/keys`, `@` file attach, `!cmd` shell, Shift+Tab mode. `src/cli/slash/commands/core.ts`
- **Welcome banner hint** adds `@ for files` and `Shift+Tab mode`. `src/cli/commands/interactive.ts`
- **Add `hint:`** to `/bgsub*`, `/worktree`, `/changelog`, `/stats`, `/allow-dir`, `/keys` so they surface as loading tips (the harvester skips commands without a hint).
- **`/keys`** documents `@<path>` attachment (+ Ctrl+V / Ctrl+X) in a new Attach group.

### Tests
loading-tips, interactive, keys, core-compact — **91 tests pass; `pnpm lint` clean.**
