### PR TITLE
fix(plan-mode): live-mode-gate exit_plan_mode + restore working mode across the Shift+Tab ring

### DIFF
--- a/src/agent/providers/anthropic-direct/exit-plan-mode-live-tools.test.ts
+++ b/src/agent/providers/anthropic-direct/exit-plan-mode-live-tools.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression: the model-callable `exit_plan_mode` tool must be advertised (and
+ * callable) based on the LIVE permission mode, not the mode captured at
+ * `query()` construction.
+ *
+ * The bug: `buildDispatcher` registered the tool's handler + schema ONLY when
+ * `permissionMode === 'plan'` at construction, and `setPermissionMode` does not
+ * rebuild the dispatcher. So a session launched in a non-plan mode that entered
+ * plan mode LATER (Shift+Tab / `/plan`) never got the tool wired — the model was
+ * told (by the plan-mode addendum) to call it, did, and got
+ * "Unknown tool exit_plan_mode".
+ *
+ * The fix registers the tool RESIDENT (whenever the session supplied
+ * `planExitControls` — top-level only) and gates ADVERTISEMENT per-turn on the
+ * live mode in `query.ts`. These tests assert at the `messages.create` boundary
+ * (the tool list the model actually sees) across a mid-session mode flip in both
+ * directions.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { RawMessageStreamEvent } from '@anthropic-ai/sdk/resources';
+import type { PlanExitControls } from '../../types/config-types.js';
+import { AnthropicDirectProvider, __setAnthropicClientFactory } from './index.js';
+
+const messagesCreateMock = vi.fn();
+class MockAnthropic {
+  public messages = { create: messagesCreateMock };
+}
+
+async function* fromArray<T>(arr: T[]): AsyncIterable<T> {
+  for (const x of arr) yield x;
+}
+
+function makeTextStream(text: string): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_test', type: 'message', role: 'assistant', content: [],
+        model: 'claude-sonnet-5', stop_reason: null, stop_sequence: null,
+        usage: { input_tokens: 5, output_tokens: 0, cache_creation_input_tokens: 0, cache_read_input_tokens: 0, server_tool_use: null, service_tier: null },
+      },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '', citations: [] } } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text } } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    { type: 'message_delta', delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 4 } } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+async function drainQuery(query: AsyncIterable<unknown>): Promise<void> {
+  for await (const _ev of query) { void _ev; }
+}
+
+function toolNamesOfCall(callIndex: number): string[] {
+  const args = messagesCreateMock.mock.calls[callIndex]?.[0] as { tools?: unknown } | undefined;
+  const tools = args?.tools;
+  if (!Array.isArray(tools)) return [];
+  return (tools as { name?: string }[]).map((t) => t.name ?? '').filter(Boolean);
+}
+
+const planExitControls: PlanExitControls = {
+  setPermissionMode: async () => {},
+  requestImplementSeed: () => {},
+  getPrePlanMode: () => 'default',
+};
+
+describe('exit_plan_mode live advertisement (anthropic-direct)', () => {
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(() => new MockAnthropic() as unknown as Anthropic);
+  });
+
+  it('started in plan mode → exit_plan_mode IS offered on turn 1', async () => {
+    const provider = new AnthropicDirectProvider();
+    messagesCreateMock.mockImplementation(() => fromArray(makeTextStream('t1')));
+    const query = provider.query({
+      prompt: (async function* () { yield { content: 't1' }; })(),
+      config: { model: 'claude-sonnet-5', apiKey: 'sk-ant-oat01-test', permissionMode: 'plan', planExitControls },
+    });
+    await drainQuery(query as AsyncIterable<unknown>);
+    expect(toolNamesOfCall(0)).toContain('exit_plan_mode');
+  });
+
+  it('started default, flipped to plan mid-session → exit_plan_mode IS offered on turn 2', async () => {
+    const provider = new AnthropicDirectProvider();
+    let flipResolver: (() => void) | null = null;
+    const flip = new Promise<void>((r) => { flipResolver = r; });
+    async function* twoInputs() { yield { content: 't1' }; await flip; yield { content: 't2' }; }
+    const query = provider.query({
+      prompt: twoInputs(),
+      config: { model: 'claude-sonnet-5', apiKey: 'sk-ant-oat01-test', permissionMode: 'default', planExitControls },
+    });
+    let turnIdx = 0;
+    messagesCreateMock.mockImplementation(() => {
+      turnIdx += 1;
+      if (turnIdx === 1) {
+        queueMicrotask(async () => { await query.setPermissionMode?.('plan'); flipResolver?.(); });
+      }
+      return fromArray(makeTextStream(`turn ${turnIdx}`));
+    });
+    await drainQuery(query as AsyncIterable<unknown>);
+    expect(messagesCreateMock).toHaveBeenCalledTimes(2);
+    // Turn 1 (default) must NOT offer it; turn 2 (plan) MUST — the regression.
+    expect(toolNamesOfCall(0)).not.toContain('exit_plan_mode');
+    expect(toolNamesOfCall(1)).toContain('exit_plan_mode');
+  });
+
+  it('started in plan, flipped to default mid-session → exit_plan_mode is NOT offered on turn 2', async () => {
+    const provider = new AnthropicDirectProvider();
+    let flipResolver: (() => void) | null = null;
+    const flip = new Promise<void>((r) => { flipResolver = r; });
+    async function* twoInputs() { yield { content: 't1' }; await flip; yield { content: 't2' }; }
+    const query = provider.query({
+      prompt: twoInputs(),
+      config: { model: 'claude-sonnet-5', apiKey: 'sk-ant-oat01-test', permissionMode: 'plan', planExitControls },
+    });
+    let turnIdx = 0;
+    messagesCreateMock.mockImplementation(() => {
+      turnIdx += 1;
+      if (turnIdx === 1) {
+        queueMicrotask(async () => { await query.setPermissionMode?.('default'); flipResolver?.(); });
+      }
+      return fromArray(makeTextStream(`turn ${turnIdx}`));
+    });
+    await drainQuery(query as AsyncIterable<unknown>);
+    expect(messagesCreateMock).toHaveBeenCalledTimes(2);
+    expect(toolNamesOfCall(0)).toContain('exit_plan_mode');
+    expect(toolNamesOfCall(1)).not.toContain('exit_plan_mode');
+  });
+
+  it('subagent-style session (no planExitControls) never offers exit_plan_mode, even in plan', async () => {
+    const provider = new AnthropicDirectProvider();
+    messagesCreateMock.mockImplementation(() => fromArray(makeTextStream('t1')));
+    const query = provider.query({
+      prompt: (async function* () { yield { content: 't1' }; })(),
+      config: { model: 'claude-sonnet-5', apiKey: 'sk-ant-oat01-test', permissionMode: 'plan' },
+    });
+    await drainQuery(query as AsyncIterable<unknown>);
+    expect(toolNamesOfCall(0)).not.toContain('exit_plan_mode');
+  });
+});

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -417,12 +417,18 @@ export class AnthropicDirectProvider implements ModelProvider {
       }
     }
     const mcpSchemas = this._mcpToolsCache ?? [];
