### PR TITLE
fix(subagent): grant main-repo read root to worktree subagents

### DIFF
--- a/src/agent/subagent-worktree-readroot.test.ts
+++ b/src/agent/subagent-worktree-readroot.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Regression tests: forkSubagent grants the MAIN repo root as a read root to
+ * subagents whose cwd is a linked git worktree.
+ *
+ * Bug (pre-fix): a subagent forked from an `afk -w` worktree session inherits
+ * the worktree cwd but no read roots, so its dispatcher defaults to
+ * `readRoots = [worktree]`. Any `read_file <mainRepo>/…` is rejected as
+ * "outside the allowed read roots", and the subagent cannot approve it (the
+ * path-approval hook auto-denies forked children). This locks subagents out of
+ * main-repo paths that pervade their context.
+ *
+ * Fix: forkSubagent resolves the worktree's main-repo root (best-effort, via
+ * ./worktree-read-root) and sets `childConfig.readRoots = [cwd, mainRoot]` when
+ * the caller did not pin its own read roots. These tests capture the config
+ * handed to the child AgentSession and assert the grant.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Message } from './types.js';
+
+type CapturedConfig = Record<string, unknown> | null;
+
+const shared = vi.hoisted(() => ({
+  lastConfig: null as CapturedConfig,
+}));
+
+vi.mock('./session.js', () => {
+  class MockAgentSession {
+    public readonly sessionId?: string;
+    public sendMessage: ReturnType<typeof vi.fn>;
+    public sendMessageStream: ReturnType<typeof vi.fn>;
+    public interrupt = vi.fn(async () => undefined);
+    public close = vi.fn(async () => undefined);
+    constructor(config: Record<string, unknown>) {
+      shared.lastConfig = config;
+      this.sessionId = (config.sessionId as string | undefined) ?? 'child-session-id';
+      this.sendMessage = vi.fn(async (content: string): Promise<Message> => ({
+        role: 'assistant',
+        content: `ok:${content}`,
+        timestamp: new Date(),
+      }));
+      this.sendMessageStream = vi.fn(async function* (this: MockAgentSession, content: string) {
+        const result = await this.sendMessage(content);
+        yield { type: 'message', message: result };
+        yield { type: 'done' };
+      }.bind(this));
+    }
+    get abortSignal(): AbortSignal {
+      return new AbortController().signal;
+    }
+  }
+  return { AgentSession: MockAgentSession };
+});
+
+// Control the worktree → main-root resolver without touching real git.
+vi.mock('./worktree-read-root.js', () => ({
+  resolveWorktreeMainRoot: vi.fn(async () => undefined),
+}));
+
+import { SubagentManager } from './subagent.js';
+import { resolveWorktreeMainRoot } from './worktree-read-root.js';
+
+const WORKTREE = '/repo/.afk-worktrees/wt';
+const MAIN = '/repo';
+
+const mockedResolve = vi.mocked(resolveWorktreeMainRoot);
+
+function forkOpts(
+  config: Record<string, unknown>,
+): Parameters<SubagentManager['forkSubagent']>[0] {
+  return {
+    parent: { sessionId: 'parent' },
+    config,
+  } as Parameters<SubagentManager['forkSubagent']>[0];
+}
+
+describe('forkSubagent — worktree main-repo read-root grant', () => {
+  beforeEach(() => {
+    shared.lastConfig = null;
+    mockedResolve.mockReset();
+    mockedResolve.mockResolvedValue(undefined);
+  });
+
+  it('grants [cwd, mainRoot] when the manager cwd is a linked worktree', async () => {
+    mockedResolve.mockResolvedValue(MAIN);
+    const mgr = new SubagentManager({ cwd: WORKTREE });
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' }));
+
+    const cfg = shared.lastConfig as { cwd?: string; readRoots?: string[] } | null;
+    expect(cfg?.cwd).toBe(WORKTREE);
+    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN]);
+    expect(mockedResolve).toHaveBeenCalledWith(WORKTREE);
+  });
+
+  it('grants [cwd, mainRoot] when cwd comes from per-call config (agent tool cwd)', async () => {
+    mockedResolve.mockResolvedValue(MAIN);
+    const mgr = new SubagentManager(); // no manager cwd
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k', cwd: WORKTREE }));
+
+    const cfg = shared.lastConfig as { cwd?: string; readRoots?: string[] } | null;
+    expect(cfg?.cwd).toBe(WORKTREE);
+    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN]);
+    expect(mockedResolve).toHaveBeenCalledWith(WORKTREE);
+  });
+
+  it('does NOT set readRoots when cwd is not a worktree (resolver returns undefined)', async () => {
+    mockedResolve.mockResolvedValue(undefined);
+    const mgr = new SubagentManager({ cwd: '/plain/repo' });
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' }));
+
+    const cfg = shared.lastConfig as { cwd?: string; readRoots?: string[] } | null;
+    expect(cfg?.cwd).toBe('/plain/repo');
+    // Left unset so the provider applies its own `[cwd]` default.
+    expect(cfg?.readRoots).toBeUndefined();
+  });
+
+  it('does NOT override caller-pinned readRoots (e.g. afk farm) and skips resolution', async () => {
+    const mgr = new SubagentManager({ cwd: WORKTREE });
+    await mgr.forkSubagent(
+      forkOpts({ model: 'sonnet', apiKey: 'k', cwd: WORKTREE, readRoots: [WORKTREE], writeRoots: [WORKTREE] }),
+    );
+
+    const cfg = shared.lastConfig as { readRoots?: string[]; writeRoots?: string[] } | null;
+    expect(cfg?.readRoots).toEqual([WORKTREE]);
+    expect(cfg?.writeRoots).toEqual([WORKTREE]);
+    // Caller pinned readRoots → we must not even resolve (no git subprocess).
+    expect(mockedResolve).not.toHaveBeenCalled();
+  });
+
+  it('does not grant a write root (worktree write isolation preserved)', async () => {
+    mockedResolve.mockResolvedValue(MAIN);
+    const mgr = new SubagentManager({ cwd: WORKTREE });
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' }));
+
+    const cfg = shared.lastConfig as { readRoots?: string[]; writeRoots?: string[] } | null;
+    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN]);
+    // writeRoots untouched → provider defaults writes to [cwd] = the worktree.
+    expect(cfg?.writeRoots).toBeUndefined();
+  });
+
+  it('caches resolution per cwd: two forks share one resolver call', async () => {
+    mockedResolve.mockResolvedValue(MAIN);
+    const mgr = new SubagentManager({ cwd: WORKTREE });
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' }));
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' }));
+    expect(mockedResolve).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not set readRoots when the resolved main root equals cwd (defensive)', async () => {
+    mockedResolve.mockResolvedValue(WORKTREE);
+    const mgr = new SubagentManager({ cwd: WORKTREE });
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' }));
+
+    const cfg = shared.lastConfig as { readRoots?: string[] } | null;
+    expect(cfg?.readRoots).toBeUndefined();
+  });
+
+  it('does not resolve or set readRoots when no cwd is available anywhere', async () => {
+    const mgr = new SubagentManager(); // no cwd
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' })); // no config.cwd
+
+    const cfg = shared.lastConfig as { readRoots?: string[] } | null;
+    expect(cfg?.readRoots).toBeUndefined();
+    expect(mockedResolve).not.toHaveBeenCalled();
+  });
+});

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -35,6 +35,7 @@ import type { Surface } from './awareness/types.js';
 import { appendRoutingDecision } from './routing-telemetry.js';
 import { getCurrentSink } from './_lib/skill-sink-channel.js';
 import { touchWorktreeOccupancy } from './worktree-occupancy.js';
