### PR TITLE
feat(hooks): add Stop as a harness hook event

### DIFF
--- a/src/agent/hooks.test.ts
+++ b/src/agent/hooks.test.ts
@@ -19,6 +19,7 @@ import type {
   HookHandler,
   PreToolUseContext,
   SessionStartContext,
+  StopContext,
   SubagentStopContext,
 } from './hooks.js';
 
@@ -234,8 +235,13 @@ describe('HookContext — discriminated union narrowing', () => {
           return `pre:${ctx.toolName}`;
         case 'PostToolUse':
           return `post:${ctx.toolName}`;
+        case 'Stop':
+          return `stop:${ctx.sessionId ?? '-'}`;
       }
     };
+
+    const stopHook: StopContext = { event: 'Stop', sessionId: 's-stop' };
+    expect(describe(stopHook)).toBe('stop:s-stop');
 
     const stop: SubagentStopContext = {
       event: 'SubagentStop',

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -42,7 +42,8 @@ export type HarnessHookEvent =
   | 'SubagentStart'
   | 'SubagentStop'
   | 'PreToolUse'
-  | 'PostToolUse';
+  | 'PostToolUse'
+  | 'Stop';
 
 export interface HookDecision {
   /** False halts session lifecycle; undefined/true continues. */
@@ -155,6 +156,17 @@ export interface PostToolUseContext {
   output?: unknown;
 }
 
+export interface StopContext {
+  event: 'Stop';
+  /** Session id from the REPL session that completed the turn. */
+  sessionId?: string;
+  /**
+   * Parent session id when this Stop fires inside a forked subagent.
+   * Top-level sessions leave this undefined.
+   */
+  parentSessionId?: string;
+}
+
 /** Discriminated union — narrow via `switch (context.event)`. */
 export type HookContext =
   | SessionStartContext
@@ -162,7 +174,8 @@ export type HookContext =
   | SubagentStartContext
   | SubagentStopContext
   | PreToolUseContext
-  | PostToolUseContext;
+  | PostToolUseContext
+  | StopContext;
 
 /**
  * A hook handler. `signal` is the turn/dispatch {@link AbortSignal} forwarded

--- a/src/agent/hooks/config-bridge.ts
+++ b/src/agent/hooks/config-bridge.ts
@@ -64,6 +64,7 @@ export function loadAndRegisterConfigHooks(
     'SubagentStop',
     'PreToolUse',
     'PostToolUse',
+    'Stop',
   ];
 
   for (const event of validEvents) {

--- a/src/agent/hooks/config-loader.ts
+++ b/src/agent/hooks/config-loader.ts
@@ -227,6 +227,7 @@ export function loadHooksConfigFile(
     'SubagentStop',
     'PreToolUse',
     'PostToolUse',
+    'Stop',
   ];
 
   for (const event of validEvents) {
@@ -344,6 +345,7 @@ export function loadHooksConfig(opts: LoadHooksConfigOptions = {}): LoadedHooksC
     'SubagentStop',
     'PreToolUse',
     'PostToolUse',
+    'Stop',
   ];
 
   for (const layer of layers) {

--- a/src/agent/hooks/stop.test.ts
+++ b/src/agent/hooks/stop.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the Stop harness hook event.
+ *
+ * Covers:
+ * - Registry fires Stop and handler receives the StopContext
+ * - config-loader accepts 'Stop' in a hooks config file
+ * - Trust-gate suppression when shell hooks are disabled
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createHookRegistry } from '../hooks.js';
+import type { StopContext, HookHandler } from '../hooks.js';
+import { loadHooksConfigFile } from './config-loader.js';
+import { loadAndRegisterConfigHooks } from './config-bridge.js';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Registry fires Stop
+// ---------------------------------------------------------------------------
+
+describe('Stop hook -- registry dispatch', () => {
+  it('fires a registered Stop handler with the correct StopContext', async () => {
+    const registry = createHookRegistry();
+    const handler = vi.fn<HookHandler>(async () => ({}));
+    registry.register('Stop', handler);
+
+    const ctx: StopContext = { event: 'Stop', sessionId: 'sess-42' };
+    await registry.dispatch(ctx);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const received = handler.mock.calls[0]?.[0] as StopContext;
+    expect(received.event).toBe('Stop');
+    expect(received.sessionId).toBe('sess-42');
+  });
+
+  it('count reflects a registered Stop handler', () => {
+    const registry = createHookRegistry();
+    expect(registry.count('Stop')).toBe(0);
+    registry.register('Stop', async () => ({}));
+    expect(registry.count('Stop')).toBe(1);
+  });
+
+  it('unsubscribe removes the Stop handler', async () => {
+    const registry = createHookRegistry();
+    const handler = vi.fn<HookHandler>(async () => ({}));
+    const unsub = registry.register('Stop', handler);
+    unsub();
+    await registry.dispatch({ event: 'Stop', sessionId: 's-1' });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('Stop handler receives parentSessionId when provided', async () => {
+    const registry = createHookRegistry();
+    const received: StopContext[] = [];
+    registry.register('Stop', async (ctx) => {
+      received.push(ctx as StopContext);
+      return {};
+    });
+
+    await registry.dispatch({
+      event: 'Stop',
+      sessionId: 'child',
+      parentSessionId: 'parent',
+    });
+
+    expect(received[0]?.parentSessionId).toBe('parent');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// config-loader accepts 'Stop'
+// ---------------------------------------------------------------------------
+
+describe('Stop hook -- config-loader', () => {
+  it('loadHooksConfigFile parses a Stop hook entry without warnings', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'stop-hook-loader-'));
+    const cfgPath = join(dir, 'afk.config.json');
+    try {
+      writeFileSync(
+        cfgPath,
+        JSON.stringify({
+          enableShellHooks: true,
+          hooks: {
+            Stop: [
+              { hooks: [{ type: 'command', command: 'echo stop' }] },
+            ],
+          },
+        }),
+      );
+
+      const result = loadHooksConfigFile(cfgPath, 'user-global');
+      expect(result.warnings).toHaveLength(0);
+      expect(result.hooks['Stop']).toBeDefined();
+      expect(result.hooks['Stop']?.[0]?.hooks[0]?.command).toBe('echo stop');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Trust-gate suppression
+// ---------------------------------------------------------------------------
+
+describe('Stop hook -- trust-gate suppression', () => {
+  it('does not register Stop handlers when userGlobalEnabled is false', () => {
+    const registry = createHookRegistry();
+    const hookConfig = {
+      hooks: {
+        Stop: [
+          {
+            hooks: [{ type: 'command' as const, command: 'echo blocked', timeoutMs: 5000 }],
+            tier: 'user-global' as const,
+          },
+        ],
+      },
+      userGlobalEnabled: false,
+      allowProjectHooks: false,
+      sources: [],
+      warnings: [],
+    };
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    loadAndRegisterConfigHooks(registry, hookConfig, {});
+    warnSpy.mockRestore();
+
+    expect(registry.count('Stop')).toBe(0);
+  });
+
+  it('registers Stop handlers when userGlobalEnabled is true', () => {
+    const registry = createHookRegistry();
+    const hookConfig = {
+      hooks: {
+        Stop: [
+          {
+            hooks: [{ type: 'command' as const, command: 'echo stop', timeoutMs: 5000 }],
+            tier: 'user-global' as const,
+          },
+        ],
+      },
+      userGlobalEnabled: true,
+      allowProjectHooks: false,
+      sources: [],
+      warnings: [],
+    };
+
+    loadAndRegisterConfigHooks(registry, hookConfig, {});
+    expect(registry.count('Stop')).toBe(1);
+  });
+});

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -70,6 +70,7 @@ export type {
   PreToolUseContext,
   SessionEndContext,
   SessionStartContext,
+  StopContext,
   SubagentHookStatus,
   SubagentStartContext,
   SubagentStopContext,

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -732,6 +732,7 @@ export async function bootstrapSession(
     ...(resumeTarget !== undefined ? { resumeTarget } : {}),
     teardownTrustedSkillEvents: undefined,  // wired below
     backgroundRegistry,
+    hookRegistry: hookRegistryBundle.registry,
     // Expose the root executor's narrow promotion seam so the turn handler can
     // make Ctrl+B background a running foreground subagent. The executor
     // implements `SubagentControl`; the keyboard layer sees only that interface.

--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -113,6 +113,8 @@ import { BackgroundAgentRegistry } from '../../../agent/background-registry.js';
 import { runTurn } from './turn-handler.js';
 import * as slashMod from '../../slash/registry.js';
 import { createHookRegistry } from '../../../agent/hooks.js';
+import { HookBlockedError } from '../../../utils/errors.js';
+import { HookHandlerTimeoutError } from '../../../agent/hook-registry.js';
 
 function makeCtx(): InteractiveCtx {
   return {
@@ -287,6 +289,83 @@ describe('runReplLoop -- Stop hook fires after runTurn completes', () => {
     await expect(
       runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn()),
     ).resolves.toBeUndefined();
+    expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates sessionId in the Stop context', async () => {
+    surfaceState.readLineQueue = [
+      { text: 'hello', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+
+    const registry = createHookRegistry();
+    const stopHandler = vi.fn(async () => ({}));
+    registry.register('Stop', stopHandler);
+
+    const ctx = makeCtx();
+    ctx.hookRegistry = registry;
+
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    const received = stopHandler.mock.calls[0]?.[0];
+    expect(received).toMatchObject({ event: 'Stop', sessionId: 'mock' });
+  });
+
+  it('renders a blocked notice and continues when a Stop handler blocks', async () => {
+    surfaceState.readLineQueue = [
+      { text: 'hello', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+
+    const registry = createHookRegistry();
+    // A handler that returns decision: 'block' triggers HookBlockedError.
+    registry.register('Stop', async () => ({ decision: 'block', reason: 'test block' }));
+
+    const ctx = makeCtx();
+    ctx.hookRegistry = registry;
+    const writerFn = vi.fn();
+    ctx.completionWriter = { fn: writerFn, idleFn: vi.fn() };
+
+    // The loop should complete (not throw) -- block is non-fatal for Stop.
+    await expect(
+      runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn()),
+    ).resolves.toBeUndefined();
+
+    // completionWriter.fn should have been called with a blocked message.
+    const writeCalls = writerFn.mock.calls.map((c: unknown[]) => c[0]);
+    expect(writeCalls.some((msg: unknown) => typeof msg === 'string' && msg.includes('blocked'))).toBe(true);
+    // runTurn ran the 'hello' turn.
+    expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a timed-out notice and continues when a Stop handler times out', async () => {
+    surfaceState.readLineQueue = [
+      { text: 'hello', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+
+    const registry = createHookRegistry();
+    // Simulate a timed-out handler by throwing HookHandlerTimeoutError directly.
+    // hook-registry.ts re-throws HookHandlerTimeoutError raw (not wrapped as
+    // HookBlockedError), so throwing it from the handler replicates the real
+    // timeout code path through dispatch().
+    registry.register('Stop', async () => {
+      throw new HookHandlerTimeoutError('Stop', 30000);
+    });
+
+    const ctx = makeCtx();
+    ctx.hookRegistry = registry;
+    const writerFn = vi.fn();
+    ctx.completionWriter = { fn: writerFn, idleFn: vi.fn() };
+
+    // The loop should complete (not throw) -- timeout is non-fatal for Stop.
+    await expect(
+      runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn()),
+    ).resolves.toBeUndefined();
+
+    // completionWriter.fn should have been called with a timed-out message.
+    const writeCalls = writerFn.mock.calls.map((c: unknown[]) => c[0]);
+    expect(writeCalls.some((msg: unknown) => typeof msg === 'string' && msg.includes('timed out'))).toBe(true);
     expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -112,6 +112,7 @@ import type { InteractiveCtx } from './shared.js';
 import { BackgroundAgentRegistry } from '../../../agent/background-registry.js';
 import { runTurn } from './turn-handler.js';
 import * as slashMod from '../../slash/registry.js';
+import { createHookRegistry } from '../../../agent/hooks.js';
 
 function makeCtx(): InteractiveCtx {
   return {
@@ -245,5 +246,47 @@ describe('runReplLoop — shell-passthrough dispatch branch', () => {
     expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
     const firstArg = vi.mocked(runTurn).mock.calls[0]?.[0] as { text: string };
     expect(firstArg.text).toBe('!echo hi');
+  });
+});
+
+describe('runReplLoop -- Stop hook fires after runTurn completes', () => {
+  it('dispatches Stop event to ctx.hookRegistry after a completed turn', async () => {
+    // One real text turn, then /exit.
+    surfaceState.readLineQueue = [
+      { text: 'hello', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+
+    const registry = createHookRegistry();
+    const stopHandler = vi.fn(async () => ({}));
+    registry.register('Stop', stopHandler);
+
+    const ctx = makeCtx();
+    ctx.hookRegistry = registry;
+
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    // runTurn fired once (the 'hello' turn).
+    expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
+    // Stop handler fired exactly once, after the turn.
+    expect(stopHandler).toHaveBeenCalledTimes(1);
+    const received = stopHandler.mock.calls[0]?.[0];
+    expect(received).toMatchObject({ event: 'Stop' });
+  });
+
+  it('does not dispatch Stop when ctx.hookRegistry is absent', async () => {
+    surfaceState.readLineQueue = [
+      { text: 'hello', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+
+    const ctx = makeCtx();
+    // hookRegistry intentionally not set
+
+    // Should not throw even with no registry.
+    await expect(
+      runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn()),
+    ).resolves.toBeUndefined();
+    expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -369,6 +369,68 @@ describe('runReplLoop -- Stop hook fires after runTurn completes', () => {
     expect(writeCalls.some((msg: unknown) => typeof msg === 'string' && msg.includes('timed out'))).toBe(true);
     expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
   });
+
+  it('sanitises escape sequences in a blocked Stop reason before rendering', async () => {
+    // SEC-1: a malicious hook reason containing ANSI escape sequences and OSC
+    // payloads must not reach the terminal unescaped — sanitizeForDisplay must
+    // strip all control sequences before the string is passed to palette.dim().
+    surfaceState.readLineQueue = [
+      { text: 'hello', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+
+    const maliciousReason = '\u001b[31mhacked\u001b[0m\u001b]0;evil-title\u0007';
+
+    const registry = createHookRegistry();
+    registry.register('Stop', async () => ({ decision: 'block', reason: maliciousReason }));
+
+    const ctx = makeCtx();
+    ctx.hookRegistry = registry;
+    const writerFn = vi.fn();
+    ctx.completionWriter = { fn: writerFn, idleFn: vi.fn() };
+
+    await expect(
+      runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn()),
+    ).resolves.toBeUndefined();
+
+    // The rendered string must contain 'blocked' (the user-visible notice still fires).
+    const writeCalls = writerFn.mock.calls.map((c: unknown[]) => c[0] as string);
+    const blockedMsg = writeCalls.find((msg) => msg.includes('blocked'));
+    expect(blockedMsg).toBeDefined();
+
+    // The raw ESC byte must have been stripped.
+    expect(blockedMsg).not.toContain('\u001b');
+    // The OSC payload text must not leak as visible output.
+    expect(blockedMsg).not.toContain('evil-title');
+    // The innocuous text content may or may not survive sanitisation depending
+    // on implementation — what matters is the control-sequence removal above.
+  });
+
+  it('dispatches Stop with the explicit 5000ms per-handler timeout', async () => {
+    // Perf-observability: Stop fires every REPL turn, so it uses
+    // STOP_HOOK_HANDLER_TIMEOUT_MS (5s) rather than the registry default (30s).
+    // Spy on dispatch (call-through) and verify the third positional arg.
+    surfaceState.readLineQueue = [
+      { text: 'hello', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+
+    const registry = createHookRegistry();
+    const dispatchSpy = vi.spyOn(registry, 'dispatch');
+
+    const ctx = makeCtx();
+    ctx.hookRegistry = registry;
+
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    // Find the dispatch call whose first argument has event === 'Stop'.
+    const stopCall = dispatchSpy.mock.calls.find(
+      (args) => (args[0] as { event?: string }).event === 'Stop',
+    );
+    expect(stopCall).toBeDefined();
+    // Third positional arg must be the explicit 5s timeout.
+    expect(stopCall?.[2]).toBe(5000);
+  });
 });
 
 describe('runReplLoop — UserPromptSubmit hook integration', () => {

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -20,6 +20,7 @@ import {
 } from '../../slash/plugin-skills.js';
 import type { InteractiveCtx } from './shared.js';
 import { formatStatusFields } from './shared.js';
+import { AbortError, HookBlockedError } from '../../../utils/errors.js';
 import type { TranscriptHandle } from './transcript.js';
 import { runTurn } from './turn-handler.js';
 import { saveSession } from '../../session-store.js';
@@ -499,5 +500,26 @@ export async function runInputLoop(
         // surfaces that haven't armed (e.g. a future test path).
         surface.toRunTurnRefs(buildPrompt(ctx.stats.permissionMode)),
       );
+
+      // Contract: Stop fires post-turn as a notification event. AbortError
+      // propagates (abort precedence is non-negotiable). HookBlockedError
+      // surfaces a brief notice and continues -- block does NOT force REPL
+      // continuation in v1 (deferred: block-to-force-continuation and
+      // injectContext-into-next-turn need cross-turn state).
+      if (ctx.hookRegistry) {
+        try {
+          await ctx.hookRegistry.dispatch({
+            event: 'Stop',
+            sessionId: ctx.stats.sessionId,
+          });
+        } catch (err) {
+          if (err instanceof AbortError) throw err;
+          if (err instanceof HookBlockedError) {
+            ctx.completionWriter.fn(
+              palette.dim(`  [stop hook] blocked: ${err.reason ?? 'no reason given'}`),
+            );
+          }
+        }
+      }
     }
 }

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -21,6 +21,7 @@ import {
 import type { InteractiveCtx } from './shared.js';
 import { formatStatusFields } from './shared.js';
 import { AbortError, HookBlockedError } from '../../../utils/errors.js';
+import { HookHandlerTimeoutError } from '../../../agent/hook-registry.js';
 import type { TranscriptHandle } from './transcript.js';
 import { runTurn } from './turn-handler.js';
 import { saveSession } from '../../session-store.js';
@@ -506,6 +507,17 @@ export async function runInputLoop(
       // surfaces a brief notice and continues -- block does NOT force REPL
       // continuation in v1 (deferred: block-to-force-continuation and
       // injectContext-into-next-turn need cross-turn state).
+      //
+      // Invariant: Stop fires only on non-throwing runTurn completions. Any
+      // throw from runTurn (including model errors and abort) bypasses this
+      // block entirely -- error and abort paths skip Stop by design. The
+      // sequential placement (not finally) is intentional: Stop signals
+      // successful turn completion, not turn exit.
+      //
+      // Invariant: slash-command-only iterations (res.handled paths above)
+      // end in `continue` before reaching this block, so Stop does not fire
+      // for slash-command-only turns. Only turns that invoke runTurn trigger
+      // Stop.
       if (ctx.hookRegistry) {
         try {
           await ctx.hookRegistry.dispatch({
@@ -514,10 +526,15 @@ export async function runInputLoop(
           });
         } catch (err) {
           if (err instanceof AbortError) throw err;
-          if (err instanceof HookBlockedError) {
+          if (err instanceof HookHandlerTimeoutError) {
+            debugLog('[stop hook] handler timed out');
+            ctx.completionWriter.fn(palette.dim('  [stop hook] timed out'));
+          } else if (err instanceof HookBlockedError) {
             ctx.completionWriter.fn(
               palette.dim(`  [stop hook] blocked: ${err.reason ?? 'no reason given'}`),
             );
+          } else {
+            debugLog('[stop hook] unexpected error: ' + String(err));
           }
         }
       }

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -12,6 +12,7 @@ import {
 } from '../../slash/preflight/index.js';
 import { renderDebugBanner } from '../../debug-banner.js';
 import { isDebugEnabled, debugLog } from '../../../utils/debug.js';
+import { sanitizeForDisplay } from '../../../utils/terminal-sanitize.js';
 import { env } from '../../../config/env.js';
 import { palette } from '../../palette.js';
 import { cyclePermissionMode } from '../../permission-mode-cycle.js';
@@ -31,6 +32,11 @@ import type { InputSurface } from '../../input/input-surface.js';
 import type { ReplHistory } from '../../input/history.js';
 import { buildPrompt, type TurnState } from './repl-loop-shared.js';
 import type { FooterSubsystems } from './footer-subsystems.js';
+
+/** Per-handler timeout for the post-turn Stop notification. Tighter than the
+ *  registry default (HOOK_HANDLER_TIMEOUT_MS = 30s) because Stop fires every
+ *  REPL turn — a notification hook must not stall the prompt for 30s × N handlers. */
+const STOP_HOOK_HANDLER_TIMEOUT_MS = 5_000;
 
 async function runFirstTurnHookIfNeeded(ctx: InteractiveCtx, text: string): Promise<void> {
   // First-turn hook — awaited before any first-turn side effect that relies on
@@ -418,7 +424,7 @@ export async function runInputLoop(
           if (err instanceof HookBlockedError) {
             ctx.replRenderer.writeLine(
               palette.warning('⊘ Turn blocked by hook') +
-                (err.reason ? palette.dim(`: ${err.reason}`) : ''),
+                (err.reason ? palette.dim(`: ${sanitizeForDisplay(err.reason)}`) : ''),
             );
             ctx.statusLine.rearm();
             continue;
@@ -563,12 +569,17 @@ export async function runInputLoop(
       // end in `continue` before reaching this block, so Stop does not fire
       // for slash-command-only turns. Only turns that invoke runTurn trigger
       // Stop.
+      //
+      // Contract: Stop dispatch uses STOP_HOOK_HANDLER_TIMEOUT_MS (5s) rather
+      // than the registry default (30s) because Stop fires every REPL turn —
+      // a notification hook must not stall the prompt for 30s × N handlers.
       if (ctx.hookRegistry) {
         try {
-          await ctx.hookRegistry.dispatch({
-            event: 'Stop',
-            sessionId: ctx.stats.sessionId,
-          });
+          await ctx.hookRegistry.dispatch(
+            { event: 'Stop', sessionId: ctx.stats.sessionId },
+            undefined,
+            STOP_HOOK_HANDLER_TIMEOUT_MS,
+          );
         } catch (err) {
           if (err instanceof AbortError) throw err;
           if (err instanceof HookHandlerTimeoutError) {
@@ -576,7 +587,7 @@ export async function runInputLoop(
             ctx.completionWriter.fn(palette.dim('  [stop hook] timed out'));
           } else if (err instanceof HookBlockedError) {
             ctx.completionWriter.fn(
-              palette.dim(`  [stop hook] blocked: ${err.reason ?? 'no reason given'}`),
+              palette.dim(`  [stop hook] blocked: ${sanitizeForDisplay(err.reason ?? 'no reason given')}`),
             );
           } else {
             debugLog('[stop hook] unexpected error: ' + String(err));

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -10,6 +10,7 @@ import type { StoredSession } from '../../session-store.js';
 import type { StatusLine } from '../../status-line.js';
 import type { ReplRenderer } from './repl-renderer.js';
 import type { ResolvedResumeTarget } from '../../resume-session.js';
+import type { HookRegistry } from '../../../agent/hooks.js';
 import { contextLimitFor } from '../../model-limits.js';
 import { ContextSampler } from '../../context-sampler.js';
 import type { GitStatusSampler } from '../../git-status-sampler.js';
@@ -414,6 +415,13 @@ export interface InteractiveCtx {
    * the ghost toggle.
    */
   suggestGhostConfig?: boolean;
+  /**
+   * Hook registry for dispatching harness lifecycle events from the REPL loop.
+   * Absent in test stubs that do not exercise hooks. Set by bootstrap.ts from
+   * `hookRegistryBundle.registry`. The Stop event is dispatched here after each
+   * completed turn.
+   */
+  hookRegistry?: HookRegistry;
 }
 
 /**


### PR DESCRIPTION
## Summary

Additive wiring of `Stop` as the 7th `HarnessHookEvent`. Fires as a
post-turn notification after each completed REPL turn. No existing event
semantics are changed.

## What changed

| File | Change |
|------|--------|
| `src/agent/hooks.ts` | Add `'Stop'` to union; add `StopContext` interface; add to `HookContext` |
| `src/agent/hooks/config-loader.ts` | Append `'Stop'` to both `validEvents` arrays |
| `src/agent/hooks/config-bridge.ts` | Append `'Stop'` to `validEvents`; no matcher branch (always-match) |
| `src/agent/hooks/command-executor.ts` | No change (Stop has no extra scalar payload) |
| `src/cli/commands/interactive/shared.ts` | Add `hookRegistry?: HookRegistry` to `InteractiveCtx` |
| `src/cli/commands/interactive/bootstrap.ts` | Set `hookRegistry: hookRegistryBundle.registry` on ctx |
| `src/cli/commands/interactive/loop-iteration.ts` | Dispatch `StopContext` after `runTurn`; re-throw `AbortError`; notice on `HookBlockedError` |
| `src/agent/hooks/stop.test.ts` (new) | 7 tests: registry dispatch, config-loader, trust-gate suppression |
| `src/agent/hooks.test.ts` | Add `case 'Stop'` to discriminated-union switch |
| `src/cli/commands/interactive/loop-iteration.test.ts` | 2 new tests: Stop fires after runTurn; no-op without hookRegistry |

## Dispatch site

`src/cli/commands/interactive/loop-iteration.ts`, immediately after
`await runTurn(...)` returns in `runInputLoop`. Guarded by
`if (ctx.hookRegistry)` so non-REPL surfaces (daemon, one-shot chat) are
unaffected.

## Design decisions

- **Post-turn notification, v1 scope small**: Stop is a notification hook.
  `HookBlockedError` renders a brief notice and continues -- no forced REPL
  halt in v1. `AbortError` propagates unconditionally (abort precedence is
  non-negotiable per the existing invariant).
- **Always-match, not tool-scoped**: Stop falls through the PreToolUse/
  PostToolUse matcher branch in config-bridge, matching the
  SessionStart/SessionEnd pattern.
- **hookRegistry on InteractiveCtx**: threads the existing
  `hookRegistryBundle.registry` through ctx rather than creating a new
  registry, keeping the same handler registrations that SessionStart/End
  and the other events already use.

## Deferred (documented in code comment)

- **block-to-force-continuation**: Stop `HookBlockedError` halting the REPL
  needs cross-turn state to be useful.
- **injectContext-into-next-turn**: queuing hook output to the next user
  message also requires cross-turn state.

## Gates

- `pnpm lint` (tsc --noEmit strict): exit 0
- `pnpm exec vitest run` (3 touched test files): 31/31 pass
- `pnpm audit:sdk:check`: OK, no new SDK imports
