### PR TITLE
fix(memory): wrap schema migrations in transactions to close torn-state window

### DIFF
--- a/src/agent/memory/memory-store.test.ts
+++ b/src/agent/memory/memory-store.test.ts
@@ -435,25 +435,14 @@ describe('schema migration — sessions.actor (v2 → v3)', () => {
     }
   });
 
-  it('swallows a concurrent duplicate-column ALTER and still reaches v4', () => {
+  it('handles concurrent racer adding the actor column via pre-check (no try/catch) and still reaches v4', () => {
     const dbPath = join(migDir, 'memory.db');
-    seedV2Db(dbPath);
-
-    // Simulate the cross-process race: the table_info guard sees no actor
-    // column, but by the time THIS process runs the ALTER a concurrent opener
-    // has already added it, so SQLite throws "duplicate column name". The mock
-    // adds the column for real (post-condition holds) then throws.
-    const originalExec = Database.prototype.exec;
-    vi.spyOn(Database.prototype, 'exec').mockImplementation(function (
-      this: BetterSqlite3.Database,
-      sql: string,
-    ) {
-      if (/ALTER TABLE sessions ADD COLUMN actor/i.test(sql)) {
-        originalExec.call(this, sql); // the racer wins the ALTER
-        throw new Error('duplicate column name: actor');
-      }
-      return originalExec.call(this, sql);
-    } as BetterSqlite3.Database['exec']);
+    // Simulate a cross-process race: another opener has already added the actor
+    // column to the DB (user_version still 2 — the racer ran the ALTER but was
+    // killed before stamping the version). With the new pre-check-only pattern,
+    // the transaction body reads table_info, sees the column is already present,
+    // skips the ALTER, and stamps the version — no try/catch needed or present.
+    seedV2Db(dbPath, true /* withActorColumn — racer already added it */);
 
     expect(() => new MemoryStore(migDir)).not.toThrow();
 
@@ -501,6 +490,68 @@ describe('schema migration — sessions.actor (v2 → v3)', () => {
       expect(check.pragma('user_version', { simple: true })).toBe(4);
     } finally {
       check.close();
+    }
+  });
+
+  it('atomicity: a pragma throw after the ALTER rolls back the whole step (version NOT stamped, column absent)', () => {
+    const dbPath = join(migDir, 'memory.db');
+    // Start from v2: sessions table without actor, facts table without evidence.
+    seedV2Db(dbPath);
+
+    // Intercept the pragma that stamps user_version = 3 and make it throw
+    // AFTER the ALTER has run inside the transaction body. Because the throw
+    // happens inside the transaction function, better-sqlite3 rolls back the
+    // entire transaction — the ALTER and the version bump together — leaving the
+    // DB in its original pre-v3 state.
+    const originalPragma = Database.prototype.pragma;
+    vi.spyOn(Database.prototype, 'pragma').mockImplementation(function (
+      this: BetterSqlite3.Database,
+      ...args: Parameters<BetterSqlite3.Database['pragma']>
+    ) {
+      if (typeof args[0] === 'string' && /user_version\s*=\s*3/i.test(args[0])) {
+        throw new Error('simulated pragma failure');
+      }
+      return originalPragma.apply(this, args);
+    } as BetterSqlite3.Database['pragma']);
+
+    // Construction must throw because the v2→v3 transaction rolls back.
+    expect(() => new MemoryStore(migDir)).toThrow(/simulated pragma failure/);
+
+    // Both the ALTER and the version stamp must have been rolled back.
+    const check1 = new Database(dbPath, { readonly: true });
+    try {
+      expect(
+        check1.pragma('user_version', { simple: true }),
+        'user_version must still be 2 (transaction rolled back)',
+      ).toBe(2);
+      const cols = (check1.pragma('table_info(sessions)') as Array<{ name: string }>).map(
+        (c) => c.name,
+      );
+      expect(cols, 'actor column must be absent (ALTER rolled back)').not.toContain('actor');
+    } finally {
+      check1.close();
+    }
+
+    // Restore mocks, then verify a fresh open self-heals and migrates cleanly.
+    vi.restoreAllMocks();
+    expect(() => new MemoryStore(migDir)).not.toThrow();
+
+    const check2 = new Database(dbPath, { readonly: true });
+    try {
+      expect(
+        check2.pragma('user_version', { simple: true }),
+        'user_version must be 4 after self-heal',
+      ).toBe(4);
+      const cols = (check2.pragma('table_info(sessions)') as Array<{ name: string }>).map(
+        (c) => c.name,
+      );
+      expect(cols, 'actor column must be present after self-heal').toContain('actor');
+      const factCols = (check2.pragma('table_info(facts)') as Array<{ name: string }>).map(
+        (c) => c.name,
+      );
+      expect(factCols, 'evidence column must be present after self-heal').toContain('evidence');
+    } finally {
+      check2.close();
     }
   });
 });

--- a/src/agent/memory/memory-store.ts
+++ b/src/agent/memory/memory-store.ts
@@ -209,24 +209,28 @@ export class MemoryStore {
       // on completion. The chain is exhaustive over [1, SCHEMA_VERSION); a
       // future step appends a new `if (existingVersion < N)` block.
       if (existingVersion < 2) {
-        // v1 → v2: add UNIQUE index on facts(content, created_at, session_id, category).
-        // First, deduplicate any colliding rows keeping the lowest id.
-        this.db.exec(`
-          DELETE FROM facts
-          WHERE id NOT IN (
-            SELECT MIN(id)
-            FROM facts
-            GROUP BY content, created_at, COALESCE(session_id, ''), category
-          );
-        `);
-        // Rebuild FTS index after the dedup deletes.
-        this.db.exec(`INSERT INTO facts_fts(facts_fts) VALUES('rebuild');`);
-        // Apply the new unique index.
-        this.db.exec(`
-          CREATE UNIQUE INDEX IF NOT EXISTS idx_facts_fingerprint
-            ON facts(content, created_at, COALESCE(session_id, ''), category);
-        `);
-        this.db.pragma(`user_version = 2`);
+        // v1 → v2: add UNIQUE index on facts(content, created_at, session_id,
+        // category). Uses CREATE … IF NOT EXISTS — already idempotent — so a
+        // plain transaction wrapper is sufficient.
+        this.db.transaction(() => {
+          // First, deduplicate any colliding rows keeping the lowest id.
+          this.db.exec(`
+            DELETE FROM facts
+            WHERE id NOT IN (
+              SELECT MIN(id)
+              FROM facts
+              GROUP BY content, created_at, COALESCE(session_id, ''), category
+            );
+          `);
+          // Rebuild FTS index after the dedup deletes.
+          this.db.exec(`INSERT INTO facts_fts(facts_fts) VALUES('rebuild');`);
+          // Apply the new unique index.
+          this.db.exec(`
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_facts_fingerprint
+              ON facts(content, created_at, COALESCE(session_id, ''), category);
+          `);
+          this.db.pragma(`user_version = 2`);
+        })();
         debugLog('memory-store: migrated schema v1 → v2 (added fingerprint UNIQUE index)');
       }
       if (existingVersion < 3) {
@@ -236,25 +240,26 @@ export class MemoryStore {
         // additive, but the SCHEMA_VERSION guard above still rejects a v3 DB
         // from older builds — see the deployment note.)
         //
-        // SQLite has no `ADD COLUMN IF NOT EXISTS`. The table_info check is
-        // cheap and covers sequential re-runs. It is NOT atomic across
-        // processes, though — this global DB is cold-opened concurrently by
-        // every AFK surface, so two new-build processes can race the ALTER and
-        // the loser throws "duplicate column name". Wrap it: treat an
-        // already-present column (re-checked via table_info, not the error
-        // text) as success; re-throw if the column stayed absent.
-        const hasActor = (): boolean =>
-          (this.db.pragma('table_info(sessions)') as Array<{ name: string }>).some(
+        // Invariant: pre-check-only pattern instead of try/catch. SQLite has
+        // no `ADD COLUMN IF NOT EXISTS`, and this global DB is cold-opened
+        // concurrently by every AFK surface, so two new-build processes can
+        // race the ALTER. By checking column presence INSIDE the transaction
+        // BEFORE attempting the ALTER we avoid a swallowed error masking a
+        // partial commit:
+        //   - Normal case: column absent → ALTER runs → version stamped → commit.
+        //   - Concurrent racer added the column first → pre-check sees it →
+        //     skip ALTER → stamp version → commit. (No try/catch needed.)
+        //   - Genuine ALTER failure (disk error) → transaction throws → ROLLS
+        //     BACK (version NOT stamped) → next open re-runs from existingVersion.
+        this.db.transaction(() => {
+          const hasActor = (this.db.pragma('table_info(sessions)') as Array<{ name: string }>).some(
             (col) => col.name === 'actor',
           );
-        if (!hasActor()) {
-          try {
+          if (!hasActor) {
             this.db.exec(`ALTER TABLE sessions ADD COLUMN actor TEXT;`);
-          } catch (err) {
-            if (!hasActor()) throw err;
           }
-        }
-        this.db.pragma(`user_version = 3`);
+          this.db.pragma(`user_version = 3`);
+        })();
         debugLog('memory-store: migrated schema v2 → v3 (added sessions.actor column)');
       }
       if (existingVersion < 4) {
@@ -262,24 +267,19 @@ export class MemoryStore {
         // citation backing a codebase fact). No default → existing rows read
         // back NULL (= uncited), so the migration cannot fail on stored data.
         //
-        // Same concurrency-safe ALTER wrapper as the v2→v3 actor migration:
-        // SQLite has no `ADD COLUMN IF NOT EXISTS`, and this global DB is
-        // cold-opened concurrently by every AFK surface, so two new-build
-        // processes can race the ALTER and the loser throws "duplicate column
-        // name". Treat an already-present column (re-checked via table_info,
-        // not the error text) as success; re-throw if the column stayed absent.
-        const hasEvidence = (): boolean =>
-          (this.db.pragma('table_info(facts)') as Array<{ name: string }>).some(
+        // Invariant: same pre-check-only pattern as v2→v3 (see comment above).
+        // The column presence check happens inside the transaction so the
+        // pre-check and ALTER are atomic: if the ALTER fails, the transaction
+        // rolls back and the version stamp is not advanced.
+        this.db.transaction(() => {
+          const hasEvidence = (this.db.pragma('table_info(facts)') as Array<{ name: string }>).some(
             (col) => col.name === 'evidence',
           );
-        if (!hasEvidence()) {
-          try {
+          if (!hasEvidence) {
             this.db.exec(`ALTER TABLE facts ADD COLUMN evidence TEXT;`);
-          } catch (err) {
-            if (!hasEvidence()) throw err;
           }
-        }
-        this.db.pragma(`user_version = 4`);
+          this.db.pragma(`user_version = 4`);
+        })();
         debugLog('memory-store: migrated schema v3 → v4 (added facts.evidence column)');
       }
     } else {


### PR DESCRIPTION
Each migration step (ALTER TABLE + PRAGMA user_version) previously ran as
two separate unguarded statements. A crash between them left the DB in a
torn state: the new column present but user_version not yet advanced.

Wrap every migration step in this.db.transaction(() => { ... })() so the
DDL and the version stamp commit atomically. SQLite rolls back both on any
throw, so the next open re-runs the step cleanly (self-heal preserved).

Replace the try/catch idempotency pattern (v2→v3, v3→v4) with a
pre-check-only pattern inside the transaction: read PRAGMA table_info()
before attempting ALTER. If the column is already present (concurrent racer
won the slot), skip the ALTER and stamp the version — no try/catch needed.
Normal failures (disk error) throw through the transaction and roll back.

Tests:
- Updated 'swallows concurrent duplicate-column ALTER' test to reflect the
  new pre-check behavior: the racer scenario is represented by seeding the
  DB with the column already present (withActorColumn=true), verifying the
  store opens cleanly and reaches v4 without any exec spy.
- Added atomicity test: spy on pragma to throw on 'user_version = 3';
  assert the transaction rolled back (version still 2, actor column absent);
  restore mocks and assert a fresh MemoryStore self-heals cleanly to v4.

Closes #249
