### PR TITLE
fix(permissions): dedup session-grants.jsonl audit — append only on grant state change

### DIFF
--- a/src/agent/permissions-store.ts
+++ b/src/agent/permissions-store.ts
@@ -254,10 +254,12 @@ export function allowedPathsForMode(
  * `persist` elicitation choice actually deliver "future sessions inherit it".
  *
  * No-op when the file is absent or empty. `addReadRoot`/`addWriteRoot` are
- * idempotent, so re-seeding (or overlap with the cwd root) is harmless. A
- * write-mode grant is added to BOTH lists: `allowedPathsForMode('read')`
- * includes write grants (read ⊆ write), and the write loop additionally pushes
- * them into the write roots.
+ * idempotent in BOTH state and audit: they append to `session-grants.jsonl`
+ * only when a root is newly added, so re-seeding within a live process (or
+ * overlap with the cwd root) is truly harmless — a fresh process still audits
+ * each restored root once at seed. A write-mode grant is added to BOTH lists:
+ * `allowedPathsForMode('read')` includes write grants (read ⊆ write), and the
+ * write loop additionally pushes them into the write roots.
  *
  * The param is a structural subset of the `GrantManager` interface so this
  * module (agent layer) needn't import it from the CLI layer.

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -559,10 +559,14 @@ export class AnthropicDirectProvider implements ModelProvider {
   addReadRoot(absPath: string, source: 'slash' | 'tool' = 'slash', sessionId?: string): void {
     this.ensureSharedRoots();
     const p = path.resolve(absPath);
+    // Invariant: audit only on state change — a repeat grant of an
+    // already-present root must not emit a duplicate ledger record (see
+    // SessionToolDispatcher.addReadRoot; the unconditional append caused a
+    // 196x blow-up of session-grants.jsonl).
     if (!this._sharedReadRoots!.includes(p)) {
       this._sharedReadRoots!.push(p);
+      this.appendProviderAuditLog({ action: 'grant-read', path: p, source, sessionId });
     }
-    this.appendProviderAuditLog({ action: 'grant-read', path: p, source, sessionId });
   }
 
   addWriteRoot(absPath: string, source: 'slash' | 'tool' = 'slash', sessionId?: string): void {
@@ -573,8 +577,8 @@ export class AnthropicDirectProvider implements ModelProvider {
     }
     if (!this._sharedWriteRoots!.includes(p)) {
       this._sharedWriteRoots!.push(p);
+      this.appendProviderAuditLog({ action: 'grant-write', path: p, source, sessionId });
     }
-    this.appendProviderAuditLog({ action: 'grant-write', path: p, source, sessionId });
   }
 
   revokeRoot(absPath: string, source: 'slash' | 'tool' = 'slash', sessionId?: string): void {

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -522,16 +522,22 @@ export class OpenAICompatibleProvider implements ModelProvider {
   addReadRoot(absPath: string, source: 'slash' | 'tool' = 'slash', sessionId?: string): void {
     this.ensureSharedRoots();
     const p = path.resolve(absPath);
-    if (!this._sharedReadRoots!.includes(p)) this._sharedReadRoots!.push(p);
-    this.appendProviderAuditLog({ action: 'grant-read', path: p, source, sessionId });
+    // Invariant: audit only on state change (see dispatcher.addReadRoot) —
+    // repeat grants of an already-present root must not duplicate the ledger.
+    if (!this._sharedReadRoots!.includes(p)) {
+      this._sharedReadRoots!.push(p);
+      this.appendProviderAuditLog({ action: 'grant-read', path: p, source, sessionId });
+    }
   }
 
   addWriteRoot(absPath: string, source: 'slash' | 'tool' = 'slash', sessionId?: string): void {
     this.ensureSharedRoots();
     const p = path.resolve(absPath);
     if (!this._sharedReadRoots!.includes(p)) this._sharedReadRoots!.push(p);
-    if (!this._sharedWriteRoots!.includes(p)) this._sharedWriteRoots!.push(p);
-    this.appendProviderAuditLog({ action: 'grant-write', path: p, source, sessionId });
+    if (!this._sharedWriteRoots!.includes(p)) {
+      this._sharedWriteRoots!.push(p);
+      this.appendProviderAuditLog({ action: 'grant-write', path: p, source, sessionId });
+    }
   }
 
   revokeRoot(absPath: string, source: 'slash' | 'tool' = 'slash', sessionId?: string): void {

--- a/src/agent/tools/dispatcher-audit-log.test.ts
+++ b/src/agent/tools/dispatcher-audit-log.test.ts
@@ -127,4 +127,36 @@ describe('SessionToolDispatcher audit log — sessionId schema symmetry', () => 
       expect(Object.keys(e).sort()).toEqual(expectedKeys);
     }
   });
+
+  // Regression: the audit append must fire only when a root is NEWLY added.
+  // Before the dedup fix, addReadRoot/addWriteRoot appended unconditionally, so
+  // repeated per-tool-call grants of an already-granted path (e.g. the cwd)
+  // ballooned session-grants.jsonl ~196x (1,143 unique grants → 224k rows).
+  it('does not re-append when the same read root is granted repeatedly', () => {
+    const dispatcher = makeDispatcher();
+    dispatcher.addReadRoot('/dup/read', 'tool');
+    dispatcher.addReadRoot('/dup/read', 'tool');
+    dispatcher.addReadRoot('/dup/read', 'tool');
+    const entries = readAuditEntries().filter((e) => e['path'] === '/dup/read');
+    expect(entries.length).toBe(1);
+    expect(entries[0]!['action']).toBe('grant-read');
+  });
+
+  it('does not re-append when the same write root is granted repeatedly', () => {
+    const dispatcher = makeDispatcher();
+    dispatcher.addWriteRoot('/dup/write', 'tool');
+    dispatcher.addWriteRoot('/dup/write', 'tool');
+    const entries = readAuditEntries().filter((e) => e['path'] === '/dup/write');
+    expect(entries.length).toBe(1);
+    expect(entries[0]!['action']).toBe('grant-write');
+  });
+
+  it('still audits a read→write upgrade as a new grant-write', () => {
+    const dispatcher = makeDispatcher();
+    dispatcher.addReadRoot('/upgrade/path', 'tool'); // grant-read (new to readRoots)
+    dispatcher.addWriteRoot('/upgrade/path', 'tool'); // grant-write (new to writeRoots)
+    dispatcher.addWriteRoot('/upgrade/path', 'tool'); // no-op — already a write root
+    const entries = readAuditEntries().filter((e) => e['path'] === '/upgrade/path');
+    expect(entries.map((e) => e['action'])).toEqual(['grant-read', 'grant-write']);
+  });
 });

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -345,17 +345,26 @@ export class SessionToolDispatcher implements ToolDispatcher {
   /**
    * Grant read access to `absPath`. No-op if already present.
    * `resolveBase` is always implicitly readable and need not be added.
+   *
+   * Invariant: the audit append fires ONLY when `p` is newly added. Re-granting
+   * an already-granted path is a state no-op and must not emit a duplicate
+   * ledger record — the previous unconditional append let per-tool-call
+   * re-grants of the same root balloon `session-grants.jsonl` ~196x (1,143
+   * unique grants → 224k rows before this fix).
    */
   addReadRoot(absPath: string, source: 'slash' | 'tool' = 'slash'): void {
     const p = path.resolve(absPath);
     if (!this._readRoots.includes(p)) {
       this._readRoots.push(p);
+      this.appendAuditLog({ action: 'grant-read', path: p, source });
     }
-    this.appendAuditLog({ action: 'grant-read', path: p, source });
   }
 
   /**
    * Grant read + write access to `absPath`. Ensures path is in BOTH lists.
+   * Audits `grant-write` only when `p` is newly added to `_writeRoots`, so a
+   * read→write upgrade still records (new to writeRoots) while a repeat
+   * write-grant is silent. See `addReadRoot` for the dedup rationale.
    */
   addWriteRoot(absPath: string, source: 'slash' | 'tool' = 'slash'): void {
     const p = path.resolve(absPath);
@@ -364,8 +373,8 @@ export class SessionToolDispatcher implements ToolDispatcher {
     }
     if (!this._writeRoots.includes(p)) {
       this._writeRoots.push(p);
+      this.appendAuditLog({ action: 'grant-write', path: p, source });
     }
-    this.appendAuditLog({ action: 'grant-write', path: p, source });
   }
 
   /**


### PR DESCRIPTION
## What
`session-grants.jsonl` (the path-permission audit ledger under `~/.afk/state/`) had grown to **46 MB / 224,049 rows from only 1,143 unique `(action, path)` grants — a 196× duplication**, climbing ~1.6 MB/day.

## Root cause
`addReadRoot` / `addWriteRoot` in all three grant managers — `SessionToolDispatcher` (`dispatcher.ts`), `AnthropicDirectProvider`, and the OpenAI-compatible provider — called `appendAuditLog` / `appendProviderAuditLog` **unconditionally**, *outside* the `if (!roots.includes(p)) push` dedup guard. Every repeat grant of an already-granted path wrote a duplicate ledger record:
- `path-approval-hook` calls `addReadRoot`/`addWriteRoot` on ~every tool call that touches a granted path (e.g. the cwd);
- `seedPersistedGrants` re-seeds all persisted grants at every bootstrap.

**Duplication signature** confirming the mechanism (not seed-bursts): the top key is `grant-read` on the cwd — **2,404 records across 2,402 _distinct_ timestamps** (spread over time; max identical-timestamp run = 2), 100% `sessionId=null`, 99.6% `source=tool`.

## Fix
Move the audit append **inside** the "newly added" guard in all three managers, so a grant is recorded once, on genuine state change. A read→write upgrade still audits (new to `writeRoots`); a repeat grant is silent. `revokeRoot` is unchanged. Also corrected the `seedPersistedGrants` docstring (re-seeding is now audit-idempotent within a live process).

## Tests
- `pnpm lint` (tsc --noEmit, strict): **clean**.
- All grant / permission / provider / telegram-wiring suites pass; **+3 regression tests** in `dispatcher-audit-log.test.ts`: repeat read grant → 1 record; repeat write grant → 1 record; read→write upgrade → `[grant-read, grant-write]`.

## Note — pre-existing failures (NOT from this PR)
4 `src/cli/commands/chat.*.test.ts` suites fail on `origin/main` independently of this change (incomplete `vi.mock('../../agent/tools/schemas.js')` missing the `builtinToolSchemas` export). Verified by stashing this PR's diff and re-running on a clean tree — the failure is identical. Flagging as a separate main-branch test-mock bug worth its own fix.

## Out of scope (operational follow-up)
The ledger's residual per-bootstrap growth is amplified by a **Telegram bot restart loop** — 578 restarts, 78× `409: Conflict: terminated by other getUpdates request` from two concurrent pollers (`afk daemon` + `dist/telegram.mjs`). That's a launchd/process fix, not a code change; tracked separately.
