### PR TITLE
feat(improve): fixture-replay eval-run proves recorded failure fixed

### DIFF
--- a/docs/improve-eval-run.md
+++ b/docs/improve-eval-run.md
@@ -1,0 +1,109 @@
+# `afk improve eval-run` — deterministic validation
+
+`afk improve eval-run <evalCaseId|cardSlug>` loads an eval-case and runs
+deterministic checks that the failure it records is actually handled by the
+current code. No LLM, no patch/apply, no git. It exits non-zero on a
+regression so it can gate scripts (`afk improve eval-run X && …`).
+
+It writes an `EvalRun` triple under `$AFK_HOME/agent-framework/improve/eval-runs/`
+(`<id>.json` + `<id>.md` + an `.index.jsonl` append) and prints a check table.
+
+## Two validation layers
+
+A single run can contribute checks from two layers.
+
+### 1. Guardrail-presence (`contracts.ts`)
+
+For each supported pattern, the smallest deterministic probe that the guardrail
+the pattern maps to **exists and behaves** — e.g. building a throwaway
+`SessionToolDispatcher` and asserting the repeat-loop circuit breaker trips at
+its threshold. This is generic: it proves a guardrail is present, not that it
+covers any specific recorded failure.
+
+| Pattern | Guardrail validated |
+|---|---|
+| `repeated-tool-use` | repeat-loop circuit breaker |
+| `subagent-block` | skill max-depth recovery hint |
+| `tool-failure-density` | detector enabled by default |
+| `closure-anomaly` | abort-closure recovery hint |
+
+### 2. Fixture-replay (`replay.ts`) — "is the behaviour fixed?"
+
+For patterns with a registered replay handler (**currently `repeated-tool-use`
+only**), the runner re-drives **this card's actual recorded failure** through
+the live guardrail and asserts it would not recur at the recorded magnitude.
+
+This is the layer that distinguishes *"a guardrail exists"* from *"this
+failure is fixed."* It is strictly stronger than the presence check because it
+is bound to the recorded tool and loop length — it catches, for example, a
+guardrail whose threshold was raised above the magnitude the failure actually
+reached, or a tool that the guardrail does not cover.
+
+#### Why not "re-scan the fixture and expect zero findings"
+
+The eval-case's stored assertion reads literally as *"replay the fixture
+through the detector after the fix lands and expect zero findings."* That can
+**never pass**: a detector is a pure function of the trace bytes, and the
+committed fixture is an immutable byte-identical recording. Fixing code does
+not rewrite an old trace, so re-scanning the static fixture always reproduces
+the original finding. A naive rescan therefore cannot tell fixed from unfixed —
+which is exactly why this layer does something else.
+
+#### What it actually does
+
+1. **Reproduce.** Parse the committed fixture and run the detector to confirm
+   it still encodes the recorded pattern (and to extract the recorded
+   `toolName` + `runLength`).
+2. **Re-drive.** Feed that recorded loop's shape (byte-identical calls to the
+   recorded tool, bounded to the breaker threshold) through the **live**
+   `SessionToolDispatcher` and observe whether the circuit breaker trips at or
+   before the recorded length.
+
+| Outcome | `replay:` checks | Run verdict |
+|---|---|---|
+| Reproduces **and** guardrail neutralises the loop | reproduces ✓, neutralised ✓ | `pass` — fixed |
+| Reproduces **but** guardrail does not neutralise it | reproduces ✓, neutralised ✗ | `fail` — still reproduces |
+| Fixture intact but no longer encodes the pattern | reproduces – (skipped) | `unsupported` — **never `pass`**; the card-specific behaviour was not verified, even though the guardrail contract passed |
+| Fixture missing / sha256 mismatch | (no replay) | `fail` via `fixture-integrity` before any replay runs |
+
+#### Boundary (no overclaiming)
+
+The replay re-drives the recorded loop **shape** (tool name + consecutive
+byte-identical count), not the original tool or LLM execution. It proves the
+live guardrail covers the recorded failure; it does not prove the loop can
+never arise for an unrelated reason. The fixture bytes are checksum-pinned by
+the eval-case, so the stimulus is stable across runs and the whole check is
+deterministic.
+
+## Status precedence
+
+`error` > `fail` > `unsupported` > `pass`. Any failing check forces `fail`; a
+contract or replay that throws forces `error`; `skipped` checks never force a
+non-pass on their own.
+
+`unsupported` is reached two ways: an eval-case whose pattern has no validation
+at all (no guardrail contract and no replay handler), **or** a pattern that has
+a replay handler whose replay was skipped (intact fixture that no longer
+reproduces the loop). The second case is deliberate: when a replay is expected
+but cannot run, the card-specific behaviour was never verified, so the run must
+not report `pass` — a guardrail-presence-only result must never be mistaken for
+behavioural proof. `pass` therefore means *the strongest validation available
+for the pattern actually ran and passed* (a real neutralise result for
+`repeated-tool-use`; guardrail presence for patterns without a replay handler).
+
+## Adding a replay handler for another pattern
+
+1. Implement an `async` handler `(evalCase, fixtureBytes, ctx) => { checks, evidence }`
+   in `src/improve/eval-run/replay.ts` that re-drives the recorded failure
+   through the **production** guardrail symbol (import it; never re-implement).
+2. Register it in `REPLAY_HANDLERS` keyed on its `patternId`.
+3. Emit a reproduce check and a neutralise check, both prefixed `replay:`.
+4. Add a committed fixture under `src/improve/eval-run/__fixtures__/` and a
+   fixture-backed test asserting the gate flips: real guardrail → `pass`,
+   stripped guardrail → `fail`.
+
+## Scope (not yet built)
+
+This is step 1 of automating the improve pipeline. It does **not** apply fixes,
+classify root causes with an LLM, auto-triage cards, or bridge into the
+harvest → distill → forge loop. Those are deliberately deferred.

