### PR TITLE
refactor(models): generalize o-series predicate to reasoning-model contract

### DIFF
--- a/src/agent/model-capabilities.test.ts
+++ b/src/agent/model-capabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterAll } from 'vitest';
-import { supportsVision, isOSeriesModel } from './model-capabilities.js';
+import { supportsVision, isOSeriesModel, isReasoningModel } from './model-capabilities.js';
 import { resetSlotBindings } from './session/model-slots.js';
 
 describe('supportsVision', () => {
@@ -110,5 +110,50 @@ describe('isOSeriesModel', () => {
     for (const m of ['gpt-4o', 'gpt-4o-mini', 'claude-sonnet-4', 'codex', 'ollama', 'mixtral-8x7b', '', undefined]) {
       expect(isOSeriesModel(m)).toBe(false);
     }
+  });
+});
+
+describe('isReasoningModel', () => {
+  // isReasoningModel is a superset of isOSeriesModel — every o-series id is a
+  // reasoning model, but so are the gpt-5.x ids that replace them.
+
+  it('matches all o-series models (delegates to isOSeriesModel)', () => {
+    for (const m of ['o1', 'o1-mini', 'o3', 'o3-mini', 'o4-mini', 'o5']) {
+      expect(isReasoningModel(m), m).toBe(true);
+    }
+  });
+
+  it('matches gpt-5.x reasoning models (the non-o-series families)', () => {
+    for (const m of ['gpt-5', 'gpt-5.1', 'gpt-5.5', 'gpt-5-mini', 'gpt-5-codex']) {
+      expect(isReasoningModel(m), m).toBe(true);
+    }
+  });
+
+  it('strips provider/ prefix for gpt-5.x ids', () => {
+    expect(isReasoningModel('openai/gpt-5')).toBe(true);
+    expect(isReasoningModel('openrouter/gpt-5.5')).toBe(true);
+  });
+
+  it('is case-insensitive and tolerates whitespace', () => {
+    expect(isReasoningModel('GPT-5')).toBe(true);
+    expect(isReasoningModel('  gpt-5.1  ')).toBe(true);
+  });
+
+  it('does NOT match classic chat models (gpt-4o, gpt-4.1, claude, local)', () => {
+    for (const m of ['gpt-4o', 'gpt-4o-mini', 'gpt-4.1', 'gpt-4.1-mini', 'claude-sonnet-4', 'codex', 'ollama', 'mixtral-8x7b', '', undefined]) {
+      expect(isReasoningModel(m), m).toBe(false);
+    }
+  });
+
+  it('is a strict superset of isOSeriesModel', () => {
+    // Every o-series id must also be a reasoning model.
+    const oSeriesIds = ['o1', 'o1-mini', 'o3', 'o3-mini', 'o4-mini', 'openai/o3'];
+    for (const m of oSeriesIds) {
+      expect(isOSeriesModel(m)).toBe(true);
+      expect(isReasoningModel(m)).toBe(true);
+    }
+    // But gpt-5.x is reasoning without being o-series.
+    expect(isOSeriesModel('gpt-5')).toBe(false);
+    expect(isReasoningModel('gpt-5')).toBe(true);
   });
 });

