### PR TITLE
fix(telegram): render markdown in daemon task notifications

### DIFF
--- a/src/cli/commands/daemon.test.ts
+++ b/src/cli/commands/daemon.test.ts
@@ -306,6 +306,7 @@ describe('afk daemon (CLI integration)', () => {
 
     expect(mockPushIfConfigured).toHaveBeenCalledWith(
       expect.stringContaining('full daemon output'),
+      { markdown: true },
     );
   });
 });

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -417,7 +417,10 @@ export function registerDaemonCommand(program: Command): void {
           ...(trigger === 'pull' ? { pullPollIntervalMs: 30_000, queueDir: getQueueDir() } : {}),
           tasks,
           onTaskComplete: (record: TelemetryRecord, details?: TaskCompletionDetails) => {
-            void pushIfConfigured(formatTaskCompletion(record, details)).catch(() => undefined);
+            // markdown:true — task output is agent-authored markdown; render it
+            // to Telegram HTML so **bold**/`code`/headers format instead of
+            // showing their literal markers (plain-text fallback on parse error).
+            void pushIfConfigured(formatTaskCompletion(record, details), { markdown: true }).catch(() => undefined);
           },
         });
 

--- a/src/telegram/push.test.ts
+++ b/src/telegram/push.test.ts
@@ -214,6 +214,29 @@ describe('pushMarkdown', () => {
     // No duplicate send — only the HTML attempt was made.
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
+
+  test('re-splits rendered HTML so escaping-expanded content is never truncated past 4096', async () => {
+    const fetchImpl = makeFetchOk();
+    // 3000 '<' chars escape to 3000 '&lt;' = 12000 chars of HTML — ~3x Telegram's
+    // 4096 limit. Without the inner re-split, push() truncates to 4096 and the
+    // remaining ~8000 chars are silently dropped.
+    const raw = '<'.repeat(3000);
+    const result = await pushMarkdown({ token: 't', chatId: '1', text: raw, fetchImpl });
+
+    expect(result.ok).toBe(true);
+    const calls = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    // Sent as multiple messages rather than one truncated blob.
+    expect(calls.length).toBeGreaterThan(1);
+    let reassembled = '';
+    for (const call of calls) {
+      const body = JSON.parse(call[1].body);
+      expect(body.parse_mode).toBe('HTML');
+      expect(body.text.length).toBeLessThanOrEqual(4096);
+      reassembled += body.text;
+    }
+    // Full payload delivered across the chunks — no silent truncation.
+    expect(reassembled).toBe('&lt;'.repeat(3000));
+  });
 });
 
 describe('pushIfConfigured', () => {

--- a/src/telegram/push.test.ts
+++ b/src/telegram/push.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
-import { push, pushIfConfigured } from './push';
+import { push, pushIfConfigured, pushMarkdown } from './push';
 
 // loadTelegramConfig reads afk.config.json; mock it so these tests are hermetic
 // (notify routing is then driven purely by the env vars set per-test). The pure
@@ -161,6 +161,61 @@ describe('push', () => {
   });
 });
 
