### PR TITLE
feat(cli): add `digest` thinking-display mode (live preview + persisted reasoning)

### DIFF
--- a/src/cli/_lib/stream-renderer-contexts.ts
+++ b/src/cli/_lib/stream-renderer-contexts.ts
@@ -32,7 +32,7 @@ export function makeOrchestratorCtx(args: {
   overlayComposer: OverlayComposer | null;
   toolLane: ToolLane;
   thinkingLane: ThinkingLane;
-  thinkingMode: 'off' | 'summary' | 'live';
+  thinkingMode: 'off' | 'summary' | 'live' | 'digest';
   streamingMarkdown: { current: StreamingMarkdownRenderer | null };
   coordinator: CommitCoordinator;
   stageTracker?: StageTrackerState;
@@ -68,7 +68,7 @@ export function makeSubagentCtx(args: {
   toolLane: ToolLane;
   out: Writer;
   streamingMarkdown: Map<string, StreamingMarkdownRenderer>;
-  thinkingMode: 'off' | 'summary' | 'live';
+  thinkingMode: 'off' | 'summary' | 'live' | 'digest';
   orchestratorCtx: OrchestratorCtx;
 }): SubagentCtx {
   return {

--- a/src/cli/_lib/stream-renderer-lifecycle.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.ts
@@ -42,7 +42,7 @@ export interface LifecycleContext {
   toolLane: ToolLane;
   streamingMarkdownRef: { current: StreamingMarkdownRenderer | null };
   lastProgressByTask: Map<string, ProgressEvent>;
-  thinkingMode: 'off' | 'summary' | 'live';
+  thinkingMode: 'off' | 'summary' | 'live' | 'digest';
   out: Writer;
   isTTY: boolean;
   sources: Map<string, SourceState>;
@@ -84,7 +84,7 @@ export function registerOverlaySlots(
       // gating on hasBufferedContent() alone would keep re-painting the
       // already-collapsed thinking into the idle overlay between turns.
       if (
-        ctx.thinkingMode !== 'live' ||
+        (ctx.thinkingMode !== 'live' && ctx.thinkingMode !== 'digest') ||
         !ctx.thinkingLane.isActive() ||
         !ctx.thinkingLane.hasBufferedContent()
       ) {

--- a/src/cli/_lib/stream-renderer-orchestrator-emit.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator-emit.ts
@@ -13,6 +13,8 @@ import { renderMarkdownToTerminal } from '../formatter.js';
 import { getTerminalWidth } from '../terminal-size.js';
 import { wrapToWidth } from '../wrap.js';
 import { formatThoughtSummary } from '../commands/interactive/thinking-lane.js';
+import { formatThinkingParagraph } from '../commands/interactive/thinking-paragraph.js';
+import { sanitizeLabel } from '../commands/interactive/tool-lane-format-sanitize.js';
 import { commitBlockAbove } from './commit-block.js';
 
 import type { OrchestratorCtx } from './stream-renderer-orchestrator.js';
@@ -51,9 +53,12 @@ export function emitPanel(
 }
 
 /**
- * Seal the current thinking phase and return its formatted `◆ thought for Xs ·
- * N tok` summary line, or `null` when no phase is pending or it produced only
- * whitespace.
+ * Seal the current thinking phase and return both its raw drained text and its
+ * formatted `◆ thought for Xs · N tok` summary line, or `null` when no phase is
+ * pending or it produced only whitespace. Callers pass the result to
+ * {@link renderSealedPhase} to build the scrollback rows (mode-dependent —
+ * `digest` prepends a capped reasoning paragraph, other modes emit the stat
+ * line alone).
  *
  * Single source of truth for the drain + timer-clear + duration + format step
  * shared by the two TTY callers — {@link commitThinkingPhase} (immediate commit
@@ -68,13 +73,58 @@ export function emitPanel(
  * duration here — not at commit time — lets the finalize path schedule a
  * deferred commit without the elapsed time drifting to flush time.
  */
-function sealThinkingPhase(source: SourceState, ctx: OrchestratorCtx): string | null {
+/**
+ * Number of reasoning body lines `digest` mode commits to scrollback per sealed
+ * thinking phase. Matches {@link formatThinkingParagraph}'s DEFAULT_MAX_BODY_LINES
+ * so `digest` reads as "the live preview, frozen into scrollback on seal" —
+ * short phases render in full; long phases keep their most-recent
+ * DIGEST_MAX_LINES lines and gain a `⋯ +N chars earlier` footer.
+ */
+const DIGEST_MAX_LINES = 5;
+
+function sealThinkingPhase(
+  source: SourceState,
+  ctx: OrchestratorCtx,
+): { summaryLine: string; phaseText: string } | null {
   const start = source.thinkingPhaseStartedAt;
   if (start == null) return null;
   source.thinkingPhaseStartedAt = undefined;
   const phase = ctx.thinkingLane.drainPhase();
   if (!phase.trim()) return null;
-  return formatThoughtSummary(Date.now() - start, phase.length);
+  return {
+    summaryLine: formatThoughtSummary(Date.now() - start, phase.length),
+    phaseText: phase,
+  };
+}
+
+/**
+ * Build the physical scrollback rows for a sealed thinking phase.
+ *
+ * All modes emit the `◆ thought for Xs · N tok` stat line. `digest` mode
+ * additionally prepends the capped reasoning paragraph (`◆ thinking` header +
+ * body + optional `⋯ +N chars earlier` footer) ABOVE the stat, so scrollback
+ * reads top-to-bottom as: reasoning → its cost → the tool it produced.
+ *
+ * The phase text is scrubbed through {@link sanitizeLabel} before formatting:
+ * unlike the ephemeral `live` overlay, a digest row is COMMITTED to scrollback,
+ * so raw ANSI / C0 / C1 control bytes in model reasoning must be stripped to
+ * avoid persistent terminal corruption. `formatThinkingParagraph` collapses
+ * whitespace but does not strip control sequences — hence the explicit scrub.
+ */
+function renderSealedPhase(
+  sealed: { summaryLine: string; phaseText: string },
+  ctx: OrchestratorCtx,
+): string[] {
+  const lines: string[] = [];
+  if (ctx.thinkingMode === 'digest') {
+    const paragraph = formatThinkingParagraph(sanitizeLabel(sealed.phaseText), {
+      cols: getTerminalWidth(),
+      maxLines: DIGEST_MAX_LINES,
+    });
+    if (paragraph) lines.push(...paragraph.split('\n'));
+  }
+  lines.push(sealed.summaryLine);
+  return lines;
 }
 
 /**
@@ -95,12 +145,17 @@ function sealThinkingPhase(source: SourceState, ctx: OrchestratorCtx): string | 
  * {@link sealThinkingPhase} (shared with the finalize trailing-phase path).
  */
 export function commitThinkingPhase(source: SourceState, ctx: OrchestratorCtx): void {
-  const line = sealThinkingPhase(source, ctx);
-  if (line == null) return;
+  const sealed = sealThinkingPhase(source, ctx);
+  if (sealed == null) return;
+  const lines = renderSealedPhase(sealed, ctx);
   if (ctx.isTTY && ctx.compositor) {
-    ctx.compositor.commitAbove(line);
+    // digest mode yields a multi-line block (paragraph + stat) — commit it
+    // atomically (one geometry decision) via commitBlockAbove; other modes
+    // are a single stat line and take the direct commitAbove path.
+    if (lines.length > 1) commitBlockAbove(ctx.compositor, lines);
+    else ctx.compositor.commitAbove(lines[0] ?? '');
   } else {
-    ctx.out.line(line);
+    for (const line of lines) ctx.out.line(line);
   }
 }
 
@@ -250,8 +305,9 @@ export function finalizeOrchestrator(
     // tool. sealThinkingPhase returns null (→ no schedule) when no phase is
     // pending or it produced only whitespace.
     if (ctx.isTTY && ctx.thinkingMode !== 'off') {
-      const line = sealThinkingPhase(source, ctx);
-      if (line != null) {
+      const sealed = sealThinkingPhase(source, ctx);
+      if (sealed != null) {
+        const lines = renderSealedPhase(sealed, ctx);
         // Capture ctx refs used in the closure — avoids closing over the
         // mutable ctx object (mirrors the tool-lane closure above).
         const compositor = ctx.compositor;
@@ -260,8 +316,12 @@ export function finalizeOrchestrator(
         ctx.coordinator.schedule({
           anchor: 'before-content',
           commits: [() => {
-            if (isTTY && compositor) compositor.commitAbove(line);
-            else out.line(line);
+            if (isTTY && compositor) {
+              if (lines.length > 1) commitBlockAbove(compositor, lines);
+              else compositor.commitAbove(lines[0] ?? '');
+            } else {
+              for (const line of lines) out.line(line);
+            }
           }],
         });
       }

--- a/src/cli/_lib/stream-renderer-orchestrator.test.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.test.ts
@@ -787,6 +787,23 @@ describe('handleOrchestratorEvent — stage rail single-paint invariant', () => 
     expect(overlay).not.toContain('◆ model');
   });
 
+  it('thinking-digest streams the live overlay while thinking (like live)', () => {
+    // digest shows the live preview overlay exactly like 'live'; the ONLY
+    // difference is that digest ALSO commits the reasoning paragraph to
+    // scrollback on phase seal (covered by the emit tests). Here we assert the
+    // live paragraph reaches the overlay in digest mode.
+    const toolLane = new ToolLane();
+    const { ctx, setOverlay } = makeStageCtx(toolLane);
+    ctx.thinkingMode = 'digest';
+    const source: SourceState = freshSourceState('__main__');
+
+    handleOrchestratorEvent(thinkingEvt('reasoning step'), source, ctx);
+
+    expect(setOverlay).toHaveBeenCalledTimes(1);
+    const overlay = strip(setOverlay.mock.calls[0]?.[0] ?? '');
+    expect(overlay).toContain('reasoning step');
+  });
+
   // ── Test that catches the FOLLOW-ON regression introduced by removing  ─
   // ── the pre-switch repaint (would fail without the case-arm fix)      ─
 
@@ -1175,7 +1192,7 @@ describe('handleOrchestratorEvent — cross-flush tool grouping (run accumulatio
   }
   function makeCaptureCtx(
     toolLane: ToolLane,
-    opts: { thinkingMode?: 'off' | 'summary' | 'live' } = {},
+    opts: { thinkingMode?: 'off' | 'summary' | 'live' | 'digest' } = {},
   ): { ctx: OrchestratorCtx; commitAboveCalls: string[] } {
     const commitAboveCalls: string[] = [];
     const compositor = {
@@ -1256,5 +1273,32 @@ describe('handleOrchestratorEvent — cross-flush tool grouping (run accumulatio
     const scrollback = commitAboveCalls.join('\n');
     expect(scrollback).not.toContain('×2');            // b1/b2 rendered individually
     expect(scrollback.toLowerCase()).toContain('thought for'); // thought committed between them
+  });
+
+  it('digest mode persists the reasoning paragraph above the stat line on phase seal', () => {
+    const toolLane = new ToolLane();
+    const { ctx, commitAboveCalls } = makeCaptureCtx(toolLane, { thinkingMode: 'digest' });
+    const source = freshSourceState('__main__');
+
+    handleOrchestratorEvent(thinkingEvent('Planning the read order DIGEST_PROOF next'), source, ctx);
+    handleOrchestratorEvent(namedToolStart('r1', 'Read'), source, ctx); // tool boundary seals the phase
+
+    const scrollback = commitAboveCalls.join('\n');
+    expect(scrollback).toContain('DIGEST_PROOF');              // actual reasoning persisted
+    expect(scrollback).toContain('◆ thinking');                // under the paragraph header
+    expect(scrollback.toLowerCase()).toContain('thought for'); // stat line still emitted
+  });
+
+  it('summary mode commits only the stat line, never the reasoning text', () => {
+    const toolLane = new ToolLane();
+    const { ctx, commitAboveCalls } = makeCaptureCtx(toolLane, { thinkingMode: 'summary' });
+    const source = freshSourceState('__main__');
+
+    handleOrchestratorEvent(thinkingEvent('secret reasoning DIGEST_PROOF must not persist'), source, ctx);
+    handleOrchestratorEvent(namedToolStart('r1', 'Read'), source, ctx);
+
+    const scrollback = commitAboveCalls.join('\n');
+    expect(scrollback).not.toContain('DIGEST_PROOF');          // reasoning NOT persisted in summary mode
+    expect(scrollback.toLowerCase()).toContain('thought for');
   });
 });

--- a/src/cli/_lib/stream-renderer-orchestrator.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.ts
@@ -68,11 +68,13 @@ export interface OrchestratorCtx {
    * `'off'` suppresses thinking entirely (no buffer, no overlay, no summary).
    * `'summary'` buffers and emits a collapsed summary on finalize.
    * `'live'` shows a streaming preview overlay and the finalize summary.
+   * `'digest'` shows the live streaming overlay (like `'live'`) AND commits a
+   * capped reasoning paragraph to scrollback above the summary at each phase seal.
    */
   // Optional: omitted callers (tests, non-TTY surfaces) behave as 'summary' —
   // the consuming checks are `=== 'off'` / `!== 'off'` / `=== 'live'`, all of
   // which treat undefined as the documented summary default.
-  thinkingMode?: 'off' | 'summary' | 'live';
+  thinkingMode?: 'off' | 'summary' | 'live' | 'digest';
   /** Lazy holder so callers can swap StreamingMarkdownRenderer in/out. */
   streamingMarkdown: { current: StreamingMarkdownRenderer | null };
   /**
@@ -332,11 +334,11 @@ export function handleOrchestratorEvent(
           source.thinkingPhaseStartedAt = Date.now();
         }
         ctx.thinkingLane.push(chunk.content);
-        // Only repaint the overlay in 'live' mode — summary mode buffers
-        // silently and has nothing overlay-visible to push (the stage rail
-        // moved to a footer bar and is repainted via onStageChange in
-        // stream-renderer.ts, not through setComposedOverlay).
-        if (ctx.isTTY && ctx.thinkingMode === 'live') setComposedOverlay(ctx);
+        // Repaint the overlay in 'live' and 'digest' modes — both stream the
+        // live preview. ('summary' buffers silently, with nothing overlay-visible
+        // to push; the stage rail moved to a footer bar and is repainted via
+        // onStageChange in stream-renderer.ts, not through setComposedOverlay.)
+        if (ctx.isTTY && (ctx.thinkingMode === 'live' || ctx.thinkingMode === 'digest')) setComposedOverlay(ctx);
       }
       return;
     }
@@ -404,8 +406,8 @@ export function setComposedOverlay(ctx: OrchestratorCtx): void {
   }
 
   // Live thinking preview — rendered above the tool lane so the user sees
-  // the model's current reasoning while it streams. Only in 'live' mode;
-  // 'summary' mode buffers silently and emits a single line at turn-end.
+  // the model's current reasoning while it streams. In 'live' and 'digest'
+  // modes; 'summary' buffers silently and emits a single line at turn-end.
   //
   // Rendered as a wrapped, soft-capped paragraph (`◆ thinking` header +
   // indented body, ~5 visible lines, `⋯ +N chars earlier` footer when the
@@ -419,7 +421,7 @@ export function setComposedOverlay(ctx: OrchestratorCtx): void {
   // block in that file for why parallel subagents stay on the single-line
   // tail treatment instead of the paragraph format.
   const parts: string[] = [];
-  if (ctx.thinkingMode === 'live' && ctx.thinkingLane.hasBufferedContent()) {
+  if ((ctx.thinkingMode === 'live' || ctx.thinkingMode === 'digest') && ctx.thinkingLane.hasBufferedContent()) {
     const paragraph = formatThinkingParagraph(ctx.thinkingLane.peek(), {
       cols: getTerminalWidth(),
     });

--- a/src/cli/_lib/stream-renderer-subagent.ts
+++ b/src/cli/_lib/stream-renderer-subagent.ts
@@ -62,7 +62,7 @@ export interface SubagentCtx {
    * silently dropping thinking events when the field is omitted by callers
    * (tests, future surfaces).
    */
-  thinkingMode: 'off' | 'summary' | 'live';
+  thinkingMode: 'off' | 'summary' | 'live' | 'digest';
   /**
    * Reference to the parent orchestrator's context. Used by subagent
    * handlers to compose the full overlay frame (stage rail + thinking

--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -69,7 +69,7 @@ export interface StreamRendererOptions {
    *
    * Subagent thinking is always suppressed regardless of this flag.
    */
-  thinkingMode?: 'off' | 'summary' | 'live';
+  thinkingMode?: 'off' | 'summary' | 'live' | 'digest';
   /**
    * @deprecated Use `thinkingMode: 'live'` instead. Kept as a back-compat alias:
    * `verbose: true` maps to `thinkingMode: 'live'`, `false`/unset to `'summary'`.
@@ -194,7 +194,7 @@ export interface StreamRendererOptions {
  */
 export class StreamRenderer {
   private readonly out: Writer;
-  private readonly thinkingMode: 'off' | 'summary' | 'live';
+  private readonly thinkingMode: 'off' | 'summary' | 'live' | 'digest';
   private readonly isTTY: boolean;
   private readonly captureMode: boolean;
   private readonly reducedMotion: boolean;

--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -59,10 +59,10 @@ export function setInteractiveUpdateNotices(
 }
 
 function parseThinkingUiMode(raw: string): ThinkingUiMode {
-  if (raw === 'summary' || raw === 'live' || raw === 'off') {
+  if (raw === 'summary' || raw === 'live' || raw === 'digest' || raw === 'off') {
     return raw;
   }
-  throw new Error(`Invalid --thinking-ui value: ${raw}. Expected summary|live|off`);
+  throw new Error(`Invalid --thinking-ui value: ${raw}. Expected summary|live|digest|off`);
 }
 
 /**
@@ -161,7 +161,7 @@ export function registerInteractiveCommand(program: Command): void {
     )
     .option('--max-turns <number>', 'Maximum conversation turns', '100')
     .option('--thinking <mode>', "Thinking mode: 'adaptive' | 'disabled' | 'enabled:<N>'", 'enabled:max')
-    .option('--thinking-ui <mode>', 'Thinking display mode: summary|live|off', parseThinkingUiMode, 'live')
+    .option('--thinking-ui <mode>', 'Thinking display mode: summary|live|digest|off', parseThinkingUiMode, 'live')
     .option('--effort <level>', 'Effort level: low|medium|high|xhigh|max')
     .option('--max-output-tokens <n|max>', "Per-response output cap ('max' = model ceiling). Env: AFK_MAX_OUTPUT_TOKENS")
     .option('--resume <id>', 'Resume a persisted SDK session by id')

--- a/src/cli/slash/commands/thinking.test.ts
+++ b/src/cli/slash/commands/thinking.test.ts
@@ -82,6 +82,15 @@ describe('/thinking slash command', () => {
     expect(lines.some((l) => l.startsWith('SUCCESS:') && l.includes('off'))).toBe(true);
   });
 
+  it('switches to digest and mutates stats', async () => {
+    const stats = makeStats({ thinkingUi: 'live' });
+    const { ctx, lines } = makeCtx(stats);
+    const result = await thinkingCmd.handler(ctx, 'digest');
+    expect(result).toBe('continue');
+    expect(stats.thinkingUi).toBe('digest');
+    expect(lines.some((l) => l.startsWith('SUCCESS:') && l.includes('digest'))).toBe(true);
+  });
+
   it('switches back to live from summary', async () => {
     const stats = makeStats({ thinkingUi: 'summary' });
     const { ctx, lines } = makeCtx(stats);
@@ -111,7 +120,7 @@ describe('/thinking slash command', () => {
   it('exposes metadata for autocomplete', () => {
     expect(thinkingCmd.name).toBe('/thinking');
     expect(thinkingCmd.aliases).toContain('/thinking-ui');
-    expect(thinkingCmd.flags).toEqual(['summary', 'live', 'off']);
+    expect(thinkingCmd.flags).toEqual(['summary', 'live', 'digest', 'off']);
     expect(thinkingCmd.summary).toBeTruthy();
     expect(thinkingCmd.hint).toBeTruthy();
   });

--- a/src/cli/slash/commands/thinking.ts
+++ b/src/cli/slash/commands/thinking.ts
@@ -10,6 +10,7 @@
  *   /thinking           — show the current mode
  *   /thinking live       — stream thinking preview + finalize summary (default)
  *   /thinking summary    — collapsed one-line summary on finalize, no live preview
+ *   /thinking digest     — live preview + persist a capped reasoning paragraph to scrollback per phase
  *   /thinking off        — suppress thinking entirely
  *
  * Mutates `ctx.stats.thinkingUi`, which the REPL loop reads at the top of each
@@ -21,26 +22,28 @@ import type { ThinkingUiMode } from '../types.js';
 import type { SlashCommand } from '../types.js';
 import { palette } from '../../palette.js';
 
-const VALID_MODES: readonly ThinkingUiMode[] = ['summary', 'live', 'off'];
+const VALID_MODES: readonly ThinkingUiMode[] = ['summary', 'live', 'digest', 'off'];
 
 const MODE_DESCRIPTIONS: Record<ThinkingUiMode, string> = {
   live: 'streaming preview + finalize summary',
   summary: 'collapsed one-line summary on finalize',
+  digest: 'live preview + reasoning paragraph persisted to scrollback per phase',
   off: 'suppressed entirely',
 };
 
 export const thinkingCmd: SlashCommand = {
   name: '/thinking',
   aliases: ['/thinking-ui'],
-  usage: '/thinking [summary|live|off]',
+  usage: '/thinking [summary|live|digest|off]',
   summary: 'Toggle how thinking blocks are rendered mid-session',
   hint:
     'Switch thinking display: `live` (streaming preview + summary, default), ' +
-    '`summary` (one-line collapse only), or `off` (hidden). ' +
+    '`summary` (one-line collapse only), `digest` (live preview + persists a capped ' +
+    'reasoning paragraph to scrollback per phase — good for AFK review), or `off` (hidden). ' +
     'This is a display-only toggle — extended thinking still runs; cost and latency are unaffected. ' +
     'Takes effect on the next turn — same semantics as `/model`. ' +
     'Run without args to see the current mode.',
-  flags: ['summary', 'live', 'off'],
+  flags: ['summary', 'live', 'digest', 'off'],
   async handler(ctx, args) {
     const target = args.trim().toLowerCase() as ThinkingUiMode;
 

--- a/src/cli/slash/types.ts
+++ b/src/cli/slash/types.ts
@@ -30,13 +30,16 @@ export type ResumeSwapResult =
  * How the REPL renders the model's extended-thinking blocks:
  * - `'live'` (default) — streaming preview overlay + finalize summary
  * - `'summary'` — collapsed one-line summary on finalize, no live preview
+ * - `'digest'` — streaming preview overlay (like `'live'`) AND, on each phase
+ *   seal, commits a capped reasoning paragraph to scrollback above the finalize
+ *   summary (persists what the model thought, for async / AFK review)
  * - `'off'` — suppressed entirely (no buffer, no overlay, no summary)
  *
  * Canonical definition lives here (neutral slash-layer) to avoid the upward
  * import that would result from placing it in `commands/interactive/shared.ts`.
  * `commands/interactive/shared.ts` re-exports this for backward compat.
  */
-export type ThinkingUiMode = 'summary' | 'live' | 'off';
+export type ThinkingUiMode = 'summary' | 'live' | 'digest' | 'off';
 
 /** A recorded tool invocation within a turn — persisted for post-mortem diagnosis. */
 export interface ToolEvent {


### PR DESCRIPTION
## Summary

Adds a fourth thinking-display mode, **`digest`**, to the interactive REPL (`--thinking-ui digest` / `/thinking digest`). It answers a simple AFK need: *scroll back and see what the agent was actually thinking*, without overloading the transcript.

Today the model's reasoning streams into an **ephemeral** bottom-of-terminal overlay (repainted ~50 Hz, wiped when each phase ends); only a one-line stat `◆ thought for Xs · N tok` is ever committed to scrollback — the reasoning text itself is never persisted. `digest` fixes that.

## Behavior

`digest` = **"live that doesn't collapse."** It streams the live overlay exactly like `live`, and on each thinking→acting phase seal it commits the reasoning paragraph to scrollback (above the stat line) instead of letting the overlay vanish:

```
  ◆ thinking
  <reasoning, capped at 5 lines>
  ⋯ +N chars earlier        ← only when truncated
  ◆ thought for 2.1s · 320 tok
```

- Default stays `live` — `digest` is **opt-in**.
- Short phases render in full; long ones keep the last 5 lines + a `⋯ +N chars earlier` footer (reuses `formatThinkingParagraph`).
- The streamed phase lands in scrollback **verbatim** on seal (`peekPhase` overlay → `drainPhase` commit): clean handoff, no double-show, no gap.

## What changed

- New `'digest'` value on `ThinkingUiMode`, threaded through the renderer plumbing (contexts, orchestrator, lifecycle, subagent, `StreamRenderer` options) and the `/thinking` command + `--thinking-ui` flag.
- Phase seal now renders via a new `renderSealedPhase()`: `digest` prepends the reasoning paragraph, other modes emit the stat line alone. Committed atomically via `commitBlockAbove`.
- The three live-overlay gates (`=== 'live'`) also fire for `digest`, so it streams while thinking.
- Non-TTY `digest` behaves like `summary`; subagents unchanged.

## Design decisions

- **Sanitization, not redaction.** The persisted paragraph is scrubbed through `sanitizeLabel` (ANSI/C0/C1 strip) — a *terminal-integrity* concern, since a stray control byte committed to scrollback would corrupt the render. **No secret redaction:** the scrollback is a *local display* surface (your own machine, your own keys), not an egress boundary. Every `redactSecrets`/`redactInlineSecrets` site in the repo guards egress (Haiku summarizer, Telegram push, telemetry JSONL, witness traces) — tool output is already un-redacted on screen, so thinking-specific redaction would be inconsistent and add false-positive mangling. If share-time protection is ever wanted, it belongs at the copy/export boundary across all scrollback, not here.
- **Opt-in + capped** bounds the "~8 phases/turn" overload concern to consenting users.

## Testing

- `pnpm lint` (tsc --noEmit, strict) — clean.
- Full `pnpm test` — **10796 passed / 0 failed / 14 skipped**.
- New assertions: `digest` streams the live overlay (`stream-renderer-orchestrator.test.ts`), `digest` persists reasoning while `summary` persists only the stat (emit path), and `/thinking digest` mutates mode (`thinking.test.ts`).
