### PR TITLE
fix(agent): cap session-grants.jsonl growth with atomic size trim

### DIFF
--- a/src/agent/log-retention.test.ts
+++ b/src/agent/log-retention.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for capJsonlBySize — best-effort size-cap for append-only JSONL logs.
+ *
+ * Disk tests use a fresh temp dir so they never touch real state files.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, readFile, rm, readdir } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  capJsonlBySize,
+  SESSION_GRANTS_MAX_BYTES,
+  SESSION_GRANTS_KEEP_TAIL_LINES,
+} from './log-retention.js';
+
+let dir: string;
+let file: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'afk-log-retention-'));
+  file = join(dir, 'grants.jsonl');
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+/** Build `n` newline-terminated JSONL records `{"i":<idx>}`. */
+function makeLines(n: number): string {
+  const rows: string[] = [];
+  for (let i = 0; i < n; i++) rows.push(JSON.stringify({ i }));
+  return rows.join('\n') + '\n';
+}
+
+function nonEmptyLines(raw: string): string[] {
+  return raw.split('\n').filter((l) => l.length > 0);
+}
+
+describe('capJsonlBySize', () => {
+  it('is a no-op when the file is under maxBytes', async () => {
+    const content = makeLines(10);
+    await writeFile(file, content);
+    const res = await capJsonlBySize(file, { maxBytes: 1_000_000, keepTailLines: 5 });
+    expect(res).toEqual({ trimmed: false, removedLines: 0 });
+    expect(await readFile(file, 'utf8')).toBe(content);
+  });
+
+  it('is a no-op (never throws) when the file does not exist', async () => {
+    const res = await capJsonlBySize(join(dir, 'missing.jsonl'), {
+      maxBytes: 10,
+      keepTailLines: 5,
+    });
+    expect(res).toEqual({ trimmed: false, removedLines: 0 });
+  });
+
+  it('trims to exactly keepTailLines newest lines when over maxBytes', async () => {
+    await writeFile(file, makeLines(1000));
+    const res = await capJsonlBySize(file, { maxBytes: 100, keepTailLines: 100 });
+    expect(res.trimmed).toBe(true);
+    expect(res.removedLines).toBe(900);
+
+    const out = await readFile(file, 'utf8');
+    const lines = nonEmptyLines(out);
+    expect(lines.length).toBe(100);
+    // Newest kept: first retained record is i=900, last is i=999.
+    expect(JSON.parse(lines[0]!).i).toBe(900);
+    expect(JSON.parse(lines[lines.length - 1]!).i).toBe(999);
+    // Exactly one trailing newline (no doubled or missing terminator).
+    expect(out.endsWith('\n')).toBe(true);
+    expect(out.endsWith('\n\n')).toBe(false);
+  });
+
+  it('drops the OLDEST lines, preserving the recent audit tail', async () => {
+    await writeFile(file, makeLines(50));
+    await capJsonlBySize(file, { maxBytes: 1, keepTailLines: 10 });
+    const ids = nonEmptyLines(await readFile(file, 'utf8')).map((l) => JSON.parse(l).i);
+    expect(ids).toEqual([40, 41, 42, 43, 44, 45, 46, 47, 48, 49]);
+  });
+
+  it('tolerates malformed / non-JSON lines (slices by line, never parses)', async () => {
+    const content = 'not json\n{"a":1}\ngarbage}{\n{"ok":true}\n';
+    await writeFile(file, content);
+    const res = await capJsonlBySize(file, { maxBytes: 1, keepTailLines: 2 });
+    expect(res.trimmed).toBe(true);
+    expect(nonEmptyLines(await readFile(file, 'utf8'))).toEqual(['garbage}{', '{"ok":true}']);
+  });
+
+  it('leaves the file untouched when over bytes but at/under the line budget', async () => {
+    const huge = 'x'.repeat(200);
+    const content = `{"a":"${huge}"}\n{"b":"${huge}"}\n`;
+    await writeFile(file, content);
+    const res = await capJsonlBySize(file, { maxBytes: 10, keepTailLines: 5 });
+    expect(res).toEqual({ trimmed: false, removedLines: 0 });
+    expect(await readFile(file, 'utf8')).toBe(content);
+  });
+
+  it('handles a file with no trailing newline', async () => {
+    await writeFile(file, 'a\nb\nc\nd\ne'); // 5 lines, no trailing newline
+    const res = await capJsonlBySize(file, { maxBytes: 1, keepTailLines: 2 });
+    expect(res.trimmed).toBe(true);
+    expect(res.removedLines).toBe(3);
+    expect(await readFile(file, 'utf8')).toBe('d\ne\n');
+  });
+
+  it('does not leave a temp file behind after a successful trim', async () => {
+    await writeFile(file, makeLines(100));
+    await capJsonlBySize(file, { maxBytes: 1, keepTailLines: 10 });
+    expect(await readdir(dir)).toEqual(['grants.jsonl']);
+  });
+
+  it('exposes the session-grants default constants', () => {
+    expect(SESSION_GRANTS_MAX_BYTES).toBe(5 * 1024 * 1024);
+    expect(SESSION_GRANTS_KEEP_TAIL_LINES).toBe(5_000);
+  });
+});

