### PR TITLE
fix(worktree): warn on stale-clean in slash list

### DIFF
--- a/src/cli/slash/commands/worktree.test.ts
+++ b/src/cli/slash/commands/worktree.test.ts
@@ -140,6 +140,27 @@ describe('/worktree slash command', () => {
     expect(rowsForThis.every((l) => !l.includes('→'))).toBe(true);
   });
 
+  it('list renders stale-clean as a warning', async () => {
+    const wtPath = join(tmpRoot, 'wt-stale-clean');
+    await fs.mkdir(wtPath, { recursive: true });
+
+    mockRunSweep.mockResolvedValue({
+      candidates: [{ path: wtPath, verdict: 'stale-clean', owner: 'interactive', ageMs: 99_000_000 }],
+      removed: [],
+      warnings: [],
+      dryRun: true,
+    });
+
+    const { ctx, lines } = makeCtx();
+    await worktreeCmd.handler(ctx, 'list');
+
+    const tail = wtPath.slice(-44);
+    const row = lines.find((l) => l.includes(tail.slice(-20)));
+    expect(row).toContain('stale-clean');
+    expect(row).toContain('warn');
+    expect(row).not.toContain('no');
+  });
+
   it('prune without --apply runs as dry-run', async () => {
     mockRunSweep.mockResolvedValue({
       candidates: [

--- a/src/cli/slash/commands/worktree.ts
+++ b/src/cli/slash/commands/worktree.ts
@@ -43,6 +43,11 @@ const PRUNABLE_VERDICTS = new Set([
   'dead-owner',
 ]);
 
+const WARNING_VERDICTS = new Set([
+  'stale-clean',
+  'stale-dirty',
+]);
+
 async function resolveRepoRoot(): Promise<string> {
   const result = await execFile('git', ['rev-parse', '--git-common-dir']);
   const raw = result.stdout.trim();
@@ -63,7 +68,7 @@ function formatAge(ageMs: number): string {
 
 function verdictColor(verdict: string, text: string): string {
   if (PRUNABLE_VERDICTS.has(verdict)) return palette.error(text);
-  if (verdict === 'stale-dirty') return palette.warning(text);
+  if (WARNING_VERDICTS.has(verdict)) return palette.warning(text);
   if (verdict === 'locked') return palette.dim(text);
   return palette.dim(text);
 }
@@ -166,7 +171,7 @@ async function renderList(
     const verdict = c.verdict.padEnd(22);
     const wouldPrune = PRUNABLE_VERDICTS.has(c.verdict)
       ? palette.error('yes')
-      : c.verdict === 'stale-dirty'
+      : WARNING_VERDICTS.has(c.verdict)
         ? palette.warning('warn')
         : palette.dim('no');
     const verdictColored = verdictColor(c.verdict, verdict);


### PR DESCRIPTION
Fixes #396.

Makes `/worktree list` show `stale-clean` as `warn`, matching the CLI worktree list output.

Tested with `pnpm vitest run src/cli/slash/commands/worktree.test.ts` and `pnpm lint`.