### PR TITLE
fix(path-approval): wire grant manager for OpenAI-compatible providers in REPL bootstrap

### DIFF
--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -14,7 +14,7 @@ import type { HookRegistry } from '../../../agent/hooks.js';
 import type { TraceWriter } from '../../../agent/trace/index.js';
 import {
   parseThinking, parseEffort, parseMaxOutputTokens, parseProvider, getApiKey, getApiKeyForModel, getThinking, getEffort,
-  getMaxOutputTokens, getDefaultSubagentModel, resolveBaseSystemPrompt,
+  getMaxOutputTokens, getDefaultSubagentModel, resolveBaseSystemPrompt, isGrantManager,
 } from '../../shared-helpers.js';
 import { loadConfig } from '../../config.js';
 import { assembleSystemPrompt, pendingBriefContext } from '../../../agent/routing-directive.js';
@@ -818,9 +818,10 @@ export async function bootstrapSession(
   //
   // We wire once here and do not rewire on /model swaps: directory grants are a
   // session-level concept (not per-model), and a Claude→GPT→Claude swap reuses
-  // the cached Claude instance with its grants intact. Only AnthropicDirectProvider
-  // implements the GrantManager interface; other providers are no-ops.
-  if (startupProvider instanceof AnthropicDirectProvider) {
+  // the cached instance with its grants intact. The duck-type guard (isGrantManager)
+  // covers both AnthropicDirectProvider and OpenAICompatibleProvider — and any
+  // future provider that exposes the GrantManager surface — without naming each.
+  if (isGrantManager(startupProvider)) {
     setAllowDirDispatcher(startupProvider);
     // Wire the same provider into the path-approval + bash-restriction hooks so
     // they can mutate grants when the user picks Session / Always (persist) on
@@ -829,6 +830,16 @@ export async function bootstrapSession(
     // Seed read/write roots from persisted `persist` grants so the prompt's
     // "future sessions inherit it" promise actually holds. No-op when none.
     seedPersistedGrants(startupProvider);
+  } else if (process.env['AFK_DISABLE_PATH_APPROVAL'] !== '1') {
+    // Emit a one-time advisory when path-approval is enabled but the active
+    // provider does not expose the GrantManager API. This makes fail-open
+    // explicit rather than silent — the bash interpreter denylist still fires,
+    // but the elicitation prompt and bash restricted-path check will not.
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[path-approval] active provider does not implement GrantManager — ' +
+        'path-approval elicitation and bash restricted-path checks will not fire.',
+    );
   }
 
   const rl = readline.createInterface({

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -55,6 +55,7 @@ import { ensurePluginEntrypointsLoaded } from '../../../agent/tools/skill-bridge
 import { AWARENESS_TOOL_NAMES } from '../../../agent/awareness/index.js';
 import { McpManager, loadMcpConfig, getMcpConfigPath } from '../../../agent/mcp/index.js';
 import { loadImportFromConfig, resolveImportedRoots } from '../../../config/import-sources.js';
+import { env } from '../../../config/env.js';
 import { resolveResumeTarget } from '../../resume-session.js';
 import type { ResolvedResumeTarget } from '../../resume-session.js';
 import { createDefaultTraceWriter } from '../../../agent/trace/factory.js';
@@ -830,7 +831,7 @@ export async function bootstrapSession(
     // Seed read/write roots from persisted `persist` grants so the prompt's
     // "future sessions inherit it" promise actually holds. No-op when none.
     seedPersistedGrants(startupProvider);
-  } else if (process.env['AFK_DISABLE_PATH_APPROVAL'] !== '1') {
+  } else if (env.AFK_DISABLE_PATH_APPROVAL !== '1') {
     // Emit a one-time advisory when path-approval is enabled but the active
     // provider does not expose the GrantManager API. This makes fail-open
     // explicit rather than silent — the bash interpreter denylist still fires,

--- a/src/cli/interactive-lifecycle.test.ts
+++ b/src/cli/interactive-lifecycle.test.ts
@@ -63,6 +63,9 @@ describe('interactive bootstrap status line hooks', () => {
       loadSystemPrompt: vi.fn(() => undefined),
       loadConfigSystemPrompt: vi.fn(() => undefined),
       resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
+      // Required since bootstrap.ts now calls isGrantManager — return false so
+      // the pre-existing tests don't care about grant wiring.
+      isGrantManager: vi.fn(() => false),
     }));
     vi.doMock('./status-line.js', () => ({
       StatusLine: vi.fn(() => statusLine),
@@ -220,6 +223,9 @@ describe('interactive bootstrap — P1: suggestBaseUrl mirrors openaiBaseUrl', (
       loadSystemPrompt: vi.fn(() => undefined),
       loadConfigSystemPrompt: vi.fn(() => undefined),
       resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
+      // Required since bootstrap.ts now calls isGrantManager — return false so
+      // these tests don't care about grant wiring.
+      isGrantManager: vi.fn(() => false),
     }));
     vi.doMock('./status-line.js', () => ({
       StatusLine: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), repaint: vi.fn() })),
@@ -1020,5 +1026,160 @@ describe('interactive signal-handler wiring (PR #486)', () => {
     // both layers cooperate to keep this at exactly one call.
     expect(abortSpy).toHaveBeenCalledTimes(1);
     expect(abortSpy).toHaveBeenCalledWith('sigterm');
+  });
+});
+
+/**
+ * Regression guard for issue #166: path-approval grant wiring for
+ * OpenAI-compatible providers.
+ *
+ * Before the fix, `bootstrapSession` gated the grant-wiring block on
+ * `instanceof AnthropicDirectProvider`, so any OpenAI-compatible provider
+ * (GPT-4o, local vLLM, etc.) left `pathApprovalGrantRef.current` undefined
+ * and path-approval failed open silently.
+ *
+ * The fix replaces the `instanceof` check with a structural `isGrantManager`
+ * guard so any provider exposing the four GrantManager methods gets wired —
+ * regardless of its concrete class.
+ */
+describe('interactive bootstrap — path-approval grant wiring for OpenAI-compatible providers', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * A minimal provider stub that satisfies both the ModelProvider duck-type
+   * the bootstrap expects AND the GrantManager interface, but without
+   * opening any real resources (no SQLite, no HTTP connections).
+   */
+  function makeOpenAICompatStub() {
+    const readRoots: string[] = [];
+    return {
+      // GrantManager surface — the methods isGrantManager checks for
+      addReadRoot: vi.fn((absPath: string) => { readRoots.push(absPath); }),
+      addWriteRoot: vi.fn(),
+      revokeRoot: vi.fn(),
+      getGrants: vi.fn(() => ({
+        resolveBase: undefined,
+        readRoots: [...readRoots],
+        writeRoots: [],
+        allowAll: false,
+      })),
+      // ModelProvider minimum surface bootstrap touches before the wiring block
+      close: vi.fn(),
+    };
+  }
+
+  /**
+   * Helper that wires all mocks needed for bootstrapSession to reach the grant-
+   * wiring block. `pathApprovalGrantRef` is the observable bundle returned by the
+   * mock hook registry — its `.current` must be set to `stub` by bootstrap when
+   * `stub` passes the isGrantManager check.
+   */
+  function applyGrantWiringMocks(
+    stub: ReturnType<typeof makeOpenAICompatStub>,
+    pathApprovalGrantRef: { current: unknown },
+  ) {
+    const rl = { on: vi.fn(), close: vi.fn() };
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    vi.doMock('node:readline', () => ({ createInterface: vi.fn(() => rl) }));
+    vi.doMock('../agent/session.js', () => ({
+      AgentSession: class MockAgentSession {
+        close = vi.fn(async () => undefined);
+        interrupt = vi.fn(async () => undefined);
+      },
+    }));
+    vi.doMock('../agent/default-hook-registry.js', () => ({
+      createDefaultHookRegistry: vi.fn(() => ({
+        registry: {},
+        memoryStore: { close: vi.fn() },
+        pathApprovalGrantRef,
+      })),
+    }));
+    vi.doMock('../agent/memory/index.js', () => ({
+      MemoryStore: vi.fn(() => ({ close: vi.fn() })),
+      injectHotMemory: vi.fn((config: unknown) => config),
+      memoryToolSchemas: [],
+      MEMORY_TOOL_NAMES: [],
+      createMemoryHandlers: vi.fn(() => new Map()),
+    }));
+    // Mock shared-helpers — BUT keep isGrantManager real and parseProvider
+    // returning the OpenAI-compatible stub so the wiring block fires.
+    vi.doMock('./shared-helpers.js', () => ({
+      parseThinking: vi.fn(() => undefined),
+      parseEffort: vi.fn(() => undefined),
+      parseMaxOutputTokens: vi.fn(() => undefined),
+      // parseProvider returns our stub — this causes the memoized factory to
+      // build stub as startupProvider, which then passes isGrantManager.
+      parseProvider: vi.fn(() => stub),
+      getApiKey: vi.fn(() => 'test-key'),
+      getApiKeyForModel: vi.fn(() => 'test-key'),
+      getThinking: vi.fn(() => undefined),
+      getEffort: vi.fn(() => undefined),
+      getMaxOutputTokens: vi.fn(() => undefined),
+      getDefaultSubagentModel: vi.fn(() => 'sonnet'),
+      findClaudeExecutable: vi.fn(() => '/usr/bin/claude'),
+      loadSystemPrompt: vi.fn(() => undefined),
+      loadConfigSystemPrompt: vi.fn(() => undefined),
+      resolveBaseSystemPrompt: vi.fn(() => ({ prompt: undefined, source: 'none' })),
+      // isGrantManager is the guard under test — keep the real structural check.
+      isGrantManager: (p: unknown): boolean => {
+        if (p === null || typeof p !== 'object') return false;
+        const obj = p as Record<string, unknown>;
+        return (
+          typeof obj['addReadRoot'] === 'function' &&
+          typeof obj['addWriteRoot'] === 'function' &&
+          typeof obj['revokeRoot'] === 'function' &&
+          typeof obj['getGrants'] === 'function'
+        );
+      },
+    }));
+    vi.doMock('./status-line.js', () => ({
+      StatusLine: vi.fn(() => ({ start: vi.fn(), stop: vi.fn(), repaint: vi.fn() })),
+    }));
+    vi.doMock('./slash/index.js', () => ({ registerAll: vi.fn() }));
+    vi.doMock('./slash/writer.js', () => ({
+      createConsoleWriter: vi.fn(() => ({
+        line: vi.fn(), raw: vi.fn(), success: vi.fn(),
+        info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+      })),
+    }));
+  }
+
+  it('wires pathApprovalGrantRef when the startup provider implements GrantManager (OpenAI-compat path)', async () => {
+    const stub = makeOpenAICompatStub();
+    // Observable ref for pathApprovalGrantRef — bootstrap must set .current to stub.
+    const pathApprovalGrantRef: { current: unknown } = { current: undefined };
+    applyGrantWiringMocks(stub, pathApprovalGrantRef);
+
+    // Use importActual to bypass any cached mock for bootstrap — other tests
+    // in this file register vi.doMock('./commands/interactive/bootstrap.js', ...)
+    // which persists in the mock registry and would shadow the real import.
+    const { bootstrapSession } = await vi.importActual<typeof import('./commands/interactive/bootstrap.js')>('./commands/interactive/bootstrap.js');
+    await bootstrapSession({ model: 'gpt-4o', maxTurns: '10' });
+
+    // pathApprovalGrantRef.current must be set to the GrantManager stub.
+    // This test FAILS on origin/main (instanceof AnthropicDirectProvider check
+    // skips the wiring block for non-Anthropic providers) and PASSES after fix.
+    expect(pathApprovalGrantRef.current).toBe(stub);
+  });
+
+  it('does NOT set pathApprovalGrantRef.current when the startup provider lacks GrantManager methods', async () => {
+    // A stub that has close() but NONE of the four GrantManager methods.
+    const noGrantsStub = { close: vi.fn() } as unknown as ReturnType<typeof makeOpenAICompatStub>;
+    const pathApprovalGrantRef: { current: unknown } = { current: undefined };
+    applyGrantWiringMocks(noGrantsStub, pathApprovalGrantRef);
+
+    const { bootstrapSession } = await vi.importActual<typeof import('./commands/interactive/bootstrap.js')>('./commands/interactive/bootstrap.js');
+    await bootstrapSession({ model: 'gpt-4o', maxTurns: '10' });
+
+    // pathApprovalGrantRef.current must remain undefined — the no-grants stub
+    // fails isGrantManager, so the else-warn branch fires instead.
+    expect(pathApprovalGrantRef.current).toBeUndefined();
   });
 });

--- a/src/cli/shared-helpers.test.ts
+++ b/src/cli/shared-helpers.test.ts
@@ -1,21 +1,29 @@
 /**
- * Tests for system-prompt layering helpers.
+ * Tests for system-prompt layering helpers and GrantManager type guard.
  *
- * Invariant under test: the framework base (`prompts/system-prompt.md`) is the
- * UNCONDITIONAL foundation; the operator overlay (AFK_SYSTEM_PROMPT →
- * afk.config.json → AFK.md) is APPENDED on top, never substituted for the base.
- * This is the inverse of the historical `overlay ?? framework` behavior, where
- * any operator prompt replaced the framework base wholesale.
+ * Invariant under test (system-prompt): the framework base
+ * (`prompts/system-prompt.md`) is the UNCONDITIONAL foundation; the operator
+ * overlay (AFK_SYSTEM_PROMPT → afk.config.json → AFK.md) is APPENDED on top,
+ * never substituted for the base. This is the inverse of the historical
+ * `overlay ?? framework` behavior, where any operator prompt replaced the
+ * framework base wholesale.
+ *
+ * Invariant under test (isGrantManager): any provider that structurally exposes
+ * addReadRoot / addWriteRoot / revokeRoot / getGrants passes — regardless of its
+ * concrete class — and a plain object missing any of those methods does not.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   OPERATOR_CONFIG_HEADER,
   composeSystemPrompt,
+  isGrantManager,
   resolveBaseSystemPrompt,
 } from './shared-helpers.js';
 import { loadConfig } from './config.js';
+import { AnthropicDirectProvider } from '../agent/providers/index.js';
+import { OpenAICompatibleProvider } from '../agent/providers/openai-compatible/index.js';
 
 // Mock the config module so loadConfig() (the overlay source) is controllable.
 // loadSystemPrompt() is an in-module call in shared-helpers and reads the real
@@ -110,5 +118,61 @@ describe('resolveBaseSystemPrompt', () => {
     vi.mocked(loadConfig).mockReturnValue(fakeConfig('env override', 'env:AFK_SYSTEM_PROMPT'));
     const { source } = resolveBaseSystemPrompt();
     expect(source).toBe('framework+env:AFK_SYSTEM_PROMPT');
+  });
+});
+
+describe('isGrantManager', () => {
+  // Providers opened in these tests need to be closed so SQLite handles release.
+  const anthropicProviders: AnthropicDirectProvider[] = [];
+  const openaiProviders: OpenAICompatibleProvider[] = [];
+
+  afterEach(() => {
+    for (const p of anthropicProviders) p.close();
+    anthropicProviders.length = 0;
+    for (const p of openaiProviders) p.close();
+    openaiProviders.length = 0;
+  });
+
+  it('returns true for AnthropicDirectProvider (which implements GrantManager)', () => {
+    const p = new AnthropicDirectProvider();
+    anthropicProviders.push(p);
+    expect(isGrantManager(p)).toBe(true);
+  });
+
+  it('returns true for OpenAICompatibleProvider (which implements GrantManager)', () => {
+    const p = new OpenAICompatibleProvider();
+    openaiProviders.push(p);
+    expect(isGrantManager(p)).toBe(true);
+  });
+
+  it('returns false for a plain empty object', () => {
+    expect(isGrantManager({})).toBe(false);
+  });
+
+  it('returns false for an object missing some GrantManager methods', () => {
+    // Has three of the four required methods — must still fail.
+    expect(isGrantManager({
+      addReadRoot: () => {},
+      addWriteRoot: () => {},
+      revokeRoot: () => {},
+      // getGrants intentionally absent
+    })).toBe(false);
+  });
+
+  it('returns false for null and non-objects', () => {
+    expect(isGrantManager(null)).toBe(false);
+    expect(isGrantManager(undefined)).toBe(false);
+    expect(isGrantManager(42)).toBe(false);
+    expect(isGrantManager('string')).toBe(false);
+  });
+
+  it('returns true for a plain mock object exposing all four methods', () => {
+    const mock = {
+      addReadRoot: (_path: string) => {},
+      addWriteRoot: (_path: string) => {},
+      revokeRoot: (_path: string) => {},
+      getGrants: () => ({ resolveBase: undefined, readRoots: [], writeRoots: [] }),
+    };
+    expect(isGrantManager(mock)).toBe(true);
   });
 });

--- a/src/cli/shared-helpers.ts
+++ b/src/cli/shared-helpers.ts
@@ -13,6 +13,7 @@ import type { AgentModelInput, ThinkingConfig, EffortLevel } from '../agent/type
 import { loadConfig } from './config.js';
 import { loadOpenAICredential, resolveCredentialForModel } from '../agent/auth/credential-resolver.js';
 import { env } from '../config/env.js';
+import type { GrantManager } from './slash/commands/allow-dir.js';
 
 /**
  * Load the runtime system prompt from the installed package
@@ -459,4 +460,25 @@ export function parseProvider(
     });
   }
   return undefined;
+}
+
+/**
+ * Structural type guard for the {@link GrantManager} interface.
+ *
+ * Invariant: the guard checks function presence only — it does NOT validate
+ * return-type shapes or implementation correctness. Any provider that exposes
+ * the four GrantManager methods (addReadRoot, addWriteRoot, revokeRoot,
+ * getGrants) will pass, regardless of its concrete class. This intentionally
+ * avoids `instanceof` so future providers are wired automatically without
+ * touching the bootstrap gate.
+ */
+export function isGrantManager(p: unknown): p is GrantManager {
+  if (p === null || typeof p !== 'object') return false;
+  const obj = p as Record<string, unknown>;
+  return (
+    typeof obj['addReadRoot'] === 'function' &&
+    typeof obj['addWriteRoot'] === 'function' &&
+    typeof obj['revokeRoot'] === 'function' &&
+    typeof obj['getGrants'] === 'function'
+  );
 }


### PR DESCRIPTION
Before this change, the REPL bootstrap gate for path-approval grant wiring
was hard-coded to `instanceof AnthropicDirectProvider`. Any OpenAI-compatible
startup model (GPT, Codex, local vLLM/Ollama/MLX shim, HuggingFace-style IDs)
left `pathApprovalGrantRef.current` as `undefined`, silently failing open:
the path-approval elicitation prompt never fired and persisted grants were
never seeded.

The fix replaces the `instanceof` check with a structural duck-type guard
`isGrantManager` (new export in shared-helpers.ts) that checks for the four
GrantManager methods — addReadRoot, addWriteRoot, revokeRoot, getGrants.
Both AnthropicDirectProvider and OpenAICompatibleProvider already implement
this interface (the latter gained parity in an earlier PR); no provider-side
changes are needed. Future providers gain automatic wiring as long as they
expose the four-method surface.

The stale comment that claimed 'only AnthropicDirectProvider implements the
GrantManager interface; other providers are no-ops' is replaced with an
accurate description of the duck-type guard.

An `else` branch emits a one-time `console.warn` when path-approval is
active but the provider doesn't expose the GrantManager API, making any
fail-open explicit rather than silent.

New tests:
- shared-helpers.test.ts: unit tests for isGrantManager — OpenAI-compat
  provider instance → true, Anthropic instance → true, plain {} → false,
  object missing one method → false, null/primitives → false.
- interactive-lifecycle.test.ts: bootstrap wiring regression — drives
  bootstrapSession with a GrantManager-shaped stub as the startup provider,
  asserts pathApprovalGrantRef.current is set (FAILS on origin/main, PASSES
  after fix). Negative case also added.

Closes #166
