### PR TITLE
feat(trace): emit tool_call + session_phase from openai-compatible provider

### DIFF
--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -2011,3 +2011,224 @@ describe('OpenAICompatibleQuery — retry / backoff (issue #126)', () => {
     ).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Witness-layer trace emission — parity with anthropic-direct/loop.test.ts
+// ---------------------------------------------------------------------------
+
+describe('OpenAICompatibleQuery — witness-layer trace emission', () => {
+  // Build a two-turn scripted client: turn 1 returns a tool_call, turn 2 text.
+  function installToolThenTextClient(
+    toolId: string,
+    toolName: string,
+    toolArgs: string,
+  ): void {
+    const factory = () =>
+      ({
+        chat: {
+          completions: {
+            create: (() => {
+              let callIdx = 0;
+              return async (_args: unknown, _opts?: unknown) => {
+                const turn = callIdx++;
+                if (turn === 0) {
+                  // First call: tool_call finish
+                  return (async function* () {
+                    yield {
+                      choices: [
+                        {
+                          delta: {
+                            tool_calls: [
+                              {
+                                index: 0,
+                                id: toolId,
+                                type: 'function',
+                                function: { name: toolName, arguments: toolArgs },
+                              },
+                            ],
+                          },
+                        },
+                      ],
+                    };
+                    yield {
+                      choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+                      usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+                    };
+                  })();
+                } else {
+                  // Subsequent calls: text finish
+                  return (async function* () {
+                    yield {
+                      choices: [
+                        { delta: { content: 'done' }, finish_reason: 'stop' },
+                      ],
+                      usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12 },
+                    };
+                  })();
+                }
+              };
+            })(),
+          },
+        },
+      }) as unknown as import('openai').default;
+    __setOpenAIClientFactory(factory);
+  }
+
+  it('emits tool_call started+completed for each dispatched tool', async () => {
+    const { InMemoryTraceWriter } = await import('../../trace/writer.js');
+    const writer = new InMemoryTraceWriter();
+
+    installToolThenTextClient('call_search_1', 'search', '{"q":"hello"}');
+
+    const handlerCalls: string[] = [];
+    const { dispatcher } = makeDispatcherForPR2();
+    // Override the echo handler so it returns a deterministic result.
+    (dispatcher as unknown as { handlers: Map<string, unknown> }).handlers?.set(
+      'search',
+      async () => {
+        handlerCalls.push('search');
+        return { content: 'search result' };
+      },
+    );
+
+    // Build a provider that has the trace writer threaded in.
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'sk-test', source: 'env:OPENAI_API_KEY' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'test-session',
+      promptStream: singleInput('search please'),
+      config: { model: 'gpt-4o-mini', apiKey: 'sk-test' } as AgentConfig,
+      toolDispatcher: dispatcher,
+      traceWriter: writer,
+    });
+
+    await collect(q);
+    // Drain microtasks so fire-and-forget emit calls settle.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const toolCallEvents = writer.events.filter((e) => e.kind === 'tool_call');
+    expect(toolCallEvents).toHaveLength(2);
+    if (toolCallEvents[0]?.kind !== 'tool_call' || toolCallEvents[1]?.kind !== 'tool_call') {
+      throw new Error('unreachable');
+    }
+    const [started, completed] = [toolCallEvents[0], toolCallEvents[1]];
+    expect(started.payload.phase).toBe('started');
+    expect(completed.payload.phase).toBe('completed');
+
+    if (started.payload.phase !== 'started') throw new Error('unreachable');
+    if (completed.payload.phase !== 'completed') throw new Error('unreachable');
+
+    expect(started.payload.toolUseId).toBe('call_search_1');
+    expect(started.payload.name).toBe('search');
+    expect(started.payload.inputBytes).toBeGreaterThan(0);
+
+    expect(completed.payload.toolUseId).toBe('call_search_1');
+    expect(completed.payload.name).toBe('search');
+    expect(completed.payload.isError).toBe(false);
+    expect(completed.payload.truncated).toBe(false);
+    expect(completed.payload.durationMs).toBeGreaterThanOrEqual(0);
+    expect(completed.payload.resultBytes).toBeGreaterThan(0);
+  });
+
+  it('emits session_phase loop_start and loop_end for each turn', async () => {
+    const { InMemoryTraceWriter } = await import('../../trace/writer.js');
+    const writer = new InMemoryTraceWriter();
+
+    // Simple text-only turn — no tools.
+    pendingChunks = [
+      {
+        choices: [{ delta: { content: 'hello' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+      },
+    ];
+    // installMockClient() was already called in beforeEach; pendingChunks drives it.
+
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'sk-test', source: 'env:OPENAI_API_KEY' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'test-session-2',
+      promptStream: singleInput('hi'),
+      config: { model: 'gpt-4o-mini', apiKey: 'sk-test' } as AgentConfig,
+      traceWriter: writer,
+    });
+
+    await collect(q);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const phaseEvents = writer.events.filter((e) => e.kind === 'session_phase');
+    const phases = phaseEvents.map((e) =>
+      e.kind === 'session_phase' ? e.payload.phase : '',
+    );
+    expect(phases).toContain('loop_start');
+    expect(phases).toContain('loop_end');
+    // loop_end must carry a durationMs.
+    const loopEnd = phaseEvents.find(
+      (e) => e.kind === 'session_phase' && e.payload.phase === 'loop_end',
+    );
+    if (!loopEnd || loopEnd.kind !== 'session_phase') throw new Error('unreachable');
+    expect(typeof loopEnd.payload.durationMs).toBe('number');
+  });
+
+  it('emits model_ttfb on the first streamed chunk', async () => {
+    const { InMemoryTraceWriter } = await import('../../trace/writer.js');
+    const writer = new InMemoryTraceWriter();
+
+    pendingChunks = [
+      {
+        choices: [{ delta: { content: 'hello' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
+      },
+    ];
+
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'sk-test', source: 'env:OPENAI_API_KEY' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'test-session-3',
+      promptStream: singleInput('hi'),
+      config: { model: 'gpt-4o-mini', apiKey: 'sk-test' } as AgentConfig,
+      traceWriter: writer,
+    });
+
+    await collect(q);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const ttfbEvents = writer.events.filter(
+      (e) => e.kind === 'session_phase' && e.payload.phase === 'model_ttfb',
+    );
+    expect(ttfbEvents).toHaveLength(1);
+    const ttfb = ttfbEvents[0]!;
+    if (ttfb.kind !== 'session_phase') throw new Error('unreachable');
+    expect(typeof ttfb.payload.durationMs).toBe('number');
+    expect(ttfb.payload.resolvedModel).toBe('gpt-4o-mini');
+  });
+
+  it('emits no events and does not throw when traceWriter is absent', async () => {
+    // No traceWriter — all emit helpers are no-ops.
+    installToolThenTextClient('call_noop', 'echo', '{"msg":"hi"}');
+
+    const handlerMap = new Map<string, unknown>([
+      ['echo', async () => ({ content: 'echoed' })],
+    ]);
+    const { SessionToolDispatcher: STD } = await import('../../tools/dispatcher.js');
+    const { createHookRegistry: chr } = await import('../../hooks.js');
+    const disp = new STD({
+      handlers: handlerMap as Map<string, import('../../tools/types.js').ToolHandler>,
+      schemas: [{ name: 'echo', description: 'Echo', input_schema: { type: 'object' } }],
+      hookRegistry: chr(),
+    });
+
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'sk-test', source: 'env:OPENAI_API_KEY' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'test-session-4',
+      promptStream: singleInput('echo hi'),
+      config: { model: 'gpt-4o-mini', apiKey: 'sk-test' } as AgentConfig,
+      toolDispatcher: disp,
+      // traceWriter intentionally absent
+    });
+
+    // Should not throw.
+    const events = await collect(q);
+    expect(events.some((e) => e.type === 'turn.completed')).toBe(true);
+  });
+});

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -27,6 +27,8 @@ import OpenAI from 'openai';
 import { randomUUID } from 'node:crypto';
 import type { AgentConfig } from '../../types/config-types.js';
 import type { EffortLevel } from '../../types/sdk-types.js';
