### PR TITLE
fix(plan-mode): mirror exit_plan_mode's deferred flip onto stats.permissionMode (#495)

### DIFF
--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -947,13 +947,21 @@ export class AgentSession implements IAgentSession {
    * Return and CLEAR the pending plan-exit implement-turn queued by an approved
    * `exit_plan_mode` call, or `undefined` if none is pending. The REPL drains
    * this at the top of each input-loop iteration (post-turn) and, when set,
-   * atomically applies the deferred permission-mode flip then returns the seed
-   * message to be auto-submitted as a fresh user turn. Single-shot: a second call
-   * returns `undefined` until the next approval.
+   * atomically applies the deferred permission-mode flip then returns BOTH the
+   * seed message and the flipped-to mode. Single-shot: a second call returns
+   * `undefined` until the next approval.
    *
    * The mode flip is applied HERE (not in the handler) so the gate stays locked
    * in plan mode for the entire model turn and only opens at this clean
    * post-turn boundary — closing the mid-turn TOCTOU window.
+   *
+   * Invariant (#495): the flip updates the session's OWN mode (metadata +
+   * provider), but the plan-mode gate and the REPL prompt read a SEPARATE mirror
+   * — `stats.permissionMode` — which the session cannot reach. So the applied
+   * `mode` is returned alongside the message; the REPL drain
+   * (`loop-iteration.ts`) mirrors it onto `stats.permissionMode`, exactly as
+   * `togglePlanMode` does for `/plan off`. Returning it (rather than exposing a
+   * getter the caller re-reads) guarantees the mirror equals the applied value.
    *
    * If the deferred flip rejects (e.g. the provider's query handle is closing —
    * the same failure mode `togglePlanMode` guards for `/plan off`), the seed is
@@ -963,7 +971,7 @@ export class AgentSession implements IAgentSession {
    * (which has no try/catch around this drain) and crash it. The model stays in
    * plan mode and can retry `exit_plan_mode`.
    */
-  async takePendingPlanExitSeed(): Promise<string | undefined> {
+  async takePendingPlanExitSeed(): Promise<{ message: string; mode: PermissionMode } | undefined> {
     const seed = this._pendingPlanExitSeed;
     this._pendingPlanExitSeed = undefined;
     if (seed === undefined) return undefined;
@@ -975,7 +983,7 @@ export class AgentSession implements IAgentSession {
       );
       return undefined;
     }
-    return seed.message;
+    return { message: seed.message, mode: seed.mode };
   }
 
   /**

--- a/src/agent/tools/handlers/exit-plan-mode.test.ts
+++ b/src/agent/tools/handlers/exit-plan-mode.test.ts
@@ -216,8 +216,10 @@ describe('AgentSession plan-exit seed bridge', () => {
     // Pass the approved mode alongside the seed message (new signature).
     controls!.requestImplementSeed('SEED-MSG', 'default');
 
-    // takePendingPlanExitSeed is now async — it applies the mode flip then returns the message.
-    expect(await session.takePendingPlanExitSeed()).toBe('SEED-MSG');
+    // takePendingPlanExitSeed applies the mode flip then returns BOTH the seed
+    // message AND the flipped-to mode (#495) — the caller mirrors `mode` onto
+    // stats.permissionMode so the gate + prompt unlock.
+    expect(await session.takePendingPlanExitSeed()).toEqual({ message: 'SEED-MSG', mode: 'default' });
     // Single-shot: drained value is cleared.
     expect(await session.takePendingPlanExitSeed()).toBeUndefined();
 

--- a/src/agent/types/session-types.ts
+++ b/src/agent/types/session-types.ts
@@ -235,12 +235,14 @@ export interface IAgentSession {
   /**
    * Return and CLEAR any implement-turn queued by an approved `exit_plan_mode`
    * tool call. Atomically applies the deferred permission-mode flip (closing the
-   * mid-turn TOCTOU window) then returns the seed message. The REPL drains this
-   * post-turn and auto-submits the message as a fresh user turn (reproducing
+   * mid-turn TOCTOU window) then returns BOTH the seed message AND the mode it
+   * flipped to. The REPL drains this post-turn: it mirrors `mode` onto
+   * `stats.permissionMode` (the value the plan-mode gate and prompt read — see
+   * #495) and auto-submits `message` as a fresh user turn (reproducing
    * `/plan off`'s save-and-implement handoff). Returns `undefined` when nothing
-   * is pending.
+   * is pending (or when the deferred flip rejected and the seed was dropped).
    */
-  takePendingPlanExitSeed(): Promise<string | undefined>;
+  takePendingPlanExitSeed(): Promise<{ message: string; mode: PermissionMode } | undefined>;
 
   waitForInitialization(): Promise<SessionMetadata>;
 

--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -215,6 +215,41 @@ describe('runReplLoop — seed-buffer auto-submit fast-path (multi-iteration)', 
   });
 });
 
