### PR TITLE
fix(anthropic-direct): keep session alive after mid-turn interrupt (ESC)

### DIFF
--- a/src/agent/providers/anthropic-direct/interrupt-resume.test.ts
+++ b/src/agent/providers/anthropic-direct/interrupt-resume.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Regression test for the "ESC mid-turn → can't resume" bug.
+ *
+ * Repro: in the REPL the user hit ESC to stop a running turn. Afterward, plain
+ * prompts were echoed but started NO agent turn, while slash commands still
+ * worked. Root cause: `AnthropicDirectQuery`'s outer multi-turn generator
+ * `return`ed on ANY aborted per-turn controller (`if (controller.signal.aborted)
+ * return`). Because `interrupt()` and `close()` both abort the per-turn
+ * controller and differ only in an un-inspected reason string, an ESC interrupt
+ * was treated like a session close and permanently terminated the generator.
+ * `AgentSession` reuses ONE `providerIterator` across turns, so once the
+ * generator returned every later `sendMessageStream` got `{done:true}` and ran
+ * no turn. Slash commands kept working because they never pull the iterator.
+ *
+ * The fix discriminates close (`state.closed`) from interrupt and, on interrupt,
+ * emits a terminal event (if the turn produced none) then loops back for the
+ * next prompt instead of returning — mirroring the OpenAI-compatible provider.
+ *
+ * These tests drive the REAL `AnthropicDirectQuery[Symbol.asyncIterator]`
+ * generator (where the bug lived) via `provider.query()`, mocking the Anthropic
+ * SDK's `messages.create`. A mock-provider test at the AgentSession layer would
+ * NOT catch the bug.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { RawMessageStreamEvent } from '@anthropic-ai/sdk/resources';
+import type { ProviderEvent } from '../../provider.js';
+import { AnthropicDirectProvider, __setAnthropicClientFactory } from './index.js';
+
+// --- Mock SDK plumbing (mirrors query-auth-retry.test.ts) ---
+
+const messagesCreateMock = vi.fn();
+
+class MockAnthropic {
+  public messages: { create: typeof messagesCreateMock };
+  constructor() {
+    this.messages = { create: messagesCreateMock };
+  }
+}
+
+function installFactory(): void {
+  __setAnthropicClientFactory(() => new MockAnthropic() as unknown as Anthropic);
+}
+
+// --- Helpers ---
+
+async function* fromArray<T>(arr: T[]): AsyncIterable<T> {
+  for (const x of arr) yield x;
+}
+
+/** A single-message prompt stream that completes after one turn. */
+async function* singleInput(content: string): AsyncIterable<{ content: string }> {
+  yield { content };
+}
+
+async function collect(query: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  for await (const ev of query) out.push(ev);
+  return out;
+}
+
+/** A prompt stream we can push user turns to over the life of the test. */
+function createPushStream<T>(): {
+  push: (item: T) => void;
+  close: () => void;
+  iterable: AsyncIterable<T>;
+} {
+  const queue: T[] = [];
+  let waiting: ((r: IteratorResult<T>) => void) | null = null;
+  let closed = false;
+  return {
+    push(item: T): void {
+      if (waiting) {
+        const resolve = waiting;
+        waiting = null;
+        resolve({ value: item, done: false });
+      } else {
+        queue.push(item);
+      }
+    },
+    close(): void {
+      closed = true;
+      if (waiting) {
+        const resolve = waiting;
+        waiting = null;
+        resolve({ value: undefined as unknown as T, done: true });
+      }
+    },
+    iterable: {
+      [Symbol.asyncIterator](): AsyncIterator<T> {
+        return {
+          next(): Promise<IteratorResult<T>> {
+            const head = queue.shift();
+            if (head !== undefined) return Promise.resolve({ value: head, done: false });
+            if (closed) return Promise.resolve({ value: undefined as unknown as T, done: true });
+            return new Promise<IteratorResult<T>>((resolve) => {
+              waiting = resolve;
+            });
+          },
+        };
+      },
+    },
+  };
+}
+
+/** Minimal text-only stream that ends with stop_reason=end_turn. */
+function makeTextStream(text: string): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_test',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-4-5-20250929',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 5,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '', citations: [] },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 4 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+function makeAbortError(): Error {
+  const e = new Error('Request was aborted.');
+  e.name = 'AbortError';
+  return e;
+}
+
+// --- Tests ---
+
+describe('AnthropicDirectQuery — interrupt mid-turn then resume', () => {
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    installFactory();
+  });
+
+  it('keeps the session alive so the next message runs after a mid-turn interrupt', async () => {
+    const prompts = createPushStream<{ content: string }>();
+
+    // The mock needs to interrupt the in-flight query; the query is built after
+    // the factory is installed, so reference it through a forward `let`.
+    let queryRef: { interrupt(): Promise<void> } | null = null;
+    let turnIdx = 0;
+
+    messagesCreateMock.mockImplementation(() => {
+      turnIdx += 1;
+      if (turnIdx === 1) {
+        // Simulate ESC mid-stream: interrupt the running turn, then let the
+        // request abort (SDK throws AbortError). loop.ts catches the abort and
+        // yields turn.completed; the OUTER generator must then loop back for the
+        // next prompt rather than terminating the shared iterator.
+        return (async function* (): AsyncGenerator<RawMessageStreamEvent> {
+          await queryRef!.interrupt();
+          throw makeAbortError();
+        })();
+      }
+      // Turn 2: a normal text reply — the message that "wouldn't send" pre-fix.
+      return fromArray(makeTextStream('resumed reply'));
+    });
+
+    const provider = new AnthropicDirectProvider();
+    const query = provider.query({
+      prompt: prompts.iterable,
+      config: { model: 'claude-sonnet-4-5-20250929', apiKey: 'sk-ant-oat01-test' },
+    });
+    queryRef = query;
+
+    const it = (query as AsyncIterable<ProviderEvent>)[Symbol.asyncIterator]();
+
+    // session.init handshake.
+    const init = await it.next();
+    expect(init.done).toBe(false);
+    expect((init.value as ProviderEvent).type).toBe('session.init');
+
+    // Turn 1 — drive it; it self-interrupts mid-stream.
+    prompts.push({ content: 'first' });
+    let r = await it.next();
+    while (!r.done && (r.value as ProviderEvent).type !== 'turn.completed') {
+      r = await it.next();
+    }
+    // The aborted turn yields a terminal turn.completed AND the generator is
+    // still alive (the bug terminated it here).
+    expect(r.done).toBe(false);
+    expect((r.value as ProviderEvent).type).toBe('turn.completed');
+
+    // Turn 2 — the regression: before the fix the shared generator had already
+    // returned, so pushing a new message produced nothing (no agent turn).
+    prompts.push({ content: 'second' });
+    let assistantText = '';
+    let sawTurn2Completed = false;
+    r = await it.next();
+    while (!r.done) {
+      const ev = r.value as ProviderEvent;
+      if (ev.type === 'delta.text') assistantText += ev.text;
+      if (ev.type === 'assistant.message') assistantText = ev.text;
+      if (ev.type === 'turn.completed') {
+        sawTurn2Completed = true;
+        break;
+      }
+      r = await it.next();
+    }
+
+    expect(sawTurn2Completed).toBe(true);
+    expect(assistantText).toContain('resumed reply');
+
+    // A second mid-conversation model call confirms the turn actually ran.
+    expect(turnIdx).toBe(2);
+
+    prompts.close();
+    await it.return?.();
+  });
+
+  it('a real (non-abort) error still terminates the generator with an error event', async () => {
+    // Guards against over-correction: only interrupts keep the session alive.
+    // A genuine error (no abort signal) must still surface as an `error` event
+    // and end the generator — the catch path's non-abort branch is unchanged.
+    messagesCreateMock.mockImplementation(() => {
+      throw new Error('boom: upstream failure');
+    });
+
+    const provider = new AnthropicDirectProvider();
+    const query = provider.query({
+      prompt: singleInput('first'),
+      config: { model: 'claude-sonnet-4-5-20250929', apiKey: 'sk-ant-oat01-test' },
+    });
+
+    // `collect` runs the generator to completion — if a real error wrongly kept
+    // the session alive, it would block on the next prompt and time out here.
+    const events = await collect(query as AsyncIterable<ProviderEvent>);
+
+    expect(events.some((e) => e.type === 'error')).toBe(true);
+  });
+});

