### PR TITLE
fix(afk-gate): classify MCP/browser/schedule/web tools so AFK gate covers them (#198)

### DIFF
--- a/src/agent/afk-mode-gate.ts
+++ b/src/agent/afk-mode-gate.ts
@@ -22,6 +22,11 @@
  *     `chmod`/`chown`)
  *   - writes that escape the workspace, hit the write-denylist (`~/.ssh`,
  *     `/etc`, …), or target the `.git` object store
+ *   - schedule mutations: `create_schedule` / `cancel_schedule` — modify the
+ *     daemon cron store with potential immediate live-sync side-effects
+ *   - MCP tools with destructive verb sub-names (`*delete*`, `*drop*`,
+ *     `*write*`, `*create*`, `*update*`, `*exec*`, `*send*`, `*deploy*`, …) —
+ *     arbitrary third-party server functions the classifier cannot introspect
  * `'medium'` ops (normal `git push`/`git commit`, installs, builds, file moves)
  * and `'safe'` ops (reads, tests, lint) are ALLOWED — autonomous work has to be
  * useful, and these are reversible enough to run unattended.

--- a/src/agent/risk-classifier.test.ts
+++ b/src/agent/risk-classifier.test.ts
@@ -187,8 +187,8 @@ describe('classifyRisk — other tools', () => {
     expect(classifyRisk('list_directory', { path: '.' }, ctx)).toBe('safe');
   });
 
