### PR TITLE
feat(sdk): wire canUseTool into the dispatcher — Agent SDK parity Dim 8 (increment 1)

### DIFF
--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -24,6 +24,7 @@ import { appendFileSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
 import Anthropic from '@anthropic-ai/sdk';
 import type { AgentConfig } from '../../types/config-types.js';
+import type { CanUseTool } from '../../types/sdk-types.js';
 import type {
   ModelProvider,
   ProviderQuery,
@@ -117,6 +118,8 @@ export interface AnthropicDirectProviderOptions {
   hookRegistry?: HookRegistry;
   /** Tool permission configuration (allowlist). */
   permissions?: ToolPermissionConfig;
+  /** In-process permission callback, forwarded to the session dispatcher. */
+  canUseTool?: CanUseTool;
   /**
    * Optional client factory override. When set, takes precedence over the
    * module-scope `__setAnthropicClientFactory` hook. Useful for callers that
@@ -193,6 +196,7 @@ export class AnthropicDirectProvider implements ModelProvider {
   private readonly schemas: readonly import('../../tools/types.js').AnthropicToolDef[];
   private readonly hookRegistry: import('../../hooks.js').HookRegistry | undefined;
   private readonly permissions: ToolPermissionConfig | undefined;
+  private readonly canUseTool: CanUseTool | undefined;
   private readonly subagentExecutor: import('../../tools/subagent-executor.js').SubagentExecutor | undefined;
   private readonly composeExecutor: import('../../tools/compose-executor.js').ComposeExecutor | undefined;
   private readonly surface: string;
@@ -291,6 +295,7 @@ export class AnthropicDirectProvider implements ModelProvider {
     this.schemas = schemas;
     this.hookRegistry = opts.hookRegistry;
     this.permissions = opts.permissions;
+    this.canUseTool = opts.canUseTool;
     this.subagentExecutor = opts.subagentExecutor;
     this.composeExecutor = opts.composeExecutor;
     this.surface = opts.surface ?? 'cli';
@@ -452,6 +457,9 @@ export class AnthropicDirectProvider implements ModelProvider {
       subagentExecutor: this.subagentExecutor,
       skillExecutor: this.skillExecutor,
       composeExecutor: this.composeExecutor,
+      // In-process permission callback (Dim 8). No-op when unset; forwarded by
+      // reference so it composes with the static allowlist in the dispatcher.
+      ...(this.canUseTool !== undefined ? { canUseTool: this.canUseTool } : {}),
       cwd: opts?.cwd,
       readRoots: opts?.readRoots,
       writeRoots: opts?.writeRoots,

--- a/src/agent/providers/index.ts
+++ b/src/agent/providers/index.ts
@@ -268,24 +268,30 @@ export function providerForModel(
 export function resolveProvider(
   model: string | undefined,
   hints?: ProviderRouteHints,
-  opts?: { customTools?: import('../tools/custom-tool.js').CustomToolDef[] },
+  opts?: {
+    customTools?: import('../tools/custom-tool.js').CustomToolDef[];
+    canUseTool?: import('../types/sdk-types.js').CanUseTool;
+  },
 ): ModelProvider {
   const name = providerForModel(model, hints);
   const customTools = opts?.customTools;
+  const canUseTool = opts?.canUseTool;
+  // Mirror the customTools threading: forward each only when present so the
+  // default path constructs the provider with an empty options bag.
+  const ctorOpts = {
+    ...(customTools !== undefined && customTools.length > 0 ? { customTools } : {}),
+    ...(canUseTool !== undefined ? { canUseTool } : {}),
+  };
   switch (name) {
     case 'openai-compatible':
     case 'openai-codex':
       // IMPORTANT: fresh instance per session — see docstring above.
-      return new OpenAICompatibleProvider(
-        customTools !== undefined && customTools.length > 0 ? { customTools } : {},
-      );
+      return new OpenAICompatibleProvider(ctorOpts);
     case 'anthropic':
     case 'anthropic-direct':
     default:
       // IMPORTANT: fresh instance per session — see docstring above.
-      return new AnthropicDirectProvider(
-        customTools !== undefined && customTools.length > 0 ? { customTools } : {},
-      );
+      return new AnthropicDirectProvider(ctorOpts);
   }
 }
 

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -28,6 +28,7 @@ import type { SubagentExecutor } from '../../tools/subagent-executor.js';
 import type { SkillExecutor } from '../../tools/skill-executor.js';
 import type { ComposeExecutor } from '../../tools/compose-executor.js';
 import { withMcpToolsAllowed, withCustomToolsAllowed, type ToolPermissionConfig } from '../../tools/permissions.js';
+import type { CanUseTool } from '../../types/sdk-types.js';
 import type { ToolDispatcher } from '../anthropic-direct/tool-dispatcher.js';
 import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { pathContainmentBypassed } from '../../permission-policy.js';
@@ -74,6 +75,8 @@ export interface OpenAICompatibleProviderOptions {
   hookRegistry?: HookRegistry;
   /** Tool permission gate (allowlist/denylist). */
   permissions?: ToolPermissionConfig;
+  /** In-process permission callback, forwarded to the session dispatcher. */
+  canUseTool?: CanUseTool;
   subagentExecutor?: SubagentExecutor;
   skillExecutor?: SkillExecutor;
   composeExecutor?: ComposeExecutor;
@@ -449,6 +452,9 @@ export class OpenAICompatibleProvider implements ModelProvider {
       dispatcherOpts.skillExecutor = this.providerOpts.skillExecutor;
     if (this.providerOpts.composeExecutor !== undefined)
       dispatcherOpts.composeExecutor = this.providerOpts.composeExecutor;
+    // In-process permission callback (Dim 8) — parity with anthropic-direct.
+    if (this.providerOpts.canUseTool !== undefined)
+      dispatcherOpts.canUseTool = this.providerOpts.canUseTool;
     if (opts.cwd !== undefined) dispatcherOpts.cwd = opts.cwd;
     if (opts.readRoots !== undefined) dispatcherOpts.readRoots = opts.readRoots;
     if (opts.writeRoots !== undefined) dispatcherOpts.writeRoots = opts.writeRoots;

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -259,7 +259,10 @@ export class AgentSession implements IAgentSession {
       const resolveProviderFn = this.config.providerFactory
         ? this.config.providerFactory
         : (m: string | undefined) =>
-            resolveProvider(m, undefined, { customTools: this.config.customTools });
+            resolveProvider(m, undefined, {
+              customTools: this.config.customTools,
+              canUseTool: this.config.canUseTool,
+            });
       this.providerQuery = new ProviderRouter(
         { prompt: promptIterable, config: this.config },
         {

--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -9,6 +9,7 @@ import type { ToolCall } from './types.js';
 import type { ToolHandler } from './types.js';
 import type { CanUseTool } from '../types/sdk-types.js';
 import { createHookRegistryImpl } from '../hook-registry.js';
+import { InMemoryTraceWriter } from '../trace/writer.js';
 
 function makeCall(overrides?: Partial<ToolCall>): ToolCall {
   return {
@@ -1369,5 +1370,60 @@ describe('SessionToolDispatcher — canUseTool (Dim 8 in-process permission poli
     const r = await d.execute(makeCall());
     expect(r.content).toBe('hello');
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('deny emits a hook_decision block', async () => {
+    const writer = new InMemoryTraceWriter();
+    const denyPolicy: CanUseTool = async (name) => ({
+      behavior: 'deny',
+      message: `policy denied ${name}`,
+    });
+    const d = makeDispatcher({
+      handlers: new Map<string, ToolHandler>([['echo', echoHandler()]]),
+      canUseTool: denyPolicy,
+      traceWriter: writer,
+    });
+    await d.execute(makeCall());
+    const hookEvents = writer.events.filter((e) => e.kind === 'hook_decision');
+    expect(hookEvents).toHaveLength(1);
+    const ev = hookEvents[0]!;
+    if (ev.kind !== 'hook_decision') throw new Error('unreachable');
+    expect(ev.payload.hookEvent).toBe('PreToolUse');
+    expect(ev.payload.decision).toBe('block');
+    expect(ev.payload.blockedTool).toBe('echo');
+    expect(ev.payload.reason).toContain('policy denied echo');
+  });
+
+  it('throw (fail-closed) emits a hook_decision block', async () => {
+    const writer = new InMemoryTraceWriter();
+    const boom: CanUseTool = async () => {
+      throw new Error('policy bug');
+    };
+    const d = makeDispatcher({
+      handlers: new Map<string, ToolHandler>([['echo', echoHandler()]]),
+      canUseTool: boom,
+      traceWriter: writer,
+    });
+    await d.execute(makeCall());
+    const hookEvents = writer.events.filter((e) => e.kind === 'hook_decision');
+    expect(hookEvents).toHaveLength(1);
+    const ev = hookEvents[0]!;
+    if (ev.kind !== 'hook_decision') throw new Error('unreachable');
+    expect(ev.payload.hookEvent).toBe('PreToolUse');
+    expect(ev.payload.decision).toBe('block');
+    expect(ev.payload.blockedTool).toBe('echo');
+    expect(ev.payload.reason).toContain('threw');
+    expect(ev.payload.reason).toContain('policy bug');
+  });
+
+  it('allow emits no hook_decision', async () => {
+    const writer = new InMemoryTraceWriter();
+    const d = makeDispatcher({
+      handlers: new Map<string, ToolHandler>([['echo', echoHandler()]]),
+      canUseTool: allowAll,
+      traceWriter: writer,
+    });
+    await d.execute(makeCall());
+    expect(writer.events.filter((e) => e.kind === 'hook_decision')).toHaveLength(0);
   });
 });

--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -7,6 +7,7 @@ import {
 import { builtinToolSchemas } from './schemas.js';
 import type { ToolCall } from './types.js';
 import type { ToolHandler } from './types.js';
+import type { CanUseTool } from '../types/sdk-types.js';
 import { createHookRegistryImpl } from '../hook-registry.js';
 
 function makeCall(overrides?: Partial<ToolCall>): ToolCall {
@@ -1243,5 +1244,130 @@ describe('SessionToolDispatcher — repeat-loop circuit breaker', () => {
     const r = await d2.execute(makeCall());
     expect(r.isError).toBeUndefined();
     expect(r.content).toBe('hello');
+  });
+});
+
+describe('SessionToolDispatcher — canUseTool (Dim 8 in-process permission policy)', () => {
+  const allowAll: CanUseTool = async () => ({ behavior: 'allow' });
+
+  it('allow result lets the call through to the handler', async () => {
+    const handler = vi.fn(echoHandler());
+    const d = makeDispatcher({
+      handlers: new Map<string, ToolHandler>([['echo', handler]]),
+      canUseTool: allowAll,
+    });
+    const r = await d.execute(makeCall());
+    expect(r.isError).toBeUndefined();
+    expect(r.content).toBe('hello');
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('deny result short-circuits before the handler runs', async () => {
+    const handler = vi.fn(echoHandler());
+    const denyEcho: CanUseTool = async (name) => ({
+      behavior: 'deny',
+      message: `policy denied ${name}`,
+    });
+    const d = makeDispatcher({
+      handlers: new Map<string, ToolHandler>([['echo', handler]]),
+      canUseTool: denyEcho,
+    });
+    const r = await d.execute(makeCall());
+    expect(r.isError).toBe(true);
+    expect(r.content).toBe('policy denied echo');
+    expect(r.failureClass).toBe('permission-denied');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('deny overrides a tool that the static allowlist permits (policy can restrict)', async () => {
+    // 'echo' IS allowlisted, but the policy denies it. canUseTool runs AFTER
+    // the allowlist, so it can further restrict — never widen.
+    const handler = vi.fn(echoHandler());
+    const d = makeDispatcher({
+      handlers: new Map<string, ToolHandler>([['echo', handler]]),
+      permissions: { allowedTools: ['echo'] },
+      canUseTool: async () => ({ behavior: 'deny', message: 'nope' }),
+    });
+    const r = await d.execute(makeCall());
+    expect(r.isError).toBe(true);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('static allowlist still wins: canUseTool cannot widen a denied tool', async () => {
+    // 'forbidden' is NOT allowlisted. Even though the policy would allow it,
+    // checkToolPermission runs first and denies — canUseTool never widens.
+    const handler = vi.fn(echoHandler());
+    const d = makeDispatcher({
+      handlers: new Map<string, ToolHandler>([['forbidden', handler]]),
+      permissions: { allowedTools: ['echo'] },
+      canUseTool: allowAll,
+    });
+    const r = await d.execute(makeCall({ name: 'forbidden' }));
+    expect(r.isError).toBe(true);
+    expect(r.content).toContain('not in the configured allowlist');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('allow.updatedInput rewrites the input the handler receives', async () => {
+    const handler = vi.fn(echoHandler());
+    const rewrite: CanUseTool = async () => ({
+      behavior: 'allow',
+      updatedInput: { message: 'rewritten' },
+    });
+    const d = makeDispatcher({
+      handlers: new Map<string, ToolHandler>([['echo', handler]]),
+      canUseTool: rewrite,
+    });
+    const r = await d.execute(makeCall({ input: { message: 'original' } }));
+    expect(r.content).toBe('rewritten');
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed: a throwing policy denies rather than crashing the turn', async () => {
+    const handler = vi.fn(echoHandler());
+    const boom: CanUseTool = async () => {
+      throw new Error('policy bug');
+    };
+    const d = makeDispatcher({
+      handlers: new Map<string, ToolHandler>([['echo', handler]]),
+      canUseTool: boom,
+    });
+    const r = await d.execute(makeCall());
+    expect(r.isError).toBe(true);
+    expect(r.failureClass).toBe('permission-denied');
+    expect(r.content).toContain('policy bug');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('gates parallel calls in executeBatch (policy not bypassed on batched rounds)', async () => {
+    const handler = vi.fn(echoHandler());
+    const policy: CanUseTool = async (_name, input) => {
+      const msg = (input as { message?: string }).message;
+      return msg === 'deny-me'
+        ? { behavior: 'deny', message: 'blocked in batch' }
+        : { behavior: 'allow' };
+    };
+    const d = makeDispatcher({
+      handlers: new Map<string, ToolHandler>([['echo', handler]]),
+      permissions: { allowedTools: ['echo'] },
+      canUseTool: policy,
+    });
+    const results = await d.executeBatch([
+      makeCall({ id: 'a', input: { message: 'ok' } }),
+      makeCall({ id: 'b', input: { message: 'deny-me' } }),
+    ]);
+    expect(results[0]!.isError).toBeUndefined();
+    expect(results[0]!.content).toBe('ok');
+    expect(results[1]!.isError).toBe(true);
+    expect(results[1]!.content).toBe('blocked in batch');
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op when canUseTool is unset (default path unchanged)', async () => {
+    const handler = vi.fn(echoHandler());
+    const d = makeDispatcher({ handlers: new Map<string, ToolHandler>([['echo', handler]]) });
+    const r = await d.execute(makeCall());
+    expect(r.content).toBe('hello');
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -29,6 +29,7 @@ import { checkToolPermission, type ToolPermissionConfig } from './permissions.js
 import type { CanUseTool, PermissionResult } from '../types/sdk-types.js';
 import { classifyBashCommand } from './readonly-bash.js';
 import { getSessionGrantsPath } from '../../paths.js';
+import { emitHookDecision } from '../trace/emit.js';
 import type { TraceWriter } from '../trace/index.js';
 import { builtinToolSchemas, agentTool, skillTool, composeTool } from './schemas.js';
 import { memoryToolSchemas } from '../memory/memory-tools.js';
@@ -572,6 +573,14 @@ export class SessionToolDispatcher implements ToolDispatcher {
     } catch (err) {
       // Fail closed: a throwing policy denies the call rather than crashing the
       // turn. The message names the cause so the denial is never silent.
+      await emitHookDecision(this.traceWriter, {
+        hookEvent: 'PreToolUse',
+        decision: 'block',
+        blockedTool: call.name,
+        reason: `Tool "${call.name}" denied by canUseTool (threw): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      });
       return {
         content: `Tool "${call.name}" denied by canUseTool (threw): ${
           err instanceof Error ? err.message : String(err)
@@ -581,6 +590,12 @@ export class SessionToolDispatcher implements ToolDispatcher {
       };
     }
     if (result.behavior === 'deny') {
+      await emitHookDecision(this.traceWriter, {
+        hookEvent: 'PreToolUse',
+        decision: 'block',
+        blockedTool: call.name,
+        reason: result.message || `Tool "${call.name}" denied by permission policy`,
+      });
       return {
         content: result.message || `Tool "${call.name}" denied by permission policy`,
         isError: true,

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -26,6 +26,7 @@ import type { SkillExecutor } from './skill-executor.js';
 import type { ComposeExecutor } from './compose-executor.js';
 import type { ToolHandler, ToolHandlerContext, ConcurrencyClassifier } from './types.js';
 import { checkToolPermission, type ToolPermissionConfig } from './permissions.js';
+import type { CanUseTool, PermissionResult } from '../types/sdk-types.js';
 import { classifyBashCommand } from './readonly-bash.js';
 import { getSessionGrantsPath } from '../../paths.js';
 import type { TraceWriter } from '../trace/index.js';
@@ -132,6 +133,16 @@ export interface SessionToolDispatcherOptions {
    */
   hookRegistry: HookRegistry | undefined;
   permissions?: ToolPermissionConfig;
+  /**
+   * Optional in-process permission callback. When set it is consulted on every
+   * tool call AFTER the static allowlist (`permissions`) but BEFORE the
+   * read-only-bash gate, so an allowlist hard-deny still wins. A `deny` result
+   * short-circuits the call with a permission-denied error; an `allow` result
+   * may carry `updatedInput` to rewrite the call's input before the handler
+   * runs. `ask` is resolved inside the callback (see `createCanUseToolHook`),
+   * so the dispatcher only ever observes a final allow/deny. No-op when unset.
+   */
+  canUseTool?: CanUseTool;
   subagentExecutor?: SubagentExecutor;
   skillExecutor?: SkillExecutor;
   composeExecutor?: ComposeExecutor;
@@ -196,6 +207,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
   private readonly schemas: AnthropicToolDef[];
   private readonly hookRegistry: HookRegistry | undefined;
   private readonly permissions: ToolPermissionConfig | undefined;
+  private readonly canUseTool: CanUseTool | undefined;
   private readonly subagentExecutor: SubagentExecutor | undefined;
   private readonly skillExecutor: SkillExecutor | undefined;
   private readonly composeExecutor: ComposeExecutor | undefined;
@@ -241,6 +253,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
     this.schemas = opts.schemas;
     this.hookRegistry = opts.hookRegistry;
     this.permissions = opts.permissions;
+    this.canUseTool = opts.canUseTool;
     this.subagentExecutor = opts.subagentExecutor;
     this.skillExecutor = opts.skillExecutor;
     this.composeExecutor = opts.composeExecutor;
@@ -537,6 +550,50 @@ export class SessionToolDispatcher implements ToolDispatcher {
     };
   }
 
+  /**
+   * Consult the optional `canUseTool` permission callback for a single call.
+   * Returns a permission-denied {@link ToolResult} to short-circuit when the
+   * policy denies (or throws — fail-closed), or `null` to proceed. On an
+   * `allow` result carrying `updatedInput`, the call's input is rewritten in
+   * place so both the handler and the PostToolUse hook observe the new value.
+   *
+   * Invariant: callers MUST invoke this AFTER `checkToolPermission` (the static
+   * allowlist wins) and BEFORE the read-only-bash gate, in BOTH `execute()` and
+   * the `executeBatch()` phase-1 loop, so parallel tool calls are gated too.
+   */
+  private async runCanUseTool(call: ToolCall): Promise<ToolResult | null> {
+    if (!this.canUseTool) return null;
+    let result: PermissionResult;
+    try {
+      result = await this.canUseTool(call.name, (call.input ?? {}) as Record<string, unknown>, {
+        signal: call.signal,
+        toolUseID: call.id,
+      });
+    } catch (err) {
+      // Fail closed: a throwing policy denies the call rather than crashing the
+      // turn. The message names the cause so the denial is never silent.
+      return {
+        content: `Tool "${call.name}" denied by canUseTool (threw): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        isError: true,
+        failureClass: 'permission-denied',
+      };
+    }
+    if (result.behavior === 'deny') {
+      return {
+        content: result.message || `Tool "${call.name}" denied by permission policy`,
+        isError: true,
+        failureClass: 'permission-denied',
+      };
+    }
+    // allow — apply an optional input rewrite in place.
+    if (result.updatedInput !== undefined) {
+      call.input = result.updatedInput;
+    }
+    return null;
+  }
+
   async execute(call: ToolCall): Promise<ToolResult> {
     if (call.signal.aborted) {
       return { content: 'Tool call aborted', isError: true, failureClass: 'abort' };
@@ -579,6 +636,12 @@ export class SessionToolDispatcher implements ToolDispatcher {
         failureClass: 'permission-denied',
       };
     }
+
+    // 2a. In-process permission callback (canUseTool). Consulted AFTER the
+    // static allowlist (a hard allowlist deny wins) and BEFORE the bash gate.
+    // A `deny` short-circuits here; an `allow` may have rewritten `call.input`.
+    const canUseDeny = await this.runCanUseTool(call);
+    if (canUseDeny) return canUseDeny;
 
     // 2b. Read-only-skill bash gate. Runs after the permission check so the
     // allowlist denial (if any) takes precedence; blocks mutating bash while
@@ -749,6 +812,16 @@ export class SessionToolDispatcher implements ToolDispatcher {
           isError: true,
           failureClass: 'permission-denied',
         };
+        blocked.add(i);
+        continue;
+      }
+
+      // In-process permission callback (canUseTool) — same precedence as
+      // execute(): after the allowlist, before the bash gate. Parallel tool
+      // calls must be gated too, else the policy is bypassed on batched rounds.
+      const canUseDeny = await this.runCanUseTool(call);
+      if (canUseDeny) {
+        results[i] = canUseDeny;
         blocked.add(i);
         continue;
       }


### PR DESCRIPTION
## What

Closes the **runtime half** of Agent SDK parity **Dim 8** (permission rules-engine). `canUseTool` was already a fully-typed surface (`src/agent/types/sdk-types.ts`) and was bubbled to sub-agents (`subagent.ts` `parentCanUseTool`), **but it was never invoked inside the dispatcher** — inert at runtime. This wires it in, enforced.

## Changes

- **`SessionToolDispatcher`** consults `canUseTool` on every tool call in **both** `execute()` and the `executeBatch()` phase-1 loop (so parallel/batched rounds are gated too) — **after** the static allowlist (`checkToolPermission`) and **before** the read-only-bash gate.
  - **Precedence:** a hard allowlist deny still wins; `canUseTool` can only *further restrict*, never widen (covered by a test).
  - **`deny`** → `permission-denied` `ToolResult` (uses `result.message`). A **throwing** policy **fails closed** (deny) rather than crashing the turn.
  - **`allow`** → proceeds; an **`allow.updatedInput`** rewrites `call.input` in place so both the handler and PostToolUse observe the new value.
  - `ask` is resolved inside the callback (`createCanUseToolHook`), so the dispatcher only ever observes a final allow/deny.
- **Threading:** `AgentConfig.canUseTool` → `resolveProvider` (mirrors the existing `customTools` pattern) → both providers' options → `buildDispatcher` → dispatcher. **No behavior change when unset** — default sessions and existing consumers are unaffected. Sub-agent bubbling now reaches the dispatcher end-to-end via the same path.

## Not in this increment (deferred)

Persisted allow/deny/ask **rule lists with settings-tier destinations**, the `PermissionRequest` hook, and `deny.interrupt` (turn-abort) semantics — the persistence layer of Dim 8. This increment is the enforcement primitive those build on.

## Verification

- `pnpm lint` clean (rebased on v5.3.0); `pnpm audit:sdk:check` **green — zero new `@anthropic-ai/sdk` symbols** (`CanUseTool`/`PermissionResult` are local types).
- `dispatcher.test.ts`: **+8 `canUseTool` cases** (allow, deny short-circuit, deny-overrides-allowlist, allowlist-still-wins, `updatedInput`, fail-closed-on-throw, `executeBatch` gating, no-op-when-unset) — all pass.
- **2322 pass** across `tools` + both providers + `permissions` + `query` + `subagent` + `session`; the lone failure is the pre-existing `anthropic-direct.test.ts` compact-model-id env test (documented on `main`, unrelated to this change).

> Note: merging cuts a `feat:` minor release → **v5.4.0** (v5.3.0 already shipped via #294).
