### PR TITLE
fix(anthropic): surface silent 429/503/529 backoff in trace; fix transient rate-limit 429 misclassification

### DIFF
--- a/src/agent/providers/anthropic-direct/auth.ts
+++ b/src/agent/providers/anthropic-direct/auth.ts
@@ -58,19 +58,29 @@ export function detectAuthMode(token: string): AuthMode {
  * option. Used by the local-server path (`AFK_LOCAL_BASE_URL`) to point
  * Messages traffic at a self-hosted Anthropic-compatible shim. The SDK
  * appends `/v1/messages` to whatever is passed.
+ *
+ * `fetchImpl`, when provided, is forwarded as the SDK's `fetch` client option
+ * so every HTTP request (including the SDK's own internal retries) flows
+ * through it. Used to inject an observability wrapper (see
+ * {@link makeTracingFetch}) that records 429/503/529 throttling into the
+ * witness trace — otherwise the SDK's silent retry-after backoff is invisible.
  */
 export function buildClientOptions(
   token: string,
   mode: AuthMode,
   baseUrl?: string,
-): ({ authToken: string } | { apiKey: string }) & { baseURL?: string } {
+  fetchImpl?: typeof fetch,
+): ({ authToken: string } | { apiKey: string }) & { baseURL?: string; fetch?: typeof fetch } {
   const base = mode === 'oauth'
     ? { authToken: token }
     : { apiKey: token };
-  if (typeof baseUrl === 'string' && baseUrl.length > 0) {
-    return { ...base, baseURL: baseUrl };
+  const withBase = typeof baseUrl === 'string' && baseUrl.length > 0
+    ? { ...base, baseURL: baseUrl }
+    : base;
+  if (fetchImpl) {
+    return { ...withBase, fetch: fetchImpl };
   }
-  return base;
+  return withBase;
 }
 
 /**

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -37,6 +37,7 @@ import {
   detectAuthMode,
 } from './auth.js';
 import { oneShotCompletion, type OneShotInput } from './oneshot.js';
+import { makeTracingFetch } from './tracing-fetch.js';
 import { refreshClaudeCodeOauthToken } from '../../auth/keychain.js';
 import { AnthropicDirectQuery } from './query.js';
 import { pathContainmentBypassed } from '../../permission-policy.js';
@@ -95,7 +96,7 @@ const DEFAULT_MODEL = 'claude-sonnet-5';
  * `buildClientOptions` when the local-server path is active).
  */
 export type AnthropicClientFactory = (
-  opts: ({ authToken: string } | { apiKey: string }) & { baseURL?: string },
+  opts: ({ authToken: string } | { apiKey: string }) & { baseURL?: string; fetch?: typeof fetch },
 ) => Anthropic;
 
 let clientFactory: AnthropicClientFactory | null = null;
@@ -635,7 +636,17 @@ export class AnthropicDirectProvider implements ModelProvider {
       );
     }
     const authMode = detectAuthMode(token);
-    const clientOpts = buildClientOptions(token, authMode, config.baseUrl);
+    const clientOpts = buildClientOptions(
+      token,
+      authMode,
+      config.baseUrl,
+      // Observability: route SDK HTTP through a wrapper that records 429/503/529
+      // throttling into the witness trace, so the SDK's otherwise-silent
+      // retry-after backoff is legible in `afk trace show`. Skipped in
+      // local-shim mode (not Anthropic's billing surface) and when no trace
+      // writer is attached.
+      !localMode && config.traceWriter ? makeTracingFetch(config.traceWriter) : undefined,
+    );
     const factory = this.providerFactory ?? clientFactory;
     const client = factory ? factory(clientOpts) : new Anthropic(clientOpts);
     // In local-server mode, suppress the OAuth CLI-mimicry system-prefix
@@ -861,7 +872,15 @@ export class AnthropicDirectProvider implements ModelProvider {
       tokenRefresher = async (): Promise<Anthropic | null> => {
         const freshToken = await refreshClaudeCodeOauthToken();
         if (!freshToken) return null;
-        const opts = buildClientOptions(freshToken, 'oauth', config.baseUrl);
+        const opts = buildClientOptions(
+          freshToken,
+          'oauth',
+          config.baseUrl,
+          // Preserve throttle observability across an OAuth account swap — the
+          // rebuilt client must keep the tracing-fetch wrapper. localMode is
+          // false in this branch (see the guard above).
+          config.traceWriter ? makeTracingFetch(config.traceWriter) : undefined,
+        );
         return factory ? factory(opts) : new Anthropic(opts);
       };
     }

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -345,6 +345,15 @@ export async function* runTurn(
 
     if (retryOverload) {
       overloadRetries += 1;
+      // Witness layer: record the mid-stream overload backoff so a re-driven
+      // round is legible in the trace. The tracing-fetch wrapper cannot see
+      // this one — a mid-stream `overloaded_error` arrives in the SSE body of
+      // an HTTP 200 response, so it never trips the wrapper's status check.
+      // Fire-and-forget; trace latency must never stall the retry.
+      void emitSessionPhase(input.traceWriter, {
+        phase: 'rate_limit',
+        metadata: { reason: 'overloaded', source: 'mid-stream', attempt: overloadRetries },
+      });
       // Tell surfaces to discard the current round's already-streamed text:
       // the re-driven request below re-streams the round from scratch, so
       // without a reset the partial text visibly duplicates. Emitted before

--- a/src/agent/providers/anthropic-direct/query/retry-layer.ts
+++ b/src/agent/providers/anthropic-direct/query/retry-layer.ts
@@ -216,6 +216,12 @@ export class RetryLayer {
           pendingErrorEvent = event;
           break;
         }
+        // `rate-limit-transient` (a standard API rate-limit 429, distinct from
+        // OAuth subscription exhaustion) intentionally does NOT break into the
+        // wait/pause path below. The SDK has already auto-retried it honoring
+        // `retry-after`; a still-failing 429 here is surfaced as an error via
+        // the `yield event` below rather than parked in a 2-hour
+        // subscription-reset poll. See classifyUsageLimitError.
       }
       yield event;
     }

--- a/src/agent/providers/anthropic-direct/tracing-fetch.test.ts
+++ b/src/agent/providers/anthropic-direct/tracing-fetch.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for {@link makeTracingFetch} — the observability wrapper that records
+ * 429/503/529 throttling into the witness trace without altering retry behavior.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { makeTracingFetch } from './tracing-fetch.js';
+import type { TraceWriter } from '../../trace/index.js';
+
+function mockWriter(): {
+  writer: TraceWriter;
+  events: Array<{ kind: string; payload: Record<string, unknown> }>;
+} {
+  const events: Array<{ kind: string; payload: Record<string, unknown> }> = [];
+  const writer = {
+    write: vi.fn(async (e: { kind: string; payload: Record<string, unknown> }) => {
+      events.push(e);
+    }),
+  } as unknown as TraceWriter;
+  return { writer, events };
+}
+
+function res(status: number, headers?: Record<string, string>): Response {
+  return new Response('{}', headers ? { status, headers } : { status });
+}
+
+describe('makeTracingFetch', () => {
+  it('returns the base fetch unchanged when no writer is provided', () => {
+    const base = vi.fn() as unknown as typeof fetch;
+    expect(makeTracingFetch(undefined, base)).toBe(base);
+  });
+
+  it('emits a rate_limit trace event on a 429 with retry-after', async () => {
+    const { writer, events } = mockWriter();
+    const base = vi.fn(async () => res(429, { 'retry-after': '30' })) as unknown as typeof fetch;
+    const r = await makeTracingFetch(writer, base)('https://api.anthropic.com/v1/messages');
+    await Promise.resolve();
+    expect(r.status).toBe(429);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.kind).toBe('session_phase');
+    expect(events[0]!.payload['phase']).toBe('rate_limit');
+    expect(events[0]!.payload['durationMs']).toBe(30_000);
+    const md = events[0]!.payload['metadata'] as Record<string, unknown>;
+    expect(md['status']).toBe(429);
+    expect(md['reason']).toBe('rate-limit');
+    expect(md['source']).toBe('sdk-fetch');
+    expect(md['retryAfterMs']).toBe(30_000);
+  });
+
+  it('classifies 503 and 529 as reason=overloaded', async () => {
+    for (const status of [503, 529]) {
+      const { writer, events } = mockWriter();
+      const base = vi.fn(async () => res(status)) as unknown as typeof fetch;
+      await makeTracingFetch(writer, base)('u');
+      await Promise.resolve();
+      expect(events).toHaveLength(1);
+      const md = events[0]!.payload['metadata'] as Record<string, unknown>;
+      expect(md['reason']).toBe('overloaded');
+      expect(md['status']).toBe(status);
+    }
+  });
+
+  it('does NOT emit on a 200 response and passes it through', async () => {
+    const { writer, events } = mockWriter();
+    const base = vi.fn(async () => res(200)) as unknown as typeof fetch;
+    const r = await makeTracingFetch(writer, base)('u');
+    await Promise.resolve();
+    expect(r.status).toBe(200);
+    expect(events).toHaveLength(0);
+  });
+
+  it('omits durationMs when no retry-after header is present', async () => {
+    const { writer, events } = mockWriter();
+    const base = vi.fn(async () => res(429)) as unknown as typeof fetch;
+    await makeTracingFetch(writer, base)('u');
+    await Promise.resolve();
+    expect(events).toHaveLength(1);
+    expect(events[0]!.payload['durationMs']).toBeUndefined();
+  });
+});

--- a/src/agent/providers/anthropic-direct/tracing-fetch.ts
+++ b/src/agent/providers/anthropic-direct/tracing-fetch.ts
@@ -1,0 +1,60 @@
+/**
+ * Observability wrapper for the Anthropic SDK's `fetch` client option.
+ *
+ * The SDK retries transient failures (429 rate limit, 503/529 overload)
+ * internally, honoring the `retry-after` header — but that backoff is
+ * completely SILENT: it happens inside a single `messages.create` call, emits
+ * no event, and surfaces only as an abnormally long `model_ttfb` in the trace
+ * (a 429 with a 70s `retry-after`, retried twice, looks like a ~140s "stuck"
+ * turn with no explanation). This wrapper sits under the SDK and records every
+ * throttled response into the witness trace as a `rate_limit` session-phase
+ * event, so `afk trace show` explains the stall instead of hiding it.
+ *
+ * Purely observational: it forwards the request unchanged and returns the
+ * Response untouched (only `res.headers` is read, which does not consume the
+ * body), so retry behavior is exactly as before.
+ *
+ * @module agent/providers/anthropic-direct/tracing-fetch
+ */
+
+import type { TraceWriter } from '../../trace/index.js';
+import { emitSessionPhase } from '../../trace/emit.js';
+import { parseRetryAfterMs } from './usage-limit.js';
+
+/** HTTP statuses that indicate throttling / transient overload. */
+const THROTTLE_STATUSES = new Set([429, 503, 529]);
+
+/**
+ * Wrap a `fetch` implementation so throttled responses (429/503/529) emit a
+ * `rate_limit` trace event. Returns the wrapped fetch; when `writer` is
+ * undefined the base fetch is returned unchanged (no overhead).
+ */
+export function makeTracingFetch(
+  writer: TraceWriter | undefined,
+  baseFetch: typeof fetch = fetch,
+): typeof fetch {
+  if (!writer) return baseFetch;
+  return async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ): Promise<Response> => {
+    const res = await baseFetch(input, init);
+    if (THROTTLE_STATUSES.has(res.status)) {
+      const retryAfterMs = parseRetryAfterMs({ headers: res.headers });
+      const metadata: Record<string, string | number | boolean> = {
+        status: res.status,
+        reason: res.status === 429 ? 'rate-limit' : 'overloaded',
+        source: 'sdk-fetch',
+      };
+      if (retryAfterMs !== undefined) metadata['retryAfterMs'] = retryAfterMs;
+      // Fire-and-forget: a broken trace writer must never disturb the request
+      // path. emitSessionPhase already swallows writer errors internally.
+      void emitSessionPhase(writer, {
+        phase: 'rate_limit',
+        ...(retryAfterMs !== undefined ? { durationMs: retryAfterMs } : {}),
+        metadata,
+      });
+    }
+    return res;
+  };
+}

