### PR TITLE
fix(afk-gate): close 2-segment MCP verb-gate bypass from #339 review

### DIFF
--- a/src/agent/afk-mode-gate.ts
+++ b/src/agent/afk-mode-gate.ts
@@ -24,9 +24,10 @@
  *     `/etc`, …), or target the `.git` object store
  *   - schedule mutations: `create_schedule` / `cancel_schedule` — modify the
  *     daemon cron store with potential immediate live-sync side-effects
- *   - MCP tools with destructive verb sub-names (`*delete*`, `*drop*`,
- *     `*write*`, `*create*`, `*update*`, `*exec*`, `*send*`, `*deploy*`, …) —
- *     arbitrary third-party server functions the classifier cannot introspect
+ *   - MCP tools whose sub-name contains a destructive verb (the full list is
+ *     `DESTRUCTIVE_VERBS` in `risk-classifier.ts` — the single source of truth;
+ *     not duplicated here so it cannot drift) — arbitrary third-party server
+ *     functions the classifier cannot introspect
  * `'medium'` ops (normal `git push`/`git commit`, installs, builds, file moves)
  * and `'safe'` ops (reads, tests, lint) are ALLOWED — autonomous work has to be
  * useful, and these are reversible enough to run unattended.

--- a/src/agent/risk-classifier.test.ts
+++ b/src/agent/risk-classifier.test.ts
@@ -208,7 +208,9 @@ describe('classifyRisk — schedule tools', () => {
     ).toBe('high');
   });
 
