### PR TITLE
refactor(providers): extract shared helpers into providers/shared + fix env-bleed test

### DIFF
--- a/src/agent/providers/anthropic-direct/afk-mode-addendum.ts
+++ b/src/agent/providers/anthropic-direct/afk-mode-addendum.ts
@@ -1,59 +1,16 @@
 /**
- * AFK-mode system-prompt addendum.
+ * Re-export shim — the canonical implementation has moved to
+ * `../shared/afk-mode-addendum.ts`.
  *
- * When the session is in `'autonomous'` permission mode (AFK mode), this module
- * supplies a single text block that the provider's `composeSystem()` appends to
- * the system payload. The addendum is the *posture* half of AFK mode — its
- * companion is the hook-layer refusal in {@link module:agent/afk-mode-gate},
- * which is the *enforcement* half (the mechanical safety ceiling).
- *
- * Design notes:
- *  - The posture is **bounded autonomy, not YOLO.** It tells the model to act
- *    on reversible work without waiting, but to STOP at one-way doors
- *    (irreversible / external / genuinely ambiguous forks) and surface an
- *    Asking summary to Telegram instead of guessing. The text explicitly defers
- *    to the gate: the model is told a mechanical layer refuses high-risk ops
- *    regardless of what it decides, so it should not treat the posture as a
- *    licence to bypass safety.
- *  - The channel to the operator is Telegram via the `send_telegram` tool —
- *    `send_telegram` is the one outbound op the gate never blocks.
- *  - The block carries no `cache_control` of its own — `withSystemBreakpoint`
- *    in `cache-policy.ts` floats the breakpoint to whichever block is last, so
- *    toggling AFK mode busts the cache once (correct) and same-mode turns hit
- *    cleanly. This mirrors the plan-mode addendum's cache behaviour exactly.
- *  - AFK mode and plan mode are mutually exclusive permission modes, so at most
- *    one of the two addenda is ever appended in a turn.
+ * This file is kept so existing test imports
+ * (`./afk-mode-addendum.js` from `afk-mode-addendum.test.ts` and
+ *  `plan-mode-system-payload.test.ts`) continue to resolve without
+ * modification.
  *
  * @module agent/providers/anthropic-direct/afk-mode-addendum
  */
 
-import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
-
-export const AFK_MODE_ADDENDUM_TEXT = [
-  '## AFK mode is active',
-  '',
-  'The operator is away from keyboard. Your channel to them is Telegram via the `send_telegram` tool — not this transcript, which no one is watching live. At the end of each turn, push your terminal state (Done / Blocked / Asking) to Telegram so the operator can review asynchronously.',
-  '',
-  'Posture — bounded autonomy, not unchecked action:',
-  '  - Proceed autonomously on reversible work. Do not stop to confirm actions you are already authorized to take and can undo (edits, reads, tests, local commits, non-force pushes, installs).',
-  '  - At a one-way door — anything irreversible, externally visible, credential- or payment-touching, or where multiple readings lead to materially different work — do NOT guess. Push a concise Asking summary to Telegram naming the decision and your recommended default, then stop and end the turn in the Asking state.',
-  '  - A mechanical gate refuses high-risk and irreversible operations at the hook layer regardless of this text. Treat a gate refusal as a signal to surface the decision to the operator, not an obstacle to work around.',
-  '',
-  'Communication discipline:',
-  '  - Batch updates. Send a Telegram message at terminal state (and at a genuinely blocking fork), not a play-by-play — the operator gets a push notification for every message.',
-  '  - Keep pushes short and scannable: what happened, what changed, what (if anything) you need. Never paste raw tool output, logs, secrets, or full file contents into a push.',
-  '',
-  'Exit: the operator returns and runs `/afk off` (or Shift+Tab) to restore default permissions and terminal-channel interaction.',
-].join('\n');
-
-/**
- * Returns the addendum block when the session is in `'autonomous'` (AFK) mode,
- * else `null`. The block is a plain text content block with no `cache_control`
- * stamp (the breakpoint stamper handles cache markers).
- */
-export function buildAfkModeAddendumBlock(
-  mode: string | undefined,
-): ContentBlockParam | null {
-  if (mode !== 'autonomous') return null;
-  return { type: 'text', text: AFK_MODE_ADDENDUM_TEXT };
-}
+export {
+  AFK_MODE_ADDENDUM_TEXT,
+  buildAfkModeAddendumBlock,
+} from '../shared/afk-mode-addendum.js';

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -51,6 +51,8 @@ import { translateMessageStream } from './translate.js';
 import { emitToolCall, emitSessionPhase } from '../../trace/emit.js';
 import { extractRawToolInput } from '../../facets/raw-input.js';
 import { env } from '../../../config/env.js';
