### PR TITLE
chore: launch-readiness polish (README badges/CTAs/migrate wedge + npm discoverability)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,14 @@
 > Agent AFK isn't "smarter than Claude Code." It's *yours* in a way Claude Code can't be.
 
 [![npm version](https://img.shields.io/npm/v/agent-afk.svg)](https://www.npmjs.com/package/agent-afk)
+[![CI](https://github.com/griffinwork40/agent-afk/actions/workflows/ci.yml/badge.svg)](https://github.com/griffinwork40/agent-afk/actions/workflows/ci.yml)
 [![Node](https://img.shields.io/node/v/agent-afk.svg)](https://nodejs.org/)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/griffinwork40/agent-afk?style=social)](https://github.com/griffinwork40/agent-afk/stargazers)
+
+<!-- DEMO GIF GOES HERE ▸ drop a 20–30s screen recording of one autonomous AFK run (e.g. kick off `afk daemon` / `afk mint "..."`, walk away, get the Telegram ping, come back done). Drag-and-drop the file into a GitHub issue/PR to host it on GitHub's CDN, then paste the URL as ![demo](URL) right here. This is the single biggest star-conversion lever — keep it above the fold. -->
+
+> ⭐ **Like the idea of an agent loop you fully own? [Star the repo](https://github.com/griffinwork40/agent-afk/stargazers)** — it's the fastest way to help other people find it.
 
 ## Claude Code vs. Agent AFK
 
@@ -36,6 +43,8 @@ afk doctor       # environment self-check
 afk login        # save an Anthropic API key or OAuth token
 afk chat "hello"
 ```
+
+**Already using Claude Code or Codex?** Run `afk migrate` — it imports your existing plugins, skills, and MCP servers. It doesn't copy files; it live-reads the source tool's dirs, so anything you install there keeps showing up in AFK with no re-run.
 
 ## What you can do with it
 
@@ -179,6 +188,12 @@ With containment on (`default`), a file tool (read/write/edit/list/glob/grep) ta
 ## Changelog
 
 Recent releases at [`CHANGELOG.md`](CHANGELOG.md), also viewable in-REPL via `/changelog`.
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=griffinwork40/agent-afk&type=Date)](https://star-history.com/#griffinwork40/agent-afk&Date)
+
+If Agent AFK saves you time, **[⭐ star the repo](https://github.com/griffinwork40/agent-afk/stargazers)** — it's the single best way to help it reach more people.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -57,15 +57,29 @@
     "local-first",
     "mcp",
     "telegram",
-    "cli"
+    "cli",
+    "claude",
+    "anthropic",
+    "llm",
+    "coding-assistant",
+    "coding-agent",
+    "autonomous-agent",
+    "claude-code",
+    "subagent",
+    "daemon",
+    "openai",
+    "afk"
   ],
   "author": "Griffin Long",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/griffinwork40/agent-afk.git"
   },
-  "homepage": "https://github.com/griffinwork40/agent-afk#readme",
+  "homepage": "https://docs.agentafk.com",
   "bugs": {
     "url": "https://github.com/griffinwork40/agent-afk/issues"
   },


### PR DESCRIPTION
## What
Launch-readiness polish — **docs + npm metadata only, no code changes**.

**README**
- CI / License / GitHub-stars badges
- above-the-fold demo-GIF placeholder (HTML comment — ready for you to drop the recording in)
- two ⭐ star CTAs (top + new Star History section)
- surface `afk migrate` in Install (the Claude Code / Codex import wedge — same displaced-user move that drove comparable repos)
- Star History chart

**package.json**
- discovery keywords (claude, anthropic, llm, coding-assistant, autonomous-agent, claude-code, subagent, daemon, openai, afk) → 20 total
- `publishConfig.access: public` (publish hygiene)
- `homepage` → https://docs.agentafk.com

## Also done outside this diff (live now)
- Set 15 GitHub repo **Topics** → 20 total (claude, anthropic, autonomous-agent, mcp, claude-code, telegram-bot, typescript, …) for GitHub/Google/LLM discovery.

## Still yours (not in this PR)
- 🎥 The **demo GIF** (placeholder marked in README) — biggest single star-conversion lever.
- 🚀 A coordinated **Show HN + r/LocalLLaMA + r/selfhosted** launch window.

Self-merge when ready; CI runs on this branch. Full growth playbook lives at `.afk/plans/github-growth-playbook.md` (local-only).