### PR TITLE
feat(plugins): load plugin entrypoints on chat/daemon/telegram surfaces (B4)

### DIFF
--- a/src/cli/commands/chat.mcp.test.ts
+++ b/src/cli/commands/chat.mcp.test.ts
@@ -99,6 +99,14 @@ vi.mock('../../agent/tools/compose-executor.js', () => ({
   ComposeExecutor: vi.fn().mockImplementation(() => ({})),
 }));
 
+// chat.ts awaits ensurePluginEntrypointsLoaded() before session construction
+// (plugin `main` entrypoints must run before the skill manifest is built). This
+// test isolates MCP wiring, so stub it to a no-op — the real impl scans the
+// filesystem for plugin roots, which is out of scope here.
+vi.mock('../../agent/tools/skill-bridge.js', () => ({
+  ensurePluginEntrypointsLoaded: vi.fn(async () => {}),
+}));
+
 vi.mock('../../agent/tools/nesting.js', () => ({
   createChildProviderFactory: vi.fn(() => ({})),
   createChildSkillExecutorFactory: vi.fn(() => ({})),

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -21,6 +21,7 @@ import { SubagentManager } from '../../agent/subagent.js';
 import { SubagentExecutor } from '../../agent/tools/subagent-executor.js';
 import { SkillExecutor } from '../../agent/tools/skill-executor.js';
 import { ComposeExecutor } from '../../agent/tools/compose-executor.js';
+import { ensurePluginEntrypointsLoaded } from '../../agent/tools/skill-bridge.js';
 import { createChildProviderFactory, createChildSkillExecutorFactory } from '../../agent/tools/nesting.js';
 import { AnthropicDirectProvider } from '../../agent/providers/anthropic-direct/index.js';
 import { BUILTIN_TOOL_NAMES } from '../../agent/tools/schemas.js';
@@ -627,6 +628,13 @@ export function registerChatCommand(program: Command): void {
             ...(mcpManager !== undefined ? { mcpManager } : {}),
           });
 
+
+        // Import any plugin JS entrypoints (manifest `main`) before constructing
+        // the session: the skill manifest is assembled synchronously in the
+        // AgentSession constructor, so a plugin's registerSkill() side-effects
+        // must already have run for its code-backed skills to appear. Idempotent
+        // + non-fatal; no-op without plugins.
+        await ensurePluginEntrypointsLoaded();
 
         // Witness layer: `trace` was opened above (before executors) so
         // SkillExecutor could be wired with traceWriter; reuse it here for

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -29,6 +29,7 @@ import { SubagentManager } from '../../agent/subagent.js';
 import { SubagentExecutor } from '../../agent/tools/subagent-executor.js';
 import { SkillExecutor } from '../../agent/tools/skill-executor.js';
 import { ComposeExecutor } from '../../agent/tools/compose-executor.js';
+import { ensurePluginEntrypointsLoaded } from '../../agent/tools/skill-bridge.js';
 import { createChildProviderFactory, createChildSkillExecutorFactory, createStubParentSession } from '../../agent/tools/nesting.js';
 import { AnthropicDirectProvider } from '../../agent/providers/anthropic-direct/index.js';
 import { BUILTIN_TOOL_NAMES } from '../../agent/tools/schemas.js';
@@ -396,6 +397,15 @@ export function registerDaemonCommand(program: Command): void {
       const daemonModel = getModel();
       const daemonApiKey = getApiKey();
       const daemonCwdResolved = daemonCwd !== undefined && daemonCwd.length > 0 ? daemonCwd : undefined;
+
+      // Import any plugin JS entrypoints (manifest `main`) once at daemon
+      // startup, before the session factory is built and before the scheduler
+      // spawns any task session. Each daemon-spawned session assembles its skill
+      // manifest synchronously at construction, so a plugin's registerSkill()
+      // side-effects must already have run for its code-backed skills (e.g. a
+      // scheduled task command) to resolve. Idempotent + non-fatal; no-op
+      // without plugins.
+      await ensurePluginEntrypointsLoaded();
 
       // Build a fully-wired session factory so skill/agent/compose tools are
       // available in daemon-spawned sessions. Without this, commands like

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -5,6 +5,7 @@
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TelegramBot } from './bot';
 import { isRateLimitError, isNetworkError } from './error-utils';
+import * as skillBridge from '../agent/tools/skill-bridge.js';
 import type { IAgentSession, AgentConfig, SessionState, OutputEvent } from '../agent/types';
 import type { Context } from 'telegraf';
 
@@ -278,6 +279,30 @@ describe('TelegramBot', () => {
 
     test('should allow stop even if not running', async () => {
       await expect(bot.stop()).resolves.not.toThrow();
+    });
+
+    test('loads plugin entrypoints before launching the bot', async () => {
+      // Invariant: a plugin's registerSkill() side-effects must run before the
+      // first update is handled, because each per-chat session assembles its
+      // skill manifest synchronously at construction. Lock the ordering:
+      // ensurePluginEntrypointsLoaded() must be awaited before bot.launch().
+      const order: string[] = [];
+      const entrypointsSpy = vi
+        .spyOn(skillBridge, 'ensurePluginEntrypointsLoaded')
+        .mockImplementation(async () => {
+          order.push('entrypoints');
+        });
+      (bot as any).bot.launch = vi.fn(async () => {
+        order.push('launch');
+      });
+      (bot as any).bot.telegram.setMyCommands = vi.fn(async () => {});
+
+      await bot.start();
+      await bot.stop();
+
+      expect(entrypointsSpy).toHaveBeenCalledTimes(1);
+      expect(order).toEqual(['entrypoints', 'launch']);
+      entrypointsSpy.mockRestore();
     });
   });
 });

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -20,6 +20,7 @@ import {
   composeTelegramElicitation,
 } from './elicitation-telegram.js';
 import { elicitationRouter } from '../agent/elicitation-router.js';
