### PR TITLE
fix(skills): make SKILL.md context: authoritative; drop DEFAULT_FORK_SKILLS

### DIFF
--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -132,29 +132,6 @@ export const RECON_ALLOWED_TOOLS: readonly string[] = [
 // prose). Add a name here only for skills that are genuinely read-only recon.
 export const DEFAULT_READ_ONLY_SKILLS: ReadonlySet<string> = new Set(['ground-state']);
 
-// Skills forced to FORK execution by NAME, independent of their SKILL.md
-// frontmatter. Same rationale as DEFAULT_READ_ONLY_SKILLS: first-registrant-
-// wins registration means a user/project copy of a bundled skill can shadow
-// it, and a stale copy missing `context: fork` silently degrades to load
-// mode — the caller gets instruction text instead of the structured envelope
-// (e.g. diagnose's auto-verify parses shadow-verify's JSON), and name-keyed
-// read-only enforcement is bypassed because it only runs on the forked path.
-// Seeded with every bundled skill that declares `context: fork`
-// (src/bundled-plugins/awa-bundled/skills/*). When this set forces a fork on
-// a copy whose frontmatter lacked `context: fork`, the executor emits a
-// warning naming the skill so a deliberate local load-mode edit is never
-// silently overridden.
-export const DEFAULT_FORK_SKILLS: ReadonlySet<string> = new Set([
-  'shadow-verify',
-  'review',
-  'research',
-  'ground-state',
-  'spec',
-  'ship',
-  'simplify',
-  'refactor',
-]);
-
 /**
  * Bootstrap-time options captured by closure into the factory returned by
  * {@link createChildProviderFactory}. Held at factory-construction (not

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -23,7 +23,6 @@ import { collectSkillEntries, discoverPluginSkillBodies, type PluginSkillBody } 
 import type { SdkPluginConfig } from '../types/sdk-types.js';
 import {
   DEFAULT_MAX_NESTING_DEPTH,
-  DEFAULT_FORK_SKILLS,
   DEFAULT_READ_ONLY_SKILLS,
   RECON_ALLOWED_TOOLS,
   buildReadOnlyReconProvider,
@@ -321,28 +320,16 @@ export class SkillExecutor {
 
     // 2. Try plugin skills (SKILL.md body). Default is in-context LOAD; a
     //    plugin skill forks a subagent ONLY when its frontmatter explicitly
-    //    declares `context: fork`. (History: the default was fork until
-    //    2026-06; flipped to load so authored skills act in-context by
-    //    default. Isolation-critical bundled skills are pinned to
-    //    `context: fork`. See docs/skill-load-mode.md.)
+    //    declares `context: fork`. The SKILL.md `context:` field is the single
+    //    source of truth — there is no name-keyed override, so a `context: load`
+    //    or absent field always loads, even for a copy that shadows a bundled
+    //    skill. (History: the default was fork until 2026-06; flipped to load
+    //    so authored skills act in-context by default. Isolation-critical
+    //    bundled skills are pinned to `context: fork` in their own SKILL.md.
+    //    See docs/skill-load-mode.md.)
     const pluginSkill = this.getPluginSkillBody(parsed.name);
     if (pluginSkill) {
-      // Fork enforcement is name-keyed as well as frontmatter-keyed: first-
-      // registrant-wins registration lets a user/project copy shadow a
-      // bundled skill, and a stale copy missing `context: fork` would
-      // silently degrade an isolation-critical skill to load mode (no
-      // structured output envelope, no read-only child enforcement). A name
-      // in DEFAULT_FORK_SKILLS forces the fork path for ANY copy; the warn
-      // below makes the override observable so a deliberate local load-mode
-      // edit is never silently ignored.
-      const forcedFork =
-        pluginSkill.context !== 'fork' && DEFAULT_FORK_SKILLS.has(parsed.name);
-      if (forcedFork) {
-        console.warn(
-          `[skill] "${parsed.name}" (${pluginSkill.pluginPath}) lacks \`context: fork\` in its frontmatter but is fork-enforced by name (DEFAULT_FORK_SKILLS) — running in fork mode. Add \`context: fork\` to its SKILL.md to silence this warning.`,
-        );
-      }
-      if (pluginSkill.context === 'fork' || forcedFork) {
+      if (pluginSkill.context === 'fork') {
         // Read-only enforcement: a plugin skill is read-only when its SKILL.md
         // frontmatter declares `read-only: true` (surfaced as `pluginSkill.readOnly`)
         // OR its name is in DEFAULT_READ_ONLY_SKILLS (name-keyed so any copy of

--- a/src/agent/tools/skill-load-mode.test.ts
+++ b/src/agent/tools/skill-load-mode.test.ts
@@ -205,58 +205,7 @@ describe('context: load — plugin skills', () => {
     expect(mockFork).toHaveBeenCalledOnce();
   });
 
-  it('forces FORK by name for a DEFAULT_FORK_SKILLS skill whose frontmatter lacks context: fork', async () => {
-    // Regression: first-registrant-wins registration lets a user/project
-    // copy shadow a bundled fork-mode skill. A stale copy missing
-    // `context: fork` previously degraded to load mode — instruction text
-    // instead of the structured envelope (broke diagnose's shadow-verify
-    // parsing) and bypassed name-keyed read-only enforcement.
-    const mockFork = vi.fn().mockResolvedValue({
-      runToResult: vi.fn().mockResolvedValue({ status: 'succeeded', message: { content: 'forced-fork' } }),
-      teardown: vi.fn().mockResolvedValue(undefined),
-    });
-    vi.spyOn(SubagentManager.prototype, 'forkSubagent').mockImplementation(mockFork);
-    vi.spyOn(SubagentManager.prototype, 'teardownAll').mockResolvedValue(undefined);
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const executor = makeExecutor();
-    // 'shadow-verify' is in DEFAULT_FORK_SKILLS; this copy has NO context field.
-    setPluginBodies(executor, [
-      ['shadow-verify', { body: 'stale private copy', pluginPath: '/fake/private-plugin' }],
-    ]);
-
-    const result = await executor.execute(makeCall({ name: 'shadow-verify' }));
-
-    expect(result.content).toBe('forced-fork');
-    expect(mockFork).toHaveBeenCalledOnce();
-    // The override must be observable — never a silent frontmatter override.
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('fork-enforced by name'),
-    );
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('shadow-verify'));
-  });
-
-  it('does NOT warn when a DEFAULT_FORK_SKILLS skill already declares context: fork', async () => {
-    const mockFork = vi.fn().mockResolvedValue({
-      runToResult: vi.fn().mockResolvedValue({ status: 'succeeded', message: { content: 'ok' } }),
-      teardown: vi.fn().mockResolvedValue(undefined),
-    });
-    vi.spyOn(SubagentManager.prototype, 'forkSubagent').mockImplementation(mockFork);
-    vi.spyOn(SubagentManager.prototype, 'teardownAll').mockResolvedValue(undefined);
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const executor = makeExecutor();
-    setPluginBodies(executor, [
-      ['shadow-verify', { body: 'proper copy', pluginPath: '/fake', context: 'fork' }],
-    ]);
-
-    await executor.execute(makeCall({ name: 'shadow-verify' }));
-
-    expect(mockFork).toHaveBeenCalledOnce();
-    expect(warnSpy).not.toHaveBeenCalled();
-  });
-
-  it('a plugin skill NOT in DEFAULT_FORK_SKILLS still loads in-context by default', async () => {
+  it('a plugin skill without context: fork loads in-context by default', async () => {
     const mockFork = spyNoFork();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const executor = makeExecutor();
@@ -267,6 +216,49 @@ describe('context: load — plugin skills', () => {
     const result = await executor.execute(makeCall({ name: 'ordinary-skill' }));
 
     expect(result.content).toContain('ordinary body');
+    expect(result.content).toContain('loaded into your current context');
+    expect(mockFork).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('SKILL.md context is authoritative: a shadowing copy of a bundled fork skill lacking context: fork LOADS (no name-keyed fork override)', async () => {
+    // Regression guard for the removal of DEFAULT_FORK_SKILLS. A user/project
+    // copy that shadows a bundled fork-mode skill (here 'shadow-verify') and
+    // OMITS `context: fork` now loads in-context — the SKILL.md `context:`
+    // field is the single source of truth. There is no name-keyed force-fork:
+    // that override could hijack an unrelated same-named third-party skill and
+    // was a no-op for the correctly-configured bundled copies (which declare
+    // `context: fork` themselves).
+    const mockFork = spyNoFork();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const executor = makeExecutor();
+    setPluginBodies(executor, [
+      ['shadow-verify', { body: 'shadowing copy without context', pluginPath: '/fake/private-plugin' }],
+    ]);
+
+    const result = await executor.execute(makeCall({ name: 'shadow-verify' }));
+
+    expect(result.content).toContain('shadowing copy without context');
+    expect(result.content).toContain('loaded into your current context');
+    expect(mockFork).not.toHaveBeenCalled();
+    // No name-keyed override means no override warning either.
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('respects an explicit context: load even for a name that shadows a bundled skill', async () => {
+    // A third-party plugin skill sharing a bundled skill's name (here 'review')
+    // that explicitly declares `context: load` must load in-context, never be
+    // hijacked into fork mode against the author's declared intent.
+    const mockFork = spyNoFork();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const executor = makeExecutor();
+    setPluginBodies(executor, [
+      ['review', { body: 'third-party review body', pluginPath: '/fake/third-party', context: 'load' }],
+    ]);
+
+    const result = await executor.execute(makeCall({ name: 'review' }));
+
+    expect(result.content).toContain('third-party review body');
     expect(result.content).toContain('loaded into your current context');
     expect(mockFork).not.toHaveBeenCalled();
     expect(warnSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
Follow-up to #399, addressing the two review findings on its fork-by-name half. Removes `DEFAULT_FORK_SKILLS` so each skill's own `SKILL.md` `context:` frontmatter is the single source of truth for fork-vs-load.

## Findings addressed

**1. `DEFAULT_FORK_SKILLS` generic-name blast radius.** The set force-forked skills by name regardless of frontmatter. Verified against the code:
- All eight names are bundled *plugin* skills (not registry skills), so they resolve on the plugin-body path where the override applied; `discoverPluginSkillBodies` is first-wins **project → user → bundled**, so a same-named third-party project/user skill wins and *was* reachable by the force-fork — confirming it could hijack an unrelated skill's explicit `context: load`.
- Every bundled copy already declares `context: fork`, so the override was a **no-op for the copies it aimed to protect**; it only ever fired on a non-bundled copy, where a stale copy of ours is indistinguishable by `pluginPath` from a third party's own skill (so the "key on pluginPath" alternative can't disambiguate either).
- Only `shadow-verify` (parsed by `diagnose`'s verifier) and `ground-state` (read-only enforcement runs only on the fork path) had any real fork dependency — and both keep it via their own `context: fork` frontmatter.

**2. Stale "forks ONLY when frontmatter declares `context: fork`" comment.** Removing the override makes that statement true again, so it's resolved by making the code match the comment (reverted the executor/test comments to that wording).

The spawn-cwd half of #399 is untouched.

## Changes
- `nesting.ts` — remove `DEFAULT_FORK_SKILLS`.
- `skill-executor.ts` — drop the import, the `forcedFork` branch, and the warn; the gate is now just `pluginSkill.context === 'fork'`.
- `skill-load-mode.test.ts` — replace the force-fork-by-name tests with guards that (a) a shadowing copy of a bundled fork skill lacking `context: fork` now **loads**, and (b) an explicit `context: load` is respected.

## Verification
- `pnpm lint` (strict `tsc --noEmit`) → clean.
- `skill-load-mode.test.ts` (15) + `skill-executor.test.ts` (75) → **90 passed**.

## Note (not changed)
`DEFAULT_READ_ONLY_SKILLS` (ground-state read-only enforcement) is a separate name-keyed override left intact — it wasn't part of this finding. With fork now frontmatter-only, that guarantee applies only when the skill's `SKILL.md` declares `context: fork` (bundled `ground-state` does). Flag if you want the same "leave it to the skill file" treatment there.
