### PR TITLE
feat(improve): fixture-replay eval-run for closure-anomaly

### DIFF
--- a/docs/improve-eval-run.md
+++ b/docs/improve-eval-run.md
@@ -30,8 +30,9 @@ covers any specific recorded failure.
 ### 2. Fixture-replay (`replay.ts`) — "is the behaviour fixed?"
 
 For patterns with a registered replay handler (**currently `repeated-tool-use`
-only**), the runner re-drives **this card's actual recorded failure** through
-the live guardrail and asserts it would not recur at the recorded magnitude.
+and `closure-anomaly`**), the runner re-drives **this card's actual recorded
+failure** through the live guardrail and asserts it would not recur at the
+recorded magnitude.
 
 This is the layer that distinguishes *"a guardrail exists"* from *"this
 failure is fixed."* It is strictly stronger than the presence check because it
@@ -51,29 +52,41 @@ which is exactly why this layer does something else.
 
 #### What it actually does
 
-1. **Reproduce.** Parse the committed fixture and run the detector to confirm
-   it still encodes the recorded pattern (and to extract the recorded
-   `toolName` + `runLength`).
-2. **Re-drive.** Feed that recorded loop's shape (byte-identical calls to the
-   recorded tool, bounded to the breaker threshold) through the **live**
-   `SessionToolDispatcher` and observe whether the circuit breaker trips at or
-   before the recorded length.
+Each handler runs the same two-step shape — **reproduce** (confirm the fixture
+still encodes the pattern and extract the recorded failure shape) then
+**re-drive** (feed that shape through the live guardrail) — specialised per
+pattern:
+
+- **`repeated-tool-use`** — reproduce extracts the recorded `toolName` +
+  `runLength`; re-drive feeds that loop's shape (byte-identical calls to the
+  recorded tool, bounded to the breaker threshold) through the live
+  `SessionToolDispatcher` and observes whether the circuit breaker trips at or
+  before the recorded length.
+- **`closure-anomaly`** — reproduce extracts the recorded `closureReason`
+  (selected by the evidence `seq`, since this detector has no fingerprint);
+  re-drive calls the live `buildClosureGuidance(reason)` and asserts the
+  recorded anomalous closure now carries actionable recovery guidance.
+  *Neutralisation here is advisory, not preventive* — the abort still aborts;
+  "neutralised" means the closure no longer surfaces without a recovery path.
+  The guardrail covers `abort` today; an anomalous reason it does not cover yet
+  (e.g. `timeout`) yields no guidance → **fail-closed**, mirroring how the
+  repeat-loop handler fails a sub-threshold loop.
 
 | Outcome | `replay:` checks | Run verdict |
 |---|---|---|
-| Reproduces **and** guardrail neutralises the loop | reproduces ✓, neutralised ✓ | `pass` — fixed |
+| Reproduces **and** guardrail neutralises the recorded failure | reproduces ✓, neutralised ✓ | `pass` — fixed |
 | Reproduces **but** guardrail does not neutralise it | reproduces ✓, neutralised ✗ | `fail` — still reproduces |
 | Fixture intact but no longer encodes the pattern | reproduces – (skipped) | `unsupported` — **never `pass`**; the card-specific behaviour was not verified, even though the guardrail contract passed |
 | Fixture missing / sha256 mismatch | (no replay) | `fail` via `fixture-integrity` before any replay runs |
 
 #### Boundary (no overclaiming)
 
-The replay re-drives the recorded loop **shape** (tool name + consecutive
-byte-identical count), not the original tool or LLM execution. It proves the
-live guardrail covers the recorded failure; it does not prove the loop can
-never arise for an unrelated reason. The fixture bytes are checksum-pinned by
-the eval-case, so the stimulus is stable across runs and the whole check is
-deterministic.
+The replay re-drives the recorded failure **shape** (the loop's tool +
+consecutive byte-identical count, or the closure reason), not the original tool
+or LLM execution. It proves the live guardrail covers the recorded failure; it
+does not prove the failure can never arise for an unrelated reason. The fixture
+bytes are checksum-pinned by the eval-case, so the stimulus is stable across
+runs and the whole check is deterministic.
 
 ## Status precedence
 

--- a/src/improve/eval-run/__fixtures__/closure-anomaly-abort.fixture.jsonl
+++ b/src/improve/eval-run/__fixtures__/closure-anomaly-abort.fixture.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-06-20T10:00:00.000Z","seq":0,"kind":"tool_call","payload":{"phase":"started","toolUseId":"tu-1","name":"bash","inputBytes":80}}
+{"ts":"2026-06-20T10:00:00.050Z","seq":1,"kind":"tool_call","payload":{"phase":"completed","toolUseId":"tu-1","name":"bash","resultBytes":256,"isError":false,"truncated":false,"durationMs":50}}
+{"ts":"2026-06-20T10:00:01.000Z","seq":2,"kind":"closure","payload":{"reason":"abort","finalTurnCount":3,"finalCostUsd":0.0123,"finalTokens":{"input":1200,"output":340}}}

