### PR TITLE
fix(hooks): merge injectContext across non-blocking handlers instead of last-wins

### DIFF
--- a/src/agent/hook-registry.test.ts
+++ b/src/agent/hook-registry.test.ts
@@ -382,3 +382,88 @@ describe('[R3 follow-up] dispatchSubagentStop — abort mid-dispatch', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// injectContext merge policy
+// ---------------------------------------------------------------------------
+//
+// Non-blocking handlers that return injectContext must have their values
+// concatenated in registration order (joined by '\n'), not silently dropped by
+// last-wins. Blocking handlers still short-circuit before any accumulation.
+describe('HookRegistryImpl.dispatch — injectContext merge policy', () => {
+  it('concatenates injectContext from two non-blocking handlers in registration order', async () => {
+    const registry = createHookRegistryImpl();
+    registry.register('SubagentStop', async () => ({ injectContext: 'first note' }));
+    registry.register('SubagentStop', async () => ({ injectContext: 'second note' }));
+
+    const decision = await registry.dispatch({ event: 'SubagentStop', subagentId: 'x' });
+    expect(decision.injectContext).toBe('first note\nsecond note');
+  });
+
+  it('concatenates injectContext from three non-blocking handlers in registration order', async () => {
+    const registry = createHookRegistryImpl();
+    registry.register('SubagentStop', async () => ({ injectContext: 'alpha' }));
+    registry.register('SubagentStop', async () => ({ injectContext: 'beta' }));
+    registry.register('SubagentStop', async () => ({ injectContext: 'gamma' }));
+
+    const decision = await registry.dispatch({ event: 'SubagentStop', subagentId: 'x' });
+    expect(decision.injectContext).toBe('alpha\nbeta\ngamma');
+  });
+
+  it('returns the single handler value unchanged when only one handler provides injectContext', async () => {
+    const registry = createHookRegistryImpl();
+    registry.register('SubagentStop', async () => ({ injectContext: 'only note' }));
+
+    const decision = await registry.dispatch({ event: 'SubagentStop', subagentId: 'x' });
+    expect(decision.injectContext).toBe('only note');
+  });
+
+  it('skips handlers that return no injectContext — no leading/trailing newlines', async () => {
+    const registry = createHookRegistryImpl();
+    registry.register('SubagentStop', async () => ({}));
+    registry.register('SubagentStop', async () => ({ injectContext: 'middle note' }));
+    registry.register('SubagentStop', async () => ({}));
+
+    const decision = await registry.dispatch({ event: 'SubagentStop', subagentId: 'x' });
+    expect(decision.injectContext).toBe('middle note');
+    // No stray separator on either end.
+    expect(decision.injectContext?.startsWith('\n')).toBe(false);
+    expect(decision.injectContext?.endsWith('\n')).toBe(false);
+  });
+
+  it('produces no injectContext when no handler returns one', async () => {
+    const registry = createHookRegistryImpl();
+    registry.register('SubagentStop', async () => ({}));
+    registry.register('SubagentStop', async () => ({}));
+
+    const decision = await registry.dispatch({ event: 'SubagentStop', subagentId: 'x' });
+    expect(decision.injectContext).toBeUndefined();
+  });
+
+  it('blocking handler short-circuits before accumulation — later injectContext not reached', async () => {
+    const registry = createHookRegistryImpl();
+    const later = vi.fn(async () => ({ injectContext: 'should-not-appear' }));
+    registry.register('SubagentStop', async () => ({ decision: 'block', reason: 'policy' }));
+    registry.register('SubagentStop', later);
+
+    await expect(registry.dispatch({ event: 'SubagentStop', subagentId: 'x' })).rejects.toThrow();
+    expect(later).not.toHaveBeenCalled();
+  });
+
+  it('preserves last-handler-wins for non-injectContext fields while merging injectContext', async () => {
+    const registry = createHookRegistryImpl();
+    registry.register('SubagentStop', async () => ({
+      injectContext: 'first',
+      reason: 'reason-a',
+    }));
+    registry.register('SubagentStop', async () => ({
+      injectContext: 'second',
+      reason: 'reason-b',
+    }));
+
+    const decision = await registry.dispatch({ event: 'SubagentStop', subagentId: 'x' });
+    expect(decision.injectContext).toBe('first\nsecond');
+    // Non-injectContext fields: last handler wins.
+    expect(decision.reason).toBe('reason-b');
+  });
+});

--- a/src/agent/hook-registry.ts
+++ b/src/agent/hook-registry.ts
@@ -215,12 +215,22 @@ class HookRegistryImpl implements HookRegistry {
         );
       }
 
