### PR TITLE
fix(telegram): interrupt provider turn on ANY incomplete stream exit

### DIFF
--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -477,7 +477,7 @@ describe('renderSubagentFooter (bounded sub-agent progress)', () => {
   });
 });
 
-describe('inactivity watchdog (timeout → interrupt)', () => {
+describe('provider-turn interrupt on incomplete exit (stale-buffer guard)', () => {
   it('throws StreamTimeoutError and interrupts the still-running turn on total silence', async () => {
     vi.useFakeTimers();
     try {
@@ -510,14 +510,46 @@ describe('inactivity watchdog (timeout → interrupt)', () => {
     }
   }, 15_000);
 
-  it('does NOT interrupt on a provider error event — interrupt is timeout-only', async () => {
+  it('does NOT interrupt on a provider error EVENT — the turn already ended (terminal event seen)', async () => {
     const { ctx } = makeCtx();
     const session = makeSession(async function* () {
       yield { type: 'chunk' as const, chunk: { type: 'content' as const, content: 'partial' } };
       yield { type: 'error' as const, error: new Error('mid-stream boom') };
     });
     await expect(streamResponse(ctx, session, 'go')).rejects.toThrow('mid-stream boom');
-    // A real provider error already ended the turn; interrupting would be wrong.
+    // An 'error' EVENT is terminal: the provider emitted it and parked itself at
+    // the next-prompt boundary, so there is nothing to interrupt. (Contrast with
+    // a RAW throw / non-terminal exit below, which DOES require interrupt().)
+    expect((session as { interrupt: ReturnType<typeof vi.fn> }).interrupt).not.toHaveBeenCalled();
+  });
+
+  it('interrupts on a non-terminal early exit (raw throw, no done/error event)', async () => {
+    // The leak the fix closes: the consumer exits WITHOUT a terminal event
+    // (here a raw throw, standing in for a Telegram render exception or other
+    // mid-stream failure). The shared provider iterator is still live, so
+    // without interrupt() its buffered events would be drained by the user's
+    // NEXT message — the "send a '.' to recover the lost result" bug. Previously
+    // this path was NOT covered because interrupt() was gated on `timedOut` alone.
+    const { ctx } = makeCtx();
+    const session = makeSession(async function* () {
+      yield { type: 'chunk' as const, chunk: { type: 'content' as const, content: 'partial' } };
+      throw new Error('render boom'); // raw throw — NOT an 'error' OutputEvent
+    });
+    await expect(streamResponse(ctx, session, 'go')).rejects.toThrow('render boom');
+    expect((session as { interrupt: ReturnType<typeof vi.fn> }).interrupt).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT interrupt on a clean turn that reaches done', async () => {
+    // Happy path: a terminal done event was seen, so interrupt() must be a
+    // no-op here — firing it would abort an already-completed turn (and, before
+    // iter.return() runs, currentState is still 'streaming', so the abort would
+    // NOT be swallowed). The gate must therefore key off the terminal event.
+    const { ctx } = makeCtx();
+    const session = makeSession(async function* () {
+      yield { type: 'chunk' as const, chunk: { type: 'content' as const, content: 'all good' } };
+      yield { type: 'done' as const, metadata: undefined };
+    });
+    await streamResponse(ctx, session, 'go');
     expect((session as { interrupt: ReturnType<typeof vi.fn> }).interrupt).not.toHaveBeenCalled();
   });
 });

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -128,6 +128,13 @@ export async function streamResponse(
   // event AND by sub-agent sink activity, so the re-armed timeout does not
   // false-fire during deep fan-out.
   let timedOut = false;
+  // Set true once a terminal `done`/`error` event is processed for this turn.
+  // Gates the finally-block interrupt(): any exit WITHOUT a terminal event
+  // (watchdog timeout, a Telegram render exception, an early break) leaves the
+  // long-lived shared provider iterator generating with no consumer, so the
+  // user's NEXT message drains the stale buffer — the "send a '.' to recover
+  // the lost result" bug.
+  let sawTerminalEvent = false;
   let lastActivityAt = Date.now();
   // Bounded sub-agent progress region (see renderSubagentFooter): a rolling
   // counter + the last few lines, instead of an unbounded per-tool-call append.
@@ -455,6 +462,7 @@ export async function streamResponse(
         }
 
         if (event.type === 'done') {
+          sawTerminalEvent = true;
           if (countdownInterval !== null) {
             clearInterval(countdownInterval);
             countdownInterval = null;
@@ -484,6 +492,9 @@ export async function streamResponse(
           break;
         }
         if (event.type === 'error') {
+          // The provider already emitted a terminal error and parked itself, so
+          // no interrupt() is needed (and would wrongly abort the NEXT turn).
+          sawTerminalEvent = true;
           if (countdownInterval !== null) {
             clearInterval(countdownInterval);
             countdownInterval = null;
@@ -508,16 +519,20 @@ export async function streamResponse(
         }
       }
     } finally {
-      // On a genuine inactivity timeout the provider turn is STILL RUNNING — the
-      // watchdog only abandoned our consumer; it did not abort the turn. Without
-      // this, the provider keeps streaming into the long-lived shared
-      // providerIterator with no consumer, and the NEXT message drains those
-      // buffered events — the "turn cut off, send a '.' to recover the lost
-      // result" bug. interrupt() is the same turn-scoped abort the REPL uses for
-      // ESC; it leaves providerIterator parked cleanly at the next-prompt
-      // boundary. Must run BEFORE iter.return(), which flips currentState to
-      // 'idle' and would make interrupt() an early-return no-op.
-      if (timedOut) {
+      // Park the still-running provider turn on ANY exit that did NOT reach a
+      // terminal done/error event: a genuine inactivity timeout (the watchdog
+      // abandoned our consumer but did not abort the turn), a Telegram render
+      // exception, or an early break. Without this the provider keeps streaming
+      // into the long-lived shared providerIterator with no consumer, and the
+      // NEXT message drains those buffered events — the "turn cut off, send a
+      // '.' to recover the lost result" bug. Previously this was gated on
+      // `timedOut` alone, which left every NON-timeout early-exit path leaking.
+      // interrupt() is the same turn-scoped abort the REPL uses for ESC; it
+      // leaves providerIterator parked cleanly at the next-prompt boundary, and
+      // is a no-op once the turn completed cleanly. Must run BEFORE iter.return(),
+      // which flips currentState to 'idle' and would make interrupt() an
+      // early-return no-op.
+      if (timedOut || !sawTerminalEvent) {
         await Promise.resolve(session.interrupt?.()).catch(() => {});
       }
       // Stop the usage-limit countdown timer on EVERY exit path (incl. a throw):


### PR DESCRIPTION
## Symptom

On the Telegram bot, a message would appear to do nothing; sending a **second** message would surface the **first** message's result, so users learned to send a throwaway `.` to flush the previous turn. The agent was perpetually one message behind.

## Root cause

The provider iterator is **long-lived and shared across messages** (`agent-session.ts` `providerIterator`, driven per-turn by `sendMessageStreamInternal`; the provider parks at the next-prompt boundary between turns). The Telegram streaming consumer only aborted the in-flight provider turn when the inactivity watchdog fired:

```ts
if (timedOut) { await session.interrupt?.(); }
```

On **any other** early exit — a Telegram render exception, a raw mid-stream throw, an early break — the provider kept generating into that shared iterator with **no consumer**. The user's **next** message attached a fresh consumer that drained those **stale buffered events** first. The code comment at the same site already named this ("send a `.` to recover the lost result") but only guarded the timeout path.

## Fix

Gate `interrupt()` on whether a **terminal `done`/`error` event was seen** (`sawTerminalEvent`) rather than `timedOut`:

```ts
if (timedOut || !sawTerminalEvent) { await session.interrupt?.(); }
```

This fires on **every** incomplete exit (closing all leak paths), but stays a **no-op on a clean turn**.

### Why not just drop the `if (timedOut)` guard?

Because at the `finally`, a cleanly-completed turn's generator is still **suspended at `yield done`** — its own `currentState = 'idle'` finalizer has **not run yet**, so `currentState` is still `'streaming'`. An *unconditional* `interrupt()` would therefore abort the turn that just finished. Keying the gate off the terminal event avoids that.

An `error` **event** is terminal (the provider emitted it and parked itself), so it does **not** trigger `interrupt()`.

## Tests (`src/telegram/streaming.test.ts`, 20/20)

- **NEW** — non-terminal raw-throw exit → `interrupt()` fires (the leak guard)
- **NEW** — clean `done` → `interrupt()` NOT called (happy-path safety)
- updated the error-event test framing (terminal event seen → no interrupt)
- existing watchdog-timeout → interrupt test still green

`pnpm lint` (`tsc --noEmit`) clean. Change is isolated to Telegram glue.

## Notes for reviewer

- **Residual:** the exact production trigger (which non-terminal exit fires) was not reproduced from logs; this closes the defect **class** regardless. A likely co-conspirator is a mid-stream Telegram render 400 from the formatter's unclosed-HTML bold/italic regex (`formatter.ts:127-134`) — a recommended **follow-up PR** to also remove the trigger (defense in depth).
- This bug is **Telegram-only**; the REPL/CLI uses a different streaming path.