### PR TITLE
feat(plugins): plugin JS `main` entrypoint run at session boot

### DIFF
--- a/src/agent/plugins-scanner.test.ts
+++ b/src/agent/plugins-scanner.test.ts
@@ -51,6 +51,30 @@ describe('plugins-scanner', () => {
     expect(scanLocalPlugins(tmpHome)).toEqual([{ type: 'local', path: pluginDir }]);
   });
 
+  it('attaches the manifest `main` entrypoint when declared', () => {
+    const pluginDir = join(tmpHome, 'with-main');
+    mkdirSync(join(pluginDir, '.claude-plugin'), { recursive: true });
+    writeFileSync(
+      join(pluginDir, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'm', version: '0.0.0', main: 'dist/index.js' }),
+    );
+
+    expect(scanLocalPlugins(tmpHome)).toEqual([
+      { type: 'local', path: pluginDir, main: 'dist/index.js' },
+    ]);
+  });
+
+  it('omits `main` when the manifest declares it blank (plain absence covered above)', () => {
+    const blankMain = join(tmpHome, 'blank-main');
+    mkdirSync(join(blankMain, '.claude-plugin'), { recursive: true });
+    writeFileSync(
+      join(blankMain, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'b', version: '0.0.0', main: '   ' }),
+    );
+
+    expect(scanLocalPlugins(tmpHome)).toEqual([{ type: 'local', path: blankMain }]);
+  });
+
   it('discovers a marketplace-cache-layout plugin when it has an enabled index entry', () => {
     const pluginDir = join(tmpHome, 'cache', 'some-market', 'some-plugin');
     writePluginManifest(pluginDir);

--- a/src/agent/plugins-scanner.ts
+++ b/src/agent/plugins-scanner.ts
@@ -125,7 +125,7 @@ function walk(
     if (key === null) {
       // Path that doesn't fit either layout — keep loading it (matches
       // pre-marketplace behavior for unexpected directory shapes).
-      out.push({ type: 'local', path: dir });
+      pushPlugin(out, dir);
       return;
     }
     if (key.layout === 'cache') {
@@ -136,13 +136,13 @@ function walk(
         const entry = indexPlugins[key.key];
         if (!entry || entry.enabled === false) return;
       }
-      out.push({ type: 'local', path: dir });
+      pushPlugin(out, dir);
       return;
     }
     // Flat layout: include unless explicitly disabled.
     const entry = indexPlugins[key.key];
     if (entry && entry.enabled === false) return;
-    out.push({ type: 'local', path: dir });
+    pushPlugin(out, dir);
     return;
   }
 
@@ -164,6 +164,37 @@ function walk(
     }
     if (stat.isDirectory()) walk(root, full, depth + 1, out, seen, indexPlugins, trustAll);
   }
+}
+
+/**
+ * Read the optional `main` entrypoint from a plugin's manifest. Returns the
+ * declared string (relative or absolute) when present and non-blank, else
+ * undefined. Defensive: the scan must never throw on a malformed/unreadable
+ * manifest — such a plugin simply contributes no entrypoint.
+ */
+function readPluginMain(dir: string): string | undefined {
+  try {
+    const raw = readFileSync(join(dir, '.claude-plugin', 'plugin.json'), 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed !== null && typeof parsed === 'object' && 'main' in parsed) {
+      const main = (parsed as { main?: unknown }).main;
+      if (typeof main === 'string' && main.trim() !== '') return main;
+    }
+  } catch {
+    // Missing/unreadable/invalid manifest → no entrypoint.
+  }
+  return undefined;
+}
+
+/**
+ * Push a discovered plugin onto the scan result, attaching its manifest `main`
+ * entrypoint when declared. Centralizes the three walk() push sites so the
+ * `main` field is populated consistently. Omits the key entirely when absent so
+ * existing `{ type, path }` deep-equality expectations stay green.
+ */
+function pushPlugin(out: SdkPluginConfig[], dir: string): void {
+  const main = readPluginMain(dir);
+  out.push(main !== undefined ? { type: 'local', path: dir, main } : { type: 'local', path: dir });
 }
 
 /**

--- a/src/agent/plugins/load-entrypoints.test.ts
+++ b/src/agent/plugins/load-entrypoints.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for boot-time plugin entrypoint loading. The load-bearing proof is that
+ * a plugin's `main` module is actually imported and its top-level side-effects
+ * run — this is the mechanism that lets a plugin register code-backed skills at
+ * session boot without a core edit.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { pathToFileURL } from 'url';
+import { loadPluginEntrypoints, _resetLoadedEntrypoints } from './load-entrypoints.js';
+import type { SdkPluginConfig } from '../types/sdk-types.js';
+
+let dir: string;
+
+beforeEach(() => {
+  _resetLoadedEntrypoints();
+  dir = mkdtempSync(join(tmpdir(), 'afk-entrypoints-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('loadPluginEntrypoints', () => {
+  it('imports and runs a plugin main module (side-effects fire at boot)', async () => {
+    const key = `__afkBootProof_${Math.random().toString(36).slice(2)}`;
+    writeFileSync(
+      join(dir, 'entry.mjs'),
+      `globalThis[${JSON.stringify(key)}] = (globalThis[${JSON.stringify(key)}] ?? 0) + 1;\n`,
+    );
+    const plugins: SdkPluginConfig[] = [{ type: 'local', path: dir, main: 'entry.mjs' }];
+
+    await loadPluginEntrypoints(plugins);
+
+    const store = globalThis as unknown as Record<string, unknown>;
+    try {
+      expect(store[key]).toBe(1);
+    } finally {
+      delete store[key];
+    }
+  });
+
+  it('skips plugins that declare no main (no import attempted)', async () => {
+    let calls = 0;
+    await loadPluginEntrypoints([{ type: 'local', path: dir }], {
+      importer: async () => {
+        calls++;
+      },
+    });
+    expect(calls).toBe(0);
+  });
+
+  it('does not re-import the same resolved path within a process', async () => {
+    let calls = 0;
+    const plugins: SdkPluginConfig[] = [{ type: 'local', path: dir, main: 'entry.mjs' }];
+    const importer = async (): Promise<void> => {
+      calls++;
+    };
+    await loadPluginEntrypoints(plugins, { importer });
+    await loadPluginEntrypoints(plugins, { importer });
+    expect(calls).toBe(1);
+  });
+
+  it('is non-fatal when an entrypoint is missing/throws, reporting via onError', async () => {
+    const errors: unknown[] = [];
+    const plugins: SdkPluginConfig[] = [
+      { type: 'local', path: dir, main: 'does-not-exist.mjs' },
+    ];
+    await expect(
+      loadPluginEntrypoints(plugins, { onError: (_p, e) => errors.push(e) }),
+    ).resolves.toBeUndefined();
+    expect(errors).toHaveLength(1);
+  });
+
+  it('resolves a relative main against the plugin path as a file URL', async () => {
+    const seen: string[] = [];
+    await loadPluginEntrypoints([{ type: 'local', path: dir, main: 'sub/entry.mjs' }], {
+      importer: async (s) => {
+        seen.push(s);
+      },
+    });
+    expect(seen).toEqual([pathToFileURL(join(dir, 'sub', 'entry.mjs')).href]);
+  });
+
+  it('honors an absolute main as-is', async () => {
+    const abs = join(dir, 'abs.mjs');
+    const seen: string[] = [];
+    await loadPluginEntrypoints([{ type: 'local', path: '/elsewhere', main: abs }], {
+      importer: async (s) => {
+        seen.push(s);
+      },
+    });
+    expect(seen).toEqual([pathToFileURL(abs).href]);
+  });
+});

--- a/src/agent/plugins/load-entrypoints.ts
+++ b/src/agent/plugins/load-entrypoints.ts
@@ -1,0 +1,64 @@
+/**
+ * Boot-time loading of plugin JS entrypoints.
+ *
+ * A plugin manifest may declare a `main` module (see {@link SdkPluginConfig.main}).
+ * Importing that module at session boot runs its top-level side-effects —
+ * typically `registerSkill()` / agent registration — so a plugin can contribute
+ * code-backed capabilities without a core edit. This is the seam that lets an
+ * internal-tier skill bundle live entirely in a plugin rather than in `src/`.
+ *
+ * Invariant: a failing entrypoint MUST NOT abort session boot. A broken plugin
+ * degrades to "its skills don't load," never "the session won't start."
+ *
+ * @module agent/plugins/load-entrypoints
+ */
+
+import { isAbsolute, resolve as resolvePath } from 'path';
+import { pathToFileURL } from 'url';
+import type { SdkPluginConfig } from '../types/sdk-types.js';
+
+/**
+ * Resolved-entrypoint paths already imported in this process. Dynamic `import()`
+ * caches modules itself, but tracking here lets us skip redundant awaits when
+ * the scanner is consulted multiple times per turn and keeps load deterministic.
+ */
+const loadedEntrypoints = new Set<string>();
+
+/** Clear the loaded-entrypoint set. For tests and `/reload-plugins`. */
+export function _resetLoadedEntrypoints(): void {
+  loadedEntrypoints.clear();
+}
+
+export type LoadEntrypointsOptions = {
+  /** Injectable importer for tests; defaults to native dynamic `import()`. */
+  importer?: (specifier: string) => Promise<unknown>;
+  /** Invoked (non-fatally) when a plugin entrypoint fails to import. */
+  onError?: (plugin: SdkPluginConfig, error: unknown) => void;
+};
+
+/**
+ * Import the `main` entrypoint of every plugin that declares one. Idempotent
+ * per resolved path within a process; per-plugin failures are isolated and
+ * non-fatal (reported via {@link LoadEntrypointsOptions.onError}).
+ */
+export async function loadPluginEntrypoints(
+  plugins: readonly SdkPluginConfig[],
+  opts: LoadEntrypointsOptions = {},
+): Promise<void> {
+  const importer = opts.importer ?? ((specifier: string) => import(specifier));
+  for (const plugin of plugins) {
+    if (plugin.main === undefined) continue;
+    const absPath = isAbsolute(plugin.main)
+      ? plugin.main
+      : resolvePath(plugin.path, plugin.main);
+    if (loadedEntrypoints.has(absPath)) continue;
+    // Mark before awaiting: a re-entrant call during the same boot must not
+    // double-import, and a failed entrypoint must not be retried this process.
+    loadedEntrypoints.add(absPath);
+    try {
+      await importer(pathToFileURL(absPath).href);
+    } catch (error) {
+      opts.onError?.(plugin, error);
+    }
+  }
+}

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -18,8 +18,15 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { buildSkillManifest, collectSkillEntries, discoverPluginSkillBodies } from './skill-bridge.js';
+import {
+  buildSkillManifest,
+  collectSkillEntries,
+  discoverPluginSkillBodies,
+  scanAllPluginRoots,
+} from './skill-bridge.js';
 import { registerSkill, _resetRegistry } from '../../skills/index.js';
