### PR TITLE
fix(telegram): disable Telegraf 90s handlerTimeout so long turns aren't guillotined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Fixed
+- Telegram: don't guillotine long agent turns at 90s — disable Telegraf's default `handlerTimeout` so the purpose-built `streaming.ts` inactivity watchdog is the sole timeout authority; fixes the spurious "❌ An unexpected error occurred. Please try again." shown while a turn (sub-agents, web_scrape, long tool calls) was still running and would complete
+
 ## [5.25.10] - 2026-07-09
 
 ### Fixed

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -112,6 +112,19 @@ describe('TelegramBot', () => {
     }
   });
 
+  describe('construction', () => {
+    test('disables Telegraf handlerTimeout so long turns are governed by the streaming watchdog, not a 90s guillotine', () => {
+      // Regression: Telegraf's default handlerTimeout (90_000ms) p-timeouts the
+      // whole turn → bot.catch → generic error, while the AgentSession keeps
+      // running in the background. streaming.ts owns timeout policy instead.
+      const handlerTimeout = (
+        bot as unknown as { bot: { options: { handlerTimeout: number } } }
+      ).bot.options.handlerTimeout;
+      expect(handlerTimeout).toBe(Infinity);
+      expect(handlerTimeout).not.toBe(90_000);
+    });
+  });
+
   describe('commands', () => {
     test('should handle /start command', async () => {
       const ctx = createMockContext(12345, '/start');

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -63,7 +63,15 @@ export class TelegramBot {
 
   constructor(options: BotOptions) {
     this.options = options;
-    this.bot = new Telegraf(options.botToken);
+    // Disable Telegraf's default handlerTimeout (90_000ms). It wraps the ENTIRE
+    // update handler — a full agent turn — in a p-timeout, so any turn over 90s
+    // total (sub-agents, web_scrape, long bash) rejects to `bot.catch` as a
+    // generic "unexpected error" even though the AgentSession keeps running
+    // (p-timeout does not abort the underlying promise). src/telegram/streaming.ts
+    // is the real timeout authority: an inter-event, tool-in-flight-aware,
+    // usage-limit-pause-aware watchdog that throws a handled StreamTimeoutError.
+    // p-timeout short-circuits on Infinity, handing it sole timeout control.
+    this.bot = new Telegraf(options.botToken, { handlerTimeout: Infinity });
     this.sessionManager = new SessionManager(options);
     this.messageHandler = new MessageHandler(
       this.bot,


### PR DESCRIPTION
## Problem

Long agent turns on Telegram surface a spurious **"❌ An unexpected error occurred. Please try again."** — while the turn is *still running in the background* and often completes (in the case that surfaced this, it implemented + committed + opened a PR *after* the error was shown). It recurs constantly in the service log (dozens of occurrences).

## Root cause

`src/telegram/bot.ts` constructs `new Telegraf(options.botToken)` with no options, so Telegraf applies its **default `handlerTimeout: 90_000`** (`telegraf/lib/telegraf.js:46`) and wraps the *entire* update handler — a full agent turn — in `p-timeout(..., 90_000)` (`telegraf.js:233`). Any turn over 90s total wall-clock (sub-agents, `web_scrape`, long bash) rejects to the global `bot.catch` → the generic error.

Because `p-timeout` does **not** abort the underlying promise, the `AgentSession` keeps running detached — which is exactly why the turn finishes (and can ship a PR) *after* the user already saw the failure.

Meanwhile the app already has the *correct* timeout in `src/telegram/streaming.ts`: an inter-event inactivity watchdog (90s first event / 180s between) that is **tool-in-flight aware** and **usage-limit-pause aware**, and throws a *handled* `StreamTimeoutError` with an honest message. The two timeouts collide and the blunt one wins.

## Fix

```ts
this.bot = new Telegraf(options.botToken, { handlerTimeout: Infinity });
```

`p-timeout@4.1.0` short-circuits on `Infinity` (`if (milliseconds === Infinity) { resolve(promise); }` — no timer armed), so this hands **sole** timeout authority to the `streaming.ts` watchdog, which is strictly better than a blunt 90s wall-clock cap.

## Verification

- `pnpm lint` (tsc --noEmit, strict) — clean
- `pnpm test` — full suite green (597 files / 11,165 tests)
- New regression test in `bot.test.ts` asserts the bot is constructed with `handlerTimeout === Infinity` (and not the `90_000` default)

## Deploy note

The running Telegram **service must be rebuilt + restarted** (`pnpm build`, then restart the launchd service) to pick this up — the source fix alone does not touch the live `dist/telegram.mjs`.
