### PR TITLE
feat(plugins): inject host runtime API into plugin entrypoints (fixes singleton trap)

### DIFF
--- a/src/agent/plugins/load-entrypoints.test.ts
+++ b/src/agent/plugins/load-entrypoints.test.ts
@@ -12,6 +12,8 @@ import { tmpdir } from 'os';
 import { pathToFileURL } from 'url';
 import { loadPluginEntrypoints, _resetLoadedEntrypoints } from './load-entrypoints.js';
 import type { SdkPluginConfig } from '../types/sdk-types.js';
+import { registerSkill, getSkill, listSkills, _resetRegistry } from '../../skills/index.js';
+import { loadSkillPrompts } from '../../skills/_lib/prompt-loader.js';
 
 let dir: string;
 
@@ -94,5 +96,53 @@ describe('loadPluginEntrypoints', () => {
       },
     });
     expect(seen).toEqual([pathToFileURL(abs).href]);
+  });
+
+  it('injects the host API into a default-export entrypoint so a plugin registers into the HOST registry (round-trip)', async () => {
+    // The load-bearing proof: a plugin's default export, invoked with the host
+    // PluginApi, must reach the SAME singleton registry the host reads via
+    // getSkill/listSkills. Without injection, a plugin importing its own copy of
+    // the package would write to a different registry instance — a silent no-op.
+    _resetRegistry();
+    const skillName = `__afkRtProof_${Math.random().toString(36).slice(2)}`;
+    writeFileSync(
+      join(dir, 'entry.mjs'),
+      `export default (api) => {\n` +
+        `  api.registerSkill({\n` +
+        `    name: ${JSON.stringify(skillName)},\n` +
+        `    description: 'round-trip proof',\n` +
+        `    handler: async () => ({}),\n` +
+        `  });\n` +
+        `};\n`,
+    );
+    const plugins: SdkPluginConfig[] = [{ type: 'local', path: dir, main: 'entry.mjs' }];
+
+    await loadPluginEntrypoints(plugins, {
+      pluginApi: { registerSkill, listSkills, getSkill, loadSkillPrompts },
+    });
+
+    try {
+      expect(listSkills()).toContain(skillName);
+      expect(getSkill(skillName).description).toBe('round-trip proof');
+    } finally {
+      _resetRegistry();
+    }
+  });
+
+  it('still runs top-level side-effects when an entrypoint has no default export, even with pluginApi supplied (back-compat)', async () => {
+    const key = `__afkSideEffectProof_${Math.random().toString(36).slice(2)}`;
+    writeFileSync(join(dir, 'entry.mjs'), `globalThis[${JSON.stringify(key)}] = true;\n`);
+    const plugins: SdkPluginConfig[] = [{ type: 'local', path: dir, main: 'entry.mjs' }];
+    const store = globalThis as unknown as Record<string, unknown>;
+    try {
+      await expect(
+        loadPluginEntrypoints(plugins, {
+          pluginApi: { registerSkill, listSkills, getSkill, loadSkillPrompts },
+        }),
+      ).resolves.toBeUndefined();
+      expect(store[key]).toBe(true);
+    } finally {
+      delete store[key];
+    }
   });
 });

--- a/src/agent/plugins/load-entrypoints.ts
+++ b/src/agent/plugins/load-entrypoints.ts
@@ -18,6 +18,29 @@ import { pathToFileURL } from 'url';
 import type { SdkPluginConfig } from '../types/sdk-types.js';
 
 /**
+ * Host runtime API injected into a plugin entrypoint's default-export function.
+ *
+ * Invariant: a code-backed plugin MUST register through this object, not by
+ * importing `agent-afk` itself. The skill registry is a module-level singleton
+ * (`src/skills/index.ts`), so a plugin that imports its OWN copy of `agent-afk`
+ * (its `node_modules`, a bundle, or a version-skewed install — the default for a
+ * marketplace-cloned plugin with no shared `node_modules`) would call a
+ * `registerSkill` backed by a DIFFERENT registry than the host reads → the skill
+ * silently never appears. Receiving these functions from the host guarantees the
+ * same module instance regardless of how the plugin was installed.
+ *
+ * Stateless helpers (`env`, the `paths` getters, `describeFailure`) are safe for
+ * a plugin to import directly — they hold no singleton state — and are
+ * intentionally omitted to keep this surface minimal. The type is derived via
+ * `typeof import(...)` so the injected signatures cannot drift from the source.
+ */
+export type PluginApi = Pick<
+  typeof import('../../skills/index.js'),
+  'registerSkill' | 'listSkills' | 'getSkill'
+> &
+  Pick<typeof import('../../skills/_lib/prompt-loader.js'), 'loadSkillPrompts'>;
+
+/**
  * Resolved-entrypoint paths already imported in this process. Dynamic `import()`
  * caches modules itself, but tracking here lets us skip redundant awaits when
  * the scanner is consulted multiple times per turn and keeps load deterministic.
@@ -34,6 +57,15 @@ export type LoadEntrypointsOptions = {
   importer?: (specifier: string) => Promise<unknown>;
   /** Invoked (non-fatally) when a plugin entrypoint fails to import. */
   onError?: (plugin: SdkPluginConfig, error: unknown) => void;
