### PR TITLE
fix(agent): bound subagent fan-out in compose/DAG layers and runWave

### DIFF
--- a/src/agent/concurrency-pool.test.ts
+++ b/src/agent/concurrency-pool.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for the shared bounded-concurrency worker pool
+ * (`settleWithConcurrencyLimit`) reused by the tool dispatcher, the compose/DAG
+ * layer executor, and the skill wave runner.
+ *
+ * Verifies: input-order results, cap enforcement, parallel behaviour when the
+ * cap is slack, the floor-at-1 degenerate case, empty input, and in-place
+ * rejection capture without failing siblings.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  settleWithConcurrencyLimit,
+  DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS,
+} from './concurrency-pool.js';
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+describe('settleWithConcurrencyLimit', () => {
+  it('returns results in input order regardless of completion order', async () => {
+    // item 0 finishes slowest, item 2 fastest — order must still be [0,1,2].
+    const out = await settleWithConcurrencyLimit([30, 20, 10], 3, async (ms) => {
+      await sleep(ms);
+      return ms;
+    });
+    expect(out.map((r) => (r.status === 'fulfilled' ? r.value : null))).toEqual([30, 20, 10]);
+  });
+
+  it('runs at most `limit` workers simultaneously', async () => {
+    let live = 0;
+    let peak = 0;
+    await settleWithConcurrencyLimit([...Array(6).keys()], 2, async (n) => {
+      live++;
+      peak = Math.max(peak, live);
+      await sleep(20);
+      live--;
+      return n;
+    });
+    expect(peak).toBe(2);
+  });
+
+  it('with limit >= items.length runs everything in parallel (peak === length)', async () => {
+    let live = 0;
+    let peak = 0;
+    await settleWithConcurrencyLimit([...Array(4).keys()], 10, async (n) => {
+      live++;
+      peak = Math.max(peak, live);
+      await sleep(15);
+      live--;
+      return n;
+    });
+    expect(peak).toBe(4);
+  });
+
+  it('floors a non-positive limit to 1 (sequential, peak === 1)', async () => {
+    let live = 0;
+    let peak = 0;
+    await settleWithConcurrencyLimit([1, 2, 3], 0, async (n) => {
+      live++;
+      peak = Math.max(peak, live);
+      await sleep(10);
+      live--;
+      return n;
+    });
+    expect(peak).toBe(1);
+  });
+
+  it('returns [] for empty items without invoking the worker', async () => {
+    let calls = 0;
+    const out = await settleWithConcurrencyLimit([], 4, async () => {
+      calls++;
+      return 1;
+    });
+    expect(out).toEqual([]);
+    expect(calls).toBe(0);
+  });
+
+  it('captures a worker rejection in place without failing siblings', async () => {
+    const out = await settleWithConcurrencyLimit([0, 1, 2], 3, async (n) => {
+      if (n === 1) throw new Error('boom');
+      return n;
+    });
+    expect(out[0]).toEqual({ status: 'fulfilled', value: 0 });
+    const r1 = out[1]!;
+    expect(r1.status).toBe('rejected');
+    if (r1.status === 'rejected') expect(r1.reason).toBeInstanceOf(Error);
+    expect(out[2]).toEqual({ status: 'fulfilled', value: 2 });
+  });
+
+  it('DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS is a positive integer >= 2', () => {
+    expect(Number.isInteger(DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS)).toBe(true);
+    expect(DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/agent/concurrency-pool.ts
+++ b/src/agent/concurrency-pool.ts
@@ -1,0 +1,78 @@
+/**
+ * Bounded-concurrency worker pool shared by every subagent fan-out site.
+ *
+ * `settleWithConcurrencyLimit` was extracted from the tool dispatcher (which
+ * bounded the foreground safe-batch, PR #376) so the two other subagent
+ * fan-out paths can reuse the same primitive instead of an unbounded
+ * `Promise.all`/`Promise.allSettled`:
+ *   - the compose/DAG layer executor (`agent/dag.ts`), where one `compose`
+ *     tool call can enqueue up to 20 nodes in a single layer, and
+ *   - the skill wave runner (`agent/subagent/wave.ts`).
+ *
+ * @module agent/concurrency-pool
+ */
+
+/**
+ * Ceiling on subagent forks dispatched simultaneously from a SINGLE fan-out
+ * site — one compose/DAG layer, or one `runWave` call. Each unit is a forked
+ * `AgentSession` (the real memory + provider-rate-limit cost), so an unbounded
+ * layer — e.g. a 20-node `compose` — could exhaust memory or storm the 429
+ * ceiling. 8 sits above typical parallel-wave width (2–6 nodes/critics) so
+ * ordinary fan-outs are never throttled, while bounding a runaway one; it
+ * mirrors the dispatcher's safe-batch ceiling and the background-job ceiling
+ * of 10. Injectable per site (DAGRunOptions.maxConcurrency /
+ * RunWaveOptions.maxConcurrency) for tuning and tests.
+ *
+ * Deadlock-free by construction: each fan-out site drains its OWN fresh pool
+ * (this function is stateless — no shared/module-level limiter object), so a
+ * parent subagent that forks a child which itself fans out never contends for
+ * its parent's permits. A single shared cross-site/tree-wide semaphore WOULD
+ * deadlock (a parent holds a permit while awaiting a child that needs one);
+ * the per-site design avoids that hold-and-wait cycle.
+ */
+export const DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS = 8;
+
+/**
+ * Run `worker` over every `items` element with at most `limit` invocations in
+ * flight, returning results in `items` order with the same fulfilled/rejected
+ * shape as `Promise.allSettled`. Workers are started eagerly up to the cap, so
+ * when `limit >= items.length` this is behaviourally identical to
+ * `Promise.allSettled(items.map(worker))` — the parallel-timing tests rely on
+ * that. `limit` is floored at 1, so a non-positive cap degrades to sequential
+ * rather than deadlocking on an empty pool.
+ *
+ * Invariant: `worker` is invoked LAZILY, once per dequeue (never before an
+ * item's turn). Callers that must defer per-item setup (arming a timeout,
+ * wiring an AbortController) until the item actually runs — so queue-wait is
+ * not charged against a runtime budget — should perform that setup INSIDE
+ * `worker`, not before enqueueing. dag.ts relies on this for timeout fairness.
+ */
+export async function settleWithConcurrencyLimit<T, I>(
+  items: readonly I[],
+  limit: number,
+  worker: (item: I) => Promise<T>,
+): Promise<PromiseSettledResult<T>[]> {
+  const results: PromiseSettledResult<T>[] = new Array(items.length);
+  const poolSize = Math.min(Math.max(1, Math.floor(limit)), items.length);
+  let cursor = 0;
+  const runners: Promise<void>[] = [];
+  for (let w = 0; w < poolSize; w++) {
+    runners.push(
+      (async () => {
+        // `cursor < length` test and `cursor++` are not separated by an await,
+        // so each index is claimed by exactly one runner (no double-dispatch,
+        // no skip) despite the shared cursor.
+        while (cursor < items.length) {
+          const i = cursor++;
+          try {
+            results[i] = { status: 'fulfilled', value: await worker(items[i]!) };
+          } catch (reason) {
+            results[i] = { status: 'rejected', reason };
+          }
+        }
+      })(),
+    );
+  }
+  await Promise.all(runners);
+  return results;
+}

--- a/src/agent/dag.test.ts
+++ b/src/agent/dag.test.ts
@@ -603,3 +603,70 @@ describe('runDAG — nodeTimeoutMs', () => {
     expect(result.failed[0]!.id).toBe('slow');
   });
 });
+
+// ---------------------------------------------------------------------------
+// runDAG — maxConcurrency (bounded per-layer subagent fan-out).
+// ---------------------------------------------------------------------------
+
+describe('runDAG — maxConcurrency', () => {
+  function trackedNode(id: string, ms: number, t: { live: number; peak: number }): DAGNode {
+    return {
+      id,
+      run: vi.fn(async () => {
+        t.live++;
+        t.peak = Math.max(t.peak, t.live);
+        await new Promise((r) => setTimeout(r, ms));
+        t.live--;
+        return id;
+      }),
+    };
+  }
+
+  it('runs at most maxConcurrency nodes per layer simultaneously', async () => {
+    const t = { live: 0, peak: 0 };
+    const nodes = ['a', 'b', 'c', 'd', 'e'].map((id) => trackedNode(id, 30, t));
+
+    const result = await runDAG({ nodes, edges: [] }, new AbortController().signal, {
+      maxConcurrency: 2,
+    });
+
+    // All five ran to completion (none throttled out) and concurrency never
+    // exceeded the cap.
+    expect(Object.keys(result.outputs).sort()).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(result.failed).toEqual([]);
+    expect(t.peak).toBe(2);
+  });
+
+  it('default (no maxConcurrency) does not throttle a typical layer', async () => {
+    const t = { live: 0, peak: 0 };
+    const nodes = ['a', 'b', 'c', 'd'].map((id) => trackedNode(id, 20, t));
+
+    // No maxConcurrency → defaults to DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS (8),
+    // which sits above this 4-node layer, so all four run at once (peak 4).
+    const result = await runDAG({ nodes, edges: [] }, new AbortController().signal);
+
+    expect(result.failed).toEqual([]);
+    expect(t.peak).toBe(4);
+  });
+
+  it('does not charge queue-wait against nodeTimeoutMs (timeout fairness)', async () => {
+    // maxConcurrency=1 forces A then B to run strictly sequentially. Each node
+    // runs 60ms; the per-node timeout is 100ms. B is dequeued only after A
+    // (~60ms) finishes. Because the timeout is armed INSIDE the pool worker (on
+    // dequeue), B's 100ms clock starts when B starts, so B completes (~120ms)
+    // inside its own budget and does NOT time out. If the timer were armed at
+    // enqueue (t=0) it would fire at 100ms while B was only ~40ms into its run,
+    // spuriously failing it.
+    const a = delayNode('a', 60);
+    const b = delayNode('b', 60);
+
+    const result = await runDAG({ nodes: [a, b], edges: [] }, new AbortController().signal, {
+      maxConcurrency: 1,
+      nodeTimeoutMs: 100,
+    });
+
+    expect(result.failed).toEqual([]);
+    expect(result.outputs['a']).toBe('a');
+    expect(result.outputs['b']).toBe('b');
+  });
+});

--- a/src/agent/dag.ts
+++ b/src/agent/dag.ts
@@ -2,13 +2,17 @@
  * Workflow DAG executor — Phase 2.
  *
  * Layer-by-layer Kahn execution: nodes with satisfied dependencies run in
- * parallel per layer, then the next layer starts. No concurrency semaphore
- * — layer boundaries provide natural drain points with zero deadlock risk.
+ * parallel per layer (bounded by {@link DAGRunOptions.maxConcurrency} — each
+ * node may fork an AgentSession), then the next layer starts. Layer boundaries
+ * are the natural drain points; the per-layer limiter is a fresh, per-call pool
+ * (never a shared/tree-wide semaphore), so a node that forks a nested compose
+ * cannot deadlock waiting on its own ancestor's permits.
  *
  * @module agent/dag
  */
 
 import { TimeoutError } from '../utils/errors.js';
+import { settleWithConcurrencyLimit, DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS } from './concurrency-pool.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -45,6 +49,16 @@ export interface DAGRunOptions {
    * Undefined (default) or non-positive = no timeout, matching prior behavior.
    */
   nodeTimeoutMs?: number;
+  /**
+   * Max nodes executed concurrently within a single layer. Each node typically
+   * forks an `AgentSession` (compose), so an unbounded layer can exhaust memory
+   * or storm the provider rate limit. The layer drains through a bounded pool;
+   * per-node results and their order are unaffected (the post-layer processing
+   * still keys off `ready` order). Default:
+   * {@link DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS}; floored at 1. Injected by
+   * tests to assert the cap.
+   */
+  maxConcurrency?: number;
 }
 
 export interface DAGRunResult {
@@ -146,7 +160,7 @@ export async function runDAG(
 
   validateDAG(graph);
 
-  const { failFast = true, nodeTimeoutMs } = options;
+  const { failFast = true, nodeTimeoutMs, maxConcurrency = DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS } = options;
   const nodeTimeoutEnabled =
     nodeTimeoutMs !== undefined && Number.isFinite(nodeTimeoutMs) && nodeTimeoutMs > 0;
   const adj = buildAdjacency(graph);
@@ -179,8 +193,18 @@ export async function runDAG(
       }
       if (ready.length === 0) break;
 
-      const layerResults = await Promise.allSettled(
-        ready.map(async (id) => {
+      // Bounded per-layer fan-out: at most `maxConcurrency` nodes run at once,
+      // so a wide layer (e.g. a 20-node compose) cannot fork an unbounded burst
+      // of AgentSessions. Within the cap this is identical to the prior
+      // `Promise.allSettled(ready.map(...))` — results stay in `ready` order.
+      // The whole per-node closure (AbortController + abort listener + timeout
+      // arming, below) is the pool `worker`, and the pool invokes it lazily on
+      // dequeue — so a node queued behind the cap does NOT arm its timeout while
+      // waiting (queue-wait is never charged against nodeTimeoutMs).
+      const layerResults = await settleWithConcurrencyLimit(
+        ready,
+        maxConcurrency,
+        async (id) => {
           const node = nodeMap.get(id)!;
           const nodeController = new AbortController();
 
@@ -233,7 +257,7 @@ export async function runDAG(
             if (nodeTimeoutHandle !== undefined) clearTimeout(nodeTimeoutHandle);
             dagController.signal.removeEventListener('abort', forwardNodeAbort);
           }
-        }),
+        },
       );
 
       for (let i = 0; i < layerResults.length; i++) {

--- a/src/agent/subagent-wave.test.ts
+++ b/src/agent/subagent-wave.test.ts
@@ -290,4 +290,38 @@ describe('runWave', () => {
     expect(results[0]?.status).toBe('succeeded');
     expect(events).toHaveLength(1);
   });
+
+  it('bounds in-flight runs to maxConcurrency', async () => {
+    const mgr = new SubagentManager();
+    shared.sessions.length = 0;
+    const handles = await Promise.all(
+      [0, 1, 2, 3, 4].map(() =>
+        mgr.forkSubagent({ parent: { sessionId: 'p' }, config: { model: 'sonnet' } }),
+      ),
+    );
+
+    // Instrument every mock session's sendMessage to track live concurrency
+    // across the whole wave (each run holds a 30ms window).
+    let live = 0;
+    let peak = 0;
+    for (const s of shared.sessions) {
+      s.sendMessage.mockImplementation(async (content: string): Promise<Message> => {
+        live++;
+        peak = Math.max(peak, live);
+        await new Promise((r) => setTimeout(r, 30));
+        live--;
+        return { role: 'assistant', content: `ok:${content}`, timestamp: new Date() };
+      });
+    }
+
+    const results = await runWave(
+      handles.map((handle, i) => ({ handle, prompt: `p${i}` })),
+      { maxConcurrency: 2 },
+    );
+
+    // All five completed (none dropped) and no more than 2 ran at once.
+    expect(results).toHaveLength(5);
+    expect(results.every((r) => r?.status === 'succeeded')).toBe(true);
+    expect(peak).toBe(2);
+  });
 });

--- a/src/agent/subagent-wave.test.ts
+++ b/src/agent/subagent-wave.test.ts
@@ -324,4 +324,71 @@ describe('runWave', () => {
     expect(results.every((r) => r?.status === 'succeeded')).toBe(true);
     expect(peak).toBe(2);
   });
+
+  it('fail-fast skips still-QUEUED peers behind maxConcurrency — no wasted provider call', async () => {
+    const mgr = new SubagentManager();
+    shared.sessions.length = 0;
+    const h0 = await mgr.forkSubagent({ parent: { sessionId: 'p' }, config: { model: 'sonnet' } });
+    const h1 = await mgr.forkSubagent({ parent: { sessionId: 'p' }, config: { model: 'sonnet' } });
+    const h2 = await mgr.forkSubagent({ parent: { sessionId: 'p' }, config: { model: 'sonnet' } });
+
+    // Task 0 fails immediately. With maxConcurrency: 1, tasks 1 and 2 never
+    // start until a worker frees up — they are QUEUED, not running, when
+    // task 0's failure trips fail-fast.
+    shared.sessions[0]!.sendMessage.mockRejectedValueOnce(new Error('immediate-fail'));
+
+    const results = await runWave(
+      [
+        { handle: h0, prompt: 'a' },
+        { handle: h1, prompt: 'b' },
+        { handle: h2, prompt: 'c' },
+      ],
+      { failFast: true, maxConcurrency: 1 },
+    );
+
+    expect(results[0]?.status).toBe('failed');
+    expect(results[1]?.status).toBe('cancelled');
+    expect(results[2]?.status).toBe('cancelled');
+
+    // The fix: queued tasks are skipped entirely, so their mock sendMessage
+    // is never invoked — no provider call was spent on doomed work.
+    expect(shared.sessions[1]!.sendMessage).not.toHaveBeenCalled();
+    expect(shared.sessions[2]!.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('fail-fast skips queued peers while a running peer is still cancelled (maxConcurrency: 2)', async () => {
+    const mgr = new SubagentManager();
+    shared.sessions.length = 0;
+    const handles = await Promise.all(
+      [0, 1, 2, 3].map(() =>
+        mgr.forkSubagent({ parent: { sessionId: 'p' }, config: { model: 'sonnet' } }),
+      ),
+    );
+
+    // With maxConcurrency: 2, tasks 0 and 1 start immediately; tasks 2 and 3
+    // are QUEUED. Task 0 fails fast while task 1 is still running slowly.
+    shared.sessions[0]!.sendMessage.mockRejectedValueOnce(new Error('fast-fail'));
+    shared.sessions[1]!.state.replyDelayMs = 200;
+
+    const start = Date.now();
+    const results = await runWave(
+      handles.map((handle, i) => ({ handle, prompt: `p${i}` })),
+      { failFast: true, maxConcurrency: 2 },
+    );
+    const elapsed = Date.now() - start;
+
+    expect(results[0]?.status).toBe('failed');
+    expect(results[1]?.status).toBe('cancelled');
+    expect(results[2]?.status).toBe('cancelled');
+    expect(results[3]?.status).toBe('cancelled');
+
+    // Running peer (task 1) was cancelled via interrupt; queued peers (2, 3)
+    // never had a provider call dispatched at all.
+    expect(shared.sessions[1]!.interrupt).toHaveBeenCalled();
+    expect(shared.sessions[2]!.sendMessage).not.toHaveBeenCalled();
+    expect(shared.sessions[3]!.sendMessage).not.toHaveBeenCalled();
+
+    // The wave should finish well under the slow peer's 200ms reply delay.
+    expect(elapsed).toBeLessThan(150);
+  });
 });

--- a/src/agent/subagent/wave.ts
+++ b/src/agent/subagent/wave.ts
@@ -25,6 +25,7 @@
 
 import type { SubagentHandle } from './handle.js';
 import type { SubagentResult } from './result.js';
+import { settleWithConcurrencyLimit, DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS } from '../concurrency-pool.js';
 
 export interface WaveTask<T = unknown> {
   handle: SubagentHandle<T>;
@@ -44,6 +45,12 @@ export interface RunWaveOptions {
    * when the caller wants to reuse handles for additional runs.
    */
   teardown?: boolean;
+  /**
+   * Max subagent runs in flight at once (each is a forked AgentSession).
+   * Bounds a wide wave so it cannot storm memory / the provider rate limit.
+   * Default: {@link DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS}; floored at 1.
+   */
+  maxConcurrency?: number;
 }
 
 /**
@@ -57,14 +64,30 @@ export async function runWave<T = unknown>(
   tasks: ReadonlyArray<WaveTask<T>>,
   options: RunWaveOptions = {},
 ): Promise<SubagentResult<T>[]> {
-  const { failFast = true, teardown = true } = options;
+  const { failFast = true, teardown = true, maxConcurrency = DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS } = options;
   if (tasks.length === 0) return [];
 
   const results = new Array<SubagentResult<T>>(tasks.length);
   const pending = new Set(tasks.map((_, i) => i));
 
-  const promises = tasks.map((task, i) =>
-    task.handle.runToResult(task.prompt).then((result) => {
+  // Bounded fan-out: at most `maxConcurrency` subagent runs are in flight at
+  // once (each is a forked AgentSession). Within the cap this is identical to
+  // the prior unbounded `Promise.all(tasks.map(...))`. `runToResult` absorbs
+  // its own errors into SubagentResult and each index is dispatched exactly
+  // once, so the worker never rejects; `results[i]` is filled in task order.
+  //
+  // fail-fast note: peer-cancellation only targets handles already `running`.
+  // When tasks.length > maxConcurrency, a task still QUEUED behind the cap is
+  // not yet running, so an earlier failure does not cancel it — it runs when
+  // dequeued (a minor efficiency-only difference under fail-fast, never a
+  // correctness one; every result is still populated). At or under the cap
+  // (all current callers) behaviour is unchanged.
+  await settleWithConcurrencyLimit(
+    tasks.map((_, i) => i),
+    maxConcurrency,
+    async (i) => {
+      const task = tasks[i]!;
+      const result = await task.handle.runToResult(task.prompt);
       results[i] = result;
       pending.delete(i);
 
@@ -80,12 +103,8 @@ export async function runWave<T = unknown>(
           }
         }
       }
-    }),
+    },
   );
-
-  // `runToResult` absorbs errors into SubagentResult, so this Promise.all
-  // never rejects in practice — it simply waits for every task to settle.
-  await Promise.all(promises);
 
   if (teardown) {
     await Promise.allSettled(tasks.map((t) => t.handle.teardown()));

--- a/src/agent/subagent/wave.ts
+++ b/src/agent/subagent/wave.ts
@@ -11,8 +11,10 @@
  *
  *   2. **Fail-fast cancellation.** When any task resolves non-succeeded and
  *      `failFast` is on (default), every peer still executing a run is
- *      cancelled. Saves wasted API calls on slow siblings after an early
- *      failure has already doomed the wave.
+ *      cancelled — and any peer still queued behind `maxConcurrency` (not yet
+ *      started) is skipped rather than dispatched. Saves wasted API calls on
+ *      slow or not-yet-started siblings after an early failure has already
+ *      doomed the wave.
  *
  *   3. **End-of-wave teardown.** After all runs settle, each handle's
  *      `teardown()` is invoked so `SubagentStop` fires exactly once per handle
@@ -69,6 +71,10 @@ export async function runWave<T = unknown>(
 
   const results = new Array<SubagentResult<T>>(tasks.length);
   const pending = new Set(tasks.map((_, i) => i));
+  // Tripped once any task resolves non-succeeded under fail-fast. Checked at
+  // each worker's entry so a task still QUEUED behind maxConcurrency is
+  // skipped instead of dispatched — see the fail-fast guard below.
+  let failFastTripped = false;
 
   // Bounded fan-out: at most `maxConcurrency` subagent runs are in flight at
   // once (each is a forked AgentSession). Within the cap this is identical to
@@ -76,25 +82,38 @@ export async function runWave<T = unknown>(
   // its own errors into SubagentResult and each index is dispatched exactly
   // once, so the worker never rejects; `results[i]` is filled in task order.
   //
-  // fail-fast note: peer-cancellation only targets handles already `running`.
-  // When tasks.length > maxConcurrency, a task still QUEUED behind the cap is
-  // not yet running, so an earlier failure does not cancel it — it runs when
-  // dequeued (a minor efficiency-only difference under fail-fast, never a
-  // correctness one; every result is still populated). At or under the cap
-  // (all current callers) behaviour is unchanged.
+  // Fixed: queued tasks now skip under fail-fast, not just running ones. When
+  // tasks.length > maxConcurrency, a task still QUEUED behind the cap has not
+  // started when an earlier peer fails; the `failFastTripped` guard cancels
+  // it before dispatch so it yields a 'cancelled' result with NO provider
+  // call — matching the prior unbounded Promise.all, where every peer had
+  // already started and thus got cancelled on an early failure.
   await settleWithConcurrencyLimit(
     tasks.map((_, i) => i),
     maxConcurrency,
     async (i) => {
       const task = tasks[i]!;
+
+      // Skip dispatch entirely if fail-fast already tripped while this task
+      // was queued. `cancel()` sets status synchronously before its first
+      // `await`; the `runToResult` call below then short-circuits inside
+      // `run()`'s cancelled guard and returns a proper 'cancelled' result
+      // without ever calling the provider.
+      if (failFast && failFastTripped) {
+        await task.handle.cancel().catch(() => undefined);
+      }
+
       const result = await task.handle.runToResult(task.prompt);
       results[i] = result;
       pending.delete(i);
 
       if (failFast && result.status !== 'succeeded') {
+        failFastTripped = true;
         // Cancel every peer still executing a run. `cancel()` is idempotent
         // (stopDispatched guard in handle.ts) so concurrent fail-fast hits on
-        // the same peer dispatch `SubagentStop` once.
+        // the same peer dispatch `SubagentStop` once. Peers still queued
+        // (not yet started) are skipped by the guard above when their turn
+        // arrives.
         for (const peerIdx of pending) {
           const peer = tasks[peerIdx];
           if (peer && peer.handle.status === 'running') {

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -16,6 +16,7 @@ import { dirname } from 'path';
 import { createHash } from 'node:crypto';
 import { debugLog } from '../../utils/debug.js';
 import { HookBlockedError } from '../../utils/errors.js';
+import { settleWithConcurrencyLimit } from '../concurrency-pool.js';
 import type { HookRegistry, PreToolUseContext, PostToolUseContext, PostToolUseFailureContext } from '../hooks.js';
 import type { AnthropicToolDef } from '../providers/anthropic-direct/types.js';
 import type { ToolDispatcher } from '../providers/anthropic-direct/tool-dispatcher.js';
@@ -134,45 +135,6 @@ function partitionIntoBatches(
  * regress; injectable via SessionToolDispatcherOptions.maxConcurrentSafeCalls.
  */
 export const DEFAULT_MAX_CONCURRENT_SAFE_TOOL_CALLS = 8;
-
-/**
- * Run `worker` over every `items` element with at most `limit` invocations in
- * flight, returning results in `items` order with the same fulfilled/rejected
- * shape as `Promise.allSettled`. Workers are started eagerly up to the cap, so
- * when `limit >= items.length` this is behaviourally identical to
- * `Promise.allSettled(items.map(worker))` — the parallel-timing tests rely on
- * that. `limit` is floored at 1, so a non-positive cap degrades to sequential
- * rather than deadlocking on an empty pool.
- */
-async function settleWithConcurrencyLimit<T, I>(
-  items: readonly I[],
-  limit: number,
-  worker: (item: I) => Promise<T>,
-): Promise<PromiseSettledResult<T>[]> {
-  const results: PromiseSettledResult<T>[] = new Array(items.length);
-  const poolSize = Math.min(Math.max(1, Math.floor(limit)), items.length);
-  let cursor = 0;
-  const runners: Promise<void>[] = [];
-  for (let w = 0; w < poolSize; w++) {
-    runners.push(
-      (async () => {
-        // `cursor < length` test and `cursor++` are not separated by an await,
-        // so each index is claimed by exactly one runner (no double-dispatch,
-        // no skip) despite the shared cursor.
-        while (cursor < items.length) {
-          const i = cursor++;
-          try {
-            results[i] = { status: 'fulfilled', value: await worker(items[i]!) };
-          } catch (reason) {
-            results[i] = { status: 'rejected', reason };
-          }
-        }
-      })(),
-    );
-  }
-  await Promise.all(runners);
-  return results;
-}
 
 export interface SessionToolDispatcherOptions {
   handlers: Map<string, ToolHandler>;


### PR DESCRIPTION
## Problem

PR #376 bounded the **foreground safe-batch** tool fan-out, but two other subagent fan-out paths stayed **unbounded**:

- **`dag.ts` (compose/DAG layers)** — `runDAG` fanned out an entire layer via `Promise.allSettled(ready.map(...))` with *"No concurrency semaphore"*. A single `compose` call (max 20 nodes) can fork **up to 20 `AgentSession`s in one layer**.
- **`wave.ts` (`runWave`)** — `Promise.all` over all handles.

Each fork is a full `AgentSession` — the real memory + provider-429 risk. #376 bounded the *rarest* of the three paths (≥9 sibling `agent` calls in one turn); these two were left open.

## Fix

- Extract the proven worker-pool primitive `settleWithConcurrencyLimit` from `dispatcher.ts` into a shared module **`src/agent/concurrency-pool.ts`** and reuse it at both fan-out sites.
- New `DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS = 8` (mirrors the safe-batch ceiling and the background-job ceiling of 10) + a per-site injectable `maxConcurrency` (`DAGRunOptions` / `RunWaveOptions`).
- **No schema changes** — every dag/wave item is already a subagent fork, so no leaf-vs-subagent classification is needed here.

### Deadlock-free by construction
Each site drains its **own fresh per-call pool** (the primitive is stateless — no shared/tree-wide semaphore), so a node that forks a nested `compose` never contends for an ancestor's permits. A single shared cross-tree semaphore *would* deadlock (hold-and-wait); this per-site design avoids it.

### Timeout fairness
In `dag.ts` the whole per-node closure (AbortController + abort listener + `nodeTimeoutMs` arming) is the pool `worker`, and the pool invokes it lazily on dequeue — so a node queued behind the cap does **not** arm its timeout while waiting. Queue-wait is never charged against a node's runtime budget.

### Behaviour unchanged at/under the cap
Covers all current callers (compose typically <20 nodes; `runWave` callers pass 2–few tasks). `runWave` fail-fast still cancels `running` peers; a queued task past a fail-fast simply runs to completion when dequeued (efficiency-only, never a correctness change).

## Tests
- **`concurrency-pool.test.ts`** (new): input-order results, cap enforcement, `limit >= length` parallelism, floor-at-1, empty input, in-place rejection capture.
- **`dag.test.ts`** (+3): at-most-K per layer, default (8) doesn't throttle a typical layer, **timeout fairness for queued nodes**.
- **`subagent-wave.test.ts`** (+1): in-flight runs bounded to `maxConcurrency`.

## Gates
- `tsc --noEmit` (strict): clean
- Full suite: **10497 passed / 14 skipped / 0 failed**
- `audit:sdk:check`: OK (no new SDK symbols) · `scan:env:check`: in sync
- `test:coverage`: exit 0 — `dag.ts` **99%**, `wave.ts` **100%**

## Not in scope (deliberate)
- The per-schema **weight/lane axis** ("Option 4") — rejected as premature (biggest blast radius, targets the weakest-evidence problem: leaf-throttling). The leaf-vs-subagent distinction is a name predicate, not schema data.
- Relaxing the dispatcher's leaf cap for read-throttling — recommend measuring with fan-out telemetry first (repo philosophy: *"runtime enforcement only after we can measure it"*).
- A session-tree-wide subagent governor — correct long-term, but deadlock-prone without a release-on-await design; revisit only if per-site caps prove insufficient.
