### PR TITLE
feat: searchable conversation transcripts (FTS5)

### DIFF
--- a/src/agent/transcript-search/transcript-index.test.ts
+++ b/src/agent/transcript-search/transcript-index.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdirSync, writeFileSync, rmSync, statSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { TranscriptIndex, withTranscriptIndex } from './transcript-index.js';
@@ -267,7 +267,23 @@ describe('TranscriptIndex', () => {
       }
     });
 
-    it('includes a non-empty snippet from the document content', () => {
+    it('stores the "unknown" session_at sentinel for a non-stamp filename', () => {
+      // A stray .md whose name is not the ISO-stamp pattern must not produce a
+      // malformed session_at; filenameToIso returns the sentinel instead.
+      writeTranscript('release-notes.md', `# Notes\n\nThe xanadu feature shipped today.\n`);
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        idx.reindex();
+        const results = idx.search('xanadu');
+        expect(results.length).toBe(1);
+        expect(results[0]?.filename).toBe('release-notes.md');
+        expect(results[0]?.session_at).toBe('unknown');
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('returns a snippet containing the matched term, not the session header', () => {
       const idx = new TranscriptIndex(indexDir, transcriptsDir);
       try {
         idx.reindex();
@@ -276,6 +292,11 @@ describe('TranscriptIndex', () => {
         expect(typeof results[0]?.snippet).toBe('string');
         expect(results[0]!.snippet.length).toBeGreaterThan(0);
         expect(results[0]!.snippet.length).toBeLessThanOrEqual(300);
+        // The snippet must be the FTS5 matching excerpt — it contains the matched
+        // term and is NOT the boilerplate "# Session — <ts>" header that every
+        // transcript starts with (the bug a content.slice(0,300) would reintroduce).
+        expect(results[0]!.snippet).toContain('memory_search');
+        expect(results[0]!.snippet).not.toContain('# Session');
       } finally {
         idx.close();
       }
@@ -386,6 +407,23 @@ describe('FTS5 query safety', () => {
       idx.reindex();
       const results = idx.search('xyzzy AND nonexistent');
       expect(results).toEqual([]);
+    } finally {
+      idx.close();
+    }
+  });
+});
+
+describe('index directory permissions', () => {
+  it('creates a fresh index dir with owner-only (0o700) permissions on POSIX', () => {
+    // POSIX file modes only; Windows has no equivalent.
+    if (process.platform === 'win32') return;
+    // Use a dir the test harness has NOT pre-created so the constructor's own
+    // mkdir (with mode 0o700) is what sets the permissions we assert.
+    const freshIndexDir = join(testDir, 'fresh-index');
+    const idx = new TranscriptIndex(freshIndexDir, transcriptsDir);
+    try {
+      const mode = statSync(freshIndexDir).mode & 0o777;
+      expect(mode).toBe(0o700);
     } finally {
       idx.close();
     }

--- a/src/agent/transcript-search/transcript-index.test.ts
+++ b/src/agent/transcript-search/transcript-index.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Tests for the FTS5 transcript search index.
+ *
+ * Uses a fresh temp directory per test suite so tests are fully isolated
+ * from user state. No real transcript files from `~/.afk/` are read.
+ *
+ * @module agent/transcript-search/transcript-index.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { TranscriptIndex, withTranscriptIndex } from './transcript-index.js';
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+/** A minimal transcript in the real format (markdown, as written by initTranscript). */
+const TRANSCRIPT_A = `# Session — 2026-06-15T10:45:52.728Z
+
+- model: claude-opus-4-5
+
+---
+
+_2026-06-15T10:45:52.728Z · model: claude-opus-4-5_
+
+## User
+
+How do I configure the Telegram bot for agent-afk?
+
+## Assistant
+
+To configure the Telegram bot, set AFK_TELEGRAM_BOT_TOKEN in your .env file
+and run \`afk telegram setup\`. The bot will start listening for messages.
+
+---
+
+_ended: 2026-06-15T11:02:10.000Z_
+`;
+
+const TRANSCRIPT_B = `# Session — 2026-06-16T14:22:30.100Z
+
+- model: claude-haiku-4-0
+
+---
+
+_2026-06-16T14:22:30.100Z · model: claude-haiku-4-0_
+
+## User
+
+What is the memory_search tool and how does it work?
+
+## Assistant
+
+memory_search queries the SQLite fact archive for curated facts the agent has
+recorded across sessions. It uses FTS5 full-text search with a porter tokenizer.
+
+---
+
+_ended: 2026-06-16T14:35:00.000Z_
+`;
+
+const TRANSCRIPT_C = `# Session — 2026-06-17T09:00:00.000Z
+
+- model: claude-sonnet-4-5
+
+---
+
+_2026-06-17T09:00:00.000Z · model: claude-sonnet-4-5_
+
+## User
+
+Explain the worktree feature.
+
+## Assistant
+
+Worktrees let you work on multiple branches simultaneously without switching.
+Use \`afk worktree add\` to create a new worktree for a branch.
+
+---
+
+_ended: 2026-06-17T09:20:00.000Z_
+`;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+let testDir: string;
+let indexDir: string;
+let transcriptsDir: string;
+
+function writeTranscript(filename: string, content: string): void {
+  writeFileSync(join(transcriptsDir, filename), content, 'utf-8');
+}
+
+// ── Setup / teardown ───────────────────────────────────────────────────────
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `afk-transcript-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  indexDir = join(testDir, 'index');
+  transcriptsDir = join(testDir, 'transcripts');
+  mkdirSync(transcriptsDir, { recursive: true });
+  mkdirSync(indexDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('TranscriptIndex', () => {
+  describe('reindex()', () => {
+    it('indexes transcript files and returns the count', () => {
+      writeTranscript('2026-06-15T10-45-52-728Z.md', TRANSCRIPT_A);
+      writeTranscript('2026-06-16T14-22-30-100Z.md', TRANSCRIPT_B);
+
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        const n = idx.reindex();
+        expect(n).toBe(2);
+        expect(idx.count()).toBe(2);
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('returns 0 when the transcripts directory is empty', () => {
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        const n = idx.reindex();
+        expect(n).toBe(0);
+        expect(idx.count()).toBe(0);
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('returns 0 when the transcripts directory does not exist', () => {
+      const missingDir = join(testDir, 'no-such-dir');
+      const idx = new TranscriptIndex(indexDir, missingDir);
+      try {
+        const n = idx.reindex();
+        expect(n).toBe(0);
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('skips non-.md files', () => {
+      writeTranscript('2026-06-15T10-45-52-728Z.md', TRANSCRIPT_A);
+      writeFileSync(join(transcriptsDir, 'notes.txt'), 'some notes', 'utf-8');
+      writeFileSync(join(transcriptsDir, 'data.json'), '{}', 'utf-8');
+
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        const n = idx.reindex();
+        expect(n).toBe(1);
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('is idempotent — reindexing twice does not duplicate rows', () => {
+      writeTranscript('2026-06-15T10-45-52-728Z.md', TRANSCRIPT_A);
+
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        idx.reindex();
+        idx.reindex(); // second call
+        expect(idx.count()).toBe(1);
+      } finally {
+        idx.close();
+      }
+    });
+  });
+
+  describe('search()', () => {
+    beforeEach(() => {
+      writeTranscript('2026-06-15T10-45-52-728Z.md', TRANSCRIPT_A);
+      writeTranscript('2026-06-16T14-22-30-100Z.md', TRANSCRIPT_B);
+      writeTranscript('2026-06-17T09-00-00-000Z.md', TRANSCRIPT_C);
+    });
+
+    it('returns the matching transcript for a term query', () => {
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        idx.reindex();
+        const results = idx.search('Telegram');
+        expect(results.length).toBeGreaterThanOrEqual(1);
+        // The Telegram hit should come from transcript A
+        expect(results[0]?.filename).toBe('2026-06-15T10-45-52-728Z.md');
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('returns results ranked best-first (rank closer to 0 is better)', () => {
+      // Both TRANSCRIPT_A and TRANSCRIPT_B mention "setup" / configuration-like
+      // terms; verify results are ordered (rank values non-decreasing from best).
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        idx.reindex();
+        const results = idx.search('configure');
+        // If multiple hits, ranks should be non-decreasing (FTS5 rank is negative;
+        // ORDER BY rank puts the most-negative / best hit first).
+        for (let i = 1; i < results.length; i++) {
+          expect(results[i]!.rank).toBeGreaterThanOrEqual(results[i - 1]!.rank);
+        }
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('returns empty array for a query with no matches', () => {
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        idx.reindex();
+        const results = idx.search('xyzzy_no_such_term_9999');
+        expect(results).toEqual([]);
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('returns empty array for empty query string', () => {
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        idx.reindex();
+        const results = idx.search('');
+        expect(results).toEqual([]);
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('returns empty array for whitespace-only query', () => {
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        idx.reindex();
+        const results = idx.search('   ');
+        expect(results).toEqual([]);
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('respects the limit parameter', () => {
+      // All three transcripts contain common words — use a broad term
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        idx.reindex();
+        const results = idx.search('Session', 2);
+        expect(results.length).toBeLessThanOrEqual(2);
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('returns session_at in ISO-8601 format recovered from filename', () => {
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        idx.reindex();
+        const results = idx.search('Telegram');
+        expect(results[0]?.session_at).toBe('2026-06-15T10:45:52.728Z');
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('includes a non-empty snippet from the document content', () => {
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        idx.reindex();
+        const results = idx.search('memory_search');
+        expect(results.length).toBeGreaterThanOrEqual(1);
+        expect(typeof results[0]?.snippet).toBe('string');
+        expect(results[0]!.snippet.length).toBeGreaterThan(0);
+        expect(results[0]!.snippet.length).toBeLessThanOrEqual(300);
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('handles FTS5 phrase query (quoted terms)', () => {
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        idx.reindex();
+        // "Telegram bot" as an exact phrase should hit transcript A
+        const results = idx.search('"Telegram bot"');
+        expect(results.length).toBeGreaterThanOrEqual(1);
+        expect(results[0]?.filename).toBe('2026-06-15T10-45-52-728Z.md');
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('throws a descriptive error on invalid FTS5 syntax', () => {
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        idx.reindex();
+        // An unclosed quote is invalid FTS5 syntax
+        expect(() => idx.search('"unclosed phrase')).toThrow(/FTS5 query failed/);
+      } finally {
+        idx.close();
+      }
+    });
+  });
+
+  describe('count()', () => {
+    it('returns 0 before reindex', () => {
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        expect(idx.count()).toBe(0);
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('returns the number of indexed transcripts after reindex', () => {
+      writeTranscript('2026-06-15T10-45-52-728Z.md', TRANSCRIPT_A);
+      writeTranscript('2026-06-16T14-22-30-100Z.md', TRANSCRIPT_B);
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        idx.reindex();
+        expect(idx.count()).toBe(2);
+      } finally {
+        idx.close();
+      }
+    });
+  });
+});
+
+describe('withTranscriptIndex()', () => {
+  it('closes the DB after the callback and returns the callback result', () => {
+    writeTranscript('2026-06-15T10-45-52-728Z.md', TRANSCRIPT_A);
+
+    const count = withTranscriptIndex(
+      (idx) => {
+        idx.reindex();
+        return idx.count();
+      },
+      indexDir,
+      transcriptsDir,
+    );
+    expect(count).toBe(1);
+  });
+
+  it('closes the DB even when the callback throws', () => {
+    expect(() =>
+      withTranscriptIndex(
+        () => {
+          throw new Error('test error');
+        },
+        indexDir,
+        transcriptsDir,
+      ),
+    ).toThrow('test error');
+    // If we get here, the DB was closed (no open handles blocking cleanup).
+    // Verify by trying to use the same indexDir again — should not throw.
+    expect(() =>
+      withTranscriptIndex((idx) => idx.count(), indexDir, transcriptsDir),
+    ).not.toThrow();
+  });
+});
+
+describe('FTS5 query safety', () => {
+  beforeEach(() => {
+    writeTranscript('2026-06-15T10-45-52-728Z.md', TRANSCRIPT_A);
+  });
+
+  it('handles a query with special regex characters without crashing (FTS5 syntax)', () => {
+    const idx = new TranscriptIndex(indexDir, transcriptsDir);
+    try {
+      idx.reindex();
+      // Asterisk is valid FTS5 prefix operator — should return results
+      const results = idx.search('Telegr*');
+      expect(results.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      idx.close();
+    }
+  });
+
+  it('returns empty for a valid but non-matching complex FTS5 query', () => {
+    const idx = new TranscriptIndex(indexDir, transcriptsDir);
+    try {
+      idx.reindex();
+      const results = idx.search('xyzzy AND nonexistent');
+      expect(results).toEqual([]);
+    } finally {
+      idx.close();
+    }
+  });
+});

--- a/src/agent/transcript-search/transcript-index.test.ts
+++ b/src/agent/transcript-search/transcript-index.test.ts
@@ -116,8 +116,9 @@ describe('TranscriptIndex', () => {
 
       const idx = new TranscriptIndex(indexDir, transcriptsDir);
       try {
-        const n = idx.reindex();
-        expect(n).toBe(2);
+        const result = idx.reindex();
+        expect(result.indexed).toBe(2);
+        expect(result.skipped).toBe(0);
         expect(idx.count()).toBe(2);
       } finally {
         idx.close();
@@ -127,8 +128,9 @@ describe('TranscriptIndex', () => {
     it('returns 0 when the transcripts directory is empty', () => {
       const idx = new TranscriptIndex(indexDir, transcriptsDir);
       try {
-        const n = idx.reindex();
-        expect(n).toBe(0);
+        const result = idx.reindex();
+        expect(result.indexed).toBe(0);
+        expect(result.skipped).toBe(0);
         expect(idx.count()).toBe(0);
       } finally {
         idx.close();
@@ -139,8 +141,9 @@ describe('TranscriptIndex', () => {
       const missingDir = join(testDir, 'no-such-dir');
       const idx = new TranscriptIndex(indexDir, missingDir);
       try {
-        const n = idx.reindex();
-        expect(n).toBe(0);
+        const result = idx.reindex();
+        expect(result.indexed).toBe(0);
+        expect(result.skipped).toBe(0);
       } finally {
         idx.close();
       }
@@ -153,8 +156,9 @@ describe('TranscriptIndex', () => {
 
       const idx = new TranscriptIndex(indexDir, transcriptsDir);
       try {
-        const n = idx.reindex();
-        expect(n).toBe(1);
+        const result = idx.reindex();
+        expect(result.indexed).toBe(1);
+        expect(result.skipped).toBe(0);
       } finally {
         idx.close();
       }
@@ -167,6 +171,23 @@ describe('TranscriptIndex', () => {
       try {
         idx.reindex();
         idx.reindex(); // second call
+        expect(idx.count()).toBe(1);
+      } finally {
+        idx.close();
+      }
+    });
+
+    it('counts unreadable .md entries as skipped, not indexed', () => {
+      writeTranscript('2026-06-15T10-45-52-728Z.md', TRANSCRIPT_A);
+      // A directory whose name ends in .md is enumerated by readdir but cannot
+      // be read: readFileSync throws EISDIR, exercising the skip-count path.
+      mkdirSync(join(transcriptsDir, 'broken.md'));
+
+      const idx = new TranscriptIndex(indexDir, transcriptsDir);
+      try {
+        const result = idx.reindex();
+        expect(result.indexed).toBe(1);
+        expect(result.skipped).toBe(1);
         expect(idx.count()).toBe(1);
       } finally {
         idx.close();

--- a/src/agent/transcript-search/transcript-index.ts
+++ b/src/agent/transcript-search/transcript-index.ts
@@ -26,7 +26,7 @@
 
 import Database from 'better-sqlite3';
 import type BetterSqlite3 from 'better-sqlite3';
-import { existsSync, mkdirSync, readdirSync, readFileSync } from 'fs';
+import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync } from 'fs';
 import { join, basename } from 'path';
 import { getTranscriptsDir, getAfkStateDir } from '../../paths.js';
 import { debugLog } from '../../utils/debug.js';
@@ -90,6 +90,14 @@ export interface TranscriptSearchResult {
   rank: number;
 }
 
+/** Outcome of a {@link TranscriptIndex.reindex} run. */
+export interface ReindexResult {
+  /** Number of transcript files successfully read and indexed. */
+  indexed: number;
+  /** Number of `.md` entries skipped because they could not be read. */
+  skipped: number;
+}
+
 // ── Filename helpers ───────────────────────────────────────────────────────
 
 /**
@@ -135,7 +143,21 @@ export class TranscriptIndex {
     // 0o700 dir is what keeps that duplicated content unreadable by other users.
     mkdirSync(this.indexDir, { recursive: true, mode: 0o700 });
 
-    this.db = new Database(join(this.indexDir, DB_FILE));
+    const dbPath = join(this.indexDir, DB_FILE);
+    this.db = new Database(dbPath);
+    // Defense-in-depth beyond the 0o700 dir: tighten the DB file itself to 0o600
+    // so the duplicated transcript content matches the confidentiality of the
+    // source transcripts (also 0o600) even if the file is later copied out of the
+    // dir (backup/sync), where the directory's protection no longer applies.
+    // POSIX only — chmod is a no-op on Windows. Best-effort: a chmod failure must
+    // not break indexing, so it is logged and swallowed.
+    if (process.platform !== 'win32') {
+      try {
+        chmodSync(dbPath, 0o600);
+      } catch (err) {
+        debugLog('transcript-index: could not chmod index.db to 0o600:', String(err));
+      }
+    }
     // Invariant: busy_timeout must be set before any schema or data operation
     // so contended reads wait rather than fail immediately. WAL mode is set
     // next so concurrent readers don't block the writer.
@@ -171,12 +193,12 @@ export class TranscriptIndex {
    * A full reindex is used for v1 (reindex-on-demand design). Incremental
    * indexing (mtime-gated upsert) is left for a future iteration.
    *
-   * @returns count of transcript files indexed
+   * @returns counts of indexed and skipped (unreadable) transcript files
    */
-  reindex(): number {
+  reindex(): ReindexResult {
     if (!existsSync(this.transcriptsDir)) {
       debugLog('transcript-index: transcripts dir does not exist, nothing to index');
-      return 0;
+      return { indexed: 0, skipped: 0 };
     }
 
     const files = readdirSync(this.transcriptsDir).filter((f) => f.endsWith('.md'));
@@ -196,7 +218,8 @@ export class TranscriptIndex {
         VALUES (?, ?, ?)
       `);
 
-      let count = 0;
+      let indexed = 0;
+      let skipped = 0;
       for (const filename of files) {
         const filePath = join(this.transcriptsDir, filename);
         let content: string;
@@ -204,19 +227,20 @@ export class TranscriptIndex {
           content = readFileSync(filePath, 'utf-8');
         } catch (err) {
           debugLog(`transcript-index: skipping unreadable file ${filename}:`, String(err));
+          skipped++;
           continue;
         }
         const sessionAt = filenameToIso(filename);
         insert.run(filename, sessionAt, content);
-        count++;
+        indexed++;
       }
 
       // Rebuild the FTS index from the now-populated content table.
       this.db.exec(`INSERT INTO transcripts_fts(transcripts_fts) VALUES('rebuild');`);
-      return count;
+      return { indexed, skipped };
     });
 
-    return doReindex() as number;
+    return doReindex() as ReindexResult;
   }
 
   /**

--- a/src/agent/transcript-search/transcript-index.ts
+++ b/src/agent/transcript-search/transcript-index.ts
@@ -47,7 +47,9 @@ const SCHEMA_VERSION = 1;
 // table. The FTS5 table uses `content=transcripts` (external content mode) so
 // ranking information (via the hidden `rank` column) is available on queries.
 // `porter` tokenizer matches the memory store convention for stem-aware search.
-// Triggers keep the FTS index in sync with the content table.
+// No per-row sync triggers: reindex() is the only write path and rebuilds the
+// whole FTS index in bulk via the FTS5 'rebuild' command (see reindex()), so
+// INSERT/DELETE triggers would be redundant work on every full reindex.
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS transcripts (
   id      INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -66,19 +68,6 @@ CREATE VIRTUAL TABLE IF NOT EXISTS transcripts_fts USING fts5(
   tokenize='porter'
 );
 
-CREATE TRIGGER IF NOT EXISTS transcripts_ai AFTER INSERT ON transcripts BEGIN
-  INSERT INTO transcripts_fts(rowid, content) VALUES (new.id, new.content);
-END;
-
-CREATE TRIGGER IF NOT EXISTS transcripts_ad AFTER DELETE ON transcripts BEGIN
-  INSERT INTO transcripts_fts(transcripts_fts, rowid, content) VALUES ('delete', old.id, old.content);
-END;
-
-CREATE TRIGGER IF NOT EXISTS transcripts_au AFTER UPDATE ON transcripts BEGIN
-  INSERT INTO transcripts_fts(transcripts_fts, rowid, content) VALUES ('delete', old.id, old.content);
-  INSERT INTO transcripts_fts(rowid, content) VALUES (new.id, new.content);
-END;
-
 CREATE INDEX IF NOT EXISTS idx_transcripts_session_at ON transcripts(session_at DESC);
 `;
 
@@ -91,8 +80,10 @@ export interface TranscriptSearchResult {
   /** ISO-8601 session timestamp recovered from the filename. */
   session_at: string;
   /**
-   * Leading snippet of the transcript content (first 300 chars). Callers that
-   * want the full body should read the file directly via `getTranscriptsDir()`.
+   * Matching excerpt with surrounding context, produced by FTS5 `snippet()`
+   * (~16 tokens around the best match, whitespace-collapsed for one-line
+   * display). Callers that want the full body should read the file directly via
+   * `getTranscriptsDir()`.
    */
   snippet: string;
   /** Raw FTS5 rank (lower is better). Exposed so callers can sort if needed. */
@@ -110,6 +101,9 @@ export interface TranscriptSearchResult {
  *
  * Example: `2026-06-15T10-45-52-728Z.md` → `2026-06-15T10:45:52.728Z`
  */
+/** Stored in `session_at` when a filename is not a recognizable ISO stamp. */
+const UNKNOWN_SESSION_AT = 'unknown';
+
 function filenameToIso(filename: string): string {
   // Strip the .md suffix, then un-mangle the time portion.
   // The date part (YYYY-MM-DD) already uses '-' legitimately; only the
@@ -118,7 +112,11 @@ function filenameToIso(filename: string): string {
   // Pattern: after the 'T' separator, replace the first two '-' separating
   // HH-MM-SS with ':', and the third '-' separating SS-mmm with '.'.
   // The trailing 'Z' is preserved as-is.
-  return stem.replace(/T(\d{2})-(\d{2})-(\d{2})-(\d{3}Z)$/, 'T$1:$2:$3.$4');
+  const iso = stem.replace(/T(\d{2})-(\d{2})-(\d{2})-(\d{3}Z)$/, 'T$1:$2:$3.$4');
+  // A no-op replace (iso === stem) means the filename was not a recognized
+  // stamp (a stray or legacy file). Return a sentinel rather than store a
+  // non-ISO string in `session_at` that callers would render as a timestamp.
+  return iso === stem ? UNKNOWN_SESSION_AT : iso;
 }
 
 // ── TranscriptIndex class ──────────────────────────────────────────────────
@@ -131,7 +129,11 @@ export class TranscriptIndex {
   constructor(indexDir?: string, transcriptsDir?: string) {
     this.indexDir = indexDir ?? join(getAfkStateDir(), INDEX_DIR_NAME);
     this.transcriptsDir = transcriptsDir ?? getTranscriptsDir();
-    mkdirSync(this.indexDir, { recursive: true });
+    // The index DB holds a full copy of every transcript's content, which the
+    // transcript writer deliberately stores at mode 0o600. better-sqlite3
+    // creates index.db (+ -wal/-shm) at the process umask (often 0o644), so a
+    // 0o700 dir is what keeps that duplicated content unreadable by other users.
+    mkdirSync(this.indexDir, { recursive: true, mode: 0o700 });
 
     this.db = new Database(join(this.indexDir, DB_FILE));
     // Invariant: busy_timeout must be set before any schema or data operation
@@ -157,11 +159,13 @@ export class TranscriptIndex {
   /**
    * Rebuild the FTS index from scratch by scanning the transcripts directory.
    *
-   * Invariant (ordered writes): the FTS table is kept in sync with the content
-   * table via SQLite triggers — INSERT on `transcripts` automatically fires
-   * `INSERT INTO transcripts_fts`. The governing constraint is the FTS5 trigger
-   * protocol: content-table rows must be written before the FTS virtual table
-   * can be queried, because FTS5 external-content tables do not self-populate.
+   * Invariant (FTS5 external-content rebuild): content-table rows must be
+   * written before the FTS index is rebuilt, because an external-content FTS5
+   * table (`content=transcripts`) does not self-populate. reindex() therefore
+   * (1) clears the content table, (2) inserts every transcript from disk, then
+   * (3) runs the FTS5 'rebuild' command to reconstruct the index from the
+   * now-current content rows. The bulk rebuild is the single sync point — no
+   * per-row triggers are used.
    *
    * All writes run inside a single transaction for atomicity and performance.
    * A full reindex is used for v1 (reindex-on-demand design). Incremental
@@ -178,23 +182,18 @@ export class TranscriptIndex {
     const files = readdirSync(this.transcriptsDir).filter((f) => f.endsWith('.md'));
     debugLog(`transcript-index: reindexing ${files.length} transcript files`);
 
-    // Invariant (ordered operation sequence): clear the FTS index before
-    // clearing the content table. The FTS `delete` command requires the content
-    // row to still be present in the backing store; however, with external-
-    // content FTS5 we issue a full `rebuild` command after clearing, which
-    // reconstructs the FTS index from the (now-replaced) content table rows
-    // without needing the old rows. Therefore the correct order is:
+    // Invariant (ordered operation sequence): with external-content FTS5 the
+    // index is rebuilt from the content table, so the order is:
     //   1. DELETE all rows from `transcripts` (content table)
-    //   2. INSERT new rows from disk
-    //   3. Rebuild FTS index from updated content table
-    // This is done inside a transaction to ensure atomicity.
+    //   2. INSERT new rows from disk (no ON CONFLICT needed — the table is empty)
+    //   3. Rebuild the FTS index from the updated content table
+    // All inside one transaction for atomicity.
     const doReindex = this.db.transaction(() => {
       this.db.exec(`DELETE FROM transcripts;`);
 
       const insert = this.db.prepare<[string, string, string]>(`
         INSERT INTO transcripts (filename, session_at, content)
         VALUES (?, ?, ?)
-        ON CONFLICT(filename) DO UPDATE SET session_at=excluded.session_at, content=excluded.content
       `);
 
       let count = 0;
@@ -230,7 +229,7 @@ export class TranscriptIndex {
    * Contract:
    * - Returns up to `limit` results, ordered by FTS5 rank (best match first).
    * - Returns an empty array when the index is empty or no query matches.
-   * - Each result includes a 300-char snippet from the start of the document.
+   * - Each result includes an FTS5 `snippet()` excerpt around the best match.
    * - Callers should call {@link reindex} at least once before searching.
    *
    * @param query  FTS5 query string
@@ -241,8 +240,13 @@ export class TranscriptIndex {
     // parse error on an empty MATCH expression).
     if (!query.trim()) return [];
 
+    // Use FTS5 snippet() to return the matching excerpt (not the file header)
+    // and to avoid transferring full `content` per row just to slice it.
+    // snippet(table, colIdx 0, startMark '', endMark '', ellipsis '…', tokens).
     const sql = `
-      SELECT t.filename, t.session_at, t.content, transcripts_fts.rank
+      SELECT t.filename, t.session_at,
+             snippet(transcripts_fts, 0, '', '', '…', 16) AS snippet,
+             transcripts_fts.rank
       FROM transcripts t
       JOIN transcripts_fts ON transcripts_fts.rowid = t.id
       WHERE transcripts_fts MATCH ?
@@ -250,12 +254,14 @@ export class TranscriptIndex {
       LIMIT ?
     `;
 
-    let rows: Array<{ filename: string; session_at: string; content: string; rank: number }>;
+    let rows: Array<{ filename: string; session_at: string; snippet: string; rank: number }>;
     try {
       rows = this.db.prepare(sql).all(query, limit) as typeof rows;
     } catch (err) {
+      // Note: the user-supplied query is intentionally not echoed into the
+      // message; the SQLite error text already pinpoints the parse failure.
       throw new Error(
-        `Transcript FTS5 query failed for "${query}": ${String(err)}. ` +
+        `Transcript FTS5 query failed: ${String(err)}. ` +
           `Use FTS5 syntax — wrap phrases in "quotes", use * for prefix, AND/OR for boolean.`,
       );
     }
@@ -263,7 +269,8 @@ export class TranscriptIndex {
     return rows.map((row) => ({
       filename: row.filename,
       session_at: row.session_at,
-      snippet: row.content.slice(0, 300),
+      // Collapse whitespace/newlines so the one-line CLI display stays clean.
+      snippet: row.snippet.replace(/\s+/g, ' ').trim(),
       rank: row.rank,
     }));
   }

--- a/src/agent/transcript-search/transcript-index.ts
+++ b/src/agent/transcript-search/transcript-index.ts
@@ -1,0 +1,305 @@
+/**
+ * Transcript search index — FTS5-backed full-text search over session transcripts.
+ *
+ * Transcripts live at `~/.afk/state/transcripts/<isoStamp>.md` (plain Markdown).
+ * This module builds and queries an SQLite FTS5 index over their content,
+ * complementing the curated fact archive in `src/agent/memory/memory-store.ts`.
+ *
+ * Design notes:
+ * - Reindex-on-demand only (no incremental indexing at session close). This is
+ *   the safest v1 choice: no hooks required, no session lifecycle coupling,
+ *   trivially correct. With 565 files at ~10-50 KB each, a full reindex takes
+ *   well under a second. If incremental becomes desirable, add a last-modified
+ *   mtime gate in a follow-up.
+ * - Standalone SQLite at `~/.afk/state/transcripts-index/index.db` — isolated
+ *   from the memory DB to avoid schema coupling.
+ * - FTS5 with `porter` tokenizer matches the memory store convention.
+ * - Query strings passed verbatim to FTS5 MATCH (callers may use FTS5 syntax
+ *   such as "exact phrase", prefix*, AND, OR). Errors from malformed queries are
+ *   caught and re-thrown as a descriptive Error.
+ * - The in-session `transcript_search` tool is deferred for v1 — the CLI
+ *   commands (`afk transcript search`, `afk transcript reindex`) are the
+ *   required surface.
+ *
+ * @module agent/transcript-search/transcript-index
+ */
+
+import Database from 'better-sqlite3';
+import type BetterSqlite3 from 'better-sqlite3';
+import { existsSync, mkdirSync, readdirSync, readFileSync } from 'fs';
+import { join, basename } from 'path';
+import { getTranscriptsDir, getAfkStateDir } from '../../paths.js';
+import { debugLog } from '../../utils/debug.js';
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const DB_FILE = 'index.db';
+const INDEX_DIR_NAME = 'transcripts-index';
+
+/**
+ * Increment when the schema changes incompatibly.
+ *
+ * v1: initial schema — `transcripts` content table + `transcripts_fts` FTS5 table.
+ */
+const SCHEMA_VERSION = 1;
+
+// Contract: SCHEMA_SQL creates the backing content table and the FTS5 virtual
+// table. The FTS5 table uses `content=transcripts` (external content mode) so
+// ranking information (via the hidden `rank` column) is available on queries.
+// `porter` tokenizer matches the memory store convention for stem-aware search.
+// Triggers keep the FTS index in sync with the content table.
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS transcripts (
+  id      INTEGER PRIMARY KEY AUTOINCREMENT,
+  -- filename is the stable key: ISO timestamp with ':' and '.' → '-'.
+  filename TEXT NOT NULL UNIQUE,
+  -- ISO-8601 timestamp recovered from the filename (no parsing of file body).
+  session_at TEXT NOT NULL,
+  -- Full raw Markdown content of the transcript file.
+  content TEXT NOT NULL
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS transcripts_fts USING fts5(
+  content,
+  content=transcripts,
+  content_rowid=id,
+  tokenize='porter'
+);
+
+CREATE TRIGGER IF NOT EXISTS transcripts_ai AFTER INSERT ON transcripts BEGIN
+  INSERT INTO transcripts_fts(rowid, content) VALUES (new.id, new.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS transcripts_ad AFTER DELETE ON transcripts BEGIN
+  INSERT INTO transcripts_fts(transcripts_fts, rowid, content) VALUES ('delete', old.id, old.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS transcripts_au AFTER UPDATE ON transcripts BEGIN
+  INSERT INTO transcripts_fts(transcripts_fts, rowid, content) VALUES ('delete', old.id, old.content);
+  INSERT INTO transcripts_fts(rowid, content) VALUES (new.id, new.content);
+END;
+
+CREATE INDEX IF NOT EXISTS idx_transcripts_session_at ON transcripts(session_at DESC);
+`;
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+/** One search hit returned by {@link searchTranscripts}. */
+export interface TranscriptSearchResult {
+  /** Basename of the transcript file, e.g. `2026-06-15T10-45-52-728Z.md`. */
+  filename: string;
+  /** ISO-8601 session timestamp recovered from the filename. */
+  session_at: string;
+  /**
+   * Leading snippet of the transcript content (first 300 chars). Callers that
+   * want the full body should read the file directly via `getTranscriptsDir()`.
+   */
+  snippet: string;
+  /** Raw FTS5 rank (lower is better). Exposed so callers can sort if needed. */
+  rank: number;
+}
+
+// ── Filename helpers ───────────────────────────────────────────────────────
+
+/**
+ * Recover an ISO-8601 datetime string from a transcript filename.
+ *
+ * Filenames use the pattern `<isoStamp>.md` where `:` and `.` in the ISO
+ * timestamp are replaced by `-` to survive plain filesystems. This reverses
+ * the transform — but only for the datetime portion, not the `.md` suffix.
+ *
+ * Example: `2026-06-15T10-45-52-728Z.md` → `2026-06-15T10:45:52.728Z`
+ */
+function filenameToIso(filename: string): string {
+  // Strip the .md suffix, then un-mangle the time portion.
+  // The date part (YYYY-MM-DD) already uses '-' legitimately; only the
+  // characters after 'T' need restoring: colons and the millisecond dot.
+  const stem = basename(filename, '.md');
+  // Pattern: after the 'T' separator, replace the first two '-' separating
+  // HH-MM-SS with ':', and the third '-' separating SS-mmm with '.'.
+  // The trailing 'Z' is preserved as-is.
+  return stem.replace(/T(\d{2})-(\d{2})-(\d{2})-(\d{3}Z)$/, 'T$1:$2:$3.$4');
+}
+
+// ── TranscriptIndex class ──────────────────────────────────────────────────
+
+export class TranscriptIndex {
+  private readonly indexDir: string;
+  private readonly transcriptsDir: string;
+  private readonly db: BetterSqlite3.Database;
+
+  constructor(indexDir?: string, transcriptsDir?: string) {
+    this.indexDir = indexDir ?? join(getAfkStateDir(), INDEX_DIR_NAME);
+    this.transcriptsDir = transcriptsDir ?? getTranscriptsDir();
+    mkdirSync(this.indexDir, { recursive: true });
+
+    this.db = new Database(join(this.indexDir, DB_FILE));
+    // Invariant: busy_timeout must be set before any schema or data operation
+    // so contended reads wait rather than fail immediately. WAL mode is set
+    // next so concurrent readers don't block the writer.
+    this.db.pragma('busy_timeout = 5000');
+    this.db.pragma('journal_mode = WAL');
+
+    const existingVersion = this.db.pragma('user_version', { simple: true }) as number;
+    if (existingVersion === 0) {
+      this.db.exec(SCHEMA_SQL);
+      this.db.pragma(`user_version = ${SCHEMA_VERSION}`);
+    } else if (existingVersion > SCHEMA_VERSION) {
+      this.db.close();
+      throw new Error(
+        `transcript index schema v${existingVersion} is newer than this build supports (v${SCHEMA_VERSION}). ` +
+          `Upgrade agent-afk or delete ${join(this.indexDir, DB_FILE)} to rebuild.`,
+      );
+    }
+    // existingVersion === SCHEMA_VERSION: no migration needed (v1 only for now).
+  }
+
+  /**
+   * Rebuild the FTS index from scratch by scanning the transcripts directory.
+   *
+   * Invariant (ordered writes): the FTS table is kept in sync with the content
+   * table via SQLite triggers — INSERT on `transcripts` automatically fires
+   * `INSERT INTO transcripts_fts`. The governing constraint is the FTS5 trigger
+   * protocol: content-table rows must be written before the FTS virtual table
+   * can be queried, because FTS5 external-content tables do not self-populate.
+   *
+   * All writes run inside a single transaction for atomicity and performance.
+   * A full reindex is used for v1 (reindex-on-demand design). Incremental
+   * indexing (mtime-gated upsert) is left for a future iteration.
+   *
+   * @returns count of transcript files indexed
+   */
+  reindex(): number {
+    if (!existsSync(this.transcriptsDir)) {
+      debugLog('transcript-index: transcripts dir does not exist, nothing to index');
+      return 0;
+    }
+
+    const files = readdirSync(this.transcriptsDir).filter((f) => f.endsWith('.md'));
+    debugLog(`transcript-index: reindexing ${files.length} transcript files`);
+
+    // Invariant (ordered operation sequence): clear the FTS index before
+    // clearing the content table. The FTS `delete` command requires the content
+    // row to still be present in the backing store; however, with external-
+    // content FTS5 we issue a full `rebuild` command after clearing, which
+    // reconstructs the FTS index from the (now-replaced) content table rows
+    // without needing the old rows. Therefore the correct order is:
+    //   1. DELETE all rows from `transcripts` (content table)
+    //   2. INSERT new rows from disk
+    //   3. Rebuild FTS index from updated content table
+    // This is done inside a transaction to ensure atomicity.
+    const doReindex = this.db.transaction(() => {
+      this.db.exec(`DELETE FROM transcripts;`);
+
+      const insert = this.db.prepare<[string, string, string]>(`
+        INSERT INTO transcripts (filename, session_at, content)
+        VALUES (?, ?, ?)
+        ON CONFLICT(filename) DO UPDATE SET session_at=excluded.session_at, content=excluded.content
+      `);
+
+      let count = 0;
+      for (const filename of files) {
+        const filePath = join(this.transcriptsDir, filename);
+        let content: string;
+        try {
+          content = readFileSync(filePath, 'utf-8');
+        } catch (err) {
+          debugLog(`transcript-index: skipping unreadable file ${filename}:`, String(err));
+          continue;
+        }
+        const sessionAt = filenameToIso(filename);
+        insert.run(filename, sessionAt, content);
+        count++;
+      }
+
+      // Rebuild the FTS index from the now-populated content table.
+      this.db.exec(`INSERT INTO transcripts_fts(transcripts_fts) VALUES('rebuild');`);
+      return count;
+    });
+
+    return doReindex() as number;
+  }
+
+  /**
+   * Search indexed transcripts for the given query string.
+   *
+   * The query is passed verbatim to SQLite FTS5 MATCH — callers may use FTS5
+   * syntax: `"exact phrase"`, `term*`, `term1 AND term2`, `term1 OR term2`.
+   * Malformed queries throw a descriptive Error (FTS5 parse error surfaced as-is).
+   *
+   * Contract:
+   * - Returns up to `limit` results, ordered by FTS5 rank (best match first).
+   * - Returns an empty array when the index is empty or no query matches.
+   * - Each result includes a 300-char snippet from the start of the document.
+   * - Callers should call {@link reindex} at least once before searching.
+   *
+   * @param query  FTS5 query string
+   * @param limit  Maximum results to return (default 10)
+   */
+  search(query: string, limit = 10): TranscriptSearchResult[] {
+    // Contract: empty or whitespace-only query returns nothing (avoids an FTS5
+    // parse error on an empty MATCH expression).
+    if (!query.trim()) return [];
+
+    const sql = `
+      SELECT t.filename, t.session_at, t.content, transcripts_fts.rank
+      FROM transcripts t
+      JOIN transcripts_fts ON transcripts_fts.rowid = t.id
+      WHERE transcripts_fts MATCH ?
+      ORDER BY transcripts_fts.rank
+      LIMIT ?
+    `;
+
+    let rows: Array<{ filename: string; session_at: string; content: string; rank: number }>;
+    try {
+      rows = this.db.prepare(sql).all(query, limit) as typeof rows;
+    } catch (err) {
+      throw new Error(
+        `Transcript FTS5 query failed for "${query}": ${String(err)}. ` +
+          `Use FTS5 syntax — wrap phrases in "quotes", use * for prefix, AND/OR for boolean.`,
+      );
+    }
+
+    return rows.map((row) => ({
+      filename: row.filename,
+      session_at: row.session_at,
+      snippet: row.content.slice(0, 300),
+      rank: row.rank,
+    }));
+  }
+
+  /**
+   * Return the count of transcripts currently in the index (0 = not yet indexed).
+   * Useful for telling users to run `afk transcript reindex` first.
+   */
+  count(): number {
+    const row = this.db.prepare('SELECT COUNT(*) as n FROM transcripts').get() as { n: number };
+    return row.n;
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+
+// ── Module-level helpers (thin wrappers for CLI use) ───────────────────────
+
+/**
+ * Open a {@link TranscriptIndex} at the default path, run the provided
+ * callback, then close the DB — ensuring the connection is always released.
+ *
+ * Contract: `fn` must be synchronous. The DB is closed unconditionally in a
+ * `finally` block regardless of whether `fn` throws.
+ */
+export function withTranscriptIndex<T>(
+  fn: (idx: TranscriptIndex) => T,
+  indexDir?: string,
+  transcriptsDir?: string,
+): T {
+  const idx = new TranscriptIndex(indexDir, transcriptsDir);
+  try {
+    return fn(idx);
+  } finally {
+    idx.close();
+  }
+}

--- a/src/cli/commands/transcript.test.ts
+++ b/src/cli/commands/transcript.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for the `afk transcript search --limit` normalization helper.
+ *
+ * @module cli/commands/transcript.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normalizeLimit, MAX_SEARCH_LIMIT } from './transcript.js';
+
+describe('normalizeLimit', () => {
+  it('returns the parsed value for a valid positive integer', () => {
+    expect(normalizeLimit('5')).toBe(5);
+    expect(normalizeLimit('1')).toBe(1);
+  });
+
+  it('falls back to the default (10) for zero', () => {
+    expect(normalizeLimit('0')).toBe(10);
+  });
+
+  it('falls back to the default (10) for negative values', () => {
+    expect(normalizeLimit('-5')).toBe(10);
+  });
+
+  it('falls back to the default (10) for non-numeric input', () => {
+    expect(normalizeLimit('abc')).toBe(10);
+  });
+
+  it('falls back to the default (10) for empty input', () => {
+    expect(normalizeLimit('')).toBe(10);
+  });
+
+  it('caps values above MAX_SEARCH_LIMIT', () => {
+    expect(normalizeLimit(String(MAX_SEARCH_LIMIT + 50))).toBe(MAX_SEARCH_LIMIT);
+    expect(normalizeLimit('999999999')).toBe(MAX_SEARCH_LIMIT);
+  });
+
+  it('returns MAX_SEARCH_LIMIT exactly at the cap', () => {
+    expect(normalizeLimit(String(MAX_SEARCH_LIMIT))).toBe(MAX_SEARCH_LIMIT);
+  });
+
+  it('honors a custom fallback for invalid input', () => {
+    expect(normalizeLimit('nope', 25)).toBe(25);
+  });
+
+  it('uses parseInt leading-integer semantics for mixed input', () => {
+    expect(normalizeLimit('7abc')).toBe(7);
+  });
+});

--- a/src/cli/commands/transcript.ts
+++ b/src/cli/commands/transcript.ts
@@ -1,0 +1,105 @@
+/**
+ * CLI subcommands for searching and indexing session transcripts.
+ *
+ * Transcripts are autosaved Markdown files under `~/.afk/state/transcripts/`.
+ * This command exposes an SQLite FTS5 full-text index over their content as a
+ * high-recall complement to the curated fact archive (`memory_search`).
+ *
+ * Subcommands:
+ *   afk transcript search <query>   — search indexed transcripts via FTS5
+ *   afk transcript reindex          — build/rebuild the FTS5 index from disk
+ *
+ * Design notes (v1):
+ * - The index is reindex-on-demand only. Incremental indexing at session close
+ *   is deferred for a follow-up (it would require session lifecycle coupling
+ *   and the mtime-gate logic, which adds risk for minimal v1 gain).
+ * - The in-session `transcript_search` tool is also deferred for v1 — it would
+ *   require wiring into the tool registry, which is heavier and riskier than
+ *   the CLI surface. The CLI commands are the v1 required deliverable.
+ * - Query strings are passed verbatim to FTS5 MATCH. Callers may use FTS5
+ *   syntax: "exact phrase", term*, AND, OR.
+ *
+ * @module cli/commands/transcript
+ */
+
+import { Command } from 'commander';
+import { handleCommandError } from '../errors/index.js';
+import { withTranscriptIndex } from '../../agent/transcript-search/transcript-index.js';
+
+// ── Command registration ────────────────────────────────────────────────────
+
+export function registerTranscriptCommand(program: Command): void {
+  const transcript = program
+    .command('transcript')
+    .description(
+      'Search and index session transcripts.\n' +
+        'Transcripts are autosaved at ~/.afk/state/transcripts/.\n' +
+        'Run `afk transcript reindex` once before searching.',
+    );
+
+  // ── afk transcript reindex ────────────────────────────────────────────────
+
+  transcript
+    .command('reindex')
+    .description(
+      'Build (or rebuild) the FTS5 full-text index from all transcript files on disk.\n' +
+        'Safe to run repeatedly — replaces the index atomically.',
+    )
+    .action(async () => {
+      try {
+        const count = withTranscriptIndex((idx) => idx.reindex());
+        process.stdout.write(`Indexed ${count} transcript${count === 1 ? '' : 's'}.\n`);
+      } catch (err) {
+        handleCommandError(err);
+      }
+    });
+
+  // ── afk transcript search <query> ─────────────────────────────────────────
+
+  transcript
+    .command('search <query>')
+    .description(
+      'Search indexed transcripts via FTS5 full-text search.\n' +
+        'Supports FTS5 syntax: "exact phrase", term*, AND, OR.\n' +
+        'Run `afk transcript reindex` first to build the index.',
+    )
+    .option('-n, --limit <number>', 'Maximum results to return', '10')
+    .action(async (query: string, options: { limit: string }) => {
+      try {
+        const limit = Math.max(1, parseInt(options.limit, 10) || 10);
+
+        const results = withTranscriptIndex((idx) => {
+          const count = idx.count();
+          if (count === 0) {
+            return { empty: true as const, results: [] };
+          }
+          return { empty: false as const, results: idx.search(query, limit) };
+        });
+
+        if (results.empty) {
+          process.stdout.write(
+            'No transcripts indexed yet. Run `afk transcript reindex` first.\n',
+          );
+          return;
+        }
+
+        if (results.results.length === 0) {
+          process.stdout.write(`No results for "${query}".\n`);
+          return;
+        }
+
+        for (const hit of results.results) {
+          // Format: timestamp header + first line of snippet
+          const date = hit.session_at.replace('T', ' ').slice(0, 19);
+          const firstLine = hit.snippet.split('\n').find((l) => l.trim().length > 0) ?? '';
+          process.stdout.write(`${date}  ${hit.filename}\n  ${firstLine.trim()}\n\n`);
+        }
+        process.stdout.write(
+          `${results.results.length} result${results.results.length === 1 ? '' : 's'} ` +
+            `(use FTS5 syntax for advanced queries: "exact phrase", term*, AND, OR)\n`,
+        );
+      } catch (err) {
+        handleCommandError(err);
+      }
+    });
+}

--- a/src/cli/commands/transcript.ts
+++ b/src/cli/commands/transcript.ts
@@ -26,6 +26,24 @@ import { Command } from 'commander';
 import { handleCommandError } from '../errors/index.js';
 import { withTranscriptIndex } from '../../agent/transcript-search/transcript-index.js';
 
+// ── Limit normalization ─────────────────────────────────────────────────────
+
+/** Largest result count `afk transcript search --limit` will honor. */
+export const MAX_SEARCH_LIMIT = 1000;
+
+/**
+ * Normalize the raw `--limit` CLI string to a sane, bounded integer.
+ *
+ * Invalid or non-positive input (NaN, 0, negatives, empty) falls back to
+ * `fallback` (default 10); values above {@link MAX_SEARCH_LIMIT} are capped so a
+ * pathological `--limit` cannot push an unbounded value into the SQL `LIMIT`.
+ */
+export function normalizeLimit(raw: string, fallback = 10): number {
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+  return Math.min(parsed, MAX_SEARCH_LIMIT);
+}
+
 // ── Command registration ────────────────────────────────────────────────────
 
 export function registerTranscriptCommand(program: Command): void {
@@ -63,10 +81,10 @@ export function registerTranscriptCommand(program: Command): void {
         'Supports FTS5 syntax: "exact phrase", term*, AND, OR.\n' +
         'Run `afk transcript reindex` first to build the index.',
     )
-    .option('-n, --limit <number>', 'Maximum results to return', '10')
+    .option('-n, --limit <number>', `Maximum results to return (1-${MAX_SEARCH_LIMIT})`, '10')
     .action(async (query: string, options: { limit: string }) => {
       try {
-        const limit = Math.max(1, parseInt(options.limit, 10) || 10);
+        const limit = normalizeLimit(options.limit);
 
         const results = withTranscriptIndex((idx) => {
           const count = idx.count();
@@ -89,10 +107,9 @@ export function registerTranscriptCommand(program: Command): void {
         }
 
         for (const hit of results.results) {
-          // Format: timestamp header + first line of snippet
+          // Format: timestamp + filename, then the matching excerpt (FTS5 snippet).
           const date = hit.session_at.replace('T', ' ').slice(0, 19);
-          const firstLine = hit.snippet.split('\n').find((l) => l.trim().length > 0) ?? '';
-          process.stdout.write(`${date}  ${hit.filename}\n  ${firstLine.trim()}\n\n`);
+          process.stdout.write(`${date}  ${hit.filename}\n  ${hit.snippet}\n\n`);
         }
         process.stdout.write(
           `${results.results.length} result${results.results.length === 1 ? '' : 's'} ` +

--- a/src/cli/commands/transcript.ts
+++ b/src/cli/commands/transcript.ts
@@ -65,8 +65,12 @@ export function registerTranscriptCommand(program: Command): void {
     )
     .action(async () => {
       try {
-        const count = withTranscriptIndex((idx) => idx.reindex());
-        process.stdout.write(`Indexed ${count} transcript${count === 1 ? '' : 's'}.\n`);
+        const { indexed, skipped } = withTranscriptIndex((idx) => idx.reindex());
+        const skippedNote =
+          skipped > 0 ? ` (${skipped} skipped — run with DEBUG=1 for details)` : '';
+        process.stdout.write(
+          `Indexed ${indexed} transcript${indexed === 1 ? '' : 's'}${skippedNote}.\n`,
+        );
       } catch (err) {
         handleCommandError(err);
       }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -71,6 +71,7 @@ import { registerServiceCommand } from './commands/service.js';
 import { registerBrowserCommand } from './commands/browser.js';
 import { registerImproveCommand } from './commands/improve.js';
 import { registerShellInitCommand } from './commands/shell-init.js';
+import { registerTranscriptCommand } from './commands/transcript.js';
 import { setInteractiveUpdateNotices } from './commands/interactive.js';
 import { loadConfig, loadCredential } from './config.js';
 import { providerForModel } from '../agent/providers/index.js';
@@ -123,6 +124,7 @@ registerServiceCommand(program);
 registerBrowserCommand(program);
 registerImproveCommand(program);
 registerShellInitCommand(program);
+registerTranscriptCommand(program);
 
 // Add aliases
 program.commands.find((c) => c.name() === 'chat')?.alias('c');


### PR DESCRIPTION
## Summary
Adds SQLite **FTS5** full-text search over session transcripts as a high-recall complement to the curated fact archive (`memory_search`). You can now search raw conversation history: `afk transcript search <query>`.

Why: transcripts were already written to `~/.afk/state/transcripts/*.md` but were never searchable — `memory_search` only covers the curated fact archive (high precision, low recall). This closes the recall gap ("what did we discuss/decide N sessions ago").

## What changed
- **New `src/agent/transcript-search/transcript-index.ts`** — `TranscriptIndex` over a standalone FTS5 DB at `~/.afk/state/transcripts-index/index.db`; `reindex()` (transactional full scan of the transcripts dir), `search(query, limit)` (FTS5 MATCH, porter tokenizer → filename + ISO `session_at` + snippet + rank), `withTranscriptIndex()` RAII helper.
- **New `src/agent/transcript-search/transcript-index.test.ts`** — 21 tests (reindex, term/phrase/no-match/empty/limit/snippet/invalid-syntax/escaping, RAII).
- **New `src/cli/commands/transcript.ts`** — `afk transcript reindex` + `afk transcript search <query> [--limit]`.
- **`src/cli/index.ts`** — registers the `transcript` command.

Additive only: 4 files, ~805 insertions; the existing memory/fact system is untouched.

## Design choices & deferrals
- **Reindex-on-demand** (not incremental at session close) — full reindex is ~50ms on ~560 files; no session-lifecycle coupling needed for v1.
- **Standalone index DB**, isolated from `memory.db` (no schema coupling).
- **In-session `transcript_search` tool deferred** — the CLI is the v1 surface; wiring a tool into the dispatcher is heavier/riskier. Natural follow-up.
- **No new runtime deps** (reuses `better-sqlite3`).

## Testing (independently verified by the orchestrator, not just the author)
- `pnpm lint` (`tsc --noEmit`): **clean**.
- New tests: **21/21 pass**.
- Existing sqlite-backed memory tests: **63/63 pass** (confirms no env/regression issue).
- End-to-end smoke: `afk transcript reindex` → "Indexed 566 transcripts"; `afk transcript search "session" --limit 3` → ranked results with timestamps + snippets.

---
🤖 Built in an isolated git worktree via a delegated subagent (mint methodology); diff + tests + end-to-end behavior verified by the orchestrator before this PR was opened.
