### PR TITLE
fix(afk): don't fire path-approval prompts in AFK mode

### DIFF
--- a/src/agent/afk-mode-gate.test.ts
+++ b/src/agent/afk-mode-gate.test.ts
@@ -102,6 +102,31 @@ describe('createAfkModeGate', () => {
     expect(result.decision).toBeUndefined();
   });
 
+  it('prefers a live getCwd() over the static cwd for the workspace-escape check', () => {
+    // Static cwd is the project root, but the live getCwd() reports the session
+    // moved into a deeper subdir. A write into the project root (inside the
+    // STATIC cwd) now escapes the LIVE workspace and must be blocked — proving
+    // the gate reads getCwd() first. In AFK this gate is the sole path-safety
+    // layer (path-approval is disabled via allowAll), so this must stay live.
+    const gate = createAfkModeGate(
+      () => 'autonomous' as PermissionMode,
+      '/Users/dev/project',
+      () => '/Users/dev/project/sub',
+    );
+    const escaping = gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: '/Users/dev/project/feature.ts' },
+    });
+    expect(escaping.decision).toBe('block');
+    const inside = gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: '/Users/dev/project/sub/feature.ts' },
+    });
+    expect(inside.decision).toBeUndefined();
+  });
+
   // ---- send_telegram is the channel: always exempt --------------------------
   it('never blocks send_telegram in AFK mode (it is the operator channel)', () => {
     const { gate } = makeGate('autonomous');

--- a/src/agent/afk-mode-gate.ts
+++ b/src/agent/afk-mode-gate.ts
@@ -25,6 +25,14 @@
  * and `'safe'` ops (reads, tests, lint) are ALLOWED — autonomous work has to be
  * useful, and these are reversible enough to run unattended.
  *
+ * Path-safety note: in `'autonomous'` mode the typed-file path-approval prompt
+ * is disabled (`allowAll`, see `agent/permission-policy.ts`) so AFK does not
+ * stall on keyboard prompts the operator cannot answer. That makes THIS gate
+ * the sole path-containment layer in AFK — its workspace-escape rule (a
+ * `write_file`/`edit_file` whose path resolves outside the session root →
+ * `high` → blocked) is load-bearing, which is why the gate is wired with a
+ * live `getCwd` (so a mid-session `/cwd` change cannot stale the boundary).
+ *
  * `send_telegram` is ALWAYS exempt: it is the operator's channel in AFK mode,
  * and the posture explicitly relies on it to surface Asking states.
  *
@@ -51,6 +59,7 @@ import { classifyRisk } from './risk-classifier.js';
 export function createAfkModeGate(
   getMode: () => PermissionMode,
   cwd?: string,
+  getCwd?: () => string | undefined,
 ): (context: HookContext) => HookDecision {
   return function afkModeGate(context: HookContext): HookDecision {
     if (context.event !== 'PreToolUse') return {};
@@ -65,8 +74,11 @@ export function createAfkModeGate(
 
     // Single source of truth for risk. `workspaceRoot` is set to the session
     // cwd so writes that escape it are flagged `high` (classifyRisk's workspace
-    // boundary rule); falling back to process.cwd() when unknown.
-    const root = cwd ?? process.cwd();
+    // boundary rule). Prefer the live getCwd() (tracks a mid-session /cwd
+    // change) over the static construction-time cwd; fall back to process.cwd()
+    // when both are unknown. This matters because in AFK the path-approval
+    // prompt is disabled (allowAll), so this gate is the SOLE path-safety layer.
+    const root = getCwd?.() ?? cwd ?? process.cwd();
     const risk = classifyRisk(toolName, context.input, {
       cwd: root,
       workspaceRoot: root,

--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -93,7 +93,11 @@ export function createDefaultHookRegistry(
     // one applies tree-wide (no subagent exemption) — see afk-mode-gate.ts.
     registry.register(
       'PreToolUse',
-      createAfkModeGate(getPermissionMode, agentOptions?.cwd),
+      // getCwd (live) is preferred over the static agentOptions.cwd so the
+      // gate's workspace-escape rule tracks a mid-session /cwd change — it is
+      // the SOLE path-safety layer in AFK (the path-approval prompt is disabled
+      // via allowAll for 'autonomous'; see agent/permission-policy.ts).
+      createAfkModeGate(getPermissionMode, agentOptions?.cwd, getCwd),
     );
   }
 

--- a/src/agent/permission-policy.test.ts
+++ b/src/agent/permission-policy.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { pathContainmentBypassed } from './permission-policy.js';
+import type { PermissionMode } from './types/sdk-types.js';
+
+describe('pathContainmentBypassed', () => {
+  it('returns true for bypassPermissions (explicit full power)', () => {
+    expect(pathContainmentBypassed('bypassPermissions')).toBe(true);
+  });
+
+  it('returns true for autonomous (AFK — must not fire keyboard path prompts)', () => {
+    expect(pathContainmentBypassed('autonomous')).toBe(true);
+  });
+
+  it.each<PermissionMode>(['default', 'plan', 'acceptEdits', 'dontAsk', 'auto'])(
+    'returns false for containment-preserving mode %s',
+    (mode) => {
+      expect(pathContainmentBypassed(mode)).toBe(false);
+    },
+  );
+
+  it('returns false for undefined / unknown strings', () => {
+    expect(pathContainmentBypassed(undefined)).toBe(false);
+    expect(pathContainmentBypassed('nonsense')).toBe(false);
+  });
+});

--- a/src/agent/permission-policy.ts
+++ b/src/agent/permission-policy.ts
@@ -1,0 +1,40 @@
+/**
+ * Permission-mode policy predicates.
+ *
+ * Single source of truth for "does this permission mode disable typed-file
+ * path containment and the path-approval elicitation prompt?" — i.e. the
+ * dispatcher's `allowAll` flag. Both providers derive `allowAll` (the per-call
+ * dispatcher flag AND the provider's `getGrants().allowAll`, which the
+ * path-approval hook consults) through THIS predicate, so the two reads stay in
+ * lockstep. Divergence fails UNSAFE — the `setPermissionMode` comments in each
+ * provider's query.ts explain why (a badge can clear while the agent stays
+ * unrestricted, or vice versa).
+ *
+ * Why `autonomous` (AFK) qualifies alongside `bypassPermissions`:
+ * AFK mode runs unattended. A keyboard-blocking path-approval prompt would
+ * stall the session against a human who is away — exactly the friction AFK
+ * exists to remove, and it would make AFK MORE restrictive than the new-install
+ * default (`bypassPermissions`). The safety mechanism in AFK is instead the
+ * afk-mode-gate (`agent/afk-mode-gate.ts`), a risk-classifier ceiling that
+ * independently refuses high-risk / irreversible ops — destructive bash,
+ * write-denylist paths, `.git`-store writes, and writes that escape the
+ * workspace root — regardless of `allowAll`. So AFK = bypass-level path freedom
+ * + the risk gate, matching the posture "autonomous on reversible work;
+ * high-risk / irreversible refused".
+ *
+ * @module agent/permission-policy
+ */
+
+import type { PermissionMode } from './types/sdk-types.js';
+
+/**
+ * True when the permission mode disables typed-file path containment and the
+ * path-approval prompt (the dispatcher's `allowAll`). Both `bypassPermissions`
+ * (explicit full power) and `autonomous` (AFK) qualify; every other mode
+ * (`default`, `plan`, `acceptEdits`, `dontAsk`, `auto`) preserves containment.
+ */
+export function pathContainmentBypassed(
+  mode: PermissionMode | string | undefined,
+): boolean {
+  return mode === 'bypassPermissions' || mode === 'autonomous';
+}

--- a/src/agent/providers/anthropic-direct/bypass-live-toggle.test.ts
+++ b/src/agent/providers/anthropic-direct/bypass-live-toggle.test.ts
@@ -85,12 +85,21 @@ describe('AnthropicDirectProvider — live /bypass toggle changes effective enfo
       expect(provider.getGrants().allowAll).toBe(true);
       expect(liveDispatcherAllowAll(q)).toBe(true);
 
-      // No non-bypass mode ever enables allowAll.
-      for (const mode of ['default', 'plan', 'autonomous']) {
+      // Containment-restoring modes disable allowAll on BOTH enforcement reads.
+      for (const mode of ['default', 'plan']) {
         await q.setPermissionMode(mode);
         expect(provider.getGrants().allowAll, `provider:${mode}`).toBe(false);
         expect(liveDispatcherAllowAll(q), `dispatcher:${mode}`).toBe(false);
       }
+
+      // AFK (autonomous) is path-containment-bypassed like bypassPermissions: it
+      // must NOT fire keyboard-blocking path-approval prompts while the operator
+      // is away. The afk-mode-gate (risk-classifier ceiling) is the safety layer
+      // in AFK, not path containment. Both enforcement reads flip to
+      // allowAll=true so the dispatcher and the path-approval hook agree.
+      await q.setPermissionMode('autonomous');
+      expect(provider.getGrants().allowAll, 'provider:autonomous').toBe(true);
+      expect(liveDispatcherAllowAll(q), 'dispatcher:autonomous').toBe(true);
 
       await q.close?.();
     } finally {

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -38,6 +38,7 @@ import {
 import { oneShotCompletion, type OneShotInput } from './oneshot.js';
 import { refreshClaudeCodeOauthToken } from '../../auth/keychain.js';
 import { AnthropicDirectQuery } from './query.js';
+import { pathContainmentBypassed } from '../../permission-policy.js';
 import {
   resolveAutoCompactThreshold,
   resolveEffort,
@@ -361,9 +362,11 @@ export class AnthropicDirectProvider implements ModelProvider {
     const mcpSchemas = this._mcpToolsCache ?? [];
     return new SessionToolDispatcher({
       handlers,
-      // Bypass mode: when the session runs in bypassPermissions, every per-call
-      // ToolHandlerContext carries allowAll:true so path containment is disabled.
-      allowAll: permissionMode === 'bypassPermissions',
+      // Path-containment bypass: bypassPermissions (explicit) AND autonomous
+      // (AFK) both carry allowAll:true so path containment + the path-approval
+      // prompt are disabled per-call. In AFK the afk-mode-gate is the safety
+      // ceiling (see agent/permission-policy.ts).
+      allowAll: pathContainmentBypassed(permissionMode),
       // Constraint (semantic invariant): MCP schemas appended AFTER builtins
       // so builtin tool names always take precedence in any overlap.
       schemas: [...this.schemas, ...mcpSchemas],
@@ -506,7 +509,7 @@ export class AnthropicDirectProvider implements ModelProvider {
       resolveBase: this._initialResolveBase,
       readRoots: this._sharedReadRoots?.slice() ?? [],
       writeRoots: this._sharedWriteRoots?.slice() ?? [],
-      allowAll: this._currentPermissionMode === 'bypassPermissions',
+      allowAll: pathContainmentBypassed(this._currentPermissionMode),
     };
   }
 

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -31,6 +31,7 @@
 import type Anthropic from '@anthropic-ai/sdk';
 import type { ContentBlockParam, MessageParam } from '@anthropic-ai/sdk/resources';
 import { randomUUID } from 'node:crypto';
+import { pathContainmentBypassed } from '../../permission-policy.js';
 import type {
   ProviderAccountInfo,
   ProviderAgentInfo,
@@ -556,8 +557,9 @@ export class AnthropicDirectQuery implements ProviderQuery {
     // fails UNSAFE: badge clears while the agent stays unrestricted):
     //  1. File-tool path containment reads the dispatcher's `allowAll` fresh
     //     per call, so flip it in place — effective on the next tool call.
-    const bypass = mode === 'bypassPermissions';
-    this.state.toolDispatcher.setAllowAll?.(bypass);
+    //     autonomous (AFK) bypasses containment alongside bypassPermissions.
+    const allowAll = pathContainmentBypassed(mode);
+    this.state.toolDispatcher.setAllowAll?.(allowAll);
     //  2. The path-approval hook reads the PROVIDER's getGrants().allowAll (a
     //     different field, `_currentPermissionMode`); update it via the
     //     provider-supplied callback.

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -30,6 +30,7 @@ import type { ComposeExecutor } from '../../tools/compose-executor.js';
 import { withMcpToolsAllowed, type ToolPermissionConfig } from '../../tools/permissions.js';
 import type { ToolDispatcher } from '../anthropic-direct/tool-dispatcher.js';
 import { SessionToolDispatcher } from '../../tools/dispatcher.js';
+import { pathContainmentBypassed } from '../../permission-policy.js';
 import { createBuiltinHandlers } from '../../tools/handlers/index.js';
 import {
   builtinToolSchemas,
@@ -402,8 +403,9 @@ export class OpenAICompatibleProvider implements ModelProvider {
     // the provider's construction-time flag so a read-only skill's forked
     // OpenAI-routed child also blocks mutating shell commands.
     if (this.providerOpts.readOnlyBash === true) dispatcherOpts.readOnlyBash = true;
-    // Bypass mode: disable path containment for every per-call context.
-    dispatcherOpts.allowAll = permissionMode === 'bypassPermissions';
+    // Path-containment bypass: bypassPermissions (explicit) + autonomous (AFK)
+    // both disable path containment for every per-call context.
+    dispatcherOpts.allowAll = pathContainmentBypassed(permissionMode);
 
     return new SessionToolDispatcher(dispatcherOpts);
   }
@@ -462,7 +464,7 @@ export class OpenAICompatibleProvider implements ModelProvider {
       resolveBase: this._initialResolveBase,
       readRoots: this._sharedReadRoots?.slice() ?? [],
       writeRoots: this._sharedWriteRoots?.slice() ?? [],
-      allowAll: this._currentPermissionMode === 'bypassPermissions',
+      allowAll: pathContainmentBypassed(this._currentPermissionMode),
     };
   }
 

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -1043,6 +1043,35 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
     expect(spy).toHaveBeenCalledWith('/new/path');
     q.close();
   });
+
+  it('setPermissionMode flips dispatcher allowAll: autonomous (AFK) + bypass ON, default/plan OFF', async () => {
+    const hookRegistry = createHookRegistry();
+    const dispatcher = new SessionToolDispatcher({
+      handlers: new Map<string, ToolHandler>(),
+      schemas: [] as AnthropicToolDef[],
+      hookRegistry,
+    });
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'k', source: 'config', last4: 'kkkk' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'sid',
+      promptStream: singleInput('x'),
+      config: baseConfig(),
+      toolDispatcher: dispatcher,
+    });
+    // AFK (autonomous) must bypass path containment like bypassPermissions so an
+    // unattended session never stalls on a keyboard path-approval prompt.
+    await q.setPermissionMode('autonomous');
+    expect(dispatcher.getGrants().allowAll).toBe(true);
+    await q.setPermissionMode('bypassPermissions');
+    expect(dispatcher.getGrants().allowAll).toBe(true);
+    // Containment-restoring modes turn it back off.
+    await q.setPermissionMode('default');
+    expect(dispatcher.getGrants().allowAll).toBe(false);
+    await q.setPermissionMode('plan');
+    expect(dispatcher.getGrants().allowAll).toBe(false);
+    q.close();
+  });
 });
 
 describe('OpenAICompatibleQuery — plan-mode addendum (U2)', () => {

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -28,6 +28,7 @@ import { randomUUID } from 'node:crypto';
 import type { AgentConfig } from '../../types/config-types.js';
 import type { EffortLevel } from '../../types/sdk-types.js';
 import { emitToolCall, emitSessionPhase } from '../../trace/emit.js';
+import { pathContainmentBypassed } from '../../permission-policy.js';
 import type { TraceWriter } from '../../trace/index.js';
 import type {
   ProviderQuery,
@@ -1206,8 +1207,9 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     // Live enforcement, two fields kept in sync (else `/bypass off` fails
     // UNSAFE — badge clears while the agent stays unrestricted):
     //  1. file-tool containment ← dispatcher's allowAll (read fresh per call).
-    const bypass = this.currentPermissionMode === 'bypassPermissions';
-    this.toolDispatcher?.setAllowAll?.(bypass);
+    //     autonomous (AFK) bypasses containment alongside bypassPermissions.
+    const allowAll = pathContainmentBypassed(this.currentPermissionMode);
+    this.toolDispatcher?.setAllowAll?.(allowAll);
     //  2. path-approval hook ← provider's _currentPermissionMode (callback).
     this.onPermissionMode?.(this.currentPermissionMode);
   }


### PR DESCRIPTION
## Summary

Fixes AFK mode firing keyboard-blocking path-approval prompts — the bug that defeats "away from keyboard."

- AFK (`autonomous`) set the dispatcher `allowAll=false`, re-enabling typed-file path-approval elicitations that block on a keyboard the operator has walked away from — making AFK *stricter* than the new-install default (`bypassPermissions`).
- New `src/agent/permission-policy.ts` exports `pathContainmentBypassed(mode)` (true for `bypassPermissions` **and** `autonomous`) as the single source of truth, applied at all six `allowAll` derivation sites across both providers, so the dispatcher flag and `getGrants().allowAll` stay in lockstep (divergence fails unsafe).
- Safety is unchanged: the `afk-mode-gate` risk ceiling still refuses high-risk / irreversible ops (destructive bash, write-denylist, `.git`-store, workspace-escape writes) **independently** of `allowAll`.
- Hardening: the gate — now the sole path-safety layer in AFK — takes a live `getCwd` (the same getter path-approval already uses, wired from the REPL bootstrap) so its workspace-escape boundary tracks a mid-session `/cwd` change.

Net effect: **AFK = `bypassPermissions`-level path freedom + the risk gate.** Behavior in `default` / `plan` / `bypassPermissions` is unchanged.

## Test results

- `pnpm lint` (`tsc --noEmit`, strict) → clean.
- `pnpm exec vitest run` (full suite, rebased onto `v4.45.0`) → **10137 passed / 14 skipped / 1 failed**.
- The single failure — `anthropic-direct.test.ts > compact() summarizes older history…` — is **pre-existing and unrelated**: it fails identically on clean HEAD with these edits `git stash`ed, and the diff touches no compaction code.
- Touched-area focus (5 files) → **123 passed**: `permission-policy.test.ts` (new), `afk-mode-gate.test.ts` (incl. new `getCwd`-precedence test), `bypass-live-toggle.test.ts` (autonomous ⇒ allowAll on both enforcement reads), `openai-compatible/query.test.ts` (OpenAI parity), `path-approval-hook.test.ts` (no regression).

## Verification

Adversarial re-derivation from the diff alone (independent read-only pass):

- **C1 CONFIRM** — `pathContainmentBypassed` (`permission-policy.ts:39`) returns true for both modes; applied at all 6 sites (`anthropic-direct/index.ts:369,512`, `query.ts:561`; `openai-compatible/index.ts:408,467`, `query.ts:1211`); no bare `=== 'bypassPermissions'` remains at any `allowAll` site.
- **C2 CONFIRM** — `afk-mode-gate.ts` blocks `classifyRisk()==='high'` independently of `allowAll`/grants; only a `getCwd` param was added.
- **C3 CONFIRM** — both enforcement reads per provider derive through the same predicate; no drift.
- Flagged residual (resolved): the `getCwd` wired in `default-hook-registry.ts` is the REPL bootstrap's live `() => extras?.cwd ?? process.cwd()` (`bootstrap.ts:568`) — the same getter path-approval uses — so the gate's workspace boundary stays live, not stale.

## Out of scope

- Phase 2 "two-way AFK" (inbound Telegram replies steering a live run; high-risk-gate → phone approve/deny) is **deferred** — recon found the elicitation/abort round-trip is already ~90% built (auto-subscribe + ledger channel + `/abort` + HMAC). Roadmap captured in the local plan doc (`.afk/plans/…`, gitignored).
