### PR TITLE
fix(cli): bottom-pin the input frame on a fresh session

### DIFF
--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -144,36 +144,28 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   const extraRows = self.scrollRegion?.getExtraRows() ?? 0;
   // Invariant (one geometry per commit): the room/scroll/band math below must
   // measure the frame at the position Phase 2's repaint will ACTUALLY use.
-  // Frame placement runs in two regimes (terminal-compositor.frame.ts ~236):
-  // banner-following while `hasBanner && !commitInFlight` (idle frame sits
-  // just below the banner / band), bottom-anchored during a commit. With a
-  // banner and an EMPTY band the idle frame banner-follows at ~anchorRow, so
-  // capturing prevTopRow from that regime reports zero above-frame room and
-  // misroutes the commit into the overflow path — Phase 1 then "archives" the
-  // block ON SCREEN at anchorFloor (an untracked orphan, not scrollback),
-  // Phase 3 paints a second copy at anchorFloor while recording the band at
-  // the bottom-anchored rows, and the next commit's merge repaints a third —
-  // the first-turn "echo first line duplicated + card body lost" bug. Flip
-  // into the commit regime FIRST (clear the banner-followed frame, repaint at
-  // the bottom-anchored position) so every phase sees one geometry. Band
-  // non-empty ⇒ contentFloor = committedBandBottomRow keeps idle placement
-  // bottom-consistent already ⇒ skip (no extra clear/repaint flicker on the
-  // steady-state per-commit path). repositionCommittedBand is suppressed
-  // under commitInFlight (committed-band-repin.ts:72) and the band is empty
-  // here anyway; commitInFlight is re-set below and reset at Phase 3's end.
-  if (self.anchorRow !== undefined && self.anchorRow > 1 && self.committedBand.length === 0) {
-    self.commitInFlight = true;
-    self.logUpdate.clear(extraRows);
-    self.repaint();
-  }
+  // Frame placement now runs in a SINGLE regime — the input frame is always
+  // bottom-anchored (terminal-compositor.frame.ts: targetBottomRow ===
+  // absoluteBottom), idle and during a commit alike — so the idle frame's
+  // prevTopRow captured below already reflects exactly where Phase 2 will
+  // re-render it. No regime-sync clear/repaint is needed before capturing it.
+  //
+  // History: a "content-following" regime used to banner-follow the idle frame
+  // up to ~anchorRow while the band was empty. Capturing prevTopRow from that
+  // regime reported zero above-frame room and misrouted the FIRST commit into
+  // the overflow path (Phase 1 archived the block on-screen at anchorFloor as
+  // an untracked orphan, Phase 3 painted a second copy, the next commit's merge
+  // a third — the first-turn "echo first line duplicated + card body lost"
+  // bug). The guard for it was a pre-commit `clear()+repaint()` that flipped
+  // into the bottom-anchored regime first. Unconditional bottom-pinning removed
+  // the content-following regime entirely, so that guard is obsolete and gone.
   // Decide where the committed text is written so it lands in scrollback
   // EXACTLY ONCE. Capture the live frame's top row BEFORE clear() resets it:
   // every frame mutation (setOverlay, setSpinner, keypress) repaints
-  // synchronously — and the regime-sync above re-ran placement for the
-  // banner-followed case — so `topRow` reflects the frame Phase 2's repaint
-  // will reproduce. `capacity` is the number of rows available to DISPLAY
-  // committed text above the frame, between the pre-arm content ceiling
-  // (anchorRow) and the frame top.
+  // synchronously, so `topRow` reflects the frame Phase 2's repaint will
+  // reproduce. `capacity` is the number of rows available to DISPLAY committed
+  // text above the frame, between the pre-arm content ceiling (anchorRow) and
+  // the frame top.
   const prevTopRow = self.logUpdate.topRow ?? 0;
   const frameTop = prevTopRow > 1 ? prevTopRow : Math.max(1, rows - 1 - extraRows);
   const anchorFloor = Math.max(self.anchorRow ?? 1, 1);