-  it('web_scrape → safe', () => {
-    expect(classifyRisk('web_scrape', { url: 'https://example.com' }, ctx)).toBe('safe');
+  it('web_scrape → medium (network side-effect)', () => {
+    expect(classifyRisk('web_scrape', { url: 'https://example.com' }, ctx)).toBe('medium');
   });
 
   it('send_telegram → medium', () => {
@@ -197,5 +197,98 @@ describe('classifyRisk — other tools', () => {
 
   it('unknown tool → safe', () => {
     expect(classifyRisk('my_custom_tool', {}, ctx)).toBe('safe');
+  });
+});
+
+// ---- schedule tools ------------------------------------------------------
+describe('classifyRisk — schedule tools', () => {
+  it('create_schedule → high (irreversible daemon mutation)', () => {
+    expect(
+      classifyRisk('create_schedule', { name: 'nightly', command: 'afk chat "run"', cron: '0 2 * * *' }, ctx),
+    ).toBe('high');
+  });
+
+  it('cancel_schedule → high (irreversible daemon mutation)', () => {
+    expect(classifyRisk('cancel_schedule', { taskId: 'nightly' }, ctx)).toBe('high');
+  });
+
+  it('list_schedules → safe (read-only)', () => {
+    expect(classifyRisk('list_schedules', {}, ctx)).toBe('safe');
+  });
+
+  it('get_schedule_history → safe (read-only)', () => {
+    expect(classifyRisk('get_schedule_history', { taskId: 'nightly' }, ctx)).toBe('safe');
+  });
+});
+
+// ---- browser tools -------------------------------------------------------
+describe('classifyRisk — browser tools', () => {
+  it('browser_open → medium (stateful navigation)', () => {
+    expect(classifyRisk('browser_open', { url: 'https://example.com' }, ctx)).toBe('medium');
+  });
+
+  it('browser_act → medium (may submit forms / click destructive UI)', () => {
+    expect(
+      classifyRisk('browser_act', { action: 'click', target: { kind: 'semantic', text: 'Delete' } }, ctx),
+    ).toBe('medium');
+  });
+
+  it('browser_observe → safe (read-only DOM snapshot)', () => {
+    expect(classifyRisk('browser_observe', {}, ctx)).toBe('safe');
+  });
+
+  it('browser_screenshot → safe (read-only capture)', () => {
+    expect(classifyRisk('browser_screenshot', {}, ctx)).toBe('safe');
+  });
+
+  it('browser_close → safe (cleanup)', () => {
+    expect(classifyRisk('browser_close', {}, ctx)).toBe('safe');
+  });
+});
+
+// ---- MCP tools -----------------------------------------------------------
+describe('classifyRisk — MCP tools', () => {
+  it('mcp__postgres__query → medium (unknown but non-destructive verb)', () => {
+    expect(classifyRisk('mcp__postgres__query', { sql: 'SELECT 1' }, ctx)).toBe('medium');
+  });
+
+  it('mcp__postgres__execute → high (exec verb)', () => {
+    expect(classifyRisk('mcp__postgres__execute', { sql: 'SELECT 1' }, ctx)).toBe('high');
+  });
+
+  it('mcp__db__drop_table → high (drop verb)', () => {
+    expect(classifyRisk('mcp__db__drop_table', { table: 'users' }, ctx)).toBe('high');
+  });
+
+  it('mcp__db__delete_record → high (delete verb)', () => {
+    expect(classifyRisk('mcp__db__delete_record', { id: 1 }, ctx)).toBe('high');
+  });
+
+  it('mcp__github__create_issue → high (create verb)', () => {
+    expect(classifyRisk('mcp__github__create_issue', { title: 'bug' }, ctx)).toBe('high');
+  });
+
+  it('mcp__github__update_file → high (update verb)', () => {
+    expect(classifyRisk('mcp__github__update_file', { path: 'README.md' }, ctx)).toBe('high');
+  });
+
+  it('mcp__slack__send_message → high (send verb)', () => {
+    expect(classifyRisk('mcp__slack__send_message', { text: 'hi' }, ctx)).toBe('high');
+  });
+
+  it('mcp__slack__publish_post → high (publish verb)', () => {
+    expect(classifyRisk('mcp__slack__publish_post', { text: 'hi' }, ctx)).toBe('high');
+  });
+
+  it('mcp__infra__deploy → high (deploy verb)', () => {
+    expect(classifyRisk('mcp__infra__deploy', { env: 'prod' }, ctx)).toBe('high');
+  });
+
+  it('mcp__fs__read_file → medium (non-destructive, no verb match)', () => {
+    expect(classifyRisk('mcp__fs__read_file', { path: '/tmp/foo' }, ctx)).toBe('medium');
+  });
+
+  it('MCP__server__write_data → high (write verb, case-insensitive prefix)', () => {
+    expect(classifyRisk('MCP__server__write_data', {}, ctx)).toBe('high');
   });
 });

--- a/src/agent/risk-classifier.ts
+++ b/src/agent/risk-classifier.ts
@@ -242,6 +242,75 @@ export function classifyRisk(
     return 'medium';
   }
 
+  // ---- MCP tools ----------------------------------------------------------
+  // Invariant: any tool whose name begins with `mcp__` is an externally-
+  // contributed function from a third-party server (postgres, filesystem,
+  // GitHub, etc.). The classifier has NO visibility into what that tool does,
+  // so it cannot distinguish a safe MCP read from a destructive mutation
+  // (e.g. `mcp__postgres__drop_table`, `mcp__fs__delete`). Failing open here
+  // (returning 'safe') would let an unattended run silently execute arbitrary
+  // external side-effects — exactly the scenario AFK gate exists to prevent.
+  //
+  // Policy (conservative default, operator-upgradable):
+  //   - Mutation-patterned names (`*delete*`, `*drop*`, `*remove*`, `*write*`,
+  //     `*create*`, `*update*`, `*insert*`, `*exec*`, `*run*`, `*send*`,
+  //     `*push*`, `*publish*`, `*deploy*`) → 'high': irreversible external
+  //     side-effects, gate behind approval.
+  //   - All other MCP tools → 'medium': may have network/quota side-effects,
+  //     but not obviously destructive. Medium is allowed in AFK (gate only
+  //     blocks 'high'), which matches the posture for normal git push / install.
+  //
+  // Rationale for not defaulting ALL MCP to 'high': the policy guide says
+  // "medium ops … are ALLOWED — autonomous work has to be useful." A blanket
+  // 'high' on every MCP call would make MCP unusable in AFK, defeating its
+  // value for automation-friendly setups. The sub-name filter catches the
+  // clearly-dangerous verbs; a future per-server allowlist can refine further.
+  if (toolName.startsWith('mcp__') || toolName.startsWith('MCP__')) {
+    const subName = toolName.split('__').slice(2).join('__').toLowerCase();
+    const DESTRUCTIVE_VERBS = [
+      'delete', 'drop', 'remove', 'destroy', 'truncate', 'purge',
+      'write', 'create', 'update', 'insert', 'upsert', 'patch',
+      'exec', 'execute', 'run', 'eval',
+      'send', 'push', 'publish', 'deploy', 'post',
+    ];
+    for (const verb of DESTRUCTIVE_VERBS) {
+      if (subName.includes(verb)) return 'high';
+    }
+    return 'medium';
+  }
+
+  // ---- schedule mutations --------------------------------------------------
+  // Invariant: create_schedule and cancel_schedule modify the daemon's cron
+  // store (schedules.json) and may immediately affect a running daemon via live
+  // sync. These are irreversible in the sense that a wrongly-scheduled task
+  // could run before the operator notices — so they are 'high', gated behind
+  // explicit approval in AFK mode. list_schedules and get_schedule_history are
+  // read-only and fall through to the 'safe' default below.
+  if (tool === 'create_schedule' || tool === 'cancel_schedule') {
+    return 'high';
+  }
+
+  // ---- browser actions -----------------------------------------------------
+  // browser_act and browser_open drive a stateful headed browser session and
+  // can submit forms, click "Delete", trigger purchases, or navigate to
+  // arbitrary URLs — side-effects that survive the session and may be
+  // irreversible. They are 'medium' rather than 'high' because they are
+  // generally recoverable (navigate away, close the tab) and the AFK posture
+  // allows medium ops unattended. browser_screenshot and browser_observe are
+  // read-only; browser_close is a cleanup op — all safe.
+  if (tool === 'browser_act' || tool === 'browser_open') {
+    return 'medium';
+  }
+
+  // ---- web_scrape ----------------------------------------------------------
+  // web_scrape issues outbound HTTP requests (and optionally headless-browser
+  // renders for JS-heavy pages). It may hit rate-limited, metered, or
+  // auth-gated endpoints. 'medium' — notable network side-effect but recoverable
+  // and broadly necessary for autonomous research work in AFK mode.
+  if (tool === 'web_scrape') {
+    return 'medium';
+  }
+
   // ---- unknown tool -------------------------------------------------------
   // Don't gate things we haven't classified — default to safe so the
   // classifier never blocks novel tools without an explicit rule.


### PR DESCRIPTION
## Problem

`classifyRisk()` in `src/agent/risk-classifier.ts` fell through to `return 'safe'` for four tool classes that were never explicitly handled:

- **MCP tools** (`mcp__*`): `categorizeTool` returns `'mcp'`, not `'read'`, so the read short-circuit never fired → every MCP tool was rated `'safe'`. A model in AFK mode could call `mcp__postgres__drop_table` unattended.
- **`create_schedule` / `cancel_schedule`**: `categorizeTool` returns `'schedule'` → fell to unknown → `'safe'`. Could silently mutate the daemon cron store.
- **`browser_open` / `browser_act`**: `categorizeTool` returns `'browser'` → fell to unknown → `'safe'`. Could submit forms or click destructive UI unattended.
- **`web_scrape`**: `categorizeTool` returns `'web'` → fell to unknown → `'safe'`. The existing test even incorrectly asserted `'safe'`.

## Policy applied (minimal, defensible)

| Tool class | Old | New | Rationale |
|---|---|---|---|
| `mcp__*` with destructive verb (`delete`, `drop`, `remove`, `write`, `create`, `update`, `insert`, `exec/execute/run`, `eval`, `send`, `push`, `publish`, `deploy`, `post`) | safe | **high** | Irreversible external side-effects; classifier has no visibility into what MCP servers do |
| `mcp__*` without destructive verb | safe | **medium** | May have network/quota side-effects; medium is allowed in AFK and needed for autonomous research |
| `create_schedule` | safe | **high** | Mutates daemon cron store; may live-sync immediately |
| `cancel_schedule` | safe | **high** | Same — permanent until re-created |
| `list_schedules`, `get_schedule_history` | safe | safe (unchanged) | Read-only |
| `browser_open`, `browser_act` | safe | **medium** | Stateful navigation; recoverable so not high; needed for AFK browser automation |
| `browser_observe`, `browser_screenshot`, `browser_close` | safe | safe (unchanged) | Read-only / cleanup |
| `web_scrape` | safe (wrong) | **medium** | Outbound HTTP; recoverable but notable network side-effect |

**Deferred:** Per-server MCP allowlist (e.g. treat `mcp__github__list_issues` as `'safe'`). The verb-filter catches the clearly-dangerous cases; a future per-server config can refine individual servers. Noted in code comments.

## Files changed

- `src/agent/risk-classifier.ts` — four new classified sections (MCP, schedule mutations, browser actions, web_scrape); invariant comments follow the ≥15-line prefix convention
- `src/agent/risk-classifier.test.ts` — 20 new test cases (schedule ×4, browser ×5, MCP ×11); fixed existing wrong `web_scrape → safe` assertion
- `src/agent/afk-mode-gate.ts` — updated module-level policy comment to name the two newly-gated classes

## Test evidence

```
Risk-classifier: 58 passed (58)   ← +20 new cases, 0 failures
AFK-mode-gate:   43 passed (43)   ← all existing, unchanged
Lint:            tsc --noEmit clean
```

Closes #198