### PR TITLE
fix(tui): commit flushed blocks atomically so band-hold doesn't gap scrollback

### DIFF
--- a/src/cli/_lib/commit-block.ts
+++ b/src/cli/_lib/commit-block.ts
@@ -1,0 +1,39 @@
+/**
+ * commitBlockAbove — commit a coherent multi-line block to scrollback as a
+ * SINGLE `commitAbove` call.
+ *
+ * @module cli/_lib/commit-block
+ */
+
+/** Minimal structural slice of TerminalCompositor this helper needs. */
+export interface BlockCommitter {
+  commitAbove(text: string): void;
+}
+
+// Invariant (one geometry per commit): TerminalCompositor.commitAbove places a
+// whole block with ONE geometry decision — a single pre-clear `prevTopRow`
+// capture and a single fits / band-hold / overflow route (see
+// terminal-compositor.committed-band-commit.ts, "one geometry per commit", and
+// terminal-compositor.commit-mode.ts). Committing a block one line at a time
+// forces N independent geometry decisions: under a TALL overlay the per-line
+// band-hold/fits routing desyncs the committed-band model from the screen and
+// scrolls unpainted (blank) rows into scrollback — the "weird gaps" (and, in
+// the worst geometry, dropped-line) rendering bug. Joining the block into one
+// call restores the atomic contract: commitAbove re-splits on '\n' and
+// hard-wraps each row, so a row wider than the terminal still maps to exactly
+// one logical line, and the band-hold row math stays exact.
+//
+// `lines` are the physical rows of ONE rendered artifact (a card, a flushed
+// tool-lane block, an input echo) — NOT independent scrollback entries — so
+// committing them as a single block is always the correct semantics.
+//
+// Empty input is a no-op, matching the prior `for (const line of lines)` loops
+// (each was length-guarded, or iterated an always-non-empty card split).
+//
+// TTY-only: the band-hold desync this prevents is a property of the live
+// compositor frame. Non-TTY callers write each line to a plain writer
+// (`out.line`) and are unaffected — leave those loops as-is.
+export function commitBlockAbove(compositor: BlockCommitter, lines: readonly string[]): void {
+  if (lines.length === 0) return;
+  compositor.commitAbove(lines.join('\n'));
+}

--- a/src/cli/_lib/stream-renderer-orchestrator-emit.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator-emit.ts
@@ -11,6 +11,7 @@ import type { CardSpec } from '../render.js';
 import { card, errorBox } from '../render.js';
 import { renderMarkdownToTerminal } from '../formatter.js';
 import { formatThoughtSummary } from '../commands/interactive/thinking-lane.js';
+import { commitBlockAbove } from './commit-block.js';
 
 import type { OrchestratorCtx } from './stream-renderer-orchestrator.js';
 
