### PR TITLE
fix(daemon): don't default the daemon task to an unavailable skill

### DIFF
--- a/src/cli/commands/daemon-session-factory.test.ts
+++ b/src/cli/commands/daemon-session-factory.test.ts
@@ -6,7 +6,7 @@
  * Root cause being tested: `afk daemon` previously passed no `sessionFactory`
  * to `startDaemon`, so sessions fell through to `resolveProvider()` →
  * `new AnthropicDirectProvider()` with no executor opts, omitting the three
- * orchestration tools. Skill commands like `/forge-friction --auto` would
+ * orchestration tools. Skill commands like `/some-skill --auto` would
  * fail because the provider's permission gate rejected tool calls it had
  * no handler for.
  *

--- a/src/cli/commands/daemon.test.ts
+++ b/src/cli/commands/daemon.test.ts
@@ -2,10 +2,11 @@
  * Tests for `afk daemon` command — Daemon Gap B (zero-config invocability).
  *
  * Covers:
- *   - `afk daemon` with no flags starts with sessionstart trigger + compiled
- *     default task (no error, no required options).
+ *   - `afk daemon` with no flags starts with sessionstart trigger and does NOT
+ *     fabricate a default task (no error, no required options).
  *   - `afk daemon --task <x>` still wires through correctly.
- *   - `afk daemon --cron <expr>` auto-selects cron trigger.
+ *   - `afk daemon --task <x> --cron <expr>` auto-selects cron trigger.
+ *   - `afk daemon --cron <expr>` without a task produces an error.
  *   - `afk daemon --trigger cron` without --cron still produces an error.
  *   - Config-driven default: `daemon.task` from afk.config.json is used when
  *     no --task flag is provided.
@@ -189,21 +190,19 @@ describe('afk daemon (CLI integration)', () => {
     consoleSpy.mockRestore();
   });
 
