### PR TITLE
fix(anthropic-direct): preserve redacted_thinking blocks to prevent session wedge

### DIFF
--- a/src/agent/providers/anthropic-direct/translate.test.ts
+++ b/src/agent/providers/anthropic-direct/translate.test.ts
@@ -152,6 +152,14 @@ function signatureDelta(index: number, signature: string): RawMessageStreamEvent
   } as unknown as RawMessageStreamEvent;
 }
 
+function redactedThinkingStart(index: number, data: string): RawMessageStreamEvent {
+  return {
+    type: 'content_block_start',
+    index,
+    content_block: { type: 'redacted_thinking', data },
+  } as unknown as RawMessageStreamEvent;
+}
+
 describe('anthropic-direct translateMessageStream', () => {
   it('text-only stream emits delta.text events and an end_turn turn-result', async () => {
     const events: RawMessageStreamEvent[] = [
@@ -372,6 +380,66 @@ describe('anthropic-direct translateMessageStream', () => {
       type: 'text',
       text: 'hello',
     });
+  });
+
+  it('preserves a redacted_thinking block verbatim in turn-result', async () => {
+    const events: RawMessageStreamEvent[] = [
+      messageStart(),
+      redactedThinkingStart(0, 'ENCRYPTED_PAYLOAD'),
+      blockStop(0),
+      textBlockStart(1),
+      textDelta(1, 'done'),
+      blockStop(1),
+      messageDelta('end_turn'),
+      messageStop(),
+    ];
+
+    const out = await collect(
+      translateMessageStream(fromArray(events), { sessionId: SESSION_ID }),
+    );
+
+    const last = out[out.length - 1];
+    if (!last || last.kind !== 'turn-result') {
+      throw new Error('expected turn-result at end');
+    }
+    expect(last.result.assistantBlocks).toEqual([
+      { type: 'redacted_thinking', data: 'ENCRYPTED_PAYLOAD' },
+      { type: 'text', text: 'done' },
+    ]);
+  });
+
+  it('redacted_thinking followed by tool_use leads the assistant turn with the reasoning block (regression: must not be dropped)', async () => {
+    // Regression for the session-wedge bug: a security-adjacent prompt makes
+    // the server emit redacted_thinking, then the model calls tools. When
+    // extended thinking is enabled, the continuation request 400s unless the
+    // assistant turn LEADS with a thinking/redacted_thinking block. Dropping
+    // the redacted block (the pre-fix behavior) produced a tool_use-only turn
+    // that 400'd on every subsequent request — permanently wedging the session.
+    const events: RawMessageStreamEvent[] = [
+      messageStart(),
+      redactedThinkingStart(0, 'OPAQUE'),
+      blockStop(0),
+      toolUseStart(1, 'toolu_9', 'web_scrape'),
+      inputJsonDelta(1, '{"url":"https://x"}'),
+      blockStop(1),
+      messageDelta('tool_use'),
+      messageStop(),
+    ];
+
+    const out = await collect(
+      translateMessageStream(fromArray(events), { sessionId: SESSION_ID }),
+    );
+
+    const last = out[out.length - 1];
+    if (!last || last.kind !== 'turn-result') {
+      throw new Error('expected turn-result at end');
+    }
+    // The reasoning block must come FIRST, before the tool_use.
+    const blocks = last.result.assistantBlocks;
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toEqual({ type: 'redacted_thinking', data: 'OPAQUE' });
+    expect(blocks[1]).toMatchObject({ type: 'tool_use', id: 'toolu_9', name: 'web_scrape' });
+    expect(last.result.toolUseBlocks).toHaveLength(1);
   });
 
   it('error mid-stream yields an error event, no turn-result, and does not throw', async () => {

--- a/src/agent/providers/anthropic-direct/translate.ts
+++ b/src/agent/providers/anthropic-direct/translate.ts
@@ -25,11 +25,14 @@ import { env } from '../../../config/env.js';
 /**
  * Per-block accumulator. The block kind dictates which fields are populated
  * — text/thinking blocks accumulate strings, tool_use blocks accumulate a
- * partial JSON buffer that is parsed at `content_block_stop`.
+ * partial JSON buffer that is parsed at `content_block_stop`, and
+ * redacted_thinking carries an opaque server-encrypted payload delivered
+ * whole at `content_block_start` (it has no deltas).
  */
 type BlockAcc =
   | { kind: 'text'; text: string }
   | { kind: 'thinking'; thinking: string; signature: string }
+  | { kind: 'redacted_thinking'; data: string }
   | { kind: 'tool_use'; id: string; name: string; partialJson: string };
 
 /**
@@ -77,6 +80,17 @@ function buildTurnResult(
           signature: acc.signature,
         });
       }
+    } else if (acc.kind === 'redacted_thinking') {
+      // Invariant: redacted_thinking must be preserved VERBATIM in the
+      // assistant turn. When extended thinking is enabled and the turn
+      // contains tool_use, the Messages API requires the assistant message
+      // to LEAD with a thinking/redacted_thinking block; dropping it makes
+      // the next (continuation) request 400 — and because that malformed
+      // turn persists in the session's reused messages array, every later
+      // turn re-fails too (a permanent session wedge). The payload is
+      // server-encrypted, has no signature to validate, and is always
+      // round-trippable, so it is pushed unconditionally.
+      assistantBlocks.push({ type: 'redacted_thinking', data: acc.data });
     } else {
       assistantBlocks.push({
         type: 'tool_use',
@@ -148,6 +162,11 @@ export async function* translateMessageStream(
               thinking: '',
               signature: '',
             };
+          } else if (cb.type === 'redacted_thinking') {
+            // Redacted reasoning is delivered whole here (no deltas), so
+            // capture `data` at start. Preserved for round-trip; see
+            // buildTurnResult. No visible event — the payload is opaque.
+            blocks[evt.index] = { kind: 'redacted_thinking', data: cb.data };
           } else if (cb.type === 'tool_use') {
             blocks[evt.index] = {
               kind: 'tool_use',


### PR DESCRIPTION
## Summary

Fixes a bug where an interactive REPL session could **permanently wedge** ("the turn ended itself and I can't send anything else") after the model used tools. Observed with `opus_1m` (resolves to `claude-opus-4-8`) on a query that did extended thinking → parallel `web_scrape` calls; reproduced across 3 sessions in witness telemetry.

## Root cause

The `anthropic-direct` stream translator (`src/agent/providers/anthropic-direct/translate.ts`) had **no handling for `redacted_thinking` content blocks** at all:

- `BlockAcc` had no `redacted_thinking` variant,
- `content_block_start` had no case for it,
- `buildTurnResult` never emitted one.

So when the model emitted *redacted* reasoning (common on security-adjacent prompts — here, "jailbreak an old Amazon Echo") and then called tools, the assistant turn was reconstructed as `[text?, tool_use…]` with **no leading reasoning block**.

The Anthropic Messages API requires an assistant turn containing `tool_use` to **lead with a `thinking`/`redacted_thinking` block when extended thinking is enabled**. The post-tool-use continuation request therefore 400s. And because the provider reuses **one stable `state.messages` array across turns**, mutated in place (`query.ts`), whose only pre-request self-heal is `repairOrphanToolUses` (which fixes orphan `tool_use` but *not* a missing leading reasoning block), the malformed turn **persists and re-fails on every subsequent request** — wedging the session. The first request succeeds because there is no prior assistant turn to round-trip.

(Model context: `opus_1m → claude-opus-4-8`, an `isOpus47Plus` model using adaptive/summarized thinking at effort `max` — the deepest thinking-block contract.)

## Fix

Capture `redacted_thinking` at `content_block_start` (it is delivered whole — no deltas) and preserve it verbatim in `assistantBlocks`, so the assistant turn round-trips with its required leading reasoning block. The payload is server-encrypted and always round-trippable, so it is pushed unconditionally (unlike `thinking`, which is correctly dropped when it lacks a signature). No visible stream event is emitted — the payload is opaque.

- No new `@anthropic-ai/sdk` symbol (`redacted_thinking` is part of the already-imported `ContentBlockParam` union) → SDK dependency lock unchanged.

## Test plan

- `pnpm lint` (tsc --noEmit, strict): clean.
- `pnpm exec vitest run …/translate.test.ts`: **10/10 pass** (8 existing + 2 new).
  - New regression test: a `redacted_thinking` block followed by `tool_use` must yield an assistant turn whose **first block is the reasoning block** (the exact shape that, when dropped, caused the wedge).
- `pnpm audit:sdk:check`: OK (lock matches imports).
- Full suite: 1 failure, `anthropic-direct.test.ts > compact() summarizes…` (`claude-haiku-4-5` vs `claude-haiku-4-5-20251001`) — **pre-existing**, verified to fail identically on clean `main@2027bb5`; unrelated to this change.

## Honest scope note / recommended follow-up

This fixes the **most likely trigger** (a confirmed `translate.ts` gap). The exact trigger of the original session wasn't captured (no `[afk] thinking-block diagnostic` log line / live repro), so as **defense-in-depth** I recommend a follow-up PR adding a wedge-resilience self-heal (sibling to `repairOrphanToolUses`): before a request — or on a thinking-flavored continuation 400 — detect an assistant turn that contains `tool_use` but lacks a leading `thinking`/`redacted_thinking` block while thinking is enabled, and repair/roll it back so **no** malformed turn (from any cause) can permanently brick a session. I scoped it out here to keep this change minimal and reviewable in delicate hot-path provider code.

🤖 Diagnosis verified via parallel shadow-verify (CLAIM "error is silently swallowed" was corrected → the error is rendered via `presentError`; the load-bearing wedge mechanism and the `redacted_thinking` gap were independently confirmed).
