### PR TITLE
style(cli): thin ▏ caret + cornflower-blue palette.caret accent

### DIFF
--- a/src/cli/_lib/capture-mode.ts
+++ b/src/cli/_lib/capture-mode.ts
@@ -79,6 +79,24 @@ export function detectReducedMotion(env: NodeJS.ProcessEnv = process.env): boole
 }
 
 /**
+ * Decide whether the input caret should blink (pulse on/off like a terminal
+ * cursor).
+ *
+ * ON by default; `AFK_CARET_BLINK=0` opts OUT (steady caret). Only the literal
+ * string "0" disables — any other value (or unset) leaves blinking on. Distinct
+ * in intent from reduced-motion: a motion-sensitive user sets
+ * `AFK_REDUCED_MOTION=1`, which the interactive caller ANDs in to force the
+ * caret solid regardless of this flag. Kept here beside detectReducedMotion /
+ * detectBell because it is the same class of CLI motion / UX preference, read
+ * via the same `env`-parameter pattern.
+ *
+ * Reads `process.env` at call time. Pure function with no side effects.
+ */
+export function detectCaretBlink(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env['AFK_CARET_BLINK'] !== '0';
+}
+
+/**
  * Ring the terminal bell (audible BEL, \x07) if the bell is enabled
  * and the stream is a TTY. Non-printing; does not disturb the overlay.
  *

--- a/src/cli/input/caret-blink.test.ts
+++ b/src/cli/input/caret-blink.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for CaretBlinkController — the input caret's blink phase + timer.
+ *
+ * Fake timers throughout: the controller's only observable effects are the
+ * `visible` phase flips and the `onTick` repaint requests it emits on each
+ * interval boundary.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { CaretBlinkController, DEFAULT_CARET_BLINK_INTERVAL_MS } from './caret-blink.js';
+
+interface MakeOpts {
+  enabled?: boolean;
+  captureMode?: boolean;
+  intervalMs?: number;
+}
+
+function make(opts: MakeOpts = {}): { c: CaretBlinkController; onTick: ReturnType<typeof vi.fn> } {
+  const onTick = vi.fn();
+  const c = new CaretBlinkController({
+    enabled: opts.enabled ?? true,
+    captureMode: opts.captureMode ?? false,
+    intervalMs: opts.intervalMs ?? 100,
+    onTick,
+  });
+  return { c, onTick };
+}
+
+describe('CaretBlinkController', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('exports a positive default interval', () => {
+    expect(DEFAULT_CARET_BLINK_INTERVAL_MS).toBeGreaterThan(0);
+  });
+
+  it('is visible before start (solid caret until armed)', () => {
+    const { c } = make();
+    expect(c.visible).toBe(true);
+  });
+
+  it('toggles the visible phase and ticks once per interval after start', () => {
+    const { c, onTick } = make({ intervalMs: 100 });
+    c.start();
+    expect(c.visible).toBe(true);
+
+    vi.advanceTimersByTime(100);
+    expect(c.visible).toBe(false);
+    expect(onTick).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(100);
+    expect(c.visible).toBe(true);
+    expect(onTick).toHaveBeenCalledTimes(2);
+  });
+
+  it('disabled: stays visible, starts no timer, never ticks', () => {
+    const { c, onTick } = make({ enabled: false });
+    c.start();
+    vi.advanceTimersByTime(1000);
+    expect(c.visible).toBe(true);
+    expect(onTick).not.toHaveBeenCalled();
+  });
+
+  it('capture mode: stays visible, starts no timer, never ticks', () => {
+    const { c, onTick } = make({ captureMode: true });
+    c.start();
+    vi.advanceTimersByTime(1000);
+    expect(c.visible).toBe(true);
+    expect(onTick).not.toHaveBeenCalled();
+  });
+
+  it('start is idempotent — a second call does not spawn a second timer', () => {
+    const { c, onTick } = make({ intervalMs: 100 });
+    c.start();
+    c.start();
+    vi.advanceTimersByTime(100);
+    // A doubled timer would tick twice per interval.
+    expect(onTick).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop clears the timer and resets to the solid phase', () => {
+    const { c, onTick } = make({ intervalMs: 100 });
+    c.start();
+    vi.advanceTimersByTime(100);
+    expect(c.visible).toBe(false);
+
+    c.stop();
+    expect(c.visible).toBe(true);
+
+    onTick.mockClear();
+    vi.advanceTimersByTime(500);
+    expect(onTick).not.toHaveBeenCalled();
+  });
+
+  it('stop is idempotent', () => {
+    const { c } = make();
+    c.start();
+    c.stop();
+    expect(() => c.stop()).not.toThrow();
+    expect(c.visible).toBe(true);
+  });
+
+  it('resetVisible snaps an off-phase caret back to solid and repaints once', () => {
+    const { c, onTick } = make({ intervalMs: 100 });
+    c.start();
+    vi.advanceTimersByTime(100); // → off phase
+    expect(c.visible).toBe(false);
+
+    onTick.mockClear();
+    c.resetVisible();
+    expect(c.visible).toBe(true);
+    expect(onTick).toHaveBeenCalledTimes(1); // un-hid → exactly one repaint
+  });
+
+  it('resetVisible while already visible does not request a repaint', () => {
+    const { c, onTick } = make({ intervalMs: 100 });
+    c.start();
+    onTick.mockClear();
+    c.resetVisible();
+    expect(c.visible).toBe(true);
+    expect(onTick).not.toHaveBeenCalled();
+  });
+
+  it('resetVisible restarts the dwell window so the caret stays solid while typing', () => {
+    const { c, onTick } = make({ intervalMs: 100 });
+    c.start();
+    vi.advanceTimersByTime(80); // still in the first visible window
+    expect(c.visible).toBe(true);
+
+    c.resetVisible(); // restart the 100ms window from here
+    onTick.mockClear();
+
+    vi.advanceTimersByTime(80); // 80ms since reset < 100 → still solid
+    expect(c.visible).toBe(true);
+    expect(onTick).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(20); // 100ms since reset → first flip
+    expect(c.visible).toBe(false);
+    expect(onTick).toHaveBeenCalledTimes(1);
+  });
+
+  it('resetVisible before start is a no-op', () => {
+    const { c, onTick } = make({ intervalMs: 100 });
+    c.resetVisible();
+    expect(c.visible).toBe(true);
+    expect(onTick).not.toHaveBeenCalled();
+  });
+
+  it('resetVisible is a no-op when disabled', () => {
+    const { c, onTick } = make({ enabled: false });
+    c.start();
+    c.resetVisible();
+    expect(c.visible).toBe(true);
+    expect(onTick).not.toHaveBeenCalled();
+  });
+
+  it('can be restarted after stop', () => {
+    const { c, onTick } = make({ intervalMs: 100 });
+    c.start();
+    c.stop();
+    onTick.mockClear();
+    c.start();
+    vi.advanceTimersByTime(100);
+    expect(c.visible).toBe(false);
+    expect(onTick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli/input/caret-blink.test.ts
+++ b/src/cli/input/caret-blink.test.ts
@@ -103,23 +103,25 @@ describe('CaretBlinkController', () => {
     expect(c.visible).toBe(true);
   });
 
-  it('resetVisible snaps an off-phase caret back to solid and repaints once', () => {
+  it('resetVisible snaps an off-phase caret back to solid and returns true (no self-repaint)', () => {
     const { c, onTick } = make({ intervalMs: 100 });
     c.start();
     vi.advanceTimersByTime(100); // → off phase
     expect(c.visible).toBe(false);
 
     onTick.mockClear();
-    c.resetVisible();
+    // Pure state mutation: reports the un-hide via its return value and does NOT
+    // repaint — the caller coalesces the repaint with the keystroke's own frame.
+    expect(c.resetVisible()).toBe(true);
     expect(c.visible).toBe(true);
-    expect(onTick).toHaveBeenCalledTimes(1); // un-hid → exactly one repaint
+    expect(onTick).not.toHaveBeenCalled();
   });
 
-  it('resetVisible while already visible does not request a repaint', () => {
+  it('resetVisible while already visible returns false and does not repaint', () => {
     const { c, onTick } = make({ intervalMs: 100 });
     c.start();
     onTick.mockClear();
-    c.resetVisible();
+    expect(c.resetVisible()).toBe(false);
     expect(c.visible).toBe(true);
     expect(onTick).not.toHaveBeenCalled();
   });
@@ -142,17 +144,17 @@ describe('CaretBlinkController', () => {
     expect(onTick).toHaveBeenCalledTimes(1);
   });
 
-  it('resetVisible before start is a no-op', () => {
+  it('resetVisible before start is a no-op and returns false', () => {
     const { c, onTick } = make({ intervalMs: 100 });
-    c.resetVisible();
+    expect(c.resetVisible()).toBe(false);
     expect(c.visible).toBe(true);
     expect(onTick).not.toHaveBeenCalled();
   });
 
-  it('resetVisible is a no-op when disabled', () => {
+  it('resetVisible is a no-op and returns false when disabled', () => {
     const { c, onTick } = make({ enabled: false });
     c.start();
-    c.resetVisible();
+    expect(c.resetVisible()).toBe(false);
     expect(c.visible).toBe(true);
     expect(onTick).not.toHaveBeenCalled();
   });

--- a/src/cli/input/caret-blink.ts
+++ b/src/cli/input/caret-blink.ts
@@ -36,8 +36,10 @@ export interface CaretBlinkControllerOptions {
   /** Blink half-period in ms — the dwell time in each (on / off) phase. */
   intervalMs: number;
   /**
-   * Invoked whenever the visible phase flips (and when {@link resetVisible}
-   * un-hides an off-phase caret). The controller's sole render path.
+   * Invoked whenever the blink TIMER flips the visible phase — the controller's
+   * sole render path. {@link resetVisible} does NOT call this; it reports its
+   * un-hide via a return value so the caller can coalesce the repaint with the
+   * keystroke's own frame instead of writing the frame twice.
    */
   onTick: () => void;
 }
