### PR TITLE
refactor(cli): remove /reset slash command; fix stale /clear docs

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -82,7 +82,6 @@ The interactive REPL registers slash commands directly in TypeScript (`src/cli/s
 - `/exit`, `/quit` — leave the REPL
 - `/clear` — clear screen
 - `/compact` — manually compact conversation history
-- `/reset` — start a fresh session, discarding history
 
 ### Information
 - `/cost` — running cost for the session
@@ -191,7 +190,7 @@ The setup wizard prompts for the token and the chat IDs allowed to interact with
 
 **Bot commands:**
 - `/start` — welcome
-- `/reset` — clear conversation
+- `/clear` — clear conversation history
 - `/model local|small|medium|large|opus|sonnet|haiku|fable` — switch model
 
 Send any other message to chat. The bot runs in the default permission mode — tools execute without per-tool prompts, and file access outside the working directory stays contained.

--- a/src/cli/slash-commands.test.ts
+++ b/src/cli/slash-commands.test.ts
@@ -100,7 +100,7 @@ describe('slash commands — registration', () => {
     const names = list().map((c) => c.name);
     for (const expected of [
       '/exit', '/clear', '/compact', '/help',
-      '/cost', '/tokens', '/history', '/reset', '/model', '/tools', '/mcp', '/limits',
+      '/cost', '/tokens', '/history', '/model', '/tools', '/mcp', '/limits',
       '/plan', '/todo',
       '/skills', '/reload-plugins', '/agents',
     ]) {
@@ -787,23 +787,5 @@ describe('/exit', () => {
     const res = await dispatch('/exit', ctx);
     expect(res.handled).toBe(true);
     expect(res.result).toBe('exit');
-  });
-});
-
-describe('/reset', () => {
-  beforeEach(() => { resetRegistry(); registerAll(); });
-
-  it('clears stats and calls /clear on the session', async () => {
-    const sess = fakeSession();
-    const stats = makeStats();
-    stats.totalTurns = 5;
-    stats.totalCostUsd = 0.25;
-    stats.turns.push({ user: 'x', assistant: 'y', timestamp: Date.now() });
-    const { ctx } = makeCtx({ session: { current: sess } as unknown as SlashContext['session'], stats });
-    await dispatch('/reset', ctx);
-    expect(sess.sendMessage).toHaveBeenCalledWith('/clear');
-    expect(ctx.stats.totalTurns).toBe(0);
-    expect(ctx.stats.totalCostUsd).toBe(0);
-    expect(ctx.stats.turns).toHaveLength(0);
   });
 });

--- a/src/cli/slash/commands/info.ts
+++ b/src/cli/slash/commands/info.ts
@@ -1,6 +1,6 @@
 /**
  * Information / introspection commands:
- *   /cost /tokens /history /reset /model /tools /mcp /debug
+ *   /cost /tokens /history /model /tools /mcp /debug
  *
  * These all read from SessionStats or session metadata and format for
  * display. `/model` mutates state by calling `session.setModel()`.
@@ -188,30 +188,6 @@ const historyCmd: SlashCommand = {
       out.line(`      ${palette.brand('◆')} ${palette.dim(asstPreview)}`);
     });
     out.line();
-    return 'continue';
-  },
-};
-
-const resetCmd: SlashCommand = {
-  name: '/reset',
-  summary: 'Clear screen, history, and session stats',
-  async handler(ctx) {
-    const { stats, ui, out } = ctx;
-    try {
-      await ctx.session.current.sendMessage('/clear');
-    } catch {
-      // best-effort
-    }
-    stats.totalTurns = 0;
-    stats.totalCostUsd = 0;
-    stats.totalTokens = 0;
-    stats.totalDurationMs = 0;
-    stats.turnCosts.length = 0;
-    stats.turnTokens.length = 0;
-    stats.turns.length = 0;
-    stats.sessionStartTime = Date.now();
-    ui.clearScreen();
-    out.success('Session reset.');
     return 'continue';
   },
 };
@@ -450,5 +426,5 @@ const debugCmd: SlashCommand = {
 };
 
 export const infoCommands: SlashCommand[] = [
-  costCmd, tokensCmd, historyCmd, resetCmd, modelCmd, toolsCmd, mcpCmd, limitsCmd, debugCmd,
+  costCmd, tokensCmd, historyCmd, modelCmd, toolsCmd, mcpCmd, limitsCmd, debugCmd,
 ];

--- a/website/content/docs/surfaces/repl.mdx
+++ b/website/content/docs/surfaces/repl.mdx
@@ -39,7 +39,6 @@ Type `/` in the REPL to see available commands. Typos are caught automatically â
 | `/help` | List all available slash commands |
 | `/exit`, `/quit` | Leave the REPL |
 | `/clear` | Clear the screen |
-| `/reset` | Start a fresh session, discarding history |
 | `/compact` | Manually compact conversation history |
 | `/save` | Snapshot session state to disk |
 | `/resume` | Resume a saved session |

--- a/website/content/docs/surfaces/telegram.mdx
+++ b/website/content/docs/surfaces/telegram.mdx
@@ -66,7 +66,7 @@ Inside Telegram, the bot recognizes:
 | Command | Description |
 |---|---|
 | `/start` | Welcome message |
-| `/reset` | Clear conversation history and start fresh |
+| `/clear` | Clear conversation history and start fresh |
 | `/model opus` | Switch the active model (`opus`, `sonnet`, `haiku`, `fable`) |
 
 Any other message is sent to the session as a regular turn. The bot runs in the **default**


### PR DESCRIPTION
## Summary
Removes the REPL `/reset` slash command and corrects stale Telegram `/clear` documentation.

## Why
`/reset` called `session.sendMessage('/clear')`, which forwards the literal string `"/clear"` to the provider as a normal user turn — so it **never actually cleared conversation history** despite its *"Clear screen, history, and session stats"* summary. Only `/clear` (which calls `session.reset()` to tear down and rebuild the SDK conversation) genuinely clears history. `/reset` merely duplicated `/clear`'s screen + local-stats reset while being subtly broken.

The Telegram bot **never registered a `/reset` command** — it registers `/clear` (`src/telegram/bot.ts:93`) and its in-product `/help` lists `/clear`. So the Telegram `/reset` doc rows were stale; they're **corrected to `/clear`** (not deleted — the bot does have a clear-conversation command).

## Changes
- **`src/cli/slash/commands/info.ts`** — remove `resetCmd` definition, its `infoCommands` array entry, and the header-comment mention.
- **`src/cli/slash-commands.test.ts`** — remove `/reset` from the expected-registry list and delete its `describe('/reset')` block.
- **`docs/reference.md`** — delete the REPL `/reset` line; correct Telegram `/reset` → `/clear`.
- **`website/content/docs/surfaces/repl.mdx`** — delete the REPL `/reset` row.
- **`website/content/docs/surfaces/telegram.mdx`** — correct Telegram `/reset` → `/clear`.

## Verification
- `pnpm test` — **589 files / 10,791 tests pass**.
- `pnpm lint` (`tsc --noEmit`) — clean.

## Out of scope
`formatReset()` in `src/telegram/formatter.ts` remains a now-orphaned backward-compat alias for `formatClear()` (still exported + tested). Left for a separate cleanup.
