### PR TITLE
fix(hooks): scope the bash interpreter-eval guard to credential-adjacent payloads

### DIFF
--- a/src/agent/tools/hooks/bash-restriction-hook.test.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.test.ts
@@ -1,13 +1,18 @@
 /**
  * Tests for `createBashRestrictionHook` — pre-tool-use gate that hard-blocks
- * bash invocations referencing restricted paths or evaluating interpreter
- * code.
+ * bash invocations referencing restricted paths, plus interpreter `-c`/`-e`
+ * one-liners whose payload references those same sensitive paths.
  *
  * Threat-model invariant pinned by these tests:
  *   - Substring match catches the cat /restricted/path case we observed.
- *   - The interpreter denylist catches python -c, node -e, ruby -e, sh -c.
- *   - Variable-assembled bypasses are EXPLICITLY out of scope — see
- *     `bash-restriction-hook.ts` module header. The "documented bypass"
+ *   - The interpreter guard is SCOPED to credential-adjacent payloads: it
+ *     catches `python -c`/`node -e`/`sh -c` one-liners that reference a
+ *     sensitive path (`.ssh`, `id_rsa`, `.aws`, `/etc/shadow`, or a
+ *     home path assembled at runtime), but NOT pure-computation one-liners
+ *     (`python -c "1+1"`) — those touch no secret, so blocking them was pure
+ *     friction. See the module-header History note.
+ *   - Variable-assembled / string-split bypasses are EXPLICITLY out of scope —
+ *     see `bash-restriction-hook.ts` module header. The "documented bypass"
  *     test pins that behavior.
  */
 
@@ -32,41 +37,67 @@ function ctx(command: unknown): PreToolUseContext {
   return { event: 'PreToolUse', toolName: 'bash', input: { command } };
 }
 