-  it('cancel_schedule → high (irreversible daemon mutation)', () => {
+  it('cancel_schedule → high (mutates daemon cron store)', () => {
+    // Reversible at its default (enabled:false); only { permanent:true } removes
+    // it. Still 'high' — a silently disabled schedule is a notable daemon change.
     expect(classifyRisk('cancel_schedule', { taskId: 'nightly' }, ctx)).toBe('high');
   });
 
@@ -290,5 +292,116 @@ describe('classifyRisk — MCP tools', () => {
 
   it('MCP__server__write_data → high (write verb, case-insensitive prefix)', () => {
     expect(classifyRisk('MCP__server__write_data', {}, ctx)).toBe('high');
+  });
+
+  // --- 2-segment names (no server component) --------------------------------
+  // Regression: PR #339 extracted the sub-name with `.split('__').slice(2)`,
+  // which dropped everything for a 2-segment `mcp__<verb>` name → empty sub-name
+  // → destructive-verb scan never fired → rated 'medium' (allowed unattended).
+  // The gate MUST rate these 'high'. Guards the exact bypass the review flagged.
+  it('mcp__deploy → high (2-segment destructive name — no server component)', () => {
+    expect(classifyRisk('mcp__deploy', { env: 'prod' }, ctx)).toBe('high');
+  });
+
+  it('mcp__delete → high (2-segment destructive name)', () => {
+    expect(classifyRisk('mcp__delete', { id: 1 }, ctx)).toBe('high');
+  });
+
+  it('mcp__exec → high (2-segment destructive name)', () => {
+    expect(classifyRisk('mcp__exec', { cmd: 'ls' }, ctx)).toBe('high');
+  });
+
+  it('mcp__drop → high (2-segment destructive name)', () => {
+    expect(classifyRisk('mcp__drop', { table: 'users' }, ctx)).toBe('high');
+  });
+
+  it('mcp__reset → high (2-segment destructive name — review example)', () => {
+    expect(classifyRisk('mcp__reset', {}, ctx)).toBe('high');
+  });
+
+  it('mcp__query → medium (2-segment, non-destructive)', () => {
+    expect(classifyRisk('mcp__query', { sql: 'SELECT 1' }, ctx)).toBe('medium');
+  });
+
+  it('mcp__status → medium (2-segment, non-destructive)', () => {
+    expect(classifyRisk('mcp__status', {}, ctx)).toBe('medium');
+  });
+
+  // --- extended destructive verbs -------------------------------------------
+  // Realistic destructive operations the original verb list missed; all run
+  // unattended at 'medium' before this change. Financial, infra-lifecycle,
+  // repo, auth, and storage mutations must gate 'high'.
+  it('mcp__payments__charge → high (financial mutation)', () => {
+    expect(classifyRisk('mcp__payments__charge', { amount: 100 }, ctx)).toBe('high');
+  });
+
+  it('mcp__billing__refund → high (financial mutation)', () => {
+    expect(classifyRisk('mcp__billing__refund', { id: 'txn_1' }, ctx)).toBe('high');
+  });
+
+  it('mcp__github__merge_pr → high (irreversible repo write)', () => {
+    expect(classifyRisk('mcp__github__merge_pr', { number: 7 }, ctx)).toBe('high');
+  });
+
+  it('mcp__aws__terminate_instance → high (infra destruction)', () => {
+    expect(classifyRisk('mcp__aws__terminate_instance', { id: 'i-123' }, ctx)).toBe('high');
+  });
+
+  it('mcp__auth__revoke_token → high (access revocation)', () => {
+    expect(classifyRisk('mcp__auth__revoke_token', { token: 'x' }, ctx)).toBe('high');
+  });
+
+  it('mcp__infra__provision_cluster → high (infra lifecycle)', () => {
+    expect(classifyRisk('mcp__infra__provision_cluster', {}, ctx)).toBe('high');
+  });
+
+  it('mcp__k8s__scale_deployment → high (infra lifecycle)', () => {
+    expect(classifyRisk('mcp__k8s__scale_deployment', { replicas: 0 }, ctx)).toBe('high');
+  });
+
+  it('mcp__storage__wipe_bucket → high (storage destruction)', () => {
+    expect(classifyRisk('mcp__storage__wipe_bucket', { bucket: 'b' }, ctx)).toBe('high');
+  });
+
+  it('mcp__flags__disable_feature → high (state change)', () => {
+    expect(classifyRisk('mcp__flags__disable_feature', { flag: 'f' }, ctx)).toBe('high');
+  });
+
+  it('mcp__db__rollback_migration → high (rollback verb)', () => {
+    expect(classifyRisk('mcp__db__rollback_migration', {}, ctx)).toBe('high');
+  });
+
+  it('mcp__fs__rename_file → high (rename verb)', () => {
+    expect(classifyRisk('mcp__fs__rename_file', { from: 'a', to: 'b' }, ctx)).toBe('high');
+  });
+
+  // --- word-boundary matching (no substring false positives) ----------------
+  // Substring `.includes()` wrongly gated these 'high' ('run' ⊂ 'runner',
+  // 'exec' ⊂ 'executor'). Token matching on `_`/`-` boundaries keeps whole-word
+  // verbs and lets these benign read-ish tools through as 'medium'.
+  it('mcp__test__runner → medium (runner is not the verb "run")', () => {
+    expect(classifyRisk('mcp__test__runner', {}, ctx)).toBe('medium');
+  });
+
+  it('mcp__server__executor → medium (executor is not the verb "exec")', () => {
+    expect(classifyRisk('mcp__server__executor', {}, ctx)).toBe('medium');
+  });
+
+  it('mcp__shell__run → high (run is a whole-word verb here)', () => {
+    expect(classifyRisk('mcp__shell__run', { cmd: 'ls' }, ctx)).toBe('high');
+  });
+
+  it('mcp__postgres__list_tables → medium (server "postgres" contains "post" but token match avoids the false positive)', () => {
+    // Correctness guard: since the scan now includes the server segment, a raw
+    // `.includes('post')` would wrongly gate every mcp__postgres__* tool 'high'.
+    // Token matching on word boundaries keeps `postgres` distinct from `post`.
+    expect(classifyRisk('mcp__postgres__list_tables', {}, ctx)).toBe('medium');
+  });
+
+  // --- mixed-case prefix ----------------------------------------------------
+  // The prefix test uses the already-lowercased tool name, so mixed-case
+  // `Mcp__…` is classified (not silently dropped to the 'safe' default).
+  it('Mcp__server__delete_record → high (mixed-case prefix classified)', () => {
+    expect(classifyRisk('Mcp__server__delete_record', { id: 1 }, ctx)).toBe('high');
   });
 });

--- a/src/agent/risk-classifier.ts
+++ b/src/agent/risk-classifier.ts
@@ -195,6 +195,65 @@ function classifyFilePath(filePath: string, ctx: RiskContext): RiskLevel {
 }
 
 // ---------------------------------------------------------------------------
+// MCP destructive-verb table
+// ---------------------------------------------------------------------------
+
+// Invariant: an MCP tool name is `mcp__<server>__<tool>` (3 segments) by the
+// bridge convention, but a server MAY expose a 2-segment `mcp__<tool>` name.
+// classifyRisk scans EVERY word token after the `mcp__` prefix (server segment
+// included) for a destructive verb, matching on `_`/`-` word boundaries — never
+// a raw substring. Two failure modes this guards against, both surfaced in the
+// review of PR #339:
+//   1. UNDER-GATING (the security hole this table exists to close): extracting
+//      only the 3rd+ segment (`.slice(2)`) made a 2-segment `mcp__deploy` yield
+//      an empty sub-name, so the verb scan never fired and an irreversible op
+//      ran unattended at 'medium'. Scanning the full post-prefix suffix
+//      (`.slice(1)`) closes this — `mcp__deploy` now matches the `deploy` verb.
+//   2. FALSE POSITIVES from substring matching: `.includes('run')` gated
+//      `mcp__test__runner` and `.includes('exec')` gated `mcp__server__executor`
+//      to 'high'. Token matching on `_`/`-` boundaries keeps `run`/`execute` as
+//      whole-word verbs while letting `runner`/`executor` through as 'medium'.
+// Token (not substring) matching is REQUIRED once the server segment is scanned:
+// the `postgres` server name contains `post` (a verb), so substring matching
+// would wrongly gate every `mcp__postgres__*` tool 'high'. The tradeoff is that a
+// verb concatenated WITHOUT a separator (`mcp__db__dropall`) is not caught — but
+// real MCP tools use snake_case/kebab-case (`drop_all`), so this is a narrow gap.
+// Scanning the server segment too can over-gate a benign tool whose SERVER is
+// named after a verb (e.g. `mcp__deploy__status` → 'high'). That is deliberate
+// safe-side error: over-gating merely asks the operator to approve; under-gating
+// runs a destructive op unattended. A future per-server allowlist can refine it.
+const DESTRUCTIVE_VERBS: ReadonlySet<string> = new Set([
+  // data / storage mutation
+  'delete', 'drop', 'remove', 'destroy', 'truncate', 'purge', 'wipe',
+  'write', 'create', 'update', 'insert', 'upsert', 'patch', 'rename',
+  // execution
+  'exec', 'execute', 'run', 'eval',
+  // messaging / publishing
+  'send', 'push', 'publish', 'deploy', 'post',
+  // repo / vcs
+  'merge', 'rollback', 'reset',
+  // infra lifecycle
+  'terminate', 'provision', 'scale', 'disable',
+  // financial
+  'charge', 'refund',
+  // auth / access
+  'revoke',
+]);
+
+/**
+ * Lowercase word tokens of an MCP tool's sub-name (everything after the `mcp__`
+ * prefix), split on `_`/`-`/`__` boundaries. The server segment is intentionally
+ * included: a 2-segment name has no server, and the verb may live in either
+ * position. Empty tokens (from `__` separators or leading/trailing delimiters)
+ * are dropped so they never spuriously match a verb. `tool` must already be
+ * lowercased by the caller.
+ */
+function mcpSubNameTokens(tool: string): string[] {
+  const suffix = tool.split('__').slice(1).join('__');
+  return suffix.split(/[_-]+/).filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -243,39 +302,25 @@ export function classifyRisk(
   }
 
   // ---- MCP tools ----------------------------------------------------------
-  // Invariant: any tool whose name begins with `mcp__` is an externally-
-  // contributed function from a third-party server (postgres, filesystem,
-  // GitHub, etc.). The classifier has NO visibility into what that tool does,
-  // so it cannot distinguish a safe MCP read from a destructive mutation
-  // (e.g. `mcp__postgres__drop_table`, `mcp__fs__delete`). Failing open here
+  // Any `mcp__*` tool is an externally-contributed function from a third-party
+  // server (postgres, filesystem, GitHub, …). The classifier has NO visibility
+  // into what it does, so it cannot tell a safe MCP read from a destructive
+  // mutation (`mcp__postgres__drop_table`, `mcp__fs__delete`). Failing open
   // (returning 'safe') would let an unattended run silently execute arbitrary
-  // external side-effects — exactly the scenario AFK gate exists to prevent.
+  // external side-effects — exactly what the AFK gate exists to prevent.
   //
-  // Policy (conservative default, operator-upgradable):
-  //   - Mutation-patterned names (`*delete*`, `*drop*`, `*remove*`, `*write*`,
-  //     `*create*`, `*update*`, `*insert*`, `*exec*`, `*run*`, `*send*`,
-  //     `*push*`, `*publish*`, `*deploy*`) → 'high': irreversible external
-  //     side-effects, gate behind approval.
-  //   - All other MCP tools → 'medium': may have network/quota side-effects,
-  //     but not obviously destructive. Medium is allowed in AFK (gate only
-  //     blocks 'high'), which matches the posture for normal git push / install.
+  // Policy (conservative default, operator-upgradable): a destructive verb in
+  // any post-prefix token → 'high' (gated behind approval); all other MCP tools
+  // → 'medium' (may have network/quota side-effects but not obviously
+  // destructive, and medium is allowed in AFK so autonomous research stays
+  // useful). See DESTRUCTIVE_VERBS / mcpSubNameTokens above for the exact scan
+  // rule and why it covers 2-segment names and matches on word boundaries.
   //
-  // Rationale for not defaulting ALL MCP to 'high': the policy guide says
-  // "medium ops … are ALLOWED — autonomous work has to be useful." A blanket
-  // 'high' on every MCP call would make MCP unusable in AFK, defeating its
-  // value for automation-friendly setups. The sub-name filter catches the
-  // clearly-dangerous verbs; a future per-server allowlist can refine further.
-  if (toolName.startsWith('mcp__') || toolName.startsWith('MCP__')) {
-    const subName = toolName.split('__').slice(2).join('__').toLowerCase();
-    const DESTRUCTIVE_VERBS = [
-      'delete', 'drop', 'remove', 'destroy', 'truncate', 'purge',
-      'write', 'create', 'update', 'insert', 'upsert', 'patch',
-      'exec', 'execute', 'run', 'eval',
-      'send', 'push', 'publish', 'deploy', 'post',
-    ];
-    for (const verb of DESTRUCTIVE_VERBS) {
-      if (subName.includes(verb)) return 'high';
-    }
+  // Prefix test uses the already-lowercased `tool` so mixed-case `Mcp__…` names
+  // are classified too, not silently dropped to the 'safe' default below.
+  if (tool.startsWith('mcp__')) {
+    const tokens = mcpSubNameTokens(tool);
+    if (tokens.some((t) => DESTRUCTIVE_VERBS.has(t))) return 'high';
     return 'medium';
   }
 


### PR DESCRIPTION
Follow-up to #339. The automated review on #339 returned **DO NOT MERGE** for one blocking security gap in the gate that PR installs. This PR closes it (plus the two related medium security findings and the low nits).

## 🔴 BLOCKING (fixed) — 2-segment MCP names bypass the gate

`classifyRisk()` extracted the MCP sub-name with `.split('__').slice(2)`, which drops the server segment. For a **2-segment** `mcp__<verb>` name (no server component) the result is the empty string, so the destructive-verb scan never matches and the tool is rated `'medium'` (allowed unattended) instead of `'high'`:

```ts
// before:
const subName = toolName.split('__').slice(2).join('__').toLowerCase();
// 'mcp__deploy'.split('__') = ['mcp','deploy'] -> .slice(2) = [] -> subName = ''
// ''.includes('deploy')     = false            -> 'medium'  BYPASSED
// 'mcp__infra__deploy'      -> subName='deploy' -> 'high'    (only 3-seg gated)
```

Affected any `mcp__<verb>` (`mcp__deploy`, `mcp__exec`, `mcp__delete`, `mcp__drop`, `mcp__reset`). #339's tests only exercised the 3-segment form, so it slipped through green CI.

**Fix:** scan the **full suffix** after the `mcp__` prefix (`.slice(1)`), so 2-segment names are covered — `mcp__deploy` now matches the `deploy` verb -> `'high'`.

## 🟠 medium (fixed) — word-boundary matching instead of substring

Verb matching now tokenizes the sub-name on `_`/`-` boundaries (`subName.split(/[_-]+/)`) rather than raw `.includes()`.

- **Required for correctness** once the server segment is scanned: the `postgres` server name *contains* `post` (a verb), so substring matching would wrongly gate every `mcp__postgres__*` tool `'high'`. Token matching keeps `postgres` distinct from `post`.
- Also fixes the pre-existing false positives the review flagged: `mcp__test__runner` (`run` in `runner`) and `mcp__server__executor` (`exec` in `executor`) no longer gate benign reads `'high'`.
- Tradeoff (documented in code): a verb concatenated **without** a separator (`mcp__db__dropall`) isn't caught — but real MCP tools use snake_case/kebab-case, so this is a narrow gap and safe-side.

## 🟠 medium (fixed) — extended `DESTRUCTIVE_VERBS`

Added realistic destructive operations that previously ran unattended at `'medium'`: `terminate`, `merge`, `charge`, `refund`, `revoke`, `disable`, `scale`, `wipe`, `rename`, `provision`, `rollback`, `reset`. So `mcp__payments__charge`, `mcp__github__merge_pr`, `mcp__aws__terminate_instance`, etc. now gate `'high'`.

## Low nits (fixed)

- **Mixed-case prefix** — the prefix test now uses the already-lowercased tool name, so `Mcp__...` is classified rather than dropped to the `'safe'` default.
- **JSDoc drift** — `afk-mode-gate.ts` now points to `DESTRUCTIVE_VERBS` (single source of truth) instead of an inline verb list that would drift.
- **Test wording** — softened the over-claimed "irreversible" label on the `cancel_schedule` test (reversible at its `enabled:false` default; only `permanent:true` removes it).

## Safety framing

The only production consumer is `afk-mode-gate.ts`, which gates on `'high'` only. So every re-rate in this PR is `medium->high` (newly gated) or a false-positive `high->medium` fix — no previously-gated op becomes ungated. Scanning the server segment can over-gate a tool whose *server* is named after a verb (`mcp__deploy__status` -> `'high'`); that is deliberate safe-side error (over-gating asks for approval; under-gating runs unattended).

## Test evidence

```
risk-classifier:  81 passed  (was 58; +23 — 2-segment destructive/non-destructive,
                              extended verbs, word-boundary false-positive fixes,
                              postgres/token guard, mixed-case prefix)
afk-mode-gate:    43 passed  (unchanged)
Lint:             tsc --noEmit clean
```
