### PR TITLE
fix: name dead-cwd spawn failures and fork-enforce bundled skills by name

### DIFF
--- a/src/agent/tools/handlers/bash.test.ts
+++ b/src/agent/tools/handlers/bash.test.ts
@@ -543,6 +543,22 @@ describe('bashHandler', () => {
         await fs.rm(tmpB, { recursive: true, force: true });
       }
     });
+
+    it('names the dead working directory when cwd was deleted (ENOENT masquerade)', async () => {
+      // Spawn with a deleted cwd rejects as `spawn /bin/sh ENOENT` — naming
+      // the shell, not the missing directory. The handler must translate
+      // this into an actionable error so agents stop retrying blindly
+      // (production incident: 4 consecutive identical retries after a
+      // worktree was reaped mid-session).
+      const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'bash-cwd-dead-'));
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+      const handler = createBashHandler('default', tmpRoot);
+      const result = await handler({ command: 'echo alive' }, createSignal());
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('working directory does not exist');
+      expect(result.content).toContain(tmpRoot);
+      expect(result.content).toContain('deleted worktree?');
+    });
   });
 
   describe('concurrent execution', () => {

--- a/src/agent/tools/handlers/bash.ts
+++ b/src/agent/tools/handlers/bash.ts
@@ -16,6 +16,7 @@ import type { ToolHandler, ToolHandlerContext } from '../types.js';
 import { appendRoutingDecision } from '../../routing-telemetry.js';
 import { detectTestResult } from './test-runner-detector.js';
 import { stripEscapeSequences } from '../../../utils/terminal-sanitize.js';
+import { describeSpawnCwdError, isSpawnEnoent } from '../../../utils/spawn-cwd-error.js';
 
 /**
  * Input shape for the bash tool (validated at runtime).
@@ -328,7 +329,25 @@ export function createBashHandler(
     });
 
     proc.on('error', (err) => {
-      settle({ content: `Failed to execute: ${err.message}`, isError: true });
+      // Spawn ENOENT masquerade: a dead working directory (deleted worktree)
+      // surfaces as `spawn /bin/sh ENOENT` — naming the shell, not the dir.
+      // Translate post-failure via statSync (error path only — no TOCTOU).
+      // When no explicit cwd was passed, spawn inherited the process cwd;
+      // process.cwd() itself throws when that directory has been deleted,
+      // which is the same masquerade — report it as such.
+      const effectiveCwd = context?.resolveBase ?? context?.cwd ?? cwd;
+      let message: string;
+      if (effectiveCwd === undefined && isSpawnEnoent(err)) {
+        try {
+          const inherited = process.cwd();
+          message = describeSpawnCwdError(err, inherited);
+        } catch {
+          message = `working directory does not exist (process cwd deleted — deleted worktree?) — underlying: ${err.message}`;
+        }
+      } else {
+        message = describeSpawnCwdError(err, effectiveCwd);
+      }
+      settle({ content: `Failed to execute: ${message}`, isError: true });
     });
   });
   };

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -131,6 +131,29 @@ export const RECON_ALLOWED_TOOLS: readonly string[] = [
 // prose). Add a name here only for skills that are genuinely read-only recon.
 export const DEFAULT_READ_ONLY_SKILLS: ReadonlySet<string> = new Set(['ground-state']);
 
+// Skills forced to FORK execution by NAME, independent of their SKILL.md
+// frontmatter. Same rationale as DEFAULT_READ_ONLY_SKILLS: first-registrant-
+// wins registration means a user/project copy of a bundled skill can shadow
+// it, and a stale copy missing `context: fork` silently degrades to load
+// mode — the caller gets instruction text instead of the structured envelope
+// (e.g. diagnose's auto-verify parses shadow-verify's JSON), and name-keyed
+// read-only enforcement is bypassed because it only runs on the forked path.
+// Seeded with every bundled skill that declares `context: fork`
+// (src/bundled-plugins/awa-bundled/skills/*). When this set forces a fork on
+// a copy whose frontmatter lacked `context: fork`, the executor emits a
+// warning naming the skill so a deliberate local load-mode edit is never
+// silently overridden.
+export const DEFAULT_FORK_SKILLS: ReadonlySet<string> = new Set([
+  'shadow-verify',
+  'review',
+  'research',
+  'ground-state',
+  'spec',
+  'ship',
+  'simplify',
+  'refactor',
+]);
+
 /**
  * Bootstrap-time options captured by closure into the factory returned by
  * {@link createChildProviderFactory}. Held at factory-construction (not

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -23,6 +23,7 @@ import { collectSkillEntries, discoverPluginSkillBodies, type PluginSkillBody } 
 import type { SdkPluginConfig } from '../types/sdk-types.js';
 import {
   DEFAULT_MAX_NESTING_DEPTH,
+  DEFAULT_FORK_SKILLS,
   DEFAULT_READ_ONLY_SKILLS,
   RECON_ALLOWED_TOOLS,
   buildReadOnlyReconProvider,
@@ -318,7 +319,22 @@ export class SkillExecutor {
     //    `context: fork`. See docs/skill-load-mode.md.)
     const pluginSkill = this.getPluginSkillBody(parsed.name);
     if (pluginSkill) {
-      if (pluginSkill.context === 'fork') {
+      // Fork enforcement is name-keyed as well as frontmatter-keyed: first-
+      // registrant-wins registration lets a user/project copy shadow a
+      // bundled skill, and a stale copy missing `context: fork` would
+      // silently degrade an isolation-critical skill to load mode (no
+      // structured output envelope, no read-only child enforcement). A name
+      // in DEFAULT_FORK_SKILLS forces the fork path for ANY copy; the warn
+      // below makes the override observable so a deliberate local load-mode
+      // edit is never silently ignored.
+      const forcedFork =
+        pluginSkill.context !== 'fork' && DEFAULT_FORK_SKILLS.has(parsed.name);
+      if (forcedFork) {
+        console.warn(
+          `[skill] "${parsed.name}" (${pluginSkill.pluginPath}) lacks \`context: fork\` in its frontmatter but is fork-enforced by name (DEFAULT_FORK_SKILLS) — running in fork mode. Add \`context: fork\` to its SKILL.md to silence this warning.`,
+        );
+      }
+      if (pluginSkill.context === 'fork' || forcedFork) {
         // Read-only enforcement: a plugin skill is read-only when its SKILL.md
         // frontmatter declares `read-only: true` (surfaced as `pluginSkill.readOnly`)
         // OR its name is in DEFAULT_READ_ONLY_SKILLS (name-keyed so any copy of

--- a/src/agent/tools/skill-load-mode.test.ts
+++ b/src/agent/tools/skill-load-mode.test.ts
@@ -205,6 +205,73 @@ describe('context: load — plugin skills', () => {
     expect(mockFork).toHaveBeenCalledOnce();
   });
 
+  it('forces FORK by name for a DEFAULT_FORK_SKILLS skill whose frontmatter lacks context: fork', async () => {
+    // Regression: first-registrant-wins registration lets a user/project
+    // copy shadow a bundled fork-mode skill. A stale copy missing
+    // `context: fork` previously degraded to load mode — instruction text
+    // instead of the structured envelope (broke diagnose's shadow-verify
+    // parsing) and bypassed name-keyed read-only enforcement.
+    const mockFork = vi.fn().mockResolvedValue({
+      runToResult: vi.fn().mockResolvedValue({ status: 'succeeded', message: { content: 'forced-fork' } }),
+      teardown: vi.fn().mockResolvedValue(undefined),
+    });
+    vi.spyOn(SubagentManager.prototype, 'forkSubagent').mockImplementation(mockFork);
+    vi.spyOn(SubagentManager.prototype, 'teardownAll').mockResolvedValue(undefined);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const executor = makeExecutor();
+    // 'shadow-verify' is in DEFAULT_FORK_SKILLS; this copy has NO context field.
+    setPluginBodies(executor, [
+      ['shadow-verify', { body: 'stale private copy', pluginPath: '/fake/private-plugin' }],
+    ]);
+
+    const result = await executor.execute(makeCall({ name: 'shadow-verify' }));
+
+    expect(result.content).toBe('forced-fork');
+    expect(mockFork).toHaveBeenCalledOnce();
+    // The override must be observable — never a silent frontmatter override.
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('fork-enforced by name'),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('shadow-verify'));
+  });
+
+  it('does NOT warn when a DEFAULT_FORK_SKILLS skill already declares context: fork', async () => {
+    const mockFork = vi.fn().mockResolvedValue({
+      runToResult: vi.fn().mockResolvedValue({ status: 'succeeded', message: { content: 'ok' } }),
+      teardown: vi.fn().mockResolvedValue(undefined),
+    });
+    vi.spyOn(SubagentManager.prototype, 'forkSubagent').mockImplementation(mockFork);
+    vi.spyOn(SubagentManager.prototype, 'teardownAll').mockResolvedValue(undefined);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const executor = makeExecutor();
+    setPluginBodies(executor, [
+      ['shadow-verify', { body: 'proper copy', pluginPath: '/fake', context: 'fork' }],
+    ]);
+
+    await executor.execute(makeCall({ name: 'shadow-verify' }));
+
+    expect(mockFork).toHaveBeenCalledOnce();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('a plugin skill NOT in DEFAULT_FORK_SKILLS still loads in-context by default', async () => {
+    const mockFork = spyNoFork();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const executor = makeExecutor();
+    setPluginBodies(executor, [
+      ['ordinary-skill', { body: 'ordinary body', pluginPath: '/fake' }],
+    ]);
+
+    const result = await executor.execute(makeCall({ name: 'ordinary-skill' }));
+
+    expect(result.content).toContain('ordinary body');
+    expect(result.content).toContain('loaded into your current context');
+    expect(mockFork).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it('expands ${PLUGIN_ROOT} and $PLUGIN_ROOT in body to pluginPath when context: load', async () => {
     const mockFork = spyNoFork();
     const executor = makeExecutor();

--- a/src/skills/diagnose.test.ts
+++ b/src/skills/diagnose.test.ts
@@ -971,6 +971,50 @@ describe('runReproducerBaseline', () => {
 
     expect(result.skipped).toBe(false);
   });
+
+  it('skips with a named reason on spawn ENOENT when the cwd does not exist (dead worktree)', async () => {
+    // Regression: spawn with a deleted cwd rejects with code:'ENOENT'
+    // (string) + syscall:'spawn /bin/sh' — previously coerced through the
+    // non-zero-exit path into { skipped:false, exitCode:null, stdout:'',
+    // stderr:'' }, masquerading as "reproducer ran and produced nothing".
+    const exec: FakeExec = async () => {
+      throw Object.assign(new Error('spawn /bin/sh ENOENT'), {
+        code: 'ENOENT',
+        errno: -2,
+        syscall: 'spawn /bin/sh',
+        path: '/bin/sh',
+        stdout: '',
+        stderr: '',
+      });
+    };
+    // CWD ('/fake/repo') does not exist on disk — the dead-worktree case.
+    const result = await runReproducerBaseline('npm test', CWD, exec as never);
+
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toContain('cwd does not exist');
+    expect(result.reason).toContain(CWD);
+    expect(result.exitCode).toBeNull();
+  });
+
+  it('does NOT skip on spawn ENOENT when the cwd exists (genuinely missing binary)', async () => {
+    const { tmpdir } = await import('node:os');
+    const exec: FakeExec = async () => {
+      throw Object.assign(new Error('spawn not-a-binary ENOENT'), {
+        code: 'ENOENT',
+        errno: -2,
+        syscall: 'spawn not-a-binary',
+        path: 'not-a-binary',
+        stdout: '',
+        stderr: '',
+      });
+    };
+    const result = await runReproducerBaseline('npm test', tmpdir(), exec as never);
+
+    // Live cwd → not a dead-worktree masquerade; falls through to the
+    // string-code coercion (exitCode null, not skipped).
+    expect(result.skipped).toBe(false);
+    expect(result.exitCode).toBeNull();
+  });
 });
 
 // =============================================================================

--- a/src/skills/diagnose/_phases/orchestrator.ts
+++ b/src/skills/diagnose/_phases/orchestrator.ts
@@ -30,6 +30,7 @@ import { researchAgent } from '../../_agents/research-agent.js';
 import { gitInvestigator } from '../../_agents/git-investigator.js';
 import { vendoredToolAllowlist } from '../../_agents/to-definition.js';
 import { classifyBashCommand } from '../../../agent/tools/readonly-bash.js';
+import { describeSpawnCwdError } from '../../../utils/spawn-cwd-error.js';
 import type {
   DiagnosisResult,
   Hypothesis,
@@ -263,12 +264,15 @@ async function testHypothesisInWorktree(
 
     return verificationResult.output;
   } catch (error) {
+    // Spawn ENOENT masquerade: `git worktree add` with a dead `cwd: repoPath`
+    // rejects as `spawn git ENOENT` — naming git, not the missing repo dir.
+    // Translate post-failure (statSync on error path only — no TOCTOU).
     return {
       hypothesis_id: hypothesis.id,
       predicted_pass: false,
       regressions: [],
       confidence: 0,
-      verification_log: `Error during verification: ${error instanceof Error ? error.message : String(error)}`,
+      verification_log: `Error during verification: ${describeSpawnCwdError(error, repoPath)}`,
     };
   } finally {
     // Tear down the verifier handle (fires SubagentStop with the real

--- a/src/skills/diagnose/_phases/verifier.ts
+++ b/src/skills/diagnose/_phases/verifier.ts
@@ -14,6 +14,7 @@ import { execFile as execFileCallback } from 'node:child_process';
 import { promisify } from 'node:util';
 import { env } from '../../../config/env.js';
 import { shouldAutoVerify } from '../../_lib/confidence-gate.js';
+import { cwdIsMissing, isSpawnEnoent } from '../../../utils/spawn-cwd-error.js';
 import type {
   Verification,
   Hypothesis,
@@ -223,6 +224,21 @@ export async function runReproducerBaseline(
       killed?: boolean;
       signal?: string;
     };
+    // Spawn ENOENT masquerade: a dead `cwd` (deleted worktree) rejects with
+    // code:'ENOENT' (string) — which would otherwise coerce below into
+    // { skipped:false, exitCode:null, stdout:'', stderr:'' } and masquerade
+    // as "reproducer ran and produced nothing". Surface it as a typed skip
+    // instead (statSync runs on the error path only — no TOCTOU).
+    if (isSpawnEnoent(err) && cwdIsMissing(cwd)) {
+      return {
+        skipped: true,
+        reason: `cwd does not exist: ${cwd} (deleted worktree?)`,
+        exitCode: null,
+        stdout: '',
+        stderr: '',
+        timedOut: false,
+      };
+    }
     const timedOut = e.killed === true || e.signal === 'SIGTERM';
     const exitCode = typeof e.code === 'number' ? e.code : null;
     return {

--- a/src/utils/spawn-cwd-error.test.ts
+++ b/src/utils/spawn-cwd-error.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for spawn-cwd error enrichment ({@link describeSpawnCwdError}).
+ *
+ * Covers the ENOENT masquerade: Node's spawn/execFile with a dead `cwd`
+ * rejects with an error naming the BINARY (`spawn git ENOENT`), not the
+ * missing directory. The helper translates that into an actionable message
+ * — but ONLY when the cwd is actually missing, so a genuinely missing
+ * binary is never mislabeled.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile as execFileCallback, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import {
+  describeSpawnCwdError,
+  isSpawnEnoent,
+  cwdIsMissing,
+} from './spawn-cwd-error.js';
+
+const execFile = promisify(execFileCallback);
+
+/** Build a realistic spawn-ENOENT error object (shape Node emits). */
+function spawnEnoentError(binary: string): Error {
+  const err = new Error(`spawn ${binary} ENOENT`) as Error & {
+    code: string;
+    errno: number;
+    syscall: string;
+    path: string;
+  };
+  err.code = 'ENOENT';
+  err.errno = -2;
+  err.syscall = `spawn ${binary}`;
+  err.path = binary;
+  return err;
+}
+
+describe('isSpawnEnoent', () => {
+  it('matches a spawn-phase ENOENT error', () => {
+    expect(isSpawnEnoent(spawnEnoentError('git'))).toBe(true);
+  });
+
+  it('rejects non-spawn ENOENT (e.g. fs read)', () => {
+    const err = new Error('ENOENT: no such file') as Error & { code: string; syscall: string };
+    err.code = 'ENOENT';
+    err.syscall = 'open';
+    expect(isSpawnEnoent(err)).toBe(false);
+  });
+
+  it('rejects non-ENOENT errors and non-objects', () => {
+    expect(isSpawnEnoent(new Error('boom'))).toBe(false);
+    expect(isSpawnEnoent('spawn git ENOENT')).toBe(false);
+    expect(isSpawnEnoent(null)).toBe(false);
+    expect(isSpawnEnoent(undefined)).toBe(false);
+  });
+});
+
+describe('cwdIsMissing', () => {
+  it('returns false for undefined and for an existing directory', () => {
+    expect(cwdIsMissing(undefined)).toBe(false);
+    expect(cwdIsMissing(tmpdir())).toBe(false);
+  });
+
+  it('returns true for a deleted directory', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'spawn-cwd-test-'));
+    rmSync(dir, { recursive: true, force: true });
+    expect(cwdIsMissing(dir)).toBe(true);
+  });
+});
+
+describe('describeSpawnCwdError', () => {
+  it('rewrites a spawn ENOENT when the cwd is dead', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'spawn-cwd-test-'));
+    rmSync(dir, { recursive: true, force: true });
+    const msg = describeSpawnCwdError(spawnEnoentError('git'), dir);
+    expect(msg).toContain(`working directory does not exist: ${dir}`);
+    expect(msg).toContain('deleted worktree?');
+    expect(msg).toContain('spawn git ENOENT'); // original preserved
+  });
+
+  it('passes through a spawn ENOENT when the cwd is alive (genuinely missing binary)', () => {
+    const msg = describeSpawnCwdError(
+      spawnEnoentError('definitely-not-a-real-binary'),
+      tmpdir(),
+    );
+    expect(msg).toBe('spawn definitely-not-a-real-binary ENOENT');
+  });
+
+  it('passes through non-ENOENT errors unchanged', () => {
+    expect(describeSpawnCwdError(new Error('exit code 1'), '/nonexistent')).toBe('exit code 1');
+  });
+
+  it('stringifies non-Error inputs', () => {
+    expect(describeSpawnCwdError('weird', undefined)).toBe('weird');
+  });
+
+  it('enriches a REAL execFile rejection from a dead cwd (integration)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'spawn-cwd-test-'));
+    rmSync(dir, { recursive: true, force: true });
+    let caught: unknown;
+    try {
+      await execFile('git', ['--version'], { cwd: dir });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    const msg = describeSpawnCwdError(caught, dir);
+    expect(msg).toContain(`working directory does not exist: ${dir}`);
+  });
+
+  it("enriches a REAL spawn 'error' event from a dead cwd (integration)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'spawn-cwd-test-'));
+    rmSync(dir, { recursive: true, force: true });
+    const err = await new Promise<Error>((resolve) => {
+      const proc = spawn('echo alive', { shell: true, cwd: dir });
+      proc.on('error', resolve);
+    });
+    expect(err.message).toContain('ENOENT');
+    const msg = describeSpawnCwdError(err, dir);
+    expect(msg).toContain(`working directory does not exist: ${dir}`);
+  });
+});

