### PR TITLE
style(cli): lowercase bypass chip + drop redundant model from REPL caret

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Aliases: `afk c` → `chat`, `afk i` → `interactive`, `afk s` → `status`.
 **To re-enable path containment**, set the mode back any of these ways:
 
 - Persistently: `afk config set permissionMode default` (or `plan`), or `"permissionMode": "default"` in `afk.config.json`. It stays that way until you change it again.
-- For one session: `/bypass off` in the REPL (the status line clears `⚠ BYPASS`).
+- For one session: `/bypass off` in the REPL (the status line clears `⚡ bypass`).
 
 With containment on (`default`), a file tool (read/write/edit/list/glob/grep) targeting a path *outside* the session's working directory triggers a **path-approval** prompt; pre-authorize paths with `/allow-dir <path>` (or answer "persist" at the prompt to remember them across sessions). Toggle bypass live anytime with `/bypass`. `afk daemon` always runs in bypass (no human to prompt); **Telegram** sessions stay contained (`default`) and rely on hook-based enforcement.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,7 +126,7 @@ Permission mode `'default'` runs tools without a per-tool approval prompt, but a
 
 - Skips path-approval prompts; disables out-of-root containment
 - Allows fully automated workflows
-- Enable with `/bypass` in the REPL (status line shows `⚠ BYPASS`)
+- Enable with `/bypass` in the REPL (status line shows `⚡ bypass`)
 - Does **not** affect `ask_question` (the model asking you a question is a separate axis)
 
 ### Default mode by surface

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -185,7 +185,7 @@ export async function runInputLoop(
         // readLine echo path so scrollback parity holds).
         const queued = seedBuffer;
         seedBuffer = undefined;
-        const prompt = buildPrompt(ctx.stats.model, ctx.stats.permissionMode);
+        const prompt = buildPrompt(ctx.stats.permissionMode);
         const echo = formatSubmittedEcho({
           buffer: queued.text,
           promptText: prompt,
@@ -201,7 +201,7 @@ export async function runInputLoop(
         // on non-TTY surfaces. Shift+Tab and onSigint are wired ONCE at
         // armCompositor time (above) — no need to re-pass per-call.
         const result = await surface.readLine({
-          promptFn: () => buildPrompt(ctx.stats.model, ctx.stats.permissionMode),
+          promptFn: () => buildPrompt(ctx.stats.permissionMode),
           onSigint: sigintHandler,
           onShiftTab: () => {
             // Shift+Tab is the keyboard speed lane: it advances the permission-
@@ -497,7 +497,7 @@ export async function runInputLoop(
         // by armCompositor and the renderer's borrow skips this branch
         // — passing them anyway is a defensive belt-and-suspenders for
         // surfaces that haven't armed (e.g. a future test path).
-        surface.toRunTurnRefs(buildPrompt(ctx.stats.model, ctx.stats.permissionMode)),
+        surface.toRunTurnRefs(buildPrompt(ctx.stats.permissionMode)),
       );
     }
 }

--- a/src/cli/commands/interactive/repl-loop-shared.ts
+++ b/src/cli/commands/interactive/repl-loop-shared.ts
@@ -56,8 +56,12 @@ export interface TurnState {
   requestSoftStop?: (() => void) | null;
 }
 
-export function buildPrompt(model: string, mode: PermissionMode): string {
-  const base = palette.brand('afk') + palette.dim(` (${model})`);
+export function buildPrompt(mode: PermissionMode): string {
+  // The model name lives only in the persistent status line (status-line.ts,
+  // a never-drop field) — the caret carries just the brand + the non-default
+  // permission-mode chip (the gate-check worth confirming at the cursor), so
+  // model + mode aren't redundantly stacked two lines apart.
+  const base = palette.brand('afk');
   const marker =
     mode === 'plan' ? palette.warning(' ● plan') :
     mode === 'autonomous' ? palette.info(' ◐ AFK') :

--- a/src/cli/commands/interactive/surface-setup.ts
+++ b/src/cli/commands/interactive/surface-setup.ts
@@ -93,7 +93,7 @@ export async function setupSurface(
   // The caller's try block wraps this call so a rejection from armCompositor
   // still reaches the finally and surface.dispose() cleans up raw-mode stdin.
   await surface.armCompositor({
-    promptFn: () => buildPrompt(ctx.stats.model, ctx.stats.permissionMode),
+    promptFn: () => buildPrompt(ctx.stats.permissionMode),
     // Stable cancel handler for both idle (between turns) and streaming
     // (mid-turn). handleSigint internally dispatches on `turnInFlight`:
     //   - In flight: session.interrupt() + arm "press Ctrl+C again to exit".

--- a/src/cli/palette.ts
+++ b/src/cli/palette.ts
@@ -49,7 +49,7 @@ export const palette = {
   warning: chalk.yellow,
   /** Plan tone — magenta hex, used for PLAN card border + title chip. */
   plan: chalk.hex('#9F7CE0'),
-  /** Bypass tone — electric synthwave pink, bold, used for the `⚡ BYPASS` status-line chip + `/bypass` toggle (bypassPermissions mode). Deliberately reads as a "full-power / turbo unlocked" badge, NOT a caution: bypass is the default CLI mode now, so the indicator should inform at a glance without alarming. Warm-pink pairs with brand orange (sunset/synthwave) yet stays distinct from it and from plan lavender, so the chip never reads as the model name or plan mode. */
+  /** Bypass tone — electric synthwave pink, bold, used for the `⚡ bypass` status-line chip + `/bypass` toggle (bypassPermissions mode). Deliberately reads as a "full-power / turbo unlocked" badge, NOT a caution: bypass is the default CLI mode now, so the indicator should inform at a glance without alarming. Warm-pink pairs with brand orange (sunset/synthwave) yet stays distinct from it and from plan lavender, so the chip never reads as the model name or plan mode. */
   bypass: chalk.bold.hex('#FF6AC1'),
   /** Meta tone — bright-black, used for per-turn stats, dim hints, diff hunk headers, "other"/"planning" tool fallbacks, and the neutral "interrupted" verdict. */
   meta: chalk.blackBright,

--- a/src/cli/permission-mode-cycle.ts
+++ b/src/cli/permission-mode-cycle.ts
@@ -55,7 +55,7 @@ function emitCycleCopy(ctx: SlashContext, mode: CycleMode): void {
       // Plain line (not the ✓ channel) so bypass reads as a cool "full-power"
       // badge rather than a red alarm — matches the `/bypass` ON notice.
       ctx.out.line(
-        palette.bypass('⚡ BYPASS ON') +
+        palette.bypass('⚡ bypass ON') +
           palette.dim(
             ' — path-approval prompts + containment OFF; read/write any path. ' +
               '(Does not affect ask_question.)',

--- a/src/cli/slash/commands/bypass.ts
+++ b/src/cli/slash/commands/bypass.ts
@@ -29,7 +29,7 @@ import { palette } from '../../palette.js';
 import type { SlashCommand, SlashContext, SlashResult } from '../types.js';
 
 const ON_NOTICE =
-  palette.bypass('⚡ BYPASS ON') +
+  palette.bypass('⚡ bypass ON') +
   palette.dim(
     ' — full-power mode: path-approval prompts OFF; the agent can read/write ANY ' +
     'path on this machine with no confirmation. Run /bypass off to restore ' +
@@ -37,7 +37,7 @@ const ON_NOTICE =
   );
 
 const OFF_NOTICE =
-  palette.success('○ BYPASS OFF') +
+  palette.success('○ bypass OFF') +
   palette.dim(' — default permissions restored (path containment + prompts back on)');
 
 export const bypassCmd: SlashCommand = {

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -30,7 +30,7 @@ export interface StatusLineFields {
   /**
    * Current REPL permission mode. Renders a never-dropped indicator: `● plan`
    * (plan mode, warning tone), `◐ AFK` (autonomous/AFK mode, info tone), or
-   * `⚡ BYPASS` (bypassPermissions, bypass tone — a cool "full-power" badge, not
+   * `⚡ bypass` (bypassPermissions, bypass tone — a cool "full-power" badge, not
    * a caution glyph, since bypass is the default mode). `'default'` renders none.
    */
   permissionMode?: PermissionMode;
@@ -394,7 +394,7 @@ export class StatusLine {
     } else if (f.permissionMode === 'autonomous') {
       parts.push({ text: palette.info('◐ AFK') }); // never drop
     } else if (f.permissionMode === 'bypassPermissions') {
-      parts.push({ text: palette.bypass('⚡ BYPASS') }); // never drop
+      parts.push({ text: palette.bypass('⚡ bypass') }); // never drop
     }
 
     if (f.contextPct !== undefined) {


### PR DESCRIPTION
## Summary

Two small, related polish fixes to the interactive REPL chrome:

1. **Standardize the bypass chip to lowercase.** The permission-mode chip rendered inconsistently — the prompt caret showed `⚡ bypass` (lowercase) while the persistent status line showed `⚡ BYPASS` (caps). Now lowercase `bypass` everywhere, matching the existing `● plan` lowercase convention.
2. **Declutter the caret.** The model name *and* the mode chip were each shown **twice** — once in the prompt line, once in the status line, two lines apart. The prompt now drops the redundant model name; the status line stays the single source for it.

## Before → after

```
# before
afk (opus_1m) ⚡ bypass ›
… · opus_1m · ⚡ BYPASS · [▓░░] 10% 113.4k/1m · $0.00 · 25.8k tok

# after
afk ⚡ bypass ›                        ← just `afk ›` in default mode
… · opus_1m · ⚡ bypass · [▓░░] 10% 113.4k/1m · $0.00 · 25.8k tok
```

## Changes

**Casing → lowercase `bypass`** (5 render sites):
- `palette.ts` — tone doc comment
- `status-line.ts` — status chip + doc comment
- `slash/commands/bypass.ts` — `/bypass` on / off notices
- `permission-mode-cycle.ts` — Shift+Tab cycle copy

**Declutter prompt:**
- `repl-loop-shared.ts` — `buildPrompt(mode)` drops the `model` param and the `(model)` segment (+ rationale comment)
- `loop-iteration.ts`, `surface-setup.ts` — 3 call sites updated

## Why dropping the model from the prompt is safe

The status line renders the model as a **never-drop** field (`status-line.ts`), so it stays visible even on narrow terminals — the prompt copy was pure redundancy. The mode chip stays at the caret because the permission mode is the gate-check most worth confirming right where you type (it governs whether the agent can write anywhere).

## Verification

- `tsc --noEmit` clean (all `buildPrompt` call sites updated; no unused-param error under `noUnusedParameters`)
- **96 targeted CLI tests pass**: bypass (8), permission-mode-cycle (7), status-line (45), input-surface (19), compositor banner-echo (3), loop-iteration (3), repl-loop-wiring (11)
- No test asserted `buildPrompt`'s output, so none needed updating

## Notes

- Approach (`afk ⚡ bypass ›`, model dropped, chip kept) was stress-tested against three alternatives (drop chip too / move model out of the status line / merge the loop-phase strip) — this one won on goal-fit + minimal blast radius.
