### PR TITLE
feat(worktree): lifecycle tool + sweep fix for agent-managed worktrees

### DIFF
--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -436,9 +436,10 @@ export class CronScheduler {
         telemetryPath: this.telemetryPath(),
       });
 
+      // 'stale-clean' is intentionally absent: the sweep engine preserves +
+      // warns on stale-clean (commits ahead of base) rather than removing.
       const prunableVerdicts = new Set([
         'empty',
-        'stale-clean',
         'orphaned-dir',
         'orphaned-registration',
         'dead-owner',

--- a/src/agent/plan-mode-gate.ts
+++ b/src/agent/plan-mode-gate.ts
@@ -59,6 +59,25 @@ export function createPlanModeGate(
       };
     }
 
+    // `worktree` is action-gated: `list` is a read-only dry-run sweep and
+    // passes; create/keep/release/remove mutate the git worktree registry
+    // and/or filesystem, mirroring the bash classifier's GIT_WORKTREE_MUTATING
+    // rule so the two surfaces cannot disagree about what "mutating" means.
+    if (toolName === 'worktree') {
+      const action =
+        typeof context.input === 'object' && context.input !== null
+          ? String((context.input as Record<string, unknown>)['action'] ?? '')
+          : '';
+      if (action !== 'list') {
+        return {
+          decision: 'block',
+          reason:
+            `plan mode: worktree "${action}" is refused (mutates the worktree ` +
+            `registry). Only action "list" is allowed in plan mode. Use /plan off to act.`,
+        };
+      }
+    }
+
     // `bash` is mutation-gated, not blanket-refused: read-only recon runs,
     // state-mutating commands are refused. Reuses the same best-effort
     // classifier as the read-only skill phases (single source of mutation

--- a/src/agent/risk-classifier.test.ts
+++ b/src/agent/risk-classifier.test.ts
@@ -223,6 +223,47 @@ describe('classifyRisk — schedule tools', () => {
   });
 });
 
