### PR TITLE
fix(tui): coalesce post-ESC type-ahead so soft-stop doesn't strand input one turn behind

### DIFF
--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -626,11 +626,29 @@ function handleEnter(self: KeyDispatchHost, key: KeyInfo, sequence: string): boo
   const displayText = self.input.buffer;
   const expandedText = Paste.expandPastePlaceholders(self, displayText);
   const attachments = [...self.attachments];
-  self.pendingSubmissions.push(
+  const payload: SubmissionPayload =
     expandedText === displayText
       ? { text: expandedText, attachments }
-      : { text: expandedText, displayText, attachments },
-  );
+      : { text: expandedText, displayText, attachments };
+  // Invariant: during the ESC soft-stop window — `softStopped` is set by
+  // handleEscape and cleared only at the post-soft-stop `→ idle` transition
+  // (setInputMode, terminal-compositor.input-mode.ts) — Enter must NOT
+  // accumulate a type-ahead backlog. That window is the async turn-teardown
+  // gap: for a subagent turn, cancelActiveForeground() (subagent-executor.ts)
+  // resolves the parent `await` only after the child settles — seconds for a
+  // deep/wide wave — and the compositor lingers in 'streaming' the whole time.
+  // Each Enter would otherwise push onto the FIFO, which drains ONE payload per
+  // turn (the `→ idle` flush), stranding the user one turn behind: the "it
+  // doesn't send, then I keep sending characters to catch up" report. So during
+  // a soft-stop we keep only the LATEST message (last-wins) — the user's most
+  // recent post-stop intent runs as exactly one next turn, no backlog. Normal
+  // mid-turn type-ahead (softStopped === false) still accumulates: sequential-
+  // turn delivery is the intended contract there (the "NO ESC" regression tests).
+  if (self.softStopped) {
+    self.pendingSubmissions = [payload];
+  } else {
+    self.pendingSubmissions.push(payload);
+  }
   self.queued = true; // maintained mirror: pendingSubmissions is now non-empty
   // Clear the compose window for the next message. Mirrors the idle-mode
   // submit reset above so dropdown chrome / paste side-table / attachments

