### PR TITLE
feat(hooks): ask-question PreToolUse gate + orphan root-settings warning

### DIFF
--- a/src/agent/ask-question-gate.test.ts
+++ b/src/agent/ask-question-gate.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for the ask-question PreToolUse gate.
+ *
+ * Invariants pinned here:
+ *   - No elicitation handler → `ask_question` is blocked pre-flight with the
+ *     proceed-on-assumption guidance, and the operator notification fires
+ *     (park-and-notify parity with the elicitation router's unattended path).
+ *   - Handler installed → the gate is a transparent no-op (waiting for an AFK
+ *     operator is designed behavior; the router deliberately has no deadline).
+ *   - The gate never touches other tools or other hook events.
+ *   - Notification is best-effort: a throwing notifier cannot change the
+ *     decision; question text is truncated to bound inadvertent exposure.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the Telegram push primitive before the gate module (which imports it
+// for its default notifier) so no test can touch the network.
+vi.mock('../telegram/push.js', () => ({
+  pushIfConfigured: vi.fn().mockResolvedValue(null),
+}));
+
+import { createAskQuestionGate, ASK_QUESTION_GATE_REASON } from './ask-question-gate.js';
+import { elicitationRouter } from './elicitation-router.js';
+import type { HookContext } from './hooks.js';
+import type { ElicitationResult } from './types/sdk-types.js';
+
+function preToolUse(toolName: string, input?: unknown): HookContext {
+  return {
+    event: 'PreToolUse',
+    toolName,
+    ...(input !== undefined ? { input } : {}),
+  };
+}
+
+describe('createAskQuestionGate', () => {
+  it('blocks ask_question with guidance when no handler is installed', () => {
+    const gate = createAskQuestionGate({ hasHandler: () => false, notify: () => undefined });
+    const decision = gate(preToolUse('ask_question', { question: 'Deploy to prod?' }));
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toBe(ASK_QUESTION_GATE_REASON);
+    // The guidance must instruct the recovery path, not just refuse.
+    expect(decision.reason).toContain('state the assumption');
+    expect(decision.reason).toContain('Blocked terminal state');
+  });
+
+  it('is a no-op when a handler is installed', () => {
+    const notify = vi.fn();
+    const gate = createAskQuestionGate({ hasHandler: () => true, notify });
+    expect(gate(preToolUse('ask_question', { question: 'x' }))).toEqual({});
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('ignores other tools', () => {
+    const notify = vi.fn();
+    const gate = createAskQuestionGate({ hasHandler: () => false, notify });
+    expect(gate(preToolUse('bash', { command: 'ls' }))).toEqual({});
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-PreToolUse events', () => {
+    const gate = createAskQuestionGate({ hasHandler: () => false, notify: () => undefined });
+    const stop: HookContext = { event: 'Stop', sessionId: 's' };
+    expect(gate(stop)).toEqual({});
+  });
+
+  it('notifies the operator with the question text', () => {
+    const notify = vi.fn();
+    const gate = createAskQuestionGate({ hasHandler: () => false, notify });
+    gate(preToolUse('ask_question', { question: 'Which region?' }));
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(String(notify.mock.calls[0]?.[0])).toContain('Which region?');
+  });
+
+  it('truncates long question text in the notification', () => {
+    const notify = vi.fn();
+    const gate = createAskQuestionGate({ hasHandler: () => false, notify });
+    gate(preToolUse('ask_question', { question: 'q'.repeat(500) }));
+    const message = String(notify.mock.calls[0]?.[0]);
+    expect(message).toContain('…(truncated)');
+    expect(message).not.toContain('q'.repeat(301));
+  });
+
+  it('still blocks when the notifier throws', () => {
+    const gate = createAskQuestionGate({
+      hasHandler: () => false,
+      notify: () => {
+        throw new Error('push down');
+      },
+    });
+    const decision = gate(preToolUse('ask_question', { question: 'x' }));
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toBe(ASK_QUESTION_GATE_REASON);
+  });
+
+  it('handles malformed input without crashing', () => {
+    const notify = vi.fn();
+    const gate = createAskQuestionGate({ hasHandler: () => false, notify });
+    const decision = gate(preToolUse('ask_question', 'not-an-object'));
+    expect(decision.decision).toBe('block');
+    expect(String(notify.mock.calls[0]?.[0])).toContain('(question text unavailable)');
+  });
+
+  it('defaults the handler probe to the module elicitationRouter', () => {
+    elicitationRouter.uninstall();
+    const notify = vi.fn();
+    const gate = createAskQuestionGate({ notify });
+    expect(gate(preToolUse('ask_question', { question: 'x' })).decision).toBe('block');
+
+    const handler = async (): Promise<ElicitationResult> => ({ action: 'decline' });
+    elicitationRouter.install(handler);
+    try {
+      expect(gate(preToolUse('ask_question', { question: 'x' }))).toEqual({});
+    } finally {
+      elicitationRouter.uninstall();
+    }
+  });
+});

--- a/src/agent/ask-question-gate.ts
+++ b/src/agent/ask-question-gate.ts
@@ -1,0 +1,115 @@
+/**
+ * Ask-question gate hook factory.
+ *
+ * PreToolUse gate on the `ask_question` built-in: when NO elicitation handler
+ * is installed (daemon, scheduler, one-shot `afk chat` — no interactive
+ * operator attached to this process), a question can never be answered
+ * interactively. Without the gate, the elicitation router would park-and-notify
+ * then auto-decline AFTER the round-trip, handing the model a bare
+ * `{ action: 'decline' }` it may mishandle or retry. The gate moves that
+ * outcome BEFORE the call and converts it into actionable guidance at the
+ * moment of temptation:
+ *
+ *   - fires the same best-effort Telegram notification the router would have
+ *     fired (park-and-notify is preserved — enforcement must not regress the
+ *     operator's async visibility into what the agent wanted to know);
+ *   - blocks with a reason instructing the model to proceed on a stated
+ *     assumption, or end with a Blocked terminal state when no safe
+ *     assumption exists.
+ *
+ * When a handler IS installed (REPL, Telegram), the gate is a no-op: waiting
+ * minutes/hours for an AFK operator is the *designed* behavior of
+ * `ask_question` (see `elicitation-router.ts` — deliberately no deadline).
+ * Handler presence is probed at call time, so a handler installed after
+ * registry construction (the normal bootstrap order) is observed correctly.
+ *
+ * The block lands in the witness trace as a `hook_decision` event
+ * (`hook_block:ask_question`), which doubles as the gate's structured
+ * catch-record for the failure-mode telemetry substrate. Classify it as a
+ * deliberate guardrail firing — "working as designed" — not new friction.
+ *
+ * Migration provenance: first gate-skill → hook migration (the `ask-gate`
+ * skill's reachability rule, made deterministic). Pattern precedent:
+ * `plan-mode-gate.ts`. Plan: `.afk/plans/friction-substrate-and-gate-migration.md`.
+ *
+ * @module agent/ask-question-gate
+ */
+
+import type { HookContext, HookDecision } from './hooks.js';
+import { elicitationRouter } from './elicitation-router.js';
+import { pushIfConfigured } from '../telegram/push.js';
+
+/**
+ * Cap on the question text echoed to Telegram — mirrors the router's
+ * `MAX_NOTIFY_MESSAGE_CHARS` rationale: the prompt is the minimal disclosure
+ * the operator needs, and truncation bounds inadvertent exposure of any
+ * sensitive text a model might embed in it.
+ */
+const MAX_NOTIFY_QUESTION_CHARS = 300;
+
+/** Block reason surfaced to the model. Exported for tests and for surfaces
+ *  that want to detect this specific gate in tool-error output. */
+export const ASK_QUESTION_GATE_REASON =
+  'ask_question gate: no interactive operator is attached to this surface ' +
+  '(no elicitation handler — daemon/scheduled/one-shot run), so the question ' +
+  'cannot be answered now. The operator has been notified asynchronously. ' +
+  'Do not re-ask or wait. Choose the most reasonable interpretation, state ' +
+  'the assumption explicitly in your final report for async review, and ' +
+  'proceed. If no safe assumption exists and the next action would be ' +
+  'irreversible, end the turn with a Blocked terminal state naming exactly ' +
+  'what the operator must supply.';
+
+export interface AskQuestionGateOptions {
+  /**
+   * Override the handler-availability probe. Default: the module-scope
+   * {@link elicitationRouter}. Injected in tests.
+   */
+  hasHandler?: () => boolean;
+  /**
+   * Override the best-effort operator notification. Default: Telegram
+   * `pushIfConfigured` (no-op when Telegram is unconfigured; transport
+   * errors swallowed). Injected in tests.
+   */
+  notify?: (message: string) => void;
+}
+
+function defaultNotify(message: string): void {
+  void pushIfConfigured(message).catch(() => undefined);
+}
+
+export function createAskQuestionGate(
+  options: AskQuestionGateOptions = {},
+): (context: HookContext) => HookDecision {
+  const hasHandler = options.hasHandler ?? ((): boolean => elicitationRouter.hasHandler());
+  const notify = options.notify ?? defaultNotify;
+
+  return function askQuestionGate(context: HookContext): HookDecision {
+    if (context.event !== 'PreToolUse') return {};
+    if (context.toolName !== 'ask_question') return {};
+    // Interactive operator attached — asking (and waiting) is legitimate.
+    if (hasHandler()) return {};
+
+    // Park-and-notify parity with the router's unattended path: the block
+    // must not cost the operator their async visibility. Best-effort and
+    // exception-proof — a notification failure never affects the decision.
+    try {
+      const question =
+        typeof context.input === 'object' && context.input !== null
+          ? String((context.input as Record<string, unknown>)['question'] ?? '')
+          : '';
+      const trimmed = question.trim();
+      const text =
+        trimmed.length <= MAX_NOTIFY_QUESTION_CHARS
+          ? trimmed
+          : `${trimmed.slice(0, MAX_NOTIFY_QUESTION_CHARS)}…(truncated)`;
+      notify(
+        '🔔 AFK question (auto-gated; agent proceeds on a stated assumption):\n' +
+          (text !== '' ? text : '(question text unavailable)'),
+      );
+    } catch {
+      // Observational only.
+    }
+
+    return { decision: 'block', reason: ASK_QUESTION_GATE_REASON };
+  };
+}

--- a/src/agent/default-hook-registry.test.ts
+++ b/src/agent/default-hook-registry.test.ts
@@ -1,0 +1,98 @@
+/**
+ * createDefaultHookRegistry — config-loader warning surfacing (PR #477 review P2).
+ *
+ * The hooks config-loader records non-fatal problems (parse/schema errors and
+ * the orphan root-settings notice for a misplaced `$AFK_HOME/settings.json`) on
+ * `LoadedHooksConfig.warnings`, documented as "the caller should surface". No
+ * caller did: every surface (chat, REPL bootstrap, daemon/scheduler, Telegram)
+ * passes the config straight into `createDefaultHookRegistry`, which — before
+ * this fix — only registered hooks and never emitted `warnings`. A misplaced
+ * root settings file therefore stayed silent and the owner could believe those
+ * hooks were active. These tests pin that the registry now emits each distinct
+ * warning once, deduped so repeated session construction can't re-spam.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createDefaultHookRegistry, _resetWarningForTests } from './default-hook-registry.js';
+import type { LoadedHooksConfig } from './hooks/config-loader.js';
+
+function makeConfig(overrides: Partial<LoadedHooksConfig> = {}): LoadedHooksConfig {
+  return {
+    hooks: {},
+    userGlobalEnabled: true,
+    allowProjectHooks: false,
+    sources: [],
+    warnings: [],
+    ...overrides,
+  };
+}
+
+// Representative loader warning (the orphan root-settings notice). The exact
+// text is irrelevant to this contract — only that whatever lands in
+// `warnings[]` reaches the user — so this is a fixture, not a format assertion.
+const ORPHAN_WARNING =
+  'found /home/u/.afk/settings.json but AFK does not read settings from the AFK-home root; ' +
+  'user-global hooks/settings belong in /home/u/.afk/config/settings.json — the root file is ignored';
+
+describe('createDefaultHookRegistry — surfaces config-loader warnings (PR #477 P2)', () => {
+  beforeEach(() => {
+    _resetWarningForTests();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('emits the orphan root-settings warning that was previously silent', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    createDefaultHookRegistry(undefined, 'cli', undefined, undefined, makeConfig({ warnings: [ORPHAN_WARNING] }));
+    const messages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(messages.some((m) => m.includes(ORPHAN_WARNING))).toBe(true);
+    // Surfaced through the shared `[hooks]` channel, like skipped-hook warnings.
+    expect(messages.some((m) => m.includes('[hooks]'))).toBe(true);
+  });
+
+  it('surfaces warnings even when the config has zero registrable hooks (the orphan case)', () => {
+    // The orphan case: a root settings.json exists → a warning, but hooks:{}
+    // so nothing registers. The warning must still surface — this is exactly
+    // the state that was silent before the fix.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    createDefaultHookRegistry(undefined, 'cli', undefined, undefined, makeConfig({ hooks: {}, warnings: [ORPHAN_WARNING] }));
+    const messages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(messages.some((m) => m.includes(ORPHAN_WARNING))).toBe(true);
+  });
+
+  it('emits every distinct warning in the array', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const a = 'hooks config at /p/.afk/settings.json: parse error — bad json';
+    const b = ORPHAN_WARNING;
+    createDefaultHookRegistry(undefined, 'cli', undefined, undefined, makeConfig({ warnings: [a, b] }));
+    const messages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(messages.some((m) => m.includes(a))).toBe(true);
+    expect(messages.some((m) => m.includes(b))).toBe(true);
+  });
+
+  it('dedupes: repeated session construction does not re-spam the same warning', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const cfg = makeConfig({ warnings: [ORPHAN_WARNING] });
+    // Two constructions in one process (e.g. two daemon ticks / two Telegram chats).
+    createDefaultHookRegistry(undefined, 'cli', undefined, undefined, cfg);
+    createDefaultHookRegistry(undefined, 'telegram', undefined, undefined, cfg);
+    const hits = warnSpy.mock.calls.map((c) => String(c[0])).filter((m) => m.includes(ORPHAN_WARNING));
+    expect(hits).toHaveLength(1);
+  });
+
+  it('stays silent when the config carries no warnings', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    createDefaultHookRegistry(undefined, 'cli', undefined, undefined, makeConfig({ warnings: [] }));
+    const messages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(messages.some((m) => m.includes('[hooks]'))).toBe(false);
+  });
+
+  it('does not emit config warnings when hookConfig is omitted (the common case)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    createDefaultHookRegistry(undefined, 'cli');
+    const messages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(messages.some((m) => m.includes('[hooks]'))).toBe(false);
+  });
+});

--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -66,6 +66,20 @@ export interface DefaultHookRegistryResult {
 let warnedPathApprovalDisabled = false;
 
 /**
+ * Distinct hooks-config loader warnings already surfaced this process. The
+ * loader records non-fatal problems (parse/schema errors, and the orphan
+ * root-settings notice for a misplaced `$AFK_HOME/settings.json`) on
+ * `LoadedHooksConfig.warnings`, documented as "the caller should surface" —
+ * but no caller did, so a misplaced root file stayed silent and the owner
+ * could believe those hooks were active. We surface them here (the single
+ * chokepoint every surface routes through), deduped per distinct message so
+ * repeated session construction (daemon ticks, per-chat Telegram sessions)
+ * doesn't re-spam the same process-global notice while a genuinely new
+ * warning from a later session still surfaces.
+ */
+const surfacedConfigWarnings = new Set<string>();
+
+/**
  * Test-only: reset the once-per-process warning flag so Vitest files that
  * exercise the AFK_DISABLE_PATH_APPROVAL=1 warn path don't bleed state into
  * each other (module scope persists across files in a single worker).
@@ -73,6 +87,7 @@ let warnedPathApprovalDisabled = false;
  */
 export function _resetWarningForTests(): void {
   warnedPathApprovalDisabled = false;
+  surfacedConfigWarnings.clear();
 }
 
 export function createDefaultHookRegistry(
@@ -234,6 +249,17 @@ export function createDefaultHookRegistry(
   // handlers always run first. Config hooks are optional — when no
   // hookConfig is provided (the common case) this is a no-op.
   if (hookConfig !== undefined) {
+    // Surface loader warnings (parse/schema errors, orphan root-settings
+    // notice) that were computed but previously dropped on the floor — see
+    // surfacedConfigWarnings above. Emit before registration so problems are
+    // visible even when the config has zero registrable hooks (the orphan
+    // case). Mirrors the bridge's skipped-hook `[hooks]` console.warn channel.
+    for (const warning of hookConfig.warnings) {
+      if (surfacedConfigWarnings.has(warning)) continue;
+      surfacedConfigWarnings.add(warning);
+      // eslint-disable-next-line no-console
+      console.warn(`[hooks] ${warning}`);
+    }
     loadAndRegisterConfigHooks(registry, hookConfig, {
       cwd: agentOptions?.cwd,
       sessionId: agentOptions?.sessionId,

--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -8,6 +8,7 @@
 
 import { createHookRegistry, type HookRegistry } from './hooks.js';
 import { createShadowVerifyNudge } from './shadow-verify-nudge.js';
+import { createAskQuestionGate } from './ask-question-gate.js';
 import { MemoryStore, createMemorySessionEndHook } from './memory/index.js';
 import { createPlanModeGate } from './plan-mode-gate.js';
 import { createAfkModeGate } from './afk-mode-gate.js';
@@ -90,6 +91,12 @@ export function createDefaultHookRegistry(
   const shadowVerifyNudge = createShadowVerifyNudge();
   registry.register('SubagentStop', shadowVerifyNudge);
   registry.register('Stop', shadowVerifyNudge);
+  // Ask-question gate: on surfaces with no elicitation handler (daemon,
+  // scheduler, one-shot chat) a question can never be answered — block it
+  // pre-flight with proceed-on-assumption guidance instead of letting the
+  // router park-and-decline after the round-trip. No-op on REPL/Telegram
+  // (handler installed; probed at call time). See ask-question-gate.ts.
+  registry.register('PreToolUse', createAskQuestionGate());
   const store = memoryStore ?? new MemoryStore();
   if (getPermissionMode !== undefined) {
     registry.register('PreToolUse', createPlanModeGate(getPermissionMode));

--- a/src/agent/elicitation-router.test.ts
+++ b/src/agent/elicitation-router.test.ts
@@ -330,3 +330,16 @@ describe('elicitationRouter', () => {
     });
   });
 });
+
+describe('hasHandler', () => {
+  it('reflects install/uninstall state', () => {
+    elicitationRouter.uninstall();
+    expect(elicitationRouter.hasHandler()).toBe(false);
+
+    elicitationRouter.install(async (): Promise<ElicitationResult> => ({ action: 'decline' }));
+    expect(elicitationRouter.hasHandler()).toBe(true);
+
+    elicitationRouter.uninstall();
+    expect(elicitationRouter.hasHandler()).toBe(false);
+  });
+});

--- a/src/agent/elicitation-router.ts
+++ b/src/agent/elicitation-router.ts
@@ -92,6 +92,17 @@ class ElicitationRouter {
     this.handler = null;
   }
 
+  /**
+   * Whether an elicitation handler is currently installed. Deterministic
+   * probe used by the ask-question PreToolUse gate (`ask-question-gate.ts`):
+   * handler presence is the ground truth for "an interactive operator surface
+   * (REPL/Telegram) is attached to this process". Read at call time — a
+   * handler installed later is observed by subsequent probes.
+   */
+  hasHandler(): boolean {
+    return this.handler !== null;
+  }
+
   /** Number of requests currently waiting in (or executing from) the queue. */
   pendingCount(): number {
     return this.queueDepth;

--- a/src/agent/hooks/config-bridge.test.ts
+++ b/src/agent/hooks/config-bridge.test.ts
@@ -369,9 +369,11 @@ describe('createDefaultHookRegistry integration', () => {
 
   it('createDefaultHookRegistry without hookConfig → 0 config hooks registered', () => {
     const { registry } = createDefaultHookRegistry();
-    // Built-in handlers exist for SubagentStop and SessionEnd, but NO PreToolUse
-    // config hooks since we passed no hookConfig (path-approval disabled above).
-    expect(registry.count('PreToolUse')).toBe(0);
+    // Built-in handlers exist for SubagentStop and SessionEnd, plus exactly ONE
+    // built-in PreToolUse handler (the ask-question gate, registered
+    // unconditionally). No further PreToolUse hooks since we passed no
+    // hookConfig (path-approval disabled above).
+    expect(registry.count('PreToolUse')).toBe(1);
   });
 
   it('createDefaultHookRegistry with hookConfig → config hooks ARE registered', () => {
@@ -396,8 +398,8 @@ describe('createDefaultHookRegistry integration', () => {
       hookConfig,
       { cwd: projectCwd },
     );
-    // 1 config hook for PreToolUse
-    expect(registry.count('PreToolUse')).toBe(1);
+    // 1 built-in (ask-question gate) + 1 config hook for PreToolUse
+    expect(registry.count('PreToolUse')).toBe(2);
   });
 
   it('built-in SubagentStop handler still present when hookConfig is provided', () => {

--- a/src/agent/hooks/config-loader.test.ts
+++ b/src/agent/hooks/config-loader.test.ts
@@ -524,3 +524,59 @@ describe('loadHooksConfig (layered)', () => {
     expect(groups[0]!.hooks[0]!.command).toBe('echo once');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Orphan root settings warning (~/.afk/settings.json misplacement)
+// ---------------------------------------------------------------------------
+
+describe('orphan root settings warning', () => {
+  let afkHome: string;
+  let projectCwd: string;
+  let originalAfkHome: string | undefined;
+
+  beforeEach(() => {
+    afkHome = join(tmp, 'afk-home-orphan');
+    projectCwd = join(tmp, 'project-orphan');
+    mkdirSync(join(afkHome, 'config'), { recursive: true });
+    mkdirSync(projectCwd, { recursive: true });
+    originalAfkHome = process.env['AFK_HOME'];
+    process.env['AFK_HOME'] = afkHome;
+  });
+
+  afterEach(() => {
+    if (originalAfkHome === undefined) delete process.env['AFK_HOME'];
+    else process.env['AFK_HOME'] = originalAfkHome;
+  });
+
+  it('warns when a settings.json sits at the AFK-home root', () => {
+    const orphan = join(afkHome, 'settings.json');
+    writeFileSync(orphan, JSON.stringify({ hooks: {} }), 'utf-8');
+
+    const result = loadHooksConfig({ cwd: projectCwd });
+    expect(result.warnings.some((w) => w.includes('AFK-home root'))).toBe(true);
+    // The orphan file contributes nothing: not a source, no hooks.
+    expect(result.sources).not.toContain(orphan);
+  });
+
+  it('does not warn when no root settings.json exists', () => {
+    const result = loadHooksConfig({ cwd: projectCwd });
+    expect(result.warnings.some((w) => w.includes('AFK-home root'))).toBe(false);
+  });
+
+  it('still loads the real user-global settings layer alongside the warning', () => {
+    writeFileSync(join(afkHome, 'settings.json'), JSON.stringify({ hooks: {} }), 'utf-8');
+    writeFileSync(
+      join(afkHome, 'config', 'settings.json'),
+      JSON.stringify({
+        enableShellHooks: true,
+        hooks: { SessionStart: [{ hooks: [{ type: 'command', command: 'echo hi' }] }] },
+      }),
+      'utf-8',
+    );
+
+    const result = loadHooksConfig({ cwd: projectCwd });
+    expect(result.userGlobalEnabled).toBe(true);
+    expect(result.hooks.SessionStart).toHaveLength(1);
+    expect(result.warnings.some((w) => w.includes('AFK-home root'))).toBe(true);
+  });
+});

--- a/src/agent/hooks/config-loader.ts
+++ b/src/agent/hooks/config-loader.ts
@@ -28,7 +28,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { getJsonConfigPath, getSettingsPath, getProjectSettingsPath } from '../../paths.js';
+import { getAfkHome, getJsonConfigPath, getSettingsPath, getProjectSettingsPath } from '../../paths.js';
 import type { HarnessHookEvent } from '../hooks.js';
 import { HOOK_HANDLER_TIMEOUT_MS } from '../hook-registry.js';
 
@@ -329,6 +329,24 @@ export function loadHooksConfig(opts: LoadHooksConfigOptions = {}): LoadedHooksC
     seenPaths.add(layer.path);
     return true;
   });
+
+  // Misplacement guard: a settings file at the AFK-home ROOT
+  // (`~/.afk/settings.json`) is NOT a config source — the user-global
+  // supplemental layer lives at `~/.afk/config/settings.json` (layer 1).
+  // A root-level file is otherwise a silent no-op (found in the wild holding
+  // a dead SubagentStop hook shim the owner believed was active), so surface
+  // the misplacement through the warnings channel instead of ignoring it.
+  try {
+    const orphanSettings = join(getAfkHome(), 'settings.json');
+    if (!seenPaths.has(orphanSettings) && existsSync(orphanSettings)) {
+      allWarnings.push(
+        `found ${orphanSettings} but AFK does not read settings from the AFK-home root; ` +
+          `user-global hooks/settings belong in ${getSettingsPath()} — the root file is ignored`,
+      );
+    }
+  } catch {
+    // Probe failure must never affect config loading.
+  }
 
   // First pass (user-global layers only): determine trust flags before
   // deciding which project-local hooks to admit.


### PR DESCRIPTION
## What

First **gate-skill → hook migration** (Wave 0 of the friction-substrate / gate-migration plan). Principle: **capabilities can be voluntary; constraints cannot** — a gate that relies on the failing agent to invoke it is not a gate. The nightly forge-friction telemetry has been saying this for weeks: *"adoption/enforcement gap, not a skill gap."*

### 1. `ask_question` PreToolUse gate (new built-in hook)

When **no elicitation handler** is installed (daemon, scheduler, one-shot `afk chat` — no interactive operator attached), a question can never be answered. Previously the elicitation router would park-and-notify then auto-decline **after** the round-trip, handing the model a bare `{ action: "decline" }` it may mishandle or retry. The gate moves that outcome **before** the call:

- blocks with guidance: *proceed on a stated assumption recorded for async review, or end with a Blocked terminal state naming what the operator must supply*;
- fires the same best-effort Telegram push (park-and-notify parity — enforcement must not regress async operator visibility);
- no-op on REPL/Telegram (handler installed; probed at call time, so normal bootstrap order is safe);
- the block is witnessed as `hook_block:ask_question` — a structured, pre-classified catch-record for the failure-mode telemetry substrate (classify as deliberate-guardrail, "working as designed").

Pattern precedent: `plan-mode-gate.ts` (deterministic PreToolUse block) and `shadow-verify-nudge.ts` (skill logic ported to a native built-in hook).

### 2. Orphan root-settings warning (real-world bug)

`~/.afk/settings.json` (AFK-home **root**) is not a hooks-config source — the user-global layer is `~/.afk/config/settings.json`. A root-level file was a **silent no-op**; one was found in the wild holding a dead SubagentStop shim the owner believed was active. `loadHooksConfig()` now surfaces the misplacement through its existing `warnings` channel.

### 3. Supporting changes

- `elicitationRouter.hasHandler()` — deterministic reachability probe (read at call time).
- `config-bridge.test.ts` count baselines +1 for the new unconditional built-in PreToolUse handler.

## Verification

- `pnpm lint` (strict tsc) clean
- Full `pnpm test`: **598 files / 11,185 tests passed** (2 pre-existing count assertions updated with rationale)
- `pnpm audit:sdk:check` + `pnpm scan:env:check` clean
- New tests: 9 gate cases (block/allow/ignore/notify/truncate/throw-safety/malformed-input/default-wiring), router `hasHandler()`, 3 orphan-warning loader cases

## Roadmap context

Wave 0 of `.afk/plans/friction-substrate-and-gate-migration.md` (local plan doc): next waves migrate safe-destruct / target-lock / release-boundary-gate to PreToolUse hooks (injectContext-first rollout), move fanout-pace + long-bash detection into harness code, ship Stop block-enforcement, then re-point forge-friction onto the reasoning-failure substrate (gate catch-records + pattern-cards).