--- a/src/agent/model-capabilities.ts
+++ b/src/agent/model-capabilities.ts
@@ -126,13 +126,27 @@ export function supportsVision(model: string | undefined): boolean {
 }
 
 /**
+ * Normalize a model id for family matching: strip a leading `provider/` segment
+ * (OpenRouter-style ids such as `openai/o3`) and lower-case + trim it. Shared by
+ * the family predicates below so `openai/o3`, `  O3  `, and `o3` all classify
+ * identically. Because the result is already lower-cased, the predicates' regex
+ * patterns do not need the `/i` flag.
+ */
+function bareModelId(model: string): string {
+  const trimmed = model.trim().toLowerCase();
+  return trimmed.includes('/') ? trimmed.slice(trimmed.lastIndexOf('/') + 1) : trimmed;
+}
+
+/**
  * Detect OpenAI o-series reasoning models — o1, o3, o4, and any future `oN`.
  *
- * Single source of truth for o-series classification, consumed by the provider
- * router (`providers/index.ts`), context/output token sizing
- * (`model-limits.ts`), and the openai-compatible provider's request shaping
- * (`query/model-params.ts` — which re-exports it under the same name for
- * backward compatibility — and `oneshot.ts`).
+ * This is the *id-family* predicate — it answers "is this an o-series id?" — and
+ * is the single source of truth consumed by the provider router
+ * (`providers/index.ts`) and token sizing (`model-limits.ts`) to route bare
+ * o-series ids to the openai-compatible provider. For the *request contract*
+ * (which token field / effort param to send) use {@link isReasoningModel}, a
+ * superset that also covers the gpt-5.x models OpenAI names as the o-series
+ * replacements.
  *
  * Robustness the enumerated `startsWith('o1'|'o3'|'o4')` copies lacked:
  *   - matches ANY `o<digit>` prefix, so o5/o6/… are covered without edits;
@@ -146,7 +160,39 @@ export function supportsVision(model: string | undefined): boolean {
  */
 export function isOSeriesModel(model: string | undefined): boolean {
   if (!model) return false;
-  const trimmed = model.trim();
-  const bare = trimmed.includes('/') ? trimmed.slice(trimmed.lastIndexOf('/') + 1) : trimmed;
-  return /^o[0-9]/i.test(bare);
+  return /^o[0-9]/.test(bareModelId(model));
+}
+
+/**
+ * Reasoning-model id families *beyond* the o-series (which {@link isOSeriesModel}
+ * already covers). These speak OpenAI's reasoning request contract on Chat
+ * Completions: they reject `max_tokens` (requiring `max_completion_tokens`) and
+ * accept `reasoning_effort` — the inverse of the classic chat models (gpt-4o,
+ * gpt-4.1, …) which want `max_tokens` and ignore effort.
+ *
+ * Kept as a data table (not an enumerated `||` chain) so a new reasoning family
+ * — a future gpt-6, say — is a one-line addition that propagates to every
+ * request-shaping call site at once. Patterns run against the provider-stripped,
+ * lower-cased id from {@link bareModelId}, so no `/i` flag is needed.
+ */
+const REASONING_MODEL_PATTERNS: readonly RegExp[] = [
+  /^gpt-5/, // gpt-5.x line: gpt-5, gpt-5.1, gpt-5.5, gpt-5-mini, gpt-5-codex, …
+];
+
+/**
+ * Detect OpenAI reasoning models — the o-series (o1/o3/o4/oN) *and* the gpt-5.x
+ * line — i.e. every model that requires the `max_completion_tokens` +
+ * `reasoning_effort` request contract rather than plain `max_tokens`.
+ *
+ * Single source of truth for request shaping in the openai-compatible provider:
+ * `query/model-params.ts` (`resolveStreamingMaxTokens`, `resolveReasoningEffort`)
+ * and `oneshot.ts`. A superset of {@link isOSeriesModel}: every o-series id is a
+ * reasoning model, but so are the gpt-5.x ids that replace them. Extend the
+ * non-o-series families via {@link REASONING_MODEL_PATTERNS}.
+ */
+export function isReasoningModel(model: string | undefined): boolean {
+  if (!model) return false;
+  if (isOSeriesModel(model)) return true;
+  const bare = bareModelId(model);
+  return REASONING_MODEL_PATTERNS.some((re) => re.test(bare));
 }

--- a/src/agent/providers/openai-compatible/oneshot.ts
+++ b/src/agent/providers/openai-compatible/oneshot.ts
@@ -18,7 +18,7 @@
 
 import OpenAI from 'openai';
 import { resolveOpenAIAuth } from './auth.js';
-import { isOSeriesModel } from '../../model-capabilities.js';
+import { isReasoningModel } from '../../model-capabilities.js';
 
 /** Test injection hook — supplants the real `OpenAI` constructor. */
 export type OneShotOpenAIClientFactory = (opts: { apiKey: string; baseURL?: string }) => OpenAI;
