### PR TITLE
feat: add /thinking slash command for mid-session thinking-UI toggle

### DIFF
--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -542,6 +542,10 @@ export async function bootstrapSession(
   if (initialPermissionMode !== undefined) {
     stats.permissionMode = initialPermissionMode;
   }
+  // Seed thinking-UI mode from the CLI flag so `/thinking` has a live value
+  // to mutate. `createSessionStats()` already defaults to 'live'; this
+  // overrides with the user's explicit `--thinking-ui` choice (if any).
+  stats.thinkingUi = options.thinkingUi;
   // Stamp the effective working directory on stats so the status line can
   // render it. We capture the same cwd the provider will see: the explicit
   // `extras.cwd` override (e.g. from `--worktree`) when present, else

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -580,7 +580,7 @@ export async function runInputLoop(
         // transitions.  The bar is a per-session singleton; the callback is
         // safe to call on non-TTY (LoopStageBar.repaint() TTY-gates itself).
         ...(loopStageBar ? { onStageChange: (stage) => loopStageBar!.repaint(stage) } : {}),
-      }, ctx.options.thinkingUi, ctx.completionWriter,
+      }, ctx.stats.thinkingUi ?? ctx.options.thinkingUi, ctx.completionWriter,
         // Surface refs threaded into the per-turn StreamRenderer for the
         // legacy non-borrow path (non-TTY, when surface.getCompositor()
         // is null and the renderer constructs its own compositor). In

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -6,7 +6,7 @@ import type { AgentModelInput } from '../../../agent/types.js';
 import type { BackgroundAgentRegistry } from '../../../agent/background-registry.js';
 import type { BackgroundSummarizer } from '../../../agent/background-summarizer.js';
 import type { SubagentControl } from '../../../agent/tools/subagent-executor.js';
-import type { SlashContext, SessionStats, ResumeSwapResult } from '../../slash/types.js';
+import type { SlashContext, SessionStats, ResumeSwapResult, ThinkingUiMode } from '../../slash/types.js';
 import type { StoredSession } from '../../session-store.js';
 import type { StatusLine } from '../../status-line.js';
 import type { ReplRenderer } from './repl-renderer.js';
@@ -212,7 +212,12 @@ function truncate(s: string, max: number): string {
   return codePoints.slice(0, max - 1).join('') + '…';
 }
 