+import { sleepWithAbort } from '../shared/sleep-with-abort.js';
+import { summarizeToolInput } from '../shared/tool-input-summary.js';
 
 /**
  * Default cap on tool-use rounds within a single user turn. `0` means "no
@@ -113,15 +115,6 @@ export function isOverloadedErrorEvent(err: unknown): boolean {
   return innerType === 'overloaded_error';
 }
 
-function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
-  return new Promise((resolve) => {
-    if (signal.aborted) { resolve(); return; }
-    const timer = setTimeout(resolve, ms);
-    timer.unref();
-    signal.addEventListener('abort', () => { clearTimeout(timer); resolve(); }, { once: true });
-  });
-}
-
 async function createWithRetry(
   client: { messages: { create(params: unknown, opts: unknown): unknown } },
   params: AnthropicMessagesCreateParams,
@@ -147,36 +140,6 @@ async function createWithRetry(
       throw e;
     }
   }
-}
-
-function summarizeToolInput(toolName: string, input: unknown): string {
-  if (!input || typeof input !== 'object') return '';
-  const obj = input as Record<string, unknown>;
-  // Skill dispatch: the `name` field IS the skill being invoked (diagnose,
-  // review, mint, …). Surface it as a paren-wrapped label so the tool lane
-  // renders `skill(diagnose)` instead of a bare `skill [skill]` — matching the
-  // `Agent(<label>)` dispatch convention and the paren-wrap signal the overflow
-  // renderer keys on (cli/commands/interactive/tool-lane-render-grouping-overflow.ts).
-  // Unlike `agent`, a skill's label is fully known from the tool input, so it
-  // needs no deferred mergeAgentLabel promotion — and it MUST be surfaced here
-  // because load-mode skills never fork a child Agent row to carry the name.
-  if (toolName === 'skill' || toolName === 'Skill') {
-    const skillName = obj['name'];
-    if (typeof skillName === 'string' && skillName.length > 0) {
-      return `(${skillName.length > 60 ? skillName.slice(0, 59) + '…' : skillName})`;
-    }
-    return '';
-  }
-  const path = obj['file_path'] ?? obj['path'] ?? obj['filePath'];
-  if (typeof path === 'string') return ' ' + path;
-  const cmd = obj['command'] ?? obj['cmd'];
-  if (typeof cmd === 'string') {
-    const firstLine = cmd.split('\n')[0]!;
-    return ' ' + (firstLine.length > 80 ? firstLine.slice(0, 77) + '…' : firstLine);
-  }
-  const query = obj['query'] ?? obj['pattern'] ?? obj['url'] ?? obj['description'];
-  if (typeof query === 'string') return ' ' + query;
-  return '';
 }
 
 /**

--- a/src/agent/providers/anthropic-direct/plan-mode-addendum.ts
+++ b/src/agent/providers/anthropic-direct/plan-mode-addendum.ts
@@ -1,66 +1,16 @@
 /**
- * Plan-mode system-prompt addendum.
+ * Re-export shim — the canonical implementation has moved to
+ * `../shared/plan-mode-addendum.ts`.
  *
- * When the session is in `'plan'` permission mode, this module supplies a
- * single text block that the provider's `composeSystem()` appends to the
- * system payload. The addendum is the *posture* half of plan mode — its
- * companion is the hook-layer refusal in {@link module:agent/plan-mode-gate}
- * which is the *enforcement* half.
- *
- * Design notes:
- *  - The text is intentionally short. It names the topology (ground → gather
- *    → reveal → pressure → embody) and the skill primitives that match each
- *    step. It does not script a sequence; the model chooses which steps the
- *    work needs.
- *  - The block carries no `cache_control` of its own — `withSystemBreakpoint`
- *    in `cache-policy.ts` floats the breakpoint to whichever block is last,
- *    so toggling plan mode busts the cache once (correct) and same-mode
- *    turns hit cleanly.
- *  - The skill names listed here MUST stay in sync with the bundled-plugin
- *    skills under `src/bundled-plugins/awa-bundled/skills/`. They are the
- *    skills the model can already invoke via the `skill` tool; the addendum
- *    just nominates the relevant subset for the planning topology.
+ * This file is kept so existing test imports
+ * (`./plan-mode-addendum.js` from `plan-mode-addendum.test.ts`,
+ *  `plan-mode-system-payload.test.ts`, and `openai-compatible/query.test.ts`)
+ * continue to resolve without modification.
  *
  * @module agent/providers/anthropic-direct/plan-mode-addendum
  */
 
-import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
-
-export const PLAN_MODE_ADDENDUM_TEXT = [
-  '## Plan mode is active',
-  '',
-  'File and memory write tools (`write_file`, `edit_file`, `memory_update`, `procedure_write`) are refused at the hook layer.',
-  '`bash` runs for read-only investigation (git status/log/diff, ls, cat, grep, find — chained or not); state-mutating bash (file writes, rm, installs, commits, pushes) is refused while planning. The user has asked you to plan, not yet to act — exit plan mode to make changes.',
-  'Treat this turn as planning work.',
-  '',
-  'Traverse the shape that matches the work — skip steps the terrain already covers, do not skip steps the terrain hides:',
-  '',
-  '  unknown field → ground the current terrain → gather missing codebase context →',
-  '  research missing external context → reveal chaos / constraints / risks →',
-  '  name the failure geometry → form a candidate plan → apply adversarial pressure → embody the final plan',
-  '',
-  'Reach for these skills (invoke via the `skill` tool) when the cost of skipping exceeds the cost of dispatching:',
-  '  - `ground-state` — survey git, infra, memory before non-trivial work',
-  '  - `gather` — parallel context-gathering for a code area',
-  '  - `research` — parallel external + local context for the current task',
-  '  - `devils-advocate` — generate alternatives and rank them before committing',
-  '  - `shadow-verify` — independently re-derive load-bearing claims',
-  '',
-  'Do not declare readiness silently. When the plan is ready, state: chosen approach, risks named, and alternatives considered.',
-  '',
-  'Then, IF the task requires implementation (writing code or files), call the `exit_plan_mode` tool to present your plan. The user picks how to proceed (approve and implement, or keep planning). After calling it, END YOUR TURN — on approval you will receive a separate instruction to save the plan to a file and implement it. Do NOT use `ask_question` to ask whether the plan is OK; that is exactly what `exit_plan_mode` does — use `ask_question` only to resolve open requirement questions first. For research / read-only tasks that need no code changes, do NOT call `exit_plan_mode` — just answer.',
-  '',
-  'Manual fallbacks remain: the user can exit with `/plan off` (same save-and-implement handoff), and Shift+Tab advances the permission-mode ring without saving or implementing. Keep the plan concrete and complete enough to act on directly.',
-].join('\n');
-
-/**
- * Returns the addendum block when the session is in `'plan'` mode, else
- * `null`. The block is a plain text content block with no `cache_control`
- * stamp (the breakpoint stamper handles cache markers).
- */
-export function buildPlanModeAddendumBlock(
-  mode: string | undefined,
-): ContentBlockParam | null {
-  if (mode !== 'plan') return null;
-  return { type: 'text', text: PLAN_MODE_ADDENDUM_TEXT };
-}
+export {
+  PLAN_MODE_ADDENDUM_TEXT,
+  buildPlanModeAddendumBlock,
+} from '../shared/plan-mode-addendum.js';

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -54,7 +54,7 @@ import {
 } from './cache-policy.js';
 import { buildPlanModeAddendumBlock } from './plan-mode-addendum.js';
 import { buildAfkModeAddendumBlock } from './afk-mode-addendum.js';
-import { collectSkillEntries } from '../../tools/skill-bridge.js';
+import { collectSupportedCommands } from '../shared/supported-commands.js';
 import { contextLimitFor } from '../../model-limits.js';
 import { resolveModelId } from '../../session/model-resolution.js';
 import type { ToolDispatcher } from './tool-dispatcher.js';