-  it('runs with no flags — uses sessionstart trigger and compiled default task', async () => {
+  it('runs with no flags — sessionstart trigger, no fabricated default task', async () => {
     await runDaemon();
 
     expect(mockStartDaemon).toHaveBeenCalledOnce();
     const opts = mockStartDaemon.mock.calls[0]?.[0];
     expect(opts).toBeDefined();
 
-    // The main task should use compiled defaults
+    // With no --task / env / config task, the daemon no longer invents a
+    // default task (previously '/forge-friction --auto'). The 'default' task id
+    // is unique to that fabricated task, so its absence is the precise signal —
+    // robust even if persisted schedules exist on the test machine.
     const tasks = opts?.tasks ?? [];
-    const mainTask = tasks.find((t) => t.taskId !== 'worktree-prune');
-    expect(mainTask).toBeDefined();
-    expect(mainTask?.command).toBe(COMPILED_DEFAULT_TASK);
-    expect(mainTask?.trigger).toBe('sessionstart');
-    // No cron expression required for sessionstart
-    expect(mainTask?.cronExpression).toBeUndefined();
+    expect(tasks.find((t) => t.taskId === COMPILED_DEFAULT_TASK_ID)).toBeUndefined();
   });
 
   it('passes --task through correctly', async () => {
@@ -222,13 +221,20 @@ describe('afk daemon (CLI integration)', () => {
     expect(mainTask?.trigger).toBe('sessionstart');
   });
 
-  it('auto-selects cron trigger when --cron is provided', async () => {
-    await runDaemon('--cron', '0 */6 * * *');
+  it('auto-selects cron trigger when --cron is provided (with a task)', async () => {
+    await runDaemon('--task', '/my-task --auto', '--cron', '0 */6 * * *');
 
     const opts = mockStartDaemon.mock.calls[0]?.[0];
-    const mainTask = opts?.tasks?.find((t) => t.taskId !== 'worktree-prune');
+    const mainTask = opts?.tasks?.find((t) => t.taskId === COMPILED_DEFAULT_TASK_ID);
+    expect(mainTask?.command).toBe('/my-task --auto');
     expect(mainTask?.trigger).toBe('cron');
     expect(mainTask?.cronExpression).toBe('0 */6 * * *');
+  });
+
+  it('errors when --cron is provided but no task is configured', async () => {
+    await expect(runDaemon('--cron', '0 */6 * * *')).rejects.toThrow(
+      /task is required for the cron and both triggers/,
+    );
   });
 
   it('errors when --trigger cron is explicit but --cron is absent', async () => {

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -9,7 +9,6 @@ import { getQueueDir } from '../../paths.js';
 import { pushIfConfigured } from '../../telegram/push.js';
 import type { TaskCompletionDetails, TelemetryRecord } from '../../agent/daemon/scheduler.js';
 import {
-  COMPILED_DEFAULT_TASK,
   COMPILED_DEFAULT_TASK_ID,
   resolveDaemonHost,
   resolveDaemonTimeoutMs,
@@ -236,7 +235,7 @@ export function registerDaemonCommand(program: Command): void {
       '--host <address>',
       'Bind address for the control HTTP surface. Overrides AFK_DAEMON_HOST. Defaults to 127.0.0.1 (loopback only). The control surface is UNAUTHENTICATED — bind a non-loopback address (e.g. 0.0.0.0) only on a trusted or firewalled network.',
     )
-    .option('-t, --task <command>', `Command to fire on each tick (default: ${COMPILED_DEFAULT_TASK})`)
+    .option('-t, --task <command>', 'Command to fire on each tick. Required for the cron and both triggers; optional otherwise.')
     .option('-c, --cron <expression>', 'Cron expression (e.g. "0 */6 * * *"). Required when --trigger includes cron.')
     .option('-i, --task-id <id>', `Task identifier (default: ${COMPILED_DEFAULT_TASK_ID})`)
     .option('--once', 'Fire one tick and exit (for testing)', false)
@@ -295,6 +294,18 @@ export function registerDaemonCommand(program: Command): void {
       if ((trigger === 'cron' || trigger === 'both') && !options.cron) {
         handleCommandError(new Error(`--cron is required when --trigger is '${trigger}'.`));
       }
+      // A task is mandatory for cron/both: the user scheduled a tick but, with
+      // no --task / AFK_DAEMON_TASK / daemon.task, there is nothing to run. Fail
+      // clearly instead of registering an empty default task (historically this
+      // fell back to an internal-only skill a public build cannot execute).
+      if ((trigger === 'cron' || trigger === 'both') && command.trim() === '') {
+        handleCommandError(
+          new Error(
+            'A daemon task is required for the cron and both triggers. Provide one via ' +
+              '--task, the AFK_DAEMON_TASK env var, or daemon.task in afk.config.json.',
+          ),
+        );
+      }
       // pull mode: no cron expression needed — tasks are dequeued from the queue directory
 
       let thinking: ThinkingConfig | undefined;
@@ -318,8 +329,11 @@ export function registerDaemonCommand(program: Command): void {
       };
 
       // In pull mode, the task queue is file-driven — no ScheduledTask registered.
-      // For all other trigger modes, register the default task.
-      const tasks: ScheduledTask[] = trigger === 'pull'
+      // For other trigger modes, register the default task only when one is
+      // actually configured: with an empty command the daemon runs just its
+      // persisted schedules + worktree-prune rather than fabricating a task.
+      // (cron/both with an empty task already errored above.)
+      const tasks: ScheduledTask[] = (trigger === 'pull' || command.trim() === '')
         ? []
         : [{
             taskId,

--- a/src/cli/daemon-options.test.ts
+++ b/src/cli/daemon-options.test.ts
@@ -160,8 +160,8 @@ describe('resolveDefaultTask', () => {
     expect(resolveDefaultTask(undefined, undefined, '')).toBe(COMPILED_DEFAULT_TASK);
   });
 
-  it('frozen-default guard: COMPILED_DEFAULT_TASK is "/forge-friction --auto"', () => {
-    expect(COMPILED_DEFAULT_TASK).toBe('/forge-friction --auto');
+  it('default guard: COMPILED_DEFAULT_TASK is empty (daemon fabricates no task)', () => {
+    expect(COMPILED_DEFAULT_TASK).toBe('');
   });
 });
 

--- a/src/cli/daemon-options.ts
+++ b/src/cli/daemon-options.ts
@@ -89,10 +89,15 @@ export function resolveTriggerMode(
 }
 
 /**
- * Compiled-in default daemon task slash command. Used when no flag, env
- * var, or config value is provided.
+ * Compiled-in default daemon task slash command.
+ *
+ * Empty by design: the daemon must not fabricate a task when the user
+ * configured none. Supply a task via --task, the AFK_DAEMON_TASK env var, or
+ * `daemon.task` in afk.config.json; the cron and both triggers require one
+ * (enforced in registerDaemonCommand). This previously defaulted to an
+ * internal-only skill, which a build lacking that skill could not run.
  */
-export const COMPILED_DEFAULT_TASK = '/forge-friction --auto';
+export const COMPILED_DEFAULT_TASK = '';
 
 /**
  * Compiled-in default daemon task ID. Used when no flag, env var, or


### PR DESCRIPTION
## What

The daemon's compiled-in default task was `/forge-friction --auto` — a skill not registered in this build. When `afk daemon` ran with **no** task configured (`--task`, `AFK_DAEMON_TASK`, or `daemon.task`), it fell back to that command and dispatched it via `session.sendMessage` on every scheduled tick → a confused/no-op model run (the skill isn't in the manifest) that burns the turn + tokens. Latent since the initial release; reachable e.g. via `afk daemon --cron "…"` with no `--task`.

## Fix

- **`COMPILED_DEFAULT_TASK` is now empty** — the daemon never fabricates a task.
- **cron / both triggers error clearly** when no task is configured ("A daemon task is required for the cron and both triggers. Provide one via --task, AFK_DAEMON_TASK, or daemon.task…"). These triggers already require `--cron`; scheduling a tick with nothing to run is a user mistake worth surfacing.
- **sessionstart with no task** registers no default task and proceeds — the daemon still runs persisted schedules + the built-in worktree-prune.
- `--task` help text no longer advertises an internal default.

Behavior is **unchanged** whenever a task is supplied via flag/env/config.

## Why this design

A daemon shouldn't invent an unrequested scheduled task, and it certainly shouldn't reference a skill the build can't run. Empty-default + fail-fast-on-cron is the correct, build-agnostic behavior and is forward-compatible with moving the self-improvement loop's task into config/a plugin.

## Tests

- Updated the "no flags" integration test → asserts the fabricated `default` task is **absent** (keyed on `taskId === COMPILED_DEFAULT_TASK_ID`, robust to any persisted schedules on the machine).
- Updated the cron-trigger test to supply a task; added a test that **`--cron` with no task errors**.
- Updated the `COMPILED_DEFAULT_TASK` value guard.
- `tsc --noEmit` clean; daemon suites green (1217 tests across `src/agent/daemon/**` + `src/cli/commands/**`).

## Out of scope (follow-ups)

- The `routing-directive.ts` `pendingBriefContext()` `/forge` nudge is a separate, **dormant** coupling (only fires when the briefs dir is non-empty, which only the internal loop produces) — left for the broader extraction/hygiene pass.
- Cosmetic `/forge-friction --auto` example strings remain in some daemon test fixtures / JSDoc (generic command examples; not dependent on the default).
