### PR TITLE
fix(agent): fire SubagentStop for naturally-completing background subagents

### DIFF
--- a/src/agent/background-registry.test.ts
+++ b/src/agent/background-registry.test.ts
@@ -32,6 +32,8 @@ interface StubHandle extends SubagentHandle {
   /** Captured by `runInBackground` — invoke to trigger terminal-state. */
   __fireTerminal: (result: SubagentResult) => void;
   __cancelCalled: number;
+  /** Number of times `teardown()` was invoked (registry natural-completion seam). */
+  __teardownCalled: number;
   /** Captured onProgress callback, if any. */
   __onProgress?: (event: import('./types/session-types.js').OutputEvent) => void;
   /** Fire a progress event through the captured onProgress callback. */
@@ -45,6 +47,7 @@ function createStubHandle(id: string): StubHandle {
     id,
     status: 'idle' as SubagentStatus,
     __cancelCalled: 0,
+    __teardownCalled: 0,
     runInBackground(
       _prompt: string,
       onResult?: (r: SubagentResult) => void,
@@ -72,7 +75,12 @@ function createStubHandle(id: string): StubHandle {
     },
     async run() { throw new Error('not implemented'); },
     async runToResult() { throw new Error('not implemented'); },
-    async teardown() { /* no-op */ },
+    // Count invocations so tests can assert the registry's natural-completion
+    // path reaches teardown (which is where SubagentStop fires on the real
+    // handle). The real `stopDispatched` idempotency guard lives in
+    // SubagentHandleImpl, not this stub, so exactly-once hook semantics are
+    // asserted end-to-end in hooks-integration.test.ts.
+    async teardown() { (stub.__teardownCalled as number)++; },
   };
   return stub as StubHandle;
 }
@@ -319,6 +327,7 @@ describe('BackgroundAgentRegistry', () => {
         id: 'hang-1',
         status: 'idle' as SubagentStatus,
         __cancelCalled: 0,
+        __teardownCalled: 0,
         runInBackground(_prompt: string, onResult?: (r: SubagentResult) => void) {
           captured = onResult;
           // Intentionally never called: simulates a detached job that ignores abort.
@@ -331,7 +340,7 @@ describe('BackgroundAgentRegistry', () => {
         },
         async run() { throw new Error('not implemented'); },
         async runToResult() { throw new Error('not implemented'); },
-        async teardown() { /* no-op */ },
+        async teardown() { (hangingHandle.__teardownCalled as number)++; },
         __fireTerminal(_result: SubagentResult) {
           // never used in this test
         },
@@ -578,6 +587,138 @@ describe('BackgroundAgentRegistry', () => {
       h2.__fireTerminal(successResult('sub-ee-7b', 'done'));
 
       expect(listener).toHaveBeenCalledTimes(1); // still 1, not 2
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // SubagentStop lifecycle seam — a naturally-completing background job must
+  // tear its handle down so `SubagentStop` fires, matching the guarantee
+  // foreground jobs get from SubagentExecutor's finally block. Regression test
+  // for the bug where markTerminal() settled + emitted telemetry but never
+  // called handle.teardown(), so background SubagentStop handlers never ran.
+  //
+  // These assert the WIRING (teardown is reached on natural completion). The
+  // exactly-once hook semantics — which depend on SubagentHandleImpl's
+  // `stopDispatched` guard, not on this stub — are proven end-to-end in
+  // hooks-integration.test.ts.
+  // ---------------------------------------------------------------------------
+  describe('SubagentStop teardown seam', () => {
+    it('natural completion (succeeded) tears the handle down exactly once', async () => {
+      const handle = createStubHandle('stop-1');
+      const job = registry.register({ handle, prompt: 'work', model: 'sonnet' });
+
+      expect(handle.__teardownCalled).toBe(0); // not yet — still running
+
+      handle.__fireTerminal(successResult('stop-1', 'answer'));
+
+      // Terminal state is observable synchronously (settle + emit happen before
+      // the trailing `await handle.teardown()`), so join resolves immediately.
+      const result = await registry.join(job.jobId);
+      expect(result.status).toBe('succeeded');
+
+      // The async teardown resolves on a later microtask; flush before asserting.
+      await Promise.resolve();
+      expect(handle.__teardownCalled).toBe(1);
+    });
+
+    it('natural completion (failed) also tears the handle down', async () => {
+      const handle = createStubHandle('stop-2');
+      const job = registry.register({ handle, prompt: 'work', model: 'sonnet' });
+
+      handle.__fireTerminal(failureResult('stop-2', 'boom'));
+
+      const result = await registry.join(job.jobId);
+      expect(result.status).toBe('failed');
+
+      await Promise.resolve();
+      expect(handle.__teardownCalled).toBe(1);
+    });
+
+    it('teardown runs AFTER settle + witness emit (synchronous observability preserved)', () => {
+      // Firing terminal synchronously must leave the job observable as
+      // terminal *before* the async teardown suspends — the ordering invariant
+      // that keeps every synchronous assertion in this file valid.
+      const handle = createStubHandle('stop-3');
+      const settled: string[] = [];
+      registry.on('settled', (j) => settled.push(j.status));
+
+      const job = registry.register({ handle, prompt: 'work', model: 'sonnet' });
+      handle.__fireTerminal(successResult('stop-3', 'answer'));
+
+      // No await yet: settle + emit already ran synchronously inside __fireTerminal.
+      expect(settled).toEqual(['completed']);
+      expect(registry.get(job.jobId)?.status).toBe('completed');
+    });
+
+    it('complete-then-cancel: teardown reached on completion; later cancelJob is a no-op', async () => {
+      const handle = createStubHandle('stop-4');
+      const job = registry.register({ handle, prompt: 'work', model: 'sonnet' });
+
+      // Natural completion first — reaches teardown (fires SubagentStop on a
+      // real handle) and settles the job.
+      handle.__fireTerminal(successResult('stop-4', 'answer'));
+      await registry.join(job.jobId);
+      await Promise.resolve();
+      expect(handle.__teardownCalled).toBe(1);
+      expect(registry.get(job.jobId)?.status).toBe('completed');
+
+      // A subsequent cancelJob on the already-terminal job returns false and
+      // does NOT re-cancel or re-tear-down: the registry short-circuits on
+      // non-running status, so SubagentStop cannot double-fire.
+      const cancelled = await registry.cancelJob(job.jobId);
+      expect(cancelled).toBe(false);
+      expect(handle.__cancelCalled).toBe(0);
+      expect(handle.__teardownCalled).toBe(1); // still exactly one
+    });
+
+    it('cancelJob before completion: markTerminal short-circuits, no double teardown', async () => {
+      // On the cancel path the real handle fires SubagentStop from cancel()
+      // itself (setting stopDispatched) before the synthesized cancelled result
+      // re-enters markTerminal — so the trailing teardown there is a guaranteed
+      // no-op. The stub can't model the shared guard, but it CAN prove the
+      // registry never invokes teardown twice for one job.
+      const handle = createStubHandle('stop-5');
+      const job = registry.register({ handle, prompt: 'work', model: 'sonnet' });
+
+      await registry.cancelJob(job.jobId);
+      await Promise.resolve();
+
+      expect(handle.__cancelCalled).toBe(1);
+      expect(registry.get(job.jobId)?.status).toBe('cancelled');
+      // markTerminal ran once (via the cancelled result the stub's cancel()
+      // fires), so the registry called teardown at most once for this job.
+      expect(handle.__teardownCalled).toBeLessThanOrEqual(1);
+    });
+
+    it('promotion path (adoptRunning): natural completion tears the handle down', async () => {
+      // adoptRunning attaches to an already-in-flight runPromise instead of
+      // calling runInBackground. The terminal callback still routes through
+      // markTerminal, so promoted jobs get the same SubagentStop guarantee.
+      const handle = createStubHandle('stop-promote');
+      let resolveRun!: (r: SubagentResult) => void;
+      const runPromise = new Promise<SubagentResult>((res) => {
+        resolveRun = res;
+      });
+
+      const job = registry.adoptRunning({
+        handle,
+        runPromise,
+        prompt: 'promoted work',
+        model: 'sonnet',
+      });
+      expect(registry.get(job.jobId)?.status).toBe('running');
+      expect(handle.__teardownCalled).toBe(0);
+
+      // Resolve the in-flight run — drives markTerminal via the `.then`.
+      resolveRun(successResult('stop-promote', 'promoted answer'));
+
+      const result = await registry.join(job.jobId);
+      expect(result.status).toBe('succeeded');
+
+      // Flush the adoptRunning .then → markTerminal → await teardown chain.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(handle.__teardownCalled).toBe(1);
     });
   });
 

--- a/src/agent/background-registry.ts
+++ b/src/agent/background-registry.ts
@@ -224,10 +224,18 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
     // Start detached execution. `runInBackground` swallows the promise; the
     // callback is our terminal-state hook. The onProgress callback pipes every
     // OutputEvent to the writer and also feeds text content to appendTranscript.
+    //
+    // `markTerminal` is async (it awaits `handle.teardown()` to fire
+    // SubagentStop) but the callback is synchronous — `void` + `.catch` mirrors
+    // `runInBackground`'s own naked-void-promise guard so a teardown rejection
+    // never escapes as an unhandled rejection on this detached path.
     args.handle.runInBackground(
       args.prompt,
       (result) => {
-        this.markTerminal(jobId, result, writer, metaRecord);
+        void this.markTerminal(jobId, result, writer, metaRecord).catch(
+          (err: unknown) =>
+            debugLog(`markTerminal (register) rejected for ${jobId}: ${String(err)}`),
+        );
       },
       (event) => {
         writer.write(event);
@@ -271,13 +279,16 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
     // path. `.catch` is defense-in-depth, mirroring `runInBackground`'s naked
     // void-promise guard: if anything unexpected escapes, synthesize a failed
     // terminal so the job never hangs in 'running'.
+    // `markTerminal` is async (awaits `handle.teardown()` for SubagentStop);
+    // await it inside both branches so a teardown rejection surfaces to the
+    // trailing `.catch` rather than leaking as an unhandled rejection. The
+    // promotion path's handle already ran to completion, so teardown here fires
+    // SubagentStop exactly as the native-background path does.
     void args.runPromise
-      .then((result) => {
-        this.markTerminal(jobId, result, writer, metaRecord);
-      })
+      .then((result) => this.markTerminal(jobId, result, writer, metaRecord))
       .catch((err: unknown) => {
         debugLog('adoptRunning: unexpected rejection from in-flight runPromise', err);
-        this.markTerminal(
+        return this.markTerminal(
           jobId,
           buildResultFromError(args.handle.id, 'failed', err, createEmptyTrace()),
           writer,
@@ -520,9 +531,10 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
   }
 
   /**
-   * Terminal-state hook installed in `register()`. Sets final status,
-   * stores the result, fires witness events, and settles the join promise.
-   * Must run exactly once per job — guarded by the running-status check.
+   * Terminal-state hook installed in `register()` / `adoptRunning()`. Sets
+   * final status, stores the result, fires witness events, settles the join
+   * promise, and finally tears the handle down so `SubagentStop` fires. Must
+   * run exactly once per job — guarded by the running-status check.
    *
    * After settling, schedules a TTL eviction (~5 min) so terminal entries
    * don't accumulate indefinitely. The timer is `.unref()`-ed so it won't
@@ -532,15 +544,36 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
    * `cancelJob()` ('explicit') or `cancelAll()` ('cascade') before calling
    * `handle.cancel()`. Defaults to `'explicit'` when not set.
    *
+   * Invariant: the ordered sequence below is governed by two external
+   * constraints and MUST NOT be reordered:
+   *   1. Synchronous observability. `register()`'s `onResult` callback (and
+   *      `adoptRunning()`'s `.then`) invoke this method but do not await it.
+   *      Callers (and every synchronous unit test) observe terminal state
+   *      immediately after firing the callback, so all state that must be
+   *      visible synchronously — status mutation, witness/telemetry emit,
+   *      `job.settle(result)`, log finalize, eviction scheduling — happens
+   *      BEFORE the first `await`. JS runs an async function synchronously up
+   *      to its first suspension point; placing `await handle.teardown()`
+   *      last preserves that guarantee.
+   *   2. Fire-SubagentStop-once. `teardown()` fires `SubagentStop` via the
+   *      handle's `stopDispatched` guard. On the cancel path
+   *      (`cancelJob`/`cancelAll` → `handle.cancel()`), the handle already
+   *      dispatched `SubagentStop` and set `stopDispatched` BEFORE synthesizing
+   *      the cancelled result that re-enters this method — so the trailing
+   *      `teardown()` is a guaranteed no-op there. Only natural completion
+   *      (where `run()`/`runToResult()` called `onTerminal()` but never the
+   *      stop path) reaches `teardown()` with `stopDispatched === false`, so
+   *      the hook fires exactly once for both natural and cancelled endings.
+   *
    * @param writer — persistent JSONL log writer for this job (optional; omitted in legacy paths).
    * @param openMeta — the meta record written at start, used to build the terminal update.
    */
-  private markTerminal(
+  private async markTerminal(
     jobId: string,
     result: SubagentResult,
     writer?: BgJobLogWriter,
     openMeta?: BgJobMeta,
-  ): void {
+  ): Promise<void> {
     const job = this.jobs.get(jobId);
     if (!job || job.status !== 'running') return;
 
@@ -632,6 +665,35 @@ export class BackgroundAgentRegistry extends EventEmitter<BackgroundRegistryEven
       this.jobs.delete(jobId);
     }, TERMINAL_EVICT_TTL_MS);
     timer.unref();
+
+    // Tear the handle down so a naturally-completing background job fires
+    // `SubagentStop` — the same lifecycle guarantee foreground jobs get from
+    // `SubagentExecutor`'s finally block. This MUST be the last step (see the
+    // synchronous-observability invariant above): all state a caller observes
+    // synchronously is already committed by the time we suspend here.
+    //
+    // injectContext for background: `teardown()` routes any `injectContext` a
+    // SubagentStop handler returns through the handle's default channel —
+    // `queueFrameworkContext` on a live `parentInputStreamRef` (so it rides the
+    // parent's next real user message), else a no-op. A background job has no
+    // waiting tool_result to carry the note in-turn, so this default-queue path
+    // is the only correct delivery; if the parent already detached (no live
+    // ref), the note is silently dropped. That trade-off is intentional:
+    // firing the hook + sealing the trace is the primary goal here; inject
+    // delivery is best-effort and secondary for detached background work.
+    //
+    // Idempotent with the cancel path: on `cancelJob`/`cancelAll` the handle
+    // already fired `SubagentStop` (and set `stopDispatched`) before the
+    // cancelled result re-entered this method, so this call is a no-op there.
+    // Errors are swallowed — teardown is a cleanup step and must never turn a
+    // settled job into an unhandled rejection on the detached callback path.
+    try {
+      await job.handle.teardown();
+    } catch (err) {
+      debugLog(
+        `markTerminal: handle.teardown() failed for job ${jobId}: ${String(err)}`,
+      );
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/src/agent/hooks-integration.test.ts
+++ b/src/agent/hooks-integration.test.ts
@@ -102,6 +102,8 @@ vi.mock('./session.js', () => {
 // Import AFTER the mock so SubagentManager picks up the mock session.
 import { SubagentManager } from './subagent.js';
 import { createDefaultHookRegistry } from './default-hook-registry.js';
+import { BackgroundAgentRegistry } from './background-registry.js';
+import type { SubagentResult } from './subagent.js';
 
 describe('SubagentManager — hook integration', () => {
   it('dispatches SubagentStart before creating the child session', async () => {
@@ -1010,5 +1012,149 @@ describe('SubagentManager.teardownAll()', () => {
     expect(ids).toEqual([h1.id, h2.id].sort());
     // Neither ran, so both report 'cancelled' as fallback.
     expect(events.every((e) => e.status === 'cancelled')).toBe(true);
+  });
+});
+
+describe('BackgroundAgentRegistry — SubagentStop lifecycle (end-to-end)', () => {
+  // These wire a REAL SubagentManager handle (real SubagentHandleImpl, mocked
+  // child session) through the real BackgroundAgentRegistry to prove the
+  // firing + exactly-once semantics the stub-level background-registry tests
+  // cannot: the `stopDispatched` guard lives in SubagentHandleImpl, so only a
+  // real handle exercises it.
+
+  /** Await the registry's terminal settle, then flush the async teardown chain. */
+  async function joinAndFlush(
+    registry: BackgroundAgentRegistry,
+    jobId: string,
+  ): Promise<SubagentResult> {
+    const result = await registry.join(jobId);
+    // markTerminal awaits handle.teardown() after settling; the join resolves
+    // at settle time, so drain a couple of microtasks to let teardown (and its
+    // SubagentStop dispatch) run to completion before assertions.
+    await Promise.resolve();
+    await Promise.resolve();
+    return result;
+  }
+
+  it('naturally-completing background job fires SubagentStop exactly once (status "succeeded")', async () => {
+    const registry = createHookRegistry();
+    const events: HookContext[] = [];
+    registry.register('SubagentStop', (ctx) => {
+      events.push(ctx);
+      return {};
+    });
+
+    const mgr = new SubagentManager({ hookRegistry: registry });
+    const handle = await mgr.forkSubagent({
+      parent: { sessionId: 'p-bg' },
+      config: { model: 'sonnet' },
+      idPrefix: 'research',
+    });
+
+    const bg = new BackgroundAgentRegistry({});
+    const job = bg.register({ handle, prompt: 'inspect', model: 'sonnet' });
+
+    // Before the fix, the run completed and settled but SubagentStop never
+    // fired for a background job. Now it must fire via markTerminal → teardown.
+    await joinAndFlush(bg, job.jobId);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: 'SubagentStop',
+      subagentId: handle.id,
+      status: 'succeeded',
+      agentType: 'research',
+    });
+    // Teardown does not clobber status — a succeeded run stays 'succeeded'.
+    expect(handle.status).toBe('succeeded');
+  });
+
+  it('naturally-completing background job seals the child session (close called)', async () => {
+    const registry = createHookRegistry();
+    const mgr = new SubagentManager({ hookRegistry: registry });
+    const handle = await mgr.forkSubagent({
+      parent: { sessionId: 'p-bg' },
+      config: { model: 'sonnet' },
+    });
+    const childSession = shared.sessions[shared.sessions.length - 1]!;
+
+    const bg = new BackgroundAgentRegistry({});
+    const job = bg.register({ handle, prompt: 'inspect', model: 'sonnet' });
+    await joinAndFlush(bg, job.jobId);
+
+    // teardown() → session.close(). The mock exposes close as a vi.fn on the
+    // session instance; assert it was invoked exactly once (no double-close).
+    const closeSpy = (handle.session as unknown as { close: ReturnType<typeof vi.fn> }).close;
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    void childSession;
+  });
+
+  it('idempotency: completing then cancelling the same job fires SubagentStop exactly once', async () => {
+    const registry = createHookRegistry();
+    const events: HookContext[] = [];
+    registry.register('SubagentStop', (ctx) => {
+      events.push(ctx);
+      return {};
+    });
+
+    const mgr = new SubagentManager({ hookRegistry: registry });
+    const handle = await mgr.forkSubagent({
+      parent: { sessionId: 'p-bg' },
+      config: { model: 'sonnet' },
+    });
+
+    const bg = new BackgroundAgentRegistry({});
+    const job = bg.register({ handle, prompt: 'inspect', model: 'sonnet' });
+
+    // Natural completion fires SubagentStop (once) and marks the job terminal.
+    await joinAndFlush(bg, job.jobId);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ status: 'succeeded' });
+
+    // A later cancelJob on the now-terminal job returns false (registry
+    // short-circuits on non-running status) — SubagentStop must NOT fire again.
+    const cancelled = await bg.cancelJob(job.jobId);
+    expect(cancelled).toBe(false);
+    expect(events).toHaveLength(1);
+
+    // Defense-in-depth: even a direct handle.cancel() after teardown is a
+    // no-op via the shared `stopDispatched` guard, so still exactly one event.
+    await handle.cancel();
+    expect(events).toHaveLength(1);
+    expect(handle.status).toBe('succeeded');
+  });
+
+  it('cancelled-before-completion background job fires SubagentStop once with status "cancelled"', async () => {
+    const registry = createHookRegistry();
+    const events: HookContext[] = [];
+    registry.register('SubagentStop', (ctx) => {
+      events.push(ctx);
+      return {};
+    });
+
+    const mgr = new SubagentManager({ hookRegistry: registry });
+    const handle = await mgr.forkSubagent({
+      parent: { sessionId: 'p-bg' },
+      config: { model: 'sonnet' },
+    });
+    // Make the child run hang so cancelJob wins before natural completion.
+    const childSession = shared.sessions[shared.sessions.length - 1]!;
+    (childSession.sendMessage as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      () => new Promise(() => {}), // never resolves
+    );
+
+    const bg = new BackgroundAgentRegistry({});
+    const job = bg.register({ handle, prompt: 'inspect', model: 'sonnet' });
+
+    // cancelJob → handle.cancel() fires SubagentStop (setting stopDispatched)
+    // before the synthesized cancelled result re-enters markTerminal, so the
+    // trailing teardown there is a no-op — the hook fires exactly once.
+    const cancelled = await bg.cancelJob(job.jobId);
+    expect(cancelled).toBe(true);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ status: 'cancelled', subagentId: handle.id });
   });
 });


### PR DESCRIPTION
## Summary

A `mode:"background"` subagent that completes **naturally** (runs to completion; not cancelled) never fired the `SubagentStop` hook. Foreground jobs get this lifecycle guarantee from `SubagentExecutor`'s `finally` block (`src/agent/tools/subagent-executor.ts:985-989`, which calls `handle.teardown()`); background jobs had no equivalent. The result: `SubagentStop` handlers didn't run for background jobs, the child trace never sealed via `teardown()` → `session.close()`, and lifecycle telemetry was inconsistent with foreground jobs.

### Root cause (re-confirmed by reading, post #359/#387)

- **`src/agent/subagent/handle.ts`** — `run()`'s natural-completion path (`:150-177`) calls only `onTerminal()`, never the stop path. `dispatchSubagentStop(...)` is reachable only via the private `dispatchStopAndRelease(...)` (`:434`), which is called only from `cancel()` (`:399`) and `teardown()` (`:424`). So a successful `run()` never fires `SubagentStop`.
- **`src/agent/tools/subagent-executor.ts`** — the `mode === 'background'` branch (`:739-787`) calls `registry.register(...)` and returns immediately, **before** the `try/finally` (`:834+`) that tears foreground handles down. So the executor never tears down a background handle.
- **`src/agent/background-registry.ts`** — `register()` (`:227`) wires `handle.runInBackground(prompt, onResult=markTerminal, onProgress)`. `markTerminal()` (`:538`) emitted trace/telemetry and called `job.settle(...)` but **never** called `handle.teardown()`/`.cancel()`. Only `cancelJob()`/`cancelAll()` reached `handle.cancel()`. The promotion path (`adoptRunning()`, `:266`) also funnels its terminal state through `markTerminal()`, so it had the same gap.

> Note: PR #387 (`deferInjectContextToCaller` + `getLastStopInjectContext()`) is still **open**, so `teardown()` on `main` takes **no options** — this fix targets the merged-`main` shape.

## The fix (seam chosen)

`markTerminal()` is the single natural-completion point shared by both `register()` (native background) and `adoptRunning()` (promoted). Added `await job.handle.teardown()` as the **last** step of `markTerminal()`, after status mutation, witness/telemetry emit, `job.settle(result)`, log finalization, and eviction scheduling.

- **Hook fires exactly once.** On natural completion, `run()`/`runToResult()` called `onTerminal()` but never the stop path, so `stopDispatched === false` and `teardown()` fires `SubagentStop` for the first and only time. On the cancel path (`cancelJob`/`cancelAll` → `handle.cancel()`), the handle **already** dispatched `SubagentStop` and set `stopDispatched` *before* synthesizing the cancelled result that re-enters `markTerminal()`, so the trailing `teardown()` is a guaranteed no-op. The existing `stopDispatched` guard fully covers this ordering — verified end-to-end.
- **Trace sealing / no double-close.** `teardown()` → `session.close()` runs after the run has already settled, so it's safe. `markTerminal`'s existing `job.status !== 'running'` guard already prevents double-`markTerminal`, so telemetry is emitted once; adding teardown does **not** duplicate telemetry (teardown emits the `SubagentStop` hook + lifecycle trace, which is the missing piece, not the `background_agent` telemetry that was already firing). A new e2e test asserts `session.close()` is called exactly once.
- **Ordering invariant documented.** `markTerminal` became `async`; the `await` is placed **last** so all synchronously-observable state (status, `emit('settled')`, `job.settle`) is committed before the first suspension point — preserving every existing synchronous assertion in `background-registry.test.ts`. This constraint is captured in an `// Invariant:` comment block.
- **Floating-promise safety.** The two call sites (`register`'s `onResult`, `adoptRunning`'s `.then`) `void` the now-async `markTerminal` with a `.catch` guard, mirroring `runInBackground`'s existing naked-void-promise (R1) convention; teardown errors are also swallowed inside `markTerminal` (defense-in-depth) so a settled job can never leak an unhandled rejection on the detached path.
- **Promotion/adoption preserved.** Promoted jobs (`adoptRunning`) route their terminal state through the same `markTerminal`, so they now get `SubagentStop` too — and the foreground `finally` already skips `handle.teardown()` when `promoted` (`subagent-executor.ts:985`), so there's no double-teardown. A new test covers the promotion path.

## injectContext-for-background decision

`teardown()` (no options) routes any `injectContext` a `SubagentStop` handler returns through the handle's **default channel**: `queueFrameworkContext` on a live `parentInputStreamRef` (so it rides the parent's next real user message), else a no-op. A background job has no waiting tool_result to carry the note in-turn, so this default-queue path is the only correct delivery. **If the parent has already detached (no live ref), the note is silently dropped — intentionally.** Firing the hook + sealing the trace is the primary goal here; inject delivery is best-effort and secondary for detached background work. (I did **not** introduce any suppress-injectContext special-case — the existing default-queue behavior already degrades correctly.)

## How tested

- `pnpm lint` (tsc --noEmit strict) — **clean**.
- Full `pnpm test` — **571 files, 10553 passed, 14 skipped, 0 failed** (run twice, stable).
- Directly-affected files: `background-registry.test.ts` (46), `hooks-integration.test.ts` (39), `subagent/handle.test.ts` (3), `tools/subagent-executor.test.ts` (76) — **164 passed**.
- **Regression-guard verified:** temporarily reverting only the `await handle.teardown()` line makes the new natural-completion tests **fail** (4/6 stub-level, 3/4 e2e), then pass again once restored — proving the tests catch the bug.

New tests added:
- `background-registry.test.ts` → `describe('SubagentStop teardown seam')`: natural completion (succeeded/failed) reaches teardown; teardown runs after settle (synchronous-observability); complete-then-cancel is a no-op; cancel-before-completion no double-teardown; **promotion path** (`adoptRunning`) tears down.
- `hooks-integration.test.ts` → `describe('BackgroundAgentRegistry — SubagentStop lifecycle (end-to-end)')`: real `SubagentManager` handle through the real registry proving **SubagentStop fires exactly once** (status `succeeded`), session sealed (`close()` once), **idempotency** (complete-then-`cancelJob` → still one event; even a direct `handle.cancel()` after → still one), and cancel-before-completion fires once with status `cancelled`.

## Checklist

- [x] `pnpm lint` clean
- [x] Tests green (full suite + affected files); regression-guard verified
- [x] DCO sign-off (`git commit -s`)
- [x] No secrets / tokens / private absolute paths in the diff
- [x] Minimal, additive change; ordering invariant + injectContext decision documented in code comments
