### PR TITLE
feat(queue): add list/remove/clear subcommands + document improve & farm in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,58 @@ afk --help               # full command tree
 
 Aliases: `afk c` → `chat`, `afk i` → `interactive`, `afk s` → `status`.
 
+### Queue management
+
+`afk queue` manages the pull-trigger daemon's task queue — tasks are persisted as JSON files and consumed one-by-one by `afk daemon --trigger pull`.
+
+```bash
+afk queue add "/forge-friction --auto" --notify-on failure
+                         # enqueue a command; daemon picks it up on next poll
+afk queue list           # print all pending tasks (id, enqueued time, command)
+afk queue remove <id>    # drop a single pending task by id
+afk queue clear          # remove all pending tasks (prompts for confirmation)
+afk queue clear --yes    # clear without prompting (CI / non-interactive)
+```
+
+### Self-improvement pipeline
+
+`afk improve` is a zero-LLM, deterministic pipeline that mines `~/.afk/state/witness/` session traces for ranked failure patterns, without making any model calls.
+
+```bash
+# Scan traces for failure patterns (dry-run; add --write to persist cards)
+afk improve scan [--since 7d] [--write] [--only <detector,...>]
+
+# Inspect failure cards
+afk improve cards list [--pattern <name>] [--severity <level>] [--status open|deferred|resolved]
+afk improve cards show <slug>
+afk improve cards triage <slug> --note "..." [--status resolved]
+
+# Draft a template-mode improvement proposal for a card (no LLM)
+afk improve propose <slug> [--no-write]
+
+# Generate a replay-mode eval-case from a failure card
+afk improve eval-gen <cardSlug> [--evidence-row <i>] [--no-write]
+
+# Run the deterministic guardrail contract for an eval-case
+afk improve eval-run <evalCaseIdOrCardSlug> [--no-write]
+```
+
+Available detectors (run `afk improve scan --help` for thresholds): `repeated-tool-use`, `subagent-block`, `closure-anomaly`, `tool-failure-density`.
+
+### Speculative branch farm
+
+`afk farm` spawns N isolated git worktrees, runs an agent on each in parallel, scores the results (tests + lint + LoC delta), and prints a ranked summary.
+
+```bash
+afk farm "add retry logic to the queue consumer" --branches 3
+afk farm "<task>" -n 5 --model sonnet --fail-fast
+afk farm "<task>" -n 3 --no-score    # skip post-run scoring
+afk farm "<task>" -n 3 --labels "approach-a,approach-b,approach-c"
+afk farm "<task>" -n 3 --no-memory --no-digest  # skip memory write + Telegram
+```
+
+Each branch gets a dedicated worktree under `~/.afk/state/farm/`. A commit-count escape check confirms each agent did real work. On completion, the winner (branch that passes tests and makes the smallest net change) is surfaced; the rest are left for manual cherry-pick or deletion.
+
 ## A note on permissions
 
 `afk` does not prompt before each tool call — there is no per-tool approval flow. Claude runs bash, reads and writes files, fetches URLs, and calls MCP servers without asking each time. This is intentional — `afk` is built for unattended work, where a permission prompt with no human in front of it is just a wedged session.

--- a/src/agent/daemon/queue-store.test.ts
+++ b/src/agent/daemon/queue-store.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, readdirSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { enqueue, dequeueNext, listPending } from './queue-store.js';
+import { enqueue, dequeueNext, listPending, removePending, clearPending } from './queue-store.js';
 
 // Use a fresh temp dir for each test to guarantee isolation
 let tmpDir: string;
