### PR TITLE
feat(plugins): inject session-facet substrate into PluginApi (11→15)

### DIFF
--- a/src/agent/plugins/load-entrypoints.test.ts
+++ b/src/agent/plugins/load-entrypoints.test.ts
@@ -19,6 +19,12 @@ import { SubagentManager } from '../subagent.js';
 import { describeFailure } from '../subagent/result.js';
 import { env } from '../../config/env.js';
 import { getAgentFrameworkDir, getSkillsDir, getSessionsDir } from '../../paths.js';
+import {
+  deriveSessionFacet,
+  getOrDeriveFacet,
+  listSessionIds,
+  loadStoredSession,
+} from '../facets/index.js';
 
 // The full host-injected API, mirroring skill-bridge.ensurePluginEntrypointsLoaded.
 // `discoverPluginSkillBodies` is stubbed here (its real wiring is type-checked at
@@ -35,6 +41,10 @@ const fullApi: PluginApi = {
   getAgentFrameworkDir,
   getSkillsDir,
   getSessionsDir,
+  getOrDeriveFacet,
+  listSessionIds,
+  deriveSessionFacet,
+  loadStoredSession,
 };
 
 let dir: string;
@@ -180,6 +190,10 @@ describe('loadPluginEntrypoints', () => {
         `    describeFailureType: typeof api.describeFailure,\n` +
         `    getAgentFrameworkDirType: typeof api.getAgentFrameworkDir,\n` +
         `    discoverPluginSkillBodiesType: typeof api.discoverPluginSkillBodies,\n` +
+        `    getOrDeriveFacetType: typeof api.getOrDeriveFacet,\n` +
+        `    listSessionIdsType: typeof api.listSessionIds,\n` +
+        `    deriveSessionFacetType: typeof api.deriveSessionFacet,\n` +
+        `    loadStoredSessionType: typeof api.loadStoredSession,\n` +
         `  };\n` +
         `};\n`,
     );
@@ -195,6 +209,10 @@ describe('loadPluginEntrypoints', () => {
       expect(probe?.describeFailureType).toBe('function');
       expect(probe?.getAgentFrameworkDirType).toBe('function');
       expect(probe?.discoverPluginSkillBodiesType).toBe('function');
+      expect(probe?.getOrDeriveFacetType).toBe('function');
+      expect(probe?.listSessionIdsType).toBe('function');
+      expect(probe?.deriveSessionFacetType).toBe('function');
+      expect(probe?.loadStoredSessionType).toBe('function');
     } finally {
       delete store.__afkApiProbe;
     }

--- a/src/agent/plugins/load-entrypoints.ts
+++ b/src/agent/plugins/load-entrypoints.ts
@@ -35,8 +35,10 @@ import type { SdkPluginConfig } from '../types/sdk-types.js';
  *
  * So every runtime VALUE a plugin needs is passed in: the registry trio +
  * `loadSkillPrompts` (identity-critical) plus `env`, `SubagentManager`,
- * `describeFailure`, `discoverPluginSkillBodies`, and the `paths` getters
- * (resolution-critical). Type-only imports are erased at build, so a plugin may
+ * `describeFailure`, `discoverPluginSkillBodies`, the session-facet substrate
+ * (`getOrDeriveFacet`, `listSessionIds`, `deriveSessionFacet`,
+ * `loadStoredSession`), and the `paths` getters (resolution-critical). Type-only
+ * imports are erased at build, so a plugin may
  * still `import type { … } from 'agent-afk'` via a build-time devDependency. The
  * shape is derived via `typeof import(...)` so the injected signatures cannot
  * drift from their source modules.
@@ -50,6 +52,10 @@ export type PluginApi = Pick<
   Pick<typeof import('../subagent.js'), 'SubagentManager'> &
   Pick<typeof import('../subagent/result.js'), 'describeFailure'> &
   Pick<typeof import('../tools/skill-bridge.js'), 'discoverPluginSkillBodies'> &
+  Pick<
+    typeof import('../facets/index.js'),
+    'getOrDeriveFacet' | 'listSessionIds' | 'deriveSessionFacet' | 'loadStoredSession'
+  > &
   Pick<
     typeof import('../../paths.js'),
     'getAgentFrameworkDir' | 'getSkillsDir' | 'getSessionsDir'

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -22,6 +22,12 @@ import { loadPluginEntrypoints } from '../plugins/load-entrypoints.js';
 import { extractPluginSkills } from '../plugins/tool-injector.js';
 import { SubagentManager } from '../subagent.js';
 import { describeFailure } from '../subagent/result.js';
+import {
+  deriveSessionFacet,
+  getOrDeriveFacet,
+  listSessionIds,
+  loadStoredSession,
+} from '../facets/index.js';
 import type { SdkPluginConfig } from '../types/sdk-types.js';
 import {
   getAgentFrameworkDir,
@@ -276,7 +282,7 @@ export async function ensurePluginEntrypointsLoaded(): Promise<void> {
   // Inject the host's runtime API so a code-backed plugin's default-export
   // entrypoint (a) registers against THIS process's singleton registry, and
   // (b) can reach core runtime values (env, SubagentManager, describeFailure,
-  // discoverPluginSkillBodies, the paths getters) WITHOUT a bare
+  // discoverPluginSkillBodies, the session-facet substrate, the paths getters) WITHOUT a bare
   // `import 'agent-afk'` — which a marketplace-cloned plugin (no node_modules)
   // cannot resolve at all. See PluginApi for the full rationale.
   await loadPluginEntrypoints(scanAllPluginRoots(), {
@@ -292,6 +298,10 @@ export async function ensurePluginEntrypointsLoaded(): Promise<void> {
       getAgentFrameworkDir,
       getSkillsDir,
       getSessionsDir,
+      getOrDeriveFacet,
+      listSessionIds,
+      deriveSessionFacet,
+      loadStoredSession,
     },
   });
 }


### PR DESCRIPTION
## What
Widens `PluginApi` from 11 → 15 injected symbols, adding the **session-facet substrate**: `getOrDeriveFacet`, `listSessionIds`, `deriveSessionFacet`, `loadStoredSession` (from `src/agent/facets`).

## Why
Follow-up to #335. Extracting the internal skill bundle into a code-backed marketplace plugin requires **harvest**, which calls these four facet functions at runtime (`harvest/index.ts:126,148`; `harvest/_lib/rank.ts:378,396,399`). A marketplace-cloned plugin has **no `node_modules`**, so it cannot `import 'agent-afk'` to reach them — they must be injected, exactly like the runtime values #335 added. The 11-symbol set was insufficient; this closes the gap so a code-backed plugin can consume the host purely via the injected `api`.

## Changes
- `load-entrypoints.ts` — add the facet `Pick` to `PluginApi` (derived via `typeof import('../facets/index.js')` so signatures can't drift from source).
- `skill-bridge.ts` — import + inject the four functions in `ensurePluginEntrypointsLoaded`.
- `load-entrypoints.test.ts` — extend the `fullApi` fixture + the resolution-probe test to assert all four arrive as callable functions.

## Verification
- `pnpm lint` (tsc strict) ✅
- `load-entrypoints.test.ts` + `skill-bridge.test.ts`: 45/45 ✅
- Empirically validated against the published artifact: a flat no-`node_modules` code-backed probe plugin received exactly these symbols via the injected api and round-tripped `registerSkill` → host `listSkills`.

Additive + backward-compatible — existing plugins ignore the new keys. Type-only imports (`SessionFacet`, `StoredSessionInput`) remain erased at build, so no runtime dependency is added.
