### PR TITLE
fix(trace): make witness traces correlatable to sessions via ledger meta

### DIFF
--- a/src/agent/session-ledger.ts
+++ b/src/agent/session-ledger.ts
@@ -38,8 +38,21 @@ import type { ElicitationRequest, ElicitationResult } from './types/sdk-types.js
 export type LedgerRecord = { v: 1; ts: number } & LedgerPayload;
 
 export type LedgerPayload =
-  /** Session-level metadata, written once when the ledger opens. */
-  | { kind: 'meta'; sessionId: string; model: string; cwd?: string; surface?: string }
+  /** Session-level metadata, written once when the ledger opens.
+   *  `traceLabel` is the witness-trace directory name (`state/witness/<label>/`)
+   *  for this session, letting a reader correlate the id-keyed ledger to the
+   *  trace — whose label is a random UUID for fresh sessions, decoupled from
+   *  the session id. `null` means no trace was wired (tracing disabled/failed),
+   *  making that state explicit rather than a silently-absent directory.
+   *  Optional for back-compat with ledgers written before this field existed. */
+  | {
+      kind: 'meta';
+      sessionId: string;
+      model: string;
+      cwd?: string;
+      surface?: string;
+      traceLabel?: string | null;
+    }
   /** A user turn entering the session (summary text, never raw blocks). */
   | { kind: 'user'; text: string }
   /** A complete assistant message. */

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -51,6 +51,7 @@ import type {
 } from '../types.js';
 import { QueryInputStream } from './input-iterable.js';
 import { SessionLedgerWriter } from '../session-ledger.js';
+import { sessionLabelFromTracePath } from '../../paths.js';
 import type { ElicitationRequest } from '../types/sdk-types.js';
 import { env } from '../../config/env.js';
 import { resolveModelId } from './model-resolution.js';
@@ -695,6 +696,11 @@ export class AgentSession implements IAgentSession {
       sessionId: id,
       model: meta.model ?? String(this.config.model),
       ...(meta.cwd !== undefined ? { cwd: meta.cwd } : {}),
+      // Correlate this id-keyed ledger to its witness trace: fresh sessions
+      // label the trace dir with a random UUID (not the session id), so the
+      // ledger is the durable id→label bridge. `null` when tracing is
+      // disabled/unwired, so absence is explicit rather than silent.
+      traceLabel: sessionLabelFromTracePath(this.config.traceWriter?.getTracePath()),
     });
   }
 

--- a/src/cli/commands/trace.test.ts
+++ b/src/cli/commands/trace.test.ts
@@ -27,7 +27,7 @@ import {
   listTraces,
   resolveLatestSession,
 } from './trace.js';
