### PR TITLE
fix(telegram): stop mid-turn cutoffs, false rate-limit errors, and tool-call spam

### DIFF
--- a/docs/telegram-bug-investigation.md
+++ b/docs/telegram-bug-investigation.md
@@ -1,0 +1,195 @@
+# Telegram bot reliability — root-cause investigation
+
+Investigation date: 2026-06-26. Method: 5 parallel read-only sub-agent investigators
+(cutoff, false-errors, progress-spam, general-sweep, daemon) + direct code reads.
+Scope: `src/telegram/**`, `src/agent/session/**`, `src/agent/subagent/**`, `src/telegram.ts`,
+`src/service/**`. **No code was changed** — this is diagnosis only.
+
+**Shadow-verification (2026-06-26):** the three load-bearing claims (Bug 1 cutoff mechanism,
+Bug 2 false-rate-limit, Bug 4 timer leak) were independently re-derived from primary sources by
+three parallel adversarial verifiers — **all CONFIRMED**. Corrections folded in below. Net new
+facts from verification: `session.interrupt()` (agent-session.ts:628-632) and `session.abort()`
+(agent-session.ts:423) **already exist** and route to `AbortCoordinator.requestAbort('interrupted')`
+→ the Bug 1 "smallest fix" is confirmed viable; `isRateLimitError` has **two more** vulnerable
+call sites at `message.ts:330` (photo) and `message.ts:422` (text outer handler) beyond the one
+in `processOne`.
+
+---
+
+## TL;DR — the three reported bugs share one causal chain
+
+A single heavy turn (one that fans out sub-agents — `/ground-state`, `/diagnose`, `compose`,
+research skills) triggers **all three** complaints at once, in this order:
+
+1. **Spam** — `subagentSink` appends one `◦ label: tool args` line **per child tool call**,
+   unbounded, into a single ever-growing edited message. This is the "recon: read_file …" wall.
+2. **False "rate limit"** — that per-tool-call editing **floods Telegram's API**, which returns
+   HTTP **429 "Too Many Requests"**. The classifier matches that string and tells the user
+   *"⏳ Rate limit reached"* — as if **Claude** rate-limited them. It didn't; **Telegram** did.
+3. **Cutoff** — while the sub-agents run, the **parent** stream is silent at the provider level
+   for >60s, so the streaming timeout fires, throws, and **abandons the stream without aborting
+   the underlying turn**. The turn keeps running; its events buffer; the user sees an error.
+   Sending `.` starts a new consumer that **drains the buffered events** → the delayed final answer.
+
+So: **spam → edit-flood → Telegram 429 → false "rate limit"**, and **fan-out silence → 60s
+timeout → orphaned turn → "cut off, recovered by a period."** Fixing the spam (cap/coalesce) and
+the timeout (abort-on-timeout + reset-on-subagent-activity) removes the whole cluster.
+
+---
+
+## Bug 1 — Mid-turn cutoff; final result withheld until a follow-up message  ⟶ CRITICAL
+
+**Symptom (user):** turn starts, gets cut off mid-agent, no final result; sending a `.` later
+delivers the withheld result with lag.
+
+**Root cause chain** (confidence: High):
+1. `streaming.ts:199-233` `nextWithTimeout()` rejects with *"Response timed out"* after
+   `NEXT_EVENT_TIMEOUT_MS = 60_000` (streaming.ts:22) of **parent-stream** silence.
+2. During sub-agent fan-out the parent provider loop is parked inside the tool dispatcher; **no
+   `OutputEvent` crosses the parent `providerIterator` until all tools return.** Sub-agent
+   progress reaches Telegram via the out-of-band `subagentSink`/`runWithSink` channel
+   (`streaming.ts:238-250`, `skill-sink-channel.ts`) which calls `sendOrEdit` directly and **does
+   not reset the 60s timeout.** So a busy turn looks "silent" and the timeout fires falsely.
+3. On timeout, `streamResponse` throws; the `finally` (streaming.ts:438-444) calls
+   `iter.return?.()`. That runs the generator's cleanup `finally` in `agent-session.ts:489-497`
+   (sendMessageStream) / `541-543` (sendMessageStreamInternal), setting `currentState = 'idle'` —
+   **but never aborts `providerQuery` / the turn's `AbortController`.** The shared `providerIterator`
+   is created once per session in `initSdkLifecycle` (`agent-session.ts:254-255`) and reused by
+   every `sendMessageStream` call — so the provider keeps streaming into it, now unconsumed.
+   [verified: shared-iterator lifecycle re-derived from agent-session.ts + query.ts + abort-coordinator.ts]
+4. User sees a generic/timeout error (`message.ts:602-608`).
+5. The `.` follow-up sees `session.state === 'idle'` (set in step 3) → `processOne` →
+   `sendMessageStream('.')` pulls from the **same** `providerIterator`, draining the *original*
+   turn's buffered events (including its `done`/final answer) → delayed answer + lag.
+
+**Why this is the in-process path, not a restart:** after a real process restart the buffered
+events would be gone, so a `.` could not recover the original answer. Recovery-by-poke proves the
+turn survived in-process. (Daemon restart is a *separate*, rarer cutoff path — see Bug 8.)
+
+**Smallest correct fix:** in the `finally`, after `iter.return?.()`, also call
+`session.interrupt?.()` so the provider turn is actually aborted and `providerIterator` is left at
+a clean turn boundary. **[verified] `session.interrupt()` (agent-session.ts:628-632) and
+`session.abort()` (agent-session.ts:423) already exist** and route to
+`providerQuery.interrupt()` → `AbortCoordinator.requestAbort('interrupted')` → the turn's signal
+aborts and `loop.ts` short-circuits — so this fix wires into an existing, tested path.
+**Cleaner structural fix:** push the inactivity timeout into the session layer — have
+`sendMessageStream` accept an `AbortSignal` (e.g. `AbortSignal.timeout(...)` extended on each
+received event), so a timeout cleanly interrupts `providerIterator.next()` via the existing
+`providerQuery.interrupt()` path instead of orphaning it.
+**Also:** reset the inactivity timer on sub-agent sink activity (or raise `NEXT_EVENT_TIMEOUT_MS`
+substantially) so deep fan-out does not look idle.
+
+---
+
+## Bug 2 — Spurious error / timeout / "rate limit" messages  ⟶ HIGH
+
+Four distinct misclassifications, ranked by likely frequency (confidence: High unless noted):
+
+1. **False "⏳ Rate limit reached" from a Telegram 429.** [verified — incl. telegraf source]
+   telegraf builds `TelegramError.message` as `"429: Too Many Requests: retry after N"`
+   (`node_modules/telegraf/lib/core/network/error.js`). The unswallowed reply call sites — initial
+   `ctx.reply` (`streaming.ts:103-110`), overflow `ctx.reply` (`streaming.ts:434`), and
+   `deliverClean` (`streaming.ts:154-161`) — throw a `TelegramError` up to `processOne`'s catch
+   (rate-limit reply at `message.ts:602-603`), where `isRateLimitError()`
+   (`utils/error-classifiers.ts:22-28`) matches `"too many requests"` **with no Telegram-origin
+   exclusion** and fires *"⏳ Rate limit reached"*. **This is a Telegram rate limit, misreported as
+   a Claude one — and it is caused by the Bug 3 edit-flood.** The **same** classifier mistake
+   exists at two more catch sites: `message.ts:330` (photo handler) and `message.ts:422` (outer
+   text handler).
+2. **False "🌐 Network error"** from transient telegraf/undici blips (`ECONNRESET`, `ETIMEDOUT`,
+   `fetch failed`) reaching `isNetworkError()` via the same unswallowed call sites — blames the
+   *user's* connection for a bot↔Telegram hiccup.
+3. **False "An unexpected error occurred"** via `bot.catch` (`bot.ts:263`): benign Telegram
+   `400 "message is not modified"` / `400 "message to edit not found"` / `403 "bot was blocked"`
+   / expired callback queries all fall through to the generic message.
+4. **False "Response/Request timed out"** (medium confidence): the 60s/90s `nextWithTimeout`
+   thresholds also fire on a slow *bot→Anthropic* path; the message contains `"timeout"` so it is
+   then re-classified as a network error and blames the user's connection.
+
+**Fix:** classify `instanceof TelegramError` **before** the provider rate-limit/network
+classifiers, and route Telegram-origin 429/400/403 to log-only or a distinct "Telegram is busy"
+message — never to the Claude rate-limit path. Distinguish the inactivity-timeout error class
+from network errors. (The deepest fix is Bug 3: stop flooding Telegram so the 429s stop.)
+
+---
+
+## Bug 3 — Tool-call progress spam (the "recon: read_file …" wall)  ⟶ HIGH
+
+**Mechanism** (confidence: High): every child tool call emits a `tool_use_detail` chunk
+(`subagent/handle.ts:257-263`; `compose-executor.ts:557` per node). The Telegram `subagentSink`
+(`streaming.ts:238-250`) does, **for each one**:
+`accumulated += "\n◦ " + label + ": " + toolName + " " + toolArgs; void sendOrEdit(accumulated);`
+There is **no cap, no coalescing, no dedup** — the buffer grows one line per tool call across all
+sub-agents, and `splitLongMessage` (`formatter.ts`) eventually splits the giant buffer into many
+Telegram messages (the long scroll in the screenshot).
+
+**Blast radius:** N sub-agents × M tool calls = N·M retained lines + a Telegram edit per line
+(throttled to one per 300ms, but the *buffer* is never bounded). A typical fan-out (5 agents ×
+15 reads) ≈ 75 lines → multi-message spam and sustained edit pressure → Telegram 429 (→ Bug 2.1).
+
+**`cleanFinal` does NOT save it on the bad paths:** the clean-final delivery + preview deletion
+(`streaming.ts:390-399`) only runs on the `done` event. On timeout/error/abort (Bug 1) the turn
+throws first, so the noisy buffer is what the user is left with.
+
+**Fix design (recommended):** keep a *rolling* progress indicator instead of an append log —
+e.g. a single line `◦ sub-agents working — <K> tool calls (<lastTool>)` updated in place, or cap
+retained progress lines to the last K (collapsing consecutive same-tool lines), and throttle the
+**buffer growth**, not just the edit. Optionally render progress as a separate ephemeral message
+deleted on `done`. This preserves "something is happening" signal without the wall.
+
+---
+
+## Additional bugs found in the general sweep (ranked)
+
+| # | Bug | File:line | Severity | Fix direction |
+|---|-----|-----------|----------|---------------|
+| 4 | `countdownInterval` / `editInFlight` leak when `streamResponse` throws before `done`/`error` (e.g. the Bug 1 timeout) — interval keeps firing `sendOrEdit` on a dead message forever [verified] | declared `streaming.ts:80`, set `streaming.ts:355`; cleared **only** at `:373` (resumed) / `:386` (done) / `:415` (error); **`finally` `:438-444` does not clear it**, and the callback's only guard (`pausedUntil===null`) is never satisfied on the throw path | High | Clear the interval (and reset `editInFlight`) in the `finally`. |
+| 5 | `splitLongMessage` splits inside HTML tags/entities → malformed HTML → Telegram `400 can't parse entities`; overflow chunks (sent with `parse_mode:HTML`) can be silently lost | `formatter.ts:19-65`; callers `streaming.ts:119,430,433,153` | High | Make the splitter HTML-aware (never bisect a tag/entity) or split pre-HTML. |
+| 1 | `drainQueue` has no re-entrancy guard; it is `public` and also called directly from `bot.ts` after `/compact`, so two concurrent drains for one chat can double-process/reorder | `message.ts:622-635`; `streaming.ts:609-614`; `bot.ts` compact path | High | Add a per-chatId `draining` flag set before `shift()`, cleared in `finally`. |
+| 6 | `enqueueClear` / `enqueueCompact` bypass `MAX_QUEUE_DEPTH` (=5) — spamming `/clear` during a busy turn grows the queue unbounded (each item holds a live `Context`) | `message.ts:537-556` | Med | Apply the depth gate (or dedup) to command enqueues. |
+| 7 | Elicitation `pending` map is a module-scope singleton never cleared on bot restart; stale resolvers/entries accumulate; only `_resetPendingForTests` clears it | `elicitation-telegram.ts:84,329` | Med | Clear `pending` in `stop()` / `elicitationRouter.uninstall()`. |
+| 8 | `/clear` calls `getSession()` (which can **spawn** a session) just to check state, with no try/catch — an unhandled throw if creation fails (e.g. missing key); also redundant spawn-then-close | `bot.ts:98-101` | Med | Use a non-spawning state check; wrap in try/catch. |
+| 9 | `pushMarkdown` fallback re-sends the **entire** original text when any single chunk fails → duplicate delivery | `push.ts:148` | Med | Resend only the failed chunk. |
+
+---
+
+## Bug 8 (daemon) — version-drift / KeepAlive restart can sever an in-flight turn  ⟶ MED
+
+**Verdict: the daemon/service layer is a SECONDARY, occasional contributor — not the cause of the
+"cut off, recovered by a period" symptom** (that is the in-process Bug 1).
+
+Facts (telegram.ts:496-555; `src/service/launchd*`):
+- The bot can run as a macOS LaunchAgent (`com.afk.telegram`) under launchd **KeepAlive**, or
+  standalone (`afk telegram start` / `pnpm telegram:start`).
+- A **version-drift watchdog** ticks every 5 min: if the on-disk `afk` version differs from the
+  running one (i.e. an upgrade happened), it `process.exit(0)` so KeepAlive relaunches the new
+  binary. It **defers while any session is mid-turn** (`getBusySessionCount() > 0`) — good — **but
+  has a bounded escape hatch**: after `MAX_DRIFT_DEFERRALS` (~1h) it **force-exits anyway, even
+  mid-turn** (`case 'force-exit'`, telegram.ts:530-533).
+- The code comment is explicit (telegram.ts:508-516): force-exiting mid-stream "severs the
+  in-flight turn (plus its queued messages and sub-agent dispatch), and the cold relaunch cannot
+  resume it (\"An unexpected error occurred\")."
+- `shutdown` on SIGINT/SIGTERM (telegram.ts:540-547) calls `bot.stop()` then `process.exit(0)`
+  and **does not drain in-flight turns** — a launchd restart / OOM / crash mid-turn loses it.
+
+So a post-upgrade force-exit (or crash/OOM) explains the occasional standalone "An unexpected
+error occurred" with **no** recovery-by-poke (the new process has no buffered events). It is far
+rarer than Bug 1 and produces a permanently-lost turn, not a recoverable one.
+
+**Fix direction (if pursued):** on the force-exit and SIGTERM paths, attempt a bounded graceful
+drain (or persist a "turn was interrupted — resend" marker) so the user is told to resend rather
+than seeing a bare error; consider lengthening/》removing the hard force-exit while truly busy.
+
+---
+
+## Recommended fix order (highest leverage first)
+
+1. **Bug 3 (spam cap/coalesce)** — also kills the Telegram-429 source feeding Bug 2.1.
+2. **Bug 1 (abort-on-timeout + reset timer on sub-agent activity)** — fixes the cutoff and the
+   false-timeout; the structural `AbortSignal` variant is the durable fix.
+3. **Bug 2 (classify `TelegramError` before provider classifiers)** — stops blaming Claude.
+4. **Bug 4 (clear `countdownInterval` in `finally`)** — small, stops a real timer leak.
+5. **Bug 5 (HTML-aware split)** then **Bugs 1/6/7/8/9** as a cleanup pass.
+
+All fixes are additive/local except the Bug 1 structural variant (touches the session streaming
+API). None require destructive operations.

--- a/src/telegram/error-utils.test.ts
+++ b/src/telegram/error-utils.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for Telegram error classification — specifically the
+ * `isTelegramTransportError` guard that prevents a Telegram-origin 429 from
+ * being misreported to the user as a *Claude* rate limit.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TelegramError } from 'telegraf';
+import { isTelegramTransportError } from './error-utils.js';
+import { isRateLimitError, isNetworkError } from '../utils/error-classifiers.js';
+
+function makeTelegram429(): TelegramError {
+  // Shape telegraf builds on a flood-control response:
+  // message === "429: Too Many Requests: retry after N"
+  return new TelegramError({
+    ok: false,
+    error_code: 429,
+    description: 'Too Many Requests: retry after 5',
+    parameters: { retry_after: 5 },
+  });
+}
+
+describe('isTelegramTransportError', () => {
+  it('is true for a telegraf TelegramError (e.g. a flood-control 429)', () => {
+    expect(isTelegramTransportError(makeTelegram429())).toBe(true);
+  });
+
+  it('is true for non-429 TelegramErrors (400 / 403)', () => {
+    expect(
+      isTelegramTransportError(
+        new TelegramError({ ok: false, error_code: 400, description: 'Bad Request: message is not modified' }),
+      ),
+    ).toBe(true);
+    expect(
+      isTelegramTransportError(
+        new TelegramError({ ok: false, error_code: 403, description: 'Forbidden: bot was blocked by the user' }),
+      ),
+    ).toBe(true);
+  });
+
+  it('is false for a real (Claude/provider) rate-limit Error and for non-Errors', () => {
+    expect(isTelegramTransportError(new Error('rate limit exceeded'))).toBe(false);
+    expect(isTelegramTransportError('429 too many requests')).toBe(false);
+    expect(isTelegramTransportError(undefined)).toBe(false);
+  });
+
+  it('REGRESSION: a Telegram 429 also matches isRateLimitError — which is exactly why the Telegram guard must be checked FIRST', () => {
+    const tgErr = makeTelegram429();
+    // The surface-agnostic classifier cannot tell a Telegram 429 from a Claude
+    // one (it matches the "too many requests" substring)…
+    expect(isRateLimitError(tgErr)).toBe(true);
+    expect(isNetworkError(tgErr)).toBe(false);
+    // …so the handler must branch on isTelegramTransportError BEFORE
+    // isRateLimitError to avoid telling the user "Claude rate limit reached".
+    expect(isTelegramTransportError(tgErr)).toBe(true);
+  });
+});

