### PR TITLE
feat(compact): emit PreCompact hook on auto-compaction

### DIFF
--- a/src/agent/providers/anthropic-direct/compact.test.ts
+++ b/src/agent/providers/anthropic-direct/compact.test.ts
@@ -227,6 +227,7 @@ import type Anthropic from '@anthropic-ai/sdk';
 import type { RawMessageStreamEvent } from '@anthropic-ai/sdk/resources';
 import { AnthropicDirectQuery } from './query.js';
 import type { ToolDispatcher } from './tool-dispatcher.js';
+import { createHookRegistry } from '../../hooks.js';
 
 const autoCompactMock = vi.fn();
 
@@ -428,5 +429,83 @@ describeIntegration('auto-compaction integration', () => {
     for await (const _ev of query) { /* drain */ }
 
     expectIntegration(compactSpy).not.toHaveBeenCalled();
+  });
+
+  itIntegration('dispatches PreCompact(trigger:auto) hook before compact() fires', async () => {
+    let callCount = 0;
+    autoCompactMock.mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 1) return fromArr(makeHighUsageStream());
+      return fromArr(makeSummaryStream());
+    });
+
+    const registry = createHookRegistry();
+    const preCompactContexts: Array<{ trigger?: string }> = [];
+    registry.register('PreCompact', async (ctx) => {
+      preCompactContexts.push({ trigger: (ctx as { trigger?: string }).trigger });
+      return { decision: 'continue' as const };
+    });
+
+    const query = new AnthropicDirectQuery({
+      client: new MockAnthropicForAutoCompact() as unknown as Anthropic,
+      authMode: 'api-key',
+      promptStream: singleTurnStream('test message'),
+      toolDispatcher: noopAutoCompactDispatcher,
+      initialMessages: makeMinimalHistory(),
+      model: 'claude-sonnet-4-5-20250929',
+      maxTokens: 4096,
+      tools: null,
+      userSystem: null,
+      systemPrefix: null,
+      autoCompactThreshold: 0.9,
+      hookRegistry: registry,
+    });
+
+    const compactSpy = vi.spyOn(query, 'compact');
+
+    for await (const _ev of query) { /* drain */ }
+
+    // Hook must have fired exactly once with trigger:'auto'.
+    expectIntegration(preCompactContexts).toHaveLength(1);
+    expectIntegration(preCompactContexts[0]?.trigger).toBe('auto');
+    // compact() must have been called — hook allowed it.
+    expectIntegration(compactSpy).toHaveBeenCalledTimes(1);
+  });
+
+  itIntegration('honors a blocking PreCompact hook — skips compact() without error', async () => {
+    autoCompactMock.mockImplementation(() => fromArr(makeHighUsageStream()));
+
+    const registry = createHookRegistry();
+    registry.register('PreCompact', async () => {
+      return { decision: 'block' as const, reason: 'test block' };
+    });
+
+    const query = new AnthropicDirectQuery({
+      client: new MockAnthropicForAutoCompact() as unknown as Anthropic,
+      authMode: 'api-key',
+      promptStream: singleTurnStream('test message'),
+      toolDispatcher: noopAutoCompactDispatcher,
+      initialMessages: makeMinimalHistory(),
+      model: 'claude-sonnet-4-5-20250929',
+      maxTokens: 4096,
+      tools: null,
+      userSystem: null,
+      systemPrefix: null,
+      autoCompactThreshold: 0.9,
+      hookRegistry: registry,
+    });
+
+    const compactSpy = vi.spyOn(query, 'compact');
+    const events: import('../../provider.js').ProviderEvent[] = [];
+
+    for await (const ev of query) {
+      events.push(ev);
+    }
+
+    // Hook blocked compaction — compact() must NOT have been called.
+    expectIntegration(compactSpy).not.toHaveBeenCalled();
+    // Session still completed normally (not an error event).
+    const completed = events.find((e) => e.type === 'turn.completed');
+    expectIntegration(completed).toBeDefined();
   });
 });

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -1022,6 +1022,12 @@ export class AnthropicDirectProvider implements ModelProvider {
       ...(resolveAutoCompactThreshold(config.autoCompact) !== undefined
         ? { autoCompactThreshold: resolveAutoCompactThreshold(config.autoCompact) }
         : {}),
+      // Thread the resolved hook registry into the query so auto-compaction
+      // can dispatch PreCompact(trigger:'auto') before calling compact().
+      // resolveSessionHookRegistry is already called above for the dispatcher;
+      // we reuse config.hookRegistry directly here — the query stores it
+      // separately from the dispatcher and dispatches only PreCompact events.
+      ...(config.hookRegistry !== undefined ? { hookRegistry: config.hookRegistry } : {}),
     });
   }
 }

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -70,6 +70,8 @@ import { AbortCoordinator } from './query/abort-coordinator.js';
 import { RetryLayer } from './query/retry-layer.js';
 import { compactHistory } from './query/compact-handler.js';
 import { contextWindowTokensUsed, shouldAutoCompact, buildContextUsageFields } from './query/auto-compact.js';