+import { emitToolCall, emitSessionPhase } from '../../trace/emit.js';
+import type { TraceWriter } from '../../trace/index.js';
 import type {
   ProviderQuery,
   ProviderEvent,
@@ -261,6 +263,14 @@ export interface OpenAICompatibleQueryOptions {
    * Responses automatically regardless of this flag.
    */
   useResponsesApi?: boolean;
+  /**
+   * Witness-layer trace writer. When provided, `loop_start`/`loop_end`/
+   * `model_ttfb` session_phase events and `tool_call` started/completed
+   * events are emitted — mirroring the anthropic-direct provider's trace
+   * coverage. All emit calls are fire-and-forget; a broken writer never
+   * stalls or crashes the session.
+   */
+  traceWriter?: TraceWriter;
 }
 
 function normalizePermissionMode(mode: string | undefined): string {
@@ -330,6 +340,8 @@ export class OpenAICompatibleQuery implements ProviderQuery {
   private readonly openAITools: OpenAIFunctionTool[] | undefined;
   /** Which wire this session speaks: Chat Completions (default) or Responses. */
   private readonly wireMode: WireMode;
+  /** Witness-layer trace writer (optional). Mirrors RunTurnInput.traceWriter in anthropic-direct. */
+  private readonly traceWriter: TraceWriter | undefined;
 
   /** Running conversation state for multi-turn sessions. */
   private priorTurns: OpenAIMessage[] = [];
@@ -359,6 +371,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     this.currentPermissionMode = normalizePermissionMode(opts.config.permissionMode);
     this.toolDispatcher = opts.toolDispatcher;
     this.onPermissionMode = opts.onPermissionMode;
+    this.traceWriter = opts.traceWriter;
 
     // Pre-compute the OpenAI tool catalog once. Only `SessionToolDispatcher`
     // (and not the structural `ToolDispatcher` minimal interface) exposes
@@ -475,6 +488,29 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     // anthropic-direct/loop.ts.
     const turnStartTime = Date.now();
     const taskId = randomUUID();
+
+    // Witness layer: mark loop entry. Mirrors anthropic-direct/loop.ts:229.
+    // Fire-and-forget — a broken trace writer must never stall the turn.
+    void emitSessionPhase(this.traceWriter, { phase: 'loop_start' });
+    try {
+    yield* this._runTurnInner(content, controller, turnStartTime, taskId);
+    } finally {
+      // Witness layer: loop_end fires regardless of which exit path fired —
+      // abort, error, clean end-of-turn, or iteration cap. Mirrors
+      // anthropic-direct/loop.ts:728–734.
+      void emitSessionPhase(this.traceWriter, {
+        phase: 'loop_end',
+        durationMs: Date.now() - turnStartTime,
+      });
+    }
+  }
+
+  private async *_runTurnInner(
+    content: ProviderUserTurn['content'],
+    controller: AbortController,
+    turnStartTime: number,
+    taskId: string,
+  ): AsyncGenerator<ProviderEvent> {
 
     // Vision capability is fixed for the turn (the model can only change
     // between turns via setModel). Computed once here and threaded into the
@@ -757,6 +793,9 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       for (;;) {
         const state = createStreamState();
 
+        // Witness layer: stamp request-initiation time for model_ttfb below.
+        const requestStartedAt = Date.now();
+
         // ── Connection-phase retry ──────────────────────────────────────
         let stream: AsyncIterable<ResponsesStreamEvent>;
         let connectionError: unknown = null;
@@ -786,10 +825,23 @@ export class OpenAICompatibleQuery implements ProviderQuery {
 
         // ── Mid-stream consumption with retry ───────────────────────────
         let streamError: unknown = null;
+        // Witness layer: emit model_ttfb exactly once per API call, on the
+        // first translated stream event. Reset per for(;;) iteration so each
+        // retry-driven call reports its own time-to-first-byte. Mirrors
+        // anthropic-direct/loop.ts:307–327.
+        let ttfbEmitted = false;
         try {
           for await (const event of stream!) {
             if (this.closed) return null;
             for (const ev of translateResponsesEvent(event, state, this.initSessionId)) {
+              if (!ttfbEmitted) {
+                ttfbEmitted = true;
+                void emitSessionPhase(this.traceWriter, {
+                  phase: 'model_ttfb',
+                  durationMs: Date.now() - requestStartedAt,
+                  resolvedModel: this.currentModel,
+                });
+              }
               yield ev;
             }
           }
@@ -855,6 +907,9 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       for (;;) {
         const state = createStreamState();
 
+        // Witness layer: stamp request-initiation time for model_ttfb below.
+        const requestStartedAt = Date.now();
+
         // ── Connection-phase retry ──────────────────────────────────────
         let stream: AsyncIterable<OpenAIChunk>;
         let connectionError: unknown = null;
@@ -885,10 +940,23 @@ export class OpenAICompatibleQuery implements ProviderQuery {
 
         // ── Mid-stream consumption with retry ───────────────────────────
         let streamError: unknown = null;
+        // Witness layer: emit model_ttfb exactly once per API call, on the
+        // first translated stream event. Reset per for(;;) iteration so each
+        // retry-driven call reports its own time-to-first-byte. Mirrors
+        // anthropic-direct/loop.ts:307–327.
+        let ttfbEmitted = false;
         try {
           for await (const chunk of stream!) {
             if (this.closed) return null;
             for (const ev of translateChunk(chunk, state, this.initSessionId)) {
+              if (!ttfbEmitted) {
+                ttfbEmitted = true;
+                void emitSessionPhase(this.traceWriter, {
+                  phase: 'model_ttfb',
+                  durationMs: Date.now() - requestStartedAt,
+                  resolvedModel: this.currentModel,
+                });
+              }
               yield ev;
             }
           }
@@ -960,8 +1028,26 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     }
     const { calls, parseErrors } = accumulatedToolCallsToToolCalls(accumulated, signal);
 
+    // Witness layer: per-call start timestamps keyed by toolUseId so the
+    // completed trace event carries an accurate durationMs. Mirrors
+    // anthropic-direct/loop.ts:524-525. Lives within this dispatchAndAppend
+    // invocation only — the next tool-use round starts fresh.
+    const startTimes = new Map<string, number>();
+
     // Emit tool.use.start BEFORE dispatching, matching anthropic-direct.
+    // Witness layer: tool_call.started fires here too — BEFORE dispatch so
+    // even a crashing tool leaves evidence that it was attempted. Mirrors
+    // anthropic-direct/loop.ts:535-543.
     for (const call of calls) {
+      const now = Date.now();
+      startTimes.set(call.id, now);
+      // Fire-and-forget — emitToolCall swallows writer errors internally.
+      void emitToolCall(this.traceWriter, {
+        phase: 'started',
+        toolUseId: call.id,
+        name: call.name,
+        inputBytes: Buffer.byteLength(JSON.stringify(call.input ?? {}), 'utf8'),
+      });
       yield {
         type: 'tool.use.start',
         toolUseId: call.id,
@@ -1035,6 +1121,25 @@ export class OpenAICompatibleQuery implements ProviderQuery {
           };
         }
         results.push({ call, result });
+
+        // Witness layer: tool_call.completed pairs with the .started event
+        // emitted above. Mirrors anthropic-direct/loop.ts:605-624.
+        // Fire-and-forget to keep the loop iteration cheap.
+        const startedAt = startTimes.get(call.id);
+        const durationMs = typeof startedAt === 'number' ? Date.now() - startedAt : 0;
+        const truncated = result.truncated === true || result.content.includes('[output truncated');
+        void emitToolCall(this.traceWriter, {
+          phase: 'completed',
+          toolUseId: call.id,
+          name: call.name,
+          resultBytes: Buffer.byteLength(result.content, 'utf8'),
+          isError: result.isError === true,
+          truncated,
+          durationMs,
+          ...(result.circuitBreaker === true ? { circuitBreaker: true } : {}),
+          ...(result.failureClass ? { failureClass: result.failureClass } : {}),
+        });
+
         yield {
           type: 'tool.output',
           toolUseId: call.id,
@@ -1312,5 +1417,8 @@ export function buildQueryFromConfig(
   if (options.onPermissionMode !== undefined) opts.onPermissionMode = options.onPermissionMode;
   if (options.mcpManager !== undefined) opts.mcpManager = options.mcpManager;
   if (options.useResponsesApi !== undefined) opts.useResponsesApi = options.useResponsesApi;
+  // Thread traceWriter from AgentConfig so witness events are emitted for
+  // openai-compatible sessions when a session-scoped trace writer is present.
+  if (config.traceWriter !== undefined) opts.traceWriter = config.traceWriter;
   return new OpenAICompatibleQuery(opts);
 }


### PR DESCRIPTION
## What & why

The openai-compatible provider (`gpt-*`, `codex-*`, and local OpenAI-shim models — MLX / Qwen / llama.cpp / vLLM) emitted **zero** witness-trace events for tool calls and loop phases, while `anthropic-direct` emits them. Every non-Anthropic session was a blind spot for per-tool latency/error/truncation telemetry and the loop latency waterfall — even though the trace writer was already threaded into the provider.

Surfaced by a trace-parity audit (HIGH-severity gap).

## Change

Mirror `anthropic-direct/loop.ts` emission in the openai-compatible query loop:

- `session_phase`: `loop_start` (turn entry), `loop_end` (in a `try/finally` so it fires on every exit path — abort / error / clean end / iteration-cap), and `model_ttfb` (first translated stream event, once per API call, in **both** the Chat Completions and Responses wire paths).
- `tool_call`: `started` (before dispatch, so a crashing tool still leaves evidence) and `completed` (with `durationMs`, `resultBytes`, `isError`, `truncated`, `circuitBreaker?`, `failureClass?`) — the same field shape anthropic-direct uses.
- `traceWriter` threaded from `AgentConfig` via `buildQueryFromConfig`.

All emit calls are fire-and-forget (`void emit...`); a missing or broken writer is a no-op and never stalls the turn.

## Tests

+4 tests in `query.test.ts` — `tool_call` started+completed, `loop_start`/`loop_end`, `model_ttfb`, and no-throw / no-emit when `traceWriter` is absent. **68/68 pass.**

## Verification

- `pnpm lint` (tsc --noEmit strict): clean
- `pnpm exec vitest run src/agent/providers/openai-compatible/query.test.ts`: 68 passed

No new `@anthropic-ai/sdk` imports (the emit helpers are internal to `agent-afk`).
