### PR TITLE
fix(telegram): suspend stream watchdog while a foreground tool is in flight

### DIFF
--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -552,4 +552,67 @@ describe('provider-turn interrupt on incomplete exit (stale-buffer guard)', () =
     await streamResponse(ctx, session, 'go');
     expect((session as { interrupt: ReturnType<typeof vi.fn> }).interrupt).not.toHaveBeenCalled();
   });
+
+  it('suspends the watchdog while a foreground tool is in flight, then fires past MAX_TOOL_INFLIGHT_MS', async () => {
+    vi.useFakeTimers();
+    try {
+      let releaseHang: () => void = () => {};
+      const hang = new Promise<void>((resolve) => { releaseHang = resolve; });
+      const session = makeSession(async function* () {
+        // A foreground tool STARTS (tool_use_detail) then the parent stream goes
+        // silent for the whole tool run — exactly a long bash / nested `afk chat`.
+        // No tool_result arrives, so the tool stays "in flight" and the watchdog
+        // must SUSPEND rather than fire at NEXT_EVENT_TIMEOUT_MS.
+        yield { type: 'chunk' as const, chunk: { type: 'tool_use_detail' as const, toolUseId: 't1', toolName: 'bash', toolInput: 'afk chat' } };
+        await hang;
+      });
+      (session as { interrupt: ReturnType<typeof vi.fn> }).interrupt = vi.fn(async () => { releaseHang(); });
+      const { ctx } = makeCtx();
+
+      const p = streamResponse(ctx, session, 'go');
+      let settled = false;
+      void p.then(() => { settled = true; }, () => { settled = true; });
+
+      await vi.advanceTimersByTimeAsync(1);        // flush tool_use_detail → tool in flight
+      await vi.advanceTimersByTimeAsync(180_001);  // past NEXT_EVENT_TIMEOUT_MS
+      await vi.advanceTimersByTimeAsync(180_001);  // still in flight → suspended, no timeout
+      expect(settled).toBe(false);
+      expect((session as { interrupt: ReturnType<typeof vi.fn> }).interrupt).not.toHaveBeenCalled();
+
+      // Past MAX_TOOL_INFLIGHT_MS (660s) the tool is treated as genuinely wedged
+      // and the watchdog is finally allowed to fire.
+      const rejection = expect(p).rejects.toBeInstanceOf(StreamTimeoutError);
+      await vi.advanceTimersByTimeAsync(660_001);
+      await rejection;
+      expect((session as { interrupt: ReturnType<typeof vi.fn> }).interrupt).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  }, 20_000);
+
+  it('resumes the watchdog after a tool_result clears the in-flight set', async () => {
+    vi.useFakeTimers();
+    try {
+      let releaseHang: () => void = () => {};
+      const hang = new Promise<void>((resolve) => { releaseHang = resolve; });
+      const session = makeSession(async function* () {
+        // Tool starts AND finishes (tool_result), so the in-flight set is empty
+        // again — subsequent silence is a genuinely stuck turn and MUST time out.
+        yield { type: 'chunk' as const, chunk: { type: 'tool_use_detail' as const, toolUseId: 't1', toolName: 'bash', toolInput: 'x' } };
+        yield { type: 'chunk' as const, chunk: { type: 'tool_result' as const, toolUseId: 't1', content: 'ok' } };
+        await hang;
+      });
+      (session as { interrupt: ReturnType<typeof vi.fn> }).interrupt = vi.fn(async () => { releaseHang(); });
+      const { ctx } = makeCtx();
+
+      const p = streamResponse(ctx, session, 'go');
+      const rejection = expect(p).rejects.toBeInstanceOf(StreamTimeoutError);
+      await vi.advanceTimersByTimeAsync(1);        // flush tool_use_detail + tool_result
+      await vi.advanceTimersByTimeAsync(180_001);  // silence, no tool in flight → fires
+      await rejection;
+      expect((session as { interrupt: ReturnType<typeof vi.fn> }).interrupt).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  }, 15_000);
 });

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -28,6 +28,20 @@ const FIRST_EVENT_TIMEOUT_MS = 90_000;
  */
 const NEXT_EVENT_TIMEOUT_MS = 180_000;
 
+/**
+ * Ceiling on how long the inactivity watchdog stays SUSPENDED for in-flight
+ * foreground tool calls (see `inFlightTools`). A long foreground tool — a
+ * nested `afk chat` via bash, a multi-minute build/test — is silent on the
+ * parent stream between its `tool_use_detail` (start) and `tool_result` (end),
+ * so counting that silence as a stuck stream is wrong. The bash tool self-caps
+ * at 600s (src/agent/tools/handlers/bash.ts), so no single foreground tool call
+ * can legitimately exceed this; a tool still in flight past the ceiling is
+ * genuinely wedged and the watchdog is allowed to fire.
+ */
+const MAX_TOOL_INFLIGHT_MS = 660_000;
+/** While suspended for an in-flight tool, re-check the ceiling at this cadence. */
+const TOOL_INFLIGHT_RECHECK_MS = 15_000;
+
 /** Max sub-agent progress lines retained in the bounded live-preview footer. */
 const MAX_SUBAGENT_PREVIEW_LINES = 4;
 
