### PR TITLE
feat(mcp): wire MCP servers into chat, daemon, and telegram surfaces

### DIFF
--- a/src/agent/daemon/scheduler-pull.test.ts
+++ b/src/agent/daemon/scheduler-pull.test.ts
@@ -48,18 +48,35 @@ function makeScheduler(
 let queueDir: string;
 let telemetryDir: string;
 let telemetryPath: string;
+// Isolate AFK_HOME so spawnSession's loadMcpConfig() does not pick up the
+// operator's real ~/.afk/config/mcp.json (which would try to connect real MCP
+// servers under fake timers and hang the tick). Mirrors scheduler.test.ts.
+let homeDir: string | undefined;
+let savedAfkHome: string | undefined;
+let savedAllowProjectMcp: string | undefined;
 
 beforeEach(() => {
   vi.useFakeTimers();
   queueDir = mkdtempSync(join(tmpdir(), 'afk-pull-test-queue-'));
   telemetryDir = mkdtempSync(join(tmpdir(), 'afk-pull-test-tel-'));
   telemetryPath = join(telemetryDir, 'forge-telemetry.jsonl');
+  homeDir = mkdtempSync(join(tmpdir(), 'afk-pull-test-home-'));
+  savedAfkHome = process.env['AFK_HOME'];
+  savedAllowProjectMcp = process.env['AFK_ALLOW_PROJECT_MCP'];
+  process.env['AFK_HOME'] = homeDir;
+  process.env['AFK_ALLOW_PROJECT_MCP'] = '0';
 });
 
 afterEach(async () => {
   vi.useRealTimers();
   rmSync(queueDir, { recursive: true, force: true });
   rmSync(telemetryDir, { recursive: true, force: true });
+  if (savedAfkHome === undefined) delete process.env['AFK_HOME'];
+  else process.env['AFK_HOME'] = savedAfkHome;
+  if (savedAllowProjectMcp === undefined) delete process.env['AFK_ALLOW_PROJECT_MCP'];
+  else process.env['AFK_ALLOW_PROJECT_MCP'] = savedAllowProjectMcp;
+  if (homeDir !== undefined) rmSync(homeDir, { recursive: true, force: true });
+  homeDir = undefined;
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/daemon/scheduler.test.ts
+++ b/src/agent/daemon/scheduler.test.ts
@@ -6,18 +6,60 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const schedulerTestState = vi.hoisted(() => ({ cleanupOrder: [] as string[] }));
+
+vi.mock('../providers/index.js', () => ({
+  resolveProvider: () => { throw new Error('resolveProvider is not used by scheduler tests'); },
+  providerForModel: () => 'anthropic-direct',
+}));
+
+vi.mock('../default-hook-registry.js', () => ({
+  createDefaultHookRegistry: () => ({
+    registry: undefined,
+    memoryStore: { close: () => schedulerTestState.cleanupOrder.push('memory.close') },
+  }),
+}));
+
 import { CronScheduler, daemonTraceLabel, resolveWorktreePruneRoot } from './scheduler.js';
 import { getTraceDir } from '../../paths.js';
-import type { AgentSession } from '../session/agent-session.js';
+import { AgentSession } from '../session/agent-session.js';
 import type { AgentConfig } from '../types.js';
+import type { ModelProvider, ProviderEvent, ProviderQuery, ProviderQueryArgs, ProviderUserTurn } from '../provider.js';
 import type { ExecFileFn } from '../worktree-sweep.js';
 
 function makeTmpDir(): string {
   return mkdtempSync(join(tmpdir(), 'agent-afk-scheduler-'));
 }
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const MCP_FIXTURE = resolve(__dirname, '../mcp/__fixtures__/test-server.mjs');
+
+let isolatedAfkHome: string | undefined;
+let savedAfkHome: string | undefined;
+let savedAllowProjectMcp: string | undefined;
+
+beforeEach(() => {
+  isolatedAfkHome = makeTmpDir();
+  savedAfkHome = process.env['AFK_HOME'];
+  savedAllowProjectMcp = process.env['AFK_ALLOW_PROJECT_MCP'];
+  process.env['AFK_HOME'] = isolatedAfkHome;
+  process.env['AFK_ALLOW_PROJECT_MCP'] = '0';
+});
+
+afterEach(() => {
+  if (savedAfkHome === undefined) delete process.env['AFK_HOME'];
+  else process.env['AFK_HOME'] = savedAfkHome;
+  if (savedAllowProjectMcp === undefined) delete process.env['AFK_ALLOW_PROJECT_MCP'];
+  else process.env['AFK_ALLOW_PROJECT_MCP'] = savedAllowProjectMcp;
+  if (isolatedAfkHome !== undefined) rmSync(isolatedAfkHome, { recursive: true, force: true });
+  isolatedAfkHome = undefined;
+});
 
 /**
  * Build a minimal fake AgentSession whose sendMessage() either resolves or
@@ -30,6 +72,88 @@ function makeSession(opts: { throws?: Error; response?: string }): AgentSession 
       : () => Promise.resolve({ content: opts.response ?? '' }),
     close: () => Promise.resolve(),
   } as unknown as AgentSession;
+}
+
+function makeToolSurfacingProvider(): ModelProvider {
+  return {
+    name: 'scheduler-mcp-fixture-provider',
+    query(args: ProviderQueryArgs): ProviderQuery {
+      const promptIter = args.prompt[Symbol.asyncIterator]();
+      const mcpTools = args.config.mcpManager?.getMcpToolWireNames().sort() ?? [];
+      const mcpServers = args.config.mcpManager?.getServerStates().map((s) => ({
+        name: s.serverName,
+        status: s.status,
+      })) ?? [];
+      const originalDisconnect = args.config.mcpManager?.disconnectAll.bind(args.config.mcpManager);
+      if (args.config.mcpManager && originalDisconnect) {
+        vi.spyOn(args.config.mcpManager, 'disconnectAll').mockImplementation(async () => {
+          schedulerTestState.cleanupOrder.push('mcp.disconnect');
+          await originalDisconnect();
+        });
+      }
+
+      let closed = false;
+      let closeResolve: (() => void) | undefined;
+      const closedPromise = new Promise<'__closed__'>((resolveClose) => {
+        closeResolve = () => resolveClose('__closed__');
+      });
+
+      return {
+        async *[Symbol.asyncIterator](): AsyncIterator<ProviderEvent> {
+          yield {
+            type: 'session.init',
+            info: {
+              sessionId: 'scheduler-mcp-fixture-session',
+              model: 'sonnet',
+              permissionMode: 'bypassPermissions',
+              cwd: args.config.cwd,
+              tools: mcpTools,
+              slashCommands: [],
+              skills: [],
+              plugins: [],
+              mcpServers,
+              apiKeySource: 'api-key',
+              version: 'scheduler-mcp-fixture-provider',
+            },
+          };
+
+          while (!closed) {
+            const nextOrClose = await Promise.race([promptIter.next(), closedPromise]);
+            if (nextOrClose === '__closed__') break;
+            const turn = nextOrClose as IteratorResult<ProviderUserTurn>;
+            if (turn.done) break;
+            const content = typeof turn.value.content === 'string' ? turn.value.content : '[blocks]';
+            yield { type: 'assistant.message', text: `Echo: ${content}`, sessionId: 'scheduler-mcp-fixture-session' };
+            yield {
+              type: 'turn.completed',
+              sessionId: 'scheduler-mcp-fixture-session',
+              usage: {
+                resultSubtype: 'success',
+                stopReason: 'end_turn',
+                durationMs: 1,
+                totalCostUsd: 0,
+              },
+            };
+          }
+        },
+        async interrupt() {},
+        async setModel() {},
+        async setPermissionMode() {},
+        async supportedCommands() { return []; },
+        async supportedModels() { return []; },
+        async supportedAgents() { return []; },
+        async getContextUsage() { return { tools: mcpTools, isAutoCompactEnabled: false, apiUsage: null }; },
+        async mcpServerStatus() { return mcpServers; },
+        async accountInfo() { return { subscriptionType: 'api-key' }; },
+        async rewindFiles() { return { canRewind: false }; },
+        close() {
+          schedulerTestState.cleanupOrder.push('session.close');
+          closed = true;
+          closeResolve?.();
+        },
+      };
+    },
+  };
 }
 
 describe('CronScheduler telemetry — errorMessage redaction', () => {
@@ -262,6 +386,83 @@ describe('CronScheduler — witness trace-writer wiring', () => {
 
     await scheduler.stop();
   });
+});
+
+describe('CronScheduler — MCP fixture wiring', () => {
+  it(
+    'spawns a headless AgentSession with fixture mcp__ tools and cleans up session before MCP before memory',
+    async () => {
+      const dir = makeTmpDir();
+      const telemetryPath = join(dir, 'forge-telemetry.jsonl');
+      const savedHome = process.env['AFK_HOME'];
+      const savedTraceDisabled = process.env['AFK_TRACE_DISABLED'];
+      const savedAllowProjectMcp = process.env['AFK_ALLOW_PROJECT_MCP'];
+      process.env['AFK_HOME'] = dir;
+      process.env['AFK_TRACE_DISABLED'] = '1';
+      process.env['AFK_ALLOW_PROJECT_MCP'] = '1';
+      writeFileSync(
+        join(dir, '.mcp.json'),
+        JSON.stringify({
+          mcpServers: {
+            testsrv: {
+              type: 'stdio',
+              command: process.execPath,
+              args: [MCP_FIXTURE],
+            },
+          },
+        }),
+        'utf-8',
+      );
+
+      schedulerTestState.cleanupOrder.length = 0;
+
+      let scheduler: CronScheduler | undefined;
+      let capturedConfig: AgentConfig | undefined;
+      let spawnedSession: AgentSession | undefined;
+      try {
+        scheduler = new CronScheduler({
+          telemetryPath,
+          sessionConfig: { cwd: dir, provider: makeToolSurfacingProvider() },
+          sessionFactory: (config) => {
+            capturedConfig = config;
+            spawnedSession = new AgentSession(config);
+            return spawnedSession;
+          },
+        });
+        scheduler.register({
+          taskId: 'scheduler-mcp-fixture',
+          command: 'hello fixture mcp',
+          trigger: 'cron',
+          cronExpression: '* * * * *',
+        });
+
+        const record = await scheduler.tick('scheduler-mcp-fixture');
+
+        expect(record.status).toBe('success');
+        expect(capturedConfig?.isNonInteractive).toBe(true);
+        expect(capturedConfig?.permissionMode).toBe('bypassPermissions');
+        expect(spawnedSession?.getSessionMetadata().tools?.sort()).toEqual([
+          'mcp__testsrv__add',
+          'mcp__testsrv__boom',
+          'mcp__testsrv__echo',
+        ]);
+        expect(spawnedSession?.getSessionMetadata().mcpServers).toEqual([
+          { name: 'testsrv', status: 'connected' },
+        ]);
+        expect(schedulerTestState.cleanupOrder).toEqual(['session.close', 'mcp.disconnect', 'memory.close']);
+      } finally {
+        await scheduler?.stop();
+        if (savedHome === undefined) delete process.env['AFK_HOME'];
+        else process.env['AFK_HOME'] = savedHome;
+        if (savedTraceDisabled === undefined) delete process.env['AFK_TRACE_DISABLED'];
+        else process.env['AFK_TRACE_DISABLED'] = savedTraceDisabled;
+        if (savedAllowProjectMcp === undefined) delete process.env['AFK_ALLOW_PROJECT_MCP'];
+        else process.env['AFK_ALLOW_PROJECT_MCP'] = savedAllowProjectMcp;
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+    { timeout: 15_000 },
+  );
 });
 
 describe('daemonTraceLabel', () => {

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -31,6 +31,7 @@ import { loadHooksConfig } from '../hooks/config-loader.js';
 import { createDefaultTraceWriter } from '../trace/factory.js';
 import { MemoryStore, injectHotMemory } from '../memory/index.js';
 import { McpManager, loadMcpConfig } from '../mcp/index.js';
+import { loadImportFromConfig, resolveImportedRoots } from '../../config/import-sources.js';
 import type { AgentConfig } from '../types.js';
 import { getTelemetryPath } from '../../paths.js';
 import { redactInlineSecrets } from '../session/prompt-dump.js';
@@ -492,15 +493,33 @@ export class CronScheduler {
     const trace = createDefaultTraceWriter({ sessionLabel: daemonTraceLabel(taskId) });
 
     let mcpManager: McpManager | undefined;
-    const loadedMcp = loadMcpConfig({ cwd: agentCwd });
+    // Mirror the chat / telegram / interactive surfaces: include MCP configs
+    // contributed by imported roots so the daemon reaches the same MCP
+    // surface-parity, not just cwd `.mcp.json` + the global config.
+    const importedMcpConfigs = resolveImportedRoots(loadImportFromConfig())
+      .mcpConfigs.filter((c) => c.format === 'json')
+      .map((c) => c.source);
+    const loadedMcp = loadMcpConfig({
+      cwd: agentCwd,
+      ...(importedMcpConfigs.length > 0 ? { importedMcpConfigs } : {}),
+    });
     const enabledMcpCount = Object.values(loadedMcp.mcpServers).filter((s) => !s.disabled).length;
-    if (enabledMcpCount > 0) {
-      mcpManager = await McpManager.fromConfig(loadedMcp.mcpServers, {
-        warnings: loadedMcp.warnings,
-        ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
-      });
-    } else if (loadedMcp.warnings.length > 0) {
-      for (const warning of loadedMcp.warnings) console.warn(`[mcp] ${warning}`);
+    try {
+      if (enabledMcpCount > 0) {
+        mcpManager = await McpManager.fromConfig(loadedMcp.mcpServers, {
+          warnings: loadedMcp.warnings,
+          ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
+        });
+      } else if (loadedMcp.warnings.length > 0) {
+        for (const warning of loadedMcp.warnings) console.warn(`[mcp] ${warning}`);
+      }
+    } catch (err) {
+      // McpManager.fromConfig re-throws when an `alwaysLoad` server fails to
+      // connect. runOnce()'s finally cannot close this tick's MemoryStore
+      // (its local is still null until spawnSession returns), so close it here
+      // to avoid orphaning the SQLite handle on a connect failure.
+      memoryStore.close();
+      throw err;
     }
 
     const config: AgentConfig = {
@@ -536,6 +555,10 @@ export class CronScheduler {
       if (mcpManager) {
         await mcpManager.disconnectAll().catch(() => undefined);
       }
+      // Session construction failed after MCP connected — close this tick's
+      // MemoryStore too (runOnce()'s finally can't, per the fromConfig catch
+      // above) so it is not orphaned.
+      memoryStore.close();
       throw err;
     }
   }

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -30,6 +30,7 @@ import { createDefaultHookRegistry } from '../default-hook-registry.js';
 import { loadHooksConfig } from '../hooks/config-loader.js';
 import { createDefaultTraceWriter } from '../trace/factory.js';
 import { MemoryStore, injectHotMemory } from '../memory/index.js';
+import { McpManager, loadMcpConfig } from '../mcp/index.js';
 import type { AgentConfig } from '../types.js';
 import { getTelemetryPath } from '../../paths.js';
 import { redactInlineSecrets } from '../session/prompt-dump.js';
@@ -319,11 +320,13 @@ export class CronScheduler {
 
     let session: AgentSession | null = null;
     let memoryStore: MemoryStore | null = null;
+    let mcpManager: McpManager | null = null;
     this.idleDetector.increment();
     try {
-      const spawned = this.spawnSession(task.taskId);
+      const spawned = await this.spawnSession(task.taskId);
       session = spawned.session;
       memoryStore = spawned.memoryStore;
+      mcpManager = spawned.mcpManager ?? null;
       const response = await session.sendMessage(task.command);
       const responseText = redactInlineSecrets(response.content);
       const record: TelemetryRecord = {
@@ -350,6 +353,13 @@ export class CronScheduler {
           await session.close();
         } catch {
           // already-closed sessions throw; ignore.
+        }
+      }
+      if (mcpManager) {
+        try {
+          await mcpManager.disconnectAll();
+        } catch {
+          // MCP server shutdown is best-effort during daemon tick teardown.
         }
       }
       memoryStore?.close();
@@ -454,7 +464,11 @@ export class CronScheduler {
     }
   }
 
-  private spawnSession(taskId: string): { session: AgentSession; memoryStore: MemoryStore } {
+  private async spawnSession(taskId: string): Promise<{
+    session: AgentSession;
+    memoryStore: MemoryStore;
+    mcpManager?: McpManager;
+  }> {
     // Derive a unique-per-tick sessionId (daemonTraceLabel appends a random
     // suffix, so each tick gets its own label) so hook commands receive a
     // non-empty AFK_SESSION_ID and traces stay greppable by task name.
@@ -476,6 +490,19 @@ export class CronScheduler {
     // daemonTraceLabel) so traces are greppable by task name while each tick
     // still gets its own trace dir.
     const trace = createDefaultTraceWriter({ sessionLabel: daemonTraceLabel(taskId) });
+
+    let mcpManager: McpManager | undefined;
+    const loadedMcp = loadMcpConfig({ cwd: agentCwd });
+    const enabledMcpCount = Object.values(loadedMcp.mcpServers).filter((s) => !s.disabled).length;
+    if (enabledMcpCount > 0) {
+      mcpManager = await McpManager.fromConfig(loadedMcp.mcpServers, {
+        warnings: loadedMcp.warnings,
+        ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
+      });
+    } else if (loadedMcp.warnings.length > 0) {
+      for (const warning of loadedMcp.warnings) console.warn(`[mcp] ${warning}`);
+    }
+
     const config: AgentConfig = {
       model: 'sonnet',
       // Daemon-spawned sessions run autonomously and require tool use without
@@ -495,14 +522,22 @@ export class CronScheduler {
       // sessionConfig.traceWriter still wins (escape-hatch parity with
       // permissionMode).
       ...(trace ? { traceWriter: trace.writer } : {}),
+      ...(mcpManager !== undefined ? { mcpManager } : {}),
       // sessionConfig may override permissionMode if the operator explicitly
       // wants a different mode for daemon tasks (intentional escape hatch).
       ...this.options.sessionConfig,
     };
-    const session = this.options.sessionFactory
-      ? this.options.sessionFactory(config)
-      : new AgentSession(injectHotMemory(config));
-    return { session, memoryStore };
+    try {
+      const session = this.options.sessionFactory
+        ? this.options.sessionFactory(config)
+        : new AgentSession(injectHotMemory(config));
+      return { session, memoryStore, ...(mcpManager !== undefined ? { mcpManager } : {}) };
+    } catch (err) {
+      if (mcpManager) {
+        await mcpManager.disconnectAll().catch(() => undefined);
+      }
+      throw err;
+    }
   }
 
   private telemetryPath(): string {

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -152,6 +152,13 @@ export interface AgentConfig {
    */
   mcpServers?: Record<string, import('../mcp/types.js').McpServerConfig>;
 
+  /**
+   * Live MCP manager for the session. Entry points that own MCP lifecycle
+   * construct this with `McpManager.fromConfig()` and close it after the
+   * AgentSession shuts down; provider/session wiring only consumes it.
+   */
+  mcpManager?: import('../mcp/index.js').McpManager;
+
   /** Subagent definitions. Passed through when SDK V2 supports it. */
   agents?: Record<string, AgentDefinition>;
 

--- a/src/cli/commands/chat.mcp.test.ts
+++ b/src/cli/commands/chat.mcp.test.ts
@@ -1,17 +1,26 @@
 /**
- * Tests for stdin input resolution in `afk chat`.
+ * Focused regression tests for one-shot chat MCP behavior in `afk chat`.
  *
- * Covers: `-` sentinel, pipe-auto-detect (omitted arg + piped stdin),
- * literal arg pass-through, and TTY-stdin error.
+ * Verifies that configuring an MCP server (using the stdio fixture) wires
+ * the MCP tools into the provider's allowedTools set, and that omitting config
+ * leaves the default (no MCP tools) behavior unchanged.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Command } from 'commander';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import type { OutputEvent } from '../../agent/types/session-types.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const FIXTURE = resolve(__dirname, '../../agent/mcp/__fixtures__/test-server.mjs');
 
 async function* makeStream(events: OutputEvent[]): AsyncIterable<OutputEvent> {
   for (const event of events) {
@@ -20,7 +29,7 @@ async function* makeStream(events: OutputEvent[]): AsyncIterable<OutputEvent> {
 }
 
 // ---------------------------------------------------------------------------
-// Mocks — must be hoisted above module imports.
+// Mocks — hoisted above module imports.
 // ---------------------------------------------------------------------------
 
 vi.mock('../../agent/session.js', () => {
@@ -58,13 +67,6 @@ vi.mock('../shared-helpers.js', () => ({
   loadSystemPrompt: vi.fn(() => undefined),
   loadConfigSystemPrompt: vi.fn(() => undefined),
   resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
-}));
-
-vi.mock('../../agent/mcp/index.js', () => ({
-  McpManager: {
-    fromConfig: vi.fn(),
-  },
-  loadMcpConfig: vi.fn(() => ({ mcpServers: {}, sources: [], warnings: [] })),
 }));
 
 vi.mock('../../agent/routing-directive.js', () => ({
@@ -154,11 +156,19 @@ vi.mock('../slash/session-stats.js', () => ({
   recordTurn: vi.fn(() => ({ user: '', assistant: '', timestamp: Date.now() })),
 }));
 
+// We also mock the import config logic to return empty lists so we only load our override mcp config
+vi.mock('../../config/import-sources.js', () => ({
+  loadImportFromConfig: vi.fn(() => ({})),
+  resolveImportedRoots: vi.fn(() => ({ mcpConfigs: [] })),
+}));
+
 // ---------------------------------------------------------------------------
 // Import after mocks
 // ---------------------------------------------------------------------------
 
 import { AgentSession } from '../../agent/session.js';
+import { AnthropicDirectProvider } from '../../agent/providers/anthropic-direct/index.js';
+import { McpManager } from '../../agent/mcp/index.js';
 import { registerChatCommand } from './chat.js';
 
 // ---------------------------------------------------------------------------
@@ -172,150 +182,96 @@ async function runChat(...args: string[]): Promise<void> {
   await program.parseAsync(['node', 'afk', 'chat', ...args]);
 }
 
-/** Capture stderr lines written during fn(). */
-async function captureStderr(fn: () => Promise<void>): Promise<string> {
-  const chunks: string[] = [];
-  const spy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
-    chunks.push(String(chunk));
-    return true;
-  });
-  try {
-    await fn();
-  } catch {
-    // ignore — we just want stderr
-  } finally {
-    spy.mockRestore();
-  }
-  return chunks.join('');
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('afk chat — stdin input', () => {
+describe('afk chat — MCP integration', () => {
+  let tempDir: string;
+  let mcpConfigPath: string;
+  const originalIsTTY = process.stdin.isTTY;
+
   beforeEach(() => {
     vi.mocked(AgentSession).mockClear();
+    vi.mocked(AnthropicDirectProvider).mockClear();
+    // Force non-TTY for headless runChat execution
+    // @ts-expect-error - overriding readonly property for tests
+    process.stdin.isTTY = false;
+    process.exitCode = undefined;
+
+    tempDir = mkdtempSync(join(tmpdir(), 'afk-chat-mcp-test-'));
+    vi.stubEnv('AFK_HOME', tempDir);
+    mcpConfigPath = join(tempDir, 'mcp.json');
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
-    // Reset process.exitCode after each test.
+    // @ts-expect-error - restore
+    process.stdin.isTTY = originalIsTTY;
     process.exitCode = undefined;
+    vi.unstubAllEnvs();
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
   });
 
-  it('passes a literal positional message directly', async () => {
-    vi.mocked(AgentSession).mockImplementationOnce(() => ({
-      close: vi.fn().mockResolvedValue(undefined),
-      sendMessage: vi.fn().mockResolvedValue({ content: 'pong', timestamp: new Date() }),
-      sendMessageStream: vi.fn().mockReturnValue(makeStream([{ type: 'done' }])),
-      getLastResponseMetadata: vi.fn().mockReturnValue(null),
-      getInputStreamRef: vi.fn().mockReturnValue({ pushUserMessage: vi.fn() }),
-      sessionId: 'mock-session-id',
-      abortSignal: new AbortController().signal,
-    }));
+  it('wires up MCP servers, handshake succeeds, exposes tools, and disconnects after session close', async () => {
+    const disconnectSpy = vi.spyOn(McpManager.prototype, 'disconnectAll');
+    try {
+      const mcpConfig = {
+        mcpServers: {
+          testsrv: {
+            type: 'stdio',
+            command: process.execPath,
+            args: [FIXTURE],
+          },
+        },
+      };
+      writeFileSync(mcpConfigPath, JSON.stringify(mcpConfig), 'utf-8');
 
+      await runChat('hello world', '--mcp-config', mcpConfigPath, '--format', 'json');
+
+      // Verify AnthropicDirectProvider was initialized with the MCP tools.
+      expect(vi.mocked(AnthropicDirectProvider)).toHaveBeenCalled();
+      const firstCallArgs = vi.mocked(AnthropicDirectProvider).mock.calls[0]?.[0];
+      expect(firstCallArgs).toBeDefined();
+      expect(firstCallArgs?.permissions?.allowedTools).toEqual(
+        expect.arrayContaining([
+          'mcp__testsrv__add',
+          'mcp__testsrv__boom',
+          'mcp__testsrv__echo',
+        ]),
+      );
+
+      // Verify that the provider also received mcpManager.
+      expect(firstCallArgs?.mcpManager).toBeDefined();
+
+      // Verify cleanup ordering: the agent session closes before MCP children disconnect.
+      const sessionInstance = vi.mocked(AgentSession).mock.results[0]?.value as { close: ReturnType<typeof vi.fn> } | undefined;
+      expect(sessionInstance?.close).toHaveBeenCalledTimes(1);
+      expect(disconnectSpy).toHaveBeenCalledTimes(1);
+      expect(sessionInstance!.close.mock.invocationCallOrder[0]).toBeLessThan(
+        disconnectSpy.mock.invocationCallOrder[0]!,
+      );
+    } finally {
+      disconnectSpy.mockRestore();
+    }
+  }, 15000);
+
+  it('no-config behavior remains unchanged and does not register MCP tools', async () => {
+    // We pass an empty configuration file or no --mcp-config flag
     await runChat('hello world', '--format', 'json');
 
-    const instance = vi.mocked(AgentSession).mock.results[0]?.value as
-      { sendMessage: ReturnType<typeof vi.fn> } | undefined;
-    expect(instance?.sendMessage).toHaveBeenCalledWith('hello world', expect.anything());
-  });
+    expect(vi.mocked(AnthropicDirectProvider)).toHaveBeenCalled();
+    const firstCallArgs = vi.mocked(AnthropicDirectProvider).mock.calls[0]?.[0];
+    expect(firstCallArgs).toBeDefined();
 
-  it('reads from stdin when arg is `-` and stdin is a pipe', async () => {
-    // Simulate a piped stdin stream.
-    const originalIsTTY = process.stdin.isTTY;
-    // @ts-expect-error — forcing non-TTY for test
-    process.stdin.isTTY = false;
+    // Verify no mcp__ tools are present in allowedTools
+    const mcpTools = firstCallArgs?.permissions?.allowedTools.filter((t: string) => t.startsWith('mcp__'));
+    expect(mcpTools).toEqual([]);
 
-    let stdinData = '';
-    vi.mocked(AgentSession).mockImplementationOnce(() => ({
-      close: vi.fn().mockResolvedValue(undefined),
-      sendMessage: vi.fn().mockImplementation((msg: string) => {
-        stdinData = msg;
-        return Promise.resolve({ content: 'ok', timestamp: new Date() });
-      }),
-      sendMessageStream: vi.fn().mockReturnValue(makeStream([{ type: 'done' }])),
-      getLastResponseMetadata: vi.fn().mockReturnValue(null),
-      getInputStreamRef: vi.fn().mockReturnValue({ pushUserMessage: vi.fn() }),
-      sessionId: 'mock-session-id',
-      abortSignal: new AbortController().signal,
-    }));
-
-    // Stub process.stdin to emit "piped content\n" then end.
-    const { Readable } = await import('node:stream');
-    const mockStdin = new Readable({ read() {} });
-    const originalStdin = process.stdin;
-    Object.defineProperty(process, 'stdin', { value: mockStdin, configurable: true });
-
-    const runPromise = runChat('-', '--format', 'json');
-    mockStdin.push('piped content\n');
-    mockStdin.push(null); // EOF
-    await runPromise;
-
-    Object.defineProperty(process, 'stdin', { value: originalStdin, configurable: true });
-    // @ts-expect-error
-    process.stdin.isTTY = originalIsTTY;
-
-    expect(stdinData).toBe('piped content');
-  });
-
-  it('errors when `-` is used and stdin is a TTY', async () => {
-    const originalIsTTY = process.stdin.isTTY;
-    // @ts-expect-error
-    process.stdin.isTTY = true;
-
-    const stderr = await captureStderr(() => runChat('-', '--format', 'json'));
-
-    // @ts-expect-error
-    process.stdin.isTTY = originalIsTTY;
-
-    expect(stderr).toContain('no stdin available');
-    expect(process.exitCode).toBe(1);
-  });
-
-  it('errors when no message is supplied and stdin is a TTY', async () => {
-    const originalIsTTY = process.stdin.isTTY;
-    // @ts-expect-error
-    process.stdin.isTTY = true;
-
-    const stderr = await captureStderr(() => runChat('--format', 'json'));
-
-    // @ts-expect-error
-    process.stdin.isTTY = originalIsTTY;
-
-    expect(stderr).toMatch(/missing message/);
-    expect(process.exitCode).toBe(1);
-  });
-
-  // Regression: readStdin used to hang forever when stdin had already reached
-  // EOF before the call (process.stdin.readableEnded === true). The fix
-  // resolves with '' synchronously; the empty-message guard then exits 1.
-  it('exits cleanly when stdin reached EOF before the handler ran', async () => {
-    const originalIsTTY = process.stdin.isTTY;
-    // @ts-expect-error
-    process.stdin.isTTY = false;
-
-    const { Readable } = await import('node:stream');
-    const endedStdin = new Readable({ read() {} });
-    endedStdin.push(null); // EOF immediately
-    // Wait one tick so the stream transitions to readableEnded=true.
-    await new Promise<void>((r) => setImmediate(r));
-
-    const originalStdin = process.stdin;
-    Object.defineProperty(process, 'stdin', { value: endedStdin, configurable: true });
-
-    // Tight timeout to fail loudly if the regression returns and readStdin hangs.
-    const stderr = await Promise.race([
-      captureStderr(() => runChat('-', '--format', 'json')),
-      new Promise<string>((_, rej) => setTimeout(() => rej(new Error('readStdin hung')), 2000)),
-    ]);
-
-    Object.defineProperty(process, 'stdin', { value: originalStdin, configurable: true });
-    // @ts-expect-error
-    process.stdin.isTTY = originalIsTTY;
-
-    expect(stderr).toMatch(/message is empty/);
-    expect(process.exitCode).toBe(1);
-  });
+    // Verify no mcpManager is passed
+    expect(firstCallArgs?.mcpManager).toBeUndefined();
+  }, 15000);
 });

--- a/src/cli/commands/chat.post.test.ts
+++ b/src/cli/commands/chat.post.test.ts
@@ -68,6 +68,13 @@ vi.mock('../shared-helpers.js', () => ({
   resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
 }));
 
+vi.mock('../../agent/mcp/index.js', () => ({
+  McpManager: {
+    fromConfig: vi.fn(),
+  },
+  loadMcpConfig: vi.fn(() => ({ mcpServers: {}, sources: [], warnings: [] })),
+}));
+
 vi.mock('../../agent/routing-directive.js', () => ({
   assembleSystemPrompt: vi.fn(() => undefined),
 }));

--- a/src/cli/commands/chat.resume.test.ts
+++ b/src/cli/commands/chat.resume.test.ts
@@ -94,6 +94,13 @@ vi.mock('../shared-helpers.js', () => ({
   resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
 }));
 
+vi.mock('../../agent/mcp/index.js', () => ({
+  McpManager: {
+    fromConfig: vi.fn(),
+  },
+  loadMcpConfig: vi.fn(() => ({ mcpServers: {}, sources: [], warnings: [] })),
+}));
+
 vi.mock('../../agent/routing-directive.js', () => ({
   assembleSystemPrompt: vi.fn(() => undefined),
 }));

--- a/src/cli/commands/chat.stream-json.test.ts
+++ b/src/cli/commands/chat.stream-json.test.ts
@@ -76,6 +76,13 @@ vi.mock('../shared-helpers.js', () => ({
   resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
 }));
 
+vi.mock('../../agent/mcp/index.js', () => ({
+  McpManager: {
+    fromConfig: vi.fn(),
+  },
+  loadMcpConfig: vi.fn(() => ({ mcpServers: {}, sources: [], warnings: [] })),
+}));
+
 vi.mock('../../agent/routing-directive.js', () => ({
   assembleSystemPrompt: vi.fn(
     (_base: unknown, _routing: unknown, _surface: unknown) => undefined,

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -34,6 +34,10 @@ import { saveSession, findSession } from '../session-store.js';
 import { createSessionStats, recordTurn } from '../slash/session-stats.js';
 import { runReviewPostPublish, parsePostTargets, type PostTarget } from '../slash/_lib/review-post.js';
 import type { Writer } from '../slash/types.js';
+import { McpManager, loadMcpConfig } from '../../agent/mcp/index.js';
+import { loadImportFromConfig, resolveImportedRoots } from '../../config/import-sources.js';
+import { emitSessionPhase } from '../../agent/trace/emit.js';
+
 
 /** Loose UUID format check: 8-4-4-4-12 hex groups separated by dashes. */
 function isUuidShaped(s: string): boolean {
@@ -148,6 +152,7 @@ export function registerChatCommand(program: Command): void {
       '--worktree-base <ref>',
       'Base git ref for the worktree created by --worktree. Default: the remote\'s default branch (origin/main), fetched fresh. Pass HEAD to base on your local checkout instead. Also: AFK_WORKTREE_BASE.',
     )
+    .option('--mcp-config <path>', 'Path to an additional MCP config file (highest priority — merges over ~/.afk/config/mcp.json, project-local .mcp.json, and plugin-contributed configs). File format identical to mcp.json.')
     .option('--resume <id>', 'Resume a persisted session by id')
     .option('--continue', 'Continue the most recent persisted session in cwd')
     .option('--session-id <uuid>', 'Assign a specific UUID to this session (creates new; errors if already exists)')
@@ -168,6 +173,7 @@ export function registerChatCommand(program: Command): void {
       dumpPrompt?: string | boolean;
       worktree?: string | true;
       worktreeBase?: string;
+      mcpConfig?: string;
       resume?: string;
       continue?: boolean;
       sessionId?: string;
@@ -258,6 +264,7 @@ export function registerChatCommand(program: Command): void {
       let sharedMemoryStore: MemoryStore | undefined;
       let worktreeHandle: Awaited<ReturnType<typeof setupWorktree>> | undefined;
       let worktreeCwd: string | undefined;
+      let mcpManager: McpManager | undefined;
       // Whether this run should persist a session sidecar on exit.
       // True only when a session flag (--resume / --continue / --session-id) is set.
       let shouldPersist = false;
@@ -549,17 +556,70 @@ export function registerChatCommand(program: Command): void {
 
         sharedMemoryStore = new MemoryStore();
 
-        // Pass sharedMemoryStore into parseProvider so that when --provider
-        // anthropic-direct is explicit, both paths share the same SQLite DB
-        // (C7 fix: avoid dual MemoryStore instances on the same file).
-        provider = parseProvider(options.provider, { subagentExecutor, skillExecutor, composeExecutor, memoryStore: sharedMemoryStore, model: String(options.model), ...(cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: cliConfig.openaiBaseUrl } : {}) })
+        {
+          const projectCwd = worktreeCwd ?? process.cwd();
+          const importedMcpConfigs = resolveImportedRoots(loadImportFromConfig())
+            .mcpConfigs.filter((c) => c.format === 'json')
+            .map((c) => c.source);
+          const loaded = loadMcpConfig({
+            cwd: projectCwd,
+            ...(importedMcpConfigs.length > 0 ? { importedMcpConfigs } : {}),
+            ...(options.mcpConfig !== undefined ? { cliOverride: options.mcpConfig } : {}),
+          });
+          const enabledCount = Object.values(loaded.mcpServers).filter((s) => !s.disabled).length;
+          if (enabledCount > 0) {
+            const mcpStartedAt = Date.now();
+            void emitSessionPhase(trace?.writer, {
+              phase: 'mcp_connect_start',
+              metadata: { serverCount: enabledCount },
+            });
+            try {
+              mcpManager = await McpManager.fromConfig(loaded.mcpServers, {
+                warnings: loaded.warnings,
+                ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
+              });
+            } finally {
+              void emitSessionPhase(trace?.writer, {
+                phase: 'mcp_connect_done',
+                durationMs: Date.now() - mcpStartedAt,
+                metadata: { serverCount: enabledCount },
+              });
+            }
+          } else if (loaded.warnings.length > 0) {
+            for (const w of loaded.warnings) {
+              process.stderr.write(`[mcp] ${w}\n`);
+            }
+          }
+        }
+
+        const mcpToolWireNames = mcpManager?.getMcpToolWireNames() ?? [];
+        provider = parseProvider(options.provider, {
+          subagentExecutor,
+          skillExecutor,
+          composeExecutor,
+          memoryStore: sharedMemoryStore,
+          model: String(options.model),
+          ...(cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: cliConfig.openaiBaseUrl } : {}),
+          ...(mcpManager !== undefined ? { mcpManager } : {}),
+        })
           ?? new AnthropicDirectProvider({
-            permissions: { allowedTools: [...BUILTIN_TOOL_NAMES, ...MEMORY_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, 'agent', 'skill', 'compose'] },
+            permissions: {
+              allowedTools: [
+                ...BUILTIN_TOOL_NAMES,
+                ...MEMORY_TOOL_NAMES,
+                ...AWARENESS_TOOL_NAMES,
+                'agent',
+                'skill',
+                'compose',
+                ...mcpToolWireNames,
+              ],
+            },
             subagentExecutor,
             skillExecutor,
             composeExecutor,
             memoryStore: sharedMemoryStore,
             surface: 'cli',
+            ...(mcpManager !== undefined ? { mcpManager } : {}),
           });
 
 
@@ -796,6 +856,9 @@ export function registerChatCommand(program: Command): void {
               /* best-effort — never mask the run's real outcome */
             }
           }
+        }
+        if (mcpManager) {
+          await mcpManager.disconnectAll();
         }
         sharedMemoryStore?.close();
         // Worktree cleanup: session close must finish before

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -159,6 +159,8 @@ export function buildDaemonSessionFactory(
     });
 
     memoryStore ??= new MemoryStore();
+    const mcpManager = config.mcpManager;
+    const mcpToolWireNames = mcpManager?.getMcpToolWireNames() ?? [];
 
     const provider = parseProvider(undefined, {
       subagentExecutor,
@@ -167,15 +169,17 @@ export function buildDaemonSessionFactory(
       memoryStore,
       model: String(opts.model),
       ...(opts.openaiBaseUrl !== undefined ? { openaiBaseUrl: opts.openaiBaseUrl } : {}),
+      ...(mcpManager !== undefined ? { mcpManager } : {}),
     }) ?? new AnthropicDirectProvider({
       permissions: {
-        allowedTools: [...BUILTIN_TOOL_NAMES, ...MEMORY_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, 'agent', 'skill', 'compose'],
+        allowedTools: [...BUILTIN_TOOL_NAMES, ...MEMORY_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, 'agent', 'skill', 'compose', ...mcpToolWireNames],
       },
       subagentExecutor,
       skillExecutor,
       composeExecutor,
       memoryStore,
       surface: 'daemon',
+      ...(mcpManager !== undefined ? { mcpManager } : {}),
     });
 
     return new AgentSession(injectHotMemory({

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -55,6 +55,7 @@ import { BUILTIN_TOOL_NAMES } from './agent/tools/schemas.js';
 import { MEMORY_TOOL_NAMES } from './agent/memory/index.js';
 import { AWARENESS_TOOL_NAMES } from './agent/awareness/index.js';
 import { createChildProviderFactory, createChildSkillExecutorFactory } from './agent/tools/nesting.js';
+import { attachMcpCleanup, loadTelegramMcpManager } from './telegram/mcp-session.js';
 
 // Capture version once at module load. Used by checkVersionDrift on each stats tick.
 // One level up from dist/ reaches project root where package.json lives.
@@ -229,15 +230,18 @@ async function main() {
         typeof overlayPrompt === 'string' ? overlayPrompt : undefined,
       );
 
-      let directProvider;
-      if (!isCodex) {
+      const sessionCwd = sessionConfig.cwd ?? telegramCwd;
+      const mcpManager = await loadTelegramMcpManager(sessionCwd);
+      let returnedSession: AgentSession | undefined;
+      try {
+        let directProvider;
+        if (!isCodex) {
         let boundSession: AgentSession | undefined;
         const telegramApiKey = sessionConfig.apiKey ?? config.apiKey ?? '';
         const telegramBaseUrl = config.baseUrl;
         // Inherit configured-or-host cwd so forked subagents stay in the
         // same working tree as the parent session — important when the
         // bot is pointed at a worktree via AFK_TELEGRAM_CWD.
-        const sessionCwd = sessionConfig.cwd ?? telegramCwd;
         const rootManager = new SubagentManager({
           apiKey: telegramApiKey,
           ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
@@ -325,12 +329,21 @@ async function main() {
           systemPrompt: layeredBasePrompt ?? '',
         });
 
-        const allowedTools = [...BUILTIN_TOOL_NAMES, ...MEMORY_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, 'agent', 'skill', 'compose'];
+        const allowedTools = [
+          ...BUILTIN_TOOL_NAMES,
+          ...MEMORY_TOOL_NAMES,
+          ...AWARENESS_TOOL_NAMES,
+          'agent',
+          'skill',
+          'compose',
+          ...(mcpManager?.getMcpToolWireNames() ?? []),
+        ];
         directProvider = new AnthropicDirectProvider({
           permissions: { allowedTools },
           subagentExecutor,
           skillExecutor,
           composeExecutor,
+          ...(mcpManager !== undefined ? { mcpManager } : {}),
           // Tag the presence file (~/.afk/state/presence/<id>.json) and
           // get_runtime_state as the Telegram surface. Without this the provider
           // defaults to 'cli' (anthropic-direct/index.ts) and `/watch`
@@ -359,7 +372,7 @@ async function main() {
           { cwd: sessionCwd !== undefined && sessionCwd.length > 0 ? sessionCwd : undefined },
           () => sessionCwd,
         );
-        const session = constructTelegramSession({
+        const session = attachMcpCleanup(constructTelegramSession({
           ...(sessionConfig.apiKey !== undefined ? { apiKey: sessionConfig.apiKey } : {}),
           model: sessionConfig.model,
           ...(systemPromptInner !== undefined ? { systemPrompt: systemPromptInner } : {}),
@@ -371,7 +384,8 @@ async function main() {
           ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
           provider: directProvider,
           hookRegistry: telegramHookBundle.registry,
-        });
+        }), mcpManager);
+        returnedSession = session;
         // Wire the path-approval grant ref to the provider so elicitation
         // approvals mutate readRoots / writeRoots on the right backend.
         telegramHookBundle.pathApprovalGrantRef.current = directProvider;
@@ -388,7 +402,7 @@ async function main() {
         ? assembleSystemPrompt(rawPrompt, telegramAutoRouting, 'telegram', pendingBriefContext())
         : rawPrompt;
       // Codex branch: same cwd resolution as the Anthropic branch above.
-      const codexSessionCwd = sessionConfig.cwd ?? telegramCwd;
+      const codexSessionCwd = sessionCwd;
 
       // permissionMode is intentionally omitted here: AgentSession defaults
       // to 'default' (post-C2 fix), which is the correct mode for Telegram
@@ -403,7 +417,10 @@ async function main() {
       // sessions (PR #202 review H1). surface:'telegram' is the lone constructor
       // arg — there is no per-query surface field — and prevents the presence
       // file mis-labeling Telegram sessions as 'cli' in `/watch`.
-      const codexProvider = new OpenAICompatibleProvider({ surface: 'telegram' });
+      const codexProvider = new OpenAICompatibleProvider({
+        surface: 'telegram',
+        ...(mcpManager !== undefined ? { mcpManager } : {}),
+      });
       const codexHookBundle = createDefaultHookRegistry(
         undefined,
         'telegram',
@@ -413,7 +430,7 @@ async function main() {
         { cwd: codexSessionCwd !== undefined && codexSessionCwd.length > 0 ? codexSessionCwd : undefined },
         () => codexSessionCwd,
       );
-      const session = constructTelegramSession({
+      const session = attachMcpCleanup(constructTelegramSession({
         ...(sessionConfig.apiKey !== undefined ? { apiKey: sessionConfig.apiKey } : {}),
         model: sessionConfig.model,
         ...(systemPrompt !== undefined ? { systemPrompt } : {}),
@@ -424,14 +441,23 @@ async function main() {
           : {}),
         provider: codexProvider,
         hookRegistry: codexHookBundle.registry,
-      });
+      }), mcpManager);
+      returnedSession = session;
       // Wire the path-approval grant ref + seed persisted `persist` grants so
       // the OpenAI Telegram surface gets the same restricted-path prompts and
       // persisted-grant replay as the Anthropic branch.
       codexHookBundle.pathApprovalGrantRef.current = codexProvider;
       seedPersistedGrants(codexProvider);
 
-      return session;
+        return session;
+      } catch (error) {
+        if (returnedSession !== undefined) {
+          await returnedSession.close().catch(() => undefined);
+        } else if (mcpManager !== undefined) {
+          await mcpManager.disconnectAll();
+        }
+        throw error;
+      }
     },
   });
 

--- a/src/telegram/mcp-session.test.ts
+++ b/src/telegram/mcp-session.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Telegram MCP session wiring contract.
+ *
+ * Exercises the remote bot session construction path with a project-local MCP
+ * fixture config: load Telegram's session-scoped McpManager, pass it into the
+ * Telegram provider, construct the Telegram session config, and verify the
+ * provider-visible tool catalog includes the bridged fixture tools.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { OpenAICompatibleProvider } from '../agent/providers/index.js';
+import type { ProviderEvent } from '../agent/provider.js';
+import type { AgentConfig } from '../agent/types.js';
+import type { AgentSession } from '../agent/session.js';
+import type { McpManager } from '../agent/mcp/index.js';
+import { constructTelegramSession } from './construct-session.js';
+import { loadTelegramMcpManager } from './mcp-session.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const FIXTURE = resolve(__dirname, '../agent/mcp/__fixtures__/test-server.mjs');
+const FIXTURE_TOOL_NAMES = [
+  'mcp__testsrv__add',
+  'mcp__testsrv__boom',
+  'mcp__testsrv__echo',
+];
+
+async function* emptyPrompt(): AsyncIterable<never> {
+  // Intentionally empty: the provider emits session.init before reading user input.
+}
+
+async function writeFixtureMcpConfig(cwd: string): Promise<void> {
+  await writeFile(
+    join(cwd, '.mcp.json'),
+    JSON.stringify({
+      mcpServers: {
+        testsrv: {
+          type: 'stdio',
+          command: process.execPath,
+          args: [FIXTURE],
+        },
+      },
+    }),
+    'utf8',
+  );
+}
+
+describe('Telegram MCP session wiring', () => {
+  let tmpHome: string;
+  let projectCwd: string;
+  let noConfigCwd: string;
+  let savedAfkHome: string | undefined;
+  let savedAllowProjectMcp: string | undefined;
+  let manager: McpManager | undefined;
+  let provider: OpenAICompatibleProvider | undefined;
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(join(tmpdir(), 'afk-tg-mcp-home-'));
+    projectCwd = await mkdtemp(join(tmpdir(), 'afk-tg-mcp-project-'));
+    noConfigCwd = await mkdtemp(join(tmpdir(), 'afk-tg-mcp-empty-'));
+    savedAfkHome = process.env['AFK_HOME'];
+    savedAllowProjectMcp = process.env['AFK_ALLOW_PROJECT_MCP'];
+    process.env['AFK_HOME'] = tmpHome;
+    process.env['AFK_ALLOW_PROJECT_MCP'] = '1';
+  });
+
+  afterEach(async () => {
+    provider?.close();
+    provider = undefined;
+    await manager?.disconnectAll();
+    manager = undefined;
+    if (savedAfkHome === undefined) delete process.env['AFK_HOME'];
+    else process.env['AFK_HOME'] = savedAfkHome;
+    if (savedAllowProjectMcp === undefined) delete process.env['AFK_ALLOW_PROJECT_MCP'];
+    else process.env['AFK_ALLOW_PROJECT_MCP'] = savedAllowProjectMcp;
+    await rm(tmpHome, { recursive: true, force: true });
+    await rm(projectCwd, { recursive: true, force: true });
+    await rm(noConfigCwd, { recursive: true, force: true });
+  });
+
+  it('returns undefined when the Telegram session has no MCP config', async () => {
+    await expect(loadTelegramMcpManager(noConfigCwd)).resolves.toBeUndefined();
+  });
+
+  it(
+    'exposes project-local fixture MCP tools through the Telegram provider/session path',
+    async () => {
+      await writeFixtureMcpConfig(projectCwd);
+      manager = await loadTelegramMcpManager(projectCwd);
+      expect(manager?.getMcpToolWireNames().sort()).toEqual(FIXTURE_TOOL_NAMES);
+
+      provider = new OpenAICompatibleProvider({ surface: 'telegram', mcpManager: manager });
+      let captured: AgentConfig | undefined;
+      constructTelegramSession(
+        {
+          model: 'gpt-4o-mini',
+          apiKey: 'test-openai-key',
+          cwd: projectCwd,
+          provider,
+        },
+        {
+          createTraceWriter: () => null,
+          newSession: (config): AgentSession => {
+            captured = config;
+            return { close: async () => {} } as unknown as AgentSession;
+          },
+        },
+      );
+
+      expect(captured?.surface).toBe('telegram');
+      expect(captured?.provider).toBe(provider);
+
+      const query = provider.query({ prompt: emptyPrompt(), config: captured! });
+      try {
+        const first = await query[Symbol.asyncIterator]().next();
+        expect(first.done).toBe(false);
+        expect(first.value?.type).toBe('session.init');
+        const init = first.value as Extract<ProviderEvent, { type: 'session.init' }>;
+        expect(init.info.tools).toEqual(expect.arrayContaining(FIXTURE_TOOL_NAMES));
+        expect(init.info.mcpServers).toEqual([{ name: 'testsrv', status: 'connected' }]);
+      } finally {
+        await query.close();
+      }
+    },
+    { timeout: 15_000 },
+  );
+});

--- a/src/telegram/mcp-session.test.ts
+++ b/src/telegram/mcp-session.test.ts
@@ -7,7 +7,7 @@
  * provider-visible tool catalog includes the bridged fixture tools.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
@@ -15,11 +15,11 @@ import { fileURLToPath } from 'node:url';
 
 import { OpenAICompatibleProvider } from '../agent/providers/index.js';
 import type { ProviderEvent } from '../agent/provider.js';
-import type { AgentConfig } from '../agent/types.js';
+import type { AgentConfig, IAgentSession } from '../agent/types.js';
 import type { AgentSession } from '../agent/session.js';
 import type { McpManager } from '../agent/mcp/index.js';
 import { constructTelegramSession } from './construct-session.js';
-import { loadTelegramMcpManager } from './mcp-session.js';
+import { attachMcpCleanup, loadTelegramMcpManager } from './mcp-session.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -129,4 +129,54 @@ describe('Telegram MCP session wiring', () => {
     },
     { timeout: 15_000 },
   );
+});
+
+describe('attachMcpCleanup', () => {
+  it('wraps session.close() to disconnect the manager exactly once, after close', async () => {
+    const order: string[] = [];
+    const disconnectAll = vi.fn(async () => {
+      order.push('disconnect');
+    });
+    const close = vi.fn(async () => {
+      order.push('close');
+    });
+    const session = { close } as unknown as IAgentSession;
+    const manager = { disconnectAll } as unknown as McpManager;
+
+    const wrapped = attachMcpCleanup(session, manager);
+    expect(wrapped).toBe(session);
+
+    await wrapped.close();
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(disconnectAll).toHaveBeenCalledTimes(1);
+    // Teardown order mirrors the other surfaces: session closes BEFORE MCP disconnect.
+    expect(order).toEqual(['close', 'disconnect']);
+
+    // Idempotent: a second close() does not double-disconnect the manager.
+    await wrapped.close();
+    expect(close).toHaveBeenCalledTimes(2);
+    expect(disconnectAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('still disconnects the manager when the wrapped close() rejects', async () => {
+    const disconnectAll = vi.fn(async () => {});
+    const close = vi.fn(async () => {
+      throw new Error('close failed');
+    });
+    const session = { close } as unknown as IAgentSession;
+    const manager = { disconnectAll } as unknown as McpManager;
+
+    const wrapped = attachMcpCleanup(session, manager);
+    await expect(wrapped.close()).rejects.toThrow('close failed');
+    // The finally in attachMcpCleanup runs disconnectAll even on a failed close.
+    expect(disconnectAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op passthrough when no manager is supplied', () => {
+    const close = vi.fn();
+    const session = { close } as unknown as IAgentSession;
+    expect(attachMcpCleanup(session, undefined)).toBe(session);
+    // close is left unwrapped.
+    expect(session.close).toBe(close);
+  });
 });

--- a/src/telegram/mcp-session.ts
+++ b/src/telegram/mcp-session.ts
@@ -1,0 +1,53 @@
+/**
+ * Telegram MCP session wiring.
+ *
+ * Telegram constructs one AgentSession per chat, so MCP managers must be
+ * session-scoped too: load configured servers before provider construction,
+ * pass the manager into the provider, then disconnect it after the session
+ * closes. No configured/enabled servers returns `undefined` so the historical
+ * no-MCP path is unchanged.
+ */
+
+import type { IAgentSession } from '../agent/types.js';
+import { McpManager, loadMcpConfig, getMcpConfigPath } from '../agent/mcp/index.js';
+import { loadImportFromConfig, resolveImportedRoots } from '../config/import-sources.js';
+
+export async function loadTelegramMcpManager(cwd: string | undefined): Promise<McpManager | undefined> {
+  const importedMcpConfigs = resolveImportedRoots(loadImportFromConfig())
+    .mcpConfigs.filter((c) => c.format === 'json')
+    .map((c) => c.source);
+  const loaded = loadMcpConfig({
+    cwd: cwd ?? process.cwd(),
+    ...(importedMcpConfigs.length > 0 ? { importedMcpConfigs } : {}),
+  });
+  const enabledCount = Object.values(loaded.mcpServers).filter((s) => !s.disabled).length;
+  if (enabledCount === 0) {
+    for (const w of loaded.warnings) console.warn(`[mcp] ${w}`);
+    return undefined;
+  }
+
+  const sourcesLabel = loaded.sources.length === 1
+    ? loaded.sources[0]
+    : `${loaded.sources.length} source(s)`;
+  console.log(`  mcp: ${enabledCount} server(s) from ${sourcesLabel ?? getMcpConfigPath()}`);
+  return McpManager.fromConfig(loaded.mcpServers, { warnings: loaded.warnings });
+}
+
+export function attachMcpCleanup<T extends IAgentSession>(session: T, mcpManager: McpManager | undefined): T {
+  if (mcpManager === undefined) return session;
+
+  const closeSession = session.close.bind(session);
+  let disconnected = false;
+  session.close = (async () => {
+    try {
+      await closeSession();
+    } finally {
+      if (!disconnected) {
+        disconnected = true;
+        await mcpManager.disconnectAll();
+      }
+    }
+  }) as T['close'];
+
+  return session;
+}


### PR DESCRIPTION
## Summary

Today only the interactive REPL wires MCP servers (`src/cli/commands/interactive/bootstrap.ts`). The other three surfaces construct `AgentSession`s **without MCP**, so `mcp__<server>__<tool>` tools are absent from three of four surfaces — including `daemon` and `telegram`, where unattended/remote tool access matters most for an AFK harness.

This wires MCP into all three, mirroring the interactive pattern (load config → `McpManager.fromConfig` → thread manager into provider → disconnect in teardown):

- **`chat`** (`src/cli/commands/chat.ts`): loads layered MCP config (cwd `.mcp.json`, imported configs, `~/.afk/config/mcp.json`, new `--mcp-config` override flag matching interactive), connects via `McpManager.fromConfig`, threads the manager into the provider, adds wire names to `allowedTools`, disconnects in the existing teardown path.
- **`daemon`** (`src/agent/daemon/scheduler.ts`): `spawnSession()` now loads MCP config scoped to the tick cwd and connects a **per-tick** manager (fresh, isolated lifecycle each tick). Adds `mcpManager` to `AgentConfig` so the daemon session factory consumes it. Disconnects after `session.close()`; on spawn failure, disconnects the partial manager.
- **`telegram`** (`src/telegram.ts` + new `src/telegram/mcp-session.ts`): a per-chat manager loaded before provider construction, threaded into **both** the Anthropic and Codex/OpenAI branches. New `attachMcpCleanup()` wraps `session.close` so the manager disconnects after the session closes.

All three paths guard on enabled-server count and short-circuit to the historical no-MCP path when no servers are configured (no regression). Teardown ordering mirrors interactive: `session.close()` before `mcpManager.disconnectAll()`.

Each surface wires MCP inline (rather than via a shared helper) to keep this change additive and reviewable; a follow-up could extract a shared helper to DRY the three + the existing interactive site.

## How was this tested?

```
pnpm lint             # tsc --noEmit (strict) — clean
pnpm test             # 9866 passed / 0 failed / 12 skipped (532 files)
pnpm audit:sdk:check  # OK — no SDK import changes
pnpm audit:env:check  # OK — 0 violations
pnpm build            # OK
```

New tests:
- `chat.mcp.test.ts` — fixture-based test proving `mcp__` tools surface in the chat providers `allowedTools` when a stdio MCP server is configured, and that omitting config leaves the default behavior unchanged.
- `scheduler.test.ts` — MCP-fixture tests verifying the daemon tick connects and cleanup ordering holds; isolates `AFK_HOME` so `spawnSession`s config load does not pick up the operators real `mcp.json`.
- `scheduler-pull.test.ts` — `AFK_HOME` isolation added (the pull-tick tests share `spawnSession`, which now reads MCP config — without isolation they pick up the operators `~/.afk/config/mcp.json`).
- `mcp-session.test.ts` — covers the telegram load + `attachMcpCleanup` helpers.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the DCO
- [x] No secrets, tokens, or private paths in the diff