### PR TITLE
fix(trace): make agent-tool and compose forks visible in the witness trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Fixed
+- `agent`-tool and `compose` subagents are now visible in the witness trace (`afk trace show`). Three gaps closed: (1) `forkSubagent` resolves the trace writer as per-fork config → manager-level writer, so the `subagent_lifecycle` started/succeeded/failed/cancelled events and the handle's writer no longer silently drop when inheritance came from the manager; (2) the REPL/chat/Telegram root managers and compose executors now carry the session trace writer; (3) the writer chains through nested child managers (depth ≥ 2 `agent` forks), mirroring the existing `cwd` chain. Previously a raw `agent` dispatch produced zero trace events between `tool_call started` and `completed` — a stuck child was indistinguishable from a never-started one.
+
 ## [5.25.1] - 2026-07-07
 
 ### Fixed

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -477,6 +477,18 @@ export class SubagentManager {
     const registry =
       options.config.hookRegistry ?? this.hookRegistry ?? options.parent.hookRegistry;
 
+    // Witness-writer resolution: explicit per-fork config wins, then the
+    // manager-level writer (constructed at the surface bootstrap). This is
+    // the SINGLE resolved value used by every witness touchpoint in this
+    // fork path — SubagentStart dispatch, the child handle, and the
+    // subagent_lifecycle 'started' emit below. Before this, those three
+    // read `options.config.traceWriter` directly, so a fork relying on
+    // manager-level inheritance (the `agent`-tool path — its executors
+    // never set config.traceWriter) produced a child whose entire lifetime
+    // was invisible in `afk trace show` even though childConfig inherited
+    // the writer for the session's own events.
+    const effectiveTraceWriter = options.config.traceWriter ?? this.parentTraceWriter;
+
     // SubagentStart fires BEFORE session creation so a block truly prevents
     // the child from existing. Abort precedence is honored via rootController.
     if (registry) {
@@ -489,7 +501,7 @@ export class SubagentManager {
         },
         {
           signal: this.rootController.signal,
-          ...(options.config.traceWriter ? { traceWriter: options.config.traceWriter } : {}),
+          ...(effectiveTraceWriter ? { traceWriter: effectiveTraceWriter } : {}),
         },
       );
     }