+import { _resetPluginScanCache } from '../plugins-scanner.js';
+import { getPluginsDir } from '../../paths.js';
 
 // ---------------------------------------------------------------------------
 // File-level isolation: redirect AFK_HOME + cwd before every test so the
@@ -712,5 +719,37 @@ describe('collectSkillEntries — disk-scan regression (user + project skills)',
       (e) => e.source === 'user' || e.source === 'project',
     );
     expect(userOrProject).toHaveLength(0);
+  });
+});
+
+describe('scanAllPluginRoots', () => {
+  it('returns well-formed local plugin configs', () => {
+    _resetPluginScanCache();
+    const roots = scanAllPluginRoots();
+    expect(Array.isArray(roots)).toBe(true);
+    for (const r of roots) {
+      expect(r.type).toBe('local');
+      expect(typeof r.path).toBe('string');
+    }
+  });
+
+  it('surfaces a user-scope plugin together with its manifest `main`', () => {
+    // AFK_HOME is stubbed to an empty temp dir by the file-level beforeEach, so
+    // getPluginsDir() points inside it. Drop a fixture plugin that declares a
+    // `main`, then assert scanAllPluginRoots() carries it through — this is the
+    // scan→entrypoint flow that loadPluginEntrypoints() consumes at boot.
+    const pluginDir = join(getPluginsDir(), 'with-main');
+    mkdirSync(join(pluginDir, '.claude-plugin'), { recursive: true });
+    writeFileSync(
+      join(pluginDir, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: 'with-main', version: '0.0.0', main: 'dist/index.js' }),
+    );
+    _resetPluginScanCache();
+
+    expect(scanAllPluginRoots()).toContainEqual({
+      type: 'local',
+      path: pluginDir,
+      main: 'dist/index.js',
+    });
   });
 });

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -17,6 +17,7 @@ import '../../skills/all.js';
 import { listSkills, getSkill, isSkillVisible } from '../../skills/index.js';
 import { scanSkillsFromDir } from '../../skills/user-skills.js';
 import { scanLocalPlugins } from '../plugins-scanner.js';
