### PR TITLE
feat(anthropic): classify usage-limit 429s via anthropic-ratelimit-unified-* headers (#488)

### DIFF
--- a/src/agent/providers/anthropic-direct/usage-limit.test.ts
+++ b/src/agent/providers/anthropic-direct/usage-limit.test.ts
@@ -260,6 +260,92 @@ describe('classifyUsageLimitError', () => {
       expect(result.resetsAt.getTime()).toBe(resetEpochSec * 1000);
     }
   });
+
+  // -------------------------------------------------------------------------
+  // #490 review follow-ups — edge cases the original #488 suite did not cover.
+  // -------------------------------------------------------------------------
+
+  // M1 regression: a `unified-reset` past the ECMAScript Date ceiling must NOT
+  // produce an `oauth-limit` with an Invalid Date (NaN getTime), which would
+  // slip past the downstream `> TWO_HOURS_MS` surface-guard and hang
+  // `waitForReset` on a NaN deadline. It falls to the timestamp-less path.
+  it('falls to oauth-limit-no-ts for a unified-reset beyond the JS Date range', () => {
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', {
+      'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+      'anthropic-ratelimit-unified-reset': '99999999999999', // ~1e14 s → overflows Date
+    });
+    expect(classifyUsageLimitError(err)?.kind).toBe('oauth-limit-no-ts');
+  });
+
+  // M1 regression, step-1 parity: an out-of-range `|ts` timestamp falls through
+  // the header steps to the fallback (no retry-after → oauth-limit-no-ts),
+  // never an Invalid-Date oauth-limit.
+  it('falls through a |ts timestamp beyond the JS Date range (step 1 guard)', () => {
+    const err = makeError(429, 'usage limit|99999999999999');
+    expect(classifyUsageLimitError(err)?.kind).toBe('oauth-limit-no-ts');
+  });
+
+  // Precedence: when BOTH a unified subscription header and per-minute throttle
+  // headers are present, step 2 (subscription) wins over step 3 (transient).
+  it('prefers the unified subscription header over per-minute throttle headers', () => {
+    const resetEpochSec = Math.floor(Date.now() / 1000) + 3600;
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', {
+      'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+      'anthropic-ratelimit-unified-reset': String(resetEpochSec),
+      'anthropic-ratelimit-requests-remaining': '0',
+      'retry-after': '30',
+    });
+    const result = classifyUsageLimitError(err);
+    expect(result?.kind).toBe('oauth-limit');
+    if (result?.kind === 'oauth-limit') {
+      expect(result.resetsAt.getTime()).toBe(resetEpochSec * 1000);
+    }
+  });
+
+  // Step 3 with per-minute headers but no retry-after hint → transient with an
+  // undefined retryAfterMs (retry-layer falls back to its default backoff).
+  it('returns rate-limit-transient with undefined retryAfterMs for per-minute headers and no retry-after', () => {
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', {
+      'anthropic-ratelimit-requests-remaining': '0',
+    });
+    const result = classifyUsageLimitError(err);
+    expect(result?.kind).toBe('rate-limit-transient');
+    if (result?.kind === 'rate-limit-transient') {
+      expect(result.retryAfterMs).toBeUndefined();
+    }
+  });
+
+  // Characterization (review M2 / #488 design): step 3 is intentionally
+  // magnitude-blind — per-minute headers route to `rate-limit-transient` even
+  // when retry-after exceeds the transient threshold. retry-layer clamps the
+  // wait, so this stays a bounded retry rather than a subscription pause.
+  it('keeps per-minute headers with a long retry-after as rate-limit-transient (magnitude-blind step 3)', () => {
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', {
+      'anthropic-ratelimit-requests-remaining': '0',
+      'retry-after': '3600',
+    });
+    const result = classifyUsageLimitError(err);
+    expect(result?.kind).toBe('rate-limit-transient');
+    if (result?.kind === 'rate-limit-transient') {
+      expect(result.retryAfterMs).toBe(3_600_000);
+    }
+  });
+
+  // Characterization (review L2): a past `unified-reset` is accepted as-is
+  // (parity with the |ts path); downstream the deadline collapses to ~now →
+  // immediate replay. Guarding future-ness is deliberately left as follow-up.
+  it('accepts a past unified-reset as oauth-limit with a past resetsAt', () => {
+    const pastSec = Math.floor(Date.now() / 1000) - 3600;
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', {
+      'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+      'anthropic-ratelimit-unified-reset': String(pastSec),
+    });
+    const result = classifyUsageLimitError(err);
+    expect(result?.kind).toBe('oauth-limit');
+    if (result?.kind === 'oauth-limit') {
+      expect(result.resetsAt.getTime()).toBe(pastSec * 1000);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/providers/anthropic-direct/usage-limit.test.ts
+++ b/src/agent/providers/anthropic-direct/usage-limit.test.ts
@@ -132,6 +132,134 @@ describe('classifyUsageLimitError', () => {
     });
     expect(classifyUsageLimitError(pastThreshold)?.kind).toBe('oauth-limit-no-ts');
   });
