### PR TITLE
fix(openai-compatible): don't send Chat-Completions max_tokens on the Responses path

### DIFF
--- a/src/agent/providers/openai-compatible/query-responses.test.ts
+++ b/src/agent/providers/openai-compatible/query-responses.test.ts
@@ -124,6 +124,25 @@ describe('query — Responses wire (public opt-in)', () => {
     // Public API-key path must NOT force store:false (that's a ChatGPT-backend rule).
     expect(createArgsSeen!['store']).toBeUndefined();
   });
+
+  it('caps output via `max_output_tokens` (Responses param) — never Chat Completions `max_tokens`', async () => {
+    installResponsesMock();
+    pendingEvents = [{ type: 'response.completed', response: { status: 'completed' } }];
+    const query = new OpenAICompatibleQuery({
+      auth: { apiKey: 'sk-x', source: 'env' },
+      model: 'gpt-5',
+      synthesizedSessionId: 'sess-cap-public',
+      promptStream: singleInput('hi'),
+      config: config({ maxOutputTokens: 1234 } as Partial<AgentConfig>),
+      useResponsesApi: true,
+    });
+    await collect(query);
+    // The Responses API uses `max_output_tokens`; the Chat Completions fields
+    // (`max_tokens` / `max_completion_tokens`) must never appear on this wire.
+    expect(createArgsSeen!['max_output_tokens']).toBe(1234);
+    expect(createArgsSeen!['max_tokens']).toBeUndefined();
+    expect(createArgsSeen!['max_completion_tokens']).toBeUndefined();
+  });
 });
 
 describe('query — Responses wire (ChatGPT subscription auth)', () => {
@@ -156,6 +175,26 @@ describe('query — Responses wire (ChatGPT subscription auth)', () => {
     // Backend requirements: store:false + the (system-prompt) instructions present.
     expect(createArgsSeen!['store']).toBe(false);
     expect(createArgsSeen!['instructions']).toBe('You are helpful.');
+  });
+
+  it('omits the output-token cap entirely (the Codex backend 400s on `max_tokens` AND `max_output_tokens`)', async () => {
+    installResponsesMock();
+    pendingEvents = [{ type: 'response.completed', response: { status: 'completed' } }];
+    const auth: OpenAIAuthResolution = { apiKey: 'tok', source: 'chatgpt-oauth', accountId: 'acct_z' };
+    const query = new OpenAICompatibleQuery({
+      auth,
+      model: 'gpt-5.5',
+      synthesizedSessionId: 'sess-cap-chatgpt',
+      promptStream: singleInput('hi'),
+      config: config({ maxOutputTokens: 1234 } as Partial<AgentConfig>),
+    });
+    await collect(query);
+    // The private ChatGPT/Codex backend rejects every output-cap parameter with
+    // an opaque 400 — sending `max_tokens` here was the root cause of the
+    // "ChatGPT subscription" failure. No cap field may be present.
+    expect(createArgsSeen!['max_tokens']).toBeUndefined();
+    expect(createArgsSeen!['max_output_tokens']).toBeUndefined();
+    expect(createArgsSeen!['max_completion_tokens']).toBeUndefined();
   });
 
   it('supplies default instructions when the session has no system prompt (backend requires non-empty)', async () => {

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -191,13 +191,36 @@ export function __setOpenAIClientFactory(factory: OpenAIClientFactory | null): v
 }
 
 /**
- * Resolve the streaming output-token cap for the OpenAI API.
+ * Resolve the effective output-token cap (a plain number).
+ *
+ * Honours `config.maxOutputTokens` when finite+positive, otherwise falls back
+ * to the model's output ceiling (matching Anthropic's resolveMaxTokens).  Uses
+ * maxOutputTokensFor (output ceiling), not contextLimitFor (context window),
+ * because the cap bounds *output*, not the full context window.
+ *
+ * Field-name selection (`max_tokens` vs `max_completion_tokens` vs
+ * `max_output_tokens`) is the caller's concern — it differs by wire mode:
+ * Chat Completions uses {@link resolveStreamingMaxTokens}; the Responses API
+ * uses `max_output_tokens` directly.
+ */
+function resolveEffectiveMaxOutputTokens(
+  model: string,
+  configMaxOutput: number | undefined,
+): number {
+  const ceiling = maxOutputTokensFor(model);
+  return typeof configMaxOutput === 'number' && Number.isFinite(configMaxOutput) && configMaxOutput > 0
+    ? Math.floor(configMaxOutput)
+    : ceiling;
+}
+
+/**
+ * Resolve the **Chat Completions** streaming output-token cap.
  *
  * Mirrors the o-series field-selection logic in `oneshot.ts:91–96`:
  * o-series reasoning models (o1/o3/o4…) reject `max_tokens` and require
  * `max_completion_tokens`; everything else (chat models, local shims)
- * wants `max_tokens`.  Strips any `provider/` prefix (OpenRouter-style ids)
- * before the regex check so `openai/o3` is treated the same as `o3`.
+ * wants `max_tokens`.  (The Responses API is different again — it uses
+ * `max_output_tokens` — so this helper is Chat-Completions-only.)
  *
  * Always returns an object containing the resolved cap; uses the model's
  * output ceiling as a fallback so the field is always present on the wire.
@@ -206,23 +229,10 @@ function resolveStreamingMaxTokens(
   model: string,
   configMaxOutput: number | undefined,
 ): Record<string, number> {
-  // Strip any `provider/` prefix (OpenRouter-style ids) before the o-series
-  // regex — mirrors oneshot.ts:93.
-  const bareModel = model.includes('/') ? model.slice(model.lastIndexOf('/') + 1) : model;
-  const isOSeries = /^o[0-9]/.test(bareModel);
-
-  // Resolve the effective cap: honour config.maxOutputTokens when finite+positive,
-  // otherwise fall back to the model's output ceiling (matching Anthropic's
-  // resolveMaxTokens).  Uses maxOutputTokensFor (output ceiling), not
-  // contextLimitFor (context window), because the cap bounds *output*, not
-  // the full context window.
-  const ceiling = maxOutputTokensFor(model);
-  const effectiveMax =
-    typeof configMaxOutput === 'number' && Number.isFinite(configMaxOutput) && configMaxOutput > 0
-      ? Math.floor(configMaxOutput)
-      : ceiling;
-
-  return isOSeries ? { max_completion_tokens: effectiveMax } : { max_tokens: effectiveMax };
+  const effectiveMax = resolveEffectiveMaxOutputTokens(model, configMaxOutput);
+  return isOSeriesModel(model)
+    ? { max_completion_tokens: effectiveMax }
+    : { max_tokens: effectiveMax };
 }
 
 /** Construction options. */
@@ -761,15 +771,19 @@ export class OpenAICompatibleQuery implements ProviderQuery {
         input: req.input,
         stream: true,
       };
-      // Thread the output-token cap into the streaming request so callers can
-      // bound output length (parity with Anthropic's always-forwarded
-      // max_tokens).  Reuses the o-series field-selection logic from
-      // oneshot.ts:91–96.
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      Object.assign(requestBody, resolveStreamingMaxTokens(
-        this.currentModel,
-        this.opts.config.maxOutputTokens,
-      ));
+      // Output-token cap. The Responses API uses `max_output_tokens` — NOT Chat
+      // Completions' `max_tokens`/`max_completion_tokens`. The private ChatGPT/
+      // Codex subscription backend rejects *every* output-cap parameter with an
+      // opaque HTTP 400 (`{"detail":"Unsupported parameter: max_tokens"}`, and
+      // likewise for `max_output_tokens`), so omit the cap there entirely and
+      // let the backend apply its own limit. (Sending `max_tokens` here is what
+      // made every ChatGPT-subscription request fail.)
+      if (!isChatGptBackend) {
+        requestBody['max_output_tokens'] = resolveEffectiveMaxOutputTokens(
+          this.currentModel,
+          this.opts.config.maxOutputTokens,
+        );
+      }
       // The private ChatGPT backend (subscription path) has two hard
       // requirements the public Responses API does not: a non-empty
       // `instructions`, and `store: false`. Scope both to that path so the

--- a/src/agent/subagent/handle-streaming.test.ts
+++ b/src/agent/subagent/handle-streaming.test.ts
@@ -257,23 +257,21 @@ describe('SubagentHandle streaming', () => {
   describe('Sink invocation and event ordering', () => {
     it('calls progressSink for each event in order with correct metadata', async () => {
       const sinkFn = vi.fn();
-      const events: OutputEvent[] = [
-        { type: 'progress', progress: { taskId: 'task-1', description: 'starting', totalTokens: 0, toolUses: 0, durationMs: 10 } },
-        {
-          type: 'message',
-          message: {
-            role: 'assistant',
-            content: 'hello',
-            timestamp: new Date(),
-          },
-        },
-        { type: 'done' },
-      ];
+      // handle.run() returns the `message` event's payload (handle.ts: finalMessage
+      // = event.message), so the expectation must compare against that exact object.
+      // Constructing a second message with its own `new Date()` raced the millisecond
+      // boundary and made `expect(msg).toEqual(finalMessage)` flaky on slower CI
+      // runners. Share one Message reference across the event and the expectation.
       const finalMessage: Message = {
         role: 'assistant',
         content: 'hello',
         timestamp: new Date(),
       };
+      const events: OutputEvent[] = [
+        { type: 'progress', progress: { taskId: 'task-1', description: 'starting', totalTokens: 0, toolUses: 0, durationMs: 10 } },
+        { type: 'message', message: finalMessage },
+        { type: 'done' },
+      ];
 
       const session = createDeterministicMockSession(events, finalMessage);
       const handle = new SubagentHandleImpl(


### PR DESCRIPTION
## Summary

ChatGPT-subscription (Codex OAuth) sessions were **completely broken**: every request failed and afk reported a misleading *"ChatGPT/Codex backend rejected model … gpt-5.5 works …"* error that pointed at OAuth/model when neither was the problem.

**Root cause:** the Responses wire path attached the **Chat-Completions** output cap (`max_tokens` / `max_completion_tokens`) to the request body:

```ts
// query.ts (Responses path)
Object.assign(requestBody, resolveStreamingMaxTokens(this.currentModel, this.opts.config.maxOutputTokens));
```

But the Responses API uses **`max_output_tokens`**, and the private ChatGPT/Codex subscription backend (`chatgpt.com/backend-api/codex`) rejects **every** output-cap parameter with an opaque `HTTP 400`:

```json
{"detail":"Unsupported parameter: max_tokens"}
```

`clarifyResponsesError` then failed to surface that body and substituted a hardcoded "model not supported" guess — which is why this looked like an auth/model issue.

## Proof (live backend)

Captured afk's literal request body and replayed it against the real backend with afk's own credentials:

| Request | Result |
|---|---|
| afk body verbatim | `400 {"detail":"Unsupported parameter: max_tokens"}` |
| **same body, `max_tokens` removed** | **`200 OK`** |
| same body, `max_tokens` → `max_output_tokens` | `400 {"detail":"Unsupported parameter: max_output_tokens"}` |

So the cap must be **omitted entirely** on the ChatGPT/Codex backend (it imposes its own limit), and the public Responses path must use `max_output_tokens`, not `max_tokens`. The `codex` CLI itself works fine against the same backend/credentials, confirming OAuth is healthy.

## Fix

Scoped to the Responses path only — **Chat Completions is unchanged**:

- **Public API-key Responses**: send `max_output_tokens` (the correct param); never `max_tokens` / `max_completion_tokens`.
- **ChatGPT/Codex backend** (`auth.source === 'chatgpt-oauth'`): omit the output cap entirely.
- Extracted `resolveEffectiveMaxOutputTokens` so both wire modes share the cap math.

## Tests

- `pnpm exec vitest run src/agent/providers/openai-compatible/` → **221 passed** (incl. 2 new regression tests):
  - public Responses path asserts `max_output_tokens` is set and `max_tokens`/`max_completion_tokens` are absent;
  - ChatGPT-backend path asserts **no** cap field is present.
- `pnpm lint` (tsc --noEmit) → clean.
- Full suite: 10128 passed / 14 skipped. The 2 unrelated failures (`anthropic-direct.test.ts` compact, `daemon.test.ts` scheduler) reproduce on clean `main` (env bleed / full-suite flakiness) and are untouched by this change.

## Follow-up (out of scope)

`clarifyResponsesError` masks the backend's real `{detail}` body behind a hardcoded "model not supported (gpt-5.5 works)" message — that masking is what made this hard to diagnose. Worth a separate PR to surface the actual `detail` and drop the stale model claim.