--- a/src/telegram/error-utils.ts
+++ b/src/telegram/error-utils.ts
@@ -14,8 +14,25 @@
  * @module telegram/error-utils
  */
 
+import { TelegramError } from 'telegraf';
 import { classifyUsageLimitError } from '../agent/providers/anthropic-direct/usage-limit.js';
 export type { UsageLimitClassification } from '../agent/providers/anthropic-direct/usage-limit.js';
+
+/**
+ * True when the error originates from the Telegram Bot API itself (telegraf
+ * `TelegramError`) — e.g. flood-control `429 Too Many Requests`, `400`, `403`.
+ *
+ * Invariant: this MUST be checked BEFORE the surface-agnostic
+ * `isRateLimitError` / `isNetworkError` predicates. A Telegram 429's message is
+ * `"429: Too Many Requests: retry after N"`, which `isRateLimitError` matches on
+ * `"too many requests"` — so without this guard a Telegram-side delivery limit
+ * (caused by the bot's own edit/reply rate, not the model) is misreported to the
+ * user as a *Claude* rate limit. Such an error is not a model/agent failure and
+ * must not surface a "Claude rate limit" / "network error" message.
+ */
+export function isTelegramTransportError(error: unknown): boolean {
+  return error instanceof TelegramError;
+}
 
 /**
  * Classify a thrown error as a usage-limit event (OAuth subscription limit or

--- a/src/telegram/handlers/message.ts
+++ b/src/telegram/handlers/message.ts
@@ -3,8 +3,12 @@ import type { Message } from 'telegraf/types';
 import { Telegraf } from 'telegraf';
 import { SessionManager } from '../session-manager.js';
 import { formatError, formatClear, formatInternalError, formatCompact, formatCompactNoop, formatQueued } from '../formatter.js';
-import { isRateLimitError, isNetworkError } from '../error-utils.js';
+import { isRateLimitError, isNetworkError, isTelegramTransportError } from '../error-utils.js';
 import { streamResponse } from '../streaming.js';
+// Import StreamTimeoutError from its own module, NOT '../streaming.js': many
+// handler tests vi.mock('../streaming.js'), which would make the class resolve
+// to undefined and turn `instanceof StreamTimeoutError` into a TypeError.
+import { StreamTimeoutError } from '../stream-timeout-error.js';
 import { registerChatCommands } from './registration.js';
 import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
 
@@ -327,7 +331,11 @@ export class MessageHandler {
       this.log('Photo handling error:', sanitizedErr);
       // Note: 'session is busy' is no longer handled here — that race is covered
       // inside processOne's catch so it applies uniformly to all callers.
-      if (isRateLimitError(error)) {
+      if (isTelegramTransportError(error)) {
+        // Telegram-side failure fetching the image (e.g. getFileLink 429) — a
+        // Telegram limit, not a Claude one. Attribute it honestly.
+        await ctx.reply('❌ Couldn\'t reach Telegram to fetch that image. Please try resending.');
+      } else if (isRateLimitError(error)) {
         await ctx.reply('⏳ Rate limit reached. Please wait a moment and try again.');
       } else if (isNetworkError(error)) {
         await ctx.reply('❌ Couldn\'t download the image. Please try resending.');
@@ -419,7 +427,10 @@ export class MessageHandler {
       this.log('Message handling error:', error);
       // Note: 'session is busy' is no longer handled here — that race is covered
       // inside processOne's catch so it applies uniformly to all callers.
-      if (isRateLimitError(error)) {
+      if (isTelegramTransportError(error)) {
+        // Telegram-side delivery failure — not a Claude rate limit / network
+        // error. Already logged; stay silent rather than misattribute it.
+      } else if (isRateLimitError(error)) {
         await ctx.reply('⏳ Rate limit reached. Please wait a moment and try again.');
       } else if (isNetworkError(error)) {
         await ctx.reply('🌐 Network error. Please check your connection and try again.');
@@ -599,7 +610,16 @@ export class MessageHandler {
         reEnqueued = true;
         return;
       }
-      if (isRateLimitError(error)) {
+      if (error instanceof StreamTimeoutError) {
+        // Honest timeout — the message already explains the cause. NOT a network
+        // or Claude rate-limit error, so don't misclassify it as one.
+        await ctx.reply(`⏱️ ${error.message}`);
+      } else if (isTelegramTransportError(error)) {
+        // A Telegram-side delivery failure (flood-control 429, transient 5xx) —
+        // NOT a Claude problem. Reporting it as a Claude rate limit is the bug.
+        // Already logged above; stay silent (a further reply would likely hit
+        // the same Telegram limit), and let the queue drain normally.
+      } else if (isRateLimitError(error)) {
         await ctx.reply('⏳ Rate limit reached. Please wait a moment and try again.');
       } else if (isNetworkError(error)) {
         await ctx.reply('🌐 Network error. Please check your connection and try again.');

--- a/src/telegram/stream-timeout-error.ts
+++ b/src/telegram/stream-timeout-error.ts
@@ -1,0 +1,26 @@
+/**
+ * StreamTimeoutError — thrown by the Telegram streaming inactivity watchdog
+ * when no event arrives within the timeout window.
+ *
+ * Invariant: this lives in its OWN module (not `streaming.ts`) so that the
+ * message handler can `import { StreamTimeoutError }` and use `instanceof`
+ * WITHOUT being affected by the many tests that `vi.mock('./streaming.js')`.
+ * Those mocks replace streaming.ts's exports with stubs, which would make a
+ * `StreamTimeoutError` imported from there resolve to `undefined` — turning
+ * `error instanceof StreamTimeoutError` into a TypeError at runtime. Keeping the
+ * class here keeps the class identity stable across the mock boundary.
+ *
+ * @module telegram/stream-timeout-error
+ */
+
+/**
+ * Distinct error type for an inactivity timeout, so the Telegram message
+ * handler can surface an honest "timed out" message instead of misclassifying
+ * it as a network or (Claude) rate-limit error.
+ */
+export class StreamTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StreamTimeoutError';
+  }
+}

