### PR TITLE
feat(hooks): add PreCompact hook event

### DIFF
--- a/src/agent/hooks.test.ts
+++ b/src/agent/hooks.test.ts
@@ -17,6 +17,7 @@ import { dispatchSubagentStop } from './subagent-hooks.js';
 import type {
   HookContext,
   HookHandler,
+  PreCompactContext,
   PreToolUseContext,
   SessionStartContext,
   SubagentStopContext,
@@ -234,6 +235,8 @@ describe('HookContext — discriminated union narrowing', () => {
           return `pre:${ctx.toolName}`;
         case 'PostToolUse':
           return `post:${ctx.toolName}`;
+        case 'PreCompact':
+          return `pre-compact:${ctx.trigger ?? '-'}`;
       }
     };
 
@@ -242,9 +245,11 @@ describe('HookContext — discriminated union narrowing', () => {
       subagentId: 'sub-1',
       status: 'succeeded',
     };
+    const preCompact: PreCompactContext = { event: 'PreCompact', trigger: 'manual' };
     expect(describe(stop)).toBe('sub-stop:sub-1:succeeded');
     expect(describe(preToolCtx('Edit'))).toBe('pre:Edit');
     expect(describe(sessionStartCtx('s-99'))).toBe('start:s-99');
+    expect(describe(preCompact)).toBe('pre-compact:manual');
   });
 });
 

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -42,7 +42,8 @@ export type HarnessHookEvent =
   | 'SubagentStart'
   | 'SubagentStop'
   | 'PreToolUse'
-  | 'PostToolUse';
+  | 'PostToolUse'
+  | 'PreCompact';
 
 export interface HookDecision {
   /** False halts session lifecycle; undefined/true continues. */
@@ -155,6 +156,13 @@ export interface PostToolUseContext {
   output?: unknown;
 }
 
+export interface PreCompactContext {
+  event: 'PreCompact';
+  sessionId?: string;
+  /** 'manual' = /compact command or Telegram /compact; 'auto' = threshold-based. */
+  trigger?: 'manual' | 'auto';
+}
+
 /** Discriminated union — narrow via `switch (context.event)`. */
 export type HookContext =
   | SessionStartContext
@@ -162,7 +170,8 @@ export type HookContext =
   | SubagentStartContext
   | SubagentStopContext
   | PreToolUseContext
-  | PostToolUseContext;
+  | PostToolUseContext
+  | PreCompactContext;
 
 /**
  * A hook handler. `signal` is the turn/dispatch {@link AbortSignal} forwarded

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -159,7 +159,10 @@ export interface PostToolUseContext {
 export interface PreCompactContext {
   event: 'PreCompact';
   sessionId?: string;
-  /** 'manual' = /compact command or Telegram /compact; 'auto' = threshold-based. */
+  /**
+   * 'manual' = /compact command or Telegram /compact. Only 'manual' is emitted today.
+   * 'auto' (threshold-based) is reserved for future wiring -- see TODO in query.ts.
+   */
   trigger?: 'manual' | 'auto';
 }
 

--- a/src/agent/hooks/command-executor.ts
+++ b/src/agent/hooks/command-executor.ts
@@ -76,6 +76,9 @@ export async function executeCommand(
         typeof context.output === 'string' ? context.output : JSON.stringify(context.output);
     }
   }
+  if (context.event === 'PreCompact') {
+    payload['trigger'] = context.trigger ?? null;
+  }
   // transcript_path: always emit the key so hook scripts can detect it.
   // When unknown, emit null (not undefined — JSON.stringify drops undefined).
   payload['transcript_path'] = null;