--- a/src/improve/eval-run/__fixtures__/repeated-tool-use-loop.fixture.jsonl
+++ b/src/improve/eval-run/__fixtures__/repeated-tool-use-loop.fixture.jsonl
@@ -1,0 +1,16 @@
+{"ts":"2026-06-20T10:00:00.000Z","seq":0,"kind":"tool_call","payload":{"phase":"started","toolUseId":"tu-1","name":"get_runtime_state","inputBytes":120}}
+{"ts":"2026-06-20T10:00:00.050Z","seq":1,"kind":"tool_call","payload":{"phase":"completed","toolUseId":"tu-1","name":"get_runtime_state","resultBytes":512,"isError":false,"truncated":false,"durationMs":50}}
+{"ts":"2026-06-20T10:00:01.000Z","seq":2,"kind":"tool_call","payload":{"phase":"started","toolUseId":"tu-2","name":"get_runtime_state","inputBytes":120}}
+{"ts":"2026-06-20T10:00:01.050Z","seq":3,"kind":"tool_call","payload":{"phase":"completed","toolUseId":"tu-2","name":"get_runtime_state","resultBytes":512,"isError":false,"truncated":false,"durationMs":50}}
+{"ts":"2026-06-20T10:00:02.000Z","seq":4,"kind":"tool_call","payload":{"phase":"started","toolUseId":"tu-3","name":"get_runtime_state","inputBytes":120}}
+{"ts":"2026-06-20T10:00:02.050Z","seq":5,"kind":"tool_call","payload":{"phase":"completed","toolUseId":"tu-3","name":"get_runtime_state","resultBytes":512,"isError":false,"truncated":false,"durationMs":50}}
+{"ts":"2026-06-20T10:00:03.000Z","seq":6,"kind":"tool_call","payload":{"phase":"started","toolUseId":"tu-4","name":"get_runtime_state","inputBytes":120}}
+{"ts":"2026-06-20T10:00:03.050Z","seq":7,"kind":"tool_call","payload":{"phase":"completed","toolUseId":"tu-4","name":"get_runtime_state","resultBytes":512,"isError":false,"truncated":false,"durationMs":50}}
+{"ts":"2026-06-20T10:00:04.000Z","seq":8,"kind":"tool_call","payload":{"phase":"started","toolUseId":"tu-5","name":"get_runtime_state","inputBytes":120}}
+{"ts":"2026-06-20T10:00:04.050Z","seq":9,"kind":"tool_call","payload":{"phase":"completed","toolUseId":"tu-5","name":"get_runtime_state","resultBytes":512,"isError":false,"truncated":false,"durationMs":50}}
+{"ts":"2026-06-20T10:00:05.000Z","seq":10,"kind":"tool_call","payload":{"phase":"started","toolUseId":"tu-6","name":"get_runtime_state","inputBytes":120}}
+{"ts":"2026-06-20T10:00:05.050Z","seq":11,"kind":"tool_call","payload":{"phase":"completed","toolUseId":"tu-6","name":"get_runtime_state","resultBytes":512,"isError":false,"truncated":false,"durationMs":50}}
+{"ts":"2026-06-20T10:00:06.000Z","seq":12,"kind":"tool_call","payload":{"phase":"started","toolUseId":"tu-7","name":"get_runtime_state","inputBytes":120}}
+{"ts":"2026-06-20T10:00:06.050Z","seq":13,"kind":"tool_call","payload":{"phase":"completed","toolUseId":"tu-7","name":"get_runtime_state","resultBytes":512,"isError":false,"truncated":false,"durationMs":50}}
+{"ts":"2026-06-20T10:00:07.000Z","seq":14,"kind":"tool_call","payload":{"phase":"started","toolUseId":"tu-8","name":"get_runtime_state","inputBytes":120}}
+{"ts":"2026-06-20T10:00:07.050Z","seq":15,"kind":"tool_call","payload":{"phase":"completed","toolUseId":"tu-8","name":"get_runtime_state","resultBytes":512,"isError":false,"truncated":false,"durationMs":50}}

--- a/src/improve/eval-run/contracts.ts
+++ b/src/improve/eval-run/contracts.ts
@@ -7,12 +7,14 @@
  * no I/O side effects (the circuit-breaker probe builds a throwaway dispatcher
  * with no trace writer / hooks; the others read constants and pure helpers).
  *
- * ## Why guardrail-presence, not fixture replay
+ * ## Guardrail-presence vs. fixture-replay
  *
