### PR TITLE
feat(agents): plugin-contributed agent scope + scoped nested dispatch

### DIFF
--- a/src/agent/agents/builtins.ts
+++ b/src/agent/agents/builtins.ts
@@ -65,7 +65,19 @@ export function builtinAgents(): Map<string, RegisteredAgent> {
       definition: {
         description: researchAgent.description,
         prompt: vendoredPromptBody(researchAgent.systemPrompt),
-        tools: [...researchAgent.allowedTools],
+        // The scoped `Agent(git-investigator)` grant matches the vendored
+        // prompt's frontmatter intent (`tools: …, Agent(git-investigator)`)
+        // and lets research-agent nest a git-investigator when a finding needs
+        // git archaeology — the capability the prompt already instructs it to
+        // use. Added HERE (registry entry) rather than in the shared
+        // `researchAgent.allowedTools` const, because that const is also the
+        // read-only leaf surface diagnose (RESEARCH_READONLY_TOOLS) and
+        // audit-fit (inspectorTools) build their gates from — they must NOT
+        // gain a dispatch tool. resolve.ts captures the paren scope as
+        // `nestedAgentTypes`, and the subagent executor mechanically restricts
+        // research-agent to dispatching ONLY git-investigator (no bare/other
+        // dispatch), so the read-only contract can't be escalated.
+        tools: [...researchAgent.allowedTools, 'Agent(git-investigator)'],
       },
     },
     {

--- a/src/agent/agents/registry.test.ts
+++ b/src/agent/agents/registry.test.ts
@@ -156,4 +156,86 @@ describe('loadAgentRegistry', () => {
     // no read-failure warnings for absent dirs
     expect(warn).not.toHaveBeenCalledWith(expect.stringContaining('cannot read'));
   });
+
+  describe('pluginAgents scope', () => {
+    it('merges pluginAgents into the registry with their plugin source', () => {
+      const registry = loadAgentRegistry({
+        cwd: join(tmp, 'proj'),
+        warn: () => {},
+        pluginAgents: [
+          {
+            name: 'demo:helper',
+            source: 'plugin:demo',
+            definition: { description: 'd', prompt: 'p' },
+            filePath: '/x/agents/helper.md',
+          },
+        ],
+      });
+      expect(registry.get('demo:helper')?.source).toBe('plugin:demo');
+      expect(registry.get('demo:helper')?.filePath).toBe('/x/agents/helper.md');
+    });
+
+    it('namespaced plugin agents coexist with bare builtins (no shadow)', () => {
+      const registry = loadAgentRegistry({
+        cwd: join(tmp, 'proj'),
+        warn: () => {},
+        pluginAgents: [
+          {
+            name: 'demo:research-agent',
+            source: 'plugin:demo',
+            definition: { description: 'd', prompt: 'p' },
+          },
+        ],
+      });
+      expect(registry.get('research-agent')?.source).toBe('builtin');
+      expect(registry.get('demo:research-agent')?.source).toBe('plugin:demo');
+    });
+
+    it('plugin agents shadow builtins by name (plugin > builtin)', () => {
+      const registry = loadAgentRegistry({
+        cwd: join(tmp, 'proj'),
+        warn: () => {},
+        pluginAgents: [
+          {
+            name: 'research-agent',
+            source: 'plugin:x',
+            definition: { description: 'plugin override', prompt: 'p' },
+          },
+        ],
+      });
+      expect(registry.get('research-agent')?.source).toBe('plugin:x');
+    });
+
+    it('user scope shadows a plugin agent of the same name (user > plugin)', () => {
+      writeAgent(join(tmp, 'afk-home', 'agents'), 's.md', 'shared-name');
+      const registry = loadAgentRegistry({
+        cwd: join(tmp, 'proj'),
+        warn: () => {},
+        pluginAgents: [
+          {
+            name: 'shared-name',
+            source: 'plugin:x',
+            definition: { description: 'plugin', prompt: 'p' },
+          },
+        ],
+      });
+      expect(registry.get('shared-name')?.source).toBe('user');
+    });
+
+    it('config scope shadows a plugin agent of the same name (config > plugin)', () => {
+      const registry = loadAgentRegistry({
+        cwd: join(tmp, 'proj'),
+        warn: () => {},
+        pluginAgents: [
+          {
+            name: 'p:dupe',
+            source: 'plugin:p',
+            definition: { description: 'plugin', prompt: 'p' },
+          },
+        ],
+        configAgents: { 'p:dupe': { description: 'config', prompt: 'c' } },
+      });
+      expect(registry.get('p:dupe')?.source).toBe('config');
+    });
+  });
 });

--- a/src/agent/agents/registry.test.ts
+++ b/src/agent/agents/registry.test.ts
@@ -41,13 +41,17 @@ describe('loadAgentRegistry', () => {
     expect(registry.get('git-investigator')?.bashReadOnly).toBe(true);
     expect(registry.get('general-purpose')?.source).toBe('builtin');
     expect(registry.get('Explore')?.source).toBe('builtin');
-    // research-agent keeps its vendored tool contract
+    // research-agent keeps its vendored read-only contract PLUS the scoped
+    // git-investigator dispatch grant (matches the vendored prompt frontmatter;
+    // resolve.ts turns Agent(git-investigator) into nestedAgentTypes and the
+    // executor restricts research-agent to dispatching only git-investigator).
     expect(registry.get('research-agent')?.definition.tools).toEqual([
       'Read',
       'Grep',
       'Glob',
       'WebFetch',
       'WebSearch',
+      'Agent(git-investigator)',
     ]);
   });
 

--- a/src/agent/agents/registry.ts
+++ b/src/agent/agents/registry.ts
@@ -4,13 +4,19 @@
  * Scopes and precedence (ascending — later shadows earlier on the same name):
  *
  *   builtin                          (programmatic; see builtins.ts)
+ *   plugin   <plugin>/agents/        (installed plugins; namespaced <plugin>:<agent>)
  *   user     ~/.afk/agents/          (all projects on this machine)
  *   project  <cwd>/.claude/agents/   (Claude Code compat, read-only)
  *   project  <cwd>/.afk/agents/      (AFK-native project scope)
  *   config   AgentSessionConfig.agents (programmatic per-session injection)
  *
- * Plugin `agents/` directories are a planned scope (between builtin and
- * user); the plugin scanner does not surface them yet.
+ * Plugin agents are discovered by `discoverPluginAgents` (skill-bridge.ts) and
+ * passed in via {@link LoadAgentRegistryOptions.pluginAgents}; they merge just
+ * above the builtins. Because they are namespaced `<plugin>:<agent>` they never
+ * collide with a bare builtin name (e.g. the plugin agent
+ * `example-plugin:research-agent` coexists with the builtin `research-agent`),
+ * so bundled skills that dispatch bare `subagent_type: "research-agent"` keep
+ * resolving to the builtin.
  *
  * Directories are scanned recursively for `*.md` files. Identity comes from
  * the frontmatter `name` field, not the filename (Claude Code parity). A
