### PR TITLE
feat(plugins): inject runtime values into PluginApi for code-backed plugins

### DIFF
--- a/src/agent/plugins/load-entrypoints.test.ts
+++ b/src/agent/plugins/load-entrypoints.test.ts
@@ -11,9 +11,31 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { pathToFileURL } from 'url';
 import { loadPluginEntrypoints, _resetLoadedEntrypoints } from './load-entrypoints.js';
+import type { PluginApi } from './load-entrypoints.js';
 import type { SdkPluginConfig } from '../types/sdk-types.js';
 import { registerSkill, getSkill, listSkills, _resetRegistry } from '../../skills/index.js';
 import { loadSkillPrompts } from '../../skills/_lib/prompt-loader.js';
+import { SubagentManager } from '../subagent.js';
+import { describeFailure } from '../subagent/result.js';
+import { env } from '../../config/env.js';
+import { getAgentFrameworkDir, getSkillsDir, getSessionsDir } from '../../paths.js';
+
+// The full host-injected API, mirroring skill-bridge.ensurePluginEntrypointsLoaded.
+// `discoverPluginSkillBodies` is stubbed here (its real wiring is type-checked at
+// the skill-bridge assembly site) so this test need not import that heavy barrel.
+const fullApi: PluginApi = {
+  registerSkill,
+  listSkills,
+  getSkill,
+  loadSkillPrompts,
+  env,
+  SubagentManager,
+  describeFailure,
+  discoverPluginSkillBodies: (() => new Map()) as PluginApi['discoverPluginSkillBodies'],
+  getAgentFrameworkDir,
+  getSkillsDir,
+  getSessionsDir,
+};
 
 let dir: string;
 
@@ -117,9 +139,7 @@ describe('loadPluginEntrypoints', () => {
     );
     const plugins: SdkPluginConfig[] = [{ type: 'local', path: dir, main: 'entry.mjs' }];
 
-    await loadPluginEntrypoints(plugins, {
-      pluginApi: { registerSkill, listSkills, getSkill, loadSkillPrompts },
-    });
+    await loadPluginEntrypoints(plugins, { pluginApi: fullApi });
 
     try {
       expect(listSkills()).toContain(skillName);
@@ -136,13 +156,47 @@ describe('loadPluginEntrypoints', () => {
     const store = globalThis as unknown as Record<string, unknown>;
     try {
       await expect(
-        loadPluginEntrypoints(plugins, {
-          pluginApi: { registerSkill, listSkills, getSkill, loadSkillPrompts },
-        }),
+        loadPluginEntrypoints(plugins, { pluginApi: fullApi }),
       ).resolves.toBeUndefined();
       expect(store[key]).toBe(true);
     } finally {
       delete store[key];
+    }
+  });
+
+  it('injects core runtime values (env, SubagentManager, …) a marketplace clone cannot import directly', async () => {
+    // A marketplace-cloned plugin has no node_modules, so a bare
+    // `import { SubagentManager } from 'agent-afk'` throws ERR_MODULE_NOT_FOUND.
+    // Prove the host instead INJECTS these runtime values into the default-export
+    // entrypoint and that they arrive intact (env object, the real SubagentManager
+    // class, the helper functions) — the resolution half of the PluginApi contract.
+    writeFileSync(
+      join(dir, 'entry.mjs'),
+      `export default (api) => {\n` +
+        `  globalThis.__afkApiProbe = {\n` +
+        `    envType: typeof api.env,\n` +
+        `    subagentManagerType: typeof api.SubagentManager,\n` +
+        `    subagentManagerName: api.SubagentManager && api.SubagentManager.name,\n` +
+        `    describeFailureType: typeof api.describeFailure,\n` +
+        `    getAgentFrameworkDirType: typeof api.getAgentFrameworkDir,\n` +
+        `    discoverPluginSkillBodiesType: typeof api.discoverPluginSkillBodies,\n` +
+        `  };\n` +
+        `};\n`,
+    );
+    const plugins: SdkPluginConfig[] = [{ type: 'local', path: dir, main: 'entry.mjs' }];
+    const store = globalThis as unknown as Record<string, unknown>;
+    try {
+      await loadPluginEntrypoints(plugins, { pluginApi: fullApi });
+      const probe = store.__afkApiProbe as Record<string, unknown> | undefined;
+      expect(probe).toBeDefined();
+      expect(probe?.envType).toBe('object');
+      expect(probe?.subagentManagerType).toBe('function');
+      expect(probe?.subagentManagerName).toBe('SubagentManager');
+      expect(probe?.describeFailureType).toBe('function');
+      expect(probe?.getAgentFrameworkDirType).toBe('function');
+      expect(probe?.discoverPluginSkillBodiesType).toBe('function');
+    } finally {
+      delete store.__afkApiProbe;
     }
   });
 });

