### PR TITLE
fix(tools): subset advertised tool schema to permission allowlist

### DIFF
--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -105,9 +105,46 @@ describe('SessionToolDispatcher', () => {
     expect(result.failureClass).toBe('abort');
   });
 
-  it('exposes toolDefs from schemas', () => {
-    const dispatcher = makeDispatcher();
+  it('exposes toolDefs from schemas (no allowlist = full pass-through)', () => {
+    // Pass undefined permissions so no allowlist is configured — full schema returned.
+    const dispatcher = makeDispatcher({ permissions: undefined });
     expect(dispatcher.toolDefs).toEqual(builtinToolSchemas);
+  });
+
+  describe('toolDefs allowlist subsetting', () => {
+    it('returns all schemas when no allowlist is configured (permissions undefined)', () => {
+      const dispatcher = new SessionToolDispatcher({
+        handlers: new Map(),
+        schemas: [...builtinToolSchemas],
+        // no permissions → undefined
+      });
+      expect(dispatcher.toolDefs).toEqual(builtinToolSchemas);
+    });
+
+    it('returns only allowlisted schemas when allowedTools is set', () => {
+      const bashSchema = builtinToolSchemas.find((s) => s.name === 'bash')!;
+      const readFileSchema = builtinToolSchemas.find((s) => s.name === 'read_file')!;
+      expect(bashSchema).toBeDefined();
+      expect(readFileSchema).toBeDefined();
+      const dispatcher = new SessionToolDispatcher({
+        handlers: new Map(),
+        schemas: [bashSchema, readFileSchema],
+        permissions: { allowedTools: ['read_file'] },
+      });
+      const defs = dispatcher.toolDefs;
+      expect(defs).toHaveLength(1);
+      expect(defs[0]!.name).toBe('read_file');
+      expect(defs.map((d) => d.name)).not.toContain('bash');
+    });
+
+    it('returns empty array when allowedTools matches no schema', () => {
+      const dispatcher = new SessionToolDispatcher({
+        handlers: new Map(),
+        schemas: [...builtinToolSchemas],
+        permissions: { allowedTools: ['nonexistent_tool'] },
+      });
+      expect(dispatcher.toolDefs).toEqual([]);
+    });
   });
 
   describe('permissions', () => {

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -456,8 +456,20 @@ export class SessionToolDispatcher implements ToolDispatcher {
     }
   }
 
+  // Contract: advertised schema MUST mirror the enforced allowlist.
+  // When an allowlist is configured, return only the schemas whose name is
+  // in that set — the model must not be shown tools the permission gate will
+  // reject (read-only / recon forks call bash, get "not in the configured
+  // allowlist", and waste turns).  An undefined allowlist means full access
+  // (all schemas returned unchanged), preserving the default unrestricted path.
+  // MCP tool visibility is preserved because the allowlist is already unioned
+  // with live MCP wire-names before reaching the dispatcher (see
+  // permissions.ts:withMcpToolsAllowed).
   get toolDefs(): readonly AnthropicToolDef[] {
-    return this.schemas;
+    const allowed = this.permissions?.allowedTools;
+    if (!allowed) return this.schemas;
+    const set = new Set(allowed);
+    return this.schemas.filter((s) => set.has(s.name));
   }
 
   /**


### PR DESCRIPTION
## Problem

Phase-restricted subagent forks — mint's `spec`/`research`/`plan` phases (forked with `phaseRole: 'read-only'`) and recon forks — are advertised the **full** builtin tool schema in their `tools:` API payload (`bash`, `write_file`, `edit_file`, `web_scrape`, `browser_*`, …), even though their permission gate only allows a small allowlist (`READ_ONLY_PHASE_TOOLS` / `RECON_ALLOWED_TOOLS`).

The model sees `bash` in its toolbox, reasonably reaches for it during codebase recon (`git log`, `rg`, `find`, `cat`), and gets back `Tool "bash" is not in the configured allowlist` — a flat rejection with no redirect. It then wastes a turn or two re-routing to `read_file`/`glob`/`grep`. The advertised schema and the enforced allowlist were never kept in sync.

## Root cause

The allowlist (`permissions.allowedTools`) was enforced **only at call time** in `checkToolPermission` (`permissions.ts` → `dispatcher.ts`), and did **not** subset the schema sent to the model. `SessionToolDispatcher.toolDefs` returned `this.schemas` unconditionally, and both providers build their `tools:` array from that getter:

- anthropic-direct: `providers/anthropic-direct/index.ts` reads `queryDispatcher.toolDefs` → sent as `tools:`
- openai-compatible: `providers/openai-compatible/query.ts` duck-types `.toolDefs` → `openAITools` → sent as `tools:`

The same seam is already acknowledged in `tool-category.ts` for `get_runtime_state` ("a tool the schema offered but the allowlist rejected").

## Fix

One place — subset `SessionToolDispatcher.toolDefs` by the configured allowlist:

```ts
get toolDefs(): readonly AnthropicToolDef[] {
  const allowed = this.permissions?.allowedTools;
  if (!allowed) return this.schemas;
  const set = new Set(allowed);
  return this.schemas.filter((s) => set.has(s.name));
}
```

Because both providers read `tools:` from this getter, the single change covers **both** the anthropic-direct and openai-compatible paths, and **recon** forks (same `permissions.allowedTools` path) — no provider-level changes.

### Invariants preserved
- **Undefined allowlist → full schema** (the default unrestricted path is unchanged).
- **MCP tools stay visible**: the dispatcher's `permissions` is the post-`withMcpToolsAllowed` union, so MCP wire-names are already in the allowlist before subsetting.
- **Skill-dispatch strip** of `ask_question`/`terminal_font_size` composes correctly — it's an independent filter applied separately in each provider.
- **Nice side effect:** `getEnabledToolNames` (which feeds `get_runtime_state`) now reports only the tools a restricted fork can actually call, instead of over-reporting.

## Testing
- `pnpm lint` (`tsc --noEmit`, strict): clean.
- `src/agent/tools/dispatcher.test.ts`: 76 passed (1 existing test updated to the no-allowlist path; 3 new cases — full pass-through when undefined, subset when set, empty when no match).
- `subagent-phase-role.test.ts`, `mint.test.ts`, `awareness/tool.test.ts`: pass.
- Full suite: the only failure is the pre-existing `anthropic-direct.test.ts > compact()` test (unrelated to tool schemas), which fails identically on clean `main`.

## Risk
Low. Read-only getter, tiny array filter, no state mutation. The only behavior that changes is for sessions that already had an allowlist configured — which were already broken (shown tools they couldn't call).