-describe('createBashRestrictionHook — interpreter denylist', () => {
+describe('createBashRestrictionHook — interpreter denylist (scoped to credential-adjacent payloads)', () => {
   const hook = createBashRestrictionHook({ getGrantManager: mockGrants });
 
-  it('blocks python -c', () => {
-    const decision = hook(ctx('python -c "import os; print(os.uname())"'));
+  // --- BLOCKS: interpreter one-liners that reference a sensitive path ---
+
+  it('blocks python -c that reads an SSH key', () => {
+    const decision = hook(ctx('python -c "print(open(\'~/.ssh/id_rsa\').read())"'));
     expect(decision.decision).toBe('block');
     expect(decision.reason).toContain('Interpreter');
   });
 
-  it('blocks python3 -c', () => {
-    expect(hook(ctx('python3 -c "1+1"')).decision).toBe('block');
+  it('blocks node -e that references cloud credentials', () => {
+    expect(
+      hook(ctx('node -e "require(\'fs\').readFileSync(process.env.HOME + \'/.aws/credentials\')"'))
+        .decision,
+    ).toBe('block');
   });
 
-  it('blocks node -e', () => {
-    expect(hook(ctx('node -e "console.log(1)"')).decision).toBe('block');
+  it('blocks sh -c that cats an SSH key', () => {
+    expect(hook(ctx('sh -c "cat ~/.ssh/id_ed25519"')).decision).toBe('block');
   });
 
-  it('blocks ruby -e', () => {
-    expect(hook(ctx('ruby -e "puts 1"')).decision).toBe('block');
+  it('blocks a home path the interpreter assembles at runtime (the gap check 2 cannot see)', () => {
+    // check 2's literal-substring scan never sees this — the home dir is built
+    // by expanduser at runtime — but the `.ssh` / `id_rsa` fragments do.
+    expect(
+      hook(ctx('python3 -c "import os; open(os.path.expanduser(\'~/.ssh/id_rsa\'))"')).decision,
+    ).toBe('block');
   });
 
-  it('blocks osascript -e', () => {
-    expect(hook(ctx('osascript -e \'tell app "Finder" to quit\'')).decision).toBe('block');
-  });
-
-  it('blocks sh -c, bash -c, zsh -c, fish -c', () => {
-    expect(hook(ctx('sh -c "rm x"')).decision).toBe('block');
-    expect(hook(ctx('bash -c "rm x"')).decision).toBe('block');
-    expect(hook(ctx('zsh -c "rm x"')).decision).toBe('block');
-    expect(hook(ctx('fish -c "rm x"')).decision).toBe('block');
+  it('DOES block interpreter reads of /etc/shadow', () => {
+    expect(hook(ctx('sh -c "cat /etc/shadow"')).decision).toBe('block');
   });
 
   it('block message names typed file tools as the proper escape', () => {
-    const decision = hook(ctx('python -c "open(\\"/etc/passwd\\").read()"'));
+    const decision = hook(ctx('python -c "open(\'~/.ssh/id_rsa\').read()"'));
     expect(decision.reason).toMatch(/read_file|write_file|edit_file/);
+  });
+
+  // --- PASSES: pure-computation one-liners touch no sensitive path (the calibration) ---
+
+  it('does NOT block pure-computation python -c', () => {
+    // Previously blocked as blanket friction; now allowed — no secret is touched.
+    expect(hook(ctx('python -c "1+1"')).decision).not.toBe('block');
+    expect(hook(ctx('python3 -c "print(2**64)"')).decision).not.toBe('block');
+  });
+
+  it('does NOT block pure-computation node -e / ruby -e', () => {
+    expect(hook(ctx('node -e "console.log(1)"')).decision).not.toBe('block');
+    expect(hook(ctx('ruby -e "puts 1"')).decision).not.toBe('block');
+  });
+
+  it('does NOT block sh -c / bash -c / zsh -c that touch no sensitive path', () => {
+    expect(hook(ctx('sh -c "rm x"')).decision).not.toBe('block');
+    expect(hook(ctx('bash -c "echo hi"')).decision).not.toBe('block');
+    expect(hook(ctx('zsh -c "ls"')).decision).not.toBe('block');
+  });
+
+  it('does NOT block interpreter reads of world-readable /etc/passwd (no secret)', () => {
+    // /etc/passwd is world-readable and carries no secret; /etc/shadow does.
+    expect(hook(ctx('python -c "print(open(\'/etc/passwd\').read())"')).decision).not.toBe('block');
   });
 
   it('does NOT block paths that just CONTAIN the interpreter name', () => {
@@ -82,14 +113,19 @@ describe('createBashRestrictionHook — interpreter denylist', () => {
 });
 
 describe('createBashRestrictionHook — interpreter guard opt-out (AFK_DISABLE_BASH_INTERPRETER_GUARD)', () => {
-  it('skips the interpreter denylist when disableInterpreterGuard is true', () => {
+  it('skips the interpreter guard when disableInterpreterGuard is true', () => {
     const hook = createBashRestrictionHook({
       getGrantManager: mockGrants,
       disableInterpreterGuard: true,
     });
-    expect(hook(ctx('python -c "1+1"')).decision).not.toBe('block');
-    expect(hook(ctx('sh -c "echo hi"')).decision).not.toBe('block');
-    expect(hook(ctx('node -e "console.log(1)"')).decision).not.toBe('block');
+    // Even credential-adjacent one-liners (which WOULD block by default, and
+    // which check 2 misses because the path is quote-tilde / runtime-assembled)
+    // pass once the interpreter guard is disabled.
+    expect(hook(ctx('python -c "open(\'~/.ssh/id_rsa\').read()"')).decision).not.toBe('block');
+    expect(
+      hook(ctx('node -e "require(\'fs\').readFileSync(process.env.HOME + \'/.aws/credentials\')"'))
+        .decision,
+    ).not.toBe('block');
   });
 
   it('opting out does NOT weaken the restricted-root substring check', () => {
@@ -106,37 +142,55 @@ describe('createBashRestrictionHook — interpreter guard opt-out (AFK_DISABLE_B
 
   it('guard is active by default when the option is omitted', () => {
     const hook = createBashRestrictionHook({ getGrantManager: mockGrants });
-    expect(hook(ctx('python -c "1+1"')).decision).toBe('block');
+    expect(hook(ctx('python -c "open(\'~/.ssh/id_rsa\').read()"')).decision).toBe('block');
   });
 });
 
 describe('createBashRestrictionHook — interpreter guard interactivity gate (H2)', () => {
-  // The interpreter denylist hard-blocks only on INTERACTIVE surfaces (a wired
-  // grant manager), where the model can be redirected to the prompt-able typed
-  // file tools. On HEADLESS surfaces (no grant manager) it fails open by
-  // default so legitimate automation (`python -c`, `sh -c`) is not hard-blocked
-  // with no recourse — the day-one regression this gate fixes.
+  // The interpreter guard hard-blocks credential-adjacent one-liners only on
+  // INTERACTIVE surfaces (a wired grant manager), where the model can be
+  // redirected to the prompt-able typed file tools. On HEADLESS surfaces (no
+  // grant manager) it fails open by default so legitimate automation is not
+  // hard-blocked with no recourse — the day-one regression this gate fixes.
+  //
+  // `cred` is credential-adjacent (matches SENSITIVE_PATH_SIGNAL) AND uses a
+  // quote-prefixed `~` that check 2's literal scan does NOT normalize, so the
+  // interpreter guard (check 1) is the sole decider — isolating this behavior.
+  const cred = 'python -c "open(\'~/.ssh/id_rsa\').read()"';
 
-  it('does NOT block interpreter eval on a headless surface (no grant manager wired)', () => {
+  it('does NOT block a credential-adjacent eval on a headless surface (no grant manager wired)', () => {
     const hook = createBashRestrictionHook({ getGrantManager: () => undefined });
-    expect(hook(ctx('python -c "1+1"')).decision).not.toBe('block');
-    expect(hook(ctx('sh -c "echo hi"')).decision).not.toBe('block');
-    expect(hook(ctx('node -e "console.log(1)"')).decision).not.toBe('block');
+    expect(hook(ctx(cred)).decision).not.toBe('block');
   });
 
-  it('DOES block interpreter eval on an interactive surface (grant manager wired)', () => {
+  it('DOES block a credential-adjacent eval on an interactive surface (grant manager wired)', () => {
     const hook = createBashRestrictionHook({ getGrantManager: mockGrants });
-    expect(hook(ctx('python -c "1+1"')).decision).toBe('block');
+    expect(hook(ctx(cred)).decision).toBe('block');
   });
 
-  it('forceInterpreterGuard re-enables the denylist on headless surfaces', () => {
+  it('never blocks a pure-computation eval, interactive or headless', () => {
+    const interactive = createBashRestrictionHook({ getGrantManager: mockGrants });
+    const headless = createBashRestrictionHook({ getGrantManager: () => undefined });
+    expect(interactive(ctx('python -c "1+1"')).decision).not.toBe('block');
+    expect(headless(ctx('python -c "1+1"')).decision).not.toBe('block');
+  });
+
+  it('forceInterpreterGuard re-enables the guard on headless surfaces', () => {
     const hook = createBashRestrictionHook({
       getGrantManager: () => undefined,
       forceInterpreterGuard: true,
     });
-    const decision = hook(ctx('python -c "1+1"'));
+    const decision = hook(ctx(cred));
     expect(decision.decision).toBe('block');
     expect(decision.reason).toContain('Interpreter');
+  });
+
+  it('forceInterpreterGuard still does NOT block pure computation on headless', () => {
+    const hook = createBashRestrictionHook({
+      getGrantManager: () => undefined,
+      forceInterpreterGuard: true,
+    });
+    expect(hook(ctx('python -c "1+1"')).decision).not.toBe('block');
   });
 
   it('disableInterpreterGuard wins over forceInterpreterGuard (explicit OFF beats opt-in ON)', () => {
@@ -145,7 +199,7 @@ describe('createBashRestrictionHook — interpreter guard interactivity gate (H2
       disableInterpreterGuard: true,
       forceInterpreterGuard: true,
     });
-    expect(hook(ctx('python -c "1+1"')).decision).not.toBe('block');
+    expect(hook(ctx(cred)).decision).not.toBe('block');
   });
 
   it('forcing the guard on headless does not change the substring check (stays open)', () => {
@@ -154,7 +208,7 @@ describe('createBashRestrictionHook — interpreter guard interactivity gate (H2
       forceInterpreterGuard: true,
     });
     // A plain restricted-path cat (no interpreter) stays open on headless —
-    // forceInterpreterGuard only governs the interpreter denylist.
+    // forceInterpreterGuard only governs the interpreter guard.
     expect(hook(ctx(`cat ${homedir()}/.ssh/id_rsa`)).decision).not.toBe('block');
   });
 });

--- a/src/agent/tools/hooks/bash-restriction-hook.test.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.test.ts
@@ -17,7 +17,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { createBashRestrictionHook } from './bash-restriction-hook.js';
+import {
+  createBashRestrictionHook,
+  deriveRestrictedSubstrings,
+  SENSITIVE_PATH_SIGNAL,
+} from './bash-restriction-hook.js';
 import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
 import type { PreToolUseContext } from '../../hooks.js';
 import { homedir } from 'os';
@@ -64,6 +68,20 @@ describe('createBashRestrictionHook — interpreter denylist (scoped to credenti
     // by expanduser at runtime — but the `.ssh` / `id_rsa` fragments do.
     expect(
       hook(ctx('python3 -c "import os; open(os.path.expanduser(\'~/.ssh/id_rsa\'))"')).decision,
+    ).toBe('block');
+  });
+
+  it('blocks an interpreter one-liner assembling a Library/Application Support path', () => {
+    // ~/Library/Application Support holds Chrome "Login Data" (saved passwords)
+    // and Cookies (session tokens) — a deriveRestrictedSubstrings root. The
+    // quote-prefixed `~` is NOT normalized, so check 2's literal scan misses it;
+    // only the SENSITIVE_PATH_SIGNAL fragment (check 1) catches this.
+    expect(
+      hook(
+        ctx(
+          'python3 -c "import os; open(os.path.expanduser(\'~/Library/Application Support/Google/Chrome/Default/Login Data\'))"',
+        ),
+      ).decision,
     ).toBe('block');
   });
 
@@ -322,5 +340,26 @@ describe('createBashRestrictionHook — wiring failsafes', () => {
   it('does NOT block on non-bash tools', () => {
     const hook = createBashRestrictionHook({ getGrantManager: mockGrants });
     expect(hook({ event: 'PreToolUse', toolName: 'read_file', input: { file_path: '/etc/passwd' } }).decision).not.toBe('block');
+  });
+});
+
+describe('SENSITIVE_PATH_SIGNAL stays in sync with deriveRestrictedSubstrings', () => {
+  // Invariant: every restricted root check 2 protects must ALSO be matchable by
+  // check 1's lexical signal — otherwise an interpreter one-liner that assembles
+  // that root at runtime (a quote-prefixed `~`, which normalizeHomeRefs leaves
+  // alone) slips past BOTH checks. This test fails if a candidate is added to
+  // deriveRestrictedSubstrings without a corresponding SENSITIVE_PATH_SIGNAL
+  // fragment — the exact drift that once left ~/Library/Application Support
+  // (Chrome saved passwords / cookies) reachable via `python -c`.
+  const allCandidates = deriveRestrictedSubstrings({
+    resolveBase: undefined,
+    readRoots: [],
+    writeRoots: [],
+  });
+
+  it('covers every deriveRestrictedSubstrings candidate root', () => {
+    expect(allCandidates.length).toBeGreaterThan(0);
+    const uncovered = allCandidates.filter((c) => !SENSITIVE_PATH_SIGNAL.test(c));
+    expect(uncovered).toEqual([]);
   });
 });

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -88,7 +88,7 @@ const INTERPRETER_DENYLIST =
 /**
  * Credential-path fragments that survive runtime home-dir assembly. Kept in
  * sync with the sensitive roots in `deriveRestrictedSubstrings`, but expressed
- * as trailing fragments (plus the canonical private-key filenames) so they
+ * as trailing fragments (plus private-key filenames and the browser-profile root) so they
  * match even when an interpreter assembles the home prefix at runtime
  * (`os.environ['HOME']+'/.ssh'`, `expanduser('~/.ssh')`) — the exact case
  * check 2's literal `~`/`$HOME` normalization cannot see. Word-boundary
@@ -98,8 +98,8 @@ const INTERPRETER_DENYLIST =
  * secret; the secret companion `/etc/shadow` IS covered. This is the calibration
  * that lets benign one-liners through while still catching credential access.
  */
-const SENSITIVE_PATH_SIGNAL =
-  /\.ssh\b|\bid_rsa\b|\bid_ed25519\b|\.gnupg\b|\.aws\b|\.config\/gh\b|\.netrc\b|\.password-store\b|\/etc\/shadow\b|\/etc\/sudoers\b/i;
+export const SENSITIVE_PATH_SIGNAL =
+  /\.ssh\b|\bid_rsa\b|\bid_ed25519\b|\.gnupg\b|\.aws\b|\.config\/gh\b|\.netrc\b|\.password-store\b|Library\/Application Support\b|\/etc\/shadow\b|\/etc\/sudoers\b/i;
 
 export interface BashRestrictionHookOptions {
   /**
@@ -284,7 +284,7 @@ function referencesSensitivePath(
  * Each is included only when the user's resolveBase is NOT already inside it
  * (so a user working in `~/.ssh` doesn't self-block).
  */
-function deriveRestrictedSubstrings(grants: {
+export function deriveRestrictedSubstrings(grants: {
   resolveBase: string | undefined;
   readRoots: string[];
   writeRoots: string[];

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -1,6 +1,7 @@
 /**
- * PreToolUse hook that blocks bash invocations referencing restricted paths
- * or evaluating arbitrary code via interpreter `-c`/`-e` flags.
+ * PreToolUse hook that blocks bash invocations referencing restricted paths,
+ * plus interpreter `-c`/`-e` one-liners that reference those same sensitive
+ * paths.
  *
  * # Invariant — threat model (load-bearing)
  *
@@ -12,13 +13,10 @@
  *   - Brace expansion:          `cat /etc/{passwd,shadow}`
  *   - Process substitution:     `cat <(echo /etc/passwd)`
  *   - File descriptor tricks:   `exec 3</etc/passwd; cat <&3`
- *   - Interpreter scripts:      `python -c "open('/etc/passwd').read()"`
+ *   - String-split obfuscation: `python -c "open('~/.s'+'sh/id_rsa')"`
  *
- * The interpreter denylist below closes the most obvious adjacent bypass
- * (interpreter scripts). The rest are accepted as residual risk for the
- * accidental-prevention threat model.
- *
- * For adversarial containment, run agent-afk inside an OS-level sandbox:
+ * These are accepted as residual risk for the accidental-prevention threat
+ * model. For adversarial containment, run agent-afk inside an OS-level sandbox:
  *   - macOS:  `sandbox-exec` (note: deprecated in newer Xcode releases)
  *   - Linux:  Landlock or seccomp via systemd, bubblewrap, firejail
  *   - Docker: drop --cap-add and mount only the workspace
@@ -26,17 +24,38 @@
  * # What this hook does
  *
  * 1. Reads the bash `command` string from the tool input.
- * 2. If the command matches the interpreter denylist (`python -c`, `node -e`,
- *    `ruby -e`, `osascript -e`, `sh -c`, `bash -c`, `zsh -c`, `fish -c`) AND an
- *    interactive approval path exists (a grant manager is wired — REPL or
- *    Telegram), block with redirect guidance. Headless surfaces (afk chat,
- *    daemon, threads, subagents of headless sessions) fail OPEN by default,
- *    because the "use typed file tools" advice is only actionable where a
- *    human can approve the prompt; opt back in with
- *    AFK_FORCE_BASH_INTERPRETER_GUARD=1.
- * 3. If the command contains a literal substring referencing a restricted
- *    root (any path NOT inside the session's grant lists), block with
- *    redirect guidance pointing the model at typed file tools.
+ * 2. INTERPRETER-EVAL GUARD (check 1): if the command is an interpreter
+ *    one-liner (`python -c`, `node -e`, `ruby -e`, `sh -c`, ...) AND the
+ *    payload references a sensitive path — a grant-filtered restricted root, or
+ *    a credential fragment like `.ssh` / `id_rsa` / `.aws` / `/etc/shadow` that
+ *    an interpreter can assemble at runtime (see `SENSITIVE_PATH_SIGNAL`) — AND
+ *    an interactive approval path exists (a grant manager is wired — REPL or
+ *    Telegram), block with redirect guidance. This is deliberately NARROW:
+ *    pure-computation one-liners (`python -c 'print(2**64)'`, `node -e
+ *    'console.log(1)'`) are NOT blocked — they touch no sensitive path, so the
+ *    block was pure friction with no safety value. The guard exists to close
+ *    the one thing check 2's literal-substring scan cannot see: an interpreter
+ *    building a credential path at runtime (`open(expanduser('~/.ssh/id_rsa'))`).
+ *    Headless surfaces (afk chat, daemon, threads, subagents of headless
+ *    sessions) fail OPEN by default, because the "use typed file tools" advice
+ *    is only actionable where a human can approve the prompt; opt back in with
+ *    AFK_FORCE_BASH_INTERPRETER_GUARD=1, or lift it entirely with
+ *    AFK_DISABLE_BASH_INTERPRETER_GUARD=1.
+ * 3. RESTRICTED-ROOT SUBSTRING GUARD (check 2): if the command contains a
+ *    literal substring referencing a restricted root (any sensitive path NOT
+ *    inside the session's grant lists), block with redirect guidance pointing
+ *    the model at typed file tools.
+ *
+ * # History (why check 1 is scoped, not blanket)
+ *
+ * Check 1 previously hard-blocked EVERY interpreter `-c`/`-e` one-liner
+ * regardless of payload. That over-broad default was the single highest-
+ * frequency source of self-inflicted agent friction (harmless computation
+ * one-liners blocked constantly), which predictably drove operators to disable
+ * the guard wholesale via AFK_DISABLE_BASH_INTERPRETER_GUARD=1 — silencing its
+ * genuine, narrow value. Scoping check 1 to credential-adjacent payloads keeps
+ * the protection live by no longer crying wolf. The pinned expectations live in
+ * `bash-restriction-hook.test.ts`.
  *
  * The block reason is **structured** — the model sees "use read_file /
  * write_file / edit_file, they support per-call approval" — so it routes
@@ -57,18 +76,30 @@ import type { HookContext, HookDecision } from '../../hooks.js';
  * and scripting languages. Anchored with `\b` so a path containing the
  * literal `python3` (e.g. `/usr/local/bin/python3-config`) does not match.
  *
- * Note: this is a hard-block — no elicitation — because:
- *   (a) the user cannot reasonably audit an arbitrary shell-script string
- *       inside a prompt; clicking [Allow] would be a reflex, not a
- *       considered decision (the architect's "training-wheels" critique);
- *   (b) the model can almost always re-route via typed tools instead.
- *
- * If the user genuinely needs to run an interpreter script, they can do it
- * outside the agent. The agent's escape hatch is to ask the user explicitly,
- * not to evaluate code on the user's behalf.
+ * This regex only identifies that a command IS an interpreter one-liner; it is
+ * necessary but NOT sufficient to block. Check 1 blocks only when this matches
+ * AND `referencesSensitivePath()` is also true (see the factory below and the
+ * module header) — so `python -c 'print(2**64)'` passes while
+ * `python -c "open(expanduser('~/.ssh/id_rsa'))"` is caught.
  */
 const INTERPRETER_DENYLIST =
   /\b(python|python3|node|ruby|perl|osascript|sh|bash|zsh|fish|lua)\s+-[cCeE](\s|$)/;
+
+/**
+ * Credential-path fragments that survive runtime home-dir assembly. Kept in
+ * sync with the sensitive roots in `deriveRestrictedSubstrings`, but expressed
+ * as trailing fragments (plus the canonical private-key filenames) so they
+ * match even when an interpreter assembles the home prefix at runtime
+ * (`os.environ['HOME']+'/.ssh'`, `expanduser('~/.ssh')`) — the exact case
+ * check 2's literal `~`/`$HOME` normalization cannot see. Word-boundary
+ * anchored to curb false positives (`.awstats`, `foo.sshconfig` do not match).
+ *
+ * `/etc/passwd` is deliberately ABSENT — it is world-readable and carries no
+ * secret; the secret companion `/etc/shadow` IS covered. This is the calibration
+ * that lets benign one-liners through while still catching credential access.
+ */
+const SENSITIVE_PATH_SIGNAL =
+  /\.ssh\b|\bid_rsa\b|\bid_ed25519\b|\.gnupg\b|\.aws\b|\.config\/gh\b|\.netrc\b|\.password-store\b|\/etc\/shadow\b|\/etc\/sudoers\b/i;
 
 export interface BashRestrictionHookOptions {
   /**
@@ -125,41 +156,61 @@ export function createBashRestrictionHook(opts: BashRestrictionHookOptions) {
     const grantManager = opts.getGrantManager();
     const interactiveSurface = grantManager !== undefined;
 
-    // 1. Interpreter denylist — hard block.
+    // Precompute the sensitive-path view ONCE — both checks below consume it.
+    // `normalized` resolves the obvious `~` / `$HOME` shell idioms to the real
+    // home dir (NOT a parser — variable-assembled paths are out of scope; see
+    // module header). `restrictedSubstrings` is the grant-filtered set of
+    // sensitive roots; it is empty when no grant manager is wired (headless),
+    // so check 2 fails open there and check 1 falls back to the lexical signal.
+    const home = homedir();
+    const normalized = normalizeHomeRefs(command, home);
+    const restrictedSubstrings = grantManager
+      ? deriveRestrictedSubstrings(grantManager.getGrants())
+      : [];
+
+    // 1. Interpreter-eval guard — hard block, SCOPED to credential-adjacent
+    // one-liners.
     //
-    // Invariant: the interpreter guard fires ONLY where redirection is
-    // actionable. The block reason tells the model to "use typed file tools,
-    // which support per-call approval" — advice that only works on an
-    // interactive surface, where a human can approve the prompt. On headless
-    // surfaces there is no approval path, so hard-blocking `python -c` / `sh -c`
-    // there merely breaks legitimate automation with no recourse (the day-one
-    // regression this gate fixes). We therefore require `interactiveSurface`
-    // (a wired grant manager), matching the restricted-root substring check
-    // below which also fails open on headless. Overrides:
+    // Invariant: the interpreter guard fires ONLY where (a) redirection is
+    // actionable and (b) the eval payload actually references a sensitive path.
+    // (a) The block reason tells the model to "use typed file tools, which
+    // support per-call approval" — advice that only works on an interactive
+    // surface (a wired grant manager), so we require `interactiveSurface`,
+    // matching check 2 which also fails open on headless.
+    // (b) `referencesSensitivePath` scopes the block so pure-computation
+    // one-liners pass — that scoping is the calibration; see the module header
+    // History note. Overrides:
     //   - AFK_DISABLE_BASH_INTERPRETER_GUARD=1 (`disableInterpreterGuard`)
     //     forces it OFF even on interactive surfaces — and wins over force;
     //   - AFK_FORCE_BASH_INTERPRETER_GUARD=1 (`forceInterpreterGuard`) forces
-    //     it ON even on headless surfaces.
+    //     it ON even on headless surfaces (where `restrictedSubstrings` is
+    //     empty, so only the lexical SENSITIVE_PATH_SIGNAL applies).
     const interpreterGuardActive =
       !opts.disableInterpreterGuard &&
       (interactiveSurface || opts.forceInterpreterGuard === true);
-    if (interpreterGuardActive && INTERPRETER_DENYLIST.test(command)) {
+    if (
+      interpreterGuardActive &&
+      INTERPRETER_DENYLIST.test(command) &&
+      referencesSensitivePath(normalized, command, restrictedSubstrings)
+    ) {
       return {
         decision: 'block',
         reason:
-          'Interpreter-with-eval flags (python -c, node -e, ruby -e, sh -c, ...) are blocked by ' +
-          'the path-approval policy. Use the typed file tools (read_file, write_file, edit_file) ' +
-          'which support per-call user approval, or ask the user to run the script themselves. ' +
-          'To lift this block — e.g. headless automation that legitimately runs interpreter ' +
-          'one-liners — set AFK_DISABLE_BASH_INTERPRETER_GUARD=1, or disable all of path-approval ' +
-          'with AFK_DISABLE_PATH_APPROVAL=1.',
+          'Interpreter one-liner (python -c, node -e, sh -c, ...) referencing a sensitive path ' +
+          '(SSH keys, cloud credentials, GPG, /etc/shadow, ...) is blocked by the path-approval ' +
+          'policy — an interpreter can assemble a path the shell-substring check cannot see. Use ' +
+          'the typed file tools (read_file, write_file, edit_file), which support per-call user ' +
+          'approval, or ask the user to run the script themselves. To lift this block — e.g. ' +
+          'headless automation that legitimately reads such paths — set ' +
+          'AFK_DISABLE_BASH_INTERPRETER_GUARD=1, or disable all of path-approval with ' +
+          'AFK_DISABLE_PATH_APPROVAL=1.',
       };
     }
 
     // 2. Restricted-root substring check.
     // Only fires when a grant manager is wired (during the bootstrap race and
     // on headless surfaces we fail open). The check is intentionally crude:
-    // literal `command.includes` against every "restricted directory" we can
+    // literal `normalized.includes` against every "restricted directory" we can
     // derive. False positives (echo "see ~/.ssh/config") block the bash call
     // and ask the model to explain what it was doing, which is acceptable for
     // the accidental threat model.
@@ -172,17 +223,7 @@ export function createBashRestrictionHook(opts: BashRestrictionHookOptions) {
     // for stricter headless containment use an OS-level sandbox, or opt the
     // interpreter guard back in with AFK_FORCE_BASH_INTERPRETER_GUARD=1.
     if (!grantManager) return {};
-    const grants = grantManager.getGrants();
-    const restrictedSubstrings = deriveRestrictedSubstrings(grants);
     if (restrictedSubstrings.length === 0) return {};
-
-    // Normalize `~` and `$HOME` in the command to the real home dir for the
-    // substring match. This catches the obvious-shell-idiom case without
-    // pretending to be a real parser.
-    const home = homedir();
-    const normalized = command
-      .replace(/\$HOME/g, home)
-      .replace(/(^|[\s/=:])~(?=$|[/\s])/g, `$1${home}`);
 
     for (const sub of restrictedSubstrings) {
       if (normalized.includes(sub)) {
@@ -200,6 +241,35 @@ export function createBashRestrictionHook(opts: BashRestrictionHookOptions) {
 
     return {};
   };
+}
+
+/**
+ * Normalize the obvious `~` and `$HOME` shell idioms to the real home dir so
+ * the substring checks catch the non-adversarial accident case. NOT a parser —
+ * variable-assembled paths (`H=$HOME; …$H/…`) are intentionally out of scope
+ * (see module-header threat model). Shared by both checks.
+ */
+function normalizeHomeRefs(command: string, home: string): string {
+  return command
+    .replace(/\$HOME/g, home)
+    .replace(/(^|[\s/=:])~(?=$|[/\s])/g, `$1${home}`);
+}
+
+/**
+ * True when a command references a sensitive location the path-approval policy
+ * protects — via either the grant-filtered restricted substrings (literal /
+ * `~` / `$HOME` forms, same as check 2) or the lexical credential-fragment
+ * signal (which catches interpreter-assembled paths the literal scan misses).
+ * Used to scope the interpreter-eval guard (check 1) so it fires only on
+ * credential-adjacent one-liners, not on every `-c`/`-e` invocation.
+ */
+function referencesSensitivePath(
+  normalized: string,
+  rawCommand: string,
+  restrictedSubstrings: string[],
+): boolean {
+  if (restrictedSubstrings.some((sub) => normalized.includes(sub))) return true;
+  return SENSITIVE_PATH_SIGNAL.test(rawCommand);
 }
 
 /**

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -18,7 +18,11 @@ export const bashTool: AnthropicToolDef = {
     'Execute a shell command and return its stdout and stderr. ' +
     'Use for running programs, installing packages, git operations, and any task that requires a shell. ' +
     'Commands run in the user\'s default shell. Long-running commands should use timeout_ms. ' +
-    'Output is capped at ~100KB; excess is truncated with a notice.',
+    'Output is capped at ~100KB; excess is truncated with a notice. ' +
+    'For reading or writing files — especially anything sensitive — prefer the typed file tools ' +
+    '(read_file, write_file, edit_file): they support per-call user approval, and interpreter ' +
+    'one-liners (python -c, node -e, sh -c, ...) that reference credential paths (SSH keys, cloud ' +
+    'credentials, /etc/shadow) are blocked by the path-approval policy on interactive surfaces.',
   input_schema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## What & why

The path-approval `bash` PreToolUse hook has two checks:
1. **interpreter-eval guard** — blocks `python -c`, `node -e`, `sh -c`, … one-liners on interactive surfaces (REPL/Telegram);
2. **restricted-root substring guard** — blocks bash commands that literally reference `~/.ssh`, `~/.aws`, `/etc/shadow`, … (unchanged here).

Check 1 fired on **every** interpreter `-c`/`-e` one-liner regardless of payload — so `python -c "1+1"` and `node -e "console.log(1)"` were hard-blocked with **zero** safety value (they touch no sensitive path). That over-broad default was the dominant recurring, self-inflicted agent friction in telemetry, and it predictably pushes operators to disable the guard wholesale (`AFK_DISABLE_BASH_INTERPRETER_GUARD=1`) — which silences its genuine, narrow value entirely. The guard's own module header states it exists only to close the one thing check 2 can't see: an interpreter assembling a credential path at runtime.

## The change

Scope check 1 to fire only when the interpreter one-liner **references a sensitive path**, via two complementary detectors that together close the gap each leaves alone:

- **reuse check 2's grant-filtered restricted-substring scan** — catches literal / `~` / `$HOME` forms (e.g. `/etc/shadow`), respecting `/allow-dir` grants;
- **a lexical credential-fragment signal** (`SENSITIVE_PATH_SIGNAL`: `.ssh`, `id_rsa`, `id_ed25519`, `.gnupg`, `.aws`, `.config/gh`, `.netrc`, `.password-store`, `/etc/shadow`, `/etc/sudoers`) — catches home paths an interpreter builds at runtime (`open(os.path.expanduser('~/.ssh/id_rsa'))`), which check 2's literal scan never sees.

Word-boundary anchored to curb false positives (`.awstats`, `foo.sshconfig` don't match).

Plus a small **`bash` tool-description nudge** steering the model toward the typed file tools for file access, so it self-steers away from interpreter one-liners in the first place.

## Behavior delta

| Command | Before | After |
|---|---|---|
| `python -c "1+1"` | 🔴 blocked | 🟢 allowed |
| `node -e "console.log(1)"` | 🔴 blocked | 🟢 allowed |
| `sh -c "rm x"` | 🔴 blocked | 🟢 allowed |
| `python -c "print(open('/etc/passwd').read())"` | 🔴 blocked | 🟢 allowed (world-readable, no secret) |
| `python -c "open(expanduser('~/.ssh/id_rsa'))"` | 🔴 blocked | 🔴 blocked |
| `sh -c "cat /etc/shadow"` | 🔴 blocked | 🔴 blocked |
| `cat ~/.ssh/id_rsa` (check 2) | 🔴 blocked | 🔴 blocked (unchanged) |

**Unchanged:** check 2, both env knobs (`AFK_DISABLE_`/`AFK_FORCE_BASH_INTERPRETER_GUARD`), the interactive-only / headless-fail-open posture, and the non-adversarial threat model (variable-assembly / string-split bypasses remain explicitly out of scope — use an OS-level sandbox for adversarial containment).

## Contract change (intentional)

This **reverses a previously-pinned "blanket block" contract**. The `bash-restriction-hook.test.ts` interpreter-denylist assertions and the module/test docstrings are updated to pin the new scoped behavior (e.g. `python -c "1+1"` now asserts *not blocked*; credential-adjacent one-liners assert blocked). Reviewers should confirm they agree with the recalibration, not just that tests are green.

## Testing

- `pnpm lint` (tsc --noEmit strict) — clean
- full `pnpm test:coverage` — 589 files / 10,797 pass, 14 skipped, 0 fail; coverage thresholds met
- `pnpm audit:sdk:check`, `pnpm audit:env:check`, `pnpm scan:env:check` — all green (no new SDK imports, no new env vars, docs in sync)

Files: `src/agent/tools/hooks/bash-restriction-hook.ts`, `src/agent/tools/hooks/bash-restriction-hook.test.ts`, `src/agent/tools/schemas.ts`.
