### PR TITLE
feat(subagent): wire passive SIGNAL-block parsing into SubagentResult

### DIFF
--- a/src/agent/signal-block.ts
+++ b/src/agent/signal-block.ts
@@ -46,12 +46,6 @@
  *   observer's job; we just gatekeep the shape.
  *
  * @module agent/signal-block
- *
- * TODO(signal-block-wiring): `parseSignal` is defined and tested but not yet
- * imported by any runtime caller (`handle.ts`, `result.ts`, `executor.ts`).
- * Wiring into the subagent result pipeline is intentionally deferred to a
- * follow-up PR — this PR only lands the parser + schema so observers can
- * adopt it incrementally. Remove this TODO when a caller imports it.
  */
 
 import { z } from 'zod';

--- a/src/agent/subagent/result.test.ts
+++ b/src/agent/subagent/result.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for SIGNAL block wiring into buildResultFromMessage.
+ *
+ * Covers the passive-observation contract: `result.signal` is populated from
+ * the subagent's final message when a well-formed SIGNAL block is present,
+ * and is absent otherwise. Signal extraction is independent of outputSchema
+ * presence / validation outcome.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import type { Message } from '../types.js';
+import { buildResultFromMessage } from './result.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_SIGNAL = {
+  issue: 'cache-race',
+  stance: 'supports' as const,
+  confidence: 0.82,
+  evidence: ['src/cache/lru.ts:142'],
+  claim: 'The eviction path races with concurrent reads under load.',
+};
+
+const VALID_SIGNAL_BLOCK = { signal: VALID_SIGNAL };
+
+function fenced(body: unknown): string {
+  return '```json\n' + JSON.stringify(body, null, 2) + '\n```';
+}
+
+function makeMessage(content: string): Message {
+  return {
+    role: 'assistant',
+    content,
+    timestamp: new Date(),
+    metadata: { usage: { inputTokens: 1, outputTokens: 1 }, stopReason: 'end_turn' },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('buildResultFromMessage — signal wiring', () => {
+  describe('no outputSchema', () => {
+    it('attaches signal when the message contains a valid SIGNAL block', () => {
+      const content = 'Analysis complete.\n\n' + fenced(VALID_SIGNAL_BLOCK);
+      const result = buildResultFromMessage('a', 'succeeded', makeMessage(content), undefined);
+      expect(result.signal).toEqual(VALID_SIGNAL);
+    });
+
+    it('leaves signal absent when the message has no SIGNAL block', () => {
+      const content = 'No structured signal here.';
+      const result = buildResultFromMessage('b', 'succeeded', makeMessage(content), undefined);
+      expect(result.signal).toBeUndefined();
+    });
+
+    it('leaves signal absent when the SIGNAL block is malformed (bad stance enum)', () => {
+      const malformed = {
+        signal: {
+          issue: 'i',
+          stance: 'maybe', // invalid — not in enum
+          confidence: 0.5,
+          evidence: [],
+          claim: 'c',
+        },
+      };
+      const content = fenced(malformed);
+      const result = buildResultFromMessage('c', 'succeeded', makeMessage(content), undefined);
+      expect(result.signal).toBeUndefined();
+    });
+
+    it('leaves signal absent when the SIGNAL block has missing required fields', () => {
+      const malformed = { signal: { issue: 'x' } };
+      const content = fenced(malformed);
+      const result = buildResultFromMessage('d', 'succeeded', makeMessage(content), undefined);
+      expect(result.signal).toBeUndefined();
+    });
+  });
+
+  describe('with outputSchema — signal is independent of schema outcome', () => {
+    const OutputSchema = z.object({ value: z.string() });
+    const VALID_OUTPUT = { value: 'hello' };
+
+    it('populates both output and signal when schema matches and SIGNAL block is present', () => {
+      // Single cohabitated block carrying both schema keys and signal key.
+      const combined = { ...VALID_OUTPUT, ...VALID_SIGNAL_BLOCK };
+      const content = 'result:\n\n' + fenced(combined);
+      const result = buildResultFromMessage('e', 'succeeded', makeMessage(content), OutputSchema);
+      expect(result.status).toBe('succeeded');
+      expect(result.output).toEqual(VALID_OUTPUT);
+      expect(result.signal).toEqual(VALID_SIGNAL);
+    });
+
+    it('carries signal on schema-mismatch failure (status failed, schemaError set, signal present)', () => {
+      // Schema expects { value: string } but message has wrong shape.
+      // Signal block is a separate fenced block before the schema block.
+      const content = [
+        fenced(VALID_SIGNAL_BLOCK),
+        'output:',
+        fenced({ wrong_key: 42 }),
+      ].join('\n');
+      const result = buildResultFromMessage('f', 'succeeded', makeMessage(content), OutputSchema);
+      expect(result.status).toBe('failed');
+      expect(result.schemaError).toBeDefined();
+      expect(result.signal).toEqual(VALID_SIGNAL);
+    });
+
+    it('leaves signal absent on schema failure when no SIGNAL block is present', () => {
+      const content = fenced({ wrong_key: 42 });
+      const result = buildResultFromMessage('g', 'succeeded', makeMessage(content), OutputSchema);
+      expect(result.status).toBe('failed');
+      expect(result.signal).toBeUndefined();
+    });
+  });
+});

--- a/src/agent/subagent/result.ts
+++ b/src/agent/subagent/result.ts
@@ -10,6 +10,7 @@
 import type { ZodError, ZodType } from 'zod';
 import type { Message } from '../types.js';
 import { extractStructuredOutput } from '../output-extractor.js';
+import { parseSignal, type Signal } from '../signal-block.js';
 
 export type SubagentStatus = 'idle' | 'running' | 'succeeded' | 'failed' | 'cancelled';
 
@@ -93,6 +94,13 @@ export interface SubagentResult<T = unknown> {
   completionPercent?: number;
   /** Execution trace: tool calls, tool results, thinking presence, and usage. */
   trace?: SubagentTrace;
+  /**
+   * Passive SIGNAL block parsed from the subagent's final message, when present
+   * and well-formed. Non-authoritative v0 metadata — callers MUST NOT use this
+   * to gate finalization, block tools, or alter control flow. Only set when the
+   * message contained a valid SIGNAL block; absent otherwise.
+   */
+  signal?: Signal;
 }
 
 /**
@@ -106,14 +114,17 @@ export function buildResultFromMessage<T>(
   outputSchema: ZodType<T> | undefined,
   trace?: SubagentTrace,
 ): SubagentResult<T> {
+  const sig = parseSignal(message.content);
+  const signal = sig.ok ? sig.signal : undefined;
+
   if (!outputSchema) {
-    return { id, status, message, trace };
+    return { id, status, message, trace, ...(signal !== undefined && { signal }) };
   }
 
   const candidate = extractStructuredOutput(message.content);
   const parsed = outputSchema.safeParse(candidate);
   if (parsed.success) {
-    return { id, status, message, output: parsed.data, trace };
+    return { id, status, message, output: parsed.data, trace, ...(signal !== undefined && { signal }) };
   }
 
   return {
@@ -125,6 +136,7 @@ export function buildResultFromMessage<T>(
     }),
     schemaError: parsed.error,
     trace,
+    ...(signal !== undefined && { signal }),
   };
 }
 


### PR DESCRIPTION
## What

Wires `parseSignal()` from `src/agent/signal-block.ts` into `buildResultFromMessage` (`src/agent/subagent/result.ts`), surfacing a parsed signal as an optional `signal?: Signal` field on `SubagentResult<T>`. Removes the now-satisfied `TODO(signal-block-wiring)` from the `signal-block.ts` module header.

## Why

`parseSignal` shipped ahead of its caller with a TODO deferring the wiring, so it was effectively dead code — defined and fully tested but imported by nothing in production. This closes that deferral at the one natural integration point: the final-message result builder, right beside the existing `extractStructuredOutput` call.

## Passive v0 — non-authoritative by contract

Strictly passive observation, per the `signal-block.ts` v0 contract:

- `parseSignal` is called once per final message, unconditionally (independent of `outputSchema` presence or validity — the parser is key-scoped so it coexists with schema extraction).
- `signal` is purely additive — no existing field, status, control-flow, or schema-validation path changes.
- Consumers **MUST NOT** use `signal` to gate finalization, block tools, or mutate message history. This invariant is documented on the field.

## Explicitly deferred (future increments)

- Telemetry / trace emission of signal values
- Cross-subagent consensus / voting
- Any observer beyond the `SubagentResult` field (hooks, session-level aggregation)

## Verification

- `pnpm lint` (`tsc --noEmit`, strict): **clean**.
- New `src/agent/subagent/result.test.ts` (7 tests): valid signal w/o schema, absent signal, malformed signal (bad stance enum), signal + schema-success (both `output` and `signal` populated), and signal + schema-failure (`status:'failed'`/`schemaError` with `signal` still present). All pass. Existing `signal-block.test.ts` (27 tests) unchanged and passing.
- Full suite: the only failures (`anthropic-direct.test.ts` model-alias assertion; an intermittent `config.test.ts` env-bleed) **reproduce on `main`** without this change and are unrelated. This PR adds 7 passing tests and introduces no new failures.
