### PR TITLE
fix(nudge): stop shadow-verify nudge self-triggering on verifier verdict output (#355)

### DIFF
--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -7,7 +7,7 @@
  */
 
 import { createHookRegistry, type HookRegistry } from './hooks.js';
-import { shadowVerifyNudge } from './shadow-verify-nudge.js';
+import { createShadowVerifyNudge } from './shadow-verify-nudge.js';
 import { MemoryStore, createMemorySessionEndHook } from './memory/index.js';
 import { createPlanModeGate } from './plan-mode-gate.js';
 import { createAfkModeGate } from './afk-mode-gate.js';
@@ -84,7 +84,12 @@ export function createDefaultHookRegistry(
   getCwd?: () => string | undefined,
 ): DefaultHookRegistryResult {
   const registry = createHookRegistry();
+  // Session-scoped instance: the nudge latches once-per-turn (reset on 'Stop')
+  // and once-per-child, so a parallel verifier wave can't spam the parent with
+  // identical nudges across consecutive turns (#355).
+  const shadowVerifyNudge = createShadowVerifyNudge();
   registry.register('SubagentStop', shadowVerifyNudge);
+  registry.register('Stop', shadowVerifyNudge);
   const store = memoryStore ?? new MemoryStore();
   if (getPermissionMode !== undefined) {
     registry.register('PreToolUse', createPlanModeGate(getPermissionMode));

--- a/src/agent/shadow-verify-nudge.test.ts
+++ b/src/agent/shadow-verify-nudge.test.ts
@@ -9,12 +9,16 @@
  */
 import { describe, expect, it } from 'vitest';
 import type { SubagentStopContext } from './hooks.js';
-import { shadowVerifyNudge } from './shadow-verify-nudge.js';
+import { createShadowVerifyNudge, shadowVerifyNudge } from './shadow-verify-nudge.js';
 
-function stopCtx(lastMessage: string | undefined, agentType?: string): SubagentStopContext {
+function stopCtx(
+  lastMessage: string | undefined,
+  agentType?: string,
+  subagentId = 'test-id',
+): SubagentStopContext {
   return {
     event: 'SubagentStop',
-    subagentId: 'test-id',
+    subagentId,
     status: 'succeeded',
     lastMessage,
     agentType,
@@ -116,5 +120,81 @@ describe('shadowVerifyNudge', () => {
       'lorem ipsum '.repeat(60);
     const result = shadowVerifyNudge(stopCtx(output, 'research'));
     expect(result.injectContext).toBeDefined();
+  });
+
+  // --- #355 regression guards: self-trigger on verifier output ---
+
+  it('returns {} for verdict-table verifier output (CONFIRMED/REFUTED rows)', () => {
+    const verdictTable =
+      'Verification wave complete. Verdict table:\n\n' +
+      '| Claim | Result | Evidence |\n' +
+      '|-------|--------|----------|\n' +
+      '| The sweep never deletes branches | CONFIRMED | worktree-sweep.ts:607 |\n' +
+      '| The failure is swallowed silently | CONFIRMED | .catch(() => {}) at :618 |\n' +
+      '| 210 branches are orphaned fallout | REFUTED | some predate the sweep |\n\n' +
+      'Recommend acting only on the confirmed claims. ' +
+      'lorem ipsum '.repeat(40);
+    expect(shadowVerifyNudge(stopCtx(verdictTable, 'sv-claim1'))).toEqual({});
+  });
+
+  it('returns {} for a | Claim | table header even without repeated verdict tokens', () => {
+    const table =
+      'Findings below.\n| Claim | Status |\n|---|---|\n| module is broken | holds |\n' +
+      'Recommend removing the unused helpers; found 3 critical severity bugs. ' +
+      'lorem ipsum '.repeat(50);
+    expect(shadowVerifyNudge(stopCtx(table))).toEqual({});
+  });
+
+  it.each([['verify-claim1'], ['sv-verifier'], ['skill-fork-verify']])(
+    'suppresses when id prefix carries a verify token (%s)',
+    (agentType) => {
+      const decisionHeavy =
+        'Verdict: the auth module is broken. Recommend removing several unused helpers. ' +
+        'I found 4 critical severity bugs. ' +
+        'lorem ipsum '.repeat(70);
+      expect(shadowVerifyNudge(stopCtx(decisionHeavy, agentType))).toEqual({});
+    },
+  );
+
+  it('still nudges for look-alike prefix verification-x (hyphen-boundary match)', () => {
+    const decisionHeavy =
+      'Verdict: the auth module is broken. Recommend removing several unused helpers. ' +
+      'I found 4 critical severity bugs. ' +
+      'lorem ipsum '.repeat(70);
+    expect(shadowVerifyNudge(stopCtx(decisionHeavy, 'verification-x')).injectContext).toBeDefined();
+  });
+
+  describe('createShadowVerifyNudge dedup latch', () => {
+    const decisionHeavy =
+      'Verdict: the auth module is broken. Recommend removing several unused helpers. ' +
+      'I found 4 critical severity bugs. ' +
+      'lorem ipsum '.repeat(70);
+
+    it('injects at most once per turn across a parallel wave', () => {
+      const nudge = createShadowVerifyNudge();
+      expect(nudge(stopCtx(decisionHeavy, 'research', 'child-1')).injectContext).toBeDefined();
+      expect(nudge(stopCtx(decisionHeavy, 'research', 'child-2'))).toEqual({});
+      expect(nudge(stopCtx(decisionHeavy, 'research', 'child-3'))).toEqual({});
+    });
+
+    it('re-arms after a Stop (next turn) but never re-fires for the same child', () => {
+      const nudge = createShadowVerifyNudge();
+      expect(nudge(stopCtx(decisionHeavy, 'research', 'child-1')).injectContext).toBeDefined();
+      nudge({ event: 'Stop' });
+      // Same child again (duplicate SubagentStop delivery) — stays silent.
+      expect(nudge(stopCtx(decisionHeavy, 'research', 'child-1'))).toEqual({});
+      // A genuinely new child on the new turn nudges again.
+      expect(nudge(stopCtx(decisionHeavy, 'research', 'child-2')).injectContext).toBeDefined();
+    });
+
+    it('a suppressed (verifier-looking) child does not consume the turn latch', () => {
+      const nudge = createShadowVerifyNudge();
+      const verdictTable =
+        '| Claim | Result |\n|---|---|\n| x | CONFIRMED |\n| y | REFUTED |\n' +
+        'Recommend acting only on confirmed claims. ' +
+        'lorem ipsum '.repeat(50);
+      expect(nudge(stopCtx(verdictTable, 'sv-1', 'verifier-child'))).toEqual({});
+      expect(nudge(stopCtx(decisionHeavy, 'research', 'real-child')).injectContext).toBeDefined();
+    });
   });
 });

--- a/src/agent/shadow-verify-nudge.ts
+++ b/src/agent/shadow-verify-nudge.ts
@@ -28,6 +28,15 @@ const VERIFIED_ORCHESTRATORS = [
   // parent to re-verify its output would either fire on a report it can't act
   // on destructively, or double-verify what review already verified. Suppress.
   'review',
+  // The shadow-verify skill dispatches its verifier wave via raw `agent`
+  // calls, so nothing forces the id_prefix to carry the skill name — prefixes
+  // like `verify-claim1` or `sv-verifier` sail past the tokens above and the
+  // nudge fires on its own verification wave (#355). An agent whose prefix
+  // carries a `verify`/`verifier` token is a verification dispatch by
+  // construction, so suppression cannot mute a legitimate nudge. (Hyphen-
+  // bounded matching below keeps look-alikes like `verification-x` unmatched.)
+  'verify',
+  'verifier',
 ];
 
 const DECISION_MARKERS: RegExp[] = [
@@ -56,6 +65,15 @@ const VERIFIER_SIGNATURES: RegExp[] = [
   /\bre-derived\b[^.\n]{0,80}\bindependent/i,
   /\bindependently\s+(re-derived|re-verified|verified|checked)\b/i,
   /\bverifier\s+(agrees|disagrees|confirms|refutes)\b/i,
+  // Verdict-table style output (#355): a typical shadow-verify verifier reply
+  // is a markdown table of per-claim CONFIRMED/REFUTED/UNVERIFIABLE rows that
+  // hit none of the signatures above while hitting many DECISION_MARKERS —
+  // the more structured the verifier's report, the more certainly it
+  // (wrongly) triggered the nudge. Two case-sensitive verdict tokens = a
+  // verification report, not ordinary findings prose.
+  /\b(CONFIRMED|REFUTED|UNVERIFIABLE)\b[\s\S]*?\b(CONFIRMED|REFUTED|UNVERIFIABLE)\b/,
+  // Markdown table header with a claim/verdict column.
+  /\|\s*(claims?|verdicts?)\s*\|/i,
 ];
 
 const CONTEXT_MESSAGE =
@@ -99,12 +117,49 @@ function decisionHits(output: string): number {
   return hits;
 }
 
+/**
+ * Create a session-scoped nudge handler with dedup state (#355).
+ *
+ * Register the SAME returned handler for both `SubagentStop` and `Stop`:
+ * - `SubagentStop` runs the heuristics and injects at most ONCE per parent
+ *   turn — a parallel wave of decision-heavy children produces one nudge,
+ *   not N identical ones.
+ * - `Stop` (dispatched at turn end) resets the once-per-turn latch. On
+ *   surfaces that never dispatch `Stop`, the latch degrades to once-per-
+ *   session — conservative by design ("false alarms train users to ignore
+ *   the nudge"; false silence is cheap).
+ *
+ * A per-child `nudged` set additionally guarantees the same subagentId can
+ * never generate the nudge twice, even across turn boundaries (duplicate
+ * SubagentStop delivery for one child re-fired the nudge on turns where no
+ * new sub-agent had completed).
+ */
+export function createShadowVerifyNudge(): (context: HookContext) => HookDecision {
+  let injectedThisTurn = false;
+  const nudged = new Set<string>();
+  return (context: HookContext): HookDecision => {
+    if (context.event === 'Stop') {
+      injectedThisTurn = false;
+      return {};
+    }
+    if (context.event !== 'SubagentStop') return {};
+    const output = context.lastMessage ?? '';
+    if (output.length < MIN_OUTPUT_CHARS) return {};
+    if (fromVerifiedOrchestrator(context.agentType)) return {};
+    if (looksLikeVerifierResponse(output)) return {};
+    if (decisionHits(output) < MIN_MARKER_HITS) return {};
+    if (injectedThisTurn || nudged.has(context.subagentId)) return {};
+    injectedThisTurn = true;
+    nudged.add(context.subagentId);
+    return { injectContext: CONTEXT_MESSAGE };
+  };
+}
+
+/**
+ * Stateless single-shot evaluation (no dedup) — retained for callers/tests
+ * that check the heuristics in isolation. Production registration should use
+ * {@link createShadowVerifyNudge} so the dedup latch is session-scoped.
+ */
 export function shadowVerifyNudge(context: HookContext): HookDecision {
-  if (context.event !== 'SubagentStop') return {};
-  const output = context.lastMessage ?? '';
-  if (output.length < MIN_OUTPUT_CHARS) return {};
-  if (fromVerifiedOrchestrator(context.agentType)) return {};
-  if (looksLikeVerifierResponse(output)) return {};
-  if (decisionHits(output) < MIN_MARKER_HITS) return {};
-  return { injectContext: CONTEXT_MESSAGE };
+  return createShadowVerifyNudge()(context);
 }


### PR DESCRIPTION
## Problem
The shadow-verify nudge (a built-in `SubagentStop` hook) fired on the output of shadow-verify **verifier** sub-agents themselves, on consecutive turns. Two gaps:
1. A typical verifier reply is a markdown verdict table (`| Claim | Result | Evidence |` with `CONFIRMED`/`REFUTED`/`UNVERIFIABLE` rows) that matched none of the verifier signatures while hitting 2+ decision-markers — so the more structured the verifier output, the more surely it self-triggered.
2. No cooldown: the nudge re-fired across turns even when no new sub-agent had completed.

## Fix
- Broaden verifier-output recognition: 2+ `CONFIRMED|REFUTED|UNVERIFIABLE` tokens, or a claim/verdict table header; plus `verify`/`verifier` id-prefix tokens (hyphen-bounded so look-alikes like `verification-x` do not match).
- Session-scoped per-turn cooldown via `createShadowVerifyNudge()`: `SubagentStop` injects at most once per parent turn; `Stop` resets the latch; a per-child `nudged` set prevents duplicate `SubagentStop` delivery from re-firing.

## Verification
- `pnpm lint` clean; `shadow-verify-nudge.test.ts` 30/30 pass (adds verdict-table-suppression + cooldown cases; existing fire-correctly cases still green).

## Provenance
This change was cherry-picked from a completed local fix (`bcf5112`) that was authored ~4 days ago but never pushed or opened as a PR — recovered rather than re-implemented.

Closes #355