-    // Plan-exit tool: the model-callable `exit_plan_mode`, registered per-query
-    // ONLY while in plan mode and only when the session supplied control
-    // callbacks (top-level sessions). Mirrors the `get_runtime_state` per-query
-    // registration above; the schema is appended to the dispatcher's list to
-    // match so the model sees the tool exactly when it is callable.
-    const planExitControls = permissionMode === 'plan' ? opts?.planExitControls : undefined;
+    // Plan-exit tool: the model-callable `exit_plan_mode`, registered RESIDENT
+    // whenever the session supplied control callbacks (top-level sessions only —
+    // subagents never get planExitControls). NOT gated on the construction-time
+    // `permissionMode`: the dispatcher is built once per query() and is NOT
+    // rebuilt by setPermissionMode, so a mode-gated registration here left the
+    // tool permanently unwired for the common "enter plan mode AFTER launch"
+    // flow (Shift+Tab / `/plan`), and the model got "Unknown tool exit_plan_mode".
+    // Callability is instead gated per-turn on the LIVE mode: query.ts filters
+    // this tool out of the advertised tool list on non-plan turns, so the model
+    // is offered it exactly when it is actionable — and it becomes callable the
+    // instant plan mode is entered mid-session, with no query rebuild.
+    const planExitControls = opts?.planExitControls;
     if (planExitControls) {
       handlers.set(EXIT_PLAN_MODE_TOOL_NAME, createExitPlanModeHandler(planExitControls));
     }
