### PR TITLE
fix(tool-lane): surface most-recent tool-groups instead of burying them in overflow

### DIFF
--- a/src/cli/commands/interactive/__snapshots__/tool-lane.test.ts.snap
+++ b/src/cli/commands/interactive/__snapshots__/tool-lane.test.ts.snap
@@ -19,9 +19,9 @@ exports[`Snapshot pins — tool-lane-render.ts representative outputs > scenario
 
 exports[`Snapshot pins — tool-lane-render.ts representative outputs > scenario 5 — subagent Agent entry with overflow (4 children, MAX=3) 1`] = `
 "◉ → Agent(snap-overflower) [subagent] — 4 tools
-│ ├─ ● Read("snap0.ts") — ✓ snap-result-0
+│ ├─ … +1 (1 Read)
 │ ├─ $ Bash("snap1.ts") — ✓ snap-result-1
 │ ├─ ● Grep("snap2.ts") — ✓ snap-result-2
-│ ├─ … +1 (1 Glob)
+│ ├─ ● Glob("snap3.ts") — ✓ snap-result-3
 │ ╰─ Done (4 tools · 4.0s)"
 `;

--- a/src/cli/commands/interactive/tool-lane-render-grouping-overflow.ts
+++ b/src/cli/commands/interactive/tool-lane-render-grouping-overflow.ts
@@ -18,12 +18,25 @@ export interface OverflowSibling {
 }
 
 /**
- * If `siblings.length > maxVisible`, returns the first `maxVisible` siblings
- * followed by a single synthetic {@link OverflowSibling} representing the
- * hidden remainder. Otherwise returns `siblings` unchanged.
+ * Recency window. If `siblings.length > maxVisible`, returns a single leading
+ * synthetic {@link OverflowSibling} (summarizing the OLDER head) followed by
+ * the MOST-RECENT `maxVisible` siblings, in dispatch order. Otherwise returns
+ * `siblings` unchanged.
  *
- * The overflow synthetic obeys `assignConnectors`'s last-child rule just like
- * any real sibling — it is added to the list BEFORE `assignConnectors` runs.
+ * History: siblings arrive in first-occurrence (chronological) order, so the
+ * tail is the most recent activity — including the file mutations that
+ * typically land late in a run. The pre-fix `slice(0, maxVisible)` kept the
+ * OLDEST groups and collapsed the newest into the "+N" line, burying exactly
+ * the recent work a watcher most wants to see (reported UX bug:
+ * fix-tool-recency-display). Switching to the tail surfaces it; placing the
+ * overflow FIRST keeps the block readable top→bottom — "… +N older", then the
+ * newest groups — instead of inverting the timeline against the footnote.
+ *
+ * The overflow synthetic obeys `assignConnectors`'s positional rule like any
+ * real sibling — it is added to the list BEFORE `assignConnectors` runs. As
+ * the FIRST sibling it now receives the MID connector (`├`); the last visible
+ * group (overlay path) or the appended result-summary (flush path) keeps the
+ * LAST connector (`└`), so the exactly-one-last-child invariant is preserved.
  *
  * Accepts only real tool / grouped siblings (not overflow or resultSummary
  * synthetics) — those are added after this step.
@@ -33,10 +46,11 @@ export function addOverflowSynthetic(
   maxVisible: number,
 ): Array<ToolEntry | GroupedSibling | OverflowSibling> {
   if (siblings.length <= maxVisible) return siblings;
-  const visible = siblings.slice(0, maxVisible);
-  const hidden = siblings.slice(maxVisible);
+  const splitAt = siblings.length - maxVisible;
+  const hidden = siblings.slice(0, splitAt);
+  const visible = siblings.slice(splitAt);
   const text = formatCategoricalOverflow(hidden);
-  return [...visible, { kind: 'overflow', count: hidden.length, text }];
+  return [{ kind: 'overflow', count: hidden.length, text }, ...visible];
 }
 
 /**

--- a/src/cli/commands/interactive/tool-lane.test.ts
+++ b/src/cli/commands/interactive/tool-lane.test.ts
@@ -343,16 +343,19 @@ describe('ToolLane.upsertTextChild / removeTextChildrenUnder', () => {
   it('categorical overflow lists tool-name buckets when the visible budget overflows', () => {
     const lane = new ToolLane();
     lane.addStartWithAgentContext('synth-A', 'Agent', '(researcher)', undefined);
+    // Recency window keeps the most-recent 3 visible; the OLDER head collapses
+    // into the overflow line. Dispatch the intended-hidden pair (Write, Glob)
+    // FIRST so they land in the older head.
+    lane.addStartWithAgentContext('t-4', 'Write', '("c.ts")', 'synth-A');
+    lane.addResult('t-4', makeResult('1 line'));
+    lane.addStartWithAgentContext('t-5', 'Glob', '("**/*")', 'synth-A');
+    lane.addResult('t-5', makeResult('1 line'));
     lane.addStartWithAgentContext('t-1', 'Read', '("a.ts")', 'synth-A');
     lane.addResult('t-1', makeResult('1 line'));
     lane.addStartWithAgentContext('t-2', 'Bash', '("ls")', 'synth-A');
     lane.addResult('t-2', makeResult('1 line'));
     lane.addStartWithAgentContext('t-3', 'Grep', '("foo")', 'synth-A');
     lane.addResult('t-3', makeResult('1 line'));
-    lane.addStartWithAgentContext('t-4', 'Write', '("c.ts")', 'synth-A');
-    lane.addResult('t-4', makeResult('1 line'));
-    lane.addStartWithAgentContext('t-5', 'Glob', '("**/*")', 'synth-A');
-    lane.addResult('t-5', makeResult('1 line'));
     lane.addResult('synth-A', makeResult('done'));
 
     const overlay = stripAnsi(lane.getOverlay());
@@ -371,19 +374,21 @@ describe('ToolLane.upsertTextChild / removeTextChildrenUnder', () => {
   // (sh|ch|x|z + already-`s`) keeps these names invariant.
   it('categorical overflow keeps sibilant-cluster names invariant when n > 1', () => {
     // Hidden = [bash, bash] (2 instances, below GROUP_THRESHOLD_LEAF=3, so
-    // they appear individually and land in the categorical bucket).
+    // they appear individually and land in the categorical bucket). Recency
+    // window keeps the newest 3 visible, so dispatch the 2 bash calls FIRST
+    // (oldest) to land them in the collapsed older head.
     const lane = new ToolLane();
     lane.addStartWithAgentContext('parent', 'Agent', '(tester)', undefined);
+    lane.addStartWithAgentContext('b1', 'bash', '("ls")', 'parent');
+    lane.addResult('b1', makeResult('ok'));
+    lane.addStartWithAgentContext('b2', 'bash', '("pwd")', 'parent');
+    lane.addResult('b2', makeResult('ok'));
     lane.addStartWithAgentContext('r1', 'Read', '("a.ts")', 'parent');
     lane.addResult('r1', makeResult('ok'));
     lane.addStartWithAgentContext('g1', 'Grep', '("TODO")', 'parent');
     lane.addResult('g1', makeResult('ok'));
     lane.addStartWithAgentContext('glob1', 'Glob', '("**/*")', 'parent');
     lane.addResult('glob1', makeResult('ok'));
-    lane.addStartWithAgentContext('b1', 'bash', '("ls")', 'parent');
-    lane.addResult('b1', makeResult('ok'));
-    lane.addStartWithAgentContext('b2', 'bash', '("pwd")', 'parent');
-    lane.addResult('b2', makeResult('ok'));
     lane.addResult('parent', makeResult('done'));
 
     const overlay = stripAnsi(lane.getOverlay());
@@ -898,10 +903,10 @@ describe('Bug #5 — agentResultSummary must use └ tree connector and appear a
     // single-glyph toContain. Populated by `pnpm test -u` on first run.
     expect(stripped).toMatchInlineSnapshot(`
       "◉ → Agent(overflow-tester) [subagent] — 4 tools
-      │ ├─ ● Read("file0.ts") — ✓ result0
+      │ ├─ … +1 (1 Read)
       │ ├─ $ Bash("file1.ts") — ✓ result1
       │ ├─ ● Grep("file2.ts") — ✓ result2
-      │ ├─ … +1 (1 Glob)
+      │ ├─ ● Glob("file3.ts") — ✓ result3
       │ ╰─ Done (4 tools · 2.5s)"
     `);
   });
@@ -1014,15 +1019,36 @@ describe('assignConnectors — property tests', () => {
     }
   });
 
-  it('overflow synthetic as last item → gets ╰─  connector', () => {
+  it('overflow synthetic as FIRST item → gets ├─ ; last visible group gets ╰─ ', () => {
     const siblings = Array.from({ length: 5 }, (_, i) => makeToolSibling(i));
-    // addOverflowSynthetic with maxVisible=3: first 3 + overflow
+    // Recency window (maxVisible=3): leading overflow (older head) + most-recent 3.
     const withOverflow = addOverflowSynthetic(siblings, 3);
     const connected = assignConnectors(withOverflow);
 
+    // Overflow now LEADS the list (summarizes the older head) → MID connector.
+    const firstItem = connected[0]!;
+    expect(firstItem.sibling.kind).toBe('overflow');
+    expect(firstItem.connector).toBe('├─ ');
+
+    // A real visible group is now last → keeps the LAST connector.
     const lastItem = connected[connected.length - 1]!;
-    expect(lastItem.sibling.kind).toBe('overflow');
+    expect(lastItem.sibling.kind).toBe('tool');
     expect(lastItem.connector).toBe('╰─ ');
+  });
+
+  it('addOverflowSynthetic keeps the most-recent maxVisible (tail) and leads with overflow', () => {
+    const siblings = Array.from({ length: 5 }, (_, i) => makeToolSibling(i)); // t0..t4
+    const result = addOverflowSynthetic(siblings, 3);
+    expect(result).toHaveLength(4); // leading overflow + 3 visible
+    expect(result[0]!.kind).toBe('overflow');
+    // Visible tail = the 3 MOST-RECENT siblings, preserving dispatch order.
+    const visibleIds = result
+      .slice(1)
+      .map((s) => (s.kind === 'tool' ? s.toolUseId : undefined));
+    expect(visibleIds).toEqual(['t2', 't3', 't4']);
+    // The leading overflow summarizes the older head (t0, t1).
+    const overflow = result[0]!;
+    expect(overflow.kind === 'overflow' && overflow.count).toBe(2);
   });
 
   it('resultSummary synthetic as last item → gets ╰─  connector', () => {
@@ -1035,18 +1061,18 @@ describe('assignConnectors — property tests', () => {
     expect(lastItem.connector).toBe('╰─ ');
   });
 
-  it('overflow before resultSummary: overflow gets ├─ , resultSummary gets ╰─ ', () => {
+  it('overflow (first) gets ├─ , resultSummary (last) gets ╰─ ', () => {
     const siblings = Array.from({ length: 5 }, (_, i) => makeToolSibling(i));
     const withOverflow = addOverflowSynthetic(siblings, 3);
     const withSummary = addResultSummarySynthetic(withOverflow, 'Done (5 tools · 2.0s)');
     const connected = assignConnectors(withSummary);
 
-    // Second-to-last is overflow
-    const overflowItem = connected[connected.length - 2]!;
+    // Overflow now LEADS the list (older-head summary) → MID connector.
+    const overflowItem = connected[0]!;
     expect(overflowItem.sibling.kind).toBe('overflow');
     expect(overflowItem.connector).toBe('├─ ');
 
-    // Last is resultSummary
+    // resultSummary remains the appended LAST sibling.
     const summaryItem = connected[connected.length - 1]!;
     expect(summaryItem.sibling.kind).toBe('resultSummary');
     expect(summaryItem.connector).toBe('╰─ ');
@@ -1085,65 +1111,63 @@ describe('formatCategoricalOverflow — label-aware dispatch overflow', () => {
     lane.addResult('parent', makeResult('done'));
 
     const overlay = stripAnsi(lane.getOverlay());
-    // MAX_VISIBLE_CHILDREN = 3, so pr1–pr3 are visible, pr4–pr6 hidden.
-    // Overflow line: … +3 more: pr4, pr5, pr6
-    expect(overlay).toMatch(/… \+3 more: pr4, pr5, pr6/);
+    // Recency window: MAX_VISIBLE_CHILDREN = 3 keeps the MOST-RECENT pr4–pr6
+    // visible; the older pr1–pr3 collapse into the leading overflow line.
+    // Overflow line: … +3 more: pr1, pr2, pr3
+    expect(overlay).toMatch(/… \+3 more: pr1, pr2, pr3/);
     // The label-list must NOT collapse to a categorical bucket
     expect(overlay).not.toMatch(/\+3 \(/);
   });
 
   it('4 distinct leaf tools → categorical overflow shows pluralized names', () => {
-    // 4 different leaf tool names under one Agent:
-    // Read, Bash, Grep, Glob → Read visible (pos 1), Bash (pos 2), Grep (pos 3),
-    // Glob hidden → +1 (1 Glob). n=1 so no pluralization (correct).
-    // To see pluralization we need more: 3 visible + 2 hidden (same tool name).
-    // Use: Read, Bash, Grep all at n=1 (individual), plus 2 hidden Writes.
-    // But leaf threshold = 3 → 2 Writes don't group. They appear as 2 siblings.
-    // So: Read (1), Bash (1), Grep (1), Write (2 individuals) = 5 siblings.
-    // MAX_VISIBLE=3 → 3 visible, 2 hidden. Hidden: [Write1, Write2].
-    // formatCategoricalOverflow({Write, Write}) → allDispatch=false → categorical
-    // → "… +2 (2 Writes)" (Write ends in 'e' not 's' → pluralizes to 'Writes').
+    // Recency window keeps the MOST-RECENT 3 visible and collapses the OLDER
+    // head, so the items we want hidden (the 2 Writes) must be dispatched
+    // FIRST. Order: Write, Write (oldest), then Read, Bash, Grep (newest 3).
+    // Leaf threshold = 3 → 2 Writes don't group; they appear as 2 siblings,
+    // both in the older head. 5 siblings, MAX_VISIBLE=3 → 3 visible, 2 hidden.
+    // Hidden: [Write1, Write2]. formatCategoricalOverflow({Write, Write}) →
+    // allDispatch=false → categorical → "… +2 (2 Writes)" (Write ends in 'e'
+    // not 's' → pluralizes to 'Writes').
     const lane = new ToolLane();
     lane.addStartWithAgentContext('parent', 'Agent', '(tester)', undefined);
+    lane.addStartWithAgentContext('w1', 'Write', '("x.ts")', 'parent');
+    lane.addResult('w1', makeResult('ok'));
+    lane.addStartWithAgentContext('w2', 'Write', '("y.ts")', 'parent');
+    lane.addResult('w2', makeResult('ok'));
     lane.addStartWithAgentContext('r1', 'Read', '("a.ts")', 'parent');
     lane.addResult('r1', makeResult('ok'));
     lane.addStartWithAgentContext('b1', 'Bash', '("ls")', 'parent');
     lane.addResult('b1', makeResult('ok'));
     lane.addStartWithAgentContext('g1', 'Grep', '("TODO")', 'parent');
     lane.addResult('g1', makeResult('ok'));
-    lane.addStartWithAgentContext('w1', 'Write', '("x.ts")', 'parent');
-    lane.addResult('w1', makeResult('ok'));
-    lane.addStartWithAgentContext('w2', 'Write', '("y.ts")', 'parent');
-    lane.addResult('w2', makeResult('ok'));
     lane.addResult('parent', makeResult('done'));
 
     const overlay = stripAnsi(lane.getOverlay());
-    // Hidden: Write ×2 → "… +2 (2 Writes)"
+    // Hidden (older head): Write ×2 → "… +2 (2 Writes)"
     expect(overlay).toMatch(/… \+2 \(2 Writes\)/);
     // Must not use the label-aware path (Write is not dispatch-class)
     expect(overlay).not.toMatch(/more:/);
   });
 
   it('mixed dispatch + leaf hidden → categorical fallback (heterogeneous)', () => {
-    // 2 Agent + 2 bash hidden → allDispatch=false → categorical bucket path.
-    // Set up 5 visible children to guarantee the hidden slice is mixed.
-    // MAX_VISIBLE=3: use Read, Bash, Grep visible (3), then Agent1, Agent2 hidden.
-    // But wait — Agent siblings with distinct labels won't group. We need exactly
-    // 2 hidden items that are mixed (1 Agent + 1 bash).
-    // Layout: Read, Bash, Grep visible; Agent(pr1), bash("cmd") hidden.
+    // A mixed (1 Agent + 1 bash) HIDDEN slice → allDispatch=false → categorical.
+    // Recency window collapses the OLDER head, so the mixed pair must be
+    // dispatched FIRST: Agent(pr1), bash (oldest, → hidden), then Read, Bash,
+    // Grep (newest 3, → visible). 5 siblings, MAX_VISIBLE=3 → 2 hidden.
     const lane = new ToolLane();
     lane.addStartWithAgentContext('parent', 'Agent', '(outer)', undefined);
+    // Older head (becomes hidden): 1 Agent + 1 bash → heterogeneous.
+    lane.addStartWithAgentContext('inner-agent', 'Agent', '(pr1)', 'parent');
+    lane.addResult('inner-agent', makeResult('done'));
+    lane.addStartWithAgentContext('b2', 'bash', '("cmd")', 'parent');
+    lane.addResult('b2', makeResult('ok'));
+    // Most-recent 3 (stay visible):
     lane.addStartWithAgentContext('r1', 'Read', '("a.ts")', 'parent');
     lane.addResult('r1', makeResult('ok'));
     lane.addStartWithAgentContext('b1', 'Bash', '("ls")', 'parent');
     lane.addResult('b1', makeResult('ok'));
     lane.addStartWithAgentContext('g1', 'Grep', '("TODO")', 'parent');
     lane.addResult('g1', makeResult('ok'));
-    // Now the hidden ones (beyond MAX_VISIBLE=3):
-    lane.addStartWithAgentContext('inner-agent', 'Agent', '(pr1)', 'parent');
-    lane.addResult('inner-agent', makeResult('done'));
-    lane.addStartWithAgentContext('b2', 'bash', '("cmd")', 'parent');
-    lane.addResult('b2', makeResult('ok'));
     lane.addResult('parent', makeResult('done'));
 
     const overlay = stripAnsi(lane.getOverlay());
@@ -1166,8 +1190,9 @@ describe('formatCategoricalOverflow — label-aware dispatch overflow', () => {
     lane.addResult('parent', makeResult('done'));
 
     const overlay = stripAnsi(lane.getOverlay());
-    // 9 children, MAX_VISIBLE=3, hidden=6. LABEL_LIST_CAP=5, so shows 5 labels + (+1).
-    expect(overlay).toMatch(/… \+6 more: pr4, pr5, pr6, pr7, pr8 \(\+1\)/);
+    // 9 children, MAX_VISIBLE=3 keeps newest pr7–pr9 visible; older pr1–pr6
+    // collapse (hidden=6). LABEL_LIST_CAP=5 → shows pr1–pr5 + (+1) for pr6.
+    expect(overlay).toMatch(/… \+6 more: pr1, pr2, pr3, pr4, pr5 \(\+1\)/);
   });
 
   it('getGroupKey invariant: different Agent labels do NOT merge (existing invariant preserved)', () => {
@@ -1206,16 +1231,17 @@ describe('formatCategoricalOverflow — label-aware dispatch overflow', () => {
   // slice. The unmerged entry's toolName (`agent`/`skill`/`compose`) differs
   // from the merged entry's toolName (`Agent`) — heterogeneous → categorical.
   it('hidden slice mixing merged Agent + unmerged agent → categorical fallback', () => {
-    // 5 agent dispatches, 4 merged + 1 still pre-merge. Visible 1-3, hidden 4-5.
-    // Hidden = [Agent(pr4) merged, agent(' …') unmerged]. Both in NESTING_TOOLS
-    // but different toolNames → heterogeneous → categorical.
+    // 5 agent dispatches, 4 merged + 1 still pre-merge. Recency window keeps the
+    // newest 3 visible; the older head (oldest 2) collapses. Dispatch the
+    // pre-merge 'agent' FIRST so the hidden slice mixes it with a merged
+    // 'Agent' → different toolNames → heterogeneous → categorical.
     const lane = new ToolLane();
     lane.addStartWithAgentContext('parent', 'skill', '(compose)', undefined);
+    // Pre-merge entry — literal placeholder from translate.ts (oldest → hidden).
+    lane.addStartWithAgentContext('agent-5', 'agent', ' …', 'parent');
     for (let i = 1; i <= 4; i++) {
       lane.addStartWithAgentContext(`agent-${i}`, 'Agent', `(pr${i})`, 'parent');
     }
-    // Pre-merge entry — literal placeholder from translate.ts.
-    lane.addStartWithAgentContext('agent-5', 'agent', ' …', 'parent');
 
     const overlay = stripAnsi(lane.getOverlay());
     // Must NOT render ellipsis or empty strings as labels.
@@ -1232,6 +1258,12 @@ describe('formatCategoricalOverflow — label-aware dispatch overflow', () => {
     // ' …', which must NOT be emitted as a label.
     const lane = new ToolLane();
     lane.addStartWithAgentContext('parent', 'skill', '(compose)', undefined);
+    // 2 unmerged agents with shared ' …' toolInput → collapse to one group
+    // (GROUP_THRESHOLD_DISPATCH=2). Dispatch FIRST so the group lands in the
+    // collapsed older head; the 3 newest leaf entries stay visible.
+    for (let i = 1; i <= 2; i++) {
+      lane.addStartWithAgentContext(`agent-${i}`, 'agent', ' …', 'parent');
+    }
     // 3 visible leaf entries (Read/Bash/Grep — distinct names, no grouping).
     lane.addStartWithAgentContext('r1', 'Read', '("a.ts")', 'parent');
     lane.addResult('r1', makeResult('ok'));
@@ -1239,11 +1271,6 @@ describe('formatCategoricalOverflow — label-aware dispatch overflow', () => {
     lane.addResult('b1', makeResult('ok'));
     lane.addStartWithAgentContext('g1', 'Grep', '("TODO")', 'parent');
     lane.addResult('g1', makeResult('ok'));
-    // 2 unmerged agents with shared ' …' toolInput → collapse to one group
-    // (GROUP_THRESHOLD_DISPATCH=2). Group lands at position 4 → hidden.
-    for (let i = 1; i <= 2; i++) {
-      lane.addStartWithAgentContext(`agent-${i}`, 'agent', ' …', 'parent');
-    }
 
     const overlay = stripAnsi(lane.getOverlay());
     // Must NOT render ' …' as a label.
@@ -1261,20 +1288,21 @@ describe('formatCategoricalOverflow — label-aware dispatch overflow', () => {
   it('heterogeneous dispatch (Agent + skill) hidden → categorical fallback', () => {
     const lane = new ToolLane();
     lane.addStartWithAgentContext('parent', 'compose', '(wave)', undefined);
-    // 3 visible Read/Bash/Grep, then 3 hidden mixed-dispatch items.
-    lane.addStartWithAgentContext('r1', 'Read', '("a.ts")', 'parent');
-    lane.addResult('r1', makeResult('ok'));
-    lane.addStartWithAgentContext('b1', 'Bash', '("ls")', 'parent');
-    lane.addResult('b1', makeResult('ok'));
-    lane.addStartWithAgentContext('g1', 'Grep', '("TODO")', 'parent');
-    lane.addResult('g1', makeResult('ok'));
-    // Hidden: 1 Agent + 2 skills — all in NESTING_TOOLS, but heterogeneous.
+    // Hidden (older head): 1 Agent + 2 skills — all NESTING_TOOLS, heterogeneous.
+    // Dispatch FIRST so they collapse; the 3 newest leaf tools stay visible.
     lane.addStartWithAgentContext('a1', 'Agent', '(pr1)', 'parent');
     lane.addResult('a1', makeResult('done'));
     lane.addStartWithAgentContext('s1', 'skill', '(forge)', 'parent');
     lane.addResult('s1', makeResult('done'));
     lane.addStartWithAgentContext('s2', 'skill', '(resolve)', 'parent');
     lane.addResult('s2', makeResult('done'));
+    // 3 most-recent Read/Bash/Grep stay visible.
+    lane.addStartWithAgentContext('r1', 'Read', '("a.ts")', 'parent');
+    lane.addResult('r1', makeResult('ok'));
+    lane.addStartWithAgentContext('b1', 'Bash', '("ls")', 'parent');
+    lane.addResult('b1', makeResult('ok'));
+    lane.addStartWithAgentContext('g1', 'Grep', '("TODO")', 'parent');
+    lane.addResult('g1', makeResult('ok'));
     lane.addResult('parent', makeResult('done'));
 
     const overlay = stripAnsi(lane.getOverlay());
@@ -1299,17 +1327,19 @@ describe('formatCategoricalOverflow — label-aware dispatch overflow', () => {
     // Post-fix output: `… +4 more: pr1 ×4` (entries explicit).
     const lane = new ToolLane();
     lane.addStartWithAgentContext('parent', 'skill', '(compose)', undefined);
+    // Same-label Agents collapse to one group (GROUP_THRESHOLD_DISPATCH=2).
+    // Dispatch FIRST so the group lands in the collapsed older head; the 3
+    // newest leaf tools stay visible.
+    for (let i = 1; i <= 4; i++) {
+      lane.addStartWithAgentContext(`a-${i}`, 'Agent', '(pr1)', 'parent');
+      lane.addResult(`a-${i}`, makeResult('done'));
+    }
     lane.addStartWithAgentContext('r1', 'Read', '("a.ts")', 'parent');
     lane.addResult('r1', makeResult('ok'));
     lane.addStartWithAgentContext('b1', 'Bash', '("ls")', 'parent');
     lane.addResult('b1', makeResult('ok'));
     lane.addStartWithAgentContext('g1', 'Grep', '("TODO")', 'parent');
     lane.addResult('g1', makeResult('ok'));
-    // Same-label Agents collapse to one group (GROUP_THRESHOLD_DISPATCH=2).
-    for (let i = 1; i <= 4; i++) {
-      lane.addStartWithAgentContext(`a-${i}`, 'Agent', '(pr1)', 'parent');
-      lane.addResult(`a-${i}`, makeResult('done'));
-    }
     lane.addResult('parent', makeResult('done'));
 
     const overlay = stripAnsi(lane.getOverlay());
@@ -1325,12 +1355,8 @@ describe('formatCategoricalOverflow — label-aware dispatch overflow', () => {
     // equals leading +5 with no trailing (+M).
     const lane = new ToolLane();
     lane.addStartWithAgentContext('parent', 'skill', '(compose)', undefined);
-    lane.addStartWithAgentContext('r1', 'Read', '("a.ts")', 'parent');
-    lane.addResult('r1', makeResult('ok'));
-    lane.addStartWithAgentContext('b1', 'Bash', '("ls")', 'parent');
-    lane.addResult('b1', makeResult('ok'));
-    lane.addStartWithAgentContext('g1', 'Grep', '("TODO")', 'parent');
-    lane.addResult('g1', makeResult('ok'));
+    // The agent dispatches are the intended hidden slice — dispatch FIRST so
+    // they collapse into the older head; the 3 newest leaf tools stay visible.
     // 3 same-label Agents → group of 3.
     for (let i = 1; i <= 3; i++) {
       lane.addStartWithAgentContext(`a-${i}`, 'Agent', '(pr1)', 'parent');
@@ -1341,6 +1367,12 @@ describe('formatCategoricalOverflow — label-aware dispatch overflow', () => {
     lane.addResult('a-x', makeResult('done'));
     lane.addStartWithAgentContext('a-y', 'Agent', '(pr3)', 'parent');
     lane.addResult('a-y', makeResult('done'));
+    lane.addStartWithAgentContext('r1', 'Read', '("a.ts")', 'parent');
+    lane.addResult('r1', makeResult('ok'));
+    lane.addStartWithAgentContext('b1', 'Bash', '("ls")', 'parent');
+    lane.addResult('b1', makeResult('ok'));
+    lane.addStartWithAgentContext('g1', 'Grep', '("TODO")', 'parent');
+    lane.addResult('g1', makeResult('ok'));
     lane.addResult('parent', makeResult('done'));
 
     const overlay = stripAnsi(lane.getOverlay());
@@ -1354,12 +1386,8 @@ describe('formatCategoricalOverflow — label-aware dispatch overflow', () => {
     // Output: `… +8 more: pr1 ×3, pr2, pr3, pr4, pr5 (+1)`.
     const lane = new ToolLane();
     lane.addStartWithAgentContext('parent', 'skill', '(compose)', undefined);
-    lane.addStartWithAgentContext('r1', 'Read', '("a.ts")', 'parent');
-    lane.addResult('r1', makeResult('ok'));
-    lane.addStartWithAgentContext('b1', 'Bash', '("ls")', 'parent');
-    lane.addResult('b1', makeResult('ok'));
-    lane.addStartWithAgentContext('g1', 'Grep', '("TODO")', 'parent');
-    lane.addResult('g1', makeResult('ok'));
+    // The agent dispatches are the intended hidden slice — dispatch FIRST so
+    // they collapse into the older head; the 3 newest leaf tools stay visible.
     // 3 same-label Agents → group of 3.
     for (let i = 1; i <= 3; i++) {
       lane.addStartWithAgentContext(`a-${i}`, 'Agent', '(pr1)', 'parent');
@@ -1370,6 +1398,12 @@ describe('formatCategoricalOverflow — label-aware dispatch overflow', () => {
       lane.addStartWithAgentContext(`a-${i}-uniq`, 'Agent', `(pr${i})`, 'parent');
       lane.addResult(`a-${i}-uniq`, makeResult('done'));
     }
+    lane.addStartWithAgentContext('r1', 'Read', '("a.ts")', 'parent');
+    lane.addResult('r1', makeResult('ok'));
+    lane.addStartWithAgentContext('b1', 'Bash', '("ls")', 'parent');
+    lane.addResult('b1', makeResult('ok'));
+    lane.addStartWithAgentContext('g1', 'Grep', '("TODO")', 'parent');
+    lane.addResult('g1', makeResult('ok'));
     lane.addResult('parent', makeResult('done'));
 
     const overlay = stripAnsi(lane.getOverlay());
@@ -1385,20 +1419,22 @@ describe('formatCategoricalOverflow — label-aware dispatch overflow', () => {
   it('label-aware overflow strips CR/LF/ESC control characters from labels', () => {
     const lane = new ToolLane();
     lane.addStartWithAgentContext('parent', 'skill', '(compose)', undefined);
-    // 6 distinct Agent labels — hidden = pr4, pr5, pr6 (3 rows).
+    // 6 distinct Agent labels — hidden (older head) = pr4, pr5, pr6 (3 rows).
+    // Recency window keeps the newest 3 visible, so dispatch the injected
+    // labels FIRST so they land in the collapsed (and sanitized) overflow line.
     // pr4 carries CR+LF; pr5 carries ANSI CSI sequence; pr6 is clean.
-    lane.addStartWithAgentContext('a-1', 'Agent', '(pr1)', 'parent');
-    lane.addResult('a-1', makeResult('done'));
-    lane.addStartWithAgentContext('a-2', 'Agent', '(pr2)', 'parent');
-    lane.addResult('a-2', makeResult('done'));
-    lane.addStartWithAgentContext('a-3', 'Agent', '(pr3)', 'parent');
-    lane.addResult('a-3', makeResult('done'));
     lane.addStartWithAgentContext('a-4', 'Agent', '(pr4\r\nINJECTED)', 'parent');
     lane.addResult('a-4', makeResult('done'));
     lane.addStartWithAgentContext('a-5', 'Agent', '(pr5\x1b[31mRED)', 'parent');
     lane.addResult('a-5', makeResult('done'));
     lane.addStartWithAgentContext('a-6', 'Agent', '(pr6)', 'parent');
     lane.addResult('a-6', makeResult('done'));
+    lane.addStartWithAgentContext('a-1', 'Agent', '(pr1)', 'parent');
+    lane.addResult('a-1', makeResult('done'));
+    lane.addStartWithAgentContext('a-2', 'Agent', '(pr2)', 'parent');
+    lane.addResult('a-2', makeResult('done'));
+    lane.addStartWithAgentContext('a-3', 'Agent', '(pr3)', 'parent');
+    lane.addResult('a-3', makeResult('done'));
     lane.addResult('parent', makeResult('done'));
 
     const overlay = stripAnsi(lane.getOverlay());


### PR DESCRIPTION
## Summary

The subagent tool-use tree caps visible tool-groups at `MAX_VISIBLE_CHILDREN = 3` and collapses the rest into a `… +N (…)` overflow line. It was keeping the **oldest** 3 groups (`slice(0, maxVisible)`) and hiding the newest — so a watcher saw stale early reads while the **most recent** activity, including the `edit_file`/`write_file` mutations that typically land late in a run, was buried behind `+N`.

This switches `addOverflowSynthetic` to a **recency window**: keep the most-recent `maxVisible` groups (the tail), collapse the older head, and lead with the overflow summary so the block reads chronologically top→bottom. Applies to **both** the live overlay and committed scrollback via the shared helper.

```
 before                                  after
 ◉ → Agent(fix) [subagent] — 4 tools     ◉ → Agent(fix) [subagent] — 4 tools
 │ ├─ ● Read(…)      ← oldest shown       │ ├─ … +1 (1 Read)  ← older collapsed (top)
 │ ├─ $ Bash(…)                           │ ├─ $ Bash(…)
 │ ├─ ● Grep(…)                           │ ├─ ● Grep(…)
 │ ├─ … +1 (1 Glob)  ← newest hidden      │ ├─ ● Glob(…)      ← newest now shown
 │ ╰─ Done                                │ ╰─ Done
```

The overflow synthetic moves to the front of the sibling list. `assignConnectors` is positional, so the exactly-one-last-child (`└`) invariant is preserved — the overflow takes the mid `├`, and the genuine last sibling (a real group in the overlay path, or the appended result-summary in the flush path) keeps the `└`. Both overflow grammars (categorical `… +N (…)` and label-aware `… +N more: …`) are unchanged.

## Test results

- `pnpm lint` (tsc --noEmit): **clean**.
- `tool-lane*` suites (5 files incl. the overlay + format suites): **280 passed**. Contract unit tests updated for the new ordering; integration tests reordered so each one's intended-hidden items dispatch first (intent preserved); scenario-5 snapshot regenerated.
- Full suite (`vitest run`): **10,210 passed**, 14 skipped, **2 failed**. The 2 failures are pre-existing and unrelated to this change — `src/cli/config.test.ts` (DEFAULT_SLOT_BINDINGS MLX env-bleed) and `src/agent/providers/anthropic-direct.test.ts` (`compact()`); neither file has any import path to tool-lane rendering, and no tool-lane file failed.

## Verification

Adversarial diff verification (independent re-derivation from source, read-only) — all CONFIRMED:
1. **Recency window** — `addOverflowSynthetic` keeps the most-recent `maxVisible` (tail) and prepends the overflow synthetic (`tool-lane-render-grouping-overflow.ts:49-53`). CONFIRM.
2. **Connector invariant preserved** — `assignConnectors` is positional (`tool-lane-render-grouping.ts:58-61`); overflow at index 0 gets the mid connector, the true last sibling keeps the last connector. CONFIRM.
3. **Overflow grammar unchanged** — `formatCategoricalOverflow` text formats untouched; only the hidden/visible slice and synthetic position changed. CONFIRM.
