### PR TITLE
fix(openai): fall back to AFK_OPENAI_BASE_URL so deep subagents don't hit api.openai.com

### DIFF
--- a/src/agent/providers/openai-compatible/base-url.test.ts
+++ b/src/agent/providers/openai-compatible/base-url.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { resolveEffectiveOpenAIBaseUrl } from './base-url.js';
+
+describe('resolveEffectiveOpenAIBaseUrl', () => {
+  it('prefers per-session config.openaiBaseUrl over ctor and env', () => {
+    expect(
+      resolveEffectiveOpenAIBaseUrl('https://cfg/v1', 'https://ctor/v1', 'https://env/v1'),
+    ).toBe('https://cfg/v1');
+  });
+
+  it('falls back to the construction-time baseURL when config is undefined', () => {
+    expect(resolveEffectiveOpenAIBaseUrl(undefined, 'https://ctor/v1', 'https://env/v1')).toBe(
+      'https://ctor/v1',
+    );
+  });
+
+  it('falls back to AFK_OPENAI_BASE_URL when config and ctor are undefined (the lost-base-URL fix)', () => {
+    // Regression guard: a deep OpenAI-routed subagent whose child config never
+    // threaded openaiBaseUrl must still reach the configured endpoint, NOT
+    // api.openai.com (where a non-OpenAI key 401s as "Incorrect API key").
+    expect(resolveEffectiveOpenAIBaseUrl(undefined, undefined, 'https://opencode.ai/zen/go/v1')).toBe(
+      'https://opencode.ai/zen/go/v1',
+    );
+  });
+
+  it('returns undefined (→ SDK default api.openai.com) when nothing is set', () => {
+    expect(resolveEffectiveOpenAIBaseUrl(undefined, undefined, undefined)).toBeUndefined();
+  });
+
+  it('strips a trailing /chat/completions from the env fallback (SDK appends it)', () => {
+    expect(
+      resolveEffectiveOpenAIBaseUrl(undefined, undefined, 'https://x/v1/chat/completions'),
+    ).toBe('https://x/v1');
+  });
+
+  it('treats a whitespace-only env value as absent', () => {
+    expect(resolveEffectiveOpenAIBaseUrl(undefined, undefined, '   ')).toBeUndefined();
+  });
+
+  it('preserves an empty-string config value (parity with the prior ?? behavior)', () => {
+    // The original `config.openaiBaseUrl ?? providerOpts.baseURL` kept a set-but-
+    // empty config value; `!== undefined` matches that (config is never '' in
+    // practice — loadConfig gates on a truthy env — but keep the semantics stable).
+    expect(resolveEffectiveOpenAIBaseUrl('', 'https://ctor/v1', 'https://env/v1')).toBe('');
+  });
+});

