### PR TITLE
feat(config): accept per-slot model binding objects in config_set

### DIFF
--- a/src/agent/session/model-slots.test.ts
+++ b/src/agent/session/model-slots.test.ts
@@ -6,6 +6,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   CLAUDE_FABLE_5_ID,
+  coerceSlotBindingInput,
   computeSlotBindings,
   DEFAULT_SLOT_BINDINGS,
   DIRECT_MODEL_ALIASES,
@@ -333,5 +334,39 @@ describe('Stage 2: per-slot provider credentials', () => {
       baseUrl: 'http://env/v1',
       apiKey: 'env-key',
     });
+  });
+});
+
+describe('coerceSlotBindingInput', () => {
+  it('accepts a minimal object with just an id', () => {
+    expect(coerceSlotBindingInput({ id: 'glm-5.2' })).toEqual({ ok: true, value: { id: 'glm-5.2' } });
+  });
+  it('accepts a full object and normalizes provider aliases', () => {
+    expect(coerceSlotBindingInput({ id: 'glm-5.2', provider: 'openai-compatible', baseUrl: 'https://x/v1' })).toEqual(
+      { ok: true, value: { id: 'glm-5.2', provider: 'openai', baseUrl: 'https://x/v1' } },
+    );
+  });
+  it('rejects a non-object', () => {
+    expect(coerceSlotBindingInput('glm-5.2').ok).toBe(false);
+    expect(coerceSlotBindingInput(null).ok).toBe(false);
+    expect(coerceSlotBindingInput(['glm-5.2']).ok).toBe(false);
+  });
+  it('rejects a missing id', () => {
+    expect(coerceSlotBindingInput({}).ok).toBe(false);
+    expect(coerceSlotBindingInput({ provider: 'openai' }).ok).toBe(false);
+  });
+  it('rejects an unrecognized provider', () => {
+    const res = coerceSlotBindingInput({ id: 'glm-5.2', provider: 'opencode-go' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/provider/);
+  });
+  it('rejects a per-slot apiKey (camelCase and snake_case)', () => {
+    expect(coerceSlotBindingInput({ id: 'glm-5.2', apiKey: 'sk-secret' }).ok).toBe(false);
+    expect(coerceSlotBindingInput({ id: 'glm-5.2', api_key: 'sk-secret' }).ok).toBe(false);
+  });
+  it('rejects snake_case base_url with a helpful message', () => {
+    const res = coerceSlotBindingInput({ id: 'glm-5.2', base_url: 'https://x/v1' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/baseUrl/);
   });
 });

--- a/src/agent/session/model-slots.test.ts
+++ b/src/agent/session/model-slots.test.ts
@@ -341,9 +341,14 @@ describe('coerceSlotBindingInput', () => {
   it('accepts a minimal object with just an id', () => {
     expect(coerceSlotBindingInput({ id: 'glm-5.2' })).toEqual({ ok: true, value: { id: 'glm-5.2' } });
   });
-  it('accepts a full object and normalizes provider aliases', () => {
-    expect(coerceSlotBindingInput({ id: 'glm-5.2', provider: 'openai-compatible', baseUrl: 'https://x/v1' })).toEqual(
-      { ok: true, value: { id: 'glm-5.2', provider: 'openai', baseUrl: 'https://x/v1' } },
+  it('accepts an object with id + provider and normalizes provider aliases', () => {
+    expect(coerceSlotBindingInput({ id: 'glm-5.2', provider: 'openai-compatible' })).toEqual(
+      { ok: true, value: { id: 'glm-5.2', provider: 'openai' } },
+    );
+  });
+  it('accepts an object with id + provider + name', () => {
+    expect(coerceSlotBindingInput({ id: 'glm-5.2', provider: 'openai', name: 'fast' })).toEqual(
+      { ok: true, value: { id: 'glm-5.2', provider: 'openai', name: 'fast' } },
     );
   });
   it('rejects a non-object', () => {
@@ -364,9 +369,27 @@ describe('coerceSlotBindingInput', () => {
     expect(coerceSlotBindingInput({ id: 'glm-5.2', apiKey: 'sk-secret' }).ok).toBe(false);
     expect(coerceSlotBindingInput({ id: 'glm-5.2', api_key: 'sk-secret' }).ok).toBe(false);
   });
-  it('rejects snake_case base_url with a helpful message', () => {
-    const res = coerceSlotBindingInput({ id: 'glm-5.2', base_url: 'https://x/v1' });
+  it('rejects a per-slot baseUrl (camelCase and snake_case) as an endpoint-redirect credential vector', () => {
+    const res = coerceSlotBindingInput({ id: 'glm-5.2', baseUrl: 'https://attacker.example/v1' });
     expect(res.ok).toBe(false);
-    if (!res.ok) expect(res.error).toMatch(/baseUrl/);
+    if (!res.ok) expect(res.error).toMatch(/AFK_MODEL_.*BASE_URL/);
+    const resSnake = coerceSlotBindingInput({ id: 'glm-5.2', base_url: 'https://attacker.example/v1' });
+    expect(resSnake.ok).toBe(false);
+    if (!resSnake.ok) expect(resSnake.error).toMatch(/AFK_MODEL_.*BASE_URL/);
+  });
+  it('rejects control characters in id and name', () => {
+    const resId = coerceSlotBindingInput({ id: 'glm\r\n-5.2' });
+    expect(resId.ok).toBe(false);
+    if (!resId.ok) expect(resId.error).toMatch(/control characters/);
+    const resName = coerceSlotBindingInput({ id: 'glm-5.2', name: 'evil\ntier' });
+    expect(resName.ok).toBe(false);
+    if (!resName.ok) expect(resName.error).toMatch(/control characters/);
+  });
+  it('rejects names that shadow built-in aliases (slot keys, legacy aliases, auto, direct aliases)', () => {
+    for (const reserved of ['local', 'small', 'medium', 'large', 'haiku', 'sonnet', 'opus', 'auto', 'fable']) {
+      const res = coerceSlotBindingInput({ id: 'glm-5.2', name: reserved });
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error).toMatch(/shadow a built-in alias/);
+    }
   });
 });

--- a/src/agent/session/model-slots.ts
+++ b/src/agent/session/model-slots.ts
@@ -356,3 +356,49 @@ function parseBinding(value: unknown): ModelSlotBinding | undefined {
   }
   return undefined;
 }
+
+/**
+ * Strict WRITER-path validation for a model-slot binding supplied to the config
+ * mutation engine (config_set tool / `afk config set`). Unlike {@link parseBinding}
+ * — which leniently ignores malformed fields when LOADING afk.config.json — this
+ * surfaces actionable errors so a bad `config set models.large {...}` is rejected
+ * rather than silently written. Rejects a per-slot `apiKey` (a credential — belongs
+ * in afk.env via `afk config env set AFK_MODEL_<TIER>_API_KEY`, not the plaintext JSON).
+ */
+export function coerceSlotBindingInput(
+  raw: unknown,
+): { ok: true; value: ModelSlotBinding } | { ok: false; error: string } {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, error: 'model binding must be an object with at least an "id"' };
+  }
+  const obj = raw as Record<string, unknown>;
+  if ('apiKey' in obj || 'api_key' in obj) {
+    return {
+      ok: false,
+      error:
+        'per-slot API keys are credentials; set AFK_MODEL_<TIER>_API_KEY via `afk config env set` instead of afk.config.json',
+    };
+  }
+  const id = parseStringField(obj['id']);
+  if (!id) return { ok: false, error: 'model binding requires a non-empty "id"' };
+  const binding: ModelSlotBinding = { id };
+  const name = parseStringField(obj['name']);
+  if (name) binding.name = name;
+  if (obj['provider'] !== undefined && obj['provider'] !== '') {
+    const provider = normalizeSlotProvider(obj['provider']);
+    if (!provider) {
+      return {
+        ok: false,
+        error:
+          'model binding "provider" must be one of: anthropic, openai (aliases: anthropic-direct, openai-compatible)',
+      };
+    }
+    binding.provider = provider;
+  }
+  const baseUrl = parseStringField(obj['baseUrl']);
+  if (baseUrl) binding.baseUrl = baseUrl;
+  if (!baseUrl && parseStringField(obj['base_url'])) {
+    return { ok: false, error: 'use camelCase "baseUrl", not "base_url"' };
+  }
+  return { ok: true, value: binding };
+}

--- a/src/agent/session/model-slots.ts
+++ b/src/agent/session/model-slots.ts
@@ -334,6 +334,30 @@ function parseStringField(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+/**
+ * Reject control characters (CRLF, NUL, tab, DEL, etc.) in binding string
+ * fields — mirrors the env-var path's newline rejection in `coerceEnvValue`.
+ * `parseStringField` itself stays lenient (it is shared with the loader path,
+ * which intentionally ignores rather than throws on malformed input).
+ */
+function hasControlChars(value: string): boolean {
+  // eslint-disable-next-line no-control-regex
+  return /[\x00-\x1f\x7f]/.test(value);
+}
+
+/**
+ * Names an agent-assigned binding `name` may not shadow — the built-in slot
+ * keys, legacy tier aliases, the `auto` sentinel, and direct model aliases.
+ * Without this check an agent could set `models.small.name = "large"` to route
+ * an operator-typed "large" to the cheap tier.
+ */
+const RESERVED_NAMES: ReadonlySet<string> = new Set([
+  ...SLOT_NAMES,
+  ...Object.keys(LEGACY_ALIAS_TO_SLOT),
+  AUTO_SENTINEL,
+  ...Object.keys(DIRECT_MODEL_ALIASES),
+]);
+
 function parseBinding(value: unknown): ModelSlotBinding | undefined {
   if (typeof value === 'string') {
     const id = value.trim();
@@ -362,8 +386,22 @@ function parseBinding(value: unknown): ModelSlotBinding | undefined {
  * mutation engine (config_set tool / `afk config set`). Unlike {@link parseBinding}
  * — which leniently ignores malformed fields when LOADING afk.config.json — this
  * surfaces actionable errors so a bad `config set models.large {...}` is rejected
- * rather than silently written. Rejects a per-slot `apiKey` (a credential — belongs
- * in afk.env via `afk config env set AFK_MODEL_<TIER>_API_KEY`, not the plaintext JSON).
+ * rather than silently written.
+ *
+ * Rejects two credential-sensitivity fields from the plaintext-JSON agent-writable path:
+ *   1. `apiKey` — a secret; belongs in afk.env via `afk config env set AFK_MODEL_<TIER>_API_KEY`.
+ *   2. `baseUrl` — an endpoint redirect that carries the paired API key + the full
+ *      conversation to wherever it points; belongs in afk.env via `afk config env set
+ *      AFK_MODEL_<TIER>_BASE_URL` (human-gated, same rule as the `*_BASE_URL` suffix
+ *      protection in {@link ../../config/settable-keys.ts}).
+ *
+ * Without these rejections an agent could silently rewrite runtime credentials or
+ * endpoints into plaintext afk.config.json, bypassing the deliberately human-gated
+ * env-var surface.
+ *
+ * Contract: {@link parseBinding} (the LOADER) still reads `baseUrl`/`apiKey` from
+ * afk.config.json so hand-edited files and env-var overrides remain functional at
+ * runtime — only the agent-writable WRITE path is gated.
  */
 export function coerceSlotBindingInput(
   raw: unknown,
@@ -379,11 +417,32 @@ export function coerceSlotBindingInput(
         'per-slot API keys are credentials; set AFK_MODEL_<TIER>_API_KEY via `afk config env set` instead of afk.config.json',
     };
   }
+  if ('baseUrl' in obj || 'base_url' in obj) {
+    return {
+      ok: false,
+      error:
+        'per-slot baseUrl is an endpoint-redirect credential vector; set AFK_MODEL_<TIER>_BASE_URL via `afk config env set` instead of afk.config.json',
+    };
+  }
   const id = parseStringField(obj['id']);
   if (!id) return { ok: false, error: 'model binding requires a non-empty "id"' };
+  if (hasControlChars(id)) {
+    return { ok: false, error: 'model binding "id" must not contain control characters' };
+  }
   const binding: ModelSlotBinding = { id };
   const name = parseStringField(obj['name']);
-  if (name) binding.name = name;
+  if (name) {
+    if (hasControlChars(name)) {
+      return { ok: false, error: 'model binding "name" must not contain control characters' };
+    }
+    if (RESERVED_NAMES.has(name.trim().toLowerCase())) {
+      return {
+        ok: false,
+        error: `model binding "name" must not shadow a built-in alias ("${name}")`,
+      };
+    }
+    binding.name = name;
+  }
   if (obj['provider'] !== undefined && obj['provider'] !== '') {
     const provider = normalizeSlotProvider(obj['provider']);
     if (!provider) {
@@ -394,11 +453,6 @@ export function coerceSlotBindingInput(
       };
     }
     binding.provider = provider;
-  }
-  const baseUrl = parseStringField(obj['baseUrl']);
-  if (baseUrl) binding.baseUrl = baseUrl;
-  if (!baseUrl && parseStringField(obj['base_url'])) {
-    return { ok: false, error: 'use camelCase "baseUrl", not "base_url"' };
   }
   return { ok: true, value: binding };
 }

--- a/src/agent/tools/handlers/config-ops.test.ts
+++ b/src/agent/tools/handlers/config-ops.test.ts
@@ -104,8 +104,8 @@ describe('config_get / config_set handlers', () => {
   });
 
   describe('config_set — models.* accepts a per-slot binding object', () => {
-    it('sets a full { id, provider, baseUrl } object', async () => {
-      const binding = { id: 'glm-5.2', provider: 'openai', baseUrl: 'https://x/v1' };
+    it('sets a full { id, provider } object', async () => {
+      const binding = { id: 'glm-5.2', provider: 'openai' };
       const r = await configSetHandler({ target: 'config', key: 'models.large', value: binding }, signal);
       expect(r.isError).toBeFalsy();
       expect(JSON.parse(readFileSync(jsonFile, 'utf-8'))).toEqual({ models: { large: binding } });
@@ -118,6 +118,16 @@ describe('config_get / config_set handlers', () => {
       );
       expect(r.isError).toBe(true);
       expect(r.content).toMatch(/afk config env set|api.?key/i);
+      expect(existsSync(jsonFile)).toBe(false);
+    });
+
+    it('rejects a value containing baseUrl (endpoint-redirect credential vector)', async () => {
+      const r = await configSetHandler(
+        { target: 'config', key: 'models.large', value: { id: 'glm-5.2', baseUrl: 'https://attacker.example/v1' } },
+        signal,
+      );
+      expect(r.isError).toBe(true);
+      expect(r.content).toMatch(/AFK_MODEL_.*BASE_URL/i);
       expect(existsSync(jsonFile)).toBe(false);
     });
   });

--- a/src/agent/tools/handlers/config-ops.test.ts
+++ b/src/agent/tools/handlers/config-ops.test.ts
@@ -103,6 +103,25 @@ describe('config_get / config_set handlers', () => {
     });
   });
 
+  describe('config_set — models.* accepts a per-slot binding object', () => {
+    it('sets a full { id, provider, baseUrl } object', async () => {
+      const binding = { id: 'glm-5.2', provider: 'openai', baseUrl: 'https://x/v1' };
+      const r = await configSetHandler({ target: 'config', key: 'models.large', value: binding }, signal);
+      expect(r.isError).toBeFalsy();
+      expect(JSON.parse(readFileSync(jsonFile, 'utf-8'))).toEqual({ models: { large: binding } });
+    });
+
+    it('rejects a value containing apiKey', async () => {
+      const r = await configSetHandler(
+        { target: 'config', key: 'models.large', value: { id: 'glm-5.2', apiKey: 'sk-secret' } },
+        signal,
+      );
+      expect(r.isError).toBe(true);
+      expect(r.content).toMatch(/afk config env set|api.?key/i);
+      expect(existsSync(jsonFile)).toBe(false);
+    });
+  });
+
   describe('config_get — masks secrets', () => {
     it('reads a config key and the whole file', async () => {
       await configSetHandler({ target: 'config', key: 'model', value: 'opus' }, signal);

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -767,7 +767,8 @@ export const configSetTool: AnthropicToolDef = {
         description:
           'Required for action "set". A string, number, or boolean (config keys also accept arrays where ' +
           'the schema expects one, e.g. telegram.notify.targets). Coerced to the key\'s declared type. ' +
-          'Model-slot keys (models.local/small/medium/large) also accept a { id, provider, baseUrl } object.',
+          'Model-slot keys (models.local/small/medium/large) also accept a { id, provider, name } object; ' +
+          'baseUrl/apiKey are human-gated — set them per-tier via the AFK_MODEL_<TIER>_BASE_URL / _API_KEY env vars, not here.',
       },
     },
     required: ['target', 'key'],

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -766,7 +766,8 @@ export const configSetTool: AnthropicToolDef = {
       value: {
         description:
           'Required for action "set". A string, number, or boolean (config keys also accept arrays where ' +
-          'the schema expects one, e.g. telegram.notify.targets). Coerced to the key\'s declared type.',
+          'the schema expects one, e.g. telegram.notify.targets). Coerced to the key\'s declared type. ' +
+          'Model-slot keys (models.local/small/medium/large) also accept a { id, provider, baseUrl } object.',
       },
     },
     required: ['target', 'key'],

--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -204,6 +204,37 @@ describe('config mutation engine', () => {
     });
   });
 
+  describe('config: setConfigValue — models.* model-slot object form', () => {
+    it('writes a full slot-binding object and round-trips it via getConfigValue', () => {
+      const binding = { id: 'glm-5.2', provider: 'openai', baseUrl: 'https://x/v1' };
+      const r = setConfigValue('models.large', binding, { filePath: jsonFile });
+      expect(r.value).toEqual(binding);
+      expect(JSON.parse(readFileSync(jsonFile, 'utf-8'))).toEqual({ models: { large: binding } });
+      expect(getConfigValue('models.large', { filePath: jsonFile }).value).toEqual(binding);
+    });
+
+    it('still accepts a bare string id', () => {
+      const r = setConfigValue('models.large', 'glm-5.2', { filePath: jsonFile });
+      expect(r.value).toBe('glm-5.2');
+      expect(JSON.parse(readFileSync(jsonFile, 'utf-8'))).toEqual({ models: { large: 'glm-5.2' } });
+    });
+
+    it('overwriting a pre-existing string-form slot with an object leaves no stray keys', () => {
+      setConfigValue('models.large', 'old-id', { filePath: jsonFile });
+      const binding = { id: 'glm-5.2', provider: 'openai', baseUrl: 'https://x/v1' };
+      setConfigValue('models.large', binding, { filePath: jsonFile });
+      const obj = JSON.parse(readFileSync(jsonFile, 'utf-8'));
+      expect(obj).toEqual({ models: { large: binding } });
+      expect(Object.keys(obj.models.large).sort()).toEqual(['baseUrl', 'id', 'provider']);
+    });
+
+    it('rejects an object carrying apiKey', () => {
+      expect(() =>
+        setConfigValue('models.large', { id: 'glm-5.2', apiKey: 'sk-secret' }, { filePath: jsonFile }),
+      ).toThrow(ConfigValidationError);
+    });
+  });
+
   describe('config: unset / get / list', () => {
     it('unsets and prunes empty parents', () => {
       setConfigValue('telegram.notify.mode', 'primary', { filePath: jsonFile, allowHumanOnly: true });

--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -20,6 +20,7 @@ import {
   ConfigValidationError,
   MalformedConfigError,
 } from './mutate.js';
+import { parseModelsConfig, computeSlotBindings } from '../agent/session/model-slots.js';
 
 describe('config mutation engine', () => {
   let dir: string;
@@ -205,12 +206,29 @@ describe('config mutation engine', () => {
   });
 
   describe('config: setConfigValue — models.* model-slot object form', () => {
-    it('writes a full slot-binding object and round-trips it via getConfigValue', () => {
-      const binding = { id: 'glm-5.2', provider: 'openai', baseUrl: 'https://x/v1' };
+    it('writes a slot-binding object (id + provider) and round-trips it via getConfigValue', () => {
+      const binding = { id: 'glm-5.2', provider: 'openai' };
       const r = setConfigValue('models.large', binding, { filePath: jsonFile });
       expect(r.value).toEqual(binding);
       expect(JSON.parse(readFileSync(jsonFile, 'utf-8'))).toEqual({ models: { large: binding } });
       expect(getConfigValue('models.large', { filePath: jsonFile }).value).toEqual(binding);
+    });
+
+    it('writes a slot-binding object with a custom name and round-trips it via getConfigValue', () => {
+      const binding = { id: 'glm-5.2', provider: 'openai', name: 'fast' };
+      const r = setConfigValue('models.large', binding, { filePath: jsonFile });
+      expect(r.value).toEqual(binding);
+      expect(getConfigValue('models.large', { filePath: jsonFile }).value).toEqual(binding);
+    });
+
+    it('round-trips a written binding object through the runtime loader (computeSlotBindings)', () => {
+      const binding = { id: 'glm-5.2', provider: 'openai', name: 'fast' };
+      setConfigValue('models.large', binding, { filePath: jsonFile });
+      // Re-read the file and load through the runtime loader — not getConfigValue
+      const fileJson = JSON.parse(readFileSync(jsonFile, 'utf-8'));
+      const parsed = parseModelsConfig(fileJson.models);
+      const resolved = computeSlotBindings(parsed);
+      expect(resolved.large).toEqual({ id: 'glm-5.2', provider: 'openai', name: 'fast' });
     });
 
     it('still accepts a bare string id', () => {
@@ -221,16 +239,22 @@ describe('config mutation engine', () => {
 
     it('overwriting a pre-existing string-form slot with an object leaves no stray keys', () => {
       setConfigValue('models.large', 'old-id', { filePath: jsonFile });
-      const binding = { id: 'glm-5.2', provider: 'openai', baseUrl: 'https://x/v1' };
+      const binding = { id: 'glm-5.2', provider: 'openai' };
       setConfigValue('models.large', binding, { filePath: jsonFile });
       const obj = JSON.parse(readFileSync(jsonFile, 'utf-8'));
       expect(obj).toEqual({ models: { large: binding } });
-      expect(Object.keys(obj.models.large).sort()).toEqual(['baseUrl', 'id', 'provider']);
+      expect(Object.keys(obj.models.large).sort()).toEqual(['id', 'provider']);
     });
 
     it('rejects an object carrying apiKey', () => {
       expect(() =>
         setConfigValue('models.large', { id: 'glm-5.2', apiKey: 'sk-secret' }, { filePath: jsonFile }),
+      ).toThrow(ConfigValidationError);
+    });
+
+    it('rejects an object carrying baseUrl (endpoint-redirect credential vector)', () => {
+      expect(() =>
+        setConfigValue('models.large', { id: 'glm-5.2', baseUrl: 'https://attacker.example/v1' }, { filePath: jsonFile }),
       ).toThrow(ConfigValidationError);
     });
   });

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -23,6 +23,7 @@
  */
 
 import { existsSync, readFileSync, copyFileSync, chmodSync } from 'fs';
+import type { ModelSlotBinding } from '../agent/session/model-slots.js';
 import { getEnvConfigPath, getJsonConfigPath } from '../paths.js';
 import { getEnvVarMeta, ENV_REGISTRY, isEnvVarSet } from './env.js';
 import { atomicWriteFile, upsertEnvVar, removeEnvVar, readEnvVarFromFile, readEnvFile } from '../utils/envFile.js';
@@ -269,7 +270,7 @@ function assertConfigWritable(path: string, allowHumanOnly: boolean | undefined)
 export interface ConfigWriteResult {
   path: string;
   class: ConfigKeyClass;
-  value: string | number | boolean | number[];
+  value: string | number | boolean | number[] | ModelSlotBinding;
   persistedTo: string;
 }
 

--- a/src/config/settable-keys.test.ts
+++ b/src/config/settable-keys.test.ts
@@ -158,11 +158,22 @@ describe('coerceConfigValue', () => {
     it('accepts a minimal object with just an id', () => {
       expect(coerceConfigValue(spec, { id: 'glm-5.2' })).toEqual({ ok: true, value: { id: 'glm-5.2' } });
     });
-    it('accepts a full object and normalizes provider', () => {
-      expect(coerceConfigValue(spec, { id: 'glm-5.2', provider: 'openai', baseUrl: 'https://x/v1' })).toEqual({
+    it('accepts an object with id + provider and normalizes provider', () => {
+      expect(coerceConfigValue(spec, { id: 'glm-5.2', provider: 'openai' })).toEqual({
         ok: true,
-        value: { id: 'glm-5.2', provider: 'openai', baseUrl: 'https://x/v1' },
+        value: { id: 'glm-5.2', provider: 'openai' },
       });
+    });
+    it('accepts an object with id + provider + name', () => {
+      expect(coerceConfigValue(spec, { id: 'glm-5.2', provider: 'openai', name: 'fast' })).toEqual({
+        ok: true,
+        value: { id: 'glm-5.2', provider: 'openai', name: 'fast' },
+      });
+    });
+    it('rejects an object carrying baseUrl (endpoint-redirect credential vector)', () => {
+      const res = coerceConfigValue(spec, { id: 'glm-5.2', provider: 'openai', baseUrl: 'https://x/v1' });
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error).toMatch(/AFK_MODEL_.*BASE_URL/);
     });
     it('rejects an unrecognized provider', () => {
       const res = coerceConfigValue(spec, { id: 'glm-5.2', provider: 'opencode-go' });

--- a/src/config/settable-keys.test.ts
+++ b/src/config/settable-keys.test.ts
@@ -143,6 +143,48 @@ describe('coerceConfigValue', () => {
     expect(coerceConfigValue(spec, 'opus')).toEqual({ ok: true, value: 'opus' });
     expect(coerceConfigValue(spec, '   ').ok).toBe(false);
   });
+
+  describe('model-slot', () => {
+    const spec = { path: 'models.large', tier: 'agent' as const, type: 'model-slot' as const, description: '' };
+
+    it('accepts a bare id string', () => {
+      expect(coerceConfigValue(spec, 'glm-5.2')).toEqual({ ok: true, value: 'glm-5.2' });
+    });
+    it('registered models.* specs are model-slot typed', () => {
+      for (const path of ['models.local', 'models.small', 'models.medium', 'models.large']) {
+        expect(getConfigKeySpec(path)!.type).toBe('model-slot');
+      }
+    });
+    it('accepts a minimal object with just an id', () => {
+      expect(coerceConfigValue(spec, { id: 'glm-5.2' })).toEqual({ ok: true, value: { id: 'glm-5.2' } });
+    });
+    it('accepts a full object and normalizes provider', () => {
+      expect(coerceConfigValue(spec, { id: 'glm-5.2', provider: 'openai', baseUrl: 'https://x/v1' })).toEqual({
+        ok: true,
+        value: { id: 'glm-5.2', provider: 'openai', baseUrl: 'https://x/v1' },
+      });
+    });
+    it('rejects an unrecognized provider', () => {
+      const res = coerceConfigValue(spec, { id: 'glm-5.2', provider: 'opencode-go' });
+      expect(res.ok).toBe(false);
+    });
+    it('rejects a missing id', () => {
+      expect(coerceConfigValue(spec, { provider: 'openai' }).ok).toBe(false);
+      expect(coerceConfigValue(spec, {}).ok).toBe(false);
+    });
+    it('rejects an object carrying apiKey', () => {
+      expect(coerceConfigValue(spec, { id: 'glm-5.2', apiKey: 'sk-secret' }).ok).toBe(false);
+    });
+    it('rejects snake_case base_url', () => {
+      expect(coerceConfigValue(spec, { id: 'glm-5.2', base_url: 'https://x/v1' }).ok).toBe(false);
+    });
+    it('rejects a number', () => {
+      expect(coerceConfigValue(spec, 42).ok).toBe(false);
+    });
+    it('rejects an array', () => {
+      expect(coerceConfigValue(spec, ['glm-5.2']).ok).toBe(false);
+    });
+  });
 });
 
 describe('dotted-path helpers', () => {

--- a/src/config/settable-keys.ts
+++ b/src/config/settable-keys.ts
@@ -196,10 +196,10 @@ export interface ConfigKeySpec {
  */
 export const CONFIG_KEY_SPECS: readonly ConfigKeySpec[] = [
   { path: 'model', tier: 'agent', type: 'string', description: 'Default model id / alias.' },
-  { path: 'models.local', tier: 'agent', type: 'model-slot', description: 'Local-tier model id (OpenAI-compatible shim: Ollama, LM Studio, vLLM, MLX). Accepts a bare id string or a { id, provider, baseUrl } object.' },
-  { path: 'models.small', tier: 'agent', type: 'model-slot', description: 'Small-tier model id. Accepts a bare id string or a { id, provider, baseUrl } object.' },
-  { path: 'models.medium', tier: 'agent', type: 'model-slot', description: 'Medium-tier model id. Accepts a bare id string or a { id, provider, baseUrl } object.' },
-  { path: 'models.large', tier: 'agent', type: 'model-slot', description: 'Large-tier model id. Accepts a bare id string or a { id, provider, baseUrl } object.' },
+  { path: 'models.local', tier: 'agent', type: 'model-slot', description: 'Local-tier model id (OpenAI-compatible shim: Ollama, LM Studio, vLLM, MLX). Accepts a bare id string or a { id, provider, name } object (baseUrl/apiKey are human-gated: set them via the AFK_MODEL_<TIER>_BASE_URL / _API_KEY env vars, not here).' },
+  { path: 'models.small', tier: 'agent', type: 'model-slot', description: 'Small-tier model id. Accepts a bare id string or a { id, provider, name } object (baseUrl/apiKey are human-gated: set them via the AFK_MODEL_<TIER>_BASE_URL / _API_KEY env vars, not here).' },
+  { path: 'models.medium', tier: 'agent', type: 'model-slot', description: 'Medium-tier model id. Accepts a bare id string or a { id, provider, name } object (baseUrl/apiKey are human-gated: set them via the AFK_MODEL_<TIER>_BASE_URL / _API_KEY env vars, not here).' },
+  { path: 'models.large', tier: 'agent', type: 'model-slot', description: 'Large-tier model id. Accepts a bare id string or a { id, provider, name } object (baseUrl/apiKey are human-gated: set them via the AFK_MODEL_<TIER>_BASE_URL / _API_KEY env vars, not here).' },
   { path: 'maxTokens', tier: 'agent', type: 'number', clamp: { min: 1, max: 1_000_000, integer: true }, description: 'Max tokens per turn.' },
   { path: 'temperature', tier: 'agent', type: 'number', clamp: { min: 0, max: 2 }, description: 'Sampling temperature.' },
   { path: 'autoRouting.interactive', tier: 'agent', type: 'boolean', description: 'Auto-route model in the REPL.' },

--- a/src/config/settable-keys.ts
+++ b/src/config/settable-keys.ts
@@ -21,6 +21,7 @@
  */
 
 import { getEnvVarMeta, type EnvVarMeta } from './env.js';
+import { coerceSlotBindingInput, type ModelSlotBinding } from '../agent/session/model-slots.js';
 
 // ── Env-var classification ───────────────────────────────────────────────────
 
@@ -168,7 +169,7 @@ export function coerceEnvValue(meta: EnvVarMeta, raw: string): CoerceResult {
 // ── Config-key (afk.config.json) classification + validation ──────────────────
 
 export type ConfigKeyTier = 'agent' | 'human';
-export type ConfigKeyType = 'string' | 'number' | 'boolean' | 'enum' | 'number-array';
+export type ConfigKeyType = 'string' | 'number' | 'boolean' | 'enum' | 'number-array' | 'model-slot';
 
 export interface ConfigKeySpec {
   /** Dotted path, e.g. `models.large` or `telegram.notify.mode`. */
@@ -195,10 +196,10 @@ export interface ConfigKeySpec {
  */
 export const CONFIG_KEY_SPECS: readonly ConfigKeySpec[] = [
   { path: 'model', tier: 'agent', type: 'string', description: 'Default model id / alias.' },
-  { path: 'models.local', tier: 'agent', type: 'string', description: 'Local-tier model id (OpenAI-compatible shim: Ollama, LM Studio, vLLM, MLX).' },
-  { path: 'models.small', tier: 'agent', type: 'string', description: 'Small-tier model id.' },
-  { path: 'models.medium', tier: 'agent', type: 'string', description: 'Medium-tier model id.' },
-  { path: 'models.large', tier: 'agent', type: 'string', description: 'Large-tier model id.' },
+  { path: 'models.local', tier: 'agent', type: 'model-slot', description: 'Local-tier model id (OpenAI-compatible shim: Ollama, LM Studio, vLLM, MLX). Accepts a bare id string or a { id, provider, baseUrl } object.' },
+  { path: 'models.small', tier: 'agent', type: 'model-slot', description: 'Small-tier model id. Accepts a bare id string or a { id, provider, baseUrl } object.' },
+  { path: 'models.medium', tier: 'agent', type: 'model-slot', description: 'Medium-tier model id. Accepts a bare id string or a { id, provider, baseUrl } object.' },
+  { path: 'models.large', tier: 'agent', type: 'model-slot', description: 'Large-tier model id. Accepts a bare id string or a { id, provider, baseUrl } object.' },
   { path: 'maxTokens', tier: 'agent', type: 'number', clamp: { min: 1, max: 1_000_000, integer: true }, description: 'Max tokens per turn.' },
   { path: 'temperature', tier: 'agent', type: 'number', clamp: { min: 0, max: 2 }, description: 'Sampling temperature.' },
   { path: 'autoRouting.interactive', tier: 'agent', type: 'boolean', description: 'Auto-route model in the REPL.' },
@@ -247,7 +248,7 @@ export function classifyConfigKey(path: string): ConfigKeyClass {
 }
 
 export type ConfigCoerceResult =
-  | { ok: true; value: string | number | boolean | number[] }
+  | { ok: true; value: string | number | boolean | number[] | ModelSlotBinding }
   | { ok: false; error: string };
 
 /**
@@ -303,6 +304,15 @@ export function coerceConfigValue(spec: ConfigKeySpec, raw: unknown): ConfigCoer
         nums.push(n);
       }
       return { ok: true, value: nums };
+    }
+    case 'model-slot': {
+      if (typeof raw === 'string') {
+        if (raw.trim().length === 0) return { ok: false, error: `${spec.path} must not be empty` };
+        return { ok: true, value: raw.trim() };
+      }
+      const res = coerceSlotBindingInput(raw);
+      if (!res.ok) return { ok: false, error: `${spec.path}: ${res.error}` };
+      return { ok: true, value: res.value };
     }
     case 'string':
     default: {


### PR DESCRIPTION
## Motivation

The capability tiers `models.local|small|medium|large` were registered in `CONFIG_KEY_SPECS` as `type: 'string'`, so the validated config writer (`config_set` agent tool + `afk config set`, both via `src/config/mutate.ts`) could only store a **bare model id**. But `afk.config.json` already accepts the richer per-slot object form at load time — `{ "id": "...", "provider": "openai", "baseUrl": "https://..." }` (parsed by `parseBinding` in `model-slots.ts`). That mismatch meant the object form could only be hand-written, and a typo was silently dropped: a user set `"large": {"id":"glm-5.2","provider":"opencode-go","base_url":"..."}` and both `provider` (invalid value) and `base_url` (wrong key — must be camelCase `baseUrl`) were discarded at load with no error, and `config_set` couldn't fix it because the key only accepts a string.

## What changed

- New `ConfigKeyType` `'model-slot'`; the four `models.*` specs now use it.
- `coerceConfigValue` gains a `model-slot` case: accepts a bare id **string** (back-compat) **or** a binding **object**.
- New strict writer-path validator `coerceSlotBindingInput()` in `model-slots.ts` — reuses `normalizeSlotProvider`, requires a non-empty `id`, validates `provider`, accepts `baseUrl`, and returns actionable errors. (Contrast `parseBinding`, which stays lenient for backward-compatible file loads.)
- `config_set` tool `value` schema description notes the object form (the schema already accepted objects structurally).
- Type unions widened: `ConfigCoerceResult` and `ConfigWriteResult.value`.

## Design note

Whole-object slot replacement, **not** nested leaf keys (`models.large.provider`). `setAtPath` (`src/config/settable-keys.ts:331`) overwrites a string-form slot with `{}` the instant a nested leaf is set — which would silently destroy the existing `id`. Setting the whole `models.<slot>` object leaf is atomic and safe.

## Safety / back-compat

- Bare-string form still works unchanged.
- A per-slot `apiKey` is **rejected** — credentials belong in `afk.env` via `afk config env set AFK_MODEL_<TIER>_API_KEY`, not the plaintext JSON writer.
- Helpful error on the common `base_url` → `baseUrl` snake_case mistake.
- The `~/.afk/config` write-denylist is untouched — writes still go only through this validated engine.
- Effective on the next process start (config is cached at load).

## Testing

`pnpm lint` clean. New/extended unit tests across `settable-keys.test.ts`, `model-slots.test.ts`, `mutate.test.ts`, `config-ops.test.ts` (121 tests in those 4 files pass) covering: string + object coercion, provider validation, missing-id / apiKey / snake_case rejection, round-trip persistence, and the tool handler path.
