### PR TITLE
fix(telegram): thread openaiBaseUrl so OpenAI Telegram sessions reach the configured endpoint

### DIFF
--- a/src/agent/providers/routing.test.ts
+++ b/src/agent/providers/routing.test.ts
@@ -23,12 +23,17 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { providerForModel, resolveProvider } from './index.js';
-import { createChildProviderFactory } from '../tools/nesting.js';
+import {
+  createChildProviderFactory,
+  createChildSkillExecutorFactory,
+  type ChildProviderFactoryArgs,
+} from '../tools/nesting.js';
 import { AnthropicDirectProvider } from './anthropic-direct/index.js';
 import { OpenAICompatibleProvider } from './openai-compatible/index.js';
 import { getDefaultSubagentModel } from '../../cli/shared-helpers.js';
 import type { SubagentExecutor } from '../tools/subagent-executor.js';
 import type { SkillExecutor } from '../tools/skill-executor.js';
+import type { ModelProvider } from '../provider.js';
 
 describe('providerForModel', () => {
   // Scrub env vars that `providerForModel` now consults internally.
@@ -501,6 +506,84 @@ describe('createChildProviderFactory — child provider routing', () => {
     expect(
       factory({ childExecutor, childSkillExecutor, model: 'gpt-4o' }),
     ).toBeInstanceOf(OpenAICompatibleProvider);
+  });
+});
+
+/**
+ * createChildSkillExecutorFactory's trailing `openaiBaseUrl` positional arg
+ * (nesting.ts) must be threaded onto every nested SkillExecutor's ctx —
+ * `ctx.openaiBaseUrl` is what `buildForkedChildConfig` later forwards into
+ * `buildReadOnlyReconProvider` / `buildSkillRestrictedProvider` (depth-cap
+ * fallback, see nesting.test.ts) and into the grandchild SubagentExecutor's
+ * `defaultConfig` (see skill-executor.test.ts's openaiBaseUrl propagation
+ * test). This closes the gap at the factory→ctx handoff itself, mirroring
+ * nesting.model-fallback.test.ts's coverage of the sibling
+ * `defaultSubagentModel` parameter on the same factory.
+ */
+describe('createChildSkillExecutorFactory — openaiBaseUrl threading', () => {
+  const stubProviderFactory = (_args: ChildProviderFactoryArgs): ModelProvider =>
+    ({}) as ModelProvider;
+
+  it('threads openaiBaseUrl into the constructed SkillExecutor ctx', () => {
+    const factory = createChildSkillExecutorFactory(
+      'gpt-4o', // 1 defaultModel
+      undefined, // 2 apiKey
+      stubProviderFactory, // 3 childProviderFactory
+      undefined, // 4 baseUrl
+      undefined, // 5 traceWriter
+      undefined, // 6 backgroundRegistry
+      undefined, // 7 cwd
+      undefined, // 8 resolveApiKeyForModel
+      'cli', // 9 surface
+      undefined, // 10 defaultSubagentModel
+      undefined, // 11 agentRegistry
+      'http://localhost:8080/v1', // 12 openaiBaseUrl
+    );
+    const skillExecutor = factory(1, 3, new AbortController().signal);
+    expect(
+      (skillExecutor as unknown as { ctx: { openaiBaseUrl?: string } }).ctx.openaiBaseUrl,
+    ).toBe('http://localhost:8080/v1');
+  });
+
+  it('recursively propagates openaiBaseUrl to grandchild SkillExecutors (skill→skill→skill)', () => {
+    const factory = createChildSkillExecutorFactory(
+      'gpt-4o',
+      undefined,
+      stubProviderFactory,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'cli',
+      undefined,
+      undefined,
+      'http://localhost:8080/v1',
+    );
+    const child = factory(1, 3, new AbortController().signal);
+    const recursiveFactory = (
+      child as unknown as {
+        ctx: {
+          childSkillExecutorFactory: (
+            depth: number,
+            maxDepth: number,
+            signal: AbortSignal,
+          ) => SkillExecutor;
+        };
+      }
+    ).ctx.childSkillExecutorFactory;
+    const grandchild = recursiveFactory(2, 3, new AbortController().signal);
+    expect(
+      (grandchild as unknown as { ctx: { openaiBaseUrl?: string } }).ctx.openaiBaseUrl,
+    ).toBe('http://localhost:8080/v1');
+  });
+
+  it('omits openaiBaseUrl when the caller does not supply it (back-compat)', () => {
+    const factory = createChildSkillExecutorFactory('sonnet', undefined, stubProviderFactory);
+    const skillExecutor = factory(1, 3, new AbortController().signal);
+    expect(
+      (skillExecutor as unknown as { ctx: { openaiBaseUrl?: string } }).ctx.openaiBaseUrl,
+    ).toBeUndefined();
   });
 });
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -251,6 +251,9 @@ async function main() {
         let boundSession: AgentSession | undefined;
         const telegramApiKey = sessionConfig.apiKey ?? config.apiKey ?? '';
         const telegramBaseUrl = config.baseUrl;
+        // OpenAI-compatible endpoint (distinct from telegramBaseUrl, which is
+        // Anthropic-only) — threaded for parity with chat.ts's cliConfig.openaiBaseUrl wiring.
+        const telegramOpenaiBaseUrl = sessionConfig.openaiBaseUrl ?? config.openaiBaseUrl;
         // Inherit configured-or-host cwd so forked subagents stay in the
         // same working tree as the parent session — important when the
         // bot is pointed at a worktree via AFK_TELEGRAM_CWD.
@@ -272,7 +275,11 @@ async function main() {
           get hookRegistry() { return boundSession?.hookRegistry; },
         };
 
-        const childProviderFactory = createChildProviderFactory();
+        // Pass openaiBaseUrl so OpenAI-routed children point at the configured
+        // local shim instead of the default api.openai.com (parity with chat.ts).
+        const childProviderFactory = createChildProviderFactory(
+          telegramOpenaiBaseUrl !== undefined ? { openaiBaseUrl: telegramOpenaiBaseUrl } : {},
+        );
 
         // Named-agent registry: session-static scan enabling `agent_type`
         // dispatch (builtin + user + project scopes, anchored at the bot cwd).
@@ -304,6 +311,8 @@ async function main() {
           getDefaultSubagentModel(sessionConfig.model),
           // Named-agent registry propagates to nested skill executors.
           agentRegistry,
+          // OpenAI endpoint → nested restricted/depth-cap provider builders.
+          telegramOpenaiBaseUrl,
         );
 
         // Pass `sessionConfig.model` to `getDefaultSubagentModel` for
@@ -320,6 +329,7 @@ async function main() {
             apiKey: telegramApiKey,
             systemPrompt: layeredBasePrompt,
             ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
+            ...(telegramOpenaiBaseUrl !== undefined ? { openaiBaseUrl: telegramOpenaiBaseUrl } : {}),
           },
           defaultSubagentModel: getDefaultSubagentModel(sessionConfig.model),
           childProviderFactory,
@@ -347,6 +357,7 @@ async function main() {
           // Per-model credential resolver — mirrors bootstrap.ts / chat.ts.
           resolveApiKeyForModel: getApiKeyForModel,
           ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
+          ...(telegramOpenaiBaseUrl !== undefined ? { openaiBaseUrl: telegramOpenaiBaseUrl } : {}),
         });
 
         // Compose subagents inherit the framework base + operator overlay