--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -108,6 +108,15 @@ export interface KeyDispatchHost {
 
   /** Once-only soft-stop guard for ESC in streaming mode. */
   softStopped: boolean;
+  /**
+   * Snapshot of `pendingSubmissions.length` taken at ESC soft-stop time
+   * (handleEscape). Entries at indices `0..softStopQueueBase-1` were queued
+   * BEFORE esc and are contract-protected (handleEscape comment lines 318-327):
+   * "Already-queued messages: left untouched." Post-ESC Enters coalesce to
+   * last-wins by truncating back to this base before pushing, so the pre-ESC
+   * queue is never silently dropped.
+   */
+  softStopQueueBase: number;
   /** Hard-abort flag set by Ctrl+C in streaming mode. */
   canceled: boolean;
   /** Once-only guard for Ctrl+B background in streaming mode. */
@@ -329,6 +338,10 @@ function handleEscape(self: KeyDispatchHost, key: KeyInfo): boolean {
   // committing it would fling it as a turn the user never submitted. Ctrl+C
   // (handleInterrupt below) follows the same no-auto-commit rule.
   self.softStopped = true;
+  // Snapshot the queue length so post-ESC coalesce (handleEnter) can truncate
+  // back to here — preserving pre-ESC payloads per the contract above —
+  // while still giving last-wins for messages Entered after this ESC.
+  self.softStopQueueBase = self.pendingSubmissions.length;
   if (self.onSoftStop) self.onSoftStop();
   return true;
 }
@@ -640,12 +653,21 @@ function handleEnter(self: KeyDispatchHost, key: KeyInfo, sequence: string): boo
   // Each Enter would otherwise push onto the FIFO, which drains ONE payload per
   // turn (the `→ idle` flush), stranding the user one turn behind: the "it
   // doesn't send, then I keep sending characters to catch up" report. So during
-  // a soft-stop we keep only the LATEST message (last-wins) — the user's most
-  // recent post-stop intent runs as exactly one next turn, no backlog. Normal
-  // mid-turn type-ahead (softStopped === false) still accumulates: sequential-
-  // turn delivery is the intended contract there (the "NO ESC" regression tests).
+  // a soft-stop we keep only the LATEST post-ESC message (last-wins) — the user's
+  // most recent post-stop intent runs as exactly one next turn, no backlog.
+  //
+  // Contract preservation: `softStopQueueBase` was snapshotted by handleEscape
+  // at ESC time, capturing the count of pre-ESC payloads already on the FIFO.
+  // Truncating back to that base before pushing preserves those pre-ESC entries
+  // (they drain as their own sequential turns via the `→ idle` flush), so the
+  // handleEscape contract — "Already-queued messages: left untouched" — holds.
+  // Array-wide reassignment (`= [payload]`) would silently drop them; truncate-
+  // then-push does not. Normal mid-turn type-ahead (softStopped === false) still
+  // accumulates: sequential-turn delivery is the intended contract there (the
+  // "NO ESC" regression tests).
   if (self.softStopped) {
-    self.pendingSubmissions = [payload];
+    self.pendingSubmissions.length = self.softStopQueueBase;
+    self.pendingSubmissions.push(payload);
   } else {
     self.pendingSubmissions.push(payload);
   }

--- a/src/cli/terminal-compositor.input-mode.ts
+++ b/src/cli/terminal-compositor.input-mode.ts
@@ -42,6 +42,9 @@ export interface InputModeHost {
   /** Once-only ESC soft-stop guard. */
   softStopped: boolean;
 
+  /** Queue-length snapshot at ESC time; coalesce boundary for post-ESC Enters. */
+  softStopQueueBase: number;
+
   /** Hard-abort flag (Ctrl+C in streaming mode). */
   canceled: boolean;
 
@@ -173,6 +176,7 @@ export function setInputMode(self: InputModeHost, mode: CompositorInputMode): vo
     self.canceled = false;
     self.backgrounded = false;
     self.softStopped = false;
+    self.softStopQueueBase = 0;
     // Reset autocomplete at the idle→streaming transition so any
     // open dropdown rows are not rendered into the first streaming
     // frame. Mirrors the reset in the idle Enter handler above.
@@ -210,6 +214,7 @@ export function setInputMode(self: InputModeHost, mode: CompositorInputMode): vo
   // keeps an EMPTY-buffer ESC from leaving it armed into the idle period.
   if (mode === 'idle' && self.softStopped) {
     self.softStopped = false;
+    self.softStopQueueBase = 0;
     // No early return: fall through so a queued buffer flushes via the branch
     // below when onSubmit is installed (readLine→idle), or — at the
     // dispose→idle transition where onSubmit is still null — stays queued for

--- a/src/cli/terminal-compositor.reset.ts
+++ b/src/cli/terminal-compositor.reset.ts
@@ -32,6 +32,7 @@ export interface ResetStateHost {
   canceled: boolean;
   backgrounded: boolean;
   softStopped: boolean;
+  softStopQueueBase: number;
   paused: boolean;
   activeGhost: string | null;
   anchorRow: number | undefined;
@@ -64,6 +65,7 @@ export function resetState(self: ResetStateHost): void {
   self.canceled = false;
   self.backgrounded = false;
   self.softStopped = false;
+  self.softStopQueueBase = 0;
   self.paused = false;
   // Clear active ghost — stale suggestions must not survive a disarm/rearm
   // cycle. The engine itself is NOT disposed here (only in disarm) since

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -1801,6 +1801,61 @@ describe('TerminalCompositor', () => {
         submitTurn('gamma');
       });
 
+      it('coalesces MULTIPLE messages Entered during ONE soft-stop window (last-wins, no backlog)', async () => {
+        // The residual regression the Bug-B fix (see block comment above) did NOT
+        // cover: it assumed the synchronous interrupt closes the streaming window
+        // at the source. For a SUBAGENT turn that assumption fails —
+        // cancelActiveForeground() (subagent-executor.ts) resolves the parent
+        // await only after the child settles, so the compositor lingers in
+        // 'streaming' for seconds. A user who sees no turn start types several
+        // messages + Enter; pre-fix each pushed onto the FIFO, which drains ONE
+        // per turn → the "it doesn't send, then I keep sending characters to catch
+        // up" report. Post-fix, only the LATEST message survives the window.
+        const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
+        await c.arm();
+        c.setInputMode('idle');
+        c.setInputMode('streaming'); // turn arm
+
+        // ESC once (soft-stop), then THREE messages Entered during the teardown
+        // window (softStopped stays true until the post-soft-stop → idle transition).
+        stdin.emit('keypress', undefined, { name: 'escape' });
+        for (const msg of ['first', 'second', 'third']) {
+          for (const ch of msg) stdin.emit('keypress', ch, { name: ch, sequence: ch });
+          stdin.emit('keypress', undefined, { name: 'return' });
+        }
+        // Last-wins: the FIFO holds only the most recent message, not a backlog of 3.
+        expect(c.getPendingCount()).toBe(1);
+        expect(c.getBuffer()).toEqual({ text: '', queued: true });
+
+        // dispose → idle: softStopped cleared, no drain (onSubmit null).
+        c.setInputMode('idle');
+        expect(c.getPendingCount()).toBe(1);
+
+        // readLine drains the single surviving payload as exactly ONE next turn.
+        const onSubmit = vi.fn();
+        c.setOnSubmit(onSubmit);
+        c.setInputMode('idle');
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit).toHaveBeenCalledWith({ text: 'third', attachments: [] });
+      });
+
+      it('normal multi-message type-ahead (NO ESC) still accumulates every message (blast-radius guard)', async () => {
+        // The last-wins coalesce fires ONLY under softStopped. Ordinary mid-turn
+        // type-ahead must still queue every message for sequential-turn delivery —
+        // coalescing here would silently drop queued turns the user intended.
+        const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
+        await c.arm();
+        c.setInputMode('idle');
+        c.setInputMode('streaming'); // turn arm, no ESC → softStopped stays false
+
+        for (const msg of ['one', 'two', 'three']) {
+          for (const ch of msg) stdin.emit('keypress', ch, { name: ch, sequence: ch });
+          stdin.emit('keypress', undefined, { name: 'return' });
+        }
+        // All three accumulate — the sequential-turn delivery contract is preserved.
+        expect(c.getPendingCount()).toBe(3);
+      });
+
       it('still auto-flushes normal mid-turn type-ahead (NO ESC) — no regression', async () => {
         const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
         await c.arm();

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -1856,6 +1856,79 @@ describe('TerminalCompositor', () => {
         expect(c.getPendingCount()).toBe(3);
       });
 
+      it('pre-ESC queued message survives a post-ESC Enter (coalesce preserves pre-ESC queue)', async () => {
+        // Regression guard for the HIGH review finding: the array-wide
+        // `pendingSubmissions = [payload]` reassignment silently dropped any
+        // message committed via Enter BEFORE pressing ESC — violating the
+        // handleEscape contract ("Already-queued messages: left untouched").
+        // The fix snapshots the queue length at ESC time (softStopQueueBase)
+        // and truncates back to that base before pushing, so pre-ESC payloads
+        // drain as their own turns while post-ESC type-ahead still coalesces.
+        const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
+        await c.arm();
+        c.setInputMode('idle');
+        c.setInputMode('streaming'); // turn arm
+
+        // 1. Enter "msg1" while streaming (no ESC yet) → push, queue=[msg1].
+        for (const ch of 'msg1') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+        stdin.emit('keypress', undefined, { name: 'return' });
+        expect(c.getPendingCount()).toBe(1);
+
+        // 2. ESC → softStopped=true, softStopQueueBase=1, queue untouched.
+        stdin.emit('keypress', undefined, { name: 'escape' });
+
+        // 3. Enter "msg2" during linger → truncate-to-base(1) + push → queue=[msg1, msg2].
+        for (const ch of 'msg2') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+        stdin.emit('keypress', undefined, { name: 'return' });
+        expect(c.getPendingCount()).toBe(2); // pre-ESC msg1 is NOT dropped
+
+        // 4. dispose → idle: softStopped cleared, no drain (onSubmit null).
+        c.setInputMode('idle');
+        expect(c.getPendingCount()).toBe(2);
+
+        // 5. readLine drains the FIFO oldest-first: msg1 as the first turn, msg2 as the second.
+        const onSubmit = vi.fn();
+        c.setOnSubmit(onSubmit);
+        c.setInputMode('idle'); // drain #1 → msg1
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit).toHaveBeenCalledWith({ text: 'msg1', attachments: [] });
+        c.setInputMode('idle'); // drain #2 → msg2
+        expect(onSubmit).toHaveBeenCalledTimes(2);
+        expect(onSubmit).toHaveBeenNthCalledWith(2, { text: 'msg2', attachments: [] });
+      });
+
+      it('pre-ESC queued message survives MULTIPLE post-ESC Enters (coalesce replaces only post-ESC entries)', async () => {
+        // Same contract as above, but with several post-ESC Enters: the pre-ESC
+        // payload must survive while the post-ESC ones coalesce to last-wins.
+        const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
+        await c.arm();
+        c.setInputMode('idle');
+        c.setInputMode('streaming'); // turn arm
+
+        for (const ch of 'pre') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+        stdin.emit('keypress', undefined, { name: 'return' });
+        expect(c.getPendingCount()).toBe(1);
+
+        stdin.emit('keypress', undefined, { name: 'escape' });
+
+        for (const msg of ['post1', 'post2', 'post3']) {
+          for (const ch of msg) stdin.emit('keypress', ch, { name: ch, sequence: ch });
+          stdin.emit('keypress', undefined, { name: 'return' });
+        }
+        // pre-ESC "pre" survives (base=1); three post-ESC Enters coalesce to
+        // last-wins ("post3") → total queue = 2, NOT 1 (pre not dropped) and NOT 4.
+        expect(c.getPendingCount()).toBe(2);
+
+        c.setInputMode('idle'); // dispose → no drain (onSubmit null)
+
+        const onSubmit = vi.fn();
+        c.setOnSubmit(onSubmit);
+        c.setInputMode('idle'); // drain #1 → "pre"
+        expect(onSubmit).toHaveBeenCalledWith({ text: 'pre', attachments: [] });
+        c.setInputMode('idle'); // drain #2 → "post3" (last-wins)
+        expect(onSubmit).toHaveBeenNthCalledWith(2, { text: 'post3', attachments: [] });
+      });
+
       it('still auto-flushes normal mid-turn type-ahead (NO ESC) — no regression', async () => {
         const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
         await c.arm();

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -81,6 +81,14 @@ export class TerminalCompositor {
    * @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost).
    */
   softStopped = false;
+  /**
+   * Snapshot of `pendingSubmissions.length` at ESC soft-stop time. Post-ESC
+   * Enters truncate the queue back to this base before pushing, so pre-ESC
+   * payloads are preserved (handleEscape contract) while post-ESC type-ahead
+   * coalesces to last-wins. Reset alongside `softStopped`.
+   * @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost).
+   */
+  softStopQueueBase = 0;
   /** @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost). */
   onBackground?: () => void;
   /**


### PR DESCRIPTION
## Problem

After pressing **ESC to soft-stop** a running turn, the next message "doesn't send" — the user has to send a follow-up to get the turn to start, and then input lags so they "keep having to send single characters to catch up."

## Root cause

Input mode is coupled to turn-teardown timing:

1. `handleEscape` (`terminal-compositor.input-dispatch.ts`) sets `softStopped = true` but leaves the compositor in **`'streaming'`** mode — it stays streaming until the async teardown finishes.
2. In streaming mode, **Enter queues** onto the `pendingSubmissions` FIFO (`handleEnter`) instead of submitting.
3. The FIFO **drains one payload per `readLine→idle`** — the turn-end `dispose→idle` can't drain (`onSubmit` is null then), so a backlog drains one-behind, turn after turn.
4. The window is long **only for slow teardowns**: #400 added `cancelActiveForeground()`, which is async/best-effort — the parent for-await can't break until the child subagent settles (seconds for a deep/wide wave), and the compositor lingers in `streaming` the whole time. (Token-streaming ESC is unaffected — its interrupt is effectively synchronous.)

This is a regression **surfaced** by #400: before it, ESC-during-subagent did nothing (the turn hung), so the drain-backlog path was never reached.

## Fix

Gate the streaming-Enter queue on `softStopped`: during the ESC window keep only the **latest** post-ESC message (last-wins), so the user's most recent post-stop intent runs as exactly one next turn — no backlog. `softStopped` is set only by ESC (and cleared at the post-soft-stop `→ idle` transition), so **normal mid-turn type-ahead is untouched** (it still accumulates every message for sequential-turn delivery).

Pre-ESC payloads already on the FIFO are contract-protected (`handleEscape`: "Already-queued messages: left untouched"). `handleEscape` snapshots `pendingSubmissions.length` into `softStopQueueBase` at ESC time; `handleEnter` then **truncates back to that base before pushing** — preserving pre-ESC entries (they drain as their own sequential turns) while post-ESC type-ahead still coalesces to last-wins.

> *Note:* array-wide reassignment (`pendingSubmissions = [payload]`) would silently drop those pre-ESC payloads, violating the `handleEscape` contract. Truncate-then-push does not.

```ts
// handleEscape: snapshot the pre-ESC queue length at ESC time.
self.softStopQueueBase = self.pendingSubmissions.length;

// handleEnter: during the soft-stop window, truncate-then-push (last-wins
// for post-ESC entries, pre-ESC entries untouched).
if (self.softStopped) {
  self.pendingSubmissions.length = self.softStopQueueBase;
  self.pendingSubmissions.push(payload);   // last-wins during the ESC window
} else {
  self.pendingSubmissions.push(payload);   // normal type-ahead: accumulate
}
```

`softStopQueueBase` is reset to `0` at every site that clears `softStopped` (idle→streaming, post-soft-stop →idle, `resetState`, class initializer).

## Tests

Added to `describe('soft-stop drain')` in `terminal-compositor.test.ts`:

- **Multi-message-during-window coalesce** — ESC, then 3 messages Entered during the teardown window → FIFO holds only the latest → drains as exactly one next turn.
- **No-ESC blast-radius guard** — ordinary type-ahead (no ESC) still accumulates all 3 messages.
- **Pre-ESC queue survives a post-ESC Enter** — a message committed via Enter *before* ESC is not dropped when a post-ESC Enter truncates; both drain as their own turns (oldest-first).
- **Pre-ESC queue survives MULTIPLE post-ESC Enters** — same contract with 3 post-ESC Enters: pre-ESC payload survives, three post-ESC ones coalesce to last-wins (queue=2, not 1 and not 4).

## Verification

- `pnpm lint` (`tsc --noEmit`) — clean (exit 0)
- Full suite — **10,643 passed / 0 failed / 14 skipped**
- Focused `soft-stop drain` block — 10/10 pass

## Not included (follow-ups)

- **"interrupting…" affordance for ESC** — an affordance exists but its copy is Ctrl+C-specific and only fires from the SIGINT handler; reusing it for ESC needs a parameterized message + tests. The queue fix already removes the substantive harm (the backlog); the affordance only improves the *perception* of the inherent teardown latency.
- **Interrupt telemetry event** — the witness trace records no soft-stop/interrupt marker today. `AgentSession.interrupt()` can reach the trace writer, but the only existing event is `abort` (AbortGraph hard-abort semantics); a graceful soft-stop wants a dedicated event kind (schema + reader + tests across `src/agent/trace/`).
- **Repaint-starvation** — "catch up with single characters" *may* also point at a render-loop issue distinct from the queue backlog; unconfirmed. Repro: ESC a long subagent, type one message, watch whether the queued turn renders without further keystrokes.
