### PR TITLE
fix(anthropic): restore usage-limit pause + hot-swap for subscription 429s (regression)

### DIFF
--- a/src/agent/providers/anthropic-direct/usage-limit.test.ts
+++ b/src/agent/providers/anthropic-direct/usage-limit.test.ts
@@ -3,7 +3,13 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { classifyUsageLimitError, parseRetryAfterMs, waitForReset, waitForHotSwap } from './usage-limit.js';
+import {
+  classifyUsageLimitError,
+  parseRetryAfterMs,
+  waitForReset,
+  waitForHotSwap,
+  RATE_LIMIT_TRANSIENT_MAX_RETRY_AFTER_MS,
+} from './usage-limit.js';
 
 // ---------------------------------------------------------------------------
 // classifyUsageLimitError
@@ -101,6 +107,30 @@ describe('classifyUsageLimitError', () => {
     if (result?.kind === 'rate-limit-transient') {
       expect(result.retryAfterMs).toBe(5_000);
     }
+  });
+
+  // Regression (2026-07): Anthropic delivers an OAuth *subscription* cap as a
+  // bare `429 rate_limit_error` + a LONG retry-after and no |ts — identical in
+  // shape to a transient throttle except for magnitude (anthropics/claude-
+  // code#30930). It must route to the pause + hot-swap path (oauth-limit-no-ts),
+  // NOT the silent transient-retry path — which emits no `paused` event (so the
+  // operator is never notified) and never watches the keychain for an account
+  // switch (so switching accounts never resumes the turn).
+  it('returns oauth-limit-no-ts for a 429 with a long retry-after and no |ts (subscription cap)', () => {
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', { 'retry-after': '3600' });
+    expect(classifyUsageLimitError(err)?.kind).toBe('oauth-limit-no-ts');
+  });
+
+  it('routes a retry-after AT the transient threshold as transient, just PAST it as subscription', () => {
+    const atThreshold = makeErrorWithHeaders(429, '429', {
+      'retry-after-ms': String(RATE_LIMIT_TRANSIENT_MAX_RETRY_AFTER_MS),
+    });
+    expect(classifyUsageLimitError(atThreshold)?.kind).toBe('rate-limit-transient');
+
+    const pastThreshold = makeErrorWithHeaders(429, '429', {
+      'retry-after-ms': String(RATE_LIMIT_TRANSIENT_MAX_RETRY_AFTER_MS + 1),
+    });
+    expect(classifyUsageLimitError(pastThreshold)?.kind).toBe('oauth-limit-no-ts');
   });
 });
 

--- a/src/agent/providers/anthropic-direct/usage-limit.ts
+++ b/src/agent/providers/anthropic-direct/usage-limit.ts
@@ -22,6 +22,21 @@ export type UsageLimitClassification =
   | { kind: 'credit-exhausted' };
 
 /**
+ * Upper bound (ms) on a `retry-after` hint that still counts as a *transient*
+ * API-tier rate limit (per-minute RPM/ITPM/OTPM windows that clear in seconds).
+ *
+ * Invariant: Anthropic returns the SAME `429 rate_limit_error` + `retry-after`
+ * shape for BOTH a per-minute API throttle AND an OAuth *subscription* cap — the
+ * subscription limit arrives as a bare `rate_limit_error` with a `retry-after`
+ * header and no `|<ts>` (see anthropics/claude-code#30930). Header PRESENCE
+ * therefore cannot distinguish them; only its MAGNITUDE can. Per-minute
+ * throttles clear in ≤ a minute or two; a subscription reset is hours away, so a
+ * `retry-after` above this line is treated as subscription exhaustion (pause +
+ * hot-swap + auto-resume), not a short silent retry.
+ */
+export const RATE_LIMIT_TRANSIENT_MAX_RETRY_AFTER_MS = 5 * 60 * 1000;
+
+/**
  * Best-effort parse of a transient-backoff hint from an error's HTTP headers.
  *
  * Reads `retry-after-ms` (milliseconds) first, then `retry-after` (seconds, or
@@ -71,13 +86,17 @@ export function parseRetryAfterMs(error: unknown): number | undefined {
  * Recognised patterns:
  *   - HTTP 429 with message containing `|<unix-ts>` — OAuth subscription limit
  *     (the timestamp is when the limit resets).
- *   - HTTP 429 with a `retry-after`/`retry-after-ms` header and NO `|<unix-ts>`
- *     — a transient API-tier rate limit (RPM/ITPM), NOT subscription
- *     exhaustion. The header gives a short (seconds) backoff. Kept distinct so
- *     callers do not apply the 2-hour subscription-pause semantics to a
- *     throttle that clears in seconds.
- *   - HTTP 429 without timestamp AND without a retry-after header — OAuth
- *     subscription limit with unknown reset (unchanged fallback).
+ *   - HTTP 429 with a SHORT `retry-after`/`retry-after-ms` header
+ *     (≤ {@link RATE_LIMIT_TRANSIENT_MAX_RETRY_AFTER_MS}) and no `|<unix-ts>` —
+ *     a transient API-tier rate limit (per-minute RPM/ITPM) that clears in
+ *     seconds. Kept distinct so callers do not apply the 2-hour subscription-
+ *     pause semantics to a throttle that clears in seconds.
+ *   - HTTP 429 with a LONG `retry-after` (> the threshold) OR no `retry-after`
+ *     header, and no `|<unix-ts>` — OAuth subscription exhaustion with unknown
+ *     reset. Anthropic delivers the subscription cap as a bare
+ *     `rate_limit_error` + `retry-after` (anthropics/claude-code#30930), so a
+ *     long/absent backoff is the signal that separates it from a per-minute
+ *     throttle. Routed to the pause + hot-swap + auto-resume path.
  *   - HTTP 400 + `invalid_request_error` + `credit balance` — API key balance
  *     exhausted.
  */