@@ -136,6 +150,14 @@ export async function streamResponse(
   // the lost result" bug.
   let sawTerminalEvent = false;
   let lastActivityAt = Date.now();
+  // In-flight FOREGROUND tool tracking for the watchdog. A parent
+  // `tool_use_detail` chunk adds its toolUseId; the matching `tool_result`
+  // removes it. While non-empty, a tool is legitimately executing (silent on
+  // the parent stream) so the watchdog SUSPENDS instead of firing — bounded by
+  // MAX_TOOL_INFLIGHT_MS from `toolInFlightSince`. A Set keyed by toolUseId
+  // makes a repeated tool_use_detail (e.g. from a stream_retry) idempotent.
+  const inFlightTools = new Set<string>();
+  let toolInFlightSince: number | null = null;
   // Bounded sub-agent progress region (see renderSubagentFooter): a rolling
   // counter + the last few lines, instead of an unbounded per-tool-call append.
   let subagentSteps = 0;
@@ -268,6 +290,19 @@ export async function streamResponse(
         const arm = (): void => {
           const remaining = windowMs - (Date.now() - lastActivityAt);
           if (remaining <= 0) {
+            // A foreground tool call in flight (a long bash / nested `afk chat`)
+            // is silent on the parent stream but is NOT a stuck turn: suspend
+            // the watchdog while any tool runs, bounded by MAX_TOOL_INFLIGHT_MS
+            // measured from when the first tool started, so a genuinely wedged
+            // tool still eventually trips.
+            if (
+              inFlightTools.size > 0 &&
+              toolInFlightSince !== null &&
+              Date.now() - toolInFlightSince < MAX_TOOL_INFLIGHT_MS
+            ) {
+              timeoutId = setTimeout(arm, TOOL_INFLIGHT_RECHECK_MS);
+              return;
+            }
             timeoutId = null;
             timedOut = true;
             reject(
@@ -343,6 +378,17 @@ export async function streamResponse(
           receivedAny = true;
           console.log('📡 First stream event received:', event.type);
           logger?.('First stream event received:', event.type);
+        }
+
+        // Track in-flight FOREGROUND tool calls so arm() can suspend the
+        // watchdog while a long tool (bash / nested afk chat) runs silently
+        // between its tool_use_detail (start) and tool_result (end).
+        if (event.type === 'chunk' && event.chunk.type === 'tool_use_detail') {
+          if (inFlightTools.size === 0) toolInFlightSince = Date.now();
+          inFlightTools.add(event.chunk.toolUseId);
+        } else if (event.type === 'chunk' && event.chunk.type === 'tool_result') {
+          inFlightTools.delete(event.chunk.toolUseId);
+          if (inFlightTools.size === 0) toolInFlightSince = null;
         }
 
         if (event.type === 'chunk' && event.chunk.type === 'content') {


### PR DESCRIPTION
## Symptom
In Telegram, running a long operation — most acutely a nested `afk chat` headless run via bash — shows **"Response timed out. Try sending a shorter message or try again."** mid-turn, interrupts a perfectly healthy turn, and leaks a stray late tool line. Nothing was actually wrong; the turn was working.

## Root cause
The inactivity watchdog in `src/telegram/streaming.ts` fires `StreamTimeoutError` after `NEXT_EVENT_TIMEOUT_MS = 180_000` (3 min) of stream silence. A long **foreground** tool call is silent on the parent stream between its `tool_use_detail` (start) and `tool_result` (end), so the 3-min window trips even though the agent is busy. The bash tool itself allows up to 600s (`bash.ts`), a 3.3x mismatch. In-process sub-agent fan-out was already protected (sink bumps `lastActivityAt`); foreground tools were not.

## Fix
Track in-flight foreground tools by `toolUseId` (add on `tool_use_detail`, remove on `tool_result`) and **suspend** the watchdog while any tool is in flight — bounded by `MAX_TOOL_INFLIGHT_MS` (660s ≈ bash's 600s cap + slack) so a genuinely wedged tool still trips. A `Set` keyed by `toolUseId` makes a `stream_retry`-reemitted `tool_use_detail` idempotent. Sub-agent fan-out protection is unchanged.

## Test plan
- `pnpm exec tsc --noEmit` clean.
- `streaming.test.ts` 22/22 incl. 2 new: watchdog stays suspended past 180s while a tool is in flight and fires after `MAX_TOOL_INFLIGHT_MS`; a `tool_result` clears suspension so later silence still times out.

## Risk
Low. Change is scoped to the watchdog re-arm path; the wedged-tool ceiling preserves the "catch a genuinely stuck stream" guarantee.