### PR TITLE
feat(memory): evidence-gate durable memory writes behind AFK_MEMORY_EVIDENCE_GATE

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -293,6 +293,14 @@
       "category": "model"
     },
     {
+      "name": "AFK_MEMORY_EVIDENCE_GATE",
+      "description": "Opt-in (set to 1) evidence gate for durable memory writes. When enabled, a codebase fact (memory_update category \"convention\") stored without an `evidence` citation is recalled as [unverified], and memory_search results carry a verification verdict. User preferences and agent reflections are never gated. Default off — memory behaves identically to legacy when unset.",
+      "type": "boolean",
+      "required": false,
+      "example": "1",
+      "category": "misc"
+    },
+    {
       "name": "AFK_MODEL",
       "description": "Default model for agent turns. Accepts slot names (local, small, medium, large), legacy aliases (opus, sonnet, haiku), the fixed-id fable alias (Claude Fable 5), or full model IDs.",
       "type": "string",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**115 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**116 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 
@@ -174,6 +174,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_BANNER_PLAIN` | boolean |  |  | `1` | Suppress the ANSI-colored banner at REPL startup. Useful for non-TTY captures and CI logs. |
 | `AFK_DEMO_CLEAN` | boolean |  |  | `1` | Explicit opt-in to capture-mode. When set to 1, suppresses high-frequency repaint drivers (spinner ticker, live thinking-preview) so recorded artifacts contain each state once instead of once per timer tick. |
 | `AFK_DIFF_LINES` | number |  |  | `50` | Maximum number of diff lines shown in the inline diff render during write_file tool calls. Set to 0 for no cap. Non-integer values are silently ignored and the default applies. |
+| `AFK_MEMORY_EVIDENCE_GATE` | boolean |  |  | `1` | Opt-in (set to 1) evidence gate for durable memory writes. When enabled, a codebase fact (memory_update category "convention") stored without an `evidence` citation is recalled as [unverified], and memory_search results carry a verification verdict. User preferences and agent reflections are never gated. Default off — memory behaves identically to legacy when unset. |
 | `AFK_SHELL_PASSTHROUGH` | boolean |  | `1` | `0` | Enable the interactive REPL `!cmd` / `!&cmd` shell-passthrough feature. On by default. Set to 0, false, off, or no (case-insensitive) to disable, so inputs beginning with ! are sent to the model as literal text instead of being executed as shell commands. Equivalent to the --no-shell-passthrough flag. |
 | `AFK_SHOW_DIFFS` | boolean |  |  |  | Show inline diffs in the tool-lane output for edit/write tool calls. 1 = on, 0 = off. |
 | `AFK_SPINNER_TIPS` | boolean |  |  |  | Show rotating tips in the loading spinner during long calls. 1 = on, 0 = off. |

--- a/src/agent/memory/memory-evidence-gate.test.ts
+++ b/src/agent/memory/memory-evidence-gate.test.ts
@@ -74,6 +74,23 @@ async function recallOne(query: string): Promise<MemorySearchResult> {
   return fact!;
 }
 
+async function supersede(
+  supersedes: number,
+  content: string,
+  evidence?: string,
+): Promise<Record<string, unknown>> {
+  const input: Record<string, unknown> = {
+    target: 'fact',
+    action: 'supersede',
+    supersedes,
+    content,
+  };
+  if (evidence !== undefined) input['evidence'] = evidence;
+  const res = await update(input, signal);
+  expect(res.isError).toBeFalsy();
+  return JSON.parse(res.content) as Record<string, unknown>;
+}
+
 describe('memory evidence gate (AFK_MEMORY_EVIDENCE_GATE=1)', () => {
   it('1. a citable codebase fact (convention) with evidence is stored and recalled as verified', async () => {
     const out = await setFact(
@@ -127,6 +144,83 @@ describe('memory evidence gate (AFK_MEMORY_EVIDENCE_GATE=1)', () => {
     expect(out['warning']).toBeUndefined();
     const fact = await recallOne('snibbledecide');
     expect(fact.verification).toBe('not-applicable');
+  });
+});
+
+describe('memory evidence gate — supersede + evidence', () => {
+  it('carries a prior citation forward and warns it may be stale (no fresh evidence)', async () => {
+    const set = await setFact('convention', 'snorgflux owns the alpha layer', 'src/alpha.ts:10');
+    expect(set['warning'], 'a cited set must not warn').toBeUndefined();
+
+    // Supersede with changed content and NO fresh evidence → the prior citation
+    // is carried forward, so recall stays 'verified' against the OLD evidence,
+    // but the agent is warned it may no longer back the changed claim.
+    const out = await supersede(set['id'] as number, 'snorgflux owns the beta layer instead');
+    expect(out['warning'], 'a carried-forward citation must warn').toBeDefined();
+    expect(out['warning'] as string).toContain('carried forward');
+
+    const fact = await recallOne('snorgflux');
+    expect(fact.verification).toBe('verified');
+    expect(fact.evidence).toBe('src/alpha.ts:10');
+    expect(fact.content).not.toContain('[unverified]');
+  });
+
+  it('replaces the citation when fresh evidence is supplied (no warning)', async () => {
+    const set = await setFact('convention', 'plimbo owns the gamma layer', 'src/old.ts:1');
+    const out = await supersede(
+      set['id'] as number,
+      'plimbo owns the gamma layer (refined)',
+      'src/new.ts:2',
+    );
+    expect(out['warning'], 'a freshly cited supersede must not warn').toBeUndefined();
+
+    const fact = await recallOne('plimbo');
+    expect(fact.verification).toBe('verified');
+    expect(fact.evidence).toBe('src/new.ts:2');
+  });
+
+  it('clears the citation on empty/whitespace evidence and recalls as [unverified]', async () => {
+    const set = await setFact('convention', 'wuzzle owns the delta layer', 'src/d.ts:1');
+    const out = await supersede(set['id'] as number, 'wuzzle owns the delta layer (unsure)', '   ');
+    expect(out['warning'], 'a cleared citation must warn').toBeDefined();
+    expect(out['warning'] as string).toContain('[unverified]');
+
+    const fact = await recallOne('wuzzle');
+    expect(fact.verification).toBe('unverified');
+    expect(fact.content.startsWith('[unverified]')).toBe(true);
+    expect(fact.evidence ?? null).toBeNull();
+  });
+
+  it('warns and recalls [unverified] when an uncited convention fact is superseded with no evidence', async () => {
+    const set = await setFact('convention', 'gribbnar owns the epsilon layer');
+    expect(set['warning'], 'the uncited set itself must warn').toBeDefined();
+
+    const out = await supersede(set['id'] as number, 'gribbnar owns the epsilon and zeta layers');
+    expect(out['warning'], 'an uncited supersede must warn').toBeDefined();
+    expect(out['warning'] as string).toContain('[unverified]');
+
+    const fact = await recallOne('gribbnar');
+    expect(fact.verification).toBe('unverified');
+    expect(fact.content.startsWith('[unverified]')).toBe(true);
+  });
+
+  it('never warns when superseding a non-codebase category (preference)', async () => {
+    const set = await setFact('preference', 'quibblepref the user prefers tabs');
+    const out = await supersede(set['id'] as number, 'quibblepref the user prefers spaces');
+    expect(out['warning'], 'preferences must never warn on supersede').toBeUndefined();
+
+    const fact = await recallOne('quibblepref');
+    expect(fact.verification).toBe('not-applicable');
+  });
+
+  it('emits no warning on supersede when the gate is off', async () => {
+    // A cited convention fact superseded with no fresh evidence WOULD warn
+    // (carried-forward) under the gate; with the gate off it must be silent.
+    const set = await setFact('convention', 'zibbloff owns the theta layer', 'src/t.ts:1');
+    delete process.env['AFK_MEMORY_EVIDENCE_GATE'];
+    const out = await supersede(set['id'] as number, 'zibbloff owns the theta layer changed');
+    expect(out['warning']).toBeUndefined();
+    expect(out['id']).toBeTypeOf('number');
   });
 });
 

--- a/src/agent/memory/memory-evidence-gate.test.ts
+++ b/src/agent/memory/memory-evidence-gate.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for the evidence gate on durable memory writes
+ * (AFK_MEMORY_EVIDENCE_GATE — opt-in, prototype).
+ *
+ * Pins the contract from the four scoped acceptance criteria:
+ *   1. a citable codebase fact (convention) WITH evidence → recalled verified
+ *   2. a codebase fact WITHOUT evidence → recalled as [unverified]
+ *   3. a user preference does NOT require file evidence (never gated)
+ *   4. an agent reflection (learning) is NOT treated as factual codebase knowledge
+ * plus two safety properties:
+ *   - gate OFF is a byte-identical no-op (no provenance fields, no warnings)
+ *   - the v3→v4 schema migration adds facts.evidence to a pre-existing DB
+ *     without data loss
+ *
+ * @module agent/memory/memory-evidence-gate.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import Database from 'better-sqlite3';
+import { MemoryStore } from './memory-store.js';
+import { createMemoryHandlers } from './memory-tools.js';
+import type { ToolHandler } from '../tools/types.js';
+import type { MemorySearchResult } from './types.js';
+
+let tmpDir: string;
+let store: MemoryStore;
+let update: ToolHandler;
+let search: ToolHandler;
+
+const signal = new AbortController().signal;
+
+function freshTmpDir(label: string): string {
+  return join(tmpdir(), `afk-${label}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+}
+
+beforeEach(() => {
+  tmpDir = freshTmpDir('evidence-gate');
+  mkdirSync(tmpDir, { recursive: true });
+  store = new MemoryStore(tmpDir);
+  const handlers = createMemoryHandlers(store, 'sess-1', 'test');
+  update = handlers.get('memory_update')!;
+  search = handlers.get('memory_search')!;
+  // Gate ON by default; individual gate-off cases delete it mid-test.
+  process.env['AFK_MEMORY_EVIDENCE_GATE'] = '1';
+});
+
+afterEach(() => {
+  delete process.env['AFK_MEMORY_EVIDENCE_GATE'];
+  store.close();
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function setFact(
+  category: string,
+  content: string,
+  evidence?: string,
+): Promise<Record<string, unknown>> {
+  const input: Record<string, unknown> = { target: 'fact', action: 'set', category, content };
+  if (evidence !== undefined) input['evidence'] = evidence;
+  const res = await update(input, signal);
+  expect(res.isError).toBeFalsy();
+  return JSON.parse(res.content) as Record<string, unknown>;
+}
+
+async function recallOne(query: string): Promise<MemorySearchResult> {
+  const res = await search({ query }, signal);
+  expect(res.isError).toBeFalsy();
+  const results = JSON.parse(res.content) as MemorySearchResult[];
+  const fact = results.find((r) => r.type === 'fact');
+  expect(fact, `expected a fact result for query "${query}"`).toBeDefined();
+  return fact!;
+}
+
+describe('memory evidence gate (AFK_MEMORY_EVIDENCE_GATE=1)', () => {
+  it('1. a citable codebase fact (convention) with evidence is stored and recalled as verified', async () => {
+    const out = await setFact(
+      'convention',
+      'zorptest the dispatcher routes via providerForModel',
+      'src/agent/providers/index.ts:124',
+    );
+    expect(out['warning'], 'a cited fact must not warn').toBeUndefined();
+
+    const fact = await recallOne('zorptest');
+    expect(fact.verification).toBe('verified');
+    expect(fact.evidence).toBe('src/agent/providers/index.ts:124');
+    expect(fact.content).not.toContain('[unverified]');
+  });
+
+  it('2. a codebase fact without evidence is recalled as [unverified] (and warns on write)', async () => {
+    const out = await setFact('convention', 'wibblegate the foo module owns bar');
+    expect(out['warning'], 'an uncited codebase fact must warn').toBeDefined();
+    expect(out['warning'] as string).toContain('[unverified]');
+    // Not a hard reject — the fact is still stored.
+    expect(out['id']).toBeTypeOf('number');
+
+    const fact = await recallOne('wibblegate');
+    expect(fact.verification).toBe('unverified');
+    expect(fact.content.startsWith('[unverified]')).toBe(true);
+    expect(fact.evidence ?? null).toBeNull();
+  });
+
+  it('3. a user preference does not require file evidence (no warning, never gated)', async () => {
+    const out = await setFact('preference', 'flooberpref the user prefers pnpm over npm');
+    expect(out['warning'], 'preferences must never warn').toBeUndefined();
+
+    const fact = await recallOne('flooberpref');
+    expect(fact.verification).toBe('not-applicable');
+    expect(fact.content).not.toContain('[unverified]');
+  });
+
+  it('4. an agent reflection (learning) is not treated as factual codebase knowledge', async () => {
+    const out = await setFact('learning', 'grumblelesson parallel subagents cut context bloat');
+    expect(out['warning'], 'reflections must never warn').toBeUndefined();
+
+    const fact = await recallOne('grumblelesson');
+    // Never 'verified' (no false factual authority) and never 'unverified'
+    // (it is not a codebase claim to be checked) — simply not-applicable.
+    expect(fact.verification).toBe('not-applicable');
+    expect(fact.content).not.toContain('[unverified]');
+  });
+
+  it('decision is treated as rationale, not a gated codebase fact', async () => {
+    const out = await setFact('decision', 'snibbledecide chose Exa over Brave for search');
+    expect(out['warning']).toBeUndefined();
+    const fact = await recallOne('snibbledecide');
+    expect(fact.verification).toBe('not-applicable');
+  });
+});
+
+describe('memory evidence gate — OFF is a byte-identical no-op', () => {
+  it('recall output carries no provenance fields when the gate is off', async () => {
+    // Stored while ON (so evidence is persisted)...
+    await setFact('convention', 'plonkoff the baz layer', 'src/x.ts:1');
+    // ...recalled while OFF.
+    delete process.env['AFK_MEMORY_EVIDENCE_GATE'];
+
+    const res = await search({ query: 'plonkoff' }, signal);
+    const fact = (JSON.parse(res.content) as MemorySearchResult[]).find((r) => r.type === 'fact')!;
+    expect(fact).toBeDefined();
+    expect('verification' in fact).toBe(false);
+    expect('evidence' in fact).toBe(false);
+    expect(fact.content).not.toContain('[unverified]');
+  });
+
+  it('an uncited codebase fact write returns no warning when the gate is off', async () => {
+    delete process.env['AFK_MEMORY_EVIDENCE_GATE'];
+    const out = await setFact('convention', 'snorgleoff a thing with no citation');
+    expect(out['warning']).toBeUndefined();
+    expect(out['id']).toBeTypeOf('number');
+  });
+});
+
+describe('memory evidence gate — schema migration v3 → v4', () => {
+  it('a fresh store is at schema v4 with a facts.evidence column', () => {
+    const dir = freshTmpDir('evidence-fresh');
+    mkdirSync(dir, { recursive: true });
+    const s = new MemoryStore(dir);
+    try {
+      const id = s.storeFact({
+        category: 'convention',
+        content: 'freshschema cited fact',
+        source_surface: 'cli',
+        evidence: 'src/a.ts:1',
+      });
+      expect(s.getFact(id)!.evidence).toBe('src/a.ts:1');
+    } finally {
+      s.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('migrates a pre-existing v3 database forward without data loss', () => {
+    const dir = freshTmpDir('evidence-migrate');
+    mkdirSync(dir, { recursive: true });
+    const dbPath = join(dir, 'memory.db');
+
+    // Build a v3-shaped DB by hand: facts table WITHOUT the evidence column,
+    // plus the FTS mirror + triggers a real v3 DB carries, stamped user_version=3.
+    const raw = new Database(dbPath);
+    raw.exec(`
+      CREATE TABLE facts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT,
+        created_at TEXT NOT NULL,
+        category TEXT NOT NULL CHECK(category IN ('preference', 'convention', 'decision', 'learning')),
+        content TEXT NOT NULL,
+        source_surface TEXT NOT NULL DEFAULT 'cli',
+        superseded_by INTEGER REFERENCES facts(id),
+        confidence REAL NOT NULL DEFAULT 1.0,
+        access_count INTEGER NOT NULL DEFAULT 0,
+        last_accessed TEXT
+      );
+      CREATE VIRTUAL TABLE facts_fts USING fts5(
+        content, category, content=facts, content_rowid=id, tokenize='porter'
+      );
+      CREATE TRIGGER facts_ai AFTER INSERT ON facts BEGIN
+        INSERT INTO facts_fts(rowid, content, category) VALUES (new.id, new.content, new.category);
+      END;
+      CREATE TRIGGER facts_ad AFTER DELETE ON facts BEGIN
+        INSERT INTO facts_fts(facts_fts, rowid, content, category) VALUES ('delete', old.id, old.content, old.category);
+      END;
+      CREATE TRIGGER facts_au AFTER UPDATE ON facts BEGIN
+        INSERT INTO facts_fts(facts_fts, rowid, content, category) VALUES ('delete', old.id, old.content, old.category);
+        INSERT INTO facts_fts(rowid, content, category) VALUES (new.id, new.content, new.category);
+      END;
+      CREATE UNIQUE INDEX idx_facts_fingerprint
+        ON facts(content, created_at, COALESCE(session_id, ''), category);
+    `);
+    raw
+      .prepare(`INSERT INTO facts (created_at, category, content, source_surface) VALUES (?, ?, ?, ?)`)
+      .run(new Date().toISOString(), 'convention', 'legacymigrate an old uncited fact', 'cli');
+    raw.pragma('user_version = 3');
+    raw.close();
+
+    // Open via MemoryStore → runs the v3→v4 migration (adds facts.evidence).
+    const migrated = new MemoryStore(dir);
+    try {
+      // The pre-existing row survives and reads back evidence = null (uncited).
+      const old = migrated.searchFacts('legacymigrate');
+      expect(old.length).toBeGreaterThan(0);
+      expect(old[0]!.evidence ?? null).toBeNull();
+
+      // A new write can now persist evidence.
+      const id = migrated.storeFact({
+        category: 'convention',
+        content: 'freshmigrate a newly cited fact',
+        source_surface: 'cli',
+        evidence: 'src/b.ts:2',
+      });
+      expect(migrated.getFact(id)!.evidence).toBe('src/b.ts:2');
+    } finally {
+      migrated.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agent/memory/memory-evidence.ts
+++ b/src/agent/memory/memory-evidence.ts
@@ -1,0 +1,96 @@
+/**
+ * Evidence-gate policy for durable memory writes.
+ *
+ * Prototype, opt-in behind `AFK_MEMORY_EVIDENCE_GATE=1`. Goal: stop uncited
+ * agent claims about the codebase from silently becoming future ground truth.
+ *
+ * The existing fact `category` already encodes the classification the gate
+ * needs, so no separate classifier is introduced:
+ *
+ *   - 'convention'             → codebase fact/convention  → EVIDENCE-GATED
+ *   - 'preference'             → user preference/instruction → never gated
+ *   - 'learning' | 'decision'  → agent reflection / rationale → never gated
+ *
+ * Only `convention` is treated as a checkable codebase claim. Preferences are
+ * the user's own instructions (not the agent's claims) and reflections/
+ * decisions are inherently conversational (a file:line citation would be
+ * ceremony, not signal) — so neither is gated, and neither is ever stamped
+ * 'verified' (that would lend a reflection false factual authority).
+ *
+ * Design: these helpers are PURE (no I/O, no env) except {@link evidenceGateEnabled},
+ * which is the single env read-point. The store persists `evidence` as plain
+ * data regardless of the flag; the memory-tool handlers consult the flag and
+ * apply warn-on-write / tag-on-recall policy. This keeps classification
+ * unit-testable in isolation from both the SQLite layer and the env.
+ *
+ * @module agent/memory/memory-evidence
+ */
+
+import { env } from '../../config/env.js';
+import type { FactCategory, FactVerification } from './types.js';
+
+/**
+ * Fact categories treated as checkable codebase claims subject to the gate.
+ * A `ReadonlySet` (not a bare `=== 'convention'`) so the gated set can grow
+ * (e.g. add `'decision'`) in exactly one place without touching call sites.
+ */
+export const CODEBASE_FACT_CATEGORIES: ReadonlySet<FactCategory> = new Set<FactCategory>([
+  'convention',
+]);
+
+/** Marker prefixed to recalled content for an uncited codebase fact. */
+export const UNVERIFIED_TAG = '[unverified]';
+
+/** True when `category` is a checkable codebase claim. */
+export function isCodebaseFactCategory(category: FactCategory): boolean {
+  return CODEBASE_FACT_CATEGORIES.has(category);
+}
+
+/**
+ * Whether the evidence gate is enabled. Opt-in; any value other than the
+ * literal '1' (including unset) leaves memory behavior identical to legacy.
+ * The single env read-point for this subsystem.
+ */
+export function evidenceGateEnabled(): boolean {
+  return env.AFK_MEMORY_EVIDENCE_GATE === '1';
+}
+
+/**
+ * Whether a write of `category` is expected to carry evidence under the gate.
+ * (A missing citation does NOT block the write — it downgrades the recall
+ * verdict to 'unverified' and surfaces a warning. Never a hard reject.)
+ */
+export function requiresEvidence(category: FactCategory): boolean {
+  return isCodebaseFactCategory(category);
+}
+
+/** Trim an evidence string; treat empty/whitespace/non-string as absent (null). */
+export function normalizeEvidence(evidence: string | null | undefined): string | null {
+  if (typeof evidence !== 'string') return null;
+  const trimmed = evidence.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Recall-time provenance verdict for a fact.
+ *   - non-codebase category        → 'not-applicable'
+ *   - codebase category + citation → 'verified'
+ *   - codebase category, no cite   → 'unverified'
+ */
+export function verificationStatus(
+  category: FactCategory,
+  evidence: string | null | undefined,
+): FactVerification {
+  if (!isCodebaseFactCategory(category)) return 'not-applicable';
+  return normalizeEvidence(evidence) ? 'verified' : 'unverified';
+}
+
+/**
+ * Prefix recalled content with {@link UNVERIFIED_TAG} for an uncited codebase
+ * fact. Idempotent (never double-tags) and a no-op for any other verdict.
+ */
+export function applyUnverifiedTag(content: string, status: FactVerification): string {
+  if (status !== 'unverified') return content;
+  if (content.startsWith(UNVERIFIED_TAG)) return content;
+  return `${UNVERIFIED_TAG} ${content}`;
+}

--- a/src/agent/memory/memory-store.test.ts
+++ b/src/agent/memory/memory-store.test.ts
@@ -310,8 +310,11 @@ describe('schema migration — sessions.actor (v2 → v3)', () => {
     if (existsSync(migDir)) rmSync(migDir, { recursive: true, force: true });
   });
 
-  /** Seed a minimal pre-v3 (user_version = 2) sessions table, optionally with
-   *  the actor column already present (interrupted-migration shape). */
+  /** Seed a minimal pre-v4 database (user_version = 2): the pre-v3 sessions
+   *  table (optionally with the actor column already present — the
+   *  interrupted-migration shape) plus a pre-v4 facts table (no evidence
+   *  column). Both tables are present because opening the store runs the full
+   *  v2 → v3 → v4 chain, and the v3 → v4 step ALTERs `facts`. */
   function seedV2Db(dbPath: string, withActorColumn = false): void {
     const seed = new Database(dbPath);
     seed.exec(`
@@ -326,15 +329,29 @@ describe('schema migration — sessions.actor (v2 → v3)', () => {
         token_count INTEGER,
         cost_usd REAL${withActorColumn ? ',\n        actor TEXT' : ''}
       );
+      CREATE TABLE facts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT,
+        created_at TEXT NOT NULL,
+        category TEXT NOT NULL,
+        content TEXT NOT NULL,
+        source_surface TEXT NOT NULL DEFAULT 'cli',
+        superseded_by INTEGER,
+        confidence REAL NOT NULL DEFAULT 1.0,
+        access_count INTEGER NOT NULL DEFAULT 0,
+        last_accessed TEXT
+      );
     `);
     seed.pragma('user_version = 2');
     seed.close();
   }
 
-  it('upgrades a v2 DB to v3, adds a nullable actor column, and preserves existing rows', () => {
+  it('upgrades a v2 DB to v4, adds a nullable actor column, and preserves existing rows', () => {
     const dbPath = join(migDir, 'memory.db');
-    // Build a minimal v2 database: the pre-v3 sessions table (no actor column),
-    // stamped user_version = 2, with one pre-existing session row.
+    // Build a minimal v2 database: the pre-v3 sessions table (no actor column)
+    // plus a pre-v4 facts table (no evidence column), stamped user_version = 2,
+    // with one pre-existing session row. The facts table is required because
+    // opening the store runs the full chain and the v3 → v4 step ALTERs it.
     const seed = new Database(dbPath);
     seed.exec(`
       CREATE TABLE sessions (
@@ -348,6 +365,18 @@ describe('schema migration — sessions.actor (v2 → v3)', () => {
         token_count INTEGER,
         cost_usd REAL
       );
+      CREATE TABLE facts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT,
+        created_at TEXT NOT NULL,
+        category TEXT NOT NULL,
+        content TEXT NOT NULL,
+        source_surface TEXT NOT NULL DEFAULT 'cli',
+        superseded_by INTEGER,
+        confidence REAL NOT NULL DEFAULT 1.0,
+        access_count INTEGER NOT NULL DEFAULT 0,
+        last_accessed TEXT
+      );
     `);
     seed
       .prepare('INSERT INTO sessions (session_id, surface, started_at) VALUES (?, ?, ?)')
@@ -355,14 +384,15 @@ describe('schema migration — sessions.actor (v2 → v3)', () => {
     seed.pragma('user_version = 2');
     seed.close();
 
-    // Opening the store runs the v2 → v3 migration.
+    // Opening the store runs the v2 → v3 → v4 migration chain (actor added at
+    // v3, evidence at v4). This test asserts the actor (v3) behavior.
     const migrated = new MemoryStore(migDir);
     migrated.startSession({ session_id: 'sub-sess', surface: 'telegram', actor: 'subagent' });
     migrated.startSession({ session_id: 'plain-sess', surface: 'cli' });
 
     const check = new Database(dbPath, { readonly: true });
     try {
-      expect(check.pragma('user_version', { simple: true })).toBe(3);
+      expect(check.pragma('user_version', { simple: true })).toBe(4);
       const cols = (check.pragma('table_info(sessions)') as Array<{ name: string }>).map(
         (c) => c.name,
       );
@@ -389,13 +419,13 @@ describe('schema migration — sessions.actor (v2 → v3)', () => {
     }
   });
 
-  it('stamps a fresh DB at v3 with the actor column present', () => {
+  it('stamps a fresh DB at v4 with the actor column present', () => {
     const freshStore = new MemoryStore(migDir);
     freshStore.startSession({ session_id: 's', surface: 'cli', actor: 'main' });
 
     const check = new Database(join(migDir, 'memory.db'), { readonly: true });
     try {
-      expect(check.pragma('user_version', { simple: true })).toBe(3);
+      expect(check.pragma('user_version', { simple: true })).toBe(4);
       const row = check
         .prepare('SELECT actor FROM sessions WHERE session_id = ?')
         .get('s') as { actor: string | null };
@@ -405,7 +435,7 @@ describe('schema migration — sessions.actor (v2 → v3)', () => {
     }
   });
 
-  it('swallows a concurrent duplicate-column ALTER and still reaches v3', () => {
+  it('swallows a concurrent duplicate-column ALTER and still reaches v4', () => {
     const dbPath = join(migDir, 'memory.db');
     seedV2Db(dbPath);
 
@@ -429,7 +459,7 @@ describe('schema migration — sessions.actor (v2 → v3)', () => {
 
     const check = new Database(dbPath, { readonly: true });
     try {
-      expect(check.pragma('user_version', { simple: true })).toBe(3);
+      expect(check.pragma('user_version', { simple: true })).toBe(4);
       const cols = (check.pragma('table_info(sessions)') as Array<{ name: string }>).map(
         (c) => c.name,
       );
@@ -468,7 +498,7 @@ describe('schema migration — sessions.actor (v2 → v3)', () => {
 
     const check = new Database(dbPath, { readonly: true });
     try {
-      expect(check.pragma('user_version', { simple: true })).toBe(3);
+      expect(check.pragma('user_version', { simple: true })).toBe(4);
     } finally {
       check.close();
     }

--- a/src/agent/memory/memory-store.ts
+++ b/src/agent/memory/memory-store.ts
@@ -76,8 +76,15 @@ const HOT_TRUNCATION_SENTINEL =
  * v2 → v3: Added a nullable `actor` column to sessions ('main' | 'subagent'
  *          execution role). ALTER ADD COLUMN with no default → existing rows
  *          read back NULL, so the migration cannot fail on stored data.
+ * v3 → v4: Added a nullable `evidence` column to facts (provenance citation
+ *          backing a codebase fact, for the AFK_MEMORY_EVIDENCE_GATE feature).
+ *          ALTER ADD COLUMN with no default → existing rows read back NULL
+ *          (= uncited), so the migration cannot fail on stored data. The
+ *          column is additive and populated/consulted only when the gate is
+ *          enabled, but the SCHEMA_VERSION guard still rejects a v4 DB from
+ *          older builds — enabling the prototype migrates the DB forward.
  */
-const SCHEMA_VERSION = 3;
+const SCHEMA_VERSION = 4;
 
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS sessions (
@@ -106,7 +113,12 @@ CREATE TABLE IF NOT EXISTS facts (
   superseded_by INTEGER REFERENCES facts(id),
   confidence REAL NOT NULL DEFAULT 1.0,
   access_count INTEGER NOT NULL DEFAULT 0,
-  last_accessed TEXT
+  last_accessed TEXT,
+  -- v4: provenance citation backing a codebase fact (file:line, commit SHA,
+  -- trace-event id). Nullable (NULL on pre-v4 rows and uncited writes).
+  -- Listed last to match the position ALTER TABLE ADD COLUMN appends it on
+  -- migrated databases, so fresh and migrated DBs share one column order.
+  evidence TEXT
 );
 
 CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts USING fts5(
@@ -245,6 +257,31 @@ export class MemoryStore {
         this.db.pragma(`user_version = 3`);
         debugLog('memory-store: migrated schema v2 → v3 (added sessions.actor column)');
       }
+      if (existingVersion < 4) {
+        // v3 → v4: add a NULLABLE `evidence` column to facts (provenance
+        // citation backing a codebase fact). No default → existing rows read
+        // back NULL (= uncited), so the migration cannot fail on stored data.
+        //
+        // Same concurrency-safe ALTER wrapper as the v2→v3 actor migration:
+        // SQLite has no `ADD COLUMN IF NOT EXISTS`, and this global DB is
+        // cold-opened concurrently by every AFK surface, so two new-build
+        // processes can race the ALTER and the loser throws "duplicate column
+        // name". Treat an already-present column (re-checked via table_info,
+        // not the error text) as success; re-throw if the column stayed absent.
+        const hasEvidence = (): boolean =>
+          (this.db.pragma('table_info(facts)') as Array<{ name: string }>).some(
+            (col) => col.name === 'evidence',
+          );
+        if (!hasEvidence()) {
+          try {
+            this.db.exec(`ALTER TABLE facts ADD COLUMN evidence TEXT;`);
+          } catch (err) {
+            if (!hasEvidence()) throw err;
+          }
+        }
+        this.db.pragma(`user_version = 4`);
+        debugLog('memory-store: migrated schema v3 → v4 (added facts.evidence column)');
+      }
     } else {
       // existingVersion > SCHEMA_VERSION: DB was written by a newer build.
       this.db.close();
@@ -380,8 +417,8 @@ export class MemoryStore {
       data: { ...fact, created_at: now },
     });
     const stmt = this.db.prepare(`
-      INSERT INTO facts (session_id, created_at, category, content, source_surface)
-      VALUES (?, ?, ?, ?, ?)
+      INSERT INTO facts (session_id, created_at, category, content, source_surface, evidence)
+      VALUES (?, ?, ?, ?, ?, ?)
     `);
     const result = stmt.run(
       fact.session_id ?? null,
@@ -389,16 +426,26 @@ export class MemoryStore {
       fact.category,
       fact.content,
       fact.source_surface,
+      fact.evidence ?? null,
     );
     return Number(result.lastInsertRowid);
   }
 
-  supersedeFact(factId: number, newContent: string, category?: string): number {
+  supersedeFact(
+    factId: number,
+    newContent: string,
+    category?: string,
+    evidence?: string | null,
+  ): number {
     const old = this.db.prepare('SELECT * FROM facts WHERE id = ?').get(factId) as Fact | undefined;
     if (!old) throw new Error(`Fact ${factId} not found`);
 
     const now = new Date().toISOString();
     const resolvedCategory = category ?? old.category;
+    // `undefined` = caller did not re-supply evidence → carry the prior
+    // citation forward. An explicit `null` clears it; an explicit string
+    // replaces it.
+    const resolvedEvidence = evidence === undefined ? old.evidence : evidence;
 
     this.appendWAL({
       type: 'fact',
@@ -409,12 +456,13 @@ export class MemoryStore {
         category: resolvedCategory,
         content: newContent,
         source_surface: old.source_surface,
+        evidence: resolvedEvidence,
       },
     });
 
     const stmt = this.db.prepare(`
-      INSERT INTO facts (session_id, created_at, category, content, source_surface, confidence)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT INTO facts (session_id, created_at, category, content, source_surface, confidence, evidence)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
     `);
 
     let newId: number;
@@ -426,6 +474,7 @@ export class MemoryStore {
         newContent,
         old.source_surface,
         1.0,
+        resolvedEvidence,
       );
       newId = Number(result.lastInsertRowid);
     } catch (e: unknown) {
@@ -638,6 +687,9 @@ export class MemoryStore {
           created_at: f.created_at,
           source_session: f.session_id,
           confidence: f.confidence,
+          // Raw provenance; the verdict + [unverified] tag are applied by the
+          // memory-tool handler (policy layer) only when the gate is enabled.
+          evidence: f.evidence ?? null,
         });
       }
     } catch {
@@ -707,14 +759,15 @@ export class MemoryStore {
             ).get(d['content'], d['created_at'], d['session_id'] ?? '', d['category'] ?? '');
             if (!existing) {
               this.db.prepare(`
-                INSERT INTO facts (session_id, created_at, category, content, source_surface)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO facts (session_id, created_at, category, content, source_surface, evidence)
+                VALUES (?, ?, ?, ?, ?, ?)
               `).run(
                 d['session_id'] ?? null,
                 d['created_at'],
                 d['category'],
                 d['content'],
                 d['source_surface'] ?? 'cli',
+                d['evidence'] ?? null,
               );
               replayed++;
             }

--- a/src/agent/memory/memory-tools.ts
+++ b/src/agent/memory/memory-tools.ts
@@ -159,6 +159,18 @@ const UNCITED_CODEBASE_FACT_WARNING =
   'sessions can trust it as ground truth rather than an unverified agent claim.';
 
 /**
+ * Returned on a `supersede` of a codebase fact that carries a prior citation
+ * forward unchanged (no fresh evidence supplied this call). The recall verdict
+ * stays 'verified' against the OLD evidence, which may no longer back the
+ * changed content — so the warning nudges the agent to re-cite.
+ */
+const INHERITED_CITATION_SUPERSEDE_WARNING =
+  'Superseded without fresh evidence — the prior citation is carried forward and this ' +
+  'codebase fact (category "convention") is still recalled as verified against the OLD ' +
+  'evidence, which may not back the changed content. Re-supply `evidence` if the claim ' +
+  'changed (or pass an empty string to clear it and recall as [unverified]).';
+
+/**
  * Project raw search results onto the wire shape returned to the agent.
  *
  *   - gate OFF → provenance fields (`evidence`, `verification`) are dropped, so
@@ -311,23 +323,47 @@ export function createMemoryHandlers(
             isError: true,
           };
         }
-        // supersedeFact accepts category?: string, which is compatible with FactCategory | undefined.
+        // Read the prior fact first so the gate can classify the *resolved*
+        // category/evidence for the write-time warning. supersedeFact re-reads
+        // it internally; this extra read is off the hot path (memory_update is
+        // a low-frequency tool) and returns null for a missing id — in which
+        // case supersedeFact throws the same "not found" error below.
+        const prior = store.getFact(parsed.supersedes);
         // evidence: `undefined` carries the prior citation forward; an explicit
         // string replaces it (empty/whitespace normalizes to null = cleared).
+        const freshEvidence =
+          parsed.evidence === undefined ? undefined : normalizeEvidence(parsed.evidence);
+        // supersedeFact accepts category?: string, which is compatible with FactCategory | undefined.
         const newId = store.supersedeFact(
           parsed.supersedes,
           parsed.content,
           parsed.category ?? undefined,
-          parsed.evidence === undefined ? undefined : normalizeEvidence(parsed.evidence),
+          freshEvidence,
         );
-        return {
-          content: JSON.stringify({
-            id: newId,
-            action: 'supersede',
-            target: 'fact',
-            supersedes: parsed.supersedes,
-          }),
+        const result: Record<string, unknown> = {
+          id: newId,
+          action: 'supersede',
+          target: 'fact',
+          supersedes: parsed.supersedes,
         };
+        // Evidence gate (opt-in): mirror the `set` warning on the supersede
+        // path. supersede is the recommended way to update a fact, so an
+        // uncited codebase fact must nudge here too. The warning reflects the
+        // RESOLVED state after carry-forward: a fresh citation silences it; a
+        // carried-forward citation warns it may be stale; no citation at all
+        // warns it will be recalled as [unverified].
+        if (evidenceGateEnabled()) {
+          const resolvedCategory: FactCategory | undefined = parsed.category ?? prior?.category;
+          if (resolvedCategory && requiresEvidence(resolvedCategory)) {
+            const resolvedEvidence = freshEvidence === undefined ? (prior?.evidence ?? null) : freshEvidence;
+            if (!resolvedEvidence) {
+              result['warning'] = UNCITED_CODEBASE_FACT_WARNING;
+            } else if (freshEvidence === undefined) {
+              result['warning'] = INHERITED_CITATION_SUPERSEDE_WARNING;
+            }
+          }
+        }
+        return { content: JSON.stringify(result) };
       }
 
       if (parsed.action === 'remove') {

--- a/src/agent/memory/memory-tools.ts
+++ b/src/agent/memory/memory-tools.ts
@@ -9,10 +9,18 @@
 
 import type { AnthropicToolDef, ToolHandler } from '../tools/types.js';
 import { MemoryStore, HOT_SOFT_WARN_RATIO } from './memory-store.js';
+import {
+  evidenceGateEnabled,
+  requiresEvidence,
+  verificationStatus,
+  applyUnverifiedTag,
+  normalizeEvidence,
+} from './memory-evidence.js';
 import type {
   FactCategory,
   MemoryUpdateAction,
   MemoryUpdateTarget,
+  MemorySearchResult,
 } from './types.js';
 
 /**
@@ -86,6 +94,13 @@ export const memoryUpdateTool: AnthropicToolDef = {
         enum: ['preference', 'convention', 'decision', 'learning'],
         description: 'Required for fact target',
       },
+      evidence: {
+        type: 'string',
+        description:
+          'Optional provenance citation backing a codebase fact — a file:line, commit SHA, ' +
+          'or trace-event id. When the evidence gate is enabled, a "convention" fact stored ' +
+          'without it is recalled as [unverified]; preferences and reflections never need it.',
+      },
       supersedes: {
         type: 'number',
         description: 'Fact ID being superseded (for supersede action)',
@@ -135,6 +150,47 @@ export const memoryToolSchemas: readonly AnthropicToolDef[] = [
 
 export const MEMORY_TOOL_NAMES = memoryToolSchemas.map((t) => t.name);
 
+// ── Evidence-gate policy (opt-in: AFK_MEMORY_EVIDENCE_GATE=1) ─────────────────
+
+/** Returned on a `set`/`supersede` of an uncited codebase fact under the gate. */
+const UNCITED_CODEBASE_FACT_WARNING =
+  'Stored without evidence — this codebase fact (category "convention") will be recalled as ' +
+  '[unverified]. Supply `evidence` (a file:line, commit SHA, or trace-event id) so future ' +
+  'sessions can trust it as ground truth rather than an unverified agent claim.';
+
+/**
+ * Project raw search results onto the wire shape returned to the agent.
+ *
+ *   - gate OFF → provenance fields (`evidence`, `verification`) are dropped, so
+ *     the JSON is byte-identical to pre-gate behavior (a true no-op).
+ *   - gate ON  → each codebase fact gains a `verification` verdict and any
+ *     uncited one has its `content` prefixed with `[unverified]`. Preferences,
+ *     reflections, and procedures are passed through verdict 'not-applicable'
+ *     (no tag) so a reflection is never lent false factual authority.
+ *
+ * Pure: no I/O, no env read (the gate flag is resolved by the caller).
+ */
+function projectSearchResults(
+  results: MemorySearchResult[],
+  gateOn: boolean,
+): MemorySearchResult[] {
+  if (!gateOn) {
+    return results.map((r) => {
+      const legacy = { ...r };
+      delete legacy.evidence;
+      delete legacy.verification;
+      return legacy;
+    });
+  }
+  return results.map((r) => {
+    if (r.type !== 'fact' || !r.category) {
+      return { ...r, verification: 'not-applicable' as const };
+    }
+    const verification = verificationStatus(r.category, r.evidence);
+    return { ...r, verification, content: applyUnverifiedTag(r.content, verification) };
+  });
+}
+
 // ── Handler implementations ─────────────────────────────────────────────────
 
 /**
@@ -161,7 +217,7 @@ export function createMemoryHandlers(
         since: parsed.since,
         limit: parsed.limit ?? 10,
       });
-      return { content: JSON.stringify(results) };
+      return { content: JSON.stringify(projectSearchResults(results, evidenceGateEnabled())) };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return { content: `memory_search error: ${message}`, isError: true };
@@ -223,13 +279,23 @@ export function createMemoryHandlers(
             isError: true,
           };
         }
+        const category = parsed.category as FactCategory;
+        const evidence = normalizeEvidence(parsed.evidence);
         const id = store.storeFact({
           session_id: sessionId,
-          category: parsed.category as FactCategory,
+          category,
           content: parsed.content,
           source_surface: surface ?? 'cli',
+          evidence,
         });
-        return { content: JSON.stringify({ id, action: 'set', target: 'fact' }) };
+        const result: Record<string, unknown> = { id, action: 'set', target: 'fact' };
+        // Evidence gate (opt-in): a codebase fact stored without a citation is
+        // not rejected — it is stored and will be recalled as [unverified].
+        // Surface a warning so the agent can supply evidence next time.
+        if (evidenceGateEnabled() && requiresEvidence(category) && !evidence) {
+          result['warning'] = UNCITED_CODEBASE_FACT_WARNING;
+        }
+        return { content: JSON.stringify(result) };
       }
 
       if (parsed.action === 'supersede') {
@@ -245,11 +311,14 @@ export function createMemoryHandlers(
             isError: true,
           };
         }
-        // supersedeFact accepts category?: string, which is compatible with FactCategory | undefined
+        // supersedeFact accepts category?: string, which is compatible with FactCategory | undefined.
+        // evidence: `undefined` carries the prior citation forward; an explicit
+        // string replaces it (empty/whitespace normalizes to null = cleared).
         const newId = store.supersedeFact(
           parsed.supersedes,
           parsed.content,
           parsed.category ?? undefined,
+          parsed.evidence === undefined ? undefined : normalizeEvidence(parsed.evidence),
         );
         return {
           content: JSON.stringify({
@@ -358,6 +427,7 @@ interface MemoryUpdateInput {
   action: MemoryUpdateAction;
   content?: string;
   category?: FactCategory;
+  evidence?: string;
   supersedes?: number;
   id?: number;
 }
@@ -401,6 +471,13 @@ function parseMemoryUpdateInput(input: unknown): MemoryUpdateInput {
       );
     }
     parsed.category = obj['category'] as FactCategory;
+  }
+
+  if (obj['evidence'] !== undefined) {
+    if (typeof obj['evidence'] !== 'string') {
+      throw new Error('evidence must be a string');
+    }
+    parsed.evidence = obj['evidence'];
   }
 
   if (obj['supersedes'] !== undefined) {

--- a/src/agent/memory/types.ts
+++ b/src/agent/memory/types.ts
@@ -14,6 +14,17 @@ export type SessionOutcome = 'completed' | 'failed' | 'abandoned';
 export type MemoryUpdateAction = 'set' | 'supersede' | 'remove';
 export type MemoryUpdateTarget = 'hot' | 'fact';
 
+/**
+ * Recall-time provenance verdict for a fact, computed by the evidence gate
+ * (see `./memory-evidence.ts`). Only meaningful when the gate is enabled
+ * (AFK_MEMORY_EVIDENCE_GATE=1); otherwise the field is omitted from results.
+ *   - 'verified'        — a codebase-fact category carrying a citation.
+ *   - 'unverified'      — a codebase-fact category with no citation; recalled
+ *                         content is prefixed `[unverified]`.
+ *   - 'not-applicable'  — a preference/reflection category (never gated).
+ */
+export type FactVerification = 'verified' | 'unverified' | 'not-applicable';
+
 export interface Fact {
   id: number;
   session_id: string | null;
@@ -25,6 +36,13 @@ export interface Fact {
   confidence: number;
   access_count: number;
   last_accessed: string | null;
+  /**
+   * Provenance citation backing a codebase fact (file:line, commit SHA,
+   * trace-event id, …). NULL on rows written before schema v4 and on any
+   * uncited write. Surfaced + verdict-classified at recall only when the
+   * evidence gate is enabled.
+   */
+  evidence: string | null;
 }
 
 export interface NewFact {
@@ -32,6 +50,8 @@ export interface NewFact {
   category: FactCategory;
   content: string;
   source_surface: string;
+  /** Optional provenance citation; see {@link Fact.evidence}. */
+  evidence?: string | null;
 }
 
 export interface SessionRecord {
@@ -82,6 +102,17 @@ export interface MemorySearchResult {
   created_at: string;
   source_session?: string | null;
   confidence: number;
+  /**
+   * Provenance citation, populated from {@link Fact.evidence}. Surfaced to the
+   * agent only when the evidence gate is enabled; omitted otherwise so
+   * gate-off recall output is byte-identical to legacy behavior.
+   */
+  evidence?: string | null;
+  /**
+   * Recall-time provenance verdict. Present only when the evidence gate is
+   * enabled; see {@link FactVerification}.
+   */
+  verification?: FactVerification;
 }
 
 export interface WALEntry {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -217,6 +217,19 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     category: 'model',
   },
   {
+    name: 'AFK_MEMORY_EVIDENCE_GATE',
+    description:
+      'Opt-in (set to 1) evidence gate for durable memory writes. When enabled, a codebase ' +
+      'fact (memory_update category "convention") stored without an `evidence` citation is ' +
+      'recalled as [unverified], and memory_search results carry a verification verdict. ' +
+      'User preferences and agent reflections are never gated. Default off — memory behaves ' +
+      'identically to legacy when unset.',
+    type: 'boolean',
+    required: false,
+    example: '1',
+    category: 'misc',
+  },
+  {
     name: 'AFK_MODEL',
     description: 'Default model for agent turns. Accepts slot names (local, small, medium, large), legacy aliases (opus, sonnet, haiku), the fixed-id fable alias (Claude Fable 5), or full model IDs.',
     type: 'string',
@@ -1116,6 +1129,7 @@ export const env = {
   get AFK_MAX_BUDGET_USD(): string | undefined { return process.env['AFK_MAX_BUDGET_USD']; },
   get AFK_MAX_OUTPUT_TOKENS(): string | undefined { return process.env['AFK_MAX_OUTPUT_TOKENS']; },
   get AFK_MAX_TOKENS(): string | undefined { return process.env['AFK_MAX_TOKENS']; },
+  get AFK_MEMORY_EVIDENCE_GATE(): string | undefined { return process.env['AFK_MEMORY_EVIDENCE_GATE']; },
   get AFK_MODEL(): string | undefined { return process.env['AFK_MODEL']; },
   get AFK_MODEL_LARGE(): string | undefined { return process.env['AFK_MODEL_LARGE']; },
   get AFK_MODEL_LARGE_API_KEY(): string | undefined { return process.env['AFK_MODEL_LARGE_API_KEY']; },

--- a/tests/agent/memory/memory-store.test.ts
+++ b/tests/agent/memory/memory-store.test.ts
@@ -294,16 +294,17 @@ describe('Concurrent open', () => {
 });
 
 describe('Schema versioning', () => {
-  it('stamps the current schema version (3) on a fresh database', () => {
+  it('stamps the current schema version (4) on a fresh database', () => {
     // The store created in beforeEach is a fresh DB.
     // Re-open the same dir with better-sqlite3 directly to read the pragma.
-    // Bumped to v3 in Stage D (added the nullable sessions.actor column).
+    // Bumped to v3 in Stage D (nullable sessions.actor column), then to v4 by
+    // the evidence-gate feature (nullable facts.evidence column).
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const Database = require('better-sqlite3');
     const db = new Database(join(tmpMemDir, 'memory.db'));
     const version = db.pragma('user_version', { simple: true });
     db.close();
-    expect(version).toBe(3);
+    expect(version).toBe(4);
   });
 
   it('opens cleanly when user_version matches SCHEMA_VERSION', () => {


### PR DESCRIPTION
## What

Evidence-gated durable memory writes, opt-in behind **`AFK_MEMORY_EVIDENCE_GATE=1`** (default off → byte-identical to current behaviour).

**Goal:** stop uncited agent claims about the codebase from silently becoming future ground truth. Today `memory_update` stores agent-authored content verbatim (`memory-store.ts`: *"agent-authored content is stored verbatim"*), and the `confidence` column is hardcoded to `1.0` and read by nothing. Memory is the most durable, highest-blast-radius write the agent makes, and it has no provenance gate — a hallucinated fact poisons every future session silently.

## How

Classification rides the **existing fact categories** — no new classifier:

| category | bucket | gated? | on recall |
|---|---|---|---|
| `convention` | codebase fact | ✅ | cited → `verified`; uncited → `[unverified]` (+ warning on write) |
| `preference` | user instruction | — | `not-applicable` |
| `learning` / `decision` | reflection / rationale | — | `not-applicable` (never stamped a fact) |

- **Never hard-rejects.** A codebase fact without evidence is stored, warned, and recall-tagged `[unverified]` (the "require *or* strongly warn" → strong-warn variant).
- **Layered:** store = pure data (new nullable `evidence` column); `memory-evidence.ts` = pure policy helpers; handlers = flag-gated warn-on-write / tag-on-recall.
- **Schema v3→v4:** nullable `facts.evidence` column via the same idempotent, concurrency-safe `ALTER` as the v2→v3 `actor` migration.

## Acceptance criteria → tests

New `src/agent/memory/memory-evidence-gate.test.ts`:
1. ✅ a citable codebase fact (convention) **with** evidence → recalled `verified`
2. ✅ a codebase fact **without** evidence → recalled `[unverified]`
3. ✅ a user preference does **not** require file evidence (no warning)
4. ✅ an agent reflection (learning) is **not** treated as factual codebase knowledge
- plus: gate-off is a byte-identical no-op, and a pre-existing v3 DB migrates forward without data loss.

## Verification

`tsc --noEmit` clean · memory (57) + env-parity (19) + score (58) tests green · `scan:env:check` + `audit:env:check` pass. Built and verified in an isolated worktree on the current `main` (v4.27.3) base.

## Notes / follow-ups

- **Forward-incompatible schema bump:** enabling this migrates the DB to v4; an older `afk` build then rejects it (documented contract, same as `actor`).
- **Scope choices open to feedback (each a one-liner to change):** `decision` left ungated (rationale records are usually chat-derived; gating would be ceremony); strong-warn chosen over hard-require.
- **Origin:** prototype sparked by an r/AI_Agents thread + the discussion on #237. This is the *memory-write* half; the separate Telegram-`Done`-verification slice (#237's other half) is developed independently on `feat/telegram-verify-done`. Disjoint file sets.