@@ -70,11 +70,11 @@ export interface OpenAIOneShotInput {
  * Token-limit field: chat models AND local OpenAI-shim runners (MLX,
  * llama.cpp, vLLM, ollama) accept `max_tokens` — and some shims reject the
  * newer `max_completion_tokens` — so `max_tokens` stays the default. The
- * reasoning o-series (o1/o3/o4…) is the inverse: it rejects `max_tokens` with a
- * 400 and requires `max_completion_tokens`. We switch the field only for those,
- * keyed off the bare model id, so an o-series `AFK_SUGGEST_MODEL` override (or
- * an o-series session model inherited as the suggest model) does not 400 on
- * every keystroke.
+ * reasoning models (o-series ∪ gpt-5.x) are the inverse: they reject
+ * `max_tokens` with a 400 and require `max_completion_tokens`. We switch the
+ * field only for those, keyed off the bare model id, so a reasoning-model
+ * `AFK_SUGGEST_MODEL` override (or a reasoning session model inherited as the
+ * suggest model) does not 400 on every keystroke.
  */
 export async function oneShotChatCompletion(input: OpenAIOneShotInput): Promise<string> {
   const { apiKey, baseURL, model, system, user, maxTokens = 64, signal, clientFactory } = input;
@@ -89,11 +89,11 @@ export async function oneShotChatCompletion(input: OpenAIOneShotInput): Promise<
   const factory = clientFactory ?? oneShotClientFactory;
   const client = factory ? factory(clientOpts) : new OpenAI(clientOpts);
 
-  // o-series reasoning models reject `max_tokens` and require
+  // Reasoning models (o-series ∪ gpt-5.x) reject `max_tokens` and require
   // `max_completion_tokens`; everything else (chat models + local shims) wants
   // `max_tokens`. Classification (incl. `provider/`-prefix strip) is shared —
-  // see `isOSeriesModel` in model-capabilities.ts.
-  const tokenLimit = isOSeriesModel(model)
+  // see `isReasoningModel` in model-capabilities.ts.
+  const tokenLimit = isReasoningModel(model)
     ? { max_completion_tokens: maxTokens }
     : { max_tokens: maxTokens };
 

--- a/src/agent/providers/openai-compatible/query/model-params.ts
+++ b/src/agent/providers/openai-compatible/query/model-params.ts
@@ -1,6 +1,6 @@
 /**
  * Model-shape parameter helpers for the openai-compatible provider: output-
- * token cap resolution, o-series detection, and effort→reasoning_effort
+ * token cap resolution, reasoning-model detection, and effort→reasoning_effort
  * mapping. Pure functions extracted from `query.ts` so the query module
  * carries only the session class and its turn loop.
  *
@@ -9,7 +9,7 @@
 
 import type { EffortLevel } from '../../../types/sdk-types.js';
 import { maxOutputTokensFor } from '../../../model-limits.js';
-import { isOSeriesModel } from '../../../model-capabilities.js';
+import { isOSeriesModel, isReasoningModel } from '../../../model-capabilities.js';
 
 /**
  * Resolve the effective output-token cap (a plain number).
@@ -37,9 +37,9 @@ export function resolveEffectiveMaxOutputTokens(
 /**
  * Resolve the **Chat Completions** streaming output-token cap.
  *
- * Mirrors the o-series field-selection logic in `oneshot.ts:91–96`:
- * o-series reasoning models (o1/o3/o4…) reject `max_tokens` and require
- * `max_completion_tokens`; everything else (chat models, local shims)
+ * Mirrors the reasoning-model field-selection logic in `oneshot.ts`: reasoning
+ * models (o-series ∪ gpt-5.x) reject `max_tokens` and require
+ * `max_completion_tokens`; everything else (classic chat models, local shims)
  * wants `max_tokens`.  (The Responses API is different again — it uses
  * `max_output_tokens` — so this helper is Chat-Completions-only.)
  *
@@ -51,7 +51,7 @@ export function resolveStreamingMaxTokens(
   configMaxOutput: number | undefined,
 ): Record<string, number> {
   const effectiveMax = resolveEffectiveMaxOutputTokens(model, configMaxOutput);
-  return isOSeriesModel(model)
+  return isReasoningModel(model)
     ? { max_completion_tokens: effectiveMax }
     : { max_tokens: effectiveMax };
 }
@@ -61,11 +61,12 @@ export function normalizePermissionMode(mode: string | undefined): string {
 }
 
 /**
- * Re-exported for backward compatibility — `query.ts` re-exports it and older
- * call sites import it from here. Canonical definition (incl. o5+/`oN` and
- * `provider/`-prefix handling) now lives in `model-capabilities.ts`.
+ * Re-exported for backward compatibility — `query.ts` re-exports these and older
+ * call sites import them from here. Canonical definitions live in
+ * `model-capabilities.ts`: `isOSeriesModel` (id family → routing) and
+ * `isReasoningModel` (request contract → o-series ∪ gpt-5.x).
  */
-export { isOSeriesModel };
+export { isOSeriesModel, isReasoningModel };
 
 /**
  * Map AFK's `EffortLevel` to OpenAI's `reasoning_effort` values.
@@ -87,7 +88,7 @@ export function mapEffortForOpenAI(effort: EffortLevel): 'low' | 'medium' | 'hig
 
 /**
  * Resolve the `reasoning_effort` to send for a given model + effort config.
- * Returns `undefined` when effort should not be forwarded (non-o-series model
+ * Returns `undefined` when effort should not be forwarded (non-reasoning model
  * or no effort configured). Callers attach the result to the request body
  * under `reasoning_effort` (Chat Completions) or `reasoning.effort` (Responses).
  */
@@ -96,6 +97,6 @@ export function resolveReasoningEffort(
   model: string,
 ): 'low' | 'medium' | 'high' | undefined {
   if (effort === undefined) return undefined;
-  if (!isOSeriesModel(model)) return undefined;
+  if (!isReasoningModel(model)) return undefined;
   return mapEffortForOpenAI(effort);
 }


### PR DESCRIPTION
## Summary

Generalizes the o-series-specific request-shaping predicate to cover **all reasoning models** — the o-series (o1/o3/o4) **and** the gpt-5.x line that replaces them.

## Motivation

PR #457 consolidated the o-series detection into one predicate (`isOSeriesModel`), which was the right enabling refactor. But the underlying contract — `max_completion_tokens` + `reasoning_effort` on Chat Completions — is **not** o-series-specific; it's the reasoning-model contract. The gpt-5.x models OpenAI designates as o-series replacements need the identical request shape.

Per OpenAI's [live deprecations page](https://platform.openai.com/docs/deprecations) (2026-07-06):
- `o1`, `o1-pro`, `o3-mini`, `o4-mini` retire **2026-10-23**
- `o3`, `o3-pro` retire **2026-12-11**
- All replaced by gpt-5.x

Today, gpt-5.x on the default Chat Completions path (Responses is only for subscription/opt-in) gets `max_tokens` and no effort — a latent gap this PR closes.

## Changes

### `src/agent/model-capabilities.ts`
- **Add `isReasoningModel()`** — superset of `isOSeriesModel()` covering o-series ∪ gpt-5.x
- **`REASONING_MODEL_PATTERNS`** table — extensible for future reasoning families (currently `/^gpt-5/`)
- `isOSeriesModel` kept for routing (used in `providers/index.ts` and `model-limits.ts`)

### `src/agent/providers/openai-compatible/query/model-params.ts`
- `resolveStreamingMaxTokens` uses `isReasoningModel` → gpt-5.x gets `max_completion_tokens`
- `resolveReasoningEffort` uses `isReasoningModel` → gpt-5.x gets `reasoning_effort`

### `src/agent/providers/openai-compatible/oneshot.ts`
- Uses `isReasoningModel` instead of inline regex → one-shot completions work for gpt-5.x

### `src/agent/model-capabilities.test.ts`
- Tests for `isReasoningModel`: o-series delegation, gpt-5.x matching, provider-prefix stripping, case-insensitivity, superset relationship

## Verification

- `pnpm lint` — passes
- `pnpm test` — 596 files, 11110 tests pass (including 20 model-capabilities tests)

## Impact

- **gpt-5.x on Chat Completions**: now gets correct request contract (was broken before)
- **o-series**: behavior unchanged, continues working until 2026-12-11
- **Future reasoning families**: one-line addition to `REASONING_MODEL_PATTERNS` propagates to all call sites

## Migration path

The o-series arm ages out naturally by 2026-12-11 with a one-line deletion from `isOSeriesModel`. The `isReasoningModel` predicate remains for gpt-5.x and future reasoning models.