### PR TITLE
fix(mint): resolve subagent credential per child model, not ambient (#378)

### DIFF
--- a/src/skills/mint/_phases/build.ts
+++ b/src/skills/mint/_phases/build.ts
@@ -6,7 +6,7 @@
 import { z } from 'zod';
 import { SubagentManager } from '../../../agent/subagent.js';
 import { describeFailure } from '../../../agent/subagent/result.js';
-import { getApiKey } from '../../../cli/shared-helpers.js';
+import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { AgentModelInput } from '../../../agent/types.js';
 import { emitCard } from '../../_lib/emit-card.js';
@@ -55,7 +55,7 @@ export async function runBuildPhase(
     config: {
       model: defaultSubagentModel,
       systemPrompt: buildPrompt,
-      apiKey: getApiKey(),
+      apiKey: resolveCredentialForModel(defaultSubagentModel),
     },
     idPrefix: 'mint-build',
     agentType: 'mint-build',

--- a/src/skills/mint/_phases/heal.ts
+++ b/src/skills/mint/_phases/heal.ts
@@ -8,7 +8,7 @@ import { getSkill } from '../../index.js';
 import type { AgentModelInput, IAgentSession } from '../../../agent/types.js';
 import { SubagentManager } from '../../../agent/subagent.js';
 import { describeFailure } from '../../../agent/subagent/result.js';
-import { getApiKey } from '../../../cli/shared-helpers.js';
+import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { VerifyResult } from './verify.js';
 import type { BuildResult } from './build.js';
@@ -103,7 +103,7 @@ export async function runHealPhase(
       config: {
         model: defaultSubagentModel,
         systemPrompt: healPrompt,
-        apiKey: getApiKey(),
+        apiKey: resolveCredentialForModel(defaultSubagentModel),
       },
       idPrefix: 'mint-heal',
       agentType: 'mint-heal',

--- a/src/skills/mint/_phases/plan.ts
+++ b/src/skills/mint/_phases/plan.ts
@@ -5,7 +5,7 @@
 
 import { SubagentManager } from '../../../agent/subagent.js';
 import { describeFailure } from '../../../agent/subagent/result.js';
-import { getApiKey } from '../../../cli/shared-helpers.js';
+import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { AgentModelInput } from '../../../agent/types.js';
 
@@ -35,7 +35,7 @@ export async function runPlanPhase(
     config: {
       model: defaultSubagentModel,
       systemPrompt: planPrompt,
-      apiKey: getApiKey(),
+      apiKey: resolveCredentialForModel(defaultSubagentModel),
     },
     idPrefix: 'mint-plan',
     agentType: 'mint-plan',

--- a/src/skills/mint/_phases/research.ts
+++ b/src/skills/mint/_phases/research.ts
@@ -5,7 +5,7 @@
 
 import { SubagentManager } from '../../../agent/subagent.js';
 import { describeFailure } from '../../../agent/subagent/result.js';
-import { getApiKey } from '../../../cli/shared-helpers.js';
+import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { AgentModelInput } from '../../../agent/types.js';
 
@@ -35,7 +35,7 @@ export async function runResearchPhase(
     config: {
       model: defaultSubagentModel,
       systemPrompt: researchPrompt,
-      apiKey: getApiKey(),
+      apiKey: resolveCredentialForModel(defaultSubagentModel),
     },
     idPrefix: 'mint-research',
     agentType: 'mint-research',

--- a/src/skills/mint/_phases/ship.ts
+++ b/src/skills/mint/_phases/ship.ts
@@ -5,7 +5,7 @@
 
 import { SubagentManager } from '../../../agent/subagent.js';
 import { describeFailure } from '../../../agent/subagent/result.js';
-import { getApiKey } from '../../../cli/shared-helpers.js';
+import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { AgentModelInput } from '../../../agent/types.js';
 import { emitCard } from '../../_lib/emit-card.js';
@@ -37,7 +37,7 @@ export async function runShipPhase(
     config: {
       model: defaultSubagentModel,
       systemPrompt: shipPrompt,
-      apiKey: getApiKey(),
+      apiKey: resolveCredentialForModel(defaultSubagentModel),
     },
     idPrefix: 'mint-ship',
     agentType: 'mint-ship',

--- a/src/skills/mint/_phases/spec.ts
+++ b/src/skills/mint/_phases/spec.ts
@@ -5,7 +5,7 @@
 
 import { SubagentManager } from '../../../agent/subagent.js';
 import { describeFailure } from '../../../agent/subagent/result.js';
-import { getApiKey } from '../../../cli/shared-helpers.js';
+import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { AgentModelInput } from '../../../agent/types.js';
 
@@ -37,7 +37,7 @@ export async function runSpecPhase(
     config: {
       model: defaultSubagentModel,
       systemPrompt: specPrompt,
-      apiKey: getApiKey(),
+      apiKey: resolveCredentialForModel(defaultSubagentModel),
     },
     idPrefix: 'mint-spec',
     agentType: 'mint-spec',

--- a/src/skills/mint/_phases/verify.ts
+++ b/src/skills/mint/_phases/verify.ts
@@ -6,7 +6,7 @@
 import { z } from 'zod';
 import { SubagentManager } from '../../../agent/subagent.js';
 import { describeFailure } from '../../../agent/subagent/result.js';
-import { getApiKey } from '../../../cli/shared-helpers.js';
+import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import { emitCard } from '../../_lib/emit-card.js';
 import type { BuildResult } from './build.js';
@@ -48,7 +48,7 @@ async function forkVerifyMode(
     config: {
       model: defaultSubagentModel,
       systemPrompt: verifyPrompt,
-      apiKey: getApiKey(),
+      apiKey: resolveCredentialForModel(defaultSubagentModel),
     },
     idPrefix: `mint-verify-${mode}`,
     agentType: `mint-verify-${mode}`,


### PR DESCRIPTION
## Problem
Seven `mint` phase modules forked subagents with an explicit `apiKey: getApiKey()` paired with `model: defaultSubagentModel`. `getApiKey()` resolves the credential for the **ambient** top-level model (`AFK_MODEL`/`CLAUDE_MODEL`), not for the model the child actually runs. When the two route to different providers (e.g. an OpenAI top-level operator forking a `sonnet` subagent), the wrong provider's key is sent to the child's endpoint — an OpenAI `sk-proj-…` key shipped as a Bearer to `api.anthropic.com` → 401 + cross-provider credential exposure.

## Fix
Replace `apiKey: getApiKey()` with `apiKey: resolveCredentialForModel(defaultSubagentModel)` (the canonical per-model resolver in `src/agent/auth/credential-resolver.ts`, which gates on `providerForModel(model)`) at all 7 sites: `spec.ts`, `plan.ts`, `research.ts`, `build.ts`, `ship.ts`, `verify.ts`, `heal.ts`. The now-unused `getApiKey` import is removed from each file.

## Verification
- `pnpm lint` clean (noUnusedLocals would catch a stray import); `src/skills/mint` 67/67 tests pass.
- No bespoke regression test added — asserting per-model credential selection needs env + provider-routing mocking with no clean seam today. Flagging a focused test as a follow-up.

Closes #378