### PR TITLE
feat(skills): loadSkillPrompts(name, baseDir?) for out-of-tree plugins

### DIFF
--- a/src/skills/_lib/prompt-loader.test.ts
+++ b/src/skills/_lib/prompt-loader.test.ts
@@ -15,7 +15,10 @@
  * @module skills/_lib/prompt-loader.test
  */
 
-import { describe, it, expect } from 'vitest';
+import { afterAll, beforeAll, describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { loadSkillPrompts } from './prompt-loader.js';
 
 describe('P3 — loadSkillPrompts path-traversal guard', () => {
@@ -72,5 +75,57 @@ describe('P3 — loadSkillPrompts path-traversal guard', () => {
     } catch (err) {
       expect((err as Error).message).not.toMatch(/illegal path component/i);
     }
+  });
+});
+
+describe('loadSkillPrompts — baseDir override (out-of-tree plugin support)', () => {
+  // Simulate a plugin's own skills root: <root>/demo/prompts/*.md
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'afk-prompt-loader-'));
+    const promptsDir = join(root, 'demo', 'prompts');
+    mkdirSync(promptsDir, { recursive: true });
+    writeFileSync(join(promptsDir, 'system.md'), 'system body');
+    writeFileSync(join(promptsDir, 'agent.md'), 'agent body');
+    writeFileSync(join(promptsDir, 'ignored.txt'), 'not markdown');
+    // A sibling skill dir with no prompts/ subdir, to exercise that error path.
+    mkdirSync(join(root, 'no-prompts'), { recursive: true });
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('loads prompts from the supplied baseDir, not the in-tree root', () => {
+    const prompts = loadSkillPrompts('demo', root);
+    expect(prompts['system.md']).toBe('system body');
+    expect(prompts['agent.md']).toBe('agent body');
+  });
+
+  it('returns only .md files, keyed in alphabetical order', () => {
+    const prompts = loadSkillPrompts('demo', root);
+    expect(Object.keys(prompts)).toEqual(['agent.md', 'system.md']);
+    expect(prompts).not.toHaveProperty('ignored.txt');
+  });
+
+  it('lists available skills from baseDir when the skill is unknown', () => {
+    let msg = '';
+    try {
+      loadSkillPrompts('missing', root);
+    } catch (err) {
+      msg = (err as Error).message;
+    }
+    expect(msg).toMatch(/Unknown skill: missing/);
+    // The available list is derived from baseDir, surfacing the fixture skills.
+    expect(msg).toMatch(/Available:.*demo/);
+  });
+
+  it('throws the no-prompts error for a baseDir skill missing prompts/', () => {
+    expect(() => loadSkillPrompts('no-prompts', root)).toThrow(/has no prompts\/ dir/);
+  });
+
+  it('still enforces the path-traversal guard even with a baseDir', () => {
+    expect(() => loadSkillPrompts('../escape', root)).toThrow(/illegal path component/i);
   });
 });

--- a/src/skills/_lib/prompt-loader.ts
+++ b/src/skills/_lib/prompt-loader.ts
@@ -11,14 +11,21 @@ import { fileURLToPath } from 'url';
  * Load all markdown prompts from a skill's prompts/ directory.
  * Returns a Record<filename, content> with keys in alphabetical order.
  *
- * @param name - The skill name (matches directory name under src/skills/)
+ * @param name - The skill name (matches a directory name under the skills root)
+ * @param baseDir - Optional absolute path to the skills root that CONTAINS the
+ *   `<name>/` directory. When omitted, resolves the in-tree skills root relative
+ *   to this module (`dist/skills` at runtime, `src/skills` under tsx). Pass this
+ *   so an out-of-tree plugin can load prompts bundled in its own package — e.g.
+ *   `loadSkillPrompts('my-skill', join(dirname(fileURLToPath(import.meta.url)), 'skills'))`.
  * @returns Record mapping filename to file content
  * @throws Error if skill directory or prompts/ subdirectory doesn't exist
  */
-export function loadSkillPrompts(name: string): Record<string, string> {
-  // P3 path-traversal guard: reject any name that could escape the skills/
-  // directory. This is a defence-in-depth check for future callers who may
-  // pass user-controlled input; today's callers already validate via getSkill().
+export function loadSkillPrompts(name: string, baseDir?: string): Record<string, string> {
+  // P3 path-traversal guard: reject any name that could escape the skills root.
+  // This is the only segment that ever derives from a skill id; the guard keeps
+  // a malicious `name` from climbing out of `baseDir` (or the in-tree root).
+  // Today's in-tree callers already validate via getSkill(); plugins pass a
+  // trusted baseDir, so the name remains the sole traversal vector here.
   if (
     name.includes('/') ||
     name.includes('\\') ||
@@ -28,16 +35,16 @@ export function loadSkillPrompts(name: string): Record<string, string> {
     throw new Error(`Skill name contains illegal path components: ${name}`);
   }
 
-  // Resolve the prompts directory relative to this file's location
-  const currentDir = dirname(fileURLToPath(import.meta.url));
-  const projectRoot = join(currentDir, '../..');
-  const skillPath = join(projectRoot, 'skills', name);
+  // Resolve the skills root: an explicit baseDir (plugin-supplied) wins; otherwise
+  // derive the in-tree root relative to this module's location.
+  const skillsDir =
+    baseDir ?? join(dirname(fileURLToPath(import.meta.url)), '../..', 'skills');
+  const skillPath = join(skillsDir, name);
   const promptsPath = join(skillPath, 'prompts');
 
   // Check if skill directory exists
   if (!existsSync(skillPath)) {
-    // Get available skills by listing src/skills/
-    const skillsDir = join(projectRoot, 'skills');
+    // Get available skills by listing the skills root
     let available: string[] = [];
     if (existsSync(skillsDir)) {
       try {


### PR DESCRIPTION
## What

Adds an optional second argument `baseDir` to `loadSkillPrompts(name)`. It is the **skills-root directory** that contains the `<name>/` dir. When supplied it overrides the in-tree root (resolved relative to the module), so an **out-of-tree plugin** can load prompts bundled in its own package:

```ts
loadSkillPrompts('my-skill', join(dirname(fileURLToPath(import.meta.url)), 'skills'))
```

## Why

Third step of the plugin-extensibility roadmap. Combined with:
- **#298** (merged) — a plugin `main` JS entrypoint that runs `registerSkill()` at session boot, and
- **#305** (open) — re-exporting the framework skill/facet API from `src/index.ts`,

…this lets a plugin register a skill **and resolve that skill's prompt files from its own directory**, rather than being forced to live in this repo's `src/skills/` tree.

## Backward compatibility

Fully additive. Every existing caller passes `name` only (verified: ~30 call sites across `src/skills/**`, `src/agent/tools/**`) and is unaffected — `baseDir` defaults to the current in-tree resolution.

## Safety

The `name` path-traversal guard (rejects `/`, `\`, leading `.`, `..`) still fires **regardless of `baseDir`**, so a malicious skill id cannot escape the supplied root. The available-skills listing and the no-prompts error now derive from the resolved root.

## Tests

`src/skills/_lib/prompt-loader.test.ts` extended with a `baseDir` suite (temp-fixture skills root): loads from baseDir, `.md`-only + alphabetical keys, unknown-skill listing from baseDir, no-prompts error, and guard-still-fires-with-baseDir. Existing guard + behavior tests unchanged.

- `tsc --noEmit` clean
- 21 prompt-loader tests green; consuming suites (`skill-executor`, `skill-load-mode`) green