--- a/src/agent/providers/openai-compatible/base-url.ts
+++ b/src/agent/providers/openai-compatible/base-url.ts
@@ -1,0 +1,43 @@
+/**
+ * Effective baseURL resolution for the OpenAI-compatible client.
+ *
+ * Precedence: per-session `config.openaiBaseUrl` > construction-time
+ * `providerOpts.baseURL` > global `AFK_OPENAI_BASE_URL` (normalized) >
+ * undefined (→ the OpenAI SDK default `https://api.openai.com/v1`).
+ *
+ * The env tier is a safety net. A deep child/grandchild session dispatched
+ * through the skill / subagent / compose executors inherits a child config that
+ * does NOT thread `openaiBaseUrl` (SubagentExecutorContext.defaultConfig is
+ * `Pick<AgentConfig,'apiKey'|'systemPrompt'|'baseUrl'>` — no openaiBaseUrl).
+ * Without this fallback such a session silently POSTs to api.openai.com and a
+ * non-OpenAI key (e.g. an opencode key) is rejected as "Incorrect API key".
+ * Reading the env here — not only at config load — makes the endpoint resilient
+ * to that gap. A trailing `/chat/completions` is stripped (the SDK appends it);
+ * this mirrors `normalizeOpenAIBaseUrl` (cli/config.ts) but is kept local to
+ * avoid an agent→cli import cycle, and without the config-time stderr warning.
+ *
+ * @module agent/providers/openai-compatible/base-url
+ */
+
+/**
+ * Pick the baseURL to hand the OpenAI SDK, or `undefined` to let it use its
+ * own default. See the module docstring for the precedence rationale.
+ */
+export function resolveEffectiveOpenAIBaseUrl(
+  configOpenaiBaseUrl: string | undefined,
+  ctorBaseUrl: string | undefined,
+  envBaseUrl: string | undefined,
+): string | undefined {
+  if (configOpenaiBaseUrl !== undefined) return configOpenaiBaseUrl;
+  if (ctorBaseUrl !== undefined) return ctorBaseUrl;
+  return normalizeEnvBaseUrl(envBaseUrl);
+}
+
+/** Trim + drop a redundant trailing `/chat/completions`; empty → undefined. */
+function normalizeEnvBaseUrl(raw: string | undefined): string | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  const suffix = '/chat/completions';
+  return trimmed.endsWith(suffix) ? trimmed.slice(0, -suffix.length) : trimmed;
+}

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -16,6 +16,8 @@ import path from 'path';
 import { appendFileSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
 import { getSessionGrantsPath } from '../../../paths.js';
+import { env } from '../../../config/env.js';
+import { resolveEffectiveOpenAIBaseUrl } from './base-url.js';
 import type {
   ModelProvider,
   ProviderQuery,
@@ -257,11 +259,19 @@ export class OpenAICompatibleProvider implements ModelProvider {
       onPermissionMode?: (mode: string) => void;
       mcpManager?: import('../../mcp/index.js').McpManager;
     } = {};
-    // Per-slot / per-session baseURL (`config.openaiBaseUrl`, set by
-    // applySlotCredentials) wins over the construction-time global
-    // (`providerOpts.baseURL`, from AFK_OPENAI_BASE_URL) so a tier bound to its
-    // own endpoint overrides the process default. See model-slots Stage 2.
-    const effectiveBaseURL = config.openaiBaseUrl ?? this.providerOpts.baseURL;
+    // Effective baseURL precedence (see resolveEffectiveOpenAIBaseUrl):
+    //   per-session config.openaiBaseUrl (set by applySlotCredentials / loadConfig)
+    //   > construction-time providerOpts.baseURL
+    //   > global AFK_OPENAI_BASE_URL (normalized) > SDK default (api.openai.com).
+    // The env tier is the safety net: a deep child/grandchild dispatched through the
+    // skill/subagent/compose executors inherits a child config that does not thread
+    // `openaiBaseUrl`, so without it an OpenAI-routed subagent would POST to
+    // api.openai.com and a non-OpenAI key be rejected as "Incorrect API key".
+    const effectiveBaseURL = resolveEffectiveOpenAIBaseUrl(
+      config.openaiBaseUrl,
+      this.providerOpts.baseURL,
+      env.AFK_OPENAI_BASE_URL,
+    );
     if (effectiveBaseURL !== undefined) buildOpts.baseURL = effectiveBaseURL;
     buildOpts.toolDispatcher = dispatcher;
     // Path-approval half of the live `/bypass` toggle: keep the provider's


### PR DESCRIPTION
## Motivation

An OpenAI-routed subagent dispatched **deep** inside a skill chain (e.g. `/review` → review → review → `agent(research-agent)`) fails with `401 Incorrect API key provided: sk-…` — and the key is *valid*. Diagnosis: that exact string is OpenAI's canonical error, returned when a **non-OpenAI key is sent to `api.openai.com`**. The subagent's request went to the default OpenAI endpoint instead of the configured `AFK_OPENAI_BASE_URL` (e.g. opencode), so a valid opencode key was (correctly) rejected there.

## Root cause

The OpenAI-compatible client's endpoint is resolved as `config.openaiBaseUrl ?? providerOpts.baseURL` (`openai-compatible/index.ts`), defaulting to `https://api.openai.com/v1` when both are undefined. But:

- `config.openaiBaseUrl` is only set on the **main** session (`loadConfig`) or a **per-slot** binding (`applySlotCredentials`). It is **not threaded** through the child-config chain: `SubagentExecutorContext.defaultConfig` is `Pick<AgentConfig,'apiKey'|'systemPrompt'|'baseUrl'>` — no `openaiBaseUrl` — and the skill/compose executors forward `apiKey` + the Anthropic `baseUrl` but not `openaiBaseUrl`.
- `resolveProvider` constructs `new OpenAICompatibleProvider(ctorOpts)` with no `baseURL`, so `providerOpts.baseURL` is undefined too.

Net: a deep grandchild loses the endpoint and silently hits `api.openai.com`. Shallow subagents work (their child config still carries it), which is why the failure only appears deep in a fan-out.

## Fix

Add a **third precedence tier** at the single resolution chokepoint, extracted into a pure, tested helper `resolveEffectiveOpenAIBaseUrl()`:

```
config.openaiBaseUrl  >  providerOpts.baseURL  >  AFK_OPENAI_BASE_URL (normalized)  >  SDK default (api.openai.com)
```

This reads the env at **query time**, so the endpoint is resilient to the child-config threading gap regardless of nesting depth — and it makes the code honor its own docstring, which already claimed `providerOpts.baseURL` comes "from AFK_OPENAI_BASE_URL". A trailing `/chat/completions` is stripped (mirrors `normalizeOpenAIBaseUrl`; kept local to avoid an agent→cli import cycle).

Chosen over threading `openaiBaseUrl` through every executor (subagent/skill/compose) because the chokepoint fixes **all** paths at once with far less surface and risk.

## Safety / back-compat

- Only activates when `AFK_OPENAI_BASE_URL` is set **and** no higher-precedence base URL exists — i.e. the operator has globally redirected OpenAI traffic, so falling back to it (rather than `api.openai.com`) is the correct behavior, never a regression.
- Per-session and per-slot base URLs still win (precedence unchanged).
- The per-slot custom-`baseUrl` case is already covered by `applySlotCredentials`; this handles the global-env case.
- Effective immediately (query-time resolution).

## Tests

New `base-url.test.ts` (7 cases: precedence order, the lost-base-URL fallback regression guard, `/chat/completions` strip, whitespace/empty handling). `pnpm lint` clean; full suite green (10723 passed / 14 skipped).