+import { loadPluginEntrypoints } from '../plugins/load-entrypoints.js';
 import { extractPluginSkills } from '../plugins/tool-injector.js';
 import type { SdkPluginConfig } from '../types/sdk-types.js';
 import { getBundledPluginsDir, getProjectPluginsDir, getProjectSkillsDir, getSkillsDir } from '../../paths.js';
@@ -138,12 +139,7 @@ export function collectSkillEntries(
   //    Plugin frontmatter MAY carry `audience: internal` to opt into the
   //    same tier gate — extractPluginSkills() surfaces it as `audience`,
   //    defaulting to 'public' when absent.
-  const plugins = pluginConfigs ?? [
-    ...scanLocalPlugins(getProjectPluginsDir()),
-    ...scanLocalPlugins(),
-    ...scanLocalPlugins(getBundledPluginsDir()),
-    ...importedRoots.pluginRoots.flatMap((root) => scanLocalPlugins(root, { trustAll: true })),
-  ];
+  const plugins = pluginConfigs ?? scanAllPluginRoots();
   for (const plugin of plugins) {
     if (plugin.type !== 'local') continue;
     const skills = extractPluginSkills(plugin.path);
@@ -215,14 +211,7 @@ export function discoverPluginSkillBodies(
   // Imported plugin roots are resolved inline in the fallback so the
   // loadImportFromConfig() + existsSync work only runs when no pluginConfigs
   // were supplied (a caller passing pluginConfigs skips it entirely).
-  const plugins = pluginConfigs ?? [
-    ...scanLocalPlugins(getProjectPluginsDir()),
-    ...scanLocalPlugins(),
-    ...scanLocalPlugins(getBundledPluginsDir()),
-    ...resolveImportedRoots(loadImportFromConfig()).pluginRoots.flatMap((root) =>
-      scanLocalPlugins(root, { trustAll: true }),
-    ),
-  ];
+  const plugins = pluginConfigs ?? scanAllPluginRoots();
 
   for (const plugin of plugins) {
     if (plugin.type !== 'local') continue;
@@ -241,4 +230,38 @@ export function discoverPluginSkillBodies(
   }
 
   return bodies;
+}
+
+/**
+ * Aggregate every plugin root AFK loads from, in priority order:
+ * project-scope → user-scope → bundled → imported (trusted) roots. Single
+ * source of truth for "which plugins exist," shared by skill-manifest
+ * collection, plugin-body discovery, and boot-time entrypoint loading so the
+ * three never drift apart.
+ */
+export function scanAllPluginRoots(): SdkPluginConfig[] {
+  return [
+    ...scanLocalPlugins(getProjectPluginsDir()),
+    ...scanLocalPlugins(),
+    ...scanLocalPlugins(getBundledPluginsDir()),
+    ...resolveImportedRoots(loadImportFromConfig()).pluginRoots.flatMap((root) =>
+      scanLocalPlugins(root, { trustAll: true }),
+    ),
+  ];
+}
+
+/**
+ * Import the JS entrypoint of every discovered plugin that declares a manifest
+ * `main`, so a plugin's top-level `registerSkill()` side-effects populate the
+ * global registry BEFORE the skill manifest is built. Awaiting this before
+ * constructing an AgentSession is what lets a plugin contribute code-backed
+ * skills (the manifest is assembled synchronously at session construction).
+ *
+ * Idempotent and process-global (see {@link loadPluginEntrypoints}): cheap to
+ * await from every surface bootstrap, a no-op for already-loaded entrypoints,
+ * and non-fatal per plugin. A subagent inherits the parent process's registry,
+ * so calling it again in a child is a safe no-op.
+ */
+export async function ensurePluginEntrypointsLoaded(): Promise<void> {
+  await loadPluginEntrypoints(scanAllPluginRoots());
 }

--- a/src/agent/types/sdk-types.ts
+++ b/src/agent/types/sdk-types.ts
@@ -256,6 +256,16 @@ export type AgentDefinition = {
 export type SdkPluginConfig = {
   type: 'local';
   path: string;
+  /**
+   * Optional path (relative to {@link path}, or absolute) of a JS module to
+   * dynamically import at session boot, taken from the plugin manifest's `main`
+   * field. Importing the module runs its top-level side-effects — e.g.
+   * `registerSkill()` calls — so a plugin can contribute code-backed skills or
+   * agents without editing core. Resolved and imported by
+   * {@link loadPluginEntrypoints}; a failing import is non-fatal. Absent when
+   * the manifest declares no `main`.
+   */
+  main?: string;
 };
 
 // ---------------------------------------------------------------------------

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -51,6 +51,7 @@ import { seedPersistedGrants } from '../../../agent/permissions-store.js';
 import { providerForModel } from '../../../agent/providers/index.js';
 import { createMemoizedProviderFactory } from './provider-factory.js';
 import { BUILTIN_TOOL_NAMES } from '../../../agent/tools/schemas.js';
+import { ensurePluginEntrypointsLoaded } from '../../../agent/tools/skill-bridge.js';
 import { AWARENESS_TOOL_NAMES } from '../../../agent/awareness/index.js';
 import { McpManager, loadMcpConfig, getMcpConfigPath } from '../../../agent/mcp/index.js';
 import { loadImportFromConfig, resolveImportedRoots } from '../../../config/import-sources.js';
@@ -588,6 +589,12 @@ export async function bootstrapSession(
     autoResumeOnUsageLimit: cliConfig.autoResumeOnUsageLimit,
     ...(initialPermissionMode !== undefined ? { permissionMode: initialPermissionMode } : {}),
   };
+
+  // Import any plugin JS entrypoints (manifest `main`) before constructing the
+  // session: the skill manifest is assembled synchronously in the constructor,
+  // so a plugin's registerSkill() side-effects must already have run for its
+  // code-backed skills to appear. Idempotent + non-fatal; no-op without plugins.
+  await ensurePluginEntrypointsLoaded();
 
   const session = buildAgentSession(sharedDeps);
   // Populate sessionRef (declared above deferredParent so the proxy works).


### PR DESCRIPTION
## What

Adds a plugin **JS `main` entrypoint** loaded at session boot, so a plugin can contribute **code-backed** skills/agents (anything that calls `registerSkill()` at module load) without editing core — the same way `src/skills/all.ts` pulls in built-in skills today.

This is the enabling mechanism for moving code-backed capabilities out of the core tree and into a plugin/package.

## Why

Today the only way to register a code-backed skill is a static `import` in core (`src/skills/all.ts`). Plugins are discovered as `{ type, path }` and can only contribute markdown (`SKILL.md`) — there is no way for a plugin to run JS at boot. This PR adds that seam.

## How

- **`SdkPluginConfig.main?: string`** — additive, optional; declared by the plugin manifest's `main`.
- **`plugins-scanner`** parses `main` from `.claude-plugin/plugin.json` and attaches it to the scan result (omitted when absent/blank, so existing `{ type, path }` deep-equality stays green).
- **`agent/plugins/load-entrypoints.ts`** — `loadPluginEntrypoints()` resolves each plugin's `main` (relative to the plugin dir, or absolute), imports it as a `file://` URL, **dedupes per resolved path within a process**, and **isolates failures** (a broken entrypoint is non-fatal, surfaced via `onError`).
- **`skill-bridge`** — `scanAllPluginRoots()` is now the single source of truth for "which plugins exist" (project → user → bundled → imported); the two pre-existing duplicated root lists were refactored onto it so **entrypoint roots can never drift from skill roots**. `ensurePluginEntrypointsLoaded()` (idempotent, process-global, non-fatal) is the one call surfaces await before constructing a session.
- **`interactive/bootstrap`** awaits `ensurePluginEntrypointsLoaded()` before `buildAgentSession()`. This ordering is required: the skill manifest is built **synchronously** in the `AgentSession` constructor (`anthropic-direct` `query()`), so a plugin's `registerSkill()` must already have run for its skills to appear.

## Scope / follow-ups

- Wires the **REPL** (primary interactive surface) as the reference integration. `chat` / `daemon` / `telegram` are one-line follow-ups using the same `ensurePluginEntrypointsLoaded()` helper, landing with their own tests. **Subagents need no wiring** — they inherit the parent process's registry (the helper is a no-op there).
- `/reload-plugins` semantics: a newly-added plugin's entrypoint loads on the next `ensurePluginEntrypointsLoaded()` (new path); module unload on removal is out of scope.

## Tests / gates

- New: loader (import + side-effects fire at boot, skip-when-no-main, idempotency, non-fatal failure, relative+absolute resolution); scanner `main` parse (declared / blank-omitted); `scanAllPluginRoots` shape + surfaces a fixture plugin's `main`.
- `tsc --noEmit` clean. Touched suites green: `agent/tools` + `agent/plugins` + `cli/commands/interactive` (2254 pass, 0 fail). Branch rebased on current `main` (v4.45.3).
