### PR TITLE
fix(tools): stop glob from descending node_modules/.git; add multi-** tests (#436)

### DIFF
--- a/src/agent/tools/handlers/glob.test.ts
+++ b/src/agent/tools/handlers/glob.test.ts
@@ -328,3 +328,126 @@ describe('globHandler cwd containment', () => {
     expect(result.content).toContain('root.ts');
   });
 });
+
+describe('glob handler — default directory pruning (#436)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'glob-prune-'));
+    // A normal source file that should always be found.
+    await fs.mkdir(path.join(tempDir, 'src'), { recursive: true });
+    await fs.writeFile(path.join(tempDir, 'src', 'a.ts'), '');
+    // Files inside default-pruned dirs that should be skipped by default.
+    await fs.mkdir(path.join(tempDir, 'node_modules', 'pkg'), { recursive: true });
+    await fs.writeFile(path.join(tempDir, 'node_modules', 'pkg', 'b.ts'), '');
+    await fs.mkdir(path.join(tempDir, '.git'), { recursive: true });
+    await fs.writeFile(path.join(tempDir, '.git', 'config'), '');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('PRUNE: **/*.ts from root skips node_modules and .git', async () => {
+    const result = await globHandler(
+      { pattern: '**/*.ts', path: tempDir },
+      new AbortController().signal,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toContain('src/a.ts');
+    expect(result.content).not.toContain('node_modules/');
+    expect(result.content).not.toContain('.git/');
+  });
+
+  it('PRUNE: **/* from root skips node_modules and .git contents', async () => {
+    const result = await globHandler(
+      { pattern: '**/*', path: tempDir },
+      new AbortController().signal,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toContain('src/a.ts');
+    // Nothing under the pruned dirs should surface.
+    expect(result.content).not.toContain('node_modules/pkg/b.ts');
+    expect(result.content).not.toContain('.git/config');
+  });
+
+  it('OPT-IN: naming node_modules literally searches it', async () => {
+    const result = await globHandler(
+      { pattern: 'node_modules/**/*.ts', path: tempDir },
+      new AbortController().signal,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toContain('node_modules/pkg/b.ts');
+  });
+
+  it('OPT-IN: node_modules/** returns node_modules contents', async () => {
+    const result = await globHandler(
+      { pattern: 'node_modules/**', path: tempDir },
+      new AbortController().signal,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toContain('node_modules/pkg/b.ts');
+  });
+
+  it('never prunes the search root even if its basename is a pruned name', async () => {
+    // Point the search root AT a node_modules dir; its own contents must be
+    // searchable (the root is walked directly, never pruned as a child).
+    const nmRoot = path.join(tempDir, 'node_modules');
+    const result = await globHandler(
+      { pattern: '**/*.ts', path: nmRoot },
+      new AbortController().signal,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toContain('pkg/b.ts');
+  });
+});
+
+describe('glob handler — multi-** matcher correctness (#436)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'glob-globstar-'));
+    // Build a/x/b/y/c.txt to exercise a two-globstar pattern.
+    await fs.mkdir(path.join(tempDir, 'a', 'x', 'b', 'y'), { recursive: true });
+    await fs.writeFile(path.join(tempDir, 'a', 'x', 'b', 'y', 'c.txt'), '');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('matches a/**/b/**/c.txt against a/x/b/y/c.txt', async () => {
+    const result = await globHandler(
+      { pattern: 'a/**/b/**/c.txt', path: tempDir },
+      new AbortController().signal,
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toContain('a/x/b/y/c.txt');
+  });
+
+  it('does NOT match a/**/b/**/c.txt when the "b" segment is absent', async () => {
+    // Rebuild the tree without a "b" directory: a/x/y/z/c.txt.
+    await fs.rm(path.join(tempDir, 'a'), { recursive: true, force: true });
+    await fs.mkdir(path.join(tempDir, 'a', 'x', 'y', 'z'), { recursive: true });
+    await fs.writeFile(path.join(tempDir, 'a', 'x', 'y', 'z', 'c.txt'), '');
+
+    const result = await globHandler(
+      { pattern: 'a/**/b/**/c.txt', path: tempDir },
+      new AbortController().signal,
+    );
+
+    // No file matches; the handler reports the "no files matched" message.
+    // (Note: that message echoes the pattern, which itself contains the
+    // substring "c.txt" — so assert the concrete file path is absent, not
+    // the bare filename.)
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toContain('No files matched');
+    expect(result.content).not.toContain('a/x/y/z/c.txt');
+  });
+});

--- a/src/agent/tools/handlers/glob.ts
+++ b/src/agent/tools/handlers/glob.ts
@@ -5,6 +5,9 @@
  * Supports basic glob patterns: * (any filename chars), ** (any path segment),
  * and ? (single char). Returns up to 500 results.
  *
+ * By default, recursion skips node_modules/.git/.hg/.svn; naming such a
+ * directory as a literal pattern segment opts back into searching it.
+ *
  * @module agent/tools/handlers/glob
  */
 
@@ -12,6 +15,29 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import type { ToolHandler, ToolHandlerContext } from '../types.js';
 import { resolveAndContain } from './_cwd-utils.js';
+
+/**
+ * Directory basenames pruned from recursion by default: VCS metadata and
+ * dependency stores that are large and rarely the intended search target.
+ * A caller opts back into any of these by naming it as a literal (non-glob)
+ * segment of the pattern (e.g. `node_modules/**\/*.js`).
+ */
+const DEFAULT_PRUNE_DIRS = new Set(['node_modules', '.git', '.hg', '.svn']);
+
+/**
+ * Extract the literal (no `*`/`?`) path segments of a glob pattern. These are
+ * the directory names the caller has committed to traversing, so they must
+ * never be pruned even when they collide with {@link DEFAULT_PRUNE_DIRS}.
+ */
+function literalPatternSegments(pattern: string): Set<string> {
+  const literals = new Set<string>();
+  for (const segment of pattern.replace(/\\/g, '/').split('/')) {
+    if (segment !== '' && !segment.includes('*') && !segment.includes('?')) {
+      literals.add(segment);
+    }
+  }
+  return literals;
+}
 
 /**
  * Check if a relative path matches a glob pattern.
@@ -78,6 +104,9 @@ function convertGlobPartToRegex(part: string): string {
 async function collectMatches(dir: string, pattern: string): Promise<string[]> {
   const matches: string[] = [];
   const maxResults = 500;
+  // Directory names the caller explicitly named as literal pattern segments
+  // are exempt from default pruning (opt back into node_modules/.git/etc.).
+  const literalSegments = literalPatternSegments(pattern);
 
   async function walk(currentPath: string, relPath: string): Promise<boolean> {
     if (matches.length >= maxResults) {
@@ -100,8 +129,14 @@ async function collectMatches(dir: string, pattern: string): Promise<string[]> {
           matches.push(entryRel);
         }
 
-        // Always recurse into directories to find deeper matches
+        // Recurse into directories to find deeper matches, but skip the
+        // default-pruned dirs (node_modules/.git/.hg/.svn) unless the caller
+        // named them literally in the pattern. The search root itself is
+        // never pruned here (it is walked directly, not as a child entry).
         if (entry.isDirectory()) {
+          if (DEFAULT_PRUNE_DIRS.has(entry.name) && !literalSegments.has(entry.name)) {
+            continue;
+          }
           const shouldStop = await walk(entryPath, entryRel);
           if (shouldStop) {
             return true;

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -134,7 +134,8 @@ export const globTool: AnthropicToolDef = {
   description:
     'Find files matching a glob pattern. Returns matching file paths, capped at 500 results. ' +
     'Use for discovering files before reading them. Patterns follow standard glob syntax ' +
-    '(e.g., "src/**/*.ts", "*.json").',
+    '(e.g., "src/**/*.ts", "*.json"). Skips node_modules/.git/.hg/.svn by default; ' +
+    'name such a directory literally in the pattern (e.g. "node_modules/**/*.js") to search it.',
   input_schema: {
     type: 'object',
     properties: {


### PR DESCRIPTION
## Summary

The `glob` handler's `walk` recursed into **every** directory with no ignore
list, so it descended `node_modules/`, `.git/`, etc. That made repo-root globs
slow on large trees and let the 500-result cap fill with junk (top-down,
alphabetically) before real `src` matches surfaced — returning
`[results capped at 500 entries]` of noise.

This PR makes recursion skip a small default set of directories, with an
explicit opt-in, and adds the missing multi-`**` matcher coverage the issue
flagged.

## What changed

- **Default pruning** — added a module-level
  `DEFAULT_PRUNE_DIRS = new Set(['node_modules', '.git', '.hg', '.svn'])`.
  During recursion the walk no longer descends into a subdirectory whose
  basename is in that set.
- **Literal-segment opt-in** — the set of literal (no `*`/`?`) segments of the
  pattern is computed once per call; a name that appears there is never pruned.
  So `node_modules/**/*.js` (or `node_modules/**`) still searches
  `node_modules`. The **search root itself is never pruned** (it is walked
  directly, not as a child entry).
- **Behavior preserved** — pruned directories are still *tested against the
  pattern* before recursion is skipped; the 500 cap + `[results capped at 500
  entries]` note, the `No files matched` message, error handling, the matcher,
  and the public input/output shape are all unchanged.
- **Docs in sync** — the `globTool` description in `schemas.ts` now notes the
  default prune set and the literal-segment opt-in.
- **Tests** — new cases in `glob.test.ts`:
  - PRUNE: `**/*.ts` and `**/*` from a root containing `src/a.ts`,
    `node_modules/pkg/b.ts`, `.git/config` return `src/a.ts` and nothing under
    `node_modules/` or `.git/`.
  - OPT-IN: `node_modules/**/*.ts` and `node_modules/**` do return the
    `node_modules` file (pruning bypassed when the pattern names it literally).
  - Search root is never pruned even when its basename is `node_modules`.
  - MULTI-`**`: `a/**/b/**/c.txt` matches `a/x/b/y/c.txt`; a clear negative
    (no `b` segment) does not match.

## Multi-`**` matcher verdict

The hand-rolled matcher is **correct for the cases exercised here** — the
canonical two-globstar positive (`a/**/b/**/c.txt` vs `a/x/b/y/c.txt`) and the
clear negative both pass as-is, so the new tests lock in current behavior; no
matcher change was needed for them.

While probing I did find a genuine limitation: the current split-on-`**`
matcher does **not** collapse a `/**/` boundary to zero segments, so e.g.
`x/**/b/**/c.txt` does not match `x/b/b/c.txt` (second `**` = zero segments).
Fixing that correctly means broadening globstar boundary semantics across all
patterns — which is squarely the picomatch/fast-glob migration below — so it is
**deferred** rather than partially hacked in here.

## Scope / deferred (Refs #436, not Closes)

This PR is scoped to the default-prune-dirs behavior + multi-`**` tests. The
following parts of #436 are intentionally **deferred to follow-ups**:

- `.gitignore` respect (git-aware ignore, like ripgrep/fd).
- Replacing the hand-rolled `**` matcher with `picomatch`/`fast-glob`
  (behavior-compatible, well-tested) — which would also fix the zero-segment
  `/**/` boundary limitation noted above.

Using `Refs #436` (not `Closes`) because the issue is only partially addressed.

## Gates run (all passed)

```
pnpm lint
pnpm exec vitest run src/agent/tools/handlers/glob.test.ts src/agent/tools/handlers/multi-root.test.ts src/agent/tools/schemas.test.ts
```

- `pnpm lint` (`tsc --noEmit`): clean, exit 0.
- vitest: **3 files passed — 56 passed, 1 skipped** (the pre-existing skipped
  cwd test). glob.test.ts: 29 tests (1 skipped); multi-root.test.ts: 11;
  schemas.test.ts: 17.
