### PR TITLE
feat(interactive): persist thinking-ui default via AFK_THINKING_UI + interactive.thinkingUi

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -645,6 +645,15 @@
       "category": "model"
     },
     {
+      "name": "AFK_THINKING_UI",
+      "description": "Default thinking-display mode for the interactive REPL: summary | live | digest | off. Display-only — controls how extended-thinking blocks render, never whether thinking runs (cost/latency unaffected). Overridden per-launch by --thinking-ui and mutable mid-session via /thinking. Precedence: --thinking-ui flag > this env > interactive.thinkingUi config > live. Invalid values are ignored.",
+      "type": "string",
+      "required": false,
+      "default": "live",
+      "example": "digest",
+      "category": "misc"
+    },
+    {
       "name": "AFK_TIMEOUT_MS",
       "description": "Per-turn timeout in milliseconds. Provider/SDK default if unset.",
       "type": "number",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**118 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**119 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 
@@ -180,6 +180,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_SHELL_PASSTHROUGH` | boolean |  | `1` | `0` | Enable the interactive REPL `!cmd` / `!&cmd` shell-passthrough feature. On by default. Set to 0, false, off, or no (case-insensitive) to disable, so inputs beginning with ! are sent to the model as literal text instead of being executed as shell commands. Equivalent to the --no-shell-passthrough flag. |
 | `AFK_SHOW_DIFFS` | boolean |  |  |  | Show inline diffs in the tool-lane output for edit/write tool calls. 1 = on, 0 = off. |
 | `AFK_SPINNER_TIPS` | boolean |  |  |  | Show rotating tips in the loading spinner during long calls. 1 = on, 0 = off. |
+| `AFK_THINKING_UI` | string |  | `live` | `digest` | Default thinking-display mode for the interactive REPL: summary \| live \| digest \| off. Display-only — controls how extended-thinking blocks render, never whether thinking runs (cost/latency unaffected). Overridden per-launch by --thinking-ui and mutable mid-session via /thinking. Precedence: --thinking-ui flag > this env > interactive.thinkingUi config > live. Invalid values are ignored. |
 | `AFK_USER_CARD_MAX_ROWS` | number |  |  | `24` | Maximum number of visual rows emitted by renderUserCard before collapsing the remainder into a dim "…(N lines collapsed)" summary row. Defaults to 24. Non-integer or non-positive values are silently ignored and the default applies. |
 | `AFK_WRITE_DENYLIST` | string |  |  | `**/.env,**/secrets/**` | Comma-separated list of additional path globs that the write_file tool refuses to write to. |
 | `AFK_WRITE_DIFF` | boolean |  |  |  | Show a diff preview before each write_file tool call. Defaults provider-controlled when unset. |

--- a/src/cli/commands/interactive.test.ts
+++ b/src/cli/commands/interactive.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { StreamingMarkdownRenderer } from '../markdown-stream.js';
 import { renderMarkdownToTerminal } from '../formatter.js';
 import { palette } from '../palette.js';
-import { formatToolResultLine, isAutonameEnabled, formatAutonameSkipReason, startupHintLine } from './interactive.js';
+import { formatToolResultLine, isAutonameEnabled, resolveThinkingUi, formatAutonameSkipReason, startupHintLine } from './interactive.js';
 import type { ToolResultChunk } from '../../agent/types/message-types.js';
 import type { CliOptions } from './interactive/shared.js';
 import type { CliConfig } from '../config.js';
@@ -509,6 +509,77 @@ describe('interactive command - streaming logic', () => {
       process.env['AFK_WORKTREE_AUTONAME'] = '1';
       const options = { worktreeAutoname: false } as unknown as CliOptions;
       expect(isAutonameEnabled(options, emptyConfig)).toBe(false);
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────
+  // resolveThinkingUi: --thinking-ui flag > AFK_THINKING_UI env > config > 'live'
+  // ────────────────────────────────────────────────────────────────────────
+  describe('resolveThinkingUi — precedence (flag > env > config > default)', () => {
+    const emptyConfig: CliConfig = {};
+    const noFlagOptions = {} as CliOptions;
+
+    let savedEnv: string | undefined;
+
+    beforeEach(() => {
+      savedEnv = process.env['AFK_THINKING_UI'];
+      delete process.env['AFK_THINKING_UI'];
+    });
+
+    afterEach(() => {
+      if (savedEnv === undefined) {
+        delete process.env['AFK_THINKING_UI'];
+      } else {
+        process.env['AFK_THINKING_UI'] = savedEnv;
+      }
+    });
+
+    it('nothing set → defaults to live', () => {
+      expect(resolveThinkingUi(noFlagOptions, emptyConfig)).toBe('live');
+    });
+
+    it.each(['summary', 'live', 'digest', 'off'] as const)(
+      'CLI flag %s wins over everything',
+      (mode) => {
+        process.env['AFK_THINKING_UI'] = 'off';
+        const options = { thinkingUi: mode } as CliOptions;
+        const config: CliConfig = { interactive: { thinkingUi: 'summary' } };
+        expect(resolveThinkingUi(options, config)).toBe(mode);
+      },
+    );
+
+    it.each(['summary', 'live', 'digest', 'off'])(
+      'env=%s used when no flag (over config)',
+      (envVal) => {
+        process.env['AFK_THINKING_UI'] = envVal;
+        const config: CliConfig = { interactive: { thinkingUi: 'summary' } };
+        expect(resolveThinkingUi(noFlagOptions, config)).toBe(envVal);
+      },
+    );
+
+    it.each(['DIGEST', ' Off ', 'Summary'])(
+      'env is case- and whitespace-insensitive (%s)',
+      (envVal) => {
+        process.env['AFK_THINKING_UI'] = envVal;
+        expect(resolveThinkingUi(noFlagOptions, emptyConfig)).toBe(envVal.trim().toLowerCase());
+      },
+    );
+
+    it.each(['verbose', 'quiet', '', 'liv'])(
+      'invalid env=%j falls through to config/default (not fatal)',
+      (envVal) => {
+        process.env['AFK_THINKING_UI'] = envVal;
+        // No config → default live
+        expect(resolveThinkingUi(noFlagOptions, emptyConfig)).toBe('live');
+        // With config → config wins over the invalid env
+        const config: CliConfig = { interactive: { thinkingUi: 'digest' } };
+        expect(resolveThinkingUi(noFlagOptions, config)).toBe('digest');
+      },
+    );
+
+    it('config used when no flag and no env', () => {
+      const config: CliConfig = { interactive: { thinkingUi: 'summary' } };
+      expect(resolveThinkingUi(noFlagOptions, config)).toBe('summary');
     });
   });
 

--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -132,6 +132,34 @@ export function isAutonameEnabled(options: CliOptions, config: CliConfig): boole
 }
 
 /**
+ * Resolve the REPL thinking-display mode with precedence:
+ *   1. `--thinking-ui <mode>` CLI flag (already validated by parseThinkingUiMode)
+ *   2. `AFK_THINKING_UI` env (validated here; invalid values ignored, not fatal)
+ *   3. `interactive.thinkingUi` from `afk.config.json`
+ *   4. Default: `'live'`
+ *
+ * Display-only — the mode changes how extended-thinking blocks render in the
+ * REPL, never whether thinking runs. Mirrors `isAutonameEnabled`'s
+ * flag > env > config > default shape so a user can set a persistent default
+ * (env or config) that the per-launch `--thinking-ui` flag still overrides.
+ */
+export function resolveThinkingUi(options: CliOptions, config: CliConfig): ThinkingUiMode {
+  if (options.thinkingUi !== undefined) return options.thinkingUi;
+  const envRaw = env.AFK_THINKING_UI;
+  if (envRaw !== undefined) {
+    const lowered = envRaw.trim().toLowerCase();
+    if (lowered === 'summary' || lowered === 'live' || lowered === 'digest' || lowered === 'off') {
+      return lowered;
+    }
+    // Invalid env value → fall through to config/default rather than throw;
+    // an env typo shouldn't hard-fail an interactive launch.
+  }
+  const fromConfig = config.interactive?.thinkingUi;
+  if (fromConfig !== undefined) return fromConfig;
+  return 'live';
+}
+
+/**
  * The hint line rendered under the welcome banner at session startup.
  *
  * Kept deliberately short and first-session-oriented: it teaches the handful
@@ -161,7 +189,7 @@ export function registerInteractiveCommand(program: Command): void {
     )
     .option('--max-turns <number>', 'Maximum conversation turns', '100')
     .option('--thinking <mode>', "Thinking mode: 'adaptive' | 'disabled' | 'enabled:<N>'", 'enabled:max')
-    .option('--thinking-ui <mode>', 'Thinking display mode: summary|live|digest|off', parseThinkingUiMode, 'live')
+    .option('--thinking-ui <mode>', 'Thinking display mode: summary|live|digest|off. Default live. Also: AFK_THINKING_UI env, or interactive.thinkingUi in afk.config.json.', parseThinkingUiMode)
     .option('--effort <level>', 'Effort level: low|medium|high|xhigh|max')
     .option('--max-output-tokens <n|max>', "Per-response output cap ('max' = model ceiling). Env: AFK_MAX_OUTPUT_TOKENS")
     .option('--resume <id>', 'Resume a persisted SDK session by id')
@@ -264,6 +292,12 @@ export function registerInteractiveCommand(program: Command): void {
       // and (later) the first-turn rename use the same value. Env wins
       // over config; both yield to an explicit CLI string in `--worktree`.
       const cliConfig = loadConfig();
+      // Resolve the thinking-display mode (--thinking-ui flag > AFK_THINKING_UI
+      // env > interactive.thinkingUi config > 'live') and assign it back onto
+      // options so the downstream bootstrap seeding (stats.thinkingUi =
+      // options.thinkingUi) and the /thinking runtime toggle start from the
+      // resolved persistent default.
+      options.thinkingUi = resolveThinkingUi(options, cliConfig);
       const branchPrefixOverride =
         env.AFK_WORKTREE_BRANCH_PREFIX ??
         cliConfig.interactive?.worktreeBranchPrefix;

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -547,10 +547,15 @@ export async function bootstrapSession(
   if (initialPermissionMode !== undefined) {
     stats.permissionMode = initialPermissionMode;
   }
-  // Seed thinking-UI mode from the CLI flag so `/thinking` has a live value
-  // to mutate. `createSessionStats()` already defaults to 'live'; this
-  // overrides with the user's explicit `--thinking-ui` choice (if any).
-  stats.thinkingUi = options.thinkingUi;
+  // Seed thinking-UI mode so `/thinking` has a live value to mutate.
+  // `options.thinkingUi` was already resolved by the interactive action handler
+  // via `resolveThinkingUi` (--thinking-ui flag > AFK_THINKING_UI env >
+  // interactive.thinkingUi config > 'live'), so this seeds the persistent
+  // default. `createSessionStats()` pre-seeds 'live' for any path that reaches
+  // bootstrap without that resolution (e.g. tests constructing options directly).
+  if (options.thinkingUi !== undefined) {
+    stats.thinkingUi = options.thinkingUi;
+  }
   // Stamp the effective working directory on stats so the status line can
   // render it. We capture the same cwd the provider will see: the explicit
   // `extras.cwd` override (e.g. from `--worktree`) when present, else

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -229,7 +229,13 @@ export interface CliOptions {
   model: AgentModelInput;
   maxTurns: string;
   thinking?: string;
-  thinkingUi: ThinkingUiMode;
+  /**
+   * `--thinking-ui` display mode. Optional at the CLI layer: the Commander
+   * option carries no static default, so this is `undefined` until the action
+   * handler resolves the flag > `AFK_THINKING_UI` env > `interactive.thinkingUi`
+   * config > `'live'` precedence (see `resolveThinkingUi`) and assigns it back.
+   */
+  thinkingUi?: ThinkingUiMode;
   effort?: string;
   maxOutputTokens?: string;
   resume?: string;

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -707,6 +707,57 @@ describe('loadConfig() — interactive.suggestGhost JSON integration', () => {
   });
 });
 
