### PR TITLE
feat(hooks): add UserPromptSubmit as 7th harness hook event

### DIFF
--- a/src/agent/hooks.test.ts
+++ b/src/agent/hooks.test.ts
@@ -20,6 +20,7 @@ import type {
   PreToolUseContext,
   SessionStartContext,
   SubagentStopContext,
+  UserPromptSubmitContext,
 } from './hooks.js';
 
 function sessionStartCtx(sessionId = 'sess-1'): SessionStartContext {
@@ -234,6 +235,8 @@ describe('HookContext — discriminated union narrowing', () => {
           return `pre:${ctx.toolName}`;
         case 'PostToolUse':
           return `post:${ctx.toolName}`;
+        case 'UserPromptSubmit':
+          return `ups:${ctx.prompt}`;
       }
     };
 
@@ -242,9 +245,15 @@ describe('HookContext — discriminated union narrowing', () => {
       subagentId: 'sub-1',
       status: 'succeeded',
     };
+    const ups: UserPromptSubmitContext = {
+      event: 'UserPromptSubmit',
+      prompt: 'hello from user',
+      sessionId: 's-42',
+    };
     expect(describe(stop)).toBe('sub-stop:sub-1:succeeded');
     expect(describe(preToolCtx('Edit'))).toBe('pre:Edit');
     expect(describe(sessionStartCtx('s-99'))).toBe('start:s-99');
+    expect(describe(ups)).toBe('ups:hello from user');
   });
 });
 

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -18,17 +18,22 @@
  * with the original error attached as `cause`. This prevents a bug in one
  * handler from silently skipping policy enforcement.
  *
- * **Context injection (SubagentStop only):** Foreground subagents hand their
- * final assistant output to the parent through the normal `agent` tool result;
- * `injectContext` is a separate hook-generated framework note, not text typed
- * by the human user. When a `SubagentStop` handler returns `injectContext`, the
- * dispatch result is propagated to the caller, which queues the context string
- * to the parent session's input stream for the parent's next turn. If the
- * parent is aborting, the injection is skipped. DAG/compose and background
- * paths are not guaranteed to inject (some intentionally leave this channel
- * dark), and multiple `injectContext` values do not merge today: hook dispatch
- * returns the last non-blocking decision. Other hook events ignore
- * `injectContext` entirely.
+ * **Context injection (SubagentStop and UserPromptSubmit):** Foreground
+ * subagents hand their final assistant output to the parent through the normal
+ * `agent` tool result; `injectContext` is a separate hook-generated framework
+ * note, not text typed by the human user. When a `SubagentStop` handler returns
+ * `injectContext`, the dispatch result is propagated to the caller, which queues
+ * the context string to the parent session's input stream for the parent's next
+ * turn. If the parent is aborting, the injection is skipped. DAG/compose and
+ * background paths are not guaranteed to inject (some intentionally leave this
+ * channel dark), and multiple `injectContext` values do not merge today: hook
+ * dispatch returns the last non-blocking decision.
+ *
+ * For `UserPromptSubmit`, `injectContext` works differently: the returned string
+ * is prepended to the user's prompt text before `runTurn` is called — allowing
+ * hook handlers to inject per-turn system notes or policy context inline with
+ * the human's message. The injection is performed by the REPL loop immediately
+ * after dispatch; other hook events ignore `injectContext` entirely.
  *
  * @module agent/hooks
  */
@@ -42,7 +47,8 @@ export type HarnessHookEvent =
   | 'SubagentStart'
   | 'SubagentStop'
   | 'PreToolUse'
