### PR TITLE
refactor(subagent): extract execute() into subagent/ modules (1316→577 LOC)

### DIFF
--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -8,34 +8,30 @@
  * @module agent/tools/subagent-executor
  */
 
-import { isAbsolute } from 'node:path';
-
 import { SubagentManager } from '../subagent.js';
-import { BackgroundAgentRegistry, BackgroundJobCapError } from '../background-registry.js';
+import { BackgroundAgentRegistry } from '../background-registry.js';
 import type { ModelProvider } from '../provider.js';
 import type { AgentModelInput, IAgentSession } from '../types.js';
 import type { AgentConfig } from '../types/config-types.js';
-import { providerForModel } from '../providers/index.js';
-import { applyParentCredentialFallback } from './child-credential.js';
-import { resolveCredentialForModel } from '../auth/credential-resolver.js';
 import type { AnthropicToolDef, ToolCall, ToolResult } from './types.js';
 import {
-  CHILD_ALLOWED_TOOLS,
   DEFAULT_MAX_NESTING_DEPTH,
-  buildSkillRestrictedProvider,
-  createStubParentSession,
   type ChildProviderFactoryArgs,
 } from './nesting.js';
-import { buildAgentToolDef, resolveAgentToolAccess } from '../agents/index.js';
+import { buildAgentToolDef } from '../agents/index.js';
 import type { AgentRegistry, RegisteredAgent } from '../agents/index.js';
 import type { SkillExecutor } from './skill-executor.js';
-import { appendRoutingDecision } from '../routing-telemetry.js';
-import { debugLog } from '../../utils/debug.js';
 import { stripEscapeSequences } from '../../utils/terminal-sanitize.js';
 import type { Surface } from '../awareness/types.js';
 import { deriveOrigin, actorFromDepth, type TraceOrigin, type TraceActor } from '../session/session-identity.js';
+import { parseAgentInput, type AgentInput, type AgentExecutionMode } from './subagent/input-parse.js';
+import { emitTelemetry, truncate } from './subagent/failure-payload.js';
+import { buildChildConfig } from './subagent/child-config.js';
+import { runBackgroundBranch } from './subagent/background-branch.js';
+import { runForegroundWithPromotion, type PromotionTrigger } from './subagent/foreground-promotion.js';
 
 export { DEFAULT_MAX_NESTING_DEPTH, type ChildProviderFactoryArgs } from './nesting.js';