- * An eval-case's own assertion is `pattern-absent`: replay the committed
- * fixture through the detector after the fix lands and expect zero findings.
- * That broader replay capability is reserved for a later sprint. This runner
- * validates the *fix* instead — the guardrail the pattern maps to:
+ * The contracts here are the guardrail-PRESENCE layer: each proves a guardrail
+ * EXISTS and behaves against a synthetic stimulus. A complementary
+ * fixture-REPLAY layer ({@link ./replay}) re-drives a card's actual recorded
+ * failure through the live guardrail for patterns that have a handler
+ * (currently `repeated-tool-use`); the runner runs both. A contract validates
+ * the *fix* — the guardrail the pattern maps to:
  *
  *   - `repeated-tool-use`    → the repeat-loop circuit breaker (PR #80).
  *   - `subagent-block`       → the skill max-depth recovery hint (PR #80).

--- a/src/improve/eval-run/replay.test.ts
+++ b/src/improve/eval-run/replay.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for `improve/eval-run/replay.ts` — the fixture-replay validation layer.
+ *
+ * The load-bearing property under test: eval-run FAILS when the recorded
+ * failure still reproduces (the live guardrail does not neutralise it) and
+ * PASSES only when it is neutralised. Demonstrated three ways:
+ *
+ *   - against the REAL `SessionToolDispatcher` circuit breaker (→ neutralised);
+ *   - against an injected no-breaker driver simulating the pre-fix world
+ *     (→ still reproduces → fail);
+ *   - against a fixture that no longer encodes the pattern (→ fail-closed).
+ *
+ * Also guards the committed fixture against trace-schema drift, and exercises
+ * the real driver end-to-end so a regression in the production breaker is
+ * caught here too.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import {
+  liveCircuitBreakerDriver,
+  REPLAY_CHECK_NEUTRALIZED,
+  REPLAY_CHECK_PREFIX,
+  REPLAY_CHECK_REPRODUCES,
+  replaySupportedPatterns,
+  resolveReplayHandler,
+  type LoopDriver,
+} from './replay.js';
+import { detectRepeatedToolUse } from '../scan/detectors/repeated-tool-use.js';
+import { parseTraceContent } from '../scan/reader.js';
+import type { EvalCase, EvalCheck } from '../schemas.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const COMMITTED_FIXTURE = resolve(
+  __dirname,
+  '__fixtures__/repeated-tool-use-loop.fixture.jsonl',
+);
+
+function committedBytes(): Buffer {
+  return readFileSync(COMMITTED_FIXTURE);
+}
+
+/** Generate a byte-identical repeated-tool-use loop of `n` (started, completed) pairs. */
+function loopContent(n: number, toolName = 'get_runtime_state'): string {
+  const lines: string[] = [];
+  for (let i = 0; i < n; i++) {
+    const id = `tu-${i + 1}`;
+    lines.push(
+      JSON.stringify({
+        ts: '2026-06-20T10:00:00.000Z',
+        seq: i * 2,
+        kind: 'tool_call',
+        payload: { phase: 'started', toolUseId: id, name: toolName, inputBytes: 120 },
+      }),
+    );
+    lines.push(
+      JSON.stringify({
+        ts: '2026-06-20T10:00:00.050Z',
+        seq: i * 2 + 1,
+        kind: 'tool_call',
+        payload: {
+          phase: 'completed',
+          toolUseId: id,
+          name: toolName,
+          resultBytes: 512,
+          isError: false,
+          truncated: false,
+          durationMs: 50,
+        },
+      }),
+    );
+  }
+  return lines.join('\n') + '\n';
+}
+
+function makeReplayEvalCase(fingerprint: string | null = null): EvalCase {
+  return {
+    schemaVersion: 1,
+    evalCaseId: 'repeated-tool-get-runtime-state-abc123-eval-20260620-0a1b2c',
+    cardSlug: 'repeated-tool-get-runtime-state-abc123',
+    proposalId: null,
+    title: 'Replay [pattern-absent]: get_runtime_state repeated',
+    createdAt: '2026-06-20T11:00:00.000Z',
+    kind: 'replay',
+    replay: {
+      sourceSessionId: 'sess-loop',
+      sourceTracePath: 'state/witness/sess-loop/trace.jsonl',
+      fixturePath: 'agent-framework/improve/eval-cases/x.fixture.jsonl',
+      evidenceRowIndex: 0,
+      evidenceEventIndices: [15],
+      sliceLineRange: { startLine: 1, endLine: 16 },
+      sliceLineCount: 16,
+      sliceSha256: 'a'.repeat(64),
+    },
+    assertion: {
+      kind: 'pattern-absent',
+      patternId: 'repeated-tool-use',
+      detectorVersion: 'repeated-tool-use@v1',
+      rationale: 'test',
+    },
+    provenance: {
+      detectorAtGeneration: 'repeated-tool-use@v1',
+      fingerprintAtGeneration: fingerprint,
+      cardOccurrenceCountAtGeneration: 1,
+      cardLastSeenAtGeneration: '2026-06-20T11:00:00.000Z',
+      generatedBy: 'replay-fixture',
+    },
+    status: 'draft',
+    notes: [],
+  };
+}
+
+function check(checks: EvalCheck[], name: string): EvalCheck | undefined {
+  return checks.find((c) => c.name === name);
+}
+
+const handler = resolveReplayHandler('repeated-tool-use');
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+describe('replay registry', () => {
+  it('registers a handler for repeated-tool-use', () => {
+    expect(handler).toBeDefined();
+    expect(replaySupportedPatterns()).toContain('repeated-tool-use');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Committed fixture integrity (schema-drift guard)
+// ---------------------------------------------------------------------------
+
+describe('committed fixture', () => {
+  it('parses cleanly under the live trace schema and reproduces an 8× loop', () => {
+    const session = parseTraceContent({
+      sessionId: 'sess-loop',
+      tracePath: 'state/witness/sess-loop/trace.jsonl',
+      relativeTracePath: 'state/witness/sess-loop/trace.jsonl',
+      content: committedBytes().toString('utf8'),
+      sessionMtimeMs: 0,
+    });
+    // No invalid lines → the committed JSONL still matches TraceEventSchema.
+    expect(session.invalidLineCount).toBe(0);
+
+    const findings = detectRepeatedToolUse([session], { minRepeats: 4 });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.detail['toolName']).toBe('get_runtime_state');
+    expect(findings[0]!.detail['runLength']).toBe(8);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The core regression behaviour
+// ---------------------------------------------------------------------------
+
+describe('replayRepeatedToolUse', () => {
+  it('PASSES against the real guardrail (recorded loop neutralised)', async () => {
+    const probe = await handler!.run(makeReplayEvalCase(), committedBytes(), {});
+
+    const reproduces = check(probe.checks, REPLAY_CHECK_REPRODUCES);
+    const neutralized = check(probe.checks, REPLAY_CHECK_NEUTRALIZED);
+    expect(reproduces?.status).toBe('pass');
+    expect(neutralized?.status).toBe('pass');
+    // Real breaker (threshold 8) trips at call 8 of the recorded ×8 loop.
+    expect(neutralized?.actual).toContain('tripped at call 8');
+  });
+
+  it('FAILS when the guardrail is absent (fixture still reproduces)', async () => {
+    // Simulate the pre-fix world: a driver whose breaker never trips.
+    const noBreaker: LoopDriver = async (_tool, count) => ({
+      trippedAtCall: null,
+      callsDriven: count,
+    });
+    const probe = await handler!.run(makeReplayEvalCase(), committedBytes(), {
+      driveLoop: noBreaker,
+    });
+
+    // The fixture still encodes the pattern — that check passes …
+    expect(check(probe.checks, REPLAY_CHECK_REPRODUCES)?.status).toBe('pass');
+    // … but the loop is NOT neutralised, so the gate flips to fail.
+    const neutralized = check(probe.checks, REPLAY_CHECK_NEUTRALIZED);
+    expect(neutralized?.status).toBe('fail');
+    expect(neutralized?.actual).toContain('no trip');
+  });
+
+  it('skips (does not fail) when the fixture no longer reproduces the pattern', async () => {
+    // 3 repeats < detector threshold (4) → no finding. The bytes are intact
+    // (integrity is checked upstream), so this is an eval-case quality gap,
+    // not a code regression: skip rather than fail.
+    const bytes = Buffer.from(loopContent(3), 'utf8');
+    const probe = await handler!.run(makeReplayEvalCase(), bytes, {});
+
+    const reproduces = check(probe.checks, REPLAY_CHECK_REPRODUCES);
+    expect(reproduces?.status).toBe('skipped');
+    // No neutralisation check is emitted — there is no loop to drive.
+    expect(check(probe.checks, REPLAY_CHECK_NEUTRALIZED)).toBeUndefined();
+    expect(probe.checks).toHaveLength(1);
+  });
+
+  it('bounds the drive to the breaker threshold even for a long recorded loop', async () => {
+    const seen: Array<{ tool: string; count: number }> = [];
+    const capturing: LoopDriver = async (tool, count) => {
+      seen.push({ tool, count });
+      return { trippedAtCall: count, callsDriven: count };
+    };
+    // Recorded loop of 12 — drive must be capped at the threshold (8).
+    const bytes = Buffer.from(loopContent(12), 'utf8');
+    await handler!.run(makeReplayEvalCase(), bytes, { driveLoop: capturing });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toEqual({ tool: 'get_runtime_state', count: 8 });
+  });
+
+  it('every replay check carries the replay: prefix', async () => {
+    const probe = await handler!.run(makeReplayEvalCase(), committedBytes(), {});
+    expect(probe.checks.length).toBeGreaterThan(0);
+    for (const c of probe.checks) {
+      expect(c.name.startsWith(REPLAY_CHECK_PREFIX)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The real driver, end-to-end (production circuit breaker)
+// ---------------------------------------------------------------------------
+
+describe('liveCircuitBreakerDriver', () => {
+  it('trips the real breaker at the threshold for a normal tool', async () => {
+    const result = await liveCircuitBreakerDriver('get_runtime_state', 8);
+    expect(result.trippedAtCall).toBe(8);
+  });
+
+  it('does not trip below the threshold', async () => {
+    const result = await liveCircuitBreakerDriver('get_runtime_state', 5);
+    expect(result.trippedAtCall).toBeNull();
+    expect(result.callsDriven).toBe(5);
+  });
+});

--- a/src/improve/eval-run/replay.ts
+++ b/src/improve/eval-run/replay.ts
@@ -1,0 +1,294 @@
+/**
+ * Fixture-replay validation for `afk improve eval-run`.
+ *
+ * Where the guardrail-presence contracts in {@link ./contracts} prove a
+ * guardrail EXISTS and behaves against a synthetic stimulus, a fixture-replay
+ * handler proves the guardrail NEUTRALISES *this card's recorded failure* —
+ * the actual tool and loop magnitude captured in the committed fixture.
+ *
+ * ## Why not "re-scan the fixture and expect zero findings"
+ *
+ * Invariant: a detector is a PURE function of the trace bytes, and the
+ * committed fixture is an IMMUTABLE byte-identical recording. Fixing the code
+ * does not rewrite an old trace, so re-scanning the static fixture through the
+ * same detector ALWAYS reproduces the original finding — it can never flip to
+ * "absent". A naive rescan therefore cannot distinguish fixed from unfixed,
+ * which is exactly why the eval-case's literal `pattern-absent`-by-rescan
+ * assertion is not what this handler evaluates.
+ *
+ * ## What a fixture-replay handler does instead
+ *
+ * It re-drives the fixture's recorded failure CONDITIONS through the LIVE
+ * guardrailed code path and asserts the failure would not recur at the
+ * magnitude the fixture recorded:
+ *
+ *   1. Parse the committed fixture and run the detector over it to confirm the
+ *      fixture genuinely encodes the pattern (fail-closed: a fixture that no
+ *      longer reproduces cannot green-light a fix). This also extracts the
+ *      recorded `(toolName, runLength)`.
+ *   2. Re-drive that recorded loop through the production guardrail symbol and
+ *      assert it neutralises the loop before it reaches the recorded length.
+ *
+ * "Still reproduces" → the guardrail does not cut the loop short → `fail`.
+ * "Fixed"            → the guardrail cuts the loop short            → `pass`.
+ *
+ * ## Boundary (no overclaiming)
+ *
+ * This re-drives the recorded loop SHAPE (tool name + consecutive-identical
+ * count), not the original tool/LLM execution. It proves the live guardrail
+ * covers the recorded failure; it does not prove the loop can never arise for
+ * an unrelated reason. The fixture bytes are checksum-pinned by the eval-case
+ * (the runner re-verifies the sha256 before any replay runs), so the stimulus
+ * is stable across runs.
+ *
+ * @module improve/eval-run/replay
+ */
+
+import {
+  REPEAT_CIRCUIT_BREAKER_THRESHOLD,
+  SessionToolDispatcher,
+} from '../../agent/tools/dispatcher.js';
+import type { ToolCall, ToolHandler, ToolResult } from '../../agent/tools/types.js';
+import {
+  DEFAULT_MIN_REPEATS,
+  detectRepeatedToolUse,
+} from '../scan/detectors/repeated-tool-use.js';
+import { parseTraceContent } from '../scan/reader.js';
+import type { DetectorResult, EvalCase, EvalCheck, EvalRunEvidenceRef, FailurePattern } from '../schemas.js';
+import { makeCheck, type ContractProbeResult } from './contracts.js';
+
+// ---------------------------------------------------------------------------
+// Stable check names — exported so the runner can detect that a replay ran
+// (it adjusts its markdown disclaimer) without a schema field.
+// ---------------------------------------------------------------------------
+
+/** Prefix marking a check as produced by a fixture-replay handler. */
+export const REPLAY_CHECK_PREFIX = 'replay:';
+/** Check #1 — the committed fixture still encodes the recorded pattern. */
+export const REPLAY_CHECK_REPRODUCES = `${REPLAY_CHECK_PREFIX}fixture-reproduces-pattern`;
+/** Check #2 — the live guardrail neutralises the recorded loop. */
+export const REPLAY_CHECK_NEUTRALIZED = `${REPLAY_CHECK_PREFIX}guardrail-neutralizes-recorded-loop`;
+
+/** Shared description for the reproduce check — emitted on both the matched
+ *  (`pass`) and the non-reproducing (`skipped`) path, so it lives once here. */
+const REPRODUCES_DESCRIPTION =
+  'The committed fixture still reproduces the recorded repeated-tool-use loop when re-scanned by the detector';
+
+// ---------------------------------------------------------------------------
+// Loop driver — the injectable seam
+// ---------------------------------------------------------------------------
+
+/** Outcome of driving a recorded loop through a guardrailed executor. */
+export interface LoopDriveResult {
+  /**
+   * 1-based position at which the circuit breaker tripped, or `null` if it
+   * never tripped within the calls driven.
+   */
+  trippedAtCall: number | null;
+  /** How many calls were actually driven (bounded by the caller). */
+  callsDriven: number;
+}
+
+/**
+ * Drives `count` byte-identical calls to `toolName` and reports whether the
+ * live repeat-loop circuit breaker tripped. Injectable so tests can simulate
+ * the pre-fix world (a driver that never trips) and assert the gate flips.
+ */
+export type LoopDriver = (toolName: string, count: number) => Promise<LoopDriveResult>;
+
+/** Constant input object — byte-identical across calls so the breaker's
+ *  `(name, JSON(input))` fingerprint collides and the consecutive count grows. */
+const REPLAY_PROBE_INPUT = Object.freeze({ replay: 'byte-identical-input' });
+
+/**
+ * Default driver: drive the recorded loop through the REAL
+ * {@link SessionToolDispatcher}. Builds a throwaway dispatcher (no hooks, no
+ * trace writer, permission scoped to the single probe tool) so the only
+ * production behaviour exercised is the repeat-loop circuit breaker. Mirrors
+ * the isolation the guardrail-presence contract uses.
+ */
+export const liveCircuitBreakerDriver: LoopDriver = async (toolName, count) => {
+  const handler: ToolHandler = async () => ({ content: 'replay-probe-ok' });
+  const dispatcher = new SessionToolDispatcher({
+    handlers: new Map<string, ToolHandler>([[toolName, handler]]),
+    schemas: [],
+    hookRegistry: undefined,
+    permissions: { allowedTools: [toolName] },
+  });
+  const signal = new AbortController().signal;
+
+  let trippedAtCall: number | null = null;
+  let callsDriven = 0;
+  for (let i = 1; i <= count; i++) {
+    const call: ToolCall = { id: `replay-${i}`, name: toolName, input: REPLAY_PROBE_INPUT, signal };
+    const result: ToolResult = await dispatcher.execute(call);
+    callsDriven = i;
+    if (result.circuitBreaker === true) {
+      trippedAtCall = i;
+      break;
+    }
+  }
+  return { trippedAtCall, callsDriven };
+};
+
+// ---------------------------------------------------------------------------
+// Replay handlers
+// ---------------------------------------------------------------------------
+
+/** Optional injection seams for a replay handler. */
+export interface ReplayContext {
+  /** Override the loop driver. Defaults to {@link liveCircuitBreakerDriver}. */
+  driveLoop?: LoopDriver;
+}
+
+export interface ReplayHandler {
+  /** The pattern whose recorded failure this handler replays. */
+  patternId: FailurePattern;
+  /** Replay the fixture and return checks + evidence (never throws for a
+   *  non-reproducing fixture — it returns a failing check instead). */
+  run: (evalCase: EvalCase, fixtureBytes: Buffer, ctx: ReplayContext) => Promise<ContractProbeResult>;
+}
+
+function runLengthOf(result: DetectorResult): number {
+  const n = result.detail['runLength'];
+  return typeof n === 'number' ? n : 0;
+}
+
+/**
+ * Fixture-replay for `repeated-tool-use`.
+ *
+ * Re-drives the recorded loop through the live repeat-loop circuit breaker and
+ * asserts the breaker trips at or before the recorded run length. A run length
+ * below {@link REPEAT_CIRCUIT_BREAKER_THRESHOLD} correctly reports "not
+ * neutralised" — the breaker genuinely does not cover loops shorter than its
+ * threshold, and a gate must fail closed rather than imply coverage it lacks.
+ */
+async function replayRepeatedToolUse(
+  evalCase: EvalCase,
+  fixtureBytes: Buffer,
+  ctx: ReplayContext,
+): Promise<ContractProbeResult> {
+  const checks: EvalCheck[] = [];
+  const evidence: EvalRunEvidenceRef[] = [];
+
+  // 1. Re-scan the committed fixture and confirm it still encodes the pattern.
+  const content = fixtureBytes.toString('utf8');
+  const session = parseTraceContent({
+    sessionId: evalCase.replay.sourceSessionId,
+    tracePath: evalCase.replay.sourceTracePath,
+    relativeTracePath: evalCase.replay.sourceTracePath,
+    content,
+    sessionMtimeMs: 0,
+  });
+  const findings = detectRepeatedToolUse([session], { minRepeats: DEFAULT_MIN_REPEATS });
+
+  // Prefer the run whose fingerprint matches the eval-case provenance; fall
+  // back to the longest run when no fingerprint was recorded.
+  const wantFp = evalCase.provenance.fingerprintAtGeneration;
+  const byFingerprint = wantFp
+    ? findings.find((f) => f.detail['fingerprint'] === wantFp)
+    : undefined;
+  const longest = [...findings].sort((a, b) => runLengthOf(b) - runLengthOf(a))[0];
+  const matched = byFingerprint ?? longest;
+
+  if (matched === undefined) {
+    // The fixture's sha256 already re-verified upstream, so the bytes are
+    // intact — they simply do not encode the pattern. That is an eval-case
+    // quality problem, not a code regression: emit a `skipped` check (which
+    // does NOT force the run to `fail`) so the run's verdict is still governed
+    // by the guardrail-presence contract, and surface the gap loudly. `fail`
+    // stays reserved for the real "still reproduces" signal below.
+    checks.push(
+      makeCheck({
+        name: REPLAY_CHECK_REPRODUCES,
+        description: REPRODUCES_DESCRIPTION,
+        pass: false,
+        status: 'skipped',
+        expected: wantFp
+          ? `detector finds a run with fingerprint ${wantFp.slice(0, 12)}…`
+          : 'detector finds ≥1 repeated-tool-use run in the fixture',
+        actual: `detector found ${findings.length} run(s); none matched — replay skipped (eval-case may be stale or misgenerated)`,
+      }),
+    );
+    evidence.push({
+      kind: 'fixture',
+      ref: evalCase.replay.fixturePath,
+      detail:
+        'fixture did not reproduce the repeated-tool-use pattern; replay skipped (no loop to re-drive)',
+    });
+    return { checks, evidence };
+  }
+
+  checks.push(
+    makeCheck({
+      name: REPLAY_CHECK_REPRODUCES,
+      description: REPRODUCES_DESCRIPTION,
+      pass: true,
+      expected: wantFp
+        ? `detector finds a run with fingerprint ${wantFp.slice(0, 12)}…`
+        : 'detector finds ≥1 repeated-tool-use run in the fixture',
+      actual: `found '${String(matched.detail['toolName'])}' ×${runLengthOf(matched)}`,
+    }),
+  );
+
+  const toolName = String(matched.detail['toolName']);
+  const recordedRunLength = runLengthOf(matched);
+
+  // 2. Re-drive the recorded loop through the live guardrail. Bounded to the
+  //    breaker threshold: we only need to observe whether it trips at or
+  //    before the recorded length, and the breaker trips deterministically at
+  //    call #threshold.
+  const driveLoop = ctx.driveLoop ?? liveCircuitBreakerDriver;
+  const driveCount = Math.min(recordedRunLength, REPEAT_CIRCUIT_BREAKER_THRESHOLD);
+  const drive = await driveLoop(toolName, driveCount);
+
+  const neutralized = drive.trippedAtCall !== null && drive.trippedAtCall <= recordedRunLength;
+  checks.push(
+    makeCheck({
+      name: REPLAY_CHECK_NEUTRALIZED,
+      description:
+        'Re-driving the recorded loop through the live guardrail trips the circuit breaker at or before the recorded length',
+      pass: neutralized,
+      expected: `circuit breaker trips at call ≤ ${recordedRunLength} (recorded run length)`,
+      actual:
+        drive.trippedAtCall === null
+          ? `no trip within ${drive.callsDriven} call(s) — recorded loop of ${recordedRunLength} would still complete`
+          : `tripped at call ${drive.trippedAtCall}`,
+    }),
+  );
+
+  evidence.push(
+    {
+      kind: 'observed-behavior',
+      ref: 'SessionToolDispatcher.execute (repeat-loop circuit breaker)',
+      detail: `'${toolName}' recorded ×${recordedRunLength}; live breaker ${
+        drive.trippedAtCall === null ? 'did NOT trip' : `tripped at call ${drive.trippedAtCall}`
+      } (threshold ${REPEAT_CIRCUIT_BREAKER_THRESHOLD})`,
+    },
+    {
+      kind: 'fixture',
+      ref: evalCase.replay.fixturePath,
+      detail: `replayed recorded loop on '${toolName}' (run length ${recordedRunLength})`,
+    },
+  );
+
+  return { checks, evidence };
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const REPLAY_HANDLERS: readonly ReplayHandler[] = Object.freeze([
+  { patternId: 'repeated-tool-use', run: replayRepeatedToolUse },
+] satisfies ReplayHandler[]);
+
+/** Resolve the fixture-replay handler for a pattern, or `undefined` if none. */
+export function resolveReplayHandler(patternId: FailurePattern): ReplayHandler | undefined {
+  return REPLAY_HANDLERS.find((h) => h.patternId === patternId);
+}
+
+/** Patterns that currently have a fixture-replay handler. */
+export function replaySupportedPatterns(): readonly FailurePattern[] {
+  return REPLAY_HANDLERS.map((h) => h.patternId);
+}

--- a/src/improve/eval-run/runner.test.ts
+++ b/src/improve/eval-run/runner.test.ts
@@ -13,7 +13,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { dirname, join, resolve } from 'path';
 import { tmpdir } from 'os';
 import {
   decideStatus,
@@ -26,6 +26,11 @@ import {
   writeEvalRun,
 } from './runner.js';
 import { makeCheck } from './contracts.js';
+import {
+  REPLAY_CHECK_NEUTRALIZED,
+  REPLAY_CHECK_REPRODUCES,
+  type LoopDriver,
+} from './replay.js';
 import { sha256Bytes } from '../eval-gen/replay-fixture.js';
 import { EvalCaseSchema, type EvalCase, type FailurePattern } from '../schemas.js';
 import {
@@ -61,6 +66,11 @@ function mkdtemp(): string {
 
 const FIXED_NOW = () => new Date('2026-06-11T12:00:00.000Z');
 const DEFAULT_FIXTURE_BYTES = Buffer.from('{"seq":0,"kind":"tool_call"}\n');
+
+/** The committed fixture that encodes a real 8× repeated-tool-use loop. */
+const LOOP_FIXTURE_BYTES = readFileSync(
+  resolve(__dirname, '__fixtures__/repeated-tool-use-loop.fixture.jsonl'),
+);
 
 /**
  * Build a schema-valid EvalCase and (by default) write its fixture under the
@@ -165,6 +175,20 @@ describe('decideStatus precedence', () => {
   it('pass when a contract ran and every check passed', () => {
     expect(decideStatus({ hasContract: true, contractThrew: false, checks: [passCheck] })).toBe('pass');
   });
+
+  it('replayInconclusive forces unsupported even with a contract and passing checks', () => {
+    // A skipped replay must never read as `pass` — guardrail presence is not
+    // card-specific behavioural proof.
+    expect(
+      decideStatus({ hasContract: true, contractThrew: false, checks: [passCheck], replayInconclusive: true }),
+    ).toBe('unsupported');
+  });
+
+  it('a real failure still beats replayInconclusive', () => {
+    expect(
+      decideStatus({ hasContract: true, contractThrew: false, checks: [failCheck], replayInconclusive: true }),
+    ).toBe('fail');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -178,8 +202,13 @@ describe('runEvalCase', () => {
     clockMs: stubClock([1000, 1042]),
   };
 
-  it('passes for a supported pattern with an intact fixture', async () => {
-    const run = await runEvalCase(makeEvalCase({ pattern: 'repeated-tool-use' }), { ...baseCtx, clockMs: stubClock([1000, 1042]) });
+  it('passes for a supported pattern with an intact fixture that reproduces the loop', async () => {
+    // Intact fixture that actually encodes the recorded loop → the replay layer
+    // runs end to end (reproduces + neutralised) alongside the guardrail contract.
+    const run = await runEvalCase(makeEvalCase({ pattern: 'repeated-tool-use', fixtureBytes: LOOP_FIXTURE_BYTES }), {
+      ...baseCtx,
+      clockMs: stubClock([1000, 1042]),
+    });
 
     expect(run.status).toBe('pass');
     expect(run.contract).toBe('repeat-loop-circuit-breaker');
@@ -191,9 +220,11 @@ describe('runEvalCase', () => {
     // fixture-integrity is always the first check.
     expect(run.checks[0]?.name).toBe('fixture-integrity');
     expect(run.checks[0]?.status).toBe('pass');
-    // ...followed by the 4 circuit-breaker checks, all passing.
+    // fixture-integrity + 4 circuit-breaker checks + 2 fixture-replay checks.
     expect(run.checks.every((c) => c.status === 'pass')).toBe(true);
-    expect(run.checks).toHaveLength(5);
+    expect(run.checks).toHaveLength(7);
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_REPRODUCES)?.status).toBe('pass');
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_NEUTRALIZED)?.status).toBe('pass');
   });
 
   it('fails when the committed fixture no longer matches its sha256', async () => {
@@ -267,7 +298,7 @@ describe('runEvalCase', () => {
 
 describe('writeEvalRun / getEvalRun / listEvalRuns', () => {
   it('writes JSON + md + index, and round-trips through getEvalRun', async () => {
-    const run = await runEvalCase(makeEvalCase(), {
+    const run = await runEvalCase(makeEvalCase({ fixtureBytes: LOOP_FIXTURE_BYTES }), {
       evalRunId: 'repeated-tool-grep-abc123-run-20260611-aaa111',
       now: FIXED_NOW,
       clockMs: stubClock([0, 3]),
@@ -293,12 +324,12 @@ describe('writeEvalRun / getEvalRun / listEvalRuns', () => {
   });
 
   it('lists runs newest-first', async () => {
-    const older = await runEvalCase(makeEvalCase(), {
+    const older = await runEvalCase(makeEvalCase({ fixtureBytes: LOOP_FIXTURE_BYTES }), {
       evalRunId: 'slug-run-20260611-000001',
       now: () => new Date('2026-06-11T10:00:00.000Z'),
       clockMs: stubClock([0, 1]),
     });
-    const newer = await runEvalCase(makeEvalCase(), {
+    const newer = await runEvalCase(makeEvalCase({ fixtureBytes: LOOP_FIXTURE_BYTES }), {
       evalRunId: 'slug-run-20260611-000002',
       now: () => new Date('2026-06-11T11:00:00.000Z'),
       clockMs: stubClock([0, 1]),
@@ -317,22 +348,38 @@ describe('writeEvalRun / getEvalRun / listEvalRuns', () => {
 // ---------------------------------------------------------------------------
 
 describe('renderEvalRunMarkdown', () => {
-  it('renders the header, disclaimer, checks table, and evidence', async () => {
-    const run = await runEvalCase(makeEvalCase({ pattern: 'repeated-tool-use' }), {
-      evalRunId: 'repeated-tool-grep-abc123-run-20260611-7e1a09',
-      now: FIXED_NOW,
-      clockMs: stubClock([0, 7]),
-    });
+  it('renders the header, replay disclaimer, checks table, and evidence', async () => {
+    const run = await runEvalCase(
+      makeEvalCase({ pattern: 'repeated-tool-use', fixtureBytes: LOOP_FIXTURE_BYTES }),
+      {
+        evalRunId: 'repeated-tool-grep-abc123-run-20260611-7e1a09',
+        now: FIXED_NOW,
+        clockMs: stubClock([0, 7]),
+      },
+    );
     const md = renderEvalRunMarkdown(run);
 
     expect(md).toContain('# repeated-tool-grep-abc123-run-20260611-7e1a09 — `eval-run` — `pass`');
-    expect(md).toContain('does');
-    expect(md).toContain('NOT replay the fixture through the detector');
+    // The fixture reproduced + was neutralised, so the replay disclaimer renders.
+    expect(md).toContain('proving the behaviour is fixed');
+    expect(md).toContain('NOT re-execute the original tool/LLM');
     expect(md).toContain('## Result: ✓ PASS');
     expect(md).toContain('| Check | Status | Expected | Actual |');
     expect(md).toContain('fixture-integrity');
+    expect(md).toContain(REPLAY_CHECK_NEUTRALIZED);
     expect(md).toContain('REPEAT_CIRCUIT_BREAKER_THRESHOLD');
     expect(md).toContain(`\`${EVAL_RUN_RUNNER_VERSION}\``);
+  });
+
+  it('renders the guardrail-only disclaimer for a pattern with no replay handler', async () => {
+    const run = await runEvalCase(makeEvalCase({ pattern: 'tool-failure-density' }), {
+      evalRunId: 'slug-run-20260611-cccccc',
+      now: FIXED_NOW,
+      clockMs: stubClock([0, 1]),
+    });
+    const md = renderEvalRunMarkdown(run);
+    expect(md).toContain('the guardrail the pattern maps to');
+    expect(md).not.toContain('proving the behaviour is fixed');
   });
 
   it('escapes pipes in table cells so the markdown table stays valid', async () => {
@@ -351,6 +398,67 @@ describe('renderEvalRunMarkdown', () => {
       const delimiters = row.replace(/\\\|/g, '').split('|').length - 1;
       expect(delimiters).toBe(5);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runEvalCase — fixture-replay (the "behaviour fixed?" gate)
+// ---------------------------------------------------------------------------
+
+describe('runEvalCase fixture-replay', () => {
+  const baseCtx = {
+    evalRunId: 'repeated-tool-get-runtime-state-abc123-run-20260611-7e1a09',
+    now: FIXED_NOW,
+    clockMs: stubClock([0, 5]),
+  };
+
+  it('PASSES end to end when the live guardrail neutralises the recorded loop', async () => {
+    const run = await runEvalCase(
+      makeEvalCase({ pattern: 'repeated-tool-use', fixtureBytes: LOOP_FIXTURE_BYTES }),
+      baseCtx,
+    );
+
+    expect(run.status).toBe('pass');
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_REPRODUCES)?.status).toBe('pass');
+    const neutralized = run.checks.find((c) => c.name === REPLAY_CHECK_NEUTRALIZED);
+    expect(neutralized?.status).toBe('pass');
+    expect(neutralized?.actual).toContain('tripped at call 8');
+  });
+
+  it('FAILS end to end when the recorded loop still reproduces (guardrail stripped)', async () => {
+    // Inject a driver whose breaker never trips — the pre-fix world.
+    const noBreaker: LoopDriver = async (_tool, count) => ({ trippedAtCall: null, callsDriven: count });
+    const run = await runEvalCase(
+      makeEvalCase({ pattern: 'repeated-tool-use', fixtureBytes: LOOP_FIXTURE_BYTES }),
+      { ...baseCtx, driveLoop: noBreaker },
+    );
+
+    expect(run.status).toBe('fail');
+    // The fixture still reproduces, so that check passes …
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_REPRODUCES)?.status).toBe('pass');
+    // … but the loop is not neutralised → the gate fails.
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_NEUTRALIZED)?.status).toBe('fail');
+  });
+
+  it('reports unsupported (NOT pass) when an intact fixture no longer reproduces the loop', async () => {
+    // The default 1-line stub fixture is intact but encodes no loop, so the
+    // replay is skipped. The guardrail contract passes, but a skipped replay
+    // must never surface as `pass` — that would be guardrail presence
+    // masquerading as card-specific behavioural proof.
+    const run = await runEvalCase(makeEvalCase({ pattern: 'repeated-tool-use' }), baseCtx);
+
+    expect(run.status).toBe('unsupported');
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_REPRODUCES)?.status).toBe('skipped');
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_NEUTRALIZED)).toBeUndefined();
+    // The guardrail contract itself still passed — the demotion is purely the
+    // missing card-specific proof, not a guardrail regression.
+    expect(run.checks.filter((c) => c.name.startsWith('replay:')).length).toBe(1);
+  });
+
+  it('does not run a replay for a pattern with no registered handler', async () => {
+    const run = await runEvalCase(makeEvalCase({ pattern: 'tool-failure-density' }), baseCtx);
+    expect(run.checks.some((c) => c.name === REPLAY_CHECK_REPRODUCES)).toBe(false);
+    expect(run.checks.some((c) => c.name === REPLAY_CHECK_NEUTRALIZED)).toBe(false);
   });
 });
 

--- a/src/improve/eval-run/runner.ts
+++ b/src/improve/eval-run/runner.ts
@@ -13,10 +13,23 @@
  *
  * ## What this runner does NOT do
  *
- * No LLM. No patch/apply. No git. No fixture *replay* through the detector —
- * the eval-case's own `pattern-absent` assertion remains the full contract;
- * this runner validates the guardrail the pattern maps to instead. The
- * boundary is documented on {@link EvalRunSchema}.
+ * No LLM. No patch/apply. No git.
+ *
+ * ## Two validation layers
+ *
+ *   1. Guardrail-presence contract (see {@link ./contracts}) — proves the
+ *      guardrail a pattern maps to EXISTS and behaves against a synthetic
+ *      stimulus. Every supported pattern has one.
+ *   2. Fixture-replay (see {@link ./replay}) — for patterns with a registered
+ *      handler (currently `repeated-tool-use`), re-drives THIS card's recorded
+ *      failure through the live guardrail and asserts it is neutralised at the
+ *      recorded magnitude. This is the "is the behaviour fixed?" signal, not
+ *      merely "does a guardrail exist?". It runs only after the fixture's
+ *      sha256 re-verifies — a corrupt/missing fixture forces `fail` first.
+ *
+ * The replay does NOT re-execute the original tool/LLM; it re-drives the
+ * recorded loop shape. The boundary is documented on {@link ./replay} and
+ * {@link EvalRunSchema}.
  *
  * ## Eval-run ID format
  *
@@ -56,6 +69,11 @@ import { getAfkHome } from '../../paths.js';
 import { sha256Bytes } from '../eval-gen/replay-fixture.js';
 import type { IdContext } from '../eval-gen/writer.js';
 import { makeCheck, resolveContract, snapshot, supportedContractPatterns } from './contracts.js';
+import {
+  REPLAY_CHECK_NEUTRALIZED,
+  resolveReplayHandler,
+  type LoopDriver,
+} from './replay.js';
 
 /** Runner identity stamped into every result. */
 export const EVAL_RUN_RUNNER_VERSION = 'eval-run@v1';
@@ -103,6 +121,13 @@ export interface RunEvalCaseContext {
    * Tests inject for isolation.
    */
   resolveFixtureAbsPath?: (relativeFixturePath: string) => string;
+  /**
+   * Override the fixture-replay loop driver. Defaults to the live
+   * {@link SessionToolDispatcher}-backed driver inside the replay handler.
+   * Tests inject a no-breaker driver to simulate the pre-fix world and assert
+   * the gate flips to `fail`.
+   */
+  driveLoop?: LoopDriver;
 }
 
 /**
@@ -157,7 +182,49 @@ export async function runEvalCase(evalCase: EvalCase, ctx: RunEvalCaseContext): 
     }
   }
 
-  const status = decideStatus({ hasContract: contract !== undefined, contractThrew, checks });
+  // 3. Fixture-replay (pattern-specific): re-drive the recorded failure through
+  //    the live guardrail. Runs only when the fixture read cleanly AND its
+  //    sha256 matched (fixture.check passed) — a corrupt/missing fixture has
+  //    already produced a failing integrity check, so we never replay bytes we
+  //    cannot trust.
+  const replayHandler = resolveReplayHandler(evalCase.assertion.patternId);
+  let replayRan = false;
+  if (replayHandler && fixture.bytes !== undefined && fixture.check.status === 'pass') {
+    try {
+      const probe = await replayHandler.run(evalCase, fixture.bytes, {
+        ...(ctx.driveLoop ? { driveLoop: ctx.driveLoop } : {}),
+      });
+      checks.push(...probe.checks);
+      evidence.push(...probe.evidence);
+      replayRan = true;
+    } catch (err) {
+      // A replay throw is an execution error, same precedence as a contract throw.
+      contractThrew = true;
+      const message = err instanceof Error ? err.message : String(err);
+      notes.push({
+        at: nowIso,
+        text: `Fixture-replay for '${evalCase.assertion.patternId}' threw during execution: ${snapshot(message)}`,
+      });
+    }
+  }
+
+  // A replay was expected (handler exists) and the fixture was intact, but it
+  // produced no neutralise check — i.e. the recorded loop did not reproduce, so
+  // the card-specific behaviour was never actually verified. That must not
+  // surface as `pass`: see decideStatus.
+  const replayDrove = checks.some((c) => c.name === REPLAY_CHECK_NEUTRALIZED);
+  const replayInconclusive =
+    replayHandler !== undefined && fixture.check.status === 'pass' && replayRan && !replayDrove;
+
+  // `hasContract` gates the `unsupported` verdict; a replay that ran is itself
+  // a validation, so it must suppress `unsupported` even for a pattern with no
+  // guardrail-presence contract.
+  const status = decideStatus({
+    hasContract: contract !== undefined || replayRan,
+    contractThrew,
+    checks,
+    replayInconclusive,
+  });
   const durationMs = Math.max(0, Math.round(clock() - t0));
 
   const evalRun: EvalRun = {
@@ -183,27 +250,43 @@ export async function runEvalCase(evalCase: EvalCase, ctx: RunEvalCaseContext): 
 
 /**
  * Aggregate a top-line {@link EvalRunStatus} from the run signals. Pure and
- * exported for direct precedence testing: once every registered
- * {@link FailurePattern} has a contract, `unsupported` is unreachable through
- * {@link runEvalCase} (the eval-case/eval-run schemas reject unregistered
- * patterns), so the `hasContract: false` branch is exercised here instead.
+ * exported for direct precedence testing.
  *
  * Precedence (highest wins): `error` > `fail` > `unsupported` > `pass`.
+ *
+ * `unsupported` is reached two ways: when no validation ran (`!hasContract`),
+ * or when a fixture-replay was EXPECTED but could not conclusively run
+ * (`replayInconclusive`). The latter is load-bearing: a skipped replay must
+ * never surface as `pass`, or a guardrail-presence-only result would be
+ * mistaken for card-specific behavioural proof.
  */
 export function decideStatus(args: {
   hasContract: boolean;
   contractThrew: boolean;
   checks: EvalCheck[];
+  /**
+   * True when a replay handler exists for the pattern and the fixture was
+   * intact, yet the recorded loop did not reproduce — so no drive happened and
+   * the card-specific behaviour was NOT proven. Forces a non-`pass` verdict.
+   */
+  replayInconclusive?: boolean;
 }): EvalRunStatus {
   if (args.contractThrew) return 'error';
   if (args.checks.some((c) => c.status === 'fail')) return 'fail';
-  if (!args.hasContract) return 'unsupported';
+  if (!args.hasContract || args.replayInconclusive === true) return 'unsupported';
   return 'pass';
 }
 
 interface FixtureCheckResult {
   check: EvalCheck;
   evidence?: EvalRunEvidenceRef;
+  /**
+   * The fixture bytes, present only when the file was read successfully
+   * (regardless of whether the sha256 matched). Undefined when the file is
+   * missing or unreadable. The replay stage consumes these to avoid a second
+   * read, and only when `check.status === 'pass'`.
+   */
+  bytes?: Buffer;
 }
 
 /**
@@ -232,9 +315,9 @@ function checkFixtureIntegrity(evalCase: EvalCase, ctx: RunEvalCaseContext): Fix
     };
   }
 
-  let actualSha: string;
+  let bytes: Buffer;
   try {
-    actualSha = sha256Bytes(readFileSync(abs));
+    bytes = readFileSync(abs);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return {
@@ -248,6 +331,7 @@ function checkFixtureIntegrity(evalCase: EvalCase, ctx: RunEvalCaseContext): Fix
     };
   }
 
+  const actualSha = sha256Bytes(bytes);
   const ok = actualSha === expectedSha;
   return {
     check: makeCheck({
@@ -262,6 +346,7 @@ function checkFixtureIntegrity(evalCase: EvalCase, ctx: RunEvalCaseContext): Fix
       ref: evalCase.replay.fixturePath,
       detail: `sha256 ${ok ? 'match' : 'MISMATCH'} (${evalCase.replay.sliceLineCount} lines)`,
     },
+    bytes,
   };
 }
 
@@ -336,11 +421,23 @@ export function renderEvalRunMarkdown(run: EvalRun): string {
   );
   out.push('');
 
-  out.push('> **What this is.** A narrow, deterministic check that the guardrail');
-  out.push(`> mapped to pattern \`${run.patternId}\` is present and behaving. It does`);
-  out.push('> NOT replay the fixture through the detector — that broader capability');
-  out.push("> is reserved for a later sprint. The eval-case's own `pattern-absent`");
-  out.push('> assertion remains the full contract.');
+  // A NEUTRALIZED check is present only when a fixture-replay actually drove
+  // the recorded loop (not when it was skipped for a non-reproducing fixture),
+  // so it is the honest signal that this run proved a fix vs. only a guardrail.
+  const didReplay = run.checks.some((c) => c.name === REPLAY_CHECK_NEUTRALIZED);
+  if (didReplay) {
+    out.push('> **What this is.** A deterministic validation of pattern');
+    out.push(`> \`${run.patternId}\`. It re-drove the failure recorded in the committed`);
+    out.push('> fixture through the LIVE guardrail and asserts the loop would not recur');
+    out.push('> at the recorded magnitude — proving the behaviour is fixed, not merely');
+    out.push('> that a guardrail exists. It re-drives the recorded loop shape; it does');
+    out.push('> NOT re-execute the original tool/LLM.');
+  } else {
+    out.push('> **What this is.** A narrow, deterministic check that the guardrail');
+    out.push(`> mapped to pattern \`${run.patternId}\` is present and behaving. It`);
+    out.push("> validates the guardrail the pattern maps to; the eval-case's own");
+    out.push('> `pattern-absent` assertion remains the full contract.');
+  }
   out.push('');
 
   out.push(`## Result: ${STATUS_GLYPH[run.status]}  (${passed}/${run.checks.length} checks passed${failed ? `, ${failed} failed` : ''}${skipped ? `, ${skipped} skipped` : ''})`);


### PR DESCRIPTION
## Summary

Adds a **fixture-replay** validation layer to `afk improve eval-run` for the `repeated-tool-use` pattern — step 1 of automating the improve pipeline.

- Previously eval-run validated only that a guardrail **exists** (against a synthetic stimulus). It never proved a card's **actual recorded failure** is handled, so a passing run could green-light an unfixed card.
- Fixture-replay re-drives the recorded loop — tool name + run-length extracted from the committed `.fixture.jsonl` — through the **live** `SessionToolDispatcher` circuit breaker and asserts it is neutralised at the recorded magnitude. **`fail` = still reproduces; `pass` = fixed.**
- A literal "re-scan the fixture and expect zero findings" can't work: a detector is a pure function of immutable trace bytes, so fixing code never rewrites an old recording. The boundary (re-drives the recorded loop *shape*, not the original tool/LLM) is documented.
- **Safety invariant:** a *skipped* replay (intact fixture that no longer reproduces the pattern) reports `unsupported`, **never `pass`** — guardrail presence is never mistaken for card-specific behavioural proof.

Scope: `dispatcher.ts` is import-only; no `schemas.ts` change. New `docs/improve-eval-run.md` documents the validator, the two layers, the status truth table, and how to add a handler for another pattern.

## Test results

- `pnpm lint` (`tsc --noEmit`, strict): **clean**.
- `pnpm test` (full suite): **9910 passed, 1 failed, 12 skipped**.
  - The single failure is `src/agent/providers/anthropic-direct.test.ts > compact()` — a model-id normalization assertion (`claude-haiku-4-5` vs `claude-haiku-4-5-20251001`). It is **pre-existing and unrelated**: this PR touches only `src/improve/eval-run/**` + `docs/`, which has zero overlap with the anthropic-direct provider.
- `src/improve/eval-run` suite in isolation: **46/46 pass** (contracts 13, replay 9, runner 24).

## Verification

Adversarial verifier wave (claims re-derived from the diff alone, not the commit prose):

- **CLAIM A — skipped replay ⇒ `unsupported`, never `pass`:** CONFIRM (`replay.ts` skipped branch emits a `skipped` reproduce check + no neutralize check → `runner.ts` computes `replayInconclusive=true` → `decideStatus` returns `unsupported`).
- **CLAIM B — not neutralised ⇒ `fail`, neutralised ⇒ `pass`, driven through the real breaker:** CONFIRM (`liveCircuitBreakerDriver` constructs the production `SessionToolDispatcher` and reads `result.circuitBreaker`; the neutralize check's pass/fail maps to overall status via `decideStatus` precedence).
- **CLAIM C — no schema change, dispatcher import-only:** CONFIRM (diff is exactly 7 files; neither `schemas.ts` nor `dispatcher.ts` is modified).
- **OVERALL: ship-safe, no CONTRADICT.** Noted edge (intended): a replay that *throws* yields `error`, not `unsupported`.

## Out of scope (deferred)

Fixture-replay handlers for the other patterns; and improve-pipeline steps 2–6 (LLM reviewer, auto-triage, closure bridge, scheduling, risk-gated apply, forge bridge).
