### PR TITLE
fix(skills): evict project-origin skills across cwd change (#179)

### DIFF
--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -722,6 +722,109 @@ describe('collectSkillEntries — disk-scan regression (user + project skills)',
   });
 });
 
+// ---------------------------------------------------------------------------
+// Regression: #179 — project-origin skills must be evicted when cwd changes.
+//
+// Simulates a long-lived daemon serving project A, then project B: the project
+// scan in collectSkillEntries() must remove stale project-A entries before
+// registering project-B entries. User-origin and built-in skills must survive.
+// ---------------------------------------------------------------------------
+describe('collectSkillEntries — project skill eviction on cwd change (#179)', () => {
+  let tmpAfkHome: string;
+  let cwdA: string;
+  let cwdB: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    _resetRegistry();
+    vi.unstubAllEnvs();
+
+    tmpAfkHome = mkdtempSync('/tmp/skill-bridge-evict-afkhome-');
+    cwdA = mkdtempSync('/tmp/skill-bridge-evict-cwdA-');
+    cwdB = mkdtempSync('/tmp/skill-bridge-evict-cwdB-');
+    origCwd = process.cwd();
+
+    vi.stubEnv('AFK_HOME', tmpAfkHome);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    process.chdir(origCwd);
+    try { rmSync(tmpAfkHome, { recursive: true }); } catch { /* non-fatal */ }
+    try { rmSync(cwdA, { recursive: true }); } catch { /* non-fatal */ }
+    try { rmSync(cwdB, { recursive: true }); } catch { /* non-fatal */ }
+  });
+
+  function writeSkillIn(baseDir: string, name: string, description: string): void {
+    const dir = join(baseDir, '.afk', 'skills', name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'SKILL.md'),
+      `---\nname: ${name}\ndescription: ${description}\n---\n# Body\n`,
+    );
+  }
+
+  function writeUserSkillIn(afkHome: string, name: string, description: string): void {
+    const dir = join(afkHome, 'skills', name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'SKILL.md'),
+      `---\nname: ${name}\ndescription: ${description}\n---\n# Body\n`,
+    );
+  }
+
+  it('evicts project-A skills after switching to project B', () => {
+    writeSkillIn(cwdA, 'proj-a-skill', 'Skill only in project A');
+    writeSkillIn(cwdB, 'proj-b-skill', 'Skill only in project B');
+
+    // First call: cwd = project A
+    process.chdir(cwdA);
+    const entriesA = collectSkillEntries([]);
+    const namesA = entriesA.map((e) => e.name);
+    expect(namesA).toContain('proj-a-skill');
+    expect(namesA).not.toContain('proj-b-skill');
+
+    // Second call: cwd = project B — proj-a-skill must be gone
+    process.chdir(cwdB);
+    const entriesB = collectSkillEntries([]);
+    const namesB = entriesB.map((e) => e.name);
+    expect(namesB).toContain('proj-b-skill');
+    expect(namesB).not.toContain('proj-a-skill');
+  });
+
+  it('user-origin skills survive the cwd change', () => {
+    writeUserSkillIn(tmpAfkHome, 'global-user-skill', 'Always present');
+    writeSkillIn(cwdA, 'proj-a-only', 'Project A only');
+    writeSkillIn(cwdB, 'proj-b-only', 'Project B only');
+
+    // First call: cwd = project A
+    process.chdir(cwdA);
+    const entriesA = collectSkillEntries([]);
+    expect(entriesA.map((e) => e.name)).toContain('global-user-skill');
+
+    // Second call: cwd = project B — user skill must still be present
+    process.chdir(cwdB);
+    const entriesB = collectSkillEntries([]);
+    const namesB = entriesB.map((e) => e.name);
+    expect(namesB).toContain('global-user-skill');
+    expect(namesB).toContain('proj-b-only');
+    expect(namesB).not.toContain('proj-a-only');
+  });
+
+  it('evicted project entries are fully absent from the manifest', () => {
+    writeSkillIn(cwdA, 'stale-skill', 'Stale from project A');
+
+    process.chdir(cwdA);
+    const manifestA = buildSkillManifest([]);
+    expect(manifestA).toContain('stale-skill');
+
+    // Switch to project B (no skills)
+    process.chdir(cwdB);
+    const manifestB = buildSkillManifest([]);
+    expect(manifestB).not.toContain('stale-skill');
+  });
+});
+
 describe('scanAllPluginRoots', () => {
   it('returns well-formed local plugin configs', () => {
     _resetPluginScanCache();

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -14,7 +14,7 @@
 // Barrel import triggers self-registration side-effects for built-in skills.
 import '../../skills/all.js';
 
-import { listSkills, getSkill, registerSkill, isSkillVisible } from '../../skills/index.js';
+import { listSkills, getSkill, registerSkill, isSkillVisible, evictSkillsByOrigin } from '../../skills/index.js';
 import { loadSkillPrompts } from '../../skills/_lib/prompt-loader.js';
 import { scanSkillsFromDir } from '../../skills/user-skills.js';
 import { scanLocalPlugins } from '../plugins-scanner.js';
@@ -118,6 +118,16 @@ export function collectSkillEntries(
   //    `project:<name>`. Both lose the bare slot to an already-registered
   //    builtin (origin undefined) via the resolveSkillKey collision logic.
   scanSkillsFromDir(getSkillsDir(), 'user');
+  // Invariant: evict stale project-origin skills before rescanning the
+  // project dir. In a long-lived process (daemon, Telegram bot) the cwd may
+  // have changed since the previous call, and any skills registered for the
+  // old cwd must not persist into the new project context. User-origin and
+  // built-in skills are deliberately excluded from eviction — they are
+  // cwd-agnostic and must survive across project boundaries. The eviction
+  // cost is O(registry size) and bounded by the number of registered skills
+  // (typically <100), so it is negligible relative to the disk scan that
+  // follows.
+  evictSkillsByOrigin('project');
   scanSkillsFromDir(getProjectSkillsDir(), 'project');
   // Imported skills from trusted source binaries (Claude Code, Codex) opted
   // into via `importFrom`. Scanned AFTER native scopes so a native skill keeps

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -221,6 +221,32 @@ export function listVisibleSkills(internalUnlocked: boolean): string[] {
 }
 
 /**
+ * Evict all skills whose `origin` matches the given value.
+ *
+ * Used by `collectSkillEntries()` before each project scan so that skills
+ * registered for a previous cwd do not persist when the working directory
+ * changes in a long-lived process (daemon, Telegram bot). Only
+ * `'project'`-origin entries are evicted in production; the caller is
+ * responsible for passing the correct origin.
+ *
+ * User-origin (`~/.afk/skills/`) and built-in (undefined origin) skills are
+ * never passed here and therefore survive across cwd changes, which is the
+ * correct steady-state: global skills are cwd-agnostic.
+ *
+ * Returns the number of registry entries removed.
+ */
+export function evictSkillsByOrigin(origin: SkillMetadata['origin']): number {
+  let removed = 0;
+  for (const [key, meta] of registry) {
+    if (meta.origin === origin) {
+      registry.delete(key);
+      removed++;
+    }
+  }
+  return removed;
+}
+
+/**
  * Internal: reset registry for testing.
  * Marked with underscore to indicate test-only usage.
  */


### PR DESCRIPTION
## Problem

`collectSkillEntries()` (`src/agent/tools/skill-bridge.ts`) scans `<cwd>/.afk/skills/` into a module-scoped registry `Map` (`src/skills/index.ts`) on every manifest build, but never evicted the previous project-origin entries first. In a short-lived CLI process this is invisible — the process exits before cwd ever changes. In a long-lived daemon or Telegram bot process, once the working directory changes (e.g. daemon serving a different project, or `cd` between tasks), stale project-A skills stayed registered and were merged into project-B's manifest, leaking skills across project boundaries.

Fixes #179.

## Fix

- Added `evictSkillsByOrigin(origin)` to `src/skills/index.ts` — removes every registry entry whose `origin` matches the given value and returns the removed count.
- `collectSkillEntries()` now calls `evictSkillsByOrigin('project')` immediately before rescanning `getProjectSkillsDir()`, so each manifest build starts from a clean project-scope slate before repopulating it from the current cwd.
- User-origin (`~/.afk/skills/`) and built-in skills are deliberately excluded from eviction — they're cwd-agnostic and must survive project switches. Only `'project'`-origin entries are evicted.
- Cost is O(registry size), bounded by the number of registered skills (typically <100), negligible next to the disk scan that follows.

## Tests

Added a new regression suite in `src/agent/tools/skill-bridge.test.ts` (`collectSkillEntries — project skill eviction on cwd change (#179)`) simulating a long-lived daemon serving project A then project B:

1. `evicts project-A skills after switching to project B` — project-A skill disappears once cwd moves to project B, project-B skill appears.
2. `user-origin skills survive the cwd change` — a `~/.afk/skills/`-scoped skill remains registered across both cwd switches while project-scoped skills correctly rotate.
3. `evicted project entries are fully absent from the manifest` — asserts the rendered `buildSkillManifest()` string, not just the registry, no longer mentions the stale skill.

Verified:
- `pnpm lint` (`tsc --noEmit`) — clean.
- `vitest run src/agent/tools/skill-bridge.test.ts` — 39/39 passed.
- `vitest run src/skills` — 452/452 passed (22 files), no collateral breakage.
