### PR TITLE
fix(skills): normalize canUseTool gates to AFK runtime tool names

### DIFF
--- a/src/agent/permissions.test.ts
+++ b/src/agent/permissions.test.ts
@@ -6,6 +6,33 @@ import { describe, it, expect, vi } from 'vitest';
 import { createCanUseToolHook } from './permissions.js';
 
 describe('createCanUseToolHook', () => {
+  const OPTS = { signal: new AbortController().signal, toolUseID: 't' };
+
+  // Contract guard: rule keys are matched VERBATIM against the AFK runtime tool
+  // name (snake_case), which is what the dispatcher passes to canUseTool. This
+  // is the namespace consumers must use; the JSDoc example teaches it.
+  it('matches rules by AFK runtime (snake_case) tool name', async () => {
+    const hook = createCanUseToolHook({
+      rules: { defaultMode: 'allow', tools: { bash: 'deny', edit_file: 'deny' } },
+    });
+    expect((await hook('bash', {}, OPTS)).behavior).toBe('deny');
+    expect((await hook('edit_file', {}, OPTS)).behavior).toBe('deny');
+    expect((await hook('read_file', {}, OPTS)).behavior).toBe('allow');
+  });
+
+  // Fail-open trap: a PascalCase (Claude Code alias) key does NOT match the
+  // snake_case runtime name, so it falls through to defaultMode. With
+  // defaultMode:'allow' the tool the author meant to DENY is silently allowed.
+  // This test documents the trap so the docs-vs-runtime contract can't regress
+  // to teaching PascalCase keys.
+  it('fails open when a PascalCase key is used with defaultMode:allow (documented trap)', async () => {
+    const hook = createCanUseToolHook({
+      rules: { defaultMode: 'allow', tools: { Bash: 'deny' } }, // WRONG namespace
+    });
+    // Author intended to block bash, but the runtime name 'bash' misses 'Bash':
+    expect((await hook('bash', {}, OPTS)).behavior).toBe('allow');
+  });
+
   it('allows tools matching allow rules', async () => {
     const hook = createCanUseToolHook({
       rules: {

--- a/src/agent/permissions.ts
+++ b/src/agent/permissions.ts
@@ -19,7 +19,16 @@ export type ToolPermissionMode = 'allow' | 'deny' | 'ask';
  * Permission rule for a specific tool name.
  */
 export interface ToolPermission {
-  /** Tool name (e.g. `Bash`, `Read`, `Edit`). */
+  /**
+   * Tool name — MUST be the AFK **runtime** name (snake_case): `bash`,
+   * `read_file`, `edit_file`, `write_file`, `grep`, `glob`, `web_scrape`, … —
+   * NOT the Claude Code PascalCase alias (`Bash`, `Read`, `Edit`). Rule keys
+   * are matched verbatim against the runtime tool name the dispatcher passes;
+   * a key that doesn't match falls through to `defaultMode`. With
+   * `defaultMode: 'allow'` a mismatched key therefore FAILS OPEN — the tool you
+   * meant to deny is silently permitted. (MCP tools use their wire name,
+   * `mcp__<server>__<tool>`.)
+   */
   tool: string;
   /** Behavior when the tool is requested. */
   mode: ToolPermissionMode;
@@ -83,11 +92,16 @@ function toPermissionResult(decision: PermissionDecision): PermissionResult {
  *
  * The returned function is safe to pass directly as `AgentConfig.canUseTool`.
  *
+ * ⚠️ Rule keys MUST be AFK **runtime** tool names (snake_case) — see
+ * {@link ToolPermission.tool}. A key that doesn't match the runtime name falls
+ * through to `defaultMode`, so a PascalCase key like `Bash` combined with
+ * `defaultMode: 'allow'` FAILS OPEN (the tool you meant to deny still runs).
+ *
  * ```ts
  * const hook = createCanUseToolHook({
  *   rules: {
  *     defaultMode: 'allow',
- *     tools: { Bash: 'deny' },
+ *     tools: { bash: 'deny', edit_file: 'deny' }, // runtime names, not Bash/Edit
  *   },
  * });
  * const session = new AgentSession({ model: 'sonnet', canUseTool: hook });

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -696,6 +696,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
     // top-level totalTokens the REPL consumers read. See buildContextUsageFields.
     const { totalTokens, apiUsage } = buildContextUsageFields(last);
     return {
+      // Context-window usage shape: tools/agents are per-entry token stats AFK does not populate (NOT AgentConfig.agents).
       tools: [],
       agents: [],
       isAutoCompactEnabled: this.state.autoCompactThreshold !== undefined,

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -1273,6 +1273,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     // top-level totalTokens the REPL consumers read. See buildContextUsageFields.
     const { totalTokens, apiUsage } = buildContextUsageFields(last);
     return {
+      // Context-window usage shape: tools/agents are per-entry token stats AFK does not populate (NOT AgentConfig.agents).
       tools: [],
       agents: [],
       isAutoCompactEnabled: false,

--- a/src/agent/tool-category.ts
+++ b/src/agent/tool-category.ts
@@ -68,6 +68,12 @@ const WRITE_TOOLS = new Set([
   // READ_ONLY_PHASE_TOOLS) and sequential (not concurrency-safe).
   'config_set',
 ]);
+// These categorization sets intentionally list BOTH the Claude Code / SDK
+// PascalCase tool names (Bash, Agent, Task, Skill, Compose) and AFK's lowercase
+// runtime names (bash, agent, skill, compose). They drive display/categorization
+// only (e.g. TUI lane routing) and match a tool call in EITHER namespace — the
+// PascalCase entries are NOT evidence that AFK dispatches PascalCase tools; AFK
+// dispatches only the lowercase names.
 const SHELL_TOOLS = new Set([
   'Bash', 'BashOutput', 'KillBash',
   'bash',

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -200,10 +200,19 @@ export interface AgentConfig {
    */
   mcpManager?: import('../mcp/index.js').McpManager;
 
-  /** Subagent definitions. Passed through when SDK V2 supports it. */
+  /**
+   * Subagent definitions. NOT currently consumed by AFK's harness — reserved
+   * for future SDK V2 support. AFK's SubagentManager forks via the `agent`/
+   * `skill`/`compose` tools, not this registry, so populating `agents` is a
+   * silent no-op today; do not rely on it for nested dispatch. See
+   * skills/_agents/to-definition.ts (toAgentDefinition).
+   */
   agents?: Record<string, AgentDefinition>;
 
-  /** Main agent name when using agents. Passed through when SDK V2 supports it. */
+  /**
+   * Main agent name when using `agents`. NOT currently consumed (reserved for
+   * future SDK V2 support); has no effect today.
+   */
   agent?: string;
 
   /**
@@ -247,10 +256,17 @@ export interface AgentConfig {
    */
   env?: Record<string, string>;
 
-  /** Enable file checkpointing for rewind. Passed through when SDK V2 supports it. */
+  /**
+   * Enable file checkpointing for rewind. NOT currently consumed by any
+   * provider (reserved for future SDK V2 support); has no effect today.
+   */
   enableFileCheckpointing?: boolean;
 
-  /** Path to the Claude Code executable. Uses the SDK's built-in CLI if not specified. */
+  /**
+   * Path to a Claude Code executable. NOT currently consumed — AFK runs its own
+   * provider harness and never spawns a Claude Code CLI. Reserved for future
+   * SDK V2 support; has no effect today.
+   */
   pathToClaudeCodeExecutable?: string;
 
   /** Continue the most recent persisted session in the current working directory */

--- a/src/skills/_agents/to-definition.ts
+++ b/src/skills/_agents/to-definition.ts
@@ -1,8 +1,59 @@
 import type { AgentDefinition } from '../../agent/types/sdk-types.js';
+import { normalizeToolToken } from '../../agent/plugins/tool-injector.js';
+import { BUILTIN_TOOL_NAMES } from '../../agent/tools/schemas.js';
+import { AWARENESS_TOOL_NAMES } from '../../agent/awareness/tool.js';
+
+// Invariant: the vendored agent modules (research-agent, git-investigator) pin
+// their `allowedTools` to upstream Claude Code's PascalCase namespace (Read,
+// Grep, Glob, Bash, WebFetch, …) — byte-equality is enforced by vendored.test.ts.
+// AFK's dispatcher, however, hands a `canUseTool` gate the snake_case *runtime*
+// tool name (read_file, grep, glob, bash, web_scrape). A gate that compares the
+// raw vendored list against the runtime name therefore denies EVERY core call
+// ('read_file' ∉ {Read, Grep, …}). This set is the bridge — the same known-tool
+// universe the plugin `tools:` parser normalizes against (resolveKnownToolNames).
+const KNOWN_AFK_TOOL_NAMES: ReadonlySet<string> = new Set([
+  ...BUILTIN_TOOL_NAMES,
+  ...AWARENESS_TOOL_NAMES,
+  'memory_search',
+  'agent',
+  'skill',
+]);
+
+/**
+ * Translate a vendored agent's Claude Code tool allowlist (PascalCase aliases
+ * like `Read`, `Grep`, `Bash`, `WebFetch`) into the set of AFK runtime tool
+ * names (`read_file`, `grep`, `bash`, `web_scrape`) that a `canUseTool`
+ * permission gate actually receives at call time.
+ *
+ * Reuses `normalizeToolToken` (the same alias map the plugin `tools:` frontmatter
+ * parser uses), so the mapping stays a single source of truth. Tokens with no AFK
+ * equivalent (e.g. `Agent`, `Task` — SDK-nested-dispatch names AFK does not wire)
+ * are dropped rather than passed through, keeping the gate fail-closed.
+ *
+ * @param allowedTools Vendored PascalCase tool tokens
+ * @returns Set of canonical AFK runtime tool names
+ */
+export function vendoredToolAllowlist(allowedTools: readonly string[]): Set<string> {
+  const out = new Set<string>();
+  for (const token of allowedTools) {
+    const canonical = normalizeToolToken(token, KNOWN_AFK_TOOL_NAMES);
+    if (canonical !== undefined) out.add(canonical);
+  }
+  return out;
+}
 
 /**
  * Convert a vendored agent module into an SDK AgentDefinition for use with
  * Options.agents (nested subagent dispatch via the built-in Agent tool).
+ *
+ * ⚠️ NOT CURRENTLY WIRED. AFK's harness does not consume `AgentSessionConfig.agents`
+ * (it is a "passed through when SDK V2 supports it" placeholder — see
+ * config-types.ts). SubagentManager forks via `agent`/`skill`/`compose`, not the
+ * SDK's built-in `Agent` tool, so an `agents: { … }` registry on a fork config is
+ * a silent no-op. Do NOT rely on this for nested dispatch — a lane that needs a
+ * capability must be granted the tool directly (this is exactly the trap that
+ * left the /diagnose git lane unable to run git). `tools` here also stay in the
+ * vendored PascalCase namespace; use `vendoredToolAllowlist` for runtime gates.
  */
 export function toAgentDefinition(agent: {
   systemPrompt: string;

--- a/src/skills/audit-fit.test.ts
+++ b/src/skills/audit-fit.test.ts
@@ -37,6 +37,7 @@ import {
 import { loadSkillPrompts } from './_lib/prompt-loader.js';
 import { getSkill } from './index.js';
 import { researchAgent } from './_agents/research-agent.js';
+import { vendoredToolAllowlist } from './_agents/to-definition.js';
 
 // Utility to create a valid verdict (defaults to plugin-source for back-compat
 // with existing fixture paths under ~/.afk/plugins/).
@@ -384,31 +385,22 @@ describe('AuditFit Skill', () => {
   });
 
   describe('canUseTool restriction', () => {
-    it('creates a restrictive canUseTool callback', async () => {
-      const allowedTools = researchAgent.allowedTools;
-
-      const testCanUseTool = async (toolName: string) => {
-        if (!allowedTools.includes(toolName as never)) {
-          return {
-            behavior: 'deny' as const,
-            message: `Tool ${toolName} not allowed`,
-          };
-        }
-        return { behavior: 'allow' as const };
-      };
-
-      // Test allowed tools
-      for (const tool of allowedTools) {
-        const result = await testCanUseTool(tool);
-        expect(result.behavior).toBe('allow');
+    // The inspector gate compares against the NORMALIZED AFK runtime names, not
+    // the vendored PascalCase list — comparing raw denies every read call at
+    // runtime. This verifies the actual translation the gate relies on.
+    it('normalizes research-agent tools to AFK runtime names (allows reads, excludes writes)', () => {
+      const allowed = vendoredToolAllowlist(researchAgent.allowedTools);
+      // AFK snake_case runtime names the gate will actually see
+      for (const t of ['read_file', 'grep', 'glob', 'web_scrape']) {
+        expect(allowed.has(t), `${t} should be allowed`).toBe(true);
       }
-
-      // Test disallowed tools
-      const disallowedTools = ['Edit', 'Write', 'Bash', 'Agent'];
-      for (const tool of disallowedTools) {
-        const result = await testCanUseTool(tool);
-        expect(result.behavior).toBe('deny');
-        expect((result as { message?: string }).message).toContain(tool);
+      // never grant writes or shell to a read-only inspector
+      for (const t of ['write_file', 'edit_file', 'bash', 'agent']) {
+        expect(allowed.has(t), `${t} should be excluded`).toBe(false);
+      }
+      // the raw PascalCase tokens must NOT leak through as runtime names
+      for (const t of ['Read', 'Grep', 'Glob']) {
+        expect(allowed.has(t), `${t} (PascalCase) must not be a runtime name`).toBe(false);
       }
     });
 

--- a/src/skills/audit-fit/index.ts
+++ b/src/skills/audit-fit/index.ts
@@ -24,6 +24,7 @@ import { runWave } from '../../agent/subagent/wave.js';
 import type { IAgentSession } from '../../agent/types.js';
 import type { CanUseTool } from '../../agent/types/sdk-types.js';
 import { researchAgent } from '../_agents/research-agent.js';
+import { vendoredToolAllowlist } from '../_agents/to-definition.js';
 import { getAfkHome, getAgentFrameworkDir, getBriefsDir } from '../../paths.js';
 import {
   discoverUserScope,
@@ -347,11 +348,16 @@ async function handler(
     apiKey,
     ...(ctx?.traceWriter !== undefined ? { traceWriter: ctx.traceWriter } : {}),
   });
+  // Invariant: the gate receives AFK snake_case runtime tool names (read_file,
+  // grep, …), but researchAgent.allowedTools is upstream PascalCase (Read,
+  // Grep, …). Compare against the normalized AFK names or every read call is
+  // denied. See _agents/to-definition.ts:vendoredToolAllowlist.
+  const inspectorTools = vendoredToolAllowlist(researchAgent.allowedTools);
   const createCanUseTool = (): CanUseTool => async (toolName: string) => {
-    if (!researchAgent.allowedTools.includes(toolName as never)) {
+    if (!inspectorTools.has(toolName)) {
       return {
         behavior: 'deny',
-        message: `Tool ${toolName} not allowed for audit-fit inspectors. Allowed tools: ${researchAgent.allowedTools.join(', ')}`,
+        message: `Tool ${toolName} not allowed for audit-fit inspectors. Allowed tools: ${[...inspectorTools].join(', ')}`,
       };
     }
     return { behavior: 'allow' };

--- a/src/skills/diagnose.test.ts
+++ b/src/skills/diagnose.test.ts
@@ -20,10 +20,12 @@ import {
   type Hypothesis,
   type VerificationResult,
   diagnoseSkill,
+  createReadOnlyCanUseTool,
+  createGitLaneCanUseTool,
+  createVerifierCanUseTool,
 } from './diagnose/index.js';
 import { loadSkillPrompts } from './_lib/prompt-loader.js';
 import { _resetRegistry, getSkill } from './index.js';
-import { researchAgent } from './_agents/research-agent.js';
 
 // Utility to create a valid hypothesis
 function createValidHypothesis(id = 'h1'): z.infer<typeof HypothesisSchema> {
@@ -376,41 +378,53 @@ describe('Diagnose Skill', () => {
     });
   });
 
-  describe('canUseTool restrictions', () => {
-    it('allows read-only tools (Read, Grep, Glob, WebFetch, WebSearch)', () => {
-      const allowedTools = researchAgent.allowedTools;
-      expect(allowedTools).toContain('Read');
-      expect(allowedTools).toContain('Grep');
-      expect(allowedTools).toContain('Glob');
-      expect(allowedTools).toContain('WebFetch');
-      expect(allowedTools).toContain('WebSearch');
-    });
+  describe('canUseTool gates (AFK runtime tool names)', () => {
+    // Regression guard for the tool-name namespace mismatch: the gates receive
+    // AFK's snake_case RUNTIME names (read_file, grep, bash, …), NOT the
+    // vendored agents' upstream PascalCase allowlist (Read, Grep, Bash, …).
+    // These tests exercise the REAL exported gates against runtime names. The
+    // previous version tested a REPLICA against PascalCase, which passed while
+    // every read_file/grep/bash call was denied at runtime (see screenshot in
+    // the diagnose-tool-errors report). Upstream PascalCase fidelity of the
+    // vendored source is covered separately by _agents/vendored.test.ts.
+    const OPTS = { signal: new AbortController().signal, toolUseID: 't' };
 
-    it('denies write/edit tools', () => {
-      const deniedTools = ['Edit', 'Write', 'Bash'];
-      for (const tool of deniedTools) {
-        expect(researchAgent.allowedTools).not.toContain(tool);
+    it('read-only gate ALLOWS AFK read tools (read_file, grep, glob, web_scrape)', async () => {
+      const gate = createReadOnlyCanUseTool();
+      for (const t of ['read_file', 'grep', 'glob', 'web_scrape']) {
+        expect((await gate(t, {}, OPTS)).behavior, `${t} should be allowed`).toBe('allow');
       }
     });
 
-    it('can construct a verifier canUseTool that rejects Edit', () => {
-      const deniedTools = ['Edit', 'Write', 'Bash', 'Agent', 'Task'];
+    it('read-only gate DENIES writes and shell (write_file, edit_file, bash, agent)', async () => {
+      const gate = createReadOnlyCanUseTool();
+      for (const t of ['write_file', 'edit_file', 'bash', 'agent']) {
+        expect((await gate(t, {}, OPTS)).behavior, `${t} should be denied`).toBe('deny');
+      }
+    });
 
-      const testCanUseTool = async (toolName: string) => {
-        if (deniedTools.includes(toolName)) {
-          return { behavior: 'deny' as const };
-        }
-        if (!researchAgent.allowedTools.includes(toolName as never)) {
-          return { behavior: 'deny' as const };
-        }
-        return { behavior: 'allow' as const };
-      };
+    it('git lane ALLOWS read-only git bash + reads, DENIES mutating bash + writes', async () => {
+      const gate = createGitLaneCanUseTool();
+      // read-only git + research reads → allowed
+      expect((await gate('read_file', {}, OPTS)).behavior).toBe('allow');
+      expect((await gate('grep', {}, OPTS)).behavior).toBe('allow');
+      expect((await gate('bash', { command: 'git log --oneline -40' }, OPTS)).behavior).toBe('allow');
+      expect((await gate('bash', { command: 'git blame src/x.ts' }, OPTS)).behavior).toBe('allow');
+      // mutating git / chained shell → denied
+      expect((await gate('bash', { command: 'git commit -m x' }, OPTS)).behavior).toBe('deny');
+      expect((await gate('bash', { command: 'git push' }, OPTS)).behavior).toBe('deny');
+      expect((await gate('bash', { command: 'git log && rm -rf /tmp/x' }, OPTS)).behavior).toBe('deny');
+      // writes / dispatch → denied (not in git-investigator's tool contract)
+      expect((await gate('write_file', {}, OPTS)).behavior).toBe('deny');
+      expect((await gate('agent', {}, OPTS)).behavior).toBe('deny');
+    });
 
-      // Test denial of disallowed tools
-      for (const tool of ['Edit', 'Write', 'Bash']) {
-        testCanUseTool(tool).then((result) => {
-          expect(result.behavior).toBe('deny');
-        });
+    it('verifier gate is read-only: ALLOWS reads, DENIES edit/write/bash/agent', async () => {
+      const gate = createVerifierCanUseTool();
+      expect((await gate('read_file', {}, OPTS)).behavior).toBe('allow');
+      expect((await gate('grep', {}, OPTS)).behavior).toBe('allow');
+      for (const t of ['edit_file', 'write_file', 'bash', 'agent']) {
+        expect((await gate(t, {}, OPTS)).behavior, `${t} should be denied`).toBe('deny');
       }
     });
   });

--- a/src/skills/diagnose/_phases/orchestrator.ts
+++ b/src/skills/diagnose/_phases/orchestrator.ts
@@ -28,7 +28,8 @@ import type { AgentModelInput, IAgentSession } from '../../../agent/types.js';
 import type { CanUseTool } from '../../../agent/types/sdk-types.js';
 import { researchAgent } from '../../_agents/research-agent.js';
 import { gitInvestigator } from '../../_agents/git-investigator.js';
-import { toAgentDefinition } from '../../_agents/to-definition.js';
+import { vendoredToolAllowlist } from '../../_agents/to-definition.js';
+import { classifyBashCommand } from '../../../agent/tools/readonly-bash.js';
 import type {
   DiagnosisResult,
   Hypothesis,
@@ -50,46 +51,82 @@ const execFile = promisify(execFileCallback);
 // Tool-permission helpers
 // ---------------------------------------------------------------------------
 
+// Invariant: canUseTool gates receive AFK's snake_case *runtime* tool name
+// (read_file, grep, bash, …), NOT the vendored agents' upstream PascalCase
+// allowlist (Read, Grep, Bash, …). vendoredToolAllowlist bridges the two
+// namespaces once at module load; comparing the raw vendored list against the
+// runtime name denies every call. See _agents/to-definition.ts for the mapping.
+//
+// RESEARCH lane (codebase, hypothesis, verifier base): read-only, no shell.
+//   research-agent.allowedTools = [Read, Grep, Glob, WebFetch, WebSearch]
+//                               → {read_file, grep, glob, web_scrape}
+const RESEARCH_READONLY_TOOLS: ReadonlySet<string> = vendoredToolAllowlist(
+  researchAgent.allowedTools,
+);
+// GIT lane: AFK does not wire the SDK `agents` nested-dispatch registry
+// (AgentSessionConfig.agents is a "passed through when SDK V2 supports it"
+// placeholder — never consumed by SubagentManager). So the git lane cannot
+// dispatch git-investigator; instead it IS the investigator and runs git
+// itself. Its allowlist therefore derives from git-investigator's own tool
+// contract, and `bash` is gated read-only (git log/blame/diff pass; commit/
+// push/reset are denied) at call time via classifyBashCommand.
+//   git-investigator.allowedTools = [Bash, Read, Grep, Glob]
+//                                 → {bash, read_file, grep, glob}
+const GIT_LANE_TOOLS: ReadonlySet<string> = vendoredToolAllowlist(
+  gitInvestigator.allowedTools,
+);
+
 /**
- * Create a restrictive canUseTool that only allows read-only tools.
+ * Create a restrictive canUseTool that only allows read-only research tools
+ * (no shell, no writes). Used by the codebase-research and hypothesis lanes.
  */
-function createReadOnlyCanUseTool(): CanUseTool {
+export function createReadOnlyCanUseTool(): CanUseTool {
   return async (toolName: string) => {
-    if (!researchAgent.allowedTools.includes(toolName as never)) {
+    if (!RESEARCH_READONLY_TOOLS.has(toolName)) {
       return {
         behavior: 'deny',
-        message: `Tool ${toolName} not allowed. Allowed tools: ${researchAgent.allowedTools.join(', ')}`,
+        message: `Tool ${toolName} not allowed. Allowed tools: ${[...RESEARCH_READONLY_TOOLS].join(', ')}`,
       };
     }
     return { behavior: 'allow' };
   };
 }
 
-// Orchestrator allowlist — research-agent's read-only base plus Agent for
-// dispatching git-investigator via the SDK's built-in Agent tool. Paired with
-// an `agents: { 'git-investigator': ... }` registry on the same fork config.
-const GIT_ORCHESTRATOR_ALLOWED_TOOLS = [...researchAgent.allowedTools, 'Agent'] as const;
-
 /**
- * Create a canUseTool for the git-orchestrator subagent.
+ * Create a canUseTool for the git-research lane: read-only research tools plus
+ * `bash` restricted to non-mutating git commands (history, blame, diff, log).
+ * Mutating shell (commit, push, reset, checkout, chained/redirected writes) is
+ * denied via classifyBashCommand, which handles `&&`/`;`/`$()` and redirects.
  */
-function createGitOrchestratorCanUseTool(): CanUseTool {
-  return async (toolName: string) => {
-    if (!GIT_ORCHESTRATOR_ALLOWED_TOOLS.includes(toolName as never)) {
+export function createGitLaneCanUseTool(): CanUseTool {
+  return async (toolName: string, input: Record<string, unknown>) => {
+    if (!GIT_LANE_TOOLS.has(toolName)) {
       return {
         behavior: 'deny',
-        message: `Tool ${toolName} not allowed for git orchestrator. Allowed tools: ${GIT_ORCHESTRATOR_ALLOWED_TOOLS.join(', ')}`,
+        message: `Tool ${toolName} not allowed for git research. Allowed tools: ${[...GIT_LANE_TOOLS].join(', ')}`,
       };
+    }
+    if (toolName === 'bash') {
+      const command = typeof input['command'] === 'string' ? input['command'] : '';
+      const verdict = classifyBashCommand(command);
+      if (verdict.mutating) {
+        return {
+          behavior: 'deny',
+          message: `Bash command denied in git research (read-only lane): ${verdict.reason ?? 'mutating command'}`,
+        };
+      }
     }
     return { behavior: 'allow' };
   };
 }
 
 /**
- * Create a canUseTool that allows only reading (no Edit, Write, Bash, commit).
+ * Create a canUseTool for worktree verification: strictly read-only. Denies all
+ * writes, shell, and subagent dispatch (using AFK runtime tool names), then
+ * falls through to the read-only research allowlist.
  */
-function createVerifierCanUseTool(): CanUseTool {
-  const deniedTools = ['Edit', 'Write', 'Bash', 'Agent', 'Task'];
+export function createVerifierCanUseTool(): CanUseTool {
+  const deniedTools = ['edit_file', 'write_file', 'bash', 'agent', 'skill', 'compose'];
 
   return async (toolName: string) => {
     if (deniedTools.includes(toolName)) {
@@ -98,10 +135,10 @@ function createVerifierCanUseTool(): CanUseTool {
         message: `Tool ${toolName} not allowed in worktree verification. Verification is read-only.`,
       };
     }
-    if (!researchAgent.allowedTools.includes(toolName as never)) {
+    if (!RESEARCH_READONLY_TOOLS.has(toolName)) {
       return {
         behavior: 'deny',
-        message: `Tool ${toolName} not allowed. Allowed tools: ${researchAgent.allowedTools.join(', ')}`,
+        message: `Tool ${toolName} not allowed. Allowed tools: ${[...RESEARCH_READONLY_TOOLS].join(', ')}`,
       };
     }
     return { behavior: 'allow' };
@@ -345,21 +382,20 @@ export async function handler(
   // shared triage anchor points so their findings can be cross-referenced
   // in Phase 3 on common axes (location, category, confidence).
   //
-  // Lane override: research-agent.md is the shared vendored system prompt
+  // Lane overrides: research-agent.md is the shared vendored system prompt
   // (byte-pinned in src/skills/_agents/vendored.test.ts) and tells the agent
-  // to dispatch `git-investigator` via the Agent tool on git-flavored
-  // signals. The CODEBASE lane mechanically denies Agent (see
-  // createReadOnlyCanUseTool below), so those dispatch instructions describe
-  // a capability the lane doesn't have. Without an explicit override the
-  // agent falls back to reading `.git/` internals directly — which
-  // research-agent.md itself flags as a contract violation, and which
-  // produces noise like "60 worktrees and 1 stash" when the failure
-  // description happens to mention git terms.
+  // to dispatch `git-investigator` via the Agent tool on git-flavored signals.
+  // Neither AFK lane can do that — AFK doesn't wire the SDK `agents` registry
+  // (see gitHandle fork below) — so BOTH lanes get an explicit override that
+  // has the last word (appended after researchAgent.systemPrompt):
   //
-  // The override is appended AFTER researchAgent.systemPrompt so it has the
-  // last word, and is scoped to the codebase lane only — the git lane has
-  // both the Agent tool and the git-investigator registry, so the upstream
-  // instructions apply correctly there.
+  //  - CODEBASE lane: no shell at all. Without the override the agent falls
+  //    back to reading `.git/` internals directly — which research-agent.md
+  //    itself flags as a contract violation, and which produces noise like
+  //    "60 worktrees and 1 stash" when the failure text mentions git terms.
+  //  - GIT lane: has `bash` (read-only-gated). It must run git commands
+  //    itself (git log/blame/diff/show) instead of trying to dispatch
+  //    git-investigator, which would be denied.
   const codebaseLaneOverride =
     '\n\n## Lane override (codebase research)\n\n' +
     'The Agent tool is not available in this lane. Do not attempt to ' +
@@ -369,8 +405,17 @@ export async function handler(
     'are not codebase findings and surfacing them is the documented ' +
     'anti-pattern. Confine investigation to source code paths via Read, ' +
     'Grep, and Glob.';
+  const gitLaneOverride =
+    '\n\n## Lane override (git research)\n\n' +
+    'Do not dispatch `git-investigator` or any other subagent — the Agent ' +
+    'tool is not available here and those calls will be denied. Investigate ' +
+    'git history yourself by running read-only git commands through the ' +
+    '`bash` tool (e.g. `git log`, `git blame`, `git diff`, `git show`, ' +
+    '`git log -S`). Mutating commands (commit, push, reset, checkout, ' +
+    'rebase, and any redirect or chained write) are denied — keep it ' +
+    'strictly read-only.';
   const codebaseResearchPrompt = `${researchAgent.systemPrompt}${codebaseLaneOverride}\n\n${researchPrompt}\n\nFocus: CODEBASE\n${triageBlock}\nFailure: ${parsedInput.failure}${parsedInput.context ? `\nContext: ${parsedInput.context}` : ''}`;
-  const gitResearchPrompt = `${researchAgent.systemPrompt}\n\n${researchPrompt}\n\nFocus: GIT HISTORY\n${triageBlock}\nFailure: ${parsedInput.failure}${parsedInput.context ? `\nContext: ${parsedInput.context}` : ''}\n\nRepo: ${parsedInput.repoPath}`;
+  const gitResearchPrompt = `${researchAgent.systemPrompt}${gitLaneOverride}\n\n${researchPrompt}\n\nFocus: GIT HISTORY\n${triageBlock}\nFailure: ${parsedInput.failure}${parsedInput.context ? `\nContext: ${parsedInput.context}` : ''}\n\nRepo: ${parsedInput.repoPath}`;
 
   // `parentId: ctx.callId` (when present) anchors the synthesized `Agent(...)`
   // entry under THIS skill's tool-lane entry in the live overlay AND in the
@@ -393,23 +438,20 @@ export async function handler(
     ...(skillCallId ? { parentId: skillCallId } : {}),
   });
 
-  // Restriction to git-investigator comes from the single-entry `agents`
-  // registry below — the SDK exposes it via the built-in Agent tool. The
-  // `Agent(git-investigator)` syntax in upstream's frontmatter is plugin
-  // parser syntax, not SDK syntax; here we set the registry directly.
+  // The git lane runs read-only git commands itself (createGitLaneCanUseTool +
+  // GIT_LANE_TOOLS). AFK does not consume the SDK `agents` nested-dispatch
+  // registry (AgentSessionConfig.agents is a "passed through when SDK V2
+  // supports it" placeholder), so — unlike upstream, where research-agent
+  // dispatches git-investigator via the Agent tool — this lane cannot fork a
+  // nested investigator. It IS the investigator: it inherits git-investigator's
+  // tool contract with `bash` gated to non-mutating git operations.
   const gitHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {
       model: subagentModel,
       systemPrompt: gitResearchPrompt,
       cwd: parsedInput.repoPath,
-      agents: {
-        'git-investigator': {
-          ...toAgentDefinition(gitInvestigator),
-          model: subagentModel,
-        },
-      },
-      canUseTool: createGitOrchestratorCanUseTool(),
+      canUseTool: createGitLaneCanUseTool(),
     },
     idPrefix: 'diagnose-git-research',
     agentType: 'diagnose-git-research',

--- a/src/skills/diagnose/index.ts
+++ b/src/skills/diagnose/index.ts
@@ -48,6 +48,12 @@ export {
   autoVerifyHypotheses,
 } from './_phases/verifier.js';
 
+export {
+  createReadOnlyCanUseTool,
+  createGitLaneCanUseTool,
+  createVerifierCanUseTool,
+} from './_phases/orchestrator.js';
+
 import { handler } from './_phases/orchestrator.js';
 import { registerSkill, type SkillMetadata } from '../index.js';
 


### PR DESCRIPTION
## Summary
The `/diagnose` and `/audit-fit` skills were denying **every** subagent tool call. Root cause: their `canUseTool` permission gates compared AFK's snake_case **runtime** tool names (`read_file`, `grep`, `bash`, `web_scrape`) against vendored Claude Code **PascalCase** allowlists (`Read`, `Grep`, `Bash`, …). `'read_file' !== 'Read'`, so `.includes()` never matched and the research / git / verifier lanes were fully broken. The unit tests masked it by feeding PascalCase to *replica* gates instead of exercising the real ones.

## What changed
- **`vendoredToolAllowlist()`** (`_agents/to-definition.ts`) — single source of truth translating vendored PascalCase → AFK runtime names, reusing the existing `normalizeToolToken` alias map.
- **Diagnose gates + audit-fit gate** now compare against normalized AFK names. The **git lane** derives its allowlist from `git-investigator`'s own tool contract and gates `bash` to **non-mutating** git commands via `classifyBashCommand` (`git log`/`blame`/`diff` allowed; `commit`/`push`/chained writes denied).
- Removed the **dead `config.agents`** git-investigator registry (AFK never consumes `AgentSessionConfig.agents`) and added a git-lane prompt override so the lane runs git directly instead of dispatching a nested subagent that can't exist.
- **Un-masked the tests** — replaced replica-gate tests with regression guards that exercise the real exported gates against snake_case runtime names.

## Related hardening (found while auditing for the same bug class)
- **Fail-open fix** in the public `createCanUseToolHook` (`agent/permissions.ts`): its docs taught PascalCase rule keys, so a consumer using `{ defaultMode: 'allow', tools: { Bash: 'deny' } }` silently **allowed** bash. Corrected docs to snake_case + added regression tests documenting the trap.
- **Documented inert placeholders**: `AgentConfig` SDK-V2 fields (`agents`, `agent`, `enableFileCheckpointing`, `pathToClaudeCodeExecutable`) and the dual-namespace `tool-category` sets, so they can't mislead again.

A parallel audit confirmed **no other instances** of this bug class remain internally, and **no other masking tests**.

## Verification
- `pnpm lint` (tsc --noEmit strict): clean
- `pnpm build`: clean
- `pnpm audit:sdk:check`: OK (no new SDK symbols — all added imports are internal)
- `pnpm test`: **10448 passed / 0 failed / 14 skipped** (564 files)

## Notes
- Comment-only edits to `config-types.ts`, `tool-category.ts`, and both `query.ts` (no behavior change).
- All claims independently re-derived by an adversarial shadow-verify wave before this PR.