### PR TITLE
fix(daemon): redact filename in pull-queue quarantine log lines

### DIFF
--- a/src/agent/daemon/queue-store.test.ts
+++ b/src/agent/daemon/queue-store.test.ts
@@ -3,7 +3,7 @@
  * @module agent/daemon/queue-store.test
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, readdirSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -215,5 +215,46 @@ describe('listPending', () => {
     const remaining = readdirSync(tmpDir).filter((f) => f.endsWith('.json'));
     expect(remaining).toHaveLength(3);
     expect(readdirSync(tmpDir)).not.toContain('poison');
+  });
+});
+
+describe('filename redaction in log output', () => {
+  // Anthropic API key pattern that redactInlineSecrets replaces.
+  // Using a syntactically-valid key shape so the pattern fires reliably.
+  const SECRET_FILENAME = 'sk-ant-api03-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA.json';
+
+  it('redacts a secret-shaped filename from quarantine log (dequeueNext path)', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      writeFileSync(join(tmpDir, `0000-${SECRET_FILENAME}`), '{ invalid json');
+      dequeueNext(tmpDir);
+    } finally {
+      spy.mockRestore();
+    }
+    // Every console.error call must NOT contain the raw secret-shaped name.
+    const raw = SECRET_FILENAME;
+    for (const call of spy.mock.calls) {
+      const msg = String(call[0]);
+      expect(msg).not.toContain(raw);
+      // The log line should contain a redaction marker instead.
+      expect(msg).toMatch(/<REDACTED/);
+    }
+  });
+
+  it('redacts a secret-shaped filename from listPending log', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      // Write corrupt content under the secret-shaped name.
+      writeFileSync(join(tmpDir, `0000-${SECRET_FILENAME}`), '{ invalid json');
+      listPending(tmpDir);
+    } finally {
+      spy.mockRestore();
+    }
+    const raw = SECRET_FILENAME;
+    for (const call of spy.mock.calls) {
+      const msg = String(call[0]);
+      expect(msg).not.toContain(raw);
+      expect(msg).toMatch(/<REDACTED/);
+    }
   });
 });

--- a/src/agent/daemon/queue-store.ts
+++ b/src/agent/daemon/queue-store.ts
@@ -167,13 +167,18 @@ export function dequeueNext(queueDir: string = getQueueDir()): QueuedTask | null
  * outcome is logged to stderr so the operator can investigate.
  */
 function quarantinePoisonEntry(queueDir: string, filename: string, err: unknown): void {
-  // Redact every error-derived string before logging: a JSON.parse SyntaxError
+  // Redact every caller-supplied string before logging. The filename comes from
+  // the OS readdir listing — normally safe (<seq>-q-<ts>-<hex>.json), but a
+  // stray file with a secret-shaped name dropped into the queue dir would be
+  // logged unredacted without this guard. Error-derived strings (reason,
+  // moveReason, unlinkReason) carry the same risk: a JSON.parse SyntaxError
   // can embed a snippet of the malformed entry's bytes, and a queue `command`
   // may carry an inline secret. This matches the daemon's existing convention
   // for error-derived logs (see redactInlineSecrets use in scheduler.ts runOnce).
   // NOTE(#337-poison-telemetry): quarantines are logged to stderr only — a
   // structured `status:'poison'` telemetry record for parity with runOnce is a
   // tracked follow-up, not added here to keep the change focused.
+  const redactedFilename = redactInlineSecrets(filename);
   const reason = redactInlineSecrets(err instanceof Error ? err.message : String(err));
   const poisonDir = join(queueDir, POISON_SUBDIR);
   const src = join(queueDir, filename);
@@ -194,7 +199,7 @@ function quarantinePoisonEntry(queueDir: string, filename: string, err: unknown)
     }
     // eslint-disable-next-line no-console
     console.error(
-      `[daemon] pull-queue: quarantined malformed entry ${filename} → ${POISON_SUBDIR}/ (${reason})`,
+      `[daemon] pull-queue: quarantined malformed entry ${redactedFilename} → ${POISON_SUBDIR}/ (${reason})`,
     );
   } catch (moveErr) {
     // Last resort: if we cannot move it aside, unlink so the queue unblocks
@@ -202,7 +207,7 @@ function quarantinePoisonEntry(queueDir: string, filename: string, err: unknown)
     const moveReason = redactInlineSecrets(moveErr instanceof Error ? moveErr.message : String(moveErr));
     // eslint-disable-next-line no-console
     console.error(
-      `[daemon] pull-queue: failed to quarantine malformed entry ${filename}; removing to unblock queue (${moveReason})`,
+      `[daemon] pull-queue: failed to quarantine malformed entry ${redactedFilename}; removing to unblock queue (${moveReason})`,
     );
     try {
       unlinkSync(src);
@@ -216,7 +221,7 @@ function quarantinePoisonEntry(queueDir: string, filename: string, err: unknown)
       );
       // eslint-disable-next-line no-console
       console.error(
-        `[daemon] pull-queue: could not remove unquarantinable entry ${filename}; will retry next tick (${unlinkReason})`,
+        `[daemon] pull-queue: could not remove unquarantinable entry ${redactedFilename}; will retry next tick (${unlinkReason})`,
       );
     }
   }
@@ -252,10 +257,11 @@ export function listPending(queueDir: string = getQueueDir()): QueuedTask[] {
     try {
       tasks.push(JSON.parse(readFileSync(filePath, 'utf-8')) as QueuedTask);
     } catch (err) {
+      const redactedFilename = redactInlineSecrets(filename);
       const reason = redactInlineSecrets(err instanceof Error ? err.message : String(err));
       // eslint-disable-next-line no-console
       console.error(
-        `[daemon] pull-queue: skipping unreadable entry ${filename} in listPending (${reason})`,
+        `[daemon] pull-queue: skipping unreadable entry ${redactedFilename} in listPending (${reason})`,
       );
     }
   }


### PR DESCRIPTION
All four console.error sites in quarantinePoisonEntry() and listPending()
that interpolated the raw `filename` now wrap it in redactInlineSecrets()
before logging. The error-derived strings (reason, moveReason, unlinkReason)
were already redacted; this closes the asymmetric gap noted in #250.

Updated the comment block to document the filename redaction rationale, and
added two focused vitest cases asserting that a secret-shaped filename
(sk-ant-api03-... pattern) is never emitted raw to stderr from either path.

Closes #250
