### PR TITLE
fix(awareness): report a clean git tree as dirty:false, not null

### DIFF
--- a/src/agent/awareness/workspace-source.test.ts
+++ b/src/agent/awareness/workspace-source.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
 import { gatherWorkspace } from './workspace-source.js';
 import * as os from 'os';
 import * as fs from 'fs';
@@ -105,5 +106,55 @@ describe('gatherWorkspace (mocked spawnSync)', () => {
     // even if it is, headSha will be non-null — so we only assert structure).
     expect(typeof ws.branch === 'string' || ws.branch === null).toBe(true);
     expect(typeof ws.headSha === 'string' || ws.headSha === null).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Clean vs dirty temp repo — regression guard for the clean-repo null bug.
+//
+// A CLEAN working tree emits empty `git status --porcelain` (exit 0). The
+// gatherWorkspace happy-path test above cannot catch this: its dirty/dirtyCount
+// assertions are guarded behind `if (ws.dirty !== null && ...)`, so a buggy
+// null value skips the assertion (vacuous pass). These tests construct a real
+// repo and assert dirty/dirtyCount UNCONDITIONALLY, so a regression to
+// dirty:null on a clean tree fails loudly.
+// ---------------------------------------------------------------------------
+
+describe('gatherWorkspace (clean vs dirty temp repo)', () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-ws-clean-'));
+    const git = (...args: string[]): void => {
+      execFileSync('git', args, { cwd: repo, stdio: 'pipe' });
+    };
+    git('init', '-q');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'Test');
+    // Never prompt for a GPG passphrase in CI.
+    git('config', 'commit.gpgsign', 'false');
+    fs.writeFileSync(path.join(repo, 'file.txt'), 'hello\n');
+    git('add', 'file.txt');
+    git('commit', '-q', '-m', 'init');
+  });
+
+  afterEach(() => {
+    fs.rmSync(repo, { recursive: true, force: true });
+  });
+
+  it('reports a CLEAN repo as dirty:false / dirtyCount:0 (not null)', () => {
+    const ws = gatherWorkspace(repo);
+    expect(ws.headSha).not.toBeNull();
+    // The regression: empty porcelain output must be read as "clean", never
+    // conflated with a failed status call.
+    expect(ws.dirty).toBe(false);
+    expect(ws.dirtyCount).toBe(0);
+  });
+
+  it('reports a DIRTY repo as dirty:true with a positive count', () => {
+    fs.writeFileSync(path.join(repo, 'untracked.txt'), 'x\n');
+    const ws = gatherWorkspace(repo);
+    expect(ws.dirty).toBe(true);
+    expect(ws.dirtyCount).toBeGreaterThan(0);
   });
 });

--- a/src/agent/awareness/workspace-source.ts
+++ b/src/agent/awareness/workspace-source.ts
@@ -31,10 +31,18 @@ const NULL_WORKSPACE: RuntimeWorkspace = {
 };
 
 /**
- * Run a single `git` command in `cwd` and return trimmed stdout, or `null`
- * on any failure (non-zero status, signal, error, or empty output).
+ * Run a single `git` command in `cwd` and return trimmed stdout.
+ *
+ * Contract: returns `null` on any failure (non-zero status, signal, spawn
+ * error). By default an empty-but-successful stdout ALSO collapses to `null`,
+ * since an empty branch name or remote URL is meaningless. Pass
+ * `allowEmpty: true` when empty output is itself a valid, distinct result —
+ * notably `git status --porcelain`, whose empty output means "clean tree" and
+ * MUST be distinguished from a failed status call. Without this flag a clean
+ * repo was indistinguishable from a git error and reported `dirty: null`
+ * instead of `dirty: false` (see gatherWorkspace).
  */
