### PR TITLE
feat: named agent definitions with agent_type dispatch on the agent tool

### DIFF
--- a/src/agent/agents/builtins.ts
+++ b/src/agent/agents/builtins.ts
@@ -1,0 +1,98 @@
+/**
+ * Built-in named agents.
+ *
+ * Registered programmatically (no filesystem scan) at the BOTTOM of the
+ * precedence order, so a user or project file with the same name shadows
+ * them. Two sources:
+ *
+ * 1. Vendored plugin agents (`research-agent`, `git-investigator`) from
+ *    `src/skills/_agents/` — byte-pinned to upstream by `vendored.test.ts`.
+ *    Wrapped here, never edited. These make the bundled orchestration
+ *    SKILL.mds (review, shadow-verify, devils-advocate, research, ship,
+ *    refactor) resolve their `subagent_type: "research-agent"` dispatches.
+ * 2. Claude Code compatibility types (`general-purpose`, `Explore`) with
+ *    AFK-authored prompts, so prompts ported from Claude Code — and the
+ *    bundled research skill's documented `Explore` fallback — resolve too.
+ *
+ * @module agent/agents/builtins
+ */
+
+import { researchAgent } from '../../skills/_agents/research-agent.js';
+import { gitInvestigator } from '../../skills/_agents/git-investigator.js';
+import type { RegisteredAgent } from './types.js';
+
+const GENERAL_PURPOSE_PROMPT = `You are a general-purpose sub-agent for complex, multi-step tasks that require both exploration and action.
+
+Work autonomously from the task prompt you were dispatched with: investigate, act, and verify. You have the parent session's full child tool surface. Keep intermediate exploration out of your reply.
+
+Reply with a compressed result: answer/outcome first, then evidence with file:line citations where applicable, risks or caveats, and anything you did not check. Your final message is the only thing the dispatching session sees.`;
+
+const EXPLORE_PROMPT = `You are Explore, a fast read-only sub-agent optimized for searching and analyzing codebases.
+
+Rules:
+- You are READ-ONLY: never write, edit, or mutate anything.
+- Find and read the files relevant to the dispatched question. Prefer targeted grep/glob over broad reads.
+- Match the requested thoroughness when the prompt names one (quick / medium / very thorough); default to medium.
+
+Reply compactly: the answer first, then evidence as file:line citations, then open questions or paths not checked. No preamble.`;
+
+/**
+ * Build the built-in agents, keyed by name.
+ *
+ * A fresh map per call — callers merge it into a mutable registry under
+ * construction; sharing one module-level map would let one session's
+ * shadowing leak into the next in long-lived processes (tests, telegram).
+ */
+export function builtinAgents(): Map<string, RegisteredAgent> {
+  const entries: RegisteredAgent[] = [
+    {
+      name: researchAgent.name,
+      source: 'builtin',
+      definition: {
+        description: researchAgent.description,
+        prompt: researchAgent.systemPrompt,
+        tools: [...researchAgent.allowedTools],
+      },
+    },
+    {
+      name: gitInvestigator.name,
+      source: 'builtin',
+      definition: {
+        description: gitInvestigator.description,
+        prompt: gitInvestigator.systemPrompt,
+        tools: [...gitInvestigator.allowedTools],
+        model: gitInvestigator.model,
+      },
+      // The vendored definition grants Bash for git archaeology; its contract
+      // is read-only ("Runs git commands only — no mutations"). Enforce that
+      // contract mechanically with the read-only bash gate.
+      bashReadOnly: true,
+    },
+    {
+      name: 'general-purpose',
+      source: 'builtin',
+      definition: {
+        description:
+          'Capable agent for complex, multi-step tasks that require both exploration and action. ' +
+          'Inherits the full child tool surface. Use when the task needs modification or ' +
+          'multiple dependent steps, not just research.',
+        prompt: GENERAL_PURPOSE_PROMPT,
+        // No `tools` — inherit-all (Claude Code parity for general-purpose).
+      },
+    },
+    {
+      name: 'Explore',
+      source: 'builtin',
+      definition: {
+        description:
+          'Fast, read-only agent for searching and analyzing codebases: file discovery, code ' +
+          'search, tracing usages. Cannot write, edit, or run shell commands. Claude Code ' +
+          'compatibility type — accepts a thoroughness hint (quick/medium/very thorough) in the prompt.',
+        prompt: EXPLORE_PROMPT,
+        tools: ['Read', 'Grep', 'Glob', 'list_directory'],
+        model: 'haiku',
+      },
+    },
+  ];
+  return new Map(entries.map((agent) => [agent.name, agent]));
+}

--- a/src/agent/agents/builtins.ts
+++ b/src/agent/agents/builtins.ts
@@ -19,7 +19,21 @@
 
 import { researchAgent } from '../../skills/_agents/research-agent.js';
 import { gitInvestigator } from '../../skills/_agents/git-investigator.js';
+import { parseAgentMarkdown } from './parser.js';
 import type { RegisteredAgent } from './types.js';
+
+/**
+ * A vendored agent module's `systemPrompt` is the RAW upstream markdown —
+ * frontmatter included (byte-equality with upstream is enforced, so the
+ * wrapper cannot pre-strip it). A system prompt should be the body only:
+ * parse and take the body, falling back to the raw text if the vendored
+ * format ever changes shape. Tools/description stay sourced from the
+ * wrapper constants (the vendored contract diagnose already relies on),
+ * NOT from the file's frontmatter.
+ */
+function vendoredPromptBody(raw: string): string {
+  return parseAgentMarkdown(raw)?.definition.prompt ?? raw;
+}
 
 const GENERAL_PURPOSE_PROMPT = `You are a general-purpose sub-agent for complex, multi-step tasks that require both exploration and action.
 
@@ -50,7 +64,7 @@ export function builtinAgents(): Map<string, RegisteredAgent> {
       source: 'builtin',
       definition: {
         description: researchAgent.description,
-        prompt: researchAgent.systemPrompt,
+        prompt: vendoredPromptBody(researchAgent.systemPrompt),
         tools: [...researchAgent.allowedTools],
       },
     },
@@ -59,7 +73,7 @@ export function builtinAgents(): Map<string, RegisteredAgent> {
       source: 'builtin',
       definition: {
         description: gitInvestigator.description,
-        prompt: gitInvestigator.systemPrompt,
+        prompt: vendoredPromptBody(gitInvestigator.systemPrompt),
         tools: [...gitInvestigator.allowedTools],
         model: gitInvestigator.model,
       },

--- a/src/agent/agents/index.ts
+++ b/src/agent/agents/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Named agents: public module surface.
+ *
+ * @module agent/agents
+ */
+
+export type {
+  AgentRegistry,
+  AgentSource,
+  RegisteredAgent,
+  ResolvedAgentToolAccess,
+} from './types.js';
+export { parseAgentMarkdown, type ParsedAgentFile } from './parser.js';
+export { resolveAgentToolAccess } from './resolve.js';
+export { builtinAgents } from './builtins.js';
+export { loadAgentRegistry, type LoadAgentRegistryOptions } from './registry.js';
+export { buildAgentToolDef } from './tool-def.js';

--- a/src/agent/agents/parser.test.ts
+++ b/src/agent/agents/parser.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the Claude Code subagent markdown parser.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { parseAgentMarkdown } from './parser.js';
+
+const VALID = `---
+name: code-reviewer
+description: Reviews code for quality
+tools: Read, Glob, Grep
+model: sonnet
+---
+
+You are a code reviewer. Analyze the code.`;
+
+describe('parseAgentMarkdown', () => {
+  it('parses required fields, tools, model, and body-as-prompt', () => {
+    const parsed = parseAgentMarkdown(VALID);
+    expect(parsed).toBeDefined();
+    expect(parsed?.name).toBe('code-reviewer');
+    expect(parsed?.definition.description).toBe('Reviews code for quality');
+    expect(parsed?.definition.tools).toEqual(['Read', 'Glob', 'Grep']);
+    expect(parsed?.definition.model).toBe('sonnet');
+    expect(parsed?.definition.prompt).toBe('You are a code reviewer. Analyze the code.');
+  });
+
+  it('returns undefined without frontmatter', () => {
+    const warn = vi.fn();
+    expect(parseAgentMarkdown('just a plain file', warn)).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('frontmatter'));
+  });
+
+  it('returns undefined when name or description is missing', () => {
+    expect(
+      parseAgentMarkdown('---\ndescription: no name\n---\nbody'),
+    ).toBeUndefined();
+    expect(parseAgentMarkdown('---\nname: no-desc\n---\nbody')).toBeUndefined();
+  });
+
+  it('returns undefined when the body (system prompt) is empty', () => {
+    const warn = vi.fn();
+    expect(
+      parseAgentMarkdown('---\nname: x\ndescription: y\n---\n   \n', warn),
+    ).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('empty body'));
+  });
+
+  it('parses YAML-list tools and disallowedTools (both spellings)', () => {
+    const doc = `---
+name: lists
+description: list forms
+tools:
+  - Read
+  - Grep
+disallowed-tools: Write, Edit
+---
+prompt body`;
+    const parsed = parseAgentMarkdown(doc);
+    expect(parsed?.definition.tools).toEqual(['Read', 'Grep']);
+    expect(parsed?.definition.disallowedTools).toEqual(['Write', 'Edit']);
+  });
+
+  it('accepts allowed-tools as a space-separated alias (agentskills.io form)', () => {
+    const doc = `---
+name: spacey
+description: space separated
+allowed-tools: Read Grep Glob
+---
+prompt`;
+    const parsed = parseAgentMarkdown(doc);
+    expect(parsed?.definition.tools).toEqual(['Read', 'Grep', 'Glob']);
+  });
+
+  it('keeps Agent(...) paren groups intact through tokenization', () => {
+    const doc = `---
+name: coordinator
+description: with paren group
+tools: Agent(worker, researcher), Read
+---
+prompt`;
+    const parsed = parseAgentMarkdown(doc);
+    // Comma-splitting fragments the group; the resolver handles fragments.
+    expect(parsed?.definition.tools).toContain('Agent(worker');
+    expect(parsed?.definition.tools).toContain('Read');
+  });
+
+  it('parses maxTurns and the bash: read-only AFK extension', () => {
+    const doc = `---
+name: budgeted
+description: with budget
+maxTurns: 5
+bash: read-only
+---
+prompt`;
+    const parsed = parseAgentMarkdown(doc);
+    expect(parsed?.definition.maxTurns).toBe(5);
+    expect(parsed?.bashReadOnly).toBe(true);
+  });
+
+  it('records recognized long-tail fields as ignoredKeys and warns on unknown keys', () => {
+    const warn = vi.fn();
+    const doc = `---
+name: longtail
+description: fields galore
+memory: project
+color: red
+isolation: worktree
+totally-made-up: nope
+---
+prompt`;
+    const parsed = parseAgentMarkdown(doc, warn);
+    expect(parsed?.ignoredKeys).toEqual(['memory', 'color', 'isolation']);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('totally-made-up'));
+  });
+
+  it('joins folded multi-line descriptions', () => {
+    const doc = `---
+name: folded
+description: >-
+  A long description
+  spanning lines
+---
+prompt`;
+    const parsed = parseAgentMarkdown(doc);
+    expect(parsed?.definition.description).toBe('A long description spanning lines');
+  });
+
+  it('strips quotes from scalar values', () => {
+    const doc = `---
+name: "quoted"
+description: 'single quoted desc'
+model: "opus"
+---
+prompt`;
+    const parsed = parseAgentMarkdown(doc);
+    expect(parsed?.name).toBe('quoted');
+    expect(parsed?.definition.description).toBe('single quoted desc');
+    expect(parsed?.definition.model).toBe('opus');
+  });
+});

--- a/src/agent/agents/parser.ts
+++ b/src/agent/agents/parser.ts
@@ -1,0 +1,246 @@
+/**
+ * Parser for Claude Code-format subagent markdown files.
+ *
+ * Format: YAML frontmatter (name, description, tools, disallowedTools, model,
+ * maxTurns, …) followed by a markdown body that becomes the child session's
+ * system prompt. Only `name` and `description` are required. Unknown and
+ * long-tail keys are tolerated (recorded, never fatal) so files written for
+ * Claude Code parse without modification.
+ *
+ * Deliberately hand-rolled line parser in the same style as
+ * `plugins/tool-injector.ts` — no YAML dependency, tolerant of the narrow
+ * shapes real agent files use.
+ *
+ * @module agent/agents/parser
+ */
+
+import type { AgentDefinition } from '../types/sdk-types.js';
+import { parseToolsField } from '../plugins/tool-injector.js';
+
+/** Parse outcome for a single agent markdown file. */
+export interface ParsedAgentFile {
+  name: string;
+  definition: AgentDefinition;
+  bashReadOnly?: boolean;
+  ignoredKeys?: string[];
+}
+
+/**
+ * Claude Code long-tail frontmatter fields AFK recognizes but does not honor
+ * yet. Parsed tolerantly (recorded in `ignoredKeys`) rather than warned as
+ * unknown, so a file using them still loads with correct core semantics.
+ */
+const RECOGNIZED_UNSUPPORTED_KEYS: ReadonlySet<string> = new Set([
+  'permissionmode',
+  'permission-mode',
+  'skills',
+  'mcpservers',
+  'mcp-servers',
+  'hooks',
+  'memory',
+  'background',
+  'effort',
+  'isolation',
+  'color',
+  'initialprompt',
+  'initial-prompt',
+]);
+
+/** Strip one layer of surrounding single/double quotes. */
+function stripQuotes(value: string): string {
+  const t = value.trim();
+  if (
+    (t.startsWith('"') && t.endsWith('"') && t.length >= 2) ||
+    (t.startsWith("'") && t.endsWith("'") && t.length >= 2)
+  ) {
+    return t.slice(1, -1).trim();
+  }
+  return t;
+}
+
+/**
+ * Read a scalar frontmatter value that may continue on following indented
+ * lines (YAML folded `>`/`>-` style or bare continuation). Returns the joined
+ * value and the number of continuation lines consumed.
+ */
+function readScalar(
+  inline: string,
+  lines: string[],
+  startIdx: number,
+): { value: string; consumed: number } {
+  let value = stripQuotes(inline);
+  const isFoldMarker = value === '>' || value === '>-' || value === '|' || value === '|-';
+  if (isFoldMarker) value = '';
+  let consumed = 0;
+  // Continuation lines: indented, not a new `key:` at column 0, not a list item.
+  for (let i = startIdx; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) break;
+    if (!/^\s+\S/.test(line)) break; // requires leading indentation
+    const trimmed = line.trim();
+    if (trimmed.startsWith('- ')) break; // sequences belong to list fields
+    // A new top-level key never matches (no leading indent), so any indented
+    // text is continuation.
+    value = value.length > 0 ? `${value} ${trimmed}` : trimmed;
+    consumed++;
+  }
+  return { value, consumed };
+}
+
+/**
+ * Parse a Claude Code subagent markdown document.
+ *
+ * @param content Raw file content.
+ * @param warn Sink for non-fatal diagnostics (missing fields, unknown keys).
+ * @returns Parsed file, or `undefined` when the document has no valid
+ *   frontmatter or misses a required field (`name`, `description`) or has an
+ *   empty body (no system prompt to run).
+ */
+export function parseAgentMarkdown(
+  content: string,
+  warn: (message: string) => void = () => {},
+): ParsedAgentFile | undefined {
+  if (!content.startsWith('---')) {
+    warn('missing frontmatter (file must start with ---)');
+    return undefined;
+  }
+  const afterOpen = content.slice(3);
+  const endIdx = afterOpen.indexOf('\n---');
+  if (endIdx === -1) {
+    warn('unterminated frontmatter (no closing ---)');
+    return undefined;
+  }
+  const frontmatterText = afterOpen.slice(0, endIdx);
+  // Body starts after the closing `---` line.
+  const rest = afterOpen.slice(endIdx + 4);
+  const body = rest.startsWith('\n') ? rest.slice(1) : rest;
+
+  const lines = frontmatterText.split('\n');
+  let name: string | undefined;
+  let description: string | undefined;
+  let model: string | undefined;
+  let maxTurns: number | undefined;
+  let bashReadOnly: boolean | undefined;
+  let tools: string[] | undefined;
+  let disallowedTools: string[] | undefined;
+  const ignoredKeys: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+    if (line.trim().length === 0) continue;
+    if (/^\s/.test(line)) continue; // continuation/sequence lines are consumed by their key
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const keyLower = key.toLowerCase();
+    const inline = line.slice(colonIdx + 1);
+    const remaining = lines.slice(i + 1);
+
+    switch (keyLower) {
+      case 'name': {
+        name = stripQuotes(inline);
+        break;
+      }
+      case 'description': {
+        const { value, consumed } = readScalar(inline, lines, i + 1);
+        description = value;
+        i += consumed;
+        break;
+      }
+      case 'tools':
+      case 'allowed-tools': {
+        // `allowed-tools` accepted as an alias (agentskills.io skills use it;
+        // authors conflate the two formats). Space-separated values are also
+        // tokenized for the same reason.
+        tools = splitPossiblySpaceSeparated(parseToolsField(inline, remaining));
+        break;
+      }
+      case 'disallowedtools':
+      case 'disallowed-tools': {
+        disallowedTools = splitPossiblySpaceSeparated(parseToolsField(inline, remaining));
+        break;
+      }
+      case 'model': {
+        const value = stripQuotes(inline);
+        if (value.length > 0) model = value;
+        break;
+      }
+      case 'maxturns':
+      case 'max-turns': {
+        const parsed = Number.parseInt(stripQuotes(inline), 10);
+        if (Number.isFinite(parsed) && parsed > 0) maxTurns = parsed;
+        else warn(`invalid ${key} value ${JSON.stringify(inline.trim())} — ignored`);
+        break;
+      }
+      case 'bash': {
+        // AFK extension: `bash: read-only` gates the child's shell to
+        // non-mutating commands (classifyBashCommand) when bash is granted.
+        const value = stripQuotes(inline).toLowerCase();
+        if (value === 'read-only' || value === 'readonly') bashReadOnly = true;
+        else warn(`unrecognized bash value ${JSON.stringify(inline.trim())} — ignored`);
+        break;
+      }
+      default: {
+        if (RECOGNIZED_UNSUPPORTED_KEYS.has(keyLower)) {
+          ignoredKeys.push(key);
+        } else {
+          warn(`unknown frontmatter key ${JSON.stringify(key)} — ignored`);
+        }
+        break;
+      }
+    }
+  }
+
+  if (name === undefined || name.length === 0) {
+    warn('missing required frontmatter field "name"');
+    return undefined;
+  }
+  if (description === undefined || description.length === 0) {
+    warn(`agent ${JSON.stringify(name)}: missing required frontmatter field "description"`);
+    return undefined;
+  }
+  const prompt = body.trim();
+  if (prompt.length === 0) {
+    warn(`agent ${JSON.stringify(name)}: empty body — an agent file's body is its system prompt`);
+    return undefined;
+  }
+
+  const definition: AgentDefinition = {
+    description,
+    prompt,
+    ...(tools !== undefined && tools.length > 0 ? { tools } : {}),
+    ...(disallowedTools !== undefined && disallowedTools.length > 0 ? { disallowedTools } : {}),
+    ...(model !== undefined ? { model } : {}),
+    ...(maxTurns !== undefined ? { maxTurns } : {}),
+  };
+
+  return {
+    name,
+    definition,
+    ...(bashReadOnly === true ? { bashReadOnly: true } : {}),
+    ...(ignoredKeys.length > 0 ? { ignoredKeys } : {}),
+  };
+}
+
+/**
+ * Post-split tokens that may themselves be space-separated. agentskills.io's
+ * `allowed-tools` is a space-separated string; Claude Code uses commas. After
+ * `parseToolsField` handles commas/YAML lists, split any token that still
+ * contains internal whitespace — EXCEPT parenthesized groups like
+ * `Agent(worker, researcher)`, which stay intact for downstream paren
+ * stripping.
+ */
+function splitPossiblySpaceSeparated(tokens: string[]): string[] {
+  const out: string[] = [];
+  for (const token of tokens) {
+    if (token.includes('(')) {
+      out.push(token);
+      continue;
+    }
+    for (const part of token.split(/\s+/)) {
+      if (part.length > 0) out.push(part);
+    }
+  }
+  return out;
+}