--- a/src/agent/log-retention.ts
+++ b/src/agent/log-retention.ts
@@ -1,0 +1,98 @@
+/**
+ * Bounded retention for append-only JSONL logs.
+ *
+ * The first (and currently only) consumer is `session-grants.jsonl`, a
+ * write-only forensic audit log that grew to 46MB from an already-fixed
+ * duplication bug (PR #449). This module provides a best-effort, atomic
+ * size-cap that keeps the newest N lines. Designed to be reused by a future
+ * class-wide log sweep for the other write-only logs.
+ *
+ * @module agent/log-retention
+ */
+
+import { stat, readFile, writeFile, rename, unlink } from 'node:fs/promises';
+
+/**
+ * Size cap for the session-grants audit log (`session-grants.jsonl`) and how
+ * many of the newest lines to preserve when the cap is exceeded.
+ *
+ * Hardcoded rather than env-tunable, mirroring the repl-history cap
+ * (`src/cli/input/history.ts` `MAX_ENTRIES`): a forensic audit log that grows
+ * ~1 row per genuine grant post-#449 does not warrant an operator knob. The
+ * ~750KB tail floor (5k lines) vs 5MB ceiling gives hysteresis so the trim
+ * fires rarely, not on every boot.
+ */
+export const SESSION_GRANTS_MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+export const SESSION_GRANTS_KEEP_TAIL_LINES = 5_000;
+
+export interface CapJsonlOptions {
+  /** Rewrite the file only when its on-disk size exceeds this many bytes. */
+  maxBytes: number;
+  /** Number of newest (trailing) lines to keep when rewriting. */
+  keepTailLines: number;
+}
+
+export interface CapJsonlResult {
+  /** True when the file was over `maxBytes` and was rewritten. */
+  trimmed: boolean;
+  /** Count of leading (oldest) lines dropped; 0 when not trimmed. */
+  removedLines: number;
+}
+
+// Invariant: this trim is safe to run ONLY off the write hot-path (e.g. once at
+// session bootstrap), never inline per append. session-grants.jsonl is written
+// with O_APPEND by multiple concurrent processes (REPL, daemon, telegram) and
+// by in-process subagent forks. The read-then-atomic-rename below is NOT
+// serialised against those appenders: any line appended between the readFile
+// and the rename is dropped. Running once at top-level bootstrap bounds that
+// loss to the rare two-simultaneous-boots case, acceptable for a write-only
+// forensic audit log (no production code reads it) but a per-grant data-loss
+// bug if wired into the append sites.
+/**
+ * Cap an append-only JSONL file at `maxBytes`, keeping the newest
+ * `keepTailLines` lines. Atomic (temp sibling + rename, so a crash mid-write
+ * leaves the original intact) and best-effort: never throws — a missing file,
+ * permission error, ENOSPC, or race is swallowed and reported as
+ * `{ trimmed: false }`.
+ */
+export async function capJsonlBySize(
+  path: string,
+  { maxBytes, keepTailLines }: CapJsonlOptions,
+): Promise<CapJsonlResult> {
+  const noop: CapJsonlResult = { trimmed: false, removedLines: 0 };
+  let tmp: string | undefined;
+  try {
+    const st = await stat(path);
+    if (st.size <= maxBytes) return noop;
+
+    const raw = await readFile(path, 'utf8');
+    const lines = raw.split('\n');
+    // `split` yields a trailing '' for a file ending in '\n'; drop it so the
+    // line count reflects real records and we can re-add exactly one newline.
+    if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+
+    // Over the byte cap but at/under the line budget: a few pathologically long
+    // lines. Nothing safe to drop by line count — leave the file untouched.
+    if (lines.length <= keepTailLines) return noop;
+
+    const kept = lines.slice(lines.length - keepTailLines);
+    const removedLines = lines.length - kept.length;
+
+    // Unique temp name (pid + random) so concurrent same-process trims of the
+    // same path never clobber each other's staging file.
+    tmp = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+    await writeFile(tmp, kept.join('\n') + '\n', { mode: 0o600 });
+    await rename(tmp, path);
+    tmp = undefined; // renamed away — nothing to clean up
+    return { trimmed: true, removedLines };
+  } catch {
+    if (tmp !== undefined) {
+      try {
+        await unlink(tmp);
+      } catch {
+        /* temp already gone or unremovable — ignore */
+      }
+    }
+    return noop;
+  }
+}

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -64,6 +64,12 @@ import {
 } from './session-setup.js';
 import { SessionStateManager } from './session-state.js';
 import { transformProviderEvent, type TransformDeps } from './stream-consumer.js';
