### PR TITLE
fix(subagent): bound forked-child tool-use loop to prevent parent hang

### DIFF
--- a/src/agent/providers/anthropic-direct.test.ts
+++ b/src/agent/providers/anthropic-direct.test.ts
@@ -683,6 +683,47 @@ describe('AnthropicDirectProvider', () => {
     }
   });
 
+  it('caps the tool-use loop at config.maxToolUseIterations (config → provider → loop)', async () => {
+    // End-to-end plumbing guard: AgentConfig.maxToolUseIterations must thread
+    // through AnthropicDirectProvider.query() → AnthropicDirectQueryOptions →
+    // the constructor → runInput → the loop's `maxIterations`. The mock model
+    // emits tool_use on every round, so the ONLY thing that can terminate the
+    // turn is the iteration cap — this is the guard a forked subagent relies on
+    // to avoid hanging its parent (see SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS).
+    let callIdx = 0;
+    messagesCreateMock.mockImplementation(() => {
+      callIdx += 1;
+      return fromArray(
+        makeToolUseStream(`toolu_${callIdx}`, 'get_weather', '{"city":"SF"}'),
+      );
+    });
+
+    const dispatcher: ToolDispatcher = {
+      async execute(): Promise<ToolResult> {
+        return { content: 'sunny' };
+      },
+    };
+
+    const provider = new AnthropicDirectProvider({ tools: dispatcher });
+    const query = provider.query({
+      prompt: singleInput('weather?'),
+      config: {
+        model: 'claude-sonnet-5',
+        apiKey: 'sk-ant-api03-test',
+        maxToolUseIterations: 2,
+      },
+    });
+    const events = await collect(query);
+
+    // Stopped after exactly 2 tool-use rounds, not left to spin unbounded.
+    expect(messagesCreateMock).toHaveBeenCalledTimes(2);
+    const completed = events.find((e) => e.type === 'turn.completed');
+    expect(completed).toBeDefined();
+    if (completed?.type === 'turn.completed') {
+      expect(completed.usage.stopReason).toBe('tool_use_loop_capped');
+    }
+  });
+
   it('default SessionToolDispatcher rejects unknown tools with isError', async () => {
     let callIdx = 0;
     messagesCreateMock.mockImplementation(() => {

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -1006,6 +1006,9 @@ export class AnthropicDirectProvider implements ModelProvider {
       ...(config.autoResumeOnUsageLimit !== undefined
         ? { autoResumeOnUsageLimit: config.autoResumeOnUsageLimit }
         : {}),
+      ...(config.maxToolUseIterations !== undefined
+        ? { maxToolUseIterations: config.maxToolUseIterations }
+        : {}),
       ...(cwdDependentsFactory !== undefined ? { cwdDependentsFactory } : {}),
       // Path-approval half of the live `/bypass` toggle: keep the provider's
       // `_currentPermissionMode` (read by getGrants().allowAll) in sync with

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -133,6 +133,13 @@ export interface AnthropicDirectQueryOptions {
    * across all turns (see `isCacheEnabled({baseUrl})`).
    */
   baseUrl?: string;
+  /**
+   * Hard cap on tool-use loop iterations within a single user turn, forwarded
+   * to `runTurn` as `RunTurnInput.maxToolUseIterations`. Unset/`0` means no cap
+   * (the top-level default); subagent forks pass a non-zero ceiling so a
+   * runaway child cannot spin unboundedly while the parent awaits its result.
+   */
+  maxToolUseIterations?: number;
   /** Witness-layer trace writer threaded into each per-turn run. */
   traceWriter?: import('../../trace/index.js').TraceWriter;
   /**
@@ -212,6 +219,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
   private readonly thinking?: import('@anthropic-ai/sdk/resources').ThinkingConfigParam;
   private readonly effort?: import('../../types/sdk-types.js').EffortLevel;
   private readonly baseUrl?: string;
+  private readonly maxToolUseIterations?: number;
   private readonly traceWriter?: import('../../trace/index.js').TraceWriter;
 
   /**
@@ -257,6 +265,8 @@ export class AnthropicDirectQuery implements ProviderQuery {
     this.thinking = opts.thinking;
     if (opts.effort !== undefined) this.effort = opts.effort;
     if (opts.baseUrl !== undefined) this.baseUrl = opts.baseUrl;
+    if (opts.maxToolUseIterations !== undefined)
+      this.maxToolUseIterations = opts.maxToolUseIterations;
     this.traceWriter = opts.traceWriter;
     this.cwdDependentsFactory = opts.cwdDependentsFactory;
     this.onPermissionMode = opts.onPermissionMode;
@@ -375,6 +385,9 @@ export class AnthropicDirectQuery implements ProviderQuery {
           ...(this.thinking !== undefined ? { thinking: this.thinking } : {}),
           ...(this.effort !== undefined ? { effort: this.effort } : {}),
           ...(this.baseUrl !== undefined ? { baseUrl: this.baseUrl } : {}),
+          ...(this.maxToolUseIterations !== undefined
+            ? { maxToolUseIterations: this.maxToolUseIterations }
+            : {}),
           ...(this.traceWriter ? { traceWriter: this.traceWriter } : {}),
           onUsageProgress: (usage) => { this.state.lastUsage = usage; },
         };

--- a/src/agent/subagent.test.ts
+++ b/src/agent/subagent.test.ts
@@ -76,7 +76,7 @@ vi.mock('./session.js', () => {
   return { AgentSession: MockAgentSession };
 });
 
-import { SubagentManager } from './subagent.js';
+import { SubagentManager, SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS } from './subagent.js';
 
 function lastSessionState(): SessionState {
   return shared.sessions[shared.sessions.length - 1].state;
@@ -160,6 +160,47 @@ describe('SubagentManager', () => {
     expect(shared.lastConfig).toEqual(
       expect.objectContaining({ baseUrl: 'http://127.0.0.1:8080' }),
     );
+  });
+
+  // Anti-hang: every fork gets a positive tool-use-iteration ceiling so a
+  // runaway child cannot spin unbounded on anthropic-direct (whose provider
+  // default is 0 = no cap) while the parent is suspended awaiting its result.
+  it('applies the default tool-use-iteration cap when child config omits it', async () => {
+    shared.lastConfig = null;
+    const mgr = new SubagentManager();
+    await mgr.forkSubagent({
+      parent: { sessionId: 'p' },
+      config: { model: 'sonnet' },
+    });
+    // Pin parity with openai-compatible's built-in 50-round cap.
+    expect(SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS).toBe(50);
+    expect(shared.lastConfig).toEqual(
+      expect.objectContaining({
+        maxToolUseIterations: SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS,
+      }),
+    );
+  });
+
+  it('preserves an explicit maxToolUseIterations override on the child config', async () => {
+    shared.lastConfig = null;
+    const mgr = new SubagentManager();
+    await mgr.forkSubagent({
+      parent: { sessionId: 'p' },
+      config: { model: 'sonnet', maxToolUseIterations: 7 },
+    });
+    expect(shared.lastConfig).toEqual(
+      expect.objectContaining({ maxToolUseIterations: 7 }),
+    );
+  });
+
+  it('preserves an explicit maxToolUseIterations of 0 (opt back into unbounded)', async () => {
+    shared.lastConfig = null;
+    const mgr = new SubagentManager();
+    await mgr.forkSubagent({
+      parent: { sessionId: 'p' },
+      config: { model: 'sonnet', maxToolUseIterations: 0 },
+    });
+    expect((shared.lastConfig as unknown as Record<string, unknown>)['maxToolUseIterations']).toBe(0);
   });
 
   // Cross-provider credential anti-leak (composition boundary).

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -54,6 +54,21 @@ export const DENY_ELICITATION: NonNullable<AgentConfig['onElicitation']> = async
   _options: { signal: AbortSignal },
 ): Promise<ElicitationResult> => ({ action: 'decline' });
 
+/**
+ * Default tool-use-iteration ceiling applied to every forked subagent.
+ *
+ * A subagent runs exactly one conversation turn (one `sendMessageStream`), so
+ * this bounds the tool-use loop WITHIN that turn. anthropic-direct otherwise
+ * defaults to `0` (unbounded — see DEFAULT_MAX_TOOL_USE_ITERATIONS), which lets
+ * a runaway child spin indefinitely while its parent is suspended at
+ * `await runToResult`. `50` matches openai-compatible's built-in cap so both
+ * providers bound child loops identically. Hitting the cap surfaces as a
+ * `tool_use_loop_capped` done (not an error), returning the child's partial
+ * work. Callers may override per-fork via `config.maxToolUseIterations` (e.g.
+ * `0` to opt a trusted deep-investigation child back into unbounded mode).
+ */
+export const SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS = 50;
+
 export interface ForkParent {
   sessionId?: string;
   /**
@@ -473,6 +488,17 @@ export class SubagentManager {
       // no attribution. A caller may opt a fork back in with
       // `isNonInteractive: false`.
       isNonInteractive: options.config.isNonInteractive ?? true,
+      // External constraint (anti-hang): a forked child's tool-use loop is
+      // otherwise unbounded on anthropic-direct (DEFAULT_MAX_TOOL_USE_ITERATIONS
+      // = 0 = no cap), so a runaway child could spin forever while the parent is
+      // suspended at `await runToResult`. Give every fork a positive default
+      // ceiling (parity with openai-compatible's built-in 50-round cap); the
+      // caller's explicit `options.config.maxToolUseIterations` (already carried
+      // by the `...options.config` spread above) wins when set, including `0` to
+      // opt back into unbounded. Hitting the cap surfaces as a
+      // `tool_use_loop_capped` done, returning the child's partial work.
+      maxToolUseIterations:
+        options.config.maxToolUseIterations ?? SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS,
       // Awareness metadata: surface parent identity + phase role into the
       // child's config so the get_runtime_state tool's `self` view can report
       // the topology fields. Caller-supplied values on options.config win on

--- a/src/agent/subagent/handle-streaming.test.ts
+++ b/src/agent/subagent/handle-streaming.test.ts
@@ -226,6 +226,38 @@ describe('SubagentHandle streaming', () => {
       await expect(handle.run('p')).rejects.toThrow(/produced no terminal message/);
     });
 
+    it('returns a capped partial result (not a throw) when the tool-use cap fires with no message', async () => {
+      // Anti-hang contract: a forked child that hits its tool-use-iteration cap
+      // ends the turn with a `tool_use_loop_capped` done and no assistant
+      // message. A pure tool-only runaway also streams no text, so the child
+      // must NOT be reported as a failed subagent — it returns a capped partial
+      // result (status 'succeeded') carrying a cap marker. Regression guard for
+      // the #394 Codex P2 finding.
+      const events: OutputEvent[] = [
+        { type: 'done', metadata: { stopReason: 'tool_use_loop_capped' } },
+      ];
+      const session = createDeterministicMockSession(events, {
+        role: 'assistant',
+        content: 'unused',
+        timestamp: new Date(),
+      });
+      const handle = new SubagentHandleImpl(
+        'subagent-capped-test',
+        session,
+        controller,
+        abortGraph,
+        undefined,
+        5000,
+        undefined,
+        vi.fn(),
+      );
+
+      const msg = await handle.run('p');
+      expect(msg.role).toBe('assistant');
+      expect(String(msg.content)).toMatch(/capped/i);
+      expect(handle.status).toBe('succeeded');
+    });
+
     it('throws error event even when partial streamed content exists', async () => {
       const streamError = new Error('upstream stream failure');
       const events: OutputEvent[] = [

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -257,6 +257,7 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
   ): Promise<Message> {
     let finalMessage: Message | undefined;
     let streamError: Error | undefined;
+    let stopReason: string | undefined;
 
     // Reset partial-content accumulator before each run. Surviving across the
     // throw boundary is the whole point — the local `streamedContent` of the
@@ -311,6 +312,12 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
         streamError = event.error;
         break;
       } else if (event.type === 'done') {
+        // Capture the turn's stop reason so the post-loop fallback can tell a
+        // tool-use-cap termination (which yields a `done` with no assistant
+        // message) apart from a genuinely empty stream.
+        if (typeof event.metadata?.stopReason === 'string') {
+          stopReason = event.metadata.stopReason;
+        }
         if (typeof event.metadata?.usage === 'object' && event.metadata.usage !== null) {
           const u = event.metadata.usage as Record<string, unknown>;
           this.currentTrace.usage = {
@@ -328,6 +335,23 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     if (finalMessage) return finalMessage;
     if (this.lastStreamedContent.length > 0) {
       return { role: 'assistant', content: this.lastStreamedContent, timestamp: new Date() };
+    }
+    // Anti-hang contract (see SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS in
+    // subagent.ts): a forked child that exhausts its tool-use-iteration cap ends
+    // the turn with a `tool_use_loop_capped` done and NO assistant message. A
+    // pure tool-only runaway also streams no text, so both fallbacks above miss.
+    // Surface the cap as a terminal "capped" message instead of throwing, so
+    // `runToResult` reports a capped *partial* result (status 'succeeded')
+    // rather than an opaque subagent failure — the behavior the cap default
+    // already documents.
+    if (stopReason === 'tool_use_loop_capped') {
+      return {
+        role: 'assistant',
+        content:
+          `[subagent ${this.id} reached its tool-use iteration cap before ` +
+          `producing a final message; returning a capped partial result]`,
+        timestamp: new Date(),
+      };
     }
     throw new Error(`Subagent ${this.id} produced no terminal message`);
   }

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -125,6 +125,17 @@ export interface AgentConfig {
   maxTurns?: number;
 
   /**
+   * Hard cap on tool-use rounds within a single user turn (anthropic-direct
+   * only; openai-compatible carries its own built-in 50-round cap). Forwarded
+   * to the provider as `RunTurnInput.maxToolUseIterations`. `0` or unset means
+   * no cap — the top-level default. Subagent forks set a non-zero default (see
+   * `SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS` in subagent.ts) so a runaway
+   * child tool-loop cannot hang the parent, which is suspended awaiting the
+   * child's result.
+   */
+  maxToolUseIterations?: number;
+
+  /**
    * Controls Claude's extended-thinking / reasoning behavior. When omitted,
    * the SDK picks the model-appropriate default (adaptive on Opus 4.6+).
    * See the SDK's `ThinkingConfig` union.


### PR DESCRIPTION
## Problem

A parent that dispatches a subagent (`agent` / `skill` / `compose` / dag) suspends at `await runToResult` for the child's entire lifetime. On the **anthropic-direct** provider that lifetime was **unbounded**:

- `DEFAULT_MAX_TOOL_USE_ITERATIONS = 0` means "no cap" on the tool-use loop, and nothing in non-test code ever set `RunTurnInput.maxToolUseIterations` for a child.
- A subagent runs **exactly one** conversation turn (`runToResult` → `run()` → a single `sendMessageStream`), so the harness-level `max_turns` never bounds the tool-use loop *within* that turn — it only limits sends, and a child makes just one.

Net effect: a child stuck in a tool-calling doom-loop could spin forever while the parent hangs — no cap, no error, and (on a daemon or nested fork) no Ctrl+B rescue. `openai-compatible` children were already safe (built-in 50-round cap); only anthropic-direct was exposed.

## Fix

Thread a tool-use-iteration ceiling end-to-end and default every fork to **50** (parity with openai-compatible) at the single `forkSubagent` chokepoint that all four subagent paths funnel through:

- `AgentConfig.maxToolUseIterations` — new optional field
- forwarded in `AnthropicDirectProvider.query()` → `AnthropicDirectQueryOptions` → constructor field → `runInput` (same optional-spread idiom as `effort` / `baseUrl`)
- `SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS = 50` applied in `forkSubagent`'s childConfig (mirrors the existing `isNonInteractive ?? true` pattern, so caller overrides win)

Hitting the cap surfaces as a clean `tool_use_loop_capped` **done**, so the child returns its partial work rather than erroring. Callers may override per-fork via `config.maxToolUseIterations`, including `0` to opt a trusted deep child back into unbounded.

## Blast radius

Top-level sessions (REPL / chat / telegram / daemon / one-shot query) are **unaffected** — their `AgentConfig` objects never pass through `forkSubagent`; every other `new AgentSession` site was verified to be a top-level entry point. openai-compatible unchanged (already caps at 50).

## Testing

- `pnpm lint` — clean (`tsc --noEmit`, strict)
- `pnpm test` — full suite **10570 passed / 0 failed / 14 skipped** (571 files)
- `pnpm audit:sdk:check` — OK (no new SDK symbols)
- New tests:
  - `subagent.test.ts` — default cap applied, explicit override preserved, `0` opt-out preserved
  - `anthropic-direct.test.ts` — end-to-end `config.maxToolUseIterations` → provider → loop cap fires at exactly N rounds with `tool_use_loop_capped`

## Follow-up (out of scope)

openai-compatible ignores an explicit `config.maxToolUseIterations` (its 50-round cap is hardcoded); honoring an explicit override there would make the two providers fully symmetric. Left out to keep this change minimal.