--- a/src/agent/agents/registry.test.ts
+++ b/src/agent/agents/registry.test.ts
@@ -99,6 +99,28 @@ describe('loadAgentRegistry', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('duplicate agent name'));
   });
 
+  it('warns when a name is defined in both project dirs (.claude + .afk); .afk still wins', () => {
+    const warn = vi.fn();
+    const proj = join(tmp, 'proj');
+    writeAgent(join(proj, '.claude', 'agents'), 'dup.md', 'both-dirs');
+    writeAgent(join(proj, '.afk', 'agents'), 'dup.md', 'both-dirs');
+    const registry = loadAgentRegistry({ cwd: proj, warn });
+    // Precedence unchanged: .afk wins the project tier.
+    expect(registry.get('both-dirs')?.filePath).toBe(join(proj, '.afk', 'agents', 'dup.md'));
+    // ...but the cross-directory override is no longer silent.
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('overrides'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('duplicate agent name'));
+  });
+
+  it('does not warn on override when a project name lives in only one project dir', () => {
+    const warn = vi.fn();
+    const proj = join(tmp, 'proj');
+    writeAgent(join(proj, '.claude', 'agents'), 'cc.md', 'cc-only-agent');
+    writeAgent(join(proj, '.afk', 'agents'), 'afk.md', 'afk-only-agent');
+    loadAgentRegistry({ cwd: proj, warn });
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('overrides'));
+  });
+
   it('skips malformed files without failing the scan', () => {
     const warn = vi.fn();
     const dir = join(tmp, 'proj', '.afk', 'agents');

--- a/src/agent/agents/registry.test.ts
+++ b/src/agent/agents/registry.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the named-agent registry: scopes, precedence, duplicates,
+ * builtins, and config-tier injection.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { loadAgentRegistry } from './registry.js';
+
+let tmp: string;
+let prevAfkHome: string | undefined;
+
+function writeAgent(dir: string, file: string, name: string, extra = ''): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, file),
+    `---\nname: ${name}\ndescription: from ${dir}\n${extra}---\nprompt for ${name}\n`,
+  );
+}
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'afk-agents-test-'));
+  prevAfkHome = process.env['AFK_HOME'];
+  process.env['AFK_HOME'] = join(tmp, 'afk-home');
+});
+
+afterEach(() => {
+  if (prevAfkHome === undefined) delete process.env['AFK_HOME'];
+  else process.env['AFK_HOME'] = prevAfkHome;
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('loadAgentRegistry', () => {
+  it('always contains the builtin agents', () => {
+    const registry = loadAgentRegistry({ cwd: join(tmp, 'proj'), warn: () => {} });
+    expect(registry.get('research-agent')?.source).toBe('builtin');
+    expect(registry.get('git-investigator')?.source).toBe('builtin');
+    expect(registry.get('git-investigator')?.bashReadOnly).toBe(true);
+    expect(registry.get('general-purpose')?.source).toBe('builtin');
+    expect(registry.get('Explore')?.source).toBe('builtin');
+    // research-agent keeps its vendored tool contract
+    expect(registry.get('research-agent')?.definition.tools).toEqual([
+      'Read',
+      'Grep',
+      'Glob',
+      'WebFetch',
+      'WebSearch',
+    ]);
+  });
+
+  it('scans user scope (~/.afk/agents) recursively', () => {
+    const userDir = join(tmp, 'afk-home', 'agents', 'review');
+    writeAgent(userDir, 'security.md', 'security-reviewer');
+    const registry = loadAgentRegistry({ cwd: join(tmp, 'proj'), warn: () => {} });
+    expect(registry.get('security-reviewer')?.source).toBe('user');
+    expect(registry.get('security-reviewer')?.filePath).toBe(join(userDir, 'security.md'));
+  });
+
+  it('project scope shadows user scope; .afk/agents shadows .claude/agents', () => {
+    const proj = join(tmp, 'proj');
+    writeAgent(join(tmp, 'afk-home', 'agents'), 'a.md', 'shadowed');
+    writeAgent(join(proj, '.claude', 'agents'), 'a.md', 'shadowed');
+    writeAgent(join(proj, '.claude', 'agents'), 'cc-only.md', 'cc-only');
+    writeAgent(join(proj, '.afk', 'agents'), 'a.md', 'shadowed');
+
+    const registry = loadAgentRegistry({ cwd: proj, warn: () => {} });
+    const winner = registry.get('shadowed');
+    expect(winner?.source).toBe('project');
+    expect(winner?.filePath).toBe(join(proj, '.afk', 'agents', 'a.md'));
+    // Claude Code compat dir is read when not shadowed
+    expect(registry.get('cc-only')?.filePath).toBe(join(proj, '.claude', 'agents', 'cc-only.md'));
+  });
+
+  it('user/project files shadow builtins by name', () => {
+    writeAgent(join(tmp, 'afk-home', 'agents'), 'r.md', 'research-agent');
+    const registry = loadAgentRegistry({ cwd: join(tmp, 'proj'), warn: () => {} });
+    expect(registry.get('research-agent')?.source).toBe('user');
+  });
+
+  it('warns on same-scope duplicate names and keeps the first (sorted) file', () => {
+    const warn = vi.fn();
+    const dir = join(tmp, 'proj', '.afk', 'agents');
+    writeAgent(dir, 'a-first.md', 'dupe');
+    writeAgent(dir, 'z-second.md', 'dupe');
+    const registry = loadAgentRegistry({ cwd: join(tmp, 'proj'), warn });
+    expect(registry.get('dupe')?.filePath).toBe(join(dir, 'a-first.md'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('duplicate agent name'));
+  });
+
+  it('skips malformed files without failing the scan', () => {
+    const warn = vi.fn();
+    const dir = join(tmp, 'proj', '.afk', 'agents');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'broken.md'), 'no frontmatter here');
+    writeAgent(dir, 'ok.md', 'works');
+    const registry = loadAgentRegistry({ cwd: join(tmp, 'proj'), warn });
+    expect(registry.get('works')).toBeDefined();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('configAgents take highest precedence', () => {
+    writeAgent(join(tmp, 'proj', '.afk', 'agents'), 'a.md', 'contested');
+    const registry = loadAgentRegistry({
+      cwd: join(tmp, 'proj'),
+      warn: () => {},
+      configAgents: {
+        contested: { description: 'programmatic', prompt: 'config prompt' },
+      },
+    });
+    expect(registry.get('contested')?.source).toBe('config');
+    expect(registry.get('contested')?.definition.prompt).toBe('config prompt');
+  });
+
+  it('missing scope directories are silently fine', () => {
+    const warn = vi.fn();
+    const registry = loadAgentRegistry({ cwd: join(tmp, 'nonexistent-proj'), warn });
+    expect(registry.size).toBeGreaterThanOrEqual(4); // builtins only
+    // no read-failure warnings for absent dirs
+    expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('cannot read'));
+  });
+});

--- a/src/agent/agents/registry.test.ts
+++ b/src/agent/agents/registry.test.ts
@@ -51,6 +51,15 @@ describe('loadAgentRegistry', () => {
     ]);
   });
 
