### PR TITLE
fix(cli): protect narrow table columns from ellipsis truncation

### DIFF
--- a/src/cli/formatter.test.ts
+++ b/src/cli/formatter.test.ts
@@ -102,20 +102,16 @@ describe('renderMarkdownToTerminal', () => {
     });
 
     /**
-     * Proportional column-shrink contract.
+     * Wide:narrow ratio under the degenerate squeeze path.
      *
-     * The pre-edit algorithm shrunk the widest column by 1 each loop, which
-     * tended to equalize columns when one was much wider than the other —
-     * destroying the ratio the table author chose. The current algorithm
-     * shrinks every column proportional to its own reducible width, so the
-     * wide column stays meaningfully wider than the narrow column even
-     * under tight maxWidth constraints.
-     *
-     * Concrete check: with widths [5, 15] and a maxWidth that forces ~9
-     * units of shrink, the new algorithm preserves col2 > 2x col1.
-     * The old algorithm would have flattened them to roughly equal.
+     * Both columns are single, unbreakable tokens (5 and 15 chars), so their
+     * incompressible floors (min(natural, longestWord, CAP)) sum to more than
+     * the content budget at maxWidth 18 — the degenerate path. It shrinks the
+     * floors proportionally, which keeps the wide column meaningfully wider than
+     * the narrow one instead of flattening both to roughly equal (the original
+     * trim-widest-by-1 failure mode).
      */
