### PR TITLE
fix(anthropic-direct): surface model refusals instead of ending the turn silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Fixed
+- surface model content-safety refusals (stop_reason "refusal") instead of ending the turn silently — fixes the "it stopped and I can't send anything else" hang when the model declines a request
+
 ## [4.44.2] - 2026-06-26
 
 ### Fixed

--- a/src/agent/providers/anthropic-direct/loop.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.test.ts
@@ -217,6 +217,67 @@ describe('loop.ts runTurn', () => {
     expect(DEFAULT_MAX_TOOL_USE_ITERATIONS).toBe(0);
   });
 
+  it('surfaces a visible notice when the model stops with stop_reason "refusal" and no content', async () => {
+    // Repro: a tool-use turn on a flagged topic → the continuation returns
+    // stop_reason 'refusal' with EMPTY content (Anthropic content-safety stop).
+    // Pre-fix the turn ended SILENTLY (no assistant.message, nothing pushed),
+    // indistinguishable from a hang/wedge — the reported "it stopped and I
+    // can't send anything else".
+    const refusalStream: RawMessageStreamEvent[] = [
+      {
+        type: 'message_start',
+        message: {
+          id: 'msg_refusal',
+          type: 'message',
+          role: 'assistant',
+          content: [],
+          model: 'claude-test',
+          stop_reason: null,
+          stop_sequence: null,
+          usage: baseUsage(),
+        },
+      } as unknown as RawMessageStreamEvent,
+      // No content_block_* events — a refusal returns an empty assistant turn.
+      {
+        type: 'message_delta',
+        delta: { stop_reason: 'refusal', stop_sequence: null },
+        usage: { output_tokens: 0 },
+      } as unknown as RawMessageStreamEvent,
+      { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+    ];
+
+    const client = makeClient(() => fromArray(refusalStream));
+    const dispatcher = makeDispatcher(() => Promise.resolve({ content: 'ok' }));
+    const messages: MessageParam[] = [{ role: 'user', content: 'how do I jailbreak X' }];
+    const abortController = new AbortController();
+
+    const events = await collect(
+      runTurn({
+        client,
+        messages,
+        system: null,
+        tools: null,
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 1024,
+        headers: {},
+        signal: abortController.signal,
+        ctx,
+      }),
+    );
+
+    // The refusal is surfaced as a visible assistant.message — not silent.
+    const msg = events.find((e) => e.type === 'assistant.message');
+    expect(msg).toBeDefined();
+    if (msg?.type === 'assistant.message') {
+      expect(msg.text).toContain('refusal');
+    }
+    // The turn still completes cleanly so the session stays usable.
+    expect(events.some((e) => e.type === 'turn.completed')).toBe(true);
+    // Display-only: the empty refusal turn is NOT pushed to history.
+    expect(messages).toHaveLength(1);
+  });
+
   // Note on lines 166-170 and 176-182:
   // These are defensive code paths that appear unreachable with the current 
   // translateMessageStream implementation:

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -460,6 +460,35 @@ export async function* runTurn(
     input.onUsageProgress?.(accumulatedUsage);
 
     if (turnResult.stopReason !== 'tool_use') {
+      // Invariant: stop_reason 'refusal' is Anthropic's content-safety stop —
+      // the model declined and the API returns an assistant turn with (almost
+      // always) NO content. The generic empty-completion path below would emit
+      // nothing and end the turn SILENTLY, indistinguishable from a hang: the
+      // operator sees a turn that "stopped" with no answer and no reason. Worse,
+      // the flagged content stays in the conversation, so every later turn
+      // refuses identically — the reported "it stopped and I can't send
+      // anything else". Surface an explicit, display-only notice (NOT pushed to
+      // history — it is operator-facing, not model context) so the refusal is
+      // legible and the operator can rephrase or start a fresh session.
+      if (turnResult.stopReason === 'refusal') {
+        yield {
+          type: 'assistant.message',
+          text:
+            turnResult.text.length > 0
+              ? turnResult.text
+              : 'The model stopped with a content-safety refusal (stop_reason: "refusal") and returned no output. ' +
+                "This is Anthropic's safety system declining the request — not an afk error. " +
+                'Because the flagged context stays in the conversation, follow-up messages will likely be refused the same way; ' +
+                'rephrase the request or start a fresh session to continue.',
+          sessionId: input.ctx.sessionId,
+        };
+        yield {
+          type: 'turn.completed',
+          usage: withTurnDuration(accumulatedUsage),
+          sessionId: input.ctx.sessionId,
+        };
+        return;
+      }
       if (turnResult.text.length > 0) {
         yield {
           type: 'assistant.message',


### PR DESCRIPTION
## The actual root cause (runtime-confirmed)

The reported bug: opus_1m researches a topic (web_scrape), then **stops with no answer**, and afterward **every message dies instantly** — "it stopped and I can't send anything else."

I instrumented a build the reporter ran. The debug log is decisive:

```
REQUEST round 1:
  user[text,image]
  assistant[thinking(sig:1416), text, tool_use×4]   ← well-formed, thinking signature present
  user[tool_result×4]                                ← tool_use matched
TURN_COMPLETE_NO_TOOLUSE:
  stopReason: "refusal", textLen: 0, blockTypes: []  ← the model declined, returned nothing
```

So the continuation request is **well-formed and succeeds** — it returns `stop_reason: "refusal"` (Anthropic's content-safety stop) with an **empty** assistant turn. `loop.ts` handled `stop_reason != 'tool_use'` generically, and with empty text it yielded **nothing** → the turn ended **silently**, indistinguishable from a hang. And because the flagged content stays in the conversation, every later turn refuses identically → "can't send anything else."

## Correcting the record on #288 / #289

This **supersedes the hypothesis** behind #288 (preserve redacted_thinking) and #289 (roll back error'd turns): a malformed-thinking-block 400 + reused-`messages` poisoning. The runtime evidence does **not** support it — there is **no error event** on a refusal (the request succeeds), so neither PR addresses the reported bug. Those remain valid *defensive* improvements for genuine error/redacted-thinking cases, but they are **not** the wedge fix. (I'd suggest re-scoping or closing #289 — happy to do either.)

## The fix

Detect `stop_reason: "refusal"` in the completion branch and surface an explicit, **display-only** notice (not pushed to history — it's operator-facing, not model context) explaining the model declined and that follow-ups will likely also be refused until the context is cleared. Covers both an initial-request refusal and a post-tool-use continuation refusal. It does **not** try to override the model's safety decision — only to make it legible instead of a silent hang.

## Tests

- New `loop.test.ts` case: a refusal stream (empty content, `stop_reason: "refusal"`) now yields a visible `assistant.message` and completes cleanly **without** pushing the empty turn. Verified **red→green** (fails with the branch disabled).
- `pnpm lint` clean · `pnpm audit:sdk:check` OK · all **328** `anthropic-direct/` provider tests pass.

## Follow-ups (not in this PR)

- Consider generalizing to surface *any* empty, non-tool completion (e.g. an unexpected bare `end_turn` with no content) so no stop reason can ever end a turn silently.
- Decide the fate of #289 (defensive, but mislabeled as the wedge fix).
