### PR TITLE
feat(trace): read-only SessionEnd run receipt

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -439,6 +439,14 @@
       "category": "model"
     },
     {
+      "name": "AFK_RUN_RECEIPT_DISABLED",
+      "description": "Disable the post-session run receipt (state/receipts/<label>.json and .md). Set to 1 to skip receipt writes; the underlying witness trace is unaffected. Receipts are also implicitly off when AFK_TRACE_DISABLED=1 (no trace to summarize).",
+      "type": "boolean",
+      "required": false,
+      "example": "1",
+      "category": "debug"
+    },
+    {
       "name": "AFK_SESSION_ID",
       "description": "Override the browser session ID used by the native browser-control tools. Defaults to 'default' for single-session use. Subagents inherit the parent's session by default. Set this when running multiple concurrent AFK processes that should each manage an isolated browser context.",
       "type": "string",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**114 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**115 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 
@@ -137,6 +137,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_DEBUG_COMPOSITOR` | boolean |  |  |  | Gate compositor phase-boundary traces to stderr; any truthy value enables. |
 | `AFK_DIAGNOSE_BASELINE` | boolean |  | `1` | `0` | Kill switch for /diagnose reproducer baseline execution. When set to '0', the /diagnose skill skips executing the detected reproducer command for a ground-truth baseline; default enabled (runs). Set to '0' to disable. |
 | `AFK_DUMP_PROMPT` | string |  |  | `/tmp/afk-prompt.txt` | Write the resolved system prompt to a file at startup. Accepts a path or 1 for default location. |
+| `AFK_RUN_RECEIPT_DISABLED` | boolean |  |  | `1` | Disable the post-session run receipt (state/receipts/<label>.json and .md). Set to 1 to skip receipt writes; the underlying witness trace is unaffected. Receipts are also implicitly off when AFK_TRACE_DISABLED=1 (no trace to summarize). |
 | `AFK_SESSION_LEDGER_DISABLED` | boolean |  |  | `1` | Disable the per-session durable event ledger (state/sessions/<id>/events.jsonl). Set to 1 to skip ledger writes; live cross-surface watching (e.g. the Telegram /watch command) will report no activity for sessions started while disabled. |
 | `AFK_SKILL_STREAM_VERBOSE` | boolean |  |  |  | Verbose streaming output when a skill is dispatched. Logs sub-agent setup, intermediate events, and final result. |
 | `AFK_TELEGRAM_TRACE` | boolean |  |  | `1` | Set to 1 to dump raw bridge traffic between the agent and the Telegram bot — debugging only. |

--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -12,6 +12,7 @@ import { MemoryStore, createMemorySessionEndHook } from './memory/index.js';
 import { createPlanModeGate } from './plan-mode-gate.js';
 import { createAfkModeGate } from './afk-mode-gate.js';
 import { cleanupComposeSpills } from './tools/compose-executor.js';
+import { runReceiptSessionEndHook } from './trace/receipt.js';
 import { env } from '../config/env.js';
 import {
   createPathApprovalHook,
@@ -186,6 +187,11 @@ export function createDefaultHookRegistry(
     if (context.sessionId) cleanupComposeSpills(context.sessionId);
     return {};
   });
+  // Read-only run receipt: after the trace is sealed (sealing precedes
+  // SessionEnd dispatch — see agent-session.ts dispatchSessionEndOnce), emit a
+  // JSON+Markdown summary of the run under ~/.afk/state/receipts/. Best-effort
+  // and never injects/blocks; skips subagents and honors AFK_RUN_RECEIPT_DISABLED.
+  registry.register('SessionEnd', runReceiptSessionEndHook);
   if (onSubagentComplete) {
     registry.register('SubagentStop', (context) => {
       if (context.event !== 'SubagentStop') return {};

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -82,6 +82,15 @@ export interface SessionEndContext {
    * per-session state.
    */
   parentSessionId?: string;
+  /**
+   * Absolute path to this session's witness `trace.jsonl`, when a trace writer
+   * is configured. Threaded from the writer because the trace directory is
+   * keyed by the writer's session LABEL (a random UUID on the one-shot path),
+   * which is NOT the same as {@link sessionId} — a handler cannot reconstruct
+   * it from sessionId alone. Used by the run-receipt hook to read the sealed
+   * trace after SessionEnd. Absent when tracing is disabled.
+   */
+  tracePath?: string;
 }
 
 export interface SubagentStartContext {

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -973,6 +973,12 @@ export class AgentSession implements IAgentSession {
         // Subagent provenance: lets session-scoped SessionEnd hooks (e.g. the
         // memory writer) skip forked children, which inherit this registry.
         parentSessionId: this.config.parentSessionId,
+        // Authoritative trace path for the run-receipt hook. The witness dir is
+        // keyed by the writer's session label (random on the one-shot path),
+        // not by sessionId, so a hook cannot reconstruct it — thread it here.
+        ...(this.config.traceWriter
+          ? { tracePath: this.config.traceWriter.getTracePath() }
+          : {}),
       },
       this.config.traceWriter ? { traceWriter: this.config.traceWriter } : {},
     );

--- a/src/agent/trace/receipt.test.ts
+++ b/src/agent/trace/receipt.test.ts
@@ -1,0 +1,402 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getReceiptsDir } from '../../paths.js';
+import {
+  generateReceipt,
+  parseTraceJsonl,
+  receiptPathsFor,
+  renderReceiptMarkdown,
+  runReceiptSessionEndHook,
+  writeRunReceipt,
+  type RunReceipt,
+} from './receipt.js';
+import type { ClosureReason, ToolFailureClass, TraceEvent } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Event builders — keep the on-disk envelope ({ ts, seq, kind, payload }).
+// ---------------------------------------------------------------------------
+
+let seq = 0;
+const TS = (n: number): string => `2026-01-01T00:00:${String(n).padStart(2, '0')}.000Z`;
+
+function toolDone(
+  name: string,
+  opts: {
+    isError?: boolean;
+    failureClass?: ToolFailureClass;
+    circuitBreaker?: boolean;
+    durationMs?: number;
+    toolUseId?: string;
+    truncated?: boolean;
+  } = {},
+): TraceEvent {
+  const s = seq++;
+  return {
+    ts: TS(s + 1),
+    seq: s,
+    kind: 'tool_call',
+    payload: {
+      phase: 'completed',
+      toolUseId: opts.toolUseId ?? `t${s}`,
+      name,
+      resultBytes: 12,
+      isError: opts.isError ?? false,
+      truncated: opts.truncated ?? false,
+      durationMs: opts.durationMs ?? 7,
+      ...(opts.failureClass !== undefined ? { failureClass: opts.failureClass } : {}),
+      ...(opts.circuitBreaker !== undefined ? { circuitBreaker: opts.circuitBreaker } : {}),
+    },
+  };
+}
+
+function closure(reason: ClosureReason): TraceEvent {
+  const s = seq++;
+  return {
+    ts: TS(s + 1),
+    seq: s,
+    kind: 'closure',
+    payload: {
+      reason,
+      finalTurnCount: 4,
+      finalCostUsd: 0.1234,
+      finalTokens: { input: 100, output: 50, cacheRead: 10 },
+      lastStopReason: 'end_turn',
+    },
+  };
+}
+
+function sealed(
+  status: 'succeeded' | 'failed' | 'cancelled',
+  extra: { incomplete?: boolean } = {},
+): TraceEvent {
+  const s = seq++;
+  return {
+    ts: TS(s + 1),
+    seq: s,
+    kind: 'session_sealed',
+    payload: {
+      status,
+      finalCostUsd: 0.1234,
+      finalTurnCount: 4,
+      closedAt: TS(s + 1),
+      ...(extra.incomplete !== undefined ? { incomplete: extra.incomplete } : {}),
+    },
+  };
+}
+
+function subagentFailed(): TraceEvent {
+  const s = seq++;
+  return {
+    ts: TS(s + 1),
+    seq: s,
+    kind: 'subagent_lifecycle',
+    payload: {
+      transition: 'failed',
+      subagentId: `sa${s}`,
+      errorClass: 'Error',
+      errorMessage: 'boom',
+      partialOutputBytes: 0,
+    },
+  };
+}
+
+const META = { tracePath: '/x/witness/run-abc/trace.jsonl', witnessLabel: 'run-abc' };
+
+beforeEach(() => {
+  seq = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — success-only trace
+// ---------------------------------------------------------------------------
+
+describe('generateReceipt — success-only trace', () => {
+  it('reports succeeded status, zero failures, and no review required', () => {
+    const events = [
+      toolDone('read_file'),
+      toolDone('bash'),
+      toolDone('bash'),
+      closure('model_end_turn'),
+      sealed('succeeded'),
+    ];
+    const r = generateReceipt(events, META);
+
+    expect(r.status).toBe('succeeded');
+    expect(r.toolCalls.total).toBe(3);
+    expect(r.toolCalls.succeeded).toBe(3);
+    expect(r.toolCalls.errored).toBe(0);
+    expect(r.toolCalls.erroredNotable).toBe(0);
+    expect(r.toolCalls.byTool['bash']).toEqual({ total: 2, errored: 0 });
+    expect(r.failures).toEqual([]);
+    expect(r.humanReviewRequired).toBe(false);
+    expect(r.humanReviewReasons).toEqual([]);
+    expect(r.closureReason).toBe('model_end_turn');
+    expect(r.cost.finalCostUsd).toBeCloseTo(0.1234);
+    expect(r.cost.turnCount).toBe(4);
+    expect(r.witnessLabel).toBe('run-abc');
+    expect(r.tracePath).toBe(META.tracePath);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — failed tool calls (notable vs exempt) + circuit breaker
+// ---------------------------------------------------------------------------
+
+describe('generateReceipt — failed tool calls', () => {
+  it('separates notable from exempt failures and flags review', () => {
+    const events = [
+      toolDone('bash', { isError: true, toolUseId: 'fail-unclassified' }),
+      toolDone('browser_open', { isError: true, failureClass: 'timeout', toolUseId: 'fail-timeout' }),
+      toolDone('browser_open', {
+        isError: true,
+        failureClass: 'policy-refusal',
+        toolUseId: 'exempt-policy',
+      }),
+      toolDone('ask_question', {
+        isError: true,
+        failureClass: 'elicitation-declined',
+        toolUseId: 'exempt-elicit',
+      }),
+      toolDone('bash', { circuitBreaker: true, isError: true }),
+      toolDone('read_file'),
+      closure('abort'),
+      sealed('failed'),
+    ];
+    const r = generateReceipt(events, META);
+
+    // circuitBreaker completion is excluded from totals, counted separately.
+    expect(r.toolCalls.total).toBe(5);
+    expect(r.toolCalls.errored).toBe(4);
+    expect(r.toolCalls.erroredNotable).toBe(2); // unclassified + timeout
+    expect(r.toolCalls.circuitBreakerHits).toBe(1);
+    expect(r.toolCalls.byFailureClass).toMatchObject({
+      unclassified: 1,
+      timeout: 1,
+      'policy-refusal': 1,
+      'elicitation-declined': 1,
+    });
+
+    expect(r.failures).toHaveLength(4);
+    const unclassified = r.failures.find((f) => f.toolUseId === 'fail-unclassified');
+    expect(unclassified?.failureClass).toBeUndefined();
+    expect(unclassified?.exempt).toBe(false);
+    expect(r.failures.find((f) => f.toolUseId === 'fail-timeout')?.exempt).toBe(false);
+    expect(r.failures.find((f) => f.toolUseId === 'exempt-policy')?.exempt).toBe(true);
+    expect(r.failures.find((f) => f.toolUseId === 'exempt-elicit')?.exempt).toBe(true);
+
+    expect(r.status).toBe('failed');
+    expect(r.humanReviewRequired).toBe(true);
+    const joined = r.humanReviewReasons.join('\n');
+    expect(joined).toContain('status "failed"');
+    expect(joined).toContain('2 tool call(s) returned an error');
+    expect(joined).toContain('circuit breaker fired 1');
+    expect(joined).toContain('Closure reason "abort"');
+  });
+
+  it('flags review when a subagent failed', () => {
+    const events = [toolDone('read_file'), subagentFailed(), closure('model_end_turn'), sealed('succeeded')];
+    const r = generateReceipt(events, META);
+    expect(r.subagents.failed).toBe(1);
+    expect(r.humanReviewRequired).toBe(true);
+    expect(r.humanReviewReasons.join('\n')).toContain('1 subagent(s) failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — missing / partial metadata
+// ---------------------------------------------------------------------------
+
+describe('generateReceipt — missing/partial metadata', () => {
+  it('tolerates no closure and no session_sealed', () => {
+    const events = [toolDone('bash'), toolDone('read_file', { isError: true })];
+    const r = generateReceipt(events, META);
+
+    expect(r.status).toBe('unknown');
+    expect(r.closureReason).toBeUndefined();
+    expect(r.cost.finalCostUsd).toBeUndefined();
+    expect(r.cost.turnCount).toBeUndefined();
+    expect(r.toolCalls.total).toBe(2);
+    expect(r.toolCalls.errored).toBe(1);
+    // status unknown is itself a review trigger.
+    expect(r.humanReviewRequired).toBe(true);
+    expect(r.humanReviewReasons.join('\n')).toContain('No terminal session_sealed record');
+    expect(r.limitations.join('\n')).toContain('No session_sealed record was present');
+  });
+
+  it('flags an incomplete (process-exit backstop) seal', () => {
+    const events = [toolDone('bash'), sealed('failed', { incomplete: true })];
+    const r = generateReceipt(events, META);
+    expect(r.incomplete).toBe(true);
+    expect(r.humanReviewReasons.join('\n')).toContain('process-exit backstop');
+  });
+
+  it('does not throw on an empty event list', () => {
+    const r = generateReceipt([], META);
+    expect(r.status).toBe('unknown');
+    expect(r.toolCalls.total).toBe(0);
+    expect(r.events.total).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Markdown rendering
+// ---------------------------------------------------------------------------
+
+describe('renderReceiptMarkdown', () => {
+  it('renders the review banner, reasons, and failures table for a failed run', () => {
+    const events = [
+      toolDone('bash', { isError: true }),
+      closure('abort'),
+      sealed('failed'),
+    ];
+    const md = renderReceiptMarkdown(generateReceipt(events, META));
+    expect(md).toContain('# Run receipt — run-abc');
+    expect(md).toContain('⚠️ YES');
+    expect(md).toContain('## Why review is required');
+    expect(md).toContain('## Failures');
+    expect(md).toContain(META.tracePath);
+    expect(md).toContain('## Limitations');
+    expect(md).toContain('read-only; no agent behavior was modified');
+  });
+
+  it('renders a clean run without a review section', () => {
+    const md = renderReceiptMarkdown(
+      generateReceipt([toolDone('bash'), closure('model_end_turn'), sealed('succeeded')], META),
+    );
+    expect(md).toContain('✓ no');
+    expect(md).toContain('No tool failures recorded.');
+    expect(md).not.toContain('## Why review is required');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseTraceJsonl + receiptPathsFor
+// ---------------------------------------------------------------------------
+
+describe('parseTraceJsonl', () => {
+  it('skips blank and malformed lines', () => {
+    const good = JSON.stringify(toolDone('bash'));
+    const sealedLine = JSON.stringify(sealed('succeeded'));
+    const raw = ['', good, '   ', '{not json', sealedLine, '{"partial":'].join('\n');
+    const events = parseTraceJsonl(raw);
+    expect(events).toHaveLength(2);
+    expect(events[0]?.kind).toBe('tool_call');
+    expect(events[1]?.kind).toBe('session_sealed');
+  });
+});
+
+describe('receiptPathsFor', () => {
+  it('derives the label from the trace dir name', () => {
+    const { label, jsonPath, mdPath } = receiptPathsFor('/a/b/witness/sess-9/trace.jsonl');
+    expect(label).toBe('sess-9');
+    expect(jsonPath.endsWith('sess-9.json')).toBe(true);
+    expect(mdPath.endsWith('sess-9.md')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// I/O: writeRunReceipt + the SessionEnd hook (isolated AFK_HOME)
+// ---------------------------------------------------------------------------
+
+describe('writeRunReceipt + runReceiptSessionEndHook (filesystem)', () => {
+  let home: string;
+  let savedHome: string | undefined;
+  let savedState: string | undefined;
+  let savedDisabled: string | undefined;
+
+  beforeEach(async () => {
+    home = await mkdtemp(join(tmpdir(), 'afk-receipt-test-'));
+    savedHome = process.env['AFK_HOME'];
+    savedState = process.env['AFK_STATE_DIR'];
+    savedDisabled = process.env['AFK_RUN_RECEIPT_DISABLED'];
+    process.env['AFK_HOME'] = home;
+    delete process.env['AFK_STATE_DIR'];
+    delete process.env['AFK_RUN_RECEIPT_DISABLED'];
+  });
+
+  afterEach(async () => {
+    if (savedHome === undefined) delete process.env['AFK_HOME'];
+    else process.env['AFK_HOME'] = savedHome;
+    if (savedState === undefined) delete process.env['AFK_STATE_DIR'];
+    else process.env['AFK_STATE_DIR'] = savedState;
+    if (savedDisabled === undefined) delete process.env['AFK_RUN_RECEIPT_DISABLED'];
+    else process.env['AFK_RUN_RECEIPT_DISABLED'] = savedDisabled;
+    await rm(home, { recursive: true, force: true });
+  });
+
+  async function writeTrace(label: string, events: TraceEvent[]): Promise<string> {
+    const dir = join(home, 'witness', label);
+    await mkdir(dir, { recursive: true });
+    const tracePath = join(dir, 'trace.jsonl');
+    await writeFile(tracePath, events.map((e) => JSON.stringify(e)).join('\n') + '\n', 'utf8');
+    return tracePath;
+  }
+
+  it('writes JSON + Markdown receipts from a sealed trace', async () => {
+    const tracePath = await writeTrace('run-1', [
+      toolDone('bash', { isError: true }),
+      closure('model_end_turn'),
+      sealed('succeeded'),
+    ]);
+    const res = await writeRunReceipt({ tracePath, sessionId: 'sess-logical', reason: 'close' });
+    expect(res).not.toBeNull();
+    expect(res?.label).toBe('run-1');
+    expect(existsSync(join(getReceiptsDir(), 'run-1.json'))).toBe(true);
+    expect(existsSync(join(getReceiptsDir(), 'run-1.md'))).toBe(true);
+
+    const parsed = JSON.parse(await readFile(join(getReceiptsDir(), 'run-1.json'), 'utf8')) as RunReceipt;
+    expect(parsed.witnessLabel).toBe('run-1');
+    expect(parsed.sessionId).toBe('sess-logical');
+    expect(parsed.endReason).toBe('close');
+    expect(parsed.toolCalls.errored).toBe(1);
+    expect(parsed.schemaVersion).toBe(1);
+  });
+
+  it('returns null when the trace file is absent', async () => {
+    const res = await writeRunReceipt({ tracePath: join(home, 'nope', 'trace.jsonl') });
+    expect(res).toBeNull();
+  });
+
+  it('returns null for an empty trace', async () => {
+    const tracePath = await writeTrace('empty', []);
+    expect(await writeRunReceipt({ tracePath })).toBeNull();
+  });
+
+  it('hook writes a receipt for a top-level SessionEnd', async () => {
+    const tracePath = await writeTrace('hooked', [toolDone('bash'), sealed('succeeded')]);
+    const decision = await runReceiptSessionEndHook({
+      event: 'SessionEnd',
+      sessionId: 's1',
+      reason: 'close',
+      tracePath,
+    });
+    expect(decision).toEqual({});
+    expect(existsSync(join(getReceiptsDir(), 'hooked.json'))).toBe(true);
+  });
+
+  it('hook skips forked subagents (parentSessionId set)', async () => {
+    const tracePath = await writeTrace('child', [toolDone('bash'), sealed('succeeded')]);
+    await runReceiptSessionEndHook({
+      event: 'SessionEnd',
+      sessionId: 'child-sess',
+      parentSessionId: 'parent-sess',
+      tracePath,
+    });
+    expect(existsSync(join(getReceiptsDir(), 'child.json'))).toBe(false);
+  });
+
+  it('hook respects AFK_RUN_RECEIPT_DISABLED=1', async () => {
+    process.env['AFK_RUN_RECEIPT_DISABLED'] = '1';
+    const tracePath = await writeTrace('disabled', [toolDone('bash'), sealed('succeeded')]);
+    await runReceiptSessionEndHook({ event: 'SessionEnd', sessionId: 's2', tracePath });
+    expect(existsSync(join(getReceiptsDir(), 'disabled.json'))).toBe(false);
+  });
+
+  it('hook no-ops when no tracePath is present', async () => {
+    const decision = await runReceiptSessionEndHook({ event: 'SessionEnd', sessionId: 's3' });
+    expect(decision).toEqual({});
+  });
+});

--- a/src/agent/trace/receipt.ts
+++ b/src/agent/trace/receipt.ts
@@ -1,0 +1,517 @@
+/**
+ * Read-only run-receipt generator — the first slice of the verification
+ * lifecycle surface.
+ *
+ * After a session's witness trace is sealed (see the SessionEnd ordering in
+ * `src/agent/session/agent-session.ts` — closure → seal → SessionEnd hook),
+ * this module reads the sealed `trace.jsonl` and emits a human- and
+ * machine-readable summary of what happened: tool-call and failure counts,
+ * terminal status, cost, notable failure metadata, and an explicit
+ * human-review verdict with reasons.
+ *
+ * Invariant: strictly READ-ONLY. This never injects context into a running
+ * model, never mutates session control flow, and runs only AFTER the trace is
+ * sealed. A receipt-write failure is swallowed and must never break teardown.
+ *
+ * Provenance honesty: the trace records tool-call METADATA (name, isError,
+ * failureClass, durationMs, timestamps) — NOT raw tool output. The receipt
+ * therefore summarizes metadata and points to the trace as evidence; it never
+ * fabricates output it does not have. This is stated in `limitations`.
+ *
+ * @module agent/trace/receipt
+ */
+
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { basename, dirname, join } from 'path';
+import { getReceiptsDir } from '../../paths.js';
+import { env } from '../../config/env.js';
+import type { HookHandler } from '../hooks.js';
+import type {
+  ClosureReason,
+  ToolFailureClass,
+  TraceEvent,
+  TraceEventKind,
+} from './types.js';
+
+export const RECEIPT_SCHEMA_VERSION = 1 as const;
+
+// Invariant: mirrors the "system correctly said no" set documented on
+// {@link ToolFailureClass} in `./types.ts` and applied by the
+// `tool-failure-density` detector. These failure classes are EXPECTED
+// outcomes (a gate / policy / human correctly refused), so they are counted
+// but do NOT trip the human-review flag on their own. Note `'timeout'` and
+// unclassified failures are deliberately NOT exempt — they still warrant review.
+const REVIEW_EXEMPT_FAILURE_CLASSES: ReadonlySet<ToolFailureClass> = new Set([
+  'policy-refusal',
+  'permission-denied',
+  'hook-block',
+  'abort',
+  'elicitation-declined',
+]);
+
+/** A single failed tool call, summarized from trace metadata (no raw output). */
+export interface ReceiptToolFailure {
+  toolUseId: string;
+  name: string;
+  failureClass?: ToolFailureClass;
+  durationMs: number;
+  ts: string;
+  truncated: boolean;
+  /** True when `failureClass` is an expected refusal ("system correctly said no"). */
+  exempt: boolean;
+  subagentId?: string;
+}
+
+/** The machine-readable run receipt. Written to `<receipts>/<label>.json`. */
+export interface RunReceipt {
+  schemaVersion: typeof RECEIPT_SCHEMA_VERSION;
+  generatedAt: string;
+  /** Witness-trace directory name — the stable correlation key for this run. */
+  witnessLabel: string;
+  /** Absolute path to the sealed `trace.jsonl` this receipt summarizes. */
+  tracePath: string;
+  /** Logical session id, when the session exposed one (may be absent). */
+  sessionId?: string;
+  /** SessionEnd reason that triggered this receipt ('close' | 'reset' | 'error'). */
+  endReason?: string;
+  status: 'succeeded' | 'failed' | 'cancelled' | 'unknown';
+  closureReason?: ClosureReason;
+  lastStopReason?: string;
+  guidance?: string;
+  /** True when the trace was sealed by the synchronous process-exit backstop. */
+  incomplete: boolean;
+  startedAt?: string;
+  endedAt?: string;
+  durationMs?: number;
+  toolCalls: {
+    total: number;
+    succeeded: number;
+    errored: number;
+    /** `errored` minus the expected-refusal (exempt) classes. */
+    erroredNotable: number;
+    circuitBreakerHits: number;
+    byTool: Record<string, { total: number; errored: number }>;
+    byFailureClass: Record<string, number>;
+  };
+  events: {
+    total: number;
+    byKind: Partial<Record<TraceEventKind, number>>;
+  };
+  subagents: {
+    started: number;
+    succeeded: number;
+    failed: number;
+    cancelled: number;
+  };
+  cost: {
+    finalCostUsd?: number;
+    turnCount?: number;
+    tokens?: {
+      input?: number;
+      output?: number;
+      cacheRead?: number;
+      cacheCreation?: number;
+    };
+  };
+  failures: ReceiptToolFailure[];
+  humanReviewRequired: boolean;
+  humanReviewReasons: string[];
+  limitations: string[];
+}
+
+/** Inputs to {@link generateReceipt} that are not derivable from the events. */
+export interface ReceiptMeta {
+  tracePath: string;
+  witnessLabel: string;
+  sessionId?: string;
+  endReason?: string;
+  /** Override "now" for deterministic tests. */
+  now?: Date;
+}
+
+/**
+ * Parse NDJSON trace content into events, tolerantly: blank lines and lines
+ * that fail to parse (e.g. a half-written final line after a crash) are
+ * skipped rather than thrown, so a partially-corrupt trace still yields a
+ * receipt from the events that ARE intact.
+ */
+export function parseTraceJsonl(raw: string): TraceEvent[] {
+  const out: TraceEvent[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '') continue;
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (isTraceEvent(parsed)) out.push(parsed);
+    } catch {
+      // Skip malformed line — tolerance is the point.
+    }
+  }
+  return out;
+}
+
+function isTraceEvent(v: unknown): v is TraceEvent {
+  if (typeof v !== 'object' || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return typeof o['kind'] === 'string' && typeof o['ts'] === 'string' && 'payload' in o;
+}
+
+/**
+ * Derive the receipt file paths from a trace path. The witness dir is
+ * `<state>/witness/<label>/trace.jsonl`; the parent-dir name is the trace's
+ * session label, which we reuse as the receipt key so a receipt sits 1:1 with
+ * the trace it summarizes.
+ */
+export function receiptPathsFor(tracePath: string): {
+  label: string;
+  jsonPath: string;
+  mdPath: string;
+} {
+  const label = basename(dirname(tracePath));
+  const dir = getReceiptsDir();
+  return {
+    label,
+    jsonPath: join(dir, `${label}.json`),
+    mdPath: join(dir, `${label}.md`),
+  };
+}
+
+/** Build a {@link RunReceipt} from parsed trace events. Pure — no I/O. */
+export function generateReceipt(events: TraceEvent[], meta: ReceiptMeta): RunReceipt {
+  const byKind: Partial<Record<TraceEventKind, number>> = {};
+  const byTool: Record<string, { total: number; errored: number }> = {};
+  const byFailureClass: Record<string, number> = {};
+  const failures: ReceiptToolFailure[] = [];
+
+  let total = 0;
+  let succeeded = 0;
+  let errored = 0;
+  let circuitBreakerHits = 0;
+  const subagents = { started: 0, succeeded: 0, failed: 0, cancelled: 0 };
+
+  let closureReason: ClosureReason | undefined;
+  let lastStopReason: string | undefined;
+  let guidance: string | undefined;
+  let closureTokens: RunReceipt['cost']['tokens'];
+  let closureCostUsd: number | undefined;
+  let closureTurnCount: number | undefined;
+
+  let sealedStatus: 'succeeded' | 'failed' | 'cancelled' | undefined;
+  let sealedCostUsd: number | undefined;
+  let sealedTurnCount: number | undefined;
+  let sealedClosedAt: string | undefined;
+  let incomplete = false;
+
+  for (const ev of events) {
+    byKind[ev.kind] = (byKind[ev.kind] ?? 0) + 1;
+    switch (ev.kind) {
+      case 'tool_call': {
+        const p = ev.payload;
+        if (p.phase !== 'completed') break;
+        // Synthetic circuit-breaker completions are not real dispatches; the
+        // failure-density detector excludes them, so we count them separately.
+        if (p.circuitBreaker === true) {
+          circuitBreakerHits++;
+          break;
+        }
+        total++;
+        const bucket = byTool[p.name] ?? { total: 0, errored: 0 };
+        bucket.total++;
+        if (p.isError === true) {
+          errored++;
+          bucket.errored++;
+          const cls = p.failureClass;
+          const key = cls ?? 'unclassified';
+          byFailureClass[key] = (byFailureClass[key] ?? 0) + 1;
+          failures.push({
+            toolUseId: p.toolUseId,
+            name: p.name,
+            ...(cls !== undefined ? { failureClass: cls } : {}),
+            durationMs: p.durationMs,
+            ts: ev.ts,
+            truncated: p.truncated === true,
+            exempt: cls !== undefined && REVIEW_EXEMPT_FAILURE_CLASSES.has(cls),
+            ...(p.subagentId !== undefined ? { subagentId: p.subagentId } : {}),
+          });
+        } else {
+          succeeded++;
+        }
+        byTool[p.name] = bucket;
+        break;
+      }
+      case 'subagent_lifecycle': {
+        const t = ev.payload.transition;
+        if (t === 'started') subagents.started++;
+        else if (t === 'succeeded') subagents.succeeded++;
+        else if (t === 'failed') subagents.failed++;
+        else if (t === 'cancelled') subagents.cancelled++;
+        break;
+      }
+      case 'closure': {
+        const p = ev.payload;
+        closureReason = p.reason;
+        lastStopReason = p.lastStopReason;
+        guidance = p.guidance;
+        closureCostUsd = p.finalCostUsd;
+        closureTurnCount = p.finalTurnCount;
+        if (p.finalTokens !== undefined) closureTokens = p.finalTokens;
+        break;
+      }
+      case 'session_sealed': {
+        const p = ev.payload;
+        sealedStatus = p.status;
+        sealedCostUsd = p.finalCostUsd;
+        sealedTurnCount = p.finalTurnCount;
+        sealedClosedAt = p.closedAt;
+        if (p.incomplete === true) incomplete = true;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  const erroredNotable = failures.filter((f) => !f.exempt).length;
+  const status = sealedStatus ?? 'unknown';
+
+  const startedAt = events[0]?.ts;
+  const endedAt = sealedClosedAt ?? (events.length > 0 ? events[events.length - 1]?.ts : undefined);
+  let durationMs: number | undefined;
+  if (startedAt !== undefined && endedAt !== undefined) {
+    const d = Date.parse(endedAt) - Date.parse(startedAt);
+    if (Number.isFinite(d) && d >= 0) durationMs = d;
+  }
+
+  const finalCostUsd = sealedCostUsd ?? closureCostUsd;
+  const turnCount = sealedTurnCount ?? closureTurnCount;
+
+  const reasons: string[] = [];
+  if (status === 'failed') reasons.push('Session sealed with status "failed".');
+  else if (status === 'cancelled') reasons.push('Session was cancelled.');
+  else if (status === 'unknown')
+    reasons.push(
+      'No terminal session_sealed record found — the trace may be truncated or was read before the session sealed.',
+    );
+  if (incomplete)
+    reasons.push(
+      'Trace was sealed by the process-exit backstop, indicating an abnormal exit (crash, early EOF, or process.exit()).',
+    );
+  if (closureReason !== undefined && closureReason !== 'model_end_turn')
+    reasons.push(`Closure reason "${closureReason}" is not a clean completion.`);
+  if (erroredNotable > 0)
+    reasons.push(
+      `${erroredNotable} tool call(s) returned an error (excluding expected policy/permission refusals).`,
+    );
+  if (circuitBreakerHits > 0)
+    reasons.push(`Repeat-loop circuit breaker fired ${circuitBreakerHits} time(s).`);
+  if (subagents.failed > 0) reasons.push(`${subagents.failed} subagent(s) failed.`);
+
+  const limitations = [
+    'Sourced from witness-trace metadata only: raw tool output (stdout/stderr, file contents, error messages) is NOT recorded in the trace and is therefore absent here.',
+    'Failure entries list tool name, failure class, duration, and timestamp; inspect the trace at the path above for full per-call detail.',
+  ];
+  if (status === 'unknown')
+    limitations.push('No session_sealed record was present when this receipt was generated.');
+
+  const cost: RunReceipt['cost'] = {
+    ...(finalCostUsd !== undefined ? { finalCostUsd } : {}),
+    ...(turnCount !== undefined ? { turnCount } : {}),
+    ...(closureTokens !== undefined ? { tokens: closureTokens } : {}),
+  };
+
+  return {
+    schemaVersion: RECEIPT_SCHEMA_VERSION,
+    generatedAt: (meta.now ?? new Date()).toISOString(),
+    witnessLabel: meta.witnessLabel,
+    tracePath: meta.tracePath,
+    ...(meta.sessionId !== undefined ? { sessionId: meta.sessionId } : {}),
+    ...(meta.endReason !== undefined ? { endReason: meta.endReason } : {}),
+    status,
+    ...(closureReason !== undefined ? { closureReason } : {}),
+    ...(lastStopReason !== undefined ? { lastStopReason } : {}),
+    ...(guidance !== undefined ? { guidance } : {}),
+    incomplete,
+    ...(startedAt !== undefined ? { startedAt } : {}),
+    ...(endedAt !== undefined ? { endedAt } : {}),
+    ...(durationMs !== undefined ? { durationMs } : {}),
+    toolCalls: {
+      total,
+      succeeded,
+      errored,
+      erroredNotable,
+      circuitBreakerHits,
+      byTool,
+      byFailureClass,
+    },
+    events: { total: events.length, byKind },
+    subagents,
+    cost,
+    failures,
+    humanReviewRequired: reasons.length > 0,
+    humanReviewReasons: reasons,
+    limitations,
+  };
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s % 60);
+  return `${m}m${rem}s`;
+}
+
+/** Render a {@link RunReceipt} as human-readable Markdown. Pure — no I/O. */
+export function renderReceiptMarkdown(r: RunReceipt): string {
+  const lines: string[] = [];
+  lines.push(`# Run receipt — ${r.witnessLabel}`);
+  lines.push('');
+  lines.push(
+    `**Status:** ${r.status} · **Review required:** ${r.humanReviewRequired ? '⚠️ YES' : '✓ no'}`,
+  );
+  const metaParts: string[] = [];
+  if (r.sessionId !== undefined) metaParts.push(`**Session:** ${r.sessionId}`);
+  if (r.endedAt !== undefined) metaParts.push(`**Ended:** ${r.endedAt}`);
+  if (r.durationMs !== undefined) metaParts.push(`**Duration:** ${formatDuration(r.durationMs)}`);
+  if (metaParts.length > 0) lines.push(metaParts.join(' · '));
+  lines.push(`**Trace:** \`${r.tracePath}\``);
+  lines.push('');
+
+  if (r.humanReviewRequired) {
+    lines.push('## Why review is required');
+    for (const reason of r.humanReviewReasons) lines.push(`- ${reason}`);
+    lines.push('');
+  }
+
+  lines.push('## Summary');
+  lines.push('');
+  lines.push('| Metric | Value |');
+  lines.push('| --- | --- |');
+  lines.push(`| Tool calls | ${r.toolCalls.total} |`);
+  lines.push(`| Errored | ${r.toolCalls.errored} (${r.toolCalls.erroredNotable} notable) |`);
+  if (r.toolCalls.circuitBreakerHits > 0)
+    lines.push(`| Circuit-breaker hits | ${r.toolCalls.circuitBreakerHits} |`);
+  if (r.cost.turnCount !== undefined) lines.push(`| Turns | ${r.cost.turnCount} |`);
+  if (r.cost.finalCostUsd !== undefined)
+    lines.push(`| Cost (USD) | ${r.cost.finalCostUsd.toFixed(4)} |`);
+  if (r.subagents.started > 0)
+    lines.push(
+      `| Subagents | ${r.subagents.started} started · ${r.subagents.succeeded} ok · ` +
+        `${r.subagents.failed} failed · ${r.subagents.cancelled} cancelled |`,
+    );
+  if (r.closureReason !== undefined) lines.push(`| Closure | ${r.closureReason} |`);
+  lines.push('');
+
+  const toolNames = Object.keys(r.toolCalls.byTool).sort();
+  if (toolNames.length > 0) {
+    lines.push('## Tool calls by name');
+    lines.push('');
+    lines.push('| Tool | Calls | Errored |');
+    lines.push('| --- | --- | --- |');
+    for (const name of toolNames) {
+      const b = r.toolCalls.byTool[name];
+      if (b === undefined) continue;
+      lines.push(`| ${name} | ${b.total} | ${b.errored} |`);
+    }
+    lines.push('');
+  }
+
+  if (r.failures.length > 0) {
+    lines.push('## Failures');
+    lines.push('');
+    lines.push('| Tool | Class | Duration | When | Exempt |');
+    lines.push('| --- | --- | --- | --- | --- |');
+    for (const f of r.failures) {
+      lines.push(
+        `| ${f.name} | ${f.failureClass ?? 'unclassified'} | ${f.durationMs}ms | ${f.ts} | ` +
+          `${f.exempt ? 'yes' : 'no'} |`,
+      );
+    }
+    lines.push('');
+  } else {
+    lines.push('No tool failures recorded.');
+    lines.push('');
+  }
+
+  lines.push('## Limitations');
+  lines.push('');
+  for (const lim of r.limitations) lines.push(`- ${lim}`);
+  lines.push('');
+  lines.push('---');
+  lines.push(
+    `_Generated ${r.generatedAt} by the AFK run-receipt writer ` +
+      `(read-only; no agent behavior was modified)._`,
+  );
+  lines.push('');
+  return lines.join('\n');
+}
+
+/** Options for {@link writeRunReceipt}. */
+export interface WriteRunReceiptOptions {
+  /** Absolute path to the sealed trace.jsonl to summarize. */
+  tracePath: string;
+  sessionId?: string;
+  reason?: string;
+  now?: Date;
+}
+
+/**
+ * Read a sealed trace, generate the receipt, and write both the JSON and
+ * Markdown files under `<state>/receipts/`. Returns the written paths, or
+ * `null` when there is nothing to summarize (no trace file on disk — e.g.
+ * tracing disabled — or an empty trace). Never throws on a missing trace.
+ */
+export async function writeRunReceipt(
+  opts: WriteRunReceiptOptions,
+): Promise<{ label: string; jsonPath: string; mdPath: string } | null> {
+  let raw: string;
+  try {
+    raw = await readFile(opts.tracePath, 'utf8');
+  } catch {
+    return null; // No trace file — receipts piggyback on the witness layer.
+  }
+  const events = parseTraceJsonl(raw);
+  if (events.length === 0) return null;
+
+  const paths = receiptPathsFor(opts.tracePath);
+  const receipt = generateReceipt(events, {
+    tracePath: opts.tracePath,
+    witnessLabel: paths.label,
+    ...(opts.sessionId !== undefined ? { sessionId: opts.sessionId } : {}),
+    ...(opts.reason !== undefined ? { endReason: opts.reason } : {}),
+    ...(opts.now !== undefined ? { now: opts.now } : {}),
+  });
+
+  await mkdir(getReceiptsDir(), { recursive: true });
+  await writeFile(paths.jsonPath, JSON.stringify(receipt, null, 2) + '\n', 'utf8');
+  await writeFile(paths.mdPath, renderReceiptMarkdown(receipt), 'utf8');
+  return paths;
+}
+
+/**
+ * Built-in SessionEnd hook that writes a run receipt for top-level sessions.
+ *
+ * Read-only and best-effort: it returns an empty decision (never blocks or
+ * injects), skips forked subagents (one receipt per user-facing run), honors
+ * `AFK_RUN_RECEIPT_DISABLED=1`, and swallows any write error so a receipt
+ * failure can never break session teardown. It relies on `context.tracePath`
+ * (threaded from the trace writer) because the witness dir is keyed by the
+ * writer's session label, NOT by `sessionId`.
+ */
+export const runReceiptSessionEndHook: HookHandler = async (context) => {
+  if (context.event !== 'SessionEnd') return {};
+  if (context.parentSessionId !== undefined) return {}; // skip subagents
+  if (env.AFK_RUN_RECEIPT_DISABLED === '1') return {};
+  if (context.tracePath === undefined) return {};
+  try {
+    await writeRunReceipt({
+      tracePath: context.tracePath,
+      ...(context.sessionId !== undefined ? { sessionId: context.sessionId } : {}),
+      ...(context.reason !== undefined ? { reason: context.reason } : {}),
+    });
+  } catch {
+    // Best-effort: a receipt-write failure must never break teardown.
+  }
+  return {};
+};