+  /**
+   * Host API injected into a plugin entrypoint's default-export function. When a
+   * plugin's `main` module exports a callable `default`, it is invoked as
+   * `await mod.default(pluginApi)` AFTER import — the sanctioned way for a
+   * code-backed plugin to register skills against the host's singleton registry
+   * (see {@link PluginApi}). Modules with no default-export function still run
+   * their top-level side-effects at import time (backward-compatible).
+   */
+  pluginApi?: PluginApi;
 };
 
 /**
@@ -56,7 +88,15 @@ export async function loadPluginEntrypoints(
     // double-import, and a failed entrypoint must not be retried this process.
     loadedEntrypoints.add(absPath);
     try {
-      await importer(pathToFileURL(absPath).href);
+      // Importing runs the module's top-level side-effects (back-compat). If it
+      // ALSO exports a callable default, invoke it with the host API so the
+      // plugin registers against the host's singleton registry rather than a
+      // bare-specifier-imported copy of its own (see {@link PluginApi}).
+      const mod = await importer(pathToFileURL(absPath).href);
+      const entry = (mod as { default?: unknown } | undefined)?.default;
+      if (typeof entry === 'function') {
+        await (entry as (api: PluginApi | undefined) => unknown)(opts.pluginApi);
+      }
     } catch (error) {
       opts.onError?.(plugin, error);
     }

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -14,7 +14,8 @@
 // Barrel import triggers self-registration side-effects for built-in skills.
 import '../../skills/all.js';
 
-import { listSkills, getSkill, isSkillVisible } from '../../skills/index.js';
+import { listSkills, getSkill, registerSkill, isSkillVisible } from '../../skills/index.js';
+import { loadSkillPrompts } from '../../skills/_lib/prompt-loader.js';
 import { scanSkillsFromDir } from '../../skills/user-skills.js';
 import { scanLocalPlugins } from '../plugins-scanner.js';
 import { loadPluginEntrypoints } from '../plugins/load-entrypoints.js';
@@ -263,5 +264,11 @@ export function scanAllPluginRoots(): SdkPluginConfig[] {
  * so calling it again in a child is a safe no-op.
  */
 export async function ensurePluginEntrypointsLoaded(): Promise<void> {
-  await loadPluginEntrypoints(scanAllPluginRoots());
+  // Inject the host's registry functions (+ loadSkillPrompts) so a code-backed
+  // plugin's default-export entrypoint registers against THIS process's
+  // singleton registry — not a bare-specifier-imported copy of its own, which
+  // would silently write to a registry the host never reads. See PluginApi.
+  await loadPluginEntrypoints(scanAllPluginRoots(), {
+    pluginApi: { registerSkill, listSkills, getSkill, loadSkillPrompts },
+  });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,11 @@ export {
 } from './skills/index.js';
 export type { SkillExecutionContext, SkillMetadata } from './skills/index.js';
 export { loadSkillPrompts } from './skills/_lib/prompt-loader.js';
+// PluginApi: the host runtime API injected into a code-backed plugin's
+// default-export entrypoint. A plugin types its entrypoint as
+// `export default (api: PluginApi) => { … }` and registers through `api` so its
+// skills land in the host's singleton registry regardless of install layout.
+export type { PluginApi } from './agent/plugins/load-entrypoints.js';
 
 export {
   deriveSessionFacet,


### PR DESCRIPTION
## What

Adds **host-API injection** to the plugin `main` entrypoint mechanism so a code-backed, out-of-tree plugin can register skills that actually reach the host's registry.

If a plugin's `main` module exports a **callable default**, the host now invokes it after import:

```ts
// plugin main (afk-moat/dist/index.js)
import type { PluginApi } from 'agent-afk';
export default ({ registerSkill, loadSkillPrompts }: PluginApi) => {
  registerSkill({ name: 'forge', /* … */ });
};
```

The host passes a `PluginApi` assembled from **its own** modules (`{ registerSkill, listSkills, getSkill, loadSkillPrompts }`). Modules with no default export still run their top-level side-effects at import — fully backward-compatible.

## Why (the bug this fixes)

#298 loads a plugin `main` purely for side-effects, which forces a code-backed plugin to `import { registerSkill } from 'agent-afk'` itself. But the skill registry is a **module-level singleton** (`src/skills/index.ts`). A plugin that resolves its **own** copy of `agent-afk` — its `node_modules`, a bundle, or a version-skewed/**marketplace-cloned install with no shared `node_modules`** — calls a `registerSkill` backed by a *different* registry than the host reads. The skill silently never appears. No error.

This is the blocker for distributing the moat (forge/harvest) as an out-of-tree code-backed plugin: marketplace plugins are git-cloned with no `node_modules`, so bare-specifier resolution can't reach the host instance. Injecting the API from the host guarantees the same module instance regardless of install layout.

## Design notes

- `PluginApi` is typed via `typeof import(...)` so the injected signatures **cannot drift** from source; exported from `src/index.ts` (verified it survives into the shipped `dist/index.d.ts`).
- Assembled in `skill-bridge`'s `ensurePluginEntrypointsLoaded` (already in the host module graph) and passed down through `loadPluginEntrypoints` — avoids an import cycle into `load-entrypoints`.
- Stateless helpers (`env`, paths getters, `describeFailure`) are intentionally **omitted** — they hold no singleton state, so a plugin can import them directly; only the registry *must* be shared.

## Tests

- **Round-trip proof** (the coverage that was missing): a plugin's default export calls the injected `registerSkill`, and the host's `getSkill`/`listSkills` sees it — exercised against the **real** registry, not a spy.
- **Back-compat**: a no-default side-effect-only plugin still runs at import even when `pluginApi` is supplied.

## Verification

- `tsc --noEmit` clean
- `src/agent/plugins/` + `src/agent/tools/` + `chat.mcp` sweep: **1552 pass / 2 skip**, incl. the 2 new tests
- `PluginApi` present in regenerated `dist/index.d.ts`
