### PR TITLE
fix(agent): bound foreground safe-batch tool concurrency

### DIFF
--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -852,6 +852,108 @@ describe('SessionToolDispatcher', () => {
       expect(results[0]!.content).toBe('slow');
       expect(results[1]!.content).toBe('fast');
     });
+
+    describe('maxConcurrentSafeCalls (bounded concurrency)', () => {
+      // A safe handler that records concurrency: increments a live counter on
+      // entry, tracks the peak, decrements on exit. `peak` is the maximum
+      // number that were ever in flight simultaneously.
+      function makeConcurrencyProbe() {
+        const state = { inFlight: 0, peak: 0 };
+        const handler: ToolHandler = async () => {
+          state.inFlight += 1;
+          state.peak = Math.max(state.peak, state.inFlight);
+          await new Promise((r) => setTimeout(r, 20));
+          state.inFlight -= 1;
+          return { content: 'ok' };
+        };
+        return { state, handler };
+      }
+
+      it('caps simultaneous in-flight safe calls at the configured limit', async () => {
+        const { state, handler } = makeConcurrencyProbe();
+        const dispatcher = makeDispatcher({
+          handlers: new Map([['read_file', handler]]),
+          permissions: { allowedTools: ['read_file'] },
+          maxConcurrentSafeCalls: 2,
+        });
+
+        const calls = Array.from({ length: 6 }, (_, i) =>
+          makeBatchCall('read_file', `read-${i}`),
+        );
+        const results = await dispatcher.executeBatch(calls);
+
+        expect(results).toHaveLength(6);
+        expect(results.every((r) => r.content === 'ok')).toBe(true);
+        // Never more than 2 running at once, despite 6 safe calls in the batch.
+        expect(state.peak).toBe(2);
+      });
+
+      it('runs the whole batch concurrently when the cap exceeds batch width', async () => {
+        const { state, handler } = makeConcurrencyProbe();
+        const dispatcher = makeDispatcher({
+          handlers: new Map([['read_file', handler]]),
+          permissions: { allowedTools: ['read_file'] },
+          maxConcurrentSafeCalls: 10,
+        });
+
+        const calls = Array.from({ length: 4 }, (_, i) =>
+          makeBatchCall('read_file', `read-${i}`),
+        );
+        await dispatcher.executeBatch(calls);
+
+        // Cap (10) > batch width (4): all four run at once, like allSettled.
+        expect(state.peak).toBe(4);
+      });
+
+      it('preserves result order when draining a batch wider than the cap', async () => {
+        // Descending delays: without index-keyed write-back, a naive pool
+        // would return results in completion order (fastest first).
+        const mk = (ms: number, content: string): ToolHandler => async () => {
+          await new Promise((r) => setTimeout(r, ms));
+          return { content };
+        };
+        const dispatcher = makeDispatcher({
+          handlers: new Map([
+            ['read_file', mk(40, 'a')],
+            ['glob', mk(30, 'b')],
+            ['grep', mk(20, 'c')],
+            ['list_directory', mk(10, 'd')],
+          ]),
+          permissions: { allowedTools: ['read_file', 'glob', 'grep', 'list_directory'] },
+          maxConcurrentSafeCalls: 2,
+        });
+
+        const results = await dispatcher.executeBatch([
+          makeBatchCall('read_file'),
+          makeBatchCall('glob'),
+          makeBatchCall('grep'),
+          makeBatchCall('list_directory'),
+        ]);
+
+        expect(results.map((r) => r.content)).toEqual(['a', 'b', 'c', 'd']);
+      });
+
+      it('degrades to sequential (not deadlock) when the cap is below 1', async () => {
+        // A non-positive/non-finite cap falls back to the default in the
+        // constructor, so behaviour stays parallel — assert it does not hang
+        // and every call still resolves.
+        const { state, handler } = makeConcurrencyProbe();
+        const dispatcher = makeDispatcher({
+          handlers: new Map([['read_file', handler]]),
+          permissions: { allowedTools: ['read_file'] },
+          maxConcurrentSafeCalls: 0,
+        });
+
+        const calls = Array.from({ length: 3 }, (_, i) =>
+          makeBatchCall('read_file', `read-${i}`),
+        );
+        const results = await dispatcher.executeBatch(calls);
+
+        expect(results.map((r) => r.content)).toEqual(['ok', 'ok', 'ok']);
+        // Default cap (8) applies → all 3 run at once.
+        expect(state.peak).toBe(3);
+      });
+    });
   });
 
   describe('compose tool routing (L4)', () => {

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -122,6 +122,58 @@ function partitionIntoBatches(
   }, []);
 }
 