-function gitOutput(cwd: string, args: string[]): string | null {
+function gitOutput(cwd: string, args: string[], allowEmpty = false): string | null {
   try {
     const result = spawnSync('git', args, {
       cwd,
@@ -50,7 +58,8 @@ function gitOutput(cwd: string, args: string[]): string | null {
       return null;
     }
     const out = typeof result.stdout === 'string' ? result.stdout.trim() : null;
-    return out !== null && out.length > 0 ? out : null;
+    if (out === null) return null;
+    return out.length > 0 || allowEmpty ? out : null;
   } catch {
     return null;
   }
@@ -80,19 +89,23 @@ export function gatherWorkspace(cwd: string): RuntimeWorkspace {
   // Branch name — symbolic-ref fails on detached HEAD, falls back to null.
   const branchRaw = gitOutput(cwd, ['symbolic-ref', '--short', 'HEAD']);
 
-  // Porcelain status: one line per dirty file. Empty output = clean.
-  const statusRaw = gitOutput(cwd, ['status', '--porcelain']);
+  // Porcelain status: one line per dirty file. Empty output = clean tree.
+  // `allowEmpty: true` is load-bearing here — a clean repo emits empty stdout
+  // with exit 0, which must be read as "clean" (dirty:false, count:0), NOT
+  // conflated with a failed status call. Without it, gitOutput collapses
+  // empty→null and a clean checkout wrongly reports dirty:null/dirtyCount:null.
+  const statusRaw = gitOutput(cwd, ['status', '--porcelain'], true);
   let dirty: boolean | null = false;
   let dirtyCount: number | null = 0;
   if (statusRaw !== null) {
-    // Each non-empty line is one dirty file.
+    // Each non-empty line is one dirty file; '' (clean) yields zero lines.
     const lines = statusRaw.split('\n').filter((l) => l.trim().length > 0);
     dirty = lines.length > 0;
     dirtyCount = lines.length;
-  }
-  // statusRaw === null means git status itself failed — leave dirty/dirtyCount null.
-  // We know HEAD is valid (checked above), so null status means an unexpected error.
-  if (statusRaw === null) {
+  } else {
+    // statusRaw === null now means git status genuinely FAILED (not merely
+    // clean). HEAD was already validated above, so this is an unexpected error
+    // — surface it as null rather than a misleading "clean".
     dirty = null;
     dirtyCount = null;
   }


### PR DESCRIPTION
## Summary

`get_runtime_state`'s `workspace` view reported a **clean** git checkout as `dirty: null` / `dirtyCount: null` instead of `dirty: false` / `dirtyCount: 0`. This affected **every** session — top-level and subagent — whenever the working tree was clean.

It surfaced while diagnosing "a subagent's `get_runtime_state` returns a lot of nulls." Most of those nulls turned out to be **expected** (a leaf subagent legitimately has `phaseRole: null`, `mcpServers: []`, and empty `subagents` arrays), but `workspace.dirty` / `dirtyCount` being null on a clean tree was a genuine defect.

## Root cause

`gitOutput()` collapsed empty-but-successful stdout to `null`:

```ts
return out !== null && out.length > 0 ? out : null;
```

A clean `git status --porcelain` emits **empty output with exit 0** — indistinguishable from a failed call under that logic. `gatherWorkspace()` then took its `statusRaw === null` branch and overwrote the correct `false` / `0` defaults with `null`, with a comment that misread the empty case as "an unexpected error."

## Fix

- Add an `allowEmpty` flag to `gitOutput`; pass it **only** for the `status --porcelain` call, so empty output is read as "clean" and `null` stays reserved for a genuine failure.
- Branch / remote / HEAD calls keep the previous empty→null behavior (an empty branch name or remote URL is meaningless).

## Test

A new `gatherWorkspace (clean vs dirty temp repo)` block builds a **real** clean temp repo and asserts `dirty: false` / `dirtyCount: 0` **unconditionally** (plus a dirty control). The prior happy-path test guarded those assertions behind `if (ws.dirty !== null && …)`, so the null bug passed **vacuously** — which is why it shipped. Verified the new test **fails on the pre-fix code** (`expected null to be false`) and passes after.

- `pnpm lint` (strict `tsc --noEmit`): clean
- `pnpm exec vitest run src/agent/awareness/`: **88/88 pass**

## Verification

Confirmed empirically before fixing: executed `gatherWorkspace` against a freshly-created clean repo → `dirty:null`; dirty control → `dirty:true, dirtyCount:1`. The load-bearing claims were then independently re-derived via a `/shadow-verify` wave (CONFIRMED, no overreach).

## Known follow-up (NOT in this PR)

A second, subagent-specific null was diagnosed and confirmed but **deliberately left out** to keep this PR focused and low-risk: `get_runtime_state` `self.sessionId` is `null` for forked subagents (the topology fields `depth` / `parentSessionId` / `maxDepth` **do** populate correctly).

Root cause: the child's own session id (minted by `randomUUID()` in the provider, stored in the live `stateManager`) is never written back into `config.sessionId`, which is what the awareness source reads. The naive fix (`childConfig.sessionId = <handle id>`) is **unsafe** — `config.sessionId` feeds `resumedSessionId` in `anthropic-direct`, which drives the OAuth `X-Claude-Code-Session-Id` header and the sessionId stamped on every emitted event. A correct fix is a live session-id accessor on the awareness source (which would also fix the top-level "pre-init null" case). Tracked as a separate change.

Also noted (minor, not fixed): `gitOutput`'s intentional `maxBuffer: 4096` cap could make `status --porcelain` fail and report null in a repo with 100+ dirty files.
