### PR TITLE
fix(retry): patient 429 retry-after handling + surface stopReason on SubagentResult

### DIFF
--- a/src/agent/providers/anthropic-direct/query-auth-retry.test.ts
+++ b/src/agent/providers/anthropic-direct/query-auth-retry.test.ts
@@ -627,6 +627,19 @@ function make400CreditExhaustedError(): Error {
   return err;
 }
 
+/**
+ * Build a transient rate-limit 429: a `retry-after` header and NO `|<unix-ts>`
+ * in the message (rate-limit-transient classification).
+ */
+function make429TransientError(retryAfterSec = 2): Error {
+  const err = new Error('rate_limit_error: Number of requests has exceeded your per-minute rate limit');
+  (err as Error & { status: number }).status = 429;
+  (err as Error & { headers: Record<string, string> }).headers = {
+    'retry-after': String(retryAfterSec),
+  };
+  return err;
+}
+
 describe('AnthropicDirectProvider — turnWithUsageLimitRetry', () => {
   beforeEach(() => {
     messagesCreateMock.mockReset();
@@ -999,6 +1012,98 @@ describe('AnthropicDirectProvider — turnWithUsageLimitRetry', () => {
       callIdx += 1;
       if (callIdx <= 2) throw make429NoTsError();
       return fromArray(makeTextStream('resumed on third attempt'));
+    });
+
+    const provider = new AnthropicDirectProvider();
+    const query = provider.query({
+      prompt: singleInput('hello'),
+      config: { model: 'claude-sonnet-5', apiKey: 'sk-ant-oat01-test', autoResumeOnUsageLimit: true },
+    });
+
+    const collectPromise = collect(query);
+    await vi.runAllTimersAsync();
+    const events = await collectPromise;
+
+    const types = events.map((e) => e.type);
+    expect(events.filter((e) => e.type === 'paused')).toHaveLength(1);
+    expect(events.filter((e) => e.type === 'resumed')).toHaveLength(1);
+    expect(types).toContain('turn.completed');
+    expect(events.filter((e) => e.type === 'error')).toHaveLength(0);
+    expect(messagesCreateMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('rate-limit-transient: 429 + retry-after → silent wait → replay succeeds (no paused, no error)', async () => {
+    // Regression guard: a transient 429 (retry-after header, no |ts) used to
+    // surface as a fatal error the instant the SDK's own retries ran out —
+    // killing headless daemon cron tasks in seconds on account-rate-limit
+    // collisions. The retry layer must now honor retry-after and replay.
+    let callIdx = 0;
+    messagesCreateMock.mockImplementation(() => {
+      callIdx += 1;
+      if (callIdx === 1) throw make429TransientError(2);
+      return fromArray(makeTextStream('recovered after transient 429'));
+    });
+
+    const provider = new AnthropicDirectProvider();
+    const query = provider.query({
+      prompt: singleInput('hello'),
+      config: { model: 'claude-sonnet-5', apiKey: 'sk-ant-oat01-test', autoResumeOnUsageLimit: true },
+    });
+
+    const collectPromise = collect(query);
+    await vi.runAllTimersAsync(); // advance past the retry-after wait + jitter
+    const events = await collectPromise;
+
+    const types = events.map((e) => e.type);
+    // Transient retry is silent — no paused/resumed pair (this is not a
+    // subscription pause), no surfaced error, and the turn completes.
+    expect(types).not.toContain('paused');
+    expect(types).not.toContain('resumed');
+    expect(events.filter((e) => e.type === 'error')).toHaveLength(0);
+    expect(types).toContain('turn.completed');
+    expect(messagesCreateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('rate-limit-transient: budget exhaustion → error surfaces after 3 replays (4 calls total)', async () => {
+    // Every call rate-limits. The layer replays RATE_LIMIT_TRANSIENT_MAX_RETRIES
+    // (3) times, then surfaces the error instead of waiting forever.
+    messagesCreateMock.mockImplementation(() => {
+      throw make429TransientError(1);
+    });
+
+    const provider = new AnthropicDirectProvider();
+    const query = provider.query({
+      prompt: singleInput('hello'),
+      config: { model: 'claude-sonnet-5', apiKey: 'sk-ant-oat01-test', autoResumeOnUsageLimit: true },
+    });
+
+    const collectPromise = collect(query);
+    await vi.runAllTimersAsync();
+    const events = await collectPromise;
+
+    const types = events.map((e) => e.type);
+    expect(types).not.toContain('paused');
+    expect(types).not.toContain('resumed');
+    const errors = events.filter((e) => e.type === 'error');
+    expect(errors).toHaveLength(1);
+    if (errors[0]?.type === 'error') {
+      expect((errors[0].error as Error & { status?: number }).status).toBe(429);
+    }
+    // 1 initial + 3 replays = 4 API calls.
+    expect(messagesCreateMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('rate-limit-transient does not disturb the oauth-limit path: 429+ts after a transient retry still pauses/resumes', async () => {
+    // Interleave the two kinds: call 1 is a transient 429 (retry-after), call 2
+    // is a subscription 429 with |ts, call 3 succeeds. The transient retry
+    // must be silent; the oauth-limit must still produce the paused → resumed
+    // lifecycle exactly as before.
+    let callIdx = 0;
+    messagesCreateMock.mockImplementation(() => {
+      callIdx += 1;
+      if (callIdx === 1) throw make429TransientError(1);
+      if (callIdx === 2) throw make429UsageLimitError(5 * 60 * 1_000);
+      return fromArray(makeTextStream('resumed after oauth limit'));
     });
 
     const provider = new AnthropicDirectProvider();

--- a/src/agent/providers/anthropic-direct/query/retry-layer.ts
+++ b/src/agent/providers/anthropic-direct/query/retry-layer.ts
@@ -40,6 +40,8 @@ import { runTurn } from '../loop.js';
 import { buildRequestHeaders } from '../auth.js';
 import { classifyUsageLimitError, waitForReset, waitForHotSwap } from '../usage-limit.js';
 import { loadClaudeCodeOauthToken, parseAccountIdentifier } from '../../../../cli/keychain.js';
+import { sleepWithAbort } from '../../shared/sleep-with-abort.js';
+import { emitSessionPhase } from '../../../trace/emit.js';
 import type {
   AnthropicClientLike,
   AuthMode,
@@ -47,6 +49,20 @@ import type {
 } from '../types.js';
 
 const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
+
+// Transient rate-limit (429 + retry-after header, no `|ts`) replay budget.
+// The SDK has already auto-retried twice by the time the error surfaces here,
+// but on account-level RPM/ITPM collisions (e.g. several daemon cron sessions
+// firing at once) two quick retries are not enough — the correct behavior is
+// to honor `retry-after` patiently and replay the turn, instead of dying in
+// seconds. Bounded per turn so a persistent limit still surfaces as an error.
+export const RATE_LIMIT_TRANSIENT_MAX_RETRIES = 3;
+/** Cap on a single retry-after wait — a server hint beyond this surfaces the error path sooner. */
+export const RATE_LIMIT_RETRY_MAX_WAIT_MS = 120_000;
+/** Fallback wait when the classification carries no usable `retryAfterMs`. */
+const RATE_LIMIT_RETRY_DEFAULT_WAIT_MS = 5_000;
+/** Small random jitter added to each wait so concurrent sessions de-synchronize. */
+const RATE_LIMIT_RETRY_JITTER_MS = 1_000;
 
 // Invariant: a 429 with no reset timestamp gives no deadline to wait on, so the
 // no-ts path poll-retries the turn on this fixed cadence to probe whether the
@@ -194,6 +210,11 @@ export class RetryLayer {
    *     (and wake immediately on a hot-swap) until the limit lifts, the user
    *     aborts, or the 2h cap is hit. Stays in the `paused` state across failed
    *     probes and emits `resumed` only once the limit genuinely lifts.
+   *
+   * Additionally handles `rate-limit-transient` (429 + `retry-after` header,
+   * no `|ts`): wait out the server's backoff hint (clamped + jittered) and
+   * silently replay the turn, up to {@link RATE_LIMIT_TRANSIENT_MAX_RETRIES}
+   * attempts per turn, after which the error surfaces as before.
    */
   private async *turnWithUsageLimitRetry(
     runInput: RunTurnInput,
@@ -202,28 +223,85 @@ export class RetryLayer {
     let pendingErrorEvent: ProviderEvent | null = null;
     let resetsAt: Date | null = null;
     let noTimestamp = false;
+    // Per-turn transient 429 replay budget. Local to this generator, so each
+    // user turn gets a fresh RATE_LIMIT_TRANSIENT_MAX_RETRIES attempts.
+    let rateLimitRetries = 0;
 
-    for await (const event of this.turnWithAuthRetry(runInput, isClosed)) {
-      if (event.type === 'error') {
-        const c = classifyUsageLimitError(event.error);
-        if (c && c.kind === 'oauth-limit') {
-          resetsAt = c.resetsAt;
-          pendingErrorEvent = event;
-          break;
+    for (;;) {
+      let transientRetryAfterMs: number | undefined;
+      let sawTransient = false;
+
+      for await (const event of this.turnWithAuthRetry(runInput, isClosed)) {
+        if (event.type === 'error') {
+          const c = classifyUsageLimitError(event.error);
+          if (c && c.kind === 'oauth-limit') {
+            resetsAt = c.resetsAt;
+            pendingErrorEvent = event;
+            break;
+          }
+          if (c && c.kind === 'oauth-limit-no-ts') {
+            noTimestamp = true;
+            pendingErrorEvent = event;
+            break;
+          }
+          // `rate-limit-transient` (a standard API rate-limit 429, distinct
+          // from OAuth subscription exhaustion) does NOT enter the pause/
+          // wait paths below. The SDK has already auto-retried it twice, but
+          // on account-level RPM/ITPM collisions (several daemon sessions
+          // firing at once) that is not enough: honor `retry-after` here and
+          // replay the turn, bounded at RATE_LIMIT_TRANSIENT_MAX_RETRIES per
+          // turn. Once the budget is exhausted this branch stops matching
+          // and the error surfaces via `yield event` below — never parked in
+          // a 2-hour subscription-reset poll. See classifyUsageLimitError.
+          if (
+            c &&
+            c.kind === 'rate-limit-transient' &&
+            rateLimitRetries < RATE_LIMIT_TRANSIENT_MAX_RETRIES
+          ) {
+            sawTransient = true;
+            transientRetryAfterMs = c.retryAfterMs;
+            break;
+          }
         }
-        if (c && c.kind === 'oauth-limit-no-ts') {
-          noTimestamp = true;
-          pendingErrorEvent = event;
-          break;
-        }
-        // `rate-limit-transient` (a standard API rate-limit 429, distinct from
-        // OAuth subscription exhaustion) intentionally does NOT break into the
-        // wait/pause path below. The SDK has already auto-retried it honoring
-        // `retry-after`; a still-failing 429 here is surfaced as an error via
-        // the `yield event` below rather than parked in a 2-hour
-        // subscription-reset poll. See classifyUsageLimitError.
+        yield event;
       }
-      yield event;
+
+      if (!sawTransient) break;
+
+      rateLimitRetries += 1;
+      if (isClosed() || runInput.signal.aborted) return;
+
+      // Honor the server's backoff hint, clamped so a pathological header
+      // cannot park the turn indefinitely; add jitter so concurrent sessions
+      // hitting the same account limit de-synchronize their replays.
+      const baseWaitMs = Math.min(
+        transientRetryAfterMs ?? RATE_LIMIT_RETRY_DEFAULT_WAIT_MS,
+        RATE_LIMIT_RETRY_MAX_WAIT_MS,
+      );
+      const waitMs = baseWaitMs + Math.floor(Math.random() * RATE_LIMIT_RETRY_JITTER_MS);
+      // Witness layer: record the backoff so the replayed round is legible in
+      // the trace (mirrors loop.ts's mid-stream overload phase). Fire-and-
+      // forget; trace latency must never stall the retry.
+      void emitSessionPhase(runInput.traceWriter, {
+        phase: 'rate_limit',
+        metadata: {
+          reason: 'retry-after',
+          source: 'retry-layer',
+          attempt: rateLimitRetries,
+          waitMs,
+        },
+      });
+      await sleepWithAbort(waitMs, runInput.signal);
+      if (isClosed() || runInput.signal.aborted) return;
+
+      // Rotate the request id before replaying (mirrors the oauth-limit
+      // resume paths). Same client, same token — only the headers refresh.
+      runInput.headers = buildRequestHeaders(
+        this._authMode,
+        this.initSessionId,
+        randomUUID(),
+      );
+      // Loop: replay the turn.
     }
 
     if (!pendingErrorEvent) {

--- a/src/agent/subagent/handle-streaming.test.ts
+++ b/src/agent/subagent/handle-streaming.test.ts
@@ -258,6 +258,66 @@ describe('SubagentHandle streaming', () => {
       expect(handle.status).toBe('succeeded');
     });
 
+    it('surfaces stopReason=tool_use_loop_capped on the SubagentResult for a capped run', async () => {
+      // Callers of runToResult must be able to distinguish a capped partial
+      // (synthetic marker message) from a genuine answer without substring-
+      // matching the message content — SubagentResult.stopReason carries the
+      // provider's terminal stop reason for exactly this purpose.
+      const events: OutputEvent[] = [
+        { type: 'done', metadata: { stopReason: 'tool_use_loop_capped' } },
+      ];
+      const session = createDeterministicMockSession(events, {
+        role: 'assistant',
+        content: 'unused',
+        timestamp: new Date(),
+      });
+      const handle = new SubagentHandleImpl(
+        'subagent-capped-result-test',
+        session,
+        controller,
+        abortGraph,
+        undefined,
+        5000,
+        undefined,
+        vi.fn(),
+      );
+
+      const result = await handle.runToResult('p');
+      expect(result.status).toBe('succeeded');
+      expect(result.stopReason).toBe('tool_use_loop_capped');
+      expect(String(result.message?.content)).toMatch(/capped/i);
+    });
+
+    it('surfaces a normal stopReason (end_turn) on the SubagentResult', async () => {
+      const events: OutputEvent[] = [
+        { type: 'chunk', chunk: { type: 'content', content: 'real answer' } },
+        {
+          type: 'message',
+          message: { role: 'assistant', content: 'real answer', timestamp: new Date() },
+        },
+        { type: 'done', metadata: { stopReason: 'end_turn' } },
+      ];
+      const session = createDeterministicMockSession(events, {
+        role: 'assistant',
+        content: 'real answer',
+        timestamp: new Date(),
+      });
+      const handle = new SubagentHandleImpl(
+        'subagent-stop-reason-test',
+        session,
+        controller,
+        abortGraph,
+        undefined,
+        5000,
+        undefined,
+        vi.fn(),
+      );
+
+      const result = await handle.runToResult('p');
+      expect(result.status).toBe('succeeded');
+      expect(result.stopReason).toBe('end_turn');
+    });
+
     it('throws error event even when partial streamed content exists', async () => {
       const streamError = new Error('upstream stream failure');
       const events: OutputEvent[] = [

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -128,7 +128,9 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
    * `done` event (e.g. `'end_turn'`, `'tool_use_loop_capped'`). Persisted as
    * an instance field so `runToResult` can attach it to the built
    * {@link SubagentResult}, letting callers distinguish a capped partial from
-   * a genuine completion. Reset at the start of each run.
+   * a genuine completion. Reset at the start of `run()` (before the
+   * `cancelled` short-circuit) so a re-invoked or cancelled handle never
+   * surfaces a prior run's stop reason on the error result.
    */
   private lastStopReason: string | undefined;
 
@@ -169,6 +171,13 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
 
   async run(prompt: string, sinkOverride?: SubagentProgressSink): Promise<Message> {
     if (this.currentStatus === 'running') throw new Error(`Subagent ${this.id} is already running`);
+    // Invariant: reset the captured stop reason here — after the `running`
+    // guard, before the `cancelled` short-circuit — so a re-invoked or
+    // cancelled handle never surfaces a PRIOR run's stopReason on the error
+    // result built by `runToResult`'s catch. Past the `running` guard
+    // `currentStatus` is never `running` (and there is no `await` before it is
+    // set below), so no in-flight run owns this value for us to clobber.
+    this.lastStopReason = undefined;
     if (this.currentStatus === 'cancelled') throw new Error(`Subagent ${this.id} is cancelled`);
 
     this.currentStatus = 'running';
@@ -270,7 +279,6 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     // throw boundary is the whole point — the local `streamedContent` of the
     // previous version got dropped on the floor when the iterator threw.
     this.lastStreamedContent = '';
-    this.lastStopReason = undefined;
     this.currentTrace = createEmptyTrace();
 
     const activeSink = sinkOverride ?? this.progressSink ?? getCurrentSink();

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -123,6 +123,14 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
    * managed to produce instead of just the error.
    */
   private lastStreamedContent: string = '';
+  /**
+   * The provider's terminal stop reason captured from the most recent run's
+   * `done` event (e.g. `'end_turn'`, `'tool_use_loop_capped'`). Persisted as
+   * an instance field so `runToResult` can attach it to the built
+   * {@link SubagentResult}, letting callers distinguish a capped partial from
+   * a genuine completion. Reset at the start of each run.
+   */
+  private lastStopReason: string | undefined;
 
   /** @internal — positional argument order is not part of any public contract. */
   constructor(
@@ -257,12 +265,12 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
   ): Promise<Message> {
     let finalMessage: Message | undefined;
     let streamError: Error | undefined;
-    let stopReason: string | undefined;
 
     // Reset partial-content accumulator before each run. Surviving across the
     // throw boundary is the whole point — the local `streamedContent` of the
     // previous version got dropped on the floor when the iterator threw.
     this.lastStreamedContent = '';
+    this.lastStopReason = undefined;
     this.currentTrace = createEmptyTrace();
 
     const activeSink = sinkOverride ?? this.progressSink ?? getCurrentSink();
@@ -314,9 +322,10 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
       } else if (event.type === 'done') {
         // Capture the turn's stop reason so the post-loop fallback can tell a
         // tool-use-cap termination (which yields a `done` with no assistant
-        // message) apart from a genuinely empty stream.
+        // message) apart from a genuinely empty stream — and so `runToResult`
+        // can surface it on the SubagentResult (persisted on the handle).
         if (typeof event.metadata?.stopReason === 'string') {
-          stopReason = event.metadata.stopReason;
+          this.lastStopReason = event.metadata.stopReason;
         }
         if (typeof event.metadata?.usage === 'object' && event.metadata.usage !== null) {
           const u = event.metadata.usage as Record<string, unknown>;
@@ -344,7 +353,7 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     // `runToResult` reports a capped *partial* result (status 'succeeded')
     // rather than an opaque subagent failure — the behavior the cap default
     // already documents.
-    if (stopReason === 'tool_use_loop_capped') {
+    if (this.lastStopReason === 'tool_use_loop_capped') {
       return {
         role: 'assistant',
         content:
@@ -359,9 +368,22 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
   async runToResult(prompt: string, sinkOverride?: SubagentProgressSink): Promise<SubagentResult<T>> {
     try {
       const message = await this.run(prompt, sinkOverride);
-      return buildResultFromMessage(this.id, this.currentStatus, message, this.outputSchema, this.currentTrace);
+      return buildResultFromMessage(
+        this.id,
+        this.currentStatus,
+        message,
+        this.outputSchema,
+        this.currentTrace,
+        this.lastStopReason,
+      );
     } catch (err) {
-      const result = buildResultFromError<T>(this.id, this.currentStatus, err, this.currentTrace);
+      const result = buildResultFromError<T>(
+        this.id,
+        this.currentStatus,
+        err,
+        this.currentTrace,
+        this.lastStopReason,
+      );
       // Preserve any assistant text streamed before the failure so the parent
       // receives partial findings rather than just an opaque error. The
       // raw string fragment is the best we have when a structured parse

--- a/src/agent/subagent/result.test.ts
+++ b/src/agent/subagent/result.test.ts
@@ -116,3 +116,37 @@ describe('buildResultFromMessage — signal wiring', () => {
     });
   });
 });
+
+describe('buildResultFromMessage — stopReason wiring', () => {
+  it('attaches stopReason when provided (no outputSchema)', () => {
+    const result = buildResultFromMessage(
+      'h',
+      'succeeded',
+      makeMessage('capped partial'),
+      undefined,
+      undefined,
+      'tool_use_loop_capped',
+    );
+    expect(result.stopReason).toBe('tool_use_loop_capped');
+  });
+
+  it('leaves stopReason absent when not provided', () => {
+    const result = buildResultFromMessage('i', 'succeeded', makeMessage('done'), undefined);
+    expect(result.stopReason).toBeUndefined();
+    expect('stopReason' in result).toBe(false);
+  });
+
+  it('carries stopReason through the schema-failure path', () => {
+    const OutputSchema = z.object({ answer: z.string() });
+    const result = buildResultFromMessage(
+      'j',
+      'succeeded',
+      makeMessage(fenced({ wrong_key: 42 })),
+      OutputSchema,
+      undefined,
+      'end_turn',
+    );
+    expect(result.status).toBe('failed');
+    expect(result.stopReason).toBe('end_turn');
+  });
+});

--- a/src/agent/subagent/result.ts
+++ b/src/agent/subagent/result.ts
@@ -101,6 +101,16 @@ export interface SubagentResult<T = unknown> {
    * message contained a valid SIGNAL block; absent otherwise.
    */
   signal?: Signal;
+  /**
+   * The provider's terminal stop reason for the subagent's final turn, when
+   * known (e.g. `'end_turn'`, `'max_tokens'`). In particular,
+   * `'tool_use_loop_capped'` means the tool-use iteration cap fired before the
+   * child produced a final message — `message` may then be a synthetic
+   * capped-partial marker rather than a real answer, so callers can use this
+   * field to distinguish a capped partial from a genuine completion. Absent
+   * when the provider reported no stop reason.
+   */
+  stopReason?: string;
 }
 
 /**
@@ -113,18 +123,34 @@ export function buildResultFromMessage<T>(
   message: Message,
   outputSchema: ZodType<T> | undefined,
   trace?: SubagentTrace,
+  stopReason?: string,
 ): SubagentResult<T> {
   const sig = parseSignal(message.content);
   const signal = sig.ok ? sig.signal : undefined;
 
   if (!outputSchema) {
-    return { id, status, message, trace, ...(signal !== undefined && { signal }) };
+    return {
+      id,
+      status,
+      message,
+      trace,
+      ...(signal !== undefined && { signal }),
+      ...(stopReason !== undefined && { stopReason }),
+    };
   }
 
   const candidate = extractStructuredOutput(message.content);
   const parsed = outputSchema.safeParse(candidate);
   if (parsed.success) {
-    return { id, status, message, output: parsed.data, trace, ...(signal !== undefined && { signal }) };
+    return {
+      id,
+      status,
+      message,
+      output: parsed.data,
+      trace,
+      ...(signal !== undefined && { signal }),
+      ...(stopReason !== undefined && { stopReason }),
+    };
   }
 
   return {
@@ -137,6 +163,7 @@ export function buildResultFromMessage<T>(
     schemaError: parsed.error,
     trace,
     ...(signal !== undefined && { signal }),
+    ...(stopReason !== undefined && { stopReason }),
   };
 }
 
@@ -148,9 +175,10 @@ export function buildResultFromError<T>(
   status: SubagentStatus,
   err: unknown,
   trace?: SubagentTrace,
+  stopReason?: string,
 ): SubagentResult<T> {
   const error = err instanceof Error ? err : new Error(String(err));
-  return { id, status, error, trace };
+  return { id, status, error, trace, ...(stopReason !== undefined && { stopReason }) };
 }
 
 /**


### PR DESCRIPTION
## Problem

Two related failure modes diagnosed from production telemetry (2026-07-05):

1. **Transient 429s kill headless sessions in seconds.** `turnWithUsageLimitRetry` handles OAuth-subscription 429s (pause/replay), but a `rate-limit-transient` 429 (retry-after header, no `|ts`) deliberately falls through as fatal once the SDK's two internal retries run out. On account-level rate-limit collisions (hourly daemon cron firing at :00 during interactive subagent fan-outs), cron tasks died in ~3.4s with `429 rate_limit_error`.

2. **Callers cannot distinguish a capped partial from a real answer.** `handle.ts` tracks the provider `stopReason` and synthesizes a `[... capped partial result]` message on `tool_use_loop_capped`, but `SubagentResult` never carried the stop reason — so orchestrators (e.g. forge's qualify loop) mechanically misread budget exhaustion as a substantive answer (observed: capped qualify runs scored as REJECT verdicts).

## Changes

**Commit 1 — fix(retry):** `rate-limit-transient` 429s now wait out the server's `retry-after` hint (clamped at 120s, plus 0-1s jitter to de-synchronize concurrent sessions) and silently replay the turn, up to 3 attempts per turn. Budget exhausted -> error surfaces exactly as before. Respects `isClosed()`/abort via `sleepWithAbort`; each backoff recorded as a `rate_limit` session phase (mirrors loop.ts's mid-stream overload trace). Unconditional — honoring retry-after is correct on every surface. OAuth-limit paths untouched.

**Commit 2 — feat(subagent):** optional `stopReason?: string` on `SubagentResult`, threaded from the provider's `done` event through `buildResultFromMessage`/`buildResultFromError`. `tool_use_loop_capped` now lets callers branch on capped partials instead of parsing the marker string.

## Verification

- `tsc --noEmit` clean
- `vitest run src/agent/providers/anthropic-direct/`: 357/357 pass (3 new: silent replay success, budget exhaustion, oauth-limit interleave unchanged)
- `vitest run src/agent/subagent/`: 48/48 pass (5 new stopReason assertions incl. capped -> `tool_use_loop_capped`)
- SubagentResult consumers: background-registry + subagent-executor tests 132/132 pass

Diagnosis chain (session evidence): keychain-shared rate budget confirmed via credential-resolver; 529/503-only predicates in loop.ts confirmed; SDK default `maxRetries: 2` confirmed (no override in `buildClientOptions`); forge REJECT-fallback confirmed in the plugin verdict parser (companion fix in the plugin repo).