--- a/src/utils/spawn-cwd-error.ts
+++ b/src/utils/spawn-cwd-error.ts
@@ -1,0 +1,79 @@
+/**
+ * Spawn-cwd error enrichment.
+ *
+ * Node's `spawn()`/`execFile()` with a non-existent `cwd` rejects with an
+ * ENOENT that names the BINARY, not the missing directory — e.g.
+ * `spawn git ENOENT` / `spawn /bin/sh ENOENT` (err = { code: 'ENOENT',
+ * syscall: 'spawn git', path: 'git' }). To an agent (or human) this
+ * masquerades as "the binary is missing", triggering pointless retries,
+ * when the real cause is usually a deleted working directory (e.g. a git
+ * worktree reaped mid-session).
+ *
+ * This module translates that failure AFTER it happens: `statSync(cwd)` runs
+ * only on the error path, so there is no TOCTOU window, no happy-path cost,
+ * and no pre-spawn contract change. Callers wire it into their existing
+ * catch / `'error'`-event sites.
+ *
+ * @module utils/spawn-cwd-error
+ */
+
+import { statSync } from 'node:fs';
+
+/** Structural shape of a Node spawn ENOENT error (subset we inspect). */
+interface SpawnErrorLike {
+  code?: unknown;
+  syscall?: unknown;
+  message?: unknown;
+}
+
+/**
+ * True when `err` is a spawn-phase ENOENT — the error Node emits both for a
+ * genuinely missing binary AND for a missing `cwd` (indistinguishable by the
+ * error object alone; disambiguated by {@link cwdIsMissing}).
+ */
+export function isSpawnEnoent(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as SpawnErrorLike;
+  return (
+    e.code === 'ENOENT' &&
+    typeof e.syscall === 'string' &&
+    e.syscall.startsWith('spawn')
+  );
+}
+
+/**
+ * True when `cwd` is defined and does not exist (or is unreachable) on disk
+ * at the moment of the check. Runs `statSync` — call only on error paths.
+ */
+export function cwdIsMissing(cwd: string | undefined): boolean {
+  if (cwd === undefined) return false;
+  try {
+    statSync(cwd);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Return an enriched, actionable message when `err` is a spawn ENOENT whose
+ * real cause is a dead working directory; otherwise return the original
+ * error message unchanged.
+ *
+ * Contract: pure translation — never throws, never mutates `err`, and only
+ * touches the filesystem (statSync) when the error already matched the
+ * spawn-ENOENT shape.
+ */
+export function describeSpawnCwdError(err: unknown, cwd: string | undefined): string {
+  const original =
+    err instanceof Error
+      ? err.message
+      : typeof (err as SpawnErrorLike)?.message === 'string'
+        ? String((err as SpawnErrorLike).message)
+        : String(err);
+
+  if (isSpawnEnoent(err) && cwdIsMissing(cwd)) {
+    return `working directory does not exist: ${cwd} (deleted worktree?) — underlying: ${original}`;
+  }
+  return original;
+}


### PR DESCRIPTION
## Two related failure modes, both verified against production evidence

### 1. Spawn ENOENT masquerade
`spawn()`/`execFile()` with a deleted `cwd` (e.g. a reaped git worktree) rejects as `spawn git ENOENT` / `spawn /bin/sh ENOENT` — naming the **binary**, not the dead directory. Observed in production (session `01320a8e…`: 4 consecutive identical `Failed to execute: spawn /bin/sh ENOENT` bash failures while non-spawn tools kept working). Diagnose's `runReproducerBaseline` additionally coerced the string-`ENOENT` code through the non-zero-exit path into `{ skipped: false, exitCode: null }` — "reproducer ran and produced nothing".

**Fix:** new `src/utils/spawn-cwd-error.ts` translates the failure **post-hoc** (`statSync` on the error path only — no TOCTOU, no happy-path cost, no pre-spawn contract change), wired into the three consuming catch sites:
- bash handler `proc.on('error')` → named `working directory does not exist: <path> (deleted worktree?)` error
- diagnose orchestrator worktree-verification catch
- `runReproducerBaseline` → typed `{ skipped: true, reason }` (fits the existing skip contract)

### 2. Fork-skill shadowing
First-registrant-wins registration (`skill-bridge.ts`) lets a user-scope plugin copy shadow a bundled skill; a stale copy missing `context: fork` degraded isolation-critical skills to load mode — instruction text instead of the structured JSON envelope (diagnose auto-verify → INCONCLUSIVE by design) and bypassed name-keyed read-only enforcement (fork-path only).

**Fix:** `DEFAULT_FORK_SKILLS` in `nesting.ts` (mirrors the shipped `DEFAULT_READ_ONLY_SKILLS` idiom) forces fork **by name** for the bundled fork skills, with a `console.warn` so a deliberate local load-mode edit is never silently overridden.

## Design notes
- Alternatives rejected: pre-spawn `existsSync` guards at 4 layers (TOCTOU-prone, contract churn), fork-time dispatch refusal (corrected evidence — 4 retries not 80 — removed its justification), silent fallback to `process.cwd()` (masks worktree-isolation failures).
- Validated via /shadow-verify (5/5 claims independently confirmed) + /devils-advocate (3-critic synthesis).

## Testing
- `pnpm lint` clean
- Full suite: 10583 passed / 14 skipped / 0 failed
- New tests: spawn-cwd-error unit matrix (dead-cwd enrich / live-cwd passthrough / non-ENOENT passthrough), bash dead-cwd integration, baseline ENOENT→skip, name-keyed fork forcing + override warning
