### PR TITLE
fix(cli): don't silently exit plan mode on /afk off

### DIFF
--- a/src/cli/slash/commands/afk.test.ts
+++ b/src/cli/slash/commands/afk.test.ts
@@ -63,6 +63,23 @@ describe('/afk command', () => {
     expect(toggleAfkMode).toHaveBeenCalledWith(ctx, true);
   });
 
+  it('/afk off while in plan mode — warns, preserves plan mode, does NOT toggle', async () => {
+    const warn = vi.fn();
+    const ctx = { ...ctxWithMode('plan'), out: { warn } } as unknown as SlashContext;
+    const result = await afkCmd.handler(ctx, 'off');
+    // Must not clobber plan mode via toggleAfkMode
+    expect(toggleAfkMode).not.toHaveBeenCalled();
+    // Must return continue (no-op for the REPL loop)
+    expect(result).toBe('continue');
+    // Must surface a helpful, accurate message
+    expect(warn).toHaveBeenCalledOnce();
+    const msg: string = warn.mock.calls[0][0] as string;
+    expect(msg).toMatch(/plan mode/i);
+    expect(msg).toMatch(/\/plan off/i);
+    // permissionMode must remain 'plan' (ctx was not mutated)
+    expect((ctx as unknown as { stats: { permissionMode: string } }).stats.permissionMode).toBe('plan');
+  });
+
   it('exposes correct metadata', () => {
     expect(afkCmd.name).toBe('/afk');
     expect(afkCmd.usage).toContain('/afk');

--- a/src/cli/slash/commands/afk.ts
+++ b/src/cli/slash/commands/afk.ts
@@ -50,6 +50,15 @@ export const afkCmd: SlashCommand = {
       // Already on — suppress the no-op success line for ergonomics.
       return 'continue';
     }
+    if (!desired && ctx.stats.permissionMode === 'plan') {
+      // In plan mode — AFK has never been on, so there is nothing to turn off.
+      // Do NOT call toggleAfkMode here: it would call setPermissionMode('default')
+      // and silently drop plan mode with a misleading "AFK mode OFF" message.
+      ctx.out.warn(
+        'AFK is already off — you\'re in plan mode. Use \`/plan off\` to leave plan mode.',
+      );
+      return 'continue';
+    }
     if (!desired && ctx.stats.permissionMode !== 'autonomous') {
       // Already off — surface the affordance with a no-op toggle.
       await toggleAfkMode(ctx, false);

--- a/src/cli/slash/commands/afk.ts
+++ b/src/cli/slash/commands/afk.ts
@@ -55,7 +55,7 @@ export const afkCmd: SlashCommand = {
       // Do NOT call toggleAfkMode here: it would call setPermissionMode('default')
       // and silently drop plan mode with a misleading "AFK mode OFF" message.
       ctx.out.warn(
-        'AFK is already off — you\'re in plan mode. Use \`/plan off\` to leave plan mode.',
+        'AFK is already off — you\'re in plan mode. Use `/plan off` to leave plan mode.',
       );
       return 'continue';
     }


### PR DESCRIPTION
When `permissionMode === 'plan'`, the existing 'already off' guard
(`!desired && permissionMode !== 'autonomous'`) was true, so it called
`toggleAfkMode(ctx, false)` which invoked `setPermissionMode('default')`,
silently dropping plan mode and printing a misleading 'AFK mode OFF —
default permissions restored' message — even though the user was never
in AFK mode.

Fix: add an explicit `permissionMode === 'plan'` guard that short-circuits
before the toggle call, emits a clear warning directing the user to
`/plan off`, and returns without mutating session state.

Test: new focused case asserts toggle is not called, result is 'continue',
warn message references both 'plan mode' and '/plan off', and
permissionMode remains 'plan'.

Closes #199
