### PR TITLE
feat(hooks): observe-only safe-destruct PreToolUse detector (gate-migration wave 1)

### DIFF
--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -9,6 +9,7 @@
 import { createHookRegistry, type HookRegistry } from './hooks.js';
 import { createShadowVerifyNudge } from './shadow-verify-nudge.js';
 import { createAskQuestionGate } from './ask-question-gate.js';
+import { createSafeDestructDetect } from './safe-destruct-detect.js';
 import { MemoryStore, createMemorySessionEndHook } from './memory/index.js';
 import { createPlanModeGate } from './plan-mode-gate.js';
 import { createAfkModeGate } from './afk-mode-gate.js';
@@ -112,6 +113,18 @@ export function createDefaultHookRegistry(
   // router park-and-decline after the round-trip. No-op on REPL/Telegram
   // (handler installed; probed at call time). See ask-question-gate.ts.
   registry.register('PreToolUse', createAskQuestionGate());
+  // Safe-destruct detector (observe-only, ALL surfaces): witness — but never
+  // block — bash commands matching a curated destructive/irreversible pattern
+  // (rm -rf, git reset --hard, DROP DATABASE, dd of=/dev/*, mkfs, terraform
+  // destroy, ...). It emits a `hook_decision` catch-record via the unused
+  // `approve` outcome, so it (a) adds ZERO blocking friction — the interpreter-
+  // eval lesson that started this program — and (b) is filterable as
+  // decision==='approve' and ignored by the mechanical friction detectors. This
+  // is the Wave-1 shadow window whose records calibrate a later block/nudge
+  // slice. Registered unconditionally (no deps, never blocks → safe on headless/
+  // autonomous surfaces too). See safe-destruct-detect.ts and
+  // .afk/plans/friction-substrate-and-gate-migration.md §9.
+  registry.register('PreToolUse', createSafeDestructDetect());
   const store = memoryStore ?? new MemoryStore();
   if (getPermissionMode !== undefined) {
     registry.register('PreToolUse', createPlanModeGate(getPermissionMode));

--- a/src/agent/hooks/config-bridge.test.ts
+++ b/src/agent/hooks/config-bridge.test.ts
@@ -369,11 +369,12 @@ describe('createDefaultHookRegistry integration', () => {
 
   it('createDefaultHookRegistry without hookConfig → 0 config hooks registered', () => {
     const { registry } = createDefaultHookRegistry();
-    // Built-in handlers exist for SubagentStop and SessionEnd, plus exactly ONE
-    // built-in PreToolUse handler (the ask-question gate, registered
-    // unconditionally). No further PreToolUse hooks since we passed no
-    // hookConfig (path-approval disabled above).
-    expect(registry.count('PreToolUse')).toBe(1);
+    // Built-in handlers exist for SubagentStop and SessionEnd, plus the TWO
+    // always-on built-in PreToolUse handlers (the ask-question gate and the
+    // observe-only safe-destruct detector), both registered unconditionally. No
+    // further PreToolUse hooks since we passed no hookConfig (path-approval
+    // disabled above).
+    expect(registry.count('PreToolUse')).toBe(2);
   });
 
   it('createDefaultHookRegistry with hookConfig → config hooks ARE registered', () => {
@@ -398,8 +399,8 @@ describe('createDefaultHookRegistry integration', () => {
       hookConfig,
       { cwd: projectCwd },
     );
-    // 1 built-in (ask-question gate) + 1 config hook for PreToolUse
-    expect(registry.count('PreToolUse')).toBe(2);
+    // 2 built-ins (ask-question gate + safe-destruct detector) + 1 config hook
+    expect(registry.count('PreToolUse')).toBe(3);
   });
 
   it('built-in SubagentStop handler still present when hookConfig is provided', () => {

--- a/src/agent/safe-destruct-detect.test.ts
+++ b/src/agent/safe-destruct-detect.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for the observe-only safe-destruct detector (Wave 1, gate-migration).
+ *
+ * Three contracts:
+ *   1. `detectDestructiveCommands` matches the curated catastrophic patterns
+ *      and — critically for calibration — does NOT flag common-but-safe near
+ *      misses (`rm -r build/`, `rm -f lock`, `git branch -d`, `truncate -s 0`).
+ *   2. The hook returns an `approve` catch-record (never a block) only on a
+ *      `bash` PreToolUse with a destructive command; `{}` otherwise.
+ *   3. It is wired into the default registry and, dispatched end-to-end, passes
+ *      the command through (no throw) while recording `decision: 'approve'`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { HookContext, HookDecision, PreToolUseContext } from './hooks.js';
+import {
+  createSafeDestructDetect,
+  detectDestructiveCommands,
+  SAFE_DESTRUCT_DETECT_REASON_PREFIX,
+} from './safe-destruct-detect.js';
+import { createDefaultHookRegistry } from './default-hook-registry.js';
+
+function preCtx(command: string, toolName = 'bash'): HookContext {
+  const ctx: PreToolUseContext = { event: 'PreToolUse', toolName, input: { command } };
+  return ctx;
+}
+
+describe('detectDestructiveCommands', () => {
+  it.each([
+    ['rm -rf /tmp/foo', 'rm-recursive-force'],
+    ['rm -fr build', 'rm-recursive-force'],
+    ['sudo rm -Rf /var/x', 'rm-recursive-force'],
+    ['rm -rfv ~/.cache', 'rm-recursive-force'],
+    ['rm -r -f dir', 'rm-recursive-force-split'],
+    ['rm -f -r dir', 'rm-recursive-force-split'],
+    ['rm --recursive --force dir', 'rm-recursive-force-long'],
+    ['rm -rf --no-preserve-root /', 'rm-no-preserve-root'],
+    ['git reset --hard HEAD~3', 'git-reset-hard'],
+    ['git clean -fd', 'git-clean-force'],
+    ['git push --force origin main', 'git-push-force'],
+    ['git push -f', 'git-push-force'],
+    ['git branch -D feature', 'git-branch-force-delete'],
+    ['dd if=/x.img of=/dev/sda bs=1M', 'dd-to-device'],
+    ['mkfs.ext4 /dev/sdb1', 'mkfs'],
+    ['echo boot > /dev/sda', 'redirect-to-block-device'],
+    ["find . -name '*.log' -delete", 'find-delete'],
+    ['find . -exec rm {} +', 'find-delete'],
+    ['shred -u secret.key', 'shred'],
+    ["psql -c 'DROP DATABASE prod'", 'sql-drop-truncate-delete'],
+    ["mysql -e 'TRUNCATE TABLE users'", 'sql-drop-truncate-delete'],
+    ["psql -c 'DELETE FROM orders'", 'sql-drop-truncate-delete'],
+    ['docker system prune -af', 'docker-destructive'],
+    ['docker rm -f web', 'docker-destructive'],
+    ['kubectl delete pod api-0', 'kubectl-delete'],
+    ['terraform destroy -auto-approve', 'terraform-destroy'],
+  ])('flags %j → %s', (command, expectedId) => {
+    expect(detectDestructiveCommands(command)).toContain(expectedId);
+  });
+
+  it.each([
+    ['rm file.txt'], // no recursive/force
+    ['rm -r build'], // recursive only — deliberately NOT flagged
+    ['rm -f stale.lock'], // force only
+    ['git status'],
+    ['git commit -m "wip"'],
+    ['git push origin main'], // no force
+    ['git branch -d merged'], // lowercase -d is the safe delete
+    ['ls -la /var'],
+    ['npm install'],
+    ['dd if=/dev/zero of=/tmp/file bs=1M count=1'], // writes a file, not a device
+    ['dd if=/dev/urandom of=/dev/null'], // pseudo-device excluded
+    ['cat /dev/null > app.log'], // redirect to a file, not a device
+    ['truncate -s 0 app.log'], // shell truncate, not SQL TRUNCATE TABLE
+    ['echo "safe"'],
+    [''],
+  ])('does not flag benign %j', (command) => {
+    expect(detectDestructiveCommands(command)).toEqual([]);
+  });
+
+  it('reports every distinct pattern in a compound command', () => {
+    const ids = detectDestructiveCommands('rm -rf x && git push --force');
+    expect(ids).toContain('rm-recursive-force');
+    expect(ids).toContain('git-push-force');
+  });
+});
+
+describe('createSafeDestructDetect (observe-only hook)', () => {
+  const hook = createSafeDestructDetect();
+
+  it('returns an approve catch-record with the stable reason prefix on a destructive bash command', () => {
+    const decision = hook(preCtx('rm -rf /tmp/x'));
+    expect(decision.decision).toBe('approve');
+    expect(decision.reason).toContain(SAFE_DESTRUCT_DETECT_REASON_PREFIX);
+    expect(decision.reason).toContain('rm-recursive-force');
+  });
+
+  it('NEVER blocks — no block decision, no continue:false (the interpreter-eval lesson)', () => {
+    const decision: HookDecision = hook(preCtx('rm -rf / --no-preserve-root'));
+    expect(decision.decision).not.toBe('block');
+    expect(decision.continue).not.toBe(false);
+  });
+
+  it('passes through benign bash commands', () => {
+    expect(hook(preCtx('rm -r build'))).toEqual({});
+    expect(hook(preCtx('git status'))).toEqual({});
+  });
+
+  it('ignores non-bash tools', () => {
+    expect(hook(preCtx('rm -rf /tmp/x', 'read_file'))).toEqual({});
+  });
+
+  it('ignores non-PreToolUse events', () => {
+    const stop: HookContext = { event: 'Stop', sessionId: 's1' };
+    expect(hook(stop)).toEqual({});
+  });
+
+  it('passes through when the command is absent or empty', () => {
+    const noInput: HookContext = { event: 'PreToolUse', toolName: 'bash' };
+    expect(hook(noInput)).toEqual({});
+    expect(hook(preCtx(''))).toEqual({});
+  });
+});
+
+describe('safe-destruct-detect wiring in the default registry', () => {
+  it('is registered and records approve (without blocking) for a destructive bash call', async () => {
+    const { registry } = createDefaultHookRegistry(undefined, 'cli');
+    const ctx: PreToolUseContext = {
+      event: 'PreToolUse',
+      toolName: 'bash',
+      input: { command: 'rm -rf /tmp/scratch' },
+    };
+    // Must not throw (a block would throw HookBlockedError through dispatch).
+    const decision = await registry.dispatch(ctx);
+    expect(decision.decision).toBe('approve');
+    expect(decision.reason).toContain(SAFE_DESTRUCT_DETECT_REASON_PREFIX);
+  });
+
+  it('leaves benign bash calls untouched through the default registry', async () => {
+    const { registry } = createDefaultHookRegistry(undefined, 'cli');
+    const ctx: PreToolUseContext = {
+      event: 'PreToolUse',
+      toolName: 'bash',
+      input: { command: 'git status' },
+    };
+    const decision = await registry.dispatch(ctx);
+    expect(decision.decision).not.toBe('approve');
+    expect(decision.decision).not.toBe('block');
+  });
+});

--- a/src/agent/safe-destruct-detect.ts
+++ b/src/agent/safe-destruct-detect.ts
@@ -1,0 +1,162 @@
+/**
+ * Safe-destruct detector — an **observe-only** PreToolUse hook.
+ *
+ * Migrates the detection half of the `safe-destruct` gate-skill into
+ * deterministic harness code (Wave 1 of the friction-substrate / gate-migration
+ * program — `.afk/plans/friction-substrate-and-gate-migration.md`). It watches
+ * `bash` commands for a curated set of catastrophic / irreversible operations
+ * (`rm -rf`, `git reset --hard`, `DROP DATABASE`, `dd of=/dev/*`, `mkfs`,
+ * `terraform destroy`, ...) and, on a match, emits a witnessed catch-record —
+ * **without blocking the command**.
+ *
+ * # Why observe-only (the interpreter-eval lesson)
+ *
+ * This whole program exists because an over-firing PreToolUse *hard block* (the
+ * interpreter-eval guard) generated 18 nights of self-inflicted friction. The
+ * plan's de-risking rule is therefore "injectContext-first, shadow-window
+ * before enforcing". PreToolUse cannot `injectContext` — the harness honors that
+ * field only for `SubagentStop` / `UserPromptSubmit` (see `hooks.ts`) — and a
+ * hard block would repeat the exact mistake. So slice 1 changes ZERO behavior:
+ * it only records that a destructive command was attempted. The records are the
+ * shadow window; a later slice uses their real-world frequency per pattern to
+ * calibrate which (if any) warrant a block or nudge.
+ *
+ * # How the catch-record is emitted (the `approve` outcome)
+ *
+ * A PreToolUse handler can only `block` or pass; passing (`{}`) is not
+ * witnessed with a reason. To emit a filterable catch-record while letting the
+ * command run, this hook returns the otherwise-unused `decision: 'approve'`
+ * outcome with a structured `reason`. `approve`:
+ *   - is behaviorally identical to unset — `isBlocking()` (`hook-registry.ts`)
+ *     checks only `block` / `continue:false`, so the command proceeds and the
+ *     other PreToolUse gates (afk-mode, bash-restriction, ...) still run;
+ *   - is recorded by `dispatchPreToolUse` as a `hook_decision` event carrying
+ *     the `reason` (`subagent-hooks.ts`), which is the Wave-4 substrate signal;
+ *   - is IGNORED by the mechanical friction detectors (they count `block`
+ *     outcomes / error `failureClass`es — see `improve/scan/detectors`), so
+ *     these observations never masquerade as new friction.
+ * No existing hook returns `approve`, so `decision === 'approve'` cleanly
+ * isolates safe-destruct observations in the trace.
+ *
+ * Registered unconditionally on ALL surfaces (including headless/autonomous,
+ * where destructive actions are most dangerous and least observed) precisely
+ * because it never blocks — it is safe everywhere.
+ *
+ * @module agent/safe-destruct-detect
+ */
+
+import type { HookContext, HookDecision } from './hooks.js';
+
+/**
+ * Stable prefix on the emitted `reason`. Exported so the telemetry substrate,
+ * tests, and `afk trace show` can match safe-destruct observations by prefix.
+ */
+export const SAFE_DESTRUCT_DETECT_REASON_PREFIX =
+  'safe-destruct observe-only: destructive-command attempt';
+
+/**
+ * Curated destructive / irreversible command patterns.
+ *
+ * Calibration bias: high-signal only. Operations that are catastrophic AND
+ * rarely a legitimate agent action. Recursive-only deletes (`rm -r build/`) are
+ * deliberately NOT flagged — common and usually safe; only recursive+force
+ * (no prompt, no recovery) is. Each regex avoids nested quantifiers so the scan
+ * is linear (no ReDoS); `[^|&;\n]*` bounds a match to a single command segment.
+ *
+ * Reused by the future block/nudge slice — keep it the single source of truth.
+ */
+const DESTRUCTIVE_PATTERNS: readonly { readonly id: string; readonly re: RegExp }[] = [
+  // --- rm: recursive AND force (irrecoverable, no prompt) ---------------------
+  // One flag cluster containing both r and f (`-rf`, `-fr`, `-rfv`, `-Rf`, ...).
+  { id: 'rm-recursive-force', re: /\brm\s+-(?=[a-z]*r)(?=[a-z]*f)[a-z]+/i },
+  // Recursive and force in separate flag tokens (`rm -r -f`, `rm -f -r`).
+  {
+    id: 'rm-recursive-force-split',
+    re: /\brm\s+-[a-z]*r[a-z]*\s+-[a-z]*f|\brm\s+-[a-z]*f[a-z]*\s+-[a-z]*r/i,
+  },
+  // Long-form, both flags present in either order.
+  {
+    id: 'rm-recursive-force-long',
+    re: /\brm\s+[^|&;\n]*--recursive\b[^|&;\n]*--force\b|\brm\s+[^|&;\n]*--force\b[^|&;\n]*--recursive\b/i,
+  },
+  // The explicit "yes, wipe /" escape hatch — always catastrophic.
+  { id: 'rm-no-preserve-root', re: /\brm\b[^|&;\n]*--no-preserve-root\b/i },
+
+  // --- git: history / worktree destroyers ------------------------------------
+  { id: 'git-reset-hard', re: /\bgit\s+reset\s+--hard\b/i },
+  { id: 'git-clean-force', re: /\bgit\s+clean\s+-[a-z]*f|\bgit\s+clean\s+[^|&;\n]*--force\b/i },
+  {
+    id: 'git-push-force',
+    re: /\bgit\s+push\b[^|&;\n]*--force\b|\bgit\s+push\b[^|&;\n]*(?<![\w-])-f\b/i,
+  },
+  // Case-sensitive: `-D` force-deletes a branch; `-d` refuses on unmerged.
+  { id: 'git-branch-force-delete', re: /\bgit\s+branch\s+[^|&;\n]*-D\b/ },
+
+  // --- filesystem / raw device -----------------------------------------------
+  // Writing to a real device node (excludes the harmless pseudo-devices).
+  {
+    id: 'dd-to-device',
+    re: /\bof=\/dev\/(?!null\b|zero\b|random\b|urandom\b|stdout\b|stderr\b|tty\b)\S/i,
+  },
+  { id: 'mkfs', re: /\bmkfs(\.\w+)?\b/i },
+  { id: 'redirect-to-block-device', re: />\s*\/dev\/(sd|nvme|hd|disk|mmcblk|vd)\w*/i },
+  { id: 'find-delete', re: /\bfind\b[^|&;\n]*-delete\b|\bfind\b[^|&;\n]*-exec\s+rm\b/i },
+  { id: 'shred', re: /\bshred\b/i },
+
+  // --- SQL --------------------------------------------------------------------
+  {
+    id: 'sql-drop-truncate-delete',
+    re: /\b(drop\s+(table|database|schema|index)\b|truncate\s+table\b|delete\s+from\b)/i,
+  },
+
+  // --- infra / containers -----------------------------------------------------
+  {
+    id: 'docker-destructive',
+    re: /\bdocker\s+(system\s+prune|volume\s+(rm|prune)|image\s+prune|container\s+prune|network\s+prune)\b|\bdocker\b[^|&;\n]*\brmi?\s+[^|&;\n]*-f/i,
+  },
+  { id: 'kubectl-delete', re: /\bkubectl\s+delete\b/i },
+  { id: 'terraform-destroy', re: /\bterraform\s+destroy\b/i },
+];
+
+/**
+ * Return the ids of every destructive pattern the command matches (empty when
+ * none). Pure and stateless — no global-flag regexes, so `.test()` is safe to
+ * call repeatedly. Exported for the block/nudge slice and for tests.
+ */
+export function detectDestructiveCommands(command: string): string[] {
+  if (!command) return [];
+  const hits: string[] = [];
+  for (const { id, re } of DESTRUCTIVE_PATTERNS) {
+    if (re.test(command)) hits.push(id);
+  }
+  return hits;
+}
+
+/**
+ * Create the observe-only safe-destruct PreToolUse hook.
+ *
+ * Stateless (no dedup): every destructive attempt is a distinct data point —
+ * an agent looping on `rm -rf x` is exactly the signal the shadow window wants
+ * to surface, so occurrences are not collapsed.
+ */
+export function createSafeDestructDetect(): (context: HookContext) => HookDecision {
+  return function safeDestructDetect(context: HookContext): HookDecision {
+    if (context.event !== 'PreToolUse') return {};
+    if (context.toolName !== 'bash') return {};
+
+    const input = context.input as Record<string, unknown> | undefined;
+    const command = typeof input?.['command'] === 'string' ? input['command'] : '';
+    if (!command) return {};
+
+    const matched = detectDestructiveCommands(command);
+    if (matched.length === 0) return {};
+
+    // approve == allow (never blocks; see module header) but carries a reason
+    // that lands as a `hook_decision` catch-record for the reasoning-failure
+    // substrate.
+    return {
+      decision: 'approve',
+      reason: `${SAFE_DESTRUCT_DETECT_REASON_PREFIX} [${matched.join(', ')}]`,
+    };
+  };
+}


### PR DESCRIPTION
## What

First slice of **Wave 1** of the friction-substrate / gate-migration program:
migrate the **safe-destruct** gate-skill's detection into a deterministic harness
hook.

`src/agent/safe-destruct-detect.ts` — an **observe-only** PreToolUse hook that
witnesses destructive / irreversible `bash` commands (`rm -rf`, `git reset
--hard`, `git push --force`, `DROP`/`TRUNCATE`/`DELETE FROM`, `dd of=/dev/*`,
`mkfs`, `find -delete`, `shred`, docker/kubectl/terraform destroyers, ...) and
emits a `hook_decision` catch-record **without blocking**.

## Why observe-only (not a block, not injectContext)

- **PreToolUse cannot `injectContext`.** The harness honors that field only for
  `SubagentStop` / `UserPromptSubmit` (`hooks.ts`), so the plan's
  "injectContext-first" phrasing isn't directly expressible for a PreToolUse gate.
- **A hard block would repeat the mistake that started this program** — the
  over-firing interpreter-eval guard. The plan's de-risking rule is explicitly
  "shadow-window before enforcing."
- So this slice changes **zero behavior**. It records the attempt via the
  otherwise-unused `decision: 'approve'` outcome:
  - `approve` == allow — `isBlocking()` checks only `block` / `continue:false`,
    so the command proceeds and the other PreToolUse gates still run;
  - it lands as a `hook_decision` event carrying a `reason` (the Wave-4 substrate
    signal), via the existing `dispatchPreToolUse` witness path;
  - it is **ignored by the mechanical friction detectors** (they count `block`
    outcomes / error `failureClass`es), so observations never masquerade as new
    friction. No existing hook returns `approve`, so `decision === 'approve'`
    cleanly isolates safe-destruct records in the trace.
- Registered **unconditionally on all surfaces** (incl. headless / autonomous,
  where destructive actions are most dangerous and least observed) precisely
  because it never blocks.

The catch-records are the shadow window: a later slice uses their real-world
per-pattern frequency to calibrate which (if any) warrant a block or nudge.

## Calibration bias

High-signal only. Recursive-only deletes (`rm -r build/`) are deliberately NOT
flagged — only recursive **and** force. `git branch -D` is matched
case-sensitively (`-d` is the safe delete). Shell `truncate -s 0 file` is
distinguished from SQL `TRUNCATE TABLE`. Regexes avoid nested quantifiers (linear
scan, no ReDoS).

## Tests / gates

- New `safe-destruct-detect.test.ts` (50 tests): match/non-match pattern tables
  (incl. benign near-misses), the hook contract (approve+reason, **never**
  blocks), and end-to-end wiring through `createDefaultHookRegistry`.
- Updated two PreToolUse count assertions in `config-bridge.test.ts` (one new
  always-on built-in).
- Full suite green (602 files / 11137 tests, 0 failures); `lint`, `audit:sdk`,
  `audit:env`, `scan:env` all clean.

## Scope

Detection + observation only. No blocking, no new env var, no SDK import.
Follow-up slices: calibrate → enforce; `target-lock` + `release-boundary-gate`
hooks; Wave 2 Stop block-enforcement.

Plan: `.afk/plans/friction-substrate-and-gate-migration.md` §5 (Wave 1) + §9.
