### PR TITLE
refactor(subagent): extract appendInjectContext helper

### DIFF
--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -14,6 +14,7 @@
 import { getSkill } from '../../skills/index.js';
 import { SubagentManager } from '../subagent.js';
 import { annotateIfIncomplete } from '../subagent/result.js';
+import { appendInjectContext } from './subagent/inject-context.js';
 import type { AgentModelInput, IAgentSession } from '../types.js';
 import type { ModelProvider } from '../provider.js';
 import type { ToolCall, ToolResult } from './types.js';
@@ -1184,9 +1185,7 @@ export class SkillExecutor {
       // The catch path leaves toolResult unset — nothing to append to, note
       // dropped for that stop by design (the error string is the signal).
       const injectContext = handle?.getLastStopInjectContext?.();
-      if (toolResult !== undefined && injectContext !== undefined && injectContext.length > 0) {
-        toolResult.content = `${toolResult.content}\n\n${injectContext}`;
-      }
+      appendInjectContext(toolResult, injectContext);
       await childManager?.teardownAll();
       await manager.teardownAll();
     }

--- a/src/agent/tools/subagent/foreground-promotion.ts
+++ b/src/agent/tools/subagent/foreground-promotion.ts
@@ -25,6 +25,7 @@ import type { TraceOrigin, TraceActor } from '../../session/session-identity.js'
 import type { ToolResult } from '../types.js';
 import type { PromotedSubagentInfo } from '../subagent-executor.js';
 import { emitTelemetry, truncate, measurePartial, buildFailurePayload } from './failure-payload.js';
+import { appendInjectContext } from './inject-context.js';
 
 type ForkedHandle = Awaited<ReturnType<SubagentManager['forkSubagent']>>;
 
@@ -324,9 +325,7 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
       // Optional-chain: real SubagentHandleImpl always defines this; the
       // `?.()` tolerates narrow handle doubles (returns undefined = no note).
       const injectContext = handle.getLastStopInjectContext?.();
-      if (toolResult !== undefined && injectContext !== undefined && injectContext.length > 0) {
-        toolResult.content = `${toolResult.content}\n\n${injectContext}`;
-      }
+      appendInjectContext(toolResult, injectContext);
     }
   }
 }

--- a/src/agent/tools/subagent/inject-context.ts
+++ b/src/agent/tools/subagent/inject-context.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared in-turn SubagentStop injectContext append helper.
+ *
+ * Extracted from the duplicate guard+append blocks in `skill-executor.ts` and
+ * `foreground-promotion.ts` (issue #393). Each call site keeps its own
+ * `getLastStopInjectContext?.()` extraction (the handle-nullability differs)
+ * then calls this to perform the identical guard + append.
+ *
+ * @module agent/tools/subagent/inject-context
+ */
+
+import type { ToolResult } from '../types.js';
+
+/**
+ * Append a SubagentStop injectContext note to a completion `ToolResult`
+ * in-turn. No-op unless the run produced a `ToolResult` AND the note is a
+ * non-empty string — the error/rethrow paths leave `toolResult` unset, so the
+ * note is dropped for that stop by design (the error is the parent's signal).
+ * Mutates `toolResult.content` in place.
+ */
+export function appendInjectContext(
+  toolResult: ToolResult | undefined,
+  injectContext: string | undefined,
+): void {
+  if (toolResult !== undefined && injectContext !== undefined && injectContext.length > 0) {
+    toolResult.content = `${toolResult.content}\n\n${injectContext}`;
+  }
+}


### PR DESCRIPTION
## What

Extract the duplicated in-turn `SubagentStop` injectContext guard+append block into a shared helper `appendInjectContext(toolResult, injectContext)`.

New file: `src/agent/tools/subagent/inject-context.ts`

```ts
export function appendInjectContext(
  toolResult: ToolResult | undefined,
  injectContext: string | undefined,
): void {
  if (toolResult !== undefined && injectContext !== undefined && injectContext.length > 0) {
    toolResult.content = `${toolResult.content}\n\n${injectContext}`;
  }
}
```

Each call site keeps its **own** `getLastStopInjectContext?.()` extraction line (preserving the `handle?.` vs `handle.` nullability difference) and its surrounding invariant comments, then delegates the guard+append to the helper.

## Why

Pure behavior-preserving deduplication — the guard+append was byte-identical in two places. No functional change.

## Scope correction

The issue title says **3x** duplication (follow-up to #387), but there are now exactly **TWO** identical sites at fix time — the third was already removed in prior work. Verified via `grep -rn "injectContext !== undefined && injectContext.length" src/` before starting (two hits only). The refactor therefore covers the two remaining sites.

## Call sites updated

- `src/agent/tools/skill-executor.ts` (~L1186, `finally` block — uses `handle?.getLastStopInjectContext?.()`)
- `src/agent/tools/subagent/foreground-promotion.ts` (~L326, non-promoted teardown — uses `handle.getLastStopInjectContext?.()`)

## Helper location + no import cycle

Placed in `src/agent/tools/subagent/inject-context.ts`, a sibling to the existing pure-helper module `failure-payload.ts` in the same dir.

The helper imports only `type { ToolResult }` from `../types.js`, which is a **leaf type-only re-export module** (it only re-exports types from `providers/anthropic-direct/types.ts`). Both call-site modules already import `ToolResult` from that same leaf. Neither the new helper nor `../types.js` imports `skill-executor.ts` or `foreground-promotion.ts`, so no runtime cycle is introduced (the only back-references from the subagent dir toward `skill-executor.ts` are `import type`, which is erased at compile). `tsc --noEmit` confirms clean.

## Verification

- **Lint** (`pnpm lint` = `tsc --noEmit`, maximally strict): clean, exit 0. No unused imports.
- **Tests**: full suite green — **597 test files, 11181 passed / 14 skipped / 0 failed**. Targeted re-run of the affected/adjacent files (`subagent-executor.test.ts`, `skill-executor.test.ts`, `hooks-integration.test.ts`, `child-config.test.ts`, `failure-payload.test.ts`): **276 passed / 0 failed**.
- The dedicated in-turn injectContext append tests in `subagent-executor.test.ts` (success path, no-injectContext, empty-string no-op, failure-payload path) all pass — directly confirming behavior is unchanged.

Closes #393
