### PR TITLE
docs(website): bring Fumadocs site up to date with code

### DIFF
--- a/website/content/docs/configuration/browser.mdx
+++ b/website/content/docs/configuration/browser.mdx
@@ -127,6 +127,76 @@ The witness layer redacts known credential formats (AWS keys, OpenAI bearer
 tokens, GitHub PATs, Slack tokens, JWTs, `password=` form values) before
 persisting. The page receives the real value; only the trace file is redacted.
 
+## Driving your real Chrome (`afk browser`)
+
+The native `browser_*` tools use Playwright against an isolated Chromium instance — they cannot attach to your real, logged-in Chrome profile. The `afk browser` command group wires Google's [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp) into agent-afk's MCP client so the agent can drive the browser you're already signed into.
+
+### Why not Playwright?
+
+Chrome 136+ refuses `--remote-debugging-port` on the default user-data-dir, and Chrome M144's sanctioned `--autoConnect` consent flow requires Puppeteer's `handleDevToolsAsPage` option, which Playwright lacks. `chrome-devtools-mcp` vendors Puppeteer and implements the `--autoConnect` flow, so wiring it in via MCP is the supported path.
+
+### Subcommands
+
+#### `afk browser connect`
+
+Writes a `chrome-devtools` entry to `~/.afk/config/mcp.json` (idempotent — preserves any other servers you have configured) and prints one-time setup steps.
+
+```bash
+afk browser connect                    # target stable Chrome (default)
+afk browser connect --channel canary   # target Chrome Canary's profile
+```
+
+**Flag:**
+
+| Flag | Values | Default | Description |
+|------|--------|---------|-------------|
+| `--channel <channel>` | `stable`, `beta`, `canary`, `dev` | `stable` | Chrome channel whose default profile `--autoConnect` targets |
+
+The MCP entry written looks like:
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["chrome-devtools-mcp@latest", "--autoConnect"]
+    }
+  }
+}
+```
+
+Non-stable channels append `--channel <channel>` to that `args` array.
+
+#### `afk browser disconnect`
+
+Removes the `chrome-devtools` entry from `~/.afk/config/mcp.json`.
+
+```bash
+afk browser disconnect
+```
+
+No flags. Safe to run even if the entry is not present (prints a warning and exits cleanly).
+
+### One-time Chrome setup
+
+1. Open `chrome://inspect/#remote-debugging` and **enable** remote debugging.
+2. The first time the agent drives Chrome, click **Allow** on the prompt Chrome shows.
+3. A *"being controlled by automated test software"* banner appears in Chrome while a session is active — that is expected.
+
+**Requirement:** Chrome ≥ 144. The `connect` command detects your installed version and warns if it is too old.
+
+### How it relates to the native browser tools
+
+Once connected, the agent gains `mcp__chrome-devtools__*` tools (`navigate_page`, `click`, `fill`, `take_snapshot`, `take_screenshot`, …) that operate on your real profile. The native `browser_*` tools (Playwright / isolated Chromium) remain available alongside them for throwaway automation that does not need your real logins. Run `/mcp` in the REPL to confirm the `chrome-devtools` server connected.
+
+### Security note
+
+The consent flow is intentionally human-gated and cannot be bypassed: you enable it once at `chrome://inspect`, then approve each new session. While connected, the agent can read and interact with anything in your logged-in profile — only connect when you want it acting as you.
+
+### Known limitation
+
+`chrome-devtools-mcp`'s `take_screenshot` returns an image, but agent-afk's MCP bridge currently text-stubs image results, so those screenshots are not yet visible to the model. Use `take_snapshot` (an accessibility-tree snapshot) as the primary automation surface; it works today.
+
 ## Troubleshooting
 
 **`browserType.launch: Executable doesn't exist`** — run

