### PR TITLE
refactor(cli): dedupe elicitation validators into field-validation module

### DIFF
--- a/src/cli/elicitation-repl.ts
+++ b/src/cli/elicitation-repl.ts
@@ -27,6 +27,7 @@ import { renderMultiSelector, renderSelector, CUSTOM_ANSWER_SENTINEL } from './i
 import { ringBellIfEnabled } from './_lib/capture-mode.js';
 import { sanitizeSchemaString } from './_lib/sanitize.js';
 import { palette } from './palette.js';
+import { validateNumberField, validateTextField } from './elicitation/field-validation.js';
 
 // DoS caps for MCP-controlled schema content. A malicious server can otherwise
 // send `properties` with 10k+ fields or an enum with 1M+ values; both would
@@ -530,16 +531,13 @@ async function runOverlayTextOrNumber(
 
     const help = `enter to submit · esc to cancel${boundsHint}`;
     const validate = (raw: string): string | null => {
-      const trimmed = raw.trim();
-      if (trimmed === '') {
-        if (allowSkip) return null;
-        return 'Please enter a number (or esc to cancel).';
-      }
-      const n = Number(trimmed);
-      if (!Number.isFinite(n)) return 'Please enter a valid number.';
-      if (minVal !== undefined && n < minVal) return `Value must be \u2265 ${minVal}.`;
-      if (maxVal !== undefined && n > maxVal) return `Value must be \u2264 ${maxVal}.`;
-      return null;
+      const r = validateNumberField(raw.trim(), {
+        allowSkip,
+        min: minVal,
+        max: maxVal,
+        emptyError: 'Please enter a number (or esc to cancel).',
+      });
+      return r.ok ? null : r.error;
     };
 
     const result = await readTextOverlay({ header, help, validate, signal });
@@ -554,17 +552,13 @@ async function runOverlayTextOrNumber(
   const minLen = request.minLength;
   const maxLen = request.maxLength;
   const validate = (raw: string): string | null => {
-    if (raw === '') {
-      if (allowSkip) return null;
-      return 'Please enter a response (or esc to cancel).';
-    }
-    if (minLen !== undefined && raw.length < minLen) {
-      return `Response must be at least ${minLen} characters.`;
-    }
-    if (maxLen !== undefined && raw.length > maxLen) {
-      return `Response must be at most ${maxLen} characters.`;
-    }
-    return null;
+    const r = validateTextField(raw, {
+      allowSkip,
+      minLength: minLen,
+      maxLength: maxLen,
+      emptyError: 'Please enter a response (or esc to cancel).',
+    });
+    return r.ok ? null : r.error;
   };
 
   const result = await readTextOverlay({ header, validate, signal });
@@ -895,25 +889,18 @@ async function renderAgentQuestion(
       }
       if (signal.aborted) return CANCEL;
       if (input === ':cancel') return CANCEL;
-      if (input === '' && request.allowSkip) return SKIP;
-      if (input === '' && !request.allowSkip) {
-        writer.line(palette.warning('  Please enter a number (or :cancel to skip).'));
+      const r = validateNumberField(input, {
+        allowSkip: request.allowSkip === true,
+        min: minVal,
+        max: maxVal,
+        emptyError: 'Please enter a number (or :cancel to skip).',
+      });
+      if (!r.ok) {
+        writer.line(palette.warning('  ' + r.error));
         continue;
       }
-      const n = Number(input);
-      if (!isFinite(n)) {
-        writer.line(palette.warning('  Please enter a valid number.'));
-        continue;
-      }
-      if (minVal !== undefined && n < minVal) {
-        writer.line(palette.warning(`  Value must be \u2265 ${minVal}.`));
-        continue;
-      }
-      if (maxVal !== undefined && n > maxVal) {
-        writer.line(palette.warning(`  Value must be \u2264 ${maxVal}.`));
-        continue;
-      }
-      return { action: 'accept', content: { value: n } };
+      if (r.skip) return SKIP;
+      return { action: 'accept', content: { value: r.value } };
     }
   }
 
@@ -930,19 +917,17 @@ async function renderAgentQuestion(
     }
     if (signal.aborted) return CANCEL;
     if (input === ':cancel') return CANCEL;
-    if (input === '' && request.allowSkip) return SKIP;
-    if (input === '') {
-      writer.line(palette.warning('  Please enter a response (or type :cancel to skip).'));
+    const r = validateTextField(input, {
+      allowSkip: request.allowSkip === true,
+      minLength: minLen,
+      maxLength: maxLen,
+      emptyError: 'Please enter a response (or type :cancel to skip).',
+    });
+    if (!r.ok) {
+      writer.line(palette.warning('  ' + r.error));
       continue;
     }
-    if (minLen !== undefined && input.length < minLen) {
-      writer.line(palette.warning(`  Response must be at least ${minLen} characters.`));
-      continue;
-    }
-    if (maxLen !== undefined && input.length > maxLen) {
-      writer.line(palette.warning(`  Response must be at most ${maxLen} characters.`));
-      continue;
-    }
+    if (r.skip) return SKIP;
     return { action: 'accept', content: { value: input } };
   }
 }