--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { streamResponse } from './streaming.js';
+import { streamResponse, StreamTimeoutError, renderSubagentFooter } from './streaming.js';
 import { TelegramError } from 'telegraf';
 import type { Context } from 'telegraf';
 import type { IAgentSession, OutputEvent } from '../agent/types.js';
@@ -446,5 +446,78 @@ describe('generator finalizer cleanup', () => {
     // The generator's finally block must have run — proving iter.return() was
     // called on the error path, not just on the normal exhaustion path.
     expect(finallyRan).toBe(true);
+  });
+});
+
+describe('renderSubagentFooter (bounded sub-agent progress)', () => {
+  it('returns empty string when there is no activity', () => {
+    expect(renderSubagentFooter(0, [])).toBe('');
+    expect(renderSubagentFooter(0, ['ignored'])).toBe('');
+  });
+
+  it('reports the step count and pluralizes correctly', () => {
+    expect(renderSubagentFooter(1, ['recon: read_file a'])).toContain('1 step');
+    expect(renderSubagentFooter(1, ['recon: read_file a'])).not.toContain('1 steps');
+    expect(renderSubagentFooter(5, ['recon: read_file a'])).toContain('5 steps');
+  });
+
+  it('bounds the preview to the last few lines regardless of total step count', () => {
+    // The pre-fix sink appended one line per child tool call, unbounded. The
+    // footer must stay bounded even after 50 tool calls.
+    const many = Array.from({ length: 50 }, (_, i) => `recon: read_file file${i}`);
+    const footer = renderSubagentFooter(50, many);
+    const shownLines = footer.split('\n').filter((l) => l.includes('read_file'));
+    expect(shownLines.length).toBeLessThanOrEqual(4);
+    // The rolling tail keeps the MOST RECENT entries…
+    expect(footer).toContain('file49');
+    // …and drops the oldest.
+    expect(footer).not.toContain('file0 ');
+    // The counter still reflects the true total even though lines are capped.
+    expect(footer).toContain('50 steps');
+  });
+});
+
+describe('inactivity watchdog (timeout → interrupt)', () => {
+  it('throws StreamTimeoutError and interrupts the still-running turn on total silence', async () => {
+    vi.useFakeTimers();
+    try {
+      let releaseHang: () => void = () => {};
+      const hang = new Promise<void>((resolve) => { releaseHang = resolve; });
+      const session = makeSession(async function* () {
+        // One event so receivedAny becomes true (NEXT_EVENT_TIMEOUT_MS applies),
+        // then the provider goes silent — simulating a turn still running with
+        // no parent-stream events AND no sink activity, so the watchdog fires.
+        yield { type: 'chunk' as const, chunk: { type: 'content' as const, content: 'partial' } };
+        await hang;
+      });
+      // Mirror the real interrupt() contract: aborting the turn unblocks the
+      // in-flight provider pull so the generator can finalize cleanly.
+      (session as { interrupt: ReturnType<typeof vi.fn> }).interrupt = vi.fn(async () => { releaseHang(); });
+      const { ctx } = makeCtx();
+
+      const p = streamResponse(ctx, session, 'go');
+      const rejection = expect(p).rejects.toBeInstanceOf(StreamTimeoutError);
+      // Flush the first event, then advance past the 180s inactivity window.
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(180_001);
+      await rejection;
+      // The fix: a timeout MUST abort the underlying turn so it doesn't keep
+      // streaming into the shared providerIterator and get drained by the next
+      // message ("send a '.' to recover the lost result" bug).
+      expect((session as { interrupt: ReturnType<typeof vi.fn> }).interrupt).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  }, 15_000);
+
+  it('does NOT interrupt on a provider error event — interrupt is timeout-only', async () => {
+    const { ctx } = makeCtx();
+    const session = makeSession(async function* () {
+      yield { type: 'chunk' as const, chunk: { type: 'content' as const, content: 'partial' } };
+      yield { type: 'error' as const, error: new Error('mid-stream boom') };
+    });
+    await expect(streamResponse(ctx, session, 'go')).rejects.toThrow('mid-stream boom');
+    // A real provider error already ended the turn; interrupting would be wrong.
+    expect((session as { interrupt: ReturnType<typeof vi.fn> }).interrupt).not.toHaveBeenCalled();
   });
 });

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -8,6 +8,7 @@ import type { Context } from 'telegraf';
 import { TelegramError } from 'telegraf';
 import type { Message } from 'telegraf/types';
 import { splitLongMessage, markdownToTelegramHtml } from './formatter.js';
+import { StreamTimeoutError } from './stream-timeout-error.js';
 import type { IAgentSession, OutputEvent, SubagentProgressMeta, ResponseMetadata } from '../agent/types.js';
 import { runWithSink } from '../agent/_lib/skill-sink-channel.js';
 import { env } from '../config/env.js';
@@ -18,8 +19,41 @@ const EDIT_THROTTLE_MS = 300;
 
 /** Max wait for first stream event (e.g. SDK/API cold start) */
 const FIRST_EVENT_TIMEOUT_MS = 90_000;
-/** Max wait between subsequent events (e.g. long thinking) */
-const NEXT_EVENT_TIMEOUT_MS = 60_000;
+/**
+ * Max wait between subsequent events. The window is re-armed whenever sub-agent
+ * progress arrives via the sink (see `lastActivityAt`), so deep sub-agent
+ * fan-out — which is silent on the PARENT stream while children run — no longer
+ * trips a false timeout. 180s of TOTAL silence (no parent event AND no
+ * sub-agent activity) is treated as a genuinely stuck turn.
+ */
+const NEXT_EVENT_TIMEOUT_MS = 180_000;
+
+/** Max sub-agent progress lines retained in the bounded live-preview footer. */
+const MAX_SUBAGENT_PREVIEW_LINES = 4;
+
+// StreamTimeoutError lives in its own module so the message handler's
+// `instanceof` check survives `vi.mock('./streaming.js')` in tests (see
+// stream-timeout-error.ts). Imported above for local use (the watchdog throws
+// it); re-exported here so callers/tests that import it from the streaming
+// module keep working.
+export { StreamTimeoutError };
+
+/**
+ * Render a compact, BOUNDED footer summarizing sub-agent tool activity for the
+ * live preview. Returns '' when there is no activity. Pure + exported for unit
+ * tests. `recent` is the rolling tail (most recent last); only the last
+ * MAX_SUBAGENT_PREVIEW_LINES are shown regardless of how many are passed.
+ *
+ * Replaces the old behavior where the sink appended one line to the message
+ * buffer per child tool call (unbounded) — a fan-out produced dozens of lines
+ * and a Telegram edit per line, which also tripped Telegram's flood-control 429.
+ */
+export function renderSubagentFooter(steps: number, recent: readonly string[]): string {
+  if (steps <= 0) return '';
+  const shown = recent.slice(-MAX_SUBAGENT_PREVIEW_LINES);
+  const head = `◦ sub-agents working — ${steps} ${steps === 1 ? 'step' : 'steps'}`;
+  return shown.length > 0 ? `\n${head}\n  ${shown.join('\n  ')}` : `\n${head}`;
+}
 
 /** Countdown update granularity during a usage-limit pause: every 5 minutes. */
 const PAUSE_COUNTDOWN_INTERVAL_MS = 5 * 60 * 1_000;
@@ -88,6 +122,17 @@ export async function streamResponse(
   let contentRunStartAccumulated = 0;
   let contentRunStartAnswer = 0;
   let inContentRun = false;
+  // Inactivity watchdog state. `timedOut` is set ONLY when the watchdog fires,
+  // so the finally can abort the still-running provider turn (and the handler
+  // can show an honest timeout). `lastActivityAt` is bumped by every parent
+  // event AND by sub-agent sink activity, so the re-armed timeout does not
+  // false-fire during deep fan-out.
+  let timedOut = false;
+  let lastActivityAt = Date.now();
+  // Bounded sub-agent progress region (see renderSubagentFooter): a rolling
+  // counter + the last few lines, instead of an unbounded per-tool-call append.
+  let subagentSteps = 0;
+  const recentSubagentSteps: string[] = [];
 
   const sendOrEdit = async (text: string, force = false): Promise<void> => {
     // markdownToTelegramHtml runs 8 serial regex passes over the full accumulated
@@ -163,6 +208,12 @@ export async function streamResponse(
     }
   };
 
+  // Live preview = answer/content buffer + bounded sub-agent footer. Used for
+  // every in-turn edit so sub-agent progress stays visible without the buffer
+  // growing one line per child tool call.
+  const livePreview = (): string =>
+    accumulated + renderSubagentFooter(subagentSteps, recentSubagentSteps);
+
   try {
     const stream =
       // For content-block arrays (e.g. photo + caption), prefer sendMessageStream —
@@ -199,20 +250,31 @@ export async function streamResponse(
     const nextWithTimeout = (): Promise<IteratorResult<OutputEvent>> => {
       // During a usage-limit pause, extend the deadline to reset time + slack
       // so we don't fire a "timed out" error while the provider is waiting.
-      const waitMs = pausedUntil !== null
+      const windowMs = pausedUntil !== null
         ? Math.max(NEXT_EVENT_TIMEOUT_MS, pausedUntil.getTime() - Date.now() + PAUSE_SLACK_MS)
         : (receivedAny ? NEXT_EVENT_TIMEOUT_MS : FIRST_EVENT_TIMEOUT_MS);
       return new Promise<IteratorResult<OutputEvent>>((resolve, reject) => {
-        timeoutId = setTimeout(() => {
-          timeoutId = null;
-          reject(
-            new Error(
-              receivedAny
-                ? 'Response timed out. Try sending a shorter message or try again.'
-                : 'Request timed out. The agent may still be starting (first message can take a minute). Try again in a moment.'
-            )
-          );
-        }, waitMs);
+        // Re-arming watchdog: fire only after `windowMs` of silence measured
+        // from the LAST activity. Sub-agent sink events bump `lastActivityAt`,
+        // so an active fan-out re-arms the timer instead of tripping a false
+        // timeout while the parent stream is legitimately quiet.
+        const arm = (): void => {
+          const remaining = windowMs - (Date.now() - lastActivityAt);
+          if (remaining <= 0) {
+            timeoutId = null;
+            timedOut = true;
+            reject(
+              new StreamTimeoutError(
+                receivedAny
+                  ? 'Response timed out. Try sending a shorter message or try again.'
+                  : 'Request timed out. The agent may still be starting (first message can take a minute). Try again in a moment.'
+              )
+            );
+          } else {
+            timeoutId = setTimeout(arm, remaining);
+          }
+        };
+        timeoutId = setTimeout(arm, windowMs);
         iter.next().then(
           (result) => {
             if (timeoutId != null) {
@@ -237,15 +299,22 @@ export async function streamResponse(
     // subagent events are silently dropped because no ambient sink is set.
     const subagentSink = (event: OutputEvent, meta: SubagentProgressMeta): void => {
       const label = meta.agentType ?? meta.subagentId;
+      // Sub-agent activity keeps the turn alive: bump the watchdog so deep
+      // fan-out (silent on the parent stream) does not trip a false timeout.
+      lastActivityAt = Date.now();
       if (event.type === 'chunk' && event.chunk.type === 'tool_use_detail') {
         const toolArgs = event.chunk.toolInput.length > 60
           ? event.chunk.toolInput.slice(0, 57) + '...'
           : event.chunk.toolInput;
-        accumulated += `\n◦ ${label}: ${event.chunk.toolName} ${toolArgs}`;
-        void sendOrEdit(accumulated);
+        // Bounded: count every step but retain only the most recent few lines,
+        // rendered as a compact footer rather than one appended line per call.
+        subagentSteps++;
+        recentSubagentSteps.push(`${label}: ${event.chunk.toolName} ${toolArgs}`);
+        if (recentSubagentSteps.length > MAX_SUBAGENT_PREVIEW_LINES) recentSubagentSteps.shift();
+        void sendOrEdit(livePreview());
       } else if (event.type === 'done') {
-        accumulated += `\n◦ ${label}: Done`;
-        void sendOrEdit(accumulated);
+        // A child finishing refreshes the footer but must not grow the buffer.
+        void sendOrEdit(livePreview());
       }
     };
 
@@ -260,6 +329,9 @@ export async function streamResponse(
         if (traceEnabled) console.log('[trace] event arrived:', result.done ? 'DONE' : (result.value as OutputEvent).type);
         if (result.done) break;
         const event: OutputEvent = result.value;
+        // A real parent event resets the inactivity window (the watchdog
+        // measures silence from lastActivityAt, not from the arm() time).
+        lastActivityAt = Date.now();
         if (!receivedAny) {
           receivedAny = true;
           console.log('📡 First stream event received:', event.type);
@@ -274,7 +346,7 @@ export async function streamResponse(
           }
           accumulated += event.chunk.content;
           answerText += event.chunk.content;
-          await sendOrEdit(accumulated);
+          await sendOrEdit(livePreview());
         }
         if (event.type === 'stream_retry') {
           // Mid-stream overload re-drive: discard the current round's partial
@@ -284,7 +356,7 @@ export async function streamResponse(
           accumulated = accumulated.slice(0, contentRunStartAccumulated);
           answerText = answerText.slice(0, contentRunStartAnswer);
           inContentRun = false;
-          await sendOrEdit(accumulated, true);
+          await sendOrEdit(livePreview(), true);
         }
         if (event.type === 'chunk' && event.chunk.type === 'tool_diff') {
           // intentional no-op: diff is CLI-only; Telegram has no terminal palette
@@ -293,7 +365,7 @@ export async function streamResponse(
           accumulated = event.message.content;
           answerText = event.message.content;
           inContentRun = false;
-          await sendOrEdit(accumulated);
+          await sendOrEdit(livePreview());
         }
         // Lane D — progress summaries appear in the response as dim lines
         // prefixed with `◦`. These are debounced by the EDIT_THROTTLE_MS
@@ -309,7 +381,7 @@ export async function streamResponse(
             : `\n◦ ${description}`;
           accumulated += line;
           if (summary) accumulated += `\n  ${summary}`;
-          await sendOrEdit(accumulated);
+          await sendOrEdit(livePreview());
         }
         // Lane D — post-turn prompt suggestion appended to the message.
         // Skip when the suggestion duplicates the already-rendered response:
@@ -322,7 +394,7 @@ export async function streamResponse(
         if (event.type === 'suggestion' && event.suggestion.trim() !== accumulated.trim()) {
           accumulated += `\n\n💡 ${event.suggestion}`;
           answerText += `\n\n💡 ${event.suggestion}`;
-          await sendOrEdit(accumulated);
+          await sendOrEdit(livePreview());
         }
         if (event.type === 'paused') {
           // Start a 5-minute-granularity countdown updater so the Telegram
@@ -436,6 +508,27 @@ export async function streamResponse(
         }
       }
     } finally {
+      // On a genuine inactivity timeout the provider turn is STILL RUNNING — the
+      // watchdog only abandoned our consumer; it did not abort the turn. Without
+      // this, the provider keeps streaming into the long-lived shared
+      // providerIterator with no consumer, and the NEXT message drains those
+      // buffered events — the "turn cut off, send a '.' to recover the lost
+      // result" bug. interrupt() is the same turn-scoped abort the REPL uses for
+      // ESC; it leaves providerIterator parked cleanly at the next-prompt
+      // boundary. Must run BEFORE iter.return(), which flips currentState to
+      // 'idle' and would make interrupt() an early-return no-op.
+      if (timedOut) {
+        await Promise.resolve(session.interrupt?.()).catch(() => {});
+      }
+      // Stop the usage-limit countdown timer on EVERY exit path (incl. a throw):
+      // it was previously cleared only on the done/error event branches, so a
+      // timeout-throw while paused leaked an interval that kept editing a dead
+      // message forever (and pinned editInFlight=true).
+      if (countdownInterval !== null) {
+        clearInterval(countdownInterval);
+        countdownInterval = null;
+      }
+      editInFlight = false;
       // Always close the async generator — on both the happy path and the error
       // path — so the session's currentState resets to 'idle' only after all
       // Telegram messages are sent. Without this, a throw at event.type ===


### PR DESCRIPTION
## Summary

Fixes three coupled Telegram-bot failures that all surface during a single sub-agent fan-out (reported symptoms: *"it gets cut off mid-agent and I have to send a `.` to get the result"*, *"random rate-limit/timeout errors when I'm not actually rate-limited on Claude"*, and *"tool calling is spammy"*). They share one causal chain: **spam → edit-flood → Telegram 429 → false "rate limit"**, and **fan-out silence → false 60s timeout → orphaned turn → cutoff**.

Root causes were investigated with parallel sub-agents and **shadow-verified** (independent re-derivation from source). Full analysis + deferred follow-ups: [`docs/telegram-bug-investigation.md`](docs/telegram-bug-investigation.md).

## What changed

**1. Mid-turn cutoff [Critical]** — `streaming.ts`
- The 60s inactivity timeout fired while the *parent* stream was legitimately quiet (children running), threw, and abandoned the stream **without aborting the turn**. The turn kept running into the long-lived shared `providerIterator`; the next message drained its buffered events, producing the *"send a `.` to recover the lost result"* symptom.
- Fix: **re-arm the watchdog on sub-agent sink activity** (silence window 60s → 180s, measured from last activity), and **`session.interrupt()` on a genuine timeout** — the same turn-scoped abort the REPL uses for ESC — so the turn aborts and `providerIterator` parks cleanly at the next-prompt boundary.

**2. False "Rate limit reached" [High]** — `error-utils.ts`, `handlers/message.ts`
- The bot's own edit/reply flood tripped Telegram's `429 Too Many Requests`, whose message matched `isRateLimitError` and was reported to the user as a **Claude** rate limit.
- Fix: new `isTelegramTransportError` guard, checked **before** the provider classifiers at every catch site, so a Telegram-side limit shows an honest Telegram-attributed message (or stays silent) instead of blaming Claude.

**3. Tool-call spam — the "recon: read_file ..." wall [High]** — `streaming.ts`
- `subagentSink` appended one `◦ label: tool args` line **per child tool call**, unbounded, and that edit flood fed bug #2.
- Fix: a **bounded rolling footer** (step counter + last 4 lines) via the pure, unit-tested `renderSubagentFooter`.

**Also**
- Clear the usage-limit `countdownInterval` on **every** exit path — it leaked on the timeout-throw path, editing a dead message forever — and reset `editInFlight`.
- Surface `StreamTimeoutError` honestly instead of as a generic/network error. It lives in its own module so the handler's `instanceof` check survives the many `vi.mock('./streaming.js')` tests.

## Scope / blast radius

Entirely within `src/telegram/`: `streaming.js` and `error-utils.js` are imported only by Telegram code, and `error-classifiers.ts` is unchanged. Additive and reversible; no destructive operations.

## Not in this PR (documented follow-ups)

`docs/telegram-bug-investigation.md` also catalogs lower-severity issues left for follow-up: `drainQueue` re-entrancy guard, `enqueueClear`/`enqueueCompact` bypassing the queue cap, HTML-unaware `splitLongMessage`, the elicitation `pending` map not cleared on restart, `/clear` `getSession` throw, `pushMarkdown` duplicate-delivery, and a daemon force-exit-mid-turn edge.

## Verification

- `pnpm lint` (tsc --noEmit, strict): clean.
- `pnpm test`: 10114 passed, 13 skipped, 1 failure (`anthropic-direct.test.ts > compact()`) confirmed **pre-existing** on the clean base (stash-verified) and unrelated to this change.
- New tests: `renderSubagentFooter` bounding; interrupt-on-timeout (fake timers) and no-interrupt on provider errors; the Telegram-429 classifier guard. A self-introduced mock-coupling regression (`message-handler-drain.test.ts`) was caught and fixed during development.
