### PR TITLE
feat(afk): opt-in "Done" verification for AFK Telegram pushes (#237)

### DIFF
--- a/src/cli/commands/interactive/afk-push.test.ts
+++ b/src/cli/commands/interactive/afk-push.test.ts
@@ -2,14 +2,22 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   formatTerminalStateForTelegram,
   pushTerminalStateToTelegram,
+  doneHasCorroboratingEvidence,
   resetAfkPushBudget,
   afkPushCount,
   MAX_PUSHES_PER_SESSION,
 } from './afk-push.js';
 import type { TerminalState } from './terminal-state.js';
+import type { ToolEvent } from '../../slash/types.js';
 
 function done(extra: Partial<TerminalState> = {}): TerminalState {
   return { kind: 'done', rawBody: '', ...extra };
+}
+
+let toolSeq = 0;
+function tool(toolName: string, isError?: boolean): ToolEvent {
+  toolSeq += 1;
+  return { toolName, toolUseId: `tu-${toolSeq}`, input: '', ...(isError !== undefined && { isError }) };
 }
 
 describe('formatTerminalStateForTelegram', () => {
@@ -107,5 +115,72 @@ describe('pushTerminalStateToTelegram — rate limiting', () => {
     await expect(
       pushTerminalStateToTelegram(done({ whatWasDone: 'x' }), push),
     ).resolves.toBeUndefined();
+  });
+
+  it('forwards the unverified flag to the formatter', async () => {
+    const push = vi.fn().mockResolvedValue(null);
+    await pushTerminalStateToTelegram(done({ whatWasDone: 'maybe' }), push, { unverified: true });
+    expect(String(push.mock.calls[0]?.[0]).toLowerCase()).toContain('unverified');
+  });
+});
+
+describe('doneHasCorroboratingEvidence', () => {
+  it('is false for no tool events', () => {
+    expect(doneHasCorroboratingEvidence([])).toBe(false);
+  });
+
+  it('is false when the turn only read (read_file/grep/glob/list_directory)', () => {
+    expect(
+      doneHasCorroboratingEvidence([tool('read_file'), tool('grep'), tool('glob'), tool('list_directory')]),
+    ).toBe(false);
+  });
+
+  it('is true for a successful write_file / edit_file / bash', () => {
+    expect(doneHasCorroboratingEvidence([tool('write_file')])).toBe(true);
+    expect(doneHasCorroboratingEvidence([tool('edit_file')])).toBe(true);
+    expect(doneHasCorroboratingEvidence([tool('bash')])).toBe(true);
+  });
+
+  it('treats isError:false and omitted isError as success', () => {
+    expect(doneHasCorroboratingEvidence([tool('write_file', false)])).toBe(true);
+    expect(doneHasCorroboratingEvidence([tool('bash')])).toBe(true);
+  });
+
+  it('does NOT count a failed corroborating tool call', () => {
+    expect(doneHasCorroboratingEvidence([tool('write_file', true)])).toBe(false);
+    expect(doneHasCorroboratingEvidence([tool('bash', true)])).toBe(false);
+  });
+
+  it('is true when at least one corroborating call succeeded amid failures/reads', () => {
+    expect(
+      doneHasCorroboratingEvidence([tool('read_file'), tool('bash', true), tool('write_file')]),
+    ).toBe(true);
+  });
+});
+
+describe('formatTerminalStateForTelegram — verification downgrade', () => {
+  it('downgrades a done verdict to "unverified" when opts.unverified is true', () => {
+    const msg = formatTerminalStateForTelegram(done({ whatWasDone: 'shipped' }), { unverified: true });
+    expect(msg.toLowerCase()).toContain('unverified');
+    // The structured field still appears — downgrade annotates, never hides.
+    expect(msg).toContain('shipped');
+    // A caveat line explains the downgrade.
+    expect(msg.toLowerCase()).toContain('no file write');
+  });
+
+  it('keeps the standard done label when unverified is false or absent', () => {
+    expect(formatTerminalStateForTelegram(done()).toLowerCase()).not.toContain('unverified');
+    expect(
+      formatTerminalStateForTelegram(done(), { unverified: false }).toLowerCase(),
+    ).not.toContain('unverified');
+  });
+
+  it('only downgrades the done kind — blocked/asking are never relabelled', () => {
+    expect(
+      formatTerminalStateForTelegram({ kind: 'blocked', rawBody: 'x' }, { unverified: true }).toLowerCase(),
+    ).not.toContain('unverified');
+    expect(
+      formatTerminalStateForTelegram({ kind: 'asking', rawBody: 'x' }, { unverified: true }).toLowerCase(),
+    ).not.toContain('unverified');
   });
 });

