### PR TITLE
models: bound default-sonnet cost via auto-compaction budget (keep truthful 1M); split openai-compatible/query.ts

### DIFF
--- a/src/agent/model-limits.test.ts
+++ b/src/agent/model-limits.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Tests for autoCompactLimitFor — the per-model auto-compaction working budget.
+ *
+ * Base `sonnet` has a truthful 1M window (see MODEL_CONTEXT_LIMITS) but is
+ * capped at a 200k compaction budget so long default sessions compact early for
+ * cost/latency. The `sonnet_1m` opt-in and every non-sonnet model use their
+ * full context window. See src/agent/model-limits.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { autoCompactLimitFor, contextLimitFor } from './model-limits.js';
+
+describe('autoCompactLimitFor', () => {
+  it('caps the default sonnet alias at the 200k working budget (not its 1M window)', () => {
+    // The window is truthfully 1M; only the compaction trigger is reduced.
+    expect(contextLimitFor('sonnet')).toBe(1_000_000);
+    expect(autoCompactLimitFor('sonnet')).toBe(200_000);
+  });
+
+  it('caps the claude-sonnet-5 wire id at 200k (requestedModel may be the wire id)', () => {
+    expect(autoCompactLimitFor('claude-sonnet-5')).toBe(200_000);
+  });
+
+  it('the sonnet_1m opt-in bypasses the budget and uses the full 1M window', () => {
+    expect(autoCompactLimitFor('sonnet_1m')).toBe(1_000_000);
+  });
+
+  it('leaves opus / opus_1m / haiku / fable at their full window (no budget)', () => {
+    expect(autoCompactLimitFor('opus')).toBe(200_000);
+    expect(autoCompactLimitFor('opus_1m')).toBe(1_000_000);
+    expect(autoCompactLimitFor('haiku')).toBe(200_000);
+    expect(autoCompactLimitFor('fable')).toBe(1_000_000);
+    expect(autoCompactLimitFor('claude-fable-5')).toBe(1_000_000);
+  });
+
+  it('falls back to the model window for unknown / openai-compatible models', () => {
+    expect(autoCompactLimitFor('gpt-4.1')).toBe(1_000_000);
+    expect(autoCompactLimitFor('claude-xyz' as unknown as 'opus')).toBe(200_000);
+    expect(autoCompactLimitFor('mlx-community/qwen3-32b-4bit')).toBe(128_000);
+  });
+});

--- a/src/agent/model-limits.ts
+++ b/src/agent/model-limits.ts
@@ -85,21 +85,21 @@ export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   // Claude aliases
   opus: 200_000,
   opus_1m: 1_000_000,
-  // Base `sonnet` uses the standard 200k Claude window; `sonnet_1m` is the
-  // explicit 1M opt-in (parallel to opus/opus_1m). Both resolve to the same
-  // `claude-sonnet-5` wire id — the `_1m` suffix only widens the client-side
-  // context accounting (status-line % + the auto-compaction trigger point).
-  sonnet: 200_000,
+  // Sonnet 5 ships a 1M-token context window natively (like Fable 5) — no beta
+  // header required: per Anthropic's docs 1M is both the default and the maximum,
+  // with no smaller variant. The `sonnet` alias, the `sonnet_1m` alias, and the
+  // `claude-sonnet-5` wire id all report the full 1M window. Base `sonnet` still
+  // auto-compacts early for cost/latency (see MODEL_AUTOCOMPACT_BUDGET /
+  // autoCompactLimitFor below) — that is a compaction policy, NOT a smaller window.
+  sonnet: 1_000_000,
   sonnet_1m: 1_000_000,
   haiku: 200_000,
-  // Native 1M-context models (no `_1m` opt-in, unlike opus/sonnet/haiku whose
-  // base window is 200k). Keyed by both the short alias (where one exists) and
-  // the wire id so lookups hit either side of the alias boundary.
+  // Native 1M-context models (no `_1m` opt-in, unlike opus/haiku whose base
+  // window is 200k). Keyed by both the short alias (where one exists) and the
+  // wire id so lookups hit either side of the alias boundary.
   fable: 1_000_000,
   'claude-fable-5': 1_000_000,
-  // Sonnet 5's base wire id sits at the standard 200k; the 1M opt-in is the
-  // `sonnet_1m` alias above (which short-circuits before this lookup).
-  'claude-sonnet-5': 200_000,
+  'claude-sonnet-5': 1_000_000,
   // OpenAI flagship + cost-tier models (windows per OpenAI platform docs
   // as of 2026-Q1). Listed here so the openai-compatible provider's
   // getContextUsage() returns an accurate percentage instead of the
@@ -174,4 +174,39 @@ export function contextLimitFor(model: ClaudeModel | string): number {
   return routesToOpenAICompatible(id)
     ? DEFAULT_CONTEXT_LIMIT_OPENAI_COMPATIBLE
     : DEFAULT_CONTEXT_LIMIT;
+}
+
+/**
+ * Per-model auto-compaction working budget (absolute tokens).
+ *
+ * Sonnet 5 ships a truthful 1M window, but resending the whole conversation
+ * prefix every turn on a long DEFAULT session is slow and expensive. So base
+ * `sonnet` triggers auto-compaction around a smaller working budget rather than
+ * at `threshold × 1M`. This is a deliberate cost/latency policy, NOT a claim
+ * about the window (`MODEL_CONTEXT_LIMITS` stays truthful at 1M): the full
+ * window is one `sonnet_1m` away (the `_1m` opt-in bypasses the budget), or the
+ * user can raise the `autoCompact` threshold. Keyed by the resolved wire id so
+ * both the `sonnet` alias and a literal `claude-sonnet-5` requestedModel hit it.
+ */
+const MODEL_AUTOCOMPACT_BUDGET: Record<string, number> = {
+  'claude-sonnet-5': 200_000,
+};
+
+/**
+ * Token limit at which auto-compaction should trigger for a model: its context
+ * window, capped by its {@link MODEL_AUTOCOMPACT_BUDGET} entry when one exists.
+ * Used ONLY by the turn loop's auto-compaction check — the status-line /
+ * percentage path uses {@link contextLimitFor} (the true window). Mirrors
+ * `contextLimitFor`'s alias handling: an explicit `*_1m` opt-in always uses the
+ * full window, never the reduced budget. Models with no budget entry return
+ * their full window (identical to the pre-budget behavior).
+ */
+export function autoCompactLimitFor(model: ClaudeModel | string): number {
+  const window = contextLimitFor(model);
+  const lowered = String(model).trim().toLowerCase();
+  // Explicit *_1m opt-in → full window, never the reduced default budget.
+  if (lowered.endsWith('_1m')) return window;
+  const id = resolveModelInput(model) ?? String(model);
+  const budget = MODEL_AUTOCOMPACT_BUDGET[id] ?? MODEL_AUTOCOMPACT_BUDGET[id.toLowerCase()];
+  return budget !== undefined ? Math.min(window, budget) : window;
 }

