### PR TITLE
fix(cli): space out ⚡ glyph and bp tag in bypass prompt caret

### DIFF
--- a/src/cli/commands/interactive/repl-loop-shared.test.ts
+++ b/src/cli/commands/interactive/repl-loop-shared.test.ts
@@ -2,7 +2,7 @@
  * Tests for buildPrompt (repl-loop-shared.ts).
  *
  * The caret carries the brand plus a compact echo of the non-default
- * permission mode (` ●` / ` ◐` / ` ⚡bp`) — never the worded chip, which lives
+ * permission mode (` ●` / ` ◐` / ` ⚡ bp`) — never the worded chip, which lives
  * on the status line. The echo must stay at the caret because the status
  * row is painted outside the scroll region and never enters scrollback: the
  * prompt is the only mode signal that survives into the linear transcript.

--- a/src/cli/commands/interactive/repl-loop-shared.ts
+++ b/src/cli/commands/interactive/repl-loop-shared.ts
@@ -70,13 +70,13 @@ export function buildPrompt(mode: PermissionMode): string {
   // the security-sensitive mode, and an ASCII token is what lets a post-hoc
   // `grep` of a piped transcript locate the windows where permissions were off
   // (a bare glyph is not reliably searchable). A post-hoc transcript scan
-  // should grep the COMPOUND token `⚡bp` (not a bare `bp`), because bare `bp`
+  // should grep the spaced token `⚡ bp` (not a bare `bp`), because bare `bp`
   // also matches unrelated substrings like "subprocess".
   const base = palette.brand('afk');
   const marker =
     mode === 'plan' ? palette.warning(' ●') :
     mode === 'autonomous' ? palette.info(' ◐') :
-    mode === 'bypassPermissions' ? palette.bypass(' ⚡bp') :
+    mode === 'bypassPermissions' ? palette.bypass(' ⚡ bp') :
     '';
   return base + marker + palette.dim('  › ');
 }


### PR DESCRIPTION
## What
The bypass-mode marker in the interactive REPL prompt caret rendered `⚡bp` — the lightning glyph glued directly to the ASCII `bp` tag with no space, so it looked smashed together. This adds a space → `⚡ bp`, matching the spaced `⚡ bypass` chip already used on the status line.

## Changes
- `src/cli/commands/interactive/repl-loop-shared.ts`: `buildPrompt` bypass marker `' ⚡bp'` → `' ⚡ bp'`; updated grep-rationale comment to reference the new spaced `⚡ bp` token.
- `repl-loop-shared.test.ts`: updated header comment reference; existing assertions (`toContain('⚡')`, `toContain('bp')`, `not.toContain('bypass')`) unchanged and still pass.

## Verification
`pnpm test -- src/cli/commands/interactive/repl-loop-shared.test.ts` passes.