@@ -627,30 +627,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
   }
 
   async supportedCommands(): Promise<ProviderCommandInfo[]> {
-    // Surface every skill discovered by the skill-bridge — built-in TS
-    // skills, user-scope `~/.afk/skills/`, and plugin SKILL.md files under
-    // `~/.afk/plugins/` — so the REPL slash registry can register a
-    // passthrough `/<skill>` for each one. Without this, `/reload-plugins`
-    // reports 0 and typing `/mint` does not autocomplete.
-    //
-    // The model already learns about these skills via the system-prompt
-    // manifest (built from `collectSkillEntries()` in
-    // `AnthropicDirectProvider.query()`); reusing the same collector here
-    // keeps the slash list and the manifest in lockstep.
-    try {
-      const entries = collectSkillEntries();
-      return entries.map((e) => {
-        const info: ProviderCommandInfo = {
-          name: e.name,
-          description: e.description,
-        };
-        if (e.argumentHint) info.argumentHint = e.argumentHint;
-        return info;
-      });
-    } catch {
-      // Discovery is best-effort — the REPL stays usable without it.
-      return [];
-    }
+    return collectSupportedCommands();
   }
 
   async supportedModels(): Promise<ProviderModelInfo[]> {

--- a/src/agent/providers/anthropic-direct/query/auto-compact.ts
+++ b/src/agent/providers/anthropic-direct/query/auto-compact.ts
@@ -1,126 +1,23 @@
 /**
- * Auto-compaction threshold logic for {@link AnthropicDirectQuery}.
+ * Re-export shim — the canonical implementation has moved to
+ * `../../shared/auto-compact.ts`.
  *
- * Intentionally pure — no I/O, no logging, no side effects. The caller
- * (query.ts's turn loop) reads the result and decides whether to fire
- * `this.compact()`.
+ * This file is kept so existing test imports
+ * (`./auto-compact.js` from `auto-compact.test.ts`) and any other relative
+ * importers inside the `anthropic-direct/` subtree continue to resolve
+ * without modification.
  *
  * @module agent/providers/anthropic-direct/query/auto-compact
  */
 
-import type { ProviderUsage } from '../../../provider.js';
+export {
+  computeUsedTokens,
+  contextWindowTokensUsed,
+  buildContextUsageFields,
+  shouldAutoCompact,
+} from '../../shared/auto-compact.js';
 
-/**
- * Cumulative billed tokens for a turn: `inputTokens + outputTokens`.
- *
- * This is the FALLBACK for {@link contextWindowTokensUsed} (used when a
- * provider has not populated {@link ProviderUsage.contextWindowTokens}) and the
- * `/tokens` total. It deliberately omits cache: `sumProviderUsage` accumulates
- * input/output cumulatively across tool-loop rounds but keeps cache fields at
- * their latest (last-round) value, so summing the two is a mixed basis. The
- * real context-window footprint is computed per-round at the provider — see
- * {@link ProviderUsage.contextWindowTokens}.
- *
- * Contract: returns input + output only. (A prior comment here claimed
- * Anthropic's `input_tokens` "already includes cache reads" — that is wrong.
- * Per the Anthropic API docs, `input_tokens` counts only tokens NOT read from
- * or used to create a cache; total = input + cache_read + cache_creation.
- * https://platform.claude.com/docs/en/build-with-claude/prompt-caching)
- */
-export function computeUsedTokens(usage: Partial<ProviderUsage>): number {
-  return (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
-}
-
-/**
- * Context-window footprint for the latest model call — the value that drives
- * the context-usage % and auto-compaction. Prefers the provider-computed
- * {@link ProviderUsage.contextWindowTokens} (correct per-provider cache
- * accounting) and falls back to {@link computeUsedTokens} when absent.
- */
-export function contextWindowTokensUsed(usage: Partial<ProviderUsage>): number {
-  return usage.contextWindowTokens ?? computeUsedTokens(usage);
-}
-
-/**
- * Snake_case per-field last-turn API usage, matching the shape both the
- * `/tokens` command (src/cli/slash/commands/info.ts) and the status-line
- * sampler (src/cli/context-sampler.ts) read off `apiUsage`.
- */
-// A `type` alias (not `interface`) so it stays assignable to the
-// `Record<string, unknown>` shape that ProviderContextUsage.apiUsage expects —
-// interfaces are open to declaration merging and TS refuses the assignment.
-export type ContextUsageApiBreakdown = {
-  input_tokens: number;
-  output_tokens: number;
-  cache_read_input_tokens: number;
-  cache_creation_input_tokens: number;
-};
-
-/** Consumer-facing context-usage fields derived from a completed turn. */
-export interface ContextUsageFields {
-  totalTokens: number;
-  apiUsage: ContextUsageApiBreakdown | null;
-}
-
-/**
- * Translate a provider's native {@link ProviderUsage} (camelCase) into the
- * SDK-shaped context-usage fields the REPL consumers read.
- *
- * Contract: `SDKControlGetContextUsageResponse` (src/agent/types/sdk-types.ts)
- * declares `totalTokens: number` and a snake_case `apiUsage`. The provider's
- * `getContextUsage()` returns the looser `ProviderContextUsage`, so without
- * this translation the consumers read `usage.totalTokens` (→ `undefined`, which
- * `formatTokens` renders as `NaNm`) and `apiUsage.input_tokens` et al. (→
- * `undefined ?? 0` → all zeros). This helper is the single source of truth for
- * that mapping, shared by both the anthropic-direct and openai-compatible
- * providers.
- *
- * - `totalTokens` uses {@link contextWindowTokensUsed} — the provider-computed
- *   context-window footprint (falling back to inputTokens + outputTokens) — so
- *   the displayed total stays consistent with the context-usage percentage,
- *   which is derived from the same value. Deliberately does NOT read
- *   `ProviderUsage.totalTokens` — that field is provider-dependent and would
- *   diverge from the percentage.
- * - `apiUsage` carries the raw per-field breakdown (including cache reads /
- *   creation) for the "Last turn (API)" display, and is `null` when no turn has
- *   completed yet — matching the SDK response's nullable contract.
- */
-export function buildContextUsageFields(
-  last: ProviderUsage | null | undefined,
-): ContextUsageFields {
-  if (!last) {
-    return { totalTokens: 0, apiUsage: null };
-  }
-  return {
-    totalTokens: contextWindowTokensUsed(last),
-    apiUsage: {
-      input_tokens: last.inputTokens ?? 0,
-      output_tokens: last.outputTokens ?? 0,
-      cache_read_input_tokens: last.cachedInputTokens ?? 0,
-      cache_creation_input_tokens: last.cacheCreationTokens ?? 0,
-    },
-  };
-}
-
-/**
- * Return true when automatic compaction should be triggered.
- *
- * @param usedTokens  - Total tokens consumed in the last turn
- *   (`inputTokens + outputTokens` — see {@link computeUsedTokens}).
- *   A value <= 0 means usage is unknown — returns false in that case.
- * @param contextLimit - Model's full context window in tokens.
- *   A value <= 0 means the limit is unknown — returns false.
- * @param threshold - Fraction of the context window (0–1 exclusive) at which
- *   to trigger. Defaults to 0.90. Values outside (0, 1) are treated as
- *   disabled and return false.
- */
-export function shouldAutoCompact(
-  usedTokens: number,
-  contextLimit: number,
-  threshold: number,
-): boolean {
-  if (contextLimit <= 0) return false;
-  if (usedTokens <= 0) return false;
-  if (threshold <= 0 || threshold >= 1) return false;
-  return usedTokens / contextLimit >= threshold;
-}
+export type {
+  ContextUsageApiBreakdown,
+  ContextUsageFields,
+} from '../../shared/auto-compact.js';

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -47,8 +47,8 @@ import type {
 import { sumProviderUsage } from '../../usage.js';
 import { contextLimitFor, maxOutputTokensFor } from '../../model-limits.js';
 import { resolveModelId } from '../../session/model-resolution.js';
-import { collectSkillEntries } from '../../tools/skill-bridge.js';
 import { extractRawToolInput } from '../../facets/raw-input.js';
+import { collectSupportedCommands } from '../shared/supported-commands.js';
 import { debugLog } from '../../../utils/debug.js';
 import {
   resolveOpenAIAuth,
@@ -81,9 +81,11 @@ import { resolveWireMode, envFlagEnabled, isClaudeFamilyModel, DEFAULT_RESPONSES
 import { env } from '../../../config/env.js';
 import type { ToolDispatcher } from '../anthropic-direct/tool-dispatcher.js';
 import type { ToolResult } from '../anthropic-direct/types.js';
-import { contextWindowTokensUsed, buildContextUsageFields } from '../anthropic-direct/query/auto-compact.js';
-import { PLAN_MODE_ADDENDUM_TEXT } from '../anthropic-direct/plan-mode-addendum.js';
-import { AFK_MODE_ADDENDUM_TEXT } from '../anthropic-direct/afk-mode-addendum.js';
+import { contextWindowTokensUsed, buildContextUsageFields } from '../shared/auto-compact.js';
+import { PLAN_MODE_ADDENDUM_TEXT } from '../shared/plan-mode-addendum.js';
+import { AFK_MODE_ADDENDUM_TEXT } from '../shared/afk-mode-addendum.js';
+import { sleepWithAbort } from '../shared/sleep-with-abort.js';
+import { summarizeToolInput } from '../shared/tool-input-summary.js';
 
 const PROVIDER_NAME = 'openai-compatible';
 
@@ -164,15 +166,6 @@ function isRetryableStreamError(err: unknown): boolean {
   const status = getErrorStatus(err);
   if (status === undefined) return false;
   return RETRYABLE_STATUS_CODES.has(status);
-}
-
-function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
-  return new Promise((resolve) => {
-    if (signal.aborted) { resolve(); return; }
-    const timer = setTimeout(resolve, ms);
-    timer.unref();
-    signal.addEventListener('abort', () => { clearTimeout(timer); resolve(); }, { once: true });
-  });
 }
 
 /**
@@ -1239,29 +1232,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
   }
 
   async supportedCommands(): Promise<ProviderCommandInfo[]> {
-    // Mirrors anthropic-direct/query.ts:supportedCommands — surfaces every
-    // skill discovered by skill-bridge (built-in TS skills, ~/.afk/skills/,
-    // and plugin SKILL.md files) so the REPL slash registry can register a
-    // passthrough /<skill> for each one. Without this, /reload-plugins
-    // reports 0 skills on OpenAI sessions and typing /mint does not
-    // autocomplete. collectSkillEntries() is provider-agnostic (no model
-    // SDK imports) so the body lifts unchanged.
-    //
-    // Extract to a shared helper module when a third provider lands.
-    try {
-      const entries = collectSkillEntries();
-      return entries.map((e) => {
-        const info: ProviderCommandInfo = {
-          name: e.name,
-          description: e.description,
-        };
-        if (e.argumentHint) info.argumentHint = e.argumentHint;
-        return info;
-      });
-    } catch {
-      // Discovery is best-effort — the REPL stays usable without it.
-      return [];
-    }
+    return collectSupportedCommands();
   }
 
   async supportedModels(): Promise<ProviderModelInfo[]> {
@@ -1356,38 +1327,6 @@ function defaultClientFactory(opts: {
   if (opts.baseURL !== undefined) clientOpts.baseURL = opts.baseURL;
   if (opts.defaultHeaders !== undefined) clientOpts.defaultHeaders = opts.defaultHeaders;
   return new OpenAI(clientOpts);
-}
-
-/**
- * Best-effort one-line summary of a tool input. Mirrors the same-named
- * helper in anthropic-direct/loop.ts so `tool.use.start` events render
- * identically across providers.
- */
-function summarizeToolInput(toolName: string, input: unknown): string {
-  if (!input || typeof input !== 'object') return '';
-  const obj = input as Record<string, unknown>;
-  // Skill dispatch: the `name` field IS the skill being invoked (diagnose,
-  // review, mint, …). Surface it as a paren-wrapped label so the tool lane
-  // renders `skill(diagnose)` instead of a bare `skill [skill]`. Mirrors the
-  // anthropic-direct helper exactly so labels render identically across
-  // providers — see the rationale comment in anthropic-direct/loop.ts.
-  if (toolName === 'skill' || toolName === 'Skill') {
-    const skillName = obj['name'];
-    if (typeof skillName === 'string' && skillName.length > 0) {
-      return `(${skillName.length > 60 ? skillName.slice(0, 59) + '…' : skillName})`;
-    }
-    return '';
-  }
-  const path = obj['file_path'] ?? obj['path'] ?? obj['filePath'];
-  if (typeof path === 'string') return ' ' + path;
-  const cmd = obj['command'] ?? obj['cmd'];
-  if (typeof cmd === 'string') {
-    const firstLine = cmd.split('\n')[0]!;
-    return ' ' + (firstLine.length > 80 ? firstLine.slice(0, 77) + '…' : firstLine);
-  }
-  const query = obj['query'] ?? obj['pattern'] ?? obj['url'] ?? obj['description'];
-  if (typeof query === 'string') return ' ' + query;
-  return '';
 }
 
 /**

--- a/src/agent/providers/shared/afk-mode-addendum.ts
+++ b/src/agent/providers/shared/afk-mode-addendum.ts
@@ -1,0 +1,64 @@
+/**
+ * AFK-mode system-prompt addendum — provider-neutral.
+ *
+ * When the session is in `'autonomous'` permission mode (AFK mode), this module
+ * supplies a single text block that the provider's `composeSystem()` appends to
+ * the system payload. The addendum is the *posture* half of AFK mode — its
+ * companion is the hook-layer refusal in {@link module:agent/afk-mode-gate},
+ * which is the *enforcement* half (the mechanical safety ceiling).
+ *
+ * Design notes:
+ *  - The posture is **bounded autonomy, not YOLO.** It tells the model to act
+ *    on reversible work without waiting, but to STOP at one-way doors
+ *    (irreversible / external / genuinely ambiguous forks) and surface an
+ *    Asking summary to Telegram instead of guessing. The text explicitly defers
+ *    to the gate: the model is told a mechanical layer refuses high-risk ops
+ *    regardless of what it decides, so it should not treat the posture as a
+ *    licence to bypass safety.
+ *  - The channel to the operator is Telegram via the `send_telegram` tool —
+ *    `send_telegram` is the one outbound op the gate never blocks.
+ *  - The block carries no `cache_control` of its own — `withSystemBreakpoint`
+ *    in `cache-policy.ts` floats the breakpoint to whichever block is last, so
+ *    toggling AFK mode busts the cache once (correct) and same-mode turns hit
+ *    cleanly. This mirrors the plan-mode addendum's cache behaviour exactly.
+ *  - AFK mode and plan mode are mutually exclusive permission modes, so at most
+ *    one of the two addenda is ever appended in a turn.
+ *
+ * Previously located at `anthropic-direct/afk-mode-addendum.ts`. Moved here
+ * because both the anthropic-direct and openai-compatible providers consume
+ * these exports. The original file now re-exports from this location so
+ * existing imports continue to resolve without change.
+ *
+ * @module agent/providers/shared/afk-mode-addendum
+ */
+
+import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
+
+export const AFK_MODE_ADDENDUM_TEXT = [
+  '## AFK mode is active',
+  '',
+  'The operator is away from keyboard. Your channel to them is Telegram via the `send_telegram` tool — not this transcript, which no one is watching live. At the end of each turn, push your terminal state (Done / Blocked / Asking) to Telegram so the operator can review asynchronously.',
+  '',
+  'Posture — bounded autonomy, not unchecked action:',
+  '  - Proceed autonomously on reversible work. Do not stop to confirm actions you are already authorized to take and can undo (edits, reads, tests, local commits, non-force pushes, installs).',
+  '  - At a one-way door — anything irreversible, externally visible, credential- or payment-touching, or where multiple readings lead to materially different work — do NOT guess. Push a concise Asking summary to Telegram naming the decision and your recommended default, then stop and end the turn in the Asking state.',
+  '  - A mechanical gate refuses high-risk and irreversible operations at the hook layer regardless of this text. Treat a gate refusal as a signal to surface the decision to the operator, not an obstacle to work around.',
+  '',
+  'Communication discipline:',
+  '  - Batch updates. Send a Telegram message at terminal state (and at a genuinely blocking fork), not a play-by-play — the operator gets a push notification for every message.',
+  '  - Keep pushes short and scannable: what happened, what changed, what (if anything) you need. Never paste raw tool output, logs, secrets, or full file contents into a push.',
+  '',
+  'Exit: the operator returns and runs `/afk off` (or Shift+Tab) to restore default permissions and terminal-channel interaction.',
+].join('\n');
+
+/**
+ * Returns the addendum block when the session is in `'autonomous'` (AFK) mode,
+ * else `null`. The block is a plain text content block with no `cache_control`
+ * stamp (the breakpoint stamper handles cache markers).
+ */
+export function buildAfkModeAddendumBlock(
+  mode: string | undefined,
+): ContentBlockParam | null {
+  if (mode !== 'autonomous') return null;
+  return { type: 'text', text: AFK_MODE_ADDENDUM_TEXT };
+}

--- a/src/agent/providers/shared/auto-compact.ts
+++ b/src/agent/providers/shared/auto-compact.ts
@@ -1,0 +1,131 @@
+/**
+ * Auto-compaction threshold logic — provider-neutral.
+ *
+ * Intentionally pure — no I/O, no logging, no side effects. The caller
+ * (each provider's turn loop) reads the result and decides whether to fire
+ * `compact()`.
+ *
+ * Previously located at `anthropic-direct/query/auto-compact.ts`. Moved here
+ * because both the anthropic-direct and openai-compatible providers consume
+ * these helpers. The original file now re-exports from this location so
+ * existing test imports continue to resolve without change.
+ *
+ * @module agent/providers/shared/auto-compact
+ */
+
+import type { ProviderUsage } from '../../provider.js';
+
+/**
+ * Cumulative billed tokens for a turn: `inputTokens + outputTokens`.
+ *
+ * This is the FALLBACK for {@link contextWindowTokensUsed} (used when a
+ * provider has not populated {@link ProviderUsage.contextWindowTokens}) and the
+ * `/tokens` total. It deliberately omits cache: `sumProviderUsage` accumulates
+ * input/output cumulatively across tool-loop rounds but keeps cache fields at
+ * their latest (last-round) value, so summing the two is a mixed basis. The
+ * real context-window footprint is computed per-round at the provider — see
+ * {@link ProviderUsage.contextWindowTokens}.
+ *
+ * Contract: returns input + output only. (A prior comment here claimed
+ * Anthropic's `input_tokens` "already includes cache reads" — that is wrong.
+ * Per the Anthropic API docs, `input_tokens` counts only tokens NOT read from
+ * or used to create a cache; total = input + cache_read + cache_creation.
+ * https://platform.claude.com/docs/en/build-with-claude/prompt-caching)
+ */
+export function computeUsedTokens(usage: Partial<ProviderUsage>): number {
+  return (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
+}
+
+/**
+ * Context-window footprint for the latest model call — the value that drives
+ * the context-usage % and auto-compaction. Prefers the provider-computed
+ * {@link ProviderUsage.contextWindowTokens} (correct per-provider cache
+ * accounting) and falls back to {@link computeUsedTokens} when absent.
+ */
+export function contextWindowTokensUsed(usage: Partial<ProviderUsage>): number {
+  return usage.contextWindowTokens ?? computeUsedTokens(usage);
+}
+
+/**
+ * Snake_case per-field last-turn API usage, matching the shape both the
+ * `/tokens` command (src/cli/slash/commands/info.ts) and the status-line
+ * sampler (src/cli/context-sampler.ts) read off `apiUsage`.
+ */
+// A `type` alias (not `interface`) so it stays assignable to the
+// `Record<string, unknown>` shape that ProviderContextUsage.apiUsage expects —
+// interfaces are open to declaration merging and TS refuses the assignment.
+export type ContextUsageApiBreakdown = {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+};
+
+/** Consumer-facing context-usage fields derived from a completed turn. */
+export interface ContextUsageFields {
+  totalTokens: number;
+  apiUsage: ContextUsageApiBreakdown | null;
+}
+
+/**
+ * Translate a provider's native {@link ProviderUsage} (camelCase) into the
+ * SDK-shaped context-usage fields the REPL consumers read.
+ *
+ * Contract: `SDKControlGetContextUsageResponse` (src/agent/types/sdk-types.ts)
+ * declares `totalTokens: number` and a snake_case `apiUsage`. The provider's
+ * `getContextUsage()` returns the looser `ProviderContextUsage`, so without
+ * this translation the consumers read `usage.totalTokens` (→ `undefined`, which
+ * `formatTokens` renders as `NaNm`) and `apiUsage.input_tokens` et al. (→
+ * `undefined ?? 0` → all zeros). This helper is the single source of truth for
+ * that mapping, shared by both the anthropic-direct and openai-compatible
+ * providers.
+ *
+ * - `totalTokens` uses {@link contextWindowTokensUsed} — the provider-computed
+ *   context-window footprint (falling back to inputTokens + outputTokens) — so
+ *   the displayed total stays consistent with the context-usage percentage,
+ *   which is derived from the same value. Deliberately does NOT read
+ *   `ProviderUsage.totalTokens` — that field is provider-dependent and would
+ *   diverge from the percentage.
+ * - `apiUsage` carries the raw per-field breakdown (including cache reads /
+ *   creation) for the "Last turn (API)" display, and is `null` when no turn has
+ *   completed yet — matching the SDK response's nullable contract.
+ */
+export function buildContextUsageFields(
+  last: ProviderUsage | null | undefined,
+): ContextUsageFields {
+  if (!last) {
+    return { totalTokens: 0, apiUsage: null };
+  }
+  return {
+    totalTokens: contextWindowTokensUsed(last),
+    apiUsage: {
+      input_tokens: last.inputTokens ?? 0,
+      output_tokens: last.outputTokens ?? 0,
+      cache_read_input_tokens: last.cachedInputTokens ?? 0,
+      cache_creation_input_tokens: last.cacheCreationTokens ?? 0,
+    },
+  };
+}
+
+/**
+ * Return true when automatic compaction should be triggered.
+ *
+ * @param usedTokens  - Total tokens consumed in the last turn
+ *   (`inputTokens + outputTokens` — see {@link computeUsedTokens}).
+ *   A value <= 0 means usage is unknown — returns false in that case.
+ * @param contextLimit - Model's full context window in tokens.
+ *   A value <= 0 means the limit is unknown — returns false.
+ * @param threshold - Fraction of the context window (0–1 exclusive) at which
+ *   to trigger. Defaults to 0.90. Values outside (0, 1) are treated as
+ *   disabled and return false.
+ */
+export function shouldAutoCompact(
+  usedTokens: number,
+  contextLimit: number,
+  threshold: number,
+): boolean {
+  if (contextLimit <= 0) return false;
+  if (usedTokens <= 0) return false;
+  if (threshold <= 0 || threshold >= 1) return false;
+  return usedTokens / contextLimit >= threshold;
+}

--- a/src/agent/providers/shared/plan-mode-addendum.ts
+++ b/src/agent/providers/shared/plan-mode-addendum.ts
@@ -1,0 +1,71 @@
+/**
+ * Plan-mode system-prompt addendum — provider-neutral.
+ *
+ * When the session is in `'plan'` permission mode, this module supplies a
+ * single text block that the provider's `composeSystem()` appends to the
+ * system payload. The addendum is the *posture* half of plan mode — its
+ * companion is the hook-layer refusal in {@link module:agent/plan-mode-gate}
+ * which is the *enforcement* half.
+ *
+ * Design notes:
+ *  - The text is intentionally short. It names the topology (ground → gather
+ *    → reveal → pressure → embody) and the skill primitives that match each
+ *    step. It does not script a sequence; the model chooses which steps the
+ *    work needs.
+ *  - The block carries no `cache_control` of its own — `withSystemBreakpoint`
+ *    in `cache-policy.ts` floats the breakpoint to whichever block is last,
+ *    so toggling plan mode busts the cache once (correct) and same-mode
+ *    turns hit cleanly.
+ *  - The skill names listed here MUST stay in sync with the bundled-plugin
+ *    skills under `src/bundled-plugins/awa-bundled/skills/`. They are the
+ *    skills the model can already invoke via the `skill` tool; the addendum
+ *    just nominates the relevant subset for the planning topology.
+ *
+ * Previously located at `anthropic-direct/plan-mode-addendum.ts`. Moved here
+ * because both the anthropic-direct and openai-compatible providers (and their
+ * tests) consume these exports. The original file now re-exports from this
+ * location so existing imports continue to resolve without change.
+ *
+ * @module agent/providers/shared/plan-mode-addendum
+ */
+
+import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
+
+export const PLAN_MODE_ADDENDUM_TEXT = [
+  '## Plan mode is active',
+  '',
+  'File and memory write tools (`write_file`, `edit_file`, `memory_update`, `procedure_write`) are refused at the hook layer.',
+  '`bash` runs for read-only investigation (git status/log/diff, ls, cat, grep, find — chained or not); state-mutating bash (file writes, rm, installs, commits, pushes) is refused while planning. The user has asked you to plan, not yet to act — exit plan mode to make changes.',
+  'Treat this turn as planning work.',
+  '',
+  'Traverse the shape that matches the work — skip steps the terrain already covers, do not skip steps the terrain hides:',
+  '',
+  '  unknown field → ground the current terrain → gather missing codebase context →',
+  '  research missing external context → reveal chaos / constraints / risks →',
+  '  name the failure geometry → form a candidate plan → apply adversarial pressure → embody the final plan',
+  '',
+  'Reach for these skills (invoke via the `skill` tool) when the cost of skipping exceeds the cost of dispatching:',
+  '  - `ground-state` — survey git, infra, memory before non-trivial work',
+  '  - `gather` — parallel context-gathering for a code area',
+  '  - `research` — parallel external + local context for the current task',
+  '  - `devils-advocate` — generate alternatives and rank them before committing',
+  '  - `shadow-verify` — independently re-derive load-bearing claims',
+  '',
+  'Do not declare readiness silently. When the plan is ready, state: chosen approach, risks named, and alternatives considered.',
+  '',
+  'Then, IF the task requires implementation (writing code or files), call the `exit_plan_mode` tool to present your plan. The user picks how to proceed (approve and implement, or keep planning). After calling it, END YOUR TURN — on approval you will receive a separate instruction to save the plan to a file and implement it. Do NOT use `ask_question` to ask whether the plan is OK; that is exactly what `exit_plan_mode` does — use `ask_question` only to resolve open requirement questions first. For research / read-only tasks that need no code changes, do NOT call `exit_plan_mode` — just answer.',
+  '',
+  'Manual fallbacks remain: the user can exit with `/plan off` (same save-and-implement handoff), and Shift+Tab advances the permission-mode ring without saving or implementing. Keep the plan concrete and complete enough to act on directly.',
+].join('\n');
+
+/**
+ * Returns the addendum block when the session is in `'plan'` mode, else
+ * `null`. The block is a plain text content block with no `cache_control`
+ * stamp (the breakpoint stamper handles cache markers).
+ */
+export function buildPlanModeAddendumBlock(
+  mode: string | undefined,
+): ContentBlockParam | null {
+  if (mode !== 'plan') return null;
+  return { type: 'text', text: PLAN_MODE_ADDENDUM_TEXT };
+}

--- a/src/agent/providers/shared/sleep-with-abort.ts
+++ b/src/agent/providers/shared/sleep-with-abort.ts
@@ -1,0 +1,26 @@
+/**
+ * Provider-neutral abort-aware sleep helper.
+ *
+ * Resolves immediately when `signal` is already aborted; otherwise waits
+ * `ms` milliseconds, resolving early if the signal fires while sleeping.
+ * The `timer.unref()` call prevents Node.js from keeping the event loop
+ * alive solely due to the timeout — correct for server-side agentic loops
+ * where the process should exit freely when all real work is done.
+ *
+ * Previously duplicated verbatim in:
+ *   - `anthropic-direct/loop.ts`   (`sleepWithAbort`)
+ *   - `openai-compatible/query.ts` (`sleepWithAbort`)
+ *
+ * Both copies have been replaced with an import from this module.
+ *
+ * @module agent/providers/shared/sleep-with-abort
+ */
+
+export function sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) { resolve(); return; }
+    const timer = setTimeout(resolve, ms);
+    timer.unref();
+    signal.addEventListener('abort', () => { clearTimeout(timer); resolve(); }, { once: true });
+  });
+}

--- a/src/agent/providers/shared/supported-commands.ts
+++ b/src/agent/providers/shared/supported-commands.ts
@@ -1,0 +1,48 @@
+/**
+ * Provider-neutral `supportedCommands` helper.
+ *
+ * Surfaces every skill discovered by the skill-bridge — built-in TS skills,
+ * user-scope `~/.afk/skills/`, and plugin SKILL.md files under
+ * `~/.afk/plugins/` — so the REPL slash registry can register a passthrough
+ * `/<skill>` for each one. Without this, `/reload-plugins` reports 0 skills
+ * and typing `/mint` does not autocomplete.
+ *
+ * The model learns about skills via the system-prompt manifest (built from
+ * `collectSkillEntries()` in each provider's query method); reusing the same
+ * collector here keeps the slash list and the manifest in lockstep.
+ *
+ * Previously duplicated verbatim in:
+ *   - `anthropic-direct/query.ts`  (`AnthropicDirectQuery.supportedCommands`)
+ *   - `openai-compatible/query.ts` (`OpenAICompatibleQuery.supportedCommands`)
+ *
+ * Both methods have been replaced with a delegating call to this helper.
+ *
+ * @module agent/providers/shared/supported-commands
+ */
+
+import type { ProviderCommandInfo } from '../../provider.js';
+import { collectSkillEntries } from '../../tools/skill-bridge.js';
+
+/**
+ * Returns `ProviderCommandInfo` for every skill the skill-bridge can discover.
+ * Discovery is best-effort — returns `[]` on any error so the REPL stays
+ * usable without skill plugins installed.
+ */
+export function collectSupportedCommands(): Promise<ProviderCommandInfo[]> {
+  try {
+    const entries = collectSkillEntries();
+    return Promise.resolve(
+      entries.map((e) => {
+        const info: ProviderCommandInfo = {
+          name: e.name,
+          description: e.description,
+        };
+        if (e.argumentHint) info.argumentHint = e.argumentHint;
+        return info;
+      }),
+    );
+  } catch {
+    // Discovery is best-effort — the REPL stays usable without it.
+    return Promise.resolve([]);
+  }
+}

--- a/src/agent/providers/shared/tool-input-summary.ts
+++ b/src/agent/providers/shared/tool-input-summary.ts
@@ -1,0 +1,50 @@
+/**
+ * Provider-neutral tool-input summary helper.
+ *
+ * Produces a one-line annotation appended to `tool.use.start` event labels so
+ * the interactive tool lane renders `read_file /foo/bar.ts` rather than a bare
+ * `read_file [read_file]`. Intentionally pure — no I/O, no SDK imports.
+ *
+ * Previously duplicated verbatim in:
+ *   - `anthropic-direct/loop.ts`   (`summarizeToolInput`)
+ *   - `openai-compatible/query.ts` (`summarizeToolInput`)
+ *
+ * Both copies have been replaced with an import from this module.
+ *
+ * @module agent/providers/shared/tool-input-summary
+ */
+
+/**
+ * Best-effort one-line summary of a tool input, appended to the tool-lane
+ * label in the interactive REPL.
+ *
+ * Skill dispatch: the `name` field IS the skill being invoked (diagnose,
+ * review, mint, …). Surface it as a paren-wrapped label so the tool lane
+ * renders `skill(diagnose)` instead of a bare `skill [skill]` — matching the
+ * `Agent(<label>)` dispatch convention and the paren-wrap signal the overflow
+ * renderer keys on (cli/commands/interactive/tool-lane-render-grouping-overflow.ts).
+ * Unlike `agent`, a skill's label is fully known from the tool input, so it
+ * needs no deferred mergeAgentLabel promotion — and it MUST be surfaced here
+ * because load-mode skills never fork a child Agent row to carry the name.
+ */
+export function summarizeToolInput(toolName: string, input: unknown): string {
+  if (!input || typeof input !== 'object') return '';
+  const obj = input as Record<string, unknown>;
+  if (toolName === 'skill' || toolName === 'Skill') {
+    const skillName = obj['name'];
+    if (typeof skillName === 'string' && skillName.length > 0) {
+      return `(${skillName.length > 60 ? skillName.slice(0, 59) + '…' : skillName})`;
+    }
+    return '';
+  }
+  const path = obj['file_path'] ?? obj['path'] ?? obj['filePath'];
+  if (typeof path === 'string') return ' ' + path;
+  const cmd = obj['command'] ?? obj['cmd'];
+  if (typeof cmd === 'string') {
+    const firstLine = cmd.split('\n')[0]!;
+    return ' ' + (firstLine.length > 80 ? firstLine.slice(0, 77) + '…' : firstLine);
+  }
+  const query = obj['query'] ?? obj['pattern'] ?? obj['url'] ?? obj['description'];
+  if (typeof query === 'string') return ' ' + query;
+  return '';
+}

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -503,7 +503,11 @@ describe('Config Loader', () => {
     const mockedReadFileSync = () => vi.mocked(fs.readFileSync);
     const cwdConfigJson = join(process.cwd(), 'afk.config.json');
 
-    const ENV = ['AFK_MODEL', 'CLAUDE_MODEL', 'AFK_MODEL_SMALL', 'AFK_MODEL_MEDIUM', 'AFK_MODEL_LARGE'];
+    const ENV = [
+      'AFK_MODEL', 'CLAUDE_MODEL',
+      'AFK_MODEL_SMALL', 'AFK_MODEL_MEDIUM', 'AFK_MODEL_LARGE',
+      'AFK_MODEL_LOCAL', 'AFK_MODEL_LOCAL_BASE_URL', 'AFK_MODEL_LOCAL_API_KEY',
+    ];
 
     function mockConfig(json: unknown): void {
       mockedExistsSync().mockImplementation((p) => {


### PR DESCRIPTION
## Summary

Extracts verbatim-duplicated and cross-boundary-imported helpers from both providers into a new `src/agent/providers/shared/` directory, eliminating the duplication the code comments already called out.

## Changes

### (A) Fix env-bleed test flakiness
`src/cli/config.test.ts` model-slots `beforeEach`/`afterEach` now clears `AFK_MODEL_LOCAL`, `AFK_MODEL_LOCAL_BASE_URL`, and `AFK_MODEL_LOCAL_API_KEY` in addition to the existing vars — preventing developer shells with those set from bleeding into `DEFAULT_SLOT_BINDINGS` assertions.

### (B) Extract 3 verbatim-duplicated pure functions
New modules in `src/agent/providers/shared/`:
- `sleep-with-abort.ts` — `sleepWithAbort` (was in both `anthropic-direct/loop.ts` and `openai-compatible/query.ts`)
- `tool-input-summary.ts` — `summarizeToolInput` (same files; the comment in openai already said "mirrors anthropic-direct helper exactly")
- `supported-commands.ts` — `collectSupportedCommands` extracted from `supportedCommands()` class method (both providers; the comment in openai already said "Extract to a shared helper module when a third provider lands")

Both inline copies deleted; imports updated.

### (C) Relocate mislocated shared helpers
Three files that `openai-compatible/query.ts` was already importing cross-boundary from `anthropic-direct/` moved to `shared/`:
- `shared/auto-compact.ts` (was `anthropic-direct/query/auto-compact.ts`)
- `shared/plan-mode-addendum.ts` (was `anthropic-direct/plan-mode-addendum.ts`)
- `shared/afk-mode-addendum.ts` (was `anthropic-direct/afk-mode-addendum.ts`)

Original files become thin re-export shims so all existing test imports resolve unchanged. `openai-compatible/query.ts` cross-boundary imports updated to `../shared/*`.

### (D) Deferred
Haiku model-ID divergence (`query.ts:91` `claude-haiku-4-5-20250929` vs `compact-handler.ts:54` `claude-haiku-4-5-20251001`) is pre-existing and masked by `AFK_COMPACT_MODEL` env bleed in the test runner (present on main before this branch). Deferred to avoid false signal.

## Testing

```
pnpm lint          # tsc --noEmit — CLEAN
pnpm exec vitest run src/agent/providers src/cli/config.test.ts --no-cache
# 1 failed (pre-existing: AFK_COMPACT_MODEL env bleed in anthropic-direct.test.ts,
#           reproduced on main/unmodified — not introduced by this branch)
# 789 passed (+1 vs main's 788 passed — the env-bleed config.test fix landed)
```

Part of a top-5 improvements batch.