### PR TITLE
feat(bundled): add automate skill to awa-bundled plugin

### DIFF
--- a/scripts/update-hash-pins.ts
+++ b/scripts/update-hash-pins.ts
@@ -60,6 +60,7 @@ const bundledSkillsDir = join(repoRoot, 'src/bundled-plugins/awa-bundled/skills'
 const bundledTarget: PinTarget = {
   testFile: join(repoRoot, 'src/bundled-plugins/awa-bundled/bundled.test.ts'),
   pins: {
+    automate: join(bundledSkillsDir, 'automate/SKILL.md'),
     contract: join(bundledSkillsDir, 'contract/SKILL.md'),
     'devils-advocate': join(bundledSkillsDir, 'devils-advocate/SKILL.md'),
     gather: join(bundledSkillsDir, 'gather/SKILL.md'),

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -35,6 +35,11 @@ const __dirname = dirname(__filename);
 // test cannot prevent that on its own — but the hash-bump moment forces the
 // developer to look at both copies.
 const PINNED_HASHES = {
+  // automate: afk-native scheduled-run skill (create_schedule + send_telegram +
+  // `afk service install daemon`). Mirrors the awa-dev upstream (→ framework);
+  // vendored byte-equal, so no INTENTIONAL_DIFFS entry is needed. Drift row is
+  // wired in UPSTREAM_PATHS below (skips until example-plugin is co-located).
+  automate: '40de5b802991e4be6dcf41305ed02885d0f0bde9b2877bfc1f33dfe9fe634d0f',
   contract: '748eaf01deda592913f463b23c81a6be3a89ae3b316f31f531a8488dc5bc1a7c',
   // Hash re-bumped during PR #187 review: the Merge section now routes the
   // second convergence condition (≥2 critics agree on the same alternative) to
@@ -115,6 +120,7 @@ const WORKSPACE_ROOT = join(__dirname, '../../../..');
 // Upstream source paths relative to WORKSPACE_ROOT.
 // intent-lock, simplify, refactor are bundled-only — no upstream comparison row.
 const UPSTREAM_PATHS: Partial<Record<SkillName, string>> = {
+  automate: 'example-plugin/plugins/framework/skills/automate/SKILL.md',
   contract: 'example-plugin/plugins/framework/skills/contract/SKILL.md',
   gather: 'example-plugin/plugins/framework/skills/gather/SKILL.md',
   'ground-claim': 'example-plugin/plugins/framework/skills/ground-claim/SKILL.md',

--- a/src/bundled-plugins/awa-bundled/skills/automate/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/automate/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: automate
+description: "Set up a scheduled headless afk run that pushes a summary to Telegram. Use when the user wants to automate a recurring task via the afk daemon scheduler (cron) with push-notified results."
+disable-model-invocation: true
+---
+
+Set up a recurring headless task using afk's **native** scheduler. Do NOT hand-roll launchd plists or shell scripts — afk has first-class scheduling: the `create_schedule` tool writes `~/.afk/config/schedules.json` entries that `afk daemon` runs on cron.
+
+Dispatch two sub-agents in parallel:
+1. **Scout** — call `list_schedules` and inspect `~/.afk/config/schedules.json` for existing or overlapping jobs, run `afk service status` to see whether the daemon is installed as a launchd service and running, confirm Telegram is configured (`TELEGRAM_BOT_TOKEN` + `AFK_TELEGRAM_ALLOWED_CHAT_IDS`), and scan the target project folder for conventions. Report conflicts, daemon/service state, and any missing prerequisite.
+2. **Prompt designer** — draft the recurring task's `command` string: a self-contained prompt (or `/skill --flags` invocation) sent verbatim into a freshly spawned session each run. The daemon session starts cold, so encode all input context explicitly, and require the run to END by calling the `send_telegram` tool with a concise, push-ready summary.
+
+When both return:
+- If Telegram is unconfigured, stop and tell the user to run `/telegram-setup` first — `send_telegram` fails closed without `TELEGRAM_BOT_TOKEN` and `AFK_TELEGRAM_ALLOWED_CHAT_IDS`.
+- Create the job with the `create_schedule` tool: `name`, the designed `command`, the requested 5-field `cron`, `trigger: "cron"`, and `notifyOn: "failure"` as a crash safety-net (the per-run summary comes from the agent's own `send_telegram` call, not from `notifyOn`).
+- Schedules only fire while the daemon is running, so make it survive reboot/crash: if `afk service status` shows the daemon isn't installed, run `afk service install daemon` (launchd `RunAtLoad` + `KeepAlive` on macOS).
+
+Dispatch a **verification** sub-agent to confirm the job registered (`list_schedules`), the daemon is running (`afk service status`), and — by running the task's `command` once as a one-shot (`afk chat "<command>"`) — that the Telegram summary actually arrives. On failure, diagnose (Telegram config, daemon not running, cron syntax, prompt shape) and fix before exiting. Report the schedule id, cron, `notifyOn`, daemon/service status, and the next scheduled run.


### PR DESCRIPTION
## What

Bundle the afk-native `/automate` skill into the always-shipped `awa-bundled` plugin, so scheduled-headless-run setup is available out of the box (no external plugin install).

`/automate` sets up a recurring headless task using afk's **native** scheduler:
- `create_schedule` tool → `~/.afk/config/schedules.json`, run by `afk daemon`
- per-run summary delivered by the agent calling `send_telegram` (with `notifyOn: "failure"` as a crash backstop)
- `afk service install daemon` to survive reboot/crash

It dispatches a Scout + Prompt-designer recon pair, creates the schedule, then a verification sub-agent confirms the job registered and the Telegram summary actually arrives.

## How it's registered

The `awa-bundled` plugin is integrity-gated by `bundled.test.ts` (pinned SHA-256 per skill + an inventory invariant requiring `readdir(skills/)` to equal `PINNED_HASHES`). Added automate in all three required spots:

1. `src/bundled-plugins/awa-bundled/skills/automate/SKILL.md` — the skill, vendored **byte-equal** from the awa-dev upstream (sha `40de5b80…`).
2. `PINNED_HASHES` in `bundled.test.ts` — integrity snapshot + satisfies the inventory invariant.
3. the bundled `pins` map in `scripts/update-hash-pins.ts` — so `pnpm fix:pins` tracks it.

Also wired `UPSTREAM_PATHS['automate'] → example-plugin/plugins/framework/skills/automate/SKILL.md` (automate lives in awa-dev, which maps to `framework`). The namespace-normalized drift comparison will enforce bundled↔upstream sync when `example-plugin` is co-located; it **skips** otherwise — as it does for every mirrorable skill in standalone checkouts today. No `INTENTIONAL_DIFFS` entry is needed because the copy is byte-equal.

## Verification
- `pnpm fix:pins:check` → "All hash pins are up to date."
- `pnpm test src/bundled-plugins/awa-bundled/bundled.test.ts` → 16 passed / 12 skipped (automate pinned-hash passes; inventory invariant passes; automate drift row skips, no co-located upstream).
- `src/agent/plugins/inventory.test.ts` + `tests/copy-bundled-plugins.test.ts` → 16 passed.
- `pnpm lint` (`tsc --noEmit`) → clean.

## Related
Source of the skill: the afk-native rewrite landed in the awa-private repo (`plugins/awa-dev/skills/automate/SKILL.md`). This PR vendors that byte-equal into the bundled plugin.

## Follow-up (not in this PR)
To activate the drift check, automate must also be ported to the public `example-plugin` mirror (`plugins/framework/skills/automate/`); until then the drift row skips by design.