-export type ThinkingUiMode = 'summary' | 'live' | 'off';
+/**
+ * Canonical definition lives in `slash/types.ts` (neutral layer) to avoid the
+ * upward import that would result from defining it here. Re-exported for
+ * backward compat — existing imports from this module continue to work.
+ */
+export type { ThinkingUiMode } from '../../slash/types.js';
 
 export interface CliOptions {
   /**

--- a/src/cli/slash/commands/thinking.test.ts
+++ b/src/cli/slash/commands/thinking.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for the /thinking slash command.
+ *
+ * The command mutates `ctx.stats.thinkingUi` (a shared `SessionStats` field)
+ * to toggle the thinking-display mode mid-session. Tests assert:
+ *   1. no args → current mode is printed
+ *   2. valid mode → stats mutated + success confirmation printed
+ *   3. invalid mode → error surfaced, stats NOT mutated
+ *   4. alias `/thinking-ui` resolves to the same command
+ *   5. effect is on the next turn (stats is the shared object, not a copy)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { SlashContext, SessionStats } from '../types.js';
+import { thinkingCmd } from './thinking.js';
+
+function makeStats(overrides?: Partial<SessionStats>): SessionStats {
+  return {
+    totalTurns: 0,
+    totalCostUsd: 0,
+    totalTokens: 0,
+    totalDurationMs: 0,
+    sessionStartTime: Date.now(),
+    turnCosts: [],
+    turnTokens: [],
+    turns: [],
+    model: 'sonnet',
+    permissionMode: 'default',
+    thinkingUi: 'live',
+    ...overrides,
+  };
+}
+
+function makeCtx(stats?: SessionStats): { ctx: SlashContext; lines: string[] } {
+  const lines: string[] = [];
+  const ctx: SlashContext = {
+    session: { current: {} } as unknown as SlashContext['session'],
+    stats: stats ?? makeStats(),
+    out: {
+      line: (t = ''): void => { lines.push(`LINE:${t}`); },
+      raw: (t): void => { lines.push(`RAW:${t}`); },
+      success: (t): void => { lines.push(`SUCCESS:${t}`); },
+      info: (t): void => { lines.push(`INFO:${t}`); },
+      warn: (t): void => { lines.push(`WARN:${t}`); },
+      error: (t): void => { lines.push(`ERROR:${t}`); },
+    },
+    ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
+  };
+  return { ctx, lines };
+}
+
+describe('/thinking slash command', () => {
+  it('prints current mode when no args given', async () => {
+    const { ctx, lines } = makeCtx(makeStats({ thinkingUi: 'summary' }));
+    const result = await thinkingCmd.handler(ctx, '');
+    expect(result).toBe('continue');
+    expect(lines.some((l) => l.startsWith('INFO:') && l.includes('summary'))).toBe(true);
+  });
+
+  it('defaults to "live" when stats.thinkingUi is undefined', async () => {
+    const { ctx, lines } = makeCtx(makeStats({ thinkingUi: undefined }));
+    const result = await thinkingCmd.handler(ctx, '');
+    expect(result).toBe('continue');
+    expect(lines.some((l) => l.startsWith('INFO:') && l.includes('live'))).toBe(true);
+  });
+
+  it('switches to summary and mutates stats', async () => {
+    const stats = makeStats({ thinkingUi: 'live' });
+    const { ctx, lines } = makeCtx(stats);
+    const result = await thinkingCmd.handler(ctx, 'summary');
+    expect(result).toBe('continue');
+    expect(stats.thinkingUi).toBe('summary');
+    expect(lines.some((l) => l.startsWith('SUCCESS:') && l.includes('summary'))).toBe(true);
+  });
+
+  it('switches to off and mutates stats', async () => {
+    const stats = makeStats({ thinkingUi: 'live' });
+    const { ctx, lines } = makeCtx(stats);
+    const result = await thinkingCmd.handler(ctx, 'off');
+    expect(result).toBe('continue');
+    expect(stats.thinkingUi).toBe('off');
+    expect(lines.some((l) => l.startsWith('SUCCESS:') && l.includes('off'))).toBe(true);
+  });
+
+  it('switches back to live from summary', async () => {
+    const stats = makeStats({ thinkingUi: 'summary' });
+    const { ctx, lines } = makeCtx(stats);
+    const result = await thinkingCmd.handler(ctx, 'live');
+    expect(result).toBe('continue');
+    expect(stats.thinkingUi).toBe('live');
+    expect(lines.some((l) => l.startsWith('SUCCESS:') && l.includes('live'))).toBe(true);
+  });
+
+  it('rejects invalid mode without mutating stats', async () => {
+    const stats = makeStats({ thinkingUi: 'live' });
+    const { ctx, lines } = makeCtx(stats);
+    const result = await thinkingCmd.handler(ctx, 'verbose');
+    expect(result).toBe('continue');
+    expect(stats.thinkingUi).toBe('live'); // unchanged
+    expect(lines.some((l) => l.startsWith('WARN:') && l.includes('Invalid mode'))).toBe(true);
+  });
+
+  it('trims and lowercases the argument', async () => {
+    const stats = makeStats({ thinkingUi: 'live' });
+    const { ctx } = makeCtx(stats);
+    const result = await thinkingCmd.handler(ctx, '  SUMMARY  ');
+    expect(result).toBe('continue');
+    expect(stats.thinkingUi).toBe('summary');
+  });
+
+  it('exposes metadata for autocomplete', () => {
+    expect(thinkingCmd.name).toBe('/thinking');
+    expect(thinkingCmd.aliases).toContain('/thinking-ui');
+    expect(thinkingCmd.flags).toEqual(['summary', 'live', 'off']);
+    expect(thinkingCmd.summary).toBeTruthy();
+    expect(thinkingCmd.hint).toBeTruthy();
+  });
+});

--- a/src/cli/slash/commands/thinking.ts
+++ b/src/cli/slash/commands/thinking.ts
@@ -37,6 +37,7 @@ export const thinkingCmd: SlashCommand = {
   hint:
     'Switch thinking display: `live` (streaming preview + summary, default), ' +
     '`summary` (one-line collapse only), or `off` (hidden). ' +
+    'This is a display-only toggle — extended thinking still runs; cost and latency are unaffected. ' +
     'Takes effect on the next turn — same semantics as `/model`. ' +
     'Run without args to see the current mode.',
   flags: ['summary', 'live', 'off'],
@@ -63,7 +64,7 @@ export const thinkingCmd: SlashCommand = {
     ctx.stats.thinkingUi = target;
     ctx.out.success(
       `Thinking display set to ${palette.brand(target)} (${MODE_DESCRIPTIONS[target]}). ` +
-      `Takes effect on the next turn.`,
+      `Takes effect on the next turn. (display only — thinking still runs; cost and latency are unaffected.)`,
     );
     return 'continue';
   },

--- a/src/cli/slash/commands/thinking.ts
+++ b/src/cli/slash/commands/thinking.ts
@@ -1,0 +1,70 @@
+/**
+ * /thinking slash command — toggle the thinking-display mode mid-session.
+ *
+ * Exposes the boot-time-only `--thinking-ui <summary|live|off>` flag as a
+ * runtime slash command so the operator can switch thinking rendering without
+ * restarting the REPL. The effect applies on the next turn (the
+ * `StreamRenderer` is frozen per-turn — same semantics as `/model`).
+ *
+ * Usage:
+ *   /thinking           — show the current mode
+ *   /thinking live       — stream thinking preview + finalize summary (default)
+ *   /thinking summary    — collapsed one-line summary on finalize, no live preview
+ *   /thinking off        — suppress thinking entirely
+ *
+ * Mutates `ctx.stats.thinkingUi`, which the REPL loop reads at the top of each
+ * turn (`loop-iteration.ts`). No status-line integration — acknowledgment is
+ * printed via `ctx.out.success`, matching the `/model` confirmation pattern.
+ */
+
+import type { ThinkingUiMode } from '../types.js';
+import type { SlashCommand } from '../types.js';
+import { palette } from '../../palette.js';
+
+const VALID_MODES: readonly ThinkingUiMode[] = ['summary', 'live', 'off'];
+
+const MODE_DESCRIPTIONS: Record<ThinkingUiMode, string> = {
+  live: 'streaming preview + finalize summary',
+  summary: 'collapsed one-line summary on finalize',
+  off: 'suppressed entirely',
+};
+
+export const thinkingCmd: SlashCommand = {
+  name: '/thinking',
+  aliases: ['/thinking-ui'],
+  usage: '/thinking [summary|live|off]',
+  summary: 'Toggle how thinking blocks are rendered mid-session',
+  hint:
+    'Switch thinking display: `live` (streaming preview + summary, default), ' +
+    '`summary` (one-line collapse only), or `off` (hidden). ' +
+    'Takes effect on the next turn — same semantics as `/model`. ' +
+    'Run without args to see the current mode.',
+  flags: ['summary', 'live', 'off'],
+  async handler(ctx, args) {
+    const target = args.trim().toLowerCase() as ThinkingUiMode;
+
+    // No args → show current mode.
+    if (!target) {
+      const current = ctx.stats.thinkingUi ?? 'live';
+      ctx.out.info(`Thinking display: ${palette.brand(current)} (${MODE_DESCRIPTIONS[current]})`);
+      return 'continue';
+    }
+
+    // Validate.
+    if (!VALID_MODES.includes(target)) {
+      ctx.out.warn(
+        `Invalid mode: "${target}". Valid modes: ${VALID_MODES.join(', ')}`,
+      );
+      return 'continue';
+    }
+
+    // Mutate the shared stats object — the REPL loop reads
+    // `ctx.stats.thinkingUi` at the top of the next turn.
+    ctx.stats.thinkingUi = target;
+    ctx.out.success(
+      `Thinking display set to ${palette.brand(target)} (${MODE_DESCRIPTIONS[target]}). ` +
+      `Takes effect on the next turn.`,
+    );
+    return 'continue';
+  },
+};

--- a/src/cli/slash/index.ts
+++ b/src/cli/slash/index.ts
@@ -22,6 +22,7 @@ import { shCmd } from './commands/sh.js';
 import { initCmd } from './commands/init.js';
 import { statsCmd } from './commands/stats.js';
 import { fontSizeCmd } from './commands/font-size.js';
+import { thinkingCmd } from './commands/thinking.js';
 import { allowDirCmd } from './commands/allow-dir.js';
 import { keysCmd } from './commands/keys.js';
 import { worktreeCmd } from './commands/worktree.js';
@@ -51,6 +52,7 @@ export function registerAll(): void {
   register(initCmd);
   register(statsCmd);
   register(fontSizeCmd);
+  register(thinkingCmd);
   register(allowDirCmd);
   register(worktreeCmd);
   register(reauthCmd);

--- a/src/cli/slash/session-stats.ts
+++ b/src/cli/slash/session-stats.ts
@@ -23,6 +23,7 @@ export function createSessionStats(model: AgentModelInput): SessionStats {
     turns: [],
     model,
     permissionMode: 'default',
+    thinkingUi: 'live',
   };
 }
 
@@ -53,6 +54,8 @@ export function resetStats(stats: SessionStats): void {
   delete stats.name;
   // Preserve `permissionMode` (user-controlled state — the plan/AFK gates read
   // it live; `/clear` should not silently drop the operator out of AFK mode).
+  // Preserve `thinkingUi` for the same reason — the `/thinking` user setting
+  // should survive a `/clear` just as `/model`'s choice does.
 }
 
 /**

--- a/src/cli/slash/types.ts
+++ b/src/cli/slash/types.ts
@@ -26,6 +26,18 @@ export type ResumeSwapResult =
   | { ok: true; sessionId: string }
   | { ok: false; reason: string };
 
+/**
+ * How the REPL renders the model's extended-thinking blocks:
+ * - `'live'` (default) — streaming preview overlay + finalize summary
+ * - `'summary'` — collapsed one-line summary on finalize, no live preview
+ * - `'off'` — suppressed entirely (no buffer, no overlay, no summary)
+ *
+ * Canonical definition lives here (neutral slash-layer) to avoid the upward
+ * import that would result from placing it in `commands/interactive/shared.ts`.
+ * `commands/interactive/shared.ts` re-exports this for backward compat.
+ */
+export type ThinkingUiMode = 'summary' | 'live' | 'off';
+
 /** A recorded tool invocation within a turn — persisted for post-mortem diagnosis. */
 export interface ToolEvent {
   toolName: string;
@@ -84,6 +96,15 @@ export interface SessionStats {
    * field), which is why AFK is not a separate boolean alongside plan.
    */
   permissionMode: PermissionMode;
+  /**
+   * Current thinking-display mode — the `--thinking-ui` knob, made mutable
+   * mid-session via the `/thinking` slash command. Seeded once at bootstrap
+   * from `options.thinkingUi` and mutated by `/thinking`; the REPL loop reads
+   * it on each new turn. Optional so existing test fixtures that build
+   * `SessionStats` literals don't need updating — `createSessionStats()`
+   * always seeds a value in production.
+   */
+  thinkingUi?: ThinkingUiMode;
   /** SDK session ID once initialized. Populated from ResponseMetadata. */
   sessionId?: string;
   /**


### PR DESCRIPTION
## Summary

Adds a `/thinking` slash command that lets the operator toggle the thinking-display mode mid-session, without restarting the REPL. Previously the render mode was only settable at boot via the `--thinking-ui <summary|live|off>` CLI flag.

- `/thinking` — print the current mode
- `/thinking live` — streaming preview + finalize summary (default)
- `/thinking summary` — collapsed one-line summary on finalize, no live preview
- `/thinking off` — suppress thinking entirely
- Alias: `/thinking-ui`

## Approach

Follows the same idiom as the existing `/model` command: the handler mutates a field on the shared, per-session `ctx.stats` object (`SessionStats.thinkingUi`), and the REPL loop reads that field at the top of the next turn — so the effect is visible starting on the following turn, matching `/model`'s semantics exactly. No new subsystem, no status-line integration; confirmation is printed via `ctx.out.success`, same as `/model`.

`ThinkingUiMode` (`'summary' | 'live' | 'off'`) moved from `cli/commands/interactive/shared.ts` to the neutral `cli/slash/types.ts` layer (re-exported from the old location for backward compatibility) so the slash-command layer can reference it without an upward import.

`createSessionStats()` now defaults `thinkingUi` to `'live'`; `bootstrapSession()` overrides that default with the operator's explicit `--thinking-ui` flag value when provided. `resetStats()` (used by `/clear`) preserves `thinkingUi` across a clear, for the same reason it already preserves `permissionMode`: it's user-controlled session state, not per-turn statistics.

## Files changed

- `src/cli/slash/commands/thinking.ts` (new) — command implementation
- `src/cli/slash/commands/thinking.test.ts` (new) — 8 tests
- `src/cli/slash/index.ts` — register the command
- `src/cli/slash/types.ts` — canonical `ThinkingUiMode` type + `SessionStats.thinkingUi` field
- `src/cli/slash/session-stats.ts` — default `thinkingUi: 'live'` in `createSessionStats()`; preserve across `resetStats()`
- `src/cli/commands/interactive/bootstrap.ts` — seed `stats.thinkingUi` from the `--thinking-ui` CLI flag
- `src/cli/commands/interactive/loop-iteration.ts` — read `ctx.stats.thinkingUi ?? ctx.options.thinkingUi` per turn
- `src/cli/commands/interactive/shared.ts` — re-export `ThinkingUiMode` from the new canonical location

## Test results

- New tests: `src/cli/slash/commands/thinking.test.ts` — **8/8 passing**
- Full suite: **10754 passed**, 14 skipped (10768 total), 585 test files — all green
- Lint (`tsc --noEmit`): **clean**