--- a/website/content/docs/configuration/environment-variables.mdx
+++ b/website/content/docs/configuration/environment-variables.mdx
@@ -170,6 +170,7 @@ These three tune the path-approval and bash-restriction hooks — see [Permissio
 | `AFK_DEBUG_COMPOSITOR` | boolean | Gate compositor phase-boundary traces to stderr; any truthy value enables. | — |
 | `AFK_DIAGNOSE_BASELINE` | boolean | Kill switch for /diagnose reproducer baseline execution. When set to '0', the /diagnose skill skips executing the detected reproducer command for a ground-truth baseline; default enabled (runs). Set to '0' to disable. | `1` |
 | `AFK_DUMP_PROMPT` | string | Write the resolved system prompt to a file at startup. Accepts a path or 1 for default location. | — |
+| `AFK_RUN_RECEIPT_DISABLED` | boolean | Disable the post-session run receipt (state/receipts/&lt;label&gt;.json and .md). Set to 1 to skip receipt writes; the underlying witness trace is unaffected. Receipts are also implicitly off when AFK_TRACE_DISABLED=1 (no trace to summarize). | — |
 | `AFK_SESSION_LEDGER_DISABLED` | boolean | Disable the per-session durable event ledger (state/sessions/&lt;id&gt;/events.jsonl). Set to 1 to skip ledger writes; live cross-surface watching (e.g. the Telegram /watch command) will report no activity for sessions started while disabled. | — |
 | `AFK_SKILL_STREAM_VERBOSE` | boolean | Verbose streaming output when a skill is dispatched. Logs sub-agent setup, intermediate events, and final result. | — |
 | `AFK_TELEGRAM_TRACE` | boolean | Set to 1 to dump raw bridge traffic between the agent and the Telegram bot — debugging only. | — |
@@ -185,6 +186,7 @@ These three tune the path-approval and bash-restriction hooks — see [Permissio
 | `AFK_BANNER_PLAIN` | boolean | Suppress the ANSI-colored banner at REPL startup. Useful for non-TTY captures and CI logs. | — |
 | `AFK_DEMO_CLEAN` | boolean | Explicit opt-in to capture-mode. When set to 1, suppresses high-frequency repaint drivers (spinner ticker, live thinking-preview) so recorded artifacts contain each state once instead of once per timer tick. | — |
 | `AFK_DIFF_LINES` | number | Maximum number of diff lines shown in the inline diff render during write_file tool calls. Set to 0 for no cap. Non-integer values are silently ignored and the default applies. | — |
+| `AFK_MEMORY_EVIDENCE_GATE` | boolean | Opt-in (set to 1) evidence gate for durable memory writes. When enabled, a codebase fact (memory_update category "convention") stored without an `evidence` citation is recalled as [unverified], and memory_search results carry a verification verdict. User preferences and agent reflections are never gated. Default off — memory behaves identically to legacy when unset. | — |
 | `AFK_SHELL_PASSTHROUGH` | boolean | Enable the interactive REPL `!cmd` / `!&cmd` shell-passthrough feature. On by default. Set to 0, false, off, or no (case-insensitive) to disable, so inputs beginning with ! are sent to the model as literal text instead of being executed as shell commands. Equivalent to the --no-shell-passthrough flag. | `1` |
 | `AFK_SHOW_DIFFS` | boolean | Show inline diffs in the tool-lane output for edit/write tool calls. 1 = on, 0 = off. | — |
 | `AFK_SPINNER_TIPS` | boolean | Show rotating tips in the loading spinner during long calls. 1 = on, 0 = off. | — |

--- a/website/content/docs/configuration/model-slots.mdx
+++ b/website/content/docs/configuration/model-slots.mdx
@@ -21,6 +21,8 @@ An unconfigured install uses these defaults:
 | `medium` | `claude-sonnet-4-6` | `sonnet`, `sonnet_1m` |
 | `large` | `claude-opus-4-8` | `opus`, `opus_1m` |
 
+**Note:** These default model IDs reflect the latest available models as of this writing. As new versions ship, these defaults are updated in the codebase (`src/agent/session/model-slots.ts`). You can override any slot via environment variables (`AFK_MODEL_SMALL`, `AFK_MODEL_MEDIUM`, `AFK_MODEL_LARGE`) or `afk.config.json` — see [Configuring slots](/docs/configuration/model-slots#configuring-slots-in-afkconfigjson) for details.
+
 If you never touch slots, behavior is identical to before this feature existed.
 
 ## Configuring slots in `afk.config.json`

--- a/website/content/docs/configuration/overview.mdx
+++ b/website/content/docs/configuration/overview.mdx
@@ -308,14 +308,20 @@ user-global file.
 
 #### Event keys
 
-| Event | Fires when |
-|-------|-----------|
-| `PreToolUse` | Before a tool call is dispatched. The hook can block the call. |
-| `PostToolUse` | After a tool call completes. |
-| `SessionStart` | At the start of a session. |
-| `SessionEnd` | When a session finishes. |
-| `SubagentStart` | When a subagent session is forked. |
-| `SubagentStop` | When a subagent session finishes. `hookSpecificOutput.additionalContext` injects text into the parent session. |
+| Event | Fires when | Payload fields (stdin JSON) | Surfaces |
+|-------|-----------|----------------------------|----------|
+| `PreToolUse` | Before a tool call is dispatched. The hook can block the call. | `hook_event_name`, `session_id`, `tool_name`, `tool_input` | All |
+| `PostToolUse` | After a tool call completes successfully. | `hook_event_name`, `session_id`, `tool_name`, `tool_output` (omitted when undefined) | All |
+| `SessionStart` | At the start of a session. | `hook_event_name`, `session_id` | All |
+| `SessionEnd` | When a session finishes. | `hook_event_name`, `session_id`, `reason` | All |
+| `SubagentStart` | When a subagent session is forked. | `hook_event_name`, `session_id` | All |
+| `SubagentStop` | When a subagent session finishes. `hookSpecificOutput.additionalContext` injects text into the parent session. | `hook_event_name`, `session_id` | All |
+| `Stop` | After a main-session turn completes (end of one agent turn). Dispatched from the REPL turn loop only — subagents do not fire it. | `hook_event_name`, `session_id` | REPL only |
+| `UserPromptSubmit` | When the user submits a prompt in the REPL, after shell injection and forward-manifest stitching but before `runTurn`. Handler can return `injectContext` to prepend text to the prompt. | `hook_event_name`, `session_id`, `prompt` | REPL only |
+| `PreCompact` | Before context compaction runs. `trigger` is `"manual"` (via `/compact` command) or `"auto"` (threshold-based, reserved for future wiring). | `hook_event_name`, `session_id`, `trigger` (`null` when unset) | All |
+| `PostToolUseFailure` | After a tool call throws an error. Distinct from `PostToolUse` — only one fires per call. `tool_input` is intentionally not forwarded to shell hooks to avoid exposing sensitive inputs to arbitrary scripts. | `hook_event_name`, `session_id`, `tool_name`, `error` | All |
+
+Every event's payload also includes `cwd` and `transcript_path` (the latter is `null` when no transcript file is tracked).
 
 #### Matcher group fields
 

--- a/website/content/docs/configuration/permissions.mdx
+++ b/website/content/docs/configuration/permissions.mdx
@@ -21,11 +21,41 @@ A session runs in one permission mode, set by the `permissionMode` key in `afk.c
 |---|---|---|
 | `default` | Path containment + path-approval prompts for out-of-root file access. No per-tool flow. | REPL and Telegram default |
 | `plan` | Read-only investigation; write-class tools are blocked until you approve a plan. | `/plan` in the REPL |
-| `autonomous` | Default containment **plus** a risk gate that blocks high-risk actions, and a remote channel so you can answer prompts from Telegram. | `/afk` in the REPL |
-| `bypassPermissions` | Disables containment and path approval entirely — read/write any path with no prompt. | `/bypass`, `--dangerously-skip-permissions`, or `afk daemon` |
+| `autonomous` | AFK-specific mode (agent-afk `PermissionMode` value). Default containment **plus** a risk gate that refuses high-risk/irreversible actions tree-wide, a system-prompt addendum telling the model to work autonomously on reversible operations, and a Telegram channel that pushes each turn's terminal state so you can supervise from your phone. | `/afk` in the REPL |
+| `bypassPermissions` | Disables containment and path approval entirely — read/write any path with no prompt. | Shift+Tab from `plan`, the `--dangerously-skip-permissions` flag, or `afk daemon` |
 
 The interactive default is `default`, **not** bypass. Plan and autonomous modes are mutually
-exclusive with each other (they share the one mode field).
+exclusive with each other (they share the one `permissionMode` field). `autonomous` is an
+agent-afk–local value; it is not an Anthropic SDK permission level. The internal SDK-level values
+`dontAsk`, `auto`, and `acceptEdits` are not user-facing modes and are not surfaced in the REPL.
+
+### Cycling modes with Shift+Tab
+
+In the REPL, **Shift+Tab** advances through a fixed three-stop ring without leaving the keyboard:
+
+```
+default → plan → bypassPermissions → default → …
+```
+
+`autonomous` (AFK) is intentionally excluded from the ring — entering it activates
+non-idempotent machinery (Telegram push-budget reset, abort-watcher, ledger channel swap) that
+must not fire on a transient keypress. If the session is already in `autonomous`, Shift+Tab exits
+AFK cleanly (running full teardown) and lands on `default`; the next press resumes the ring.
+
+### Leaving plan mode — `exit_plan_mode` escalation
+
+When the model judges its plan ready, it calls the `exit_plan_mode` tool and the REPL presents
+you with a picker:
+
+| Choice | Effect |
+|---|---|
+| **Approve — implement now (restore previous mode)** | Restores the mode you were in *before* entering plan (typically `default`). Implementation begins on the next turn. |
+| **Approve — implement now (bypass mode)** | Escalates to `bypassPermissions` for the implement turn — offered unless you were already in bypass before planning. |
+| **Keep planning** | Stays in plan mode; the model continues refining. |
+
+The permission flip is deferred to the post-turn drain boundary so the plan-mode gate stays
+locked for the entire current model turn, closing a mid-turn TOCTOU window. This is
+behaviorally identical to running `/plan off` yourself.
 
 ## Path-access approval
 
@@ -108,13 +138,9 @@ Bypass mode (`permissionMode: 'bypassPermissions'`) turns the containment off en
 tools may read and write **any** path with no confirmation, and the path-approval prompt never
 fires.
 
-```
-/bypass        # enable bypass for the current REPL session
-/bypass off    # return to default mode
-```
-
-While bypass is active the status line shows a `⚠ BYPASS` badge. From the command line, the
-equivalent is the `--dangerously-skip-permissions` flag on both `afk i` and `afk chat`:
+In the REPL the primary keyboard entry point is **Shift+Tab** (advances the ring
+`default → plan → bypassPermissions`). From the command line, the equivalent is the
+`--dangerously-skip-permissions` flag on both `afk i` and `afk chat`:
 
 ```bash
 afk chat "migrate the schema" --dangerously-skip-permissions
@@ -157,7 +183,7 @@ Three things switch on together:
 
 | Surface | Default mode | Notes |
 |---|---|---|
-| REPL (`afk i`) | `default` | Out-of-root file access prompts inline; `/bypass` to disable containment. |
+| REPL (`afk i`) | `default` | Out-of-root file access prompts inline; cycle to `bypassPermissions` with Shift+Tab to disable containment. |
 | Telegram bot | `default` | Same as the REPL; prompts are pushed to your chat. |
 | `afk chat` | `default` | Non-interactive — out-of-root access can't be approved, so it is denied; pass `--dangerously-skip-permissions` for wide-open access. |
 | `afk daemon` | `bypassPermissions` | Unattended; containment off so no prompt can wedge the run. |

--- a/website/content/docs/guides/headless.mdx
+++ b/website/content/docs/guides/headless.mdx
@@ -15,6 +15,8 @@ Writes the raw `OutputEvent` stream to **stdout** as [NDJSON](https://ndjson.org
 
 ## OutputEvent schema
 
+> This is the canonical reference for the `--format stream-json` event schema, jq recipes, and parsing examples. [`surfaces/chat`](../surfaces/chat) links here for the full specification.
+
 Full event schema: `src/agent/types/session-types.ts`.
 
 - `OutputEvent` — top-level discriminated union

--- a/website/content/docs/guides/mcp-plugins.mdx
+++ b/website/content/docs/guides/mcp-plugins.mdx
@@ -86,7 +86,7 @@ Source: `src/agent/mcp/types.ts` (`McpServerConfig`).
 }
 ```
 
-`${VAR}` placeholders in `env` and `headers` are expanded from the host environment at connect time (not via shell eval). Run `/mcp auth` in the REPL to view and complete any pending OAuth consent flows.
+`${VAR}` placeholders in `env` and `headers` are expanded from the host environment at connect time (not via shell eval). Run `/mcp auth` in the REPL to view and complete any pending OAuth consent flows (the URL is also pushed via Telegram when running headless).
 
 ### Tool naming
 
@@ -98,9 +98,13 @@ mcp__filesystem__read_file
 
 Tools are read fresh per query. When an MCP server sends a `notifications/tools/list_changed` notification, the tool list updates in-place — no session restart needed.
 
+### Surface coverage
+
+MCP servers load on **all surfaces** — REPL, `afk chat`, daemon, and Telegram. Each surface constructs `McpManager` from the resolved config before the `AgentSession` is created, so MCP tools are available regardless of how AFK is invoked.
+
 ### Viewing server status
 
-In the REPL:
+In the REPL, use the `/mcp` slash commands:
 
 ```
 /mcp          # list connected servers and tool counts
@@ -185,6 +189,7 @@ A plugin directory can contain:
 | `agents/<agent>/` | Subagent definition |
 | `commands/<cmd>/` | Slash command |
 | `.claude-plugin/mcp.json` | MCP server config (lowest priority layer) |
+| `main` field in `plugin.json` | JS entrypoint — a module path loaded via dynamic `import()` before `AgentSession` is constructed. Use it to call `registerSkill()` or other side-effecting setup that must run synchronously before the session's skill manifest is assembled. Non-fatal: a failing entrypoint is caught and reported as a warning, never aborting boot. Idempotent per resolved path across plugin reloads. |
 
 Skills from plugins are auto-registered at session start and appear in `/skills` (alias `/builtin-skills`). Use `/reload-plugins` in the REPL to pick up changes after editing a plugin without restarting.
 

--- a/website/content/docs/guides/meta.json
+++ b/website/content/docs/guides/meta.json
@@ -1,1 +1,1 @@
-{"title":"Guides","pages":["unattended-runs","subagents","verification","memory","mcp-plugins","worktrees","headless"]}
+{"title":"Guides","pages":["unattended-runs","subagents","verification","observability","self-improvement","memory","mcp-plugins","worktrees","headless"]}

--- a/website/content/docs/guides/observability.mdx
+++ b/website/content/docs/guides/observability.mdx
@@ -1,0 +1,173 @@
+---
+title: "Observability"
+description: "Inspect what a run did: witness traces (afk trace), full-text transcript search (afk transcript), and the /transcript slash command."
+---
+
+Agent AFK records durable evidence of every unattended run so you can review exactly what happened — without watching the terminal. There are two complementary inspection surfaces: the **witness trace** (structured NDJSON of each event as it happened) and the **transcript search index** (full-text search over saved session Markdown files).
+
+## Witness traces (`afk trace`)
+
+Every agent session appends an append-only NDJSON record to:
+
+```
+~/.afk/state/witness/<session-id>/trace.jsonl
+```
+
+The file is written event-by-event during the run, so it survives crashes and partially-written tails are tolerated — malformed trailing lines are counted and skipped, never fatal.
+
+### What a trace records
+
+Each line is a JSON event with a `kind`, a monotonic `seq`, a timestamp `ts`, and a `payload`. The recorded kinds are:
+
+| Kind | What it captures |
+|---|---|
+| `tool_call` | Every tool invocation: name, duration, result size, error flag, subagent id |
+| `hook_decision` | Hook approvals and blocks, with the blocking reason |
+| `subagent_lifecycle` | Subagent start / success / failure / cancel, with cost and turn count |
+| `background_agent` | Background job start, completion, failure, cancel, and join |
+| `budget` | Cost checkpoints against the configured ceiling |
+| `abort` | Abort origin and cascade count |
+| `compaction` | Context-window compaction: messages before/after, estimated tokens saved |
+| `closure` | Session end reason, final turn count, cost, and the provider `stop_reason` |
+| `claim` | Agent-emitted claims: assertion text, confidence, evidence count |
+| `browser_event` | Browser tool actions and their status |
+| `session_phase` | Latency waterfall (init, TTFB, etc.) — hidden by default, shown with `--all` |
+| `session_sealed` | Final seal status, subagent count, cost (written at clean close) |
+
+### `afk trace list`
+
+List all sessions that have a trace, most recent first:
+
+```bash
+afk trace list
+```
+
+Prints `<timestamp>  <session-id>` rows. Pass `-n` / `--max` to cap the output (default 20, max 200):
+
+```bash
+afk trace list --max 50
+```
+
+### `afk trace show`
+
+Pretty-print a session's trace for human review. With no argument, shows the **most recently written** trace:
+
+```bash
+afk trace show            # latest run
+afk trace show <session>  # a specific session id
+```
+
+**Options:**
+
+| Flag | Meaning |
+|---|---|
+| `--all` | Include low-signal events (latency phases, paired tool-call `started` lines) |
+| `--json` | Emit the raw NDJSON unchanged — pipe to `jq` for programmatic inspection |
+| `-n, --limit <N>` | Show only the last N rendered events |
+
+The default view filters out `session_phase` events and paired tool-call `started` lines — keeping the output scannable. Orphaned `started` events (a tool that began but never returned) are always shown because they indicate a crash or abort mid-call.
+
+### Debugging with traces
+
+Common patterns:
+
+```bash
+# Did the last run finish cleanly?
+afk trace show | grep -E "SEALED|closure"
+
+# What tools ran, and did any error?
+afk trace show | grep "tool"
+
+# Which subagents were launched and how did they end?
+afk trace show | grep "subagent"
+
+# Full latency waterfall
+afk trace show --all | grep "phase"
+
+# Raw dump for scripting
+afk trace show --json | jq '.kind'
+```
+
+Because the trace is written live, you can tail it while a long run is in progress:
+
+```bash
+tail -f ~/.afk/state/witness/<session-id>/trace.jsonl | jq .
+```
+
+---
+
+## Transcript search (`afk transcript`)
+
+In addition to structured traces, AFK saves every session as a plain Markdown transcript at:
+
+```
+~/.afk/state/transcripts/<iso-timestamp>.md
+```
+
+The `afk transcript` commands build and query an **SQLite FTS5 full-text index** over these files — a high-recall complement to the curated fact archive searched by `memory_search`.
+
+### Build the index
+
+The index is not built automatically. Run this once (and re-run whenever you want to catch up on new sessions):
+
+```bash
+afk transcript reindex
+```
+
+Output: `Indexed N transcripts.` The operation is idempotent — safe to run repeatedly. It replaces the index atomically.
+
+### `afk transcript search`
+
+Search the index with an FTS5 query:
+
+```bash
+afk transcript search <query>
+```
+
+**Option:**
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `-n, --limit <N>` | `10` | Maximum results (1–1000) |
+
+**FTS5 query syntax** (passed verbatim to SQLite):
+
+| Syntax | Meaning |
+|---|---|
+| `worktree` | Any transcript containing the word `worktree` |
+| `"afk trace"` | Exact phrase match |
+| `trace*` | Prefix match — `trace`, `traces`, `traced`, … |
+| `subagent AND cost` | Both terms must appear |
+| `telegram OR slack` | Either term |
+
+**Examples:**
+
+```bash
+# Find sessions where you discussed rate limiting
+afk transcript search "rate limit"
+
+# Find any transcript mentioning the daemon scheduler
+afk transcript search "daemon AND cron"
+
+# Find recent sessions mentioning a specific function name
+afk transcript search "resolveBaseSystemPrompt"
+
+# Limit to top 3 results
+afk transcript search "MCP server" --limit 3
+```
+
+Each result shows the session timestamp, filename, and an FTS5-extracted snippet around the match. A malformed FTS5 query (e.g. an unclosed quote) throws a descriptive error rather than silently returning nothing.
+
+---
+
+## The `/transcript` slash command
+
+Inside an interactive REPL session (`afk i`), the `/transcript` slash command opens the **current session's** Markdown transcript in your `$PAGER`:
+
+```
+/transcript
+```
+
+This is useful for reviewing your conversation so far without leaving the session. For searching across past sessions, use `afk transcript search` described above.
+
+See the [Interactive REPL](/surfaces/repl) page for the full list of slash commands.

--- a/website/content/docs/guides/self-improvement.mdx
+++ b/website/content/docs/guides/self-improvement.mdx
@@ -1,0 +1,170 @@
+---
+title: "Self-Improvement Pipeline"
+description: "How afk improve mines session traces to surface failure patterns, triage cards, draft proposals, and generate replay eval-cases."
+---
+
+`afk improve` is a self-improvement pipeline that reads the witness traces AFK writes for every session, runs pattern detectors over them, and produces a chain of artifacts — failure cards → proposals → eval-cases → eval-runs — that guide targeted improvements to the agent's own behavior.
+
+No subcommand in the pipeline makes LLM calls or applies patches. Every step is deterministic and writes artifacts a human reviews before anything changes.
+
+## How it works
+
+The pipeline has four stages:
+
+1. **Scan** — read witness traces, run registered detectors, and write failure cards. Each card captures a named failure pattern (e.g. `repeated-tool-use`), its severity, evidence rows pointing back to source traces, and a status (`open` / `deferred` / `resolved`).
+2. **Cards + triage** — inspect, filter, and annotate cards. Append a note and/or change status on any card without losing prior evidence or notes.
+3. **Propose** — generate a template-mode improvement proposal from a card. The template engine maps the card's pattern to a structured starter proposal a human refines before any patch is written.
+4. **Eval-gen → eval-run** — generate a replay-mode eval-case that slices a byte-identical fixture from the source trace, then run the deterministic validation contract against the live codebase. `eval-run` exits non-zero on regression, making it usable as a CI gate.
+
+Stages are loosely coupled: you can run `scan` repeatedly without generating proposals, or run `eval-run` on an existing eval-case without re-scanning.
+
+## Commands
+
+### `afk improve scan`
+
+Runs all registered detectors against witness traces and prints a summary. **Dry-run by default** — pass `--write` to persist failure cards.
+
+Detectors currently registered: `repeated-tool-use`, `closure-anomaly`, `subagent-block`, `tool-failure-density`. Some detectors are disabled by default; enable them with `--include-disabled` or target them explicitly with `--only`.
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--since <duration>` | `7d` | Only scan sessions newer than this (e.g. `24h`, `all`) |
+| `--write` | off | Persist failure cards. Without this flag, scan is dry-run. |
+| `--min-repeats <n>` | detector default | `repeated-tool-use` threshold |
+| `--closure-min-occurrences <n>` | detector default | `closure-anomaly` threshold |
+| `--block-min-occurrences <n>` | detector default | `subagent-block` threshold |
+| `--tool-failure-min-failures <n>` | detector default | `tool-failure-density` absolute count threshold |
+| `--tool-failure-min-rate <rate>` | detector default | `tool-failure-density` rate threshold, 0–1 |
+| `--only <names>` | all enabled | Comma-separated detector names to run |
+| `--include-disabled` | off | Run detectors that are disabled by default |
+
+```bash
+afk improve scan                        # dry-run, last 7 days
+afk improve scan --since 24h --write    # persist cards from the last 24 h
+afk improve scan --only repeated-tool-use --write
+```
+
+### `afk improve cards`
+
+Inspect and triage failure cards written by `scan`. Three subcommands:
+
+**`cards list`** — tabular listing of all cards, newest first.
+
+| Flag | Purpose |
+|---|---|
+| `--pattern <name>` | Filter by pattern name |
+| `--severity <level>` | Filter by severity: `low \| medium \| high` |
+| `--status <state>` | Filter by status: `open \| deferred \| resolved` |
+| `--regressed` | Only show resolved/deferred cards that fired again after their latest triage note (read-only observability view) |
+| `--json` | Emit JSON instead of a table |
+
+**`cards show <slug>`** — print one card. Pass `--json` for raw JSON.
+
+**`cards triage <slug>`** — append a human note and/or change status. Preserves all existing evidence and prior notes.
+
+| Flag | Purpose |
+|---|---|
+| `--note <text>` | Note text to append |
+| `--status <state>` | New status: `open \| deferred \| resolved` |
+| `--json` | Emit the resulting card as JSON |
+
+```bash
+afk improve cards list --status open
+afk improve cards show repeated-tool-use--2026-01-15
+afk improve cards triage repeated-tool-use--2026-01-15 \
+  --note "root-caused to X" --status deferred
+```
+
+### `afk improve propose <slug>`
+
+Generates a template-mode improvement proposal for a failure card and writes it under `proposals/<id>.{json,md}`. **No LLM calls** — the template engine deterministically maps the card's pattern to a starter proposal a human refines before any patch.
+
+| Flag | Purpose |
+|---|---|
+| `--id <override>` | Override the auto-generated proposal id |
+| `--no-write` | Preview mode: render without persisting |
+| `--json` | Emit proposal JSON to stdout (still writes to disk unless `--no-write`) |
+
+```bash
+afk improve propose repeated-tool-use--2026-01-15
+afk improve propose repeated-tool-use--2026-01-15 --no-write  # preview
+```
+
+### `afk improve proposals`
+
+Read-only inspection of proposals on disk. Two subcommands:
+
+**`proposals list`** — tabular listing, newest first. Filter with `--card <slug>` or `--risk <l|m|h>`. Pass `--json` for JSON.
+
+**`proposals show <id>`** — print one proposal. Pass `--json` for raw JSON.
+
+### `afk improve eval-gen <cardSlug>`
+
+Generates a replay-mode eval-case from a failure card. Slices a byte-identical fixture from the source witness trace and writes the eval-case contract under `eval-cases/<id>.{json,md}` alongside the fixture. **No LLM calls.** Does not run the fixture through a detector — that is reserved for a later sprint.
+
+| Flag | Purpose |
+|---|---|
+| `--proposal <id>` | Back-reference to a proposal (validated to exist; does not mutate the proposal artifact) |
+| `--evidence-row <index>` | 0-based index into the card's evidence array. Default: most recent row. |
+| `--id <override>` | Override the auto-generated eval-case id |
+| `--no-write` | Preview mode: render and report fixture size without persisting |
+| `--json` | Emit eval-case JSON to stdout |
+
+```bash
+afk improve eval-gen repeated-tool-use--2026-01-15
+afk improve eval-gen repeated-tool-use--2026-01-15 --no-write  # preview
+```
+
+### `afk improve eval-cases`
+
+Read-only inspection of eval-cases on disk. Two subcommands:
+
+**`eval-cases list`** — tabular listing, newest first. Filter with `--card <slug>`, `--pattern <name>`, or `--status <state>` (`draft | approved | rejected | superseded`). Pass `--json` for JSON.
+
+**`eval-cases show <id>`** — print one eval-case. Pass `--json` for raw JSON.
+
+### `afk improve eval-run <evalCaseIdOrCardSlug>`
+
+Runs the smallest deterministic validation contract for an eval-case's pattern against the live codebase and persists an eval-run result under `eval-runs/<id>.{json,md}`. Re-verifies the committed fixture checksum. **No LLM calls. No patch/apply.** Exits non-zero on `fail` or `error` — usable as a CI gate.
+
+The argument may be an eval-case id or a card slug; if a slug is given, the most recent eval-case for that card is used.
+
+| Flag | Purpose |
+|---|---|
+| `--id <override>` | Override the auto-generated eval-run id |
+| `--no-write` | Run and render without persisting |
+| `--json` | Emit eval-run JSON to stdout |
+
+```bash
+afk improve eval-run repeated-tool-use--2026-01-15
+afk improve eval-run <eval-case-id> --no-write
+```
+
+## Typical workflow
+
+```bash
+# 1. Scan recent sessions; preview first, then persist.
+afk improve scan --since 7d
+afk improve scan --since 7d --write
+
+# 2. Inspect what was found.
+afk improve cards list --status open
+
+# 3. Triage a card: add a note and defer it.
+afk improve cards triage <slug> --note "root-caused to X" --status deferred
+
+# 4. Generate a proposal for a card you want to address.
+afk improve propose <slug>
+afk improve proposals list
+
+# 5. Generate an eval-case to lock in a regression test.
+afk improve eval-gen <slug>
+afk improve eval-cases list
+
+# 6. Run the deterministic contract to verify the guardrail.
+afk improve eval-run <slug>
+```
+
+The pipeline is additive: each step produces durable artifacts on disk. You can pause between any two stages and resume later.
+
+> **Out of scope (reserved for later sprints):** LLM-mode proposals, applying patches, fixture replay through the detector, branch creation, git operations, and PR publishing.

--- a/website/content/docs/guides/subagents.mdx
+++ b/website/content/docs/guides/subagents.mdx
@@ -85,6 +85,18 @@ The status bar at the bottom of the REPL shows running background task counts.
 
 Source: `src/cli/background-status-bar.ts`, `src/cli/commands/interactive/background.js`.
 
+### `afk bg` — CLI background job inspection
+
+From the terminal, inspect persisted background job logs with the `afk bg` command:
+
+```bash
+afk bg list              # list all jobs (most recent first, --max <n> to limit)
+afk bg tail <jobId>      # stream live events (--from-start to replay first)
+afk bg replay <jobId>    # replay all events, then exit
+```
+
+Jobs are persisted to `~/.afk/state/bg/` even after the parent REPL exits. Use `afk bg` to check status, review logs, or re-stream a job's output from disk. Complements `/bgsub:join` when you need access outside an active REPL session.
+
 ## The `compose` tool — DAG orchestration
 
 For structured multi-agent workflows, the `compose` tool dispatches up to 20 subagent nodes with explicit dependency edges. Independent nodes run in parallel; dependent nodes wait.

--- a/website/content/docs/guides/unattended-runs.mdx
+++ b/website/content/docs/guides/unattended-runs.mdx
@@ -152,6 +152,43 @@ afk schedule add \
   --notify always     # always | failure | never
 ```
 
+## Pull queue (`afk queue`)
+
+`afk queue` lets you enqueue tasks that a daemon running in `--trigger pull` mode will drain.
+Tasks are persisted as JSON files in `~/.afk/state/queue/` and consumed one-by-one on the
+daemon's poll interval (30 seconds).
+
+### Subcommands
+
+| Subcommand | Description |
+|---|---|
+| `afk queue add <command>` | Enqueue a command for the pull-trigger daemon to execute |
+| `afk queue list` | List all pending queued tasks in FIFO order |
+| `afk queue remove <id>` | Remove a pending task by id |
+| `afk queue clear` | Remove all pending tasks from the queue |
+
+`add` accepts one option:
+
+| Flag | Description |
+|---|---|
+| `--notify-on <mode>` | When to send a Telegram notification: `failure` \| `always` \| `never` |
+
+### Typical workflow
+
+```bash
+# 1. Start the daemon in pull mode (no cron needed)
+afk daemon --trigger pull
+
+# 2. Enqueue tasks from another terminal (or a script) while the daemon runs
+afk queue add "/forge-friction --auto" --notify-on failure
+afk queue add "/review --auto" --notify-on always
+
+# Tasks are picked up and executed in order on the next poll (≤30s)
+```
+
+The daemon prints `✔ Daemon in pull mode` on start and processes each queued file in
+sequence-number order, deleting it after the task completes.
+
 ## Putting it together
 
 A complete setup for a nightly unattended run:

--- a/website/content/docs/how-it-works.mdx
+++ b/website/content/docs/how-it-works.mdx
@@ -118,7 +118,7 @@ present wedges the session.
 
 The one boundary enforced in the interactive default mode is **path containment**: a file tool
 reaching *outside* the session's working directory triggers a one-time approval prompt before it
-runs. Bypass mode (`/bypass`, or `--dangerously-skip-permissions`) turns containment off entirely;
+runs. Bypass mode (cycle with **Shift+Tab**, or the `--dangerously-skip-permissions` flag) turns containment off entirely;
 the `afk daemon` runs in bypass by default. See [Permissions](/configuration/permissions) for the
 full model — path approval, bash restrictions, autonomous mode, and the env-var knobs.
 

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -49,7 +49,7 @@ Every surface shares the same context, memory, and tools — so work started in 
   <Card title="Subagent orchestration" href="/guides/subagents" description="Run many subagents at once — independent tasks run in parallel, dependent ones wait their turn." />
   <Card title="Slash skills" href="/skills/overview" description="A registry of built-in slash commands plus auto-discovered SKILL.md plugins, with typo-tolerant command suggestions." />
   <Card title="Verification workflows" href="/guides/verification" description="Skills like /review and /diagnose fan parallel checks across a change before surfacing a recommendation." />
-  <Card title="Local traces" href="/guides/headless" description="Every run appends an inspectable trace — tool calls, gate decisions, cost — readable with afk trace show." />
+  <Card title="Local traces" href="/guides/observability" description="Every run appends an inspectable trace — tool calls, gate decisions, cost — readable with afk trace show." />
   <Card title="Telegram supervision" href="/surfaces/telegram" description="Get a phone ping when a scheduled task lands, then reply to drive the session from anywhere." />
   <Card title="Unattended guardrails" href="/guides/unattended-runs" description="Cost ceilings, turn limits, and worktree isolation keep long unattended runs in bounds." />
 </Cards>

--- a/website/content/docs/quickstart.mdx
+++ b/website/content/docs/quickstart.mdx
@@ -20,6 +20,16 @@ Confirm the binary is on your `PATH`:
 afk --version
 ```
 
+To update to the latest published version at any time:
+
+```bash
+afk update              # installs latest via npm install -g
+afk update --check      # check for a newer version without installing
+afk update --pin 1.2.3  # install a specific semver instead of latest
+```
+
+`afk upgrade` is an alias for `afk update`.
+
 ## Set your API key
 
 The simplest path is an environment variable:
@@ -95,6 +105,19 @@ afk i --model haiku
 | `opus` | Complex reasoning, multi-step planning |
 | `sonnet` | Balanced speed and capability (default) |
 | `haiku` | Fast and cheap, good for simple tasks |
+
+## Coming from Claude Code or Codex?
+
+If you already have plugins, skills, or MCP servers installed in Claude Code or Codex, import them into AFK with a single command:
+
+```bash
+afk migrate             # auto-detects Claude Code and Codex; prompts before writing
+afk migrate --dry-run   # preview what would be imported without changing anything
+afk migrate --mcp       # also import MCP servers (discloses each server's command first)
+afk migrate -y          # skip the confirmation prompt (CI / non-interactive)
+```
+
+Rather than copying files, `afk migrate` records a trust grant in `afk.config.json`. AFK then live-reads the source tool's directories every session — plugins installed in Claude Code tomorrow appear in AFK tomorrow without re-running the command. MCP import is opt-in (`--mcp`) because MCP servers auto-run a command on session start.
 
 ## Next steps
 

--- a/website/content/docs/surfaces/chat.mdx
+++ b/website/content/docs/surfaces/chat.mdx
@@ -67,74 +67,11 @@ Cost, duration, and token fields appear only when the provider populates them.
 
 ### `--format stream-json`
 
-Writes one JSON object per line to stdout ([newline-delimited JSON](https://ndjson.org/)) — no color codes, no spinner. Use this when a script or CI pipeline needs to parse AFK's output.
+Writes one JSON object per line to stdout ([newline-delimited JSON](https://ndjson.org/)) — no color codes, no spinner. Use this when a script or CI pipeline needs to parse AFK's output. Events include `chunk`, `message`, `done`, `error`, `progress`, `paused`, and `resumed`. The process exits `0` on `done` and `1` on `error`.
 
-```bash
-afk chat "summarise this repo" --format stream-json
-```
+For the full event schema, jq recipes, and TypeScript parsing examples, see [Headless & Machine-Readable Output](../guides/headless).
 
-#### Event types
-
-| `type` | Additional fields | Notes |
-|---|---|---|
-| `chunk` | `chunk: MessageChunk` | Streaming text or tool fragment |
-| `message` | `message: { content, timestamp }` | Complete assistant message |
-| `done` | `metadata?` | Always the final event on success |
-| `error` | `error: { message, name }` | Fatal error; process exits with code 1 |
-| `progress` | `progress: { taskId, description, ... }` | Subagent progress |
-| `suggestion` | `suggestion: string` | Prompt suggestion from the model |
-| `paused` | `reason: 'usage-limit'; resetsAt?` | OAuth usage-limit pause |
-| `resumed` | `hotSwapped: boolean` | Resumed after pause |
-
-#### Example transcript
-
-```json
-{"type":"chunk","chunk":{"type":"content","content":"Hello"}}
-{"type":"chunk","chunk":{"type":"content","content":", world!"}}
-{"type":"message","message":{"content":"Hello, world!","timestamp":"2024-06-01T12:00:01.234Z"}}
-{"type":"done","metadata":{"durationMs":812,"usage":{"input_tokens":14,"output_tokens":5}}}
-```
-
-#### Reading with `jq`
-
-```bash
-# Extract text content only
-afk chat "summarise this repo" --format stream-json \
-  | jq -r 'select(.type == "chunk" and .chunk.type == "content") | .chunk.content'
-
-# Get final token usage
-afk chat "count words" --format stream-json \
-  | jq 'select(.type == "done") | .metadata.usage'
-
-# Detect tool calls
-afk chat "list files" --format stream-json \
-  | jq 'select(.type == "chunk" and .chunk.type == "tool_use")'
-```
-
-#### Parsing in TypeScript
-
-```typescript
-import { createInterface } from 'node:readline';
-import { spawn } from 'node:child_process';
-
-const proc = spawn('afk', ['chat', 'say hi', '--format', 'stream-json']);
-const rl = createInterface({ input: proc.stdout });
-
-for await (const line of rl) {
-  const event = JSON.parse(line);
-  if (event.type === 'chunk' && event.chunk.type === 'content') {
-    process.stdout.write(event.chunk.content);
-  }
-  if (event.type === 'done') break;
-  if (event.type === 'error') {
-    console.error('AFK error:', event.error.message);
-    process.exit(1);
-  }
-}
-```
-
-`--format stream-json` exits with code `1` on error and `0` on `done`. Combine with `tee` to
-log the raw stream while still processing it:
+Combine with `tee` to log the raw stream while still processing it:
 
 ```bash
 afk chat "build the project" --format stream-json | tee run.ndjson

--- a/website/content/docs/surfaces/daemon.mdx
+++ b/website/content/docs/surfaces/daemon.mdx
@@ -22,6 +22,19 @@ The daemon supports four trigger modes set with `--trigger`:
 | `both` | Fire on sessionstart and then on the cron schedule |
 | `pull` | Dequeue tasks from a file-based queue (no cron expression needed) |
 
+### Pull mode
+
+`--trigger pull` starts the daemon without a cron expression. Instead of firing on a schedule,
+it polls `~/.afk/state/queue/` every 30 seconds and dequeues tasks written there by `afk queue add`.
+
+```bash
+afk daemon --trigger pull
+```
+
+No `--cron` or `--task` flag is needed. Tasks are consumed one-by-one in the order they were
+enqueued. Use pull mode when you want to push work to a running daemon on demand rather than
+on a fixed schedule.
+
 ## Common options
 
 ```bash

--- a/website/content/docs/surfaces/repl.mdx
+++ b/website/content/docs/surfaces/repl.mdx
@@ -43,6 +43,9 @@ Type `/` in the REPL to see available commands. Typos are caught automatically �
 | `/compact` | Manually compact conversation history |
 | `/save` | Snapshot session state to disk |
 | `/resume` | Resume a saved session |
+| `/fork` | Duplicate this conversation into a new, independent session |
+| `/name [name]` | Show or set this session's name |
+| `/sh [list \| show \<id\> \| kill \<id\>]` | Inspect or kill user-typed `!cmd` shell jobs |
 
 ### Information
 
@@ -50,22 +53,28 @@ Type `/` in the REPL to see available commands. Typos are caught automatically �
 |---|---|
 | `/cost` | Running cost for the session |
 | `/tokens` | Context usage breakdown (total, categories, MCP tools, agents, skills) |
+| `/stats` | Show session statistics including skill runs |
 | `/history` | Print prior turns |
+| `/transcript` | View full session transcript in `$PAGER` |
 | `/model` | Show or switch the active model |
 | `/tools` | List registered tools |
 | `/mcp` | Show MCP server status |
 | `/limits` | Show rate-limit and budget state |
 | `/debug` | Toggle verbose debug output |
+| `/keys` | Show keybinding reference |
+| `/config` | View resolved configuration (model, provider, API keys, env vars) |
+| `/doctor` | Run system health checks (API keys, directories, config, Telegram) |
+| `/font-size [size] [editor]` | Get or set the terminal font size in Cursor / VS Code |
+| `/reauth [--check]` | Re-read keychain credentials and swap the running session's client |
 
 ### Permissions
 
 | Command | Description |
 |---|---|
 | `/allow-dir <path>` | Pre-authorize a directory for file tools (`--revoke <path>` to remove a grant) |
-| `/bypass` | Disable path containment entirely (`/bypass off` to restore); shows a `⚠ BYPASS` badge |
 | `/afk` | Enter autonomous mode — risk-gated, with remote answer/abort over Telegram (`/afk off` to exit) |
 
-See [Permissions](/configuration/permissions) for the full model behind these commands.
+There is no `/bypass` command — cycle into `bypassPermissions` with **Shift+Tab** (the REPL shows a `⚠ BYPASS` badge while it is active). See [Permissions](/configuration/permissions) for the full model behind these commands.
 
 ### Planning and state
 
@@ -74,7 +83,7 @@ See [Permissions](/configuration/permissions) for the full model behind these co
 | `/plan` | Open the plan editor |
 | `/todo` | Manage the persistent todo list |
 | `/init` | Scan the current project and generate an `AFK.md` |
-| `/changelog` | Render `CHANGELOG.md` paginated |
+| `/changelog [--dry-run]` | Generate CHANGELOG entries from commits since last tag |
 
 ### Background tasks
 
@@ -116,6 +125,43 @@ to surface them.
 `/plan` opens an in-REPL plan editor. You can write a multi-step plan, iterate on it, and
 then let the agent execute it. Plan state is saved to `~/.afk/state/` and survives session
 restarts.
+
+### Exiting plan mode
+
+When the model judges its plan ready, it calls the `exit_plan_mode` tool. This presents a
+three-choice picker:
+
+| Choice | What happens |
+|---|---|
+| **Approve — implement now (restore your previous mode)** | Restores the permission mode you were in before entering plan mode (e.g. `default`, `acceptEdits`) and seeds the implement turn |
+| **Approve — implement now (bypass mode)** | Escalates to `bypassPermissions` — no approval prompts, read/write any path — then seeds the implement turn |
+| **Keep planning** | Stays in plan mode; the model continues refining |
+
+The mode flip is deferred to the start of the next turn — the gate stays locked in plan mode
+for the remainder of the current turn. On approval, the model is instructed to first save the
+plan to `.afk/plans/` as a markdown file, then implement it.
+
+You can also exit plan mode manually with `/plan off`.
+
+## Shift+Tab permission cycle
+
+Press **Shift+Tab** at any time to cycle the active permission mode. The cycle order is:
+
+```
+default → plan → bypassPermissions → default (wraps)
+```
+
+| Mode | What it does |
+|---|---|
+| `default` | Path containment + approval prompts active |
+| `plan` | Writes refused; read-only bash allowed, mutating bash blocked |
+| `bypassPermissions` | Path-approval prompts and containment off; read/write any path |
+
+Each press advances one step and prints a one-line status message. If the session is already
+in `autonomous` (AFK) mode, Shift+Tab exits AFK and lands on `default` — the key never
+_enters_ AFK. Use `/afk` to enter autonomous mode.
+
+See [Permissions](../configuration/permissions.mdx) for full mode descriptions.
 
 ## Streaming output
 


### PR DESCRIPTION
## Summary

Brings the published Fumadocs site (`website/content/docs`) up to date with code on `main`. The published docs had lagged active development (~378 `src/` commits vs ~16 docs commits over 90 days). 16 pages updated + 2 new guides (+617 / −93).

- **Undocumented surfaces now covered:** `afk queue` (add/list/remove/clear), `afk improve`, `afk bg`, `afk browser` (drive your real Chrome via Chrome DevTools MCP), `afk trace`, `afk transcript` (FTS5 search), `afk update`, `afk migrate`.
- **Hooks:** added the four newer events — `Stop`, `UserPromptSubmit`, `PreCompact`, `PostToolUseFailure` — with correct stdin payload keys and per-surface coverage.
- **Permissions / plan mode:** documented the `exit_plan_mode` exit flow (implement / escalate-to-bypass / keep planning) and the `Shift+Tab` permission cycle; retired stale `/bypass`-as-command references (entry is now Shift+Tab).
- **Plugins / MCP:** plugin JS `main` entrypoint loaded at session boot; MCP now wired on all four surfaces (REPL, chat, daemon, telegram).
- **New guides:** `observability` (witness traces + transcript search) and `self-improvement` (the `afk improve` pipeline).
- **Housekeeping:** de-duplicated the stream-json schema (headless canonical, chat links to it); reframed model-slot default IDs as point-in-time.

## Test results

- `cd website && npm ci` — ok
- `npm run typecheck` (`tsc --noEmit`) — **passed**
- `npm run build` (`next build`) — **passed**, 31 static pages incl. both new guides
- Root `pnpm test` / `pnpm lint` — **N/A**: no TypeScript changed. The docs site is a standalone npm app; its CI gate is the `ci.yml` docs job (typecheck + build), which is green here.

## Verification (`--verify` adversarial wave)

An independent read-only verifier re-derived the load-bearing claims from the diff against `src/`. It returned **NEEDS-FIX** and caught 3 issues — all fixed before this commit:

1. **Hook payload key** was documented as `event`; corrected to `hook_event_name` across all rows (`src/agent/hooks/command-executor.ts:61`).
2. **`Stop` event** was documented as firing inside subagents on all surfaces; corrected to REPL-only with no `parent_session_id` (dispatched only at `src/cli/commands/interactive/loop-iteration.ts:592`).
3. **`afk queue`** was documented with only `add`; updated to `add`/`list`/`remove`/`clear` after rebasing onto `main` (which includes #327).

All other sampled claims verified **CONFIRM** against source — every CLI flag/subcommand, the `/bypass` retirement, the `exit_plan_mode` choices, the internal links (incl. the repointed index "Local traces" card → `/guides/observability`), and the witness-trace path `~/.afk/state/witness/<session>/trace.jsonl`.

## Out of scope

- A docs-staleness **prevention** proposal (a CI docs-coverage gate mirroring `audit:sdk`/`scan:env`) was drafted at `docs/proposals/docs-staleness-prevention.md` but is intentionally **not** included in this PR — separate follow-up.
