### PR TITLE
feat(plan-mode): restore pre-plan permission mode on exit

### DIFF
--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -76,6 +76,16 @@ export class AgentSession implements IAgentSession {
    * mid-turn tool call to the post-turn REPL boundary.
    */
   private _pendingPlanExitSeed: { message: string; mode: PermissionMode } | undefined;
+  /**
+   * The permission mode the session was in immediately BEFORE entering plan
+   * mode. Captured by {@link setPermissionMode} on the transition INTO 'plan'
+   * (covering every entry path — `/plan`, free-text `/plan`, Shift+Tab) and read
+   * by an approved plan-exit ({@link getPrePlanMode}) so the implement-turn
+   * restores it instead of forcing 'default'. `undefined` until the first
+   * plan-entry, and reset to `undefined` when the prior mode was 'autonomous'
+   * (AFK is not restorable by a bare flip) so restore falls back to 'default'.
+   */
+  private _prePlanPermissionMode: PermissionMode | undefined;
   private currentState: SessionState = 'idle';
   private providerQuery!: ProviderQuery;
   private providerIterator!: AsyncIterator<ProviderEvent>;
@@ -170,6 +180,7 @@ export class AgentSession implements IAgentSession {
               requestImplementSeed: (message, mode) => {
                 this._pendingPlanExitSeed = { message, mode };
               },
+              getPrePlanMode: () => this._prePlanPermissionMode,
             },
           }
         : config;
