### PR TITLE
fix(cli): width-cap the markdown message-fallback render path

### DIFF
--- a/src/cli/_lib/stream-renderer-emit-width.test.ts
+++ b/src/cli/_lib/stream-renderer-emit-width.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression tests for emitMarkdown width-capping.
+ *
+ * emitMarkdown is the fallback render path used when a `message` event arrives
+ * with no active streaming renderer (cached/non-incremental responses) and on
+ * non-TTY surfaces. It previously called renderMarkdownToTerminal(text) with no
+ * maxWidth, so wide tables rendered at their natural width and overflowed past
+ * the right edge on any terminal narrower than the table (and never reflowed on
+ * resize, because the lines are already committed to scrollback). These tests
+ * lock the fix: on a TTY the output is capped to the visible content width;
+ * piped/non-TTY output stays full-width.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { emitMarkdown } from './stream-renderer-orchestrator-emit.js';
+import { displayWidth } from '../display.js';
+import type { Writer } from '../slash/types.js';
+
+function captureWriter(): { lines: string[]; out: Writer } {
+  const lines: string[] = [];
+  const out: Writer = {
+    line: (text = '') => lines.push(text),
+    raw: (text) => lines.push(text),
+    success: (text) => lines.push(text),
+    info: (text) => lines.push(text),
+    warn: (text) => lines.push(text),
+    error: (text) => lines.push(text),
+  };
+  return { lines, out };
+}
+
+const WIDE_TABLE = [
+  '| Column One Header | Column Two Header | Column Three Header |',
+  '| --- | --- | --- |',
+  '| alpha value here | beta value here | gamma value here too |',
+  '| delta value here | epsilon value here | zeta value here also |',
+].join('\n');
+
+describe('emitMarkdown width capping', () => {
+  const origColumns = Object.getOwnPropertyDescriptor(process.stdout, 'columns');
+  const origIsTTY = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+
+  afterEach(() => {
+    if (origColumns) Object.defineProperty(process.stdout, 'columns', origColumns);
+    if (origIsTTY) Object.defineProperty(process.stdout, 'isTTY', origIsTTY);
+  });
+
+  function stubTerminal(isTTY: boolean, columns: number): void {
+    Object.defineProperty(process.stdout, 'isTTY', { value: isTTY, configurable: true });
+    Object.defineProperty(process.stdout, 'columns', { value: columns, configurable: true });
+  }
+
+  it('caps every emitted line to the content width on a TTY', () => {
+    stubTerminal(true, 40);
+    const { lines, out } = captureWriter();
+    emitMarkdown(WIDE_TABLE, out);
+
+    expect(lines.length).toBeGreaterThan(0);
+    // contentWidth budget is terminal − 2 = 38. No emitted line may exceed it.
+    for (const line of lines) {
+      expect(displayWidth(line)).toBeLessThanOrEqual(38);
+    }
+  });
+
+  it('breaks an over-long bare token instead of overflowing on a TTY', () => {
+    stubTerminal(true, 40);
+    const { lines, out } = captureWriter();
+    emitMarkdown('See https://example.com/' + 'x'.repeat(80), out);
+
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      expect(displayWidth(line)).toBeLessThanOrEqual(38);
+    }
+  });
+
+  it('leaves output full-width off a TTY (piped/redirected)', () => {
+    stubTerminal(false, 40);
+    const { lines, out } = captureWriter();
+    emitMarkdown(WIDE_TABLE, out);
+
+    // Non-TTY preserves the historical behavior: the table renders at its
+    // natural width, so at least one row exceeds the 38-col TTY budget.
+    expect(lines.some((line) => displayWidth(line) > 38)).toBe(true);
+  });
+});

--- a/src/cli/_lib/stream-renderer-orchestrator-emit.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator-emit.ts
@@ -10,6 +10,8 @@ import type { Writer } from '../slash/types.js';
 import type { CardSpec } from '../render.js';
 import { card, errorBox } from '../render.js';
 import { renderMarkdownToTerminal } from '../formatter.js';
