### PR TITLE
feat(agent): deliver SubagentStop injectContext in-turn via the subagent tool_result

### DIFF
--- a/src/agent/hooks-integration.test.ts
+++ b/src/agent/hooks-integration.test.ts
@@ -970,6 +970,151 @@ describe('SubagentHandle.teardown()', () => {
     expect(queued).toContain('post-teardown note');
   });
 
+  // ----------------------------------------------------------------------
+  // In-turn injectContext delivery (deferInjectContextToCaller).
+  //
+  // Exactly-once crux: when teardown() is asked to defer delivery to the
+  // caller, the produced injectContext is recorded on
+  // getLastStopInjectContext() for the caller to append to the tool_result,
+  // and the queue push is SUPPRESSED. Without the flag, delivery still rides
+  // the queue (the compose/DAG + cancel/fail-fast paths keep this behavior).
+  // ----------------------------------------------------------------------
+  it('teardown({ deferInjectContextToCaller: true }) records the note and does NOT queue (deliver-once)', async () => {
+    const registry = createHookRegistry();
+    registry.register('SubagentStop', () => ({
+      injectContext: 'defer: in-turn nudge',
+    }));
+
+    const parentMgr = new SubagentManager({ hookRegistry: registry });
+    const parentHandle = await parentMgr.forkSubagent({
+      parent: { sessionId: 'root-defer' },
+      config: { model: 'sonnet' },
+      idPrefix: 'parent',
+    });
+    const parentSession = shared.sessions[shared.sessions.length - 1]!;
+
+    const childMgr = new SubagentManager({ hookRegistry: registry });
+    const childHandle = await childMgr.forkSubagent({
+      parent: {
+        sessionId: parentHandle.session.sessionId,
+        getInputStreamRef: parentHandle.session.getInputStreamRef.bind(parentHandle.session),
+      },
+      config: { model: 'sonnet' },
+      idPrefix: 'child',
+    });
+
+    await childHandle.run('audit');
+    await childHandle.teardown({ deferInjectContextToCaller: true });
+
+    // Recorded for the caller to deliver in-turn…
+    expect(childHandle.getLastStopInjectContext()).toBe('defer: in-turn nudge');
+    // …and NEITHER queue channel fired (suppressed — deliver-once).
+    expect(parentSession.getMockQueuedFrameworkContext()).toEqual([]);
+    expect(parentSession.getMockInputStreamMessages()).toEqual([]);
+  });
+
+  it('teardown() WITHOUT the defer flag still queues and leaves getLastStopInjectContext undefined', async () => {
+    const registry = createHookRegistry();
+    registry.register('SubagentStop', () => ({
+      injectContext: 'queue: default channel',
+    }));
+
+    const parentMgr = new SubagentManager({ hookRegistry: registry });
+    const parentHandle = await parentMgr.forkSubagent({
+      parent: { sessionId: 'root-default-queue' },
+      config: { model: 'sonnet' },
+      idPrefix: 'parent',
+    });
+    const parentSession = shared.sessions[shared.sessions.length - 1]!;
+
+    const childMgr = new SubagentManager({ hookRegistry: registry });
+    const childHandle = await childMgr.forkSubagent({
+      parent: {
+        sessionId: parentHandle.session.sessionId,
+        getInputStreamRef: parentHandle.session.getInputStreamRef.bind(parentHandle.session),
+      },
+      config: { model: 'sonnet' },
+      idPrefix: 'child',
+    });
+
+    await childHandle.run('audit');
+    await childHandle.teardown();
+
+    // Default path: queued, and nothing recorded for the caller.
+    expect(parentSession.getMockQueuedFrameworkContext()).toContain('queue: default channel');
+    expect(childHandle.getLastStopInjectContext()).toBeUndefined();
+  });
+
+  it('deferInjectContextToCaller: parent abort suppresses BOTH channels (nothing recorded, nothing queued)', async () => {
+    // Abort precedence is checked before the defer branch — an aborting parent
+    // will unwind before it could consume the note, so neither the caller nor
+    // the queue receives it.
+    const registry = createHookRegistry();
+    registry.register('SubagentStop', () => ({
+      injectContext: 'defer: should be suppressed by abort',
+    }));
+
+    const parentAbortController = new AbortController();
+    const parentMgr = new SubagentManager({
+      hookRegistry: registry,
+      parentAbortSignal: parentAbortController.signal,
+    });
+    const parentHandle = await parentMgr.forkSubagent({
+      parent: { sessionId: 'root-defer-abort' },
+      config: { model: 'sonnet' },
+      idPrefix: 'parent',
+    });
+    const parentSession = shared.sessions[shared.sessions.length - 1]!;
+
+    const childMgr = new SubagentManager({ hookRegistry: registry });
+    const childHandle = await childMgr.forkSubagent({
+      parent: {
+        sessionId: parentHandle.session.sessionId,
+        getInputStreamRef: parentHandle.session.getInputStreamRef.bind(parentHandle.session),
+        abortSignal: parentHandle.session.abortSignal,
+      },
+      config: { model: 'sonnet' },
+      idPrefix: 'child',
+    });
+
+    await childHandle.run('audit');
+    parentAbortController.abort('parent-abort');
+    await childHandle.teardown({ deferInjectContextToCaller: true });
+
+    expect(childHandle.getLastStopInjectContext()).toBeUndefined();
+    expect(parentSession.getMockQueuedFrameworkContext()).toEqual([]);
+    expect(parentSession.getMockInputStreamMessages()).toEqual([]);
+  });
+
+  it('deferInjectContextToCaller with no injectContext produced: getter stays undefined, no queue', async () => {
+    const registry = createHookRegistry();
+    registry.register('SubagentStop', () => ({})); // no injectContext
+
+    const parentMgr = new SubagentManager({ hookRegistry: registry });
+    const parentHandle = await parentMgr.forkSubagent({
+      parent: { sessionId: 'root-defer-none' },
+      config: { model: 'sonnet' },
+      idPrefix: 'parent',
+    });
+    const parentSession = shared.sessions[shared.sessions.length - 1]!;
+
+    const childMgr = new SubagentManager({ hookRegistry: registry });
+    const childHandle = await childMgr.forkSubagent({
+      parent: {
+        sessionId: parentHandle.session.sessionId,
+        getInputStreamRef: parentHandle.session.getInputStreamRef.bind(parentHandle.session),
+      },
+      config: { model: 'sonnet' },
+      idPrefix: 'child',
+    });
+
+    await childHandle.run('audit');
+    await childHandle.teardown({ deferInjectContextToCaller: true });
+
+    expect(childHandle.getLastStopInjectContext()).toBeUndefined();
+    expect(parentSession.getMockQueuedFrameworkContext()).toEqual([]);
+  });
+
   it('teardown() closes the underlying session', async () => {
     const registry = createHookRegistry();
     const mgr = new SubagentManager({ hookRegistry: registry });

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -54,8 +54,25 @@ export interface SubagentHandle<T = unknown> {
    * explicit "work is done, tear down quietly" lifecycle endpoint used after
    * a successful `run()` / `runToResult()`. Idempotent; composes with
    * `cancel()` via the shared `stopDispatched` guard.
+   *
+   * @param options.deferInjectContextToCaller — when true, a non-empty
+   *   `SubagentStop.injectContext` produced by this teardown is NOT pushed to
+   *   the parent's input-stream/queue channel. Instead it is recorded and made
+   *   readable via {@link getLastStopInjectContext} so the caller can deliver
+   *   it in-turn (e.g. appended to the foreground `agent`/`skill` tool_result).
+   *   The abort-precedence guard still applies: when the parent is aborting,
+   *   nothing is recorded (the parent will unwind before it could consume it).
+   *   Delivery is exactly-once — deferring here suppresses the queue push.
    */
-  teardown(): Promise<void>;
+  teardown(options?: { deferInjectContextToCaller?: boolean }): Promise<void>;
+  /**
+   * The `SubagentStop.injectContext` captured by the most recent teardown that
+   * was invoked with `deferInjectContextToCaller: true`. `undefined` when no
+   * context was produced, when delivery went through the queue channel, or
+   * when suppressed by the abort-precedence guard. Read once after `teardown`
+   * resolves; the caller owns delivery of the returned string.
+   */
+  getLastStopInjectContext(): string | undefined;
 }
 
 /**
@@ -81,6 +98,16 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
   private latestTerminalStatus: SubagentStatus | undefined;
   /** Guard so teardown-side SubagentStop fires exactly once per handle. */
   private stopDispatched = false;
+  /**
+   * The `SubagentStop.injectContext` captured for in-turn delivery by the
+   * caller — set only when {@link dispatchStopAndRelease} ran with
+   * `deferInjectContextToCaller: true` and the hook produced a non-empty
+   * context that was NOT suppressed by the abort-precedence guard. When set,
+   * the queue push is skipped, so this and the queue are mutually exclusive
+   * (exactly-once delivery). Read by the caller via
+   * {@link getLastStopInjectContext} after `teardown()` resolves.
+   */
+  private lastStopInjectContext: string | undefined;
   /** Optional sink for streaming progress events. Never mutated after construction. */
   private readonly progressSink: SubagentProgressSink | undefined;
   /** Optional parent session ID for context injection tracing. */
@@ -400,7 +427,7 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     }
   }
 