+import { resolveWorktreeMainRoot } from './worktree-read-root.js';
 import { buildPhaseRestrictedProvider, type PhaseRole } from './tools/nesting.js';
 import { applyManagerApiKeyFallback } from './tools/child-credential.js';
 import { providerForModel, type BundledProviderName } from './providers/index.js';
@@ -275,6 +276,12 @@ export class SubagentManager {
   // `afk -w` worktree is created mid-session. Read at fork time (forkSubagent),
   // so updating it makes every subsequent fork inherit the new worktree cwd.
   private parentCwd: string | undefined;
+  // Per-cwd cache of the resolved main-repo root for worktree children (see
+  // `resolveWorktreeMainRoot`). Forks overwhelmingly share one cwd, so this
+  // collapses N git subprocesses to one per distinct cwd for the whole
+  // manager lifetime. `undefined` value = resolved-and-there-is-none, so the
+  // Map's `.has()` distinguishes "not yet resolved" from "resolved to none".
+  private readonly worktreeMainRootCache = new Map<string, string | undefined>();
   private readonly parentTraceWriter: TraceWriter | undefined;
   private readonly parentSurface: Surface | undefined;
   private readonly abortGraph: AbortGraph;
@@ -364,6 +371,23 @@ export class SubagentManager {
   }
 
   /**
+   * Resolve (and memoize) the main-repo root for a worktree `cwd`. Returns the
+   * main repository root when `cwd` is inside a linked git worktree distinct
+   * from the main worktree, else undefined. Best-effort — never throws.
+   *
+   * Cached per cwd so a fan-out of subagents sharing one worktree pays a single
+   * `git rev-parse`, not one per fork.
+   */
+  private async resolveMainRootForCwd(cwd: string): Promise<string | undefined> {
+    if (this.worktreeMainRootCache.has(cwd)) {
+      return this.worktreeMainRootCache.get(cwd);
+    }
+    const mainRoot = await resolveWorktreeMainRoot(cwd);
+    this.worktreeMainRootCache.set(cwd, mainRoot);
+    return mainRoot;
+  }
+
+  /**
    * Abort the entire managed tree.
    *
    * @param reason   Forwarded to every cascade victim's AbortController. Read
@@ -448,6 +472,24 @@ export class SubagentManager {
     this.abortGraph.register(id, childController);
     this.abortGraph.linkChild(this.rootId, id);
 
+    // Worktree read-root grant: when the child runs in a linked git worktree
+    // and the caller did not pin its own read roots, add the MAIN repo root as
+    // a READ root (never a write root — writes stay confined to the worktree).
+    // Without this, a subagent is confined to `[cwd]` and cannot read main-repo
+    // absolute paths that pervade its context (system prompt, skill prompts,
+    // parent messages), yet it cannot approve them interactively either — the
+    // path-approval hook auto-denies forked children. See ./worktree-read-root.
+    // A caller that pins `readRoots` (e.g. `afk farm`, which deliberately
+    // confines each branch worker) is left untouched.
+    const effectiveChildCwd = options.config.cwd ?? this.parentCwd;
+    let worktreeReadRoots: string[] | undefined;
+    if (options.config.readRoots === undefined && effectiveChildCwd !== undefined) {
+      const mainRoot = await this.resolveMainRootForCwd(effectiveChildCwd);
+      if (mainRoot !== undefined && mainRoot !== effectiveChildCwd) {
+        worktreeReadRoots = [effectiveChildCwd, mainRoot];
+      }
+    }
+
     const childConfig: AgentConfig = {
       ...options.config,
       resume,
@@ -520,6 +562,11 @@ export class SubagentManager {
       ...(options.config.cwd === undefined && this.parentCwd !== undefined
         ? { cwd: this.parentCwd }
         : {}),
+      // Worktree read-root grant (see the computation above the literal). Only
+      // set when the child runs in a linked worktree AND the caller left
+      // readRoots unset; otherwise the `...options.config` spread's readRoots
+      // (or the provider's `[cwd]` default) stands.
+      ...(worktreeReadRoots !== undefined ? { readRoots: worktreeReadRoots } : {}),
       // Invariant: a forked child's trace origin comes from its inherited
       // parent surface, not from any actor-role value (see session-identity.ts).
       // Inherit traceWriter + surface from the manager so every worker session

--- a/src/agent/worktree-read-root.test.ts
+++ b/src/agent/worktree-read-root.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for resolveWorktreeMainRoot — the git-worktree → main-repo-root
+ * resolver that lets forked subagents read main-repo paths from a worktree.
+ *
+ * All cases inject a fake `execFile` so no real git is invoked.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import path from 'node:path';
+import { resolveWorktreeMainRoot, type ExecFileFn } from './worktree-read-root.js';
+
+/** Build a fake execFile that returns fixed rev-parse stdout. */
+function fakeGit(stdout: string): ExecFileFn {
+  return vi.fn(async () => ({ stdout, stderr: '' }));
+}
+
+/** Build a fake execFile that rejects (git failure / not a repo). */
+function failingGit(): ExecFileFn {
+  return vi.fn(async () => {
+    throw new Error('fatal: not a git repository');
+  });
+}
+
+describe('resolveWorktreeMainRoot', () => {
+  const MAIN = '/repo';
+  const WORKTREE = '/repo/.afk-worktrees/wt';
+
+  it('returns the main-repo root for a linked worktree', async () => {
+    // rev-parse --git-common-dir --show-toplevel from a linked worktree:
+    //   line 1 = <main>/.git (absolute), line 2 = <worktree>
+    const exec = fakeGit(`${MAIN}/.git\n${WORKTREE}\n`);
+    const root = await resolveWorktreeMainRoot(WORKTREE, exec);
+    expect(root).toBe(MAIN);
+    expect(exec).toHaveBeenCalledWith('git', [
+      '-C',
+      WORKTREE,
+      'rev-parse',
+      '--git-common-dir',
+      '--show-toplevel',
+    ]);
+  });
+
+  it('returns undefined for the main worktree (relative .git, toplevel === cwd)', async () => {
+    // From the main worktree git prints a RELATIVE ".git" for --git-common-dir.
+    const exec = fakeGit(`.git\n${MAIN}\n`);
+    const root = await resolveWorktreeMainRoot(MAIN, exec);
+    expect(root).toBeUndefined();
+  });
+
+  it('returns undefined for the main worktree (absolute .git, toplevel === cwd)', async () => {
+    const exec = fakeGit(`${MAIN}/.git\n${MAIN}\n`);
+    const root = await resolveWorktreeMainRoot(MAIN, exec);
+    expect(root).toBeUndefined();
+  });
+
+  it('returns undefined for a subdir of the main worktree', async () => {
+    // A plain subdir: --show-toplevel is the main root, not the cwd, so it
+    // equals mainRoot → no distinct worktree to grant.
+    const exec = fakeGit(`${MAIN}/.git\n${MAIN}\n`);
+    const root = await resolveWorktreeMainRoot(`${MAIN}/src`, exec);
+    expect(root).toBeUndefined();
+  });
+
+  it('returns the main root for a subdir INSIDE a linked worktree', async () => {
+    // toplevel is the worktree root (≠ mainRoot), so we still grant the main.
+    const exec = fakeGit(`${MAIN}/.git\n${WORKTREE}\n`);
+    const root = await resolveWorktreeMainRoot(`${WORKTREE}/src`, exec);
+    expect(root).toBe(MAIN);
+  });
+
+  it('resolves a relative --git-common-dir against cwd', async () => {
+    // Contrived: relative common-dir but toplevel is a distinct worktree.
+    const exec = fakeGit(`../../.git\n${WORKTREE}\n`);
+    const root = await resolveWorktreeMainRoot(WORKTREE, exec);
+    // path.resolve('/repo/.afk-worktrees/wt', '../../.git') → /repo/.git → /repo
+    expect(root).toBe(path.resolve(WORKTREE, '../../.git', '..'));
+    expect(root).toBe(MAIN);
+  });
+
+  it('handles a worktree located OUTSIDE the main repo tree', async () => {
+    const exec = fakeGit(`${MAIN}/.git\n/tmp/external-wt\n`);
+    const root = await resolveWorktreeMainRoot('/tmp/external-wt', exec);
+    expect(root).toBe(MAIN);
+  });
+
+  it('returns undefined when cwd is undefined (and never calls git)', async () => {
+    const exec = fakeGit('ignored');
+    const root = await resolveWorktreeMainRoot(undefined, exec);
+    expect(root).toBeUndefined();
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when cwd is empty (and never calls git)', async () => {
+    const exec = fakeGit('ignored');
+    const root = await resolveWorktreeMainRoot('', exec);
+    expect(root).toBeUndefined();
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined (never throws) when git fails', async () => {
+    const exec = failingGit();
+    await expect(resolveWorktreeMainRoot(WORKTREE, exec)).resolves.toBeUndefined();
+  });
+
+  it('returns undefined on empty git output', async () => {
+    const exec = fakeGit('\n');
+    const root = await resolveWorktreeMainRoot(WORKTREE, exec);
+    expect(root).toBeUndefined();
+  });
+
+  it('returns undefined when only one line is printed', async () => {
+    const exec = fakeGit(`${MAIN}/.git\n`);
+    const root = await resolveWorktreeMainRoot(WORKTREE, exec);
+    expect(root).toBeUndefined();
+  });
+});

--- a/src/agent/worktree-read-root.ts
+++ b/src/agent/worktree-read-root.ts
@@ -1,0 +1,111 @@
+/**
+ * Resolve the MAIN repository working-tree root for a git worktree.
+ *
+ * # Why
+ *
+ * A session — and especially a forked subagent — running with `cwd` set to a
+ * linked git worktree (e.g. `afk interactive -w`, whose worktrees live at
+ * `<repoRoot>/.afk-worktrees/<slug>`) is confined by the tool dispatcher's
+ * read-root containment (`tools/handlers/_cwd-utils.resolveAndContain`) to
+ * `[cwd]`. But the worktree is a *checkout of the main repo*, and main-repo
+ * absolute paths pervade the context a subagent sees: the system prompt's
+ * `# Environment` block, skill prompts, the parent session's messages, and the
+ * model's own priors. When a subagent tries `read_file <mainRepo>/package.json`
+ * the lexical containment check rejects it as "outside the allowed read roots"
+ * — and, unlike a top-level session, a subagent cannot resolve this
+ * interactively: the path-approval hook auto-denies forked children (see the
+ * `parentSessionId` guard in `tools/hooks/path-approval-hook.ts`). The subagent
+ * is locked in with no remedy.
+ *
+ * Granting the main repo root as a READ root (never a write root — writes stay
+ * confined to the worktree for isolation) removes the lock. Reading main-repo
+ * files from a worktree is not a privilege escalation: it is the same project.
+ *
+ * # Tradeoff (accepted)
+ *
+ * When the model uses a *main-repo* absolute path, the read now returns the
+ * main worktree's copy of the file rather than the worktree's — which can
+ * differ if the worktree has uncommitted edits to that path. This is strictly
+ * better than the pre-fix behavior (a hard error), and relative paths continue
+ * to resolve against `cwd` (the worktree), so worktree-local content is still
+ * reachable the normal way. Rewriting main-repo paths to their worktree
+ * equivalents was rejected as far more complex and error-prone (not every
+ * main-repo path has a worktree twin — `.git`, sibling worktrees).
+ *
+ * # Contract
+ *
+ * Returns the main repo root ONLY when `cwd` is inside a *linked* worktree
+ * whose main root is a distinct path. Returns undefined when:
+ *   - `cwd` is undefined or empty,
+ *   - `cwd` is not inside a git repository,
+ *   - `cwd` is inside the MAIN worktree (its root or a subdir) — nothing
+ *     distinct to grant,
+ *   - git resolution fails for any reason.
+ *
+ * Best-effort: never throws. A resolution failure degrades to today's behavior
+ * (worktree-only read root).
+ *
+ * @module agent/worktree-read-root
+ */
+
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+
+const execFilePromise = promisify(execFileCb);
+
+/** Minimal `execFile` shape — injectable so tests can drive it without git. */
+export type ExecFileFn = (
+  cmd: string,
+  args: string[],
+) => Promise<{ stdout: string; stderr: string }>;
+
+const defaultExecFile: ExecFileFn = (cmd, args) =>
+  execFilePromise(cmd, args) as Promise<{ stdout: string; stderr: string }>;
+
+/**
+ * Resolve the main repository root for a worktree at `cwd`. See the module
+ * header for the full contract. Returns undefined when there is no distinct
+ * main root to grant, or on any git failure (best-effort).
+ */
+export async function resolveWorktreeMainRoot(
+  cwd: string | undefined,
+  execFile: ExecFileFn = defaultExecFile,
+): Promise<string | undefined> {
+  if (cwd === undefined || cwd === '') return undefined;
+  try {
+    // One `git rev-parse` yields both values, in request order:
+    //   line 1 = --git-common-dir  (the .git shared by all linked worktrees;
+    //            from a linked worktree it is <mainRoot>/.git, from the main
+    //            worktree it is a relative ".git")
+    //   line 2 = --show-toplevel   (the root of the worktree containing cwd)
+    const { stdout } = await execFile('git', [
+      '-C',
+      cwd,
+      'rev-parse',
+      '--git-common-dir',
+      '--show-toplevel',
+    ]);
+    const lines = stdout.split('\n').map((l) => l.trim());
+    const commonDirRaw = lines[0];
+    const topLevelRaw = lines[1];
+    if (!commonDirRaw || !topLevelRaw) return undefined;
+
+    // --git-common-dir may be relative (from the main worktree) — anchor it.
+    const absCommonDir = path.isAbsolute(commonDirRaw)
+      ? commonDirRaw
+      : path.resolve(cwd, commonDirRaw);
+    const mainRoot = path.resolve(path.dirname(absCommonDir));
+    const topLevel = path.resolve(topLevelRaw);
+
+    // cwd sits inside the MAIN worktree (its root or a subdir) when the
+    // containing worktree's toplevel equals the main root — no distinct main
+    // repo to grant, so return undefined.
+    if (mainRoot === topLevel) return undefined;
+
+    return mainRoot;
+  } catch {
+    // Not a git repo, git missing, or any other failure — best-effort.
+    return undefined;
+  }
+}

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -39,7 +39,7 @@ const PINNED_HASHES = {
   // `afk service install daemon`). Mirrors the awa-dev upstream (→ framework);
   // vendored byte-equal, so no INTENTIONAL_DIFFS entry is needed. Drift row is
   // wired in UPSTREAM_PATHS below (skips until example-plugin is co-located).
-  automate: '40de5b802991e4be6dcf41305ed02885d0f0bde9b2877bfc1f33dfe9fe634d0f',
+  automate: '93380f58316e607f6b95b27a9c2375f0a5403f3a42eb695d0490b50225d8838c',
   contract: '748eaf01deda592913f463b23c81a6be3a89ae3b316f31f531a8488dc5bc1a7c',
   // Hash re-bumped during PR #187 review: the Merge section now routes the
   // second convergence condition (≥2 critics agree on the same alternative) to
@@ -73,8 +73,8 @@ const PINNED_HASHES = {
   // refactor is bundled-only (no upstream example-plugin counterpart); verbatim
   // copy of the user-scope /refactor at ~/.afk/skills/.
   refactor: '9cb84710ddf2cf63e1a648460a64656d3f4a9aae8e21753b031556070740c51e',
-  research: '10692d77e392cedce928f66cb5dec27dbc2066f48cfc33047820f56506da762a',
-  review: '9b06e0743832df2fce20905b5de6ba424193ce6d683fc9c4f338940433569087',
+  research: 'abe79d75a5f3c74696ef002293dbe8714e446f8955de97089d1005f1e70bc269',
+  review: 'f313e3779af068a623692473abab2300938db8da3ebf3e2998d47fcb21ee9627',
   // Hash bumped 2026-06-09 (PR #52): records the confidence-trigger enhancement
   // landed in this branch's commit 1e35850 — adds high-confidence language
   // ("confident", "certain", "clearly", ≥80%) as a verification trigger in its
@@ -89,7 +89,7 @@ const PINNED_HASHES = {
   // new UNVERIFIED-COMPOSITION / UNVERIFIED-ECHO-CHAMBER verdict states — prose-
   // consistency fix only; no behavior change to the composition-axis guard.
   'shadow-verify':
-    '9a9f7f2d0482f4258036e4b204113f37f3b44e1b390d6ddaaf97f13e7b4cd858',
+    '1a0a6e75a09c9f366ddfa8c15f6a1150f6f3fcb6c30aebbf30f6df8d1463d30e',
   // Hash bumped 2026-06: Phase 4 (commit) + Phase 8 (PR) switched from the
   // `--body "$(cat <<'EOF' … EOF)"` heredoc-in-command-substitution antipattern
   // to the file-based form (`git commit -F` / `gh pr create --body-file`). The
@@ -102,7 +102,7 @@ const PINNED_HASHES = {
   ship: 'e778f20e30cb24edd04e2fa25b939c21db2b49b95ad0e0076be0e49dae8a34a3',
   // simplify is bundled-only (no upstream example-plugin counterpart).
   simplify:
-    'f9c9e93b1263ed782b5703b6f30fd981908b0af1fa219d0124405a318ff2756e',
+    'ce720df16e81eff5e6022db38067d376f2177e08a9783fc377e04cf520c7bf3c',
   spec: '167e7cbb84de5b716efa11bb9f20a6e4b940f6f9a6d1812a7fbd735dae4f67dd',
 } as const;
 


### PR DESCRIPTION
## Problem

When a subagent is dispatched from a **worktree session** (`afk interactive -w`, whose worktrees live at `<repoRoot>/.afk-worktrees/<slug>`), its dispatcher inherits the worktree `cwd` but **no read roots** — so it defaults to `readRoots = [worktree]` (`dispatcher.ts:304`, provider init `anthropic-direct/index.ts:684`).

The containment check at `src/agent/tools/handlers/_cwd-utils.ts:106-123` is **purely lexical** (realpath compare against the roots). It has no idea the worktree is a checkout of the main repo. So when the subagent does `read_file /path/to/repo/package.json` — a **main-repo absolute path**, which appears in the system prompt's `# Environment` block, skill prompts, the parent's messages, and the model's own priors — it gets:

```
Path `/path/to/repo/package.json` is outside the allowed read roots [`…/afk-<slug>`].
```

The subagent **cannot escape this**: the path-approval hook auto-denies out-of-root access for forked children via the `parentSessionId` guard (`path-approval-hook.ts:225-237`) — sub-agents can't prompt the operator. It is locked in with no remedy.

*(Verified still valid on `main` @ `56a65c7`: `_cwd-utils.ts:106-118` lexical compare, `dispatcher.ts:303-304` `readRoots ?? [cwd]`, forked child provider gets a fresh `_sharedReadRoots = [cwd]`, hook auto-deny. Only bites `permissionMode: default` — the new-install default `bypassPermissions` disables containment.)*

## Fix

`SubagentManager.forkSubagent` now resolves the worktree's **main-repo root** and grants it as a **READ root** (never a write root — writes stay confined to the worktree for isolation) when the caller left `readRoots` unset:

```
childConfig.readRoots = [cwd, mainRoot]
```

Reading main-repo files from a worktree is not a privilege escalation — it is the same project. Resolution is best-effort via `git rev-parse --git-common-dir --show-toplevel`, and **cached per cwd** so a fan-out of subagents sharing one worktree pays a single `git` call.

Callers that pin their own `readRoots` — notably `afk farm`, which deliberately confines each branch worker to its own tree — are **left untouched** (the grant is skipped when `options.config.readRoots` is set, and no `git` even runs).

### Files
- **`src/agent/worktree-read-root.ts`** (new) — `resolveWorktreeMainRoot(cwd, execFile?)`. Returns the main root only for a *linked* worktree whose main root is distinct; `undefined` for the main worktree (root or subdir), a non-repo, empty/partial git output, or any git failure. Never throws.
- **`src/agent/subagent.ts`** — resolve + inject `readRoots` in `forkSubagent`; per-cwd cache field + `resolveMainRootForCwd`.

### Tradeoff (documented in the helper)
When the model uses a *main-repo* absolute path, the read now returns the main worktree's copy rather than the worktree's — which can differ if the worktree has uncommitted edits to that path. This is strictly better than the pre-fix hard error, and relative paths still resolve against `cwd` (the worktree). Rewriting main-repo paths to worktree equivalents was rejected as far more complex (not every main-repo path has a worktree twin — `.git`, sibling worktrees).

### Scope
Subagent-only (the reported, unfixable-by-prompt case). Top-level worktree sessions can still add the main repo via the interactive approval prompt / `/allow-dir`; broadening the parent's default roots touches several CLI entry points and the deferred-worktree `setCwd` flow, and is deliberately out of scope here.

## Tests
- `src/agent/worktree-read-root.test.ts` — 12 cases (linked worktree, main worktree relative/absolute `.git`, subdir in/out of worktree, external worktree, relative common-dir resolution, undefined/empty cwd, git failure, empty/partial output).
- `src/agent/subagent-worktree-readroot.test.ts` — 8 cases (grant from manager cwd + per-call cwd, no grant for non-worktree, caller-pinned readRoots preserved + resolver skipped, no write root, per-cwd caching, mainRoot==cwd defensive, no-cwd no-op).

## Gates
- `pnpm lint` (tsc --noEmit strict) — clean
- full suite — **10766 pass / 0 fail / 14 skip** (586 files)
- `pnpm audit:sdk:check` — OK (no new SDK imports)
- `pnpm audit:env:check` — 0 violations
- `pnpm scan:env:check` — in sync