--- a/src/cli/commands/interactive/afk-push.ts
+++ b/src/cli/commands/interactive/afk-push.ts
@@ -29,6 +29,7 @@
 
 import { redactInlineSecrets } from '../../../agent/session/prompt-dump.js';
 import { pushIfConfigured } from '../../../telegram/push.js';
+import type { ToolEvent } from '../../slash/types.js';
 import type { TerminalState, TerminalKind } from './terminal-state.js';
 
 /** Per-AFK-session push budget. Generous enough for a long autonomous run,
@@ -68,13 +69,49 @@ const KIND_FIELDS: Record<TerminalKind, ReadonlyArray<readonly [string, keyof Te
   ],
 };
 
+// ---------------------------------------------------------------------------
+// "Done" verification (opt-in via telegram.verifyDone)
+// ---------------------------------------------------------------------------
+
+// Contract: tools whose SUCCESSFUL invocation is observable corroboration that
+// real work happened this turn — a file mutation or an executed command. A
+// `Done` turn with none of these may be a self-certified completion with no
+// artifact behind it. Read-only tools (read_file/grep/glob/list_directory/…)
+// deliberately do NOT count: reading is not doing. Conservative + opt-in by
+// design; extend this set rather than loosening the success check.
+export const DONE_EVIDENCE_TOOLS: ReadonlySet<string> = new Set([
+  'write_file',
+  'edit_file',
+  'bash',
+]);
+
+/**
+ * True when at least one of this turn's tool events is a successful
+ * ({@link ToolEvent.isError} not `true`) corroborating tool call — see
+ * {@link DONE_EVIDENCE_TOOLS}. Pure: the caller owns the policy decision of
+ * whether to act on the result (gated behind `telegram.verifyDone`).
+ */
+export function doneHasCorroboratingEvidence(toolEvents: readonly ToolEvent[]): boolean {
+  return toolEvents.some((e) => DONE_EVIDENCE_TOOLS.has(e.toolName) && e.isError !== true);
+}
+
 /**
  * Format a parsed terminal state into a compact, scannable Telegram message
  * built strictly from structured fields, then scrub secrets. Returns the
  * ready-to-send string (the caller decides whether to send).
+ *
+ * When `opts.unverified` is true AND the kind is `done`, the header is
+ * downgraded to "⚠️ Done (unverified)" and a trailing caveat line is appended —
+ * the caller sets this only when `telegram.verifyDone` is on and the turn
+ * produced no corroborating evidence ({@link doneHasCorroboratingEvidence}).
  */
