### PR TITLE
fix(daemon): stop JSON.parse error snippets leaking secrets in poison logs

### DIFF
--- a/src/agent/daemon/queue-store.test.ts
+++ b/src/agent/daemon/queue-store.test.ts
@@ -369,6 +369,9 @@ describe('SyntaxError snippet redaction in log output (issue #251)', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
 describe('removePending', () => {
   it('returns false on an empty queue', () => {
     expect(removePending(tmpDir, 'q-0000000000000-aabbcc')).toBe(false);

--- a/src/agent/daemon/queue-store.test.ts
+++ b/src/agent/daemon/queue-store.test.ts
@@ -296,3 +296,78 @@ describe('filename redaction in log output', () => {
     }
   });
 });
+
+describe('SyntaxError snippet redaction in log output (issue #251)', () => {
+  // V8 embeds a verbatim snippet of the malformed file bytes inside the
+  // SyntaxError.message from JSON.parse — e.g.
+  //   "Unexpected token 'T', "TOKEN=abc12..." is not valid JSON"
+  // redactInlineSecrets's generic KEY=value pattern requires ≥16 chars in the
+  // value, so short secrets and long-but-truncated secrets both slip through.
+  // The fix suppresses the message entirely for SyntaxErrors, replacing it with
+  // the content-free label 'SyntaxError: invalid JSON'.
+
+  it('does not emit short secret value from SyntaxError message (dequeueNext path)', () => {
+    // Short value — 11 chars — below the {16,} threshold; escapes redactInlineSecrets.
+    const shortSecretContent = 'TOKEN=abc12345678';
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      writeFileSync(join(tmpDir, '0000-q-short-secret.json'), shortSecretContent);
+      dequeueNext(tmpDir);
+      // Capture calls before mockRestore() clears them (vitest clears mock.calls on restore).
+      const allMessages = spy.mock.calls.map((c) => String(c[0]));
+      // (a) The secret fragment must NOT appear in any log line.
+      for (const msg of allMessages) {
+        expect(msg).not.toContain('abc12345678');
+        expect(msg).not.toContain('TOKEN=');
+      }
+      // (b) The safe content-free label must appear instead.
+      expect(allMessages.some((m) => m.includes('SyntaxError: invalid JSON'))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('does not emit truncated long-value secret from SyntaxError message (dequeueNext path)', () => {
+    // Long value that gets truncated inside the V8 SyntaxError snippet; after
+    // truncation the remaining fragment is short enough to evade redaction.
+    const longSecretContent = 'OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012mno345';
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      writeFileSync(join(tmpDir, '0000-q-long-secret.json'), longSecretContent);
+      dequeueNext(tmpDir);
+      // Capture calls before mockRestore() clears them (vitest clears mock.calls on restore).
+      const allMessages = spy.mock.calls.map((c) => String(c[0]));
+      // (a) None of the secret-derived fragments must appear.
+      for (const msg of allMessages) {
+        expect(msg).not.toContain('OPENAI_API_KEY');
+        expect(msg).not.toContain('sk-proj');
+        expect(msg).not.toContain('abc123def456');
+      }
+      // (b) The safe label must appear.
+      expect(allMessages.some((m) => m.includes('SyntaxError: invalid JSON'))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('does not emit secret snippet from SyntaxError message (listPending path)', () => {
+    // Same short-value scenario exercised on the listPending code path.
+    const shortSecretContent = 'TOKEN=abc12345678';
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      writeFileSync(join(tmpDir, '0000-q-list-secret.json'), shortSecretContent);
+      listPending(tmpDir);
+      // Capture calls before mockRestore() clears them (vitest clears mock.calls on restore).
+      const allMessages = spy.mock.calls.map((c) => String(c[0]));
+      // (a) Secret fragments must not appear.
+      for (const msg of allMessages) {
+        expect(msg).not.toContain('abc12345678');
+        expect(msg).not.toContain('TOKEN=');
+      }
+      // (b) Safe label must appear.
+      expect(allMessages.some((m) => m.includes('SyntaxError: invalid JSON'))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/src/agent/daemon/queue-store.ts
+++ b/src/agent/daemon/queue-store.ts
@@ -179,7 +179,18 @@ function quarantinePoisonEntry(queueDir: string, filename: string, err: unknown)
   // structured `status:'poison'` telemetry record for parity with runOnce is a
   // tracked follow-up, not added here to keep the change focused.
   const redactedFilename = redactInlineSecrets(filename);
-  const reason = redactInlineSecrets(err instanceof Error ? err.message : String(err));
+  // Invariant: SyntaxError messages from JSON.parse embed a verbatim snippet of
+  // the file content (≤20 chars, or the first ~10 chars for longer inputs). That
+  // window is structurally too short for redactInlineSecrets's {16,}-value
+  // patterns to match, so any short or truncated secret in the malformed bytes
+  // would reach stderr unredacted. For SyntaxError we therefore use a
+  // content-free label; only non-SyntaxError errors (filesystem errors from
+  // readFileSync, etc.) carry paths — not file content — and are safe to redact
+  // and log with their message.
+  const reason =
+    err instanceof SyntaxError
+      ? 'SyntaxError: invalid JSON'
+      : redactInlineSecrets(err instanceof Error ? err.message : String(err));
   const poisonDir = join(queueDir, POISON_SUBDIR);
   const src = join(queueDir, filename);
   try {
@@ -258,7 +269,18 @@ export function listPending(queueDir: string = getQueueDir()): QueuedTask[] {
       tasks.push(JSON.parse(readFileSync(filePath, 'utf-8')) as QueuedTask);
     } catch (err) {
       const redactedFilename = redactInlineSecrets(filename);
-      const reason = redactInlineSecrets(err instanceof Error ? err.message : String(err));
+      // Invariant: SyntaxError messages from JSON.parse embed a verbatim snippet of
+      // the file content (≤20 chars, or the first ~10 chars for longer inputs). That
+      // window is structurally too short for redactInlineSecrets's {16,}-value
+      // patterns to match, so any short or truncated secret in the malformed bytes
+      // would reach stderr unredacted. For SyntaxError we therefore use a
+      // content-free label; only non-SyntaxError errors (filesystem errors from
+      // readFileSync, etc.) carry paths — not file content — and are safe to redact
+      // and log with their message.
+      const reason =
+        err instanceof SyntaxError
+          ? 'SyntaxError: invalid JSON'
+          : redactInlineSecrets(err instanceof Error ? err.message : String(err));
       // eslint-disable-next-line no-console
       console.error(
         `[daemon] pull-queue: skipping unreadable entry ${redactedFilename} in listPending (${reason})`,


### PR DESCRIPTION
V8's SyntaxError from JSON.parse embeds a verbatim snippet of the
malformed file bytes in its message (≤20 chars, or the first ~10 chars
for longer inputs). That window is structurally shorter than
redactInlineSecrets's generic KEY=value pattern requirement of ≥16 value
characters, so short secrets (e.g. TOKEN=abc12345678) and
long-but-truncated secrets (OPENAI_API_KEY=sk-proj-...) both survive
redaction and reach daemon stderr.

Fix: at both sites in queue-store.ts where a JSON.parse error message
becomes a logged reason, branch on err instanceof SyntaxError:
- SyntaxError → use content-free label 'SyntaxError: invalid JSON'
- Other errors (filesystem errors from readFileSync, rename, unlink)
  → keep existing redactInlineSecrets path (those carry paths, not
  file content, and the {16,} threshold covers them adequately)

Each branch is guarded by an // Invariant: comment explaining why the
message is suppressed rather than redacted.

Adds three regression tests that craft malformed queue files whose bytes
contain secret-shaped values (short value below {16,} threshold; long
value that V8 would truncate to a short snippet), confirm no fragment
appears in stderr, and assert the safe label appears instead.

Closes #251