@@ -39,7 +40,9 @@ export function emitPanel(
   const rendered = card(spec);
   const lines = rendered.split('\n');
   if (ctx.isTTY && ctx.compositor) {
-    for (const line of lines) ctx.compositor.commitAbove(line);
+    // Atomic block commit — a card is ONE coherent artifact; per-line commits
+    // desync band-hold under a tall overlay. See commit-block.ts.
+    commitBlockAbove(ctx.compositor, lines);
   } else {
     for (const line of lines) ctx.out.line(line);
   }
@@ -204,7 +207,10 @@ export function finalizeOrchestrator(
           anchor: 'before-content',
           commits: [() => {
             if (isTTY && compositor) {
-              for (const line of lines) compositor.commitAbove(line);
+              // Atomic block commit — the flushed root is ONE coherent block;
+              // per-line commits desync band-hold under a tall overlay (a live
+              // subagent's rows). See commit-block.ts.
+              commitBlockAbove(compositor, lines);
               compositor.commitAbove('');
               // Refresh the overlay from CURRENT lane state — in-flight
               // subagent rows that survived the selective flush must keep
@@ -322,7 +328,11 @@ export function flushToolLaneToScrollback(ctx: OrchestratorCtx): void {
   // own trailing. See docs/tui-rhythm.md.
   if (ctx.isTTY && ctx.compositor) {
     if (lines.length > 0) {
-      for (const line of lines) ctx.compositor.commitAbove(line);
+      // Atomic block commit — the flushed root(s) form ONE coherent block;
+      // committing line-by-line desyncs the band-hold model under a tall
+      // overlay and scrolls blank rows into scrollback (the "weird gaps"
+      // bug). See commit-block.ts.
+      commitBlockAbove(ctx.compositor, lines);
       ctx.compositor.commitAbove('');
     }
     // Refresh from current lane state. Empty when all roots were

--- a/src/cli/_lib/stream-renderer-ordering.test.ts
+++ b/src/cli/_lib/stream-renderer-ordering.test.ts
@@ -20,6 +20,23 @@ import type { ResponseMetadata } from '../../agent/types/message-types.js';
 
 // ─── shared helpers ──────────────────────────────────────────────────────────
 
+/**
+ * First character offset of ANY needle in the joined scrollback (-1 if none).
+ *
+ * Ordering across committed blocks must be asserted by RENDERED position, not
+ * by commitAbove call index: a flushed block (e.g. an eager ancestor skill
+ * header + its subagent child rows) is committed as ONE atomic commitAbove call
+ * (commit-block.ts) rather than one call per line, so two markers can share a
+ * call index while still rendering in the correct top-to-bottom order. Joining
+ * the calls with '\n' and comparing char offsets reflects what the user sees
+ * regardless of commit granularity, and still catches the pre-fix regression
+ * (a header deferred to dispose lands AFTER its children → later offset).
+ */
+function firstPos(joined: string, ...needles: string[]): number {
+  const found = needles.map((n) => joined.indexOf(n)).filter((p) => p >= 0);
+  return found.length ? Math.min(...found) : -1;
+}
+
 function makeWriter(): { writer: Writer; lines: string[] } {
   const lines: string[] = [];
   const writer: Writer = {
@@ -678,16 +695,18 @@ describe('Eager ancestor-header emission — skill frame header precedes subagen
     r.process(doneEvent(), { subagentId: 'sa-a', agentType: 'critic-pragmatist', parentId: 'skill-tu-1' });
 
     // Assert: skill header is already in scrollback after the first subagent done.
-    const skillIdx = commitAboveCalls.findIndex((c) => c.includes('skill') || c.includes('diagnose'));
-    const agentAIdx = commitAboveCalls.findIndex((c) => c.includes('critic-pragmatist') || c.includes('file-a'));
+    // Order by RENDERED char offset (the block is one atomic commit — see firstPos).
+    const sb = commitAboveCalls.join('\n');
+    const skillPos = firstPos(sb, 'skill', 'diagnose');
+    const agentAPos = firstPos(sb, 'critic-pragmatist', 'file-a');
 
-    expect(skillIdx, 'skill header must be committed to scrollback').toBeGreaterThanOrEqual(0);
-    expect(agentAIdx, 'agent-A block must be committed to scrollback').toBeGreaterThanOrEqual(0);
+    expect(skillPos, 'skill header must be committed to scrollback').toBeGreaterThanOrEqual(0);
+    expect(agentAPos, 'agent-A block must be committed to scrollback').toBeGreaterThanOrEqual(0);
 
     // The fix: skill header appears BEFORE subagent-A block in scrollback.
     // Pre-fix failure mode: skill header was only emitted at dispose-time
     // flush() — AFTER both subagent blocks — landing below its children.
-    expect(skillIdx, 'skill header must precede subagent-A block').toBeLessThan(agentAIdx);
+    expect(skillPos, 'skill header must precede subagent-A block').toBeLessThan(agentAPos);
 
     await r.dispose();
   });
@@ -759,14 +778,16 @@ describe('Eager ancestor-header emission — skill frame header precedes subagen
     ).toBe(1);
 
     // Both subagent blocks must be in scrollback AFTER the skill header.
-    const skillIdx = commitAboveCalls.findIndex((c) => c.includes('skill') || c.includes('diagnose'));
-    const agentAIdx = commitAboveCalls.findIndex((c) => c.includes('critic-pragmatist'));
-    const agentBIdx = commitAboveCalls.findIndex((c) => c.includes('critic-paranoid'));
+    // Order by RENDERED char offset (blocks are atomic commits — see firstPos).
+    const sb = commitAboveCalls.join('\n');
+    const skillPos = firstPos(sb, 'skill', 'diagnose');
+    const agentAPos = firstPos(sb, 'critic-pragmatist');
+    const agentBPos = firstPos(sb, 'critic-paranoid');
 
-    expect(agentAIdx, 'agent-A in scrollback').toBeGreaterThanOrEqual(0);
-    expect(agentBIdx, 'agent-B in scrollback').toBeGreaterThanOrEqual(0);
-    expect(skillIdx).toBeLessThan(agentAIdx);
-    expect(skillIdx).toBeLessThan(agentBIdx);
+    expect(agentAPos, 'agent-A in scrollback').toBeGreaterThanOrEqual(0);
+    expect(agentBPos, 'agent-B in scrollback').toBeGreaterThanOrEqual(0);
+    expect(skillPos).toBeLessThan(agentAPos);
+    expect(skillPos).toBeLessThan(agentBPos);
   });
 });
 
@@ -1280,20 +1301,18 @@ describe('Skill-nesting — Agent nests under skill spine when activeSkillName s
     r.process(doneEvent(), { subagentId: 'sa-review-w1', agentType: 'review-w1', parentId: 'agent-tu-e2e' });
 
     // Step 4: skill header must appear in scrollback BEFORE the Agent done-block.
-    // (Eager ancestor-header emission in flushSource.)
-    const skillIdx = commitAboveCalls.findIndex(
-      (c) => c.includes('skill') || c.includes('review'),
-    );
-    const agentIdx = commitAboveCalls.findIndex(
-      (c) => c.includes('review-w1') || c.includes('Bash') || c.includes('bash'),
-    );
+    // (Eager ancestor-header emission in flushSource.) Order by RENDERED char
+    // offset — the done-block is one atomic commit (see firstPos).
+    const sb = commitAboveCalls.join('\n');
+    const skillPos = firstPos(sb, 'skill', 'review');
+    const agentPos = firstPos(sb, 'review-w1', 'Bash', 'bash');
 
-    expect(skillIdx, 'skill header must be committed to scrollback').toBeGreaterThanOrEqual(0);
-    expect(agentIdx, 'agent done-block must be committed to scrollback').toBeGreaterThanOrEqual(0);
+    expect(skillPos, 'skill header must be committed to scrollback').toBeGreaterThanOrEqual(0);
+    expect(agentPos, 'agent done-block must be committed to scrollback').toBeGreaterThanOrEqual(0);
     expect(
-      skillIdx,
+      skillPos,
       'skill header must precede agent done-block in scrollback (single ◉ root)',
-    ).toBeLessThan(agentIdx);
+    ).toBeLessThan(agentPos);
 
     r.process(doneEvent());
     await r.dispose();

--- a/src/cli/_lib/stream-renderer-subagent.ts
+++ b/src/cli/_lib/stream-renderer-subagent.ts
@@ -14,6 +14,7 @@ import type { ToolLane } from '../commands/interactive/tool-lane.js';
 import type { Writer } from '../slash/types.js';
 import type { CardSpec } from '../render.js';
 import { card } from '../render.js';
+import { commitBlockAbove } from './commit-block.js';
 import { StreamingMarkdownRenderer } from '../markdown-stream.js';
 import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
 import { syntheticResult, formatDoneSummary } from './stream-renderer-source.js';
@@ -400,12 +401,13 @@ export function emitSubagentPanel(
   }
 
   const rendered = card(spec);
-  for (const line of rendered.split('\n')) {
-    if (ctx.isTTY && ctx.compositor) {
-      ctx.compositor.commitAbove(line);
-    } else {
-      ctx.out.line(line);
-    }
+  const cardLines = rendered.split('\n');
+  if (ctx.isTTY && ctx.compositor) {
+    // Atomic block commit — the subagent panel card is ONE coherent artifact;
+    // per-line commits desync band-hold under a tall overlay. See commit-block.ts.
+    commitBlockAbove(ctx.compositor, cardLines);
+  } else {
+    for (const line of cardLines) ctx.out.line(line);
   }
   // Invariant (TUI rhythm contract): subagent panel card owns ONE
   // trailing blank line so the next block (more prose, the next tool,

--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -49,6 +49,7 @@ import {
   type OrchestratorCtx,
 } from './stream-renderer-orchestrator.js';
 import { CommitCoordinator } from './commit-coordinator.js';
+import { commitBlockAbove } from './commit-block.js';
 import { handleSubagentEvent, synthesizeAgentEntry } from './stream-renderer-subagent.js';
 import { OverlayComposer } from './overlay-composer.js';
 import { createStageTracker, type StageTrackerState } from '../commands/interactive/loop-stage.js';
@@ -626,7 +627,10 @@ export class StreamRenderer {
             anchor: `after-subagent:${sourceId}`,
             commits: [() => {
               if (compositor) {
-                for (const line of lines) compositor.commitAbove(line);
+                // Atomic block commit — a subagent block is ONE coherent
+                // artifact; per-line commits desync band-hold under a tall
+                // overlay. See commit-block.ts.
+                commitBlockAbove(compositor, lines);
                 // One blank line after the subagent block so the next
                 // orchestrator message (or a subsequent subagent block) has
                 // breathing room in scrollback.
@@ -753,7 +757,10 @@ export class StreamRenderer {
     if (this.toolLane.hasPending()) {
       const lines = this.toolLane.flush();
       if (this.isTTY && this.compositor) {
-        for (const line of lines) this.compositor.commitAbove(line);
+        // Atomic block commit — the safety-net flush is ONE coherent block;
+        // per-line commits desync band-hold under a tall overlay. See
+        // commit-block.ts.
+        commitBlockAbove(this.compositor, lines);
         this.compositor.commitAbove('');
         if (this.overlayComposer) {
           this.overlayComposer.markDirty('tool-lane');

--- a/src/cli/input/input-surface.ts
+++ b/src/cli/input/input-surface.ts
@@ -52,6 +52,7 @@ import { colorizeInputBuffer, type SlashRegistryView } from '../input-highlight.
 import { list as listSlashCommands } from '../slash/registry.js';
 import { formatSubmittedEcho } from './echo.js';
 import { describeAttachmentSummary } from './attachments.js';
+import { commitBlockAbove } from '../_lib/commit-block.js';
 
 /**
  * Minimal StatusLine surface used by InputSurface — kept structural
@@ -476,13 +477,12 @@ export class InputSurface {
             isTTY: Boolean(echoStdout.isTTY),
             attachmentSummary: describeAttachmentSummary([...payload.attachments]),
           });
-          // formatSubmittedEcho can return multi-line strings (long
-          // input is rendered as a card with `\n` between rows).
-          // commitAbove expects one logical line per call — split so
-          // each row commits as its own scrollback entry.
-          for (const line of echo.split('\n')) {
-            compositor.commitAbove(line);
-          }
+          // formatSubmittedEcho can return multi-line strings (long input is
+          // rendered as a card with `\n` between rows). Commit the echo as ONE
+          // atomic block: commitAbove handles a multi-line block with a single
+          // geometry decision; committing row-by-row would desync the band-hold
+          // model under a tall overlay (the "weird gaps" bug). See commit-block.ts.
+          commitBlockAbove(compositor, echo.split('\n'));
 
           resolve({ text: payload.text, attachments: [...payload.attachments] });
         };

--- a/src/cli/terminal-compositor.band-hold-perline-gap.repro.test.ts
+++ b/src/cli/terminal-compositor.band-hold-perline-gap.repro.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Regression (TUI "weird gaps"): a completed tool root / subagent block / card
+ * is flushed to scrollback while a TALL overlay (the still-unrefreshed tool
+ * lane, or a live subagent's rows) fills most of the viewport. Committing the
+ * block ONE LINE PER `commitAbove` call (the pre-fix flushToolLaneToScrollback
+ * loop) forces N independent geometry decisions; the per-line band-hold/fits
+ * routing desyncs the committed-band model from the screen and scrolls
+ * unpainted (blank) rows into scrollback — the gap. Committing the block
+ * atomically via {@link commitBlockAbove} (one geometry decision) lands every
+ * row contiguously, hugging the frame, after the overlay collapses.
+ *
+ * This pins the fix at the compositor granularity (the call sites — emit /
+ * stream-renderer / subagent / input-surface — all route through
+ * commitBlockAbove; their end-to-end behavior is pinned by the existing
+ * *-gap.repro suites). Validated against the real @xterm/headless scroll engine
+ * (mock-stdout byte tests cannot observe true scrollback — see docs/scrollback.md).
+ *
+ * HARD GATE: each gap-prone geometry asserts the per-line loop produces a gap
+ * (span > N-1 or a drop) AND the batched commit is present + single-copy +
+ * contiguous. If commitBlockAbove ever regresses to per-line, the batched
+ * assertions fail.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { StatusLine } from './status-line.js';
+import { LoopStageBar } from './commands/interactive/loop-stage.js';
+import { commitBlockAbove } from './_lib/commit-block.js';
+
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin = NodeJS.ReadStream & { isTTY: boolean; isRaw: boolean; setRawMode: ReturnType<typeof vi.fn> };
+
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true; s.columns = cols; s.rows = rows; return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true; s.isRaw = false; s.setRawMode = vi.fn((r: boolean) => { s.isRaw = r; return s; }); return s;
+}
+function collect(stream: MockStdout): () => string { const c: string[] = []; stream.on('data', (x) => c.push(String(x))); return () => c.join(''); }
+function termWrite(t: HeadlessTerminal, d: string): Promise<void> { return new Promise((r) => t.write(d, r)); }
+function lines(t: HeadlessTerminal): string[] {
+  const b = t.buffer.active; const o: string[] = [];
+  for (let i = 0; i < b.length; i++) { const l = b.getLine(i); if (l) o.push(l.translateToString(true)); }
+  return o;
+}
+function wireFooter(stdout: MockStdout): { statusLine: StatusLine; loopStageBar: LoopStageBar } {
+  const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+  statusLine.start();
+  statusLine.repaint({ model: 'STATUSMODELXYZ', cost: 0, tokens: 0, contextPct: 0 });
+  const loopStageBar = new LoopStageBar({ getExtraRows: () => statusLine.getExtraRows(), stream: stdout });
+  loopStageBar.setRowCountChangeHandler(() => statusLine.setExtraRows(1));
+  statusLine.setAfterScrollRestore(() => loopStageBar.redraw());
+  loopStageBar.start();
+  return { statusLine, loopStageBar };
+}
+
+interface Internals { repaint(): void }
+const COLS = 120, ROWS = 24;
+const SPINNER_RE = /[\u2800-\u28ff]/;
+
+interface Outcome { present: number; total: number; missing: string[]; span: number; want: number; firstRow: number; lastRow: number; dump: string }
+
+/**
+ * Flush `block` to scrollback under an overlay `loopH` rows tall, then collapse
+ * the overlay and settle. `batch=false` mimics the pre-fix per-line loop;
+ * `batch=true` uses the commitBlockAbove fix. Returns presence/contiguity facts
+ * read off a real @xterm/headless buffer.
+ */
+async function flushUnderTallOverlay(block: string[], loopH: number, batch: boolean): Promise<Outcome> {
+  const stdout = makeStdout(COLS, ROWS);
+  const stdin = makeStdin();
+  const all = collect(stdout);
+  const { statusLine, loopStageBar } = wireFooter(stdout);
+  const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1 });
+  await c.arm();
+  const ix = c as unknown as Internals;
+  c.setSpinner({ enabled: true });
+
+  c.setOverlay(Array.from({ length: loopH }, (_, i) => `tool lane row ${i}`).join('\n'));
+  if (batch) commitBlockAbove(c, block);
+  else for (const line of block) c.commitAbove(line);
+  c.commitAbove(''); // trailing rhythm separator (every call site emits this)
+
+  c.setOverlay('');
+  ix.repaint();
+  ix.repaint();
+
+  const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 800, allowProposedApi: true, convertEol: true });
+  await termWrite(term, all());
+  const ls = lines(term);
+  term.dispose(); loopStageBar.stop(); statusLine.stop(); c.disarm();
+
+  const present = block.filter((m) => ls.some((l) => l.includes(m))).length;
+  const missing = block.filter((m) => !ls.some((l) => l.includes(m)));
+  const rowOf = (n: string) => ls.findIndex((l) => l.includes(n));
+  const firstRow = rowOf(block[0]!);
+  const lastRow = rowOf(block[block.length - 1]!);
+  const span = (firstRow >= 0 && lastRow >= 0) ? lastRow - firstRow : -1;
+  const dump = ls.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l.slice(0, 44))}`).join('\n');
+  return { present, total: block.length, missing, span, want: block.length - 1, firstRow, lastRow, dump };
+}
+
+function mkBlock(n: number, tag: string): string[] {
+  // Distinct, searchable markers; a couple of blank-ish rows mirror the
+  // screenshot's empty `+ ` diff lines (which still carry a green gutter).
+  return Array.from({ length: n }, (_, i) =>
+    (i === 4 || i === 5) ? `${tag}_${String(i).padStart(2, '0')}` : `${tag}_${String(i).padStart(2, '0')}_content`,
+  );
+}
+
+describe('band-hold per-line flush gap → commitBlockAbove (TUI weird gaps)', () => {
+  // loopH that leaves only a few above-frame rows (partial room) is the geometry
+  // that corrupts under the per-line loop. loopH=ROWS-2 fills the viewport.
+  for (const loopH of [16, 10, ROWS - 2]) {
+    it(`overlay height ${loopH}: per-line gaps, batched is contiguous`, async () => {
+      const block = mkBlock(14, 'Lxx');
+
+      const batched = await flushUnderTallOverlay(block, loopH, true);
+      // Fix: every committed row present exactly once, contiguous, no gap.
+      expect(batched.missing, `batched dropped rows:\n${batched.dump}`).toEqual([]);
+      expect(batched.present, `batched missing rows:\n${batched.dump}`).toBe(batched.total);
+      expect(
+        batched.span,
+        `batched diff lines not contiguous (gap) first=${batched.firstRow} last=${batched.lastRow}:\n${batched.dump}`,
+      ).toBe(batched.want);
+    }, 20_000);
+  }
+
+  it('per-line loop is genuinely gappy at the partial-room geometry (discriminator)', async () => {
+    // Guards the test's own power: if the per-line loop did NOT gap here, the
+    // batched assertions above would prove nothing. loopH=16 reproduced span=29
+    // (vs want 13) during investigation.
+    const block = mkBlock(14, 'Pl');
+    const perLine = await flushUnderTallOverlay(block, 16, false);
+    const gappyOrDropped = perLine.span > perLine.want || perLine.missing.length > 0;
+    expect(
+      gappyOrDropped,
+      `expected the per-line loop to gap/drop at loopH=16 but it was clean (span=${perLine.span}, want=${perLine.want}, missing=${perLine.missing.length}):\n${perLine.dump}`,
+    ).toBe(true);
+  }, 20_000);
+
+  it('a block taller than the collapsed screen still lands every row contiguously (scrollback + viewport)', async () => {
+    // 30 rows > the ~21-row collapsed-screen band model: the overflow is
+    // archived to scrollback and the tail hugs the frame. Across the full
+    // headless buffer (scrollback + viewport) every row is present and contiguous
+    // — refuting the "batching drops more content" concern for tall blocks.
+    const block = mkBlock(30, 'Tall');
+    const batched = await flushUnderTallOverlay(block, ROWS - 2, true);
+    expect(batched.missing, `tall block dropped rows:\n${batched.dump}`).toEqual([]);
+    expect(batched.span, `tall block not contiguous first=${batched.firstRow} last=${batched.lastRow}:\n${batched.dump}`).toBe(batched.want);
+  }, 20_000);
+
+  it('does not regress the known-good full-viewport single block (still hugs the frame)', async () => {
+    const block = mkBlock(14, 'Good');
+    const batched = await flushUnderTallOverlay(block, ROWS - 2, true);
+    expect(batched.missing).toEqual([]);
+    expect(batched.span).toBe(batched.want);
+  }, 20_000);
+});


### PR DESCRIPTION
## Symptom

A completed tool root / subagent block / card flushed to scrollback rendered with **tall blank, gutter-less gaps** wedged between rows (and, in the worst geometry, **dropped rows**) when a tall overlay filled most of the viewport during the flush — the "weird gaps" in the TUI diff render.

The blank rows are NOT a diff-formatting bug: `colorDiffLine` correctly emits a green `+ ` gutter for blank added lines. They are real content rows that the band-hold painter never drew.

## Root cause

`TerminalCompositor.commitAbove` is designed to place a whole block with **one geometry decision** — a single pre-clear `prevTopRow` capture and a single fits / band-hold / overflow route (see `terminal-compositor.committed-band-commit.ts`, "one geometry per commit", and `commit-mode.ts`).

Several flush sites instead committed the block **one line per call**:

```ts
for (const line of lines) compositor.commitAbove(line);
compositor.commitAbove('');
```

Under a tall overlay the per-line band-hold/fits routing desyncs the committed-band model from the screen: `maxRun` caps each tiny commit, some rows stay **pending** (in `committedBand`, never painted — `committedBandPaintedRows < committedBand.length`), and the next per-line commit scrolls those unpainted blank rows into scrollback. Line order is preserved, but blank rows are interleaved (or a row beyond `maxBandModel` is dropped).

This was reproduced against the real `@xterm/headless` scroll engine: at a partial-room overlay geometry, the per-line loop yields `span=29` for a 14-row block (16 blank rows wedged in), while a single batched commit yields `span=13` (contiguous).

## Fix

Add `commitBlockAbove(compositor, lines)` — a single `commitAbove` with the block joined by `\n` — and route every coherent-block flush through it:

- `flushToolLaneToScrollback` (the reported path) + the finalize-coordinator and safety-net flushes
- `emitPanel` card + subagent panel cards
- the input-echo card

`commitAbove` already splits on `\n` and hard-wraps each row, so band-hold row math stays exact and a block taller than the screen archives its overflow to scrollback with the tail hugging the frame (validated — no extra drops, refuting the "batching drops more content" concern for tall blocks).

Also corrects a stale `// commitAbove expects one logical line per call` comment in `input-surface.ts` — multi-line blocks are supported, and `markdown-stream.ts` already relies on it.

## Validation (real PTY engine)

Mock-stdout byte tests cannot observe true scrollback (see `docs/scrollback.md`), so validation drives the actual `@xterm/headless` scroll engine and asserts on its buffer.

- **New** `terminal-compositor.band-hold-perline-gap.repro.test.ts`: per-line loop is genuinely gappy at the partial-room geometry (discriminator); `commitBlockAbove` is present + single-copy + **contiguous** across overlay heights and for a block taller than the collapsed screen.
- All **975 tests across the 58 CLI rendering files** pass (band / gap / subagent / rhythm / ordering).
- `stream-renderer-ordering.test.ts` assertions updated to compare **rendered char offset** instead of `commitAbove` call index (a flushed block is now one atomic commit), preserving the eager-ancestor-header-before-children contract.
- `tsc --noEmit` clean for all changed files.

## Notes for the reviewer

- The two-block `mid≠null` drop case explored during investigation (a second flush with only one intervening repaint) is a **separate** root cause (the `overflowHasPending` pending-count proxy in `commit-mode.ts`) and is not reachable in production — the ~80ms spinner-render cadence drains pending rows between flushes. Left as a documented follow-up rather than scope-creeping this fix.