### PR TITLE
feat(trace): trace skill-forked subagent tool denials + receipt refusal tally

### DIFF
--- a/src/agent/tools/skill-executor.test.ts
+++ b/src/agent/tools/skill-executor.test.ts
@@ -144,6 +144,53 @@ describe('SkillExecutor', () => {
     );
   });
 
+  it('forwards the witness traceWriter as ctx.traceWriter so skill-forked subagent denials are traced', async () => {
+    // Regression: inline handlers (e.g. /diagnose) that fork their OWN
+    // SubagentManager need the parent's traceWriter to thread it into the fork,
+    // or the child dispatcher's emitHookDecision/emitToolCall no-op and the
+    // restrictive-allowlist permission-denials vanish from the witness trace
+    // (and the run receipt's refusal tally). The executor must surface its
+    // ctx.traceWriter on the SkillExecutionContext handed to the handler.
+    const fakeTraceWriter = { write: vi.fn() } as unknown as import('../trace/index.js').TraceWriter;
+    const handler = vi.fn().mockResolvedValue('ok');
+    registerSkill({ name: 'tracewriter-skill', description: 'test', handler });
+
+    const executor = new SkillExecutor({
+      parentSession: {
+        sessionId: 'parent-session',
+        getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+        abortSignal,
+      },
+      traceWriter: fakeTraceWriter,
+    });
+
+    await executor.execute(makeCall({ name: 'tracewriter-skill' }));
+
+    expect(handler).toHaveBeenCalledWith(
+      undefined,
+      expect.anything(),
+      expect.objectContaining({ traceWriter: fakeTraceWriter }),
+    );
+  });
+
+  it('omits ctx.traceWriter when the executor has none (tracing disabled)', async () => {
+    const handler = vi.fn().mockResolvedValue('ok');
+    registerSkill({ name: 'no-tracewriter-skill', description: 'test', handler });
+
+    const executor = new SkillExecutor({
+      parentSession: {
+        sessionId: 'parent-session',
+        getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+        abortSignal,
+      },
+    });
+
+    await executor.execute(makeCall({ name: 'no-tracewriter-skill' }));
+
+    const ctxArg = handler.mock.calls[0]?.[2] as { traceWriter?: unknown };
+    expect(ctxArg.traceWriter).toBeUndefined();
+  });
+
   it('should return error for unknown skill with available list', async () => {
     registerSkill({
       name: 'known-skill',

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -436,6 +436,13 @@ export class SkillExecutor {
           // (context: 'fork') registry/plugin paths below.
           callId: call.id,
           dispatchSkill: this.createDispatchSkillCallback(call),
+          // Forward the witness writer so inline handlers that fork their own
+          // SubagentManager (e.g. /diagnose, /audit-fit) make the forked
+          // sub-agents' tool activity AND permission-denials land in the
+          // parent trace — see SkillExecutionContext.traceWriter.
+          ...(this.ctx.traceWriter !== undefined
+            ? { traceWriter: this.ctx.traceWriter }
+            : {}),
         },
       );
     } catch (err) {

--- a/src/agent/trace/receipt.test.ts
+++ b/src/agent/trace/receipt.test.ts
@@ -129,6 +129,7 @@ describe('generateReceipt — success-only trace', () => {
     expect(r.toolCalls.succeeded).toBe(3);
     expect(r.toolCalls.errored).toBe(0);
     expect(r.toolCalls.erroredNotable).toBe(0);
+    expect(r.toolCalls.refused).toBe(0);
     expect(r.toolCalls.byTool['bash']).toEqual({ total: 2, errored: 0 });
     expect(r.failures).toEqual([]);
     expect(r.humanReviewRequired).toBe(false);
@@ -171,6 +172,9 @@ describe('generateReceipt — failed tool calls', () => {
     expect(r.toolCalls.total).toBe(5);
     expect(r.toolCalls.errored).toBe(4);
     expect(r.toolCalls.erroredNotable).toBe(2); // unclassified + timeout
+    // refused = gate-refusal classes only: policy-refusal counts;
+    // elicitation-declined is exempt-but-not-a-denial, so it does NOT.
+    expect(r.toolCalls.refused).toBe(1);
     expect(r.toolCalls.circuitBreakerHits).toBe(1);
     expect(r.toolCalls.byFailureClass).toMatchObject({
       unclassified: 1,
@@ -202,6 +206,34 @@ describe('generateReceipt — failed tool calls', () => {
     expect(r.subagents.failed).toBe(1);
     expect(r.humanReviewRequired).toBe(true);
     expect(r.humanReviewReasons.join('\n')).toContain('1 subagent(s) failed');
+  });
+
+  it('tallies gate refusals (permission-denied + hook-block) without forcing review', () => {
+    // Mirrors the /diagnose case: a restrictive allowlist denies repeated
+    // tool calls (permission-denied) alongside a PreToolUse hook block.
+    const events = [
+      toolDone('bash', { isError: true, failureClass: 'permission-denied', toolUseId: 'd1' }),
+      toolDone('list_directory', {
+        isError: true,
+        failureClass: 'permission-denied',
+        toolUseId: 'd2',
+      }),
+      toolDone('bash', { isError: true, failureClass: 'hook-block', toolUseId: 'd3' }),
+      toolDone('read_file'), // 1 clean call → total 4, rate 75%
+      closure('model_end_turn'),
+      sealed('succeeded'),
+    ];
+    const r = generateReceipt(events, META);
+
+    expect(r.toolCalls.total).toBe(4);
+    expect(r.toolCalls.refused).toBe(3);
+    // All three are exempt refusals → none count as "notable".
+    expect(r.toolCalls.erroredNotable).toBe(0);
+    // Denials are EXPECTED outcomes — they must not force human review on their own.
+    expect(r.humanReviewRequired).toBe(false);
+
+    const md = renderReceiptMarkdown(r);
+    expect(md).toContain('| Refused (denylisted) | 3 (75.0% of calls) |');
   });
 });
 
@@ -269,6 +301,7 @@ describe('renderReceiptMarkdown', () => {
     expect(md).toContain('✓ no');
     expect(md).toContain('No tool failures recorded.');
     expect(md).not.toContain('## Why review is required');
+    expect(md).not.toContain('Refused (denylisted)');
   });
 });
 

--- a/src/agent/trace/receipt.ts
+++ b/src/agent/trace/receipt.ts
@@ -49,6 +49,20 @@ const REVIEW_EXEMPT_FAILURE_CLASSES: ReadonlySet<ToolFailureClass> = new Set([
   'elicitation-declined',
 ]);
 
+// Invariant: the subset of exempt classes that represent a GATE refusing a
+// tool call — an allowlist/`canUseTool` deny (`permission-denied`), a
+// PreToolUse hook block (`hook-block`), or a policy refusal (`policy-refusal`).
+// These are "the system denylisted this call". Deliberately EXCLUDES `abort`
+// (user/cascade cancellation) and `elicitation-declined` (no handler) — those
+// are not denials. Surfaced as the receipt's `toolCalls.refused` tally so
+// restrictive sub-agent/skill allowlists (e.g. /diagnose, /audit-fit) get a
+// per-session count instead of being buried in `byFailureClass`.
+const GATE_REFUSAL_FAILURE_CLASSES: readonly ToolFailureClass[] = [
+  'permission-denied',
+  'hook-block',
+  'policy-refusal',
+];
+
 /** A single failed tool call, summarized from trace metadata (no raw output). */
 export interface ReceiptToolFailure {
   toolUseId: string;
@@ -89,6 +103,14 @@ export interface RunReceipt {
     errored: number;
     /** `errored` minus the expected-refusal (exempt) classes. */
     erroredNotable: number;
+    /**
+     * Count of tool calls a gate denylisted: `permission-denied` (allowlist /
+     * `canUseTool` deny) + `hook-block` (PreToolUse hook) + `policy-refusal`.
+     * A subset of `errored`; per-class detail is in `byFailureClass`. Divide by
+     * `total` for the refusal rate. Surfaces denials that `erroredNotable`
+     * deliberately excludes — the per-session "how often was a call denied" tally.
+     */
+    refused: number;
     circuitBreakerHits: number;
     byTool: Record<string, { total: number; errored: number }>;
     byFailureClass: Record<string, number>;
@@ -272,6 +294,10 @@ export function generateReceipt(events: TraceEvent[], meta: ReceiptMeta): RunRec
   }
 
   const erroredNotable = failures.filter((f) => !f.exempt).length;
+  const refused = GATE_REFUSAL_FAILURE_CLASSES.reduce(
+    (n, cls) => n + (byFailureClass[cls] ?? 0),
+    0,
+  );
   const status = sealedStatus ?? 'unknown';
 
   const startedAt = events[0]?.ts;
@@ -339,6 +365,7 @@ export function generateReceipt(events: TraceEvent[], meta: ReceiptMeta): RunRec
       succeeded,
       errored,
       erroredNotable,
+      refused,
       circuitBreakerHits,
       byTool,
       byFailureClass,
@@ -390,6 +417,13 @@ export function renderReceiptMarkdown(r: RunReceipt): string {
   lines.push('| --- | --- |');
   lines.push(`| Tool calls | ${r.toolCalls.total} |`);
   lines.push(`| Errored | ${r.toolCalls.errored} (${r.toolCalls.erroredNotable} notable) |`);
+  if (r.toolCalls.refused > 0) {
+    const rate =
+      r.toolCalls.total > 0
+        ? ((r.toolCalls.refused / r.toolCalls.total) * 100).toFixed(1)
+        : '0.0';
+    lines.push(`| Refused (denylisted) | ${r.toolCalls.refused} (${rate}% of calls) |`);
+  }
   if (r.toolCalls.circuitBreakerHits > 0)
     lines.push(`| Circuit-breaker hits | ${r.toolCalls.circuitBreakerHits} |`);
   if (r.cost.turnCount !== undefined) lines.push(`| Turns | ${r.cost.turnCount} |`);

--- a/src/skills/audit-fit/index.ts
+++ b/src/skills/audit-fit/index.ts
@@ -340,7 +340,13 @@ async function handler(
     byType[a.type].push(a);
   }
 
-  const manager = new SubagentManager({ apiKey });
+  // Forward the parent's witness writer (when ctx supplies one) so the
+  // inspector forks below inherit it and their `canUseTool` permission-denials
+  // land in the parent trace. See skills/index.ts SkillExecutionContext.traceWriter.
+  const manager = new SubagentManager({
+    apiKey,
+    ...(ctx?.traceWriter !== undefined ? { traceWriter: ctx.traceWriter } : {}),
+  });
   const createCanUseTool = (): CanUseTool => async (toolName: string) => {
     if (!researchAgent.allowedTools.includes(toolName as never)) {
       return {

--- a/src/skills/diagnose/_phases/orchestrator.ts
+++ b/src/skills/diagnose/_phases/orchestrator.ts
@@ -321,7 +321,15 @@ export async function handler(
     );
   }
 
-  const manager = new SubagentManager({ apiKey });
+  // Forward the parent's witness writer (when ctx supplies one) so the
+  // research/git/hypothesis forks below inherit it and their tool activity —
+  // notably the read-only `canUseTool` permission-denials these restrictive
+  // allowlists produce — lands in the parent trace as hook_decision + tool_call
+  // events instead of being lost. See skills/index.ts SkillExecutionContext.traceWriter.
+  const manager = new SubagentManager({
+    apiKey,
+    ...(ctx?.traceWriter !== undefined ? { traceWriter: ctx.traceWriter } : {}),
+  });
 
   // Phase 1: Triage — reproducer + structured failure classification.
   const reproducer = detectReproducer(parsedInput.context);

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -7,6 +7,7 @@
  */
 
 import type { AgentModelInput, IAgentSession } from '../agent/types.js';
+import type { TraceWriter } from '../agent/trace/index.js';
 
 /**
  * Execution context handed to inline-registry skill handlers by the
@@ -63,6 +64,23 @@ export interface SkillExecutionContext {
    * as throws.
    */
   dispatchSkill?: (name: string, args?: string) => Promise<string>;
+  /**
+   * The parent session's witness trace writer, when one is open. Inline
+   * handlers that fork sub-agents via their OWN `new SubagentManager(...)`
+   * MUST forward this so the forked sub-agents inherit the writer and their
+   * tool activity — including `canUseTool` permission-denials, emitted as
+   * `hook_decision` block + `tool_call` (failureClass: 'permission-denied')
+   * events — lands in the parent's `trace.jsonl`. Without it the child
+   * dispatcher's `traceWriter` is undefined and every `emitHookDecision` /
+   * `emitToolCall` no-ops, so the denials a restrictive allowlist produces are
+   * visible only in the live TUI and are lost from the durable witness record
+   * (and therefore from the run receipt's refusal tally).
+   *
+   * Optional: callers must handle `undefined` (tracing disabled via
+   * `AFK_TRACE_DISABLED=1`, or older SkillExecutor versions / test stubs that
+   * do not provide it). In that case forking proceeds untraced, as before.
+   */
+  traceWriter?: TraceWriter;
 }
 
 export interface SkillMetadata {

--- a/src/skills/user-skills.ts
+++ b/src/skills/user-skills.ts
@@ -155,6 +155,11 @@ function makeUserSkillHandler(parsed: ParsedSkillMd): SkillMetadata['handler'] {
 
     const manager = new SubagentManager({
       parentAbortSignal: parentSession?.abortSignal,
+      // Forward the parent's witness writer (when ctx supplies one) so this
+      // user-skill's forked sub-agent inherits it and its tool activity —
+      // including any permission-denials a restricted user SKILL.md produces —
+      // lands in the parent trace. See skills/index.ts SkillExecutionContext.traceWriter.
+      ...(ctx?.traceWriter !== undefined ? { traceWriter: ctx.traceWriter } : {}),
     });
 
     // `parentId: ctx.callId` (when present) anchors the synthesized


### PR DESCRIPTION
## Problem

When a skill orchestrator forks sub-agents through its **own** `new SubagentManager({ apiKey })` (e.g. `/diagnose`, `/audit-fit`), those forks never received the parent session's witness `traceWriter`, because `SkillExecutionContext` did not expose one. As a result the child dispatcher's `traceWriter` was `undefined`, so every `emitHookDecision` / `emitToolCall` no-op'd, and the forks' tool activity — including `canUseTool` `behavior:'deny'` **permission-denials** (the red "Tool X not allowed" spam visible when running `/diagnose`) — was **lost from the durable witness trace**. It rendered live in the TUI and then vanished. Main-session denials were traced; skill sub-agent denials were not.

Empirically confirmed on a live `/diagnose` trace: 56 `hook_decision` events, **all** non-block, **zero** denial reasons, despite ~10+ on-screen denials.

## What changed

**Plumbing (denials now reach the trace)**
- Add `traceWriter?: TraceWriter` to `SkillExecutionContext` (`src/skills/index.ts`).
- `SkillExecutor` forwards `this.ctx.traceWriter` into the inline-handler context (`src/agent/tools/skill-executor.ts`).
- `/diagnose` orchestrator, `/audit-fit`, and user-skills thread `ctx?.traceWriter` into their hand-built `SubagentManager`. The existing fork-inheritance backfill (`subagent.ts:449-451`) then propagates it to every child dispatcher, so denials emit `hook_decision` + `tool_call(failureClass:'permission-denied')` into the parent `trace.jsonl`.

**Per-session denial tally (durable rollup)**
- Denied calls already emit a `tool_call(completed, failureClass:'permission-denied')` event (`loop.ts:652`), which the run receipt buckets into `byFailureClass` (`receipt.ts:217-225`).
- Add `RunReceipt.toolCalls.refused` (`permission-denied` + `hook-block` + `policy-refusal`, via a new `GATE_REFUSAL_FAILURE_CLASSES`) and render `Refused (denylisted) N (X% of calls)` in the receipt Summary — surfacing denials that `erroredNotable` deliberately excludes. The receipt auto-writes to `$AFK_STATE_DIR/receipts/<label>.{json,md}` at SessionEnd.

## Verification

- `pnpm lint` (tsc --noEmit, strict): clean.
- Full suite: **10,297 passed / 2 failed / 14 skipped**. The 2 failures are pre-existing, environment-only (`config.test.ts` DEFAULT_SLOT_BINDINGS MLX bleed; `anthropic-direct.test.ts` compact) — neither file is touched here. Zero new failures.
- New tests: `skill-executor.test.ts` (+2 — traceWriter forwarded / omitted when absent); `receipt.test.ts` (+1 test + baseline assertions — gate-refusal tally, 75% rate render, clean-run negative).

## Deferred (follow-up)

`mint` phases also fork managers without the writer, but (a) they are threaded by **positional-param** signatures (no `ctx`), and (b) they emit **no** `canUseTool` denials (restriction is via `phaseRole`/provider). So threading the writer there serves only general trace completeness, not denial tracking, and is best done via an options-object refactor in a separate PR.

## Notes

This PR edits already-public files with generic trace/receipt infrastructure — no secrets or moat content.
