### PR TITLE
fix(tui): rendering commit-ordering — Phase 2 increment 1

### DIFF
--- a/src/agent/dag-subagent.ts
+++ b/src/agent/dag-subagent.ts
@@ -101,9 +101,10 @@ export async function runSubagentDAG(options: SubagentDAGOptions): Promise<DAGRu
         ...(spec.outputSchema !== undefined ? { outputSchema: spec.outputSchema } : {}),
         // Render hints: lift label + parent anchor through to the CLI so the
         // tool-lane can render `Agent(<label>)` entries nested under the
-        // dispatching tool's entry (e.g. `compose`). Both are optional and
-        // execution-neutral — see ForkSubagentOptions.
-        ...(spec.agentType !== undefined ? { agentType: spec.agentType } : {}),
+        // dispatching tool's entry (e.g. `compose`). agentType is required
+        // on ForkSubagentOptions — fall back to idPrefix when the caller did
+        // not supply an explicit display label.
+        agentType: spec.agentType ?? spec.idPrefix ?? `dag-${spec.id}`,
         ...(spec.parentId !== undefined ? { parentId: spec.parentId } : {}),
       });
 

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -86,13 +86,23 @@ export interface ForkSubagentOptions<T = unknown> {
    */
   outputSchema?: ZodType<T>;
   /**
-   * Optional display label used by the CLI renderer to title the synthesized
-   * `Agent(<label>)` tool-lane entry for this subagent. When omitted, the
-   * renderer falls back to `idPrefix`. Use to give compose-spawned nodes
-   * human-readable labels (e.g. `"diagnose [1/3]"`) without polluting
-   * `idPrefix` — which is also threaded into routing telemetry.
+   * Required display label used by the CLI renderer to title the synthesized
+   * `Agent(<label>)` tool-lane entry for this subagent. Use to give
+   * compose-spawned nodes human-readable labels (e.g. `"diagnose [1/3]"`)
+   * without polluting `idPrefix` — which is also threaded into routing
+   * telemetry.
+   *
+   * Invariant: every `forkSubagent` callsite must supply an explicit label.
+   * The type is `required` (not optional) so future omissions are caught at
+   * compile time rather than silently falling back to the raw `idPrefix` at
+   * render time. Callers that have no better label than `idPrefix` should
+   * pass `agentType: idPrefix` explicitly to document that choice.
+   *
+   * Runtime: empty strings are normalized to `undefined` before use, so
+   * `forkSubagent` still falls back to `idPrefix` if the caller passes `''`.
+   * See `SubagentManager.forkSubagent` (this file, `effectiveAgentType`).
    */
-  agentType?: string;
+  agentType: string;
   /**
    * Optional parent identifier for the renderer's nesting machinery. When
    * provided, overrides the default of `parent.sessionId`. Used by the

--- a/src/skills/audit-fit/index.ts
+++ b/src/skills/audit-fit/index.ts
@@ -391,6 +391,7 @@ async function handler(
             canUseTool: createCanUseTool(),
           },
           idPrefix: `inspector-${cfg.type}`,
+          agentType: `inspector-${cfg.type}`,
           outputSchema: z.array(VerdictSchema),
           ...(skillCallId ? { parentId: skillCallId } : {}),
         }),

--- a/src/skills/diagnose/_phases/orchestrator.ts
+++ b/src/skills/diagnose/_phases/orchestrator.ts
@@ -197,6 +197,7 @@ async function testHypothesisInWorktree(
         canUseTool: createVerifierCanUseTool(),
       },
       idPrefix: `diagnose-verifier-${hypothesis.id}`,
+      agentType: `diagnose-verifier-${hypothesis.id}`,
       outputSchema: VerificationResultSchema,
       ...(skillCallId ? { parentId: skillCallId } : {}),
     });
@@ -380,6 +381,7 @@ export async function handler(
       canUseTool: createReadOnlyCanUseTool(),
     },
     idPrefix: 'diagnose-codebase-research',
+    agentType: 'diagnose-codebase-research',
     ...(skillCallId ? { parentId: skillCallId } : {}),
   });
 
@@ -402,6 +404,7 @@ export async function handler(
       canUseTool: createGitOrchestratorCanUseTool(),
     },
     idPrefix: 'diagnose-git-research',
+    agentType: 'diagnose-git-research',
     ...(skillCallId ? { parentId: skillCallId } : {}),
   });
 
@@ -437,6 +440,7 @@ export async function handler(
       canUseTool: createReadOnlyCanUseTool(),
     },
     idPrefix: 'diagnose-hypothesis-synthesis',
+    agentType: 'diagnose-hypothesis-synthesis',
     outputSchema: z.object({
       hypotheses: z.array(HypothesisSchema),
     }),

--- a/src/skills/mint/_phases/build.ts
+++ b/src/skills/mint/_phases/build.ts
@@ -58,6 +58,7 @@ export async function runBuildPhase(
       apiKey: getApiKey(),
     },
     idPrefix: 'mint-build',
+    agentType: 'mint-build',
     outputSchema: BuildOutputSchema,
     ...(skillCallId ? { parentId: skillCallId } : {}),
   });

--- a/src/skills/mint/_phases/heal.ts
+++ b/src/skills/mint/_phases/heal.ts
@@ -106,6 +106,7 @@ export async function runHealPhase(
         apiKey: getApiKey(),
       },
       idPrefix: 'mint-heal',
+      agentType: 'mint-heal',
       ...(skillCallId ? { parentId: skillCallId } : {}),
     });
 

--- a/src/skills/mint/_phases/parallelize-dispatch.ts
+++ b/src/skills/mint/_phases/parallelize-dispatch.ts
@@ -123,6 +123,7 @@ export async function runParallelizeDispatch(
           env: { PLUGIN_ROOT: skill.pluginPath },
         },
         idPrefix: 'mint-parallelize',
+        agentType: 'mint-parallelize',
         ...(skillCallId ? { parentId: skillCallId } : {}),
       });
       const result = await handle.runToResult(JSON.stringify({ plan }));

--- a/src/skills/mint/_phases/plan.ts
+++ b/src/skills/mint/_phases/plan.ts
@@ -38,6 +38,7 @@ export async function runPlanPhase(
       apiKey: getApiKey(),
     },
     idPrefix: 'mint-plan',
+    agentType: 'mint-plan',
     phaseRole: 'read-only',
     ...(skillCallId ? { parentId: skillCallId } : {}),
   });

--- a/src/skills/mint/_phases/research.ts
+++ b/src/skills/mint/_phases/research.ts
@@ -38,6 +38,7 @@ export async function runResearchPhase(
       apiKey: getApiKey(),
     },
     idPrefix: 'mint-research',
+    agentType: 'mint-research',
     phaseRole: 'read-only',
     ...(skillCallId ? { parentId: skillCallId } : {}),
   });

--- a/src/skills/mint/_phases/ship.ts
+++ b/src/skills/mint/_phases/ship.ts
@@ -40,6 +40,7 @@ export async function runShipPhase(
       apiKey: getApiKey(),
     },
     idPrefix: 'mint-ship',
+    agentType: 'mint-ship',
     ...(skillCallId ? { parentId: skillCallId } : {}),
   });
 

--- a/src/skills/mint/_phases/spec.ts
+++ b/src/skills/mint/_phases/spec.ts
@@ -40,6 +40,7 @@ export async function runSpecPhase(
       apiKey: getApiKey(),
     },
     idPrefix: 'mint-spec',
+    agentType: 'mint-spec',
     phaseRole: 'read-only',
     ...(skillCallId ? { parentId: skillCallId } : {}),
   });

--- a/src/skills/mint/_phases/verify.ts
+++ b/src/skills/mint/_phases/verify.ts
@@ -51,6 +51,7 @@ async function forkVerifyMode(
       apiKey: getApiKey(),
     },
     idPrefix: `mint-verify-${mode}`,
+    agentType: `mint-verify-${mode}`,
     outputSchema: VerifyModeOutputSchema,
     ...(skillCallId ? { parentId: skillCallId } : {}),
   });

--- a/src/skills/user-skills.ts
+++ b/src/skills/user-skills.ts
@@ -187,6 +187,7 @@ function makeUserSkillHandler(parsed: ParsedSkillMd): SkillMetadata['handler'] {
         isSkillDispatch: true,
       },
       idPrefix: `user-skill-${parsed.name}`,
+      agentType: `user-skill-${parsed.name}`,
       ...(skillCallId ? { parentId: skillCallId } : {}),
     });
 


### PR DESCRIPTION
## Summary

Enforces the `agentType` render-label invariant at the TypeScript type boundary (Phase 2 increment 1 of the rendering refactor described in `docs/specs/phase-2-rendering-refactor.md`).

## Increment scope

**Spec §2d — agentType propagation invariant (Bug #2)**: Makes `agentType` a *required* field on `ForkSubagentOptions` so future omissions are caught at compile time rather than silently falling back to the raw `idPrefix` at render time. All 15 existing callsites are migrated.

**Why this increment:** The five underlying TUI rendering bugs (#1 CommitCoordinator, #2 agentType label, #3 bounded stall, #4 counter unification, #5 assignConnectors) are already implemented and tested in `main`. The one remaining spec item from §2d was the compile-time enforcement: making `agentType: string` (required) instead of `agentType?: string` (optional). This is the smallest independently-shippable piece that adds a real regression-prevention guarantee without touching the rendering pipeline itself.

## Changes

| File | Change |
|------|--------|
| `src/agent/subagent.ts` | `agentType?: string` → `agentType: string`; updated JSDoc to document invariant |
| `src/agent/dag-subagent.ts` | Replace conditional `agentType` spread with explicit `agentType: spec.agentType ?? spec.idPrefix ?? `dag-${spec.id}`` |
| `src/skills/mint/_phases/{build,heal,parallelize-dispatch,plan,research,ship,spec,verify}.ts` | Add `agentType: idPrefix` to each `forkSubagent` call |
| `src/skills/user-skills.ts` | Add `agentType: `user-skill-${parsed.name}`` |
| `src/skills/diagnose/_phases/orchestrator.ts` | Add `agentType: idPrefix` to 4 `forkSubagent` calls |
| `src/skills/audit-fit/index.ts` | Add `agentType: `inspector-${cfg.type}`` |

The 4 callers that already passed `agentType` (`subagent-executor.ts`, `skill-executor.ts` ×2, `compose-executor.ts`) are **unchanged**.

## Testing

```bash
pnpm lint          # tsc --noEmit — clean (0 errors)
pnpm exec vitest run src/cli/_lib/stream-renderer-ordering.test.ts src/cli/commands/interactive/tool-lane.test.ts src/cli/_lib/commit-coordinator.test.ts src/agent/subagent.test.ts --no-cache
# 172 tests pass (14 ordering + 99 tool-lane + 20 coordinator + 39 subagent)
```

Pre-existing failures (2): `anthropic-direct.test.ts` model-name test — unrelated, present on `main` before this branch.

## Remaining increments (deferred — all from docs/specs/phase-2-rendering-refactor.md)

The following spec items are already implemented in `main` and tested; this PR does not re-land them but they are documented here for traceability:

- **§2a** CommitCoordinator + ordering fix + `committing` guard (Bug #1) — `commit-coordinator.ts` exists, all 14 ordering tests green
- **§2b** Declarative `assignConnectors` (Bug #5) — `tool-lane-render-children.ts` uses `assignConnectors` before both overflow and result-summary; 99 tool-lane tests green
- **§2c** Counter unification / `progressReportedToolUses` isolation (Bug #4) — `stream-renderer-subagent.ts` writes to advisory field; tests green
- **§2e** Bounded stall lifecycle / 2K-tick auto-settle (Bug #3) — `stream-renderer-lifecycle.ts` implements `checkPauseAnnotations` with K=375 and 2K hard cutoff; tests green
- **§2f** Hygiene (spinner events, SIGINT routing, markdown wrap, `logUpdate.done()`) — already in `main`

Part of a top-5 TUI improvements batch. This is increment 1 of the §2d compile-time invariant; remaining increments from the spec are already shipped.