### PR TITLE
chore: credit @LIghtJUNction via .mailmap (fix Anonymous contributor from #96)

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -8,3 +8,10 @@
 # produced a phantom "noreply" contributor and dropped the real author. Re-attribute it to the
 # actual author. (The afk-port skill was fixed to preserve the source PR author going forward.)
 Griffin Long <griffinwork40@gmail.com> afk-port <noreply@users.noreply.github.com>
+#
+# PR #96 (commit 4bc3b560) was authored by @LIghtJUNction but recorded with a malformed GitHub
+# noreply email whose numeric prefix (1005396112984780862) is not a valid GitHub user ID, so
+# GitHub could not link the commit and surfaced an "Anonymous" contributor instead of crediting
+# the real account (@LIghtJUNction, id 106986785). Map it to their canonical noreply address so
+# the contributor graph links the commit to the account.
+LIghtJUNction <106986785+LIghtJUNction@users.noreply.github.com> <1005396112984780862+LIghtJUNction@users.noreply.github.com>


### PR DESCRIPTION
## What

Adds a `.mailmap` entry re-attributing the commit from #96 to its real author, **@LIghtJUNction**.

## Why

#96 was genuinely authored by @LIghtJUNction, but the commit's author email
(`1005396112984780862+LIghtJUNction@users.noreply.github.com`) carries a malformed numeric prefix that is **not a valid GitHub user id** — their real id is `106986785` (9 digits), not the 19-digit value in the email. Because GitHub can't link that email to an account, it lists the commit as an **`Anonymous`** contributor, so @LIghtJUNction receives no credit on the contributors graph.

## Fix

Map the malformed identity to the canonical, account-bound noreply `106986785+LIghtJUNction@users.noreply.github.com`. Verified locally with `git check-mailmap` (resolves correctly; the existing `afk-port` mapping is unaffected).

GitHub honors `.mailmap` for the contributor graph (confirmed live against the `richardebeling/github-mailmap-test` monitor, whose contributors API returns the mailmap-resolved identity), so the graph should re-link the commit to @LIghtJUNction within ~24–48h. No history rewrite required.

## Notes

- The `github-actions[bot]` contributor is intentionally left as-is — it's legitimate release automation, and `.mailmap` is the wrong tool for it anyway.
- If the entry is still `Anonymous` after ~48h, the only definitive remedy is rewriting that single commit's author (destructive on `main`), to be decided separately.
