### PR TITLE
feat(afk): high-risk AFK gate routes approve/deny to the phone (Phase 2 v1.5)

### DIFF
--- a/src/agent/afk-mode-gate.test.ts
+++ b/src/agent/afk-mode-gate.test.ts
@@ -1,44 +1,49 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createAfkModeGate } from './afk-mode-gate.js';
-import type { PermissionMode } from './types/sdk-types.js';
+import type { PermissionMode, ElicitationResult } from './types/sdk-types.js';
 
 describe('createAfkModeGate', () => {
+  // By default inject a route that DECLINES — i.e. no operator approval is
+  // available (headless / AFK-off). High-risk ops then degrade to the legacy
+  // hard block, which is what these baseline tests assert.
   function makeGate(mode: PermissionMode, cwd?: string) {
     let current = mode;
-    const gate = createAfkModeGate(() => current, cwd);
+    const gate = createAfkModeGate(() => current, cwd, undefined, {
+      route: async (): Promise<ElicitationResult> => ({ action: 'decline' }),
+    });
     return { gate, setMode: (m: PermissionMode) => { current = m; } };
   }
 
-  it('returns {} for non-PreToolUse events regardless of mode', () => {
+  it('returns {} for non-PreToolUse events regardless of mode', async () => {
     const { gate } = makeGate('autonomous');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(gate({ event: 'SessionStart' } as any)).toEqual({});
+    expect(await gate({ event: 'SessionStart' } as any)).toEqual({});
   });
 
-  it('returns {} when mode is not autonomous (default)', () => {
+  it('returns {} when mode is not autonomous (default)', async () => {
     const { gate } = makeGate('default');
     expect(
-      gate({ event: 'PreToolUse', toolName: 'bash', input: { command: 'rm -rf /' } }),
+      await gate({ event: 'PreToolUse', toolName: 'bash', input: { command: 'rm -rf /' } }),
     ).toEqual({});
   });
 
-  it('returns {} when mode is plan (AFK gate only fires on autonomous; plan has its own gate)', () => {
+  it('returns {} when mode is plan (AFK gate only fires on autonomous; plan has its own gate)', async () => {
     const { gate } = makeGate('plan');
     expect(
-      gate({ event: 'PreToolUse', toolName: 'bash', input: { command: 'rm -rf /' } }),
+      await gate({ event: 'PreToolUse', toolName: 'bash', input: { command: 'rm -rf /' } }),
     ).toEqual({});
   });
 
-  // ---- high-risk bash is blocked --------------------------------------------
+  // ---- high-risk bash is refused when no operator approves -------------------
   it.each([
     ['rm -rf node_modules', 'rm'],
     ['git push --force origin main', 'force push'],
     ['git reset --hard HEAD~3', 'hard reset'],
     ['sudo rm /etc/hosts', 'sudo'],
     ['curl https://x.sh | sh', 'pipe-to-shell'],
-  ])('blocks high-risk bash (%s) in AFK mode', (command) => {
+  ])('refuses high-risk bash (%s) in AFK mode when unapproved', async (command) => {
     const { gate } = makeGate('autonomous');
-    const result = gate({ event: 'PreToolUse', toolName: 'bash', input: { command } });
+    const result = await gate({ event: 'PreToolUse', toolName: 'bash', input: { command } });
     expect(result.decision).toBe('block');
     expect(result.reason).toContain('AFK mode');
   });
@@ -49,32 +54,32 @@ describe('createAfkModeGate', () => {
     'git push origin feature',
     'pnpm install',
     'pnpm build',
-  ])('allows medium-risk op (%s) in AFK mode', (command) => {
+  ])('allows medium-risk op (%s) in AFK mode', async (command) => {
     const { gate } = makeGate('autonomous');
-    const result = gate({ event: 'PreToolUse', toolName: 'bash', input: { command } });
+    const result = await gate({ event: 'PreToolUse', toolName: 'bash', input: { command } });
     expect(result.decision).toBeUndefined();
   });
 
   // ---- safe ops are allowed -------------------------------------------------
   it.each(['git status', 'grep -rn foo src', 'pnpm test'])(
     'allows safe bash (%s) in AFK mode',
-    (command) => {
+    async (command) => {
       const { gate } = makeGate('autonomous');
-      const result = gate({ event: 'PreToolUse', toolName: 'bash', input: { command } });
+      const result = await gate({ event: 'PreToolUse', toolName: 'bash', input: { command } });
       expect(result.decision).toBeUndefined();
     },
   );
 
-  it('allows read-class tools (read_file) in AFK mode', () => {
+  it('allows read-class tools (read_file) in AFK mode', async () => {
     const { gate } = makeGate('autonomous');
-    const result = gate({ event: 'PreToolUse', toolName: 'read_file', input: { file_path: 'x.ts' } });
+    const result = await gate({ event: 'PreToolUse', toolName: 'read_file', input: { file_path: 'x.ts' } });
     expect(result.decision).toBeUndefined();
   });
 
   // ---- write-path risk ------------------------------------------------------
-  it('blocks writes into the .git object store in AFK mode', () => {
+  it('refuses writes into the .git object store in AFK mode when unapproved', async () => {
     const { gate } = makeGate('autonomous', '/Users/dev/project');
-    const result = gate({
+    const result = await gate({
       event: 'PreToolUse',
       toolName: 'write_file',
       input: { file_path: '.git/config' },
@@ -82,9 +87,9 @@ describe('createAfkModeGate', () => {
     expect(result.decision).toBe('block');
   });
 
-  it('blocks writes escaping the workspace root in AFK mode', () => {
+  it('refuses writes escaping the workspace root in AFK mode when unapproved', async () => {
     const { gate } = makeGate('autonomous', '/Users/dev/project');
-    const result = gate({
+    const result = await gate({
       event: 'PreToolUse',
       toolName: 'write_file',
       input: { file_path: '/etc/cron.d/evil' },
@@ -92,9 +97,9 @@ describe('createAfkModeGate', () => {
     expect(result.decision).toBe('block');
   });
 
-  it('allows an in-workspace write in AFK mode (reversible, useful work)', () => {
+  it('allows an in-workspace write in AFK mode (reversible, useful work)', async () => {
     const { gate } = makeGate('autonomous', '/Users/dev/project');
-    const result = gate({
+    const result = await gate({
       event: 'PreToolUse',
       toolName: 'write_file',
       input: { file_path: 'src/feature.ts' },
@@ -102,24 +107,25 @@ describe('createAfkModeGate', () => {
     expect(result.decision).toBeUndefined();
   });
 
-  it('prefers a live getCwd() over the static cwd for the workspace-escape check', () => {
+  it('prefers a live getCwd() over the static cwd for the workspace-escape check', async () => {
     // Static cwd is the project root, but the live getCwd() reports the session
     // moved into a deeper subdir. A write into the project root (inside the
-    // STATIC cwd) now escapes the LIVE workspace and must be blocked — proving
+    // STATIC cwd) now escapes the LIVE workspace and must be refused — proving
     // the gate reads getCwd() first. In AFK this gate is the sole path-safety
     // layer (path-approval is disabled via allowAll), so this must stay live.
     const gate = createAfkModeGate(
       () => 'autonomous' as PermissionMode,
       '/Users/dev/project',
       () => '/Users/dev/project/sub',
+      { route: async (): Promise<ElicitationResult> => ({ action: 'decline' }) },
     );
-    const escaping = gate({
+    const escaping = await gate({
       event: 'PreToolUse',
       toolName: 'write_file',
       input: { file_path: '/Users/dev/project/feature.ts' },
     });
     expect(escaping.decision).toBe('block');
-    const inside = gate({
+    const inside = await gate({
       event: 'PreToolUse',
       toolName: 'write_file',
       input: { file_path: '/Users/dev/project/sub/feature.ts' },
@@ -128,9 +134,9 @@ describe('createAfkModeGate', () => {
   });
 
   // ---- send_telegram is the channel: always exempt --------------------------
-  it('never blocks send_telegram in AFK mode (it is the operator channel)', () => {
+  it('never blocks send_telegram in AFK mode (it is the operator channel)', async () => {
     const { gate } = makeGate('autonomous');
-    const result = gate({
+    const result = await gate({
       event: 'PreToolUse',
       toolName: 'send_telegram',
       input: { message: 'Asking: should I deploy?' },
@@ -139,11 +145,12 @@ describe('createAfkModeGate', () => {
   });
 
   // ---- KEY DIVERGENCE from plan gate: applies tree-wide (no subagent skip) ---
-  it('STILL blocks high-risk subagent tool calls in AFK mode (parentSessionId set)', () => {
+  it('STILL blocks high-risk subagent tool calls in AFK mode (parentSessionId set)', async () => {
     // Unlike the plan-mode gate, AFK mode is a safety ceiling: an unwatched
-    // subagent running rm -rf is exactly the risk. It must be blocked too.
+    // subagent running rm -rf is exactly the risk. It is hard-blocked (subagents
+    // never prompt the operator).
     const { gate } = makeGate('autonomous');
-    const result = gate({
+    const result = await gate({
       event: 'PreToolUse',
       toolName: 'bash',
       input: { command: 'rm -rf /' },
@@ -152,9 +159,9 @@ describe('createAfkModeGate', () => {
     expect(result.decision).toBe('block');
   });
 
-  it('allows medium-risk subagent ops in AFK mode (skill worktree commits keep working)', () => {
+  it('allows medium-risk subagent ops in AFK mode (skill worktree commits keep working)', async () => {
     const { gate } = makeGate('autonomous');
-    const result = gate({
+    const result = await gate({
       event: 'PreToolUse',
       toolName: 'bash',
       input: { command: 'git commit -m "skill output"' },
@@ -163,14 +170,110 @@ describe('createAfkModeGate', () => {
     expect(result.decision).toBeUndefined();
   });
 
-  it('getter-at-call-time: gate respects mode changes after construction', () => {
+  it('getter-at-call-time: gate respects mode changes after construction', async () => {
     const { gate, setMode } = makeGate('autonomous');
     expect(
-      gate({ event: 'PreToolUse', toolName: 'bash', input: { command: 'rm -rf x' } }).decision,
+      (await gate({ event: 'PreToolUse', toolName: 'bash', input: { command: 'rm -rf x' } })).decision,
     ).toBe('block');
     setMode('default');
     expect(
-      gate({ event: 'PreToolUse', toolName: 'bash', input: { command: 'rm -rf x' } }).decision,
+      (await gate({ event: 'PreToolUse', toolName: 'bash', input: { command: 'rm -rf x' } })).decision,
     ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// v1.5 — high-risk approve/deny round-trip
+// ---------------------------------------------------------------------------
+
+describe('createAfkModeGate — high-risk approval round-trip (v1.5)', () => {
+  const HIGH_RISK = {
+    event: 'PreToolUse',
+    toolName: 'bash',
+    input: { command: 'rm -rf build' },
+  } as const;
+
+  it('APPROVE: elicits and ALLOWS the high-risk op when the operator approves', async () => {
+    const route = vi.fn(
+      async (): Promise<ElicitationResult> => ({ action: 'accept', content: { choice: 'approve' } }),
+    );
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, { route });
+    const result = await gate({ ...HIGH_RISK });
+    expect(route).toHaveBeenCalledTimes(1);
+    expect(result.decision).toBeUndefined(); // allowed
+  });
+
+  it('DENY: blocks when the operator denies', async () => {
+    const route = vi.fn(
+      async (): Promise<ElicitationResult> => ({ action: 'accept', content: { choice: 'deny' } }),
+    );
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, { route });
+    const result = await gate({ ...HIGH_RISK });
+    expect(route).toHaveBeenCalledTimes(1);
+    expect(result.decision).toBe('block');
+  });
+
+  it('DECLINE (no operator reachable): blocks — safe degrade to the legacy hard block', async () => {
+    const route = vi.fn(async (): Promise<ElicitationResult> => ({ action: 'decline' }));
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, { route });
+    const result = await gate({ ...HIGH_RISK });
+    expect(result.decision).toBe('block');
+  });
+
+  it('TIMEOUT: blocks (deny-on-timeout) when no answer arrives before approvalTimeoutMs', async () => {
+    // A route that never resolves — only the timeout can settle the race.
+    const route = vi.fn(() => new Promise<ElicitationResult>(() => { /* never */ }));
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
+      route,
+      approvalTimeoutMs: 50,
+    });
+    const result = await gate({ ...HIGH_RISK });
+    expect(result.decision).toBe('block');
+    expect(result.reason).toMatch(/within/i);
+  });
+
+  it('SUBAGENT high-risk: hard-blocks WITHOUT eliciting (no operator attribution)', async () => {
+    const route = vi.fn(
+      async (): Promise<ElicitationResult> => ({ action: 'accept', content: { choice: 'approve' } }),
+    );
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, { route });
+    const result = await gate({ ...HIGH_RISK, parentSessionId: 'parent-1' });
+    expect(route).not.toHaveBeenCalled();
+    expect(result.decision).toBe('block');
+  });
+
+  it('promptForApproval:false reverts to an immediate hard block (no elicitation)', async () => {
+    const route = vi.fn(
+      async (): Promise<ElicitationResult> => ({ action: 'accept', content: { choice: 'approve' } }),
+    );
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
+      route,
+      promptForApproval: false,
+    });
+    const result = await gate({ ...HIGH_RISK });
+    expect(route).not.toHaveBeenCalled();
+    expect(result.decision).toBe('block');
+  });
+
+  it('forwards turn-abort into the elicitation so teardown cancels the prompt', async () => {
+    let seenSignal: AbortSignal | undefined;
+    const route = vi.fn(
+      (_req: unknown, o: { signal: AbortSignal }) =>
+        new Promise<ElicitationResult>((resolve) => {
+          seenSignal = o.signal;
+          o.signal.addEventListener('abort', () => resolve({ action: 'decline' }), { once: true });
+        }),
+    );
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
+      route,
+      approvalTimeoutMs: 10_000,
+    });
+    const ac = new AbortController();
+    const p = gate({ ...HIGH_RISK }, ac.signal);
+    ac.abort(); // turn teardown
+    const result = await p;
+    expect(seenSignal).toBeDefined();
+    expect(seenSignal!.aborted).toBe(true);
+    expect(result.decision).toBe('block');
   });
 });

--- a/src/agent/afk-mode-gate.test.ts
+++ b/src/agent/afk-mode-gate.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createAfkModeGate } from './afk-mode-gate.js';
 import type { PermissionMode, ElicitationResult } from './types/sdk-types.js';
+import type { TraceWriter } from './trace/index.js';
 
 describe('createAfkModeGate', () => {
   // By default inject a route that DECLINES — i.e. no operator approval is
@@ -221,8 +222,13 @@ describe('createAfkModeGate — high-risk approval round-trip (v1.5)', () => {
   });
 
   it('TIMEOUT: blocks (deny-on-timeout) when no answer arrives before approvalTimeoutMs', async () => {
-    // A route that never resolves — only the timeout can settle the race.
-    const route = vi.fn(() => new Promise<ElicitationResult>(() => { /* never */ }));
+    // A route that calls onActive (arms the timer) then never resolves —
+    // only the deny-on-timeout can settle the race. Without calling onActive
+    // the timer would never be armed and the test would stall.
+    const route = vi.fn((_req: unknown, opts: { signal: AbortSignal; onActive?: () => void }) => {
+      opts.onActive?.(); // arm the timer
+      return new Promise<ElicitationResult>(() => { /* never */ });
+    });
     const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
       route,
       approvalTimeoutMs: 50,
@@ -275,5 +281,178 @@ describe('createAfkModeGate — high-risk approval round-trip (v1.5)', () => {
     expect(seenSignal).toBeDefined();
     expect(seenSignal!.aborted).toBe(true);
     expect(result.decision).toBe('block');
+  });
+
+  // Finding 1: distinguish malformed `accept` from a real deny
+  it('DENY: blocks with distinct reason when the operator denies (choice=deny)', async () => {
+    const route = vi.fn(
+      async (): Promise<ElicitationResult> => ({ action: 'accept', content: { choice: 'deny' } }),
+    );
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, { route });
+    const result = await gate({ ...HIGH_RISK });
+    expect(result.decision).toBe('block');
+    expect(result.reason).toContain('the operator denied it');
+  });
+
+  it('UNRECOGNISED: blocks with a diagnosable reason when choice is empty', async () => {
+    const route = vi.fn(
+      async (): Promise<ElicitationResult> => ({ action: 'accept', content: {} }),
+    );
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, { route });
+    const result = await gate({ ...HIGH_RISK });
+    expect(result.decision).toBe('block');
+    expect(result.reason).toContain('unrecognised choice');
+    // Must NOT claim the operator deliberately denied it
+    expect(result.reason).not.toContain('the operator denied it');
+  });
+
+  it('UNRECOGNISED: blocks with a diagnosable reason when choice is an unknown value', async () => {
+    const route = vi.fn(
+      async (): Promise<ElicitationResult> => ({ action: 'accept', content: { choice: 'maybe' } }),
+    );
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, { route });
+    const result = await gate({ ...HIGH_RISK });
+    expect(result.decision).toBe('block');
+    expect(result.reason).toContain('unrecognised choice');
+    expect(result.reason).not.toContain('the operator denied it');
+  });
+
+  it('CANCEL: blocks with the cancel reason when operator cancels the prompt', async () => {
+    const route = vi.fn(
+      async (): Promise<ElicitationResult> => ({ action: 'cancel' }),
+    );
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, { route });
+    const result = await gate({ ...HIGH_RISK });
+    expect(result.decision).toBe('block');
+    expect(result.reason).toContain('the operator cancelled');
+  });
+
+  // Finding 3: emit a structured audit trace on every approval decision
+  describe('trace emission', () => {
+    function fakeWriter(): { writer: TraceWriter; calls: ReturnType<typeof vi.fn> } {
+      const write = vi.fn().mockResolvedValue(undefined);
+      return { writer: { write } as unknown as TraceWriter, calls: write };
+    }
+
+    it('emits hook_decision with approvalOutcome:approved on an approve', async () => {
+      const { writer, calls } = fakeWriter();
+      const route = vi.fn(
+        async (): Promise<ElicitationResult> => ({ action: 'accept', content: { choice: 'approve' } }),
+      );
+      const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
+        route,
+        traceWriter: writer,
+      });
+      const result = await gate({ ...HIGH_RISK });
+      expect(result.decision).toBeUndefined(); // allowed
+      expect(calls).toHaveBeenCalledTimes(1);
+      const [event] = calls.mock.calls[0] as [{ kind: string; payload: Record<string, unknown> }];
+      expect(event.kind).toBe('hook_decision');
+      expect(event.payload['approvalOutcome']).toBe('approved');
+      expect(typeof event.payload['durationMs']).toBe('number');
+    });
+
+    it('emits hook_decision with approvalOutcome:denied on a deny', async () => {
+      const { writer, calls } = fakeWriter();
+      const route = vi.fn(
+        async (): Promise<ElicitationResult> => ({ action: 'accept', content: { choice: 'deny' } }),
+      );
+      const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
+        route,
+        traceWriter: writer,
+      });
+      const result = await gate({ ...HIGH_RISK });
+      expect(result.decision).toBe('block');
+      expect(calls).toHaveBeenCalledTimes(1);
+      const [event] = calls.mock.calls[0] as [{ kind: string; payload: Record<string, unknown> }];
+      expect(event.payload['approvalOutcome']).toBe('denied');
+      expect(typeof event.payload['durationMs']).toBe('number');
+    });
+
+    it('emits hook_decision with approvalOutcome:timeout on a timeout', async () => {
+      const { writer, calls } = fakeWriter();
+      const route = vi.fn(
+        (_req: unknown, opts: { signal: AbortSignal; onActive?: () => void }) => {
+          // Arm the timer so it can fire
+          opts.onActive?.();
+          return new Promise<ElicitationResult>(() => { /* never */ });
+        },
+      );
+      const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
+        route,
+        approvalTimeoutMs: 30,
+        traceWriter: writer,
+      });
+      const result = await gate({ ...HIGH_RISK });
+      expect(result.decision).toBe('block');
+      expect(calls).toHaveBeenCalledTimes(1);
+      const [event] = calls.mock.calls[0] as [{ kind: string; payload: Record<string, unknown> }];
+      expect(event.payload['approvalOutcome']).toBe('timeout');
+    });
+
+    it('emits hook_decision with approvalOutcome:unrecognised for a garbled choice', async () => {
+      const { writer, calls } = fakeWriter();
+      const route = vi.fn(
+        async (): Promise<ElicitationResult> => ({ action: 'accept', content: {} }),
+      );
+      const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
+        route,
+        traceWriter: writer,
+      });
+      await gate({ ...HIGH_RISK });
+      const [event] = calls.mock.calls[0] as [{ kind: string; payload: Record<string, unknown> }];
+      expect(event.payload['approvalOutcome']).toBe('unrecognised');
+    });
+  });
+
+  // Finding 2: deny-on-timeout timer starts only after onActive fires
+  describe('onActive gates the timer', () => {
+    it('timeout does NOT fire when onActive is never called (route declines without calling it)', async () => {
+      // A route that immediately declines without calling onActive — timer must
+      // not arm, so even with a tiny approvalTimeoutMs the test does not stall.
+      const route = vi.fn(
+        async (): Promise<ElicitationResult> => ({ action: 'decline' }),
+      );
+      const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
+        route,
+        approvalTimeoutMs: 20,
+      });
+      const result = await gate({ ...HIGH_RISK });
+      // Declines without calling onActive → timer never arms → route result wins
+      expect(result.decision).toBe('block');
+      expect(result.reason).toContain('no operator approval was available');
+    });
+
+    it('timeout fires only after onActive is invoked', async () => {
+      // A route that calls onActive then never resolves → timeout should fire.
+      const route = vi.fn(
+        (_req: unknown, opts: { signal: AbortSignal; onActive?: () => void }) => {
+          opts.onActive?.();
+          return new Promise<ElicitationResult>(() => { /* never */ });
+        },
+      );
+      const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
+        route,
+        approvalTimeoutMs: 30,
+      });
+      const result = await gate({ ...HIGH_RISK });
+      expect(result.decision).toBe('block');
+      expect(result.reason).toMatch(/within/i);
+    });
+
+    it('approve after onActive fires is still allowed (end-to-end)', async () => {
+      const route = vi.fn(
+        async (_req: unknown, opts: { signal: AbortSignal; onActive?: () => void }): Promise<ElicitationResult> => {
+          opts.onActive?.();
+          return { action: 'accept', content: { choice: 'approve' } };
+        },
+      );
+      const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
+        route,
+        approvalTimeoutMs: 5_000,
+      });
+      const result = await gate({ ...HIGH_RISK });
+      expect(result.decision).toBeUndefined(); // allowed
+    });
   });
 });

--- a/src/agent/afk-mode-gate.test.ts
+++ b/src/agent/afk-mode-gate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createAfkModeGate } from './afk-mode-gate.js';
-import type { PermissionMode, ElicitationResult } from './types/sdk-types.js';
+import type { PermissionMode, ElicitationResult, ElicitationRequest } from './types/sdk-types.js';
 import type { TraceWriter } from './trace/index.js';
 
 describe('createAfkModeGate', () => {
@@ -281,6 +281,27 @@ describe('createAfkModeGate — high-risk approval round-trip (v1.5)', () => {
     expect(seenSignal).toBeDefined();
     expect(seenSignal!.aborted).toBe(true);
     expect(result.decision).toBe('block');
+  });
+
+  // SEC-1 (review): the tool-input preview embedded in the phone approval
+  // prompt must not leak secrets. Mirrors the redaction the AFK push path
+  // applies (cli/commands/interactive/afk-push.ts).
+  it('redacts secrets from the approval-prompt input preview before it reaches the operator', async () => {
+    let seenReq: ElicitationRequest | undefined;
+    const route = vi.fn(async (req: ElicitationRequest): Promise<ElicitationResult> => {
+      seenReq = req;
+      return { action: 'accept', content: { choice: 'deny' } };
+    });
+    const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, { route });
+    const secret = 'wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY';
+    await gate({
+      event: 'PreToolUse',
+      toolName: 'bash',
+      input: { command: `AWS_SECRET_ACCESS_KEY=${secret} terraform apply` },
+    });
+    expect(seenReq).toBeDefined();
+    expect(seenReq!.message).not.toContain(secret);
+    expect(seenReq!.message).toContain('REDACTED');
   });
 
   // Finding 1: distinguish malformed `accept` from a real deny

--- a/src/agent/afk-mode-gate.ts
+++ b/src/agent/afk-mode-gate.ts
@@ -1,7 +1,7 @@
 /**
  * AFK-mode gate hook factory.
  *
- * Returns a `HookHandler` that blocks high-risk / irreversible tool calls when
+ * Returns a `HookHandler` that governs high-risk / irreversible tool calls when
  * the session is in `'autonomous'` (AFK) mode. The handler reads the current
  * mode at call time (not at construction time), so toggling the mode
  * mid-session is reflected immediately without reconstructing the registry.
@@ -10,12 +10,13 @@
  * when no human is watching. The posture addendum
  * ({@link module:agent/providers/anthropic-direct/afk-mode-addendum}) asks the
  * model to stop at one-way doors, but posture text is not a safety mechanism.
- * This gate is the enforcement half — it refuses the irreversible/destructive
+ * This gate is the enforcement half — it governs the irreversible/destructive
  * operations that must never run unattended on a model's say-so.
  *
  * Policy: the single source of truth for "how dangerous is this op" is
  * {@link classifyRisk} (`risk-classifier.ts`) — the same taxonomy the status
- * line and audit log use. AFK mode blocks anything it rates `'high'`:
+ * line and audit log use. AFK mode treats anything it rates `'high'` as
+ * requiring explicit operator approval:
  *   - destructive/irreversible bash (`rm`, `sudo`, `git push --force`,
  *     `git reset --hard`, `mkfs`/`dd`/`diskutil`, pipe-to-shell, `eval`,
  *     `chmod`/`chown`)
@@ -25,50 +26,162 @@
  * and `'safe'` ops (reads, tests, lint) are ALLOWED — autonomous work has to be
  * useful, and these are reversible enough to run unattended.
  *
+ * High-risk handling (v1.5 — approve/deny round-trip):
+ *   - MAIN session: instead of a hard block, route an approve/deny prompt to
+ *     the operator via the module-scope {@link elicitationRouter}. In AFK mode
+ *     that router is swapped to the ledger channel (`/afk on`), so the prompt
+ *     renders on the operator's phone (racing the keyboard) and the signed
+ *     answer round-trips back. Approve → the op runs (this single call); deny,
+ *     decline, cancel, or no answer within the timeout → blocked. This reuses
+ *     the proven elicitation hop and adds NO new ledger record. Because the
+ *     wait blocks on a human, the gate is registered `longRunning: true` and
+ *     forwards the turn signal so session/turn teardown cancels the prompt.
+ *   - DENY-ON-TIMEOUT: the elicitation router has no deadline by design (an AFK
+ *     operator may be away). For a *high-risk approval* we impose one anyway —
+ *     an unanswered destructive op degrades to the safe default (refused),
+ *     never silently runs and never stalls the run forever.
+ *   - SUBAGENTS: a forked sub-agent (`parentSessionId` set) never prompts — the
+ *     prompt would surface on the parent's surface with no attribution. It hard-
+ *     blocks, mirroring the path-approval hook's sub-agent auto-deny. The safety
+ *     ceiling still applies tree-wide; only the *approval affordance* is main-
+ *     session-only.
+ *   - NO OPERATOR REACHABLE: when no elicitation handler is installed (headless
+ *     surfaces, or AFK off), `route()` declines immediately → blocked. This is
+ *     the legacy hard-block behavior, preserved as the safe degrade.
+ *
  * Path-safety note: in `'autonomous'` mode the typed-file path-approval prompt
  * is disabled (`allowAll`, see `agent/permission-policy.ts`) so AFK does not
  * stall on keyboard prompts the operator cannot answer. That makes THIS gate
  * the sole path-containment layer in AFK — its workspace-escape rule (a
  * `write_file`/`edit_file` whose path resolves outside the session root →
- * `high` → blocked) is load-bearing, which is why the gate is wired with a
- * live `getCwd` (so a mid-session `/cwd` change cannot stale the boundary).
+ * `high` → approval-gated) is load-bearing, which is why the gate is wired with
+ * a live `getCwd` (so a mid-session `/cwd` change cannot stale the boundary).
  *
  * `send_telegram` is ALWAYS exempt: it is the operator's channel in AFK mode,
  * and the posture explicitly relies on it to surface Asking states.
  *
- * Deliberate divergence from the plan-mode gate: this gate does NOT skip
- * forked subagents (`context.parentSessionId`). Plan mode is a main-session
- * conversation affordance, so its gate exempts subagents. AFK mode is a SAFETY
- * ceiling — an unwatched subagent running `rm -rf` is exactly the risk the gate
- * exists to stop — so the ceiling applies tree-wide. Medium ops (e.g. a skill's
- * worktree commit) stay allowed, so this does not break skill flows; only
- * high-risk ops are refused, in the parent and in every child alike.
- *
  * Like the plan-mode gate, the bash classification is a best-effort honesty
  * guardrail, not a sandbox: bash is Turing-complete, so obfuscated writes can
  * slip through. It catches the destructive shapes a cooperative model naturally
- * emits and surfaces refusal so the operator can take over.
+ * emits and surfaces refusal/approval so the operator can take over.
  *
  * @module agent/afk-mode-gate
  */
 
-import type { HookContext, HookDecision } from './hooks.js';
+import type { HookContext, HookDecision, HookHandler } from './hooks.js';
 import type { PermissionMode } from './types/sdk-types.js';
+import type { ElicitationRequest, ElicitationResult } from './types/sdk-types.js';
 import { classifyRisk } from './risk-classifier.js';
+import { elicitationRouter } from './elicitation-router.js';
+
+/** Default deny-on-timeout window for a high-risk approval (ms). */
+const DEFAULT_APPROVAL_TIMEOUT_MS = 300_000;
+/** Cap the tool-input preview shown to the operator in the approval prompt. */
+const MAX_INPUT_PREVIEW = 300;
+
+export interface AfkModeGateOptions {
+  /**
+   * Max time to wait for an operator approve/deny before denying (deny-on-
+   * timeout). Defaults to {@link DEFAULT_APPROVAL_TIMEOUT_MS}.
+   */
+  approvalTimeoutMs?: number;
+  /**
+   * When false, high-risk ops hard-block immediately (legacy behaviour) instead
+   * of eliciting approval. Defaults to true.
+   */
+  promptForApproval?: boolean;
+  /**
+   * Elicitation entry point. Defaults to the module-scope
+   * {@link elicitationRouter}. Injectable for tests.
+   */
+  route?: (
+    request: ElicitationRequest,
+    options: { signal: AbortSignal },
+  ) => Promise<ElicitationResult>;
+}
 
 export function createAfkModeGate(
   getMode: () => PermissionMode,
   cwd?: string,
   getCwd?: () => string | undefined,
-): (context: HookContext) => HookDecision {
-  return function afkModeGate(context: HookContext): HookDecision {
+  opts?: AfkModeGateOptions,
+): HookHandler {
+  const approvalTimeoutMs = opts?.approvalTimeoutMs ?? DEFAULT_APPROVAL_TIMEOUT_MS;
+  const promptForApproval = opts?.promptForApproval ?? true;
+  const route =
+    opts?.route ??
+    ((request: ElicitationRequest, options: { signal: AbortSignal }) =>
+      elicitationRouter.route(request, options));
+
+  async function requestApproval(
+    toolName: string,
+    input: unknown,
+    signal?: AbortSignal,
+  ): Promise<HookDecision> {
+    const request = buildApprovalRequest(toolName, input);
+
+    // A child controller so a deny-on-timeout (or a parent turn abort) cancels
+    // the pending elicitation prompt — the real router resolves to a decline on
+    // abort, so the phone prompt does not linger past the decision.
+    const ac = new AbortController();
+    const onParentAbort = (): void => ac.abort();
+    if (signal) {
+      if (signal.aborted) ac.abort();
+      else signal.addEventListener('abort', onParentAbort, { once: true });
+    }
+
+    const TIMEOUT = Symbol('afk-approval-timeout');
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeoutP = new Promise<typeof TIMEOUT>((resolve) => {
+      timer = setTimeout(() => {
+        ac.abort();
+        resolve(TIMEOUT);
+      }, approvalTimeoutMs);
+      timer.unref?.();
+    });
+
+    let outcome: ElicitationResult | typeof TIMEOUT;
+    try {
+      // Race the operator's answer against the deny-on-timeout. Racing (rather
+      // than relying on the handler to observe the abort) guarantees progress
+      // even for a handler that ignores its signal.
+      outcome = await Promise.race([route(request, { signal: ac.signal }), timeoutP]);
+    } finally {
+      if (timer) clearTimeout(timer);
+      if (signal) signal.removeEventListener('abort', onParentAbort);
+    }
+
+    if (outcome === TIMEOUT) {
+      return blockDecision(
+        toolName,
+        `no approval arrived within ${Math.round(approvalTimeoutMs / 1000)}s`,
+      );
+    }
+    if (outcome.action !== 'accept') {
+      return blockDecision(
+        toolName,
+        outcome.action === 'cancel'
+          ? 'the operator cancelled the approval prompt'
+          : 'no operator approval was available',
+      );
+    }
+    const choice = String(outcome.content?.['choice'] ?? '').toLowerCase();
+    if (choice === 'approve') return {}; // operator approved this single call
+    return blockDecision(toolName, 'the operator denied it');
+  }
+
+  return function afkModeGate(
+    context: HookContext,
+    signal?: AbortSignal,
+  ): HookDecision | Promise<HookDecision> {
     if (context.event !== 'PreToolUse') return {};
-    // No subagent guard, on purpose: the safety ceiling applies tree-wide.
+    // No subagent guard on the ceiling itself, on purpose: the safety ceiling
+    // applies tree-wide. (The approval *affordance* below is main-session-only.)
     if (getMode() !== 'autonomous') return {};
 
     const { toolName } = context;
 
-    // The operator's channel is never blocked — the posture relies on it to
+    // The operator's channel is never gated — the posture relies on it to
     // surface Asking states from an unattended run.
     if (toolName === 'send_telegram') return {};
 
@@ -84,17 +197,71 @@ export function createAfkModeGate(
       workspaceRoot: root,
     });
 
-    if (risk === 'high') {
-      return {
-        decision: 'block',
-        reason:
-          `AFK mode: ${toolName} is refused — this op is high-risk or ` +
-          `irreversible, and AFK mode runs autonomously without a human ` +
-          `watching. Push an Asking summary to Telegram (send_telegram) and ` +
-          `stop, or have the operator run /afk off and take over.`,
-      };
+    if (risk !== 'high') return {};
+
+    // High-risk in AFK. A forked sub-agent must not prompt the operator (the
+    // prompt would surface on the parent's surface with no attribution), and the
+    // approval path can be opted out — both degrade to the legacy hard block.
+    if (context.parentSessionId !== undefined || !promptForApproval) {
+      return blockDecision(toolName, 'AFK mode runs autonomously without a human watching');
     }
 
-    return {};
+    // Main session: ask the operator to approve/deny (deny-on-timeout). Returns
+    // a Promise<HookDecision>; the gate is registered `longRunning: true`.
+    return requestApproval(toolName, context.input, signal);
+  };
+}
+
+/** Build the approve/deny form elicitation (same shape the path-approval hook
+ *  uses, so it renders via the proven REPL numbered-prompt / Telegram inline-
+ *  keyboard path). */
+function buildApprovalRequest(toolName: string, input: unknown): ElicitationRequest {
+  const preview = clipInput(input);
+  const message =
+    `AFK: \`${toolName}\` is high-risk / irreversible and AFK mode runs ` +
+    `unattended. Approve this single call?` +
+    (preview ? `\n\nInput: ${preview}` : '');
+  return {
+    serverName: 'agent-afk',
+    message,
+    mode: 'form',
+    title: 'AFK high-risk approval',
+    requestedSchema: {
+      type: 'object',
+      properties: {
+        choice: {
+          type: 'string',
+          title: 'Approve this high-risk operation?',
+          enum: ['approve', 'deny'],
+          description:
+            "'approve' runs this single call. 'deny' refuses it (the model " +
+            'gets an error and should push an Asking summary or take a safe path).',
+        },
+      },
+      required: ['choice'],
+    },
+  };
+}
+
+/** Compact, bounded preview of a tool input for the approval prompt. */
+function clipInput(input: unknown): string {
+  let s: string;
+  try {
+    s = typeof input === 'string' ? input : JSON.stringify(input);
+  } catch {
+    s = String(input);
+  }
+  if (!s) return '';
+  return s.length > MAX_INPUT_PREVIEW ? `${s.slice(0, MAX_INPUT_PREVIEW)}… [truncated]` : s;
+}
+
+/** The refusal decision surfaced to the model, with a cause-specific tail. */
+function blockDecision(toolName: string, why: string): HookDecision {
+  return {
+    decision: 'block',
+    reason:
+      `AFK mode: ${toolName} is refused — this op is high-risk or irreversible, ` +
+      `and ${why}. Push an Asking summary to Telegram (send_telegram) and stop, ` +
+      `or have the operator run /afk off and take over.`,
   };
 }

--- a/src/agent/afk-mode-gate.ts
+++ b/src/agent/afk-mode-gate.ts
@@ -78,6 +78,7 @@ import type { TraceWriter } from './trace/index.js';
 import { classifyRisk } from './risk-classifier.js';
 import { elicitationRouter } from './elicitation-router.js';
 import { emitHookDecision } from './trace/emit.js';
+import { redactInlineSecrets } from './session/prompt-dump.js';
 
 /** Default deny-on-timeout window for a high-risk approval (ms). */
 const DEFAULT_APPROVAL_TIMEOUT_MS = 300_000;
@@ -300,7 +301,14 @@ function buildApprovalRequest(toolName: string, input: unknown): ElicitationRequ
   };
 }
 
-/** Compact, bounded preview of a tool input for the approval prompt. */
+/**
+ * Compact, bounded, secret-redacted preview of a tool input for the approval
+ * prompt. Secrets are scrubbed via {@link redactInlineSecrets} BEFORE truncation
+ * so a credential straddling the {@link MAX_INPUT_PREVIEW} boundary cannot leak a
+ * partial value. This preview renders on the operator's phone in AFK mode, so it
+ * gets the same redaction the AFK push path applies (see
+ * cli/commands/interactive/afk-push.ts).
+ */
 function clipInput(input: unknown): string {
   let s: string;
   try {
@@ -309,6 +317,9 @@ function clipInput(input: unknown): string {
     s = String(input);
   }
   if (!s) return '';
+  // Redact secrets before any truncation — a credential split across the
+  // MAX_INPUT_PREVIEW boundary must not leak a partial value to the phone.
+  s = redactInlineSecrets(s);
   return s.length > MAX_INPUT_PREVIEW ? `${s.slice(0, MAX_INPUT_PREVIEW)}… [truncated]` : s;
 }
 

--- a/src/agent/afk-mode-gate.ts
+++ b/src/agent/afk-mode-gate.ts
@@ -39,7 +39,10 @@
  *   - DENY-ON-TIMEOUT: the elicitation router has no deadline by design (an AFK
  *     operator may be away). For a *high-risk approval* we impose one anyway —
  *     an unanswered destructive op degrades to the safe default (refused),
- *     never silently runs and never stalls the run forever.
+ *     never silently runs and never stalls the run forever. The timer is armed
+ *     by the `onActive` callback so it starts only once this request leaves the
+ *     elicitation queue and is actually shown to the operator — a prior queued
+ *     prompt's open time is never charged against this op's window.
  *   - SUBAGENTS: a forked sub-agent (`parentSessionId` set) never prompts — the
  *     prompt would surface on the parent's surface with no attribution. It hard-
  *     blocks, mirroring the path-approval hook's sub-agent auto-deny. The safety
@@ -71,8 +74,10 @@
 import type { HookContext, HookDecision, HookHandler } from './hooks.js';
 import type { PermissionMode } from './types/sdk-types.js';
 import type { ElicitationRequest, ElicitationResult } from './types/sdk-types.js';
+import type { TraceWriter } from './trace/index.js';
 import { classifyRisk } from './risk-classifier.js';
 import { elicitationRouter } from './elicitation-router.js';
+import { emitHookDecision } from './trace/emit.js';
 
 /** Default deny-on-timeout window for a high-risk approval (ms). */
 const DEFAULT_APPROVAL_TIMEOUT_MS = 300_000;
@@ -96,8 +101,14 @@ export interface AfkModeGateOptions {
    */
   route?: (
     request: ElicitationRequest,
-    options: { signal: AbortSignal },
+    options: { signal: AbortSignal; onActive?: () => void },
   ) => Promise<ElicitationResult>;
+  /**
+   * Trace writer for structured audit events. When provided, the gate emits a
+   * `hook_decision` event on every approval decision (approve, deny, timeout,
+   * cancel, decline, or unrecognised choice). No-op when undefined.
+   */
+  traceWriter?: TraceWriter;
 }
 
 export function createAfkModeGate(
@@ -108,9 +119,10 @@ export function createAfkModeGate(
 ): HookHandler {
   const approvalTimeoutMs = opts?.approvalTimeoutMs ?? DEFAULT_APPROVAL_TIMEOUT_MS;
   const promptForApproval = opts?.promptForApproval ?? true;
+  const traceWriter = opts?.traceWriter;
   const route =
     opts?.route ??
-    ((request: ElicitationRequest, options: { signal: AbortSignal }) =>
+    ((request: ElicitationRequest, options: { signal: AbortSignal; onActive?: () => void }) =>
       elicitationRouter.route(request, options));
 
   async function requestApproval(
@@ -118,6 +130,7 @@ export function createAfkModeGate(
     input: unknown,
     signal?: AbortSignal,
   ): Promise<HookDecision> {
+    const start = Date.now();
     const request = buildApprovalRequest(toolName, input);
 
     // A child controller so a deny-on-timeout (or a parent turn abort) cancels
@@ -132,42 +145,86 @@ export function createAfkModeGate(
 
     const TIMEOUT = Symbol('afk-approval-timeout');
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let armTimer!: () => void;
+    // Contract: timeoutP resolves only after armTimer() is called (i.e. once
+    // this request leaves the elicitation queue and is shown to the operator).
+    // If onActive never fires (no handler / pre-aborted / aborted-in-queue),
+    // the timer is never armed and timeoutP never resolves — that's correct,
+    // because route() resolves DECLINE and wins the race. This ensures a prior
+    // queued prompt's open time is never charged against this op's window.
     const timeoutP = new Promise<typeof TIMEOUT>((resolve) => {
-      timer = setTimeout(() => {
-        ac.abort();
-        resolve(TIMEOUT);
-      }, approvalTimeoutMs);
-      timer.unref?.();
+      armTimer = () => {
+        if (timer) return; // idempotent
+        // Start the deny-on-timeout window only once this request leaves the
+        // elicitation queue and is shown to the operator, so a prior queued
+        // prompt's open time is not charged against this op's window.
+        timer = setTimeout(() => {
+          ac.abort();
+          resolve(TIMEOUT);
+        }, approvalTimeoutMs);
+        timer.unref?.();
+      };
     });
+
+    // Helper to emit the structured audit trace and return the hook decision.
+    // Called on every exit path from requestApproval — centralises the emit so
+    // no path accidentally skips it, and keeps the mapping explicit.
+    function decide(
+      decision: HookDecision,
+      approvalOutcome: 'approved' | 'denied' | 'unrecognised' | 'timeout' | 'decline' | 'cancel',
+    ): HookDecision {
+      const durationMs = Date.now() - start;
+      const isBlock = decision.decision === 'block';
+      void emitHookDecision(traceWriter, {
+        hookEvent: 'PreToolUse',
+        ...(isBlock ? { decision: 'block' as const } : {}),
+        ...(isBlock && decision.reason !== undefined ? { reason: decision.reason } : {}),
+        ...(isBlock ? { blockedTool: toolName } : {}),
+        durationMs,
+        approvalOutcome,
+      });
+      return decision;
+    }
 
     let outcome: ElicitationResult | typeof TIMEOUT;
     try {
       // Race the operator's answer against the deny-on-timeout. Racing (rather
       // than relying on the handler to observe the abort) guarantees progress
-      // even for a handler that ignores its signal.
-      outcome = await Promise.race([route(request, { signal: ac.signal }), timeoutP]);
+      // even for a handler that ignores its signal. The timer is armed via
+      // onActive so it starts only when the prompt is actually shown.
+      outcome = await Promise.race([route(request, { signal: ac.signal, onActive: armTimer }), timeoutP]);
     } finally {
       if (timer) clearTimeout(timer);
       if (signal) signal.removeEventListener('abort', onParentAbort);
     }
 
     if (outcome === TIMEOUT) {
-      return blockDecision(
-        toolName,
-        `no approval arrived within ${Math.round(approvalTimeoutMs / 1000)}s`,
+      return decide(
+        blockDecision(toolName, `no approval arrived within ${Math.round(approvalTimeoutMs / 1000)}s`),
+        'timeout',
       );
     }
     if (outcome.action !== 'accept') {
-      return blockDecision(
-        toolName,
-        outcome.action === 'cancel'
-          ? 'the operator cancelled the approval prompt'
-          : 'no operator approval was available',
+      return decide(
+        blockDecision(
+          toolName,
+          outcome.action === 'cancel'
+            ? 'the operator cancelled the approval prompt'
+            : 'no operator approval was available',
+        ),
+        outcome.action === 'cancel' ? 'cancel' : 'decline',
       );
     }
     const choice = String(outcome.content?.['choice'] ?? '').toLowerCase();
-    if (choice === 'approve') return {}; // operator approved this single call
-    return blockDecision(toolName, 'the operator denied it');
+    if (choice === 'approve') return decide({}, 'approved'); // operator approved this single call
+    if (choice === 'deny') return decide(blockDecision(toolName, 'the operator denied it'), 'denied');
+    // action was 'accept' but choice ∉ {approve,deny} — a handler regression
+    // (dropped/garbled choice), not a deliberate deny. Fail closed with a distinct,
+    // diagnosable reason instead of masquerading as a deny.
+    return decide(
+      blockDecision(toolName, 'the approval prompt returned an unrecognised choice'),
+      'unrecognised',
+    );
   }
 
   return function afkModeGate(

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -482,22 +482,23 @@ export class CronScheduler {
     // non-empty AFK_SESSION_ID and traces stay greppable by task name.
     const sessionId = daemonTraceLabel(taskId);
     const agentCwd = this.options.sessionConfig?.cwd ?? process.cwd();
-    const { registry, memoryStore } = createDefaultHookRegistry(
-      undefined,
-      'daemon',
-      undefined,
-      undefined,
-      loadHooksConfig({ cwd: agentCwd }),
-      { cwd: agentCwd, sessionId },
-    );
     // Witness layer: open a fresh trace per spawned daemon session so its
     // subagent + skill lifecycle events are durable on disk — the AFK
     // (away-from-keyboard) surface where post-hoc inspection matters most.
     // Mirrors chat.ts / interactive bootstrap.ts. Returns null under
     // AFK_TRACE_DISABLED=1. The label is derived from the taskId (see
     // daemonTraceLabel) so traces are greppable by task name while each tick
-    // still gets its own trace dir.
+    // still gets its own trace dir. Created before the hook registry so the
+    // AFK gate's structured audit trace is wired from the start of the session.
     const trace = createDefaultTraceWriter({ sessionLabel: daemonTraceLabel(taskId) });
+    const { registry, memoryStore } = createDefaultHookRegistry(
+      undefined,
+      'daemon',
+      undefined,
+      undefined,
+      loadHooksConfig({ cwd: agentCwd }),
+      { cwd: agentCwd, sessionId, ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}) },
+    );
 
     let mcpManager: McpManager | undefined;
     // Mirror the chat / telegram / interactive surfaces: include MCP configs

--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -98,6 +98,11 @@ export function createDefaultHookRegistry(
       // the SOLE path-safety layer in AFK (the path-approval prompt is disabled
       // via allowAll for 'autonomous'; see agent/permission-policy.ts).
       createAfkModeGate(getPermissionMode, agentOptions?.cwd, getCwd),
+      // Longrunning: on a high-risk op the gate awaits an operator approve/deny
+      // via elicitationRouter.route() (deny-on-timeout). Bypass the 30s per-
+      // handler deadline; the gate forwards the turn signal so session/turn
+      // teardown cancels the pending prompt. Mirrors the path-approval hook.
+      { longRunning: true },
     );
   }
 

--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -21,6 +21,7 @@ import {
 import { createBashRestrictionHook } from './tools/hooks/bash-restriction-hook.js';
 import type { GrantManager } from '../cli/slash/commands/allow-dir.js';
 import type { PermissionMode } from './types/sdk-types.js';
+import type { TraceWriter } from './trace/index.js';
 import type { LoadedHooksConfig } from './hooks/config-loader.js';
 import { loadAndRegisterConfigHooks } from './hooks/config-bridge.js';
 
@@ -79,7 +80,7 @@ export function createDefaultHookRegistry(
   memoryStore?: MemoryStore,
   getPermissionMode?: () => PermissionMode,
   hookConfig?: LoadedHooksConfig,
-  agentOptions?: { cwd?: string; sessionId?: string },
+  agentOptions?: { cwd?: string; sessionId?: string; traceWriter?: TraceWriter },
   getCwd?: () => string | undefined,
 ): DefaultHookRegistryResult {
   const registry = createHookRegistry();
@@ -97,7 +98,9 @@ export function createDefaultHookRegistry(
       // gate's workspace-escape rule tracks a mid-session /cwd change — it is
       // the SOLE path-safety layer in AFK (the path-approval prompt is disabled
       // via allowAll for 'autonomous'; see agent/permission-policy.ts).
-      createAfkModeGate(getPermissionMode, agentOptions?.cwd, getCwd),
+      createAfkModeGate(getPermissionMode, agentOptions?.cwd, getCwd, {
+        ...(agentOptions?.traceWriter !== undefined ? { traceWriter: agentOptions.traceWriter } : {}),
+      }),
       // Longrunning: on a high-risk op the gate awaits an operator approve/deny
       // via elicitationRouter.route() (deny-on-timeout). Bypass the 30s per-
       // handler deadline; the gate forwards the turn signal so session/turn

--- a/src/agent/elicitation-router.test.ts
+++ b/src/agent/elicitation-router.test.ts
@@ -124,6 +124,63 @@ describe('elicitationRouter', () => {
     expect(result.action).toBe('decline');
   });
 
+  describe('onActive callback', () => {
+    it('fires exactly once for a served request, immediately before the handler', async () => {
+      const order: string[] = [];
+      elicitationRouter.install(async () => {
+        order.push('handler');
+        return { action: 'accept' };
+      });
+      const onActive = vi.fn(() => { order.push('onActive'); });
+      await elicitationRouter.route(URL_REQUEST, { signal: NO_SIGNAL, onActive });
+      expect(onActive).toHaveBeenCalledTimes(1);
+      expect(order).toEqual(['onActive', 'handler']);
+    });
+
+    it('is NOT called when the signal is pre-aborted (fast-path decline)', async () => {
+      elicitationRouter.install(vi.fn().mockResolvedValue({ action: 'accept' } as ElicitationResult));
+      const controller = new AbortController();
+      controller.abort();
+      const onActive = vi.fn();
+      await elicitationRouter.route(URL_REQUEST, { signal: controller.signal, onActive });
+      expect(onActive).not.toHaveBeenCalled();
+    });
+
+    it('is NOT called when the signal is aborted while waiting in queue', async () => {
+      let resolveBlock!: () => void;
+      const block = new Promise<void>((res) => { resolveBlock = res; });
+      elicitationRouter.install(async () => {
+        await block;
+        return { action: 'accept' };
+      });
+      const controller = new AbortController();
+      const p1 = elicitationRouter.route(URL_REQUEST, { signal: NO_SIGNAL });
+      const onActive2 = vi.fn();
+      const p2 = elicitationRouter.route(URL_REQUEST, { signal: controller.signal, onActive: onActive2 });
+      controller.abort();
+      resolveBlock();
+      await p1;
+      await p2;
+      expect(onActive2).not.toHaveBeenCalled();
+    });
+
+    it('is NOT called when no handler is installed', async () => {
+      // No install() — no handler
+      const onActive = vi.fn();
+      const result = await elicitationRouter.route(URL_REQUEST, { signal: NO_SIGNAL, onActive });
+      expect(result.action).toBe('decline');
+      expect(onActive).not.toHaveBeenCalled();
+    });
+
+    it('a throwing onActive does not break the queue or the result', async () => {
+      elicitationRouter.install(async () => ({ action: 'accept' } as ElicitationResult));
+      const onActive = vi.fn(() => { throw new Error('boom from onActive'); });
+      const result = await elicitationRouter.route(URL_REQUEST, { signal: NO_SIGNAL, onActive });
+      expect(onActive).toHaveBeenCalledTimes(1);
+      expect(result.action).toBe('accept');
+    });
+  });
+
   describe('serial queue', () => {
     it('resolves requests in enqueue order — second never starts before first finishes', async () => {
       const order: number[] = [];

--- a/src/agent/elicitation-router.ts
+++ b/src/agent/elicitation-router.ts
@@ -61,7 +61,7 @@ class ElicitationRouter {
 
   route(
     request: ElicitationRequest,
-    options: { signal: AbortSignal },
+    options: { signal: AbortSignal; onActive?: () => void },
   ): Promise<ElicitationResult> {
     // Fast-path: already aborted before entering the queue
     if (options.signal.aborted) return Promise.resolve(DECLINE);
@@ -105,6 +105,12 @@ class ElicitationRouter {
         });
 
         try {
+          // Contract: onActive fires exactly once, immediately before the handler
+          // is called — only on the path where the operator is actually about to
+          // be prompted (NOT on pre-aborted, aborted-in-queue, or no-handler
+          // DECLINE paths). It is observational only: a throwing callback must
+          // never break the queue or the "must always resolve" invariant.
+          try { options.onActive?.(); } catch { /* observational only */ }
           const result = await Promise.race([
             capturedHandler(request, options).catch(() => DECLINE),
             abortPromise,
@@ -139,7 +145,7 @@ export const elicitationRouter = new ElicitationRouter();
  */
 export async function routeElicitation(
   request: ElicitationRequest,
-  options: { signal: AbortSignal },
+  options: { signal: AbortSignal; onActive?: () => void },
 ): Promise<ElicitationResult> {
   return elicitationRouter.route(request, options);
 }

--- a/src/agent/trace/events.test.ts
+++ b/src/agent/trace/events.test.ts
@@ -150,6 +150,39 @@ describe('hook_decision payload', () => {
     expect(TraceEventSchema.safeParse(onDisk).success).toBe(true);
   });
 
+  it('accepts durationMs and approvalOutcome from the AFK high-risk gate', () => {
+    expect(() =>
+      HookDecisionPayloadSchema.parse({
+        hookEvent: 'PreToolUse',
+        decision: 'block',
+        reason: 'the operator denied it',
+        blockedTool: 'bash',
+        durationMs: 1234,
+        approvalOutcome: 'denied',
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts approvalOutcome:approved with no decision key (pass-through)', () => {
+    expect(() =>
+      HookDecisionPayloadSchema.parse({
+        hookEvent: 'PreToolUse',
+        durationMs: 42,
+        approvalOutcome: 'approved',
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects an unknown approvalOutcome value', () => {
+    expect(() =>
+      HookDecisionPayloadSchema.parse({
+        hookEvent: 'PreToolUse',
+        durationMs: 10,
+        approvalOutcome: 'maybe',
+      }),
+    ).toThrow();
+  });
+
   it('rejects unknown hookEvent', () => {
     expect(() =>
       HookDecisionPayloadSchema.parse({

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -82,6 +82,10 @@ export const HookDecisionPayloadSchema = z.object({
   reason: z.string().optional(),
   blockedTool: z.string().optional(),
   injectedContextBytes: z.number().int().nonnegative().optional(),
+  /** Set only by the AFK high-risk approval gate. Wall-clock ms from gate entry to decision. */
+  durationMs: z.number().nonnegative().optional(),
+  /** Set only by the AFK high-risk approval gate. Fine-grained approval outcome. */
+  approvalOutcome: z.enum(['approved', 'denied', 'unrecognised', 'timeout', 'decline', 'cancel']).optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/trace/index.ts
+++ b/src/agent/trace/index.ts
@@ -12,6 +12,7 @@
  */
 
 export type {
+  AfkApprovalOutcome,
   AbortOrigin,
   AbortPayload,
   BackgroundAgentCancelledPayload,

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -124,6 +124,18 @@ export type HookEventName =
   | 'SubagentStart'
   | 'SubagentStop';
 
+/**
+ * Fine-grained outcome of the AFK high-risk approval gate. Set only by that
+ * gate; absent on all other hook_decision events.
+ */
+export type AfkApprovalOutcome =
+  | 'approved'
+  | 'denied'
+  | 'unrecognised'
+  | 'timeout'
+  | 'decline'
+  | 'cancel';
+
 export interface HookDecisionPayload {
   hookEvent: HookEventName;
   /**
@@ -138,6 +150,10 @@ export interface HookDecisionPayload {
   blockedTool?: string;
   /** Set only when the hook returned `injectContext`. */
   injectedContextBytes?: number;
+  /** Set only by the AFK high-risk approval gate. Wall-clock ms from gate entry to decision. */
+  durationMs?: number;
+  /** Set only by the AFK high-risk approval gate. Fine-grained approval outcome. */
+  approvalOutcome?: AfkApprovalOutcome;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -662,7 +662,7 @@ export function registerChatCommand(program: Command): void {
               : {}),
           hookRegistry: createDefaultHookRegistry((info) => {
             console.log(formatSubagentCompletion(info));
-          }, 'cli', sharedMemoryStore, undefined, loadHooksConfig({ cwd: worktreeCwd }), { cwd: worktreeCwd }).registry,
+          }, 'cli', sharedMemoryStore, undefined, loadHooksConfig({ cwd: worktreeCwd }), { cwd: worktreeCwd, ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}) }).registry,
           ...(systemPrompt !== undefined ? { systemPrompt } : {}),
           ...(systemPromptSource !== undefined ? { systemPromptSource } : {}),
           ...(thinking !== undefined ? { thinking } : {}),

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -564,7 +564,7 @@ export async function bootstrapSession(
     sharedMemoryStore,
     () => stats.permissionMode,
     loadHooksConfig({ cwd: extras?.cwd }),
-    { cwd: extras?.cwd },
+    { cwd: extras?.cwd, ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}) },
     () => extras?.cwd ?? process.cwd(),
   );
   const hookRegistry = hookRegistryBundle.registry;

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -380,7 +380,7 @@ async function main() {
           sharedMemoryStore,
           undefined,
           loadHooksConfig(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
-          { cwd: sessionCwd !== undefined && sessionCwd.length > 0 ? sessionCwd : undefined },
+          { cwd: sessionCwd !== undefined && sessionCwd.length > 0 ? sessionCwd : undefined, ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}) },
           () => sessionCwd,
         );
         const session = attachMcpCleanup(constructTelegramSession({
@@ -438,7 +438,7 @@ async function main() {
         sharedMemoryStore,
         undefined,
         loadHooksConfig(codexSessionCwd !== undefined && codexSessionCwd.length > 0 ? { cwd: codexSessionCwd } : {}),
-        { cwd: codexSessionCwd !== undefined && codexSessionCwd.length > 0 ? codexSessionCwd : undefined },
+        { cwd: codexSessionCwd !== undefined && codexSessionCwd.length > 0 ? codexSessionCwd : undefined, ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}) },
         () => codexSessionCwd,
       );
       const session = attachMcpCleanup(constructTelegramSession({

--- a/src/telegram/afk-two-way-roundtrip.test.ts
+++ b/src/telegram/afk-two-way-roundtrip.test.ts
@@ -1,0 +1,156 @@
+/**
+ * End-to-end seam test for two-way AFK comms.
+ *
+ * The component tests cover each end of the cross-process hop in isolation:
+ *   - `afk-ledger-channel.test.ts` exercises the REPL side (resolves on a
+ *     verified response, ignores forged ones, abort-watcher matrix);
+ *   - `watch.test.ts` exercises the daemon side (`_run` intercepts an
+ *     elicitation, renders it, and writes back a HMAC-signed response).
+ * Both ends meet at the `afk-channel.ts` canonical signing form — but no single
+ * test wires the REAL daemon `SessionWatchManager._run` to the REAL REPL
+ * `makeLedgerChannelHandler`/`makeAbortWatcher` over one shared ledger + key.
+ * This file closes that seam: it proves the full round-trip settles, end to end,
+ * with production components on both sides and nothing hand-signed in between.
+ *
+ * Temp AFK_HOME set before import so no real ~/.afk/state is touched (the ledger
+ * path is derived from AFK_HOME at import time).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-twoway-e2e-'));
+process.env['AFK_HOME'] = tmpDir;
+
+import { SessionWatchManager } from './watch.js';
+import { makeLedgerChannelHandler, makeAbortWatcher } from '../agent/afk-ledger-channel.js';
+import { SessionLedgerWriter } from '../agent/session-ledger.js';
+import { ensureSessionKey, signAbortRequest, freshChannelId } from '../agent/afk-channel.js';
+import type { ElicitationRequest, ElicitationResult } from '../agent/types/sdk-types.js';
+import type { MessageHandler } from './handlers/message.js';
+
+let seq = 0;
+function freshId(): string {
+  return `twoway-e2e-${Date.now()}-${seq++}`;
+}
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Minimal Telegraf bot + MessageHandler stub sufficient for the elicitation
+ * path in `_run` — mirrors `makeElicitStubs` in watch.test.ts. The bot stub
+ * only needs `sendMessage` + `action`; the MessageHandler stub only needs the
+ * two pending-resolver maps `makeTelegramElicitationHandler` populates.
+ */
+function makeElicitStubs(chatId: number) {
+  const pendingElicitations = new Map<number, (text: string) => void>();
+  const ledgerOriginatedPendingChats = new Set<number>();
+  const sentMessages: string[] = [];
+  const bot = {
+    action: vi.fn(),
+    telegram: {
+      sendMessage: vi.fn().mockImplementation((_chatId: number, text: string) => {
+        sentMessages.push(text);
+        return Promise.resolve({ message_id: 1 });
+      }),
+    },
+  };
+  const messageHandler = {
+    pendingElicitations,
+    ledgerOriginatedPendingChats,
+  } as unknown as MessageHandler;
+  return { bot, messageHandler, sentMessages, pendingElicitations, chatId };
+}
+
+describe('two-way AFK round-trip (real daemon ↔ real REPL over one ledger)', () => {
+  it('elicitation: REPL handler emits → daemon renders+signs+writes-back → REPL handler resolves with the operator answer', async () => {
+    const id = freshId();
+    const chatId = 7;
+    const key = ensureSessionKey(id); // written by /afk on in production
+    expect(key).toBeTruthy();
+
+    // The REPL session's ledger writer — emitElicitation appends through this.
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('setup'); // touch the ledger so the daemon tail has a file
+    await sleep(50);
+
+    // --- DAEMON SIDE: the real SessionWatchManager._run loop ---
+    const { bot, messageHandler, pendingElicitations } = makeElicitStubs(chatId);
+    const pushed: string[] = [];
+    const manager = new SessionWatchManager(
+      () => {},
+      bot as unknown as import('telegraf').Telegraf,
+      messageHandler,
+    );
+    manager.start(chatId, id, async (text) => { pushed.push(text); });
+    await sleep(100);
+
+    // --- REPL SIDE: the real ledger ElicitationChannel handler ---
+    // The keyboard fallback never settles, so ONLY the verified phone reply can
+    // resolve the handler — proving the cross-process write-back is what won.
+    const neverFallback = (): Promise<ElicitationResult> =>
+      new Promise<ElicitationResult>(() => { /* pending forever */ });
+    const handler = makeLedgerChannelHandler({
+      sessionId: id,
+      key,
+      emitElicitation: (record) => writer.record(record),
+      fallback: neverFallback,
+      newReqId: () => 'req-e2e',
+    });
+
+    // The agent asks a question while AFK.
+    const request: ElicitationRequest = { type: 'text', message: 'What is your name?' };
+    const answerP = handler(request, { signal: new AbortController().signal });
+
+    // The daemon tail should observe the elicitation and install the resolver.
+    await sleep(300);
+    const resolver = pendingElicitations.get(chatId);
+    expect(resolver).toBeDefined();
+
+    // Operator answers on the phone. The daemon signs + writes back the response;
+    // the REPL handler verifies the HMAC and resolves.
+    resolver!('Alice');
+
+    const result = await answerP;
+    expect(result.action).toBe('accept'); // resolved by the phone, not declined
+    expect(JSON.stringify(result)).toContain('Alice'); // the answer round-tripped
+
+    manager.stop(chatId);
+    await writer.close();
+  }, 15_000);
+
+  it('abort: a daemon /abort-style signed write fires the REPL abort-watcher exactly once', async () => {
+    const id = freshId();
+    const key = ensureSessionKey(id);
+    expect(key).toBeTruthy();
+
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('setup');
+    await sleep(50);
+
+    // --- REPL SIDE: the real abort-watcher ---
+    const reasons: string[] = [];
+    const watcher = makeAbortWatcher({
+      sessionId: id,
+      key,
+      onAbort: (reason) => reasons.push(reason),
+    });
+    await sleep(80);
+
+    // --- DAEMON SIDE: write an abort_request exactly as bot.ts's /abort does
+    // (fresh nonce + signAbortRequest + a single-record SessionLedgerWriter). ---
+    const nonce = freshChannelId();
+    const hmac = signAbortRequest(key!, id, nonce);
+    new SessionLedgerWriter(id).record({ kind: 'abort_request', nonce, hmac });
+
+    await sleep(300);
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain('abort');
+
+    watcher.stop();
+    await writer.close();
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary

Phase 2 of two-way AFK comms, building on #292 (the AFK path-permission fix, already merged). Two commits:

1. **`test(afk)` — end-to-end two-way round-trip seam test** (verification spike, no production change).
2. **`feat(afk)` — high-risk AFK gate routes approve/deny to the phone (v1.5)**.

Mental model: **AFK = `bypassPermissions` − footguns + phone.** #292 removed the footgun (keyboard-blocking path prompts in AFK). This PR adds the phone: a high-risk op no longer hard-stops an unattended run — it asks the operator to approve or deny from Telegram, over the elicitation round-trip that already exists.

## Background

Two-way AFK comms was already ~90% built (outbound auto-subscribe + batched render; inbound elicitation-answer and abort round-trips over an HMAC-signed on-disk ledger hop). This PR (a) proves that loop end-to-end with one seam test, and (b) closes the highest-value gap: the high-risk gate previously hard-blocked and relied on the model to `send_telegram`, with no way for the operator to say "yes, do it."

## What changed

### 1. Round-trip seam test (`src/telegram/afk-two-way-roundtrip.test.ts`)
Component tests already covered each end in isolation (`afk-ledger-channel.test.ts` = REPL side; `watch.test.ts` = daemon side), both against the `afk-channel` canonical signing form. This adds the one missing assertion: the **real** daemon `SessionWatchManager._run` wired to the **real** REPL `makeLedgerChannelHandler` / `makeAbortWatcher` over a single shared ledger + key, with nothing hand-signed in between — proving the full cross-process round-trip settles for both the elicitation and abort halves.

### 2. v1.5 — high-risk gate → phone approve/deny (`afk-mode-gate.ts`, `default-hook-registry.ts`)
In `autonomous` (AFK) mode, on a `high`-risk / irreversible tool call:

| Case | Behaviour |
|------|-----------|
| **Main session** | Emit an approve/deny form elicitation via `elicitationRouter.route()`. In AFK that router is swapped to the ledger→phone channel (`/afk on`), so it renders on the phone (racing the keyboard) and the signed answer round-trips back. **Approve → the op runs** (this single call). |
| **Deny / decline / cancel / timeout** | Blocked (refused to the model). |
| **Deny-on-timeout** | The elicitation router has no deadline by design (an AFK operator may be away); for a *high-risk approval* we impose one (default 5m) so an unanswered destructive op degrades to the safe refusal instead of stalling the run forever. |
| **Subagents** (`parentSessionId` set) | Still hard-block — a fork never prompts the operator (no attribution on the parent surface), mirroring the path-approval hook's sub-agent auto-deny. The safety ceiling still applies tree-wide; only the *approval affordance* is main-session-only. |
| **No operator reachable** (headless / AFK off) | `route()` declines immediately → blocked. This is the legacy hard-block behaviour, preserved as the safe degrade. |

Implementation notes:
- The gate is now async and registered `longRunning: true` (mirrors the path-approval hook), forwarding the turn signal so session/turn teardown cancels a pending prompt.
- It emits the **same form shape** the path-approval hook uses, so it renders via the already-proven REPL numbered-prompt / Telegram inline-keyboard path.
- **No new ledger record** — reuses the existing `elicitation` / `elicitation_response` hop.

## Verification

- `pnpm lint` (`tsc --noEmit`, strict): clean.
- `pnpm test` (full suite): **10146 passed / 14 skipped / 1 failed**. The single failure is the pre-existing `anthropic-direct.test.ts > compact()` model-id assertion (`claude-haiku-4-5` vs `claude-haiku-4-5-20251001`) — unrelated to this change, fails identically on `main`.
- Coverage spans all three layers, each proven independently:
  - **gate logic** — `afk-mode-gate.test.ts` (31 tests, incl. a new v1.5 suite: approve→allow, deny→block, decline→block, deny-on-timeout, subagent hard-block-without-eliciting, `promptForApproval:false` opt-out, turn-abort forwarding);
  - **form render + button tap** — `elicitation-telegram.test.ts` (same form/enum shape → also neutralizes the latent "ledger-originated form elicitation" UX gap);
  - **ledger round-trip** — `afk-two-way-roundtrip.test.ts` + `watch.test.ts` + `afk-ledger-channel.test.ts`.

### Pending before merge: real-phone smoke (Step 1b)
The single **full** chain (gate → ledger → Telegram form → tap → gate) is not in one automated test — each link is proven separately, but the marquee UX has not been exercised once on real hardware. Validate with a two-terminal smoke:

- [ ] Terminal A: `afk i` → `/afk on`; Terminal B: `pnpm telegram:start`.
- [ ] Session auto-renders to the phone with no manual `/watch`.
- [ ] An `ask_question` renders on the phone; a phone answer unblocks the REPL turn.
- [ ] A high-risk op (e.g. `rm -rf <throwaway>`) surfaces an **Approve / Deny** prompt on the phone; **Approve** runs it, **Deny** refuses it.
- [ ] `/abort` from the phone cancels the run.

## Not in this PR (follow-ups)
- **v2 — free-form steering** (text a live AFK run): new signed `user_message` record + REPL consumer; design call queue-after-turn vs interrupt.
- **v3 hardening** — multi-session disambiguation, presence TTL, `/afk on` bot-liveness check.
