### PR TITLE
feat: agent browser autonomy MVP (session vault, park-and-notify, retrying fetch)

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -58,6 +58,14 @@
       "category": "browser"
     },
     {
+      "name": "AFK_BROWSER_DEFAULT_PROFILE",
+      "description": "Name of the persistent session-vault profile the agent reuses for browser sessions. The context restores its login from (and saves it back to) ~/.afk/state/browser/<profile>/storageState.json, so a human runs `afk browser login --profile <name>` once and the agent reuses that authenticated session across unattended runs. Unset defaults to `default` (a fresh, empty profile — identical to pre-vault behavior). Allowed charset: [A-Za-z0-9_-], max 128 chars.",
+      "type": "string",
+      "required": false,
+      "example": "work",
+      "category": "browser"
+    },
+    {
       "name": "AFK_BROWSER_DOM_SNAPSHOTS",
       "description": "Phase 2 opt-in: when set to 1, every browser_act writes a gzipped DOM snapshot sidecar under ~/.afk/state/witness/<sid>/browser/dom-snapshots/. Off by default because snapshots are large; useful for post-mortem analysis of failed actions.",
       "type": "boolean",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**116 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**117 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 
@@ -124,6 +124,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_BROWSER_BACKEND` | string |  |  | `playwright` | Select the browser provider backend. Phase 1 supports only `playwright`. Reserved for future `cdp` / `mcp` adapters. Unset defaults to `playwright`. |
 | `AFK_BROWSER_BLOCKED_DOMAINS` | string |  |  | `*.ads.example.com` | Comma-separated blocklist of URL host globs. Browser navigation that matches any entry returns status: blocked_by_policy regardless of the allowlist. |
 | `AFK_BROWSER_CONFIG` | string |  |  | `/path/to/browser.json` | Absolute path to an alternate browser config file. Overrides the default ~/.afk/config/browser.json lookup. Useful for per-project overrides in CI. |
+| `AFK_BROWSER_DEFAULT_PROFILE` | string |  |  | `work` | Name of the persistent session-vault profile the agent reuses for browser sessions. The context restores its login from (and saves it back to) ~/.afk/state/browser/<profile>/storageState.json, so a human runs `afk browser login --profile <name>` once and the agent reuses that authenticated session across unattended runs. Unset defaults to `default` (a fresh, empty profile — identical to pre-vault behavior). Allowed charset: [A-Za-z0-9_-], max 128 chars. |
 | `AFK_BROWSER_DOM_SNAPSHOTS` | boolean |  |  | `1` | Phase 2 opt-in: when set to 1, every browser_act writes a gzipped DOM snapshot sidecar under ~/.afk/state/witness/<sid>/browser/dom-snapshots/. Off by default because snapshots are large; useful for post-mortem analysis of failed actions. |
 | `AFK_BROWSER_HEADLESS` | boolean |  |  | `1` | Override the default headless mode for native browser-control tools. `1`/`true` forces headless; `0`/`false` forces headed. When unset the default is headless for daemon and subagent surfaces and headed for repl/interactive — so an operator can watch the agent work in REPL mode. |
 | `AFK_SESSION_ID` | string |  | `default` | `session-abc123` | Override the browser session ID used by the native browser-control tools. Defaults to 'default' for single-session use. Subagents inherit the parent's session by default. Set this when running multiple concurrent AFK processes that should each manage an isolated browser context. |

--- a/src/agent/elicitation-router.test.ts
+++ b/src/agent/elicitation-router.test.ts
@@ -17,7 +17,15 @@
 
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import type { ElicitationRequest, ElicitationResult } from './types/sdk-types.js';
+
+// Mock the Telegram push primitive so park-and-notify can be asserted without
+// touching the network. Hoisted above the router import below.
+vi.mock('../telegram/push.js', () => ({
+  pushIfConfigured: vi.fn().mockResolvedValue(null),
+}));
+
 import { elicitationRouter } from './elicitation-router.js';
+import { pushIfConfigured } from '../telegram/push.js';
 
 const NO_SIGNAL = new AbortController().signal;
 
@@ -32,6 +40,7 @@ const URL_REQUEST: ElicitationRequest = {
 describe('elicitationRouter', () => {
   beforeEach(() => {
     elicitationRouter.uninstall();
+    vi.mocked(pushIfConfigured).mockClear();
   });
 
   afterEach(() => {
@@ -41,6 +50,36 @@ describe('elicitationRouter', () => {
   it('auto-declines when no handler is installed', async () => {
     const result = await elicitationRouter.route(URL_REQUEST, { signal: NO_SIGNAL });
     expect(result.action).toBe('decline');
+  });
+
+  it('park-and-notify: no handler → fires a Telegram notification, then declines', async () => {
+    const result = await elicitationRouter.route(URL_REQUEST, { signal: NO_SIGNAL });
+    expect(result.action).toBe('decline');
+    expect(pushIfConfigured).toHaveBeenCalledTimes(1);
+    const msg = vi.mocked(pushIfConfigured).mock.calls[0]?.[0] as string;
+    expect(msg).toContain('supabase'); // serverName label
+    expect(msg).toContain('Sign in with Supabase to continue'); // request.message
+    expect(msg).toContain('https://supabase.example/oauth/abc'); // request.url
+  });
+
+  it('park-and-notify: does NOT notify when a handler is installed (human already prompted)', async () => {
+    elicitationRouter.install(vi.fn().mockResolvedValue({ action: 'accept' } as ElicitationResult));
+    await elicitationRouter.route(URL_REQUEST, { signal: NO_SIGNAL });
+    expect(pushIfConfigured).not.toHaveBeenCalled();
+  });
+
+  it('park-and-notify: a notification failure never breaks the decline', async () => {
+    vi.mocked(pushIfConfigured).mockRejectedValueOnce(new Error('telegram down'));
+    const result = await elicitationRouter.route(URL_REQUEST, { signal: NO_SIGNAL });
+    expect(result.action).toBe('decline');
+  });
+
+  it('park-and-notify: does NOT fire on the pre-aborted fast path', async () => {
+    const aborted = new AbortController();
+    aborted.abort();
+    const result = await elicitationRouter.route(URL_REQUEST, { signal: aborted.signal });
+    expect(result.action).toBe('decline');
+    expect(pushIfConfigured).not.toHaveBeenCalled();
   });
 
   it('forwards to the installed handler and returns its result', async () => {

--- a/src/agent/elicitation-router.test.ts
+++ b/src/agent/elicitation-router.test.ts
@@ -82,6 +82,36 @@ describe('elicitationRouter', () => {
     expect(pushIfConfigured).not.toHaveBeenCalled();
   });
 
+  it('park-and-notify: no handler + aborted while waiting in queue → declines without notifying', async () => {
+    // A first request (with a handler) holds the serial queue; a second request
+    // is captured with NO handler, then aborted while it waits behind the first.
+    // When the queue reaches it, the abort re-check fires BEFORE the no-handler
+    // branch — so it declines silently rather than firing park-and-notify.
+    const handler = vi.fn().mockResolvedValue({ action: 'accept' } as ElicitationResult);
+    elicitationRouter.install(handler);
+    const firstSignal = new AbortController();
+    const first = elicitationRouter.route(URL_REQUEST, { signal: firstSignal.signal });
+
+    elicitationRouter.uninstall(); // the second request captures a null handler
+    const secondAbort = new AbortController();
+    const second = elicitationRouter.route(URL_REQUEST, { signal: secondAbort.signal });
+    secondAbort.abort(); // aborted while still queued behind the first
+
+    const [r1, r2] = await Promise.all([first, second]);
+    expect(r1).toEqual({ action: 'accept' });
+    expect(r2).toEqual({ action: 'decline' });
+    expect(pushIfConfigured).not.toHaveBeenCalled();
+  });
+
+  it('park-and-notify: truncates an over-long message to bound inadvertent disclosure', async () => {
+    const longMsg = 'x'.repeat(500);
+    await elicitationRouter.route({ ...URL_REQUEST, message: longMsg }, { signal: NO_SIGNAL });
+    const msg = vi.mocked(pushIfConfigured).mock.calls[0]?.[0] as string;
+    expect(msg).toContain('…(truncated)');
+    expect(msg).not.toContain(longMsg); // the full 500-char message is never sent
+    expect(msg).toContain('x'.repeat(300)); // first 300 chars preserved
+  });
+
   it('forwards to the installed handler and returns its result', async () => {
     const accepted: ElicitationResult = { action: 'accept' };
     const handler = vi.fn().mockResolvedValue(accepted);

--- a/src/agent/elicitation-router.ts
+++ b/src/agent/elicitation-router.ts
@@ -33,6 +33,7 @@
  */
 
 import type { ElicitationRequest, ElicitationResult } from './types/sdk-types.js';
+import { pushIfConfigured } from '../telegram/push.js';
 
 export type ElicitationHandler = (
   request: ElicitationRequest,
@@ -40,6 +41,29 @@ export type ElicitationHandler = (
 ) => Promise<ElicitationResult>;
 
 const DECLINE: ElicitationResult = { action: 'decline' };
+
+/**
+ * Park-and-notify: when no elicitation handler is installed (daemon, scheduler,
+ * subagent, one-shot — nobody is watching), a prompt would otherwise DECLINE
+ * silently, the worst autonomy outcome: the run fails at an auth wall / captcha
+ * / permission gate with zero signal to the operator. Instead we fire a
+ * best-effort Telegram notification so the human can act asynchronously, then
+ * the caller still DECLINEs so the run continues rather than blocking.
+ *
+ * Fully fire-and-forget and exception-proof: `pushIfConfigured` no-ops when
+ * Telegram is unconfigured and swallows transport errors; this wrapper never
+ * throws into the router's must-always-resolve path.
+ */
+function notifyUnattendedElicitation(request: ElicitationRequest): void {
+  try {
+    const label = request.title ?? request.serverName;
+    const parts = [`🔔 AFK needs you — stuck on: ${label}`, request.message];
+    if (request.url !== undefined && request.url !== '') parts.push(request.url);
+    void pushIfConfigured(parts.join('\n')).catch(() => undefined);
+  } catch {
+    // Never let a notification failure affect the DECLINE path.
+  }
+}
 
 class ElicitationRouter {
   private handler: ElicitationHandler | null = null;
@@ -85,6 +109,9 @@ class ElicitationRouter {
           return;
         }
         if (!capturedHandler) {
+          // No handler = unattended surface. Surface the prompt out-of-band
+          // (Telegram) instead of declining silently, then DECLINE to continue.
+          notifyUnattendedElicitation(request);
           resolveResult(DECLINE);
           return;
         }

--- a/src/agent/elicitation-router.ts
+++ b/src/agent/elicitation-router.ts
@@ -43,6 +43,20 @@ export type ElicitationHandler = (
 const DECLINE: ElicitationResult = { action: 'decline' };
 
 /**
+ * Cap on the model-authored `message` echoed to Telegram. The prompt itself is
+ * the minimal disclosure the operator needs to act, but a model could embed
+ * sensitive text in it; truncating bounds inadvertent exposure. The richer
+ * `request.context` field is deliberately never sent.
+ */
+const MAX_NOTIFY_MESSAGE_CHARS = 300;
+
+function truncateForNotify(text: string): string {
+  return text.length <= MAX_NOTIFY_MESSAGE_CHARS
+    ? text
+    : `${text.slice(0, MAX_NOTIFY_MESSAGE_CHARS)}…(truncated)`;
+}
+
+/**
  * Park-and-notify: when no elicitation handler is installed (daemon, scheduler,
  * subagent, one-shot — nobody is watching), a prompt would otherwise DECLINE
  * silently, the worst autonomy outcome: the run fails at an auth wall / captcha
@@ -57,7 +71,7 @@ const DECLINE: ElicitationResult = { action: 'decline' };
 function notifyUnattendedElicitation(request: ElicitationRequest): void {
   try {
     const label = request.title ?? request.serverName;
-    const parts = [`🔔 AFK needs you — stuck on: ${label}`, request.message];
+    const parts = [`🔔 AFK needs you — stuck on: ${label}`, truncateForNotify(request.message)];
     if (request.url !== undefined && request.url !== '') parts.push(request.url);
     void pushIfConfigured(parts.join('\n')).catch(() => undefined);
   } catch {

--- a/src/agent/tools/handlers/web-scrape.ts
+++ b/src/agent/tools/handlers/web-scrape.ts
@@ -32,6 +32,7 @@
 import type { ToolHandler } from '../types.js';
 import { scrapeToMarkdown } from '../../../web/scrape.js';
 import { resolveSearchBackend, formatSearchResults } from '../../../web/search.js';
+import { retryFetch } from '../../../web/retryFetch.js';
 import type { RenderFn } from '../../../web/types.js';
 
 // External constraint: Node 20+ ships `fetch` as a global. Older runtimes
@@ -206,7 +207,8 @@ export function createWebScrapeHandler(opts: WebScrapeOptions = {}): ToolHandler
       if (parsed.mode === 'raw') {
         let res: Response;
         try {
-          res = await fetchFn(parsed.url!, {
+          // retryFetch survives transient 429/5xx + network blips (idempotent GET).
+          res = await retryFetch(fetchFn, parsed.url!, {
             method: 'GET',
             headers: { 'User-Agent': 'agent-afk/web_scrape', Accept: '*/*' },
             signal: ac.signal,

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -379,3 +379,50 @@ describe('enforceDomainPolicy', () => {
     expect(enforceDomainPolicy('https://github.com/', cfg)).toEqual({ allowed: true });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Session-vault default profile
+// ---------------------------------------------------------------------------
+
+describe('loadBrowserConfig — defaultProfile (session vault)', () => {
+  it('defaults to "default" when AFK_BROWSER_DEFAULT_PROFILE is unset', () => {
+    const cfg = loadBrowserConfig({ env: makeEnv(), readFileSync: noFile });
+    expect(cfg.defaultProfile).toBe('default');
+  });
+
+  it('treats empty/whitespace as unset → "default"', () => {
+    expect(
+      loadBrowserConfig({ env: makeEnv({ AFK_BROWSER_DEFAULT_PROFILE: '' }), readFileSync: noFile })
+        .defaultProfile,
+    ).toBe('default');
+    expect(
+      loadBrowserConfig({ env: makeEnv({ AFK_BROWSER_DEFAULT_PROFILE: '   ' }), readFileSync: noFile })
+        .defaultProfile,
+    ).toBe('default');
+  });
+
+  it('reads and trims a custom profile name from env', () => {
+    const cfg = loadBrowserConfig({
+      env: makeEnv({ AFK_BROWSER_DEFAULT_PROFILE: '  work  ' }),
+      readFileSync: noFile,
+    });
+    expect(cfg.defaultProfile).toBe('work');
+  });
+
+  it('throws on an unsafe (path-traversal) profile name', () => {
+    expect(() =>
+      loadBrowserConfig({
+        env: makeEnv({ AFK_BROWSER_DEFAULT_PROFILE: '../../etc' }),
+        readFileSync: noFile,
+      }),
+    ).toThrow(/Invalid browser profile/);
+  });
+
+  it('lets browser.json override the env profile', () => {
+    const cfg = loadBrowserConfig({
+      env: makeEnv({ AFK_BROWSER_DEFAULT_PROFILE: 'work' }),
+      readFileSync: withFile(JSON.stringify({ defaultProfile: 'staging' })),
+    });
+    expect(cfg.defaultProfile).toBe('staging');
+  });
+});

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -418,6 +418,17 @@ describe('loadBrowserConfig — defaultProfile (session vault)', () => {
     ).toThrow(/Invalid browser profile/);
   });
 
+  it('throws on an unsafe (path-traversal) profile name from browser.json', () => {
+    // The file value routes through the same guard as the env var, so a
+    // traversal name in browser.json must be rejected too.
+    expect(() =>
+      loadBrowserConfig({
+        env: makeEnv(),
+        readFileSync: withFile(JSON.stringify({ defaultProfile: '../../etc' })),
+      }),
+    ).toThrow(/Invalid browser profile/);
+  });
+
   it('lets browser.json override the env profile', () => {
     const cfg = loadBrowserConfig({
       env: makeEnv({ AFK_BROWSER_DEFAULT_PROFILE: 'work' }),

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -12,7 +12,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'path';
 import { env as defaultEnv } from '../config/env.js';
-import { getAfkConfigDir } from '../paths.js';
+import { getAfkConfigDir, assertSafeBrowserProfile } from '../paths.js';
 import type { BrowserConfig } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -116,6 +116,18 @@ function resolveBackend(raw: string | undefined): 'playwright' {
   );
 }
 
+/**
+ * Resolve the session-vault profile name. Unset/empty → `'default'`. A
+ * provided name is validated against the filesystem-safe charset and throws
+ * loudly on dangerous input (path traversal) — consistent with this loader's
+ * fail-fast posture on bad config, and matching the guard in the path helpers.
+ */
+function resolveDefaultProfile(raw: string | undefined): string {
+  const name = raw === undefined || raw.trim() === '' ? 'default' : raw.trim();
+  assertSafeBrowserProfile(name);
+  return name;
+}
+
 // ---------------------------------------------------------------------------
 // Boolean env helper
 // ---------------------------------------------------------------------------
@@ -183,6 +195,9 @@ function mergeFileConfig(base: BrowserConfig, fileConfig: Record<string, unknown
       `AFK_BROWSER_BACKEND: only "playwright" is supported in Phase 1, got: ${String(fileConfig['backend'])}`,
     );
   }
+  if (typeof fileConfig['defaultProfile'] === 'string') {
+    result.defaultProfile = resolveDefaultProfile(fileConfig['defaultProfile']);
+  }
 
   return result;
 }
@@ -205,6 +220,7 @@ export function loadBrowserConfig(opts?: LoadBrowserConfigOptions): BrowserConfi
   const blockedDomains = parseDomainList(envSource['AFK_BROWSER_BLOCKED_DOMAINS']);
   const domSnapshots = parseBooleanEnv(envSource['AFK_BROWSER_DOM_SNAPSHOTS']);
   const backend = resolveBackend(envSource['AFK_BROWSER_BACKEND']);
+  const defaultProfile = resolveDefaultProfile(envSource['AFK_BROWSER_DEFAULT_PROFILE']);
 
   const base: BrowserConfig = {
     headless,
@@ -213,6 +229,7 @@ export function loadBrowserConfig(opts?: LoadBrowserConfigOptions): BrowserConfi
     domSnapshots,
     backend,
     configPath: null,
+    defaultProfile,
   };
 
   // Determine JSON config path: explicit env override, or default location.

--- a/src/browser/playwright/index.test.ts
+++ b/src/browser/playwright/index.test.ts
@@ -76,6 +76,7 @@ vi.mock('../config.js', () => ({
     domSnapshots: false,
     backend: 'playwright',
     configPath: null,
+    defaultProfile: 'default',
   }),
   enforceDomainPolicy: vi.fn(),
 }));
@@ -166,6 +167,7 @@ const defaultConfig: BrowserConfig = {
   domSnapshots: false,
   backend: 'playwright',
   configPath: null,
+  defaultProfile: 'default',
 };
 
 // ---------------------------------------------------------------------------

--- a/src/browser/playwright/launcher.test.ts
+++ b/src/browser/playwright/launcher.test.ts
@@ -10,7 +10,10 @@
  * before launcher.ts is imported.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import nodePath from 'node:path';
 
 // ---------------------------------------------------------------------------
 // Stub types
@@ -32,6 +35,7 @@ interface StubPage {
 interface StubContext {
   newPage: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
+  storageState: ReturnType<typeof vi.fn>;
   _pages: StubPage[];
 }
 
@@ -84,6 +88,7 @@ function makeStubContext(): StubContext {
   const ctx: StubContext = {
     close: vi.fn().mockResolvedValue(undefined),
     newPage: vi.fn(),
+    storageState: vi.fn().mockResolvedValue({ cookies: [{ name: 'sid', value: 'abc' }], origins: [] }),
     _pages: [],
   };
   ctx.newPage.mockImplementation(() => {
@@ -129,6 +134,7 @@ vi.mock('playwright', () => ({
 import { BrowserLauncher } from './launcher.js';
 import type { BrowserConfig } from '../types.js';
 import { chromium } from 'playwright';
+import { getBrowserProfileStateDir, getBrowserStorageStatePath } from '../../paths.js';
 
 // ---------------------------------------------------------------------------
 // Test config fixture
@@ -141,6 +147,7 @@ const TEST_CONFIG: BrowserConfig = {
   domSnapshots: false,
   backend: 'playwright',
   configPath: null,
+  defaultProfile: 'default',
 };
 
 // ---------------------------------------------------------------------------
@@ -739,5 +746,91 @@ describe('BrowserLauncher', () => {
       await launcher.ensurePage('session-A');
       await expect(launcher.dismissDialog('session-A', true)).resolves.toBeUndefined();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session vault (storageState restore-on-open / save-on-close)
+// ---------------------------------------------------------------------------
+
+describe('BrowserLauncher — session vault', () => {
+  let tmpStateDir: string;
+  let prevStateDir: string | undefined;
+
+  // The vault profile for these tests. TEST_CONFIG uses 'default'; here we use a
+  // named profile so "established" semantics are unambiguous.
+  const VAULT_CONFIG: BrowserConfig = { ...TEST_CONFIG, defaultProfile: 'work' };
+
+  beforeEach(() => {
+    currentStubBrowser = makeStubBrowser();
+    vi.mocked(chromium.launch).mockClear();
+    vi.mocked(chromium.launch).mockImplementation(async () => currentStubBrowser);
+
+    // Point the state tier at a temp dir so the vault path resolves there.
+    tmpStateDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'afk-vault-test-'));
+    prevStateDir = process.env['AFK_STATE_DIR'];
+    process.env['AFK_STATE_DIR'] = tmpStateDir;
+  });
+
+  afterEach(() => {
+    if (prevStateDir === undefined) delete process.env['AFK_STATE_DIR'];
+    else process.env['AFK_STATE_DIR'] = prevStateDir;
+    fs.rmSync(tmpStateDir, { recursive: true, force: true });
+  });
+
+  function establishProfile(profile: string, state: unknown = { cookies: [], origins: [] }): string {
+    const file = getBrowserStorageStatePath(profile);
+    fs.mkdirSync(getBrowserProfileStateDir(profile), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify(state));
+    return file;
+  }
+
+  function firstNewContextOpts(): Record<string, unknown> | undefined {
+    return vi.mocked(currentStubBrowser.newContext).mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+  }
+
+  it('restores storageState into newContext when a vault file exists', async () => {
+    establishProfile('work', { cookies: [{ name: 'sid', value: 'abc' }], origins: [] });
+    const launcher = new BrowserLauncher(VAULT_CONFIG);
+    await launcher.ensureContext('s1');
+    expect(firstNewContextOpts()?.['storageState']).toBeDefined();
+  });
+
+  it('does NOT pass storageState when no vault file exists (fresh context)', async () => {
+    const launcher = new BrowserLauncher(VAULT_CONFIG);
+    await launcher.ensureContext('s1');
+    expect(firstNewContextOpts()?.['storageState']).toBeUndefined();
+  });
+
+  it('degrades to a fresh context when the vault file is corrupt', async () => {
+    fs.mkdirSync(getBrowserProfileStateDir('work'), { recursive: true });
+    fs.writeFileSync(getBrowserStorageStatePath('work'), '{ not valid json');
+    const launcher = new BrowserLauncher(VAULT_CONFIG);
+    await expect(launcher.ensureContext('s1')).resolves.toBeDefined();
+    expect(firstNewContextOpts()?.['storageState']).toBeUndefined();
+  });
+
+  it('saves storageState back on close when the profile is already established', async () => {
+    const file = establishProfile('work');
+    const launcher = new BrowserLauncher(VAULT_CONFIG);
+    await launcher.ensureContext('s1');
+    const ctx = currentStubBrowser._contexts[0];
+    await launcher.closeSession('s1');
+
+    expect(ctx?.storageState).toHaveBeenCalledTimes(1);
+    const saved = JSON.parse(fs.readFileSync(file, 'utf8')) as Record<string, unknown>;
+    expect(saved).toHaveProperty('cookies');
+  });
+
+  it('does NOT create a vault file on close for an unestablished/ephemeral profile', async () => {
+    const launcher = new BrowserLauncher(VAULT_CONFIG);
+    await launcher.ensureContext('s1');
+    const ctx = currentStubBrowser._contexts[0];
+    await launcher.closeSession('s1');
+
+    expect(ctx?.storageState).not.toHaveBeenCalled();
+    expect(fs.existsSync(getBrowserStorageStatePath('work'))).toBe(false);
   });
 });

--- a/src/browser/playwright/launcher.test.ts
+++ b/src/browser/playwright/launcher.test.ts
@@ -824,6 +824,39 @@ describe('BrowserLauncher — session vault', () => {
     expect(saved).toHaveProperty('cookies');
   });
 
+  it('saves the vault file at 0600 after refreshing an established profile on close', async () => {
+    const file = establishProfile('work');
+    // Loosen perms first so the assertion proves the atomic save re-tightens to
+    // 0600 (the named observable: "saves storageState mode 0600").
+    fs.chmodSync(file, 0o644);
+    const launcher = new BrowserLauncher(VAULT_CONFIG);
+    await launcher.ensureContext('s1');
+    await launcher.closeSession('s1');
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it('renderHtml bypasses the vault even when the default profile IS established', async () => {
+    // A session context WOULD restore this vault; a one-shot render must not —
+    // renderHtml builds an ephemeral context that never loads storageState.
+    establishProfile('work', { cookies: [{ name: 'sid', value: 'abc' }], origins: [] });
+    const launcher = new BrowserLauncher(VAULT_CONFIG);
+    const ctx = makeStubContext();
+    currentStubBrowser.newContext.mockResolvedValueOnce(ctx);
+    ctx.newPage.mockImplementationOnce(async () => {
+      const p = makeStubPage();
+      p.goto.mockResolvedValueOnce({ status: () => 200 });
+      p.content.mockResolvedValueOnce('<html><body>ok</body></html>');
+      p.url.mockReturnValue('https://example.com/final');
+      ctx._pages.push(p);
+      return p;
+    });
+
+    await launcher.renderHtml('https://example.com/start', { timeoutMs: 5000, waitUntil: 'load' });
+
+    expect(firstNewContextOpts()?.['storageState']).toBeUndefined();
+    expect(launcher.activeSessions()).toBe(0); // ephemeral — not tracked as a session
+  });
+
   it('does NOT create a vault file on close for an unestablished/ephemeral profile', async () => {
     const launcher = new BrowserLauncher(VAULT_CONFIG);
     await launcher.ensureContext('s1');

--- a/src/browser/playwright/launcher.ts
+++ b/src/browser/playwright/launcher.ts
@@ -14,10 +14,12 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { randomBytes } from 'node:crypto';
 import { chromium } from 'playwright';
 import type { Browser, BrowserContext, Dialog, Page, Request, Response } from 'playwright';
 import type { BrowserConfig } from '../types.js';
 import { getBrowserStorageStatePath } from '../../paths.js';
+import { debugLog } from '../../utils/debug.js';
 
 // Playwright's serialized cookies + localStorage. `newContext({ storageState })`
 // accepts exactly this shape, so reusing the method's return type keeps the
@@ -529,11 +531,17 @@ export class BrowserLauncher {
    * behavior instead of breaking the browser.
    */
   private loadStorageState(profile: string): StorageState | undefined {
+    const file = getBrowserStorageStatePath(profile);
     try {
-      const file = getBrowserStorageStatePath(profile);
       if (!fs.existsSync(file)) return undefined;
-      return JSON.parse(fs.readFileSync(file, 'utf8')) as StorageState;
-    } catch {
+      const state = JSON.parse(fs.readFileSync(file, 'utf8')) as StorageState;
+      debugLog('[browser/vault] restored session', { profile, file });
+      return state;
+    } catch (err) {
+      // Corrupt/unreadable vault degrades to a fresh context (pre-vault
+      // behavior). Surface under AFK_DEBUG so an unexpected "logged-out"
+      // unattended session is diagnosable rather than silent.
+      debugLog('[browser/vault] ignoring unreadable vault', { profile, file, err });
       return undefined;
     }
   }
@@ -553,12 +561,22 @@ export class BrowserLauncher {
       const file = getBrowserStorageStatePath(profile);
       if (!fs.existsSync(file)) return;
       const state = await context.storageState();
-      fs.writeFileSync(file, JSON.stringify(state), { mode: 0o600 });
-      // writeFileSync's `mode` only applies on creation; chmod enforces 0600
-      // even when overwriting a file that pre-existed with looser perms.
-      fs.chmodSync(file, 0o600);
-    } catch {
+      // Atomic 0600 write: stage into a uniquely-named sibling temp at 0600,
+      // then POSIX-rename it over the vault. The rename swaps the file in whole,
+      // so freshly-written credentials are never observed truncated or at looser
+      // perms (the old write-then-chmod left exactly that transient window). The
+      // temp lives in the same dir as the dest, so the rename never hits EXDEV.
+      const tmp = path.join(
+        path.dirname(file),
+        `.${path.basename(file)}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`,
+      );
+      fs.writeFileSync(tmp, JSON.stringify(state), { mode: 0o600 });
+      fs.chmodSync(tmp, 0o600); // enforce exact perms regardless of umask
+      fs.renameSync(tmp, file);
+      debugLog('[browser/vault] saved session', { profile, file });
+    } catch (err) {
       // Swallow — vault maintenance is best-effort and must not break close().
+      debugLog('[browser/vault] save failed', { profile, err });
     }
   }
 }

--- a/src/browser/playwright/launcher.ts
+++ b/src/browser/playwright/launcher.ts
@@ -17,6 +17,12 @@ import path from 'node:path';
 import { chromium } from 'playwright';
 import type { Browser, BrowserContext, Dialog, Page, Request, Response } from 'playwright';
 import type { BrowserConfig } from '../types.js';
+import { getBrowserStorageStatePath } from '../../paths.js';
+
+// Playwright's serialized cookies + localStorage. `newContext({ storageState })`
+// accepts exactly this shape, so reusing the method's return type keeps the
+// vault save/restore round-trip type-safe without importing a named symbol.
+type StorageState = Awaited<ReturnType<BrowserContext['storageState']>>;
 
 // ---------------------------------------------------------------------------
 // Version resolution
@@ -185,7 +191,16 @@ export class BrowserLauncher {
 
     const browser = await this.ensureBrowser();
 
-    const context = await browser.newContext(this.contextOptions());
+    // Session vault: restore a human-authorized login from the configured
+    // profile so the agent reuses it across unattended runs. Missing/corrupt
+    // vault → fresh context (loadStorageState returns undefined), preserving
+    // pre-vault behavior. `renderHtml()` builds ephemeral contexts that never
+    // reach this path, so one-shot renders stay vault-free by design.
+    const storageState = this.loadStorageState(this.config.defaultProfile);
+    const context = await browser.newContext({
+      ...this.contextOptions(),
+      ...(storageState !== undefined ? { storageState } : {}),
+    });
 
     const entry: SessionEntry = {
       context,
@@ -439,6 +454,11 @@ export class BrowserLauncher {
     // before we start tearing it down.
     this.sessions.delete(sessionId);
 
+    // Invariant: persist the vault BEFORE teardown — storageState() requires a
+    // live context. Save-back only refreshes an already-established profile
+    // (see saveStorageState); it never implicitly creates one.
+    await this.saveStorageState(this.config.defaultProfile, entry.context);
+
     if (entry.page !== undefined) {
       await entry.page.close().catch(() => {
         // Swallow — page may already be closed if the browser crashed.
@@ -500,5 +520,45 @@ export class BrowserLauncher {
       viewport: { width: 1280, height: 800 },
       userAgent: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 agent-afk/${AFK_VERSION}`,
     };
