### PR TITLE
fix(anthropic-direct): recover from a wedged session on rejected continuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Fixed
+- recover from a wedged session when the API rejects a continuation request (a rejected post-tool-use request no longer permanently poisons the reused messages array)
+
 ## [4.44.2] - 2026-06-26
 
 ### Fixed

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -337,6 +337,18 @@ export class AnthropicDirectQuery implements ProviderQuery {
         // either shape natively.
         this.state.messages.push({ role: 'user', content: turn.content });
 
+        // Invariant: the messages array up to and including the just-pushed
+        // user turn is a known-sendable prefix — every prior assistant turn
+        // was accepted by the API at least once, and a bare user turn is
+        // always appendable. The tool-use loop will push assistant/tool_result
+        // turns past this point; if the turn ends in an `error` (e.g. the API
+        // rejects a continuation request), those pushes are left behind in the
+        // reused array and every later turn re-sends — and re-fails on — the
+        // same rejected history, permanently wedging the session. Capturing
+        // the prefix length here lets the error path below truncate back to it
+        // so a failed turn degrades to a recoverable per-turn error instead.
+        const sendablePrefixLen = this.state.messages.length;
+
         const system = this.composeSystem();
         const headers = buildRequestHeaders(
           this.retry.authMode,
@@ -372,6 +384,11 @@ export class AnthropicDirectQuery implements ProviderQuery {
         // `providerIterator.next()` loop is never advanced past a turn it
         // already saw end.
         let turnEmittedTerminal = false;
+        // Tracks whether THIS turn surfaced an `error` event (as opposed to a
+        // clean `turn.completed`). Drives the post-turn history rollback that
+        // prevents a single rejected request from permanently wedging the
+        // session — see `sendablePrefixLen` above.
+        let turnErrored = false;
         try {
           for await (const event of this.retry.turnWithRetries(runInput, () => this.state.closed)) {
             if (this.state.closed) return;
@@ -389,6 +406,9 @@ export class AnthropicDirectQuery implements ProviderQuery {
             }
             if (event.type === 'turn.completed' || event.type === 'error') {
               turnEmittedTerminal = true;
+            }
+            if (event.type === 'error') {
+              turnErrored = true;
             }
             yield event;
           }
@@ -435,6 +455,35 @@ export class AnthropicDirectQuery implements ProviderQuery {
         if (controller.signal.aborted) {
           if (!turnEmittedTerminal) yield this.makeInterruptedTurnEvent();
           continue;
+        }
+
+        // Wedge recovery: a turn that surfaced an `error` (e.g. the API
+        // rejected a continuation request — a malformed thinking block under
+        // interleaved thinking, an over-budget payload, a transient 5xx not
+        // absorbed by the retry layer) leaves its partial assistant/tool_result
+        // pushes in the reused messages array. The loop's own rollback
+        // (`messagesRollbackIdx`) only covers throws DURING tool execution, not
+        // the next iteration's request failure, and `repairOrphanToolUses` only
+        // heals orphan `tool_use` blocks — neither removes an assistant turn the
+        // API keeps rejecting. Without this, every later prompt re-sends the
+        // same rejected history and re-fails: a permanent session wedge where
+        // the user "can't send anything else". Truncating back to the
+        // known-sendable prefix (history through the triggering user turn)
+        // converts that brick into a recoverable per-turn error — the next
+        // prompt starts from a prefix the API has already accepted. Gated on
+        // !aborted (handled above) so an interrupt's partial state is preserved
+        // for resume; `splice` mutates in place per the never-reassign invariant
+        // on `state.messages`.
+        //
+        // Tradeoff: for a multi-iteration tool turn, this drops ALL of the
+        // turn's assistant/tool_result pairs, not just the failing last one —
+        // including iterations that executed successfully. That is intentional:
+        // the turn produced no final answer (it ended in error), and reverting
+        // to the pre-turn prefix is the only target GUARANTEED sendable, whereas
+        // keeping earlier iterations risks leaving the very block the API keeps
+        // rejecting. Recovering the session beats preserving partial tool churn.
+        if (turnErrored && this.state.messages.length > sendablePrefixLen) {
+          this.state.messages.splice(sendablePrefixLen);
         }
 
         // Auto-compaction: fire at the natural turn boundary — after the

--- a/src/agent/providers/anthropic-direct/wedge-recovery.test.ts
+++ b/src/agent/providers/anthropic-direct/wedge-recovery.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Regression test for the "wedged session after a rejected continuation
+ * request" bug.
+ *
+ * Repro: a turn that uses tools pushes its `[assistant(thinking+tool_use),
+ * tool_result]` turns into the per-session `messages` array — which is mutated
+ * in place and REUSED across turns. If the FOLLOW-UP continuation request is
+ * rejected by the API (e.g. a malformed thinking block under interleaved
+ * thinking, or any non-retryable 4xx), `loop.ts` yields an `error` event and
+ * returns — but those pushed turns are left behind. The loop's own rollback
+ * (`messagesRollbackIdx`) only covers throws DURING tool execution, not the
+ * NEXT iteration's request failure, and `repairOrphanToolUses` only heals
+ * orphan `tool_use` blocks (here the array ends in a MATCHED `tool_result`, so
+ * it no-ops). So every later prompt re-sends the same rejected history and
+ * re-fails: a permanent session wedge where the user "can't send anything
+ * else".
+ *
+ * The fix truncates the failed turn's pushes back to the known-sendable prefix
+ * (history through the triggering user turn) so the next prompt starts from a
+ * prefix the API has already accepted.
+ *
+ * These tests drive the REAL `AnthropicDirectQuery` generator (where the fix
+ * lives) directly, mocking `messages.create` to (1) return a tool-use stream,
+ * (2) reject the continuation, then (3) capture exactly what the NEXT turn
+ * sends. A mock-provider test at the AgentSession layer would NOT catch this.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { RawMessageStreamEvent, MessageParam } from '@anthropic-ai/sdk/resources';
+import type { ProviderEvent } from '../../provider.js';
+import { AnthropicDirectQuery } from './query.js';
+import type { ToolDispatcher } from './tool-dispatcher.js';
+import type { ToolCall, ToolResult } from './types.js';
+
+// --- Mock SDK plumbing ---
+
+const messagesCreateMock = vi.fn();
+
+class MockAnthropic {
+  public messages: { create: typeof messagesCreateMock };
+  constructor() {
+    this.messages = { create: messagesCreateMock };
+  }
+}
+
+// --- Helpers ---
+
+async function* fromArray<T>(arr: T[]): AsyncIterable<T> {
+  for (const x of arr) yield x;
+}
+
+/** Push-driven prompt stream so we can deliver user turns over the session. */
+function createPushStream<T>(): {
+  push: (item: T) => void;
+  close: () => void;
+  iterable: AsyncIterable<T>;
+} {
+  const queue: T[] = [];
+  let waiting: ((r: IteratorResult<T>) => void) | null = null;
+  let closed = false;
+  return {
+    push(item: T): void {
+      if (waiting) {
+        const resolve = waiting;
+        waiting = null;
+        resolve({ value: item, done: false });
+      } else {
+        queue.push(item);
+      }
+    },
+    close(): void {
+      closed = true;
+      if (waiting) {
+        const resolve = waiting;
+        waiting = null;
+        resolve({ value: undefined as unknown as T, done: true });
+      }
+    },
+    iterable: {
+      [Symbol.asyncIterator](): AsyncIterator<T> {
+        return {
+          next(): Promise<IteratorResult<T>> {
+            const head = queue.shift();
+            if (head !== undefined) return Promise.resolve({ value: head, done: false });
+            if (closed) return Promise.resolve({ value: undefined as unknown as T, done: true });
+            return new Promise<IteratorResult<T>>((resolve) => {
+              waiting = resolve;
+            });
+          },
+        };
+      },
+    },
+  };
+}
+
+const baseUsage = () => ({
+  input_tokens: 5,
+  output_tokens: 0,
+  cache_creation_input_tokens: 0,
+  cache_read_input_tokens: 0,
+  server_tool_use: null,
+  service_tier: null,
+});
+
+/** Assistant turn with a leading (signed) thinking block followed by tool_use. */
+function makeThinkingToolUseStream(toolId: string, toolName: string): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_tu',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-test',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: baseUsage(),
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'thinking', thinking: '' },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'thinking_delta', thinking: 'reasoning about the request' },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'signature_delta', signature: 'sig-deadbeef' },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 1,
+      content_block: { type: 'tool_use', id: toolId, name: toolName, input: {} },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 1,
+      delta: { type: 'input_json_delta', partial_json: '{}' },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 1 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'tool_use', stop_sequence: null },
+      usage: { output_tokens: 9 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+/** Plain text turn that ends with stop_reason=end_turn. */
+function makeTextStream(text: string): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_text',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-test',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: baseUsage(),
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '', citations: [] },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 4 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+/** Deep-copy a captured messages array so later in-place mutation cannot bleed in. */
+function snapshot(messages: MessageParam[]): MessageParam[] {
+  return JSON.parse(JSON.stringify(messages)) as MessageParam[];
+}
+
+function hasAssistantToolUse(messages: MessageParam[]): boolean {
+  return messages.some(
+    (m) =>
+      m.role === 'assistant' &&
+      Array.isArray(m.content) &&
+      m.content.some((b) => (b as { type: string }).type === 'tool_use'),
+  );
+}
+
+function makeQuery(
+  promptStream: AsyncIterable<{ content: string }>,
+  dispatcher: ToolDispatcher,
+): AnthropicDirectQuery {
+  return new AnthropicDirectQuery({
+    client: new MockAnthropic() as unknown as Anthropic,
+    authMode: 'api-key',
+    promptStream,
+    toolDispatcher: dispatcher,
+    model: 'claude-sonnet-4-5-20250929',
+    maxTokens: 1024,
+    tools: [{ name: 'probe', input_schema: { type: 'object' } }],
+    userSystem: null,
+    systemPrefix: null,
+    thinking: { type: 'enabled', budget_tokens: 1024 },
+    // Seed a completed prior exchange: the "known-good" prefix the wedge must
+    // never destroy and the rollback must preserve.
+    initialMessages: [
+      { role: 'user', content: 'earlier question' },
+      { role: 'assistant', content: 'earlier answer' },
+    ],
+  });
+}
+
+// --- Tests ---
+
+describe('AnthropicDirectQuery — recovery from a rejected continuation request', () => {
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+  });
+
+  it('does not wedge: a turn whose continuation is rejected leaves the next turn a sendable history', async () => {
+    const prompts = createPushStream<{ content: string }>();
+    const dispatcher: ToolDispatcher = {
+      execute: (_call: ToolCall): Promise<ToolResult> =>
+        Promise.resolve({ content: 'tool ran fine' }),
+    };
+
+    const sentPerCall: MessageParam[][] = [];
+    let callIdx = 0;
+    messagesCreateMock.mockImplementation((params: { messages: MessageParam[] }) => {
+      callIdx += 1;
+      sentPerCall.push(snapshot(params.messages));
+      if (callIdx === 1) {
+        // Turn 1 request → model emits thinking + a tool_use.
+        return fromArray(makeThinkingToolUseStream('toolu_1', 'probe'));
+      }
+      if (callIdx === 2) {
+        // Turn 1 continuation (tool_result already in history) → API rejects it.
+        // The message body mentions "thinking" to mirror the real failure mode;
+        // any non-retryable error reaches the same yield-error path.
+        throw new Error(
+          'messages.0: `thinking` blocks in the latest assistant turn were not valid',
+        );
+      }
+      // Turn 2 request → must succeed, proving the session is not wedged.
+      return fromArray(makeTextStream('recovered and answered'));
+    });
+
+    const query = makeQuery(prompts.iterable, dispatcher);
+    const it = (query as AsyncIterable<ProviderEvent>)[Symbol.asyncIterator]();
+
+    // session.init handshake.
+    const init = await it.next();
+    expect((init.value as ProviderEvent).type).toBe('session.init');
+
+    // Turn 1 — drive to its terminal event (an `error` from the rejected continuation).
+    prompts.push({ content: 'first question' });
+    let sawError = false;
+    let r = await it.next();
+    while (!r.done) {
+      const ev = r.value as ProviderEvent;
+      if (ev.type === 'error') sawError = true;
+      // Turn 1 ends when the error event is yielded; loop yields error then the
+      // outer generator suspends awaiting the next prompt.
+      if (ev.type === 'error' || ev.type === 'turn.completed') break;
+      r = await it.next();
+    }
+    expect(sawError).toBe(true);
+
+    // Turn 2 — the regression: pre-fix, the poisoned [assistant(tool_use),
+    // tool_result] turns are still in history, so this request re-sends them.
+    prompts.push({ content: 'second question' });
+    let assistantText = '';
+    let sawTurn2Completed = false;
+    r = await it.next();
+    while (!r.done) {
+      const ev = r.value as ProviderEvent;
+      if (ev.type === 'delta.text') assistantText += ev.text;
+      if (ev.type === 'assistant.message') assistantText = ev.text;
+      if (ev.type === 'turn.completed') {
+        sawTurn2Completed = true;
+        break;
+      }
+      r = await it.next();
+    }
+
+    // The second turn actually ran (3rd model call) and completed.
+    expect(callIdx).toBe(3);
+    expect(sawTurn2Completed).toBe(true);
+    expect(assistantText).toContain('recovered and answered');
+
+    // The decisive assertion: the turn-2 request did NOT re-send the poisoned
+    // assistant tool_use turn. Pre-fix this array still contained it and the
+    // real API would reject it identically → permanent wedge.
+    const turn2Sent = sentPerCall[2]!;
+    expect(hasAssistantToolUse(turn2Sent)).toBe(false);
+    // It is exactly the known-sendable prefix plus the new user turn:
+    // [earlier question, earlier answer, first question, second question].
+    expect(turn2Sent.map((m) => m.role)).toEqual(['user', 'assistant', 'user', 'user']);
+
+    prompts.close();
+    await it.return?.();
+  });
+
+  it('preserves the prior good exchange — rollback truncates only the failed turn', async () => {
+    const prompts = createPushStream<{ content: string }>();
+    const dispatcher: ToolDispatcher = {
+      execute: (_call: ToolCall): Promise<ToolResult> => Promise.resolve({ content: 'ok' }),
+    };
+
+    let callIdx = 0;
+    const sentPerCall: MessageParam[][] = [];
+    messagesCreateMock.mockImplementation((params: { messages: MessageParam[] }) => {
+      callIdx += 1;
+      sentPerCall.push(snapshot(params.messages));
+      if (callIdx === 1) return fromArray(makeThinkingToolUseStream('toolu_a', 'probe'));
+      if (callIdx === 2) throw new Error('invalid request: thinking signature mismatch');
+      return fromArray(makeTextStream('ok answer'));
+    });
+
+    const query = makeQuery(prompts.iterable, dispatcher);
+    const it = (query as AsyncIterable<ProviderEvent>)[Symbol.asyncIterator]();
+    await it.next(); // session.init
+
+    prompts.push({ content: 'q1' });
+    let r = await it.next();
+    while (!r.done) {
+      const ev = r.value as ProviderEvent;
+      if (ev.type === 'error' || ev.type === 'turn.completed') break;
+      r = await it.next();
+    }
+
+    prompts.push({ content: 'q2' });
+    r = await it.next();
+    while (!r.done) {
+      const ev = r.value as ProviderEvent;
+      if (ev.type === 'turn.completed') break;
+      r = await it.next();
+    }
+
+    // The seeded prior exchange survives the rollback (it is part of the
+    // known-good prefix), so context is not lost — only the failed turn's
+    // partial tool churn is dropped.
+    const turn2Sent = sentPerCall[2]!;
+    expect(turn2Sent[0]).toMatchObject({ role: 'user', content: 'earlier question' });
+    expect(turn2Sent[1]).toMatchObject({ role: 'assistant', content: 'earlier answer' });
+
+    prompts.close();
+    await it.return?.();
+  });
+});


