### PR TITLE
fix(repl): honor trailing-backslash newline escape on the live TTY path

### DIFF
--- a/src/cli/input/enter-decision.test.ts
+++ b/src/cli/input/enter-decision.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { isSoftNewlineEnter, endsWithBackslashContinuation } from './enter-decision.js';
+
+describe('isSoftNewlineEnter', () => {
+  it('is true for shift+Enter (key.shift)', () => {
+    expect(isSoftNewlineEnter({ shift: true }, undefined)).toBe(true);
+  });
+
+  it('is true for alt/option+Enter (key.meta)', () => {
+    expect(isSoftNewlineEnter({ meta: true }, undefined)).toBe(true);
+  });
+
+  it('is true for the kitty shift+Enter sequence \\x1b[13;2u even without key.shift', () => {
+    expect(isSoftNewlineEnter(undefined, '\x1b[13;2u')).toBe(true);
+    expect(isSoftNewlineEnter({}, '\x1b[13;2u')).toBe(true);
+  });
+
+  it('is false for plain Enter (no modifiers, no special sequence)', () => {
+    expect(isSoftNewlineEnter({}, undefined)).toBe(false);
+    expect(isSoftNewlineEnter({ shift: false, meta: false }, '\r')).toBe(false);
+  });
+
+  it('is false for an undefined key with no kitty sequence', () => {
+    expect(isSoftNewlineEnter(undefined, undefined)).toBe(false);
+    expect(isSoftNewlineEnter(undefined, '\r')).toBe(false);
+  });
+});
+
+describe('endsWithBackslashContinuation', () => {
+  it('is true when the buffer ends in a backslash', () => {
+    expect(endsWithBackslashContinuation('foo\\')).toBe(true);
+    expect(endsWithBackslashContinuation('\\')).toBe(true);
+  });
+
+  it('is true when the buffer ends in two backslashes (still ends with a backslash)', () => {
+    // Matches the original reader.ts semantics: a simple trailing-char test,
+    // not an even/odd escape count.
+    expect(endsWithBackslashContinuation('foo\\\\')).toBe(true);
+  });
+
+  it('is false when the buffer does not end in a backslash', () => {
+    expect(endsWithBackslashContinuation('foo')).toBe(false);
+    expect(endsWithBackslashContinuation('a\\b')).toBe(false);
+  });
+
+  it('is false for an empty buffer', () => {
+    expect(endsWithBackslashContinuation('')).toBe(false);
+  });
+});

--- a/src/cli/input/enter-decision.ts
+++ b/src/cli/input/enter-decision.ts
@@ -1,0 +1,54 @@
+/**
+ * Single source of truth for the Enter-key decision shared by both input
+ * surfaces — the live `TerminalCompositor` (`handleEnter` in
+ * terminal-compositor.input-dispatch.ts) and the legacy / non-TTY
+ * `readWithAutocompleteTty` reader (`handleKeypress` in input/reader.ts).
+ *
+ * History: the two surfaces previously carried byte-cloned copies of this
+ * logic that drifted. The trailing-backslash continuation lived only in the
+ * reader, so `\`+Enter silently submitted the raw backslash in the live REPL
+ * instead of inserting a newline. Extracting the decision into pure, testable
+ * functions makes that class of drift structurally impossible.
+ *
+ * These are pure predicates — no I/O, no state mutation. Each surface keeps its
+ * own side-effecting follow-through (applyEdit vs repaint, submit vs queue,
+ * dropdown handling), but the BRANCH CONDITIONS now resolve identically.
+ */
+
+/** Minimal structural shape of a keypress payload these predicates read. Both
+ *  surfaces' richer `KeyInfo` types satisfy it (only shift/meta are consulted). */
+export interface EnterKeyModifiers {
+  shift?: boolean;
+  meta?: boolean;
+}
+
+/**
+ * True when an Enter keystroke is an explicit soft-newline request rather than
+ * a submit:
+ *   - shift+Enter — most terminals report `key.shift` on Return.
+ *   - `\x1b[13;2u` — the kitty keyboard-protocol fallback for shift+Enter in
+ *     terminals that don't set `key.shift`.
+ *   - alt/option+Enter — reported as `key.meta`.
+ *
+ * Invariant: the `\x1b[13;2u` sequence is an externally-governed terminal
+ * protocol constant (kitty), not an arbitrary value — keep it byte-exact.
+ * Terminals that report none of these fall back to the trailing-backslash
+ * escape ({@link endsWithBackslashContinuation}).
+ */
+export function isSoftNewlineEnter(
+  key: EnterKeyModifiers | undefined,
+  sequence: string | undefined,
+): boolean {
+  const isShiftEnter = key?.shift === true || sequence === '\x1b[13;2u';
+  const isAltEnter = key?.meta === true;
+  return isShiftEnter || isAltEnter;
+}
+
+/**
+ * True when the buffer ends in a trailing backslash — the documented escape
+ * hatch that converts Enter into a real newline for terminals that don't report
+ * shift-state on Return. The caller replaces the trailing `\` with `\n`.
+ */
+export function endsWithBackslashContinuation(buffer: string): boolean {
+  return buffer.endsWith('\\');
+}

