### PR TITLE
feat(cli): show git branch + open PR on the REPL status line

### DIFF
--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -621,7 +621,13 @@ export async function bootstrapSession(
   // side-effect-free (no process spawn): the initial sample + the on-update
   // repaint wiring are kicked by setupSurface (REPL Phase 1), so bootstrap-only
   // unit tests never shell out to git/gh.
-  const gitStatusSampler = new GitStatusSampler({ cwd: stats.cwd ?? process.cwd() });
+  const gitStatusSampler = new GitStatusSampler({
+    cwd: stats.cwd ?? process.cwd(),
+    // Suppress the per-turn git subprocess if the branch was checked < 1 s
+    // ago — human turns are seconds apart so this is imperceptible, and it
+    // bounds overhead on slow filesystems (network mounts, Docker volumes).
+    branchTtlMs: 1_000,
+  });
 
   const slashCtx: SlashContext = {
     session: sessionRef,

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -19,6 +19,7 @@ import {
 import { loadConfig } from '../../config.js';
 import { assembleSystemPrompt, pendingBriefContext } from '../../../agent/routing-directive.js';
 import { StatusLine } from '../../status-line.js';
+import { GitStatusSampler } from '../../git-status-sampler.js';
 import { registerAll } from '../../slash/index.js';
 import { setAllowDirDispatcher } from '../../slash/commands/allow-dir.js';
 import { createConsoleWriter } from '../../slash/writer.js';
@@ -614,6 +615,13 @@ export async function bootstrapSession(
   // called by performResumeSwap (resume-swap.ts step 8) on every mid-session
   // swap to rebind the source and reset the cache; no call needed here.
   const contextSampler = new ContextSampler(session);
+  // GitStatusSampler resolves the current branch (fast, local) + open PR
+  // (network, detached) for the status line. Bound to the session's effective
+  // cwd — under `--worktree` that differs from process.cwd(). Construction is
+  // side-effect-free (no process spawn): the initial sample + the on-update
+  // repaint wiring are kicked by setupSurface (REPL Phase 1), so bootstrap-only
+  // unit tests never shell out to git/gh.
+  const gitStatusSampler = new GitStatusSampler({ cwd: stats.cwd ?? process.cwd() });
 
   const slashCtx: SlashContext = {
     session: sessionRef,
@@ -644,12 +652,12 @@ export async function bootstrapSession(
         process.stdout.write('\x1b[3J\x1b[2J\x1b[H');
         statusLine.start();
         // Read contextSampler at call time so any swap-replaced sampler is used.
-        statusLine.repaint(formatStatusFields(stats, contextSampler));
+        statusLine.repaint(formatStatusFields(stats, contextSampler, gitStatusSampler));
       },
       // Read contextSampler at call time (not at closure-capture time) so
       // a mid-session swap that calls contextSampler.attach(newSession) is
       // reflected on the next repaint.
-      repaintStatusLine: () => statusLine.repaint(formatStatusFields(stats, contextSampler)),
+      repaintStatusLine: () => statusLine.repaint(formatStatusFields(stats, contextSampler, gitStatusSampler)),
     },
     ledger: trustedSkillLedger,
     // Expose mcpManager so `/mcp auth complete` can call completeAuth().
@@ -670,6 +678,7 @@ export async function bootstrapSession(
       sessionRef,
       stats,
       contextSampler,
+      gitStatusSampler,
       statusLine,
       backgroundRegistry,
       completionWriter,
@@ -703,6 +712,7 @@ export async function bootstrapSession(
     stats,
     statusLine,
     contextSampler,
+    gitStatusSampler,
     completionWriter,
     replRenderer,
     slashCtx,

--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -135,6 +135,7 @@ function makeCtx(): InteractiveCtx {
       repaint: vi.fn(),
     },
     contextSampler: { onTurn: vi.fn(async () => {}), getRatio: () => undefined, refresh: vi.fn(async () => {}) },
+    gitStatusSampler: { refresh: vi.fn(async () => {}), setOnUpdate: vi.fn(), getBranch: () => undefined, getPr: () => undefined },
     completionWriter: { fn: vi.fn(), idleFn: vi.fn() },
     replRenderer: { writeLine: vi.fn(), setCompositor: vi.fn() },
     slashCtx: { stats: { permissionMode: 'default' } },

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -440,6 +440,9 @@ export async function runInputLoop(
         },
         async onAfterTurn() {
           await ctx.contextSampler.onTurn(ctx.stats.totalTurns);
+          // Re-sample the git branch each turn (cheap, local). The PR lookup
+          // (network) is detached inside refresh() and lands on a later repaint.
+          await ctx.gitStatusSampler.refresh();
           ctx.statusLine.rearm();
           // Reset the loop-stage bar to 'observing' so the footer rail shows
           // a clean "waiting" state between turns rather than the last active
@@ -480,7 +483,7 @@ export async function runInputLoop(
         setPauseInterruptHandler: (handler) => surface.setPauseInterruptHandler(handler),
         async onContextProgress() {
           await ctx.contextSampler.refresh();
-          ctx.statusLine.repaint(formatStatusFields(ctx.stats, ctx.contextSampler));
+          ctx.statusLine.repaint(formatStatusFields(ctx.stats, ctx.contextSampler, ctx.gitStatusSampler));
         },
         // Repaint the LoopStageBar footer row whenever the agent's loop stage
         // transitions.  The bar is a per-session singleton; the callback is

--- a/src/cli/commands/interactive/repl-loop-wiring.test.ts
+++ b/src/cli/commands/interactive/repl-loop-wiring.test.ts
@@ -145,6 +145,7 @@ function makeMinimalCtx(backgroundRegistry: BackgroundAgentRegistry): Interactiv
       setAfterScrollRestore: vi.fn(),
     },
     contextSampler: { onTurn: vi.fn(async () => {}), getRatio: () => undefined },
+    gitStatusSampler: { refresh: vi.fn(async () => {}), setOnUpdate: vi.fn(), getBranch: () => undefined, getPr: () => undefined },
     completionWriter: { fn: () => {}, idleFn: () => {} },
     replRenderer: { writeLine: vi.fn(), setCompositor: vi.fn() },
     slashCtx: { stats: { permissionMode: 'default' } },

--- a/src/cli/commands/interactive/resume-swap.ts
+++ b/src/cli/commands/interactive/resume-swap.ts
@@ -6,6 +6,7 @@ import { formatStatusFields, printResumeBanner, reseedStatsFromStored, type Resu
 import type { SessionRef } from '../../../agent/session-ref.js';
 import type { SessionStats } from '../../slash/types.js';
 import type { ContextSampler } from '../../context-sampler.js';
+import type { GitStatusSampler } from '../../git-status-sampler.js';
 import type { StatusLine } from '../../status-line.js';
 import type { BackgroundAgentRegistry } from '../../../agent/background-registry.js';
 import type { AgentSession } from '../../../agent/session.js';
@@ -37,6 +38,13 @@ export interface ResumeSwapDeps {
   sessionRef: SessionRef;
   stats: SessionStats;
   contextSampler: ContextSampler;
+  /**
+   * Git branch + PR sampler for the status line. Optional — the resumed
+   * session keeps the SAME working directory (resume does not chdir), so the
+   * branch is unchanged across a swap and the cache stays valid; this is
+   * threaded only so the post-swap repaint shows the branch/PR segment.
+   */
+  gitStatusSampler?: GitStatusSampler;
   statusLine: StatusLine;
   backgroundRegistry: BackgroundAgentRegistry;
   completionWriter: CompletionWriter;
@@ -231,7 +239,7 @@ export async function performResumeSwap(
   printResumeBanner(deps.stats, deps.completionWriter);
 
   // Step 12 — Repaint status line.
-  deps.statusLine.repaint(formatStatusFields(deps.stats, deps.contextSampler));
+  deps.statusLine.repaint(formatStatusFields(deps.stats, deps.contextSampler, deps.gitStatusSampler));
 
   return { ok: true, sessionId: newSession.sessionId ?? deps.stats.sessionId ?? target.resumeId };
 }

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -12,6 +12,7 @@ import type { ReplRenderer } from './repl-renderer.js';
 import type { ResolvedResumeTarget } from '../../resume-session.js';
 import { contextLimitFor } from '../../model-limits.js';
 import { ContextSampler } from '../../context-sampler.js';
+import type { GitStatusSampler } from '../../git-status-sampler.js';
 import { formatTurnSparkline } from '../../context-sparkline.js';
 import { palette } from '../../palette.js';
 
@@ -284,6 +285,7 @@ export interface InteractiveCtx {
   stats: SessionStats;          // mutable across turns
   statusLine: StatusLine;        // mutable — owns terminal side-effects
   contextSampler: ContextSampler; // mutable — cached SDK calls
+  gitStatusSampler: GitStatusSampler; // mutable — cached git branch + PR for the status line
   completionWriter: CompletionWriter;
   replRenderer: ReplRenderer;
   slashCtx: SlashContext;
@@ -634,7 +636,11 @@ export function contextRatio(stats: SessionStats, sampler?: ContextSampler): num
   return used / contextLimitFor(stats.model);
 }
 
-export function formatStatusFields(stats: SessionStats, sampler?: ContextSampler) {
+export function formatStatusFields(
+  stats: SessionStats,
+  sampler?: ContextSampler,
+  gitSampler?: GitStatusSampler,
+) {
   const pct = contextRatio(stats, sampler);
   const contextLimit = contextLimitFor(stats.model);
 
@@ -663,6 +669,9 @@ export function formatStatusFields(stats: SessionStats, sampler?: ContextSampler
     }
   }
 
+  const branch = gitSampler?.getBranch();
+  const pr = gitSampler?.getPr();
+
   return {
     model: stats.model,
     cost: stats.totalCostUsd,
@@ -673,5 +682,7 @@ export function formatStatusFields(stats: SessionStats, sampler?: ContextSampler
     contextSparkline,
     permissionMode: stats.permissionMode,
     ...(stats.cwd !== undefined ? { cwd: stats.cwd } : {}),
+    ...(branch !== undefined ? { branch } : {}),
+    ...(pr !== undefined ? { pr } : {}),
   };
 }

--- a/src/cli/commands/interactive/surface-setup.ts
+++ b/src/cli/commands/interactive/surface-setup.ts
@@ -308,7 +308,8 @@ export async function setupSurface(
   ctx.slashCtx.onStageChange = (stage) => deps.getLoopStageBar()?.repaint(stage);
   ctx.slashCtx.onContextProgress = async () => {
     await ctx.contextSampler.refresh();
-    ctx.statusLine.repaint(formatStatusFields(ctx.stats, ctx.contextSampler));
+    await ctx.gitStatusSampler.refresh();
+    ctx.statusLine.repaint(formatStatusFields(ctx.stats, ctx.contextSampler, ctx.gitStatusSampler));
   };
   // Transcript parity for skill turns: runSkillDispatchTurn appends the
   // completed `/skill args → assistant text` exchange through this handle,
@@ -333,6 +334,16 @@ export async function setupSurface(
   if (ctx.inputSurfaceRef) {
     ctx.inputSurfaceRef.current = surface;
   }
+
+  // Git branch + PR sampler: wire an on-change repaint and kick the initial
+  // sample. Deferred to here (REPL Phase 1) rather than bootstrap so a
+  // bootstrap-only unit test never shells out to git/gh. The branch resolves
+  // in ≈ a local git call and the PR lands when its network lookup settles;
+  // onUpdate repaints the status line so both appear without waiting for a turn.
+  ctx.gitStatusSampler.setOnUpdate(() => {
+    ctx.statusLine.repaint(formatStatusFields(ctx.stats, ctx.contextSampler, ctx.gitStatusSampler));
+  });
+  void ctx.gitStatusSampler.refresh();
 
   return { installSoftStop };
 }

--- a/src/cli/git-status-sampler.test.ts
+++ b/src/cli/git-status-sampler.test.ts
@@ -199,7 +199,7 @@ describe('GitStatusSampler', () => {
     const state = { branch: 'A' };
     const exec: GitStatusExecFn = async (file) => {
       if (file === 'git') return { stdout: state.branch + '\n', stderr: '' };
-      return ghPromise; // gh stays pending
+      return ghPromise; // gh always returns ghPromise (re-used for the follow-up)
     };
     const sampler = new GitStatusSampler({ cwd: '/r', exec, now: () => 1000 });
 
@@ -209,10 +209,69 @@ describe('GitStatusSampler', () => {
     state.branch = 'B';
     await sampler.refresh(); // branch=B; PR(A) still in flight
     expect(sampler.getBranch()).toBe('B');
+    expect(sampler.getPr()).toBeUndefined(); // B's PR not resolved yet
 
-    // Resolve the stale PR(A) lookup — it must be discarded because branch is now B.
+    // Resolve the in-flight gh(A) lookup. A's result is discarded by the branch
+    // guard, then a follow-up fetch for B is kicked automatically. Because
+    // ghPromise is already resolved, B's fetch settles in the next microtask.
     resolveGh({ stdout: '111\n', stderr: '' });
-    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 10)); // allow all microtasks to settle
+    // B's PR is now resolved via the follow-up kick — NOT from A's stale result.
+    expect(sampler.getPr()).toBe(111);
+    expect(sampler.getBranch()).toBe('B'); // branch was never corrupted
+  });
+
+  it('fetches PR for branch B after an in-flight fetch for branch A settles', async () => {
+    // Verify C1: the .finally() follow-up kick resolves the new branch's PR
+    // when B's gh call returns a *different* result from A's.
+    let resolveGhA: (v: { stdout: string; stderr: string }) => void = () => {};
+    const ghAPromise = new Promise<{ stdout: string; stderr: string }>((r) => {
+      resolveGhA = r;
+    });
+    const state = { branch: 'A', ghResult: '111' };
+    const exec: GitStatusExecFn = async (file) => {
+      if (file === 'git') return { stdout: state.branch + '\n', stderr: '' };
+      if (state.branch === 'A') return ghAPromise; // A hangs
+      return { stdout: state.ghResult + '\n', stderr: '' }; // B resolves immediately
+    };
+    const sampler = new GitStatusSampler({ cwd: '/r', exec, now: () => 1000 });
+
+    await sampler.refresh(); // branch=A; PR(A) fetch in flight
+    expect(sampler.getBranch()).toBe('A');
+
+    state.branch = 'B';
+    state.ghResult = '456';
+    await sampler.refresh(); // branch=B; PR(A) still in flight
+    expect(sampler.getBranch()).toBe('B');
+    expect(sampler.getPr()).toBeUndefined(); // B's PR not yet resolved
+
+    // A's stale result settles → discarded → follow-up for B kicks and resolves.
+    resolveGhA({ stdout: '111\n', stderr: '' });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(sampler.getPr()).toBe(456); // B's PR, not A's
+  });
+
+  it('reset() mid-fetch discards the settling result without writing stale state', async () => {
+    // Verify C2: in-flight updateBranch captures a generation token and returns
+    // early if reset() has incremented it before the git call settles.
+    let resolveBranch: (v: { stdout: string; stderr: string }) => void = () => {};
+    const branchPromise = new Promise<{ stdout: string; stderr: string }>((r) => {
+      resolveBranch = r;
+    });
+    const exec: GitStatusExecFn = async (file) => {
+      if (file === 'git') return branchPromise; // branch fetch hangs
+      return { stdout: '123\n', stderr: '' };
+    };
+    const sampler = new GitStatusSampler({ cwd: '/r', exec, now: () => 1000 });
+
+    const refreshPromise = sampler.refresh(); // branch fetch in flight
+    sampler.reset(); // advance the generation token mid-flight
+
+    resolveBranch({ stdout: 'feat/x\n', stderr: '' }); // settle the stale fetch
+    await refreshPromise;
+
+    // The stale result must have been discarded — branch stays cleared.
+    expect(sampler.getBranch()).toBeUndefined();
     expect(sampler.getPr()).toBeUndefined();
   });
 });

--- a/src/cli/git-status-sampler.test.ts
+++ b/src/cli/git-status-sampler.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for src/cli/git-status-sampler.ts
+ *
+ * The sampler is fully exercised through its injected `exec` — no real `git`
+ * or `gh` process is ever spawned. The injected exec routes by `file`:
+ *   - `git symbolic-ref --short HEAD` → the current branch (or throws ⇒ detached)
+ *   - `gh pr view --json number --jq .number` → the PR number string (via the
+ *     real `resolveCurrentBranchPr`, which calls back into our injected exec)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { GitStatusSampler, type GitStatusExecFn } from './git-status-sampler.js';
+
+interface MockState {
+  /** Branch returned by `git symbolic-ref`; null ⇒ exec throws (detached HEAD). */
+  branch: string | null;
+  /** PR stdout returned by `gh pr view`; null ⇒ empty (no PR); 'throw' ⇒ exec throws. */
+  pr: string | null | 'throw';
+  now: number;
+}
+
+function makeSampler(initial?: Partial<MockState>, prTtlMs = 60_000) {
+  // Use `in` checks (not `??`) so an intentional `null` (detached HEAD / no PR)
+  // is honored rather than swallowed by the default.
+  const state: MockState = {
+    branch: initial && 'branch' in initial ? (initial.branch as string | null) : 'feat/x',
+    pr: initial && 'pr' in initial ? (initial.pr as string | null | 'throw') : '123',
+    now: initial?.now ?? 1000,
+  };
+  const calls = { git: 0, gh: 0 };
+  const exec: GitStatusExecFn = vi.fn(async (file: string, _args: string[], _cwd: string) => {
+    if (file === 'git') {
+      calls.git++;
+      if (state.branch === null) throw new Error('not a symbolic ref'); // detached HEAD
+      return { stdout: state.branch + '\n', stderr: '' };
+    }
+    // gh pr view
+    calls.gh++;
+    if (state.pr === 'throw') throw new Error('gh failed');
+    return { stdout: (state.pr ?? '') + '\n', stderr: '' };
+  });
+  const sampler = new GitStatusSampler({ cwd: '/repo', exec, now: () => state.now, prTtlMs });
+  return { sampler, state, calls, exec };
+}
+
+describe('GitStatusSampler', () => {
+  it('resolves the current branch and open PR', async () => {
+    const { sampler } = makeSampler();
+    await sampler.refresh({ blockOnPr: true });
+    expect(sampler.getBranch()).toBe('feat/x');
+    expect(sampler.getPr()).toBe(123);
+  });
+
+  it('runs git and gh in the configured cwd', async () => {
+    const { sampler, exec } = makeSampler();
+    await sampler.refresh({ blockOnPr: true });
+    for (const call of (exec as unknown as { mock: { calls: unknown[][] } }).mock.calls) {
+      expect(call[2]).toBe('/repo'); // 3rd arg is cwd
+    }
+  });
+
+  it('leaves branch and PR undefined on a detached HEAD (git symbolic-ref fails)', async () => {
+    const { sampler } = makeSampler({ branch: null });
+    await sampler.refresh({ blockOnPr: true });
+    expect(sampler.getBranch()).toBeUndefined();
+    expect(sampler.getPr()).toBeUndefined();
+  });
+
+  it('skips the PR network call entirely on a detached HEAD', async () => {
+    const { sampler, calls } = makeSampler({ branch: null });
+    await sampler.refresh({ blockOnPr: true });
+    expect(calls.git).toBe(1);
+    expect(calls.gh).toBe(0);
+  });
+
+  it('shows the branch but no PR when the branch has no open PR', async () => {
+    const { sampler } = makeSampler({ pr: null });
+    await sampler.refresh({ blockOnPr: true });
+    expect(sampler.getBranch()).toBe('feat/x');
+    expect(sampler.getPr()).toBeUndefined();
+  });
+
+  it('never throws and leaves the PR empty when gh fails', async () => {
+    const { sampler } = makeSampler({ pr: 'throw' });
+    await expect(sampler.refresh({ blockOnPr: true })).resolves.toBeUndefined();
+    expect(sampler.getBranch()).toBe('feat/x');
+    expect(sampler.getPr()).toBeUndefined();
+  });
+
+  it('does not re-query the PR for the same branch within the TTL', async () => {
+    const { sampler, state, calls } = makeSampler();
+    await sampler.refresh({ blockOnPr: true });
+    const ghAfterFirst = calls.gh;
+    expect(ghAfterFirst).toBe(1);
+
+    state.now += 1_000; // well within the 60s TTL
+    await sampler.refresh({ blockOnPr: true });
+    expect(calls.gh).toBe(ghAfterFirst); // no re-fetch
+  });
+
+  it('re-queries the PR for the same branch once the TTL elapses', async () => {
+    const { sampler, state, calls } = makeSampler();
+    await sampler.refresh({ blockOnPr: true });
+    expect(calls.gh).toBe(1);
+
+    state.now += 60_000; // TTL boundary reached
+    await sampler.refresh({ blockOnPr: true });
+    expect(calls.gh).toBe(2);
+  });
+
+  it('re-fetches the PR immediately when the branch changes', async () => {
+    const { sampler, state, calls } = makeSampler();
+    await sampler.refresh({ blockOnPr: true });
+    expect(sampler.getPr()).toBe(123);
+
+    state.branch = 'feat/y';
+    state.pr = '456';
+    state.now += 1_000; // still within TTL — branch change must override it
+    await sampler.refresh({ blockOnPr: true });
+    expect(sampler.getBranch()).toBe('feat/y');
+    expect(sampler.getPr()).toBe(456);
+    expect(calls.gh).toBe(2);
+  });
+
+  it('dedupes concurrent branch refreshes', async () => {
+    const { sampler, calls } = makeSampler();
+    await Promise.all([sampler.refresh(), sampler.refresh(), sampler.refresh()]);
+    expect(calls.git).toBe(1);
+  });
+
+  it('reset() clears the cached branch and PR', async () => {
+    const { sampler } = makeSampler();
+    await sampler.refresh({ blockOnPr: true });
+    expect(sampler.getBranch()).toBe('feat/x');
+    sampler.reset();
+    expect(sampler.getBranch()).toBeUndefined();
+    expect(sampler.getPr()).toBeUndefined();
+  });
+
+  it('dispose() stops further sampling', async () => {
+    const { sampler, calls } = makeSampler();
+    sampler.dispose();
+    await sampler.refresh({ blockOnPr: true });
+    expect(calls.git).toBe(0);
+    expect(sampler.getBranch()).toBeUndefined();
+  });
+
+  it('fires onUpdate when the branch first resolves and again when the PR lands', async () => {
+    const onUpdate = vi.fn();
+    const { sampler } = makeSampler();
+    sampler.setOnUpdate(onUpdate);
+    await sampler.refresh({ blockOnPr: true });
+    // One notify for branch (undefined → feat/x), one for PR (undefined → 123).
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not fire onUpdate on a no-op refresh (same branch, same PR, within TTL)', async () => {
+    const onUpdate = vi.fn();
+    const { sampler, state } = makeSampler();
+    sampler.setOnUpdate(onUpdate);
+    await sampler.refresh({ blockOnPr: true });
+    onUpdate.mockClear();
+    state.now += 1_000; // within TTL — no re-fetch, nothing changes
+    await sampler.refresh({ blockOnPr: true });
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('fires onUpdate once when the branch changes (PR cleared then re-resolved)', async () => {
+    const onUpdate = vi.fn();
+    const { sampler, state } = makeSampler();
+    sampler.setOnUpdate(onUpdate);
+    await sampler.refresh({ blockOnPr: true });
+    onUpdate.mockClear();
+    state.branch = 'feat/y';
+    state.pr = '456';
+    await sampler.refresh({ blockOnPr: true });
+    // One notify for the branch change (clears stale PR), one for the new PR.
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+    expect(sampler.getBranch()).toBe('feat/y');
+    expect(sampler.getPr()).toBe(456);
+  });
+
+  it('swallows a throwing onUpdate callback without breaking sampling', async () => {
+    const { sampler } = makeSampler();
+    sampler.setOnUpdate(() => {
+      throw new Error('repaint blew up');
+    });
+    await expect(sampler.refresh({ blockOnPr: true })).resolves.toBeUndefined();
+    expect(sampler.getBranch()).toBe('feat/x');
+    expect(sampler.getPr()).toBe(123);
+  });
+
+  it('discards a stale PR result when the branch changed during the in-flight fetch', async () => {
+    // gh hangs until we resolve it manually, simulating a slow network call.
+    let resolveGh: (v: { stdout: string; stderr: string }) => void = () => {};
+    const ghPromise = new Promise<{ stdout: string; stderr: string }>((r) => {
+      resolveGh = r;
+    });
+    const state = { branch: 'A' };
+    const exec: GitStatusExecFn = async (file) => {
+      if (file === 'git') return { stdout: state.branch + '\n', stderr: '' };
+      return ghPromise; // gh stays pending
+    };
+    const sampler = new GitStatusSampler({ cwd: '/r', exec, now: () => 1000 });
+
+    await sampler.refresh(); // branch=A; PR(A) fetch in flight
+    expect(sampler.getBranch()).toBe('A');
+
+    state.branch = 'B';
+    await sampler.refresh(); // branch=B; PR(A) still in flight
+    expect(sampler.getBranch()).toBe('B');
+
+    // Resolve the stale PR(A) lookup — it must be discarded because branch is now B.
+    resolveGh({ stdout: '111\n', stderr: '' });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(sampler.getPr()).toBeUndefined();
+  });
+});

--- a/src/cli/git-status-sampler.ts
+++ b/src/cli/git-status-sampler.ts
@@ -50,6 +50,15 @@ export interface GitStatusSamplerOptions {
    * always forces an immediate re-fetch regardless of this. Default 60_000.
    */
   prTtlMs?: number;
+  /**
+   * Minimum ms between branch re-checks via `git symbolic-ref`. The
+   * `branchInFlight` dedup prevents concurrent spawns; this guards against
+   * serial per-turn subprocess overhead on slow filesystems (network mounts,
+   * Docker volumes). Default 0 (no guard — always re-sample). Production sets
+   * this to 1_000 ms in bootstrap so turns never fork git more than once per
+   * second.
+   */
+  branchTtlMs?: number;
   /** Injectable clock for tests. Defaults to `Date.now`. */
   now?: () => number;
   /** Per-call exec timeout in ms (bounds a hung `gh` when offline). Default 10_000. */
@@ -80,6 +89,7 @@ export class GitStatusSampler {
   private readonly cwd: string;
   private readonly exec: GitStatusExecFn;
   private readonly prTtlMs: number;
+  private readonly branchTtlMs: number;
   private readonly now: () => number;
   private onUpdate: (() => void) | undefined;
 
@@ -89,15 +99,25 @@ export class GitStatusSampler {
   private prBranch: string | undefined;
   /** Timestamp of the last PR fetch attempt (success or "no PR"). */
   private prFetchedAt = 0;
+  /** Timestamp of the last branch check (via `git symbolic-ref`). */
+  private branchFetchedAt = 0;
 
   private branchInFlight: Promise<void> | null = null;
   private prInFlight: Promise<void> | null = null;
   private disposed = false;
+  /**
+   * Incremented by reset() to invalidate in-flight updateBranch /
+   * maybeFetchPr tasks. Each task captures this before its first await and
+   * checks it after settling — a mismatch means reset() fired mid-flight and
+   * the result must be discarded rather than written to shared state.
+   */
+  private resetToken = 0;
 
   constructor(opts: GitStatusSamplerOptions) {
     this.cwd = opts.cwd;
     this.exec = opts.exec ?? defaultExec(opts.timeoutMs ?? 10_000);
     this.prTtlMs = opts.prTtlMs ?? 60_000;
+    this.branchTtlMs = opts.branchTtlMs ?? 0;
     this.now = opts.now ?? Date.now;
     this.onUpdate = opts.onUpdate;
   }
@@ -141,12 +161,19 @@ export class GitStatusSampler {
     if (opts.blockOnPr && this.prInFlight) await this.prInFlight;
   }
 
-  /** Clear cached values so the next refresh starts cold. */
+  /**
+   * Clear cached values so the next refresh starts cold. Increments the
+   * internal generation token so any concurrently-settling updateBranch() or
+   * maybeFetchPr() task detects the reset via token mismatch and discards its
+   * result rather than writing stale state.
+   */
   reset(): void {
+    this.resetToken++;
     this.branch = undefined;
     this.pr = undefined;
     this.prBranch = undefined;
     this.prFetchedAt = 0;
+    this.branchFetchedAt = 0;
     this.branchInFlight = null;
     this.prInFlight = null;
   }
@@ -157,8 +184,22 @@ export class GitStatusSampler {
   }
 
   private async updateBranch(): Promise<void> {
+    // Skip if the branch was checked within branchTtlMs — guards per-turn
+    // subprocess overhead on slow filesystems. Default 0 = always re-sample.
+    if (
+      this.branchTtlMs > 0 &&
+      this.branchFetchedAt > 0 &&
+      this.now() - this.branchFetchedAt < this.branchTtlMs
+    ) {
+      return;
+    }
+    // Capture the generation token before the first await. If reset() fires
+    // while the git call is in flight, the token increments and we discard
+    // the result rather than writing stale state.
+    const token = this.resetToken;
+    this.branchFetchedAt = this.now();
     const newBranch = await this.gitBranch();
-    if (this.disposed) return;
+    if (this.disposed || this.resetToken !== token) return;
     const branchChanged = newBranch !== this.branch;
     this.branch = newBranch;
 
@@ -215,9 +256,12 @@ export class GitStatusSampler {
 
     this.prFetchedAt = this.now();
     const task = (async () => {
+      // Capture the generation token before the network call. If reset() fires
+      // while gh is in flight, the token increments and we discard the result.
+      const token = this.resetToken;
       // resolveCurrentBranchPr never throws — returns the number string or null.
       const prStr = await resolveCurrentBranchPr((file, args) => this.exec(file, args, this.cwd));
-      if (this.disposed) return;
+      if (this.disposed || this.resetToken !== token) return;
       // Discard if the branch changed while the network call was in flight.
       if (this.branch !== branch) return;
       const n = prStr !== null ? Number.parseInt(prStr, 10) : NaN;
@@ -227,6 +271,14 @@ export class GitStatusSampler {
       if (this.pr !== prevPr) this.notify();
     })().finally(() => {
       this.prInFlight = null;
+      // If the branch changed while this fetch was in flight, the branch guard
+      // above discarded the stale result. Kick a follow-up lookup for the
+      // current branch so its PR resolves on the next settled repaint rather
+      // than waiting for the next turn's refresh() call.
+      const currentBranch = this.branch;
+      if (!this.disposed && currentBranch !== undefined && currentBranch !== branch) {
+        void this.maybeFetchPr(currentBranch);
+      }
     });
     this.prInFlight = task;
     return task;

--- a/src/cli/git-status-sampler.ts
+++ b/src/cli/git-status-sampler.ts
@@ -1,0 +1,234 @@
+/**
+ * Cached, sampled view of the session's git branch + open PR for the status
+ * line.
+ *
+ * The status line repaints every turn (and on every mid-turn token event);
+ * shelling out to `git` / `gh` on every repaint would be both chatty and slow
+ * (a `gh pr view` is a network round-trip). This sampler:
+ *
+ *   - caches the current branch and the open-PR number so repaints are O(1)
+ *     cache reads (`getBranch()` / `getPr()`);
+ *   - resolves the branch via a fast local `git symbolic-ref` that callers may
+ *     `await` (≈ a few ms) — `refresh()` resolves once the branch is updated;
+ *   - resolves the PR via `gh pr view` in a DETACHED background task that never
+ *     blocks `refresh()`, the turn loop, or a repaint. The PR appears on a
+ *     later repaint once the network call settles;
+ *   - throttles the network call: the PR is only re-fetched when the branch
+ *     changes or the cached value is older than `prTtlMs`, so a branch with no
+ *     PR is not re-queried every turn;
+ *   - degrades gracefully: a detached HEAD, a non-git directory, a missing
+ *     `gh`, or any failure leaves the field empty rather than throwing.
+ *
+ * The sampler is session-scoped; the REPL constructs one per session.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { resolveCurrentBranchPr } from '../agent/gh.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Exec shape used for both the local `git` call and the injected `gh` call.
+ * `cwd` is mandatory so the branch/PR reflect the SESSION's working directory
+ * (which, under `--worktree`, differs from `process.cwd()`). Matches the slice
+ * of `promisify(execFile)` we use.
+ */
+export type GitStatusExecFn = (
+  file: string,
+  args: string[],
+  cwd: string,
+) => Promise<{ stdout: string; stderr: string }>;
+
+export interface GitStatusSamplerOptions {
+  /** Session working directory the git/gh calls run in. */
+  cwd: string;
+  /** Injectable exec for tests. Defaults to a timeout-bounded `execFile`. */
+  exec?: GitStatusExecFn;
+  /**
+   * Minimum ms between PR network fetches for the SAME branch. A branch change
+   * always forces an immediate re-fetch regardless of this. Default 60_000.
+   */
+  prTtlMs?: number;
+  /** Injectable clock for tests. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Per-call exec timeout in ms (bounds a hung `gh` when offline). Default 10_000. */
+  timeoutMs?: number;
+  /**
+   * Fired after the displayed branch or PR actually CHANGES (not on every
+   * refresh). The REPL wires this to a status-line repaint so the branch
+   * appears as soon as the (fast, local) git call resolves and the PR lands
+   * when its (slow, network) lookup settles — without waiting for the next
+   * turn. A throwing callback is swallowed so a UI error never breaks sampling.
+   */
+  onUpdate?: () => void;
+}
+
+/** Default exec: timeout-bounded, no shell, runs in the supplied cwd. */
+function defaultExec(timeoutMs: number): GitStatusExecFn {
+  return (file, args, cwd) =>
+    execFileAsync(file, args, {
+      cwd,
+      timeout: timeoutMs,
+      killSignal: 'SIGTERM',
+      // Branch names / PR numbers are tiny; cap output defensively.
+      maxBuffer: 64 * 1024,
+    }).then((r) => ({ stdout: r.stdout, stderr: r.stderr }));
+}
+
+export class GitStatusSampler {
+  private readonly cwd: string;
+  private readonly exec: GitStatusExecFn;
+  private readonly prTtlMs: number;
+  private readonly now: () => number;
+  private onUpdate: (() => void) | undefined;
+
+  private branch: string | undefined;
+  private pr: number | undefined;
+  /** Branch the cached `pr` value (number OR "no PR") was last fetched for. */
+  private prBranch: string | undefined;
+  /** Timestamp of the last PR fetch attempt (success or "no PR"). */
+  private prFetchedAt = 0;
+
+  private branchInFlight: Promise<void> | null = null;
+  private prInFlight: Promise<void> | null = null;
+  private disposed = false;
+
+  constructor(opts: GitStatusSamplerOptions) {
+    this.cwd = opts.cwd;
+    this.exec = opts.exec ?? defaultExec(opts.timeoutMs ?? 10_000);
+    this.prTtlMs = opts.prTtlMs ?? 60_000;
+    this.now = opts.now ?? Date.now;
+    this.onUpdate = opts.onUpdate;
+  }
+
+  /**
+   * Register (or replace) the on-change callback after construction. Used by
+   * the REPL bootstrap, where the repaint closure is only available after the
+   * sampler exists.
+   */
+  setOnUpdate(cb: (() => void) | undefined): void {
+    this.onUpdate = cb;
+  }
+
+  /** Latest cached branch, or undefined (detached HEAD / not a git repo / unfetched). */
+  getBranch(): string | undefined {
+    return this.branch;
+  }
+
+  /** Latest cached open-PR number for the current branch, or undefined. */
+  getPr(): number | undefined {
+    return this.pr;
+  }
+
+  /**
+   * Refresh the branch (awaited — fast, local) and kick a detached PR fetch
+   * (network — never awaited here). Dedupes concurrent branch refreshes.
+   *
+   * Pass `{ blockOnPr: true }` to also await the in-flight PR fetch — used by
+   * tests and the initial paint when the caller wants the PR resolved before
+   * reading the cache. The hot path (turn loop) omits it so the network call
+   * never delays a turn.
+   */
+  async refresh(opts: { blockOnPr?: boolean } = {}): Promise<void> {
+    if (this.disposed) return;
+    if (!this.branchInFlight) {
+      this.branchInFlight = this.updateBranch().finally(() => {
+        this.branchInFlight = null;
+      });
+    }
+    await this.branchInFlight;
+    if (opts.blockOnPr && this.prInFlight) await this.prInFlight;
+  }
+
+  /** Clear cached values so the next refresh starts cold. */
+  reset(): void {
+    this.branch = undefined;
+    this.pr = undefined;
+    this.prBranch = undefined;
+    this.prFetchedAt = 0;
+    this.branchInFlight = null;
+    this.prInFlight = null;
+  }
+
+  /** Stop any future sampling. Safe to call multiple times. */
+  dispose(): void {
+    this.disposed = true;
+  }
+
+  private async updateBranch(): Promise<void> {
+    const newBranch = await this.gitBranch();
+    if (this.disposed) return;
+    const branchChanged = newBranch !== this.branch;
+    this.branch = newBranch;
+
+    if (newBranch === undefined) {
+      // Detached HEAD or non-git dir: no branch ⇒ no PR.
+      const hadPr = this.pr !== undefined;
+      this.pr = undefined;
+      this.prBranch = undefined;
+      if (branchChanged || hadPr) this.notify();
+      return;
+    }
+
+    if (branchChanged) {
+      // Drop the previous branch's PR immediately — showing it against the new
+      // branch would be wrong. maybeFetchPr resolves the new branch's PR (or
+      // confirms none) shortly after. Notify now so the new branch paints.
+      this.pr = undefined;
+      this.notify();
+    }
+    // Detached, non-blocking PR fetch — the only path that touches the network.
+    void this.maybeFetchPr(newBranch);
+  }
+
+  /** Fire the on-change callback; a throwing UI callback must not break sampling. */
+  private notify(): void {
+    try {
+      this.onUpdate?.();
+    } catch {
+      /* swallow — the sampler is not responsible for UI errors */
+    }
+  }
+
+  /** `git symbolic-ref --short HEAD` → branch, or undefined on any failure. */
+  private async gitBranch(): Promise<string | undefined> {
+    try {
+      const { stdout } = await this.exec('git', ['symbolic-ref', '--short', 'HEAD'], this.cwd);
+      const b = stdout.trim();
+      return b.length > 0 ? b : undefined;
+    } catch {
+      // Detached HEAD (symbolic-ref exits non-zero), not a git repo, or no git.
+      return undefined;
+    }
+  }
+
+  /**
+   * Fetch the open PR for `branch` if stale, in a deduped background task.
+   * Caches "no PR" (undefined) too, so a PR-less branch is not re-queried on
+   * every repaint — only after `prTtlMs` elapses (to catch a PR opened later).
+   */
+  private maybeFetchPr(branch: string): Promise<void> {
+    if (this.prInFlight) return this.prInFlight;
+    const stale = this.prBranch !== branch || this.now() - this.prFetchedAt >= this.prTtlMs;
+    if (!stale) return Promise.resolve();
+
+    this.prFetchedAt = this.now();
+    const task = (async () => {
+      // resolveCurrentBranchPr never throws — returns the number string or null.
+      const prStr = await resolveCurrentBranchPr((file, args) => this.exec(file, args, this.cwd));
+      if (this.disposed) return;
+      // Discard if the branch changed while the network call was in flight.
+      if (this.branch !== branch) return;
+      const n = prStr !== null ? Number.parseInt(prStr, 10) : NaN;
+      const prevPr = this.pr;
+      this.pr = Number.isFinite(n) && n > 0 ? n : undefined;
+      this.prBranch = branch;
+      if (this.pr !== prevPr) this.notify();
+    })().finally(() => {
+      this.prInFlight = null;
+    });
+    this.prInFlight = task;
+    return task;
+  }
+}

--- a/src/cli/status-line.test.ts
+++ b/src/cli/status-line.test.ts
@@ -630,6 +630,112 @@ describe('StatusLine with cwd field', () => {
   });
 });
 
+describe('StatusLine with git branch + PR field', () => {
+  let stream: MockStream;
+
+  beforeEach(() => {
+    stream = mockStream({ isTTY: true, rows: 24 });
+  });
+
+  it('renders the branch with the ⎇ glyph when provided', () => {
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', branch: 'feat/x' });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('⎇');
+    expect(out).toContain('feat/x');
+    expect(out).toContain('sonnet');
+    status.stop();
+  });
+
+  it('appends the PR number as #<n> when provided alongside a branch', () => {
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', branch: 'feat/x', pr: 123 });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('feat/x');
+    expect(out).toContain('#123');
+    status.stop();
+  });
+
+  it('omits the git segment entirely when no branch is set', () => {
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({ model: 'sonnet' });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).not.toContain('⎇');
+    expect(out).toContain('sonnet');
+    status.stop();
+  });
+
+  it('does not render a PR number without a branch (pr is only meaningful with branch)', () => {
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', pr: 123 });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).not.toContain('#123');
+    expect(out).not.toContain('⎇');
+    expect(out).toContain('sonnet');
+    status.stop();
+  });
+
+  it('places the branch after cwd and before the model', () => {
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', cwd: '/tmp/proj', branch: 'feat/x' });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    const cwdIdx = out.indexOf('proj');
+    const branchIdx = out.indexOf('feat/x');
+    const modelIdx = out.indexOf('sonnet');
+    expect(cwdIdx).toBeGreaterThanOrEqual(0);
+    expect(branchIdx).toBeGreaterThan(cwdIdx);
+    expect(modelIdx).toBeGreaterThan(branchIdx);
+    status.stop();
+  });
+
+  it('truncates an over-long branch name (cap 30 cols)', () => {
+    stream.columns = 200; // wide enough that the line itself never truncates
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    const longBranch = 'feat/' + 'a'.repeat(60);
+    status.repaint({ model: 'sonnet', branch: longBranch });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('…');
+    expect(out).not.toContain('a'.repeat(40));
+    status.stop();
+  });
+
+  it('keeps the branch but drops tokens/cost on a narrow terminal (branch drops last)', () => {
+    stream.columns = 30;
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', branch: 'feat/x', cost: 0.05, tokens: 1200 });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('feat/x'); // branch (lowest drop priority) survives
+    expect(out).not.toContain('tok'); // tokens (drop-first) gone
+    status.stop();
+  });
+
+  it('drops the branch before the model on a very narrow terminal', () => {
+    stream.columns = 12;
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', branch: 'feat/x' });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('sonnet'); // model never drops
+    expect(out).not.toContain('feat/x');
+    status.stop();
+  });
+});
+
 describe('StatusLine narrow-terminal priority drop', () => {
   let stream: MockStream;
 

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -41,6 +41,20 @@ export interface StatusLineFields {
    * worth keeping visible on narrow terminals.
    */
   cwd?: string;
+  /**
+   * Current git branch (e.g. `feat/x`). Rendered after the cwd as `⎇ <branch>`
+   * — both are "where am I?" identity fields. Undefined on a detached HEAD or
+   * outside a git repo, in which case no branch segment is drawn. Sampled
+   * off-thread (see git-status-sampler.ts), so this is a cache read.
+   */
+  branch?: string;
+  /**
+   * Open PR number for the current branch, appended to the branch segment as
+   * `#<n>` (e.g. `⎇ feat/x #123`). Undefined when there is no open PR for the
+   * branch, when `gh` is unavailable, or before the (network) lookup settles.
+   * Only meaningful alongside `branch`.
+   */
+  pr?: number;
 }
 
 interface StatusLineOpts {
@@ -337,11 +351,13 @@ export class StatusLine {
   }
 
   private formatLine(f: StatusLineFields): string {
-    // Invariant: parts are built in semantic order (cwd, model, plan, context,
-    // cost, tokens), tagged with droppability priority so narrow terminals can
-    // shed lower-priority fields before resorting to right-edge truncation that
-    // arbitrarily loses model info. Drop order: tokens → cost → context bar.
-    // Never drop: cwd, model, plan.
+    // Invariant: parts are built in semantic order (cwd, branch, model, plan,
+    // context, cost, tokens), tagged with droppability priority so narrow
+    // terminals can shed lower-priority fields before resorting to right-edge
+    // truncation that arbitrarily loses model info. Drop order (drop-first →
+    // drop-last): tokens → cost → context bar → branch. The branch drops LAST
+    // among droppables because it is identity ("which branch am I on?"), like
+    // cwd. Never drop: cwd, model, plan.
     interface Part {
       text: string;
       droppablePriority?: number; // undefined = never drop, higher = drop first
@@ -357,6 +373,16 @@ export class StatusLine {
       const cwdBudget = Math.max(8, Math.floor(maxW * 0.4));
       const formatted = formatCwd(f.cwd, { maxWidth: cwdBudget });
       if (formatted) parts.push({ text: palette.dim(formatted) }); // never drop
+    }
+
+    // Git branch (+ open PR) sits next to the cwd — both answer "where am I?".
+    // The branch name is capped at 30 cols so a long branch can't dominate the
+    // line; the whole segment is droppable (lowest priority ⇒ dropped last).
+    if (f.branch) {
+      const branchText = truncateDisplayWidth(f.branch, 30);
+      let gitText = `${palette.dim('⎇')} ${palette.fileRef(branchText)}`;
+      if (f.pr !== undefined) gitText += ` ${palette.meta(`#${f.pr}`)}`;
+      parts.push({ text: gitText, droppablePriority: 1 }); // drop last among droppables
     }
 
     // Trusted-skill in-flight indicator no longer renders on the status line;
@@ -379,15 +405,15 @@ export class StatusLine {
         sparkline: f.contextSparkline,
         width: maxW,
       });
-      parts.push({ text: barOutput, droppablePriority: 1 }); // drop 3rd (after cost)
+      parts.push({ text: barOutput, droppablePriority: 2 }); // drop 3rd (after cost, before branch)
     }
 
     if (f.cost !== undefined) {
-      parts.push({ text: palette.meta(`$${f.cost.toFixed(2)}`), droppablePriority: 2 }); // drop 2nd
+      parts.push({ text: palette.meta(`$${f.cost.toFixed(2)}`), droppablePriority: 3 }); // drop 2nd
     }
 
     if (f.tokens !== undefined) {
-      parts.push({ text: palette.meta(`${formatTokens(f.tokens)} tok`), droppablePriority: 3 }); // drop 1st
+      parts.push({ text: palette.meta(`${formatTokens(f.tokens)} tok`), droppablePriority: 4 }); // drop 1st
     }
 
     // Join with separator and measure the result.


### PR DESCRIPTION
## What

The interactive REPL status line now shows the current **git branch** as `⎇ <branch>`, and when an **open PR** exists for that branch it appends `#<n>` — e.g. `⎇ feat/x #123`. The segment sits next to the cwd, since both answer "where am I?".

## How

New session-scoped `GitStatusSampler` (`src/cli/git-status-sampler.ts`), mirroring the existing `ContextSampler` caching pattern so status-line repaints stay O(1) and never block on git/network:

- **Branch** — fast local `git symbolic-ref --short HEAD`, awaited.
- **PR** — reuses `gh.ts`'s `resolveCurrentBranchPr` (`gh pr view`), run **detached** so the network call never blocks a repaint or the turn loop; TTL-cached per branch (60s) and invalidated on branch change; a "no PR" result is cached too (avoids re-querying every repaint).
- **Graceful** — detached HEAD, non-git dir, missing/unauthed `gh`, or any failure leaves the segment empty rather than throwing.
- **Reactive** — an `onUpdate` callback repaints the status line when the branch/PR actually change, so both appear without waiting for a turn.

Rendering (`src/cli/status-line.ts`): the git segment is **droppable-last** (drop order tokens → cost → context bar → branch), so the branch survives narrow terminals; cwd/model/plan are still never dropped. The branch name is capped at 30 cols.

Wiring: `bootstrap` constructs the sampler **side-effect-free** (no process spawn); `setupSurface` (REPL Phase 1) kicks the initial sample + wires the repaint — so bootstrap-only unit tests never shell out to git/gh. The per-turn `onAfterTurn` refresh catches mid-session branch switches; resume threads the sampler into the post-swap repaint.

## Tests

- New `git-status-sampler.test.ts` (17 tests): branch/PR resolution, cwd routing, detached HEAD, no-PR, gh failure, TTL throttle, branch-change re-fetch, dedup, dispose, `onUpdate` change-detection, and the supersede guard for a branch that changes mid-fetch.
- `status-line.test.ts`: 9 new cases — branch + `#PR` rendering, omission rules, ordering (after cwd, before model), long-branch truncation, and drop-priority (branch survives when tokens/cost drop; drops before model on a very narrow terminal).

## Verification

- `pnpm lint` clean · `pnpm build` clean · `pnpm audit:sdk:check` OK (no new SDK symbols)
- Full `src/cli` suite: **4048 passed / 230 files**

REPL-only (the status line is interactive-surface only); Telegram/daemon are unaffected. No SDK imports added. No config flag (always-on; degrades to branch-only or empty silently).
