### PR TITLE
fix(telegram): run safety-net strip before fence restore

### DIFF
--- a/src/telegram/formatter.test.ts
+++ b/src/telegram/formatter.test.ts
@@ -663,4 +663,15 @@ describe('markdownToTelegramHtml — mis-nested emphasis safety net', () => {
     expect(markdownToTelegramHtml('**A** and *b* and snake_case'))
       .toBe('<b>A</b> and <i>b</i> and snake_case');
   });
+
+  test('empty-fence label survives the strip when a separate emphasis run is mis-nested', () => {
+    // The empty-fence placeholder is <i>(empty … block)</i>. Because the safety net
+    // runs before the fenced restore, the label's <i> is not collateral-stripped when
+    // an unrelated interleaved run ("**a _b** c_") in the same message trips the net.
+    const out = markdownToTelegramHtml('**a _b** c_\n```bash\n```');
+    expect(tagsBalanced(out)).toBe(true);
+    expect(out).toContain('<i>(empty bash block)</i>'); // label keeps its italic
+    expect(out).not.toContain('<b>'); // mis-nested emphasis still dropped
+    expect(out).toContain('a b c'); // emphasis text preserved as plain
+  });
 });

--- a/src/telegram/formatter.ts
+++ b/src/telegram/formatter.ts
@@ -152,22 +152,28 @@ export function markdownToTelegramHtml(text: string): string {
   // 8. Headers: drop # prefix, keep text
   out = out.replace(/^#{1,6}\s+/gm, '');
 
-  // 9. Restore code spans and fenced blocks after ALL inline transforms.
-  // External constraint: restore must happen last so no inline regex re-scans
-  // the restored HTML content. Inline code before fenced to prevent nested substitution.
-  out = out.replace(/\x02CODE(\d+)\x03/g, (_m, i: string) => codeSpans[Number(i)] ?? _m);
-  // 10. Restore fenced code blocks
-  out = out.replace(/\x02FENCED(\d+)\x03/g, (_m, i: string) => fencedBlocks[Number(i)] ?? _m);
-
-  // 11. Safety net: interleaved/overlapping emphasis markers (e.g. "**a _b** c_")
+  // 9. Safety net: interleaved/overlapping emphasis markers (e.g. "**a _b** c_")
   // can yield improperly-NESTED tags like "<b>a <i>b</b> c</i>", which Telegram
   // rejects with HTTP 400 "can't parse entities" — failing or degrading the send.
   // Code/pre/link tags are emitted as atomic, always-balanced units, so any
   // imbalance is necessarily from emphasis (<b>/<i>/<s>); drop just those to
   // recover guaranteed-valid, readable HTML instead of breaking the message.
+  //
+  // Invariant: this MUST precede the code/fenced restore below. While they are
+  // still placeholders, the balance check and strip see only real emphasis/link
+  // tags — never the restored content. That matters because an empty fence is
+  // emitted as a <i>(empty … block)</i> placeholder; restoring it first would
+  // expose that <i> to the strip and silently de-italicise the label whenever an
+  // unrelated mis-nested emphasis run in the same message trips the net.
   if (!telegramHtmlTagsBalanced(out)) {
     out = out.replace(/<\/?[bis]>/g, '');
   }
+
+  // 10. Restore code spans, then fenced blocks, AFTER the safety net — so no regex
+  // re-scans the restored HTML content and the empty-fence <i> label survives the
+  // strip above. Inline code before fenced to prevent nested substitution.
+  out = out.replace(/\x02CODE(\d+)\x03/g, (_m, i: string) => codeSpans[Number(i)] ?? _m);
+  out = out.replace(/\x02FENCED(\d+)\x03/g, (_m, i: string) => fencedBlocks[Number(i)] ?? _m);
 
   return out;
 }


### PR DESCRIPTION
## The bug

`markdownToTelegramHtml` restores code/fenced-block placeholders (steps 9–10)
*before* the mis-nesting safety net runs (step 11). The safety net strips all
`<b>/<i>/<s>` tags when it finds unbalanced HTML — but by the time it runs on
main, an empty fenced code block has already been restored from its
placeholder into `<i>(empty bash block)</i>`. If the same message also
contains an unrelated interleaved/mis-nested emphasis run, the strip
collateral-damages the fence label's italics too.

Concrete repro:

```
**a _b** c_
```bash
```
```

- On **main**: the interleaved `**a _b** c_` correctly trips the safety net
  and its emphasis is stripped, but the *separately restored* empty-fence
  label `<i>(empty bash block)</i>` gets caught by the same blanket
  `<\/?[bis]>` regex and loses its `<i>` — even though the fence label was
  never part of the imbalance.
- **After this fix**: the safety net runs while the fence is still an opaque
  `\x02FENCED0\x03` placeholder, so the balance check only ever sees real
  emphasis/link tags. The label is restored *after* the strip and keeps its
  italics: `<i>(empty bash block)</i>`.

This also fixes the stated-but-violated invariant from #321 that restore
"must happen last so no inline regex re-scans restored content" — on main the
strip regex runs *after* restore, i.e. it does re-scan restored content.

## Verified against current main

Confirmed by reading `origin/main`'s `src/telegram/formatter.ts`: steps 9–10
(restore) still precede step 11 (safety net strip). The bug is present and
unfixed on main as of this PR.

## Changes

Cherry-pick of `f54acbd` (2nd commit of the branch that produced #321 — #321
merged the 1st commit only) onto current `main`. Clean pick, no conflicts.
Reorders the safety net to run before the code/fenced restore and adds a
regression test asserting the fence label keeps its `<i>` when a separate
mis-nested emphasis run is present in the same message.

## Testing

- `pnpm lint` (`tsc --noEmit`): clean
- `pnpm test -- src/telegram/formatter.test.ts`: 97/97 passed (includes new
  regression test `empty-fence label survives the strip when a separate
  emphasis run is mis-nested`)
- Full suite (`pnpm test`): 596 files / 11100 tests passed, 14 skipped, 0
  failed

**CI red expected: org billing lock; suite green locally.**
