### PR TITLE
feat(sdk): export framework skill/facet API for out-of-tree plugins

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -17,4 +17,26 @@ describe('library entry point', () => {
     expect(mod.SessionManager).toBeDefined();
   });
 
+  it('exports the framework SDK surface consumed by out-of-tree skill plugins', async () => {
+    const mod = await import('./index.js');
+    // Skills registry + prompts
+    expect(typeof mod.registerSkill).toBe('function');
+    expect(typeof mod.listSkills).toBe('function');
+    expect(typeof mod.getSkill).toBe('function');
+    expect(typeof mod.loadSkillPrompts).toBe('function');
+    // Session facets
+    expect(typeof mod.deriveSessionFacet).toBe('function');
+    expect(typeof mod.getOrDeriveFacet).toBe('function');
+    expect(typeof mod.listSessionIds).toBe('function');
+    expect(typeof mod.loadStoredSession).toBe('function');
+    // Subagent + skill discovery
+    expect(typeof mod.describeFailure).toBe('function');
+    expect(typeof mod.discoverPluginSkillBodies).toBe('function');
+    // Env + user-scope state dirs
+    expect(mod.env).toBeDefined();
+    expect(typeof mod.getSessionsDir).toBe('function');
+    expect(typeof mod.getSkillsDir).toBe('function');
+    expect(typeof mod.getAgentFrameworkDir).toBe('function');
+  });
+
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,5 +65,36 @@ export type {
 } from './agent/index.js';
 export type { DiffHunk, DiffLine, DiffPayload } from './utils/diff.js';
 
+// Framework SDK surface for out-of-tree skill plugins.
+// These re-exports expose the core symbols an external skill plugin installed
+// under ~/.afk/plugins/ needs to register skills and read session facets at
+// boot, so a plugin can depend on the published `agent-afk` package instead of
+// reaching into the source tree. Purely additive — no behavior change.
+export {
+  registerSkill,
+  listSkills,
+  getSkill,
+} from './skills/index.js';
+export type { SkillExecutionContext, SkillMetadata } from './skills/index.js';
+export { loadSkillPrompts } from './skills/_lib/prompt-loader.js';
+
+export {
+  deriveSessionFacet,
+  getOrDeriveFacet,
+  listSessionIds,
+  loadStoredSession,
+} from './agent/facets/index.js';
+export type {
+  SessionFacet,
+  StoredSessionInput,
+  ToolEventInput,
+} from './agent/facets/index.js';
+
+export { describeFailure } from './agent/subagent/result.js';
+export { discoverPluginSkillBodies } from './agent/tools/skill-bridge.js';
+
+export { env } from './config/env.js';
+export { getSessionsDir, getSkillsDir, getAgentFrameworkDir } from './paths.js';
+
 export { TelegramBot, SessionManager } from './telegram/index.js';
 export type { BotOptions, SessionManagerOptions } from './telegram/index.js';


### PR DESCRIPTION
## What

Re-exports the core symbols an out-of-tree skill plugin (installed under `~/.afk/plugins/`) needs to register skills and read session facets at boot, from the published `agent-afk` package entry (`src/index.ts`).

Added to the public API:
- **Skills registry:** `registerSkill`, `listSkills`, `getSkill`, types `SkillExecutionContext`/`SkillMetadata`, and `loadSkillPrompts`.
- **Session facets:** `deriveSessionFacet`, `getOrDeriveFacet`, `listSessionIds`, `loadStoredSession`, types `SessionFacet`/`StoredSessionInput`/`ToolEventInput`.
- **Subagent + discovery:** `describeFailure`, `discoverPluginSkillBodies`.
- **Env + state dirs:** `env`, `getSessionsDir`, `getSkillsDir`, `getAgentFrameworkDir`.

(`SubagentManager` and `IAgentSession`, also needed by plugins, were already exported.)

## Why

Builds on #298 (plugin JS `main` entrypoint). For a skill plugin to run `registerSkill()` at boot via its `main` module, it must import these symbols from the package — today they're only reachable via deep relative source paths. This re-export surface mirrors the in-tree imports exactly, so a plugin depends on the public package instead of reaching into the tree.

## Risk

Purely **additive** — no runtime behavior change; it only widens the public API surface. The re-exported list was derived by enumerating the exact core imports a plugin makes, then verified symbol-by-symbol against the current modules.

## Verification

- `pnpm lint` (tsc --noEmit, strict) — clean.
- `pnpm build` — clean (tsc emit + prompt copy).
- `src/index.test.ts` extended with a framework-SDK-surface assertion (all new value exports resolve at runtime) — passes.
- Full suite: only the 2 known env-dependent pre-existing failures (config slot-bindings, anthropic compact) — unrelated to this change.