### PR TITLE
fix(tui): merge post-ESC type-ahead instead of last-wins so soft-stop never drops a typed message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Fixed
+- Messages typed during the ESC soft-stop settle window now **merge** into one next turn instead of last-wins replacement. The #403 coalescing kept only the latest post-ESC message, so a real instruction followed by a "." liveness poke silently dropped the instruction — the "it didn't send" report, round 2. All post-ESC messages now join (newline-separated, attachments concatenated) and run as exactly one next turn; the no-backlog invariant and the pre-ESC queue-preservation contract are unchanged.
+
 ## [5.25.2] - 2026-07-07
 
 ### Fixed

--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -112,9 +112,9 @@ export interface KeyDispatchHost {
    * Snapshot of `pendingSubmissions.length` taken at ESC soft-stop time
    * (handleEscape). Entries at indices `0..softStopQueueBase-1` were queued
    * BEFORE esc and are contract-protected (handleEscape comment lines 318-327):
-   * "Already-queued messages: left untouched." Post-ESC Enters coalesce to
-   * last-wins by truncating back to this base before pushing, so the pre-ESC
-   * queue is never silently dropped.
+   * "Already-queued messages: left untouched." Post-ESC Enters coalesce by
+   * MERGING everything at/above this base into one payload, so neither the
+   * pre-ESC queue nor earlier post-ESC messages are ever silently dropped.
    */
   softStopQueueBase: number;
   /** Hard-abort flag set by Ctrl+C in streaming mode. */
@@ -338,9 +338,9 @@ function handleEscape(self: KeyDispatchHost, key: KeyInfo): boolean {
   // committing it would fling it as a turn the user never submitted. Ctrl+C
   // (handleInterrupt below) follows the same no-auto-commit rule.
   self.softStopped = true;
-  // Snapshot the queue length so post-ESC coalesce (handleEnter) can truncate
-  // back to here — preserving pre-ESC payloads per the contract above —
-  // while still giving last-wins for messages Entered after this ESC.
+  // Snapshot the queue length so post-ESC coalesce (handleEnter) can merge
+  // everything at/above this base — preserving pre-ESC payloads per the
+  // contract above while folding post-ESC messages into one next turn.
   self.softStopQueueBase = self.pendingSubmissions.length;
   if (self.onSoftStop) self.onSoftStop();
   return true;
@@ -486,6 +486,32 @@ function handleVerticalNav(self: KeyDispatchHost, key: KeyInfo): boolean {
     return true;
   }
   return false;
+}
+
+/**
+ * Merge multiple soft-stop-window submissions into ONE payload.
+ *
+ * Texts join with a newline (empty texts skipped) so every post-ESC message
+ * the user typed survives into the single coalesced next turn; attachments
+ * concatenate in submission order. `displayText` merges the same way — it is
+ * emitted only when at least one constituent carried a distinct displayText
+ * (i.e. a paste placeholder was expanded somewhere), mirroring the
+ * "absent when identical" contract on SubmissionPayload.
+ */
+function mergeSubmissionPayloads(payloads: readonly SubmissionPayload[]): SubmissionPayload {
+  if (payloads.length === 1) return payloads[0]!;
+  const text = payloads
+    .map((p) => p.text)
+    .filter((t) => t.length > 0)
+    .join('\n');
+  const attachments = payloads.flatMap((p) => [...p.attachments]);
+  const hasDisplay = payloads.some((p) => p.displayText !== undefined);
+  if (!hasDisplay) return { text, attachments };
+  const displayText = payloads
+    .map((p) => p.displayText ?? p.text)
+    .filter((t) => t.length > 0)
+    .join('\n');
+  return { text, displayText, attachments };
 }
 
 function handleEnter(self: KeyDispatchHost, key: KeyInfo, sequence: string): boolean {
@@ -653,21 +679,30 @@ function handleEnter(self: KeyDispatchHost, key: KeyInfo, sequence: string): boo
   // Each Enter would otherwise push onto the FIFO, which drains ONE payload per
   // turn (the `→ idle` flush), stranding the user one turn behind: the "it
   // doesn't send, then I keep sending characters to catch up" report. So during
-  // a soft-stop we keep only the LATEST post-ESC message (last-wins) — the user's
-  // most recent post-stop intent runs as exactly one next turn, no backlog.
+  // a soft-stop, all post-ESC messages COALESCE into a single payload that runs
+  // as exactly one next turn — no backlog.
+  //
+  // Coalesce = MERGE, not last-wins. The original #403 fix kept only the
+  // latest post-ESC message, which silently DROPPED earlier ones: a user who
+  // typed a real instruction during the settle window and then poked with "."
+  // (because nothing appeared to send) had the instruction replaced by the "."
+  // — the "message → no response → retype it" report, round 2. Merging joins
+  // the post-ESC texts with newlines (and concatenates attachments) so the
+  // user's full post-stop intent survives while the no-backlog invariant —
+  // exactly ONE next turn — still holds.
   //
   // Contract preservation: `softStopQueueBase` was snapshotted by handleEscape
   // at ESC time, capturing the count of pre-ESC payloads already on the FIFO.
-  // Truncating back to that base before pushing preserves those pre-ESC entries
-  // (they drain as their own sequential turns via the `→ idle` flush), so the
+  // Entries below the base are pre-ESC turns and are left untouched (they
+  // drain as their own sequential turns via the `→ idle` flush), so the
   // handleEscape contract — "Already-queued messages: left untouched" — holds.
-  // Array-wide reassignment (`= [payload]`) would silently drop them; truncate-
-  // then-push does not. Normal mid-turn type-ahead (softStopped === false) still
-  // accumulates: sequential-turn delivery is the intended contract there (the
-  // "NO ESC" regression tests).
+  // Only entries at/above the base participate in the merge. Normal mid-turn
+  // type-ahead (softStopped === false) still accumulates: sequential-turn
+  // delivery is the intended contract there (the "NO ESC" regression tests).
   if (self.softStopped) {
+    const postEsc = self.pendingSubmissions.slice(self.softStopQueueBase);
     self.pendingSubmissions.length = self.softStopQueueBase;
-    self.pendingSubmissions.push(payload);
+    self.pendingSubmissions.push(mergeSubmissionPayloads([...postEsc, payload]));
   } else {
     self.pendingSubmissions.push(payload);
   }

--- a/src/cli/terminal-compositor.test.ts
+++ b/src/cli/terminal-compositor.test.ts
@@ -1801,7 +1801,7 @@ describe('TerminalCompositor', () => {
         submitTurn('gamma');
       });
 
-      it('coalesces MULTIPLE messages Entered during ONE soft-stop window (last-wins, no backlog)', async () => {
+      it('coalesces MULTIPLE messages Entered during ONE soft-stop window (merged, no backlog)', async () => {
         // The residual regression the Bug-B fix (see block comment above) did NOT
         // cover: it assumed the synchronous interrupt closes the streaming window
         // at the source. For a SUBAGENT turn that assumption fails —
@@ -1810,7 +1810,9 @@ describe('TerminalCompositor', () => {
         // 'streaming' for seconds. A user who sees no turn start types several
         // messages + Enter; pre-fix each pushed onto the FIFO, which drains ONE
         // per turn → the "it doesn't send, then I keep sending characters to catch
-        // up" report. Post-fix, only the LATEST message survives the window.
+        // up" report. Post-fix, all window messages MERGE into one payload —
+        // last-wins (the original #403 shape) silently dropped the earlier
+        // messages, which users experienced as "it didn't send" all over again.
         const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
         await c.arm();
         c.setInputMode('idle');
@@ -1823,7 +1825,8 @@ describe('TerminalCompositor', () => {
           for (const ch of msg) stdin.emit('keypress', ch, { name: ch, sequence: ch });
           stdin.emit('keypress', undefined, { name: 'return' });
         }
-        // Last-wins: the FIFO holds only the most recent message, not a backlog of 3.
+        // Merged: the FIFO holds ONE payload carrying all three messages,
+        // not a backlog of 3 — and not just the last one.
         expect(c.getPendingCount()).toBe(1);
         expect(c.getBuffer()).toEqual({ text: '', queued: true });
 
@@ -1831,16 +1834,44 @@ describe('TerminalCompositor', () => {
         c.setInputMode('idle');
         expect(c.getPendingCount()).toBe(1);
 
-        // readLine drains the single surviving payload as exactly ONE next turn.
+        // readLine drains the single merged payload as exactly ONE next turn.
         const onSubmit = vi.fn();
         c.setOnSubmit(onSubmit);
         c.setInputMode('idle');
         expect(onSubmit).toHaveBeenCalledTimes(1);
-        expect(onSubmit).toHaveBeenCalledWith({ text: 'third', attachments: [] });
+        expect(onSubmit).toHaveBeenCalledWith({ text: 'first\nsecond\nthird', attachments: [] });
+      });
+
+      it('a "." poke after a real post-ESC message does NOT drop the message (merge, not last-wins)', async () => {
+        // The exact field signature (v5.25.0 postmortem): during a slow
+        // subagent-cancel settle the user types a real instruction + Enter,
+        // sees nothing happen, and pokes with "." + Enter to test liveness.
+        // Under last-wins the "." REPLACED the instruction — silently lost,
+        // user had to retype: "it didn't send" round 2. Under merge, both
+        // survive as one turn.
+        const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
+        await c.arm();
+        c.setInputMode('idle');
+        c.setInputMode('streaming'); // turn arm
+
+        stdin.emit('keypress', undefined, { name: 'escape' });
+        for (const ch of 'fix the bug') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+        stdin.emit('keypress', undefined, { name: 'return' });
+        stdin.emit('keypress', '.', { name: '.', sequence: '.' });
+        stdin.emit('keypress', undefined, { name: 'return' });
+
+        expect(c.getPendingCount()).toBe(1);
+        c.setInputMode('idle'); // dispose → no drain (onSubmit null)
+
+        const onSubmit = vi.fn();
+        c.setOnSubmit(onSubmit);
+        c.setInputMode('idle');
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit).toHaveBeenCalledWith({ text: 'fix the bug\n.', attachments: [] });
       });
 
       it('normal multi-message type-ahead (NO ESC) still accumulates every message (blast-radius guard)', async () => {
-        // The last-wins coalesce fires ONLY under softStopped. Ordinary mid-turn
+        // The merge coalesce fires ONLY under softStopped. Ordinary mid-turn
         // type-ahead must still queue every message for sequential-turn delivery —
         // coalescing here would silently drop queued turns the user intended.
         const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
@@ -1899,7 +1930,7 @@ describe('TerminalCompositor', () => {
 
       it('pre-ESC queued message survives MULTIPLE post-ESC Enters (coalesce replaces only post-ESC entries)', async () => {
         // Same contract as above, but with several post-ESC Enters: the pre-ESC
-        // payload must survive while the post-ESC ones coalesce to last-wins.
+        // payload must survive while the post-ESC ones coalesce into one merged payload.
         const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
         await c.arm();
         c.setInputMode('idle');
@@ -1915,8 +1946,8 @@ describe('TerminalCompositor', () => {
           for (const ch of msg) stdin.emit('keypress', ch, { name: ch, sequence: ch });
           stdin.emit('keypress', undefined, { name: 'return' });
         }
-        // pre-ESC "pre" survives (base=1); three post-ESC Enters coalesce to
-        // last-wins ("post3") → total queue = 2, NOT 1 (pre not dropped) and NOT 4.
+        // pre-ESC "pre" survives (base=1); three post-ESC Enters coalesce into
+        // ONE merged payload → total queue = 2, NOT 1 (pre not dropped) and NOT 4.
         expect(c.getPendingCount()).toBe(2);
 
         c.setInputMode('idle'); // dispose → no drain (onSubmit null)
@@ -1925,8 +1956,8 @@ describe('TerminalCompositor', () => {
         c.setOnSubmit(onSubmit);
         c.setInputMode('idle'); // drain #1 → "pre"
         expect(onSubmit).toHaveBeenCalledWith({ text: 'pre', attachments: [] });
-        c.setInputMode('idle'); // drain #2 → "post3" (last-wins)
-        expect(onSubmit).toHaveBeenNthCalledWith(2, { text: 'post3', attachments: [] });
+        c.setInputMode('idle'); // drain #2 → merged post-ESC intent (nothing dropped)
+        expect(onSubmit).toHaveBeenNthCalledWith(2, { text: 'post1\npost2\npost3', attachments: [] });
       });
 
       it('still auto-flushes normal mid-turn type-ahead (NO ESC) — no regression', async () => {

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -83,9 +83,9 @@ export class TerminalCompositor {
   softStopped = false;
   /**
    * Snapshot of `pendingSubmissions.length` at ESC soft-stop time. Post-ESC
-   * Enters truncate the queue back to this base before pushing, so pre-ESC
+   * Enters merge everything at/above this base into one payload, so pre-ESC
    * payloads are preserved (handleEscape contract) while post-ESC type-ahead
-   * coalesces to last-wins. Reset alongside `softStopped`.
+   * coalesces into a single merged next turn. Reset alongside `softStopped`.
    * @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost).
    */
   softStopQueueBase = 0;


### PR DESCRIPTION
## Problem

PR #403 fixed the post-ESC one-behind backlog with **last-wins** coalescing: during the soft-stop settle window, each Enter replaced the pending post-ESC payload. That prevented the backlog but introduced silent message loss.

Field signature (v5.25.0 postmortem, stuck-subagent session): user ESCs a turn with foreground subagents running → the cancel settle takes tens of seconds (children can sit in the SDK's non-abortable 429 retry sleeps — `client.js` `await sleep()` honors retry-after up to <60s and only observes abort after the sleep) → user types a real instruction + Enter → nothing appears to send → user pokes with `.` + Enter → **the poke replaces the instruction**. The instruction is silently discarded and the user retypes it: "it didn't send," round 2.

## Fix

Coalesce = **merge**, not last-wins (`terminal-compositor.input-dispatch.ts`, handleEnter soft-stop branch):
- All post-ESC submissions (entries at/above `softStopQueueBase`) fold into ONE payload: texts join with newlines, attachments concatenate, `displayText` merges only when a constituent carried one (preserving the "absent when identical" contract).
- **Unchanged invariants:** exactly one next turn drains (no backlog); pre-ESC queue entries below the base are untouched (handleEscape contract); normal NO-ESC type-ahead still accumulates as sequential turns.

## Tests

- Updated both last-wins pins to assert merged text (`first\nsecond\nthird`; `post1\npost2\npost3` after a surviving pre-ESC entry).
- New regression: the exact field signature — `fix the bug` + Enter, then `.` + Enter → one turn with `fix the bug\n.`.
- Pre-ESC preservation guards and NO-ESC blast-radius guards untouched and green.
- Full suite: 596 files, 11,136 passed / 0 failed; `tsc --noEmit` clean.

## Not in scope (deliberate)

The settle window's *length* (SDK-internal retry sleeps are not abort-aware; `maxRetries: 0` + letting the abort-aware retry-layer own replays would fix it) is a separate, larger-blast-radius change — this PR only guarantees nothing typed during that window is lost.

Part 3 of the stuck-subagent fix series (#465 hang bounds → #466 trace visibility → this).