-      // Accumulate non-blocking decisions so the caller can inspect them.
-      // Current contract: decisions are not merged. If multiple SubagentStop
-      // handlers return injectContext, the last handler's value wins and earlier
-      // values are dropped. This documents the existing behavior until a typed
-      // result envelope or explicit merge policy replaces it.
-      lastDecision = decision;
+      // Invariant: merge policy for non-blocking decisions.
+      // - injectContext: concatenated across all non-blocking handlers in
+      //   registration order, joined by '\n'. Empty/absent values are skipped
+      //   so there are no leading, trailing, or duplicate separators.
+      // - All other decision fields: last-handler-wins (same as before), so
+      //   callers reading `reason`, `decision`, `continue` see the final value.
+      // - Blocking short-circuit (isBlocking check above) fires BEFORE this
+      //   accumulation, so a blocking handler never contributes to the merge.
+      const mergedInjectContext = [lastDecision.injectContext, decision.injectContext]
+        .filter((s): s is string => typeof s === 'string' && s.length > 0)
+        .join('\n');
+      lastDecision = {
+        ...lastDecision,
+        ...decision,
+        ...(mergedInjectContext.length > 0 ? { injectContext: mergedInjectContext } : {}),
+      };
     }
 
     return lastDecision;

--- a/src/agent/hooks.test.ts
+++ b/src/agent/hooks.test.ts
@@ -289,7 +289,7 @@ describe('dispatchSubagentStop — return value', () => {
     });
   });
 