--- a/src/agent/model-limits.ts
+++ b/src/agent/model-limits.ts
@@ -85,18 +85,21 @@ export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   // Claude aliases
   opus: 200_000,
   opus_1m: 1_000_000,
-  // Sonnet 5 ships a 1M-token context window natively (like Fable 5, unlike
-  // opus/haiku whose base window is 200k). The `sonnet` alias, the now-redundant
-  // `sonnet_1m` back-compat alias, and the `claude-sonnet-5` wire id all report 1M.
-  sonnet: 1_000_000,
+  // Base `sonnet` uses the standard 200k Claude window; `sonnet_1m` is the
+  // explicit 1M opt-in (parallel to opus/opus_1m). Both resolve to the same
+  // `claude-sonnet-5` wire id — the `_1m` suffix only widens the client-side
+  // context accounting (status-line % + the auto-compaction trigger point).
+  sonnet: 200_000,
   sonnet_1m: 1_000_000,
   haiku: 200_000,
-  // Native 1M-context models (no `_1m` opt-in, unlike opus/haiku whose base
-  // window is 200k). Keyed by both the short alias (where one exists) and the
-  // wire id so lookups hit either side of the alias boundary.
+  // Native 1M-context models (no `_1m` opt-in, unlike opus/sonnet/haiku whose
+  // base window is 200k). Keyed by both the short alias (where one exists) and
+  // the wire id so lookups hit either side of the alias boundary.
   fable: 1_000_000,
   'claude-fable-5': 1_000_000,
-  'claude-sonnet-5': 1_000_000,
+  // Sonnet 5's base wire id sits at the standard 200k; the 1M opt-in is the
+  // `sonnet_1m` alias above (which short-circuits before this lookup).
+  'claude-sonnet-5': 200_000,
   // OpenAI flagship + cost-tier models (windows per OpenAI platform docs
   // as of 2026-Q1). Listed here so the openai-compatible provider's
   // getContextUsage() returns an accurate percentage instead of the

