### PR TITLE
fix(tui): stop double-rendering finished subagents in the REPL overlay

### DIFF
--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -37,7 +37,7 @@ import {
 } from '../../../agent/_lib/trusted-skill-events.js';
 import { formatTrustedSkillCompletion, formatTrustedSkillInFlight } from '../../trusted-skill-badge.js';
 import type { TrustedSkillResult } from '../../../agent/trusted-skill-result.js';
-import { formatSubagentCompletion } from './progress-banner.js';
+import { emitSubagentCompletion } from './progress-banner.js';
 import { ContextSampler } from '../../context-sampler.js';
 import { SubagentManager } from '../../../agent/subagent.js';
 import { SubagentExecutor } from '../../../agent/tools/subagent-executor.js';
@@ -578,7 +578,7 @@ export async function bootstrapSession(
   // path-approval hook fails open until then (mirroring `setAllowDirDispatcher`
   // wiring order).
   const hookRegistryBundle = createDefaultHookRegistry(
-    (info) => { completionWriter.fn(formatSubagentCompletion(info)); },
+    (info) => { emitSubagentCompletion(completionWriter, info); },
     'cli',
     sharedMemoryStore,
     () => stats.permissionMode,

--- a/src/cli/commands/interactive/progress-banner.test.ts
+++ b/src/cli/commands/interactive/progress-banner.test.ts
@@ -22,8 +22,11 @@ import {
   formatProgressBanner,
   formatProgressSummary,
   formatSubagentCompletion,
+  emitSubagentCompletion,
 } from './progress-banner.js';
 import type { ProgressEvent } from '../../../agent/types.js';
+import type { CompletionWriter } from './shared.js';
+import type { SubagentCompleteInfo } from '../../../agent/default-hook-registry.js';
 
 // Force color output so ANSI sequences are present in the rendered strings and
 // the ANSI-aware truncation path is exercised (not just plain-text slicing).
@@ -275,6 +278,73 @@ describe('progress-banner — terminal width clamping', () => {
         Infinity,
       );
       expect(stripAnsi(line)).toContain(LONG);
+    });
+  });
+
+  // Regression: the compositor/scrollback overlap on parallel subagent
+  // completion (`compose`/devils-advocate). The SubagentStop hook fires
+  // Channel B (`✓ <node> · <time>`) independently of the parent turn's SDK
+  // events; in the REPL the ToolLane (Channel A) already renders each
+  // foreground subagent, so Channel B must be suppressed WHILE the live
+  // overlay owns the surface — otherwise its uncoordinated commitAbove races
+  // the OverlayComposer and corrupts the compositor's row-accounting (ghost
+  // ◉ markers + swallowed committed lines). Previously UNCOVERED: no test
+  // combined concurrent subagent completions with a live-overlay commit gate.
+  describe('emitSubagentCompletion — turn-scoped suppression gate', () => {
+    function makeWriter(): { writer: CompletionWriter; committed: string[] } {
+      const committed: string[] = [];
+      const writer: CompletionWriter = {
+        fn: (line) => committed.push(line),
+        idleFn: (line) => committed.push(line),
+      };
+      return { writer, committed };
+    }
+    const info = (id: string): SubagentCompleteInfo => ({
+      subagentId: id,
+      status: 'succeeded',
+      durationMs: 28_000,
+      agentType: id,
+    });
+
+    it('emits the completion line when NOT suppressed (between turns / chat)', () => {
+      const { writer, committed } = makeWriter();
+      emitSubagentCompletion(writer, info('da-paranoid'));
+      expect(committed).toHaveLength(1);
+      expect(stripAnsi(committed[0]!)).toContain('da-paranoid');
+    });
+
+    it('drops the completion line when suppressed (live foreground overlay)', () => {
+      const { writer, committed } = makeWriter();
+      writer.suppressSubagentCompletion = true;
+      emitSubagentCompletion(writer, info('da-pragmatist'));
+      expect(committed).toHaveLength(0);
+    });
+
+    it('suppresses every concurrent sibling while the overlay is live (no double-render)', () => {
+      // The screenshot case: 3 parallel critics finishing on independent
+      // schedules. With the overlay live, NONE of the ✓ lines commit — the
+      // ToolLane tree is the sole completion record, so no interleaved
+      // commitAbove perturbs the frame geometry.
+      const { writer, committed } = makeWriter();
+      writer.suppressSubagentCompletion = true;
+      for (const id of ['da-paranoid', 'da-pragmatist', 'da-architect']) {
+        emitSubagentCompletion(writer, info(id));
+      }
+      expect(committed).toHaveLength(0);
+
+      // Once the turn ends and suppression clears, a late (backgrounded)
+      // completion surfaces again — Channel B is only muted, never removed.
+      writer.suppressSubagentCompletion = false;
+      emitSubagentCompletion(writer, info('bg-late'));
+      expect(committed).toHaveLength(1);
+      expect(stripAnsi(committed[0]!)).toContain('bg-late');
+    });
+
+    it('treats an undefined flag as not-suppressed (default behavior preserved)', () => {
+      const { writer, committed } = makeWriter();
+      expect(writer.suppressSubagentCompletion).toBeUndefined();
+      emitSubagentCompletion(writer, info('sa-default'));
+      expect(committed).toHaveLength(1);
     });
   });
 });

