### PR TITLE
fix(agent): thread defaultSubagentModel through nested skill executors

### DIFF
--- a/src/agent/tools/nesting.model-fallback.test.ts
+++ b/src/agent/tools/nesting.model-fallback.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression tests: createChildSkillExecutorFactory must thread the resolved
+ * `defaultSubagentModel` policy into every nested SkillExecutor it builds.
+ *
+ * Bug (closed here): the factory received only `defaultModel`, leaving each
+ * nested SkillExecutor's `defaultSubagentModel` undefined. That undefined then
+ * flows into the child SubagentExecutor those skills construct
+ * (skill-executor.ts buildForkedChildConfig, which passes
+ * `defaultSubagentModel: this.ctx.defaultSubagentModel`). The `agent`-tool
+ * default resolution there is `parsed.model ?? defaultSubagentModel ??
+ * 'sonnet'` — with NO `defaultModel` link — so an unset `defaultSubagentModel`
+ * routes straight to Anthropic `sonnet` even under an OpenAI-only parent,
+ * surfacing as "subagent dispatch unavailable due missing Anthropic
+ * credentials".
+ *
+ * These tests mock SkillExecutor to capture the exact ctx the factory builds,
+ * proving the resolved policy is threaded at depth 1 AND recursively at
+ * depth 2+ (skill→skill→skill), and that omitting it preserves back-compat.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Capture every SkillExecutor construction. Hoisted so the (also-hoisted)
+// vi.mock factory below can close over it (mirrors the appendRoutingDecision
+// pattern in orchestration-telemetry.test.ts).
+const constructed = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+
+vi.mock('./skill-executor.js', () => ({
+  // Capturing constructor: records each ctx and returns a light stub. The
+  // factory only stores the reference into the child ctx and reads nothing
+  // back, so a stub suffices.
+  SkillExecutor: vi.fn(function (this: unknown, ctx: Record<string, unknown>) {
+    constructed.push(ctx);
+    return { ctx } as unknown;
+  }),
+}));
+
+import { createChildSkillExecutorFactory } from './nesting.js';
+import type { ChildProviderFactoryArgs } from './nesting.js';
+import type { ModelProvider } from '../provider.js';
+
+// No-op provider factory — never invoked here (the factory only stores the
+// reference into the child ctx).
+const stubProviderFactory = (_args: ChildProviderFactoryArgs): ModelProvider =>
+  ({}) as ModelProvider;
+
+describe('createChildSkillExecutorFactory — defaultSubagentModel threading', () => {
+  beforeEach(() => {
+    constructed.length = 0;
+  });
+
+  it('threads the resolved defaultSubagentModel into the depth-1 nested SkillExecutor', () => {
+    const factory = createChildSkillExecutorFactory(
+      'gpt-5.5', // 1 defaultModel (parent model)
+      undefined, // 2 apiKey
+      stubProviderFactory, // 3 childProviderFactory
+      undefined, // 4 baseUrl
+      undefined, // 5 traceWriter
+      undefined, // 6 backgroundRegistry
+      undefined, // 7 cwd
+      undefined, // 8 resolveApiKeyForModel
+      'cli', // 9 surface
+      'sonnet', // 10 defaultSubagentModel (resolved policy)
+    );
+    factory(1, 3, new AbortController().signal);
+
+    expect(constructed).toHaveLength(1);
+    expect(constructed[0]!['defaultSubagentModel']).toBe('sonnet');
+    // defaultModel is still threaded — it drives provider routing and its own
+    // fallback; the fix ADDS defaultSubagentModel, it does not replace it.
+    expect(constructed[0]!['defaultModel']).toBe('gpt-5.5');
+  });
+
+  it('propagates defaultSubagentModel recursively (skill→skill→skill)', () => {
+    const factory = createChildSkillExecutorFactory(
+      'gpt-5.5',
+      undefined,
+      stubProviderFactory,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'cli',
+      'sonnet',
+    );
+    factory(1, 3, new AbortController().signal);
+
+    // The nested executor's own childSkillExecutorFactory must carry the policy
+    // forward. Invoke it to build a grandchild and assert it too — this is the
+    // depth-2+ path where the pre-fix leak actually manifested.
+    const recursive = constructed[0]!['childSkillExecutorFactory'] as (
+      depth: number,
+      maxDepth: number,
+      signal: AbortSignal,
+    ) => unknown;
+    expect(typeof recursive).toBe('function');
+    recursive(2, 3, new AbortController().signal);
+
+    expect(constructed).toHaveLength(2);
+    expect(constructed[1]!['defaultSubagentModel']).toBe('sonnet');
+  });
+
+  it('omits defaultSubagentModel when the caller does not supply it (back-compat)', () => {
+    const factory = createChildSkillExecutorFactory(
+      'sonnet',
+      undefined,
+      stubProviderFactory,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'cli',
+      // 10th arg omitted — legacy/test callers keep the pre-fix shape.
+    );
+    factory(1, 3, new AbortController().signal);
+
+    expect(constructed[0]!).not.toHaveProperty('defaultSubagentModel');
+  });
+});

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -237,6 +237,24 @@ export function buildReadOnlyReconProvider(model: AgentModelInput | undefined): 
  * would have `agent`/`skill` tools, but its skill grandchildren would
  * silently fall back to the bare provider (the same bug the depth-0
  * caller fixes).
