### PR TITLE
fix(daemon): quarantine malformed pull-queue entries instead of silent deadlock

### DIFF
--- a/src/agent/daemon/queue-store.test.ts
+++ b/src/agent/daemon/queue-store.test.ts
@@ -157,6 +157,25 @@ describe('dequeueNext — malformed (poison) entries', () => {
     expect(task).not.toBeNull();
     expect(task!.command).toBe('valid');
   });
+
+  it('quarantines an unreadable entry (read error, not parse error) and keeps draining', () => {
+    // A directory whose name ends in `.json` passes the FIFO filter but makes
+    // readFileSync throw EISDIR — exercising the read-error branch, which is
+    // distinct from the JSON.parse branch every other poison test covers.
+    mkdirSync(join(tmpDir, '0000-q-unreadable.json'), { recursive: true });
+    enqueue('valid-after-unreadable', {}, tmpDir);
+
+    const task = dequeueNext(tmpDir);
+    expect(task).not.toBeNull();
+    expect(task!.command).toBe('valid-after-unreadable');
+
+    // The unreadable entry was moved aside into poison/, not left at the head.
+    expect(readdirSync(join(tmpDir, 'poison'))).toHaveLength(1);
+    const remaining = readdirSync(tmpDir).filter(
+      (f) => f.endsWith('.json') && !f.startsWith('.tmp-'),
+    );
+    expect(remaining).toHaveLength(0);
+  });
 });
 
 describe('listPending', () => {
@@ -180,5 +199,21 @@ describe('listPending', () => {
     enqueue('keep', {}, tmpDir);
     listPending(tmpDir);
     expect(readdirSync(tmpDir)).toHaveLength(1);
+  });
+
+  it('skips malformed entries instead of throwing', () => {
+    enqueue('alpha', {}, tmpDir);
+    writeFileSync(join(tmpDir, '0002-q-poison.json'), '{ not json');
+    enqueue('gamma', {}, tmpDir);
+
+    // Must not throw on the poison entry, and returns only the parseable tasks.
+    const tasks = listPending(tmpDir);
+    expect(tasks.map((t) => t.command)).toEqual(['alpha', 'gamma']);
+
+    // Read-only: nothing moved or removed — the poison entry is left in place
+    // for the dequeue path to quarantine, and no poison/ dir is created here.
+    const remaining = readdirSync(tmpDir).filter((f) => f.endsWith('.json'));
+    expect(remaining).toHaveLength(3);
+    expect(readdirSync(tmpDir)).not.toContain('poison');
   });
 });