--- a/src/cli/input/printable.test.ts
+++ b/src/cli/input/printable.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { isPrintableGrapheme } from './printable.js';
+
+describe('isPrintableGrapheme', () => {
+  it('accepts a single ASCII printable character', () => {
+    expect(isPrintableGrapheme('a')).toBe(true);
+    expect(isPrintableGrapheme('Z')).toBe(true);
+    expect(isPrintableGrapheme(' ')).toBe(true); // space is the low bound (>= ' ')
+  });
+
+  it('accepts a multi-UTF-16-unit emoji as one grapheme (the bug the shared helper fixes)', () => {
+    // '😀' is a surrogate pair (length 2). The old `length === 1` test dropped
+    // it; isPrintableGrapheme admits it as a single grapheme cluster.
+    expect('😀'.length).toBe(2);
+    expect(isPrintableGrapheme('😀')).toBe(true);
+  });
+
+  it('rejects control characters', () => {
+    expect(isPrintableGrapheme('\x1b')).toBe(false); // ESC
+    expect(isPrintableGrapheme('\x00')).toBe(false); // NUL
+    expect(isPrintableGrapheme('\t')).toBe(false); // tab (< ' ')
+    expect(isPrintableGrapheme('\n')).toBe(false); // newline (< ' ')
+  });
+
+  it('rejects multi-character fragments', () => {
+    expect(isPrintableGrapheme('ab')).toBe(false);
+    expect(isPrintableGrapheme('\x1b[A')).toBe(false); // an escape sequence
+  });
+
+  it('rejects the empty string', () => {
+    expect(isPrintableGrapheme('')).toBe(false);
+  });
+});

--- a/src/cli/input/printable.ts
+++ b/src/cli/input/printable.ts
@@ -1,0 +1,19 @@
+import { nextGraphemeIndex } from '../display.js';
+
+/**
+ * True when `s` is a single printable grapheme cluster (one visual character):
+ * not a control char (< ' '), and exactly one grapheme — so multi-UTF-16-unit
+ * emoji (surrogate pairs, variation selectors, skin-tone modifiers) count as
+ * one printable character, while escape sequences and multi-char fragments are
+ * rejected. Replaces the old `s.length === 1` UTF-16 code-unit test that
+ * silently dropped all astral / composed emoji.
+ *
+ * Single source of truth shared by both input surfaces — the live
+ * TerminalCompositor (`handlePrintable`) and the legacy/non-TTY
+ * `readWithAutocompleteTty` reader — so the printable-char admission rule
+ * cannot drift between them (the reader previously carried the stale
+ * `length === 1` test and dropped emoji on the fallback path).
+ */
+export function isPrintableGrapheme(s: string): boolean {
+  return s >= ' ' && nextGraphemeIndex(s, 0) === s.length;
+}

--- a/src/cli/input/reader.ts
+++ b/src/cli/input/reader.ts
@@ -19,6 +19,8 @@ import stringWidth from 'string-width';
 import { list as listSlashCommands, aliasEntries } from '../slash/registry.js';
 import { stripAnsi } from '../display.js';
 import { acquireStdinClaim } from './stdin-claim.js';
+import { isPrintableGrapheme } from './printable.js';
+import { isSoftNewlineEnter, endsWithBackslashContinuation } from './enter-decision.js';
 import { InputCore, type InputCoreState } from '../input-core.js';
 import { colorizeInputBuffer, type SlashRegistryView } from '../input-highlight.js';
 import { describeAttachmentSummary, renderStatusLine, type ImageAttachment } from './attachments.js';