+import type { HookRegistry } from '../../hooks.js';
+import { HookBlockedError } from '../../../utils/errors.js';
 
 /**
  * Small static starter list returned by `supportedModels()`. The provider
@@ -176,6 +178,14 @@ export interface AnthropicDirectQueryOptions {
    * undefined means auto-compaction is disabled (the default).
    */
   autoCompactThreshold?: number;
+  /**
+   * Hook registry forwarded from the session harness. When present, the
+   * auto-compact path dispatches `PreCompact(trigger:'auto')` before calling
+   * `compact()`, matching the manual-compact paths in the REPL and Telegram
+   * surfaces. A `block` decision (HookBlockedError) skips compaction for that
+   * turn without surfacing an error to the caller.
+   */
+  hookRegistry?: HookRegistry;
 }
 
 /**
@@ -236,6 +246,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
   private readonly cwdDependentsFactory?: (cwd: string) => { userSystem: string; dispatcher: ToolDispatcher };
   private readonly onPermissionMode?: (mode: string) => void;
   private readonly mcpManager?: import('../../mcp/index.js').McpManager;
+  private readonly hookRegistry?: HookRegistry;
 
   constructor(opts: AnthropicDirectQueryOptions) {
     this.initSessionId = opts.sessionId ?? randomUUID();
@@ -250,6 +261,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
     this.cwdDependentsFactory = opts.cwdDependentsFactory;
     this.onPermissionMode = opts.onPermissionMode;
     this.mcpManager = opts.mcpManager;
+    if (opts.hookRegistry !== undefined) this.hookRegistry = opts.hookRegistry;
     this.retry = new RetryLayer({
       client: opts.client,
       authMode: opts.authMode,
@@ -466,10 +478,29 @@ export class AnthropicDirectQuery implements ProviderQuery {
               // boundary here (generator suspended at promptIterator.next()
               // on the next iteration). Awaiting inline keeps the ordering
               // deterministic and avoids a dangling promise race.
-              // TODO(PreCompact): auto-compact does not yet dispatch PreCompact(trigger:'auto').
-              // hookRegistry is not threaded into the provider-internal compact path.
-              // Tracked as a follow-up to feat/pre-compact-hook; remove this comment when wired.
-              await this.compact();
+              //
+              // Invariant: dispatch PreCompact(trigger:'auto') BEFORE compact()
+              // so registered hooks can block or observe the operation, mirroring
+              // the manual-compact paths in REPL (/compact) and Telegram. A block
+              // decision throws HookBlockedError — caught here to skip compaction
+              // for this turn without propagating to the outer error handler.
+              try {
+                if (this.hookRegistry) {
+                  await this.hookRegistry.dispatch({
+                    event: 'PreCompact',
+                    sessionId: this.initSessionId,
+                    trigger: 'auto',
+                  });
+                }
+                await this.compact();
+              } catch (compactErr) {
+                if (compactErr instanceof HookBlockedError) {
+                  // Hook blocked auto-compaction — skip this turn's compaction
+                  // without surfacing an error; the session continues normally.
+                } else {
+                  throw compactErr;
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

Closes the `TODO(PreCompact)` at `src/agent/providers/anthropic-direct/query.ts:469` by wiring the session hook registry into the `AnthropicDirectQuery` auto-compact path.

When auto-compaction fires at a turn boundary (usage crosses the configured threshold), `PreCompact(trigger:'auto')` is now dispatched before `compact()` is called — mirroring the exact dispatch signature and block-decision handling of the manual-compact paths in the REPL (`/compact`) and Telegram handlers.

Part of a top-5 improvements batch.

## Changes

- **`src/agent/providers/anthropic-direct/query.ts`**
  - Import `HookRegistry` (type) from `hooks.ts` and `HookBlockedError` from `utils/errors`
  - Add `hookRegistry?: HookRegistry` to `AnthropicDirectQueryOptions`
  - Store `hookRegistry` as a private field on `AnthropicDirectQuery`
  - In the auto-compact branch: dispatch `PreCompact(trigger:'auto')` via the registry before calling `this.compact()`; catch `HookBlockedError` to skip compaction for that turn without propagating
  - Remove the `TODO(PreCompact)` comment block

- **`src/agent/providers/anthropic-direct/index.ts`**
  - Pass `config.hookRegistry` into the `AnthropicDirectQuery` constructor so the session-resolved hook registry reaches the auto-compact path

- **`src/agent/providers/anthropic-direct/compact.test.ts`**
  - Import `createHookRegistry` for integration tests
  - New: `dispatches PreCompact(trigger:auto) hook before compact() fires` — verifies the hook fires exactly once with `trigger:'auto'` and `compact()` is called
  - New: `honors a blocking PreCompact hook — skips compact() without error` — verifies `compact()` is NOT called and the session still emits `turn.completed`

## Testing

```
pnpm exec vitest run src/agent/providers/anthropic-direct/compact.test.ts --no-cache
```
19 tests pass (17 pre-existing + 2 new).

`pnpm lint` (tsc --noEmit): clean.