--- a/src/agent/daemon/queue-store.test.ts
+++ b/src/agent/daemon/queue-store.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, readdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, readdirSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { enqueue, dequeueNext, listPending } from './queue-store.js';
@@ -96,6 +96,66 @@ describe('dequeueNext', () => {
     enqueue('only', {}, tmpDir);
     dequeueNext(tmpDir);
     expect(dequeueNext(tmpDir)).toBeNull();
+  });
+});
+
+describe('dequeueNext — malformed (poison) entries', () => {
+  it('quarantines a malformed JSON entry at the FIFO head and returns the next valid task', () => {
+    // Drop a corrupt file that sorts before any enqueued task.
+    writeFileSync(join(tmpDir, '0000-q-poison.json'), '{ not valid json');
+    enqueue('valid-task', {}, tmpDir);
+
+    const task = dequeueNext(tmpDir);
+    expect(task).not.toBeNull();
+    expect(task!.command).toBe('valid-task');
+
+    // No malformed entry left in the FIFO path; valid task consumed.
+    const remaining = readdirSync(tmpDir).filter(
+      (f) => f.endsWith('.json') && !f.startsWith('.tmp-'),
+    );
+    expect(remaining).toHaveLength(0);
+
+    // Malformed entry preserved in poison/ for diagnosis.
+    const poison = readdirSync(join(tmpDir, 'poison'));
+    expect(poison).toHaveLength(1);
+  });
+
+  it('returns null when every entry is malformed (all quarantined, queue unblocked)', () => {
+    writeFileSync(join(tmpDir, '0001-q-a.json'), 'garbage');
+    writeFileSync(join(tmpDir, '0002-q-b.json'), 'also{bad');
+
+    expect(dequeueNext(tmpDir)).toBeNull();
+
+    // Both moved aside — a subsequent call finds an empty FIFO path.
+    const remaining = readdirSync(tmpDir).filter(
+      (f) => f.endsWith('.json') && !f.startsWith('.tmp-'),
+    );
+    expect(remaining).toHaveLength(0);
+    expect(readdirSync(join(tmpDir, 'poison'))).toHaveLength(2);
+    // And the queue is unblocked: another dequeue returns null cleanly.
+    expect(dequeueNext(tmpDir)).toBeNull();
+  });
+
+  it('preserves the malformed entry bytes in poison/ (not deleted)', () => {
+    writeFileSync(join(tmpDir, '0001-q-x.json'), '!!broken!!');
+    dequeueNext(tmpDir);
+
+    const poison = readdirSync(join(tmpDir, 'poison'));
+    expect(poison).toHaveLength(1);
+    const restored = readFileSync(join(tmpDir, 'poison', poison[0]!), 'utf-8');
+    expect(restored).toBe('!!broken!!');
+  });
+
+  it('does not treat the poison/ subdir itself as a queue entry', () => {
+    // Create a poison dir first, then a valid task. dequeueNext must not
+    // try to read `poison` as a .json file (it is filtered out by suffix).
+    mkdirSync(join(tmpDir, 'poison'), { recursive: true });
+    writeFileSync(join(tmpDir, 'poison', 'stale.json'), 'old');
+    enqueue('valid', {}, tmpDir);
+
+    const task = dequeueNext(tmpDir);
+    expect(task).not.toBeNull();
+    expect(task!.command).toBe('valid');
   });
 });
 

