### PR TITLE
refactor(repl): calm REPL chrome (glyph mode marker, idle rail, cwd/branch dedupe)

### DIFF
--- a/src/cli/commands/interactive/loop-stage.test.ts
+++ b/src/cli/commands/interactive/loop-stage.test.ts
@@ -186,10 +186,12 @@ describe('formatStageRail', () => {
     bold: (s: string) => `bold<${s}>`,
   };
 
-  it('renders all five stages joined by separators', () => {
+  it('collapses "observing" (idle/reset) to a single dim "· idle" cell', () => {
     const out = formatStageRail('observing', fmt);
+    expect(out).toBe('dim<· idle>');
+    // The idle collapse must NOT leak any of the five stage labels.
     for (const stage of LOOP_STAGES) {
-      expect(out).toContain(STAGE_LABEL[stage]);
+      expect(out).not.toContain(STAGE_LABEL[stage]);
     }
   });
 
@@ -199,6 +201,21 @@ describe('formatStageRail', () => {
     // Inactives use the hollow diamond + dim.
     expect(out).toContain('dim<◇ observe>');
     expect(out).toContain('dim<◇ update>');
+  });
+
+  it('renders the full 5-cell rail (with ◆ on the active cell) for every non-observing stage', () => {
+    for (const stage of LOOP_STAGES.filter((s) => s !== 'observing')) {
+      const out = formatStageRail(stage, fmt);
+      // All five stage labels present — the rail is not collapsed.
+      for (const label of Object.values(STAGE_LABEL)) {
+        expect(out).toContain(label);
+      }
+      // Exactly the active stage's cell carries the solid diamond.
+      expect(out).toContain(`◆ ${STAGE_LABEL[stage]}`);
+      for (const other of LOOP_STAGES.filter((s) => s !== stage)) {
+        expect(out).not.toContain(`◆ ${STAGE_LABEL[other]}`);
+      }
+    }
   });
 });
 
@@ -266,9 +283,10 @@ describe('LoopStageBar', () => {
     const out = joinWrites(stream);
     // rows=24, extraRows=1 → paint at row 23 (immediately above the status row).
     expect(cupRows(out)).toContain(23);
-    // Idle rail shows every stage label, with 'observe' active.
-    expect(out).toContain('observe');
-    expect(out).toContain('update');
+    // Idle paint collapses to the single dim `· idle` cell (formatStageRail
+    // special-cases the between-turns 'observing' stage) — no stage labels.
+    expect(out).toContain('· idle');
+    expect(out).not.toContain('observe');
     bar.stop();
   });
 

--- a/src/cli/commands/interactive/loop-stage.ts
+++ b/src/cli/commands/interactive/loop-stage.ts
@@ -156,11 +156,21 @@ export function advanceStage(s: StageTrackerState, event: OutputEvent): boolean 
  *
  * Color is intentionally restrained — bold + accent on the active stage,
  * dim on inactives. The goal is glance-readable, not decorative.
+ *
+ * Special case: `observing` is the idle/reset stage between turns (a turn
+ * just armed with no events yet, or no turn in flight at all) — the rail has
+ * nothing earned to show, so painting all five cells persistently between
+ * turns is chrome, not signal. Collapse to a single dim `· idle` cell
+ * instead of the full 5-cell rail. Every other stage renders the full rail
+ * unchanged.
  */
 export function formatStageRail(
   active: LoopStage,
   fmt: { dim: (s: string) => string; accent: (s: string) => string; bold: (s: string) => string },
 ): string {
+  if (active === 'observing') {
+    return fmt.dim('· idle');
+  }
   const cells = LOOP_STAGES.map((stage) => {
     const isActive = stage === active;
     const glyph = isActive ? '◆' : '◇';
@@ -205,7 +215,9 @@ export function formatStageRail(
  * `BackgroundStatusBar.repaint()`. It renders exactly one row.
  *
  * Visibility: renders whenever `started === true` and the stream is a TTY.
- * Between turns (stage = `'observing'`) it shows a dim "idle" rail.
+ * Between turns (stage = `'observing'`) `formatStageRail` collapses the full
+ * 5-cell rail to a single dim `· idle` cell (see its docstring) rather than
+ * painting all five stages with none of them earned yet.
  */
 export class LoopStageBar {
   private readonly stream: NodeJS.WriteStream;

--- a/src/cli/commands/interactive/repl-loop-shared.test.ts
+++ b/src/cli/commands/interactive/repl-loop-shared.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for buildPrompt (repl-loop-shared.ts).
+ *
+ * The caret carries the brand plus a GLYPH-ONLY echo of the non-default
+ * permission mode (` ●` / ` ◐` / ` ⚡`) — never the worded chip, which lives
+ * on the status line. The glyph must stay at the caret because the status
+ * row is painted outside the scroll region and never enters scrollback: the
+ * prompt is the only mode signal that survives into the linear transcript.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildPrompt } from './repl-loop-shared.js';
+
+const BROAD_ANSI_RE = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+
+function strip(s: string): string {
+  return s.replace(BROAD_ANSI_RE, '');
+}
+
+describe('buildPrompt', () => {
+  it('renders bare brand + caret with no marker in default mode', () => {
+    const out = strip(buildPrompt('default'));
+    expect(out).toBe('afk  › ');
+  });
+
+  it('renders a glyph-only plan marker (no word)', () => {
+    const out = strip(buildPrompt('plan'));
+    expect(out).toContain('●');
+    expect(out).not.toContain('plan');
+  });
+
+  it('renders a glyph-only autonomous marker (no word)', () => {
+    const out = strip(buildPrompt('autonomous'));
+    expect(out).toContain('◐');
+    expect(out).not.toContain('AFK');
+  });
+
+  it('renders a glyph-only bypass marker (no word)', () => {
+    const out = strip(buildPrompt('bypassPermissions'));
+    expect(out).toContain('⚡');
+    expect(out).not.toContain('bypass');
+  });
+
+  it('always ends with the caret', () => {
+    for (const mode of ['default', 'plan', 'autonomous', 'bypassPermissions'] as const) {
+      expect(strip(buildPrompt(mode))).toMatch(/› $/);
+    }
+  });
+});

--- a/src/cli/commands/interactive/repl-loop-shared.test.ts
+++ b/src/cli/commands/interactive/repl-loop-shared.test.ts
@@ -1,11 +1,13 @@
 /**
  * Tests for buildPrompt (repl-loop-shared.ts).
  *
- * The caret carries the brand plus a GLYPH-ONLY echo of the non-default
- * permission mode (` ●` / ` ◐` / ` ⚡`) — never the worded chip, which lives
- * on the status line. The glyph must stay at the caret because the status
+ * The caret carries the brand plus a compact echo of the non-default
+ * permission mode (` ●` / ` ◐` / ` ⚡bp`) — never the worded chip, which lives
+ * on the status line. The echo must stay at the caret because the status
  * row is painted outside the scroll region and never enters scrollback: the
  * prompt is the only mode signal that survives into the linear transcript.
+ * Plan and AFK are glyph-only; bypass ALSO keeps a short ASCII tag (`bp`)
+ * because it is security-sensitive and must stay grep-able in piped logs.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -35,9 +37,13 @@ describe('buildPrompt', () => {
     expect(out).not.toContain('AFK');
   });
 
-  it('renders a glyph-only bypass marker (no word)', () => {
+  it('renders the bypass marker with a grep-able ASCII token (glyph + bp)', () => {
     const out = strip(buildPrompt('bypassPermissions'));
     expect(out).toContain('⚡');
+    // Bypass is security-sensitive: it keeps an ASCII tag so a post-hoc grep
+    // of a piped transcript can still locate permission-off windows.
+    expect(out).toContain('bp');
+    // …but still not the full worded chip (that lives on the status line).
     expect(out).not.toContain('bypass');
   });
 

--- a/src/cli/commands/interactive/repl-loop-shared.ts
+++ b/src/cli/commands/interactive/repl-loop-shared.ts
@@ -57,15 +57,20 @@ export interface TurnState {
 }
 
 export function buildPrompt(mode: PermissionMode): string {
-  // The model name lives only in the persistent status line (status-line.ts,
-  // a never-drop field) — the caret carries just the brand + the non-default
-  // permission-mode chip (the gate-check worth confirming at the cursor), so
-  // model + mode aren't redundantly stacked two lines apart.
+  // The model name AND the worded mode chip (`○ default`, `● plan`, `◐ AFK`,
+  // `⚡ bypass`) live only in the persistent status line (status-line.ts) —
+  // the caret carries just the brand + a glyph-only echo of the non-default
+  // permission mode. The glyph stays here (rather than moving entirely to
+  // the status line) because the status row is carved out of the scroll
+  // region (see status-line.ts's writeScrollRegion) and never enters
+  // scrollback or piped logs: the prompt is the ONLY mode signal that
+  // survives into the linear transcript. Default mode adds no glyph — its
+  // absence is itself the "contained" signal, mirrored at the caret.
   const base = palette.brand('afk');
   const marker =
-    mode === 'plan' ? palette.warning(' ● plan') :
-    mode === 'autonomous' ? palette.info(' ◐ AFK') :
-    mode === 'bypassPermissions' ? palette.bypass(' ⚡ bypass') :
+    mode === 'plan' ? palette.warning(' ●') :
+    mode === 'autonomous' ? palette.info(' ◐') :
+    mode === 'bypassPermissions' ? palette.bypass(' ⚡') :
     '';
   return base + marker + palette.dim('  › ');
 }

--- a/src/cli/commands/interactive/repl-loop-shared.ts
+++ b/src/cli/commands/interactive/repl-loop-shared.ts
@@ -59,18 +59,22 @@ export interface TurnState {
 export function buildPrompt(mode: PermissionMode): string {
   // The model name AND the worded mode chip (`○ default`, `● plan`, `◐ AFK`,
   // `⚡ bypass`) live only in the persistent status line (status-line.ts) —
-  // the caret carries just the brand + a glyph-only echo of the non-default
-  // permission mode. The glyph stays here (rather than moving entirely to
+  // the caret carries just the brand + a compact echo of the non-default
+  // permission mode. That echo stays here (rather than moving entirely to
   // the status line) because the status row is carved out of the scroll
   // region (see status-line.ts's writeScrollRegion) and never enters
   // scrollback or piped logs: the prompt is the ONLY mode signal that
-  // survives into the linear transcript. Default mode adds no glyph — its
-  // absence is itself the "contained" signal, mirrored at the caret.
+  // survives into the linear transcript. Default mode adds no marker — its
+  // absence is itself the "contained" signal, mirrored at the caret. Plan and
+  // AFK stay glyph-only, but bypass ALSO keeps a short ASCII tag (`bp`): it is
+  // the security-sensitive mode, and an ASCII token is what lets a post-hoc
+  // `grep` of a piped transcript locate the windows where permissions were off
+  // (a bare glyph is not reliably searchable).
   const base = palette.brand('afk');
   const marker =
     mode === 'plan' ? palette.warning(' ●') :
     mode === 'autonomous' ? palette.info(' ◐') :
-    mode === 'bypassPermissions' ? palette.bypass(' ⚡') :
+    mode === 'bypassPermissions' ? palette.bypass(' ⚡bp') :
     '';
   return base + marker + palette.dim('  › ');
 }

--- a/src/cli/commands/interactive/repl-loop-shared.ts
+++ b/src/cli/commands/interactive/repl-loop-shared.ts
@@ -69,7 +69,9 @@ export function buildPrompt(mode: PermissionMode): string {
   // AFK stay glyph-only, but bypass ALSO keeps a short ASCII tag (`bp`): it is
   // the security-sensitive mode, and an ASCII token is what lets a post-hoc
   // `grep` of a piped transcript locate the windows where permissions were off
-  // (a bare glyph is not reliably searchable).
+  // (a bare glyph is not reliably searchable). A post-hoc transcript scan
+  // should grep the COMPOUND token `⚡bp` (not a bare `bp`), because bare `bp`
+  // also matches unrelated substrings like "subprocess".
   const base = palette.brand('afk');
   const marker =
     mode === 'plan' ? palette.warning(' ●') :

--- a/src/cli/status-line.test.ts
+++ b/src/cli/status-line.test.ts
@@ -1019,4 +1019,50 @@ describe('StatusLine cwd/branch worktree dedupe', () => {
     expect(out).toContain('⎇ feat/x');
     status.stop();
   });
+
+  it('does NOT merge on a name coincidence outside .afk-worktrees (positive worktree signal required)', () => {
+    // cwd basename `redesign` equals the branch, but the parent dir is `/tmp`,
+    // not `.afk-worktrees` — this is a plain checkout, not a managed worktree.
+    // The cwd ("where am I?") must NOT be suppressed on a name coincidence
+    // alone; a positive worktree signal (parent dir) is required to dedupe.
+    stream.columns = 100;
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', cwd: '/tmp/redesign', branch: 'redesign' });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    // Both the cwd and the branch segment render, so the coincident identity
+    // appears twice — it was NOT collapsed into one merged segment (contrast
+    // the afk-worktree dedupe cases, where the shared slug renders exactly once).
+    expect(out).toContain('⎇ redesign');
+    expect(out.indexOf('redesign')).not.toBe(out.lastIndexOf('redesign'));
+    status.stop();
+  });
+
+  it('does NOT merge when the shared identity exceeds the 30-col cap — keeps cwd as a second signal', () => {
+    // A genuine managed-worktree path (parent IS .afk-worktrees) whose identity
+    // is >30 cols. Merging would truncate the branch to 30 cols and drop the
+    // cwd, leaving an ambiguous truncated string as the SOLE location signal —
+    // strictly worse than the un-deduped line. So dedupe falls back and keeps
+    // the cwd leaf as a second signal. Wide terminal so the cwd leaf (which
+    // formatCwd always preserves) isn't itself right-edge truncated.
+    stream.columns = 200;
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({
+      model: 'sonnet',
+      cwd: '/Users/x/proj/.afk-worktrees/afk-20260705-142358-verylongsuffix-xy',
+      branch: 'afk/20260705-142358-verylongsuffix-xy',
+    });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    // The cwd leaf (dash-form) is preserved — under the merge path it would be
+    // hidden entirely, so its presence proves the >30-col fallback fired.
+    expect(out).toContain('afk-20260705-142358-verylongsuffix-xy');
+    // The branch segment still renders…
+    expect(out).toContain('⎇');
+    // …but capped at 30 cols, so the full slash-form branch does not appear.
+    expect(out).not.toContain('afk/20260705-142358-verylongsuffix-xy');
+    status.stop();
+  });
 });

--- a/src/cli/status-line.test.ts
+++ b/src/cli/status-line.test.ts
@@ -945,3 +945,78 @@ describe('StatusLine narrow-terminal priority drop', () => {
     status.stop();
   });
 });
+
+describe('StatusLine cwd/branch worktree dedupe', () => {
+  let stream: MockStream;
+
+  beforeEach(() => {
+    stream = mockStream({ isTTY: true, rows: 24 });
+  });
+
+  it('renders one merged ⎇ segment when branch matches the cwd basename (afk worktree pattern)', () => {
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({
+      model: 'sonnet',
+      cwd: '/Users/x/proj/.afk-worktrees/afk-20260705-142358-47b3ec',
+      branch: 'afk/20260705-142358-47b3ec',
+    });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    // The branch spelling appears (once, via the merged ⎇ segment)…
+    expect(out).toContain('⎇ afk/20260705-142358-47b3ec');
+    // …and the cwd spelling (slash → dash) does not: the cwd part was omitted.
+    expect(out).not.toContain('afk-20260705-142358-47b3ec');
+    // The shared slug renders exactly once across the whole line.
+    const slug = '20260705-142358-47b3ec';
+    expect(out.indexOf(slug)).toBe(out.lastIndexOf(slug));
+    status.stop();
+  });
+
+  it('keeps the merged segment on a narrow terminal (promoted to never-drop)', () => {
+    stream.columns = 32;
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({
+      model: 'sonnet',
+      cwd: '/Users/x/proj/.afk-worktrees/afk-20260705-142358-47b3ec',
+      branch: 'afk/20260705-142358-47b3ec',
+      cost: 0.05,
+      tokens: 1200,
+    });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    // Droppables shed first; the merged location segment survives because it
+    // is never-drop (contrast: the plain droppable branch is shed at this
+    // width in the 'drops the branch before the model' test above).
+    expect(out).toContain('afk/20260705-142358-47b3ec');
+    expect(out).not.toContain('tok');
+    status.stop();
+  });
+
+  it('preserves the #PR suffix inside the merged segment', () => {
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({
+      model: 'sonnet',
+      cwd: '/Users/x/proj/.afk-worktrees/afk-20260705-142358-47b3ec',
+      branch: 'afk/20260705-142358-47b3ec',
+      pr: 7,
+    });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('⎇ afk/20260705-142358-47b3ec #7');
+    status.stop();
+  });
+
+  it('renders cwd and branch separately when they do not match', () => {
+    const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
+    status.start();
+    stream.writes.length = 0;
+    status.repaint({ model: 'sonnet', cwd: '/tmp/proj', branch: 'feat/x' });
+    const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
+    expect(out).toContain('proj');
+    expect(out).toContain('⎇ feat/x');
+    status.stop();
+  });
+});

--- a/src/cli/status-line.test.ts
+++ b/src/cli/status-line.test.ts
@@ -973,7 +973,13 @@ describe('StatusLine cwd/branch worktree dedupe', () => {
     status.stop();
   });
 
-  it('keeps the merged segment on a narrow terminal (promoted to never-drop)', () => {
+  it('sheds the merged location segment before truncating the model on a narrow terminal', () => {
+    // Regression guard for the dedupe model-truncation bug: the merged segment
+    // is drop-last among droppables (droppablePriority 1), NOT never-drop. If
+    // it were never-drop it would stack with the never-drop model, blow maxW at
+    // this width, and the final blind truncation would shear the model 'sonnet'
+    // off the right edge — violating formatLine's "never drop: model" invariant.
+    // So at this pathological width the location sheds and the MODEL survives.
     stream.columns = 32;
     const status = new StatusLine({ stream: stream as unknown as NodeJS.WriteStream, throttleMs: 0 });
     status.start();
@@ -986,10 +992,13 @@ describe('StatusLine cwd/branch worktree dedupe', () => {
       tokens: 1200,
     });
     const out = lastJoined(stream).replace(BROAD_ANSI_RE, '');
-    // Droppables shed first; the merged location segment survives because it
-    // is never-drop (contrast: the plain droppable branch is shed at this
-    // width in the 'drops the branch before the model' test above).
-    expect(out).toContain('afk/20260705-142358-47b3ec');
+    // The model — the never-drop identity — is preserved…
+    expect(out).toContain('sonnet');
+    // …at this width the merged location segment had to shed to make room, so
+    // the full worktree identity does not survive (it drops, like the plain
+    // branch does in the else-branch at the same width).
+    expect(out).not.toContain('afk/20260705-142358-47b3ec');
+    // Lowest-priority droppables (tokens) still shed first.
     expect(out).not.toContain('tok');
     status.stop();
   });

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -12,6 +12,7 @@
  *   status.stop();   // before exit
  */
 
+import { basename } from 'node:path';
 import type { PermissionMode } from '../agent/types/sdk-types.js';
 import { truncateDisplayWidth, displayWidth } from './display.js';
 import { palette } from './palette.js';
@@ -351,13 +352,15 @@ export class StatusLine {
   }
 
   private formatLine(f: StatusLineFields): string {
-    // Invariant: parts are built in semantic order (cwd, branch, model, plan,
+    // Invariant: parts are built in semantic order (cwd/branch, model, plan,
     // context, cost, tokens), tagged with droppability priority so narrow
     // terminals can shed lower-priority fields before resorting to right-edge
     // truncation that arbitrarily loses model info. Drop order (drop-first →
     // drop-last): tokens → cost → context bar → branch. The branch drops LAST
     // among droppables because it is identity ("which branch am I on?"), like
-    // cwd. Never drop: cwd, model, plan.
+    // cwd. Never drop: cwd, model, plan. Exception: when cwd and branch are
+    // deduped into one merged segment (see worktreeDedupe below), that merged
+    // segment is ALSO never-drop — it's the sole surviving location signal.
     interface Part {
       text: string;
       droppablePriority?: number; // undefined = never drop, higher = drop first
@@ -366,23 +369,50 @@ export class StatusLine {
     let parts: Part[] = [];
     const maxW = Math.max(4, (this.stream.columns ?? 80) - 2);
 
-    // Cwd leads the line so it survives right-edge truncation. Cap its share
-    // of the budget at ~40% so a deep path can't shove the model/cost/context
-    // pieces off the right edge before the truncator ever sees them.
-    if (f.cwd) {
-      const cwdBudget = Math.max(8, Math.floor(maxW * 0.4));
-      const formatted = formatCwd(f.cwd, { maxWidth: cwdBudget });
-      if (formatted) parts.push({ text: palette.dim(formatted) }); // never drop
-    }
+    // afk-worktree cwd/branch dedupe: `.afk-worktrees/<slug>` directories are
+    // named by replacing `/` with `-` in the branch that seeded them (see
+    // createWorktreeAt, commands/interactive/worktree.ts), so for that
+    // pattern cwd and branch carry the SAME identity string twice — e.g. dir
+    // `afk-20260705-142358-47b3ec` vs branch `afk/20260705-142358-47b3ec`.
+    // Comparison runs on EVERY repaint (uncached, not memoized): cwd is fixed
+    // per-session but the branch comes from GitStatusSampler, an async
+    // sampler whose cached value can change mid-session (e.g. a manual
+    // checkout inside the worktree), so a cached compare could go stale.
+    // Uses the RAW cwd (f.cwd is the unformatted session cwd — formatCwd()
+    // only shortens it below, for display), not the tildified/collapsed
+    // formatCwd() output, so display shortening never breaks the match.
+    const worktreeDedupe =
+      f.cwd !== undefined &&
+      f.branch !== undefined &&
+      f.branch.replaceAll('/', '-') === basename(f.cwd);
 
-    // Git branch (+ open PR) sits next to the cwd — both answer "where am I?".
-    // The branch name is capped at 30 cols so a long branch can't dominate the
-    // line; the whole segment is droppable (lowest priority ⇒ dropped last).
-    if (f.branch) {
-      const branchText = truncateDisplayWidth(f.branch, 30);
-      let gitText = `${palette.dim('⎇')} ${palette.fileRef(branchText)}`;
+    if (worktreeDedupe) {
+      // Matched: cwd is pure duplication of the branch identity, so it's
+      // omitted entirely and the branch segment (+ PR suffix) alone carries
+      // "where am I?" — promoted to never-drop since nothing else says so.
+      const branchText = truncateDisplayWidth(f.branch!, 30);
+      let gitText = `${palette.dim('⎇')} ${palette.dim(branchText)}`;
       if (f.pr !== undefined) gitText += ` ${palette.meta(`#${f.pr}`)}`;
-      parts.push({ text: gitText, droppablePriority: 1 }); // drop last among droppables
+      parts.push({ text: gitText }); // never drop
+    } else {
+      // Cwd leads the line so it survives right-edge truncation. Cap its share
+      // of the budget at ~40% so a deep path can't shove the model/cost/context
+      // pieces off the right edge before the truncator ever sees them.
+      if (f.cwd) {
+        const cwdBudget = Math.max(8, Math.floor(maxW * 0.4));
+        const formatted = formatCwd(f.cwd, { maxWidth: cwdBudget });
+        if (formatted) parts.push({ text: palette.dim(formatted) }); // never drop
+      }
+
+      // Git branch (+ open PR) sits next to the cwd — both answer "where am I?".
+      // The branch name is capped at 30 cols so a long branch can't dominate the
+      // line; the whole segment is droppable (lowest priority ⇒ dropped last).
+      if (f.branch) {
+        const branchText = truncateDisplayWidth(f.branch, 30);
+        let gitText = `${palette.dim('⎇')} ${palette.dim(branchText)}`;
+        if (f.pr !== undefined) gitText += ` ${palette.meta(`#${f.pr}`)}`;
+        parts.push({ text: gitText, droppablePriority: 1 }); // drop last among droppables
+      }
     }
 
     // Trusted-skill in-flight indicator no longer renders on the status line;

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -12,7 +12,7 @@
  *   status.stop();   // before exit
  */
 
-import { basename } from 'node:path';
+import { basename, dirname } from 'node:path';
 import type { PermissionMode } from '../agent/types/sdk-types.js';
 import { truncateDisplayWidth, displayWidth } from './display.js';
 import { palette } from './palette.js';
@@ -369,11 +369,25 @@ export class StatusLine {
     let parts: Part[] = [];
     const maxW = Math.max(4, (this.stream.columns ?? 80) - 2);
 
-    // afk-worktree cwd/branch dedupe: `.afk-worktrees/<slug>` directories are
-    // named by replacing `/` with `-` in the branch that seeded them (see
-    // createWorktreeAt, commands/interactive/worktree.ts), so for that
-    // pattern cwd and branch carry the SAME identity string twice — e.g. dir
-    // `afk-20260705-142358-47b3ec` vs branch `afk/20260705-142358-47b3ec`.
+    // Invariant: afk-worktree cwd/branch dedupe. `.afk-worktrees/<slug>`
+    // directories are named by replacing `/` with `-` in the branch that
+    // seeded them (see createWorktreeAt, commands/interactive/worktree.ts),
+    // so for that pattern cwd and branch carry the SAME identity string
+    // twice — e.g. dir `afk-20260705-142358-47b3ec` vs branch
+    // `afk/20260705-142358-47b3ec`. Three conditions must ALL hold before the
+    // cwd is suppressed:
+    //   1. the cwd's PARENT directory is literally `.afk-worktrees` — a
+    //      positive worktree signal. Without it, a plain checkout whose
+    //      basename merely coincides with its branch (cwd `/repos/feature-foo`
+    //      on branch `feature/foo`) would have its repository path hidden even
+    //      though no worktree is involved.
+    //   2. the slash-normalized branch equals the cwd basename (the identity
+    //      match itself).
+    //   3. the branch fits the 30-col cap uncut. When it would truncate,
+    //      merging would leave a truncated branch as the SOLE location signal
+    //      (cwd is gone), which is strictly worse than the un-deduped line —
+    //      so we fall through to the else branch and keep cwd as a second
+    //      signal.
     // Comparison runs on EVERY repaint (uncached, not memoized): cwd is fixed
     // per-session but the branch comes from GitStatusSampler, an async
     // sampler whose cached value can change mid-session (e.g. a manual
@@ -384,7 +398,9 @@ export class StatusLine {
     const worktreeDedupe =
       f.cwd !== undefined &&
       f.branch !== undefined &&
-      f.branch.replaceAll('/', '-') === basename(f.cwd);
+      basename(dirname(f.cwd)) === '.afk-worktrees' &&
+      f.branch.replaceAll('/', '-') === basename(f.cwd) &&
+      displayWidth(f.branch) <= 30;
 
     if (worktreeDedupe) {
       // Matched: cwd is pure duplication of the branch identity, so it's

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -358,9 +358,12 @@ export class StatusLine {
     // truncation that arbitrarily loses model info. Drop order (drop-first →
     // drop-last): tokens → cost → context bar → branch. The branch drops LAST
     // among droppables because it is identity ("which branch am I on?"), like
-    // cwd. Never drop: cwd, model, plan. Exception: when cwd and branch are
-    // deduped into one merged segment (see worktreeDedupe below), that merged
-    // segment is ALSO never-drop — it's the sole surviving location signal.
+    // cwd. Never drop: cwd, model, plan. When cwd and branch are deduped into
+    // one merged segment (see worktreeDedupe below), that segment inherits the
+    // branch's droppablePriority 1 (drop-last among droppables), NOT never-drop:
+    // a never-drop location there would stack with the never-drop model and
+    // force right-edge truncation to lose model info on a narrow terminal, so
+    // the location sheds before the model is ever truncated.
     interface Part {
       text: string;
       droppablePriority?: number; // undefined = never drop, higher = drop first
@@ -405,11 +408,17 @@ export class StatusLine {
     if (worktreeDedupe) {
       // Matched: cwd is pure duplication of the branch identity, so it's
       // omitted entirely and the branch segment (+ PR suffix) alone carries
-      // "where am I?" — promoted to never-drop since nothing else says so.
+      // "where am I?". It takes droppablePriority 1 — drop-LAST among
+      // droppables, identical to the plain branch in the else-branch — and is
+      // deliberately NOT never-drop: the model is the never-drop identity the
+      // top-of-method invariant protects, and a never-drop location here would
+      // stack with the never-drop model and blow maxW on a narrow terminal,
+      // forcing the final blind truncation to shear the model off the right
+      // edge. Drop-last means the location sheds before the model is ever cut.
       const branchText = truncateDisplayWidth(f.branch!, 30);
       let gitText = `${palette.dim('⎇')} ${palette.dim(branchText)}`;
       if (f.pr !== undefined) gitText += ` ${palette.meta(`#${f.pr}`)}`;
-      parts.push({ text: gitText }); // never drop
+      parts.push({ text: gitText, droppablePriority: 1 }); // drop last among droppables — matches the plain branch; keeps the model never-drop
     } else {
       // Cwd leads the line so it survives right-edge truncation. Cap its share
       // of the budget at ~40% so a deep path can't shove the model/cost/context

--- a/src/cli/terminal-compositor.footer-ghost.test.ts
+++ b/src/cli/terminal-compositor.footer-ghost.test.ts
@@ -120,6 +120,14 @@ describe('footer-ghost regression (real StatusLine + LoopStageBar, extraRows=1)'
     const { statusLine, loopStageBar } = wireFooter(stdout);
     expect(statusLine.getExtraRows()).toBe(1); // sanity: rail reserved its row
 
+    // Drive the bar to a mid-turn stage so the FULL 5-cell rail is the
+    // expected row content — the idle 'observing' stage now collapses to a
+    // single `· idle` cell (formatStageRail), which would defeat the
+    // 'observe' + 'update' rail-finder probes below. redraw() (the self-heal
+    // under test) re-asserts the stored currentStage, so the probes see the
+    // same full rail after the scroll.
+    loopStageBar.repaint('acting');
+
     const c = new TerminalCompositor({
       stdout,
       stdin,


### PR DESCRIPTION
## Problem

Three stacked lines of chrome around the REPL input read busy and redundant:

- the `⚡ bypass` chip renders **twice** (prompt line + status line), bold pink both times
- cwd and git branch are near-duplicate strings for afk worktrees (`afk-20260705-…` dir vs `afk/20260705-…` branch) — ~80 columns encoding one fact
- the 5-cell loop rail paints **permanently**, even when no turn is running — persistent chrome for transient activity

## Before / after (idle)

```
before:
afk ⚡ bypass  ›
  ◇ observe · ◇ model · ◇ choose · ◆ act · ◇ update
~/…/afk-20260705-142358-47b3ec · ⎇ afk/20260705-142358-47b3ec · opus_1m · ⚡ bypass

after:
afk ⚡  ›
  · idle
⎇ afk/20260705-142358-47b3ec · opus_1m · ⚡ bypass
```

During an active turn the full 5-cell rail renders exactly as before.

## Changes

- **Prompt** (`repl-loop-shared.ts`): mode markers become glyph-only — ` ●` plan, ` ◐` AFK, ` ⚡` bypass, nothing for default. The worded chip lives on the status line only.
- **Loop rail** (`loop-stage.ts`): `formatStageRail` collapses the idle/reset `observing` stage to a single dim `· idle` cell. Content-only change — no row-reservation, paint-mechanics, or state-machine changes; `extraRows` geometry untouched.
- **Status line** (`status-line.ts`): when `branch.replaceAll('/','-') === basename(cwd)` (the afk-worktree naming scheme), the cwd part is omitted and the `⎇ branch` segment renders alone, **promoted to never-drop** as the sole surviving location signal. The compare runs uncached on every repaint (raw cwd, not the display-shortened form) so it cannot go stale against the async git sampler.
- **Palette mute** (`status-line.ts` only): branch text teal→dim; `palette.fileRef` untouched for its other consumers. The bypass chip is now the single saturated accent.

## Safety rationale

The status row is painted in a row carved **outside the scroll region** (`writeScrollRegion`) — it never enters scrollback or piped logs. The prompt is therefore the only permission-mode signal that survives into the linear transcript, which matters for an away-from-keyboard operator auditing after the fact — and `bypassPermissions` is the new-install default. Hence glyph-only at the caret rather than full removal. The deduped location segment is promoted to never-drop so narrow terminals cannot shed the only "where am I" indicator.

## Verification

- `pnpm lint` (strict tsc) green
- Full `pnpm test`: **10901 passed | 14 skipped, 0 failing tests**. The 4 `chat.*.test.ts` file-level collection errors (`builtinToolSchemas` mock) fail identically on clean `main` at the base commit — pre-existing, unrelated to this diff.
- Tests updated: `loop-stage.test.ts` (idle collapse + full-rail-per-stage + exactly-one-active-diamond assertions), `terminal-compositor.footer-ghost.test.ts` (drives the bar to a mid-turn stage so the rail-finder probes the full rail; the self-heal `redraw()` re-asserts stored `currentStage`)
- Tests added: `repl-loop-shared.test.ts` (buildPrompt glyphs, all 4 modes), `status-line.test.ts` (dedupe: merged segment, never-drop survival at narrow width, `#PR` suffix, non-matching pair unchanged)
- Compositor geometry tests pass untouched (only footer-ghost's content probe needed the stage drive; no geometry assertions changed)

## Design provenance

Options were researched against Claude Code / Codex CLI / Gemini CLI / opencode / aider / Crush chrome conventions, then adversarially reviewed (3-lens devils-advocate critique); this implements the revised **A-prime hybrid** — the original "move the mode chip fully to the status line" variant was rejected for erasing the scrollback-persistent safety signal.
