### PR TITLE
fix(router): re-point backend on a same-family /model switch to a different endpoint

### DIFF
--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -675,6 +675,56 @@ describe('OpenAICompatibleQuery — model-slot resolution in request body', () =
     await collect(q);
     expect((createCalls[0]!.args as { model: string }).model).toBe('gpt-4o-mini');
   });
+
+  it('resolves a slot alias passed to setModel mid-session before the request body', async () => {
+    // Regression: openai-compatible `setModel` must resolve aliases like the
+    // construction path (buildQueryFromConfig) already does. Without it, a
+    // mid-session `/model <alias>` switch sent the literal alias as the wire
+    // model and the backend rejected it (the same-backend half of the
+    // ChatGPT/Codex 400 on a tier switch).
+    setSlotBindings({
+      local: { id: '' },
+      small: { id: 'gpt-4o-mini' },
+      medium: { id: 'gpt-5.5' },
+      large: { id: 'gpt-5.5' },
+    });
+    const controlled = makeControlledPromptStream();
+    const q = buildQueryFromConfig(baseConfig({ model: 'small' }), controlled.stream);
+    const iter = q[Symbol.asyncIterator]();
+
+    // Turn 1 on the `small` tier → gpt-4o-mini.
+    pendingChunks = [
+      { choices: [{ delta: { content: 'a' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ];
+    controlled.send('one');
+    let ev: IteratorResult<ProviderEvent>;
+    do {
+      ev = await iter.next();
+    } while (!ev.done && ev.value.type !== 'turn.completed');
+    expect((createCalls[0]!.args as { model: string }).model).toBe('gpt-4o-mini');
+
+    // Switch to the `medium` alias mid-session, then drive turn 2.
+    await q.setModel('medium');
+    pendingChunks = [
+      { choices: [{ delta: { content: 'b' } }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } },
+    ];
+    controlled.send('two');
+    do {
+      ev = await iter.next();
+    } while (!ev.done && ev.value.type !== 'turn.completed');
+
+    // The wire model for turn 2 is the RESOLVED id, not the literal alias.
+    const sentModel = (createCalls[1]!.args as { model: string }).model;
+    expect(sentModel).toBe('gpt-5.5');
+    expect(sentModel).not.toBe('medium');
+
+    controlled.end();
+    while (!(await iter.next()).done) {
+      /* drain */
+    }
+  });
 });
 
 describe('OpenAICompatibleQuery — reasoning_effort for o-series models', () => {

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -1213,7 +1213,13 @@ export class OpenAICompatibleQuery implements ProviderQuery {
   }
 
   async setModel(model?: string): Promise<void> {
-    if (model !== undefined) this.currentModel = model;
+    // Resolve slot/legacy aliases (small/medium/large, custom tier names,
+    // haiku/sonnet/opus) to the bound concrete id BEFORE it reaches the request
+    // body — mirroring buildQueryFromConfig (the construction path) and
+    // anthropic-direct's setModel. Without this, a mid-session same-backend
+    // switch to an alias would send the literal alias as the wire model and the
+    // backend would reject it. resolveModelId is a no-op for full ids / `auto`.
+    if (model !== undefined) this.currentModel = resolveModelId(model) ?? model;
   }
 
   async setPermissionMode(mode: string): Promise<void> {

--- a/src/agent/providers/router/provider-router.test.ts
+++ b/src/agent/providers/router/provider-router.test.ts
@@ -7,7 +7,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { ProviderRouter, type ProviderRouterDeps } from './provider-router.js';
 import { QueryInputStream } from '../../session/input-iterable.js';
-import { resetSlotBindings } from '../../session/model-slots.js';
+import { resetSlotBindings, setSlotBindings } from '../../session/model-slots.js';
+import { resolveModelId } from '../../session/model-resolution.js';
 import type { AgentConfig } from '../../types/config-types.js';
 import type {
   ModelProvider,
@@ -160,6 +161,36 @@ async function driveTurn(
   return events;
 }
 
+/**
+ * Slot-aware router for routing-SIGNATURE tests (same-family endpoint changes).
+ * Family is decided by the BOUND id's prefix (resolveModelId → fakeFamily) so
+ * slot aliases route correctly; per-slot `provider: 'openai'` makes the real
+ * applySlotCredentials (called inside the router) set `openaiBaseUrl`
+ * deterministically without reading env. Install bindings via setSlotBindings()
+ * BEFORE constructing.
+ */
+function makeSlotRouter(model: string): {
+  router: ProviderRouter;
+  outer: QueryInputStream;
+  openai: FakeProvider;
+  anthropic: FakeProvider;
+} {
+  const anthropic = new FakeProvider('anthropic-direct');
+  const openai = new FakeProvider('openai-compatible', /* supportsCompact */ false);
+  const deps: ProviderRouterDeps = {
+    resolveProvider: (m) =>
+      fakeFamily(resolveModelId(m) ?? m) === 'openai-compatible' ? openai : anthropic,
+    providerNameForModel: (m) => fakeFamily(resolveModelId(m) ?? m),
+    resolveApiKey: () => undefined,
+  };
+  const outer = new QueryInputStream(() => 'sess');
+  const router = new ProviderRouter(
+    { prompt: outer.createIterable(), config: { model } as AgentConfig },
+    deps,
+  );
+  return { router, outer, openai, anthropic };
+}
+
 describe('ProviderRouter', () => {
   beforeEach(() => resetSlotBindings());
   afterEach(() => resetSlotBindings());
@@ -304,5 +335,58 @@ describe('ProviderRouter', () => {
     await driveTurn(iter, outer, 'hi');
     await router.close();
     expect(anthropic.queries[0]!.rec.closed).toBe(true);
+  });
+
+  it('rebuilds the inner on a same-family switch when the resolved endpoint differs', async () => {
+    // Two OpenAI-family tiers on DIFFERENT endpoints: a cloud tier and a local
+    // shim tier with its own baseUrl. Switching cloud → local must REBUILD the
+    // inner so the new endpoint/credentials apply. The prior family-only check
+    // reused the cloud inner and kept the request on the cloud backend (the
+    // gpt-5.5 → local `/model` bug: ChatGPT/Codex 400 on the frozen backend).
+    setSlotBindings({
+      local: { id: '' },
+      small: { id: 'gpt-cloud', provider: 'openai' },
+      medium: { id: 'gpt-local', provider: 'openai', baseUrl: 'http://localhost:8081/v1' },
+      large: { id: 'claude-opus-4-8' },
+    });
+    const { router, outer, openai } = makeSlotRouter('small');
+    const iter = router[Symbol.asyncIterator]();
+    await pullInit(iter);
+
+    await driveTurn(iter, outer, 'on cloud');
+    expect(openai.queries).toHaveLength(1);
+    expect(openai.queries[0]!.rec.config.openaiBaseUrl).toBeUndefined();
+
+    await router.setModel('medium'); // same family (openai), different endpoint
+    const events = await driveTurn(iter, outer, 'on local');
+    expect(events.map((e) => e.type)).toEqual(['delta.text', 'assistant.message', 'turn.completed']);
+
+    // A SECOND inner was constructed, pointed at the local endpoint…
+    expect(openai.queries).toHaveLength(2);
+    expect(openai.queries[1]!.rec.config.openaiBaseUrl).toBe('http://localhost:8081/v1');
+    // …and the old cloud inner was torn down.
+    expect(openai.queries[0]!.rec.closed).toBe(true);
+    await router.close();
+  });
+
+  it('does NOT rebuild a same-family switch when the endpoint is unchanged (forwards instead)', async () => {
+    setSlotBindings({
+      local: { id: '' },
+      small: { id: 'gpt-4o-mini', provider: 'openai' },
+      medium: { id: 'gpt-4o', provider: 'openai' },
+      large: { id: 'claude-opus-4-8' },
+    });
+    const { router, outer, openai } = makeSlotRouter('small');
+    const iter = router[Symbol.asyncIterator]();
+    await pullInit(iter);
+
+    await driveTurn(iter, outer, 'first');
+    await router.setModel('medium'); // same family AND same (default) endpoint
+    await driveTurn(iter, outer, 'second');
+
+    // No rebuild: still ONE inner, and it received the forwarded switch.
+    expect(openai.queries).toHaveLength(1);
+    expect(openai.queries[0]!.rec.setModelCalls).toContain('medium');
+    await router.close();
   });
 });

--- a/src/agent/providers/router/provider-router.ts
+++ b/src/agent/providers/router/provider-router.ts
@@ -12,10 +12,11 @@
  * This class is a {@link ProviderQuery} facade the session installs as its
  * single `providerQuery`. It owns ONE active inner provider at a time; its
  * long-lived async-iterator pumps the active inner and yields its events
- * straight through. When the selected model's provider FAMILY changes, at the
- * next turn boundary it tears down the inner, constructs the target inner
- * (seeded with a router-maintained text shadow history), swallows the new
- * inner's `session.init`, and keeps pumping.
+ * straight through. When the selected model's routing SIGNATURE changes — its
+ * provider family OR its resolved endpoint/credentials (so a same-family switch
+ * onto a different backend counts) — at the next turn boundary it tears down the
+ * inner, constructs the target inner (seeded with a router-maintained text
+ * shadow history), swallows the new inner's `session.init`, and keeps pumping.
  *
  * Why this beats a session-level reset (the rejected "fork-on-switch"): the
  * swap happens BELOW the session. `AgentSession`'s cost/token/turn accumulators
@@ -34,8 +35,9 @@
  * equivalent, and tool-call ID schemas differ. The router therefore carries a
  * TEXT-ONLY shadow history (`ResumeHistoryTurn[]`) across a family switch — the
  * new model sees prior turns as plain prose, not structured tool/thinking
- * content. This is the documented, accepted degradation for cross-provider
- * switches; same-family runs keep full native fidelity inside the live inner.
+ * content. This is the documented, accepted degradation for any inner rebuild
+ * (cross-family, or same-family onto a different endpoint); same-signature runs
+ * keep full native fidelity inside the live inner.
  *
  * @module agent/providers/router/provider-router
  */
@@ -82,6 +84,14 @@ export interface ProviderRouterArgs {
 /** One constructed inner provider plus the plumbing to drive it. */
 interface ActiveInner {
   family: string;
+  /**
+   * Routing signature the inner was built for: family + resolved endpoint(s) +
+   * resolved apiKey (see {@link ProviderRouter.resolveInner}). A switch whose
+   * target signature differs requires a REBUILD — `family` alone is too coarse
+   * because two same-family tiers can target different endpoints/credentials
+   * (e.g. a cloud OpenAI model vs. a local OpenAI-shim tier on its own baseUrl).
+   */
+  signature: string;
   query: ProviderQuery;
   iterator: AsyncIterator<ProviderEvent>;
   input: QueryInputStream;
@@ -114,6 +124,12 @@ export class ProviderRouter implements ProviderQuery {
   private readonly startupFamily: string;
 
   private active: ActiveInner | undefined;
+  /**
+   * The model the `active` inner was built for. Gates the per-turn signature
+   * recompute in the event lane: an unchanged model skips resolution entirely,
+   * so a session that never switches pays no per-turn cost.
+   */
+  private activeModel: string | undefined;
   private closed = false;
 
   /** Text-only conversation carry, seeded from any resumeHistory, grown per turn. */
@@ -137,13 +153,25 @@ export class ProviderRouter implements ProviderQuery {
   // ---- inner construction -------------------------------------------------
 
   /**
-   * Build the inner provider for `model`. When `seed` is true (a family swap),
-   * the inner is seeded with the text shadow history so the new model sees
-   * prior turns as prose. Credentials are resolved for the model's OWN family.
+   * Resolve the effective inner-construction inputs for `model`: its provider,
+   * the fully credential-resolved inner config (per-family apiKey anti-leak +
+   * per-slot provider/baseUrl/apiKey via {@link applySlotCredentials}), and a
+   * routing SIGNATURE capturing the inner's identity.
+   *
+   * The signature is what {@link buildInner} stores and the event lane / setModel
+   * compare against: two models with the same signature can share one live inner;
+   * a differing signature forces a rebuild. Crucially it folds in the per-slot
+   * endpoint/credentials — without that, a same-family switch onto a different
+   * backend (a cloud OpenAI model → a local OpenAI-shim tier on its own baseUrl)
+   * would reuse the old inner's frozen credentials and keep hitting the old
+   * endpoint. Pure w.r.t. router state: operates on a fresh copy of baseConfig.
    */
-  private buildInner(model: string | undefined, seed: boolean): ActiveInner {
+  private resolveInner(model: string | undefined): {
+    provider: ModelProvider;
+    innerConfig: AgentConfig;
+    signature: string;
+  } {
     const provider = this.deps.resolveProvider(model);
-    const input = new QueryInputStream(() => this.lastSessionId);
 
     const innerConfig: AgentConfig = { ...this.baseConfig };
     innerConfig.model = (model ?? this.baseConfig.model) as AgentConfig['model'];
@@ -162,7 +190,30 @@ export class ProviderRouter implements ProviderQuery {
     // carries explicit provider/baseUrl/apiKey for the (possibly aliased) model.
     applySlotCredentials(innerConfig);
 
-    // Carry mid-session permission-mode / cwd changes onto the new inner.
+    // Identity = family + resolved endpoint(s) + resolved key. NUL-joined so no
+    // value can collide across fields. In-memory only — never logged/persisted.
+    const signature = [
+      provider.name,
+      innerConfig.baseUrl ?? '',
+      innerConfig.openaiBaseUrl ?? '',
+      innerConfig.apiKey ?? '',
+    ].join('\u0000');
+
+    return { provider, innerConfig, signature };
+  }
+
+  /**
+   * Build the inner provider for `model`. When `seed` is true (a swap), the
+   * inner is seeded with the text shadow history so the new model sees prior
+   * turns as prose. Credentials/endpoint are resolved for the model's OWN family
+   * + tier via {@link resolveInner}.
+   */
+  private buildInner(model: string | undefined, seed: boolean): ActiveInner {
+    const { provider, innerConfig, signature } = this.resolveInner(model);
+    const input = new QueryInputStream(() => this.lastSessionId);
+
+    // Carry mid-session permission-mode / cwd changes onto the new inner. These
+    // do not affect the routing signature (computed in resolveInner above).
     if (this.currentPermissionMode !== undefined) innerConfig.permissionMode = this.currentPermissionMode;
     if (this.currentCwd !== undefined) innerConfig.cwd = this.currentCwd;
 
@@ -171,6 +222,7 @@ export class ProviderRouter implements ProviderQuery {
     const query = provider.query({ prompt: input.createIterable(), config: innerConfig });
     return {
       family: provider.name,
+      signature,
       query,
       iterator: (query as AsyncIterable<ProviderEvent>)[Symbol.asyncIterator](),
       input,
@@ -214,6 +266,7 @@ export class ProviderRouter implements ProviderQuery {
     try {
       // Construct the first inner and surface its session.init to the session.
       this.active = this.buildInner(this.currentModel, /* seed */ false);
+      this.activeModel = this.currentModel;
       yield* this.driveUntilInit(/* swallow */ false);
 
       while (!this.closed) {
@@ -222,9 +275,20 @@ export class ProviderRouter implements ProviderQuery {
         const turn = next.value;
         this.lastSessionId = turn.sessionId;
 
-        // Switch the inner provider at this turn boundary if the family changed.
-        const targetFamily = this.deps.providerNameForModel(this.currentModel);
-        if (!this.active || targetFamily !== this.active.family) {
+        // Rebuild the inner at this turn boundary when the resolved routing
+        // SIGNATURE for the current model differs from the active inner's. This
+        // captures BOTH a provider-family swap AND a same-family endpoint/
+        // credential change (e.g. a cloud OpenAI model → a local OpenAI-shim
+        // tier on its own baseUrl) — the latter previously slipped through a
+        // family-only check, leaving the request on the prior model's frozen
+        // backend. Gated on a model change so an unchanged session never pays
+        // the per-turn resolution cost (same model ⇒ same signature).
+        const modelChanged = this.currentModel !== this.activeModel;
+        const needSwap =
+          !this.active ||
+          (modelChanged && this.resolveInner(this.currentModel).signature !== this.active.signature);
+        this.activeModel = this.currentModel;
+        if (needSwap) {
           await this.closeActive();
           this.active = this.buildInner(this.currentModel, /* seed */ true);
           debugLog(`🔀 ProviderRouter: switched inner provider → ${this.active.family} (model=${this.currentModel})`);
@@ -301,10 +365,14 @@ export class ProviderRouter implements ProviderQuery {
   async setModel(model?: string): Promise<void> {
     if (typeof model === 'string' && model.length > 0) {
       this.currentModel = model;
-      // Same-family switch: forward to the live inner so the next turn uses the
-      // new model string. Cross-family switch: recorded only — the swap happens
-      // at the next turn boundary in the event lane.
-      if (this.active && this.deps.providerNameForModel(model) === this.active.family) {
+      // Forward to the live inner ONLY for a true same-inner switch — same
+      // routing signature (family + endpoint + credentials). A switch that
+      // changes the effective backend (e.g. a cloud OpenAI model → a local
+      // OpenAI-shim tier on its own baseUrl) must NOT be forwarded: forwarding
+      // would leave the request on the old inner's frozen endpoint/credentials.
+      // Such a switch is recorded only; the turn-boundary rebuild in the event
+      // lane re-points it. (A family-only check used to forward these wrongly.)
+      if (this.active && this.resolveInner(model).signature === this.active.signature) {
         await this.active.query.setModel(model);
       }
     }


### PR DESCRIPTION
## Summary

Fixes a mid-session `/model` switch that silently kept hitting the **previous** model's backend when switching between two models in the **same provider family but on different endpoints** — e.g. `gpt-5.5` (ChatGPT/Codex OAuth backend) → a configured **local** tier on `http://localhost:8081/v1`.

The switch reported `✓ Model switched to local`, then the next turn failed with:

```
ChatGPT/Codex backend rejected model "local" (HTTP 400). A ChatGPT subscription
only serves certain OpenAI models on this backend (gpt-5.5 works; gpt-5, gpt-5.1,
gpt-5.2 and *-codex do not).
```

i.e. the literal alias `local` was sent to the **ChatGPT backend** instead of `froggeric/…` going to `localhost:8081`.

## Root cause

Two compounding defects, both on the mid-session switch path (startup / `-m local` was unaffected — that path resolves correctly):

1. **`ProviderRouter` keyed inner reuse on provider FAMILY alone.** `gpt-5.5` and a local OpenAI-shim tier both resolve to `openai-compatible`, so the family matched and the router reused the live inner — forwarding the new model string without rebuilding. `applySlotCredentials` (which applies the per-slot `baseUrl`/`apiKey`) only runs inside `buildInner`, which only ran on a cross-family swap. So the inner stayed frozen on the ChatGPT OAuth backend (`auth.source`/baseURL are construction-time).

2. **`OpenAICompatibleQuery.setModel` stored the raw alias** as `currentModel` and sent it verbatim as the wire model — unlike `buildQueryFromConfig` (construction) and `anthropic-direct`'s `setModel`, which resolve the alias via `resolveModelId`.

## Fix

1. `ProviderRouter` now keys inner reuse on a full **routing signature** (`family + resolved baseUrl + openaiBaseUrl + apiKey`) rather than family alone. A signature change forces a turn-boundary rebuild, so a same-family switch onto a different endpoint re-points the backend. The check is gated on a model change, so a session that never switches pays no per-turn resolution cost. `setModel` likewise forwards to the live inner only on a true same-inner (same-signature) switch.

2. `OpenAICompatibleQuery.setModel` resolves slot/legacy aliases via `resolveModelId` before storing `currentModel`, matching the construction path and anthropic-direct.

The Telegram `/model` path goes through the same `AgentSession.setModel` → router, so it's fixed too.

## Tests

- `provider-router.test.ts`: rebuilds the inner on a same-family switch when the resolved endpoint differs; does **not** rebuild (forwards instead) when the endpoint is unchanged.
- `query.test.ts` (openai-compatible): a slot alias passed to `setModel` mid-session resolves to the bound wire id before the request body.

## Verification

- `pnpm lint` — clean.
- New + existing `src/agent/providers` + `src/agent/session` suites pass (936 tests), except one **pre-existing, environment-dependent** failure (`anthropic-direct.test.ts > compact()` resolving `claude-haiku-4-5` vs `claude-haiku-4-5-20251001`) confirmed failing identically on `main` without this change — unrelated to this fix.

No new `@anthropic-ai/sdk` symbols (no SDK lock change).
