### PR TITLE
feat(awareness): surface current date in system-prompt environment block

### DIFF
--- a/src/agent/awareness/runtime-snapshot.test.ts
+++ b/src/agent/awareness/runtime-snapshot.test.ts
@@ -220,18 +220,26 @@ describe('buildRuntimeSnapshot', () => {
 // --- formatEnvironmentFragment ----------------------------------------------
 
 describe('formatEnvironmentFragment', () => {
-  it('emits only working-directory line when no identity fields supplied', () => {
-    const out = formatEnvironmentFragment({ cwd: '/tmp/project' });
-    expect(out).toBe('# Environment\n- Working directory: /tmp/project');
+  // Fixed clock + timezone so exact-match assertions stay deterministic across
+  // CI machines (the host timezone otherwise varies). 2026-06-18T12:00:00Z is a
+  // Thursday in UTC.
+  const FIXED_NOW = new Date('2026-06-18T12:00:00Z');
+  const FIXED_DATE_LINE = '- Date: Thursday, 2026-06-18 (UTC)';
+
+  it('emits working-directory and date lines when no identity fields supplied', () => {
+    const out = formatEnvironmentFragment({ cwd: '/tmp/project', now: FIXED_NOW, timeZone: 'UTC' });
+    expect(out).toBe(`# Environment\n- Working directory: /tmp/project\n${FIXED_DATE_LINE}`);
   });
 
   it('appends session line with truncated id when sessionId supplied', () => {
     const out = formatEnvironmentFragment({
       cwd: '/tmp',
       sessionId: 'af31a2b0-1234-4567-89ab-cdef01234567',
+      now: FIXED_NOW,
+      timeZone: 'UTC',
     });
     expect(out).toBe(
-      '# Environment\n- Working directory: /tmp\n- Session: af31a2b0',
+      `# Environment\n- Working directory: /tmp\n${FIXED_DATE_LINE}\n- Session: af31a2b0`,
     );
   });
 
@@ -269,9 +277,11 @@ describe('formatEnvironmentFragment', () => {
       cwd: '/tmp',
       sessionId: 'af31a2b0-x',
       surface: 'unknown',
+      now: FIXED_NOW,
+      timeZone: 'UTC',
     });
     expect(out).toBe(
-      '# Environment\n- Working directory: /tmp\n- Session: af31a2b0',
+      `# Environment\n- Working directory: /tmp\n${FIXED_DATE_LINE}\n- Session: af31a2b0`,
     );
     expect(out).not.toContain('unknown');
   });
@@ -283,8 +293,10 @@ describe('formatEnvironmentFragment', () => {
       surface: null,
       depth: null,
       maxDepth: null,
+      now: FIXED_NOW,
+      timeZone: 'UTC',
     });
-    expect(out).toBe('# Environment\n- Working directory: /tmp');
+    expect(out).toBe(`# Environment\n- Working directory: /tmp\n${FIXED_DATE_LINE}`);
   });
 
   it('omits session id when sessionId is empty string', () => {
@@ -301,8 +313,38 @@ describe('formatEnvironmentFragment', () => {
     const out = formatEnvironmentFragment({
       cwd: '/tmp',
       surface: 'daemon',
+      now: FIXED_NOW,
+      timeZone: 'UTC',
     });
-    expect(out).toBe('# Environment\n- Working directory: /tmp\n- Session: (daemon)');
+    expect(out).toBe(`# Environment\n- Working directory: /tmp\n${FIXED_DATE_LINE}\n- Session: (daemon)`);
+  });
+
+  it('includes a Date line with weekday, ISO date, and timezone (injected now/tz)', () => {
+    const out = formatEnvironmentFragment({ cwd: '/tmp', now: FIXED_NOW, timeZone: 'UTC' });
+    expect(out).toContain('- Date: Thursday, 2026-06-18 (UTC)');
+  });
+
+  it('renders the date in the supplied timezone (shifts local date across UTC midnight)', () => {
+    const out = formatEnvironmentFragment({
+      cwd: '/tmp',
+      // 03:00Z on the 18th is 20:00 PDT on the 17th — the local date is the 17th.
+      now: new Date('2026-06-18T03:00:00Z'),
+      timeZone: 'America/Los_Angeles',
+    });
+    expect(out).toContain('- Date: Wednesday, 2026-06-17 (America/Los_Angeles)');
+  });
+
+  it('falls back to a UTC ISO date without throwing on an invalid timezone', () => {
+    let out = '';
+    expect(() => {
+      out = formatEnvironmentFragment({ cwd: '/tmp', now: FIXED_NOW, timeZone: 'Not/AZone' });
+    }).not.toThrow();
+    expect(out).toContain('- Date: 2026-06-18');
+  });
+
+  it('emits a well-formed Date line using the host clock when now/timeZone omitted', () => {
+    const out = formatEnvironmentFragment({ cwd: '/tmp' });
+    expect(out).toMatch(/\n- Date: \w+, \d{4}-\d{2}-\d{2} \(.+\)/);
   });
 
   // External constraint: the fragment is appended verbatim to the system

--- a/src/agent/awareness/runtime-snapshot.ts
+++ b/src/agent/awareness/runtime-snapshot.ts
@@ -61,9 +61,10 @@ export function parseView(raw: unknown): RuntimeView {
 /**
  * Build the `# Environment` block for the system prompt.
  *
- * Always includes the working directory (existing behavior preserved). The
- * session identity line is appended only when at least one of `sessionId`,
- * `surface`, or `depth` is supplied — never with placeholder dashes.
+ * Always includes the working directory and the current date (existing
+ * working-directory behavior preserved). The session identity line is appended
+ * only when at least one of `sessionId`, `surface`, or `depth` is supplied —
+ * never with placeholder dashes.
  *
  * Phase 2: When `workspace` is supplied and at least one of `branch` or
  * `headSha` is non-null, a `- Workspace:` line is emitted. If the workspace
@@ -73,6 +74,7 @@ export function parseView(raw: unknown): RuntimeView {
  *
  *   # Environment
  *   - Working directory: /Users/me/project
+ *   - Date: Thursday, 2026-06-18 (America/Los_Angeles)
  *   - Session: af31a2b0 (repl, depth 1/3)
  *   - Workspace: main @ a1b2c3d (clean)
  *
@@ -80,12 +82,14 @@ export function parseView(raw: unknown): RuntimeView {
  *
  *   # Environment
  *   - Working directory: /Users/me/project
+ *   - Date: Thursday, 2026-06-18 (America/Los_Angeles)
  *   - Workspace: feat/foo @ a1b2c3d (3 dirty)
  *
  * Output shape (cwd only, no git):
  *
  *   # Environment
  *   - Working directory: /Users/me/project
+ *   - Date: Thursday, 2026-06-18 (America/Los_Angeles)
  */
 export function formatEnvironmentFragment(args: {
   cwd: string;
@@ -105,6 +109,17 @@ export function formatEnvironmentFragment(args: {
    * are null, i.e. when the cwd is not a git repo).
    */
   workspace?: RuntimeWorkspace | null;
+  /**
+   * Clock used for the always-present `- Date:` line. Defaults to `new Date()`.
+   * Injectable so tests stay deterministic.
+   */
+  now?: Date;
+  /**
+   * IANA timezone (e.g. `America/Los_Angeles`) the date is rendered in.
+   * Defaults to the host zone (`Intl…resolvedOptions().timeZone`). Injectable
+   * so tests can pin a zone; an invalid value falls back to a UTC ISO date.
+   */
+  timeZone?: string;
 }): string {
   // Sanitise CR/LF in cwd so a working directory containing a newline (rare
   // but reachable via network mounts or hostile-input scenarios) cannot inject
@@ -114,6 +129,14 @@ export function formatEnvironmentFragment(args: {
   // working-directory line that the model would then trust.
   const safeCwd = args.cwd.replace(/[\r\n]/g, ' ');
   const lines: string[] = [`- Working directory: ${safeCwd}`];
+
+  // Always-present current-date line — gives the model temporal grounding
+  // (relative-date math, "latest"/"recent" reasoning, weekday-gated skills,
+  // log interpretation). Date granularity (not clock time) keeps this block
+  // stable across turns within a session, so the cached system-prompt
+  // breakpoint is not busted per turn (the block is built once per provider
+  // query()). `now`/`timeZone` are injectable for deterministic tests.
+  lines.push(`- Date: ${formatDateLine(args.now ?? new Date(), args.timeZone)}`);
 
   const idShort =
     typeof args.sessionId === 'string' && args.sessionId.length > 0
@@ -163,4 +186,34 @@ export function formatEnvironmentFragment(args: {
   }
 
   return `# Environment\n${lines.join('\n')}`;
+}
+
+/**
+ * Render the `- Date:` line value: `<Weekday>, <YYYY-MM-DD> (<IANA-TZ>)`.
+ *
+ * Locale is pinned (`en-US` weekday, `en-CA` ISO date assembled via
+ * `formatToParts`) so the output never varies with the host locale — only the
+ * timezone reflects the host (or the injected `timeZone`). Wrapped in
+ * try/catch because this runs inside system-prompt assembly on every query:
+ * an invalid `timeZone` (only reachable via a bad caller-supplied value) must
+ * never throw and abort the request — it falls back to a UTC ISO date.
+ */
+function formatDateLine(now: Date, timeZone?: string): string {
+  try {
+    const tz = timeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone ?? 'UTC';
+    const parts = new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(now);
+    const pick = (t: string): string => parts.find((p) => p.type === t)?.value ?? '';
+    const weekday = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      weekday: 'long',
+    }).format(now);
+    return `${weekday}, ${pick('year')}-${pick('month')}-${pick('day')} (${tz})`;
+  } catch {
+    return now.toISOString().slice(0, 10);
+  }
 }


### PR DESCRIPTION
## What

Adds an always-present `- Date: <Weekday>, <YYYY-MM-DD> (<IANA-TZ>)` line to the `# Environment` block of the system prompt, e.g.:

```
# Environment
- Working directory: /Users/me/project
- Date: Wednesday, 2026-06-24 (America/New_York)
- Session: af31a2b0 (repl, depth 1/3)
- Workspace: main @ a1b2c3d (clean)
```

## Why

The agent had no awareness of the current date. This grounds it for relative-date math, "latest"/"recent" reasoning, weekday-gated skills (e.g. `weekly-reflect`), scheduling, and log interpretation.

## How

- One change point: `formatEnvironmentFragment()` in `src/agent/awareness/runtime-snapshot.ts` — the single function **both** providers (`anthropic-direct`, `openai-compatible`) already call to assemble the `# Environment` block. So the date reaches **every surface** (one-shot `chat`, REPL, Telegram, daemon, farm) **and every forked subagent** with **zero provider call-site changes**.
- Locale is pinned (`en-US` weekday, `en-CA` ISO date via `formatToParts`) so output never varies with the host locale; only the timezone reflects the host.
- New optional `now` / `timeZone` params keep tests deterministic; production uses the host clock + IANA zone. An invalid timezone falls back to a UTC ISO date and **never throws** inside prompt assembly.

## Freshness & caching (by design)

- Captured at session start — correct for one-shot `chat`, every daemon cron run, and each REPL/Telegram launch.
- **Date** granularity (not clock time) keeps the once-per-session `# Environment` block stable across turns, so the cached system-prompt breakpoint is **not** invalidated per turn.
- Known limitation: a single long-lived REPL/Telegram session left open across midnight shows the start date until restart — identical to how the existing `Session`/`Workspace` fields behave.

## Testing

- `pnpm lint` (strict `tsc --noEmit`): clean.
- `runtime-snapshot.test.ts`: **28/28 pass** — 5 exact-match tests updated to include the date line (deterministic via injected `now`/`timeZone`) + 4 new tests: injected now/tz, timezone shift across a UTC-midnight boundary, invalid-timezone fallback, and the host-clock default path.
- Full `pnpm test`: 10015 pass / 12 skip; the only 2 failures are pre-existing and unrelated to this change (`anthropic-direct` compact model-id — fails identically on `main`; `daemon` scheduler callback — passes in isolation, a parallel-run flake).
- Verified live: `afk chat --dump-prompt` shows the `- Date:` line in the assembled system prompt.
