### PR TITLE
fix(agent): deliver SubagentStop injectContext with the next user message, not as its own turn

### DIFF
--- a/src/agent/hooks-integration.test.ts
+++ b/src/agent/hooks-integration.test.ts
@@ -23,7 +23,10 @@ interface SessionState {
 interface MockSessionTracker {
   state: SessionState;
   sendMessage: ReturnType<typeof vi.fn>;
+  /** Standalone messages pushed via `pushUserMessage` (live-steering channel). */
   getMockInputStreamMessages: () => string[];
+  /** Hook context queued via `queueFrameworkContext` (rides with the next real message). */
+  getMockQueuedFrameworkContext: () => string[];
 }
 
 const shared = vi.hoisted(() => ({
@@ -40,6 +43,7 @@ vi.mock('./session.js', () => {
     public interrupt = vi.fn(async () => undefined);
     public close = vi.fn(async () => undefined);
     private mockInputStreamMessages: string[] = [];
+    private mockQueuedFrameworkContext: string[] = [];
 
     constructor(config: Record<string, unknown>) {
       shared.lastConfig = config;
@@ -62,6 +66,7 @@ vi.mock('./session.js', () => {
         state: this.state,
         sendMessage: this.sendMessage,
         getMockInputStreamMessages: () => this.mockInputStreamMessages,
+        getMockQueuedFrameworkContext: () => this.mockQueuedFrameworkContext,
       });
     }
 
@@ -70,15 +75,25 @@ vi.mock('./session.js', () => {
     }
 
     getInputStreamRef() {
+      // Mirrors the real AgentSession ref: both channels exposed. The handle
+      // must route hook injectContext to `queueFrameworkContext` (rides with
+      // the next real message) and never to `pushUserMessage` (own turn).
       return {
         pushUserMessage: (content: string) => {
           this.mockInputStreamMessages.push(content);
+        },
+        queueFrameworkContext: (text: string) => {
+          this.mockQueuedFrameworkContext.push(text);
         },
       };
     }
 
     getMockInputStreamMessages(): string[] {
       return this.mockInputStreamMessages;
+    }
+
+    getMockQueuedFrameworkContext(): string[] {
+      return this.mockQueuedFrameworkContext;
     }
   }
   return { AgentSession: MockAgentSession };
@@ -259,10 +274,13 @@ describe('SubagentManager — hook integration', () => {
     await childHandle.run('audit the module');
     await childHandle.cancel();
 
-    const messages = parentSession.getMockInputStreamMessages();
-    expect(messages).toHaveLength(1);
-    expect(messages[0]).toMatch(/^\[framework-generated context: shadow-verify nudge\]/);
-    expect(messages[0]).toContain('/shadow-verify');
+    const queued = parentSession.getMockQueuedFrameworkContext();
+    expect(queued).toHaveLength(1);
+    expect(queued[0]).toMatch(/^\[framework-generated context: shadow-verify nudge\]/);
+    expect(queued[0]).toContain('/shadow-verify');
+    // Never delivered as a standalone input-stream message — that channel
+    // makes the nudge its own turn and displaces the user's next real message.
+    expect(parentSession.getMockInputStreamMessages()).toEqual([]);
   });
 
   it('resolves the registry from the PARENT session when manager + config omit it (production wiring)', async () => {
@@ -307,9 +325,10 @@ describe('SubagentManager — hook integration', () => {
     await childHandle.run('audit the module');
     await childHandle.cancel();
 
-    const messages = parentSession.getMockInputStreamMessages();
-    expect(messages).toHaveLength(1);
-    expect(messages[0]).toMatch(/^\[framework-generated context: shadow-verify nudge\]/);
+    const queued = parentSession.getMockQueuedFrameworkContext();
+    expect(queued).toHaveLength(1);
+    expect(queued[0]).toMatch(/^\[framework-generated context: shadow-verify nudge\]/);
+    expect(parentSession.getMockInputStreamMessages()).toEqual([]);
   });
 
   it('stays silent when neither config, manager, nor parent supplies a registry', async () => {
@@ -343,6 +362,7 @@ describe('SubagentManager — hook integration', () => {
     await childHandle.run('audit the module');
     await childHandle.cancel();
 
+    expect(parentSession.getMockQueuedFrameworkContext()).toEqual([]);
     expect(parentSession.getMockInputStreamMessages()).toEqual([]);
   });
 
@@ -397,6 +417,7 @@ describe('SubagentManager — hook integration', () => {
     await childHandle.cancel();
 
     // agentType='diagnose' is on the VERIFIED_ORCHESTRATORS list, so no nudge.
+    expect(parentSession.getMockQueuedFrameworkContext()).toEqual([]);
     expect(parentSession.getMockInputStreamMessages()).toEqual([]);
   });
 
@@ -549,9 +570,10 @@ describe('SubagentManager — hook integration', () => {
 
     await childHandle.cancel();
 
-    // After cancel, the child's SubagentStop should have injected context into parent.
-    const messages = parentSession.getMockInputStreamMessages();
-    expect(messages).toContain('verify: output looks suspicious');
+    // After cancel, the child's SubagentStop should have queued context on the parent.
+    const queued = parentSession.getMockQueuedFrameworkContext();
+    expect(queued).toContain('verify: output looks suspicious');
+    expect(parentSession.getMockInputStreamMessages()).toEqual([]);
   });
 
   it('SubagentStop without injectContext does not queue message to parent', async () => {
@@ -579,8 +601,8 @@ describe('SubagentManager — hook integration', () => {
 
     await childHandle.cancel();
 
-    const messages = parentSession.getMockInputStreamMessages();
-    expect(messages).toEqual([]);
+    expect(parentSession.getMockQueuedFrameworkContext()).toEqual([]);
+    expect(parentSession.getMockInputStreamMessages()).toEqual([]);
   });
 
   it('SubagentStop injectContext is NOT injected when parent is aborting', async () => {
@@ -625,8 +647,8 @@ describe('SubagentManager — hook integration', () => {
     await childHandle.cancel();
 
     // injectContext is suppressed because parent.abortSignal is set.
-    const messages = parentSession.getMockInputStreamMessages();
-    expect(messages).toEqual([]);
+    expect(parentSession.getMockQueuedFrameworkContext()).toEqual([]);
+    expect(parentSession.getMockInputStreamMessages()).toEqual([]);
   });
 
   it('SubagentStop injectContext still fires when no parent abortSignal is provided (opt-in check)', async () => {
@@ -660,8 +682,8 @@ describe('SubagentManager — hook integration', () => {
 
     await childHandle.cancel();
 
-    const messages = parentSession.getMockInputStreamMessages();
-    expect(messages).toContain('verify: no abort signal, proceed');
+    const queued = parentSession.getMockQueuedFrameworkContext();
+    expect(queued).toContain('verify: no abort signal, proceed');
   });
 
   it('multiple concurrent subagent cancels inject contexts in order', async () => {
@@ -701,10 +723,39 @@ describe('SubagentManager — hook integration', () => {
     await child1.cancel();
     await child2.cancel();
 
-    const messages = parentSession.getMockInputStreamMessages();
-    expect(messages).toHaveLength(2);
-    expect(messages[0]).toContain(child1.id);
-    expect(messages[1]).toContain(child2.id);
+    const queued = parentSession.getMockQueuedFrameworkContext();
+    expect(queued).toHaveLength(2);
+    expect(queued[0]).toContain(child1.id);
+    expect(queued[1]).toContain(child2.id);
+  });
+
+  it('falls back to pushUserMessage when the parent ref lacks queueFrameworkContext', async () => {
+    // Narrow stubs (older callers, minimal test doubles) may expose only the
+    // push channel. Delivery must degrade to the legacy behavior rather than
+    // silently dropping the context.
+    const registry = createHookRegistry();
+    registry.register('SubagentStop', () => ({
+      injectContext: 'verify: legacy channel delivery',
+    }));
+
+    const pushed: string[] = [];
+    const mgr = new SubagentManager({ hookRegistry: registry });
+    const handle = await mgr.forkSubagent({
+      parent: {
+        sessionId: 'root-legacy-ref',
+        getInputStreamRef: () => ({
+          pushUserMessage: (content: string) => {
+            pushed.push(content);
+          },
+        }),
+      },
+      config: { model: 'sonnet' },
+      idPrefix: 'child',
+    });
+
+    await handle.cancel();
+
+    expect(pushed).toEqual(['verify: legacy channel delivery']);
   });
 });
 
@@ -915,8 +966,8 @@ describe('SubagentHandle.teardown()', () => {
     await childHandle.run('audit');
     await childHandle.teardown();
 
-    const messages = parentSession.getMockInputStreamMessages();
-    expect(messages).toContain('post-teardown note');
+    const queued = parentSession.getMockQueuedFrameworkContext();
+    expect(queued).toContain('post-teardown note');
   });
 
   it('teardown() closes the underlying session', async () => {

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -304,6 +304,7 @@ export class AgentSession implements IAgentSession {
     this.subagentCompletedCount = 0;
     this.subagentRunningTokens = { input: 0, output: 0, cacheRead: 0, cacheCreation: 0 };
     this.subagentRunningCostUsd = 0;
+    this.pendingFrameworkContext = [];
 
     const iterable = this.providerQuery as AsyncIterable<ProviderEvent>;
     this.providerIterator = iterable[Symbol.asyncIterator]();

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -94,6 +94,12 @@ export class AgentSession implements IAgentSession {
   private providerIterator!: AsyncIterator<ProviderEvent>;
   private conversationHistory: Message[] = [];
   private turnCount = 0;
+  /**
+   * Hook-generated context (e.g. SubagentStop `injectContext`) waiting to be
+   * prepended to the next outbound user message. Never delivered as its own
+   * input-stream message — see `queueFrameworkContext`.
+   */
+  private pendingFrameworkContext: string[] = [];
   private lastResponseMetadata: ResponseMetadata | null = null;
   private initPromise: Promise<void> | null = null;
   private inputStream!: QueryInputStream;
@@ -585,11 +591,19 @@ export class AgentSession implements IAgentSession {
   private async *sendMessageStreamInternal(content: string | ContentBlockParam[]): AsyncIterableIterator<OutputEvent> {
     if (this.initPromise) await this.initPromise;
 
-    const historySummary = typeof content === 'string' ? content : this.summarizeContentBlocks(content);
+    // Fold queued hook context into THIS message so it rides along with the
+    // user's text instead of becoming a turn of its own — see
+    // `queueFrameworkContext` for the displacement bug this prevents.
+    const effectiveContent = this.withPendingFrameworkContext(content);
+
+    const historySummary =
+      typeof effectiveContent === 'string'
+        ? effectiveContent
+        : this.summarizeContentBlocks(effectiveContent);
 
     const userMessage: Message = { role: 'user', content: historySummary, timestamp: new Date() };
     this.conversationHistory.push(userMessage);
-    this.inputStream.pushUserMessage(content);
+    this.inputStream.pushUserMessage(effectiveContent);
 
     // Durable ledger: initialization is deferred to here (not the
     // constructor) because the provider-issued session id only exists after
@@ -1048,8 +1062,44 @@ export class AgentSession implements IAgentSession {
     );
   }
 
-  getInputStreamRef(): Pick<InputStreamRef, 'pushUserMessage'> {
-    return { pushUserMessage: (content: string) => this.inputStream.pushUserMessage(content) };
+  /**
+   * Queue hook-generated framework context (e.g. SubagentStop `injectContext`)
+   * for delivery WITH the next real outbound user message.
+   *
+   * Contract: the provider consumes exactly one input-stream message per turn,
+   * so delivering hook context via `pushUserMessage` makes it a turn of its
+   * own — and a push that lands after the current turn ends displaces the
+   * user's next real message by one queue position (every later send is then
+   * answered by the message before it). Holding the context here and
+   * prepending it in `sendMessageStreamInternal` keeps one send = one turn,
+   * keeps the model's view identical to the ledger/transcript, and lets
+   * undelivered context expire with the session.
+   */
+  queueFrameworkContext(text: string): void {
+    const trimmed = text.trim();
+    if (trimmed.length === 0) return;
+    this.pendingFrameworkContext.push(trimmed);
+    debugLog(
+      `AgentSession: queued framework context (${trimmed.length} chars) for the next user message`,
+    );
+  }
+
+  /** Drain queued framework context, prepending it to the outbound content (FIFO). */
+  private withPendingFrameworkContext(
+    content: string | ContentBlockParam[],
+  ): string | ContentBlockParam[] {
+    if (this.pendingFrameworkContext.length === 0) return content;
+    const prefix = this.pendingFrameworkContext.join('\n\n');
+    this.pendingFrameworkContext = [];
+    if (typeof content === 'string') return `${prefix}\n\n${content}`;
+    return [{ type: 'text', text: prefix }, ...content];
+  }
+
+  getInputStreamRef(): Pick<InputStreamRef, 'pushUserMessage' | 'queueFrameworkContext'> {
+    return {
+      pushUserMessage: (content: string) => this.inputStream.pushUserMessage(content),
+      queueFrameworkContext: (text: string) => this.queueFrameworkContext(text),
+    };
   }
 
   getHistory(): readonly Message[] {

--- a/src/agent/session/framework-context-queue.test.ts
+++ b/src/agent/session/framework-context-queue.test.ts
@@ -133,4 +133,16 @@ describe('AgentSession framework-context queue', () => {
     expect(capturedTurns[0]!.content).toBe(`${NUDGE}\n\nnext real message`);
     await session.close();
   });
+
+  it('drops queued context when reset starts a fresh conversation', async () => {
+    const session = new AgentSession(config);
+    session.queueFrameworkContext(NUDGE);
+
+    await session.reset();
+    await drain(session.sendMessageStream('fresh message'));
+
+    expect(capturedTurns).toHaveLength(1);
+    expect(capturedTurns[0]!.content).toBe('fresh message');
+    await session.close();
+  });
 });

--- a/src/agent/session/framework-context-queue.test.ts
+++ b/src/agent/session/framework-context-queue.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the framework-context queue on AgentSession.
+ *
+ * Hook-generated context (SubagentStop `injectContext`) must ride along with
+ * the NEXT real outbound user message — prepended to it — rather than being
+ * pushed as a standalone input-stream message. The provider consumes exactly
+ * one input-stream message per turn, so a standalone push becomes its own
+ * model turn and displaces the user's next real message by one queue position
+ * (every later send is then answered by the message before it). These tests
+ * pin the ride-along contract end to end: provider payload, conversation
+ * history, drain-once semantics, and the getInputStreamRef channel.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
+import type { AgentConfig } from '../types.js';
+import type { ProviderUserTurn } from '../provider.js';
+import { createMockProvider } from '../__fixtures__/mock-provider.js';
+
+vi.mock('../../utils/debug.js', () => ({
+  debugLog: vi.fn(),
+}));
+
+import { AgentSession } from '../session.js';
+
+const NUDGE = '[framework-generated context: test nudge]\n\nConsider verifying.';
+
+async function drain(stream: AsyncIterableIterator<unknown>): Promise<void> {
+  for await (const _event of stream) {
+    // consume all events
+  }
+}
+
+describe('AgentSession framework-context queue', () => {
+  let config: AgentConfig;
+  let capturedTurns: ProviderUserTurn[];
+
+  beforeEach(() => {
+    capturedTurns = [];
+    config = {
+      model: 'sonnet',
+      maxTurns: 10,
+      apiKey: 'test-key',
+      provider: createMockProvider({ onTurn: (turn) => capturedTurns.push(turn) }),
+    };
+  });
+
+  it('prepends queued context to the next string message — one turn, not two', async () => {
+    const session = new AgentSession(config);
+    session.queueFrameworkContext(NUDGE);
+
+    await drain(session.sendMessageStream('/resolve'));
+
+    expect(capturedTurns).toHaveLength(1);
+    expect(capturedTurns[0]!.content).toBe(`${NUDGE}\n\n/resolve`);
+    await session.close();
+  });
+
+  it('drains the queue once — the following send is unprefixed', async () => {
+    const session = new AgentSession(config);
+    session.queueFrameworkContext(NUDGE);
+
+    await drain(session.sendMessageStream('first'));
+    await drain(session.sendMessageStream('second'));
+
+    expect(capturedTurns).toHaveLength(2);
+    expect(capturedTurns[1]!.content).toBe('second');
+    await session.close();
+  });
+
+  it('joins multiple queued contexts FIFO with blank-line separators', async () => {
+    const session = new AgentSession(config);
+    session.queueFrameworkContext('note one');
+    session.queueFrameworkContext('note two');
+
+    await drain(session.sendMessageStream('go'));
+
+    expect(capturedTurns[0]!.content).toBe('note one\n\nnote two\n\ngo');
+    await session.close();
+  });
+
+  it('prepends a text block when the outbound content is ContentBlockParam[]', async () => {
+    const session = new AgentSession(config);
+    session.queueFrameworkContext(NUDGE);
+
+    const blocks: ContentBlockParam[] = [{ type: 'text', text: 'describe this' }];
+    await drain(session.sendMessageStream(blocks));
+
+    const sent = capturedTurns[0]!.content as ContentBlockParam[];
+    expect(Array.isArray(sent)).toBe(true);
+    expect(sent).toHaveLength(2);
+    expect(sent[0]).toEqual({ type: 'text', text: NUDGE });
+    expect(sent[1]).toEqual({ type: 'text', text: 'describe this' });
+    await session.close();
+  });
+
+  it('records the combined message in conversation history (ledger/transcript parity)', async () => {
+    // The displacement bug was invisible in transcripts because the pushed
+    // nudge bypassed recordUser. With ride-along delivery the history entry
+    // must contain exactly what the model saw.
+    const session = new AgentSession(config);
+    session.queueFrameworkContext(NUDGE);
+
+    await drain(session.sendMessageStream('/resolve'));
+
+    const userEntries = session.getHistory().filter((m) => m.role === 'user');
+    expect(userEntries).toHaveLength(1);
+    expect(userEntries[0]!.content).toBe(`${NUDGE}\n\n/resolve`);
+    await session.close();
+  });
+
+  it('ignores empty and whitespace-only context', async () => {
+    const session = new AgentSession(config);
+    session.queueFrameworkContext('');
+    session.queueFrameworkContext('   \n  ');
+
+    await drain(session.sendMessageStream('plain'));
+
+    expect(capturedTurns[0]!.content).toBe('plain');
+    await session.close();
+  });
+
+  it('exposes the queue on getInputStreamRef — the channel SubagentStop delivery uses', async () => {
+    const session = new AgentSession(config);
+    const ref = session.getInputStreamRef();
+
+    expect(typeof ref.queueFrameworkContext).toBe('function');
+    ref.queueFrameworkContext!(NUDGE);
+
+    await drain(session.sendMessageStream('next real message'));
+
+    expect(capturedTurns).toHaveLength(1);
+    expect(capturedTurns[0]!.content).toBe(`${NUDGE}\n\nnext real message`);
+    await session.close();
+  });
+});

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -458,15 +458,22 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
       this.traceWriter ? { traceWriter: this.traceWriter } : {},
     );
 
-    // Invariant: SubagentStop.injectContext is a framework-generated next-turn
-    // note, not the foreground subagent result and not human-authored text. The
-    // final subagent answer has already returned through the `agent` tool result;
-    // this side-channel queues only supplemental hook context for the parent's
-    // next input-stream read. Abort precedence: if the parent's abortSignal was
-    // provided AND is set, skip injection — the parent's query loop will unwind
-    // before it can consume the message. Matches the abort-graph invariant that
-    // abort is terminal for side effects. Injection failures are logged, not
-    // propagated.
+    // Invariant: SubagentStop.injectContext is a framework-generated note, not
+    // the foreground subagent result and not human-authored text. The final
+    // subagent answer has already returned through the `agent` tool result;
+    // this side-channel carries only supplemental hook context for the parent.
+    //
+    // Delivery MUST ride along with the parent's next real user message
+    // (queueFrameworkContext), never as a standalone input-stream message:
+    // the provider consumes exactly one input-stream message per turn, so a
+    // pushed message that lands after the parent's turn ends displaces the
+    // user's next real message by one queue position — every later send is
+    // then answered by the message before it, and the injected text never
+    // appears in the ledger. `pushUserMessage` remains only as a fallback for
+    // narrow parent refs that predate the queue channel. Abort precedence: if
+    // the parent's abortSignal was provided AND is set, skip injection — the
+    // parent's query loop will unwind before it can consume the message.
+    // Injection failures are logged, not propagated.
     if (decision.injectContext && this.parentInputStreamRef) {
       if (this.parentAbortSignal?.aborted) {
         debugLog(
@@ -474,7 +481,12 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
         );
       } else {
         try {
-          this.parentInputStreamRef.pushUserMessage(decision.injectContext);
+          const ref = this.parentInputStreamRef;
+          if (ref.queueFrameworkContext) {
+            ref.queueFrameworkContext(decision.injectContext);
+          } else {
+            ref.pushUserMessage(decision.injectContext);
+          }
         } catch (err) {
           debugLog(`Failed to inject context from SubagentStop handler: ${String(err)}`);
         }

--- a/src/agent/types/permission-types.ts
+++ b/src/agent/types/permission-types.ts
@@ -16,9 +16,22 @@ export interface PermissionBubbler {
 }
 
 /**
- * Narrow reference to a session's input stream for pushing user messages.
- * Used by SubagentStop handlers to inject context into parent sessions.
+ * Narrow reference to a session's input channels.
+ *
+ * `pushUserMessage` enqueues a standalone message on the session's input
+ * stream. The provider consumes exactly ONE input-stream message per turn, so
+ * a pushed message becomes its own model turn — correct for live steering,
+ * wrong for hook-generated context (a push that lands after the current turn
+ * ends displaces the user's next real message by one queue position).
+ *
+ * `queueFrameworkContext` is the channel for hook-generated context
+ * (e.g. SubagentStop `injectContext`): the text is held in session state and
+ * prepended to the NEXT real outbound user message, so it rides along with —
+ * never instead of — what the user actually sends. Optional because narrow
+ * stubs (tests, deferred-parent proxies) may only implement the push channel;
+ * callers fall back to `pushUserMessage` when absent.
  */
 export interface InputStreamRef {
   pushUserMessage(content: string): void;
+  queueFrameworkContext?(text: string): void;
 }

--- a/src/agent/types/session-types.ts
+++ b/src/agent/types/session-types.ts
@@ -257,10 +257,14 @@ export interface IAgentSession {
   getOutputStream(): AsyncIterable<OutputEvent>;
 
   /**
-   * Get a narrow reference to the input stream for pushing user messages.
-   * Used by SubagentStop handlers to inject context into the parent's next turn.
+   * Get a narrow reference to the session's input channels.
+   *
+   * `pushUserMessage` starts a standalone turn (live steering);
+   * `queueFrameworkContext` holds hook-generated context (SubagentStop
+   * `injectContext`) to be prepended to the next real user message so it can
+   * never displace one. See `InputStreamRef` for the full contract.
    */
-  getInputStreamRef(): Pick<InputStreamRef, 'pushUserMessage'>;
+  getInputStreamRef(): Pick<InputStreamRef, 'pushUserMessage' | 'queueFrameworkContext'>;
 
   supportedCommands(): Promise<SlashCommand[]>;
   supportedModels(): Promise<ModelInfo[]>;


### PR DESCRIPTION
## Summary

SubagentStop `injectContext` (the shadow-verify nudge) was delivered by pushing a **standalone user message** onto the parent's input stream (`handle.ts` → `pushUserMessage`). The provider consumes exactly one input-stream message per turn (`anthropic-direct/query.ts`) and never reads input mid-turn, so every injected nudge became a turn of its own — and any nudge queued after a turn ended **displaced the user's next real message by one queue position**. From then on each send was answered by the message before it. The push also bypassed the ledger, so the injected text never appeared in transcripts: sessions looked like the model was ignoring commands.

Observed in production (session `61db02da`, 2026-07-01): after `/review` forked 11 subagents, two unsuppressed nudges consumed the user's next two `/resolve` commands; the third `/resolve` was answered by the first one's text, leaving two stale commands latent in the queue.

**Fix — ride-along delivery instead of standalone turns:**
- `AgentSession` gains a `pendingFrameworkContext` queue with a `queueFrameworkContext()` method; queued context is drained and **prepended to the next real outbound user message** in `sendMessageStreamInternal` (mirrors how UserPromptSubmit `injectContext` prepends to `runText`).
- `getInputStreamRef()` now exposes both channels; SubagentStop delivery prefers `queueFrameworkContext`, falling back to `pushUserMessage` only for narrow refs that predate the queue channel. Live steering via `pushUserMessage` is unchanged.
- One send = one turn; the model's view now matches conversation history / ledger / transcripts; undelivered context expires with the session.

## How was this tested?

- `pnpm lint` clean (strict tsc).
- `pnpm test`: full suite **567 files / 10,466 passed** (14 pre-existing skips).
- New `src/agent/session/framework-context-queue.test.ts` (7 tests): prepend-to-string, drain-once, FIFO join, ContentBlockParam[] prepend, history/ledger parity, whitespace no-op, ref-channel delivery.
- `hooks-integration.test.ts`: nudge-delivery assertions moved to the queued channel with explicit "push channel stayed empty" guards; silent/abort/verified-orchestrator cases assert both channels empty; new fallback test covers legacy pushUserMessage-only parent refs.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/) — see [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or private paths in the diff
