### PR TITLE
fix(trace): thread session surface into fork managers so forked subagents get correct trace origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Fixed
+- Witness-trace `origin` attribution for forked subagents: `agent`-tool and `compose` child (and grandchild) sessions were made trace-visible in #466 but recorded `origin: "unknown"` instead of the owning surface, because the session `surface` was never threaded into the fork managers (only `traceWriter`/`cwd` were). The REPL/chat/Telegram/daemon root managers, the nested depth-2+ child manager, and the compose executor's manager now carry the surface, so forked children inherit the correct `origin` (`cli`/`telegram`/`daemon`) via `forkSubagent`'s `parentSurface` fill — mirroring the existing `farm.ts` pattern. Follow-up to Codex review on #466. (Skill-forked subagents share the same latent gap and are tracked separately.)
+
 ## [5.25.2] - 2026-07-07
 
 ### Fixed

--- a/src/agent/tools/compose-executor.ts
+++ b/src/agent/tools/compose-executor.ts
@@ -591,6 +591,11 @@ export class ComposeExecutor {
       // subagent_lifecycle events into the session trace (compose nodes never
       // set config.traceWriter). See ComposeExecutorContext.traceWriter.
       ...(this.ctx.traceWriter !== undefined ? { traceWriter: this.ctx.traceWriter } : {}),
+      // Origin attribution: thread the surface into the manager so every DAG
+      // node fork inherits the owning surface's origin ('cli'/'telegram'/
+      // 'daemon', not 'unknown') via forkSubagent's parentSurface fill.
+      // this.ctx.surface already drives routing telemetry (deriveOrigin).
+      ...(this.ctx.surface !== undefined ? { surface: this.ctx.surface } : {}),
     });
 
     const startedAt = Date.now();

--- a/src/agent/tools/subagent/child-config.test.ts
+++ b/src/agent/tools/subagent/child-config.test.ts
@@ -355,6 +355,49 @@ describe('buildChildConfig', () => {
       expect(capturedCtx!.traceWriter).toBeUndefined();
     });
 
+    // Regression (PR #466 follow-up): `agent`-tool + compose forks became
+    // trace-visible but were attributed origin:'unknown' because the surface
+    // was never threaded into the fork managers. The nested manager must
+    // inherit the owning surface like traceWriter/cwd, so depth-2+ forks report
+    // the real origin via forkSubagent's parentSurface fill. See
+    // session-identity.ts:deriveOrigin.
+    it('forwards surface to the child manager and the recursive executor ctx', () => {
+      let capturedCtx: SubagentExecutorContext | undefined;
+      const childProviderFactory = vi.fn(() => mockProvider());
+      const createChildExecutor = vi.fn((ctx: SubagentExecutorContext) => {
+        capturedCtx = ctx;
+        return stubChildExecutor();
+      });
+      const { childManager } = buildChildConfig(
+        baseArgs({
+          depth: 0,
+          maxDepth: 3,
+          surface: 'cli',
+          childProviderFactory,
+          createChildExecutor,
+        }),
+      );
+      const mgr = childManager as unknown as { parentSurface: string | undefined };
+      expect(mgr.parentSurface).toBe('cli');
+      expect(capturedCtx).toBeDefined();
+      expect(capturedCtx!.surface).toBe('cli');
+    });
+
+    it('omits surface from the child manager and executor ctx when unset', () => {
+      let capturedCtx: SubagentExecutorContext | undefined;
+      const childProviderFactory = vi.fn(() => mockProvider());
+      const createChildExecutor = vi.fn((ctx: SubagentExecutorContext) => {
+        capturedCtx = ctx;
+        return stubChildExecutor();
+      });
+      const { childManager } = buildChildConfig(
+        baseArgs({ depth: 0, maxDepth: 3, childProviderFactory, createChildExecutor }),
+      );
+      const mgr = childManager as unknown as { parentSurface: unknown };
+      expect(mgr.parentSurface).toBeUndefined();
+      expect(capturedCtx!.surface).toBeUndefined();
+    });
+
     it('skips nesting (no child manager, no provider) at the depth cap', () => {
       const childProviderFactory = vi.fn(() => mockProvider());
       const { childConfig, childManager, childParentSession } = buildChildConfig(

--- a/src/agent/tools/subagent/child-config.ts
+++ b/src/agent/tools/subagent/child-config.ts
@@ -271,6 +271,12 @@ export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigRe
       // agent-tool dispatches never set config.traceWriter. Mirrors the
       // cwd chaining above; see BuildChildConfigArgs.traceWriter.
       ...(args.traceWriter !== undefined ? { traceWriter: args.traceWriter } : {}),
+      // Origin attribution: thread the surface into the nested manager so
+      // depth-2+ `agent` forks inherit the owning surface's origin
+      // ('cli'/'telegram'/'daemon', not 'unknown') via forkSubagent's
+      // parentSurface fill. Mirrors the traceWriter/cwd chaining above and the
+      // recursive child executor ctx below (which already forwards args.surface).
+      ...(args.surface !== undefined ? { surface: args.surface } : {}),
     });
     childParentSession = createStubParentSession(signal) as ChildParentSession;
     const childExecutor = createChildExecutor({

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -455,6 +455,10 @@ export function registerChatCommand(program: Command): void {
           // never set config.traceWriter) emit subagent_lifecycle events and
           // hand the writer to their handles. Mirrors bootstrap.ts.
           ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
+          // Origin attribution: `afk chat` is a `cli` entrypoint. Thread the
+          // surface so forked `agent`-tool children inherit origin 'cli' (not
+          // 'unknown') via forkSubagent's parentSurface fill. Mirrors farm.ts.
+          surface: 'cli',
         });
 
         // Pass openaiBaseUrl so OpenAI-routed children point at the

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -96,6 +96,10 @@ export function buildDaemonSessionFactory(
       parentModel: opts.model,
       ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
       ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+      // Origin attribution: the daemon is a `daemon` entrypoint. Thread the
+      // surface so forked `agent`-tool children inherit origin 'daemon' (not
+      // 'unknown') via forkSubagent's parentSurface fill. Mirrors farm.ts.
+      surface: 'daemon',
     });
 
     const childProviderFactory = createChildProviderFactory(

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -229,6 +229,11 @@ export async function bootstrapSession(
     // the writer to their handles. Skill forks already thread it via
     // SkillExecutorContext; this closes the same gap for raw agent dispatch.
     ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}),
+    // Origin attribution: the REPL is a `cli` entrypoint. Threading the surface
+    // into the manager makes forked `agent`-tool children inherit origin 'cli'
+    // (not 'unknown') via forkSubagent's parentSurface fill — mirrors the
+    // traceWriter/cwd inheritance above and farm.ts. See session-identity.ts.
+    surface: 'cli',
   });
   // Witness layer: trace writer is now live — emit the bootstrap_start marker.
   // (Total bootstrap span is reported by bootstrap_done, measured from the

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -268,6 +268,10 @@ async function main() {
           // never set config.traceWriter) emit subagent_lifecycle events and
           // hand the writer to their handles. Mirrors bootstrap.ts / chat.ts.
           ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}),