### PR DESCRIPTION
## Why

A user hit a session that "stopped" and then **couldn't send anything else** — every subsequent message died in ~2s with no output. Telemetry (3 sessions) showed the same signature: a turn used parallel tools, then the post-tool **continuation request was rejected by the API**, and from that point on every later turn re-failed identically.

### Root mechanism (code-confirmed)

The provider keeps **one `state.messages` array, mutated in place and reused across turns** (`query.ts:216`). A tool-use turn pushes `[assistant(thinking+tool_use), tool_result]` into it (`loop.ts:514`, `loop.ts:689`). If the **next iteration's continuation request** is rejected (a malformed thinking block under interleaved thinking — enabled unconditionally at `auth.ts:29` — or any non-retryable 4xx), `loop.ts:282–296` yields an `error` event and returns, but **those pushed turns are never rolled back**:

- the loop's own rollback (`messagesRollbackIdx`, `loop.ts:699`) only covers throws **during tool execution**, not the next request's failure;
- `repairOrphanToolUses` (`query.ts:333`) only heals **orphan `tool_use`** — here the array ends in a *matched* `tool_result`, so it no-ops.

The session generator then continues to the next prompt with poisoned history → every later request re-sends and re-fails → **permanent wedge**.

## What this changes

On any turn that surfaces an `error` event, truncate the failed turn's pushes back to the **known-sendable prefix** (history through the triggering user turn — a prefix the API already accepted). A failed turn now degrades to a **recoverable per-turn error** instead of bricking the session.

