### PR TITLE
feat(improve): classification eval for tool-failure-density contract

### DIFF
--- a/src/improve/eval-run/contracts.test.ts
+++ b/src/improve/eval-run/contracts.test.ts
@@ -9,6 +9,7 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  buildToolFailureClassificationCorpus,
   knownContractIds,
   makeCheck,
   resolveContract,
@@ -17,6 +18,7 @@ import {
 } from './contracts.js';
 import { REPEAT_CIRCUIT_BREAKER_THRESHOLD } from '../../agent/tools/dispatcher.js';
 import { SKILL_MAX_DEPTH_RECOVERY_HINT } from '../../agent/tools/skill-depth-message.js';
+import { detectToolFailureDensity } from '../scan/detectors/tool-failure-density.js';
 import type { FailurePattern } from '../schemas.js';
 
 // ---------------------------------------------------------------------------
@@ -112,9 +114,18 @@ describe('repeat-loop-circuit-breaker contract', () => {
 
 // ---------------------------------------------------------------------------
 // Contract: skill max-depth recovery hint
+//
+// KNOWN MISMAPPING: this contract is registered under patternId
+// `subagent-block`, but it validates the skill MAX-DEPTH refusal — a different
+// mechanism than the `hook_decision`/SubagentStart/`block` events the
+// subagent-block detector actually fires on (see the note in contracts.ts).
+// The checks below still pass (the refusal builder is healthy); they just do
+// not prove anything about the detector's recorded failures. Do NOT add a
+// fixture-replay for subagent-block against this contract until the mapping is
+// resolved.
 // ---------------------------------------------------------------------------
 
-describe('skill-max-depth-recovery-hint contract', () => {
+describe('skill-max-depth-recovery-hint contract (KNOWN subagent-block mismapping)', () => {
   it('all checks pass against the live refusal builder', async () => {
     const result = await resolveContract('subagent-block')!.run();
     expect(result.checks.map((c) => c.name)).toEqual([
@@ -136,18 +147,108 @@ describe('skill-max-depth-recovery-hint contract', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Contract: tool-failure-density enabled by default
+// Contract: tool-failure-density enabled by default + classification fidelity
 // ---------------------------------------------------------------------------
 
 describe('tool-failure-density-enabled contract', () => {
-  it('all checks pass — the detector is enabled by default', async () => {
+  it('all checks pass — enabled-by-default presence + classification fidelity', async () => {
     const result = await resolveContract('tool-failure-density')!.run();
-    expect(result.checks.map((c) => c.name)).toEqual(['in-default-enabled-set', 'not-opt-in']);
+    expect(result.checks.map((c) => c.name)).toEqual([
+      'in-default-enabled-set',
+      'not-opt-in',
+      'classification-fires-on-dual-threshold',
+      'classification-excludes-system-said-no-classes',
+      'classification-excludes-circuit-breaker',
+      'classification-counts-timeout-and-unclassified',
+      'classification-respects-thresholds',
+      'classification-reports-affected-sessions-and-seqs',
+    ]);
     for (const c of result.checks) {
       expect(c.status, `${c.name}: ${c.actual}`).toBe('pass');
     }
     const evidence = result.evidence.find((e) => e.ref.includes('enabledByDefault'));
     expect(evidence?.detail).toBe('true');
+  });
+
+  it('classification probe records the live detector as evidence', async () => {
+    const result = await resolveContract('tool-failure-density')!.run();
+    const detectorEvidence = result.evidence.find((e) => e.ref.includes('detectToolFailureDensity'));
+    expect(detectorEvidence).toBeDefined();
+    expect(detectorEvidence!.detail).toContain('flaky_tool');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Classification: detectToolFailureDensity over the synthetic SessionRead corpus
+//
+// These feed the SAME synthetic corpus the contract probe uses directly through
+// the live detector and assert the classification math at field granularity —
+// the regression surface the contract's pass/fail checks summarise.
+// ---------------------------------------------------------------------------
+
+describe('tool-failure-density classification (synthetic SessionRead corpus)', () => {
+  const cards = detectToolFailureDensity(buildToolFailureClassificationCorpus(), {});
+  const flaky = cards.find((c) => c.slug === 'tool-failure-flaky-tool');
+
+  it('emits exactly one card — the tool that clears BOTH thresholds', () => {
+    expect(cards.map((c) => c.slug)).toEqual(['tool-failure-flaky-tool']);
+    expect(flaky).toBeDefined();
+  });
+
+  it('excludes system-said-no classes from numerator AND denominator', () => {
+    // 3 counted failures (timeout + 2 unclassified) over 5 counted calls.
+    expect(flaky!.detail['failureCount']).toBe(3);
+    expect(flaky!.detail['totalCalls']).toBe(5);
+    expect(flaky!.detail['failureRate']).toBe(0.6);
+    expect(flaky!.detail['excludedByClass']).toEqual({
+      'policy-refusal': 1,
+      'permission-denied': 1,
+      abort: 1,
+      'hook-block': 1,
+      'elicitation-declined': 1,
+    });
+  });
+
+  it('never manufactures a card from excluded classes alone', () => {
+    // refusal_only_tool has 5 isError results, ALL excluded classes (a raw 5/6
+    // error rate that would fire if the exclusion regressed) + 1 success.
+    expect(cards.find((c) => c.slug === 'tool-failure-refusal-only-tool')).toBeUndefined();
+  });
+
+  it('excludes circuitBreaker-synthesised completions before classification', () => {
+    // The breaker event (isError, no class) would push totalCalls→6 and
+    // unclassified→3 if counted; it is skipped, and never lands in excludedByClass.
+    expect(flaky!.detail['totalCalls']).toBe(5);
+    expect(flaky!.detail['failureClassBreakdown']).toEqual({ timeout: 1, unclassified: 2 });
+    expect(Object.keys(flaky!.detail['excludedByClass'] as Record<string, number>)).not.toContain(
+      'circuitBreaker',
+    );
+  });
+
+  it('counts timeout and unclassified real tool failures', () => {
+    expect(flaky!.detail['failureClassBreakdown']).toEqual({ timeout: 1, unclassified: 2 });
+  });
+
+  it('respects the dual count+rate threshold (both must clear)', () => {
+    const corpus = buildToolFailureClassificationCorpus();
+    // Count gate: raise the failure floor above the recorded 3 → card drops out.
+    expect(
+      detectToolFailureDensity(corpus, { minFailures: 4 }).map((c) => c.slug),
+    ).not.toContain('tool-failure-flaky-tool');
+    // Rate gate: raise the rate floor above the recorded 0.6 → card drops out.
+    expect(
+      detectToolFailureDensity(corpus, { minFailureRate: 0.7 }).map((c) => c.slug),
+    ).not.toContain('tool-failure-flaky-tool');
+  });
+
+  it('reports affected sessions and per-failure seqs deterministically', () => {
+    expect(flaky!.detail['affectedSessionCount']).toBe(2);
+    expect([...(flaky!.detail['sessionIds'] as string[])].sort()).toEqual([
+      'tfd-sess-a',
+      'tfd-sess-b',
+    ]);
+    // Failure seqs in iteration order: sess-a seq1, sess-a seq2, sess-b seq0.
+    expect(flaky!.detail['seqs']).toEqual([1, 2, 0]);
   });
 });
 

--- a/src/improve/eval-run/contracts.ts
+++ b/src/improve/eval-run/contracts.ts
@@ -52,6 +52,9 @@ import {
   defaultEnabledDetectorNames,
   disabledByDefaultDetectorNames,
 } from '../scan/detectors/index.js';
+import { detectToolFailureDensity } from '../scan/detectors/tool-failure-density.js';
+import { parseTraceContent, type SessionRead } from '../scan/reader.js';
+import type { ToolFailureClass } from '../../agent/trace/types.js';
 import type { EvalCheck, EvalCheckStatus, EvalRunEvidenceRef, FailurePattern } from '../schemas.js';
 
 // ---------------------------------------------------------------------------
@@ -209,6 +212,19 @@ async function runRepeatLoopCircuitBreaker(): Promise<ContractProbeResult> {
 // Contract: subagent-block → skill max-depth recovery hint (PR #80)
 // ---------------------------------------------------------------------------
 
+// KNOWN MISMAPPING — do NOT add a fixture-replay for `subagent-block` against
+// this guardrail. The `subagent-block` DETECTOR fires on `hook_decision` events
+// with `hookEvent:'SubagentStart'` + `decision:'block'`
+// (src/improve/scan/detectors/subagent-block.ts), emitted by a user/plugin hook
+// via `dispatchSubagentStart` (src/agent/subagent-hooks.ts). This contract
+// instead validates the skill MAX-DEPTH refusal (`buildSkillMaxDepthRefusal`),
+// which fires inside skill-executor.ts BEFORE `forkSubagent` and emits a
+// `delegation.skipped` routing row — NOT the `hook_decision` event the detector
+// reads. So this contract proves a guardrail the detector never observes, and
+// no runtime guardrail neutralises a recurring SubagentStart block. The mapping
+// must be resolved before `subagent-block` gets a fixture-replay; left intact in
+// this slice (see contracts.test.ts and the recon plan for the full write-up).
+
 /**
  * Assert the skill-tool max-depth refusal carries the actionable recovery
  * hint. Validates the same builder {@link SkillExecutor.execute} returns, so a
@@ -263,10 +279,28 @@ async function runSkillMaxDepthRecoveryHint(): Promise<ContractProbeResult> {
 }
 
 // ---------------------------------------------------------------------------
-// Contract: tool-failure-density → enabled by default (PR #80)
+// Contract: tool-failure-density → enabled by default (PR #80) + classification
+//           fidelity (synthetic-corpus detector exercise)
 // ---------------------------------------------------------------------------
+//
+// `tool-failure-density` has no runtime guardrail to re-drive a recorded failure
+// through (unlike repeated-tool-use's circuit breaker or closure-anomaly's
+// recovery-hint builder), so it gets NO fixture-replay. What CAN regress and
+// silently manufacture/suppress real cards is the detector's CLASSIFICATION math
+// — the "system-said-no" exclusions, the circuit-breaker exclusion, and the dual
+// count+rate threshold. The classification probe below exercises the live
+// `detectToolFailureDensity` over a hand-verifiable synthetic corpus to pin that
+// behaviour. No fixture file, no schema change.
 
 const TFD_DETECTOR = 'tool-failure-density';
+
+// Synthetic-corpus tool names + their derived card slugs (see makeSlug in the
+// detector). The test asserts against these exact slugs, so they live here as
+// the single source of truth.
+const TFD_FLAKY_TOOL = 'flaky_tool';
+const TFD_REFUSAL_ONLY_TOOL = 'refusal_only_tool';
+const TFD_FLAKY_TOOL_SLUG = 'tool-failure-flaky-tool';
+const TFD_REFUSAL_ONLY_TOOL_SLUG = 'tool-failure-refusal-only-tool';
 
 /**
  * Assert the `tool-failure-density` detector runs in a default `afk improve
@@ -303,6 +337,278 @@ async function runToolFailureDensityEnabled(): Promise<ContractProbeResult> {
   ];
 
   return { checks, evidence };
+}
+
+// --- Synthetic classification corpus --------------------------------------
+
+/** Render one synthetic `tool_call` `completed` trace line (schema-valid JSONL). */
+function tfdCompletedLine(
+  seq: number,
+  name: string,
+  opts: {
+    isError: boolean;
+    failureClass?: ToolFailureClass;
+    circuitBreaker?: boolean;
+  },
+): string {
+  const payload: Record<string, unknown> = {
+    phase: 'completed',
+    toolUseId: `tu-${seq}`,
+    name,
+    resultBytes: 128,
+    isError: opts.isError,
+    truncated: false,
+    durationMs: 10,
+  };
+  if (opts.circuitBreaker === true) payload['circuitBreaker'] = true;
+  if (opts.failureClass !== undefined) payload['failureClass'] = opts.failureClass;
+  return JSON.stringify({ ts: '2026-06-20T10:00:00.000Z', seq, kind: 'tool_call', payload });
+}
+
+/** Parse synthetic JSONL lines into a `SessionRead` via the real reader, so the
+ *  corpus is schema-validated exactly like a witness trace on disk. */
+function tfdSession(sessionId: string, lines: string[]): SessionRead {
+  const relativeTracePath = `state/witness/${sessionId}/trace.jsonl`;
+  return parseTraceContent({
+    sessionId,
+    tracePath: relativeTracePath,
+    relativeTracePath,
+    content: lines.join('\n') + '\n',
+    sessionMtimeMs: 0,
+  });
+}
+
+/**
+ * The synthetic corpus the classification probe runs over. Exported so the
+ * contract test asserts against the SAME stimulus the contract sees.
+ *
+ * Hand-verifiable expected detector output at defaults (minFailures=3,
+ * minFailureRate=0.25):
+ *
+ *   `flaky_tool` → ONE card. Counted: sess-a {success, timeout-fail,
+ *     unclassified-fail} + sess-b {unclassified-fail, success} = 5 calls,
+ *     3 failures, rate 0.6. Excluded from BOTH numerator and denominator:
+ *     policy-refusal / permission-denied / abort / hook-block /
+ *     elicitation-declined (1 each) → excludedByClass; plus one circuitBreaker
+ *     block (skipped BEFORE the class check, so it never appears in
+ *     excludedByClass and never inflates totalCalls or the unclassified count).
+ *     failureClassBreakdown = {timeout:1, unclassified:2}; affected sessions
+ *     {sess-a, sess-b}; failure seqs [1, 2, 0] (sess-a first, then sess-b).
+ *
+ *   `refusal_only_tool` → NO card. All 5 isError results are excluded classes,
+ *     so 0 counted failures — despite a raw 5/6 error rate that WOULD fire if
+ *     the exclusion regressed. This is the false-positive guard (the
+ *     browser_open / ask_question "looked broken but was working as designed"
+ *     class of bug).
+ */
+export function buildToolFailureClassificationCorpus(): SessionRead[] {
+  const sessA = tfdSession('tfd-sess-a', [
+    tfdCompletedLine(0, TFD_FLAKY_TOOL, { isError: false }),
+    tfdCompletedLine(1, TFD_FLAKY_TOOL, { isError: true, failureClass: 'timeout' }),
+    tfdCompletedLine(2, TFD_FLAKY_TOOL, { isError: true }), // unclassified — counts
+    tfdCompletedLine(3, TFD_FLAKY_TOOL, { isError: true, failureClass: 'policy-refusal' }), // excluded
+    tfdCompletedLine(4, TFD_FLAKY_TOOL, { isError: true, circuitBreaker: true }), // excluded (synthetic)
+  ]);
+  const sessB = tfdSession('tfd-sess-b', [
+    tfdCompletedLine(0, TFD_FLAKY_TOOL, { isError: true }), // unclassified — counts
+    tfdCompletedLine(1, TFD_FLAKY_TOOL, { isError: false }),
+    tfdCompletedLine(2, TFD_FLAKY_TOOL, { isError: true, failureClass: 'permission-denied' }), // excluded
+    tfdCompletedLine(3, TFD_FLAKY_TOOL, { isError: true, failureClass: 'abort' }), // excluded
+    tfdCompletedLine(4, TFD_FLAKY_TOOL, { isError: true, failureClass: 'hook-block' }), // excluded
+    tfdCompletedLine(5, TFD_FLAKY_TOOL, { isError: true, failureClass: 'elicitation-declined' }), // excluded
+  ]);
+  const sessC = tfdSession('tfd-sess-c', [
+    tfdCompletedLine(0, TFD_REFUSAL_ONLY_TOOL, { isError: false }),
+    tfdCompletedLine(1, TFD_REFUSAL_ONLY_TOOL, { isError: true, failureClass: 'policy-refusal' }),
+    tfdCompletedLine(2, TFD_REFUSAL_ONLY_TOOL, { isError: true, failureClass: 'policy-refusal' }),
+    tfdCompletedLine(3, TFD_REFUSAL_ONLY_TOOL, { isError: true, failureClass: 'permission-denied' }),
+    tfdCompletedLine(4, TFD_REFUSAL_ONLY_TOOL, { isError: true, failureClass: 'hook-block' }),
+    tfdCompletedLine(5, TFD_REFUSAL_ONLY_TOOL, { isError: true, failureClass: 'abort' }),
+  ]);
+  return [sessA, sessB, sessC];
+}
+
+// --- Classification-probe helpers -----------------------------------------
+
+/** Read a numeric detail field, or `undefined` when absent / non-numeric. */
+function tfdNum(detail: Record<string, unknown>, key: string): number | undefined {
+  const v = detail[key];
+  return typeof v === 'number' ? v : undefined;
+}
+
+/** Normalise a `{class: count}` blob to a plain record of numbers. */
+function tfdCounts(value: unknown): Record<string, number> {
+  const out: Record<string, number> = {};
+  if (value === null || typeof value !== 'object') return out;
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof v === 'number') out[k] = v;
+  }
+  return out;
+}
+
+/** Order-independent equality of two `{key: count}` maps. */
+function tfdSameCounts(actual: unknown, expected: Record<string, number>): boolean {
+  const a = tfdCounts(actual);
+  const aKeys = Object.keys(a);
+  const eKeys = Object.keys(expected);
+  if (aKeys.length !== eKeys.length) return false;
+  for (const k of eKeys) {
+    if (a[k] !== expected[k]) return false;
+  }
+  return true;
+}
+
+function tfdNumArray(value: unknown): number[] {
+  return Array.isArray(value) ? value.filter((n): n is number => typeof n === 'number') : [];
+}
+
+function tfdStrArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((s): s is string => typeof s === 'string') : [];
+}
+
+/**
+ * Synthetic-corpus classification probe for `tool-failure-density`.
+ *
+ * Feeds {@link buildToolFailureClassificationCorpus} through the LIVE
+ * {@link detectToolFailureDensity} and asserts the classification math most
+ * prone to silent regression: the "system-said-no" exclusions, the
+ * circuit-breaker exclusion, the timeout/unclassified inclusions, the dual
+ * count+rate threshold, and the emitted counts / rate / breakdowns / affected
+ * sessions / seqs. Pure (no I/O); a regression in the detector surfaces here as
+ * a failing check, exactly as it would in a real `afk improve eval-run`.
+ */
+function runToolFailureDensityClassification(): ContractProbeResult {
+  const corpus = buildToolFailureClassificationCorpus();
+  const cards = detectToolFailureDensity(corpus, {});
+  const flaky = cards.find((c) => c.slug === TFD_FLAKY_TOOL_SLUG);
+  const refusalOnly = cards.find((c) => c.slug === TFD_REFUSAL_ONLY_TOOL_SLUG);
+
+  const detail: Record<string, unknown> = flaky?.detail ?? {};
+  const failureCount = tfdNum(detail, 'failureCount');
+  const totalCalls = tfdNum(detail, 'totalCalls');
+  const failureRate = tfdNum(detail, 'failureRate');
+  const affectedSessionCount = tfdNum(detail, 'affectedSessionCount');
+  const breakdown = tfdCounts(detail['failureClassBreakdown']);
+  const excluded = tfdCounts(detail['excludedByClass']);
+  const sessionIds = tfdStrArray(detail['sessionIds']).slice().sort();
+  const seqs = tfdNumArray(detail['seqs']);
+
+  // Threshold gates: raise the count floor above the recorded 3, and the rate
+  // floor above the recorded 0.6, and assert the card drops out each time —
+  // proving BOTH thresholds must clear (dual AND), not just one.
+  const aboveCount = detectToolFailureDensity(corpus, { minFailures: 4 });
+  const aboveRate = detectToolFailureDensity(corpus, { minFailureRate: 0.7 });
+  const countGate = !aboveCount.some((c) => c.slug === TFD_FLAKY_TOOL_SLUG);
+  const rateGate = !aboveRate.some((c) => c.slug === TFD_FLAKY_TOOL_SLUG);
+
+  const expectedExcluded: Record<string, number> = {
+    'policy-refusal': 1,
+    'permission-denied': 1,
+    abort: 1,
+    'hook-block': 1,
+    'elicitation-declined': 1,
+  };
+  const expectedBreakdown: Record<string, number> = { timeout: 1, unclassified: 2 };
+
+  const checks: EvalCheck[] = [
+    makeCheck({
+      name: 'classification-fires-on-dual-threshold',
+      description:
+        'A tool clearing BOTH the failure-count and failure-rate floors yields exactly one card at the recorded magnitude',
+      pass:
+        cards.length === 1 &&
+        flaky !== undefined &&
+        failureCount === 3 &&
+        totalCalls === 5 &&
+        failureRate === 0.6,
+      expected: `1 card '${TFD_FLAKY_TOOL_SLUG}' with failureCount=3, totalCalls=5, failureRate=0.6`,
+      actual:
+        flaky === undefined
+          ? `no '${TFD_FLAKY_TOOL_SLUG}' card; ${cards.length} card(s): [${cards.map((c) => c.slug).join(', ')}]`
+          : `${cards.length} card(s); failureCount=${failureCount}, totalCalls=${totalCalls}, failureRate=${failureRate}`,
+    }),
+    makeCheck({
+      name: 'classification-excludes-system-said-no-classes',
+      description:
+        'policy-refusal / permission-denied / hook-block / abort / elicitation-declined are excluded from BOTH numerator and denominator and never manufacture a card alone',
+      pass:
+        tfdSameCounts(excluded, expectedExcluded) &&
+        failureCount === 3 &&
+        totalCalls === 5 &&
+        refusalOnly === undefined,
+      expected:
+        'excludedByClass={policy-refusal:1,permission-denied:1,abort:1,hook-block:1,elicitation-declined:1}; counts not inflated; refusal-only tool yields NO card',
+      actual: `excludedByClass=${JSON.stringify(excluded)}; failureCount=${failureCount}, totalCalls=${totalCalls}; refusal_only_tool card ${refusalOnly === undefined ? 'absent' : 'PRESENT'}`,
+    }),
+    makeCheck({
+      name: 'classification-excludes-circuit-breaker',
+      description:
+        'A circuitBreaker-synthesised completion is skipped before classification — it inflates neither totalCalls nor the unclassified count, and never lands in excludedByClass',
+      pass: totalCalls === 5 && breakdown['unclassified'] === 2 && excluded['circuitBreaker'] === undefined,
+      expected:
+        'totalCalls=5 (breaker not counted); unclassified=2 (breaker not folded in); no circuitBreaker key in excludedByClass',
+      actual: `totalCalls=${totalCalls}; unclassified=${breakdown['unclassified'] ?? 0}; excludedByClass keys=[${Object.keys(excluded).join(', ')}]`,
+    }),
+    makeCheck({
+      name: 'classification-counts-timeout-and-unclassified',
+      description: 'timeout and unclassified (no failureClass) failures DO count toward the failure stats',
+      pass: tfdSameCounts(breakdown, expectedBreakdown),
+      expected: 'failureClassBreakdown={timeout:1,unclassified:2}',
+      actual: `failureClassBreakdown=${JSON.stringify(breakdown)}`,
+    }),
+    makeCheck({
+      name: 'classification-respects-thresholds',
+      description:
+        'The card drops out when EITHER the count floor or the rate floor is raised above the recorded magnitude (dual AND threshold)',
+      pass: countGate && rateGate,
+      expected: 'minFailures=4 → no card (count gate); minFailureRate=0.7 → no card (rate gate)',
+      actual: `count gate ${countGate ? 'held' : 'LEAKED'}; rate gate ${rateGate ? 'held' : 'LEAKED'}`,
+    }),
+    makeCheck({
+      name: 'classification-reports-affected-sessions-and-seqs',
+      description: 'The card reports the distinct affected sessions and per-failure seqs in deterministic order',
+      pass:
+        affectedSessionCount === 2 &&
+        JSON.stringify(sessionIds) === JSON.stringify(['tfd-sess-a', 'tfd-sess-b']) &&
+        JSON.stringify(seqs) === JSON.stringify([1, 2, 0]),
+      expected: 'affectedSessionCount=2; sessionIds=[tfd-sess-a,tfd-sess-b]; seqs=[1,2,0]',
+      actual: `affectedSessionCount=${affectedSessionCount}; sessionIds=[${sessionIds.join(',')}]; seqs=[${seqs.join(',')}]`,
+    }),
+  ];
+
+  const evidence: EvalRunEvidenceRef[] = [
+    {
+      kind: 'source-symbol',
+      ref: 'src/improve/scan/detectors/tool-failure-density.ts#detectToolFailureDensity',
+      detail:
+        flaky === undefined
+          ? `synthetic corpus → ${cards.length} card(s); '${TFD_FLAKY_TOOL_SLUG}' absent`
+          : `synthetic corpus → flaky_tool ${failureCount}/${totalCalls} (rate ${failureRate}); breakdown ${JSON.stringify(breakdown)}`,
+    },
+    {
+      kind: 'observed-behavior',
+      ref: 'detectToolFailureDensity (EXCLUDED_FAILURE_CLASSES + circuitBreaker exclusion)',
+      detail: `excludedByClass=${JSON.stringify(excluded)}; refusal_only_tool card ${refusalOnly === undefined ? 'absent' : 'PRESENT'}`,
+    },
+  ];
+
+  return { checks, evidence };
+}
+
+/**
+ * The registered `tool-failure-density` contract: the enabled-by-default
+ * presence check (proves the detector runs in a default scan) followed by the
+ * synthetic-corpus classification probe (proves the detector classifies a known
+ * failure mix correctly). Kept under the stable contract id
+ * `tool-failure-density-enabled` so existing eval-run artifacts keep resolving.
+ */
+async function runToolFailureDensityContract(): Promise<ContractProbeResult> {
+  const presence = await runToolFailureDensityEnabled();
+  const classification = runToolFailureDensityClassification();
+  return {
+    checks: [...presence.checks, ...classification.checks],
+    evidence: [...presence.evidence, ...classification.evidence],
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -391,8 +697,8 @@ const CONTRACTS: readonly EvalContract[] = Object.freeze([
   {
     id: 'tool-failure-density-enabled',
     patternId: 'tool-failure-density',
-    title: 'tool-failure-density detector is enabled by default',
-    run: runToolFailureDensityEnabled,
+    title: 'tool-failure-density detector is enabled by default and classifies a known failure mix correctly',
+    run: runToolFailureDensityContract,
   },
   {
     id: 'closure-abort-recovery-hint',


### PR DESCRIPTION
## Summary
Upgrades the `tool-failure-density` eval-run contract from a registry-flag check ("is the detector enabled by default?") into a **synthetic-corpus classification eval** that exercises the live `detectToolFailureDensity`.

This is the smallest safe slice from a read-only recon of the remaining supported improve patterns. `tool-failure-density` has **no runtime guardrail** to re-drive a recorded failure through (unlike `repeated-tool-use`'s circuit breaker or `closure-anomaly`'s recovery-hint builder), so it gets **no fixture-replay** — what *can* silently regress is the detector's classification math, and that is what this pins.

## What changed (2 files)
- `src/improve/eval-run/contracts.ts` — append a classification probe to the existing `tool-failure-density` contract (stable id `tool-failure-density-enabled`, so existing eval-run artifacts keep resolving). Builds a hand-verifiable multi-session `SessionRead[]` via the real `parseTraceContent` (schema-faithful, mirrors `replay.ts`) and runs the live detector.
- `src/improve/eval-run/contracts.test.ts` — assert the contract's 8 checks pass + a field-granular `describe` over the same corpus.

## Assertions
- excluded "system said no" classes (policy-refusal / permission-denied / hook-block / abort / elicitation-declined) count toward **neither** numerator nor denominator, and never manufacture a card on their own (a refusal-only tool with a raw 5/6 error rate yields **no card**)
- `circuitBreaker`-synthesised completions are excluded *before* classification
- `timeout` + unclassified failures **are** counted
- the dual count+rate threshold is enforced — both must clear (verified by raising each floor independently)
- emitted `failureCount` / `totalCalls` / `failureRate` / `failureClassBreakdown` / `excludedByClass` / `affectedSessionCount` / `sessionIds` / `seqs` all match

## Also
- Flags the `subagent-block` contract as a **known detector <-> guardrail mismapping** (comment in `contracts.ts` + a clarifying test `describe` name only; behavior unchanged). The detector fires on `hook_decision` / SubagentStart / `block` events, but the contract validates the skill max-depth refusal — a different mechanism that does not emit that event. Resolving the mapping is deliberately deferred.

## Scope / constraints honored
- No fixture-replay for `tool-failure-density`. No schema change. No detector / runner / replay source changes. No LLM reviewer, apply, auto-triage, scheduling, or forge bridge. Limited to the two files above.

## Testing
- `vitest run src/improve/eval-run/ src/improve/scan/detectors/tool-failure-density.test.ts` → **106/106 pass** (contracts 21, runner 28, replay 16, detector 41).
- `pnpm lint` (`tsc --noEmit`, strict) → clean.
