### PR TITLE
feat(trace): surface raw provider stop_reason in `afk trace show`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Added
+- `afk trace show` now surfaces the raw provider `stop_reason` (`stop=…`) on the closure line — it was already persisted on the closure event but unrendered, so silent stops (a turn that ends with no output and no error, e.g. a content-safety `refusal`) were only diagnosable by reading the raw `trace.jsonl`
+
 ## [4.44.2] - 2026-06-26
 
 ### Fixed

--- a/src/cli/commands/trace.test.ts
+++ b/src/cli/commands/trace.test.ts
@@ -130,6 +130,57 @@ describe('formatTrace — default human view', () => {
   });
 });
 
+describe('formatTrace — closure stop_reason rendering', () => {
+  const seal: EventObj = {
+    ts: '2026-06-05T12:35:00.500Z',
+    seq: 2,
+    kind: 'session_sealed',
+    payload: {
+      status: 'succeeded',
+      finalCostUsd: 0.01,
+      finalTurnCount: 1,
+      closedAt: '2026-06-05T12:35:00.500Z',
+    },
+  };
+
+  // Regression: the raw provider stop_reason (e.g. `refusal`) is persisted on
+  // the closure event but was previously unrendered, so a silent stop (turn
+  // ends with no output and no error) was only diagnosable from raw
+  // trace.jsonl. `afk trace show` must now surface it.
+  it('renders the raw provider stop_reason on the closure line when present', () => {
+    const closure: EventObj = {
+      ts: '2026-06-05T12:35:00.000Z',
+      seq: 1,
+      kind: 'closure',
+      payload: {
+        reason: 'model_end_turn',
+        finalTurnCount: 1,
+        finalCostUsd: 0.01,
+        finalTokens: {},
+        lastStopReason: 'refusal',
+      },
+    };
+    const out = formatTrace('s', '/p', parseTrace(toJsonl([closure, seal])));
+    expect(out).toContain('stop=refusal');
+  });
+
+  it('omits stop= when the closure carries no lastStopReason', () => {
+    const closure: EventObj = {
+      ts: '2026-06-05T12:35:00.000Z',
+      seq: 1,
+      kind: 'closure',
+      payload: {
+        reason: 'model_end_turn',
+        finalTurnCount: 1,
+        finalCostUsd: 0.01,
+        finalTokens: {},
+      },
+    };
+    const out = formatTrace('s', '/p', parseTrace(toJsonl([closure, seal])));
+    expect(out).not.toContain('stop=');
+  });
+});
+
 describe('formatTrace — root model provenance header', () => {
   const initStart = (model: string, resolvedModel: string): EventObj => ({
     ts: '2026-06-05T12:30:00.000Z',

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -329,7 +329,16 @@ function renderEvent(event: TraceEvent, ctx: RenderContext): string | null {
     case 'closure': {
       const p = event.payload;
       const guidance = p.guidance ? `  — ${truncate(p.guidance, 100)}` : '';
-      return line('closure', `${p.reason}  turns=${p.finalTurnCount}  ${fmtUsd(p.finalCostUsd)}${guidance}`);
+      // Surface the raw provider stop_reason (e.g. `refusal`, `max_tokens`)
+      // alongside the AFK-classified closure reason. It is already persisted
+      // on the closure event but was previously unrendered — leaving silent
+      // stops (a turn that ends with no output and no error) diagnosable only
+      // by reading the raw trace.jsonl. See docs: silent-model-loop debugging.
+      const stop = p.lastStopReason ? `  stop=${p.lastStopReason}` : '';
+      return line(
+        'closure',
+        `${p.reason}  turns=${p.finalTurnCount}${stop}  ${fmtUsd(p.finalCostUsd)}${guidance}`,
+      );
     }
 
     case 'claim': {


### PR DESCRIPTION
## What & why

`afk trace show` now surfaces the raw provider `stop_reason` as `stop=<reason>` on the closure line.

The value was **already persisted** on the witness closure event (`ClosurePayload.lastStopReason` — captured `agent-session.ts:359`, emitted `:1026`, typed `trace/types.ts:377`) — the human reader at `trace.ts:332` just never rendered it. So a **silent stop** (a turn that ends with no output and no error) was only diagnosable by reading the raw `trace.jsonl`.

This is the gap behind the recent "it stopped and I can't send anything else" investigation: `lastStopReason: "refusal"` was sitting on disk in every wedged session's trace the whole time, unrendered, so the failure looked like an unexplained hang. (A `grep -l '"lastStopReason":"refusal"' ~/.afk/state/witness/*/trace.jsonl` returned 4 traces.)

## Change

One render line on the `closure` case (read-only, additive — shown only when the field is present):

```
closure  abort  turns=1  stop=refusal  $0.0000  — Session ended via abort…
```

(The AFK closure reason here is `abort` because the operator Ctrl-C'd the wedged session; `stop=refusal` is the raw provider reason that explains *why* it produced nothing.)

## Verification

- **Live**, against the real wedge session `d7429db6`: `afk trace show` now prints `stop=refusal` (shown above).
- Regression test (`trace.test.ts`): closure **with** `lastStopReason` renders `stop=refusal`; **without** it omits `stop=`. Verified **red→green**.
- `pnpm lint` clean · `pnpm audit:sdk:check` OK · `trace.test.ts` 20 pass.

## Context

Recommendation #1 (highest debuggability-per-effort) from the silent-model-loop debuggability investigation. Companion to #290 (which surfaces refusals at runtime); this makes the stop reason inspectable post-hoc with no re-run. Follow-ups not in this PR: a `warning` event on any empty non-tool completion, persisting `stopReason` into `events.jsonl`, and an `AFK_DEBUG_PROVIDER` raw-trace flag.
