### PR TITLE
fix(skills): expand ${PLUGIN_ROOT:-fallback} idiom in load-mode substitution

### DIFF
--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -339,8 +339,15 @@ export class SkillExecutor {
       }
       // Default: in-context LOAD (2026-06 load-by-default flip). No readOnly —
       // loaded skills execute in the caller's context, not a restrictable child.
+      // Expand PLUGIN_ROOT so shell commands in the body resolve to the plugin
+      // dir. Handles `$PLUGIN_ROOT`, `${PLUGIN_ROOT}`, and the Claude-Code
+      // portability idiom `${PLUGIN_ROOT:-<default>}` (default may hold one
+      // nested `${...}`, e.g. `${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}`) — in AFK
+      // PLUGIN_ROOT is always known so the whole reference collapses to
+      // pluginPath. (Fork skills instead get PLUGIN_ROOT as a shell env var via
+      // executePluginSkill, so the shell expands the `:-` fallback natively.)
       const bodyWithRoot = pluginSkill.body.replace(
-        /\$\{?PLUGIN_ROOT\}?/g,
+        /\$\{PLUGIN_ROOT(?::-(?:[^{}]|\$\{[^{}]*\})*)?\}|\$PLUGIN_ROOT\b/g,
         () => pluginSkill.pluginPath,
       );
       return this.executeLoadedPluginSkill(

--- a/src/agent/tools/skill-load-mode.test.ts
+++ b/src/agent/tools/skill-load-mode.test.ts
@@ -230,6 +230,41 @@ describe('context: load — plugin skills', () => {
     expect(result.content).not.toContain('${PLUGIN_ROOT}');
     expect(mockFork).not.toHaveBeenCalled();
   });
+
+  it('expands the ${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}} portability idiom to pluginPath when context: load', async () => {
+    // Regression: the previous /\$\{?PLUGIN_ROOT\}?/g regex matched only
+    // `${PLUGIN_ROOT` of the Claude-Code fallback idiom and left `:-${CLAUDE_
+    // PLUGIN_ROOT}}` dangling, producing a broken path. Skills using the
+    // portable `${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}` form (forge-gate-check,
+    // distill, forge-l2-eval, ceiling-test) failed their python3 invocations
+    // in load mode as a result.
+    const mockFork = spyNoFork();
+    const executor = makeExecutor();
+    const PLUGIN_PATH = '/home/user/.afk/plugins/my-plugin';
+    setPluginBodies(executor, [
+      [
+        'plugin-root-fallback',
+        {
+          body: 'python3 ${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/foo.py and "${PLUGIN_ROOT:-/tmp/x}/bin/bar"',
+          pluginPath: PLUGIN_PATH,
+          context: 'load',
+        },
+      ],
+    ]);
+
+    const result = await executor.execute(makeCall({ name: 'plugin-root-fallback' }));
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toContain(`python3 ${PLUGIN_PATH}/scripts/foo.py`);
+    expect(result.content).toContain(`"${PLUGIN_PATH}/bin/bar"`);
+    // The whole `${PLUGIN_ROOT:-...}` fallback (incl. the nested ${...})
+    // collapses to pluginPath — nothing of the placeholder or fallback survives.
+    expect(result.content).not.toContain('$PLUGIN_ROOT');
+    expect(result.content).not.toContain('${PLUGIN_ROOT');
+    expect(result.content).not.toContain('CLAUDE_PLUGIN_ROOT');
+    expect(result.content).not.toContain(':-');
+    expect(mockFork).not.toHaveBeenCalled();
+  });
 });
 
 describe('context: load — SKILL.md frontmatter parsing (end-to-end)', () => {


### PR DESCRIPTION
## Problem

The load-mode PLUGIN_ROOT substitution in `skill-executor.ts` used the regex `/\$\{?PLUGIN_ROOT\}?/g`. Against the Claude-Code portability idiom `${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}` it matches only the leading `${PLUGIN_ROOT` and leaves `:-${CLAUDE_PLUGIN_ROOT}}` dangling — producing a corrupt path. Plugin skills that use this portable form fail their `python3` invocations when dispatched in **load** mode:

- `forge-gate-check`, `forge-l2-eval`, `distill`, `ceiling-test` (all in the `awa-private` marketplace plugin)

The **fork** path is unaffected — `executePluginSkill` injects `PLUGIN_ROOT` as a real shell env var (`env: { PLUGIN_ROOT: pluginPath }`), so the shell expands the `:-` fallback natively. The load-path comment for that idiom already documents this as the intended behavior; this PR simply brings the load-path regex in line with it.

## Fix

New regex handles all three forms:

```
/\$\{PLUGIN_ROOT(?::-(?:[^{}]|\$\{[^{}]*\})*)?\}|\$PLUGIN_ROOT\b/g
```

- `$PLUGIN_ROOT` (bare, word-boundary terminated)
- `${PLUGIN_ROOT}`
- `${PLUGIN_ROOT:-<default>}` where `<default>` may contain **one** level of nested `${...}` (covers `${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}`)

In AFK `PLUGIN_ROOT` is always known, so the entire reference (fallback included) collapses to `pluginPath`.

## Test

Adds a regression test in `skill-load-mode.test.ts` asserting the `${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}` idiom (and a `${PLUGIN_ROOT:-/literal}` variant) expand fully to `pluginPath` with no dangling `:-`, placeholder, or `CLAUDE_PLUGIN_ROOT` remnant.

## Gates

- `pnpm lint` (tsc --noEmit strict) — clean
- full `vitest run` — 10602 passed / 14 skipped / 0 failed

## Notes

This is the framework-level fix; a companion marketplace change adds `context: fork` to the affected `awa-private` skills so they get immediate relief on already-released afk (fork path → shell env expansion) without waiting for this to ship. `ceiling-test` is intentionally left to this load-path fix rather than fork-pinned, since it is a top-level orchestrator whose sub-agent depth budget would be degraded by an extra fork level.
