### PR TITLE
test(daemon): cover pull-queue poison fallback + collision-retry branches

### DIFF
--- a/src/agent/daemon/queue-store-poison-fallback.test.ts
+++ b/src/agent/daemon/queue-store-poison-fallback.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests for quarantinePoisonEntry fallback branches in queue-store.
+ *
+ * Lives in its own file because vi.mock('node:fs', ...) is hoisted to module
+ * scope and replaces the fs module for the entire module graph of this file.
+ * Isolating here prevents the mock from contaminating queue-store.test.ts.
+ *
+ * Covered branches (issue #253):
+ *   Branch 1 (outer-catch): both renameSync attempts throw → falls back to
+ *     unlinkSync so the queue unblocks.
+ *   Branch 2 (inner-catch): both renameSync AND unlinkSync throw →
+ *     quarantinePoisonEntry still does NOT rethrow; the entry is left in place
+ *     and retried on the next tick.
+ *
+ * @module agent/daemon/queue-store-poison-fallback.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as realFs from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// ---------------------------------------------------------------------------
+// Mock strategy:
+//
+//   We replace `renameSync` and `unlinkSync` with controlled fakes while
+//   delegating everything else (mkdirSync, readdirSync, readFileSync,
+//   writeFileSync, mkdtempSync, rmSync, …) to the real implementation so
+//   that test setup/teardown and assertions against real disk state work.
+//
+//   `renameSyncShouldThrow` and `unlinkSyncShouldThrow` are module-scoped
+//   flags that individual tests flip on/off to arm specific branches.
+//   Flags are reset to false in beforeEach so tests are independent.
+//
+//   vi.mock is hoisted above imports by vitest so the mock is in place when
+//   queue-store.ts is first imported.
+// ---------------------------------------------------------------------------
+
+let renameSyncShouldThrow = false;
+let unlinkSyncShouldThrow = false;
+
+vi.mock('node:fs', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...original,
+    renameSync: (...args: Parameters<typeof original.renameSync>): void => {
+      if (renameSyncShouldThrow) {
+        const err = new Error('EPERM: operation not permitted, rename') as NodeJS.ErrnoException;
+        err.code = 'EPERM';
+        throw err;
+      }
+      original.renameSync(...args);
+    },
+    unlinkSync: (...args: Parameters<typeof original.unlinkSync>): void => {
+      if (unlinkSyncShouldThrow) {
+        const err = new Error('EACCES: permission denied, unlink') as NodeJS.ErrnoException;
+        err.code = 'EACCES';
+        throw err;
+      }
+      original.unlinkSync(...args);
+    },
+  };
+});
+
+// Import AFTER vi.mock is registered (hoisting ensures this executes first).
+import { dequeueNext } from './queue-store.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures — use realFs for setup/teardown to bypass the rename/unlink mock
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  renameSyncShouldThrow = false;
+  unlinkSyncShouldThrow = false;
+  tmpDir = realFs.mkdtempSync(join(tmpdir(), 'afk-queue-fallback-test-'));
+});
+
+afterEach(() => {
+  renameSyncShouldThrow = false;
+  unlinkSyncShouldThrow = false;
+  realFs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('quarantinePoisonEntry — outer-catch fallback (branch 1: both renames fail)', () => {
+  it('unlinks the entry and unblocks the queue when both renameSync calls throw', () => {
+    // Arm: all renameSync calls throw EPERM (simulating a permission error that
+    // blocks every rename attempt, including the timestamp-suffixed retry).
+    renameSyncShouldThrow = true;
+
+    // Write a malformed entry followed by a valid task.
+    realFs.writeFileSync(join(tmpDir, '0001-q-poison.json'), 'not-json');
+    realFs.writeFileSync(join(tmpDir, '0002-q-valid.json'), JSON.stringify({
+      id: 'q-1-valid',
+      command: 'echo hi',
+      enqueuedAt: new Date().toISOString(),
+      sequence: 2,
+    }));
+
+    // dequeueNext must not throw even though rename fails.
+    // quarantinePoisonEntry falls back to unlinkSync (which succeeds — only
+    // renameSync is mocked to throw), removes the poison entry, then continues
+    // the loop and returns the valid task — all in a single call.
+    const result = dequeueNext(tmpDir);
+
+    // The valid task behind the poison entry was reached — queue unblocked.
+    expect(result).not.toBeNull();
+    expect(result!.command).toBe('echo hi');
+
+    // The FIFO path is now clear: both entries were consumed on the single call.
+    const remaining = realFs.readdirSync(tmpDir).filter(
+      (f) => f.endsWith('.json') && !f.startsWith('.tmp-'),
+    );
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('does not throw even when both renames fail (outer-catch is never-throw)', () => {
+    renameSyncShouldThrow = true;
+
+    realFs.writeFileSync(join(tmpDir, '0001-q-poison.json'), 'garbage');
+
+    // Must complete without propagating the rename error.
+    expect(() => dequeueNext(tmpDir)).not.toThrow();
+  });
+});
+
+describe('quarantinePoisonEntry — inner-catch (branch 2: rename AND unlink fail)', () => {
+  it('does not throw when both renameSync and unlinkSync fail', () => {
+    // Arm: every rename AND unlink throws — the "unremovable entry" scenario.
+    renameSyncShouldThrow = true;
+    unlinkSyncShouldThrow = true;
+
+    realFs.writeFileSync(join(tmpDir, '0001-q-stuck.json'), 'bad-json');
+
+    // quarantinePoisonEntry must swallow the unlinkSync error too — never rethrows.
+    expect(() => dequeueNext(tmpDir)).not.toThrow();
+  });
+
+  it('leaves the entry in place (for retry on next tick) when unlink also fails', () => {
+    renameSyncShouldThrow = true;
+    unlinkSyncShouldThrow = true;
+
+    const poisonFile = '0001-q-stuck.json';
+    realFs.writeFileSync(join(tmpDir, poisonFile), 'bad-json');
+
+    dequeueNext(tmpDir);
+
+    // The entry could not be moved or removed — it stays in the queue dir.
+    // dequeueNext's loop still exits (did not deadlock), but the file remains
+    // for the next tick to retry.
+    const entries = realFs.readdirSync(tmpDir).filter(
+      (f) => f.endsWith('.json') && !f.startsWith('.tmp-'),
+    );
+    expect(entries).toContain(poisonFile);
+  });
+
+  it('returns null (not a crash) when every entry is stuck', () => {
+    renameSyncShouldThrow = true;
+    unlinkSyncShouldThrow = true;
+
+    realFs.writeFileSync(join(tmpDir, '0001-q-stuck.json'), 'garbage');
+
+    // dequeueNext returns null — the stuck entry is logged and skipped for
+    // this tick, and the loop terminates cleanly.
+    const result = dequeueNext(tmpDir);
+    expect(result).toBeNull();
+  });
+});

--- a/src/agent/daemon/queue-store.test.ts
+++ b/src/agent/daemon/queue-store.test.ts
@@ -176,6 +176,44 @@ describe('dequeueNext — malformed (poison) entries', () => {
     );
     expect(remaining).toHaveLength(0);
   });
+
+  it('collision-retry: uses a unique name when the first rename fails (dest already a directory)', () => {
+    // Branch: quarantinePoisonEntry inner try/catch — first renameSync(src, poison/<filename>)
+    // throws because poison/<filename> already exists as a directory (EISDIR on macOS/Linux).
+    // The retry path appends `${Date.now()}-${randomHex}-<filename>` so the original
+    // poison file (directory here) is never overwritten.
+    //
+    // Setup: pre-create poison/<filename> as a DIRECTORY so renameSync throws EISDIR.
+    const poisonDir = join(tmpDir, 'poison');
+    const poisonedFilename = '0001-q-collision.json';
+    mkdirSync(join(poisonDir, poisonedFilename), { recursive: true });
+
+    // Write the actual (malformed) queue entry with the same name at the queue root.
+    writeFileSync(join(tmpDir, poisonedFilename), 'not-valid-json');
+
+    dequeueNext(tmpDir);
+
+    // The original destination (the directory) is still there — it was NOT overwritten.
+    const poisonEntries = readdirSync(poisonDir);
+    // The directory sentinel is still there; plus one new uniquely-named file.
+    expect(poisonEntries.length).toBe(2);
+
+    // The newly-quarantined file has the timestamp+random prefix pattern and is a FILE.
+    const newEntry = poisonEntries.find((e) => e !== poisonedFilename);
+    expect(newEntry).toBeDefined();
+    // Pattern: <digits>-<hex>-<original filename>
+    expect(newEntry).toMatch(new RegExp(`^\\d+-[a-z0-9]+-${poisonedFilename.replace('.', '\\.')}$`));
+
+    // The content of the uniquely-named file is preserved from the original malformed entry.
+    const rescued = readFileSync(join(poisonDir, newEntry!), 'utf-8');
+    expect(rescued).toBe('not-valid-json');
+
+    // The malformed entry is no longer in the FIFO path (the src was moved).
+    const queueEntries = readdirSync(tmpDir).filter(
+      (f) => f.endsWith('.json') && !f.startsWith('.tmp-'),
+    );
+    expect(queueEntries).toHaveLength(0);
+  });
 });
 
 describe('listPending', () => {

--- a/src/agent/daemon/scheduler-pull-catch.test.ts
+++ b/src/agent/daemon/scheduler-pull-catch.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for the pullTick outer-catch path in CronScheduler (issue #253).
+ *
+ * Lives in its own file because vi.mock('./queue-store.js') is hoisted to
+ * module scope, replacing queue-store for the entire module graph of this
+ * file.  Isolating avoids contaminating scheduler-pull.test.ts which uses the
+ * real queue-store with real disk I/O.
+ *
+ * Covered branch (issue #253 — branch 4, optional):
+ *   pullTick outer-catch: when dequeueNext throws, the error is logged but
+ *   the poll loop survives (isDequeuing is reset, no unhandled rejection).
+ *
+ * @module agent/daemon/scheduler-pull-catch.test
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { AgentConfig } from '../types.js';
+import type { AgentSession } from '../session/agent-session.js';
+
+// ---------------------------------------------------------------------------
+// Mock strategy:
+//
+//   `dequeueNext` is mocked at module scope so CronScheduler (which imports
+//   it from './queue-store.js') picks up the fake. Each test can override the
+//   mock implementation via `vi.mocked(dequeueNext).mockImplementation(...)`.
+//
+//   We also spy on console.error to verify the pull-tick-failed log fires
+//   without hard-asserting its exact wording (a sibling issue is changing the
+//   exact log text).
+// ---------------------------------------------------------------------------
+
+vi.mock('./queue-store.js', () => ({
+  dequeueNext: vi.fn(),
+  enqueue: vi.fn(),
+  listPending: vi.fn().mockReturnValue([]),
+}));
+
+// Import AFTER vi.mock is registered (vitest hoists vi.mock above imports).
+import { CronScheduler } from './scheduler.js';
+import { dequeueNext } from './queue-store.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMockSession(response = 'ok'): AgentSession {
+  return {
+    sendMessage: vi.fn().mockResolvedValue({ content: response }),
+    close: vi.fn().mockResolvedValue(undefined),
+  } as unknown as AgentSession;
+}
+
+function makeScheduler(
+  queueDir: string,
+  telemetryPath: string,
+  sessionFactory?: (config: AgentConfig) => AgentSession,
+): CronScheduler {
+  return new CronScheduler({
+    queueDir,
+    telemetryPath,
+    pullPollIntervalMs: 30_000,
+    sessionFactory: sessionFactory ?? (() => makeMockSession()),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+let queueDir: string;
+let telemetryDir: string;
+let telemetryPath: string;
+let homeDir: string | undefined;
+let savedAfkHome: string | undefined;
+let savedAllowProjectMcp: string | undefined;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  queueDir = mkdtempSync(join(tmpdir(), 'afk-pull-catch-test-queue-'));
+  telemetryDir = mkdtempSync(join(tmpdir(), 'afk-pull-catch-test-tel-'));
+  telemetryPath = join(telemetryDir, 'forge-telemetry.jsonl');
+  homeDir = mkdtempSync(join(tmpdir(), 'afk-pull-catch-test-home-'));
+  savedAfkHome = process.env['AFK_HOME'];
+  savedAllowProjectMcp = process.env['AFK_ALLOW_PROJECT_MCP'];
+  process.env['AFK_HOME'] = homeDir;
+  process.env['AFK_ALLOW_PROJECT_MCP'] = '0';
+
+  vi.mocked(dequeueNext).mockReset();
+});
+
+afterEach(async () => {
+  vi.useRealTimers();
+  rmSync(queueDir, { recursive: true, force: true });
+  rmSync(telemetryDir, { recursive: true, force: true });
+  if (savedAfkHome === undefined) delete process.env['AFK_HOME'];
+  else process.env['AFK_HOME'] = savedAfkHome;
+  if (savedAllowProjectMcp === undefined) delete process.env['AFK_ALLOW_PROJECT_MCP'];
+  else process.env['AFK_ALLOW_PROJECT_MCP'] = savedAllowProjectMcp;
+  if (homeDir !== undefined) rmSync(homeDir, { recursive: true, force: true });
+  homeDir = undefined;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('pullTick — outer-catch branch (branch 4: dequeueNext throws)', () => {
+  it('logs the error but does NOT crash or rethrow when dequeueNext throws', async () => {
+    // Arm: dequeueNext throws an unexpected error that escapes quarantinePoisonEntry.
+    vi.mocked(dequeueNext).mockImplementation(() => {
+      throw new Error('unexpected dequeue failure');
+    });
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const scheduler = makeScheduler(queueDir, telemetryPath);
+    scheduler.startPullLoop();
+
+    // Advance past one poll interval — pullTick fires and hits the outer catch.
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    // The scheduler is still alive — stop() resolves cleanly (no unhandled rejection).
+    await expect(scheduler.stop()).resolves.toBeUndefined();
+
+    // console.error was called (the pull-tick-failed log fired).
+    // We assert it was called at least once rather than on exact wording,
+    // because issue #250 is changing the log text.
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
+  it('resets isDequeuing after a pullTick catch so the next tick can proceed', async () => {
+    // First call throws; second call succeeds and returns null (empty queue).
+    let callCount = 0;
+    vi.mocked(dequeueNext).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) throw new Error('transient failure');
+      return null; // second tick: empty queue, do nothing
+    });
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const scheduler = makeScheduler(queueDir, telemetryPath);
+    scheduler.startPullLoop();
+
+    // First tick — throws, outer catch fires, isDequeuing reset.
+    await vi.advanceTimersByTimeAsync(30_000);
+    // Second tick — dequeueNext called again (proves isDequeuing was reset).
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(callCount).toBe(2);
+
+    await scheduler.stop();
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Branch 1 (outer-catch, move failed): vi.mock('node:fs') forces both
renameSync attempts to throw EPERM; asserts unlinkSync fallback fires
and the valid task behind the poison entry is still returned.

Branch 2 (inner-catch, unlink also fails): renameSync + unlinkSync both
mocked to throw; asserts quarantinePoisonEntry never rethrows, entry
stays in place for retry on next tick, dequeueNext returns null cleanly.

Branch 3 (collision-retry rename): real filesystem, pre-populates
poison/<filename> as a directory so first renameSync throws EISDIR;
asserts the uniquely-suffixed file (timestamp+hex prefix) lands in
poison/ and original bytes are preserved.

Branch 4 (pullTick outer catch, optional): vi.mock('./queue-store.js')
forces dequeueNext to throw; asserts scheduler logs the error and
resets isDequeuing so the next tick can proceed.

New files added (each isolated due to vi.mock hoisting):
  queue-store-poison-fallback.test.ts (branches 1 + 2)
  scheduler-pull-catch.test.ts (branch 4)

Branch 3 added inline to queue-store.test.ts (no mock needed — EISDIR
from a real directory blocks renameSync on macOS/Linux).

Closes #253
