### PR TITLE
chore(core): drop dormant forge/briefs plugin couplings from core

### DIFF
--- a/src/agent/daemon.test.ts
+++ b/src/agent/daemon.test.ts
@@ -391,14 +391,12 @@ describe('CronScheduler onTaskComplete callback', () => {
 
 describe('CronScheduler.fireOnStart (Phase 6)', () => {
   let telemetryPath: string;
-  let briefsDir: string;
   let scheduler: CronScheduler;
   let lastFakeSession: FakeAgentSessionShape | null = null;
   let nextReply: string | Error = 'ok';
 
   beforeEach(() => {
     telemetryPath = tmpTelemetryFile();
-    briefsDir = mkdtempSync(join(tmpdir(), 'agent-afk-briefs-'));
     lastFakeSession = null;
     nextReply = 'ok';
   });
@@ -406,13 +404,11 @@ describe('CronScheduler.fireOnStart (Phase 6)', () => {
   afterEach(async () => {
     await scheduler.stop();
     rmSync(telemetryPath, { force: true });
-    rmSync(briefsDir, { recursive: true, force: true });
   });
 
   function spinScheduler(now: () => number = Date.now, cooldownMs = 0): CronScheduler {
     scheduler = new CronScheduler({
       telemetryPath,
-      briefsDir,
       cooldownMs,
       now,
       sessionFactory: (_config: AgentConfig) => {
@@ -495,21 +491,6 @@ describe('CronScheduler.fireOnStart (Phase 6)', () => {
       status: 'skipped',
       skipReason: 'cooldown',
       durationMs: 0,
-    });
-    expect(lastFakeSession).toBeNull();
-  });
-
-  it('records a skipped telemetry entry when briefs are pending', async () => {
-    writeFileSync(join(briefsDir, 'brief-1.md'), '');
-    spinScheduler();
-    scheduler.register({ taskId: 't', command: 'x', trigger: 'sessionstart' });
-
-    const records = await scheduler.fireOnStart();
-    expect(records).toHaveLength(1);
-    expect(records[0]).toMatchObject({
-      taskId: 't',
-      status: 'skipped',
-      skipReason: 'briefs_pending',
     });
     expect(lastFakeSession).toBeNull();
   });

--- a/src/agent/daemon.ts
+++ b/src/agent/daemon.ts
@@ -47,8 +47,6 @@ export interface DaemonOptions {
    * task. Flows into `CronScheduler`.
    */
   cooldownMs?: number;
-  /** Override briefs directory scanned by the sessionstart gate. */
-  briefsDir?: string;
   /** Clock injection (tests). */
   now?: () => number;
   /** Optional callback fired after every telemetry record is written. */
@@ -100,7 +98,6 @@ export async function startDaemon(options: DaemonOptions = {}): Promise<DaemonHa
     ...(options.telemetryPath !== undefined ? { telemetryPath: options.telemetryPath } : {}),
     ...(options.sessionFactory !== undefined ? { sessionFactory: options.sessionFactory } : {}),
     ...(options.cooldownMs !== undefined ? { cooldownMs: options.cooldownMs } : {}),
-    ...(options.briefsDir !== undefined ? { briefsDir: options.briefsDir } : {}),
     ...(options.now !== undefined ? { now: options.now } : {}),
     ...(options.onTaskComplete !== undefined ? { onTaskComplete: options.onTaskComplete } : {}),
     ...(options.pullPollIntervalMs !== undefined ? { pullPollIntervalMs: options.pullPollIntervalMs } : {}),

--- a/src/agent/daemon/gates.test.ts
+++ b/src/agent/daemon/gates.test.ts
@@ -1,13 +1,12 @@
 /**
- * Tests for Phase 6 sessionstart gates — cooldown + brief-queue.
+ * Tests for Phase 6 sessionstart gates — cooldown.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  countPendingBriefs,
   evaluateSessionStartGates,
   readLastTickTime,
   DEFAULT_SESSIONSTART_COOLDOWN_MS,
@@ -69,72 +68,25 @@ describe('readLastTickTime', () => {
   });
 });
 
-describe('countPendingBriefs', () => {
-  let dir: string;
-
-  beforeEach(() => {
-    dir = makeTmpDir();
-  });
-
-  afterEach(() => {
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  it('returns 0 when the directory does not exist', () => {
-    expect(countPendingBriefs(join(dir, 'missing'))).toBe(0);
-  });
-
-  it('returns 0 when the directory is empty', () => {
-    expect(countPendingBriefs(dir)).toBe(0);
-  });
-
-  it('counts top-level .md files, ignoring dotfiles and non-md files', () => {
-    writeFileSync(join(dir, 'brief-1.md'), '');
-    writeFileSync(join(dir, 'brief-2.md'), '');
-    writeFileSync(join(dir, '.hidden'), '');
-    writeFileSync(join(dir, 'notes.txt'), '');
-    expect(countPendingBriefs(dir)).toBe(2);
-  });
-
-  it('does NOT count subdirectories (consumed/ and failed/ lifecycle bins)', () => {
-    // Regression: the daemon's briefs dir always holds consumed/ and failed/
-    // subdirs once any brief has been processed. Counting them as pending
-    // briefs would permanently trip the sessionstart gate's briefs_pending
-    // skip even when zero real briefs remain. Only top-level .md files count,
-    // and .md files nested inside those bins must not leak into the count.
-    mkdirSync(join(dir, 'consumed'));
-    mkdirSync(join(dir, 'failed'));
-    writeFileSync(join(dir, 'consumed', 'old-brief.md'), '');
-    expect(countPendingBriefs(dir)).toBe(0);
-
-    writeFileSync(join(dir, 'real-brief.md'), '');
-    expect(countPendingBriefs(dir)).toBe(1);
-  });
-});
-
 describe('evaluateSessionStartGates', () => {
   let dir: string;
   let telemetryPath: string;
-  let briefsDir: string;
 
   beforeEach(() => {
     dir = makeTmpDir();
     telemetryPath = join(dir, 'telemetry.jsonl');
-    briefsDir = join(dir, 'briefs');
-    mkdirSync(briefsDir);
   });
 
   afterEach(() => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it('fires when no prior telemetry and no briefs', () => {
+  it('fires when no prior telemetry', () => {
     const decision = evaluateSessionStartGates({
       taskId: 't',
       cooldownMs: DEFAULT_SESSIONSTART_COOLDOWN_MS,
       nowMs: Date.now(),
       telemetryPath,
-      briefsDir,
     });
     expect(decision.fire).toBe(true);
     expect(decision.skipReason).toBeUndefined();
@@ -152,7 +104,6 @@ describe('evaluateSessionStartGates', () => {
       cooldownMs: 6 * 60 * 60 * 1000, // 6h
       nowMs,
       telemetryPath,
-      briefsDir,
     });
     expect(decision.fire).toBe(false);
     expect(decision.skipReason).toBe('cooldown');
@@ -172,7 +123,6 @@ describe('evaluateSessionStartGates', () => {
       cooldownMs: 6 * 60 * 60 * 1000,
       nowMs,
       telemetryPath,
-      briefsDir,
     });
     expect(decision.fire).toBe(true);
     expect(decision.lastFiredAtMs).toBe(Date.parse(lastFiredAt));
@@ -189,41 +139,7 @@ describe('evaluateSessionStartGates', () => {
       cooldownMs: 0,
       nowMs,
       telemetryPath,
-      briefsDir,
     });
     expect(decision.fire).toBe(true);
-  });
-
-  it('skips when a brief is pending even after cooldown passes', () => {
-    writeFileSync(join(briefsDir, 'brief-pending.md'), '');
-    const decision = evaluateSessionStartGates({
-      taskId: 't',
-      cooldownMs: DEFAULT_SESSIONSTART_COOLDOWN_MS,
-      nowMs: Date.now(),
-      telemetryPath,
-      briefsDir,
-    });
-    expect(decision.fire).toBe(false);
-    expect(decision.skipReason).toBe('briefs_pending');
-    expect(decision.pendingBriefCount).toBe(1);
-  });
-
-  it('cooldown is checked before brief queue — cooldown miss reported, not briefs', () => {
-    // Both gates would fail; cooldown gate fires first.
-    const nowMs = Date.parse('2026-04-18T12:00:00Z');
-    writeFileSync(
-      telemetryPath,
-      `${JSON.stringify({ taskId: 't', triggeredAt: '2026-04-18T11:00:00Z' })}\n`,
-    );
-    writeFileSync(join(briefsDir, 'brief.md'), '');
-    const decision = evaluateSessionStartGates({
-      taskId: 't',
-      cooldownMs: 6 * 60 * 60 * 1000,
-      nowMs,
-      telemetryPath,
-      briefsDir,
-    });
-    expect(decision.fire).toBe(false);
-    expect(decision.skipReason).toBe('cooldown');
   });
 });

--- a/src/agent/daemon/gates.ts
+++ b/src/agent/daemon/gates.ts
@@ -2,33 +2,24 @@
  * Gating helpers for Phase 6 sessionstart triggers.
  *
  * `evaluateSessionStartGates` decides whether a sessionstart fire should
- * proceed by checking two gates:
- *   1. Cooldown — has the task fired (on any trigger) within `cooldownMs`?
- *      Read from the most recent telemetry entry for this taskId.
- *   2. Brief queue — are there any pending briefs under `briefsDir`? If so,
- *      coordinate with `forge_brief_nudge` and skip fire so briefs are
- *      consumed before more are generated.
+ * proceed by checking the cooldown gate: has the task fired (on any trigger)
+ * within `cooldownMs`? Read from the most recent telemetry entry for this
+ * taskId.
  *
  * @module agent/daemon/gates
  */
 
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { getBriefsDir } from '../../paths.js';
+import { existsSync, readFileSync } from 'node:fs';
 
 export const DEFAULT_SESSIONSTART_COOLDOWN_MS = 6 * 60 * 60 * 1000; // 6 hours
 
-export function defaultBriefsDir(): string {
-  return getBriefsDir();
-}
-
-export type SessionStartSkipReason = 'cooldown' | 'briefs_pending';
+export type SessionStartSkipReason = 'cooldown';
 
 export interface GateDecision {
   fire: boolean;
   skipReason?: SessionStartSkipReason;
   lastFiredAtMs?: number;
   cooldownRemainingMs?: number;
-  pendingBriefCount?: number;
 }
 
 export interface GateOptions {
@@ -36,7 +27,6 @@ export interface GateOptions {
   cooldownMs: number;
   nowMs: number;
   telemetryPath: string;
-  briefsDir: string;
 }
 
 /**
@@ -70,29 +60,6 @@ export function readLastTickTime(taskId: string, telemetryPath: string): number 
   return null;
 }
 
-/**
- * Count pending briefs in `briefsDir`. A "brief" is a top-level regular `.md`
- * file; subdirectories (notably the `consumed/` and `failed/` lifecycle bins,
- * which persist once any brief has been processed) and non-`.md` files are
- * ignored. Missing directory returns 0.
- *
- * Mirrors the brief detection in `pendingBriefContext`
- * (agent/routing-directive.ts) so the daemon's sessionstart gate and the
- * system-prompt nudge agree on the count. A bare `readdirSync(...).filter(name
- * => !name.startsWith('.'))` would count `consumed/`/`failed/` as pending
- * briefs and permanently trip the `briefs_pending` skip.
- */
-export function countPendingBriefs(briefsDir: string): number {
-  if (!existsSync(briefsDir)) return 0;
-  try {
-    return readdirSync(briefsDir, { withFileTypes: true }).filter(
-      (entry) => entry.isFile() && entry.name.endsWith('.md'),
-    ).length;
-  } catch {
-    return 0;
-  }
-}
-
 export function evaluateSessionStartGates(options: GateOptions): GateDecision {
   const lastFiredMs = readLastTickTime(options.taskId, options.telemetryPath);
   if (lastFiredMs !== null && options.cooldownMs > 0) {
@@ -105,16 +72,6 @@ export function evaluateSessionStartGates(options: GateOptions): GateDecision {
         cooldownRemainingMs: options.cooldownMs - elapsed,
       };
     }
-  }
-
-  const pendingBriefs = countPendingBriefs(options.briefsDir);
-  if (pendingBriefs > 0) {
-    return {
-      fire: false,
-      skipReason: 'briefs_pending',
-      pendingBriefCount: pendingBriefs,
-      ...(lastFiredMs !== null ? { lastFiredAtMs: lastFiredMs } : {}),
-    };
   }
 
   return {

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -39,7 +39,6 @@ import { redactInlineSecrets } from '../session/prompt-dump.js';
 import { ScheduledTask, validateScheduledTask } from './triggers.js';
 import {
   DEFAULT_SESSIONSTART_COOLDOWN_MS,
-  defaultBriefsDir,
   evaluateSessionStartGates,
   type GateDecision,
   type SessionStartSkipReason,
@@ -103,8 +102,6 @@ export interface SchedulerOptions {
    * 6 hours. `0` disables the cooldown check.
    */
   cooldownMs?: number;
-  /** Directory scanned for pending briefs (sessionstart brief-queue gate). */
-  briefsDir?: string;
   /** Clock injection (tests). Defaults to `Date.now`. */
   now?: () => number;
   /**
@@ -157,7 +154,6 @@ export class CronScheduler {
   private readonly registry = new Map<string, RegisteredEntry>();
   private readonly options: SchedulerOptions;
   private readonly defaultCooldownMs: number;
-  private readonly briefsDir: string;
   private readonly now: () => number;
   private readonly idleDetector = new IdleDetector();
   private pullPollTimer: ReturnType<typeof setInterval> | undefined;
@@ -168,7 +164,6 @@ export class CronScheduler {
   constructor(options: SchedulerOptions = {}) {
     this.options = options;
     this.defaultCooldownMs = options.cooldownMs ?? DEFAULT_SESSIONSTART_COOLDOWN_MS;
-    this.briefsDir = options.briefsDir ?? defaultBriefsDir();
     this.now = options.now ?? Date.now;
     this.queueDir = options.queueDir ?? getQueueDir();
     this.ensureTelemetrySink();
@@ -237,7 +232,6 @@ export class CronScheduler {
         cooldownMs,
         nowMs: this.now(),
         telemetryPath: this.telemetryPath(),
-        briefsDir: this.briefsDir,
       });
       if (decision.fire) {
         records.push(await this.runOnce(task, 'sessionstart'));

--- a/src/agent/daemon/separation.test.ts
+++ b/src/agent/daemon/separation.test.ts
@@ -25,10 +25,10 @@ afterEach(() => {
 });
 
 describe('separation — daemon resolves all paths under ~/.afk', () => {
-  it('gates.defaultBriefsDir returns ~/.afk/agent-framework/briefs', async () => {
-    const { defaultBriefsDir } = await import('./gates.js');
-    const briefs = defaultBriefsDir();
-    expect(briefs).toBe(join(tmpHome, '.afk', 'agent-framework', 'briefs'));
-    expect(briefs).not.toContain('.claude');
+  it('getQueueDir resolves under ~/.afk, never ~/.claude', async () => {
+    const { getQueueDir } = await import('../../paths.js');
+    const queueDir = getQueueDir();
+    expect(queueDir.startsWith(join(tmpHome, '.afk'))).toBe(true);
+    expect(queueDir).not.toContain('.claude');
   });
 });

--- a/src/agent/plugin-coupling-regression.test.ts
+++ b/src/agent/plugin-coupling-regression.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression guard: optional-plugin couplings stay out of core.
+ *
+ * Invariant: the /forge and /harvest skills and their pending-briefs queue are
+ * provided by an optional external plugin, not by core. The dormant couplings
+ * that used to reference those plugin concepts — the pending-briefs
+ * system-prompt nudge and the daemon sessionstart brief-queue gate — were
+ * removed from core. This test fails if those specific identifiers reappear.
+ *
+ * Scope is intentionally narrow — exact removed identifiers in the two files
+ * that carried them — so it cannot false-positive on legitimate generic
+ * plumbing (e.g. getBriefsDir still exists in paths.ts for the audit-fit skill).
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function readSource(relativePath: string): string {
+  return readFileSync(join(here, relativePath), 'utf-8');
+}
+
+describe('plugin-coupling regression — forge/briefs concepts stay out of core', () => {
+  it('routing-directive.ts carries no pendingBriefContext nudge or briefs-dir coupling', () => {
+    const src = readSource('routing-directive.ts');
+    expect(src).not.toContain('pendingBriefContext');
+    expect(src).not.toContain('getBriefsDir');
+  });
+
+  it('daemon/gates.ts carries no briefs_pending gate or briefs-dir coupling', () => {
+    const src = readSource('daemon/gates.ts');
+    expect(src).not.toContain('briefs_pending');
+    expect(src).not.toContain('countPendingBriefs');
+    expect(src).not.toContain('getBriefsDir');
+  });
+});

--- a/src/agent/routing-directive.test.ts
+++ b/src/agent/routing-directive.test.ts
@@ -11,11 +11,7 @@
  * motivated this fix.
  */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 import { parseTerminalState } from '../cli/commands/interactive/terminal-state.js';
 
@@ -23,7 +19,6 @@ import {
   END_OF_TURN_DIRECTIVE,
   ROUTING_DIRECTIVE,
   assembleSystemPrompt,
-  pendingBriefContext,
 } from './routing-directive.js';
 
 const BASE = 'You are a careful assistant.';
@@ -126,55 +121,6 @@ describe('assembleSystemPrompt', () => {
       // Three sections → at least two `\n\n` separators.
       const separators = (out!.match(/\n\n/g) ?? []).length;
       expect(separators).toBeGreaterThanOrEqual(2);
-    });
-  });
-
-  describe('briefContext parameter', () => {
-    const BRIEF_CTX = '[forge: 1 pending skill brief]\n\nRun /forge to process.';
-
-    it('injects briefContext before end-of-turn on the repl surface', () => {
-      const out = assembleSystemPrompt(BASE, false, 'repl', BRIEF_CTX);
-      expect(out).toContain(BRIEF_CTX);
-      expect(out).toContain(END_OF_TURN_DIRECTIVE);
-      // brief context must precede end-of-turn
-      expect(out!.indexOf(BRIEF_CTX)).toBeLessThan(out!.indexOf(END_OF_TURN_DIRECTIVE));
-    });
-
-    it('injects briefContext before end-of-turn on the telegram surface', () => {
-      const out = assembleSystemPrompt(BASE, false, 'telegram', BRIEF_CTX);
-      expect(out).toContain(BRIEF_CTX);
-      expect(out!.indexOf(BRIEF_CTX)).toBeLessThan(out!.indexOf(END_OF_TURN_DIRECTIVE));
-    });
-
-    it('does NOT inject briefContext on one-shot surface', () => {
-      const out = assembleSystemPrompt(BASE, false, 'one-shot', BRIEF_CTX);
-      expect(out).not.toContain(BRIEF_CTX);
-    });
-
-    it('does NOT inject briefContext on subagent surface', () => {
-      const out = assembleSystemPrompt(BASE, false, 'subagent', BRIEF_CTX);
-      expect(out).not.toContain(BRIEF_CTX);
-    });
-
-    it('orders sections as: base, routing, brief-context, end-of-turn', () => {
-      const out = assembleSystemPrompt(BASE, true, 'repl', BRIEF_CTX);
-      expect(out).toBeDefined();
-      const baseIdx = out!.indexOf(BASE);
-      const routingIdx = out!.indexOf(ROUTING_DIRECTIVE);
-      const briefIdx = out!.indexOf(BRIEF_CTX);
-      const endIdx = out!.indexOf(END_OF_TURN_DIRECTIVE);
-      expect(baseIdx).toBeLessThan(routingIdx);
-      expect(routingIdx).toBeLessThan(briefIdx);
-      expect(briefIdx).toBeLessThan(endIdx);
-    });
-
-    it('skips brief injection when briefContext is undefined (backward compat)', () => {
-      const withBrief = assembleSystemPrompt(BASE, false, 'repl', BRIEF_CTX);
-      const withoutBrief = assembleSystemPrompt(BASE, false, 'repl');
-      expect(withBrief).toContain(BRIEF_CTX);
-      expect(withoutBrief).not.toContain(BRIEF_CTX);
-      // Without brief, the output still contains end-of-turn
-      expect(withoutBrief).toContain(END_OF_TURN_DIRECTIVE);
     });
   });
 
@@ -316,90 +262,5 @@ describe('assembleSystemPrompt', () => {
       expect(verdict?.kind).toBe('interrupted');
       expect(verdict?.whatWasInProgress).toContain('migration');
     });
-  });
-});
-
-describe('pendingBriefContext', () => {
-  let tmpDir: string | null = null;
-
-  afterEach(() => {
-    if (tmpDir !== null) {
-      rmSync(tmpDir, { recursive: true, force: true });
-      tmpDir = null;
-    }
-  });
-
-  it('returns undefined when the briefs directory does not exist', () => {
-    expect(pendingBriefContext('/nonexistent/path/briefs-xyz')).toBeUndefined();
-  });
-
-  it('returns undefined when the briefs directory is empty', () => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
-    expect(pendingBriefContext(tmpDir)).toBeUndefined();
-  });
-
-  it('returns undefined when only non-.md files are present', () => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
-    writeFileSync(join(tmpDir, 'not-a-brief.txt'), 'hello');
-    writeFileSync(join(tmpDir, 'README'), 'hello');
-    expect(pendingBriefContext(tmpDir)).toBeUndefined();
-  });
-
-  it('returns undefined when only subdirectories are present', () => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
-    mkdirSync(join(tmpDir, 'consumed'));
-    mkdirSync(join(tmpDir, 'consumed', 'old-brief.md')); // dir named .md
-    expect(pendingBriefContext(tmpDir)).toBeUndefined();
-  });
-
-  it('returns singular nudge for one brief', () => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
-    writeFileSync(join(tmpDir, 'my-skill.md'), '# brief');
-    const ctx = pendingBriefContext(tmpDir);
-    expect(ctx).toBeDefined();
-    expect(ctx).toContain('[forge: 1 pending skill brief]');
-    expect(ctx).toContain('1 skill brief');
-    expect(ctx).toContain('my-skill.md');
-    expect(ctx).toContain('/forge');
-  });
-
-  it('returns plural nudge for multiple briefs', () => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
-    writeFileSync(join(tmpDir, 'alpha.md'), '');
-    writeFileSync(join(tmpDir, 'beta.md'), '');
-    const ctx = pendingBriefContext(tmpDir);
-    expect(ctx).toBeDefined();
-    expect(ctx).toContain('[forge: 2 pending skill briefs]');
-    expect(ctx).toContain('2 skill briefs');
-  });
-
-  it('lists up to 3 brief names in the preview', () => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
-    for (const name of ['a.md', 'b.md', 'c.md']) {
-      writeFileSync(join(tmpDir, name), '');
-    }
-    const ctx = pendingBriefContext(tmpDir);
-    expect(ctx).toBeDefined();
-    expect(ctx).toContain('a.md, b.md, c.md');
-    expect(ctx).not.toContain('+');
-  });
-
-  it('truncates preview to 3 with "+N more" for larger sets', () => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
-    for (const name of ['a.md', 'b.md', 'c.md', 'd.md', 'e.md']) {
-      writeFileSync(join(tmpDir, name), '');
-    }
-    const ctx = pendingBriefContext(tmpDir);
-    expect(ctx).toBeDefined();
-    expect(ctx).toContain('[forge: 5 pending skill briefs]');
-    expect(ctx).toContain('+2 more');
-  });
-
-  it('ignores .md files inside subdirectories (consumed/, failed/)', () => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'afk-briefs-test-'));
-    mkdirSync(join(tmpDir, 'consumed'));
-    writeFileSync(join(tmpDir, 'consumed', 'archived.md'), '');
-    // No top-level .md files → should return undefined
-    expect(pendingBriefContext(tmpDir)).toBeUndefined();
   });
 });

