### PR TITLE
fix(trace): accept absent hook_decision.decision key (zod 4.4 regression)

### DIFF
--- a/src/agent/trace/events.test.ts
+++ b/src/agent/trace/events.test.ts
@@ -125,6 +125,31 @@ describe('hook_decision payload', () => {
     ).not.toThrow();
   });
 
+  // Regression: the pass-through case writes `decision: undefined`, and
+  // JSON.stringify drops undefined-valued keys, so a PERSISTED line has no
+  // `decision` key at all. The reader must accept the absent-key form. Under a
+  // `z.union([..., z.undefined()])` field, zod ≥4.4 rejected the missing key
+  // ("expected nonoptional"), silently invalidating ~every hook_decision line
+  // in `afk improve scan`. `.optional()` is what makes absence valid.
+  it('accepts a payload with the decision key entirely absent', () => {
+    expect(() =>
+      HookDecisionPayloadSchema.parse({ hookEvent: 'SessionStart' }),
+    ).not.toThrow();
+  });
+
+  it('round-trips a pass-through event through JSON (the reader path)', () => {
+    const event = {
+      ts: '2026-06-23T16:08:08.736Z',
+      seq: 7,
+      kind: 'hook_decision' as const,
+      payload: { hookEvent: 'SessionStart' as const, decision: undefined },
+    };
+    // JSON.stringify drops `decision: undefined`; the on-disk line has no key.
+    const onDisk = JSON.parse(JSON.stringify(event));
+    expect(Object.prototype.hasOwnProperty.call(onDisk.payload, 'decision')).toBe(false);
+    expect(TraceEventSchema.safeParse(onDisk).success).toBe(true);
+  });
+
   it('rejects unknown hookEvent', () => {
     expect(() =>
       HookDecisionPayloadSchema.parse({

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -71,7 +71,13 @@ export const HookEventNameSchema = z.enum([
 
 export const HookDecisionPayloadSchema = z.object({
   hookEvent: HookEventNameSchema,
-  decision: z.union([z.literal('block'), z.literal('approve'), z.undefined()]),
+  // Invariant: `decision` is absent on the wire for the pass-through case —
+  // the writer sets it to `undefined`, and JSON.stringify drops undefined-valued
+  // keys, so a persisted line has no `decision` key at all. `.optional()` (not a
+  // `z.undefined()` union member) is required: zod ≥4.4 treats a union-with-undefined
+  // field as nonoptional and rejects a MISSING key, which silently invalidated
+  // every pass-through hook_decision line in `afk improve scan`.
+  decision: z.union([z.literal('block'), z.literal('approve')]).optional(),
   reason: z.string().optional(),
   blockedTool: z.string().optional(),
   injectedContextBytes: z.number().int().nonnegative().optional(),

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -125,8 +125,13 @@ export type HookEventName =
 
 export interface HookDecisionPayload {
   hookEvent: HookEventName;
-  /** `undefined` when no hook emitted a decision (all handlers passed). */
-  decision: 'block' | 'approve' | undefined;
+  /**
+   * `undefined` when no hook emitted a decision (all handlers passed). This is
+   * the common pass-through case. Optional (not `: 'block' | 'approve' | undefined`)
+   * because JSON.stringify drops undefined-valued keys: a persisted line has no
+   * `decision` key, and the reader's schema must validate that absent-key form.
+   */
+  decision?: 'block' | 'approve';
   reason?: string;
   /** Set only when `hookEvent === 'PreToolUse'` and `decision === 'block'`. */
   blockedTool?: string;


### PR DESCRIPTION
## Summary

`afk improve scan` reports a large, alarming "⚠ N invalid JSONL lines skipped" warning (observed `1014` → `1070` → `1192` across runs as sessions accumulate). The lines are **not corrupt** — they are valid, correctly-written `hook_decision` trace events that the reader's schema wrongly rejects.

This one-line schema fix (+ type alignment + regression test) makes the reader accept them again.

## Root cause

A transitive zod bump (**4.3.6 → 4.4.x**) in published builds changed object-field optionality semantics.

- The witness writer emits `hook_decision` events. For the common **pass-through** case (a hook fired but neither blocked nor approved) it sets `decision: undefined`. `JSON.stringify` drops undefined-valued keys, so the **persisted line has no `decision` key at all** (e.g. `{"...","kind":"hook_decision","payload":{"hookEvent":"SessionStart"}}`).
- The reader schema typed the field as `z.union([z.literal('block'), z.literal('approve'), z.undefined()])`.
- **zod ≥4.4** treats a union-with-`z.undefined()` field as *nonoptional* and rejects a **missing key** (`expected nonoptional, received undefined`). **zod 4.3.x accepted** the missing key.
- Net: every pass-through `hook_decision` line is dropped by the reader — a self-inflicted write/read asymmetry (writer validates `decision: undefined` fine *before* stringify; reader rejects the absent key *after* stringify).

In the affected window, **1113 of 1121** `hook_decision` lines omit `decision` (only 8 carry `decision: 'block'`), which is why the warning count tracks the hook population.

## Evidence (controlled)

- Same schema text, two zod versions: missing-`decision` payload → **accepted under 4.3.6**, **rejected under 4.4.3** (`{"code":"invalid_type","expected":"nonoptional","path":["decision"]}`).
- Per-kind isolation against the published binary: only `hook_decision` lines **without** a `decision` key are flagged; a line **with** `decision` (real or synthetic) passes; all other event kinds pass.
- Only one instance of the `z.union([…, z.undefined()])` anti-pattern exists in the tree (`src/agent/trace/events.ts`).

## Changes

- `src/agent/trace/events.ts` — `decision: z.union([z.literal('block'), z.literal('approve')]).optional()` + an `Invariant:` comment documenting the zod-4.4 trap.
- `src/agent/trace/types.ts` — canonical type aligned to `decision?: 'block' | 'approve'` (matches the wire reality: the key is genuinely absent for pass-through).
- `src/agent/trace/events.test.ts` — regression test that round-trips a pass-through event through `JSON.stringify` (dropping the undefined key) and asserts `TraceEventSchema` still accepts it. The prior test only covered `decision: undefined` (key present), which never exercised the absent-key form — that's why this slipped through.

## Verification

- `tsc --noEmit` — clean (exit 0).
- `vitest run src/agent/trace/events.test.ts src/improve/scan/reader.test.ts` — 44 tests pass.
- Authored/verified in isolation in a dedicated worktree off `origin/main` (v4.32.0); the change is forward-correct under both zod 4.3.x and 4.4.x.

## Blast radius

Low. The only detector consuming `hook_decision` is `subagent-block`, which needs `decision: 'block'` lines (retained either way), so existing detections are unaffected. The fix restores the dropped pass-through events to the scan's event stream and removes the spurious warning. No runtime behavior change to the writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