--- a/src/agent/providers/anthropic-direct/compact.test.ts
+++ b/src/agent/providers/anthropic-direct/compact.test.ts
@@ -245,7 +245,8 @@ async function* fromArr<T>(arr: T[]): AsyncIterable<T> {
 /**
  * Build a minimal streaming event sequence that reports `inputTokens` high
  * enough to cross the 90% auto-compaction threshold. The integration tests run
- * on `claude-sonnet-5`, whose base context window is 200k, so cross 90% of 200k:
+ * on `claude-sonnet-5`: its context window is 1M, but the DEFAULT auto-compaction
+ * *budget* is 200k (see autoCompactLimitFor), so cross 90% of the 200k budget:
  * 200_000 * 0.90 = 180_000 — use 181_000 to be safely above.
  */
 function makeHighUsageStream(): RawMessageStreamEvent[] {

--- a/src/agent/providers/anthropic-direct/compact.test.ts
+++ b/src/agent/providers/anthropic-direct/compact.test.ts
@@ -245,8 +245,8 @@ async function* fromArr<T>(arr: T[]): AsyncIterable<T> {
 /**
  * Build a minimal streaming event sequence that reports `inputTokens` high
  * enough to cross the 90% auto-compaction threshold. The integration tests run
- * on `claude-sonnet-5`, whose context window is 1M, so cross 90% of 1M:
- * 1_000_000 * 0.90 = 900_000 — use 901_000 to be safely above.
+ * on `claude-sonnet-5`, whose base context window is 200k, so cross 90% of 200k:
+ * 200_000 * 0.90 = 180_000 — use 181_000 to be safely above.
  */
 function makeHighUsageStream(): RawMessageStreamEvent[] {
   return [
@@ -261,7 +261,7 @@ function makeHighUsageStream(): RawMessageStreamEvent[] {
         stop_reason: null,
         stop_sequence: null,
         usage: {
-          input_tokens: 901_000,
+          input_tokens: 181_000,
           output_tokens: 0,
           cache_creation_input_tokens: 0,
           cache_read_input_tokens: 0,

--- a/src/agent/providers/anthropic-direct/context-limit-1m.test.ts
+++ b/src/agent/providers/anthropic-direct/context-limit-1m.test.ts
@@ -74,17 +74,20 @@ describe('getContextUsage — 1M-context aliases', () => {
     expect(usage.maxTokens).toBe(200_000);
   });
 
-  it('reports the 200k base window for sonnet (1M is the sonnet_1m opt-in)', async () => {
+  it('reports the true 1M window for base sonnet (Sonnet 5 is natively 1M)', async () => {
+    // getContextUsage reports the model's real window. Base `sonnet` compacts
+    // early via a working budget (see autoCompactLimitFor), but the status-line
+    // window it reports here is the full 1M.
     const query = makeQuery({ model: 'claude-sonnet-5', requestedModel: 'sonnet' });
     const usage = await query.getContextUsage();
-    expect(usage.maxTokens).toBe(200_000);
+    expect(usage.maxTokens).toBe(1_000_000);
   });
 
-  it('setModel preserves the alias: switching to sonnet_1m widens the window', async () => {
-    const query = makeQuery({ model: 'claude-sonnet-5', requestedModel: 'sonnet' });
+  it('setModel preserves the alias: switching to opus_1m widens the window', async () => {
+    const query = makeQuery({ model: 'claude-opus-4-8', requestedModel: 'opus' });
     expect((await query.getContextUsage()).maxTokens).toBe(200_000);
 
-    await query.setModel('sonnet_1m');
+    await query.setModel('opus_1m');
     expect((await query.getContextUsage()).maxTokens).toBe(1_000_000);
   });
 

--- a/src/agent/providers/anthropic-direct/context-limit-1m.test.ts
+++ b/src/agent/providers/anthropic-direct/context-limit-1m.test.ts
@@ -74,17 +74,17 @@ describe('getContextUsage — 1M-context aliases', () => {
     expect(usage.maxTokens).toBe(200_000);
   });
 
-  it('reports the 1M window for sonnet (Sonnet 5 is natively 1M, no _1m opt-in)', async () => {
+  it('reports the 200k base window for sonnet (1M is the sonnet_1m opt-in)', async () => {
     const query = makeQuery({ model: 'claude-sonnet-5', requestedModel: 'sonnet' });
     const usage = await query.getContextUsage();
-    expect(usage.maxTokens).toBe(1_000_000);
+    expect(usage.maxTokens).toBe(200_000);
   });
 
-  it('setModel preserves the alias: switching to opus_1m widens the window', async () => {
-    const query = makeQuery({ model: 'claude-opus-4-8', requestedModel: 'opus' });
+  it('setModel preserves the alias: switching to sonnet_1m widens the window', async () => {
+    const query = makeQuery({ model: 'claude-sonnet-5', requestedModel: 'sonnet' });
     expect((await query.getContextUsage()).maxTokens).toBe(200_000);
 
-    await query.setModel('opus_1m');
+    await query.setModel('sonnet_1m');
     expect((await query.getContextUsage()).maxTokens).toBe(1_000_000);
   });
 

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -55,7 +55,7 @@ import {
 import { buildPlanModeAddendumBlock } from './plan-mode-addendum.js';
 import { buildAfkModeAddendumBlock } from './afk-mode-addendum.js';
 import { collectSupportedCommands } from '../shared/supported-commands.js';
-import { contextLimitFor } from '../../model-limits.js';
+import { contextLimitFor, autoCompactLimitFor } from '../../model-limits.js';
 import { resolveModelId } from '../../session/model-resolution.js';
 import type { ToolDispatcher } from './tool-dispatcher.js';
 import type {
@@ -477,16 +477,19 @@ export class AnthropicDirectQuery implements ProviderQuery {
           const usage = this.state.lastUsage;
           // requestedModel (not the wire currentModel) so 1M aliases use their
           // true window — opus_1m resolves to the same wire id as opus but must
-          // compact at ~90% of 1M, not 200k.
-          const contextLimit = contextLimitFor(this.state.requestedModel);
-          if (usage !== null && contextLimit > 0) {
+          // compact at ~90% of 1M, not 200k. autoCompactLimitFor additionally
+          // caps the DEFAULT `sonnet` at a 200k working budget: its 1M window is
+          // truthful, but base sessions compact early for cost/latency, while the
+          // `sonnet_1m` opt-in bypasses the cap. See model-limits.ts.
+          const compactionLimit = autoCompactLimitFor(this.state.requestedModel);
+          if (usage !== null && compactionLimit > 0) {
             // Use the context-window footprint (input + cache_read +
             // cache_creation + output for the last round), NOT input+output
             // alone — Anthropic's input_tokens excludes cache, so the cached
             // conversation prefix (often the bulk of the window) must be
             // counted or compaction never fires before the window overflows.
             const usedTokens = contextWindowTokensUsed(usage);
-            if (shouldAutoCompact(usedTokens, contextLimit, this.state.autoCompactThreshold)) {
+            if (shouldAutoCompact(usedTokens, compactionLimit, this.state.autoCompactThreshold)) {
               // Fire-and-await: compact() is async but we hold the turn
               // boundary here (generator suspended at promptIterator.next()
               // on the next iteration). Awaiting inline keeps the ordering

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -26,7 +26,6 @@
 import OpenAI from 'openai';
 import { randomUUID } from 'node:crypto';
 import type { AgentConfig } from '../../types/config-types.js';
-import type { EffortLevel } from '../../types/sdk-types.js';
 import { emitToolCall, emitSessionPhase } from '../../trace/emit.js';
 import { pathContainmentBypassed } from '../../permission-policy.js';
 import type { TraceWriter } from '../../trace/index.js';
@@ -45,7 +44,7 @@ import type {
   ProviderUsage,
 } from '../../provider.js';
 import { sumProviderUsage } from '../../usage.js';
-import { contextLimitFor, maxOutputTokensFor } from '../../model-limits.js';
+import { contextLimitFor } from '../../model-limits.js';
 import { resolveModelId } from '../../session/model-resolution.js';
 import { extractRawToolInput } from '../../facets/raw-input.js';
 import { collectSupportedCommands } from '../shared/supported-commands.js';
@@ -86,6 +85,28 @@ import { PLAN_MODE_ADDENDUM_TEXT } from '../shared/plan-mode-addendum.js';
 import { AFK_MODE_ADDENDUM_TEXT } from '../shared/afk-mode-addendum.js';
 import { sleepWithAbort } from '../shared/sleep-with-abort.js';
 import { summarizeToolInput } from '../shared/tool-input-summary.js';
+import {
+  MAX_CONNECTION_RETRIES,
+  MAX_STREAM_RETRIES,
+  isRetryableConnectionError,
+  isRetryableStreamError,
+  computeBackoffDelay,
+} from './query/retry.js';
+import {
+  resolveEffectiveMaxOutputTokens,
+  resolveStreamingMaxTokens,
+  normalizePermissionMode,
+  resolveReasoningEffort,
+} from './query/model-params.js';
+import { resolveClientFactory } from './query/client.js';
+
+// Re-exported from the extracted query/ submodules so existing import sites
+// (sibling tests + index.ts) keep resolving these from './query.js'.
+export { __setRetryBaseDelay } from './query/retry.js';
+export { __setOpenAIClientFactory } from './query/client.js';
+export type { OpenAIClientFactory } from './query/client.js';
+export { isOSeriesModel, mapEffortForOpenAI } from './query/model-params.js';
+export { resolveReasoningEffort };
 
 const PROVIDER_NAME = 'openai-compatible';
 
@@ -96,137 +117,6 @@ const PROVIDER_NAME = 'openai-compatible';
  * two providers behave identically on this edge case.
  */
 const MAX_TOOL_ITERATIONS = 50;
-
-// ── Retry / backoff constants ──────────────────────────────────────────────
-// Mirrors the Anthropic provider's connection-phase + mid-stream retry pattern
-// (see `anthropic-direct/loop.ts:createWithRetry` and the overload-retry block
-// in `runTurn`). The Anthropic `RetryLayer` class is too coupled to OAuth /
-// keychain hot-swap to share; the core retry pattern (bounded exponential
-// backoff on retryable HTTP status codes) is simple enough to implement here
-// directly. See issue #126.
-
-/**
- * HTTP status codes that warrant a retry with backoff. 429 (rate limit) and
- * 5xx server errors are transient by nature — the same request sent again
- * after a short wait is likely to succeed. 400/401/403/404 are deterministic
- * client errors and must NOT be retried (they would just burn quota).
- */
-const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 529]);
-
-/** Max connection-phase retries per iteration (matches Anthropic's budget). */
-const MAX_CONNECTION_RETRIES = 3;
-
-/** Max mid-stream retries per iteration (matches Anthropic's OVERLOAD_MAX_RETRIES). */
-const MAX_STREAM_RETRIES = 3;
-
-/** Base delay for exponential backoff: 2s → 4s → 8s (shorter than Anthropic's 5s because OpenAI-compatible shims are often local). */
-let RETRY_BASE_DELAY_MS = 2_000;
-
-/**
- * Test injection hook for retry base delay. Set to 0 in tests to avoid real
- * waits. Pass `null` to restore the production default (2000ms).
- */
-export function __setRetryBaseDelay(ms: number | null): void {
-  RETRY_BASE_DELAY_MS = ms ?? 2_000;
-}
-
-/**
- * Extract an HTTP status code from an error thrown by the OpenAI SDK (or a
- * compatible shim). The SDK throws `APIError` instances with a `status` field;
- * network errors and generic throws have no status and are treated as
- * retryable (transient network blip) only when they carry no explicit code.
- */
-function getErrorStatus(err: unknown): number | undefined {
-  if (err === null || typeof err !== 'object') return undefined;
-  const e = err as { status?: unknown };
-  return typeof e.status === 'number' ? e.status : undefined;
-}
-
-/**
- * Connection-phase retryability: the HTTP call itself failed before any
- * streaming began. Only retry on known transient status codes — errors with
- * no status (network drops, DNS failures, wrong baseURL) are deterministic
- * and must surface immediately to avoid wasting time on misconfigurations.
- * Mirrors the Anthropic provider's `isTransientServerError` which also
- * requires an explicit status.
- */
-function isRetryableConnectionError(err: unknown): boolean {
-  const status = getErrorStatus(err);
-  if (status === undefined) return false;
-  return RETRYABLE_STATUS_CODES.has(status);
-}
-
-/**
- * Mid-stream retryability: the stream was established but the server sent an
- * error event mid-flight. OpenAI-compatible APIs surface this as an `APIError`
- * thrown from the async iterator. Same status-code set as connection-phase —
- * only retry on explicit transient codes, not on status-less errors.
- */
-function isRetryableStreamError(err: unknown): boolean {
-  const status = getErrorStatus(err);
-  if (status === undefined) return false;
-  return RETRYABLE_STATUS_CODES.has(status);
-}
-
-/**
- * Test injection hook for the OpenAI client. Set to a factory to swap in a
- * mock client; pass `null` to restore the real constructor. Not part of the
- * stable surface — tests reach into this module directly.
- */
-export type OpenAIClientFactory = (opts: {
-  apiKey: string;
-  baseURL?: string;
-  defaultHeaders?: Record<string, string>;
-}) => OpenAI;
-let clientFactory: OpenAIClientFactory | null = null;
-export function __setOpenAIClientFactory(factory: OpenAIClientFactory | null): void {
-  clientFactory = factory;
-}
-
-/**
- * Resolve the effective output-token cap (a plain number).
- *
- * Honours `config.maxOutputTokens` when finite+positive, otherwise falls back
- * to the model's output ceiling (matching Anthropic's resolveMaxTokens).  Uses
- * maxOutputTokensFor (output ceiling), not contextLimitFor (context window),
- * because the cap bounds *output*, not the full context window.
- *
- * Field-name selection (`max_tokens` vs `max_completion_tokens` vs
- * `max_output_tokens`) is the caller's concern — it differs by wire mode:
- * Chat Completions uses {@link resolveStreamingMaxTokens}; the Responses API
- * uses `max_output_tokens` directly.
- */
-function resolveEffectiveMaxOutputTokens(
-  model: string,
-  configMaxOutput: number | undefined,
-): number {
-  const ceiling = maxOutputTokensFor(model);
-  return typeof configMaxOutput === 'number' && Number.isFinite(configMaxOutput) && configMaxOutput > 0
-    ? Math.floor(configMaxOutput)
-    : ceiling;
-}
-
-/**
- * Resolve the **Chat Completions** streaming output-token cap.
- *
- * Mirrors the o-series field-selection logic in `oneshot.ts:91–96`:
- * o-series reasoning models (o1/o3/o4…) reject `max_tokens` and require
- * `max_completion_tokens`; everything else (chat models, local shims)
- * wants `max_tokens`.  (The Responses API is different again — it uses
- * `max_output_tokens` — so this helper is Chat-Completions-only.)
- *
- * Always returns an object containing the resolved cap; uses the model's
- * output ceiling as a fallback so the field is always present on the wire.
- */
-function resolveStreamingMaxTokens(
-  model: string,
-  configMaxOutput: number | undefined,
-): Record<string, number> {
-  const effectiveMax = resolveEffectiveMaxOutputTokens(model, configMaxOutput);
-  return isOSeriesModel(model)
-    ? { max_completion_tokens: effectiveMax }
-    : { max_tokens: effectiveMax };
-}
 
 /** Construction options. */
 export interface OpenAICompatibleQueryOptions {
@@ -275,53 +165,6 @@ export interface OpenAICompatibleQueryOptions {
    * stalls or crashes the session.
    */
   traceWriter?: TraceWriter;
-}
-
-function normalizePermissionMode(mode: string | undefined): string {
-  return mode ?? 'default';
-}
-
-/**
- * Detect OpenAI o-series reasoning models (o1, o3, o4, and their variants).
- * Strips any `provider/` prefix (OpenRouter-style ids) before matching.
- * Mirrors the detection in `oneshot.ts` for the `max_completion_tokens` switch.
- */
-export function isOSeriesModel(model: string): boolean {
-  const bareModel = model.includes('/') ? model.slice(model.lastIndexOf('/') + 1) : model;
-  return /^o[0-9]/.test(bareModel);
-}
-
-/**
- * Map AFK's `EffortLevel` to OpenAI's `reasoning_effort` values.
- * OpenAI accepts `low`, `medium`, `high`. AFK's `xhigh` and `max` are
- * Anthropic-specific and map to `high` for OpenAI.
- */
-export function mapEffortForOpenAI(effort: EffortLevel): 'low' | 'medium' | 'high' {
-  switch (effort) {
-    case 'low':
-      return 'low';
-    case 'medium':
-      return 'medium';
-    case 'high':
-    case 'xhigh':
-    case 'max':
-      return 'high';
-  }
-}
-
-/**
- * Resolve the `reasoning_effort` to send for a given model + effort config.
- * Returns `undefined` when effort should not be forwarded (non-o-series model
- * or no effort configured). Callers attach the result to the request body
- * under `reasoning_effort` (Chat Completions) or `reasoning.effort` (Responses).
- */
-export function resolveReasoningEffort(
-  effort: EffortLevel | undefined,
-  model: string,
-): 'low' | 'medium' | 'high' | undefined {
-  if (effort === undefined) return undefined;
-  if (!isOSeriesModel(model)) return undefined;
-  return mapEffortForOpenAI(effort);
 }
 
 /** Internal record used to drive the per-turn iteration loop. */
@@ -401,7 +244,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     if (opts.auth.apiKey === null) {
       this.client = null as unknown as OpenAI;
     } else {
-      const ctor = clientFactory ?? defaultClientFactory;
+      const ctor = resolveClientFactory();
       const clientOpts: { apiKey: string; baseURL?: string; defaultHeaders?: Record<string, string> } = {
         apiKey: opts.auth.apiKey,
       };
@@ -832,7 +675,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
           } catch (err) {
             if (controller.signal.aborted) return null;
             if (isRetryableConnectionError(err) && attempt < MAX_CONNECTION_RETRIES) {
-              const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+              const delay = computeBackoffDelay(attempt);
               await sleepWithAbort(delay, controller.signal);
               if (controller.signal.aborted) return null;
               continue;
@@ -875,7 +718,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
             streamRetries++;
             yield { type: 'stream.retry', sessionId: this.initSessionId };
             await sleepWithAbort(
-              RETRY_BASE_DELAY_MS * Math.pow(2, streamRetries - 1),
+              computeBackoffDelay(streamRetries - 1),
               controller.signal,
             );
             if (controller.signal.aborted) return null;
@@ -946,7 +789,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
           } catch (err) {
             if (controller.signal.aborted) return null;
             if (isRetryableConnectionError(err) && attempt < MAX_CONNECTION_RETRIES) {
-              const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+              const delay = computeBackoffDelay(attempt);
               await sleepWithAbort(delay, controller.signal);
               if (controller.signal.aborted) return null;
               continue;
@@ -990,7 +833,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
             streamRetries++;
             yield { type: 'stream.retry', sessionId: this.initSessionId };
             await sleepWithAbort(
-              RETRY_BASE_DELAY_MS * Math.pow(2, streamRetries - 1),
+              computeBackoffDelay(streamRetries - 1),
               controller.signal,
             );
             if (controller.signal.aborted) return null;
@@ -1333,17 +1176,6 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     this.closeResolve?.();
     debugLog(`🟢 ${PROVIDER_NAME}: closed`);
   }
-}
-
-function defaultClientFactory(opts: {
-  apiKey: string;
-  baseURL?: string;
-  defaultHeaders?: Record<string, string>;
-}): OpenAI {
-  const clientOpts: ConstructorParameters<typeof OpenAI>[0] = { apiKey: opts.apiKey };
-  if (opts.baseURL !== undefined) clientOpts.baseURL = opts.baseURL;
-  if (opts.defaultHeaders !== undefined) clientOpts.defaultHeaders = opts.defaultHeaders;
-  return new OpenAI(clientOpts);
 }
 
 /**

--- a/src/agent/providers/openai-compatible/query/client.ts
+++ b/src/agent/providers/openai-compatible/query/client.ts
@@ -1,0 +1,47 @@
+/**
+ * OpenAI client construction for the openai-compatible provider, plus the
+ * test-injection factory hook. Extracted from `query.ts` so the query module
+ * carries only the session class and its turn loop.
+ *
+ * @module agent/providers/openai-compatible/query/client
+ */
+
+import OpenAI from 'openai';
+
+/**
+ * Test injection hook for the OpenAI client. Set to a factory to swap in a
+ * mock client; pass `null` to restore the real constructor. Not part of the
+ * stable surface — tests reach into this module (re-exported via `query.ts`)
+ * directly.
+ */
+export type OpenAIClientFactory = (opts: {
+  apiKey: string;
+  baseURL?: string;
+  defaultHeaders?: Record<string, string>;
+}) => OpenAI;
+
+let clientFactory: OpenAIClientFactory | null = null;
+
+export function __setOpenAIClientFactory(factory: OpenAIClientFactory | null): void {
+  clientFactory = factory;
+}
+
+function defaultClientFactory(opts: {
+  apiKey: string;
+  baseURL?: string;
+  defaultHeaders?: Record<string, string>;
+}): OpenAI {
+  const clientOpts: ConstructorParameters<typeof OpenAI>[0] = { apiKey: opts.apiKey };
+  if (opts.baseURL !== undefined) clientOpts.baseURL = opts.baseURL;
+  if (opts.defaultHeaders !== undefined) clientOpts.defaultHeaders = opts.defaultHeaders;
+  return new OpenAI(clientOpts);
+}
+
+/**
+ * Return the active client factory: the test-injected one when set, else the
+ * real `new OpenAI(...)` constructor. Encapsulates the mutable injection state
+ * so callers never read the module global directly.
+ */
+export function resolveClientFactory(): OpenAIClientFactory {
+  return clientFactory ?? defaultClientFactory;
+}

--- a/src/agent/providers/openai-compatible/query/model-params.ts
+++ b/src/agent/providers/openai-compatible/query/model-params.ts
@@ -1,0 +1,103 @@
+/**
+ * Model-shape parameter helpers for the openai-compatible provider: output-
+ * token cap resolution, o-series detection, and effort→reasoning_effort
+ * mapping. Pure functions extracted from `query.ts` so the query module
+ * carries only the session class and its turn loop.
+ *
+ * @module agent/providers/openai-compatible/query/model-params
+ */
+
+import type { EffortLevel } from '../../../types/sdk-types.js';
+import { maxOutputTokensFor } from '../../../model-limits.js';
+
+/**
+ * Resolve the effective output-token cap (a plain number).
+ *
+ * Honours `config.maxOutputTokens` when finite+positive, otherwise falls back
+ * to the model's output ceiling (matching Anthropic's resolveMaxTokens).  Uses
+ * maxOutputTokensFor (output ceiling), not contextLimitFor (context window),
+ * because the cap bounds *output*, not the full context window.
+ *
+ * Field-name selection (`max_tokens` vs `max_completion_tokens` vs
+ * `max_output_tokens`) is the caller's concern — it differs by wire mode:
+ * Chat Completions uses {@link resolveStreamingMaxTokens}; the Responses API
+ * uses `max_output_tokens` directly.
+ */
+export function resolveEffectiveMaxOutputTokens(
+  model: string,
+  configMaxOutput: number | undefined,
+): number {
+  const ceiling = maxOutputTokensFor(model);
+  return typeof configMaxOutput === 'number' && Number.isFinite(configMaxOutput) && configMaxOutput > 0
+    ? Math.floor(configMaxOutput)
+    : ceiling;
+}
+
+/**
+ * Resolve the **Chat Completions** streaming output-token cap.
+ *
+ * Mirrors the o-series field-selection logic in `oneshot.ts:91–96`:
+ * o-series reasoning models (o1/o3/o4…) reject `max_tokens` and require
+ * `max_completion_tokens`; everything else (chat models, local shims)
+ * wants `max_tokens`.  (The Responses API is different again — it uses
+ * `max_output_tokens` — so this helper is Chat-Completions-only.)
+ *
+ * Always returns an object containing the resolved cap; uses the model's
+ * output ceiling as a fallback so the field is always present on the wire.
+ */
+export function resolveStreamingMaxTokens(
+  model: string,
+  configMaxOutput: number | undefined,
+): Record<string, number> {
+  const effectiveMax = resolveEffectiveMaxOutputTokens(model, configMaxOutput);
+  return isOSeriesModel(model)
+    ? { max_completion_tokens: effectiveMax }
+    : { max_tokens: effectiveMax };
+}
+
+export function normalizePermissionMode(mode: string | undefined): string {
+  return mode ?? 'default';
+}
+
+/**
+ * Detect OpenAI o-series reasoning models (o1, o3, o4, and their variants).
+ * Strips any `provider/` prefix (OpenRouter-style ids) before matching.
+ * Mirrors the detection in `oneshot.ts` for the `max_completion_tokens` switch.
+ */
+export function isOSeriesModel(model: string): boolean {
+  const bareModel = model.includes('/') ? model.slice(model.lastIndexOf('/') + 1) : model;
+  return /^o[0-9]/.test(bareModel);
+}
+
+/**
+ * Map AFK's `EffortLevel` to OpenAI's `reasoning_effort` values.
+ * OpenAI accepts `low`, `medium`, `high`. AFK's `xhigh` and `max` are
+ * Anthropic-specific and map to `high` for OpenAI.
+ */
+export function mapEffortForOpenAI(effort: EffortLevel): 'low' | 'medium' | 'high' {
+  switch (effort) {
+    case 'low':
+      return 'low';
+    case 'medium':
+      return 'medium';
+    case 'high':
+    case 'xhigh':
+    case 'max':
+      return 'high';
+  }
+}
+
+/**
+ * Resolve the `reasoning_effort` to send for a given model + effort config.
+ * Returns `undefined` when effort should not be forwarded (non-o-series model
+ * or no effort configured). Callers attach the result to the request body
+ * under `reasoning_effort` (Chat Completions) or `reasoning.effort` (Responses).
+ */
+export function resolveReasoningEffort(
+  effort: EffortLevel | undefined,
+  model: string,
+): 'low' | 'medium' | 'high' | undefined {
+  if (effort === undefined) return undefined;
+  if (!isOSeriesModel(model)) return undefined;
+  return mapEffortForOpenAI(effort);
+}

--- a/src/agent/providers/openai-compatible/query/retry.ts
+++ b/src/agent/providers/openai-compatible/query/retry.ts
@@ -1,0 +1,88 @@
+/**
+ * Connection-phase + mid-stream retry helpers for the openai-compatible
+ * provider's turn loop.
+ *
+ * Mirrors the Anthropic provider's connection-phase + mid-stream retry pattern
+ * (see `anthropic-direct/loop.ts:createWithRetry` and the overload-retry block
+ * in `runTurn`). The Anthropic `RetryLayer` class is too coupled to OAuth /
+ * keychain hot-swap to share; the core retry pattern (bounded exponential
+ * backoff on retryable HTTP status codes) is simple enough to implement here
+ * directly. See issue #126.
+ *
+ * Extracted from `query.ts` so the query module carries only the session class
+ * and its turn loop; the retryability predicates + backoff schedule live here.
+ *
+ * @module agent/providers/openai-compatible/query/retry
+ */
+
+/**
+ * HTTP status codes that warrant a retry with backoff. 429 (rate limit) and
+ * 5xx server errors are transient by nature — the same request sent again
+ * after a short wait is likely to succeed. 400/401/403/404 are deterministic
+ * client errors and must NOT be retried (they would just burn quota).
+ */
+const RETRYABLE_STATUS_CODES = new Set([429, 500, 502, 503, 529]);
+
+/** Max connection-phase retries per iteration (matches Anthropic's budget). */
+export const MAX_CONNECTION_RETRIES = 3;
+
+/** Max mid-stream retries per iteration (matches Anthropic's OVERLOAD_MAX_RETRIES). */
+export const MAX_STREAM_RETRIES = 3;
+
+/** Base delay for exponential backoff: 2s → 4s → 8s (shorter than Anthropic's 5s because OpenAI-compatible shims are often local). */
+let retryBaseDelayMs = 2_000;
+
+/**
+ * Test injection hook for retry base delay. Set to 0 in tests to avoid real
+ * waits. Pass `null` to restore the production default (2000ms).
+ */
+export function __setRetryBaseDelay(ms: number | null): void {
+  retryBaseDelayMs = ms ?? 2_000;
+}
+
+/**
+ * Exponential backoff delay for a zero-based attempt index: `base * 2^attempt`.
+ * `base` honours the {@link __setRetryBaseDelay} test hook. Encapsulates the
+ * mutable base-delay state so callers never read a module global directly.
+ */
+export function computeBackoffDelay(attempt: number): number {
+  return retryBaseDelayMs * Math.pow(2, attempt);
+}
+
+/**
+ * Extract an HTTP status code from an error thrown by the OpenAI SDK (or a
+ * compatible shim). The SDK throws `APIError` instances with a `status` field;
+ * network errors and generic throws have no status and are treated as
+ * retryable (transient network blip) only when they carry no explicit code.
+ */
+function getErrorStatus(err: unknown): number | undefined {
+  if (err === null || typeof err !== 'object') return undefined;
+  const e = err as { status?: unknown };
+  return typeof e.status === 'number' ? e.status : undefined;
+}
+
+/**
+ * Connection-phase retryability: the HTTP call itself failed before any
+ * streaming began. Only retry on known transient status codes — errors with
+ * no status (network drops, DNS failures, wrong baseURL) are deterministic
+ * and must surface immediately to avoid wasting time on misconfigurations.
+ * Mirrors the Anthropic provider's `isTransientServerError` which also
+ * requires an explicit status.
+ */
+export function isRetryableConnectionError(err: unknown): boolean {
+  const status = getErrorStatus(err);
+  if (status === undefined) return false;
+  return RETRYABLE_STATUS_CODES.has(status);
+}
+
+/**
+ * Mid-stream retryability: the stream was established but the server sent an
+ * error event mid-flight. OpenAI-compatible APIs surface this as an `APIError`
+ * thrown from the async iterator. Same status-code set as connection-phase —
+ * only retry on explicit transient codes, not on status-less errors.
+ */
+export function isRetryableStreamError(err: unknown): boolean {
+  const status = getErrorStatus(err);
+  if (status === undefined) return false;
+  return RETRYABLE_STATUS_CODES.has(status);
+}

--- a/src/cli/model-limits.test.ts
+++ b/src/cli/model-limits.test.ts
@@ -9,7 +9,7 @@ describe('model-limits', () => {
   it('declares limits for opus, opus_1m, sonnet, sonnet_1m, haiku', () => {
     expect(MODEL_CONTEXT_LIMITS['opus']).toBe(200_000);
     expect(MODEL_CONTEXT_LIMITS['opus_1m']).toBe(1_000_000);
-    expect(MODEL_CONTEXT_LIMITS['sonnet']).toBe(1_000_000);
+    expect(MODEL_CONTEXT_LIMITS['sonnet']).toBe(200_000);
     expect(MODEL_CONTEXT_LIMITS['sonnet_1m']).toBe(1_000_000);
     expect(MODEL_CONTEXT_LIMITS['haiku']).toBe(200_000);
   });
@@ -29,14 +29,15 @@ describe('model-limits', () => {
     expect(contextLimitFor('claude-fable-5')).toBe(1_000_000);
   });
 
-  it('declares the 1M context window for Claude Sonnet 5 (alias + wire id)', () => {
-    // Sonnet 5 ships 1M natively (no `_1m` opt-in). Both the `sonnet` alias and
-    // the `claude-sonnet-5` wire id must report the full window, not the 200k
-    // Anthropic fallback. `sonnet_1m` stays a redundant back-compat alias.
-    expect(MODEL_CONTEXT_LIMITS['sonnet']).toBe(1_000_000);
-    expect(MODEL_CONTEXT_LIMITS['claude-sonnet-5']).toBe(1_000_000);
-    expect(contextLimitFor('sonnet')).toBe(1_000_000);
-    expect(contextLimitFor('claude-sonnet-5')).toBe(1_000_000);
+  it('base sonnet + claude-sonnet-5 use the 200k window; sonnet_1m is the 1M opt-in', () => {
+    // Sonnet 5's base window is the standard 200k (like opus/haiku). The 1M
+    // window is an explicit opt-in via the `sonnet_1m` alias, which short-
+    // circuits in contextLimitFor() before slot resolution.
+    expect(MODEL_CONTEXT_LIMITS['sonnet']).toBe(200_000);
+    expect(MODEL_CONTEXT_LIMITS['claude-sonnet-5']).toBe(200_000);
+    expect(contextLimitFor('sonnet')).toBe(200_000);
+    expect(contextLimitFor('claude-sonnet-5')).toBe(200_000);
+    expect(contextLimitFor('sonnet_1m')).toBe(1_000_000);
   });
 
   it('contextLimitFor falls back to 200k for unknown Anthropic-style models', () => {

--- a/src/cli/model-limits.test.ts
+++ b/src/cli/model-limits.test.ts
@@ -9,7 +9,7 @@ describe('model-limits', () => {
   it('declares limits for opus, opus_1m, sonnet, sonnet_1m, haiku', () => {
     expect(MODEL_CONTEXT_LIMITS['opus']).toBe(200_000);
     expect(MODEL_CONTEXT_LIMITS['opus_1m']).toBe(1_000_000);
-    expect(MODEL_CONTEXT_LIMITS['sonnet']).toBe(200_000);
+    expect(MODEL_CONTEXT_LIMITS['sonnet']).toBe(1_000_000);
     expect(MODEL_CONTEXT_LIMITS['sonnet_1m']).toBe(1_000_000);
     expect(MODEL_CONTEXT_LIMITS['haiku']).toBe(200_000);
   });
@@ -29,14 +29,15 @@ describe('model-limits', () => {
     expect(contextLimitFor('claude-fable-5')).toBe(1_000_000);
   });
 
-  it('base sonnet + claude-sonnet-5 use the 200k window; sonnet_1m is the 1M opt-in', () => {
-    // Sonnet 5's base window is the standard 200k (like opus/haiku). The 1M
-    // window is an explicit opt-in via the `sonnet_1m` alias, which short-
-    // circuits in contextLimitFor() before slot resolution.
-    expect(MODEL_CONTEXT_LIMITS['sonnet']).toBe(200_000);
-    expect(MODEL_CONTEXT_LIMITS['claude-sonnet-5']).toBe(200_000);
-    expect(contextLimitFor('sonnet')).toBe(200_000);
-    expect(contextLimitFor('claude-sonnet-5')).toBe(200_000);
+  it('declares the 1M context window for Claude Sonnet 5 (alias + wire id)', () => {
+    // Sonnet 5 ships 1M natively — no `_1m` opt-in needed for the window. Both
+    // the `sonnet` alias and the `claude-sonnet-5` wire id report the full 1M
+    // window. `sonnet_1m` also reports 1M and additionally opts out of the
+    // default auto-compaction budget (see autoCompactLimitFor).
+    expect(MODEL_CONTEXT_LIMITS['sonnet']).toBe(1_000_000);
+    expect(MODEL_CONTEXT_LIMITS['claude-sonnet-5']).toBe(1_000_000);
+    expect(contextLimitFor('sonnet')).toBe(1_000_000);
+    expect(contextLimitFor('claude-sonnet-5')).toBe(1_000_000);
     expect(contextLimitFor('sonnet_1m')).toBe(1_000_000);
   });
 


### PR DESCRIPTION
Two independent changes on one branch.

> **Note on history:** the models change landed in two steps — `43f01b8` first reverted base `sonnet` to a 200k *window*, then `d7df9dd` corrected course after a P1 review (see below). The **net** diff vs `main` makes **no context-window value change** (base `sonnet` stays 1M); it adds an auto-compaction *budget* instead. Squash-merge collapses the interim step.

### 1. Bound default-`sonnet` cost/latency via an auto-compaction budget — keep the truthful 1M window

`claude-sonnet-5` ships a **1M-token context window by default** — no `context-1m` beta header, "1M is both the default and the maximum, there is no smaller variant" ([whats-new-sonnet-5](https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5), and the [models/overview](https://platform.claude.com/docs/en/about-claude/models/overview) comparison table lists Sonnet 5 at 1M alongside Fable 5 / Opus 4.8). So the window stays truthfully **1M** everywhere it is the window (status line, `/tokens`, hard ceiling).

The real problem this branch targets is **cost/latency on long default sessions**: a 1M window that only auto-compacts at ~90% means resending up to ~900k input tokens every turn. Fix — a per-model **auto-compaction budget**, decoupled from the window:

- `MODEL_CONTEXT_LIMITS['sonnet']` / `['claude-sonnet-5']` = **1M** (truthful).
- New `MODEL_AUTOCOMPACT_BUDGET` (`{ claude-sonnet-5: 200k }`) + `autoCompactLimitFor(model)` = `min(window, budget ?? window)`.
- The auto-compaction trigger (`query.ts`) uses `autoCompactLimitFor(requestedModel)`; the status-line / `getContextUsage()` window keeps `contextLimitFor` (the true 1M).

Result: base `sonnet` auto-compacts at ~180k (`0.9 × 200k` — the same trigger point as before `da492d4`) **without** lying about the window or hard-capping context. The full 1M is one `sonnet_1m` away (the `*_1m` opt-in bypasses the budget), or raise the `autoCompact` threshold. Auto-compaction is **off by default**, so opted-out users see the full truthful 1M window and no early compaction.

Resolves the P1 review (`chatgpt-codex-connector`): Sonnet 5's 1M window is restored/kept; the earlier 200k-*window* approach (which would have compacted a 1M model prematurely at 180k) is replaced by an explicit, opt-out cost budget.

### 2. Decompose `openai-compatible/query.ts` — `refactor(openai-compatible)`

Was the largest file in the repo (1403 LOC) and never got the `query/` subdir treatment `anthropic-direct` already has. Extracted the standalone helpers into cohesive modules — the session class + turn loop stay in `query.ts` (now 1235 LOC):

- `query/retry.ts` — retryability predicates + `computeBackoffDelay` + `__setRetryBaseDelay`
- `query/model-params.ts` — output-cap, o-series detection, and effort helpers
- `query/client.ts` — `resolveClientFactory` + `__setOpenAIClientFactory`

`query.ts` re-exports the moved symbols so **every existing import path** (sibling tests + `index.ts`) keeps resolving unchanged — zero import churn. Behavior-preserving.

## Verification
- `pnpm lint` — clean (`tsc --noEmit`, exit 0)
- Full `pnpm test` — **576 files, 10645 passed / 0 failed / 14 skipped**
- New `src/agent/model-limits.test.ts` unit-tests `autoCompactLimitFor` (sonnet → 200k budget, sonnet_1m → 1M, opus/haiku/fable → full window, unknown → window). Window-assertion tests report the truthful 1M for base sonnet.

## Notes
- Phase C (extracting `openai-compatible/query.ts`'s `runIteration` / `dispatchAndAppend` streaming methods) remains deferred — higher risk, needs explicit dep-threading.
- These two changes are unrelated; happy to split into two PRs if preferred.
