### PR TITLE
fix(subagent): bound fork wall-clock budget + fail fast on usage-limit pauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Fixed
+- Forked subagents no longer hang their parent indefinitely: every fork now gets a bounded wall-clock budget by default — 20 min foreground (`SUBAGENT_DEFAULT_TIMEOUT_MS`), 60 min background (`SUBAGENT_BACKGROUND_TIMEOUT_MS`) — instead of the unbounded session default. On expiry the child's controller aborts (cascading to descendants) and the parent receives a legible timeout error. Explicit `timeoutMs` wins; `0` restores unbounded.
+- Forked subagents now **fail fast on OAuth usage-limit pauses** (`autoResumeOnUsageLimit` defaults to `false` for forks) instead of silently polling for reset — up to 2 h — while the parent looked frozen. The classified usage-limit error surfaces to the parent, which decides whether to retry, reroute, or surface the pause. Callers may opt a child back in with an explicit `autoResumeOnUsageLimit: true`.
+
 ## [5.25.0] - 2026-07-07
 
 ### Added

--- a/src/agent/subagent.test.ts
+++ b/src/agent/subagent.test.ts
@@ -76,7 +76,12 @@ vi.mock('./session.js', () => {
   return { AgentSession: MockAgentSession };
 });
 
-import { SubagentManager, SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS } from './subagent.js';
+import {
+  SubagentManager,
+  SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS,
+  SUBAGENT_DEFAULT_TIMEOUT_MS,
+  SUBAGENT_BACKGROUND_TIMEOUT_MS,
+} from './subagent.js';
 
 function lastSessionState(): SessionState {
   return shared.sessions[shared.sessions.length - 1].state;
@@ -201,6 +206,31 @@ describe('SubagentManager', () => {
       config: { model: 'sonnet', maxToolUseIterations: 0 },
     });
     expect((shared.lastConfig as unknown as Record<string, unknown>)['maxToolUseIterations']).toBe(0);
+  });
+
+  // Anti-hang (sibling of the iteration cap): a fork that hits an OAuth
+  // usage-limit 429 must FAIL FAST with the classified error, not silently
+  // auto-pause and poll for reset (up to 2h in retry-layer.ts) while its
+  // parent looks frozen. A fork has no human to wait for — the parent decides
+  // what happens next.
+  it('defaults autoResumeOnUsageLimit to false on the child config', async () => {
+    shared.lastConfig = null;
+    const mgr = new SubagentManager();
+    await mgr.forkSubagent({
+      parent: { sessionId: 'p' },
+      config: { model: 'sonnet' },
+    });
+    expect((shared.lastConfig as unknown as Record<string, unknown>)['autoResumeOnUsageLimit']).toBe(false);
+  });
+
+  it('preserves an explicit autoResumeOnUsageLimit: true (unattended flows opt back in)', async () => {
+    shared.lastConfig = null;
+    const mgr = new SubagentManager();
+    await mgr.forkSubagent({
+      parent: { sessionId: 'p' },
+      config: { model: 'sonnet', autoResumeOnUsageLimit: true },
+    });
+    expect((shared.lastConfig as unknown as Record<string, unknown>)['autoResumeOnUsageLimit']).toBe(true);
   });
 
   // Isolation: AFK_MAX_TOOL_USE_ITERATIONS is a TOP-LEVEL-only escape hatch. The
