### PR TITLE
fix(telegram): never emit improperly-nested HTML from interleaved emphasis

### DIFF
--- a/src/telegram/formatter.test.ts
+++ b/src/telegram/formatter.test.ts
@@ -617,3 +617,50 @@ describe('formatCompactNoop — new reasons', () => {
     expect(result.toLowerCase()).toContain('failed');
   });
 });
+
+describe('markdownToTelegramHtml — mis-nested emphasis safety net', () => {
+  // Stack check mirroring Telegram's HTML parser: every tag must be closed and
+  // properly nested. A mis-nested run like "<b>..<i>..</b>..</i>" → 400.
+  const tagsBalanced = (html: string): boolean => {
+    const stack: string[] = [];
+    const re = /<(\/?)([a-zA-Z][a-zA-Z0-9-]*)\b[^>]*>/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(html)) !== null) {
+      const tag = (m[2] ?? '').toLowerCase();
+      if (m[1] === '/') { if (stack.pop() !== tag) return false; }
+      else stack.push(tag);
+    }
+    return stack.length === 0;
+  };
+
+  test('interleaved ** / _ markers never emit improperly-nested tags', () => {
+    // Pre-fix this produced "<b>a <i>b</b> c</i>" → Telegram 400 "can't parse entities".
+    const out = markdownToTelegramHtml('**a _b** c_');
+    expect(tagsBalanced(out)).toBe(true);
+    expect(out).not.toContain('<b>');
+    expect(out).not.toContain('<i>');
+    expect(out).toBe('a b c');
+  });
+
+  test('interleaved __ / * markers never emit improperly-nested tags', () => {
+    const out = markdownToTelegramHtml('__a *b__ c*');
+    expect(tagsBalanced(out)).toBe(true);
+    expect(out).toBe('a b c');
+  });
+
+  test('safety net preserves code/link tags while dropping only mis-nested emphasis', () => {
+    const out = markdownToTelegramHtml('**a _b** `keep=1` c_');
+    expect(tagsBalanced(out)).toBe(true);
+    expect(out).toContain('<code>keep=1</code>'); // code span survives
+    expect(out).not.toContain('<b>');
+    expect(out).not.toContain('<i>');
+  });
+
+  test('properly-nested emphasis is left untouched (no false strip)', () => {
+    // Italic fully containing bold is valid HTML and must be preserved verbatim.
+    expect(markdownToTelegramHtml('*a **b** c*')).toBe('<i>a <b>b</b> c</i>');
+    // Separate spans + identifiers are unaffected by the safety net.
+    expect(markdownToTelegramHtml('**A** and *b* and snake_case'))
+      .toBe('<b>A</b> and <i>b</i> and snake_case');
+  });
+});

--- a/src/telegram/formatter.ts
+++ b/src/telegram/formatter.ts
@@ -159,7 +159,38 @@ export function markdownToTelegramHtml(text: string): string {
   // 10. Restore fenced code blocks
   out = out.replace(/\x02FENCED(\d+)\x03/g, (_m, i: string) => fencedBlocks[Number(i)] ?? _m);
 
+  // 11. Safety net: interleaved/overlapping emphasis markers (e.g. "**a _b** c_")
+  // can yield improperly-NESTED tags like "<b>a <i>b</b> c</i>", which Telegram
+  // rejects with HTTP 400 "can't parse entities" — failing or degrading the send.
+  // Code/pre/link tags are emitted as atomic, always-balanced units, so any
+  // imbalance is necessarily from emphasis (<b>/<i>/<s>); drop just those to
+  // recover guaranteed-valid, readable HTML instead of breaking the message.
+  if (!telegramHtmlTagsBalanced(out)) {
+    out = out.replace(/<\/?[bis]>/g, '');
+  }
+
   return out;
+}
+
+/**
+ * True iff every HTML tag in `html` is properly closed and correctly nested — a
+ * simple stack check over the tags markdownToTelegramHtml emits (b, i, s, code,
+ * pre, a). Used as a safety net so a mis-nested emphasis run never produces HTML
+ * that Telegram rejects with a 400 "can't parse entities".
+ */
+function telegramHtmlTagsBalanced(html: string): boolean {
+  const stack: string[] = [];
+  const re = /<(\/?)([a-zA-Z][a-zA-Z0-9-]*)\b[^>]*>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    const tag = (m[2] ?? '').toLowerCase();
+    if (m[1] === '/') {
+      if (stack.pop() !== tag) return false;
+    } else {
+      stack.push(tag);
+    }
+  }
+  return stack.length === 0;
 }
 
 /**


### PR DESCRIPTION
## Symptom

Telegram messages with **interleaved/overlapping** markdown emphasis fail or render degraded — Telegram returns HTTP 400 `can't parse entities`.

## Root cause (empirically confirmed)

`markdownToTelegramHtml` runs bold then italic as independent regex passes. When emphasis markers overlap, the passes produce **improperly-nested** tags. Verified with a tag-balance probe:

```
**a _b** c_   ->  <b>a <i>b</b> c</i>     (mismatch: </i> expected, </b> found)
__a *b__ c_   ->  <b>a <i>b</b> c</i>     (same)
```

`<b>...<i>...</b>...</i>` is invalid HTML; Telegram's parser rejects it with a 400. (The earlier hypothesis was "unclosed tags" — the probe showed it is actually **mis-nesting**; unmatched markers stay literal and are harmless.)

## Fix

A final validation **safety net** in `markdownToTelegramHtml`: after conversion, a stack check verifies tag nesting. If the emphasis ended up mis-nested, drop **only** the emphasis tags (`<b>` / `<i>` / `<s>`).

Why this is safe and sufficient: code/pre/link tags are emitted as **atomic, always-balanced** units (code & fences via placeholders, links in one replace), so any imbalance is necessarily from emphasis. Stripping emphasis is therefore **guaranteed** to yield valid HTML. The rare gnarly message renders without bold/italic (still readable) instead of 400ing — and **properly-nested** emphasis (`*a **b** c*` -> `<i>a <b>b</b> c</i>`) is left untouched (no false strip).

## Tests (`src/telegram/formatter.test.ts`, 96/96)

4 new:
- both interleaved orders (`**`/`_` and `__`/`*`) now produce valid, balanced HTML
- the safety net **preserves code spans** while dropping mis-nested emphasis
- **properly-nested** emphasis is not falsely stripped (regression guard)

`pnpm lint` (`tsc --noEmit`) clean.

## Relationship to #320

Companion to #320 (the stale-buffer interrupt fix). That PR **contains** the consequence of any mid-stream render throw; this PR removes a **likely trigger**. Independent, non-overlapping diffs — either can merge first. Telegram-only.
