### PR TITLE
Fix TUI wrap overflow + bound diagnose verifier fan-out

### DIFF
--- a/src/cli/markdown-stream-format.ts
+++ b/src/cli/markdown-stream-format.ts
@@ -25,7 +25,13 @@ export function renderTextBlock(text: string, contentWidth: number): string {
   if (isMarkdown) {
     return renderMarkdownToTerminal(text, { maxWidth: contentWidth });
   } else {
-    return wrapToWidth(text, contentWidth);
+    // breakLongWords: this output is painted as raw lines by the compositor,
+    // which then hard-wraps at paint time. A soft wrap here leaves a long
+    // unbreakable token (file path, URL) overflowing contentWidth, so the
+    // compositor's row-count math and resize reflow disagree with the stored
+    // line — the persistent-wrap / fucky-on-resize bug. Break here so no
+    // emitted line ever exceeds contentWidth.
+    return wrapToWidth(text, contentWidth, { breakLongWords: true });
   }
 }
 
@@ -58,7 +64,10 @@ export function formatPendingBuffer(
     pendingRender = renderTextBlock(buffer, contentWidth);
   }
 
-  return wrapToWidth(pendingRender, contentWidth);
+  // breakLongWords: same contract as formatBlockForCommit — a long unbreakable
+  // token must not overflow contentWidth, or the live overlay paints past the
+  // right edge and the compositor's row accounting drifts.
+  return wrapToWidth(pendingRender, contentWidth, { breakLongWords: true });
 }
 
 /**
@@ -89,7 +98,16 @@ export function formatBlockForCommit(
   // while leaving table/code lines untouched (they already fit contentWidth).
   // Wrapping after indent (to contentWidth) would re-split structural lines
   // like table borders mid-row.
-  const wrapped = wrapToWidth(rendered, contentWidth);
+  //
+  // breakLongWords: a single unbreakable token wider than contentWidth (a bare
+  // file path or URL — which afk prints constantly) is broken at the column
+  // boundary instead of overflowing. Without it, the committed line exceeds
+  // contentWidth; the compositor then hard-wraps it at a DIFFERENT width at
+  // paint time (committed-band-commit.ts) and band-reflow re-splits the stored
+  // over-wide line on resize — the persistent-wrap / fucky-on-resize bug.
+  // Tables/code that already fit are unaffected (breakLongWords only splits
+  // tokens strictly wider than contentWidth).
+  const wrapped = wrapToWidth(rendered, contentWidth, { breakLongWords: true });
   const indented = applyIndent(wrapped, indentStr);
   // Strip BOTH leading and trailing blank lines. The caller (`commitBlock`)
   // re-adds exactly one trailing blank via `commitAbove(trimmed + '\n\n')`, so

--- a/src/skills/diagnose.test.ts
+++ b/src/skills/diagnose.test.ts
@@ -169,6 +169,23 @@ describe('Diagnose Skill', () => {
       const result = VerificationResultSchema.safeParse(valid);
       expect(result.success).toBe(true);
     });
+
+    it('treats timed_out as optional (absent === not a timeout)', () => {
+      // The verifier subagent reports substantive verdicts only and never emits
+      // timed_out; a plain failure result must parse without it.
+      const withoutFlag = createValidVerificationResult('h1', false);
+      expect(withoutFlag).not.toHaveProperty('timed_out');
+      expect(VerificationResultSchema.safeParse(withoutFlag).success).toBe(true);
+    });
+
+    it('accepts an explicit timed_out flag for wall-clock-exhausted verifiers', () => {
+      // The orchestrator sets timed_out:true when a fork fails with a
+      // TimeoutError, distinguishing it from a genuine falsification.
+      const timedOut = { ...createValidVerificationResult('h1', false), timed_out: true };
+      const parsed = VerificationResultSchema.safeParse(timedOut);
+      expect(parsed.success).toBe(true);
+      if (parsed.success) expect(parsed.data.timed_out).toBe(true);
+    });
   });
 
   describe('DiagnosisResultSchema', () => {

--- a/src/skills/diagnose/_phases/orchestrator.ts
+++ b/src/skills/diagnose/_phases/orchestrator.ts
@@ -35,6 +35,7 @@ import { gitInvestigator } from '../../_agents/git-investigator.js';
 import { vendoredToolAllowlist } from '../../_agents/to-definition.js';
 import { classifyBashCommand } from '../../../agent/tools/readonly-bash.js';
 import { describeSpawnCwdError } from '../../../utils/spawn-cwd-error.js';
+import { TimeoutError } from '../../../utils/errors.js';
 import type {
   DiagnosisResult,
   Hypothesis,
@@ -267,12 +268,19 @@ async function testHypothesisInWorktree(
     const verificationResult = await verifierHandle.runToResult(userPrompt);
 
     if (verificationResult.status !== 'succeeded' || !verificationResult.output) {
+      // A verifier that exhausts VERIFIER_TIMEOUT_MS surfaces here: runToResult
+      // catches the withTimeout rejection internally and returns a failed result
+      // carrying the TimeoutError, rather than throwing into the catch below.
+      // Flag it so the surfaced verification_results distinguish an out-of-time
+      // verifier from one that genuinely falsified the hypothesis — both
+      // otherwise share this exact {predicted_pass:false, confidence:0} shape.
       return {
         hypothesis_id: hypothesis.id,
         predicted_pass: false,
         regressions: [],
         confidence: 0,
         verification_log: `Verification failed: ${describeFailure(verificationResult)}`,
+        timed_out: verificationResult.error instanceof TimeoutError,
       };
     }
 
@@ -287,6 +295,10 @@ async function testHypothesisInWorktree(
       regressions: [],
       confidence: 0,
       verification_log: `Error during verification: ${describeSpawnCwdError(error, repoPath)}`,
+      // Defensive: a timeout normally surfaces via the runToResult-failed path
+      // above (it does not throw), but flag it here too so no timeout escapes
+      // unlabelled if the abort cascade ever rejects into this catch.
+      timed_out: error instanceof TimeoutError,
     };
   } finally {
     // Tear down the verifier handle (fires SubagentStop with the real
@@ -682,6 +694,7 @@ export async function handler(
             verification_log: `Verification worker rejected: ${
               settled.reason instanceof Error ? settled.reason.message : String(settled.reason)
             }`,
+            timed_out: settled.reason instanceof TimeoutError,
           },
   );
 

--- a/src/skills/diagnose/_phases/orchestrator.ts
+++ b/src/skills/diagnose/_phases/orchestrator.ts
@@ -23,6 +23,10 @@ import type { SkillExecutionContext } from '../../index.js';
 import { SubagentManager } from '../../../agent/subagent.js';
 import type { SubagentHandle } from '../../../agent/subagent/handle.js';
 import { runWave } from '../../../agent/subagent/wave.js';
+import {
+  settleWithConcurrencyLimit,
+  DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS,
+} from '../../../agent/concurrency-pool.js';
 import { describeFailure } from '../../../agent/subagent/result.js';
 import type { AgentModelInput, IAgentSession } from '../../../agent/types.js';
 import type { CanUseTool } from '../../../agent/types/sdk-types.js';
@@ -628,21 +632,48 @@ export async function handler(
     };
   }
 
-  const verificationPromises = hypotheses_to_test.map((hypothesis) =>
-    testHypothesisInWorktree(
-      hypothesis,
-      reproduceCommand,
-      parsedInput.repoPath,
-      parentSessionId,
-      verifyPrompt,
-      manager,
-      skillCallId,
-      baseline,
-      subagentModel,
-    ),
+  // Invariant: every subagent fan-out site drains the shared bounded pool, so
+  // no single site can storm memory / the 429 ceiling with unbounded parallel
+  // forks. This verifier wave previously used a raw `Promise.all` — the one
+  // fan-out that bypassed the pool the research wave above (runWave) already
+  // uses. Each verifier forks a full AgentSession that runs tests in an
+  // isolated worktree (the heaviest lane here), so route it through
+  // settleWithConcurrencyLimit too. `testHypothesisInWorktree` never throws
+  // (its try/catch/finally converts every failure into a VerificationResult),
+  // so in practice every settled entry is 'fulfilled'; the 'rejected' arm is a
+  // defensive fallback that preserves array shape + order for the winner
+  // selection below. (Cap is the shared default; per-wave tuning of
+  // concurrency/timeout is a separate cost-budget change, not this one.)
+  const settledVerifications = await settleWithConcurrencyLimit(
+    hypotheses_to_test,
+    DEFAULT_MAX_CONCURRENT_SUBAGENT_CALLS,
+    (hypothesis) =>
+      testHypothesisInWorktree(
+        hypothesis,
+        reproduceCommand,
+        parsedInput.repoPath,
+        parentSessionId,
+        verifyPrompt,
+        manager,
+        skillCallId,
+        baseline,
+        subagentModel,
+      ),
   );
-
-  const verificationResults = await Promise.all(verificationPromises);
+  const verificationResults: VerificationResult[] = settledVerifications.map(
+    (settled, i) =>
+      settled.status === 'fulfilled'
+        ? settled.value
+        : {
+            hypothesis_id: hypotheses_to_test[i]!.id,
+            predicted_pass: false,
+            regressions: [],
+            confidence: 0,
+            verification_log: `Verification worker rejected: ${
+              settled.reason instanceof Error ? settled.reason.message : String(settled.reason)
+            }`,
+          },
+  );
 
   // Phase 5: Select winner. Among hypotheses whose predicted_pass is true with
   // no regressions, take the highest-confidence one (tiebreak); fall back

--- a/src/skills/diagnose/_phases/orchestrator.ts
+++ b/src/skills/diagnose/_phases/orchestrator.ts
@@ -52,6 +52,15 @@ import {
 
 const execFile = promisify(execFileCallback);
 
+// Wall-clock ceiling for a single hypothesis verifier fork. Verification is
+// strictly read-only (createVerifierCanUseTool denies bash/edit/write) — static
+// code-reading of one hypothesis — so it needs far less than the 20-min default
+// subagent ceiling (SUBAGENT_DEFAULT_TIMEOUT_MS). Non-converging verifiers that
+// ran to the 20-min wall (~100k+ tokens each) were a primary driver of the
+// usage-limit burn; 10 min stays generous for read-only work. Per-fork only —
+// this does NOT touch the shared dispatch primitive (that budget is separate).
+const VERIFIER_TIMEOUT_MS = 10 * 60_000;
+
 // ---------------------------------------------------------------------------
 // Tool-permission helpers
 // ---------------------------------------------------------------------------
@@ -237,6 +246,7 @@ async function testHypothesisInWorktree(
         model: subagentModel,
         systemPrompt: `${verifyPrompt}\n\nYou are testing in an isolated worktree at: ${worktreePath}`,
         canUseTool: createVerifierCanUseTool(),
+        timeoutMs: VERIFIER_TIMEOUT_MS,
       },
       idPrefix: `diagnose-verifier-${hypothesis.id}`,
       agentType: `diagnose-verifier-${hypothesis.id}`,

--- a/src/skills/diagnose/_phases/types.ts
+++ b/src/skills/diagnose/_phases/types.ts
@@ -72,6 +72,14 @@ export const VerificationResultSchema = z.object({
   regressions: z.array(z.string()),
   confidence: z.number().min(0).max(1),
   verification_log: z.string(),
+  // Distinguishes a verifier that exhausted its wall-clock budget
+  // (VERIFIER_TIMEOUT_MS) from one that genuinely falsified the hypothesis:
+  // both otherwise collapse to `predicted_pass: false, confidence: 0`, so a
+  // consumer reading only those two fields cannot tell "ran out of time" apart
+  // from "disproven". Optional because the verifier subagent never emits it (it
+  // reports substantive verdicts only), so absent/undefined means "not a
+  // timeout"; the orchestrator sets `true` when a fork fails with a TimeoutError.
+  timed_out: z.boolean().optional(),
 });
 
 export type VerificationResult = z.infer<typeof VerificationResultSchema>;


### PR DESCRIPTION
## Context

Both fixes came out of investigating a session that **burned its usage limit mid-turn**: a `/diagnose` run fanned out ~7 subagents (the verifier lanes each ran to the 20-min ceiling, ~600k+ combined tokens) and blew the cap; because the turn never completed, nothing was committed and `/fork` found 0 turns. The persistent TUI wrap bug that prompted that session was root-caused in the same pass. Three focused fixes:

## 1 · TUI wrap overflow — `79ac764`

Long file paths / URLs overflowed the wrap budget in the streaming markdown formatter. `renderTextBlock`, `formatPendingBuffer`, and `formatBlockForCommit` all called `wrapToWidth` **without** `breakLongWords`, so committed lines ran ~2× past `contentWidth` (probe: **118 cols vs a 58-col budget**). The compositor then `hardWrapToWidth`s them at a *different* width and `band-reflow` re-splits them on resize — the persistent-wrap / "fucky-on-resize" bug. Fix: pass `{ breakLongWords: true }` at the three sinks, matching the sibling renderer at `stream-renderer-orchestrator-emit.ts:375`.

## 2 · Bound the diagnose verifier fan-out — `22ea114`

The Phase-4 verifier wave used a raw `Promise.all` — the one subagent fan-out that bypassed `settleWithConcurrencyLimit`, the shared pool `runWave` (research wave) and every compose/DAG layer already drain. Routed through the pool at the shared default cap. **Structural**: with `maxHypotheses ≤ 4 < cap 8` this doesn't change behavior for a typical run — it closes the unbounded hole and bounds the runaway case. `testHypothesisInWorktree` never throws, so settled entries are always fulfilled; a defensive `rejected` arm preserves array order for winner selection.

## 3 · Cut read-only verifier timeout 20m → 10m — `45ffc54`

Verifiers are strictly read-only (`createVerifierCanUseTool` denies bash/edit/write) — static code-reading of a single hypothesis. The 20-min default subagent ceiling let non-converging verifiers run to the wall (~100k+ tokens each), a primary burn driver. Per-fork `timeoutMs` only (via new `VERIFIER_TIMEOUT_MS`); does **not** touch the shared dispatch primitive.

## Verification

- `tsc --noEmit` clean.
- **489** wrap/markdown/formatter/compositor tests pass (fix 1).
- **118** diagnose tests pass (fixes 2 & 3).

## Deliberately NOT in this PR

The per-turn subagent **spend budget** — the real cost cap that would reach skill fan-outs — is out of scope: it touches the shared dispatch primitive (`SubagentManager.forkSubagent` + `AbortGraph`) and needs a meter-type + default decision (a naive global cap could throttle a legitimate 20-node `compose` DAG). Incremental checkpointing (mid-turn work loss) is likewise deferred. Both are designed in a separate local plan.