-  it('keeps the last injectContext when multiple stop hooks return one', async () => {
+  it('concatenates injectContext when multiple stop hooks return one', async () => {
     const registry = createHookRegistry();
 
     registry.register('SubagentStop', async () => ({
@@ -305,10 +305,10 @@ describe('dispatchSubagentStop — return value', () => {
       status: 'succeeded',
     });
 
-    // Current contract: hook decisions are not merged. The last non-blocking
-    // SubagentStop decision is the only one the parent injection path sees.
+    // Merge policy: non-blocking injectContext values are concatenated in
+    // registration order, joined by '\n', so neither injection is dropped.
     expect(decision).toEqual({
-      injectContext: 'second framework note',
+      injectContext: 'first framework note\nsecond framework note',
     });
   });
 

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -26,8 +26,10 @@
  * the context string to the parent session's input stream for the parent's next
  * turn. If the parent is aborting, the injection is skipped. DAG/compose and
  * background paths are not guaranteed to inject (some intentionally leave this
- * channel dark), and multiple `injectContext` values do not merge today: hook
- * dispatch returns the last non-blocking decision.
+ * channel dark). When multiple non-blocking handlers each return `injectContext`,
+ * all non-empty values are concatenated in registration order, joined by `'\n'`,
+ * and returned as a single string — so no injection is silently dropped. A
+ * blocking handler still short-circuits before any accumulation occurs.
  *
  * For `UserPromptSubmit`, `injectContext` works differently: the returned string
  * is prepended to the user's prompt text before `runTurn` is called — allowing
@@ -65,12 +67,16 @@ export interface HookDecision {
    *
    * For **SubagentStop**: queued to the parent session's input stream after
    * dispatch completes; dropped if the parent is aborting. DAG/compose and
-   * background paths may intentionally not inject. Multiple injected contexts do
-   * not merge — the last non-blocking hook decision wins.
+   * background paths may intentionally not inject. When multiple non-blocking
+   * handlers each return `injectContext`, all non-empty values are concatenated
+   * in registration order (joined by `'\n'`) and returned as a single string —
+   * no injection is silently dropped. A blocking handler short-circuits before
+   * any accumulation.
    *
    * For **UserPromptSubmit**: prepended to the user's prompt text before
    * `runTurn` is called. Allows per-turn system notes or policy context to be
-   * injected inline with the human's message.
+   * injected inline with the human's message. Same concatenation merge policy
+   * applies when multiple handlers return `injectContext`.
    *
    * Ignored for all other hook events.
    */


### PR DESCRIPTION
## Problem

When multiple non-blocking hook handlers registered on the same event each return `{ injectContext: "..." }`, only the **last** handler's value was kept — all earlier injections were silently dropped. This blocked any workflow that registers multiple gate-hooks on one lifecycle event, since all but the final registered handler would lose their injected context.

## Root cause

`HookRegistryImpl.dispatch()` in `src/agent/hook-registry.ts` (line 218–224) tracked accumulated decisions with a single `lastDecision` variable. Each non-blocking handler **replaced** `lastDecision` wholesale, so earlier `injectContext` values were overwritten:

```ts
// Before (last-wins):
lastDecision = decision;
```

A comment at that site explicitly documented this as the existing behavior: *"decisions are not merged. If multiple SubagentStop handlers return injectContext, the last handler's value wins and earlier values are dropped."*

## Fix

In the dispatch loop, for non-blocking decisions:
- **`injectContext`**: all non-empty values are concatenated in registration order, joined by `'\n'`. Empty/absent values are skipped so there are no leading, trailing, or duplicate separators.
- **All other decision fields**: last-handler-wins (unchanged), so callers reading `reason`, `decision`, `continue` see the final handler's value.
- **Return type unchanged**: still returns a single `HookDecision` with `injectContext?: string` — no consumer changes needed.
- **Blocking short-circuit unchanged**: a handler returning `{ continue: false }` or `{ decision: 'block' }` still throws `HookBlockedError` and fires **before** any accumulation.

Updated both doc comments (`hook-registry.ts` and `hooks.ts`) to describe the new merge policy.

## Blast radius

Zero consumer changes required. All downstream readers consume `injectContext` as a single string, which is preserved:
- `src/agent/subagent/handle.ts:470` — `decision.injectContext && this.parentInputStreamRef...pushUserMessage(decision.injectContext)`
- `src/cli/commands/interactive/loop-iteration.ts:433` — `upsDecision.injectContext + runText`
- Trace recorders in `subagent-hooks.ts` and `session/hooks-dispatch.ts` — read `decision.injectContext` as a string field

## Tests

- **Updated** `src/agent/hooks.test.ts` test at line ~292: renamed from `'keeps the last injectContext when multiple stop hooks return one'` → `'concatenates injectContext when multiple stop hooks return one'`, and updated assertion to expect both values concatenated (`'first framework note\nsecond framework note'`).
- **Added** 7 new tests in `src/agent/hook-registry.test.ts` under a new `'HookRegistryImpl.dispatch — injectContext merge policy'` describe block:
  - (a) two non-blocking handlers concatenated in registration order
  - (b) three non-blocking handlers concatenated in registration order
  - (c) single handler returns its value unchanged
  - (d) handlers returning no `injectContext` are skipped — no leading/trailing newlines
  - (e) no handler returns `injectContext` → `undefined`
  - (f) blocking handler short-circuits before accumulation — later handler never called
  - (g) last-handler-wins preserved for non-`injectContext` fields while merging `injectContext`

## Verification

**`pnpm lint` (`tsc --noEmit`)**:
```
> agent-afk@5.14.0 lint
> tsc --noEmit
```
Zero errors.

**Test suite (9 required files)**:
```
Test Files  9 passed (9)
Tests       171 passed (171)
```
Files: `hook-registry.test.ts` (22), `hooks.test.ts` (19), `hooks-integration.test.ts` (34 via worktree), `shadow-verify-nudge.test.ts` (21), `command-executor.test.ts` (28), `config-bridge.test.ts` (16), `user-prompt-submit.test.ts` (7), `loop-iteration.test.ts` (15), `wiring.test.ts` (9). All pass.