### PR TITLE
refactor(agent): extract dispatch-batching + repeat-circuit-breaker from dispatcher.ts (#361)

### DIFF
--- a/src/agent/tools/dispatch-batching.ts
+++ b/src/agent/tools/dispatch-batching.ts
@@ -1,0 +1,63 @@
+/**
+ * Concurrency batching for the session tool dispatcher.
+ *
+ * Pure helpers extracted from `dispatcher.ts` (#361): the concurrency-safety
+ * classifier and the round-partitioner that groups a tool-call sequence into
+ * runs of concurrency-safe vs. sequential batches. No dispatcher state — see
+ * `SessionToolDispatcher.executeBatch` for the stateful consumer.
+ *
+ * @module agent/tools/dispatch-batching
+ */
+
+import { builtinToolSchemas, agentTool, skillTool, composeTool } from './schemas.js';
+import { memoryToolSchemas } from '../memory/memory-tools.js';
+import { getRuntimeStateTool } from '../awareness/index.js';
+import type { ToolCall } from '../providers/anthropic-direct/types.js';
+import type { ConcurrencyClassifier } from './types.js';
+
+/**
+ * Derived at module load from the union of all built-in tool schemas.
+ * A tool is concurrency-safe when its schema declares `concurrencySafe: true`.
+ * This replaces the former hand-maintained list and stays automatically in sync
+ * with schema changes.
+ *
+ * External constraint: schemas.ts and memory-tools.ts are the single source
+ * of truth. Mutations to those files propagate here without any secondary edit.
+ */
+const SAFE_TOOLS: ReadonlySet<string> = new Set(
+  [
+    ...builtinToolSchemas,
+    agentTool,
+    skillTool,
+    composeTool,
+    ...memoryToolSchemas,
+    getRuntimeStateTool,
+  ]
+    .filter((s) => s.concurrencySafe === true)
+    .map((s) => s.name),
+);
+
+export function defaultConcurrencyClassifier(toolName: string): boolean {
+  return SAFE_TOOLS.has(toolName);
+}
+
+export interface Batch {
+  isConcurrencySafe: boolean;
+  indices: number[];
+}
+
+export function partitionIntoBatches(
+  calls: ToolCall[],
+  classifier: ConcurrencyClassifier,
+): Batch[] {
+  return calls.reduce<Batch[]>((acc, call, i) => {
+    const safe = classifier(call.name, call.input);
+    const last = acc[acc.length - 1];
+    if (last && safe && last.isConcurrencySafe) {
+      last.indices.push(i);
+    } else {
+      acc.push({ isConcurrencySafe: safe, indices: [i] });
+    }
+    return acc;
+  }, []);
+}

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -10,7 +10,6 @@
  * @module agent/tools/dispatcher
  */
 
-import { createHash } from 'node:crypto';
 import { debugLog } from '../../utils/debug.js';
 import { HookBlockedError } from '../../utils/errors.js';
 import { settleWithConcurrencyLimit } from '../concurrency-pool.js';
@@ -29,35 +28,12 @@ import { classifyBashCommand } from './readonly-bash.js';
 import { PathGrantManager, type GrantSnapshot } from './grant-manager.js';
 import { emitHookDecision } from '../trace/emit.js';
 import type { TraceWriter } from '../trace/index.js';
-import { builtinToolSchemas, agentTool, skillTool, composeTool } from './schemas.js';
-import { memoryToolSchemas } from '../memory/memory-tools.js';
-import { getRuntimeStateTool } from '../awareness/index.js';
+import { defaultConcurrencyClassifier, partitionIntoBatches } from './dispatch-batching.js';
+import { repeatCallFingerprint } from './repeat-circuit-breaker.js';
 
-/**
- * Derived at module load from the union of all built-in tool schemas.
- * A tool is concurrency-safe when its schema declares `concurrencySafe: true`.
- * This replaces the former hand-maintained list and stays automatically in sync
- * with schema changes.
- *
- * External constraint: schemas.ts and memory-tools.ts are the single source
- * of truth. Mutations to those files propagate here without any secondary edit.
- */
-const SAFE_TOOLS: ReadonlySet<string> = new Set(
-  [
-    ...builtinToolSchemas,
-    agentTool,
-    skillTool,
-    composeTool,
-    ...memoryToolSchemas,
-    getRuntimeStateTool,
-  ]
-    .filter((s) => s.concurrencySafe === true)
-    .map((s) => s.name),
-);
-
-export function defaultConcurrencyClassifier(toolName: string): boolean {
-  return SAFE_TOOLS.has(toolName);
-}
+// Re-exported for backward compatibility: external importers (dispatcher.test.ts,
+// schema-classification.test.ts) historically import this from './dispatcher.js'.
+export { defaultConcurrencyClassifier } from './dispatch-batching.js';
 
 /**
  * Repeat-loop circuit breaker threshold.
@@ -82,43 +58,6 @@ export const REPEAT_CIRCUIT_BREAKER_THRESHOLD = 8;
  * current tool. Add a name here only if a real false-trip surfaces.
  */
 const REPEAT_BREAKER_EXEMPT_TOOLS: ReadonlySet<string> = new Set<string>();
-
-/**
- * Stable fingerprint of a tool call for repeat detection: sha256 over
- * `name \0 JSON(input)`. Hashing bounds retained state to 64 hex chars
- * regardless of input size. Identical tool_use blocks from the model
- * serialize identically, so byte-identical calls collide as intended.
- */
-function repeatCallFingerprint(call: ToolCall): string {
-  let input: string;
-  try {
-    input = JSON.stringify(call.input) ?? 'null';
-  } catch {
-    input = String(call.input);
-  }
-  return createHash('sha256').update(call.name).update('\u0000').update(input).digest('hex');
-}
-
-interface Batch {
-  isConcurrencySafe: boolean;
-  indices: number[];
-}
-
-function partitionIntoBatches(
-  calls: ToolCall[],
-  classifier: ConcurrencyClassifier,
-): Batch[] {
-  return calls.reduce<Batch[]>((acc, call, i) => {
-    const safe = classifier(call.name, call.input);
-    const last = acc[acc.length - 1];
-    if (last && safe && last.isConcurrencySafe) {
-      last.indices.push(i);
-    } else {
-      acc.push({ isConcurrencySafe: safe, indices: [i] });
-    }
-    return acc;
-  }, []);
-}
 
 /**
  * Default ceiling on concurrency-safe tool calls run simultaneously within one

--- a/src/agent/tools/repeat-circuit-breaker.ts
+++ b/src/agent/tools/repeat-circuit-breaker.ts
@@ -1,0 +1,28 @@
+/**
+ * Repeat-loop circuit breaker fingerprinting.
+ *
+ * Pure helper extracted from `dispatcher.ts` (#361). The stateful breaker
+ * (per-dispatcher consecutive-call counter + threshold check) stays on
+ * `SessionToolDispatcher`; only the standalone fingerprint function lives here.
+ *
+ * @module agent/tools/repeat-circuit-breaker
+ */
+
+import { createHash } from 'node:crypto';
+import type { ToolCall } from '../providers/anthropic-direct/types.js';
+
+/**
+ * Stable fingerprint of a tool call for repeat detection: sha256 over
+ * `name \0 JSON(input)`. Hashing bounds retained state to 64 hex chars
+ * regardless of input size. Identical tool_use blocks from the model
+ * serialize identically, so byte-identical calls collide as intended.
+ */
+export function repeatCallFingerprint(call: ToolCall): string {
+  let input: string;
+  try {
+    input = JSON.stringify(call.input) ?? 'null';
+  } catch {
+    input = String(call.input);
+  }
+  return createHash('sha256').update(call.name).update('\u0000').update(input).digest('hex');
+}


### PR DESCRIPTION
Closes #361 (scope-corrected — see note).

## Scope correction
Issue #361 proposed extracting **three** concerns from `dispatcher.ts`: grant-manager, batching, circuit-breaker. **The grant-manager extraction already landed in PR #489** (`PathGrantManager` in `grant-manager.ts`; `dispatcher.ts` composes it and delegates). So this PR does only the two remaining self-contained extractions.

## Move manifest
| New file | Lines | Symbols moved (verbatim) |
|---|---|---|
| `src/agent/tools/dispatch-batching.ts` | 63 | `SAFE_TOOLS` (module-private), `defaultConcurrencyClassifier`, `Batch`, `partitionIntoBatches` |
| `src/agent/tools/repeat-circuit-breaker.ts` | 28 | `repeatCallFingerprint` |

`dispatcher.ts`: 1031 → 969 lines. Bodies moved byte-verbatim; only mechanical edits: added `export` to `Batch`/`partitionIntoBatches` (now cross a module boundary), added imports, short file headers.

## What deliberately stayed in `dispatcher.ts`
- `REPEAT_CIRCUIT_BREAKER_THRESHOLD` and `REPEAT_BREAKER_EXEMPT_TOOLS` — policy constants consumed by the **stateful** breaker method, and `THRESHOLD` has non-test external consumers (`src/improve/eval-run/contracts.ts`, `replay.ts`) plus a hardcoded evidence-ref string `dispatcher.ts#REPEAT_CIRCUIT_BREAKER_THRESHOLD`. Keeping it defined here preserves that ref's accuracy and avoids a re-export.
- `checkRepeatCircuitBreaker` method + `repeatBreaker` instance field — dispatch-pipeline state, not pure logic.
- `DEFAULT_MAX_CONCURRENT_SAFE_TOOL_CALLS` — bound to `executeBatch` + the options interface default.

## Symbol inventory (export surface)
**Unchanged.** `defaultConcurrencyClassifier` is re-exported from `dispatcher.ts` for its two historical external importers (`dispatcher.test.ts`, `schema-classification.test.ts`). `partitionIntoBatches`, `Batch`, `repeatCallFingerprint` were never externally exported (module-private before), so no re-export needed. `SAFE_TOOLS` stays module-private in its new home.

## Move-fidelity check (self-audited)
- Each moved symbol defined **exactly once** in its new module — no facade/tier duplication.
- `SAFE_TOOLS` is a single module-load-time `Set` in `dispatch-batching.ts` (was single in `dispatcher.ts`) — **no dual-instance risk**, no mutable module state moved.
- All internal call sites rewired: classifier default (dispatcher L230), fingerprint (L480), partition (L728); breaker method + field intact (L478/L210), both call sites (L612/L713).

## Suspected findings (report-only)
None. The moved code is 3 pure helpers; no latent issues observed. (No bug-hunt beyond the moved surface was in scope.)

## Verification
- `pnpm test` (full suite): **604 files / 11168 passed / 14 skipped** — **identical to baseline** captured on the clean worktree before edits. Zero tests lost/added/skipped.
- `pnpm lint` (`tsc --noEmit`): clean.
- Test blocks left co-located in `dispatcher.test.ts`: the circuit-breaker tests exercise `dispatcher.execute()` (entangled with the instance) and the `defaultConcurrencyClassifier` describe is trivially small — moving them adds churn without reducing risk. Coverage is preserved via the re-export.
