### PR TITLE
feat(subagent): uncap turn/tool-use budgets by default; graceful wind-down on cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Changed
+- `agent` tool subagents are now uncapped by default and settable per dispatch: `max_turns` defaults to unlimited (was default 10, hard-clamped to `[1,50]`) — pass a positive integer to cap. Added a `max_tool_use_iterations` param and a matching `maxToolUseIterations` agent-frontmatter field (both default unlimited on the agent-tool path). Skill/compose internal forks keep the 50-round anti-hang default; openai-compatible models retain a provider-internal 50-round cap regardless.
+
+### Fixed
+- Hitting the tool-use iteration cap no longer ends a turn silently (which read as a hang / empty subagent result). The anthropic-direct loop now runs one final tools-stripped "wind-down" round so the model synthesizes a real answer from what it gathered, and the closure classifier maps the capped stop reason to `iteration_cap` instead of silently sealing it as a clean `model_end_turn`.
+
 ## [5.23.2] - 2026-07-05
 
 ### Fixed

--- a/src/agent/agents/parser.test.ts
+++ b/src/agent/agents/parser.test.ts
@@ -98,6 +98,36 @@ prompt`;
     expect(parsed?.bashReadOnly).toBe(true);
   });
 
+  it('parses maxToolUseIterations frontmatter (camelCase + kebab alias)', () => {
+    const camel = parseAgentMarkdown(`---
+name: capped
+description: capped rounds
+maxToolUseIterations: 12
+---
+prompt`);
+    expect(camel?.definition.maxToolUseIterations).toBe(12);
+
+    const kebab = parseAgentMarkdown(`---
+name: capped2
+description: capped rounds
+max-tool-use-iterations: 8
+---
+prompt`);
+    expect(kebab?.definition.maxToolUseIterations).toBe(8);
+  });
+
+  it('ignores non-positive maxToolUseIterations with a warning', () => {
+    const warn = vi.fn();
+    const parsed = parseAgentMarkdown(`---
+name: bad
+description: bad cap
+maxToolUseIterations: 0
+---
+prompt`, warn);
+    expect(parsed?.definition.maxToolUseIterations).toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+
   it('records recognized long-tail fields as ignoredKeys and warns on unknown keys', () => {
     const warn = vi.fn();
     const doc = `---

