### PR TITLE
fix(subagent): cancel in-flight foreground subagents on soft-stop (ESC/Ctrl-C)

### DIFF
--- a/AFK.md
+++ b/AFK.md
@@ -30,6 +30,21 @@ afk daemon                # cron-based headless runner
 pnpm telegram:start       # Telegram bot
 ```
 
+### Observability / tracing
+
+Every session writes a **witness trace** — the durable, chronological record of what the agent actually did (tool calls with timing + result bytes + ok/err, subagent lifecycle, session phases). This is the first thing to reach for when reconstructing "what happened" in a past run — not the transcript (prose only) and not the service logs (other processes).
+
+```bash
+afk trace show              # pretty-print the latest session's trace (default: "latest")
+afk trace show <session>    # a specific session id
+afk trace show --all        # include low-signal events (latency phases, paired tool starts)
+afk trace show -n 40        # only the last N events
+afk trace show --json       # raw NDJSON, unchanged — pipe to jq
+afk trace list              # sessions that have a trace, most recent first (-n/--max <N>, default 20)
+```
+
+Traces live at `~/.afk/state/witness/<session>/trace.jsonl` (`$AFK_HOME/state/witness/<sessionLabel>/trace.jsonl`). Writer + reader: `src/agent/trace/`; CLI: `src/cli/commands/trace.ts`. Known gaps (do not assume the trace answers these): tool **args** live in `~/.afk/state/sessions/<id>/events.jsonl`, not the witness trace; raw tool **output** is not recorded anywhere durable; a usage-limit **pause** has no event (silent gap); subagent-spawning calls may record `started` without a terminal if the write races the session seal.
+
 ## Architecture
 
 Three layers under `src/`:

--- a/src/agent/tools/subagent-executor.test.ts
+++ b/src/agent/tools/subagent-executor.test.ts
@@ -1915,4 +1915,73 @@ describe('SubagentExecutor', () => {
       expect(payload.error).toBe('kaboom');
     });
   });
+
+  // ── Cancellation (soft-stop via SubagentControl) ──────────────────────────
+  // Unlike promotion, cancellation must work with NO background registry wired:
+  // it is how ESC / Ctrl+C unblocks a parent turn suspended on a subagent
+  // `await` (the "stuck mid-subagent, have to fork the session" bug). These
+  // tests use the default `executor`, which has no backgroundRegistry.
+  describe('cancellation (soft-stop via SubagentControl)', () => {
+    const tick = () => new Promise((r) => setImmediate(r));
+
+    it('hasActiveForeground is false when nothing is in flight', () => {
+      expect(executor.hasActiveForeground()).toBe(false);
+    });
+
+    it('cancelActiveForeground is a no-op returning 0 when nothing is in flight', async () => {
+      expect(await executor.cancelActiveForeground()).toBe(0);
+    });
+
+    it('tracks an in-flight foreground subagent and cancels it WITHOUT a registry', async () => {
+      const { handle, resolveRun } = hangingHandle();
+      mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
+
+      // Start the foreground run but do NOT await — it hangs until resolveRun.
+      const execPromise = executor.execute(makeCall({ input: { prompt: 'deep investigation' } }));
+      await tick(); // let execute() fork + register the handle
+
+      expect(executor.hasActiveForeground()).toBe(true);
+      // Cancellation is available even though promotion is NOT (no registry).
+      expect(executor.hasPromotableForeground()).toBe(false);
+
+      const cancelled = await executor.cancelActiveForeground();
+      expect(cancelled).toBe(1);
+      expect(handle.cancel).toHaveBeenCalledTimes(1);
+
+      // In production handle.cancel() resolves runToResult; the mock's cancel is
+      // inert, so simulate that resolution to unblock execute() and let its
+      // finally clear the tracking map.
+      resolveRun({
+        id: 'test-handle',
+        status: 'cancelled' as SubagentResult['status'],
+        error: new Error('cancelled'),
+      } as SubagentResult);
+      await execPromise.catch(() => { /* failure payload path returns, no throw */ });
+      expect(executor.hasActiveForeground()).toBe(false);
+    });
+
+    it('cancel-all: cancels every in-flight foreground subagent and returns the count', async () => {
+      const a = hangingHandle();
+      const b = hangingHandle();
+      (a.handle as any).id = 'sub-a';
+      (b.handle as any).id = 'sub-b';
+      const forks = [a.handle, b.handle];
+      let i = 0;
+      mockSubagentMgr.forkSubagent = vi.fn().mockImplementation(() => Promise.resolve(forks[i++]));
+
+      const p1 = executor.execute(makeCall({ id: 'call-a', input: { prompt: 'first' } }));
+      const p2 = executor.execute(makeCall({ id: 'call-b', input: { prompt: 'second' } }));
+      await tick();
+
+      expect(executor.hasActiveForeground()).toBe(true);
+      expect(await executor.cancelActiveForeground()).toBe(2);
+      expect(a.handle.cancel).toHaveBeenCalledTimes(1);
+      expect(b.handle.cancel).toHaveBeenCalledTimes(1);
+
+      a.resolveRun({ id: 'sub-a', status: 'cancelled' as SubagentResult['status'], error: new Error('x') } as SubagentResult);
+      b.resolveRun({ id: 'sub-b', status: 'cancelled' as SubagentResult['status'], error: new Error('x') } as SubagentResult);
+      await Promise.allSettled([p1, p2]);
+      expect(executor.hasActiveForeground()).toBe(false);
+    });
+  });
 });

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -188,6 +188,25 @@ export interface SubagentControl {
    * background-job cap was hit) are omitted from the returned array.
    */
   promoteActiveForeground(): Promise<PromotedSubagentInfo[]>;
+  /**
+   * True iff at least one foreground subagent dispatched by this executor is
+   * currently in flight. Unlike {@link hasPromotableForeground} this does NOT
+   * require a `BackgroundAgentRegistry` — cancellation is always available. The
+   * keyboard layer reads this to decide whether a soft-stop (ESC / first Ctrl+C)
+   * must cancel in-flight subagents to unblock a turn suspended on a subagent
+   * `await`.
+   */
+  hasActiveForeground(): boolean;
+  /**
+   * Cancel every in-flight foreground subagent dispatched by this executor.
+   * Each cancellation resolves the subagent's suspended `runToResult` (as a
+   * failed result carrying any streamed partial output), which lets the parent
+   * turn's tool-use loop unblock and observe the pending soft-stop so the turn
+   * ends cleanly instead of hanging for the subagent's entire lifetime (up to
+   * the 2h usage-limit cap). Returns the number of subagents cancelled; a no-op
+   * returning 0 when none are in flight.
+   */
+  cancelActiveForeground(): Promise<number>;
 }
 
 interface AgentInput {
@@ -454,8 +473,33 @@ export class SubagentExecutor implements SubagentControl {
     { fire: () => void; ready: Promise<PromotedSubagentInfo | null> }
   >();
 
+  // In-flight foreground handles keyed by `handle.id`. Tracked separately from
+  // promotionTriggers because cancellation must work with NO background
+  // registry wired: a soft-stop (ESC / Ctrl+C) cancels these to unblock a
+  // parent turn parked on a subagent `await`. Populated alongside the promotion
+  // trigger in execute()'s foreground branch and cleared in the same finally.
+  private readonly activeForegroundHandles = new Map<string, { cancel: () => Promise<void> }>();
+
   hasPromotableForeground(): boolean {
     return this.ctx.backgroundRegistry !== undefined && this.promotionTriggers.size > 0;
+  }
+
+  hasActiveForeground(): boolean {
+    return this.activeForegroundHandles.size > 0;
+  }
+
+  async cancelActiveForeground(): Promise<number> {
+    // Snapshot first: cancel() resolves the run, whose finally removes the entry
+    // from the map while we iterate. handle.cancel() is idempotent and aborts
+    // the child session; its runToResult settles (buildResultFromError with any
+    // partialOutput), the Promise.race in execute() picks the 'result' branch,
+    // and the parent receives a structured failure tool_result — unblocking the
+    // suspended turn. We do NOT delete entries here; the run's own finally does
+    // so idempotently.
+    const handles = [...this.activeForegroundHandles.values()];
+    if (handles.length === 0) return 0;
+    await Promise.all(handles.map((h) => h.cancel().catch(() => { /* best-effort */ })));
+    return handles.length;
   }
 
   async promoteActiveForeground(): Promise<PromotedSubagentInfo[]> {
@@ -826,6 +870,9 @@ export class SubagentExecutor implements SubagentControl {
       resolveJob = resolve;
     });
     this.promotionTriggers.set(handle.id, { fire: firePromotion, ready: jobReady });
+    // Registry-independent cancel handle (soft-stop path). Removed in the same
+    // finally as the promotion trigger below.
+    this.activeForegroundHandles.set(handle.id, handle);
 
     // In-turn SubagentStop delivery.
     //
@@ -1000,6 +1047,7 @@ export class SubagentExecutor implements SubagentControl {
       throw err;
     } finally {
       this.promotionTriggers.delete(handle.id);
+      this.activeForegroundHandles.delete(handle.id);
       // Safety net: if the run won the race (or threw) before a fired
       // promotion could be honored, resolve the trigger so a concurrent
       // promoteActiveForeground() await never hangs. Idempotent — a no-op

--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -1042,6 +1042,8 @@ describe('runTurn — borrowed-compositor regression (PR 424 / Stage 3e)', () =>
     const subagentControl = {
       hasPromotableForeground: () => true,
       promoteActiveForeground,
+      hasActiveForeground: () => false,
+      cancelActiveForeground: vi.fn().mockResolvedValue(0),
     };
 
     const { h, onTurnComplete } = makeHandles();
@@ -1086,6 +1088,8 @@ describe('runTurn — borrowed-compositor regression (PR 424 / Stage 3e)', () =>
     const subagentControl = {
       hasPromotableForeground: () => false, // nothing running to background
       promoteActiveForeground,
+      hasActiveForeground: () => false,
+      cancelActiveForeground: vi.fn().mockResolvedValue(0),
     };
 
     const { h, onTurnComplete } = makeHandles();
@@ -1288,6 +1292,83 @@ describe('runTurn — ESC soft-stop', () => {
 
     // Core assertion: session.interrupt() was called — stream halted.
     expect(interruptSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: a turn suspended on a subagent `await` cannot be halted by
+  // session.interrupt() alone. Soft-stop MUST also cancel in-flight foreground
+  // subagents so the suspended parent unblocks and returns to the prompt —
+  // otherwise ESC / Ctrl+C are dead for the whole subagent run (the "stuck
+  // mid-subagent, have to fork the session" bug).
+  it('cancels in-flight foreground subagents on soft-stop', async () => {
+    const events: OutputEvent[] = [
+      { type: 'chunk', chunk: { type: 'content', content: 'partial' } },
+      { type: 'done', metadata: { durationMs: 5 } },
+    ];
+    const session = streamFrom(events);
+
+    const cancelActiveForeground = vi.fn().mockResolvedValue(1);
+    const subagentControl = {
+      hasPromotableForeground: () => false,
+      promoteActiveForeground: vi.fn().mockResolvedValue([]),
+      hasActiveForeground: () => true, // a subagent IS running
+      cancelActiveForeground,
+    };
+
+    let installedHandler: (() => void) | null = null;
+    const setSoftStopHandler = vi.fn((hh: (() => void) | null) => { installedHandler = hh; });
+
+    let callCount = 0;
+    const realStream = session.sendMessageStream;
+    session.sendMessageStream = async function* (payload: unknown) {
+      for await (const event of (realStream as typeof session.sendMessageStream).call(session, payload)) {
+        yield event;
+        callCount++;
+        if (callCount === 1 && installedHandler) installedHandler();
+      }
+    };
+
+    const { h } = makeHandles();
+    const handles: TurnHandles = { ...h, subagentControl, setSoftStopHandler };
+
+    await runTurn({ text: 'q', attachments: [] }, session, makeStats(), handles);
+
+    expect(cancelActiveForeground).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT cancel subagents on soft-stop when none are in flight', async () => {
+    const events: OutputEvent[] = [
+      { type: 'chunk', chunk: { type: 'content', content: 'partial' } },
+      { type: 'done', metadata: { durationMs: 5 } },
+    ];
+    const session = streamFrom(events);
+
+    const cancelActiveForeground = vi.fn().mockResolvedValue(0);
+    const subagentControl = {
+      hasPromotableForeground: () => false,
+      promoteActiveForeground: vi.fn().mockResolvedValue([]),
+      hasActiveForeground: () => false, // nothing running
+      cancelActiveForeground,
+    };
+
+    let installedHandler: (() => void) | null = null;
+    const setSoftStopHandler = vi.fn((hh: (() => void) | null) => { installedHandler = hh; });
+
+    let callCount = 0;
+    const realStream = session.sendMessageStream;
+    session.sendMessageStream = async function* (payload: unknown) {
+      for await (const event of (realStream as typeof session.sendMessageStream).call(session, payload)) {
+        yield event;
+        callCount++;
+        if (callCount === 1 && installedHandler) installedHandler();
+      }
+    };
+
+    const { h } = makeHandles();
+    const handles: TurnHandles = { ...h, subagentControl, setSoftStopHandler };
+
+    await runTurn({ text: 'q', attachments: [] }, session, makeStats(), handles);
+
+    expect(cancelActiveForeground).not.toHaveBeenCalled();
   });
 
   it('does NOT call onTurnComplete when soft-stopped (incomplete turn = no state write)', async () => {

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -254,6 +254,24 @@ export async function runTurn(
             console.error('  ' + palette.error('soft-stop session.interrupt() failed:'), err);
           }
         });
+        // A turn suspended on a subagent `await` (the parent tool-use loop is
+        // parked awaiting the subagent tool_result) cannot be halted by
+        // session.interrupt() alone — the parent stream is not what's blocked.
+        // Cancel any in-flight foreground subagent so its runToResult resolves,
+        // the tool_result flows back, and the for-await loop wakes to observe
+        // softStopRequested and stop cleanly — returning the user to the prompt
+        // with context intact. Without this, ESC / Ctrl+C are dead for the
+        // entire subagent run (up to the 2h usage-limit cap): the "stuck
+        // mid-subagent, have to fork the session" bug. Fire-and-forget; the
+        // cancel resolves the await that unblocks the loop.
+        const ctrl = h.subagentControl;
+        if (ctrl?.hasActiveForeground()) {
+          void ctrl.cancelActiveForeground().catch((err) => {
+            if (isDebugEnabled()) {
+              console.error('  ' + palette.error('soft-stop cancelActiveForeground() failed:'), err);
+            }
+          });
+        }
       });
     }
 

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -350,6 +350,21 @@ export async function runTurn(
         // already initiated in the handler, the stream's async iterator
         // terminates naturally (no throw), and the post-stream block detects
         // softStopRequested to render the notice and suppress recordTurn.
+        //
+        // History consistency: breaking mid-tool-use (e.g. after
+        // cancelActiveForeground() resolves a stuck subagent's tool_result)
+        // can leave the provider's running history terminating in an assistant
+        // `tool_use` whose `tool_result` was never appended — anthropic-direct
+        // pushes the assistant turn (loop.ts) BEFORE yielding tool output and
+        // appends the tool_result only after. That transient orphan is healed
+        // before the NEXT request: repairOrphanToolUses (anthropic-direct
+        // query.ts) runs before every new-user-turn append and synthesizes
+        // is_error tool_result placeholders, and the abort-path rollback in
+        // loop.ts covers the throw case — so the following turn never 400s with
+        // "tool_use ids ... without tool_result blocks". The OpenAI-compatible
+        // provider appends assistant{tool_calls} + results together (one
+        // synchronous block after the yield loop), so it has no orphan window.
+        // See PR #400 review + query/repair-orphan-tool-uses.ts.
         if (softStopRequested || pauseInterruptRequested) {
           break;
         }


### PR DESCRIPTION
## Problem

A REPL turn suspended on a foreground subagent `await` — the parent tool-use loop parked awaiting the subagent's `tool_result` — could **not** be halted by ESC / Ctrl-C. The session became "stuck stuck": the only escape was forking the session and typing *continue*, or `kill -9`.

Trigger (confirmed against session history): a usage-limit **429 landing inside a subagent** silently pauses it (auto-resume, up to a 2h retry cap), and the parent is blocked awaiting that child the whole time.

## Root cause (RC2 of a three-cause diagnosis)

- The soft-stop path calls `session.interrupt()`, which (`agent-session.ts:729-733`) only sets `currentState='idle'` and interrupts the **parent's own** provider stream. It never touches `abortController`, so it never fires the per-turn `call.signal`.
- The one pre-existing bridge that cancels a subagent — `call.signal` → `handle.cancel()` (`subagent-executor.ts:835-838`) — is driven by `session.abort()`, **not** `interrupt()`. And `abort()` is keyboard-unreachable during a suspended turn (the SIGINT handler gates it behind `turnInFlight===false`, which never flips while the turn is parked).

Net: no keypress could reach the subagent-cancel path, so the turn never ended.

## Fix

Add a registry-independent cancel seam to the sanctioned `SubagentControl` interface:

- `hasActiveForeground()` / `cancelActiveForeground()`, backed by an `activeForegroundHandles` map registered beside the existing promotion triggers and cleaned up in the **same** `execute()` `finally`.
- Wire it into the soft-stop closure that both ESC and Ctrl-C converge on (`turn-handler.ts:242-275`; both keys share one handler via `surface-setup.ts:288-290`).

`cancelActiveForeground()` calls `handle.cancel()` on every in-flight foreground child. `cancel()` aborts the child graph + interrupts the child session → the child's `runToResult` resolves as a failed result carrying `partialOutput` → the parent's awaited promise resolves → the for-await loop wakes, observes `softStopRequested`, and ends the turn cleanly — back at the prompt, context intact, **no fork**. It even breaks a child out of the 2h usage-limit poll (the child's abort signal is already wired into the wait). Idempotent + best-effort; errors are swallowed so it never blocks soft-stop.

This recovers the turn **in place** rather than quitting afk, so the delicate SIGINT `turnInFlight` gating is left untouched.

## Verification

- `tsc --noEmit` clean; full suite green (**574 files, 10608 tests, 14 skipped, 0 fail**).
- 6 new tests: 4 executor cancel-path (incl. *cancels without a background registry* + cancel-all + tracking-map clears) and 2 turn-handler soft-stop wiring (cancels when a child is active; no-op when none).
- Load-bearing claims (root cause, `cancel()`→`runToResult` resolution, dual-key wiring, no promotion-path regression) independently re-derived from source and **CONFIRMED**.

## Scope / deferred

Closes **RC2** (recoverability) only. Deferred as separate design-choice work (both diagnosed in `.afk/diagnostics/subagent-termination-2026-07-02.md`):

- **RC1** — surface subagent usage-limit pauses in the UI and/or default `autoResumeOnUsageLimit:false` for children (so a limit surfaces fast instead of silently polling 2h).
- **RC3** — turn-cap exhaustion should emit a final synthesis instead of throwing (why `/review --post` returned "nothing to post").