@@ -716,8 +728,11 @@ export class SubagentManager {
       // traceWriter: child shares the parent's writer so its SubagentStop
       // hook decision lands in the same trace file. Contract:
       // docs/philosophy/afk-contract.md — "a child sub-agent inherits its
-      // parent's witness." Inheritance is config-driven via childConfig.
-      options.config.traceWriter,
+      // parent's witness." Resolved once above (per-fork config →
+      // manager-level writer) so the handle's terminal lifecycle emits
+      // pair with the 'started' emit below even when inheritance came
+      // from the manager rather than the per-fork config.
+      effectiveTraceWriter,
       // onSubagentSucceeded: propagate completion data to the parent
       // session's session_sealed rollup accumulators.
       this.onSubagentSucceededCb,
@@ -736,7 +751,7 @@ export class SubagentManager {
     const modelString = typeof options.config.model === 'string'
       ? options.config.model
       : JSON.stringify(options.config.model);
-    void emitSubagentLifecycle(options.config.traceWriter, {
+    void emitSubagentLifecycle(effectiveTraceWriter, {
       transition: 'started',
       subagentId: id,
       parentId: options.parent.sessionId ?? this.rootId,

--- a/src/agent/tools/compose-executor.test.ts
+++ b/src/agent/tools/compose-executor.test.ts
@@ -1034,6 +1034,32 @@ describe('ComposeExecutor', () => {
     });
   });
 
+  describe('witness trace threading', () => {
+    // Regression: compose DAG nodes never set config.traceWriter, so without
+    // manager-level threading their subagent_lifecycle events silently
+    // no-op'd — every compose fan-out was invisible in `afk trace show`.
+    it('seeds ctx.traceWriter into the SubagentManager so DAG nodes emit lifecycle events', async () => {
+      mockRunSubagentDAG.mockResolvedValue({ outputs: { a: 'ok' }, failed: [], skipped: [] });
+      const traceWriter = { write: vi.fn(async () => undefined) };
+      const executor = new ComposeExecutor(
+        makeContext({ traceWriter: traceWriter as never }),
+      );
+
+      await executor.execute(makeCall({ nodes: [{ id: 'a', prompt: 'task a' }] }));
+
+      expect((lastManagerOpts as { traceWriter?: unknown })?.traceWriter).toBe(traceWriter);
+    });
+
+    it('omits traceWriter when ctx.traceWriter is undefined', async () => {
+      mockRunSubagentDAG.mockResolvedValue({ outputs: { a: 'ok' }, failed: [], skipped: [] });
+      const executor = new ComposeExecutor(makeContext());
+
+      await executor.execute(makeCall({ nodes: [{ id: 'a', prompt: 'task a' }] }));
+
+      expect((lastManagerOpts as { traceWriter?: unknown })?.traceWriter).toBeUndefined();
+    });
+  });
+
   describe('max_tool_calls_per_node enforcement', () => {
     it('installs a progressSink on the SubagentManager when budget is set', async () => {
       mockRunSubagentDAG.mockResolvedValue({ outputs: { a: 'ok' }, failed: [], skipped: [] });

--- a/src/agent/tools/compose-executor.ts
+++ b/src/agent/tools/compose-executor.ts
@@ -17,6 +17,7 @@ import { providerForModel } from '../providers/index.js';
 import type { DAGEdge, DAGRunResult } from '../dag.js';
 import type { AgentModelInput, IAgentSession } from '../types.js';
 import type { Surface } from '../awareness/types.js';
+import type { TraceWriter } from '../trace/index.js';
 import type { ToolCall, ToolResult } from './types.js';
 import { appendRoutingDecision } from '../routing-telemetry.js';
 import { deriveOrigin, actorFromDepth } from '../session/session-identity.js';
@@ -98,6 +99,14 @@ export interface ComposeExecutorContext {
    * behavior).
    */
   cwd?: string;
+  /**
+   * Witness-layer trace writer inherited from the owning surface. Seeded into
+   * the per-call {@link SubagentManager} so every compose DAG node emits
+   * `subagent_lifecycle` events into the session trace. Without it, compose
+   * nodes are invisible in `afk trace show` — same gap as the raw `agent`
+   * tool path; see SubagentExecutorContext.traceWriter.
+   */
+  traceWriter?: TraceWriter;
   /**
    * User-facing surface of the session that owns this executor
    * (cli/telegram/daemon). Recorded as `origin` on compose routing-decision
@@ -578,6 +587,10 @@ export class ComposeExecutor {
       // setCwd). Without this the manager's parentCwd is undefined and nodes
       // fall back to the host's process.cwd() (subagent.ts fork fallback).
       ...(this.currentCwd !== undefined ? { cwd: this.currentCwd } : {}),
+      // Witness layer: manager-level writer so every DAG node fork emits
+      // subagent_lifecycle events into the session trace (compose nodes never
+      // set config.traceWriter). See ComposeExecutorContext.traceWriter.
+      ...(this.ctx.traceWriter !== undefined ? { traceWriter: this.ctx.traceWriter } : {}),
     });
 
     const startedAt = Date.now();

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -663,6 +663,10 @@ export class SkillExecutor {
       // Forward cwd so the grandchild executor's own childManager (when it
       // recursively constructs one for great-grandchild forks) is also cwd-anchored.
       ...(this.currentCwd !== undefined ? { cwd: this.currentCwd } : {}),
+      // Witness layer: forward the trace writer so the grandchild executor's
+      // own childManager (depth-2+ `agent` forks under this skill child) emits
+      // subagent_lifecycle events into the session trace. Mirrors cwd above.
+      ...(this.ctx.traceWriter !== undefined ? { traceWriter: this.ctx.traceWriter } : {}),
       // Invariant: background dispatch requires the registry to be present
       // in every SubagentExecutor in the chain — root → skill-forked child →
       // skill-forked grandchild. Without forwarding, a plugin skill's

--- a/src/agent/tools/subagent-executor.test.ts
+++ b/src/agent/tools/subagent-executor.test.ts
@@ -1252,6 +1252,54 @@ describe('SubagentExecutor', () => {
       expect(capturedChildExecutorCtx!.cwd).toBe('/tmp/wt/feat-x');
     });
 
+    // Witness-trace propagation through the `agent` tool's recursive nesting —
+    // same shape as the cwd chain above. Without ctx.traceWriter, the per-call
+    // childManager had no writer and depth-2+ `agent` forks emitted zero
+    // subagent_lifecycle events (invisible in `afk trace show`).
+    it('forwards ctx.traceWriter to childManager and recursive child executor (depth ≥ 2 visibility)', async () => {
+      let capturedChildExecutorCtx: SubagentExecutorContext | undefined;
+
+      const handle = mockHandle();
+      const manager = {
+        forkSubagent: vi.fn().mockResolvedValue(handle),
+        teardownAll: vi.fn().mockResolvedValue(undefined),
+      };
+      const traceWriter = {
+        write: vi.fn(async () => undefined),
+        getTracePath: () => 'in-memory://trace',
+      };
+
+      const factory = vi.fn().mockImplementation(({ childExecutor }: { childExecutor: SubagentExecutor }) => {
+        capturedChildExecutorCtx = (childExecutor as any).ctx as SubagentExecutorContext;
+        return { name: 'p', query: vi.fn() };
+      });
+
+      const exec = new SubagentExecutor({
+        subagentManager: manager as any,
+        parentSession: {
+          sessionId: 'root',
+          getInputStreamRef: vi.fn(),
+          abortSignal: new AbortController().signal,
+        },
+        defaultConfig: { apiKey: 'k', systemPrompt: 'sp' },
+        childProviderFactory: factory,
+        depth: 0,
+        maxDepth: DEFAULT_MAX_NESTING_DEPTH,
+        traceWriter: traceWriter as never,
+      });
+
+      await exec.execute(makeCall());
+
+      expect(capturedChildExecutorCtx).toBeDefined();
+      // (1) childManager carries the writer so depth-2 forks emit lifecycle events.
+      const childManager = capturedChildExecutorCtx!.subagentManager as unknown as {
+        parentTraceWriter: unknown;
+      };
+      expect(childManager.parentTraceWriter).toBe(traceWriter);
+      // (2) the recursive executor received it, so the chain holds depth-3+.
+      expect(capturedChildExecutorCtx!.traceWriter).toBe(traceWriter);
+    });
+
     // setCwd re-anchors mid-session (born-named `afk -w` worktree on turn 1):
     //   (1) the root manager (depth-1 forks) is re-anchored via manager.setCwd
     //   (2) the depth-2+ childManager built in execute() uses the new cwd

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -23,6 +23,7 @@ import type { AgentRegistry, RegisteredAgent } from '../agents/index.js';
 import type { SkillExecutor } from './skill-executor.js';
 import { stripEscapeSequences } from '../../utils/terminal-sanitize.js';
 import type { Surface } from '../awareness/types.js';
+import type { TraceWriter } from '../trace/index.js';
 import { deriveOrigin, actorFromDepth, type TraceOrigin, type TraceActor } from '../session/session-identity.js';
 import { parseAgentInput, type AgentInput, type AgentExecutionMode } from './subagent/input-parse.js';
 import { emitTelemetry, truncate } from './subagent/failure-payload.js';
@@ -137,6 +138,17 @@ export interface SubagentExecutorContext {
    * applies.
    */
   cwd?: string;
+  /**
+   * Witness-layer trace writer inherited from the owning surface. Forwarded
+   * into the per-call child {@link SubagentManager} built by
+   * `buildChildConfig` so depth ≥ 2 `agent` forks (a depth-1 subagent calling
+   * the `agent` tool) emit `subagent_lifecycle` events into the same trace
+   * file as the root session. Depth-1 forks are covered separately by the
+   * root manager's own manager-level writer (bootstrap/chat/telegram wiring);
+   * this field closes the same gap for the nested managers, mirroring how
+   * `cwd` chains through every depth.
+   */
+  traceWriter?: TraceWriter;
   /**
    * Tool allowlist to propagate to grandchild providers when this executor
    * is itself a read-only skill's child. Forwarded into `childProviderFactory`
@@ -482,6 +494,7 @@ export class SubagentExecutor implements SubagentControl {
       ...(this.ctx.readOnlyBash !== undefined ? { readOnlyBash: this.ctx.readOnlyBash } : {}),
       ...(this.ctx.agentRegistry !== undefined ? { agentRegistry: this.ctx.agentRegistry } : {}),
       ...(this.ctx.parentModel !== undefined ? { parentModel: this.ctx.parentModel } : {}),
+      ...(this.ctx.traceWriter !== undefined ? { traceWriter: this.ctx.traceWriter } : {}),
       createChildExecutor: (childCtx) => new SubagentExecutor(childCtx),
     });
 

--- a/src/agent/tools/subagent/child-config.test.ts
+++ b/src/agent/tools/subagent/child-config.test.ts
@@ -27,6 +27,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import { buildChildConfig, type BuildChildConfigArgs } from './child-config.js';
+import { InMemoryTraceWriter } from '../../trace/writer.js';
 import type { AgentInput } from './input-parse.js';
 import type { RegisteredAgent } from '../../agents/index.js';
 import type { ModelProvider } from '../../provider.js';
@@ -307,6 +308,51 @@ describe('buildChildConfig', () => {
       );
       const mgr = childManager as unknown as { parentCwd: string | undefined };
       expect(mgr.parentCwd).toBe('/tmp/wt/feat-y');
+    });
+
+    // Regression: depth-2+ `agent` forks were invisible in the witness trace —
+    // the nested child manager was built without a traceWriter and agent-tool
+    // dispatches never set config.traceWriter, so subagent_lifecycle emits
+    // no-op'd. traceWriter must chain like cwd: into the nested manager AND
+    // into the recursive child executor ctx (for depth-3+).
+    it('forwards traceWriter to the child manager and the recursive executor ctx', () => {
+      const traceWriter = new InMemoryTraceWriter();
+      let capturedCtx: SubagentExecutorContext | undefined;
+      const childProviderFactory = vi.fn(() => mockProvider());
+      const createChildExecutor = vi.fn((ctx: SubagentExecutorContext) => {
+        capturedCtx = ctx;
+        return stubChildExecutor();
+      });
+      const { childManager } = buildChildConfig(
+        baseArgs({
+          depth: 0,
+          maxDepth: 3,
+          traceWriter,
+          childProviderFactory,
+          createChildExecutor,
+        }),
+      );
+      const mgr = childManager as unknown as {
+        parentTraceWriter: { write: unknown } | undefined;
+      };
+      expect(mgr.parentTraceWriter).toBe(traceWriter);
+      expect(capturedCtx).toBeDefined();
+      expect(capturedCtx!.traceWriter).toBe(traceWriter);
+    });
+
+    it('omits traceWriter from the child manager and executor ctx when unset', () => {
+      let capturedCtx: SubagentExecutorContext | undefined;
+      const childProviderFactory = vi.fn(() => mockProvider());
+      const createChildExecutor = vi.fn((ctx: SubagentExecutorContext) => {
+        capturedCtx = ctx;
+        return stubChildExecutor();
+      });
+      const { childManager } = buildChildConfig(
+        baseArgs({ depth: 0, maxDepth: 3, childProviderFactory, createChildExecutor }),
+      );
+      const mgr = childManager as unknown as { parentTraceWriter: unknown };
+      expect(mgr.parentTraceWriter).toBeUndefined();
+      expect(capturedCtx!.traceWriter).toBeUndefined();
     });
 
     it('skips nesting (no child manager, no provider) at the depth cap', () => {

--- a/src/agent/tools/subagent/child-config.ts
+++ b/src/agent/tools/subagent/child-config.ts
@@ -37,6 +37,7 @@ import type { RegisteredAgent } from '../../agents/index.js';
 import type { AgentRegistry } from '../../agents/index.js';
 import type { SkillExecutor } from '../skill-executor.js';
 import type { Surface } from '../../awareness/types.js';
+import type { TraceWriter } from '../../trace/index.js';
 import type { SubagentExecutor, SubagentExecutorContext } from '../subagent-executor.js';
 import type { AgentInput } from './input-parse.js';
 
@@ -69,6 +70,16 @@ export interface BuildChildConfigArgs {
   readOnlyBash?: boolean;
   agentRegistry?: AgentRegistry;
   parentModel?: AgentModelInput;
+  /**
+   * Witness-layer trace writer inherited from the dispatching executor.
+   * Applied at TWO points so nested `agent` forks stay visible in
+   * `afk trace show`:
+   *   1. the depth-2+ child {@link SubagentManager} (manager-level
+   *      inheritance → subagent_lifecycle events for grandchild forks), and
+   *   2. the recursive child executor's ctx (so the chain holds to maxDepth,
+   *      mirroring `cwd`).
+   */
+  traceWriter?: TraceWriter;
   /**
    * Construct the recursive child executor. Injected by the owning
    * `SubagentExecutor.execute()` as `(ctx) => new SubagentExecutor(ctx)` so
@@ -255,6 +266,11 @@ export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigRe
     childManager = new SubagentManager({
       parentAbortSignal: signal,
       ...(currentCwd !== undefined ? { cwd: currentCwd } : {}),
+      // Witness layer: without this, depth-2+ `agent` forks emit no
+      // subagent_lifecycle events — the nested manager had no writer and
+      // agent-tool dispatches never set config.traceWriter. Mirrors the
+      // cwd chaining above; see BuildChildConfigArgs.traceWriter.
+      ...(args.traceWriter !== undefined ? { traceWriter: args.traceWriter } : {}),
     });
     childParentSession = createStubParentSession(signal) as ChildParentSession;
     const childExecutor = createChildExecutor({
@@ -278,6 +294,9 @@ export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigRe
       // ITS own childManager for depth-3+ forks, also receives cwd. The
       // chain holds for arbitrary depth up to maxDepth.
       ...(currentCwd !== undefined ? { cwd: currentCwd } : {}),
+      // Forward the trace writer for the same reason — the child executor's
+      // own childManager (depth-3+) needs it. See BuildChildConfigArgs.
+      ...(args.traceWriter !== undefined ? { traceWriter: args.traceWriter } : {}),
       // Propagate read-only constraints so depth ≥ 2 forks (this depth-1
       // child calling the `agent` tool) keep the same tool allowlist and
       // bash gate that the originating read-only skill imposed.

--- a/src/agent/trace/subagent-lifecycle.test.ts
+++ b/src/agent/trace/subagent-lifecycle.test.ts
@@ -161,6 +161,67 @@ describe('subagent_lifecycle trace events', () => {
       await new Promise((resolve) => setImmediate(resolve));
       expect(writer.events).toHaveLength(0);
     });
+
+    // Regression: the `agent`-tool path never sets config.traceWriter — its
+    // forks relied on manager-level inheritance, which only reached the
+    // child session's own events, NOT the lifecycle emits or the handle.
+    // Result: raw agent dispatches were invisible in `afk trace show`
+    // (the 2026-07-06 stuck-subagent incident's forensic dead end).
+    // forkSubagent now resolves effectiveTraceWriter = config → manager.
+    it('inherits the manager-level writer when config.traceWriter is unset', async () => {
+      const writer = new InMemoryTraceWriter();
+      const mgr = new SubagentManager({ traceWriter: writer });
+      const handle = await mgr.forkSubagent({
+        parent: { sessionId: 'parent-mgr' },
+        config: { model: 'sonnet' }, // no per-fork traceWriter — the agent-tool shape
+        idPrefix: 'agent-tool',
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const started = writer.events.find(
+        (e) => e.kind === 'subagent_lifecycle' && e.payload.transition === 'started',
+      );
+      if (started?.kind !== 'subagent_lifecycle' || started.payload.transition !== 'started') {
+        throw new Error('expected started event via manager-level writer');
+      }
+      expect(started.payload.subagentId).toBe(handle.id);
+      expect(started.payload.parentId).toBe('parent-mgr');
+    });
+
+    it('manager-level writer also covers the handle terminal emits (succeeded)', async () => {
+      const writer = new InMemoryTraceWriter();
+      const mgr = new SubagentManager({ traceWriter: writer });
+      const handle = await mgr.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'sonnet' }, // no per-fork traceWriter
+      });
+      await handle.run('hi');
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const transitions = writer.events
+        .filter((e) => e.kind === 'subagent_lifecycle')
+        .map((e) => (e.kind === 'subagent_lifecycle' ? e.payload.transition : ''));
+      expect(transitions).toContain('started');
+      expect(transitions).toContain('succeeded');
+    });
+
+    it('per-fork config.traceWriter wins over the manager-level writer', async () => {
+      const managerWriter = new InMemoryTraceWriter();
+      const forkWriter = new InMemoryTraceWriter();
+      const mgr = new SubagentManager({ traceWriter: managerWriter });
+      await mgr.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'sonnet', traceWriter: forkWriter },
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(
+        forkWriter.events.some(
+          (e) => e.kind === 'subagent_lifecycle' && e.payload.transition === 'started',
+        ),
+      ).toBe(true);
+      expect(managerWriter.events).toHaveLength(0);
+    });
   });
 
   describe('succeeded', () => {

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -451,6 +451,10 @@ export function registerChatCommand(program: Command): void {
           // bash/grep run in the isolated tree, not the Node host's
           // process.cwd().
           ...(worktreeCwd !== undefined ? { cwd: worktreeCwd } : {}),
+          // Witness layer: manager-level writer so `agent`-tool forks (which
+          // never set config.traceWriter) emit subagent_lifecycle events and
+          // hand the writer to their handles. Mirrors bootstrap.ts.
+          ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
         });
 
         // Pass openaiBaseUrl so OpenAI-routed children point at the
@@ -551,6 +555,9 @@ export function registerChatCommand(program: Command): void {
           // `inherit` anchor for named-agent model resolution.
           agentRegistry,
           parentModel: options.model,
+          // Witness layer: thread the writer so depth ≥ 2 `agent` forks stay
+          // visible in the trace. Mirrors bootstrap.ts.
+          ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
         });
 
         const skillExecutor = new SkillExecutor({
@@ -595,6 +602,8 @@ export function registerChatCommand(program: Command): void {
           // Session identity for routing-decision rows (afk chat → cli).
           surface: 'cli',
           depth: 0,
+          // Witness layer: DAG nodes emit subagent_lifecycle into the session trace.
+          ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
         });
 
         sharedMemoryStore = new MemoryStore();

--- a/src/cli/commands/farm.ts
+++ b/src/cli/commands/farm.ts
@@ -361,11 +361,10 @@ export async function runFarm(opts: RunFarmOptions): Promise<void> {
   // Contract: surface 'cli' is the correct origin for `afk farm` — it is a
   // CLI batch command whose workers should resolve to origin='cli', matching
   // `afk chat` / `afk interactive`. Worker sessions forked via runSubagentDAG
-  // inherit the writer through SubagentManager once SubagentManager gains
-  // manager-level traceWriter inheritance (tracked as a follow-up: the
-  // `dag-subagent.ts` forkSubagent path does not yet forward traceWriter from
-  // SubagentManagerOptions into child AgentConfigs the way apiKey/baseUrl/cwd
-  // do; adding that inheritance is the remaining gap).
+  // inherit the writer through SubagentManager's manager-level traceWriter
+  // inheritance: childConfig inherits it for session events, and forkSubagent's
+  // effectiveTraceWriter resolution makes the lifecycle emits + handle use the
+  // manager writer too (the former follow-up gap, now closed).
   const trace = createTraceWriterFn();
   const abortController = new AbortController();
   const manager = new SubagentManager({

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -195,6 +195,19 @@ export async function bootstrapSession(
   // sessionRef is populated after the session is constructed below.
   const sessionRef: SessionRef = { current: null! };
 
+  // Witness layer: open trace BEFORE the root SubagentManager and the
+  // executor so (a) the manager inherits the writer — the `agent`-tool path
+  // relies on manager-level inheritance for its forks' lifecycle events
+  // (see forkSubagent's effectiveTraceWriter) — and (b) the
+  // BackgroundAgentRegistry can be constructed with the writer in hand.
+  // The trace path is logged after `bootstrapSession` returns (caller-side
+  // banner), so we open the file here but defer the log line until later
+  // to preserve startup-message ordering.
+  const traceSessionLabel = resumeTarget?.stored?.sessionId;
+  const trace = createDefaultTraceWriter(
+    traceSessionLabel ? { sessionLabel: traceSessionLabel } : {},
+  );
+
   const apiKey = getApiKey();
   const rootManager = new SubagentManager({
     apiKey,
@@ -211,17 +224,12 @@ export async function bootstrapSession(
     // repo and the `read_file` handler returns parent-repo contents instead
     // of the worktree's. Mirrors `chat.ts:163` for the one-shot path.
     ...(extras?.cwd !== undefined ? { cwd: extras.cwd } : {}),
+    // Witness layer: manager-level writer so `agent`-tool forks (which never
+    // set config.traceWriter) still emit subagent_lifecycle events and hand
+    // the writer to their handles. Skill forks already thread it via
+    // SkillExecutorContext; this closes the same gap for raw agent dispatch.
+    ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
   });
-
-  // Witness layer: open trace BEFORE the executor so the
-  // BackgroundAgentRegistry can be constructed with the writer in hand.
-  // The trace path is logged after `bootstrapSession` returns (caller-side
-  // banner), so we open the file here but defer the log line until later
-  // to preserve startup-message ordering.
-  const traceSessionLabel = resumeTarget?.stored?.sessionId;
-  const trace = createDefaultTraceWriter(
-    traceSessionLabel ? { sessionLabel: traceSessionLabel } : {},
-  );
   // Witness layer: trace writer is now live — emit the bootstrap_start marker.
   // (Total bootstrap span is reported by bootstrap_done, measured from the
   // function-entry timestamp captured above.)
@@ -360,6 +368,10 @@ export async function bootstrapSession(
     // anchor for named-agent model resolution.
     agentRegistry,
     parentModel: sessionModel,
+    // Witness layer: thread the writer so depth ≥ 2 `agent` forks (nested
+    // child managers built inside execute()) stay visible in the trace.
+    // Depth-1 forks are covered by rootManager's traceWriter above.
+    ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
   });
 
   const skillExecutor = new SkillExecutor({
@@ -415,6 +427,8 @@ export async function bootstrapSession(
     // Session identity for routing-decision rows (REPL → cli).
     surface: 'cli',
     depth: 0,
+    // Witness layer: DAG nodes emit subagent_lifecycle into the session trace.
+    ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
   });
 
   const sharedMemoryStore = new MemoryStore();

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -264,6 +264,10 @@ async function main() {
           parentModel: sessionConfig.model,
           ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
           ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
+          // Witness layer: manager-level writer so `agent`-tool forks (which
+          // never set config.traceWriter) emit subagent_lifecycle events and
+          // hand the writer to their handles. Mirrors bootstrap.ts / chat.ts.
+          ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}),
         });
 
         const deferredParent = {
@@ -341,6 +345,9 @@ async function main() {
           // Named-agent dispatch: registry + `inherit` anchor.
           agentRegistry,
           parentModel: sessionConfig.model,
+          // Witness layer: thread the writer so depth ≥ 2 `agent` forks stay
+          // visible in the trace. Mirrors bootstrap.ts / chat.ts.
+          ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}),
         });
 
         const skillExecutor = new SkillExecutor({
@@ -378,6 +385,8 @@ async function main() {
           // Session identity for routing-decision rows (Telegram → telegram).
           surface: 'telegram',
           depth: 0,
+          // Witness layer: DAG nodes emit subagent_lifecycle into the session trace.
+          ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}),
         });
 
         const allowedTools = topLevelSurfaceAllowedTools(mcpManager?.getMcpToolWireNames() ?? []);


### PR DESCRIPTION
## Problem

PR 2 of the stuck-subagent fix package (follows #465).

During the 2026-07-06 incident, four `agent`-tool children spun for 29 minutes while `afk trace show` showed **nothing** between `tool_call started` and `completed` — a stuck child was indistinguishable from a never-started one. The doctrine "reach for the witness trace first" failed exactly where it was needed most.

Root cause: three layered gaps —

1. `forkSubagent` read `options.config.traceWriter` directly for the `subagent_lifecycle` emits, the `SubagentStart` hook dispatch, and the handle's writer. The `agent`-tool path never sets a per-fork writer (it relies on manager-level inheritance), so all three silently no-op'd — even though `childConfig` inherited the writer for the child's *own* session events.
2. The top-level root `SubagentManager`s (REPL / `afk chat` / Telegram) were never given the session trace writer, so manager-level inheritance had nothing to inherit.
3. Nested child managers (depth ≥ 2 `agent` forks) and compose DAG managers were constructed with no writer at all.

## Fix

- **`forkSubagent`**: resolve `effectiveTraceWriter = config.traceWriter ?? this.parentTraceWriter` once; use it for `SubagentStart`, the handle, and the `started` emit. Per-fork config still wins.
- **Surfaces**: bootstrap / chat / telegram root managers now receive the session writer (trace creation moved above manager construction in bootstrap.ts). `farm.ts`'s tracked follow-up comment is now resolved by this inheritance.
- **Depth chain**: `SubagentExecutorContext` + `BuildChildConfigArgs` gain `traceWriter`, chained through nested child managers and recursive executors to `maxDepth` — mirroring the existing `cwd` chain. Skill executor forwards it into grandchild executors.
- **Compose**: `ComposeExecutorContext` gains `traceWriter`, seeded into the per-call DAG manager; wired at all three surfaces.

## Tests

- `subagent-lifecycle.test.ts`: manager-level inheritance emits `started` + terminal transitions; per-fork override wins over manager writer; absent-writer no-op preserved.
- `child-config.test.ts`: writer chains into the nested manager AND the recursive executor ctx; omitted cleanly when unset.
- `compose-executor.test.ts`: ctx writer seeds the DAG manager; omitted when unset.
- `subagent-executor.test.ts`: depth ≥ 2 threading (childManager + recursive ctx), same shape as the cwd-chain regression test.

Full suite: **596 files / 11,125 passed**, strict `tsc --noEmit` clean.

## Impact

Next time a subagent stalls, `afk trace show` answers *which child, when it started, and whether it terminated* instead of requiring a forensic dig. Also un-blinds #414's backoff-visibility events on the agent-tool path.

Part of the stuck-subagent fix plan: #465 (budgets, merged) → **this** (visibility) → PR 3 (ESC-cancel input lag).