### PR TITLE
test(web): backfill 4 uncovered scraper/render branches

### DIFF
--- a/src/browser/playwright/launcher.test.ts
+++ b/src/browser/playwright/launcher.test.ts
@@ -364,6 +364,36 @@ describe('BrowserLauncher', () => {
       expect(ctx.newPage).not.toHaveBeenCalled();
       expect(ctx.close).toHaveBeenCalledTimes(1);
     });
+
+    it('returns httpStatus:null when page.goto() resolves to null', async () => {
+      // Branch: launcher.ts ~L342 — `resp !== null ? resp.status() : null`.
+      // Playwright's goto() can return null when no HTTP response is produced
+      // (e.g. about:blank, data: URIs, or certain navigation modes). We mock
+      // goto to resolve to null and assert the result carries httpStatus:null.
+      const launcher = new BrowserLauncher(TEST_CONFIG);
+      const ctx = makeStubContext();
+      currentStubBrowser.newContext.mockResolvedValueOnce(ctx);
+      ctx.newPage.mockImplementationOnce(async () => {
+        const p = makeStubPage();
+        // goto resolves to null — no HTTP response object.
+        p.goto.mockResolvedValueOnce(null);
+        p.content.mockResolvedValueOnce('<html><body>no-response page</body></html>');
+        p.url.mockReturnValue('about:blank');
+        ctx._pages.push(p);
+        return p;
+      });
+
+      const out = await launcher.renderHtml('about:blank', {
+        timeoutMs: 5000,
+        waitUntil: 'load',
+      });
+
+      expect(out.httpStatus).toBeNull();
+      expect(out.html).toBe('<html><body>no-response page</body></html>');
+      expect(out.finalUrl).toBe('about:blank');
+      // Context must still be torn down.
+      expect(ctx.close).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('getPage', () => {

--- a/src/web/extract.test.ts
+++ b/src/web/extract.test.ts
@@ -7,7 +7,8 @@
  * (c) sparse pages degrade to a flagged whole-body fallback.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { Readability } from '@mozilla/readability';
 import { extractReadableMarkdown, THIN_CONTENT_CHARS } from './extract.js';
 
 /** A realistic article page with nav, sidebar, and footer chrome around it. */
@@ -110,5 +111,31 @@ describe('extractReadableMarkdown — thin / fallback paths', () => {
     expect(out.usedFallback).toBe(true);
     expect(out.markdown).toBe('');
     expect(out.textLength).toBe(0);
+  });
+});
+
+describe('extractReadableMarkdown — Readability.parse() throws (safeExtract catch branch)', () => {
+  it('falls back to whole-body content when Readability.parse() throws', () => {
+    // Branch: extract.ts lines 84-89 — the try/catch around `new Readability(clone).parse()`.
+    // When parse() throws (degenerate DOM or internal error), article is set to
+    // null and the function falls through to the whole-body fallback path.
+    // We spy on Readability.prototype.parse to simulate the throw deterministically.
+    const parseSpy = vi.spyOn(Readability.prototype, 'parse').mockImplementationOnce(() => {
+      throw new Error('simulated Readability parse failure');
+    });
+
+    // Provide an HTML page with visible body content so the fallback path
+    // returns something we can assert on.
+    const html = `<!DOCTYPE html><html><head><title>Throws Doc</title></head>
+      <body><div>fallback body content</div></body></html>`;
+
+    const out = extractReadableMarkdown(html, 'https://example.com/throws');
+
+    // The throw was swallowed; we fell back to the whole-body path.
+    expect(out.usedFallback).toBe(true);
+    expect(out.title).toBe('Throws Doc');
+    expect(out.markdown).toContain('fallback body content');
+
+    parseSpy.mockRestore();
   });
 });

--- a/src/web/scrape.test.ts
+++ b/src/web/scrape.test.ts
@@ -198,4 +198,63 @@ describe('scrapeToMarkdown — cancellation', () => {
       }),
     ).rejects.toThrow();
   });
+
+  it('propagates an abort that occurs during render (Phase 3 signal.aborted guard)', async () => {
+    // Branch: scrape.ts ~L170 — signal is aborted when the render catch block
+    // runs. The renderFn fires the abort and then throws so the catch branch
+    // sees signal.aborted === true and re-throws rather than degrading.
+    const ac = new AbortController();
+    const fetchFn = vi.fn(async () =>
+      makeResponse({ contentType: 'text/html', body: SHELL_HTML }),
+    );
+    const renderFn = vi.fn<RenderFn>(async () => {
+      ac.abort(new Error('render aborted'));
+      throw new Error('render aborted');
+    });
+
+    await expect(
+      scrapeToMarkdown('https://example.com/a', {
+        fetchFn: fetchFn as unknown as typeof fetch,
+        renderFn,
+        timeoutMs: 5000,
+        signal: ac.signal,
+      }),
+    ).rejects.toThrow(/render aborted/);
+  });
+});
+
+describe('scrapeToMarkdown — render produces fewer chars than thin fetch', () => {
+  it('returns the fetched content with usedRender:false when render yields less text', async () => {
+    // Branch: scrape.ts ~L160 — render succeeds but renderedContent.textLength
+    // is strictly less than fetched.textLength. The condition
+    // `renderedContent.textLength >= fetched.textLength` is false so we fall
+    // through to Phase 4 and return the thin fetched content with usedRender:false.
+    //
+    // Setup: the thin shell HTML has a visible "Loading…" word (a few chars of
+    // text). The render returns a completely empty document — even fewer chars —
+    // so the comparison flips and we keep the fetch result.
+    const fetchFn = vi.fn(async () =>
+      makeResponse({ contentType: 'text/html', body: SHELL_HTML }),
+    );
+    const emptyHtml = '<html><head><title></title></head><body></body></html>';
+    const renderFn = vi.fn<RenderFn>(async () => ({
+      html: emptyHtml,
+      finalUrl: 'https://example.com/a',
+      httpStatus: 200,
+    }));
+
+    const out = await scrapeToMarkdown('https://example.com/a', {
+      fetchFn: fetchFn as unknown as typeof fetch,
+      renderFn,
+      timeoutMs: 5000,
+      signal: freshSignal(),
+    });
+
+    // Render was invoked (thin fetch triggered escalation)…
+    expect(renderFn).toHaveBeenCalledOnce();
+    // …but the render produced less content, so we fell back to the fetch result.
+    expect(out.usedRender).toBe(false);
+    // The thin fetched content should be present (the "Loading" text from SHELL_HTML).
+    expect(out.markdown).toContain('Loading');
+  });
 });


### PR DESCRIPTION
Cover the four branches identified in #181:

1. scrape.ts Phase 3 — render succeeds but produces fewer chars than the
   thin fetch → falls through to Phase 4, returning usedRender:false.
2. launcher.ts renderHtml — page.goto() resolves to null (no HTTP response,
   e.g. about:blank) → httpStatus:null in the returned RenderedPage.
3. extract.ts — Readability.parse() throws (degenerate DOM); spy forces the
   throw, verifies the catch branch sets article=null and falls back to the
   whole-body path (usedFallback:true).
4. scrape.ts Phase 3 signal.aborted guard — renderFn aborts the controller
   then throws; the catch re-throws rather than degrading gracefully.

No production code changes. All 64 tests in the three touched files pass;
pnpm lint (tsc --noEmit) is clean.

Closes #181
