### PR TITLE
fix(cli): always allow exit_plan_mode on top-level surfaces (REPL/chat/Telegram)

### DIFF
--- a/src/agent/tools/top-level-allowlist.test.ts
+++ b/src/agent/tools/top-level-allowlist.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression tests for {@link topLevelSurfaceAllowedTools}.
+ *
+ * Locks the fix for the bug where the human-facing top-level surfaces (REPL,
+ * one-shot `chat`, Telegram) each constructed their own `AnthropicDirectProvider`
+ * with an inline allowlist that dropped `exit_plan_mode`. `parseProvider`
+ * returns undefined for the default Anthropic model (no `--provider` flag), so
+ * those surfaces fall back to that hardcoded provider — and with plan mode
+ * active the provider registers the `exit_plan_mode` tool and the model calls
+ * it, but the STATIC allowlist omitted the name, so the dispatcher's permission
+ * gate rejected it with "not in the configured allowlist". This helper is the
+ * single source of truth those three surfaces now consume.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { topLevelSurfaceAllowedTools } from './top-level-allowlist.js';
+import { BUILTIN_TOOL_NAMES } from './schemas.js';
+import { MEMORY_TOOL_NAMES } from '../memory/index.js';
+import { AWARENESS_TOOL_NAMES } from '../awareness/index.js';
+import { EXIT_PLAN_MODE_TOOL_NAME } from './handlers/exit-plan-mode.js';
+
+describe('topLevelSurfaceAllowedTools', () => {
+  it('includes exit_plan_mode (the always-on, plan-mode-only tool that was missing)', () => {
+    expect(topLevelSurfaceAllowedTools()).toContain(EXIT_PLAN_MODE_TOOL_NAME);
+    expect(topLevelSurfaceAllowedTools()).toContain('exit_plan_mode');
+  });
+
+  it('includes every always-on builtin, memory, and awareness tool name', () => {
+    const list = topLevelSurfaceAllowedTools();
+    for (const name of BUILTIN_TOOL_NAMES) expect(list).toContain(name);
+    for (const name of MEMORY_TOOL_NAMES) expect(list).toContain(name);
+    for (const name of AWARENESS_TOOL_NAMES) expect(list).toContain(name);
+    expect(list).toContain('get_runtime_state');
+  });
+
+  it('includes the full executor set (agent, skill, compose) these surfaces always wire', () => {
+    const list = topLevelSurfaceAllowedTools();
+    expect(list).toContain('agent');
+    expect(list).toContain('skill');
+    expect(list).toContain('compose');
+  });
+
+  it('unions MCP wire names when supplied, and defaults to none when omitted', () => {
+    const withMcp = topLevelSurfaceAllowedTools(['mcp__srv__do', 'mcp__srv__list']);
+    expect(withMcp).toContain('mcp__srv__do');
+    expect(withMcp).toContain('mcp__srv__list');
+    // Omitting the arg must not leak any mcp__ names.
+    expect(topLevelSurfaceAllowedTools().some((n) => n.startsWith('mcp__'))).toBe(false);
+  });
+
+  it('produces the exact canonical list (locks against accidental drift)', () => {
+    expect(topLevelSurfaceAllowedTools()).toEqual([
+      ...BUILTIN_TOOL_NAMES,
+      ...MEMORY_TOOL_NAMES,
+      ...AWARENESS_TOOL_NAMES,
+      EXIT_PLAN_MODE_TOOL_NAME,
+      'agent',
+      'skill',
+      'compose',
+    ]);
+  });
+});

--- a/src/agent/tools/top-level-allowlist.ts
+++ b/src/agent/tools/top-level-allowlist.ts
@@ -1,0 +1,35 @@
+import { BUILTIN_TOOL_NAMES } from './schemas.js';
+import { MEMORY_TOOL_NAMES } from '../memory/index.js';
+import { AWARENESS_TOOL_NAMES } from '../awareness/index.js';
+import { EXIT_PLAN_MODE_TOOL_NAME } from './handlers/exit-plan-mode.js';
+
+/**
+ * Contract: the canonical tool allowlist for a top-level, human-facing surface
+ * (REPL, one-shot `chat`, Telegram) that always wires the full executor set.
+ *
+ * These surfaces construct their own `AnthropicDirectProvider` (to tag the
+ * correct `surface`) instead of routing through `parseProvider`, so each one
+ * previously re-spelled this list inline. The instant one copy dropped an
+ * always-registered tool name — `get_runtime_state` (awareness) or
+ * `exit_plan_mode` — the dispatcher's permission gate rejected that tool with
+ * "not in the configured allowlist" even though the model could see and call
+ * it. `exit_plan_mode` is registered only while in plan mode, but the allowlist
+ * is static (snapshotted at construction), so its name must be present here; it
+ * is harmless on surfaces that never enter plan mode (the dispatcher simply
+ * never routes to it). `mcpToolWireNames` are unioned in because every
+ * MCP-bridged tool must appear on the allowlist or it is rejected as unknown.
+ *
+ * Single source of truth: a new always-on tool is a one-line change here.
+ */
+export function topLevelSurfaceAllowedTools(mcpToolWireNames: readonly string[] = []): string[] {
+  return [
+    ...BUILTIN_TOOL_NAMES,
+    ...MEMORY_TOOL_NAMES,
+    ...AWARENESS_TOOL_NAMES,
+    EXIT_PLAN_MODE_TOOL_NAME,
+    'agent',
+    'skill',
+    'compose',
+    ...mcpToolWireNames,
+  ];
+}

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -13,6 +13,7 @@ import type { AgentModelInput, ThinkingConfig, EffortLevel } from '../../agent/t
 import { unconfiguredSlotError } from '../../agent/session/model-slots.js';
 import { formatDuration, formatCost, formatTokens } from '../format-utils.js';
 import { parseThinking, parseEffort, parseBudget, parseMaxOutputTokens, parseProvider, getApiKey, getApiKeyForModel, getModel, getThinking, getEffort, getMaxBudgetUsd, getTaskBudget, getMaxOutputTokens, getDefaultSubagentModel, resolveBaseSystemPrompt } from '../shared-helpers.js';