-    it('preserves wide:narrow ratio under proportional shrink', () => {
+    it('preserves wide:narrow ratio under the degenerate squeeze', () => {
       const sample = [
         '| Short | WideHeader12345 |',
         '|-------|-----------------|',
@@ -131,9 +127,45 @@ describe('renderMarkdownToTerminal', () => {
       expect(cells).toHaveLength(2);
       const col1Width = stringWidth(cells[0]!);
       const col2Width = stringWidth(cells[1]!);
-      // Pre-edit equalize-by-1 would have produced ~1.14x ratio for this
-      // input; proportional shrink keeps the ratio at 2x or higher.
+      // Proportional floor-shrink keeps the ratio at 2x or higher; the original
+      // equalize-by-1 would have produced ~1.14x for this input.
       expect(col2Width).toBeGreaterThanOrEqual(col1Width * 2);
+    });
+
+    /**
+     * Narrow single-word column protection (the "Verd…" bug).
+     *
+     * A content-heavy table much wider than the terminal used to shrink EVERY
+     * column by the same proportion, crushing a narrow single-word column (e.g.
+     * a "Verdict" of CONFIRMED/OVERSTATED) below its content width so each value
+     * was chopped to "CONF…"/"OVER…". Floor-based water-filling gives each column
+     * its incompressible-word width as a floor and takes the squeeze from the
+     * genuinely wide columns instead, so the verdict words render in full while
+     * the table still fits the budget and the commit-time re-wrap stays a no-op.
+     */
+    it('protects a narrow single-word column from ellipsis truncation', () => {
+      const sample = [
+        '| # | Claim | Verdict | Source |',
+        '|---|-------|---------|--------|',
+        '| 1 | The dispatcher mishandles partial rows while streaming output | OVERSTATED | src/cli/formatter.ts:340 plus the downstream wrap pass |',
+        '| 2 | Column widths derive from natural content width alone here | CONFIRMED | src/cli/markdown-stream-format.ts:92 second wrapToWidth |',
+        '',
+      ].join('\n');
+      const maxWidth = 70;
+      const out = stripAnsi(renderMarkdownToTerminal(sample, { maxWidth }));
+      // The narrow Verdict column's single-word values survive in full — not
+      // chopped to "OVER…"/"CONF…" the way the old proportional squeeze did.
+      expect(out).toContain('OVERSTATED');
+      expect(out).toContain('CONFIRMED');
+      // No rendered line exceeds the budget...
+      for (const line of out.split('\n').filter((l) => l.length > 0)) {
+        expect(stringWidth(line)).toBeLessThanOrEqual(maxWidth);
+      }
+      // ...and the commit-time second wrap pass stays a no-op (no orphan-│
+      // fragments, no physical line-count inflation).
+      const rendered = renderMarkdownToTerminal(sample, { maxWidth });
+      expect(wrapToWidth(rendered, maxWidth).split('\n').length)
+        .toBe(rendered.split('\n').length);
     });
 
     /**

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -329,56 +329,106 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           const dataRows = table.rows.map((row) => row.map(renderCell));
           const colCount = headerCells.length;
           const widths: number[] = new Array<number>(colCount).fill(0);
+          // longestWord[i] = widest UNBREAKABLE token in column i. A word cannot
+          // be wrapped, so it is the column's incompressible minimum — used by the
+          // squeeze below as a per-column floor so a narrow single-word column
+          // (e.g. a "Verdict" of CONFIRMED/OVERSTATED) is never crushed below its
+          // own content and chopped to an ellipsis.
+          const longestWord: number[] = new Array<number>(colCount).fill(0);
+          const wordWidth = (s: string): number => {
+            let max = 0;
+            for (const tok of s.split(/\s+/)) {
+              if (tok) max = Math.max(max, visualWidth(tok));
+            }
+            return max;
+          };
           for (let i = 0; i < colCount; i++) {
             let w = visualWidth(headerCells[i] ?? '');
+            let lw = wordWidth(headerCells[i] ?? '');
             for (const row of dataRows) {
               w = Math.max(w, visualWidth(row[i] ?? ''));
+              lw = Math.max(lw, wordWidth(row[i] ?? ''));
             }
             widths[i] = w;
+            longestWord[i] = lw;
           }
 
           const targetWidth = maxTableWidth ?? Number.POSITIVE_INFINITY;
           const chromeWidth = (3 * colCount) + 1;
-          const minColWidth = targetWidth >= chromeWidth + colCount ? 1 : 0;
-          const availableContentWidth = Math.max(colCount * minColWidth, targetWidth - chromeWidth);
-          let totalContentWidth = widths.reduce((sum, width) => sum + width, 0);
+          const availableContentWidth = Math.max(0, targetWidth - chromeWidth);
+          const totalContentWidth = widths.reduce((sum, width) => sum + width, 0);
           if (Number.isFinite(targetWidth) && totalContentWidth > availableContentWidth) {
-            const constrained = widths.slice();
-            const reducibleTotal = constrained.reduce(
-              (sum, w) => sum + Math.max(0, w - minColWidth), 0,
+            // Invariant: after this block sum(widths) <= availableContentWidth, so
+            // every emitted row fits maxTableWidth and the commit-time second
+            // wrapToWidth pass (markdown-stream-format.ts) stays a no-op for tables
+            // (a row even 1 col over budget would re-split at its last space into a
+            // fragment + orphan '│' line and desync the compositor's row count).
+            //
+            // Allocation is floor-based water-filling, NOT uniform proportional
+            // shrink. Proportional shrink scaled every column by the same factor,
+            // so a high overflow ratio crushed narrow single-word columns (a
+            // "Verdict" of CONFIRMED/OVERSTATED) below their content width and
+            // truncateDisplayWidth chopped them to "Verd…". Instead: floor each
+            // column at min(natural, longestWord, WORD_FLOOR_CAP) — its
+            // incompressible width, capped so one long token (a path/URL) cannot
+            // starve the rest — then hand the leftover budget to columns in
+            // proportion to their reducible slack (natural - floor). All the
+            // squeeze lands on genuinely wide columns; narrow ones stay readable.
+            const WORD_FLOOR_CAP = 14;
+            const floors = widths.map((w, i) =>
+              Math.min(w, Math.max(1, Math.min(longestWord[i] ?? 1, WORD_FLOOR_CAP))),
             );
-            if (reducibleTotal > 0) {
-              const excess = totalContentWidth - availableContentWidth;
-              const ratio = Math.min(1, excess / reducibleTotal);
-              for (let i = 0; i < constrained.length; i++) {
-                const reducible = Math.max(0, constrained[i]! - minColWidth);
-                constrained[i] = Math.max(minColWidth, constrained[i]! - Math.round(reducible * ratio));
+            const floorTotal = floors.reduce((sum, w) => sum + w, 0);
+            const constrained = floors.slice();
+            if (floorTotal <= availableContentWidth) {
+              const slack = widths.map((w, i) => Math.max(0, w - (floors[i] ?? 0)));
+              const slackTotal = slack.reduce((sum, s) => sum + s, 0);
+              const leftover = availableContentWidth - floorTotal;
+              if (slackTotal > 0 && leftover > 0) {
+                for (let i = 0; i < colCount; i++) {
+                  constrained[i] = (floors[i] ?? 0) +
+                    Math.floor(((slack[i] ?? 0) / slackTotal) * leftover);
+                }
+                // Hand the Math.floor remainder to the widest-slack columns until
+                // the total reaches exactly availableContentWidth (never over it).
+                const order = constrained
+                  .map((_, i) => i)
+                  .sort((a, b) => (slack[b] ?? 0) - (slack[a] ?? 0));
+                let used = constrained.reduce((sum, w) => sum + w, 0);
+                let guard = 0;
+                while (used < availableContentWidth && order.length > 0 && guard < colCount * 4) {
+                  const i = order[guard % order.length]!;
+                  if ((constrained[i] ?? 0) < (widths[i] ?? 0)) {
+                    constrained[i] = (constrained[i] ?? 0) + 1;
+                    used += 1;
+                  }
+                  guard += 1;
+                }
               }
-              // Invariant: sum(constrained) must not exceed availableContentWidth.
-              // Per-column Math.round above can under-reduce (round-down error
-              // accumulates across columns), leaving rows 1+ col wider than
-              // maxWidth. Downstream, formatBlockForCommit re-wraps committed
-              // output at contentWidth with word-wrap: a row even 1 col over
-              // splits at its last space into a fragment + orphan '│' line,
-              // inflating the physical line count and corrupting the
-              // compositor's row accounting (clipped table tails + blank gaps
-              // in the REPL). Trim the widest reducible column until the total
-              // fits so rendered rows never exceed the budget.
+            } else {
+              // Degenerate: even the floors exceed the budget (too many columns
+              // for the width — chromeWidth alone can dominate). Shrink the floors
+              // proportionally to fit, preserving relative column sizes. The
+              // return-line cap below still guarantees no line exceeds the budget.
+              const scale = availableContentWidth / floorTotal;
+              for (let i = 0; i < colCount; i++) {
+                constrained[i] = Math.max(1, Math.floor((floors[i] ?? 0) * scale));
+              }
               let constrainedTotal = constrained.reduce((sum, w) => sum + w, 0);
               while (constrainedTotal > availableContentWidth) {
                 let widest = -1;
-                for (let i = 0; i < constrained.length; i++) {
-                  if (constrained[i]! > minColWidth &&
-                      (widest === -1 || constrained[i]! > constrained[widest]!)) {
+                for (let i = 0; i < colCount; i++) {
+                  if ((constrained[i] ?? 0) > 1 &&
+                      (widest === -1 || (constrained[i] ?? 0) > (constrained[widest] ?? 0))) {
                     widest = i;
                   }
                 }
-                if (widest === -1) break; // nothing left above minColWidth
-                constrained[widest] = constrained[widest]! - 1;
+                if (widest === -1) break;
+                constrained[widest] = (constrained[widest] ?? 0) - 1;
                 constrainedTotal -= 1;
               }
             }
-            for (let i = 0; i < constrained.length; i++) {
+            for (let i = 0; i < colCount; i++) {
               widths[i] = constrained[i] ?? widths[i] ?? 0;
             }
           }
@@ -424,7 +474,16 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
           }
 
           lines.push(borderLine('└', '┴', '┘'));
-          return lines.join('\n') + '\n';
+          // Safety net: hard-cap every emitted line to the budget. In the normal
+          // and degenerate squeeze paths the rows already fit, so this is a no-op;
+          // it only bites in pathological cases (e.g. chromeWidth alone exceeds
+          // targetWidth), guaranteeing the downstream wrapToWidth never re-splits
+          // a structural table row regardless of column math.
+          if (!Number.isFinite(targetWidth)) {
+            return lines.join('\n') + '\n';
+          }
+          const lineCap = Math.floor(targetWidth);
+          return lines.map((line) => truncateDisplayWidth(line, lineCap)).join('\n') + '\n';
         }
         default:
           return token.raw;


### PR DESCRIPTION
## What & why

Fixes broken markdown table rendering in the REPL: when a content-heavy table is wider than the terminal, the renderer truncated a narrow column's values to an ellipsis — e.g. a `Verdict` column of `CONFIRMED`/`OVERSTATED` rendered as `CONF…`/`OVER…` — while wide columns kept plenty of room.

### Root cause
`renderMarkdownToTerminal`'s `case 'table'` (`src/cli/formatter.ts`) shrank every column by the **same proportion** under overflow, with a floor of `minColWidth = 1`. A high overflow ratio therefore crushed narrow single-word columns below their own content width, and `truncateDisplayWidth` chopped each value to `…`. (Tall single-column cells — long `Source` citations — also wrapped into stray continuation lines.)

## The fix

**Floor-based water-filling** replaces the proportional squeeze:
- Per-column floor = `min(natural, longestWord, 14)` — the column's incompressible single-token width, capped so one long token (a path/URL) can't starve the rest.
- Leftover budget is distributed by **reducible slack** (`natural − floor`), so the squeeze lands on genuinely wide columns and narrow ones stay readable.
- A degenerate path (floors exceed the budget — too many columns for the width) shrinks floors proportionally, preserving relative sizes.

**Hard line-cap safety net**: every emitted table line is capped to the budget via `truncateDisplayWidth` at the renderer's return, making "no line exceeds `maxWidth`" a guaranteed invariant. This keeps the commit-time second `wrapToWidth` pass (`markdown-stream-format.ts:92`) a provable no-op for tables, closing the latent row-shredding class for many-column tables (chrome-overflow).

## Tests
- New regression test: a narrow single-word column renders its values in full under a tight `maxWidth` (no ellipsis), the table still fits, and the re-wrap stays a no-op.
- Updated the existing ratio test's doc comment to describe the new two-path allocation (it now exercises the degenerate path and still passes).

## Verification
- `pnpm lint` (tsc --noEmit strict): clean.
- `pnpm exec vitest run src/cli/formatter.test.ts`: 66/66 pass.
- Full suite: 10018 passed, 12 skipped, 1 failed — the single failure (`anthropic-direct.test.ts > compact()`, `claude-haiku-4-5` vs `claude-haiku-4-5-20251001`) is **pre-existing and unrelated**: it reproduces on clean `main` (verified by stashing this branch's changes) and this PR touches only `src/cli/formatter.ts` + `src/cli/formatter.test.ts`.

## Notes
- Behavior change is confined to the overflow path; tables that already fit the terminal are unchanged.
- The tall-cell continuation-line sprawl (long columns wrapping to many lines) is reduced as a side effect but is not the target of this PR.