--- a/src/agent/providers/anthropic-direct/query-auth-retry.test.ts
+++ b/src/agent/providers/anthropic-direct/query-auth-retry.test.ts
@@ -65,6 +65,52 @@ async function* singleInput(content: string): AsyncIterable<{ content: string }>
   yield { content };
 }
 
+/** A prompt stream we can push user turns to over the life of the test. */
+function createPushStream(): {
+  push: (item: { content: string }) => void;
+  close: () => void;
+  iterable: AsyncIterable<{ content: string }>;
+} {
+  const queue: Array<{ content: string }> = [];
+  let waiting: ((r: IteratorResult<{ content: string }>) => void) | null = null;
+  let closed = false;
+  return {
+    push(item): void {
+      if (waiting) {
+        const resolve = waiting;
+        waiting = null;
+        resolve({ value: item, done: false });
+      } else {
+        queue.push(item);
+      }
+    },
+    close(): void {
+      closed = true;
+      if (waiting) {
+        const resolve = waiting;
+        waiting = null;
+        resolve({ value: undefined as unknown as { content: string }, done: true });
+      }
+    },
+    iterable: {
+      [Symbol.asyncIterator](): AsyncIterator<{ content: string }> {
+        return {
+          next(): Promise<IteratorResult<{ content: string }>> {
+            const head = queue.shift();
+            if (head !== undefined) return Promise.resolve({ value: head, done: false });
+            if (closed) {
+              return Promise.resolve({ value: undefined as unknown as { content: string }, done: true });
+            }
+            return new Promise((resolve) => {
+              waiting = resolve;
+            });
+          },
+        };
+      },
+    },
+  };
+}
+
 /** Build a minimal text-only stream that ends with stop_reason=end_turn. */
 function makeTextStream(text: string): RawMessageStreamEvent[] {
   return [
@@ -690,80 +736,90 @@ describe('AnthropicDirectProvider — turnWithUsageLimitRetry', () => {
     expect(messagesCreateMock).toHaveBeenCalledTimes(1);
   });
 
-  it('interrupt during wait: 429+ts → paused → interrupt() → generator terminates (no hang, no resumed)', async () => {
-    // Regression guard for the usage-limit hang. When Ctrl+C (interrupt) lands
-    // during the usage-limit wait, `turnWithRetries` returns CLEANLY (not via
-    // throw — see retry-layer's `if (result === 'aborted') return`), so the
-    // catch-path abort guard in query.ts never fires. Without the post-finally
-    // guard the outer loop falls through to the next `promptIterator.next()`
-    // and BLOCKS there forever while the consumer is still awaiting a terminal
-    // event for the aborted turn — the REPL hangs (can't quit, auto-resume
-    // never re-fires, queued input never drains).
+  it('interrupt during wait: 429+ts → paused → interrupt() → yields terminal + stays resumable (no hang, no auto-resume)', async () => {
+    // Regression guard for the usage-limit interrupt path. When Ctrl+C
+    // (interrupt) lands during the usage-limit wait, `turnWithRetries` returns
+    // CLEANLY (not via throw — see retry-layer's `if (result === 'aborted')
+    // return`), so the catch-path abort guard never fires and control reaches
+    // the post-loop guard with the signal still aborted.
     //
-    // The prompt stream below blocks on its 2nd pull, exactly like the live
-    // REPL idle wait, so the hang is observable. A single-shot stream would
-    // return `done` on the 2nd loop and mask the bug. Uses REAL timers because
-    // the abort short-circuits waitForReset synchronously (the signal is
-    // already aborted when waitForReset is entered) and we want a wall-clock
-    // failsafe that fires if the hang regresses.
+    // Contract (fix/interrupt-mid-turn-resume): the generator must NOT
+    // terminate. An earlier fix (commit c462ebd) `return`ed here to stop the
+    // consumer hanging on a `next()` that never resolves — but terminating the
+    // generator permanently exhausts AgentSession's shared providerIterator, so
+    // every later `sendMessageStream` silently runs no turn (the "can't resume
+    // after ESC" bug). The correct behavior: emit a terminal `turn.completed`
+    // (so the consumer unblocks — still no hang) AND loop back to await the
+    // next prompt (so the session stays usable). The interrupted turn is
+    // abandoned — no `resumed`, no replay.
+    //
+    // Uses REAL timers because the abort short-circuits waitForReset
+    // synchronously (the signal is already aborted when waitForReset re-checks).
     vi.useRealTimers();
 
-    let releaseSecondPull: (() => void) | undefined;
-    const blockingPrompt = (async function* (): AsyncIterable<{ content: string }> {
-      yield { content: 'hello' };
-      // 2nd pull blocks until released — mirrors the REPL awaiting next input.
-      await new Promise<void>((resolve) => { releaseSecondPull = resolve; });
-    })();
-
+    const prompts = createPushStream();
     let callIdx = 0;
     messagesCreateMock.mockImplementation(() => {
       callIdx += 1;
       if (callIdx === 1) throw make429UsageLimitError(60 * 60 * 1_000); // 1h reset
-      return fromArray(makeTextStream('should not reach'));
+      return fromArray(makeTextStream('resumed after interrupt'));
     });
 
     const provider = new AnthropicDirectProvider();
     const query = provider.query({
-      prompt: blockingPrompt,
+      prompt: prompts.iterable,
       config: { model: 'claude-sonnet-4-5-20250929', apiKey: 'sk-ant-oat01-test', autoResumeOnUsageLimit: true },
     });
 
-    const events: ProviderEvent[] = [];
-    const collectWithInterrupt = async (): Promise<void> => {
-      for await (const ev of query) {
-        events.push(ev);
-        if (ev.type === 'paused') {
-          // User hits Ctrl+C during the usage-limit wait.
-          await query.interrupt();
-        }
+    const it = (query as AsyncIterable<ProviderEvent>)[Symbol.asyncIterator]();
+    await it.next(); // session.init
+
+    // Turn 1: 429 → paused → interrupt during the wait.
+    prompts.push({ content: 'hello' });
+    const turn1Types: string[] = [];
+    let interrupted = false;
+    let r = await it.next();
+    while (!r.done) {
+      const ev = r.value as ProviderEvent;
+      turn1Types.push(ev.type);
+      if (ev.type === 'paused' && !interrupted) {
+        interrupted = true;
+        await query.interrupt(); // user hits Ctrl+C during the usage-limit wait
       }
-    };
-
-    // Fail fast and legibly if the hang regresses: once interrupted, the
-    // generator must terminate well within this window.
-    let failsafeTimer: ReturnType<typeof setTimeout> | undefined;
-    const failsafe = new Promise<never>((_resolve, reject) => {
-      failsafeTimer = setTimeout(
-        () => reject(new Error(
-          'HANG: query generator did not terminate after interrupt() during the usage-limit wait — regression of the query.ts post-finally abort guard',
-        )),
-        2_000,
-      );
-    });
-
-    try {
-      await Promise.race([collectWithInterrupt(), failsafe]);
-    } finally {
-      if (failsafeTimer !== undefined) clearTimeout(failsafeTimer);
-      releaseSecondPull?.();
+      if (ev.type === 'turn.completed') break; // terminal — the consumer unblocks here
+      r = await it.next();
     }
 
-    const types = events.map((e) => e.type);
-    expect(types).toContain('paused');
-    expect(types).not.toContain('resumed');
-    // Only the first (429'd) call — the interrupt prevents any replay.
-    expect(messagesCreateMock).toHaveBeenCalledTimes(1);
-  });
+    // The interrupt unblocked the turn via a terminal event — no hang — and the
+    // generator did NOT terminate (the bug terminated it here, bricking resume).
+    expect(turn1Types).toContain('paused');
+    expect(turn1Types).not.toContain('resumed');
+    expect(r.done).toBe(false);
+    expect((r.value as ProviderEvent).type).toBe('turn.completed');
+
+    // Resumability: a fresh prompt runs a new turn. The interrupted turn was
+    // abandoned (callIdx 1 = the 429); callIdx 2 is this new prompt, NOT a
+    // replay — `resumed` never appeared.
+    prompts.push({ content: 'next' });
+    let reply = '';
+    let sawTurn2 = false;
+    r = await it.next();
+    while (!r.done) {
+      const ev = r.value as ProviderEvent;
+      if (ev.type === 'delta.text') reply += ev.text;
+      if (ev.type === 'turn.completed') {
+        sawTurn2 = true;
+        break;
+      }
+      r = await it.next();
+    }
+    expect(sawTurn2).toBe(true);
+    expect(reply).toContain('resumed after interrupt');
+    expect(callIdx).toBe(2);
+
+    prompts.close();
+    await it.return?.();
+  }, 10_000);
 
   it('2h cap: 429 with resetsAt > 2h from now → error surfaces immediately, no paused/resumed', async () => {
     messagesCreateMock.mockImplementation(() => {

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -309,6 +309,15 @@ export class AnthropicDirectQuery implements ProviderQuery {
           // entered yet, so clear the slot here. `abort.clear()` is the
           // only write path to null and uses compare-and-clear so a
           // parallel scope replacing the slot is preserved.
+          //
+          // This fires only when `begin()` drained a pending abort onto the
+          // fresh controller — i.e. an `interrupt()`/`close()` that arrived
+          // BETWEEN turns (no live controller to fire on). The REPL never
+          // interrupts between turns (the ESC soft-stop handler is per-turn
+          // and `handleSigint` fires only while `turnInFlight`), so unlike the
+          // mid-turn abort handled below, terminating here is correct and
+          // expected (covered by anthropic-direct.test.ts's pendingAbort +
+          // compact-not-blocked guards).
           this.abort.clear(controller);
           return;
         }
@@ -357,6 +366,12 @@ export class AnthropicDirectQuery implements ProviderQuery {
           onUsageProgress: (usage) => { this.state.lastUsage = usage; },
         };
 
+        // Tracks whether THIS turn yielded a terminal event (`turn.completed`
+        // → 'done', or `error`). The abort handling below synthesizes a
+        // terminal event only when the turn produced none, so the consumer's
+        // `providerIterator.next()` loop is never advanced past a turn it
+        // already saw end.
+        let turnEmittedTerminal = false;
         try {
           for await (const event of this.retry.turnWithRetries(runInput, () => this.state.closed)) {
             if (this.state.closed) return;
@@ -372,10 +387,32 @@ export class AnthropicDirectQuery implements ProviderQuery {
               // generator is resumed.
               this.abort.clear(controller);
             }
+            if (event.type === 'turn.completed' || event.type === 'error') {
+              turnEmittedTerminal = true;
+            }
             yield event;
           }
         } catch (err) {
-          if (controller.signal.aborted) return;
+          // Invariant: a `close()` terminates this generator; an `interrupt()`
+          // (ESC soft-stop) must NOT — it aborts the current turn but keeps the
+          // session alive for the next message. Both abort the per-turn
+          // controller, so distinguish on `state.closed` (only `close()` sets
+          // it), NOT on `signal.aborted` (true for both). Returning on
+          // interrupt is the "can't resume after ESC" bug: it permanently ends
+          // the shared provider iterator (AgentSession reuses ONE iterator
+          // across turns), so every later `sendMessageStream` gets `{done:true}`
+          // and silently runs no turn while slash commands — which bypass the
+          // iterator — keep working.
+          if (this.state.closed) return;
+          if (controller.signal.aborted) {
+            this.abort.clear(controller);
+            // `loop.ts` yields `turn.completed` on a graceful mid-stream abort,
+            // so a terminal event is usually already delivered. Synthesize one
+            // only if the throw pre-empted it, so the consumer unwinds instead
+            // of hanging on a `next()` that never resolves.
+            if (!turnEmittedTerminal) yield this.makeInterruptedTurnEvent();
+            continue;
+          }
           const e = err instanceof Error ? err : new Error(String(err));
           yield { type: 'error', error: e };
           return;
@@ -383,20 +420,22 @@ export class AnthropicDirectQuery implements ProviderQuery {
           this.abort.clear(controller);
         }
 
-        // Invariant: a turn aborted mid-flight must terminate this generator,
-        // not loop back for another prompt. When the turn THROWS, the catch
-        // above returns on `signal.aborted`. But an interrupt that lands during
-        // the usage-limit wait makes `turnWithRetries` return CLEANLY (no throw
-        // — see retry-layer's `if (result === 'aborted') return`), so the catch
-        // never fires and we arrive here with the signal still aborted. Without
-        // this guard the loop falls through to `promptIterator.next()` and
-        // blocks forever while the consumer (`sendMessageStreamInternal`) is
-        // still awaiting a terminal event for the aborted turn — the REPL hangs:
-        // Ctrl+C can't quit, auto-resume never re-fires, and queued input never
-        // drains. Returning yields `{done:true}` to the consumer so the turn
-        // unwinds cleanly. Mirrors the catch-path guard above. (`abort.clear`
-        // in the finally nulls the slot but does NOT reset `signal.aborted`.)
-        if (controller.signal.aborted) return;
+        // A turn that exits the loop CLEANLY (no throw) while the signal is
+        // aborted is an interrupt: `loop.ts` handles a mid-stream abort by
+        // yielding `turn.completed` and returning, and an interrupt during the
+        // usage-limit auto-resume wait makes the retry layer return cleanly
+        // (retry-layer's `if (result === 'aborted') return`) with NO terminal
+        // event. In both cases the session must survive — only `close()`
+        // (state.closed) terminates the generator. Emit a terminal event if
+        // the turn produced none (the usage-limit-wait case — the hang behind
+        // commit c462ebd, which `return` fixed at the cost of bricking resume),
+        // then loop back for the next prompt. (`abort.clear` in the finally
+        // nulls the slot but does NOT reset `signal.aborted`.)
+        if (this.state.closed) return;
+        if (controller.signal.aborted) {
+          if (!turnEmittedTerminal) yield this.makeInterruptedTurnEvent();
+          continue;
+        }
 
         // Auto-compaction: fire at the natural turn boundary — after the
         // per-turn event loop exits and the abort slot is cleared — so we
@@ -475,6 +514,27 @@ export class AnthropicDirectQuery implements ProviderQuery {
 
   async interrupt(): Promise<void> {
     this.abort.requestAbort('interrupted');
+  }
+
+  /**
+   * Synthetic terminal event for an interrupted turn that yielded none of its
+   * own. The harness consumer (`AgentSession.sendMessageStreamInternal`) breaks
+   * its shared-`providerIterator.next()` loop only on a terminal output
+   * (`turn.completed` → 'done', or `error`); without one it strands on a
+   * `next()` that never resolves. `loop.ts` already yields `turn.completed` on
+   * a normal mid-stream abort, but an interrupt during the usage-limit
+   * auto-resume wait makes the retry layer return cleanly with NO terminal
+   * event — this fills that gap so the turn unwinds while the session stays
+   * alive for the next prompt. Mirrors the OpenAI-compatible provider's
+   * `finishTurn` (openai-compatible/query.ts). Minimal usage (no
+   * `totalCostUsd`) so the budget gate in `transformProviderEvent` is skipped.
+   */
+  private makeInterruptedTurnEvent(): ProviderEvent {
+    return {
+      type: 'turn.completed',
+      usage: { stopReason: 'interrupted', resultSubtype: 'interrupted', isError: false },
+      sessionId: this.initSessionId,
+    };
   }
 
   async setModel(model?: string): Promise<void> {


### PR DESCRIPTION
## Problem

Hitting **ESC** to stop a running turn in the REPL left the session unable to start new turns: plain prompts were echoed (`▶`) but produced **no agent turn**, while slash commands (`/afk`, `/model`, `/fork`) kept working. Reported as: *"hit esc to stop mid agent-turn and it wouldn't let me send a message to resume."*

## Root cause

`AnthropicDirectQuery`'s outer multi-turn generator (`src/agent/providers/anthropic-direct/query.ts`) returned on **any** aborted per-turn controller:

```ts
} catch (err) {
  if (controller.signal.aborted) return;   // catch-path guard
  ...
}
...
if (controller.signal.aborted) return;     // post-loop guard (added in c462ebd)
```

`interrupt()` (ESC soft-stop) and `close()` **both** abort the per-turn controller via `AbortCoordinator.requestAbort(reason)` and differ only in an **un-inspected reason string**. The guards check only the `signal.aborted` *boolean*, so an ESC interrupt was treated identically to a session close and **permanently terminated the generator** — even though `state.closed` was still `false` and the `while (!this.state.closed)` loop intended to continue.

`AgentSession` reuses **one** shared `providerIterator` across every turn (created at `agent-session.ts:254`, pulled at `:518`). Once the generator returned, `.next()` yielded `{done:true}` forever, so every later `sendMessageStream` produced no events → no turn. Slash commands kept working because they bypass the iterator entirely.

The OpenAI-compatible provider already handles this correctly (`openai-compatible/query.ts:428-435,510-529`; the comment at 607-610 names "the permanent 'esc to interrupt' hang") — this brings anthropic-direct in line.

## Fix

Discriminate **interrupt** from **close** on `this.state.closed` (only `close()` sets it; `interrupt()` never does):

- **close** → `return` (terminate the generator), as before.
- **interrupt** → emit a terminal `turn.completed` **only if the turn produced none** (so the consumer's `providerIterator.next()` loop unblocks instead of hanging — the usage-limit-wait case behind c462ebd), then **`continue`** to await the next prompt, keeping the session alive.

A `turnEmittedTerminal` flag prevents double-emitting a terminal (which would brick the *next* turn). The early-return drain path (a pre-aborted controller from a between-turns abort) is deliberately left as `return` — the REPL cannot trigger a between-turns interrupt (the soft-stop handler is per-turn; `handleSigint` fires only while `turnInFlight`), and the existing pendingAbort / compact-not-blocked guards rely on it.

## Tests

- **New** `interrupt-resume.test.ts` — drives the **real** query generator across a mid-turn interrupt and asserts a second message still runs; plus a guard that a genuine (non-abort) error still terminates with an `error` event. Fails on pre-fix code (turn 2 returns `{done:true}`).
- **Updated** the c462ebd usage-limit interrupt test to the corrected contract: **yields a terminal event + stays resumable**, instead of terminating the generator (which was itself the resume bug).

## Verification

- `pnpm lint` clean; `pnpm audit:sdk:check` clean (no new SDK imports).
- Full suite green except one **pre-existing, unrelated** failure (`anthropic-direct.test.ts` `compact()` — model-alias suffix `claude-haiku-4-5` vs `claude-haiku-4-5-20251001`).
- Diff independently re-derived by an adversarial verifier: close/error termination intact, no abort-slot leak, no double-terminal, auto-compact correctly skipped on interrupt, between-turns interrupt provably unreachable from the REPL.