+import { ensurePluginEntrypointsLoaded } from '../agent/tools/skill-bridge.js';
 import { SessionWatchManager, resolveWatchTarget, listWatchableSessions } from './watch.js';
 import { readPresenceFiles } from '../agent/awareness/presence.js';
 import { readSessionKey, signAbortRequest, freshChannelId } from '../agent/afk-channel.js';
@@ -303,6 +304,13 @@ export class TelegramBot {
       );
       elicitationRouter.install(composeTelegramElicitation(askHandler, formHandler));
     }
+
+    // Import any plugin JS entrypoints (manifest `main`) before launching: each
+    // per-chat session assembles its skill manifest synchronously at
+    // construction, so a plugin's registerSkill() side-effects must already have
+    // run before the first update is handled. Idempotent + non-fatal; no-op
+    // without plugins.
+    await ensurePluginEntrypointsLoaded();
 
     this.log('Starting bot...');
     await this.bot.launch();


### PR DESCRIPTION
## What

Completes the plugin-entrypoint wiring across all top-level surfaces. **#298** added the plugin `main` JS entrypoint mechanism (`ensurePluginEntrypointsLoaded()`) but wired only the REPL. This wires the remaining three so plugin-contributed, **code-backed** skills are available everywhere a session is constructed:

| Surface | Placement | Why there |
|---|---|---|
| `chat` | `await` before `new AgentSession` in the one-shot action | single-pass; manifest builds synchronously in the constructor |
| `daemon` | `await` once at startup, before the session factory + scheduler | the factory closure `(config) => AgentSession` is **synchronous**, so loading inside it is the wrong layer; a plugin can own a scheduled task |
| `telegram` | `await` in `bot.start()` before `bot.launch()` | entrypoints must run before the first update constructs a per-chat session |

Subagents inherit the parent process registry, so no child wiring is needed.

## Why this placement

The skill manifest is assembled **synchronously in the `AgentSession` constructor**, so a plugin's `registerSkill()` side-effects must already have run before construction. There is no single shared pre-construction chokepoint (sessions are built at ~7 sites), which is why each surface awaits the shared helper. The helper is **idempotent + process-global + non-fatal per plugin**, so each call is cheap and a no-op without plugins.

## Tests

- **`bot.test.ts`** — new test locks the ordering invariant: `ensurePluginEntrypointsLoaded()` is awaited **before** `bot.launch()`.
- **`chat.mcp.test.ts`** — stubs `skill-bridge` (a new heavy dependency of `chat.ts` — the real impl scans the filesystem for plugin roots), matching how the test already stubs the sibling executors to isolate MCP wiring. Without the stub the MCP test hit the real plugin scan.

## Verification

- `tsc --noEmit` clean
- `src/telegram/` + `src/cli/commands/` full sweep: **1599 tests pass** (incl. the new ordering test and the fixed MCP tests)

## Roadmap

Part of the moat-as-plugin track. With #298 (entrypoint) + #305 (public runtime API) + #307 (`loadSkillPrompts(baseDir?)`) + this (all surfaces wired), an out-of-tree plugin can register skills, resolve their prompts, and have them load on every surface. Next: the extraction itself.
