### PR TITLE
feat(tui): collapse sequential same-tool runs into one grouped ×N row

### DIFF
--- a/src/cli/_lib/stream-renderer-orchestrator.test.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.test.ts
@@ -542,10 +542,16 @@ describe('handleOrchestratorEvent — tool-use-loop scrollback (no content emiss
     return { ctx, setOverlay, commitAbove };
   }
 
-  it('eager-flushes completed root tools on the NEXT tool_use_detail', () => {
+  it('eager-flushes a completed root tool on the NEXT (different) tool_use_detail', () => {
     // The core regression test: simulate a tool-use loop with no content
-    // chunks. After tool B starts, tool A (now completed) must be in
-    // scrollback — not stuck in the live overlay waiting for content.
+    // chunks. After a DIFFERENT tool starts, the prior completed tool must be
+    // in scrollback — not stuck in the live overlay waiting for content.
+    //
+    // Note: the next tool here is a DIFFERENT tool (edit_file) so the
+    // cross-flush run-accumulation gate does not hold it. Consecutive
+    // SAME-tool calls intentionally accumulate into one grouped `×N` row —
+    // that behavior is pinned by the 'cross-flush tool grouping' describe
+    // block below.
     const toolLane = new ToolLane();
     const { ctx, commitAbove } = makeLoopCtx(toolLane);
     const source: SourceState = freshSourceState('__main__');
@@ -558,15 +564,16 @@ describe('handleOrchestratorEvent — tool-use-loop scrollback (no content emiss
     // flush trigger is on the NEXT tool_use_detail, not on tool_result).
     expect(commitAbove).not.toHaveBeenCalled();
 
-    // Iteration 2: bash B starts. THIS is the flush trigger.
-    handleOrchestratorEvent(bashStart('bash-B', '"pwd"'), source, ctx);
+    // Iteration 2: a DIFFERENT tool (edit_file) starts. THIS is the flush
+    // trigger — a tool-name change never holds.
+    handleOrchestratorEvent(editStart('edit-B'), source, ctx);
 
     // bash-A must now be in scrollback.
     const scrollback = commitAbove.mock.calls.map((c) => strip(c[0])).join('\n');
     expect(scrollback).toContain('ls');
     expect(toolLane.hasEntry('bash-A')).toBe(false);
-    // bash-B must still be live (not committed — it just started).
-    expect(toolLane.hasEntry('bash-B')).toBe(true);
+    // edit-B must still be live (not committed — it just started).
+    expect(toolLane.hasEntry('edit-B')).toBe(true);
   });
 
   it('preserves tool_diff sidecar visibility — diff lands BEFORE the eager flush', () => {
@@ -1117,5 +1124,101 @@ describe('handleOrchestratorEvent — skill-nesting gate', () => {
     const entries = (toolLane as unknown as PrivateLane).entries;
     const composeEntry = entries.get('compose-tu-1');
     expect(composeEntry?.agentContext).toBe('skill-tu-4');
+  });
+});
+
+describe('handleOrchestratorEvent — cross-flush tool grouping (run accumulation)', () => {
+  function namedToolStart(id: string, toolName: string): OutputEvent {
+    return {
+      type: 'chunk',
+      chunk: { type: 'tool_use_detail', toolUseId: id, toolName, toolInput: '"cmd"' },
+    };
+  }
+  function thinkingEvent(content: string): OutputEvent {
+    return { type: 'chunk', chunk: { type: 'thinking', content } };
+  }
+  function makeCaptureCtx(
+    toolLane: ToolLane,
+    opts: { thinkingMode?: 'off' | 'summary' | 'live' } = {},
+  ): { ctx: OrchestratorCtx; commitAboveCalls: string[] } {
+    const commitAboveCalls: string[] = [];
+    const compositor = {
+      commitAbove(text: string) { commitAboveCalls.push(text); },
+      setOverlay: vi.fn(),
+      setSpinner: vi.fn(),
+    } as unknown as OrchestratorCtx['compositor'];
+    const { writer } = makeWriter();
+    const ctx: OrchestratorCtx = {
+      out: writer,
+      isTTY: true,
+      compositor,
+      toolLane,
+      thinkingLane: new ThinkingLane(),
+      thinkingMode: opts.thinkingMode ?? 'off',
+      streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
+    };
+    return { ctx, commitAboveCalls };
+  }
+
+  it('collapses a run of ≥2 sequential same-tool calls (no thinking) into one grouped ×N block', () => {
+    const toolLane = new ToolLane();
+    const { ctx, commitAboveCalls } = makeCaptureCtx(toolLane);
+    const source = freshSourceState('__main__');
+
+    // 3 sequential Bash calls, each completing before the next — no thinking.
+    for (const id of ['b1', 'b2', 'b3']) {
+      handleOrchestratorEvent(namedToolStart(id, 'Bash'), source, ctx);
+      handleOrchestratorEvent(toolResultEvent(id), source, ctx);
+    }
+    // A different tool breaks the run → the held Bash run flushes as a group.
+    handleOrchestratorEvent(namedToolStart('r1', 'Read'), source, ctx);
+
+    const scrollback = commitAboveCalls.join('\n');
+    expect(scrollback).toContain('×3');
+  });
+
+  it('collapses at exactly 2 — root grouping has no threshold-3 gate', () => {
+    const toolLane = new ToolLane();
+    const { ctx, commitAboveCalls } = makeCaptureCtx(toolLane);
+    const source = freshSourceState('__main__');
+    for (const id of ['b1', 'b2']) {
+      handleOrchestratorEvent(namedToolStart(id, 'Bash'), source, ctx);
+      handleOrchestratorEvent(toolResultEvent(id), source, ctx);
+    }
+    handleOrchestratorEvent(namedToolStart('r1', 'Read'), source, ctx);
+    expect(commitAboveCalls.join('\n')).toContain('×2');
+  });
+
+  it('does NOT collapse distinct sequential tools', () => {
+    const toolLane = new ToolLane();
+    const { ctx, commitAboveCalls } = makeCaptureCtx(toolLane);
+    const source = freshSourceState('__main__');
+    handleOrchestratorEvent(namedToolStart('b1', 'Bash'), source, ctx);
+    handleOrchestratorEvent(toolResultEvent('b1'), source, ctx);
+    handleOrchestratorEvent(namedToolStart('r1', 'Read'), source, ctx);
+    handleOrchestratorEvent(toolResultEvent('r1'), source, ctx);
+    handleOrchestratorEvent(namedToolStart('g1', 'Glob'), source, ctx); // break
+    expect(commitAboveCalls.join('\n')).not.toContain('×');
+  });
+
+  it('a thinking phase between same-tool calls breaks the run (append-only ordering)', () => {
+    const toolLane = new ToolLane();
+    const { ctx, commitAboveCalls } = makeCaptureCtx(toolLane, { thinkingMode: 'summary' });
+    const source = freshSourceState('__main__');
+
+    handleOrchestratorEvent(namedToolStart('b1', 'Bash'), source, ctx);
+    handleOrchestratorEvent(toolResultEvent('b1'), source, ctx);
+    // Model thinks before the next same-tool call → an inline "thought for Xs"
+    // line commits here, so the run MUST break (else the thought would reorder
+    // above the group).
+    handleOrchestratorEvent(thinkingEvent('deliberating about the next step'), source, ctx);
+    handleOrchestratorEvent(namedToolStart('b2', 'Bash'), source, ctx);
+    handleOrchestratorEvent(toolResultEvent('b2'), source, ctx);
+    handleOrchestratorEvent(namedToolStart('r1', 'Read'), source, ctx); // break
+
+    const scrollback = commitAboveCalls.join('\n');
+    expect(scrollback).not.toContain('×2');            // b1/b2 rendered individually
+    expect(scrollback.toLowerCase()).toContain('thought for'); // thought committed between them
   });
 });

--- a/src/cli/_lib/stream-renderer-orchestrator.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.ts
@@ -190,11 +190,31 @@ export function handleOrchestratorEvent(
         // next orchestrator tool_use_detail fires. In-flight roots stay in
         // the lane (`flushCompletedRoots` filters them out).
         if (ctx.isTTY) {
-          // Order: prior completed tool first, THEN the thinking phase that
-          // produced THIS tool — so the inline "◆ thought for Xs" line hugs the
-          // tool it preceded (and sits below the prior tool). commitThinkingPhase
-          // is a no-op when no phase is pending.
-          flushToolLaneToScrollback(ctx);
+          // Invariant (cross-flush run accumulation + append-only ordering):
+          // when the incoming tool would EXTEND a run of the same flat tool
+          // already completed in the lane, skip the eager flush so the run
+          // accumulates and commits as one grouped `toolName ×N` block when it
+          // breaks — UNLESS a thinking phase is pending. A pending thought MUST
+          // break the run: commitThinkingPhase below commits `◆ thought for Xs`
+          // inline, and a held run would otherwise commit AFTER that thought,
+          // reordering it above its own tool group (scrollback is append-only,
+          // so it cannot be fixed post-commit). `thinkingPhaseStartedAt == null`
+          // is exactly "no thought pending" (set only in non-off thinking modes
+          // by the 'thinking' handler below). peekTrailingCompletedRootToolName
+          // returns undefined for NESTING/in-flight trailing roots, so dispatch
+          // tools and parallel blocks are unaffected.
+          const trailingRun = ctx.toolLane.peekTrailingCompletedRootToolName();
+          const holdRun =
+            trailingRun !== undefined &&
+            trailingRun === chunk.toolName &&
+            source.thinkingPhaseStartedAt == null;
+          if (!holdRun) {
+            // Order: prior completed tool first, THEN the thinking phase that
+            // produced THIS tool — so the inline "◆ thought for Xs" line hugs the
+            // tool it preceded (and sits below the prior tool). commitThinkingPhase
+            // is a no-op when no phase is pending.
+            flushToolLaneToScrollback(ctx);
+          }
           commitThinkingPhase(source, ctx);
         }
         // Invariant: skill-nesting gate — when this is a skill-dispatch turn

--- a/src/cli/commands/interactive/tool-lane.test.ts
+++ b/src/cli/commands/interactive/tool-lane.test.ts
@@ -2645,3 +2645,51 @@ describe('ToolLane.flushCompletedRoots', () => {
     expect(lane.hasPending()).toBe(false);
   });
 });
+
+describe('ToolLane.peekTrailingCompletedRootToolName — cross-flush run gate', () => {
+  it('returns undefined for an empty lane', () => {
+    const lane = new ToolLane();
+    expect(lane.peekTrailingCompletedRootToolName()).toBeUndefined();
+  });
+
+  it('returns the toolName of the trailing completed flat root', () => {
+    const lane = new ToolLane();
+    lane.addStart('b1', 'Bash', '"echo a"');
+    lane.addResult('b1', makeResult('a'));
+    expect(lane.peekTrailingCompletedRootToolName()).toBe('Bash');
+  });
+
+  it('returns undefined when the trailing flat root is still in-flight', () => {
+    const lane = new ToolLane();
+    lane.addStart('b1', 'Bash', '"echo a"');
+    lane.addResult('b1', makeResult('a'));
+    lane.addStart('b2', 'Bash', '"echo b"'); // registered, no result yet
+    expect(lane.peekTrailingCompletedRootToolName()).toBeUndefined();
+  });
+
+  it('returns undefined when the trailing root is a NESTING tool (own commit path)', () => {
+    const lane = new ToolLane();
+    lane.addStart('a1', 'Agent', '(researcher)');
+    lane.addResult('a1', makeResult('done'));
+    expect(lane.peekTrailingCompletedRootToolName()).toBeUndefined();
+  });
+
+  it('skips nested (agentContext) children to report the trailing ROOT tool', () => {
+    const lane = new ToolLane();
+    lane.addStart('b1', 'Bash', '"echo a"');
+    lane.addResult('b1', makeResult('a'));
+    // A completed child bound to an agent context — must be skipped (not a root).
+    lane.addStartWithAgentContext('child-1', 'Read', '("x.ts")', 'some-agent');
+    lane.addResult('child-1', makeResult('1 line'));
+    expect(lane.peekTrailingCompletedRootToolName()).toBe('Bash');
+  });
+
+  it('reports the MOST-RECENT completed flat root when several tool names differ', () => {
+    const lane = new ToolLane();
+    lane.addStart('b1', 'Bash', '"a"');
+    lane.addResult('b1', makeResult('a'));
+    lane.addStart('r1', 'Read', '("x.ts")');
+    lane.addResult('r1', makeResult('1 line'));
+    expect(lane.peekTrailingCompletedRootToolName()).toBe('Read');
+  });
+});

--- a/src/cli/commands/interactive/tool-lane.ts
+++ b/src/cli/commands/interactive/tool-lane.ts
@@ -282,6 +282,36 @@ export class ToolLane {
     return undefined;
   }
 
+  /**
+   * Returns the toolName of the trailing completed *flat* root — the most
+   * recent entry (scanning {@link order} newest→oldest) that is a leaf tool
+   * with a result and no `agentContext` — or `undefined` when that trailing
+   * root is in-flight, is a NESTING tool, or the lane has no such root.
+   *
+   * Drives the orchestrator's cross-flush run-accumulation gate: when the
+   * incoming tool matches this name (and no thinking phase is pending), the
+   * eager per-tool flush is skipped so consecutive same-tool roots stay in the
+   * lane and commit as one grouped `toolName ×N` block via
+   * {@link flushCompletedRoots} → {@link renderGroupedRootTools}. Returns
+   * undefined for NESTING roots so dispatch tools (which commit via their own
+   * subagent-done path) never trigger a hold, and undefined for an in-flight
+   * trailing root so parallel blocks keep their existing accumulate-then-flush
+   * behavior untouched.
+   */
+  peekTrailingCompletedRootToolName(): string | undefined {
+    for (let i = this.order.length - 1; i >= 0; i--) {
+      const id = this.order[i]!;
+      const entry = this.entries.get(id);
+      if (!entry || entry.kind !== 'tool') continue; // skip non-tool entries
+      if (entry.agentContext) continue;              // skip nested (non-root) entries
+      // First flat root from the tail decides the verdict:
+      if (entry.result === undefined) return undefined;        // in-flight → don't hold
+      if (NESTING_TOOLS.has(entry.toolName)) return undefined; // nesting → own commit path
+      return entry.toolName;
+    }
+    return undefined;
+  }
+
   getOverlay(): string {
     const childMap = this.buildChildMap();
     const lines: string[] = [];


### PR DESCRIPTION
## Problem
In the interactive REPL, a run of sequential same-tool calls (e.g. 8 back-to-back `bash git show`) renders as N separate scrollback rows — a wall of near-identical lines. Collapsing into a single `bash ×N` row already exists and already works for **parallel** same-tool blocks, but not for **sequential** runs.

## Root cause
`flushToolLaneToScrollback` fires on every incoming `tool_use_detail` (`stream-renderer-orchestrator.ts`), and `flushCompletedRoots` (`tool-lane.ts`) commits **and deletes** the single prior completed root each time. So each flush batch held exactly one completed root → the grouped-render path (`entries.length > 1` → `formatGroupedToolResults`) was never reached for sequential tools. Effective grouping window = 1. (Parallel blocks group because their details arrive together as in-flight entries and flush as one batch.)

## Fix
At the single per-tool orchestrator call site, **skip the eager flush** when the incoming tool extends the trailing completed same-tool run and no thinking phase is pending — so the run accumulates in the lane and commits as one `toolName ×N` block when it breaks (different tool / thinking / prose / turn end).

- `ToolLane.peekTrailingCompletedRootToolName()` reports the trailing completed **flat** root's name (undefined for in-flight or NESTING roots, so dispatch tools and parallel blocks are untouched).
- Root grouping fires at **≥2** — no threshold (`GROUP_THRESHOLD_LEAF` only gates nested children).

## Correctness / constraints respected
- **Append-only ordering:** a pending thinking phase MUST break the run — `commitThinkingPhase` emits an inline `◆ thought for Xs` line, and a held run would otherwise commit *after* it, reordering the thought above its own tool group. So **thinking-interleaved runs intentionally do not collapse** (default `thinkingMode='summary'` commits these between tools).
- **No data loss:** `dispose()`'s unconditional `flush()` drains any held run on turn end / abort / error — no error-branch flush needed.
- **Diff sidecars & subagent rows:** `addDiff` is keyed by `toolUseId` (holding longer only helps attachment); `flushSource` (subagent path) is disjoint from `flushCompletedRoots`. Unaffected.

## Tests
- New: `ToolLane.peekTrailingCompletedRootToolName` edge cases (empty / completed / in-flight / NESTING / nested-child / most-recent).
- New: orchestrator run-accumulation — collapse ≥2, collapse at exactly 2, no-collapse for distinct tools, and the **thinking-break** (a thought between same-tool calls prevents collapse).
- Updated: the "eager-flush on next tool_use_detail" regression test now uses a *different* next tool (the tool-change path still flushes immediately); same-tool accumulation is pinned by the new tests.
- Gates: `pnpm lint` clean; full suite **10,479 passed / 0 failed**.

## Scope / provenance
Independent of #373 (touches the flush cadence, not the progress banner) — branched off `main` as a separate PR. This is the "cross-flush tool grouping window" follow-up deferred from the loading-state-feedback work.

## Follow-ups (out of scope)
- Unify the two grouping mechanisms (root ad-hoc bucketing vs `groupSiblings` for nested children) into one threshold/format policy.
- Optional: render a held run as one live-overlay unit to remove the bounded `MAX_OVERLAY_ROOTS` transient-elision during a long run.