+import { getSessionGrantsPath } from '../../paths.js';
+import {
+  capJsonlBySize,
+  SESSION_GRANTS_MAX_BYTES,
+  SESSION_GRANTS_KEEP_TAIL_LINES,
+} from '../log-retention.js';
 
 
 export class AgentSession implements IAgentSession {
@@ -234,6 +240,19 @@ export class AgentSession implements IAgentSession {
     });
 
     this.initSdkLifecycle();
+
+    // Bound the write-only session-grants audit log at session start. Top-level
+    // sessions only: subagents share the parent's path, so re-running per fork
+    // is redundant and widens the rewrite-collision window. Fire-and-forget +
+    // silent-fail — best-effort housekeeping that must never delay or break
+    // construction. Runs at bootstrap rather than inline at the (concurrent)
+    // append sites; see src/agent/log-retention.ts for why.
+    if (this.config.parentSessionId === undefined) {
+      void capJsonlBySize(getSessionGrantsPath(), {
+        maxBytes: SESSION_GRANTS_MAX_BYTES,
+        keepTailLines: SESSION_GRANTS_KEEP_TAIL_LINES,
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## What & why

`~/.afk/state/session-grants.jsonl` — a **write-only** permission-grant audit log — had grown to ~46 MB / 235k lines. Root cause was the since-fixed 196x duplication bug from #449 (1,143 unique grants had ballooned to 224,049 rows). That write-path fix stopped new duplication but left the historical bloat, and nothing bounds the file's size.

This adds a best-effort, atomic size-cap that keeps the newest N lines, run once per top-level session at bootstrap.

## Approach

- **New `src/agent/log-retention.ts`** — `capJsonlBySize(path, { maxBytes, keepTailLines })`: when the file exceeds `maxBytes`, atomically (temp + rename) rewrite it keeping the newest `keepTailLines` lines. Best-effort — never throws (missing file, permission error, ENOSPC, or race is swallowed). Reusable for a future class-wide log sweep.
- **Wired into `AgentSession`** (`src/agent/session/agent-session.ts`) — one fire-and-forget, silent-fail call in the constructor, **top-level sessions only** (`parentSessionId === undefined`), on the async path so it never blocks the synchronous constructor. Covers REPL + Telegram + daemon.
- **Hardcoded constants** (`SESSION_GRANTS_MAX_BYTES = 5 MB`, `KEEP_TAIL_LINES = 5000`) — mirrors the `src/cli/input/history.ts` `MAX_ENTRIES` precedent; no env var, no `ENV_REGISTRY` / `scan:env` surface.

### Why bootstrap, not inline at the write sites

`session-grants.jsonl` is appended with `O_APPEND` by multiple concurrent processes (REPL / daemon / Telegram) and by in-process subagent forks. An inline read-then-rename size-cap would race those appenders and silently drop lines. Running once at top-level bootstrap bounds that window to the rare two-simultaneous-boots case — acceptable for a write-only audit log (no production code reads it), and documented as an `// Invariant:` in the module.

### Why keep a tail (not truncate to empty)

The file is a forensic audit trail. Even though no code reads it, preserving the newest 5,000 records keeps its manual / support-review value.

## Verification

- `pnpm lint` (tsc --noEmit, strict): **exit 0**.
- `src/agent/log-retention.test.ts`: **9/9 pass** — under-cap no-op, over-cap keeps exactly N newest, missing-file no-op, malformed-line tolerance, never-throws, no-trailing-newline handling, no temp file left behind.
- Full suite: **598 files / 11,173 tests pass, 0 fail**.
- End-to-end on the real file via the actual code path: **48,762,199 -> 1,028,064 bytes** (~47.7 MB reclaimed), 230,284 duplicate lines dropped, newest audit record byte-identical before/after (tail preserved).

## Deferred (follow-up)

A class-wide `__BUILTIN_LOG_ROTATE__` scheduled sweep governing the other ~10 unbounded logs with per-file policy (size-cap write-only logs; age-based keep-recent for read-back logs like `trace.jsonl` / `events.jsonl`). `capJsonlBySize` is the building block for its write-only entries.