+  }
+
+  /**
+   * Read a profile's persisted `storageState` for restore-on-open. Returns
+   * undefined when the vault file is absent OR unreadable/corrupt — the caller
+   * then builds a fresh context, so a bad vault file degrades to pre-vault
+   * behavior instead of breaking the browser.
+   */
+  private loadStorageState(profile: string): StorageState | undefined {
+    try {
+      const file = getBrowserStorageStatePath(profile);
+      if (!fs.existsSync(file)) return undefined;
+      return JSON.parse(fs.readFileSync(file, 'utf8')) as StorageState;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Persist a session's `storageState` back to its profile on close so a
+   * human-authorized login stays fresh across runs (e.g. rotated tokens).
+   *
+   * Invariant: only an ALREADY-ESTABLISHED profile (its file exists, created by
+   * `afk browser login`) is refreshed — runtime never implicitly creates a
+   * vault for an unconfigured/ephemeral profile, so default sessions stay
+   * cookie-free. Best-effort: a write failure must never break teardown. The
+   * file is written 0600 (secrets-at-rest: cookies + tokens).
+   */
+  private async saveStorageState(profile: string, context: BrowserContext): Promise<void> {
+    try {
+      const file = getBrowserStorageStatePath(profile);
+      if (!fs.existsSync(file)) return;
+      const state = await context.storageState();
+      fs.writeFileSync(file, JSON.stringify(state), { mode: 0o600 });
+      // writeFileSync's `mode` only applies on creation; chmod enforces 0600
+      // even when overwriting a file that pre-existed with looser perms.
+      fs.chmodSync(file, 0o600);
+    } catch {
+      // Swallow — vault maintenance is best-effort and must not break close().
+    }
   }
 }

--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -385,4 +385,16 @@ export interface BrowserConfig {
   backend: 'playwright';
   /** Optional path to a config JSON used to override anything above. */
   configPath: string | null;
+  /**
+   * Name of the persistent session-vault profile this process reuses. Session
+   * contexts restore `storageState` from (and save it back to)
+   * `~/.afk/state/browser/<defaultProfile>/storageState.json`, so an agent
+   * reuses a human-authorized login across unattended runs. `'default'` when
+   * unset (a fresh, empty profile — identical to pre-vault behavior).
+   *
+   * Resolved from `AFK_BROWSER_DEFAULT_PROFILE`. Operator-controlled, NOT a
+   * per-call model choice: the human runs `afk browser login --profile <name>`
+   * once, then points the agent at that profile via the env var.
+   */
+  defaultProfile: string;
 }

--- a/src/cli/commands/browser.ts
+++ b/src/cli/commands/browser.ts
@@ -32,7 +32,7 @@ import { Command } from 'commander';
 import chalk from 'chalk';
 import { execFileSync } from 'child_process';
 import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { basename, dirname, join } from 'path';
 import { randomBytes } from 'crypto';
 import { createInterface } from 'node:readline';
 import { palette } from '../palette.js';
@@ -291,9 +291,16 @@ export function registerBrowserCommand(program: Command): void {
 
         const state = await context.storageState();
         mkdirSync(getBrowserProfileStateDir(profile), { recursive: true });
-        writeFileSync(statePath, JSON.stringify(state), { mode: 0o600 });
-        // mode only applies on creation; chmod enforces 0600 on overwrite too.
-        chmodSync(statePath, 0o600);
+        // Atomic 0600 write (temp in the same dir → no EXDEV, then POSIX rename):
+        // the vault is never observed truncated or at looser perms, closing the
+        // write-then-chmod window on freshly-written credentials.
+        const tmp = join(
+          dirname(statePath),
+          `.${basename(statePath)}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`,
+        );
+        writeFileSync(tmp, JSON.stringify(state), { mode: 0o600 });
+        chmodSync(tmp, 0o600);
+        renameSync(tmp, statePath);
         await browserInstance.close().catch(() => undefined);
 
         console.log(chalk.green(`✓ Saved session for profile "${profile}"`));

--- a/src/cli/commands/browser.ts
+++ b/src/cli/commands/browser.ts
@@ -1,10 +1,14 @@
 /**
- * `afk browser` command group — connect the agent to the user's REAL Chrome.
+ * `afk browser` command group — give the agent web hands.
  *
  * Subcommands:
  *   afk browser connect      — wire Google's `chrome-devtools-mcp` (--autoConnect)
  *                              into ~/.afk/config/mcp.json + print setup steps
  *   afk browser disconnect   — remove the chrome-devtools server entry
+ *   afk browser login <url>  — open a headed browser, let the human log in, and
+ *                              save the session to a vault profile the agent's
+ *                              native browser tools reuse across unattended runs
+ *   afk browser profiles     — list saved session-vault profiles
  *
  * Why an MCP server and not a native browser provider:
  *   Driving the user's real, logged-in default Chrome profile is impossible via
@@ -27,13 +31,35 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { execFileSync } from 'child_process';
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'fs';
+import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { randomBytes } from 'crypto';
+import { createInterface } from 'node:readline';
 import { palette } from '../palette.js';
 import { handleCommandError } from '../errors/index.js';
 import { getMcpConfigPath, type McpConfigFile } from '../../agent/mcp/config-loader.js';
 import type { McpServerConfig } from '../../agent/mcp/types.js';
+import {
+  assertSafeBrowserProfile,
+  getBrowserProfileStateDir,
+  getBrowserStateRoot,
+  getBrowserStorageStatePath,
+} from '../../paths.js';
+
+/**
+ * Block until the operator presses Enter. Used by `login` to know the human has
+ * finished authenticating before we capture the session. We capture from the
+ * live context (the human must NOT close the window themselves).
+ */
+function waitForEnter(prompt: string): Promise<void> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise<void>((resolve) => {
+    rl.question(prompt, () => {
+      rl.close();
+      resolve();
+    });
+  });
+}
 
 /** MCP server key written into mcpServers. Stable so connect/disconnect agree. */
 export const CHROME_DEVTOOLS_SERVER_NAME = 'chrome-devtools';
@@ -161,7 +187,7 @@ function printSetupGuidance(): void {
 export function registerBrowserCommand(program: Command): void {
   const browser = program
     .command('browser')
-    .description('Connect the agent to your real Chrome browser (via Chrome DevTools MCP)');
+    .description('Give the agent web hands: connect your real Chrome, or save a login it reuses');
 
   browser
     .command('connect')
@@ -217,6 +243,90 @@ export function registerBrowserCommand(program: Command): void {
         delete cfg.mcpServers[CHROME_DEVTOOLS_SERVER_NAME];
         writeMcpConfigFileAtomic(path, cfg);
         console.log(chalk.green(`✓ Removed "${CHROME_DEVTOOLS_SERVER_NAME}" from ${path}`));
+      } catch (err) {
+        handleCommandError(err);
+      }
+    });
+
+  browser
+    .command('login <url>')
+    .description("Open a headed browser, log in manually, and save the session to a vault profile the agent's native browser tools reuse")
+    .option('--profile <name>', 'Vault profile name to save the session under', 'default')
+    .action(async (url: string, opts: { profile?: string }) => {
+      try {
+        const profile = (opts.profile ?? 'default').trim();
+        assertSafeBrowserProfile(profile);
+
+        let parsed: URL;
+        try {
+          parsed = new URL(url);
+        } catch {
+          throw new Error(`Invalid URL: ${url}`);
+        }
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+          throw new Error(`login URL must be http(s), got: ${parsed.protocol}`);
+        }
+
+        const statePath = getBrowserStorageStatePath(profile);
+
+        // Dynamic import: Playwright is heavy; only load it when login actually runs.
+        const { chromium } = await import('playwright');
+        console.log(palette.meta(`Launching a browser for profile "${profile}"…`));
+        const browserInstance = await chromium.launch({ headless: false });
+        // Restore an existing session if present, so re-running login refreshes
+        // the same profile rather than starting from a logged-out state.
+        const context = await browserInstance.newContext(
+          existsSync(statePath) ? { storageState: statePath } : {},
+        );
+        const page = await context.newPage();
+        await page.goto(url, { waitUntil: 'load' }).catch(() => {
+          // Non-fatal — the user can navigate manually if the initial load fails.
+        });
+
+        console.log('');
+        console.log(chalk.bold('Log in to the site in the opened browser window.'));
+        console.log(palette.meta('When fully logged in, return here and press Enter to save the session.'));
+        console.log(palette.meta('(Do NOT close the browser window yourself — this command closes it for you.)'));
+        await waitForEnter('Press Enter to save the session… ');
+
+        const state = await context.storageState();
+        mkdirSync(getBrowserProfileStateDir(profile), { recursive: true });
+        writeFileSync(statePath, JSON.stringify(state), { mode: 0o600 });
+        // mode only applies on creation; chmod enforces 0600 on overwrite too.
+        chmodSync(statePath, 0o600);
+        await browserInstance.close().catch(() => undefined);
+
+        console.log(chalk.green(`✓ Saved session for profile "${profile}"`));
+        console.log(palette.meta(`  Vault: ${statePath} (0600 — treat as a credential)`));
+        console.log(palette.meta('  Point the agent at it:'));
+        console.log(palette.meta(`    export AFK_BROWSER_DEFAULT_PROFILE=${profile}`));
+      } catch (err) {
+        handleCommandError(err);
+      }
+    });
+
+  browser
+    .command('profiles')
+    .description('List saved browser session-vault profiles')
+    .action(() => {
+      try {
+        const root = getBrowserStateRoot();
+        const dirs = existsSync(root)
+          ? readdirSync(root, { withFileTypes: true }).filter((d) => d.isDirectory())
+          : [];
+        if (dirs.length === 0) {
+          console.log(palette.meta('No saved profiles. Create one with `afk browser login <url> --profile <name>`.'));
+          return;
+        }
+        console.log(chalk.bold('Saved browser profiles:'));
+        for (const d of dirs) {
+          const hasState = existsSync(join(root, d.name, 'storageState.json'));
+          const marker = hasState ? chalk.green('●') : palette.meta('○');
+          const note = hasState ? '' : palette.meta(' (no saved session)');
+          console.log(`  ${marker} ${d.name}${note}`);
+        }
+        console.log('');
+        console.log(palette.meta('Use one:  export AFK_BROWSER_DEFAULT_PROFILE=<name>'));
       } catch (err) {
         handleCommandError(err);
       }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1002,6 +1002,21 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     example: '/path/to/browser.json',
     category: 'browser',
   },
+  {
+    name: 'AFK_BROWSER_DEFAULT_PROFILE',
+    description:
+      'Name of the persistent session-vault profile the agent reuses for browser ' +
+      'sessions. The context restores its login from (and saves it back to) ' +
+      '~/.afk/state/browser/<profile>/storageState.json, so a human runs ' +
+      '`afk browser login --profile <name>` once and the agent reuses that ' +
+      'authenticated session across unattended runs. Unset defaults to `default` ' +
+      '(a fresh, empty profile — identical to pre-vault behavior). ' +
+      'Allowed charset: [A-Za-z0-9_-], max 128 chars.',
+    type: 'string',
+    required: false,
+    example: 'work',
+    category: 'browser',
+  },
 
   // ── Filesystem ────────────────────────────────────────────────────────────
   {
@@ -1251,6 +1266,7 @@ export const env = {
   get AFK_BROWSER_DOM_SNAPSHOTS(): string | undefined { return process.env['AFK_BROWSER_DOM_SNAPSHOTS']; },
   get AFK_BROWSER_BACKEND(): string | undefined { return process.env['AFK_BROWSER_BACKEND']; },
   get AFK_BROWSER_CONFIG(): string | undefined { return process.env['AFK_BROWSER_CONFIG']; },
+  get AFK_BROWSER_DEFAULT_PROFILE(): string | undefined { return process.env['AFK_BROWSER_DEFAULT_PROFILE']; },
 
   // Filesystem
   get AFK_WRITE_DENYLIST(): string | undefined { return process.env['AFK_WRITE_DENYLIST']; },

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -32,6 +32,10 @@ import {
   getBgJobDir,
   getBgJobLog,
   getBgJobMeta,
+  assertSafeBrowserProfile,
+  getBrowserStateRoot,
+  getBrowserProfileStateDir,
+  getBrowserStorageStatePath,
 } from './paths.js';
 
 let tmpHome: string;
@@ -261,6 +265,62 @@ describe('assertSafeJobId and bg job path accessors', () => {
       expect(getBgJobDir('bg-abc-1').startsWith(root + '/')).toBe(true);
       expect(getBgJobLog('bg-abc-1').startsWith(root + '/')).toBe(true);
       expect(getBgJobMeta('bg-abc-1').startsWith(root + '/')).toBe(true);
+    });
+  });
+});
+
+describe('assertSafeBrowserProfile and browser vault path accessors', () => {
+  describe('assertSafeBrowserProfile', () => {
+    it('accepts simple profile names', () => {
+      expect(() => assertSafeBrowserProfile('default')).not.toThrow();
+      expect(() => assertSafeBrowserProfile('work')).not.toThrow();
+      expect(() => assertSafeBrowserProfile('WORK_2')).not.toThrow();
+      expect(() => assertSafeBrowserProfile('a-b-c')).not.toThrow();
+      expect(() => assertSafeBrowserProfile('a')).not.toThrow();
+    });
+
+    it.each([
+      ['empty string', ''],
+      ['traversal: ../..', '../..'],
+      ['traversal: ../../etc/passwd', '../../etc/passwd'],
+      ['forward slash', 'work/sub'],
+      ['back slash', 'work\\sub'],
+      ['null byte', 'work\u0000'],
+      ['leading dot', '.hidden'],
+      ['parent ref', '..'],
+      ['just dot', '.'],
+      ['space', 'my work'],
+      ['unicode', 'wörk'],
+      ['absolute path', '/etc/passwd'],
+      ['url-encoded slash', 'work%2Fsub'],
+    ])('rejects %s', (_label, payload) => {
+      expect(() => assertSafeBrowserProfile(payload)).toThrow(/Invalid browser profile/);
+    });
+
+    it('rejects payloads longer than 128 chars', () => {
+      expect(() => assertSafeBrowserProfile('a'.repeat(129))).toThrow(/exceeds 128/);
+    });
+
+    it('accepts exactly 128 chars', () => {
+      expect(() => assertSafeBrowserProfile('a'.repeat(128))).not.toThrow();
+    });
+  });
+
+  describe('browser vault path accessors guard against traversal', () => {
+    it('getBrowserProfileStateDir throws on traversal attempt', () => {
+      expect(() => getBrowserProfileStateDir('../../etc/passwd')).toThrow(/Invalid browser profile/);
+    });
+
+    it('getBrowserStorageStatePath throws on traversal attempt', () => {
+      expect(() => getBrowserStorageStatePath('../../etc')).toThrow(/Invalid browser profile/);
+    });
+
+    it('valid profiles resolve under the browser state root, with the storageState leaf', () => {
+      const root = getBrowserStateRoot();
+      expect(getBrowserProfileStateDir('work').startsWith(root + '/')).toBe(true);
+      const statePath = getBrowserStorageStatePath('work');
+      expect(statePath.startsWith(root + '/')).toBe(true);
+      expect(statePath.endsWith('/work/storageState.json')).toBe(true);
     });
   });
 });

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -492,6 +492,61 @@ export function getBgJobMeta(jobId: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Browser session-vault paths
+//
+// Invariant: a profile name flows into a filesystem path, so it MUST pass
+// assertSafeBrowserProfile() before any join() — same containment rationale as
+// assertSafeJobId. Mirrors the bg-job pattern: a leading guard means every
+// downstream helper is automatically protected without per-call sanitization.
+// ---------------------------------------------------------------------------
+
+const BROWSER_PROFILE_PATTERN = /^[A-Za-z0-9_-]+$/;
+const BROWSER_PROFILE_MAX_LEN = 128;
+
+export function assertSafeBrowserProfile(profile: string): void {
+  if (typeof profile !== 'string' || profile.length === 0) {
+    throw new Error('Invalid browser profile: must be a non-empty string');
+  }
+  if (profile.length > BROWSER_PROFILE_MAX_LEN) {
+    throw new Error(`Invalid browser profile: exceeds ${BROWSER_PROFILE_MAX_LEN} chars`);
+  }
+  if (!BROWSER_PROFILE_PATTERN.test(profile)) {
+    throw new Error(
+      `Invalid browser profile: ${JSON.stringify(profile)} contains characters outside [A-Za-z0-9_-]`,
+    );
+  }
+}
+
+/**
+ * Root directory for persistent browser session-vault profiles.
+ * Each profile gets its own subdirectory: `~/.afk/state/browser/<profile>/`.
+ */
+export function getBrowserStateRoot(): string {
+  return join(getAfkStateDir(), 'browser');
+}
+
+/**
+ * Directory holding a specific browser profile's persisted state.
+ * @throws if `profile` fails {@link assertSafeBrowserProfile}.
+ */
+export function getBrowserProfileStateDir(profile: string): string {
+  assertSafeBrowserProfile(profile);
+  return join(getBrowserStateRoot(), profile);
+}
+
+/**
+ * Path to a profile's Playwright `storageState` (cookies + localStorage).
+ *
+ * Invariant: this file holds live session credentials — callers MUST write it
+ * with `0600` perms and treat it as secrets-at-rest.
+ *
+ * @throws if `profile` fails {@link assertSafeBrowserProfile}.
+ */
+export function getBrowserStorageStatePath(profile: string): string {
+  return join(getBrowserProfileStateDir(profile), 'storageState.json');
+}
+
+// ---------------------------------------------------------------------------
 // Session event-ledger paths
 // ---------------------------------------------------------------------------
 

--- a/src/web/retryFetch.test.ts
+++ b/src/web/retryFetch.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for retryFetch — the web-layer self-unsticking wrapper.
+ *
+ * Strategy: mock fetchFn and inject a no-op `sleep` so retries don't wait on
+ * real timers. Asserts call counts (retry behavior), terminal statuses, and the
+ * abort-is-terminal invariant.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { retryFetch } from './retryFetch.js';
+import type { FetchFn } from './types.js';
+
+const noSleep = (): Promise<void> => Promise.resolve();
+
+function res(status: number, body = 'ok', headers?: Record<string, string>): Response {
+  return new Response(body, { status, ...(headers ? { headers } : {}) });
+}
+
+describe('retryFetch', () => {
+  it('returns immediately on success (one call, no retry)', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(res(200));
+    const r = await retryFetch(fetchFn as unknown as FetchFn, 'https://x', {}, { sleep: noSleep });
+    expect(r.status).toBe(200);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a non-retryable status (404)', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(res(404));
+    const r = await retryFetch(fetchFn as unknown as FetchFn, 'https://x', {}, { sleep: noSleep });
+    expect(r.status).toBe(404);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a retryable status (503) then succeeds', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(res(503))
+      .mockResolvedValueOnce(res(200, 'good'));
+    const r = await retryFetch(fetchFn as unknown as FetchFn, 'https://x', {}, { sleep: noSleep });
+    expect(r.status).toBe(200);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a transient network error then succeeds', async () => {
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce(res(200));
+    const r = await retryFetch(fetchFn as unknown as FetchFn, 'https://x', {}, { sleep: noSleep });
+    expect(r.status).toBe(200);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns the last non-ok response after exhausting retries on a retryable status', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(res(429));
+    const r = await retryFetch(fetchFn as unknown as FetchFn, 'https://x', {}, { retries: 2, sleep: noSleep });
+    expect(r.status).toBe(429);
+    expect(fetchFn).toHaveBeenCalledTimes(3); // 1 initial + 2 retries
+  });
+
+  it('throws the last error after exhausting retries on network failure', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('down'));
+    await expect(
+      retryFetch(fetchFn as unknown as FetchFn, 'https://x', {}, { retries: 2, sleep: noSleep }),
+    ).rejects.toThrow('down');
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('defaults to 3 retries (4 total attempts)', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(res(502));
+    await retryFetch(fetchFn as unknown as FetchFn, 'https://x', {}, { sleep: noSleep });
+    expect(fetchFn).toHaveBeenCalledTimes(4);
+  });
+
+  it('is terminal on a pre-aborted signal (never calls fetch)', async () => {
+    const ac = new AbortController();
+    ac.abort(new Error('canceled'));
+    const fetchFn = vi.fn().mockResolvedValue(res(200));
+    await expect(
+      retryFetch(fetchFn as unknown as FetchFn, 'https://x', { signal: ac.signal }, { sleep: noSleep }),
+    ).rejects.toThrow();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('does not retry once the signal aborts mid-flight', async () => {
+    const ac = new AbortController();
+    const fetchFn = vi.fn().mockImplementation(() => {
+      ac.abort(new Error('canceled'));
+      return Promise.reject(new Error('aborted fetch'));
+    });
+    await expect(
+      retryFetch(fetchFn as unknown as FetchFn, 'https://x', { signal: ac.signal }, { sleep: noSleep }),
+    ).rejects.toThrow();
+    expect(fetchFn).toHaveBeenCalledTimes(1); // aborted → not retried
+  });
+
+  it('honors a numeric Retry-After header for the backoff wait', async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(res(503, '', { 'retry-after': '2' }))
+      .mockResolvedValueOnce(res(200));
+    await retryFetch(fetchFn as unknown as FetchFn, 'https://x', {}, { sleep });
+    expect(sleep).toHaveBeenCalledWith(2000, undefined);
+  });
+});