@@ -52,6 +58,14 @@ export interface LoadAgentRegistryOptions {
    */
   configAgents?: Record<string, AgentDefinition>;
   /**
+   * Agents contributed by installed plugins, pre-scanned + namespaced
+   * `<plugin>:<agent>` by `discoverPluginAgents` (skill-bridge.ts). Merged just
+   * above the builtins (lowest file scope, Claude Code parity). Kept as a
+   * caller-supplied array — not scanned here — so this module stays free of the
+   * plugin-scanner import and the registry load stays a pure merge.
+   */
+  pluginAgents?: RegisteredAgent[];
+  /**
    * Diagnostic sink for scan warnings (malformed files, duplicate names,
    * unknown frontmatter). Defaults to stderr, matching the plugin skill
    * scanner's convention. Pass a no-op to silence.
@@ -59,8 +73,13 @@ export interface LoadAgentRegistryOptions {
   warn?: (message: string) => void;
 }
 
-/** Recursively collect `*.md` file paths under `dir`. Missing dir → []. */
-function collectMarkdownFiles(dir: string, depth = 0): string[] {
+/**
+ * Recursively collect `*.md` file paths under `dir`. Missing dir → []. Skips
+ * dotfiles/dirs, caps recursion at {@link MAX_SCAN_DEPTH}, returns sorted for
+ * deterministic same-scope ordering. Exported so the plugin-agent scanner
+ * (`discoverPluginAgents`) reuses the exact same traversal semantics.
+ */
+export function collectMarkdownFiles(dir: string, depth = 0): string[] {
   if (depth > MAX_SCAN_DEPTH) return [];
   let entries;
   try {
@@ -165,6 +184,15 @@ export function loadAgentRegistry(options: LoadAgentRegistryOptions = {}): Agent
   const warn = options.warn ?? ((message: string) => process.stderr.write(message + '\n'));
 
   const registry = new Map<string, RegisteredAgent>(builtinAgents());
+
+  // plugin scope (namespaced <plugin>:<agent>; between builtin and user).
+  // Pre-scanned + first-wins-deduped by discoverPluginAgents, so this is a
+  // straight merge: later user/project/config scopes still shadow by name.
+  if (options.pluginAgents !== undefined) {
+    for (const agent of options.pluginAgents) {
+      registry.set(agent.name, agent);
+    }
+  }
 
   // user scope
   scanScope(registry, join(getAfkHome(), 'agents'), 'user', warn);

--- a/src/agent/agents/resolve.test.ts
+++ b/src/agent/agents/resolve.test.ts
@@ -48,7 +48,7 @@ describe('resolveAgentToolAccess', () => {
     expect(resolved.allowedTools).toEqual(['agent', 'skill', 'read_file']);
   });
 
-  it('strips Agent(...) paren groups and ignores their fragments silently', () => {
+  it('maps Agent(...) to the agent tool and captures the paren scope', () => {
     const resolved = resolveAgentToolAccess(
       // parseToolsField comma-splits `Agent(worker, researcher)` into fragments
       agent({ tools: ['Agent(worker', 'researcher)', 'Read'] }),
@@ -56,6 +56,8 @@ describe('resolveAgentToolAccess', () => {
     );
     expect(resolved.allowedTools).toEqual(['agent', 'read_file']);
     expect(resolved.droppedTokens).toEqual([]); // fragments are not fail-closed noise
+    // The paren content is no longer ignored — it becomes the nested-dispatch scope.
+    expect(resolved.nestedAgentTypes).toEqual(['worker', 'researcher']);
   });
 
   it('drops unknown tokens fail-closed and reports them', () => {
@@ -109,5 +111,59 @@ describe('resolveAgentToolAccess', () => {
   it('carries bashReadOnly from the registration', () => {
     expect(resolveAgentToolAccess(agent({ bashReadOnly: true }), POOL).bashReadOnly).toBe(true);
     expect(resolveAgentToolAccess(agent({}), POOL).bashReadOnly).toBe(false);
+  });
+});
+
+describe('resolveAgentToolAccess — nested-dispatch scope', () => {
+  it('captures a single scoped Agent(x) grant as nestedAgentTypes', () => {
+    const resolved = resolveAgentToolAccess(
+      agent({ tools: ['Read', 'Grep', 'Agent(git-investigator)'] }),
+      POOL,
+    );
+    expect(resolved.allowedTools).toEqual(['read_file', 'grep', 'agent']);
+    expect(resolved.nestedAgentTypes).toEqual(['git-investigator']);
+  });
+
+  it('treats a bare Agent grant as unrestricted (nestedAgentTypes undefined)', () => {
+    const resolved = resolveAgentToolAccess(agent({ tools: ['Read', 'Agent'] }), POOL);
+    expect(resolved.allowedTools).toEqual(['read_file', 'agent']);
+    expect(resolved.nestedAgentTypes).toBeUndefined();
+  });
+
+  it('treats Task the same as Agent for scope capture', () => {
+    const resolved = resolveAgentToolAccess(agent({ tools: ['Task(worker)'] }), POOL);
+    expect(resolved.allowedTools).toEqual(['agent']);
+    expect(resolved.nestedAgentTypes).toEqual(['worker']);
+  });
+
+  it('lets the widest grant win: a bare token alongside a scoped one is unrestricted', () => {
+    const resolved = resolveAgentToolAccess(
+      agent({ tools: ['Agent', 'Task(only-this)'] }),
+      POOL,
+    );
+    expect(resolved.allowedTools).toEqual(['agent']);
+    expect(resolved.nestedAgentTypes).toBeUndefined();
+  });
+
+  it('leaves nestedAgentTypes undefined when no dispatch tool is granted', () => {
+    const resolved = resolveAgentToolAccess(agent({ tools: ['Read', 'Grep'] }), POOL);
+    expect(resolved.nestedAgentTypes).toBeUndefined();
+  });
+
+  it('drops the scope when the agent tool is denied out of the effective surface', () => {
+    // Scoped grant present, but disallowedTools removes `agent` — a scope on an
+    // agent that cannot dispatch is inert, so it is not surfaced.
+    const resolved = resolveAgentToolAccess(
+      agent({ tools: ['Read', 'Agent(git-investigator)'], disallowedTools: ['Agent'] }),
+      POOL,
+    );
+    expect(resolved.allowedTools).toEqual(['read_file']);
+    expect(resolved.nestedAgentTypes).toBeUndefined();
+  });
+
+  it('leaves nestedAgentTypes undefined for inherit-all (no tools field)', () => {
+    const resolved = resolveAgentToolAccess(agent({}), POOL);
+    expect(resolved.allowedTools).toBeUndefined();
+    expect(resolved.nestedAgentTypes).toBeUndefined();
   });
 });

--- a/src/agent/agents/resolve.test.ts
+++ b/src/agent/agents/resolve.test.ts
@@ -130,6 +130,43 @@ describe('resolveAgentToolAccess — nested-dispatch scope', () => {
     expect(resolved.nestedAgentTypes).toBeUndefined();
   });
 
+  it('treats an EMPTY paren group Agent() as deny-all (nestedAgentTypes [], not undefined)', () => {
+    // Regression guard (fail-open → fail-closed): `Agent()` grants the dispatch
+    // tool but names zero types. It MUST resolve to [] (deny-all), NOT undefined
+    // (unrestricted) — the opposite of a safe default. The distinction is what
+    // the executor gate keys on: [] rejects every nested dispatch.
+    const resolved = resolveAgentToolAccess(agent({ tools: ['Read', 'Agent()'] }), POOL);
+    expect(resolved.allowedTools).toEqual(['read_file', 'agent']);
+    expect(resolved.nestedAgentTypes).toEqual([]);
+    expect(resolved.nestedAgentTypes).not.toBeUndefined();
+  });
+
+  it('treats Task() (empty parens) as deny-all too', () => {
+    const resolved = resolveAgentToolAccess(agent({ tools: ['Task()'] }), POOL);
+    expect(resolved.allowedTools).toEqual(['agent']);
+    expect(resolved.nestedAgentTypes).toEqual([]);
+  });
+
+  it('treats a whitespace-only paren group Agent(   ) as deny-all', () => {
+    const resolved = resolveAgentToolAccess(agent({ tools: ['Agent(   )'] }), POOL);
+    expect(resolved.allowedTools).toEqual(['agent']);
+    expect(resolved.nestedAgentTypes).toEqual([]);
+  });
+
+  it('lets a bare token win over an empty paren group (unrestricted, not deny-all)', () => {
+    // Widest grant governs: bare `Agent` beats `Agent()` → undefined, not [].
+    const resolved = resolveAgentToolAccess(agent({ tools: ['Agent()', 'Agent'] }), POOL);
+    expect(resolved.allowedTools).toEqual(['agent']);
+    expect(resolved.nestedAgentTypes).toBeUndefined();
+  });
+
+  it('lets a scoped name win over an empty paren group (named, not deny-all)', () => {
+    // A real name anywhere makes the grant a named restriction, not deny-all.
+    const resolved = resolveAgentToolAccess(agent({ tools: ['Agent()', 'Agent(worker)'] }), POOL);
+    expect(resolved.allowedTools).toEqual(['agent']);
+    expect(resolved.nestedAgentTypes).toEqual(['worker']);
+  });
+
   it('treats Task the same as Agent for scope capture', () => {
     const resolved = resolveAgentToolAccess(agent({ tools: ['Task(worker)'] }), POOL);
     expect(resolved.allowedTools).toEqual(['agent']);

--- a/src/agent/agents/resolve.ts
+++ b/src/agent/agents/resolve.ts
@@ -20,7 +20,10 @@
  *   executor gates the child's `agent_type` against it, so AFK enforces the
  *   paren scope that Claude Code parses but silently ignores inside a subagent
  *   definition. A bare `Agent`/`Task` (no parens) grants unrestricted nesting
- *   (`nestedAgentTypes: undefined`).
+ *   (`nestedAgentTypes: undefined`); an EMPTY paren group `Agent()` is a
+ *   deny-all (`nestedAgentTypes: []`) — the dispatch tool is granted but zero
+ *   child types are permitted, so every nested dispatch is rejected
+ *   (fail-closed, the opposite of the bare-token default).
  * - `mcp__*` tokens pass through verbatim (forward-compat: child providers
  *   currently receive no MCP manager, so these grant nothing today).
  * - Unknown tokens are dropped fail-closed and reported in `droppedTokens`.
@@ -137,18 +140,28 @@ function splitTopLevel(joined: string): string[] {
 
 /**
  * Extract the nested-dispatch scope declared by `Agent(x, y)` / `Task(x)`
- * tokens in a raw tools list. Returns the permitted child agent-type names, or
- * `undefined` when nesting is unrestricted (a bare `Agent`/`Task` token) or
- * not requested (no dispatch token). Paren groups may arrive whole or split by
- * a naive comma tokenizer — rejoined via {@link splitTopLevel} before parsing.
+ * tokens in a raw tools list. Paren groups may arrive whole or split by a naive
+ * comma tokenizer — rejoined via {@link splitTopLevel} before parsing.
+ *
+ * Returns:
+ * - a NON-EMPTY list — the permitted child agent-type names (scoped grant).
+ * - `[]` (deny-all) — an EMPTY paren group with no bare token, e.g. `Agent()`:
+ *   the author opted into the dispatch tool but named zero permitted types, so
+ *   the executor gate must reject EVERY nested dispatch. Fail-CLOSED.
+ * - `undefined` — nesting is unrestricted (a bare `Agent`/`Task` token) or not
+ *   requested (no dispatch token at all).
  *
  * Semantics: a bare `Agent`/`Task` anywhere in the list wins as "unrestricted"
  * (returns undefined) even if a scoped group is also present — the widest grant
- * governs. Only scoped groups with no bare token produce a restriction.
+ * governs. A scoped group with ≥1 name produces a named restriction; an empty
+ * paren group with no bare token produces the deny-all `[]`. The `[]` vs
+ * `undefined` distinction is load-bearing: `[]` is a decision (dispatch
+ * nothing), `undefined` is the absence of a restriction (dispatch anything).
  */
 function extractNestedAgentScope(raw: readonly string[]): string[] | undefined {
   const tokens = splitTopLevel(raw.join(','));
   let sawBare = false;
+  let sawParenGroup = false;
   const scoped = new Set<string>();
   for (const token of tokens) {
     const t = token.trim();
@@ -160,6 +173,7 @@ function extractNestedAgentScope(raw: readonly string[]): string[] | undefined {
       sawBare = true;
       continue;
     }
+    sawParenGroup = true;
     const inner = t.slice(parenIdx + 1).replace(/\)\s*$/, '');
     for (const name of inner.split(',')) {
       const n = name.trim();
@@ -167,7 +181,13 @@ function extractNestedAgentScope(raw: readonly string[]): string[] | undefined {
     }
   }
   if (sawBare) return undefined; // widest grant wins: unrestricted nesting
-  return scoped.size > 0 ? [...scoped] : undefined;
+  if (scoped.size > 0) return [...scoped]; // restricted to the named types
+  // An empty paren group with no bare token (e.g. `Agent()`) is an explicit
+  // deny-all: dispatch tool granted, zero child types permitted. Return [] so
+  // the executor gate rejects every nested dispatch — fail-closed. Distinct
+  // from `undefined` below (no dispatch token → nesting simply not requested).
+  if (sawParenGroup) return [];
+  return undefined;
 }
 
 /**

--- a/src/agent/agents/resolve.ts
+++ b/src/agent/agents/resolve.ts
@@ -15,9 +15,12 @@
  *   declared pool), then `tools` resolves against the remainder. A tool in
  *   both lists is removed.
  * - `Task`/`Agent` map to AFK's `agent` tool (opt-in nesting; Claude Code
- *   v2.1.172+ allows nested spawns the same way). `Agent(worker, …)` paren
- *   groups are accepted and the paren content ignored — CC ignores it inside
- *   subagent definitions too.
+ *   v2.1.172+ allows nested spawns the same way). A SCOPED `Agent(worker, …)`
+ *   grant is additionally captured as `nestedAgentTypes` — the dispatch
+ *   executor gates the child's `agent_type` against it, so AFK enforces the
+ *   paren scope that Claude Code parses but silently ignores inside a subagent
+ *   definition. A bare `Agent`/`Task` (no parens) grants unrestricted nesting
+ *   (`nestedAgentTypes: undefined`).
  * - `mcp__*` tokens pass through verbatim (forward-compat: child providers
  *   currently receive no MCP manager, so these grant nothing today).
  * - Unknown tokens are dropped fail-closed and reported in `droppedTokens`.
@@ -105,6 +108,69 @@ function normalizeList(raw: readonly string[]): { names: string[]; dropped: stri
 }
 
 /**
+ * Split a comma-joined token string on TOP-LEVEL commas only (commas outside
+ * parentheses), so a paren group that a naive tokenizer split across fragments
+ * (`Agent(a, b)` → `['Agent(a', 'b)']`) is reconstructed as one token before
+ * scope extraction. Depth never goes negative on unbalanced input.
+ */
+function splitTopLevel(joined: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let cur = '';
+  for (const ch of joined) {
+    if (ch === '(') {
+      depth++;
+      cur += ch;
+    } else if (ch === ')') {
+      depth = Math.max(0, depth - 1);
+      cur += ch;
+    } else if (ch === ',' && depth === 0) {
+      out.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  if (cur.length > 0) out.push(cur);
+  return out;
+}
+
+/**
+ * Extract the nested-dispatch scope declared by `Agent(x, y)` / `Task(x)`
+ * tokens in a raw tools list. Returns the permitted child agent-type names, or
+ * `undefined` when nesting is unrestricted (a bare `Agent`/`Task` token) or
+ * not requested (no dispatch token). Paren groups may arrive whole or split by
+ * a naive comma tokenizer — rejoined via {@link splitTopLevel} before parsing.
+ *
+ * Semantics: a bare `Agent`/`Task` anywhere in the list wins as "unrestricted"
+ * (returns undefined) even if a scoped group is also present — the widest grant
+ * governs. Only scoped groups with no bare token produce a restriction.
+ */
+function extractNestedAgentScope(raw: readonly string[]): string[] | undefined {
+  const tokens = splitTopLevel(raw.join(','));
+  let sawBare = false;
+  const scoped = new Set<string>();
+  for (const token of tokens) {
+    const t = token.trim();
+    if (t.length === 0) continue;
+    const parenIdx = t.indexOf('(');
+    const base = (parenIdx === -1 ? t : t.slice(0, parenIdx)).trim().toLowerCase();
+    if (base !== 'agent' && base !== 'task') continue;
+    if (parenIdx === -1) {
+      sawBare = true;
+      continue;
+    }
+    const inner = t.slice(parenIdx + 1).replace(/\)\s*$/, '');
+    for (const name of inner.split(',')) {
+      const n = name.trim();
+      if (n.length > 0) scoped.add(n);
+    }
+  }
+  if (sawBare) return undefined; // widest grant wins: unrestricted nesting
+  return scoped.size > 0 ? [...scoped] : undefined;
+}
+
+/**
  * Resolve the effective tool access for a registered agent.
  *
  * @param agent The registered agent whose `tools`/`disallowedTools` to resolve.
@@ -142,5 +208,17 @@ export function resolveAgentToolAccess(
   const pool = allowed?.names ?? [...inheritPool];
   const effective = pool.filter((name) => !deniedSet.has(name));
 
-  return { allowedTools: effective, bashReadOnly, droppedTokens: dropped };
+  // Nested-dispatch scope: only meaningful when the `agent` tool survives into
+  // the effective surface (a scope on an agent that can't dispatch is inert).
+  const nested =
+    tools !== undefined && effective.includes('agent')
+      ? extractNestedAgentScope(tools)
+      : undefined;
+
+  return {
+    allowedTools: effective,
+    bashReadOnly,
+    droppedTokens: dropped,
+    ...(nested !== undefined ? { nestedAgentTypes: nested } : {}),
+  };
 }

--- a/src/agent/agents/types.ts
+++ b/src/agent/agents/types.ts
@@ -80,4 +80,15 @@ export interface ResolvedAgentToolAccess {
    * (e.g. `NotebookEdit`). Surfaced in warnings so authors see the gap.
    */
   droppedTokens: string[];
+  /**
+   * Child agent types this agent may dispatch via the `agent` tool, extracted
+   * from a scoped `Agent(x, y)` grant. `undefined` = unrestricted (bare
+   * `Agent`/`Task`) or no dispatch tool. A non-empty list is enforced by the
+   * subagent executor: the child rejects any `agent_type` outside it — and any
+   * bare/no-type dispatch — closing the escalation where a read-only agent,
+   * once granted `agent`, could spawn an unrestricted `general-purpose`
+   * grandchild (the grandchild inherits the parent CAGE, which is unrestricted
+   * at top level).
+   */
+  nestedAgentTypes?: string[];
 }

--- a/src/agent/agents/types.ts
+++ b/src/agent/agents/types.ts
@@ -82,9 +82,14 @@ export interface ResolvedAgentToolAccess {
   droppedTokens: string[];
   /**
    * Child agent types this agent may dispatch via the `agent` tool, extracted
-   * from a scoped `Agent(x, y)` grant. `undefined` = unrestricted (bare
-   * `Agent`/`Task`) or no dispatch tool. A non-empty list is enforced by the
-   * subagent executor: the child rejects any `agent_type` outside it — and any
+   * from a scoped `Agent(x, y)` grant. Three states:
+   * - a NON-EMPTY list — the child may dispatch only these named types.
+   * - `[]` (deny-all) — an empty paren group `Agent()`: dispatch tool granted,
+   *   zero types permitted, so EVERY nested dispatch is rejected (fail-closed).
+   * - `undefined` — unrestricted (bare `Agent`/`Task`) or no dispatch tool.
+   *
+   * Any non-`undefined` value (including `[]`) is enforced by the subagent
+   * executor: the child rejects any `agent_type` outside the list — and any
    * bare/no-type dispatch — closing the escalation where a read-only agent,
    * once granted `agent`, could spawn an unrestricted `general-purpose`
    * grandchild (the grandchild inherits the parent CAGE, which is unrestricted

--- a/src/agent/tools/skill-bridge.test.ts
+++ b/src/agent/tools/skill-bridge.test.ts
@@ -22,6 +22,7 @@ import {
   buildSkillManifest,
   collectSkillEntries,
   discoverPluginSkillBodies,
+  discoverPluginAgents,
   scanAllPluginRoots,
 } from './skill-bridge.js';
 import { registerSkill, _resetRegistry } from '../../skills/index.js';
@@ -562,6 +563,134 @@ describe('discoverPluginSkillBodies', () => {
     const entry = bodies.get('full-skill');
     expect(entry).toBeDefined();
     expect(entry?.allowedTools).toBeUndefined();
+  });
+});
+
+describe('discoverPluginAgents', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync('/tmp/plugin-agents-test-');
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true });
+    } catch {
+      // Non-fatal cleanup.
+    }
+  });
+
+  function writeManifest(pluginPath: string, name: string): void {
+    const dir = join(pluginPath, '.claude-plugin');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'plugin.json'), JSON.stringify({ name, version: '1.0.0' }));
+  }
+
+  function writeAgentFile(pluginPath: string, file: string, name: string, extra = ''): void {
+    const dir = join(pluginPath, 'agents');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, file),
+      `---\nname: ${name}\ndescription: A test agent\n${extra}---\nAgent body for ${name}.\n`,
+    );
+  }
+
+  it('namespaces discovered agents as <plugin>:<agent> with plugin source', () => {
+    const pluginA = join(tmpDir, 'plugin-a');
+    writeManifest(pluginA, 'demo');
+    writeAgentFile(pluginA, 'researcher.md', 'research-agent');
+
+    const agents = discoverPluginAgents([{ type: 'local', path: pluginA }]);
+    expect(agents).toHaveLength(1);
+    expect(agents[0]?.name).toBe('demo:research-agent');
+    expect(agents[0]?.source).toBe('plugin:demo');
+    expect(agents[0]?.definition.description).toBe('A test agent');
+    expect(agents[0]?.definition.prompt).toContain('Agent body for research-agent.');
+    expect(agents[0]?.filePath).toBe(join(pluginA, 'agents', 'researcher.md'));
+  });
+
+  it('takes identity from frontmatter name, not filename (CC parity)', () => {
+    const pluginA = join(tmpDir, 'plugin-a');
+    writeManifest(pluginA, 'demo');
+    writeAgentFile(pluginA, 'anything.md', 'git-investigator');
+    const agents = discoverPluginAgents([{ type: 'local', path: pluginA }]);
+    expect(agents[0]?.name).toBe('demo:git-investigator');
+  });
+
+  it('scans agents/ recursively (subfolders)', () => {
+    const pluginA = join(tmpDir, 'plugin-a');
+    writeManifest(pluginA, 'demo');
+    const sub = join(pluginA, 'agents', 'review');
+    mkdirSync(sub, { recursive: true });
+    writeFileSync(join(sub, 'sec.md'), '---\nname: security\ndescription: d\n---\nbody\n');
+    const agents = discoverPluginAgents([{ type: 'local', path: pluginA }]);
+    expect(agents.map((a) => a.name)).toContain('demo:security');
+  });
+
+  it('carries bash: read-only through as bashReadOnly', () => {
+    const pluginA = join(tmpDir, 'plugin-a');
+    writeManifest(pluginA, 'demo');
+    writeAgentFile(pluginA, 'git.md', 'git-investigator', 'tools: Bash, Read\nbash: read-only\n');
+    const agents = discoverPluginAgents([{ type: 'local', path: pluginA }]);
+    expect(agents[0]?.bashReadOnly).toBe(true);
+  });
+
+  it('first-wins on qualified-name collisions', () => {
+    const a = join(tmpDir, 'a');
+    const b = join(tmpDir, 'b');
+    writeManifest(a, 'dup');
+    writeManifest(b, 'dup');
+    writeAgentFile(a, 'x.md', 'shared');
+    writeAgentFile(b, 'x.md', 'shared');
+    const agents = discoverPluginAgents([
+      { type: 'local', path: a },
+      { type: 'local', path: b },
+    ]);
+    const shared = agents.filter((ag) => ag.name === 'dup:shared');
+    expect(shared).toHaveLength(1);
+    expect(shared[0]?.filePath).toBe(join(a, 'agents', 'x.md'));
+  });
+
+  it('supports agents-only plugins (no skills/ dir)', () => {
+    const pluginA = join(tmpDir, 'agents-only');
+    writeManifest(pluginA, 'agentsonly');
+    writeAgentFile(pluginA, 'a.md', 'solo');
+    const agents = discoverPluginAgents([{ type: 'local', path: pluginA }]);
+    expect(agents.map((a) => a.name)).toEqual(['agentsonly:solo']);
+  });
+
+  it('skips a plugin with no readable manifest name', () => {
+    const pluginA = join(tmpDir, 'no-manifest');
+    // No .claude-plugin/plugin.json written — its agents have no stable id.
+    writeAgentFile(pluginA, 'a.md', 'orphan');
+    const agents = discoverPluginAgents([{ type: 'local', path: pluginA }]);
+    expect(agents).toHaveLength(0);
+  });
+
+  it('skips malformed agent files without failing the scan', () => {
+    const pluginA = join(tmpDir, 'plugin-a');
+    writeManifest(pluginA, 'demo');
+    const dir = join(pluginA, 'agents');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'broken.md'), 'no frontmatter at all');
+    writeAgentFile(pluginA, 'ok.md', 'works');
+    const agents = discoverPluginAgents([{ type: 'local', path: pluginA }]);
+    expect(agents.map((a) => a.name)).toEqual(['demo:works']);
+  });
+
+  it('returns empty for a plugin with no agents/ dir', () => {
+    const pluginA = join(tmpDir, 'plugin-a');
+    writeManifest(pluginA, 'demo');
+    const agents = discoverPluginAgents([{ type: 'local', path: pluginA }]);
+    expect(agents).toHaveLength(0);
+  });
+
+  it('ignores non-local plugin configs', () => {
+    const agents = discoverPluginAgents([
+      { type: 'git', path: join(tmpDir, 'nope') } as never,
+    ]);
+    expect(agents).toHaveLength(0);
   });
 });
 

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -14,12 +14,19 @@
 // Barrel import triggers self-registration side-effects for built-in skills.
 import '../../skills/all.js';
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { listSkills, getSkill, registerSkill, isSkillVisible, evictSkillsByOrigin } from '../../skills/index.js';
 import { loadSkillPrompts } from '../../skills/_lib/prompt-loader.js';
 import { scanSkillsFromDir } from '../../skills/user-skills.js';
 import { scanLocalPlugins } from '../plugins-scanner.js';
 import { loadPluginEntrypoints } from '../plugins/load-entrypoints.js';
 import { extractPluginSkills } from '../plugins/tool-injector.js';
+import { readPluginManifest } from '../plugins/plugin-manifest.js';
+import { parseAgentMarkdown } from '../agents/parser.js';
+import { collectMarkdownFiles } from '../agents/registry.js';
+import type { RegisteredAgent } from '../agents/types.js';
 import { SubagentManager } from '../subagent.js';
 import { describeFailure } from '../subagent/result.js';
 import {
@@ -276,6 +283,61 @@ export function discoverPluginSkillBodies(
   }
 
   return bodies;
+}
+
+/**
+ * Discover plugin-contributed named agents for the agent registry.
+ *
+ * Scans each local plugin's `agents/` directory recursively for `*.md` files
+ * (Claude Code parity: plugins contribute agents via a bare convention
+ * directory — no manifest field required). Each agent is namespaced
+ * `<plugin>:<agent>` (plugin name from `<path>/.claude-plugin/plugin.json`,
+ * agent name from frontmatter), the same form skills use to address them
+ * (`subagent_type: "example-plugin:research-agent"`). Namespacing means a
+ * plugin agent named `research-agent` never shadows the builtin — the two
+ * coexist, and bundled skills' bare `research-agent` dispatches are unaffected.
+ *
+ * First-wins on a namespaced-name collision (mirrors {@link
+ * discoverPluginSkillBodies}). A plugin whose manifest has no readable `name`
+ * is skipped — its agents would have no stable qualified id to dispatch by.
+ * Cross-scope precedence (plugin < user < project < config) is applied by
+ * {@link import('../agents/registry.js').loadAgentRegistry}, which merges the
+ * returned list just above the builtins. Read/parse failures are contained
+ * per-file: one malformed agent never blocks the rest.
+ */
+export function discoverPluginAgents(
+  pluginConfigs?: SdkPluginConfig[],
+): RegisteredAgent[] {
+  const plugins = pluginConfigs ?? scanAllPluginRoots();
+  const agents: RegisteredAgent[] = [];
+  const seen = new Set<string>(); // qualified name → first wins
+  for (const plugin of plugins) {
+    if (plugin.type !== 'local') continue;
+    const pluginName = readPluginManifest(plugin.path).name;
+    if (pluginName === null) continue;
+    for (const filePath of collectMarkdownFiles(join(plugin.path, 'agents'))) {
+      let content: string;
+      try {
+        content = readFileSync(filePath, 'utf8');
+      } catch {
+        continue; // unreadable file — contained, skip
+      }
+      const parsed = parseAgentMarkdown(content);
+      if (parsed === undefined) continue; // malformed frontmatter — skip
+      const qualifiedName = `${pluginName}:${parsed.name}`;
+      if (seen.has(qualifiedName)) continue; // first plugin wins
+      seen.add(qualifiedName);
+      agents.push({
+        name: qualifiedName,
+        definition: parsed.definition,
+        source: `plugin:${pluginName}`,
+        filePath,
+        ...(parsed.bashReadOnly === true ? { bashReadOnly: true } : {}),
+        ...(parsed.ignoredKeys !== undefined ? { ignoredKeys: parsed.ignoredKeys } : {}),
+      });
+    }
+  }
+  return agents;
 }
 
 /**

--- a/src/agent/tools/subagent-executor.named-agents.test.ts
+++ b/src/agent/tools/subagent-executor.named-agents.test.ts
@@ -316,6 +316,27 @@ describe('SubagentExecutor named-agent dispatch', () => {
       expect(forkSubagent).not.toHaveBeenCalled();
     });
 
+    it('rejects EVERY dispatch under an empty deny-all allowlist ([] from Agent())', async () => {
+      // An `Agent()` grant resolves to nestedAgentTypes [] → nestedAgentAllowlist [].
+      // Presence (not length) gates, so even a registered, in-registry agent_type
+      // is rejected — the fail-closed default the medium finding fixed.
+      const executor = makeExecutor({ nestedAgentAllowlist: [] });
+      const result = await executor.execute(
+        makeCall({ prompt: 'go', agent_type: 'research-agent' }),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('not permitted to dispatch any nested agents');
+      expect(forkSubagent).not.toHaveBeenCalled();
+    });
+
+    it('rejects a bare dispatch under an empty deny-all allowlist', async () => {
+      const executor = makeExecutor({ nestedAgentAllowlist: [] });
+      const result = await executor.execute(makeCall({ prompt: 'go' }));
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('not permitted to dispatch any nested agents');
+      expect(forkSubagent).not.toHaveBeenCalled();
+    });
+
     it('does not restrict dispatch when no allowlist is set (top-level executor)', async () => {
       const executor = makeExecutor();
       const result = await executor.execute(

--- a/src/agent/tools/subagent-executor.named-agents.test.ts
+++ b/src/agent/tools/subagent-executor.named-agents.test.ts
@@ -89,6 +89,19 @@ const INHERIT_AGENT: RegisteredAgent = {
   },
 };
 
+// Mirrors the real builtin research-agent's scoped nesting grant
+// (`Agent(git-investigator)`): read-only leaf tools PLUS a single scoped
+// dispatch. Used to exercise the nested-dispatch scope gate end-to-end.
+const RESEARCH_NESTER: RegisteredAgent = {
+  name: 'research-nester',
+  source: 'builtin',
+  definition: {
+    description: 'research that may nest git-investigator',
+    prompt: 'You may dispatch git-investigator.',
+    tools: ['Read', 'Grep', 'Glob', 'Agent(git-investigator)'],
+  },
+};
+
 describe('SubagentExecutor named-agent dispatch', () => {
   let forkSubagent: ReturnType<typeof vi.fn>;
   let factoryCalls: Array<Record<string, unknown>>;
@@ -270,6 +283,74 @@ describe('SubagentExecutor named-agent dispatch', () => {
     expect(forkArgs.config.systemPrompt).toBe('BASE PROMPT');
     expect(factoryCalls[0]?.['allowedTools']).toBeUndefined();
     expect(forkArgs.agentType).toBe('plain dispatch');
+  });
+
+  describe('nested-dispatch scope gate', () => {
+    it('allows an in-scope agent_type dispatch', async () => {
+      const executor = makeExecutor({ nestedAgentAllowlist: ['git-investigator'] });
+      const result = await executor.execute(
+        makeCall({ prompt: 'go', agent_type: 'git-investigator' }),
+      );
+      expect(result.isError).toBeFalsy();
+      expect(forkSubagent).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects an out-of-scope agent_type without forking', async () => {
+      const executor = makeExecutor({ nestedAgentAllowlist: ['git-investigator'] });
+      // research-agent IS in the registry (resolves fine) but is out of scope.
+      const result = await executor.execute(
+        makeCall({ prompt: 'go', agent_type: 'research-agent' }),
+      );
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('may only dispatch');
+      expect(result.content).toContain('git-investigator');
+      expect(result.content).toContain('out of scope');
+      expect(forkSubagent).not.toHaveBeenCalled();
+    });
+
+    it('rejects a bare dispatch (no agent_type) without forking', async () => {
+      const executor = makeExecutor({ nestedAgentAllowlist: ['git-investigator'] });
+      const result = await executor.execute(makeCall({ prompt: 'go' }));
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('bare dispatch');
+      expect(forkSubagent).not.toHaveBeenCalled();
+    });
+
+    it('does not restrict dispatch when no allowlist is set (top-level executor)', async () => {
+      const executor = makeExecutor();
+      const result = await executor.execute(
+        makeCall({ prompt: 'go', agent_type: 'research-agent' }),
+      );
+      expect(result.isError).toBeFalsy();
+      expect(forkSubagent).toHaveBeenCalledTimes(1);
+    });
+
+    it('grants the agent tool to a scoped agent (research-nester can dispatch)', async () => {
+      const executor = makeExecutor({
+        agentRegistry: makeRegistry([RESEARCH_NESTER, GIT]),
+      });
+      await executor.execute(makeCall({ prompt: 'go', agent_type: 'research-nester' }));
+      // The dispatch grant reaches the child provider — `agent` is present.
+      expect(factoryCalls[0]?.['allowedTools']).toEqual(['read_file', 'grep', 'glob', 'agent']);
+    });
+
+    it('threads the scope into the dispatched agent\'s own executor (end-to-end)', async () => {
+      const executor = makeExecutor({
+        agentRegistry: makeRegistry([RESEARCH_NESTER, GIT]),
+      });
+      await executor.execute(makeCall({ prompt: 'go', agent_type: 'research-nester' }));
+      // The child provider factory received research-nester's OWN executor.
+      const childExecutor = factoryCalls[0]?.['childExecutor'] as SubagentExecutor | undefined;
+      expect(childExecutor).toBeDefined();
+      // When research-nester attempts a BARE dispatch, its threaded scope gates
+      // it — proving the escalation path (unrestricted grandchild) is closed.
+      // The gate returns before any real fork, so this is safe against the
+      // child's real (non-mocked) SubagentManager.
+      const nested = await childExecutor!.execute(makeCall({ prompt: 'escalate' }));
+      expect(nested.isError).toBe(true);
+      expect(nested.content).toContain('may only dispatch');
+      expect(nested.content).toContain('git-investigator');
+    });
   });
 
   describe('describeAgentTool', () => {

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -154,6 +154,24 @@ export interface SubagentExecutorContext {
    */
   readOnlyBash?: boolean;
   /**
+   * Nested-dispatch allowlist for the agent that OWNS this executor. Set when
+   * the dispatching agent declared a scoped `Agent(x)` grant (e.g.
+   * research-agent's `Agent(git-investigator)`, surfaced by resolve.ts as
+   * `nestedAgentTypes`). When present, {@link SubagentExecutor.execute} rejects
+   * any `agent_type` not in the list — and any bare/no-type dispatch — before a
+   * fork happens. `undefined` = no restriction (top-level executors, or an
+   * inherit-all / bare-`Agent` agent).
+   *
+   * Why this is the safety boundary: a dispatched child's own grandchild
+   * executor inherits the parent CAGE ({@link allowedTools}), NOT the child's
+   * definition (see the childExecutor wiring below). At top level that cage is
+   * unrestricted, so a read-only agent granted the `agent` tool could otherwise
+   * spawn an unrestricted `general-purpose` (or bare) grandchild with full
+   * bash/write. This allowlist scopes the child to exactly the leaf agents its
+   * definition named — each of which is self-caged by its own definition.
+   */
+  nestedAgentAllowlist?: readonly string[];
+  /**
    * Session-wide named-agent registry (see `agent/agents/`). When present,
    * the `agent` tool accepts an `agent_type` (alias `subagent_type`) input
    * that dispatches the named definition: its body becomes the child's
@@ -658,6 +676,30 @@ export class SubagentExecutor implements SubagentControl {
       }
     }
 
+    // Nested-dispatch scope gate. When THIS executor belongs to an agent that
+    // declared a scoped `Agent(x)` grant (e.g. research-agent's
+    // `Agent(git-investigator)`), it may dispatch ONLY those agent types.
+    // Reject any out-of-scope type AND any bare/no-type dispatch (which would
+    // otherwise fork an unrestricted general-purpose grandchild inheriting the
+    // parent's unrestricted cage — the escalation this gate closes). Top-level
+    // executors and inherit-all/bare-`Agent` agents leave the allowlist unset,
+    // so their dispatch is unchanged.
+    const nestedScope = this.ctx.nestedAgentAllowlist;
+    if (nestedScope !== undefined) {
+      const requested = parsed.agent_type;
+      if (requested === undefined || !nestedScope.includes(requested)) {
+        return {
+          content:
+            `This agent may only dispatch the following agent type(s): ${nestedScope.join(', ')}. ` +
+            (requested === undefined
+              ? 'A bare dispatch with no agent_type is not permitted here — ' +
+                'set agent_type to one of the allowed types, or complete the task with your own tools.'
+              : `agent_type "${requested}" is out of scope.`),
+          isError: true,
+        };
+      }
+    }
+
     // Build child config.
     //
     // Invariant: `ctx.depth` is required (see SubagentExecutorContext.depth
@@ -845,6 +887,14 @@ export class SubagentExecutor implements SubagentControl {
         // Named-agent registry + the child's model (for grandchild `inherit`
         // resolution) thread through every depth.
         ...(this.ctx.agentRegistry !== undefined ? { agentRegistry: this.ctx.agentRegistry } : {}),
+        // Scope the dispatched agent's OWN nested dispatches to the leaf types
+        // its definition named (resolve.ts `nestedAgentTypes`). This is what
+        // lets research-agent dispatch git-investigator and NOTHING else — the
+        // gate at execute() top reads this from its ctx. Unset ⇒ unrestricted
+        // (top-level, inherit-all, or bare-`Agent` agents).
+        ...(resolvedAccess?.nestedAgentTypes !== undefined
+          ? { nestedAgentAllowlist: resolvedAccess.nestedAgentTypes }
+          : {}),
         parentModel: childModel,
       });
       const childSkillExecutor = this.ctx.childSkillExecutorFactory

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -159,7 +159,9 @@ export interface SubagentExecutorContext {
    * research-agent's `Agent(git-investigator)`, surfaced by resolve.ts as
    * `nestedAgentTypes`). When present, {@link SubagentExecutor.execute} rejects
    * any `agent_type` not in the list — and any bare/no-type dispatch — before a
-   * fork happens. `undefined` = no restriction (top-level executors, or an
+   * fork happens. An EMPTY array `[]` is a deny-all (from an `Agent()` grant):
+   * the check is on presence, not length, so `[]` matches nothing and rejects
+   * every dispatch. `undefined` = no restriction (top-level executors, or an
    * inherit-all / bare-`Agent` agent).
    *
    * Why this is the safety boundary: a dispatched child's own grandchild
@@ -681,20 +683,26 @@ export class SubagentExecutor implements SubagentControl {
     // `Agent(git-investigator)`), it may dispatch ONLY those agent types.
     // Reject any out-of-scope type AND any bare/no-type dispatch (which would
     // otherwise fork an unrestricted general-purpose grandchild inheriting the
-    // parent's unrestricted cage — the escalation this gate closes). Top-level
-    // executors and inherit-all/bare-`Agent` agents leave the allowlist unset,
-    // so their dispatch is unchanged.
+    // parent's unrestricted cage — the escalation this gate closes). An empty
+    // allowlist (`[]`, from an `Agent()` deny-all grant) matches nothing and so
+    // rejects every dispatch. Top-level executors and inherit-all/bare-`Agent`
+    // agents leave the allowlist unset (`undefined`), so their dispatch is
+    // unchanged. The guard is on presence, not length — see nestedAgentAllowlist.
     const nestedScope = this.ctx.nestedAgentAllowlist;
     if (nestedScope !== undefined) {
       const requested = parsed.agent_type;
       if (requested === undefined || !nestedScope.includes(requested)) {
         return {
           content:
-            `This agent may only dispatch the following agent type(s): ${nestedScope.join(', ')}. ` +
-            (requested === undefined
-              ? 'A bare dispatch with no agent_type is not permitted here — ' +
-                'set agent_type to one of the allowed types, or complete the task with your own tools.'
-              : `agent_type "${requested}" is out of scope.`),
+            nestedScope.length === 0
+              ? 'This agent is not permitted to dispatch any nested agents ' +
+                '(its definition granted the dispatch tool but named zero allowed ' +
+                'types, e.g. `Agent()`). Complete the task with your own tools.'
+              : `This agent may only dispatch the following agent type(s): ${nestedScope.join(', ')}. ` +
+                (requested === undefined
+                  ? 'A bare dispatch with no agent_type is not permitted here — ' +
+                    'set agent_type to one of the allowed types, or complete the task with your own tools.'
+                  : `agent_type "${requested}" is out of scope.`),
           isError: true,
         };
       }

--- a/src/cli/commands/chat.mcp.test.ts
+++ b/src/cli/commands/chat.mcp.test.ts
@@ -105,6 +105,7 @@ vi.mock('../../agent/tools/compose-executor.js', () => ({
 // filesystem for plugin roots, which is out of scope here.
 vi.mock('../../agent/tools/skill-bridge.js', () => ({
   ensurePluginEntrypointsLoaded: vi.fn(async () => {}),
+  discoverPluginAgents: vi.fn(() => []),
 }));
 
 vi.mock('../../agent/tools/nesting.js', () => ({

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -22,7 +22,7 @@ import { SubagentManager } from '../../agent/subagent.js';
 import { SubagentExecutor } from '../../agent/tools/subagent-executor.js';
 import { SkillExecutor } from '../../agent/tools/skill-executor.js';
 import { ComposeExecutor } from '../../agent/tools/compose-executor.js';
-import { ensurePluginEntrypointsLoaded } from '../../agent/tools/skill-bridge.js';
+import { ensurePluginEntrypointsLoaded, discoverPluginAgents } from '../../agent/tools/skill-bridge.js';
 import { createChildProviderFactory, createChildSkillExecutorFactory } from '../../agent/tools/nesting.js';
 import { loadAgentRegistry } from '../../agent/agents/index.js';
 import { AnthropicDirectProvider } from '../../agent/providers/anthropic-direct/index.js';
@@ -482,6 +482,7 @@ export function registerChatCommand(program: Command): void {
         // `agent_type` dispatch on the `agent` tool at every depth.
         const agentRegistry = loadAgentRegistry({
           ...(worktreeCwd !== undefined ? { cwd: worktreeCwd } : {}),
+          pluginAgents: discoverPluginAgents(),
         });
 
         const childSkillExecutorFactory = createChildSkillExecutorFactory(

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -29,7 +29,7 @@ import { SubagentManager } from '../../agent/subagent.js';
 import { SubagentExecutor } from '../../agent/tools/subagent-executor.js';
 import { SkillExecutor } from '../../agent/tools/skill-executor.js';
 import { ComposeExecutor } from '../../agent/tools/compose-executor.js';
-import { ensurePluginEntrypointsLoaded } from '../../agent/tools/skill-bridge.js';
+import { ensurePluginEntrypointsLoaded, discoverPluginAgents } from '../../agent/tools/skill-bridge.js';
 import { createChildProviderFactory, createChildSkillExecutorFactory, createStubParentSession } from '../../agent/tools/nesting.js';
 import { loadAgentRegistry } from '../../agent/agents/index.js';
 import { AnthropicDirectProvider } from '../../agent/providers/anthropic-direct/index.js';
@@ -106,6 +106,7 @@ export function buildDaemonSessionFactory(
     // dispatch for daemon-run tasks (builtin + user + project scopes).
     const agentRegistry = loadAgentRegistry({
       ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+      pluginAgents: discoverPluginAgents(),
     });
 
     const childSkillExecutorFactory = createChildSkillExecutorFactory(

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -52,7 +52,7 @@ import { AnthropicDirectProvider } from '../../../agent/providers/anthropic-dire
 import { seedPersistedGrants } from '../../../agent/permissions-store.js';
 import { providerForModel } from '../../../agent/providers/index.js';
 import { createMemoizedProviderFactory } from './provider-factory.js';
-import { ensurePluginEntrypointsLoaded } from '../../../agent/tools/skill-bridge.js';
+import { ensurePluginEntrypointsLoaded, discoverPluginAgents } from '../../../agent/tools/skill-bridge.js';
 import { McpManager, loadMcpConfig, getMcpConfigPath } from '../../../agent/mcp/index.js';
 import { loadImportFromConfig, resolveImportedRoots } from '../../../config/import-sources.js';
 import { env } from '../../../config/env.js';
@@ -283,6 +283,7 @@ export async function bootstrapSession(
   // on the `agent` tool at every depth of this REPL session.
   const agentRegistry = loadAgentRegistry({
     ...(extras?.cwd !== undefined ? { cwd: extras.cwd } : {}),
+    pluginAgents: discoverPluginAgents(),
   });
 
   const childSkillExecutorFactory = createChildSkillExecutorFactory(

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -54,6 +54,7 @@ import { SkillExecutor } from './agent/tools/skill-executor.js';
 import { ComposeExecutor } from './agent/tools/compose-executor.js';
 import { createChildProviderFactory, createChildSkillExecutorFactory } from './agent/tools/nesting.js';
 import { loadAgentRegistry } from './agent/agents/index.js';
+import { discoverPluginAgents } from './agent/tools/skill-bridge.js';
 import { attachMcpCleanup, loadTelegramMcpManager } from './telegram/mcp-session.js';
 
 // Capture version once at module load. Used by checkVersionDrift on each stats tick.
@@ -271,6 +272,7 @@ async function main() {
         // dispatch (builtin + user + project scopes, anchored at the bot cwd).
         const agentRegistry = loadAgentRegistry({
           ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
+          pluginAgents: discoverPluginAgents(),
         });
 
         // Shared child-skill-executor factory — both SubagentExecutor and


### PR DESCRIPTION
## Summary

Two related changes to the named-agent registry, in separate commits.

### 1. Scope research-agent's git-investigator nesting via a mechanical dispatch gate (`332f74c`)

Fixes the phantom-tool bug visible in `/review`, `/shadow-verify`, `/devils-advocate`, `/research`, `/ship`, `/refactor`: the vendored research-agent prompt instructs it to dispatch `git-investigator` "via the Agent tool", but the builtin registry entry withheld any dispatch tool (its allowlist is read-only), and the dispatcher filters the advertised schema to the allowlist. With no real tool to anchor on, the model guessed the name (`Task`/`agent`/`invoke_agent`/`invoke_subagent`) and every guess was permission-denied — surfacing as red errors and wasted rounds.

- `resolve.ts` now **captures** the `Agent(x)` paren scope (previously discarded) as `ResolvedAgentToolAccess.nestedAgentTypes`. Bare `Agent`/`Task` = unrestricted; widest grant wins.
- `builtins.ts` adds `Agent(git-investigator)` to the research-agent **registry entry only** — not the shared `researchAgent.allowedTools` const, which `diagnose` (`RESEARCH_READONLY_TOOLS`) and `audit-fit` (inspector tools) consume as a read-only leaf surface and must not gain a dispatch tool.
- `subagent-executor.ts` adds a **nested-dispatch scope gate**: an executor owned by a scoped agent may dispatch only its named types, rejecting out-of-scope **and** bare/no-type dispatch before any fork. This closes the escalation where a read-only agent, once granted `agent`, could spawn an unrestricted `general-purpose` grandchild (grandchildren inherit the parent cage, which is unrestricted at top level).

`diagnose`, `vendored.test.ts`, and `audit-fit` are unaffected (const untouched).

### 2. Load plugin-contributed agents into the named-agent registry (`cb5d657`)

Implements the `plugin:<name>` agent scope that was declared-but-unwired (`registry.ts`/`types.ts` reserved it; the scanner never surfaced it). Claude Code parity: a plugin contributes agents via a bare `agents/*.md` convention directory — no manifest field, exactly like skills.

- `skill-bridge.ts`: new `discoverPluginAgents(configs?)`, sibling of `discoverPluginSkillBodies`. Scans each local plugin's `agents/` dir recursively (reusing `collectMarkdownFiles` + `parseAgentMarkdown`), reads the plugin name from `.claude-plugin/plugin.json`, and returns `RegisteredAgent[]` namespaced `<plugin>:<agent>`, first-wins.
- `registry.ts`: `LoadAgentRegistryOptions.pluginAgents` merges just above the builtins (`plugin < user < project < config`). Kept a pure merge so the registry stays free of the scanner import.
- Wired at all 4 surfaces: bootstrap (REPL), chat, daemon, telegram.

Namespacing is the safety property: a plugin agent named `research-agent` registers as `<plugin>:research-agent` and never shadows the builtin, so bundled skills dispatching bare `subagent_type: "research-agent"` are unaffected. **Purely additive** — a user with no marketplace installed gets an empty list and zero behavior change.

## Test plan

- New: `discoverPluginAgents` suite (12), `resolveAgentToolAccess` nested-scope suite (7), executor scope-gate suite (6, incl. end-to-end scope threading), registry `pluginAgents` precedence suite (5); updated paren/registry tests + `chat.mcp` mock.
- Full suite: **590 files, 10821 pass / 0 fail / 14 skip**.
- `pnpm lint`, `pnpm build`, `audit:sdk:check`, `audit:env:check`, `scan:env:check` all green.
