### PR TITLE
fix(trace): pass traceWriter to MCP manager on telegram surface

### DIFF
--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -34,7 +34,7 @@ import { TelegramBot } from './telegram/bot.js';
 import { parseAllowedChatIds } from './telegram/allowlist.js';
 import { validateBotToken } from './telegram/setup-wizard.js';
 import { AgentSession } from './agent/session.js';
-import { constructTelegramSession } from './telegram/construct-session.js';
+import { constructTelegramSession, createTelegramTraceWriter } from './telegram/construct-session.js';
 import { createDefaultHookRegistry } from './agent/default-hook-registry.js';
 import { seedPersistedGrants } from './agent/permissions-store.js';
 import { loadHooksConfig } from './agent/hooks/config-loader.js';
@@ -231,7 +231,13 @@ async function main() {
       );
 
       const sessionCwd = sessionConfig.cwd ?? telegramCwd;
-      const mcpManager = await loadTelegramMcpManager(sessionCwd);
+      // Create the trace writer before loadTelegramMcpManager so the MCP
+      // connect phase (mcp_server_start/done, mcp_connect_start/done) is
+      // captured in the same session trace as the rest of the Telegram session.
+      const telegramTraceWriter = createTelegramTraceWriter();
+      const mcpManager = await loadTelegramMcpManager(sessionCwd, {
+        ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}),
+      });
       let returnedSession: AgentSession | undefined;
       try {
         let directProvider;
@@ -384,7 +390,7 @@ async function main() {
           ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
           provider: directProvider,
           hookRegistry: telegramHookBundle.registry,
-        }), mcpManager);
+        }, { traceWriter: telegramTraceWriter }), mcpManager);
         returnedSession = session;
         // Wire the path-approval grant ref to the provider so elicitation
         // approvals mutate readRoots / writeRoots on the right backend.
@@ -441,7 +447,7 @@ async function main() {
           : {}),
         provider: codexProvider,
         hookRegistry: codexHookBundle.registry,
-      }), mcpManager);
+      }, { traceWriter: telegramTraceWriter }), mcpManager);
       returnedSession = session;
       // Wire the path-approval grant ref + seed persisted `persist` grants so
       // the OpenAI Telegram surface gets the same restricted-path prompts and

--- a/src/telegram/construct-session.test.ts
+++ b/src/telegram/construct-session.test.ts
@@ -7,11 +7,11 @@
  * handed to `new AgentSession(...)` without constructing a real session.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { constructTelegramSession } from './construct-session.js';
+import { constructTelegramSession, createTelegramTraceWriter } from './construct-session.js';
 import type { AgentConfig } from '../agent/types.js';
 import type { AgentSession } from '../agent/session.js';
 import type { TraceWriter } from '../agent/trace/writer.js';
@@ -74,5 +74,50 @@ describe('constructTelegramSession', () => {
       { newSession: (c): AgentSession => { captured = c; return {} as unknown as AgentSession; } },
     );
     expect(captured?.traceWriter).toBe(operatorWriter);
+  });
+
+  it('uses a pre-created traceWriter from deps.traceWriter instead of calling the factory', () => {
+    const preCreated = { __preCreated: true } as unknown as TraceWriter;
+    const factorySpy = vi.fn();
+    let captured: AgentConfig | undefined;
+    constructTelegramSession(
+      { model: 'sonnet' },
+      {
+        traceWriter: preCreated,
+        createTraceWriter: factorySpy,
+        newSession: (c): AgentSession => { captured = c; return {} as unknown as AgentSession; },
+      },
+    );
+    expect(captured?.traceWriter).toBe(preCreated);
+    expect(factorySpy).not.toHaveBeenCalled();
+  });
+
+  it('suppresses tracing when deps.traceWriter is null (explicit disable)', () => {
+    let captured: AgentConfig | undefined;
+    constructTelegramSession(
+      { model: 'sonnet' },
+      {
+        traceWriter: null,
+        newSession: (c): AgentSession => { captured = c; return {} as unknown as AgentSession; },
+      },
+    );
+    expect(captured?.traceWriter).toBeUndefined();
+  });
+});
+
+describe('createTelegramTraceWriter', () => {
+  it('returns a TraceWriter when the factory succeeds', () => {
+    const fakeWriter = { __fake: true } as unknown as TraceWriter;
+    const result = createTelegramTraceWriter(() => ({
+      writer: fakeWriter,
+      tracePath: '/tmp/fake',
+      sessionLabel: 'test-label',
+    }));
+    expect(result).toBe(fakeWriter);
+  });
+
+  it('returns null when the factory returns null (tracing disabled)', () => {
+    const result = createTelegramTraceWriter(() => null);
+    expect(result).toBeNull();
   });
 });

