### PR TITLE
feat(agent): first-class isolation:"worktree" for the agent tool

### DIFF
--- a/docs/proposals/first-class-worktree-isolation.md
+++ b/docs/proposals/first-class-worktree-isolation.md
@@ -1,0 +1,245 @@
+# Proposal: First-Class `isolation: "worktree"` for the `agent` Tool
+
+**Status:** MVP implemented (2026-07-10) — see §9.
+**Author:** Scoped via read-only sub-agent investigation + main-session verification, 2026-07-10
+**Scope:** `src/agent/tools/subagent/*`, `src/agent/subagent.ts`, `src/agent/tools/handlers/worktree.ts`, `src/agent/worktree*.ts`, bundled skills under `src/bundled-plugins/awa-bundled/skills/`
+
+---
+
+## 9. Implementation status (MVP, 2026-07-10)
+
+Waves 1–2 shipped; Wave 3 **dropped as a misread** (see below). Delivered:
+
+- **Factored-out substrate** — `src/agent/tools/handlers/worktree-managed.ts`:
+  `createManagedWorktree`, `removeManagedWorktreeGuarded`, `isManagedWorktreeDirty`,
+  `managedWorktreeCommitsAhead`, `resolveRepoContext`, `sanitizeSlug`, plus the new
+  `createIsolatedWorktree` / `teardownIsolatedWorktree`. `worktree.ts` now delegates to it
+  (byte-identical git argv — `worktree.test.ts` still green). New `worktree-managed.test.ts`.
+- **Schema + parse** — `isolation: 'none' | 'worktree'` on the `agent` tool; parse validates the
+  enum, rejects `cwd`+`isolation` (mutually exclusive) and `isolation:worktree`+`mode:background`.
+- **Executor** — creates the worktree between `buildChildConfig` and `forkSubagent`, sets
+  `childConfig.cwd`, fails loud on a non-git cwd (never falls back to the shared tree). Read-only
+  children (research-agent, recon) skip creation via `childWriteCapable` from `buildChildConfig`.
+- **Teardown** — `foreground-promotion.ts` `if (!promoted)` finally removes the tree; a dirty /
+  commits-ahead tree is **preserved and `git worktree lock`ed** (WIP never destroyed).
+- **Verified** — lint + full suite green; real-git smoke confirms create / clean-remove /
+  dirty-preserve+lock / non-git-throws.
+
+**Wave 3 dropped (correction):** the proposal's §5/Unit 6 said to remove `'isolation'` from
+`RECOGNIZED_UNSUPPORTED_KEYS` (`agents/parser.ts:43`). That set gates **agent-file frontmatter**
+keys — a *different surface* from the `agent` tool param this feature adds — and a test
+(`parser.test.ts:143`) asserts `isolation` stays in `ignoredKeys`. Removing it would be unrelated
+and break that test. Honoring `isolation:` declared in an agent *definition* is a separate future
+feature, not part of this MVP.
+
+**Known MVP limitations (deferred to Phase 2/3):**
+- **Grandchild isolation** — only the direct child's cwd is isolated; a depth-2 fan-out anchors at
+  the parent tree. Fine for the leaf hypothesis/verifier agents the 5 skills dispatch.
+- **Promotion (Ctrl+B)** leaks the tree — a promoted job outlives the teardown; the sweep engine
+  reclaims it later (dead-owner/stale verdict), same as a killed-process tree.
+- **Meta-file dirty dependency** — `isManagedWorktreeDirty` uses `git status --porcelain`, so a
+  consumer repo that does NOT gitignore `.afk-worktree-meta.json` sees fresh trees as dirty and
+  preserves+locks them (sprawl, but never data loss). afk gitignores it (`.gitignore:60`); this is
+  a pre-existing dependency of the `worktree` tool, not new.
+- **Return shape** (§3.6) not yet surfaced — no `SubagentResult.isolation` field / content footer,
+  so `diagnose` stays on the manual `worktree`+`cwd` pattern until Phase 2.
+
+---
+
+## 1. Problem
+
+`isolation: "worktree"` is a **no-op** in afk. The `agent` dispatch tool exposes only `cwd`
+(`schemas.ts:382-399`); `parseAgentInput` parses only `cwd` (`input-parse.ts:173-208`); and
+`isolation` sits in `RECOGNIZED_UNSUPPORTED_KEYS` — "recognized but does not honor yet"
+(`agents/parser.ts:43`). So any skill that dispatches a write-capable sub-agent with
+`isolation: "worktree"` actually gets a sub-agent that **inherits the parent's working tree**.
+Parallel such agents corrupt each other's edits and test runs, invalidating any per-branch
+pass/fail attribution.
+
+This bit us concretely: the `diagnose` skill's hypothesis-testing phase (PR #480) shipped the
+`isolation:"worktree"` idiom, which was a silent regression from the deleted TS orchestrator
+that created **real** per-hypothesis worktrees in code (`git worktree add --detach` → isolated
+verifier → `git worktree remove`, commit `3095f1f` `diagnose/_phases/verifier.ts`). PR #480 was
+patched to use the manual `worktree` tool + `cwd` pattern. But **four other bundled skills use
+the same no-op idiom** and remain latently broken: `refactor` (`SKILL.md:82,92,109`),
+`shadow-verify` (`:14`), `simplify` (`:115`), `devils-advocate` (`:27`).
+
+Making `isolation:"worktree"` first-class fixes all of them at once and aligns afk's `agent`
+tool with the Claude Code Task semantics those skills were authored against.
+
+## 2. Current State (verified with file:line)
+
+**Dispatch → cwd → tool handlers (traced end-to-end):**
+- `SubagentExecutor.execute()` (`subagent-executor.ts:385`) → `parseAgentInput` (`:396`) →
+  `buildChildConfig` (`:474`) → `subagentManager.forkSubagent({config: childConfig})` (`:513`) →
+  `runForegroundWithPromotion` (`:585`).
+- `buildChildConfig` threads `parsed.cwd` → `childConfig.cwd` (`child-config.ts:247`).
+- `forkSubagent` applies `config.cwd ?? this.parentCwd` as the child cwd and grants the main
+  repo as a READ root (`subagent.ts:532-539, 621-623`), stamps occupancy (`:685`).
+- `childConfig.cwd` → `AgentSession` → dispatcher `resolveBase` (`dispatcher.ts:292,319-320`) →
+  every file/shell handler (`handlers/bash.ts:147`, `grep.ts:73`, `glob.ts:202`).
+- Executor tracks `this.currentCwd = ctx.cwd` (`subagent-executor.ts:269`).
+
+**Substrate #1 — the `worktree` tool (recommended base):** `createWorktreeHandler(): ToolHandler`
+is a **monolithic** closure (`handlers/worktree.ts:192`) with `case 'create'` (`:227-276`:
+`git worktree add -b afk/<slug> <path> HEAD` + `.afk-worktree-meta.json`) and `case 'remove'`
+(`:329-367`: refuses **dirty** `:346`, **commits-ahead** `:352`, **locked** `:338` unless
+`force`). Trees live under `.afk-worktrees/<slug>` and are protected/reclaimed by the sweep
+engine (`worktree-sweep.ts`), with `keep` = `git worktree lock` self-save. **There is no
+reusable `createManagedWorktree` function today** — it must be factored out of the handler.
+
+**Substrate #2 — Speculative Branch Farm (`worktree.ts`, NOT recommended):** `createFarm` /
+`FarmManifest`, `MAX_FARM_BRANCHES=16`, PR/human-decision lifecycle, lives in `$AFK_HOME/farms/`.
+Over-engineered for ephemeral per-dispatch isolation.
+
+## 3. Recommended Design
+
+**In a nutshell:** add `isolation: "worktree" | "none"` to the schema; in
+`SubagentExecutor.execute()` (between `buildChildConfig` and `forkSubagent`) create a managed
+worktree via a **factored-out `createManagedWorktree()`** (from substrate #1), set
+`childConfig.cwd` to it, run the child, surface the worktree path/branch on the result, then
+remove-or-preserve it in the executor's teardown using the **factored-out guarded remove**.
+
+1. **Schema (`schemas.ts:399`).** `isolation: { enum: ['worktree','none'], default 'none' }`.
+   Enum (not boolean) for future `"container"`. **Mutually exclusive with `cwd`** → error if both.
+2. **Parse (`input-parse.ts`).** Add `isolation?: 'worktree'` to `AgentInput`; validate the enum;
+   throw `"cwd and isolation are mutually exclusive"` when both present; add to the return object.
+3. **Create (executor `:474`→`:513`).** Base = `HEAD` of `this.currentCwd`'s repo, on a fresh
+   real branch `afk/iso-<idPrefix>-<counter+rand>` (a branch, **not** `--detach`, so
+   commits-ahead detection + WIP preservation work). Set `childConfig.cwd = worktreePath`.
+   Precondition: verify `currentCwd` is a git repo first (`resolveWorktreeMainRoot`/`rev-parse`);
+   if not, return a structured tool error — **do not** silently fall back to the shared tree.
+4. **Substrate: reuse #1.** Factor `createManagedWorktree(repoRoot, slug, baseRef)` and
+   `removeManagedWorktreeGuarded(repoRoot, path, {force})` out of `handlers/worktree.ts:227-276` /
+   `:329-367` into a new `worktree-managed.ts`; call from both the tool handler and the executor.
+   (Pure extraction PR, low risk.)
+5. **Cleanup (executor teardown).** NOTE: the teardown seam is **`foreground-promotion.ts:310-330`**
+   (the `if (!promoted)` branch of the `finally`, after `childManager?.teardownAll()` at `:312`) —
+   `subagent-executor.ts:585` only *calls* `runForegroundWithPromotion`. See §8. Remove with `{force:false}` so dirty /
+   commits-ahead trees are **preserved** (WIP not destroyed); when preserved, `git worktree lock`
+   it (the `keep` primitive `worktree.ts:288`) so the sweep never reaps it, and surface the path.
+   Runs on success, failure, and abort (same teardown boundary that already calls
+   `childManager.teardownAll()`). Leaked trees (process killed) are `.afk-worktrees/` trees with a
+   stamped pid → sweep's `dead-owner`/`stale-*` verdicts reclaim or preserve them.
+6. **Return value.** Add optional `isolation?: {worktreePath, branch, baseSha, commitsAhead,
+   dirty}` to `SubagentResult` (`subagent/result.ts`), and append a machine-readable footer to the
+   tool result `content` (e.g. `[isolated-worktree] path=… branch=… commits_ahead=N dirty=bool`)
+   so the parent can collect the diff / apply the winner. (Needed by diagnose's "apply to main".)
+7. **Read-only agents → no-op.** Skip creation when the resolved access has no write/edit/mutating
+   bash (e.g. `research-agent`) — detect via `resolvedAccess` already computed in
+   `child-config.ts:154-167`. Emit a soft note, not an error.
+8. **Nesting → do NOT auto-propagate** (mirror `cwd`, `schemas.ts:396-398`). A grandchild already
+   runs inside the parent's isolated tree via the manager-cwd chain; a grandchild may request its
+   own worktree (nested `git worktree add` off the parent worktree's HEAD is legal).
+9. **Concurrency.** `afk/iso-<idPrefix>-<counter>-<rand>` is collision-free; occupancy + sweep
+   already handle N concurrent `.afk-worktrees/` trees. Risk: a burst of concurrent
+   `git worktree add` can transiently hit the repo index lock — catch + retry once.
+
+## 4. Edge Cases & Risks
+
+- **Non-git cwd:** detect before creating; structured error, don't fork.
+- **Creation failure:** fail loudly; never fall back to the shared tree (reintroduces the bug).
+- **Disk/sweep pressure:** the repo already carries heavy `.afk-worktrees/` sprawl. Aggressive
+  teardown + sweep verdicts mitigate; consider a per-session concurrent-isolation cap.
+- **Cleanup race:** a child still writing when teardown fires → `isDirty` sees it and *preserves*
+  (correct but leaks) → `keep`-lock preserved trees so the sweep doesn't reap mid-work.
+- **Windows:** slug/meta path handling already normalizes `\`/`/`; low incremental risk.
+
+## 5. Migration
+
+- Remove `isolation` from `RECOGNIZED_UNSUPPORTED_KEYS` (`parser.ts:43`).
+- **Keep both** the first-class param AND the manual `worktree`-tool+`cwd` pattern (the latter is
+  strictly more flexible: custom base ref, `keep`, cross-dispatch reuse). Do not deprecate the tool.
+- After Phase 1, `refactor` / `shadow-verify` / `simplify` / `devils-advocate` "just work" (no edit
+  required; add a one-line note). Migrate `diagnose/SKILL.md` from the manual pattern to
+  `isolation:"worktree"` **only after Phase 2** (its "apply winner to main" step needs the returned
+  branch from §3.6).
+
+## 6. Effort & Phasing
+
+- **MVP (~1–1.5 d):** extract create/remove (§3.4); schema+parse+mutual-exclusion (§3.1–2);
+  executor create/set-cwd/teardown-remove (§3.3, §3.5 basic); skip-if-read-only (§3.7). Unblocks
+  refactor/simplify/shadow-verify/devils-advocate.
+- **Phase 2 (~0.5–1 d):** result-shape + content footer (§3.6); WIP-preserve + lock (§3.5 full);
+  diagnose migration.
+- **Phase 3 (~0.5 d):** concurrency hardening (create-lock retry, per-session cap), Windows pass,
+  sweep-pressure telemetry.
+
+## 7. Open Questions
+
+1. **Background-mode cleanup ownership (must resolve before MVP).** The executor branches on
+   `parsed.mode === 'background'` → `runBackgroundBranch` (`subagent-executor.ts:507`,
+   `background-branch.ts`); the child outlives the executor's turn, so a foreground `finally` would
+   destroy a still-running tree. **Recommendation:** forbid `isolation:"worktree"` +
+   `mode:"background"` in MVP, or trigger removal from the background registry's completion callback.
+2. Auto-name preserved-WIP branches (`afk/iso-<skill>-<timestamp>`) for human discoverability?
+3. Does the installed git serialize concurrent `worktree add` cleanly, or is retry mandatory?
+
+---
+
+## Verification note
+
+The two load-bearing structural claims were independently confirmed in the main session:
+(a) `handlers/worktree.ts:192` is a monolithic `createWorktreeHandler(): ToolHandler` with inline
+`case 'create'`/`case 'remove'` — no reusable extraction exists (confirms §3.4); (b) the executor
+seam (`execute` → `parseAgentInput` → `buildChildConfig` → `forkSubagent` →
+`runForegroundWithPromotion`) exists at the cited lines (confirms §3.3, §3.5). The background-mode
+branch at `:507` confirms Open Question 1 is real. Not independently verified: the internals of
+`foreground-promotion.ts` (exact teardown insertion line) and `background-branch.ts`.
+
+---
+
+## 8. Implementation orchestration plan (waves)
+
+Produced by a planning sub-agent (2026-07-10) and re-verified by file read. **Honest parallelism
+assessment: this feature is mostly serial.** Only Wave 1 has independent lanes, and they are
+small; Wave 2 (the executor integration — the real work) cannot be parallelized because units 4
+and 5 both edit `subagent-executor.ts`.
+
+### Verified seam corrections (read before dispatch)
+- Teardown lands in **`foreground-promotion.ts:310-330`** (the `if (!promoted)` finally branch),
+  not `subagent-executor.ts:585`. Worktree path/branch must be threaded via a new field on
+  `RunForegroundArgs` (`foreground-promotion.ts:42-64`).
+- The extracted `createManagedWorktree`/`removeManagedWorktreeGuarded` **must accept an injectable
+  `ExecFileFn`** — `worktree.ts` helpers (`resolveRepoContext:54`, `findEntry:123`,
+  `resolveManagedWorktree:137`, `isDirty:155`, `commitsAhead:164`) all take `execFile` as a param
+  and `worktree.test.ts:21` mocks it. Break that seam and parity tests fail.
+- Executor already has `this.currentCwd` (`subagent-executor.ts:266,479`); the git-repo
+  precondition uses existing `resolveWorktreeMainRoot` (`worktree-read-root.ts:72`).
+
+### Wave 1 — independent foundations (3 parallel lanes; disjoint files)
+| Unit | Creates/Edits | Tests | Acceptance |
+|---|---|---|---|
+| 1. Factor-out | creates `handlers/worktree-managed.ts`; edits `handlers/worktree.ts` (`case 'create':227-276`, `case 'remove':329-367` delegate) | new `worktree-managed.test.ts` + existing `worktree.test.ts` unchanged | parity: identical git argv; `worktree.test.ts` green |
+| 2. Schema | edits `tools/schemas.ts` (isolation enum after `:399`) | schema smoke assertion | enum present; lint green |
+| 3. Parse+validate | edits `subagent/input-parse.ts` (`AgentInput` `:15-65`; validation+return `:198-209`) | `input-parse.test.ts` | throws on `cwd`+`isolation`; **throws on `isolation:'worktree'`+`mode:'background'`** (MVP forbid); enum-validates |
+
+File-set disjointness confirmed (worktree*.ts / schemas.ts / input-parse.ts — no overlap).
+**GATE 1:** `pnpm lint && pnpm test` green.
+
+### Wave 2 — executor integration (single serial lane; depends on 1+2+3)
+| Unit | Edits | Tests | Acceptance |
+|---|---|---|---|
+| 4. Create + set-cwd | `subagent-executor.ts` between `buildChildConfig:474` and `forkSubagent:513` (git precondition on `currentCwd`; `createManagedWorktree`; set `childConfig.cwd`; structured error if non-git) | new `subagent-executor.isolation.test.ts` | tree created; cwd set; non-git → error, no fork |
+| 4b. Teardown | `foreground-promotion.ts` (`RunForegroundArgs:42-64` + `if(!promoted)` branch `:310-330` → `removeManagedWorktreeGuarded({force:false})`) | same test | teardown fires on success/failure/abort; dirty/ahead preserved+locked |
+| 5. Read-only skip | `subagent-executor.ts` (skip via `resolvedAccess`, `child-config.ts:154-167`) | same test | no-write child → creation skipped, soft note |
+
+Units 4/4b/5 are ONE lane (4 & 5 both edit `subagent-executor.ts`). **GATE 2:** lint + test green.
+
+### Wave 3 — cleanup (trivial; after Wave 2)
+| Unit | Edits | Acceptance |
+|---|---|---|
+| 6. Un-ignore | `agents/parser.ts:43` (drop `'isolation'` from `RECOGNIZED_UNSUPPORTED_KEYS`) | parser tests green |
+
+Sequenced last: removing it before the schema/executor honor `isolation` would turn agent-file
+`isolation:` from a tolerated no-op into an unknown-key warning (transient regression).
+**GATE 3:** lint + test green.
+
+### Coordinator decisions to resolve during execution
+1. `resolvedAccess` (Unit 5): surface it from `buildChildConfig`'s return, or compute the skip
+   inside `child-config.ts`? (Affects Wave 2 lane shape.)
+2. Worktree→teardown plumbing: new `RunForegroundArgs` field (recommended) vs. handling teardown
+   in the executor around `:585`.
+3. **MVP return-shape scope**: MVP stops at cwd-set + teardown, **no** `SubagentResult.isolation`
+   field (that footer is Phase 2, §3.6). diagnose migration waits for Phase 2.
+4. Branch-name counter source in the executor (`afk/iso-<idPrefix>-<counter>-<rand>`).

--- a/src/agent/tools/handlers/worktree-managed.test.ts
+++ b/src/agent/tools/handlers/worktree-managed.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for the factored-out managed-worktree primitives shared by the
+ * `worktree` tool handler and the `agent` tool's isolation:"worktree" path.
+ *
+ * Uses a mocked ExecFileFn (same pattern as worktree.test.ts) so no real git
+ * runs. Focus: the git argv emitted (parity with the pre-extraction handler)
+ * and the create/teardown decision logic for isolated worktrees.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  createManagedWorktree,
+  removeManagedWorktreeGuarded,
+  createIsolatedWorktree,
+  teardownIsolatedWorktree,
+} from './worktree-managed.js';
+import type { ExecFileFn } from '../../worktree-sweep.js';
+
+interface Call { file: string; args: string[] }
+
+function makeMock(
+  responder: (call: Call) => Promise<{ stdout: string; stderr: string }> | { stdout: string; stderr: string },
+): ExecFileFn & { calls: Call[] } {
+  const calls: Call[] = [];
+  const fn = (async (file: string, args: string[]) => {
+    const call = { file, args };
+    calls.push(call);
+    return responder(call);
+  }) as ExecFileFn & { calls: Call[] };
+  fn.calls = calls;
+  return fn;
+}
+
+let repoRoot: string;
+
+beforeEach(() => {
+  repoRoot = mkdtempSync(join(tmpdir(), 'wt-managed-'));
+});
+
+afterEach(() => {
+  rmSync(repoRoot, { recursive: true, force: true });
+});
+
+describe('createManagedWorktree — argv + meta parity', () => {
+  it('emits `git worktree add -b <branch> <path> <baseRef>` and writes meta', async () => {
+    const wtPath = join(repoRoot, '.afk-worktrees', 'feat');
+    const mock = makeMock((call) => {
+      if (call.args.includes('add')) {
+        return fs.mkdir(wtPath, { recursive: true }).then(() => ({ stdout: '', stderr: '' }));
+      }
+      if (call.args.includes('rev-parse')) return { stdout: 'base-sha-999\n', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+    const info = await createManagedWorktree({
+      execFile: mock,
+      repoRoot,
+      worktreePath: wtPath,
+      branch: 'afk/feat',
+      baseRef: 'HEAD',
+    });
+    expect(info).toEqual({ path: wtPath, branch: 'afk/feat', baseRef: 'HEAD', baseSha: 'base-sha-999' });
+    const addCall = mock.calls.find((c) => c.args.includes('add'));
+    expect(addCall?.args).toEqual(['-C', repoRoot, 'worktree', 'add', '-b', 'afk/feat', wtPath, 'HEAD']);
+    const meta = JSON.parse(await fs.readFile(join(wtPath, '.afk-worktree-meta.json'), 'utf-8')) as Record<string, unknown>;
+    expect(meta['owner']).toBe('agent');
+    expect(meta['baseSha']).toBe('base-sha-999');
+    expect(meta['pid']).toBe(process.pid);
+  });
+});
+
+describe('removeManagedWorktreeGuarded — guards + argv', () => {
+  it('removes a clean tree with no --force', async () => {
+    const wtPath = join(repoRoot, '.afk-worktrees', 'clean');
+    const mock = makeMock((call) => {
+      if (call.args.includes('status')) return { stdout: '', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+    const outcome = await removeManagedWorktreeGuarded({
+      execFile: mock, repoRoot, worktreePath: wtPath, branch: 'refs/heads/afk/clean',
+    });
+    expect(outcome).toEqual({ removed: true, branchPreserved: 'refs/heads/afk/clean' });
+    const rm = mock.calls.find((c) => c.args.includes('remove'));
+    expect(rm?.args).toEqual(['-C', repoRoot, 'worktree', 'remove', wtPath]);
+    expect(rm?.args).not.toContain('--force');
+  });
+
+  it('refuses a dirty tree without force (reason: dirty)', async () => {
+    const wtPath = join(repoRoot, '.afk-worktrees', 'dirty');
+    const mock = makeMock((call) => {
+      if (call.args.includes('status')) return { stdout: ' M f.ts\n', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+    const outcome = await removeManagedWorktreeGuarded({ execFile: mock, repoRoot, worktreePath: wtPath });
+    expect(outcome).toEqual({ removed: false, reason: 'dirty' });
+    expect(mock.calls.some((c) => c.args.includes('remove'))).toBe(false);
+  });
+
+  it('refuses a commits-ahead tree without force (reason: commits-ahead)', async () => {
+    const wtPath = join(repoRoot, '.afk-worktrees', 'ahead');
+    await fs.mkdir(wtPath, { recursive: true });
+    await fs.writeFile(join(wtPath, '.afk-worktree-meta.json'), JSON.stringify({ baseSha: 'base1' }));
+    const mock = makeMock((call) => {
+      if (call.args.includes('status')) return { stdout: '', stderr: '' };
+      if (call.args.includes('rev-parse')) return { stdout: 'tip9\n', stderr: '' };
+      if (call.args.includes('rev-list')) return { stdout: '3\n', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+    const outcome = await removeManagedWorktreeGuarded({ execFile: mock, repoRoot, worktreePath: wtPath });
+    expect(outcome).toEqual({ removed: false, reason: 'commits-ahead', commitsAhead: 3 });
+  });
+
+  it('force removes with --force, skipping guards', async () => {
+    const wtPath = join(repoRoot, '.afk-worktrees', 'force');
+    const mock = makeMock(() => ({ stdout: ' M dirty.ts\n', stderr: '' }));
+    const outcome = await removeManagedWorktreeGuarded({ execFile: mock, repoRoot, worktreePath: wtPath, force: true });
+    expect(outcome.removed).toBe(true);
+    const rm = mock.calls.find((c) => c.args.includes('remove'));
+    expect(rm?.args).toContain('--force');
+    // No status check when forced.
+    expect(mock.calls.some((c) => c.args.includes('status'))).toBe(false);
+  });
+});
+
+describe('createIsolatedWorktree', () => {
+  it('resolves the repo root and creates an afk/iso-* branch based on HEAD', async () => {
+    const mock = makeMock((call) => {
+      if (call.args.includes('--git-common-dir')) return { stdout: `${repoRoot}/.git\n`, stderr: '' };
+      if (call.args.includes('add')) {
+        const p = call.args[call.args.length - 2] as string; // <path> <baseRef>
+        return fs.mkdir(p, { recursive: true }).then(() => ({ stdout: '', stderr: '' }));
+      }
+      if (call.args.includes('rev-parse')) return { stdout: 'headsha\n', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+    const iso = await createIsolatedWorktree({ execFile: mock, cwd: repoRoot, slugHint: 'iso-diagnose-1-abc123' });
+    expect(iso.repoRoot).toBe(repoRoot);
+    expect(iso.path).toBe(join(repoRoot, '.afk-worktrees', 'iso-diagnose-1-abc123'));
+    expect(iso.branch).toBe('afk/iso-diagnose-1-abc123');
+    expect(iso.baseRef).toBe('HEAD');
+    const addCall = mock.calls.find((c) => c.args.includes('add'));
+    expect(addCall?.args).toEqual([
+      '-C', repoRoot, 'worktree', 'add', '-b', 'afk/iso-diagnose-1-abc123', iso.path, 'HEAD',
+    ]);
+  });
+
+  it('throws when cwd is not a git repository (executor must fail loud, not fall back)', async () => {
+    const mock = makeMock(() => { throw new Error('fatal: not a git repository'); });
+    await expect(
+      createIsolatedWorktree({ execFile: mock, cwd: '/nowhere', slugHint: 'iso-x-1-y' }),
+    ).rejects.toThrow(/not a git repository/);
+  });
+});
+
+describe('teardownIsolatedWorktree', () => {
+  it('removes a clean worktree', async () => {
+    const wtPath = join(repoRoot, '.afk-worktrees', 'iso-clean');
+    const mock = makeMock((call) => {
+      if (call.args.includes('status')) return { stdout: '', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+    const result = await teardownIsolatedWorktree({ execFile: mock, repoRoot, worktreePath: wtPath });
+    expect(result).toEqual({ removed: true, preserved: false });
+    expect(mock.calls.some((c) => c.args.includes('remove'))).toBe(true);
+    expect(mock.calls.some((c) => c.args.includes('lock'))).toBe(false);
+  });
+
+  it('preserves + locks a dirty worktree (WIP never destroyed)', async () => {
+    const wtPath = join(repoRoot, '.afk-worktrees', 'iso-dirty');
+    const mock = makeMock((call) => {
+      if (call.args.includes('status')) return { stdout: ' M wip.ts\n', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+    const result = await teardownIsolatedWorktree({ execFile: mock, repoRoot, worktreePath: wtPath });
+    expect(result).toEqual({ removed: false, preserved: true, reason: 'dirty' });
+    expect(mock.calls.some((c) => c.args.includes('remove'))).toBe(false);
+    const lock = mock.calls.find((c) => c.args.includes('lock'));
+    expect(lock?.args[0]).toBe('-C');
+    expect(lock?.args).toContain(wtPath);
+    expect(lock?.args.join(' ')).toContain('afk: isolated-worktree preserved (dirty)');
+  });
+
+  it('never throws — a git failure degrades to removed:false, preserved:false', async () => {
+    const wtPath = join(repoRoot, '.afk-worktrees', 'iso-boom');
+    const mock = makeMock((call) => {
+      if (call.args.includes('status')) return { stdout: '', stderr: '' };
+      if (call.args.includes('remove')) throw new Error('git remove exploded');
+      return { stdout: '', stderr: '' };
+    });
+    const result = await teardownIsolatedWorktree({ execFile: mock, repoRoot, worktreePath: wtPath });
+    expect(result).toEqual({ removed: false, preserved: false });
+  });
+});

--- a/src/agent/tools/handlers/worktree-managed.test.ts
+++ b/src/agent/tools/handlers/worktree-managed.test.ts
@@ -151,6 +151,44 @@ describe('createIsolatedWorktree', () => {
       createIsolatedWorktree({ execFile: mock, cwd: '/nowhere', slugHint: 'iso-x-1-y' }),
     ).rejects.toThrow(/not a git repository/);
   });
+
+  it('retries once on a lock error then succeeds (concurrent worktree add contention)', async () => {
+    let addCount = 0;
+    const mock = makeMock((call) => {
+      if (call.args.includes('--git-common-dir')) return { stdout: `${repoRoot}/.git\n`, stderr: '' };
+      if (call.args.includes('add')) {
+        addCount += 1;
+        if (addCount === 1) {
+          // First parallel `worktree add` loses the index-lock race.
+          throw new Error('fatal: could not lock ref; another worktree add is in progress (index.lock)');
+        }
+        const p = call.args[call.args.length - 2] as string; // <path> <baseRef>
+        return fs.mkdir(p, { recursive: true }).then(() => ({ stdout: '', stderr: '' }));
+      }
+      if (call.args.includes('rev-parse')) return { stdout: 'headsha\n', stderr: '' };
+      return { stdout: '', stderr: '' };
+    });
+    const iso = await createIsolatedWorktree({ execFile: mock, cwd: repoRoot, slugHint: 'iso-parallel-2-def456' });
+    expect(iso.repoRoot).toBe(repoRoot);
+    expect(iso.path).toBe(join(repoRoot, '.afk-worktrees', 'iso-parallel-2-def456'));
+    expect(iso.branch).toBe('afk/iso-parallel-2-def456');
+    expect(iso.baseRef).toBe('HEAD');
+    // Retried EXACTLY once → `worktree add` invoked twice, second time won.
+    expect(mock.calls.filter((c) => c.args.includes('add'))).toHaveLength(2);
+  });
+
+  it('does NOT retry a non-lock error (deterministic failures propagate immediately)', async () => {
+    const mock = makeMock((call) => {
+      if (call.args.includes('--git-common-dir')) return { stdout: `${repoRoot}/.git\n`, stderr: '' };
+      if (call.args.includes('add')) throw new Error('fatal: something else');
+      return { stdout: '', stderr: '' };
+    });
+    await expect(
+      createIsolatedWorktree({ execFile: mock, cwd: repoRoot, slugHint: 'iso-nonlock-3-ghi789' }),
+    ).rejects.toThrow(/something else/);
+    // No retry → `worktree add` invoked exactly once.
+    expect(mock.calls.filter((c) => c.args.includes('add'))).toHaveLength(1);
+  });
 });
 
 describe('teardownIsolatedWorktree', () => {

--- a/src/agent/tools/handlers/worktree-managed.ts
+++ b/src/agent/tools/handlers/worktree-managed.ts
@@ -1,0 +1,278 @@
+/**
+ * Reusable primitives for afk-managed git worktrees.
+ *
+ * Factored out of `handlers/worktree.ts` so BOTH the `worktree` lifecycle tool
+ * AND the `agent` tool's `isolation: "worktree"` path (subagent-executor.ts)
+ * create and tear down worktrees through the SAME git argv + meta protocol —
+ * `.afk-worktrees/<slug>` trees carrying `.afk-worktree-meta.json`, reclaimed
+ * by the sweep engine (`worktree-sweep.ts`).
+ *
+ * Invariant: the git argv emitted here must stay byte-identical to what the
+ * `worktree` handler emitted before this extraction — `worktree.test.ts`
+ * asserts exact argv, and any drift silently changes the sweep engine's
+ * contract. Every git call goes through an injectable {@link ExecFileFn}
+ * (mocked in tests); nothing here shells out except through it.
+ *
+ * @module agent/tools/handlers/worktree-managed
+ */
+
+import { execFile as execFileCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+import { promises as fs } from 'node:fs';
+import { join, resolve, isAbsolute, dirname } from 'node:path';
+import type { ExecFileFn } from '../../worktree-sweep.js';
+import { env } from '../../../config/env.js';
+
+/** Default git runner. Exported so callers without their own can reuse it. */
+export const defaultExecFile: ExecFileFn = promisify(execFileCallback) as ExecFileFn;
+
+export interface RepoContext {
+  /** MAIN checkout root (resolved via --git-common-dir, worktree-safe). */
+  repoRoot: string;
+  /** `<repoRoot>/.afk-worktrees` — where all managed trees live. */
+  afkWorktreesRoot: string;
+}
+
+/**
+ * Resolve the repo root from `cwd` via `--git-common-dir` so the answer is the
+ * MAIN checkout even when `cwd` itself is a linked worktree. Throws when `cwd`
+ * is not inside a git repository.
+ */
+export async function resolveRepoContext(
+  execFile: ExecFileFn,
+  cwd: string,
+): Promise<RepoContext> {
+  const result = await execFile('git', ['-C', cwd, 'rev-parse', '--git-common-dir']);
+  const raw = result.stdout.trim();
+  if (!raw) throw new Error('Not in a git repository.');
+  const absoluteGitDir = isAbsolute(raw) ? raw : resolve(cwd, raw);
+  const repoRoot = dirname(absoluteGitDir);
+  return { repoRoot, afkWorktreesRoot: join(repoRoot, '.afk-worktrees') };
+}
+
+/** Lowercase-kebab sanitization for worktree slugs / branch fragments. */
+export function sanitizeSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+    .slice(0, 80);
+}
+
+export interface CreateManagedWorktreeArgs {
+  execFile: ExecFileFn;
+  /** MAIN repo root (from {@link resolveRepoContext}). */
+  repoRoot: string;
+  /** Absolute checkout path (caller confines it under `.afk-worktrees/`). */
+  worktreePath: string;
+  /** Full branch name to create, e.g. `afk/my-feature`. */
+  branch: string;
+  /** Git ref the new branch is based on, e.g. `HEAD`. */
+  baseRef: string;
+  /** Meta `owner` tag. Default `'agent'`. */
+  owner?: string;
+}
+
+export interface ManagedWorktreeInfo {
+  path: string;
+  branch: string;
+  baseRef: string;
+  /** Resolved SHA of `baseRef` at creation ('' if rev-parse failed). */
+  baseSha: string;
+}
+
+/**
+ * Create a worktree + branch and stamp `.afk-worktree-meta.json`.
+ *
+ * Emits `git worktree add -b <branch> <path> <baseRef>`, then best-effort
+ * `rev-parse <baseRef>` (for `baseSha`) and the meta write — neither of which
+ * fails the create (mirrors the pre-extraction handler behavior exactly).
+ */
+export async function createManagedWorktree(
+  args: CreateManagedWorktreeArgs,
+): Promise<ManagedWorktreeInfo> {
+  const { execFile, repoRoot, worktreePath, branch, baseRef } = args;
+  await execFile('git', [
+    '-C', repoRoot, 'worktree', 'add', '-b', branch, worktreePath, baseRef,
+  ]);
+  // Meta write is what makes this tree a first-class citizen of the sweep
+  // protocol (age from createdAt, PID liveness). Best-effort: never fail the
+  // create over the rev-parse or the write.
+  let baseSha = '';
+  try {
+    const sha = await execFile('git', ['-C', repoRoot, 'rev-parse', baseRef]);
+    baseSha = sha.stdout.trim();
+  } catch { /* non-fatal */ }
+  try {
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify(
+        {
+          owner: args.owner ?? 'agent',
+          pid: process.pid,
+          createdAt: new Date().toISOString(),
+          baseSha,
+          baseBranch: baseRef,
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
+  } catch { /* best-effort */ }
+  return { path: worktreePath, branch, baseRef, baseSha };
+}
+
+/** True when the worktree has uncommitted changes (unreadable → dirty). */
+export async function isManagedWorktreeDirty(
+  execFile: ExecFileFn,
+  worktreePath: string,
+): Promise<boolean> {
+  try {
+    const status = await execFile('git', ['-C', worktreePath, 'status', '--porcelain']);
+    return status.stdout.trim().length > 0;
+  } catch {
+    return true; // unreadable → treat as dirty (safe fallback)
+  }
+}
+
+/** Commits the worktree HEAD is ahead of its recorded base (0 if unknowable). */
+export async function managedWorktreeCommitsAhead(
+  execFile: ExecFileFn,
+  repoRoot: string,
+  worktreePath: string,
+): Promise<number> {
+  // Base SHA from meta when available; unknowable without it → report 0 and
+  // rely on the dirty/lock guards (mirrors the sweep engine's fallback).
+  try {
+    const metaRaw = await fs.readFile(join(worktreePath, '.afk-worktree-meta.json'), 'utf-8');
+    const meta = JSON.parse(metaRaw) as { baseSha?: string };
+    if (!meta.baseSha) return 0;
+    const head = await execFile('git', ['-C', worktreePath, 'rev-parse', 'HEAD']);
+    const count = await execFile('git', [
+      '-C', repoRoot, 'rev-list', `${meta.baseSha}..${head.stdout.trim()}`, '--count',
+    ]);
+    return parseInt(count.stdout.trim(), 10) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Discriminated outcome of {@link removeManagedWorktreeGuarded}. */
+export type GuardedRemoveOutcome =
+  | { removed: true; branchPreserved: string | null }
+  | { removed: false; reason: 'dirty' }
+  | { removed: false; reason: 'commits-ahead'; commitsAhead: number };
+
+export interface RemoveManagedWorktreeArgs {
+  execFile: ExecFileFn;
+  repoRoot: string;
+  /** Absolute worktree path (caller owns lock/main/outside-root checks). */
+  worktreePath: string;
+  /** Branch ref for the result (never deleted — removal drops the checkout only). */
+  branch?: string | null;
+  /** When true, remove even if dirty / commits-ahead. */
+  force?: boolean;
+}
+
+/**
+ * Guarded worktree removal. Refuses (returns `removed:false` + reason) a dirty
+ * or commits-ahead tree unless `force`. Emits `git worktree remove [--force]
+ * <path>` on success. Never removes the branch ref. Caller maps the reason to
+ * user-facing text (handler) or preserve-and-lock (executor teardown).
+ */
+export async function removeManagedWorktreeGuarded(
+  args: RemoveManagedWorktreeArgs,
+): Promise<GuardedRemoveOutcome> {
+  const { execFile, repoRoot, worktreePath, force } = args;
+  if (!force) {
+    if (await isManagedWorktreeDirty(execFile, worktreePath)) {
+      return { removed: false, reason: 'dirty' };
+    }
+    const ahead = await managedWorktreeCommitsAhead(execFile, repoRoot, worktreePath);
+    if (ahead > 0) {
+      return { removed: false, reason: 'commits-ahead', commitsAhead: ahead };
+    }
+  }
+  const gitArgs = ['-C', repoRoot, 'worktree', 'remove'];
+  if (force) gitArgs.push('--force');
+  gitArgs.push(worktreePath);
+  await execFile('git', gitArgs);
+  return { removed: true, branchPreserved: args.branch ?? null };
+}
+
+/**
+ * Create an isolated worktree for a subagent dispatch. Resolves the repo root
+ * from `cwd`, derives a collision-safe slug + branch, and creates the tree.
+ * Throws when `cwd` is not a git repo — the caller MUST fail loudly rather than
+ * fall back to the shared tree (that reintroduces the cross-contamination bug
+ * isolation exists to prevent).
+ */
+export async function createIsolatedWorktree(args: {
+  execFile?: ExecFileFn;
+  /** Session cwd to resolve the repo root from. */
+  cwd: string;
+  /** Raw slug hint (sanitized here); e.g. `iso-agent-tool-3-a1b2c3`. */
+  slugHint: string;
+  /** Base ref for the branch. Default `HEAD`. */
+  baseRef?: string;
+}): Promise<ManagedWorktreeInfo & { repoRoot: string }> {
+  const execFile = args.execFile ?? defaultExecFile;
+  const ctx = await resolveRepoContext(execFile, args.cwd); // throws if non-git
+  const slug = sanitizeSlug(args.slugHint) || 'iso';
+  const worktreePath = join(ctx.afkWorktreesRoot, slug);
+  const prefix = env.AFK_WORKTREE_BRANCH_PREFIX ?? 'afk/';
+  const branch = `${prefix}${slug}`;
+  const baseRef = args.baseRef ?? 'HEAD';
+  const info = await createManagedWorktree({
+    execFile,
+    repoRoot: ctx.repoRoot,
+    worktreePath,
+    branch,
+    baseRef,
+  });
+  return { repoRoot: ctx.repoRoot, ...info };
+}
+
+/** Result of {@link teardownIsolatedWorktree}. */
+export interface IsolatedTeardownResult {
+  removed: boolean;
+  /** True when the tree was kept (dirty/ahead) and locked against the sweep. */
+  preserved: boolean;
+  reason?: 'dirty' | 'commits-ahead';
+}
+
+/**
+ * Tear down an isolated worktree after its subagent finishes. Removes a
+ * clean tree; PRESERVES a dirty / commits-ahead tree (WIP is never destroyed)
+ * and `git worktree lock`s it so the sweep engine never reaps it out from
+ * under work in progress. Best-effort — never throws (teardown runs in a
+ * `finally`).
+ */
+export async function teardownIsolatedWorktree(args: {
+  execFile?: ExecFileFn;
+  repoRoot: string;
+  worktreePath: string;
+}): Promise<IsolatedTeardownResult> {
+  const execFile = args.execFile ?? defaultExecFile;
+  try {
+    const outcome = await removeManagedWorktreeGuarded({
+      execFile,
+      repoRoot: args.repoRoot,
+      worktreePath: args.worktreePath,
+      force: false,
+    });
+    if (outcome.removed) return { removed: true, preserved: false };
+    // Dirty or commits-ahead → preserve WIP; lock so the sweep never reaps it.
+    try {
+      await execFile('git', [
+        '-C', args.repoRoot, 'worktree', 'lock',
+        '--reason', `afk: isolated-worktree preserved (${outcome.reason})`,
+        args.worktreePath,
+      ]);
+    } catch { /* best-effort */ }
+    return { removed: false, preserved: true, reason: outcome.reason };
+  } catch {
+    return { removed: false, preserved: false };
+  }
+}

--- a/src/agent/tools/handlers/worktree-managed.ts
+++ b/src/agent/tools/handlers/worktree-managed.ts
@@ -224,13 +224,34 @@ export async function createIsolatedWorktree(args: {
   const prefix = env.AFK_WORKTREE_BRANCH_PREFIX ?? 'afk/';
   const branch = `${prefix}${slug}`;
   const baseRef = args.baseRef ?? 'HEAD';
-  const info = await createManagedWorktree({
-    execFile,
-    repoRoot: ctx.repoRoot,
-    worktreePath,
-    branch,
-    baseRef,
-  });
+  // Invariant: isolation:"worktree" fans out SEVERAL parallel dispatches, each
+  // running `git worktree add` against the SAME main repo — which serializes on
+  // the repo/index lock. A burst can transiently fail with a lock error, so we
+  // retry the create EXACTLY ONCE after a short backoff. Retry is scoped to
+  // lock contention ONLY (regex below): a non-lock error — not-a-git-repo,
+  // branch/path already exists, etc. — is deterministic and MUST propagate
+  // immediately (retrying it would just fail again, or worse, mask a real bug).
+  // Note: resolveRepoContext above stays OUTSIDE this retry — it is the non-git
+  // precondition and must fail loud. Only createManagedWorktree is wrapped.
+  const LOCK_CONTENTION =
+    /could not lock|index\.lock|already locked|unable to create .*\.lock|File exists/i;
+  const create = () =>
+    createManagedWorktree({
+      execFile,
+      repoRoot: ctx.repoRoot,
+      worktreePath,
+      branch,
+      baseRef,
+    });
+  let info: ManagedWorktreeInfo;
+  try {
+    info = await create();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!LOCK_CONTENTION.test(message)) throw err; // non-lock → propagate, no retry
+    await new Promise((r) => setTimeout(r, 100)); // brief backoff, then retry once
+    info = await create();
+  }
   return { repoRoot: ctx.repoRoot, ...info };
 }
 

--- a/src/agent/tools/handlers/worktree.ts
+++ b/src/agent/tools/handlers/worktree.ts
@@ -25,51 +25,23 @@
  * @module agent/tools/handlers/worktree
  */
 
-import { execFile as execFileCallback } from 'node:child_process';
-import { promisify } from 'node:util';
-import { promises as fs } from 'node:fs';
-import { join, resolve, isAbsolute, dirname, sep } from 'node:path';
+import { join, resolve, isAbsolute, sep } from 'node:path';
 import type { ToolHandler } from '../types.js';
 import { runSweep } from '../../worktree-sweep.js';
 import type { ExecFileFn } from '../../worktree-sweep.js';
 import { env } from '../../../config/env.js';
-
-const defaultExecFile: ExecFileFn = promisify(execFileCallback) as ExecFileFn;
+import {
+  defaultExecFile,
+  resolveRepoContext,
+  sanitizeSlug,
+  createManagedWorktree,
+  removeManagedWorktreeGuarded,
+  type RepoContext,
+} from './worktree-managed.js';
 
 /** Injectable deps for tests. */
 export interface WorktreeHandlerDeps {
   execFile?: ExecFileFn;
-}
-
-interface RepoContext {
-  repoRoot: string;
-  afkWorktreesRoot: string;
-}
-
-/**
- * Resolve the repo root from the session cwd via `--git-common-dir` so the
- * answer is the MAIN checkout even when the session itself runs inside a
- * linked worktree (same trick as the `/worktree` slash command).
- */
-async function resolveRepoContext(
-  execFile: ExecFileFn,
-  cwd: string,
-): Promise<RepoContext> {
-  const result = await execFile('git', ['-C', cwd, 'rev-parse', '--git-common-dir']);
-  const raw = result.stdout.trim();
-  if (!raw) throw new Error('Not in a git repository.');
-  const absoluteGitDir = isAbsolute(raw) ? raw : resolve(cwd, raw);
-  const repoRoot = dirname(absoluteGitDir);
-  return { repoRoot, afkWorktreesRoot: join(repoRoot, '.afk-worktrees') };
-}
-
-/** Lowercase-kebab sanitization for worktree slugs / branch fragments. */
-function sanitizeSlug(name: string): string {
-  return name
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, '-')
-    .replace(/^[-.]+|[-.]+$/g, '')
-    .slice(0, 80);
 }
 
 function resolveCreateBaseRef(base: unknown): string | { error: string } {
@@ -152,36 +124,6 @@ async function resolveManagedWorktree(
   return entry;
 }
 
-async function isDirty(execFile: ExecFileFn, worktreePath: string): Promise<boolean> {
-  try {
-    const status = await execFile('git', ['-C', worktreePath, 'status', '--porcelain']);
-    return status.stdout.trim().length > 0;
-  } catch {
-    return true; // unreadable → treat as dirty (safe fallback)
-  }
-}
-
-async function commitsAhead(
-  execFile: ExecFileFn,
-  repoRoot: string,
-  worktreePath: string,
-): Promise<number> {
-  // Base SHA from meta when available; unknowable without it → report 0 and
-  // rely on the dirty/lock guards (mirrors the sweep engine's fallback).
-  try {
-    const metaRaw = await fs.readFile(join(worktreePath, '.afk-worktree-meta.json'), 'utf-8');
-    const meta = JSON.parse(metaRaw) as { baseSha?: string };
-    if (!meta.baseSha) return 0;
-    const head = await execFile('git', ['-C', worktreePath, 'rev-parse', 'HEAD']);
-    const count = await execFile('git', [
-      '-C', repoRoot, 'rev-list', `${meta.baseSha}..${head.stdout.trim()}`, '--count',
-    ]);
-    return parseInt(count.stdout.trim(), 10) || 0;
-  } catch {
-    return 0;
-  }
-}
-
 /**
  * Build the `worktree` tool handler bound to a session cwd.
  *
@@ -243,36 +185,15 @@ export function createWorktreeHandler(
           if (typeof baseRef !== 'string') {
             return { content: baseRef.error, isError: true };
           }
-          await execFile('git', [
-            '-C', ctx.repoRoot, 'worktree', 'add', '-b', branch, worktreePath, baseRef,
-          ]);
-          // Meta write is what makes this tree a first-class citizen of the
-          // sweep protocol (age from createdAt, PID liveness). Best-effort:
-          // never fail the create over it.
-          let baseSha = '';
-          try {
-            const sha = await execFile('git', ['-C', ctx.repoRoot, 'rev-parse', baseRef]);
-            baseSha = sha.stdout.trim();
-          } catch { /* non-fatal */ }
-          try {
-            await fs.writeFile(
-              join(worktreePath, '.afk-worktree-meta.json'),
-              JSON.stringify(
-                {
-                  owner: 'agent',
-                  pid: process.pid,
-                  createdAt: new Date().toISOString(),
-                  baseSha,
-                  baseBranch: baseRef,
-                },
-                null,
-                2,
-              ),
-              'utf-8',
-            );
-          } catch { /* best-effort */ }
+          const info = await createManagedWorktree({
+            execFile,
+            repoRoot: ctx.repoRoot,
+            worktreePath,
+            branch,
+            baseRef,
+          });
           return {
-            content: JSON.stringify({ path: worktreePath, branch, base: baseRef }),
+            content: JSON.stringify({ path: info.path, branch: info.branch, base: info.baseRef }),
           };
         }
 
@@ -342,28 +263,28 @@ export function createWorktreeHandler(
             };
           }
           const force = obj['force'] === true;
-          if (!force) {
-            if (await isDirty(execFile, entry.path)) {
+          const outcome = await removeManagedWorktreeGuarded({
+            execFile,
+            repoRoot: ctx.repoRoot,
+            worktreePath: entry.path,
+            branch: entry.branch ?? null,
+            force,
+          });
+          if (!outcome.removed) {
+            if (outcome.reason === 'dirty') {
               return {
                 content: `Refused: ${entry.path} has uncommitted changes. Commit/stash them, or pass force: true to discard.`,
                 isError: true,
               };
             }
-            const ahead = await commitsAhead(execFile, ctx.repoRoot, entry.path);
-            if (ahead > 0) {
-              return {
-                content: `Refused: ${entry.path} has ${ahead} commit(s) ahead of its base. The branch ref would survive, but pass force: true to confirm removing the checkout.`,
-                isError: true,
-              };
-            }
+            return {
+              content: `Refused: ${entry.path} has ${outcome.commitsAhead} commit(s) ahead of its base. The branch ref would survive, but pass force: true to confirm removing the checkout.`,
+              isError: true,
+            };
           }
-          const args = ['-C', ctx.repoRoot, 'worktree', 'remove'];
-          if (force) args.push('--force');
-          args.push(entry.path);
-          await execFile('git', args);
           // Branch intentionally left intact — removal drops the checkout only.
           return {
-            content: JSON.stringify({ path: entry.path, removed: true, branchPreserved: entry.branch ?? null }),
+            content: JSON.stringify({ path: entry.path, removed: true, branchPreserved: outcome.branchPreserved }),
           };
         }
       }

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -397,6 +397,23 @@ export const agentTool: AnthropicToolDef = {
           'further nested subagents — each `agent` call must specify `cwd` ' +
           'explicitly to operate in a worktree.',
       },
+      isolation: {
+        type: 'string',
+        enum: ['none', 'worktree'],
+        description:
+          'Filesystem isolation for the subagent. "none" (default) runs the ' +
+          "child in the parent's working tree. \"worktree\" creates a fresh " +
+          'afk-managed git worktree + branch under .afk-worktrees/ and runs the ' +
+          'child there, so several parallel write-capable subagents (e.g. ' +
+          'speculative fixes, refactor lanes) never corrupt each other\'s edits ' +
+          'or test runs. The worktree is torn down when the child finishes; a ' +
+          'dirty or commits-ahead tree is preserved and locked instead of ' +
+          'removed, so work in progress is never destroyed (recover it via the ' +
+          '`worktree` tool). Mutually exclusive with `cwd` (the runtime owns the ' +
+          "child's cwd when isolating). Ignored for read-only agents such as " +
+          'research-agent — they have nothing to isolate. Not supported together ' +
+          'with mode:"background" in this release.',
+      },
     },
     required: ['prompt'],
   },

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -30,6 +30,8 @@ import { emitTelemetry, truncate } from './subagent/failure-payload.js';
 import { buildChildConfig } from './subagent/child-config.js';
 import { runBackgroundBranch } from './subagent/background-branch.js';
 import { runForegroundWithPromotion, type PromotionTrigger } from './subagent/foreground-promotion.js';
+import { createIsolatedWorktree } from './handlers/worktree-managed.js';
+import { debugLog } from '../../utils/debug.js';
 
 export { DEFAULT_MAX_NESTING_DEPTH, type ChildProviderFactoryArgs } from './nesting.js';
 export type { AgentExecutionMode };
@@ -265,6 +267,11 @@ export class SubagentExecutor implements SubagentControl {
   // Read when building the depth-2+ child manager/executor below.
   private currentCwd: string | undefined;
 
+  // Monotonic per-executor counter for collision-free isolated-worktree slugs
+  // (`afk/iso-<idPrefix>-<counter>-<rand>`). Combined with a random suffix so
+  // concurrent `agent` calls in one turn never target the same tree.
+  private isolationCounter = 0;
+
   constructor(private readonly ctx: SubagentExecutorContext) {
     this.currentCwd = ctx.cwd;
   }
@@ -471,7 +478,7 @@ export class SubagentExecutor implements SubagentControl {
     // Build the child config + nested-dispatch wiring. All context this needs
     // is passed explicitly; the recursive child executor is injected as a
     // factory so child-config.ts never imports this class at runtime.
-    const { childConfig, childParentSession, childManager } = buildChildConfig({
+    const { childConfig, childParentSession, childManager, childWriteCapable } = buildChildConfig({
       parsed,
       namedAgent,
       depth,
@@ -497,6 +504,45 @@ export class SubagentExecutor implements SubagentControl {
       ...(this.ctx.traceWriter !== undefined ? { traceWriter: this.ctx.traceWriter } : {}),
       createChildExecutor: (childCtx) => new SubagentExecutor(childCtx),
     });
+
+    // isolation:"worktree" — fork the child inside a fresh managed git worktree
+    // so its writes/tests never collide with siblings sharing the parent tree.
+    // Skipped (no-op) for read-only children, which have nothing to isolate.
+    // Torn down in the foreground finally — a dirty / commits-ahead tree is
+    // preserved and locked, never destroyed. Forbidden with mode:'background'
+    // at parse time (a detached child would outlive the teardown that reclaims
+    // its worktree — proposal Open Q1). Only the direct child's cwd is
+    // isolated; deeper (grandchild) fan-out anchors at the parent tree for now.
+    let isolationTeardown: { repoRoot: string; worktreePath: string } | undefined;
+    if (parsed.isolation === 'worktree') {
+      if (!childWriteCapable) {
+        debugLog(
+          `[isolation] skipped worktree for read-only dispatch ` +
+            `(agent_type=${parsed.agent_type ?? 'generic'}) — nothing to isolate`,
+        );
+      } else {
+        const anchorCwd = this.currentCwd ?? process.cwd();
+        try {
+          const iso = await createIsolatedWorktree({
+            cwd: anchorCwd,
+            slugHint: `iso-${parsed.id_prefix}-${++this.isolationCounter}-${Math.random().toString(36).slice(2, 8)}`,
+          });
+          childConfig.cwd = iso.path;
+          isolationTeardown = { repoRoot: iso.repoRoot, worktreePath: iso.path };
+        } catch (err) {
+          // Fail loud: never silently fall back to the shared tree — that
+          // reintroduces the cross-contamination bug isolation exists to
+          // prevent (parallel siblings clobbering each other's edits/tests).
+          const message = err instanceof Error ? err.message : String(err);
+          return {
+            content:
+              `Failed to create isolated worktree for the subagent: ${message}. ` +
+              `isolation:"worktree" requires the dispatching session to run inside a git repository.`,
+            isError: true,
+          };
+        }
+      }
+    }
 
     // Background dispatches get a wider wall-clock budget than the foreground
     // default the manager applies (SUBAGENT_DEFAULT_TIMEOUT_MS): they don't
@@ -595,6 +641,7 @@ export class SubagentExecutor implements SubagentControl {
       registry: this.ctx.backgroundRegistry,
       promotionTriggers: this.promotionTriggers,
       activeForegroundHandles: this.activeForegroundHandles,
+      ...(isolationTeardown !== undefined ? { isolationTeardown } : {}),
     });
   }
 }

--- a/src/agent/tools/subagent/child-config.test.ts
+++ b/src/agent/tools/subagent/child-config.test.ts
@@ -157,6 +157,41 @@ describe('buildChildConfig', () => {
     });
   });
 
+  describe('childWriteCapable (isolation gating)', () => {
+    it('is true for an unrestricted dispatch (no cage → full write surface)', () => {
+      const { childWriteCapable } = buildChildConfig(baseArgs());
+      expect(childWriteCapable).toBe(true);
+    });
+
+    it('is false for a read-only cage (no write/edit, no bash)', () => {
+      const { childWriteCapable } = buildChildConfig(
+        baseArgs({ allowedTools: ['read_file', 'grep', 'glob', 'web_scrape'] }),
+      );
+      expect(childWriteCapable).toBe(false);
+    });
+
+    it('is false when bash is allowed but read-only', () => {
+      const { childWriteCapable } = buildChildConfig(
+        baseArgs({ allowedTools: ['read_file', 'grep', 'bash'], readOnlyBash: true }),
+      );
+      expect(childWriteCapable).toBe(false);
+    });
+
+    it('is true when the cage includes write_file', () => {
+      const { childWriteCapable } = buildChildConfig(
+        baseArgs({ allowedTools: ['read_file', 'write_file'] }),
+      );
+      expect(childWriteCapable).toBe(true);
+    });
+
+    it('is true when the cage includes mutating (non-read-only) bash', () => {
+      const { childWriteCapable } = buildChildConfig(
+        baseArgs({ allowedTools: ['read_file', 'bash'] }),
+      );
+      expect(childWriteCapable).toBe(true);
+    });
+  });
+
   describe('systemPrompt selection', () => {
     it('uses the parent base prompt for an unnamed dispatch', () => {
       const { childConfig } = buildChildConfig(baseArgs({ namedAgent: undefined }));

--- a/src/agent/tools/subagent/child-config.ts
+++ b/src/agent/tools/subagent/child-config.ts
@@ -99,6 +99,13 @@ export interface BuildChildConfigResult {
    * the run was promoted — the registry then owns the detached lifetime.
    */
   childManager: SubagentManager | undefined;
+  /**
+   * Whether the dispatched child can mutate the filesystem (write/edit files
+   * or run mutating bash). The executor reads this to decide whether
+   * `isolation:"worktree"` is meaningful — a read-only child has nothing to
+   * isolate, so its worktree is skipped with a debug note.
+   */
+  childWriteCapable: boolean;
 }
 
 /**
@@ -165,6 +172,20 @@ export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigRe
   }
   const effectiveReadOnlyBash =
     args.readOnlyBash === true || resolvedAccess?.bashReadOnly === true;
+
+  // Write-capability — read by the executor to decide whether
+  // isolation:"worktree" is meaningful. A child can mutate the tree when it
+  // can write/edit files OR run non-read-only bash. An unrestricted allowlist
+  // (undefined) is full access → write-capable; a read-only agent
+  // (research-agent, recon fan-out) is not, so its isolation is skipped.
+  const canWriteFiles =
+    effectiveAllowedTools === undefined ||
+    effectiveAllowedTools.includes('write_file') ||
+    effectiveAllowedTools.includes('edit_file');
+  const canMutateViaBash =
+    (effectiveAllowedTools === undefined || effectiveAllowedTools.includes('bash')) &&
+    effectiveReadOnlyBash !== true;
+  const childWriteCapable = canWriteFiles || canMutateViaBash;
   if (resolvedAccess !== undefined && resolvedAccess.droppedTokens.length > 0) {
     // Fail-closed token drops silently NARROW the child's tool surface, so a
     // misconfigured agent file must be visible by default — not only under
@@ -362,5 +383,5 @@ export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigRe
     );
   }
 
-  return { childConfig, childParentSession, childManager };
+  return { childConfig, childParentSession, childManager, childWriteCapable };
 }

--- a/src/agent/tools/subagent/foreground-promotion.ts
+++ b/src/agent/tools/subagent/foreground-promotion.ts
@@ -26,6 +26,7 @@ import type { ToolResult } from '../types.js';
 import type { PromotedSubagentInfo } from '../subagent-executor.js';
 import { emitTelemetry, truncate, measurePartial, buildFailurePayload } from './failure-payload.js';
 import { appendInjectContext } from './inject-context.js';
+import { teardownIsolatedWorktree } from '../handlers/worktree-managed.js';
 
 type ForkedHandle = Awaited<ReturnType<SubagentManager['forkSubagent']>>;
 
@@ -62,6 +63,13 @@ export interface RunForegroundArgs {
   promotionTriggers: Map<string, PromotionTrigger>;
   /** The executor's live cancellable-handle map (keyed by handle.id). */
   activeForegroundHandles: Map<string, { cancel: () => Promise<void> }>;
+  /**
+   * Present when this dispatch runs in an isolated worktree (isolation:
+   * "worktree"). Torn down in the finally unless the run was promoted to
+   * background (the detached job then owns the tree; the sweep reclaims it
+   * later). A dirty / commits-ahead tree is preserved and locked, not removed.
+   */
+  isolationTeardown?: { repoRoot: string; worktreePath: string };
 }
 
 /**
@@ -326,6 +334,22 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
       // `?.()` tolerates narrow handle doubles (returns undefined = no note).
       const injectContext = handle.getLastStopInjectContext?.();
       appendInjectContext(toolResult, injectContext);
+
+      // isolation:"worktree" teardown — remove the child's worktree now that it
+      // has finished. A dirty / commits-ahead tree is preserved and locked
+      // (WIP is never destroyed); the promoted path skips this (guarded by
+      // !promoted) so a still-running detached job keeps its tree. Best-effort:
+      // teardownIsolatedWorktree never throws, so it cannot break the finally.
+      if (args.isolationTeardown) {
+        const { repoRoot, worktreePath } = args.isolationTeardown;
+        const outcome = await teardownIsolatedWorktree({ repoRoot, worktreePath });
+        if (outcome.preserved) {
+          debugLog(
+            `[isolation] preserved worktree ${worktreePath} (${outcome.reason}) — ` +
+              `locked so the sweep will not reap it; recover via the worktree tool`,
+          );
+        }
+      }
     }
   }
 }

--- a/src/agent/tools/subagent/input-parse.test.ts
+++ b/src/agent/tools/subagent/input-parse.test.ts
@@ -363,6 +363,50 @@ describe('parseAgentInput', () => {
     });
   });
 
+  describe('isolation', () => {
+    it('defaults to omitted (no field) when absent', () => {
+      const result = parseAgentInput({ prompt: 'p' });
+      expect(result.isolation).toBeUndefined();
+      expect('isolation' in result).toBe(false);
+    });
+
+    it("normalizes 'none' to omitted (no field)", () => {
+      const result = parseAgentInput({ prompt: 'p', isolation: 'none' });
+      expect(result.isolation).toBeUndefined();
+      expect('isolation' in result).toBe(false);
+    });
+
+    it("retains 'worktree'", () => {
+      expect(parseAgentInput({ prompt: 'p', isolation: 'worktree' }).isolation).toBe(
+        'worktree',
+      );
+    });
+
+    it('throws on an unknown isolation value', () => {
+      expect(() => parseAgentInput({ prompt: 'p', isolation: 'container' })).toThrow(
+        /isolation must be "none" or "worktree"/,
+      );
+    });
+
+    it('throws when cwd and isolation:worktree are both supplied (mutually exclusive)', () => {
+      expect(() =>
+        parseAgentInput({ prompt: 'p', cwd: '/tmp/wt/x', isolation: 'worktree' }),
+      ).toThrow(/mutually exclusive/);
+    });
+
+    it("allows cwd together with isolation:'none' (none is a no-op)", () => {
+      const result = parseAgentInput({ prompt: 'p', cwd: '/tmp/wt/x', isolation: 'none' });
+      expect(result.cwd).toBe('/tmp/wt/x');
+      expect('isolation' in result).toBe(false);
+    });
+
+    it('throws when isolation:worktree is combined with mode:background (MVP forbid)', () => {
+      expect(() =>
+        parseAgentInput({ prompt: 'p', isolation: 'worktree', mode: 'background' }),
+      ).toThrow(/not supported with mode:"background"/);
+    });
+  });
+
   describe('full happy path', () => {
     it('parses every field together with expected precedence and defaults', () => {
       const result = parseAgentInput({

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -62,6 +62,21 @@ export interface AgentInput {
    * Each level must specify `cwd` explicitly to operate in a worktree.
    */
   cwd?: string;
+  /**
+   * Filesystem-isolation mode. When `'worktree'`, the executor forks the child
+   * inside a fresh afk-managed git worktree (`.afk-worktrees/<slug>` on a new
+   * branch) and sets the child's cwd to it, so parallel write-capable
+   * subagents never collide in the shared tree. Omitted / `'none'` runs the
+   * child in the parent tree (or `cwd`).
+   *
+   * Mutually exclusive with {@link cwd} (the executor owns the child's cwd when
+   * isolating). Forbidden with `mode: 'background'` in this release: a detached
+   * child outlives the executor's teardown, so nothing would reclaim its
+   * worktree in-turn (see docs/proposals/first-class-worktree-isolation.md
+   * Open Question 1). Only the honored value is retained — `'none'` normalizes
+   * to `undefined` (no field) so the executor's `=== 'worktree'` check is total.
+   */
+  isolation?: 'worktree';
 }
 
 /**
@@ -195,6 +210,36 @@ export function parseAgentInput(input: unknown): AgentInput {
     cwd = cwdValue;
   }
 
+  // isolation: optional enum. 'none' (or omitted) is a no-op and normalizes to
+  // undefined so the executor's `=== 'worktree'` check is total. 'worktree'
+  // asks the executor to fork the child inside a fresh managed git worktree.
+  //   - Mutually exclusive with cwd: isolating means the executor owns the
+  //     child's cwd, so a caller-supplied cwd would be silently overwritten —
+  //     reject loudly instead.
+  //   - Forbidden with mode:'background': a detached child outlives the
+  //     foreground teardown that removes the worktree, so nothing would reclaim
+  //     it in-turn (proposal Open Q1). Reject rather than leak.
+  let isolation: 'worktree' | undefined;
+  const isolationValue = agentInput['isolation'];
+  if (isolationValue !== undefined && isolationValue !== 'none') {
+    if (isolationValue !== 'worktree') {
+      throw new Error(
+        `Agent tool isolation must be "none" or "worktree", got: ${JSON.stringify(isolationValue)}`,
+      );
+    }
+    if (cwd !== undefined) {
+      throw new Error(
+        'Agent tool cwd and isolation are mutually exclusive — pass one or the other',
+      );
+    }
+    if (mode === 'background') {
+      throw new Error(
+        'Agent tool isolation:"worktree" is not supported with mode:"background" yet',
+      );
+    }
+    isolation = 'worktree';
+  }
+
   return {
     prompt,
     model,
@@ -206,5 +251,6 @@ export function parseAgentInput(input: unknown): AgentInput {
     mode,
     ...(agent_type !== undefined ? { agent_type } : {}),
     ...(cwd !== undefined ? { cwd } : {}),
+    ...(isolation !== undefined ? { isolation } : {}),
   };
 }

--- a/src/agent/tools/subagent/subagent-executor.isolation.test.ts
+++ b/src/agent/tools/subagent/subagent-executor.isolation.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Integration tests for the `isolation: "worktree"` wiring in
+ * {@link SubagentExecutor.execute}.
+ *
+ * The reusable worktree primitives (`createIsolatedWorktree` /
+ * `teardownIsolatedWorktree`) are unit-tested against a mocked git argv in
+ * `handlers/worktree.test.ts`. This suite tests the EXECUTOR'S USE of them —
+ * the block in `execute()` (subagent-executor.ts) that, after
+ * `buildChildConfig` (which yields `childWriteCapable`) and before dispatch:
+ *
+ *   1. SKIPS creation for a read-only child (nothing to isolate);
+ *   2. else calls `createIsolatedWorktree({ cwd, slugHint })`, sets
+ *      `childConfig.cwd = iso.path`, and records
+ *      `isolationTeardown = { repoRoot, worktreePath }`;
+ *   3. on a `createIsolatedWorktree` throw, FAILS LOUD (isError, no fork) —
+ *      never silently falling back to the shared tree;
+ *   4. threads `isolationTeardown` into `runForegroundWithPromotion`, whose
+ *      finally calls `teardownIsolatedWorktree` (covered in
+ *      foreground-promotion's own tests).
+ *
+ * Seams mocked (so we test executor LOGIC, not git and not a real child run):
+ *   - `../handlers/worktree-managed.js` — `createIsolatedWorktree` /
+ *     `teardownIsolatedWorktree` as `vi.fn()`. This single mock covers BOTH
+ *     importers (subagent-executor.ts AND foreground-promotion.ts resolve the
+ *     same absolute module).
+ *   - `./foreground-promotion.js` — `runForegroundWithPromotion` as a `vi.fn()`
+ *     that captures its args (esp. `isolationTeardown`) and returns a benign
+ *     success ToolResult, so no real child is driven. This isolates the
+ *     create→cwd→teardown-arg chain at the executor seam.
+ *   - `../auth/credential-resolver.js` / `../routing-telemetry.js` — copied
+ *     from the sibling `subagent-executor.test.ts` so construction never
+ *     touches the keychain / telemetry sink.
+ *
+ * Construction/mocking of `SubagentExecutorContext`, the manager, and the
+ * forked handle mirror `subagent-executor.test.ts` exactly.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// --- Hoisted mocks (must precede the SubagentExecutor import) --------------
+
+// Credential resolver + routing telemetry: decouple construction from the live
+// keychain / env, mirroring subagent-executor.test.ts. NOTE the relative depth:
+// this test sits one level deeper (subagent/) than subagent-executor.test.ts
+// (tools/), so the module specifiers gain one extra `../`.
+const mockResolveCredentialForModel = vi.hoisted(() =>
+  vi.fn((_model: string | undefined) => 'resolved-test-credential' as string | undefined),
+);
+vi.mock('../../auth/credential-resolver.js', () => ({
+  resolveCredentialForModel: mockResolveCredentialForModel,
+  loadAnthropicCredential: vi.fn(() => 'resolved-test-credential'),
+  loadOpenAICredential: vi.fn(() => undefined),
+}));
+
+const appendRoutingDecision = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock('../../routing-telemetry.js', () => ({ appendRoutingDecision }));
+
+// Worktree primitives: the two functions the isolation block + the foreground
+// finally call. Shared by both importers (same absolute module).
+const createIsolatedWorktree = vi.hoisted(() => vi.fn());
+const teardownIsolatedWorktree = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ removed: true, preserved: false }),
+);
+vi.mock('../handlers/worktree-managed.js', () => ({
+  createIsolatedWorktree,
+  teardownIsolatedWorktree,
+}));
+
+// Foreground path: capture the args (isolationTeardown, childManager) without
+// running a real child. Returns a benign success ToolResult. When a test needs
+// the REAL foreground finally (teardown wiring), it un-mocks per-test via
+// vi.mocked(...).mockImplementation reaching the real module — but for the
+// executor-seam assertions the double suffices.
+const runForegroundWithPromotion = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ content: 'foreground-double-result' }),
+);
+vi.mock('./foreground-promotion.js', () => ({
+  runForegroundWithPromotion,
+}));
+
+import type { SubagentHandle, SubagentResult } from '../../subagent.js';
+import type { IAgentSession } from '../../types.js';
+import type { AgentConfig } from '../../types/config-types.js';
+import type { ToolCall } from '../types.js';
+import { SubagentExecutor, type SubagentExecutorContext } from '../subagent-executor.js';
+
+// --- Shared harness (mirrors subagent-executor.test.ts) --------------------
+
+function mockHandle(overrides?: Partial<{ status: string }>): Partial<SubagentHandle> {
+  return {
+    id: 'test-handle',
+    status: (overrides?.status ?? 'succeeded') as SubagentHandle['status'],
+    runToResult: vi.fn().mockResolvedValue({
+      id: 'test-handle',
+      status: overrides?.status ?? 'succeeded',
+      message: { role: 'assistant', content: 'test output', timestamp: new Date() },
+    } as SubagentResult),
+    cancel: vi.fn().mockResolvedValue(undefined),
+    teardown: vi.fn().mockResolvedValue(undefined),
+    getLastStopInjectContext: vi.fn().mockReturnValue(undefined),
+  };
+}
+
+function makeCall(overrides?: Partial<ToolCall>): ToolCall {
+  return {
+    id: 'test-call',
+    name: 'agent',
+    input: { prompt: 'do something' },
+    signal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+/** The shape createIsolatedWorktree resolves with (ManagedWorktreeInfo & { repoRoot }). */
+const ISO_RESULT = {
+  path: '/repo/.afk-worktrees/iso-agent-tool-1-abc123',
+  branch: 'afk/iso-agent-tool-1-abc123',
+  baseRef: 'HEAD',
+  baseSha: 'deadbeef',
+  repoRoot: '/repo',
+};
+
+describe('SubagentExecutor — isolation:"worktree" wiring', () => {
+  let mockSubagentMgr: { forkSubagent: ReturnType<typeof vi.fn> };
+  let mockParentSession: Partial<IAgentSession>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Restore benign defaults cleared above.
+    mockResolveCredentialForModel.mockReturnValue('resolved-test-credential');
+    teardownIsolatedWorktree.mockResolvedValue({ removed: true, preserved: false });
+    runForegroundWithPromotion.mockResolvedValue({ content: 'foreground-double-result' });
+
+    mockSubagentMgr = { forkSubagent: vi.fn().mockResolvedValue(mockHandle()) };
+    mockParentSession = {
+      sessionId: 'parent-session-id',
+      getInputStreamRef: vi.fn(),
+      abortSignal: new AbortController().signal,
+    };
+  });
+
+  /** Build an executor. `allowedTools` (a read-only cage) drives childWriteCapable=false. */
+  function makeExecutor(overrides?: Partial<SubagentExecutorContext>): SubagentExecutor {
+    const ctx: SubagentExecutorContext = {
+      subagentManager: mockSubagentMgr as never,
+      parentSession: mockParentSession as never,
+      defaultConfig: { apiKey: 'test-key', systemPrompt: 'test system prompt' },
+      depth: 0,
+      // A real cwd so the anchor is deterministic (executor uses
+      // `this.currentCwd ?? process.cwd()` as createIsolatedWorktree's cwd).
+      cwd: '/repo',
+      ...overrides,
+    };
+    return new SubagentExecutor(ctx);
+  }
+
+  // ------------------------------------------------------------------------
+  // (1) write-capable + isolation:'worktree' → create once, cwd rewritten,
+  //     isolationTeardown threaded into the foreground call.
+  // ------------------------------------------------------------------------
+  describe('write-capable dispatch', () => {
+    it('creates the worktree once, rewrites child cwd, and threads isolationTeardown', async () => {
+      createIsolatedWorktree.mockResolvedValue(ISO_RESULT);
+      // Unrestricted cage (allowedTools unset) ⇒ childWriteCapable=true.
+      const executor = makeExecutor();
+
+      const result = await executor.execute(
+        makeCall({ input: { prompt: 'build a feature', isolation: 'worktree' } }),
+      );
+
+      // Not an error, and the foreground double's result flows out verbatim.
+      expect(result.isError).toBeUndefined();
+
+      // createIsolatedWorktree called exactly once, anchored at the session cwd,
+      // with a collision-safe slug hint derived from the id_prefix.
+      expect(createIsolatedWorktree).toHaveBeenCalledTimes(1);
+      const createArg = createIsolatedWorktree.mock.calls[0]![0] as {
+        cwd: string;
+        slugHint: string;
+      };
+      expect(createArg.cwd).toBe('/repo');
+      expect(createArg.slugHint).toMatch(/^iso-agent-tool-\d+-[a-z0-9]+$/);
+
+      // The child config handed to forkSubagent carries cwd = the worktree path
+      // (the executor mutated childConfig.cwd = iso.path before dispatch).
+      expect(mockSubagentMgr.forkSubagent).toHaveBeenCalledTimes(1);
+      const forkArg = mockSubagentMgr.forkSubagent.mock.calls[0]![0] as {
+        config: AgentConfig;
+      };
+      expect(forkArg.config.cwd).toBe(ISO_RESULT.path);
+
+      // isolationTeardown was threaded into the foreground path as
+      // { repoRoot, worktreePath } sourced from the create result.
+      expect(runForegroundWithPromotion).toHaveBeenCalledTimes(1);
+      const fgArg = runForegroundWithPromotion.mock.calls[0]![0] as {
+        isolationTeardown?: { repoRoot: string; worktreePath: string };
+      };
+      expect(fgArg.isolationTeardown).toEqual({
+        repoRoot: ISO_RESULT.repoRoot,
+        worktreePath: ISO_RESULT.path,
+      });
+    });
+
+    it('gives concurrent dispatches distinct slug hints (monotonic counter)', async () => {
+      createIsolatedWorktree.mockResolvedValue(ISO_RESULT);
+      const executor = makeExecutor();
+
+      await executor.execute(makeCall({ input: { prompt: 'a', isolation: 'worktree' } }));
+      await executor.execute(makeCall({ input: { prompt: 'b', isolation: 'worktree' } }));
+
+      const slug0 = (createIsolatedWorktree.mock.calls[0]![0] as { slugHint: string }).slugHint;
+      const slug1 = (createIsolatedWorktree.mock.calls[1]![0] as { slugHint: string }).slugHint;
+      expect(slug0).not.toBe(slug1);
+    });
+  });
+
+  // ------------------------------------------------------------------------
+  // (2) read-only dispatch + isolation:'worktree' → SKIP creation, no error,
+  //     child dispatched normally (cwd untouched, no isolationTeardown).
+  // ------------------------------------------------------------------------
+  describe('read-only dispatch (skip path)', () => {
+    it('does NOT create a worktree; dispatches normally with no isolationTeardown', async () => {
+      createIsolatedWorktree.mockResolvedValue(ISO_RESULT);
+      // A read-only cage (no write/edit, no mutating bash) ⇒ childWriteCapable=false.
+      // Same mechanism as child-config.test.ts "is false for a read-only cage".
+      const executor = makeExecutor({ allowedTools: ['read_file', 'grep', 'glob'] });
+
+      const result = await executor.execute(
+        makeCall({ input: { prompt: 'inspect the repo', isolation: 'worktree' } }),
+      );
+
+      // Skip path: creation never runs, and the call is not an error.
+      expect(createIsolatedWorktree).not.toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+
+      // The child is still dispatched (fork + foreground), just with no
+      // isolated cwd and no teardown record.
+      expect(mockSubagentMgr.forkSubagent).toHaveBeenCalledTimes(1);
+      const forkArg = mockSubagentMgr.forkSubagent.mock.calls[0]![0] as {
+        config: AgentConfig;
+      };
+      // cwd on the child config is not the worktree path (isolation was skipped).
+      expect(forkArg.config.cwd).not.toBe(ISO_RESULT.path);
+
+      expect(runForegroundWithPromotion).toHaveBeenCalledTimes(1);
+      const fgArg = runForegroundWithPromotion.mock.calls[0]![0] as {
+        isolationTeardown?: unknown;
+      };
+      expect(fgArg.isolationTeardown).toBeUndefined();
+    });
+
+    it('read-only cage with read-only bash also skips (bash present but non-mutating)', async () => {
+      createIsolatedWorktree.mockResolvedValue(ISO_RESULT);
+      // Mirrors child-config.test.ts "is false when bash is allowed but read-only".
+      const executor = makeExecutor({
+        allowedTools: ['read_file', 'grep', 'bash'],
+        readOnlyBash: true,
+      });
+
+      const result = await executor.execute(
+        makeCall({ input: { prompt: 'inspect', isolation: 'worktree' } }),
+      );
+
+      expect(createIsolatedWorktree).not.toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+      expect(mockSubagentMgr.forkSubagent).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ------------------------------------------------------------------------
+  // (3) createIsolatedWorktree throws → FAIL LOUD: isError, no fork, no
+  //     foreground run. Never silently falls back to the shared tree.
+  // ------------------------------------------------------------------------
+  describe('createIsolatedWorktree throws (non-git cwd)', () => {
+    it('resolves to an isError result mentioning "isolated worktree" and never forks', async () => {
+      createIsolatedWorktree.mockRejectedValue(new Error('Not in a git repository.'));
+      const executor = makeExecutor();
+
+      const result = await executor.execute(
+        makeCall({ input: { prompt: 'build a feature', isolation: 'worktree' } }),
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain('isolated worktree');
+      // Fail loud: the underlying error is surfaced.
+      expect(result.content).toContain('Not in a git repository.');
+
+      // No fork happened → no foreground/background dispatch either.
+      expect(mockSubagentMgr.forkSubagent).not.toHaveBeenCalled();
+      expect(runForegroundWithPromotion).not.toHaveBeenCalled();
+    });
+  });
+
+  // ------------------------------------------------------------------------
+  // (4) teardown plumbing — the value threaded as isolationTeardown equals
+  //     { repoRoot, worktreePath } derived from the create result. Asserted at
+  //     the foreground seam (runForegroundWithPromotion), which is the arg the
+  //     real foreground finally forwards to teardownIsolatedWorktree.
+  // ------------------------------------------------------------------------
+  describe('teardown plumbing', () => {
+    it('threads exactly { repoRoot, worktreePath } from the create result', async () => {
+      createIsolatedWorktree.mockResolvedValue({
+        ...ISO_RESULT,
+        path: '/repo/.afk-worktrees/iso-xyz',
+        repoRoot: '/repo',
+      });
+      const executor = makeExecutor();
+
+      await executor.execute(
+        makeCall({ input: { prompt: 'work', isolation: 'worktree' } }),
+      );
+
+      const fgArg = runForegroundWithPromotion.mock.calls[0]![0] as {
+        isolationTeardown?: { repoRoot: string; worktreePath: string };
+      };
+      expect(fgArg.isolationTeardown).toEqual({
+        repoRoot: '/repo',
+        worktreePath: '/repo/.afk-worktrees/iso-xyz',
+      });
+      // worktreePath comes from `iso.path`, NOT from any caller-supplied cwd —
+      // pin that the two are wired from the same create result.
+      const forkArg = mockSubagentMgr.forkSubagent.mock.calls[0]![0] as {
+        config: AgentConfig;
+      };
+      expect(forkArg.config.cwd).toBe(fgArg.isolationTeardown!.worktreePath);
+    });
+
+    it('end-to-end teardown: the real foreground finally calls teardownIsolatedWorktree with the threaded record', async () => {
+      // Un-mock the foreground path for THIS test so the real finally runs and
+      // forwards isolationTeardown → teardownIsolatedWorktree (still mocked).
+      const real = await vi.importActual<typeof import('./foreground-promotion.js')>(
+        './foreground-promotion.js',
+      );
+      runForegroundWithPromotion.mockImplementation(real.runForegroundWithPromotion);
+      createIsolatedWorktree.mockResolvedValue(ISO_RESULT);
+      const executor = makeExecutor();
+
+      const result = await executor.execute(
+        makeCall({ input: { prompt: 'build', isolation: 'worktree' } }),
+      );
+
+      // Real foreground drove the mock handle to success.
+      expect(result.isError).toBeUndefined();
+      // The finally forwarded the threaded record to the (mocked) teardown.
+      expect(teardownIsolatedWorktree).toHaveBeenCalledTimes(1);
+      const tdArg = teardownIsolatedWorktree.mock.calls[0]![0] as {
+        repoRoot: string;
+        worktreePath: string;
+      };
+      expect(tdArg.repoRoot).toBe(ISO_RESULT.repoRoot);
+      expect(tdArg.worktreePath).toBe(ISO_RESULT.path);
+    });
+  });
+});


### PR DESCRIPTION
## What & why

`isolation: "worktree"` on the `agent` tool was a **documented no-op**. The schema exposed only `cwd`, `parseAgentInput` ignored `isolation`, and the key sat in `RECOGNIZED_UNSUPPORTED_KEYS`. Any skill that dispatched parallel write-capable subagents with `isolation:"worktree"` — diagnose hypotheses, refactor lanes, simplify, devils-advocate, shadow-verify — actually got children **sharing the parent working tree**, so concurrent edits and test runs corrupted each other and per-branch pass/fail attribution was meaningless.

This was the **P1 flagged on #480** (diagnose's `isolation:"worktree"` no-op). Rather than patch each skill, this fixes it at the root: the four other skills now get real isolation with **no edit**.

## How

- **Factor out** the managed-worktree primitives from `handlers/worktree.ts` into `handlers/worktree-managed.ts` (`createManagedWorktree`, `removeManagedWorktreeGuarded`, `isManagedWorktreeDirty`, `managedWorktreeCommitsAhead`, `resolveRepoContext`, `sanitizeSlug`) plus new `createIsolatedWorktree` / `teardownIsolatedWorktree`. The `worktree` tool handler now delegates — **git argv stays byte-identical**, `worktree.test.ts` unchanged.
- **Schema + parse**: add `isolation: 'none' | 'worktree'`. Parse validates the enum and rejects `cwd`+`isolation` (mutually exclusive) and `isolation:worktree`+`mode:background`.
- **Executor**: creates the worktree between `buildChildConfig` and `forkSubagent`, sets `childConfig.cwd`, and **fails loud on a non-git cwd** (never silently falls back to the shared tree — that would reintroduce the bug). Read-only children (research-agent, recon) skip creation via a new `childWriteCapable` flag.
- **Teardown**: `foreground-promotion.ts` `if (!promoted)` finally removes the tree; a **dirty / commits-ahead tree is preserved and `git worktree lock`ed** so WIP is never destroyed and the sweep never reaps it.

## Correction vs. the original design

The proposal's Wave 3 (remove `isolation` from `RECOGNIZED_UNSUPPORTED_KEYS`) was **dropped** — that set gates agent-file *frontmatter* keys, a different surface, and `parser.test.ts` asserts `isolation` stays there. Honoring `isolation:` in an agent *definition* is a separate future feature.

## Tests / verification

- New `worktree-managed.test.ts` — argv parity + create/teardown decision logic.
- `input-parse.test.ts` — enum, mutual-exclusion, background-forbid.
- `child-config.test.ts` — `childWriteCapable` matrix.
- **Real-git smoke** (not just mocks): create → real worktree+branch+meta; clean teardown → removed; dirty teardown → preserved+locked; non-git cwd → throws.
- `pnpm lint` clean; `pnpm test` = **598 files / 11107 passed / 0 failed**; `audit:sdk:check`, `audit:env:check`, `scan:env:check` all green.

## Deferred (documented in `docs/proposals/first-class-worktree-isolation.md`)

- Grandchild (depth-2+) isolation — only the direct child's cwd is isolated (fine for the leaf agents the 5 skills dispatch).
- Ctrl+B promotion leaks the tree → sweep reclaims later.
- Return-shape footer (§3.6) — so `diagnose` stays on the manual `worktree`+`cwd` pattern until Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