+describe('loadConfig() — interactive.thinkingUi JSON integration', () => {
+  const mockedExistsSync = () => vi.mocked(fs.existsSync);
+  const mockedReadFileSync = () => vi.mocked(fs.readFileSync);
+
+  beforeEach(() => {
+    _resetConfigCache();
+    mockedExistsSync().mockImplementation(realFsModule.__realExistsSync);
+    mockedReadFileSync().mockImplementation(realFsModule.__realReadFileSync);
+  });
+
+  afterEach(() => {
+    mockedExistsSync().mockImplementation(realFsModule.__realExistsSync);
+    mockedReadFileSync().mockImplementation(realFsModule.__realReadFileSync);
+    _resetConfigCache();
+  });
+
+  const withConfigJson = (json: unknown) => {
+    mockedExistsSync().mockImplementation((p) => {
+      if (String(p).endsWith('afk.config.json')) return true;
+      return realFsModule.__realExistsSync(p as fs.PathLike);
+    });
+    mockedReadFileSync().mockImplementation((p, ...args) => {
+      if (String(p).endsWith('afk.config.json')) {
+        return JSON.stringify(json);
+      }
+      return (realFsModule.__realReadFileSync as Function)(p, ...args);
+    });
+  };
+
+  it.each(['summary', 'live', 'digest', 'off'] as const)(
+    'surfaces valid interactive.thinkingUi=%s from JSON config',
+    (mode) => {
+      withConfigJson({ interactive: { thinkingUi: mode } });
+      const config = loadConfig();
+      expect(config.interactive?.thinkingUi).toBe(mode);
+    },
+  );
+
+  it('ignores an invalid interactive.thinkingUi value (leaves it undefined)', () => {
+    withConfigJson({ interactive: { thinkingUi: 'verbose' } });
+    const config = loadConfig();
+    expect(config.interactive?.thinkingUi).toBeUndefined();
+  });
+
+  it('leaves interactive.thinkingUi undefined when not set in JSON', () => {
+    withConfigJson({ interactive: { worktreeAutoname: true } });
+    const config = loadConfig();
+    expect(config.interactive?.thinkingUi).toBeUndefined();
+  });
+});
+
 describe('loadConfig() — permissionMode default (new-install bypass)', () => {
   const mockedExistsSync = () => vi.mocked(fs.existsSync);
   const mockedReadFileSync = () => vi.mocked(fs.readFileSync);

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -181,6 +181,16 @@ export interface CliConfig {
      * `undefined` = not set (default-on). `false` = disable all ghost text.
      */
     suggestGhost?: boolean;
+    /**
+     * Persistent default for how the interactive REPL renders extended-thinking
+     * blocks: `'summary' | 'live' | 'digest' | 'off'`. Display-only — never
+     * changes whether thinking runs (cost/latency unaffected).
+     *
+     * Env override: `AFK_THINKING_UI`. CLI override: `--thinking-ui`.
+     * Precedence: CLI flag > env > this config value > `'live'`.
+     * Runtime-mutable per session via the `/thinking` slash command.
+     */
+    thinkingUi?: 'summary' | 'live' | 'digest' | 'off';
   };
   updatePolicy: 'notify' | 'auto' | 'off';
   /**
@@ -308,6 +318,7 @@ interface ConfigFileSchema {
     worktreeBranchPrefix?: string;
     worktreeBase?: string;
     suggestGhost?: boolean;
+    thinkingUi?: 'summary' | 'live' | 'digest' | 'off';
   };
   updatePolicy?: 'notify' | 'auto' | 'off';
   autoResumeOnUsageLimit?: boolean;
@@ -797,6 +808,16 @@ function loadJsonConfig(): {
           }
           if (typeof json.interactive.suggestGhost === 'boolean') {
             interactive.suggestGhost = json.interactive.suggestGhost;
+          }
+          // Display-only enum; silently ignore anything outside the allowlist
+          // rather than throwing — a stray value shouldn't fail config load.
+          if (
+            json.interactive.thinkingUi === 'summary' ||
+            json.interactive.thinkingUi === 'live' ||
+            json.interactive.thinkingUi === 'digest' ||
+            json.interactive.thinkingUi === 'off'
+          ) {
+            interactive.thinkingUi = json.interactive.thinkingUi;
           }
           if (Object.keys(interactive).length > 0) {
             config.interactive = interactive;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -401,6 +401,19 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     category: 'model',
   },
   {
+    name: 'AFK_THINKING_UI',
+    description:
+      'Default thinking-display mode for the interactive REPL: summary | live | digest | off. ' +
+      'Display-only — controls how extended-thinking blocks render, never whether thinking runs (cost/latency unaffected). ' +
+      'Overridden per-launch by --thinking-ui and mutable mid-session via /thinking. ' +
+      'Precedence: --thinking-ui flag > this env > interactive.thinkingUi config > live. Invalid values are ignored.',
+    type: 'string',
+    required: false,
+    default: 'live',
+    example: 'digest',
+    category: 'misc',
+  },
+  {
     name: 'AFK_TIMEOUT_MS',
     description: 'Per-turn timeout in milliseconds. Provider/SDK default if unset.',
     type: 'number',
@@ -1176,6 +1189,7 @@ export const env = {
   get AFK_TASK_BUDGET(): string | undefined { return process.env['AFK_TASK_BUDGET']; },
   get AFK_TEMPERATURE(): string | undefined { return process.env['AFK_TEMPERATURE']; },
   get AFK_THINKING(): string | undefined { return process.env['AFK_THINKING']; },
+  get AFK_THINKING_UI(): string | undefined { return process.env['AFK_THINKING_UI']; },
   get AFK_TIMEOUT_MS(): string | undefined { return process.env['AFK_TIMEOUT_MS']; },
   get CLAUDE_MODEL(): string | undefined { return process.env['CLAUDE_MODEL']; },
 

--- a/src/config/settable-keys.ts
+++ b/src/config/settable-keys.ts
@@ -212,6 +212,7 @@ export const CONFIG_KEY_SPECS: readonly ConfigKeySpec[] = [
   { path: 'telegram.verifyDone', tier: 'human', type: 'boolean', description: 'Opt-in AFK "Done" verification gate (human-tier: a self-honesty check on the agent\'s own completion reporting — the agent must not be able to disable it on its own config, same rationale as enableShellHooks/permissionMode).' },
   { path: 'interactive.worktreeAutoname', tier: 'agent', type: 'boolean', description: 'Auto-name worktrees.' },
   { path: 'interactive.suggestGhost', tier: 'agent', type: 'boolean', description: 'Ghost-text suggestions in the REPL.' },
+  { path: 'interactive.thinkingUi', tier: 'agent', type: 'enum', enumValues: ['summary', 'live', 'digest', 'off'], description: 'Default REPL thinking-display mode.' },
   { path: 'updatePolicy', tier: 'human', type: 'enum', enumValues: ['notify', 'auto', 'off'], description: 'Self-update policy (human-tier: auto self-update is scope-widening).' },
   { path: 'autoResumeOnUsageLimit', tier: 'agent', type: 'boolean', description: 'Auto-resume after a usage-limit pause.' },
   { path: 'bgSummaries', tier: 'agent', type: 'boolean', description: 'Background summarisation.' },


### PR DESCRIPTION
## What

Make the interactive REPL's thinking-display mode (`/thinking` → `live | summary | digest | off`) **persistable across sessions**. Previously it was session-only: it seeded solely from the `--thinking-ui` CLI flag (hardcoded default `live`) with no env or config layer, so the only way to change the default was to re-pass `--thinking-ui <mode>` on every launch.

## Why

A user asked whether the `/thinking` choice persists — it doesn't. The codebase already had the exact precedence pattern for this (`worktree-autoname` / `worktree-base`: flag → env → config → default), but `--thinking-ui` never got wired that way. This closes that gap additively.

## Precedence

```
--thinking-ui flag  >  AFK_THINKING_UI env  >  interactive.thinkingUi config  >  'live'
```

`/thinking` still overrides live within a session. This is **display-only** — extended thinking always runs; cost and latency are unaffected.

## Changes

- **`src/config/env.ts`** — register `AFK_THINKING_UI` (registry entry + typed getter); `docs/env-registry.{json,md}` regenerated via `pnpm scan:env`.
- **`src/cli/config.ts`** — add `interactive.thinkingUi` to the config type + JSON loader. Invalid values are silently ignored (not fatal), matching the display-only, non-security nature of the setting.
- **`src/config/settable-keys.ts`** — register `interactive.thinkingUi` (agent tier, enum) so `afk config set interactive.thinkingUi digest` works.
- **`src/cli/commands/interactive.ts`** — add exported `resolveThinkingUi()` resolver (mirrors `isAutonameEnabled`); drop the static Commander default; resolve precedence in the action handler right after `loadConfig()`.
- **`src/cli/commands/interactive/shared.ts`** — `CliOptions.thinkingUi` is now optional (resolved post-parse rather than defaulted by Commander).
- **`src/cli/commands/interactive/bootstrap.ts`** — updated seeding comment + `undefined` guard.

## Usage after this change

```bash
# one-off (unchanged)
afk i --thinking-ui digest

# persistent, via env
export AFK_THINKING_UI=digest

# persistent, via config
afk config set interactive.thinkingUi digest
```

## Testing

- `resolveThinkingUi` precedence matrix (flag wins, env-over-config, case/whitespace-insensitive env, invalid-env fall-through, config fallback, default) — `src/cli/commands/interactive.test.ts`.
- Config-loader accept-valid / ignore-invalid / leave-undefined cases — `src/cli/config.test.ts`.
- `pnpm lint` clean; `pnpm audit:sdk:check`, `pnpm audit:env:check`, `pnpm scan:env:check` all pass.
- Full suite: 10,891 passed / 14 skipped. The only failing suites are 4 `chat.*.test.ts` files failing to load on a pre-existing `builtinToolSchemas` mock-drift error — reproduced identically on `origin/main` with none of these changes present (unrelated to this PR).

## Notes

- Scope is the interactive REPL only (where `/thinking` and `--thinking-ui` live); one-shot `chat` does not use this knob.