--- a/src/web/retryFetch.test.ts
+++ b/src/web/retryFetch.test.ts
@@ -31,6 +31,13 @@ describe('retryFetch', () => {
     expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 
+  it('does not retry a 500 (not in the retryable {429,502,503,504} set)', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(res(500));
+    const r = await retryFetch(fetchFn as unknown as FetchFn, 'https://x', {}, { sleep: noSleep });
+    expect(r.status).toBe(500);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
   it('retries a retryable status (503) then succeeds', async () => {
     const fetchFn = vi
       .fn()

--- a/src/web/retryFetch.ts
+++ b/src/web/retryFetch.ts
@@ -1,0 +1,110 @@
+/**
+ * Retrying fetch wrapper for the web layer (self-unsticking, autonomy MVP).
+ *
+ * Web fetches are idempotent GETs, so retrying transient failures — network
+ * errors and HTTP 429/502/503/504 — is safe and turns a flaky upstream into a
+ * recoverable one. That is the difference between an unattended run dying on a
+ * single blip and one that survives it.
+ *
+ * Invariant: abort is terminal — a request whose signal has fired is NEVER
+ * retried; the abort error propagates immediately. Honors a numeric
+ * `Retry-After` header on a retryable response when present, otherwise uses
+ * exponential backoff with full jitter, capped.
+ *
+ * Scope: deliberately NOT used by the browser ACTION layer, where actions are
+ * state-changing (a retried click/fill could double-submit). Browser-action
+ * retry needs idempotency-aware design and is tracked separately.
+ *
+ * @module web/retryFetch
+ */
+
+import type { FetchFn } from './types.js';
+
+/** HTTP statuses worth retrying on an idempotent GET. */
+const RETRYABLE_STATUS = new Set<number>([429, 502, 503, 504]);
+
+export interface RetryFetchOptions {
+  /** Max ADDITIONAL attempts after the first (default 3 → up to 4 calls). */
+  retries?: number;
+  /** Base backoff in ms; grows exponentially per attempt (default 500). */
+  baseDelayMs?: number;
+  /** Cap on any single backoff/Retry-After wait in ms (default 10_000). */
+  maxDelayMs?: number;
+  /** Injectable sleep so tests don't wait on real timers. Rejects on abort. */
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+}
+
+function defaultSleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error('aborted'));
+      return;
+    }
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(signal?.reason ?? new Error('aborted'));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/** Exponential backoff with full jitter, capped at `max`. */
+function backoffMs(attempt: number, base: number, max: number): number {
+  const ceiling = Math.min(base * 2 ** attempt, max);
+  return Math.round(Math.random() * ceiling);
+}
+
+/** Parse a numeric `Retry-After` (delta-seconds) into ms, capped. Ignores HTTP-date form. */
+function retryAfterMs(res: Response, maxDelayMs: number): number | null {
+  const raw = res.headers.get('retry-after');
+  if (raw === null) return null;
+  const secs = Number(raw.trim());
+  if (!Number.isFinite(secs) || secs < 0) return null;
+  return Math.min(secs * 1000, maxDelayMs);
+}
+
+/**
+ * Drop-in replacement for `fetchFn(url, init)` that retries transient failures.
+ * Reads `init.signal` for abort (terminal). Returns the final Response, which
+ * MAY be non-ok after exhausting retries — the caller decides what to do with a
+ * persistent error status (escalate, surface, etc.), exactly as before.
+ */
+export async function retryFetch(
+  fetchFn: FetchFn,
+  url: string,
+  init: RequestInit = {},
+  opts: RetryFetchOptions = {},
+): Promise<Response> {
+  const retries = opts.retries ?? 3;
+  const baseDelayMs = opts.baseDelayMs ?? 500;
+  const maxDelayMs = opts.maxDelayMs ?? 10_000;
+  const sleep = opts.sleep ?? defaultSleep;
+  const signal = init.signal ?? undefined;
+
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    if (signal?.aborted) throw signal.reason ?? new Error('aborted');
+    try {
+      const res = await fetchFn(url, init);
+      // Success, non-retryable status, or out of attempts → return as-is.
+      if (!RETRYABLE_STATUS.has(res.status) || attempt === retries) {
+        return res;
+      }
+      // Retryable status with attempts left: free the connection, wait, retry.
+      const wait = retryAfterMs(res, maxDelayMs) ?? backoffMs(attempt, baseDelayMs, maxDelayMs);
+      await res.body?.cancel().catch(() => undefined);
+      await sleep(wait, signal);
+    } catch (err) {
+      if (signal?.aborted) throw err; // abort is terminal — never retried
+      lastErr = err;
+      if (attempt === retries) throw err; // exhausted → surface the last error
+      await sleep(backoffMs(attempt, baseDelayMs, maxDelayMs), signal);
+    }
+  }
+  // Loop always returns or throws; this satisfies the type checker.
+  throw lastErr ?? new Error('retryFetch: exhausted without a result');
+}

--- a/src/web/retryFetch.ts
+++ b/src/web/retryFetch.ts
@@ -19,6 +19,7 @@
  */
 
 import type { FetchFn } from './types.js';
+import { debugLog } from '../utils/debug.js';
 
 /** HTTP statuses worth retrying on an idempotent GET. */
 const RETRYABLE_STATUS = new Set<number>([429, 502, 503, 504]);
@@ -96,13 +97,16 @@ export async function retryFetch(
       }
       // Retryable status with attempts left: free the connection, wait, retry.
       const wait = retryAfterMs(res, maxDelayMs) ?? backoffMs(attempt, baseDelayMs, maxDelayMs);
+      debugLog('[web/retryFetch] retrying', { url, attempt, status: res.status, waitMs: wait });
       await res.body?.cancel().catch(() => undefined);
       await sleep(wait, signal);
     } catch (err) {
       if (signal?.aborted) throw err; // abort is terminal — never retried
       lastErr = err;
       if (attempt === retries) throw err; // exhausted → surface the last error
-      await sleep(backoffMs(attempt, baseDelayMs, maxDelayMs), signal);
+      const waitMs = backoffMs(attempt, baseDelayMs, maxDelayMs);
+      debugLog('[web/retryFetch] retrying after error', { url, attempt, waitMs });
+      await sleep(waitMs, signal);
     }
   }
   // Loop always returns or throws; this satisfies the type checker.