+import { topLevelSurfaceAllowedTools } from '../../agent/tools/top-level-allowlist.js';
 import { loadConfig } from '../config.js';
 import { assembleSystemPrompt } from '../../agent/routing-directive.js';
 import { renderMarkdownToTerminal } from '../formatter.js';
@@ -24,9 +25,6 @@ import { ComposeExecutor } from '../../agent/tools/compose-executor.js';
 import { ensurePluginEntrypointsLoaded } from '../../agent/tools/skill-bridge.js';
 import { createChildProviderFactory, createChildSkillExecutorFactory } from '../../agent/tools/nesting.js';
 import { AnthropicDirectProvider } from '../../agent/providers/anthropic-direct/index.js';
-import { BUILTIN_TOOL_NAMES } from '../../agent/tools/schemas.js';
-import { MEMORY_TOOL_NAMES } from '../../agent/memory/index.js';
-import { AWARENESS_TOOL_NAMES } from '../../agent/awareness/index.js';
 import { createDefaultTraceWriter } from '../../agent/trace/factory.js';
 import { receiptPathsFor } from '../../agent/trace/receipt.js';
 import { setupWorktree } from './interactive/worktree.js';
@@ -610,15 +608,7 @@ export function registerChatCommand(program: Command): void {
         })
           ?? new AnthropicDirectProvider({
             permissions: {
-              allowedTools: [
-                ...BUILTIN_TOOL_NAMES,
-                ...MEMORY_TOOL_NAMES,
-                ...AWARENESS_TOOL_NAMES,
-                'agent',
-                'skill',
-                'compose',
-                ...mcpToolWireNames,
-              ],
+              allowedTools: topLevelSurfaceAllowedTools(mcpToolWireNames),
             },
             subagentExecutor,
             skillExecutor,

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -6,7 +6,7 @@ import type { PermissionMode } from '../../../agent/types/sdk-types.js';
 import { unconfiguredSlotError } from '../../../agent/session/model-slots.js';
 import { createDefaultHookRegistry } from '../../../agent/default-hook-registry.js';
 import { loadHooksConfig } from '../../../agent/hooks/config-loader.js';
-import { MemoryStore, injectHotMemory, MEMORY_TOOL_NAMES } from '../../../agent/memory/index.js';
+import { MemoryStore, injectHotMemory } from '../../../agent/memory/index.js';
 import type { ThinkingConfig, EffortLevel } from '../../../agent/types.js';
 import type { AgentConfig } from '../../../agent/types.js';
 import type { ModelProvider } from '../../../agent/provider.js';
@@ -16,6 +16,7 @@ import {
   parseThinking, parseEffort, parseMaxOutputTokens, parseProvider, getApiKey, getApiKeyForModel, getThinking, getEffort,
   getMaxOutputTokens, getDefaultSubagentModel, resolveBaseSystemPrompt, isGrantManager,
 } from '../../shared-helpers.js';
+import { topLevelSurfaceAllowedTools } from '../../../agent/tools/top-level-allowlist.js';
 import { loadConfig } from '../../config.js';
 import { assembleSystemPrompt, pendingBriefContext } from '../../../agent/routing-directive.js';
 import { StatusLine } from '../../status-line.js';
@@ -50,9 +51,7 @@ import { AnthropicDirectProvider } from '../../../agent/providers/anthropic-dire
 import { seedPersistedGrants } from '../../../agent/permissions-store.js';
 import { providerForModel } from '../../../agent/providers/index.js';
 import { createMemoizedProviderFactory } from './provider-factory.js';
-import { BUILTIN_TOOL_NAMES } from '../../../agent/tools/schemas.js';
 import { ensurePluginEntrypointsLoaded } from '../../../agent/tools/skill-bridge.js';
-import { AWARENESS_TOOL_NAMES } from '../../../agent/awareness/index.js';
 import { McpManager, loadMcpConfig, getMcpConfigPath } from '../../../agent/mcp/index.js';
 import { loadImportFromConfig, resolveImportedRoots } from '../../../config/import-sources.js';
 import { env } from '../../../config/env.js';
@@ -469,15 +468,7 @@ export async function bootstrapSession(
     })
     ?? new AnthropicDirectProvider({
       permissions: {
-        allowedTools: [
-          ...BUILTIN_TOOL_NAMES,
-          ...MEMORY_TOOL_NAMES,
-          ...AWARENESS_TOOL_NAMES,
-          'agent',
-          'skill',
-          'compose',
-          ...mcpToolWireNames,
-        ],
+        allowedTools: topLevelSurfaceAllowedTools(mcpToolWireNames),
       },
       subagentExecutor,
       skillExecutor,

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -46,14 +46,12 @@ import { getEnvConfigPath } from './paths.js';
 import { assembleSystemPrompt, pendingBriefContext } from './agent/routing-directive.js';
 import { resolveModelId } from './agent/session/model-resolution.js';
 import { getDefaultSubagentModel, getMaxOutputTokens, getApiKeyForModel, loadSystemPrompt, composeSystemPrompt } from './cli/shared-helpers.js';
+import { topLevelSurfaceAllowedTools } from './agent/tools/top-level-allowlist.js';
 import type { AgentConfig, AgentModelInput } from './agent/types.js';
 import { SubagentManager } from './agent/subagent.js';
 import { SubagentExecutor } from './agent/tools/subagent-executor.js';
 import { SkillExecutor } from './agent/tools/skill-executor.js';
 import { ComposeExecutor } from './agent/tools/compose-executor.js';
-import { BUILTIN_TOOL_NAMES } from './agent/tools/schemas.js';
-import { MEMORY_TOOL_NAMES } from './agent/memory/index.js';
-import { AWARENESS_TOOL_NAMES } from './agent/awareness/index.js';
 import { createChildProviderFactory, createChildSkillExecutorFactory } from './agent/tools/nesting.js';
 import { attachMcpCleanup, loadTelegramMcpManager } from './telegram/mcp-session.js';
 
@@ -340,15 +338,7 @@ async function main() {
           depth: 0,
         });
 
-        const allowedTools = [
-          ...BUILTIN_TOOL_NAMES,
-          ...MEMORY_TOOL_NAMES,
-          ...AWARENESS_TOOL_NAMES,
-          'agent',
-          'skill',
-          'compose',
-          ...(mcpManager?.getMcpToolWireNames() ?? []),
-        ];
+        const allowedTools = topLevelSurfaceAllowedTools(mcpManager?.getMcpToolWireNames() ?? []);
         directProvider = new AnthropicDirectProvider({
           permissions: { allowedTools },
           subagentExecutor,


### PR DESCRIPTION
## Summary

`exit_plan_mode` was missing from the tool allowlist on the default REPL path (and `chat` / Telegram too), so when the model called it in plan mode the dispatcher's permission gate rejected it with **"not in the configured allowlist"** — even though the schema was offered to the model and the handler was wired.

## Root cause

`parseProvider()` returns `undefined` for the default Anthropic model when no `--provider` flag is passed (`src/cli/shared-helpers.ts`), so the REPL, one-shot `chat`, and Telegram surfaces fall through to a **hardcoded `AnthropicDirectProvider` fallback**. Each fallback spelled its tool allowlist inline, and all three omitted `exit_plan_mode`. (The `parseProvider` path itself already included it — only the fallbacks didn't.)

`AgentSession` auto-wires `planExitControls` for every top-level session (`src/agent/session/agent-session.ts`), so in plan mode the provider registers the `exit_plan_mode` tool and the model can call it — but the allowlist is **static** (snapshotted at construction), so the gate rejected the call.

## Fix

- New single source of truth: `topLevelSurfaceAllowedTools()` in `src/agent/tools/top-level-allowlist.ts`, which always includes `exit_plan_mode` alongside the builtins / memory / awareness tools, the `agent`/`skill`/`compose` executors, and unioned MCP wire names.
- The three human-facing surfaces (`bootstrap.ts`, `chat.ts`, `telegram.ts`) now consume the helper instead of re-spelling the list inline — so an always-on tool can never again be dropped from one copy (net −36 / +7 lines across them).
- Placed in the `agent/tools` layer (where the composed constants live) rather than `cli/shared-helpers`, so the surface tests that mock `shared-helpers` need no changes.

## Scope

- **Daemon is intentionally excluded** — it runs headless in `bypassPermissions` and never enters plan mode, so `exit_plan_mode` is never registered there.

## Testing

- `pnpm lint` (tsc --noEmit, strict) — clean.
- New colocated regression test `src/agent/tools/top-level-allowlist.test.ts` (5 tests) covering: `exit_plan_mode` presence, all always-on builtin/memory/awareness names, the executor set, MCP wire-name union, and the exact canonical list.
- Full suite: **10351 passed / 14 skipped / 1 failed**. The single failure is a pre-existing, unrelated `anthropic-direct.test.ts > compact()` model-id-alias mismatch (`'claude-haiku-4-5'` vs `'claude-haiku-4-5-20251001'`) — independent of this change.