+import { getTerminalWidth } from '../terminal-size.js';
+import { wrapToWidth } from '../wrap.js';
 import { formatThoughtSummary } from '../commands/interactive/thinking-lane.js';
 import { commitBlockAbove } from './commit-block.js';
 
@@ -286,8 +288,23 @@ export function finalizeOrchestrator(
  * content streaming.
  */
 export function emitMarkdown(text: string, out: Writer): void {
-  const rendered = renderMarkdownToTerminal(text);
-  for (const line of rendered.split('\n')) {
+  // History: this fallback rendered with renderMarkdownToTerminal(text) and NO
+  // maxWidth, so the table formatter used +Infinity — rows emitted at their
+  // natural width overflowed past the right edge on any terminal narrower than
+  // the table, and never reflowed on resize (the lines are already committed to
+  // scrollback). The streaming commit path was always width-capped; this aligns
+  // the fallback with it. On a TTY, cap to the visible content width (matching
+  // calculateContentWidth = terminal − 2) so tables are squeezed/truncated and
+  // prose is wrapped, breaking over-long tokens (URLs, long identifiers) that a
+  // raw-line sink would otherwise let run off the edge. Off a TTY (piped /
+  // redirected) keep the width unbounded so consumers receive full-width
+  // markdown — the prior behavior.
+  const contentWidth = process.stdout.isTTY
+    ? Math.max(1, getTerminalWidth() - 2)
+    : Number.POSITIVE_INFINITY;
+  const rendered = renderMarkdownToTerminal(text, { maxWidth: contentWidth });
+  const wrapped = wrapToWidth(rendered, contentWidth, { breakLongWords: true });
+  for (const line of wrapped.split('\n')) {
     out.line(line);
   }
 }

--- a/src/cli/wrap.test.ts
+++ b/src/cli/wrap.test.ts
@@ -33,4 +33,33 @@ describe('wrapToWidth', () => {
     expect(() => wrapToWidth('abc', Number.NaN)).not.toThrow();
     expect(wrapToWidth('abc', Number.NaN)).toBe('abc');
   });
+
+  it('leaves an over-long unbreakable token intact by default (soft wrap)', () => {
+    const url = 'https://example.com/' + 'a'.repeat(60);
+    const out = wrapToWidth(url, 20);
+    // Soft wrap: the single long token overflows past `width` on one line.
+    expect(out).toBe(url);
+    expect(out.split('\n')).toHaveLength(1);
+  });
+
+  it('breaks an over-long unbreakable token when breakLongWords is set', () => {
+    const url = 'https://example.com/' + 'a'.repeat(60);
+    const out = wrapToWidth(url, 20, { breakLongWords: true });
+    const lines = out.split('\n');
+    expect(lines.length).toBeGreaterThan(1);
+    // No physical line exceeds the width once long words are broken.
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it('breakLongWords still wraps normal prose at word boundaries (no mid-word splits)', () => {
+    const prose = 'one two three four five six seven eight nine ten';
+    const out = wrapToWidth(prose, 12, { breakLongWords: true });
+    // Every whole word survives un-split — only over-long tokens are broken.
+    for (const word of prose.split(' ')) {
+      expect(out).toContain(word);
+    }
+    expect(out.split('\n').length).toBeGreaterThan(1);
+  });
 });

--- a/src/cli/wrap.ts
+++ b/src/cli/wrap.ts
@@ -11,8 +11,17 @@ import wrapAnsi from 'wrap-ansi';
  *
  * @param text  - Source string (may include chalk / ANSI codes).
  * @param width - Target column width; non-finite or ≤0 returns `text` unchanged.
+ * @param opts.breakLongWords - When true, a single token longer than `width` is
+ *   broken at the column boundary instead of overflowing past it. Default false
+ *   (soft word-wrap, the historical behavior). Set this for any sink that paints
+ *   raw lines with no terminal CUP re-wrap, so a bare URL / long identifier
+ *   cannot run off the right edge. Normal words (≤ width) wrap identically.
  */
-export function wrapToWidth(text: string, width: number): string {
+export function wrapToWidth(
+  text: string,
+  width: number,
+  opts: { breakLongWords?: boolean } = {},
+): string {
   if (!Number.isFinite(width) || width <= 0) {
     return text;
   }
@@ -21,7 +30,7 @@ export function wrapToWidth(text: string, width: number): string {
   }
   const w = Math.floor(width);
   return wrapAnsi(text, w, {
-    hard: false,
+    hard: opts.breakLongWords ?? false,
     trim: false,
     wordWrap: true,
   });


### PR DESCRIPTION
## Summary
- **Bug:** assistant text sometimes rendered off-screen on the right; resizing didn't fix it and made it worse.
- **Root cause:** `emitMarkdown` (`src/cli/_lib/stream-renderer-orchestrator-emit.ts`) — the fallback render path used when a `message` arrives with no prior streamed deltas, and on non-TTY — called `renderMarkdownToTerminal(text)` with **no `maxWidth`**, so the table formatter fell through to `+Infinity` (`formatter.ts:356,360`) and skipped squeezing/truncation entirely. Rows emitted at natural width overflowed the right edge, and since committed lines are immutable scrollback they never reflow on resize (the resize bus only repaints the live overlay). The streaming commit path was always width-capped, which is why it was only "sometimes."
- **Fix:** TTY-gated width cap in `emitMarkdown` (`terminal - 2`, matching the streaming path's `calculateContentWidth`). Off a TTY (piped/redirected) width stays unbounded so downstream consumers get full-width markdown — prior behavior preserved.
- Adds opt-in `breakLongWords` to `wrapToWidth` so an over-long token (bare URL, long identifier) breaks at the column boundary instead of overflowing, without mid-word-splitting normal prose (toggles wrap-ansi's `hard` flag only; `wordWrap` stays true).

## Test results
- `pnpm lint` (tsc --noEmit, strict): **passed**
- `pnpm test` (full suite): **10164 passed / 14 skipped**; the only 2 failures are pre-existing, environment-only, and unrelated to this change (`config.test.ts` model-slot bindings, `anthropic-direct.test.ts` compact model-id) — neither in a file this PR touches.
- Targeted: `wrap` / `formatter` / `markdown-stream-format` / `markdown-stream` / `stream-renderer-emit-width` = **152 passed**. New coverage: `breakLongWords` cases in `wrap.test.ts` plus new `stream-renderer-emit-width.test.ts` (TTY caps every line, breaks bare long tokens, non-TTY stays full-width).

## Verification
Adversarial re-derivation from the diff alone (read-only sub-agent, no access to the commit's reasoning):
- **CLAIM 1** (pre-change: absent `maxWidth` -> `maxTableWidth=undefined` -> `targetWidth=+Infinity` -> squeeze block skipped via the `Number.isFinite` guard) — **CONFIRM** (`formatter.ts:129,356,360`).
- **CLAIM 2** (after: cap only when `process.stdout.isTTY`, else `+Infinity` leaves output unchanged) — **CONFIRM** (`orchestrator-emit.ts` + `wrap.ts:21`).
- **CLAIM 3** (`breakLongWords` toggles only `hard`; `wordWrap` stays true -> normal prose wraps identically) — **CONFIRM** (`wrap.ts:33`).
- No regressions; streaming path (`commitBlockAbove`) untouched; `Math.max(1, ...)` guards zero/negative width. Verdict: **SOUND**.

## Out of scope
- Already-committed scrollback never reflows on resize — inherent to the line-committing renderer (would need a full-screen redraw model). This PR prevents the over-wide emit at commit time on the fallback path rather than retroactively re-flowing history.
