### PR TITLE
fix(subagent): surface capped/truncated partials to the parent instead of silent success

### DIFF
--- a/src/agent/dag-subagent.ts
+++ b/src/agent/dag-subagent.ts
@@ -13,7 +13,7 @@ import type { ZodType } from 'zod';
 import type { AgentModelInput, CanUseTool, IAgentSession } from './types.js';
 import type { SubagentManager } from './subagent.js';
 import { runDAG, type DAGEdge, type DAGNode, type DAGRunResult } from './dag.js';
-import { attachSubagentContext } from './subagent/result.js';
+import { attachSubagentContext, annotateIfIncomplete } from './subagent/result.js';
 import { TimeoutError } from '../utils/errors.js';
 
 export interface SubagentDAGNode {
@@ -151,7 +151,14 @@ export async function runSubagentDAG(options: SubagentDAGOptions): Promise<DAGRu
             subagentId: result.id,
           });
         }
-        return result.output ?? result.message?.content;
+        // result.output is a structured parse (complete by construction); only
+        // the raw-text fallback can be an incomplete partial, so annotate just
+        // that branch. No-op marker for clean completions.
+        if (result.output !== undefined) return result.output;
+        const text = result.message?.content;
+        return typeof text === 'string'
+          ? annotateIfIncomplete(text, result.stopReason)
+          : text;
       } finally {
         nodeSignal.removeEventListener('abort', onNodeAbort);
         await handle.teardown().catch(() => undefined);

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -194,10 +194,16 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
       this.lastDurationMs = Date.now() - startTime;
       this.currentStatus = 'succeeded';
       this.latestTerminalStatus = 'succeeded';
-      // Witness layer: subagent_lifecycle.succeeded fires before onTerminal()
-      // so the trace records the terminal transition even if the manager
-      // tears the handle down immediately after. Fire-and-forget.
-      void emitSubagentLifecycle(this.traceWriter, {
+      // Witness layer: subagent_lifecycle.succeeded MUST be awaited before
+      // onTerminal(). onTerminal() may trigger the owning session's immediate
+      // teardown, which calls writer.seal(); once sealed, writer.write() throws
+      // and emitSubagentLifecycle swallows it, silently dropping this terminal
+      // record (the "lost terminal trace event" orphan bug). Awaiting here
+      // guarantees the succeeded event is enqueued+persisted on the writer's
+      // FIFO queue BEFORE any seal can run. Safe: write() is a bounded FS append
+      // and emitSubagentLifecycle already swallows errors, so the await cannot
+      // introduce a new failure mode or an unbounded hang.
+      await emitSubagentLifecycle(this.traceWriter, {
         transition: 'succeeded',
         subagentId: this.id,
         durationMs: this.lastDurationMs,
@@ -239,8 +245,12 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
         // externally. The trace and the result-object status must agree so
         // downstream consumers (operator dashboard, future ActiveWorkRegistry)
         // can correctly attribute cascade terminations vs. genuine failures.
+        // Awaited (not fire-and-forget) for the same reason as the success
+        // path: onTerminal() below may seal the owning session's trace, and a
+        // seal that lands before this write is enqueued would drop the terminal
+        // record. Awaiting guarantees the event is persisted first.
         if (this.controller.signal.aborted) {
-          void emitSubagentLifecycle(this.traceWriter, {
+          await emitSubagentLifecycle(this.traceWriter, {
             transition: 'cancelled',
             subagentId: this.id,
             source: 'cascade',
@@ -248,7 +258,7 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
           this.currentStatus = 'cancelled';
           this.latestTerminalStatus = 'cancelled';
         } else {
-          void emitSubagentLifecycle(this.traceWriter, {
+          await emitSubagentLifecycle(this.traceWriter, {
             transition: 'failed',
             subagentId: this.id,
             errorClass: err instanceof Error ? err.constructor.name : 'Unknown',

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -22,6 +22,7 @@ import {
   buildResultFromMessage,
   buildResultFromError,
   createEmptyTrace,
+  STREAM_INCOMPLETE,
   type SubagentResult,
   type SubagentStatus,
   type SubagentTrace,
@@ -202,6 +203,11 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
         durationMs: this.lastDurationMs,
         turnCount: this.currentTrace.turnCount,
         outputBytes: Buffer.byteLength(this.lastMessage, 'utf8'),
+        // Record the terminal stop reason so trace forensics can distinguish a
+        // clean completion from a capped/truncated partial (tool_use_loop_capped
+        // / stream_incomplete) WITHOUT recomputing marker byte-lengths. Absent
+        // when the provider reported no stop reason (a plain clean end).
+        ...(this.lastStopReason !== undefined && { stopReason: this.lastStopReason }),
       });
       // Propagate usage and cost to the parent session's rollup accumulators.
       // Fire synchronously before onTerminal() so the session_sealed event
@@ -351,6 +357,15 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     if (streamError) throw streamError;
     if (finalMessage) return finalMessage;
     if (this.lastStreamedContent.length > 0) {
+      // The stream ended with partial assistant text but no terminal `message`
+      // event: the child was cut off mid-output (an abort, an early/abnormal
+      // provider-stream close, or a provider that ended without a final
+      // message). Mark the run non-clean so `runToResult` surfaces it as an
+      // incomplete partial (via `stopReason`) instead of a silent success —
+      // consumers prepend a parent-visible marker (annotateIfIncomplete). Use
+      // `??=` so a real terminal stopReason (if one somehow arrived) is never
+      // clobbered; reaching here implies none did.
+      this.lastStopReason ??= STREAM_INCOMPLETE;
       return { role: 'assistant', content: this.lastStreamedContent, timestamp: new Date() };
     }
     // Anti-hang fallback (see SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS in

--- a/src/agent/subagent/result.test.ts
+++ b/src/agent/subagent/result.test.ts
@@ -10,7 +10,13 @@
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import type { Message } from '../types.js';
-import { buildResultFromMessage } from './result.js';
+import {
+  buildResultFromMessage,
+  isIncompleteStopReason,
+  annotateIfIncomplete,
+  STREAM_INCOMPLETE,
+} from './result.js';
+import { TOOL_USE_LOOP_CAPPED } from '../providers/shared/tool-loop-cap.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -148,5 +154,58 @@ describe('buildResultFromMessage — stopReason wiring', () => {
     );
     expect(result.status).toBe('failed');
     expect(result.stopReason).toBe('end_turn');
+  });
+});
+
+describe('isIncompleteStopReason — partial-result classification', () => {
+  it('is true for the tool-use loop cap', () => {
+    expect(isIncompleteStopReason(TOOL_USE_LOOP_CAPPED)).toBe(true);
+  });
+
+  it('is true for a stream-truncated run', () => {
+    expect(isIncompleteStopReason(STREAM_INCOMPLETE)).toBe(true);
+  });
+
+  it('is false for a clean terminal stop reason', () => {
+    expect(isIncompleteStopReason('end_turn')).toBe(false);
+  });
+
+  it('is false when the stop reason is absent', () => {
+    expect(isIncompleteStopReason(undefined)).toBe(false);
+  });
+
+  it('is false for an unrelated provider stop reason', () => {
+    expect(isIncompleteStopReason('max_tokens')).toBe(false);
+  });
+});
+
+describe('annotateIfIncomplete — parent-visible partial marker', () => {
+  const BODY = 'here are my intermediate findings';
+
+  it('returns content unchanged for a clean completion', () => {
+    expect(annotateIfIncomplete(BODY, 'end_turn')).toBe(BODY);
+  });
+
+  it('returns content unchanged when the stop reason is absent', () => {
+    expect(annotateIfIncomplete(BODY, undefined)).toBe(BODY);
+  });
+
+  it('prepends a PARTIAL marker naming the iteration cap and preserves the body', () => {
+    const out = annotateIfIncomplete(BODY, TOOL_USE_LOOP_CAPPED);
+    expect(out).not.toBe(BODY);
+    expect(out).toContain('PARTIAL RESULT');
+    expect(out).toContain('tool-use iteration cap');
+    expect(out).toContain(BODY);
+    // The original body must survive verbatim as a suffix so downstream
+    // renderers/parsers still see the full text after the marker.
+    expect(out.endsWith(BODY)).toBe(true);
+  });
+
+  it('prepends a PARTIAL marker describing a cut-off stream and preserves the body', () => {
+    const out = annotateIfIncomplete(BODY, STREAM_INCOMPLETE);
+    expect(out).not.toBe(BODY);
+    expect(out).toContain('PARTIAL RESULT');
+    expect(out).toContain('cut off');
+    expect(out.endsWith(BODY)).toBe(true);
   });
 });

--- a/src/agent/subagent/result.ts
+++ b/src/agent/subagent/result.ts
@@ -11,8 +11,53 @@ import type { ZodError, ZodType } from 'zod';
 import type { Message } from '../types.js';
 import { extractStructuredOutput } from '../output-extractor.js';
 import { parseSignal, type Signal } from '../signal-block.js';
+import { TOOL_USE_LOOP_CAPPED } from '../providers/shared/tool-loop-cap.js';
 
 export type SubagentStatus = 'idle' | 'running' | 'succeeded' | 'failed' | 'cancelled';
+
+/**
+ * Synthetic `stopReason` set by {@link SubagentHandle} when a run resolves with
+ * partial assistant text but NO terminal `message` event — i.e. the child was
+ * cut off mid-output (an abort, an early/abnormal provider-stream close, or a
+ * provider that ended the stream without a final message). Distinct from
+ * {@link TOOL_USE_LOOP_CAPPED} (the tool-use iteration cap). Both mean the
+ * result the parent receives is an INCOMPLETE partial, not a final answer.
+ *
+ * Kept a distinct sentinel (not a provider stop reason) so callers can
+ * recognise it: a clean turn always sets a real terminal message, so this
+ * value only ever appears on a genuinely truncated run.
+ */
+export const STREAM_INCOMPLETE = 'stream_incomplete';
+
+/**
+ * True when `stopReason` indicates the subagent did NOT reach a clean final
+ * answer — it was capped by the tool-use budget or cut off mid-stream. A
+ * `status: 'succeeded'` result with such a stopReason carries partial content
+ * that consumers must NOT present to the parent model as a complete answer.
+ */
+export function isIncompleteStopReason(stopReason: string | undefined): boolean {
+  return stopReason === TOOL_USE_LOOP_CAPPED || stopReason === STREAM_INCOMPLETE;
+}
+
+/**
+ * When a succeeded subagent result is actually an incomplete partial (see
+ * {@link isIncompleteStopReason}), prepend a parent-visible marker so the model
+ * consuming the tool result treats the text as a truncated intermediate finding
+ * rather than a conclusion. No-op for clean completions — returns `content`
+ * unchanged. This is the single consumption-boundary fix for the
+ * "subagent returns a partial result reported as success" class.
+ */
+export function annotateIfIncomplete(content: string, stopReason: string | undefined): string {
+  if (!isIncompleteStopReason(stopReason)) return content;
+  const why =
+    stopReason === TOOL_USE_LOOP_CAPPED
+      ? 'hit its tool-use iteration cap before finishing'
+      : 'was cut off before finishing (its stream ended without a final message)';
+  return (
+    `[⚠ PARTIAL RESULT — the subagent ${why}. The text below is an incomplete ` +
+    `intermediate finding, NOT a final answer; treat it as such.]\n\n${content}`
+  );
+}
 
 export interface SubagentToolCall {
   id: string;

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -13,6 +13,7 @@
 
 import { getSkill } from '../../skills/index.js';
 import { SubagentManager } from '../subagent.js';
+import { annotateIfIncomplete } from '../subagent/result.js';
 import type { AgentModelInput, IAgentSession } from '../types.js';
 import type { ModelProvider } from '../provider.js';
 import type { ToolCall, ToolResult } from './types.js';
@@ -1143,7 +1144,12 @@ export class SkillExecutor {
       // Assign (don't return) so the finally can append the in-turn
       // SubagentStop injectContext after teardown.
       if (result.status === 'succeeded' && result.message) {
-        toolResult = { content: result.message.content };
+        // A `succeeded` result can still be an incomplete partial (capped or
+        // stream-truncated). annotateIfIncomplete prepends a parent-visible
+        // marker in that case and is a no-op for clean completions.
+        toolResult = {
+          content: annotateIfIncomplete(result.message.content, result.stopReason),
+        };
         return toolResult;
       }
 

--- a/src/agent/tools/subagent/foreground-promotion.ts
+++ b/src/agent/tools/subagent/foreground-promotion.ts
@@ -19,6 +19,7 @@
 
 import type { BackgroundAgentRegistry } from '../../background-registry.js';
 import type { SubagentManager } from '../../subagent.js';
+import { annotateIfIncomplete } from '../../subagent/result.js';
 import { debugLog } from '../../../utils/debug.js';
 import type { TraceOrigin, TraceActor } from '../../session/session-identity.js';
 import type { ToolResult } from '../types.js';
@@ -231,7 +232,9 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
       });
       // Assign (don't return) so the finally can append the in-turn
       // SubagentStop injectContext after teardown. See `toolResult` above.
-      toolResult = { content };
+      // annotateIfIncomplete marks capped/stream-truncated partials so the
+      // parent model doesn't treat them as a final answer (no-op if clean).
+      toolResult = { content: annotateIfIncomplete(content, result.stopReason) };
       return toolResult;
     }
 

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -108,6 +108,7 @@ export const SubagentSucceededPayloadSchema = z.object({
   turnCount: z.number().int().nonnegative(),
   totalCostUsd: z.number().nonnegative().optional(),
   outputBytes: z.number().int().nonnegative(),
+  stopReason: z.string().optional(),
 });
 
 export const SubagentFailedPayloadSchema = z.object({

--- a/src/agent/trace/subagent-terminal-seal-race.test.ts
+++ b/src/agent/trace/subagent-terminal-seal-race.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Regression test for M1 — "lost terminal trace event".
+ *
+ * Symptom: a `subagent_lifecycle` `started` event with no matching terminal
+ * event (`succeeded`/`failed`/`cancelled`) — an "orphan" record. Measured at
+ * ~320/1166 subagents, mostly short-lived skill sessions. The subagents ran
+ * fine; only the witness audit record was lost.
+ *
+ * Root cause: the terminal lifecycle emit in `SubagentHandleImpl.run()` was
+ * fire-and-forget (`void emitSubagentLifecycle(...)`). `emitSubagentLifecycle`
+ * internally `await writer.write(...)`, but because the emit itself was not
+ * awaited, `run()` proceeded to `onTerminal()` (which can trigger the owning
+ * session's immediate `writer.seal()`) before the terminal `write()` reached
+ * the writer. `NdjsonTraceWriter.seal()` flips `sealed = true` synchronously
+ * and a subsequent `write()` throws `'trace is sealed; write() rejected'`,
+ * which `emitSubagentLifecycle` swallows — the terminal event is silently lost.
+ *
+ * Fix: `await` the terminal emit in `run()` (success and catch paths) so the
+ * event is enqueued+persisted on the writer's FIFO queue BEFORE `onTerminal()`
+ * can seal.
+ *
+ * Invariant locked here: `handle.runToResult(...)` (equivalently `run()`) does
+ * NOT resolve until the terminal `subagent_lifecycle` event has been durably
+ * written. Concretely — if the owning session seals its trace the instant
+ * `runToResult` resolves, the terminal event still survives ahead of the seal.
+ *
+ * Determinism note: with the REAL writer, `void emit`'s `writer.write()` call
+ * runs synchronously and enqueues the append onto the FIFO queue before the
+ * caller can seal, so a naive "await runToResult → await seal → assert present"
+ * test is GREEN on both the buggy and fixed code — it does not lock the fix.
+ * The production race only manifests when the terminal write reaches the writer
+ * *late* (real async scheduling delays it past the moment `seal()` flips
+ * `sealed`). We reproduce that gap DETERMINISTICALLY with a thin proxy writer
+ * (`DeferringTraceWriter`) whose `write()` yields to a macrotask before
+ * delegating to a real `NdjsonTraceWriter.write()`. `emitSubagentLifecycle`,
+ * `writer.seal()`, and `writer.write()` themselves are UNMODIFIED — only the
+ * *arrival time* of the write at the writer is delayed, exactly as it is in
+ * production. Under this proxy:
+ *   - buggy `void` code: run() returns before the deferred write lands; the
+ *     owning session seals; the late write() throws → swallowed → event LOST.
+ *   - fixed `await` code: run() awaits the emit → the deferred write completes
+ *     and persists BEFORE run() returns; the seal comes after → event PRESENT.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { mkdtemp, readFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { IAgentSession, Message, OutputEvent } from '../types.js';
+import { SubagentHandleImpl } from '../subagent/handle.js';
+import { AbortGraph } from '../abort-graph.js';
+import { NdjsonTraceWriter } from './writer.js';
+import type { TraceWriter } from './index.js';
+import type { SessionSealedPayload, TraceEventInput } from './types.js';
+
+/**
+ * Wraps a real {@link NdjsonTraceWriter} but defers each `write()` to a
+ * macrotask before delegating. This models the production timing gap where the
+ * terminal lifecycle write reaches the writer AFTER the owning session has
+ * begun sealing — the exact window the M1 bug lived in. `seal()`/`close()` are
+ * NOT deferred (a real teardown seals promptly), so a `write()` that was fired
+ * fire-and-forget lands after `sealed` has flipped and is rejected — precisely
+ * the lost-event path. Delegates to the unmodified real writer for all durable
+ * behavior; only arrival timing is altered.
+ */
+class DeferringTraceWriter implements TraceWriter {
+  constructor(private readonly inner: NdjsonTraceWriter) {}
+
+  async write(event: TraceEventInput): Promise<void> {
+    // Yield to a macrotask so the caller's synchronous continuation (and, in
+    // the buggy fire-and-forget path, the owning session's immediate seal) runs
+    // before the real write is even attempted.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    return this.inner.write(event);
+  }
+
+  getTracePath(): string {
+    return this.inner.getTracePath();
+  }
+
+  async seal(payload: SessionSealedPayload): Promise<void> {
+    return this.inner.seal(payload);
+  }
+
+  async close(): Promise<void> {
+    return this.inner.close();
+  }
+}
+
+function mockSucceedingSession(finalMessage: Message): IAgentSession {
+  const events: OutputEvent[] = [
+    { type: 'message', message: finalMessage },
+    { type: 'done', metadata: { stopReason: 'end_turn' } },
+  ];
+  return {
+    sessionId: 'mock-session',
+    state: 'idle',
+    abortSignal: new AbortController().signal,
+    async sendMessage() {
+      return finalMessage;
+    },
+    async *sendMessageStream() {
+      for (const e of events) yield e;
+    },
+    async interrupt() {},
+    async close() {},
+    async reset() {},
+    async setModel() {},
+    async setPermissionMode() {},
+    waitForInitialization: async () => ({
+      sessionId: 'mock-session',
+      model: 'test-model',
+      persistSession: true,
+    }),
+    getSessionIdentity: () => ({ persistSession: true }),
+    getSessionMetadata: () => ({
+      sessionId: 'mock-session',
+      model: 'test-model',
+      persistSession: true,
+    }),
+    getQuery: () => {
+      throw new Error('not implemented');
+    },
+    getLastResponseMetadata: () => null,
+    getOutputStream: async function* () {},
+    getInputStreamRef: () => ({ pushUserMessage: vi.fn() }),
+    supportedCommands: async () => [],
+    supportedModels: async () => [],
+    supportedAgents: async () => [],
+    getContextUsage: async () => ({ contextLimitTokens: 0, contextUsedTokens: 0 }),
+    mcpServerStatus: async () => [],
+    accountInfo: async () => ({ name: 'test', email: 'test@example.com' }),
+  } as unknown as IAgentSession;
+}
+
+describe('M1 — terminal subagent_lifecycle survives an immediate seal', () => {
+  it('persists the succeeded event before the owning session seals (deferred-write race)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'afk-trace-seal-race-'));
+    try {
+      const inner = new NdjsonTraceWriter({ traceDir: dir });
+      // Deferring proxy reproduces the production timing gap deterministically.
+      const writer = new DeferringTraceWriter(inner);
+
+      const graph = new AbortGraph();
+      const controller = new AbortController();
+      graph.register('root', controller);
+
+      const finalMessage: Message = {
+        role: 'assistant',
+        content: 'subagent result',
+        timestamp: new Date(),
+      };
+      const session = mockSucceedingSession(finalMessage);
+
+      const handle = new SubagentHandleImpl(
+        'sa-seal-race',
+        session,
+        controller,
+        graph,
+        undefined, // outputSchema
+        5000, // timeoutMs
+        undefined, // hookRegistry
+        vi.fn(), // onTerminal
+        undefined, // parentInputStreamRef
+        undefined, // parentAbortSignal
+        undefined, // agentType
+        undefined, // progressSink
+        undefined, // parentId
+        writer, // traceWriter
+      );
+
+      const result = await handle.runToResult('go');
+      expect(result.status).toBe('succeeded');
+
+      // Owning session seals the instant runToResult resolves — the exact race
+      // window. With the buggy `void` emit the terminal write is still in-flight
+      // (deferred) and lands after `sealed` flips, so it is rejected+swallowed.
+      // With the awaited fix it has already been persisted.
+      await writer.seal({
+        status: 'succeeded',
+        finalCostUsd: 0,
+        finalTurnCount: 1,
+        closedAt: new Date().toISOString(),
+      });
+
+      const content = await readFile(join(dir, 'trace.jsonl'), 'utf8');
+      const lines = content
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((l) => JSON.parse(l) as { kind: string; payload: Record<string, unknown> });
+
+      const succeeded = lines.find(
+        (l) => l.kind === 'subagent_lifecycle' && l.payload['transition'] === 'succeeded',
+      );
+
+      expect(
+        succeeded,
+        'terminal subagent_lifecycle.succeeded must be persisted before the seal (M1 regression)',
+      ).toBeDefined();
+      expect(succeeded?.payload['subagentId']).toBe('sa-seal-race');
+
+      // And it must precede the terminal session_sealed record on disk.
+      const succeededIdx = lines.findIndex(
+        (l) => l.kind === 'subagent_lifecycle' && l.payload['transition'] === 'succeeded',
+      );
+      const sealedIdx = lines.findIndex((l) => l.kind === 'session_sealed');
+      expect(succeededIdx).toBeGreaterThanOrEqual(0);
+      expect(sealedIdx).toBeGreaterThan(succeededIdx);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -177,6 +177,13 @@ export interface SubagentSucceededPayload {
   turnCount: number;
   totalCostUsd?: number;
   outputBytes: number;
+  /**
+   * Terminal stop reason for the subagent's final turn, when known. Present so
+   * a trace reader can distinguish a clean completion from a capped/truncated
+   * partial (`tool_use_loop_capped` / `stream_incomplete`) that was surfaced
+   * with `succeeded` status. Absent when the provider reported no stop reason.
+   */
+  stopReason?: string;
 }
 
 export interface SubagentFailedPayload {

--- a/src/cli/commands/interactive/bg-result-notifier.ts
+++ b/src/cli/commands/interactive/bg-result-notifier.ts
@@ -34,6 +34,7 @@ import type {
   BackgroundAgentRegistry,
   BackgroundJob,
 } from '../../../agent/background-registry.js';
+import { annotateIfIncomplete } from '../../../agent/subagent/result.js';
 import { env } from '../../../config/env.js';
 import { formatDuration } from '../../format-utils.js';
 
@@ -85,7 +86,9 @@ function extractOutput(job: BackgroundJob): string {
     return `Subagent failed — ${errText}${partial}`;
   }
   const raw = result.message?.content;
-  if (typeof raw === 'string') return raw;
+  // A `completed` background job can still carry an incomplete partial (capped
+  // or stream-truncated); mark it so the injected result isn't read as final.
+  if (typeof raw === 'string') return annotateIfIncomplete(raw, result.stopReason);
   if (raw !== undefined) return JSON.stringify(raw);
   return '';
 }


### PR DESCRIPTION
## Problem

A subagent run that either (a) hits the tool-use loop cap or (b) ends mid-stream — an abort, or an abnormal/early provider-stream close — resolves with `status: 'succeeded'` while carrying only **partial** assistant content. The `stopReason` plumbing to detect this already existed (`SubagentResult.stopReason`, `handle.ts` `lastStopReason`), but **no consumer read it**, so every parent-facing surface handed the partial to the parent model as a clean, complete answer.

Observed across witness traces: `succeeded` results with tiny output (58–142 B), including `turnCount: 0` runs and one that ran ~2.1 h before returning 99 B — all surfaced as success.

Two triggers:
- **Cap:** the tool-use wind-down can produce a ~142-byte "capped" marker returned as success.
- **Stream truncation:** a mid-stream abort / early clean close yields accumulated text but no final `message` event, and returns as success.

## Fix

**Producer** (`handle.ts`): the stream-truncated path now sets a synthetic `STREAM_INCOMPLETE` stop reason, and the terminal stop reason is recorded on the `subagent.succeeded` trace event (`trace/events.ts`, `trace/types.ts`) for forensics.

**Consumer** (`result.ts`): new `annotateIfIncomplete(content, stopReason)` prepends a parent-visible marker —
`[⚠ PARTIAL RESULT — the subagent … an incomplete intermediate finding, NOT a final answer …]` — and is a **no-op for clean completions**. Wired into all four parent-facing surfaces:

- skill tool — `skill-executor.ts`
- foreground agent — `foreground-promotion.ts`
- compose DAG node — `dag-subagent.ts` (**text branch only**, never structured `output`)
- background delivery — `bg-result-notifier.ts`

Internal skill-phase parsers (`mint` / `diagnose` / `heal`) are **deliberately not** annotated — a prepended banner would corrupt their content parsing.

## Tests / verification
- New unit tests for `isIncompleteStopReason` / `annotateIfIncomplete` (`result.test.ts`, +9).
- `tsc --noEmit` clean (strict config).
- Full suite green (11,109 passed) on current `main`.

## Scope
Addresses the **partial-as-success (correctness)** defect only. A separate, independent observability bug — lost terminal trace events producing "orphan" subagent records (fire-and-forget `emitSubagentLifecycle` racing an awaited `seal()`) — is **not** in this PR; it is the follow-up **stacked** PR.