--- a/src/cli/terminal-compositor.frame.ts
+++ b/src/cli/terminal-compositor.frame.ts
@@ -212,37 +212,28 @@ export function repaint(self: FrameHost): void {
   // hard upper bound for targetBottomRow in ALL branches below.
   const absoluteBottom = Math.max(1, (self.stdout.rows ?? 24) - 1 - extraRows);
   const frame = frameLines.join('\n');
-  // Invariant: content-following placement fires only when ALL conditions hold:
-  //   1. A pre-arm banner is declared (anchorRow > 1). Banner occupies rows
-  //      1..(anchorRow-1); the frame should start at anchorRow+physicalRows-1
-  //      on tall terminals so it is adjacent to the banner instead of floating
-  //      far below it. Without a banner the frame is unconditionally bottom-
-  //      pinned — all resize-ghost, shrink-gap, and scrollback-gap invariants
-  //      (which assume bottom-pinned frames on no-banner sessions) are preserved.
-  //   2. commitInFlight is false. During Phase 2 of commitAbove the frame must
-  //      render at absoluteBottom so Phase 3 can place committed text in the
-  //      above-frame region at anchorRow..(newTopRow-1). Banner-following during
-  //      Phase 2 would move the frame to ~anchorRow, leaving Phase 3 no room to
-  //      write outside the banner zone (textStartRow would equal anchorRow,
-  //      causing the Phase 3 loop to fire 0 iterations and dropping the commit).
+  // Invariant: the input frame is ALWAYS bottom-pinned (targetBottomRow ===
+  // absoluteBottom), on a fresh session and after every commit alike. The
+  // input line is the last frameLines entry, so it sits on absoluteBottom; the
+  // dropdown / hint / streaming overlay grow UPWARD into the empty viewport
+  // above it ("input pinned, content rises") without ever shifting the row the
+  // user types on. This is what makes opening the slash-command menu on a
+  // brand-new session leave the prompt put instead of shoving it down to make
+  // headroom.
   //
-  // contentFloor = max(anchorRow, committedBandBottomRow):
-  //   • anchorRow (not anchorRow-1) is the minimum floor so the frame top lands
-  //     at anchorRow+1, giving Phase 3 exactly one row at anchorRow for text.
-  //   • committedBandBottomRow grows as commits accumulate, naturally marching
-  //     the frame down until contentFloor + physicalRows ≥ absoluteBottom, at
-  //     which point targetBottomRow = absoluteBottom (identical to old path).
-  const hasBanner = self.anchorRow !== undefined && self.anchorRow > 1;
-  let targetBottomRow: number;
-  if (hasBanner && !self.commitInFlight) {
-    const physicalRows = self.logUpdate.measure
-      ? self.logUpdate.measure(frame, absoluteBottom).lineCount
-      : Math.max(1, frameLines.length);
-    const contentFloor = Math.max(self.anchorRow!, self.committedBandBottomRow);
-    targetBottomRow = Math.min(absoluteBottom, contentFloor + physicalRows);
-  } else {
-    targetBottomRow = absoluteBottom;
-  }
+  // History: this used to be a two-regime placement — "content-following"
+  // (frame pinned just below the banner at min(absoluteBottom,
+  // max(anchorRow, committedBandBottomRow) + physicalRows)) while idle with a
+  // banner, bottom-anchored only during a commit or once enough committed
+  // content had marched the frame to the floor. The side effect was that on a
+  // fresh session the prompt sat one row under the banner with no room above
+  // it, so opening the completion dropdown grew physicalRows and pushed the
+  // whole frame DOWN. Unconditional bottom-pinning removes that regime; the
+  // banner is still protected as a ceiling by the anchorRow floor in
+  // frame-preserve.ts / committed-band-repin.ts, and committed text still lands
+  // in the above-frame region — it just accumulates upward from the bottom
+  // (newest hugging the input) instead of downward from the banner.
+  const targetBottomRow = absoluteBottom;
   // Anchor-row enforcement: when an upper-bound was supplied (typically by
   // the surface that knows how many rows the welcome banner / update-
   // notice consumed before arm), make sure the frame's top row does not

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -5163,21 +5163,26 @@ describe('TerminalCompositor — background-status-bar coexistence', () => {
   });
 });
 
