### PR TITLE
fix(daemon): brief-queue gate counts only top-level .md files

### DIFF
--- a/src/agent/daemon/gates.test.ts
+++ b/src/agent/daemon/gates.test.ts
@@ -88,17 +88,27 @@ describe('countPendingBriefs', () => {
     expect(countPendingBriefs(dir)).toBe(0);
   });
 
-  it('counts regular files, ignoring dotfiles', () => {
+  it('counts top-level .md files, ignoring dotfiles and non-md files', () => {
     writeFileSync(join(dir, 'brief-1.md'), '');
     writeFileSync(join(dir, 'brief-2.md'), '');
     writeFileSync(join(dir, '.hidden'), '');
+    writeFileSync(join(dir, 'notes.txt'), '');
     expect(countPendingBriefs(dir)).toBe(2);
   });
 
-  it('counts subdirectories (each is one brief)', () => {
-    mkdirSync(join(dir, 'brief-a'));
-    mkdirSync(join(dir, 'brief-b'));
-    expect(countPendingBriefs(dir)).toBe(2);
+  it('does NOT count subdirectories (consumed/ and failed/ lifecycle bins)', () => {
+    // Regression: the daemon's briefs dir always holds consumed/ and failed/
+    // subdirs once any brief has been processed. Counting them as pending
+    // briefs would permanently trip the sessionstart gate's briefs_pending
+    // skip even when zero real briefs remain. Only top-level .md files count,
+    // and .md files nested inside those bins must not leak into the count.
+    mkdirSync(join(dir, 'consumed'));
+    mkdirSync(join(dir, 'failed'));
+    writeFileSync(join(dir, 'consumed', 'old-brief.md'), '');
+    expect(countPendingBriefs(dir)).toBe(0);
+
+    writeFileSync(join(dir, 'real-brief.md'), '');
+    expect(countPendingBriefs(dir)).toBe(1);
   });
 });
 

--- a/src/agent/daemon/gates.ts
+++ b/src/agent/daemon/gates.ts
@@ -71,14 +71,23 @@ export function readLastTickTime(taskId: string, telemetryPath: string): number 
 }
 
 /**
- * Count pending briefs in `briefsDir`. A "brief" is any regular file whose
- * name does not start with `.` (dotfiles are ignored). Missing directory
- * returns 0.
+ * Count pending briefs in `briefsDir`. A "brief" is a top-level regular `.md`
+ * file; subdirectories (notably the `consumed/` and `failed/` lifecycle bins,
+ * which persist once any brief has been processed) and non-`.md` files are
+ * ignored. Missing directory returns 0.
+ *
+ * Mirrors the brief detection in `pendingBriefContext`
+ * (agent/routing-directive.ts) so the daemon's sessionstart gate and the
+ * system-prompt nudge agree on the count. A bare `readdirSync(...).filter(name
+ * => !name.startsWith('.'))` would count `consumed/`/`failed/` as pending
+ * briefs and permanently trip the `briefs_pending` skip.
  */
 export function countPendingBriefs(briefsDir: string): number {
   if (!existsSync(briefsDir)) return 0;
   try {
-    return readdirSync(briefsDir).filter((name) => !name.startsWith('.')).length;
+    return readdirSync(briefsDir, { withFileTypes: true }).filter(
+      (entry) => entry.isFile() && entry.name.endsWith('.md'),
+    ).length;
   } catch {
     return 0;
   }


### PR DESCRIPTION
## Problem

The daemon's sessionstart **brief-queue gate** decides whether to fire the default `/forge-friction --auto` task. It skips with `skipReason: 'briefs_pending'` whenever `countPendingBriefs()` returns `> 0`.

`countPendingBriefs()` counted **every** non-dotfile entry in the briefs dir:

```ts
readdirSync(briefsDir).filter((name) => !name.startsWith('.')).length
```

`readdirSync` without `{ withFileTypes: true }` returns subdirectory names too. The briefs dir (`~/.afk/agent-framework/briefs/`) holds two persistent lifecycle bins — `consumed/` and `failed/` — that exist as soon as any brief has been processed. So the count never dropped below 2, and the gate returned `briefs_pending` on **every** sessionstart even with zero real briefs pending:

- the default `/forge-friction --auto` task was permanently suppressed, and
- a `⏭️ … skipReason=briefs_pending` notification fired on every session start.

The sibling brief detector `pendingBriefContext()` (`src/agent/routing-directive.ts`) already does it correctly (`{ withFileTypes: true }` + `isFile()` + `.endsWith('.md')`), so the two counters disagreed: the startup nudge reported "1 pending brief" while the gate behaved as if ≥ 3 were pending.

## Fix

Filter `countPendingBriefs()` to top-level regular `.md` files, matching `pendingBriefContext()` so the daemon gate and the system-prompt nudge agree on the count:

```ts
readdirSync(briefsDir, { withFileTypes: true })
  .filter((entry) => entry.isFile() && entry.name.endsWith('.md')).length
```

## Tests

- Flipped the `countPendingBriefs` test that asserted subdirectories are counted into a regression test for the `consumed/` + `failed/` scenario (also asserts a `.md` nested inside a bin does not leak into the count).
- Tightened the file test to lock the `.md`-only filter (a `notes.txt` must not count).

## Verification

- `npx vitest run src/agent/daemon/gates.test.ts` → 14/14 pass
- `pnpm lint` (tsc --noEmit, strict) → clean
- Full `vitest run` → only the 1 pre-existing unrelated failure (`anthropic-direct.test.ts > compact()`, a model-id assertion); no new failures introduced.
