### PR TITLE
fix(tui): reflow committed band at paint-time width; fail-safe commits on stale resize geometry

### DIFF
--- a/docs/rendering-architecture-current.md
+++ b/docs/rendering-architecture-current.md
@@ -1,5 +1,13 @@
 # Rendering Architecture — Current State
 
+> **SUPERSEDED (2026-07-02).** This doc is a Phase-0 snapshot from the initial
+> public release (`0a23cff`, 2026-06-05) and describes the renderer **before**
+> the five root-cause fixes it motivated. All five landed (tracked as
+> checkpoints 2a–2e in `stream-renderer-ordering.test.ts` and
+> `tool-lane.test.ts`); the source is now the only accurate reference. Kept for
+> the lifecycle vocabulary and historical rationale. For the resize/reflow
+> layer added 2026-07, see `docs/tui-resize-reflow.md`.
+
 > Phase 0 reconnaissance. All claims verified from source with file:line citations.
 
 ---

--- a/docs/rendering-architecture-desired.md
+++ b/docs/rendering-architecture-desired.md
@@ -1,5 +1,15 @@
 # Rendering Architecture — Desired State
 
+> **SUPERSEDED (2026-07-02).** All five root-cause fixes this target model
+> called for have landed (checkpoints 2a–2e; see `commit-coordinator.ts`,
+> `stream-renderer-lifecycle.ts:169-207`, `stream-renderer-source.ts:37`,
+> `tool-lane-render-grouping.ts:54-79`). Two items were deliberately built
+> differently and are NOT gaps: the entry state machine exists as enforced
+> field-mutation invariants rather than a formal enum type, and the property
+> tests are bounded hand-rolled loops (n≤30), not fast-check generators. Do
+> not implement against this doc. For the resize/reflow layer added 2026-07,
+> see `docs/tui-resize-reflow.md`.
+
 > Phase 0 target model. Addresses every "Required properties" bullet from the handoff brief.
 
 ---

