### PR TITLE
chore(ci): add dependency-vulnerability audit gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,18 @@ jobs:
       - name: Audit SDK dependency surface (no unlocked @anthropic-ai/sdk imports)
         run: pnpm audit:sdk:check
 
+      - name: Audit dependency CVEs (critical severity in prod deps)
+        # Gates on critical-severity CVEs in production dependencies only.
+        # --audit-level=critical: only fail on critical advisories (not high/moderate).
+        # --prod: exclude devDependencies (vitest, coverage-v8, esbuild, etc.) which
+        #   carry several high/moderate unfixable transitive advisories that are dev-
+        #   only build/test tools, not shipped runtime code.
+        # Current state (as of 2026-06-29): no critical CVEs in prod deps → exits 0.
+        # Non-critical prod advisories (4 high via jsdom>undici and
+        #   @modelcontextprotocol/sdk>hono) are acknowledged; upstream fixes are
+        #   tracked in pnpm-lock.yaml — tighten to --audit-level=high once resolved.
+        run: pnpm audit:deps
+
       - name: Build
         run: pnpm build
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "audit:sdk": "tsx scripts/audit-sdk-dependency.ts",
     "audit:sdk:check": "tsx scripts/audit-sdk-dependency.ts --check",
     "audit:sdk:update-lock": "tsx scripts/audit-sdk-dependency.ts --update-lock",
+    "audit:deps": "pnpm audit --audit-level=critical --prod",
     "audit:env": "tsx scripts/audit-env-access.ts",
     "audit:env:check": "tsx scripts/audit-env-access.ts --check",
     "audit:env:list": "tsx scripts/audit-env-access.ts --list",


### PR DESCRIPTION
## Summary

Adds a `pnpm audit:deps` script and a CI gate that fails on **critical-severity CVEs in production dependencies**. This is a real, blocking gate — not advisory-only — because it exits 0 on current deps.

Part of a batch of top-5 CI improvements. Coverage is already a hard gate (`pnpm test:coverage` in the test job with vitest threshold enforcement) — left untouched.

---

## Changes

- **`package.json`** — new script `audit:deps`: `pnpm audit --audit-level=critical --prod`
- **`.github/workflows/ci.yml`** — new step in `lint-build` job after `audit:sdk:check`:
  ```yaml
  - name: Audit dependency CVEs (critical severity in prod deps)
    run: pnpm audit:deps
  ```

---

## Audit flags rationale

| Flag | Why |
|---|---|
| `--audit-level=critical` | Gates only on critical CVEs. Using `high` or `moderate` would cause CI to fail permanently on unfixable transitive advisories in dev tools (vitest/vite/esbuild) that are never shipped. |
| `--prod` | Excludes devDependencies. The only critical advisory in the repo is `GHSA-5xrq-8626-4rwp` (vitest UI server arbitrary file read) — vitest is a devDependency and its UI server is never run in CI or production. Without `--prod`, CI would be permanently red on an unfixable dev-only vuln. |

---

## Current advisory state (2026-06-29)

```
Full scan (all deps):       29 vulns — 1 critical, 11 high, 13 moderate, 4 low
pnpm audit --prod only:     12 vulns — 0 critical, 4 high, 6 moderate, 2 low
pnpm audit:deps (gate):     exits 0 ✓  (no critical in prod)
```

**Gate decision: BLOCKING** (not continue-on-error) — gate exits 0 on current deps.

### Acknowledged non-critical prod advisories (unfixable transitive, not gated)

| Severity | Package | Via | Advisory | Notes |
|---|---|---|---|---|
| high | undici | `jsdom>undici` | GHSA-vmh5-mc38-953g, GHSA-vxpw-j846-p89q, GHSA-hm92-r4w5-c3mj | jsdom is a runtime dep (`src/web/extract.ts`); fix requires upstream jsdom to adopt undici ≥7.28.0 |
| high | hono | `@modelcontextprotocol/sdk>hono` | GHSA-88fw-hqm2-52qc | fix requires upstream MCP SDK to adopt hono ≥4.12.25 |

Next step once upstream patches land: tighten the gate to `--audit-level=high`.

---

## Testing

- `pnpm audit:deps` exits 0 locally ✓
- YAML validated with `python3 yaml.safe_load` ✓
- No app code changes; `pnpm lint` not required for this diff