@@ -667,6 +697,59 @@ describe('SubagentManager', () => {
 
       await expect(h.run('slow')).rejects.toThrow(/timed out/);
       expect(signal.aborted).toBe(true);
+    });
+
+    // Anti-hang: forks default to a BOUNDED wall-clock budget. The session
+    // default (DEFAULT_SESSION_TIMEOUT_MS = 0 = unbounded) is correct for
+    // top-level sessions but let a stalled child — provider throttling, a
+    // wedged stream, a slow-grinding tool loop — park its parent at
+    // `await runToResult` indefinitely (observed in production: 4 parallel
+    // children spun 29 minutes under a 429 cascade until manually cancelled).
+    it('pins the fork budget defaults (20 min foreground / 60 min background)', () => {
+      expect(SUBAGENT_DEFAULT_TIMEOUT_MS).toBe(20 * 60_000);
+      expect(SUBAGENT_BACKGROUND_TIMEOUT_MS).toBe(60 * 60_000);
+    });
+
+    it('applies SUBAGENT_DEFAULT_TIMEOUT_MS when child config omits timeoutMs', async () => {
+      vi.useFakeTimers();
+      try {
+        const mgr = new SubagentManager();
+        const h = await mgr.forkSubagent({
+          parent: { sessionId: 'p' },
+          config: { model: 'sonnet' }, // no timeoutMs → fork default applies
+        });
+        // Child never replies within the budget.
+        lastSessionState().replyDelayMs = SUBAGENT_DEFAULT_TIMEOUT_MS + 60_000;
+        const signal = lastSessionAbortSignal();
+
+        const run = h.run('slow');
+        const rejection = expect(run).rejects.toThrow(/timed out after 1200000ms/);
+        await vi.advanceTimersByTimeAsync(SUBAGENT_DEFAULT_TIMEOUT_MS);
+        await rejection;
+        expect(signal.aborted).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('preserves an explicit timeoutMs of 0 (opt back into unbounded)', async () => {
+      vi.useFakeTimers();
+      try {
+        const mgr = new SubagentManager();
+        const h = await mgr.forkSubagent({
+          parent: { sessionId: 'p' },
+          config: { model: 'sonnet', timeoutMs: 0 },
+        });
+        // Reply lands AFTER the would-be default budget — must still succeed.
+        lastSessionState().replyDelayMs = SUBAGENT_DEFAULT_TIMEOUT_MS + 60_000;
+
+        const run = h.run('slow');
+        await vi.advanceTimersByTimeAsync(SUBAGENT_DEFAULT_TIMEOUT_MS + 61_000);
+        const msg = await run;
+        expect(msg.content).toBe('ok:slow');
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -24,7 +24,7 @@ import type { ZodType } from 'zod';
 import { AbortGraph, type ChildAbortedListener } from './abort-graph.js';
 import type { HookRegistry } from './hooks.js';
 import { AgentSession } from './session.js';
-import { DEFAULT_SESSION_TIMEOUT_MS } from './timeout.js';
+
 import type { AgentConfig, IAgentSession } from './types.js';
 import type { ElicitationRequest, ElicitationResult } from './types/sdk-types.js';
 import type { SubagentProgressSink } from './types/session-types.js';
@@ -70,6 +70,36 @@ export const DENY_ELICITATION: NonNullable<AgentConfig['onElicitation']> = async
  * `0` to opt a trusted deep-investigation child back into unbounded mode).
  */
 export const SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS = 50;
+
+/**
+ * Default wall-clock budget applied to every forked subagent turn.
+ *
+ * `DEFAULT_SESSION_TIMEOUT_MS` is `0` (unbounded), which is correct for
+ * top-level sessions — a human owns them — but not for forks: a child stalled
+ * by provider throttling, a wedged stream, or a slow-grinding tool loop parks
+ * its parent at `await runToResult` indefinitely (observed 2026-07-07: four
+ * parallel children spun 29 minutes under a 429 cascade until the operator
+ * manually cancelled). The tool-iteration cap above bounds ROUNDS but not
+ * TIME — throttled rounds can each take minutes. 20 minutes is ~2× the
+ * longest healthy child observed in production traces (~10 min review
+ * agents). On expiry `withTimeout` aborts the child's controller, cascading
+ * through the AbortGraph to its descendants, and the parent receives a
+ * legible TimeoutError tool_result instead of hanging. Callers may override
+ * per-fork via `config.timeoutMs` (`0` restores unbounded).
+ */
+export const SUBAGENT_DEFAULT_TIMEOUT_MS = 20 * 60_000;
+
+/**
+ * Wall-clock budget for BACKGROUND-mode agent dispatches (fire-and-forget
+ * jobs whose results auto-deliver later). Background children don't park
+ * their parent, so the anti-hang pressure is lower — but an unbounded
+ * detached child is still a zombie token-burner when it wedges. 60 minutes
+ * keeps documented "long investigations" viable at 3× the foreground budget
+ * while guaranteeing every fork terminates. Applied by SubagentExecutor
+ * before forking (background mode is executor-level knowledge the manager
+ * doesn't have); explicit `config.timeoutMs` wins, `0` = unbounded.
+ */
+export const SUBAGENT_BACKGROUND_TIMEOUT_MS = 60 * 60_000;
 
 export interface ForkParent {
   sessionId?: string;
@@ -542,6 +572,17 @@ export class SubagentManager {
       // `tool_use_loop_capped` done, returning the child's partial work.
       maxToolUseIterations:
         options.config.maxToolUseIterations ?? SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS,
+      // External constraint (anti-hang, sibling of the cap above): a fork that
+      // hits an OAuth usage-limit 429 otherwise auto-pauses and silently polls
+      // for reset — up to two hours (retry-layer.ts) — with no subagent-level
+      // pause UI, so the parent just looks frozen. A fork has no human to wait
+      // for: fail fast with the classified usage-limit error (the provider
+      // still emits the `paused` event first, then surfaces the error), and
+      // let the PARENT decide whether to retry, reroute to another model, or
+      // surface the pause to its own operator. Callers may opt a child back
+      // into auto-resume with an explicit `autoResumeOnUsageLimit: true`
+      // (e.g. unattended daemon flows that prefer waiting over failing).
+      autoResumeOnUsageLimit: options.config.autoResumeOnUsageLimit ?? false,
       // Awareness metadata: surface parent identity + phase role into the
       // child's config so the get_runtime_state tool's `self` view can report
       // the topology fields. Caller-supplied values on options.config win on
@@ -653,7 +694,9 @@ export class SubagentManager {
       childController,
       this.abortGraph,
       options.outputSchema,
-      options.config.timeoutMs ?? DEFAULT_SESSION_TIMEOUT_MS,
+      // Wall-clock budget for the child's turn (see SUBAGENT_DEFAULT_TIMEOUT_MS
+      // above). Explicit caller values win, including `0` for unbounded.
+      options.config.timeoutMs ?? SUBAGENT_DEFAULT_TIMEOUT_MS,
       registry,
       () => {
         this.active.delete(id);

--- a/src/agent/tools/subagent-executor.test.ts
+++ b/src/agent/tools/subagent-executor.test.ts
@@ -1436,6 +1436,41 @@ describe('SubagentExecutor', () => {
       expect(mockSubagentMgr.forkSubagent).not.toHaveBeenCalled();
     });
 
+    it('mode: "background" widens the fork wall-clock budget to SUBAGENT_BACKGROUND_TIMEOUT_MS', async () => {
+      const { SUBAGENT_BACKGROUND_TIMEOUT_MS } = await import('../subagent.js');
+      const registry = new BackgroundAgentRegistry({});
+      const { handle } = bgHandle();
+      const forkSpy = vi.fn().mockResolvedValue(handle);
+      mockSubagentMgr.forkSubagent = forkSpy;
+
+      const ctxWithBg: SubagentExecutorContext = {
+        subagentManager: mockSubagentMgr as any,
+        parentSession: mockParentSession as any,
+        defaultConfig: mockConfig,
+        backgroundRegistry: registry,
+        depth: 0,
+      };
+      const bgExecutor = new SubagentExecutor(ctxWithBg);
+      await bgExecutor.execute(
+        makeCall({ input: { prompt: 'long investigation', mode: 'background' } }),
+      );
+
+      expect(forkSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ timeoutMs: SUBAGENT_BACKGROUND_TIMEOUT_MS }),
+        }),
+      );
+    });
+
+    it('foreground dispatch leaves timeoutMs unset so the manager fork default governs', async () => {
+      const forkSpy = mockSubagentMgr.forkSubagent as ReturnType<typeof vi.fn>;
+      await executor.execute(makeCall({ input: { prompt: 'quick check' } }));
+
+      expect(forkSpy).toHaveBeenCalledTimes(1);
+      const forkArg = forkSpy.mock.calls[0]![0] as { config: AgentConfig };
+      expect(forkArg.config.timeoutMs).toBeUndefined();
+    });
+
     it('mode: "background" with no registry: returns error and tears down the orphan handle', async () => {
       const { handle, teardownMock } = bgHandle();
       mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -8,7 +8,7 @@
  * @module agent/tools/subagent-executor
  */
 
-import { SubagentManager } from '../subagent.js';
+import { SubagentManager, SUBAGENT_BACKGROUND_TIMEOUT_MS } from '../subagent.js';
 import { BackgroundAgentRegistry } from '../background-registry.js';
 import type { ModelProvider } from '../provider.js';
 import type { AgentModelInput, IAgentSession } from '../types.js';
@@ -484,6 +484,16 @@ export class SubagentExecutor implements SubagentControl {
       ...(this.ctx.parentModel !== undefined ? { parentModel: this.ctx.parentModel } : {}),
       createChildExecutor: (childCtx) => new SubagentExecutor(childCtx),
     });
+
+    // Background dispatches get a wider wall-clock budget than the foreground
+    // default the manager applies (SUBAGENT_DEFAULT_TIMEOUT_MS): they don't
+    // park the parent turn, and the tool description invites "long
+    // investigations". Still bounded — a wedged detached child must not burn
+    // tokens forever. Guarded so an explicit caller-supplied budget (via
+    // AgentConfig.timeoutMs on SDK-level dispatch paths) always wins.
+    if (parsed.mode === 'background' && childConfig.timeoutMs === undefined) {
+      childConfig.timeoutMs = SUBAGENT_BACKGROUND_TIMEOUT_MS;
+    }
 
     let handle: Awaited<ReturnType<SubagentManager['forkSubagent']>>;
     try {


### PR DESCRIPTION
## Problem

A forked subagent could park its parent turn **indefinitely**:

1. **No wall-clock bound.** The fork path inherited the session default `timeoutMs` (`DEFAULT_SESSION_TIMEOUT_MS = 0` = unbounded). The raw `agent`-tool path additionally opts out of the 50-round iteration cap by design (`child-config.ts`: default `0` = unlimited rounds), so nothing bounded a child in time.
2. **Silent usage-limit pause.** A child that hit an OAuth usage-limit 429 auto-paused and silently polled for reset — up to **2 hours** (`retry-layer.ts`) — because `autoResumeOnUsageLimit` defaulted `?? true` with no per-fork override and no subagent-level pause UI.

Observed 2026-07-07 (v5.25.0): four parallel `agent` dispatches spun **29 minutes** under a 429 cascade — actively grinding tools, invisible in the witness trace — until the operator manually cancelled (#400's cancel seam worked; the hang itself had no fix).

## Fix

Two defaults at the `forkSubagent` chokepoint, same pattern as #394 — every fork path (agent / skill / compose / DAG) funnels through it, and no executor passes `timeoutMs` today:

- **`SUBAGENT_DEFAULT_TIMEOUT_MS` (20 min)** applied at handle construction when the caller omits `timeoutMs`. On expiry `withTimeout` aborts the child's controller — cascading through the `AbortGraph` to descendants — and the parent receives a legible `TimeoutError` tool_result instead of hanging. 20 min ≈ 2× the longest healthy child observed in production traces (~10 min review agents). Explicit `timeoutMs` wins; `0` restores unbounded.
- **`SUBAGENT_BACKGROUND_TIMEOUT_MS` (60 min)** — `SubagentExecutor` widens the budget for `mode: 'background'` dispatches before forking: they don't park the parent and the tool description invites long investigations, but a wedged detached child must still terminate.
- **`autoResumeOnUsageLimit: false` for forks** (childConfig default; explicit `true` opts back in). A fork has no human to wait for: the provider emits the `paused` event, then surfaces the classified usage-limit error to the parent — which decides whether to retry, reroute to another model, or surface the pause to its own operator. Top-level sessions are unchanged.

## Tests

- Fork default + explicit override + `0` opt-out for **both** knobs; the budget is covered behaviorally with fake timers (default fires at exactly 1,200,000 ms and aborts the child signal; `timeoutMs: 0` survives past the would-be budget).
- Executor: background dispatch widens to `SUBAGENT_BACKGROUND_TIMEOUT_MS`; foreground leaves `timeoutMs` unset so the manager default governs.
- Full suite **11,117 passed / 0 failed**; `tsc --noEmit` clean (strict).

## Scope / follow-ups (not in this PR)

- Threading `traceWriter` through the `agent`-tool path so child activity/backoff is visible in the witness trace (skill path already threads it).
- ESC-cancel input-lag on the slow subagent-settle window (compositor work, separate PR).
- Pairs well with #461 — a timed-out child's partial output gets the `[⚠ PARTIAL]` annotation once that lands.