@@ -727,10 +729,7 @@ export async function readWithAutocompleteTty(
           // some tmux configurations, PuTTY, older macOS Terminal.app profiles)
           // will not insert a newline — plain Enter will submit as usual. Users
           // can always use trailing `\` as an escape hatch (preserved below).
-          const isShiftEnter =
-            key?.shift === true || sequence === '\x1b[13;2u';
-          const isAltEnter = key?.meta === true;
-          if (isShiftEnter || isAltEnter) {
+          if (isSoftNewlineEnter(key, sequence)) {
             input = InputCore.insert(input, '\n');
             opts.history?.resetRecall();
             repaint();
@@ -767,7 +766,7 @@ export async function readWithAutocompleteTty(
             if (kind === 'slash' && applied) {
               onSubmit();
             }
-          } else if (input.buffer.endsWith('\\')) {
+          } else if (endsWithBackslashContinuation(input.buffer)) {
             // Trailing backslash escapes Enter → convert to a real newline.
             input = InputCore.replaceRange(
               input,
@@ -818,15 +817,15 @@ export async function readWithAutocompleteTty(
           return;
         }
 
-        // Printable char: prefer `char` (arg 1), fall back to key.sequence
+        // Printable char: prefer `char` (arg 1), fall back to key.sequence.
+        // isPrintableGrapheme (shared with the compositor's handlePrintable)
+        // admits multi-UTF-16-unit emoji that the old `length === 1` test
+        // silently dropped on this fallback path.
+        const noModifier = !key?.ctrl && !key?.meta;
         const printable =
-          typeof char === 'string' && char.length === 1 && char >= ' ' && !key?.ctrl && !key?.meta
+          noModifier && typeof char === 'string' && isPrintableGrapheme(char)
             ? char
-            : typeof key?.sequence === 'string' &&
-                key.sequence.length === 1 &&
-                key.sequence >= ' ' &&
-                !key?.ctrl &&
-                !key?.meta
+            : noModifier && typeof key?.sequence === 'string' && isPrintableGrapheme(key.sequence)
               ? key.sequence
               : null;
         if (printable !== null) {

--- a/src/cli/multi-line-reader.ts
+++ b/src/cli/multi-line-reader.ts
@@ -14,6 +14,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import type { Interface as ReadlineInterface } from 'readline';
 import { list as listSlashCommands } from './slash/registry.js';
+import { endsWithBackslashContinuation } from './input/enter-decision.js';
 
 export type Completer = (line: string) => [string[], string];
 
@@ -156,7 +157,7 @@ export async function readInput(opts: MultiLineReaderOptions): Promise<string> {
     const line: string = await new Promise((resolve) => {
       opts.rl.once('line', (input: string) => resolve(input));
     });
-    if (line.endsWith('\\')) {
+    if (endsWithBackslashContinuation(line)) {
       buffer += line.slice(0, -1) + '\n';
       prompt = cont;
       continue;

--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -18,7 +18,8 @@
  */
 
 import { InputCore, type InputCoreState } from './input-core.js';
-import { nextGraphemeIndex } from './display.js';
+import { isPrintableGrapheme } from './input/printable.js';
+import { isSoftNewlineEnter, endsWithBackslashContinuation } from './input/enter-decision.js';
 import { readClipboardImage } from './input/clipboard-image.js';
 import { MAX_DROPDOWN_ROWS } from './terminal-compositor.autocomplete.js';
 import * as Paste from './terminal-compositor.paste.js';
@@ -503,9 +504,7 @@ function handleEnter(self: KeyDispatchHost, key: KeyInfo, sequence: string): boo
   // a single libuv read tick (same Date.now()) from rapid synthetic
   // emits in tests. Bracketed-paste mode is the reliable signal —
   // and is enabled on every TTY in arm().
-  const isShiftEnter = key?.shift === true || sequence === '\x1b[13;2u';
-  const isAltEnter = key?.meta === true;
-  if (isShiftEnter || isAltEnter) {
+  if (isSoftNewlineEnter(key, sequence)) {
     // Explicit user-driven newline — route through applyEdit so the
     // autocomplete dropdown closes (a `\n` in the buffer almost
     // never matches a trigger), history recall is reset, and a
@@ -550,6 +549,23 @@ function handleEnter(self: KeyDispatchHost, key: KeyInfo, sequence: string): boo
     if (kind !== 'slash') return true;
     if (!applied) return true;
     // Slash + applied: fall through with the now-completed buffer.
+  }
+  // Trailing backslash escapes Enter → convert to a real newline. The
+  // documented escape hatch (mirrors reader.ts via endsWithBackslashContinuation)
+  // for terminals that don't report shift-state on Enter; without it the live
+  // REPL submitted the raw trailing `\` instead of continuing onto a new line.
+  // Routed through applyEdit (like the soft-newline branch above) so the
+  // dropdown closes and history recall resets.
+  if (endsWithBackslashContinuation(self.input.buffer)) {
+    self.history?.resetRecall();
+    self.applyEdit(
+      InputCore.replaceRange(
+        self.input,
+        { start: self.input.buffer.length - 1, end: self.input.buffer.length },
+        '\n',
+      ),
+    );
+    return true;
   }
   // Allow Enter to submit attachment-only messages (empty text + ≥1
   // image) — matches readWithAutocomplete's behavior on Ctrl+D /
@@ -905,18 +921,6 @@ function handleTab(self: KeyDispatchHost, key: KeyInfo): boolean {
     return true;
   }
   return false;
-}
-
-/**
- * True when `s` is a single printable grapheme cluster (one visual character):
- * not a control char (< ' '), and exactly one grapheme — so multi-UTF-16-unit
- * emoji (surrogate pairs, variation selectors, skin-tone modifiers) count as
- * one printable character, while escape sequences and multi-char fragments are
- * rejected. Replaces the old `s.length === 1` UTF-16 code-unit test that
- * silently dropped all astral / composed emoji.
- */
-function isPrintableGrapheme(s: string): boolean {
-  return s >= ' ' && nextGraphemeIndex(s, 0) === s.length;
 }
 
 function handlePrintable(self: KeyDispatchHost, char: string | undefined, key: KeyInfo): void {

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -1666,6 +1666,22 @@ describe('TerminalCompositor', () => {
       expect(c.getBuffer()).toEqual({ text: 'firstz\nsecond', queued: false });
     });
 
+    it('trailing backslash + Enter inserts a newline instead of submitting (regression: \\+Enter)', async () => {
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+      await c.arm();
+      // Type 'foo\' then press PLAIN Enter. A trailing backslash is the
+      // documented soft-newline escape for terminals that don't report
+      // shift-state on Enter. Before the fix this branch lived only in
+      // reader.ts (the non-TTY/legacy path), never in the compositor's
+      // handleEnter — so in the live REPL plain Enter submitted the raw
+      // 'foo\' instead of continuing onto a new line.
+      for (const ch of 'foo') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+      stdin.emit('keypress', '\\', { name: '\\', sequence: '\\' });
+      stdin.emit('keypress', undefined, { name: 'return' });
+      // The trailing '\' is replaced by '\n'; nothing is submitted or queued.
+      expect(c.getBuffer()).toEqual({ text: 'foo\n', queued: false });
+    });
+
     // ── Soft-stop drain (regression: ESC → perpetual input-lag-of-one) ──────
     //
     // Reported bug: after ESC (soft-stop), the user's next typed+Enter'd


### PR DESCRIPTION
## Problem
In the interactive REPL, typing a trailing `\` then **Enter** submitted the raw backslash instead of inserting a newline (continuation). shift+Enter / alt+Enter worked, but the documented `\`-escape — the fallback for terminals that do not report shift-state on Enter — did not.

## Root cause
The live armed-TTY path routes Enter through `TerminalCompositor.dispatchKey()` → `handleEnter` (`src/cli/terminal-compositor.input-dispatch.ts`). The trailing-`\`→newline branch lived **only** in the legacy `readWithAutocompleteTty` reader (`src/cli/input/reader.ts`), which is reachable only as a non-armed-TTY / non-TTY fallback. The two readers are near-clones of the same keypress decision tree with no shared code, so they drifted. The same drift had left `reader.ts` carrying a stale `length === 1` printable test that silently dropped multi-UTF-16-unit emoji on the fallback path.

## Fix
Extract the drift-prone decisions into pure, shared, unit-tested helpers so the readers cannot diverge again:
- `src/cli/input/enter-decision.ts` — `isSoftNewlineEnter`, `endsWithBackslashContinuation`
- `src/cli/input/printable.ts` — `isPrintableGrapheme` (moved out of `input-dispatch.ts`)

Wired into all three readers:
- **compositor** — gains the missing trailing-`\` branch (the live-bug fix) + emoji-safe printable guard
- **reader.ts** — uses the shared helpers; printable guard now admits emoji
- **multi-line-reader.ts** — uses `endsWithBackslashContinuation` for consistency

## Tests
- `terminal-compositor.test.ts` — end-to-end regression: `foo\` + Enter → `{ text: 'foo\n', queued: false }` (drives the bug through `dispatchKey`; would have caught the original).
- `input/enter-decision.test.ts` (9) + `input/printable.test.ts` (5) — pure-predicate coverage.

## Verification
- `pnpm lint` (strict `tsc --noEmit`): green.
- Full `pnpm test`: 10298 passed / 14 skipped; the only 2 failures are pre-existing and unrelated (`config.test.ts` MLX slot bindings, `anthropic-direct.test.ts` compact model-id) — baseline before this change was 3 failed / 10282 passed, so no regressions.

## Scope / follow-ups (not in this PR)
Discovered via a `/simplify` pass on the input subsystem. Deferred: retire-or-guard `reader.ts`'s dead-on-armed-TTY keypress loop, Home/End line-relative parity in `reader.ts`, splitting the 183-line nav+edit handler, and routing `selectors.ts` through `enterRawMode`. Dropdown up/down direction left as a deliberate wrong-abstraction defer.