--- a/src/cli/commands/interactive/progress-banner.ts
+++ b/src/cli/commands/interactive/progress-banner.ts
@@ -1,5 +1,6 @@
 import type { SubagentCompleteInfo } from '../../../agent/default-hook-registry.js';
 import type { ProgressEvent } from '../../../agent/types.js';
+import type { CompletionWriter } from './shared.js';
 import { extractLatestThinkingClause } from '../../_lib/stream-renderer-subagent-helpers.js';
 import { truncateDisplayWidth } from '../../display.js';
 import { formatDuration, formatTokens } from '../../format-utils.js';
@@ -135,4 +136,31 @@ export function formatSubagentCompletion(info: SubagentCompleteInfo, columns?: n
   const parts = [icon, label];
   if (info.durationMs !== undefined) parts.push(`· ${formatDuration(info.durationMs)}`);
   return clampToTerminal(palette.dim(`  ${parts.join(' ')}`), columns);
+}
+
+/**
+ * Emit the REPL's SubagentStop completion line (Channel B) through the shared
+ * {@link CompletionWriter}, unless the writer has flagged it suppressed for the
+ * current foreground turn.
+ *
+ * History: the SubagentStop hook fires per subagent (any dispatch path —
+ * parallel `agent` calls, `compose`/DAG nodes, skill children), independently
+ * of the parent turn's SDK-event cadence. In the interactive REPL the ToolLane
+ * (Channel A) already renders each foreground subagent as a `→ Agent(…) Done`
+ * tree, so this compact line is a redundant SECOND representation — and because
+ * it lands via an uncoordinated `commitAbove` while the OverlayComposer is
+ * concurrently repainting a tall multi-root overlay, the two writers desync the
+ * compositor's frame row-accounting (stacked ghost `◉` markers + committed
+ * lines overwritten). Parallel dispatch (`compose`, devils-advocate) maximizes
+ * the interleaving because sibling nodes finish on independent schedules.
+ *
+ * `suppressSubagentCompletion` is bracketed by turn-handler around exactly the
+ * window a live overlay owns the surface, so between-turn background-job
+ * completions and the non-TTY one-shot `chat` surface (which uses its own
+ * console writer, not this callback) are unaffected. Extracted from the inline
+ * bootstrap closure so the gate is unit-testable — see progress-banner.test.ts.
+ */
+export function emitSubagentCompletion(writer: CompletionWriter, info: SubagentCompleteInfo): void {
+  if (writer.suppressSubagentCompletion) return;
+  writer.fn(formatSubagentCompletion(info));
 }

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -457,6 +457,23 @@ export interface InteractiveCtx {
 export interface CompletionWriter {
   fn: (line: string) => void;
   idleFn: (line: string) => void;
+  /**
+   * Turn-scoped guard: when true, the REPL's SubagentStop-hook completion
+   * line (`✓ <agentType> · <duration>` via {@link emitSubagentCompletion})
+   * is dropped because a foreground turn's live overlay owns subagent
+   * rendering — the ToolLane already commits the `→ Agent(…) Done` tree to
+   * scrollback (Channel A). Emitting the compact line here (Channel B) would
+   * double-render the node AND its uncoordinated `commitAbove` races the
+   * OverlayComposer's `setOverlay`, corrupting the compositor's frame
+   * row-accounting (ghost `◉` markers + swallowed committed lines).
+   *
+   * Set true by `turn-handler.ts`'s `armAndWire` (only when a compositor is
+   * armed — TTY) and reset false in its finally block, bracketing exactly the
+   * window where the overlay is live. Left false between turns and on non-TTY
+   * / one-shot `chat` (which uses its own console writer), so background-job
+   * completions and the `chat` surface still surface the line.
+   */
+  suppressSubagentCompletion?: boolean;
 }
 
 export interface TurnHandles {

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -194,6 +194,12 @@ export async function runTurn(
     if (completionWriter && armedCompositor) {
       const c = armedCompositor;
       completionWriter.fn = (line) => c.commitAbove(line);
+      // A live overlay now owns subagent rendering (the ToolLane commits the
+      // → Agent(…) Done tree). Suppress the redundant SubagentStop completion
+      // line so its uncoordinated commitAbove can't race the OverlayComposer
+      // and corrupt the compositor's row-accounting (ghost markers + swallowed
+      // committed lines). Reset in the finally below. See CompletionWriter.
+      completionWriter.suppressSubagentCompletion = true;
     }
     h.setActiveCompositor?.(armedCompositor);
     // Publish a notifier so the SIGINT handler can toggle the live
@@ -754,7 +760,14 @@ export async function runTurn(
     // For the legacy own-compositor / non-TTY path, `idleFn` stays
     // `console.log` (set at bootstrap and never mutated) — the reset
     // is identical to the old behavior.
-    if (completionWriter) completionWriter.fn = completionWriter.idleFn;
+    if (completionWriter) {
+      completionWriter.fn = completionWriter.idleFn;
+      // Turn over: the live overlay is gone, so a subagent that completes
+      // between turns (e.g. a backgrounded job) has no ToolLane tree and no
+      // overlay to race — let its completion line surface again. Pairs with
+      // the armAndWire set above.
+      completionWriter.suppressSubagentCompletion = false;
+    }
     // setActiveCompositor's "active turn" flag is still cleared. For
     // the legacy renderer-own-compositor path, the renderer just
     // disposed its compositor — the SIGINT handler must fall back to


### PR DESCRIPTION
## Symptom

In the REPL, parallel subagent work (`compose` / `devils-advocate`) shows content **swallowed / overlapped between the live compositor overlay and scrollback**: a finished node renders *twice* — once as the live `◉ → Agent(<node>) … Done` tree and once as a compact `✓ <node> · <time>` line — and stacked ghost `◉` markers pile up. (Reported from a devils-advocate run with `da-paranoid`/`da-pragmatist`/`da-architect`.)

## Root cause

A finished subagent is rendered through **two uncoordinated channels**:

- **Channel A** — the `ToolLane` overlay + scrollback `→ Agent(…) Done` tree, driven by the *parent turn's* SDK events (`tool_use`/`tool_result`/`message_stop`). Single-writer via `OverlayComposer.setOverlay`.
- **Channel B** — the **SubagentStop hook's** compact `✓ <agentType> · <duration>` line (`formatSubagentCompletion`, `progress-banner.ts`), driven by **each subagent's own lifecycle end**, written via an uncoordinated `completionWriter.fn` → `compositor.commitAbove`.

Under parallel dispatch, sibling subagents finish on independent schedules, so Channel B's `commitAbove` interleaves with Channel A's `setOverlay` mid-frame. Result: the node is double-rendered, and the compositor's frame row-accounting (`logUpdate.measure()`/`topRow`) can't reconcile a foreign single-line commit against a concurrently-repainted tall overlay — leaving ghost `◉` rows and overwriting ("swallowing") committed lines.

Channel B is a **chat-era signal** that predates the rich `ToolLane` subagent tree; it was never suppressed once the tree superseded it for foreground dispatches. (The one-shot `chat` surface has its own `console.log` wiring and is unaffected; background-job *adoption* uses a different message.)

## Fix

Gate Channel B behind a turn-scoped `CompletionWriter.suppressSubagentCompletion` flag, bracketed by `turn-handler`'s `armAndWire` (set true when a compositor is armed) and its finally block (reset false). The `✓ <node>` line is muted **only while a foreground turn's live overlay owns subagent rendering** — where the `ToolLane` already commits the `→ Agent(…) Done` tree. Between turns (e.g. backgrounded-job completions) and on non-TTY `chat`, the line still surfaces.

The gate is extracted into a unit-testable `emitSubagentCompletion()` with a documented invariant.

## Testing

- `pnpm lint` clean.
- New regression tests in `progress-banner.test.ts` cover the **concurrent-siblings** case (previously uncovered — existing `subagent-gap` repros are strictly sequential): suppressed while overlay live → no emit for any sibling; unsuppressed between turns → late/background completion surfaces; undefined flag → default (emit).
- Full suite green locally (rebased onto `main` @ v5.20.0).

## Out of scope

The header-count vs `Done`-count mismatch (`5 tools` header vs `Done (10 tools …)`) is a **separate, documented** artifact — a mid-flight snapshot in `formatAgentSummary` (`subagent-block-gap.repro.test.ts` annotates it "STALE count (mid-flight capture)"). Not addressed here.
