### PR TITLE
test(subagent): direct unit tests for extracted subagent/ modules

### DIFF
--- a/src/agent/tools/subagent/background-branch.test.ts
+++ b/src/agent/tools/subagent/background-branch.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Direct unit tests for the background-mode dispatch branch.
+ *
+ * Follow-up to #443: `runBackgroundBranch` was extracted from
+ * `subagent-executor.ts` and previously covered only transitively through the
+ * executor's `background mode` describe block. These tests exercise the branch
+ * at its own boundary with a mock registry + mock handle, covering the three
+ * paths:
+ *   1. no registry wired → error + orphan-handle teardown
+ *   2. register throws BackgroundJobCapError → error + orphan-handle teardown
+ *   3. happy path → register-and-return the synthetic "running" pointer
+ *
+ * The registry and handle are passed in as explicit parameters (the module is
+ * `this`-free), so no executor is constructed here.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { runBackgroundBranch, type RunBackgroundBranchArgs } from './background-branch.js';
+import { BackgroundJobCapError, type BackgroundJob } from '../../background-registry.js';
+import type { SubagentHandle } from '../../subagent.js';
+
+/**
+ * Minimal handle double: the background branch only touches `handle.id` and
+ * `handle.teardown()`. Everything else is cast through `unknown` (mirrors the
+ * `bgHandle` helper in subagent-executor.test.ts).
+ */
+function fakeHandle(id = 'sub-1'): {
+  handle: RunBackgroundBranchArgs['handle'];
+  teardownMock: ReturnType<typeof vi.fn>;
+} {
+  const teardownMock = vi.fn().mockResolvedValue(undefined);
+  const handle = {
+    id,
+    status: 'idle',
+    teardown: teardownMock,
+    cancel: vi.fn().mockResolvedValue(undefined),
+    run: vi.fn(),
+    runToResult: vi.fn(),
+    runInBackground: vi.fn(),
+  } as unknown as SubagentHandle;
+  return { handle: handle as RunBackgroundBranchArgs['handle'], teardownMock };
+}
+
+/** A registry double exposing only `register`, typed loosely then cast. */
+function fakeRegistry(
+  register: (args: unknown) => BackgroundJob,
+): RunBackgroundBranchArgs['registry'] {
+  return { register: vi.fn(register) } as unknown as RunBackgroundBranchArgs['registry'];
+}
+
+function makeJob(overrides?: Partial<BackgroundJob>): BackgroundJob {
+  return {
+    jobId: 'bg-abc123',
+    subagentId: 'sub-1',
+    label: 'deep investigation',
+    model: 'sonnet',
+    startedAt: Date.now(),
+    status: 'running',
+    ...overrides,
+  } as BackgroundJob;
+}
+
+describe('runBackgroundBranch', () => {
+  describe('no registry wired', () => {
+    it('returns an isError result explaining background mode is unavailable', async () => {
+      const { handle } = fakeHandle();
+      const result = await runBackgroundBranch({
+        handle,
+        registry: undefined,
+        prompt: 'p',
+        model: 'sonnet',
+        parentSessionId: 'parent-1',
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatch(/Background mode is not available/);
+      expect(result.content).toMatch(/mode="foreground"/);
+    });
+
+    it('tears down the orphaned handle so the fork is not leaked', async () => {
+      const { handle, teardownMock } = fakeHandle();
+      await runBackgroundBranch({
+        handle,
+        registry: undefined,
+        prompt: 'p',
+        model: 'sonnet',
+        parentSessionId: undefined,
+      });
+      expect(teardownMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('swallows a teardown rejection on the no-registry path (best-effort cleanup)', async () => {
+      const { handle, teardownMock } = fakeHandle();
+      teardownMock.mockRejectedValueOnce(new Error('teardown failed'));
+      // The branch .catch()es teardown failures via debugLog, so the returned
+      // promise still resolves with the error ToolResult.
+      const result = await runBackgroundBranch({
+        handle,
+        registry: undefined,
+        prompt: 'p',
+        model: 'sonnet',
+        parentSessionId: undefined,
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatch(/Background mode is not available/);
+    });
+  });
+
+  describe('register throws BackgroundJobCapError', () => {
+    it('returns the cap-error message and does not re-throw', async () => {
+      const { handle } = fakeHandle();
+      const registry = fakeRegistry(() => {
+        throw new BackgroundJobCapError(1, 1);
+      });
+      const result = await runBackgroundBranch({
+        handle,
+        registry,
+        prompt: 'p',
+        model: 'sonnet',
+        parentSessionId: undefined,
+      });
+      expect(result.isError).toBe(true);
+      expect(result.content).toMatch(/Background job cap reached/);
+    });
+
+    it('tears down the orphaned handle after a cap error', async () => {
+      const { handle, teardownMock } = fakeHandle();
+      const registry = fakeRegistry(() => {
+        throw new BackgroundJobCapError(3, 3);
+      });
+      await runBackgroundBranch({
+        handle,
+        registry,
+        prompt: 'p',
+        model: 'sonnet',
+        parentSessionId: undefined,
+      });
+      expect(teardownMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-throws non-cap errors from register (defense in depth)', async () => {
+      const { handle, teardownMock } = fakeHandle();
+      const registry = fakeRegistry(() => {
+        throw new Error('unexpected registry failure');
+      });
+      await expect(
+        runBackgroundBranch({
+          handle,
+          registry,
+          prompt: 'p',
+          model: 'sonnet',
+          parentSessionId: undefined,
+        }),
+      ).rejects.toThrow('unexpected registry failure');
+      // A non-cap throw is NOT the leak-cleanup path — teardown is only wired
+      // for the cap branch, so it must not have been called here.
+      expect(teardownMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('happy path (register and return)', () => {
+    it('registers the handle and returns the synthetic running pointer', async () => {
+      const { handle, teardownMock } = fakeHandle('sub-1');
+      const job = makeJob({ jobId: 'bg-xyz', subagentId: 'sub-1', label: 'deep investigation' });
+      const registry = fakeRegistry(() => job);
+
+      const result = await runBackgroundBranch({
+        handle,
+        registry,
+        prompt: 'deep investigation',
+        model: 'sonnet',
+        parentSessionId: 'parent-1',
+      });
+
+      // No error, and the handle is NOT torn down — the registry now owns it.
+      expect(result.isError).toBeUndefined();
+      expect(teardownMock).not.toHaveBeenCalled();
+
+      const payload = JSON.parse(result.content) as {
+        status: string;
+        jobId: string;
+        subagentId: string;
+        label: string;
+        message: string;
+      };
+      expect(payload.status).toBe('running');
+      expect(payload.jobId).toBe('bg-xyz');
+      expect(payload.subagentId).toBe('sub-1');
+      expect(payload.label).toBe('deep investigation');
+      expect(payload.message).toMatch(/Background subagent started/);
+      expect(payload.message).toMatch(/delivered into this context/);
+      expect(payload.message).toMatch(/\/bgsub:join bg-xyz/);
+    });
+
+    it('forwards prompt, model, and parentSessionId into register', async () => {
+      const { handle } = fakeHandle();
+      const registerSpy = vi.fn(() => makeJob());
+      const registry = fakeRegistry(registerSpy);
+
+      await runBackgroundBranch({
+        handle,
+        registry,
+        prompt: 'the prompt',
+        model: 'opus',
+        parentSessionId: 'parent-42',
+      });
+
+      expect(registerSpy).toHaveBeenCalledTimes(1);
+      expect(registerSpy).toHaveBeenCalledWith({
+        handle,
+        prompt: 'the prompt',
+        model: 'opus',
+        parentSessionId: 'parent-42',
+      });
+    });
+
+    it("defaults the registry record model to 'sonnet' when model is undefined", async () => {
+      const { handle } = fakeHandle();
+      const registerSpy = vi.fn(() => makeJob());
+      const registry = fakeRegistry(registerSpy);
+
+      await runBackgroundBranch({
+        handle,
+        registry,
+        prompt: 'p',
+        model: undefined,
+        parentSessionId: undefined,
+      });
+
+      expect(registerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ model: 'sonnet' }),
+      );
+    });
+
+    it('forwards an undefined parentSessionId as-is (preserves the pre-extraction contract)', async () => {
+      const { handle } = fakeHandle();
+      const registerSpy = vi.fn(() => makeJob());
+      const registry = fakeRegistry(registerSpy);
+
+      await runBackgroundBranch({
+        handle,
+        registry,
+        prompt: 'p',
+        model: 'sonnet',
+        parentSessionId: undefined,
+      });
+
+      expect(registerSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ parentSessionId: undefined }),
+      );
+    });
+
+    it('returns valid JSON content (round-trips)', async () => {
+      const { handle } = fakeHandle();
+      const registry = fakeRegistry(() => makeJob());
+      const result = await runBackgroundBranch({
+        handle,
+        registry,
+        prompt: 'p',
+        model: 'sonnet',
+        parentSessionId: undefined,
+      });
+      expect(() => JSON.parse(result.content)).not.toThrow();
+    });
+  });
+});

--- a/src/agent/tools/subagent/child-config.test.ts
+++ b/src/agent/tools/subagent/child-config.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Direct unit tests for `buildChildConfig` — child AgentConfig construction +
+ * nesting/depth wiring.
+ *
+ * Follow-up to #443. `buildChildConfig` depends on manager/provider/credential
+ * resolution, but its DETERMINISTIC behavior is unit-testable by:
+ *   - injecting `resolveApiKeyForModel` (a first-class parameter) so the live
+ *     keychain/credential resolver is never touched;
+ *   - passing stub `createChildExecutor` / `childProviderFactory` callbacks.
+ *
+ * Scope (intentionally narrow — model/credential anti-leak and depth-2 cwd
+ * propagation are already covered transitively in `subagent-executor.test.ts`):
+ *   1. turn-budget resolution (explicit vs. named-agent frontmatter vs. default)
+ *   2. depth wiring (`depth + 1`, `maxDepth`) into the child config
+ *   3. systemPrompt selection (named-agent body vs. parent base prompt)
+ *   4. named-agent tool-access intersection (fail-closed narrowing against a cage)
+ *   5. cwd threading + omission
+ *   6. model resolution legs (named fixed / named `inherit` / unnamed fallback)
+ *   7. nesting skip at maxDepth (no childManager)
+ *   8. restricted-provider fallback at the depth cap
+ *
+ * Deferred (covered transitively, not re-implemented here): the full
+ * cross-provider credential anti-leak matrix and depth-2+ childManager cwd
+ * inheritance — see `subagent-executor.test.ts` `resolveApiKeyForModel` and
+ * `parentId attribution` describe blocks.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { buildChildConfig, type BuildChildConfigArgs } from './child-config.js';
+import type { AgentInput } from './input-parse.js';
+import type { RegisteredAgent } from '../../agents/index.js';
+import type { ModelProvider } from '../../provider.js';
+import type { SubagentExecutor, SubagentExecutorContext } from '../subagent-executor.js';
+
+/** A parsed AgentInput with the fields buildChildConfig reads. */
+function parsed(overrides?: Partial<AgentInput>): AgentInput {
+  return {
+    prompt: 'do the thing',
+    max_turns: 10,
+    max_turns_explicit: false,
+    id_prefix: 'agent-tool',
+    mode: 'foreground',
+    ...overrides,
+  };
+}
+
+/** A registered named agent with a definition. */
+function namedAgent(
+  definition: Partial<RegisteredAgent['definition']>,
+  extra?: Partial<RegisteredAgent>,
+): RegisteredAgent {
+  return {
+    name: 'test-agent',
+    source: 'user',
+    definition: {
+      description: 'a test agent',
+      prompt: 'You are a test agent.',
+      ...definition,
+    },
+    ...extra,
+  };
+}
+
+/** A stub child executor — buildChildConfig only stores the reference. */
+function stubChildExecutor(): SubagentExecutor {
+  return {} as unknown as SubagentExecutor;
+}
+
+/**
+ * Base args. `resolveApiKeyForModel` is injected so the live credential
+ * resolver is never called; `createChildExecutor` is a no-op stub.
+ */
+function baseArgs(overrides?: Partial<BuildChildConfigArgs>): BuildChildConfigArgs {
+  const signal = new AbortController().signal;
+  return {
+    parsed: parsed(),
+    namedAgent: undefined,
+    depth: 0,
+    maxDepth: 3,
+    currentCwd: undefined,
+    signal,
+    defaultConfig: {
+      apiKey: 'parent-anthropic-key',
+      systemPrompt: 'parent base prompt',
+      baseUrl: undefined,
+      openaiBaseUrl: undefined,
+    },
+    resolveApiKeyForModel: vi.fn((_m: string) => 'child-resolved-key'),
+    createChildExecutor: vi.fn((_ctx: SubagentExecutorContext) => stubChildExecutor()),
+    ...overrides,
+  };
+}
+
+describe('buildChildConfig', () => {
+  describe('turn budget (effectiveMaxTurns)', () => {
+    it('uses the parse-time default when no named agent and not explicit', () => {
+      const { childConfig } = buildChildConfig(baseArgs({ parsed: parsed({ max_turns: 10 }) }));
+      expect(childConfig.maxTurns).toBe(10);
+    });
+
+    it('uses an explicit per-call max_turns even when a named agent has maxTurns', () => {
+      const { childConfig } = buildChildConfig(
+        baseArgs({
+          parsed: parsed({ max_turns: 7, max_turns_explicit: true }),
+          namedAgent: namedAgent({ maxTurns: 30 }),
+        }),
+      );
+      expect(childConfig.maxTurns).toBe(7);
+    });
+
+    it("uses a named agent's maxTurns frontmatter when max_turns is not explicit", () => {
+      const { childConfig } = buildChildConfig(
+        baseArgs({
+          parsed: parsed({ max_turns: 10, max_turns_explicit: false }),
+          namedAgent: namedAgent({ maxTurns: 30 }),
+        }),
+      );
+      expect(childConfig.maxTurns).toBe(30);
+    });
+
+    it('clamps a named agent maxTurns above 50 down to 50', () => {
+      const { childConfig } = buildChildConfig(
+        baseArgs({ namedAgent: namedAgent({ maxTurns: 999 }) }),
+      );
+      expect(childConfig.maxTurns).toBe(50);
+    });
+
+    it('clamps a named agent maxTurns below 1 up to 1', () => {
+      const { childConfig } = buildChildConfig(
+        baseArgs({ namedAgent: namedAgent({ maxTurns: 0 }) }),
+      );
+      expect(childConfig.maxTurns).toBe(1);
+    });
+
+    it('floors a fractional named agent maxTurns', () => {
+      const { childConfig } = buildChildConfig(
+        baseArgs({ namedAgent: namedAgent({ maxTurns: 12.9 }) }),
+      );
+      expect(childConfig.maxTurns).toBe(12);
+    });
+  });
+
+  describe('depth wiring', () => {
+    it('sets childConfig.depth to depth + 1', () => {
+      const { childConfig } = buildChildConfig(baseArgs({ depth: 2, maxDepth: 5 }));
+      expect(childConfig.depth).toBe(3);
+    });
+
+    it('propagates maxDepth to the child config', () => {
+      const { childConfig } = buildChildConfig(baseArgs({ depth: 0, maxDepth: 5 }));
+      expect(childConfig.maxDepth).toBe(5);
+    });
+  });
+
+  describe('systemPrompt selection', () => {
+    it('uses the parent base prompt for an unnamed dispatch', () => {
+      const { childConfig } = buildChildConfig(baseArgs({ namedAgent: undefined }));
+      expect(childConfig.systemPrompt).toBe('parent base prompt');
+    });
+
+    it("uses the named agent's definition prompt (markdown body) for a named dispatch", () => {
+      const { childConfig } = buildChildConfig(
+        baseArgs({ namedAgent: namedAgent({ prompt: 'You are the research agent.' }) }),
+      );
+      expect(childConfig.systemPrompt).toBe('You are the research agent.');
+    });
+  });
+
+  describe('model resolution', () => {
+    it("falls back to 'sonnet' for an unnamed dispatch with no defaults", () => {
+      const { childConfig } = buildChildConfig(baseArgs({ defaultSubagentModel: undefined }));
+      expect(childConfig.model).toBe('sonnet');
+    });
+
+    it('uses defaultSubagentModel when parsed.model and named model are absent', () => {
+      const { childConfig } = buildChildConfig(baseArgs({ defaultSubagentModel: 'haiku' }));
+      expect(childConfig.model).toBe('haiku');
+    });
+
+    it('parsed.model wins over defaultSubagentModel and named model', () => {
+      const { childConfig } = buildChildConfig(
+        baseArgs({
+          parsed: parsed({ model: 'opus' }),
+          namedAgent: namedAgent({ model: 'haiku' }),
+          defaultSubagentModel: 'sonnet',
+        }),
+      );
+      expect(childConfig.model).toBe('opus');
+    });
+
+    it("uses a named agent's fixed model over defaultSubagentModel", () => {
+      const { childConfig } = buildChildConfig(
+        baseArgs({
+          namedAgent: namedAgent({ model: 'haiku' }),
+          defaultSubagentModel: 'sonnet',
+        }),
+      );
+      expect(childConfig.model).toBe('haiku');
+    });
+
+    it("resolves a named agent's model: 'inherit' to parentModel", () => {
+      const { childConfig } = buildChildConfig(
+        baseArgs({
+          namedAgent: namedAgent({ model: 'inherit' }),
+          parentModel: 'opus',
+        }),
+      );
+      expect(childConfig.model).toBe('opus');
+    });
+
+    it("falls through to the policy chain when named model is 'inherit' but parentModel is unset", () => {
+      const { childConfig } = buildChildConfig(
+        baseArgs({
+          namedAgent: namedAgent({ model: 'inherit' }),
+          parentModel: undefined,
+          defaultSubagentModel: 'haiku',
+        }),
+      );
+      expect(childConfig.model).toBe('haiku');
+    });
+
+    it('treats an omitted named model as inherit (uses parentModel)', () => {
+      const { childConfig } = buildChildConfig(
+        baseArgs({
+          namedAgent: namedAgent({}), // no model field
+          parentModel: 'opus',
+        }),
+      );
+      expect(childConfig.model).toBe('opus');
+    });
+  });
+
+  describe('cwd threading', () => {
+    it('threads parsed.cwd into childConfig.cwd when present', () => {
+      const { childConfig } = buildChildConfig(
+        baseArgs({ parsed: parsed({ cwd: '/tmp/wt/feat-x' }) }),
+      );
+      expect(childConfig.cwd).toBe('/tmp/wt/feat-x');
+    });
+
+    it('omits the cwd key entirely when parsed.cwd is absent (parent fallback preserved)', () => {
+      const { childConfig } = buildChildConfig(baseArgs({ parsed: parsed() }));
+      // Own-key absence, not just undefined value — SubagentManager's parentCwd
+      // fallback engages only when the key is truly absent.
+      expect(Object.prototype.hasOwnProperty.call(childConfig, 'cwd')).toBe(false);
+    });
+  });
+
+  describe('credential wiring (deterministic slice)', () => {
+    it('resolves the child apiKey via the injected resolver, keyed by the child model', () => {
+      const resolveApiKeyForModel = vi.fn((_m: string) => 'child-resolved-key');
+      const { childConfig } = buildChildConfig(
+        baseArgs({ parsed: parsed({ model: 'sonnet' }), resolveApiKeyForModel }),
+      );
+      expect(resolveApiKeyForModel).toHaveBeenCalledWith('sonnet');
+      expect(childConfig.apiKey).toBe('child-resolved-key');
+    });
+  });
+
+  describe('nesting wiring', () => {
+    function mockProvider(): ModelProvider {
+      return { name: 'test-provider', query: vi.fn() };
+    }
+
+    it('builds a child manager + calls the provider factory when depth < maxDepth and a factory is wired', () => {
+      const childProviderFactory = vi.fn(() => mockProvider());
+      const createChildExecutor = vi.fn((_ctx: SubagentExecutorContext) => stubChildExecutor());
+      const { childConfig, childManager, childParentSession } = buildChildConfig(
+        baseArgs({ depth: 0, maxDepth: 3, childProviderFactory, createChildExecutor }),
+      );
+
+      expect(childManager).toBeDefined();
+      expect(childParentSession).toBeDefined();
+      expect(createChildExecutor).toHaveBeenCalledTimes(1);
+      expect(childProviderFactory).toHaveBeenCalledTimes(1);
+      expect(childConfig.provider).toBeDefined();
+    });
+
+    it('passes depth + 1 and maxDepth into the recursive child executor ctx', () => {
+      let capturedCtx: SubagentExecutorContext | undefined;
+      const childProviderFactory = vi.fn(() => mockProvider());
+      const createChildExecutor = vi.fn((ctx: SubagentExecutorContext) => {
+        capturedCtx = ctx;
+        return stubChildExecutor();
+      });
+      buildChildConfig(
+        baseArgs({ depth: 1, maxDepth: 4, childProviderFactory, createChildExecutor }),
+      );
+      expect(capturedCtx).toBeDefined();
+      expect(capturedCtx!.depth).toBe(2);
+      expect(capturedCtx!.maxDepth).toBe(4);
+    });
+
+    it('forwards currentCwd to the child manager (depth-2 fork inheritance)', () => {
+      const childProviderFactory = vi.fn(() => mockProvider());
+      const { childManager } = buildChildConfig(
+        baseArgs({
+          depth: 0,
+          maxDepth: 3,
+          currentCwd: '/tmp/wt/feat-y',
+          childProviderFactory,
+        }),
+      );
+      const mgr = childManager as unknown as { parentCwd: string | undefined };
+      expect(mgr.parentCwd).toBe('/tmp/wt/feat-y');
+    });
+
+    it('skips nesting (no child manager, no provider) at the depth cap', () => {
+      const childProviderFactory = vi.fn(() => mockProvider());
+      const { childConfig, childManager, childParentSession } = buildChildConfig(
+        baseArgs({ depth: 3, maxDepth: 3, childProviderFactory }),
+      );
+      expect(childManager).toBeUndefined();
+      expect(childParentSession).toBeUndefined();
+      expect(childProviderFactory).not.toHaveBeenCalled();
+      expect(childConfig.provider).toBeUndefined();
+    });
+
+    it('skips nesting when no provider factory is wired', () => {
+      const { childConfig, childManager } = buildChildConfig(
+        baseArgs({ depth: 0, maxDepth: 3, childProviderFactory: undefined }),
+      );
+      expect(childManager).toBeUndefined();
+      expect(childConfig.provider).toBeUndefined();
+    });
+  });
+
+  describe('named-agent tool access (fail-closed intersection)', () => {
+    function mockProvider(): ModelProvider {
+      return { name: 'p', query: vi.fn() };
+    }
+
+    it('intersects the named agent allowlist with the pre-existing cage (narrows, never widens)', () => {
+      // Named agent grants read_file + bash + write_file; the executor already
+      // sits in a read-only cage of read_file + grep. Effective = intersection
+      // = read_file only. Captured via the provider factory's allowedTools arg.
+      let capturedAllowed: string[] | undefined;
+      const childProviderFactory = vi.fn((factoryArgs: { allowedTools?: string[] }) => {
+        capturedAllowed = factoryArgs.allowedTools;
+        return mockProvider();
+      });
+      buildChildConfig(
+        baseArgs({
+          depth: 0,
+          maxDepth: 3,
+          namedAgent: namedAgent({ tools: ['read_file', 'bash', 'write_file'] }),
+          allowedTools: ['read_file', 'grep'],
+          childProviderFactory,
+        }),
+      );
+      expect(capturedAllowed).toEqual(['read_file']);
+    });
+
+    it('uses the named agent allowlist directly when there is no pre-existing cage', () => {
+      let capturedAllowed: string[] | undefined;
+      const childProviderFactory = vi.fn((factoryArgs: { allowedTools?: string[] }) => {
+        capturedAllowed = factoryArgs.allowedTools;
+        return mockProvider();
+      });
+      buildChildConfig(
+        baseArgs({
+          depth: 0,
+          maxDepth: 3,
+          namedAgent: namedAgent({ tools: ['read_file', 'grep'] }),
+          allowedTools: undefined,
+          childProviderFactory,
+        }),
+      );
+      expect(capturedAllowed).toEqual(['read_file', 'grep']);
+    });
+
+    it('propagates bash read-only when the named agent declares bash: read-only', () => {
+      let capturedReadOnly: boolean | undefined;
+      const childProviderFactory = vi.fn((factoryArgs: { readOnlyBash?: boolean }) => {
+        capturedReadOnly = factoryArgs.readOnlyBash;
+        return mockProvider();
+      });
+      buildChildConfig(
+        baseArgs({
+          depth: 0,
+          maxDepth: 3,
+          namedAgent: namedAgent({ tools: ['bash'] }, { bashReadOnly: true }),
+          childProviderFactory,
+        }),
+      );
+      expect(capturedReadOnly).toBe(true);
+    });
+
+    it('builds a restricted provider at the depth cap when a cage is present (fail-closed, no fan-out)', () => {
+      // At maxDepth with an allowedTools cage but no factory-built nested
+      // executor, the else-branch installs buildSkillRestrictedProvider so the
+      // fork cannot silently inherit the unrestricted default provider.
+      const { childConfig, childManager } = buildChildConfig(
+        baseArgs({
+          depth: 3,
+          maxDepth: 3,
+          allowedTools: ['read_file', 'grep'],
+          childProviderFactory: vi.fn(),
+        }),
+      );
+      // No nested manager at the cap, but a provider IS set (restricted).
+      expect(childManager).toBeUndefined();
+      expect(childConfig.provider).toBeDefined();
+    });
+  });
+});

--- a/src/agent/tools/subagent/failure-payload.test.ts
+++ b/src/agent/tools/subagent/failure-payload.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Direct unit tests for the failure-path payload + telemetry helpers.
+ *
+ * Follow-up to #443: these helpers were extracted from `subagent-executor.ts`
+ * and previously covered only transitively through `subagent-executor.test.ts`.
+ * `truncate`, `measurePartial`, and `buildFailurePayload` are pure — tested
+ * here directly at boundaries. `emitTelemetry` wraps `appendRoutingDecision`;
+ * it is tested with a hoisted module mock (matching the harness in
+ * `subagent-executor.test.ts`) to assert the best-effort no-throw contract.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Hoisted mock so failure-payload.ts picks up the mocked appendRoutingDecision.
+// Mirrors the pattern used in subagent-executor.test.ts.
+const appendRoutingDecision = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('../../routing-telemetry.js', () => ({ appendRoutingDecision }));
+
+import {
+  emitTelemetry,
+  truncate,
+  measurePartial,
+  buildFailurePayload,
+  type StructuredFailurePayload,
+} from './failure-payload.js';
+
+describe('truncate', () => {
+  it('returns the string unchanged when at or below the limit', () => {
+    expect(truncate('short', 10)).toBe('short');
+  });
+
+  it('returns the string unchanged at the exact boundary (length === max)', () => {
+    const s = 'x'.repeat(10);
+    expect(truncate(s, 10)).toBe(s);
+  });
+
+  it('truncates and appends an ellipsis when one char over the limit', () => {
+    const s = 'x'.repeat(11);
+    const result = truncate(s, 10);
+    expect(result).toBe('x'.repeat(10) + '…');
+    // Result is max + 1 (the single ellipsis char).
+    expect(result.length).toBe(11);
+  });
+
+  it('truncates long strings to max chars + ellipsis', () => {
+    const result = truncate('y'.repeat(1000), 240);
+    expect(result.length).toBe(241);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('uses the default max of 240 when none is supplied', () => {
+    const result = truncate('z'.repeat(500));
+    expect(result.length).toBe(241);
+    expect(result).toBe('z'.repeat(240) + '…');
+  });
+
+  it('leaves a string shorter than the default max untouched', () => {
+    expect(truncate('a few words')).toBe('a few words');
+  });
+
+  it('handles the empty string', () => {
+    expect(truncate('', 240)).toBe('');
+  });
+});
+
+describe('measurePartial', () => {
+  it('returns undefined for undefined', () => {
+    expect(measurePartial(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for null', () => {
+    expect(measurePartial(null)).toBeUndefined();
+  });
+
+  it('returns the string length for a string (not the JSON-encoded length)', () => {
+    // A raw string is measured by .length, not JSON.stringify (which would add
+    // surrounding quotes → length + 2).
+    expect(measurePartial('hello')).toBe(5);
+  });
+
+  it('returns 0 for the empty string', () => {
+    // Empty string is not null/undefined, so it takes the string branch → 0.
+    expect(measurePartial('')).toBe(0);
+  });
+
+  it('returns the serialized length for an object', () => {
+    const obj = { a: 1, b: 'two' };
+    expect(measurePartial(obj)).toBe(JSON.stringify(obj).length);
+  });
+
+  it('returns the serialized length for an array', () => {
+    const arr = [1, 2, 3];
+    expect(measurePartial(arr)).toBe(JSON.stringify(arr).length);
+  });
+
+  it('returns the serialized length for a number', () => {
+    // JSON.stringify(42) === '42' → length 2.
+    expect(measurePartial(42)).toBe(2);
+  });
+
+  it('returns undefined when the value is not serializable (circular ref)', () => {
+    const circular: Record<string, unknown> = {};
+    circular['self'] = circular;
+    expect(measurePartial(circular)).toBeUndefined();
+  });
+
+  it('returns undefined when the value contains a BigInt (JSON.stringify throws)', () => {
+    expect(measurePartial({ big: 1n })).toBeUndefined();
+  });
+});
+
+describe('buildFailurePayload', () => {
+  it('builds the minimal payload with status, error, and subagent_id', () => {
+    const payload = buildFailurePayload({
+      status: 'failed',
+      errorMessage: 'something exploded',
+      subagentId: 'child-1',
+    });
+    const expected: StructuredFailurePayload = {
+      status: 'failed',
+      error: 'something exploded',
+      subagent_id: 'child-1',
+    };
+    expect(payload).toEqual(expected);
+  });
+
+  it('omits schemaError when not supplied', () => {
+    const payload = buildFailurePayload({
+      status: 'failed',
+      errorMessage: 'e',
+      subagentId: 'c',
+    });
+    expect('schemaError' in payload).toBe(false);
+  });
+
+  it('omits schemaError when supplied as an empty string (falsy)', () => {
+    // The `if (args.schemaErrorMessage)` guard treats '' as absent.
+    const payload = buildFailurePayload({
+      status: 'failed',
+      errorMessage: 'e',
+      schemaErrorMessage: '',
+      subagentId: 'c',
+    });
+    expect('schemaError' in payload).toBe(false);
+  });
+
+  it('includes schemaError when supplied', () => {
+    const payload = buildFailurePayload({
+      status: 'failed',
+      errorMessage: 'e',
+      schemaErrorMessage: 'expected string, got number',
+      subagentId: 'c',
+    });
+    expect(payload.schemaError).toBe('expected string, got number');
+  });
+
+  it('omits partialOutput when not supplied', () => {
+    const payload = buildFailurePayload({
+      status: 'failed',
+      errorMessage: 'e',
+      subagentId: 'c',
+    });
+    expect('partialOutput' in payload).toBe(false);
+  });
+
+  it('omits partialOutput when supplied as null', () => {
+    const payload = buildFailurePayload({
+      status: 'failed',
+      errorMessage: 'e',
+      partialOutput: null,
+      subagentId: 'c',
+    });
+    expect('partialOutput' in payload).toBe(false);
+  });
+
+  it('passes through a small partialOutput unchanged', () => {
+    const partial = { steps: ['a', 'b'], note: 'halfway' };
+    const payload = buildFailurePayload({
+      status: 'failed',
+      errorMessage: 'e',
+      partialOutput: partial,
+      subagentId: 'c',
+    });
+    expect(payload.partialOutput).toEqual(partial);
+  });
+
+  it('passes through a small string partialOutput unchanged', () => {
+    const payload = buildFailurePayload({
+      status: 'failed',
+      errorMessage: 'e',
+      partialOutput: 'small partial',
+      subagentId: 'c',
+    });
+    expect(payload.partialOutput).toBe('small partial');
+  });
+
+  it('replaces an over-large partialOutput with a {truncated, chars} marker', () => {
+    // ~10KB serialized — well past the 4096-char cap.
+    const big = { blob: 'x'.repeat(10_000) };
+    const payload = buildFailurePayload({
+      status: 'failed',
+      errorMessage: 'e',
+      partialOutput: big,
+      subagentId: 'c',
+    });
+    expect(payload.partialOutput).toEqual({
+      truncated: true,
+      chars: JSON.stringify(big).length,
+    });
+    // The raw blob must not be inlined into the payload.
+    expect(JSON.stringify(payload)).not.toContain('xxxxxxxxxx');
+  });
+
+  it('keeps a partialOutput that is exactly at the 4096-char cap (boundary)', () => {
+    // A raw string is measured by measurePartial via `.length` (NOT the
+    // JSON-encoded length), so a 4096-char string measures as exactly 4096.
+    // `chars > 4096` is false at the boundary → passthrough.
+    const atCap = 'x'.repeat(4096);
+    expect(measurePartial(atCap)).toBe(4096);
+    const payload = buildFailurePayload({
+      status: 'failed',
+      errorMessage: 'e',
+      partialOutput: atCap,
+      subagentId: 'c',
+    });
+    expect(payload.partialOutput).toBe(atCap);
+  });
+
+  it('replaces a string partialOutput that is one char over the cap', () => {
+    // 4097 chars measures as 4097 > 4096 → truncated marker.
+    const overCap = 'x'.repeat(4097);
+    const payload = buildFailurePayload({
+      status: 'failed',
+      errorMessage: 'e',
+      partialOutput: overCap,
+      subagentId: 'c',
+    });
+    expect(payload.partialOutput).toEqual({ truncated: true, chars: 4097 });
+  });
+
+  it('truncates the error message to the 1024-char cap (+ ellipsis)', () => {
+    const huge = 'E'.repeat(5000);
+    const payload = buildFailurePayload({
+      status: 'failed',
+      errorMessage: huge,
+      subagentId: 'c',
+    });
+    // 1024 chars + 1 ellipsis.
+    expect(payload.error.length).toBe(1025);
+    expect(payload.error.endsWith('…')).toBe(true);
+  });
+
+  it('truncates the schemaError message to the 1024-char cap (+ ellipsis)', () => {
+    const huge = 'S'.repeat(5000);
+    const payload = buildFailurePayload({
+      status: 'failed',
+      errorMessage: 'e',
+      schemaErrorMessage: huge,
+      subagentId: 'c',
+    });
+    expect(payload.schemaError).toBeDefined();
+    expect(payload.schemaError!.length).toBe(1025);
+  });
+
+  it('produces a payload that excludes prompts/stack-traces/credentials by construction', () => {
+    // Documented invariant: the payload carries ONLY status, error,
+    // schemaError, partialOutput, subagent_id. Even if a caller passes a
+    // long error string, no extra keys leak. This pins the shape so a future
+    // edit that widens the payload has to update this test.
+    const payload = buildFailurePayload({
+      status: 'failed',
+      errorMessage: 'boom',
+      schemaErrorMessage: 'schema mismatch',
+      partialOutput: { some: 'state' },
+      subagentId: 'child-x',
+    });
+    expect(Object.keys(payload).sort()).toEqual(
+      ['error', 'partialOutput', 'schemaError', 'status', 'subagent_id'].sort(),
+    );
+  });
+});
+
+describe('emitTelemetry', () => {
+  beforeEach(() => {
+    appendRoutingDecision.mockClear();
+    appendRoutingDecision.mockResolvedValue(undefined);
+  });
+
+  it('forwards the entry to appendRoutingDecision', async () => {
+    const entry = {
+      event: 'subagent.completed' as const,
+      subagent_id: 'sub-1',
+    };
+    await emitTelemetry(entry as Parameters<typeof emitTelemetry>[0]);
+    expect(appendRoutingDecision).toHaveBeenCalledTimes(1);
+    expect(appendRoutingDecision).toHaveBeenCalledWith(entry);
+  });
+
+  it('swallows a rejected appendRoutingDecision (best-effort, never rejects)', async () => {
+    appendRoutingDecision.mockRejectedValueOnce(new Error('telemetry sink down'));
+    // The wrapper .catch(() => {})s the rejection, so the returned promise
+    // resolves rather than rejecting.
+    await expect(
+      emitTelemetry({} as Parameters<typeof emitTelemetry>[0]),
+    ).resolves.toBeUndefined();
+  });
+
+  it('swallows a synchronous throw from appendRoutingDecision', async () => {
+    // Defense in depth: even if the helper throws synchronously (it should not),
+    // emitTelemetry returns a resolved promise rather than propagating.
+    appendRoutingDecision.mockImplementationOnce(() => {
+      throw new Error('sync explosion');
+    });
+    await expect(
+      emitTelemetry({} as Parameters<typeof emitTelemetry>[0]),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/agent/tools/subagent/input-parse.test.ts
+++ b/src/agent/tools/subagent/input-parse.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Direct unit tests for the pure `parseAgentInput` validator.
+ *
+ * Follow-up to #443: the extracted `subagent/` modules had no direct unit
+ * tests, only transitive coverage through `subagent-executor.test.ts`. This
+ * file covers `input-parse.ts` exhaustively at the function boundary — every
+ * happy path and every rejection/edge path of the validation pipeline —
+ * without going through the executor.
+ *
+ * `parseAgentInput` is pure (no executor instance, no I/O), so these tests are
+ * plain input → output assertions with no mock harness.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseAgentInput, type AgentInput } from './input-parse.js';
+
+describe('parseAgentInput', () => {
+  describe('input shape', () => {
+    it('throws when input is not an object (string)', () => {
+      expect(() => parseAgentInput('not an object')).toThrow(/must be an object/);
+    });
+
+    it('throws when input is null', () => {
+      expect(() => parseAgentInput(null)).toThrow(/must be an object/);
+    });
+
+    it('throws when input is a number', () => {
+      expect(() => parseAgentInput(42)).toThrow(/must be an object/);
+    });
+
+    it('throws when input is undefined', () => {
+      expect(() => parseAgentInput(undefined)).toThrow(/must be an object/);
+    });
+
+    it('accepts a plain object with only a prompt', () => {
+      const result = parseAgentInput({ prompt: 'do the thing' });
+      expect(result.prompt).toBe('do the thing');
+    });
+  });
+
+  describe('prompt', () => {
+    it('throws when prompt is missing', () => {
+      expect(() => parseAgentInput({})).toThrow(
+        /must have a "prompt" field of type string/,
+      );
+    });
+
+    it('throws when prompt is not a string (number)', () => {
+      expect(() => parseAgentInput({ prompt: 123 })).toThrow(
+        /must have a "prompt" field of type string/,
+      );
+    });
+
+    it('throws when prompt is an empty string', () => {
+      expect(() => parseAgentInput({ prompt: '' })).toThrow(/cannot be empty/);
+    });
+
+    it('throws when prompt is whitespace-only', () => {
+      expect(() => parseAgentInput({ prompt: '   \n\t  ' })).toThrow(/cannot be empty/);
+    });
+
+    it('preserves the prompt verbatim (no trimming of the stored value)', () => {
+      // Only the emptiness CHECK trims; the returned prompt is the original.
+      const result = parseAgentInput({ prompt: '  leading and trailing  ' });
+      expect(result.prompt).toBe('  leading and trailing  ');
+    });
+  });
+
+  describe('model', () => {
+    it('defaults model to undefined when omitted', () => {
+      const result = parseAgentInput({ prompt: 'p' });
+      expect(result.model).toBeUndefined();
+    });
+
+    it('accepts a string model', () => {
+      const result = parseAgentInput({ prompt: 'p', model: 'opus' });
+      expect(result.model).toBe('opus');
+    });
+
+    it('throws when model is not a string (number)', () => {
+      expect(() => parseAgentInput({ prompt: 'p', model: 5 })).toThrow(
+        /model must be a string/,
+      );
+    });
+
+    it('throws when model is null (explicit non-string)', () => {
+      // `null !== undefined`, so it reaches the type check and is rejected.
+      expect(() => parseAgentInput({ prompt: 'p', model: null })).toThrow(
+        /model must be a string/,
+      );
+    });
+  });
+
+  describe('max_turns', () => {
+    it('defaults to 10 and marks it non-explicit when omitted', () => {
+      const result = parseAgentInput({ prompt: 'p' });
+      expect(result.max_turns).toBe(10);
+      expect(result.max_turns_explicit).toBe(false);
+    });
+
+    it('marks max_turns_explicit true when supplied', () => {
+      const result = parseAgentInput({ prompt: 'p', max_turns: 5 });
+      expect(result.max_turns).toBe(5);
+      expect(result.max_turns_explicit).toBe(true);
+    });
+
+    it('clamps values above 50 down to 50', () => {
+      const result = parseAgentInput({ prompt: 'p', max_turns: 100 });
+      expect(result.max_turns).toBe(50);
+      expect(result.max_turns_explicit).toBe(true);
+    });
+
+    it('clamps the exact upper boundary (50 stays 50)', () => {
+      expect(parseAgentInput({ prompt: 'p', max_turns: 50 }).max_turns).toBe(50);
+    });
+
+    it('clamps values below 1 up to 1', () => {
+      const result = parseAgentInput({ prompt: 'p', max_turns: -5 });
+      expect(result.max_turns).toBe(1);
+    });
+
+    it('clamps zero up to 1', () => {
+      expect(parseAgentInput({ prompt: 'p', max_turns: 0 }).max_turns).toBe(1);
+    });
+
+    it('clamps the exact lower boundary (1 stays 1)', () => {
+      expect(parseAgentInput({ prompt: 'p', max_turns: 1 }).max_turns).toBe(1);
+    });
+
+    it('floors fractional values before clamping', () => {
+      // Math.floor(3.9) === 3, within range → 3.
+      expect(parseAgentInput({ prompt: 'p', max_turns: 3.9 }).max_turns).toBe(3);
+    });
+
+    it('floors a fractional value that also needs clamping (0.5 → 0 → 1)', () => {
+      // Math.floor(0.5) === 0, then clamp up to 1.
+      expect(parseAgentInput({ prompt: 'p', max_turns: 0.5 }).max_turns).toBe(1);
+    });
+
+    it('throws when max_turns is not a number (string)', () => {
+      expect(() => parseAgentInput({ prompt: 'p', max_turns: '10' })).toThrow(
+        /max_turns must be a number/,
+      );
+    });
+  });
+
+  describe('agent_type / subagent_type alias', () => {
+    it('is undefined (key omitted) when neither is supplied', () => {
+      const result = parseAgentInput({ prompt: 'p' });
+      expect(result.agent_type).toBeUndefined();
+      expect('agent_type' in result).toBe(false);
+    });
+
+    it('accepts agent_type', () => {
+      const result = parseAgentInput({ prompt: 'p', agent_type: 'research-agent' });
+      expect(result.agent_type).toBe('research-agent');
+    });
+
+    it('accepts subagent_type as an alias', () => {
+      const result = parseAgentInput({ prompt: 'p', subagent_type: 'git-investigator' });
+      expect(result.agent_type).toBe('git-investigator');
+    });
+
+    it('prefers the canonical agent_type when both are present', () => {
+      const result = parseAgentInput({
+        prompt: 'p',
+        agent_type: 'canonical',
+        subagent_type: 'alias',
+      });
+      expect(result.agent_type).toBe('canonical');
+    });
+
+    it('trims surrounding whitespace from the resolved value', () => {
+      const result = parseAgentInput({ prompt: 'p', agent_type: '  research-agent  ' });
+      expect(result.agent_type).toBe('research-agent');
+    });
+
+    it('treats a whitespace-only agent_type as absent (key omitted)', () => {
+      // Trimmed length is 0 → agent_type stays undefined and the key is omitted.
+      const result = parseAgentInput({ prompt: 'p', agent_type: '   ' });
+      expect(result.agent_type).toBeUndefined();
+      expect('agent_type' in result).toBe(false);
+    });
+
+    it('falls through to the alias when canonical is a whitespace-only string', () => {
+      // `agentInput['agent_type'] ?? agentInput['subagent_type']` uses nullish
+      // coalescing, so a present-but-empty agent_type ('') still wins the ??
+      // (it is not null/undefined). It then trims to '' and is dropped — the
+      // alias is NOT consulted. This pins that documented precedence.
+      const result = parseAgentInput({
+        prompt: 'p',
+        agent_type: '   ',
+        subagent_type: 'alias',
+      });
+      expect(result.agent_type).toBeUndefined();
+    });
+
+    it('throws when agent_type is not a string (number)', () => {
+      expect(() => parseAgentInput({ prompt: 'p', agent_type: 7 })).toThrow(
+        /agent_type must be a string/,
+      );
+    });
+
+    it('throws when only subagent_type is supplied and it is not a string', () => {
+      expect(() => parseAgentInput({ prompt: 'p', subagent_type: 7 })).toThrow(
+        /agent_type must be a string/,
+      );
+    });
+  });
+
+  describe('id_prefix', () => {
+    it("defaults to 'agent-tool' when omitted", () => {
+      expect(parseAgentInput({ prompt: 'p' }).id_prefix).toBe('agent-tool');
+    });
+
+    it('accepts a custom id_prefix', () => {
+      expect(parseAgentInput({ prompt: 'p', id_prefix: 'code-review' }).id_prefix).toBe(
+        'code-review',
+      );
+    });
+
+    it('accepts an empty-string id_prefix verbatim (no default substitution)', () => {
+      // An explicit '' is a string, so it passes the type check and is used
+      // as-is — the default only applies when the field is absent.
+      expect(parseAgentInput({ prompt: 'p', id_prefix: '' }).id_prefix).toBe('');
+    });
+
+    it('throws when id_prefix is not a string (number)', () => {
+      expect(() => parseAgentInput({ prompt: 'p', id_prefix: 1 })).toThrow(
+        /id_prefix must be a string/,
+      );
+    });
+  });
+
+  describe('mode', () => {
+    it("defaults to 'foreground' when omitted", () => {
+      expect(parseAgentInput({ prompt: 'p' }).mode).toBe('foreground');
+    });
+
+    it("accepts 'foreground'", () => {
+      expect(parseAgentInput({ prompt: 'p', mode: 'foreground' }).mode).toBe('foreground');
+    });
+
+    it("accepts 'background'", () => {
+      expect(parseAgentInput({ prompt: 'p', mode: 'background' }).mode).toBe('background');
+    });
+
+    it('rejects an unknown mode string loudly', () => {
+      expect(() => parseAgentInput({ prompt: 'p', mode: 'sideways' })).toThrow(
+        /mode must be "foreground" or "background"/,
+      );
+    });
+
+    it('includes the offending value in the error message', () => {
+      expect(() => parseAgentInput({ prompt: 'p', mode: 'back' })).toThrow(/"back"/);
+    });
+
+    it('rejects a non-string mode (number)', () => {
+      expect(() => parseAgentInput({ prompt: 'p', mode: 1 })).toThrow(
+        /mode must be "foreground" or "background"/,
+      );
+    });
+  });
+
+  describe('cwd', () => {
+    it('is undefined (key omitted) when not supplied — parent fallback preserved', () => {
+      const result = parseAgentInput({ prompt: 'p' });
+      expect(result.cwd).toBeUndefined();
+      expect('cwd' in result).toBe(false);
+    });
+
+    it('accepts an absolute POSIX path', () => {
+      expect(parseAgentInput({ prompt: 'p', cwd: '/tmp/wt/feat-x' }).cwd).toBe(
+        '/tmp/wt/feat-x',
+      );
+    });
+
+    it('throws when cwd is not a string (number)', () => {
+      expect(() => parseAgentInput({ prompt: 'p', cwd: 42 })).toThrow(
+        /cwd must be a string/,
+      );
+    });
+
+    it('throws when cwd is an empty string', () => {
+      expect(() => parseAgentInput({ prompt: 'p', cwd: '' })).toThrow(
+        /cwd must be a non-empty string/,
+      );
+    });
+
+    it('throws when cwd is a relative path', () => {
+      expect(() => parseAgentInput({ prompt: 'p', cwd: 'relative/path' })).toThrow(
+        /cwd must be an absolute path/,
+      );
+    });
+
+    it('throws when cwd is a dot-relative path', () => {
+      expect(() => parseAgentInput({ prompt: 'p', cwd: './also-relative' })).toThrow(
+        /cwd must be an absolute path/,
+      );
+    });
+
+    it("throws when cwd contains a '..' segment (forward slash)", () => {
+      expect(() => parseAgentInput({ prompt: 'p', cwd: '/tmp/wt/../escape' })).toThrow(
+        /must not contain '\.\.' segments/,
+      );
+    });
+
+    it("throws when cwd contains a '..' segment (backslash separator, Windows-shape)", () => {
+      // The segment split covers both `/` and `\` so a Windows-formatted '..'
+      // is rejected even on POSIX hosts. Use an absolute POSIX prefix so the
+      // isAbsolute() gate passes first and the split branch is what fires.
+      expect(() => parseAgentInput({ prompt: 'p', cwd: '/tmp\\..\\escape' })).toThrow(
+        /must not contain '\.\.' segments/,
+      );
+    });
+
+    it("accepts a path where '..' appears only as a substring, not a whole segment", () => {
+      // '..foo' and 'foo..' are legitimate segment names; only a bare '..'
+      // segment is rejected. This guards against an over-eager `includes('..')`
+      // on the raw string.
+      const result = parseAgentInput({ prompt: 'p', cwd: '/tmp/wt/..foo/bar..baz' });
+      expect(result.cwd).toBe('/tmp/wt/..foo/bar..baz');
+    });
+  });
+
+  describe('full happy path', () => {
+    it('parses every field together with expected precedence and defaults', () => {
+      const result = parseAgentInput({
+        prompt: 'investigate the failing test',
+        model: 'sonnet',
+        max_turns: 25,
+        id_prefix: 'diagnose',
+        subagent_type: 'research-agent',
+        mode: 'background',
+        cwd: '/tmp/wt/diagnose-run',
+      });
+
+      const expected: AgentInput = {
+        prompt: 'investigate the failing test',
+        model: 'sonnet',
+        max_turns: 25,
+        max_turns_explicit: true,
+        id_prefix: 'diagnose',
+        agent_type: 'research-agent',
+        mode: 'background',
+        cwd: '/tmp/wt/diagnose-run',
+      };
+      expect(result).toEqual(expected);
+    });
+
+    it('returns a minimal object with defaults when only prompt is given', () => {
+      const result = parseAgentInput({ prompt: 'minimal' });
+      const expected: AgentInput = {
+        prompt: 'minimal',
+        model: undefined,
+        max_turns: 10,
+        max_turns_explicit: false,
+        id_prefix: 'agent-tool',
+        mode: 'foreground',
+      };
+      expect(result).toEqual(expected);
+      // Optional keys must be omitted (not present-as-undefined) so downstream
+      // spreads and strict own-key checks behave.
+      expect('agent_type' in result).toBe(false);
+      expect('cwd' in result).toBe(false);
+    });
+
+    it('ignores unrecognized extra keys on the input object', () => {
+      const result = parseAgentInput({ prompt: 'p', bogusExtra: 'ignored' } as Record<string, unknown>);
+      expect(result.prompt).toBe('p');
+      expect('bogusExtra' in result).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #443, which refactored `src/agent/tools/subagent-executor.ts` (1316→577 LOC) by extracting `execute()` into five modules under `src/agent/tools/subagent/`. That PR's code review approved the merge with exactly one low-severity finding: **the five new modules had no direct unit tests — only transitive coverage through the unchanged `subagent-executor.test.ts` (86 cases)**. This PR closes that finding.

## Modules now directly tested

| Module | Test file | Cases | Coverage |
|---|---|---|---|
| `input-parse.ts` | `input-parse.test.ts` | 55 | Exhaustive `parseAgentInput` validation — prompt required/non-empty, model type, `max_turns` clamp `[1,50]` + floor, `agent_type`/`subagent_type` alias + trim + precedence, `id_prefix` default, `mode` allowlist (reject unknown), `cwd` absolute + no-`..`-segment rules. Every happy path **and** every rejection/edge path. |
| `failure-payload.ts` | `failure-payload.test.ts` | 33 | `truncate` boundaries (at/over/default limits), `measurePartial` (string `.length` vs. JSON size, unserializable → `undefined`), `buildFailurePayload` shape + size caps + the documented **excludes prompts/stack-traces/credentials** invariant, and `emitTelemetry`'s best-effort no-throw contract (hoisted mock of `appendRoutingDecision`, sync + async failure). |
| `background-branch.ts` | `background-branch.test.ts` | 11 | `runBackgroundBranch` three paths: no-registry error + orphan-handle teardown, `BackgroundJobCapError` teardown, non-cap error re-throw, and the register-and-return synthetic "running" pointer payload shape (+ arg forwarding, `sonnet` default). |
| `child-config.ts` | `child-config.test.ts` | 29 | `buildChildConfig` deterministic slice: turn-budget resolution (explicit vs. named-agent `maxTurns` frontmatter vs. default, with clamp/floor), `depth + 1`/`maxDepth` wiring, `systemPrompt` selection (named body vs. parent base), model resolution legs (fixed / `inherit` → parentModel / fallback chain), `cwd` threading + omission, named-agent tool-access **fail-closed intersection** against a cage, and the depth-cap restricted-provider fallback. Credential resolution is driven via the injected `resolveApiKeyForModel` parameter to avoid touching the live keychain. |

**Total: 128 new test cases across 4 co-located test files.**

### Not tested (deliberate)

`foreground-promotion.ts` gets **no dedicated file**. Its promotion-race + finally-cleanup path is already well-covered transitively by `subagent-executor.test.ts`'s `promotion`, `cancellation`, and `in-turn SubagentStop injectContext delivery` describe blocks. A direct test would reconstruct the executor's live `promotionTriggers`/`activeForegroundHandles` maps and hanging-handle harness only to re-assert existing behavior — pure duplication, so it was skipped.

Similarly, the full cross-provider **credential anti-leak matrix** and depth-2+ `childManager` cwd inheritance are left to the existing executor tests (`resolveApiKeyForModel` / `parentId attribution` blocks) rather than re-implemented here.

## Notes

- **Tests only** — no production source file was modified.
- **No bugs surfaced.** Every module behaved exactly as its own docstrings specify.

## Verification

- `pnpm exec vitest run src/agent/tools/subagent/*.test.ts` → **128/128 pass** (input-parse 55, failure-payload 33, background-branch 11, child-config 29).
- `pnpm lint` (`tsc --noEmit`, maximally strict — `noUnusedLocals`, `noUncheckedIndexedAccess`, `noPropertyAccessFromIndexSignature`, …) → **clean, exit 0**.
- `pnpm exec vitest run src/agent/tools/subagent-executor.test.ts` → existing **86/86 pass, unperturbed**.
