### PR TITLE
fix(afk): close AFK-mode coverage gaps + clip rawBody fallback (#200)

### DIFF
--- a/src/agent/providers/anthropic-direct/afk-mode-gate-wiring.test.ts
+++ b/src/agent/providers/anthropic-direct/afk-mode-gate-wiring.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Regression test for AFK-mode GATE wiring (the enforcement half).
+ *
+ * `plan-mode-system-payload.test.ts` and `afk-mode-addendum.test.ts` cover the
+ * POSTURE half — the system-prompt addendum the model sees. This file covers the
+ * ENFORCEMENT half: when a session is in `'autonomous'` (AFK) permission mode,
+ * a high-risk bash command such as `rm -rf x` must be REFUSED by the AFK-mode
+ * gate before its handler runs.
+ *
+ * The gate is a `PreToolUse` hook. It reaches the per-query
+ * `SessionToolDispatcher` only if the provider threads the session's hook
+ * registry into the dispatcher. Production entry points (REPL/chat/daemon/
+ * telegram) construct the provider WITHOUT a constructor-time `hookRegistry`
+ * and instead pass the session-scoped registry on `AgentConfig.hookRegistry`
+ * (consumed by `provider.query({ config })`). This test mirrors that exact
+ * shape — `new AnthropicDirectProvider()` (no constructor registry) + a
+ * registry supplied on the query config — so a regression that drops
+ * `config.hookRegistry` on the dispatcher path is caught here.
+ *
+ * Observation point: the `tool.output` ProviderEvent. A gate block surfaces as
+ * `isError: true` with an "AFK mode" / "blocked by PreToolUse hook" message;
+ * an un-gated call instead runs the real `bash` handler (which would execute
+ * the command).
+ *
+ * Key difference from plan-mode gate wiring: the AFK gate applies TREE-WIDE
+ * (no subagent self-skip for safety ceiling), and only `'autonomous'` mode
+ * triggers it (not `'plan'` or `'default'`).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { RawMessageStreamEvent } from '@anthropic-ai/sdk/resources';
+import type { ProviderEvent } from '../provider.js';
+import { AnthropicDirectProvider, __setAnthropicClientFactory } from './index.js';
+import { createHookRegistry, type HookRegistry } from '../../hooks.js';
+import { createAfkModeGate } from '../../afk-mode-gate.js';
+import type { ElicitationResult } from '../../types/sdk-types.js';
+
+// --- Mock Anthropic Messages-API plumbing (mirrors plan-mode-gate-wiring.test.ts) ---
+
+const messagesCreateMock = vi.fn();
+
+class MockAnthropic {
+  public messages: { create: typeof messagesCreateMock };
+  constructor() {
+    this.messages = { create: messagesCreateMock };
+  }
+}
+
+function installFactory(): void {
+  __setAnthropicClientFactory(() => new MockAnthropic() as unknown as Anthropic);
+}
+
+async function* singleInput(content: string): AsyncIterable<{ content: string }> {
+  yield { content };
+}
+
+async function* fromArray<T>(arr: T[]): AsyncIterable<T> {
+  for (const x of arr) yield x;
+}
+
+async function collect(query: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  for await (const ev of query) out.push(ev);
+  return out;
+}
+
+function makeToolUseStream(
+  toolId: string,
+  toolName: string,
+  inputJson: string,
+): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_t',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-5',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 7,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'tool_use', id: toolId, name: toolName, input: {} },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: inputJson },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'tool_use', stop_sequence: null },
+      usage: { output_tokens: 9 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+function makeTextStream(text: string): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_done',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-5',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 5,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '', citations: [] },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 4 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+/**
+ * Registry carrying ONLY the AFK-mode gate in the requested mode. The gate's
+ * `route` is stubbed to DECLINE so high-risk ops immediately degrade to the
+ * legacy hard block — this isolates the "gate fires and blocks" assertion from
+ * the elicitation round-trip path tested in `afk-mode-gate.test.ts`.
+ */
+function afkGateRegistry(mode: 'autonomous' | 'default'): HookRegistry {
+  const registry = createHookRegistry();
+  registry.register(
+    'PreToolUse',
+    createAfkModeGate(
+      () => mode,
+      undefined,
+      undefined,
+      // Stub the elicitation route to DECLINE immediately so a high-risk op
+      // degrades to a hard block without waiting for any operator response.
+      { route: async (): Promise<ElicitationResult> => ({ action: 'decline' }) },
+    ),
+    { longRunning: true },
+  );
+  return registry;
+}
+
+const BASH_RM_INPUT = JSON.stringify({ command: 'rm -rf x' });
+
+function toolOutputOf(events: ProviderEvent[]): { content: string; isError?: boolean } {
+  const ev = events.find((e) => e.type === 'tool.output');
+  if (!ev || ev.type !== 'tool.output') {
+    throw new Error('expected a tool.output event');
+  }
+  return { content: ev.content, ...(ev.isError !== undefined ? { isError: ev.isError } : {}) };
+}
+
+describe('AnthropicDirectProvider — AFK-mode gate reaches the dispatcher via config.hookRegistry', () => {
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    installFactory();
+    let callIdx = 0;
+    messagesCreateMock.mockImplementation(() => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        return fromArray(makeToolUseStream('toolu_bash', 'bash', BASH_RM_INPUT));
+      }
+      return fromArray(makeTextStream('done'));
+    });
+  });
+
+  it('BLOCKS bash rm -rf for a top-level session in autonomous (AFK) mode', async () => {
+    // Provider constructed WITHOUT a hookRegistry — exactly how bootstrap.ts,
+    // chat.ts, daemon.ts, and telegram.ts build it. The gate must still fire
+    // because the session-scoped registry is supplied on the query config.
+    const provider = new AnthropicDirectProvider({
+      permissions: { allowedTools: ['bash'] },
+    });
+    const query = provider.query({
+      prompt: singleInput('remove the build dir'),
+      config: {
+        model: 'claude-sonnet-5',
+        apiKey: 'sk-ant-oat01-test',
+        permissionMode: 'autonomous',
+        hookRegistry: afkGateRegistry('autonomous'),
+      },
+    });
+
+    const events = await collect(query);
+    const out = toolOutputOf(events);
+
+    expect(out.isError).toBe(true);
+    expect(out.content).toContain('AFK mode');
+    expect(out.content).toContain('bash');
+  });
+
+  it('does NOT block bash rm -rf when the session is in default mode', async () => {
+    // In default mode the AFK gate is a no-op — only 'autonomous' triggers it.
+    const provider = new AnthropicDirectProvider({
+      permissions: { allowedTools: ['bash'] },
+    });
+    const query = provider.query({
+      prompt: singleInput('remove the build dir'),
+      config: {
+        model: 'claude-sonnet-5',
+        apiKey: 'sk-ant-oat01-test',
+        permissionMode: 'default',
+        hookRegistry: afkGateRegistry('default'),
+      },
+    });
+
+    const events = await collect(query);
+    const out = toolOutputOf(events);
+
+    // The gate did not fire — whatever the handler returned, it is NOT the
+    // AFK-mode refusal.
+    expect(out.content).not.toContain('AFK mode');
+    expect(out.content).not.toContain('blocked by PreToolUse hook');
+  });
+});

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -28,6 +28,7 @@ import { createPlanModeGate } from '../../plan-mode-gate.js';
 import type { AnthropicToolDef } from '../anthropic-direct/types.js';
 import type { ToolHandler } from '../../tools/types.js';
 import { PLAN_MODE_ADDENDUM_TEXT } from '../anthropic-direct/plan-mode-addendum.js';