-  | 'PostToolUse';
+  | 'PostToolUse'
+  | 'UserPromptSubmit';
 
 export interface HookDecision {
   /** False halts session lifecycle; undefined/true continues. */
@@ -52,12 +58,18 @@ export interface HookDecision {
   /** Human-readable rationale for blocking or approving. */
   reason?: string;
   /**
-   * (SubagentStop only) Framework-generated context to inject into the parent
-   * session's next turn. This is not human-authored user text. Queued to the
-   * parent's input stream after dispatch completes; dropped if the parent is
-   * aborting. DAG/compose and background paths may intentionally not inject.
-   * Multiple injected contexts currently do not merge — the last non-blocking
-   * hook decision wins. Ignored for all other hook events.
+   * (SubagentStop and UserPromptSubmit) Framework-generated context to inject.
+   *
+   * For **SubagentStop**: queued to the parent session's input stream after
+   * dispatch completes; dropped if the parent is aborting. DAG/compose and
+   * background paths may intentionally not inject. Multiple injected contexts do
+   * not merge — the last non-blocking hook decision wins.
+   *
+   * For **UserPromptSubmit**: prepended to the user's prompt text before
+   * `runTurn` is called. Allows per-turn system notes or policy context to be
+   * injected inline with the human's message.
+   *
+   * Ignored for all other hook events.
    */
   injectContext?: string;
 }
@@ -155,6 +167,22 @@ export interface PostToolUseContext {
   output?: unknown;
 }
 
+export interface UserPromptSubmitContext {
+  event: 'UserPromptSubmit';
+  /**
+   * The full text of the user's prompt at the moment it is submitted to the
+   * REPL loop, after shell injection and forward-manifest stitching but before
+   * `runTurn`. Handlers may inspect it for policy enforcement; the
+   * `injectContext` return value prepends additional context to this text.
+   */
+  prompt: string;
+  /**
+   * Session identifier, propagated from {@link SessionStats.sessionId}.
+   * Optional because early turns may not yet have one.
+   */
+  sessionId?: string;
+}
+
 /** Discriminated union — narrow via `switch (context.event)`. */
 export type HookContext =
   | SessionStartContext
@@ -162,7 +190,8 @@ export type HookContext =
   | SubagentStartContext
   | SubagentStopContext
   | PreToolUseContext
-  | PostToolUseContext;
+  | PostToolUseContext
+  | UserPromptSubmitContext;
 
 /**
  * A hook handler. `signal` is the turn/dispatch {@link AbortSignal} forwarded

--- a/src/agent/hooks/command-executor.ts
+++ b/src/agent/hooks/command-executor.ts
@@ -76,6 +76,9 @@ export async function executeCommand(
         typeof context.output === 'string' ? context.output : JSON.stringify(context.output);
     }
   }
+  if (context.event === 'UserPromptSubmit') {
+    payload['prompt'] = context.prompt;
+  }
   // transcript_path: always emit the key so hook scripts can detect it.
   // When unknown, emit null (not undefined — JSON.stringify drops undefined).
   payload['transcript_path'] = null;

--- a/src/agent/hooks/config-bridge.ts
+++ b/src/agent/hooks/config-bridge.ts
@@ -64,6 +64,7 @@ export function loadAndRegisterConfigHooks(
     'SubagentStop',
     'PreToolUse',
     'PostToolUse',
+    'UserPromptSubmit',
   ];
 
   for (const event of validEvents) {

--- a/src/agent/hooks/config-loader.ts
+++ b/src/agent/hooks/config-loader.ts
@@ -227,6 +227,7 @@ export function loadHooksConfigFile(
     'SubagentStop',
     'PreToolUse',
     'PostToolUse',
+    'UserPromptSubmit',
   ];
 
   for (const event of validEvents) {
@@ -344,6 +345,7 @@ export function loadHooksConfig(opts: LoadHooksConfigOptions = {}): LoadedHooksC
     'SubagentStop',
     'PreToolUse',
     'PostToolUse',
+    'UserPromptSubmit',
   ];
 
   for (const layer of layers) {

--- a/src/agent/hooks/user-prompt-submit.test.ts
+++ b/src/agent/hooks/user-prompt-submit.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for the UserPromptSubmit hook event.
+ *
+ * Covers:
+ * - Handler receives correct prompt + sessionId from dispatched context
+ * - Blocking handler causes registry to throw HookBlockedError with correct reason
+ * - Handler returning injectContext is reflected in the dispatch result
+ * - Config-loader: UserPromptSubmit group populates hooks result
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHookRegistry } from '../hooks.js';
+import type { UserPromptSubmitContext } from '../hooks.js';
+import { HookBlockedError } from '../../utils/errors.js';
+import { loadHooksConfigFile } from './config-loader.js';
+
+// ---------------------------------------------------------------------------
+// Registry dispatch tests
+// ---------------------------------------------------------------------------
+
+describe('UserPromptSubmit — registry dispatch', () => {
+  it('dispatches UserPromptSubmit and handler receives correct prompt and sessionId', async () => {
+    const registry = createHookRegistry();
+    const handler = vi.fn(async () => ({}));
+    registry.register('UserPromptSubmit', handler);
+
+    const ctx: UserPromptSubmitContext = {
+      event: 'UserPromptSubmit',
+      prompt: 'explain recursion',
+      sessionId: 'sess-1',
+    };
+
+    await registry.dispatch(ctx);
+
+    expect(handler).toHaveBeenCalledOnce();
+    const [calledCtx] = handler.mock.calls[0]!;
+    expect((calledCtx as UserPromptSubmitContext).prompt).toBe('explain recursion');
+    expect((calledCtx as UserPromptSubmitContext).sessionId).toBe('sess-1');
+  });
+
+  it('dispatches UserPromptSubmit without sessionId (early turns)', async () => {
+    const registry = createHookRegistry();
+    const handler = vi.fn(async () => ({}));
+    registry.register('UserPromptSubmit', handler);
+
+    const ctx: UserPromptSubmitContext = {
+      event: 'UserPromptSubmit',
+      prompt: 'first prompt',
+    };
+
+    await registry.dispatch(ctx);
+
+    expect(handler).toHaveBeenCalledOnce();
+    const [calledCtx] = handler.mock.calls[0]!;
+    expect((calledCtx as UserPromptSubmitContext).sessionId).toBeUndefined();
+  });
+
+  it('blocking handler causes registry to throw HookBlockedError with correct reason', async () => {
+    const registry = createHookRegistry();
+    registry.register('UserPromptSubmit', async () => ({
+      decision: 'block' as const,
+      reason: 'blocked by policy',
+    }));
+
+    const ctx: UserPromptSubmitContext = {
+      event: 'UserPromptSubmit',
+      prompt: 'dangerous prompt',
+    };
+
+    await expect(registry.dispatch(ctx)).rejects.toBeInstanceOf(HookBlockedError);
+    await expect(registry.dispatch(ctx)).rejects.toMatchObject({
+      reason: 'blocked by policy',
+    });
+  });
+
+  it('handler returning injectContext is reflected in dispatch result', async () => {
+    const registry = createHookRegistry();
+    registry.register('UserPromptSubmit', async () => ({
+      injectContext: '[SYSTEM NOTE] Always be helpful.\n',
+    }));
+
+    const ctx: UserPromptSubmitContext = {
+      event: 'UserPromptSubmit',
+      prompt: 'what is 2+2',
+    };
+
+    const decision = await registry.dispatch(ctx);
+    expect(decision.injectContext).toBe('[SYSTEM NOTE] Always be helpful.\n');
+  });
+
+  it('handler that returns empty object does not inject context (false branch covered)', async () => {
+    const registry = createHookRegistry();
+    registry.register('UserPromptSubmit', async () => ({}));
+
+    const ctx: UserPromptSubmitContext = {
+      event: 'UserPromptSubmit',
+      prompt: 'plain prompt',
+    };
+
+    const decision = await registry.dispatch(ctx);
+    expect(decision.injectContext).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config-loader trust gate
+// ---------------------------------------------------------------------------
+
+describe('UserPromptSubmit — config-loader', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'ups-config-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function writeJson(name: string, body: unknown): string {
+    const path = join(tmp, name);
+    writeFileSync(path, JSON.stringify(body), 'utf-8');
+    return path;
+  }
+
+  it('UserPromptSubmit group populates hooks result', () => {
+    const path = writeJson('config.json', {
+      enableShellHooks: true,
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: 'echo ups', timeout_ms: 3000 }] },
+        ],
+      },
+    });
+
+    const result = loadHooksConfigFile(path, 'user-global');
+    expect(result.warnings).toEqual([]);
+    expect(result.hooks.UserPromptSubmit).toHaveLength(1);
+    expect(result.hooks.UserPromptSubmit![0]!.hooks[0]!.command).toBe('echo ups');
+    expect(result.hooks.UserPromptSubmit![0]!.hooks[0]!.timeoutMs).toBe(3000);
+  });
+
+  it('UserPromptSubmit group is ignored alongside other events when disabled', () => {
+    const path = writeJson('config.json', {
+      enableShellHooks: false,
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: 'command', command: 'echo ups' }] },
+        ],
+        SessionStart: [
+          { hooks: [{ type: 'command', command: 'echo start' }] },
+        ],
+      },
+    });
+
+    // loadHooksConfigFile still parses both (enableShellHooks is a trust gate
+    // for config-bridge, not config-loader — the loader always parses all
+    // events; the bridge decides whether to register shell handlers).
+    const result = loadHooksConfigFile(path, 'user-global');
+    expect(result.enableShellHooks).toBe(false);
+    // Both event groups are parsed regardless of enableShellHooks.
+    expect(result.hooks.UserPromptSubmit).toHaveLength(1);
+    expect(result.hooks.SessionStart).toHaveLength(1);
+  });
+});

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -762,6 +762,7 @@ export async function bootstrapSession(
     ...(cliConfig.interactive?.suggestGhost !== undefined
       ? { suggestGhostConfig: cliConfig.interactive.suggestGhost }
       : {}),
+    hookRegistry: hookRegistryBundle.registry,
   };
 
   // Trusted-skill event subscriptions — emit in-flight + completion badges

--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -112,8 +112,9 @@ import type { InteractiveCtx } from './shared.js';
 import { BackgroundAgentRegistry } from '../../../agent/background-registry.js';
 import { runTurn } from './turn-handler.js';
 import * as slashMod from '../../slash/registry.js';
+import { createHookRegistry } from '../../../agent/hooks.js';
 
-function makeCtx(): InteractiveCtx {
+function makeCtx(overrides?: Partial<InteractiveCtx>): InteractiveCtx {
   return {
     session: {
       current: {
@@ -143,6 +144,7 @@ function makeCtx(): InteractiveCtx {
     options: { thinkingUi: undefined },
     inputSurfaceRef: { current: null },
     backgroundRegistry: new BackgroundAgentRegistry({}),
+    ...overrides,
   } as unknown as InteractiveCtx;
 }
 
@@ -245,5 +247,82 @@ describe('runReplLoop — shell-passthrough dispatch branch', () => {
     expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
     const firstArg = vi.mocked(runTurn).mock.calls[0]?.[0] as { text: string };
     expect(firstArg.text).toBe('!echo hi');
+  });
+});
+
+describe('runReplLoop — UserPromptSubmit hook integration', () => {
+  it('UserPromptSubmit block hook causes loop to continue without calling runTurn', async () => {
+    const registry = createHookRegistry();
+    registry.register('UserPromptSubmit', async () => ({
+      decision: 'block' as const,
+      reason: 'test block',
+    }));
+
+    surfaceState.readLineQueue = [
+      { text: 'blocked prompt', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+
+    const ctx = makeCtx({ hookRegistry: registry });
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    // runTurn must NOT have been called — block hook short-circuits the turn.
+    expect(vi.mocked(runTurn)).not.toHaveBeenCalled();
+    // The warning message should have been written to the renderer.
+    const lines = vi.mocked(ctx.replRenderer.writeLine).mock.calls.map((c) => String(c[0]));
+    expect(lines.some((l) => l.includes('blocked by hook'))).toBe(true);
+  });
+
+  it('UserPromptSubmit injectContext hook prepends context to runText before runTurn', async () => {
+    const registry = createHookRegistry();
+    registry.register('UserPromptSubmit', async () => ({
+      injectContext: '[PREFIX] ',
+    }));
+
+    surfaceState.readLineQueue = [
+      { text: 'base prompt', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+
+    const ctx = makeCtx({ hookRegistry: registry });
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
+    const firstArg = vi.mocked(runTurn).mock.calls[0]?.[0] as { text: string };
+    expect(firstArg.text).toBe('[PREFIX] base prompt');
+  });
+
+  it('UserPromptSubmit allow (no return) hook fires and passes through to runTurn unchanged', async () => {
+    const registry = createHookRegistry();
+    const handler = vi.fn(async () => ({}));
+    registry.register('UserPromptSubmit', handler);
+
+    surfaceState.readLineQueue = [
+      { text: 'plain prompt', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+
+    const ctx = makeCtx({ hookRegistry: registry });
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
+    const firstArg = vi.mocked(runTurn).mock.calls[0]?.[0] as { text: string };
+    expect(firstArg.text).toBe('plain prompt');
+  });
+
+  it('existing tests are unaffected when no hookRegistry is set on ctx', async () => {
+    // No hookRegistry on ctx — dispatch path is skipped entirely.
+    surfaceState.readLineQueue = [
+      { text: 'normal prompt', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+
+    const ctx = makeCtx(); // no hookRegistry
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
+    const firstArg = vi.mocked(runTurn).mock.calls[0]?.[0] as { text: string };
+    expect(firstArg.text).toBe('normal prompt');
   });
 });

--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -113,6 +113,7 @@ import { BackgroundAgentRegistry } from '../../../agent/background-registry.js';
 import { runTurn } from './turn-handler.js';
 import * as slashMod from '../../slash/registry.js';
 import { createHookRegistry } from '../../../agent/hooks.js';
+import { HookHandlerTimeoutError } from '../../../agent/hook-registry.js';
 
 function makeCtx(overrides?: Partial<InteractiveCtx>): InteractiveCtx {
   return {
@@ -309,6 +310,34 @@ describe('runReplLoop — UserPromptSubmit hook integration', () => {
     expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
     const firstArg = vi.mocked(runTurn).mock.calls[0]?.[0] as { text: string };
     expect(firstArg.text).toBe('plain prompt');
+  });
+
+  it('UserPromptSubmit handler timeout fails closed — loop writes a notice and continues, does not crash', async () => {
+    // Regression (PR #280 review, finding #1): the registry re-throws
+    // HookHandlerTimeoutError raw (so dispatchSubagentStop can distinguish a
+    // timeout from a deliberate block). The REPL loop must treat it as a
+    // fail-closed block — drop the turn, write a notice, continue — rather
+    // than letting it unwind and crash the loop.
+    const registry = createHookRegistry();
+    registry.register('UserPromptSubmit', async () => {
+      throw new HookHandlerTimeoutError('UserPromptSubmit', 30_000);
+    });
+
+    surfaceState.readLineQueue = [
+      { text: 'slow prompt', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+
+    const ctx = makeCtx({ hookRegistry: registry });
+    // Must RESOLVE, not reject: before the fix the timeout propagated past the
+    // catch and this await would throw, failing the test.
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    // Turn dropped — runTurn not called for the timed-out prompt.
+    expect(vi.mocked(runTurn)).not.toHaveBeenCalled();
+    // A notice naming the timeout was written to the renderer.
+    const lines = vi.mocked(ctx.replRenderer.writeLine).mock.calls.map((c) => String(c[0]));
+    expect(lines.some((l) => l.includes('blocked by hook') && l.includes('timed out'))).toBe(true);
   });
 
   it('existing tests are unaffected when no hookRegistry is set on ctx', async () => {

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -1,4 +1,6 @@
 import type { ReadWithAutocompleteResult } from '../../input-box.js';
+import type { UserPromptSubmitContext } from '../../../agent/hooks.js';
+import { HookBlockedError, AbortError } from '../../../utils/errors.js';
 import { formatSubmittedEcho } from '../../input/echo.js';
 import { describeAttachmentSummary, type ImageAttachment } from '../../input/attachments.js';
 import { dispatch as dispatchSlash, parse as parseSlash } from '../../slash/registry.js';
@@ -394,6 +396,34 @@ export async function runInputLoop(
         runText = shellInjection + runText;
       }
 
+      // UserPromptSubmit hook — fires before every turn submission.
+      // Handlers may block the turn (HookBlockedError → continue loop),
+      // inject additional context (prepended to runText), or approve silently.
+      // AbortError propagates out of the loop unchanged.
+      if (ctx.hookRegistry) {
+        try {
+          const upsCtx: UserPromptSubmitContext = {
+            event: 'UserPromptSubmit',
+            prompt: runText,
+            sessionId: ctx.stats.sessionId,
+          };
+          const upsDecision = await ctx.hookRegistry.dispatch(upsCtx);
+          if (upsDecision.injectContext) {
+            runText = upsDecision.injectContext + runText;
+          }
+        } catch (err) {
+          if (err instanceof HookBlockedError) {
+            ctx.replRenderer.writeLine(
+              palette.warning('⊘ Turn blocked by hook') +
+                (err.reason ? palette.dim(`: ${err.reason}`) : ''),
+            );
+            ctx.statusLine.rearm();
+            continue;
+          }
+          if (err instanceof AbortError) throw err;
+          throw err;
+        }
+      }
 
       await runTurn({ text: runText, attachments }, ctx.session.current, ctx.stats, {
         setInFlight(v: boolean) { turnState.turnInFlight = v; },

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -1,6 +1,7 @@
 import type { ReadWithAutocompleteResult } from '../../input-box.js';
 import type { UserPromptSubmitContext } from '../../../agent/hooks.js';
-import { HookBlockedError, AbortError } from '../../../utils/errors.js';
+import { HookBlockedError } from '../../../utils/errors.js';
+import { HookHandlerTimeoutError } from '../../../agent/hook-registry.js';
 import { formatSubmittedEcho } from '../../input/echo.js';
 import { describeAttachmentSummary, type ImageAttachment } from '../../input/attachments.js';
 import { dispatch as dispatchSlash, parse as parseSlash } from '../../slash/registry.js';
@@ -399,7 +400,8 @@ export async function runInputLoop(
       // UserPromptSubmit hook — fires before every turn submission.
       // Handlers may block the turn (HookBlockedError → continue loop),
       // inject additional context (prepended to runText), or approve silently.
-      // AbortError propagates out of the loop unchanged.
+      // A handler timeout (HookHandlerTimeoutError) fails closed like a block;
+      // AbortError and any other throw propagate out of the loop unchanged.
       if (ctx.hookRegistry) {
         try {
           const upsCtx: UserPromptSubmitContext = {
@@ -420,7 +422,21 @@ export async function runInputLoop(
             ctx.statusLine.rearm();
             continue;
           }
-          if (err instanceof AbortError) throw err;
+          // A handler that exceeds HOOK_HANDLER_TIMEOUT_MS fails closed exactly
+          // like a deliberate block. hook-registry re-throws
+          // HookHandlerTimeoutError raw (so dispatchSubagentStop can distinguish
+          // a timeout from a block); here we drop the turn with a notice rather
+          // than letting the timeout unwind and crash the REPL loop.
+          if (err instanceof HookHandlerTimeoutError) {
+            ctx.replRenderer.writeLine(
+              palette.warning('⊘ Turn blocked by hook') +
+                palette.dim(`: handler timed out after ${err.timeoutMs}ms`),
+            );
+            ctx.statusLine.rearm();
+            continue;
+          }
+          // AbortError (Ctrl-C teardown) and every other non-block, non-timeout
+          // throw propagate out of the REPL loop unchanged.
           throw err;
         }
       }

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -1,4 +1,5 @@
 import * as readline from 'node:readline';
+import type { HookRegistry } from '../../../agent/hooks.js';
 import type { SessionRef } from '../../../agent/session-ref.js';
 import type { MemoryStore } from '../../../agent/memory/index.js';
 import type { AgentModelInput } from '../../../agent/types.js';
@@ -414,6 +415,13 @@ export interface InteractiveCtx {
    * the ghost toggle.
    */
   suggestGhostConfig?: boolean;
+  /**
+   * Hook registry wired at bootstrap. When present, the loop-iteration
+   * dispatch path fires UserPromptSubmit before each runTurn call, enabling
+   * per-prompt policy hooks (blocking, context injection). Absent in test
+   * stubs that do not exercise the hook path.
+   */
+  hookRegistry?: HookRegistry;
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds `UserPromptSubmit` as the 7th harness hook event, wired end-to-end through the existing hook infrastructure (config loader, matcher, registry, block/abort semantics). Previously the harness enumerated ~25 SDK event names in `sdk-types.ts` and had general shell-hook plumbing, but only dispatched 6 live events. This adds the highest-leverage missing one: an intercept point at the user-input boundary.

## What fires
The hook fires once per genuine user turn in the interactive REPL, after `@`-file expansion and shell-injection prepend, immediately before `runTurn` hands the message to the model. It does NOT fire for slash commands, shell passthroughs (`!`), or framework-injected context.

## Semantics
- `decision: 'block'` -> the turn is cancelled; a brief notice renders in the REPL and the loop continues
- `injectContext: 'X'` -> `X` is prepended to the prompt before the model sees it (reuses the existing `HookDecision.injectContext` field; its doc is updated to cover both SubagentStop and UserPromptSubmit)
- no handler registered -> zero-overhead pass-through
- `AbortError` always propagates; a throwing handler fails closed (blocks the turn)

## Files changed (10, +182/-20)
- `src/agent/hooks.ts` - union member, `UserPromptSubmitContext`, `HookContext` union, `injectContext` JSDoc
- `src/agent/hooks/config-loader.ts` - `UserPromptSubmit` added to both `validEvents` arrays
- `src/agent/hooks/config-bridge.ts` - `validEvents` (matcher ignored for this non-tool event, consistent with SessionStart/End)
- `src/agent/hooks/command-executor.ts` - `prompt` field in the shell-hook stdin payload
- `src/cli/commands/interactive/shared.ts` - optional `hookRegistry` on `InteractiveCtx`
- `src/cli/commands/interactive/bootstrap.ts` - wires `hookRegistry` into ctx
- `src/cli/commands/interactive/loop-iteration.ts` - dispatch call-site (block / inject / allow)
- tests: `user-prompt-submit.test.ts` (new, 7 tests), `hooks.test.ts` (narrowing arm), `loop-iteration.test.ts` (4 integration tests)

## Tests / gates
- `pnpm lint` (tsc --noEmit, strict): exit 0
- scoped vitest (6 hook/loop files): 115 passed, 0 failed
- `pnpm audit:sdk:check`: OK, no new SDK imports
- `pnpm scan:env:check`: docs in sync
- coverage of both `injectContext` branches (inject path + allow-through path) plus block and no-registry paths

Note: one unrelated pre-existing failure on `main` (`anthropic-direct.test.ts` compact() assertion) predates this branch and is untouched here.

## Scope
Frozen to `UserPromptSubmit` only. `Stop`, `PreCompact`, `PostToolUseFailure`, and the Telegram / `afk chat` / daemon surfaces are intentionally deferred to separate follow-up PRs.
