### PR TITLE
fix(worktree): reject flag-like base refs

### DIFF
--- a/src/agent/tools/handlers/worktree.test.ts
+++ b/src/agent/tools/handlers/worktree.test.ts
@@ -150,6 +150,19 @@ describe('worktree handler — create', () => {
     const result = await handler({ action: 'create', name: '///' }, SIGNAL);
     expect(result.isError).toBe(true);
   });
+
+  it('rejects a flag-like base ref before git worktree add', async () => {
+    const mock = makeMock(standardResponder(block(repoRoot)));
+    const handler = createWorktreeHandler(repoRoot, { execFile: mock });
+    const result = await handler(
+      { action: 'create', name: 'safe-name', base: '--upload-pack=evil' },
+      SIGNAL,
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('base must be a git ref');
+    expect(mock.calls.some((c) => c.args.includes('add'))).toBe(false);
+  });
 });
 
 describe('worktree handler — keep / release', () => {

--- a/src/agent/tools/handlers/worktree.ts
+++ b/src/agent/tools/handlers/worktree.ts
@@ -72,6 +72,19 @@ function sanitizeSlug(name: string): string {
     .slice(0, 80);
 }
 
+function resolveCreateBaseRef(base: unknown): string | { error: string } {
+  if (base === undefined || base === null || base === '') {
+    return 'HEAD';
+  }
+  if (typeof base !== 'string') {
+    return { error: 'Invalid input: base must be a string when provided' };
+  }
+  if (base.startsWith('-')) {
+    return { error: 'Invalid input: base must be a git ref, not an option' };
+  }
+  return base;
+}
+
 /** True when `child` is `parent` or nested inside it. */
 function isPathWithin(child: string, parent: string): boolean {
   const c = resolve(child);
@@ -226,7 +239,10 @@ export function createWorktreeHandler(
           }
           const prefix = env.AFK_WORKTREE_BRANCH_PREFIX ?? 'afk/';
           const branch = `${prefix}${slug}`;
-          const baseRef = typeof obj['base'] === 'string' && obj['base'] ? obj['base'] : 'HEAD';
+          const baseRef = resolveCreateBaseRef(obj['base']);
+          if (typeof baseRef !== 'string') {
+            return { content: baseRef.error, isError: true };
+          }
           await execFile('git', [
             '-C', ctx.repoRoot, 'worktree', 'add', '-b', branch, worktreePath, baseRef,
           ]);


### PR DESCRIPTION
Fixes #395.

This rejects `worktree.create` base values that start with `-` before they reach `git worktree add` or the later `rev-parse` call. Missing or empty base still defaults to `HEAD`.

Checked:
- pnpm vitest run src/agent/tools/handlers/worktree.test.ts
- pnpm lint