### PR TITLE
docs(website): real-world examples and a Bundled Skills reference page

### DIFF
--- a/website/content/docs/configuration/models-providers.mdx
+++ b/website/content/docs/configuration/models-providers.mdx
@@ -43,9 +43,9 @@ export AFK_MODEL=sonnet          # or: haiku, opus, fable, gpt-5, etc.
 Override for a single call:
 
 ```bash
-afk chat "explain this" --model opus
+afk chat "explain this stack trace" --model opus
 afk i --model haiku
-afk chat "refactor" --model gpt-5
+afk chat "summarise the staged diff" --model gpt-5
 ```
 
 Switch mid-session in the REPL:

--- a/website/content/docs/configuration/overview.mdx
+++ b/website/content/docs/configuration/overview.mdx
@@ -208,7 +208,7 @@ Configures default task and optional worktree pruning for `afk daemon`.
 ```json
 {
   "daemon": {
-    "task": "/review --auto",
+    "task": "/review the most recent pr",
     "taskId": "default",
     "worktreePrune": {
       "enabled": true,

--- a/website/content/docs/configuration/overview.mdx
+++ b/website/content/docs/configuration/overview.mdx
@@ -110,7 +110,7 @@ optional; unset fields fall through to env vars or built-in defaults.
   "model": "sonnet",
   "maxTokens": 4096,
   "temperature": 1.0,
-  "systemPrompt": "You are a helpful assistant.",
+  "systemPrompt": "Always run the test suite before declaring a task done. Prefer small, reversible commits.",
   "updatePolicy": "notify",
   "autoResumeOnUsageLimit": true,
   "bgSummaries": false,
@@ -208,7 +208,7 @@ Configures default task and optional worktree pruning for `afk daemon`.
 ```json
 {
   "daemon": {
-    "task": "/forge-friction --auto",
+    "task": "/review --auto",
     "taskId": "default",
     "worktreePrune": {
       "enabled": true,

--- a/website/content/docs/configuration/permissions.mdx
+++ b/website/content/docs/configuration/permissions.mdx
@@ -143,7 +143,7 @@ In the REPL the primary keyboard entry point is **Shift+Tab** (advances the ring
 `--dangerously-skip-permissions` flag on both `afk i` and `afk chat`:
 
 ```bash
-afk chat "migrate the schema" --dangerously-skip-permissions
+afk chat "run the pending migrations and fix any broken model references" --dangerously-skip-permissions
 ```
 
 <Callout type="warn">

--- a/website/content/docs/guides/headless.mdx
+++ b/website/content/docs/guides/headless.mdx
@@ -66,7 +66,7 @@ afk chat "summarise this repo" --format stream-json \
   | jq -r 'select(.type == "chunk" and .chunk.type == "content") | .chunk.content'
 
 # Extract final token usage
-afk chat "count words" --format stream-json \
+afk chat "summarise the staged diff" --format stream-json \
   | jq 'select(.type == "done") | .metadata.usage'
 
 # Detect tool-use events in the stream
@@ -106,10 +106,10 @@ for await (const line of rl) {
 
 ```bash
 # Start a session and record its ID
-afk chat "begin the task" --format stream-json | tee run1.ndjson
+afk chat "start reviewing PR 1234" --format stream-json | tee run1.ndjson
 
 # Resume later
-afk chat "continue" --format stream-json --session-id <id> | tee run2.ndjson
+afk chat "now post your findings as a PR comment" --format stream-json --session-id <id> | tee run2.ndjson
 ```
 
 ## Scope and limitations

--- a/website/content/docs/guides/subagents.mdx
+++ b/website/content/docs/guides/subagents.mdx
@@ -38,9 +38,9 @@ The primary dispatch mechanism is the built-in `agent` tool (also called `Task` 
 
 ```
 agent({
-  prompt: "Read src/auth/session.ts and summarise the session lifecycle in ≤200 words. Cite file:line for each claim.",
+  prompt: "Read the retry logic in src/http/client.ts and explain the backoff strategy in ≤150 words. Cite file:line for each claim.",
   model: "haiku",          // optional — right-size the model
-  max_turns: 10            // optional — bound the budget
+  max_turns: 5             // optional — bound the budget
 })
 ```
 
@@ -104,14 +104,18 @@ For structured multi-agent workflows, the `compose` tool dispatches up to 20 sub
 ```
 compose({
   nodes: [
-    { id: "audit", prompt: "audit the auth module" },
-    { id: "tests", prompt: "read the test suite for auth" },
-    { id: "report", prompt: "write a combined report", dependsOn: ["audit", "tests"] }
+    { id: "security", prompt: "Audit src/api for authz and injection bugs. List each finding with file:line." },
+    { id: "coverage", prompt: "Find untested branches in src/api. List each with file:line." },
+    { id: "report",   prompt: "Combine the security and coverage findings into one prioritised punch-list." }
+  ],
+  edges: [
+    { from: "security", to: "report" },
+    { from: "coverage", to: "report" }
   ]
 })
 ```
 
-`audit` and `tests` run in parallel. `report` starts only after both complete. If any node fails and fail-fast is enabled (the default), downstream nodes are cancelled rather than running with incomplete inputs.
+Dependencies are declared as `edges` (`{ from, to }` — "from must finish before to starts"), not as a field on the node. Here `security` and `coverage` have no incoming edges, so they run in parallel; `report` waits for both. If any node fails and fail-fast is enabled (the default), downstream nodes are cancelled rather than running with incomplete inputs.
 
 **Limits and failure behavior:**
 - Maximum 20 nodes per `compose` call
@@ -153,7 +157,7 @@ Subagents should have explicit budgets. Before dispatching:
 
 - Set `max_turns` on focused investigations (`max_turns: 5` for a quick lookup)
 - Choose the cheapest sufficient model (`haiku` for reads, `sonnet` for multi-file analysis)
-- For wide fan-outs, consider the `/right-size-delegation` skill before dispatching to prevent cascading timeouts
+- For wide fan-outs, dispatch in bounded waves rather than all at once — a burst of parallel children can hit provider rate limits and cascade into timeouts
 
 ## Subagent output
 

--- a/website/content/docs/guides/unattended-runs.mdx
+++ b/website/content/docs/guides/unattended-runs.mdx
@@ -18,13 +18,13 @@ The daemon accepts a task at startup and runs until it reaches a terminal state.
 Pass a task inline:
 
 ```bash
-afk daemon --task "refactor the auth module and run tests"
+afk daemon --task "run the test suite; if anything is red, diagnose it and open a draft PR with the fix"
 ```
 
 Or set a default task in your environment:
 
 ```bash
-AFK_DAEMON_TASK="triage open issues and file a daily summary" afk daemon
+AFK_DAEMON_TASK="review any PRs opened since the last run and post findings as a comment" afk daemon
 ```
 
 The working directory for spawned sessions defaults to the current directory. Override with `AFK_DAEMON_CWD`.
@@ -34,7 +34,7 @@ The working directory for spawned sessions defaults to the current directory. Ov
 `--once` runs a single task and exits when it reaches a terminal state, rather than looping:
 
 ```bash
-afk daemon --once --task "run the test suite and report"
+afk daemon --once --task "run the full test suite and send me a summary on Telegram"
 ```
 
 This is useful in CI or cron where you want a bounded execution.
@@ -87,7 +87,7 @@ export AFK_TASK_BUDGET=50000
 afk config env set AFK_MAX_BUDGET_USD 2.00
 
 # Or per-run
-afk daemon --max-budget-usd 2.00 --task "..."
+afk daemon --max-budget-usd 2.00 --task "triage today's new issues and draft a reply to each"
 ```
 
 When the session's cumulative spend crosses the ceiling, the turn aborts and you'll see `Hit the budget cap` in the output. Raise `AFK_MAX_BUDGET_USD` or unset it for the session to remove the limit.
@@ -106,8 +106,8 @@ A per-output-token cap is also available if you need tighter control:
 ```bash
 # Add a task
 afk schedule add \
-  --name "nightly test run" \
-  --command "run the test suite and file a summary" \
+  --name "nightly tests" \
+  --command "run the test suite; if it fails, diagnose the failure and open a fix PR" \
   --cron "0 2 * * *"
 
 # List all tasks
@@ -146,9 +146,9 @@ Control when Telegram notifications fire per task:
 
 ```bash
 afk schedule add \
-  --name "daily digest" \
-  --command "..." \
-  --cron "0 9 * * *" \
+  --name "daily PR review" \
+  --command "/review --auto" \
+  --cron "0 9 * * 1-5" \
   --notify always     # always | failure | never
 ```
 
@@ -180,8 +180,8 @@ daemon's poll interval (30 seconds).
 afk daemon --trigger pull
 
 # 2. Enqueue tasks from another terminal (or a script) while the daemon runs
-afk queue add "/forge-friction --auto" --notify-on failure
-afk queue add "/review --auto" --notify-on always
+afk queue add "/review 1234 --post github" --notify-on always
+afk queue add "/diagnose the failing integration test on main" --notify-on failure
 
 # Tasks are picked up and executed in order on the next poll (≤30s)
 ```

--- a/website/content/docs/guides/worktrees.mdx
+++ b/website/content/docs/guides/worktrees.mdx
@@ -95,7 +95,7 @@ Set `AFK_WORKTREE_BOOT_PRUNE=1` to have the daemon prune stale worktrees at star
 `afk farm` runs the same task across multiple isolated worktrees in parallel, then picks the best result:
 
 ```bash
-afk farm --task "refactor the auth module" --branches 3
+afk farm --task "speed up the slow /search endpoint" --branches 3
 ```
 
 Each branch runs in a separate worktree. At completion, `afk farm` scores the branches, prints a summary table, writes a memory fact about the winner, and optionally sends a Telegram digest.

--- a/website/content/docs/guides/worktrees.mdx
+++ b/website/content/docs/guides/worktrees.mdx
@@ -95,7 +95,7 @@ Set `AFK_WORKTREE_BOOT_PRUNE=1` to have the daemon prune stale worktrees at star
 `afk farm` runs the same task across multiple isolated worktrees in parallel, then picks the best result:
 
 ```bash
-afk farm --task "speed up the slow /search endpoint" --branches 3
+afk farm "speed up the slow /search endpoint" --branches 3
 ```
 
 Each branch runs in a separate worktree. At completion, `afk farm` scores the branches, prints a summary table, writes a memory fact about the winner, and optionally sends a Telegram digest.

--- a/website/content/docs/skills/built-in.mdx
+++ b/website/content/docs/skills/built-in.mdx
@@ -97,3 +97,5 @@ The following skills are registered but hidden from public surfaces unless `AFK_
 ## Skills registered at runtime by plugins
 
 Plugin skills (`~/.afk/plugins/<plugin>/skills/<skill>/SKILL.md`) are discovered automatically when the plugin is installed. They surface in `/help` and tab-complete. See [Custom Skills](/skills/custom) for how to author your own.
+
+The `awa-bundled` plugin ships fifteen additional skills with agent-afk — see [Bundled Skills](/skills/bundled) for the full list.

--- a/website/content/docs/skills/bundled.mdx
+++ b/website/content/docs/skills/bundled.mdx
@@ -1,0 +1,228 @@
+---
+title: "Bundled Skills"
+description: "Skills that ship with agent-afk via the awa-bundled plugin — slash commands, automatic guardrails, and helper conventions."
+---
+
+These skills ship with agent-afk via the built-in `awa-bundled` plugin. They surface as slash commands (type `/skillname`) and appear in `/help`. Except where noted, the model can also invoke them on its own when the situation calls for it. They complement the [core built-in skills](/skills/built-in).
+
+---
+
+## Workflow skills
+
+Skills you reach for to get work done.
+
+### `/review`
+
+```
+/review [diff|pr-url|pr-number|commit-sha|branch|--staged|--head] [--light] [--change-type hotfix|feature|refactor|dep-bump|new-service] [--post github|telegram] [--brief <text>|--spec <path>]
+```
+
+**Purpose:** Parallel code review across security, correctness, API compatibility, test coverage, and performance.
+
+**What it does:** Accepts a diff, PR URL, PR number, commit SHA, branch, staged changes, or patch file and runs two parallel review agents that cover all dimensions. A citation-verification pass removes fabricated or stale findings before synthesis. Emits a MERGE / DO NOT MERGE recommendation with ranked findings. Read-only: it never edits files, commits, pushes, or modifies a PR.
+
+**When to use:** When changes are ready for review before merge and you want a structured multi-dimension analysis.
+
+---
+
+### `/ship`
+
+```
+/ship [--verify] [--draft] [--dry-run]
+```
+
+**Purpose:** Release pipeline for already-done local work — pre-flight, tests, commit, push, and PR in one pass.
+
+**What it does:** Runs a `ground-state` pre-flight, detects and runs the project test suite (aborting on failure), drafts a Conventional Commits message, commits, pushes the feature branch, and opens a PR with a structured verification summary. Pass `--verify` to add an adversarial verifier wave on the diff before the PR goes up. Never pushes to the default branch.
+
+**When to use:** When local changes are done and you want to hand them off to review — "ship this", "push and open a PR", "release this work".
+
+---
+
+### `/refactor`
+
+```
+/refactor <refactor goal> [--scope <glob-or-path>]
+```
+
+**Purpose:** Safe, large-scale structural changes — symbol renames, API migrations, pattern standardizations, layer restructurings.
+
+**What it does:** Enumerates every affected site, groups them into dependency layers, applies changes in parallel per layer with worktree isolation, and verifies behavioral preservation at each layer boundary before proceeding. Exits immediately on the first regression and surfaces the exact site, diff, and behavioral delta. Best for changes touching more than 3 files with dependency ordering.
+
+**When to use:** When a rename, migration, or pattern change touches many files and you need guaranteed behavioral preservation at every step.
+
+---
+
+### `/simplify`
+
+```
+/simplify [target] [--apply] [--all]
+```
+
+**Purpose:** Find and rank incidental complexity, duplication, and dead code — then optionally apply safe reductions.
+
+**What it does:** Dispatches four parallel read-only lenses (clone detection, dead code, complexity hotspots, wrong abstraction) and synthesizes a ranked, behavior-preserving reduction plan. Default mode is read-only — nothing changes until you pass `--apply`. Apply mode gates on a green test suite and delegates multi-site changes to `/refactor`.
+
+**When to use:** When you want to understand what is safe to clean up in a codebase before committing to changes.
+
+---
+
+### `/spec`
+
+```
+/spec <idea or feature request>
+```
+
+**Purpose:** Transform a loose idea into a structured, actionable spec ready for implementation.
+
+**What it does:** Dispatches two parallel agents — one researching the web for prior art and comparable approaches, one inspecting the local working directory for conventions and integration points. Synthesizes a domain-appropriate spec (software, research, design, business, or generic) with an epistemic confidence section, then pauses for your confirmation before anything is built. Bug-shaped inputs (crashes, regressions) are redirected to `/diagnose` instead.
+
+**When to use:** When you have an idea or feature request that needs scoping before you start building.
+
+---
+
+### `/gather`
+
+```
+/gather
+```
+
+**Purpose:** Parallel context-gathering for a code area — structure and test coverage in one wave.
+
+**What it does:** Dispatches exactly two agents simultaneously: a Structure Agent that maps imports, callers, config references, and public interfaces; and a Test Agent that finds test files, coverage, and untested paths. Merges results into a unified context map. Prevents the slower, sequential pattern of reading files one at a time.
+
+**When to use:** When you need to understand a module, feature, or subsystem and would otherwise read three or more files sequentially.
+
+---
+
+### `/research`
+
+```
+/research
+```
+
+**Purpose:** Parallel external and local context-gathering for the current task.
+
+**What it does:** Dispatches two agents simultaneously — one searches the web for prior art, patterns, APIs, and comparable approaches; the other inspects the local working directory for domain-relevant artifacts (code, papers, design files, financial models — adapts to the domain). Returns a merged brief with findings, conflicts, risks, and coverage gaps flagged prominently.
+
+**When to use:** When you need both external context and local grounding before making a decision or starting a task.
+
+---
+
+### `/devils-advocate`
+
+```
+/devils-advocate
+```
+
+**Purpose:** Adversarially critique a proposal by generating structured alternatives before you commit to it.
+
+**What it does:** Dispatches three parallel critics — pragmatist (cheapest path), paranoid (safest path), architect (right abstraction level) — each inventing an independent alternative. A synthesis step ranks all four options (original plus three alternatives) and recommends the top choice. When critics converge, a composition-boundary check fires to catch failures invisible in isolation.
+
+**When to use:** When a plan, fix, decomposition, or named recommendation will drive decisions and you want structured alternative-generation before acting.
+
+---
+
+### `/ground-claim`
+
+```
+/ground-claim <capability question> | mode: runtime-wiring claims: [...]
+```
+
+**Purpose:** Ground capability claims with file-read evidence — no answers from model recall alone.
+
+**What it does:** In default mode, answers meta-capability questions ("what does this repo enable?", "list the available skills") with `path:line` citations from actual file reads, tagging any unverified claim explicitly. In `runtime-wiring` mode, traces actual execution paths — call sites, DI registration, middleware — for a supplied list of claims and returns CONFIRMED / UNVERIFIED / REFUTED verdicts per claim. Any non-CONFIRMED verdict blocks downstream sign-off.
+
+**When to use:** When you need an evidence-backed answer about what a system actually does, or need to verify that a capability is genuinely wired at runtime.
+
+---
+
+### `/automate`
+
+```
+/automate
+```
+
+**Purpose:** Set up a scheduled headless AFK run that pushes a summary to Telegram.
+
+**What it does:** Scouts existing schedules and daemon/service state, designs a self-contained recurring task prompt, creates the job via AFK's native scheduler (`create_schedule`), ensures the daemon survives reboot, and runs a verification pass confirming the Telegram summary actually arrives. Requires Telegram to be configured — prompts you to run `/telegram-setup` first if it isn't.
+
+**When to use:** When you want a recurring task (daily report, nightly check, scheduled workflow) to run headlessly and push results to Telegram.
+
+> **Note:** `automate` is slash-command only — the model will not auto-invoke it. Run `/automate` explicitly.
+
+---
+
+## Automatic guardrails
+
+These skills fire automatically at lifecycle points in multi-step work. You can also invoke them manually.
+
+### `/intent-lock`
+
+```
+/intent-lock
+```
+
+**Purpose:** Resolve ambiguous referents and unverified characterizations before multi-step work begins.
+
+**What it does:** Scans the request for ambiguous referents ("the text", "her draft"), unverified status claims ("the PR is approved"), identity assumptions, and code-vs-runtime dual referents (terms like "session" or "hooks" that name both a project concept and an agent runtime concept). Emits a one-sentence interpretation lock per finding and proceeds — escalating to a blocking question only when the ambiguity gates an irreversible action with multiple plausible reads.
+
+**When to use:** Fires automatically before any multi-step task with ambiguous inputs. Invoke manually when you want to surface and lock interpretations before a complex operation.
+
+---
+
+### `/ground-state`
+
+```
+/ground-state
+```
+
+**Purpose:** Pre-flight reconnaissance wave — git state, project infrastructure, and prior-session memory — before any non-trivial implementation.
+
+**What it does:** Dispatches three parallel read-only agents (state surveyor, infrastructure surveyor, memory surveyor), synthesizes a 6-line ground-truth snapshot, then constructs a Brief Anchor — a path-verified preamble that gets prepended to every subsequent sub-agent brief so they all start from the same verified cwd, branch, and HEAD. Never edits files. Domain-aware: adapts to software, research, design, or business projects.
+
+**When to use:** Fires automatically before multi-step implementations. Invoke manually before any significant work to get a verified snapshot of repo state and avoid stale-worktree errors.
+
+---
+
+### `/shadow-verify`
+
+```
+/shadow-verify
+```
+
+**Purpose:** Adversarial verification of high-stakes sub-agent findings before they drive decisions.
+
+**What it does:** Extracts 2–3 concrete, re-checkable claims from a sub-agent's report and dispatches one independent verifier per claim in parallel. Each verifier re-derives its verdict from scratch using tool calls only — never re-reading the original reasoning — and returns CONFIRMED / REFUTED / UNVERIFIABLE with evidence. Refuted claims surface with a corrected finding; unverifiable claims get a `[needs-human-review]` tag. A composition-boundary check catches echo-chamber confirmations.
+
+**When to use:** Fires automatically after high-stakes investigations (code reviews, audits, refactor plans). Invoke manually whenever a sub-agent asserts a claim with high-confidence language ("confident", "certain", "clearly") that will drive file edits, commits, or external actions.
+
+---
+
+### `/parallelize`
+
+```
+/parallelize
+```
+
+**Purpose:** Transform a sequential plan into a dependency-aware orchestration of parallel sub-agent waves.
+
+**What it does:** Dispatches a planning agent that takes the current plan, identifies which work is sequential versus parallelizable, and rewrites it as a wave-based orchestration plan with embedded test-driven development in implementation lanes. Prevents slow, sequential execution of work that could run in parallel.
+
+**When to use:** After finishing a plan in plan mode — run `/parallelize` before implementation to get a wave-optimized execution plan.
+
+---
+
+## Helper conventions
+
+### `/contract`
+
+```
+/contract
+```
+
+**Purpose:** Reference convention for structured sub-agent I/O schemas — loaded by other skills, not typically invoked directly.
+
+**What it does:** Defines the standard schema for sub-agent dispatches: `goal`, `inputs`, `artifacts`, `non_goals`, `failure_modes`, and optional `domain`. Also defines epistemic confidence fields (`confidence`, `coverage_gaps`, `boundary_flag`, `recommended_action`) that surface coverage gaps during result merging. Other orchestrator skills load this convention via `/contract` in their own prompts.
+
+**When to use:** Referenced automatically by skills like `review`, `refactor`, `shadow-verify`, and others. Invoke manually if you're authoring a custom skill and want to adopt the same structured I/O convention.

--- a/website/content/docs/skills/bundled.mdx
+++ b/website/content/docs/skills/bundled.mdx
@@ -19,7 +19,7 @@ Skills you reach for to get work done.
 
 **Purpose:** Parallel code review across security, correctness, API compatibility, test coverage, and performance.
 
-**What it does:** Accepts a diff, PR URL, PR number, commit SHA, branch, staged changes, or patch file and runs two parallel review agents that cover all dimensions. A citation-verification pass removes fabricated or stale findings before synthesis. Emits a MERGE / DO NOT MERGE recommendation with ranked findings. Read-only: it never edits files, commits, pushes, or modifies a PR.
+**What it does:** Accepts a diff, PR URL, PR number, commit SHA, branch, staged changes, or patch file and runs up to two parallel review agents that cover all dimensions. A citation-verification pass removes fabricated or stale findings before synthesis. Emits a MERGE / DO NOT MERGE recommendation with ranked findings. Read-only: it never edits files, commits, pushes, or modifies a PR.
 
 **When to use:** When changes are ready for review before merge and you want a structured multi-dimension analysis.
 

--- a/website/content/docs/skills/meta.json
+++ b/website/content/docs/skills/meta.json
@@ -1,1 +1,1 @@
-{"title":"Skills","pages":["overview","built-in","custom"]}
+{"title":"Skills","pages":["overview","built-in","bundled","custom"]}

--- a/website/content/docs/surfaces/daemon.mdx
+++ b/website/content/docs/surfaces/daemon.mdx
@@ -8,7 +8,7 @@ cron expressions, on session start, or from a pull queue — and optionally push
 notifications via Telegram.
 
 ```bash
-afk daemon --cron "0 */6 * * *" --task "/forge-friction --auto"
+afk daemon --cron "0 */6 * * *" --task "/review --auto"
 ```
 
 ## Trigger modes
@@ -80,7 +80,7 @@ status (✅ success / ⏭️ skipped / ❌ failed), duration, and a response exc
 ```bash
 export TELEGRAM_BOT_TOKEN=1234567890:ABC...
 export AFK_TELEGRAM_ALLOWED_CHAT_IDS=12345678
-afk daemon --cron "0 2 * * *" --task "/mint run-nightly"
+afk daemon --cron "0 2 * * *" --task "run the nightly test suite and triage any failures"
 ```
 
 ## Scheduled tasks with `afk schedule`


### PR DESCRIPTION
## Summary

Docs-only improvements to the fumadocs site (`website/content/docs/`), in two parts:

**1. Real-world examples (replacing contrived placeholders).** The docs repeatedly used a fictional "auth module" as the running example. Replaced those with examples grounded in actual agent-coding workflows:
- Daemon / scheduled / queue tasks now show genuine overnight work — run tests then diagnose-and-open-a-fix-PR, scheduled PR review, diagnose a failing integration test, nightly tests + Telegram summary.
- `subagents.mdx`: de-genericized the `agent()` read example and **fixed the `compose()` example to the correct `edges: [{ from, to }]` schema** — the old example used a non-existent `dependsOn` field on the node, which would silently break dependency ordering.
- `chat` / `farm` / `permissions` / `models` examples made concrete (stack trace, staged diff, perf branch-farm, migration with broken-ref fixup).
- Removed stale references to skills **absent from the public build** — `/forge-friction` (×3) and `/right-size-delegation` — swapping in public skills (`/review`, `/diagnose`) and surface-accurate guidance.

**2. New "Bundled Skills" reference page.** Added `skills/bundled.mdx` documenting all 15 skills shipped via the bundled `awa-bundled` plugin, grouped as Workflow skills (`/review`, `/ship`, `/refactor`, `/simplify`, `/spec`, `/gather`, `/research`, `/devils-advocate`, `/ground-claim`, `/automate`), Automatic guardrails (`/intent-lock`, `/ground-state`, `/shadow-verify`, `/parallelize`), and Helper conventions (`/contract`). Registered the page in `skills/meta.json` nav and cross-linked it from `built-in.mdx`. Each entry's usage and behavior is derived faithfully from the corresponding `SKILL.md`.

## Test results

- N/A — docs-only change (`website/content/docs`). The repo-root TypeScript test suite is unrelated to these docs and has known pre-existing env failures (exits non-zero on clean `main`); the `website/` workspace has no installed deps in this worktree. Validated structurally instead: balanced code fences, valid `meta.json` JSON, and MDX brace-safety (braces only inside inline code).

## Verification

- No adversarial verifier wave run (docs/prose, not code logic). Bundled-skill entries were cross-checked against their `SKILL.md` sources — e.g. `/ship`'s `--verify`/`--draft`/`--dry-run` flags and `/review`'s "2 parallel agents" and read-only guarantees are confirmed accurate, not invented.

## Notes

- 2 commits: real-world example rewrites (`f925184`) and the bundled-skills reference page (`cdb1b6b`).
- Public-safe: no private/moat skills, repo names, or PII introduced.
