### PR TITLE
feat(tui): grounded progress banner — real activity instead of mechanism noise

### DIFF
--- a/src/agent/providers/anthropic-direct.test.ts
+++ b/src/agent/providers/anthropic-direct.test.ts
@@ -825,18 +825,20 @@ describe('AnthropicDirectProvider', () => {
 
     const first = progressEvents[0]!;
     expect(first.progress.taskId).toBeTruthy();
-    expect(first.progress.description).toBe('Tool-use loop');
+    expect(first.progress.description).toBe('Working');
     expect(first.progress.toolUses).toBe(1);
     expect(first.progress.lastToolName).toBe('read_file');
     expect(first.progress.totalTokens).toBeGreaterThanOrEqual(0);
     expect(first.progress.durationMs).toBeGreaterThanOrEqual(0);
-    expect(first.progress.summary).toContain('Iteration 1');
+    expect(first.progress.summary).toContain('round 1');
+    expect(first.progress.summary).toContain('read_file');
     expect(first.sessionId).toBeTruthy();
 
     const second = progressEvents[1]!;
     expect(second.progress.toolUses).toBe(2);
     expect(second.progress.lastToolName).toBe('write_file');
-    expect(second.progress.summary).toContain('Iteration 2');
+    expect(second.progress.summary).toContain('round 2');
+    expect(second.progress.summary).toContain('write_file');
     expect(second.progress.taskId).toBe(first.progress.taskId);
   });
 

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -695,12 +695,21 @@ export async function* runTurn(
     iterations += 1;
 
     const lastTool = turnResult.toolUseBlocks[turnResult.toolUseBlocks.length - 1];
+    // Semantic summary: name the tool AND its most informative argument
+    // (path / command / query via summarizeToolInput) so the progress banner
+    // carries real signal — `bash git show f7f0a37…` instead of the old
+    // `Iteration 11: used bash`, which conveyed nothing after round 2.
+    // `description` stays STABLE across ticks for this taskId (the banner
+    // dedupes line 0 on commit); the per-tick signal lives in `summary`.
+    const lastToolHeadline = lastTool
+      ? `${lastTool.name}${summarizeToolInput(lastTool.name, lastTool.input)}`
+      : 'unknown';
     yield {
       type: 'progress',
       progress: {
         taskId,
-        description: 'Tool-use loop',
-        summary: `Iteration ${iterations}: used ${lastTool?.name ?? 'unknown'}`,
+        description: 'Working',
+        summary: `round ${iterations}: ${lastToolHeadline}`,
         lastToolName: lastTool?.name,
         totalTokens: accumulatedUsage.totalTokens ?? 0,
         toolUses: iterations,

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -594,13 +594,29 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       yield* this.dispatchAndAppend(result.state, controller.signal, vision);
 
       {
-        const lastToolName = finalizedToolCalls(result.state).at(-1)?.name;
+        const lastCall = finalizedToolCalls(result.state).at(-1);
+        const lastToolName = lastCall?.name;
+        // Semantic summary — mirror anthropic-direct/loop.ts: tool name +
+        // most informative argument via summarizeToolInput, so the progress
+        // banner carries real signal instead of a bare iteration counter.
+        // AccumulatedToolCall carries UNPARSED argumentsRaw (the streamed
+        // JSON fragments joined); parse best-effort — a malformed payload
+        // (mid-stream abort, shim quirks) degrades to the bare tool name.
+        let lastCallInput: unknown;
+        try {
+          lastCallInput = lastCall ? JSON.parse(lastCall.argumentsRaw || '{}') : undefined;
+        } catch {
+          lastCallInput = undefined;
+        }
+        const lastToolHeadline = lastCall
+          ? `${lastCall.name}${summarizeToolInput(lastCall.name, lastCallInput)}`
+          : 'unknown';
         yield {
           type: 'progress',
           progress: {
             taskId,
-            description: 'Tool-use loop',
-            summary: `Iteration ${iter + 1}: used ${lastToolName ?? 'unknown'}`,
+            description: 'Working',
+            summary: `round ${iter + 1}: ${lastToolHeadline}`,
             lastToolName,
             totalTokens: accumulatedUsage.totalTokens ?? 0,
             toolUses: iter + 1,

--- a/src/cli/_lib/stream-renderer-lifecycle.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.ts
@@ -14,7 +14,7 @@ import { OverlayComposer } from './overlay-composer.js';
 import { createStageTracker } from '../commands/interactive/loop-stage.js';
 import { formatDuration } from '../format-utils.js';
 import { formatThinkingParagraph } from '../commands/interactive/thinking-paragraph.js';
-import { formatProgressBanner } from '../commands/interactive/progress-banner.js';
+import { deriveProgressActivity, formatProgressBanner } from '../commands/interactive/progress-banner.js';
 import { palette } from '../palette.js';
 import { getTerminalWidth } from '../terminal-size.js';
 import { isDebugEnabled } from '../../utils/debug.js';
@@ -123,8 +123,13 @@ export function registerOverlaySlots(
     key: 'progress-banner',
     render: () => {
       const bannerLines: string[] = [];
+      // Grounded activity: the model's in-flight thinking clause (current
+      // uncommitted phase only — peekPhase clears at each seal boundary, so
+      // a stale clause never outlives the phase that produced it). Falls
+      // back to the event's tool-derived summary inside formatProgressBanner.
+      const activity = deriveProgressActivity(ctx.thinkingLane.peekPhase());
       for (const progress of ctx.lastProgressByTask.values()) {
-        bannerLines.push(...formatProgressBanner(progress));
+        bannerLines.push(...formatProgressBanner(progress, undefined, activity));
       }
       return bannerLines.length > 0 ? bannerLines.join('\n') : '';
     },

--- a/src/cli/_lib/stream-renderer-orchestrator-emit.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator-emit.ts
@@ -130,6 +130,15 @@ export function finalizeOrchestrator(
   source: SourceState,
   ctx: OrchestratorCtx,
 ): void {
+  // Evict the live progress entry: the tool-use loop is over, so its banner
+  // must stop rendering. Without this the entry persists (the only other
+  // mutation site is the 'progress' case's clear()+set()) and — because the
+  // OverlayComposer redraws EVERY slot on ANY markDirty — the stale banner
+  // provably repaints on every post-loop prose chunk, presenting a frozen
+  // "current activity" as live. Cleared BEFORE the overlay-refreshing
+  // commits scheduled below so their flush() paints a banner-free frame.
+  ctx.lastProgressByTask.clear();
+
   if (!ctx.streamingMarkdown.current && source.contentBuffer.trim()) {
     // Non-TTY path: no streaming renderer active. Emit accumulated content
     // directly. This path is unchanged — no coordinator needed here.

--- a/src/cli/_lib/stream-renderer-orchestrator.test.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.test.ts
@@ -16,6 +16,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   handleOrchestratorEvent,
+  setComposedOverlay,
   type OrchestratorCtx,
 } from './stream-renderer-orchestrator.js';
 import { freshSourceState, type SourceState } from './stream-renderer-source.js';
@@ -992,6 +993,41 @@ describe('handleOrchestratorEvent — progress arm (duplicate banner regression)
     expect(bannerCount).toBe(1);
     expect(lastOverlay).toContain('Iteration 15: used memory_update');
     expect(lastOverlay).not.toContain('Iteration 6: used bash');
+  });
+
+  /**
+   * Stale-banner regression: the tool-use loop ends ('done' event →
+   * finalizeOrchestrator) but the renderer keeps painting overlay frames for
+   * the post-loop prose stream. Before the fix, nothing evicted the map at
+   * loop exit — the LAST progress entry survived and the OverlayComposer
+   * (which redraws every slot on any markDirty) kept repainting a frozen
+   * "current activity" banner as if live throughout final prose streaming.
+   *
+   * Expect: after 'done', lastProgressByTask is empty, so any subsequent
+   * overlay composition renders zero banner lines.
+   */
+  it("clears lastProgressByTask when the turn finalizes ('done' event)", () => {
+    const setOverlay = vi.fn<(overlay: string) => void>();
+    const compositor = {
+      setOverlay,
+      commitAbove: vi.fn(),
+      setSpinner: vi.fn(),
+    } as unknown as OrchestratorCtx['compositor'];
+
+    const ctx = makeCtx(new ToolLane(), { isTTY: true, compositor });
+    const source: SourceState = freshSourceState('__main__');
+    const fire = (e: OutputEvent) => handleOrchestratorEvent(e, source, ctx);
+
+    fire(progressEvent('task-live', 'round 4: bash git show'));
+    expect(ctx.lastProgressByTask.size).toBe(1);
+
+    fire({ type: 'done' } as OutputEvent);
+
+    expect(ctx.lastProgressByTask.size).toBe(0);
+    // A post-done overlay composition must not resurrect the banner.
+    setComposedOverlay(ctx);
+    const lastOverlay = setOverlay.mock.calls.at(-1)?.[0] ?? '';
+    expect(lastOverlay).not.toContain('round 4: bash git show');
   });
 });
 

--- a/src/cli/_lib/stream-renderer-orchestrator.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.ts
@@ -30,7 +30,7 @@ import {
 import { stripCommandTags, extractSkillTag } from '../slash/_lib/command-tags.js';
 import { styleForCategory, SUBAGENT_TOOLS, DAG_TOOLS } from '../tool-category.js';
 import { formatThinkingParagraph } from '../commands/interactive/thinking-paragraph.js';
-import { formatProgressBanner } from '../commands/interactive/progress-banner.js';
+import { deriveProgressActivity, formatProgressBanner } from '../commands/interactive/progress-banner.js';
 import { getTerminalWidth } from '../terminal-size.js';
 import {
   emitPanel,
@@ -407,8 +407,13 @@ export function setComposedOverlay(ctx: OrchestratorCtx): void {
   }
   if (ctx.toolLane.hasPending()) parts.push(ctx.toolLane.getOverlay());
   const bannerLines: string[] = [];
+  // Grounded activity: the model's in-flight thinking clause (current
+  // uncommitted phase only — peekPhase clears at each seal boundary, so a
+  // stale clause never outlives the phase that produced it). Falls back to
+  // the event's own tool-derived summary inside formatProgressBanner.
+  const activity = deriveProgressActivity(ctx.thinkingLane.peekPhase());
   for (const progress of ctx.lastProgressByTask.values()) {
-    bannerLines.push(...formatProgressBanner(progress));
+    bannerLines.push(...formatProgressBanner(progress, undefined, activity));
   }
   if (bannerLines.length > 0) parts.push(bannerLines.join('\n'));
   ctx.compositor.setOverlay(parts.join('\n'));

--- a/src/cli/_lib/stream-renderer.test.ts
+++ b/src/cli/_lib/stream-renderer.test.ts
@@ -1280,6 +1280,7 @@ describe('finalizeOrchestrator — thinking summary routing', () => {
       thinkingLane,
       thinkingMode: 'summary' as const,
       streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
     };
     const source = freshSourceState(undefined);
     // Per-phase model: phases commit inline DURING the turn; finalize seals a
@@ -1311,6 +1312,7 @@ describe('finalizeOrchestrator — thinking summary routing', () => {
       thinkingLane,
       thinkingMode: 'summary' as const,
       streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
     };
     const source = freshSourceState(undefined);
 
@@ -1340,6 +1342,7 @@ describe('finalizeOrchestrator — thinking summary routing', () => {
       thinkingLane,
       thinkingMode: 'summary' as const,
       streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
     };
     const source = freshSourceState(undefined);
     // Trailing phase in flight → finalize seals it; compositor is null so the
@@ -1395,6 +1398,7 @@ describe('finalizeOrchestrator — thinking summary routing', () => {
       thinkingLane,
       thinkingMode: 'summary' as const,
       streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       coordinator: coordinator as any,
     };
@@ -1469,6 +1473,7 @@ describe('finalizeOrchestrator — thinking summary routing', () => {
       thinkingLane,
       thinkingMode: 'summary' as const,
       streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
       coordinator,
     };
     const source = freshSourceState(undefined);

--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -708,6 +708,12 @@ export class StreamRenderer {
       this.resizeUnsub = null;
     }
 
+    // Defensive eviction of any live progress entry. finalizeOrchestrator
+    // already clears this on the 'done' path; this covers turns that reach
+    // dispose without a 'done' event (error aborts, interrupts) so the
+    // overlay flushes below never repaint a stale progress banner.
+    this.lastProgressByTask.clear();
+
     // CommitCoordinator.flushAll() is the single async owner at turn end.
     // It drains all scheduled commit batches in fixed anchor order:
     //   1. before-content (orchestrator tool-lane entries that precede prose)

--- a/src/cli/_lib/subagent-block-gap.repro.test.ts
+++ b/src/cli/_lib/subagent-block-gap.repro.test.ts
@@ -280,6 +280,7 @@ async function runMintScenario(opts: {
     thinkingMode: 'off',
     streamingMarkdown: { current: null },
     coordinator,
+    lastProgressByTask: new Map(),
   };
   function fireOrchestratorMessageStop(): void {
     finalizeOrchestrator(orchestratorSource, orchestratorCtx);

--- a/src/cli/commands/interactive/progress-banner.test.ts
+++ b/src/cli/commands/interactive/progress-banner.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect } from 'vitest';
 import chalk from 'chalk';
 import { displayWidth, stripAnsi } from '../../display.js';
 import {
+  deriveProgressActivity,
   formatProgressBanner,
   formatProgressSummary,
   formatSubagentCompletion,
@@ -106,6 +107,99 @@ describe('progress-banner — terminal width clamping', () => {
       const lines = formatProgressBanner(mkEvent({ description: LONG }), Infinity);
       // With Infinity, the full description should be present (no truncation).
       expect(stripAnsi(lines[0]!)).toContain(LONG);
+    });
+  });
+
+  describe('formatProgressBanner — sanitization (LLM-sourced fields)', () => {
+    it('strips ANSI escapes injected via description', () => {
+      const lines = formatProgressBanner(
+        mkEvent({ description: 'evil\x1b[2Jtask' }),
+        Infinity,
+      );
+      // stripAnsi in the assertion would mask the bug — assert on the RAW
+      // string: the injected CSI must not survive into the rendered output.
+      expect(lines[0]!).not.toContain('\x1b[2J');
+      // sanitizeLabel strips the complete CSI sequence (no residual space).
+      expect(stripAnsi(lines[0]!)).toContain('eviltask');
+    });
+
+    it('strips control bytes injected via summary', () => {
+      const lines = formatProgressBanner(
+        mkEvent({ description: 'task', summary: 'sum\x07mary\x0d' }),
+        Infinity,
+      );
+      expect(lines[1]!).not.toMatch(/[\x00-\x08\x0b-\x1f\x7f-\x9f]/);
+      expect(stripAnsi(lines[1]!)).toContain('sum mary');
+    });
+
+    it('collapses newlines in the activity clause to a single line', () => {
+      const lines = formatProgressBanner(
+        mkEvent({ description: 'task' }),
+        Infinity,
+        'line one\nline two',
+      );
+      expect(lines).toHaveLength(2);
+      expect(lines[1]!).not.toContain('\n');
+      expect(stripAnsi(lines[1]!)).toContain('line one line two');
+    });
+  });
+
+  describe('formatProgressBanner — activity precedence', () => {
+    it('prefers activity over summary on the detail line', () => {
+      const lines = formatProgressBanner(
+        mkEvent({ description: 'task', summary: 'round 3: bash ls' }),
+        Infinity,
+        'Now checking the config loader',
+      );
+      expect(lines).toHaveLength(2);
+      expect(stripAnsi(lines[1]!)).toContain('Now checking the config loader');
+      expect(stripAnsi(lines[1]!)).not.toContain('round 3: bash ls');
+    });
+
+    it('falls back to summary when activity is undefined', () => {
+      const lines = formatProgressBanner(
+        mkEvent({ description: 'task', summary: 'round 3: bash ls' }),
+        Infinity,
+      );
+      expect(lines).toHaveLength(2);
+      expect(stripAnsi(lines[1]!)).toContain('round 3: bash ls');
+    });
+
+    it('falls back to summary when activity is whitespace-only', () => {
+      const lines = formatProgressBanner(
+        mkEvent({ description: 'task', summary: 'round 3: bash ls' }),
+        Infinity,
+        '   ',
+      );
+      expect(stripAnsi(lines[1]!)).toContain('round 3: bash ls');
+    });
+
+    it('renders single-line description form when neither activity nor summary exists', () => {
+      const lines = formatProgressBanner(mkEvent({ description: 'task' }), Infinity);
+      expect(lines).toHaveLength(1);
+    });
+  });
+
+  describe('deriveProgressActivity', () => {
+    it('returns undefined for an empty buffer', () => {
+      expect(deriveProgressActivity('', 80)).toBeUndefined();
+    });
+
+    it('returns undefined for a whitespace-only buffer', () => {
+      expect(deriveProgressActivity('   \n  ', 80)).toBeUndefined();
+    });
+
+    it('extracts the latest in-flight clause after a sentence boundary', () => {
+      const buffer = 'First I read the file. Now checking the dispatcher wiring';
+      expect(deriveProgressActivity(buffer, 120)).toBe('Now checking the dispatcher wiring');
+    });
+
+    it('truncates overlong clauses with an ellipsis', () => {
+      const clause = 'B'.repeat(500);
+      const out = deriveProgressActivity(clause, 60);
+      expect(out).toBeDefined();
+      expect(out!.length).toBeLessThanOrEqual(60 - 10);
+      expect(out).toMatch(/…$/);
     });
   });
 

--- a/src/cli/commands/interactive/progress-banner.ts
+++ b/src/cli/commands/interactive/progress-banner.ts
@@ -129,7 +129,9 @@ export function formatProgressSummary(event: ProgressEvent, columns?: number): s
  */
 export function formatSubagentCompletion(info: SubagentCompleteInfo, columns?: number): string {
   const icon = info.status === 'succeeded' ? '✓' : info.status === 'failed' ? '✗' : '⊘';
-  const label = info.agentType ?? info.subagentId;
+  // agentType is model-influenceable (dispatch args) — same sanitize rule as
+  // every other LLM-sourced label in this module.
+  const label = sanitizeLabel(info.agentType ?? info.subagentId);
   const parts = [icon, label];
   if (info.durationMs !== undefined) parts.push(`· ${formatDuration(info.durationMs)}`);
   return clampToTerminal(palette.dim(`  ${parts.join(' ')}`), columns);

--- a/src/cli/commands/interactive/progress-banner.ts
+++ b/src/cli/commands/interactive/progress-banner.ts
@@ -1,9 +1,12 @@
 import type { SubagentCompleteInfo } from '../../../agent/default-hook-registry.js';
 import type { ProgressEvent } from '../../../agent/types.js';
+import { extractLatestThinkingClause } from '../../_lib/stream-renderer-subagent-helpers.js';
 import { truncateDisplayWidth } from '../../display.js';
 import { formatDuration, formatTokens } from '../../format-utils.js';
 import { palette } from '../../palette.js';
+import { getTerminalWidth } from '../../terminal-size.js';
 import { styleForToolName } from '../../tool-category.js';
+import { sanitizeLabel } from './tool-lane-format-sanitize.js';
 
 /**
  * Clamp a fully-styled ANSI string to the current terminal width (or the
@@ -20,14 +23,48 @@ function clampToTerminal(line: string, columns?: number): string {
 }
 
 /**
+ * Derive the grounded "current activity" clause for the progress banner from
+ * the live thinking buffer — the in-flight thought the model is writing right
+ * now (see {@link extractLatestThinkingClause} for the boundary heuristics).
+ *
+ * Callers pass `ThinkingLane.peekPhase()` (the CURRENT uncommitted phase, not
+ * the cumulative buffer) so the activity clears once a phase is sealed at a
+ * tool/prose boundary instead of re-showing reasoning already collapsed into
+ * an inline "◆ thought for Xs" line. Returns `undefined` when the buffer holds
+ * no usable clause, so the banner falls back to the event's own `summary`.
+ *
+ * The clause is NOT sanitized here — {@link formatProgressBanner} owns the
+ * `sanitizeLabel` pass on every LLM-sourced field at render time, mirroring
+ * the tool-lane convention (extract raw → sanitize at the render site).
+ */
+export function deriveProgressActivity(
+  thinkingBuffer: string,
+  columns?: number,
+): string | undefined {
+  if (!thinkingBuffer) return undefined;
+  const cols = columns ?? getTerminalWidth();
+  const clause = extractLatestThinkingClause(thinkingBuffer, Math.max(20, cols - 10));
+  return clause || undefined;
+}
+
+/**
  * Render a progress event into one or two CLI lines.
  *
  * Line 0 is the task's stable description (invariant across ticks for a
- * given taskId). When a per-tick `summary` is present, a second indented
- * line carries the summary and the changing stats — keeping the per-tick
- * data on its own row so the description can be deduped on commit without
- * losing tool/token/duration progress. When no summary is available, stats
- * stay on the description line as a fallback.
+ * given taskId). The second indented line carries the grounded per-tick
+ * signal plus the changing stats: `activity` (the model's in-flight thinking
+ * clause, when one is live) wins over the event's own `summary` (the
+ * tool-derived headline) — the thought is the fresher intent signal, and the
+ * `via {tool}` stat segment already names the tool. Keeping the per-tick data
+ * on its own row lets the description be deduped on commit without losing
+ * tool/token/duration progress. When neither is available, stats stay on the
+ * description line as a fallback.
+ *
+ * Every LLM-sourced field (`description`, `summary`, `activity`) passes
+ * through {@link sanitizeLabel} before composition — these strings originate
+ * from model output (tool names/args, thinking text) and must not carry
+ * ANSI/control bytes into the overlay (same injection surface the tool-lane
+ * sanitizes at its render sites).
  *
  * The whole banner is rendered dim. The `via {glyph} {ToolName}` segment
  * is colored by tool category so the kind of work currently happening
@@ -38,13 +75,17 @@ function clampToTerminal(line: string, columns?: number): string {
  * provided) so long descriptions and summaries never wrap onto a second row
  * and corrupt multi-line REPL layout.
  */
-export function formatProgressBanner(event: ProgressEvent, columns?: number): string[] {
+export function formatProgressBanner(
+  event: ProgressEvent,
+  columns?: number,
+  activity?: string,
+): string[] {
   const { description, summary, lastToolName, totalTokens, toolUses, durationMs } = event;
   const stats: string[] = [];
 
   if (lastToolName) {
     const { color, glyph } = styleForToolName(lastToolName);
-    stats.push(`via ${color(`${glyph} ${lastToolName}`)}`);
+    stats.push(`via ${color(`${glyph} ${sanitizeLabel(lastToolName)}`)}`);
   }
   if (toolUses) stats.push(`${toolUses} tool${toolUses === 1 ? '' : 's'}`);
   if (totalTokens) stats.push(`${formatTokens(totalTokens)} tok`);
@@ -53,13 +94,17 @@ export function formatProgressBanner(event: ProgressEvent, columns?: number): st
 
   const statsStr = stats.length > 0 ? ` (${stats.join(' · ')})` : '';
 
-  if (summary) {
+  const cleanDescription = sanitizeLabel(description);
+  const detailRaw = activity?.trim() ? activity : summary;
+  const detail = detailRaw ? sanitizeLabel(detailRaw) : '';
+
+  if (detail) {
     return [
-      clampToTerminal(palette.dim(`  ◦ ${description}`), columns),
-      clampToTerminal(palette.dim(`    ${summary}${statsStr}`), columns),
+      clampToTerminal(palette.dim(`  ◦ ${cleanDescription}`), columns),
+      clampToTerminal(palette.dim(`    ${detail}${statsStr}`), columns),
     ];
   }
-  return [clampToTerminal(palette.dim(`  ◦ ${description}${statsStr}`), columns)];
+  return [clampToTerminal(palette.dim(`  ◦ ${cleanDescription}${statsStr}`), columns)];
 }
 
 /**
@@ -74,7 +119,7 @@ export function formatProgressSummary(event: ProgressEvent, columns?: number): s
   if (totalTokens) stats.push(`${formatTokens(totalTokens)} tok`);
   if (durationMs) stats.push(formatDuration(durationMs));
   const statsStr = stats.length > 0 ? ` (${stats.join(' · ')})` : '';
-  return clampToTerminal(palette.dim(`  ◦ ${description}${statsStr}`), columns);
+  return clampToTerminal(palette.dim(`  ◦ ${sanitizeLabel(description)}${statsStr}`), columns);
 }
 
 /**

--- a/src/cli/verdict-card-overflow.test.ts
+++ b/src/cli/verdict-card-overflow.test.ts
@@ -88,8 +88,8 @@ const STREAMING_FRAME = ['  \u25e6 generating\u2026', '~/x \u00b7 opus_1m \u00b7
 // The idle prompt the REPL returns to AFTER the card commits: loop-stage bar +
 // ledger + prompt + status.
 const IDLE_PROMPT = [
-  '  \u25e6 Tool-use loop',
-  '    Iteration 3: used read_file \u00b7 3 tools \u00b7 4.4k tok',
+  '  \u25e6 Working',
+  '    round 3: read_file /tmp/x.ts \u00b7 3 tools \u00b7 4.4k tok',
   'afk > observe  model  choose  act  update',
   'ledger  done   (1 turn)',
   '~/x \u00b7 opus_1m \u00b7 3%',

--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -112,6 +112,43 @@ describe('streamResponse', () => {
     expect(joined).toContain('12 matches in 4 files');
   });
 
+  it('sanitizes control/ANSI sequences in model-controlled progress fields before sending to Telegram', async () => {
+    // Regression: progress.description/summary/lastToolName are populated
+    // from model-controlled tool input (summarizeToolInput) and interpolated
+    // raw into the Telegram message. markdownToTelegramHtml only strips
+    // \x02/\x03 sentinels + HTML-escapes & < > — it does not strip ANSI/C1
+    // control bytes. Verify the streaming handler scrubs them itself.
+    const { ctx, replies, edits } = makeCtx();
+    const session = makeSession(async function* () {
+      yield* yieldEvents(
+        {
+          type: 'progress',
+          progress: {
+            taskId: 't1',
+            description: 'grep \x1b[2Jsrc/\x9b malicious',
+            summary: 'grep \x1b[2Jsrc/\x9b malicious',
+            lastToolName: 'Grep\x1b[2J\x9b',
+            totalTokens: 100,
+            toolUses: 2,
+            durationMs: 300,
+          },
+        },
+        { type: 'done', metadata: undefined },
+      );
+    });
+
+    await streamResponse(ctx, session, 'go');
+    const joined = [...replies, ...edits].join('\n');
+
+    // Visible text survives sanitization.
+    expect(joined).toContain('grep');
+    expect(joined).toContain('src/');
+
+    // Raw escape/control bytes must not reach the Telegram message.
+    expect(joined).not.toContain('\x1b');
+    expect(joined).not.toContain('\x9b');
+  });
+
   it('appends prompt_suggestion as a final 💡 line', async () => {
     const { ctx, replies, edits } = makeCtx();
     const session = makeSession(async function* () {

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -13,6 +13,7 @@ import type { IAgentSession, OutputEvent, SubagentProgressMeta, ResponseMetadata
 import { runWithSink } from '../agent/_lib/skill-sink-channel.js';
 import { env } from '../config/env.js';
 import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
+import { sanitizeLabel } from '../cli/commands/interactive/tool-lane-format-sanitize.js';
 
 /** Minimum interval (ms) between Telegram edit requests to avoid rate limits */
 const EDIT_THROTTLE_MS = 300;
@@ -429,11 +430,18 @@ export async function streamResponse(
           // snapshot, so a later stream_retry rolls back only the new round.
           inContentRun = false;
           const { description, summary, lastToolName } = event.progress;
-          const line = lastToolName
-            ? `\n◦ ${description} (${lastToolName})`
-            : `\n◦ ${description}`;
+          // These fields are model-controlled (path/command/URL text from
+          // summarizeToolInput) and markdownToTelegramHtml does not strip
+          // ANSI/C1/control bytes, so scrub them here to match the CLI
+          // banner's field-scoped hardening (tool-lane-format-sanitize.ts).
+          const safeDescription = sanitizeLabel(description);
+          const safeToolName = lastToolName ? sanitizeLabel(lastToolName) : lastToolName;
+          const safeSummary = summary ? sanitizeLabel(summary) : summary;
+          const line = safeToolName
+            ? `\n◦ ${safeDescription} (${safeToolName})`
+            : `\n◦ ${safeDescription}`;
           accumulated += line;
-          if (summary) accumulated += `\n  ${summary}`;
+          if (safeSummary) accumulated += `\n  ${safeSummary}`;
           await sendOrEdit(livePreview());
         }
         // Lane D — post-turn prompt suggestion appended to the message.


### PR DESCRIPTION
## Summary
- **Grounded "now line"**: the progress banner's detail row now shows the model's in-flight thinking clause (via `extractLatestThinkingClause` over `ThinkingLane.peekPhase()` — a sealed phase can never leak a stale clause), falling back to the tool-derived summary. Wired at both render sites (orchestrator fallback compose + lifecycle overlay slot).
- **Semantic progress at source**: both providers now emit `round N: <tool> <headline-arg>` (via the shared `summarizeToolInput`) and a stable `Working` description, replacing the information-free `Tool-use loop` / `Iteration N: used bash`.
- **Stale-banner eviction**: `lastProgressByTask` is cleared in `finalizeOrchestrator` (+ defensively in `dispose`). Previously nothing evicted it at loop exit, and since `OverlayComposer.flush()` redraws every slot on any `markDirty`, the frozen banner provably repainted on every post-loop prose chunk as if live.
- **Sanitization hardening**: every LLM-sourced banner field (`description`, `summary`, activity clause, tool name, subagent completion label) now passes `sanitizeLabel` — the banner previously interpolated raw model text with only width-clamping (ANSI/control-injection gap, pre-existing).

Plan was pressure-tested before implementation (devils-advocate critique wave + independent shadow verification of the load-bearing claims). Deliberately **not** done: rewriting the spinner-verb system (unsanitized path; codebase deliberately avoids raw thinking in scrollback per stream-renderer-subagent.ts:269) and consecutive-tool collapse (grouping already exists twice — `GROUP_THRESHOLD_*` live overlay + `formatGroupedToolResults` scrollback; the remaining gap is the per-flush-batch window, tracked as follow-up).

## Test results
- `pnpm lint` (tsc strict): clean
- `pnpm test` (full suite): 566 files, 10,470 passed | 14 skipped, 0 failed
- New coverage: sanitization + activity-precedence + `deriveProgressActivity` unit tests (progress-banner.test.ts), finalize-clears-progress regression test (stream-renderer-orchestrator.test.ts)

## Verification
Adversarial verifier re-derived the claims from the diff alone:
- Activity derivation uses `peekPhase()` consistently at both render sites — CONFIRM
- `clear()` placements + the single production `OrchestratorCtx` construction site (`stream-renderer.ts:507`) supplies the field — CONFIRM
- Sanitization claim — REFINE: `formatSubagentCompletion`'s `agentType` label was still raw; fixed in ceb3d47
- Consumer sweep: Telegram's progress lane renders `description`/`summary` as plain text (no terminal escape risk); string change there is cosmetic only

## Out of scope
- Cross-flush tool grouping window (confirmed real gap, tool-lane-render-agent.ts:33-37)
- First-class task-status model (`goal` field on `SubagentProgressMeta`; daemon/Telegram currently discard or reinterpret the stream)
- Triple "thought for Xs" line from the original report — diagnosis inconclusive (background agent hit env failure; `sealThinkingPhase` already guards same-phase re-commit, so the observed triple may be three legitimate phases). Needs a live repro.