+ *
+ * `defaultSubagentModel` is the resolved default-subagent policy
+ * (`getDefaultSubagentModel(parentModel)`) threaded through every depth so
+ * nested skill children inherit the SAME policy the top-level executors use.
+ * When omitted (legacy/test callers), the nested SkillExecutor's
+ * `defaultSubagentModel` stays undefined and its own fallback chain applies.
+ *
+ * Invariant: this parameter closes the "subagent model falls back to
+ * Anthropic sonnet under an OpenAI-routed parent" leak. A nested SkillExecutor
+ * built without it has `defaultSubagentModel: undefined`; that undefined then
+ * flows into the child SubagentExecutor it constructs
+ * (skill-executor.ts buildForkedChildConfig), whose `agent`-tool resolution is
+ * `parsed.model ?? defaultSubagentModel ?? 'sonnet'` — with no `defaultModel`
+ * link, so an unset `defaultSubagentModel` routes straight to Anthropic
+ * `sonnet` even when the whole session is OpenAI-only (→ "missing Anthropic
+ * credentials"). Threading the resolved value here keeps every depth on the
+ * parent's provider. Explicit `agent.model` / SKILL.md `model:` still win —
+ * this only governs the no-model-specified default.
  */
 export function createChildSkillExecutorFactory(
   defaultModel: AgentModelInput,
@@ -248,6 +266,7 @@ export function createChildSkillExecutorFactory(
   cwd?: string,
   resolveApiKeyForModel?: (model: string) => string | undefined,
   surface?: Surface,
+  defaultSubagentModel?: AgentModelInput,
 ): (depth: number, maxDepth: number, signal: AbortSignal) => SkillExecutor {
   const factory: (depth: number, maxDepth: number, signal: AbortSignal) => SkillExecutor = (
     depth,
@@ -257,6 +276,12 @@ export function createChildSkillExecutorFactory(
     new SkillExecutor({
       parentSession: createStubParentSession(signal),
       defaultModel,
+      // Resolved default-subagent policy threaded through every depth so a
+      // nested skill child (and the SubagentExecutor it builds) defaults to the
+      // parent's provider rather than the Anthropic `sonnet` literal. Optional:
+      // when the caller omits it, back-compat fallback chains apply. See the
+      // leak-closure invariant in this factory's jsdoc.
+      ...(defaultSubagentModel !== undefined ? { defaultSubagentModel } : {}),
       apiKey,
       ...(baseUrl !== undefined ? { baseUrl } : {}),
       depth,

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -486,6 +486,12 @@ export function registerChatCommand(program: Command): void {
           getApiKeyForModel,
           // Surface: chat skill executor children inherit origin 'cli'.
           'cli',
+          // Resolved default-subagent model threaded into nested skill
+          // executors so skill→skill / skill→agent chains inherit the SAME
+          // policy as the top-level executors — closing the leak where a
+          // nested subagent silently defaulted to Anthropic `sonnet` under an
+          // OpenAI-routed parent.
+          getDefaultSubagentModel(options.model),
         );
 
         // Pass `options.model` so `getDefaultSubagentModel` can fall back

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -112,6 +112,11 @@ export function buildDaemonSessionFactory(
       getApiKeyForModel,
       // Surface: daemon skill executor children inherit origin 'daemon'.
       'daemon',
+      // Resolved default-subagent model threaded into nested skill executors
+      // so skill→skill / skill→agent chains inherit the SAME policy as the
+      // top-level executors — closing the leak where a nested subagent
+      // silently defaulted to Anthropic `sonnet` under an OpenAI-routed parent.
+      getDefaultSubagentModel(opts.model),
     );
 
     const subagentExecutor = new SubagentExecutor({

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -290,6 +290,11 @@ export async function bootstrapSession(
     getApiKeyForModel,
     // Surface: REPL skill executor children inherit origin 'cli'.
     'cli',
+    // Resolved default-subagent model threaded into nested skill executors so
+    // skill→skill / skill→agent chains inherit the SAME policy as the top-level
+    // executors below — closing the leak where a nested subagent silently
+    // defaulted to Anthropic `sonnet` under an OpenAI-routed parent.
+    getDefaultSubagentModel(sessionModel),
   );
 
   // Pass `sessionModel` to `getDefaultSubagentModel` so OpenAI-routed

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -278,6 +278,12 @@ async function main() {
           getApiKeyForModel,
           // Surface: Telegram skill executor children inherit origin 'telegram'.
           'telegram',
+          // Resolved default-subagent model threaded into nested skill
+          // executors so skill→skill / skill→agent chains inherit the SAME
+          // policy as the top-level executors — closing the leak where a
+          // nested subagent silently defaulted to Anthropic `sonnet` under an
+          // OpenAI-routed parent.
+          getDefaultSubagentModel(sessionConfig.model),
         );
 
         // Pass `sessionConfig.model` to `getDefaultSubagentModel` for


### PR DESCRIPTION
## Problem

Under an **OpenAI-routed parent** (e.g. `gpt-5.5`, a local `org/model`, codex-*), a nested skill dispatch could silently fall back to Anthropic **`sonnet`** for its subagents — failing with *"subagent dispatch unavailable due missing Anthropic credentials"* even though the session has no Anthropic key and never asked for one. This showed up when a plugin skill (e.g. `/review`) dispatched its own sub-agents from a depth-2+ position.

## Root cause

`createChildSkillExecutorFactory(defaultModel, …)` (`src/agent/tools/nesting.ts`) was passed only the parent's **`defaultModel`**, never the resolved **`defaultSubagentModel`** policy. Every nested `SkillExecutor` it built therefore had `defaultSubagentModel: undefined`.

That `undefined` then flows into the child `SubagentExecutor` those skills construct (`skill-executor.ts` `buildForkedChildConfig`, which passes `defaultSubagentModel: this.ctx.defaultSubagentModel`). The `agent`-tool default resolution is:

```ts
// subagent-executor.ts
const childModel = parsed.model ?? this.ctx.defaultSubagentModel ?? 'sonnet';
```

There is **no `defaultModel` link** in that chain — so an unset `defaultSubagentModel` routes straight to the `'sonnet'` literal → Anthropic → 401 / missing-credentials, regardless of the parent's provider.

The top-level executors already avoid this: they set `defaultSubagentModel: getDefaultSubagentModel(parentModel)`, which returns the parent model for OpenAI-routed parents (and `'sonnet'` for Claude parents, preserving the cost-management default). The gap was purely that this resolved value was never threaded into the **nested** factory.

## Fix

Thread the already-resolved `getDefaultSubagentModel(parentModel)` through the factory (and recursively, via the self-referencing `childSkillExecutorFactory`) so **every depth** — skill→skill→skill and skill→agent — inherits the same default the top-level executors use.

- `nesting.ts`: add an optional `defaultSubagentModel` parameter; thread it into the nested `SkillExecutor` and forward it through the recursive factory. Optional/trailing → existing/legacy callers keep working unchanged.
- `bootstrap.ts` / `chat.ts` / `telegram.ts` / `daemon.ts`: pass the value each already computes for its top-level executors into the factory.

**The agent still chooses its subagent models.** Explicit `agent.model` and SKILL.md `model:` continue to take precedence — the `??` fallback only governs the *no-model-specified* case. This change only fixes what that unspecified default resolves to.

## Tests

New `src/agent/tools/nesting.model-fallback.test.ts` (mocks `SkillExecutor` to capture the built context):
- resolved `defaultSubagentModel` is threaded into the depth-1 nested executor;
- it propagates recursively (skill→skill→skill / the depth-2+ path where the leak manifested);
- omitting it preserves the pre-fix shape (back-compat).

Verification:
- `pnpm lint` (tsc strict) — clean
- `pnpm audit:sdk:check` — OK (no new SDK symbols)
- Full suite: **10475 passed, 14 skipped, 0 failed** (567 files)