-import { getTraceDir } from '../../paths.js';
+import { getTraceDir, getSessionLedgerDir, getSessionLedgerPath } from '../../paths.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -333,5 +333,48 @@ describe('witness discovery', () => {
 
   it('throws a helpful error for a missing session', async () => {
     await expect(loadTrace('does-not-exist-xyz')).rejects.toThrow(/No trace found/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ledger fallback: fresh sessions label the witness dir with a random UUID
+// (not the session id), so loadTrace(sessionId) must recover the real label
+// from the session ledger's `meta.traceLabel`.
+// ---------------------------------------------------------------------------
+
+async function writeLedger(sessionId: string, records: EventObj[]): Promise<void> {
+  await mkdir(getSessionLedgerDir(sessionId), { recursive: true });
+  await writeFile(getSessionLedgerPath(sessionId), toJsonl(records), 'utf8');
+}
+
+describe('loadTrace ledger fallback', () => {
+  it('resolves a trace whose witness label differs from the session id', async () => {
+    // Trace lives under a random-UUID label; nothing under <witness>/<sessionId>/.
+    await writeTrace('random-label-abc123', sampleEvents());
+    await writeLedger('sess-fresh-a', [
+      { v: 1, ts: 1000, kind: 'meta', sessionId: 'sess-fresh-a', model: 'sonnet', traceLabel: 'random-label-abc123' },
+      { v: 1, ts: 1001, kind: 'user', text: 'hi' },
+    ]);
+
+    const loaded = await loadTrace('sess-fresh-a');
+    expect(loaded.sessionId).toBe('sess-fresh-a');
+    expect(loaded.tracePath).toContain('random-label-abc123');
+    expect(loaded.events).toHaveLength(10);
+  });
+
+  it('reports tracing-disabled when the ledger meta records traceLabel: null', async () => {
+    await writeLedger('sess-notrace', [
+      { v: 1, ts: 1000, kind: 'meta', sessionId: 'sess-notrace', model: 'sonnet', traceLabel: null },
+    ]);
+
+    await expect(loadTrace('sess-notrace')).rejects.toThrow(/tracing disabled/);
+  });
+
+  it('falls through to "No trace found" when the ledger meta predates the field', async () => {
+    await writeLedger('sess-legacy', [
+      { v: 1, ts: 1000, kind: 'meta', sessionId: 'sess-legacy', model: 'sonnet' },
+    ]);
+
+    await expect(loadTrace('sess-legacy')).rejects.toThrow(/No trace found/);
   });
 });

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -29,6 +29,7 @@ import { join } from 'node:path';
 
 import { handleCommandError } from '../errors/index.js';
 import { getAfkStateDir, getTraceDir } from '../../paths.js';
+import { readLedger } from '../../agent/session-ledger.js';
 import type { TraceEvent } from '../../agent/trace/index.js';
 
 // ---------------------------------------------------------------------------
@@ -154,21 +155,78 @@ export async function loadTrace(
   }
 
   // getTraceDir validates the id shape and throws on an unsafe value.
-  const tracePath = join(getTraceDir(sessionId), 'trace.jsonl');
-  let content: string;
-  try {
-    content = await readFile(tracePath, 'utf8');
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+  let tracePath = join(getTraceDir(sessionId), 'trace.jsonl');
+  let content = await readTraceFile(tracePath);
+
+  // Fresh sessions label the witness dir with a random UUID, not the session id
+  // (only resumed sessions reuse the id) — so a direct <witness>/<id>/ lookup
+  // misses them. The session ledger's `meta` record carries the real label;
+  // consult it before giving up.
+  if (content === null) {
+    const resolved = await traceLabelFromLedger(sessionId);
+    if (resolved.kind === 'disabled') {
       throw new Error(
-        `No trace found for session "${sessionId}" at ${tracePath}. ` +
-          `See \`afk trace list\` for available sessions.`,
+        `Session "${sessionId}" ran with tracing disabled — its ledger records ` +
+          `traceLabel: null, so no witness trace was written ` +
+          `(tracing is off when AFK_TRACE_DISABLED=1).`,
       );
     }
-    throw err;
+    if (resolved.kind === 'label' && resolved.label !== sessionId) {
+      try {
+        const relabeled = join(getTraceDir(resolved.label), 'trace.jsonl');
+        const viaLedger = await readTraceFile(relabeled);
+        if (viaLedger !== null) {
+          tracePath = relabeled;
+          content = viaLedger;
+        }
+      } catch {
+        // Unsafe/garbage label in the ledger — fall through to the not-found error.
+      }
+    }
+  }
+
+  if (content === null) {
+    throw new Error(
+      `No trace found for session "${sessionId}" at ${tracePath}. ` +
+        `See \`afk trace list\` for available sessions.`,
+    );
   }
 
   return { sessionId, tracePath, ...parseTrace(content) };
+}
+
+/** Read a `trace.jsonl`, returning `null` on ENOENT (other errors rethrow). */
+async function readTraceFile(tracePath: string): Promise<string | null> {
+  try {
+    return await readFile(tracePath, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+/**
+ * Recover a session's witness label from its ledger `meta` record.
+ *   - `{ kind: 'label', label }` — meta recorded a non-empty `traceLabel`.
+ *   - `{ kind: 'disabled' }`     — meta recorded `traceLabel: null` (tracing off).
+ *   - `{ kind: 'none' }`         — no ledger, no meta, or a pre-field ledger.
+ */
+async function traceLabelFromLedger(
+  sessionId: string,
+): Promise<{ kind: 'label'; label: string } | { kind: 'disabled' } | { kind: 'none' }> {
+  try {
+    for await (const rec of readLedger(sessionId)) {
+      if (rec.kind !== 'meta') continue;
+      if (typeof rec.traceLabel === 'string' && rec.traceLabel.length > 0) {
+        return { kind: 'label', label: rec.traceLabel };
+      }
+      if (rec.traceLabel === null) return { kind: 'disabled' };
+      return { kind: 'none' }; // meta present but written before the field existed
+    }
+  } catch {
+    // Ledger unreadable — treat as no signal and fall back to the direct lookup.
+  }
+  return { kind: 'none' };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -36,6 +36,8 @@ import {
   getBrowserStateRoot,
   getBrowserProfileStateDir,
   getBrowserStorageStatePath,
+  getTraceDir,
+  sessionLabelFromTracePath,
 } from './paths.js';
 import { useUnsetAfkHome } from './__test-utils__/unset-afk-home.js';
 
@@ -353,6 +355,36 @@ describe('getAfkHome — AFK_HOME validation (F1)', () => {
   it('returns the value when AFK_HOME is a valid absolute non-root path', () => {
     vi.stubEnv('AFK_HOME', '/tmp/afk-test');
     expect(getAfkHome()).toBe('/tmp/afk-test');
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('sessionLabelFromTracePath — inverse of getTraceDir', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('recovers the witness label from a trace.jsonl path', () => {
+    expect(
+      sessionLabelFromTracePath('/home/u/.afk/state/witness/label-xyz-123/trace.jsonl'),
+    ).toBe('label-xyz-123');
+  });
+
+  it('is the inverse of getTraceDir for a valid label', () => {
+    vi.stubEnv('AFK_HOME', '/tmp/afk-label-test');
+    const p = join(getTraceDir('default-uuid-1'), 'trace.jsonl');
+    expect(sessionLabelFromTracePath(p)).toBe('default-uuid-1');
+  });
+
+  it('returns null for the in-memory writer sentinel', () => {
+    expect(sessionLabelFromTracePath('in-memory://trace')).toBeNull();
+  });
+
+  it('returns null for nullish or empty input', () => {
+    expect(sessionLabelFromTracePath(undefined)).toBeNull();
+    expect(sessionLabelFromTracePath(null)).toBeNull();
+    expect(sessionLabelFromTracePath('')).toBeNull();
   });
 });
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -35,7 +35,7 @@
  */
 
 import { existsSync, mkdirSync, renameSync, cpSync, rmSync } from 'fs';
-import { join, dirname, isAbsolute } from 'path';
+import { join, dirname, basename, isAbsolute } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
 import { env } from './config/env.js';
@@ -307,6 +307,22 @@ export function validateSessionId(sessionId: string): void {
 export function getTraceDir(sessionId: string): string {
   validateSessionId(sessionId);
   return join(getAfkStateDir(), 'witness', sessionId);
+}
+
+/**
+ * Inverse of {@link getTraceDir}: recover the witness `sessionLabel` from a
+ * trace-file path (`.../witness/<label>/trace.jsonl`).
+ *
+ * Returns `null` for the in-memory writer sentinel (`in-memory://trace`) and
+ * for an absent path, so a caller recording the label can store an explicit
+ * "no trace" marker rather than a bogus directory name. Used to stamp the
+ * witness label into the session ledger's `meta` record — the trace writer
+ * exposes only `getTracePath()` (its label is a random UUID it doesn't surface
+ * directly), so the label is derived from that path.
+ */
+export function sessionLabelFromTracePath(tracePath: string | undefined | null): string | null {
+  if (!tracePath || tracePath.startsWith('in-memory:')) return null;
+  return basename(dirname(tracePath));
 }
 
 /**


### PR DESCRIPTION
## Problem

A session can have a durable ledger (`~/.afk/state/sessions/<id>/events.jsonl`) but **no discoverable witness trace**, silently:

- Fresh sessions label the witness dir with a **random UUID** (`state/witness/<uuid>/`), decoupled from the session id — only *resumed* sessions reuse the id as the label (`src/cli/commands/interactive/bootstrap.ts:206`; the writer is opened before the session id exists).
- Trace events carry **no session id** internally.
- Net effect: `afk trace show <sessionId>` can't find a fresh session's trace, and the id-keyed ledger / routing-decisions can't be joined to it.

This was found while trying to reconstruct a real REPL session after the fact — it had a ledger but no locatable trace, and nothing recorded *why*.

## Fix

Smallest reversible change that keeps the two fire-and-forget writers **decoupled** — no bootstrap reorder, no directory rename:

1. **`src/agent/session-ledger.ts`** — add `traceLabel?: string | null` to the one-time `meta` record. Optional for back-compat with pre-field ledgers.
2. **`src/agent/session/agent-session.ts`** — populate it from `this.config.traceWriter?.getTracePath()`. `null` makes tracing-disabled/unwired **explicit** rather than a silently-absent dir.
3. **`src/paths.ts`** — add `sessionLabelFromTracePath()` (inverse of `getTraceDir`; returns `null` for the in-memory sentinel). `getTracePath()` is the documented way to locate a trace without knowing its random label.
4. **`src/cli/commands/trace.ts`** — `loadTrace()` falls back to the ledger's `traceLabel` when `<witness>/<sessionId>/` is absent, and reports a clear *"tracing disabled"* error when `traceLabel` is `null`.

### Why this shape (over alternatives)

Storing the **label** (not a live path/handle) in the always-on ledger solves correlation **and** absence-detection in one field, with no coupling of concern: the ledger opens lazily on first turn (`agent-session.ts:632,671`), by which point the trace label already exists (no race), and we do **not** rename the trace dir (no staleness). A systemic "session-id *is* the trace label from birth" fix was considered but reorders session-identity across all five entry points for marginal gain — not worth the blast radius.

## Verification

- `pnpm lint` ✓ · `pnpm build` ✓
- `pnpm audit:sdk:check` ✓ · `pnpm audit:env:check` ✓ · `pnpm scan:env:check` ✓ (no new SDK imports or env vars)
- `pnpm test` ✓ — **11171 passed, 14 skipped, 0 failed**
- New tests: `paths.test.ts` (label round-trip + in-memory/nullish sentinels); `trace.test.ts` (mismatched-label trace resolves via ledger; `traceLabel: null` → clear error; pre-field ledger falls through to "No trace found").