@@ -776,8 +787,31 @@ export class AgentSession implements IAgentSession {
   }
 
   async setPermissionMode(mode: PermissionMode): Promise<void> {
+    // Capture the mode being LEFT on the transition INTO plan, so an approved
+    // exit (exit_plan_mode tool or `/plan off`) can restore it instead of
+    // forcing 'default'. Read the live mode BEFORE flipping. Guard on the
+    // non-plan → plan edge only: a redundant plan → plan flip must not overwrite
+    // the real pre-plan mode with 'plan'. 'autonomous' (AFK) is reset to
+    // undefined — it carries dedicated enter/exit machinery (toggleAfkMode) and
+    // is not safe to re-enter by a bare flip — so restore falls back to 'default'.
+    if (mode === 'plan') {
+      const current = this.stateManager.getSessionMetadata().permissionMode;
+      if (current !== 'plan') {
+        this._prePlanPermissionMode = current === 'autonomous' ? undefined : current;
+      }
+    }
     await this.providerQuery.setPermissionMode(mode);
     this.stateManager.setSessionMetadata((prev) => ({ ...prev, permissionMode: mode }));
+  }
+
+  /**
+   * The permission mode the session was in immediately before entering plan
+   * mode, or `undefined` if none was captured (never entered plan, or the prior
+   * mode was 'autonomous'). An approved plan-exit restores this; callers fall
+   * back to 'default' on `undefined`. See {@link _prePlanPermissionMode}.
+   */
+  getPrePlanMode(): PermissionMode | undefined {
+    return this._prePlanPermissionMode;
   }
 
   /**

--- a/src/agent/tools/handlers/exit-plan-mode.test.ts
+++ b/src/agent/tools/handlers/exit-plan-mode.test.ts
@@ -34,7 +34,7 @@ function installPicker(idx: number | null): void {
   }));
 }
 
-function makeControls(): {
+function makeControls(prePlanMode?: PermissionMode): {
   controls: PlanExitControls;
   modeCalls: PermissionMode[];
   seeds: Array<{ message: string; mode: PermissionMode }>;
@@ -51,6 +51,9 @@ function makeControls(): {
       requestImplementSeed: (message, mode) => {
         seeds.push({ message, mode });
       },
+      // Pre-plan mode the handler restores. Undefined → handler falls back to
+      // 'default', which is what the original tests below assert.
+      getPrePlanMode: () => prePlanMode,
     },
   };
 }
@@ -124,6 +127,66 @@ describe('exit_plan_mode handler', () => {
 
     expect(seeds).toEqual([{ message: buildPlanExitPrompt(getProjectPlansDir(process.cwd())), mode: 'default' }]);
   });
+
+  it('approve→restore: the primary choice restores the captured pre-plan mode (acceptEdits)', async () => {
+    // Capture the offered choices so we can assert the picker shape too.
+    let offered: string[] | undefined;
+    elicitationRouter.install(async (request) => {
+      offered = request.choices;
+      return { action: 'accept', content: { value: request.choices?.[0] } };
+    });
+    const { controls, seeds } = makeControls('acceptEdits');
+    const handler = createExitPlanModeHandler(controls);
+
+    const res = await handler({}, new AbortController().signal, { resolveBase: CWD });
+
+    // Non-bypass pre-plan mode → three choices: restore, bypass-escalation, keep.
+    expect(offered).toHaveLength(3);
+    expect(offered?.[0]).toContain('restore');
+    // Primary approve restores the captured mode, not 'default'.
+    expect(seeds).toEqual([{ message: buildPlanExitPrompt(getProjectPlansDir(CWD)), mode: 'acceptEdits' }]);
+    expect(res.content).toContain('mode=acceptEdits');
+  });
+
+  it('approve→escalate: the explicit bypass choice still escalates even when pre-plan mode was acceptEdits', async () => {
+    installPicker(1); // index 1 = the bypass escalation row
+    const { controls, seeds } = makeControls('acceptEdits');
+    const handler = createExitPlanModeHandler(controls);
+
+    const res = await handler({}, new AbortController().signal, { resolveBase: CWD });
+
+    expect(seeds).toEqual([{ message: buildPlanExitPrompt(getProjectPlansDir(CWD)), mode: 'bypassPermissions' }]);
+    expect(res.content).toContain('mode=bypassPermissions');
+  });
+
+  it('pre-plan mode bypass: picker dedupes (no separate bypass row) and approve restores bypass', async () => {
+    let offered: string[] | undefined;
+    elicitationRouter.install(async (request) => {
+      offered = request.choices;
+      return { action: 'accept', content: { value: request.choices?.[0] } };
+    });
+    const { controls, seeds } = makeControls('bypassPermissions');
+    const handler = createExitPlanModeHandler(controls);
+
+    const res = await handler({}, new AbortController().signal, { resolveBase: CWD });
+
+    // Restore IS bypass → only two choices (restore-bypass, keep); no duplicate.
+    expect(offered).toHaveLength(2);
+    expect(seeds).toEqual([{ message: buildPlanExitPrompt(getProjectPlansDir(CWD)), mode: 'bypassPermissions' }]);
+    expect(res.content).toContain('mode=bypassPermissions');
+  });
+
+  it('pre-plan mode bypass: the second choice is "keep planning" (not a flip)', async () => {
+    installPicker(1); // index 1 with a 2-choice picker = keep planning
+    const { controls, modeCalls, seeds } = makeControls('bypassPermissions');
+    const handler = createExitPlanModeHandler(controls);
+
+    const res = await handler({}, new AbortController().signal, { resolveBase: CWD });
+
+    expect(modeCalls).toEqual([]);
+    expect(seeds).toEqual([]);
+    expect(res.content.toLowerCase()).toContain('keep planning');
+  });
 });
 
 describe('AgentSession plan-exit seed bridge', () => {
@@ -190,6 +253,42 @@ describe('AgentSession plan-exit seed bridge', () => {
     await expect(session.takePendingPlanExitSeed()).resolves.toBeUndefined();
     // Single-shot: the dropped seed is cleared (a retry still returns undefined).
     await expect(session.takePendingPlanExitSeed()).resolves.toBeUndefined();
+
+    await session.close();
+  });
+
+  it('captures the pre-plan mode on entering plan, exposed via getPrePlanMode + controls', async () => {
+    const { provider, getControls } = capturingProvider();
+    const session = new AgentSession({ model: 'sonnet', apiKey: 'test-key', provider });
+    await session.waitForInitialization();
+
+    // No plan entered yet → nothing captured.
+    expect(session.getPrePlanMode()).toBeUndefined();
+
+    // Enter plan FROM bypass → bypass is captured as the restore target, and the
+    // injected control bridge surfaces the same value to the exit_plan_mode tool.
+    await session.setPermissionMode('bypassPermissions');
+    await session.setPermissionMode('plan');
+    expect(session.getPrePlanMode()).toBe('bypassPermissions');
+    expect(getControls()?.getPrePlanMode()).toBe('bypassPermissions');
+
+    // A redundant plan→plan flip must NOT clobber the captured mode with 'plan'.
+    await session.setPermissionMode('plan');
+    expect(session.getPrePlanMode()).toBe('bypassPermissions');
+
+    await session.close();
+  });
+
+  it('does not capture autonomous (AFK) as a restorable pre-plan mode → restore falls back', async () => {
+    const { provider } = capturingProvider();
+    const session = new AgentSession({ model: 'sonnet', apiKey: 'test-key', provider });
+    await session.waitForInitialization();
+
+    await session.setPermissionMode('autonomous');
+    await session.setPermissionMode('plan');
+    // 'autonomous' is reset to undefined (AFK is not restorable by a bare flip)
+    // so an approved exit falls back to 'default'.
+    expect(session.getPrePlanMode()).toBeUndefined();
 
     await session.close();
   });

--- a/src/agent/tools/handlers/exit-plan-mode.ts
+++ b/src/agent/tools/handlers/exit-plan-mode.ts
@@ -4,8 +4,11 @@
  * The model-proposed counterpart to the `/plan off` slash command. When the
  * model judges its plan ready, it calls `exit_plan_mode`; the handler runs an
  * elicitation picker so the USER chooses how to proceed:
- *   - approve → implement in `default` mode (writes with path containment + prompts)
- *   - approve → implement in `bypassPermissions` mode (no prompts, read/write anywhere)
+ *   - approve → implement, RESTORING the mode the user was in before plan mode
+ *     (default / bypass / acceptEdits / …), captured by `AgentSession` on the
+ *     flip into plan and read here via `PlanExitControls.getPrePlanMode()`
+ *   - approve → escalate to `bypassPermissions` (offered unless the restored
+ *     mode is already bypass — that would be a redundant duplicate row)
  *   - keep planning (stay in plan; refine)
  *
  * On approval the handler records the approved mode ALONGSIDE the seed message
@@ -35,7 +38,7 @@
 
 import type { AnthropicToolDef, ToolHandler } from '../types.js';
 import type { PlanExitControls } from '../../types/config-types.js';
-import type { ElicitationRequest } from '../../types/sdk-types.js';
+import type { ElicitationRequest, PermissionMode } from '../../types/sdk-types.js';
 import { elicitationRouter } from '../../elicitation-router.js';
 import { buildPlanExitPrompt } from '../../plan-mode-exit-prompt.js';
 import { getProjectPlansDir } from '../../../paths.js';
@@ -43,11 +46,38 @@ import { getProjectPlansDir } from '../../../paths.js';
 /** Stable tool name — must be present in the session's tool allowlist. */
 export const EXIT_PLAN_MODE_TOOL_NAME = 'exit_plan_mode';
 