@@ -436,6 +447,9 @@ async function main() {
         : rawPrompt;
       // Codex branch: same cwd resolution as the Anthropic branch above.
       const codexSessionCwd = sessionCwd;
+      // OpenAI-compatible endpoint for this branch's own top-level session
+      // (parity with the Anthropic branch's telegramOpenaiBaseUrl above).
+      const codexOpenaiBaseUrl = sessionConfig.openaiBaseUrl ?? config.openaiBaseUrl;
 
       // permissionMode is intentionally omitted here: AgentSession defaults
       // to 'default' (post-C2 fix), which is the correct mode for Telegram
@@ -470,6 +484,10 @@ async function main() {
         maxTurns: 100,
         ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
         ...(maxToolUseIterations !== undefined ? { maxToolUseIterations } : {}),
+        // Sets config.openaiBaseUrl -> effectiveBaseURL (openai-compatible/index.ts)
+        // so this top-level OpenAI Telegram session reaches the configured shim
+        // instead of defaulting to api.openai.com.
+        ...(codexOpenaiBaseUrl !== undefined ? { openaiBaseUrl: codexOpenaiBaseUrl } : {}),
         ...(codexSessionCwd !== undefined && codexSessionCwd.length > 0
           ? { cwd: codexSessionCwd }
           : {}),

--- a/src/telegram/construct-session.test.ts
+++ b/src/telegram/construct-session.test.ts
@@ -103,6 +103,25 @@ describe('constructTelegramSession', () => {
     );
     expect(captured?.traceWriter).toBeUndefined();
   });
+
+  it('preserves openaiBaseUrl on the config handed to newSession (parity with baseUrl/surface)', () => {
+    // Regression guard: telegram.ts is the only surface that must NOT drop
+    // config.openaiBaseUrl when constructing the top-level session — see
+    // src/agent/providers/openai-compatible/index.ts effectiveBaseURL
+    // resolution (`config.openaiBaseUrl ?? this.providerOpts.baseURL`).
+    // This test pins the pass-through at the construct-session seam itself;
+    // it does not assert the telegram.ts wiring that sets the field.
+    let captured: AgentConfig | undefined;
+    constructTelegramSession(
+      { model: 'gpt-4o', openaiBaseUrl: 'http://localhost:8080/v1' },
+      {
+        traceWriter: null,
+        newSession: (c): AgentSession => { captured = c; return {} as unknown as AgentSession; },
+      },
+    );
+    expect(captured?.openaiBaseUrl).toBe('http://localhost:8080/v1');
+    expect(captured?.surface).toBe('telegram');
+  });
 });
 
 describe('createTelegramTraceWriter', () => {


### PR DESCRIPTION
## Problem

`src/telegram.ts` never propagated `openaiBaseUrl` (env `AFK_OPENAI_BASE_URL` / `config.openaiBaseUrl`). As a result the **entire OpenAI-compatible Telegram surface** — the top-level session *and* any OpenAI-routed subagents/skills forked from a Telegram parent — silently targeted `api.openai.com` instead of a configured local shim.

Only `baseUrl` (the Anthropic base) was threaded, as `telegramBaseUrl`; its OpenAI peer was dropped on every Telegram code path. The CLI surfaces (`chat.ts`, `bootstrap.ts`) already thread `cliConfig.openaiBaseUrl` into the child factories + executors — Telegram was the lone surface missing it. It only worked by accident when the operator used *per-slot* config (`AFK_MODEL_<SLOT>_BASE_URL`), which `applySlotCredentials` self-heals.

## Fix (parity with chat.ts)

**Anthropic branch** — capture `telegramOpenaiBaseUrl` and thread it into:
- `createChildProviderFactory({ openaiBaseUrl })`
- the trailing positional arg of `createChildSkillExecutorFactory(...)`
- `SubagentExecutor.defaultConfig`
- `SkillExecutor`

**Codex/OpenAI branch** — capture `codexOpenaiBaseUrl` and set it on the `constructTelegramSession` config so `config.openaiBaseUrl → effectiveBaseURL` (`openai-compatible/index.ts:264`), fixing the top-level session's endpoint.

`ComposeExecutor` is intentionally untouched — its options type has no `openaiBaseUrl` field (same as `chat.ts`).

## Testing

- `pnpm lint` (tsc --noEmit, strict) — clean.
- `pnpm exec vitest run src/telegram/construct-session.test.ts src/agent/providers/routing.test.ts` — 125/125 pass.
- Added: `construct-session` `openaiBaseUrl` pass-through test; `routing.test.ts` coverage that `createChildSkillExecutorFactory` forwards `openaiBaseUrl` to nested `SkillExecutor`s.

## Known follow-up (out of scope)

The OpenAI/Codex Telegram branch still builds **no** child executors (Sub/Skill/Compose) — a separate structural gap, and the reason a unified `assembleSurfaceExecutors` factory across all four surfaces is not a mechanical lift. This PR fixes only the endpoint routing. Context: surface-composition audit (2026-07-06).