+export type { AgentExecutionMode };
 
 export interface SubagentExecutorContext {
   subagentManager: SubagentManager;
@@ -195,8 +191,6 @@ export interface SubagentExecutorContext {
   parentModel?: AgentModelInput;
 }
 
-export type AgentExecutionMode = 'foreground' | 'background';
-
 /** Identity of a subagent that was promoted from foreground to background. */
 export interface PromotedSubagentInfo {
   jobId: string;
@@ -253,267 +247,6 @@ export interface SubagentControl {
   cancelActiveForeground(): Promise<number>;
 }
 
-interface AgentInput {
-  prompt: string;
-  model?: string;
-  max_turns?: number;
-  /**
-   * True when the caller supplied `max_turns` explicitly. Distinguishes the
-   * parse-time default (10) from a deliberate value so a named agent's
-   * `maxTurns` frontmatter can act as the default without being able to
-   * override an explicit per-call budget.
-   */
-  max_turns_explicit: boolean;
-  id_prefix?: string;
-  /**
-   * Named agent type to dispatch (`agent_type`, alias `subagent_type`).
-   * Resolved against {@link SubagentExecutorContext.agentRegistry}.
-   */
-  agent_type?: string;
-  /** Execution mode. Defaults to 'foreground' (existing await-and-return semantic). */
-  mode: AgentExecutionMode;
-  /**
-   * Optional working directory the subagent runs in. When omitted, the child
-   * inherits the parent's cwd (`SubagentManager.parentCwd`) so `afk -w`
-   * worktree isolation extends transparently. When provided, must be an
-   * absolute path with no `..` segments — the executor threads it into
-   * `AgentConfig.cwd`, which `SubagentManager.forkSubagent` applies in
-   * preference to the parent fallback (see `src/agent/subagent.ts:291-297`).
-   *
-   * Validation is format-only at parse time (existence/git-worktree status
-   * is not checked) — a non-existent path surfaces as an ENOENT on the
-   * child's first cwd-relative tool call, which the parent sees as a
-   * structured failure. Mirrors the existing AgentConfig.cwd contract
-   * used by `afk interactive -w` and the diagnose/farm orchestrators.
-   *
-   * Caveat: this field affects only the dispatched child's cwd. Depth-2+
-   * forks (the child itself calling `agent`) inherit through
-   * `SubagentExecutorContext.cwd` set at orchestrator construction —
-   * passing `cwd` here does NOT auto-propagate to recursive subagents.
-   * Each level must specify `cwd` explicitly to operate in a worktree.
-   */
-  cwd?: string;
-}
-
-/**
- * Validate and parse Agent tool input.
- * @throws if input is invalid
- */
-function parseAgentInput(input: unknown): AgentInput {
-  if (typeof input !== 'object' || input === null) {
-    throw new Error('Agent tool input must be an object');
-  }
-
-  const agentInput = input as Record<string, unknown>;
-
-  const prompt = agentInput['prompt'];
-  if (typeof prompt !== 'string') {
-    throw new Error('Agent tool input must have a "prompt" field of type string');
-  }
-  if (prompt.trim().length === 0) {
-    throw new Error('Agent tool prompt cannot be empty');
-  }
-
-  let model: string | undefined;
-  const modelValue = agentInput['model'];
-  if (modelValue !== undefined) {
-    if (typeof modelValue !== 'string') {
-      throw new Error('Agent tool model must be a string');
-    }
-    model = modelValue;
-  }
-
-  let max_turns = 10;
-  let max_turns_explicit = false;
-  const maxTurnsValue = agentInput['max_turns'];
-  if (maxTurnsValue !== undefined) {
-    if (typeof maxTurnsValue !== 'number') {
-      throw new Error('Agent tool max_turns must be a number');
-    }
-    // Clamp to [1, 50]
-    max_turns = Math.max(1, Math.min(50, Math.floor(maxTurnsValue)));
-    max_turns_explicit = true;
-  }
-
-  // agent_type: canonical param; `subagent_type` accepted as an alias for
-  // Claude Code-ported prompts (bundled SKILL.mds already write it). When
-  // both are present the canonical name wins.
-  let agent_type: string | undefined;
-  const agentTypeValue = agentInput['agent_type'] ?? agentInput['subagent_type'];
-  if (agentTypeValue !== undefined) {
-    if (typeof agentTypeValue !== 'string') {
-      throw new Error('Agent tool agent_type must be a string');
-    }
-    const trimmed = agentTypeValue.trim();
-    if (trimmed.length > 0) agent_type = trimmed;
-  }
-
-  let id_prefix = 'agent-tool';
-  const idPrefixValue = agentInput['id_prefix'];
-  if (idPrefixValue !== undefined) {
-    if (typeof idPrefixValue !== 'string') {
-      throw new Error('Agent tool id_prefix must be a string');
-    }
-    id_prefix = idPrefixValue;
-  }
-
-  // mode: default 'foreground'. Unknown strings reject loudly rather than
-  // silently coercing — a typo like "back" would be silently downgraded
-  // to a foreground run, exactly the surprise this feature is built to
-  // avoid.
-  let mode: AgentExecutionMode = 'foreground';
-  const modeValue = agentInput['mode'];
-  if (modeValue !== undefined) {
-    if (modeValue !== 'foreground' && modeValue !== 'background') {
-      throw new Error(
-        `Agent tool mode must be "foreground" or "background", got: ${JSON.stringify(modeValue)}`,
-      );
-    }
-    mode = modeValue;
-  }
-
-  // cwd: optional absolute path. Format-only validation here — existence is
-  // not checked because the call site is sync and any ENOENT surfaces
-  // cleanly through the child's first tool call. Rules:
-  //   1. Must be a non-empty string when present.
-  //   2. Must be absolute (`path.isAbsolute`) — relative paths would otherwise
-  //      resolve against `process.cwd()` and silently land somewhere
-  //      unrelated to the caller's intent.
-  //   3. Must not contain `..` as a path segment. `path.resolve` would
-  //      silently collapse them; rejecting forces the caller to write
-  //      what they mean. Splits on both `/` and `\\` so the check holds
-  //      on Windows too.
-  let cwd: string | undefined;
-  const cwdValue = agentInput['cwd'];
-  if (cwdValue !== undefined) {
-    if (typeof cwdValue !== 'string') {
-      throw new Error(
-        `Agent tool cwd must be a string, got: ${JSON.stringify(cwdValue)}`,
-      );
-    }
-    if (cwdValue.length === 0) {
-      throw new Error('Agent tool cwd must be a non-empty string');
-    }
-    if (!isAbsolute(cwdValue)) {
-      throw new Error(
-        `Agent tool cwd must be an absolute path, got: ${JSON.stringify(cwdValue)}`,
-      );
-    }
-    const segments = cwdValue.split(/[/\\]/);
-    if (segments.includes('..')) {
-      throw new Error(
-        `Agent tool cwd must not contain '..' segments, got: ${JSON.stringify(cwdValue)}`,
-      );
-    }
-    cwd = cwdValue;
-  }
-
-  return {
-    prompt,
-    model,
-    max_turns,
-    max_turns_explicit,
-    id_prefix,
-    mode,
-    ...(agent_type !== undefined ? { agent_type } : {}),
-    ...(cwd !== undefined ? { cwd } : {}),
-  };
-}
-
-/**
- * Best-effort telemetry helper. Wraps {@link appendRoutingDecision} so a
- * synchronous throw (shouldn't happen — the helper already swallows) cannot
- * propagate into the dispatch path.
- */
-function emitTelemetry(entry: Parameters<typeof appendRoutingDecision>[0]): Promise<void> {
-  try {
-    return appendRoutingDecision(entry).catch(() => {});
-  } catch {
-    return Promise.resolve();
-  }
-}
-
-/** Truncate short telemetry strings; we never log full error bodies. */
-function truncate(s: string, max = 240): string {
-  return s.length <= max ? s : s.slice(0, max) + '…';
-}
-
-/** Measure partial output size without serializing large structures repeatedly. */
-function measurePartial(partial: unknown): number | undefined {
-  if (partial === undefined || partial === null) return undefined;
-  if (typeof partial === 'string') return partial.length;
-  try {
-    return JSON.stringify(partial).length;
-  } catch {
-    return undefined;
-  }
-}
-
-/**
- * Maximum serialized size of `partialOutput` we will surface to the parent
- * model. Above this, we replace the payload with a `{ truncated, chars }`
- * marker so the parent learns partial output existed without flooding its
- * context.
- */
-const MAX_PARTIAL_OUTPUT_CHARS = 4096;
-
-/** Maximum length of the `error` field in the structured failure payload. */
-const MAX_ERROR_MESSAGE_CHARS = 1024;
-
-/**
- * Shape a partial output for inclusion in the structured failure payload.
- * Returns `undefined` when the input is null/undefined (key is omitted).
- * Returns a `{ truncated, chars }` marker when serialization exceeds the cap.
- */
-function shapePartialOutput(
-  partial: unknown,
-): unknown | undefined {
-  if (partial === undefined || partial === null) return undefined;
-  const chars = measurePartial(partial);
-  if (chars !== undefined && chars > MAX_PARTIAL_OUTPUT_CHARS) {
-    return { truncated: true, chars };
-  }
-  return partial;
-}
-
-/**
- * Build the structured JSON payload returned to the parent model on the
- * failure path. Intentionally small: status + short error + optional schema
- * error string + optional (size-capped) partial output + subagent id.
- *
- * Excludes by design: prompts, full subagent assistant messages, file
- * contents, tool inputs/outputs, credentials, stack traces.
- */
-interface StructuredFailurePayload {
-  status: string;
-  error: string;
-  schemaError?: string;
-  partialOutput?: unknown;
-  subagent_id: string;
-}
-
-function buildFailurePayload(args: {
-  status: string;
-  errorMessage: string;
-  schemaErrorMessage?: string;
-  partialOutput?: unknown;
-  subagentId: string;
-}): StructuredFailurePayload {
-  const payload: StructuredFailurePayload = {
-    status: args.status,
-    error: truncate(args.errorMessage, MAX_ERROR_MESSAGE_CHARS),
-    subagent_id: args.subagentId,
-  };
-  if (args.schemaErrorMessage) {
-    payload.schemaError = truncate(args.schemaErrorMessage, MAX_ERROR_MESSAGE_CHARS);
-  }
-  const shaped = shapePartialOutput(args.partialOutput);
-  if (shaped !== undefined) {
-    payload.partialOutput = shaped;
-  }
-  return payload;
-}
-
 export class SubagentExecutor implements SubagentControl {
   // Current worktree cwd. Seeded from ctx.cwd; updated by setCwd when the
   // session's cwd changes (born-named `afk -w` worktree created on turn 1).
@@ -561,10 +294,7 @@ export class SubagentExecutor implements SubagentControl {
    * all"), which is what unblocks a parent parked in `executeBatch` awaiting
    * several subagents at once.
    */
-  private readonly promotionTriggers = new Map<
-    string,
-    { fire: () => void; ready: Promise<PromotedSubagentInfo | null> }
-  >();
+  private readonly promotionTriggers = new Map<string, PromotionTrigger>();
 
   // In-flight foreground handles keyed by `handle.id`. Tracked separately from
   // promotionTriggers because cancellation must work with NO background
@@ -708,16 +438,14 @@ export class SubagentExecutor implements SubagentControl {
       }
     }
 
-    // Build child config.
-    //
     // Invariant: `ctx.depth` is required (see SubagentExecutorContext.depth
     // jsdoc) — top-level callers pass explicit `0` so the child's `depth + 1`
-    // arithmetic below produces a confident nesting position. A future change
-    // that loosens the type back to optional would re-introduce the silent
-    // misconfig fallback the Phase 1 awareness contract is designed to avoid.
+    // arithmetic in buildChildConfig produces a confident nesting position. A
+    // future change that loosens the type back to optional would re-introduce
+    // the silent misconfig fallback the Phase 1 awareness contract is designed
+    // to avoid.
     const depth = this.ctx.depth;
     const maxDepth = this.ctx.maxDepth ?? DEFAULT_MAX_NESTING_DEPTH;
-    let childManager: SubagentManager | undefined;
 
     // Session identity for routing-decision rows. Only emitted when this
     // executor was wired with a `surface` (the new top-level wiring); legacy/
@@ -728,218 +456,34 @@ export class SubagentExecutor implements SubagentControl {
         ? { origin: deriveOrigin(this.ctx.surface), actor: actorFromDepth(depth) }
         : {};
 
-    // Resolve the child's effective model and the provider it routes to FIRST,
-    // so we can decide whether the parent's Anthropic-shaped `apiKey` /
-    // `baseUrl` (sourced from `loadCredential()` + `AFK_LOCAL_BASE_URL`) should
-    // be forwarded. Forwarding them to an OpenAI-routed child causes
-    // `resolveOpenAIAuth()` to return the Anthropic key as if it were a config
-    // OpenAI key (tier 1 wins) — the OpenAI API then 401s. Clearing them lets
-    // the OpenAI auth resolver walk its env / codex precedence cleanly.
-    // Model resolution.
-    //   Unnamed dispatch (legacy, unchanged): call-site > policy default > 'sonnet'.
-    //   Named dispatch (Claude Code parity): call-site > definition model
-    //   ('inherit' → dispatching session's model) > inherit-by-default
-    //   (omitted model also means inherit) > policy default > 'sonnet'.
-    // `parentModel` is optional ctx wiring; when absent, inherit falls
-    // through to the policy chain rather than guessing.
-    let namedDefaultModel: string | undefined;
-    if (namedAgent !== undefined) {
-      const defModel = namedAgent.definition.model;
-      namedDefaultModel =
-        defModel !== undefined && defModel !== 'inherit'
-          ? defModel
-          : this.ctx.parentModel;
-    }
-    const childModel: string =
-      parsed.model ?? namedDefaultModel ?? this.ctx.defaultSubagentModel ?? 'sonnet';
-    const childIsOpenAI = providerForModel(childModel) === 'openai-compatible';
-
-    // Named-agent tool access: resolve the definition's declared surface into
-    // runtime terms, then compose with any cage this executor already sits in
-    // (a read-only skill's fan-out). Composition is fail-closed:
-    //   allowlist  = def ∩ cage   (when both exist; either alone otherwise)
-    //   bash gate  = def ∨ cage
-    // — mirroring skill-executor.ts buildForkedChildConfig's intersection
-    // semantics, so a named dispatch can never widen an existing cage.
-    const resolvedAccess =
-      namedAgent !== undefined
-        ? resolveAgentToolAccess(namedAgent, CHILD_ALLOWED_TOOLS)
-        : undefined;
-    let effectiveAllowedTools: string[] | undefined = this.ctx.allowedTools;
-    if (resolvedAccess?.allowedTools !== undefined) {
-      const cage = this.ctx.allowedTools;
-      effectiveAllowedTools =
-        cage !== undefined
-          ? resolvedAccess.allowedTools.filter((t) => cage.includes(t))
-          : resolvedAccess.allowedTools;
-    }
-    const effectiveReadOnlyBash =
-      this.ctx.readOnlyBash === true || resolvedAccess?.bashReadOnly === true;
-    if (resolvedAccess !== undefined && resolvedAccess.droppedTokens.length > 0) {
-      // Fail-closed token drops silently NARROW the child's tool surface, so a
-      // misconfigured agent file must be visible by default — not only under
-      // AFK_DEBUG. Route through the same stderr sink the agent registry uses
-      // for its load-time warnings (loadAgentRegistry's default `warn`).
-      process.stderr.write(
-        `[afk] agents: agent_type ${JSON.stringify(namedAgent?.name)}: ` +
-          `unknown tool token(s) dropped fail-closed: ${resolvedAccess.droppedTokens.join(', ')}\n`,
-      );
-    }
-
-    // Turn budget: explicit per-call max_turns wins; otherwise a named
-    // agent's maxTurns frontmatter (clamped to the same [1, 50] envelope);
-    // otherwise the parse-time default.
-    const effectiveMaxTurns =
-      !parsed.max_turns_explicit && namedAgent?.definition.maxTurns !== undefined
-        ? Math.max(1, Math.min(50, Math.floor(namedAgent.definition.maxTurns)))
-        : parsed.max_turns;
-
-    // Resolve the child's API key by its own model/provider. The resolver is
-    // now available directly from the agent layer (resolveCredentialForModel),
-    // so no injection is required — `this.ctx.resolveApiKeyForModel` acts as
-    // an optional override for callers that need a custom strategy (e.g. tests).
-    // When absent, the default agent-layer resolver is used. The
-    // `childIsOpenAI ? undefined` guard below is preserved as a
-    // defense-in-depth layer (cross-provider credential anti-leak invariant).
-    //
-    // applyParentCredentialFallback adds a second safety net: when fresh
-    // per-model resolution comes up empty for an Anthropic child (the sync
-    // keychain reader bailing on an expired OAuth token), reuse the parent's
-    // bootstrap-captured credential IFF it is Anthropic-shaped — so the child
-    // gets a token to attempt with and its own 401 refresher self-heals,
-    // instead of dying at the provider pre-flight. See child-credential.ts.
-    const resolvedChildApiKey = applyParentCredentialFallback({
-      childModel,
-      resolved: this.ctx.resolveApiKeyForModel
-        ? this.ctx.resolveApiKeyForModel(childModel)
-        : resolveCredentialForModel(childModel),
-      parentApiKey: this.ctx.defaultConfig.apiKey,
-    });
-
-    const childConfig: AgentConfig = {
-      model: childModel,
-      apiKey: childIsOpenAI ? undefined : resolvedChildApiKey,
-      // A named agent's markdown body IS the child's system prompt (Claude
-      // Code parity: subagents receive the definition prompt, not the parent
-      // surface's full prompt). Unnamed dispatches keep the raw base prompt.
-      systemPrompt: namedAgent !== undefined ? namedAgent.definition.prompt : this.ctx.defaultConfig.systemPrompt,
-      baseUrl: childIsOpenAI ? undefined : this.ctx.defaultConfig.baseUrl,
-      maxTurns: effectiveMaxTurns,
-      // Awareness metadata (Phase 1, get_runtime_state):
-      // Thread depth + maxDepth into the child's AgentConfig so the
-      // `self` view of the child's get_runtime_state snapshot reflects
-      // its actual nesting position. `parentSessionId` is injected later
-      // by SubagentManager.forkSubagent which has options.parent.sessionId
-      // in scope; phaseRole is also handled there.
-      depth: depth + 1,
+    // Build the child config + nested-dispatch wiring. All context this needs
+    // is passed explicitly; the recursive child executor is injected as a
+    // factory so child-config.ts never imports this class at runtime.
+    const { childConfig, childParentSession, childManager } = buildChildConfig({
+      parsed,
+      namedAgent,
+      depth,
       maxDepth,
-      // Per-call cwd override. When set, `SubagentManager.forkSubagent`
-      // applies this in preference to the manager's `parentCwd` fallback
-      // (see src/agent/subagent.ts:291-297) — the child's dispatcher
-      // resolveBase + read/write roots anchor at this path. When omitted,
-      // the parent inheritance chain stays intact.
-      ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
-    } as AgentConfig;
-
-    // Wire nesting: give the child its own executor + provider so it can
-    // dispatch Agent and Skill tool calls. Skip when at maxDepth or no
-    // factory — child gracefully loses both tools.
-    //
-    // childParentSession is a mutable stub: sessionId starts undefined and is
-    // backfilled to handle.id once forkSubagent resolves. This ensures depth-2
-    // forks (dispatched by childExecutor) see a real parentId rather than
-    // undefined, so the stream-renderer can attribute them correctly.
-    let childParentSession: ReturnType<typeof createStubParentSession> & { sessionId: string | undefined } | undefined;
-    if (this.ctx.childProviderFactory && depth < maxDepth) {
-      // Forward cwd to the child manager so depth-2 forks (this depth-1
-      // child calling the `agent` tool) inherit the worktree anchor.
-      // Without this, `SubagentManager.forkSubagent` reads `this.parentCwd`
-      // (undefined) and depth-2 child config.cwd is omitted — its
-      // bash/grep/read_file fall back to process.cwd() (host repo).
-      childManager = new SubagentManager({
-        parentAbortSignal: call.signal,
-        ...(this.currentCwd !== undefined ? { cwd: this.currentCwd } : {}),
-      });
-      childParentSession = createStubParentSession(call.signal) as ReturnType<typeof createStubParentSession> & { sessionId: string | undefined };
-      const childExecutor = new SubagentExecutor({
-        subagentManager: childManager,
-        parentSession: childParentSession as Pick<IAgentSession, 'sessionId' | 'getInputStreamRef' | 'abortSignal'>,
-        defaultConfig: this.ctx.defaultConfig,
-        // Inherit origin from the parent; `depth + 1` below makes this child's
-        // emitted rows carry actor:'subagent'.
-        ...(this.ctx.surface !== undefined ? { surface: this.ctx.surface } : {}),
-        defaultSubagentModel: this.ctx.defaultSubagentModel,
-        childProviderFactory: this.ctx.childProviderFactory,
-        childSkillExecutorFactory: this.ctx.childSkillExecutorFactory,
-        // Propagate the resolver so depth ≥ 2 forks (this depth-1 child
-        // calling the `agent` tool) also resolve credentials by child model.
-        ...(this.ctx.resolveApiKeyForModel !== undefined
-          ? { resolveApiKeyForModel: this.ctx.resolveApiKeyForModel }
-          : {}),
-        depth: depth + 1,
-        maxDepth,
-        // Forward cwd so the depth-1 child executor, when it constructs
-        // ITS own childManager for depth-3+ forks, also receives cwd. The
-        // chain holds for arbitrary depth up to maxDepth.
-        ...(this.currentCwd !== undefined ? { cwd: this.currentCwd } : {}),
-        // Propagate read-only constraints so depth ≥ 2 forks (this depth-1
-        // child calling the `agent` tool) keep the same tool allowlist and
-        // bash gate that the originating read-only skill imposed.
-        //
-        // Deliberately the CAGE (ctx) values, not the named-agent effective
-        // values: a named definition constrains the child it dispatches, not
-        // that child's own descendants (Claude Code parity — nested spawns
-        // resolve their own agent types). The cage, by contrast, cascades.
-        ...(this.ctx.allowedTools !== undefined ? { allowedTools: this.ctx.allowedTools } : {}),
-        ...(this.ctx.readOnlyBash ? { readOnlyBash: true } : {}),
-        // Named-agent registry + the child's model (for grandchild `inherit`
-        // resolution) thread through every depth.
-        ...(this.ctx.agentRegistry !== undefined ? { agentRegistry: this.ctx.agentRegistry } : {}),
-        // Scope the dispatched agent's OWN nested dispatches to the leaf types
-        // its definition named (resolve.ts `nestedAgentTypes`). This is what
-        // lets research-agent dispatch git-investigator and NOTHING else — the
-        // gate at execute() top reads this from its ctx. Unset ⇒ unrestricted
-        // (top-level, inherit-all, or bare-`Agent` agents).
-        ...(resolvedAccess?.nestedAgentTypes !== undefined
-          ? { nestedAgentAllowlist: resolvedAccess.nestedAgentTypes }
-          : {}),
-        parentModel: childModel,
-      });
-      const childSkillExecutor = this.ctx.childSkillExecutorFactory
-        ? this.ctx.childSkillExecutorFactory(depth + 1, maxDepth, call.signal, this.currentCwd)
-        : undefined;
-      // Pass `model` so the factory routes between AnthropicDirect /
-      // OpenAICompatible per `providerForModel(model)`. Without this, every
-      // child inherits the legacy hardcoded AnthropicDirectProvider — which
-      // means a gpt-4o parent silently dispatches subagents to
-      // api.anthropic.com. See nesting.ts `createChildProviderFactory`.
-      childConfig.provider = this.ctx.childProviderFactory({
-        childExecutor,
-        ...(childSkillExecutor !== undefined ? { childSkillExecutor } : {}),
-        ...(childConfig.model !== undefined ? { model: childConfig.model } : {}),
-        // Effective tool access for the dispatched child: the pre-existing
-        // cage (read-only skill fan-out), intersected with the named agent's
-        // resolved allowlist when one is in play (computed above). The
-        // dispatcher both enforces this at the permission gate AND filters
-        // the advertised schema to match (dispatcher.ts toolDefs), so a
-        // research-agent child never even sees bash/write_file/agent.
-        ...(effectiveAllowedTools !== undefined ? { allowedTools: effectiveAllowedTools } : {}),
-        ...(effectiveReadOnlyBash ? { readOnlyBash: true } : {}),
-      });
-    } else if (effectiveAllowedTools !== undefined || effectiveReadOnlyBash) {
-      // Restricted dispatch at the depth cap (or with no factory wired):
-      // without an explicit provider the fork would inherit the default
-      // UNRESTRICTED provider and the named agent's contract would silently
-      // fail open. Build a minimal restricted provider instead — no nested
-      // executors (at the cap the child cannot fan out anyway). Mirrors the
-      // cap-path fix in skill-executor.ts buildForkedChildConfig.
-      childConfig.provider = buildSkillRestrictedProvider(
-        effectiveAllowedTools ?? [...CHILD_ALLOWED_TOOLS],
-        childConfig.model,
-        effectiveReadOnlyBash,
-        this.ctx.defaultConfig.openaiBaseUrl,
-      );
-    }
+      currentCwd: this.currentCwd,
+      signal: call.signal,
+      defaultConfig: this.ctx.defaultConfig,
+      ...(this.ctx.resolveApiKeyForModel !== undefined
+        ? { resolveApiKeyForModel: this.ctx.resolveApiKeyForModel }
+        : {}),
+      defaultSubagentModel: this.ctx.defaultSubagentModel,
+      ...(this.ctx.childProviderFactory !== undefined
+        ? { childProviderFactory: this.ctx.childProviderFactory }
+        : {}),
+      ...(this.ctx.childSkillExecutorFactory !== undefined
+        ? { childSkillExecutorFactory: this.ctx.childSkillExecutorFactory }
+        : {}),
+      ...(this.ctx.surface !== undefined ? { surface: this.ctx.surface } : {}),
+      ...(this.ctx.allowedTools !== undefined ? { allowedTools: this.ctx.allowedTools } : {}),
+      ...(this.ctx.readOnlyBash !== undefined ? { readOnlyBash: this.ctx.readOnlyBash } : {}),
+      ...(this.ctx.agentRegistry !== undefined ? { agentRegistry: this.ctx.agentRegistry } : {}),
+      ...(this.ctx.parentModel !== undefined ? { parentModel: this.ctx.parentModel } : {}),
+      createChildExecutor: (childCtx) => new SubagentExecutor(childCtx),
+    });
 
     let handle: Awaited<ReturnType<SubagentManager['forkSubagent']>>;
     try {
@@ -998,319 +542,36 @@ export class SubagentExecutor implements SubagentControl {
       };
     }
 
-    // ------------------------------------------------------------------
-    // Background-mode branch.
-    //
-    // External constraint: the parent SDK tool-use loop expects a
-    // ToolResult per ToolCall *before the next assistant turn begins*.
-    // Background mode honors that contract by returning immediately with
-    // a structured pointer. The handle keeps running detached; the
-    // parent's AbortGraph still owns its lifetime (parent abort
-    // cascades down), and the registry's terminal-state callback
-    // captures the eventual outcome for explicit `join`.
-    //
-    // We deliberately do NOT wire the call.signal -> handle.cancel
-    // bridge here. That bridge ties the child's lifetime to the parent
-    // tool-call's signal, which is exactly wrong for fire-and-forget:
-    // the tool-call signal aborts at end-of-turn, and a background
-    // job is supposed to outlive the turn that spawned it. Cascade
-    // on parent-session abort still works because forkSubagent
-    // installs the SubagentManager root abort wiring independently.
-    // ------------------------------------------------------------------
+    // Background-mode branch: register the (not-yet-run) handle and return a
+    // synthetic pointer immediately, never awaiting runToResult. See
+    // background-branch.ts for the abort/lifetime invariants moved with it.
     if (parsed.mode === 'background') {
-      const registry = this.ctx.backgroundRegistry;
-      if (!registry) {
-        // Tear down the orphaned handle so the fork isn't leaked.
-        // teardown() is the safe no-op when the handle hasn't started.
-        await handle.teardown().catch((e: unknown) =>
-          debugLog('subagent-executor: handle teardown failed: ' + (e instanceof Error ? e.message : String(e))),
-        );
-        return {
-          content:
-            'Background mode is not available in this session — no BackgroundAgentRegistry is wired. ' +
-            'Re-issue the call with mode="foreground" or run inside `afk interactive`.',
-          isError: true,
-        };
-      }
-      let job: ReturnType<typeof registry.register>;
-      try {
-        job = registry.register({
-          handle,
-          prompt: parsed.prompt,
-          model: childConfig.model ?? 'sonnet',
-          parentSessionId: this.ctx.parentSession.sessionId,
-        });
-      } catch (e) {
-        if (e instanceof BackgroundJobCapError) {
-          // Cap exceeded — tear down the orphaned handle so the fork isn't leaked.
-          await handle.teardown().catch((te: unknown) =>
-            debugLog('subagent-executor: handle teardown failed after cap error: ' + (te instanceof Error ? te.message : String(te))),
-          );
-          return {
-            content: e.message,
-            isError: true,
-          };
-        }
-        throw e;
-      }
-      const payload = {
-        status: 'running' as const,
-        jobId: job.jobId,
-        subagentId: job.subagentId,
-        label: job.label,
-        message:
-          `Background subagent started (jobId=${job.jobId}). ` +
-          `It is running detached; its result will be delivered into this context ` +
-          `automatically with the next user message once it finishes. ` +
-          `/bgsub:join ${job.jobId} remains available for manual replay.`,
-      };
-      return { content: JSON.stringify(payload) };
+      return runBackgroundBranch({
+        handle,
+        registry: this.ctx.backgroundRegistry,
+        prompt: parsed.prompt,
+        model: childConfig.model,
+        parentSessionId: this.ctx.parentSession.sessionId,
+      });
     }
 
-    // Wire abort: if signal fires, cancel the handle (foreground only —
-    // see comment on the background branch above for why).
-    const abortListener = () => {
-      void handle.cancel();
-    };
-    call.signal.addEventListener('abort', abortListener, { once: true });
-
-    const startedAt = Date.now();
-    const parentSessionId = this.ctx.parentSession.sessionId;
-
-    // ------------------------------------------------------------------
-    // Promotion plumbing (user-triggered backgrounding of a running
-    // foreground subagent — Ctrl+B).
-    //
-    // External constraint: the parent model is suspended at the single
-    // `runToResult` await below for this subagent's entire lifetime, and
-    // its progress reaches the UI through a side-channel progress sink —
-    // NOT via events on the parent stream. So a keyboard flag polled in the
-    // turn loop cannot interrupt this await. Instead we expose a promotion
-    // trigger through the narrow SubagentControl seam: when fired, it wins a
-    // race against the run; we hand the still-running handle to the
-    // BackgroundAgentRegistry and return the same synthetic "running"
-    // pointer the mode:'background' branch returns — unblocking the parent
-    // turn while the subagent keeps running detached.
-    //
-    // `promoted` gates the finally so a promoted (detached) handle and its
-    // child manager are NOT torn down here: the registry now owns the
-    // handle's lifetime, bounded by parent-session abort exactly like a
-    // natively-backgrounded job.
-    // ------------------------------------------------------------------
-    let promoted = false;
-    let firePromotion!: () => void;
-    const promotionSignal = new Promise<void>((resolve) => {
-      firePromotion = resolve;
+    // Foreground branch: race the run against a user-triggered promotion
+    // (Ctrl+B), shape success/failure, and clean up in a finally. The
+    // executor's two in-flight maps are handed in so the SubagentControl seam
+    // (promote/cancel) still observes and mutates the same live entries.
+    return runForegroundWithPromotion({
+      handle,
+      signal: call.signal,
+      prompt: parsed.prompt,
+      idPrefix: parsed.id_prefix,
+      model: childConfig.model,
+      childManager,
+      identity,
+      depth,
+      parentSessionId: this.ctx.parentSession.sessionId,
+      registry: this.ctx.backgroundRegistry,
+      promotionTriggers: this.promotionTriggers,
+      activeForegroundHandles: this.activeForegroundHandles,
     });
-    let resolveJob!: (info: PromotedSubagentInfo | null) => void;
-    const jobReady = new Promise<PromotedSubagentInfo | null>((resolve) => {
-      resolveJob = resolve;
-    });
-    this.promotionTriggers.set(handle.id, { fire: firePromotion, ready: jobReady });
-    // Registry-independent cancel handle (soft-stop path). Removed in the same
-    // finally as the promotion trigger below.
-    this.activeForegroundHandles.set(handle.id, handle);
-
-    // In-turn SubagentStop delivery.
-    //
-    // Invariant (delivery order — externally governed by the SDK tool-use
-    // protocol): SubagentStop fires from `handle.teardown()` in the `finally`
-    // below, which runs BEFORE this async execute() resolves and its
-    // tool_result is assembled/sent. So a foreground `agent` fork can carry the
-    // stop hook's `injectContext` (e.g. the shadow-verify nudge) in-turn — as
-    // part of the SAME tool_result the parent sees — instead of via the
-    // deferred queue channel. We therefore hoist the completion ToolResult into
-    // `toolResult` (rather than returning inside the try) and, after teardown
-    // records the note, append it to `toolResult.content`. Exactly-once:
-    // `teardown({ deferInjectContextToCaller: true })` suppresses the queue
-    // push for this stop, so the note rides the tool_result OR the queue, never
-    // both. The promoted / error-rethrow / abort paths leave `toolResult`
-    // unset, so no append happens on them (queue/registry semantics preserved).
-    let toolResult: ToolResult | undefined;
-
-    // Start the run but don't await it directly — race it against the
-    // promotion signal. The same `runPromise` is handed to the registry on
-    // promotion (it must NOT be re-run via runInBackground; see adoptRunning).
-    const runPromise = handle.runToResult(parsed.prompt);
-    try {
-      const outcome = await Promise.race<
-        | { kind: 'result'; result: Awaited<typeof runPromise> }
-        | { kind: 'promote' }
-      >([
-        runPromise.then((result) => ({ kind: 'result' as const, result })),
-        promotionSignal.then(() => ({ kind: 'promote' as const })),
-      ]);
-
-      // Promotion path: hand the in-flight handle to the background registry
-      // and return the synthetic running pointer (mirrors mode:'background').
-      // Falls through to await the run normally when no registry is wired or
-      // the background-job cap is hit — the subagent is never dropped.
-      if (outcome.kind === 'promote') {
-        const registry = this.ctx.backgroundRegistry;
-        if (registry) {
-          try {
-            const job = registry.adoptRunning({
-              handle,
-              runPromise,
-              prompt: parsed.prompt,
-              model: childConfig.model ?? 'sonnet',
-              parentSessionId,
-            });
-            promoted = true;
-            // Detach the end-of-turn abort bridge — the promoted job must
-            // outlive the turn that spawned it, exactly like mode:'background'.
-            call.signal.removeEventListener('abort', abortListener);
-            resolveJob({ jobId: job.jobId, label: job.label });
-            return {
-              content: JSON.stringify({
-                status: 'running' as const,
-                jobId: job.jobId,
-                subagentId: job.subagentId,
-                label: job.label,
-                message:
-                  `Subagent backgrounded by user (jobId=${job.jobId}). ` +
-                  `It keeps running detached; its result will be delivered into ` +
-                  `this context automatically with the next user message once it ` +
-                  `finishes. /bgsub:join ${job.jobId} remains available for manual replay.`,
-              }),
-            };
-          } catch (e) {
-            // Cap hit (or registry refusal): stay foreground. Mark the trigger
-            // "not promoted" and await the run normally below.
-            debugLog(
-              'subagent-executor: promotion failed, staying foreground: ' +
-                (e instanceof Error ? e.message : String(e)),
-            );
-            resolveJob(null);
-          }
-        } else {
-          resolveJob(null);
-        }
-      }
-
-      // Normal completion: result already in hand from the race, or promotion
-      // fell through and we await the still-running run.
-      const result = outcome.kind === 'result' ? outcome.result : await runPromise;
-
-      // Extract success or failure
-      if (result.status === 'succeeded' && result.message) {
-        const rawContent = result.message.content;
-        // Guard against non-string content (e.g. SDK may return a ContentBlock[])
-        const content = typeof rawContent === 'string' ? rawContent : JSON.stringify(rawContent);
-        const trace = result.trace;
-        void emitTelemetry({
-          ...identity,
-          event: 'subagent.completed',
-          subagent_id: handle.id,
-          parent_session_id: parentSessionId,
-          status: result.status,
-          duration_ms: Date.now() - startedAt,
-          content_chars: content.length,
-          depth,
-          tool_call_count: trace?.toolCalls.length,
-          // Preserve `false` ("confirmed absent") distinctly from `undefined`
-          // ("no trace available"); `|| undefined` would collapse both.
-          thinking_present: trace != null ? trace.thinkingPresent : undefined,
-          tool_names: trace?.toolCalls.length
-            ? JSON.stringify([...new Set(trace.toolCalls.map(tc => tc.name))])
-            : undefined,
-        });
-        // Assign (don't return) so the finally can append the in-turn
-        // SubagentStop injectContext after teardown. See `toolResult` above.
-        toolResult = { content };
-        return toolResult;
-      }
-
-      const errorMessage =
-        result.error?.message ?? 'Subagent failed with no output';
-      const failedTrace = result.trace;
-      void emitTelemetry({
-        ...identity,
-        event: 'subagent.failed',
-        subagent_id: handle.id,
-        id_prefix: parsed.id_prefix,
-        parent_session_id: parentSessionId,
-        status: result.status,
-        duration_ms: Date.now() - startedAt,
-        error_message: truncate(errorMessage),
-        schema_error: result.schemaError
-          ? truncate(result.schemaError.message)
-          : undefined,
-        partial_output_chars: measurePartial(result.partialOutput),
-        depth,
-        // Mirror trace fields on the failure path — failed subagents are the
-        // highest-value debugging target and benefit most from this signal.
-        tool_call_count: failedTrace?.toolCalls.length,
-        thinking_present: failedTrace != null ? failedTrace.thinkingPresent : undefined,
-        tool_names: failedTrace?.toolCalls.length
-          ? JSON.stringify([...new Set(failedTrace.toolCalls.map(tc => tc.name))])
-          : undefined,
-      });
-      // Audit §F.1: surface a structured JSON payload to the parent model
-      // instead of a plain error string, so the model can distinguish
-      // schema mismatch / partial output / hard failure rather than seeing
-      // a flattened "Subagent failed: ..." line.
-      const payload = buildFailurePayload({
-        status: result.status,
-        errorMessage,
-        schemaErrorMessage: result.schemaError?.message,
-        partialOutput: result.partialOutput,
-        subagentId: handle.id,
-      });
-      // Assign (don't return) so the finally can append the in-turn
-      // SubagentStop injectContext after teardown. See `toolResult` above.
-      toolResult = {
-        content: JSON.stringify(payload),
-        isError: true,
-      };
-      return toolResult;
-    } catch (err) {
-      // Defense in depth: an unexpected throw (e.g. timeout that surfaces
-      // as a rejection rather than a `failed` status) should still emit
-      // telemetry before propagating. The outer call chain treats a thrown
-      // execute() as an error path; we preserve that by re-throwing.
-      const message = err instanceof Error ? err.message : String(err);
-      void emitTelemetry({
-        ...identity,
-        event: 'subagent.failed',
-        subagent_id: handle.id,
-        id_prefix: parsed.id_prefix,
-        parent_session_id: parentSessionId,
-        status: 'failed',
-        duration_ms: Date.now() - startedAt,
-        error_message: truncate(message),
-        depth,
-      });
-      throw err;
-    } finally {
-      this.promotionTriggers.delete(handle.id);
-      this.activeForegroundHandles.delete(handle.id);
-      // Safety net: if the run won the race (or threw) before a fired
-      // promotion could be honored, resolve the trigger so a concurrent
-      // promoteActiveForeground() await never hangs. Idempotent — a no-op
-      // once resolveJob has already settled on the promotion path.
-      resolveJob(null);
-      if (!promoted) {
-        call.signal.removeEventListener('abort', abortListener);
-        await childManager?.teardownAll();
-        // Defer the SubagentStop injectContext to this caller so it rides the
-        // tool_result in-turn instead of the deferred queue. teardown() fires
-        // SubagentStop; with deferInjectContextToCaller the queue push is
-        // suppressed and the note (if any) is readable below.
-        await handle.teardown({ deferInjectContextToCaller: true });
-        // In-turn append: only when this foreground run produced a completion
-        // ToolResult (success or structured failure). The error-rethrow path
-        // leaves toolResult unset — nothing to append to, note is dropped for
-        // that stop by design (the throw is the parent's signal). Attribution:
-        // the note is appended to THIS subagent's own result, so a parent
-        // batching multiple `agent` calls sees each nudge next to its result.
-        // Optional-chain: real SubagentHandleImpl always defines this; the
-        // `?.()` tolerates narrow handle doubles (returns undefined = no note).
-        const injectContext = handle.getLastStopInjectContext?.();
-        if (toolResult !== undefined && injectContext !== undefined && injectContext.length > 0) {
-          toolResult.content = `${toolResult.content}\n\n${injectContext}`;
-        }
-      }
-    }
   }
 }

--- a/src/agent/tools/subagent/background-branch.ts
+++ b/src/agent/tools/subagent/background-branch.ts
@@ -1,0 +1,100 @@
+/**
+ * Background-mode execution path for the Agent tool.
+ *
+ * Extracted from `subagent-executor.ts` `execute()`: the `mode: 'background'`
+ * branch that registers the freshly-forked (not-yet-run) handle with the
+ * `BackgroundAgentRegistry` and returns a synthetic "running" pointer
+ * immediately, without ever awaiting `runToResult`.
+ *
+ * Pure-ish: receives the forked handle, the registry, and the resolved dispatch
+ * fields as explicit parameters; returns the `ToolResult` to hand back to the
+ * parent. No dependency on the executor instance.
+ *
+ * @module agent/tools/subagent/background-branch
+ */
+
+import { BackgroundJobCapError, type BackgroundAgentRegistry } from '../../background-registry.js';
+import type { SubagentManager } from '../../subagent.js';
+import { debugLog } from '../../../utils/debug.js';
+import type { ToolResult } from '../types.js';
+
+type ForkedHandle = Awaited<ReturnType<SubagentManager['forkSubagent']>>;
+
+export interface RunBackgroundBranchArgs {
+  handle: ForkedHandle;
+  /** May be undefined — an unwired registry yields the "not available" error. */
+  registry: BackgroundAgentRegistry | undefined;
+  prompt: string;
+  /** Child model for the registry record; falls back to 'sonnet' when unset. */
+  model: string | undefined;
+  /** Optional: `IAgentSession.sessionId` is `string | undefined`; forwarded as-is into the registry record (preserves the pre-extraction contract). */
+  parentSessionId: string | undefined;
+}
+
+/**
+ * Run the background-mode branch. Returns the `ToolResult` the parent's SDK
+ * tool-use loop expects before its next assistant turn.
+ *
+ * External constraint: the parent SDK tool-use loop expects a ToolResult per
+ * ToolCall *before the next assistant turn begins*. Background mode honors that
+ * contract by returning immediately with a structured pointer. The handle keeps
+ * running detached; the parent's AbortGraph still owns its lifetime (parent
+ * abort cascades down), and the registry's terminal-state callback captures the
+ * eventual outcome for explicit `join`.
+ *
+ * We deliberately do NOT wire the call.signal -> handle.cancel bridge here.
+ * That bridge ties the child's lifetime to the parent tool-call's signal, which
+ * is exactly wrong for fire-and-forget: the tool-call signal aborts at
+ * end-of-turn, and a background job is supposed to outlive the turn that
+ * spawned it. Cascade on parent-session abort still works because forkSubagent
+ * installs the SubagentManager root abort wiring independently.
+ */
+export async function runBackgroundBranch(args: RunBackgroundBranchArgs): Promise<ToolResult> {
+  const { handle, registry, prompt, model, parentSessionId } = args;
+  if (!registry) {
+    // Tear down the orphaned handle so the fork isn't leaked.
+    // teardown() is the safe no-op when the handle hasn't started.
+    await handle.teardown().catch((e: unknown) =>
+      debugLog('subagent-executor: handle teardown failed: ' + (e instanceof Error ? e.message : String(e))),
+    );
+    return {
+      content:
+        'Background mode is not available in this session — no BackgroundAgentRegistry is wired. ' +
+        'Re-issue the call with mode="foreground" or run inside `afk interactive`.',
+      isError: true,
+    };
+  }
+  let job: ReturnType<typeof registry.register>;
+  try {
+    job = registry.register({
+      handle,
+      prompt,
+      model: model ?? 'sonnet',
+      parentSessionId,
+    });
+  } catch (e) {
+    if (e instanceof BackgroundJobCapError) {
+      // Cap exceeded — tear down the orphaned handle so the fork isn't leaked.
+      await handle.teardown().catch((te: unknown) =>
+        debugLog('subagent-executor: handle teardown failed after cap error: ' + (te instanceof Error ? te.message : String(te))),
+      );
+      return {
+        content: e.message,
+        isError: true,
+      };
+    }
+    throw e;
+  }
+  const payload = {
+    status: 'running' as const,
+    jobId: job.jobId,
+    subagentId: job.subagentId,
+    label: job.label,
+    message:
+      `Background subagent started (jobId=${job.jobId}). ` +
+      `It is running detached; its result will be delivered into this context ` +
+      `automatically with the next user message once it finishes. ` +
+      `/bgsub:join ${job.jobId} remains available for manual replay.`,
+  };
+  return { content: JSON.stringify(payload) };
+}

--- a/src/agent/tools/subagent/child-config.ts
+++ b/src/agent/tools/subagent/child-config.ts
@@ -1,0 +1,325 @@
+/**
+ * Child AgentSession config construction + nesting/depth wiring.
+ *
+ * Extracted from `subagent-executor.ts` `execute()`: everything between
+ * named-agent resolution and `forkSubagent` — model resolution, named-agent
+ * tool-access composition, turn-budget resolution, per-model credential
+ * resolution, the `childConfig` object, and the recursive nesting wiring
+ * (child SubagentManager + child SubagentExecutor + child provider, or the
+ * depth-cap restricted-provider fallback).
+ *
+ * Pure-ish: receives everything it needs as explicit parameters (the parsed
+ * input, the resolved named agent, the relevant executor-context fields, and
+ * two factory callbacks) and returns the built config plus the mutable child
+ * parent-session stub the caller must backfill after `forkSubagent`. The
+ * recursive `new SubagentExecutor(...)` is injected as `createChildExecutor`
+ * so this module does not import the executor at runtime (avoids a circular
+ * import) — mirroring the `import type` seam `nesting.ts` already uses.
+ *
+ * @module agent/tools/subagent/child-config
+ */
+
+import { SubagentManager } from '../../subagent.js';
+import type { ModelProvider } from '../../provider.js';
+import type { AgentModelInput, IAgentSession } from '../../types.js';
+import type { AgentConfig } from '../../types/config-types.js';
+import { providerForModel } from '../../providers/index.js';
+import { applyParentCredentialFallback } from '../child-credential.js';
+import { resolveCredentialForModel } from '../../auth/credential-resolver.js';
+import {
+  CHILD_ALLOWED_TOOLS,
+  buildSkillRestrictedProvider,
+  createStubParentSession,
+  type ChildProviderFactoryArgs,
+} from '../nesting.js';
+import { resolveAgentToolAccess } from '../../agents/index.js';
+import type { RegisteredAgent } from '../../agents/index.js';
+import type { AgentRegistry } from '../../agents/index.js';
+import type { SkillExecutor } from '../skill-executor.js';
+import type { Surface } from '../../awareness/types.js';
+import type { SubagentExecutor, SubagentExecutorContext } from '../subagent-executor.js';
+import type { AgentInput } from './input-parse.js';
+
+/** Mutable child parent-session stub: `sessionId` is backfilled to `handle.id`. */
+export type ChildParentSession = ReturnType<typeof createStubParentSession> & {
+  sessionId: string | undefined;
+};
+
+/**
+ * The subset of {@link SubagentExecutorContext} `buildChildConfig` reads, plus
+ * the resolved `depth`/`maxDepth` and the two factory callbacks. Passed
+ * explicitly (rather than the whole `ctx` + `this`) so the data this module
+ * depends on is visible at the call site — no hidden coupling.
+ */
+export interface BuildChildConfigArgs {
+  parsed: AgentInput;
+  namedAgent: RegisteredAgent | undefined;
+  depth: number;
+  maxDepth: number;
+  currentCwd: string | undefined;
+  /** The dispatching tool-call's abort signal (owns the child manager lifetime). */
+  signal: AbortSignal;
+  defaultConfig: Pick<AgentConfig, 'apiKey' | 'systemPrompt' | 'baseUrl' | 'openaiBaseUrl'>;
+  resolveApiKeyForModel?: (model: string) => string | undefined;
+  defaultSubagentModel?: AgentModelInput;
+  childProviderFactory?: (args: ChildProviderFactoryArgs) => ModelProvider;
+  childSkillExecutorFactory?: (depth: number, maxDepth: number, signal: AbortSignal, inheritedCwd?: string) => SkillExecutor;
+  surface?: Surface;
+  allowedTools?: string[];
+  readOnlyBash?: boolean;
+  agentRegistry?: AgentRegistry;
+  parentModel?: AgentModelInput;
+  /**
+   * Construct the recursive child executor. Injected by the owning
+   * `SubagentExecutor.execute()` as `(ctx) => new SubagentExecutor(ctx)` so
+   * this module never imports the executor at runtime (circular-import seam;
+   * the `SubagentExecutor` reference here is type-only, mirroring nesting.ts).
+   */
+  createChildExecutor: (ctx: SubagentExecutorContext) => SubagentExecutor;
+}
+
+export interface BuildChildConfigResult {
+  childConfig: AgentConfig;
+  /** Present only when nesting wiring built a child executor; caller backfills its sessionId. */
+  childParentSession: ChildParentSession | undefined;
+  /**
+   * The depth-2+ child manager, present only when nesting wiring ran. The
+   * caller (foreground branch) MUST `teardownAll()` it in its finally unless
+   * the run was promoted — the registry then owns the detached lifetime.
+   */
+  childManager: SubagentManager | undefined;
+}
+
+/**
+ * Build the child `AgentConfig` and wire nested dispatch (child manager +
+ * executor + provider). Returns the config plus the mutable child parent
+ * session the caller backfills with `handle.id` after `forkSubagent`.
+ */
+export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigResult {
+  const {
+    parsed,
+    namedAgent,
+    depth,
+    maxDepth,
+    currentCwd,
+    signal,
+    defaultConfig,
+    createChildExecutor,
+  } = args;
+
+  // Resolve the child's effective model and the provider it routes to FIRST,
+  // so we can decide whether the parent's Anthropic-shaped `apiKey` /
+  // `baseUrl` (sourced from `loadCredential()` + `AFK_LOCAL_BASE_URL`) should
+  // be forwarded. Forwarding them to an OpenAI-routed child causes
+  // `resolveOpenAIAuth()` to return the Anthropic key as if it were a config
+  // OpenAI key (tier 1 wins) — the OpenAI API then 401s. Clearing them lets
+  // the OpenAI auth resolver walk its env / codex precedence cleanly.
+  // Model resolution.
+  //   Unnamed dispatch (legacy, unchanged): call-site > policy default > 'sonnet'.
+  //   Named dispatch (Claude Code parity): call-site > definition model
+  //   ('inherit' → dispatching session's model) > inherit-by-default
+  //   (omitted model also means inherit) > policy default > 'sonnet'.
+  // `parentModel` is optional ctx wiring; when absent, inherit falls
+  // through to the policy chain rather than guessing.
+  let namedDefaultModel: string | undefined;
+  if (namedAgent !== undefined) {
+    const defModel = namedAgent.definition.model;
+    namedDefaultModel =
+      defModel !== undefined && defModel !== 'inherit'
+        ? defModel
+        : args.parentModel;
+  }
+  const childModel: string =
+    parsed.model ?? namedDefaultModel ?? args.defaultSubagentModel ?? 'sonnet';
+  const childIsOpenAI = providerForModel(childModel) === 'openai-compatible';
+
+  // Named-agent tool access: resolve the definition's declared surface into
+  // runtime terms, then compose with any cage this executor already sits in
+  // (a read-only skill's fan-out). Composition is fail-closed:
+  //   allowlist  = def ∩ cage   (when both exist; either alone otherwise)
+  //   bash gate  = def ∨ cage
+  // — mirroring skill-executor.ts buildForkedChildConfig's intersection
+  // semantics, so a named dispatch can never widen an existing cage.
+  const resolvedAccess =
+    namedAgent !== undefined
+      ? resolveAgentToolAccess(namedAgent, CHILD_ALLOWED_TOOLS)
+      : undefined;
+  let effectiveAllowedTools: string[] | undefined = args.allowedTools;
+  if (resolvedAccess?.allowedTools !== undefined) {
+    const cage = args.allowedTools;
+    effectiveAllowedTools =
+      cage !== undefined
+        ? resolvedAccess.allowedTools.filter((t) => cage.includes(t))
+        : resolvedAccess.allowedTools;
+  }
+  const effectiveReadOnlyBash =
+    args.readOnlyBash === true || resolvedAccess?.bashReadOnly === true;
+  if (resolvedAccess !== undefined && resolvedAccess.droppedTokens.length > 0) {
+    // Fail-closed token drops silently NARROW the child's tool surface, so a
+    // misconfigured agent file must be visible by default — not only under
+    // AFK_DEBUG. Route through the same stderr sink the agent registry uses
+    // for its load-time warnings (loadAgentRegistry's default `warn`).
+    process.stderr.write(
+      `[afk] agents: agent_type ${JSON.stringify(namedAgent?.name)}: ` +
+        `unknown tool token(s) dropped fail-closed: ${resolvedAccess.droppedTokens.join(', ')}\n`,
+    );
+  }
+
+  // Turn budget: explicit per-call max_turns wins; otherwise a named
+  // agent's maxTurns frontmatter (clamped to the same [1, 50] envelope);
+  // otherwise the parse-time default.
+  const effectiveMaxTurns =
+    !parsed.max_turns_explicit && namedAgent?.definition.maxTurns !== undefined
+      ? Math.max(1, Math.min(50, Math.floor(namedAgent.definition.maxTurns)))
+      : parsed.max_turns;
+
+  // Resolve the child's API key by its own model/provider. The resolver is
+  // now available directly from the agent layer (resolveCredentialForModel),
+  // so no injection is required — `this.ctx.resolveApiKeyForModel` acts as
+  // an optional override for callers that need a custom strategy (e.g. tests).
+  // When absent, the default agent-layer resolver is used. The
+  // `childIsOpenAI ? undefined` guard below is preserved as a
+  // defense-in-depth layer (cross-provider credential anti-leak invariant).
+  //
+  // applyParentCredentialFallback adds a second safety net: when fresh
+  // per-model resolution comes up empty for an Anthropic child (the sync
+  // keychain reader bailing on an expired OAuth token), reuse the parent's
+  // bootstrap-captured credential IFF it is Anthropic-shaped — so the child
+  // gets a token to attempt with and its own 401 refresher self-heals,
+  // instead of dying at the provider pre-flight. See child-credential.ts.
+  const resolvedChildApiKey = applyParentCredentialFallback({
+    childModel,
+    resolved: args.resolveApiKeyForModel
+      ? args.resolveApiKeyForModel(childModel)
+      : resolveCredentialForModel(childModel),
+    parentApiKey: defaultConfig.apiKey,
+  });
+
+  const childConfig: AgentConfig = {
+    model: childModel,
+    apiKey: childIsOpenAI ? undefined : resolvedChildApiKey,
+    // A named agent's markdown body IS the child's system prompt (Claude
+    // Code parity: subagents receive the definition prompt, not the parent
+    // surface's full prompt). Unnamed dispatches keep the raw base prompt.
+    systemPrompt: namedAgent !== undefined ? namedAgent.definition.prompt : defaultConfig.systemPrompt,
+    baseUrl: childIsOpenAI ? undefined : defaultConfig.baseUrl,
+    maxTurns: effectiveMaxTurns,
+    // Awareness metadata (Phase 1, get_runtime_state):
+    // Thread depth + maxDepth into the child's AgentConfig so the
+    // `self` view of the child's get_runtime_state snapshot reflects
+    // its actual nesting position. `parentSessionId` is injected later
+    // by SubagentManager.forkSubagent which has options.parent.sessionId
+    // in scope; phaseRole is also handled there.
+    depth: depth + 1,
+    maxDepth,
+    // Per-call cwd override. When set, `SubagentManager.forkSubagent`
+    // applies this in preference to the manager's `parentCwd` fallback
+    // (see src/agent/subagent.ts:291-297) — the child's dispatcher
+    // resolveBase + read/write roots anchor at this path. When omitted,
+    // the parent inheritance chain stays intact.
+    ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
+  } as AgentConfig;
+
+  // Wire nesting: give the child its own executor + provider so it can
+  // dispatch Agent and Skill tool calls. Skip when at maxDepth or no
+  // factory — child gracefully loses both tools.
+  //
+  // childParentSession is a mutable stub: sessionId starts undefined and is
+  // backfilled to handle.id once forkSubagent resolves. This ensures depth-2
+  // forks (dispatched by childExecutor) see a real parentId rather than
+  // undefined, so the stream-renderer can attribute them correctly.
+  let childParentSession: ChildParentSession | undefined;
+  let childManager: SubagentManager | undefined;
+  if (args.childProviderFactory && depth < maxDepth) {
+    // Forward cwd to the child manager so depth-2 forks (this depth-1
+    // child calling the `agent` tool) inherit the worktree anchor.
+    // Without this, `SubagentManager.forkSubagent` reads `this.parentCwd`
+    // (undefined) and depth-2 child config.cwd is omitted — its
+    // bash/grep/read_file fall back to process.cwd() (host repo).
+    childManager = new SubagentManager({
+      parentAbortSignal: signal,
+      ...(currentCwd !== undefined ? { cwd: currentCwd } : {}),
+    });
+    childParentSession = createStubParentSession(signal) as ChildParentSession;
+    const childExecutor = createChildExecutor({
+      subagentManager: childManager,
+      parentSession: childParentSession as Pick<IAgentSession, 'sessionId' | 'getInputStreamRef' | 'abortSignal'>,
+      defaultConfig,
+      // Inherit origin from the parent; `depth + 1` below makes this child's
+      // emitted rows carry actor:'subagent'.
+      ...(args.surface !== undefined ? { surface: args.surface } : {}),
+      defaultSubagentModel: args.defaultSubagentModel,
+      childProviderFactory: args.childProviderFactory,
+      childSkillExecutorFactory: args.childSkillExecutorFactory,
+      // Propagate the resolver so depth ≥ 2 forks (this depth-1 child
+      // calling the `agent` tool) also resolve credentials by child model.
+      ...(args.resolveApiKeyForModel !== undefined
+        ? { resolveApiKeyForModel: args.resolveApiKeyForModel }
+        : {}),
+      depth: depth + 1,
+      maxDepth,
+      // Forward cwd so the depth-1 child executor, when it constructs
+      // ITS own childManager for depth-3+ forks, also receives cwd. The
+      // chain holds for arbitrary depth up to maxDepth.
+      ...(currentCwd !== undefined ? { cwd: currentCwd } : {}),
+      // Propagate read-only constraints so depth ≥ 2 forks (this depth-1
+      // child calling the `agent` tool) keep the same tool allowlist and
+      // bash gate that the originating read-only skill imposed.
+      //
+      // Deliberately the CAGE (ctx) values, not the named-agent effective
+      // values: a named definition constrains the child it dispatches, not
+      // that child's own descendants (Claude Code parity — nested spawns
+      // resolve their own agent types). The cage, by contrast, cascades.
+      ...(args.allowedTools !== undefined ? { allowedTools: args.allowedTools } : {}),
+      ...(args.readOnlyBash ? { readOnlyBash: true } : {}),
+      // Named-agent registry + the child's model (for grandchild `inherit`
+      // resolution) thread through every depth.
+      ...(args.agentRegistry !== undefined ? { agentRegistry: args.agentRegistry } : {}),
+      // Scope the dispatched agent's OWN nested dispatches to the leaf types
+      // its definition named (resolve.ts `nestedAgentTypes`). This is what
+      // lets research-agent dispatch git-investigator and NOTHING else — the
+      // gate at execute() top reads this from its ctx. Unset ⇒ unrestricted
+      // (top-level, inherit-all, or bare-`Agent` agents).
+      ...(resolvedAccess?.nestedAgentTypes !== undefined
+        ? { nestedAgentAllowlist: resolvedAccess.nestedAgentTypes }
+        : {}),
+      parentModel: childModel,
+    });
+    const childSkillExecutor = args.childSkillExecutorFactory
+      ? args.childSkillExecutorFactory(depth + 1, maxDepth, signal, currentCwd)
+      : undefined;
+    // Pass `model` so the factory routes between AnthropicDirect /
+    // OpenAICompatible per `providerForModel(model)`. Without this, every
+    // child inherits the legacy hardcoded AnthropicDirectProvider — which
+    // means a gpt-4o parent silently dispatches subagents to
+    // api.anthropic.com. See nesting.ts `createChildProviderFactory`.
+    childConfig.provider = args.childProviderFactory({
+      childExecutor,
+      ...(childSkillExecutor !== undefined ? { childSkillExecutor } : {}),
+      ...(childConfig.model !== undefined ? { model: childConfig.model } : {}),
+      // Effective tool access for the dispatched child: the pre-existing
+      // cage (read-only skill fan-out), intersected with the named agent's
+      // resolved allowlist when one is in play (computed above). The
+      // dispatcher both enforces this at the permission gate AND filters
+      // the advertised schema to match (dispatcher.ts toolDefs), so a
+      // research-agent child never even sees bash/write_file/agent.
+      ...(effectiveAllowedTools !== undefined ? { allowedTools: effectiveAllowedTools } : {}),
+      ...(effectiveReadOnlyBash ? { readOnlyBash: true } : {}),
+    });
+  } else if (effectiveAllowedTools !== undefined || effectiveReadOnlyBash) {
+    // Restricted dispatch at the depth cap (or with no factory wired):
+    // without an explicit provider the fork would inherit the default
+    // UNRESTRICTED provider and the named agent's contract would silently
+    // fail open. Build a minimal restricted provider instead — no nested
+    // executors (at the cap the child cannot fan out anyway). Mirrors the
+    // cap-path fix in skill-executor.ts buildForkedChildConfig.
+    childConfig.provider = buildSkillRestrictedProvider(
+      effectiveAllowedTools ?? [...CHILD_ALLOWED_TOOLS],
+      childConfig.model,
+      effectiveReadOnlyBash,
+      defaultConfig.openaiBaseUrl,
+    );
+  }
+
+  return { childConfig, childParentSession, childManager };
+}

--- a/src/agent/tools/subagent/failure-payload.ts
+++ b/src/agent/tools/subagent/failure-payload.ts
@@ -1,0 +1,107 @@
+/**
+ * Failure-path payload + telemetry shaping helpers.
+ *
+ * Extracted from `subagent-executor.ts`: the best-effort telemetry wrapper and
+ * the small pure helpers that shape the structured JSON failure payload
+ * returned to the parent model. Shared by the fork-error, background, and
+ * foreground paths in `execute()`. All functions are pure — no dependency on
+ * the executor instance.
+ *
+ * @module agent/tools/subagent/failure-payload
+ */
+
+import { appendRoutingDecision } from '../../routing-telemetry.js';
+
+/**
+ * Best-effort telemetry helper. Wraps {@link appendRoutingDecision} so a
+ * synchronous throw (shouldn't happen — the helper already swallows) cannot
+ * propagate into the dispatch path.
+ */
+export function emitTelemetry(entry: Parameters<typeof appendRoutingDecision>[0]): Promise<void> {
+  try {
+    return appendRoutingDecision(entry).catch(() => {});
+  } catch {
+    return Promise.resolve();
+  }
+}
+
+/** Truncate short telemetry strings; we never log full error bodies. */
+export function truncate(s: string, max = 240): string {
+  return s.length <= max ? s : s.slice(0, max) + '…';
+}
+
+/** Measure partial output size without serializing large structures repeatedly. */
+export function measurePartial(partial: unknown): number | undefined {
+  if (partial === undefined || partial === null) return undefined;
+  if (typeof partial === 'string') return partial.length;
+  try {
+    return JSON.stringify(partial).length;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Maximum serialized size of `partialOutput` we will surface to the parent
+ * model. Above this, we replace the payload with a `{ truncated, chars }`
+ * marker so the parent learns partial output existed without flooding its
+ * context.
+ */
+const MAX_PARTIAL_OUTPUT_CHARS = 4096;
+
+/** Maximum length of the `error` field in the structured failure payload. */
+const MAX_ERROR_MESSAGE_CHARS = 1024;
+
+/**
+ * Shape a partial output for inclusion in the structured failure payload.
+ * Returns `undefined` when the input is null/undefined (key is omitted).
+ * Returns a `{ truncated, chars }` marker when serialization exceeds the cap.
+ */
+function shapePartialOutput(
+  partial: unknown,
+): unknown | undefined {
+  if (partial === undefined || partial === null) return undefined;
+  const chars = measurePartial(partial);
+  if (chars !== undefined && chars > MAX_PARTIAL_OUTPUT_CHARS) {
+    return { truncated: true, chars };
+  }
+  return partial;
+}
+
+/**
+ * Build the structured JSON payload returned to the parent model on the
+ * failure path. Intentionally small: status + short error + optional schema
+ * error string + optional (size-capped) partial output + subagent id.
+ *
+ * Excludes by design: prompts, full subagent assistant messages, file
+ * contents, tool inputs/outputs, credentials, stack traces.
+ */
+export interface StructuredFailurePayload {
+  status: string;
+  error: string;
+  schemaError?: string;
+  partialOutput?: unknown;
+  subagent_id: string;
+}
+
+export function buildFailurePayload(args: {
+  status: string;
+  errorMessage: string;
+  schemaErrorMessage?: string;
+  partialOutput?: unknown;
+  subagentId: string;
+}): StructuredFailurePayload {
+  const payload: StructuredFailurePayload = {
+    status: args.status,
+    error: truncate(args.errorMessage, MAX_ERROR_MESSAGE_CHARS),
+    subagent_id: args.subagentId,
+  };
+  if (args.schemaErrorMessage) {
+    payload.schemaError = truncate(args.schemaErrorMessage, MAX_ERROR_MESSAGE_CHARS);
+  }
+  const shaped = shapePartialOutput(args.partialOutput);
+  if (shaped !== undefined) {
+    payload.partialOutput = shaped;
+  }
+  return payload;
+}

--- a/src/agent/tools/subagent/foreground-promotion.ts
+++ b/src/agent/tools/subagent/foreground-promotion.ts
@@ -1,0 +1,329 @@
+/**
+ * Foreground run + user-triggered promotion (Ctrl+B) for the Agent tool.
+ *
+ * Extracted from `subagent-executor.ts` `execute()`: the deeply-nested
+ * foreground path — abort wiring, the promotion `Promise.race`, the
+ * adopt-to-background handoff, success/failure telemetry + payload shaping, and
+ * the try/finally cleanup that fires the in-turn SubagentStop and appends its
+ * injectContext to the tool_result.
+ *
+ * Pure-ish: the executor's two in-flight maps and its background registry are
+ * passed in as explicit parameters (state in), and the function returns the
+ * `ToolResult` (or re-throws) — no `this`, no hidden coupling. The exact
+ * ordering of telemetry emission, the promotion race, abort listener
+ * add/remove, and the finally-block teardown is preserved verbatim; the inline
+ * comments documenting those invariants move with the code.
+ *
+ * @module agent/tools/subagent/foreground-promotion
+ */
+
+import type { BackgroundAgentRegistry } from '../../background-registry.js';
+import type { SubagentManager } from '../../subagent.js';
+import { debugLog } from '../../../utils/debug.js';
+import type { TraceOrigin, TraceActor } from '../../session/session-identity.js';
+import type { ToolResult } from '../types.js';
+import type { PromotedSubagentInfo } from '../subagent-executor.js';
+import { emitTelemetry, truncate, measurePartial, buildFailurePayload } from './failure-payload.js';
+
+type ForkedHandle = Awaited<ReturnType<SubagentManager['forkSubagent']>>;
+
+/**
+ * Promotion trigger registered per in-flight foreground subagent. `fire()`
+ * resolves the executor's promotion signal (winning the race); `ready` resolves
+ * with the created job once the handoff completes, or `null` if promotion could
+ * not happen. Shared shape with `SubagentExecutor.promotionTriggers`.
+ */
+export interface PromotionTrigger {
+  fire: () => void;
+  ready: Promise<PromotedSubagentInfo | null>;
+}
+
+export interface RunForegroundArgs {
+  handle: ForkedHandle;
+  /** The dispatching tool-call's abort signal + id_prefix carrier. */
+  signal: AbortSignal;
+  prompt: string;
+  /** Optional: sourced from `AgentInput.id_prefix` (`id_prefix?: string`); flows only into telemetry, which accepts undefined. */
+  idPrefix: string | undefined;
+  /** Child model for the promotion registry record; falls back to 'sonnet'. */
+  model: string | undefined;
+  /** Child manager to tear down in the finally (unless promoted). */
+  childManager: SubagentManager | undefined;
+  /** Routing-decision identity fields (empty when this executor lacks a surface). */
+  identity: { origin?: TraceOrigin; actor?: TraceActor };
+  depth: number;
+  /** Optional: `IAgentSession.sessionId` is `string | undefined`; forwarded as-is into telemetry + registry (preserves the pre-extraction contract). */
+  parentSessionId: string | undefined;
+  /** May be undefined — promotion then falls through to a normal foreground await. */
+  registry: BackgroundAgentRegistry | undefined;
+  /** The executor's live promotion-trigger map (keyed by handle.id). */
+  promotionTriggers: Map<string, PromotionTrigger>;
+  /** The executor's live cancellable-handle map (keyed by handle.id). */
+  activeForegroundHandles: Map<string, { cancel: () => Promise<void> }>;
+}
+
+/**
+ * Run the foreground branch: race the run against a promotion signal, handle
+ * success/failure, and clean up in a finally. Returns the `ToolResult`, or
+ * re-throws on the defense-in-depth error path.
+ */
+export async function runForegroundWithPromotion(args: RunForegroundArgs): Promise<ToolResult> {
+  const {
+    handle,
+    signal,
+    prompt,
+    idPrefix,
+    model,
+    childManager,
+    identity,
+    depth,
+    parentSessionId,
+    registry,
+    promotionTriggers,
+    activeForegroundHandles,
+  } = args;
+
+  // Wire abort: if signal fires, cancel the handle (foreground only —
+  // see comment on the background branch above for why).
+  const abortListener = () => {
+    void handle.cancel();
+  };
+  signal.addEventListener('abort', abortListener, { once: true });
+
+  const startedAt = Date.now();
+
+  // ------------------------------------------------------------------
+  // Promotion plumbing (user-triggered backgrounding of a running
+  // foreground subagent — Ctrl+B).
+  //
+  // External constraint: the parent model is suspended at the single
+  // `runToResult` await below for this subagent's entire lifetime, and
+  // its progress reaches the UI through a side-channel progress sink —
+  // NOT via events on the parent stream. So a keyboard flag polled in the
+  // turn loop cannot interrupt this await. Instead we expose a promotion
+  // trigger through the narrow SubagentControl seam: when fired, it wins a
+  // race against the run; we hand the still-running handle to the
+  // BackgroundAgentRegistry and return the same synthetic "running"
+  // pointer the mode:'background' branch returns — unblocking the parent
+  // turn while the subagent keeps running detached.
+  //
+  // `promoted` gates the finally so a promoted (detached) handle and its
+  // child manager are NOT torn down here: the registry now owns the
+  // handle's lifetime, bounded by parent-session abort exactly like a
+  // natively-backgrounded job.
+  // ------------------------------------------------------------------
+  let promoted = false;
+  let firePromotion!: () => void;
+  const promotionSignal = new Promise<void>((resolve) => {
+    firePromotion = resolve;
+  });
+  let resolveJob!: (info: PromotedSubagentInfo | null) => void;
+  const jobReady = new Promise<PromotedSubagentInfo | null>((resolve) => {
+    resolveJob = resolve;
+  });
+  promotionTriggers.set(handle.id, { fire: firePromotion, ready: jobReady });
+  // Registry-independent cancel handle (soft-stop path). Removed in the same
+  // finally as the promotion trigger below.
+  activeForegroundHandles.set(handle.id, handle);
+
+  // In-turn SubagentStop delivery.
+  //
+  // Invariant (delivery order — externally governed by the SDK tool-use
+  // protocol): SubagentStop fires from `handle.teardown()` in the `finally`
+  // below, which runs BEFORE this async execute() resolves and its
+  // tool_result is assembled/sent. So a foreground `agent` fork can carry the
+  // stop hook's `injectContext` (e.g. the shadow-verify nudge) in-turn — as
+  // part of the SAME tool_result the parent sees — instead of via the
+  // deferred queue channel. We therefore hoist the completion ToolResult into
+  // `toolResult` (rather than returning inside the try) and, after teardown
+  // records the note, append it to `toolResult.content`. Exactly-once:
+  // `teardown({ deferInjectContextToCaller: true })` suppresses the queue
+  // push for this stop, so the note rides the tool_result OR the queue, never
+  // both. The promoted / error-rethrow / abort paths leave `toolResult`
+  // unset, so no append happens on them (queue/registry semantics preserved).
+  let toolResult: ToolResult | undefined;
+
+  // Start the run but don't await it directly — race it against the
+  // promotion signal. The same `runPromise` is handed to the registry on
+  // promotion (it must NOT be re-run via runInBackground; see adoptRunning).
+  const runPromise = handle.runToResult(prompt);
+  try {
+    const outcome = await Promise.race<
+      | { kind: 'result'; result: Awaited<typeof runPromise> }
+      | { kind: 'promote' }
+    >([
+      runPromise.then((result) => ({ kind: 'result' as const, result })),
+      promotionSignal.then(() => ({ kind: 'promote' as const })),
+    ]);
+
+    // Promotion path: hand the in-flight handle to the background registry
+    // and return the synthetic running pointer (mirrors mode:'background').
+    // Falls through to await the run normally when no registry is wired or
+    // the background-job cap is hit — the subagent is never dropped.
+    if (outcome.kind === 'promote') {
+      if (registry) {
+        try {
+          const job = registry.adoptRunning({
+            handle,
+            runPromise,
+            prompt,
+            model: model ?? 'sonnet',
+            parentSessionId,
+          });
+          promoted = true;
+          // Detach the end-of-turn abort bridge — the promoted job must
+          // outlive the turn that spawned it, exactly like mode:'background'.
+          signal.removeEventListener('abort', abortListener);
+          resolveJob({ jobId: job.jobId, label: job.label });
+          return {
+            content: JSON.stringify({
+              status: 'running' as const,
+              jobId: job.jobId,
+              subagentId: job.subagentId,
+              label: job.label,
+              message:
+                `Subagent backgrounded by user (jobId=${job.jobId}). ` +
+                `It keeps running detached; its result will be delivered into ` +
+                `this context automatically with the next user message once it ` +
+                `finishes. /bgsub:join ${job.jobId} remains available for manual replay.`,
+            }),
+          };
+        } catch (e) {
+          // Cap hit (or registry refusal): stay foreground. Mark the trigger
+          // "not promoted" and await the run normally below.
+          debugLog(
+            'subagent-executor: promotion failed, staying foreground: ' +
+              (e instanceof Error ? e.message : String(e)),
+          );
+          resolveJob(null);
+        }
+      } else {
+        resolveJob(null);
+      }
+    }
+
+    // Normal completion: result already in hand from the race, or promotion
+    // fell through and we await the still-running run.
+    const result = outcome.kind === 'result' ? outcome.result : await runPromise;
+
+    // Extract success or failure
+    if (result.status === 'succeeded' && result.message) {
+      const rawContent = result.message.content;
+      // Guard against non-string content (e.g. SDK may return a ContentBlock[])
+      const content = typeof rawContent === 'string' ? rawContent : JSON.stringify(rawContent);
+      const trace = result.trace;
+      void emitTelemetry({
+        ...identity,
+        event: 'subagent.completed',
+        subagent_id: handle.id,
+        parent_session_id: parentSessionId,
+        status: result.status,
+        duration_ms: Date.now() - startedAt,
+        content_chars: content.length,
+        depth,
+        tool_call_count: trace?.toolCalls.length,
+        // Preserve `false` ("confirmed absent") distinctly from `undefined`
+        // ("no trace available"); `|| undefined` would collapse both.
+        thinking_present: trace != null ? trace.thinkingPresent : undefined,
+        tool_names: trace?.toolCalls.length
+          ? JSON.stringify([...new Set(trace.toolCalls.map(tc => tc.name))])
+          : undefined,
+      });
+      // Assign (don't return) so the finally can append the in-turn
+      // SubagentStop injectContext after teardown. See `toolResult` above.
+      toolResult = { content };
+      return toolResult;
+    }
+
+    const errorMessage =
+      result.error?.message ?? 'Subagent failed with no output';
+    const failedTrace = result.trace;
+    void emitTelemetry({
+      ...identity,
+      event: 'subagent.failed',
+      subagent_id: handle.id,
+      id_prefix: idPrefix,
+      parent_session_id: parentSessionId,
+      status: result.status,
+      duration_ms: Date.now() - startedAt,
+      error_message: truncate(errorMessage),
+      schema_error: result.schemaError
+        ? truncate(result.schemaError.message)
+        : undefined,
+      partial_output_chars: measurePartial(result.partialOutput),
+      depth,
+      // Mirror trace fields on the failure path — failed subagents are the
+      // highest-value debugging target and benefit most from this signal.
+      tool_call_count: failedTrace?.toolCalls.length,
+      thinking_present: failedTrace != null ? failedTrace.thinkingPresent : undefined,
+      tool_names: failedTrace?.toolCalls.length
+        ? JSON.stringify([...new Set(failedTrace.toolCalls.map(tc => tc.name))])
+        : undefined,
+    });
+    // Audit §F.1: surface a structured JSON payload to the parent model
+    // instead of a plain error string, so the model can distinguish
+    // schema mismatch / partial output / hard failure rather than seeing
+    // a flattened "Subagent failed: ..." line.
+    const payload = buildFailurePayload({
+      status: result.status,
+      errorMessage,
+      schemaErrorMessage: result.schemaError?.message,
+      partialOutput: result.partialOutput,
+      subagentId: handle.id,
+    });
+    // Assign (don't return) so the finally can append the in-turn
+    // SubagentStop injectContext after teardown. See `toolResult` above.
+    toolResult = {
+      content: JSON.stringify(payload),
+      isError: true,
+    };
+    return toolResult;
+  } catch (err) {
+    // Defense in depth: an unexpected throw (e.g. timeout that surfaces
+    // as a rejection rather than a `failed` status) should still emit
+    // telemetry before propagating. The outer call chain treats a thrown
+    // execute() as an error path; we preserve that by re-throwing.
+    const message = err instanceof Error ? err.message : String(err);
+    void emitTelemetry({
+      ...identity,
+      event: 'subagent.failed',
+      subagent_id: handle.id,
+      id_prefix: idPrefix,
+      parent_session_id: parentSessionId,
+      status: 'failed',
+      duration_ms: Date.now() - startedAt,
+      error_message: truncate(message),
+      depth,
+    });
+    throw err;
+  } finally {
+    promotionTriggers.delete(handle.id);
+    activeForegroundHandles.delete(handle.id);
+    // Safety net: if the run won the race (or threw) before a fired
+    // promotion could be honored, resolve the trigger so a concurrent
+    // promoteActiveForeground() await never hangs. Idempotent — a no-op
+    // once resolveJob has already settled on the promotion path.
+    resolveJob(null);
+    if (!promoted) {
+      signal.removeEventListener('abort', abortListener);
+      await childManager?.teardownAll();
+      // Defer the SubagentStop injectContext to this caller so it rides the
+      // tool_result in-turn instead of the deferred queue. teardown() fires
+      // SubagentStop; with deferInjectContextToCaller the queue push is
+      // suppressed and the note (if any) is readable below.
+      await handle.teardown({ deferInjectContextToCaller: true });
+      // In-turn append: only when this foreground run produced a completion
+      // ToolResult (success or structured failure). The error-rethrow path
+      // leaves toolResult unset — nothing to append to, note is dropped for
+      // that stop by design (the throw is the parent's signal). Attribution:
+      // the note is appended to THIS subagent's own result, so a parent
+      // batching multiple `agent` calls sees each nudge next to its result.
+      // Optional-chain: real SubagentHandleImpl always defines this; the
+      // `?.()` tolerates narrow handle doubles (returns undefined = no note).
+      const injectContext = handle.getLastStopInjectContext?.();
+      if (toolResult !== undefined && injectContext !== undefined && injectContext.length > 0) {
+        toolResult.content = `${toolResult.content}\n\n${injectContext}`;
+      }
+    }
+  }
+}

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -1,0 +1,180 @@
+/**
+ * Agent tool input parsing.
+ *
+ * Extracted from `subagent-executor.ts` `execute()`: the `AgentInput` shape and
+ * the `parseAgentInput` validator. Pure — no dependency on the executor
+ * instance or its context.
+ *
+ * @module agent/tools/subagent/input-parse
+ */
+
+import { isAbsolute } from 'node:path';
+
+export type AgentExecutionMode = 'foreground' | 'background';
+
+export interface AgentInput {
+  prompt: string;
+  model?: string;
+  max_turns?: number;
+  /**
+   * True when the caller supplied `max_turns` explicitly. Distinguishes the
+   * parse-time default (10) from a deliberate value so a named agent's
+   * `maxTurns` frontmatter can act as the default without being able to
+   * override an explicit per-call budget.
+   */
+  max_turns_explicit: boolean;
+  id_prefix?: string;
+  /**
+   * Named agent type to dispatch (`agent_type`, alias `subagent_type`).
+   * Resolved against {@link SubagentExecutorContext.agentRegistry}.
+   */
+  agent_type?: string;
+  /** Execution mode. Defaults to 'foreground' (existing await-and-return semantic). */
+  mode: AgentExecutionMode;
+  /**
+   * Optional working directory the subagent runs in. When omitted, the child
+   * inherits the parent's cwd (`SubagentManager.parentCwd`) so `afk -w`
+   * worktree isolation extends transparently. When provided, must be an
+   * absolute path with no `..` segments — the executor threads it into
+   * `AgentConfig.cwd`, which `SubagentManager.forkSubagent` applies in
+   * preference to the parent fallback (see `src/agent/subagent.ts:291-297`).
+   *
+   * Validation is format-only at parse time (existence/git-worktree status
+   * is not checked) — a non-existent path surfaces as an ENOENT on the
+   * child's first cwd-relative tool call, which the parent sees as a
+   * structured failure. Mirrors the existing AgentConfig.cwd contract
+   * used by `afk interactive -w` and the diagnose/farm orchestrators.
+   *
+   * Caveat: this field affects only the dispatched child's cwd. Depth-2+
+   * forks (the child itself calling `agent`) inherit through
+   * `SubagentExecutorContext.cwd` set at orchestrator construction —
+   * passing `cwd` here does NOT auto-propagate to recursive subagents.
+   * Each level must specify `cwd` explicitly to operate in a worktree.
+   */
+  cwd?: string;
+}
+
+/**
+ * Validate and parse Agent tool input.
+ * @throws if input is invalid
+ */
+export function parseAgentInput(input: unknown): AgentInput {
+  if (typeof input !== 'object' || input === null) {
+    throw new Error('Agent tool input must be an object');
+  }
+
+  const agentInput = input as Record<string, unknown>;
+
+  const prompt = agentInput['prompt'];
+  if (typeof prompt !== 'string') {
+    throw new Error('Agent tool input must have a "prompt" field of type string');
+  }
+  if (prompt.trim().length === 0) {
+    throw new Error('Agent tool prompt cannot be empty');
+  }
+
+  let model: string | undefined;
+  const modelValue = agentInput['model'];
+  if (modelValue !== undefined) {
+    if (typeof modelValue !== 'string') {
+      throw new Error('Agent tool model must be a string');
+    }
+    model = modelValue;
+  }
+
+  let max_turns = 10;
+  let max_turns_explicit = false;
+  const maxTurnsValue = agentInput['max_turns'];
+  if (maxTurnsValue !== undefined) {
+    if (typeof maxTurnsValue !== 'number') {
+      throw new Error('Agent tool max_turns must be a number');
+    }
+    // Clamp to [1, 50]
+    max_turns = Math.max(1, Math.min(50, Math.floor(maxTurnsValue)));
+    max_turns_explicit = true;
+  }
+
+  // agent_type: canonical param; `subagent_type` accepted as an alias for
+  // Claude Code-ported prompts (bundled SKILL.mds already write it). When
+  // both are present the canonical name wins.
+  let agent_type: string | undefined;
+  const agentTypeValue = agentInput['agent_type'] ?? agentInput['subagent_type'];
+  if (agentTypeValue !== undefined) {
+    if (typeof agentTypeValue !== 'string') {
+      throw new Error('Agent tool agent_type must be a string');
+    }
+    const trimmed = agentTypeValue.trim();
+    if (trimmed.length > 0) agent_type = trimmed;
+  }
+
+  let id_prefix = 'agent-tool';
+  const idPrefixValue = agentInput['id_prefix'];
+  if (idPrefixValue !== undefined) {
+    if (typeof idPrefixValue !== 'string') {
+      throw new Error('Agent tool id_prefix must be a string');
+    }
+    id_prefix = idPrefixValue;
+  }
+
+  // mode: default 'foreground'. Unknown strings reject loudly rather than
+  // silently coercing — a typo like "back" would be silently downgraded
+  // to a foreground run, exactly the surprise this feature is built to
+  // avoid.
+  let mode: AgentExecutionMode = 'foreground';
+  const modeValue = agentInput['mode'];
+  if (modeValue !== undefined) {
+    if (modeValue !== 'foreground' && modeValue !== 'background') {
+      throw new Error(
+        `Agent tool mode must be "foreground" or "background", got: ${JSON.stringify(modeValue)}`,
+      );
+    }
+    mode = modeValue;
+  }
+
+  // cwd: optional absolute path. Format-only validation here — existence is
+  // not checked because the call site is sync and any ENOENT surfaces
+  // cleanly through the child's first tool call. Rules:
+  //   1. Must be a non-empty string when present.
+  //   2. Must be absolute (`path.isAbsolute`) — relative paths would otherwise
+  //      resolve against `process.cwd()` and silently land somewhere
+  //      unrelated to the caller's intent.
+  //   3. Must not contain `..` as a path segment. `path.resolve` would
+  //      silently collapse them; rejecting forces the caller to write
+  //      what they mean. Splits on both `/` and `\\` so the check holds
+  //      on Windows too.
+  let cwd: string | undefined;
+  const cwdValue = agentInput['cwd'];
+  if (cwdValue !== undefined) {
+    if (typeof cwdValue !== 'string') {
+      throw new Error(
+        `Agent tool cwd must be a string, got: ${JSON.stringify(cwdValue)}`,
+      );
+    }
+    if (cwdValue.length === 0) {
+      throw new Error('Agent tool cwd must be a non-empty string');
+    }
+    if (!isAbsolute(cwdValue)) {
+      throw new Error(
+        `Agent tool cwd must be an absolute path, got: ${JSON.stringify(cwdValue)}`,
+      );
+    }
+    const segments = cwdValue.split(/[/\\]/);
+    if (segments.includes('..')) {
+      throw new Error(
+        `Agent tool cwd must not contain '..' segments, got: ${JSON.stringify(cwdValue)}`,
+      );
+    }
+    cwd = cwdValue;
+  }
+
+  return {
+    prompt,
+    model,
+    max_turns,
+    max_turns_explicit,
+    id_prefix,
+    mode,
+    ...(agent_type !== undefined ? { agent_type } : {}),
+    ...(cwd !== undefined ? { cwd } : {}),
+  };
+}


### PR DESCRIPTION
## What

Decomposes the Agent-tool executor's `execute()` method (~673 LOC — over half the file) into focused modules under `src/agent/tools/subagent/`, leaving `execute()` a thin orchestrator.

| module | responsibility |
|---|---|
| `input-parse.ts` | `AgentInput` shape + `parseAgentInput` validator (pure) |
| `child-config.ts` | child `AgentSession` config + nesting/depth wiring |
| `background-branch.ts` | `mode:'background'` register-and-return path |
| `foreground-promotion.ts` | foreground run + Ctrl+B promotion race + `finally` cleanup |
| `failure-payload.ts` | telemetry wrapper + structured failure-payload shaping |

`subagent-executor.ts`: **1316 → 577 LOC**.

## Why

`execute()` linearly threaded seven concerns through one `try/finally` with shared mutable outer-scope state (`promoted`, `resolveJob!`, `firePromotion!`), and the promotion race nested 4–5 levels deep. No concern could be read or changed in isolation — the top readability offender in the tree.

## Behavior preservation

Pure move + wire — public API and runtime behavior unchanged. Module params sourced from optional fields (`IAgentSession.sessionId`, `AgentInput.id_prefix`) are typed `string | undefined` to preserve the pre-extraction contract: they flow only into telemetry/registry, which already accept `undefined`.

## Verification

- `tsc --noEmit` (strict) — clean
- `audit:sdk:check` — lock matches (no new SDK imports)
- `audit:env:check` — 0 violations
- `subagent-executor.test.ts` — **86/86 pass**

First of a 4-PR series decomposing the worst readability offenders (subagent-executor · anthropic-direct query · elicitation-repl · openai-compatible query). No behavior change in any of them.