+  it('strips vendored frontmatter from builtin prompts (body-only system prompt)', () => {
+    const registry = loadAgentRegistry({ cwd: join(tmp, 'proj'), warn: () => {} });
+    for (const name of ['research-agent', 'git-investigator']) {
+      const prompt = registry.get(name)?.definition.prompt ?? '';
+      expect(prompt.startsWith('---')).toBe(false);
+      expect(prompt.length).toBeGreaterThan(0);
+    }
+  });
+
   it('scans user scope (~/.afk/agents) recursively', () => {
     const userDir = join(tmp, 'afk-home', 'agents', 'review');
     writeAgent(userDir, 'security.md', 'security-reviewer');

--- a/src/agent/agents/registry.ts
+++ b/src/agent/agents/registry.ts
@@ -14,8 +14,10 @@
  *
  * Directories are scanned recursively for `*.md` files. Identity comes from
  * the frontmatter `name` field, not the filename (Claude Code parity). A
- * duplicate name within one scope keeps the first file found and warns; a
- * duplicate across scopes shadows silently by design (higher scope wins).
+ * duplicate name within one directory keeps the first file found and warns; a
+ * name defined in both project directories (.claude/agents and .afk/agents)
+ * warns on override (.afk wins); a duplicate across different scopes
+ * (user/project/config) shadows silently by design (higher scope wins).
  *
  * Loading is synchronous and session-static — called once at bootstrap
  * (mirrors the plugins scan), then threaded by reference through executor
@@ -81,16 +83,23 @@ function collectMarkdownFiles(dir: string, depth = 0): string[] {
 
 /**
  * Scan one directory scope and merge its agents into `registry`.
- * Same-scope duplicates keep the first file (sorted order) and warn;
+ * Same-directory duplicates keep the first file (sorted order) and warn;
  * cross-scope duplicates shadow the lower scope silently (by design).
+ *
+ * `crossDirSeen`, when supplied, is shared across the directories of a single
+ * scope tier (the project tier spans .claude/agents + .afk/agents). It only
+ * drives a warning when a name appears in more than one of those dirs — the
+ * later directory still wins (registry.set overwrites), so precedence is
+ * unchanged; the warning just makes the otherwise-silent override visible.
  */
 function scanScope(
   registry: Map<string, RegisteredAgent>,
   dir: string,
   source: AgentSource,
   warn: (message: string) => void,
+  crossDirSeen?: Map<string, string>,
 ): void {
-  const seenInScope = new Map<string, string>(); // name → filePath
+  const seenInScope = new Map<string, string>(); // name → filePath (this directory)
   for (const filePath of collectMarkdownFiles(dir)) {
     let content: string;
     try {
@@ -111,6 +120,20 @@ function scanScope(
       continue;
     }
     seenInScope.set(parsed.name, filePath);
+
+    // Cross-directory override within the same tier (e.g. the same name in
+    // both .claude/agents and .afk/agents — both 'project' scope). The later
+    // directory wins by design; warn so the shadow is not silent.
+    if (crossDirSeen !== undefined) {
+      const priorInTier = crossDirSeen.get(parsed.name);
+      if (priorInTier !== undefined) {
+        warn(
+          `[afk] agents: duplicate agent name ${JSON.stringify(parsed.name)} in ${source} scope — ` +
+            `${filePath} overrides ${priorInTier}`,
+        );
+      }
+      crossDirSeen.set(parsed.name, filePath);
+    }
 
     registry.set(parsed.name, {
       name: parsed.name,
@@ -145,9 +168,13 @@ export function loadAgentRegistry(options: LoadAgentRegistryOptions = {}): Agent
 
   // user scope
   scanScope(registry, join(getAfkHome(), 'agents'), 'user', warn);
-  // project scope: Claude Code compat first so AFK-native wins within the tier
-  scanScope(registry, join(cwd, '.claude', 'agents'), 'project', warn);
-  scanScope(registry, join(cwd, '.afk', 'agents'), 'project', warn);
+  // project scope: Claude Code compat first so AFK-native wins within the tier.
+  // Share one tracker across the two project dirs so a name defined in BOTH
+  // .claude/agents and .afk/agents warns on override (each dir still keeps its
+  // own same-directory keep-first policy; .afk continues to win the tier).
+  const projectSeen = new Map<string, string>();
+  scanScope(registry, join(cwd, '.claude', 'agents'), 'project', warn, projectSeen);
+  scanScope(registry, join(cwd, '.afk', 'agents'), 'project', warn, projectSeen);
 
   // config scope (programmatic, highest)
   if (options.configAgents !== undefined) {

--- a/src/agent/agents/registry.ts
+++ b/src/agent/agents/registry.ts
@@ -1,0 +1,161 @@
+/**
+ * Named-agent registry: discovery, precedence, and load.
+ *
+ * Scopes and precedence (ascending — later shadows earlier on the same name):
+ *
+ *   builtin                          (programmatic; see builtins.ts)
+ *   user     ~/.afk/agents/          (all projects on this machine)
+ *   project  <cwd>/.claude/agents/   (Claude Code compat, read-only)
+ *   project  <cwd>/.afk/agents/      (AFK-native project scope)
+ *   config   AgentSessionConfig.agents (programmatic per-session injection)
+ *
+ * Plugin `agents/` directories are a planned scope (between builtin and
+ * user); the plugin scanner does not surface them yet.
+ *
+ * Directories are scanned recursively for `*.md` files. Identity comes from
+ * the frontmatter `name` field, not the filename (Claude Code parity). A
+ * duplicate name within one scope keeps the first file found and warns; a
+ * duplicate across scopes shadows silently by design (higher scope wins).
+ *
+ * Loading is synchronous and session-static — called once at bootstrap
+ * (mirrors the plugins scan), then threaded by reference through executor
+ * nesting. Scan failures are contained per-file: one malformed agent never
+ * blocks the rest.
+ *
+ * @module agent/agents/registry
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getAfkHome } from '../../paths.js';
+import type { AgentDefinition } from '../types/sdk-types.js';
+import { parseAgentMarkdown } from './parser.js';
+import { builtinAgents } from './builtins.js';
+import type { AgentRegistry, AgentSource, RegisteredAgent } from './types.js';
+
+/** Maximum recursion depth for agent-directory scans (defense against cycles). */
+const MAX_SCAN_DEPTH = 5;
+
+export interface LoadAgentRegistryOptions {
+  /**
+   * Project root for the project scope (`.afk/agents/`, `.claude/agents/`).
+   * Defaults to `process.cwd()`. Pass the worktree root for `-w` sessions.
+   */
+  cwd?: string;
+  /**
+   * Programmatic definitions (from `AgentSessionConfig.agents`). Highest
+   * precedence — mirrors Claude Code's `--agents` CLI tier sitting above
+   * file scopes.
+   */
+  configAgents?: Record<string, AgentDefinition>;
+  /**
+   * Diagnostic sink for scan warnings (malformed files, duplicate names,
+   * unknown frontmatter). Defaults to stderr, matching the plugin skill
+   * scanner's convention. Pass a no-op to silence.
+   */
+  warn?: (message: string) => void;
+}
+
+/** Recursively collect `*.md` file paths under `dir`. Missing dir → []. */
+function collectMarkdownFiles(dir: string, depth = 0): string[] {
+  if (depth > MAX_SCAN_DEPTH) return [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return []; // scope directory absent — the common case
+  }
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectMarkdownFiles(full, depth + 1));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      files.push(full);
+    }
+  }
+  return files.sort(); // deterministic same-scope ordering across platforms
+}
+
+/**
+ * Scan one directory scope and merge its agents into `registry`.
+ * Same-scope duplicates keep the first file (sorted order) and warn;
+ * cross-scope duplicates shadow the lower scope silently (by design).
+ */
+function scanScope(
+  registry: Map<string, RegisteredAgent>,
+  dir: string,
+  source: AgentSource,
+  warn: (message: string) => void,
+): void {
+  const seenInScope = new Map<string, string>(); // name → filePath
+  for (const filePath of collectMarkdownFiles(dir)) {
+    let content: string;
+    try {
+      content = readFileSync(filePath, 'utf8');
+    } catch (err) {
+      warn(`[afk] agents: cannot read ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+      continue;
+    }
+    const parsed = parseAgentMarkdown(content, (msg) => warn(`[afk] agents: ${filePath}: ${msg}`));
+    if (parsed === undefined) continue;
+
+    const priorInScope = seenInScope.get(parsed.name);
+    if (priorInScope !== undefined) {
+      warn(
+        `[afk] agents: duplicate agent name ${JSON.stringify(parsed.name)} in ${source} scope — ` +
+          `keeping ${priorInScope}, ignoring ${filePath}`,
+      );
+      continue;
+    }
+    seenInScope.set(parsed.name, filePath);
+
+    registry.set(parsed.name, {
+      name: parsed.name,
+      definition: parsed.definition,
+      source,
+      filePath,
+      ...(parsed.bashReadOnly === true ? { bashReadOnly: true } : {}),
+      ...(parsed.ignoredKeys !== undefined ? { ignoredKeys: parsed.ignoredKeys } : {}),
+    });
+
+    if (parsed.ignoredKeys !== undefined && parsed.ignoredKeys.length > 0) {
+      warn(
+        `[afk] agents: ${filePath}: frontmatter field(s) not honored by AFK yet: ` +
+          parsed.ignoredKeys.join(', '),
+      );
+    }
+  }
+}
+
+/**
+ * Load the full named-agent registry for a session.
+ *
+ * Synchronous by design — called from session bootstrap paths that are
+ * already doing sync scans (plugins). Never throws: scan problems degrade to
+ * warnings and a smaller registry.
+ */
+export function loadAgentRegistry(options: LoadAgentRegistryOptions = {}): AgentRegistry {
+  const cwd = options.cwd ?? process.cwd();
+  const warn = options.warn ?? ((message: string) => process.stderr.write(message + '\n'));
+
+  const registry = new Map<string, RegisteredAgent>(builtinAgents());
+
+  // user scope
+  scanScope(registry, join(getAfkHome(), 'agents'), 'user', warn);
+  // project scope: Claude Code compat first so AFK-native wins within the tier
+  scanScope(registry, join(cwd, '.claude', 'agents'), 'project', warn);
+  scanScope(registry, join(cwd, '.afk', 'agents'), 'project', warn);
+
+  // config scope (programmatic, highest)
+  if (options.configAgents !== undefined) {
+    for (const [name, definition] of Object.entries(options.configAgents)) {
+      if (name.trim().length === 0) continue;
+      registry.set(name, { name, definition, source: 'config' });
+    }
+  }
+
+  return registry;
+}

--- a/src/agent/agents/resolve.test.ts
+++ b/src/agent/agents/resolve.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for named-agent tool-access resolution (Claude Code semantics).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveAgentToolAccess } from './resolve.js';
+import type { RegisteredAgent } from './types.js';
+
+const POOL = ['read_file', 'grep', 'glob', 'bash', 'write_file', 'edit_file', 'agent', 'skill'];
+
+function agent(overrides: {
+  tools?: string[];
+  disallowedTools?: string[];
+  bashReadOnly?: boolean;
+}): RegisteredAgent {
+  return {
+    name: 'test-agent',
+    source: 'builtin',
+    definition: {
+      description: 'd',
+      prompt: 'p',
+      ...(overrides.tools !== undefined ? { tools: overrides.tools } : {}),
+      ...(overrides.disallowedTools !== undefined
+        ? { disallowedTools: overrides.disallowedTools }
+        : {}),
+    },
+    ...(overrides.bashReadOnly === true ? { bashReadOnly: true } : {}),
+  };
+}
+
+describe('resolveAgentToolAccess', () => {
+  it('maps PascalCase Claude Code names to AFK runtime names', () => {
+    const resolved = resolveAgentToolAccess(
+      agent({ tools: ['Read', 'Grep', 'Glob', 'WebFetch', 'WebSearch'] }),
+      POOL,
+    );
+    expect(resolved.allowedTools).toEqual(['read_file', 'grep', 'glob', 'web_scrape']);
+    expect(resolved.droppedTokens).toEqual([]);
+  });
+
+  it('returns undefined allowlist (inherit-all) when tools is omitted', () => {
+    const resolved = resolveAgentToolAccess(agent({}), POOL);
+    expect(resolved.allowedTools).toBeUndefined();
+  });
+
+  it('maps Task/Agent to agent and Skill to skill (opt-in nesting)', () => {
+    const resolved = resolveAgentToolAccess(agent({ tools: ['Task', 'Skill', 'Read'] }), POOL);
+    expect(resolved.allowedTools).toEqual(['agent', 'skill', 'read_file']);
+  });
+
+  it('strips Agent(...) paren groups and ignores their fragments silently', () => {
+    const resolved = resolveAgentToolAccess(
+      // parseToolsField comma-splits `Agent(worker, researcher)` into fragments
+      agent({ tools: ['Agent(worker', 'researcher)', 'Read'] }),
+      POOL,
+    );
+    expect(resolved.allowedTools).toEqual(['agent', 'read_file']);
+    expect(resolved.droppedTokens).toEqual([]); // fragments are not fail-closed noise
+  });
+
+  it('drops unknown tokens fail-closed and reports them', () => {
+    const resolved = resolveAgentToolAccess(
+      agent({ tools: ['Read', 'NotebookEdit', 'FrobnicateTool'] }),
+      POOL,
+    );
+    expect(resolved.allowedTools).toEqual(['read_file']);
+    expect(resolved.droppedTokens).toEqual(['NotebookEdit', 'FrobnicateTool']);
+  });
+
+  it('passes mcp__* tokens through verbatim', () => {
+    const resolved = resolveAgentToolAccess(
+      agent({ tools: ['Read', 'mcp__github__get_issue'] }),
+      POOL,
+    );
+    expect(resolved.allowedTools).toEqual(['read_file', 'mcp__github__get_issue']);
+  });
+
+  it('applies disallowedTools against the inherit pool when tools is omitted', () => {
+    const resolved = resolveAgentToolAccess(
+      agent({ disallowedTools: ['Write', 'Edit'] }),
+      POOL,
+    );
+    expect(resolved.allowedTools).toEqual([
+      'read_file',
+      'grep',
+      'glob',
+      'bash',
+      'agent',
+      'skill',
+    ]);
+  });
+
+  it('applies deny-first when both lists are present (tool in both is removed)', () => {
+    const resolved = resolveAgentToolAccess(
+      agent({ tools: ['Read', 'Bash', 'Write'], disallowedTools: ['Bash'] }),
+      POOL,
+    );
+    expect(resolved.allowedTools).toEqual(['read_file', 'write_file']);
+  });
+
+  it('deduplicates repeated tokens', () => {
+    const resolved = resolveAgentToolAccess(
+      agent({ tools: ['Read', 'read_file', 'Read'] }),
+      POOL,
+    );
+    expect(resolved.allowedTools).toEqual(['read_file']);
+  });
+
+  it('carries bashReadOnly from the registration', () => {
+    expect(resolveAgentToolAccess(agent({ bashReadOnly: true }), POOL).bashReadOnly).toBe(true);
+    expect(resolveAgentToolAccess(agent({}), POOL).bashReadOnly).toBe(false);
+  });
+});

--- a/src/agent/agents/resolve.ts
+++ b/src/agent/agents/resolve.ts
@@ -1,0 +1,146 @@
+/**
+ * Resolve a named agent's declared tool surface into AFK runtime terms.
+ *
+ * Bridges two namespaces: agent files declare tools in Claude Code's
+ * PascalCase vocabulary (`Read`, `Grep`, `Bash`, `Task`, `WebFetch`, …) while
+ * AFK's dispatcher enforces snake_case runtime names (`read_file`, `grep`,
+ * `bash`, `agent`, `web_scrape`). Reuses `normalizeToolToken` — the same
+ * alias map the plugin SKILL.md `tools:` parser uses — so the mapping has a
+ * single source of truth.
+ *
+ * Semantics (Claude Code parity):
+ * - `tools` omitted → inherit-all (`allowedTools: undefined`; the executor
+ *   applies its default child surface).
+ * - `disallowedTools` is applied FIRST (subtracted from the inherited or
+ *   declared pool), then `tools` resolves against the remainder. A tool in
+ *   both lists is removed.
+ * - `Task`/`Agent` map to AFK's `agent` tool (opt-in nesting; Claude Code
+ *   v2.1.172+ allows nested spawns the same way). `Agent(worker, …)` paren
+ *   groups are accepted and the paren content ignored — CC ignores it inside
+ *   subagent definitions too.
+ * - `mcp__*` tokens pass through verbatim (forward-compat: child providers
+ *   currently receive no MCP manager, so these grant nothing today).
+ * - Unknown tokens are dropped fail-closed and reported in `droppedTokens`.
+ *
+ * @module agent/agents/resolve
+ */
+
+import { normalizeToolToken } from '../plugins/tool-injector.js';
+import { BUILTIN_TOOL_NAMES } from '../tools/schemas.js';
+import { AWARENESS_TOOL_NAMES } from '../awareness/index.js';
+import type { RegisteredAgent, ResolvedAgentToolAccess } from './types.js';
+
+// Invariant: mirrors KNOWN_AFK_TOOL_NAMES in skills/_agents/to-definition.ts —
+// the known-tool universe a child permission gate can actually receive.
+// Duplicated (5 lines) rather than imported to keep the layering direction
+// src/agent → src/skills one-way-free for this module.
+const KNOWN_AFK_TOOL_NAMES: ReadonlySet<string> = new Set([
+  ...BUILTIN_TOOL_NAMES,
+  ...AWARENESS_TOOL_NAMES,
+  'memory_search',
+  'agent',
+  'skill',
+]);
+
+/**
+ * Orchestration-dispatch aliases the generic normalizer deliberately does not
+ * know (it fail-closes `Task`/`Agent` for plugin skills). For NAMED agent
+ * definitions nesting is explicit opt-in, so these map to AFK's dispatch
+ * tools. Lowercase keys; lookup after paren stripping.
+ */
+const DISPATCH_TOOL_ALIASES: Record<string, string> = {
+  task: 'agent',
+  agent: 'agent',
+  skill: 'skill',
+};
+
+/**
+ * Normalize one raw token from an agent file's `tools`/`disallowedTools`
+ * list. Returns the canonical AFK name, the verbatim token for `mcp__*`, or
+ * `undefined` when the token is unknown (caller drops it fail-closed).
+ * Returns `null` for paren-group remnants (e.g. `researcher)` from a
+ * comma-split `Agent(worker, researcher)`) which are silently ignored.
+ */
+function normalizeAgentToolToken(raw: string): string | undefined | null {
+  let token = raw.trim();
+  if (token.length === 0) return null;
+  // Paren-group handling: `Agent(worker, researcher)` may arrive whole or as
+  // comma-split fragments. A token containing `(` is truncated at the paren;
+  // a bare remnant ending in `)` (or `worker)` etc. with no `(`) is a
+  // fragment of the ignored group — drop silently, not fail-closed.
+  const parenIdx = token.indexOf('(');
+  if (parenIdx !== -1) {
+    token = token.slice(0, parenIdx).trim();
+    if (token.length === 0) return null;
+  } else if (token.endsWith(')')) {
+    return null;
+  }
+  if (token.startsWith('mcp__')) return token;
+  const dispatch = DISPATCH_TOOL_ALIASES[token.toLowerCase()];
+  if (dispatch !== undefined) return dispatch;
+  return normalizeToolToken(token, KNOWN_AFK_TOOL_NAMES);
+}
+
+/**
+ * Normalize a raw token list. Returns canonical names (order-preserving,
+ * deduplicated) and the tokens that were dropped fail-closed.
+ */
+function normalizeList(raw: readonly string[]): { names: string[]; dropped: string[] } {
+  const names: string[] = [];
+  const seen = new Set<string>();
+  const dropped: string[] = [];
+  for (const token of raw) {
+    const normalized = normalizeAgentToolToken(token);
+    if (normalized === null) continue; // paren remnant / empty — silent
+    if (normalized === undefined) {
+      dropped.push(token.trim());
+      continue;
+    }
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      names.push(normalized);
+    }
+  }
+  return { names, dropped };
+}
+
+/**
+ * Resolve the effective tool access for a registered agent.
+ *
+ * @param agent The registered agent whose `tools`/`disallowedTools` to resolve.
+ * @param inheritPool The default child tool surface used as the subtraction
+ *   pool when the definition declares ONLY `disallowedTools` (Claude Code's
+ *   "inherit every tool except…" form). Callers pass `CHILD_ALLOWED_TOOLS`
+ *   (or a narrower cage when one is already in force). Taken as a parameter —
+ *   not imported from `tools/nesting.ts` — to keep this module free of the
+ *   executor-module cycle and independently testable.
+ *
+ * @see module doc for semantics. `allowedTools: undefined` means the
+ * definition inherits the executor's default child surface.
+ */
+export function resolveAgentToolAccess(
+  agent: RegisteredAgent,
+  inheritPool: readonly string[],
+): ResolvedAgentToolAccess {
+  const { tools, disallowedTools } = agent.definition;
+  const bashReadOnly = agent.bashReadOnly === true;
+
+  const denied = disallowedTools !== undefined ? normalizeList(disallowedTools) : undefined;
+  const allowed = tools !== undefined ? normalizeList(tools) : undefined;
+  const dropped = [...(allowed?.dropped ?? []), ...(denied?.dropped ?? [])];
+
+  // Neither list → inherit-all.
+  if (allowed === undefined && denied === undefined) {
+    return { allowedTools: undefined, bashReadOnly, droppedTokens: dropped };
+  }
+
+  // Deny-first: subtract from the declared pool, or from the inherited
+  // default surface when only `disallowedTools` is given. `mcp__*` deny
+  // patterns subtract nothing from the builtin pool today (children carry no
+  // MCP tools) — harmless.
+  const deniedSet = new Set(denied?.names ?? []);
+  const pool = allowed?.names ?? [...inheritPool];
+  const effective = pool.filter((name) => !deniedSet.has(name));
+
+  return { allowedTools: effective, bashReadOnly, droppedTokens: dropped };
+}

--- a/src/agent/agents/tool-def.test.ts
+++ b/src/agent/agents/tool-def.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the dynamic `agent` tool definition builder.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildAgentToolDef } from './tool-def.js';
+import { agentTool } from '../tools/schemas.js';
+import type { AgentRegistry, RegisteredAgent } from './types.js';
+
+function registryOf(...names: string[]): AgentRegistry {
+  return new Map<string, RegisteredAgent>(
+    names.map((name) => [
+      name,
+      {
+        name,
+        source: 'builtin' as const,
+        definition: { description: `${name} does things`, prompt: 'p' },
+      },
+    ]),
+  );
+}
+
+describe('buildAgentToolDef', () => {
+  it('returns the static agentTool unchanged for empty/absent registries', () => {
+    expect(buildAgentToolDef(undefined)).toBe(agentTool);
+    expect(buildAgentToolDef(new Map())).toBe(agentTool);
+  });
+
+  it('adds the agent_type property and lists available types', () => {
+    const def = buildAgentToolDef(registryOf('research-agent', 'Explore'));
+    expect(def.name).toBe('agent');
+    expect(def.input_schema.properties).toHaveProperty('agent_type');
+    expect(def.description).toContain('Available agent types');
+    expect(def.description).toContain('- research-agent: research-agent does things');
+    expect(def.description).toContain('- Explore: Explore does things');
+    // required fields unchanged — agent_type stays optional
+    expect(def.input_schema.required).toEqual(['prompt']);
+  });
+
+  it('does not mutate the static agentTool', () => {
+    const before = agentTool.description;
+    const beforeProps = Object.keys(agentTool.input_schema.properties ?? {});
+    buildAgentToolDef(registryOf('x'));
+    expect(agentTool.description).toBe(before);
+    expect(Object.keys(agentTool.input_schema.properties ?? {})).toEqual(beforeProps);
+  });
+
+  it('compacts long descriptions to one line', () => {
+    const registry: AgentRegistry = new Map([
+      [
+        'wordy',
+        {
+          name: 'wordy',
+          source: 'builtin' as const,
+          definition: {
+            description: 'line one\nline two   with   spaces ' + 'x'.repeat(300),
+            prompt: 'p',
+          },
+        },
+      ],
+    ]);
+    const def = buildAgentToolDef(registry);
+    const listingLine = def.description?.split('\n').find((l) => l.startsWith('- wordy:'));
+    expect(listingLine).toBeDefined();
+    expect(listingLine).not.toContain('\n');
+    expect((listingLine ?? '').length).toBeLessThanOrEqual(170);
+    expect(listingLine).toContain('line one line two with spaces');
+  });
+});

--- a/src/agent/agents/tool-def.ts
+++ b/src/agent/agents/tool-def.ts
@@ -1,0 +1,61 @@
+/**
+ * Dynamic `agent` tool definition: advertises the session's named agent
+ * types in the tool description (Claude Code advertises subagent types in
+ * its Task tool the same way) and documents the `agent_type` parameter.
+ *
+ * Built once per provider construction — the registry is session-static, so
+ * there is nothing to refresh mid-session.
+ *
+ * @module agent/agents/tool-def
+ */
+
+import { agentTool } from '../tools/schemas.js';
+import type { AnthropicToolDef } from '../tools/types.js';
+import type { AgentRegistry } from './types.js';
+
+/** Truncate a description to one compact line for the tool-def listing. */
+function oneLine(text: string, max = 160): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  return collapsed.length <= max ? collapsed : collapsed.slice(0, max - 1) + '…';
+}
+
+/**
+ * Build the `agent` tool definition for a session with named agents.
+ *
+ * Returns the static {@link agentTool} unchanged when the registry is empty
+ * or absent, keeping the no-registry schema byte-identical to the legacy
+ * surface. Otherwise returns a copy with:
+ * - an `agent_type` input property (documented alias: `subagent_type`), and
+ * - an "Available agent types" section appended to the description.
+ */
+export function buildAgentToolDef(registry: AgentRegistry | undefined): AnthropicToolDef {
+  if (registry === undefined || registry.size === 0) return agentTool;
+
+  const listing = [...registry.values()]
+    .map((agent) => `- ${agent.name}: ${oneLine(agent.definition.description)}`)
+    .join('\n');
+
+  return {
+    ...agentTool,
+    description:
+      (agentTool.description ?? '') +
+      '\n\nAvailable agent types (pass via `agent_type`):\n' +
+      listing +
+      '\nWhen `agent_type` is omitted, a general child agent with the default tool surface is dispatched.',
+    input_schema: {
+      ...agentTool.input_schema,
+      properties: {
+        ...agentTool.input_schema.properties,
+        agent_type: {
+          type: 'string',
+          description:
+            'Named agent type to dispatch — one of the "Available agent types" listed in this ' +
+            "tool's description. The type supplies the child's system prompt, tool allowlist " +
+            '(mechanically enforced), and default model/turn budget. Explicit `model`/`max_turns` ' +
+            'on this call override the type\'s defaults. Unknown types fail with the available ' +
+            'list. Alias: `subagent_type`.',
+        },
+      },
+    },
+  };
+}

--- a/src/agent/agents/types.ts
+++ b/src/agent/agents/types.ts
@@ -1,0 +1,83 @@
+/**
+ * Named agent definitions: types.
+ *
+ * A named agent is a reusable subagent configuration — system prompt, tool
+ * allowlist, model, turn budget — addressable from the `agent` tool via the
+ * `agent_type` parameter (alias: `subagent_type`). The on-disk format is
+ * Claude Code's subagent markdown (YAML frontmatter + body-as-system-prompt),
+ * so existing `.claude/agents/` files work unmodified.
+ *
+ * @module agent/agents/types
+ */
+
+import type { AgentDefinition } from '../types/sdk-types.js';
+
+/**
+ * Where a registered agent came from. Precedence (ascending — later shadows
+ * earlier on name collision): `builtin` → `plugin:<name>` → `user`
+ * (`~/.afk/agents/`) → `project` (`<cwd>/.afk/agents/`, plus read-only
+ * `.claude/agents/` compat) → `config` (programmatic
+ * `AgentSessionConfig.agents`). Mirrors Claude Code's scope ordering
+ * (plugin lowest, project above user, CLI/`--agents` highest).
+ */
+export type AgentSource = 'builtin' | 'user' | 'project' | 'config' | `plugin:${string}`;
+
+/** A named agent definition plus AFK-side registration metadata. */
+export interface RegisteredAgent {
+  /**
+   * Identity. Comes from the frontmatter `name` field (Claude Code parity:
+   * the filename does NOT have to match — unlike agentskills.io skills).
+   */
+  name: string;
+  /**
+   * The definition proper, in the same shape as `AgentSessionConfig.agents`
+   * values (`sdk-types.AgentDefinition`): `description`, `prompt` (= markdown
+   * body), optional `tools` / `disallowedTools` (raw tokens, unnormalized),
+   * optional `model` / `maxTurns`, plus long-tail fields AFK parses
+   * tolerantly but does not yet honor.
+   */
+  definition: AgentDefinition;
+  source: AgentSource;
+  /** Absolute path of the defining file. Absent for builtin/config agents. */
+  filePath?: string;
+  /**
+   * AFK extension (`bash: read-only` frontmatter): when true and the agent's
+   * resolved allowlist includes `bash`, the child dispatcher additionally
+   * blocks mutating shell commands via `classifyBashCommand` — the same gate
+   * read-only skills use.
+   */
+  bashReadOnly?: boolean;
+  /**
+   * Frontmatter keys that were recognized as Claude Code long-tail fields but
+   * are not honored by AFK yet (e.g. `permissionMode`, `hooks`, `memory`).
+   * Surfaced once as a scan warning; kept for `/agents` display.
+   */
+  ignoredKeys?: string[];
+}
+
+/**
+ * The session-wide registry of named agents, keyed by agent name. Read-only
+ * after load: built once at bootstrap (session-static, like the plugin scan)
+ * and threaded by reference through executor nesting.
+ */
+export type AgentRegistry = ReadonlyMap<string, RegisteredAgent>;
+
+/**
+ * Result of resolving a registered agent's tool access into AFK runtime
+ * terms. Consumed by the `agent` tool executor at dispatch time.
+ */
+export interface ResolvedAgentToolAccess {
+  /**
+   * Canonical AFK runtime tool names the child may use, or `undefined` when
+   * the definition omits `tools` entirely — Claude Code parity: omitted means
+   * "inherit all" (the executor then applies its default child surface).
+   */
+  allowedTools: string[] | undefined;
+  /** Effective read-only-bash gate (from `bash: read-only` frontmatter). */
+  bashReadOnly: boolean;
+  /**
+   * Tokens dropped fail-closed because they normalize to nothing AFK knows
+   * (e.g. `NotebookEdit`). Surfaced in warnings so authors see the gap.
+   */
+  droppedTokens: string[];
+}

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -257,7 +257,11 @@ export class AnthropicDirectProvider implements ModelProvider {
 
   constructor(opts: AnthropicDirectProviderOptions = {}) {
     const schemas = [...builtinToolSchemas];
-    if (opts.subagentExecutor) schemas.push(agentTool);
+    // The executor supplies the `agent` tool def so a named-agent registry
+    // can advertise its types in the description (see agents/tool-def.ts).
+    // Optional chaining: test stubs without describeAgentTool fall back to
+    // the static schema.
+    if (opts.subagentExecutor) schemas.push(opts.subagentExecutor.describeAgentTool?.() ?? agentTool);
     if (opts.skillExecutor) schemas.push(skillTool);
     if (opts.composeExecutor) schemas.push(composeTool);
     // Read-only memory child sessions get only `memory_search`; full sessions

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -154,7 +154,9 @@ export class OpenAICompatibleProvider implements ModelProvider {
     this.memoryStore = opts.memoryStore ?? new MemoryStore();
 
     const schemas: AnthropicToolDef[] = [...builtinToolSchemas];
-    if (opts.subagentExecutor) schemas.push(agentTool);
+    // Executor-supplied `agent` def advertises named agent types when a
+    // registry is wired — parity with anthropic-direct (see agents/tool-def.ts).
+    if (opts.subagentExecutor) schemas.push(opts.subagentExecutor.describeAgentTool?.() ?? agentTool);
     if (opts.skillExecutor) schemas.push(skillTool);
     if (opts.composeExecutor) schemas.push(composeTool);
     if (opts.readOnlyMemory === true) {

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -22,6 +22,7 @@ import { SkillExecutor } from './skill-executor.js';
 import type { SubagentExecutor } from './subagent-executor.js';
 import type { TraceWriter } from '../trace/index.js';
 import type { BackgroundAgentRegistry } from '../background-registry.js';
+import type { AgentRegistry } from '../agents/types.js';
 
 export const DEFAULT_MAX_NESTING_DEPTH = 3;
 
@@ -267,6 +268,7 @@ export function createChildSkillExecutorFactory(
   resolveApiKeyForModel?: (model: string) => string | undefined,
   surface?: Surface,
   defaultSubagentModel?: AgentModelInput,
+  agentRegistry?: AgentRegistry,
 ): (depth: number, maxDepth: number, signal: AbortSignal) => SkillExecutor {
   const factory: (depth: number, maxDepth: number, signal: AbortSignal) => SkillExecutor = (
     depth,
@@ -316,6 +318,9 @@ export function createChildSkillExecutorFactory(
       // SubagentExecutor threads surface into its recursive child executor
       // (subagent-executor.ts:626).
       ...(surface !== undefined ? { surface } : {}),
+      // Named-agent registry propagates so nested skill children can
+      // dispatch `agent_type`-named sub-agents at any depth.
+      ...(agentRegistry !== undefined ? { agentRegistry } : {}),
     });
   return factory;
 }
@@ -348,14 +353,18 @@ export type PhaseRole = 'read-only' | 'read-write';
 export function buildSkillRestrictedProvider(
   allowedTools: string[],
   model: AgentModelInput | undefined,
+  readOnlyBash = false,
 ): ModelProvider {
   // Materialise once per fork so runtime array mutations don't bleed across siblings.
   const permissions = { allowedTools: [...allowedTools] };
   const route = providerForModel(typeof model === 'string' ? model : undefined);
+  // readOnlyBash: forwarded when the restricted surface additionally gates
+  // mutating shell (named agents with `bash: read-only`, cage cap paths).
+  // Default false preserves the original skill-tools call sites unchanged.
   if (route === 'openai-compatible') {
-    return new OpenAICompatibleProvider({ permissions });
+    return new OpenAICompatibleProvider({ permissions, ...(readOnlyBash ? { readOnlyBash: true } : {}) });
   }
-  return new AnthropicDirectProvider({ permissions });
+  return new AnthropicDirectProvider({ permissions, ...(readOnlyBash ? { readOnlyBash: true } : {}) });
 }
 
 /**

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -155,6 +155,14 @@ export interface SkillExecutorContext {
    * Optional: surfaces without a worktree (telegram) leave this unset.
    */
   cwd?: string;
+  /**
+   * Session-wide named-agent registry, forwarded to the child
+   * {@link SubagentExecutor}s this executor constructs so skill-forked
+   * children (the primary orchestrators — review waves, shadow verifiers)
+   * can dispatch `agent_type`-named sub-agents. Same reference at every
+   * depth; see {@link SubagentExecutorContext.agentRegistry}.
+   */
+  agentRegistry?: import('../agents/index.js').AgentRegistry;
 }
 
 interface SkillInput {
@@ -624,6 +632,12 @@ export class SkillExecutor {
       // allowedTools/readOnlyBash and falls back to CHILD_ALLOWED_TOOLS.
       ...(effectiveAllowed !== undefined ? { allowedTools: effectiveAllowed } : {}),
       ...(effectiveReadOnlyBash ? { readOnlyBash: true as const } : {}),
+      // Named-agent registry: the skill-forked child is the primary
+      // orchestrator shape (review waves, verifiers) — it must be able to
+      // dispatch `agent_type`-named sub-agents. The child's model becomes
+      // the grandchildren's `inherit` anchor.
+      ...(this.ctx.agentRegistry !== undefined ? { agentRegistry: this.ctx.agentRegistry } : {}),
+      ...(childConfig.model !== undefined ? { parentModel: childConfig.model } : {}),
     });
     const childSkillExecutor = this.ctx.childSkillExecutorFactory
       ? this.ctx.childSkillExecutorFactory(depth + 1, maxDepth, signal)

--- a/src/agent/tools/subagent-executor.named-agents.test.ts
+++ b/src/agent/tools/subagent-executor.named-agents.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for named-agent (`agent_type`) dispatch through SubagentExecutor.
+ *
+ * Covers: resolution hit/miss, the subagent_type alias, system-prompt
+ * substitution, model precedence (call-site > def > inherit > policy),
+ * maxTurns precedence, allowlist enforcement reaching the child provider
+ * factory, cage intersection, the depth-cap restricted-provider fallback,
+ * render labels, and describeAgentTool discovery.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const appendRoutingDecision = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('../routing-telemetry.js', () => ({ appendRoutingDecision }));
+
+const mockResolveCredentialForModel = vi.hoisted(() =>
+  vi.fn((_model: string | undefined) => 'resolved-test-credential' as string | undefined),
+);
+vi.mock('../auth/credential-resolver.js', () => ({
+  resolveCredentialForModel: mockResolveCredentialForModel,
+  loadAnthropicCredential: vi.fn(() => 'resolved-test-credential'),
+  loadOpenAICredential: vi.fn(() => undefined),
+}));
+
+import type { SubagentHandle, SubagentResult } from '../subagent.js';
+import type { ToolCall } from './types.js';
+import type { ModelProvider } from '../provider.js';
+import { SubagentExecutor, type SubagentExecutorContext } from './subagent-executor.js';
+import { agentTool } from './schemas.js';
+import type { AgentRegistry, RegisteredAgent } from '../agents/index.js';
+
+function mockHandle(): Partial<SubagentHandle> {
+  return {
+    id: 'named-handle',
+    status: 'succeeded' as SubagentHandle['status'],
+    runToResult: vi.fn().mockResolvedValue({
+      id: 'named-handle',
+      status: 'succeeded',
+      message: { role: 'assistant', content: 'ok', timestamp: new Date() },
+    } as SubagentResult),
+    cancel: vi.fn().mockResolvedValue(undefined),
+    teardown: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeCall(input: Record<string, unknown>): ToolCall {
+  return {
+    id: 'call-1',
+    name: 'agent',
+    input,
+    signal: new AbortController().signal,
+  };
+}
+
+function makeRegistry(agents: RegisteredAgent[]): AgentRegistry {
+  return new Map(agents.map((a) => [a.name, a]));
+}
+
+const RESEARCH: RegisteredAgent = {
+  name: 'research-agent',
+  source: 'builtin',
+  definition: {
+    description: 'Read-only research sub-agent',
+    prompt: 'You are the research agent system prompt.',
+    tools: ['Read', 'Grep', 'Glob', 'WebFetch', 'WebSearch'],
+  },
+};
+
+const GIT: RegisteredAgent = {
+  name: 'git-investigator',
+  source: 'builtin',
+  definition: {
+    description: 'Read-only git specialist',
+    prompt: 'You are the git investigator.',
+    tools: ['Bash', 'Read', 'Grep', 'Glob'],
+    model: 'sonnet',
+  },
+  bashReadOnly: true,
+};
+
+const INHERIT_AGENT: RegisteredAgent = {
+  name: 'inheritor',
+  source: 'user',
+  definition: {
+    description: 'inherits model',
+    prompt: 'inherit prompt',
+    model: 'inherit',
+    maxTurns: 4,
+  },
+};
+
+describe('SubagentExecutor named-agent dispatch', () => {
+  let forkSubagent: ReturnType<typeof vi.fn>;
+  let factoryCalls: Array<Record<string, unknown>>;
+  let childProviderFactory: (args: never) => ModelProvider;
+
+  beforeEach(() => {
+    forkSubagent = vi.fn().mockResolvedValue(mockHandle());
+    factoryCalls = [];
+    childProviderFactory = ((args: Record<string, unknown>) => {
+      factoryCalls.push(args);
+      return { name: 'stub-provider' } as unknown as ModelProvider;
+    }) as unknown as (args: never) => ModelProvider;
+  });
+
+  function makeExecutor(overrides?: Partial<SubagentExecutorContext>): SubagentExecutor {
+    const ctx: SubagentExecutorContext = {
+      subagentManager: { forkSubagent, setCwd: vi.fn(), list: () => [] } as never,
+      parentSession: {
+        sessionId: 'parent-1',
+        getInputStreamRef: vi.fn(),
+        abortSignal: new AbortController().signal,
+      } as never,
+      defaultConfig: { apiKey: 'k', systemPrompt: 'BASE PROMPT' },
+      depth: 0,
+      childProviderFactory: childProviderFactory as never,
+      agentRegistry: makeRegistry([RESEARCH, GIT, INHERIT_AGENT]),
+      parentModel: 'opus',
+      ...overrides,
+    };
+    return new SubagentExecutor(ctx);
+  }
+
+  it('fails fast with the available list on unknown agent_type', async () => {
+    const executor = makeExecutor();
+    const result = await executor.execute(
+      makeCall({ prompt: 'x', agent_type: 'nope' }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Agent type "nope" not found');
+    expect(result.content).toContain('git-investigator');
+    expect(result.content).toContain('research-agent');
+    expect(forkSubagent).not.toHaveBeenCalled();
+  });
+
+  it('reports (none) when no registry is wired', async () => {
+    const executor = makeExecutor({ agentRegistry: undefined });
+    const result = await executor.execute(
+      makeCall({ prompt: 'x', agent_type: 'research-agent' }),
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('(none)');
+  });
+
+  it('substitutes the definition prompt, enforces the mapped allowlist, and labels the fork', async () => {
+    const executor = makeExecutor();
+    await executor.execute(makeCall({ prompt: 'go', agent_type: 'research-agent' }));
+
+    expect(forkSubagent).toHaveBeenCalledTimes(1);
+    const forkArgs = forkSubagent.mock.calls[0]?.[0];
+    expect(forkArgs.config.systemPrompt).toBe('You are the research agent system prompt.');
+    expect(forkArgs.agentType).toBe('research-agent');
+
+    // Allowlist reaches the child provider factory in AFK runtime names.
+    expect(factoryCalls).toHaveLength(1);
+    expect(factoryCalls[0]?.['allowedTools']).toEqual([
+      'read_file',
+      'grep',
+      'glob',
+      'web_scrape',
+    ]);
+    expect(factoryCalls[0]?.['readOnlyBash']).toBeUndefined();
+  });
+
+  it('accepts subagent_type as an alias', async () => {
+    const executor = makeExecutor();
+    await executor.execute(makeCall({ prompt: 'go', subagent_type: 'research-agent' }));
+    const forkArgs = forkSubagent.mock.calls[0]?.[0];
+    expect(forkArgs.agentType).toBe('research-agent');
+  });
+
+  it('applies bash: read-only as readOnlyBash on the child provider', async () => {
+    const executor = makeExecutor();
+    await executor.execute(makeCall({ prompt: 'go', agent_type: 'git-investigator' }));
+    expect(factoryCalls[0]?.['allowedTools']).toEqual(['bash', 'read_file', 'grep', 'glob']);
+    expect(factoryCalls[0]?.['readOnlyBash']).toBe(true);
+  });
+
+  it('model precedence: def model > policy default; call-site wins over def', async () => {
+    const executor = makeExecutor({ defaultSubagentModel: 'haiku' });
+    await executor.execute(makeCall({ prompt: 'go', agent_type: 'git-investigator' }));
+    expect(forkSubagent.mock.calls[0]?.[0].config.model).toBe('sonnet');
+
+    forkSubagent.mockClear();
+    await executor.execute(
+      makeCall({ prompt: 'go', agent_type: 'git-investigator', model: 'haiku' }),
+    );
+    expect(forkSubagent.mock.calls[0]?.[0].config.model).toBe('haiku');
+  });
+
+  it('model: inherit resolves to the dispatching session model', async () => {
+    const executor = makeExecutor({ defaultSubagentModel: 'haiku' });
+    await executor.execute(makeCall({ prompt: 'go', agent_type: 'inheritor' }));
+    expect(forkSubagent.mock.calls[0]?.[0].config.model).toBe('opus');
+  });
+
+  it('named dispatch with omitted model inherits the parent model (CC parity)', async () => {
+    const executor = makeExecutor({ defaultSubagentModel: 'haiku' });
+    await executor.execute(makeCall({ prompt: 'go', agent_type: 'research-agent' }));
+    expect(forkSubagent.mock.calls[0]?.[0].config.model).toBe('opus');
+  });
+
+  it('unnamed dispatch keeps the policy default chain', async () => {
+    const executor = makeExecutor({ defaultSubagentModel: 'haiku' });
+    await executor.execute(makeCall({ prompt: 'go' }));
+    expect(forkSubagent.mock.calls[0]?.[0].config.model).toBe('haiku');
+  });
+
+  it('maxTurns: def value applies as default; explicit call-site wins', async () => {
+    const executor = makeExecutor();
+    await executor.execute(makeCall({ prompt: 'go', agent_type: 'inheritor' }));
+    expect(forkSubagent.mock.calls[0]?.[0].config.maxTurns).toBe(4);
+
+    forkSubagent.mockClear();
+    await executor.execute(
+      makeCall({ prompt: 'go', agent_type: 'inheritor', max_turns: 22 }),
+    );
+    expect(forkSubagent.mock.calls[0]?.[0].config.maxTurns).toBe(22);
+  });
+
+  it('intersects the definition allowlist with an existing cage', async () => {
+    const executor = makeExecutor({
+      allowedTools: ['read_file', 'glob', 'bash'],
+      readOnlyBash: true,
+    });
+    await executor.execute(makeCall({ prompt: 'go', agent_type: 'research-agent' }));
+    // def {read_file,grep,glob,web_scrape} ∩ cage {read_file,glob,bash}
+    expect(factoryCalls[0]?.['allowedTools']).toEqual(['read_file', 'glob']);
+    expect(factoryCalls[0]?.['readOnlyBash']).toBe(true);
+  });
+
+  it('falls back to a restricted provider at the depth cap instead of failing open', async () => {
+    const executor = makeExecutor({ depth: 3, maxDepth: 3 });
+    await executor.execute(makeCall({ prompt: 'go', agent_type: 'research-agent' }));
+    expect(factoryCalls).toHaveLength(0); // factory not used at cap
+    const forkArgs = forkSubagent.mock.calls[0]?.[0];
+    // A provider override IS present (the restricted fallback), not undefined.
+    expect(forkArgs.config.provider).toBeDefined();
+  });
+
+  it('unnamed dispatch remains unchanged (no provider restriction, base prompt)', async () => {
+    const executor = makeExecutor();
+    await executor.execute(makeCall({ prompt: 'plain dispatch' }));
+    const forkArgs = forkSubagent.mock.calls[0]?.[0];
+    expect(forkArgs.config.systemPrompt).toBe('BASE PROMPT');
+    expect(factoryCalls[0]?.['allowedTools']).toBeUndefined();
+    expect(forkArgs.agentType).toBe('plain dispatch');
+  });
+
+  describe('describeAgentTool', () => {
+    it('returns the static def without a registry', () => {
+      const executor = makeExecutor({ agentRegistry: undefined });
+      expect(executor.describeAgentTool()).toBe(agentTool);
+    });
+
+    it('advertises registry types with a registry', () => {
+      const executor = makeExecutor();
+      const def = executor.describeAgentTool();
+      expect(def.description).toContain('Available agent types');
+      expect(def.description).toContain('research-agent');
+      expect(def.input_schema.properties).toHaveProperty('agent_type');
+    });
+  });
+});

--- a/src/agent/tools/subagent-executor.named-agents.test.ts
+++ b/src/agent/tools/subagent-executor.named-agents.test.ts
@@ -133,6 +133,31 @@ describe('SubagentExecutor named-agent dispatch', () => {
     expect(forkSubagent).not.toHaveBeenCalled();
   });
 
+  it('surfaces fail-closed dropped tool tokens on stderr (default-visible, not AFK_DEBUG-gated)', async () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    try {
+      const executor = makeExecutor({
+        agentRegistry: makeRegistry([
+          {
+            name: 'misconfigured',
+            source: 'user',
+            definition: {
+              description: 'declares an unknown tool token',
+              prompt: 'p',
+              tools: ['Read', 'NotARealToolToken'],
+            },
+          },
+        ]),
+      });
+      await executor.execute(makeCall({ prompt: 'x', agent_type: 'misconfigured' }));
+      const emitted = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+      expect(emitted).toContain('dropped fail-closed');
+      expect(emitted).toContain('misconfigured');
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
   it('reports (none) when no registry is wired', async () => {
     const executor = makeExecutor({ agentRegistry: undefined });
     const result = await executor.execute(

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -682,9 +682,13 @@ export class SubagentExecutor implements SubagentControl {
     const effectiveReadOnlyBash =
       this.ctx.readOnlyBash === true || resolvedAccess?.bashReadOnly === true;
     if (resolvedAccess !== undefined && resolvedAccess.droppedTokens.length > 0) {
-      debugLog(
-        `[subagent-executor] agent_type ${JSON.stringify(namedAgent?.name)}: ` +
-          `unknown tool token(s) dropped fail-closed: ${resolvedAccess.droppedTokens.join(', ')}`,
+      // Fail-closed token drops silently NARROW the child's tool surface, so a
+      // misconfigured agent file must be visible by default — not only under
+      // AFK_DEBUG. Route through the same stderr sink the agent registry uses
+      // for its load-time warnings (loadAgentRegistry's default `warn`).
+      process.stderr.write(
+        `[afk] agents: agent_type ${JSON.stringify(namedAgent?.name)}: ` +
+          `unknown tool token(s) dropped fail-closed: ${resolvedAccess.droppedTokens.join(', ')}\n`,
       );
     }
 

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -18,12 +18,16 @@ import type { AgentConfig } from '../types/config-types.js';
 import { providerForModel } from '../providers/index.js';
 import { applyParentCredentialFallback } from './child-credential.js';
 import { resolveCredentialForModel } from '../auth/credential-resolver.js';
-import type { ToolCall, ToolResult } from './types.js';
+import type { AnthropicToolDef, ToolCall, ToolResult } from './types.js';
 import {
+  CHILD_ALLOWED_TOOLS,
   DEFAULT_MAX_NESTING_DEPTH,
+  buildSkillRestrictedProvider,
   createStubParentSession,
   type ChildProviderFactoryArgs,
 } from './nesting.js';
+import { buildAgentToolDef, resolveAgentToolAccess } from '../agents/index.js';
+import type { AgentRegistry, RegisteredAgent } from '../agents/index.js';
 import type { SkillExecutor } from './skill-executor.js';
 import { appendRoutingDecision } from '../routing-telemetry.js';
 import { debugLog } from '../../utils/debug.js';
@@ -149,6 +153,26 @@ export interface SubagentExecutorContext {
    * Set together with `allowedTools` for read-only skill fan-out propagation.
    */
   readOnlyBash?: boolean;
+  /**
+   * Session-wide named-agent registry (see `agent/agents/`). When present,
+   * the `agent` tool accepts an `agent_type` (alias `subagent_type`) input
+   * that dispatches the named definition: its body becomes the child's
+   * system prompt, its resolved tool allowlist is mechanically enforced at
+   * the child provider's permission gate, and its `model`/`maxTurns` act as
+   * defaults under explicit per-call values. Threaded by reference through
+   * nested executors so depth ≥ 2 dispatches resolve the same registry.
+   * When absent, `agent_type` inputs fail with an "available: (none)" error
+   * and the legacy dispatch path is byte-identical.
+   */
+  agentRegistry?: AgentRegistry;
+  /**
+   * The dispatching session's own model. Used to resolve a named agent's
+   * `model: inherit` (and the omitted-model default for NAMED dispatches,
+   * Claude Code parity). Distinct from `defaultSubagentModel`, which is the
+   * cost-policy default for UNNAMED dispatches and stays authoritative for
+   * them. When unset, `inherit` falls back to the policy default chain.
+   */
+  parentModel?: AgentModelInput;
 }
 
 export type AgentExecutionMode = 'foreground' | 'background';
@@ -194,7 +218,19 @@ interface AgentInput {
   prompt: string;
   model?: string;
   max_turns?: number;
+  /**
+   * True when the caller supplied `max_turns` explicitly. Distinguishes the
+   * parse-time default (10) from a deliberate value so a named agent's
+   * `maxTurns` frontmatter can act as the default without being able to
+   * override an explicit per-call budget.
+   */
+  max_turns_explicit: boolean;
   id_prefix?: string;
+  /**
+   * Named agent type to dispatch (`agent_type`, alias `subagent_type`).
+   * Resolved against {@link SubagentExecutorContext.agentRegistry}.
+   */
+  agent_type?: string;
   /** Execution mode. Defaults to 'foreground' (existing await-and-return semantic). */
   mode: AgentExecutionMode;
   /**
@@ -249,6 +285,7 @@ function parseAgentInput(input: unknown): AgentInput {
   }
 
   let max_turns = 10;
+  let max_turns_explicit = false;
   const maxTurnsValue = agentInput['max_turns'];
   if (maxTurnsValue !== undefined) {
     if (typeof maxTurnsValue !== 'number') {
@@ -256,6 +293,20 @@ function parseAgentInput(input: unknown): AgentInput {
     }
     // Clamp to [1, 50]
     max_turns = Math.max(1, Math.min(50, Math.floor(maxTurnsValue)));
+    max_turns_explicit = true;
+  }
+
+  // agent_type: canonical param; `subagent_type` accepted as an alias for
+  // Claude Code-ported prompts (bundled SKILL.mds already write it). When
+  // both are present the canonical name wins.
+  let agent_type: string | undefined;
+  const agentTypeValue = agentInput['agent_type'] ?? agentInput['subagent_type'];
+  if (agentTypeValue !== undefined) {
+    if (typeof agentTypeValue !== 'string') {
+      throw new Error('Agent tool agent_type must be a string');
+    }
+    const trimmed = agentTypeValue.trim();
+    if (trimmed.length > 0) agent_type = trimmed;
   }
 
   let id_prefix = 'agent-tool';
@@ -318,7 +369,16 @@ function parseAgentInput(input: unknown): AgentInput {
     cwd = cwdValue;
   }
 
-  return { prompt, model, max_turns, id_prefix, mode, ...(cwd !== undefined ? { cwd } : {}) };
+  return {
+    prompt,
+    model,
+    max_turns,
+    max_turns_explicit,
+    id_prefix,
+    mode,
+    ...(agent_type !== undefined ? { agent_type } : {}),
+    ...(cwd !== undefined ? { cwd } : {}),
+  };
 }
 
 /**
@@ -437,6 +497,19 @@ export class SubagentExecutor implements SubagentControl {
   }
 
   /**
+   * The `agent` tool definition this executor's owning provider should
+   * advertise. With a non-empty named-agent registry, the definition gains
+   * the `agent_type` input property and an "Available agent types" listing
+   * (Claude Code advertises subagent types in its Task tool the same way).
+   * Without one, returns the static schema byte-identical to the legacy
+   * surface. Providers call this via optional chaining so stubbed executors
+   * in tests fall back to the static def.
+   */
+  describeAgentTool(): AnthropicToolDef {
+    return buildAgentToolDef(this.ctx.agentRegistry);
+  }
+
+  /**
    * In-flight foreground subagents that can be promoted to background, keyed
    * by `handle.id`. Each entry is registered by the foreground branch of
    * {@link execute} immediately before its run-vs-promotion race and removed
@@ -523,6 +596,24 @@ export class SubagentExecutor implements SubagentControl {
       };
     }
 
+    // Named-agent resolution. A miss fails fast with the available list
+    // (mirrors skill-executor.ts's "Skill not found. Available skills: …")
+    // rather than silently dispatching an unrestricted generic child under
+    // a name the caller believed carried constraints.
+    let namedAgent: RegisteredAgent | undefined;
+    if (parsed.agent_type !== undefined) {
+      namedAgent = this.ctx.agentRegistry?.get(parsed.agent_type);
+      if (namedAgent === undefined) {
+        const available = [...(this.ctx.agentRegistry?.keys() ?? [])].sort().join(', ');
+        return {
+          content:
+            `Agent type "${parsed.agent_type}" not found. ` +
+            `Available agent types: ${available.length > 0 ? available : '(none)'}`,
+          isError: true,
+        };
+      }
+    }
+
     // Build child config.
     //
     // Invariant: `ctx.depth` is required (see SubagentExecutorContext.depth
@@ -550,8 +641,60 @@ export class SubagentExecutor implements SubagentControl {
     // `resolveOpenAIAuth()` to return the Anthropic key as if it were a config
     // OpenAI key (tier 1 wins) — the OpenAI API then 401s. Clearing them lets
     // the OpenAI auth resolver walk its env / codex precedence cleanly.
-    const childModel: string = parsed.model ?? this.ctx.defaultSubagentModel ?? 'sonnet';
+    // Model resolution.
+    //   Unnamed dispatch (legacy, unchanged): call-site > policy default > 'sonnet'.
+    //   Named dispatch (Claude Code parity): call-site > definition model
+    //   ('inherit' → dispatching session's model) > inherit-by-default
+    //   (omitted model also means inherit) > policy default > 'sonnet'.
+    // `parentModel` is optional ctx wiring; when absent, inherit falls
+    // through to the policy chain rather than guessing.
+    let namedDefaultModel: string | undefined;
+    if (namedAgent !== undefined) {
+      const defModel = namedAgent.definition.model;
+      namedDefaultModel =
+        defModel !== undefined && defModel !== 'inherit'
+          ? defModel
+          : this.ctx.parentModel;
+    }
+    const childModel: string =
+      parsed.model ?? namedDefaultModel ?? this.ctx.defaultSubagentModel ?? 'sonnet';
     const childIsOpenAI = providerForModel(childModel) === 'openai-compatible';
+
+    // Named-agent tool access: resolve the definition's declared surface into
+    // runtime terms, then compose with any cage this executor already sits in
+    // (a read-only skill's fan-out). Composition is fail-closed:
+    //   allowlist  = def ∩ cage   (when both exist; either alone otherwise)
+    //   bash gate  = def ∨ cage
+    // — mirroring skill-executor.ts buildForkedChildConfig's intersection
+    // semantics, so a named dispatch can never widen an existing cage.
+    const resolvedAccess =
+      namedAgent !== undefined
+        ? resolveAgentToolAccess(namedAgent, CHILD_ALLOWED_TOOLS)
+        : undefined;
+    let effectiveAllowedTools: string[] | undefined = this.ctx.allowedTools;
+    if (resolvedAccess?.allowedTools !== undefined) {
+      const cage = this.ctx.allowedTools;
+      effectiveAllowedTools =
+        cage !== undefined
+          ? resolvedAccess.allowedTools.filter((t) => cage.includes(t))
+          : resolvedAccess.allowedTools;
+    }
+    const effectiveReadOnlyBash =
+      this.ctx.readOnlyBash === true || resolvedAccess?.bashReadOnly === true;
+    if (resolvedAccess !== undefined && resolvedAccess.droppedTokens.length > 0) {
+      debugLog(
+        `[subagent-executor] agent_type ${JSON.stringify(namedAgent?.name)}: ` +
+          `unknown tool token(s) dropped fail-closed: ${resolvedAccess.droppedTokens.join(', ')}`,
+      );
+    }
+
+    // Turn budget: explicit per-call max_turns wins; otherwise a named
+    // agent's maxTurns frontmatter (clamped to the same [1, 50] envelope);
+    // otherwise the parse-time default.
+    const effectiveMaxTurns =
+      !parsed.max_turns_explicit && namedAgent?.definition.maxTurns !== undefined
+        ? Math.max(1, Math.min(50, Math.floor(namedAgent.definition.maxTurns)))
+        : parsed.max_turns;
 
     // Resolve the child's API key by its own model/provider. The resolver is
     // now available directly from the agent layer (resolveCredentialForModel),
@@ -578,9 +721,12 @@ export class SubagentExecutor implements SubagentControl {
     const childConfig: AgentConfig = {
       model: childModel,
       apiKey: childIsOpenAI ? undefined : resolvedChildApiKey,
-      systemPrompt: this.ctx.defaultConfig.systemPrompt,
+      // A named agent's markdown body IS the child's system prompt (Claude
+      // Code parity: subagents receive the definition prompt, not the parent
+      // surface's full prompt). Unnamed dispatches keep the raw base prompt.
+      systemPrompt: namedAgent !== undefined ? namedAgent.definition.prompt : this.ctx.defaultConfig.systemPrompt,
       baseUrl: childIsOpenAI ? undefined : this.ctx.defaultConfig.baseUrl,
-      maxTurns: parsed.max_turns,
+      maxTurns: effectiveMaxTurns,
       // Awareness metadata (Phase 1, get_runtime_state):
       // Thread depth + maxDepth into the child's AgentConfig so the
       // `self` view of the child's get_runtime_state snapshot reflects
@@ -641,8 +787,17 @@ export class SubagentExecutor implements SubagentControl {
         // Propagate read-only constraints so depth ≥ 2 forks (this depth-1
         // child calling the `agent` tool) keep the same tool allowlist and
         // bash gate that the originating read-only skill imposed.
+        //
+        // Deliberately the CAGE (ctx) values, not the named-agent effective
+        // values: a named definition constrains the child it dispatches, not
+        // that child's own descendants (Claude Code parity — nested spawns
+        // resolve their own agent types). The cage, by contrast, cascades.
         ...(this.ctx.allowedTools !== undefined ? { allowedTools: this.ctx.allowedTools } : {}),
         ...(this.ctx.readOnlyBash ? { readOnlyBash: true } : {}),
+        // Named-agent registry + the child's model (for grandchild `inherit`
+        // resolution) thread through every depth.
+        ...(this.ctx.agentRegistry !== undefined ? { agentRegistry: this.ctx.agentRegistry } : {}),
+        parentModel: childModel,
       });
       const childSkillExecutor = this.ctx.childSkillExecutorFactory
         ? this.ctx.childSkillExecutorFactory(depth + 1, maxDepth, call.signal)
@@ -656,16 +811,30 @@ export class SubagentExecutor implements SubagentControl {
         childExecutor,
         ...(childSkillExecutor !== undefined ? { childSkillExecutor } : {}),
         ...(childConfig.model !== undefined ? { model: childConfig.model } : {}),
-        // Read-only propagation: when this executor is itself a read-only
-        // skill's child (e.g. ground-state fanning out via `agent`), forward
-        // the allowlist and bash gate so the grandchild provider stays gated.
-        // Mirrors skill-executor.ts:522 for the `agent` tool fan-out path.
-        ...(this.ctx.allowedTools !== undefined ? { allowedTools: this.ctx.allowedTools } : {}),
-        ...(this.ctx.readOnlyBash ? { readOnlyBash: true } : {}),
+        // Effective tool access for the dispatched child: the pre-existing
+        // cage (read-only skill fan-out), intersected with the named agent's
+        // resolved allowlist when one is in play (computed above). The
+        // dispatcher both enforces this at the permission gate AND filters
+        // the advertised schema to match (dispatcher.ts toolDefs), so a
+        // research-agent child never even sees bash/write_file/agent.
+        ...(effectiveAllowedTools !== undefined ? { allowedTools: effectiveAllowedTools } : {}),
+        ...(effectiveReadOnlyBash ? { readOnlyBash: true } : {}),
       });
+    } else if (effectiveAllowedTools !== undefined || effectiveReadOnlyBash) {
+      // Restricted dispatch at the depth cap (or with no factory wired):
+      // without an explicit provider the fork would inherit the default
+      // UNRESTRICTED provider and the named agent's contract would silently
+      // fail open. Build a minimal restricted provider instead — no nested
+      // executors (at the cap the child cannot fan out anyway). Mirrors the
+      // cap-path fix in skill-executor.ts buildForkedChildConfig.
+      childConfig.provider = buildSkillRestrictedProvider(
+        effectiveAllowedTools ?? [...CHILD_ALLOWED_TOOLS],
+        childConfig.model,
+        effectiveReadOnlyBash,
+      );
     }
 
-    let handle: Awaited<ReturnType<typeof this.ctx.subagentManager.forkSubagent>>;
+    let handle: Awaited<ReturnType<SubagentManager['forkSubagent']>>;
     try {
       handle = await this.ctx.subagentManager.forkSubagent({
         parent: this.ctx.parentSession,
@@ -682,9 +851,14 @@ export class SubagentExecutor implements SubagentControl {
         // flag that passes embedded newlines through). Strip ANSI escapes
         // and collapse interior newlines BEFORE slicing, so the rendered
         // line cannot be split mid-glyph or injected with control codes.
-        agentType: (parsed.id_prefix && parsed.id_prefix !== 'agent-tool')
-          ? stripEscapeSequences(parsed.id_prefix).replace(/[\r\n]+/g, ' ').trim() || 'agent'
-          : stripEscapeSequences(parsed.prompt).replace(/[\r\n]+/g, ' ').slice(0, 40).trim() || 'agent',
+        // Named dispatches render as Agent(<type>) — the registry name is
+        // trusted display input (already validated at registration). Unnamed
+        // dispatches keep the id_prefix / prompt-slice derivation.
+        agentType: namedAgent !== undefined
+          ? namedAgent.name
+          : (parsed.id_prefix && parsed.id_prefix !== 'agent-tool')
+            ? stripEscapeSequences(parsed.id_prefix).replace(/[\r\n]+/g, ' ').trim() || 'agent'
+            : stripEscapeSequences(parsed.prompt).replace(/[\r\n]+/g, ' ').slice(0, 40).trim() || 'agent',
         // A forked sub-agent has no human relationship of its own: it returns
         // findings (including Blocked/Asking) to its PARENT, which owns the
         // operator surface. Deny MCP elicitation for BOTH foreground and

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -201,11 +201,15 @@ export interface AgentConfig {
   mcpManager?: import('../mcp/index.js').McpManager;
 
   /**
-   * Subagent definitions. NOT currently consumed by AFK's harness — reserved
-   * for future SDK V2 support. AFK's SubagentManager forks via the `agent`/
-   * `skill`/`compose` tools, not this registry, so populating `agents` is a
-   * silent no-op today; do not rely on it for nested dispatch. See
-   * skills/_agents/to-definition.ts (toAgentDefinition).
+   * Programmatic named-agent definitions, merged into the session's
+   * named-agent registry at the HIGHEST precedence (above project/user file
+   * scopes — the analog of Claude Code's `--agents` CLI tier). Consumed by
+   * surfaces that pass it to `loadAgentRegistry({ configAgents })`; the
+   * registry powers the `agent` tool's `agent_type` dispatch (see
+   * `src/agent/agents/`). Keys are agent names; values follow the
+   * {@link AgentDefinition} shape (`prompt` = system prompt, `tools`/
+   * `disallowedTools` in Claude Code or AFK tool vocabulary, `model`,
+   * `maxTurns`; long-tail fields are tolerated but not honored yet).
    */
   agents?: Record<string, AgentDefinition>;
 

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -203,9 +203,16 @@ export interface AgentConfig {
   /**
    * Programmatic named-agent definitions, merged into the session's
    * named-agent registry at the HIGHEST precedence (above project/user file
-   * scopes — the analog of Claude Code's `--agents` CLI tier). Consumed by
-   * surfaces that pass it to `loadAgentRegistry({ configAgents })`; the
-   * registry powers the `agent` tool's `agent_type` dispatch (see
+   * scopes — the analog of Claude Code's `--agents` CLI tier).
+   *
+   * NOT wired into any built-in surface today: the one-shot chat, daemon,
+   * REPL, and Telegram bootstraps all call `loadAgentRegistry({ cwd })`
+   * WITHOUT `configAgents`, and no config-file field populates this — so it
+   * is a no-op unless a programmatic embedder builds the registry itself via
+   * `loadAgentRegistry({ configAgents })`. File-scope agents (`.afk/agents/`,
+   * `.claude/agents/`, `~/.afk/agents/`) are the supported path today.
+   *
+   * The registry powers the `agent` tool's `agent_type` dispatch (see
    * `src/agent/agents/`). Keys are agent names; values follow the
    * {@link AgentDefinition} shape (`prompt` = system prompt, `tools`/
    * `disallowedTools` in Claude Code or AFK tool vocabulary, `model`,

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -24,6 +24,7 @@ import { SkillExecutor } from '../../agent/tools/skill-executor.js';
 import { ComposeExecutor } from '../../agent/tools/compose-executor.js';
 import { ensurePluginEntrypointsLoaded } from '../../agent/tools/skill-bridge.js';
 import { createChildProviderFactory, createChildSkillExecutorFactory } from '../../agent/tools/nesting.js';
+import { loadAgentRegistry } from '../../agent/agents/index.js';
 import { AnthropicDirectProvider } from '../../agent/providers/anthropic-direct/index.js';
 import { createDefaultTraceWriter } from '../../agent/trace/factory.js';
 import { receiptPathsFor } from '../../agent/trace/receipt.js';
@@ -470,6 +471,13 @@ export function registerChatCommand(program: Command): void {
         // and `skill` tools, see anthropic-direct/index.ts:108–110) and
         // any SKILL.md instruction to "dispatch sub-agents via the Agent
         // tool" becomes unimplementable.
+        // Named-agent registry: session-static scan (builtin + user
+        // ~/.afk/agents + project .afk/agents & .claude/agents). Enables
+        // `agent_type` dispatch on the `agent` tool at every depth.
+        const agentRegistry = loadAgentRegistry({
+          ...(worktreeCwd !== undefined ? { cwd: worktreeCwd } : {}),
+        });
+
         const childSkillExecutorFactory = createChildSkillExecutorFactory(
           options.model,
           apiKey,
@@ -492,6 +500,8 @@ export function registerChatCommand(program: Command): void {
           // nested subagent silently defaulted to Anthropic `sonnet` under an
           // OpenAI-routed parent.
           getDefaultSubagentModel(options.model),
+          // Named-agent registry propagates to nested skill executors.
+          agentRegistry,
         );
 
         // Pass `options.model` so `getDefaultSubagentModel` can fall back
@@ -521,6 +531,10 @@ export function registerChatCommand(program: Command): void {
           // Worktree isolation for depth ≥ 2 `agent` dispatch. See
           // bootstrap.ts for the same wiring.
           ...(worktreeCwd !== undefined ? { cwd: worktreeCwd } : {}),
+          // Named-agent dispatch: registry + the session model as the
+          // `inherit` anchor for named-agent model resolution.
+          agentRegistry,
+          parentModel: options.model,
         });
 
         const skillExecutor = new SkillExecutor({
@@ -532,6 +546,8 @@ export function registerChatCommand(program: Command): void {
           apiKey,
           childProviderFactory,
           childSkillExecutorFactory,
+          // Named-agent registry for skill-forked orchestrator children.
+          agentRegistry,
           ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
           // Per-model credential resolver — mirrors bootstrap.ts wiring.
           resolveApiKeyForModel: getApiKeyForModel,

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -31,6 +31,7 @@ import { SkillExecutor } from '../../agent/tools/skill-executor.js';
 import { ComposeExecutor } from '../../agent/tools/compose-executor.js';
 import { ensurePluginEntrypointsLoaded } from '../../agent/tools/skill-bridge.js';
 import { createChildProviderFactory, createChildSkillExecutorFactory, createStubParentSession } from '../../agent/tools/nesting.js';
+import { loadAgentRegistry } from '../../agent/agents/index.js';
 import { AnthropicDirectProvider } from '../../agent/providers/anthropic-direct/index.js';
 import { BUILTIN_TOOL_NAMES } from '../../agent/tools/schemas.js';
 import { MEMORY_TOOL_NAMES } from '../../agent/memory/index.js';
@@ -98,6 +99,12 @@ export function buildDaemonSessionFactory(
       opts.openaiBaseUrl !== undefined ? { openaiBaseUrl: opts.openaiBaseUrl } : {},
     );
 
+    // Named-agent registry: session-static scan enabling `agent_type`
+    // dispatch for daemon-run tasks (builtin + user + project scopes).
+    const agentRegistry = loadAgentRegistry({
+      ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+    });
+
     const childSkillExecutorFactory = createChildSkillExecutorFactory(
       opts.model,
       opts.apiKey,
@@ -117,6 +124,8 @@ export function buildDaemonSessionFactory(
       // top-level executors — closing the leak where a nested subagent
       // silently defaulted to Anthropic `sonnet` under an OpenAI-routed parent.
       getDefaultSubagentModel(opts.model),
+      // Named-agent registry propagates to nested skill executors.
+      agentRegistry,
     );
 
     const subagentExecutor = new SubagentExecutor({
@@ -135,6 +144,9 @@ export function buildDaemonSessionFactory(
       resolveApiKeyForModel: getApiKeyForModel,
       depth: 0,
       ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+      // Named-agent dispatch: registry + `inherit` anchor.
+      agentRegistry,
+      parentModel: opts.model,
     });
 
     const skillExecutor = new SkillExecutor({
@@ -146,6 +158,8 @@ export function buildDaemonSessionFactory(
       ...(opts.apiKey !== undefined ? { apiKey: opts.apiKey } : {}),
       childProviderFactory,
       childSkillExecutorFactory,
+      // Named-agent registry for skill-forked orchestrator children.
+      agentRegistry,
       // Per-model credential resolver — mirrors bootstrap.ts / chat.ts.
       resolveApiKeyForModel: getApiKeyForModel,
       ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -47,6 +47,7 @@ import { setBgsubRegistry, setBgsubSummarizer } from '../../slash/commands/bgsub
 import { SkillExecutor } from '../../../agent/tools/skill-executor.js';
 import { ComposeExecutor } from '../../../agent/tools/compose-executor.js';
 import { createChildProviderFactory, createChildSkillExecutorFactory } from '../../../agent/tools/nesting.js';
+import { loadAgentRegistry } from '../../../agent/agents/index.js';
 import { AnthropicDirectProvider } from '../../../agent/providers/anthropic-direct/index.js';
 import { seedPersistedGrants } from '../../../agent/permissions-store.js';
 import { providerForModel } from '../../../agent/providers/index.js';
@@ -272,6 +273,13 @@ export async function bootstrapSession(
   // depth — root → skill-forked child → skill-forked grandchild. Without
   // this, the dispatch fast-fails with a 163-byte "BackgroundAgentRegistry
   // is not wired" error after ~24ms (no model call).
+  // Named-agent registry: session-static scan (builtin + user ~/.afk/agents
+  // + project .afk/agents & .claude/agents). Enables `agent_type` dispatch
+  // on the `agent` tool at every depth of this REPL session.
+  const agentRegistry = loadAgentRegistry({
+    ...(extras?.cwd !== undefined ? { cwd: extras.cwd } : {}),
+  });
+
   const childSkillExecutorFactory = createChildSkillExecutorFactory(
     sessionModel,
     apiKey,
@@ -295,6 +303,8 @@ export async function bootstrapSession(
     // executors below — closing the leak where a nested subagent silently
     // defaulted to Anthropic `sonnet` under an OpenAI-routed parent.
     getDefaultSubagentModel(sessionModel),
+    // Named-agent registry propagates to nested skill executors.
+    agentRegistry,
   );
 
   // Pass `sessionModel` to `getDefaultSubagentModel` so OpenAI-routed
@@ -326,6 +336,10 @@ export async function bootstrapSession(
     // already carries cwd for depth-1, but the per-call childManager
     // constructed inside SubagentExecutor.execute() needs cwd too.
     ...(extras?.cwd !== undefined ? { cwd: extras.cwd } : {}),
+    // Named-agent dispatch: registry + the session model as the `inherit`
+    // anchor for named-agent model resolution.
+    agentRegistry,
+    parentModel: sessionModel,
   });
 
   const skillExecutor = new SkillExecutor({
@@ -337,6 +351,8 @@ export async function bootstrapSession(
     apiKey,
     childProviderFactory,
     childSkillExecutorFactory,
+    // Named-agent registry for skill-forked orchestrator children.
+    agentRegistry,
     // Background dispatch: a plugin skill's subagent calling `agent` with
     // `mode:"background"` is the SKILL.md "Dispatch N sub-agents in parallel"
     // idiom — `/research`, `/diagnose`, `/shadow-verify`, etc. The registry

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -53,6 +53,7 @@ import { SubagentExecutor } from './agent/tools/subagent-executor.js';
 import { SkillExecutor } from './agent/tools/skill-executor.js';
 import { ComposeExecutor } from './agent/tools/compose-executor.js';
 import { createChildProviderFactory, createChildSkillExecutorFactory } from './agent/tools/nesting.js';
+import { loadAgentRegistry } from './agent/agents/index.js';
 import { attachMcpCleanup, loadTelegramMcpManager } from './telegram/mcp-session.js';
 
 // Capture version once at module load. Used by checkVersionDrift on each stats tick.
@@ -263,6 +264,12 @@ async function main() {
 
         const childProviderFactory = createChildProviderFactory();
 
+        // Named-agent registry: session-static scan enabling `agent_type`
+        // dispatch (builtin + user + project scopes, anchored at the bot cwd).
+        const agentRegistry = loadAgentRegistry({
+          ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
+        });
+
         // Shared child-skill-executor factory — both SubagentExecutor and
         // SkillExecutor need it for plugin skill children to nest properly.
         // See skill-executor.ts:buildForkedChildConfig for the wiring rationale.
@@ -284,6 +291,8 @@ async function main() {
           // nested subagent silently defaulted to Anthropic `sonnet` under an
           // OpenAI-routed parent.
           getDefaultSubagentModel(sessionConfig.model),
+          // Named-agent registry propagates to nested skill executors.
+          agentRegistry,
         );
 
         // Pass `sessionConfig.model` to `getDefaultSubagentModel` for
@@ -308,6 +317,9 @@ async function main() {
           resolveApiKeyForModel: getApiKeyForModel,
           // Top-level Telegram wiring → explicit depth 0. See SubagentExecutorContext.depth.
           depth: 0,
+          // Named-agent dispatch: registry + `inherit` anchor.
+          agentRegistry,
+          parentModel: sessionConfig.model,
         });
 
         const skillExecutor = new SkillExecutor({
@@ -318,6 +330,8 @@ async function main() {
           defaultSubagentModel: getDefaultSubagentModel(sessionConfig.model),
           apiKey: telegramApiKey,
           childProviderFactory,
+          // Named-agent registry for skill-forked orchestrator children.
+          agentRegistry,
           childSkillExecutorFactory,
           // Per-model credential resolver — mirrors bootstrap.ts / chat.ts.
           resolveApiKeyForModel: getApiKeyForModel,


### PR DESCRIPTION
## What

Wires the long-documented `AgentSessionConfig.agents` placeholder into a full named-agent system, giving AFK's `agent` tool Claude Code subagent parity — while keeping the tool named `agent` (not `Task`).

A named agent is a reusable subagent definition — system prompt, tool allowlist, model, turn budget — addressable via a new `agent_type` parameter (alias: `subagent_type`). The on-disk format is Claude Code's subagent markdown (YAML frontmatter + body-as-system-prompt), so existing `.claude/agents/` files work unmodified.

## Why

Diagnosed from a real incident: the `review` skill's sub-agents were firing ~296 raw bash calls across a depth-3 fork tree in one run. Root cause — the plugin's `research-agent` role (mechanically locked to Read/Grep/Glob, no Bash) has no way to express itself through AFK's `agent` tool, which accepts only `prompt/model/max_turns/id_prefix/mode/cwd`. Every bundled orchestration skill (review, shadow-verify, devils-advocate, research, ship, refactor) already writes `subagent_type: "research-agent"` in its prompt — the parameter just didn't exist, so models improvised unrestricted recursive fan-out instead.

## What's in this PR (Waves 1–3 of the plan)

New module `src/agent/agents/`:
- **`registry.ts`** — precedence-ordered scan: builtin → user (`~/.afk/agents/`) → project (`.claude/agents/` then `.afk/agents/`) → config (programmatic, highest). Recursive directory scan, identity from frontmatter `name` (not filename), same-scope duplicates warn-and-keep-first, cross-scope duplicates shadow silently by design.
- **`parser.ts`** — Claude Code subagent markdown parser: `name`/`description` required, `tools`/`disallowedTools`/`model`/`maxTurns` parsed, long-tail fields (`permissionMode`, `memory`, `hooks`, `skills`, `background`, `effort`, `isolation`, `color`, `initialPrompt`) tolerated and recorded rather than rejected. Also accepts `allowed-tools` (agentskills.io spec field) as an alias, tokenized on both commas and whitespace.
- **`resolve.ts`** — bridges Claude Code's PascalCase tool vocabulary (`Read`, `Bash`, `Task`, `WebFetch`, …) to AFK's snake_case runtime names, reusing the same `normalizeToolToken` map the plugin SKILL.md parser uses. Deny-first semantics (`disallowedTools` subtracted before `tools` resolves), `Task`/`Agent` map to AFK's `agent` tool as **opt-in** nesting, `mcp__*` passthrough, unknown tokens dropped fail-closed and reported.
- **`builtins.ts`** — four built-in types: `research-agent` and `git-investigator` (wrapping the existing vendored, byte-pinned definitions — never edited), plus AFK-authored `general-purpose` (inherit-all) and `Explore` (read-only, haiku) for Claude Code prompt portability.
- **`tool-def.ts`** — builds the `agent` tool definition dynamically, appending an "Available agent types" listing to the description when a registry is present; returns the static schema unchanged otherwise (no behavior change for callers without a registry).

Executor wiring (`subagent-executor.ts`):
- `agent_type` (or `subagent_type`) resolves against the registry; a miss fails fast with the available-types list (mirrors the existing skill-not-found error shape).
- A hit substitutes the definition body as the child's system prompt, mechanically enforces the mapped allowlist **at the child provider's permission gate** (schema-filtered too — the child never even sees a denied tool), and resolves model as call-site → definition (`inherit` → dispatching session's model) → policy default, maxTurns as call-site → definition → default.
- Composes with any existing read-only cage by intersection (never widens a cage a parent skill already imposed).
- **Depth-cap hardening**: a restricted dispatch that hits the nesting cap (or has no child-provider factory) now gets an explicit restricted fallback provider instead of silently inheriting the unrestricted default — closing a latent fail-open in the existing cap path.
- Registry + resolved parent model thread through both the `agent` and `skill` nesting chains, wired at all four top-level surfaces (REPL, one-shot `chat`, daemon, Telegram).

## Result

The bundled orchestration skills that already write `subagent_type: "research-agent"` resolve correctly with **zero prompt changes** — dispatching a mechanically-locked read-only agent instead of a full-surface child that can recurse. This is the direct fix for the reported bash-explosion.

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm test` — **10,524 passed / 0 failed / 14 skipped** (572 files), including 48 new tests covering parser edge cases, tool-resolution semantics (deny-first, paren-group handling, mcp passthrough, dedup), registry precedence/duplicates/malformed-file resilience, dynamic tool-def building, and executor integration (resolution hit/miss, alias, prompt substitution, model/maxTurns precedence, cage intersection, depth-cap fallback, render labels)
- Post-build smoke against `dist/` confirmed registry load, builtin presence, and frontmatter-stripped prompts (caught and fixed one bug: vendored agent wrappers expose raw markdown including frontmatter — second commit strips it via the parser rather than the raw file)

## Out of scope (follow-up waves, tracked in `.afk/plans/named-agents.md` locally)

- Plugin `agents/` directory scanning (plugin-scoped agent types)
- `/agents` slash command
- `compose` per-node `agent_type`
- Issue #276 skills-side compat (`allowed-tools` alias in the plugin SKILL.md parser, `afk migrate` importing `.claude/agents/`)
- `docs/agents.md`
- Live verification that a real `/review` run's bash volume collapses (mechanically implied by the allowlist enforcement, not yet re-run end-to-end)

## Risk notes

- Backward compatible: omitting `agent_type` is byte-identical to current behavior (verified by the full existing test suite passing unmodified).
- Vendored byte-equality (`vendored.test.ts`) is untouched — builtins wrap the vendored modules, never edit them.
- `WebFetch`/`WebSearch` both map to AFK's single `web_scrape` tool — granting one grants both modes (documented in code).
