### PR TITLE
feat(plan-mode): model-callable exit_plan_mode tool with elicitation picker

### DIFF
--- a/src/agent/plan-mode-exit-prompt.ts
+++ b/src/agent/plan-mode-exit-prompt.ts
@@ -1,0 +1,36 @@
+/**
+ * The crafted "save the plan, then implement it" turn used when a session
+ * leaves plan mode.
+ *
+ * Invariant: this is the SINGLE source of truth for the plan-exit implement
+ * prompt. Two call sites materialize it and MUST produce byte-identical text:
+ *   - the `/plan off` slash command (`src/cli/slash/commands/plan.ts`), which
+ *     seeds it as the next REPL user turn; and
+ *   - the model-callable `exit_plan_mode` tool
+ *     (`src/agent/tools/handlers/exit-plan-mode.ts`), which seeds the same turn
+ *     through the session→REPL seed bridge on user approval.
+ *
+ * Lives in the agent layer (not under `src/cli`) so the agent-layer tool
+ * handler can import it without inverting the cli→agent dependency direction.
+ * It depends only on a pre-resolved `plansDir` string, so it pulls in nothing
+ * from either layer.
+ *
+ * @module agent/plan-mode-exit-prompt
+ */
+
+/**
+ * Build the prompt seeded into the user's next message buffer when plan mode
+ * is exited (via `/plan off` or an approved `exit_plan_mode`). `plansDir` is an
+ * absolute path to the session's `<cwd>/.afk/plans/` directory; the model picks
+ * a descriptive filename within it (the `write_file` tool creates the directory
+ * if absent).
+ */
+export function buildPlanExitPrompt(plansDir: string): string {
+  return [
+    'The user has switched off plan mode. Writes are now permitted. Do two things, in order:',
+    '',
+    `1. Save the plan. Write the plan you developed in this conversation to a new markdown file under \`${plansDir}/\` — pick a short, descriptive kebab-case filename (e.g. \`${plansDir}/refactor-auth-flow.md\`). Capture the full plan: the chosen approach, the concrete step-by-step changes, the risks named, and the alternatives considered. This is the durable record.`,
+    '',
+    '2. Implement the plan. Work through the steps you just recorded, verifying as you go — run the project\'s lint/test gates where they apply. End in a terminal state: Done with evidence, Blocked with the exact unblock condition, or Asking one precise question.',
+  ].join('\n');
+}

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -51,6 +51,12 @@ export { resolveEffort, resolveMaxTokens, resolveThinkingParam } from './resolve
 import type { ToolDispatcher } from './tool-dispatcher.js';
 import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { createBuiltinHandlers } from '../../tools/handlers/index.js';
+import {
+  exitPlanModeTool,
+  createExitPlanModeHandler,
+  EXIT_PLAN_MODE_TOOL_NAME,
+} from '../../tools/handlers/exit-plan-mode.js';
+import type { PlanExitControls } from '../../types/config-types.js';
 import { builtinToolSchemas, agentTool, skillTool, composeTool } from '../../tools/schemas.js';
 import { TOOL_SYSTEM_PROMPT_BASE, SLASH_COMMAND_ROUTING_PROMPT, BASH_PASSTHROUGH_PROMPT, MEMORY_SYSTEM_PROMPT, MEMORY_SYSTEM_PROMPT_READONLY } from '../../tools/system-prompt.js';
 import { withMcpToolsAllowed, type ToolPermissionConfig } from '../../tools/permissions.js';
@@ -322,6 +328,12 @@ export class AnthropicDirectProvider implements ModelProvider {
        * preserves any constructor-provided registry.
        */
       hookRegistry?: import('../../hooks.js').HookRegistry;
+      /**
+       * Session-control bridge for the model-callable `exit_plan_mode` tool,
+       * forwarded from the query config (top-level sessions only). When set AND
+       * `permissionMode === 'plan'`, the handler + schema are registered.
+       */
+      planExitControls?: PlanExitControls;
     },
   ): SessionToolDispatcher {
     const handlers = createBuiltinHandlers(permissionMode, opts?.cwd);
@@ -359,14 +371,28 @@ export class AnthropicDirectProvider implements ModelProvider {
       }
     }
     const mcpSchemas = this._mcpToolsCache ?? [];