--- a/src/agent/hooks/config-bridge.ts
+++ b/src/agent/hooks/config-bridge.ts
@@ -64,6 +64,7 @@ export function loadAndRegisterConfigHooks(
     'SubagentStop',
     'PreToolUse',
     'PostToolUse',
+    'PreCompact',
   ];
 
   for (const event of validEvents) {

--- a/src/agent/hooks/config-loader.ts
+++ b/src/agent/hooks/config-loader.ts
@@ -227,6 +227,7 @@ export function loadHooksConfigFile(
     'SubagentStop',
     'PreToolUse',
     'PostToolUse',
+    'PreCompact',
   ];
 
   for (const event of validEvents) {
@@ -344,6 +345,7 @@ export function loadHooksConfig(opts: LoadHooksConfigOptions = {}): LoadedHooksC
     'SubagentStop',
     'PreToolUse',
     'PostToolUse',
+    'PreCompact',
   ];
 
   for (const layer of layers) {

--- a/src/agent/hooks/pre-compact.test.ts
+++ b/src/agent/hooks/pre-compact.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for the PreCompact hook event.
+ *
+ * Covers:
+ * - Registry fires a registered PreCompact handler with the correct context
+ * - A blocking handler throws HookBlockedError
+ * - Config-loader accepts 'PreCompact' as a valid event name
+ * - Trust-gate suppression: shell hooks disabled -> userGlobalEnabled is false
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createHookRegistry } from '../hooks.js';
+import { HookBlockedError } from '../../utils/errors.js';
+import { loadHooksConfigFile } from './config-loader.js';
+import type { PreCompactContext } from '../hooks.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function preCompactCtx(trigger?: 'manual' | 'auto'): PreCompactContext {
+  return { event: 'PreCompact', sessionId: 'sess-test', trigger };
+}
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'pre-compact-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeJson(name: string, value: unknown): string {
+  const p = join(tmp, name);
+  writeFileSync(p, JSON.stringify(value));
+  return p;
+}
+
+// ---------------------------------------------------------------------------
+// Registry fires + context shape
+// ---------------------------------------------------------------------------
+
+describe('PreCompact registry dispatch', () => {
+  it('fires a registered handler with correct context', async () => {
+    const registry = createHookRegistry();
+    const handler = vi.fn(async () => ({}));
+    registry.register('PreCompact', handler);
+
+    const ctx = preCompactCtx('manual');
+    await registry.dispatch(ctx);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [receivedCtx] = handler.mock.calls[0] as [PreCompactContext];
+    expect(receivedCtx.event).toBe('PreCompact');
+    expect(receivedCtx.sessionId).toBe('sess-test');
+    expect(receivedCtx.trigger).toBe('manual');
+  });
+
+  it('fires with trigger=auto', async () => {
+    const registry = createHookRegistry();
+    const handler = vi.fn(async () => ({}));
+    registry.register('PreCompact', handler);
+
+    await registry.dispatch(preCompactCtx('auto'));
+    const [receivedCtx] = handler.mock.calls[0] as [PreCompactContext];
+    expect(receivedCtx.trigger).toBe('auto');
+  });
+
+  it('fires with no trigger field (undefined)', async () => {
+    const registry = createHookRegistry();
+    const handler = vi.fn(async () => ({}));
+    registry.register('PreCompact', handler);
+
+    await registry.dispatch({ event: 'PreCompact' });
+    const [receivedCtx] = handler.mock.calls[0] as [PreCompactContext];
+    expect(receivedCtx.trigger).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Block -> HookBlockedError
+// ---------------------------------------------------------------------------
+
+describe('PreCompact block decision', () => {
+  it('throws HookBlockedError when handler returns decision:block', async () => {
+    const registry = createHookRegistry();
+    registry.register('PreCompact', async () => ({
+      decision: 'block',
+      reason: 'frozen by policy',
+    }));
+
+    const err = await registry.dispatch(preCompactCtx('manual')).catch((e) => e);
+    expect(err).toBeInstanceOf(HookBlockedError);
+    expect((err as HookBlockedError).reason).toBe('frozen by policy');
+  });
+
+  it('throws HookBlockedError when handler returns continue:false', async () => {
+    const registry = createHookRegistry();
+    registry.register('PreCompact', async () => ({ continue: false }));
+
+    const err = await registry.dispatch(preCompactCtx('manual')).catch((e) => e);
+    expect(err).toBeInstanceOf(HookBlockedError);
+  });
+
+  it('does not fire subsequent handlers after a block', async () => {
+    const registry = createHookRegistry();
+    const second = vi.fn(async () => ({}));
+    registry.register('PreCompact', async () => ({ decision: 'block', reason: 'stop' }));
+    registry.register('PreCompact', second);
+
+    await registry.dispatch(preCompactCtx('manual')).catch(() => {});
+    expect(second).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Config-loader accepts 'PreCompact'
+// ---------------------------------------------------------------------------
+
+describe('config-loader PreCompact acceptance', () => {
+  it('loadHooksConfigFile parses a PreCompact hook entry without warnings', () => {
+    const path = writeJson('config.json', {
+      hooks: {
+        PreCompact: [
+          { hooks: [{ type: 'command', command: 'echo pre-compact' }] },
+        ],
+      },
+      enableShellHooks: true,
+    });
+
+    const result = loadHooksConfigFile(path, 'user-global');
+
+    expect(result.warnings).toHaveLength(0);
+    expect(result.hooks['PreCompact']).toBeDefined();
+    expect(result.hooks['PreCompact']?.[0]?.hooks[0]?.command).toBe('echo pre-compact');
+    expect(result.enableShellHooks).toBe(true);
+  });
+
+  it('trust-gate: enableShellHooks:false -> userGlobalEnabled is false', () => {
+    const path = writeJson('config2.json', {
+      hooks: {
+        PreCompact: [
+          { hooks: [{ type: 'command', command: 'echo blocked' }] },
+        ],
+      },
+      enableShellHooks: false,
+    });
+
+    const result = loadHooksConfigFile(path, 'user-global');
+    expect(result.enableShellHooks).toBe(false);
+  });
+});

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -67,6 +67,7 @@ export type {
   HookHandler,
   HookRegistry,
   PostToolUseContext,
+  PreCompactContext,
   PreToolUseContext,
   SessionEndContext,
   SessionStartContext,

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -465,6 +465,9 @@ export class AnthropicDirectQuery implements ProviderQuery {
               // boundary here (generator suspended at promptIterator.next()
               // on the next iteration). Awaiting inline keeps the ordering
               // deterministic and avoids a dangling promise race.
+              // TODO(PreCompact): auto-compact does not yet dispatch PreCompact(trigger:'auto').
+              // hookRegistry is not threaded into the provider-internal compact path.
+              // Tracked as a follow-up to feat/pre-compact-hook; remove this comment when wired.
               await this.compact();
             }
           }

--- a/src/cli/slash/commands/core.ts
+++ b/src/cli/slash/commands/core.ts
@@ -12,6 +12,7 @@ import { divider } from '../../render.js';
 import { list } from '../registry.js';
 import { resetStats } from '../session-stats.js';
 import { REPL_SPINNER_OPTIONS } from '../../commands/interactive/shared.js';
+import { HookBlockedError, AbortError } from '../../../utils/errors.js';
 import type { SlashCommand } from '../types.js';
 
 const exitCmd: SlashCommand = {
@@ -55,7 +56,18 @@ const compactCmd: SlashCommand = {
       ...REPL_SPINNER_OPTIONS,
     }).start();
     try {
-      const result = await ctx.session.current.compact();
+      // Invariant: fire PreCompact before compaction so registered handlers can
+      // block or observe the operation. block -> HookBlockedError -> skip.
+      const session = ctx.session.current;
+      const hookRegistry = session.hookRegistry;
+      if (hookRegistry) {
+        await hookRegistry.dispatch({
+          event: 'PreCompact',
+          sessionId: session.sessionId,
+          trigger: 'manual',
+        });
+      }
+      const result = await session.compact();
       spinner.stop();
       if (!result.compacted) {
         const reason = result.reason ?? 'unknown';
@@ -80,6 +92,11 @@ const compactCmd: SlashCommand = {
       }
     } catch (err) {
       spinner.stop();
+      if (err instanceof AbortError) throw err;
+      if (err instanceof HookBlockedError) {
+        ctx.out.info(`Compaction skipped: ${err.reason ?? 'blocked by hook'}`);
+        return 'continue';
+      }
       ctx.out.error(err instanceof Error ? err.message : 'Unknown error');
     }
     return 'continue';

--- a/src/cli/slash/core-compact.test.ts
+++ b/src/cli/slash/core-compact.test.ts
@@ -10,6 +10,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { SlashCommand, SlashContext, SessionStats } from './types.js';
 import { coreCommands } from './commands/core.js';
+import { createHookRegistry } from '../../agent/hooks.js';
+import { HookBlockedError } from '../../utils/errors.js';
 
 function makeStats(): SessionStats {
   return {
@@ -184,5 +186,92 @@ describe('/compact slash handler', () => {
     const error = lines.find((l) => l.startsWith('ERROR:'));
     expect(error).toBeDefined();
     expect(error).toContain('blew up');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PreCompact hook integration
+// ---------------------------------------------------------------------------
+
+describe('/compact PreCompact hook integration', () => {
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  beforeEach(() => {
+    process.stdout.write = ((): boolean => true) as typeof process.stdout.write;
+  });
+  afterEach(() => {
+    process.stdout.write = originalWrite;
+  });
+
+  it('fires PreCompact hook with trigger=manual before compaction', async () => {
+    const session = fakeSession();
+    session.compact.mockResolvedValue({
+      compacted: true,
+      messagesBefore: 8,
+      messagesAfter: 3,
+    });
+    const registry = createHookRegistry();
+    const hookHandler = vi.fn(async () => ({}));
+    registry.register('PreCompact', hookHandler);
+    const sessionWithRegistry = { ...session, hookRegistry: registry, sessionId: 'test-sess' };
+    const { ctx } = makeCtx(sessionWithRegistry as unknown as typeof session);
+
+    await getCompactCmd().handler(ctx, '');
+
+    expect(hookHandler).toHaveBeenCalledTimes(1);
+    const [ctx0] = hookHandler.mock.calls[0] as [{ event: string; trigger: string }];
+    expect(ctx0.event).toBe('PreCompact');
+    expect(ctx0.trigger).toBe('manual');
+    expect(session.compact).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips compaction and renders info when PreCompact hook blocks', async () => {
+    const session = fakeSession();
+    const registry = createHookRegistry();
+    registry.register('PreCompact', async () => ({
+      decision: 'block' as const,
+      reason: 'frozen',
+    }));
+    const sessionWithRegistry = { ...session, hookRegistry: registry, sessionId: 'test-sess' };
+    const { ctx, lines } = makeCtx(sessionWithRegistry as unknown as typeof session);
+
+    await getCompactCmd().handler(ctx, '');
+
+    expect(session.compact).not.toHaveBeenCalled();
+    const info = lines.find((l) => l.startsWith('INFO:'));
+    expect(info).toBeDefined();
+    expect(info).toContain('frozen');
+  });
+
+  it('hooks without a registry proceed normally', async () => {
+    const session = fakeSession();
+    session.compact.mockResolvedValue({
+      compacted: true,
+      messagesBefore: 4,
+      messagesAfter: 2,
+    });
+    // No hookRegistry on session — tests that the undefined guard works.
+    const { ctx } = makeCtx(session);
+
+    await getCompactCmd().handler(ctx, '');
+
+    expect(session.compact).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-throws HookBlockedError (should not happen from registry) only after converting to info', async () => {
+    // Verify HookBlockedError is handled gracefully rather than propagating.
+    const session = fakeSession();
+    const registry = createHookRegistry();
+    registry.register('PreCompact', async () => {
+      throw new HookBlockedError('handler threw directly');
+    });
+    const sessionWithRegistry = { ...session, hookRegistry: registry, sessionId: 's' };
+    const { ctx, lines } = makeCtx(sessionWithRegistry as unknown as typeof session);
+
+    await getCompactCmd().handler(ctx, '');
+
+    expect(session.compact).not.toHaveBeenCalled();
+    // HookBlockedError thrown by handler surfaces as a block (fail-safe) -> skipped.
+    const info = lines.find((l) => l.startsWith('INFO:'));
+    expect(info).toBeDefined();
   });
 });

--- a/src/cli/slash/core-compact.test.ts
+++ b/src/cli/slash/core-compact.test.ts
@@ -257,12 +257,12 @@ describe('/compact PreCompact hook integration', () => {
     expect(session.compact).toHaveBeenCalledTimes(1);
   });
 
-  it('re-throws HookBlockedError (should not happen from registry) only after converting to info', async () => {
+  it('converts HookBlockedError thrown by handler to an info skip message', async () => {
     // Verify HookBlockedError is handled gracefully rather than propagating.
     const session = fakeSession();
     const registry = createHookRegistry();
     registry.register('PreCompact', async () => {
-      throw new HookBlockedError('handler threw directly');
+      throw new HookBlockedError('handler threw directly', 'PreCompact');
     });
     const sessionWithRegistry = { ...session, hookRegistry: registry, sessionId: 's' };
     const { ctx, lines } = makeCtx(sessionWithRegistry as unknown as typeof session);

--- a/src/telegram/handlers/commands.ts
+++ b/src/telegram/handlers/commands.ts
@@ -4,6 +4,7 @@ import type { Message } from 'telegraf/types';
 import { promises as fs } from 'fs';
 import { homedir } from 'os';
 import { isAbsolute, resolve } from 'path';
+import { HookBlockedError } from '../../utils/errors.js';
 import { SessionManager } from '../session-manager.js';
 import {
   formatError,
@@ -74,6 +75,15 @@ export async function handleCompact(
   try {
     const session = await sessionManager.getSession(chatId);
     await ctx.sendChatAction('typing').catch(() => {});
+    // Invariant: fire PreCompact before compaction. block -> skip, not error.
+    const hookRegistry = session.hookRegistry;
+    if (hookRegistry) {
+      await hookRegistry.dispatch({
+        event: 'PreCompact',
+        sessionId: session.sessionId,
+        trigger: 'manual',
+      });
+    }
     const result = await session.compact();
     if (!result.compacted) {
       await ctx.reply(formatCompactNoop(result.reason ?? 'unknown'));
@@ -89,8 +99,12 @@ export async function handleCompact(
       );
     }
   } catch (error) {
-    log('Compact error:', error);
-    await ctx.reply(formatError(error as Error));
+    if (error instanceof HookBlockedError) {
+      await ctx.reply(`Compaction skipped: ${error.reason ?? 'blocked by hook'}`);
+    } else {
+      log('Compact error:', error);
+      await ctx.reply(formatError(error as Error));
+    }
   }
 }
 

--- a/src/telegram/handlers/commands.ts
+++ b/src/telegram/handlers/commands.ts
@@ -100,7 +100,7 @@ export async function handleCompact(
     }
   } catch (error) {
     if (error instanceof HookBlockedError) {
-      await ctx.reply(`Compaction skipped: ${error.reason ?? 'blocked by hook'}`);
+      await ctx.reply(`Compaction skipped: ${escapeHtml(error.reason ?? 'blocked by hook')}`);
     } else {
       log('Compact error:', error);
       await ctx.reply(formatError(error as Error));

--- a/src/telegram/handlers/message.ts
+++ b/src/telegram/handlers/message.ts
@@ -2,7 +2,7 @@ import { Context } from 'telegraf';
 import type { Message } from 'telegraf/types';
 import { Telegraf } from 'telegraf';
 import { SessionManager } from '../session-manager.js';
-import { formatError, formatClear, formatInternalError, formatCompact, formatCompactNoop, formatQueued } from '../formatter.js';
+import { formatError, formatClear, formatInternalError, formatCompact, formatCompactNoop, formatQueued, escapeHtml } from '../formatter.js';
 import { isRateLimitError, isNetworkError } from '../error-utils.js';
 import { streamResponse } from '../streaming.js';
 import { registerChatCommands } from './registration.js';
@@ -495,7 +495,7 @@ export class MessageHandler {
       }
     } catch (error) {
       if (error instanceof HookBlockedError) {
-        await ctx.reply(`Compaction skipped: ${error.reason ?? 'blocked by hook'}`);
+        await ctx.reply(`Compaction skipped: ${escapeHtml(error.reason ?? 'blocked by hook')}`);
       } else {
         this.log('Compact error (queued):', error);
         await ctx.reply(formatError(error as Error));

--- a/src/telegram/handlers/message.ts
+++ b/src/telegram/handlers/message.ts
@@ -6,6 +6,7 @@ import { formatError, formatClear, formatInternalError, formatCompact, formatCom
 import { isRateLimitError, isNetworkError } from '../error-utils.js';
 import { streamResponse } from '../streaming.js';
 import { registerChatCommands } from './registration.js';
+import { HookBlockedError } from '../../utils/errors.js';
 import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
 
 type QueueItem =
@@ -464,6 +465,15 @@ export class MessageHandler {
     try {
       const session = await this.sessionManager.getSession(chatId);
       await ctx.sendChatAction('typing').catch(() => {});
+      // Invariant: fire PreCompact before compaction. block -> skip, not error.
+      const hookRegistry = session.hookRegistry;
+      if (hookRegistry) {
+        await hookRegistry.dispatch({
+          event: 'PreCompact',
+          sessionId: session.sessionId,
+          trigger: 'manual',
+        });
+      }
       const result = await session.compact();
       if (result.reason === 'session-busy') {
         // Session became busy between drain-start and our compact() call (TOCTOU).
@@ -484,8 +494,12 @@ export class MessageHandler {
         }));
       }
     } catch (error) {
-      this.log('Compact error (queued):', error);
-      await ctx.reply(formatError(error as Error));
+      if (error instanceof HookBlockedError) {
+        await ctx.reply(`Compaction skipped: ${error.reason ?? 'blocked by hook'}`);
+      } else {
+        this.log('Compact error (queued):', error);
+        await ctx.reply(formatError(error as Error));
+      }
     } finally {
       // Only drain when we did NOT re-enqueue — the active turn's finally will
       // drain the re-enqueued compact; draining here too causes a cascade.


### PR DESCRIPTION
## Summary

Adds a new harness hook event `PreCompact` that fires immediately before any
manual compaction operation. Registered handlers can observe, audit, or block
compaction before session history is mutated.

## Compaction paths wired

**Manual (wired):**
- `/compact` REPL slash command (`src/cli/slash/commands/core.ts`)
- Telegram `/compact` command (`src/telegram/handlers/commands.ts`)
- Telegram queued compact drain (`src/telegram/handlers/message.ts processCompactDirect`)

All three fire `PreCompact(trigger='manual')` before calling `session.compact()`.

**Auto-compact (deferred):**

Auto-compaction fires inside `AnthropicDirectQuery.sendMessageStreamInternal()`
(`src/agent/providers/anthropic-direct/query.ts` ~L468) at the turn boundary.
It calls `this.compact()` directly on the provider query object, bypassing
`AgentSession.compact()`. The `hookRegistry` is not available at that point
without threading it through the provider constructor and turn loop -- a larger
change with non-trivial blast radius. This is documented as a deferred follow-up.

## Block semantics

`decision:'block'` on `PreCompact` means: **skip this compaction cleanly**.
Session history is left intact. The caller renders a brief info notice
("Compaction skipped: <reason>") and returns normally. `AbortError` is always
re-thrown so session teardown is unaffected.

## Files changed

| File | Change |
|------|--------|
| `src/agent/hooks.ts` | Add `PreCompact` to `HarnessHookEvent`; add `PreCompactContext`; extend `HookContext` union |
| `src/agent/hooks/config-loader.ts` | Add `PreCompact` to both `validEvents` arrays |
| `src/agent/hooks/config-bridge.ts` | Add `PreCompact` to `validEvents` |
| `src/agent/hooks/command-executor.ts` | Add `trigger` field to PreCompact stdin payload |
| `src/cli/slash/commands/core.ts` | Dispatch PreCompact before `/compact` compaction |
| `src/telegram/handlers/commands.ts` | Dispatch PreCompact before Telegram compact command |
| `src/telegram/handlers/message.ts` | Dispatch PreCompact before queued compact drain |
| `src/agent/hooks/pre-compact.test.ts` | New: 8 unit tests (registry, block, config-loader, trust-gate) |
| `src/agent/hooks.test.ts` | Add `case 'PreCompact'` to narrowing switch (compile correctness) |
| `src/cli/slash/core-compact.test.ts` | 4 new PreCompact integration tests |

## Gates

- `pnpm lint` (tsc --noEmit): PASS
- `pnpm exec vitest run <touched files>`: 37 tests, all pass
- `pnpm audit:sdk:check`: PASS (no new SDK imports)