--- a/src/agent/plugins/load-entrypoints.ts
+++ b/src/agent/plugins/load-entrypoints.ts
@@ -20,25 +20,40 @@ import type { SdkPluginConfig } from '../types/sdk-types.js';
 /**
  * Host runtime API injected into a plugin entrypoint's default-export function.
  *
- * Invariant: a code-backed plugin MUST register through this object, not by
- * importing `agent-afk` itself. The skill registry is a module-level singleton
- * (`src/skills/index.ts`), so a plugin that imports its OWN copy of `agent-afk`
- * (its `node_modules`, a bundle, or a version-skewed install — the default for a
- * marketplace-cloned plugin with no shared `node_modules`) would call a
- * `registerSkill` backed by a DIFFERENT registry than the host reads → the skill
- * silently never appears. Receiving these functions from the host guarantees the
- * same module instance regardless of how the plugin was installed.
+ * Invariant: a code-backed plugin MUST consume the host runtime through this
+ * object, never via a bare `import … from 'agent-afk'`. Two independent failures
+ * make the bare import wrong inside a plugin:
+ *   1. Singleton identity — the skill registry is a module-level singleton
+ *      (`src/skills/index.ts`). A plugin that imports its OWN copy of the package
+ *      calls a `registerSkill` backed by a DIFFERENT registry than the host
+ *      reads, so the skill silently never appears.
+ *   2. Resolution — a marketplace-cloned plugin has NO `node_modules`, so a bare
+ *      `import 'agent-afk'` does not resolve at all and throws
+ *      `ERR_MODULE_NOT_FOUND` at boot (verified empirically). This bites even the
+ *      STATELESS helpers (`env`, the `paths` getters, `describeFailure`), which
+ *      is precisely why they are injected here rather than imported directly.
  *
- * Stateless helpers (`env`, the `paths` getters, `describeFailure`) are safe for
- * a plugin to import directly — they hold no singleton state — and are
- * intentionally omitted to keep this surface minimal. The type is derived via
- * `typeof import(...)` so the injected signatures cannot drift from the source.
+ * So every runtime VALUE a plugin needs is passed in: the registry trio +
+ * `loadSkillPrompts` (identity-critical) plus `env`, `SubagentManager`,
+ * `describeFailure`, `discoverPluginSkillBodies`, and the `paths` getters
+ * (resolution-critical). Type-only imports are erased at build, so a plugin may
+ * still `import type { … } from 'agent-afk'` via a build-time devDependency. The
+ * shape is derived via `typeof import(...)` so the injected signatures cannot
+ * drift from their source modules.
  */
 export type PluginApi = Pick<
   typeof import('../../skills/index.js'),
   'registerSkill' | 'listSkills' | 'getSkill'
 > &
