### PR TITLE
feat(mcp): emit mcp_connect_* trace phases on daemon surface (#248)

### DIFF
--- a/src/agent/daemon/scheduler.test.ts
+++ b/src/agent/daemon/scheduler.test.ts
@@ -10,6 +10,7 @@ import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import * as traceEmit from '../trace/emit.js';
 
 const schedulerTestState = vi.hoisted(() => ({ cleanupOrder: [] as string[] }));
 
@@ -479,6 +480,81 @@ describe('CronScheduler — MCP fixture wiring', () => {
         ]);
         expect(schedulerTestState.cleanupOrder).toEqual(['session.close', 'mcp.disconnect', 'memory.close']);
       } finally {
+        await scheduler?.stop();
+        if (savedHome === undefined) delete process.env['AFK_HOME'];
+        else process.env['AFK_HOME'] = savedHome;
+        if (savedTraceDisabled === undefined) delete process.env['AFK_TRACE_DISABLED'];
+        else process.env['AFK_TRACE_DISABLED'] = savedTraceDisabled;
+        if (savedAllowProjectMcp === undefined) delete process.env['AFK_ALLOW_PROJECT_MCP'];
+        else process.env['AFK_ALLOW_PROJECT_MCP'] = savedAllowProjectMcp;
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+    { timeout: 15_000 },
+  );
+});
+
+describe('CronScheduler — mcp_connect_* trace phases', () => {
+  it(
+    'emits mcp_connect_start then mcp_connect_done around McpManager.fromConfig',
+    async () => {
+      const dir = makeTmpDir();
+      const telemetryPath = join(dir, 'forge-telemetry.jsonl');
+      const savedHome = process.env['AFK_HOME'];
+      const savedTraceDisabled = process.env['AFK_TRACE_DISABLED'];
+      const savedAllowProjectMcp = process.env['AFK_ALLOW_PROJECT_MCP'];
+      process.env['AFK_HOME'] = dir;
+      // Leave AFK_TRACE_DISABLED unset so a real trace writer is created.
+      delete process.env['AFK_TRACE_DISABLED'];
+      process.env['AFK_ALLOW_PROJECT_MCP'] = '1';
+      writeFileSync(
+        join(dir, '.mcp.json'),
+        JSON.stringify({
+          mcpServers: {
+            testsrv: {
+              type: 'stdio',
+              command: process.execPath,
+              args: [MCP_FIXTURE],
+            },
+          },
+        }),
+        'utf-8',
+      );
+
+      const emitted: Array<{ phase: string; serverCount?: number }> = [];
+      const spy = vi.spyOn(traceEmit, 'emitSessionPhase').mockImplementation(
+        async (_writer, payload) => {
+          if (payload.phase === 'mcp_connect_start' || payload.phase === 'mcp_connect_done') {
+            emitted.push({
+              phase: payload.phase,
+              serverCount: payload.metadata?.['serverCount'] as number | undefined,
+            });
+          }
+        },
+      );
+
+      let scheduler: CronScheduler | undefined;
+      try {
+        scheduler = new CronScheduler({
+          telemetryPath,
+          sessionConfig: { cwd: dir, provider: makeToolSurfacingProvider() },
+          sessionFactory: (config) => new AgentSession(config),
+        });
+        scheduler.register({
+          taskId: 'mcp-trace-phases',
+          command: 'hello trace',
+          trigger: 'cron',
+          cronExpression: '* * * * *',
+        });
+
+        await scheduler.tick('mcp-trace-phases');
+
+        expect(emitted).toEqual([
+          { phase: 'mcp_connect_start', serverCount: 1 },
+          { phase: 'mcp_connect_done', serverCount: 1 },
+        ]);
+      } finally {
+        spy.mockRestore();
         await scheduler?.stop();
         if (savedHome === undefined) delete process.env['AFK_HOME'];
         else process.env['AFK_HOME'] = savedHome;

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -32,6 +32,7 @@ import { createDefaultTraceWriter } from '../trace/factory.js';
 import { MemoryStore, injectHotMemory } from '../memory/index.js';
 import { McpManager, loadMcpConfig } from '../mcp/index.js';
 import { loadImportFromConfig, resolveImportedRoots } from '../../config/import-sources.js';
+import { emitSessionPhase } from '../trace/emit.js';
 import type { AgentConfig } from '../types.js';
 import { getTelemetryPath } from '../../paths.js';
 import { redactInlineSecrets } from '../session/prompt-dump.js';
@@ -514,10 +515,28 @@ export class CronScheduler {
     const enabledMcpCount = Object.values(loadedMcp.mcpServers).filter((s) => !s.disabled).length;
     try {
       if (enabledMcpCount > 0) {
-        mcpManager = await McpManager.fromConfig(loadedMcp.mcpServers, {
-          warnings: loadedMcp.warnings,
-          ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
+        // Witness layer: bracket the whole-fleet MCP connect with
+        // mcp_connect_start / mcp_connect_done phases — surface-parity with
+        // chat.ts, interactive/bootstrap.ts, and telegram/mcp-session.ts.
+        // try/finally so mcp_connect_done fires even when an alwaysLoad server
+        // makes fromConfig throw. Fire-and-forget; never gates the connect.
+        const mcpStartedAt = Date.now();
+        void emitSessionPhase(trace?.writer, {
+          phase: 'mcp_connect_start',
+          metadata: { serverCount: enabledMcpCount },
         });
+        try {
+          mcpManager = await McpManager.fromConfig(loadedMcp.mcpServers, {
+            warnings: loadedMcp.warnings,
+            ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
+          });
+        } finally {
+          void emitSessionPhase(trace?.writer, {
+            phase: 'mcp_connect_done',
+            durationMs: Date.now() - mcpStartedAt,
+            metadata: { serverCount: enabledMcpCount },
+          });
+        }
       } else if (loadedMcp.warnings.length > 0) {
         for (const warning of loadedMcp.warnings) console.warn(`[mcp] ${warning}`);
       }


### PR DESCRIPTION
## Summary

Closes #248.

The daemon surface (`CronScheduler.spawnSession`) was the only surface missing `mcp_connect_start` / `mcp_connect_done` witness-layer trace events. The three other surfaces already emit them:
- `src/cli/commands/chat.ts` (~577/587) ✅ pre-existing
- `src/cli/commands/interactive/bootstrap.ts` (~420/430) ✅ pre-existing  
- `src/telegram/mcp-session.ts` (~51/61) ✅ pre-existing (telegram done)

## Changes

**`src/agent/daemon/scheduler.ts`** (+23 lines):
- Import `emitSessionPhase` from `../trace/emit.js`
- Wrap `McpManager.fromConfig` in `mcp_connect_start` (before) / `mcp_connect_done` (try/finally) with `{ serverCount: enabledMcpCount }` metadata — exact event shape mirroring `bootstrap.ts` and `mcp-session.ts`
- `mcp_connect_done` fires even when an `alwaysLoad` server makes `fromConfig` throw (try/finally guarantee)

**`src/agent/daemon/scheduler.test.ts`** (+76 lines):
- New describe block: `'CronScheduler — mcp_connect_* trace phases'`
- Spies on `traceEmit.emitSessionPhase` via vitest module spy
- Connects the existing fixture MCP server (`test-server.mjs`) and asserts `mcp_connect_start` then `mcp_connect_done` are emitted in order, each carrying `serverCount: 1`

## Verification

```
pnpm lint         → tsc --noEmit clean (0 errors)
pnpm test -- src/agent/daemon/scheduler.test.ts → 19/19 passed (includes new test)
```