@@ -435,7 +441,9 @@ export class AnthropicDirectProvider implements ModelProvider {
       allowAll: pathContainmentBypassed(permissionMode),
       // Constraint (semantic invariant): MCP schemas appended AFTER builtins
       // so builtin tool names always take precedence in any overlap. The
-      // plan-exit schema is appended last, only while the tool is active.
+      // plan-exit schema is appended last, RESIDENT whenever planExitControls is
+      // present (top-level); query.ts filters it out of the advertised tool list
+      // on non-plan turns so the model sees it only when it is actionable.
       schemas: [
         ...this.schemas,
         ...mcpSchemas,
@@ -969,6 +977,9 @@ export class AnthropicDirectProvider implements ModelProvider {
             traceWriter: config.traceWriter,
             runtimeStateSource,
             hookRegistry: config.hookRegistry,
+            // Carry the resident plan-exit handler across a cwd rebuild — omitting
+            // this previously dropped `exit_plan_mode` after a `/cd` while planning.
+            planExitControls: config.planExitControls,
           });
           return { userSystem: newUserSystem, dispatcher: newDispatcher };
         };

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -54,6 +54,7 @@ import {
 } from './cache-policy.js';
 import { buildPlanModeAddendumBlock } from './plan-mode-addendum.js';
 import { buildAfkModeAddendumBlock } from './afk-mode-addendum.js';
+import { EXIT_PLAN_MODE_TOOL_NAME } from '../../tools/handlers/exit-plan-mode.js';
 import { collectSupportedCommands } from '../shared/supported-commands.js';
 import { contextLimitFor } from '../../model-limits.js';
 import { resolveModelId } from '../../session/model-resolution.js';
@@ -375,7 +376,18 @@ export class AnthropicDirectQuery implements ProviderQuery {
           client: this.retry.client as unknown as AnthropicClientLike,
           messages: this.state.messages,
           system,
-          tools: this.tools,
+          // Advertise the plan-exit tool only on LIVE plan turns. The dispatcher
+          // registers it RESIDENT (handler + base schema) for top-level sessions;
+          // here we drop it from the advertised tool list whenever the live mode
+          // is not 'plan'. This mirrors composeSystem() gating the plan addendum
+          // on the same live field — so the tool appears exactly when the model
+          // is being steered to call it, and becomes callable the instant plan
+          // mode is entered mid-session, with no query rebuild. No-op when
+          // `this.tools` doesn't carry it (non-top-level sessions).
+          tools:
+            this.state.currentPermissionMode === 'plan'
+              ? this.tools
+              : (this.tools?.filter((t) => t.name !== EXIT_PLAN_MODE_TOOL_NAME) ?? null),
           toolDispatcher: this.state.toolDispatcher,
           model: this.state.currentModel,
           maxTokens: this.maxTokens,

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -405,10 +405,15 @@ export class OpenAICompatibleProvider implements ModelProvider {
         handlers.set(t.schema.name, t.handler);
       }
     }
-    // Plan-exit tool: registered per-query ONLY while in plan mode and only when
-    // the session supplied control callbacks (top-level sessions). Mirrors
+    // Plan-exit tool: registered RESIDENT whenever the session supplied control
+    // callbacks (top-level sessions only). NOT gated on the construction-time
+    // `permissionMode` — the dispatcher is built once per query() and is not
+    // rebuilt by setPermissionMode, so a mode-gated registration left the tool
+    // unwired for the "enter plan mode after launch" flow ("Unknown tool
+    // exit_plan_mode"). Callability is gated per-turn on the LIVE mode instead:
+    // query.ts drops it from the advertised tools on non-plan turns. Mirrors
     // AnthropicDirectProvider.buildDispatcher; schema appended below to match.
