### PR TITLE
fix: approve better-sqlite3 native build script for pnpm 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,11 @@
   "engines": {
     "node": ">=22.0.0"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3"
+    ]
+  },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Problem

pnpm 10 blocks dependency lifecycle scripts by default unless the package is allowlisted in `pnpm.onlyBuiltDependencies`. This repo pins `pnpm@10.32.1` and had no allowlist, so every fresh `pnpm install` — notably in new git worktrees, which this repo's workflow creates constantly — silently skipped `better-sqlite3`'s `prebuild-install || node-gyp rebuild` step and produced no `build/Release/better_sqlite3.node` binding.

Any command that opens the memory-store DB (provider construction at CLI startup, the memory test suites) then fails at runtime with **"Could not locate the bindings file"**. In a fresh worktree this manifests as ~175 phantom test failures, all tracing back to the single missing binding.

## Fix

Add `better-sqlite3` to `pnpm.onlyBuiltDependencies` so its native build script runs automatically on every install.

`esbuild`'s gated postinstall is deliberately left ignored: its binary ships via the `@esbuild/*` optional platform dependencies, so it works fine without the build script.

## Verification

In a fresh worktree off `origin/main` (v5.15.8) with this change:

- `pnpm install` produces `node_modules/better-sqlite3/build/Release/better_sqlite3.node` with no manual `pnpm approve-builds` step
- A live smoke check (`require('better-sqlite3')(':memory:')` + create/insert/select) succeeds
- `pnpm lint` (tsc --noEmit strict): clean
- Full test suite: **567 files / 10,475 passed / 0 failed / 14 skipped**

## Provenance

Cherry-picked from local commit `9808e85` (authored 2026-06-29) which diagnosed and verified this fix but was never pushed — the session that produced it died before the push step. Rebased cleanly onto v5.15.8.