-describe('TerminalCompositor — content-following placement', () => {
-  // These tests verify the content-following behaviour introduced to eliminate
-  // the blank-row gap that appeared on tall terminals between a welcome banner
-  // and the live input frame.
+describe('TerminalCompositor — input bottom-pin placement', () => {
+  // These tests verify that the live input frame is ALWAYS bottom-pinned
+  // (targetBottomRow === absoluteBottom) — on a fresh session, with or without
+  // a banner, and after any number of commits.
   //
-  // Core invariant: content-following fires ONLY when anchorRow > 1 (a pre-arm
-  // banner is declared) AND commitInFlight is false (not inside Phase 2 of
-  // commitAbove). Without a banner the frame is always unconditionally
-  // bottom-pinned — all resize-ghost, shrink-gap, and scrollback-gap invariants
-  // assume this and are preserved. The banner case uses
-  //   contentFloor = max(anchorRow, committedBandBottomRow)
-  //   targetBottomRow = min(absoluteBottom, contentFloor + physicalRows)
-  // so the frame starts just below the banner and marches down as committed
-  // content accumulates, reaching absoluteBottom once the band fills the
-  // viewport (at which point the path is identical to the old bottom-pin).
+  // Core invariant: the input line is the last frameLines entry and always
+  // lands on absoluteBottom (rows-1-extraRows); the dropdown / hint / streaming
+  // overlay grow UPWARD into the empty viewport above it. This is what lets the
+  // slash-command completion menu open on a brand-new session without shoving
+  // the prompt down to make headroom.
+  //
+  // History: this used to be a two-regime "content-following" placement — the
+  // frame pinned just below the banner at
+  //   targetBottomRow = min(absoluteBottom, max(anchorRow, committedBandBottomRow) + physicalRows)
+  // while idle with a banner, marching down to absoluteBottom only as committed
+  // content accumulated. That left a fresh-session prompt one row under the
+  // banner with no headroom, so opening the dropdown grew physicalRows and
+  // pushed the whole frame down. The regime was removed in favour of
+  // unconditional bottom-pinning; the banner is still protected as a ceiling by
+  // the anchorRow floor (frame-preserve.ts / committed-band-repin.ts).
 
   let stdout: MockStdout;
   let stdin: MockStdin;
@@ -5190,8 +5195,8 @@ describe('TerminalCompositor — content-following placement', () => {
   });
 
   it('cold start: no banner, no content — frame stays bottom-pinned', async () => {
-    // Before any commit and without a banner, the content-following branch is
-    // inactive. The frame must land at the standard bottom row (rows-1).
+    // Before any commit and without a banner, the frame must land at the
+    // standard bottom row (rows-1).
     stdout.rows = 70;
     const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), promptText: '> ' });
     await c.arm();
@@ -5201,17 +5206,14 @@ describe('TerminalCompositor — content-following placement', () => {
     c.disarm();
   });
 
-  it('tall terminal + banner: frame follows committed content instead of unconditional bottom-pin', async () => {
-    // Core fix: rows=70, anchorRow=15 (14-row welcome banner). When the
-    // committed band is at a low row (far above absoluteBottom=69), the next
-    // standalone repaint must use content-following rather than bottom-pinning.
-    //
-    // Patch committedBandBottomRow=16 to simulate the state after a small
-    // number of commits (band near the banner). Content-following:
-    //   contentFloor = max(anchorRow=15, committedBandBottomRow=16) = 16
-    //   physicalRows = 3 (overlay + gap + input)
-    //   targetBottomRow = min(absoluteBottom=69, 16+3) = 19
-    // Frame lands at rows 17-19, not row 69 — the gap is gone.
+  it('tall terminal + banner: frame stays bottom-pinned (no content-following) so the dropdown has headroom', async () => {
+    // Regression guard for the fresh-session dropdown-jump fix: rows=70,
+    // anchorRow=15 (14-row welcome banner). Even with a small committed band
+    // sitting near the banner (committedBandBottomRow=16, far above
+    // absoluteBottom=69), the next standalone repaint must bottom-pin the input
+    // frame — NOT follow the content up to ~row 19. Bottom-pinning is what
+    // leaves the empty viewport above the prompt for the completion dropdown to
+    // grow into without shoving the input down.
     stdout.rows = 70;
     const c2 = new TerminalCompositor({
       stdout, stdin, onCancel: vi.fn(), promptText: '> ',
@@ -5237,18 +5239,19 @@ describe('TerminalCompositor — content-following placement', () => {
     writes.clear();
     c2.setOverlay('FOLLOW_TEST');
     const out2 = writes.all();
-    // Frame must NOT be at row 69 (the old unconditional bottom-pin).
-    expect(out2).not.toContain('\x1b[69;1H');
+    // Input frame must land at absoluteBottom = row 69 (70-1), NOT follow the
+    // band up to ~row 19.
+    expect(out2).toContain('\x1b[69;1H');
     // The overlay text must appear in the output (frame rendered).
     expect(out2).toContain('FOLLOW_TEST');
     c2.disarm();
   });
 
   it('no-banner session: frame stays bottom-pinned regardless of committed content', async () => {
-    // Without a banner (anchorRow undefined or ≤1), the content-following path
-    // is never taken. The frame is always at absoluteBottom = rows-1-extraRows
-    // regardless of how many commits have accumulated — this preserves all
-    // resize-ghost, shrink-gap, and scrollback-gap invariants.
+    // Without a banner (anchorRow undefined or ≤1) the frame is always at
+    // absoluteBottom = rows-1-extraRows regardless of how many commits have
+    // accumulated — this preserves all resize-ghost, shrink-gap, and
+    // scrollback-gap invariants.
     stdout.rows = 24;
     const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), promptText: '> ' });
     await c.arm();
@@ -5261,16 +5264,16 @@ describe('TerminalCompositor — content-following placement', () => {
     c.setOverlay('AFTER_COMMITS');
     const out = writes.all();
 
-    // Frame must always be at absoluteBottom = rows-1 = 23 (no banner → no
-    // content-following, regardless of committed content).
+    // Frame must always be at absoluteBottom = rows-1 = 23, regardless of
+    // committed content.
     expect(out).toContain('\x1b[23;1H');
     c.disarm();
   });
 
-  it('reserved extraRows: targetBottomRow never enters reserved rows even when following content', async () => {
+  it('reserved extraRows: targetBottomRow never enters reserved rows', async () => {
     // extraRows=2 → absoluteBottom = 24-1-2 = 21.
-    // With a banner (anchorRow=5) and committed content, content-following must
-    // still cap at absoluteBottom=21 — never write into bg-status-bar rows 22-23.
+    // With a banner (anchorRow=5) and committed content, the bottom-pinned frame
+    // must cap at absoluteBottom=21 — never write into bg-status-bar rows 22-23.
     const mockScrollRegion = {
       withFullScrollRegion<T>(fn: () => T): T { return fn(); },
       getExtraRows(): number { return 2; },
@@ -5282,7 +5285,7 @@ describe('TerminalCompositor — content-following placement', () => {
       scrollRegion: mockScrollRegion,
     });
     await c.arm();
-    // Commit enough lines so content-following would try to reach absoluteBottom.
+    // Commit enough lines to fill the viewport; the frame stays bottom-pinned.
     for (let i = 0; i < 25; i++) {
       c.commitAbove(`LINE_${i}`);
     }


### PR DESCRIPTION
## Problem

On a **fresh** interactive session, opening the slash-command / skill completion menu shoved the prompt **down** to make headroom for the dropdown, instead of the dropdown growing upward into empty space the way it does after the first message.

| | Before |
|---|---|
| Fresh session | prompt sits just **below the banner**; dropdown opening pushes it down |
| After 1st message | prompt **glued to the bottom**; dropdown grows upward (correct) |

## Root cause

The compositor used a two-regime frame placement (`terminal-compositor.frame.ts`). While *idle* with a welcome banner declared (`anchorRow > 1`), the frame "content-followed" — pinned just below the banner at

```
min(absoluteBottom, max(anchorRow, committedBandBottomRow) + physicalRows)
```

rather than at `absoluteBottom`. On a fresh session the prompt therefore sat one row under the banner with **no viewport above it**, so opening the dropdown grew `physicalRows` and pushed the whole frame down. The frame only became bottom-pinned once committed output marched it to the floor — which is exactly why the menu behaves correctly *"after the first message"*.

## Fix

Pin the input frame **unconditionally** to `absoluteBottom`. The input line is the last `frameLines` entry, so the dropdown / hint / streaming overlay now grow **upward** into the empty viewport above the prompt without ever shifting the row the user types on — identical behaviour on a fresh session and after any commit.

- The banner is still protected as a scrollback ceiling by the `anchorRow` floor (`frame-preserve.ts` / `committed-band-repin.ts`).
- Committed text still lands in the above-frame region — it just accumulates **upward from the bottom** (newest hugging the input) instead of downward from the banner.
- Also removes the now-obsolete first-commit regime-sync in `committed-band-commit.ts` whose only job was to flip the banner-followed idle frame into the bottom-anchored regime before capturing `prevTopRow`. With a single bottom-pinned regime that `clear()+repaint()` is dead, and the first-turn-banner-echo bug it guarded can no longer arise.

## Intended cosmetic consequence

On a brand-new session there is now a gap between the welcome banner (top) and the prompt (bottom) until the first turn fills it — the conventional chat-style layout, rather than banner+prompt clustered at the top.

## Tests

- Renamed the placement suite `content-following placement` → `input bottom-pin placement`; converted the one test that asserted the old follow-up behaviour into a regression guard for bottom-pinning with a banner + small band.
- `pnpm lint` clean.
- Full suite green (10045 pass / 12 skip) **except** the unrelated pre-existing `anthropic-direct.test.ts compact()` model-id failure, confirmed also failing on `main`.