--- a/src/cli/elicitation/field-validation.ts
+++ b/src/cli/elicitation/field-validation.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared value validators for the agent-question `number` / `text` types.
+ *
+ * History: extracted from `elicitation-repl.ts`'s `renderAgentQuestion()`,
+ * where the same bounds-checking logic (finite-number range checks; string
+ * min/max-length checks) was copy-pasted once inside the `readTextOverlay`
+ * `validate` closure and once inside the non-TTY `readLine` retry loop, with
+ * byte-identical error message text in both places. This module is the
+ * single source for that logic; both call sites in
+ * `elicitation-repl.ts` now call into it.
+ *
+ * Design note: the "empty input" case is intentionally NOT hard-coded here.
+ * The overlay path escapes via Esc ("...or esc to cancel.") while the
+ * readLine fallback escapes via a typed `:cancel` token ("...or :cancel to
+ * skip.") — those hint strings legitimately differ per caller, so the empty-
+ * message is threaded through as `emptyError` rather than unified away.
+ * Everything that WAS byte-identical between the two call sites (the finite/
+ * NaN check, the min/max bounds checks, and their exact message text) lives
+ * here verbatim.
+ */
+
+// ---------------------------------------------------------------------------
+// Number field
+// ---------------------------------------------------------------------------
+
+export interface NumberValidationOptions {
+  /** Whether empty input should resolve as an explicit "skip" outcome. */
+  allowSkip: boolean;
+  min?: number;
+  max?: number;
+  /** Error text for the empty+!allowSkip case — caller-specific escape hint. */
+  emptyError: string;
+}
+
+export type NumberValidationOutcome =
+  | { ok: true; skip: true }
+  | { ok: true; skip: false; value: number }
+  | { ok: false; error: string };
+
+/**
+ * Validate a trimmed number-field input string against skip/min/max rules.
+ * Callers are responsible for trimming `input` before calling (both existing
+ * call sites already trim at different points in their own flow — trimming
+ * here too would be a no-op for both, but keeping the trim external avoids
+ * this module silently assuming a convention neither caller documents).
+ */
+export function validateNumberField(
+  input: string,
+  opts: NumberValidationOptions,
+): NumberValidationOutcome {
+  if (input === '') {
+    if (opts.allowSkip) return { ok: true, skip: true };
+    return { ok: false, error: opts.emptyError };
+  }
+  const n = Number(input);
+  if (!Number.isFinite(n)) {
+    return { ok: false, error: 'Please enter a valid number.' };
+  }
+  if (opts.min !== undefined && n < opts.min) {
+    return { ok: false, error: `Value must be \u2265 ${opts.min}.` };
+  }
+  if (opts.max !== undefined && n > opts.max) {
+    return { ok: false, error: `Value must be \u2264 ${opts.max}.` };
+  }
+  return { ok: true, skip: false, value: n };
+}
+
+// ---------------------------------------------------------------------------
+// Text field
+// ---------------------------------------------------------------------------
+
+export interface TextValidationOptions {
+  allowSkip: boolean;
+  minLength?: number;
+  maxLength?: number;
+  emptyError: string;
+}
+
+export type TextValidationOutcome =
+  | { ok: true; skip: true }
+  | { ok: true; skip: false }
+  | { ok: false; error: string };
+
+/**
+ * Validate a text-field input string against skip/minLength/maxLength rules.
+ * Unlike {@link validateNumberField}, callers pass the RAW (possibly
+ * untrimmed) value on purpose — the overlay path validates the untrimmed
+ * buffer while the readLine fallback validates its already-trimmed input;
+ * that pre-existing asymmetry is preserved by leaving trimming to the caller.
+ */
+export function validateTextField(
+  input: string,
+  opts: TextValidationOptions,
+): TextValidationOutcome {
+  if (input === '') {
+    if (opts.allowSkip) return { ok: true, skip: true };
+    return { ok: false, error: opts.emptyError };
+  }
+  if (opts.minLength !== undefined && input.length < opts.minLength) {
+    return { ok: false, error: `Response must be at least ${opts.minLength} characters.` };
+  }
+  if (opts.maxLength !== undefined && input.length > opts.maxLength) {
+    return { ok: false, error: `Response must be at most ${opts.maxLength} characters.` };
+  }
+  return { ok: true, skip: false };
+}


### PR DESCRIPTION
## What

Extracts the duplicated number/text field validators out of `elicitation-repl.ts` into a single tested module `src/cli/elicitation/field-validation.ts` (`validateNumberField` / `validateTextField`), and routes all **four** call sites through it.

Before, the same bounds-checking logic lived in 4 copies with byte-identical error text:
- overlay `number` validate closure + overlay `text` validate closure (in `runOverlayTextOrNumber`)
- non-TTY `number` readLine loop + non-TTY `text` readLine loop (in `renderAgentQuestion`)

## Why

Copy-pasted validation is the kind of incidental duplication that makes a long file harder to read and easy to drift (fix a message in one copy, miss the other three). One tested source removes that.

## Behavior preservation

Pure dedup — no behavior change:
- Exact error strings preserved (incl. the `≥`/`≤` bound messages).
- Skip / cancel / empty-input semantics preserved.
- The **overlay-untrimmed vs readLine-trimmed** asymmetry is preserved: the empty-input escape hint legitimately differs per caller (overlay "esc to cancel" vs readLine ":cancel to skip"), so it's threaded through `emptyError` rather than unified away — documented in the module header.

## Verification

- `tsc --noEmit` (strict) — clean
- `src/cli/elicitation-repl.test.ts` — **96/96 pass**
- `audit:env:check` — 0 violations

## Follow-up (not in this PR)

`renderAgentQuestion()` is still a ~340-line `qType` cascade. Splitting its per-type branches (choice / multi_choice / confirm / text / number, overlay + non-TTY paths) into `elicitation/question-handlers.ts` is the natural next step — deferred here to keep this change small and obviously-safe.