+          // Origin attribution: thread the surface so forked `agent`-tool
+          // children inherit origin 'telegram' (not 'unknown') via
+          // forkSubagent's parentSurface fill. Mirrors farm.ts.
+          surface: 'telegram',
         });
 
         const deferredParent = {


### PR DESCRIPTION
## What & why

Follow-up to **#466** (`fix(trace): make agent-tool and compose forks visible in the witness trace`) — addressing the two **P2 findings** Codex left on that PR.

#466 made `agent`-tool and `compose` subagent forks trace-visible, but their `session_init_start` events record **`origin: "unknown"`** instead of the owning surface (`cli` / `telegram` / `daemon`). So the newly-visible sessions are mis-attributed — degrading exactly the attribution #466 set out to add.

## Root cause

The session `surface` is wired onto every **executor** context, but was never threaded into the **`SubagentManager`** constructions that actually fork. So `SubagentManager.parentSurface` was `undefined`, and `forkSubagent`'s origin fill (`subagent.ts:634` — fills child surface from `parentSurface` only when the per-fork config omits it) no-op'd. The child config's `surface` stayed absent, and `deriveOrigin(undefined)` → `'unknown'` (`session-identity.ts:38-53`).

Only `traceWriter` and `cwd` were being chained through the managers — `surface` rode neither rail, even though `farm.ts:378` already demonstrates the correct pattern (`surface: 'cli'` on the manager → workers report `origin='cli'`).

## Fix

Thread the already-known `surface` into every fork-manager construction, mirroring the existing `farm.ts` / `traceWriter` / `cwd` inheritance:

| Site | Surface |
|------|---------|
| `bootstrap.ts` REPL root manager | `cli` |
| `chat.ts` one-shot root manager | `cli` |
| `telegram.ts` bot root manager | `telegram` |
| `daemon.ts` daemon root manager | `daemon` |
| `child-config.ts` nested depth-2+ child manager | inherits `args.surface` |
| `compose-executor.ts` per-run DAG manager | inherits `this.ctx.surface` |

All are one-line additive changes using values already in scope — no new params plumbed. `daemon.ts` was untouched by #466 but carries the identical latent gap; `compose` is in #466's stated scope.

## Tests

Adds two `child-config.test.ts` regression tests mirroring the existing `traceWriter` inheritance tests:
- `forwards surface to the child manager and the recursive executor ctx`
- `omits surface from the child manager and executor ctx when unset`

These guard the depth-2+ nested-manager path (Codex finding #2). Manager→child surface inheritance itself was already covered by `subagent.test.ts:504`.

## Verification

- `tsc --noEmit` (strict) — clean
- Full `vitest` suite — **11137 passed / 0 failed / 14 skipped** (596 files)

## Out of scope (tracked separately)

**Skill-forked** subagents (`skill-executor.ts` managers at `:625/:767/:1011`) share the same latent gap — the surface is threaded onto the child *executor* (`:651`) but not onto the fork *manager*, so skill forks are also `origin: 'unknown'`. This is **pre-existing** (skill forks were trace-visible before #466) and outside both Codex's findings and #466's scope; deferring to a separate change to keep this PR tight.