+describe('pushMarkdown', () => {
+  test('renders markdown to HTML and sends with parse_mode HTML', async () => {
+    const fetchImpl = makeFetchOk();
+    const result = await pushMarkdown({
+      token: 't',
+      chatId: '1',
+      text: '**bold** and `code`',
+      fetchImpl,
+    });
+    expect(result.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(body.parse_mode).toBe('HTML');
+    expect(body.text).toBe('<b>bold</b> and <code>code</code>');
+  });
+
+  test('falls back to plain text when Telegram rejects the HTML', async () => {
+    let call = 0;
+    const fetchImpl = vi.fn(async () => {
+      call++;
+      if (call === 1) {
+        return new Response(
+          JSON.stringify({ ok: false, description: "Bad Request: can't parse entities: unexpected tag" }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return new Response(JSON.stringify({ ok: true, result: {} }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await pushMarkdown({ token: 't', chatId: '1', text: '**weird** content', fetchImpl });
+
+    expect(result.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const calls = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const first = JSON.parse(calls[0][1].body);
+    const second = JSON.parse(calls[1][1].body);
+    expect(first.parse_mode).toBe('HTML');
+    // Fallback resends the original raw markdown with no parse_mode.
+    expect(second.parse_mode).toBeUndefined();
+    expect(second.text).toBe('**weird** content');
+  });
+
+  test('does NOT fall back on non-parse failures (e.g. 403 blocked)', async () => {
+    const fetchImpl = makeFetchError(403, 'Forbidden: bot was blocked by the user');
+    const result = await pushMarkdown({ token: 't', chatId: '1', text: '**x**', fetchImpl });
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(403);
+    // No duplicate send — only the HTML attempt was made.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('pushIfConfigured', () => {
   const NOTIFY_KEYS = [
     'TELEGRAM_BOT_TOKEN',
@@ -254,6 +309,18 @@ describe('pushIfConfigured', () => {
     const sent = calls.map((c) => JSON.parse(c[1].body).text as string);
     expect(sent.every((chunk) => chunk.length <= 4096)).toBe(true);
     expect(sent.join('')).toBe(text);
+  });
+
+  test('renders markdown to HTML per chunk when markdown:true', async () => {
+    process.env['TELEGRAM_BOT_TOKEN'] = 't';
+    process.env['AFK_TELEGRAM_ALLOWED_CHAT_IDS'] = '42';
+    const fetchImpl = makeFetchOk();
+
+    await pushIfConfigured('**hello** `world`', { markdown: true, fetchImpl });
+
+    const body = JSON.parse((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1].body);
+    expect(body.parse_mode).toBe('HTML');
+    expect(body.text).toBe('<b>hello</b> <code>world</code>');
   });
 
   test('forwards reply_markup to every chat when provided', async () => {

--- a/src/telegram/push.ts
+++ b/src/telegram/push.ts
@@ -117,24 +117,39 @@ export async function push(options: PushOptions): Promise<PushResult> {
  * `parse_mode`, Telegram renders the raw `**bold**` / `` `code` `` markers
  * verbatim instead of formatting them. This mirrors the interactive streaming
  * path's `deliverClean` resilience (src/telegram/streaming.ts): render to HTML,
- * and if a formatter edge case yields HTML Telegram won't parse, resend the
- * original text plain so the message is never silently dropped.
+ * split the rendered HTML back under Telegram's 4096-char limit, and if a
+ * formatter edge case yields HTML Telegram won't parse, resend the original
+ * text plain so the message is never silently dropped.
  */
 export async function pushMarkdown(
   options: Omit<PushOptions, 'parseMode'>,
 ): Promise<PushResult> {
   const html = markdownToTelegramHtml(options.text);
-  const htmlResult = await push({ ...options, text: html, parseMode: 'HTML' });
-  if (htmlResult.ok) return htmlResult;
-  // Fall back to plain text ONLY on Telegram's parse-entities rejection — other
-  // failures (rate limit, 403, network) must not trigger a duplicate send.
-  if (
-    htmlResult.status === 400 &&
-    /can't parse entities/i.test(htmlResult.errorMessage ?? '')
-  ) {
-    return push({ ...options });
+  // Re-split the RENDERED html before sending: escaping (& → &amp;) and tag
+  // injection (<b>, <code>) expand the text, so a chunk near the 4096 raw limit
+  // can render past it — and push() hard-truncates at 4096, silently dropping
+  // the tail. Splitting the html keeps every sendMessage within the limit.
+  // Sends are sequential so Telegram preserves message order.
+  const htmlChunks = splitLongMessage(html);
+  let result: PushResult = { ok: true, status: 200 };
+  for (const htmlChunk of htmlChunks) {
+    result = await push({ ...options, text: htmlChunk, parseMode: 'HTML' });
+    if (result.ok) continue;
+    // Fall back to plain text ONLY on Telegram's parse-entities rejection — other
+    // failures (rate limit, 403, network) must not trigger a duplicate send.
+    if (
+      result.status === 400 &&
+      /can't parse entities/i.test(result.errorMessage ?? '')
+    ) {
+      // Resend the ORIGINAL raw text plain so nothing is dropped. Like
+      // deliverClean, this may re-send a sub-chunk already accepted above — a
+      // rare edge (multi-chunk render + mid-stream parse failure) accepted
+      // over silent loss.
+      return push({ ...options });
+    }
+    return result;
   }
-  return htmlResult;
+  return result;
 }
 
 /**

--- a/src/telegram/push.ts
+++ b/src/telegram/push.ts
@@ -16,7 +16,7 @@
 import type { InlineKeyboardMarkup } from 'telegraf/types';
 
 import { resolveConfiguredNotifyTargets } from './notify-routing.js';
-import { splitLongMessage } from './formatter.js';
+import { splitLongMessage, markdownToTelegramHtml } from './formatter.js';
 import { env } from '../config/env.js';
 
 const TELEGRAM_API_BASE = 'https://api.telegram.org';
@@ -109,16 +109,51 @@ export async function push(options: PushOptions): Promise<PushResult> {
 }
 
 /**
+ * Push agent-authored markdown to one chat as Telegram HTML, falling back to
+ * plain text if Telegram rejects the rendered HTML ("can't parse entities").
+ *
+ * Out-of-band notifications (daemon task completions, the `send_telegram` tool,
+ * digests) carry GitHub-flavored markdown. Sent through `push()` with no
+ * `parse_mode`, Telegram renders the raw `**bold**` / `` `code` `` markers
+ * verbatim instead of formatting them. This mirrors the interactive streaming
+ * path's `deliverClean` resilience (src/telegram/streaming.ts): render to HTML,
+ * and if a formatter edge case yields HTML Telegram won't parse, resend the
+ * original text plain so the message is never silently dropped.
+ */
+export async function pushMarkdown(
+  options: Omit<PushOptions, 'parseMode'>,
+): Promise<PushResult> {
+  const html = markdownToTelegramHtml(options.text);
+  const htmlResult = await push({ ...options, text: html, parseMode: 'HTML' });
+  if (htmlResult.ok) return htmlResult;
+  // Fall back to plain text ONLY on Telegram's parse-entities rejection — other
+  // failures (rate limit, 403, network) must not trigger a duplicate send.
+  if (
+    htmlResult.status === 400 &&
+    /can't parse entities/i.test(htmlResult.errorMessage ?? '')
+  ) {
+    return push({ ...options });
+  }
+  return htmlResult;
+}
+
+/**
  * Push a notification to the configured delivery targets, splitting long text
  * into sequential Telegram-safe messages. Targets are resolved by
  * `resolveConfiguredNotifyTargets()` — by default a single "primary" chat, not
  * the whole allowlist (see notify-routing.ts). Returns `null` if unconfigured
  * (no token, or no resolvable targets) so callers don't gate every call site.
+ *
+ * Set `markdown: true` for agent-authored content so each chunk is rendered to
+ * Telegram HTML (with a plain-text fallback) instead of being shown verbatim;
+ * leave it off for pre-formatted or markup-sensitive text (e.g. raw URLs).
+ * `markdown` and `parseMode` are mutually exclusive — `markdown` wins.
  */
 export async function pushIfConfigured(
   text: string,
   opts: {
     parseMode?: PushOptions['parseMode'];
+    markdown?: boolean;
     replyMarkup?: PushOptions['replyMarkup'];
     fetchImpl?: typeof fetch;
   } = {},
@@ -128,18 +163,27 @@ export async function pushIfConfigured(
   const chatIds = resolveConfiguredNotifyTargets();
   if (chatIds.length === 0) return null;
 
+  // Split the RAW markdown first, then render each chunk — splitting already
+  // rendered HTML could sever a tag mid-chunk and trip Telegram's parser.
   const chunks = splitLongMessage(text);
   const results: PushResult[] = [];
   for (const chatId of chatIds) {
     for (let i = 0; i < chunks.length; i++) {
-      results.push(await push({
+      const base = {
         token,
         chatId,
         text: chunks[i] ?? '',
-        ...(opts.parseMode !== undefined ? { parseMode: opts.parseMode } : {}),
         ...(opts.replyMarkup !== undefined && i === 0 ? { replyMarkup: opts.replyMarkup } : {}),
         ...(opts.fetchImpl !== undefined ? { fetchImpl: opts.fetchImpl } : {}),
-      }));
+      };
+      results.push(
+        opts.markdown
+          ? await pushMarkdown(base)
+          : await push({
+              ...base,
+              ...(opts.parseMode !== undefined ? { parseMode: opts.parseMode } : {}),
+            }),
+      );
     }
   }
   return results;


### PR DESCRIPTION
## Problem

Daemon task-completion notifications pushed to Telegram render **raw markdown** — `**bold**` shows its asterisks, `` `code` `` shows its backticks, headers keep their `#`. (Reported via `/diagnose`; screenshot showed a `/forge-friction` daemon run rendered as literal markup.)

## Root cause

The out-of-band push path never tells Telegram to parse markdown and never converts it:

`daemon.ts onTaskComplete` → `pushIfConfigured(text)` → `push()` → Telegram `sendMessage`

`push()` only attaches `parse_mode` when the caller passes one (`src/telegram/push.ts:72`), and the daemon caller passed nothing (`src/cli/commands/daemon.ts:420`). With **no `parse_mode`, Telegram renders text verbatim**.

This is a **path asymmetry**, not a formatter bug: the interactive REPL→Telegram streaming path already converts via `markdownToTelegramHtml()` + `parse_mode: 'HTML'` with a plain-text fallback (`streaming.ts` `deliverClean`, lines 149–163). The raw `push()` primitive skipped both steps. `markdownToTelegramHtml()` itself works correctly.

## Fix

- **`src/telegram/push.ts`** — add `pushMarkdown()`: render → `parse_mode: 'HTML'` → fall back to plain text **only** on Telegram's `can't parse entities` 400 (so rate-limit/403/network failures don't double-send). Add a `markdown: true` opt-in to `pushIfConfigured()` that **splits the raw markdown first, then renders each chunk** so chunking can't sever an HTML tag. Mirrors the proven `deliverClean` resilience.
- **`src/cli/commands/daemon.ts`** — task-completion push opts into `{ markdown: true }`. This is the reported symptom.

`markdown` is opt-in and additive — existing `pushIfConfigured` callers (OAuth, review-post, afk-push, digest) are unchanged, so URLs / pre-formatted text stay raw.

## Out of scope (same defect, intentionally not touched)

The `send_telegram` tool (`send-telegram.ts:71`) and the daemon crash-push (`daemon.ts:360`) also call `push()` raw. Left unchanged to scope this PR to the reported daemon symptom; each is a one-line opt-in away.

## Verification

- `pnpm lint` (strict `tsc --noEmit`): clean
- `src/telegram/push.test.ts`: 24 pass (4 new — HTML render, parse-error fallback, no-double-send-on-403, `pushIfConfigured` markdown path)
- `src/cli/commands/daemon.test.ts`: 24 pass (completion assertion updated for the new arg)
- Full suite: **537/538 files pass**; the single failure (`anthropic-direct.test.ts > compact()`, a `claude-haiku-4-5` model-alias drift) is pre-existing and unrelated to this change.
