### PR TITLE
fix(update): restart launchd services + notify on stale manual bot after install

### DIFF
--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -10,8 +10,8 @@
  * Always exits 0 — never fails an install.
  */
 
-import { execSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { execSync, execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -35,6 +35,11 @@ export function detectPathGap(prefix, pathEnv) {
  * given file. All errors are silently discarded — this is best-effort cleanup
  * that must never fail an install.
  *
+ * NOTE: the install flow no longer calls this. SIGTERM'ing a manually-started
+ * bot left it dead with nothing to relaunch it (postinstall cannot reliably
+ * spawn a detached long-lived process). The main block now NOTIFIES instead
+ * (see isManualBotRunning). Retained as a tested, reusable utility.
+ *
  * @param {string} pidFilePath   - Full path to the PID file to read.
  * @param {function} [killFn]    - Injectable kill function; defaults to process.kill.
  *                                 Pass a stub in tests to avoid needing process.kill.
@@ -48,6 +53,88 @@ export function killStaleDaemon(pidFilePath, killFn = process.kill) {
   } catch {
     // File missing, non-numeric PID, ESRCH, EPERM, any other error — discard.
   }
+}
+
+/**
+ * Read-only probe: is a *manually-started* telegram bot still alive? Only the
+ * `afk telegram start` path records a child PID in bot.pid; a launchd-supervised
+ * bot does NOT (launchd owns its PID — see src/service/launchd/paths.ts), so a
+ * non-null result here always means a manual bot — exactly the instance the
+ * launchd kickstart below cannot reach.
+ *
+ * Unlike the manager's isRunning(), this does NOT unlink a stale PID file:
+ * postinstall must not mutate runtime state. Returns the live PID, or null when
+ * the file is missing/malformed or the process is gone.
+ *
+ * @param {string} pidFilePath
+ * @param {function} [probeFn]   - Injectable existence probe; defaults to process.kill.
+ * @returns {number|null}
+ */
+export function isManualBotRunning(pidFilePath, probeFn = process.kill) {
+  try {
+    const raw = readFileSync(pidFilePath, 'utf8').trim();
+    const pid = parseInt(raw, 10);
+    if (!Number.isFinite(pid) || pid <= 0) return null;
+    probeFn(pid, 0); // signal 0 = existence check; delivers no signal
+    return pid;
+  } catch {
+    // File missing, non-numeric PID, ESRCH, EPERM — treat as not-running.
+    return null;
+  }
+}
+
+/**
+ * Restart installed AFK launchd services so they pick up the just-installed
+ * code. A long-running Node process keeps the OLD module graph in memory after
+ * `npm install -g` overwrites the files on disk; only a restart swaps it.
+ * `launchctl kickstart -k` kills and relaunches the job against the (now
+ * updated) on-disk entrypoint — ProgramArguments are unchanged, only file
+ * contents, so no plist reload is needed.
+ *
+ * Fail-open and best-effort: a service whose plist is absent is skipped (never
+ * installed as a service); a launchctl error (job not loaded, launchctl wedged)
+ * is swallowed so the install never fails. macOS only — the caller gates on
+ * platform; elsewhere ~/Library/LaunchAgents won't exist so nothing restarts.
+ *
+ * Label / path / domain conventions mirror src/service/launchd/paths.ts
+ * (labelFor → `com.afk.<name>`, plist under ~/Library/LaunchAgents, guiDomain →
+ * `gui/<uid>`). Kept in sync by hand — this plain .mjs cannot import the
+ * compiled TS helpers.
+ *
+ * @param {object}   [opts]
+ * @param {string}   [opts.home]      - Home dir; defaults to os.homedir().
+ * @param {number}   [opts.uid]       - Numeric uid; defaults to process.getuid().
+ * @param {string[]} [opts.labels]    - launchd labels to consider.
+ * @param {function} [opts.existsFn]  - Injectable plist existence check.
+ * @param {function} [opts.execFn]    - Injectable launchctl runner; receives the argv array.
+ * @returns {string[]} labels that were successfully restarted.
+ */
+export function restartLaunchdServices(opts = {}) {
+  const home = opts.home ?? homedir();
+  const uid =
+    opts.uid ?? (typeof process.getuid === 'function' ? process.getuid() : 501);
+  const labels = opts.labels ?? ['com.afk.telegram', 'com.afk.daemon'];
+  const existsFn = opts.existsFn ?? existsSync;
+  const execFn =
+    opts.execFn ??
+    ((argv) =>
+      execFileSync('launchctl', argv, {
+        stdio: ['ignore', 'ignore', 'ignore'],
+        timeout: 8000,
+      }));
+
+  const restarted = [];
+  for (const label of labels) {
+    const plist = join(home, 'Library', 'LaunchAgents', `${label}.plist`);
+    if (!existsFn(plist)) continue; // not installed as a service
+    try {
+      execFn(['kickstart', '-k', `gui/${uid}/${label}`]);
+      restarted.push(label);
+    } catch {
+      // Job not loaded, or launchctl errored — skip; install must not fail.
+    }
+  }
+  return restarted;
 }
 
 // ─── Main block ─────────────────────────────────────────────────────────────
@@ -106,15 +193,42 @@ if (isMain) {
     // execSync failed (npm not found, timeout, etc.) — silently ignore.
   }
 
-  // Kill any stale daemon left over from the previous version so the
-  // updated binary takes over on next launch rather than the old process
-  // continuing to field requests.
+  // Bring already-running AFK services onto the just-installed code. A long
+  // running process keeps the old module graph in memory after npm overwrites
+  // the files on disk — only a restart swaps it.
+  //
+  // 1. launchd-supervised services (telegram + daemon): restart in place so
+  //    they re-exec the new entrypoint. macOS only; fail-open.
+  if (process.platform === 'darwin') {
+    try {
+      const restarted = restartLaunchdServices();
+      if (restarted.length > 0) {
+        const names = restarted.map((l) => l.replace(/^com\.afk\./, '')).join(', ');
+        process.stdout.write(
+          `\n↻ Restarted AFK service(s) onto the new version: ${names}\n`,
+        );
+      }
+    } catch {
+      // restartLaunchdServices is already fail-open; belt-and-suspenders.
+    }
+  }
+
+  // 2. A manually-started telegram bot (`afk telegram start`) is not supervised
+  //    by launchd, so we cannot relaunch it safely from an npm lifecycle script.
+  //    Earlier versions SIGTERM'd it here, which left it dead with nothing to
+  //    bring it back. Notify instead so the user can restart it deliberately.
   try {
     const afkHome = process.env['AFK_HOME'] ?? join(homedir(), '.afk');
-    const pidFilePath = join(afkHome, 'state', 'telegram', 'bot.pid');
-    killStaleDaemon(pidFilePath);
+    const botPidPath = join(afkHome, 'state', 'telegram', 'bot.pid');
+    const manualPid = isManualBotRunning(botPidPath);
+    if (manualPid !== null) {
+      process.stdout.write(
+        `\n⚠ A manually-started telegram bot (PID ${manualPid}) is still running the previous version.\n` +
+          `  Restart it to apply the update:  afk telegram restart\n`,
+      );
+    }
   } catch {
-    // Belt-and-suspenders: killStaleDaemon already swallows all errors internally.
+    // Best-effort notice — never block the install.
   }
 
   process.exit(0);

--- a/tests/postinstall.test.ts
+++ b/tests/postinstall.test.ts
@@ -1,17 +1,32 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
 type KillStaleDaemonFn = (pidFilePath: string, killFn?: (pid: number, signal: string) => void) => void;
+type IsManualBotRunningFn = (
+  pidFilePath: string,
+  probeFn?: (pid: number, signal: number) => void,
+) => number | null;
+type RestartLaunchdServicesFn = (opts?: {
+  home?: string;
+  uid?: number;
+  labels?: string[];
+  existsFn?: (p: string) => boolean;
+  execFn?: (argv: string[]) => void;
+}) => string[];
 
 let killStaleDaemon: KillStaleDaemonFn;
+let isManualBotRunning: IsManualBotRunningFn;
+let restartLaunchdServices: RestartLaunchdServicesFn;
 
 beforeAll(async () => {
   // Dynamic import avoids TypeScript transform issues with plain .mjs files.
   // Pattern mirrors src/cli/postinstall.test.ts exactly.
   const mod = await import('../scripts/postinstall.mjs');
   killStaleDaemon = mod.killStaleDaemon as KillStaleDaemonFn;
+  isManualBotRunning = mod.isManualBotRunning as IsManualBotRunningFn;
+  restartLaunchdServices = mod.restartLaunchdServices as RestartLaunchdServicesFn;
 });
 
 describe('killStaleDaemon', () => {
@@ -68,5 +83,153 @@ describe('killStaleDaemon', () => {
     });
     expect(() => killStaleDaemon(pidFile, killFn)).not.toThrow();
     expect(killFn).toHaveBeenCalledWith(42, 'SIGTERM');
+  });
+});
+
+describe('isManualBotRunning', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'afk-botprobe-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('returns null when the PID file does not exist', () => {
+    const missing = join(tmpDir, 'no-such.pid');
+    const probeFn = vi.fn();
+    expect(isManualBotRunning(missing, probeFn)).toBeNull();
+    expect(probeFn).not.toHaveBeenCalled();
+  });
+
+  it('returns null (and never probes) for non-numeric PID content', () => {
+    const pidFile = join(tmpDir, 'garbage.pid');
+    writeFileSync(pidFile, 'not-a-pid');
+    const probeFn = vi.fn();
+    expect(isManualBotRunning(pidFile, probeFn)).toBeNull();
+    expect(probeFn).not.toHaveBeenCalled();
+  });
+
+  it('returns the PID and probes with signal 0 when the process is alive', () => {
+    const pidFile = join(tmpDir, 'live.pid');
+    writeFileSync(pidFile, '4321');
+    const probeFn = vi.fn(); // no throw = process exists
+    expect(isManualBotRunning(pidFile, probeFn)).toBe(4321);
+    expect(probeFn).toHaveBeenCalledWith(4321, 0);
+  });
+
+  it('returns null when the probe throws ESRCH (stale PID, process gone)', () => {
+    const pidFile = join(tmpDir, 'stale.pid');
+    writeFileSync(pidFile, '999999999');
+    const probeFn = vi.fn(() => {
+      const err = new Error('no such process') as NodeJS.ErrnoException;
+      err.code = 'ESRCH';
+      throw err;
+    });
+    expect(isManualBotRunning(pidFile, probeFn)).toBeNull();
+  });
+
+  it('returns null when the probe throws EPERM (process owned by another user)', () => {
+    const pidFile = join(tmpDir, 'other.pid');
+    writeFileSync(pidFile, '42');
+    const probeFn = vi.fn(() => {
+      const err = new Error('operation not permitted') as NodeJS.ErrnoException;
+      err.code = 'EPERM';
+      throw err;
+    });
+    expect(isManualBotRunning(pidFile, probeFn)).toBeNull();
+  });
+
+  it('does NOT delete a stale PID file (read-only, unlike manager.isRunning)', () => {
+    const pidFile = join(tmpDir, 'stale-keep.pid');
+    writeFileSync(pidFile, '999999999');
+    const probeFn = vi.fn(() => {
+      const err = new Error('no such process') as NodeJS.ErrnoException;
+      err.code = 'ESRCH';
+      throw err;
+    });
+    isManualBotRunning(pidFile, probeFn);
+    expect(existsSync(pidFile)).toBe(true);
+  });
+});
+
+describe('restartLaunchdServices', () => {
+  const HOME = '/Users/tester';
+  const TELEGRAM_PLIST = join(HOME, 'Library', 'LaunchAgents', 'com.afk.telegram.plist');
+  const DAEMON_PLIST = join(HOME, 'Library', 'LaunchAgents', 'com.afk.daemon.plist');
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns [] and never shells out when no service plist exists', () => {
+    const execFn = vi.fn();
+    const result = restartLaunchdServices({
+      home: HOME,
+      uid: 1000,
+      existsFn: () => false,
+      execFn,
+    });
+    expect(result).toEqual([]);
+    expect(execFn).not.toHaveBeenCalled();
+  });
+
+  it('restarts only services whose plist exists, with the correct kickstart argv', () => {
+    const execFn = vi.fn();
+    const result = restartLaunchdServices({
+      home: HOME,
+      uid: 1000,
+      existsFn: (p) => p === TELEGRAM_PLIST, // only telegram installed
+      execFn,
+    });
+    expect(result).toEqual(['com.afk.telegram']);
+    expect(execFn).toHaveBeenCalledTimes(1);
+    expect(execFn).toHaveBeenCalledWith(['kickstart', '-k', 'gui/1000/com.afk.telegram']);
+  });
+
+  it('restarts both services when both plists exist', () => {
+    const execFn = vi.fn();
+    const result = restartLaunchdServices({
+      home: HOME,
+      uid: 501,
+      existsFn: (p) => p === TELEGRAM_PLIST || p === DAEMON_PLIST,
+      execFn,
+    });
+    expect(result).toEqual(['com.afk.telegram', 'com.afk.daemon']);
+    expect(execFn).toHaveBeenNthCalledWith(1, ['kickstart', '-k', 'gui/501/com.afk.telegram']);
+    expect(execFn).toHaveBeenNthCalledWith(2, ['kickstart', '-k', 'gui/501/com.afk.daemon']);
+  });
+
+  it('swallows a launchctl error for one service and still attempts the other', () => {
+    const execFn = vi.fn((argv: string[]) => {
+      if (argv[2]?.endsWith('com.afk.telegram')) {
+        throw new Error('Could not find service'); // not loaded
+      }
+    });
+    const result = restartLaunchdServices({
+      home: HOME,
+      uid: 501,
+      existsFn: () => true, // both plists present
+      execFn,
+    });
+    // telegram threw → excluded; daemon succeeded → included. No throw.
+    expect(result).toEqual(['com.afk.daemon']);
+    expect(execFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('honours a custom labels list', () => {
+    const execFn = vi.fn();
+    const result = restartLaunchdServices({
+      home: HOME,
+      uid: 1000,
+      labels: ['com.afk.daemon'],
+      existsFn: (p) => p === DAEMON_PLIST,
+      execFn,
+    });
+    expect(result).toEqual(['com.afk.daemon']);
+    expect(execFn).toHaveBeenCalledWith(['kickstart', '-k', 'gui/1000/com.afk.daemon']);
   });
 });


### PR DESCRIPTION
## Summary

A long-running telegram bot / daemon keeps the **old** module graph in memory after `npm install -g agent-afk@latest` (via `afk update`, the auto-update path, or a manual install) swaps the files on disk — so they silently run stale code until restarted. The previous `postinstall` handling only SIGTERM'd a manually-started bot (killing it with nothing to relaunch it) and never touched the daemon or any launchd-supervised service.

This change makes `scripts/postinstall.mjs` — the one chokepoint npm runs on **every** global install — bring running services onto the freshly-installed code:

- **`restartLaunchdServices()`** — `launchctl kickstart -k gui/<uid>/<label>` for any installed `com.afk.telegram` / `com.afk.daemon` LaunchAgent, so it re-execs the new on-disk entrypoint. Reuses the exact invocation `afk service restart` already uses (`src/cli/commands/service.ts`). macOS-only; fail-open (absent plist skipped, launchctl errors swallowed — the install never fails).
- **`isManualBotRunning()`** — replaces the silent SIGTERM. A manually-started bot (the only writer of `bot.pid`; launchd-supervised bots don't write it — see `src/service/launchd/paths.ts`) is now **notified** with an `afk telegram restart` hint instead of killed. Read-only probe — does not unlink a stale pid file.

`killStaleDaemon` is retained as a tested utility but no longer wired into the flow. The `↻ Restarted AFK service(s)` confirmation flows through `afk update`'s inherited stdio, so it's visible without touching `update.ts`. `dist/postinstall.mjs` is a `copyFileSync` of this source (`scripts/build-dist.mjs`), so the fix ships from the first release that includes it.

## Test results

- `pnpm lint` (tsc --noEmit, strict): **passed** (exit 0)
- `pnpm test` (full suite): **10283 passed / 2 failed / 14 skipped**. The 2 failures are pre-existing and unrelated to this change — `anthropic-direct.test.ts > compact()` and `config.test.ts > model slots … built-in tier bindings` (a known env/MLX slot-binding bleed). Neither test imports the changed file; this PR touches only `scripts/postinstall.mjs` (outside the `src/` compile graph) and its test. **Zero new failures introduced.**
- Scoped suites that actually exercise the change: `tests/postinstall.test.ts` (16) + `src/cli/postinstall.test.ts` (8) = **24 passed**, including +11 new cases (`isManualBotRunning` ×6, `restartLaunchdServices` ×5) using injected exists/exec/probe fns.
- Live `node scripts/postinstall.mjs` against a fake empty `$HOME` exits 0 with no real services touched.

## Verification

Adversarial read-only verifier re-derived the load-bearing claims from the diff (not the description):

- **Restarts installed launchd services via `kickstart -k`, skips absent plists** — CONFIRM (`postinstall.mjs` restartLaunchdServices: plist gate + argv; test asserts exact `['kickstart','-k','gui/1000/com.afk.telegram']`).
- **Manual-bot SIGTERM removed; notify instead, no pid-file mutation** — CONFIRM (`killStaleDaemon` not invoked in the main block; `isManualBotRunning` probes with signal 0 and a test asserts the stale pid file is preserved).
- **Fail-open, macOS-gated, always exits 0** — CONFIRM (`process.platform === 'darwin'` gate, both new paths try/catch-wrapped, unconditional final `process.exit(0)`).

Verdict: **SAFE TO MERGE.** One benign note: the EPERM branch of `isManualBotRunning` treats a bot owned by another user as not-running (conservative; not a regression — cross-user bot collision is a non-scenario given a single bot token).

## Out of scope

- **Linux/systemd** — AFK services are macOS-launchd-only by design; the manual-bot notify still works cross-platform.
- **`npm install --ignore-scripts`** — skips postinstall entirely (same pre-existing limitation as the PATH-gap notice).
- **No `update.ts` edit** — intentional: postinstall runs inside `afk update`'s `runNpmInstall` (inherited stdio), so adding restart logic there too would double-restart.