+    // Plan-exit tool: the model-callable `exit_plan_mode`, registered per-query
+    // ONLY while in plan mode and only when the session supplied control
+    // callbacks (top-level sessions). Mirrors the `get_runtime_state` per-query
+    // registration above; the schema is appended to the dispatcher's list to
+    // match so the model sees the tool exactly when it is callable.
+    const planExitControls = permissionMode === 'plan' ? opts?.planExitControls : undefined;
+    if (planExitControls) {
+      handlers.set(EXIT_PLAN_MODE_TOOL_NAME, createExitPlanModeHandler(planExitControls));
+    }
     return new SessionToolDispatcher({
       handlers,
       // Bypass mode: when the session runs in bypassPermissions, every per-call
       // ToolHandlerContext carries allowAll:true so path containment is disabled.
       allowAll: permissionMode === 'bypassPermissions',
       // Constraint (semantic invariant): MCP schemas appended AFTER builtins
-      // so builtin tool names always take precedence in any overlap.
-      schemas: [...this.schemas, ...mcpSchemas],
+      // so builtin tool names always take precedence in any overlap. The
+      // plan-exit schema is appended last, only while the tool is active.
+      schemas: [
+        ...this.schemas,
+        ...mcpSchemas,
+        ...(planExitControls ? [exitPlanModeTool] : []),
+      ],
       // Session hook registry via the one canonical resolver (query-scoped
       // config registry wins over any constructor-provided one). Without this
       // the plan-mode gate (the sole built-in PreToolUse hook) never reached
@@ -670,6 +696,7 @@ export class AnthropicDirectProvider implements ModelProvider {
           traceWriter: config.traceWriter,
           runtimeStateSource,
           hookRegistry: config.hookRegistry,
+          planExitControls: config.planExitControls,
         });
 
     // External-dispatcher branch: the caller owns routing for whatever tools

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -32,6 +32,12 @@ import type { ToolDispatcher } from '../anthropic-direct/tool-dispatcher.js';
 import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { createBuiltinHandlers } from '../../tools/handlers/index.js';
 import {
+  exitPlanModeTool,
+  createExitPlanModeHandler,
+  EXIT_PLAN_MODE_TOOL_NAME,
+} from '../../tools/handlers/exit-plan-mode.js';
+import type { PlanExitControls } from '../../types/config-types.js';
+import {
   builtinToolSchemas,
   agentTool,
   skillTool,
@@ -214,6 +220,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
           ...(config.isSkillDispatch ? { isSkillDispatch: true } : {}),
           ...(config.isNonInteractive ? { isNonInteractive: true } : {}),
           ...(config.hookRegistry !== undefined ? { hookRegistry: config.hookRegistry } : {}),
+          ...(config.planExitControls !== undefined ? { planExitControls: config.planExitControls } : {}),
         });
 
     const buildOpts: {
@@ -323,6 +330,12 @@ export class OpenAICompatibleProvider implements ModelProvider {
        * `providerOpts.hookRegistry` when unset. Mirrors AnthropicDirectProvider.
        */
       hookRegistry?: import('../../hooks.js').HookRegistry;
+      /**
+       * Session-control bridge for `exit_plan_mode`, forwarded from the query
+       * config (top-level sessions only). When set AND `permissionMode ===
+       * 'plan'`, the handler + schema are registered. Mirrors AnthropicDirectProvider.
+       */
+      planExitControls?: PlanExitControls;
     },
   ): SessionToolDispatcher {
     const handlers = createBuiltinHandlers(permissionMode, opts.cwd);
@@ -337,6 +350,13 @@ export class OpenAICompatibleProvider implements ModelProvider {
     }
     if (opts.runtimeStateSource) {
       handlers.set('get_runtime_state', createGetRuntimeStateHandler(opts.runtimeStateSource));
+    }
+    // Plan-exit tool: registered per-query ONLY while in plan mode and only when
+    // the session supplied control callbacks (top-level sessions). Mirrors
+    // AnthropicDirectProvider.buildDispatcher; schema appended below to match.
+    const planExitControls = permissionMode === 'plan' ? opts.planExitControls : undefined;
+    if (planExitControls) {
+      handlers.set(EXIT_PLAN_MODE_TOOL_NAME, createExitPlanModeHandler(planExitControls));
     }
     // MCP handlers + schemas — fetched fresh each query so that
     // `notifications/tools/list_changed` refreshes are picked up without
@@ -366,8 +386,9 @@ export class OpenAICompatibleProvider implements ModelProvider {
     const dispatcherOpts: ConstructorParameters<typeof SessionToolDispatcher>[0] = {
       handlers,
       // Constraint (semantic invariant): MCP schemas appended AFTER builtins
-      // so builtin tool names always take precedence in any overlap.
-      schemas: [...baseSchemas, ...mcpSchemas],
+      // so builtin tool names always take precedence in any overlap. Plan-exit
+      // schema appended last, only while the tool is active (plan mode).
+      schemas: [...baseSchemas, ...mcpSchemas, ...(planExitControls ? [exitPlanModeTool] : [])],
       // Session hook registry via the one canonical resolver (query-scoped
       // config registry wins over any constructor-provided one). Mirrors
       // AnthropicDirectProvider; the required key on the dispatcher options

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -68,12 +68,14 @@ export class AgentSession implements IAgentSession {
   /**
    * Pending plan-exit implement-turn queued by an approved `exit_plan_mode`
    * tool call (via the injected {@link PlanExitControls}). The REPL drains it
-   * with {@link takePendingPlanExitSeed} after the current turn and auto-submits
-   * it as a fresh user message — reproducing `/plan off`'s save-and-implement
-   * handoff. Lives on the session (not the per-turn dispatcher) so it survives
-   * from the mid-turn tool call to the post-turn REPL boundary.
+   * with {@link takePendingPlanExitSeed} after the current turn, which atomically
+   * applies the deferred permission-mode flip and returns the seed message.
+   * Stores both the message and the approved mode so the flip can be deferred to
+   * the post-turn boundary — closing the mid-turn TOCTOU window.
+   * Lives on the session (not the per-turn dispatcher) so it survives from the
+   * mid-turn tool call to the post-turn REPL boundary.
    */
-  private _pendingPlanExitSeed: string | undefined;
+  private _pendingPlanExitSeed: { message: string; mode: PermissionMode } | undefined;
   private currentState: SessionState = 'idle';
   private providerQuery!: ProviderQuery;
   private providerIterator!: AsyncIterator<ProviderEvent>;
@@ -165,8 +167,8 @@ export class AgentSession implements IAgentSession {
             ...config,
             planExitControls: {
               setPermissionMode: (mode) => this.setPermissionMode(mode),
-              requestImplementSeed: (message) => {
-                this._pendingPlanExitSeed = message;
+              requestImplementSeed: (message, mode) => {
+                this._pendingPlanExitSeed = { message, mode };
               },
             },
           }
@@ -782,13 +784,35 @@ export class AgentSession implements IAgentSession {
    * Return and CLEAR the pending plan-exit implement-turn queued by an approved
    * `exit_plan_mode` call, or `undefined` if none is pending. The REPL drains
    * this at the top of each input-loop iteration (post-turn) and, when set,
-   * auto-submits the message as a fresh user turn. Single-shot: a second call
+   * atomically applies the deferred permission-mode flip then returns the seed
+   * message to be auto-submitted as a fresh user turn. Single-shot: a second call
    * returns `undefined` until the next approval.
+   *
+   * The mode flip is applied HERE (not in the handler) so the gate stays locked
+   * in plan mode for the entire model turn and only opens at this clean
+   * post-turn boundary — closing the mid-turn TOCTOU window.
+   *
+   * If the deferred flip rejects (e.g. the provider's query handle is closing —
+   * the same failure mode `togglePlanMode` guards for `/plan off`), the seed is
+   * DROPPED and `undefined` is returned: we must not auto-submit the
+   * implement-turn while still gate-locked in plan mode (it would only collect
+   * write refusals), and the rejection must not escape into the REPL input loop
+   * (which has no try/catch around this drain) and crash it. The model stays in
+   * plan mode and can retry `exit_plan_mode`.
    */
-  takePendingPlanExitSeed(): string | undefined {
+  async takePendingPlanExitSeed(): Promise<string | undefined> {
     const seed = this._pendingPlanExitSeed;
     this._pendingPlanExitSeed = undefined;
-    return seed;
+    if (seed === undefined) return undefined;
+    try {
+      await this.setPermissionMode(seed.mode);
+    } catch (err) {
+      debugLog(
+        `⚠️ AgentSession: deferred plan-exit mode flip to '${seed.mode}' rejected; dropping implement-seed (staying in plan mode): ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+    return seed.message;
   }
 
   /**

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -65,6 +65,15 @@ import { transformProviderEvent, type TransformDeps } from './stream-consumer.js
 
 export class AgentSession implements IAgentSession {
   private config: AgentConfig;
+  /**
+   * Pending plan-exit implement-turn queued by an approved `exit_plan_mode`
+   * tool call (via the injected {@link PlanExitControls}). The REPL drains it
+   * with {@link takePendingPlanExitSeed} after the current turn and auto-submits
+   * it as a fresh user message — reproducing `/plan off`'s save-and-implement
+   * handoff. Lives on the session (not the per-turn dispatcher) so it survives
+   * from the mid-turn tool call to the post-turn REPL boundary.
+   */
+  private _pendingPlanExitSeed: string | undefined;
   private currentState: SessionState = 'idle';
   private providerQuery!: ProviderQuery;
   private providerIterator!: AsyncIterator<ProviderEvent>;
@@ -144,7 +153,24 @@ export class AgentSession implements IAgentSession {
   private ledgerInitAttempted = false;
 
   constructor(config: AgentConfig) {
-    this.config = config;
+    // Wire the plan-exit control bridge for top-level sessions only (plan mode
+    // is a REPL affordance; subagent/forked sessions carry a parentSessionId).
+    // The model-callable `exit_plan_mode` tool uses these callbacks to flip the
+    // live permission mode and queue the implement-turn the REPL drains. Inert
+    // unless the session actually enters plan mode (the providers only register
+    // the tool then). Respect a caller-supplied bridge if one is already set.
+    this.config =
+      config.parentSessionId === undefined && config.planExitControls === undefined
+        ? {
+            ...config,
+            planExitControls: {
+              setPermissionMode: (mode) => this.setPermissionMode(mode),
+              requestImplementSeed: (message) => {
+                this._pendingPlanExitSeed = message;
+              },
+            },
+          }
+        : config;
     this.abortController = new AbortController();
     this._hookRegistry = config.hookRegistry;
 
@@ -750,6 +776,19 @@ export class AgentSession implements IAgentSession {
   async setPermissionMode(mode: PermissionMode): Promise<void> {
     await this.providerQuery.setPermissionMode(mode);
     this.stateManager.setSessionMetadata((prev) => ({ ...prev, permissionMode: mode }));
+  }
+
+  /**
+   * Return and CLEAR the pending plan-exit implement-turn queued by an approved
+   * `exit_plan_mode` call, or `undefined` if none is pending. The REPL drains
+   * this at the top of each input-loop iteration (post-turn) and, when set,
+   * auto-submits the message as a fresh user turn. Single-shot: a second call
+   * returns `undefined` until the next approval.
+   */
+  takePendingPlanExitSeed(): string | undefined {
+    const seed = this._pendingPlanExitSeed;
+    this._pendingPlanExitSeed = undefined;
+    return seed;
   }
 
   /**

--- a/src/agent/tools/handlers/exit-plan-mode.test.ts
+++ b/src/agent/tools/handlers/exit-plan-mode.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the `exit_plan_mode` tool: the elicitation picker → mode-flip +
+ * seed-bridge behavior, plus the `AgentSession` half (controls injection and
+ * the single-shot seed drain).
+ *
+ * The load-bearing guarantee (per the plan): an APPROVED exit seeds the SAME
+ * implement-turn `/plan off` produces — proven here by asserting equality with
+ * `buildPlanExitPrompt`, the single source of truth both paths share.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createExitPlanModeHandler } from './exit-plan-mode.js';
+import { elicitationRouter } from '../../elicitation-router.js';
+import { buildPlanExitPrompt } from '../../plan-mode-exit-prompt.js';
+import { getProjectPlansDir } from '../../../paths.js';
+import { AgentSession } from '../../session/agent-session.js';
+import { createMockProvider } from '../../__fixtures__/mock-provider.js';
+import type { PlanExitControls } from '../../types/config-types.js';
+import type { ModelProvider, ProviderQueryArgs, ProviderQuery } from '../../provider.js';
+import type { PermissionMode } from '../../types/sdk-types.js';
+
+const CWD = '/work/proj';
+
+/** Install an elicitation handler that picks `request.choices[idx]` (as the REPL
+ *  picker would), or `null` to leave none installed (route → decline). */
+function installPicker(idx: number | null): void {
+  if (idx === null) {
+    elicitationRouter.uninstall();
+    return;
+  }
+  elicitationRouter.install(async (request) => ({
+    action: 'accept',
+    content: { value: request.choices?.[idx] },
+  }));
+}
+
+function makeControls(): {
+  controls: PlanExitControls;
+  modeCalls: PermissionMode[];
+  seeds: string[];
+} {
+  const modeCalls: PermissionMode[] = [];
+  const seeds: string[] = [];
+  return {
+    modeCalls,
+    seeds,
+    controls: {
+      setPermissionMode: async (mode) => {
+        modeCalls.push(mode);
+      },
+      requestImplementSeed: (message) => {
+        seeds.push(message);
+      },
+    },
+  };
+}
+
+afterEach(() => {
+  elicitationRouter.uninstall();
+});
+
+describe('exit_plan_mode handler', () => {
+  it('approve→default: flips to default and seeds the same prompt as /plan off', async () => {
+    installPicker(0); // first choice = approve/default
+    const { controls, modeCalls, seeds } = makeControls();
+    const handler = createExitPlanModeHandler(controls);
+
+    const res = await handler({}, new AbortController().signal, { resolveBase: CWD });
+
+    expect(modeCalls).toEqual(['default']);
+    expect(seeds).toEqual([buildPlanExitPrompt(getProjectPlansDir(CWD))]);
+    expect(res.isError).toBeFalsy();
+    expect(res.content).toContain('mode=default');
+  });
+
+  it('approve→bypass: flips to bypassPermissions and seeds the same prompt', async () => {
+    installPicker(1); // second choice = approve/bypass
+    const { controls, modeCalls, seeds } = makeControls();
+    const handler = createExitPlanModeHandler(controls);
+
+    const res = await handler({}, new AbortController().signal, { resolveBase: CWD });
+
+    expect(modeCalls).toEqual(['bypassPermissions']);
+    expect(seeds).toEqual([buildPlanExitPrompt(getProjectPlansDir(CWD))]);
+    expect(res.isError).toBeFalsy();
+    expect(res.content).toContain('mode=bypassPermissions');
+  });
+
+  it('keep planning: no mode flip, no seed, stays in plan', async () => {
+    installPicker(2); // third choice = keep planning
+    const { controls, modeCalls, seeds } = makeControls();
+    const handler = createExitPlanModeHandler(controls);
+
+    const res = await handler({}, new AbortController().signal, { resolveBase: CWD });
+
+    expect(modeCalls).toEqual([]);
+    expect(seeds).toEqual([]);
+    expect(res.isError).toBeFalsy();
+    expect(res.content.toLowerCase()).toContain('keep planning');
+  });
+
+  it('declined (no elicitation handler): no flip, no seed, stays in plan', async () => {
+    installPicker(null); // none installed → route auto-declines
+    const { controls, modeCalls, seeds } = makeControls();
+    const handler = createExitPlanModeHandler(controls);
+
+    const res = await handler({}, new AbortController().signal, { resolveBase: CWD });
+
+    expect(modeCalls).toEqual([]);
+    expect(seeds).toEqual([]);
+    expect(res.content.toLowerCase()).toContain('not confirmed');
+  });
+
+  it('falls back to process.cwd() when no context resolveBase/cwd is supplied', async () => {
+    installPicker(0);
+    const { controls, seeds } = makeControls();
+    const handler = createExitPlanModeHandler(controls);
+
+    await handler({}, new AbortController().signal, undefined);
+
+    expect(seeds).toEqual([buildPlanExitPrompt(getProjectPlansDir(process.cwd()))]);
+  });
+});
+
+describe('AgentSession plan-exit seed bridge', () => {
+  /** Wrap a mock provider to capture the AgentConfig the session passes down. */
+  function capturingProvider(): { provider: ModelProvider; getControls: () => PlanExitControls | undefined } {
+    const base = createMockProvider();
+    let captured: PlanExitControls | undefined;
+    const provider: ModelProvider = {
+      name: 'capture',
+      query: (args: ProviderQueryArgs): ProviderQuery => {
+        captured = args.config.planExitControls;
+        return base.query(args);
+      },
+    };
+    return { provider, getControls: () => captured };
+  }
+
+  it('top-level session: injects controls wired to a single-shot seed slot', async () => {
+    const { provider, getControls } = capturingProvider();
+    const session = new AgentSession({ model: 'sonnet', apiKey: 'test-key', provider });
+    await session.waitForInitialization();
+
+    expect(session.takePendingPlanExitSeed()).toBeUndefined();
+
+    const controls = getControls();
+    expect(controls).toBeDefined();
+    controls!.requestImplementSeed('SEED-MSG');
+
+    expect(session.takePendingPlanExitSeed()).toBe('SEED-MSG');
+    // Single-shot: drained value is cleared.
+    expect(session.takePendingPlanExitSeed()).toBeUndefined();
+
+    await session.close();
+  });
+
+  it('subagent session (parentSessionId set): does NOT receive plan-exit controls', async () => {
+    const { provider, getControls } = capturingProvider();
+    const session = new AgentSession({
+      model: 'sonnet',
+      apiKey: 'test-key',
+      provider,
+      parentSessionId: 'parent-1',
+    });
+    await session.waitForInitialization();
+
+    expect(getControls()).toBeUndefined();
+
+    await session.close();
+  });
+});

--- a/src/agent/tools/handlers/exit-plan-mode.test.ts
+++ b/src/agent/tools/handlers/exit-plan-mode.test.ts
@@ -37,10 +37,10 @@ function installPicker(idx: number | null): void {
 function makeControls(): {
   controls: PlanExitControls;
   modeCalls: PermissionMode[];
-  seeds: string[];
+  seeds: Array<{ message: string; mode: PermissionMode }>;
 } {
   const modeCalls: PermissionMode[] = [];
-  const seeds: string[] = [];
+  const seeds: Array<{ message: string; mode: PermissionMode }> = [];
   return {
     modeCalls,
     seeds,
@@ -48,8 +48,8 @@ function makeControls(): {
       setPermissionMode: async (mode) => {
         modeCalls.push(mode);
       },
-      requestImplementSeed: (message) => {
-        seeds.push(message);
+      requestImplementSeed: (message, mode) => {
+        seeds.push({ message, mode });
       },
     },
   };
@@ -60,28 +60,32 @@ afterEach(() => {
 });
 
 describe('exit_plan_mode handler', () => {
-  it('approve→default: flips to default and seeds the same prompt as /plan off', async () => {
+  it('approve→default: defers mode to seed (no mid-turn flip) and seeds the same prompt as /plan off', async () => {
     installPicker(0); // first choice = approve/default
     const { controls, modeCalls, seeds } = makeControls();
     const handler = createExitPlanModeHandler(controls);
 
     const res = await handler({}, new AbortController().signal, { resolveBase: CWD });
 
-    expect(modeCalls).toEqual(['default']);
-    expect(seeds).toEqual([buildPlanExitPrompt(getProjectPlansDir(CWD))]);
+    // Handler must NOT call setPermissionMode — flip is deferred to drain time.
+    expect(modeCalls).toEqual([]);
+    // Seed carries both the message and the approved mode.
+    expect(seeds).toEqual([{ message: buildPlanExitPrompt(getProjectPlansDir(CWD)), mode: 'default' }]);
     expect(res.isError).toBeFalsy();
     expect(res.content).toContain('mode=default');
   });
 
-  it('approve→bypass: flips to bypassPermissions and seeds the same prompt', async () => {
+  it('approve→bypass: defers mode to seed (no mid-turn flip) and seeds the same prompt', async () => {
     installPicker(1); // second choice = approve/bypass
     const { controls, modeCalls, seeds } = makeControls();
     const handler = createExitPlanModeHandler(controls);
 
     const res = await handler({}, new AbortController().signal, { resolveBase: CWD });
 
-    expect(modeCalls).toEqual(['bypassPermissions']);
-    expect(seeds).toEqual([buildPlanExitPrompt(getProjectPlansDir(CWD))]);
+    // Handler must NOT call setPermissionMode — flip is deferred to drain time.
+    expect(modeCalls).toEqual([]);
+    // Seed carries both the message and the approved mode.
+    expect(seeds).toEqual([{ message: buildPlanExitPrompt(getProjectPlansDir(CWD)), mode: 'bypassPermissions' }]);
     expect(res.isError).toBeFalsy();
     expect(res.content).toContain('mode=bypassPermissions');
   });
@@ -118,7 +122,7 @@ describe('exit_plan_mode handler', () => {
 
     await handler({}, new AbortController().signal, undefined);
 
-    expect(seeds).toEqual([buildPlanExitPrompt(getProjectPlansDir(process.cwd()))]);
+    expect(seeds).toEqual([{ message: buildPlanExitPrompt(getProjectPlansDir(process.cwd())), mode: 'default' }]);
   });
 });
 
@@ -137,20 +141,55 @@ describe('AgentSession plan-exit seed bridge', () => {
     return { provider, getControls: () => captured };
   }
 
-  it('top-level session: injects controls wired to a single-shot seed slot', async () => {
+  it('top-level session: injects controls wired to a single-shot seed slot; drain applies the deferred mode flip', async () => {
     const { provider, getControls } = capturingProvider();
     const session = new AgentSession({ model: 'sonnet', apiKey: 'test-key', provider });
     await session.waitForInitialization();
 
-    expect(session.takePendingPlanExitSeed()).toBeUndefined();
+    expect(await session.takePendingPlanExitSeed()).toBeUndefined();
 
     const controls = getControls();
     expect(controls).toBeDefined();
-    controls!.requestImplementSeed('SEED-MSG');
+    // Pass the approved mode alongside the seed message (new signature).
+    controls!.requestImplementSeed('SEED-MSG', 'default');
 
-    expect(session.takePendingPlanExitSeed()).toBe('SEED-MSG');
+    // takePendingPlanExitSeed is now async — it applies the mode flip then returns the message.
+    expect(await session.takePendingPlanExitSeed()).toBe('SEED-MSG');
     // Single-shot: drained value is cleared.
-    expect(session.takePendingPlanExitSeed()).toBeUndefined();
+    expect(await session.takePendingPlanExitSeed()).toBeUndefined();
+
+    await session.close();
+  });
+
+  it('drain drops the seed (returns undefined) when the deferred mode flip rejects', async () => {
+    // Decorate the mock query so setPermissionMode rejects — the same failure
+    // mode togglePlanMode guards for `/plan off`. The drain must swallow it,
+    // drop the seed, and stay in plan mode rather than throwing into the REPL
+    // loop or auto-submitting an implement-turn while still gate-locked.
+    const base = createMockProvider();
+    let captured: PlanExitControls | undefined;
+    const provider: ModelProvider = {
+      name: 'reject-flip',
+      query: (args: ProviderQueryArgs): ProviderQuery => {
+        captured = args.config.planExitControls;
+        const q = base.query(args);
+        return {
+          ...q,
+          setPermissionMode: async () => {
+            throw new Error('query handle closing');
+          },
+        };
+      },
+    };
+    const session = new AgentSession({ model: 'sonnet', apiKey: 'test-key', provider });
+    await session.waitForInitialization();
+
+    captured!.requestImplementSeed('SEED-MSG', 'bypassPermissions');
+
+    // Flip rejects → seed dropped, no throw, undefined returned.
+    await expect(session.takePendingPlanExitSeed()).resolves.toBeUndefined();
+    // Single-shot: the dropped seed is cleared (a retry still returns undefined).
+    await expect(session.takePendingPlanExitSeed()).resolves.toBeUndefined();
 
     await session.close();
   });

--- a/src/agent/tools/handlers/exit-plan-mode.ts
+++ b/src/agent/tools/handlers/exit-plan-mode.ts
@@ -8,13 +8,17 @@
  *   - approve → implement in `bypassPermissions` mode (no prompts, read/write anywhere)
  *   - keep planning (stay in plan; refine)
  *
- * On approval the handler (a) flips the live permission mode via the injected
- * {@link PlanExitControls.setPermissionMode} and (b) queues the SAME crafted
- * implement-turn `/plan off` uses ({@link buildPlanExitPrompt}) via
- * {@link PlanExitControls.requestImplementSeed}. The REPL drains that seed after
- * the current turn (`src/cli/commands/interactive/loop-iteration.ts`) and
- * auto-submits it — so the model receives an explicit, high-quality
- * save-and-implement instruction rather than self-directing from a tool string.
+ * On approval the handler records the approved mode ALONGSIDE the seed message
+ * via {@link PlanExitControls.requestImplementSeed} — the mode flip is NOT
+ * applied here. It is deferred to the post-turn drain boundary in the REPL loop
+ * (`src/cli/commands/interactive/loop-iteration.ts`), where
+ * `takePendingPlanExitSeed()` atomically applies the flip and promotes the seed.
+ * This mirrors how `/plan off` works: the gate stays LOCKED in plan mode for the
+ * entire current turn; it only opens for the clean, seeded implement-turn that
+ * follows — closing the mid-turn TOCTOU window.
+ *
+ * The seeded implement-turn is the SAME crafted prompt {@link buildPlanExitPrompt}
+ * produces — byte-identical to `/plan off`'s handoff.
  *
  * Invariant: the tool is offered ONLY while `permissionMode === 'plan'` (the
  * providers gate registration on that), and `PlanExitControls` is supplied only
@@ -78,6 +82,11 @@ export const exitPlanModeTool: AnthropicToolDef = {
 /**
  * Factory producing a handler closed over the session's {@link PlanExitControls}.
  * Registered per-query by the providers' `buildDispatcher` while in plan mode.
+ *
+ * Security note: the handler does NOT flip the permission mode. It records the
+ * approved mode alongside the seed via `controls.requestImplementSeed(msg, mode)`
+ * and the flip is applied atomically at the post-turn drain boundary — so the
+ * gate remains locked in plan mode for the rest of this turn.
  */
 export function createExitPlanModeHandler(controls: PlanExitControls): ToolHandler {
   return async (_input, signal, context) => {
@@ -121,22 +130,13 @@ export function createExitPlanModeHandler(controls: PlanExitControls): ToolHandl
 
     const mode = picked.includes('bypass') ? 'bypassPermissions' : 'default';
 
-    // Flip the live permission mode so the seeded implement-turn (next turn)
-    // runs with writes permitted. Surfaced as a tool error only if the flip
-    // itself rejects — without it, the seeded turn would collect gate refusals.
-    try {
-      await controls.setPermissionMode(mode);
-    } catch (err) {
-      return {
-        content: `Could not exit plan mode: ${err instanceof Error ? err.message : String(err)}`,
-        isError: true,
-      };
-    }
-
-    // Queue the SAME crafted save-and-implement turn `/plan off` seeds. The REPL
-    // drains it after this turn and auto-submits it as a fresh user message.
+    // Record the approved mode ALONGSIDE the seed. The permission flip is deferred
+    // to the post-turn drain boundary (loop-iteration.ts → takePendingPlanExitSeed)
+    // so the gate stays locked in plan mode for the remainder of this turn —
+    // closing the mid-turn TOCTOU window where the model could issue write tools
+    // in bypass mode before actually ending its turn.
     const plansDir = getProjectPlansDir(context?.resolveBase ?? context?.cwd ?? process.cwd());
-    controls.requestImplementSeed(buildPlanExitPrompt(plansDir));
+    controls.requestImplementSeed(buildPlanExitPrompt(plansDir), mode);
 
     return {
       content:

--- a/src/agent/tools/handlers/exit-plan-mode.ts
+++ b/src/agent/tools/handlers/exit-plan-mode.ts
@@ -1,0 +1,147 @@
+/**
+ * `exit_plan_mode` tool — schema + handler factory.
+ *
+ * The model-proposed counterpart to the `/plan off` slash command. When the
+ * model judges its plan ready, it calls `exit_plan_mode`; the handler runs an
+ * elicitation picker so the USER chooses how to proceed:
+ *   - approve → implement in `default` mode (writes with path containment + prompts)
+ *   - approve → implement in `bypassPermissions` mode (no prompts, read/write anywhere)
+ *   - keep planning (stay in plan; refine)
+ *
+ * On approval the handler (a) flips the live permission mode via the injected
+ * {@link PlanExitControls.setPermissionMode} and (b) queues the SAME crafted
+ * implement-turn `/plan off` uses ({@link buildPlanExitPrompt}) via
+ * {@link PlanExitControls.requestImplementSeed}. The REPL drains that seed after
+ * the current turn (`src/cli/commands/interactive/loop-iteration.ts`) and
+ * auto-submits it — so the model receives an explicit, high-quality
+ * save-and-implement instruction rather than self-directing from a tool string.
+ *
+ * Invariant: the tool is offered ONLY while `permissionMode === 'plan'` (the
+ * providers gate registration on that), and `PlanExitControls` is supplied only
+ * for top-level sessions, so it never fires on subagent / non-interactive
+ * surfaces. It is not in the `WRITE_TOOLS` set, so the plan-mode gate
+ * (`src/agent/plan-mode-gate.ts`) passes it through automatically.
+ *
+ * Colocated (schema + handler) like the awareness tool
+ * (`src/agent/awareness/tool.ts`) because the handler's contract is intrinsic
+ * to the tool — it owns the picker wording and the approve→mode mapping.
+ *
+ * @module agent/tools/handlers/exit-plan-mode
+ */
+
+import type { AnthropicToolDef, ToolHandler } from '../types.js';
+import type { PlanExitControls } from '../../types/config-types.js';
+import type { ElicitationRequest } from '../../types/sdk-types.js';
+import { elicitationRouter } from '../../elicitation-router.js';
+import { buildPlanExitPrompt } from '../../plan-mode-exit-prompt.js';
+import { getProjectPlansDir } from '../../../paths.js';
+
+/** Stable tool name — must be present in the session's tool allowlist. */
+export const EXIT_PLAN_MODE_TOOL_NAME = 'exit_plan_mode';
+
+// Choice labels. Kept clean ASCII < 128 chars so the REPL picker's
+// `sanitizeSchemaString` is a no-op and `content.value` round-trips verbatim.
+const CHOICE_DEFAULT = 'Approve — implement now (default mode: writes ask for confirmation, contained to the workspace)';
+const CHOICE_BYPASS = 'Approve — implement now (bypass mode: no prompts, read/write any path)';
+const CHOICE_KEEP = 'Keep planning';
+
+/**
+ * Tool definition for `exit_plan_mode`. Signal-only: no parameters — the plan
+ * lives in the conversation, and the seeded implement-turn instructs the model
+ * to write it to a file. The description carries the when-to-call contract;
+ * `plan-mode-addendum.ts` reinforces it at turn start.
+ */
+export const exitPlanModeTool: AnthropicToolDef = {
+  name: EXIT_PLAN_MODE_TOOL_NAME,
+  category: 'other',
+  concurrencySafe: false,
+  description:
+    'Signal that your plan is ready and present it to the user for approval. ' +
+    'The user is shown a picker: approve and implement (you pick neither mode — ' +
+    'the user does), or keep planning.\n\n' +
+    'IMPORTANT: only call this in plan mode, and only when the task requires ' +
+    'implementation (writing code or files). For research / read-only / ' +
+    'understanding tasks, do NOT call it — just answer.\n\n' +
+    'Do NOT ask "is this plan ok?" with ask_question — that is what this tool ' +
+    'does. Resolve any open requirement questions with ask_question FIRST, then ' +
+    'call exit_plan_mode.\n\n' +
+    'After calling this tool, END YOUR TURN. On approval you will receive a ' +
+    'separate instruction to save the plan and implement it — do not start ' +
+    'implementing in the same turn.',
+  input_schema: {
+    type: 'object',
+    properties: {},
+    required: [],
+  },
+};
+
+/**
+ * Factory producing a handler closed over the session's {@link PlanExitControls}.
+ * Registered per-query by the providers' `buildDispatcher` while in plan mode.
+ */
+export function createExitPlanModeHandler(controls: PlanExitControls): ToolHandler {
+  return async (_input, signal, context) => {
+    const request: ElicitationRequest = {
+      serverName: 'agent',
+      origin: 'agent',
+      type: 'choice',
+      message:
+        'Plan ready. How do you want to proceed? ' +
+        '(Your plan is in the conversation above.)',
+      choices: [CHOICE_DEFAULT, CHOICE_BYPASS, CHOICE_KEEP],
+    };
+
+    const result = await elicitationRouter.route(request, { signal });
+
+    // No human reachable (no handler) or the user interrupted → stay in plan
+    // mode and let the model keep refining. Not an error: declining to exit is
+    // a legitimate outcome, mirroring `/plan`'s no-op when already planning.
+    if (result.action !== 'accept') {
+      return {
+        content:
+          'Plan exit not confirmed (the user did not approve). Stay in plan mode — ' +
+          'keep refining the plan; do not implement. Call exit_plan_mode again when ready.',
+      };
+    }
+
+    const picked = typeof result.content?.['value'] === 'string'
+      ? (result.content['value'] as string)
+      : '';
+
+    // Keyword matching is robust to picker sanitization / numbered-fallback
+    // round-tripping. Order matters: detect "keep" first, then the dangerous
+    // "bypass" branch, else the default-mode approval.
+    if (picked.startsWith('Keep') || picked === CHOICE_KEEP) {
+      return {
+        content:
+          'User chose to keep planning. Stay in plan mode and refine the plan; ' +
+          'do not implement. Call exit_plan_mode again when ready.',
+      };
+    }
+
+    const mode = picked.includes('bypass') ? 'bypassPermissions' : 'default';
+
+    // Flip the live permission mode so the seeded implement-turn (next turn)
+    // runs with writes permitted. Surfaced as a tool error only if the flip
+    // itself rejects — without it, the seeded turn would collect gate refusals.
+    try {
+      await controls.setPermissionMode(mode);
+    } catch (err) {
+      return {
+        content: `Could not exit plan mode: ${err instanceof Error ? err.message : String(err)}`,
+        isError: true,
+      };
+    }
+
+    // Queue the SAME crafted save-and-implement turn `/plan off` seeds. The REPL
+    // drains it after this turn and auto-submits it as a fresh user message.
+    const plansDir = getProjectPlansDir(context?.resolveBase ?? context?.cwd ?? process.cwd());
+    controls.requestImplementSeed(buildPlanExitPrompt(plansDir));
+
+    return {
+      content:
+        `Plan approved (mode=${mode}). The implementation instruction will follow ` +
+        'as a new message — end your turn now.',
+    };
+  };
+}

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -36,6 +36,26 @@ export interface ResumeHistoryTurn {
   assistant: string;
 }
 
+/**
+ * Session-control callbacks handed to the model-callable `exit_plan_mode` tool
+ * so an approved plan exit can (a) flip the live permission mode and (b) queue
+ * the crafted implement-turn for the REPL to auto-submit after the current turn
+ * — reproducing `/plan off`'s save-and-implement handoff from a model-proposed,
+ * elicitation-confirmed exit.
+ *
+ * Populated by `AgentSession` for top-level sessions only (plan mode is a REPL
+ * affordance); the `exit_plan_mode` schema is offered solely while
+ * `permissionMode === 'plan'`, so these callbacks are inert on every other
+ * surface. See `src/agent/tools/handlers/exit-plan-mode.ts` and the seed drain
+ * at `src/cli/commands/interactive/loop-iteration.ts`.
+ */
+export interface PlanExitControls {
+  /** Flip the live session permission mode on approval (e.g. 'default' | 'bypassPermissions'). */
+  setPermissionMode(mode: PermissionMode): Promise<void>;
+  /** Queue the crafted implement-turn message for the REPL to auto-submit after this turn. */
+  requestImplementSeed(message: string): void;
+}
+
 /** Agent session configuration */
 export interface AgentConfig {
   /**
@@ -262,6 +282,14 @@ export interface AgentConfig {
    * SDK event plumbing.
    */
   hookRegistry?: HookRegistry;
+
+  /**
+   * Session-control bridge for the model-callable `exit_plan_mode` tool. When
+   * present (top-level sessions), the providers register the `exit_plan_mode`
+   * handler + schema while `permissionMode === 'plan'`. Absent → the tool is
+   * never offered. See {@link PlanExitControls}.
+   */
+  planExitControls?: PlanExitControls;
 
   /**
    * Witness-layer trace writer. When provided, {@link IAgentSession}

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -38,10 +38,17 @@ export interface ResumeHistoryTurn {
 
 /**
  * Session-control callbacks handed to the model-callable `exit_plan_mode` tool
- * so an approved plan exit can (a) flip the live permission mode and (b) queue
- * the crafted implement-turn for the REPL to auto-submit after the current turn
- * — reproducing `/plan off`'s save-and-implement handoff from a model-proposed,
- * elicitation-confirmed exit.
+ * so an approved plan exit can queue the crafted implement-turn for the REPL to
+ * auto-submit after the current turn — reproducing `/plan off`'s
+ * save-and-implement handoff from a model-proposed, elicitation-confirmed exit.
+ *
+ * **Deferred-flip contract**: the handler does NOT flip the permission mode
+ * mid-turn. Instead it records the approved mode alongside the seed message via
+ * `requestImplementSeed`. The mode flip is deferred to the post-turn drain
+ * boundary in `src/cli/commands/interactive/loop-iteration.ts`, where
+ * `takePendingPlanExitSeed()` atomically applies the flip and promotes the seed
+ * — so the gate stays locked in plan mode for the entire current turn and only
+ * opens for the clean, seeded implement-turn that follows.
  *
  * Populated by `AgentSession` for top-level sessions only (plan mode is a REPL
  * affordance); the `exit_plan_mode` schema is offered solely while
@@ -52,8 +59,12 @@ export interface ResumeHistoryTurn {
 export interface PlanExitControls {
   /** Flip the live session permission mode on approval (e.g. 'default' | 'bypassPermissions'). */
   setPermissionMode(mode: PermissionMode): Promise<void>;
-  /** Queue the crafted implement-turn message for the REPL to auto-submit after this turn. */
-  requestImplementSeed(message: string): void;
+  /**
+   * Queue the crafted implement-turn message AND the approved mode for the REPL
+   * to apply atomically at the post-turn drain boundary. The mode flip is NOT
+   * applied here — it is deferred to `takePendingPlanExitSeed()`.
+   */
+  requestImplementSeed(message: string, mode: PermissionMode): void;
 }
 
 /** Agent session configuration */

--- a/src/agent/types/session-types.ts
+++ b/src/agent/types/session-types.ts
@@ -213,11 +213,13 @@ export interface IAgentSession {
 
   /**
    * Return and CLEAR any implement-turn queued by an approved `exit_plan_mode`
-   * tool call. The REPL drains this post-turn and auto-submits it as a fresh
-   * user message (reproducing `/plan off`'s save-and-implement handoff).
-   * Returns `undefined` when nothing is pending.
+   * tool call. Atomically applies the deferred permission-mode flip (closing the
+   * mid-turn TOCTOU window) then returns the seed message. The REPL drains this
+   * post-turn and auto-submits the message as a fresh user turn (reproducing
+   * `/plan off`'s save-and-implement handoff). Returns `undefined` when nothing
+   * is pending.
    */
-  takePendingPlanExitSeed(): string | undefined;
+  takePendingPlanExitSeed(): Promise<string | undefined>;
 
   waitForInitialization(): Promise<SessionMetadata>;
 

--- a/src/agent/types/session-types.ts
+++ b/src/agent/types/session-types.ts
@@ -211,6 +211,14 @@ export interface IAgentSession {
   setModel(model?: AgentModelInput): Promise<void>;
   setPermissionMode(mode: PermissionMode): Promise<void>;
 
+  /**
+   * Return and CLEAR any implement-turn queued by an approved `exit_plan_mode`
+   * tool call. The REPL drains this post-turn and auto-submits it as a fresh
+   * user message (reproducing `/plan off`'s save-and-implement handoff).
+   * Returns `undefined` when nothing is pending.
+   */
+  takePendingPlanExitSeed(): string | undefined;
+
   waitForInitialization(): Promise<SessionMetadata>;
 
   getSessionIdentity(): SessionIdentity;

--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -119,7 +119,7 @@ function makeCtx(): InteractiveCtx {
       current: {
         sessionId: 'mock',
         waitForInitialization: vi.fn(async () => ({})),
-        takePendingPlanExitSeed: vi.fn(() => undefined),
+        takePendingPlanExitSeed: vi.fn(async () => undefined),
       },
     },
     stats: {

--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -119,6 +119,7 @@ function makeCtx(): InteractiveCtx {
       current: {
         sessionId: 'mock',
         waitForInitialization: vi.fn(async () => ({})),
+        takePendingPlanExitSeed: vi.fn(() => undefined),
       },
     },
     stats: {

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -173,6 +173,19 @@ export async function runInputLoop(
       let text: string;
       let attachments: ReadWithAutocompleteResult['attachments'];
 
+      // Drain any implement-turn queued by an approved `exit_plan_mode` tool
+      // call during the previous turn. The session held it (the per-turn tool
+      // dispatcher can't reach this REPL loop), so we promote it to the seed
+      // buffer here, post-turn — the model-proposed counterpart to `/plan off`'s
+      // seeded save-and-implement handoff. A `/plan off` seed (set directly,
+      // same turn) takes precedence if both are somehow present.
+      if (seedBuffer === undefined) {
+        const planExitSeed = ctx.session.current.takePendingPlanExitSeed();
+        if (planExitSeed !== undefined) {
+          seedBuffer = { text: planExitSeed, attachments: [] };
+        }
+      }
+
       if (seedBuffer !== undefined) {
         // Slash-command follow-up: a previous handler returned
         // { kind: 'submit', message } to chain itself with a user-text

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -180,7 +180,7 @@ export async function runInputLoop(
       // seeded save-and-implement handoff. A `/plan off` seed (set directly,
       // same turn) takes precedence if both are somehow present.
       if (seedBuffer === undefined) {
-        const planExitSeed = ctx.session.current.takePendingPlanExitSeed();
+        const planExitSeed = await ctx.session.current.takePendingPlanExitSeed();
         if (planExitSeed !== undefined) {
           seedBuffer = { text: planExitSeed, attachments: [] };
         }

--- a/src/cli/commands/interactive/repl-loop-wiring.test.ts
+++ b/src/cli/commands/interactive/repl-loop-wiring.test.ts
@@ -122,6 +122,7 @@ function makeMinimalCtx(backgroundRegistry: BackgroundAgentRegistry): Interactiv
       current: {
         sessionId: 'mock',
         waitForInitialization: vi.fn(async () => ({})),
+        takePendingPlanExitSeed: vi.fn(() => undefined),
       },
     },
     memoryStore: {} as never,

--- a/src/cli/commands/interactive/repl-loop-wiring.test.ts
+++ b/src/cli/commands/interactive/repl-loop-wiring.test.ts
@@ -122,7 +122,7 @@ function makeMinimalCtx(backgroundRegistry: BackgroundAgentRegistry): Interactiv
       current: {
         sessionId: 'mock',
         waitForInitialization: vi.fn(async () => ({})),
-        takePendingPlanExitSeed: vi.fn(() => undefined),
+        takePendingPlanExitSeed: vi.fn(async () => undefined),
       },
     },
     memoryStore: {} as never,

--- a/src/cli/parse-provider-agent-tool.test.ts
+++ b/src/cli/parse-provider-agent-tool.test.ts
@@ -27,6 +27,7 @@ import { OpenAICompatibleProvider } from '../agent/providers/openai-compatible/i
 import { BUILTIN_TOOL_NAMES } from '../agent/tools/schemas.js';
 import { MEMORY_TOOL_NAMES } from '../agent/memory/index.js';
 import { AWARENESS_TOOL_NAMES } from '../agent/awareness/index.js';
+import { EXIT_PLAN_MODE_TOOL_NAME } from '../agent/tools/handlers/exit-plan-mode.js';
 import type { SubagentExecutor } from '../agent/tools/subagent-executor.js';
 import type { ComposeExecutor } from '../agent/tools/compose-executor.js';
 import type { SkillExecutor } from '../agent/tools/skill-executor.js';
@@ -75,15 +76,23 @@ describe('parseProvider — Agent tool allowlist wiring (PR #84)', () => {
     expect(() => parseProvider('bogus')).toThrow(/anthropic-direct/);
   });
 
-  it("anthropic-direct without a subagentExecutor: allowlist === BUILTIN_TOOL_NAMES + MEMORY_TOOL_NAMES + AWARENESS_TOOL_NAMES (no 'agent')", () => {
+  it("anthropic-direct without a subagentExecutor: allowlist === BUILTIN + MEMORY + AWARENESS + exit_plan_mode (no 'agent')", () => {
     const provider = parseProvider('anthropic-direct');
     expect(provider).toBeInstanceOf(AnthropicDirectProvider);
     const allowed = readAllowedTools(provider as AnthropicDirectProvider);
     // Awareness tools (`get_runtime_state`) are always-on — every provider
     // registers their handlers unconditionally, so the allowlist must include
     // them or the dispatcher permission gate rejects the registered handler.
-    expect(allowed).toEqual([...BUILTIN_TOOL_NAMES, ...MEMORY_TOOL_NAMES, ...AWARENESS_TOOL_NAMES]);
+    // `exit_plan_mode` is registered only in plan mode but its name is statically
+    // present in the allowlist (the list is snapshotted at construction).
+    expect(allowed).toEqual([
+      ...BUILTIN_TOOL_NAMES,
+      ...MEMORY_TOOL_NAMES,
+      ...AWARENESS_TOOL_NAMES,
+      EXIT_PLAN_MODE_TOOL_NAME,
+    ]);
     expect(allowed).toContain('get_runtime_state');
+    expect(allowed).toContain('exit_plan_mode');
     expect(allowed).not.toContain('agent');
   });
 
@@ -110,7 +119,8 @@ describe('parseProvider — Agent tool allowlist wiring (PR #84)', () => {
     // 'agent' is added exactly once and the total length matches.
     expect(list.filter((n) => n === 'agent')).toHaveLength(1);
     expect(list).toHaveLength(
-      BUILTIN_TOOL_NAMES.length + MEMORY_TOOL_NAMES.length + AWARENESS_TOOL_NAMES.length + 1,
+      // builtins + memory + awareness + exit_plan_mode + agent
+      BUILTIN_TOOL_NAMES.length + MEMORY_TOOL_NAMES.length + AWARENESS_TOOL_NAMES.length + 1 + 1,
     );
   });
 
@@ -187,8 +197,14 @@ describe('parseProvider — openai-compatible wiring (slice 4)', () => {
     const provider = parseProvider('openai');
     expect(provider).toBeInstanceOf(OpenAICompatibleProvider);
     const allowed = readOpenAIAllowedTools(provider as OpenAICompatibleProvider);
-    expect(allowed).toEqual([...BUILTIN_TOOL_NAMES, ...MEMORY_TOOL_NAMES, ...AWARENESS_TOOL_NAMES]);
+    expect(allowed).toEqual([
+      ...BUILTIN_TOOL_NAMES,
+      ...MEMORY_TOOL_NAMES,
+      ...AWARENESS_TOOL_NAMES,
+      EXIT_PLAN_MODE_TOOL_NAME,
+    ]);
     expect(allowed).toContain('get_runtime_state');
+    expect(allowed).toContain('exit_plan_mode');
     expect(allowed).not.toContain('agent');
     expect(allowed).not.toContain('skill');
     expect(allowed).not.toContain('compose');
@@ -227,12 +243,14 @@ describe('parseProvider — openai-compatible wiring (slice 4)', () => {
     const allowed = readOpenAIAllowedTools(provider as OpenAICompatibleProvider);
     expect(allowed).toBeDefined();
     expect(allowed).toHaveLength(
-      BUILTIN_TOOL_NAMES.length + MEMORY_TOOL_NAMES.length + AWARENESS_TOOL_NAMES.length + 3,
+      // builtins + memory + awareness + exit_plan_mode + agent + skill + compose
+      BUILTIN_TOOL_NAMES.length + MEMORY_TOOL_NAMES.length + AWARENESS_TOOL_NAMES.length + 1 + 3,
     );
     expect(allowed).toContain('agent');
     expect(allowed).toContain('skill');
     expect(allowed).toContain('compose');
     expect(allowed).toContain('get_runtime_state');
+    expect(allowed).toContain('exit_plan_mode');
   });
 });
 

--- a/src/cli/shared-helpers.ts
+++ b/src/cli/shared-helpers.ts
@@ -7,6 +7,7 @@ import type { ModelProvider } from '../agent/provider.js';
 import { BUILTIN_TOOL_NAMES } from '../agent/tools/schemas.js';
 import { MEMORY_TOOL_NAMES } from '../agent/memory/index.js';
 import { AWARENESS_TOOL_NAMES } from '../agent/awareness/index.js';
+import { EXIT_PLAN_MODE_TOOL_NAME } from '../agent/tools/handlers/exit-plan-mode.js';
 
 import type { AgentModelInput, ThinkingConfig, EffortLevel } from '../agent/types.js';
 import { loadConfig } from './config.js';
@@ -419,7 +420,11 @@ export function parseProvider(
     // every provider (see `anthropic-direct/index.ts`, `openai-compatible/index.ts`),
     // so the allowlist must include them or the dispatcher's permission gate
     // rejects the registered handler. Source of truth: `agent/awareness/tool.ts`.
-    const list = [...BUILTIN_TOOL_NAMES, ...MEMORY_TOOL_NAMES, ...AWARENESS_TOOL_NAMES];
+    // `exit_plan_mode` is registered only while in plan mode, but the allowlist
+    // is static (snapshotted at construction), so its name must be present here
+    // or the gate rejects it the moment the model calls it. Harmless when the
+    // tool is not registered (the dispatcher just never routes to it).
+    const list = [...BUILTIN_TOOL_NAMES, ...MEMORY_TOOL_NAMES, ...AWARENESS_TOOL_NAMES, EXIT_PLAN_MODE_TOOL_NAME];
     if (opts?.subagentExecutor) list.push('agent');
     if (opts?.skillExecutor) list.push('skill');
     if (opts?.composeExecutor) list.push('compose');

--- a/src/cli/slash/commands/plan.ts
+++ b/src/cli/slash/commands/plan.ts
@@ -56,25 +56,10 @@
  */
 
 import { getProjectPlansDir } from '../../../paths.js';
+import { buildPlanExitPrompt } from '../../../agent/plan-mode-exit-prompt.js';
 import { togglePlanMode } from '../../plan-mode-toggle.js';
 import { palette } from '../../palette.js';
 import type { SlashCommand, SlashContext, SlashResult } from '../types.js';
-
-/**
- * Build the prompt seeded into the user's next message buffer when plan mode
- * is exited via `/plan off`. `plansDir` is an absolute path to the session's
- * `<cwd>/.afk/plans/` directory; the model picks a descriptive filename within
- * it (the `write_file` tool creates the directory if absent).
- */
-export function buildPlanExitPrompt(plansDir: string): string {
-  return [
-    'The user has switched off plan mode. Writes are now permitted. Do two things, in order:',
-    '',
-    `1. Save the plan. Write the plan you developed in this conversation to a new markdown file under \`${plansDir}/\` — pick a short, descriptive kebab-case filename (e.g. \`${plansDir}/refactor-auth-flow.md\`). Capture the full plan: the chosen approach, the concrete step-by-step changes, the risks named, and the alternatives considered. This is the durable record.`,
-    '',
-    '2. Implement the plan. Work through the steps you just recorded, verifying as you go — run the project\'s lint/test gates where they apply. End in a terminal state: Done with evidence, Blocked with the exact unblock condition, or Asking one precise question.',
-  ].join('\n');
-}
 
 /**
  * Exit plan mode and seed the save-and-implement turn. Flips to `default`


### PR DESCRIPTION
## Summary
Adds a model-callable `exit_plan_mode` tool — the model-proposed counterpart to the `/plan off` slash command — so leaving plan mode can be model-initiated + user-confirmed via an elicitation picker rather than a typed slash command.

- When the model judges its plan ready it calls `exit_plan_mode`, which shows a 3-option picker: **approve → implement in default mode** / **approve → implement in bypass mode** / **keep planning**.
- On approval the handler flips the live permission mode and queues the **byte-identical** save-and-implement turn `/plan off` already produces, via a session→REPL seed bridge.
- Registered per-query by **both** providers **only while in plan mode** (mirrors the `get_runtime_state` per-query registration); not in `WRITE_TOOLS`, so the plan-mode gate passes it automatically.
- `buildPlanExitPrompt` extracted to `src/agent/plan-mode-exit-prompt.ts` so the agent-layer handler can reuse it without a cli→agent dependency inversion; `/plan off` now imports it from there.

This is an **isolated-first slice**. A stacked follow-up PR will remove `/bypass`, add a positive `○ default` status badge, and reword the plan-mode addendum to steer the model to `exit_plan_mode` — deferred so `/plan off` stays valid until the tool is proven. `/plan` and `/afk` are unchanged here.

## Test results
- `vitest run src/agent/tools/handlers/exit-plan-mode.test.ts`: **7 passed** — approve-default & approve-bypass assert the seeded message `=== buildPlanExitPrompt(plansDir)` (identical to `/plan off`); keep-planning & declined → no mode flip, no seed; `AgentSession` injects controls for top-level (not subagent) sessions; single-shot drain.
- `vitest run` (full): **10085 passed, 12 skipped, 1 failed**. The single failure — `anthropic-direct.test.ts > compact()` — is **pre-existing and unrelated**: a model-ID alias assertion (`'claude-haiku-4-5'` vs `'claude-haiku-4-5-20251001'`); no compaction/model-resolution code is touched here.
- `pnpm lint` (tsc --noEmit): **clean**.

## Verification
Adversarial re-derivation from the diff (independent of this description) — all 3 load-bearing claims **CONFIRMED** with file:line evidence:
1. Approved exit seeds the SAME prompt as `/plan off` — both import `buildPlanExitPrompt` from the single shared `src/agent/plan-mode-exit-prompt.ts`.
2. Tool registered + schema offered **only** when `permissionMode === 'plan'` and controls present, in both providers.
3. Seed bridge: handler → `requestImplementSeed` → `AgentSession._pendingPlanExitSeed` (outlives the per-turn dispatcher) → REPL `takePendingPlanExitSeed()` drain → `seedBuffer`; single-shot; controls injected only for top-level sessions.

## Out of scope
`/bypass` removal, the `○ default` badge, and the plan-mode-addendum reword — landing as a **stacked follow-up PR** based on this branch.