### PR TITLE
fix(cli): timelier context-usage signal & overlay-safe overflow warning

### DIFF
--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -1810,7 +1810,7 @@ describe('runTurn — mid-turn context progress', () => {
   });
 
   // Two tool_use+tool_result pairs with the clock frozen: the first fires,
-  // the second is suppressed (within the 15 s throttle window).
+  // the second is suppressed (within the 3 s throttle window).
   it('fires onContextProgress on the first tool_result', async () => {
     vi.setSystemTime(1_000_000);
 
@@ -1831,7 +1831,7 @@ describe('runTurn — mid-turn context progress', () => {
 
     await runTurn({ text: 'q', attachments: [] }, session, stats, h);
 
-    // First fires, second suppressed (clock didn't advance past 15 s).
+    // First fires, second suppressed (clock didn't advance past 3 s).
     expect(onContextProgress).toHaveBeenCalledTimes(1);
   });
 

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -86,7 +86,7 @@ export async function runTurn(
   // the latest write even though the assignment happens in a microtask.
   const pickerRef: { abort: AbortController | null } = { abort: null };
   let lastContextProgressMs = 0;
-  const CONTEXT_PROGRESS_MIN_INTERVAL_MS = 15_000;
+  const CONTEXT_PROGRESS_MIN_INTERVAL_MS = 3_000;
   const toolEvents: ToolEvent[] = [];
   const pendingTools = new Map<string, ToolEvent>();
 
@@ -774,7 +774,7 @@ export function printTurnFooter(
   if (contextPct >= 1.0) {
     const overByTok = Math.round((contextPct - 1.0) * contextLimit);
     const limitK = Math.round(contextLimit / 1000);
-    console.log(palette.error(
+    write(palette.error(
       `  context OVER ${limitK}k tok by ~${formatTokens(overByTok)} tok — model output may be silently truncated`
     ));
   } else if (contextPct > 0.5) {

--- a/src/cli/terminal-compositor.types.ts
+++ b/src/cli/terminal-compositor.types.ts
@@ -63,7 +63,7 @@ export interface KeyInfo {
 // Braille spinner frames from ora's `dots` preset.
 export const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] as const;
 
-export const ELAPSED_GRACE_MS = 5_000;
+export const ELAPSED_GRACE_MS = 2_000;
 
 export function formatElapsed(startedAt: number): string {
   const elapsed = Date.now() - startedAt;


### PR DESCRIPTION
Status-feedback fixes found in a UX audit (relevant for AFK users who step away during long turns).

### Changes
- **Overlay-safe overflow warning** — the `context OVER … model output may be silently truncated` message used raw `console.log`, which strands output above the live compositor overlay (the exact footgun the surrounding comment warns about). Now uses the injected overlay-safe `write`, matching the `> 0.5` branch directly below it. `src/cli/commands/interactive/turn-handler.ts`
- **Timelier context bar** — refresh throttle `15s → 3s` so the context-usage indicator doesn't go stale mid-turn. `src/cli/commands/interactive/turn-handler.ts`
- **Earlier elapsed clock** — `ELAPSED_GRACE_MS 5s → 2s` so common 2–4s turns show elapsed time. `src/cli/terminal-compositor.types.ts`

### Tests
turn-handler, context-bar — **71 tests pass; `pnpm lint` clean.**

**Deferred:** a one-time ≥90% context notice — it needs edge-detection state that spans multiple files, out of scope for this small PR.