--- a/src/agent/trace/writer.ts
+++ b/src/agent/trace/writer.ts
@@ -61,6 +61,14 @@ export interface TraceWriter {
    *  writer is sealed. */
   write(event: TraceEventInput): Promise<void>;
 
+  /** Absolute path to the JSONL file this writer appends to. The file-backed
+   *  writer returns its real path; the in-memory writer returns a
+   *  non-filesystem sentinel (`in-memory://trace`) so consumers that try to
+   *  read it (e.g. the run-receipt writer) simply find nothing. Threaded into
+   *  the SessionEnd context so a hook can locate the trace without knowing the
+   *  writer's randomly-generated session label. */
+  getTracePath(): string;
+
   /** Write the terminal `session_sealed` record and close the underlying
    *  resource. Idempotent — subsequent calls resolve to no-op. After
    *  `seal()` returns, `write()` rejects. */
@@ -415,6 +423,12 @@ export class InMemoryTraceWriter implements TraceWriter {
     }
 
     this._events.push({ ts, seq, kind: event.kind, payload: event.payload } as TraceEvent);
+  }
+
+  /** In-memory writer has no backing file; return a non-filesystem sentinel
+   *  so a reader (e.g. the run-receipt writer) finds nothing and no-ops. */
+  getTracePath(): string {
+    return 'in-memory://trace';
   }
 
   async seal(payload: SessionSealedPayload): Promise<void> {

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -4,6 +4,7 @@ import ora from 'ora';
 import { handleCommandError } from '../errors/index.js';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { existsSync } from 'node:fs';
 import { AgentSession } from '../../agent/session.js';
 import { createDefaultHookRegistry } from '../../agent/default-hook-registry.js';
 import { loadHooksConfig } from '../../agent/hooks/config-loader.js';
@@ -26,6 +27,7 @@ import { BUILTIN_TOOL_NAMES } from '../../agent/tools/schemas.js';
 import { MEMORY_TOOL_NAMES } from '../../agent/memory/index.js';
 import { AWARENESS_TOOL_NAMES } from '../../agent/awareness/index.js';
 import { createDefaultTraceWriter } from '../../agent/trace/factory.js';
+import { receiptPathsFor } from '../../agent/trace/receipt.js';
 import { setupWorktree } from './interactive/worktree.js';
 import { resolveResumeTarget, resumeConfigFor } from '../resume-session.js';
 import { saveSession, findSession } from '../session-store.js';
@@ -268,6 +270,9 @@ export function registerChatCommand(program: Command): void {
       // with a misleading resume hint (stats.totalTurns is pre-seeded from the
       // prior session and would otherwise trip the > 0 persistence check).
       let encounteredError = false;
+      // Hoisted out of the try so the finally block can surface the run-receipt
+      // path after session.close() (the trace const is block-scoped to try).
+      let receiptTracePath: string | undefined;
 
       try {
         // Optional worktree isolation. Mirrors `afk interactive -w`: the
@@ -418,6 +423,7 @@ export function registerChatCommand(program: Command): void {
         // to keep stdout clean for piping; operators inspect the file under
         // ~/.afk/state/witness/ after the run.
         const trace = createDefaultTraceWriter();
+        receiptTracePath = trace?.tracePath;
 
         const rootManager = new SubagentManager({
           apiKey,
@@ -775,6 +781,19 @@ export function registerChatCommand(program: Command): void {
         }
         if (session) {
           await session.close();
+          // Best-effort run-receipt pointer on stderr (stdout stays pipe-clean
+          // for piping/JSON consumers). The SessionEnd hook wrote the receipt
+          // during close(); surface its path if the file is present.
+          if (receiptTracePath !== undefined) {
+            try {
+              const { mdPath } = receiptPathsFor(receiptTracePath);
+              if (existsSync(mdPath)) {
+                process.stderr.write(`Receipt: ${mdPath}\n`);
+              }
+            } catch {
+              /* best-effort — never mask the run's real outcome */
+            }
+          }
         }
         sharedMemoryStore?.close();
         // Worktree cleanup: session close must finish before

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -856,6 +856,17 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     category: 'debug',
   },
   {
+    name: 'AFK_RUN_RECEIPT_DISABLED',
+    description:
+      'Disable the post-session run receipt (state/receipts/<label>.json and .md). ' +
+      'Set to 1 to skip receipt writes; the underlying witness trace is unaffected. ' +
+      'Receipts are also implicitly off when AFK_TRACE_DISABLED=1 (no trace to summarize).',
+    type: 'boolean',
+    required: false,
+    example: '1',
+    category: 'debug',
+  },
+  {
     name: 'DEBUG',
     description: 'Standard Node `debug`-package convention. When set to 1, enables verbose logging in several modules alongside AFK_DEBUG.',
     type: 'string',
@@ -1205,6 +1216,7 @@ export const env = {
   get AFK_DEBUG_COMPOSITOR(): string | undefined { return process.env['AFK_DEBUG_COMPOSITOR']; },
   get AFK_TRACE_DISABLED(): string | undefined { return process.env['AFK_TRACE_DISABLED']; },
   get AFK_SESSION_LEDGER_DISABLED(): string | undefined { return process.env['AFK_SESSION_LEDGER_DISABLED']; },
+  get AFK_RUN_RECEIPT_DISABLED(): string | undefined { return process.env['AFK_RUN_RECEIPT_DISABLED']; },
   get DEBUG(): string | undefined { return process.env['DEBUG']; },
   get AGENT_AFK_ASCII(): string | undefined { return process.env['AGENT_AFK_ASCII']; },
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -295,6 +295,18 @@ export function getTraceDir(sessionId: string): string {
   return join(getAfkStateDir(), 'witness', sessionId);
 }
 
+/**
+ * Directory for post-session run receipts.
+ *
+ * Each completed top-level session writes `<label>.json` + `<label>.md` here,
+ * keyed by the witness-trace label so a receipt sits 1:1 with the trace it
+ * summarizes (see `src/agent/trace/receipt.ts`). Read-only derivatives of the
+ * sealed witness trace — they carry no state the trace doesn't already hold.
+ */
+export function getReceiptsDir(): string {
+  return join(getAfkStateDir(), 'receipts');
+}
+
 export function getDaemonStateDir(instanceId: string = 'default'): string {
   return join(getAfkStateDir(), 'daemon', `agent-afk@${instanceId}`);
 }


### PR DESCRIPTION
## What

After a session's witness trace is sealed, a built-in **SessionEnd hook** reads `trace.jsonl` and writes a read-only **run receipt** to `~/.afk/state/receipts/<label>.{json,md}` summarizing the run: tool-call and failure counts, terminal status, cost, notable failure metadata, and an explicit human-review verdict with reasons.

This is the first slice of a verification-lifecycle surface — deliberately **observe-first** (no PostToolUse `injectContext` nudging, which isn't viable today: `dispatchPostToolUse` is fire-and-forget and `injectContext` is only honored for `SubagentStop`).

## Design notes

- **Strictly read-only.** Never injects context, never alters control flow, runs only *after* the trace is sealed (ordering in `agent-session.ts`: `emitClosure → sealTraceWriter → dispatchSessionEnd`). A write failure is swallowed and never breaks teardown. Forked subagents are skipped (one receipt per top-level run).
- **Why thread `tracePath` into the SessionEnd context:** the witness dir is keyed by the trace writer's **session label** (a random UUID on the one-shot `chat` path), *not* by `sessionId` — so a hook cannot resolve the trace from `sessionId` alone. The writer now exposes `getTracePath()` on the `TraceWriter` interface; `agent-session` passes it into `SessionEndContext.tracePath`.
- **Provenance honesty.** The trace records tool-call *metadata* (name, `isError`, `failureClass`, `durationMs`, timestamps), **not** raw output. The receipt summarizes metadata and points to the trace as evidence; its `limitations` block states this. Expected refusals (`policy-refusal`, `permission-denied`, `hook-block`, `abort`, `elicitation-declined`) are counted but excluded from the review trigger, mirroring the `tool-failure-density` detector.

## Changes

- **new** `src/agent/trace/receipt.ts` — `generateReceipt` / `renderReceiptMarkdown` / `parseTraceJsonl` / `writeRunReceipt` / `runReceiptSessionEndHook`
- **new** `src/agent/trace/receipt.test.ts` — 17 tests
- `paths.ts` — `getReceiptsDir()`
- `trace/writer.ts` — `getTracePath()` on the `TraceWriter` interface (+ in-memory sentinel)
- `hooks.ts` — `SessionEndContext.tracePath`
- `session/agent-session.ts` — populate `tracePath` at SessionEnd dispatch
- `default-hook-registry.ts` — register `runReceiptSessionEndHook`
- `cli/commands/chat.ts` — best-effort `Receipt: <path>` hint on stderr after close (stdout stays pipe-clean)
- `config/env.ts` — `AFK_RUN_RECEIPT_DISABLED` opt-out (+ regenerated `docs/env-registry.{json,md}`)

## Tests cover

Success-only traces · traces with failed tool calls (notable vs exempt + circuit-breaker) · missing/partial metadata (no closure/seal, incomplete seal, empty) · markdown rendering · tolerant NDJSON parsing · the filesystem writer · all four hook gates (top-level write, subagent skip, env opt-out, no-tracePath no-op).

## Known limitations

- Metadata only — no raw tool output (stated in the receipt itself).
- One receipt per top-level run; subagents skipped by design.
- REPL has no post-session receipt line yet (only one-shot `chat`); deferred for TUI-compositor safety.
- Opt-out: `AFK_RUN_RECEIPT_DISABLED=1` (also implicitly off under `AFK_TRACE_DISABLED=1`).
- No runtime injection or behavior modification introduced.

## Gates

- `pnpm lint` (tsc --noEmit strict): clean
- `pnpm scan:env:check` (CI gate): in sync (115 vars)
- 17 new receipt tests pass; touched-area suites green
- The one suite-wide failure (`anthropic-direct.test.ts > compact()`) is **pre-existing** — reproduced identically with this branch's changes stashed; unrelated to receipts.
