### PR TITLE
fix(agent): close forkSubagent cross-provider credential leak

### DIFF
--- a/src/agent/subagent.test.ts
+++ b/src/agent/subagent.test.ts
@@ -162,6 +162,96 @@ describe('SubagentManager', () => {
     );
   });
 
+  // Cross-provider credential anti-leak (composition boundary).
+  //
+  // The agent-tool executor deliberately clears `apiKey`/`baseUrl` for
+  // OpenAI-routed children (subagent-executor.ts), but the manager's
+  // fallback used to be provider-blind (`config.apiKey || parentApiKey`) and
+  // reintroduced the parent's Anthropic credential — which the OpenAI auth
+  // resolver then used as its Tier-1 config key (openai-compatible/auth.ts),
+  // shipping `sk-ant-…` as a Bearer to an OpenAI-shaped endpoint. These
+  // tests exercise the REAL manager (only AgentSession is mocked) so the
+  // fallback itself — not a mocked boundary above it — is under test.
+  describe('cross-provider credential anti-leak (forkSubagent fallback)', () => {
+    it('never hands an Anthropic parent apiKey to an OpenAI-routed child', async () => {
+      shared.lastConfig = null;
+      const mgr = new SubagentManager({ apiKey: 'sk-ant-oat01-PARENT' });
+      await mgr.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'gpt-5.5' },
+        idPrefix: 'leak-check',
+        agentType: 'leak-check',
+      });
+      const cfg = shared.lastConfig as Record<string, unknown>;
+      expect(cfg['apiKey']).toBeUndefined();
+      expect(cfg['apiKey']).not.toBe('sk-ant-oat01-PARENT');
+    });
+
+    it('never hands the parent Anthropic baseUrl to an OpenAI-routed child', async () => {
+      shared.lastConfig = null;
+      const mgr = new SubagentManager({
+        apiKey: 'sk-ant-oat01-PARENT',
+        baseUrl: 'http://127.0.0.1:8080',
+      });
+      await mgr.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'gpt-5.5' },
+        idPrefix: 'leak-check',
+        agentType: 'leak-check',
+      });
+      const cfg = shared.lastConfig as Record<string, unknown>;
+      expect(cfg['baseUrl']).toBeUndefined();
+    });
+
+    it('preserves an explicit child apiKey for an OpenAI-routed child (caller wins)', async () => {
+      shared.lastConfig = null;
+      const mgr = new SubagentManager({ apiKey: 'sk-ant-oat01-PARENT' });
+      await mgr.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'gpt-5.5', apiKey: 'sk-proj-EXPLICIT' },
+        idPrefix: 'leak-check',
+        agentType: 'leak-check',
+      });
+      expect(shared.lastConfig).toEqual(
+        expect.objectContaining({ apiKey: 'sk-proj-EXPLICIT' }),
+      );
+    });
+
+    it('lets an OpenAI-shaped parent key flow to an OpenAI-routed child (same-provider inheritance)', async () => {
+      shared.lastConfig = null;
+      const mgr = new SubagentManager({ apiKey: 'sk-proj-PARENT' });
+      await mgr.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'gpt-5.5' },
+        idPrefix: 'inherit-check',
+        agentType: 'inherit-check',
+      });
+      expect(shared.lastConfig).toEqual(
+        expect.objectContaining({ apiKey: 'sk-proj-PARENT' }),
+      );
+    });
+
+    it('still inherits the Anthropic parent apiKey + baseUrl for an Anthropic-routed child', async () => {
+      shared.lastConfig = null;
+      const mgr = new SubagentManager({
+        apiKey: 'sk-ant-oat01-PARENT',
+        baseUrl: 'http://127.0.0.1:8080',
+      });
+      await mgr.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'sonnet' },
+        idPrefix: 'inherit-check',
+        agentType: 'inherit-check',
+      });
+      expect(shared.lastConfig).toEqual(
+        expect.objectContaining({
+          apiKey: 'sk-ant-oat01-PARENT',
+          baseUrl: 'http://127.0.0.1:8080',
+        }),
+      );
+    });
+  });
+
   it('lets explicit child baseUrl override the manager default', async () => {
     shared.lastConfig = null;
     const mgr = new SubagentManager({ baseUrl: 'http://127.0.0.1:8080' });

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -35,6 +35,8 @@ import type { Surface } from './awareness/types.js';
 import { appendRoutingDecision } from './routing-telemetry.js';
 import { getCurrentSink } from './_lib/skill-sink-channel.js';
 import { buildPhaseRestrictedProvider, type PhaseRole } from './tools/nesting.js';
+import { applyManagerApiKeyFallback } from './tools/child-credential.js';
+import { providerForModel } from './providers/index.js';
 import {
   SubagentHandleImpl,
   type SubagentHandle,
@@ -417,8 +419,30 @@ export class SubagentManager {
       resume,
       forkSession: resume ? true : options.config.forkSession,
       abortSignal: childController.signal,
-      apiKey: options.config.apiKey || this.parentApiKey,
-      baseUrl: options.config.baseUrl ?? this.parentBaseUrl,
+      // Invariant (cross-provider credential anti-leak): the parent-credential
+      // fallback below must never hand an Anthropic `sk-ant-…` credential to an
+      // OpenAI-routed child. Upstream executors (subagent-executor.ts,
+      // skill-executor.ts, compose-executor.ts) deliberately clear `apiKey` /
+      // `baseUrl` for OpenAI children; a provider-blind `|| this.parentApiKey`
+      // here silently undid that decision — the OpenAI auth resolver treats any
+      // explicit config key as Tier-1 (openai-compatible/auth.ts), so the
+      // Anthropic token went out as a Bearer to an OpenAI-shaped endpoint.
+      // `applyManagerApiKeyFallback` preserves explicit caller keys and
+      // legitimate same-provider inheritance; only the leaking combination
+      // (OpenAI child + Anthropic-shaped parent key) resolves to undefined.
+      apiKey: applyManagerApiKeyFallback({
+        childModel: options.config.model,
+        configApiKey: options.config.apiKey,
+        parentApiKey: this.parentApiKey,
+      }),
+      // Same guard for the Anthropic-semantic `baseUrl`: an OpenAI-routed
+      // child resolves its endpoint from `openaiBaseUrl` / env, never from the
+      // parent's Anthropic base URL. Explicit caller values still win.
+      baseUrl:
+        options.config.baseUrl ??
+        (providerForModel(options.config.model) === 'openai-compatible'
+          ? undefined
+          : this.parentBaseUrl),
       // External constraint: a forked sub-agent has no human relationship of its
       // own — it returns findings (including Blocked/Asking) to its PARENT, which
       // owns the operator surface. Mark every fork non-interactive by default so

--- a/src/agent/tools/child-credential.test.ts
+++ b/src/agent/tools/child-credential.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { applyParentCredentialFallback, isAnthropicCredential } from './child-credential.js';
+import {
+  applyManagerApiKeyFallback,
+  applyParentCredentialFallback,
+  isAnthropicCredential,
+} from './child-credential.js';
 
 // Anthropic-routed child model; OpenAI-routed child model. If providerForModel's
 // routing ever changes for these, the gating assertions below break loudly.
@@ -98,6 +102,92 @@ describe('applyParentCredentialFallback', () => {
       applyParentCredentialFallback({
         childModel: ANTHROPIC_CHILD,
         resolved: undefined,
+        parentApiKey: undefined,
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('applyManagerApiKeyFallback', () => {
+  it('preserves an explicit non-empty config key (caller wins), regardless of provider', () => {
+    expect(
+      applyManagerApiKeyFallback({
+        childModel: OPENAI_CHILD,
+        configApiKey: OPENAI_KEY,
+        parentApiKey: ANTHROPIC_OAUTH,
+      }),
+    ).toBe(OPENAI_KEY);
+    expect(
+      applyManagerApiKeyFallback({
+        childModel: ANTHROPIC_CHILD,
+        configApiKey: ANTHROPIC_API,
+        parentApiKey: ANTHROPIC_OAUTH,
+      }),
+    ).toBe(ANTHROPIC_API);
+  });
+
+  it('never leaks an Anthropic-shaped parent credential to an OpenAI-routed child (the forkSubagent leak)', () => {
+    // The exact composition-boundary bug: the executor cleared apiKey
+    // (configApiKey === undefined) and the manager's fallback used to
+    // reintroduce the Anthropic parent key. Must resolve to undefined.
+    expect(
+      applyManagerApiKeyFallback({
+        childModel: OPENAI_CHILD,
+        configApiKey: undefined,
+        parentApiKey: ANTHROPIC_OAUTH,
+      }),
+    ).toBeUndefined();
+    expect(
+      applyManagerApiKeyFallback({
+        childModel: OPENAI_CHILD,
+        configApiKey: undefined,
+        parentApiKey: ANTHROPIC_API,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('treats an empty-string config key as absent (matching the legacy || semantics)', () => {
+    expect(
+      applyManagerApiKeyFallback({
+        childModel: OPENAI_CHILD,
+        configApiKey: '',
+        parentApiKey: ANTHROPIC_OAUTH,
+      }),
+    ).toBeUndefined();
+    expect(
+      applyManagerApiKeyFallback({
+        childModel: ANTHROPIC_CHILD,
+        configApiKey: '',
+        parentApiKey: ANTHROPIC_OAUTH,
+      }),
+    ).toBe(ANTHROPIC_OAUTH);
+  });
+
+  it('lets an OpenAI-shaped parent credential flow to an OpenAI-routed child (same-provider inheritance)', () => {
+    expect(
+      applyManagerApiKeyFallback({
+        childModel: OPENAI_CHILD,
+        configApiKey: undefined,
+        parentApiKey: OPENAI_KEY,
+      }),
+    ).toBe(OPENAI_KEY);
+  });
+
+  it('lets the parent credential flow to an Anthropic-routed child (pre-existing inheritance path)', () => {
+    expect(
+      applyManagerApiKeyFallback({
+        childModel: ANTHROPIC_CHILD,
+        configApiKey: undefined,
+        parentApiKey: ANTHROPIC_OAUTH,
+      }),
+    ).toBe(ANTHROPIC_OAUTH);
+  });
+
+  it('returns undefined when neither config nor parent credential exists', () => {
+    expect(
+      applyManagerApiKeyFallback({
+        childModel: ANTHROPIC_CHILD,
+        configApiKey: undefined,
         parentApiKey: undefined,
       }),
     ).toBeUndefined();

--- a/src/agent/tools/child-credential.ts
+++ b/src/agent/tools/child-credential.ts
@@ -48,3 +48,43 @@ export function applyParentCredentialFallback(args: {
   if (providerForModel(childModel) === 'openai-compatible') return resolved;
   return isAnthropicCredential(parentApiKey) ? parentApiKey : resolved;
 }
+
+/**
+ * Contract: resolve the effective `apiKey` for a child forked by
+ * `SubagentManager.forkSubagent`, guarding the manager-level
+ * parent-credential fallback against the cross-provider leak.
+ *
+ * The manager's historical fallback was `config.apiKey || parentApiKey` —
+ * provider-blind. That reintroduced the parent's credential even when an
+ * upstream executor (subagent-executor.ts, skill-executor.ts,
+ * compose-executor.ts) had *deliberately* cleared `apiKey` for an
+ * OpenAI-routed child: an Anthropic `sk-ant-…` parent credential reached
+ * the OpenAI-compatible provider, whose auth resolver treats any explicit
+ * config key as Tier-1 (see openai-compatible/auth.ts) — shipping the
+ * Anthropic token as a Bearer to an OpenAI-shaped endpoint (401 at best).
+ *
+ * Rules (in order):
+ *   - explicit non-empty `configApiKey` → returned unchanged (caller wins).
+ *   - OpenAI-routed child + Anthropic-shaped parent credential → `undefined`
+ *     (never leak `sk-ant-…` across the provider boundary; the OpenAI auth
+ *     resolver walks its own env / codex precedence cleanly).
+ *   - otherwise → `parentApiKey` (preserves legitimate inheritance: an
+ *     OpenAI-shaped key from an OpenAI-routed parent flows to OpenAI
+ *     children; Anthropic children keep inheriting the parent credential,
+ *     including non-`sk-ant` keys used by local Anthropic-shim setups).
+ */
+export function applyManagerApiKeyFallback(args: {
+  childModel: string | undefined;
+  configApiKey: string | undefined;
+  parentApiKey: string | undefined;
+}): string | undefined {
+  const { childModel, configApiKey, parentApiKey } = args;
+  if (configApiKey !== undefined && configApiKey.length > 0) return configApiKey;
+  if (
+    providerForModel(childModel) === 'openai-compatible' &&
+    isAnthropicCredential(parentApiKey)
+  ) {
+    return undefined;
+  }
+  return parentApiKey;
+}


### PR DESCRIPTION
## Problem

`SubagentManager.forkSubagent`'s parent-credential fallback was provider-blind (`config.apiKey || this.parentApiKey`). The agent-tool executor deliberately clears `apiKey` for OpenAI-routed children (`subagent-executor.ts:580`), but the manager's fallback reintroduced the parent's Anthropic `sk-ant-*` credential downstream of that guard. Since `resolveOpenAIAuth()` treats any explicit config key as Tier-1 (`openai-compatible/auth.ts:117-120`), the Anthropic token shipped as a Bearer to an OpenAI-shaped endpoint → 401.

Root-caused via independent shadow verification (report: `.afk/diagnostics/subagent-auth-shadow-verify-2026-07-02.md`). The existing executor-boundary test mocked the manager, so the real `forkSubagent` fallback was never exercised — the leak lived in the composition boundary executor → manager → provider.

## Fix

- **New `applyManagerApiKeyFallback`** (`src/agent/tools/child-credential.ts`): explicit child key always wins; the leaking combination (OpenAI-routed child model + Anthropic-shaped parent key) resolves to `undefined` so the OpenAI auth resolver walks its own env/codex precedence; same-provider inheritance is preserved (OpenAI parent key → OpenAI child, Anthropic → Anthropic — including non-`sk-ant` keys used by local Anthropic-shim setups, which a blanket clear would break).
- **`baseUrl` gets the same provider gate**: an OpenAI-routed child no longer inherits the parent's Anthropic-semantic `baseUrl`; it resolves via `openaiBaseUrl`/env instead. Explicit caller values still win.

Shape-gated rather than blanket-clear by design — clearing unconditionally would regress legitimate inheritance paths (local shims, same-provider fan-outs).

## Tests

- 5 real-manager regression tests in `src/agent/subagent.test.ts` (only `AgentSession` is mocked): an Anthropic parent key/baseUrl never reaches a `gpt-5.5` child; explicit child key wins; OpenAI→OpenAI and Anthropic→Anthropic inheritance intact.
- 6 unit tests for `applyManagerApiKeyFallback` in `child-credential.test.ts`.
- **Mutation-verified**: reverting just the fallback fails exactly the two leak tests and nothing else.
- Full suite: 10,469 passed / 14 skipped, 0 failures. `pnpm lint` clean.