### PR TITLE
fix(tui): use exact painted-row count for the band-hold pending signal (#255 follow-up)

### DIFF
--- a/src/cli/commit-mode.test.ts
+++ b/src/cli/commit-mode.test.ts
@@ -19,6 +19,7 @@ function base(overrides: Partial<CommitModeInput> = {}): CommitModeInput {
     extraRows: 2,
     committedBand: [],
     committedBandBottomRow: 0,
+    committedBandPaintedRows: 0,
     ...overrides,
   };
 }
@@ -89,6 +90,34 @@ describe('decideCommitMode', () => {
     expect(m.overflowRun).toHaveLength(22);
     expect(m.overflowRun.length > m.maxBandModel).toBe(true);
     expect(m.useBandHold).toBe(true); // without the override this would be false
+  });
+
+  it('overflowHasPending uses the exact painted-row count, not the room geometry proxy (#255 two-block follow-up)', () => {
+    // Deferred #255 follow-up. Under a single intervening repaint the frame top
+    // can grow so `room` (frameTop - anchorFloor = 7) exceeds the band length
+    // (5) WHILE pending rows remain (only 3 of 5 painted). The OLD proxy
+    // `committedBand.length > room` reads 5 > 7 = FALSE → routes to the fits
+    // path, which scrolls the 2 unpainted rows into scrollback as BLANKS (the
+    // drop). The EXACT signal `committedBand.length > committedBandPaintedRows`
+    // reads 5 > 3 = TRUE → stays on band-hold and archives REAL content.
+    const band = ['b0', 'b1', 'b2', 'b3', 'b4'];
+    const m = decideCommitMode(
+      base({
+        prevTopRow: 8,
+        frameTop: 8, // room = 8 - 1 = 7
+        lineCount: 2,
+        textLines: ['new-a', 'new-b'],
+        committedBand: band,
+        committedBandBottomRow: 7, // === frameTop - 1 → contiguous
+        committedBandPaintedRows: 3, // 2 of 5 rows still pending
+      }),
+    );
+    // Prove this geometry is exactly where the proxy and the exact signal DIVERGE.
+    expect(m.room).toBe(7);
+    expect(band.length > m.room).toBe(false); // the old proxy → "no pending" (wrong)
+    expect(m.overflowPriorContiguous).toBe(true);
+    expect(m.overflowHasPending).toBe(true); // the exact signal → pending (right)
+    expect(m.useBandHold).toBe(true); // would route to the fits path under the proxy
   });
 
   it('merges the prior band into the run only when verifiably contiguous', () => {

--- a/src/cli/commit-mode.ts
+++ b/src/cli/commit-mode.ts
@@ -32,6 +32,14 @@ export interface CommitModeInput {
   committedBand: string[];
   /** Tracked bottom row of the committed band (0 when unset). */
   committedBandBottomRow: number;
+  /**
+   * How many of `committedBand`'s rows are MATERIALIZED on the terminal now
+   * (always the bottom suffix nearest the frame). The complementary prefix
+   * `committedBand.slice(0, length - committedBandPaintedRows)` is PENDING —
+   * held only in the in-memory band model, never painted, never archived.
+   * Drives the EXACT `overflowHasPending` signal (see decideCommitMode).
+   */
+  committedBandPaintedRows: number;
 }
 
 /** The routing decision + the geometry the caller's phases consume. */
@@ -48,7 +56,7 @@ export interface CommitMode {
   overflowPriorContiguous: boolean;
   /** Prior band + new lines (merged when contiguous, else just the new lines). */
   overflowRun: string[];
-  /** Prior band carries rows never painted on screen because the held overlay left only `room` rows visible. */
+  /** Prior band carries rows never painted on screen (`committedBandPaintedRows < committedBand.length`) — held only in the model, not on screen, not in scrollback. */
   overflowHasPending: boolean;
   /** Route this commit through the band-hold path (hold in the model; don't archive + truncate). */
   useBandHold: boolean;
@@ -76,14 +84,18 @@ export interface CommitMode {
  *    `prevTopRow <= 1` the block is HELD in the model and painted by
  *    repositionCommittedBand() on collapse, NOT dropped down the overflow path.
  *
- *  • `overflowHasPending` — once the prior band carries PENDING rows (rows in
- *    the model never painted because the held overlay left only `room` visible),
- *    the commit MUST stay on band-hold even when the merged run exceeds
- *    maxBandModel (review #649 P1). The fits path scrolls from
+ *  • `overflowHasPending` — once the prior band carries PENDING rows (rows held
+ *    in the model but never painted: `committedBandPaintedRows < committedBand
+ *    .length`), the commit MUST stay on band-hold even when the merged run
+ *    exceeds maxBandModel (review #649 P1). The fits path scrolls from
  *    `committedBand.length`, which counts those pending rows; routing there
  *    would scroll unpainted blanks into scrollback while Phase 3's cap drops the
  *    real rows. Band-hold Phase 1 instead archives the genuine overflow (the
- *    oldest rows beyond what the collapsed screen holds) as REAL content.
+ *    oldest rows beyond what the collapsed screen holds) as REAL content. This
+ *    test compares the EXACT painted-row count, NOT the `room` geometry proxy
+ *    (`committedBand.length > room`): after a single intervening repaint grew
+ *    `room` past the band length while pending rows remained, the proxy read
+ *    false and dropped them (the two-block follow-up deferred from PR #255).
  *
  * A block taller than the collapsed screen with no pending rows
  * (`overflowRun.length > maxBandModel`, `!overflowHasPending`) takes neither
@@ -105,6 +117,7 @@ export function decideCommitMode(input: CommitModeInput): CommitMode {
     extraRows,
     committedBand,
     committedBandBottomRow,
+    committedBandPaintedRows,
   } = input;
 
   const fitsAboveFrame = prevTopRow > 1 && lineCount <= frameTop - anchorFloor;
@@ -115,7 +128,8 @@ export function decideCommitMode(input: CommitModeInput): CommitMode {
   const overflowPriorContiguous =
     committedBand.length > 0 && anchorRow <= 1 && committedBandBottomRow === frameTop - 1;
   const overflowRun = overflowPriorContiguous ? [...committedBand, ...textLines] : textLines;
-  const overflowHasPending = overflowPriorContiguous && committedBand.length > room;
+  const overflowHasPending =
+    overflowPriorContiguous && committedBand.length > committedBandPaintedRows;
   const useBandHold =
     overflowHasPending || (overflowRun.length <= maxBandModel && !fitsAboveFrame);
 

--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -254,6 +254,7 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     extraRows,
     committedBand: self.committedBand,
     committedBandBottomRow: self.committedBandBottomRow,
+    committedBandPaintedRows: self.committedBandPaintedRows,
   });
 
   // Suppress the shrink re-pin for the whole commit; Phase 3 sets the band.


### PR DESCRIPTION
> **Stacked on #255** (base branch `fix/tui-band-hold-pending-gap`, not `main`). This PR is the follow-up that #255's reviewer note explicitly deferred. Review/merge after #255, or rebase onto `main` if #255 lands first.

## What this resolves

#255's "Notes for the reviewer" deferred a **separate** root cause:

> The two-block `mid != null` drop case ... is a separate root cause (the `overflowHasPending` pending-count proxy in `commit-mode.ts`) and is not reachable in production — the ~80ms spinner-render cadence drains pending rows between flushes. Left as a documented follow-up rather than scope-creeping this fix.

This PR fixes that proxy.

## Root cause

`decideCommitMode` routes a `commitAbove` block to the band-hold path when the prior committed band still carries **pending** rows — rows held in the in-memory band model but never painted to the terminal and never archived to scrollback. It detected that condition with a **geometry proxy**:

```ts
const overflowHasPending = overflowPriorContiguous && committedBand.length > room;
```

`room` (`frameTop - anchorFloor`) is the above-frame space *right now*. The proxy assumes "band taller than current room ⟹ some rows are pending." That breaks in the two-block sequence with exactly **one** intervening repaint: the repaint grows `frameTop` (the overlay shrank a little) so `room` now exceeds `committedBand.length`, yet the earlier paint left rows unpainted (`committedBandPaintedRows < committedBand.length`). The proxy reads `length > room == false` → no pending → routes the next commit to the **fits path**, which scrolls those still-unpainted rows into scrollback as **blanks** (and Phase 3's cap drops the real rows). That is the deferred drop.

In production the ~80ms spinner-render cadence fires several repaints between flushes, so `repositionCommittedBand` paints the pending rows (driving `committedBandPaintedRows` up to `committedBand.length`) before the second flush — which is why it was "not reachable" and safely deferred. This PR makes the signal correct regardless of cadence.

## Fix

Use the exact painted-row count the compositor **already tracks** instead of the geometry proxy:

```ts
const overflowHasPending =
  overflowPriorContiguous && committedBand.length > committedBandPaintedRows;
```

The pending prefix is exactly `committedBand.slice(0, length - committedBandPaintedRows)` (see the invariant on `TerminalCompositor.committedBandPaintedRows`, `terminal-compositor.ts:323-339`). `committedBandPaintedRows` is maintained at every paint site (commit Phase 3, `repositionCommittedBand`, `preserveRowsBeforeFrameRender`) and reset to 0 by `clearCommittedBand()` — so this adds **no new state**, only threads the existing field through the single `decideCommitMode` call site.

- `commit-mode.ts` — new non-optional `CommitModeInput.committedBandPaintedRows`; exact signal; doc comments updated (the `room` proxy is retired but `room` itself stays, still consumed by the fits-path math).
- `terminal-compositor.committed-band-commit.ts` — pass `self.committedBandPaintedRows` (the `CommittedBandHost` interface already declared the field).
- `commit-mode.test.ts` — `base()` gains `committedBandPaintedRows: 0`; a new divergence regression.

**Behavioral delta:** the change only flips `overflowHasPending` `false → true` in the divergence case (pending rows exist but `room >= band length`) — strictly the bug-fix direction. Everywhere else it is a no-op (when the band is fully painted there are no pending rows, and `committedBand.length > committedBandPaintedRows` matches the old proxy whenever the proxy was right).

## Validation

- **New** `commit-mode.test.ts` case `overflowHasPending uses the exact painted-row count, not the room geometry proxy (#255 two-block follow-up)`: at the divergence geometry (`band=5`, `room=7`, `painted=3`) it asserts `band.length > room === false` (the old proxy would say "no pending") while `overflowHasPending === true` and `useBandHold === true` (the exact signal routes to band-hold). It fails on the proxy, passes on the fix.
- `commit-mode.test.ts` — **14/14** (13 prior + the new case).
- All **23 `terminal-compositor*` suites — 306 tests green** (overflow-gap, scrollback-gap, banner-commit-gap, h1-prevtoprow, disarm-pending-band, band-hold-perline-gap.repro, shrink-gap, committed-band-single-copy, wrap-overlap, …).
- `tsc --noEmit` clean (the non-optional field forces every call site to be wired).

Validation is at the **pure `decideCommitMode` unit** deliberately: the deferred case is unreachable through the `@xterm/headless` harness (it needs *exactly* one intervening repaint, which the harness/cadence does not produce), so the unit that owns the routing arithmetic is the faithful and discriminating level for it.