-  Pick<typeof import('../../skills/_lib/prompt-loader.js'), 'loadSkillPrompts'>;
+  Pick<typeof import('../../skills/_lib/prompt-loader.js'), 'loadSkillPrompts'> &
+  Pick<typeof import('../../config/env.js'), 'env'> &
+  Pick<typeof import('../subagent.js'), 'SubagentManager'> &
+  Pick<typeof import('../subagent/result.js'), 'describeFailure'> &
+  Pick<typeof import('../tools/skill-bridge.js'), 'discoverPluginSkillBodies'> &
+  Pick<
+    typeof import('../../paths.js'),
+    'getAgentFrameworkDir' | 'getSkillsDir' | 'getSessionsDir'
+  >;
 
 /**
  * Resolved-entrypoint paths already imported in this process. Dynamic `import()`

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -20,8 +20,17 @@ import { scanSkillsFromDir } from '../../skills/user-skills.js';
 import { scanLocalPlugins } from '../plugins-scanner.js';
 import { loadPluginEntrypoints } from '../plugins/load-entrypoints.js';
 import { extractPluginSkills } from '../plugins/tool-injector.js';
+import { SubagentManager } from '../subagent.js';
+import { describeFailure } from '../subagent/result.js';
 import type { SdkPluginConfig } from '../types/sdk-types.js';
-import { getBundledPluginsDir, getProjectPluginsDir, getProjectSkillsDir, getSkillsDir } from '../../paths.js';
+import {
+  getAgentFrameworkDir,
+  getBundledPluginsDir,
+  getProjectPluginsDir,
+  getProjectSkillsDir,
+  getSessionsDir,
+  getSkillsDir,
+} from '../../paths.js';
 import { env } from '../../config/env.js';
 import { loadImportFromConfig, resolveImportedRoots } from '../../config/import-sources.js';
 
@@ -264,11 +273,25 @@ export function scanAllPluginRoots(): SdkPluginConfig[] {
  * so calling it again in a child is a safe no-op.
  */
 export async function ensurePluginEntrypointsLoaded(): Promise<void> {
-  // Inject the host's registry functions (+ loadSkillPrompts) so a code-backed
-  // plugin's default-export entrypoint registers against THIS process's
-  // singleton registry — not a bare-specifier-imported copy of its own, which
-  // would silently write to a registry the host never reads. See PluginApi.
+  // Inject the host's runtime API so a code-backed plugin's default-export
+  // entrypoint (a) registers against THIS process's singleton registry, and
+  // (b) can reach core runtime values (env, SubagentManager, describeFailure,
+  // discoverPluginSkillBodies, the paths getters) WITHOUT a bare
+  // `import 'agent-afk'` — which a marketplace-cloned plugin (no node_modules)
+  // cannot resolve at all. See PluginApi for the full rationale.
   await loadPluginEntrypoints(scanAllPluginRoots(), {
-    pluginApi: { registerSkill, listSkills, getSkill, loadSkillPrompts },
+    pluginApi: {
+      registerSkill,
+      listSkills,
+      getSkill,
+      loadSkillPrompts,
+      env,
+      SubagentManager,
+      describeFailure,
+      discoverPluginSkillBodies,
+      getAgentFrameworkDir,
+      getSkillsDir,
+      getSessionsDir,
+    },
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,8 +79,11 @@ export type { SkillExecutionContext, SkillMetadata } from './skills/index.js';
 export { loadSkillPrompts } from './skills/_lib/prompt-loader.js';
 // PluginApi: the host runtime API injected into a code-backed plugin's
 // default-export entrypoint. A plugin types its entrypoint as
-// `export default (api: PluginApi) => { … }` and registers through `api` so its
-// skills land in the host's singleton registry regardless of install layout.
+// `export default (api: PluginApi) => { … }` and consumes the host runtime
+// through `api` — the registry trio + `loadSkillPrompts` (so its skills land in
+// the host's singleton registry regardless of install layout) plus the runtime
+// values (`env`, `SubagentManager`, `describeFailure`, `discoverPluginSkillBodies`,
+// paths getters) a marketplace-cloned plugin can't `import 'agent-afk'` to reach.
 export type { PluginApi } from './agent/plugins/load-entrypoints.js';
 
 export {


### PR DESCRIPTION
## What

Widen `PluginApi` — the host runtime API injected into a code-backed plugin's default-export entrypoint — from 4 to 11 symbols, so an out-of-tree, code-backed plugin can reach the core runtime values it needs.

**Added (runtime values):** `env`, `SubagentManager`, `describeFailure`, `discoverPluginSkillBodies`, `getAgentFrameworkDir`, `getSkillsDir`, `getSessionsDir`.
**Already injected:** `registerSkill`, `listSkills`, `getSkill`, `loadSkillPrompts`.

## Why

A marketplace-cloned plugin has **no `node_modules` of its own**, so a bare `import … from 'agent-afk'` inside the plugin throws `ERR_MODULE_NOT_FOUND` at boot — verified empirically with a probe plugin:

```
agentAfkResolved: false
ERR_MODULE_NOT_FOUND: Cannot find package 'agent-afk' imported from <plugin>/index.mjs
```

The 4-symbol `PluginApi` from #324 fixed the **singleton-identity** half of the problem (the registry must be the host's instance). But it left every other runtime value unreachable — including otherwise-stateless helpers like `env` and the path getters — because in a clone the bare import doesn't resolve at all. A code-backed plugin that forks sub-agents (`SubagentManager`), formats failures (`describeFailure`), reads env/paths, or enumerates plugin skill bodies could not function.

## How

- `PluginApi` gains the seven runtime values, derived via `typeof import(...)` so injected signatures can't drift from their source modules.
- `skill-bridge.ensurePluginEntrypointsLoaded` assembles and injects the full set. The object literal is type-checked against `PluginApi`, so the assembly can't silently fall out of sync with the type.
- Type-only imports stay erased at build, so a plugin can still `import type { … } from 'agent-afk'` via a build-time devDependency.

Purely additive — no behavior change for existing side-effect-only plugins or the prior 4-symbol consumers.

## Tests

Extends the entrypoint round-trip test with a case proving the injected `SubagentManager` (the real class), `env`, `describeFailure`, `getAgentFrameworkDir`, and `discoverPluginSkillBodies` all arrive intact in a default-export entrypoint.

- `pnpm lint` (`tsc --noEmit`, strict): pass
- `src/agent/plugins/load-entrypoints.test.ts`: 9/9 pass
- full suite: 10348 pass (2 unrelated failures — one pre-existing, one isolation-passing flake)
- `pnpm audit:sdk:check`: OK (no SDK imports added)