@@ -84,16 +86,23 @@ export class CaretBlinkController {
    * Snap the caret back to solid and restart the dwell window — called on every
    * non-paste keystroke so the caret stays steady while typing and blinks only
    * when idle (terminal cursor behavior). No-op when disabled / capture / not
-   * running. Requests a repaint only if it un-hid an off-phase caret; the
-   * keystroke's own edit repaint covers the common (already-visible) case.
+   * running.
+   *
+   * Pure state mutation: this does NOT repaint. It RETURNS whether the call
+   * un-hid an off-phase caret — i.e. whether a frame is needed to show the
+   * now-solid caret. The caller (arm()'s keypress handler) coalesces that with
+   * the keystroke's own edit repaint: a keystroke that repaints anyway (the
+   * common case) shows the solid caret for free in that frame, so only a
+   * non-painting keystroke pays for an extra repaint. Returns false when the
+   * caret was already visible / disabled / capture / not running.
    */
-  resetVisible(): void {
-    if (!this.enabled || this.captureMode || !this.interval) return;
+  resetVisible(): boolean {
+    if (!this.enabled || this.captureMode || !this.interval) return false;
     const wasHidden = !this.visiblePhase;
     this.visiblePhase = true;
     clearInterval(this.interval);
     this.schedule();
-    if (wasHidden) this.onTick();
+    return wasHidden;
   }
 
   /**

--- a/src/cli/input/caret-blink.ts
+++ b/src/cli/input/caret-blink.ts
@@ -1,0 +1,121 @@
+/**
+ * Caret-blink controller — owns the input caret's on/off blink phase and its
+ * interval timer, extracted from TerminalCompositor in the same controller
+ * style as {@link SpinnerController} (input/spinner.ts).
+ *
+ * **Why a software blink exists at all.** AFK paints its OWN caret glyph (a ▏
+ * thin bar at end-of-buffer, or an inverse-video block mid-buffer) inside the
+ * log-update frame, and the frame renderer hides the hardware terminal cursor
+ * for the entire armed cycle (cup-frame-renderer.ts emits `\x1b[?25l`). The
+ * terminal's native cursor blink therefore never shows. To pulse the caret
+ * like a terminal cursor we toggle the painted glyph on a timer instead.
+ *
+ * Invariant: the controller never writes to the terminal. It flips its own
+ * `visiblePhase` and calls `onTick` to REQUEST a repaint; the compositor owns
+ * the frame and reads {@link visible} when it paints the input line. This
+ * preserves the single-frame ownership the renderer relies on (the same
+ * contract SpinnerController follows to avoid the ora-vs-log-update race).
+ */
+
+export interface CaretBlinkControllerOptions {
+  /**
+   * Master enable. When false the caret is permanently solid and no timer is
+   * ever created — the disabled path for `AFK_CARET_BLINK=0`, reduced-motion
+   * users, and every non-interactive / test construction that doesn't opt in.
+   * Callers that own an interactive surface resolve
+   * `detectCaretBlink() && !detectReducedMotion()` and pass the result.
+   */
+  enabled: boolean;
+  /**
+   * Capture-mode flag (script(1) / asciinema / AFK_DEMO_CLEAN). When true the
+   * ticker never starts — each phase flip would append a frame to the recorded
+   * byte stream (same rationale as SpinnerController). The caret then stays
+   * solid (visible) so recordings show a stable cursor.
+   */
+  captureMode: boolean;
+  /** Blink half-period in ms — the dwell time in each (on / off) phase. */
+  intervalMs: number;
+  /**
+   * Invoked whenever the visible phase flips (and when {@link resetVisible}
+   * un-hides an off-phase caret). The controller's sole render path.
+   */
+  onTick: () => void;
+}
+
+/** Default blink half-period — the classic VT/xterm cursor-blink cadence. */
+export const DEFAULT_CARET_BLINK_INTERVAL_MS = 530;
+
+export class CaretBlinkController {
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private visiblePhase = true;
+  private readonly enabled: boolean;
+  private readonly captureMode: boolean;
+  private readonly intervalMs: number;
+  private readonly onTick: () => void;
+
+  constructor(opts: CaretBlinkControllerOptions) {
+    this.enabled = opts.enabled;
+    this.captureMode = opts.captureMode;
+    this.intervalMs = opts.intervalMs;
+    this.onTick = opts.onTick;
+  }
+
+  /**
+   * Whether the caret glyph should be painted this frame. Always true when
+   * blinking is disabled or suppressed (capture-mode keeps the ticker from
+   * ever starting, so `visiblePhase` stays true) — the renderer then paints a
+   * solid caret unconditionally.
+   */
+  get visible(): boolean {
+    return this.enabled ? this.visiblePhase : true;
+  }
+
+  /**
+   * Start the blink ticker. Idempotent; no-op when disabled or in capture mode
+   * (the caret then stays solid). Called from arm() / resumeInput().
+   */
+  start(): void {
+    if (!this.enabled || this.captureMode || this.interval) return;
+    this.visiblePhase = true;
+    this.schedule();
+  }
+
+  /**
+   * Snap the caret back to solid and restart the dwell window — called on every
+   * non-paste keystroke so the caret stays steady while typing and blinks only
+   * when idle (terminal cursor behavior). No-op when disabled / capture / not
+   * running. Requests a repaint only if it un-hid an off-phase caret; the
+   * keystroke's own edit repaint covers the common (already-visible) case.
+   */
+  resetVisible(): void {
+    if (!this.enabled || this.captureMode || !this.interval) return;
+    const wasHidden = !this.visiblePhase;
+    this.visiblePhase = true;
+    clearInterval(this.interval);
+    this.schedule();
+    if (wasHidden) this.onTick();
+  }
+
+  /**
+   * Stop the ticker and reset to the solid phase. Idempotent. Called from
+   * disarm() / suspendInput() so no blink timer outlives the armed cycle.
+   */
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    this.visiblePhase = true;
+  }
+
+  private schedule(): void {
+    const handle = setInterval(() => {
+      this.visiblePhase = !this.visiblePhase;
+      this.onTick();
+    }, this.intervalMs);
+    // Don't let the blink timer keep the event loop alive at process exit;
+    // disarm() clears it on the normal path, this covers abrupt teardown.
+    handle.unref?.();
+    this.interval = handle;
+  }
+}

--- a/src/cli/input/input-surface.ts
+++ b/src/cli/input/input-surface.ts
@@ -49,6 +49,7 @@ import {
   type SuggestContext,
 } from '../terminal-compositor.js';
 import { colorizeInputBuffer, type SlashRegistryView } from '../input-highlight.js';
+import { detectCaptureMode, detectCaretBlink, detectReducedMotion } from '../_lib/capture-mode.js';
 import { list as listSlashCommands } from '../slash/registry.js';
 import { formatSubmittedEcho } from './echo.js';
 import { describeAttachmentSummary } from './attachments.js';
@@ -303,6 +304,12 @@ export class InputSurface {
       history: this.history,
       autocompleteState: this.autocompleteState,
       formatInputBuffer: (segment) => colorizeInputBuffer(segment, this.slashRegistryView),
+      // Blinking caret (pulse on/off like a terminal cursor). Enabled by
+      // default; AFK_CARET_BLINK=0 or AFK_REDUCED_MOTION=1 opt out. captureMode
+      // (script(1)/asciinema/AFK_DEMO_CLEAN) suppresses the ticker inside the
+      // compositor so recordings show a steady caret.
+      caretBlink: detectCaretBlink() && !detectReducedMotion(),
+      captureMode: detectCaptureMode(),
       ...(opts.scrollRegion ? { scrollRegion: opts.scrollRegion } : {}),
       ...(opts.anchorRow !== undefined ? { anchorRow: opts.anchorRow } : {}),
       ...(opts.suggest ? { suggest: opts.suggest } : {}),

--- a/src/cli/palette.ts
+++ b/src/cli/palette.ts
@@ -31,6 +31,8 @@ export const palette = {
   goblin: chalk.hex('#9CB04A'),
   /** User cyan — for user prompt text and their "you said" markers. Reserved for user identity only. */
   user: chalk.cyan,
+  /** Caret — thin vertical-bar cursor rendered in the input field. Distinct from `user` (cyan) so the cursor style can evolve independently of user-identity chrome. Soft cornflower blue pairs cleanly with JetBrains Mono dark themes and contrasts the warm brand orange without competing with info sky-blue or fileRef teal. */
+  caret: chalk.hex('#7AA2F7'),
   /** Tool name — steel blue, used as the syntax-theme color for functions / classes / titles in fenced code blocks. Originally also drove `● ToolName` bullet chrome; that role moved to `chrome` so syntax and chrome can evolve independently. */
   tool: chalk.hex('#DCDCAA'),
   /** Bullet chrome — slate grey, used for the `● ToolName` glyph + name itself when no per-tool category color overrides it. Recedes visually so the category-colored variants carry the salience. */

--- a/src/cli/render/text-input.ts
+++ b/src/cli/render/text-input.ts
@@ -261,9 +261,10 @@ function renderInputRow(state: InputCoreState): string {
   // the full nextGraphemeIndex dance the compositor uses for the
   // persistent input. If a grapheme-split edge case surfaces in practice
   // we can swap in the grapheme-aware variant.
-  const cursorChar = cursor < buffer.length ? buffer.charAt(cursor) : ' ';
+  const atEnd = cursor >= buffer.length;
+  const cursorChar = atEnd ? '▏' : buffer.charAt(cursor);
   const after = cursor < buffer.length ? buffer.slice(cursor + 1) : '';
-  const caret = palette.user.inverse(cursorChar);
+  const caret = atEnd ? palette.caret(cursorChar) : palette.caret.inverse(cursorChar);
   return `  ${palette.dim(PROMPT_GLYPH)} ${before}${caret}${after}`;
 }
 

--- a/src/cli/terminal-compositor.lifecycle.ts
+++ b/src/cli/terminal-compositor.lifecycle.ts
@@ -34,6 +34,14 @@ export interface LifecycleHost {
   repaint(): void;
   resetState(): void;
 
+  /**
+   * Monotonic frame counter — bumped once per {@link repaint}. Read by arm()'s
+   * keypress handler to detect whether dispatchKey already painted a frame this
+   * keystroke, so the caret-blink un-hide repaint fires only when nothing else
+   * did (avoids a double frame on an off-phase keystroke).
+   */
+  readonly repaintCount: number;
+
   readonly stdout: NodeJS.WriteStream;
   readonly stdin: NodeJS.ReadStream;
 
@@ -189,9 +197,20 @@ export async function arm(self: LifecycleHost & KeyDispatchHost): Promise<void> 
   // is set by handlePasteMarkers on the `\x1b[200~` open marker) — a 10K-char
   // paste would otherwise churn the interval per character with no visible
   // benefit, and applyEdit already suppresses per-char repaints during a burst.
+  //
+  // Repaint coalescing: resetVisible() only mutates phase state and REPORTS
+  // whether it un-hid an off-phase caret — it does not paint. Almost every key
+  // dispatchKey handles repaints anyway (applyEdit, nav, dropdown…), and that
+  // frame already reflects the now-solid caret; firing resetVisible's own
+  // repaint too would write the frame twice. So snapshot repaintCount, run
+  // dispatchKey, and repaint here ONLY when the caret was un-hidden AND
+  // dispatchKey painted nothing (e.g. an unbound key) — otherwise the un-hide
+  // rides the edit's frame for free.
   self.handleKeypress = (char, key) => {
-    if (!self.pasting) self.caretBlinkController.resetVisible();
+    const caretUnhidden = self.pasting ? false : self.caretBlinkController.resetVisible();
+    const repaintsBefore = self.repaintCount;
     InputDispatch.dispatchKey(self, char, key);
+    if (caretUnhidden && self.repaintCount === repaintsBefore) self.repaint();
   };
   self.stdin.on('keypress', self.handleKeypress);
 

--- a/src/cli/terminal-compositor.lifecycle.ts
+++ b/src/cli/terminal-compositor.lifecycle.ts
@@ -12,6 +12,7 @@ import { emitKeypressEventsImmediateEscape } from './input/emit-keypress.js';
 import { acquireStdinClaim, type StdinClaimHandle } from './input/stdin-claim.js';
 import { ResizeBus } from './terminal-size.js';
 import type { SpinnerController } from './input/spinner.js';
+import type { CaretBlinkController } from './input/caret-blink.js';
 import type { SuggestEngine } from './terminal-compositor.types.js';
 import type {
   CompositorScrollRegionGuard,
@@ -52,6 +53,7 @@ export interface LifecycleHost {
   canceled: boolean;
 
   readonly spinnerController: SpinnerController;
+  readonly caretBlinkController: CaretBlinkController;
   readonly ghostEngine: SuggestEngine | undefined;
 
   // Resize ghost-erase state + committed-band rows: read by arm()'s immediate
@@ -86,6 +88,9 @@ export function suspendInput(self: LifecycleHost): void {
     self.stdin.removeListener('keypress', self.handleKeypress);
   }
   try { self.stdin.setRawMode(false); } catch { /* noop */ }
+  // Pause the blink while an external readline (e.g. elicitation) owns the TTY
+  // — its own cursor takes over; resumeInput() restarts the ticker.
+  self.caretBlinkController.stop();
   self.suspended = true;
 }
 
@@ -101,6 +106,8 @@ export function resumeInput(self: LifecycleHost): void {
   }
   self.suspended = false;
   self.repaint();
+  // Resume blinking now that we hold the TTY again. No-op when disabled.
+  self.caretBlinkController.start();
 }
 
 // Contract: arm() installs a keypress listener that calls InputDispatch.dispatchKey(self, ...).
@@ -175,7 +182,17 @@ export async function arm(self: LifecycleHost & KeyDispatchHost): Promise<void> 
   // surfaced in LifecycleHost. The keypress listener calls InputDispatch.dispatchKey
   // directly (with `self` as the KeyDispatchHost) so no relaxation of
   // dispatchKey is needed and no circular dependency is introduced.
-  self.handleKeypress = (char, key) => InputDispatch.dispatchKey(self, char, key);
+  //
+  // Caret-blink reset: a deliberate keystroke snaps the caret back to solid and
+  // restarts the blink dwell window, mirroring terminal cursor behavior (steady
+  // while typing, blinks only when idle). Skipped mid-paste-burst (`self.pasting`
+  // is set by handlePasteMarkers on the `\x1b[200~` open marker) — a 10K-char
+  // paste would otherwise churn the interval per character with no visible
+  // benefit, and applyEdit already suppresses per-char repaints during a burst.
+  self.handleKeypress = (char, key) => {
+    if (!self.pasting) self.caretBlinkController.resetVisible();
+    InputDispatch.dispatchKey(self, char, key);
+  };
   self.stdin.on('keypress', self.handleKeypress);
 
   // Invariant (arm ordering): set `armed = true` BEFORE registering the
@@ -277,10 +294,17 @@ export async function arm(self: LifecycleHost & KeyDispatchHost): Promise<void> 
   // refresh the state via `applyEdit()` → `updateAutocomplete()`.
 
   self.repaint();
+
+  // Start the caret-blink ticker AFTER the first frame is painted so the
+  // initial caret is solid. No-op when blinking is disabled or in capture mode.
+  self.caretBlinkController.start();
 }
 
 export function disarm(self: LifecycleHost): void {
   self.spinnerController.dispose();
+  // Stop the caret-blink ticker so no timer outlives the armed cycle (and no
+  // stray tick fires repaint() against a disarmed compositor).
+  self.caretBlinkController.stop();
 
   if (!self.armed) {
     // Still safe to clear state — no-op for listener/raw-mode.

--- a/src/cli/terminal-compositor.render.test.ts
+++ b/src/cli/terminal-compositor.render.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { renderDropdownRows } from './terminal-compositor.render.js';
+import { renderDropdownRows, renderInputLine } from './terminal-compositor.render.js';
 import type { RenderHost } from './terminal-compositor.render.js';
 import { displayWidth, stripAnsi } from './display.js';
 import type { AutocompleteState } from './input/autocomplete-state.js';
@@ -89,5 +89,70 @@ describe('renderDropdownRows — wide-char soft-wrap counting', () => {
     expect(nonBlanks).toHaveLength(1);
     expect(blanks).toHaveLength(0);
     expect(nonBlanks.every((r) => stripAnsi(r).includes('/test-cmd'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderInputLine — caret blink phase (▏ thin-bar pulse)
+// ---------------------------------------------------------------------------
+
+const THIN_BAR = '\u258f'; // ▏ LEFT ONE EIGHTH BLOCK
+
+function makeInputHost(opts: {
+  buffer: string;
+  cursor: number;
+  caretVisible?: boolean;
+}): RenderHost {
+  return {
+    queued: false,
+    pendingSubmissions: [],
+    input: { buffer: opts.buffer, cursor: opts.cursor },
+    ...(opts.caretVisible !== undefined ? { caretVisible: opts.caretVisible } : {}),
+    activeGhost: null,
+    promptTextFn: () => '> ',
+    stdout: { columns: 80 } as NodeJS.WriteStream,
+  };
+}
+
+describe('renderInputLine — caret blink', () => {
+  it('paints the ▏ thin-bar caret in the visible phase (end-of-buffer)', () => {
+    const line = renderInputLine(makeInputHost({ buffer: '', cursor: 0, caretVisible: true }));
+    expect(line).toContain(THIN_BAR);
+  });
+
+  it('blanks the caret in the off phase, preserving the one-cell width (end-of-buffer)', () => {
+    const on = renderInputLine(makeInputHost({ buffer: '', cursor: 0, caretVisible: true }));
+    const off = renderInputLine(makeInputHost({ buffer: '', cursor: 0, caretVisible: false }));
+    // Off-phase drops the thin bar entirely…
+    expect(off).not.toContain(THIN_BAR);
+    // …and replaces it with a single blank cell — same display width as the
+    // visible phase so the line never shifts as the caret pulses.
+    expect(displayWidth(stripAnsi(off))).toBe(displayWidth(stripAnsi(on)));
+    expect(stripAnsi(off)).toBe('>  '); // prompt '> ' + one blank caret cell
+  });
+
+  it('defaults to a solid caret when caretVisible is absent (non-blinking host)', () => {
+    const line = renderInputLine(makeInputHost({ buffer: '', cursor: 0 }));
+    expect(line).toContain(THIN_BAR);
+  });
+
+  it('off-phase mid-buffer reveals the underlying char un-inverted (block-cursor off)', async () => {
+    // Cursor sits on the 'b' of 'abc'. The visible phase inverse-videos that
+    // cell (SGR `\x1b[7m`); the off phase shows the bare character. Force chalk
+    // colour so the inverse SGR is observable.
+    const chalkModule = await import('chalk');
+    const priorLevel = chalkModule.default.level;
+    chalkModule.default.level = 1;
+    try {
+      const on = renderInputLine(makeInputHost({ buffer: 'abc', cursor: 1, caretVisible: true }));
+      const off = renderInputLine(makeInputHost({ buffer: 'abc', cursor: 1, caretVisible: false }));
+      expect(on).toContain('\x1b[7m'); // inverse-video open in the visible phase
+      expect(off).not.toContain('\x1b[7m'); // off phase is un-inverted
+      // Same single-cell width in both phases (no inverse ≠ width change).
+      expect(displayWidth(stripAnsi(on))).toBe(displayWidth(stripAnsi(off)));
+      expect(stripAnsi(off)).toContain('abc');
+    } finally {
+      chalkModule.default.level = priorLevel;
+    }
   });
 });

--- a/src/cli/terminal-compositor.render.ts
+++ b/src/cli/terminal-compositor.render.ts
@@ -54,27 +54,31 @@ export function renderInputLine(self: RenderHost): string {
       : '';
   const rawBefore = self.input.buffer.slice(0, self.input.cursor);
   const cursorEnd = nextGraphemeIndex(self.input.buffer, self.input.cursor);
-  const cursorText =
-    self.input.cursor < self.input.buffer.length
-      ? self.input.buffer.slice(self.input.cursor, cursorEnd)
-      : ' ';
+  const atEnd = self.input.cursor >= self.input.buffer.length;
+  // At end-of-buffer show a thin ▏ bar (U+258F, LEFT ONE EIGHTH BLOCK) so
+  // the idle cursor reads as a modern line caret rather than a filled block.
+  // Mid-buffer the character under the cursor is kept and inverse-video is
+  // applied so the active position stays legible during editing.
+  const cursorText = atEnd
+    ? '▏'
+    : self.input.buffer.slice(self.input.cursor, cursorEnd);
   const rawAfter =
     self.input.cursor < self.input.buffer.length
       ? self.input.buffer.slice(cursorEnd)
       : '';
   // Apply the caller-supplied formatter (typically `colorizeInputBuffer`
   // closed over the slash registry) to each segment independently. The
-  // inverse-video cursor block is rendered RAW so it stays a single visual
+  // caret character is rendered RAW so it stays a single visual
   // cell — passing it through a colorizer would compose ANSI codes on top
-  // of the inverse SGR and complicate grapheme-width math.
+  // of the caret SGR and complicate grapheme-width math.
   const before = self.formatInputBuffer?.(rawBefore) ?? rawBefore;
   const after = self.formatInputBuffer?.(rawAfter) ?? rawAfter;
   // Caret is always painted. `repaint()` already gates on `armed`, so this
   // code only runs while we hold raw mode; there is no path where rendering
-  // the inverse block "leaks" a phantom cursor after disarm — every async
-  // repaint source (keypress, resize, spinner) is unsubscribed before
+  // the caret "leaks" a phantom cursor after disarm — every async repaint
+  // source (keypress, resize, spinner) is unsubscribed before
   // `logUpdate.done()` in `disarm()`.
-  const caret = palette.user.inverse(cursorText);
+  const caret = atEnd ? palette.caret(cursorText) : palette.caret.inverse(cursorText);
   // Ghost text: render a dim inline completion AFTER the caret, only when:
   //   1. cursor is at end-of-buffer (no rawAfter)
   //   2. there is an active ghost that strictly extends the current buffer

--- a/src/cli/terminal-compositor.render.ts
+++ b/src/cli/terminal-compositor.render.ts
@@ -29,6 +29,12 @@ export interface RenderHost {
   /** Pending submission FIFO — its length drives the `[N queued]` suffix. */
   readonly pendingSubmissions: readonly SubmissionPayload[];
   readonly input: InputCoreState;
+  /**
+   * Caret blink phase: `false` paints a blanked caret (the off-phase of a
+   * pulsing terminal cursor). Absent on minimal mock hosts ⇒ treated as
+   * visible, so a host that doesn't model blinking renders a solid caret.
+   */
+  readonly caretVisible?: boolean;
   readonly activeGhost: string | null;
   readonly autocompleteState?: AutocompleteState;
   readonly formatInputBuffer?: (segment: string) => string;
@@ -73,12 +79,26 @@ export function renderInputLine(self: RenderHost): string {
   // of the caret SGR and complicate grapheme-width math.
   const before = self.formatInputBuffer?.(rawBefore) ?? rawBefore;
   const after = self.formatInputBuffer?.(rawAfter) ?? rawAfter;
-  // Caret is always painted. `repaint()` already gates on `armed`, so this
-  // code only runs while we hold raw mode; there is no path where rendering
-  // the caret "leaks" a phantom cursor after disarm — every async repaint
-  // source (keypress, resize, spinner) is unsubscribed before
-  // `logUpdate.done()` in `disarm()`.
-  const caret = atEnd ? palette.caret(cursorText) : palette.caret.inverse(cursorText);
+  // Caret is always painted (in its visible phase). `repaint()` already gates
+  // on `armed`, so this code only runs while we hold raw mode; there is no path
+  // where rendering the caret "leaks" a phantom cursor after disarm — every
+  // async repaint source (keypress, resize, spinner, caret-blink) is
+  // unsubscribed/stopped before `logUpdate.done()` in `disarm()`.
+  //
+  // Blink: in the OFF phase paint a blank cell (end-of-buffer) or the
+  // un-inverted char under the cursor (mid-buffer) so the caret pulses on/off
+  // like a terminal cursor. BOTH phases occupy the SAME single cell, so the
+  // ghost-suffix budget below (which reserves +1 for the caret cell) is
+  // unaffected by the phase. `caretVisible` absent (minimal mock host) ⇒ solid.
+  const caretShown = self.caretVisible !== false;
+  let caret: string;
+  if (caretShown) {
+    caret = atEnd ? palette.caret(cursorText) : palette.caret.inverse(cursorText);
+  } else if (atEnd) {
+    caret = ' ';
+  } else {
+    caret = self.formatInputBuffer?.(cursorText) ?? cursorText;
+  }
   // Ghost text: render a dim inline completion AFTER the caret, only when:
   //   1. cursor is at end-of-buffer (no rawAfter)
   //   2. there is an active ghost that strictly extends the current buffer

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -3233,6 +3233,71 @@ describe('TerminalCompositor — caret always rendered while armed', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Caret blink wiring: arm() starts the ticker, each interval toggles the
+// painted caret, a keystroke snaps it back to solid, and disarm() stops it.
+// ---------------------------------------------------------------------------
+
+describe('TerminalCompositor — caret blink', () => {
+  let stdout: MockStdout;
+  let stdin: MockStdin;
+  let writes: ReturnType<typeof collectWrites>;
+
+  beforeEach(() => {
+    stdout = makeMockStdout();
+    stdin = makeMockStdin();
+    writes = collectWrites(stdout);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('pulses the ▏ caret on/off on the interval and resets to solid on a keystroke', async () => {
+    vi.useFakeTimers();
+    const c = new TerminalCompositor({
+      stdout,
+      stdin,
+      onCancel: vi.fn(),
+      caretBlink: true,
+      caretBlinkIntervalMs: 50,
+    });
+    await c.arm();
+    // First frame (armed) shows the solid caret.
+    expect(writes.all()).toContain('▏');
+
+    // One interval later the caret blinks OFF — the repaint paints a blank cell.
+    writes.clear();
+    vi.advanceTimersByTime(50);
+    expect(writes.all()).not.toContain('▏');
+
+    // A keystroke snaps the caret back to solid (and types the char).
+    writes.clear();
+    stdin.emit('keypress', 'x', { name: 'x', sequence: 'x' });
+    expect(writes.all()).toContain('▏');
+    expect(c.getBuffer().text).toBe('x');
+
+    // After disarm the ticker is stopped: no further repaints fire.
+    c.disarm();
+    writes.clear();
+    vi.advanceTimersByTime(500);
+    expect(writes.all()).toBe('');
+  });
+
+  it('does not start a blink timer when caretBlink is unset (default)', async () => {
+    vi.useFakeTimers();
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+    await c.arm();
+    expect(writes.all()).toContain('▏'); // solid caret painted at arm
+    writes.clear();
+    // No ticker → no timer-driven repaints regardless of how far time advances.
+    vi.advanceTimersByTime(5000);
+    expect(writes.all()).toBe('');
+    c.disarm();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tab applies dropdown selection (Fix C): mirrors reader.ts:769-772 behavior
 // so completion works during agent turns, not just user turns.
 // ---------------------------------------------------------------------------

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -3185,28 +3185,26 @@ describe('TerminalCompositor — caret always rendered while armed', () => {
     writes = collectWrites(stdout);
   });
 
-  it('emits the inverse-video SGR even when buffer is empty', async () => {
-    // Force chalk to color mode so the inverse SGR is actually emitted.
-    // Without this, tests running with chalk.level === 0 see plain text and
-    // can't observe the inverse marker. Saved/restored to avoid leaking state
-    // to other suites.
+  it('emits the thin-bar caret character even when buffer is empty', async () => {
+    // At end-of-buffer the compositor paints a ▏ (U+258F, LEFT ONE EIGHTH BLOCK)
+    // in the caret accent color instead of an inverse-video space block.
+    // chalk.level is forced to 1 so color SGRs are emitted; the ▏ character
+    // itself is present regardless of chalk level. Saved/restored to avoid
+    // leaking state to other suites.
     const chalkModule = await import('chalk');
     const priorLevel = chalkModule.default.level;
     chalkModule.default.level = 1;
     try {
       const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
       await c.arm();
-      // ESC[7m is the SGR for "reverse video" (the inverse block). The compositor
-      // paints `palette.user.inverse(' ')` for an empty buffer — verify the
-      // inverse marker is in the frame.
       const frame = writes.all();
-      expect(frame).toContain('\x1b[7m');
+      expect(frame).toContain('▏');
     } finally {
       chalkModule.default.level = priorLevel;
     }
   });
 
-  it('emits the inverse SGR on the empty buffer even after the buffer goes empty again', async () => {
+  it('emits the thin-bar caret after the buffer goes empty again', async () => {
     // Regression target: previously the caret was suppressed when buffer.length === 0
     // && !queued. Verify that after typing then deleting back to empty, the caret
     // is still painted. This exercises the post-Backspace empty-buffer render.
@@ -3219,7 +3217,7 @@ describe('TerminalCompositor — caret always rendered while armed', () => {
       stdin.emit('keypress', 'x', { name: 'x', sequence: 'x' });
       stdin.emit('keypress', undefined, { name: 'backspace' });
       // Buffer is now empty (and !queued). The most recent rendered frame must
-      // still contain the inverse SGR — i.e., the caret cell.
+      // still contain the ▏ thin-bar caret.
       expect(c.getBuffer().text).toBe('');
       expect(c.getBuffer().queued).toBe(false);
       writes.clear();
@@ -3227,7 +3225,7 @@ describe('TerminalCompositor — caret always rendered while armed', () => {
       // generated from the empty+!queued state.
       c.setOverlay('overlay-content');
       const frame = writes.all();
-      expect(frame).toContain('\x1b[7m');
+      expect(frame).toContain('▏');
     } finally {
       chalkModule.default.level = priorLevel;
     }

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -3295,6 +3295,54 @@ describe('TerminalCompositor — caret blink', () => {
     expect(writes.all()).toBe('');
     c.disarm();
   });
+
+  it('coalesces the caret un-hide with the edit repaint — one frame on an off-phase keystroke', async () => {
+    vi.useFakeTimers();
+    const c = new TerminalCompositor({
+      stdout,
+      stdin,
+      onCancel: vi.fn(),
+      caretBlink: true,
+      caretBlinkIntervalMs: 50,
+    });
+    await c.arm();
+    // Blink into the OFF phase (caret painted away).
+    writes.clear();
+    vi.advanceTimersByTime(50);
+    expect(writes.all()).not.toContain('▏');
+
+    // A printable key in the off phase: dispatchKey → applyEdit repaints once,
+    // and that single frame already shows the now-solid caret. resetVisible()
+    // must NOT add a second frame. Before the fix this painted twice.
+    const before = c.repaintCount;
+    writes.clear();
+    stdin.emit('keypress', 'x', { name: 'x', sequence: 'x' });
+    expect(c.repaintCount - before).toBe(1); // exactly one frame, not two
+    expect(c.getBuffer().text).toBe('x');
+    expect(writes.all()).toContain('▏'); // solid caret in that one frame
+    c.disarm();
+  });
+
+  it('un-hides an off-phase caret with exactly one repaint on a non-painting keystroke', async () => {
+    vi.useFakeTimers();
+    const c = new TerminalCompositor({
+      stdout,
+      stdin,
+      onCancel: vi.fn(),
+      caretBlink: true,
+      caretBlinkIntervalMs: 50,
+    });
+    await c.arm();
+    vi.advanceTimersByTime(50); // → off phase
+    // F5 is consumed by no edit handler, so dispatchKey paints nothing; the
+    // caret-blink un-hide must still issue exactly one repaint to show it solid.
+    const before = c.repaintCount;
+    writes.clear();
+    stdin.emit('keypress', undefined, { name: 'f5' });
+    expect(c.repaintCount - before).toBe(1);
+    expect(writes.all()).toContain('▏');
+    c.disarm();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -22,6 +22,7 @@ import type { AutocompleteState } from './input/autocomplete-state.js';
 import type { IHistoryRing } from './input/types.js';
 import type { ImageAttachment } from './input/attachments.js';
 import { SpinnerController } from './input/spinner.js';
+import { CaretBlinkController, DEFAULT_CARET_BLINK_INTERVAL_MS } from './input/caret-blink.js';
 import type { StdinClaimHandle } from './input/stdin-claim.js';
 import {
   type CompositorInputMode,
@@ -283,6 +284,13 @@ export class TerminalCompositor {
 
   /** @internal Relaxed from `private` for the frame module (FrameHost). */
   readonly spinnerController: SpinnerController;
+  /**
+   * Owns the input caret's blink phase + timer. Started in arm() / resumeInput(),
+   * stopped in disarm() / suspendInput(), reset-to-solid on each non-paste
+   * keystroke. `caretVisible` (read by the frame renderer) reflects its phase.
+   * @internal Relaxed from `private` for the lifecycle module (LifecycleHost).
+   */
+  readonly caretBlinkController: CaretBlinkController;
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   committing = false;
   /**
@@ -417,6 +425,17 @@ export class TerminalCompositor {
     this.scrollRegion = opts.scrollRegion;
     this.spinnerController = new SpinnerController({
       captureMode: opts.captureMode ?? false,
+      onTick: () => this.repaint(),
+    });
+    // Caret blink defaults OFF: enablement (incl. reduced-motion) is resolved
+    // by the interactive caller and passed as `caretBlink`, mirroring how the
+    // spinner's motion gating is resolved caller-side (stream-renderer). This
+    // keeps every direct/test construction free of an auto-started recurring
+    // timer. captureMode suppresses the ticker even when enabled.
+    this.caretBlinkController = new CaretBlinkController({
+      enabled: opts.caretBlink ?? false,
+      captureMode: opts.captureMode ?? false,
+      intervalMs: opts.caretBlinkIntervalMs ?? DEFAULT_CARET_BLINK_INTERVAL_MS,
       onTick: () => this.repaint(),
     });
     this.onSubmit = opts.onSubmit;
@@ -716,6 +735,16 @@ export class TerminalCompositor {
    */
   getAttachments(): ImageAttachment[] {
     return [...this.attachments];
+  }
+
+  /**
+   * Whether the caret glyph is in its visible phase this frame. Read by the
+   * frame renderer (RenderHost.caretVisible) to paint a solid vs. blanked
+   * caret. Always true unless the caret-blink ticker is running and currently
+   * in its off-phase. @internal Relaxed for the render module (RenderHost).
+   */
+  get caretVisible(): boolean {
+    return this.caretBlinkController.visible;
   }
 
   // Body extracted to terminal-compositor.render.ts (free-functions-on-host).

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -291,6 +291,16 @@ export class TerminalCompositor {
    * @internal Relaxed from `private` for the lifecycle module (LifecycleHost).
    */
   readonly caretBlinkController: CaretBlinkController;
+  /**
+   * Monotonic frame counter, bumped once per {@link repaint}. Read by the
+   * lifecycle keypress handler (`LifecycleHost.repaintCount`) to tell whether
+   * dispatchKey already painted a frame this keystroke, so the caret-blink
+   * un-hide repaint is issued only when nothing else painted — avoiding a double
+   * frame on an off-phase keystroke. Plain counter; wraparound is unreachable in
+   * a session (Number.MAX_SAFE_INTEGER frames).
+   * @internal Relaxed from `private` for the lifecycle module (LifecycleHost).
+   */
+  repaintCount = 0;
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   committing = false;
   /**
@@ -800,6 +810,9 @@ export class TerminalCompositor {
 
   /** @internal Public for sibling free-function modules (via Host interfaces) and test casts. */
   repaint(): void {
+    // Bump BEFORE painting so the lifecycle keypress handler's post-dispatch
+    // comparison sees the increment from any repaint dispatchKey triggered.
+    this.repaintCount++;
     Frame.repaint(this);
   }
 

--- a/src/cli/terminal-compositor.types.ts
+++ b/src/cli/terminal-compositor.types.ts
@@ -366,10 +366,28 @@ export interface TerminalCompositorOptions {
    * detection contract.
    *
    * Does NOT change the input-handling, scrollback-commit, or
-   * state-transition-driven overlay paths — only the spinner ticker.
+   * state-transition-driven overlay paths — only the spinner ticker
+   * and the caret-blink ticker (see {@link caretBlink}).
    * Default `false` (live-TTY behavior unchanged).
    */
   captureMode?: boolean;
+  /**
+   * Enable the blinking input caret (pulse on/off like a terminal cursor).
+   * Default `false` — the caller that owns an interactive surface
+   * (`InputSurface.armCompositor`) resolves
+   * `detectCaretBlink() && !detectReducedMotion()` and passes it; tests and
+   * non-interactive constructions leave it off, so no blink timer is ever
+   * created (this is what keeps the existing compositor suite free of
+   * auto-started recurring timers). When true, {@link captureMode} still
+   * suppresses the ticker so recordings show a steady caret.
+   */
+  caretBlink?: boolean;
+  /**
+   * Blink half-period in ms (dwell time per on/off phase). Default 530 (the
+   * classic terminal cursor cadence). Exposed mainly so tests can drive a tiny
+   * interval; intentionally NOT surfaced as an env var.
+   */
+  caretBlinkIntervalMs?: number;
   /**
    * Upper-bound row protection for the live frame. When set, the compositor
    * treats rows `1..anchorRow-1` as containing pre-arm scrollback content


### PR DESCRIPTION
## Summary

- Replace the block cursor (inverse-video space) with a thin `▏` bar (U+258F, LEFT ONE EIGHTH BLOCK) at end-of-buffer — the idle caret now reads as a modern line cursor rather than a filled rectangle
- Mid-buffer the character under the cursor keeps inverse-video for legibility while navigating/editing
- Add `palette.caret` (`#7AA2F7`, Tokyo Night cornflower blue) as a dedicated semantic key — distinct from `palette.user` (cyan) so cursor styling can evolve without touching card borders, transcript glyphs, code spans, or dropdown rows
- Both render sites updated: `terminal-compositor.render.ts` (main REPL input) and `render/text-input.ts` (elicitation overlay)

## Test results

- `pnpm lint` (`tsc --noEmit`): **clean**
- `pnpm test`: 7161 passed / 125 failed — all 125 failures are a pre-existing `better-sqlite3` native binary not compiled in this worktree (environment issue, unrelated to this change); confirmed by error class (`Could not locate the bindings file`) and that affected test files all touch the memory subsystem
- Caret rendering verified manually via `node --input-type=module` script: end-of-buffer emits `\x1b[38;2;122;162;247m▏\x1b[39m`; mid-buffer emits the character with `\x1b[7m` inverse inside the caret color SGR

## Verification

No adversarial verify requested (diff under 100-line threshold: 51 lines changed).

## Out of scope

`palette.user` (chalk.cyan) is unchanged — all existing user-identity surfaces (echo glyph `▶`, transcript `User` label, card `│` border, code spans) keep the original cyan.