@@ -294,5 +294,102 @@ describe('filename redaction in log output', () => {
       expect(msg).not.toContain(raw);
       expect(msg).toMatch(/<REDACTED/);
     }
+  });
+});
+
+describe('removePending', () => {
+  it('returns false on an empty queue', () => {
+    expect(removePending(tmpDir, 'q-0000000000000-aabbcc')).toBe(false);
+  });
+
+  it('removes a task file and returns true when id matches', () => {
+    const task = enqueue('to-remove', {}, tmpDir);
+    expect(readdirSync(tmpDir)).toHaveLength(1);
+
+    const removed = removePending(tmpDir, task.id);
+    expect(removed).toBe(true);
+    expect(readdirSync(tmpDir)).toHaveLength(0);
+  });
+
+  it('returns false when id does not match any task', () => {
+    enqueue('alpha', {}, tmpDir);
+    const removed = removePending(tmpDir, 'q-0000000000000-nonexistent');
+    expect(removed).toBe(false);
+    // File must still be present
+    expect(readdirSync(tmpDir)).toHaveLength(1);
+  });
+
+  it('removes only the matching task, leaving others intact', () => {
+    enqueue('keep-1', {}, tmpDir);
+    const target = enqueue('remove-me', {}, tmpDir);
+    enqueue('keep-2', {}, tmpDir);
+
+    const removed = removePending(tmpDir, target.id);
+    expect(removed).toBe(true);
+
+    const remaining = listPending(tmpDir);
+    expect(remaining).toHaveLength(2);
+    expect(remaining.map((t) => t.command)).toEqual(['keep-1', 'keep-2']);
+  });
+
+  it('skips malformed entries (does not throw) and still removes a valid match', () => {
+    writeFileSync(join(tmpDir, '0001-q-bad.json'), '{ corrupt');
+    const task = enqueue('good', {}, tmpDir);
+
+    // Should find and remove `good` even though a malformed file precedes it.
+    expect(removePending(tmpDir, task.id)).toBe(true);
+  });
+
+  it('creates the queue directory if it does not exist', () => {
+    const nested = join(tmpDir, 'does', 'not', 'exist');
+    const removed = removePending(nested, 'any-id');
+    expect(removed).toBe(false);
+    // Directory must now exist
+    expect(readdirSync(nested)).toHaveLength(0);
+  });
+});
+
+describe('clearPending', () => {
+  it('returns 0 on an empty queue', () => {
+    expect(clearPending(tmpDir)).toBe(0);
+  });
+
+  it('removes all task files and returns the count', () => {
+    enqueue('alpha', {}, tmpDir);
+    enqueue('beta', {}, tmpDir);
+    enqueue('gamma', {}, tmpDir);
+
+    const removed = clearPending(tmpDir);
+    expect(removed).toBe(3);
+    const remaining = readdirSync(tmpDir).filter((f) => f.endsWith('.json'));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('does not remove the poison/ subdirectory contents', () => {
+    // Enqueue a valid task and a poison entry, then clear.
+    enqueue('real', {}, tmpDir);
+    const poisonDir = join(tmpDir, 'poison');
+    mkdirSync(poisonDir, { recursive: true });
+    writeFileSync(join(poisonDir, 'stale-quarantined.json'), '{ bad }');
+
+    const removed = clearPending(tmpDir);
+    expect(removed).toBe(1); // only the real task file at root level
+
+    // Poison entry was NOT removed.
+    expect(readdirSync(poisonDir)).toHaveLength(1);
+  });
+
+  it('after clear, listPending returns an empty array', () => {
+    enqueue('x', {}, tmpDir);
+    clearPending(tmpDir);
+    expect(listPending(tmpDir)).toEqual([]);
+  });
+
+  it('creates the queue directory if it does not exist', () => {
+    const nested = join(tmpDir, 'new', 'dir');
+    const removed = clearPending(nested);
+    expect(removed).toBe(0);
+    // Directory must now exist
+    expect(readdirSync(nested)).toHaveLength(0);
   });
 });

--- a/src/agent/daemon/queue-store.ts
+++ b/src/agent/daemon/queue-store.ts
@@ -15,7 +15,7 @@
  * @module agent/daemon/queue-store
  */
 
-import { mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import { randomBytes } from 'node:crypto';
 import { join } from 'node:path';
 import { getQueueDir } from '../../paths.js';
@@ -266,4 +266,99 @@ export function listPending(queueDir: string = getQueueDir()): QueuedTask[] {
     }
   }
   return tasks;
+}
+
+/**
+ * Remove a single pending task by id.
+ *
+ * Scans the queue directory for a JSON file whose body contains the given
+ * `id`. The search is a linear scan — queue lengths are expected to be small
+ * (single-operator CLI use) so this is fine. Skips directories and temp files
+ * matching the same glob, mirroring `listPending`'s filter.
+ *
+ * @param queueDir - Override the queue directory (defaults to `getQueueDir()`).
+ * @param id       - The task id to remove (e.g. `q-1716000000000-abc123`).
+ * @returns `true` if a matching file was found and removed; `false` if no
+ *          matching task was found (id unknown or already dequeued).
+ * @throws If the matching file exists but cannot be unlinked (e.g. permission
+ *         error). The caller is responsible for surfacing this to the user.
+ */
+export function removePending(queueDir: string = getQueueDir(), id: string): boolean {
+  try {
+    mkdirSync(queueDir, { recursive: true });
+  } catch {
+    return false;
+  }
+
+  const sorted = readdirSync(queueDir)
+    .filter((f) => f.endsWith('.json') && !f.startsWith('.tmp-'))
+    .sort();
+
+  for (const filename of sorted) {
+    const filePath = join(queueDir, filename);
+    // Skip directories (e.g. `poison/` subdir) — only real files hold tasks.
+    try {
+      if (statSync(filePath).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    let task: QueuedTask;
+    try {
+      task = JSON.parse(readFileSync(filePath, 'utf-8')) as QueuedTask;
+    } catch {
+      // Malformed entry — cannot match by id, skip.
+      continue;
+    }
+    if (task.id === id) {
+      unlinkSync(filePath);
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Remove all pending tasks from the queue directory.
+ *
+ * Mirrors `listPending`'s filter (`.json`, not `.tmp-`, not directories) and
+ * deletes every matching file. The `poison/` subdirectory is left intact.
+ * Skips individual files that cannot be unlinked and logs each skip to stderr,
+ * so a single permission error does not abort the whole clear.
+ *
+ * @param queueDir - Override the queue directory (defaults to `getQueueDir()`).
+ * @returns The number of task files successfully removed.
+ */
+export function clearPending(queueDir: string = getQueueDir()): number {
+  try {
+    mkdirSync(queueDir, { recursive: true });
+  } catch {
+    return 0;
+  }
+
+  const sorted = readdirSync(queueDir)
+    .filter((f) => f.endsWith('.json') && !f.startsWith('.tmp-'))
+    .sort();
+
+  let removed = 0;
+  for (const filename of sorted) {
+    const filePath = join(queueDir, filename);
+    // Skip directories (e.g. `poison/` subdir if it somehow has a .json suffix).
+    try {
+      if (statSync(filePath).isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    try {
+      unlinkSync(filePath);
+      removed += 1;
+    } catch (err) {
+      const redactedFilename = redactInlineSecrets(filename);
+      const reason = redactInlineSecrets(err instanceof Error ? err.message : String(err));
+      // eslint-disable-next-line no-console
+      console.error(
+        `[daemon] pull-queue: failed to remove entry ${redactedFilename} in clearPending (${reason})`,
+      );
+    }
+  }
+  return removed;
 }

--- a/src/cli/commands/queue.ts
+++ b/src/cli/commands/queue.ts
@@ -1,23 +1,24 @@
 /**
- * `afk queue` command — enqueue tasks for pull-trigger daemon mode.
+ * `afk queue` command — manage pull-trigger daemon task queue.
  *
  * Usage:
- *   afk queue add <command>
- *   afk queue add "/forge-friction --auto" --notify-on failure
+ *   afk queue add <command> [--notify-on failure|always|never]
+ *   afk queue list
+ *   afk queue remove <id>
+ *   afk queue clear [--yes]
  *
  * Tasks are persisted as JSON files in `~/.afk/state/queue/`. A running
  * daemon with `--trigger pull` will dequeue and execute them one-by-one
  * on its poll interval (default 30s).
  *
- * TODO(#337-list): afk queue list/remove/clear — listPending() already supports this.
- *
  * @module cli/commands/queue
  */
 
 import { Command } from 'commander';
+import { createInterface } from 'node:readline/promises';
 import { mkdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { enqueue } from '../../agent/daemon/queue-store.js';
+import { enqueue, listPending, removePending, clearPending } from '../../agent/daemon/queue-store.js';
 import { getQueueDir } from '../../paths.js';
 import { palette } from '../palette.js';
 import { handleCommandError } from '../errors/index.js';
@@ -26,6 +27,10 @@ export function registerQueueCommand(program: Command): void {
   const queueCmd = program
     .command('queue')
     .description('Manage the pull-trigger task queue (used with `afk daemon --trigger pull`)');
+
+  // ---------------------------------------------------------------------------
+  // add
+  // ---------------------------------------------------------------------------
 
   queueCmd
     .command('add <command>')
@@ -54,4 +59,118 @@ export function registerQueueCommand(program: Command): void {
         }
       },
     );
+
+  // ---------------------------------------------------------------------------
+  // list
+  // ---------------------------------------------------------------------------
+
+  queueCmd
+    .command('list')
+    .description('List all pending queued tasks in FIFO order')
+    .action(() => {
+      try {
+        const queueDir = getQueueDir();
+        const tasks = listPending(queueDir);
+
+        if (tasks.length === 0) {
+          console.log(palette.dim('No pending tasks in queue.'));
+          return;
+        }
+
+        const header = `${'SEQ'.padEnd(4)}  ${'ID'.padEnd(26)}  ${'ENQUEUED'.padEnd(24)}  COMMAND`;
+        const sep = '─'.repeat(header.length);
+        console.log(palette.heading(header));
+        console.log(palette.dim(sep));
+
+        for (const task of tasks) {
+          const seq = String(task.sequence).padStart(4, '0');
+          const id = task.id.padEnd(26).slice(0, 26);
+          const enqueued = task.enqueuedAt.padEnd(24).slice(0, 24);
+          console.log(`${seq}  ${id}  ${enqueued}  ${task.command}`);
+        }
+
+        const plural = tasks.length === 1 ? 'task' : 'tasks';
+        console.log(palette.dim(`\n${tasks.length} pending ${plural}.`));
+      } catch (err) {
+        handleCommandError(err);
+      }
+    });
+
+  // ---------------------------------------------------------------------------
+  // remove
+  // ---------------------------------------------------------------------------
+
+  queueCmd
+    .command('remove <id>')
+    .description('Remove a pending task by id')
+    .action((id: string) => {
+      try {
+        const queueDir = getQueueDir();
+        const removed = removePending(queueDir, id);
+
+        if (!removed) {
+          console.error(palette.error(`Task not found: ${id}`));
+          console.error(palette.dim('  (already executed, already removed, or id is wrong)'));
+          process.exit(1);
+        }
+
+        console.log(palette.success(`✔ Removed task ${id}`));
+      } catch (err) {
+        handleCommandError(err);
+      }
+    });
+
+  // ---------------------------------------------------------------------------
+  // clear
+  // ---------------------------------------------------------------------------
+
+  queueCmd
+    .command('clear')
+    .description('Remove all pending tasks from the queue')
+    .option('-y, --yes', 'Skip the confirmation prompt (non-interactive / CI)')
+    .action(async (opts: { yes?: boolean }) => {
+      try {
+        const queueDir = getQueueDir();
+        const pending = listPending(queueDir);
+
+        if (pending.length === 0) {
+          console.log(palette.dim('Queue is already empty — nothing to clear.'));
+          return;
+        }
+
+        // Confirmation gate. Interactive TTY → prompt; otherwise require --yes.
+        if (opts.yes !== true) {
+          if (!process.stdin.isTTY) {
+            console.log(
+              palette.warning(
+                `Non-interactive shell: re-run with --yes to clear ${pending.length} pending task(s).`,
+              ),
+            );
+            process.exit(0);
+          }
+          const rl = createInterface({ input: process.stdin, output: process.stdout });
+          try {
+            const answer = (
+              await rl.question(
+                palette.bold(`\nRemove all ${pending.length} pending task(s) from the queue? [y/N] `),
+              )
+            )
+              .trim()
+              .toLowerCase();
+            if (answer !== 'y' && answer !== 'yes') {
+              console.log(palette.dim('Aborted — queue unchanged.'));
+              process.exit(0);
+            }
+          } finally {
+            rl.close();
+          }
+        }
+
+        const removed = clearPending(queueDir);
+        const plural = removed === 1 ? 'task' : 'tasks';
+        console.log(palette.success(`✔ Cleared ${removed} pending ${plural}.`));
+      } catch (err) {
+        handleCommandError(err);
+      }
+    });
 }


### PR DESCRIPTION
## Summary

Adds three missing `afk queue` management subcommands (`list`, `remove`, `clear`) and documents two previously-hidden commands (`afk improve`, `afk farm`) in the README.

Part of a top-5 improvements batch.

## Changes

### Part 1 — `afk queue` management subcommands

**New CLI subcommands** (`src/cli/commands/queue.ts`):
- `afk queue list` — prints all pending tasks (seq, id, enqueued timestamp, command) using the existing `listPending()` fn; handles empty queue cleanly
- `afk queue remove <id>` — removes a single pending task by id; exits 1 with helpful message if not found
- `afk queue clear [--yes]` — removes all pending tasks with an interactive readline confirmation (mirrors `migrate.ts` pattern); `--yes` skips for CI/non-interactive shells
- Removed the `TODO(#337-list)` comment at queue.ts:12 — now implemented

**New store functions** (`src/agent/daemon/queue-store.ts`):
- `removePending(queueDir, id): boolean` — linear scan by id, skips malformed entries, returns true if found+removed
- `clearPending(queueDir): number` — removes all root-level .json files, preserves `poison/` subdirectory, returns count removed
- Both mirror the style and error-handling of existing fns (mkdirSync guard, statSync directory skip, redacted error logs)

### Part 2 — README documentation

Added three subsections under **Useful commands**:
- `### Queue management` — `add`/`list`/`remove`/`clear` with `--yes` flag
- `### Self-improvement pipeline` — `afk improve` (scan → cards → propose → eval-gen → eval-run); all flags verified from `src/cli/commands/improve.ts`
- `### Speculative branch farm` — `afk farm` with `--branches`, `--model`, `--fail-fast`, `--no-score`, `--labels`, `--no-memory`, `--no-digest`; all verified from `src/cli/commands/farm.ts`

## Testing

```
pnpm exec vitest run src/agent/daemon/queue-store.test.ts --no-cache
# 32 tests pass (21 pre-existing + 11 new for removePending/clearPending)
```

```
pnpm lint
# tsc --noEmit: clean
```

## Status

- [x] `pnpm lint` clean
- [x] 32/32 queue-store tests green
- [x] `afk queue list | remove | clear` implemented
- [x] `removePending` + `clearPending` store fns added + tested
- [x] README: `### Queue management` section added
- [x] README: `### Self-improvement pipeline` (`afk improve`) section added
- [x] README: `### Speculative branch farm` (`afk farm`) section added
- [ ] Demo GIF — **deferred** (needs screen recording; placeholder `<!-- DEMO GIF GOES HERE -->` left intact at README line 16)