--- a/src/improve/eval-run/contracts.ts
+++ b/src/improve/eval-run/contracts.ts
@@ -13,8 +13,8 @@
  * EXISTS and behaves against a synthetic stimulus. A complementary
  * fixture-REPLAY layer ({@link ./replay}) re-drives a card's actual recorded
  * failure through the live guardrail for patterns that have a handler
- * (currently `repeated-tool-use`); the runner runs both. A contract validates
- * the *fix* — the guardrail the pattern maps to:
+ * (currently `repeated-tool-use` and `closure-anomaly`); the runner runs both.
+ * A contract validates the *fix* — the guardrail the pattern maps to:
  *
  *   - `repeated-tool-use`    → the repeat-loop circuit breaker (PR #80).
  *   - `subagent-block`       → the skill max-depth recovery hint (PR #80).

--- a/src/improve/eval-run/replay.test.ts
+++ b/src/improve/eval-run/replay.test.ts
@@ -20,6 +20,8 @@ import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import {
   liveCircuitBreakerDriver,
+  REPLAY_CHECK_CLOSURE_GUIDED,
+  REPLAY_CHECK_CLOSURE_REPRODUCES,
   REPLAY_CHECK_NEUTRALIZED,
   REPLAY_CHECK_PREFIX,
   REPLAY_CHECK_REPRODUCES,
@@ -28,6 +30,7 @@ import {
   type LoopDriver,
 } from './replay.js';
 import { detectRepeatedToolUse } from '../scan/detectors/repeated-tool-use.js';
+import { detectClosureAnomaly } from '../scan/detectors/closure-anomaly.js';
 import { parseTraceContent } from '../scan/reader.js';
 import type { EvalCase, EvalCheck } from '../schemas.js';
 
@@ -128,6 +131,11 @@ describe('replay registry', () => {
   it('registers a handler for repeated-tool-use', () => {
     expect(handler).toBeDefined();
     expect(replaySupportedPatterns()).toContain('repeated-tool-use');
+  });
+
+  it('registers a handler for closure-anomaly', () => {
+    expect(resolveReplayHandler('closure-anomaly')).toBeDefined();
+    expect(replaySupportedPatterns()).toContain('closure-anomaly');
   });
 });
 
@@ -239,5 +247,168 @@ describe('liveCircuitBreakerDriver', () => {
     const result = await liveCircuitBreakerDriver('get_runtime_state', 5);
     expect(result.trippedAtCall).toBeNull();
     expect(result.callsDriven).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// closure-anomaly fixture-replay
+// ---------------------------------------------------------------------------
+
+const COMMITTED_CLOSURE_FIXTURE = resolve(
+  __dirname,
+  '__fixtures__/closure-anomaly-abort.fixture.jsonl',
+);
+
+function committedClosureBytes(): Buffer {
+  return readFileSync(COMMITTED_CLOSURE_FIXTURE);
+}
+
+/** Build a minimal valid trace prefix ending in a `closure` event with `reason`. */
+function closureContent(reason: string, seq = 2): string {
+  const lines = [
+    JSON.stringify({
+      ts: '2026-06-20T10:00:00.000Z',
+      seq: 0,
+      kind: 'tool_call',
+      payload: { phase: 'started', toolUseId: 'tu-1', name: 'bash', inputBytes: 80 },
+    }),
+    JSON.stringify({
+      ts: '2026-06-20T10:00:00.050Z',
+      seq: 1,
+      kind: 'tool_call',
+      payload: {
+        phase: 'completed',
+        toolUseId: 'tu-1',
+        name: 'bash',
+        resultBytes: 256,
+        isError: false,
+        truncated: false,
+        durationMs: 50,
+      },
+    }),
+    JSON.stringify({
+      ts: '2026-06-20T10:00:01.000Z',
+      seq,
+      kind: 'closure',
+      payload: { reason, finalTurnCount: 3, finalCostUsd: 0.0123, finalTokens: { input: 1200, output: 340 } },
+    }),
+  ];
+  return lines.join('\n') + '\n';
+}
+
+function makeClosureEvalCase(evidenceSeq = 2): EvalCase {
+  return {
+    schemaVersion: 1,
+    evalCaseId: 'closure-anomaly-abort-eval-20260620-0a1b2c',
+    cardSlug: 'closure-anomaly-abort',
+    proposalId: null,
+    title: 'Replay [pattern-absent]: abort closure',
+    createdAt: '2026-06-20T11:00:00.000Z',
+    kind: 'replay',
+    replay: {
+      sourceSessionId: 'sess-abort',
+      sourceTracePath: 'state/witness/sess-abort/trace.jsonl',
+      fixturePath: 'agent-framework/improve/eval-cases/x.fixture.jsonl',
+      evidenceRowIndex: 0,
+      evidenceEventIndices: [evidenceSeq],
+      sliceLineRange: { startLine: 1, endLine: evidenceSeq + 1 },
+      sliceLineCount: evidenceSeq + 1,
+      sliceSha256: 'a'.repeat(64),
+    },
+    assertion: {
+      kind: 'pattern-absent',
+      patternId: 'closure-anomaly',
+      detectorVersion: 'closure-anomaly@v1',
+      rationale: 'test',
+    },
+    provenance: {
+      detectorAtGeneration: 'closure-anomaly@v1',
+      // closure-anomaly has no fingerprint — the handler must select by seq.
+      fingerprintAtGeneration: null,
+      cardOccurrenceCountAtGeneration: 1,
+      cardLastSeenAtGeneration: '2026-06-20T11:00:00.000Z',
+      generatedBy: 'replay-fixture',
+    },
+    status: 'draft',
+    notes: [],
+  };
+}
+
+const closureHandler = resolveReplayHandler('closure-anomaly');
+
+describe('committed closure fixture', () => {
+  it('parses cleanly under the live trace schema and reproduces an abort closure', () => {
+    const session = parseTraceContent({
+      sessionId: 'sess-abort',
+      tracePath: 'state/witness/sess-abort/trace.jsonl',
+      relativeTracePath: 'state/witness/sess-abort/trace.jsonl',
+      content: committedClosureBytes().toString('utf8'),
+      sessionMtimeMs: 0,
+    });
+    // No invalid lines → the committed JSONL still matches TraceEventSchema.
+    expect(session.invalidLineCount).toBe(0);
+
+    const findings = detectClosureAnomaly([session], { minOccurrences: 1 });
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.detail['closureReason']).toBe('abort');
+    expect(findings[0]!.detail['seqs']).toEqual([2]);
+  });
+});
+
+describe('replayClosureAnomaly', () => {
+  it('PASSES against the real guardrail (abort closure now carries recovery guidance)', async () => {
+    const probe = await closureHandler!.run(makeClosureEvalCase(), committedClosureBytes(), {});
+
+    const reproduces = check(probe.checks, REPLAY_CHECK_CLOSURE_REPRODUCES);
+    const guided = check(probe.checks, REPLAY_CHECK_CLOSURE_GUIDED);
+    expect(reproduces?.status).toBe('pass');
+    expect(guided?.status).toBe('pass');
+    expect(reproduces?.actual).toContain("closure.reason='abort'");
+  });
+
+  it('FAILS when the guidance is stripped (pre-fix world — hint dropped)', async () => {
+    // Simulate the pre-fix world: a builder that returns no guidance for abort.
+    const probe = await closureHandler!.run(makeClosureEvalCase(), committedClosureBytes(), {
+      buildGuidance: () => null,
+    });
+
+    // The fixture still encodes the anomalous closure — that check passes …
+    expect(check(probe.checks, REPLAY_CHECK_CLOSURE_REPRODUCES)?.status).toBe('pass');
+    // … but no guidance is produced, so the gate flips to fail.
+    const guided = check(probe.checks, REPLAY_CHECK_CLOSURE_GUIDED);
+    expect(guided?.status).toBe('fail');
+    expect(guided?.actual).toContain('no guidance');
+  });
+
+  it('FAILS closed for an anomalous reason the guardrail does not cover yet', async () => {
+    // `timeout` is anomalous (reproduces) but buildClosureGuidance returns null
+    // for it today → not neutralised → fail-closed (real guardrail, no inject).
+    const bytes = Buffer.from(closureContent('timeout'), 'utf8');
+    const probe = await closureHandler!.run(makeClosureEvalCase(), bytes, {});
+
+    expect(check(probe.checks, REPLAY_CHECK_CLOSURE_REPRODUCES)?.status).toBe('pass');
+    expect(check(probe.checks, REPLAY_CHECK_CLOSURE_GUIDED)?.status).toBe('fail');
+  });
+
+  it('skips (does not fail) when the fixture no longer reproduces an anomalous closure', async () => {
+    // A benign `model_end_turn` close is not anomalous → no finding. The bytes
+    // are intact (integrity is checked upstream), so this is an eval-case
+    // quality gap, not a code regression: skip rather than fail.
+    const bytes = Buffer.from(closureContent('model_end_turn'), 'utf8');
+    const probe = await closureHandler!.run(makeClosureEvalCase(), bytes, {});
+
+    const reproduces = check(probe.checks, REPLAY_CHECK_CLOSURE_REPRODUCES);
+    expect(reproduces?.status).toBe('skipped');
+    // No guided check is emitted — there is no closure to re-drive.
+    expect(check(probe.checks, REPLAY_CHECK_CLOSURE_GUIDED)).toBeUndefined();
+    expect(probe.checks).toHaveLength(1);
+  });
+
+  it('every replay check carries the replay: prefix', async () => {
+    const probe = await closureHandler!.run(makeClosureEvalCase(), committedClosureBytes(), {});
+    expect(probe.checks.length).toBeGreaterThan(0);
+    for (const c of probe.checks) {
+      expect(c.name.startsWith(REPLAY_CHECK_PREFIX)).toBe(true);
+    }
   });
 });

--- a/src/improve/eval-run/replay.ts
+++ b/src/improve/eval-run/replay.ts
@@ -49,13 +49,16 @@ import {
   SessionToolDispatcher,
 } from '../../agent/tools/dispatcher.js';
 import type { ToolCall, ToolHandler, ToolResult } from '../../agent/tools/types.js';
+import { buildClosureGuidance } from '../../agent/session/closure-guidance.js';
+import type { ClosureReason } from '../../agent/trace/index.js';
 import {
   DEFAULT_MIN_REPEATS,
   detectRepeatedToolUse,
 } from '../scan/detectors/repeated-tool-use.js';
+import { detectClosureAnomaly } from '../scan/detectors/closure-anomaly.js';
 import { parseTraceContent } from '../scan/reader.js';
 import type { DetectorResult, EvalCase, EvalCheck, EvalRunEvidenceRef, FailurePattern } from '../schemas.js';
-import { makeCheck, type ContractProbeResult } from './contracts.js';
+import { makeCheck, snapshot, type ContractProbeResult } from './contracts.js';
 
 // ---------------------------------------------------------------------------
 // Stable check names — exported so the runner can detect that a replay ran
@@ -68,6 +71,15 @@ export const REPLAY_CHECK_PREFIX = 'replay:';
 export const REPLAY_CHECK_REPRODUCES = `${REPLAY_CHECK_PREFIX}fixture-reproduces-pattern`;
 /** Check #2 — the live guardrail neutralises the recorded loop. */
 export const REPLAY_CHECK_NEUTRALIZED = `${REPLAY_CHECK_PREFIX}guardrail-neutralizes-recorded-loop`;
+
+// closure-anomaly replay check names. Distinct from the repeat-loop ones so a
+// run that mixes patterns (it never does today, but the registry allows it)
+// keeps unambiguous check names; the GUIDED check is the closure-anomaly
+// counterpart of REPLAY_CHECK_NEUTRALIZED — see {@link isReplayNeutralizeCheck}.
+/** Closure check #1 — the committed fixture still encodes an anomalous closure. */
+export const REPLAY_CHECK_CLOSURE_REPRODUCES = `${REPLAY_CHECK_PREFIX}fixture-reproduces-closure-anomaly`;
+/** Closure check #2 — the live guardrail attaches recovery guidance to the recorded closure. */
+export const REPLAY_CHECK_CLOSURE_GUIDED = `${REPLAY_CHECK_PREFIX}guardrail-guides-recorded-closure`;
 
 /** Shared description for the reproduce check — emitted on both the matched
  *  (`pass`) and the non-reproducing (`skipped`) path, so it lives once here. */
@@ -139,6 +151,13 @@ export const liveCircuitBreakerDriver: LoopDriver = async (toolName, count) => {
 export interface ReplayContext {
   /** Override the loop driver. Defaults to {@link liveCircuitBreakerDriver}. */
   driveLoop?: LoopDriver;
+  /**
+   * Override the closure-guidance builder. Defaults to the production
+   * {@link buildClosureGuidance}. Tests inject a null-returning builder to
+   * simulate the pre-fix world (the abort recovery hint dropped) and assert the
+   * closure-anomaly gate flips to `fail`.
+   */
+  buildGuidance?: (reason: ClosureReason) => string | null;
 }
 
 export interface ReplayHandler {
@@ -275,13 +294,176 @@ async function replayRepeatedToolUse(
   return { checks, evidence };
 }
 
+/** Read the recorded closure reason from a closure-anomaly finding's detail. */
+function closureReasonOf(result: DetectorResult): string | null {
+  const r = result.detail['closureReason'];
+  return typeof r === 'string' ? r : null;
+}
+
+/** Read the recorded `seq` list from a finding's detail (provenance selector). */
+function seqsOf(result: DetectorResult): number[] {
+  const s = result.detail['seqs'];
+  return Array.isArray(s) ? s.filter((n): n is number => typeof n === 'number') : [];
+}
+
+/** Shared description for the closure reproduce check — emitted on both the
+ *  matched (`pass`) and the non-reproducing (`skipped`) path. */
+const CLOSURE_REPRODUCES_DESCRIPTION =
+  'The committed fixture still reproduces the recorded anomalous closure when re-scanned by the detector';
+
+/**
+ * Fixture-replay for `closure-anomaly`.
+ *
+ * Re-drives the fixture's recorded closure reason through the live
+ * {@link buildClosureGuidance} guardrail and asserts the recorded anomalous
+ * closure now carries actionable recovery guidance.
+ *
+ * ## Neutralisation here is advisory, not preventive
+ *
+ * Unlike the repeat-loop circuit breaker (which actually cuts a loop short),
+ * the closure recovery hint does NOT prevent the closure — an abort still
+ * aborts. "Neutralised" means the recorded anomalous closure no longer surfaces
+ * WITHOUT a recovery path: the live guardrail now attaches a concrete next step
+ * (`afk --resume <id>` / re-run) for the recorded reason. This is the closure
+ * analog of the repeat-loop handler's "re-drives the loop shape, not the
+ * original tool/LLM" boundary — it proves the fix (PR-added guidance) covers
+ * THIS card's recorded reason, not that the abort can never occur.
+ *
+ * ## Fail-closed on uncovered reasons
+ *
+ * The guardrail covers `abort` today (`closure-guidance.ts`); other anomalous
+ * reasons (`timeout`, `budget_exceeded`, …) return `null` until their hints
+ * land. A `null` result reports "not neutralised" → `fail`, mirroring how the
+ * repeat-loop handler fails a sub-threshold loop: a gate must fail closed
+ * rather than imply coverage it lacks. In practice `abort` is the only
+ * anomalous reason emitted today, so a `null` for an `abort` fixture signals a
+ * genuine regression (the hint was dropped).
+ */
+async function replayClosureAnomaly(
+  evalCase: EvalCase,
+  fixtureBytes: Buffer,
+  ctx: ReplayContext,
+): Promise<ContractProbeResult> {
+  const checks: EvalCheck[] = [];
+  const evidence: EvalRunEvidenceRef[] = [];
+
+  // 1. Re-scan the committed fixture and confirm it still encodes the pattern.
+  const content = fixtureBytes.toString('utf8');
+  const session = parseTraceContent({
+    sessionId: evalCase.replay.sourceSessionId,
+    tracePath: evalCase.replay.sourceTracePath,
+    relativeTracePath: evalCase.replay.sourceTracePath,
+    content,
+    sessionMtimeMs: 0,
+  });
+  const findings = detectClosureAnomaly([session], { minOccurrences: 1 });
+
+  // closure-anomaly has no fingerprint (provenance.fingerprintAtGeneration is
+  // null by design), so select the finding whose recorded seqs include the
+  // eval-case's evidence seq; fall back to the sole finding.
+  const wantSeq = Math.max(...evalCase.replay.evidenceEventIndices);
+  const bySeq = findings.find((f) => seqsOf(f).includes(wantSeq));
+  const matched = bySeq ?? findings[0];
+
+  if (matched === undefined) {
+    // The fixture's sha256 already re-verified upstream, so the bytes are
+    // intact — they simply do not encode an anomalous closure. That is an
+    // eval-case quality problem, not a code regression: emit a `skipped` check
+    // (which does NOT force `fail`) and surface the gap. No guided check is
+    // emitted, so the runner demotes the run to `unsupported` (never `pass`).
+    checks.push(
+      makeCheck({
+        name: REPLAY_CHECK_CLOSURE_REPRODUCES,
+        description: CLOSURE_REPRODUCES_DESCRIPTION,
+        pass: false,
+        status: 'skipped',
+        expected: 'detector finds ≥1 anomalous closure in the fixture',
+        actual: `detector found ${findings.length} closure-anomaly finding(s); none matched — replay skipped (eval-case may be stale or misgenerated)`,
+      }),
+    );
+    evidence.push({
+      kind: 'fixture',
+      ref: evalCase.replay.fixturePath,
+      detail: 'fixture did not reproduce an anomalous closure; replay skipped (no closure to re-drive)',
+    });
+    return { checks, evidence };
+  }
+
+  const reason = closureReasonOf(matched) ?? '';
+  checks.push(
+    makeCheck({
+      name: REPLAY_CHECK_CLOSURE_REPRODUCES,
+      description: CLOSURE_REPRODUCES_DESCRIPTION,
+      pass: true,
+      expected: 'detector finds ≥1 anomalous closure in the fixture',
+      actual: `found closure.reason='${reason}' (seq ${wantSeq})`,
+    }),
+  );
+
+  // 2. Re-drive the recorded closure reason through the live guardrail. The
+  //    hint is advisory (see the handler docstring); a covered reason yields a
+  //    non-empty recovery hint → neutralised, an uncovered reason yields null →
+  //    fail-closed.
+  const build = ctx.buildGuidance ?? buildClosureGuidance;
+  const guidance = build(reason as ClosureReason);
+  const neutralized = guidance !== null && guidance.trim().length > 0;
+  checks.push(
+    makeCheck({
+      name: REPLAY_CHECK_CLOSURE_GUIDED,
+      description:
+        'Re-driving the recorded closure reason through the live guardrail yields actionable recovery guidance',
+      pass: neutralized,
+      expected: `buildClosureGuidance('${reason}') returns a non-empty recovery hint`,
+      actual: neutralized
+        ? snapshot(guidance as string)
+        : `no guidance for reason '${reason}' — the recorded closure anomaly would still surface with no recovery path`,
+    }),
+  );
+
+  evidence.push(
+    {
+      kind: 'observed-behavior',
+      ref: 'buildClosureGuidance (closure-anomaly recovery hint)',
+      detail: `closure.reason='${reason}'; live guardrail ${
+        neutralized ? 'returned a recovery hint' : 'returned no guidance'
+      }`,
+    },
+    {
+      kind: 'fixture',
+      ref: evalCase.replay.fixturePath,
+      detail: `replayed recorded closure reason '${reason}'`,
+    },
+  );
+
+  return { checks, evidence };
+}
+
 // ---------------------------------------------------------------------------
 // Registry
 // ---------------------------------------------------------------------------
 
 const REPLAY_HANDLERS: readonly ReplayHandler[] = Object.freeze([
   { patternId: 'repeated-tool-use', run: replayRepeatedToolUse },
+  { patternId: 'closure-anomaly', run: replayClosureAnomaly },
 ] satisfies ReplayHandler[]);
+
+/**
+ * Check names that signal a replay reached a conclusive neutralise verdict
+ * (`pass`/`fail`), as opposed to the reproduce gate. The runner uses this to
+ * distinguish "a replay actually drove the guardrail" from "a replay handler
+ * ran but the fixture did not reproduce" — the latter demotes the run to
+ * `unsupported` (a skipped replay must never read as `pass`). Each handler that
+ * conclusively drives its guardrail emits exactly one of these.
+ */
+const REPLAY_NEUTRALIZE_CHECK_NAMES: readonly string[] = [
+  REPLAY_CHECK_NEUTRALIZED,
+  REPLAY_CHECK_CLOSURE_GUIDED,
+];
+
+/** True when `name` is a conclusive neutralise check from any replay handler. */
+export function isReplayNeutralizeCheck(name: string): boolean {
+  return REPLAY_NEUTRALIZE_CHECK_NAMES.includes(name);
+}
 
 /** Resolve the fixture-replay handler for a pattern, or `undefined` if none. */
 export function resolveReplayHandler(patternId: FailurePattern): ReplayHandler | undefined {

--- a/src/improve/eval-run/runner.test.ts
+++ b/src/improve/eval-run/runner.test.ts
@@ -27,6 +27,8 @@ import {
 } from './runner.js';
 import { makeCheck } from './contracts.js';
 import {
+  REPLAY_CHECK_CLOSURE_GUIDED,
+  REPLAY_CHECK_CLOSURE_REPRODUCES,
   REPLAY_CHECK_NEUTRALIZED,
   REPLAY_CHECK_REPRODUCES,
   type LoopDriver,
@@ -71,6 +73,44 @@ const DEFAULT_FIXTURE_BYTES = Buffer.from('{"seq":0,"kind":"tool_call"}\n');
 const LOOP_FIXTURE_BYTES = readFileSync(
   resolve(__dirname, '__fixtures__/repeated-tool-use-loop.fixture.jsonl'),
 );
+
+/** The committed fixture that encodes a real `abort` closure. */
+const CLOSURE_FIXTURE_BYTES = readFileSync(
+  resolve(__dirname, '__fixtures__/closure-anomaly-abort.fixture.jsonl'),
+);
+
+/** Build a closure fixture: a prefix ending in a `closure` event with `reason`. */
+function closureFixtureBytes(reason: string): Buffer {
+  const lines = [
+    JSON.stringify({
+      ts: '2026-06-20T10:00:00.000Z',
+      seq: 0,
+      kind: 'tool_call',
+      payload: { phase: 'started', toolUseId: 'tu-1', name: 'bash', inputBytes: 80 },
+    }),
+    JSON.stringify({
+      ts: '2026-06-20T10:00:00.050Z',
+      seq: 1,
+      kind: 'tool_call',
+      payload: {
+        phase: 'completed',
+        toolUseId: 'tu-1',
+        name: 'bash',
+        resultBytes: 256,
+        isError: false,
+        truncated: false,
+        durationMs: 50,
+      },
+    }),
+    JSON.stringify({
+      ts: '2026-06-20T10:00:01.000Z',
+      seq: 2,
+      kind: 'closure',
+      payload: { reason, finalTurnCount: 3, finalCostUsd: 0.0123, finalTokens: { input: 1200, output: 340 } },
+    }),
+  ];
+  return Buffer.from(lines.join('\n') + '\n', 'utf8');
+}
 
 /**
  * Build a schema-valid EvalCase and (by default) write its fixture under the
@@ -252,10 +292,18 @@ describe('runEvalCase', () => {
   });
 
   it('validates the closure-anomaly (abort recovery hint) contract end to end', async () => {
-    const run = await runEvalCase(makeEvalCase({ pattern: 'closure-anomaly' }), { ...baseCtx, clockMs: stubClock([1, 2]) });
+    // An abort-closure fixture exercises BOTH layers: the guardrail-presence
+    // contract and the fixture-replay (reproduces + guided). All pass → `pass`.
+    const run = await runEvalCase(
+      makeEvalCase({ pattern: 'closure-anomaly', fixtureBytes: CLOSURE_FIXTURE_BYTES }),
+      { ...baseCtx, clockMs: stubClock([1, 2]) },
+    );
     expect(run.status).toBe('pass');
     expect(run.contract).toBe('closure-abort-recovery-hint');
     expect(run.checks.some((c) => c.name === 'abort-closure-has-guidance' && c.status === 'pass')).toBe(true);
+    // The replay layer also ran against the recorded abort closure.
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_CLOSURE_REPRODUCES)?.status).toBe('pass');
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_CLOSURE_GUIDED)?.status).toBe('pass');
   });
 
   it('a failed check beats a passing contract (corrupt fixture forces fail)', async () => {
@@ -382,6 +430,19 @@ describe('renderEvalRunMarkdown', () => {
     expect(md).not.toContain('proving the behaviour is fixed');
   });
 
+  it('renders the "behaviour fixed" disclaimer for a closure-anomaly replay run', async () => {
+    const run = await runEvalCase(
+      makeEvalCase({ pattern: 'closure-anomaly', fixtureBytes: CLOSURE_FIXTURE_BYTES }),
+      { evalRunId: 'closure-anomaly-abort-run-20260611-dddddd', now: FIXED_NOW, clockMs: stubClock([0, 1]) },
+    );
+    const md = renderEvalRunMarkdown(run);
+    // The guided check drove → the (now pattern-agnostic) "behaviour fixed"
+    // disclaimer renders and the closure guided check shows in the table.
+    expect(md).toContain('proving the behaviour is fixed');
+    expect(md).toContain('NOT re-execute the original tool/LLM');
+    expect(md).toContain(REPLAY_CHECK_CLOSURE_GUIDED);
+  });
+
   it('escapes pipes in table cells so the markdown table stays valid', async () => {
     const run = await runEvalCase(makeEvalCase({ pattern: 'tool-failure-density' }), {
       evalRunId: 'slug-run-20260611-bbbbbb',
@@ -459,6 +520,46 @@ describe('runEvalCase fixture-replay', () => {
     const run = await runEvalCase(makeEvalCase({ pattern: 'tool-failure-density' }), baseCtx);
     expect(run.checks.some((c) => c.name === REPLAY_CHECK_REPRODUCES)).toBe(false);
     expect(run.checks.some((c) => c.name === REPLAY_CHECK_NEUTRALIZED)).toBe(false);
+  });
+
+  it('PASSES end to end when the live guardrail guides the recorded abort closure', async () => {
+    const run = await runEvalCase(
+      makeEvalCase({ pattern: 'closure-anomaly', fixtureBytes: CLOSURE_FIXTURE_BYTES }),
+      baseCtx,
+    );
+
+    expect(run.status).toBe('pass');
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_CLOSURE_REPRODUCES)?.status).toBe('pass');
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_CLOSURE_GUIDED)?.status).toBe('pass');
+  });
+
+  it('FAILS end to end for an anomalous closure the guardrail does not cover (fail-closed)', async () => {
+    // `timeout` reproduces but buildClosureGuidance returns null for it today.
+    const run = await runEvalCase(
+      makeEvalCase({ pattern: 'closure-anomaly', fixtureBytes: closureFixtureBytes('timeout') }),
+      baseCtx,
+    );
+
+    expect(run.status).toBe('fail');
+    // The fixture still reproduces an anomalous closure, so that check passes …
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_CLOSURE_REPRODUCES)?.status).toBe('pass');
+    // … but no recovery guidance exists for the reason → the gate fails.
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_CLOSURE_GUIDED)?.status).toBe('fail');
+  });
+
+  it('reports unsupported (NOT pass) when an intact fixture has no anomalous closure', async () => {
+    // A benign `model_end_turn` close is intact but not anomalous → the replay
+    // is skipped. The guardrail contract passes, but a skipped replay must never
+    // surface as `pass` — that would be guardrail presence masquerading as
+    // card-specific behavioural proof.
+    const run = await runEvalCase(
+      makeEvalCase({ pattern: 'closure-anomaly', fixtureBytes: closureFixtureBytes('model_end_turn') }),
+      baseCtx,
+    );
+
+    expect(run.status).toBe('unsupported');
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_CLOSURE_REPRODUCES)?.status).toBe('skipped');
+    expect(run.checks.find((c) => c.name === REPLAY_CHECK_CLOSURE_GUIDED)).toBeUndefined();
   });
 });
 

--- a/src/improve/eval-run/runner.ts
+++ b/src/improve/eval-run/runner.ts
@@ -21,15 +21,16 @@
  *      guardrail a pattern maps to EXISTS and behaves against a synthetic
  *      stimulus. Every supported pattern has one.
  *   2. Fixture-replay (see {@link ./replay}) — for patterns with a registered
- *      handler (currently `repeated-tool-use`), re-drives THIS card's recorded
- *      failure through the live guardrail and asserts it is neutralised at the
- *      recorded magnitude. This is the "is the behaviour fixed?" signal, not
- *      merely "does a guardrail exist?". It runs only after the fixture's
- *      sha256 re-verifies — a corrupt/missing fixture forces `fail` first.
+ *      handler (currently `repeated-tool-use` and `closure-anomaly`), re-drives
+ *      THIS card's recorded failure through the live guardrail and asserts it is
+ *      neutralised at the recorded magnitude. This is the "is the behaviour
+ *      fixed?" signal, not merely "does a guardrail exist?". It runs only after
+ *      the fixture's sha256 re-verifies — a corrupt/missing fixture forces
+ *      `fail` first.
  *
  * The replay does NOT re-execute the original tool/LLM; it re-drives the
- * recorded loop shape. The boundary is documented on {@link ./replay} and
- * {@link EvalRunSchema}.
+ * recorded failure conditions (the loop shape, or the closure reason). The
+ * boundary is documented on {@link ./replay} and {@link EvalRunSchema}.
  *
  * ## Eval-run ID format
  *
@@ -70,7 +71,7 @@ import { sha256Bytes } from '../eval-gen/replay-fixture.js';
 import type { IdContext } from '../eval-gen/writer.js';
 import { makeCheck, resolveContract, snapshot, supportedContractPatterns } from './contracts.js';
 import {
-  REPLAY_CHECK_NEUTRALIZED,
+  isReplayNeutralizeCheck,
   resolveReplayHandler,
   type LoopDriver,
 } from './replay.js';
@@ -212,7 +213,7 @@ export async function runEvalCase(evalCase: EvalCase, ctx: RunEvalCaseContext): 
   // produced no neutralise check — i.e. the recorded loop did not reproduce, so
   // the card-specific behaviour was never actually verified. That must not
   // surface as `pass`: see decideStatus.
-  const replayDrove = checks.some((c) => c.name === REPLAY_CHECK_NEUTRALIZED);
+  const replayDrove = checks.some((c) => isReplayNeutralizeCheck(c.name));
   const replayInconclusive =
     replayHandler !== undefined && fixture.check.status === 'pass' && replayRan && !replayDrove;
 
@@ -421,17 +422,18 @@ export function renderEvalRunMarkdown(run: EvalRun): string {
   );
   out.push('');
 
-  // A NEUTRALIZED check is present only when a fixture-replay actually drove
-  // the recorded loop (not when it was skipped for a non-reproducing fixture),
-  // so it is the honest signal that this run proved a fix vs. only a guardrail.
-  const didReplay = run.checks.some((c) => c.name === REPLAY_CHECK_NEUTRALIZED);
+  // A neutralise check (repeat-loop or closure-guided) is present only when a
+  // fixture-replay actually drove the recorded failure (not when it was skipped
+  // for a non-reproducing fixture), so it is the honest signal that this run
+  // proved a fix vs. only a guardrail.
+  const didReplay = run.checks.some((c) => isReplayNeutralizeCheck(c.name));
   if (didReplay) {
     out.push('> **What this is.** A deterministic validation of pattern');
     out.push(`> \`${run.patternId}\`. It re-drove the failure recorded in the committed`);
-    out.push('> fixture through the LIVE guardrail and asserts the loop would not recur');
-    out.push('> at the recorded magnitude — proving the behaviour is fixed, not merely');
-    out.push('> that a guardrail exists. It re-drives the recorded loop shape; it does');
-    out.push('> NOT re-execute the original tool/LLM.');
+    out.push('> fixture through the LIVE guardrail and asserts the recorded failure is');
+    out.push('> neutralised at the recorded magnitude — proving the behaviour is fixed,');
+    out.push('> not merely that a guardrail exists. It re-drives the recorded failure');
+    out.push('> conditions; it does NOT re-execute the original tool/LLM.');
   } else {
     out.push('> **What this is.** A narrow, deterministic check that the guardrail');
     out.push(`> mapped to pattern \`${run.patternId}\` is present and behaving. It`);


### PR DESCRIPTION
## What

Adds the **second** fixture-replay handler to `afk improve eval-run` (after `repeated-tool-use`, merged in #263), covering the **`closure-anomaly`** pattern. This is the next step of automating the improve pipeline — replay proves *this card's recorded failure* is actually fixed by the live guardrail, not merely that a guardrail exists.

## Replay model (`closure-anomaly`)

1. **Reproduce** — parse the committed fixture, run `detectClosureAnomaly`, and select the finding by the recorded evidence `seq` (this detector has **no fingerprint**, so seq is the selector). Extract the recorded `closureReason`.
2. **Re-drive** — call the live `buildClosureGuidance(reason)` (`src/agent/session/closure-guidance.ts`) and assert the recorded anomalous closure now carries actionable recovery guidance.

| Outcome | Verdict |
|---|---|
| Reproduces **and** guardrail returns a recovery hint | `pass` — neutralized |
| Reproduces **but** reason not covered (null guidance) | `fail` — fail-closed |
| Intact fixture, no anomalous closure | `unsupported` — skipped (never `pass`) |
| Fixture missing / sha256 mismatch | `fail` via `fixture-integrity` before replay |

**Boundary (no overclaiming):** neutralization here is **advisory** — the abort still aborts; "neutralized" means the closure no longer surfaces *without a recovery path*. This is the closure analog of the repeat-loop handler's "re-drives the loop shape, not the original tool/LLM" boundary. The guardrail covers `abort` today; uncovered anomalous reasons (e.g. `timeout`) **fail-closed**, mirroring how the repeat-loop handler fails a sub-threshold loop.

## Runner generalization

The runner's replay detection moves from a hardcoded `REPLAY_CHECK_NEUTRALIZED` lookup to an `isReplayNeutralizeCheck()` predicate, so any registered handler's neutralize check drives both the verdict and the (now pattern-agnostic) markdown disclaimer.

## Why `closure-anomaly` (and not the other two)

- **`subagent-block`** — the guardrail (`buildSkillMaxDepthRefusal(depth, maxDepth)`) needs depth, which the detector doesn't capture; it also fires on *any* `SubagentStart` block, not just max-depth. Not deterministically re-drivable.
- **`tool-failure-density`** — the "guardrail" is just *the detector being enabled by default*; there's no runtime neutralizer to re-drive.

## Scope (unchanged)

No LLM, no apply, no auto-triage, no scheduling, no forge bridge, no schema changes.

## Tests / gates

- New committed fixture: `src/improve/eval-run/__fixtures__/closure-anomaly-abort.fixture.jsonl`.
- `replay.test.ts` +7, `runner.test.ts` +4. The existing closure-anomaly contract test was updated to supply an abort-closure fixture (registering the handler now also exercises replay).
- `pnpm lint` clean; **320/320 `src/improve/` tests pass**. Full suite: the only failure is a pre-existing, unrelated `anthropic-direct.test.ts` `compact()` model-id env failure, untouched by this PR.
