### PR TITLE
fix(telegram): keep the typing indicator alive for the whole turn

### DIFF
--- a/src/telegram/handlers/commands.ts
+++ b/src/telegram/handlers/commands.ts
@@ -6,6 +6,7 @@ import { homedir } from 'os';
 import { isAbsolute, resolve } from 'path';
 import { HookBlockedError } from '../../utils/errors.js';
 import { SessionManager } from '../session-manager.js';
+import { withTypingIndicator } from '../typing-indicator.js';
 import {
   formatError,
   formatClear,
@@ -74,17 +75,20 @@ export async function handleCompact(
 
   try {
     const session = await sessionManager.getSession(chatId);
-    await ctx.sendChatAction('typing').catch(() => {});
-    // Invariant: fire PreCompact before compaction. block -> skip, not error.
     const hookRegistry = session.hookRegistry;
-    if (hookRegistry) {
-      await hookRegistry.dispatch({
-        event: 'PreCompact',
-        sessionId: session.sessionId,
-        trigger: 'manual',
-      });
-    }
-    const result = await session.compact();
+    // Keep the "typing…" indicator alive across the PreCompact hook and the
+    // model-call compaction, which can outlast the ~5s one-shot expiry.
+    // Invariant: fire PreCompact before compaction. block -> skip, not error.
+    const result = await withTypingIndicator(ctx, async () => {
+      if (hookRegistry) {
+        await hookRegistry.dispatch({
+          event: 'PreCompact',
+          sessionId: session.sessionId,
+          trigger: 'manual',
+        });
+      }
+      return session.compact();
+    });
     if (!result.compacted) {
       await ctx.reply(formatCompactNoop(result.reason ?? 'unknown'));
     } else {

--- a/src/telegram/handlers/message.ts
+++ b/src/telegram/handlers/message.ts
@@ -5,6 +5,7 @@ import { SessionManager } from '../session-manager.js';
 import { formatError, formatClear, formatInternalError, formatCompact, formatCompactNoop, formatQueued, escapeHtml } from '../formatter.js';
 import { isRateLimitError, isNetworkError, isTelegramTransportError } from '../error-utils.js';
 import { streamResponse } from '../streaming.js';
+import { withTypingIndicator } from '../typing-indicator.js';
 // Import StreamTimeoutError from its own module, NOT '../streaming.js': many
 // handler tests vi.mock('../streaming.js'), which would make the class resolve
 // to undefined and turn `instanceof StreamTimeoutError` into a TypeError.
@@ -475,17 +476,20 @@ export class MessageHandler {
     let reEnqueued = false;
     try {
       const session = await this.sessionManager.getSession(chatId);
-      await ctx.sendChatAction('typing').catch(() => {});
-      // Invariant: fire PreCompact before compaction. block -> skip, not error.
       const hookRegistry = session.hookRegistry;
-      if (hookRegistry) {
-        await hookRegistry.dispatch({
-          event: 'PreCompact',
-          sessionId: session.sessionId,
-          trigger: 'manual',
-        });
-      }
-      const result = await session.compact();
+      // Keep the "typing…" indicator alive across the PreCompact hook and the
+      // model-call compaction, which can outlast the ~5s one-shot expiry.
+      // Invariant: fire PreCompact before compaction. block -> skip, not error.
+      const result = await withTypingIndicator(ctx, async () => {
+        if (hookRegistry) {
+          await hookRegistry.dispatch({
+            event: 'PreCompact',
+            sessionId: session.sessionId,
+            trigger: 'manual',
+          });
+        }
+        return session.compact();
+      });
       if (result.reason === 'session-busy') {
         // Session became busy between drain-start and our compact() call (TOCTOU).
         // Re-enqueue so the compact isn't silently dropped with a confusing no-op.
@@ -597,20 +601,23 @@ export class MessageHandler {
     let reEnqueued = false;
     try {
       const session = await this.sessionManager.getSession(chatId);
-      await ctx.sendChatAction('typing').catch(() => {});
       // User text for the stored turn record: joined text blocks (caption) for
       // content-block (photo) messages, the raw string otherwise.
       const userText = typeof content === 'string'
         ? content
         : content.map((b) => (b.type === 'text' ? b.text : '[image]')).join(' ');
-      await streamResponse(ctx, session, content, this.log, {
-        cleanFinal: true,
-        // Record the completed turn into the shared session store so the CLI
-        // can `--resume <name>` this Telegram conversation. Best-effort inside.
-        onComplete: (assistantText, metadata) => {
-          this.sessionManager.recordTelegramTurn(chatId, userText, assistantText, metadata);
-        },
-      });
+      // Keep the "typing…" indicator alive for the whole (often multi-minute)
+      // streamed turn; a one-shot chat action would expire after ~5s.
+      await withTypingIndicator(ctx, () =>
+        streamResponse(ctx, session, content, this.log, {
+          cleanFinal: true,
+          // Record the completed turn into the shared session store so the CLI
+          // can `--resume <name>` this Telegram conversation. Best-effort inside.
+          onComplete: (assistantText, metadata) => {
+            this.sessionManager.recordTelegramTurn(chatId, userText, assistantText, metadata);
+          },
+        }),
+      );
     } catch (error) {
       this.log('Message handling error:', error);
       const busyMsg = (error as Error)?.message ?? '';

--- a/src/telegram/typing-indicator.test.ts
+++ b/src/telegram/typing-indicator.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Context } from 'telegraf';
+import { withTypingIndicator } from './typing-indicator.js';
+
+/** Minimal Telegraf Context stub exposing only the sendChatAction we exercise. */
+function makeCtx(sendChatAction: () => Promise<unknown>): {
+  ctx: Context;
+  send: ReturnType<typeof vi.fn>;
+} {
+  const send = vi.fn(sendChatAction);
+  const ctx = { sendChatAction: send } as unknown as Context;
+  return { ctx, send };
+}
+
+/** A promise plus its resolver, so a test can hold `work` open across timers. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('withTypingIndicator', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('sends a typing action immediately, before work resolves', async () => {
+    const { ctx, send } = makeCtx(async () => true);
+    const p = withTypingIndicator(ctx, async () => 'ok');
+    // The initial action is fired synchronously, before the first await.
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('typing');
+    await p;
+  });
+
+  it('re-sends the typing action every ~4s while work is pending', async () => {
+    const { ctx, send } = makeCtx(async () => true);
+    const d = deferred<string>();
+    const p = withTypingIndicator(ctx, () => d.promise);
+
+    expect(send).toHaveBeenCalledTimes(1); // immediate
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(send).toHaveBeenCalledTimes(2); // first refresh
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(send).toHaveBeenCalledTimes(3); // second refresh
+
+    d.resolve('done');
+    await expect(p).resolves.toBe('done');
+  });
+
+  it('clears the refresh timer once work resolves (no interval outlives the turn)', async () => {
+    const { ctx, send } = makeCtx(async () => true);
+    await withTypingIndicator(ctx, async () => 'done');
+    const callsAfterSettle = send.mock.calls.length;
+    // Advancing well past several refresh windows must produce no further sends.
+    await vi.advanceTimersByTimeAsync(20000);
+    expect(send).toHaveBeenCalledTimes(callsAfterSettle);
+  });
+
+  it('clears the timer and propagates when work rejects', async () => {
+    const { ctx, send } = makeCtx(async () => true);
+    const boom = new Error('boom');
+    await expect(withTypingIndicator(ctx, async () => { throw boom; })).rejects.toBe(boom);
+    const callsAfterThrow = send.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(20000);
+    expect(send).toHaveBeenCalledTimes(callsAfterThrow); // timer cleared despite throw
+  });
+
+  it('runs work to completion even when the typing action itself rejects (best-effort)', async () => {
+    // A flood-control 429 / blocked-chat on the indicator must never cost the reply.
+    const { ctx } = makeCtx(async () => { throw new Error('429: Too Many Requests'); });
+    await expect(withTypingIndicator(ctx, async () => 'still-ran')).resolves.toBe('still-ran');
+  });
+
+  it('returns the resolved value of work', async () => {
+    const { ctx } = makeCtx(async () => true);
+    await expect(withTypingIndicator(ctx, async () => 42)).resolves.toBe(42);
+  });
+});

--- a/src/telegram/typing-indicator.ts
+++ b/src/telegram/typing-indicator.ts
@@ -1,0 +1,37 @@
+import type { Context } from 'telegraf';
+
+/**
+ * Delay between typing-indicator refreshes. Telegram expires a
+ * `sendChatAction('typing')` bubble after ~5s, so we re-arm just under that
+ * ceiling. (Telegraf's own `persistentChatAction` uses the same 4000ms default.)
+ */
+const TYPING_REFRESH_MS = 4000;
+
+/**
+ * Show a Telegram "typing…" indicator for the whole duration of `work`, then
+ * return its result (rejections propagate unchanged).
+ *
+ * Contract: the indicator is BEST-EFFORT — a failed chat action (flood-control
+ * 429, blocked chat, transient network) must never block or abort the turn, so
+ * every send error is swallowed. This is precisely why we do NOT use Telegraf's
+ * `ctx.persistentChatAction`: its initial `sendChatAction` is un-guarded and
+ * would throw before `work` ran, silently dropping the user's reply. A one-shot
+ * action goes stale after ~5s, so we re-send every TYPING_REFRESH_MS.
+ *
+ * Invariant: the refresh timer is armed before `work` and cleared in `finally`
+ * on every exit path (resolve or throw), so no interval outlives the turn.
+ */
+export async function withTypingIndicator<T>(
+  ctx: Context,
+  work: () => Promise<T>,
+): Promise<T> {
+  ctx.sendChatAction('typing').catch(() => {});
+  const timer: ReturnType<typeof setInterval> = setInterval(() => {
+    ctx.sendChatAction('typing').catch(() => {});
+  }, TYPING_REFRESH_MS);
+  try {
+    return await work();
+  } finally {
+    clearInterval(timer);
+  }
+}


### PR DESCRIPTION
## What

The Telegram bot's "typing…" indicator went stale on almost every turn. `sendChatAction('typing')` was fired once per turn (fire-and-forget), and Telegram auto-expires that bubble after ~5s. So any turn longer than ~5s (essentially every agent turn: streaming, tool use, compaction) showed no live typing signal during exactly the phases where the streamed message can sit static and the user most wants reassurance it's still working.

## Change

- New `src/telegram/typing-indicator.ts` — `withTypingIndicator(ctx, work)` shows typing for the full duration of `work`, re-arming every 4s (under Telegram's ~5s expiry) and clearing the timer in `finally` on every exit path (resolve or throw).
- Converted all three one-shot `sendChatAction('typing')` call sites to the wrapper:
  - `handlers/message.ts` → `processOne` — the streamed turn (the main case)
  - `handlers/message.ts` → `processCompactDirect` — `/compact` (a model call that also exceeds ~5s)
  - `handlers/commands.ts` → `handleCompact` — `/compact`

## Why a custom helper instead of Telegraf's `persistentChatAction`

Telegraf 4.16 ships `ctx.persistentChatAction`, but it does not guard its *initial* `sendChatAction`. A transient typing-only failure (flood-control 429, blocked chat, network blip) would throw **before** the wrapped work ran, silently dropping the user's reply. The helper swallows every send error — initial and refresh — preserving the pre-existing best-effort `.catch(() => {})` semantics: a failed indicator must never cost the user their reply. As a bonus, because it still calls `ctx.sendChatAction('typing')` internally, no existing test mocks or assertions needed changing.

## Testing

- New `typing-indicator.test.ts` (6 tests, fake timers): immediate send, 4s re-arm while pending, timer teardown on both resolve and throw, best-effort error swallowing, return-value passthrough.
- `pnpm lint` (`tsc --noEmit`, strict): clean.
- Full `src/telegram` suite: **541 tests pass** (incl. `bot.test.ts` real-stream path, which now exercises the wrap end-to-end).

No `@anthropic-ai/sdk` imports added; the SDK dependency lock is unaffected.