-export function formatTerminalStateForTelegram(state: TerminalState): string {
-  const header = `🤖 AFK · ${KIND_LABEL[state.kind]}`;
+export function formatTerminalStateForTelegram(
+  state: TerminalState,
+  opts: { unverified?: boolean } = {},
+): string {
+  const downgraded = state.kind === 'done' && opts.unverified === true;
+  const kindLabel = downgraded ? '⚠️ Done (unverified)' : KIND_LABEL[state.kind];
+  const header = `🤖 AFK · ${kindLabel}`;
   const lines: string[] = [];
   for (const [label, field] of KIND_FIELDS[state.kind]) {
     const value = state[field];
@@ -86,6 +123,11 @@ export function formatTerminalStateForTelegram(state: TerminalState): string {
   // Use the model's own terminal-state body (not tool output) as a last resort.
   if (lines.length === 0 && state.rawBody.trim().length > 0) {
     lines.push(state.rawBody.trim());
+  }
+  if (downgraded) {
+    lines.push(
+      '• ⚠️ Unverified: no file write/edit or successful command recorded this turn — confirm before relying on this.',
+    );
   }
 
   const body = lines.length > 0 ? lines.join('\n') : '(no detail)';
@@ -118,11 +160,14 @@ export function afkPushCount(): number {
  * Telegram is unconfigured (`pushIfConfigured` returns null). On reaching the
  * cap, sends one "muted" notice then stops. Best-effort — never throws.
  *
- * `pushImpl` is injectable for tests; defaults to `pushIfConfigured`.
+ * `pushImpl` is injectable for tests; defaults to `pushIfConfigured`. `opts`
+ * forwards the (opt-in) verification flag to the formatter — see
+ * `formatTerminalStateForTelegram`.
  */
 export async function pushTerminalStateToTelegram(
   state: TerminalState,
   pushImpl: typeof pushIfConfigured = pushIfConfigured,
+  opts: { unverified?: boolean } = {},
 ): Promise<void> {
   try {
     if (pushCount >= MAX_PUSHES_PER_SESSION) {
@@ -136,7 +181,7 @@ export async function pushTerminalStateToTelegram(
       return;
     }
     pushCount += 1;
-    await pushImpl(formatTerminalStateForTelegram(state));
+    await pushImpl(formatTerminalStateForTelegram(state, opts));
   } catch {
     // Outbound notification is best-effort; never let it break the turn.
   }

--- a/src/cli/commands/interactive/afk-push.ts
+++ b/src/cli/commands/interactive/afk-push.ts
@@ -77,8 +77,14 @@ const KIND_FIELDS: Record<TerminalKind, ReadonlyArray<readonly [string, keyof Te
 // real work happened this turn — a file mutation or an executed command. A
 // `Done` turn with none of these may be a self-certified completion with no
 // artifact behind it. Read-only tools (read_file/grep/glob/list_directory/…)
-// deliberately do NOT count: reading is not doing. Conservative + opt-in by
-// design; extend this set rather than loosening the success check.
+// deliberately do NOT count: reading is not doing. Delegation tools
+// (agent/compose/skill) also do NOT count: a subagent's internal write/command
+// streams to the CHILD session and never reaches the parent's tool events (the
+// `tool.use.start` → `tool_use_detail` emit in stream-consumer.ts is per-session),
+// so a `Done` turn whose work happened entirely inside a subagent is flagged
+// "unverified" by design — the parent has no observable artifact standing behind
+// the claim. This is the conservative default; the operator can still confirm.
+// Extend this set rather than loosening the success check.
 export const DONE_EVIDENCE_TOOLS: ReadonlySet<string> = new Set([
   'write_file',
   'edit_file',

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -25,7 +25,8 @@ import { ringBellIfEnabled } from '../../_lib/capture-mode.js';
 import { runWithSink } from '../../../agent/_lib/skill-sink-channel.js';
 import { parseTerminalState, type TerminalState } from './terminal-state.js';
 import { renderVerdictCard } from './verdict-card.js';
-import { pushTerminalStateToTelegram } from './afk-push.js';
+import { pushTerminalStateToTelegram, doneHasCorroboratingEvidence } from './afk-push.js';
+import { loadTelegramConfig } from '../../config.js';
 import { buildUserPayload } from '../../slash/_lib/user-payload.js';
 import { expandAtFileTokens } from './at-file-inject.js';
 
@@ -677,7 +678,16 @@ export async function runTurn(
         // limited (afk-push.ts); no-ops when Telegram is unconfigured.
         // Fire-and-forget — outbound notification must never block the turn.
         if (stats.permissionMode === 'autonomous') {
-          void pushTerminalStateToTelegram(verdict);
+          // Opt-in (telegram.verifyDone): when the turn self-certifies `Done`
+          // but produced no corroborating evidence this turn (a successful file
+          // write/edit or command — see doneHasCorroboratingEvidence), label the
+          // push "⚠️ Done (unverified)" so the away operator isn't pinged a
+          // confident "finished" with nothing behind it. Default off; never blocks.
+          const unverified =
+            verdict.kind === 'done' &&
+            loadTelegramConfig().verifyDone === true &&
+            !doneHasCorroboratingEvidence(toolEvents);
+          void pushTerminalStateToTelegram(verdict, undefined, { unverified });
         }
       }
 

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -563,6 +563,55 @@ describe('Config Loader', () => {
       expect(resolveModelInput('fast')).toBe('o4-mini');
     });
   });
+
+  describe('telegram.verifyDone (afk.config.json parsing)', () => {
+    const mockedExistsSync = () => vi.mocked(fs.existsSync);
+    const mockedReadFileSync = () => vi.mocked(fs.readFileSync);
+    const cwdConfigJson = join(process.cwd(), 'afk.config.json');
+
+    function mockConfig(json: unknown): void {
+      mockedExistsSync().mockImplementation((p) => {
+        const s = String(p);
+        if (s === cwdConfigJson) return true;
+        if (s.endsWith('AFK.md') || s.endsWith('afk.config.json')) return false;
+        return realFsModule.__realExistsSync(p as fs.PathLike);
+      });
+      mockedReadFileSync().mockImplementation((p, ...args) => {
+        if (String(p) === cwdConfigJson) return JSON.stringify(json);
+        return (realFsModule.__realReadFileSync as Function)(p, ...args);
+      });
+    }
+
+    beforeEach(() => {
+      _resetConfigCache();
+    });
+
+    afterEach(() => {
+      _resetConfigCache();
+      mockedExistsSync().mockImplementation(realFsModule.__realExistsSync);
+      mockedReadFileSync().mockImplementation(realFsModule.__realReadFileSync);
+    });
+
+    it('parses telegram.verifyDone: true', () => {
+      mockConfig({ telegram: { verifyDone: true } });
+      expect(loadConfig().telegram?.verifyDone).toBe(true);
+    });
+
+    it('parses telegram.verifyDone: false', () => {
+      mockConfig({ telegram: { verifyDone: false } });
+      expect(loadConfig().telegram?.verifyDone).toBe(false);
+    });
+
+    it('defaults to undefined (off) when verifyDone is absent', () => {
+      mockConfig({ telegram: { notify: { mode: 'primary' } } });
+      expect(loadConfig().telegram?.verifyDone).toBeUndefined();
+    });
+
+    it('ignores a non-boolean verifyDone (defensive parse → undefined)', () => {
+      mockConfig({ telegram: { verifyDone: 'yes' } });
+      expect(loadConfig().telegram?.verifyDone).toBeUndefined();
+    });
+  });
 });
 
 describe('resolveSuggestGhost (pure precedence function)', () => {

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -124,6 +124,15 @@ export interface CliConfig {
       primaryChatId?: number;
       targets?: number[];
     };
+    /**
+     * AFK-mode "Done" verification gate (opt-in; default off when omitted). When
+     * true, a terminal-state push whose kind is `Done` is relabelled
+     * "⚠️ Done (unverified)" unless the turn produced corroborating evidence — a
+     * successful file write/edit or executed command (see
+     * `doneHasCorroboratingEvidence` in `afk-push.ts`). Keeps the "get pinged
+     * when it finishes" notification honest without blocking the turn.
+     */
+    verifyDone?: boolean;
   };
   /**
    * `afk interactive` defaults.
@@ -291,6 +300,8 @@ interface ConfigFileSchema {
       primaryChatId?: number;
       targets?: number[];
     };
+    /** Opt-in AFK "Done" verification gate; default off. See `CliConfig.telegram.verifyDone`. */
+    verifyDone?: boolean;
   };
   interactive?: {
     worktreeAutoname?: boolean;
@@ -704,6 +715,9 @@ function loadJsonConfig(): {
               if (targets.length > 0) parsed.targets = targets;
             }
             telegram.notify = parsed;
+          }
+          if (typeof json.telegram.verifyDone === 'boolean') {
+            telegram.verifyDone = json.telegram.verifyDone;
           }
           config.telegram = telegram;
         }

--- a/src/config/settable-keys.test.ts
+++ b/src/config/settable-keys.test.ts
@@ -88,6 +88,7 @@ describe('classifyConfigKey / specs', () => {
     expect(classifyConfigKey('temperature')).toBe('agent');
     expect(classifyConfigKey('telegram.notify.mode')).toBe('human'); // notification-redirect vector
     expect(classifyConfigKey('telegram.notify.targets')).toBe('human');
+    expect(classifyConfigKey('telegram.verifyDone')).toBe('human'); // self-honesty gate — agent must not disable its own verification
     expect(classifyConfigKey('updatePolicy')).toBe('human'); // auto self-update is scope-widening
     expect(classifyConfigKey('systemPrompt')).toBe('human');
     expect(classifyConfigKey('enableShellHooks')).toBe('human'); // trust gate — agent must not flip it

--- a/src/config/settable-keys.ts
+++ b/src/config/settable-keys.ts
@@ -208,6 +208,7 @@ export const CONFIG_KEY_SPECS: readonly ConfigKeySpec[] = [
   { path: 'telegram.notify.mode', tier: 'human', type: 'enum', enumValues: ['primary', 'broadcast', 'custom'], description: 'Telegram notify routing mode (human-tier: notification-redirect vector).' },
   { path: 'telegram.notify.primaryChatId', tier: 'human', type: 'number', clamp: { min: -1e15, max: 1e15, integer: true }, description: 'Primary Telegram chat id (human-tier: notification-redirect vector).' },
   { path: 'telegram.notify.targets', tier: 'human', type: 'number-array', description: 'Custom Telegram target chat ids (human-tier: notification-redirect vector).' },
+  { path: 'telegram.verifyDone', tier: 'human', type: 'boolean', description: 'Opt-in AFK "Done" verification gate (human-tier: a self-honesty check on the agent\'s own completion reporting — the agent must not be able to disable it on its own config, same rationale as enableShellHooks/permissionMode).' },
   { path: 'interactive.worktreeAutoname', tier: 'agent', type: 'boolean', description: 'Auto-name worktrees.' },
   { path: 'interactive.suggestGhost', tier: 'agent', type: 'boolean', description: 'Ghost-text suggestions in the REPL.' },
   { path: 'updatePolicy', tier: 'human', type: 'enum', enumValues: ['notify', 'auto', 'off'], description: 'Self-update policy (human-tier: auto self-update is scope-widening).' },


### PR DESCRIPTION
## What & why

Implements the **Telegram corollary** from #237.

In AFK autonomous mode the REPL pushes each turn's parsed terminal state to Telegram (`pushTerminalStateToTelegram` → `afk-push.ts`) so the away operator can review asynchronously. As #237 notes, a `✅ Done` push the model **self-certified** — with no file write, edit, or successful command behind it — is the most expensive failure in the system: the operator acts on one line, on their phone, away from the trace.

This makes that one notification honest, **opt-in and default-off**, without touching control flow.

## Behaviour

New flag `telegram.verifyDone` in `afk.config.json` (default off / absent):

```jsonc
{
  "telegram": {
    "verifyDone": true
  }
}
```

When **on**, at the existing autonomous-mode push site (`turn-handler.ts`), a `Done` verdict whose turn produced **no corroborating evidence** is relabelled:

- `🤖 AFK · ✅ Done`  →  `🤖 AFK · ⚠️ Done (unverified)` + a caveat bullet.

"Corroborating evidence" = at least one **successful** (`isError !== true`) `write_file`, `edit_file`, or `bash` tool call in the turn (`doneHasCorroboratingEvidence` in `afk-push.ts`). Read-only tools (`read_file`/`grep`/`glob`/…) deliberately don't count — reading is not doing.

When **off** (default), behaviour is byte-for-byte unchanged.

## Design notes

- **No trace-file plumbing.** Evidence is read from the turn's in-memory `toolEvents` array already present in `turn-handler.ts` — the trace writer is *not* reachable at the Telegram send point (confirmed while scoping), so this avoids that whole seam.
- **Allowlist safety preserved.** `formatTerminalStateForTelegram` still builds the message only from the parsed `TerminalState` struct; the change passes a single `{ unverified }` boolean, never raw tool output.
- **Conservative + reversible.** Pure label change, fire-and-forget, never blocks the turn. Default off so it can be measured before anyone relies on it ("pressure first, measure, then enforce").

## Scope

This is the small slice. The broader **main-session post-turn hook** from #237 (a `Stop`/`TurnEnd` event carrying `injectContext` to bounce a self-certified turn back) is intentionally left as a follow-up.

## Verification

- `pnpm lint` (tsc --noEmit, strict): clean
- `pnpm test src/cli/commands/interactive/afk-push.test.ts`: **19/19 pass** (+14 new: evidence helper, downgrade formatting, push forwarding)
- `pnpm test src/cli/config.test.ts`: 44/44 pass
- Full suite: only 2 pre-existing failures, both unrelated to this change (`anthropic-direct.test.ts` compaction model; `memory-store.test.ts` schema-version — an in-flight memory change on `main`).

Closes the corollary half of #237.

---
Credit: proposed by @amatayomosley-web's agent **Cairn** in #237 — the citations in that issue all checked out against source.