+// ---- worktree lifecycle --------------------------------------------------
+// Regression guard for PR #390 review finding F1: the `worktree` tool had no
+// classifier branch, so every action (including `remove --force`, which can
+// discard uncommitted work) fell through to the 'safe' default and ran
+// unattended in AFK mode with no approval. Only `remove` with `force:true` is
+// irreversible → 'high'; `list` is a read-only dry-run → 'safe'; all other
+// actions are reversible → 'medium'.
+describe('classifyRisk — worktree tool', () => {
+  it('remove with force:true → high (discards uncommitted work; must be gated)', () => {
+    expect(classifyRisk('worktree', { action: 'remove', path: 'foo', force: true }, ctx)).toBe('high');
+  });
+
+  it('remove without force → medium (refuses dirty/locked/ahead; reversible)', () => {
+    expect(classifyRisk('worktree', { action: 'remove', path: 'foo' }, ctx)).toBe('medium');
+  });
+
+  it('remove with explicit force:false → medium', () => {
+    expect(classifyRisk('worktree', { action: 'remove', path: 'foo', force: false }, ctx)).toBe('medium');
+  });
+
+  it('create → medium (reversible: the worktree can be removed)', () => {
+    expect(classifyRisk('worktree', { action: 'create', name: 'feat-x' }, ctx)).toBe('medium');
+  });
+
+  it('keep → medium (lock toggle)', () => {
+    expect(classifyRisk('worktree', { action: 'keep', path: 'foo', reason: 'wip' }, ctx)).toBe('medium');
+  });
+
+  it('release → medium (unlock toggle)', () => {
+    expect(classifyRisk('worktree', { action: 'release', path: 'foo' }, ctx)).toBe('medium');
+  });
+
+  it('list → safe (dry-run sweep report, read-only)', () => {
+    expect(classifyRisk('worktree', { action: 'list' }, ctx)).toBe('safe');
+  });
+
+  it('missing/unknown action → medium (conservative default, never safe)', () => {
+    expect(classifyRisk('worktree', {}, ctx)).toBe('medium');
+  });
+});
+
 // ---- browser tools -------------------------------------------------------
 describe('classifyRisk — browser tools', () => {
   it('browser_open → medium (stateful navigation)', () => {

--- a/src/agent/risk-classifier.ts
+++ b/src/agent/risk-classifier.ts
@@ -335,6 +335,28 @@ export function classifyRisk(
     return 'high';
   }
 
+  // ---- worktree lifecycle --------------------------------------------------
+  // Invariant: the `worktree` tool mutates git worktree state under
+  // .afk-worktrees/. `remove` with `force: true` is the only irreversible
+  // action — it discards uncommitted working-tree changes and commits-ahead
+  // trees that the non-forced path refuses (the branch ref always survives, but
+  // working-tree edits do not), so it is 'high' and gated behind approval.
+  // `list` is a dry-run sweep report (read-only) → 'safe'. Every other action
+  // (create/keep/release, and non-forced remove — which refuses dirty, locked,
+  // and commits-ahead trees) is reversible → 'medium', allowed unattended like
+  // other afk-managed writes. Without this branch the tool fell through to the
+  // 'safe' default below, so `remove --force` ran unattended with no approval.
+  if (tool === 'worktree') {
+    const obj =
+      typeof input === 'object' && input !== null
+        ? (input as Record<string, unknown>)
+        : {};
+    const action = typeof obj['action'] === 'string' ? obj['action'] : '';
+    if (action === 'list') return 'safe';
+    if (action === 'remove' && obj['force'] === true) return 'high';
+    return 'medium';
+  }
+
   // ---- browser actions -----------------------------------------------------
   // browser_act and browser_open drive a stateful headed browser session and
   // can submit forms, click "Delete", trigger purchases, or navigate to

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -34,6 +34,7 @@ import type { AbortOrigin, TraceWriter } from './trace/index.js';
 import type { Surface } from './awareness/types.js';
 import { appendRoutingDecision } from './routing-telemetry.js';
 import { getCurrentSink } from './_lib/skill-sink-channel.js';
+import { touchWorktreeOccupancy } from './worktree-occupancy.js';
 import { buildPhaseRestrictedProvider, type PhaseRole } from './tools/nesting.js';
 import { applyManagerApiKeyFallback } from './tools/child-credential.js';
 import { providerForModel, type BundledProviderName } from './providers/index.js';
@@ -540,6 +541,18 @@ export class SubagentManager {
         ? { provider: buildPhaseRestrictedProvider('read-only', options.config.model) }
         : {}),
     };
+
+    // Occupancy touch: subagents never write presence files (top-level-only
+    // by design — presence.ts), so the worktree sweep's live-session guard
+    // cannot see a fork occupying a worktree. Refresh the worktree's meta
+    // (pid + createdAt) instead, resetting the sweep's age clock and PID
+    // liveness. Fire-and-forget: the helper swallows all errors and no-ops
+    // for cwds outside `.afk-worktrees/`, so it can never delay or fail the
+    // fork. Single wiring point — agent/skill/compose/farm dispatches all
+    // converge here, whether cwd came per-call or via manager inheritance.
+    if (childConfig.cwd !== undefined) {
+      void touchWorktreeOccupancy(childConfig.cwd);
+    }
 
     let session: AgentSession;
     try {

--- a/src/agent/tools/handlers/index.test.ts
+++ b/src/agent/tools/handlers/index.test.ts
@@ -5,7 +5,7 @@ import { BUILTIN_TOOL_NAMES } from '../schemas.js';
 describe('createBuiltinHandlers', () => {
   it('returns a Map with all 22 built-in tools', () => {
     const handlers = createBuiltinHandlers();
-    expect(handlers.size).toBe(22);
+    expect(handlers.size).toBe(23);
   });
 
   it('has an entry for every tool in BUILTIN_TOOL_NAMES', () => {
@@ -27,7 +27,7 @@ describe('createBuiltinHandlers', () => {
     // when permissionMode is undefined but cwd is set. Ensure we get a
     // valid map back and bash is still callable.
     const handlers = createBuiltinHandlers(undefined, '/tmp');
-    expect(handlers.size).toBe(22);
+    expect(handlers.size).toBe(23);
     expect(typeof handlers.get('bash')).toBe('function');
     expect(typeof handlers.get('grep')).toBe('function');
     expect(typeof handlers.get('glob')).toBe('function');
@@ -35,7 +35,7 @@ describe('createBuiltinHandlers', () => {
 
   it('cwd parameter: builds handler set with both permissionMode and cwd', () => {
     const handlers = createBuiltinHandlers('default', '/tmp');
-    expect(handlers.size).toBe(22);
+    expect(handlers.size).toBe(23);
     expect(typeof handlers.get('bash')).toBe('function');
   });
 

--- a/src/agent/tools/handlers/index.ts
+++ b/src/agent/tools/handlers/index.ts
@@ -24,6 +24,7 @@ import {
   cancelScheduleHandler,
 } from './schedules.js';
 import { createTerminalFontSizeHandler, terminalFontSizeHandler } from './terminal-font-size.js';
+import { createWorktreeHandler } from './worktree.js';
 import { configGetHandler, configSetHandler } from './config-ops.js';
 // below for trivial re-enable.
 import { askQuestionHandler } from './ask-question.js';
@@ -61,6 +62,7 @@ export function createBuiltinHandlers(
   const glob = cwd !== undefined ? createGlobHandler(cwd) : globHandler;
   const grep = cwd !== undefined ? createGrepHandler(cwd) : grepHandler;
   const terminalFontSize = createTerminalFontSizeHandler();
+  const worktree = createWorktreeHandler(cwd);
   return new Map<string, ToolHandler>([
     ['bash', bash],
     ['read_file', readFileHandler],
@@ -75,6 +77,7 @@ export function createBuiltinHandlers(
     ['list_schedules', listSchedulesHandler],
     ['get_schedule_history', getScheduleHistoryHandler],
     ['cancel_schedule', cancelScheduleHandler],
+    ['worktree', worktree],
     ['terminal_font_size', terminalFontSize],
     ['config_get', configGetHandler],
     ['config_set', configSetHandler],
@@ -102,6 +105,7 @@ export {
   getScheduleHistoryHandler,
   cancelScheduleHandler,
   terminalFontSizeHandler,
+  createWorktreeHandler,
   configGetHandler,
   configSetHandler,
   askQuestionHandler,

--- a/src/agent/tools/handlers/worktree.test.ts
+++ b/src/agent/tools/handlers/worktree.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Tests for the `worktree` lifecycle tool handler.
+ *
+ * Uses a mocked ExecFileFn (same pattern as worktree-sweep.test.ts) so no
+ * real git operations run. Each test verifies the guard/validation logic
+ * and the exact git argv the handler emits.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mkdtempSync } from 'node:fs';
+import { rmSync } from 'node:fs';
+import { createWorktreeHandler } from './worktree.js';
+import type { ExecFileFn } from '../../worktree-sweep.js';
+
+const SIGNAL = new AbortController().signal;
+
+interface Call { file: string; args: string[] }
+
+function makeMock(
+  responder: (call: Call) => Promise<{ stdout: string; stderr: string }> | { stdout: string; stderr: string },
+): ExecFileFn & { calls: Call[] } {
+  const calls: Call[] = [];
+  const fn = (async (file: string, args: string[]) => {
+    const call = { file, args };
+    calls.push(call);
+    return responder(call);
+  }) as ExecFileFn & { calls: Call[] };
+  fn.calls = calls;
+  return fn;
+}
+
+/** Porcelain block for `git worktree list --porcelain`. */
+function block(path: string, opts?: { branch?: string; locked?: boolean }): string {
+  const lines = [`worktree ${path}`, 'HEAD abc123'];
+  if (opts?.branch) lines.push(`branch ${opts.branch}`);
+  if (opts?.locked) lines.push('locked');
+  return lines.join('\n');
+}
+
+let repoRoot: string;
+let afkRoot: string;
+
+beforeEach(async () => {
+  repoRoot = mkdtempSync(join(tmpdir(), 'wt-handler-'));
+  afkRoot = join(repoRoot, '.afk-worktrees');
+  await fs.mkdir(afkRoot, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(repoRoot, { recursive: true, force: true });
+});
+
+/** Standard responder: repo-root resolution + a porcelain listing. */
+function standardResponder(porcelain: string, overrides?: (call: Call) => { stdout: string; stderr: string } | undefined) {
+  return (call: Call) => {
+    if (overrides) {
+      const hit = overrides(call);
+      if (hit) return hit;
+    }
+    if (call.args.includes('--git-common-dir')) {
+      return { stdout: `${repoRoot}/.git\n`, stderr: '' };
+    }
+    if (call.args.includes('list') && call.args.includes('--porcelain')) {
+      return { stdout: porcelain, stderr: '' };
+    }
+    return { stdout: '', stderr: '' };
+  };
+}
+
+describe('worktree handler — input validation', () => {
+  it('rejects non-object input', async () => {
+    const handler = createWorktreeHandler(repoRoot, { execFile: makeMock(standardResponder('')) });
+    const result = await handler('nope', SIGNAL);
+    expect(result.isError).toBe(true);
+  });
+
+  it('rejects unknown action', async () => {
+    const handler = createWorktreeHandler(repoRoot, { execFile: makeMock(standardResponder('')) });
+    const result = await handler({ action: 'frobnicate' }, SIGNAL);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('action must be one of');
+  });
+
+  it('create requires name', async () => {
+    const handler = createWorktreeHandler(repoRoot, { execFile: makeMock(standardResponder('')) });
+    const result = await handler({ action: 'create' }, SIGNAL);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('name required');
+  });
+
+  it('keep/release/remove require path', async () => {
+    const handler = createWorktreeHandler(repoRoot, { execFile: makeMock(standardResponder('')) });
+    for (const action of ['keep', 'release', 'remove']) {
+      const result = await handler({ action }, SIGNAL);
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('path required');
+    }
+  });
+});
+
+describe('worktree handler — create', () => {
+  it('creates under .afk-worktrees/ with sanitized slug, branch prefix, and meta', async () => {
+    const wtPath = join(afkRoot, 'my-feature');
+    const mock = makeMock(standardResponder(block(repoRoot), (call) => {
+      if (call.args.includes('add')) {
+        // Simulate git creating the dir so the meta write has a target.
+        // (mkdir synchronously inside the responder.)
+        return fs.mkdir(wtPath, { recursive: true }).then(() => ({ stdout: '', stderr: '' }));
+      }
+      if (call.args.includes('rev-parse') && call.args.includes('HEAD')) {
+        return { stdout: 'base-sha-123\n', stderr: '' };
+      }
+      return undefined;
+    }));
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler({ action: 'create', name: 'My Feature!' }, SIGNAL);
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(String(result.content)) as { path: string; branch: string };
+    expect(parsed.path).toBe(wtPath);
+    expect(parsed.branch).toBe('afk/my-feature');
+
+    // git worktree add argv shape
+    const addCall = mock.calls.find((c) => c.args.includes('add'));
+    expect(addCall?.args).toEqual([
+      '-C', repoRoot, 'worktree', 'add', '-b', 'afk/my-feature', wtPath, 'HEAD',
+    ]);
+
+    // Meta written with owner 'agent' + pid
+    const metaRaw = await fs.readFile(join(wtPath, '.afk-worktree-meta.json'), 'utf-8');
+    const meta = JSON.parse(metaRaw) as Record<string, unknown>;
+    expect(meta['owner']).toBe('agent');
+    expect(meta['pid']).toBe(process.pid);
+    expect(meta['baseSha']).toBe('base-sha-123');
+    expect(typeof meta['createdAt']).toBe('string');
+  });
+
+  it('refuses when a worktree already exists at the target path', async () => {
+    const wtPath = join(afkRoot, 'taken');
+    const mock = makeMock(standardResponder(`${block(repoRoot)}\n\n${block(wtPath)}\n`));
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler({ action: 'create', name: 'taken' }, SIGNAL);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('already exists');
+  });
+
+  it('rejects a name that sanitizes to empty', async () => {
+    const handler = createWorktreeHandler(repoRoot, { execFile: makeMock(standardResponder('')) });
+    const result = await handler({ action: 'create', name: '///' }, SIGNAL);
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe('worktree handler — keep / release', () => {
+  it('locks a managed worktree with an afk-prefixed reason', async () => {
+    const wtPath = join(afkRoot, 'important');
+    const mock = makeMock(standardResponder(`${block(repoRoot)}\n\n${block(wtPath)}\n`));
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler(
+      { action: 'keep', path: 'important', reason: 'unmerged spike' },
+      SIGNAL,
+    );
+    expect(result.isError).toBeUndefined();
+    const lockCall = mock.calls.find((c) => c.args.includes('lock'));
+    expect(lockCall?.args).toEqual([
+      '-C', repoRoot, 'worktree', 'lock', '--reason', 'afk: unmerged spike', wtPath,
+    ]);
+  });
+
+  it('refuses paths outside .afk-worktrees/', async () => {
+    const mock = makeMock(standardResponder(block(repoRoot)));
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler({ action: 'keep', path: '/tmp/elsewhere' }, SIGNAL);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('outside the afk-managed worktree root');
+    expect(mock.calls.some((c) => c.args.includes('lock'))).toBe(false);
+  });
+
+  it('refuses unregistered worktrees', async () => {
+    const mock = makeMock(standardResponder(block(repoRoot)));
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler({ action: 'keep', path: 'ghost' }, SIGNAL);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('No registered git worktree');
+  });
+
+  it('release unlocks a managed worktree', async () => {
+    const wtPath = join(afkRoot, 'kept');
+    const mock = makeMock(standardResponder(`${block(repoRoot)}\n\n${block(wtPath, { locked: true })}\n`));
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler({ action: 'release', path: 'kept' }, SIGNAL);
+    expect(result.isError).toBeUndefined();
+    const unlockCall = mock.calls.find((c) => c.args.includes('unlock'));
+    expect(unlockCall?.args).toEqual(['-C', repoRoot, 'worktree', 'unlock', wtPath]);
+  });
+});
+
+describe('worktree handler — remove guards', () => {
+  it('refuses a locked worktree', async () => {
+    const wtPath = join(afkRoot, 'locked-wt');
+    const mock = makeMock(standardResponder(`${block(repoRoot)}\n\n${block(wtPath, { locked: true })}\n`));
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler({ action: 'remove', path: 'locked-wt' }, SIGNAL);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('locked');
+    expect(mock.calls.some((c) => c.args.includes('remove'))).toBe(false);
+  });
+
+  it('refuses a dirty worktree without force', async () => {
+    const wtPath = join(afkRoot, 'dirty-wt');
+    const mock = makeMock(standardResponder(`${block(repoRoot)}\n\n${block(wtPath)}\n`, (call) => {
+      if (call.args.includes('status')) return { stdout: ' M file.ts\n', stderr: '' };
+      return undefined;
+    }));
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler({ action: 'remove', path: 'dirty-wt' }, SIGNAL);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('uncommitted changes');
+  });
+
+  it('refuses a worktree with commits ahead without force', async () => {
+    const wtPath = join(afkRoot, 'ahead-wt');
+    await fs.mkdir(wtPath, { recursive: true });
+    await fs.writeFile(
+      join(wtPath, '.afk-worktree-meta.json'),
+      JSON.stringify({ owner: 'agent', createdAt: new Date().toISOString(), baseSha: 'base123' }),
+    );
+    const mock = makeMock(standardResponder(`${block(repoRoot)}\n\n${block(wtPath)}\n`, (call) => {
+      if (call.args.includes('status')) return { stdout: '', stderr: '' };
+      if (call.args.includes('rev-parse') && call.args.includes('HEAD') && call.args.includes(wtPath)) {
+        return { stdout: 'tip456\n', stderr: '' };
+      }
+      if (call.args.includes('rev-list')) return { stdout: '2\n', stderr: '' };
+      return undefined;
+    }));
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler({ action: 'remove', path: 'ahead-wt' }, SIGNAL);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('commit(s) ahead');
+  });
+
+  it('removes a clean worktree and preserves the branch', async () => {
+    const wtPath = join(afkRoot, 'clean-wt');
+    const mock = makeMock(
+      standardResponder(`${block(repoRoot)}\n\n${block(wtPath, { branch: 'refs/heads/afk/clean-wt' })}\n`),
+    );
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler({ action: 'remove', path: 'clean-wt' }, SIGNAL);
+    expect(result.isError).toBeUndefined();
+    const removeCall = mock.calls.find((c) => c.args.includes('remove'));
+    expect(removeCall?.args).toEqual(['-C', repoRoot, 'worktree', 'remove', wtPath]);
+    // No --force, no branch -d.
+    expect(removeCall?.args).not.toContain('--force');
+    expect(mock.calls.some((c) => c.args.includes('branch') && c.args.includes('-d'))).toBe(false);
+  });
+
+  it('force removes a dirty worktree with --force', async () => {
+    const wtPath = join(afkRoot, 'force-wt');
+    const mock = makeMock(standardResponder(`${block(repoRoot)}\n\n${block(wtPath)}\n`, (call) => {
+      if (call.args.includes('status')) return { stdout: ' M dirty.ts\n', stderr: '' };
+      return undefined;
+    }));
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler({ action: 'remove', path: 'force-wt', force: true }, SIGNAL);
+    expect(result.isError).toBeUndefined();
+    const removeCall = mock.calls.find((c) => c.args.includes('remove'));
+    expect(removeCall?.args).toContain('--force');
+  });
+});
+
+describe('worktree handler — errors surface as isError', () => {
+  it('git failures return isError instead of throwing', async () => {
+    const wtPath = join(afkRoot, 'boom');
+    const mock = makeMock((call) => {
+      if (call.args.includes('--git-common-dir')) return { stdout: `${repoRoot}/.git\n`, stderr: '' };
+      if (call.args.includes('list') && call.args.includes('--porcelain')) {
+        return { stdout: `${block(repoRoot)}\n\n${block(wtPath)}\n`, stderr: '' };
+      }
+      if (call.args.includes('lock')) throw new Error('git exploded');
+      return { stdout: '', stderr: '' };
+    });
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler({ action: 'keep', path: 'boom' }, SIGNAL);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('git exploded');
+  });
+
+  it('unresolvable repo root returns isError', async () => {
+    const mock = makeMock(() => { throw new Error('not a git repo'); });
+    const handler = createWorktreeHandler('/nowhere', { execFile: mock });
+    const result = await handler({ action: 'list' }, SIGNAL);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('Cannot resolve git repo root');
+  });
+});

--- a/src/agent/tools/handlers/worktree.ts
+++ b/src/agent/tools/handlers/worktree.ts
@@ -1,0 +1,362 @@
+/**
+ * Handler for the `worktree` lifecycle tool.
+ *
+ * Gives the model a sanctioned lifecycle for afk-managed git worktrees under
+ * `<repoRoot>/.afk-worktrees/`, replacing the raw `bash: git worktree add`
+ * pattern that produced meta-less ghost worktrees the sweep engine
+ * (`src/agent/worktree-sweep.ts`) reaps or leaks:
+ *
+ *   - `create`  — worktree + branch under `.afk-worktrees/` WITH a
+ *                 `.afk-worktree-meta.json` (owner 'agent', pid, createdAt),
+ *                 so all sweep guards (age, PID-liveness) apply.
+ *   - `keep`    — `git worktree lock` with a reason. The sweep short-circuits
+ *                 on locked trees before every other verdict — this is the
+ *                 self-save primitive.
+ *   - `release` — `git worktree unlock`.
+ *   - `list`    — dry-run sweep: paths + verdicts + age, so the model can see
+ *                 which trees are endangered or stale.
+ *   - `remove`  — guarded removal: refuses dirty, locked, commits-ahead, main
+ *                 worktree, and anything outside `.afk-worktrees/`. `force`
+ *                 overrides the dirty/commits-ahead refusal only.
+ *
+ * Pattern: follows schedules.ts — manual input validation, isError: true on
+ * failure, no thrown exceptions.
+ *
+ * @module agent/tools/handlers/worktree
+ */
+
+import { execFile as execFileCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+import { promises as fs } from 'node:fs';
+import { join, resolve, isAbsolute, dirname, sep } from 'node:path';
+import type { ToolHandler } from '../types.js';
+import { runSweep } from '../../worktree-sweep.js';
+import type { ExecFileFn } from '../../worktree-sweep.js';
+
+const defaultExecFile: ExecFileFn = promisify(execFileCallback) as ExecFileFn;
+
+/** Injectable deps for tests. */
+export interface WorktreeHandlerDeps {
+  execFile?: ExecFileFn;
+}
+
+interface RepoContext {
+  repoRoot: string;
+  afkWorktreesRoot: string;
+}
+
+/**
+ * Resolve the repo root from the session cwd via `--git-common-dir` so the
+ * answer is the MAIN checkout even when the session itself runs inside a
+ * linked worktree (same trick as the `/worktree` slash command).
+ */
+async function resolveRepoContext(
+  execFile: ExecFileFn,
+  cwd: string,
+): Promise<RepoContext> {
+  const result = await execFile('git', ['-C', cwd, 'rev-parse', '--git-common-dir']);
+  const raw = result.stdout.trim();
+  if (!raw) throw new Error('Not in a git repository.');
+  const absoluteGitDir = isAbsolute(raw) ? raw : resolve(cwd, raw);
+  const repoRoot = dirname(absoluteGitDir);
+  return { repoRoot, afkWorktreesRoot: join(repoRoot, '.afk-worktrees') };
+}
+
+/** Lowercase-kebab sanitization for worktree slugs / branch fragments. */
+function sanitizeSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+    .slice(0, 80);
+}
+
+/** True when `child` is `parent` or nested inside it. */
+function isPathWithin(child: string, parent: string): boolean {
+  const c = resolve(child);
+  const p = resolve(parent);
+  return c === p || c.startsWith(p + sep);
+}
+
+interface PorcelainEntry {
+  path: string;
+  branch?: string;
+  locked: boolean;
+}
+
+async function listRegisteredWorktrees(
+  execFile: ExecFileFn,
+  repoRoot: string,
+): Promise<PorcelainEntry[]> {
+  const out = await execFile('git', ['-C', repoRoot, 'worktree', 'list', '--porcelain']);
+  const entries: PorcelainEntry[] = [];
+  let current: PorcelainEntry | undefined;
+  for (const line of out.stdout.split('\n')) {
+    if (line.startsWith('worktree ')) {
+      if (current) entries.push(current);
+      current = { path: line.slice('worktree '.length).trim(), locked: false };
+    } else if (line.startsWith('branch ') && current) {
+      current.branch = line.slice('branch '.length).trim();
+    } else if (line.startsWith('locked') && current) {
+      current.locked = true;
+    }
+  }
+  if (current) entries.push(current);
+  return entries;
+}
+
+/** Find the registered entry for `path`, or undefined. */
+async function findEntry(
+  execFile: ExecFileFn,
+  repoRoot: string,
+  path: string,
+): Promise<PorcelainEntry | undefined> {
+  const entries = await listRegisteredWorktrees(execFile, repoRoot);
+  return entries.find((e) => resolve(e.path) === resolve(path));
+}
+
+/**
+ * Validate a caller-supplied worktree path: absolute or relative to the afk
+ * root by slug, must resolve inside `.afk-worktrees/`, must be registered.
+ * Returns the entry, or an error string.
+ */
+async function resolveManagedWorktree(
+  execFile: ExecFileFn,
+  ctx: RepoContext,
+  pathInput: string,
+): Promise<PorcelainEntry | string> {
+  const candidate = isAbsolute(pathInput)
+    ? pathInput
+    : join(ctx.afkWorktreesRoot, pathInput);
+  if (!isPathWithin(candidate, ctx.afkWorktreesRoot)) {
+    return `Refused: ${candidate} is outside the afk-managed worktree root (${ctx.afkWorktreesRoot}). This tool only manages worktrees under .afk-worktrees/.`;
+  }
+  const entry = await findEntry(execFile, ctx.repoRoot, candidate);
+  if (!entry) {
+    return `No registered git worktree at ${candidate}. Use action "list" to see managed worktrees.`;
+  }
+  return entry;
+}
+
+async function isDirty(execFile: ExecFileFn, worktreePath: string): Promise<boolean> {
+  try {
+    const status = await execFile('git', ['-C', worktreePath, 'status', '--porcelain']);
+    return status.stdout.trim().length > 0;
+  } catch {
+    return true; // unreadable → treat as dirty (safe fallback)
+  }
+}
+
+async function commitsAhead(
+  execFile: ExecFileFn,
+  repoRoot: string,
+  worktreePath: string,
+): Promise<number> {
+  // Base SHA from meta when available; unknowable without it → report 0 and
+  // rely on the dirty/lock guards (mirrors the sweep engine's fallback).
+  try {
+    const metaRaw = await fs.readFile(join(worktreePath, '.afk-worktree-meta.json'), 'utf-8');
+    const meta = JSON.parse(metaRaw) as { baseSha?: string };
+    if (!meta.baseSha) return 0;
+    const head = await execFile('git', ['-C', worktreePath, 'rev-parse', 'HEAD']);
+    const count = await execFile('git', [
+      '-C', repoRoot, 'rev-list', `${meta.baseSha}..${head.stdout.trim()}`, '--count',
+    ]);
+    return parseInt(count.stdout.trim(), 10) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Build the `worktree` tool handler bound to a session cwd.
+ *
+ * @param cwd - Session working directory (worktree path under `afk -w`).
+ *   Repo-root resolution anchors here; falls back to `process.cwd()`.
+ * @param deps - Test injection point for the git exec function.
+ */
+export function createWorktreeHandler(
+  cwd?: string,
+  deps?: WorktreeHandlerDeps,
+): ToolHandler {
+  const execFile = deps?.execFile ?? defaultExecFile;
+
+  return async (input, _signal, context) => {
+    if (!input || typeof input !== 'object') {
+      return { content: 'Invalid input: expected object', isError: true };
+    }
+    const obj = input as Record<string, unknown>;
+    const action = obj['action'];
+    if (
+      action !== 'create' && action !== 'keep' && action !== 'release' &&
+      action !== 'list' && action !== 'remove'
+    ) {
+      return {
+        content: 'Invalid input: action must be one of create | keep | release | list | remove',
+        isError: true,
+      };
+    }
+
+    const anchor = context?.resolveBase ?? context?.cwd ?? cwd ?? process.cwd();
+    let ctx: RepoContext;
+    try {
+      ctx = await resolveRepoContext(execFile, anchor);
+    } catch (err) {
+      return {
+        content: `Cannot resolve git repo root from ${anchor}: ${err instanceof Error ? err.message : String(err)}`,
+        isError: true,
+      };
+    }
+
+    try {
+      switch (action) {
+        case 'create': {
+          if (typeof obj['name'] !== 'string' || !obj['name']) {
+            return { content: 'Invalid input: name required for create', isError: true };
+          }
+          const slug = sanitizeSlug(obj['name']);
+          if (!slug) {
+            return { content: `Invalid input: name "${obj['name']}" sanitizes to empty`, isError: true };
+          }
+          const worktreePath = join(ctx.afkWorktreesRoot, slug);
+          const existing = await findEntry(execFile, ctx.repoRoot, worktreePath);
+          if (existing) {
+            return { content: `Worktree already exists at ${worktreePath}`, isError: true };
+          }
+          const prefix = process.env['AFK_WORKTREE_BRANCH_PREFIX'] ?? 'afk/';
+          const branch = `${prefix}${slug}`;
+          const baseRef = typeof obj['base'] === 'string' && obj['base'] ? obj['base'] : 'HEAD';
+          await execFile('git', [
+            '-C', ctx.repoRoot, 'worktree', 'add', '-b', branch, worktreePath, baseRef,
+          ]);
+          // Meta write is what makes this tree a first-class citizen of the
+          // sweep protocol (age from createdAt, PID liveness). Best-effort:
+          // never fail the create over it.
+          let baseSha = '';
+          try {
+            const sha = await execFile('git', ['-C', ctx.repoRoot, 'rev-parse', baseRef]);
+            baseSha = sha.stdout.trim();
+          } catch { /* non-fatal */ }
+          try {
+            await fs.writeFile(
+              join(worktreePath, '.afk-worktree-meta.json'),
+              JSON.stringify(
+                {
+                  owner: 'agent',
+                  pid: process.pid,
+                  createdAt: new Date().toISOString(),
+                  baseSha,
+                  baseBranch: baseRef,
+                },
+                null,
+                2,
+              ),
+              'utf-8',
+            );
+          } catch { /* best-effort */ }
+          return {
+            content: JSON.stringify({ path: worktreePath, branch, base: baseRef }),
+          };
+        }
+
+        case 'keep': {
+          if (typeof obj['path'] !== 'string' || !obj['path']) {
+            return { content: 'Invalid input: path required for keep', isError: true };
+          }
+          const entry = await resolveManagedWorktree(execFile, ctx, obj['path']);
+          if (typeof entry === 'string') return { content: entry, isError: true };
+          const reason = typeof obj['reason'] === 'string' && obj['reason']
+            ? obj['reason']
+            : 'kept by agent';
+          await execFile('git', [
+            '-C', ctx.repoRoot, 'worktree', 'lock', '--reason', `afk: ${reason}`, entry.path,
+          ]);
+          return {
+            content: JSON.stringify({
+              path: entry.path,
+              locked: true,
+              note: 'The sweep engine never removes or warns about locked worktrees. Use action "release" to unlock.',
+            }),
+          };
+        }
+
+        case 'release': {
+          if (typeof obj['path'] !== 'string' || !obj['path']) {
+            return { content: 'Invalid input: path required for release', isError: true };
+          }
+          const entry = await resolveManagedWorktree(execFile, ctx, obj['path']);
+          if (typeof entry === 'string') return { content: entry, isError: true };
+          await execFile('git', ['-C', ctx.repoRoot, 'worktree', 'unlock', entry.path]);
+          return { content: JSON.stringify({ path: entry.path, locked: false }) };
+        }
+
+        case 'list': {
+          const result = await runSweep({
+            execFile,
+            repoRoot: ctx.repoRoot,
+            dryRun: true,
+            scope: 'all',
+          });
+          return {
+            content: JSON.stringify(
+              result.candidates.map((c) => ({
+                path: c.path,
+                verdict: c.verdict,
+                owner: c.owner,
+                ageDays: Math.round(c.ageMs / 86_400_000),
+              })),
+            ),
+          };
+        }
+
+        case 'remove': {
+          if (typeof obj['path'] !== 'string' || !obj['path']) {
+            return { content: 'Invalid input: path required for remove', isError: true };
+          }
+          const entry = await resolveManagedWorktree(execFile, ctx, obj['path']);
+          if (typeof entry === 'string') return { content: entry, isError: true };
+          if (resolve(entry.path) === resolve(ctx.repoRoot)) {
+            return { content: 'Refused: cannot remove the main worktree.', isError: true };
+          }
+          if (entry.locked) {
+            return {
+              content: `Refused: ${entry.path} is locked. Use action "release" first if removal is really intended.`,
+              isError: true,
+            };
+          }
+          const force = obj['force'] === true;
+          if (!force) {
+            if (await isDirty(execFile, entry.path)) {
+              return {
+                content: `Refused: ${entry.path} has uncommitted changes. Commit/stash them, or pass force: true to discard.`,
+                isError: true,
+              };
+            }
+            const ahead = await commitsAhead(execFile, ctx.repoRoot, entry.path);
+            if (ahead > 0) {
+              return {
+                content: `Refused: ${entry.path} has ${ahead} commit(s) ahead of its base. The branch ref would survive, but pass force: true to confirm removing the checkout.`,
+                isError: true,
+              };
+            }
+          }
+          const args = ['-C', ctx.repoRoot, 'worktree', 'remove'];
+          if (force) args.push('--force');
+          args.push(entry.path);
+          await execFile('git', args);
+          // Branch intentionally left intact — removal drops the checkout only.
+          return {
+            content: JSON.stringify({ path: entry.path, removed: true, branchPreserved: entry.branch ?? null }),
+          };
+        }
+      }
+    } catch (err) {
+      return {
+        content: `worktree ${action} failed: ${err instanceof Error ? err.message : String(err)}`,
+        isError: true,
+      };
+    }
+    // Unreachable — switch is exhaustive over validated actions.
+    return { content: 'Unhandled action', isError: true };
+  };
+}

--- a/src/agent/tools/handlers/worktree.ts
+++ b/src/agent/tools/handlers/worktree.ts
@@ -32,6 +32,7 @@ import { join, resolve, isAbsolute, dirname, sep } from 'node:path';
 import type { ToolHandler } from '../types.js';
 import { runSweep } from '../../worktree-sweep.js';
 import type { ExecFileFn } from '../../worktree-sweep.js';
+import { env } from '../../../config/env.js';
 
 const defaultExecFile: ExecFileFn = promisify(execFileCallback) as ExecFileFn;
 
@@ -223,7 +224,7 @@ export function createWorktreeHandler(
           if (existing) {
             return { content: `Worktree already exists at ${worktreePath}`, isError: true };
           }
-          const prefix = process.env['AFK_WORKTREE_BRANCH_PREFIX'] ?? 'afk/';
+          const prefix = env.AFK_WORKTREE_BRANCH_PREFIX ?? 'afk/';
           const branch = `${prefix}${slug}`;
           const baseRef = typeof obj['base'] === 'string' && obj['base'] ? obj['base'] : 'HEAD';
           await execFile('git', [

--- a/src/agent/tools/schemas.test.ts
+++ b/src/agent/tools/schemas.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { builtinToolSchemas, BUILTIN_TOOL_NAMES, agentTool } from './schemas.js';
 
 describe('builtinToolSchemas', () => {
-  it('contains exactly 22 tools', () => {
-    expect(builtinToolSchemas).toHaveLength(22);
+  it('contains exactly 23 tools', () => {
+    expect(builtinToolSchemas).toHaveLength(23);
   });
 
   it('exports the expected tool names', () => {
@@ -21,6 +21,7 @@ describe('builtinToolSchemas', () => {
       'list_schedules',
       'get_schedule_history',
       'cancel_schedule',
+      'worktree',
       'terminal_font_size',
       'config_get',
       'config_set',

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -366,7 +366,9 @@ export const agentTool: AnthropicToolDef = {
           'worktree). When provided, the child\'s file/shell tools (bash, grep, ' +
           'glob, read_file, write_file, edit_file) anchor at this path instead. ' +
           'Use to dispatch a subagent into a pre-existing git worktree you ' +
-          'created with `bash: git worktree add <path>` so the subagent can ' +
+          'created with the `worktree` tool (action "create" — preferred over ' +
+          'raw `git worktree add`, which produces unmanaged ghost worktrees ' +
+          'the background sweep may reap) so the subagent can ' +
           'work in isolation from the parent. Must be absolute (no relative ' +
           'paths) and must not contain `..` segments. Existence is not checked ' +
           'at dispatch time — a non-existent path surfaces as an error on the ' +
@@ -588,6 +590,70 @@ export const cancelScheduleTool: AnthropicToolDef = {
       },
     },
     required: ['taskId'],
+  },
+};
+
+export const worktreeTool: AnthropicToolDef = {
+  name: 'worktree',
+  category: 'other',
+  concurrencySafe: false,
+  riskClass: 'caution',
+  description:
+    'Manage afk-managed git worktrees under `<repoRoot>/.afk-worktrees/`. This is the sanctioned ' +
+    'lifecycle for agent-created worktrees — prefer it over raw `git worktree` bash commands, because ' +
+    'it writes the `.afk-worktree-meta.json` the background sweep engine uses to know a worktree is ' +
+    'owned and alive. Worktrees created via bare `bash: git worktree add` have no meta and are ' +
+    'eventually reaped as ghosts (or leak forever if created outside `.afk-worktrees/`).\n\n' +
+    'Actions:\n' +
+    '- `create` — new worktree + branch under `.afk-worktrees/<name>` with proper meta. `base` picks ' +
+    'the start ref (default HEAD). Returns { path, branch, base }. Pass the returned path as `cwd` ' +
+    'when dispatching subagents into it.\n' +
+    '- `keep` — lock the worktree (`git worktree lock`) so the sweep engine NEVER removes it, ' +
+    'regardless of age or cleanliness. Use this to save a worktree holding work in progress that ' +
+    'must survive across sessions. Provide a `reason` naming why.\n' +
+    '- `release` — unlock a previously kept worktree, returning it to normal sweep lifecycle.\n' +
+    '- `list` — dry-run sweep report: every afk-managed worktree with its verdict ' +
+    '(active | empty | stale-clean | stale-dirty | locked | dead-owner | orphaned-*), owner, and age ' +
+    'in days. Verdicts empty/dead-owner/orphaned-* are removal candidates on the next sweep.\n' +
+    '- `remove` — remove a worktree checkout you no longer need (branch ref is always preserved). ' +
+    'Refuses dirty trees, locked trees, and trees with commits ahead of base unless `force: true`. ' +
+    'Never removes the main worktree or paths outside `.afk-worktrees/`.',
+  input_schema: {
+    type: 'object',
+    properties: {
+      action: {
+        type: 'string',
+        enum: ['create', 'keep', 'release', 'list', 'remove'],
+        description: 'The lifecycle operation to perform.',
+      },
+      name: {
+        type: 'string',
+        description:
+          'create only: worktree slug (kebab-case; sanitized). Becomes `.afk-worktrees/<name>` and ' +
+          'branch `afk/<name>` (prefix configurable via AFK_WORKTREE_BRANCH_PREFIX).',
+      },
+      base: {
+        type: 'string',
+        description: 'create only: git ref to base the new branch on. Default: HEAD.',
+      },
+      path: {
+        type: 'string',
+        description:
+          'keep/release/remove: the worktree to operate on. Absolute path, or a bare slug resolved ' +
+          'against `.afk-worktrees/`.',
+      },
+      reason: {
+        type: 'string',
+        description: 'keep only: why this worktree must survive (stored as the git lock reason).',
+      },
+      force: {
+        type: 'boolean',
+        description:
+          'remove only: also remove when dirty or with commits ahead of base. Default false. ' +
+          'The branch ref is preserved either way.',
+      },
+    },
+    required: ['action'],
   },
 };
 
@@ -1091,6 +1157,7 @@ export const builtinToolSchemas: readonly AnthropicToolDef[] = [
   listSchedulesTool,
   getScheduleHistoryTool,
   cancelScheduleTool,
+  worktreeTool,
   terminalFontSizeTool,
   configGetTool,
   configSetTool,

--- a/src/agent/worktree-occupancy.test.ts
+++ b/src/agent/worktree-occupancy.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the worktree occupancy touch helper.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join, sep } from 'node:path';
+import { tmpdir } from 'node:os';
+import { touchWorktreeOccupancy, worktreeRootFor } from './worktree-occupancy.js';
+
+let repoRoot: string;
+let worktreePath: string;
+
+beforeEach(async () => {
+  repoRoot = mkdtempSync(join(tmpdir(), 'occupancy-'));
+  worktreePath = join(repoRoot, '.afk-worktrees', 'my-wt');
+  await fs.mkdir(worktreePath, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(repoRoot, { recursive: true, force: true });
+});
+
+describe('worktreeRootFor', () => {
+  it('resolves the worktree root from the root itself', () => {
+    expect(worktreeRootFor(worktreePath)).toBe(worktreePath);
+  });
+
+  it('resolves the worktree root from a nested path', () => {
+    expect(worktreeRootFor(join(worktreePath, 'src', 'deep'))).toBe(worktreePath);
+  });
+
+  it('returns undefined for paths outside .afk-worktrees/', () => {
+    expect(worktreeRootFor(repoRoot)).toBeUndefined();
+    expect(worktreeRootFor('/tmp/elsewhere')).toBeUndefined();
+  });
+
+  it('returns undefined for the bare .afk-worktrees dir itself', () => {
+    // Trailing separator makes the post-segment slug empty.
+    expect(worktreeRootFor(join(repoRoot, '.afk-worktrees') + sep)).toBeUndefined();
+  });
+});
+
+describe('touchWorktreeOccupancy', () => {
+  it('refreshes pid and createdAt while preserving other meta fields', async () => {
+    const metaPath = join(worktreePath, '.afk-worktree-meta.json');
+    const staleDate = new Date(Date.now() - 86_400_000 * 30).toISOString();
+    await fs.writeFile(
+      metaPath,
+      JSON.stringify({
+        owner: 'interactive',
+        pid: 999_999,
+        createdAt: staleDate,
+        baseSha: 'abc123',
+        baseBranch: 'main',
+      }),
+    );
+
+    await touchWorktreeOccupancy(join(worktreePath, 'src'));
+
+    const meta = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as Record<string, unknown>;
+    expect(meta['pid']).toBe(process.pid);
+    expect(meta['createdAt']).not.toBe(staleDate);
+    expect(Date.now() - new Date(meta['createdAt'] as string).getTime()).toBeLessThan(60_000);
+    // Preserved fields
+    expect(meta['owner']).toBe('interactive');
+    expect(meta['baseSha']).toBe('abc123');
+    expect(meta['baseBranch']).toBe('main');
+  });
+
+  it('creates minimal meta (owner agent) when none exists — adopts ghost worktrees', async () => {
+    await touchWorktreeOccupancy(worktreePath);
+    const meta = JSON.parse(
+      await fs.readFile(join(worktreePath, '.afk-worktree-meta.json'), 'utf-8'),
+    ) as Record<string, unknown>;
+    expect(meta['owner']).toBe('agent');
+    expect(meta['pid']).toBe(process.pid);
+    expect(typeof meta['createdAt']).toBe('string');
+  });
+
+  it('recovers from corrupt meta by rewriting a minimal one', async () => {
+    const metaPath = join(worktreePath, '.afk-worktree-meta.json');
+    await fs.writeFile(metaPath, '{not json');
+    await touchWorktreeOccupancy(worktreePath);
+    const meta = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as Record<string, unknown>;
+    expect(meta['owner']).toBe('agent');
+    expect(meta['pid']).toBe(process.pid);
+  });
+
+  it('no-ops for paths outside .afk-worktrees/', async () => {
+    await touchWorktreeOccupancy(repoRoot);
+    await expect(
+      fs.access(join(repoRoot, '.afk-worktree-meta.json')),
+    ).rejects.toThrow();
+  });
+
+  it('never throws when the worktree dir does not exist', async () => {
+    await expect(
+      touchWorktreeOccupancy(join(repoRoot, '.afk-worktrees', 'gone', 'src')),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/agent/worktree-occupancy.ts
+++ b/src/agent/worktree-occupancy.ts
@@ -1,0 +1,81 @@
+/**
+ * Worktree occupancy touch — keeps the sweep engine's liveness signals
+ * accurate for worktrees occupied by forked subagents.
+ *
+ * Presence files are top-level-only (`src/agent/awareness/presence.ts`):
+ * a subagent dispatched with a `cwd` inside a worktree never writes one, so
+ * the sweep's live-session guard cannot see the occupation. Without a
+ * countervailing signal, a clean worktree hosting a long investigation can
+ * cross the `empty`/`stale-clean` age thresholds and be judged reapable
+ * while a subagent is still working in it.
+ *
+ * `touchWorktreeOccupancy` closes most of that gap: at dispatch time it
+ * rewrites the worktree's `.afk-worktree-meta.json` with the current pid and
+ * a fresh `createdAt`. Effects on the sweep (`worktree-sweep.ts`):
+ *   - `ageMs` resets (meta.createdAt is preferred over dir birthtime), so
+ *     all age-gated verdicts (`empty`, `stale-clean`, `stale-dirty`) re-arm.
+ *   - `ownerLiveness` resolves to 'alive' while this process runs, which
+ *     suppresses the accelerated `dead-owner` path.
+ *
+ * Residual gap (accepted): a subagent running longer than MIN_EMPTY_AGE_MS
+ * (1h) in a tree that stays clean can still cross the `empty` threshold.
+ * The `worktree` tool's `keep` action (git worktree lock) is the sanctioned
+ * escape hatch for anything that must survive unconditionally.
+ *
+ * Best-effort by contract: every failure is swallowed. A missed touch
+ * degrades to today's behavior; it must never block or fail a dispatch.
+ *
+ * @module agent/worktree-occupancy
+ */
+
+import { promises as fs } from 'node:fs';
+import { join, resolve, sep } from 'node:path';
+
+const META_FILENAME = '.afk-worktree-meta.json';
+const AFK_WORKTREES_SEGMENT = `${sep}.afk-worktrees${sep}`;
+
+/**
+ * Resolve the worktree root containing `cwd`, when `cwd` sits inside an
+ * `.afk-worktrees/` tree. Returns undefined otherwise.
+ *
+ * Pure path computation — no filesystem access.
+ */
+export function worktreeRootFor(cwd: string): string | undefined {
+  const abs = resolve(cwd);
+  const idx = abs.indexOf(AFK_WORKTREES_SEGMENT);
+  if (idx === -1) return undefined;
+  const afterRoot = abs.slice(idx + AFK_WORKTREES_SEGMENT.length);
+  const slug = afterRoot.split(sep)[0];
+  if (!slug) return undefined;
+  return abs.slice(0, idx + AFK_WORKTREES_SEGMENT.length) + slug;
+}
+
+/**
+ * Stamp the worktree containing `cwd` as occupied by this process.
+ *
+ * Rewrites `pid` and `createdAt` in the tree's meta file, preserving any
+ * other fields (owner, baseSha, baseBranch). Creates a minimal meta when
+ * none exists (owner 'agent') — this is exactly the case of a bash-created
+ * ghost worktree being adopted by a subagent dispatch.
+ *
+ * No-op (silently) when `cwd` is not inside an `.afk-worktrees/` tree or on
+ * any filesystem error.
+ */
+export async function touchWorktreeOccupancy(cwd: string): Promise<void> {
+  const root = worktreeRootFor(cwd);
+  if (root === undefined) return;
+  const metaPath = join(root, META_FILENAME);
+  try {
+    let meta: Record<string, unknown> = {};
+    try {
+      meta = JSON.parse(await fs.readFile(metaPath, 'utf-8')) as Record<string, unknown>;
+    } catch {
+      meta = { owner: 'agent' };
+    }
+    meta['pid'] = process.pid;
+    meta['createdAt'] = new Date().toISOString();
+    await fs.writeFile(metaPath, JSON.stringify(meta, null, 2), 'utf-8');
+  } catch {
+    /* best-effort — never block dispatch */
+  }
+}

--- a/src/agent/worktree-sweep.test.ts
+++ b/src/agent/worktree-sweep.test.ts
@@ -261,11 +261,11 @@ describe('empty-detection', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 2. stale-clean-preserves-branch
+// 2. stale-clean-preserves-worktree
 // ---------------------------------------------------------------------------
 
-describe('stale-clean-preserves-branch', () => {
-  it('removes stale clean worktree via worktree remove but does NOT delete branch', async () => {
+describe('stale-clean-preserves-worktree', () => {
+  it('preserves a stale clean worktree with commits ahead and warns instead of removing', async () => {
     const worktreePath = join(afkWorktreesDir, 'afk-stale-clean');
     await fs.mkdir(worktreePath, { recursive: true });
     // 20 days old — past the 14-day clean threshold
@@ -305,15 +305,20 @@ describe('stale-clean-preserves-branch', () => {
     });
 
     expect(result.candidates.some((c) => c.verdict === 'stale-clean')).toBe(true);
-    expect(result.removed).toContain(worktreePath);
+    // Invariant: stale-clean only fires on trees with commits ahead of base
+    // (clean + 0-ahead is always classified `empty` first), so removal here
+    // would exclusively destroy committed-but-unmerged work. The sweep must
+    // preserve the worktree and surface a warning instead.
+    expect(result.removed).not.toContain(worktreePath);
+    expect(
+      result.warnings.some((w) => w.includes('stale-clean') && w.includes(worktreePath)),
+    ).toBe(true);
 
-    // worktree remove --force should be called
+    // No destructive git calls against the stale-clean worktree.
     const removeCalls = mock.calls.filter(
-      (c) => c.args.includes('remove') && c.args.includes('--force'),
+      (c) => c.args.includes('remove') && c.args.includes(worktreePath),
     );
-    expect(removeCalls.length).toBeGreaterThan(0);
-
-    // branch -d should NOT be called (branch preserved for stale-clean)
+    expect(removeCalls).toHaveLength(0);
     const branchDeleteCalls = mock.calls.filter(
       (c) => c.args.includes('branch') && c.args.includes('-d'),
     );

--- a/src/agent/worktree-sweep.ts
+++ b/src/agent/worktree-sweep.ts
@@ -619,8 +619,17 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
           }
           result.removed.push(entry.path);
         } else if (verdict === 'stale-clean') {
-          await execFile('git', ['-C', repoRoot, 'worktree', 'remove', '--force', entry.path]);
-          result.removed.push(entry.path);
+          // Invariant: `stale-clean` fires only on trees with commits ahead
+          // of base — a clean tree with zero commits ahead is always caught
+          // by `empty` first. Removing here therefore destroys exclusively
+          // trees holding committed-but-unmerged work (the branch ref
+          // survives, the checkout does not). Preserve + warn instead,
+          // mirroring `stale-dirty`; explicit removal paths (`afk worktree
+          // prune`-adjacent tooling, the model-facing `worktree` tool) are
+          // the sanctioned way to drop these.
+          result.warnings.push(
+            `[WARN] stale-clean worktree preserved (commits ahead of base): ${entry.path}`,
+          );
         } else if (verdict === 'stale-dirty') {
           result.warnings.push(
             `[WARN] stale-dirty worktree preserved (uncommitted changes): ${entry.path}`,

--- a/src/cli/commands/worktree.ts
+++ b/src/cli/commands/worktree.ts
@@ -31,12 +31,12 @@ async function resolveRepoRoot(): Promise<string> {
 }
 
 function verdictWouldPrune(v: string): string {
-  if (
-    ['empty', 'stale-clean', 'orphaned-dir', 'orphaned-registration', 'dead-owner'].includes(v)
-  ) {
+  // 'stale-clean' is preserved + warned by the sweep engine (commits ahead
+  // of base), so it renders as 'warn' alongside 'stale-dirty'.
+  if (['empty', 'orphaned-dir', 'orphaned-registration', 'dead-owner'].includes(v)) {
     return chalk.red('yes');
   }
-  if (v === 'stale-dirty') return chalk.yellow('warn');
+  if (v === 'stale-dirty' || v === 'stale-clean') return chalk.yellow('warn');
   return chalk.green('no');
 }
 

--- a/src/cli/slash/commands/worktree.ts
+++ b/src/cli/slash/commands/worktree.ts
@@ -34,9 +34,10 @@ const execFile: ExecFileFn = promisify(execFileCallback) as ExecFileFn;
 const VALID_SCOPES = ['interactive', 'diagnose', 'all'] as const;
 type Scope = (typeof VALID_SCOPES)[number];
 
+// 'stale-clean' is intentionally absent: the sweep engine preserves + warns
+// on stale-clean (commits ahead of base) rather than removing.
 const PRUNABLE_VERDICTS = new Set([
   'empty',
-  'stale-clean',
   'orphaned-dir',
   'orphaned-registration',
   'dead-owner',


### PR DESCRIPTION
## Summary

- **Sweep fix**: `stale-clean` worktrees (clean, >14 days old, commits ahead of base) are now preserved with a warning instead of force-removed. Since the `empty` verdict already catches clean+zero-commits-ahead trees earlier in classification, `stale-clean` in practice only ever fired on trees holding committed-but-unmerged work — so the old behavior exclusively destroyed unpushed commits sitting in an otherwise-clean worktree. This is the most likely cause of recurring "my worktree got swept" incidents.
- **New `worktree` tool** (`create` / `keep` / `release` / `list` / `remove`) gives the agent a protocol-aware lifecycle instead of raw `git worktree add` via bash. `create` always places trees under `.afk-worktrees/` and writes proper meta (owner, pid, createdAt, baseSha, baseBranch), closing the gap where agent-created worktrees had no meta and looked like anonymous ghosts to the sweep engine. `keep` wraps `git worktree lock`, which the sweep engine already unconditionally skips — zero sweep-engine changes needed for the lock guarantee. `remove` refuses dirty/locked/commits-ahead/main/outside-root trees and never deletes the underlying branch.
- **Subagent occupancy touch**: `forkSubagent` (the single convergence point for `agent`/`skill`/`compose` dispatch with a `cwd` override) now best-effort refreshes a worktree's meta (pid, createdAt) when the resolved cwd sits inside `.afk-worktrees/`. This resets the sweep's age clock for subagent-occupied trees and adopts previously meta-less bash-created trees, without ever blocking dispatch on failure.
- `agent` tool docs updated to point at the new `worktree` tool instead of advising `bash: git worktree add`.

## Test results
- `pnpm lint` (tsc --noEmit, strict): clean
- `pnpm test` (vitest run): 574/574 test files passed, 10571 passed / 14 skipped
- `pnpm audit:sdk:check`: OK, no new SDK imports

## Verification (adversarial `--verify` pass, independent re-derivation from diff + source)

| Claim | Verdict | Evidence |
|---|---|---|
| `stale-clean` previously force-removed clean trees with unpushed commits; now warns and preserves, no classification change | CONFIRM | `worktree-sweep.ts:280-297`, `:621-632` |
| `create` always writes meta under `.afk-worktrees/`, closing the ghost-worktree gap | REFINE | `worktree.ts:240-256` — meta fields are `owner/pid/createdAt/baseSha/baseBranch`; there is no `sessionId` field (corrected from an earlier draft claim) |
| `keep` (`git worktree lock`) requires zero sweep-engine changes — locked trees are already unconditionally skipped | CONFIRM | `worktree-sweep.ts:262` (pre-existing, untouched by this diff) |
| `forkSubagent` is the single convergence point for agent/skill/compose dispatch; occupancy touch is fire-and-forget and never blocks | CONFIRM | `subagent.ts:553-555`; call sites `subagent-executor.ts:670`, `skill-executor.ts:758,1065`, `dag-subagent.ts:89`; `worktree-occupancy.ts:64-81` swallows all errors |
| `remove` refuses dirty/locked/commits-ahead/main/outside-root; branch never deleted | CONFIRM | `worktree.ts:316-346`, `:123-133`, `:347` — lock check ordered before the `force` branch, so `force` cannot bypass a lock |

**Known residual gap (accepted, not fixed in this PR):** a worktree adopted purely via the occupancy touch (no prior `create` meta) gets a minimal record with no `baseSha`, so `remove`'s commits-ahead guard silently reads as 0 for that specific tree — only the dirty check protects it in that case. Pre-existing `create`d trees are unaffected. Tracked as a follow-up if it proves to matter in practice.

## Out of scope
- Not fixed here: unbounded growth of warned `stale-clean` trees now that they're never auto-removed — cleanup relies on the model or user invoking `worktree remove` explicitly. Intentional tradeoff (favors "never destroy unmerged work" over "never accumulate"), flagged for future follow-up if the `.afk-worktrees/` count becomes a problem.
