### PR TITLE
feat(telemetry): tag dispatched gate skills with is_gate

### DIFF
--- a/src/agent/routing-telemetry.ts
+++ b/src/agent/routing-telemetry.ts
@@ -92,6 +92,16 @@ export interface RoutingDecisionEntry {
   /** JSON-encoded string array of unique tool names invoked (privacy: names only, no inputs). */
   tool_names?: string | undefined;
   /**
+   * True when a dispatched skill (on `skill.dispatched` rows) is a routing-hint
+   * "gate" skill (ask-gate, premise-gate, fanout-pace, …). Lets usage queries
+   * measure gate-firing through the existing event surface. Privacy: a boolean
+   * flag only — no user content. NOTE: this captures only gates invoked through
+   * the skill tool; a gate the model applies purely inline (following the
+   * routing hint without dispatching the skill) produces no row and stays
+   * uncounted — closing that requires model self-report (deliberately deferred).
+   */
+  is_gate?: boolean | undefined;
+  /**
    * Tool name for tool-level events (e.g. `tool.overflow_kill`).
    * Privacy: short identifier only (e.g. "grep", "bash") — not the tool input.
    */

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -857,10 +857,17 @@ export class SkillExecutor {
       parent_session_id: this.ctx.parentSession.sessionId,
       depth,
       mode: 'load',
-      ...(isGateSkill(name) ? { is_gate: true } : {}),
       ...(model !== undefined ? { model } : {}),
     };
-    void appendRoutingDecision({ event: 'skill.dispatched', ...base }).catch(() => {});
+    // `is_gate` rides only the `skill.dispatched` row — not the shared `base`,
+    // which also feeds the `skill.completed` emit below. Matches the field doc
+    // ("on skill.dispatched rows") and the fork path, keeping the gate flag on
+    // a single canonical row across both dispatch paths.
+    void appendRoutingDecision({
+      event: 'skill.dispatched',
+      ...base,
+      ...(isGateSkill(name) ? { is_gate: true } : {}),
+    }).catch(() => {});
     void appendRoutingDecision({
       event: 'skill.completed',
       status: 'succeeded',

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -170,6 +170,29 @@ interface SkillInput {
  * `truncate` (subagent-executor.ts:158) — kept local so each emitter owns
  * its own bounds and the telemetry helper stays schema-only.
  */
+// Invariant: "gate" skills fire as routing-hint disciplines and are frequently
+// applied INLINE — the model follows the hint without dispatching the skill
+// tool. Tagging dispatched gate invocations gives partial gate-firing
+// visibility; fully inline applications stay uncountable here without model
+// self-report. This roster is the semantic gate category — keep it in sync with
+// the routing-hint gates in the system prompt's skill-routing section.
+const GATE_SKILLS = new Set<string>([
+  'ask-gate',
+  'fanout-pace',
+  'right-size-delegation',
+  'premise-gate',
+  'intent-lock',
+  'long-bash-gate',
+  'exploration-gate',
+  'irreversible-action-gate',
+  'safe-destruct',
+  'plan-probe',
+]);
+
+function isGateSkill(name: string): boolean {
+  return GATE_SKILLS.has(name);
+}
+
 const MAX_TELEMETRY_ERROR_CHARS = 240;
 
 function truncateTelemetryString(s: string, max = MAX_TELEMETRY_ERROR_CHARS): string {
@@ -396,6 +419,7 @@ export class SkillExecutor {
       requested_name: skill.name,
       parent_session_id: this.ctx.parentSession.sessionId,
       depth,
+      ...(isGateSkill(skill.name) ? { is_gate: true } : {}),
       ...(skill.model !== undefined ? { model: skill.model } : {}),
     }).catch(() => {});
 
@@ -833,6 +857,7 @@ export class SkillExecutor {
       parent_session_id: this.ctx.parentSession.sessionId,
       depth,
       mode: 'load',
+      ...(isGateSkill(name) ? { is_gate: true } : {}),
       ...(model !== undefined ? { model } : {}),
     };
     void appendRoutingDecision({ event: 'skill.dispatched', ...base }).catch(() => {});


### PR DESCRIPTION
## Source
Port of afk-workshop#823 (private). Moat-scrubbed port, not a 1:1 copy.

## Ported (public-safe)
- src/agent/routing-telemetry.ts: add optional is_gate?: boolean to RoutingDecisionEntry (with doc comment).
- src/agent/tools/skill-executor.ts: add a GATE_SKILLS roster + isGateSkill(), and tag the two skill.dispatched emit sites (inline + load) with is_gate when the dispatched skill is a routing-hint gate.

Purely additive (+35 lines), back-compat. Gives usage visibility for gate skills through the existing event surface. Captures only gates invoked via the skill tool; gates applied purely inline (no skill-tool dispatch) produce no row (deliberately deferred).

## Dropped
Nothing — the entire source PR was public-safe (no moat files/hunks).

## Verification
- lint (tsc --noEmit): clean
- build + build:dist: clean
- Moat: deterministic guard prints MOAT GUARD CLEAN (0 HARD-denylist terms across tree + dist; no structural moat; no merge markers). Independent adversarial audit sub-agent: CLEAN.
- Test suite: this local env has 125 pre-existing failures on clean public main (baseline) that are IDENTICAL with this change applied (157 files / 125 tests both) -> the port adds ZERO regressions. Not the v4 memory.db (public is SCHEMA_VERSION 4); environmental to the porting machine. CI runs the authoritative gate.

Do not merge automatically — for human review.