### PR TITLE
fix(tools): #441 robustness cluster — grep cwd-error enrichment, subagent cache invalidation, worktree-root debug log

### DIFF
--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -398,6 +398,12 @@ export class SubagentManager {
    */
   setCwd(cwd: string): void {
     this.parentCwd = cwd;
+    // Invalidate any memoized main-root for this exact path. A worktree can be
+    // deleted and recreated at the SAME path mid-session (sweep + re-create),
+    // which would otherwise hand every subsequent fork a stale mainRoot from
+    // the cache (#441). setCwd is rare (born-named worktree creation on turn 1),
+    // so forcing one re-resolution on the next fork costs nothing.
+    this.worktreeMainRootCache.delete(cwd);
   }
 
   /**

--- a/src/agent/tools/handlers/grep.test.ts
+++ b/src/agent/tools/handlers/grep.test.ts
@@ -714,4 +714,21 @@ describe('grepHandler cwd containment', () => {
     expect(result.isError).toBeFalsy();
     expect(result.content).toContain('hello');
   });
+
+  describe('spawn-cwd error enrichment (#441)', () => {
+    it('names the dead working directory when the spawn cwd was deleted (ENOENT masquerade)', async () => {
+      // Parity with the bash handler: spawning grep with a deleted cwd rejects
+      // as `spawn grep ENOENT` — naming the binary, not the missing dir — so an
+      // agent retries blindly after its worktree was reaped mid-session. The
+      // handler must translate this into an actionable message.
+      const deadCwd = mkdtempSync(join(tmpdir(), 'grep-cwd-dead-'));
+      rmSync(deadCwd, { recursive: true, force: true });
+      const handler = createGrepHandler(deadCwd);
+      const result = await handler({ pattern: 'x', path: deadCwd }, createSignal());
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('working directory does not exist');
+      expect(result.content).toContain(deadCwd);
+      expect(result.content).toContain('deleted worktree?');
+    });
+  });
 });

--- a/src/agent/tools/handlers/grep.test.ts
+++ b/src/agent/tools/handlers/grep.test.ts
@@ -730,5 +730,31 @@ describe('grepHandler cwd containment', () => {
       expect(result.content).toContain(deadCwd);
       expect(result.content).toContain('deleted worktree?');
     });
+
+    it('spawns under context.resolveBase and names IT (not the stale factory cwd) when the re-anchored worktree was deleted (#441 Codex follow-up)', async () => {
+      // Divergence guard: after an in-flight setResolveBase re-anchor, the live
+      // anchor is context.resolveBase while the handler's factory `cwd` is stale.
+      // grep must spawn under — and diagnose against — the SAME effectiveCwd
+      // (context-first, bash parity). Pre-fix, spawn used the (live) factory cwd
+      // and grep merely errored on the missing path arg; the deleted resolveBase
+      // was never surfaced.
+      const liveFactoryCwd = mkdtempSync(join(tmpdir(), 'grep-factory-live-'));
+      const deadResolveBase = mkdtempSync(join(tmpdir(), 'grep-resolvebase-dead-'));
+      rmSync(deadResolveBase, { recursive: true, force: true });
+      try {
+        const handler = createGrepHandler(liveFactoryCwd);
+        const result = await handler(
+          { pattern: 'x', path: '.' },
+          createSignal(),
+          { resolveBase: deadResolveBase } as ToolHandlerContext,
+        );
+        expect(result.isError).toBe(true);
+        expect(result.content).toContain('working directory does not exist');
+        expect(result.content).toContain(deadResolveBase);
+        expect(result.content).toContain('deleted worktree?');
+      } finally {
+        rmSync(liveFactoryCwd, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/src/agent/tools/handlers/grep.ts
+++ b/src/agent/tools/handlers/grep.ts
@@ -152,9 +152,17 @@ export function createGrepHandler(cwd?: string): ToolHandler {
 
     args.push(pattern, path);
 
-    // Scope the spawned grep to the session's worktree. spawn treats
-    // `cwd: undefined` as inherit from process.cwd().
-    const proc = spawn('grep', args, cwd !== undefined ? { cwd } : {});
+    // Effective cwd priority (parity with the bash handler, #441):
+    //   1. context?.resolveBase — permission anchor (updated in place on an
+    //      in-flight setResolveBase re-anchor)
+    //   2. context?.cwd — per-call override (back-compat)
+    //   3. factory-level `cwd` — session worktree isolation (createGrepHandler)
+    // Computed ONCE so the spawn cwd and the ENOENT diagnosis below cannot
+    // disagree: a stale factory `cwd` would otherwise make the diagnosis stat a
+    // different dir than spawn used, reverting to a raw `spawn grep ENOENT`
+    // (Codex P2 on #471). spawn treats `cwd: undefined` as inherit process.cwd().
+    const effectiveCwd = context?.resolveBase ?? context?.cwd ?? cwd;
+    const proc = spawn('grep', args, effectiveCwd !== undefined ? { cwd: effectiveCwd } : {});
 
     let stdout = '';
     let stderr = '';
@@ -307,8 +315,9 @@ export function createGrepHandler(cwd?: string): ToolHandler {
       // reaped mid-session) surfaces as `spawn grep ENOENT` — naming the binary,
       // not the missing dir — so an agent retries blindly. Translate it into an
       // actionable message via statSync on the error path only (no TOCTOU, no
-      // happy-path cost). Parity with the bash handler (#441).
-      const effectiveCwd = context?.resolveBase ?? context?.cwd ?? cwd;
+      // happy-path cost). Diagnoses against the SAME hoisted `effectiveCwd` that
+      // spawn used above, so the two can never stat different dirs (bash parity,
+      // #441).
       let message: string;
       if (effectiveCwd === undefined && isSpawnEnoent(err)) {
         // No explicit cwd was passed, so spawn inherited process.cwd(); that

--- a/src/agent/tools/handlers/grep.ts
+++ b/src/agent/tools/handlers/grep.ts
@@ -23,6 +23,7 @@ import type { ToolHandler, ToolHandlerContext } from '../types.js';
 import { appendRoutingDecision } from '../../routing-telemetry.js';
 import { resolveAndContain } from './_cwd-utils.js';
 import { stripEscapeSequences } from '../../../utils/terminal-sanitize.js';
+import { describeSpawnCwdError, isSpawnEnoent } from '../../../utils/spawn-cwd-error.js';
 
 /**
  * Input shape for the grep tool (validated at runtime).
@@ -302,7 +303,25 @@ export function createGrepHandler(cwd?: string): ToolHandler {
     });
 
     proc.on('error', (err) => {
-      settle({ content: `Failed to execute grep: ${err.message}`, isError: true });
+      // Spawn ENOENT masquerade: a dead working directory (e.g. a git worktree
+      // reaped mid-session) surfaces as `spawn grep ENOENT` — naming the binary,
+      // not the missing dir — so an agent retries blindly. Translate it into an
+      // actionable message via statSync on the error path only (no TOCTOU, no
+      // happy-path cost). Parity with the bash handler (#441).
+      const effectiveCwd = context?.resolveBase ?? context?.cwd ?? cwd;
+      let message: string;
+      if (effectiveCwd === undefined && isSpawnEnoent(err)) {
+        // No explicit cwd was passed, so spawn inherited process.cwd(); that
+        // directory itself can be deleted (same masquerade) — report as such.
+        try {
+          message = describeSpawnCwdError(err, process.cwd());
+        } catch {
+          message = `working directory does not exist (process cwd deleted — deleted worktree?) — underlying: ${err.message}`;
+        }
+      } else {
+        message = describeSpawnCwdError(err, effectiveCwd);
+      }
+      settle({ content: `Failed to execute grep: ${message}`, isError: true });
     });
   });
   };

--- a/src/agent/worktree-read-root.test.ts
+++ b/src/agent/worktree-read-root.test.ts
@@ -102,6 +102,26 @@ describe('resolveWorktreeMainRoot', () => {
     await expect(resolveWorktreeMainRoot(WORKTREE, exec)).resolves.toBeUndefined();
   });
 
+  it('logs the confinement degradation under AFK_DEBUG when git fails (#441)', async () => {
+    // The silent return re-confines a forked child to its worktree with no
+    // signal; under AFK_DEBUG=1 the degradation must be observable so an
+    // unexpectedly-confined subagent is diagnosable.
+    const prev = process.env['AFK_DEBUG'];
+    process.env['AFK_DEBUG'] = '1';
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const root = await resolveWorktreeMainRoot(WORKTREE, failingGit());
+      expect(root).toBeUndefined();
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[worktree-read-root]'),
+      );
+    } finally {
+      logSpy.mockRestore();
+      if (prev === undefined) delete process.env['AFK_DEBUG'];
+      else process.env['AFK_DEBUG'] = prev;
+    }
+  });
+
   it('returns undefined on empty git output', async () => {
     const exec = fakeGit('\n');
     const root = await resolveWorktreeMainRoot(WORKTREE, exec);

--- a/src/agent/worktree-read-root.ts
+++ b/src/agent/worktree-read-root.ts
@@ -51,6 +51,7 @@
 import { execFile as execFileCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import path from 'node:path';
+import { debugLog } from '../utils/debug.js';
 
 const execFilePromise = promisify(execFileCb);
 
@@ -104,8 +105,16 @@ export async function resolveWorktreeMainRoot(
     if (mainRoot === topLevel) return undefined;
 
     return mainRoot;
-  } catch {
-    // Not a git repo, git missing, or any other failure — best-effort.
+  } catch (err) {
+    // Not a git repo, git missing, or any other failure — best-effort. But this
+    // silent return re-confines a forked child to `[worktree]` (the #416
+    // symptom returns) with no signal, so surface the degradation under
+    // AFK_DEBUG=1 — otherwise a subagent that unexpectedly loses main-repo read
+    // access is undiagnosable (#441).
+    debugLog(
+      `[worktree-read-root] git rev-parse failed for cwd=${cwd}; child confined ` +
+        `to worktree only — ${err instanceof Error ? err.message : String(err)}`,
+    );
     return undefined;
   }
 }


### PR DESCRIPTION
## Summary

Addresses **3 of the 5** items in the #441 tracking cluster (*minor tool/subagent/worktree robustness follow-ups*). Each is small, self-contained, and independently landable.

| # | Item | Fix |
|---|------|-----|
| 1 | grep lacks dead-cwd ENOENT enrichment | grep's `proc.on('error')` now runs `describeSpawnCwdError` (parity with the bash handler): a spawn against a reaped worktree reports *"working directory does not exist (deleted worktree?)"* instead of a raw `spawn grep ENOENT` that masquerades as a missing binary. |
| 3 | `worktreeMainRootCache` not invalidated on `setCwd` | `setCwd` now `delete`s the cache entry for the incoming path, so a delete+recreate at the same path mid-session re-resolves instead of returning a stale `mainRoot`. |
| 4 | Silent re-confinement on `git rev-parse` failure | `resolveWorktreeMainRoot`'s catch now emits a `[worktree-read-root]` line via `debugLog` (gated by existing `AFK_DEBUG=1`) so an unexpectedly worktree-confined child is diagnosable. No new env var. |

## Deferred (unchanged; still tracked on #441)

- **Item 2 — `edit_file` read→write TOCTOU.** Needs a staleness-detection design decision (mtime/hash guard + read-receipt semantics); out of scope for this low-risk plumbing PR.
- **Item 5 — global/adaptive rate governor + `compose` `failFast` default.** Design-level change, deliberately excluded.

## Tests

- `grep.test.ts` — new: names the dead working directory when the spawn cwd was deleted (ENOENT masquerade), mirroring the existing bash-handler test.
- `worktree-read-root.test.ts` — new: logs the confinement degradation under `AFK_DEBUG` when git fails.

## Verification

- `pnpm lint` (tsc --noEmit, strict) — clean
- Scoped `vitest run` on grep + worktree-read-root + subagent — **113 passed**
- CI gates: `audit:sdk:check` OK · `audit:env:check` 0 violations · `scan:env:check` in sync

Closes part of #441 (items 1, 3, 4).