- `+` capture `sendablePrefixLen` right after the user turn is appended
- `+` track `turnErrored` from the per-turn event stream
- `+` `state.messages.splice(sendablePrefixLen)` on error (in place; honors the never-reassign invariant)
- Gated `!aborted` so an interrupt's partial state is preserved for resume.

## Relationship to #288

Defense-in-depth. #288 fixed **one root-cause variant** (dropped `redacted_thinking` blocks). This recovers **regardless of which block the API rejects** — and the regression test's diagnostic output (`invalid thinking blocks: none found (cause may be elsewhere)`) shows the locally-detectable signature check does **not** catch every trigger, which is exactly why a recovery net is needed.

## Honest scope

The **exact** block the API rejected in the original incident is **not runtime-confirmed** — the captured repro ran ~2 min before #288 was installed, and the error isn't persisted to telemetry (only stderr). This PR does **not** claim to eliminate the underlying rejection; it eliminates the **catastrophic permanent wedge** that turns one bad turn into a dead session. Confirming/fixing the precise trigger (likely interleaved-thinking multi-turn validation) is a worthwhile follow-up that needs a live repro with `[afk] thinking-block diagnostic` captured.

## Tests

New `wedge-recovery.test.ts` drives the **real `AnthropicDirectQuery` generator** through `tool-use turn → rejected continuation → next prompt` and asserts the next request no longer re-sends the poisoned turn.

- Verified **red→green**: with the fix disabled, the test fails (turn 2 re-sends the `assistant(tool_use)` poison); with it, passes.
- `pnpm lint` clean · `pnpm audit:sdk:check` OK (no new SDK symbols) · all **329** `anthropic-direct/` provider tests pass (abort, interrupt, usage-limit retry, reauth, compact).
- Independent adversarial review of the diff: 6/6 edge cases SAFE (abort, thrown-error path, compact interaction, over/under-rollback, never-reassign, consecutive-user validity), no must-fix.

## Note for the reporter

The earlier "still doing it" repro ran on the **pre-fix binary** (session ended ~14:41; v4.44.2 with #288 installed 14:43). Worth retesting `opus_1m` + thinking + parallel tools on the current build with both fixes in.
