### PR TITLE
fix(cli): fill width budget in degenerate table squeeze

### DIFF
--- a/src/cli/formatter.test.ts
+++ b/src/cli/formatter.test.ts
@@ -133,6 +133,35 @@ describe('renderMarkdownToTerminal', () => {
     });
 
     /**
+     * Degenerate path fills the width budget (grow-back).
+     *
+     * When the floors exceed the content budget the allocator scales them down
+     * with Math.floor, discarding fractional units. Without a grow-back step the
+     * table renders narrower than maxWidth allows. One wide column plus several
+     * narrow ones at a tight maxWidth is the concrete case: pre-fix the rendered
+     * border was ~3 columns short of the budget (27 of 30); grow-back hands the
+     * reclaimed slack to the widest column so the table fills the budget exactly.
+     */
+    it('fills the width budget in the degenerate squeeze (grow-back)', () => {
+      const sample = [
+        '| Path | One | Two | Thr | Fou |',
+        '|------|-----|-----|-----|-----|',
+        '| src/cli/formatter.ts:340-the-allocator | abc | def | ghi | jkl |',
+        '',
+      ].join('\n');
+      const maxWidth = 30;
+      const out = stripAnsi(renderMarkdownToTerminal(sample, { maxWidth }));
+      const tableLines = out
+        .split('\n')
+        .filter((l) => /[┌┐└┘├┤┬┴┼│─]/.test(l));
+      const widest = Math.max(...tableLines.map((l) => stringWidth(l)));
+      // Fills (almost) the whole budget — pre-fix it under-allocated to ~27.
+      expect(widest).toBeGreaterThanOrEqual(maxWidth - 1);
+      // ...and never exceeds it.
+      expect(widest).toBeLessThanOrEqual(maxWidth);
+    });
+
+    /**
      * Narrow single-word column protection (the "Verd…" bug).
      *
      * A content-heavy table much wider than the terminal used to shrink EVERY

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -437,7 +437,7 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
               // is < colCount, so one pass over growOrder suffices.
               const growOrder = constrained
                 .map((_, i) => i)
-                .sort((a, b) => (widths[b] ?? 0) - (widths[a] ?? 0));
+                .sort((a, b) => (widths[b] ?? 0) - (widths[a] ?? 0) || a - b);
               let grow = 0;
               while (constrainedTotal < availableContentWidth && grow < colCount * 4) {
                 const i = growOrder[grow % growOrder.length]!;

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -427,6 +427,26 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
                 constrained[widest] = (constrained[widest] ?? 0) - 1;
                 constrainedTotal -= 1;
               }
+              // Grow back budget lost to flooring in the scale step: Math.floor
+              // discards fractional units, so the total can land BELOW
+              // availableContentWidth (e.g. natural widths [37,3,3,3,3] at
+              // maxWidth 30 use 11 of 14). Hand the reclaimed slack to the widest
+              // columns first (by natural width), capped at each column's natural
+              // width so none is padded past its content, until the budget is met.
+              // Keeps the table as wide as the budget allows. Bounded: the deficit
+              // is < colCount, so one pass over growOrder suffices.
+              const growOrder = constrained
+                .map((_, i) => i)
+                .sort((a, b) => (widths[b] ?? 0) - (widths[a] ?? 0));
+              let grow = 0;
+              while (constrainedTotal < availableContentWidth && grow < colCount * 4) {
+                const i = growOrder[grow % growOrder.length]!;
+                if ((constrained[i] ?? 0) < (widths[i] ?? 0)) {
+                  constrained[i] = (constrained[i] ?? 0) + 1;
+                  constrainedTotal += 1;
+                }
+                grow += 1;
+              }
             }
             for (let i = 0; i < colCount; i++) {
               widths[i] = constrained[i] ?? widths[i] ?? 0;


### PR DESCRIPTION
Follow-up to #269 (review-surfaced cosmetic nit).

## Problem
The table column allocator's **degenerate path** — where the per-column floors already exceed the content budget (`floorTotal > availableContentWidth`) — scales the floors down with `Math.floor(...)`, which discards fractional units. There is a trim-**down** loop for the over-budget case but no grow-**back** for the under-budget case, so the rendered table can land several columns narrower than `maxWidth` allows.

Concrete case: natural widths `[37, 3, 3, 3, 3]` at `maxWidth 30` → `chromeWidth 16`, `availableContentWidth 14`, floors `[14,3,3,3,3]` (degenerate), `scale ≈ 0.538` → constrained `[7,1,1,1,1]` = **11 of 14** used. The table border renders 27 wide instead of 30.

## Fix
Add a grow-back loop after the existing trim-down pass in the degenerate branch (`src/cli/formatter.ts`): hand the reclaimed slack to the widest columns first (by natural width), **capped at each column's natural width** so no column is padded past its content, until the budget is met.

- Bounded: the post-floor deficit is `< colCount`, so one pass over the order suffices (`grow < colCount * 4` guard, consistent with the normal-path remainder loop).
- Never exceeds `availableContentWidth` (the `while` condition caps it) and never pads beyond natural content width.
- `growOrder` uses a secondary sort key (column index) so tie-breaks on equal-natural-width columns are deterministic across JS engines.

## Verification
- `tsc --noEmit` (strict lint gate): clean.
- `vitest run src/cli/formatter.test.ts`: 67/67 pass.
- New regression test `fills the width budget in the degenerate squeeze (grow-back)` is a **genuine guard** — with the grow-back loop commented out it fails (`widest = 27`), and passes with it (`= 30`).

## Out of scope
The separate `// Invariant:` doc-comment overclaim flagged in the #269 review (the comment says `sum(widths) <= availableContentWidth` always, which is technically untrue when `availableContentWidth < colCount` — the return-time line cap is the real backstop there) is **not** addressed here; it is a doc-only nit on a different sub-path and warrants its own small change if desired.