--- a/docs/tui-resize-reflow.md
+++ b/docs/tui-resize-reflow.md
@@ -1,0 +1,141 @@
+# TUI Resize Reflow — Root Causes, Fix Architecture, and Industry Context
+
+_Added 2026-07-02. Companion to `docs/scrollback.md` (committed-band mechanics)
+and `docs/tui-invariants.md` (externally-governed constraint catalog)._
+
+## The incident
+
+A live REPL session inside tmux (multiple clients of different sizes; several
+pane resizes mid-stream) produced three symptom classes in scrollback:
+
+1. **Ghost duplicates** — the same assistant paragraphs appeared up to 5×,
+   each copy truncated at a *different* historical width.
+2. **Mid-word truncation** — lines hard-cut without hyphenation at columns
+   that matched no current geometry ("…already write subage", "(st").
+3. **Silent content loss** — blocks cut mid-sentence whose completion never
+   re-landed; one committed block vanished from screen *and* scrollback.
+
+Forensic captures: `tmux capture-pane` of the affected pane showed content
+formatted at ≥5 distinct widths (~165/125/106/85/64 cols), proving repaints
+spanned several SIGWINCH events. Both root causes below were confirmed
+empirically red-first in
+`src/cli/terminal-compositor.resize-stale-width.repro.test.ts` (now converted
+to green regression tests).
+
+## Root cause 1 — stale-width verbatim repaint (ghosts + truncation)
+
+`commitAbove` hard-wraps committed text to `stdout.columns` **once, at commit
+time** (`terminal-compositor.committed-band-commit.ts`, `hardWrapToWidth`).
+Every downstream paint site — `repositionCommittedBand`, the
+`preserveRowsBeforeFrameRender` eviction paints — then CUP-painted those
+retained rows **verbatim**, regardless of how many resizes had happened since.
+
+A row wrapped at 160 cols painted into a 64-col terminal overruns the physical
+width; DECAWM autowrap (on by default; the codebase never disabled it) then
+hard-wraps it *again* at the hardware level, inserting **unaccounted phantom
+rows**. Every subsequent CUP/erase computation is desynced from the
+compositor's row model: erases miss rows, stale frames survive above the band,
+and the next scroll absorbs them into native scrollback — once per repaint
+cycle, at whatever width was current at the time.
+
+**Invariant established: strings wrapped at width W are only valid at width W.**
+
+## Root cause 2 — stale band geometry defeats the commit safety gate (loss)
+
+The SIGWINCH-immediate handler (`terminal-compositor.lifecycle.ts`) calls
+`logUpdate.resetGeometry()` — zeroing `CupFrameRenderer.previousTopRow` — but
+deliberately left `committedBandTopRow`/`committedBandBottomRow` untouched. A
+commit landing in the gap before the debounced repaint computed
+`prevTopRow = max(0, committedBandBottomRow + 1)`: the stale floor reproduced
+the **pre-resize** row number, kept `prevTopRow > 1`, and thereby defeated the
+`prevTopRow <= 1` band-hold safety fallback (BLOCKER-1, `commit-mode.ts`).
+
+Consequence (worse than the mispaint originally hypothesized):
+`fitsAboveFrame` came out spuriously true and Phase-3 merge-then-cap truncated
+the prior band as "already scrolled" rows that had never scrolled — **total
+loss of committed content** with no scrollback copy ever made.
+
+Historical note: commit `002bcd1` (PR #351) fixed a *different* trigger of the
+same class (frame-height shrink at stable width). Its floor remains correct
+for that case; the resize trigger needed its own invalidation.
+
+## Fix architecture (landed 2026-07-02)
+
+Module: `src/cli/terminal-compositor.band-reflow.ts`; wired through
+`committed-band-commit.ts`, `frame.ts`, `committed-band-repin.ts`,
+`frame-preserve.ts`, `lifecycle.ts`, `commit-mode.ts`, `reset.ts`.
+
+**F1 — reflow-before-read.** `reflowCommittedBandToWidth(self, width)` re-wraps
+the retained band at the *current* width before any consumer reads it, at both
+band-read entry points: top of `commitAbove` (before merge/contiguity math)
+and top of `repaint()` (before eviction paints and re-pin). The
+pending/painted boundary (`committedBandPaintedRows`) is split-preserved
+through the re-wrap — naive whole-array re-wrapping would desync it the moment
+a row count changes. A `{band-ref, paintedRows, width}` memo makes steady-width
+repaints a no-op. Mirrors the industry-standard reflow-from-model approach
+(ratatui/Codex `insert_history` + reflow; see comparison below). Note the
+band re-wraps its retained *rows* (already wrapped once at commit time), so a
+narrowing resize splits correctly, while a widening resize keeps the earlier
+wrap points — content-preserving and geometry-correct in both directions,
+cosmetically identical to how tmux treats hard-wrapped lines.
+
+**F1b — DECAWM bracket (defense-in-depth).** All physical band paints run
+inside `withAutowrapDisabled()` (`?7l` … `?7h`, restore in `finally`). Reflow
+guarantees fit *by our own measurement*; the bracket guarantees that a ±1
+ambiguous-width disagreement (×, —, ╭ …) between `displayWidth()` and the
+actual terminal can only **clip** a row, never spawn a phantom row.
+
+**F2 — geometry-stale gate.** The resize-immediate handler now sets
+`bandGeometryStale` alongside `resetGeometry()`. While stale,
+`decideCommitMode` forces `fitsAboveFrame = false` (routing commits through
+the same safe band-hold deferral BLOCKER-1 uses) and relaxes
+`overflowPriorContiguous`'s exact-row match to the band's frame-adjacency
+invariant (the row *numbers* are stale; the adjacency *fact* is not). The flag
+clears only when `repositionCommittedBand` re-pins against real post-resize
+geometry. Hard rule: **content preservation beats placement precision** — a
+commit may land at a slightly conservative position during the stale window,
+but committed content is never silently truncated.
+
+**Regression tests** (`terminal-compositor.resize-stale-width.repro.test.ts`):
+H1 narrow-resize reflow (no row wider than the new terminal), H2 commit-during-
+stale-window (both blocks fully present), a multi-resize storm (160→100→64,
+every marker present exactly once — the no-ghost assertion), and the 002bcd1
+baseline re-derivation.
+
+## Industry context (researched 2026-07-02)
+
+| CLI | Screen mode | Scrollback strategy | On resize |
+|---|---|---|---|
+| Claude Code | main-screen inline | custom differential renderer (ex-Ink `<Static>`) | cursor-walk overshoots → known dup-frame spill (issues #46834, #60069) |
+| Codex CLI (ratatui) | main-screen inline | `insert_history_lines` via DECSTBM scroll-region | **reflows scrollback from retained model** (PR #18575) |
+| Gemini CLI (Ink) | main-screen inline | Ink `<Static>` commits at safe split points | multiple fixes; new isolated TerminalBuffer mode (#24512) |
+| aider (rich.Live) | main-screen inline | stable/unstable-tail split, full re-render per tick | no structural fix; scrambles on resize (#457) |
+| Ink core | main-screen inline | `<Static>` write-once + erase-N-lines dynamic region | reflow ghosting ruled **undetectable/unfixable** (#916) |
+
+The load-bearing conclusion across all of them: **cursor-relative erase math is
+unrecoverable once the terminal has reflowed under you.** The only sound
+patterns are (a) making native scrollback authoritative via scroll-region
+insertion, and (b) re-deriving painted rows from retained content at
+paint-time width — never from previously wrapped strings. afk now does (b)
+for the committed band; (a) remains the long-horizon direction if the band
+model is ever replaced.
+
+tmux specifics that shaped the fix: tmux reflows only *soft*-wrapped lines
+(and only on the primary screen), so app-side hard wraps never rejoin on
+widen; tmux never sends SIGWINCH itself (`TIOCSWINSZ` → kernel), and resizes
+are debounced; multi-client `window-size latest` (default since 3.2) makes
+mid-stream width flapping a normal condition, not an edge case.
+
+## Follow-ups (deliberately out of scope here)
+
+- `cup-frame-renderer.ts` reimplements `hardWrapToWidth` inline (~:40,:93) —
+  consolidate on `wrap.ts`.
+- Five independent home-grown ANSI-strip regexes exist (`display.ts`,
+  `terminal-sanitize.ts`, `_lib/sanitize.ts`, `input/history.ts`,
+  `input/suggest.ts`); consolidate.
+- `stream-renderer-subagent.ts` width fallback is `?? 100` vs the canonical
+  helper's `?? 80`.
+- `docs/scrollback.md:108-111` still names the deepest gap: no end-to-end
+  PTY test verifies actual scrollback contents. A real-PTY (or
+  `@xterm/headless`-driven, real-timer) harness would catch the class this
+  incident belongs to before release.

--- a/src/cli/commit-mode.ts
+++ b/src/cli/commit-mode.ts
@@ -40,6 +40,15 @@ export interface CommitModeInput {
    * Drives the EXACT `overflowHasPending` signal (see decideCommitMode).
    */
   committedBandPaintedRows: number;
+  /**
+   * F2 (fail-safe commit mode on stale geometry): true when a resize landed
+   * and no repaint has yet re-established real frame geometry (set by the
+   * SIGWINCH-immediate handler, cleared by repositionCommittedBand — see
+   * TerminalCompositor.bandGeometryStale). While true, `committedBandBottomRow`
+   * is a PRE-resize row number in a coordinate space the current commit's
+   * `frameTop` no longer shares — see `overflowPriorContiguous` below.
+   */
+  geometryStale: boolean;
 }
 
 /** The routing decision + the geometry the caller's phases consume. */
@@ -145,15 +154,41 @@ export function decideCommitMode(input: CommitModeInput): CommitMode {
     committedBand,
     committedBandBottomRow,
     committedBandPaintedRows,
+    geometryStale,
   } = input;
 
-  const fitsAboveFrame = prevTopRow > 1 && lineCount <= frameTop - anchorFloor;
+  // F2 (fail-safe commit mode on stale geometry): `!geometryStale` extends the
+  // existing BLOCKER-1 guard (`prevTopRow > 1`) from "frame top is literally
+  // unknown" to "frame top is potentially WRONG" — when geometryStale, `frameTop`
+  // may have been derived from the committedBandBottomRow+1 floor using a
+  // committedBandBottomRow that describes the PRE-resize screen, a coordinate
+  // space the post-resize frame does not share. Forcing fitsAboveFrame false
+  // routes the commit through the same safe band-hold deferral BLOCKER-1 uses,
+  // instead of merge-then-cap silently truncating content that was never
+  // actually scrolled into real terminal scrollback (see
+  // terminal-compositor.resize-stale-width.repro.test.ts's H2 case).
+  const fitsAboveFrame = prevTopRow > 1 && !geometryStale && lineCount <= frameTop - anchorFloor;
 
   const room = Math.max(0, frameTop - anchorFloor);
   const overflowTargetBottom = Math.max(1, rows - 1 - extraRows);
   const maxBandModel = Math.max(0, overflowTargetBottom - anchorFloor);
+  // Invariant (committedBand is always frame-adjacent by construction): the
+  // class-level invariant on `committedBand` guarantees it holds ONLY the
+  // contiguous on-screen run immediately above wherever the live frame
+  // currently sits — that logical fact does not change across a resize, only
+  // the ROW NUMBERS describing it do. When geometryStale, `committedBandBottomRow
+  // === frameTop - 1` is comparing a pre-resize row number against a frameTop
+  // that is itself a fallback (fitsAboveFrame is forced false above, so frameTop
+  // took the `rows-1-extraRows` branch) — an exact-match test that can never
+  // pass by construction. Trust the invariant directly instead: a non-empty,
+  // anchor-safe band is mergeable regardless of the stale row arithmetic, so it
+  // rides into the band-hold model as PENDING content rather than being treated
+  // as "not contiguous" and silently left to be overwritten by the next frame
+  // render with no scrollback copy ever having been made.
   const overflowPriorContiguous =
-    committedBand.length > 0 && anchorRow <= 1 && committedBandBottomRow === frameTop - 1;
+    committedBand.length > 0 &&
+    anchorRow <= 1 &&
+    (geometryStale || committedBandBottomRow === frameTop - 1);
   const overflowRun = overflowPriorContiguous ? [...committedBand, ...textLines] : textLines;
   const overflowHasPending =
     overflowPriorContiguous && committedBand.length > committedBandPaintedRows;

--- a/src/cli/terminal-compositor.band-reflow.ts
+++ b/src/cli/terminal-compositor.band-reflow.ts
@@ -1,0 +1,177 @@
+/**
+ * Invariant (retained-logical-source reflow — "strings wrapped at width W are
+ * only valid at width W"): committed-band reflow re-wraps retained band rows
+ * at the CURRENT terminal width before any paint site reads them. Shared by
+ * commitAbove (committed-band-commit.ts, which merges the PRIOR band into a
+ * new commit) and repaint (frame.ts, which feeds both
+ * preserveRowsBeforeFrameRender's eviction paints and
+ * repositionCommittedBand's re-pin from the SAME `self.committedBand`).
+ *
+ * External constraint (DECAWM autowrap semantics): terminal-compositor.
+ * committed-band-commit.ts hard-wraps committed text to `stdout.columns` ONCE,
+ * at commit time (`hardWrapToWidth(l, cols)`), and every downstream paint
+ * site used to CUP-paint those retained rows VERBATIM regardless of how many
+ * resizes happened since. A row wrapped at 160 cols is invalid at 64 cols —
+ * the terminal's own DECAWM autowrap (on by default, never disabled elsewhere
+ * in this codebase) then hard-wraps it AGAIN at the hardware level, inserting
+ * an unaccounted phantom row that desyncs every subsequent CUP/erase
+ * computation from the compositor's row model (ghost frames, mid-word
+ * truncation, corrupted geometry). The fix mirrors the industry-standard
+ * "reflow from model" approach (ratatui, Codex): never trust a previously-
+ * wrapped string at a new width — re-derive physical rows from the retained
+ * content at the width they are about to be painted at.
+ *
+ * `reflowBandSplit` is pure (no `this`, no I/O) so it is unit-testable in
+ * isolation; `reflowCommittedBandToWidth` is the narrow mutate-self wrapper
+ * matching this module family's free-functions-on-host convention.
+ */
+
+import { hardWrapToWidth } from './wrap.js';
+
+/**
+ * Invariant (painted/pending boundary survives reflow): `committedBand`'s
+ * BOTTOM `committedBandPaintedRows` rows are the ones physically on screen
+ * right now; the complementary TOP prefix is held only in this in-memory
+ * model (see the field doc on TerminalCompositor.committedBandPaintedRows).
+ * Naively re-wrapping the WHOLE array and leaving the row-count unchanged
+ * would desync that boundary the instant reflow changes the row count (e.g.
+ * a narrowing resize splits one row into two) — `decideCommitMode`'s
+ * `overflowHasPending`, `preserveRowsBeforeFrameRender`'s `hasPending`, and
+ * `flushPendingCommittedBand`'s flush-count all read `committedBandPaintedRows`
+ * against `committedBand.length` and would misfire (spurious eviction, or a
+ * disarm flushing already-on-screen rows as if they were unpainted). Reflow
+ * therefore splits the band into its pending PREFIX and painted SUFFIX,
+ * re-wraps each independently, and reports the new suffix's row count as the
+ * new `committedBandPaintedRows` — the boundary moves with the content it
+ * describes instead of staying pinned to a row index that no longer means
+ * the same thing once the row count has changed.
+ */
+export interface BandReflowResult {
+  rows: string[];
+  paintedRows: number;
+}
+
+/**
+ * Re-wrap `band` at `width`, preserving the pending/painted boundary at
+ * `paintedRows` (see the Invariant above). Content-preserving and idempotent
+ * across arbitrary sequences of width changes — hardWrapToWidth only
+ * relocates line-break positions, it never drops characters, and re-wrapping
+ * an already-`width`-fitting row at the SAME width returns it unchanged (so a
+ * steady-width repeat call is a no-op even without the cache in
+ * {@link reflowCommittedBandToWidth}).
+ */
+export function reflowBandSplit(
+  band: readonly string[],
+  paintedRows: number,
+  width: number,
+): BandReflowResult {
+  if (band.length === 0) return { rows: [], paintedRows: 0 };
+  const clampedPainted = Math.max(0, Math.min(paintedRows, band.length));
+  const pendingPrefix = band.slice(0, band.length - clampedPainted);
+  const paintedSuffix = band.slice(band.length - clampedPainted);
+  const reflow = (lines: readonly string[]): string[] =>
+    lines.flatMap((line) => hardWrapToWidth(line, width).split('\n'));
+  const reflowedSuffix = reflow(paintedSuffix);
+  const rows = [...reflow(pendingPrefix), ...reflowedSuffix];
+  return { rows, paintedRows: reflowedSuffix.length };
+}
+
+/**
+ * Memoizes the last reflow call so a steady-width repaint is a no-op. A hit
+ * requires the CURRENT `self.committedBand` reference and
+ * `self.committedBandPaintedRows` value to both still equal what this cache
+ * entry was produced from (see {@link reflowCommittedBandToWidth}).
+ */
+export interface BandReflowCache {
+  readonly band: readonly string[];
+  readonly paintedRows: number;
+  readonly width: number;
+}
+
+/** Narrowest state slice {@link reflowCommittedBandToWidth} touches. */
+export interface BandReflowHost {
+  committedBand: string[];
+  committedBandPaintedRows: number;
+  bandReflowCache: BandReflowCache | null;
+}
+
+/**
+ * Contract: re-wrap `self.committedBand` at `width` IN PLACE (mutating both
+ * the band array and its painted-count boundary — see {@link reflowBandSplit})
+ * and update the memoization cache. Call this at every band paint/merge site
+ * — commitAbove, before it reads the prior band to merge or route through
+ * band-hold; and repaint()/repaintPickerFrame(), before
+ * preserveRowsBeforeFrameRender and repositionCommittedBand read the band —
+ * so no consumer ever sees rows wrapped at a stale width. A no-op when the
+ * band is empty (cache cleared to null) so an empty-band steady state never
+ * pays even a cache-comparison cost.
+ *
+ * Two independent things can invalidate the cache even when `width` is
+ * unchanged: (1) a commit reassigns `committedBand` to a new array reference
+ * (Phase 3's merge/cap), and (2) `repositionCommittedBand` or a
+ * preserveRowsBeforeFrameRender eviction updates `committedBandPaintedRows`
+ * ALONE, without touching `committedBand`'s reference (a row moves from
+ * pending to painted with no content change). Both are covered by comparing
+ * against the cache's recorded `band`/`paintedRows`, not just `width`.
+ */
+export function reflowCommittedBandToWidth(self: BandReflowHost, width: number): void {
+  if (self.committedBand.length === 0) {
+    self.bandReflowCache = null;
+    return;
+  }
+  const cache = self.bandReflowCache;
+  if (
+    cache !== null &&
+    cache.band === self.committedBand &&
+    cache.paintedRows === self.committedBandPaintedRows &&
+    cache.width === width
+  ) {
+    return; // already reflowed to this width from this exact band+boundary
+  }
+  const { rows, paintedRows } = reflowBandSplit(self.committedBand, self.committedBandPaintedRows, width);
+  self.committedBand = rows;
+  self.committedBandPaintedRows = paintedRows;
+  self.bandReflowCache = { band: rows, paintedRows, width };
+}
+
+// DECAWM (autowrap) private-mode escapes.
+const DECAWM_OFF = '\x1b[?7l';
+const DECAWM_ON = '\x1b[?7h';
+
+/**
+ * Invariant (DECAWM autowrap semantics — belt-and-braces second layer): run
+ * `paint` with terminal autowrap DISABLED, guaranteeing it is re-enabled
+ * afterward even if `paint` throws. Defends against width-MEASUREMENT
+ * mismatches (ambiguous-width glyphs — ×, —, ╭ box-drawing — where this
+ * codebase's displayWidth() can disagree by ±1 column with a specific
+ * terminal's actual rendering): with autowrap off, an under-measured row can
+ * only be CLIPPED at the terminal's right edge, never spill into an
+ * unaccounted phantom row that corrupts the compositor's CUP/erase row math
+ * the way DEFECT 1 did. The reflow above (wrapping at the CURRENT width) is
+ * the primary correctness fix; this is a defensive second layer for the
+ * residual measurement-gap case reflow cannot rule out by construction.
+ *
+ * Teardown before setup: the `restore` closure (DECAWM_ON) is declared BEFORE
+ * `DECAWM_OFF` is written, and fires from a `finally` clause, so a throwing
+ * `paint` (e.g. a closed stdout mid-repaint) can never leave autowrap
+ * permanently disabled for the rest of the session.
+ */
+export function withAutowrapDisabled(stream: NodeJS.WriteStream, paint: () => void): void {
+  const restore = (): void => {
+    try {
+      stream.write(DECAWM_ON);
+    } catch {
+      /* terminal already gone — nothing more to restore */
+    }
+  };
+  try {
+    stream.write(DECAWM_OFF);
+  } catch {
+    return; // terminal already gone — skip the paint; nothing to restore either
+  }
+  try {
+    paint();
+  } finally {
+    restore();
+  }
+}

--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -17,6 +17,10 @@ import type { LogUpdateFn, CompositorScrollRegionGuard } from './terminal-compos
 import { eraseAndPaintRow } from './terminal-compositor.types.js';
 import { hardWrapToWidth } from './wrap.js';
 import { capBandModel, decideCommitMode } from './commit-mode.js';
+import {
+  reflowCommittedBandToWidth,
+  type BandReflowCache,
+} from './terminal-compositor.band-reflow.js';
 
 /**
  * Narrowest TerminalCompositor state slice the committed-band functions touch.
@@ -35,6 +39,8 @@ export interface CommittedBandHost {
   committedBandBottomRow: number;
   /** How many of committedBand's rows (its bottom suffix) are painted on screen. */
   committedBandPaintedRows: number;
+  /** Memoization for reflowCommittedBandToWidth — see the field doc on the class. */
+  bandReflowCache: BandReflowCache | null;
   /** Re-entrancy guard: suppresses a repaint during the clear→write window. */
   committing: boolean;
   /** Suppresses the shrink re-pin (repositionCommittedBand) for a commit. */
@@ -43,6 +49,12 @@ export interface CommittedBandHost {
   hasCommitted: boolean;
   /** Pre-resize on-screen footprint to physically erase on the next repaint. */
   pendingResizeErase: { top: number; bottom: number } | null;
+  /**
+   * F2: true from the SIGWINCH-immediate handler until the next debounced
+   * repaint re-establishes real frame geometry. See the field doc on the
+   * class (terminal-compositor.ts) for the full failure mode this guards.
+   */
+  bandGeometryStale: boolean;
   /** Pre-arm content ceiling — committed text never lands above this row. */
   anchorRow: number | undefined;
   /** Whether the compositor currently holds raw mode + the keypress listener. */
@@ -127,6 +139,15 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   // newest content still sits against the frame). The length>1 guard keeps
   // `commitAbove('')` painting its single blank row (the subagent-done path).
   const cols = Math.max(1, self.stdout.columns ?? 80);
+  // F1 (retained-logical-source re-wrap): the prior band was hard-wrapped at
+  // WHATEVER width was current when IT was committed — possibly a resize or
+  // several ago. Re-wrap it to the CURRENT `cols` before any of the geometry
+  // below reads `self.committedBand`/`committedBandBottomRow` (the merge
+  // contiguity check, decideCommitMode's overflowRun, and Phase 3's merge all
+  // read the band) — see terminal-compositor.band-reflow.ts's module doc for
+  // why a stale-width row can never be trusted verbatim again. No-op (and
+  // free) when nothing has resized since the band was last reflowed.
+  reflowCommittedBandToWidth(self, cols);
   const logicalLines = stripped.split('\n');
   let hasTrailingSeparator = false;
   while (logicalLines.length > 1 && logicalLines[logicalLines.length - 1] === '') {
@@ -187,9 +208,27 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   // band-hold paint then overwrites the repositioned prior-band content without
   // archiving it to scrollback, permanently losing it (zero hits on the prior
   // committed block after collapse).
+  //
+  // F2 (fail-safe commit mode on stale geometry): the correction above assumes
+  // `committedBandBottomRow` was set by a repositionCommittedBand call that ran
+  // against the CURRENT screen geometry. `bandGeometryStale` — set by the
+  // SIGWINCH-immediate handler alongside logUpdate.resetGeometry(), cleared by
+  // repositionCommittedBand once it re-pins against the new geometry — is false
+  // exactly when that assumption fails: a resize landed and no repaint has run
+  // since, so `committedBandBottomRow` is a PRE-resize row number. Using it as
+  // a floor here would reproduce that stale-but-nonzero row, defeat the
+  // `prevTopRow <= 1` band-hold safety fallback below (BLOCKER-1), and route
+  // decideCommitMode into the merge-then-cap fits path against geometry that no
+  // longer describes the screen — silently truncating the prior band as
+  // "already scrolled" rows that never scrolled (DEFECT 2, confirmed by
+  // terminal-compositor.resize-stale-width.repro.test.ts's H2 case). Skipping
+  // the floor while stale falls through to `rawLogUpdateTopRow` (0, since
+  // resetGeometry() zeroed it), which takes the `frameTop` fallback below and
+  // is exactly the "genuinely no known frame top" case BLOCKER-1 already
+  // handles safely via band-hold.
   const rawLogUpdateTopRow = self.logUpdate.topRow ?? 0;
   const prevTopRow =
-    self.committedBand.length > 0 && self.committedBandBottomRow > 0
+    self.committedBand.length > 0 && self.committedBandBottomRow > 0 && !self.bandGeometryStale
       ? Math.max(rawLogUpdateTopRow, self.committedBandBottomRow + 1)
       : rawLogUpdateTopRow;
   const frameTop = prevTopRow > 1 ? prevTopRow : Math.max(1, rows - 1 - extraRows);
@@ -272,6 +311,7 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     committedBand: self.committedBand,
     committedBandBottomRow: self.committedBandBottomRow,
     committedBandPaintedRows: self.committedBandPaintedRows,
+    geometryStale: self.bandGeometryStale,
   });
 
   // Suppress the shrink re-pin for the whole commit; Phase 3 sets the band.
@@ -664,6 +704,10 @@ export function clearCommittedBand(self: CommittedBandHost): void {
   self.committedBandTopRow = 0;
   self.committedBandBottomRow = 0;
   self.committedBandPaintedRows = 0;
+  // Explicit reset (also self-invalidates via reflowCommittedBandToWidth's
+  // reference check once committedBand is reassigned above, but an empty band
+  // never needs a cache entry either way).
+  self.bandReflowCache = null;
 }
 
 /**

--- a/src/cli/terminal-compositor.committed-band-repin.ts
+++ b/src/cli/terminal-compositor.committed-band-repin.ts
@@ -7,6 +7,7 @@
 
 import type { CommittedBandHost } from './terminal-compositor.committed-band-commit.js';
 import { eraseAndPaintRow } from './terminal-compositor.types.js';
+import { withAutowrapDisabled } from './terminal-compositor.band-reflow.js';
 
 /**
  * Physically erase the pre-resize on-screen footprint snapshotted by the
@@ -73,7 +74,14 @@ export function repositionCommittedBand(
   if (self.commitInFlight || !self.logUpdate) return;
   const floor = Math.max(self.anchorRow ?? 1, 1);
   const targetBottom = desiredTopRow - 1;
-  if (self.committedBand.length === 0) return;
+  if (self.committedBand.length === 0) {
+    // F2: an empty band has nothing for a stale committedBandBottomRow to
+    // corrupt (commitAbove's floor-usage already requires
+    // `committedBandBottomRow > 0` alongside a non-empty band), so this
+    // repaint cycle's geometry is safe to trust again.
+    self.bandGeometryStale = false;
+    return;
+  }
   // On upward growth (targetBottom < committedBandBottomRow) the band must be
   // re-pinned above the NEW frame top: preserveRowsBeforeFrameRender either
   // left the whole band in place (it fits) or already scrolled the overflow
@@ -82,7 +90,15 @@ export function repositionCommittedBand(
   // computes. (Banner case keeps the legacy scroll-and-shift, which lands the
   // band at targetBottom too.) The paint is always above the frame top, so it
   // never overwrites the live frame.
-  if (targetBottom < floor) return;
+  if (targetBottom < floor) return; // F2: band exists but has NO room above the
+  // current floor — do NOT clear bandGeometryStale here: committedBandBottomRow
+  // is left at its old (possibly stale) value below, so a later commit must
+  // keep distrusting it as a floor until a repaint actually re-establishes it.
+  // F2: past this point `targetBottom`/`floor` are fresh values derived from
+  // THIS repaint's real desiredTopRow/anchorRow, so whatever `fit` computes
+  // (a real re-pin below, or "already correct, nothing moved") reflects
+  // CURRENT geometry — safe to trust committedBandBottomRow again from here.
+  self.bandGeometryStale = false;
   const maxFit = targetBottom - floor + 1;
   const fit = Math.min(self.committedBand.length, maxFit);
   if (fit <= 0) return;
@@ -107,11 +123,19 @@ export function repositionCommittedBand(
   // Re-park the cursor where CupFrameRenderer.render() left it (the frame's
   // bottom content row) so the band write does not displace it.
   out += `\x1b[${Math.max(1, targetBottomRow)};1H`;
-  try {
-    self.stdout.write(out);
-  } catch {
-    /* terminal closed mid-repaint — next render's lifecycle tears us down */
-  }
+  // Belt-and-braces (see withAutowrapDisabled doc): F1's reflow already
+  // guarantees `paint`'s rows fit the CURRENT width by construction, but a
+  // ±1-column displayWidth() disagreement with the real terminal on an
+  // ambiguous-width glyph could still let one row overrun by a cell. With
+  // DECAWM off that can only clip the row, never spawn a phantom row that
+  // desyncs `committedBandTopRow`/`committedBandBottomRow` from the screen.
+  withAutowrapDisabled(self.stdout, () => {
+    try {
+      self.stdout.write(out);
+    } catch {
+      /* terminal closed mid-repaint — next render's lifecycle tears us down */
+    }
+  });
   self.committedBandTopRow = newTop;
   self.committedBandBottomRow = targetBottom;
   // `fit` rows (the band's bottom suffix) are now materialized on screen — this

--- a/src/cli/terminal-compositor.frame-preserve.ts
+++ b/src/cli/terminal-compositor.frame-preserve.ts
@@ -10,6 +10,7 @@
 
 import type { FrameHost } from './terminal-compositor.frame.js';
 import { eraseAndPaintRow } from './terminal-compositor.types.js';
+import { withAutowrapDisabled } from './terminal-compositor.band-reflow.js';
 
 /**
  * Preserve rows that the next compositor frame is about to cover.
@@ -105,11 +106,19 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
       for (let i = 0; i < bandLen; i++) {
         out += eraseAndPaintRow(1 + i, self.committedBand[i]);
       }
-      try {
-        self.stdout.write(out);
-      } catch {
-        /* terminal closed mid-render — next render's lifecycle tears us down */
-      }
+      // Belt-and-braces DECAWM bracket (see withAutowrapDisabled doc): the band
+      // rows painted here were re-wrapped at the current width by repaint()'s
+      // reflowCommittedBandToWidth call before this function ran; disabling
+      // autowrap defends against a residual ±1-column displayWidth()
+      // measurement gap on ambiguous-width glyphs, which can otherwise
+      // fabricate an unaccounted phantom row.
+      withAutowrapDisabled(self.stdout, () => {
+        try {
+          self.stdout.write(out);
+        } catch {
+          /* terminal closed mid-render — next render's lifecycle tears us down */
+        }
+      });
       evictRowsToScrollback(self, overflow);
       // Survivors physically shifted to [1, room] by the scroll.
       self.committedBand = self.committedBand.slice(overflow);
@@ -135,11 +144,14 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
     for (let i = 0; i < bandLen; i++) {
       out += eraseAndPaintRow(1 + i, self.committedBand[i]);
     }
-    try {
-      self.stdout.write(out);
-    } catch {
-      /* terminal closed mid-render — next render's lifecycle tears us down */
-    }
+    // Belt-and-braces DECAWM bracket — see the identical comment above.
+    withAutowrapDisabled(self.stdout, () => {
+      try {
+        self.stdout.write(out);
+      } catch {
+        /* terminal closed mid-render — next render's lifecycle tears us down */
+      }
+    });
     evictRowsToScrollback(self, growOverflow);
     // Survivors physically shifted to [1, growRoom] by the scroll — already
     // hugging the new frame top (growRoom === desiredTopRow - 1). Record that so a
@@ -210,11 +222,15 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
     for (let i = 0; i < bandLenBanner; i++) {
       out += eraseAndPaintRow(floorBanner + i, self.committedBand[i]);
     }
-    try {
-      self.stdout.write(out);
-    } catch {
-      /* terminal closed mid-render — next render's lifecycle tears us down */
-    }
+    // Belt-and-braces DECAWM bracket — see the identical comment earlier in
+    // this file (the !hasBanner pending-overflow eviction).
+    withAutowrapDisabled(self.stdout, () => {
+      try {
+        self.stdout.write(out);
+      } catch {
+        /* terminal closed mid-render — next render's lifecycle tears us down */
+      }
+    });
     evictRowsToScrollback(self, overflow);
     // Survivors physically shifted to [floor, floor+room-1] by the scroll.
     self.committedBand = self.committedBand.slice(overflow);

--- a/src/cli/terminal-compositor.frame.ts
+++ b/src/cli/terminal-compositor.frame.ts
@@ -29,6 +29,10 @@ import type {
   PickerController,
 } from './terminal-compositor.types.js';
 import { preserveRowsBeforeFrameRender } from './terminal-compositor.frame-preserve.js';
+import {
+  reflowCommittedBandToWidth,
+  type BandReflowCache,
+} from './terminal-compositor.band-reflow.js';
 
 /**
  * Narrowest TerminalCompositor state slice the frame-composition functions
@@ -69,6 +73,8 @@ export interface FrameHost {
   committedBandTopRow: number;
   committedBandBottomRow: number;
   committedBandPaintedRows: number;
+  /** Memoization for reflowCommittedBandToWidth — see the field doc on the class. */
+  bandReflowCache: BandReflowCache | null;
   hasCommitted: boolean;
   anchorRow: number | undefined;
   lastKnownRows: number;
@@ -97,6 +103,14 @@ export function repaint(self: FrameHost): void {
   // expand vs shrink.
   self.flushResizeGhostErase();
   self.lastKnownRows = self.stdout.rows ?? 24;
+  // F1 (retained-logical-source re-wrap): re-wrap the retained band at the
+  // CURRENT width before EITHER downstream consumer reads it this repaint —
+  // preserveRowsBeforeFrameRender's eviction paints (called below and from
+  // repaintPickerFrame) and repositionCommittedBand's re-pin (same two call
+  // sites) both read `self.committedBand` verbatim. Placed above the picker
+  // short-circuit so both paths see fresh-width rows; a steady-width repeat
+  // repaint is a cache hit (see reflowCommittedBandToWidth) and costs nothing.
+  reflowCommittedBandToWidth(self, self.stdout.columns ?? 80);
   // Picker-mode short-circuit. The picker rents the input region
   // (dropdown + hint + input line all suppressed) and supplies its
   // own rows via `renderRows()`. Overlay/spinner/tip/attachment

--- a/src/cli/terminal-compositor.lifecycle.ts
+++ b/src/cli/terminal-compositor.lifecycle.ts
@@ -73,6 +73,10 @@ export interface LifecycleHost {
   // Read by disarm() to flush genuinely-unpainted committed-band rows to
   // scrollback before teardown. See committedBandPaintedRows on the class.
   readonly committedBandPaintedRows: number;
+  // F2: set by the SIGWINCH-immediate handler; cleared by the next debounced
+  // repaint once repositionCommittedBand re-establishes real geometry. See the
+  // field doc on the class (terminal-compositor.ts).
+  bandGeometryStale: boolean;
 }
 
 /**
@@ -300,6 +304,17 @@ export async function arm(self: LifecycleHost & KeyDispatchHost): Promise<void> 
     // for a redundant vacated-gap erase, never a stale paint). The old
     // on-screen band copy is cleared via pendingResizeErase above on EXPAND,
     // or scrolled by the terminal on SHRINK.
+    //
+    // F2 (fail-safe commit mode on stale geometry): mark the band's row
+    // geometry stale ALONGSIDE the logUpdate reset above — a commit that
+    // lands in the window between this immediate handler and the next
+    // debounced repaint (below) must not trust committedBandBottomRow as a
+    // floor for prevTopRow (see the field doc on bandGeometryStale,
+    // terminal-compositor.ts, and the prevTopRow site in
+    // terminal-compositor.committed-band-commit.ts). Cleared by
+    // repositionCommittedBand once it re-pins the band against real
+    // post-resize geometry.
+    self.bandGeometryStale = true;
   });
 
   // Intentionally NOT calling `updateAutocomplete()` here. The compositor's

--- a/src/cli/terminal-compositor.reset.ts
+++ b/src/cli/terminal-compositor.reset.ts
@@ -38,6 +38,7 @@ export interface ResetStateHost {
   hasCommitted: boolean;
   commitInFlight: boolean;
   pendingResizeErase: { top: number; bottom: number } | null;
+  bandGeometryStale: boolean;
   lastKnownRows: number;
   pickerController: PickerController | null;
   inputMode: CompositorInputMode;
@@ -86,6 +87,13 @@ export function resetState(self: ResetStateHost): void {
   // the previous arm cycle must not leak into the next one (the first repaint
   // of a fresh arm re-seeds lastKnownRows before any resize can be detected).
   self.pendingResizeErase = null;
+  // F2: a stale-geometry flag from the previous arm cycle must not leak into
+  // the next one either — a fresh arm has no geometry yet (rather than WRONG
+  // geometry), which is the same "genuinely unknown" case BLOCKER-1 already
+  // handles safely, so leaving this true would only over-defer harmlessly —
+  // but resetting it keeps the field's meaning exact: "stale since the last
+  // resize", not "stale forever until any resize happens to occur".
+  self.bandGeometryStale = false;
   self.lastKnownRows = 0;
   // Drop any active picker — a disarm during a picker would leave
   // the controller's resolve callback orphaned. The runPicker abort

--- a/src/cli/terminal-compositor.resize-stale-width.repro.test.ts
+++ b/src/cli/terminal-compositor.resize-stale-width.repro.test.ts
@@ -1,0 +1,449 @@
+/**
+ * Regression suite for two confirmed TUI defects under mid-stream terminal
+ * resize (tmux, multiple resizes). Originally an empirical repro file (RED
+ * on both defects); converted to GREEN regression tests once fixed.
+ *
+ * DEFECT 1 (ghost frames / mid-word truncation at stale widths): committedBand
+ * entries used to be hard-wrapped to terminal width ONCE at commit time
+ * (terminal-compositor.committed-band-commit.ts, `hardWrapToWidth` at commit)
+ * and later repainted VERBATIM by every paint site — repositionCommittedBand
+ * (terminal-compositor.committed-band-repin.ts), and the frame-preserve
+ * eviction paints (terminal-compositor.frame-preserve.ts). If a resize
+ * narrowed the terminal after commit but before the band materialized
+ * (band-hold defers materialization until overlay collapse), the repaint
+ * painted rows wider than the new column count — DECAWM autowrap then
+ * silently hard-wrapped them again at the hardware level, corrupting all
+ * subsequent row math.
+ *
+ * FIX: terminal-compositor.band-reflow.ts's `reflowCommittedBandToWidth` is
+ * called at every band-reading site (commitAbove, before it merges the prior
+ * band; repaint(), before preserveRowsBeforeFrameRender/repositionCommittedBand
+ * read it) — the retained LOGICAL content is re-wrapped at the CURRENT
+ * terminal width every time, never trusted verbatim across a resize. Band
+ * paint sites are additionally bracketed with DECAWM off/on
+ * (`withAutowrapDisabled`) as a belt-and-braces defense against residual
+ * ambiguous-width-glyph measurement gaps.
+ *
+ * DEFECT 2 (silent content loss): the SIGWINCH-immediate handler
+ * (terminal-compositor.lifecycle.ts) calls `logUpdate.resetGeometry()`
+ * (zeroing `CupFrameRenderer.previousTopRow`) but deliberately leaves
+ * `committedBandTopRow`/`committedBandBottomRow` stale ("intentionally NOT
+ * cleared" — preserved for repositionCommittedBand's later re-pin). A commit
+ * landing before the debounced repaint used to compute
+ * `prevTopRow = max(0, committedBandBottomRow + 1)`
+ * (terminal-compositor.committed-band-commit.ts) — the stale floor reproduced
+ * the PRE-resize row, kept `prevTopRow > 1`, and defeated the
+ * `prevTopRow <= 1` band-hold safety fallback (BLOCKER-1 in commit-mode.ts).
+ * `fitsAboveFrame` was then spuriously true and Phase-3 merge-then-cap
+ * silently truncated the prior band as "already scrolled" rows that never
+ * scrolled — the prior block vanished from screen AND scrollback.
+ *
+ * FIX: a new `bandGeometryStale` flag (TerminalCompositor) is set by the
+ * SIGWINCH-immediate handler alongside `resetGeometry()`, and cleared only
+ * once `repositionCommittedBand` re-pins the band against real post-resize
+ * geometry. While stale, `commitAbove`'s `prevTopRow` computation skips the
+ * `committedBandBottomRow + 1` floor entirely (falling through to the
+ * genuinely-unknown-frame-top case BLOCKER-1 already handles safely), and
+ * `decideCommitMode` forces `fitsAboveFrame` false and treats the prior band
+ * as mergeable-by-invariant rather than requiring an exact (and, while stale,
+ * unrecoverable) row-number match — so content rides into the band-hold model
+ * as PENDING instead of being silently dropped.
+ *
+ * Commit 002bcd1 (PR #351) fixed a DIFFERENT trigger of this same failure
+ * class (frame-height shrink at a STABLE column width) and must stay fixed —
+ * see the baseline-sanity test below.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { StatusLine } from './status-line.js';
+import { stripAnsi, displayWidth } from './display.js';
+import { VirtualScreen } from './_lib/testing/virtual-screen.js';
+
+type MockStdout = NodeJS.WriteStream & {
+  isTTY: boolean;
+  columns: number;
+  rows: number;
+};
+type MockStdin = NodeJS.ReadStream & {
+  isTTY: boolean;
+  isRaw: boolean;
+  setRawMode: ReturnType<typeof vi.fn>;
+};
+
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true;
+  s.columns = cols;
+  s.rows = rows;
+  return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true;
+  s.isRaw = false;
+  s.setRawMode = vi.fn((raw: boolean) => {
+    s.isRaw = raw;
+    return s;
+  });
+  return s;
+}
+function collectWrites(stream: MockStdout): { all: () => string } {
+  const chunks: string[] = [];
+  stream.on('data', (c: unknown) => chunks.push(String(c)));
+  return { all: () => chunks.join('') };
+}
+
+/** Internal view used to read the compositor's private geometry tracking. */
+interface Internals {
+  repaint(): void;
+  committedBand: string[];
+  committedBandTopRow: number;
+  committedBandBottomRow: number;
+  committedBandPaintedRows: number;
+  logUpdate: { topRow?: number } | null;
+}
+
+/** Parse every `CUP row;1H` + `EL` + content write (eraseAndPaintRow's shape). */
+function parseErasePaintWrites(out: string): { row: number; content: string }[] {
+  const re = /\x1b\[(\d+);1H\x1b\[2K([^\x1b]*)/g;
+  const writes: { row: number; content: string }[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(out)) !== null) {
+    writes.push({ row: Number(m[1]), content: m[2] ?? '' });
+  }
+  return writes;
+}
+
+describe('TerminalCompositor — resize-window stale-geometry corruption (H1 + H2 fix regression)', () => {
+  const armed: TerminalCompositor[] = [];
+
+  afterEach(() => {
+    // arm() registers a process-level SIGWINCH listener via ResizeBus; a failing
+    // assertion would otherwise leak it and hang the run. Disarm defensively —
+    // mirrors terminal-compositor.resize-ghost.test.ts's afterEach.
+    while (armed.length > 0) {
+      try {
+        armed.pop()?.disarm();
+      } catch {
+        /* idempotent */
+      }
+    }
+    vi.useRealTimers();
+  });
+
+  it('H1 FIXED: repositionCommittedBand re-wraps stale-width band rows at the CURRENT width after a column-shrink resize — no content loss, no overwide rows', async () => {
+    vi.useFakeTimers();
+    const stdout = makeStdout(160, 24);
+    const stdin = makeStdin();
+    const writes = collectWrites(stdout);
+    const vscreen = new VirtualScreen(64, 24); // final post-resize geometry
+    stdout.on('data', (chunk: unknown) => {
+      if (Buffer.isBuffer(chunk)) vscreen.write(chunk as Buffer);
+      else if (typeof chunk === 'string') vscreen.write(Buffer.from(chunk, 'utf-8'));
+    });
+    const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+    statusLine.start();
+    statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+    const c = new TerminalCompositor({
+      stdout,
+      stdin,
+      onCancel: vi.fn(),
+      scrollRegion: statusLine,
+      anchorRow: 1,
+    });
+    armed.push(c);
+    await c.arm();
+    statusLine.setExtraRows(2);
+    c.setSpinner({ enabled: true });
+    const internals = c as unknown as Internals;
+
+    // Force band-hold: a 22-line overlay fills the 24-row viewport, so the
+    // commit below lands with prevTopRow<=1 and is HELD in the model rather
+    // than immediately painted (band-hold, terminal-compositor.h1-prevtoprow
+    // .test.ts documents this routing). The block is committed at cols=160.
+    const tallOverlay = Array.from(
+      { length: 22 },
+      (_, i) => `thinking ${i} — held overlay row keeping the frame at full height`,
+    ).join('\n');
+    c.setOverlay(tallOverlay);
+
+    // Each row is 100 display columns: < 160 (fits, no wrap at commit time)
+    // but > 64 (the post-resize width), so it is a clean witness for
+    // "was this re-wrapped at repaint time, or painted at its stale width?"
+    const mkRow = (tag: string): string => `${tag}_` + 'Y'.repeat(100 - tag.length - 1);
+    const blockLines = [mkRow('L01'), mkRow('L02'), mkRow('L03')];
+    c.commitAbove(blockLines.join('\n') + '\n\n');
+
+    // Precondition: the band-hold model holds the block, hard-wrapped at the
+    // COMMIT-TIME width (100 chars, unwrapped because 100 < 160).
+    expect(internals.committedBand.length).toBeGreaterThan(0);
+    for (const line of internals.committedBand) {
+      if (line.length > 0) expect(displayWidth(stripAnsi(line))).toBeLessThanOrEqual(100);
+    }
+
+    // Resize: cols 160 -> 64 (a pure-width SIGWINCH, tmux pane-split style).
+    // Fire both the immediate AND (after advancing timers) the debounced
+    // channel, exactly as terminal-compositor.resize-ghost.test.ts does.
+    stdout.columns = 64;
+    process.stdout.emit('resize');
+    vi.advanceTimersByTime(150);
+
+    // Collapse the overlay so band-hold materializes the pending model —
+    // this is where repositionCommittedBand paints the retained band rows.
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    internals.repaint();
+    internals.repaint();
+
+    const out = writes.all();
+    const paints = parseErasePaintWrites(out);
+    const overWidth = paints.filter((p) => displayWidth(stripAnsi(p.content)) > 64);
+
+    // (a) Every painted row's display width fits the CURRENT (post-resize)
+    // terminal width — the compositor re-wraps retained content when it
+    // finally paints it, because the geometry it was captured under no
+    // longer exists.
+    expect(
+      overWidth,
+      `expected no band row wider than the post-resize terminal width (64 cols); ` +
+        `found: ${JSON.stringify(overWidth.slice(0, 3))}`,
+    ).toEqual([]);
+
+    // (b) Every committed logical line's content is fully present in the
+    // final combined scrollback+viewport buffer — re-wrapping may change
+    // WHERE a line breaks, but must never drop characters. Reconstruct each
+    // logical line's content (rejoin the ANSI-stripped screen, drop the
+    // static overlay/status-line chrome rows) and check the full marker text
+    // survives somewhere contiguous.
+    const combined = [...vscreen.scrollbackLines(), ...vscreen.visibleLines()].join('\n');
+    for (const line of blockLines) {
+      const [tag, ...rest] = line.split('_');
+      const body = rest.join('_');
+      // The tag prefix (e.g. "L01_") must survive intact — re-wrapping never
+      // splits it because it is only 4 chars, far under any tested width.
+      expect(combined, `marker "${tag}_" missing from final screen`).toContain(`${tag}_`);
+      // Full content check: strip all whitespace/newlines from the region
+      // around the tag and confirm the complete 96-char run of 'Y' is there,
+      // proving no characters were dropped by the re-wrap (only reflowed).
+      const flattenedRun = combined.replace(/\s+/g, '');
+      expect(
+        flattenedRun,
+        `full un-wrapped content for ${tag} not found contiguously (content loss)`,
+      ).toContain(`${tag}_${body}`.replace(/\s+/g, ''));
+    }
+  }, 15_000);
+
+  it('H2 FIXED: a commit landing between the SIGWINCH-immediate handler and the debounced repaint no longer drops the PRIOR committed block — both blocks survive, no row exceeds the new width', async () => {
+    vi.useFakeTimers();
+    const stdout = makeStdout(160, 24);
+    const stdin = makeStdin();
+    // VirtualScreen is the repo's own synchronous ANSI interpreter (used by
+    // terminal-compositor.resize-ghost.test.ts) — chosen over @xterm/headless
+    // here because @xterm/headless's internal async parsing does not resolve
+    // under vi.useFakeTimers(), which this test needs for the SIGWINCH
+    // immediate/debounced-channel split.
+    const vscreen = new VirtualScreen(100, 24); // final post-resize geometry
+    stdout.on('data', (chunk: unknown) => {
+      if (Buffer.isBuffer(chunk)) vscreen.write(chunk as Buffer);
+      else if (typeof chunk === 'string') vscreen.write(Buffer.from(chunk, 'utf-8'));
+    });
+    const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+    statusLine.start();
+    statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+    const c = new TerminalCompositor({
+      stdout,
+      stdin,
+      onCancel: vi.fn(),
+      scrollRegion: statusLine,
+      anchorRow: 1,
+    });
+    armed.push(c);
+    await c.arm();
+    statusLine.setExtraRows(2);
+    c.setSpinner({ enabled: true });
+    const internals = c as unknown as Internals;
+
+    // Overlay lines are 120 display columns: ONE physical row at cols=160,
+    // but wrap to TWO physical rows at cols=100. This makes the resize a
+    // genuine PHYSICAL-geometry change (frame row count changes) without
+    // touching stdout.rows at all — the pure-width analog of a shrink.
+    const mkOverlayLine = (i: number): string => `OV${i}_` + 'Z'.repeat(120 - `OV${i}_`.length);
+    const overlay8 = Array.from({ length: 8 }, (_, i) => mkOverlayLine(i)).join('\n');
+    c.setOverlay(overlay8);
+
+    // Commit A at cols=160 — fits above the frame; single-copy paint, band
+    // tracks it adjacent to the (wide) frame top.
+    c.commitAbove('BLOCK_A_marker committed at cols=160\n\n');
+    expect(internals.committedBand.some((l) => l.includes('BLOCK_A_marker'))).toBe(true);
+
+    // Resize cols 160 -> 100. Fire ONLY the immediate (synchronous) SIGWINCH
+    // channel — the 150ms debounce that would repaint at the new geometry
+    // has deliberately NOT fired yet. This is the exact window H2 targets:
+    // "commits landing between SIGWINCH and next debounced repaint."
+    stdout.columns = 100;
+    process.stdout.emit('resize');
+
+    // Commit B lands inside that window.
+    c.commitAbove('BLOCK_B_marker committed right after resize\n\n');
+
+    // Now let the debounce fire and the overlay collapse, exactly like a
+    // real session settling after the resize.
+    vi.advanceTimersByTime(150);
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    internals.repaint();
+    internals.repaint();
+
+    const combined = [...vscreen.scrollbackLines(), ...vscreen.visibleLines()];
+    const combinedText = combined.join('\n');
+
+    // Both committed blocks are internally-consistent and BOTH survive
+    // somewhere in the combined scrollback+viewport buffer — a commit is
+    // never silently unwritten, regardless of a resize landing mid-commit.
+    expect(combinedText).toContain('BLOCK_A_marker');
+    expect(combinedText).toContain('BLOCK_B_marker');
+    // Each appears exactly once — no duplicate ghost copy from the fix's
+    // band-hold-as-pending routing.
+    expect(combinedText.split('BLOCK_A_marker').length - 1).toBe(1);
+    expect(combinedText.split('BLOCK_B_marker').length - 1).toBe(1);
+    // No painted row exceeds the new (post-resize) terminal width.
+    for (const line of combined) {
+      expect(displayWidth(stripAnsi(line))).toBeLessThanOrEqual(100);
+    }
+  }, 15_000);
+
+  it('baseline sanity: the 002bcd1 shrink-padding case (H2 original target) remains fixed — prior committed prose still survives a frame-height shrink at a STABLE column width', async () => {
+    // Re-derives (does not import) the scenario terminal-compositor.commit-geometry
+    // .test.ts pins, as a narrow confirmation that this file's H2 fix is a
+    // DIFFERENT residual trigger's fix, not a regression of 002bcd1's original one.
+    const stdout = makeStdout(120, 24);
+    const stdin = makeStdin();
+    const writes = collectWrites(stdout);
+    const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+    statusLine.start();
+    statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+    const c = new TerminalCompositor({
+      stdout,
+      stdin,
+      onCancel: vi.fn(),
+      scrollRegion: statusLine,
+      anchorRow: 1,
+    });
+    armed.push(c);
+    await c.arm();
+    statusLine.setExtraRows(2);
+    c.setSpinner({ enabled: true });
+    const internals = c as unknown as Internals;
+
+    const tallOverlay = Array.from(
+      { length: 14 },
+      (_, i) => `thinking ${i} — subagent dispatched, analysing claim ${i}`,
+    ).join('\n');
+    c.setOverlay(tallOverlay);
+    c.commitAbove('GEO_PROSE committed block — should survive the shrink\n\n');
+    expect(internals.committedBandBottomRow).toBe(4);
+
+    // Shrink the OVERLAY height only — no SIGWINCH, no column change. This is
+    // 002bcd1's original trigger: CupFrameRenderer shrink-padding within a
+    // stable-width session.
+    const smallOverlay = Array.from({ length: 4 }, (_, i) => `overlay shrunk ${i}`).join('\n');
+    c.setOverlay(smallOverlay);
+    expect(internals.committedBandBottomRow).toBe(14); // repositionCommittedBand re-pinned it
+
+    c.commitAbove(
+      'GEO_TABLE_ROW_1 | data | col\n' +
+        'GEO_TABLE_ROW_2 | data | col\n' +
+        'GEO_TABLE_ROW_3 | data | col\n\n',
+    );
+    c.setOverlay('');
+    internals.repaint();
+    internals.repaint();
+
+    const out = writes.all();
+    expect(out).toContain('GEO_PROSE');
+    expect(out).toContain('GEO_TABLE_ROW_1');
+  }, 15_000);
+
+  it('multi-resize storm: commit, resize 160→100, commit, resize 100→64, collapse — all content present exactly once, no row exceeds 64 cols', async () => {
+    vi.useFakeTimers();
+    const stdout = makeStdout(160, 24);
+    const stdin = makeStdin();
+    const vscreen = new VirtualScreen(64, 24); // final post-resize geometry
+    stdout.on('data', (chunk: unknown) => {
+      if (Buffer.isBuffer(chunk)) vscreen.write(chunk as Buffer);
+      else if (typeof chunk === 'string') vscreen.write(Buffer.from(chunk, 'utf-8'));
+    });
+    const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+    statusLine.start();
+    statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+    const c = new TerminalCompositor({
+      stdout,
+      stdin,
+      onCancel: vi.fn(),
+      scrollRegion: statusLine,
+      anchorRow: 1,
+    });
+    armed.push(c);
+    await c.arm();
+    statusLine.setExtraRows(2);
+    c.setSpinner({ enabled: true });
+    const internals = c as unknown as Internals;
+
+    // A tall-but-not-full overlay: big enough to hold both commits above the
+    // frame in the band model (exercising BOTH the H1 stale-width repaint
+    // path and the H2 stale-geometry commit path across TWO width changes),
+    // without pinning prevTopRow<=1 for the whole scenario.
+    const tallOverlay = Array.from({ length: 20 }, (_, i) => `thinking ${i} — held overlay row`).join(
+      '\n',
+    );
+    c.setOverlay(tallOverlay);
+
+    // Commit STORM_ONE at cols=160.
+    c.commitAbove('STORM_ONE_marker committed at 160 cols with extra padding text here\n\n');
+
+    // Resize 160 -> 100, mirroring H2's window: the debounce has NOT fired
+    // yet when the next commit lands.
+    stdout.columns = 100;
+    process.stdout.emit('resize');
+
+    // Commit STORM_TWO inside that stale-geometry window.
+    c.commitAbove('STORM_TWO_marker committed right after first resize event landing\n\n');
+
+    // Let the first resize's debounced repaint settle geometry at 100 cols.
+    vi.advanceTimersByTime(150);
+    internals.repaint();
+
+    // Second resize: 100 -> 64 (narrower again — re-wraps whatever was
+    // wrapped at 100 back down to 64, exercising reflow-of-a-reflow).
+    stdout.columns = 64;
+    process.stdout.emit('resize');
+    vi.advanceTimersByTime(150);
+
+    // Collapse the overlay so the band model fully materializes.
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    internals.repaint();
+    internals.repaint();
+
+    const combined = [...vscreen.scrollbackLines(), ...vscreen.visibleLines()];
+    const combinedText = combined.join('\n');
+
+    // Each unique marker string appears EXACTLY ONCE — no duplicate ghost
+    // copies from any of the two resizes or two commits.
+    expect(combinedText.split('STORM_ONE_marker').length - 1).toBe(1);
+    expect(combinedText.split('STORM_TWO_marker').length - 1).toBe(1);
+
+    // No row in the final combined buffer exceeds the FINAL terminal width
+    // (64 cols) — content committed at 160 and re-wrapped once already (to
+    // 100) is re-wrapped AGAIN to the final width, not left stale at an
+    // intermediate width.
+    for (const line of combined) {
+      expect(
+        displayWidth(stripAnsi(line)),
+        `row exceeds 64 cols after the multi-resize storm: ${JSON.stringify(line)}`,
+      ).toBeLessThanOrEqual(64);
+    }
+  }, 15_000);
+});

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -44,6 +44,7 @@ import * as InputMode from './terminal-compositor.input-mode.js';
 import * as InputDispatch from './terminal-compositor.input-dispatch.js';
 import * as Lifecycle from './terminal-compositor.lifecycle.js';
 import * as Reset from './terminal-compositor.reset.js';
+import type { BandReflowCache } from './terminal-compositor.band-reflow.js';
 
 // Re-export public types so existing importers of './terminal-compositor.js'
 // continue to work without any import-path changes.
@@ -355,6 +356,14 @@ export class TerminalCompositor {
   // clearCommittedBand() and (transitively) resetState().
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   committedBandPaintedRows = 0;
+  // Memoization for terminal-compositor.band-reflow.ts's reflowCommittedBandToWidth:
+  // records the (band-reference, paintedRows, width) triple the LAST reflow call
+  // produced, so a steady-width repeat repaint (no commit, no resize since) skips
+  // re-wrapping. Any real mutation of committedBand/committedBandPaintedRows
+  // invalidates it automatically (see the Contract on reflowCommittedBandToWidth).
+  // Reset to null by clearCommittedBand() and (transitively) resetState().
+  /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
+  bandReflowCache: BandReflowCache | null = null;
   // Resize ghost-erase state. On SIGWINCH the immediate handler snapshots the
   // pre-resize on-screen footprint of the compositor (old live-frame rows +
   // committed-band rows) into `pendingResizeErase`; the next repaint physically
@@ -369,6 +378,20 @@ export class TerminalCompositor {
   lastKnownRows = 0;
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   pendingResizeErase: { top: number; bottom: number } | null = null;
+  // Invariant (F2 — fail-safe commit mode on stale geometry): set by the
+  // SIGWINCH-immediate handler alongside logUpdate.resetGeometry() and cleared
+  // only once the debounced post-resize repaint has re-established real
+  // geometry (repositionCommittedBand ran against the new width/height). While
+  // true, commitAbove's prevTopRow computation must NOT trust the
+  // committedBandBottomRow+1 floor (committed-band-commit.ts) — that floor
+  // reproduces the PRE-resize row number, which is stale-but-nonzero and would
+  // defeat the prevTopRow<=1 band-hold safety fallback (BLOCKER-1,
+  // commit-mode.ts), causing decideCommitMode to take the fits-path/
+  // merge-then-cap branch against geometry that no longer describes the
+  // screen — silently truncating the prior band as "already scrolled" rows
+  // that never scrolled (DEFECT 2). See commitAbove's prevTopRow site.
+  /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
+  bandGeometryStale = false;
   // True for the full duration of commitAbove (Phases 1–3). Suppresses the
   // shrink re-pin during the Phase-2 repaint — Phase 3 paints the band itself
   // and sets its rows, so re-pinning mid-commit would act on a stale band.


### PR DESCRIPTION
## Problem

A live REPL session inside tmux (multi-client, several pane resizes mid-stream) corrupted scrollback three ways: **ghost duplicate frames** of the same paragraphs at up to 5 historical widths, **mid-word truncation** at columns matching no current geometry, and **silent loss of committed content**. Forensic `tmux capture-pane` evidence showed content formatted at ≥5 distinct widths (~165/125/106/85/64 cols).

## Root causes (both confirmed red-first)

1. **Stale-width verbatim repaint** — `commitAbove` hard-wraps committed text to `stdout.columns` once at commit time; `repositionCommittedBand` and the frame-preserve eviction paints repainted those rows **verbatim** after any number of resizes. A row wrapped at 160 cols painted into a 64-col terminal overruns the width; DECAWM autowrap (never disabled) splits it at the hardware level, inserting phantom rows that desync every subsequent CUP/erase computation — stale frames leak into native scrollback once per repaint cycle.

2. **Stale band geometry defeats the commit safety gate** — the SIGWINCH-immediate handler resets frame geometry (`resetGeometry()`) but kept `committedBandBottomRow`. A commit landing before the debounced repaint derived `prevTopRow` from the pre-resize row, kept `prevTopRow > 1`, and defeated the band-hold fallback (BLOCKER-1) — Phase-3 merge-then-cap then truncated the prior band as 'already scrolled' rows that never scrolled: **total content loss**. (Commit 002bcd1 / #351 fixed a different trigger of this class at stable width; that case stays fixed — re-derived in the new baseline test.)

## Fix

- New `src/cli/terminal-compositor.band-reflow.ts`: `reflowCommittedBandToWidth` re-wraps the retained band at the **current** width before every band read (top of `commitAbove`, top of `repaint()`), split-preserving the pending/painted boundary; memoized so steady-width repaints are no-ops. Invariant: **strings wrapped at width W are only valid at width W** (the ratatui/Codex reflow-from-model principle).
- All physical band paints run inside `withAutowrapDisabled` (`?7l`/`?7h`, restore in `finally`): a ±1 ambiguous-width measurement gap (×, —, ╭) can now only clip a row, never spawn a geometry-corrupting phantom row.
- New `bandGeometryStale` flag: set on resize-immediate, cleared only when `repositionCommittedBand` re-pins against real post-resize geometry. While stale, `decideCommitMode` forces `fitsAboveFrame=false` (safe band-hold deferral) and trusts the band's frame-adjacency invariant over stale row arithmetic — **content preservation beats placement precision**.

## Tests

- `src/cli/terminal-compositor.resize-stale-width.repro.test.ts` (red-first, converted to green regression): H1 narrow-resize reflow, H2 commit-during-stale-window (both blocks fully present), multi-resize storm 160→100→64 (every marker exactly once — the no-ghost assertion), 002bcd1 baseline re-derivation.
- Full suite: **10,483 passed / 0 failed** (568 files); compositor family 328/328; `tsc --noEmit` clean. Zero existing test expectations changed.

## Docs

- New `docs/tui-resize-reflow.md`: root causes, fix architecture, industry comparison (Claude Code / Codex CLI / Gemini CLI / aider / Ink resize strategies), tmux reflow semantics, and named follow-ups (PTY e2e harness gap, ANSI-strip consolidation).
- Superseded banners on the two stale `rendering-architecture-*.md` docs (they describe the pre-fix June-5 snapshot; all five fixes they motivated landed as checkpoints 2a–2e).