### PR TITLE
fix(skills): resolve project plugins against session cwd (#179 follow-up)

### DIFF
--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -781,12 +781,17 @@ export class AnthropicDirectProvider implements ModelProvider {
         ? baseToolDefs.filter((t) => t.name !== 'ask_question')
         : baseToolDefs;
 
+    const cwd = config.cwd || process.cwd();
+
     // Build skill manifest for system prompt injection. The manifest lists
     // available skills so the model knows what the `skill` tool can invoke.
     // Let collectSkillEntries() own the full scan (project + user + bundled).
-    const manifest = this.skillExecutor ? buildSkillManifest() : '';
-
-    const cwd = config.cwd || process.cwd();
+    // Pass the session cwd so project skills (<cwd>/.afk/skills/) resolve
+    // against the session's working directory, not the host process's —
+    // they diverge on long-lived hosts (daemon, Telegram bot).
+    const manifest = this.skillExecutor
+      ? buildSkillManifest(undefined, { cwd })
+      : '';
     // Invariant: SLASH_COMMAND_ROUTING_PROMPT is omitted for skill-dispatch
     // sub-agents. Those sessions receive a "Run the <name> skill" directive
     // with no <command-name> tag, so the routing instruction (which keys off

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -908,3 +908,111 @@ describe('scanAllPluginRoots', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression: project-scoped plugins must resolve against the session cwd,
+// not process.cwd(). Same bug class as the skills-cwd fix (#179 follow-up).
+// ---------------------------------------------------------------------------
+describe('scanAllPluginRoots — project plugin session-cwd resolution', () => {
+  let tmpAfkHome: string;
+  let cwdA: string;
+  let cwdB: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    _resetPluginScanCache();
+    vi.unstubAllEnvs();
+
+    tmpAfkHome = mkdtempSync('/tmp/plugin-roots-evict-afkhome-');
+    cwdA = mkdtempSync('/tmp/plugin-roots-evict-cwdA-');
+    cwdB = mkdtempSync('/tmp/plugin-roots-evict-cwdB-');
+    origCwd = process.cwd();
+
+    vi.stubEnv('AFK_HOME', tmpAfkHome);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    process.chdir(origCwd);
+    try { rmSync(tmpAfkHome, { recursive: true }); } catch { /* non-fatal */ }
+    try { rmSync(cwdA, { recursive: true }); } catch { /* non-fatal */ }
+    try { rmSync(cwdB, { recursive: true }); } catch { /* non-fatal */ }
+  });
+
+  function writePluginIn(baseDir: string, pluginName: string, _description: string): void {
+    const pluginDir = join(baseDir, '.afk', 'plugins', pluginName);
+    mkdirSync(join(pluginDir, '.claude-plugin'), { recursive: true });
+    writeFileSync(
+      join(pluginDir, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: pluginName, version: '0.0.0' }),
+    );
+  }
+
+  it('scanAllPluginRoots resolves project plugins against opts.cwd', () => {
+    writePluginIn(cwdA, 'proj-a-plugin', 'Plugin only in project A');
+
+    _resetPluginScanCache();
+    const rootsA = scanAllPluginRoots({ cwd: cwdA });
+    const pathsA = rootsA.map((r) => r.path);
+    expect(pathsA.some((p) => p.includes('proj-a-plugin'))).toBe(true);
+
+    _resetPluginScanCache();
+    const rootsB = scanAllPluginRoots({ cwd: cwdB });
+    const pathsB = rootsB.map((r) => r.path);
+    expect(pathsB.some((p) => p.includes('proj-a-plugin'))).toBe(false);
+  });
+});
+
+describe('discoverPluginSkillBodies — project plugin session-cwd resolution', () => {
+  let tmpAfkHome: string;
+  let cwdA: string;
+  let cwdB: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    _resetPluginScanCache();
+    vi.unstubAllEnvs();
+
+    tmpAfkHome = mkdtempSync('/tmp/plugin-bodies-evict-afkhome-');
+    cwdA = mkdtempSync('/tmp/plugin-bodies-evict-cwdA-');
+    cwdB = mkdtempSync('/tmp/plugin-bodies-evict-cwdB-');
+    origCwd = process.cwd();
+
+    vi.stubEnv('AFK_HOME', tmpAfkHome);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    process.chdir(origCwd);
+    try { rmSync(tmpAfkHome, { recursive: true }); } catch { /* non-fatal */ }
+    try { rmSync(cwdA, { recursive: true }); } catch { /* non-fatal */ }
+    try { rmSync(cwdB, { recursive: true }); } catch { /* non-fatal */ }
+  });
+
+  function writePluginSkillIn(baseDir: string, skillName: string, body: string): void {
+    const pluginDir = join(baseDir, '.afk', 'plugins', `${skillName}-plugin`);
+    const skillDir = join(pluginDir, 'skills', skillName);
+    mkdirSync(skillDir, { recursive: true });
+    mkdirSync(join(pluginDir, '.claude-plugin'), { recursive: true });
+    writeFileSync(
+      join(pluginDir, '.claude-plugin', 'plugin.json'),
+      JSON.stringify({ name: `${skillName}-plugin`, version: '0.0.0' }),
+    );
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---\nname: ${skillName}\ndescription: Plugin skill ${skillName}\n---\n${body}\n`,
+    );
+  }
+
+  it('discoverPluginSkillBodies forwards opts.cwd to project scan', () => {
+    writePluginSkillIn(cwdA, 'session-cwd-plugin-skill', 'Plugin skill body');
+
+    _resetPluginScanCache();
+    const bodiesWithoutCwd = discoverPluginSkillBodies();
+    expect(bodiesWithoutCwd.has('session-cwd-plugin-skill')).toBe(false);
+
+    _resetPluginScanCache();
+    const bodiesWithCwd = discoverPluginSkillBodies(undefined, { cwd: cwdA });
+    expect(bodiesWithCwd.has('session-cwd-plugin-skill')).toBe(true);
+  });
+});

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -823,6 +823,58 @@ describe('collectSkillEntries — project skill eviction on cwd change (#179)', 
     const manifestB = buildSkillManifest([]);
     expect(manifestB).not.toContain('stale-skill');
   });
+
+  // -------------------------------------------------------------------------
+  // Session-cwd resolution (daemon / Telegram): the host process never
+  // chdir()s — the session's configured cwd is passed explicitly instead.
+  // These cases exercise the opts.cwd path with process.cwd() held constant.
+  // -------------------------------------------------------------------------
+
+  it('resolves project skills against opts.cwd without process.chdir()', () => {
+    writeSkillIn(cwdA, 'proj-a-skill', 'Skill only in project A');
+    writeSkillIn(cwdB, 'proj-b-skill', 'Skill only in project B');
+
+    // Host process cwd stays wherever the test runner lives — never chdir.
+    const entriesA = collectSkillEntries([], { cwd: cwdA });
+    const namesA = entriesA.map((e) => e.name);
+    expect(namesA).toContain('proj-a-skill');
+    expect(namesA).not.toContain('proj-b-skill');
+
+    // A different session cwd in the same process — stale entries evicted.
+    const entriesB = collectSkillEntries([], { cwd: cwdB });
+    const namesB = entriesB.map((e) => e.name);
+    expect(namesB).toContain('proj-b-skill');
+    expect(namesB).not.toContain('proj-a-skill');
+  });
+
+  it('buildSkillManifest forwards opts.cwd to the project scan', () => {
+    writeSkillIn(cwdA, 'session-cwd-skill', 'Visible only via session cwd');
+
+    // Without the override the host cwd has no .afk/skills — skill absent.
+    expect(buildSkillManifest([])).not.toContain('session-cwd-skill');
+    // With the session cwd the same process sees the project skill.
+    expect(buildSkillManifest([], { cwd: cwdA })).toContain('session-cwd-skill');
+    // And a later no-override call evicts it again (no leak into other sessions).
+    expect(buildSkillManifest([])).not.toContain('session-cwd-skill');
+  });
+
+  it('evicts collision-fallback `project:<name>` entries on cwd change', () => {
+    // Same skill name in user scope and project A: user scope scans first and
+    // keeps the bare name, so the project entry registers as `project:<name>`.
+    writeUserSkillIn(tmpAfkHome, 'shared-name', 'User-scope variant');
+    writeSkillIn(cwdA, 'shared-name', 'Project-A variant');
+
+    const entriesA = collectSkillEntries([], { cwd: cwdA });
+    const namesA = entriesA.map((e) => e.name);
+    expect(namesA).toContain('shared-name');
+    expect(namesA).toContain('project:shared-name');
+
+    // Switching to project B must evict the namespaced fallback entry too.
+    const entriesB = collectSkillEntries([], { cwd: cwdB });
+    const namesB = entriesB.map((e) => e.name);
+    expect(namesB).toContain('shared-name');
+    expect(namesB).not.toContain('project:shared-name');
+  });
 });
 
 describe('scanAllPluginRoots', () => {

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -1014,5 +1014,16 @@ describe('discoverPluginSkillBodies — project plugin session-cwd resolution', 
     _resetPluginScanCache();
     const bodiesWithCwd = discoverPluginSkillBodies(undefined, { cwd: cwdA });
     expect(bodiesWithCwd.has('session-cwd-plugin-skill')).toBe(true);
+
+    // And switching to project B must not leak project A's plugin skill,
+    // while project B's own plugin skill becomes visible (cwd-A -> cwd-B
+    // switch — mirrors the scanAllPluginRoots eviction test above, which
+    // this test previously didn't exercise).
+    writePluginSkillIn(cwdB, 'other-cwd-plugin-skill', 'Plugin skill body B');
+
+    _resetPluginScanCache();
+    const bodiesWithCwdB = discoverPluginSkillBodies(undefined, { cwd: cwdB });
+    expect(bodiesWithCwdB.has('other-cwd-plugin-skill')).toBe(true);
+    expect(bodiesWithCwdB.has('session-cwd-plugin-skill')).toBe(false);
   });
 });

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -722,6 +722,109 @@ describe('collectSkillEntries — disk-scan regression (user + project skills)',
   });
 });
 
+// ---------------------------------------------------------------------------
+// Regression: #179 — project-origin skills must be evicted when cwd changes.
+//
+// Simulates a long-lived daemon serving project A, then project B: the project
+// scan in collectSkillEntries() must remove stale project-A entries before
+// registering project-B entries. User-origin and built-in skills must survive.
+// ---------------------------------------------------------------------------
+describe('collectSkillEntries — project skill eviction on cwd change (#179)', () => {
+  let tmpAfkHome: string;
+  let cwdA: string;
+  let cwdB: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    _resetRegistry();
+    vi.unstubAllEnvs();
+
+    tmpAfkHome = mkdtempSync('/tmp/skill-bridge-evict-afkhome-');
+    cwdA = mkdtempSync('/tmp/skill-bridge-evict-cwdA-');
+    cwdB = mkdtempSync('/tmp/skill-bridge-evict-cwdB-');
+    origCwd = process.cwd();
+
+    vi.stubEnv('AFK_HOME', tmpAfkHome);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    process.chdir(origCwd);
+    try { rmSync(tmpAfkHome, { recursive: true }); } catch { /* non-fatal */ }
+    try { rmSync(cwdA, { recursive: true }); } catch { /* non-fatal */ }
+    try { rmSync(cwdB, { recursive: true }); } catch { /* non-fatal */ }
+  });
+
+  function writeSkillIn(baseDir: string, name: string, description: string): void {
+    const dir = join(baseDir, '.afk', 'skills', name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'SKILL.md'),
+      `---\nname: ${name}\ndescription: ${description}\n---\n# Body\n`,
+    );
+  }
+
+  function writeUserSkillIn(afkHome: string, name: string, description: string): void {
+    const dir = join(afkHome, 'skills', name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'SKILL.md'),
+      `---\nname: ${name}\ndescription: ${description}\n---\n# Body\n`,
+    );
+  }
+
+  it('evicts project-A skills after switching to project B', () => {
+    writeSkillIn(cwdA, 'proj-a-skill', 'Skill only in project A');
+    writeSkillIn(cwdB, 'proj-b-skill', 'Skill only in project B');
+
+    // First call: cwd = project A
+    process.chdir(cwdA);
+    const entriesA = collectSkillEntries([]);
+    const namesA = entriesA.map((e) => e.name);
+    expect(namesA).toContain('proj-a-skill');
+    expect(namesA).not.toContain('proj-b-skill');
+
+    // Second call: cwd = project B — proj-a-skill must be gone
+    process.chdir(cwdB);
+    const entriesB = collectSkillEntries([]);
+    const namesB = entriesB.map((e) => e.name);
+    expect(namesB).toContain('proj-b-skill');
+    expect(namesB).not.toContain('proj-a-skill');
+  });
+
+  it('user-origin skills survive the cwd change', () => {
+    writeUserSkillIn(tmpAfkHome, 'global-user-skill', 'Always present');
+    writeSkillIn(cwdA, 'proj-a-only', 'Project A only');
+    writeSkillIn(cwdB, 'proj-b-only', 'Project B only');
+
+    // First call: cwd = project A
+    process.chdir(cwdA);
+    const entriesA = collectSkillEntries([]);
+    expect(entriesA.map((e) => e.name)).toContain('global-user-skill');
+
+    // Second call: cwd = project B — user skill must still be present
+    process.chdir(cwdB);
+    const entriesB = collectSkillEntries([]);
+    const namesB = entriesB.map((e) => e.name);
+    expect(namesB).toContain('global-user-skill');
+    expect(namesB).toContain('proj-b-only');
+    expect(namesB).not.toContain('proj-a-only');
+  });
+
+  it('evicted project entries are fully absent from the manifest', () => {
+    writeSkillIn(cwdA, 'stale-skill', 'Stale from project A');
+
+    process.chdir(cwdA);
+    const manifestA = buildSkillManifest([]);
+    expect(manifestA).toContain('stale-skill');
+
+    // Switch to project B (no skills)
+    process.chdir(cwdB);
+    const manifestB = buildSkillManifest([]);
+    expect(manifestB).not.toContain('stale-skill');
+  });
+});
+
 describe('scanAllPluginRoots', () => {
   it('returns well-formed local plugin configs', () => {
     _resetPluginScanCache();

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -61,8 +61,9 @@ export interface SkillManifestEntry {
  */
 export function buildSkillManifest(
   pluginConfigs?: SdkPluginConfig[],
+  opts?: CollectSkillEntriesOptions,
 ): string {
-  const entries = collectSkillEntries(pluginConfigs);
+  const entries = collectSkillEntries(pluginConfigs, opts);
   if (entries.length === 0) return '';
 
   const lines: string[] = [];
@@ -85,10 +86,28 @@ export function buildSkillManifest(
 }
 
 /**
+ * Options for {@link collectSkillEntries} / {@link buildSkillManifest}.
+ */
+export interface CollectSkillEntriesOptions {
+  /**
+   * Session working directory to resolve `<cwd>/.afk/skills/` against.
+   *
+   * Long-lived hosts (daemon, Telegram bot) run sessions whose configured
+   * cwd differs from the Node host's `process.cwd()` — and the host process
+   * never chdir()s, so without this override those sessions would resolve
+   * project skills against the directory the *process* was launched from,
+   * not the project the *session* is working in. Defaults to
+   * `process.cwd()` for standalone/REPL callers, where the two coincide.
+   */
+  cwd?: string;
+}
+
+/**
  * Collect all skill entries from registry + plugins.
  */
 export function collectSkillEntries(
   pluginConfigs?: SdkPluginConfig[],
+  opts?: CollectSkillEntriesOptions,
 ): SkillManifestEntry[] {
   const entries: SkillManifestEntry[] = [];
   const seen = new Set<string>();
@@ -119,16 +138,17 @@ export function collectSkillEntries(
   //    builtin (origin undefined) via the resolveSkillKey collision logic.
   scanSkillsFromDir(getSkillsDir(), 'user');
   // Invariant: evict stale project-origin skills before rescanning the
-  // project dir. In a long-lived process (daemon, Telegram bot) the cwd may
-  // have changed since the previous call, and any skills registered for the
-  // old cwd must not persist into the new project context. User-origin and
-  // built-in skills are deliberately excluded from eviction — they are
-  // cwd-agnostic and must survive across project boundaries. The eviction
-  // cost is O(registry size) and bounded by the number of registered skills
-  // (typically <100), so it is negligible relative to the disk scan that
-  // follows.
+  // project dir. The effective project scan root can change between calls —
+  // via process.chdir() (REPL worktree auto-naming) or via a different
+  // session cwd (daemon task, Telegram chat after /cd) — and any skills
+  // registered for the old root must not persist into the new project
+  // context. User-origin and built-in skills are deliberately excluded from
+  // eviction — they are cwd-agnostic and must survive across project
+  // boundaries. The eviction cost is O(registry size) and bounded by the
+  // number of registered skills (typically <100), so it is negligible
+  // relative to the disk scan that follows.
   evictSkillsByOrigin('project');
-  scanSkillsFromDir(getProjectSkillsDir(), 'project');
+  scanSkillsFromDir(getProjectSkillsDir(opts?.cwd), 'project');
   // Imported skills from trusted source binaries (Claude Code, Codex) opted
   // into via `importFrom`. Scanned AFTER native scopes so a native skill keeps
   // the bare name on collision; an imported same-name skill falls back to

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -14,7 +14,7 @@
 // Barrel import triggers self-registration side-effects for built-in skills.
 import '../../skills/all.js';
 
-import { listSkills, getSkill, registerSkill, isSkillVisible } from '../../skills/index.js';
+import { listSkills, getSkill, registerSkill, isSkillVisible, evictSkillsByOrigin } from '../../skills/index.js';
 import { loadSkillPrompts } from '../../skills/_lib/prompt-loader.js';
 import { scanSkillsFromDir } from '../../skills/user-skills.js';
 import { scanLocalPlugins } from '../plugins-scanner.js';
@@ -118,6 +118,16 @@ export function collectSkillEntries(
   //    `project:<name>`. Both lose the bare slot to an already-registered
   //    builtin (origin undefined) via the resolveSkillKey collision logic.
   scanSkillsFromDir(getSkillsDir(), 'user');
+  // Invariant: evict stale project-origin skills before rescanning the
+  // project dir. In a long-lived process (daemon, Telegram bot) the cwd may
+  // have changed since the previous call, and any skills registered for the
+  // old cwd must not persist into the new project context. User-origin and
+  // built-in skills are deliberately excluded from eviction — they are
+  // cwd-agnostic and must survive across project boundaries. The eviction
+  // cost is O(registry size) and bounded by the number of registered skills
+  // (typically <100), so it is negligible relative to the disk scan that
+  // follows.
+  evictSkillsByOrigin('project');
   scanSkillsFromDir(getProjectSkillsDir(), 'project');
   // Imported skills from trusted source binaries (Claude Code, Codex) opted
   // into via `importFrom`. Scanned AFTER native scopes so a native skill keeps

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -185,7 +185,7 @@ export function collectSkillEntries(
   //    Plugin frontmatter MAY carry `audience: internal` to opt into the
   //    same tier gate — extractPluginSkills() surfaces it as `audience`,
   //    defaulting to 'public' when absent.
-  const plugins = pluginConfigs ?? scanAllPluginRoots();
+  const plugins = pluginConfigs ?? scanAllPluginRoots(opts);
   for (const plugin of plugins) {
     if (plugin.type !== 'local') continue;
     const skills = extractPluginSkills(plugin.path);
@@ -250,6 +250,7 @@ export interface PluginSkillBody {
  */
 export function discoverPluginSkillBodies(
   pluginConfigs?: SdkPluginConfig[],
+  opts?: CollectSkillEntriesOptions,
 ): Map<string, PluginSkillBody> {
   // Invariant: no audience filter — dispatch is always available; only surfacing is gated.
   // Do NOT add isSkillVisible() here; see this comment before 'fixing' it.
@@ -257,7 +258,7 @@ export function discoverPluginSkillBodies(
   // Imported plugin roots are resolved inline in the fallback so the
   // loadImportFromConfig() + existsSync work only runs when no pluginConfigs
   // were supplied (a caller passing pluginConfigs skips it entirely).
-  const plugins = pluginConfigs ?? scanAllPluginRoots();
+  const plugins = pluginConfigs ?? scanAllPluginRoots(opts);
 
   for (const plugin of plugins) {
     if (plugin.type !== 'local') continue;
@@ -285,9 +286,9 @@ export function discoverPluginSkillBodies(
  * collection, plugin-body discovery, and boot-time entrypoint loading so the
  * three never drift apart.
  */
-export function scanAllPluginRoots(): SdkPluginConfig[] {
+export function scanAllPluginRoots(opts?: CollectSkillEntriesOptions): SdkPluginConfig[] {
   return [
-    ...scanLocalPlugins(getProjectPluginsDir()),
+    ...scanLocalPlugins(getProjectPluginsDir(opts?.cwd)),
     ...scanLocalPlugins(),
     ...scanLocalPlugins(getBundledPluginsDir()),
     ...resolveImportedRoots(loadImportFromConfig()).pluginRoots.flatMap((root) =>

--- a/src/agent/tools/skill-executor.test.ts
+++ b/src/agent/tools/skill-executor.test.ts
@@ -988,6 +988,48 @@ describe('SkillExecutor', () => {
     });
   });
 
+  describe('getPluginSkillBody — cwd cache invalidation (regression)', () => {
+    // Regression: PR #418 threaded cwd into the FIRST population of the
+    // lazy `pluginBodies` cache but did not invalidate it on setCwd(), so a
+    // plugin skill dispatched after a mid-session cwd change (REPL worktree
+    // auto-naming, `worktree-autoname.ts`) would keep returning a stale
+    // project-A plugin body even though the session has moved to project B.
+    it('setCwd() clears the cached pluginBodies map so the next lookup re-resolves under the new cwd', () => {
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'parent-cwd-invalidate',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        defaultModel: 'sonnet',
+        cwd: '/tmp/launch/dir',
+      });
+
+      // Simulate a prior plugin-skill dispatch that already populated the
+      // lazy cache (same cache-injection idiom used elsewhere in this file,
+      // e.g. the `pluginBodies` assignments in the fork-dispatch tests below)
+      // — bypasses the real disk scan so this stays a pure unit test of the
+      // invalidation contract itself.
+      (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies =
+        new Map([
+          [
+            'stale-plugin',
+            { body: 'stale body from project A', pluginPath: '/tmp/launch/dir/.afk/plugins/stale', context: 'load' },
+          ],
+        ]);
+
+      executor.setCwd('/tmp/launch/dir/.afk-worktrees/afk-xyz');
+
+      // Before the fix, setCwd() only reassigned `currentCwd` and left the
+      // stale Map in place, so a plugin skill dispatched post-cwd-change
+      // would keep resolving project A's body (or wrongly report the new
+      // project's own plugin skill as "not found").
+      expect(
+        (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies,
+      ).toBeNull();
+    });
+  });
+
   describe('resolveApiKeyForModel — per-model credential resolution (skill fork path)', () => {
     // Regression: "Anthropic child starves when parent is OpenAI-routed."
     // Same root cause as subagent-executor.test.ts's block — the skill-dispatch

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -351,8 +351,13 @@ export class SkillExecutor {
       );
     }
 
-    // 3. Not found — return available skills list.
-    const entries = collectSkillEntries(this.ctx.pluginConfigs);
+    // 3. Not found — return available skills list. Resolve project skills
+    // against the session cwd (worktree / daemon-task / Telegram-chat dir),
+    // not the host process cwd — mirrors the manifest build in the provider.
+    const entries = collectSkillEntries(
+      this.ctx.pluginConfigs,
+      this.currentCwd !== undefined ? { cwd: this.currentCwd } : undefined,
+    );
     const available = entries.map((e) => e.name).join(', ');
     return {
       content: `Skill "${parsed.name}" not found. Available skills: ${available || '(none)'}`,

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -247,9 +247,22 @@ export class SkillExecutor {
     this.currentCwd = ctx.cwd;
   }
 
-  /** Re-anchor the cwd used for skill-forked sub-agents after a cwd change. */
+  /**
+   * Re-anchor the cwd used for skill-forked sub-agents after a cwd change.
+   *
+   * Invariant: also drops the lazily-populated `pluginBodies` cache. That
+   * cache is keyed implicitly by whatever `currentCwd` was at first
+   * population (see `getPluginSkillBody()`); without clearing it here, a
+   * plugin skill dispatched after this cwd change would keep resolving the
+   * OLD cwd's plugin bodies (returning stale content for a same-named
+   * skill, or a false "not found" for a skill that only exists at the new
+   * cwd) even though `currentCwd` itself is correctly updated below. The
+   * next `getPluginSkillBody()` call re-populates via a fresh
+   * `discoverPluginSkillBodies()` scan against the new `currentCwd`.
+   */
   setCwd(cwd: string): void {
     this.currentCwd = cwd;
+    this.pluginBodies = null;
   }
 
   /**

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -1106,7 +1106,10 @@ export class SkillExecutor {
 
   private getPluginSkillBody(name: string): PluginSkillBody | undefined {
     if (!this.pluginBodies) {
-      this.pluginBodies = discoverPluginSkillBodies(this.ctx.pluginConfigs);
+      this.pluginBodies = discoverPluginSkillBodies(
+        this.ctx.pluginConfigs,
+        this.currentCwd !== undefined ? { cwd: this.currentCwd } : undefined,
+      );
     }
     return this.pluginBodies.get(name);
   }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -122,8 +122,8 @@ export function getProjectSkillsDir(cwd: string = process.cwd()): string {
   return join(getProjectAfkDir(cwd), 'skills');
 }
 
-export function getProjectPluginsDir(): string {
-  return join(getProjectAfkDir(), 'plugins');
+export function getProjectPluginsDir(cwd: string = process.cwd()): string {
+  return join(getProjectAfkDir(cwd), 'plugins');
 }
 
 /**

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -100,12 +100,26 @@ export function getPluginsDir(): string {
 // Project-scope paths (cwd-relative)
 // ---------------------------------------------------------------------------
 
-export function getProjectAfkDir(): string {
-  return join(process.cwd(), '.afk');
+/**
+ * Project-scoped `.afk/` root: `<cwd>/.afk`.
+ *
+ * Takes an explicit `cwd` because long-lived hosts (daemon, Telegram bot) and
+ * the REPL's worktree mode track a *session* working directory that diverges
+ * from the Node host's `process.cwd()` — project-scope artifacts must resolve
+ * against the session's cwd, not the host's. The default keeps parity with
+ * call sites that genuinely mean the host process cwd (mirrors
+ * `getProjectPlansDir` below).
+ */
+export function getProjectAfkDir(cwd: string = process.cwd()): string {
+  return join(cwd, '.afk');
 }
 
-export function getProjectSkillsDir(): string {
-  return join(getProjectAfkDir(), 'skills');
+/**
+ * Project-scoped skills directory: `<cwd>/.afk/skills/`.
+ * See {@link getProjectAfkDir} for why `cwd` is a parameter.
+ */
+export function getProjectSkillsDir(cwd: string = process.cwd()): string {
+  return join(getProjectAfkDir(cwd), 'skills');
 }
 
 export function getProjectPluginsDir(): string {

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -221,6 +221,32 @@ export function listVisibleSkills(internalUnlocked: boolean): string[] {
 }
 
 /**
+ * Evict all skills whose `origin` matches the given value.
+ *
+ * Used by `collectSkillEntries()` before each project scan so that skills
+ * registered for a previous cwd do not persist when the working directory
+ * changes in a long-lived process (daemon, Telegram bot). Only
+ * `'project'`-origin entries are evicted in production; the caller is
+ * responsible for passing the correct origin.
+ *
+ * User-origin (`~/.afk/skills/`) and built-in (undefined origin) skills are
+ * never passed here and therefore survive across cwd changes, which is the
+ * correct steady-state: global skills are cwd-agnostic.
+ *
+ * Returns the number of registry entries removed.
+ */
+export function evictSkillsByOrigin(origin: SkillMetadata['origin']): number {
+  let removed = 0;
+  for (const [key, meta] of registry) {
+    if (meta.origin === origin) {
+      registry.delete(key);
+      removed++;
+    }
+  }
+  return removed;
+}
+
+/**
  * Internal: reset registry for testing.
  * Marked with underscore to indicate test-only usage.
  */


### PR DESCRIPTION
## Summary

Follow-up to #375 that fixes the same bug class for **project-scoped plugins**.

PR #375 fixed project skills to resolve against the session `cwd` instead of `process.cwd()` for daemon/Telegram sessions. However, it left `getProjectPluginsDir()` unchanged — project-scoped plugins still resolved against `process.cwd()`.

## Changes

### `src/paths.ts`
- Added optional `cwd` parameter to `getProjectPluginsDir()` (mirrors `getProjectSkillsDir()`)

### `src/agent/tools/skill-bridge.ts`
- `scanAllPluginRoots()` now accepts optional `opts` and passes `opts.cwd` to `getProjectPluginsDir()`
- `collectSkillEntries()` forwards `opts` to `scanAllPluginRoots()` in step 3
- `discoverPluginSkillBodies()` accepts optional `opts` and forwards to `scanAllPluginRoots()`

### `src/agent/tools/skill-executor.ts`
- `getPluginSkillBody()` passes `this.currentCwd` to `discoverPluginSkillBodies()`

### Tests
- `scanAllPluginRoots` resolves project plugins against `opts.cwd`
- `discoverPluginSkillBodies` forwards `opts.cwd` to project scan

## Verification
- All 44 tests in `skill-bridge.test.ts` pass
- `tsc --noEmit` clean