### PR TITLE
test(harness): isolate vitest suite from ambient AFK_* config env

### DIFF
--- a/src/__test-utils__/clean-config-env.ts
+++ b/src/__test-utils__/clean-config-env.ts
@@ -58,7 +58,7 @@ const CONFIG_OVERRIDE_VARS: readonly string[] = ENV_REGISTRY.filter(
 
 beforeEach(() => {
   for (const key of CONFIG_OVERRIDE_VARS) {
-    delete process.env[key];
+    delete process.env[key]; // audit-env-access: allow — dynamic delete of registry-derived config keys
   }
 });
 

--- a/src/__test-utils__/clean-config-env.ts
+++ b/src/__test-utils__/clean-config-env.ts
@@ -1,0 +1,69 @@
+// Global test setup: neutralize the developer's ambient AFK_*/provider config
+// so tests assert framework DEFAULTS, not whatever is configured on the machine
+// running them.
+//
+// History: this started as a hand-maintained allowlist of ~22 config-override
+// var names. A devils-advocate review found the list was already incomplete
+// (it omitted AFK_TEMPERATURE, AFK_THINKING, AFK_TIMEOUT_MS, AFK_MODEL_MEDIUM,
+// AFK_TELEGRAM_*, and the tier-2 model slots) and would rot silently as new
+// vars were added. It is now DERIVED from ENV_REGISTRY — see the Invariant
+// below. Full rationale: docs/test-env-isolation.md (add on next touch).
+//
+// Bleed vector — inherited shell env: the vitest process inherits every
+// exported AFK_* / provider var (AFK_MODEL, AFK_COMPACT_MODEL, AFK_TELEGRAM_*,
+// …), and src/config/env.ts reads each one LIVE from process.env. A test
+// exercising production code that reads one of those getters WITHOUT stubbing
+// it picks up the dev's value — e.g. an exported AFK_COMPACT_MODEL once flipped
+// the compact() summarizer assertion. The beforeEach below deletes every
+// registry-known config-override var so each test starts from a known baseline;
+// a test that needs a value sets it explicitly (process.env / vi.stubEnv).
+//
+// Invariant: the clear-list is DERIVED from ENV_REGISTRY, never hand-listed.
+// Every env getter in src/config/env.ts must have a matching ENV_REGISTRY entry
+// (enforced by the env.ts header contract + `pnpm scan:env`), so a newly-added
+// config var is covered automatically — no second place to update, no silent
+// allowlist rot.
+//
+// Invariant: categories 'paths' and 'process' are NEVER cleared. 'paths'
+// (AFK_HOME, AFK_STATE_DIR, AFK_FRAMEWORK_DIR) is BOTH the redirect surface ~11
+// test files assign at module-eval time (before any beforeEach runs) AND the
+// subject of ~44 tests that assert the UNSET fallback (getAfkHome() → ~/.afk,
+// AFK.md → ~/.afk/AFK.md, hot-memory/session-store paths). Clearing or sealing
+// it breaks both groups. 'process' carries runtime/system vars (PATH, NODE_ENV,
+// VITEST, CI) and the bash/path security guards — clearing those would break
+// vitest itself and any subprocess-spawning test.
+//
+// Residual: the OTHER bleed vector — loadConfig() dotenv-loading the real
+// ~/.afk/config/afk.env (override:false) and repopulating deleted vars — is NOT
+// closed here. Sealing AFK_HOME to a temp dir would close it but breaks the ~44
+// unset-fallback tests above (verified). It is instead handled per-test: the
+// few suites that call loadConfig() mock dotenv or reset the config cache. No
+// test currently exhibits repopulation bleed (full-suite verified green with a
+// hostile real afk.env present).
+import { beforeEach, afterEach, vi } from 'vitest';
+import { ENV_REGISTRY } from '../config/env.js';
+
+/**
+ * Registry categories that must NOT be cleared between tests. See module header.
+ */
+const NON_OVERRIDE_CATEGORIES: ReadonlySet<string> = new Set(['paths', 'process']);
+
+/**
+ * Config-override env vars cleared before every test, derived from ENV_REGISTRY
+ * (the single source of truth). A test needing a specific value sets it itself.
+ */
+const CONFIG_OVERRIDE_VARS: readonly string[] = ENV_REGISTRY.filter(
+  (entry) => !NON_OVERRIDE_CATEGORIES.has(entry.category),
+).map((entry) => entry.name);
+
+beforeEach(() => {
+  for (const key of CONFIG_OVERRIDE_VARS) {
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  // Revert any vi.stubEnv overrides a test installed. The raw deletes above are
+  // re-applied every beforeEach, so they need no explicit restore.
+  vi.unstubAllEnvs();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,12 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    setupFiles: ['./src/__test-utils__/stdin-claim-reset.ts'],
+    setupFiles: [
+      './src/__test-utils__/stdin-claim-reset.ts',
+      // Neutralize the developer's ambient AFK_*/provider config so tests
+      // assert framework defaults, not the dev's shell / ~/.afk/config/afk.env.
+      './src/__test-utils__/clean-config-env.ts',
+    ],
     // testTimeout: bumped from vitest default 5000ms to 15000ms.
     // Many CLI/bootstrap tests do `await import('./bootstrap.js')` (directly or
     // via vi.doMock setup) and the transitive import graph can exceed 5s under


### PR DESCRIPTION
## Problem

The vitest harness had **zero environment isolation**. The test process inherits the developer's exported shell vars (e.g. `AFK_MODEL`, `AFK_COMPACT_MODEL`, `AFK_TELEGRAM_*`), and any test calling `loadConfig()` dotenv-loads the real `~/.afk/config/afk.env`. Because `src/config/env.ts` exposes every var as a **live getter** over `process.env`, a developer-set config value silently overrides the framework default a test asserts.

Concrete failure: an exported `AFK_COMPACT_MODEL=claude-haiku-4-5` flipped `anthropic-direct.test.ts`'s `compact()` assertion (`expected 'claude-haiku-4-5' to be 'claude-haiku-4-5-20251001'`). These false failures surface **only on configured dev machines, never in clean CI** — a recurring, confusing class of breakage.

## Solution

A global vitest setup file (`src/__test-utils__/clean-config-env.ts`, wired via `vitest.config.ts setupFiles`):

- **`beforeEach`** deletes every config-override env var so each test starts from a known baseline; a test that needs a value sets it explicitly.
- **`afterEach`** calls `vi.unstubAllEnvs()` to revert per-test stubs.

The clear-list is **derived from `ENV_REGISTRY`** (the single source of truth), not hand-maintained — `env.ts` already requires every getter to have a registry entry (enforced by its header contract + `pnpm scan:env`), so newly-added config vars are covered automatically with no second place to update and no silent allowlist rot.

Categories **`paths`** (`AFK_HOME` / `AFK_STATE_DIR` / `AFK_FRAMEWORK_DIR`) and **`process`** (`PATH` / `NODE_ENV` / `VITEST` / `CI` + bash/path security guards) are **never** cleared — see below.

## Design notes (alternatives considered & rejected)

This went through a devils-advocate review:

- **Hand-maintained allowlist** (initial draft) — rejected: it already omitted real getters (`AFK_TEMPERATURE`, `AFK_THINKING`, `AFK_TIMEOUT_MS`, `AFK_MODEL_MEDIUM`, `AFK_TELEGRAM_*`, tier-2 model slots) and would rot. Replaced by the registry-derived list.
- **Sealing `AFK_HOME` to a temp dir** to also close the dotenv vector — rejected on evidence: it broke **44 tests across 11 files** that assert the *unset* `~/.afk` fallback (`getAfkHome() → ~/.afk`, `AFK.md → ~/.afk/AFK.md`, hot-memory / session-store paths). Hence `paths` is excluded.
- **`env.ts` `VITEST`-guarded source intercept** — deferred: adds production test-branching and depends on `ENV_REGISTRY` `default` fields which are currently sparse. Viable follow-on once defaults are filled in.

Residual: the dotenv-repopulation vector (first `loadConfig()` in a worker re-reading the real `afk.env`) is left to existing per-test discipline (those suites mock dotenv / reset the config cache); no test currently exhibits it.

## Test plan

- [x] `pnpm lint` (`tsc --noEmit`) clean
- [x] `pnpm test` — **563 files / 10409 pass / 14 skip** with a hostile ambient env exported (`AFK_MODEL=opus_1m`, `AFK_COMPACT_MODEL=claude-haiku-4-5`)
- [x] Verified the failing condition pre-fix and green post-fix
