### PR TITLE
fix(bash): close abort TOCTOU so an in-flight child is killed, not orphaned

### DIFF
--- a/src/agent/tools/handlers/bash.test.ts
+++ b/src/agent/tools/handlers/bash.test.ts
@@ -247,6 +247,33 @@ describe('bashHandler', () => {
       expect(result.isError).toBeFalsy();
       expect(result.content).toContain('success');
     });
+
+    it('[TOCTOU] kills the child promptly when abort lands after the pre-flight check but before listener registration', async () => {
+      // Regression: an abort firing in the window between the top-of-handler
+      // `signal.aborted` pre-flight check (passes → the child IS spawned) and the
+      // `addEventListener('abort', ...)` registration is never delivered to the
+      // late-added listener (a real AbortSignal does not replay an
+      // already-dispatched 'abort'). Without the post-registration re-check the
+      // child runs to completion and leaks a late result. This fake signal
+      // reproduces that exact race: `aborted` is false at the pre-flight read,
+      // then flips true when the handler registers its listener.
+      let aborted = false;
+      const raceSignal = {
+        get aborted() { return aborted; },
+        addEventListener: (_type: string, _cb: () => void) => { aborted = true; },
+        removeEventListener: () => {},
+      } as unknown as AbortSignal;
+
+      const start = Date.now();
+      const result = await bashHandler({ command: 'sleep 5' }, raceSignal);
+      const elapsed = Date.now() - start;
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBe('Command aborted');
+      // The fix kills the child immediately; without it, the result would only
+      // arrive after `sleep 5` exits on its own (~5s) via the close handler.
+      expect(elapsed).toBeLessThan(3000);
+    }, 15_000);
   });
 
   describe('ANSI stripping', () => {

--- a/src/agent/tools/handlers/bash.ts
+++ b/src/agent/tools/handlers/bash.ts
@@ -270,6 +270,15 @@ export function createBashHandler(
       settle({ content: 'Command aborted', isError: true });
     };
     signal.addEventListener('abort', abortHandler);
+    // Close the TOCTOU window between the pre-flight `signal.aborted` check (top
+    // of the handler) and this listener registration: an abort that fired in
+    // that gap never invokes `abortHandler` (addEventListener does not replay an
+    // already-dispatched 'abort' event), so the just-spawned child would run to
+    // completion and leak a late result instead of being killed promptly.
+    // settle() is idempotent (guards on `resolved`), so re-firing here is safe.
+    if (signal.aborted) {
+      abortHandler();
+    }
 
     // Normal completion — `close` fires after all stdio streams drain.
     proc.on('close', (code) => {


### PR DESCRIPTION
## Context
Follow-up to the Telegram watchdog fix. When a turn is interrupted (`session.interrupt()`), the bash tool's abort listener SIGKILLs the in-flight child process group — but only if the listener was registered **before** the abort fired.

## Root cause (TOCTOU)
An abort landing in the window between the top-of-handler `signal.aborted` pre-flight check (which passes, so the child **is** spawned) and the `addEventListener('abort', …)` registration is never delivered — a real `AbortSignal` does not replay an already-dispatched `'abort'` to a late-added listener. The child then runs to completion and `proc.on('close')` only *then* settles as "Command aborted", leaking a late tool event after the turn was supposed to end (the stray fragment observed in the field).

## Fix
Idempotent post-registration re-check in `src/agent/tools/handlers/bash.ts`: right after registering the listener, `if (signal.aborted) abortHandler()`. `settle()` guards on `resolved`, so re-firing is safe. Confined to `bash.ts`.

## Test plan
- `pnpm exec tsc --noEmit` clean.
- `bash.test.ts` 54/54 incl. 1 new: a fake signal that flips `aborted=true` during `addEventListener` reproduces the race; the child is killed promptly (`Command aborted` in <3s, not after the 5s sleep completes via the close handler).

## Risk
Low; narrow, additive guard. Same process-group SIGKILL path already covered by existing abort tests.