+describe('runReplLoop — exit_plan_mode drain mirrors the applied mode onto stats (#495)', () => {
+  it('after draining an approved plan-exit seed, stats.permissionMode reflects the flipped mode', async () => {
+    // Regression for #495. takePendingPlanExitSeed applies the deferred flip to
+    // the SESSION's mode internally, but the plan-mode gate and the REPL prompt
+    // read ctx.stats.permissionMode (bootstrap wires the gate to
+    // `() => stats.permissionMode`). The drain MUST mirror the returned mode onto
+    // stats — otherwise the gate stays plan-locked and the operator's prompt
+    // never flips, even though exit_plan_mode reported success.
+    const ctx = makeCtx();
+    ctx.stats.permissionMode = 'plan';
+    // Single-shot seed: first drain yields the approved seed + mode, then undefined.
+    let drained = false;
+    (
+      ctx.session.current as unknown as {
+        takePendingPlanExitSeed: () => Promise<{ message: string; mode: string } | undefined>;
+      }
+    ).takePendingPlanExitSeed = vi.fn(async () => {
+      if (drained) return undefined;
+      drained = true;
+      return { message: 'IMPLEMENT-SEED', mode: 'bypassPermissions' };
+    });
+    // Iteration 1 drains the seed + auto-submits (no readLine); iteration 2 reads '/exit'.
+    surfaceState.readLineQueue = [{ text: '/exit', attachments: [] }];
+
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    // The applied mode is mirrored onto stats — the gate + prompt now see bypass.
+    expect(ctx.stats.permissionMode).toBe('bypassPermissions');
+    // The seed's message was auto-submitted as the implement turn.
+    expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
+    const firstArg = vi.mocked(runTurn).mock.calls[0]?.[0] as { text: string };
+    expect(firstArg.text).toBe('IMPLEMENT-SEED');
+  });
+});
+
 describe('runReplLoop — shell-passthrough dispatch branch', () => {
   it('routes a `!cmd` line to ShellPassthrough.dispatch and does not run a model turn', async () => {
     // Iteration 1: readLine → '!echo hi' → shell dispatch handles it, continue.

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -206,9 +206,16 @@ export async function runInputLoop(
       // seeded save-and-implement handoff. A `/plan off` seed (set directly,
       // same turn) takes precedence if both are somehow present.
       if (seedBuffer === undefined) {
-        const planExitSeed = await ctx.session.current.takePendingPlanExitSeed();
-        if (planExitSeed !== undefined) {
-          seedBuffer = { text: planExitSeed, attachments: [] };
+        const planExit = await ctx.session.current.takePendingPlanExitSeed();
+        if (planExit !== undefined) {
+          // #495: takePendingPlanExitSeed already applied the deferred flip to
+          // the SESSION's mode, but the plan-mode gate and this loop's prompt
+          // read `stats.permissionMode` (bootstrap wires the gate to
+          // `() => stats.permissionMode`). Mirror the applied mode here — exactly
+          // as `togglePlanMode` does for `/plan off` — or the gate stays
+          // plan-locked and the operator's prompt indicator never flips.
+          ctx.stats.permissionMode = planExit.mode;
+          seedBuffer = { text: planExit.message, attachments: [] };
         }
       }
 


### PR DESCRIPTION
Fixes #495.

## Problem
`exit_plan_mode` returns `mode=bypassPermissions` (looks like success), but the PreToolUse plan-mode gate keeps refusing `write_file` / mutating `bash`, and the operator's REPL prompt stays stuck showing "plan". Only a manual `/plan off` clears it. Observed live.

## Root cause
Plan-mode state lives in **two** places:
- the **session's** own mode — `AgentSession` metadata + provider (`setPermissionMode`)
- **`stats.permissionMode`** — the mirror that BOTH enforcement points read: the gate (wired at `bootstrap.ts:628` as `() => stats.permissionMode`, read fresh at call time in `plan-mode-gate.ts:48`) and the REPL prompt (`loop-iteration.ts:227`).

`/plan off` updates **both** (`plan-mode-toggle.ts:62-63`). But `exit_plan_mode`'s deferred flip — applied post-turn in `takePendingPlanExitSeed()` — updated only the **session** side. The REPL drain promoted the implement-seed but never mirrored the mode onto `stats.permissionMode`, so the gate stayed plan-locked and the prompt never flipped. One missing write; both symptoms. (Not a race — the gate reads the mode fresh; it just read the stale mirror.)

## Fix
`takePendingPlanExitSeed()` now returns `{ message, mode }` — it already applied `seed.mode`, so it returns the exact applied value with no divergence possible — and the REPL drain mirrors it: `ctx.stats.permissionMode = planExit.mode`, exactly as `togglePlanMode` does for `/plan off`. Chosen over adding a `getPermissionMode()` getter so the mirror is guaranteed equal to the applied value.

## Verification
- `pnpm lint` (tsc --noEmit, strict): clean
- `pnpm test`: **11184 passed, 0 failed**
- New regression test in `loop-iteration.test.ts` ("…mirrors the applied mode onto stats (#495)"): passes with the fix, **fails without it** (`expected 'plan' to be 'bypassPermissions'`), verified by reverting the one drain line. Closes a real coverage gap — no prior test exercised the `exit_plan_mode → drain → stats` path.

## Scope / follow-up
Scoped to the observed REPL surface. A parallel sibling-bug sweep is still in flight (does the Telegram surface keep a separate permission-mode mirror with the same decoupling? any other deferred flips that skip the `stats` mirror?); any finding will be filed as a separate issue/PR.
