### PR TITLE
feat(trace): emit browser_event from browser tool handlers

### DIFF
--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -263,6 +263,11 @@ export class SessionToolDispatcher implements ToolDispatcher {
   /**
    * Returns a fresh snapshot of the current handler context. Called for every
    * handler invocation so grant mutations are always reflected.
+   *
+   * Note: `toolUseId` and `traceWriter` are NOT included here — they are
+   * per-call values added inline by `execute()` and `executeCore()` via
+   * `callHandlerContext(call)` so the getter stays call-agnostic and can be
+   * used safely by code that doesn't have a live ToolCall reference.
    */
   private get handlerContext(): ToolHandlerContext {
     return {
@@ -272,6 +277,19 @@ export class SessionToolDispatcher implements ToolDispatcher {
       writeRoots: this._writeRoots.slice(),
       ...(this._allowAll ? { allowAll: true } : {}),
       ...(this._env !== undefined ? { env: this._env } : {}),
+    };
+  }
+
+  /**
+   * Returns a per-call handler context that augments the base `handlerContext`
+   * with the tool-call-specific fields (`toolUseId`, `traceWriter`). Used by
+   * `execute()` and `executeCore()` when dispatching to a named handler.
+   */
+  private callHandlerContext(call: ToolCall): ToolHandlerContext {
+    return {
+      ...this.handlerContext,
+      toolUseId: call.id,
+      ...(this.traceWriter !== undefined ? { traceWriter: this.traceWriter } : {}),
     };
   }
 
@@ -622,7 +640,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
     // 5. Execute handler
     let result: ToolResult;
     try {
-      result = await handler(call.input, call.signal, this.handlerContext);
+      result = await handler(call.input, call.signal, this.callHandlerContext(call));
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       result = { content: `Tool execution error: ${message}`, isError: true };
@@ -850,7 +868,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
 
     let result: ToolResult;
     try {
-      result = await handler(call.input, call.signal, this.handlerContext);
+      result = await handler(call.input, call.signal, this.callHandlerContext(call));
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       result = { content: `Tool execution error: ${message}`, isError: true };

--- a/src/agent/tools/handlers/browser-act.ts
+++ b/src/agent/tools/handlers/browser-act.ts
@@ -18,16 +18,13 @@
  * @module agent/tools/handlers/browser-act
  */
 
-import type { ToolHandler } from '../types.js';
+import type { ToolHandler, ToolHandlerContext } from '../types.js';
 import type { BrowserHandlerOptions } from './browser-open.js';
 import type { Target, ActAction } from '../../../browser/types.js';
 import { truncateTargetText, hashSelector } from '../../../browser/sanitize.js';
 import { env } from '../../../config/env.js';
-
-// History: browser_event witness emission is a no-op in this handler.
-// See browser-open.ts for the full rationale. The target field sanitization
-// helpers (truncateTargetText, hashSelector) are imported and called so the
-// logic is in place for when browser_event emission is wired.
+import { emitBrowserEvent } from '../../trace/emit.js';
+import type { BrowserEventTarget } from '../../trace/types.js';
 
 import {
   browserTimeoutFailureClass,
@@ -150,26 +147,26 @@ function buildAmbiguousMessage(
 }
 
 /**
- * Sanitize the target for witness emission. Returns a descriptor string
- * safe to include in trace records.
- *
- * History: this is computed eagerly even though browser_event emission is
- * currently a no-op (no TraceWriter in ToolHandlerContext). The function is
- * called at the point where `target` is in scope so future wiring only needs
- * to pass the result into `emitBrowserEvent`.
+ * Sanitize the target for witness emission. Returns a `BrowserEventTarget`
+ * safe to include in trace records — selector contents are hashed, semantic
+ * text is truncated to 80 chars.
  */
-function witnessTarget(target: Target): string {
+function witnessTarget(target: Target): BrowserEventTarget {
   if (target.kind === 'semantic') {
-    return `semantic:${truncateTargetText(target.text)}`;
+    return {
+      kind: 'semantic',
+      text: truncateTargetText(target.text),
+      ...(target.role !== undefined ? { role: target.role } : {}),
+    };
   }
   if (target.kind === 'element_id') {
-    return `element_id:${target.elementId}`;
+    return { kind: 'element_id', elementId: target.elementId };
   }
-  return `selector:${hashSelector(target.selector)}`;
+  return { kind: 'selector', selectorHash: hashSelector(target.selector) };
 }
 
 export function createBrowserActHandler(opts: BrowserHandlerOptions = {}): ToolHandler {
-  return async (input, signal) => {
+  return async (input, signal, context?: ToolHandlerContext) => {
     // Pre-aborted short-circuit.
     if (signal.aborted) {
       const reason = signal.reason;
@@ -182,9 +179,7 @@ export function createBrowserActHandler(opts: BrowserHandlerOptions = {}): ToolH
       return { content: parsed.error, isError: true };
     }
 
-    // Compute witness target descriptor (no-op currently — ready for future wiring).
-    const _targetWitness = witnessTarget(parsed.target);
-    void _targetWitness; // suppress noUnusedLocals
+    const targetWitness = witnessTarget(parsed.target);
 
     const sessionId = env.AFK_SESSION_ID ?? 'default';
     if (!/^[a-zA-Z0-9_-]+$/.test(sessionId)) {
@@ -210,6 +205,7 @@ export function createBrowserActHandler(opts: BrowserHandlerOptions = {}): ToolH
       return { content: `browser_act failed to get provider: ${msg}`, isError: true };
     }
 
+    const t0 = Date.now();
     try {
       const result = await provider.act({
         sessionId,
@@ -219,15 +215,36 @@ export function createBrowserActHandler(opts: BrowserHandlerOptions = {}): ToolH
         timeoutMs: parsed.timeoutMs,
         screenshot: parsed.screenshot,
       });
+      const durationMs = Date.now() - t0;
 
       if ('outcome' in result) {
         if (result.outcome === 'ambiguous_target') {
+          void emitBrowserEvent(context?.traceWriter, {
+            tool: 'browser_act',
+            action: parsed.action,
+            toolUseId: context?.toolUseId ?? '',
+            target: targetWitness,
+            urlBefore: null,
+            urlAfter: null,
+            status: 'ambiguous_target',
+            durationMs,
+          });
           return {
             content: buildAmbiguousMessage(result.query, result.candidates),
             isError: true,
           };
         }
         if (result.outcome === 'blocked_by_policy') {
+          void emitBrowserEvent(context?.traceWriter, {
+            tool: 'browser_act',
+            action: parsed.action,
+            toolUseId: context?.toolUseId ?? '',
+            target: targetWitness,
+            urlBefore: null,
+            urlAfter: null,
+            status: 'blocked_by_policy',
+            durationMs,
+          });
           return {
             content: `browser_act blocked: ${result.reason}`,
             isError: true,
@@ -236,10 +253,33 @@ export function createBrowserActHandler(opts: BrowserHandlerOptions = {}): ToolH
         }
       }
 
-      // BrowserObservation
+      // BrowserObservation — url is the post-action URL.
+      void emitBrowserEvent(context?.traceWriter, {
+        tool: 'browser_act',
+        action: parsed.action,
+        toolUseId: context?.toolUseId ?? '',
+        target: targetWitness,
+        urlBefore: result.url,
+        urlAfter: result.url,
+        status: 'ok',
+        durationMs,
+        ...(result.screenshotPath !== null ? { screenshotPath: result.screenshotPath } : {}),
+      });
       return { content: JSON.stringify(result, null, 2) };
     } catch (err) {
+      const durationMs = Date.now() - t0;
       const msg = err instanceof Error ? err.message : String(err);
+      void emitBrowserEvent(context?.traceWriter, {
+        tool: 'browser_act',
+        action: parsed.action,
+        toolUseId: context?.toolUseId ?? '',
+        target: targetWitness,
+        urlBefore: null,
+        urlAfter: null,
+        status: 'error',
+        durationMs,
+        error: { reason: msg, recoverable: false },
+      });
       const failureClass = browserTimeoutFailureClass(err);
       return {
         content: `browser_act failed: ${msg}`,

--- a/src/agent/tools/handlers/browser-close.ts
+++ b/src/agent/tools/handlers/browser-close.ts
@@ -10,17 +10,15 @@
  * @module agent/tools/handlers/browser-close
  */
 
-import type { ToolHandler } from '../types.js';
+import type { ToolHandler, ToolHandlerContext } from '../types.js';
 import type { BrowserHandlerOptions } from './browser-open.js';
 import { env } from '../../../config/env.js';
-
-// History: browser_event witness emission is a no-op in this handler.
-// See browser-open.ts for the full rationale.
+import { emitBrowserEvent } from '../../trace/emit.js';
 
 import { isPlaywrightMissing, playwrightMissingHint } from './playwright-hints.js';
 
 export function createBrowserCloseHandler(opts: BrowserHandlerOptions = {}): ToolHandler {
-  return async (_input, signal) => {
+  return async (_input, signal, context?: ToolHandlerContext) => {
     // Pre-aborted short-circuit.
     if (signal.aborted) {
       const reason = signal.reason;
@@ -52,11 +50,31 @@ export function createBrowserCloseHandler(opts: BrowserHandlerOptions = {}): Too
       return { content: `browser_close failed to get provider: ${msg}`, isError: true };
     }
 
+    const t0 = Date.now();
     try {
       await provider.close({ sessionId });
+      const durationMs = Date.now() - t0;
+      void emitBrowserEvent(context?.traceWriter, {
+        tool: 'browser_close',
+        toolUseId: context?.toolUseId ?? '',
+        urlBefore: null,
+        urlAfter: null,
+        status: 'ok',
+        durationMs,
+      });
       return { content: 'Browser session closed.' };
     } catch (err) {
+      const durationMs = Date.now() - t0;
       const msg = err instanceof Error ? err.message : String(err);
+      void emitBrowserEvent(context?.traceWriter, {
+        tool: 'browser_close',
+        toolUseId: context?.toolUseId ?? '',
+        urlBefore: null,
+        urlAfter: null,
+        status: 'error',
+        durationMs,
+        error: { reason: msg, recoverable: false },
+      });
       return { content: `browser_close failed: ${msg}`, isError: true };
     }
   };

--- a/src/agent/tools/handlers/browser-event-emission.test.ts
+++ b/src/agent/tools/handlers/browser-event-emission.test.ts
@@ -1,0 +1,582 @@
+/**
+ * Tests asserting that browser_event trace records are emitted when browser
+ * tool handlers are invoked with a traceWriter in their ToolHandlerContext.
+ *
+ * Each test injects an InMemoryTraceWriter via the ToolHandlerContext (the
+ * same path the dispatcher uses after the feat/browser-event-emission wiring)
+ * and verifies the resulting browser_event payload.
+ *
+ * Pattern: handler is called with `context = { traceWriter, toolUseId }`.
+ * The emitBrowserEvent helper is fire-and-forget (void), so we await a small
+ * flush tick before inspecting the writer.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { InMemoryTraceWriter } from '../../trace/index.js';
+import type { ToolHandlerContext } from '../types.js';
+import type { BrowserEventPayload } from '../../trace/types.js';
+import type { BrowserProvider } from '../../../browser/provider.js';
+import type {
+  AmbiguousTarget,
+  BlockedByPolicy,
+  BrowserObservation,
+  InteractiveElement,
+  ScreenshotResult,
+} from '../../../browser/types.js';
+import { createBrowserOpenHandler } from './browser-open.js';
+import { createBrowserActHandler } from './browser-act.js';
+import { createBrowserObserveHandler } from './browser-observe.js';
+import { createBrowserScreenshotHandler } from './browser-screenshot.js';
+import { createBrowserCloseHandler } from './browser-close.js';
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function makeSignal(): AbortSignal {
+  return new AbortController().signal;
+}
+
+function makeContext(traceWriter: InMemoryTraceWriter, toolUseId = 'tu_test'): ToolHandlerContext {
+  return { traceWriter, toolUseId };
+}
+
+/** Flush the microtask queue so fire-and-forget void promises resolve. */
+async function flush(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+function lastBrowserEvent(writer: InMemoryTraceWriter): BrowserEventPayload {
+  const ev = [...writer.events].reverse().find((e) => e.kind === 'browser_event');
+  if (!ev) throw new Error('No browser_event found in trace');
+  return ev.payload as BrowserEventPayload;
+}
+
+function makeObs(overrides: Partial<BrowserObservation> = {}): BrowserObservation {
+  return {
+    observationId: 'obs_1',
+    url: 'https://example.com',
+    title: 'Test Page',
+    textSummary: 'text',
+    interactive: [],
+    status: { httpStatus: 200, loadingState: 'idle', hasDialog: false, consoleErrors: 0 },
+    warnings: [],
+    screenshotPath: null,
+    capturedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeElement(overrides: Partial<InteractiveElement> = {}): InteractiveElement {
+  return {
+    id: 'el_abc',
+    role: 'button',
+    label: 'Submit',
+    kind: null,
+    value: null,
+    state: { disabled: false },
+    bbox: { x: 0, y: 0, w: 80, h: 30 },
+    ...overrides,
+  };
+}
+
+function makeBlockedByPolicy(reason = 'domain refused'): BlockedByPolicy {
+  return { outcome: 'blocked_by_policy', url: 'https://example.com', reason };
+}
+
+function makeAmbiguous(query: { text: string }): AmbiguousTarget {
+  return {
+    outcome: 'ambiguous_target',
+    query,
+    candidates: [makeElement({ id: 'el_1', label: 'First' }), makeElement({ id: 'el_2', label: 'Second' })],
+  };
+}
+
+function makeScreenshotResult(overrides: Partial<ScreenshotResult> = {}): ScreenshotResult {
+  return {
+    path: '/tmp/screenshot.png',
+    bytes: 12345,
+    width: 1280,
+    height: 720,
+    dataBase64: 'AAAA',
+    mediaType: 'image/png',
+    ...overrides,
+  };
+}
+
+function makeProvider(overrides: Partial<BrowserProvider> = {}): BrowserProvider {
+  return {
+    name: 'test',
+    open: vi.fn().mockResolvedValue(makeObs()),
+    observe: vi.fn().mockResolvedValue(makeObs()),
+    act: vi.fn().mockResolvedValue(makeObs()),
+    screenshot: vi.fn().mockResolvedValue(makeScreenshotResult()),
+    extract: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+    describe: vi.fn().mockReturnValue(null),
+    shutdown: vi.fn(),
+    ...overrides,
+  } as BrowserProvider;
+}
+
+// ---------------------------------------------------------------------------
+// browser_open — happy path
+// ---------------------------------------------------------------------------
+
+describe('browser_open — emits browser_event on success', () => {
+  it('emits status=ok with urlAfter set to the loaded page URL', async () => {
+    const obs = makeObs({ url: 'https://example.com/page' });
+    const provider = makeProvider({ open: vi.fn().mockResolvedValue(obs) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserOpenHandler({ getBrowserProvider: async () => provider });
+
+    await handler({ url: 'https://example.com/page' }, makeSignal(), makeContext(writer));
+    await flush();
+
+    const ev = lastBrowserEvent(writer);
+    expect(ev.tool).toBe('browser_open');
+    expect(ev.toolUseId).toBe('tu_test');
+    expect(ev.status).toBe('ok');
+    expect(ev.urlBefore).toBeNull();
+    expect(ev.urlAfter).toBe('https://example.com/page');
+    expect(typeof ev.durationMs).toBe('number');
+    expect(ev.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('carries screenshotPath when observation has one', async () => {
+    const obs = makeObs({ screenshotPath: '/tmp/ss.png' });
+    const provider = makeProvider({ open: vi.fn().mockResolvedValue(obs) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserOpenHandler({ getBrowserProvider: async () => provider });
+
+    await handler({ url: 'https://example.com' }, makeSignal(), makeContext(writer));
+    await flush();
+
+    const ev = lastBrowserEvent(writer);
+    expect(ev.screenshotPath).toBe('/tmp/ss.png');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browser_open — blocked_by_policy
+// ---------------------------------------------------------------------------
+
+describe('browser_open — emits browser_event on blocked_by_policy', () => {
+  it('emits status=blocked_by_policy', async () => {
+    const provider = makeProvider({ open: vi.fn().mockResolvedValue(makeBlockedByPolicy()) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserOpenHandler({ getBrowserProvider: async () => provider });
+
+    const r = await handler({ url: 'https://blocked.example.com' }, makeSignal(), makeContext(writer));
+    await flush();
+
+    expect(r.isError).toBe(true);
+    const ev = lastBrowserEvent(writer);
+    expect(ev.tool).toBe('browser_open');
+    expect(ev.status).toBe('blocked_by_policy');
+    expect(ev.urlBefore).toBeNull();
+    expect(ev.urlAfter).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browser_open — provider error
+// ---------------------------------------------------------------------------
+
+describe('browser_open — emits browser_event on error', () => {
+  it('emits status=error when provider.open throws', async () => {
+    const provider = makeProvider({ open: vi.fn().mockRejectedValue(new Error('nav failed')) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserOpenHandler({ getBrowserProvider: async () => provider });
+
+    const r = await handler({ url: 'https://example.com' }, makeSignal(), makeContext(writer));
+    await flush();
+
+    expect(r.isError).toBe(true);
+    const ev = lastBrowserEvent(writer);
+    expect(ev.status).toBe('error');
+    expect(ev.error?.reason).toMatch(/nav failed/);
+    expect(ev.error?.recoverable).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browser_open — no-op without traceWriter
+// ---------------------------------------------------------------------------
+
+describe('browser_open — no trace emission without traceWriter', () => {
+  it('does not throw and returns normal result when context has no traceWriter', async () => {
+    const provider = makeProvider();
+    const handler = createBrowserOpenHandler({ getBrowserProvider: async () => provider });
+    // No traceWriter in context — should not throw
+    const r = await handler({ url: 'https://example.com' }, makeSignal(), {});
+    expect(r.isError).toBeUndefined();
+  });
+
+  it('works without any context at all', async () => {
+    const provider = makeProvider();
+    const handler = createBrowserOpenHandler({ getBrowserProvider: async () => provider });
+    const r = await handler({ url: 'https://example.com' }, makeSignal());
+    expect(r.isError).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browser_act — happy path
+// ---------------------------------------------------------------------------
+
+describe('browser_act — emits browser_event on success', () => {
+  it('emits status=ok with tool=browser_act and action', async () => {
+    const obs = makeObs({ url: 'https://example.com/after' });
+    const provider = makeProvider({ act: vi.fn().mockResolvedValue(obs) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserActHandler({ getBrowserProvider: async () => provider });
+
+    await handler(
+      { action: 'click', target: { kind: 'semantic', text: 'Submit' } },
+      makeSignal(),
+      makeContext(writer, 'tu_act_1'),
+    );
+    await flush();
+
+    const ev = lastBrowserEvent(writer);
+    expect(ev.tool).toBe('browser_act');
+    expect(ev.action).toBe('click');
+    expect(ev.toolUseId).toBe('tu_act_1');
+    expect(ev.status).toBe('ok');
+    expect(ev.urlBefore).toBe('https://example.com/after');
+    expect(ev.urlAfter).toBe('https://example.com/after');
+  });
+
+  it('emits sanitized semantic target (text truncated, not raw)', async () => {
+    const provider = makeProvider();
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserActHandler({ getBrowserProvider: async () => provider });
+
+    await handler(
+      { action: 'click', target: { kind: 'semantic', text: 'Click me', role: 'button' } },
+      makeSignal(),
+      makeContext(writer),
+    );
+    await flush();
+
+    const ev = lastBrowserEvent(writer);
+    expect(ev.target?.kind).toBe('semantic');
+    expect(ev.target?.text).toBe('Click me');
+    expect(ev.target?.role).toBe('button');
+  });
+
+  it('emits element_id target', async () => {
+    const provider = makeProvider();
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserActHandler({ getBrowserProvider: async () => provider });
+
+    await handler(
+      { action: 'click', target: { kind: 'element_id', element_id: 'el_abc123' } },
+      makeSignal(),
+      makeContext(writer),
+    );
+    await flush();
+
+    const ev = lastBrowserEvent(writer);
+    expect(ev.target?.kind).toBe('element_id');
+    expect(ev.target?.elementId).toBe('el_abc123');
+  });
+
+  it('emits selector target with selectorHash (not raw selector)', async () => {
+    const provider = makeProvider();
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserActHandler({ getBrowserProvider: async () => provider });
+
+    await handler(
+      { action: 'click', target: { kind: 'selector', selector: '#submit-btn' } },
+      makeSignal(),
+      makeContext(writer),
+    );
+    await flush();
+
+    const ev = lastBrowserEvent(writer);
+    expect(ev.target?.kind).toBe('selector');
+    // selectorHash is an 8-char hex digest — never the raw selector string
+    expect(ev.target?.selectorHash).toMatch(/^[0-9a-f]{8}$/);
+    expect(ev.target).not.toHaveProperty('selector');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browser_act — ambiguous_target
+// ---------------------------------------------------------------------------
+
+describe('browser_act — emits browser_event on ambiguous_target', () => {
+  it('emits status=ambiguous_target', async () => {
+    const provider = makeProvider({ act: vi.fn().mockResolvedValue(makeAmbiguous({ text: 'Submit' })) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserActHandler({ getBrowserProvider: async () => provider });
+
+    const r = await handler(
+      { action: 'click', target: { kind: 'semantic', text: 'Submit' } },
+      makeSignal(),
+      makeContext(writer),
+    );
+    await flush();
+
+    expect(r.isError).toBe(true);
+    const ev = lastBrowserEvent(writer);
+    expect(ev.tool).toBe('browser_act');
+    expect(ev.status).toBe('ambiguous_target');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browser_act — blocked_by_policy
+// ---------------------------------------------------------------------------
+
+describe('browser_act — emits browser_event on blocked_by_policy', () => {
+  it('emits status=blocked_by_policy', async () => {
+    const provider = makeProvider({ act: vi.fn().mockResolvedValue(makeBlockedByPolicy()) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserActHandler({ getBrowserProvider: async () => provider });
+
+    const r = await handler(
+      { action: 'click', target: { kind: 'semantic', text: 'Go' } },
+      makeSignal(),
+      makeContext(writer),
+    );
+    await flush();
+
+    expect(r.isError).toBe(true);
+    const ev = lastBrowserEvent(writer);
+    expect(ev.status).toBe('blocked_by_policy');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browser_act — provider error
+// ---------------------------------------------------------------------------
+
+describe('browser_act — emits browser_event on error', () => {
+  it('emits status=error with error.reason', async () => {
+    const provider = makeProvider({ act: vi.fn().mockRejectedValue(new Error('element gone')) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserActHandler({ getBrowserProvider: async () => provider });
+
+    await handler(
+      { action: 'click', target: { kind: 'semantic', text: 'Btn' } },
+      makeSignal(),
+      makeContext(writer),
+    );
+    await flush();
+
+    const ev = lastBrowserEvent(writer);
+    expect(ev.status).toBe('error');
+    expect(ev.error?.reason).toMatch(/element gone/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browser_observe — happy path
+// ---------------------------------------------------------------------------
+
+describe('browser_observe — emits browser_event on success', () => {
+  it('emits status=ok with current page URL in urlBefore/urlAfter', async () => {
+    const obs = makeObs({ url: 'https://example.com/watched' });
+    const provider = makeProvider({ observe: vi.fn().mockResolvedValue(obs) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserObserveHandler({ getBrowserProvider: async () => provider });
+
+    await handler({}, makeSignal(), makeContext(writer, 'tu_obs'));
+    await flush();
+
+    const ev = lastBrowserEvent(writer);
+    expect(ev.tool).toBe('browser_observe');
+    expect(ev.toolUseId).toBe('tu_obs');
+    expect(ev.status).toBe('ok');
+    expect(ev.urlBefore).toBe('https://example.com/watched');
+    expect(ev.urlAfter).toBe('https://example.com/watched');
+  });
+
+  it('carries screenshotPath when observation has one', async () => {
+    const obs = makeObs({ screenshotPath: '/tmp/obs_ss.png' });
+    const provider = makeProvider({ observe: vi.fn().mockResolvedValue(obs) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserObserveHandler({ getBrowserProvider: async () => provider });
+
+    await handler({}, makeSignal(), makeContext(writer));
+    await flush();
+
+    const ev = lastBrowserEvent(writer);
+    expect(ev.screenshotPath).toBe('/tmp/obs_ss.png');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browser_observe — provider error
+// ---------------------------------------------------------------------------
+
+describe('browser_observe — emits browser_event on error', () => {
+  it('emits status=error when provider.observe throws', async () => {
+    const provider = makeProvider({ observe: vi.fn().mockRejectedValue(new Error('no open page')) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserObserveHandler({ getBrowserProvider: async () => provider });
+
+    const r = await handler({}, makeSignal(), makeContext(writer));
+    await flush();
+
+    expect(r.isError).toBe(true);
+    const ev = lastBrowserEvent(writer);
+    expect(ev.status).toBe('error');
+    expect(ev.error?.reason).toMatch(/no open page/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browser_screenshot — happy path
+// ---------------------------------------------------------------------------
+
+describe('browser_screenshot — emits browser_event on success', () => {
+  it('emits status=ok with screenshotPath', async () => {
+    const sr = makeScreenshotResult({ path: '/tmp/cap.png' });
+    const provider = makeProvider({ screenshot: vi.fn().mockResolvedValue(sr) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserScreenshotHandler({ getBrowserProvider: async () => provider });
+
+    await handler({}, makeSignal(), makeContext(writer, 'tu_ss'));
+    await flush();
+
+    const ev = lastBrowserEvent(writer);
+    expect(ev.tool).toBe('browser_screenshot');
+    expect(ev.toolUseId).toBe('tu_ss');
+    expect(ev.status).toBe('ok');
+    expect(ev.screenshotPath).toBe('/tmp/cap.png');
+    // screenshot is non-navigating — URLs are null
+    expect(ev.urlBefore).toBeNull();
+    expect(ev.urlAfter).toBeNull();
+  });
+
+  it('still emits when screenshot exceeds MAX_IMAGE_DIMENSION (imageOmitted path)', async () => {
+    const sr = makeScreenshotResult({ width: 9000, height: 9000, path: '/tmp/big.png' });
+    const provider = makeProvider({ screenshot: vi.fn().mockResolvedValue(sr) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserScreenshotHandler({ getBrowserProvider: async () => provider });
+
+    const r = await handler({}, makeSignal(), makeContext(writer));
+    await flush();
+
+    // The result is still not an error (imageOmitted path, not isError)
+    expect(r.isError).toBeUndefined();
+    const content = JSON.parse(r.content as string) as Record<string, unknown>;
+    expect(content['imageOmitted']).toBeDefined();
+    // browser_event was still emitted
+    const ev = lastBrowserEvent(writer);
+    expect(ev.status).toBe('ok');
+    expect(ev.screenshotPath).toBe('/tmp/big.png');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browser_screenshot — provider error
+// ---------------------------------------------------------------------------
+
+describe('browser_screenshot — emits browser_event on error', () => {
+  it('emits status=error when provider.screenshot throws', async () => {
+    const provider = makeProvider({ screenshot: vi.fn().mockRejectedValue(new Error('capture failed')) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserScreenshotHandler({ getBrowserProvider: async () => provider });
+
+    const r = await handler({}, makeSignal(), makeContext(writer));
+    await flush();
+
+    expect(r.isError).toBe(true);
+    const ev = lastBrowserEvent(writer);
+    expect(ev.status).toBe('error');
+    expect(ev.error?.reason).toMatch(/capture failed/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browser_close — happy path
+// ---------------------------------------------------------------------------
+
+describe('browser_close — emits browser_event on success', () => {
+  it('emits status=ok', async () => {
+    const provider = makeProvider({ close: vi.fn().mockResolvedValue(undefined) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserCloseHandler({ getBrowserProvider: async () => provider });
+
+    await handler({}, makeSignal(), makeContext(writer, 'tu_close'));
+    await flush();
+
+    const ev = lastBrowserEvent(writer);
+    expect(ev.tool).toBe('browser_close');
+    expect(ev.toolUseId).toBe('tu_close');
+    expect(ev.status).toBe('ok');
+    expect(ev.urlBefore).toBeNull();
+    expect(ev.urlAfter).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// browser_close — provider error
+// ---------------------------------------------------------------------------
+
+describe('browser_close — emits browser_event on error', () => {
+  it('emits status=error when provider.close throws', async () => {
+    const provider = makeProvider({ close: vi.fn().mockRejectedValue(new Error('already closed')) });
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserCloseHandler({ getBrowserProvider: async () => provider });
+
+    const r = await handler({}, makeSignal(), makeContext(writer));
+    await flush();
+
+    expect(r.isError).toBe(true);
+    const ev = lastBrowserEvent(writer);
+    expect(ev.status).toBe('error');
+    expect(ev.error?.reason).toMatch(/already closed/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toolUseId correlation — all handlers carry the injected id
+// ---------------------------------------------------------------------------
+
+describe('toolUseId correlation', () => {
+  it('browser_open carries the injected toolUseId', async () => {
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserOpenHandler({ getBrowserProvider: async () => makeProvider() });
+    await handler({ url: 'https://example.com' }, makeSignal(), makeContext(writer, 'corr_001'));
+    await flush();
+    expect(lastBrowserEvent(writer).toolUseId).toBe('corr_001');
+  });
+
+  it('browser_act carries the injected toolUseId', async () => {
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserActHandler({ getBrowserProvider: async () => makeProvider() });
+    await handler({ action: 'click', target: { kind: 'semantic', text: 'X' } }, makeSignal(), makeContext(writer, 'corr_002'));
+    await flush();
+    expect(lastBrowserEvent(writer).toolUseId).toBe('corr_002');
+  });
+
+  it('browser_observe carries the injected toolUseId', async () => {
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserObserveHandler({ getBrowserProvider: async () => makeProvider() });
+    await handler({}, makeSignal(), makeContext(writer, 'corr_003'));
+    await flush();
+    expect(lastBrowserEvent(writer).toolUseId).toBe('corr_003');
+  });
+
+  it('browser_screenshot carries the injected toolUseId', async () => {
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserScreenshotHandler({ getBrowserProvider: async () => makeProvider() });
+    await handler({}, makeSignal(), makeContext(writer, 'corr_004'));
+    await flush();
+    expect(lastBrowserEvent(writer).toolUseId).toBe('corr_004');
+  });
+
+  it('browser_close carries the injected toolUseId', async () => {
+    const writer = new InMemoryTraceWriter();
+    const handler = createBrowserCloseHandler({ getBrowserProvider: async () => makeProvider() });
+    await handler({}, makeSignal(), makeContext(writer, 'corr_005'));
+    await flush();
+    expect(lastBrowserEvent(writer).toolUseId).toBe('corr_005');
+  });
+});

--- a/src/agent/tools/handlers/browser-observe.ts
+++ b/src/agent/tools/handlers/browser-observe.ts
@@ -13,15 +13,10 @@
  * @module agent/tools/handlers/browser-observe
  */
 
-import type { ToolHandler } from '../types.js';
+import type { ToolHandler, ToolHandlerContext } from '../types.js';
 import type { BrowserHandlerOptions } from './browser-open.js';
 import { env } from '../../../config/env.js';
-
-// History: browser_event witness emission is a no-op in this handler.
-// See the matching comment in browser-open.ts for the full rationale.
-// Short version: ToolHandlerContext carries no TraceWriter today; the
-// dispatcher already emits surrounding tool_call events; browser_event
-// wiring is deferred to a follow-up PR.
+import { emitBrowserEvent } from '../../trace/emit.js';
 
 import { isPlaywrightMissing, playwrightMissingHint } from './playwright-hints.js';
 
@@ -72,7 +67,7 @@ function parseInput(raw: unknown): ParsedObserveInput | { error: string } {
 }
 
 export function createBrowserObserveHandler(opts: BrowserHandlerOptions = {}): ToolHandler {
-  return async (input, signal) => {
+  return async (input, signal, context?: ToolHandlerContext) => {
     // Pre-aborted short-circuit.
     if (signal.aborted) {
       const reason = signal.reason;
@@ -109,6 +104,7 @@ export function createBrowserObserveHandler(opts: BrowserHandlerOptions = {}): T
       return { content: `browser_observe failed to get provider: ${msg}`, isError: true };
     }
 
+    const t0 = Date.now();
     try {
       const obs = await provider.observe({
         sessionId,
@@ -116,9 +112,29 @@ export function createBrowserObserveHandler(opts: BrowserHandlerOptions = {}): T
         includeHidden: parsed.includeHidden,
         maxElements: parsed.maxElements,
       });
+      const durationMs = Date.now() - t0;
+      void emitBrowserEvent(context?.traceWriter, {
+        tool: 'browser_observe',
+        toolUseId: context?.toolUseId ?? '',
+        urlBefore: obs.url,
+        urlAfter: obs.url,
+        status: 'ok',
+        durationMs,
+        ...(obs.screenshotPath !== null ? { screenshotPath: obs.screenshotPath } : {}),
+      });
       return { content: JSON.stringify(obs, null, 2) };
     } catch (err) {
+      const durationMs = Date.now() - t0;
       const msg = err instanceof Error ? err.message : String(err);
+      void emitBrowserEvent(context?.traceWriter, {
+        tool: 'browser_observe',
+        toolUseId: context?.toolUseId ?? '',
+        urlBefore: null,
+        urlAfter: null,
+        status: 'error',
+        durationMs,
+        error: { reason: msg, recoverable: false },
+      });
       return { content: `browser_observe failed: ${msg}`, isError: true };
     }
   };

--- a/src/agent/tools/handlers/browser-open.ts
+++ b/src/agent/tools/handlers/browser-open.ts
@@ -16,17 +16,10 @@
  * @module agent/tools/handlers/browser-open
  */
 
-import type { ToolHandler } from '../types.js';
+import type { ToolHandler, ToolHandlerContext } from '../types.js';
+import type { BrowserObservation } from '../../../browser/types.js';
 import { env } from '../../../config/env.js';
-
-// History: browser_event witness emission is currently a no-op in this
-// handler because `ToolHandlerContext` does not carry a `TraceWriter` field.
-// The dispatcher (`src/agent/tools/dispatcher.ts`) already emits `tool_call`
-// started/completed events that bookend every tool invocation. A future PR
-// that plumbs `sessionId` + `TraceWriter` into `ToolHandlerContext` will
-// allow handlers to also emit `browser_event` records for the browser-domain
-// semantic layer. Until then, browser_event emission lives in the dispatcher
-// tier, not in these handlers. See design doc: design-native-browser-control.
+import { emitBrowserEvent } from '../../trace/emit.js';
 
 import {
   browserTimeoutFailureClass,
@@ -103,7 +96,7 @@ export interface BrowserHandlerOptions {
 }
 
 export function createBrowserOpenHandler(opts: BrowserHandlerOptions = {}): ToolHandler {
-  return async (input, signal) => {
+  return async (input, signal, context?: ToolHandlerContext) => {
     // Pre-aborted short-circuit.
     if (signal.aborted) {
       const reason = signal.reason;
@@ -140,6 +133,7 @@ export function createBrowserOpenHandler(opts: BrowserHandlerOptions = {}): Tool
       return { content: `browser_open failed to get provider: ${msg}`, isError: true };
     }
 
+    const t0 = Date.now();
     try {
       const result = await provider.open({
         sessionId,
@@ -148,8 +142,17 @@ export function createBrowserOpenHandler(opts: BrowserHandlerOptions = {}): Tool
         screenshot: parsed.screenshot,
         timeoutMs: parsed.timeoutMs,
       });
+      const durationMs = Date.now() - t0;
 
       if ('outcome' in result && result.outcome === 'blocked_by_policy') {
+        void emitBrowserEvent(context?.traceWriter, {
+          tool: 'browser_open',
+          toolUseId: context?.toolUseId ?? '',
+          urlBefore: null,
+          urlAfter: null,
+          status: 'blocked_by_policy',
+          durationMs,
+        });
         return {
           content: `browser_open blocked: ${result.reason}`,
           isError: true,
@@ -157,10 +160,33 @@ export function createBrowserOpenHandler(opts: BrowserHandlerOptions = {}): Tool
         };
       }
 
-      // BrowserObservation
-      return { content: JSON.stringify(result, null, 2) };
+      // BrowserObservation — url is the post-load URL.
+      // Cast is safe: the blocked_by_policy branch returned above, so result
+      // is BrowserObservation here. TypeScript's 'outcome' in narrowing does
+      // not flow through the early-return so we assert manually.
+      const obs = result as BrowserObservation;
+      void emitBrowserEvent(context?.traceWriter, {
+        tool: 'browser_open',
+        toolUseId: context?.toolUseId ?? '',
+        urlBefore: null,
+        urlAfter: obs.url,
+        status: 'ok',
+        durationMs,
+        ...(obs.screenshotPath !== null ? { screenshotPath: obs.screenshotPath } : {}),
+      });
+      return { content: JSON.stringify(obs, null, 2) };
     } catch (err) {
+      const durationMs = Date.now() - t0;
       const msg = err instanceof Error ? err.message : String(err);
+      void emitBrowserEvent(context?.traceWriter, {
+        tool: 'browser_open',
+        toolUseId: context?.toolUseId ?? '',
+        urlBefore: null,
+        urlAfter: null,
+        status: 'error',
+        durationMs,
+        error: { reason: msg, recoverable: false },
+      });
       const failureClass = browserTimeoutFailureClass(err);
       return {
         content: `browser_open failed: ${msg}`,

--- a/src/agent/tools/handlers/browser-screenshot.ts
+++ b/src/agent/tools/handlers/browser-screenshot.ts
@@ -16,13 +16,11 @@
  * @module agent/tools/handlers/browser-screenshot
  */
 
-import type { ToolHandler } from '../types.js';
+import type { ToolHandler, ToolHandlerContext } from '../types.js';
 import type { BrowserHandlerOptions } from './browser-open.js';
 import type { Target } from '../../../browser/types.js';
 import { env } from '../../../config/env.js';
-
-// History: browser_event witness emission is a no-op in this handler.
-// See browser-open.ts for the full rationale.
+import { emitBrowserEvent } from '../../trace/emit.js';
 
 import { isPlaywrightMissing, playwrightMissingHint } from './playwright-hints.js';
 
@@ -103,7 +101,7 @@ function parseInput(raw: unknown): ParsedScreenshotInput | { error: string } {
 }
 
 export function createBrowserScreenshotHandler(opts: BrowserHandlerOptions = {}): ToolHandler {
-  return async (input, signal) => {
+  return async (input, signal, context?: ToolHandlerContext) => {
     // Pre-aborted short-circuit.
     if (signal.aborted) {
       const reason = signal.reason;
@@ -140,18 +138,34 @@ export function createBrowserScreenshotHandler(opts: BrowserHandlerOptions = {})
       return { content: `browser_screenshot failed to get provider: ${msg}`, isError: true };
     }
 
+    const t0 = Date.now();
     try {
       const screenshotResult = await provider.screenshot({
         sessionId,
         target: parsed.target,
         fullPage: parsed.fullPage,
       });
+      const durationMs = Date.now() - t0;
+
       // Keep the base64 image bytes OUT of the text content — `dataBase64` is
       // megabytes of base64 the model must never see as text. The pixels ride
       // on the `image` field, which the anthropic-direct provider emits as an
       // image content block; the text carries only the metadata so providers
       // that can't render tool-result images still get the path/dimensions.
       const { dataBase64, mediaType, ...meta } = screenshotResult;
+
+      void emitBrowserEvent(context?.traceWriter, {
+        tool: 'browser_screenshot',
+        toolUseId: context?.toolUseId ?? '',
+        // screenshot is a non-navigating read — URL is unchanged; we don't
+        // have a currentUrl() on the provider so we use null for both fields.
+        urlBefore: null,
+        urlAfter: null,
+        status: 'ok',
+        durationMs,
+        screenshotPath: meta.path,
+      });
+
       // Dimension guard. A full_page screenshot of a tall page can stay under
       // the 5 MiB sidecar byte cap yet exceed Anthropic's 8000px pixel limit.
       // Attaching it would 400 the request AND leave a poison image block in
@@ -175,7 +189,17 @@ export function createBrowserScreenshotHandler(opts: BrowserHandlerOptions = {})
         image: { mediaType, data: dataBase64 },
       };
     } catch (err) {
+      const durationMs = Date.now() - t0;
       const msg = err instanceof Error ? err.message : String(err);
+      void emitBrowserEvent(context?.traceWriter, {
+        tool: 'browser_screenshot',
+        toolUseId: context?.toolUseId ?? '',
+        urlBefore: null,
+        urlAfter: null,
+        status: 'error',
+        durationMs,
+        error: { reason: msg, recoverable: false },
+      });
       return { content: `browser_screenshot failed: ${msg}`, isError: true };
     }
   };

--- a/src/agent/tools/types.ts
+++ b/src/agent/tools/types.ts
@@ -13,6 +13,7 @@ export type { AnthropicToolDef } from '../providers/anthropic-direct/types.js';
 export type { ToolDispatcher } from '../providers/anthropic-direct/tool-dispatcher.js';
 
 import type { ToolResult } from '../providers/anthropic-direct/types.js';
+import type { TraceWriter } from '../trace/index.js';
 
 /**
  * Per-invocation context forwarded to every tool handler.
@@ -74,6 +75,22 @@ export interface ToolHandlerContext {
    * throw. Default (unset) enforces containment against the granted roots.
    */
   allowAll?: boolean;
+  /**
+   * Witness-layer trace writer. Forwarded from the session dispatcher so
+   * tool handlers can emit domain-specific trace events (e.g. `browser_event`)
+   * without knowing about the session's full trace plumbing.
+   *
+   * Optional — handlers that don't emit trace events ignore this field.
+   * Never required: missing writer is a no-op at the emit helper level.
+   */
+  traceWriter?: TraceWriter;
+  /**
+   * Stable identifier for the current tool use block. Correlates handler-emitted
+   * trace events with the surrounding `tool_call` started/completed records.
+   * Populated by the dispatcher from `ToolCall.id`; absent for inline test
+   * invocations that construct a context without a live dispatch cycle.
+   */
+  toolUseId?: string;
 }
 
 /**


### PR DESCRIPTION
## What & why

`emitBrowserEvent` was defined and the trace reader handled the `browser_event` kind, but it was **never called** — dead code. The 5 browser handlers carried comments deferring emission because `ToolHandlerContext` carried no trace writer. Surfaced by a trace-parity audit (MED-severity gap).

## Change

- **`types.ts`**: added optional `traceWriter?` + `toolUseId?` to `ToolHandlerContext` (additive, back-compat).
- **`dispatcher.ts`**: new `callHandlerContext(call)` augments the base handler context with the per-call `toolUseId` + `traceWriter`; wired into the 2 handler-dispatch sites. Blast radius: exactly those 2 sites — the base `handlerContext` getter stays call-agnostic.
- The 5 browser handlers (`open` / `act` / `observe` / `screenshot` / `close`) now emit `browser_event` (url-before/after, status, `toolUseId`) on each outcome path; the stale deferral comments are removed.

## Tests

+ `browser-event-emission.test.ts` — 26 tests (5 handlers × ok / error / blocked / ambiguous paths + a `toolUseId` correlation suite). **97 passed** including the dispatcher suite.

## Verification

- `pnpm lint` (tsc --noEmit strict): clean
- targeted vitest: 97 passed

## Note

`browser_screenshot` reports `null` for url (non-navigating, no URL field), and `browser_act` uses the post-action URL for both before/after (the handler has no pre-action URL). Both are consistent with the `BrowserEventPayload` contract; a future `currentUrl()` provider method could refine the before/after distinction for navigation-triggering clicks.