-  async teardown(): Promise<void> {
+  async teardown(options?: { deferInjectContextToCaller?: boolean }): Promise<void> {
     // Idempotent — once the stop hook has fired (via either path), teardown
     // is a no-op. Intentional: `handle.status` stays truthful for succeeded
     // runs; no abort-graph notification, no currentStatus mutation.
@@ -421,8 +448,12 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     try {
       await this.session.close();
     } finally {
-      await this.dispatchStopAndRelease(reportedStatus);
+      await this.dispatchStopAndRelease(reportedStatus, options);
     }
+  }
+
+  getLastStopInjectContext(): string | undefined {
+    return this.lastStopInjectContext;
   }
 
   /**
@@ -430,8 +461,16 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
    * map. Shared by `cancel()` and `teardown()` — the only difference between
    * those is pre-work (abort-graph notification, currentStatus mutation).
    * Guarded by `stopDispatched` so concurrent paths fire the hook exactly once.
+   *
+   * @param options.deferInjectContextToCaller — see {@link teardown}. When
+   *   true, a produced (non-suppressed) `injectContext` is recorded on
+   *   {@link lastStopInjectContext} for the caller to deliver in-turn INSTEAD
+   *   of pushing it to the parent's input-stream/queue channel.
    */
-  private async dispatchStopAndRelease(reportedStatus: SubagentStatus): Promise<void> {
+  private async dispatchStopAndRelease(
+    reportedStatus: SubagentStatus,
+    options?: { deferInjectContextToCaller?: boolean },
+  ): Promise<void> {
     if (this.stopDispatched) {
       // The other path already fired the hook. onTerminal() is idempotent on
       // the manager's active-map delete, so calling it again is safe — but we
@@ -463,23 +502,40 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     // subagent answer has already returned through the `agent` tool result;
     // this side-channel carries only supplemental hook context for the parent.
     //
-    // Delivery MUST ride along with the parent's next real user message
-    // (queueFrameworkContext), never as a standalone input-stream message:
-    // the provider consumes exactly one input-stream message per turn, so a
-    // pushed message that lands after the parent's turn ends displaces the
-    // user's next real message by one queue position — every later send is
-    // then answered by the message before it, and the injected text never
-    // appears in the ledger. `pushUserMessage` remains only as a fallback for
-    // narrow parent refs that predate the queue channel. Abort precedence: if
-    // the parent's abortSignal was provided AND is set, skip injection — the
-    // parent's query loop will unwind before it can consume the message.
+    // Delivery MUST reach the parent through EXACTLY ONE channel and MUST be
+    // gated by abort precedence — a single ordered decision, checked here in
+    // strict order so the two channels can never both fire and never both drop:
+    //
+    //   1. No injectContext produced        → nothing to deliver.
+    //   2. Parent is aborting                → suppress (both channels). The
+    //        parent's query loop unwinds before it could consume the note;
+    //        queuing OR recording it would be a dead letter. Matches the
+    //        abort-graph.ts "abort-signal check is unconditional" invariant.
+    //   3. deferInjectContextToCaller = true → record on lastStopInjectContext
+    //        for the CALLER to deliver in-turn (foreground agent/skill append
+    //        it to the returned tool_result). SKIP the queue push — this is the
+    //        suppression half of exactly-once. No parentInputStreamRef needed:
+    //        the caller owns delivery.
+    //   4. Otherwise (queue channel)         → ride along with the parent's
+    //        next real user message (queueFrameworkContext). Never a standalone
+    //        input-stream message: the provider consumes exactly one
+    //        input-stream message per turn, so a pushed message that lands after
+    //        the parent's turn ends displaces the user's next real message by
+    //        one queue position — every later send is then answered by the
+    //        message before it, and the injected text never appears in the
+    //        ledger. `pushUserMessage` remains only as a fallback for narrow
+    //        parent refs that predate the queue channel.
     // Injection failures are logged, not propagated.
-    if (decision.injectContext && this.parentInputStreamRef) {
+    if (decision.injectContext) {
       if (this.parentAbortSignal?.aborted) {
         debugLog(
           `Skipping SubagentStop injectContext for ${this.id}: parent is aborted`,
         );
-      } else {
+      } else if (options?.deferInjectContextToCaller) {
+        // In-turn delivery: hand the note to the caller (tool_result append)
+        // and deliberately do NOT push to the queue — exactly-once.
+        this.lastStopInjectContext = decision.injectContext;
+      } else if (this.parentInputStreamRef) {
         try {
           const ref = this.parentInputStreamRef;
           if (ref.queueFrameworkContext) {

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -746,6 +746,14 @@ export class SkillExecutor {
     // every closure-event-dependent improve detector.
     // Mirrors the pattern in subagent-executor.ts:321,533.
     let handle: Awaited<ReturnType<typeof manager.forkSubagent>> | undefined;
+    // In-turn SubagentStop delivery (mirrors subagent-executor.ts foreground
+    // path). SubagentStop fires from `handle.teardown()` in the finally, which
+    // runs before this execute() resolves — so the stop hook's injectContext
+    // (e.g. the shadow-verify nudge) can ride THIS skill's tool_result in-turn
+    // instead of the deferred queue. Hoist the completion ToolResult into
+    // `toolResult` and append the note after teardown. Exactly-once:
+    // `deferInjectContextToCaller` suppresses the queue push for this stop.
+    let toolResult: ToolResult | undefined;
     try {
       // `parentId: call.id` anchors the synthesized `Agent(<label>)` entry as
       // a child of THIS skill's tool-lane entry rather than at root. Mirrors
@@ -774,8 +782,11 @@ export class SkillExecutor {
           : `Run the ${skill.name} skill now, following the instructions in your system prompt.`;
       const result = await handle.runToResult(userMessage);
 
+      // Assign (don't return) so the finally can append the in-turn
+      // SubagentStop injectContext after teardown. See `toolResult` above.
       if (result.status === 'succeeded' && result.message) {
-        return { content: result.message.content };
+        toolResult = { content: result.message.content };
+        return toolResult;
       }
 
       // When the subagent was cancelled mid-flight but produced text before
@@ -787,11 +798,13 @@ export class SkillExecutor {
         result.partialOutput.length > 0
       ) {
         const marker = '[skill cancelled mid-flight — partial output preserved below]';
-        return { content: `${marker}\n\n${result.partialOutput}` };
+        toolResult = { content: `${marker}\n\n${result.partialOutput}` };
+        return toolResult;
       }
 
       const errorMessage = result.error?.message ?? 'Forked skill failed with no output';
-      return { content: errorMessage, isError: true };
+      toolResult = { content: errorMessage, isError: true };
+      return toolResult;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return { content: `Forked skill execution error: ${message}`, isError: true };
@@ -800,7 +813,16 @@ export class SkillExecutor {
       // grandchildren) → outer manager (any siblings that never ran).
       // Guard against `forkSubagent` having thrown before assignment —
       // see subagent.ts:316-320 for the construction-failure throw path.
-      if (handle) await handle.teardown().catch(debugLog);
+      // deferInjectContextToCaller: the stop-hook note rides the tool_result
+      // in-turn (appended below) and the queue push is suppressed.
+      if (handle) await handle.teardown({ deferInjectContextToCaller: true }).catch(debugLog);
+      // In-turn append: only when this run produced a completion ToolResult.
+      // The catch path leaves toolResult unset — nothing to append to, note
+      // dropped for that stop by design (the error string is the signal).
+      const injectContext = handle?.getLastStopInjectContext?.();
+      if (toolResult !== undefined && injectContext !== undefined && injectContext.length > 0) {
+        toolResult.content = `${toolResult.content}\n\n${injectContext}`;
+      }
       await childManager?.teardownAll();
       await manager.teardownAll();
     }
@@ -1053,6 +1075,10 @@ export class SkillExecutor {
     // event + `session_sealed`. `manager.teardownAll()` misses completed
     // handles per subagent.ts:412-414.
     let handle: Awaited<ReturnType<typeof manager.forkSubagent>> | undefined;
+    // In-turn SubagentStop delivery — same pattern as executeForkedRegistrySkill
+    // and subagent-executor.ts foreground path. See those for the ordering
+    // invariant and exactly-once rationale.
+    let toolResult: ToolResult | undefined;
     try {
       // `parentId: call.id` anchors the synthesized `Agent(<label>)` entry as
       // a child of THIS skill's tool-lane entry rather than at root. Mirrors
@@ -1079,8 +1105,11 @@ export class SkillExecutor {
           : `Run the ${skillName} skill now, following the instructions in your system prompt.`;
       const result = await handle.runToResult(userMessage);
 
+      // Assign (don't return) so the finally can append the in-turn
+      // SubagentStop injectContext after teardown. See `toolResult` above.
       if (result.status === 'succeeded' && result.message) {
-        return { content: result.message.content };
+        toolResult = { content: result.message.content };
+        return toolResult;
       }
 
       // When the subagent was cancelled mid-flight but produced text before
@@ -1092,16 +1121,24 @@ export class SkillExecutor {
         result.partialOutput.length > 0
       ) {
         const marker = '[skill cancelled mid-flight — partial output preserved below]';
-        return { content: `${marker}\n\n${result.partialOutput}` };
+        toolResult = { content: `${marker}\n\n${result.partialOutput}` };
+        return toolResult;
       }
 
       const errorMessage = result.error?.message ?? 'Plugin skill failed with no output';
-      return { content: errorMessage, isError: true };
+      toolResult = { content: errorMessage, isError: true };
+      return toolResult;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return { content: `Plugin skill execution error: ${message}`, isError: true };
     } finally {
-      if (handle) await handle.teardown().catch(debugLog);
+      // deferInjectContextToCaller: the stop-hook note rides the tool_result
+      // in-turn (appended below) and the queue push is suppressed.
+      if (handle) await handle.teardown({ deferInjectContextToCaller: true }).catch(debugLog);
+      const injectContext = handle?.getLastStopInjectContext?.();
+      if (toolResult !== undefined && injectContext !== undefined && injectContext.length > 0) {
+        toolResult.content = `${toolResult.content}\n\n${injectContext}`;
+      }
       await childManager?.teardownAll();
       await manager.teardownAll();
     }

--- a/src/agent/tools/subagent-executor.test.ts
+++ b/src/agent/tools/subagent-executor.test.ts
@@ -34,6 +34,8 @@ function mockHandle(
     status: string;
     message: { role: string; content: string; timestamp: Date };
     error: Error;
+    /** In-turn SubagentStop note the executor appends to the tool_result. */
+    injectContext: string;
   }>,
 ): Partial<SubagentHandle> {
   return {
@@ -51,6 +53,9 @@ function mockHandle(
     } as SubagentResult),
     cancel: vi.fn().mockResolvedValue(undefined),
     teardown: vi.fn().mockResolvedValue(undefined),
+    // Defaults to undefined (no note) so existing tests see unchanged content.
+    // The in-turn-delivery suite overrides this to assert the append.
+    getLastStopInjectContext: vi.fn().mockReturnValue(overrides?.injectContext),
   };
 }
 
@@ -1788,6 +1793,126 @@ describe('SubagentExecutor', () => {
       expect(exec.hasPromotableForeground()).toBe(false);
       expect(await exec.promoteActiveForeground()).toEqual([]);
       expect(handle.teardown).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // In-turn SubagentStop injectContext delivery.
+  //
+  // A foreground `agent` fork whose SubagentStop returns injectContext (e.g.
+  // the shadow-verify nudge) must deliver that note in the SAME turn — appended
+  // to the returned tool_result — and NOT via the parent's deferred input-stream
+  // queue. The executor coordinates this by calling
+  // `teardown({ deferInjectContextToCaller: true })` (which suppresses the queue
+  // push and records the note) and then appending `getLastStopInjectContext()`
+  // to the completion ToolResult in its finally.
+  // -------------------------------------------------------------------------
+  describe('in-turn SubagentStop injectContext delivery', () => {
+    it('appends the injectContext to the returned tool_result (success path)', async () => {
+      const nudge = '[framework-generated context: shadow-verify nudge]';
+      const handle = mockHandle({
+        message: { role: 'assistant', content: 'subagent findings', timestamp: new Date() },
+        injectContext: nudge,
+      });
+      mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
+
+      const result = await executor.execute(makeCall());
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toBe(`subagent findings\n\n${nudge}`);
+    });
+
+    it('calls teardown with deferInjectContextToCaller: true (suppresses queue push)', async () => {
+      const handle = mockHandle({ injectContext: 'note' });
+      mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
+
+      await executor.execute(makeCall());
+
+      // Deliver-once: the executor must ask the handle to DEFER queue delivery
+      // to the caller, so the note rides the tool_result exclusively.
+      expect(handle.teardown).toHaveBeenCalledWith({ deferInjectContextToCaller: true });
+    });
+
+    it('does NOT push to the parent input-stream / queue when delivering in-turn (deliver-once)', async () => {
+      // Full deliver-once assertion at the executor seam: with a real-shaped
+      // parent input-stream ref, neither channel is touched — the executor
+      // reads the note off the handle (deferred) instead.
+      const nudge = 'inline nudge body';
+      const queueSpy = vi.fn();
+      const pushSpy = vi.fn();
+      const handle = mockHandle({
+        message: { role: 'assistant', content: 'body', timestamp: new Date() },
+        injectContext: nudge,
+      });
+      mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
+
+      const exec = new SubagentExecutor({
+        subagentManager: mockSubagentMgr as any,
+        parentSession: {
+          sessionId: 'parent',
+          getInputStreamRef: () => ({ pushUserMessage: pushSpy, queueFrameworkContext: queueSpy }),
+          abortSignal: new AbortController().signal,
+        } as any,
+        defaultConfig: mockConfig,
+        depth: 0,
+      });
+
+      const result = await exec.execute(makeCall());
+
+      expect(result.content).toBe(`body\n\n${nudge}`);
+      // The mock handle does not fire the real SubagentStop → queue path, but
+      // the executor must never itself push to either channel for this path.
+      expect(queueSpy).not.toHaveBeenCalled();
+      expect(pushSpy).not.toHaveBeenCalled();
+    });
+
+    it('leaves content unchanged when no injectContext is produced (no stray separators)', async () => {
+      const handle = mockHandle({
+        message: { role: 'assistant', content: 'plain body', timestamp: new Date() },
+        // no injectContext → getLastStopInjectContext returns undefined
+      });
+      mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
+
+      const result = await executor.execute(makeCall());
+
+      expect(result.content).toBe('plain body');
+      expect(result.content).not.toContain('\n\n');
+    });
+
+    it('does not append when getLastStopInjectContext returns empty string', async () => {
+      const handle = mockHandle({
+        message: { role: 'assistant', content: 'body', timestamp: new Date() },
+        injectContext: '',
+      });
+      mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
+
+      const result = await executor.execute(makeCall());
+
+      expect(result.content).toBe('body');
+    });
+
+    it('appends the injectContext to the structured failure payload (failure path)', async () => {
+      const nudge = 'verify: this failure';
+      const handle = mockHandle({ status: 'failed', injectContext: nudge });
+      (handle as any).id = 'child-fail-inject';
+      (handle.runToResult as any).mockResolvedValue({
+        id: 'child-fail-inject',
+        status: 'failed',
+        error: new Error('kaboom'),
+        message: undefined,
+      });
+      mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
+
+      const result = await executor.execute(makeCall());
+
+      expect(result.isError).toBe(true);
+      // The JSON payload is followed by the appended nudge, separated by \n\n.
+      // The JSON prefix must still parse on its own.
+      const [jsonPart, ...rest] = result.content.split('\n\n');
+      expect(rest.join('\n\n')).toBe(nudge);
+      const payload = JSON.parse(jsonPart!);
+      expect(payload.status).toBe('failed');
+      expect(payload.error).toBe('kaboom');
     });
   });
 });

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -827,6 +827,23 @@ export class SubagentExecutor implements SubagentControl {
     });
     this.promotionTriggers.set(handle.id, { fire: firePromotion, ready: jobReady });
 
+    // In-turn SubagentStop delivery.
+    //
+    // Invariant (delivery order — externally governed by the SDK tool-use
+    // protocol): SubagentStop fires from `handle.teardown()` in the `finally`
+    // below, which runs BEFORE this async execute() resolves and its
+    // tool_result is assembled/sent. So a foreground `agent` fork can carry the
+    // stop hook's `injectContext` (e.g. the shadow-verify nudge) in-turn — as
+    // part of the SAME tool_result the parent sees — instead of via the
+    // deferred queue channel. We therefore hoist the completion ToolResult into
+    // `toolResult` (rather than returning inside the try) and, after teardown
+    // records the note, append it to `toolResult.content`. Exactly-once:
+    // `teardown({ deferInjectContextToCaller: true })` suppresses the queue
+    // push for this stop, so the note rides the tool_result OR the queue, never
+    // both. The promoted / error-rethrow / abort paths leave `toolResult`
+    // unset, so no append happens on them (queue/registry semantics preserved).
+    let toolResult: ToolResult | undefined;
+
     // Start the run but don't await it directly — race it against the
     // promotion signal. The same `runPromise` is handed to the registry on
     // promotion (it must NOT be re-run via runInBackground; see adoptRunning).
@@ -914,7 +931,10 @@ export class SubagentExecutor implements SubagentControl {
             ? JSON.stringify([...new Set(trace.toolCalls.map(tc => tc.name))])
             : undefined,
         });
-        return { content };
+        // Assign (don't return) so the finally can append the in-turn
+        // SubagentStop injectContext after teardown. See `toolResult` above.
+        toolResult = { content };
+        return toolResult;
       }
 
       const errorMessage =
@@ -953,10 +973,13 @@ export class SubagentExecutor implements SubagentControl {
         partialOutput: result.partialOutput,
         subagentId: handle.id,
       });
-      return {
+      // Assign (don't return) so the finally can append the in-turn
+      // SubagentStop injectContext after teardown. See `toolResult` above.
+      toolResult = {
         content: JSON.stringify(payload),
         isError: true,
       };
+      return toolResult;
     } catch (err) {
       // Defense in depth: an unexpected throw (e.g. timeout that surfaces
       // as a rejection rather than a `failed` status) should still emit
@@ -985,7 +1008,23 @@ export class SubagentExecutor implements SubagentControl {
       if (!promoted) {
         call.signal.removeEventListener('abort', abortListener);
         await childManager?.teardownAll();
-        await handle.teardown();
+        // Defer the SubagentStop injectContext to this caller so it rides the
+        // tool_result in-turn instead of the deferred queue. teardown() fires
+        // SubagentStop; with deferInjectContextToCaller the queue push is
+        // suppressed and the note (if any) is readable below.
+        await handle.teardown({ deferInjectContextToCaller: true });
+        // In-turn append: only when this foreground run produced a completion
+        // ToolResult (success or structured failure). The error-rethrow path
+        // leaves toolResult unset — nothing to append to, note is dropped for
+        // that stop by design (the throw is the parent's signal). Attribution:
+        // the note is appended to THIS subagent's own result, so a parent
+        // batching multiple `agent` calls sees each nudge next to its result.
+        // Optional-chain: real SubagentHandleImpl always defines this; the
+        // `?.()` tolerates narrow handle doubles (returns undefined = no note).
+        const injectContext = handle.getLastStopInjectContext?.();
+        if (toolResult !== undefined && injectContext !== undefined && injectContext.length > 0) {
+          toolResult.content = `${toolResult.content}\n\n${injectContext}`;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

**What:** For **foreground** `agent` (and `skill`) subagents, deliver the `SubagentStop` `injectContext` note (e.g. the shadow-verify nudge from `src/agent/shadow-verify-nudge.ts`) by **appending it to the returned tool_result `content`** — so the parent model sees it **in the same turn** as the subagent's result, per-subagent-attributed.

**Why:** This builds additively on #359 (merged, `c2d5078`), which delivers the nudge to the parent via a **deferred** channel — `parentInputStreamRef.queueFrameworkContext(...)` prepends it to the parent's *next* real user message. That works, but the nudge arrives a turn late and detached from the result it's about. Because a foreground subagent's `SubagentStop` fires from `handle.teardown()` in the executor's `finally` — which runs *before* `execute()` resolves and the tool_result is assembled — the `injectContext` is available in time to ride the very same tool_result. This change routes it there instead.

## Deliver-once invariant (the crux)

The note reaches the parent through **exactly one** channel, never both, never dropped:

| Path | Channel |
|------|---------|
| Foreground `agent` fork (non-promoted) | **tool_result append** (queue suppressed) |
| Foreground `skill` fork — registry (`context: fork`) + plugin | **tool_result append** (queue suppressed) |
| compose / DAG (`dag-subagent.ts`) | **queue** (unchanged — intentionally dark, not wired) |
| background jobs | unchanged — out of scope (registry-driven) |
| `cancel()` / fail-fast peer teardown | **queue** (`parentInputStreamRef`, unchanged) |
| foreground **promoted** (Ctrl+B) | neither this turn — registry owns the still-running handle |
| foreground **error-rethrow** | neither — `toolResult` unset, the throw is the signal |

**Mechanism:**
- `handle.teardown({ deferInjectContextToCaller: true })` fires `SubagentStop`, and when a non-empty `injectContext` is produced (and the parent is not aborting), it **records** the note on the handle (`getLastStopInjectContext()`) and **skips** the `queueFrameworkContext`/`pushUserMessage` push. That skip is the suppression half of exactly-once.
- The foreground executor hoists its completion `ToolResult` into an outer variable (instead of returning inside the `try`), then in `finally` — after teardown — reads `getLastStopInjectContext()` and appends it: `content = content + '\n\n' + injectContext`.
- **Abort precedence** is checked *first* and unconditionally: an aborting parent suppresses **both** channels (matches the existing `abort-graph.ts` invariant and #359's behavior).

## Files changed

- **`src/agent/subagent/handle.ts`** — `teardown(options?: { deferInjectContextToCaller?: boolean })`; new `getLastStopInjectContext(): string | undefined` getter + backing field; `dispatchStopAndRelease` restructured into a single ordered delivery decision (no-context → abort-suppress → defer-to-caller → queue).
- **`src/agent/tools/subagent-executor.ts`** — foreground path only (NOT the `mode:'background'` branch): hoist success + structured-failure `ToolResult`, teardown with `deferInjectContextToCaller: true`, append the deferred note. Promotion / error-rethrow paths untouched.
- **`src/agent/tools/skill-executor.ts`** — same pattern applied to both foreground fork paths (`executeForkedRegistrySkill`, `executePluginSkill`).
- **`src/agent/hooks-integration.test.ts`** — handle-level deliver-once tests (defer records + suppresses queue; default still queues; abort suppresses both; no-context → getter undefined).
- **`src/agent/tools/subagent-executor.test.ts`** — executor-level tests (nudge appended on success + failure; `teardown` called with the defer flag; neither queue channel touched; empty/absent note → content unchanged).

`getLastStopInjectContext()` is read via optional-chaining (`handle.getLastStopInjectContext?.()`) in the executors so narrow handle test-doubles that don't implement it return `undefined` (= no note); the concrete `SubagentHandleImpl` always defines it, so no production behavior changes.

`compose-executor.ts` and `dag-subagent.ts` were deliberately **not** touched.

## How tested

- `pnpm lint` (`tsc --noEmit`, strict): **clean**.
- Scoped affected-files run — all green:
  - `subagent-executor.test.ts` (82), `skill-executor.test.ts` (75), `handle.test.ts` (3), `hooks-integration.test.ts` (39), `framework-context-queue.test.ts` (8), `shadow-verify-nudge.test.ts` (21) → **228 passed**.
- Extended blast radius (all executor-touching files incl. `skill-load-mode`, `stream-renderer-ordering`, `dispatcher`, `chat.*`, routing) → **green**.
- Full suite: **571 files, 10543 passed, 14 skipped, 0 failures.**

## Checklist

- [x] `pnpm lint` passes (tsc --noEmit, strict)
- [x] Tests pass (affected files + full suite green)
- [x] DCO signed (`Signed-off-by`)
- [x] No secrets / tokens / private absolute paths in the diff
