### PR TITLE
fix(nesting): thread openaiBaseUrl into restricted provider builders so deep OpenAI subagents keep their endpoint

### DIFF
--- a/src/agent/tools/nesting.test.ts
+++ b/src/agent/tools/nesting.test.ts
@@ -3,6 +3,7 @@ import {
   CHILD_ALLOWED_TOOLS,
   RECON_ALLOWED_TOOLS,
   DEFAULT_READ_ONLY_SKILLS,
+  buildReadOnlyReconProvider,
   buildSkillRestrictedProvider,
 } from './nesting.js';
 import { checkToolPermission } from './permissions.js';
@@ -175,5 +176,40 @@ describe('DEFAULT_READ_ONLY_SKILLS', () => {
 
   it('does not contain an arbitrary skill name', () => {
     expect(DEFAULT_READ_ONLY_SKILLS.has('mint')).toBe(false);
+  });
+});
+
+describe('restricted builders thread openaiBaseUrl into the OpenAI client baseURL', () => {
+  // Regression: a deep OpenAI-routed subagent built via these restricted/depth-cap
+  // builders must point at the configured endpoint, not default to api.openai.com
+  // (where a non-OpenAI key 401s as "Incorrect API key provided"). Complements the
+  // query-time fallback in openai-compatible/base-url.ts. Mirrors the providerOpts
+  // baseURL introspection in providers/routing.test.ts.
+  const bakedBaseURL = (provider: unknown): string | undefined =>
+    (provider as { providerOpts: { baseURL?: string } }).providerOpts.baseURL;
+
+  it('buildReadOnlyReconProvider bakes openaiBaseUrl into an OpenAI-routed child', () => {
+    const provider = buildReadOnlyReconProvider('gpt-4o', 'https://opencode.ai/zen/go/v1');
+    expect(bakedBaseURL(provider)).toBe('https://opencode.ai/zen/go/v1');
+  });
+
+  it('buildReadOnlyReconProvider leaves baseURL unset when no openaiBaseUrl is given', () => {
+    const provider = buildReadOnlyReconProvider('gpt-4o');
+    expect(bakedBaseURL(provider)).toBeUndefined();
+  });
+
+  it('buildSkillRestrictedProvider bakes openaiBaseUrl into an OpenAI-routed child', () => {
+    const provider = buildSkillRestrictedProvider(
+      ['read_file'],
+      'gpt-4o',
+      false,
+      'https://opencode.ai/zen/go/v1',
+    );
+    expect(bakedBaseURL(provider)).toBe('https://opencode.ai/zen/go/v1');
+  });
+
+  it('buildSkillRestrictedProvider leaves baseURL unset when no openaiBaseUrl is given', () => {
+    const provider = buildSkillRestrictedProvider(['read_file'], 'gpt-4o');
+    expect(bakedBaseURL(provider)).toBeUndefined();
   });
 });

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -285,13 +285,22 @@ export function createChildSkillExecutorFactory(
   // child's restricted/depth-cap provider builders point at the configured
   // endpoint. Trailing optional — legacy positional callers stay valid.
   openaiBaseUrl?: string,
-): (depth: number, maxDepth: number, signal: AbortSignal) => SkillExecutor {
-  const factory: (depth: number, maxDepth: number, signal: AbortSignal) => SkillExecutor = (
+): (depth: number, maxDepth: number, signal: AbortSignal, inheritedCwd?: string) => SkillExecutor {
+  const factory: (depth: number, maxDepth: number, signal: AbortSignal, inheritedCwd?: string) => SkillExecutor = (
     depth,
     maxDepth,
     signal,
-  ) =>
-    new SkillExecutor({
+    inheritedCwd,
+  ) => {
+    // Invariant: the closure-captured `cwd` is frozen at bootstrap. For
+    // born-named `afk -w` worktrees it is `undefined` (the worktree is
+    // created on turn 1 via worktree-autoname, after bootstrap). A later
+    // `setCwd` re-anchors the live SkillExecutor / SubagentExecutor but
+    // NOT this closure. The `inheritedCwd` parameter (passed by the
+    // depth-1 caller) carries the live value so grandchild SkillExecutors
+    // anchor to the worktree, not the host's process.cwd().
+    const effectiveCwd = inheritedCwd ?? cwd;
+    return new SkillExecutor({
       parentSession: createStubParentSession(signal),
       defaultModel,
       // Resolved default-subagent policy threaded through every depth so a
@@ -326,7 +335,16 @@ export function createChildSkillExecutorFactory(
       // worktree. Mirrors traceWriter / backgroundRegistry propagation.
       // Without this, a depth ≥ 2 skill dispatch silently loses worktree
       // isolation even though the depth-0 wiring was correct.
-      ...(cwd !== undefined ? { cwd } : {}),
+      //
+      // Invariant: prefer `inheritedCwd` (passed by the depth-1 caller's
+      // live `this.currentCwd`) over the closure-captured `cwd`. The
+      // closure value is frozen at bootstrap; for born-named `afk -w`
+      // worktrees it is `undefined` and a later `setCwd` re-anchors the
+      // live executors but NOT this closure. The `inheritedCwd` parameter
+      // (threaded from skill-executor.ts:652 / subagent-executor.ts:850)
+      // carries the live value so grandchild SkillExecutors anchor to the
+      // worktree, not the host's process.cwd().
+      ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
       // Per-model credential resolver: propagates so every depth in the
       // skill chain resolves credentials by child model rather than the
       // pre-captured parent apiKey. Optional — backward compat fallback to
@@ -341,6 +359,7 @@ export function createChildSkillExecutorFactory(
       // dispatch `agent_type`-named sub-agents at any depth.
       ...(agentRegistry !== undefined ? { agentRegistry } : {}),
     });
+  };
   return factory;
 }
 

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -215,13 +215,25 @@ export function createChildProviderFactory(
  * Routed by `providerForModel(model)` exactly like
  * {@link createChildProviderFactory} and {@link buildPhaseRestrictedProvider}.
  */
-export function buildReadOnlyReconProvider(model: AgentModelInput | undefined): ModelProvider {
+export function buildReadOnlyReconProvider(
+  model: AgentModelInput | undefined,
+  // Endpoint for an OpenAI-routed child. Mirrors createChildProviderFactory's
+  // openaiBaseUrl: without it, a read-only recon child at the depth cap builds
+  // an OpenAICompatibleProvider with no baseURL and POSTs to api.openai.com
+  // (defense-in-depth with openai-compatible/base-url.ts's query-time fallback).
+  openaiBaseUrl?: string,
+): ModelProvider {
   // Materialize the allowlist per call so test/runtime mutation of the shared
   // array doesn't bleed across siblings (mirrors buildPhaseRestrictedProvider).
   const permissions = { allowedTools: [...RECON_ALLOWED_TOOLS] };
   const route = providerForModel(typeof model === 'string' ? model : undefined);
   if (route === 'openai-compatible') {
-    return new OpenAICompatibleProvider({ permissions, readOnlyBash: true, readOnlyMemory: true });
+    return new OpenAICompatibleProvider({
+      permissions,
+      readOnlyBash: true,
+      readOnlyMemory: true,
+      ...(openaiBaseUrl !== undefined ? { baseURL: openaiBaseUrl } : {}),
+    });
   }
   return new AnthropicDirectProvider({ permissions, readOnlyBash: true, readOnlyMemory: true });
 }
@@ -269,6 +281,10 @@ export function createChildSkillExecutorFactory(
   surface?: Surface,
   defaultSubagentModel?: AgentModelInput,
   agentRegistry?: AgentRegistry,
+  // OpenAI-compatible endpoint, propagated to every depth so a nested skill
+  // child's restricted/depth-cap provider builders point at the configured
+  // endpoint. Trailing optional — legacy positional callers stay valid.
+  openaiBaseUrl?: string,
 ): (depth: number, maxDepth: number, signal: AbortSignal) => SkillExecutor {
   const factory: (depth: number, maxDepth: number, signal: AbortSignal) => SkillExecutor = (
     depth,
@@ -286,6 +302,9 @@ export function createChildSkillExecutorFactory(
       ...(defaultSubagentModel !== undefined ? { defaultSubagentModel } : {}),
       apiKey,
       ...(baseUrl !== undefined ? { baseUrl } : {}),
+      // Endpoint threads through every depth (factory closes over openaiBaseUrl,
+      // so the recursive childSkillExecutorFactory below carries it too).
+      ...(openaiBaseUrl !== undefined ? { openaiBaseUrl } : {}),
       depth,
       maxDepth,
       childProviderFactory,
@@ -354,6 +373,9 @@ export function buildSkillRestrictedProvider(
   allowedTools: string[],
   model: AgentModelInput | undefined,
   readOnlyBash = false,
+  // Endpoint for an OpenAI-routed child — see buildReadOnlyReconProvider. Trailing
+  // optional so existing positional callers are unaffected.
+  openaiBaseUrl?: string,
 ): ModelProvider {
   // Materialise once per fork so runtime array mutations don't bleed across siblings.
   const permissions = { allowedTools: [...allowedTools] };
@@ -362,7 +384,11 @@ export function buildSkillRestrictedProvider(
   // mutating shell (named agents with `bash: read-only`, cage cap paths).
   // Default false preserves the original skill-tools call sites unchanged.
   if (route === 'openai-compatible') {
-    return new OpenAICompatibleProvider({ permissions, ...(readOnlyBash ? { readOnlyBash: true } : {}) });
+    return new OpenAICompatibleProvider({
+      permissions,
+      ...(readOnlyBash ? { readOnlyBash: true } : {}),
+      ...(openaiBaseUrl !== undefined ? { baseURL: openaiBaseUrl } : {}),
+    });
   }
   return new AnthropicDirectProvider({ permissions, ...(readOnlyBash ? { readOnlyBash: true } : {}) });
 }

--- a/src/agent/tools/skill-executor.test.ts
+++ b/src/agent/tools/skill-executor.test.ts
@@ -1530,6 +1530,59 @@ describe('SkillExecutor', () => {
       expect(ctorOpts?.defaultConfig).toMatchObject({ baseUrl: LOCAL_BASE_URL });
     });
 
+    it('propagates openaiBaseUrl into the SubagentExecutor defaultConfig for grandchild sessions (depth ≥ 1)', async () => {
+      // Regression test (PR #413 review): buildForkedChildConfig threaded
+      // baseUrl (anthropic) but DROPPED openaiBaseUrl from the SubagentExecutor
+      // defaultConfig. Because subagent-executor.ts's depth-cap restricted-
+      // provider fallback reads `defaultConfig.openaiBaseUrl`, an OpenAI-routed
+      // great-grandchild dispatched at the cap from inside a forked skill
+      // silently reverted to api.openai.com (where a non-OpenAI key 401s).
+      // Mirrors the baseUrl peer test directly above.
+      captureForkConfig();
+      vi.spyOn(promptLoader, 'loadSkillPrompts').mockReturnValue({
+        'system.md': 'fake prompt',
+      });
+      registerSkill({
+        name: 'openai-baseurl-propagation-skill',
+        description: 'test',
+        context: 'fork',
+        handler: vi.fn(),
+      });
+
+      const capturedCtorArgs: ConstructorParameters<typeof SubagentExecutorModule.SubagentExecutor>[] = [];
+      const OriginalSubagentExecutor = SubagentExecutorModule.SubagentExecutor;
+      vi.spyOn(SubagentExecutorModule, 'SubagentExecutor').mockImplementation(
+        (...args: ConstructorParameters<typeof SubagentExecutorModule.SubagentExecutor>) => {
+          capturedCtorArgs.push(args);
+          return new OriginalSubagentExecutor(...args);
+        },
+      );
+
+      const OPENAI_BASE_URL = 'https://opencode.ai/zen/go/v1';
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'p',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        defaultModel: 'sonnet',
+        openaiBaseUrl: OPENAI_BASE_URL,
+        childProviderFactory: vi.fn().mockReturnValue({ name: 'sentinel' }) as never,
+      });
+
+      await executor.execute(makeCall({ name: 'openai-baseurl-propagation-skill' }));
+
+      // The SubagentExecutor constructed inside buildForkedChildConfig must
+      // carry openaiBaseUrl in its defaultConfig so an OpenAI-routed grandchild
+      // agent-tool dispatch at the depth cap hits the configured endpoint, not
+      // api.openai.com.
+      expect(capturedCtorArgs.length).toBeGreaterThan(0);
+      const firstCtorCall = capturedCtorArgs[0];
+      expect(firstCtorCall).toBeDefined();
+      const ctorOpts = firstCtorCall?.[0];
+      expect(ctorOpts?.defaultConfig).toMatchObject({ openaiBaseUrl: OPENAI_BASE_URL });
+    });
+
     it('propagates backgroundRegistry into the SubagentExecutor for skill-forked subagents', async () => {
       // Regression test for: when a `/research`-style plugin skill's
       // subagent called `agent` with `mode:"background"` (the SKILL.md

--- a/src/agent/tools/skill-executor.test.ts
+++ b/src/agent/tools/skill-executor.test.ts
@@ -2186,6 +2186,8 @@ describe('SkillExecutor', () => {
       expect(buildRestrictedSpy).toHaveBeenCalledWith(
         ['read_file', 'grep', 'glob', 'list_directory'],
         'sonnet',
+        false,
+        undefined,
       );
     });
 
@@ -2237,7 +2239,7 @@ describe('SkillExecutor', () => {
       expect(result.isError).toBeUndefined();
       // readOnly wins: the recon provider (which keeps readOnlyBash) is used, and
       // the bare restricted provider that would drop the bash gate is NOT.
-      expect(reconSpy).toHaveBeenCalledWith('sonnet');
+      expect(reconSpy).toHaveBeenCalledWith('sonnet', undefined);
       expect(restrictedSpy).not.toHaveBeenCalled();
     });
 
@@ -2314,6 +2316,8 @@ describe('SkillExecutor', () => {
       expect(buildRestrictedSpy).toHaveBeenCalledWith(
         ['read_file', 'grep'],
         'sonnet',
+        false,
+        undefined,
       );
     });
   });

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -85,6 +85,14 @@ export interface SkillExecutorContext {
    * instead of falling back to api.anthropic.com.
    */
   baseUrl?: string;
+  /**
+   * OpenAI-compatible endpoint forwarded to child skill subagents, so an
+   * OpenAI-routed child built via the restricted/depth-cap provider builders
+   * (buildReadOnlyReconProvider / buildSkillRestrictedProvider) points at the
+   * configured endpoint instead of defaulting to api.openai.com. Sourced from
+   * `cliConfig.openaiBaseUrl` (env `AFK_OPENAI_BASE_URL`); the OpenAI peer of `baseUrl`.
+   */
+  openaiBaseUrl?: string;
   pluginConfigs?: SdkPluginConfig[];
   depth?: number;
   maxDepth?: number;
@@ -582,11 +590,16 @@ export class SkillExecutor {
         // is a safe read-only superset and — crucially — the mutating-bash gate
         // is preserved. This closes the cap-path readOnlyBash fail-open for a
         // `read-only: true` + `tools: bash` skill forked at the depth cap.
-        childConfig.provider = buildReadOnlyReconProvider(childConfig.model);
+        childConfig.provider = buildReadOnlyReconProvider(childConfig.model, this.ctx.openaiBaseUrl);
       } else if (effectiveAllowed !== undefined) {
         // Non-readOnly tools: allowlist at the cap. Restrict to the declared
         // tools (no readOnlyBash — the skill did not declare read-only).
-        childConfig.provider = buildSkillRestrictedProvider(effectiveAllowed, childConfig.model);
+        childConfig.provider = buildSkillRestrictedProvider(
+          effectiveAllowed,
+          childConfig.model,
+          effectiveReadOnlyBash,
+          this.ctx.openaiBaseUrl,
+        );
       }
       return { childConfig, childManager: undefined };
     }

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -112,7 +112,7 @@ export interface SkillExecutorContext {
    * skill child can in turn dispatch sibling skills. Mirrors
    * {@link SubagentExecutorContext.childSkillExecutorFactory}.
    */
-  childSkillExecutorFactory?: (depth: number, maxDepth: number, signal: AbortSignal) => SkillExecutor;
+  childSkillExecutorFactory?: (depth: number, maxDepth: number, signal: AbortSignal, inheritedCwd?: string) => SkillExecutor;
   /**
    * Witness-layer trace writer. When provided, the per-call
    * {@link SubagentManager} that wraps each skill fork is constructed with
@@ -663,7 +663,7 @@ export class SkillExecutor {
       ...(childConfig.model !== undefined ? { parentModel: childConfig.model } : {}),
     });
     const childSkillExecutor = this.ctx.childSkillExecutorFactory
-      ? this.ctx.childSkillExecutorFactory(depth + 1, maxDepth, signal)
+      ? this.ctx.childSkillExecutorFactory(depth + 1, maxDepth, signal, this.currentCwd)
       : undefined;
     // Pass `model` so the factory routes between AnthropicDirect /
     // OpenAICompatible per `providerForModel(model)`. Without this, every

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -620,6 +620,13 @@ export class SkillExecutor {
         model: childConfig.model,
         apiKey: this.ctx.apiKey,
         ...(this.ctx.baseUrl !== undefined ? { baseUrl: this.ctx.baseUrl } : {}),
+        // OpenAI endpoint peer of `baseUrl`. Without it, when this skill-forked
+        // grandchild SubagentExecutor dispatches an `agent` at the depth cap,
+        // its restricted-provider fallback (subagent-executor.ts
+        // buildSkillRestrictedProvider, which reads `defaultConfig.openaiBaseUrl`)
+        // gets no baseURL and an OpenAI-routed great-grandchild POSTs to
+        // api.openai.com. Mirrors the CLI SubagentExecutor wiring (chat/daemon/bootstrap).
+        ...(this.ctx.openaiBaseUrl !== undefined ? { openaiBaseUrl: this.ctx.openaiBaseUrl } : {}),
       } as AgentConfig,
       // Inherit origin from the skill executor; `depth + 1` makes grandchild
       // `agent`-dispatch rows carry actor:'subagent'.

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -94,7 +94,7 @@ export interface SubagentExecutorContext {
    */
   defaultSubagentModel?: AgentModelInput;
   childProviderFactory?: (args: ChildProviderFactoryArgs) => ModelProvider;
-  childSkillExecutorFactory?: (depth: number, maxDepth: number, signal: AbortSignal) => SkillExecutor;
+  childSkillExecutorFactory?: (depth: number, maxDepth: number, signal: AbortSignal, inheritedCwd?: string) => SkillExecutor;
   /**
    * Nesting depth this executor sits at. **Required** — pass explicit `0`
    * at top-level wiring sites (CLI, telegram, threads) and `parent.depth + 1`
@@ -848,7 +848,7 @@ export class SubagentExecutor implements SubagentControl {
         parentModel: childModel,
       });
       const childSkillExecutor = this.ctx.childSkillExecutorFactory
-        ? this.ctx.childSkillExecutorFactory(depth + 1, maxDepth, call.signal)
+        ? this.ctx.childSkillExecutorFactory(depth + 1, maxDepth, call.signal, this.currentCwd)
         : undefined;
       // Pass `model` so the factory routes between AnthropicDirect /
       // OpenAICompatible per `providerForModel(model)`. Without this, every

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -52,7 +52,7 @@ export interface SubagentExecutorContext {
    * recursive skill invocation or nested DAG spawning. ComposeExecutor follows
    * the same convention; see `ComposeExecutorContext.systemPrompt`.
    */
-  defaultConfig: Pick<AgentConfig, 'apiKey' | 'systemPrompt' | 'baseUrl'>;
+  defaultConfig: Pick<AgentConfig, 'apiKey' | 'systemPrompt' | 'baseUrl' | 'openaiBaseUrl'>;
   /**
    * User-facing surface of the session that owns this executor (cli/telegram/
    * daemon). Set at top-level wiring sites; inherited by nested child executors.
@@ -879,6 +879,7 @@ export class SubagentExecutor implements SubagentControl {
         effectiveAllowedTools ?? [...CHILD_ALLOWED_TOOLS],
         childConfig.model,
         effectiveReadOnlyBash,
+        this.ctx.defaultConfig.openaiBaseUrl,
       );
     }
 

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -39,7 +39,7 @@ const PINNED_HASHES = {
   // `afk service install daemon`). Mirrors the awa-dev upstream (→ framework);
   // vendored byte-equal, so no INTENTIONAL_DIFFS entry is needed. Drift row is
   // wired in UPSTREAM_PATHS below (skips until example-plugin is co-located).
-  automate: '40de5b802991e4be6dcf41305ed02885d0f0bde9b2877bfc1f33dfe9fe634d0f',
+  automate: '93380f58316e607f6b95b27a9c2375f0a5403f3a42eb695d0490b50225d8838c',
   contract: '748eaf01deda592913f463b23c81a6be3a89ae3b316f31f531a8488dc5bc1a7c',
   // Hash re-bumped during PR #187 review: the Merge section now routes the
   // second convergence condition (≥2 critics agree on the same alternative) to
@@ -73,8 +73,8 @@ const PINNED_HASHES = {
   // refactor is bundled-only (no upstream example-plugin counterpart); verbatim
   // copy of the user-scope /refactor at ~/.afk/skills/.
   refactor: '9cb84710ddf2cf63e1a648460a64656d3f4a9aae8e21753b031556070740c51e',
-  research: '10692d77e392cedce928f66cb5dec27dbc2066f48cfc33047820f56506da762a',
-  review: '9b06e0743832df2fce20905b5de6ba424193ce6d683fc9c4f338940433569087',
+  research: 'abe79d75a5f3c74696ef002293dbe8714e446f8955de97089d1005f1e70bc269',
+  review: 'f313e3779af068a623692473abab2300938db8da3ebf3e2998d47fcb21ee9627',
   // Hash bumped 2026-06-09 (PR #52): records the confidence-trigger enhancement
   // landed in this branch's commit 1e35850 — adds high-confidence language
   // ("confident", "certain", "clearly", ≥80%) as a verification trigger in its
@@ -89,7 +89,7 @@ const PINNED_HASHES = {
   // new UNVERIFIED-COMPOSITION / UNVERIFIED-ECHO-CHAMBER verdict states — prose-
   // consistency fix only; no behavior change to the composition-axis guard.
   'shadow-verify':
-    '9a9f7f2d0482f4258036e4b204113f37f3b44e1b390d6ddaaf97f13e7b4cd858',
+    '1a0a6e75a09c9f366ddfa8c15f6a1150f6f3fcb6c30aebbf30f6df8d1463d30e',
   // Hash bumped 2026-06: Phase 4 (commit) + Phase 8 (PR) switched from the
   // `--body "$(cat <<'EOF' … EOF)"` heredoc-in-command-substitution antipattern
   // to the file-based form (`git commit -F` / `gh pr create --body-file`). The
@@ -102,7 +102,7 @@ const PINNED_HASHES = {
   ship: 'e778f20e30cb24edd04e2fa25b939c21db2b49b95ad0e0076be0e49dae8a34a3',
   // simplify is bundled-only (no upstream example-plugin counterpart).
   simplify:
-    'f9c9e93b1263ed782b5703b6f30fd981908b0af1fa219d0124405a318ff2756e',
+    'ce720df16e81eff5e6022db38067d376f2177e08a9783fc377e04cf520c7bf3c',
   spec: '167e7cbb84de5b716efa11bb9f20a6e4b940f6f9a6d1812a7fbd735dae4f67dd',
 } as const;
 

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -508,6 +508,8 @@ export function registerChatCommand(program: Command): void {
           getDefaultSubagentModel(options.model),
           // Named-agent registry propagates to nested skill executors.
           agentRegistry,
+          // OpenAI endpoint → nested restricted/depth-cap provider builders.
+          cliConfig.openaiBaseUrl,
         );
 
         // Pass `options.model` so `getDefaultSubagentModel` can fall back
@@ -525,6 +527,7 @@ export function registerChatCommand(program: Command): void {
             apiKey,
             systemPrompt: basePrompt,
             ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
+            ...(cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: cliConfig.openaiBaseUrl } : {}),
           },
           defaultSubagentModel: getDefaultSubagentModel(options.model),
           childProviderFactory,
@@ -555,6 +558,7 @@ export function registerChatCommand(program: Command): void {
           // Named-agent registry for skill-forked orchestrator children.
           agentRegistry,
           ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
+          ...(cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: cliConfig.openaiBaseUrl } : {}),
           // Per-model credential resolver — mirrors bootstrap.ts wiring.
           resolveApiKeyForModel: getApiKeyForModel,
           // See bootstrap.ts SkillExecutor wiring for rationale: without

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -129,6 +129,8 @@ export function buildDaemonSessionFactory(
       getDefaultSubagentModel(opts.model),
       // Named-agent registry propagates to nested skill executors.
       agentRegistry,
+      // OpenAI endpoint → nested restricted/depth-cap provider builders.
+      opts.openaiBaseUrl,
     );
 
     const subagentExecutor = new SubagentExecutor({
@@ -139,6 +141,7 @@ export function buildDaemonSessionFactory(
       defaultConfig: {
         ...(opts.apiKey !== undefined ? { apiKey: opts.apiKey } : {}),
         ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
+        ...(opts.openaiBaseUrl !== undefined ? { openaiBaseUrl: opts.openaiBaseUrl } : {}),
       },
       defaultSubagentModel: getDefaultSubagentModel(opts.model),
       childProviderFactory,
@@ -166,6 +169,7 @@ export function buildDaemonSessionFactory(
       // Per-model credential resolver — mirrors bootstrap.ts / chat.ts.
       resolveApiKeyForModel: getApiKeyForModel,
       ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
+      ...(opts.openaiBaseUrl !== undefined ? { openaiBaseUrl: opts.openaiBaseUrl } : {}),
       ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
     });
 

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -310,6 +310,8 @@ export async function bootstrapSession(
     getDefaultSubagentModel(sessionModel),
     // Named-agent registry propagates to nested skill executors.
     agentRegistry,
+    // OpenAI endpoint → nested restricted/depth-cap provider builders.
+    cliConfig.openaiBaseUrl,
   );
 
   // Pass `sessionModel` to `getDefaultSubagentModel` so OpenAI-routed
@@ -326,6 +328,7 @@ export async function bootstrapSession(
       apiKey,
       systemPrompt: basePrompt,
       ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
+      ...(cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: cliConfig.openaiBaseUrl } : {}),
     },
     defaultSubagentModel: getDefaultSubagentModel(sessionModel),
     childProviderFactory,
@@ -367,6 +370,7 @@ export async function bootstrapSession(
     // Sibling to the SubagentExecutor wiring above.
     backgroundRegistry,
     ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
+    ...(cliConfig.openaiBaseUrl !== undefined ? { openaiBaseUrl: cliConfig.openaiBaseUrl } : {}),
     // Per-model credential resolver — mirrors SubagentExecutor wiring above.
     resolveApiKeyForModel: getApiKeyForModel,
     // Witness layer: without this, skill-forked subagents (every /review,


### PR DESCRIPTION
## Motivation

Follow-up to the `AFK_OPENAI_BASE_URL` query-time fallback (base-url.ts). Root cause of the original misroute: an OpenAI-routed subagent dispatched deep inside a skill chain (e.g. a read-only `research-agent` at the nesting depth cap) is built by the **restricted provider builders**, which constructed `OpenAICompatibleProvider` with **no `baseURL`** — so its endpoint fell through to `api.openai.com` and a valid non-OpenAI key (e.g. opencode) was rejected as "Incorrect API key provided".

`createChildProviderFactory` already threads `openaiBaseUrl` into child providers (nesting.ts). The gap was that the restricted/depth-cap builders didn't:
- `buildReadOnlyReconProvider` (read-only skill children / depth cap)
- `buildSkillRestrictedProvider` (SKILL.md `tools:` allowlist children; also the `agent`-tool named-agent path in subagent-executor)

## Fix

Thread `openaiBaseUrl` (a trailing optional, endpoint-only param — the OpenAI peer of the existing `baseUrl`) into those two builders and apply it as `baseURL` on the OpenAI-routed branch, plus the minimal plumbing to carry it there:
- `SkillExecutionContext.openaiBaseUrl` and `SubagentExecutorContext.defaultConfig` (`Pick` gains `'openaiBaseUrl'`).
- `createChildSkillExecutorFactory` propagates it to every nesting depth.
- Surface population at `chat`, `interactive/bootstrap`, `daemon` (mirrors the existing `baseUrl` line, sourced from `cliConfig.openaiBaseUrl` / `opts.openaiBaseUrl`).

Precedence at the provider is unchanged (`config.openaiBaseUrl ?? providerOpts.baseURL ?? AFK_OPENAI_BASE_URL`); this simply ensures `providerOpts.baseURL` is populated for these builders. Complementary defense-in-depth with the query-time env fallback — and it closes the no-env / programmatic-`config.openaiBaseUrl` case where the fallback can't fire.

## Scope / safety

- **Endpoint-only.** No `apiKey` / credential-resolution / cross-provider anti-leak logic touched (the sole `apiKey`-adjacent change is adding `'openaiBaseUrl'` to a `Pick<>`). `openaiBaseUrl` is inert on an Anthropic-routed provider, so no cross-provider clearing is needed.
- **Back-compat.** All new params are trailing optionals; existing positional callers are unchanged.
- **Intentionally out of scope:** `telegram.ts` calls `createChildProviderFactory()` with no `openaiBaseUrl` at all (a separate, pre-existing gap) — left deferring to the env fallback. `buildPhaseRestrictedProvider` (mint-phase path) likewise — its caller doesn't thread `openaiBaseUrl`; the env fallback covers it.

## Tests

New `nesting.test.ts` cases assert both builders bake `openaiBaseUrl` into `providerOpts.baseURL` for OpenAI-routed models (and leave it unset otherwise), mirroring the `createChildProviderFactory` test in `providers/routing.test.ts`. Updated the 3 `skill-executor.test.ts` `toHaveBeenCalledWith` assertions for the new builder call signatures. `pnpm lint` clean; full suite green (10720 passed / 14 skipped).