--- a/src/agent/agents/parser.ts
+++ b/src/agent/agents/parser.ts
@@ -120,6 +120,7 @@ export function parseAgentMarkdown(
   let description: string | undefined;
   let model: string | undefined;
   let maxTurns: number | undefined;
+  let maxToolUseIterations: number | undefined;
   let bashReadOnly: boolean | undefined;
   let tools: string[] | undefined;
   let disallowedTools: string[] | undefined;
@@ -173,6 +174,13 @@ export function parseAgentMarkdown(
         else warn(`invalid ${key} value ${JSON.stringify(inline.trim())} — ignored`);
         break;
       }
+      case 'maxtooluseiterations':
+      case 'max-tool-use-iterations': {
+        const parsed = Number.parseInt(stripQuotes(inline), 10);
+        if (Number.isFinite(parsed) && parsed > 0) maxToolUseIterations = parsed;
+        else warn(`invalid ${key} value ${JSON.stringify(inline.trim())} — ignored`);
+        break;
+      }
       case 'bash': {
         // AFK extension: `bash: read-only` gates the child's shell to
         // non-mutating commands (classifyBashCommand) when bash is granted.
@@ -213,6 +221,7 @@ export function parseAgentMarkdown(
     ...(disallowedTools !== undefined && disallowedTools.length > 0 ? { disallowedTools } : {}),
     ...(model !== undefined ? { model } : {}),
     ...(maxTurns !== undefined ? { maxTurns } : {}),
+    ...(maxToolUseIterations !== undefined ? { maxToolUseIterations } : {}),
   };
 
   return {

--- a/src/agent/providers/anthropic-direct.test.ts
+++ b/src/agent/providers/anthropic-direct.test.ts
@@ -686,13 +686,15 @@ describe('AnthropicDirectProvider', () => {
   it('caps the tool-use loop at config.maxToolUseIterations (config → provider → loop)', async () => {
     // End-to-end plumbing guard: AgentConfig.maxToolUseIterations must thread
     // through AnthropicDirectProvider.query() → AnthropicDirectQueryOptions →
-    // the constructor → runInput → the loop's `maxIterations`. The mock model
-    // emits tool_use on every round, so the ONLY thing that can terminate the
-    // turn is the iteration cap — this is the guard a forked subagent relies on
+    // the constructor → runInput → the loop's `maxIterations`. After the cap the
+    // loop runs one tools-stripped wind-down round (rounds 1-2 request tools;
+    // round 3 answers in text), so the turn ends with a real final message AND
+    // stopReason 'tool_use_loop_capped' — the guard a forked subagent relies on
     // to avoid hanging its parent (see SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS).
     let callIdx = 0;
     messagesCreateMock.mockImplementation(() => {
       callIdx += 1;
+      if (callIdx >= 3) return fromArray(makeTextStream('Summary of findings.'));
       return fromArray(
         makeToolUseStream(`toolu_${callIdx}`, 'get_weather', '{"city":"SF"}'),
       );
@@ -715,8 +717,8 @@ describe('AnthropicDirectProvider', () => {
     });
     const events = await collect(query);
 
-    // Stopped after exactly 2 tool-use rounds, not left to spin unbounded.
-    expect(messagesCreateMock).toHaveBeenCalledTimes(2);
+    // 2 tool-use rounds + 1 tools-stripped wind-down round, not left to spin.
+    expect(messagesCreateMock).toHaveBeenCalledTimes(3);
     const completed = events.find((e) => e.type === 'turn.completed');
     expect(completed).toBeDefined();
     if (completed?.type === 'turn.completed') {

--- a/src/agent/providers/anthropic-direct/loop.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.test.ts
@@ -342,14 +342,25 @@ describe('loop.ts runTurn', () => {
     expect(completed).toBeUndefined();
   });
 
-  // covers lines 324-331: maxToolUseIterations cap
-  it('caps tool-use iterations when maxToolUseIterations is set', async () => {
+  // covers the tool-use cap + wind-down: after `maxToolUseIterations` tool
+  // rounds the loop runs ONE tools-stripped round so the model can synthesize a
+  // final answer, then completes with stopReason 'tool_use_loop_capped' — no
+  // silent mid-round stop.
+  it('caps tool-use iterations, then runs a tools-stripped wind-down round', async () => {
     let callIdx = 0;
-    const client = makeClient(() => {
-      callIdx += 1;
-      // Always return tool_use — would loop forever without the cap
-      return fromArray(makeToolUseStream(`toolu_${callIdx}`, 'read_file', '{}'));
-    });
+    const createCalls: Array<{ tools?: unknown }> = [];
+    const client = {
+      messages: {
+        create: vi.fn((params: { tools?: unknown }) => {
+          createCalls.push(params);
+          callIdx += 1;
+          // Rounds 1-2 keep requesting tools; the 3rd call is the wind-down
+          // round (tools stripped) where a real model answers in text.
+          if (callIdx >= 3) return fromArray(makeTextStream('Final answer from gathered context.'));
+          return fromArray(makeToolUseStream(`toolu_${callIdx}`, 'read_file', '{}'));
+        }),
+      },
+    } as unknown as AnthropicClientLike;
     const dispatcher = makeDispatcher(() => Promise.resolve({ content: 'ok' }));
     const messages: MessageParam[] = [{ role: 'user', content: 'do stuff' }];
     const abortController = new AbortController();
@@ -366,15 +377,28 @@ describe('loop.ts runTurn', () => {
         headers: {},
         signal: abortController.signal,
         ctx,
-        maxToolUseIterations: 2, // Cap at 2 iterations
+        maxToolUseIterations: 2, // Cap at 2 tool rounds
       }),
     );
 
-    // Should have exactly 2 tool-use rounds
+    // Exactly 2 tool-use rounds emit progress; the wind-down round does not.
     const progressEvents = events.filter((e) => e.type === 'progress');
     expect(progressEvents.length).toBe(2);
 
-    // Final turn.completed should have stopReason='tool_use_loop_capped'
+    // A 3rd model call happened (the wind-down) and it was sent WITHOUT tools,
+    // while the first round WAS sent with tools.
+    expect(callIdx).toBe(3);
+    expect((createCalls[0] as { tools?: unknown[] }).tools?.length ?? 0).toBeGreaterThan(0);
+    expect((createCalls[2] as { tools?: unknown }).tools).toBeUndefined();
+
+    // The model's wind-down answer is surfaced as an assistant.message ...
+    const assistantMsg = events.find((e) => e.type === 'assistant.message');
+    expect(assistantMsg).toBeDefined();
+    if (assistantMsg?.type === 'assistant.message') {
+      expect(assistantMsg.text).toContain('Final answer');
+    }
+
+    // ... and the turn still reports it was cut short by the cap.
     const completed = events.find((e) => e.type === 'turn.completed');
     expect(completed).toBeDefined();
     if (completed?.type === 'turn.completed') {
@@ -855,11 +879,12 @@ describe('loop.ts runTurn', () => {
   // (`{ ...accumulatedUsage, stopReason: 'tool_use_loop_capped' }`) — easy
   // to refactor and accidentally drop durationMs. Pin both fields together.
   it('emits turn.completed with usage.durationMs even when iteration cap hits', async () => {
-    // Build a stream where the model keeps emitting tool_use → looped
-    // dispatch → another tool_use, exhausting maxToolUseIterations=1.
+    // maxToolUseIterations=1: round 1 is tool_use (cap hit → wind-down); the
+    // 2nd call is the tools-stripped wind-down round that answers in text.
     let callCount = 0;
     const client = makeClient(() => {
       callCount += 1;
+      if (callCount >= 2) return fromArray(makeTextStream('Wind-down summary.'));
       return fromArray(makeToolUseStream(`tu_${callCount}`, 'first_tool', '{}'));
     });
     const dispatcher = makeDispatcher(() => Promise.resolve({ content: 'tool output' }));

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -166,6 +166,13 @@ export async function* runTurn(
     input.maxToolUseIterations ?? DEFAULT_MAX_TOOL_USE_ITERATIONS;
   let accumulatedUsage: ProviderUsage = { stopReason: null };
   let iterations = 0;
+  // Set once the tool-use iteration cap is reached. The loop then runs ONE
+  // final "wind-down" round with tools stripped (see the params build and the
+  // cap-exit block below) so the model produces a real answer from what it
+  // gathered instead of being cut off mid-round — a silent stop with no final
+  // message is indistinguishable from a hang (same failure mode the `refusal`
+  // branch guards against).
+  let capReached = false;
   // Mid-stream overload retry budget. Spent as a 529/overloaded_error is
   // observed *during* stream consumption (where createWithRetry can't reach),
   // and reset to 0 after every clean round so each tool-use round gets its own
@@ -222,7 +229,10 @@ export async function* runTurn(
       messages: messagesForRequest,
       stream: true,
       ...(input.system !== null ? { system: input.system } : {}),
-      ...(input.tools !== null && input.tools.length > 0
+      // Wind-down round (capReached): omit tools so the model MUST answer in
+      // text — with no tools advertised it cannot emit another tool_use — which
+      // turns a capped turn into a final summary rather than a silent stop.
+      ...(input.tools !== null && input.tools.length > 0 && !capReached
         ? { tools: input.tools.map(toWireTool) }
         : {}),
       ...(input.thinking !== undefined ? { thinking: input.thinking } : {}),
@@ -496,7 +506,15 @@ export async function* runTurn(
       }
       yield {
         type: 'turn.completed',
-        usage: withTurnDuration(accumulatedUsage),
+        // On the wind-down round (capReached) the model ends naturally with
+        // `end_turn`, but the turn as a whole WAS cut short by the tool-use cap
+        // — preserve that signal for closure classification + telemetry while
+        // still delivering the model's synthesized final message above.
+        usage: withTurnDuration(
+          capReached
+            ? { ...accumulatedUsage, stopReason: 'tool_use_loop_capped' }
+            : accumulatedUsage,
+        ),
         sessionId: input.ctx.sessionId,
       };
       return;
@@ -726,13 +744,37 @@ export async function* runTurn(
       },
       sessionId: input.ctx.sessionId,
     };
-    if (maxIterations > 0 && iterations >= maxIterations) {
+    if (capReached) {
+      // The wind-down round (tools stripped) still came back as `tool_use` —
+      // only reachable if the model emits a tool call against an empty toolset.
+      // Honor the cap with a hard stop rather than looping unbounded.
       yield {
         type: 'turn.completed',
         usage: withTurnDuration({ ...accumulatedUsage, stopReason: 'tool_use_loop_capped' }),
         sessionId: input.ctx.sessionId,
       };
       return;
+    }
+    if (maxIterations > 0 && iterations >= maxIterations) {
+      // Cap reached. Instead of cutting the turn off HERE — which ends it with
+      // no final assistant message and reads as a silent hang — run ONE more
+      // round with tools stripped (params build above) so the model can
+      // synthesize a final answer from what it gathered. Append a brief note to
+      // the tool_result turn just pushed so the model knows why its tools are
+      // gone. `capReached` guarantees this fires at most once; the guard above
+      // hard-stops if the wind-down round pathologically emits another tool_use.
+      const lastMsg = input.messages[input.messages.length - 1];
+      if (lastMsg !== undefined && lastMsg.role === 'user' && Array.isArray(lastMsg.content)) {
+        lastMsg.content.push({
+          type: 'text',
+          text:
+            'You have reached your tool-use budget for this turn. Do not request ' +
+            'any more tools — give your final answer now using only the ' +
+            'information already gathered.',
+        });
+      }
+      capReached = true;
+      continue;
     }
   }
   } finally {

--- a/src/agent/session/closure-reason.test.ts
+++ b/src/agent/session/closure-reason.test.ts
@@ -43,6 +43,18 @@ describe('classifyClosureReason', () => {
     expect(classifyClosureReason({ ...base, lastStopReason: 'length' })).toBe('truncated');
   });
 
+  it('reports iteration_cap when the tool-use budget fired', () => {
+    expect(
+      classifyClosureReason({ ...base, lastStopReason: 'tool_use_loop_capped' }),
+    ).toBe('iteration_cap');
+  });
+
+  it('an abort signal outranks the iteration cap', () => {
+    expect(
+      classifyClosureReason({ ...base, abort: 'timeout', lastStopReason: 'tool_use_loop_capped' }),
+    ).toBe('timeout');
+  });
+
   it('reports max_turns_exceeded with the highest precedence', () => {
     expect(classifyClosureReason({ ...base, maxTurnsHit: true })).toBe('max_turns_exceeded');
     // The turn-cap throw surfaces as a generic error/abort — the flag must win.

--- a/src/agent/session/closure-reason.ts
+++ b/src/agent/session/closure-reason.ts
@@ -23,14 +23,15 @@
  *     yet the surface then closed the session cleanly (`dispatchReason` is
  *     `'close'`/`'reset'`, no abort signal). Without this a provider failure on
  *     an otherwise-clean close is silently sealed as `model_end_turn`.
- *  6. a truncation stop reason (`max_tokens` / `length`) on an otherwise clean
+ *  6. `lastStopReason === 'tool_use_loop_capped'` → `iteration_cap` — the
+ *     tool-use round budget fired (the subagent default, or an explicit
+ *     `max_tool_use_iterations`). The provider runs a tools-stripped wind-down
+ *     round first, so the session still carries the model's final summary; this
+ *     reason records that the turn was nonetheless cut short by the cap.
+ *  7. a truncation stop reason (`max_tokens` / `length`) on an otherwise clean
  *     close → `truncated` — the model's final turn was cut off by the
  *     output-token ceiling, previously indistinguishable from a clean end.
- *  7. otherwise → `model_end_turn`.
- *
- * `iteration_cap` is intentionally NOT produced here: nothing sets a tool-use
- * loop cap in production yet (`DEFAULT_MAX_TOOL_USE_ITERATIONS = 0`), so it is
- * wired alongside the cap itself in a later patch.
+ *  8. otherwise → `model_end_turn`.
  *
  * @module agent/session/closure-reason
  */
@@ -84,6 +85,7 @@ export function classifyClosureReason(i: ClosureReasonInputs): ClosureReason {
   if (i.dispatchReason === 'error') return 'abort';
   if (i.abort !== null) return i.abort;
   if (i.sawProviderError) return 'abort';
+  if (i.lastStopReason === 'tool_use_loop_capped') return 'iteration_cap';
   if (isTruncationStopReason(i.lastStopReason)) return 'truncated';
   return 'model_end_turn';
 }

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -353,14 +353,14 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     if (this.lastStreamedContent.length > 0) {
       return { role: 'assistant', content: this.lastStreamedContent, timestamp: new Date() };
     }
-    // Anti-hang contract (see SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS in
-    // subagent.ts): a forked child that exhausts its tool-use-iteration cap ends
-    // the turn with a `tool_use_loop_capped` done and NO assistant message. A
-    // pure tool-only runaway also streams no text, so both fallbacks above miss.
-    // Surface the cap as a terminal "capped" message instead of throwing, so
-    // `runToResult` reports a capped *partial* result (status 'succeeded')
-    // rather than an opaque subagent failure — the behavior the cap default
-    // already documents.
+    // Anti-hang fallback (see SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS in
+    // subagent.ts): a child that hits its tool-use cap normally returns a real
+    // summary — the provider runs a tools-stripped wind-down round on the cap
+    // (see loop.ts) whose text lands as `finalMessage`/`lastStreamedContent`
+    // above. This branch is the RARE fallback for when that wind-down produced
+    // no text at all: surface the cap as a terminal "capped" message instead of
+    // throwing, so `runToResult` reports a capped *partial* result (status
+    // 'succeeded') rather than an opaque subagent failure.
     if (this.lastStopReason === 'tool_use_loop_capped') {
       return {
         role: 'assistant',

--- a/src/agent/tools/schemas.test.ts
+++ b/src/agent/tools/schemas.test.ts
@@ -129,10 +129,11 @@ describe('agentTool', () => {
     expect(agentTool.input_schema.required).toEqual(['prompt']);
   });
 
-  it('has optional model, max_turns, and id_prefix parameters', () => {
+  it('has optional model, max_turns, max_tool_use_iterations, and id_prefix parameters', () => {
     expect(agentTool.input_schema.properties).toHaveProperty('prompt');
     expect(agentTool.input_schema.properties).toHaveProperty('model');
     expect(agentTool.input_schema.properties).toHaveProperty('max_turns');
+    expect(agentTool.input_schema.properties).toHaveProperty('max_tool_use_iterations');
     expect(agentTool.input_schema.properties).toHaveProperty('id_prefix');
   });
 

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -346,7 +346,23 @@ export const agentTool: AnthropicToolDef = {
       },
       max_turns: {
         type: 'number',
-        description: 'Maximum conversation turns (default 10, max 50).',
+        description:
+          'Maximum conversation turns. Default 0 = unlimited (no ceiling) — ' +
+          'omit to let the subagent run to natural completion. Set a positive ' +
+          'integer to cap turns. A named agent (agent_type) may also set its own ' +
+          'default via `maxTurns` frontmatter; an explicit value here overrides it.',
+      },
+      max_tool_use_iterations: {
+        type: 'number',
+        description:
+          "Maximum tool-use rounds within the subagent's single turn — the " +
+          'anti-hang ceiling on a tool-call loop. Default 0 = unlimited. Set a ' +
+          'positive integer to bound a runaway loop. When the cap is hit the ' +
+          'subagent gets one final tools-stripped round to summarize what it ' +
+          'gathered (no silent mid-loop stop). A named agent may set its own ' +
+          'default via `maxToolUseIterations` frontmatter (explicit value here wins). ' +
+          'Note: openai-compatible models keep a provider-internal 50-round cap ' +
+          'regardless of this value.',
       },
       id_prefix: {
         type: 'string',

--- a/src/agent/tools/subagent-executor.named-agents.test.ts
+++ b/src/agent/tools/subagent-executor.named-agents.test.ts
@@ -86,6 +86,7 @@ const INHERIT_AGENT: RegisteredAgent = {
     prompt: 'inherit prompt',
     model: 'inherit',
     maxTurns: 4,
+    maxToolUseIterations: 7,
   },
 };
 
@@ -254,6 +255,18 @@ describe('SubagentExecutor named-agent dispatch', () => {
       makeCall({ prompt: 'go', agent_type: 'inheritor', max_turns: 22 }),
     );
     expect(forkSubagent.mock.calls[0]?.[0].config.maxTurns).toBe(22);
+  });
+
+  it('maxToolUseIterations: def value applies as default; explicit call-site wins', async () => {
+    const executor = makeExecutor();
+    await executor.execute(makeCall({ prompt: 'go', agent_type: 'inheritor' }));
+    expect(forkSubagent.mock.calls[0]?.[0].config.maxToolUseIterations).toBe(7);
+
+    forkSubagent.mockClear();
+    await executor.execute(
+      makeCall({ prompt: 'go', agent_type: 'inheritor', max_tool_use_iterations: 30 }),
+    );
+    expect(forkSubagent.mock.calls[0]?.[0].config.maxToolUseIterations).toBe(30);
   });
 
   it('intersects the definition allowlist with an existing cage', async () => {

--- a/src/agent/tools/subagent-executor.test.ts
+++ b/src/agent/tools/subagent-executor.test.ts
@@ -140,33 +140,49 @@ describe('SubagentExecutor', () => {
       expect(result.content).toContain('object');
     });
 
-    it('clamps max_turns to 1-50 range', async () => {
+    it('passes max_turns through with no upper ceiling; floors ≤0 to 0 (unlimited)', async () => {
       const handle = mockHandle();
       mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
 
-      // Test clamping high
+      // No ceiling: a high explicit value passes through verbatim (was clamped
+      // to 50 before uncapped-by-default).
       await executor.execute(
         makeCall({ input: { prompt: 'test', max_turns: 100 } }),
       );
       expect(mockSubagentMgr.forkSubagent).toHaveBeenCalledWith(
         expect.objectContaining({
-          config: expect.objectContaining({ maxTurns: 50 }),
+          config: expect.objectContaining({ maxTurns: 100 }),
         }),
       );
 
-      // Test clamping low
+      // Negatives floor to 0 = unlimited (AgentSession treats falsy maxTurns as
+      // no cap), not 1.
       (mockSubagentMgr.forkSubagent as ReturnType<typeof vi.fn>).mockClear();
       await executor.execute(
         makeCall({ input: { prompt: 'test', max_turns: -5 } }),
       );
       expect(mockSubagentMgr.forkSubagent).toHaveBeenCalledWith(
         expect.objectContaining({
-          config: expect.objectContaining({ maxTurns: 1 }),
+          config: expect.objectContaining({ maxTurns: 0 }),
         }),
       );
     });
 
-    it('uses defaults for optional fields', async () => {
+    it('passes max_tool_use_iterations through with no upper ceiling', async () => {
+      const handle = mockHandle();
+      mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
+
+      await executor.execute(
+        makeCall({ input: { prompt: 'test', max_tool_use_iterations: 200 } }),
+      );
+      expect(mockSubagentMgr.forkSubagent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ maxToolUseIterations: 200 }),
+        }),
+      );
+    });
+
+    it('uses defaults for optional fields (turns + tool-use rounds unlimited)', async () => {
       const handle = mockHandle();
       mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
 
@@ -175,11 +191,14 @@ describe('SubagentExecutor', () => {
       // apiKey is now resolved by the agent-layer credential resolver
       // (resolveCredentialForModel), not forwarded verbatim from defaultConfig.
       // The mock returns 'resolved-test-credential' for Anthropic-routed models.
+      // maxTurns / maxToolUseIterations both default to 0 = unlimited on the
+      // agent-tool dispatch path (uncapped by default; opt into a cap).
       expect(mockSubagentMgr.forkSubagent).toHaveBeenCalledWith(
         expect.objectContaining({
           idPrefix: 'agent-tool',
           config: expect.objectContaining({
-            maxTurns: 10,
+            maxTurns: 0,
+            maxToolUseIterations: 0,
             model: 'sonnet',
             apiKey: 'resolved-test-credential',
             systemPrompt: 'test system prompt',

--- a/src/agent/tools/subagent/child-config.ts
+++ b/src/agent/tools/subagent/child-config.ts
@@ -165,13 +165,26 @@ export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigRe
     );
   }
 
-  // Turn budget: explicit per-call max_turns wins; otherwise a named
-  // agent's maxTurns frontmatter (clamped to the same [1, 50] envelope);
-  // otherwise the parse-time default.
+  // Turn budget: explicit per-call max_turns wins; otherwise a named agent's
+  // maxTurns frontmatter (floored to ≥1); otherwise the parse-time default
+  // (0 = unlimited). No upper ceiling — uncapped by default, opt into a cap
+  // via the call-site param or an agent definition's frontmatter.
   const effectiveMaxTurns =
     !parsed.max_turns_explicit && namedAgent?.definition.maxTurns !== undefined
-      ? Math.max(1, Math.min(50, Math.floor(namedAgent.definition.maxTurns)))
+      ? Math.max(1, Math.floor(namedAgent.definition.maxTurns))
       : parsed.max_turns;
+
+  // Tool-use-round budget: same precedence as turns (explicit call-site >
+  // named-agent frontmatter > parse default 0 = unlimited). Set explicitly on
+  // the child config so this agent-tool dispatch path does NOT fall through to
+  // SubagentManager's SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS (50) — that
+  // remains the anti-hang default for skill/compose internal forks, which do
+  // not build config here.
+  const effectiveMaxToolUseIterations =
+    !parsed.max_tool_use_iterations_explicit &&
+    namedAgent?.definition.maxToolUseIterations !== undefined
+      ? Math.max(1, Math.floor(namedAgent.definition.maxToolUseIterations))
+      : parsed.max_tool_use_iterations ?? 0;
 
   // Resolve the child's API key by its own model/provider. The resolver is
   // now available directly from the agent layer (resolveCredentialForModel),
@@ -204,6 +217,9 @@ export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigRe
     systemPrompt: namedAgent !== undefined ? namedAgent.definition.prompt : defaultConfig.systemPrompt,
     baseUrl: childIsOpenAI ? undefined : defaultConfig.baseUrl,
     maxTurns: effectiveMaxTurns,
+    // Always set (default 0 = unlimited) so forkSubagent's `?? 50` fallback is
+    // bypassed for agent-tool dispatches — see effectiveMaxToolUseIterations.
+    maxToolUseIterations: effectiveMaxToolUseIterations,
     // Awareness metadata (Phase 1, get_runtime_state):
     // Thread depth + maxDepth into the child's AgentConfig so the
     // `self` view of the child's get_runtime_state snapshot reflects

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -15,14 +15,24 @@ export type AgentExecutionMode = 'foreground' | 'background';
 export interface AgentInput {
   prompt: string;
   model?: string;
+  /** Conversation-turn cap. `0` (the default) means unlimited — no ceiling. */
   max_turns?: number;
   /**
    * True when the caller supplied `max_turns` explicitly. Distinguishes the
-   * parse-time default (10) from a deliberate value so a named agent's
-   * `maxTurns` frontmatter can act as the default without being able to
-   * override an explicit per-call budget.
+   * parse-time default (0 = unlimited) from a deliberate value so a named
+   * agent's `maxTurns` frontmatter can act as the default without being able
+   * to override an explicit per-call budget.
    */
   max_turns_explicit: boolean;
+  /**
+   * Tool-use-round cap within the child's single turn (anti-hang ceiling).
+   * `0` (the default) means unlimited on this dispatch path. A positive value
+   * caps rounds; openai-compatible models keep a provider-internal 50-round
+   * cap regardless.
+   */
+  max_tool_use_iterations?: number;
+  /** True when the caller supplied `max_tool_use_iterations` explicitly. */
+  max_tool_use_iterations_explicit: boolean;
   id_prefix?: string;
   /**
    * Named agent type to dispatch (`agent_type`, alias `subagent_type`).
@@ -82,16 +92,34 @@ export function parseAgentInput(input: unknown): AgentInput {
     model = modelValue;
   }
 
-  let max_turns = 10;
+  // Turn budget: default 0 = unlimited (matches AgentSession's falsy-maxTurns
+  // = no-cap check in assertCanSend). A positive value caps conversation
+  // turns; 0/negatives mean unlimited. No upper ceiling — the caller, or a
+  // named agent's `maxTurns` frontmatter, owns any cap it wants.
+  let max_turns = 0;
   let max_turns_explicit = false;
   const maxTurnsValue = agentInput['max_turns'];
   if (maxTurnsValue !== undefined) {
     if (typeof maxTurnsValue !== 'number') {
       throw new Error('Agent tool max_turns must be a number');
     }
-    // Clamp to [1, 50]
-    max_turns = Math.max(1, Math.min(50, Math.floor(maxTurnsValue)));
+    max_turns = Math.max(0, Math.floor(maxTurnsValue));
     max_turns_explicit = true;
+  }
+
+  // Tool-use-round budget within the single child turn (anti-hang ceiling).
+  // Default 0 = unlimited on the agent-tool path; a positive value caps
+  // rounds. openai-compatible children keep a provider-internal 50-round cap
+  // regardless of this value (see config-types.ts maxToolUseIterations).
+  let max_tool_use_iterations = 0;
+  let max_tool_use_iterations_explicit = false;
+  const maxToolIterValue = agentInput['max_tool_use_iterations'];
+  if (maxToolIterValue !== undefined) {
+    if (typeof maxToolIterValue !== 'number') {
+      throw new Error('Agent tool max_tool_use_iterations must be a number');
+    }
+    max_tool_use_iterations = Math.max(0, Math.floor(maxToolIterValue));
+    max_tool_use_iterations_explicit = true;
   }
 
   // agent_type: canonical param; `subagent_type` accepted as an alias for
@@ -172,6 +200,8 @@ export function parseAgentInput(input: unknown): AgentInput {
     model,
     max_turns,
     max_turns_explicit,
+    max_tool_use_iterations,
+    max_tool_use_iterations_explicit,
     id_prefix,
     mode,
     ...(agent_type !== undefined ? { agent_type } : {}),

--- a/src/agent/types/sdk-types.ts
+++ b/src/agent/types/sdk-types.ts
@@ -243,6 +243,14 @@ export type AgentDefinition = {
   skills?: string[];
   initialPrompt?: string;
   maxTurns?: number;
+  /**
+   * Optional per-agent cap on tool-use rounds within the child's single turn
+   * (anti-hang ceiling). Omitted / ≤0 means unlimited. Frontmatter key
+   * `maxToolUseIterations` (alias `max-tool-use-iterations`). Honored only on
+   * the `agent`-tool dispatch path (see child-config.ts); openai-compatible
+   * models retain a provider-internal 50-round cap regardless.
+   */
+  maxToolUseIterations?: number;
   background?: boolean;
   memory?: 'user' | 'project' | 'local';
   effort?: EffortLevel | number;


### PR DESCRIPTION
## What & why

Two related changes to how `agent`-tool subagents are bounded.

### 1. Uncapped by default, settable per dispatch
- **`max_turns`** now defaults to **unlimited** (was default `10`, hard-clamped to `[1,50]`). Pass a positive integer to cap; `0`/negatives mean unlimited (matches `AgentSession`'s existing falsy-`maxTurns` = no-cap check).
- **`max_tool_use_iterations`** — new `agent`-tool param (the real anti-hang knob: tool-use rounds within the child's single turn), also **default unlimited** on the agent-tool path.
- Both are settable two ways, same precedence as before: **explicit call-site > agent-definition frontmatter (`maxTurns` / `maxToolUseIterations`) > default**.
- **Scoped to the agent-tool path** (`child-config.ts`). Skill/compose internal forks keep `SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS = 50` as a retained anti-hang backstop; openai-compatible models keep their provider-internal 50-round cap regardless.

### 2. Fix: hitting the tool-use cap no longer "gets stuck"
Previously, hitting the tool-use iteration cap ended the turn **the instant a tool round finished** (`loop.ts`), before the model got a turn to write a final answer — so history ended on `[assistant: tool_use][user: tool_result]` with **no final message**, and the top-level closure classifier sealed it as a clean `model_end_turn`. A silent stop with no answer is indistinguishable from a hang (the same failure mode the `refusal` branch already guards against).

Now:
- The anthropic-direct loop runs **one final tools-stripped "wind-down" round** on the cap, so the model synthesizes a real answer from what it gathered (with a brief note appended telling it the tool budget is spent). A `capReached` guard hard-stops if the wind-down pathologically emits another `tool_use`.
- The final `turn.completed` still carries `stopReason: 'tool_use_loop_capped'`, and `closure-reason.ts` now maps that to **`iteration_cap`** instead of silently classifying it as `model_end_turn`.

## Behavior / safety notes
- Default path (unlimited) sidesteps the cap entirely; the graceful-cap behavior only applies when a cap is explicitly set (or on the skill/compose 50-round default).
- Foreground subagents remain bounded by the parent turn + AbortGraph; background jobs are cancelled on parent-session end. Cost-budget plumbing to children remains a separate follow-up (noted below).

## Tests
- `pnpm lint` (tsc strict) clean.
- Updated/added coverage: `loop.test.ts` (wind-down round + tools-stripped assertion), `anthropic-direct.test.ts` (end-to-end cap plumbing), `closure-reason.test.ts` (`iteration_cap`), `parser.test.ts` + `subagent-executor*.test.ts` + `schemas.test.ts` (uncapped defaults, new param, frontmatter).
- Full suite: **0 failed tests** (10,897 passed). The 4 `src/cli/commands/chat.*.test.ts` file-load failures are **pre-existing** (a `builtinToolSchemas` mock issue reproducible at clean `HEAD` with this branch stashed) and unrelated to this change.

## Follow-up (not in this PR)
- Plumb `maxBudgetUsd` (and/or a wall-clock timeout) to forked children as a real unattended-spend backstop, now that agent-tool subagents can run uncapped.