-// Choice labels. Kept clean ASCII < 128 chars so the REPL picker's
-// `sanitizeSchemaString` is a no-op and `content.value` round-trips verbatim.
-const CHOICE_DEFAULT = 'Approve — implement now (default mode: writes ask for confirmation, contained to the workspace)';
+// Choice labels. Kept < 128 chars so the REPL picker's `sanitizeSchemaString`
+// is a no-op and `content.value` round-trips verbatim.
+//
+// Invariant: the result matcher keys off the substring "bypass" to map a pick to
+// `bypassPermissions`. So `restoreChoiceLabel` MUST contain "bypass" only when
+// the restored mode IS bypass, and the static escalation label below is the only
+// other "bypass"-bearing choice — any other restore label must omit the word.
 const CHOICE_BYPASS = 'Approve — implement now (bypass mode: no prompts, read/write any path)';
 const CHOICE_KEEP = 'Keep planning';
+
+/**
+ * Label for the primary "approve and implement" choice, which restores the mode
+ * the user was in BEFORE plan mode. The phrasing reflects the concrete restored
+ * mode so the picker is honest about where you land. See the matcher invariant
+ * above: only the bypass case may contain the substring "bypass".
+ */
+function restoreChoiceLabel(mode: PermissionMode): string {
+  switch (mode) {
+    case 'bypassPermissions':
+      return 'Approve — implement now (restore bypass mode: no prompts, read/write any path)';
+    case 'acceptEdits':
+      return 'Approve — implement now (restore accept-edits mode: edits auto-approved)';
+    case 'dontAsk':
+    case 'auto':
+      return 'Approve — implement now (restore your previous mode: no approval prompts)';
+    case 'default':
+    case 'plan':
+    case 'autonomous':
+    default:
+      return 'Approve — implement now (restore default mode: writes ask for confirmation, contained to the workspace)';
+  }
+}
 
 /**
  * Tool definition for `exit_plan_mode`. Signal-only: no parameters — the plan
@@ -90,6 +120,19 @@ export const exitPlanModeTool: AnthropicToolDef = {
  */
 export function createExitPlanModeHandler(controls: PlanExitControls): ToolHandler {
   return async (_input, signal, context) => {
+    // Restore the mode the user was in before plan mode (falls back to 'default'
+    // when none was captured). This is the PRIMARY approve choice.
+    const prevMode: PermissionMode = controls.getPrePlanMode() ?? 'default';
+    const restoreChoice = restoreChoiceLabel(prevMode);
+
+    // Offer an explicit bypass ESCALATION too — unless the restore choice is
+    // already bypass (the user planned from bypass), in which case a second
+    // bypass row would be redundant.
+    const choices =
+      prevMode === 'bypassPermissions'
+        ? [restoreChoice, CHOICE_KEEP]
+        : [restoreChoice, CHOICE_BYPASS, CHOICE_KEEP];
+
     const request: ElicitationRequest = {
       serverName: 'agent',
       origin: 'agent',
@@ -97,7 +140,7 @@ export function createExitPlanModeHandler(controls: PlanExitControls): ToolHandl
       message:
         'Plan ready. How do you want to proceed? ' +
         '(Your plan is in the conversation above.)',
-      choices: [CHOICE_DEFAULT, CHOICE_BYPASS, CHOICE_KEEP],
+      choices,
     };
 
     const result = await elicitationRouter.route(request, { signal });
@@ -118,8 +161,9 @@ export function createExitPlanModeHandler(controls: PlanExitControls): ToolHandl
       : '';
 
     // Keyword matching is robust to picker sanitization / numbered-fallback
-    // round-tripping. Order matters: detect "keep" first, then the dangerous
-    // "bypass" branch, else the default-mode approval.
+    // round-tripping. Order matters: detect "keep" first, then the "bypass"
+    // branch (the escalation choice, or restore-of-bypass — both land in
+    // bypass), else restore the captured pre-plan mode.
     if (picked.startsWith('Keep') || picked === CHOICE_KEEP) {
       return {
         content:
@@ -128,7 +172,7 @@ export function createExitPlanModeHandler(controls: PlanExitControls): ToolHandl
       };
     }
 
-    const mode = picked.includes('bypass') ? 'bypassPermissions' : 'default';
+    const mode: PermissionMode = picked.includes('bypass') ? 'bypassPermissions' : prevMode;
 
     // Record the approved mode ALONGSIDE the seed. The permission flip is deferred
     // to the post-turn drain boundary (loop-iteration.ts → takePendingPlanExitSeed)

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -65,6 +65,16 @@ export interface PlanExitControls {
    * applied here — it is deferred to `takePendingPlanExitSeed()`.
    */
   requestImplementSeed(message: string, mode: PermissionMode): void;
+  /**
+   * The permission mode the session was in immediately BEFORE it entered plan
+   * mode — captured by `AgentSession.setPermissionMode` on the flip into 'plan'.
+   * An approved exit restores THIS mode instead of forcing 'default', so a user
+   * who was (say) in bypass before planning lands back in bypass. Returns
+   * `undefined` when nothing was captured (the session started in plan, or the
+   * prior mode was 'autonomous' — AFK has dedicated enter/exit machinery and is
+   * not restorable by a bare flip); callers fall back to 'default'.
+   */
+  getPrePlanMode(): PermissionMode | undefined;
 }
 
 /** Agent session configuration */

--- a/src/cli/plan-mode-toggle.test.ts
+++ b/src/cli/plan-mode-toggle.test.ts
@@ -12,6 +12,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { togglePlanMode } from './plan-mode-toggle.js';
 import type { SessionStats, SlashContext } from './slash/types.js';
+import type { PermissionMode } from '../agent/types/sdk-types.js';
 
 function makeStats(overrides: Partial<SessionStats> = {}): SessionStats {
   return {
@@ -31,15 +32,20 @@ function makeStats(overrides: Partial<SessionStats> = {}): SessionStats {
 
 interface FakeSession {
   setPermissionMode: ReturnType<typeof vi.fn>;
+  getPrePlanMode: ReturnType<typeof vi.fn>;
 }
 
 function makeCtx(opts: {
   stats: SessionStats;
   setPermissionMode?: ReturnType<typeof vi.fn>;
+  prePlanMode?: PermissionMode;
 }): { ctx: SlashContext; sess: FakeSession; lines: string[] } {
   const lines: string[] = [];
   const sess: FakeSession = {
     setPermissionMode: opts.setPermissionMode ?? vi.fn().mockResolvedValue(undefined),
+    // The session captures the pre-plan mode; `/plan off` restores it. Defaults
+    // to undefined → helper falls back to 'default' (the original behavior).
+    getPrePlanMode: vi.fn().mockReturnValue(opts.prePlanMode),
   };
   const ctx: SlashContext = {
     session: { current: sess } as unknown as SlashContext['session'],
@@ -91,6 +97,51 @@ describe('togglePlanMode', () => {
 
     expect(sess.setPermissionMode).toHaveBeenCalledWith('default');
     expect(stats.permissionMode).toBe('default');
+  });
+
+  it('restores the pre-plan mode (bypass) on exit instead of forcing default', async () => {
+    const stats = makeStats({ permissionMode: 'plan' });
+    const { ctx, sess, lines } = makeCtx({ stats, prePlanMode: 'bypassPermissions' });
+
+    await togglePlanMode(ctx, false);
+
+    expect(sess.setPermissionMode).toHaveBeenCalledWith('bypassPermissions');
+    expect(stats.permissionMode).toBe('bypassPermissions');
+    const joined = lines.join('\n').toLowerCase();
+    expect(joined).toContain('plan mode off');
+    expect(joined).toContain('bypass restored');
+  });
+
+  it('restores the pre-plan mode (acceptEdits) on exit', async () => {
+    const stats = makeStats({ permissionMode: 'plan' });
+    const { ctx, sess, lines } = makeCtx({ stats, prePlanMode: 'acceptEdits' });
+
+    await togglePlanMode(ctx, false);
+
+    expect(sess.setPermissionMode).toHaveBeenCalledWith('acceptEdits');
+    expect(stats.permissionMode).toBe('acceptEdits');
+    expect(lines.join('\n').toLowerCase()).toContain('accept-edits restored');
+  });
+
+  it('falls back to default on exit when no pre-plan mode was captured', async () => {
+    const stats = makeStats({ permissionMode: 'plan' });
+    const { ctx, sess } = makeCtx({ stats }); // prePlanMode undefined
+
+    await togglePlanMode(ctx, false);
+
+    expect(sess.setPermissionMode).toHaveBeenCalledWith('default');
+    expect(stats.permissionMode).toBe('default');
+  });
+
+  it('entering plan flips to plan and never consults getPrePlanMode (only exit restores)', async () => {
+    const stats = makeStats({ permissionMode: 'default' });
+    const { ctx, sess } = makeCtx({ stats, prePlanMode: 'bypassPermissions' });
+
+    await togglePlanMode(ctx, true);
+
+    expect(sess.setPermissionMode).toHaveBeenCalledWith('plan');
+    expect(stats.permissionMode).toBe('plan');
+    expect(sess.getPrePlanMode).not.toHaveBeenCalled();
   });
 
   it('leaves permissionMode unchanged and surfaces an error when setPermissionMode rejects', async () => {

--- a/src/cli/plan-mode-toggle.test.ts
+++ b/src/cli/plan-mode-toggle.test.ts
@@ -123,6 +123,20 @@ describe('togglePlanMode', () => {
     expect(lines.join('\n').toLowerCase()).toContain('accept-edits restored');
   });
 
+  it('restores a non-ring mode (dontAsk) with an accurate status line', async () => {
+    const stats = makeStats({ permissionMode: 'plan' });
+    const { ctx, sess, lines } = makeCtx({ stats, prePlanMode: 'dontAsk' });
+
+    await togglePlanMode(ctx, false);
+
+    expect(sess.setPermissionMode).toHaveBeenCalledWith('dontAsk');
+    expect(stats.permissionMode).toBe('dontAsk');
+    const joined = lines.join('\n').toLowerCase();
+    // Must NOT mislabel as "default permissions restored".
+    expect(joined).toContain('previous mode restored');
+    expect(joined).not.toContain('default permissions restored');
+  });
+
   it('falls back to default on exit when no pre-plan mode was captured', async () => {
     const stats = makeStats({ permissionMode: 'plan' });
     const { ctx, sess } = makeCtx({ stats }); // prePlanMode undefined

--- a/src/cli/plan-mode-toggle.ts
+++ b/src/cli/plan-mode-toggle.ts
@@ -4,12 +4,17 @@
  * `togglePlanMode` is used by the `/plan` slash command. (Shift+Tab no longer
  * calls it directly — it routes through `cyclePermissionMode` in
  * `permission-mode-cycle.ts`, which advances the ring default → plan → bypass.)
- * It flips the session permission mode (`'plan'` <-> `'default'`) and mirrors the
- * result onto `stats.permissionMode` — the value the REPL prompt and status
- * line read.
+ * It flips the session permission mode and mirrors the result onto
+ * `stats.permissionMode` — the value the REPL prompt and status line read.
  *
- * Exit semantics live in the caller, not here: `/plan off` flips to default,
- * then seeds a turn that saves the plan to a file and implements it (see
+ * Entering plan flips to `'plan'`. EXITING plan RESTORES the mode the session
+ * was in before it entered plan (captured by `AgentSession` on the flip into
+ * plan, read back via `getPrePlanMode()`), falling back to `'default'` when
+ * none was captured — so a user who planned from bypass lands back in bypass.
+ * This mirrors the model-callable `exit_plan_mode` tool's restore behavior.
+ *
+ * Exit semantics live in the caller, not here: `/plan off` exits plan then
+ * seeds a turn that saves the plan to a file and implements it (see
  * `slash/commands/plan.ts`).
  *
  * If `setPermissionMode` rejects (e.g. the provider's query handle is closing
@@ -19,8 +24,22 @@
 
 import { palette } from './palette.js';
 import type { SlashContext } from './slash/types.js';
+import type { PermissionMode } from '../agent/types/sdk-types.js';
 
 let hasShownFirstUseTip = false;
+
+/** Status-line suffix describing the mode `/plan off` restored on exit. */
+function describeRestoredMode(mode: PermissionMode): string {
+  switch (mode) {
+    case 'bypassPermissions':
+      return 'bypass restored — no prompts, read/write any path';
+    case 'acceptEdits':
+      return 'accept-edits restored — edits auto-approved';
+    case 'default':
+    default:
+      return 'default permissions restored';
+  }
+}
 
 export async function togglePlanMode(
   ctx: SlashContext,
@@ -29,9 +48,16 @@ export async function togglePlanMode(
   const current = ctx.stats.permissionMode === 'plan';
   const next = desired !== undefined ? desired : !current;
 
+  // Exiting plan restores the pre-plan mode (falls back to 'default' when none
+  // was captured); entering plan flips to 'plan'. The `?.` guards session-likes
+  // / test doubles that predate getPrePlanMode (it resolves undefined → default).
+  const target: PermissionMode = next
+    ? 'plan'
+    : (ctx.session.current.getPrePlanMode?.() ?? 'default');
+
   try {
-    await ctx.session.current.setPermissionMode(next ? 'plan' : 'default');
-    ctx.stats.permissionMode = next ? 'plan' : 'default';
+    await ctx.session.current.setPermissionMode(target);
+    ctx.stats.permissionMode = target;
     ctx.ui.repaintStatusLine();
     if (next) {
       const tip = hasShownFirstUseTip
@@ -45,7 +71,7 @@ export async function togglePlanMode(
       );
     } else {
       ctx.out.success(
-        palette.success('○ plan mode OFF') + palette.dim(' — default permissions restored'),
+        palette.success('○ plan mode OFF') + palette.dim(` — ${describeRestoredMode(target)}`),
       );
     }
   } catch (err) {

--- a/src/cli/plan-mode-toggle.ts
+++ b/src/cli/plan-mode-toggle.ts
@@ -35,6 +35,9 @@ function describeRestoredMode(mode: PermissionMode): string {
       return 'bypass restored — no prompts, read/write any path';
     case 'acceptEdits':
       return 'accept-edits restored — edits auto-approved';
+    case 'dontAsk':
+    case 'auto':
+      return 'previous mode restored — no approval prompts';
     case 'default':
     default:
       return 'default permissions restored';


### PR DESCRIPTION
## Summary
- Exiting plan mode now **restores the permission mode you were in before entering plan** instead of forcing `default`. Plan from `bypass`/`acceptEdits` and you land back there, not silently downgraded to `default`.
- Captured at one chokepoint: `AgentSession.setPermissionMode` records the outgoing mode on the flip into `plan`, so every entry path — `/plan`, free-text `/plan`, Shift+Tab — is covered. Exposed via `PlanExitControls.getPrePlanMode()` / `AgentSession.getPrePlanMode()`.
- Both exit paths restore it: the model-callable `exit_plan_mode` tool (primary picker choice) and `/plan off`. The picker keeps an explicit **bypass escalation** option (deduped when you already planned from bypass), per design discussion — no feature removed.
- Edge cases: a redundant `plan→plan` flip will not clobber the captured mode; `autonomous` (AFK) is not auto-restored — it needs `toggleAfkMode`'s enter/exit machinery — so it falls back to `default`; sessions that started in plan fall back to `default`. Shift+Tab's `default→plan→bypass` ring is deliberately left as a forward cycle, not an exit-restore.

## Test results
- `pnpm lint` (tsc --noEmit, strict): **clean**.
- `pnpm test` (full vitest): **10178 passed / 14 skipped / 3 failed**. All 3 failures are pre-existing environment noise unrelated to this change:
  - `config.test.ts` — DEFAULT_SLOT_BINDINGS MLX bleed (known).
  - `anthropic-direct.test.ts` — compact (known).
  - `daemon.test.ts` CronScheduler telemetry — parallel shared-path contention; **passes 49/49 in isolation**.
- New/updated coverage: restore variants (default/bypass/acceptEdits/dontAsk), picker bypass-dedupe, capture + redundant-flip + autonomous guards, and the `dontAsk`/`auto` status-line fix.

## Verification
Adversarial verifier wave (diff > 100 lines) independently re-derived the load-bearing claims from the diff:
- **CONFIRM** — single chokepoint: `togglePlanMode` and `cyclePermissionMode` both route through `AgentSession.setPermissionMode`, so all entry paths capture the prior mode.
- **CONFIRM** — restore routing: the `picked.includes('bypass')` matcher has no hole; no non-bypass restore label contains the substring "bypass"; `/plan off` restores the captured mode rather than hardcoding `default`.
- **CONFIRM** — guards: redundant `plan→plan` does not overwrite the capture; entry from `autonomous` yields `getPrePlanMode() === undefined` → `default`.
- One **REFINE** (cosmetic): the `/plan off` status line mislabeled `dontAsk`/`auto` restores as "default permissions restored" — **fixed in follow-up commit 24a8aa7**; routing was already correct.

## Notes
Branch is 6 commits behind `origin/main` (based off v5.1.0), but `git merge-tree` shows a clean three-way merge — no conflicts.
