### PR TITLE
test: isolate vitest state writes from real ~/.afk

### DIFF
--- a/src/__test-utils__/redirect-paths-env.ts
+++ b/src/__test-utils__/redirect-paths-env.ts
@@ -1,0 +1,72 @@
+// Global test setup: redirect the AFK paths tier (AFK_HOME + derived state/
+// framework dirs) to a per-test-file temp dir so `pnpm test` NEVER writes to
+// the real ~/.afk.
+//
+// History: before this file existed, the paths category was deliberately left
+// untouched by clean-config-env.ts (see its Invariant header) and any test
+// that exercised state-writing production code WITHOUT redirecting env wrote
+// into the developer's real ~/.afk/state — the observed damage was ~6,700
+// fixture-named witness dirs (t-*, task-a-*, ss-task-*), literal fixture ids
+// under state/sessions/ (parent-session, some-resumed-id), and ~30k `/extra`
+// rows in state/session-grants.jsonl appended by dispatcher.test.ts's
+// grant-audit-log path. Clearing/sealing the paths vars in a beforeEach was
+// previously verified to break two groups: ~11 test files that assign paths
+// vars at module-eval time, and ~44 tests that assert the UNSET fallback
+// (getAfkHome() → ~/.afk). This file threads that needle — see the Invariants.
+//
+// Invariant: the redirect happens ONCE, at setup-module EVAL time, never in a
+// beforeEach/afterEach hook. Vitest evaluates setupFiles before the test-file
+// module in the same worker, so:
+//   - test files that assign AFK_HOME/AFK_STATE_DIR at module-eval time or in
+//     their own hooks run AFTER this file and cleanly override the sentinel;
+//   - their save/restore idiom (snapshot AFK_HOME into `prev`, override,
+//     restore `prev` in afterEach) captures the SENTINEL as `prev` and
+//     restores it, keeping later tests in the same file isolated;
+//   - tests that assert the unset fallback delete AFK_HOME/AFK_STATE_DIR
+//     themselves (and point HOME at a tmp dir), which this file must not
+//     re-instate mid-file — hence no beforeEach.
+//
+// Invariant: the sentinel dir is a fresh mkdtemp per TEST FILE (vitest's
+// default isolation gives each file its own worker module registry, so this
+// module re-evaluates per file). Per-file freshness prevents cross-file bleed
+// through shared state paths (e.g. listSessions() counting another file's
+// saves). The dir is removed in afterAll, best-effort.
+//
+// Invariant: AFK_STATE_DIR and AFK_FRAMEWORK_DIR are DELETED, not set — both
+// derive from AFK_HOME when unset (src/paths.ts), so deleting them makes the
+// sentinel AFK_HOME govern the whole tier AND removes bleed from a developer
+// shell that exports them (AFK_FRAMEWORK_DIR is commonly exported by
+// src/cli/index.ts into child sessions).
+import { afterAll } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+/**
+ * Escape hatch for the rare debugging session that intentionally wants tests
+ * to run against a caller-chosen AFK_HOME. Never set in CI.
+ */
+const OPT_OUT = process.env['AFK_TEST_NO_PATH_REDIRECT'] === '1'; // audit-env-access: allow — test-only escape hatch, not a runtime config var
+
+/** Exported for the regression-guard test (tests/state-isolation.test.ts). */
+export const SENTINEL_PREFIX = 'afk-test-home-';
+
+let sentinelDir: string | undefined;
+
+if (!OPT_OUT) {
+  sentinelDir = mkdtempSync(join(tmpdir(), SENTINEL_PREFIX));
+  process.env['AFK_HOME'] = sentinelDir; // audit-env-access: allow — test-setup redirect of the paths tier
+  delete process.env['AFK_STATE_DIR']; // audit-env-access: allow — derive from sentinel AFK_HOME
+  delete process.env['AFK_FRAMEWORK_DIR']; // audit-env-access: allow — derive from sentinel AFK_HOME
+}
+
+afterAll(() => {
+  if (sentinelDir !== undefined) {
+    try {
+      rmSync(sentinelDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort: a leaked dir under os.tmpdir() is harmless and the OS
+      // reaps it eventually. Never fail the suite over cleanup.
+    }
+  }
+});

--- a/src/__test-utils__/unset-afk-home.ts
+++ b/src/__test-utils__/unset-afk-home.ts
@@ -1,0 +1,24 @@
+// Helper for suites that assert the UNSET-fallback path resolution
+// (getAfkHome() → $HOME/.afk). The global setup redirect-paths-env.ts sets a
+// sentinel AFK_HOME for every test file, which would shadow these suites'
+// HOME-based tmp-dir isolation. Calling useUnsetAfkHome() at describe/file
+// scope removes AFK_HOME before each test and restores the sentinel after,
+// so the suite exercises the fallback while the rest of the file (and any
+// suite that forgets to redirect HOME) stays pointed at the sentinel.
+//
+// Safety contract for callers: any suite using this helper MUST also point
+// HOME at a throwaway tmp dir in its own beforeEach — with AFK_HOME unset,
+// state-writing production code falls back to $HOME/.afk.
+import { beforeEach, afterEach } from 'vitest';
+
+export function useUnsetAfkHome(): void {
+  let saved: string | undefined;
+  beforeEach(() => {
+    saved = process.env['AFK_HOME']; // audit-env-access: allow — test-only env manipulation helper
+    delete process.env['AFK_HOME']; // audit-env-access: allow — test-only env manipulation helper
+  });
+  afterEach(() => {
+    if (saved !== undefined) process.env['AFK_HOME'] = saved; // audit-env-access: allow — restore sentinel
+    else delete process.env['AFK_HOME']; // audit-env-access: allow — test-only env manipulation helper
+  });
+}

--- a/src/agent/daemon/separation.test.ts
+++ b/src/agent/daemon/separation.test.ts
@@ -7,9 +7,15 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { existsSync, rmSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { useUnsetAfkHome } from '../../__test-utils__/unset-afk-home.js';
 
 let tmpHome: string;
 let originalHome: string | undefined;
+
+// This suite asserts the unset-AFK_HOME fallback ($HOME/.afk) — drop the
+// global sentinel AFK_HOME for each test; HOME is redirected to a tmp dir
+// in beforeEach below, satisfying the helper's safety contract.
+useUnsetAfkHome();
 
 beforeEach(() => {
   originalHome = process.env['HOME'];

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -399,8 +399,15 @@ describe('Config Loader', () => {
     });
 
     it('falls back to ~/.afk/AFK.md when cwd/AFK.md is absent', () => {
-      // Use homedir-based path since AFK_HOME is not set in tests
-      const homeAfkMd = join(process.env['HOME'] ?? process.env['USERPROFILE'] ?? '', '.afk', 'AFK.md');
+      // Mirror getAfkHome() precedence: the global test setup
+      // (redirect-paths-env.ts) points AFK_HOME at a tmp sentinel, so the
+      // user-scope AFK.md resolves under it; fall back to $HOME/.afk only
+      // if the redirect is opted out.
+      const homeAfkMd = join(
+        process.env['AFK_HOME'] ??
+          join(process.env['HOME'] ?? process.env['USERPROFILE'] ?? '', '.afk'),
+        'AFK.md',
+      );
       mockedExistsSync().mockImplementation((p) => {
         const s = String(p);
         if (s.endsWith('AFK.md')) return s === homeAfkMd;

--- a/src/cli/daemon-config.test.ts
+++ b/src/cli/daemon-config.test.ts
@@ -18,11 +18,17 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { loadConfig, _resetConfigCache } from './config.js';
+import { useUnsetAfkHome } from '../__test-utils__/unset-afk-home.js';
 
 vi.mock('dotenv', () => ({
   default: { config: () => ({ parsed: {} }) },
   config: () => ({ parsed: {} }),
 }));
+
+// This suite writes afk.config.json under $HOME/.afk/config and expects
+// loadConfig() to find it via the unset-AFK_HOME fallback — drop the global
+// sentinel AFK_HOME per test; HOME is redirected to a tmp dir below.
+useUnsetAfkHome();
 
 let tmpHome: string;
 let originalHome: string | undefined;

--- a/src/cli/session-store.test.ts
+++ b/src/cli/session-store.test.ts
@@ -17,9 +17,14 @@ import {
   forkStoredSession,
 } from './session-store.js';
 import { createSessionStats, recordTurn } from './slash/session-stats.js';
+import { useUnsetAfkHome } from '../__test-utils__/unset-afk-home.js';
 
 let tmpHome: string;
 let originalHome: string | undefined;
+
+// This suite asserts the unset-AFK_HOME fallback (store under $HOME/.afk) —
+// drop the global sentinel AFK_HOME per test; HOME is redirected below.
+useUnsetAfkHome();
 
 beforeEach(() => {
   originalHome = process.env['HOME'];

--- a/src/cli/slash/commands/save.test.ts
+++ b/src/cli/slash/commands/save.test.ts
@@ -13,9 +13,14 @@ import { tmpdir } from 'os';
 import { saveCmd } from './save.js';
 import { loadSession, listSessions } from '../../session-store.js';
 import type { SlashContext, SessionStats } from '../types.js';
+import { useUnsetAfkHome } from '../../../__test-utils__/unset-afk-home.js';
 
 let tmpHome: string;
 let originalHome: string | undefined;
+
+// This suite asserts the unset-AFK_HOME fallback (store under $HOME/.afk) —
+// drop the global sentinel AFK_HOME per test; HOME is redirected below.
+useUnsetAfkHome();
 
 beforeEach(() => {
   originalHome = process.env['HOME'];

--- a/src/cli/slash/plugin-skills-harvest.test.ts
+++ b/src/cli/slash/plugin-skills-harvest.test.ts
@@ -10,8 +10,15 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { useUnsetAfkHome } from '../../__test-utils__/unset-afk-home.js';
 
 describe('harvestPluginSkillFlags', () => {
+  // The "defaults to ~/.afk/plugins/cache under HOME" case asserts the
+  // unset-AFK_HOME fallback — drop the global sentinel AFK_HOME per test.
+  // The harvester is read-only and every other case passes an explicit
+  // cacheRoot, so nothing writes into $HOME/.afk.
+  useUnsetAfkHome();
+
   let tmpRoot: string;
   let harvestPluginSkillFlags: (cacheRoot?: string) => Map<string, string[]>;
 

--- a/src/paths-separation.test.ts
+++ b/src/paths-separation.test.ts
@@ -18,9 +18,14 @@ import {
   getAfkHome,
   getPluginsDir,
 } from './paths.js';
+import { useUnsetAfkHome } from './__test-utils__/unset-afk-home.js';
 
 let tmpHome: string;
 let originalHome: string | undefined;
+
+// This suite asserts the unset-AFK_HOME fallback ($HOME/.afk) — drop the
+// global sentinel AFK_HOME per test; HOME is redirected to a tmp dir below.
+useUnsetAfkHome();
 
 beforeEach(() => {
   originalHome = process.env['HOME'];

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -37,9 +37,15 @@ import {
   getBrowserProfileStateDir,
   getBrowserStorageStatePath,
 } from './paths.js';
+import { useUnsetAfkHome } from './__test-utils__/unset-afk-home.js';
 
 let tmpHome: string;
 let originalHome: string | undefined;
+
+// This suite asserts the unset-AFK_HOME fallback ($HOME/.afk) — drop the
+// global sentinel AFK_HOME per test; HOME is redirected to a tmp dir below.
+// Cases that exercise AFK_HOME explicitly set/delete it themselves.
+useUnsetAfkHome();
 
 beforeEach(() => {
   originalHome = process.env['HOME'];

--- a/src/skills/mint.test.ts
+++ b/src/skills/mint.test.ts
@@ -14,9 +14,15 @@ import { getSkill, registerSkill } from './index.js';
 import type { MintState } from './mint/index.js';
 import type { IAgentSession, OutputEvent, SubagentProgressMeta } from '../agent/types.js';
 import { runWithSink } from '../agent/_lib/skill-sink-channel.js';
+import { useUnsetAfkHome } from '../__test-utils__/unset-afk-home.js';
 
 // Import the skill module to trigger registration
 import './mint/index.js';
+
+// The disk-persisted state cases assert mint-state.json lands under
+// $HOME/.afk (mintStatePath below builds from tmpHome) — drop the global
+// sentinel AFK_HOME per test; HOME is redirected in beforeEach.
+useUnsetAfkHome();
 
 const sharedMintMock = vi.hoisted(() => ({
   forkOptions: [] as Array<Record<string, unknown>>,

--- a/src/telegram/session-manager.test.ts
+++ b/src/telegram/session-manager.test.ts
@@ -9,6 +9,7 @@ import { findSession, listSessions, loadSession } from '../cli/session-store';
 import { promises as fs, existsSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { useUnsetAfkHome } from '../__test-utils__/unset-afk-home.js';
 
 // Mock agent session
 class MockAgentSession implements IAgentSession {
@@ -530,6 +531,11 @@ describe('SessionManager', () => {
 });
 
 describe('SessionManager — recordTelegramTurn (shared session store)', () => {
+  // saveSession()/findSession() resolve the store via the unset-AFK_HOME
+  // fallback ($HOME/.afk) — drop the global sentinel AFK_HOME per test;
+  // HOME is redirected to a tmp dir in this describe's beforeEach.
+  useUnsetAfkHome();
+
   // Mock carrying a readonly SDK sessionId so we can exercise both the
   // metadata-supplied and live-session-captured sessionId paths.
   class MockSessionWithId implements IAgentSession {
@@ -627,6 +633,10 @@ describe('SessionManager — recordTelegramTurn (shared session store)', () => {
 });
 
 describe('SessionManager — session naming (/name)', () => {
+  // Same unset-fallback contract as the recordTelegramTurn suite above:
+  // the shared session store must resolve under this suite's tmp HOME.
+  useUnsetAfkHome();
+
   class MockSessionWithId implements IAgentSession {
     state: SessionState = 'idle';
     constructor(readonly sessionId?: string) {}

--- a/tests/agent/memory/memory-loader.test.ts
+++ b/tests/agent/memory/memory-loader.test.ts
@@ -11,9 +11,15 @@ import { tmpdir } from 'os';
 import { randomUUID } from 'crypto';
 import type { AgentConfig } from '../../../src/agent/types/config-types.js';
 import { loadHotMemory, injectHotMemory } from '../../../src/agent/memory/memory-loader.js';
+import { useUnsetAfkHome } from '../../../src/__test-utils__/unset-afk-home.js';
 
 let tmpHome: string;
 let originalHome: string | undefined;
+
+// HOT.md fixtures are written under $HOME/.afk/state/memory and the loader
+// resolves that via the unset-AFK_HOME fallback — drop the global sentinel
+// AFK_HOME per test; HOME is redirected to a tmp dir below.
+useUnsetAfkHome();
 
 beforeEach(() => {
   originalHome = process.env['HOME'];

--- a/tests/state-isolation.test.ts
+++ b/tests/state-isolation.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression guard: the vitest run must be isolated from the real ~/.afk.
+ *
+ * Contract: src/__test-utils__/redirect-paths-env.ts (a global setupFile)
+ * points AFK_HOME at a per-file mkdtemp sentinel under os.tmpdir() BEFORE any
+ * test module evaluates, so production code that resolves paths via
+ * src/paths.ts writes into the sentinel — never into the developer's real
+ * ~/.afk/state. This suite verifies that redirect is actually in place and
+ * actually governs the resolved path helpers. If someone removes the setup
+ * file from vitest.config.ts, reorders it after a conflicting setup, or adds
+ * a beforeEach that clears the paths category, these assertions fail loudly.
+ *
+ * History: before the redirect existed, `pnpm test` accumulated ~6,700
+ * fixture-named dirs under ~/.afk/state/witness/, fixture session ids under
+ * ~/.afk/state/sessions/, and ~30k audit rows in
+ * ~/.afk/state/session-grants.jsonl. See PR "test: isolate vitest state
+ * writes from real ~/.afk".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { tmpdir, homedir } from 'os';
+import { join, sep } from 'path';
+import { realpathSync } from 'fs';
+import { SENTINEL_PREFIX } from '../src/__test-utils__/redirect-paths-env.js';
+import {
+  getAfkHome,
+  getAfkStateDir,
+  getSessionsDir,
+  getSessionGrantsPath,
+  getTraceDir,
+  getAgentFrameworkDir,
+} from '../src/paths.js';
+
+const REAL_AFK = join(homedir(), '.afk');
+
+/**
+ * True when `p` lives inside the OS temp tree. Checks both the literal
+ * tmpdir() and its realpath because macOS aliases /tmp and /var/folders
+ * through /private.
+ */
+function isUnderTmp(p: string): boolean {
+  const tmpReal = realpathSync(tmpdir());
+  return p.startsWith(tmpdir() + sep) || p.startsWith(tmpReal + sep);
+}
+
+describe('test-run state isolation (real ~/.afk must never be written)', () => {
+  it('AFK_HOME is redirected to a sentinel temp dir by the global setup', () => {
+    const afkHome = process.env['AFK_HOME'];
+    expect(afkHome, 'redirect-paths-env.ts setup did not run').toBeDefined();
+    expect(afkHome).toContain(SENTINEL_PREFIX);
+    expect(isUnderTmp(afkHome!)).toBe(true);
+    expect(afkHome).not.toBe(REAL_AFK);
+  });
+
+  it('AFK_STATE_DIR and AFK_FRAMEWORK_DIR do not leak in from the dev shell', () => {
+    // The setup deletes both so the sentinel AFK_HOME governs the whole tier.
+    expect(process.env['AFK_STATE_DIR']).toBeUndefined();
+    expect(process.env['AFK_FRAMEWORK_DIR']).toBeUndefined();
+  });
+
+  it('every state-tier path helper resolves under the sentinel, not real ~/.afk', () => {
+    const sentinel = process.env['AFK_HOME']!;
+    expect(getAfkHome()).toBe(sentinel);
+    for (const p of [
+      getAfkStateDir(),
+      getSessionsDir(),
+      getSessionGrantsPath(),
+      getTraceDir('isolation-guard-probe'),
+      getAgentFrameworkDir(),
+    ]) {
+      expect(p.startsWith(sentinel + sep)).toBe(true);
+      expect(p.startsWith(REAL_AFK + sep)).toBe(false);
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     environment: 'node',
     setupFiles: [
       './src/__test-utils__/stdin-claim-reset.ts',
+      // Redirect the AFK paths tier (AFK_HOME) to a per-file temp sentinel so
+      // no test can write into the real ~/.afk. Runs at setup-module eval time
+      // (before the test file's module eval) so per-suite overrides still win.
+      './src/__test-utils__/redirect-paths-env.ts',
       // Neutralize the developer's ambient AFK_*/provider config so tests
       // assert framework defaults, not the dev's shell / ~/.afk/config/afk.env.
       './src/__test-utils__/clean-config-env.ts',


### PR DESCRIPTION
## Problem

`pnpm test` was writing into the developer's **real `~/.afk/state`**. Observed damage on this machine:

- **~6,700+ fixture-named witness dirs** under `~/.afk/state/witness/` (`t-*`, `task-a-*`, `ss-task-*`, `isolation-guard-probe`, …) — total dir count had grown to 17,678
- **~30k+ `/extra` grant rows** appended to `~/.afk/state/session-grants.jsonl` by dispatcher.test.ts's grant-audit-log path — file had grown to 243,594 lines / 47MB
- literal fixture session ids (`parent-session`, `some-resumed-id`) under `~/.afk/state/sessions/`

## Root cause

`src/__test-utils__/clean-config-env.ts` deliberately excludes the `paths` category (`NON_OVERRIDE_CATEGORIES`) from its env-clearing, so `AFK_HOME` / `AFK_STATE_DIR` were never neutralized. Any test that exercised state-writing production code without redirecting env itself resolved paths via `src/paths.ts` straight into the real `~/.afk`.

## Fix design

1. **`src/__test-utils__/redirect-paths-env.ts`** (new global setupFile, registered *before* clean-config-env.ts): at setup-module **eval time** — never in a beforeEach — mkdtemps a per-test-file sentinel dir under `os.tmpdir()`, sets `AFK_HOME` to it, and **deletes** `AFK_STATE_DIR` / `AFK_FRAMEWORK_DIR` (both derive from `AFK_HOME`). Eval-time placement means suites that assign paths vars themselves still cleanly override the sentinel, and their save/restore idiom restores the sentinel, not the real home. Removed in `afterAll`, best-effort. Opt-out: `AFK_TEST_NO_PATH_REDIRECT=1`.
2. **`src/__test-utils__/unset-afk-home.ts`**: `useUnsetAfkHome()` helper for the ~10 suites that assert the **unset fallback** (`getAfkHome()` → `$HOME/.afk`) — deletes `AFK_HOME` per test, restores the sentinel after. Callers must (and do) point `HOME` at a tmp dir.
3. **`tests/state-isolation.test.ts`**: regression guard — fails loudly if the setup is removed, reordered, or a beforeEach starts clearing the paths tier.

## Suites adapted (unset-fallback class)

`paths.test.ts`, `paths-separation.test.ts`, `agent/daemon/separation.test.ts`, `cli/session-store.test.ts`, `cli/slash/commands/save.test.ts`, `cli/daemon-config.test.ts`, `cli/slash/plugin-skills-harvest.test.ts`, `skills/mint.test.ts`, `telegram/session-manager.test.ts` (2 describes), `tests/agent/memory/memory-loader.test.ts` — plus `cli/config.test.ts`, whose AFK.md-fallback case now mirrors `getAfkHome()` precedence (fs-mocked; no real writes).

## Proof — pollution counters across a full suite run

| Counter | Before run | After run |
|---|---|---|
| `ls ~/.afk/state/witness \| wc -l` | 17,678 | **17,678** |
| `wc -l ~/.afk/state/session-grants.jsonl` | 243,594 | **243,594** |
| `ls ~/.afk/state/sessions \| wc -l` | 10,101 | **10,101** |

mtimes of all three paths unchanged (witness 13:00:00, sessions 13:00:24, grants 11:21:17 vs. run at 13:33). Zero leaked `afk-test-home-*` sentinel dirs left in tmp.

## Test / lint / audit results

- `pnpm test`: **582 files passed, 10,714 tests passed, 14 skipped, 0 failed** (the two occasionally-flaky local failures — config.test.ts DEFAULT_SLOT_BINDINGS MLX bleed, anthropic-direct.test.ts compact — did not reproduce; both now run against the sentinel)
- `pnpm lint` (strict tsc): clean
- `pnpm audit:env:check`: 588 files scanned, 0 violations
- `pnpm scan:env:check`: registry in sync (118 vars)