--- a/src/web/scrape.ts
+++ b/src/web/scrape.ts
@@ -22,6 +22,7 @@
 
 import { extractReadableMarkdown, THIN_CONTENT_CHARS } from './extract.js';
 import type { ExtractedContent, FetchFn, RenderFn, RenderedPage } from './types.js';
+import { retryFetch } from './retryFetch.js';
 import { debugLog } from '../utils/debug.js';
 
 /** Content-types we treat as HTML (run the extraction pipeline). */
@@ -106,7 +107,9 @@ export async function scrapeToMarkdown(url: string, opts: ScrapeOptions): Promis
   let fetchErr: unknown = null;
 
   try {
-    const res = await fetchFn(url, {
+    // retryFetch survives transient 429/5xx + network blips (idempotent GET)
+    // before we fall through to render escalation.
+    const res = await retryFetch(fetchFn, url, {
       headers: FETCH_HEADERS,
       redirect: 'follow',
       signal: opts.signal,


### PR DESCRIPTION
## Summary

Brings the browser/web layer up to the `autonomous`-mode posture the rest of the harness already enforces — three independent autonomy unlocks, each committed separately:

- **Session vault** (`c860799`) — an agent reuses a human-authorized login across unattended runs. `afk browser login <url> --profile <name>` (headed; saves `storageState` `0600`) + `afk browser profiles`; the launcher restores on open and saves back **only** to an already-established profile. Selected by `AFK_BROWSER_DEFAULT_PROFILE`. Profile names are path-traversal-guarded.
- **Park-and-notify** (`792b6c9`) — an unattended session that hits an OAuth / captcha / permission prompt now pushes a Telegram notification and **continues**, instead of declining *silently* (the worst autonomy failure). Fire-and-forget; no-ops when Telegram is unconfigured.
- **Retrying fetch** (`7548550`) — `web_scrape` survives transient 429/5xx + network blips (idempotent GET, exponential backoff + jitter, honors `Retry-After`, abort-terminal) instead of dying on the first hiccup.

Design notes: the profile is an operator-level config concern (not a per-call model choice); an unconfigured `default` profile stays **fully ephemeral** (zero behavior change for non-adopters); `renderHtml()` ephemeral contexts bypass the vault by design.

## Test results

- `pnpm lint` (strict `tsc --noEmit`): **pass** (clean) after every commit.
- Touched-area suites (`vitest run`): **298 passed / 0 failed** — `src/paths`, `src/config/env`, `src/browser/**`, `src/cli/commands/browser`, `src/agent/elicitation-router`, `src/web/retryFetch`, `src/web/scrape`, `src/agent/tools/handlers/web-scrape` (53 of these are new).

> ⚠️ **The full `pnpm test` suite could not be run in the authoring environment.** `better-sqlite3@12.9.0` fails to load its native binding under Node v24.11.0 (looks for an absent `node-v137` ABI build; `pnpm rebuild better-sqlite3` did not resolve it), which fails all `tests/agent/memory/**` (SQLite-backed) and crashes full-CLI bootstrap. This is **pre-existing and unrelated to this diff** — no SQLite or CLI-bootstrap code is touched, and lint is clean. **Please let CI / a healthy `better-sqlite3` environment run the full suite before merge.**

## Verification

An adversarial verifier independently re-derived the load-bearing claims **from the diff alone** — all **CONFIRM**, overall verdict **SHIP-OK**:

- **Vault**: restore-on-open / save-only-if-established / `0600` / traversal-guarded — confirmed (`launcher.ts`, `paths.ts`).
- **Park-and-notify**: notify→DECLINE only on the genuine no-handler path; skips the handler-installed and pre-aborted paths — confirmed (`elicitation-router.ts`).
- **retryFetch**: idempotent-GET retry, abort-terminal, wired into `web_scrape` (markdown + raw), **not** applied to the browser action layer — confirmed (`retryFetch.ts`, `scrape.ts`, `web-scrape.ts`).
- No secrets / scratch files; no broken or dangling edits.

## Out of scope / deferred

- **Browser-action retry + per-host pacing** — *deliberately deferred*: auto-retrying state-changing `browser_act` (click/fill) risks double-submits and needs idempotency-aware design. The safe, high-value half (idempotent web GETs) ships here.
- **Standing per-domain action policy + URL→memory provenance** — out of MVP scope.
