### PR TITLE
fix(worktree-sweep): require commits ahead for stale-clean

### DIFF
--- a/src/agent/worktree-sweep.test.ts
+++ b/src/agent/worktree-sweep.test.ts
@@ -324,6 +324,54 @@ describe('stale-clean-preserves-worktree', () => {
     );
     expect(branchDeleteCalls).toHaveLength(0);
   });
+
+  it('does not classify fresh zero-ahead clean worktrees as stale-clean when clean threshold is zero', async () => {
+    const worktreePath = join(afkWorktreesDir, 'afk-fresh-zero-ahead');
+    await fs.mkdir(worktreePath, { recursive: true });
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({
+        owner: 'interactive',
+        createdAt: new Date(Date.now() - 60_000).toISOString(),
+        baseSha: 'base123',
+      }),
+    );
+
+    const mainBlock = worktreeBlock({ path: repoRoot, head: 'base123' });
+    const wtBlock = worktreeBlock({
+      path: worktreePath,
+      head: 'base123',
+      branch: 'refs/heads/afk/fresh-zero-ahead',
+    });
+    const porcelainOut = `${mainBlock}\n\n${wtBlock}\n`;
+
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: porcelainOut, stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' };
+      }
+      if (args.includes('rev-list') && args.includes('--count')) {
+        return { stdout: '0\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      maxAgeDaysClean: 0,
+      telemetryPath: telemetryFile,
+    });
+
+    const candidate = result.candidates.find((c) => c.path === worktreePath);
+    expect(candidate?.verdict).toBe('active');
+    expect(result.removed).not.toContain(worktreePath);
+    expect(result.warnings.some((w) => w.includes('stale-clean'))).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/worktree-sweep.ts
+++ b/src/agent/worktree-sweep.ts
@@ -293,8 +293,15 @@ function classifyCandidate(
   // Has dirty working tree past dirty threshold
   if (candidate.isDirty && candidate.ageMs > dirtyThresholdMs) return 'stale-dirty';
 
-  // Clean (committed work, no dirty files) past clean threshold
-  if (!candidate.isDirty && candidate.ageMs > cleanThresholdMs) return 'stale-clean';
+  // Clean committed work past clean threshold. Clean zero-ahead worktrees are
+  // handled by `empty` once old enough; before then they stay active.
+  if (
+    !candidate.isDirty &&
+    candidate.commitsAhead > 0 &&
+    candidate.ageMs > cleanThresholdMs
+  ) {
+    return 'stale-clean';
+  }
 
   return 'active';
 }


### PR DESCRIPTION
Fixes #397.

This makes `stale-clean` require commits ahead of base directly, so clean zero-ahead worktrees do not hit that warning path when the clean threshold is set very low.

Checked:
- pnpm vitest run src/agent/worktree-sweep.test.ts
- pnpm lint