--- a/src/telegram/construct-session.ts
+++ b/src/telegram/construct-session.ts
@@ -20,13 +20,40 @@
 import { AgentSession } from '../agent/session.js';
 import type { AgentConfig } from '../agent/types.js';
 import { createDefaultTraceWriter, type CreatedTraceWriter } from '../agent/trace/factory.js';
+import type { TraceWriter } from '../agent/trace/index.js';
 
 /** Injection seams for tests; both default to production behavior. */
 export interface ConstructTelegramSessionDeps {
   /** Trace-writer factory. Defaults to {@link createDefaultTraceWriter}. */
   createTraceWriter?: () => CreatedTraceWriter | null;
+  /**
+   * Pre-created trace writer to reuse for this session. When supplied, the
+   * `createTraceWriter` factory is NOT called — the caller is responsible for
+   * having already created the writer (e.g. so the same writer can be shared
+   * with `loadTelegramMcpManager` for the MCP connect phase).
+   *
+   * Setting this to `null` explicitly suppresses tracing even when a factory
+   * is available (mirrors `AFK_TRACE_DISABLED=1` behavior).
+   */
+  traceWriter?: TraceWriter | null;
   /** Session constructor. Defaults to `new AgentSession(config)`. */
   newSession?: (config: AgentConfig) => AgentSession;
+}
+
+/**
+ * Create the witness trace writer for a Telegram session without yet
+ * constructing the session. Exported so the caller can share the same writer
+ * with `loadTelegramMcpManager` — the MCP connect phase runs before the
+ * session is constructed, so the writer must be created first and threaded
+ * into both call sites.
+ *
+ * Returns `null` when tracing is disabled (`AFK_TRACE_DISABLED=1`), mirroring
+ * `createDefaultTraceWriter`'s own contract.
+ */
+export function createTelegramTraceWriter(
+  factory: () => CreatedTraceWriter | null = createDefaultTraceWriter,
+): TraceWriter | null {
+  return factory()?.writer ?? null;
 }
 
 /**
@@ -39,13 +66,19 @@ export function constructTelegramSession(
   baseConfig: AgentConfig,
   deps: ConstructTelegramSessionDeps = {},
 ): AgentSession {
-  const trace = (deps.createTraceWriter ?? createDefaultTraceWriter)();
+  // Use a pre-created writer when provided (allows sharing with loadTelegramMcpManager
+  // so MCP connect events land in the same trace). Fall back to the factory when not.
+  // `undefined` means "not supplied — run the factory"; `null` means "explicitly disabled".
+  const writer: TraceWriter | null =
+    'traceWriter' in deps
+      ? (deps.traceWriter ?? null)
+      : ((deps.createTraceWriter ?? createDefaultTraceWriter)()?.writer ?? null);
   // Default trace writer is spread FIRST so an operator-supplied
   // baseConfig.traceWriter still wins — escape-hatch parity with the daemon's
   // spawnSession (where ...sessionConfig is spread last). `surface: 'telegram'`
   // is stamped last (always telegram here) for trace `origin` attribution.
-  const config: AgentConfig = trace
-    ? { traceWriter: trace.writer, ...baseConfig, surface: 'telegram' }
+  const config: AgentConfig = writer
+    ? { traceWriter: writer, ...baseConfig, surface: 'telegram' }
     : { ...baseConfig, surface: 'telegram' };
   const construct = deps.newSession ?? ((c: AgentConfig) => new AgentSession(c));
   return construct(config);

--- a/src/telegram/mcp-session.test.ts
+++ b/src/telegram/mcp-session.test.ts
@@ -17,7 +17,8 @@ import { OpenAICompatibleProvider } from '../agent/providers/index.js';
 import type { ProviderEvent } from '../agent/provider.js';
 import type { AgentConfig, IAgentSession } from '../agent/types.js';
 import type { AgentSession } from '../agent/session.js';
-import type { McpManager } from '../agent/mcp/index.js';
+import { McpManager } from '../agent/mcp/index.js';
+import type { TraceWriter } from '../agent/trace/index.js';
 import { constructTelegramSession } from './construct-session.js';
 import { attachMcpCleanup, loadTelegramMcpManager } from './mcp-session.js';
 
@@ -86,6 +87,27 @@ describe('Telegram MCP session wiring', () => {
   it('returns undefined when the Telegram session has no MCP config', async () => {
     await expect(loadTelegramMcpManager(noConfigCwd)).resolves.toBeUndefined();
   });
+
+  it(
+    'forwards the traceWriter option into McpManager.fromConfig',
+    async () => {
+      await writeFixtureMcpConfig(projectCwd);
+      const fakeWriter = { __trace: true } as unknown as TraceWriter;
+
+      const fromConfigSpy = vi.spyOn(McpManager, 'fromConfig');
+      try {
+        manager = await loadTelegramMcpManager(projectCwd, { traceWriter: fakeWriter });
+        expect(manager).toBeDefined();
+        expect(fromConfigSpy).toHaveBeenCalledOnce();
+        // The second argument to fromConfig must carry our traceWriter.
+        const optsArg = fromConfigSpy.mock.calls[0]?.[1];
+        expect(optsArg?.traceWriter).toBe(fakeWriter);
+      } finally {
+        fromConfigSpy.mockRestore();
+      }
+    },
+    { timeout: 15_000 },
+  );
 
   it(
     'exposes project-local fixture MCP tools through the Telegram provider/session path',

--- a/src/telegram/mcp-session.ts
+++ b/src/telegram/mcp-session.ts
@@ -11,8 +11,24 @@
 import type { IAgentSession } from '../agent/types.js';
 import { McpManager, loadMcpConfig, getMcpConfigPath } from '../agent/mcp/index.js';
 import { loadImportFromConfig, resolveImportedRoots } from '../config/import-sources.js';
+import { emitSessionPhase } from '../agent/trace/emit.js';
+import type { TraceWriter } from '../agent/trace/index.js';
 
-export async function loadTelegramMcpManager(cwd: string | undefined): Promise<McpManager | undefined> {
+export interface LoadTelegramMcpManagerOptions {
+  /**
+   * Witness-layer trace writer for the current session. When present,
+   * `loadTelegramMcpManager` emits `mcp_connect_start`/`mcp_connect_done`
+   * span events around the connect phase (surface-parity with chat.ts) and
+   * threads the writer into `McpManager.fromConfig` so per-server
+   * `mcp_server_start`/`mcp_server_done` events are also captured.
+   */
+  traceWriter?: TraceWriter;
+}
+
+export async function loadTelegramMcpManager(
+  cwd: string | undefined,
+  opts: LoadTelegramMcpManagerOptions = {},
+): Promise<McpManager | undefined> {
   const importedMcpConfigs = resolveImportedRoots(loadImportFromConfig())
     .mcpConfigs.filter((c) => c.format === 'json')
     .map((c) => c.source);
@@ -30,7 +46,24 @@ export async function loadTelegramMcpManager(cwd: string | undefined): Promise<M
     ? loaded.sources[0]
     : `${loaded.sources.length} source(s)`;
   console.log(`  mcp: ${enabledCount} server(s) from ${sourcesLabel ?? getMcpConfigPath()}`);
-  return McpManager.fromConfig(loaded.mcpServers, { warnings: loaded.warnings });
+
+  const mcpStartedAt = Date.now();
+  void emitSessionPhase(opts.traceWriter, {
+    phase: 'mcp_connect_start',
+    metadata: { serverCount: enabledCount },
+  });
+  try {
+    return await McpManager.fromConfig(loaded.mcpServers, {
+      warnings: loaded.warnings,
+      ...(opts.traceWriter !== undefined ? { traceWriter: opts.traceWriter } : {}),
+    });
+  } finally {
+    void emitSessionPhase(opts.traceWriter, {
+      phase: 'mcp_connect_done',
+      durationMs: Date.now() - mcpStartedAt,
+      metadata: { serverCount: enabledCount },
+    });
+  }
 }
 
 export function attachMcpCleanup<T extends IAgentSession>(session: T, mcpManager: McpManager | undefined): T {


### PR DESCRIPTION
## What & why

`telegram/mcp-session.ts` called `McpManager.fromConfig` without a `traceWriter`, so per-server MCP connect/lifecycle events (`mcp_connect_*` / `mcp_server_*`) were invisible on the telegram surface. The daemon path passes the writer; telegram didn't. Surfaced by a trace-parity audit (MED-severity gap).

## Change

Root cause: telegram connected MCP **before** the session (and its trace writer) was constructed, so there was no writer to pass. Fix:

- Export `createTelegramTraceWriter()` so `telegram.ts` can create the writer early and thread the **same** instance into both `loadTelegramMcpManager(..., { traceWriter })` and `constructTelegramSession(..., { traceWriter })` — one trace file then covers the full lifecycle (MCP connect → session turns).
- Added the `mcp_connect_start` / `mcp_connect_done` span around `fromConfig` (matches the `chat.ts` pattern).

> **Merge note:** also touches `src/telegram.ts` (3 lines). The PR `fix/routing-identity-completeness` also edits `telegram.ts` (a different hunk) — whichever merges second may need a trivial rebase.

## Tests / verification

- `construct-session.test.ts` + `mcp-session.test.ts`: **14 passed**
- `pnpm lint` (tsc --noEmit strict): clean