@@ -93,15 +112,22 @@ export function classifyUsageLimitError(error: Error): UsageLimitClassification 
         return { kind: 'oauth-limit', resetsAt: new Date(ts * 1000) };
       }
     }
-    // Invariant: OAuth *subscription* exhaustion encodes its reset in the
-    // message `|<unix-ts>` (handled above) — it does not depend on a
-    // `retry-after` header. A standard API-tier rate-limit 429 instead carries
-    // `retry-after` and no timestamp. So "429 + retry-after + no |ts" is a
-    // transient rate limit, and misrouting it into the timestamp-less
-    // subscription path (poll every 60s for up to 2h, labelled "usage limit")
-    // is the bug this branch fixes.
+    // Invariant: Anthropic returns the SAME `429 rate_limit_error` + `retry-after`
+    // shape for a per-minute API throttle AND an OAuth subscription cap — the
+    // subscription limit arrives as a bare `rate_limit_error` with a `retry-after`
+    // header and no `|<ts>` (anthropics/claude-code#30930). Header PRESENCE
+    // therefore cannot tell them apart; only its MAGNITUDE can. A short backoff
+    // (≤ threshold) is a per-minute throttle → transient short retry. A long or
+    // absent backoff is subscription-scale → fall through to oauth-limit-no-ts
+    // (pause + hot-swap + auto-resume), so the operator is notified and an
+    // account hot-swap resumes the turn. Treating EVERY retry-after 429 as
+    // transient silently lost both the pause notification and the hot-swap
+    // watcher — the regression this magnitude gate fixes.
     const retryAfterMs = parseRetryAfterMs(error);
-    if (retryAfterMs !== undefined) {
+    if (
+      retryAfterMs !== undefined &&
+      retryAfterMs <= RATE_LIMIT_TRANSIENT_MAX_RETRY_AFTER_MS
+    ) {
       return { kind: 'rate-limit-transient', retryAfterMs };
     }
     return { kind: 'oauth-limit-no-ts' };


### PR DESCRIPTION
## Summary

Fixes a regression where hitting the Claude **subscription** usage limit no longer produced a notification **and** no longer auto-resumed after switching accounts.

Both symptoms trace to a **single misclassification** in `classifyUsageLimitError`, introduced by #414 and armed by #427.

## Root cause

A 429 is sorted into:
- `oauth-limit` — message carries `|<unix-ts>` → pause + wait-for-reset (watches keychain).
- `oauth-limit-no-ts` — no timestamp, **no** `retry-after` → pause + hot-swap poll.
- `rate-limit-transient` — **has a `retry-after` header, no timestamp** → *silent* wait-and-replay ≤3×, **no `paused` event, no keychain watch**.

#414 assumed "429 + `retry-after` + no `|ts` = a transient per-minute throttle." That assumption is **false against the real API**: Anthropic delivers an OAuth **subscription** cap as a bare `429 rate_limit_error` **with** a `retry-after` header and **no** `|ts` — byte-identical in shape to a transient throttle (see [anthropics/claude-code#30930](https://github.com/anthropics/claude-code/issues/30930); Anthropic docs confirm *every* 429 carries `retry-after`). Before #414 afk did not parse `retry-after`, so these fell to `oauth-limit-no-ts` and worked; #414 started parsing it and rerouted real subscription exhaustion into the silent transient path.

Consequences of the reroute:
- **No notification** — the "⏸ Usage paused" card fires only on a `paused` event (`telegram/streaming.ts`, REPL `render/usage-limit-box.ts`). The transient path never emits `paused`.
- **No autoresume on account switch** — the transient path uses `sleepWithAbort`, never `waitForHotSwap`/`waitForReset`, so a mid-wait keychain token swap is never detected; after 3 short retries a raw error surfaces.

## Fix

Header *presence* cannot discriminate the two — **magnitude can**. A per-minute throttle clears in seconds; a subscription reset is hours away. Gate `rate-limit-transient` on `retry-after <= RATE_LIMIT_TRANSIENT_MAX_RETRY_AFTER_MS` (5 min). A **long or absent** backoff now falls through to `oauth-limit-no-ts` → pause + notification + hot-swap + auto-resume (pre-#414 behavior). Genuine transient collisions (small `retry-after`, the daemon-cron case #414/#427 fixed) keep the patient short-retry.

## Changes
- `usage-limit.ts`: threshold constant + magnitude gate; corrected the now-false invariant comments.
- `usage-limit.test.ts`: +2 regression tests (long `retry-after` → `oauth-limit-no-ts`; threshold boundary).

## Testing
- `pnpm test` — 11,183 pass / 0 fail
- `pnpm lint` (`tsc --noEmit`) — clean
- `pnpm audit:sdk:check` — OK

## Known edge / possible follow-up
A subscription cap that sends a *small* (<5 min) `retry-after` would still misclassify — unlikely for the account-switch scenario (reset is far away → large/absent backoff) and it fails bounded. Optional hardening (not in this PR, to keep it minimal): make the transient wait itself hot-swap-aware (`sleepWithAbort` → `waitForHotSwap`) so account-switching resumes even in a misclassified transient wait.