--- a/src/agent/daemon/queue-store.ts
+++ b/src/agent/daemon/queue-store.ts
@@ -19,6 +19,7 @@ import { mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFile
 import { randomBytes } from 'node:crypto';
 import { join } from 'node:path';
 import { getQueueDir } from '../../paths.js';
+import { redactInlineSecrets } from '../session/prompt-dump.js';
 
 export interface QueuedTask {
   /** Unique task identifier, e.g. `q-1716000000000-abc123`. */
@@ -95,6 +96,11 @@ export function enqueue(
  * Subdirectory (relative to `queueDir`) used to quarantine malformed queue
  * entries instead of silently dropping them or letting them block the FIFO
  * queue forever. See `dequeueNext` for the poison-handling contract.
+ *
+ * NOTE(#337-poison-gc): quarantined files are never auto-pruned — `poison/`
+ * grows unbounded and is expected to be inspected and cleared manually by the
+ * operator. A periodic sweep (e.g. prune entries older than N days) is a
+ * tracked follow-up, kept out of this fix to limit its scope.
  */
 const POISON_SUBDIR = 'poison';
 
@@ -161,7 +167,14 @@ export function dequeueNext(queueDir: string = getQueueDir()): QueuedTask | null
  * outcome is logged to stderr so the operator can investigate.
  */
 function quarantinePoisonEntry(queueDir: string, filename: string, err: unknown): void {
-  const reason = err instanceof Error ? err.message : String(err);
+  // Redact every error-derived string before logging: a JSON.parse SyntaxError
+  // can embed a snippet of the malformed entry's bytes, and a queue `command`
+  // may carry an inline secret. This matches the daemon's existing convention
+  // for error-derived logs (see redactInlineSecrets use in scheduler.ts runOnce).
+  // NOTE(#337-poison-telemetry): quarantines are logged to stderr only — a
+  // structured `status:'poison'` telemetry record for parity with runOnce is a
+  // tracked follow-up, not added here to keep the change focused.
+  const reason = redactInlineSecrets(err instanceof Error ? err.message : String(err));
   const poisonDir = join(queueDir, POISON_SUBDIR);
   const src = join(queueDir, filename);
   try {
@@ -170,7 +183,12 @@ function quarantinePoisonEntry(queueDir: string, filename: string, err: unknown)
     try {
       renameSync(src, dest);
     } catch {
-      // Collision or transient failure — disambiguate and retry once.
+      // First rename failed — almost always a name collision with a file of the
+      // same name already in poison/ (e.g. re-quarantined after a manual
+      // restore). Retry once with a unique timestamp+random prefix so an
+      // existing poison file is never overwritten. poison/ is a subdir of
+      // queueDir, so a cross-device (EXDEV) rename cannot occur here; any other
+      // rename failure rethrows and is handled by the outer catch.
       dest = join(poisonDir, `${Date.now()}-${randomBytes(3).toString('hex')}-${filename}`);
       renameSync(src, dest);
     }
@@ -181,15 +199,25 @@ function quarantinePoisonEntry(queueDir: string, filename: string, err: unknown)
   } catch (moveErr) {
     // Last resort: if we cannot move it aside, unlink so the queue unblocks
     // rather than deadlocking on every subsequent tick.
-    const moveReason = moveErr instanceof Error ? moveErr.message : String(moveErr);
+    const moveReason = redactInlineSecrets(moveErr instanceof Error ? moveErr.message : String(moveErr));
     // eslint-disable-next-line no-console
     console.error(
       `[daemon] pull-queue: failed to quarantine malformed entry ${filename}; removing to unblock queue (${moveReason})`,
     );
     try {
       unlinkSync(src);
-    } catch {
-      // ignore — nothing more we can do; the next readdir will retry.
+    } catch (unlinkErr) {
+      // Even the unlink failed (e.g. queue-dir permission loss). Surface it
+      // instead of swallowing — otherwise the stuck entry re-fails silently on
+      // every tick. The queue is NOT deadlocked (dequeueNext's loop still
+      // reaches valid entries behind it); the next readdir retries this one.
+      const unlinkReason = redactInlineSecrets(
+        unlinkErr instanceof Error ? unlinkErr.message : String(unlinkErr),
+      );
+      // eslint-disable-next-line no-console
+      console.error(
+        `[daemon] pull-queue: could not remove unquarantinable entry ${filename}; will retry next tick (${unlinkReason})`,
+      );
     }
   }
 }
@@ -197,8 +225,15 @@ function quarantinePoisonEntry(queueDir: string, filename: string, err: unknown)
 /**
  * List all pending tasks in FIFO order without removing them.
  *
+ * Mirrors `dequeueNext`'s tolerance for malformed entries: a poison file
+ * (unreadable or unparseable) is SKIPPED rather than thrown on, so one corrupt
+ * file cannot crash a `queue list` view. Unlike `dequeueNext`, this read-only
+ * path does NOT quarantine (move) the entry — a listing must not mutate the
+ * queue, and quarantining here could race the daemon's concurrent dequeue. The
+ * dequeue path stays responsible for moving poison aside.
+ *
  * @param queueDir - Override the queue directory (defaults to `getQueueDir()`).
- * @returns Array of `QueuedTask` sorted by sequence (FIFO).
+ * @returns Array of `QueuedTask` sorted by sequence (FIFO); malformed entries omitted.
  */
 export function listPending(queueDir: string = getQueueDir()): QueuedTask[] {
   try {
@@ -211,9 +246,18 @@ export function listPending(queueDir: string = getQueueDir()): QueuedTask[] {
     .filter((f) => f.endsWith('.json') && !f.startsWith('.tmp-'))
     .sort();
 
-  return sorted.map((filename) => {
+  const tasks: QueuedTask[] = [];
+  for (const filename of sorted) {
     const filePath = join(queueDir, filename);
-    const raw = readFileSync(filePath, 'utf-8');
-    return JSON.parse(raw) as QueuedTask;
-  });
+    try {
+      tasks.push(JSON.parse(readFileSync(filePath, 'utf-8')) as QueuedTask);
+    } catch (err) {
+      const reason = redactInlineSecrets(err instanceof Error ? err.message : String(err));
+      // eslint-disable-next-line no-console
+      console.error(
+        `[daemon] pull-queue: skipping unreadable entry ${filename} in listPending (${reason})`,
+      );
+    }
+  }
+  return tasks;
 }

--- a/src/agent/daemon/queue-store.ts
+++ b/src/agent/daemon/queue-store.ts
@@ -92,16 +92,32 @@ export function enqueue(
 }
 
 /**
+ * Subdirectory (relative to `queueDir`) used to quarantine malformed queue
+ * entries instead of silently dropping them or letting them block the FIFO
+ * queue forever. See `dequeueNext` for the poison-handling contract.
+ */
+const POISON_SUBDIR = 'poison';
+
+/**
  * Dequeue the next pending task (FIFO order) and remove it from disk.
  *
  * ORDERING INVARIANT: the queue file is removed from disk BEFORE this
- * function returns. Callers (e.g. `pullTick`) must spawn the session only
- * after `dequeueNext` has returned a non-null result — reverse order risks
- * double-fire on daemon restart if the process crashes between dequeue and
- * spawn.
+ * function returns a task. Callers (e.g. `pullTick`) must spawn the session
+ * only after `dequeueNext` has returned a non-null result — reverse order
+ * risks double-fire on daemon restart if the process crashes between dequeue
+ * and spawn.
+ *
+ * POISON-HANDLING CONTRACT: a malformed entry (truncated write, corrupted
+ * JSON, or a stray non-JSON file dropped into the queue dir) is moved aside
+ * into `<queueDir>/poison/` and skipped — NOT returned and NOT left in the
+ * FIFO path. This keeps the queue draining past corrupt entries while
+ * preserving them for diagnosis. Previously a parse error threw before the
+ * file was removed and `pullTick` swallowed it, leaving a single poison
+ * entry to silently deadlock every subsequent task with no log or telemetry.
  *
  * @param queueDir - Override the queue directory (defaults to `getQueueDir()`).
- * @returns The dequeued `QueuedTask`, or `null` if the queue is empty.
+ * @returns The dequeued `QueuedTask`, or `null` if the queue is empty or every
+ *          remaining entry is malformed (all quarantined).
  */
 export function dequeueNext(queueDir: string = getQueueDir()): QueuedTask | null {
   mkdirSync(queueDir, { recursive: true });
@@ -110,19 +126,72 @@ export function dequeueNext(queueDir: string = getQueueDir()): QueuedTask | null
     .filter((f) => f.endsWith('.json') && !f.startsWith('.tmp-'))
     .sort();
 
-  // noUncheckedIndexedAccess guard
-  const first = sorted[0];
-  if (first === undefined) return null;
+  for (const filename of sorted) {
+    const filePath = join(queueDir, filename);
+    let raw: string;
+    try {
+      raw = readFileSync(filePath, 'utf-8');
+    } catch (err) {
+      quarantinePoisonEntry(queueDir, filename, err);
+      continue;
+    }
+    let task: QueuedTask;
+    try {
+      task = JSON.parse(raw) as QueuedTask;
+    } catch (err) {
+      quarantinePoisonEntry(queueDir, filename, err);
+      continue;
+    }
+    // ORDERING INVARIANT: remove from disk BEFORE returning task.
+    // See JSDoc above — do NOT move this after the return.
+    unlinkSync(filePath);
+    return task;
+  }
+  return null;
+}
 
-  const filePath = join(queueDir, first);
-  const raw = readFileSync(filePath, 'utf-8');
-  const task = JSON.parse(raw) as QueuedTask;
-
-  // ORDERING INVARIANT: remove from disk BEFORE returning task.
-  // See JSDoc above — do NOT move this after the return.
-  unlinkSync(filePath);
-
-  return task;
+/**
+ * Move an unparseable queue file into `<queueDir>/poison/` so it stops
+ * blocking FIFO dequeue but is preserved for diagnosis. Uses an atomic
+ * same-directory rename (`poison/` is created lazily). On a name collision
+ * inside `poison/` (e.g. the same corrupt filename re-quarantined after a
+ * manual restore), a timestamp + random suffix is appended so nothing is
+ * ever overwritten. Never throws — if the entry cannot be moved aside it is
+ * best-effort unlinked so the queue unblocks instead of deadlocking. Every
+ * outcome is logged to stderr so the operator can investigate.
+ */
+function quarantinePoisonEntry(queueDir: string, filename: string, err: unknown): void {
+  const reason = err instanceof Error ? err.message : String(err);
+  const poisonDir = join(queueDir, POISON_SUBDIR);
+  const src = join(queueDir, filename);
+  try {
+    mkdirSync(poisonDir, { recursive: true });
+    let dest = join(poisonDir, filename);
+    try {
+      renameSync(src, dest);
+    } catch {
+      // Collision or transient failure — disambiguate and retry once.
+      dest = join(poisonDir, `${Date.now()}-${randomBytes(3).toString('hex')}-${filename}`);
+      renameSync(src, dest);
+    }
+    // eslint-disable-next-line no-console
+    console.error(
+      `[daemon] pull-queue: quarantined malformed entry ${filename} → ${POISON_SUBDIR}/ (${reason})`,
+    );
+  } catch (moveErr) {
+    // Last resort: if we cannot move it aside, unlink so the queue unblocks
+    // rather than deadlocking on every subsequent tick.
+    const moveReason = moveErr instanceof Error ? moveErr.message : String(moveErr);
+    // eslint-disable-next-line no-console
+    console.error(
+      `[daemon] pull-queue: failed to quarantine malformed entry ${filename}; removing to unblock queue (${moveReason})`,
+    );
+    try {
+      unlinkSync(src);
+    } catch {
+      // ignore — nothing more we can do; the next readdir will retry.
+    }
+  }
 }
 
 /**

--- a/src/agent/daemon/scheduler-pull.test.ts
+++ b/src/agent/daemon/scheduler-pull.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { CronScheduler } from './scheduler.js';
@@ -176,6 +176,54 @@ describe('pull tick — telemetry record fields', () => {
     const record = JSON.parse(readFileSync(telemetryPath, 'utf-8').trim());
     expect(record.taskId).toBe(queued.id);
     expect(record.trigger).toBe('pull');
+
+    await scheduler.stop();
+  });
+});
+
+describe('pull tick — malformed queue entries do not deadlock', () => {
+  it('skips a poison entry and processes the valid task behind it on the same tick', async () => {
+    // Poison file at the FIFO head sorts before any enqueued task.
+    writeFileSync(join(queueDir, '0000-q-poison.json'), '{ broken');
+    enqueue('valid-task', {}, queueDir);
+
+    const scheduler = makeScheduler(queueDir, telemetryPath);
+    scheduler.startPullLoop();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    // The valid task was reached despite the poison entry at the head.
+    const lines = readFileSync(telemetryPath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const record = JSON.parse(lines[0]!);
+    expect(record.command).toBe('valid-task');
+    expect(record.status).toBe('success');
+
+    // Poison entry moved aside, not blocking the FIFO path.
+    expect(readdirSync(join(queueDir, 'poison'))).toHaveLength(1);
+    const remaining = readdirSync(queueDir).filter(
+      (f) => f.endsWith('.json') && !f.startsWith('.tmp-'),
+    );
+    expect(remaining).toHaveLength(0);
+
+    await scheduler.stop();
+  });
+
+  it('keeps draining across ticks when multiple poison entries are present', async () => {
+    writeFileSync(join(queueDir, '0001-q-bad1.json'), 'nope');
+    writeFileSync(join(queueDir, '0002-q-bad2.json'), 'also{bad');
+    enqueue('good', {}, queueDir);
+
+    const scheduler = makeScheduler(queueDir, telemetryPath);
+    scheduler.startPullLoop();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const lines = readFileSync(telemetryPath, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!).command).toBe('good');
+    // Both poison entries quarantined on the single tick.
+    expect(readdirSync(join(queueDir, 'poison'))).toHaveLength(2);
 
     await scheduler.stop();
   });

--- a/src/agent/daemon/scheduler-pull.test.ts
+++ b/src/agent/daemon/scheduler-pull.test.ts
@@ -209,7 +209,7 @@ describe('pull tick — malformed queue entries do not deadlock', () => {
     await scheduler.stop();
   });
 
-  it('keeps draining across ticks when multiple poison entries are present', async () => {
+  it('drains multiple poison entries on a single tick while still running the valid task behind them', async () => {
     writeFileSync(join(queueDir, '0001-q-bad1.json'), 'nope');
     writeFileSync(join(queueDir, '0002-q-bad2.json'), 'also{bad');
     enqueue('good', {}, queueDir);

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -295,7 +295,9 @@ export class CronScheduler {
       // quarantined inside dequeueNext) or from synthetic-task construction.
       // Log so a bad tick is visible in daemon logs instead of vanishing;
       // the poll loop still survives (mirrors writeTelemetry's logging path).
-      const msg = err instanceof Error ? err.message : String(err);
+      // Redact error-derived text before logging, matching the runOnce
+      // telemetry path (a synthetic task's command may carry an inline secret).
+      const msg = redactInlineSecrets(err instanceof Error ? err.message : String(err));
       // eslint-disable-next-line no-console
       console.error(`[daemon] pull tick failed: ${msg}`);
     } finally {

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -289,10 +289,15 @@ export class CronScheduler {
         ...(queued.notifyOn !== undefined ? { notifyOn: queued.notifyOn } : {}),
       };
       await this.runOnce(syntheticTask, 'pull');
-    } catch {
-      // Mirror the cron error path: errors are captured inside runOnce and
-      // written to telemetry. Any uncaught error here is silently swallowed
-      // so a bad queue entry never kills the poll loop.
+    } catch (err) {
+      // Errors thrown INSIDE runOnce are captured there and written to
+      // telemetry. Errors reaching here come from the dequeue path (now
+      // quarantined inside dequeueNext) or from synthetic-task construction.
+      // Log so a bad tick is visible in daemon logs instead of vanishing;
+      // the poll loop still survives (mirrors writeTelemetry's logging path).
+      const msg = err instanceof Error ? err.message : String(err);
+      // eslint-disable-next-line no-console
+      console.error(`[daemon] pull tick failed: ${msg}`);
     } finally {
       this.isDequeuing = false;
     }


### PR DESCRIPTION
## Summary

A malformed queue file (truncated write, corrupt JSON, or a stray non-JSON file dropped into the queue dir) threw out of `dequeueNext()` **before** its `unlinkSync` ran. `pullTick()`'s empty `catch {}` then swallowed the error, leaving the poison file at the FIFO head — where it blocked **every subsequent queued task on every poll tick, silently**, with no log line and no telemetry record. One corrupt file deadlocked the whole pull-queue.

This was surfaced during a full read-through of the daemon subsystem (recon-grade finding I verified against the source before opening this).

Fix in two parts:

1. **`queue-store.dequeueNext()`** now iterates the sorted entries and **quarantines** any that fail to read or parse into `<queueDir>/poison/` (atomic same-dir rename, lazy `mkdir`, collision-suffixed on retry), then continues to the next entry. The poison entry is preserved for diagnosis instead of being dropped, and the queue keeps draining. `quarantinePoisonEntry()` never throws — if the entry cannot be moved aside it is best-effort unlinked so the queue still unblocks.

2. **`scheduler.pullTick()`** replaces the silent empty `catch` with a `console.error` log so any error that still escapes (e.g. synthetic-task construction) is at least visible in daemon logs instead of vanishing. Errors thrown inside `runOnce` continue to be written to telemetry as before.

The existing `ORDERING INVARIANT` (file removed before returning a task) is preserved — quarantine happens before any valid entry is returned.

## How was this tested?

```
pnpm lint   # tsc --noEmit (strict) — clean
pnpm test   # 9838 passed / 0 failed / 12 skipped (529 files)
pnpm audit:sdk:check   # OK — no SDK import changes
pnpm audit:env:check   # OK — no process.env changes
pnpm build             # OK
```

6 new tests added:

- `queue-store.test.ts` (4): quarantine-at-head + next-valid-returned; all-malformed → null + all quarantined; malformed bytes preserved in `poison/`; `poison/` subdir itself not scanned as a queue entry.
- `scheduler-pull.test.ts` (2): poison at FIFO head + valid task behind it processes on the same tick; multiple poison entries drain to `poison/` while the valid task still runs.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the DCO
- [x] No secrets, tokens, or private paths in the diff