+import { AFK_MODE_ADDENDUM_TEXT } from '../anthropic-direct/afk-mode-addendum.js';
 import { computeLineDiff } from '../../../utils/diff.js';
 import type { ToolCall, ToolResult } from '../anthropic-direct/types.js';
 import { setSlotBindings, resetSlotBindings } from '../../session/model-slots.js';
@@ -1159,6 +1160,61 @@ describe('OpenAICompatibleQuery — plan-mode addendum (U2)', () => {
     const args = createCalls[0]!.args as { messages: Array<{ role: string; content: string }> };
     expect(args.messages[0]?.content).toBe('be helpful');
     expect(args.messages[0]?.content).not.toContain(PLAN_MODE_ADDENDUM_TEXT);
+  });
+});
+
+describe('OpenAICompatibleQuery — AFK-mode addendum (U2-afk)', () => {
+  it('appends AFK_MODE_ADDENDUM_TEXT to system message when permissionMode is autonomous', async () => {
+    pendingChunks = [
+      {
+        choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    ];
+    const q = buildQueryFromConfig(
+      baseConfig({ permissionMode: 'autonomous', systemPrompt: 'be helpful' }),
+      singleInput('hi'),
+    );
+    await collect(q);
+    expect(createCalls).toHaveLength(1);
+    const args = createCalls[0]!.args as { messages: Array<{ role: string; content: string }> };
+    expect(args.messages[0]?.role).toBe('system');
+    expect(args.messages[0]?.content).toContain('be helpful');
+    expect(args.messages[0]?.content).toContain(AFK_MODE_ADDENDUM_TEXT);
+  });
+
+  it('does not append AFK_MODE_ADDENDUM_TEXT when permissionMode is default', async () => {
+    pendingChunks = [
+      {
+        choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    ];
+    const q = buildQueryFromConfig(
+      baseConfig({ systemPrompt: 'be helpful' }),
+      singleInput('hi'),
+    );
+    await collect(q);
+    const args = createCalls[0]!.args as { messages: Array<{ role: string; content: string }> };
+    expect(args.messages[0]?.content).toBe('be helpful');
+    expect(args.messages[0]?.content).not.toContain(AFK_MODE_ADDENDUM_TEXT);
+  });
+
+  it('does not append PLAN_MODE_ADDENDUM_TEXT when permissionMode is autonomous (modes are mutually exclusive)', async () => {
+    pendingChunks = [
+      {
+        choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    ];
+    const q = buildQueryFromConfig(
+      baseConfig({ permissionMode: 'autonomous', systemPrompt: 'be helpful' }),
+      singleInput('hi'),
+    );
+    await collect(q);
+    const args = createCalls[0]!.args as { messages: Array<{ role: string; content: string }> };
+    expect(args.messages[0]?.content).not.toContain(PLAN_MODE_ADDENDUM_TEXT);
+    expect(args.messages[0]?.content).toContain(AFK_MODE_ADDENDUM_TEXT);
   });
 });
 

--- a/src/cli/commands/interactive/afk-push.ts
+++ b/src/cli/commands/interactive/afk-push.ts
@@ -36,6 +36,17 @@ import type { TerminalState, TerminalKind } from './terminal-state.js';
  *  low enough to bound notification flood if the model loops. */
 export const MAX_PUSHES_PER_SESSION = 20;
 
+/**
+ * Maximum length (in characters) of the rawBody fallback used when no
+ * structured terminal-state fields parsed. Caps the Telegram payload so an
+ * oversized model body cannot carry unbounded prose into the push channel.
+ * Any excess is replaced with a `[truncated]` sentinel.
+ *
+ * The structured-field path is always preferred; this limit only applies to
+ * the last-resort rawBody fallback (see {@link formatTerminalStateForTelegram}).
+ */
+export const MAX_RAW_BODY_FALLBACK_CHARS = 500;
+
 const KIND_LABEL: Record<TerminalKind, string> = {
   done: '✅ Done',
   blocked: '⛔ Blocked',
@@ -127,8 +138,15 @@ export function formatTerminalStateForTelegram(
   }
   // Fallback: nothing structured parsed, but the parser found a verdict block.
   // Use the model's own terminal-state body (not tool output) as a last resort.
+  // Clip to MAX_RAW_BODY_FALLBACK_CHARS so an oversized model body cannot carry
+  // unbounded prose into the Telegram push channel.
   if (lines.length === 0 && state.rawBody.trim().length > 0) {
-    lines.push(state.rawBody.trim());
+    const raw = state.rawBody.trim();
+    lines.push(
+      raw.length > MAX_RAW_BODY_FALLBACK_CHARS
+        ? `${raw.slice(0, MAX_RAW_BODY_FALLBACK_CHARS)}… [truncated]`
+        : raw,
+    );
   }
   if (downgraded) {
     lines.push(


### PR DESCRIPTION
Closes three coverage/hardening gaps from #200:

1. Autonomous-mode addendum test in `src/agent/providers/openai-compatible/query.test.ts`
2. New `src/agent/providers/anthropic-direct/afk-mode-gate-wiring.test.ts` covering AFK-mode gate wiring in the anthropic-direct provider (verified against current `claude-sonnet-5` model id)
3. Clip the `rawBody` fallback in `afk-push.ts` terminal-state formatting to `MAX_RAW_BODY_FALLBACK_CHARS` (500 chars) so an oversized model body cannot carry unbounded prose into the Telegram push channel

`pnpm lint` and targeted `vitest run` (94 tests across the three touched files) pass.

Fixes #200