### PR TITLE
refactor(providers): consolidate o-series model detection into isOSeriesModel()

### DIFF
--- a/src/agent/model-capabilities.test.ts
+++ b/src/agent/model-capabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterAll } from 'vitest';
-import { supportsVision } from './model-capabilities.js';
+import { supportsVision, isOSeriesModel } from './model-capabilities.js';
 import { resetSlotBindings } from './session/model-slots.js';
 
 describe('supportsVision', () => {
@@ -77,5 +77,38 @@ describe('supportsVision', () => {
     process.env['AFK_VISION_MODELS'] = '!gpt-4o-mini';
     expect(supportsVision('gpt-4o-mini')).toBe(false);
     expect(supportsVision('gpt-4o')).toBe(true); // unrelated vision model unaffected
+  });
+});
+
+describe('isOSeriesModel', () => {
+  it('matches the known o-series families (o1/o3/o4) and their variants', () => {
+    for (const m of ['o1', 'o1-mini', 'o1-preview', 'o3', 'o3-mini', 'o4-mini', 'o4-mini-2025-04-16']) {
+      expect(isOSeriesModel(m)).toBe(true);
+    }
+  });
+
+  // Regression: the pre-consolidation copies (providers/index.ts,
+  // model-limits.ts) used enumerated startsWith('o1'|'o3'|'o4') and silently
+  // misclassified any future oN. This case would have failed against them.
+  it('matches future o5+/oN prefixes (the gap the enumerated copies had)', () => {
+    for (const m of ['o5', 'o5-mini', 'o6', 'o9-turbo']) {
+      expect(isOSeriesModel(m)).toBe(true);
+    }
+  });
+
+  it('strips a provider/ prefix (OpenRouter-style ids)', () => {
+    expect(isOSeriesModel('openai/o3')).toBe(true);
+    expect(isOSeriesModel('openrouter/o1-mini')).toBe(true);
+  });
+
+  it('is case-insensitive and tolerates surrounding whitespace', () => {
+    expect(isOSeriesModel('O3')).toBe(true);
+    expect(isOSeriesModel('  o1-mini  ')).toBe(true);
+  });
+
+  it('does NOT match non-o-series ids (gpt/claude/codex/local/empty)', () => {
+    for (const m of ['gpt-4o', 'gpt-4o-mini', 'claude-sonnet-4', 'codex', 'ollama', 'mixtral-8x7b', '', undefined]) {
+      expect(isOSeriesModel(m)).toBe(false);
+    }
   });
 });

--- a/src/agent/model-capabilities.ts
+++ b/src/agent/model-capabilities.ts
@@ -124,3 +124,29 @@ export function supportsVision(model: string | undefined): boolean {
   if (VISION_MODEL_IDS.has(lowered)) return true;
   return VISION_MODEL_PATTERNS.some((re) => re.test(resolved));
 }
+
+/**
+ * Detect OpenAI o-series reasoning models — o1, o3, o4, and any future `oN`.
+ *
+ * Single source of truth for o-series classification, consumed by the provider
+ * router (`providers/index.ts`), context/output token sizing
+ * (`model-limits.ts`), and the openai-compatible provider's request shaping
+ * (`query/model-params.ts` — which re-exports it under the same name for
+ * backward compatibility — and `oneshot.ts`).
+ *
+ * Robustness the enumerated `startsWith('o1'|'o3'|'o4')` copies lacked:
+ *   - matches ANY `o<digit>` prefix, so o5/o6/… are covered without edits;
+ *   - strips a leading `provider/` segment (OpenRouter-style ids) so
+ *     `openai/o3` and `openrouter/o1-mini` classify correctly;
+ *   - case-insensitive.
+ *
+ * Note: unlike `supportsVision`, this does NOT resolve slot aliases — o-series
+ * ids arrive as concrete strings (there is no `o3` alias), so it stays a pure
+ * string predicate with no `resolveModelInput` dependency.
+ */
+export function isOSeriesModel(model: string | undefined): boolean {
+  if (!model) return false;
+  const trimmed = model.trim();
+  const bare = trimmed.includes('/') ? trimmed.slice(trimmed.lastIndexOf('/') + 1) : trimmed;
+  return /^o[0-9]/i.test(bare);
+}

--- a/src/agent/model-limits.ts
+++ b/src/agent/model-limits.ts
@@ -16,6 +16,7 @@
 
 import type { ClaudeModel } from './types.js';
 import { resolveModelInput } from './session/model-slots.js';
+import { isOSeriesModel } from './model-capabilities.js';
 
 /**
  * Keys cover both short aliases (`opus`, `sonnet`, `haiku`, `*_1m`) and the
@@ -147,7 +148,7 @@ function routesToOpenAICompatible(model: string): boolean {
   // are served exclusively by local OpenAI-shim runners.
   if (lowered.includes('/')) return true;
   if (lowered.startsWith('gpt-') || lowered.startsWith('gpt_')) return true;
-  if (lowered.startsWith('o1') || lowered.startsWith('o3') || lowered.startsWith('o4')) return true;
+  if (isOSeriesModel(lowered)) return true;
   if (lowered.startsWith('codex-') || lowered.startsWith('codex_') || lowered === 'codex') return true;
   return false;
 }

--- a/src/agent/providers/index.ts
+++ b/src/agent/providers/index.ts
@@ -24,6 +24,7 @@ import { anthropicDirectProvider, AnthropicDirectProvider } from './anthropic-di
 import { OpenAICompatibleProvider } from './openai-compatible/index.js';
 import { MODEL_MAP } from '../session/model-resolution.js';
 import { resolveBinding, type ModelSlots } from '../session/model-slots.js';
+import { isOSeriesModel } from '../model-capabilities.js';
 import { env } from '../../config/env.js';
 
 /**
@@ -190,9 +191,7 @@ export function providerForModel(
     if (
       lowered.startsWith('gpt-') ||
       lowered.startsWith('gpt_') ||
-      lowered.startsWith('o1') ||
-      lowered.startsWith('o3') ||
-      lowered.startsWith('o4') ||
+      isOSeriesModel(lowered) ||
       lowered.startsWith('codex-') ||
       lowered.startsWith('codex_') ||
       lowered === 'codex' ||

--- a/src/agent/providers/openai-compatible/oneshot.ts
+++ b/src/agent/providers/openai-compatible/oneshot.ts
@@ -18,6 +18,7 @@
 
 import OpenAI from 'openai';
 import { resolveOpenAIAuth } from './auth.js';
+import { isOSeriesModel } from '../../model-capabilities.js';
 
 /** Test injection hook — supplants the real `OpenAI` constructor. */
 export type OneShotOpenAIClientFactory = (opts: { apiKey: string; baseURL?: string }) => OpenAI;