--- a/src/agent/routing-directive.ts
+++ b/src/agent/routing-directive.ts
@@ -21,9 +21,6 @@
  * @module agent/routing-directive
  */
 
-import { existsSync, readdirSync } from 'node:fs';
-import { getBriefsDir } from '../paths.js';
-
 export const ROUTING_DIRECTIVE = `[skill-routing: active]
 
 Route recurring work through registered skills instead of rolling ad-hoc solutions:
@@ -143,58 +140,15 @@ const SURFACES_WITH_END_OF_TURN: ReadonlySet<PromptSurface> = new Set([
   'telegram',
 ]);
 
-/**
- * Returns a nudge string when there are pending skill briefs awaiting `/forge`,
- * or `undefined` when the briefs directory is absent or empty.
- *
- * The TS implementation injects via `assembleSystemPrompt` (system-prompt layer)
- * rather than a SessionStart hook because AFK's `dispatchSessionStart` is
- * trace-only — `injectContext` from SessionStart hooks is never forwarded to
- * the model.
- *
- * @param briefsDir - Override the briefs directory (defaults to
- *   `getBriefsDir()`). Exists primarily for testing so callers can point at a
- *   temp dir without touching the real `~/.afk/agent-framework/briefs/`.
- */
-export function pendingBriefContext(briefsDir?: string): string | undefined {
-  const dir = briefsDir ?? getBriefsDir();
-  let briefs: string[];
-  try {
-    if (!existsSync(dir)) return undefined;
-    briefs = readdirSync(dir, { withFileTypes: true })
-      .filter((e) => e.isFile() && e.name.endsWith('.md'))
-      .map((e) => e.name)
-      .sort();
-  } catch {
-    return undefined;
-  }
-  if (briefs.length === 0) return undefined;
-
-  const count = briefs.length;
-  const noun = count === 1 ? 'brief' : 'briefs';
-  let preview = briefs.slice(0, 3).join(', ');
-  if (count > 3) preview += `, +${count - 3} more`;
-
-  return (
-    `[forge: ${count} pending skill ${noun}]\n\n` +
-    `${count} skill ${noun} from \`/forge-friction\` awaiting generation in ` +
-    `\`${dir}/\`: ${preview}\n\n` +
-    `Run \`/forge\` to process (it will pick up the pending briefs ` +
-    `automatically). Ignore if the user is mid-task on something else.`
-  );
-}
-
 export function assembleSystemPrompt(
   base: string | undefined,
   autoRouting: boolean,
   surface: PromptSurface = 'one-shot',
-  briefContext?: string,
 ): string | undefined {
   if (!base) return base;
   const parts: string[] = [base];
   if (autoRouting) parts.push(ROUTING_DIRECTIVE);
   if (SURFACES_WITH_END_OF_TURN.has(surface)) {
-    if (briefContext !== undefined) parts.push(briefContext);
     parts.push(END_OF_TURN_DIRECTIVE);
   }
   return parts.join('\n\n');

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -254,12 +254,8 @@ export function registerDaemonCommand(program: Command): void {
       '--sessionstart-cooldown-ms <ms>',
       'Cooldown between Phase 6 sessionstart fires. Overrides AFK_SESSIONSTART_COOLDOWN_MS. Defaults to 6h.',
     )
-    .option(
-      '--briefs-dir <path>',
-      'Override directory scanned for pending briefs (defaults to ~/.afk/agent-framework/briefs).',
-    )
     .option('--dump-prompt [path]', 'Dump resolved SDK prompt+options+provenance to file (default: ~/.afk/logs/prompt-dump-<ISO>.json) or "stderr"')
-    .action(async (options: { port: string; host?: string; task?: string; cron?: string; taskId?: string; once: boolean; timeoutMs?: string; thinking?: string; effort?: string; trigger?: string; sessionstartCooldownMs?: string; briefsDir?: string; dumpPrompt?: string | boolean | undefined }) => {
+    .action(async (options: { port: string; host?: string; task?: string; cron?: string; taskId?: string; once: boolean; timeoutMs?: string; thinking?: string; effort?: string; trigger?: string; sessionstartCooldownMs?: string; dumpPrompt?: string | boolean | undefined }) => {
       const port = parseInt(options.port, 10);
       if (Number.isNaN(port) || port <= 0) {
         handleCommandError(new Error(`Invalid port: ${options.port}`));
@@ -437,7 +433,6 @@ export function registerDaemonCommand(program: Command): void {
           },
           sessionFactory,
           ...(cooldownMs !== undefined ? { cooldownMs } : {}),
-          ...(options.briefsDir !== undefined ? { briefsDir: options.briefsDir } : {}),
           ...(trigger === 'pull' ? { pullPollIntervalMs: 30_000, queueDir: getQueueDir() } : {}),
           tasks,
           onTaskComplete: (record: TelemetryRecord, details?: TaskCompletionDetails) => {

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -18,7 +18,7 @@ import {
 } from '../../shared-helpers.js';
 import { topLevelSurfaceAllowedTools } from '../../../agent/tools/top-level-allowlist.js';
 import { loadConfig } from '../../config.js';
-import { assembleSystemPrompt, pendingBriefContext } from '../../../agent/routing-directive.js';
+import { assembleSystemPrompt } from '../../../agent/routing-directive.js';
 import { StatusLine } from '../../status-line.js';
 import { GitStatusSampler } from '../../git-status-sampler.js';
 import { registerAll } from '../../slash/index.js';
@@ -174,7 +174,7 @@ export async function bootstrapSession(
   const { prompt: basePrompt, source: systemPromptSource } = resolveBaseSystemPrompt();
   const cliConfig = loadConfig();
   const autoRouting = cliConfig.autoRouting?.interactive ?? true;
-  const systemPrompt = assembleSystemPrompt(basePrompt, autoRouting, 'repl', pendingBriefContext());
+  const systemPrompt = assembleSystemPrompt(basePrompt, autoRouting, 'repl');
 
   // Wire Agent tool by creating SubagentExecutor first.
   // The executor needs the session's methods, so we use a deferred parent proxy

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -43,7 +43,7 @@ import { providerForModel, AnthropicDirectProvider, OpenAICompatibleProvider } f
 import { detectAuthMode } from './agent/providers/anthropic-direct/auth.js';
 import { loadConfig, loadCredential } from './cli/config.js';
 import { getEnvConfigPath } from './paths.js';
-import { assembleSystemPrompt, pendingBriefContext } from './agent/routing-directive.js';
+import { assembleSystemPrompt } from './agent/routing-directive.js';
 import { resolveModelId } from './agent/session/model-resolution.js';
 import { getDefaultSubagentModel, getMaxOutputTokens, getApiKeyForModel, loadSystemPrompt, composeSystemPrompt } from './cli/shared-helpers.js';
 import { topLevelSurfaceAllowedTools } from './agent/tools/top-level-allowlist.js';
@@ -358,7 +358,7 @@ async function main() {
         const rawPromptInner = layeredBasePrompt;
         const telegramAutoRoutingInner = config.autoRouting?.telegram ?? false;
         const systemPromptInner = typeof rawPromptInner === 'string'
-          ? assembleSystemPrompt(rawPromptInner, telegramAutoRoutingInner, 'telegram', pendingBriefContext())
+          ? assembleSystemPrompt(rawPromptInner, telegramAutoRoutingInner, 'telegram')
           : rawPromptInner;
 
         // permissionMode is intentionally omitted here: AgentSession defaults
@@ -400,7 +400,7 @@ async function main() {
       const rawPrompt = layeredBasePrompt;
       const telegramAutoRouting = config.autoRouting?.telegram ?? false;
       const systemPrompt = typeof rawPrompt === 'string'
-        ? assembleSystemPrompt(rawPrompt, telegramAutoRouting, 'telegram', pendingBriefContext())
+        ? assembleSystemPrompt(rawPrompt, telegramAutoRouting, 'telegram')
         : rawPrompt;
       // Codex branch: same cwd resolution as the Anthropic branch above.
       const codexSessionCwd = sessionCwd;


### PR DESCRIPTION
## What

The `/forge` and `/harvest` skills and their pending-briefs queue are provided by an **optional external plugin**, not by core. Two dormant couplings to those plugin concepts still lived in core; this PR removes them so core carries no references to skills it does not ship.

### 1. Pending-briefs system-prompt nudge
- Removed `pendingBriefContext()` from `agent/routing-directive.ts` and the `briefContext?` parameter of `assembleSystemPrompt()` that fed it.
- Removed the call from the REPL bootstrap and both Telegram session paths.
- `assembleSystemPrompt` no longer reserves a brief-context slot in the prompt layering.

### 2. Daemon sessionstart brief-queue gate
- Removed the `briefs_pending` `SessionStartSkipReason`, `countPendingBriefs()`, `defaultBriefsDir()`, and the `briefsDir` threading through `CronScheduler` and `startDaemon`.
- The **cooldown gate is unchanged.**
- Removed the undocumented `--briefs-dir` daemon CLI flag — it only fed this gate and is not referenced in README/docs/completion.

## Why now

Both couplings were **no-ops on installs without the plugin**: with no briefs directory, the nudge returns `undefined` and the daemon gate never trips. They referenced a skill (`/forge`) and an artifact (briefs) that core itself does not provide, so removing them keeps the core boundary clean.

## Not removed

`getBriefsDir()` in `paths.ts` stays — it has a legitimate non-plugin consumer (the `audit-fit` skill) and remains covered by `paths-separation.test.ts`.

## Regression guard

Adds `agent/plugin-coupling-regression.test.ts` — a narrow test that fails if the removed identifiers (`pendingBriefContext`, `briefs_pending`, `countPendingBriefs`, the briefs-dir import) reappear in `routing-directive.ts` or `daemon/gates.ts`. Scoped to those two files so it cannot false-positive on the legitimate `getBriefsDir` in `paths.ts`.

## Follow-up

If the nudge proves useful, it can be re-added later as plugin-emitted output rather than a core function.

## Verification

- `pnpm lint` (tsc --noEmit strict) — clean
- `pnpm test` — 564 files, **10389 passed / 14 skipped**, 0 failures
- `pnpm scan:env:check` — in sync
- `pnpm audit:sdk:check` — lock matches (no SDK import changes)

Behavior-preserving for the common (no-plugin) case; behavior changes only for installs that have the plugin and a populated briefs dir (the nudge/gate no longer fire from core).

Diff: +60 / -365 across 12 files.