-    const planExitControls = permissionMode === 'plan' ? opts.planExitControls : undefined;
+    const planExitControls = opts.planExitControls;
     if (planExitControls) {
       handlers.set(EXIT_PLAN_MODE_TOOL_NAME, createExitPlanModeHandler(planExitControls));
     }
@@ -441,7 +446,9 @@ export class OpenAICompatibleProvider implements ModelProvider {
       handlers,
       // Constraint (semantic invariant): MCP schemas appended AFTER builtins
       // so builtin tool names always take precedence in any overlap. Plan-exit
-      // schema appended last, only while the tool is active (plan mode).
+      // schema appended last, RESIDENT whenever planExitControls is present
+      // (top-level); query.ts drops it from the advertised tools on non-plan
+      // turns so the model sees it only when it is actionable.
       schemas: [...baseSchemas, ...mcpSchemas, ...(planExitControls ? [exitPlanModeTool] : [])],
       // Session hook registry via the one canonical resolver (query-scoped
       // config registry wins over any constructor-provided one). Mirrors

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -84,6 +84,7 @@ import type { ToolResult } from '../anthropic-direct/types.js';
 import { contextWindowTokensUsed, buildContextUsageFields } from '../shared/auto-compact.js';
 import { PLAN_MODE_ADDENDUM_TEXT } from '../shared/plan-mode-addendum.js';
 import { AFK_MODE_ADDENDUM_TEXT } from '../shared/afk-mode-addendum.js';
+import { EXIT_PLAN_MODE_TOOL_NAME } from '../../tools/handlers/exit-plan-mode.js';
 import { sleepWithAbort } from '../shared/sleep-with-abort.js';
 import { summarizeToolInput } from '../shared/tool-input-summary.js';
 
@@ -414,6 +415,24 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     this.closedPromise = new Promise<'__closed__'>((resolve) => {
       this.closeResolve = () => resolve('__closed__');
     });
+  }
+
+  /**
+   * The OpenAI tool catalog to advertise for THIS turn. The plan-exit tool is
+   * registered RESIDENT (see index.ts buildDispatcher) but is only actionable in
+   * plan mode, so drop it from the advertised list on non-plan turns — mirroring
+   * the anthropic-direct per-turn filter and composeSystem()'s live gating of the
+   * plan-mode addendum. This is what makes `exit_plan_mode` become callable the
+   * instant plan mode is entered mid-session, with no query rebuild. Returns
+   * `undefined` when the catalog is empty/absent, matching the callers' guards.
+   */
+  private activeOpenAITools(): OpenAIFunctionTool[] | undefined {
+    if (!this.openAITools) return undefined;
+    if (this.currentPermissionMode === 'plan') return this.openAITools;
+    const filtered = this.openAITools.filter(
+      (t) => t.function.name !== EXIT_PLAN_MODE_TOOL_NAME,
+    );
+    return filtered.length > 0 ? filtered : undefined;
   }
 
   async *[Symbol.asyncIterator](): AsyncIterator<ProviderEvent> {
@@ -774,7 +793,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       // Responses API path. `messages` (built + plan-mode-adjusted above) is
       // converted to the Responses input shape; the system prompt becomes
       // `instructions`, tool calls/results become function_call/_output items.
-      const req = buildResponsesRequest(messages, this.openAITools);
+      const req = buildResponsesRequest(messages, this.activeOpenAITools());
       const requestBody: Record<string, unknown> = {
         model: this.currentModel,
         input: req.input,
@@ -913,10 +932,12 @@ export class OpenAICompatibleQuery implements ProviderQuery {
         this.currentModel,
         this.opts.config.maxOutputTokens,
       ));
-      // Only attach `tools` when the dispatcher actually has any — empty
-      // arrays make some providers reject the request.
-      if (this.openAITools && this.openAITools.length > 0) {
-        requestBody['tools'] = this.openAITools;
+      // Only attach `tools` when there are any to advertise THIS turn — empty
+      // arrays make some providers reject the request. `activeOpenAITools()`
+      // drops the plan-exit tool on non-plan turns (resident-but-gated).
+      const activeTools = this.activeOpenAITools();
+      if (activeTools && activeTools.length > 0) {
+        requestBody['tools'] = activeTools;
       }
       // Forward reasoning effort for o-series models on Chat Completions.
       // Uses the `reasoning_effort` field per OpenAI's Chat Completions API spec.

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -89,6 +89,22 @@ export class AgentSession implements IAgentSession {
    * (AFK is not restorable by a bare flip) so restore falls back to 'default'.
    */
   private _prePlanPermissionMode: PermissionMode | undefined;
+  /**
+   * Ring-gesture memory for the Shift+Tab permission cycle
+   * (`default → plan → bypassPermissions`, see `cli/permission-mode-cycle.ts`).
+   * `plan`'s only ring-predecessor is `default`, so cycling from a privileged
+   * working mode (e.g. bypass) INTO plan necessarily passes through a TRANSIENT
+   * `default` hop: bypass → default → plan. Without this, {@link setPermissionMode}
+   * would capture that transient `default` as the pre-plan mode and an approved
+   * exit would drop the user to `default` instead of restoring their real working
+   * mode. So on a `<privileged> → default` transition we stash the mode left
+   * behind here; the very next `default → plan` transition restores it as the
+   * pre-plan mode. Cleared at every turn boundary (see `sendMessageStreamInternal`)
+   * so it survives ONLY an uninterrupted Shift+Tab gesture — a genuine rest in
+   * `default` (which submits a turn) clears it, keeping the restore safe: it never
+   * escalates back to bypass after the user actually worked in `default`.
+   */
+  private _modeBeforeDefault: PermissionMode | undefined;
   private currentState: SessionState = 'idle';
   private providerQuery!: ProviderQuery;
   private providerIterator!: AsyncIterator<ProviderEvent>;
@@ -592,6 +608,13 @@ export class AgentSession implements IAgentSession {
   private async *sendMessageStreamInternal(content: string | ContentBlockParam[]): AsyncIterableIterator<OutputEvent> {
     if (this.initPromise) await this.initPromise;
 
+    // End any in-flight Shift+Tab ring gesture: submitting a turn means the
+    // user actually RESTED in the current mode, so a transient-default stash
+    // from `setPermissionMode` must not survive into a later `default → plan`
+    // (which would wrongly restore bypass after real work in default). See
+    // {@link _modeBeforeDefault}.
+    this._modeBeforeDefault = undefined;
+
     // Fold queued hook context into THIS message so it rides along with the
     // user's text instead of becoming a turn of its own — see
     // `queueFrameworkContext` for the displacement bug this prevents.
@@ -856,11 +879,30 @@ export class AgentSession implements IAgentSession {
     // the real pre-plan mode with 'plan'. 'autonomous' (AFK) is reset to
     // undefined — it carries dedicated enter/exit machinery (toggleAfkMode) and
     // is not safe to re-enter by a bare flip — so restore falls back to 'default'.
+    const current = this.stateManager.getSessionMetadata().permissionMode;
     if (mode === 'plan') {
-      const current = this.stateManager.getSessionMetadata().permissionMode;
       if (current !== 'plan') {
-        this._prePlanPermissionMode = current === 'autonomous' ? undefined : current;
+        // Ring-gesture rescue: the Shift+Tab cycle reaches plan only via a
+        // TRANSIENT `default` hop off a privileged mode (bypass → default → plan).
+        // When we're entering plan FROM that transient default, restore the mode
+        // stashed on the hop instead of the default itself. `_modeBeforeDefault`
+        // is turn-scoped, so this only fires for an uninterrupted gesture.
+        const effectivePrev =
+          current === 'default' && this._modeBeforeDefault !== undefined
+            ? this._modeBeforeDefault
+            : current;
+        this._prePlanPermissionMode = effectivePrev === 'autonomous' ? undefined : effectivePrev;
       }
+    } else if (mode === 'default') {
+      // Stash the privileged mode being left so the NEXT `default → plan` press
+      // in the same Shift+Tab gesture can see past this transient default. Only
+      // privileged non-plan modes are worth restoring; default/plan are not.
+      this._modeBeforeDefault =
+        current !== 'default' && current !== 'plan' ? current : undefined;
+    } else {
+      // Landing on a concrete working mode (bypass / acceptEdits / …) ends any
+      // in-flight ring gesture toward plan — drop the transient-default memory.
+      this._modeBeforeDefault = undefined;
     }
     await this.providerQuery.setPermissionMode(mode);
     this.stateManager.setSessionMetadata((prev) => ({ ...prev, permissionMode: mode }));

--- a/src/agent/session/plan-mode-restore-ring.test.ts
+++ b/src/agent/session/plan-mode-restore-ring.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Fix A — the Shift+Tab permission ring (`default → plan → bypassPermissions`)
+ * must restore the user's real WORKING mode on plan exit, not the transient
+ * `default` the ring passes through.
+ *
+ * Because `plan`'s only ring-predecessor is `default`, cycling from bypass INTO
+ * plan is necessarily `bypass → default → plan`. `AgentSession.setPermissionMode`
+ * stashes the mode left on the `→ default` hop and, on the very next
+ * `default → plan`, restores it as the pre-plan mode — so an approved exit lands
+ * back in bypass. The stash is turn-scoped (cleared at each turn boundary) so a
+ * GENUINE rest in default (a submitted turn) does NOT escalate back to bypass.
+ *
+ * These tests exercise `setPermissionMode` capture + `getPrePlanMode()` (the value
+ * both `/plan off` and the `exit_plan_mode` picker restore) directly on a real
+ * `AgentSession` backed by the mock provider.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { AgentSession } from '../session.js';
+import type { AgentConfig } from '../types.js';
+import { createMockProvider } from '../__fixtures__/mock-provider.js';
+
+function makeSession(): AgentSession {
+  const config: AgentConfig = {
+    model: 'sonnet',
+    apiKey: 'test-key',
+    provider: createMockProvider(),
+  };
+  return new AgentSession(config);
+}
+
+let active: AgentSession | undefined;
+afterEach(async () => {
+  await active?.close();
+  active = undefined;
+});
+
+describe('plan-mode pre-plan restore across the Shift+Tab ring', () => {
+  it('bypass → default → plan (ring gesture) restores bypass, not the transient default', async () => {
+    const s = (active = makeSession());
+    await s.waitForInitialization();
+    await s.setPermissionMode('bypassPermissions');
+    await s.setPermissionMode('default'); // transient ring hop
+    await s.setPermissionMode('plan');
+    expect(s.getPrePlanMode()).toBe('bypassPermissions');
+  });
+
+  it('genuine default rest (turn submitted in default) → plan restores default', async () => {
+    // NB: the mock provider's session.init reports 'bypassPermissions', so the
+    // session starts in bypass; a submitted turn in default is what makes it a
+    // genuine rest (and clears any transient ring stash).
+    const s = (active = makeSession());
+    await s.waitForInitialization();
+    await s.setPermissionMode('default');
+    await s.sendMessage('working in default');
+    await s.setPermissionMode('plan');
+    expect(s.getPrePlanMode()).toBe('default');
+  });
+
+  it('bypass → plan directly (/plan on from bypass) restores bypass', async () => {
+    const s = (active = makeSession());
+    await s.waitForInitialization();
+    await s.setPermissionMode('bypassPermissions');
+    await s.setPermissionMode('plan');
+    expect(s.getPrePlanMode()).toBe('bypassPermissions');
+  });
+
+  it('landing on a concrete mode clears the stash (last privileged-before-default wins)', async () => {
+    const s = (active = makeSession());
+    await s.waitForInitialization();
+    await s.setPermissionMode('bypassPermissions');
+    await s.setPermissionMode('default'); // stash bypass
+    await s.setPermissionMode('acceptEdits'); // concrete mode → clears stash
+    await s.setPermissionMode('default'); // stash acceptEdits
+    await s.setPermissionMode('plan');
+    expect(s.getPrePlanMode()).toBe('acceptEdits');
+  });
+
+  it('SAFETY: a submitted turn in default clears the stash → plan restores default, never escalates to bypass', async () => {
+    const s = (active = makeSession());
+    await s.waitForInitialization();
+    await s.setPermissionMode('bypassPermissions');
+    await s.setPermissionMode('default'); // stash bypass
+    await s.sendMessage('do some work in default'); // genuine rest → clears stash
+    await s.setPermissionMode('plan');
+    expect(s.getPrePlanMode()).toBe('default');
+  });
+});


### PR DESCRIPTION
## Summary

Two related plan-mode fixes, root-caused from prior-session witness traces (7 of 8 sessions where `exit_plan_mode` was called failed with "Unknown tool").

### C — `exit_plan_mode` returns "Unknown tool" after entering plan mode mid-session

The tool's handler + schema were registered in `buildDispatcher()` **only when `permissionMode === 'plan'` at `query()` construction time**, and `setPermissionMode` never rebuilds the dispatcher (it only flips the live addendum/gate fields). So a session launched in a non-plan mode that entered plan **later** (Shift+Tab / `/plan`, same model) had the tool advertised by the plan-mode addendum but never actually wired — the model called it and the dispatcher returned `Unknown tool "exit_plan_mode"`. It only worked when the dispatcher happened to be (re)built while already in plan (`--permission-mode plan` at launch, or a model switch mid-plan that rebuilt the query).

**Fix:** register the tool **resident** whenever the session supplied `planExitControls` (top-level sessions only — subagents never get them), and gate **advertisement per-turn on the live permission mode** in `query.ts` (filter it out of the API tool list on non-plan turns — mirroring how `composeSystem()` gates the plan-mode addendum on the same live field). Applied to both `anthropic-direct` and `openai-compatible`. Also threads `planExitControls` through the anthropic `cwdDependentsFactory` rebuild so the resident handler survives a `/cd` while planning (latent gap).

### A — `/plan off` dropping bypass to default after a Shift+Tab plan excursion

The Shift+Tab ring is `default -> plan -> bypassPermissions`, so `plan`'s only ring-predecessor is `default`; cycling from bypass into plan necessarily passes through a **transient `default` hop** (`bypass -> default -> plan`). The pre-plan capture therefore recorded `default`, and an approved exit restored `default` instead of the user's real working mode (bypass).

**Fix:** `AgentSession.setPermissionMode` now stashes the privileged mode left on the `-> default` hop and restores it on the next `default -> plan`. The stash is **turn-scoped** (cleared at every turn boundary in `sendMessageStreamInternal`), so a genuine rest in `default` (a submitted turn) never escalates back to bypass — the restore stays safe.

## Files
- `providers/anthropic-direct/{index,query}.ts` — resident registration + per-turn live filter + cwd-rebuild thread-through
- `providers/openai-compatible/{index,query}.ts` — same (via `activeOpenAITools()`)
- `session/agent-session.ts` — ring-aware pre-plan capture + turn-boundary safety clear

## Tests
- `anthropic-direct/exit-plan-mode-live-tools.test.ts` — mid-session flip both directions (default->plan offers it on turn 2; plan->default drops it) + subagent guard
- `session/plan-mode-restore-ring.test.ts` — ring restores bypass; genuine default rest restores default; concrete-mode clears stash; turn-boundary anti-escalation

## Verification
`tsc --noEmit` clean; `session/` + `providers/` suites **930 passing**; `audit:sdk:check` / `audit:env:check` / `scan:env:check` all pass. No new SDK symbols or `process.env` reads.