+/**
+ * Default ceiling on concurrency-safe tool calls run simultaneously within one
+ * batched round (see {@link SessionToolDispatcher.executeBatch}). Safe batches
+ * include agent/skill/compose subagent forks, not just cheap reads; unbounded,
+ * a wide fan-out (a compose layer, or a turn issuing many subagent calls) can
+ * exhaust memory or storm the provider rate limit. This is the engine-level
+ * safety ceiling — 8 sits above typical read-fan-out width so ordinary reads
+ * are never throttled, while bounding a runaway subagent fan-out (cf. the
+ * background-job ceiling of 10). Must stay >= 2 or parallel-timing tests
+ * regress; injectable via SessionToolDispatcherOptions.maxConcurrentSafeCalls.
+ */
+export const DEFAULT_MAX_CONCURRENT_SAFE_TOOL_CALLS = 8;
+
+/**
+ * Run `worker` over every `items` element with at most `limit` invocations in
+ * flight, returning results in `items` order with the same fulfilled/rejected
+ * shape as `Promise.allSettled`. Workers are started eagerly up to the cap, so
+ * when `limit >= items.length` this is behaviourally identical to
+ * `Promise.allSettled(items.map(worker))` — the parallel-timing tests rely on
+ * that. `limit` is floored at 1, so a non-positive cap degrades to sequential
+ * rather than deadlocking on an empty pool.
+ */
+async function settleWithConcurrencyLimit<T, I>(
+  items: readonly I[],
+  limit: number,
+  worker: (item: I) => Promise<T>,
+): Promise<PromiseSettledResult<T>[]> {
+  const results: PromiseSettledResult<T>[] = new Array(items.length);
+  const poolSize = Math.min(Math.max(1, Math.floor(limit)), items.length);
+  let cursor = 0;
+  const runners: Promise<void>[] = [];
+  for (let w = 0; w < poolSize; w++) {
+    runners.push(
+      (async () => {
+        // `cursor < length` test and `cursor++` are not separated by an await,
+        // so each index is claimed by exactly one runner (no double-dispatch,
+        // no skip) despite the shared cursor.
+        while (cursor < items.length) {
+          const i = cursor++;
+          try {
+            results[i] = { status: 'fulfilled', value: await worker(items[i]!) };
+          } catch (reason) {
+            results[i] = { status: 'rejected', reason };
+          }
+        }
+      })(),
+    );
+  }
+  await Promise.all(runners);
+  return results;
+}
+
 export interface SessionToolDispatcherOptions {
   handlers: Map<string, ToolHandler>;
   schemas: AnthropicToolDef[];
@@ -148,6 +200,14 @@ export interface SessionToolDispatcherOptions {
   skillExecutor?: SkillExecutor;
   composeExecutor?: ComposeExecutor;
   concurrencyClassifier?: ConcurrencyClassifier;
+  /**
+   * Ceiling on simultaneously in-flight concurrency-safe tool calls within one
+   * batched round. Defaults to {@link DEFAULT_MAX_CONCURRENT_SAFE_TOOL_CALLS}
+   * (8). A wide safe batch drains through a pool of at most this many at a time;
+   * results and their order are unaffected. Values < 1 (or non-finite) fall
+   * back to the default. Injected by tests to assert the cap.
+   */
+  maxConcurrentSafeCalls?: number;
   /** Session working directory forwarded to every handler invocation. */
   cwd?: string;
   /**
@@ -213,6 +273,8 @@ export class SessionToolDispatcher implements ToolDispatcher {
   private readonly skillExecutor: SkillExecutor | undefined;
   private readonly composeExecutor: ComposeExecutor | undefined;
   private readonly classifier: ConcurrencyClassifier;
+  /** Ceiling on simultaneously in-flight concurrency-safe calls per batch. */
+  private readonly maxConcurrentSafeCalls: number;
   // Invariant: `resolveBase` is the dispatcher's anchor for relative-path
   // resolution AND the value emitted as `ToolHandlerContext.resolveBase` /
   // `.cwd` on every dispatch. Mutated only via `setResolveBase()` so the
@@ -259,6 +321,12 @@ export class SessionToolDispatcher implements ToolDispatcher {
     this.skillExecutor = opts.skillExecutor;
     this.composeExecutor = opts.composeExecutor;
     this.classifier = opts.concurrencyClassifier ?? defaultConcurrencyClassifier;
+    this.maxConcurrentSafeCalls =
+      typeof opts.maxConcurrentSafeCalls === 'number' &&
+      Number.isFinite(opts.maxConcurrentSafeCalls) &&
+      opts.maxConcurrentSafeCalls >= 1
+        ? Math.floor(opts.maxConcurrentSafeCalls)
+        : DEFAULT_MAX_CONCURRENT_SAFE_TOOL_CALLS;
     this.resolveBase = opts.cwd;
     this._env = opts.env;
     this.sessionId = opts.sessionId;
@@ -884,8 +952,18 @@ export class SessionToolDispatcher implements ToolDispatcher {
       // when call[0] is stale, and falsely dispatching aborted calls when
       // call[0] is fresh. See the parallel-branch parity below.
       if (batch.isConcurrencySafe) {
-        const settled = await Promise.allSettled(
-          batch.indices.map(async (batchIdx) => {
+        // Bounded concurrency: at most `this.maxConcurrentSafeCalls` of these
+        // safe calls (which include agent/skill/compose subagent forks) run at
+        // once, so a wide fan-out cannot exhaust memory or storm the provider
+        // rate limit. Within the cap this is identical to Promise.allSettled;
+        // results stay keyed by originalIndex, so ordering is completion-order
+        // independent exactly as before. Abort is checked at DISPATCH time (in
+        // the worker), not at admission — a call cleared in phase 1 can abort
+        // while queued behind the cap.
+        const settled = await settleWithConcurrencyLimit(
+          batch.indices,
+          this.maxConcurrentSafeCalls,
+          async (batchIdx) => {
             const { call, originalIndex } = executableCalls[batchIdx]!;
             if (call.signal.aborted) {
               return {
@@ -895,7 +973,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
             }
             const result = await this.executeCore(call);
             return { result, originalIndex };
-          }),
+          },
         );
         for (const outcome of settled) {
           if (outcome.status === 'fulfilled') {
@@ -903,8 +981,9 @@ export class SessionToolDispatcher implements ToolDispatcher {
           } else {
             // Invariant: this branch is unreachable today. `executeCore` wraps
           // its entire body in try/catch and returns an isError ToolResult
-          // rather than propagating — so the Promise passed to allSettled
-          // always fulfills. The rejection path exists as a latent safety net
+          // rather than propagating — so the Promise passed to
+          // settleWithConcurrencyLimit always fulfills. The rejection path
+          // exists as a latent safety net
           // for future refactors that might let executeCore propagate. If that
           // happens, `firePostToolUseFailure` must be called here to preserve
           // the "exactly one of PostToolUse/PostToolUseFailure fires per call"
@@ -912,7 +991,8 @@ export class SessionToolDispatcher implements ToolDispatcher {
           const msg = outcome.reason instanceof Error
               ? outcome.reason.message
               : String(outcome.reason);
-            // Find the original index from the batch — allSettled preserves order
+            // Find the original index from the batch — the pool returns
+            // results in items (batch.indices) order, so indexOf maps back.
             const batchIdx = batch.indices[settled.indexOf(outcome)]!;
             results[executableCalls[batchIdx]!.originalIndex] = {
               content: `Tool execution error: ${msg}`,


### PR DESCRIPTION
## What

Add an engine-level ceiling on how many **concurrency-safe** tool calls `SessionToolDispatcher.executeBatch` runs simultaneously within one batched tool round. Default cap: **8**, constructor-injectable via `maxConcurrentSafeCalls`.

## Why

`executeBatch` partitions a turn's tool calls into contiguous runs and executes each concurrency-safe run through a single unbounded `Promise.allSettled`. Because `agent`, `skill`, and `compose` are all classified concurrency-safe (`schemas.ts`), a wide fan-out in one turn — a `compose` layer, or many `agent` calls issued together — spun up an **unbounded** number of in-flight `AgentSession` forks at once. That risks:

- **memory exhaustion** (N full child sessions materialized simultaneously), and
- **provider rate-limit (429) storms** — the exact failure class the `fanout-pace` skill currently mitigates at the *prompt* layer because the engine offered no ceiling.

Background jobs already cap themselves at `DEFAULT_MAX_CONCURRENT_JOBS = 10` (`background-registry.ts`); the foreground safe-batch had no analog. This PR closes that gap at the engine layer.

This is **Option 2** of a design that was validated with `/shadow-verify` (4 claims independently re-derived → all CONFIRMED) and `/devils-advocate` (3 critics → convergent → composition-boundary check CONFIRMED). The critique specifically **refuted** the alternative "just serialize subagents against sibling tools" framing (it would kill useful `agent`+`read` overlap for zero isolation gain) and confirmed the missing foreground cap as the genuine latent issue.

## How (deliberately minimal)

- New module-local worker-pool `settleWithConcurrencyLimit(items, limit, worker)` drains the safe batch through at most `limit` in-flight workers, returning results in **input order** with `Promise.allSettled` shape. Within the cap it is behaviourally identical to the previous code.
- `partitionIntoBatches` is **untouched** — grouping semantics unchanged, so the binary-contract partition tests are unaffected.
- **Both providers** (`anthropic-direct/loop.ts`, `openai-compatible/query.ts`) inherit the cap for free via the shared dispatcher — no call-site edits.
- **Abort is checked at dispatch time inside the worker**, not at admission: a call cleared in phase 1 that aborts while queued behind the cap is still handled correctly. No queue-admission timer is introduced (there are no per-call timers today; adding one would invent a spurious-timeout bug).
- Result order stays keyed by `originalIndex` — completion-order independent, exactly as before.
- **Constructor-injectable, no env var** — mirrors the closest precedent (`background-registry.ts`). Env-tunability is a trivial follow-up if wanted.

### Why 8

Above the typical parallel-read width, so ordinary fan-out of cheap read tools is never throttled, while bounding the blast radius of a runaway subagent fan-out. (Background jobs use 10 for comparison.) Must stay `>= 2` or the parallel-timing tests regress.

## Explicitly out of scope

Distinguishing cheap leaf reads from expensive subagent forks via a separate `weight` axis (so reads never count against the subagent ceiling) is **design Option 4** — deferred to a follow-up, to be explored in a fresh session.

## Known limitation (unchanged by this PR)

Foreground subagents that share the parent's `cwd` can still race on the filesystem — that TOCTOU is pre-existing and acknowledged (`write-file.ts`), and is better addressed by worktree isolation than by throttling concurrency. This PR does not change it.

## Tests

4 new cases in `dispatcher.test.ts`:
- cap is enforced (peak in-flight == configured limit across a 6-wide batch),
- a cap wider than the batch runs fully parallel (peak == batch width),
- result order is preserved when draining a batch wider than the cap (descending delays),
- a sub-1 cap falls back to the default rather than deadlocking.

**Full suite green: 566 files, 10473 passed, 14 skipped, 0 failed.** `tsc --noEmit` clean. No `@anthropic-ai/sdk` imports added (`audit:sdk:check` unaffected); no env var added (`scan:env:check` unaffected).