@@ -88,10 +89,11 @@ export async function oneShotChatCompletion(input: OpenAIOneShotInput): Promise<
   const factory = clientFactory ?? oneShotClientFactory;
   const client = factory ? factory(clientOpts) : new OpenAI(clientOpts);
 
-  // o-series reasoning models reject `max_tokens`; everything else (and local
-  // shims) want it. Strip any `provider/` prefix (OpenRouter-style ids) first.
-  const bareModel = model.includes('/') ? model.slice(model.lastIndexOf('/') + 1) : model;
-  const tokenLimit = /^o[0-9]/.test(bareModel)
+  // o-series reasoning models reject `max_tokens` and require
+  // `max_completion_tokens`; everything else (chat models + local shims) wants
+  // `max_tokens`. Classification (incl. `provider/`-prefix strip) is shared —
+  // see `isOSeriesModel` in model-capabilities.ts.
+  const tokenLimit = isOSeriesModel(model)
     ? { max_completion_tokens: maxTokens }
     : { max_tokens: maxTokens };
 

--- a/src/agent/providers/openai-compatible/query/model-params.ts
+++ b/src/agent/providers/openai-compatible/query/model-params.ts
@@ -9,6 +9,7 @@
 
 import type { EffortLevel } from '../../../types/sdk-types.js';
 import { maxOutputTokensFor } from '../../../model-limits.js';
+import { isOSeriesModel } from '../../../model-capabilities.js';
 
 /**
  * Resolve the effective output-token cap (a plain number).
@@ -60,14 +61,11 @@ export function normalizePermissionMode(mode: string | undefined): string {
 }
 
 /**
- * Detect OpenAI o-series reasoning models (o1, o3, o4, and their variants).
- * Strips any `provider/` prefix (OpenRouter-style ids) before matching.
- * Mirrors the detection in `oneshot.ts` for the `max_completion_tokens` switch.
+ * Re-exported for backward compatibility — `query.ts` re-exports it and older
+ * call sites import it from here. Canonical definition (incl. o5+/`oN` and
+ * `provider/`-prefix handling) now lives in `model-capabilities.ts`.
  */
-export function isOSeriesModel(model: string): boolean {
-  const bareModel = model.includes('/') ? model.slice(model.lastIndexOf('/') + 1) : model;
-  return /^o[0-9]/.test(bareModel);
-}
+export { isOSeriesModel };
 
 /**
  * Map AFK's `EffortLevel` to OpenAI's `reasoning_effort` values.


### PR DESCRIPTION
## Summary

Consolidates ~4 duplicated o-series-model (`o1`/`o3`/`o4`) detection checks — a mix of `startsWith('o1'|'o3'|'o4')` enumerations and an inline `/^o[0-9]/` regex — into a single `isOSeriesModel()` predicate, the canonical definition now living in `src/agent/model-capabilities.ts`.

### Why

The duplicated checks were an enumerated allowlist (`o1`, `o3`, `o4`) that would silently misclassify any future o-series id (`o5`, `o6`, …) as a non-reasoning model. They also disagreed slightly in scope — some stripped an OpenRouter-style `provider/` prefix, some didn't; none were case-insensitive.

### What changed

- **`model-capabilities.ts`** — new `isOSeriesModel()`: matches any `o<digit>` prefix (not just o1/o3/o4), strips a leading `provider/` segment, case-insensitive.
- **`model-limits.ts`** (`routesToOpenAICompatible`) and **`providers/index.ts`** (`providerForModel`) — now delegate to the shared predicate instead of their own `startsWith` enumerations.
- **`providers/openai-compatible/oneshot.ts`** — drops its inline `/^o[0-9]/` copy in favor of the shared predicate.
- **`providers/openai-compatible/query/model-params.ts`** — its local `isOSeriesModel` is now a re-export of the canonical one, preserving the existing import path for `query.ts` and any other consumers.
- New regression tests in `model-capabilities.test.ts` covering o5+/oN, `provider/`-prefix stripping, and case-insensitivity.

No behavior change for existing o1/o3/o4 ids.

### Rebase note

Rebased onto current `origin/main` (provider refactors #451–454 split `openai-compatible/query.ts` into `query/` submodules and added the tool-loop-cap machinery). The rebase applied cleanly with **no conflicts** — none of the intervening commits touched the o-series check itself, and a repo-wide grep confirms no duplicate `startsWith('o1'|'o3'|'o4')` or `/^o[0-9]/` copies remain outside the canonical predicate.

## Testing

- `pnpm lint` (tsc --noEmit): clean
- `pnpm test`: **596 test files, 11104 tests passed**, 14 pre-existing skips, 0 failures

**CI red expected:** org billing lock; suite verified green locally (11k+ tests).
