### PR TITLE
fix(anthropic-direct): terminate query generator on interrupt during usage-limit wait

### DIFF
--- a/src/agent/providers/anthropic-direct/query-auth-retry.test.ts
+++ b/src/agent/providers/anthropic-direct/query-auth-retry.test.ts
@@ -690,6 +690,81 @@ describe('AnthropicDirectProvider — turnWithUsageLimitRetry', () => {
     expect(messagesCreateMock).toHaveBeenCalledTimes(1);
   });
 
+  it('interrupt during wait: 429+ts → paused → interrupt() → generator terminates (no hang, no resumed)', async () => {
+    // Regression guard for the usage-limit hang. When Ctrl+C (interrupt) lands
+    // during the usage-limit wait, `turnWithRetries` returns CLEANLY (not via
+    // throw — see retry-layer's `if (result === 'aborted') return`), so the
+    // catch-path abort guard in query.ts never fires. Without the post-finally
+    // guard the outer loop falls through to the next `promptIterator.next()`
+    // and BLOCKS there forever while the consumer is still awaiting a terminal
+    // event for the aborted turn — the REPL hangs (can't quit, auto-resume
+    // never re-fires, queued input never drains).
+    //
+    // The prompt stream below blocks on its 2nd pull, exactly like the live
+    // REPL idle wait, so the hang is observable. A single-shot stream would
+    // return `done` on the 2nd loop and mask the bug. Uses REAL timers because
+    // the abort short-circuits waitForReset synchronously (the signal is
+    // already aborted when waitForReset is entered) and we want a wall-clock
+    // failsafe that fires if the hang regresses.
+    vi.useRealTimers();
+
+    let releaseSecondPull: (() => void) | undefined;
+    const blockingPrompt = (async function* (): AsyncIterable<{ content: string }> {
+      yield { content: 'hello' };
+      // 2nd pull blocks until released — mirrors the REPL awaiting next input.
+      await new Promise<void>((resolve) => { releaseSecondPull = resolve; });
+    })();
+
+    let callIdx = 0;
+    messagesCreateMock.mockImplementation(() => {
+      callIdx += 1;
+      if (callIdx === 1) throw make429UsageLimitError(60 * 60 * 1_000); // 1h reset
+      return fromArray(makeTextStream('should not reach'));
+    });
+
+    const provider = new AnthropicDirectProvider();
+    const query = provider.query({
+      prompt: blockingPrompt,
+      config: { model: 'claude-sonnet-4-5-20250929', apiKey: 'sk-ant-oat01-test', autoResumeOnUsageLimit: true },
+    });
+
+    const events: ProviderEvent[] = [];
+    const collectWithInterrupt = async (): Promise<void> => {
+      for await (const ev of query) {
+        events.push(ev);
+        if (ev.type === 'paused') {
+          // User hits Ctrl+C during the usage-limit wait.
+          await query.interrupt();
+        }
+      }
+    };
+
+    // Fail fast and legibly if the hang regresses: once interrupted, the
+    // generator must terminate well within this window.
+    let failsafeTimer: ReturnType<typeof setTimeout> | undefined;
+    const failsafe = new Promise<never>((_resolve, reject) => {
+      failsafeTimer = setTimeout(
+        () => reject(new Error(
+          'HANG: query generator did not terminate after interrupt() during the usage-limit wait — regression of the query.ts post-finally abort guard',
+        )),
+        2_000,
+      );
+    });
+
+    try {
+      await Promise.race([collectWithInterrupt(), failsafe]);
+    } finally {
+      if (failsafeTimer !== undefined) clearTimeout(failsafeTimer);
+      releaseSecondPull?.();
+    }
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain('paused');
+    expect(types).not.toContain('resumed');
+    // Only the first (429'd) call — the interrupt prevents any replay.
+    expect(messagesCreateMock).toHaveBeenCalledTimes(1);
+  });
+
   it('2h cap: 429 with resetsAt > 2h from now → error surfaces immediately, no paused/resumed', async () => {
     messagesCreateMock.mockImplementation(() => {
       throw make429UsageLimitError(3 * 60 * 60 * 1_000); // 3h reset

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -383,6 +383,21 @@ export class AnthropicDirectQuery implements ProviderQuery {
           this.abort.clear(controller);
         }
 
+        // Invariant: a turn aborted mid-flight must terminate this generator,
+        // not loop back for another prompt. When the turn THROWS, the catch
+        // above returns on `signal.aborted`. But an interrupt that lands during
+        // the usage-limit wait makes `turnWithRetries` return CLEANLY (no throw
+        // — see retry-layer's `if (result === 'aborted') return`), so the catch
+        // never fires and we arrive here with the signal still aborted. Without
+        // this guard the loop falls through to `promptIterator.next()` and
+        // blocks forever while the consumer (`sendMessageStreamInternal`) is
+        // still awaiting a terminal event for the aborted turn — the REPL hangs:
+        // Ctrl+C can't quit, auto-resume never re-fires, and queued input never
+        // drains. Returning yields `{done:true}` to the consumer so the turn
+        // unwinds cleanly. Mirrors the catch-path guard above. (`abort.clear`
+        // in the finally nulls the slot but does NOT reset `signal.aborted`.)
+        if (controller.signal.aborted) return;
+
         // Auto-compaction: fire at the natural turn boundary — after the
         // per-turn event loop exits and the abort slot is cleared — so we
         // never trigger while a tool call is in flight.


### PR DESCRIPTION
## Summary

Fixes an interactive-REPL hang triggered when the user presses **Ctrl+C during the Anthropic usage-limit wait** ("out of usage"). After the interrupt the session wedged: it couldn't quit, auto-resume never re-fired, and newly typed messages just showed **"queued"** forever.

**Root cause:** In `AnthropicDirectQuery[Symbol.asyncIterator]` (`query.ts`) the per-turn loop had an abort guard **only on the `catch` path**. But an interrupt landing during the usage-limit wait makes `turnWithRetries` return **cleanly** (no throw — `retry-layer.ts`: `if (result === 'aborted') return`), so the catch never fired. The outer loop then fell through to `promptIterator.next()` and **blocked forever** while the consumer (`sendMessageStreamInternal`) was still awaiting a terminal event for the aborted turn → all three symptoms.

**Fix:** add a post-`finally` abort guard symmetric with the existing catch-path guard — when the turn was aborted, `return` so the consumer observes `{done:true}` and the turn unwinds to idle. (`abort.clear()` nulls the coordinator slot but does not reset `signal.aborted`, so the post-`finally` read is valid.)

Diagnosed via `/diagnose`; winning hypothesis confirmed by isolated-worktree validation.

## Test results
- `pnpm lint` (strict `tsc --noEmit`): **passed**
- New regression test `query-auth-retry.test.ts` › *"interrupt during wait"*: **red → green** (2.2s hang → 334ms clean termination). Drives `interrupt()` during the wait with a prompt stream that **blocks on its 2nd pull**, mirroring the live REPL idle wait — the existing `close()`-based abort test couldn't catch this.
- `pnpm test` (full suite): **9815 passed / 12 skipped / 1 failed**. The lone failure — `anthropic-direct.test.ts › compact()…` asserting a haiku model id (`claude-haiku-4-5-20251001` vs `claude-haiku-4-5`) — is **pre-existing on `main`** (model-version drift) in a file this PR does **not** touch; that file is byte-identical to `origin/main`.

## Verification (`--verify`)
Adversarial verifier re-derived the load-bearing claims from the diff alone:
- **Fix correctness** — CONFIRM: the clean abort-return is the previously-unguarded exit; the new guard is the missing terminator.
- **No regression on normal completion** — CONFIRM: `signal.aborted` is false on non-aborted turns, so the guard is a no-op and auto-compaction + the next-turn loop still run.
- **Signal readable after clear** — CONFIRM: `abort-coordinator.clear()` only nulls the slot; never resets the signal.
- Regression sweep: the outer `finally` (`promptIterator.return`) still runs on the early return; no path wants to keep looping while aborted. **Verdict: SAFE TO MERGE.**

## Follow-ups (out of scope — separate bugs surfaced during diagnosis, not fixed here)
1. **Transcript "(no response recorded)" data loss** on interrupt/crash: an interrupted turn never calls `appendTurn` (gated on `doneFired`), so in-flight assistant text isn't persisted; `closeDanglingTurn` writes the placeholder on next startup. Needs an `appendPartialTurn` path.
2. **Concurrent-session usage-limit dedup**: a 2nd session awaiting the shared `usageLimitWaitPromise` doesn't register its own abort signal with `waitForReset`, so its interrupt wouldn't break the wait.