--- a/src/agent/providers/anthropic-direct/usage-limit.test.ts
+++ b/src/agent/providers/anthropic-direct/usage-limit.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { classifyUsageLimitError, waitForReset, waitForHotSwap } from './usage-limit.js';
+import { classifyUsageLimitError, parseRetryAfterMs, waitForReset, waitForHotSwap } from './usage-limit.js';
 
 // ---------------------------------------------------------------------------
 // classifyUsageLimitError
@@ -12,6 +12,18 @@ import { classifyUsageLimitError, waitForReset, waitForHotSwap } from './usage-l
 function makeError(status: number, message: string): Error {
   const e = new Error(message);
   (e as Error & { status: number }).status = status;
+  return e;
+}
+
+function makeErrorWithHeaders(
+  status: number,
+  message: string,
+  headers: Record<string, string> | Headers,
+): Error {
+  const e = new Error(message);
+  const w = e as Error & { status: number; headers: unknown };
+  w.status = status;
+  w.headers = headers;
   return e;
 }
 
@@ -57,6 +69,75 @@ describe('classifyUsageLimitError', () => {
   it('returns null for 400 without both keywords', () => {
     expect(classifyUsageLimitError(makeError(400, 'invalid_request_error: something else'))).toBeNull();
     expect(classifyUsageLimitError(makeError(400, 'credit balance issue'))).toBeNull();
+  });
+
+  // A standard API-tier rate-limit 429 must NOT be treated as OAuth
+  // subscription exhaustion (which would park the turn in a 2-hour poll).
+  it('returns rate-limit-transient for a 429 with a retry-after header and no |ts', () => {
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', { 'retry-after': '30' });
+    const result = classifyUsageLimitError(err);
+    expect(result?.kind).toBe('rate-limit-transient');
+    if (result?.kind === 'rate-limit-transient') {
+      expect(result.retryAfterMs).toBe(30_000);
+    }
+  });
+
+  it('prefers oauth-limit (|ts) over the retry-after header', () => {
+    const unixTs = 1700000000;
+    const err = makeErrorWithHeaders(429, `usage limit|${unixTs}`, { 'retry-after': '30' });
+    expect(classifyUsageLimitError(err)?.kind).toBe('oauth-limit');
+  });
+
+  it('still returns oauth-limit-no-ts for a 429 with no timestamp and no retry-after header', () => {
+    expect(classifyUsageLimitError(makeError(429, 'Claude AI usage limit reached'))?.kind).toBe(
+      'oauth-limit-no-ts',
+    );
+  });
+
+  it('reads retry-after from a web Headers object', () => {
+    const err = makeErrorWithHeaders(429, '429', new Headers({ 'retry-after': '5' }));
+    const result = classifyUsageLimitError(err);
+    expect(result?.kind).toBe('rate-limit-transient');
+    if (result?.kind === 'rate-limit-transient') {
+      expect(result.retryAfterMs).toBe(5_000);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseRetryAfterMs
+// ---------------------------------------------------------------------------
+
+describe('parseRetryAfterMs', () => {
+  it('returns undefined for non-objects and missing/empty headers', () => {
+    expect(parseRetryAfterMs(null)).toBeUndefined();
+    expect(parseRetryAfterMs('nope')).toBeUndefined();
+    expect(parseRetryAfterMs({})).toBeUndefined();
+    expect(parseRetryAfterMs({ headers: {} })).toBeUndefined();
+  });
+
+  it('prefers retry-after-ms (milliseconds)', () => {
+    expect(parseRetryAfterMs({ headers: { 'retry-after-ms': '1500' } })).toBe(1500);
+  });
+
+  it('parses retry-after seconds into milliseconds', () => {
+    expect(parseRetryAfterMs({ headers: { 'retry-after': '2' } })).toBe(2000);
+  });
+
+  it('reads from a web Headers object via .get', () => {
+    expect(parseRetryAfterMs({ headers: new Headers({ 'retry-after': '3' }) })).toBe(3000);
+  });
+
+  it('parses an HTTP-date retry-after into a forward delta', () => {
+    const future = new Date(Date.now() + 10_000).toUTCString();
+    const ms = parseRetryAfterMs({ headers: { 'retry-after': future } });
+    expect(ms).toBeGreaterThan(0);
+    expect(ms).toBeLessThanOrEqual(10_000);
+  });
+
+  it('ignores a past HTTP-date', () => {
+    const past = new Date(Date.now() - 10_000).toUTCString();
+    expect(parseRetryAfterMs({ headers: { 'retry-after': past } })).toBeUndefined();
   });
 });
 

--- a/src/agent/providers/anthropic-direct/usage-limit.ts
+++ b/src/agent/providers/anthropic-direct/usage-limit.ts
@@ -18,7 +18,52 @@ import { loadClaudeCodeOauthToken } from '../../auth/keychain.js';
 export type UsageLimitClassification =
   | { kind: 'oauth-limit'; resetsAt: Date }
   | { kind: 'oauth-limit-no-ts' }
+  | { kind: 'rate-limit-transient'; retryAfterMs?: number }
   | { kind: 'credit-exhausted' };
+
+/**
+ * Best-effort parse of a transient-backoff hint from an error's HTTP headers.
+ *
+ * Reads `retry-after-ms` (milliseconds) first, then `retry-after` (seconds, or
+ * an HTTP-date). Returns the delay in ms, or `undefined` when no usable header
+ * is present. Header access is defensive: the Anthropic SDK's `APIError.headers`
+ * has been both a web `Headers` (with `.get`) and a plain record across
+ * versions, so both shapes are handled.
+ */
+export function parseRetryAfterMs(error: unknown): number | undefined {
+  if (error === null || typeof error !== 'object') return undefined;
+  const headers = (error as { headers?: unknown }).headers;
+  if (headers === null || headers === undefined) return undefined;
+  const get = (name: string): string | undefined => {
+    const h = headers as { get?: unknown };
+    if (typeof h.get === 'function') {
+      const v = (headers as { get(n: string): string | null }).get(name);
+      return v ?? undefined;
+    }
+    if (typeof headers === 'object') {
+      const rec = headers as Record<string, unknown>;
+      const v = rec[name] ?? rec[name.toUpperCase()];
+      return typeof v === 'string' ? v : undefined;
+    }
+    return undefined;
+  };
+  const ms = get('retry-after-ms');
+  if (ms !== undefined) {
+    const n = Number(ms);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  const sec = get('retry-after');
+  if (sec !== undefined) {
+    const n = Number(sec);
+    if (Number.isFinite(n) && n >= 0) return Math.round(n * 1000);
+    const dateMs = Date.parse(sec);
+    if (!Number.isNaN(dateMs)) {
+      const delta = dateMs - Date.now();
+      if (delta >= 0) return delta;
+    }
+  }
+  return undefined;
+}
 
 /**
  * Classify an error as a usage-limit error, or return `null` if it is not one.
@@ -26,7 +71,13 @@ export type UsageLimitClassification =
  * Recognised patterns:
  *   - HTTP 429 with message containing `|<unix-ts>` — OAuth subscription limit
  *     (the timestamp is when the limit resets).
- *   - HTTP 429 without timestamp — OAuth subscription limit with unknown reset.
+ *   - HTTP 429 with a `retry-after`/`retry-after-ms` header and NO `|<unix-ts>`
+ *     — a transient API-tier rate limit (RPM/ITPM), NOT subscription
+ *     exhaustion. The header gives a short (seconds) backoff. Kept distinct so
+ *     callers do not apply the 2-hour subscription-pause semantics to a
+ *     throttle that clears in seconds.
+ *   - HTTP 429 without timestamp AND without a retry-after header — OAuth
+ *     subscription limit with unknown reset (unchanged fallback).
  *   - HTTP 400 + `invalid_request_error` + `credit balance` — API key balance
  *     exhausted.
  */
@@ -41,6 +92,17 @@ export function classifyUsageLimitError(error: Error): UsageLimitClassification 
       if (!isNaN(ts) && ts > 0) {
         return { kind: 'oauth-limit', resetsAt: new Date(ts * 1000) };
       }
+    }
+    // Invariant: OAuth *subscription* exhaustion encodes its reset in the
+    // message `|<unix-ts>` (handled above) — it does not depend on a
+    // `retry-after` header. A standard API-tier rate-limit 429 instead carries
+    // `retry-after` and no timestamp. So "429 + retry-after + no |ts" is a
+    // transient rate limit, and misrouting it into the timestamp-less
+    // subscription path (poll every 60s for up to 2h, labelled "usage limit")
+    // is the bug this branch fixes.
+    const retryAfterMs = parseRetryAfterMs(error);
+    if (retryAfterMs !== undefined) {
+      return { kind: 'rate-limit-transient', retryAfterMs };
     }
     return { kind: 'oauth-limit-no-ts' };
   }

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -383,6 +383,7 @@ export const SessionPhaseNameSchema = z.enum([
   'loop_start',
   'loop_end',
   'model_ttfb',
+  'rate_limit',
 ]);
 
 export const SessionPhasePayloadSchema = z.object({

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -563,7 +563,8 @@ export type SessionPhaseName =
   | 'mcp_server_done'
   | 'loop_start'
   | 'loop_end'
-  | 'model_ttfb';
+  | 'model_ttfb'
+  | 'rate_limit';
 
 export interface SessionPhasePayload {
   /** Which lifecycle milestone this record marks. */

--- a/src/cli/commands/trace.test.ts
+++ b/src/cli/commands/trace.test.ts
@@ -130,6 +130,49 @@ describe('formatTrace — default human view', () => {
   });
 });
 
+describe('formatTrace — rate_limit is high-signal (shown by default)', () => {
+  // Regression: a rate_limit event is a session_phase, and session_phase is
+  // hidden by default (latency waterfall). But throttling is the whole reason a
+  // stuck turn is stuck, so it must appear WITHOUT --all — otherwise the
+  // observability it provides is invisible to an operator who doesn't already
+  // know to enable low-signal output.
+  const events: EventObj[] = [
+    { ts: '2026-06-05T12:30:00.000Z', seq: 0, kind: 'session_phase', payload: { phase: 'model_ttfb', durationMs: 300 } },
+    { ts: '2026-06-05T12:30:01.000Z', seq: 1, kind: 'session_phase', payload: { phase: 'rate_limit', durationMs: 30000, metadata: { status: 429, reason: 'rate-limit', source: 'sdk-fetch', retryAfterMs: 30000 } } },
+    { ts: '2026-06-05T12:35:00.000Z', seq: 2, kind: 'session_sealed', payload: { status: 'succeeded', finalCostUsd: 0.01, finalTurnCount: 1, closedAt: '2026-06-05T12:35:00.000Z' } },
+  ];
+  const out = formatTrace('s', '/p', parseTrace(toJsonl(events)));
+
+  it('renders the rate_limit event in the DEFAULT view (no --all)', () => {
+    expect(out).toContain('throttle');
+    expect(out).toContain('rate-limit');
+    expect(out).toContain('429');
+    expect(out).toContain('retry-after 30.0s');
+    expect(out).toContain('(sdk-fetch)');
+  });
+
+  it('still hides the low-signal model_ttfb phase by default', () => {
+    expect(out).not.toContain('model_ttfb');
+  });
+
+  it('surfaces a throttled count in the summary header', () => {
+    expect(out).toContain('1 throttled');
+  });
+
+  it('omits the throttled count when there are none', () => {
+    const clean = formatTrace(
+      's',
+      '/p',
+      parseTrace(
+        toJsonl([
+          { ts: '2026-06-05T12:35:00.000Z', seq: 0, kind: 'session_sealed', payload: { status: 'succeeded', finalCostUsd: 0.01, finalTurnCount: 1, closedAt: '2026-06-05T12:35:00.000Z' } },
+        ]),
+      ),
+    );
+    expect(clean).not.toContain('throttled');
+  });
+});
+
 describe('formatTrace — closure stop_reason rendering', () => {
   const seal: EventObj = {
     ts: '2026-06-05T12:35:00.500Z',

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -364,8 +364,25 @@ function renderEvent(event: TraceEvent, ctx: RenderContext): string | null {
     }
 
     case 'session_phase': {
-      if (!ctx.showAll) return null; // latency waterfall — low signal by default
       const p = event.payload;
+      // `rate_limit` is HIGH-signal: it explains an otherwise-invisible stall
+      // (the SDK's silent 429/503/529 retry-after backoff surfaces only as an
+      // abnormally long model_ttfb). Render it in the DEFAULT view — unlike the
+      // other phases, which are low-signal latency-waterfall markers shown only
+      // with --all. Placed before the showAll gate below on purpose.
+      if (p.phase === 'rate_limit') {
+        const md = p.metadata ?? {};
+        const reason = md['reason'];
+        const status = md['status'];
+        const source = md['source'];
+        const wait =
+          p.durationMs !== undefined ? `  retry-after ${fmtDuration(p.durationMs)}` : '';
+        const statusBit = status !== undefined ? `  ${status}` : '';
+        const srcBit = source !== undefined ? `  (${source})` : '';
+        const head = reason !== undefined ? String(reason) : 'throttled';
+        return line('throttle', `${head}${statusBit}${wait}${srcBit}`);
+      }
+      if (!ctx.showAll) return null; // latency waterfall — low signal by default
       const dur = p.durationMs !== undefined ? `  ${fmtDuration(p.durationMs)}` : '';
       // Prefer the operator alias (session_init_start); fall back to the
       // resolved wire id (model_ttfb carries only that).
@@ -402,6 +419,8 @@ interface TraceSummary {
   subagents: number;
   claims: number;
   blocks: number;
+  /** Count of rate_limit events (429/503/529 backoff). */
+  throttles: number;
   sealStatus: string | null;
   finalCostUsd: number | null;
   /** Operator-typed model for the root session (from session_init_start). */
@@ -416,6 +435,7 @@ function summarize(events: TraceEvent[]): TraceSummary {
   let subagents = 0;
   let claims = 0;
   let blocks = 0;
+  let throttles = 0;
   let sealStatus: string | null = null;
   let finalCostUsd: number | null = null;
   let model: string | null = null;
@@ -430,6 +450,7 @@ function summarize(events: TraceEvent[]): TraceSummary {
         }
         break;
       case 'session_phase':
+        if (e.payload.phase === 'rate_limit') throttles++;
         // Root-session model provenance lives on session_init_start (the
         // earliest, always-emitted phase). First occurrence wins.
         if (e.payload.phase === 'session_init_start') {
@@ -467,6 +488,7 @@ function summarize(events: TraceEvent[]): TraceSummary {
     subagents,
     claims,
     blocks,
+    throttles,
     sealStatus,
     finalCostUsd,
     model,
@@ -510,6 +532,7 @@ export function formatTrace(
       ? `sealed (${summary.sealStatus})`
       : 'unsealed (live or crashed)';
   const costPart = summary.finalCostUsd !== null ? ` · ${fmtUsd(summary.finalCostUsd)}` : '';
+  const throttlePart = summary.throttles > 0 ? ` · ${summary.throttles} throttled` : '';
 
   const out: string[] = [];
   out.push(`Trace  ${sessionId}`);
@@ -524,7 +547,7 @@ export function formatTrace(
   out.push(
     `       ${status} · ${summary.total} events · ${summary.toolCalls} tool calls` +
       ` (${summary.toolErrors} err) · ${summary.subagents} subagents · ${summary.claims} claims` +
-      ` · ${summary.blocks} blocks${costPart}`,
+      ` · ${summary.blocks} blocks${throttlePart}${costPart}`,
   );
   out.push('');
 


### PR DESCRIPTION
## Problem
When Anthropic throttles a session (429 rate limit / 503 / 529 overload) it looks **stuck**:

- The SDK retries these internally, honoring `retry-after`, **inside a single `messages.create` call**. So a throttled turn surfaces only as an abnormally long `model_ttfb` — a real trace showed 39 turns with 16 >30s, 10 >60s, **max 146s** — with **no event**, indistinguishable from a hang. `AFK.md` already notes *"a usage-limit pause has no event (silent gap)."*
- `classifyUsageLimitError` treated **every** 429 as OAuth *subscription* exhaustion, so a transient API-tier rate-limit 429 was parked in the 2-hour poll/pause path under a misleading "usage limit" label.

Diagnosed from a live stuck `/review` subagent (`claude-sonnet-5`).

## Changes

### #1 — Make backoff observable (behavior-preserving)
- **`tracing-fetch.ts`** (new): `makeTracingFetch` wraps the SDK's `fetch` client option and emits a `rate_limit` witness-trace event on every 429/503/529 response (`status`, `reason`, `retryAfterMs`). Purely observational — the request is forwarded and the `Response` returned untouched (only headers are read), so **retry behavior is unchanged**. Wired at the `query()` client and the OAuth-refresh client rebuild; skipped in local-shim mode.
- **`loop.ts`**: emits the same event on the mid-stream `overloaded_error` retry, which the fetch wrapper can't see (it rides an HTTP 200 SSE body).
- New `SessionPhaseName` `'rate_limit'` (+ Zod schema).

Now `afk trace show` explains a throttled stall instead of hiding it.

### #4 — Fix 429 misclassification
- **`usage-limit.ts`**: `classifyUsageLimitError` returns a new `rate-limit-transient` kind for a 429 carrying a `retry-after`/`retry-after-ms` header and no `|<unix-ts>` (a standard API-tier rate limit), distinct from OAuth subscription exhaustion. `retry-layer.ts` therefore does **not** route it into the 2-hour subscription-pause path — it surfaces as an error after the SDK's own retry-after retries. New `parseRetryAfterMs` helper.

## Testing
- **+15 tests**: `tracing-fetch.test.ts` (5); `usage-limit.test.ts` (+10 for classification + `parseRetryAfterMs`).
- `tsc --noEmit` clean; `audit:sdk:check` / `audit:env:check` / `scan:env:check` all pass.
- Full `anthropic-direct` + `trace` suites green (**618 tests**). No new `@anthropic-ai/sdk` imports; no new `process.env` reads.

## Deferred (follow-ups)
- Surface the throttle in the **spinner/status line** (not just the trace) — needs a side-channel from the fetch layer up to the renderer.
- Optional: a short bounded auto-retry (honoring `retry-after`) for `rate-limit-transient`, to preserve auto-recovery for genuinely brief blips instead of surfacing an error.