+
+  // -------------------------------------------------------------------------
+  // #488 — prefer `anthropic-ratelimit-unified-*` headers over the retry-after
+  // magnitude proxy. These are the authoritative signals Claude Code keys on
+  // (verified v2.1.206). The change is additive + presence-gated: the fallback
+  // regression guards above must keep passing unchanged.
+  // -------------------------------------------------------------------------
+
+  it('returns oauth-limit with a header-derived resetsAt for a unified claim + unified-reset', () => {
+    const resetEpochSec = Math.floor(Date.now() / 1000) + 3600; // 1h in the future
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', {
+      'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+      'anthropic-ratelimit-unified-reset': String(resetEpochSec),
+    });
+    const result = classifyUsageLimitError(err);
+    expect(result?.kind).toBe('oauth-limit');
+    if (result?.kind === 'oauth-limit') {
+      expect(result.resetsAt.getTime()).toBe(resetEpochSec * 1000);
+    }
+  });
+
+  it('returns oauth-limit-no-ts for a unified claim header with NO unified-reset', () => {
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', {
+      'anthropic-ratelimit-unified-representative-claim': 'seven_day',
+    });
+    expect(classifyUsageLimitError(err)?.kind).toBe('oauth-limit-no-ts');
+  });
+
+  it('returns oauth-limit-no-ts for unified-status "rejected" with no reset', () => {
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', {
+      'anthropic-ratelimit-unified-status': 'rejected',
+    });
+    expect(classifyUsageLimitError(err)?.kind).toBe('oauth-limit-no-ts');
+  });
+
+  it('returns oauth-limit-no-ts for a unified-overage-status header (no reset)', () => {
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', {
+      'anthropic-ratelimit-unified-overage-status': 'active',
+    });
+    expect(classifyUsageLimitError(err)?.kind).toBe('oauth-limit-no-ts');
+  });
+
+  it('ignores a non-finite / non-positive unified-reset and falls to oauth-limit-no-ts', () => {
+    const nonFinite = makeErrorWithHeaders(429, '429', {
+      'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+      'anthropic-ratelimit-unified-reset': 'not-a-number',
+    });
+    expect(classifyUsageLimitError(nonFinite)?.kind).toBe('oauth-limit-no-ts');
+
+    const nonPositive = makeErrorWithHeaders(429, '429', {
+      'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+      'anthropic-ratelimit-unified-reset': '0',
+    });
+    expect(classifyUsageLimitError(nonPositive)?.kind).toBe('oauth-limit-no-ts');
+  });
+
+  it('returns rate-limit-transient for only per-minute headers (no unified headers)', () => {
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', {
+      'anthropic-ratelimit-requests-remaining': '0',
+      'retry-after': '30',
+    });
+    const result = classifyUsageLimitError(err);
+    expect(result?.kind).toBe('rate-limit-transient');
+    if (result?.kind === 'rate-limit-transient') {
+      expect(result.retryAfterMs).toBe(30_000);
+    }
+  });
+
+  // The authoritative subscription signal must win over retry-after MAGNITUDE:
+  // a 429 with a unified claim AND a short retry-after is a subscription cap,
+  // NOT a transient throttle (this is the core behavioral change of #488).
+  it('prefers a unified subscription header over a short retry-after', () => {
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', {
+      'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+      'retry-after': '30',
+    });
+    const result = classifyUsageLimitError(err);
+    expect(result?.kind).toBe('oauth-limit-no-ts');
+    expect(result?.kind).not.toBe('rate-limit-transient');
+  });
+
+  // Precedence: the `|<ts>` message parse (step 1) still wins over unified
+  // headers (step 2) when both are present.
+  it('prefers the |ts message parse over unified headers', () => {
+    const unixTs = 1700000000;
+    const err = makeErrorWithHeaders(429, `usage limit|${unixTs}`, {
+      'anthropic-ratelimit-unified-representative-claim': 'five_hour',
+      'anthropic-ratelimit-unified-reset': String(Math.floor(Date.now() / 1000) + 3600),
+    });
+    const result = classifyUsageLimitError(err);
+    expect(result?.kind).toBe('oauth-limit');
+    if (result?.kind === 'oauth-limit') {
+      expect(result.resetsAt.getTime()).toBe(unixTs * 1000);
+    }
+  });
+
+  // Regression guard (fallback / step 4 — no rate-limit headers at all): the
+  // pre-#488 magnitude behavior must be preserved byte-for-byte.
+  it('FALLBACK: short retry-after with no rate-limit headers → rate-limit-transient', () => {
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', { 'retry-after': '30' });
+    const result = classifyUsageLimitError(err);
+    expect(result?.kind).toBe('rate-limit-transient');
+    if (result?.kind === 'rate-limit-transient') {
+      expect(result.retryAfterMs).toBe(30_000);
+    }
+  });
+
+  it('FALLBACK: long retry-after with no rate-limit headers → oauth-limit-no-ts', () => {
+    const err = makeErrorWithHeaders(429, '429 rate_limit_error', { 'retry-after': '3600' });
+    expect(classifyUsageLimitError(err)?.kind).toBe('oauth-limit-no-ts');
+  });
+
+  it('reads unified headers from a web Headers object (not just a plain record)', () => {
+    const resetEpochSec = Math.floor(Date.now() / 1000) + 7200;
+    const err = makeErrorWithHeaders(
+      429,
+      '429',
+      new Headers({
+        'anthropic-ratelimit-unified-representative-claim': 'seven_day_opus',
+        'anthropic-ratelimit-unified-reset': String(resetEpochSec),
+      }),
+    );
+    const result = classifyUsageLimitError(err);
+    expect(result?.kind).toBe('oauth-limit');
+    if (result?.kind === 'oauth-limit') {
+      expect(result.resetsAt.getTime()).toBe(resetEpochSec * 1000);
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/providers/anthropic-direct/usage-limit.ts
+++ b/src/agent/providers/anthropic-direct/usage-limit.ts
@@ -25,49 +25,65 @@ export type UsageLimitClassification =
  * Upper bound (ms) on a `retry-after` hint that still counts as a *transient*
  * API-tier rate limit (per-minute RPM/ITPM/OTPM windows that clear in seconds).
  *
- * Invariant: Anthropic returns the SAME `429 rate_limit_error` + `retry-after`
- * shape for BOTH a per-minute API throttle AND an OAuth *subscription* cap — the
- * subscription limit arrives as a bare `rate_limit_error` with a `retry-after`
- * header and no `|<ts>` (see anthropics/claude-code#30930). Header PRESENCE
- * therefore cannot distinguish them; only its MAGNITUDE can. Per-minute
- * throttles clear in ≤ a minute or two; a subscription reset is hours away, so a
- * `retry-after` above this line is treated as subscription exhaustion (pause +
- * hot-swap + auto-resume), not a short silent retry.
+ * Invariant: this magnitude heuristic is now a LAST-RESORT fallback, used only
+ * when a 429 carries NO `anthropic-ratelimit-*` headers at all (see
+ * {@link classifyUsageLimitError}). When those authoritative headers are
+ * present the classifier keys on them directly, mirroring Claude Code. But
+ * Anthropic can still deliver an OAuth *subscription* cap as a bare
+ * `rate_limit_error` with a `retry-after` header and no `|<ts>` and no rate-
+ * limit headers (anthropics/claude-code#30930); in that header-less case
+ * PRESENCE cannot distinguish a throttle from a subscription cap, so MAGNITUDE
+ * is the only remaining signal. Per-minute throttles clear in ≤ a minute or
+ * two; a subscription reset is hours away, so a `retry-after` above this line
+ * is treated as subscription exhaustion (pause + hot-swap + auto-resume), not a
+ * short silent retry.
  */
 export const RATE_LIMIT_TRANSIENT_MAX_RETRY_AFTER_MS = 5 * 60 * 1000;
+
+/**
+ * Defensive read of a single HTTP header off an error's `headers` field.
+ *
+ * The Anthropic SDK's `APIError.headers` has been both a web `Headers` (with
+ * `.get`) and a plain record across versions, so both shapes are handled:
+ * a `.get()` method is preferred, else the record is probed for the exact key
+ * and its upper-cased form. Returns the header value, or `undefined` when the
+ * error is not an object, has no usable `headers`, or the header is absent.
+ *
+ * Shared by {@link parseRetryAfterMs} and {@link classifyUsageLimitError}'s
+ * unified/per-minute header reads so all header access uses one code path.
+ */
+export function getHeader(error: unknown, name: string): string | undefined {
+  if (error === null || typeof error !== 'object') return undefined;
+  const headers = (error as { headers?: unknown }).headers;
+  if (headers === null || headers === undefined) return undefined;
+  const h = headers as { get?: unknown };
+  if (typeof h.get === 'function') {
+    const v = (headers as { get(n: string): string | null }).get(name);
+    return v ?? undefined;
+  }
+  if (typeof headers === 'object') {
+    const rec = headers as Record<string, unknown>;
+    const v = rec[name] ?? rec[name.toUpperCase()];
+    return typeof v === 'string' ? v : undefined;
+  }
+  return undefined;
+}
 
 /**
  * Best-effort parse of a transient-backoff hint from an error's HTTP headers.
  *
  * Reads `retry-after-ms` (milliseconds) first, then `retry-after` (seconds, or
  * an HTTP-date). Returns the delay in ms, or `undefined` when no usable header
- * is present. Header access is defensive: the Anthropic SDK's `APIError.headers`
- * has been both a web `Headers` (with `.get`) and a plain record across
- * versions, so both shapes are handled.
+ * is present. Header access is via the shared {@link getHeader} helper, which
+ * handles both a web `Headers` (with `.get`) and a plain-record shape.
  */
 export function parseRetryAfterMs(error: unknown): number | undefined {
-  if (error === null || typeof error !== 'object') return undefined;
-  const headers = (error as { headers?: unknown }).headers;
-  if (headers === null || headers === undefined) return undefined;
-  const get = (name: string): string | undefined => {
-    const h = headers as { get?: unknown };
-    if (typeof h.get === 'function') {
-      const v = (headers as { get(n: string): string | null }).get(name);
-      return v ?? undefined;
-    }
-    if (typeof headers === 'object') {
-      const rec = headers as Record<string, unknown>;
-      const v = rec[name] ?? rec[name.toUpperCase()];
-      return typeof v === 'string' ? v : undefined;
-    }
-    return undefined;
-  };
-  const ms = get('retry-after-ms');
+  const ms = getHeader(error, 'retry-after-ms');
   if (ms !== undefined) {
     const n = Number(ms);
     if (Number.isFinite(n) && n >= 0) return n;
   }
-  const sec = get('retry-after');
+  const sec = getHeader(error, 'retry-after');
   if (sec !== undefined) {
     const n = Number(sec);
     if (Number.isFinite(n) && n >= 0) return Math.round(n * 1000);
@@ -83,20 +99,37 @@ export function parseRetryAfterMs(error: unknown): number | undefined {
 /**
  * Classify an error as a usage-limit error, or return `null` if it is not one.
  *
- * Recognised patterns:
- *   - HTTP 429 with message containing `|<unix-ts>` — OAuth subscription limit
- *     (the timestamp is when the limit resets).
- *   - HTTP 429 with a SHORT `retry-after`/`retry-after-ms` header
- *     (≤ {@link RATE_LIMIT_TRANSIENT_MAX_RETRY_AFTER_MS}) and no `|<unix-ts>` —
- *     a transient API-tier rate limit (per-minute RPM/ITPM) that clears in
- *     seconds. Kept distinct so callers do not apply the 2-hour subscription-
- *     pause semantics to a throttle that clears in seconds.
- *   - HTTP 429 with a LONG `retry-after` (> the threshold) OR no `retry-after`
- *     header, and no `|<unix-ts>` — OAuth subscription exhaustion with unknown
- *     reset. Anthropic delivers the subscription cap as a bare
- *     `rate_limit_error` + `retry-after` (anthropics/claude-code#30930), so a
- *     long/absent backoff is the signal that separates it from a per-minute
- *     throttle. Routed to the pause + hot-swap + auto-resume path.
+ * Invariant: a 429's classification precedence keys on AUTHORITATIVE signals
+ * first and demotes the `retry-after` MAGNITUDE heuristic to a last-resort
+ * fallback — mirroring Claude Code (verified against v2.1.206), which decides
+ * subscription-cap vs. transient by the presence of `anthropic-ratelimit-
+ * unified-*` headers, never by `retry-after` size. The change is strictly
+ * ADDITIVE and PRESENCE-GATED: when NONE of the `anthropic-ratelimit-*` headers
+ * are present the result is byte-for-byte identical to the pre-existing
+ * fallback (step 4), so there is no behavior change on real 429s that don't
+ * carry the headers. In precedence order for `status === 429`:
+ *   1. Message contains `|<unix-ts>` — OAuth subscription limit; the timestamp
+ *      is the reset. Authoritative when present, so checked first.
+ *   2. Unified subscription headers present (`unified-representative-claim` OR
+ *      `unified-overage-status` present, OR `unified-status === "rejected"`) —
+ *      a subscription cap. If `unified-reset` is present and a finite positive
+ *      number, return `oauth-limit` with `resetsAt = reset * 1000` (the header
+ *      is epoch SECONDS — an authoritative deadline that upgrades the blind
+ *      poll to a real wait); else `oauth-limit-no-ts`.
+ *   3. Per-minute throttle headers present (`anthropic-ratelimit-{requests,
+ *      input-tokens,output-tokens}-*`, e.g. `-remaining`) — a transient API-
+ *      tier rate limit that clears in seconds → `rate-limit-transient` with
+ *      `retryAfterMs` from {@link parseRetryAfterMs}.
+ *   4. No rate-limit headers at all — FALLBACK to the magnitude heuristic: a
+ *      short `retry-after` (≤ {@link RATE_LIMIT_TRANSIENT_MAX_RETRY_AFTER_MS})
+ *      is a per-minute throttle → `rate-limit-transient`; a long or absent
+ *      backoff is subscription-scale → `oauth-limit-no-ts` (pause + hot-swap +
+ *      auto-resume). Anthropic can deliver a subscription cap as a bare
+ *      `rate_limit_error` + `retry-after` with no headers
+ *      (anthropics/claude-code#30930), so magnitude is the only remaining
+ *      signal here.
+ *
+ * Also recognised:
  *   - HTTP 400 + `invalid_request_error` + `credit balance` — API key balance
  *     exhausted.
  */
@@ -105,6 +138,7 @@ export function classifyUsageLimitError(error: Error): UsageLimitClassification 
   const status = (error as Error & { status: number }).status;
 
   if (status === 429) {
+    // Step 1: `|<unix-ts>` message parse — authoritative when present.
     const parts = error.message.split('|');
     if (parts.length >= 2) {
       const ts = parseInt(parts[1]!.trim(), 10);
@@ -112,13 +146,57 @@ export function classifyUsageLimitError(error: Error): UsageLimitClassification 
         return { kind: 'oauth-limit', resetsAt: new Date(ts * 1000) };
       }
     }
+
+    // Step 2: unified subscription headers — the signal Claude Code keys on.
+    // Presence of a representative-claim / overage-status header, or an
+    // explicit rejected status, marks this 429 as a subscription cap.
+    const unifiedClaim = getHeader(error, 'anthropic-ratelimit-unified-representative-claim');
+    const unifiedOverage = getHeader(error, 'anthropic-ratelimit-unified-overage-status');
+    const unifiedStatus = getHeader(error, 'anthropic-ratelimit-unified-status');
+    if (
+      unifiedClaim !== undefined ||
+      unifiedOverage !== undefined ||
+      unifiedStatus === 'rejected'
+    ) {
+      const reset = getHeader(error, 'anthropic-ratelimit-unified-reset');
+      if (reset !== undefined) {
+        const resetSec = Number(reset);
+        if (Number.isFinite(resetSec) && resetSec > 0) {
+          // Header is epoch SECONDS; the authoritative reset deadline.
+          return { kind: 'oauth-limit', resetsAt: new Date(resetSec * 1000) };
+        }
+      }
+      return { kind: 'oauth-limit-no-ts' };
+    }
+
+    // Step 3: per-minute throttle headers — RPM/ITPM/OTPM windows that clear in
+    // seconds. Their presence (any of the requests/token counters) means this
+    // is a transient API-tier rate limit, distinct from a subscription cap.
+    const perMinutePresent =
+      getHeader(error, 'anthropic-ratelimit-requests-remaining') !== undefined ||
+      getHeader(error, 'anthropic-ratelimit-requests-limit') !== undefined ||
+      getHeader(error, 'anthropic-ratelimit-requests-reset') !== undefined ||
+      getHeader(error, 'anthropic-ratelimit-input-tokens-remaining') !== undefined ||
+      getHeader(error, 'anthropic-ratelimit-input-tokens-limit') !== undefined ||
+      getHeader(error, 'anthropic-ratelimit-input-tokens-reset') !== undefined ||
+      getHeader(error, 'anthropic-ratelimit-output-tokens-remaining') !== undefined ||
+      getHeader(error, 'anthropic-ratelimit-output-tokens-limit') !== undefined ||
+      getHeader(error, 'anthropic-ratelimit-output-tokens-reset') !== undefined;
+    if (perMinutePresent) {
+      return { kind: 'rate-limit-transient', retryAfterMs: parseRetryAfterMs(error) };
+    }
+
+    // Step 4: FALLBACK — no `anthropic-ratelimit-*` headers at all. Preserve the
+    // pre-existing magnitude heuristic byte-for-byte so this path is unchanged
+    // for real 429s that carry no rate-limit headers.
+    //
     // Invariant: Anthropic returns the SAME `429 rate_limit_error` + `retry-after`
     // shape for a per-minute API throttle AND an OAuth subscription cap — the
     // subscription limit arrives as a bare `rate_limit_error` with a `retry-after`
-    // header and no `|<ts>` (anthropics/claude-code#30930). Header PRESENCE
-    // therefore cannot tell them apart; only its MAGNITUDE can. A short backoff
-    // (≤ threshold) is a per-minute throttle → transient short retry. A long or
-    // absent backoff is subscription-scale → fall through to oauth-limit-no-ts
+    // header and no `|<ts>` (anthropics/claude-code#30930). With no rate-limit
+    // headers present, PRESENCE cannot tell them apart; only MAGNITUDE can. A
+    // short backoff (≤ threshold) is a per-minute throttle → transient short
+    // retry. A long or absent backoff is subscription-scale → oauth-limit-no-ts
     // (pause + hot-swap + auto-resume), so the operator is notified and an
     // account hot-swap resumes the turn. Treating EVERY retry-after 429 as
     // transient silently lost both the pause notification and the hot-swap

--- a/src/agent/providers/anthropic-direct/usage-limit.ts
+++ b/src/agent/providers/anthropic-direct/usage-limit.ts
@@ -96,6 +96,27 @@ export function parseRetryAfterMs(error: unknown): number | undefined {
   return undefined;
 }
 
+/** ECMAScript Date's representable range ceiling in ms (±8.64e15). */
+const MAX_ECMASCRIPT_DATE_MS = 8_640_000_000_000_000;
+
+/**
+ * Contract: convert an epoch-SECONDS reset value to a Date, or `undefined` when
+ * the value is not a usable forward deadline — i.e. not finite, not positive,
+ * or past the ECMAScript Date ceiling. A value beyond that ceiling yields
+ * `new Date(NaN)` (an Invalid Date) whose `getTime()` is NaN; downstream both
+ * the `resetsAt.getTime() - Date.now() > TWO_HOURS_MS` surface-guard and the
+ * `waitForReset` deadline are then NaN comparisons that never fire, hanging the
+ * turn until abort/hot-swap. Rejecting here routes such garbage to the
+ * timestamp-less path instead. Shared by the `|<ts>` message parse (step 1) and
+ * the `unified-reset` header read (step 2) so both are guarded identically.
+ */
+function epochSecondsToResetDate(sec: number): Date | undefined {
+  if (!Number.isFinite(sec) || sec <= 0) return undefined;
+  const ms = sec * 1000;
+  if (ms > MAX_ECMASCRIPT_DATE_MS) return undefined;
+  return new Date(ms);
+}
+
 /**
  * Classify an error as a usage-limit error, or return `null` if it is not one.
  *
@@ -112,10 +133,10 @@ export function parseRetryAfterMs(error: unknown): number | undefined {
  *      is the reset. Authoritative when present, so checked first.
  *   2. Unified subscription headers present (`unified-representative-claim` OR
  *      `unified-overage-status` present, OR `unified-status === "rejected"`) —
- *      a subscription cap. If `unified-reset` is present and a finite positive
- *      number, return `oauth-limit` with `resetsAt = reset * 1000` (the header
- *      is epoch SECONDS — an authoritative deadline that upgrades the blind
- *      poll to a real wait); else `oauth-limit-no-ts`.
+ *      a subscription cap. If `unified-reset` is present and a finite, positive,
+ *      in-range number, return `oauth-limit` with `resetsAt = reset * 1000` (the
+ *      header is epoch SECONDS — an authoritative deadline that upgrades the
+ *      blind poll to a real wait); else `oauth-limit-no-ts`.
  *   3. Per-minute throttle headers present (`anthropic-ratelimit-{requests,
  *      input-tokens,output-tokens}-*`, e.g. `-remaining`) — a transient API-
  *      tier rate limit that clears in seconds → `rate-limit-transient` with
@@ -138,12 +159,13 @@ export function classifyUsageLimitError(error: Error): UsageLimitClassification 
   const status = (error as Error & { status: number }).status;
 
   if (status === 429) {
-    // Step 1: `|<unix-ts>` message parse — authoritative when present.
+    // Step 1: `|<unix-ts>` message parse — authoritative when present. A
+    // non-numeric or out-of-range timestamp falls through to the header steps.
     const parts = error.message.split('|');
     if (parts.length >= 2) {
-      const ts = parseInt(parts[1]!.trim(), 10);
-      if (!isNaN(ts) && ts > 0) {
-        return { kind: 'oauth-limit', resetsAt: new Date(ts * 1000) };
+      const resetsAt = epochSecondsToResetDate(parseInt(parts[1]!.trim(), 10));
+      if (resetsAt !== undefined) {
+        return { kind: 'oauth-limit', resetsAt };
       }
     }
 
@@ -160,10 +182,10 @@ export function classifyUsageLimitError(error: Error): UsageLimitClassification 
     ) {
       const reset = getHeader(error, 'anthropic-ratelimit-unified-reset');
       if (reset !== undefined) {
-        const resetSec = Number(reset);
-        if (Number.isFinite(resetSec) && resetSec > 0) {
-          // Header is epoch SECONDS; the authoritative reset deadline.
-          return { kind: 'oauth-limit', resetsAt: new Date(resetSec * 1000) };
+        // Header is epoch SECONDS; the authoritative reset deadline.
+        const resetsAt = epochSecondsToResetDate(Number(reset));
+        if (resetsAt !== undefined) {
+          return { kind: 'oauth-limit', resetsAt };
         }
       }
       return { kind: 'oauth-limit-no-ts' };


### PR DESCRIPTION
## Summary

`classifyUsageLimitError` now prefers Anthropic's authoritative `anthropic-ratelimit-unified-*` response headers to tell an OAuth **subscription cap** apart from a **transient per-minute throttle** — the same signal Claude Code keys on (verified against v2.1.206). The existing 5-minute `retry-after` magnitude gate (`RATE_LIMIT_TRANSIENT_MAX_RETRY_AFTER_MS`) is demoted to a **last-resort fallback**, used only when a 429 carries no rate-limit headers at all. When the `unified-reset` header is present it yields a real `resetsAt`, upgrading the timestamp-less blind-poll path to an authoritative `waitForReset`.

Closes #488

## Safety (no regression)

The change is strictly **additive** and **presence-gated**. When **none** of the unified/per-minute `anthropic-ratelimit-*` headers are present, the classification result is **byte-for-byte identical** to today's fallback (step 4 — the `|ts` parse, then the `retry-after` magnitude heuristic). This guarantees no behavior change regardless of whether real subscription 429s actually carry the headers. `RATE_LIMIT_TRANSIENT_MAX_RETRY_AFTER_MS` remains exported and is used only in that fallback.

## Test evidence

- `src/agent/providers/anthropic-direct/usage-limit.test.ts` — **48/48 pass** (14 new cases: unified claim + reset -> `oauth-limit` with header-derived `resetsAt`; unified claim without reset -> `oauth-limit-no-ts`; `unified-status: rejected` -> `oauth-limit-no-ts`; per-minute-only headers -> `rate-limit-transient`; unified header wins over a short `retry-after`; `|ts` wins over unified; fallback short/long retry-after regression guards; web-`Headers` read).
- `src/agent/providers/anthropic-direct/query-auth-retry.test.ts` — **26/26 pass** (no downstream regression).
- `pnpm lint` (`tsc --noEmit`) — clean.

## Open question (post-merge, blocking real-world benefit)

Confirm the `anthropic-ratelimit-unified-*` headers are **actually present** on AFK's real `/v1/messages` **OAuth subscription** 429 `error.headers`. The header names/semantics are officially documented and Claude Code's code path reads them, but guarantee-of-presence on the inference endpoint's OAuth 429 is community-observed, not doc-guaranteed. Recommend a telemetry/logging check that captures `error.headers` on one real occurrence before relying on the header path. Until then, the presence-gated fallback preserves current behavior, so this ships safely.

## What changed

- **`usage-limit.ts`** — reworked the `status === 429` branch into a 4-step precedence (see summary); rewrote the `classifyUsageLimitError` doc comment (opens with `Invariant:`) to describe it.
- **`usage-limit.ts`** — factored the defensive header-access logic out of `parseRetryAfterMs` into a shared, exported `getHeader(error, name)` helper (handles both a web `Headers` with `.get()` and a plain lower/upper-case record); `parseRetryAfterMs` reuses it with identical behavior.
- **`usage-limit.test.ts`** — added the cases above; all pre-existing tests unchanged and passing.
- **`retry-layer.ts`** — **not modified.** Its `oauth-limit` (has-`resetsAt`) path already calls `waitForReset({ resetsAt, ... })` and is agnostic to whether `resetsAt` came from the `|ts` parse or the `unified-reset` header, so a header-derived deadline flows through the existing wait/resume path with no change.
