### PR TITLE
fix(cli): align getApiKey() default-model resolution with getModel()

### DIFF
--- a/src/cli/shared-helpers.test.ts
+++ b/src/cli/shared-helpers.test.ts
@@ -25,6 +25,51 @@ import { loadConfig } from './config.js';
 import { AnthropicDirectProvider } from '../agent/providers/index.js';
 import { OpenAICompatibleProvider } from '../agent/providers/openai-compatible/index.js';
 
+describe('getApiKey / getModel provider agreement (regression: default-model divergence)', () => {
+  // Regression guard for a bug where getApiKey() re-read `AFK_MODEL ?? CLAUDE_MODEL`
+  // directly (possibly undefined) instead of resolving against getModel() (which
+  // defaults to the literal 'sonnet'). With both model env vars unset and
+  // AFK_OPENAI_BASE_URL set, `providerForModel(undefined)` fell through to the
+  // Tier-4 env hint -> 'openai-compatible' (OPENAI_API_KEY), while getModel()
+  // returned 'sonnet' -> 'anthropic-direct'. The session then paired an
+  // anthropic-routed model with an OpenAI credential (401s downstream).
+  const ORIG_ENV = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env['AFK_MODEL'];
+    delete process.env['CLAUDE_MODEL'];
+    delete process.env['AFK_PROVIDER'];
+    delete process.env['ANTHROPIC_API_KEY'];
+    delete process.env['CLAUDE_CODE_OAUTH_TOKEN'];
+    delete process.env['OPENAI_API_KEY'];
+    delete process.env['CODEX_API_KEY'];
+    process.env['AFK_OPENAI_BASE_URL'] = 'http://localhost:8000/v1';
+    process.env['OPENAI_API_KEY'] = 'sk-proj-SENTINEL-OPENAI-KEY';
+    process.env['ANTHROPIC_API_KEY'] = 'sk-ant-api03-SENTINEL-ANTHROPIC-KEY';
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIG_ENV };
+  });
+
+  it('getApiKey() resolves the credential for the same provider getModel() routes to, with AFK_MODEL/CLAUDE_MODEL unset and AFK_OPENAI_BASE_URL set', async () => {
+    const { getApiKey, getModel } = await import('./shared-helpers.js');
+    const { providerForModel } = await import('../agent/providers/index.js');
+
+    const resolvedModel = getModel();
+    const resolvedApiKey = getApiKey();
+
+    // getModel() defaults to the literal 'sonnet' -> anthropic-direct.
+    expect(resolvedModel).toBe('sonnet');
+    expect(providerForModel(resolvedModel)).toBe('anthropic-direct');
+
+    // getApiKey() must agree: it should resolve the Anthropic credential,
+    // not fall through the AFK_OPENAI_BASE_URL Tier-4 hint via an undefined model.
+    expect(resolvedApiKey).toBe('sk-ant-api03-SENTINEL-ANTHROPIC-KEY');
+  });
+});
+
 // Mock the config module so loadConfig() (the overlay source) is controllable.
 // loadSystemPrompt() is an in-module call in shared-helpers and reads the real
 // prompts/system-prompt.md from the package tree — i.e. the framework base is

--- a/src/cli/shared-helpers.ts
+++ b/src/cli/shared-helpers.ts
@@ -141,10 +141,18 @@ export function resolveBaseSystemPrompt(): { prompt: string | undefined; source:
  * Callers that explicitly want the Anthropic credential surface (e.g., the
  * `doctor` and `status` diagnostic surfaces) should call `loadCredential()`
  * directly instead.
+ *
+ * Resolves against `getModel()` — not a raw re-read of `AFK_MODEL` /
+ * `CLAUDE_MODEL` — so the credential always matches the same model string the
+ * session actually runs with, including the `'sonnet'` default when both env
+ * vars are unset. Re-reading the raw env pair here previously let this
+ * resolve `undefined` (routing via the `AFK_OPENAI_BASE_URL` Tier-4 hint to
+ * `openai-compatible`) while `getModel()` returned the `'sonnet'` default
+ * (`anthropic-direct`) — an undefined-vs-defaulted divergence that paired an
+ * anthropic-routed model with an OpenAI credential and 401'd.
  */
 export function getApiKey(): string | undefined {
-  const model = env.AFK_MODEL ?? env.CLAUDE_MODEL;
-  return getApiKeyForModel(model);
+  return getApiKeyForModel(getModel());
 }
 
 /**


### PR DESCRIPTION
## Bug

`getApiKey()` read `AFK_MODEL ?? CLAUDE_MODEL` and passed the possibly-`undefined` result to `getApiKeyForModel()`, while `getModel()` defaults to the literal `'sonnet'`. With both model vars unset and `AFK_OPENAI_BASE_URL` set, `providerForModel(undefined)` falls through to the Tier-4 env hint → `openai-compatible` → returns `OPENAI_API_KEY`, while the session model resolves to `'sonnet'` → `anthropic-direct`.

Result: an Anthropic-routed session carries an OpenAI credential (401s), and `SubagentManager.parentApiKey` inherits the mismatch for every dispatched subagent.

## Fix

`getApiKey()` now resolves the credential for the same model `getModel()` returns — one shared default-resolution path.

## Testing

- New regression test in `src/cli/shared-helpers.test.ts` asserting provider agreement under the trigger env.
- Call-site audit: all `getApiKey()` callers pair it with `getModel()` for the same session; none depended on the old undefined-model behavior.
- Full suite: 11,081 passed / 14 skipped.

Note: CI will show red due to the org billing lock — tests verified green locally.