### PR TITLE
fix(cli): keep the update-notifier fresh instead of ≤24h stale

### DIFF
--- a/src/cli/commands/update.test.ts
+++ b/src/cli/commands/update.test.ts
@@ -22,6 +22,7 @@ vi.mock('../version.js', () => ({
 vi.mock('../update-checker.js', () => ({
   fetchLatestVersion: vi.fn(),
   writePendingUpdateMarker: vi.fn(),
+  writeUpdateCache: vi.fn(),
 }));
 
 vi.mock('child_process', () => ({
@@ -39,12 +40,13 @@ vi.mock('../palette.js', () => ({
 }));
 
 import { spawn } from 'child_process';
-import { fetchLatestVersion, writePendingUpdateMarker } from '../update-checker.js';
+import { fetchLatestVersion, writePendingUpdateMarker, writeUpdateCache } from '../update-checker.js';
 import { registerUpdateCommand } from './update.js';
 import { EventEmitter } from 'events';
 
 const mockFetchLatestVersion = vi.mocked(fetchLatestVersion);
 const mockWritePendingUpdateMarker = vi.mocked(writePendingUpdateMarker);
+const mockWriteUpdateCache = vi.mocked(writeUpdateCache);
 const mockSpawn = vi.mocked(spawn);
 
 // ---------------------------------------------------------------------------
@@ -111,6 +113,8 @@ describe('afk update', () => {
       expect(output).toContain('Update available');
       expect(output).toContain('1.10.1');
       expect(output).toContain('1.12.0');
+      // B: --check refreshes the notifier cache with what it learned.
+      expect(mockWriteUpdateCache).toHaveBeenCalledWith('1.12.0');
       expect(process.exitCode).toBeUndefined();
     });
 
@@ -179,6 +183,9 @@ describe('afk update', () => {
         expect.objectContaining({ stdio: 'inherit' }),
       );
       expect(mockWritePendingUpdateMarker).toHaveBeenCalledWith('1.11.0');
+      // B: an explicit --pin must NOT touch the notifier cache — it may target
+      // an older-than-latest version and would otherwise poison the banner.
+      expect(mockWriteUpdateCache).not.toHaveBeenCalled();
       const output = consoleSpy.mock.calls.flat().join('\n');
       expect(output).toContain('installed');
       expect(process.exitCode).toBeUndefined();
@@ -229,6 +236,8 @@ describe('afk update', () => {
         expect.objectContaining({ stdio: 'inherit' }),
       );
       expect(mockWritePendingUpdateMarker).toHaveBeenCalledWith('1.12.0');
+      // B: the fetched-latest install path refreshes the notifier cache.
+      expect(mockWriteUpdateCache).toHaveBeenCalledWith('1.12.0');
     });
 
     it('prints up-to-date and skips install when already on latest', async () => {
@@ -239,6 +248,9 @@ describe('afk update', () => {
       expect(mockSpawn).not.toHaveBeenCalled();
       const output = consoleSpy.mock.calls.flat().join('\n');
       expect(output).toContain('up to date');
+      // B: even when already current, we refresh the cache with the fetched
+      // latest so the banner stops offering an install we don't need.
+      expect(mockWriteUpdateCache).toHaveBeenCalledWith('1.10.1');
     });
 
     it('sets exitCode=1 when registry is unreachable', async () => {

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -5,6 +5,7 @@ import { getVersion } from '../version.js';
 import {
   fetchLatestVersion,
   writePendingUpdateMarker,
+  writeUpdateCache,
 } from '../update-checker.js';
 
 const SEMVER_RE = /^\d+\.\d+\.\d+(-[\da-z.]+)?$/i;
@@ -54,6 +55,10 @@ export function registerUpdateCommand(program: Command): void {
           process.exitCode = 1;
           return;
         }
+        // Keep the passive notifier's cache in sync with what we just learned
+        // from the registry, so the startup banner doesn't render from a stale
+        // latestVersion after the user has explicitly checked.
+        writeUpdateCache(latest);
         if (isNewer(current, latest)) {
           console.log(`${palette.bold('Update available:')} ${palette.dim(current)} → ${palette.bold(latest)}`);
           console.log(palette.dim('  Run `afk update` to install.'));
@@ -80,6 +85,10 @@ export function registerUpdateCommand(program: Command): void {
           process.exitCode = 1;
           return;
         }
+        // Refresh the notifier cache with the registry's current latest so the
+        // banner is honest right after this update (only on the fetched path —
+        // an explicit --pin may target an older version and must not poison it).
+        writeUpdateCache(target);
         if (target === current) {
           console.log(`agent-afk ${palette.bold(current)} is up to date.`);
           return;

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -85,6 +85,8 @@ const mockPrintUpdateBanner = vi.fn();
 const mockCheckPendingUpdate = vi.fn();
 vi.mock('./update-checker.js', () => ({
   checkForUpdates: mockCheckForUpdates,
+  coldStartUpdateCheck: vi.fn().mockResolvedValue(null),
+  hasUpdateCache: vi.fn().mockReturnValue(true),
   printUpdateBanner: mockPrintUpdateBanner,
   triggerAutoUpdate: vi.fn(),
   checkPendingUpdate: mockCheckPendingUpdate,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -78,7 +78,14 @@ import { providerForModel } from '../agent/providers/index.js';
 import { getModel } from './shared-helpers.js';
 import { runAuthWizard } from './auth-wizard.js';
 import { getVersion } from './version.js';
-import { checkForUpdates, printUpdateBanner, triggerAutoUpdate, checkPendingUpdate } from './update-checker.js';
+import {
+  checkForUpdates,
+  coldStartUpdateCheck,
+  hasUpdateCache,
+  printUpdateBanner,
+  triggerAutoUpdate,
+  checkPendingUpdate,
+} from './update-checker.js';
 
 // Re-export shared helpers for tests
 export {
@@ -220,7 +227,15 @@ if (isDirectRun) {
     const config = loadConfig();
     const noCheckArg = process.argv.slice(2).some((a) => a === '--no-update-check');
     const policy = noCheckArg ? ('off' as const) : config.updatePolicy;
-    const updateInfo = checkForUpdates(policy);
+    // Warm cache: the fully synchronous fast path (may spawn a background
+    // refresh if the cache is stale). Cold cache: checkForUpdates() could only
+    // fire a detached fetch and return null, so the banner would never appear
+    // on the very first run — await one short bounded inline fetch instead so
+    // that first run can surface it. Guards (off/CI/NO_UPDATE_NOTIFIER) are
+    // applied inside both functions.
+    const updateInfo = hasUpdateCache()
+      ? checkForUpdates(policy)
+      : await coldStartUpdateCheck(policy);
 
     // Intercept the pending-update message that checkPendingUpdate() would
     // write to stderr, so we can re-emit it AFTER the interactive mode screen

--- a/src/cli/update-checker.test.ts
+++ b/src/cli/update-checker.test.ts
@@ -83,10 +83,13 @@ import { spawn } from 'child_process';
 import { getVersion } from './version.js';
 import {
   checkForUpdates,
+  coldStartUpdateCheck,
+  hasUpdateCache,
   printUpdateBanner,
   triggerAutoUpdate,
   checkPendingUpdate,
   writePendingUpdateMarker,
+  writeUpdateCache,
   fetchLatestVersion,
 } from './update-checker.js';
 
@@ -97,6 +100,7 @@ const mockUnlinkSync = vi.mocked(unlinkSync);
 const mockSpawn = vi.mocked(spawn);
 const mockGetVersion = vi.mocked(getVersion);
 const pendingFile = join(FAKE_CACHE_DIR, 'pending-update.json');
+const cacheFile = join(FAKE_CACHE_DIR, 'update-check.json');
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
 describe('update-checker', () => {
@@ -180,6 +184,32 @@ describe('update-checker', () => {
 
     it('does not spawn background check when cache is fresh', () => {
       const freshCache = JSON.stringify({ latestVersion: '1.11.0', checkedAt: Date.now() });
+      mockReadFileSync.mockReturnValue(freshCache);
+
+      checkForUpdates('notify');
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    // --- cache TTL (A) --------------------------------------------------------
+    // The TTL was shortened from 24h → 3h so the passive banner tracks a
+    // several-releases-per-day cadence instead of going blind for up to a day.
+
+    it('spawns background check when cache is older than the 3h TTL', () => {
+      const staleCache = JSON.stringify({
+        latestVersion: '1.11.0',
+        checkedAt: Date.now() - 4 * 60 * 60 * 1000, // 4h: past 3h TTL, within old 24h
+      });
+      mockReadFileSync.mockReturnValue(staleCache);
+
+      checkForUpdates('notify');
+      expect(mockSpawn).toHaveBeenCalled();
+    });
+
+    it('does not spawn background check for a cache younger than the 3h TTL', () => {
+      const freshCache = JSON.stringify({
+        latestVersion: '1.11.0',
+        checkedAt: Date.now() - 2 * 60 * 60 * 1000, // 2h: within the 3h TTL
+      });
       mockReadFileSync.mockReturnValue(freshCache);
 
       checkForUpdates('notify');
@@ -451,6 +481,109 @@ describe('update-checker', () => {
       buildFakeHttp(200, JSON.stringify({ version: 'not-a-semver' }));
       const result = await fetchLatestVersion();
       expect(result).toBeUndefined();
+    });
+  });
+
+  // --- writeUpdateCache (B) ---------------------------------------------------
+
+  describe('writeUpdateCache', () => {
+    it('writes the update-check cache for a valid semver', () => {
+      writeUpdateCache('1.12.0');
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        cacheFile,
+        expect.stringContaining('"latestVersion":"1.12.0"'),
+      );
+    });
+
+    it('rejects a non-semver version without writing', () => {
+      writeUpdateCache('1.0.0; rm -rf /');
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it('silently swallows writeFileSync errors (best-effort)', () => {
+      mockWriteFileSync.mockImplementation(() => {
+        throw new Error('EACCES: permission denied');
+      });
+      expect(() => writeUpdateCache('1.12.0')).not.toThrow();
+      // Reset the throwing impl so it does not leak into later tests
+      // (the suite uses clearAllMocks, which keeps implementations).
+      mockWriteFileSync.mockReset();
+    });
+  });
+
+  // --- hasUpdateCache (C) -----------------------------------------------------
+
+  describe('hasUpdateCache', () => {
+    it('returns true when a parseable cache exists', () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ latestVersion: '1.11.0', checkedAt: Date.now() }),
+      );
+      expect(hasUpdateCache()).toBe(true);
+    });
+
+    it('returns false when the cache is missing', () => {
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('ENOENT');
+      });
+      expect(hasUpdateCache()).toBe(false);
+    });
+  });
+
+  // --- coldStartUpdateCheck (C) -----------------------------------------------
+  // First-launch path: awaits ONE bounded inline registry fetch so the banner
+  // can appear on the very first run instead of only on a second invocation.
+
+  describe('coldStartUpdateCheck', () => {
+    beforeEach(() => {
+      mockHttpsGet.mockReset();
+    });
+
+    it('returns UpdateInfo and persists the cache when a newer version exists', async () => {
+      buildFakeHttp(200, JSON.stringify({ version: '1.12.0' }));
+      const result = await coldStartUpdateCheck('notify');
+      expect(result).toEqual({ currentVersion: '1.10.1', latestVersion: '1.12.0' });
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        cacheFile,
+        expect.stringContaining('"latestVersion":"1.12.0"'),
+      );
+    });
+
+    it('returns null but still persists the cache when already up to date', async () => {
+      buildFakeHttp(200, JSON.stringify({ version: '1.10.1' }));
+      const result = await coldStartUpdateCheck('notify');
+      expect(result).toBeNull();
+      expect(mockWriteFileSync).toHaveBeenCalledWith(
+        cacheFile,
+        expect.stringContaining('"latestVersion":"1.10.1"'),
+      );
+    });
+
+    it('returns null and falls back to a background refresh when the fetch fails', async () => {
+      buildFakeHttp(500, null);
+      const result = await coldStartUpdateCheck('notify');
+      expect(result).toBeNull();
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      expect(mockSpawn).toHaveBeenCalled();
+    });
+
+    it('returns null without fetching when policy is off', async () => {
+      const result = await coldStartUpdateCheck('off');
+      expect(result).toBeNull();
+      expect(mockHttpsGet).not.toHaveBeenCalled();
+    });
+
+    it('returns null without fetching when CI is set', async () => {
+      process.env['CI'] = 'true';
+      const result = await coldStartUpdateCheck('notify');
+      expect(result).toBeNull();
+      expect(mockHttpsGet).not.toHaveBeenCalled();
+    });
+
+    it('returns null without fetching when NO_UPDATE_NOTIFIER is set', async () => {
+      process.env['NO_UPDATE_NOTIFIER'] = '1';
+      const result = await coldStartUpdateCheck('notify');
+      expect(result).toBeNull();
+      expect(mockHttpsGet).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/cli/update-checker.ts
+++ b/src/cli/update-checker.ts
@@ -24,7 +24,20 @@ interface PendingUpdate {
   triggeredAt: number;
 }
 
-const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
+/**
+ * How long the cached "latest published version" is trusted before the next
+ * launch spawns a background refresh. Kept deliberately short: agent-afk can
+ * ship several releases in a single day, and a day-long TTL left the passive
+ * banner blind to a fresh publish for up to 24h. 3h tracks that cadence while
+ * still bounding background npm-registry hits to at most one per window.
+ */
+const CACHE_TTL_MS = 3 * 60 * 60 * 1000;
+/**
+ * Bounded timeout for the ONE inline registry fetch `coldStartUpdateCheck()`
+ * performs when no cache exists yet. Short enough not to noticeably delay a
+ * cold first launch; on timeout it falls back to the detached background path.
+ */
+const COLD_START_TIMEOUT_MS = 800;
 /**
  * How long a pending-update marker is trusted to mean "an install is still in
  * flight." Within this window `triggerAutoUpdate()` refuses to spawn a second
@@ -130,7 +143,7 @@ export function checkForUpdates(updatePolicy: 'notify' | 'auto' | 'off'): Update
   const cache = readCache();
   const now = Date.now();
 
-  if (!cache || now - cache.checkedAt > TWENTY_FOUR_HOURS) {
+  if (!cache || now - cache.checkedAt > CACHE_TTL_MS) {
     spawnBackgroundCheck();
   }
 
@@ -141,6 +154,43 @@ export function checkForUpdates(updatePolicy: 'notify' | 'auto' | 'off'): Update
     return { currentVersion, latestVersion: cache.latestVersion };
   }
 
+  return null;
+}
+
+/** True when a parseable update-check cache exists on disk. */
+export function hasUpdateCache(): boolean {
+  return readCache() !== null;
+}
+
+/**
+ * Cold-cache path for the very first launch after install (or a cache clear),
+ * where `checkForUpdates()` can only spawn a detached background fetch and
+ * return null — so a banner would never appear until a *second* run. Here we
+ * instead await one short bounded registry fetch, persist the result to the
+ * cache, and render the banner on this run. Applies the same off/CI/
+ * NO_UPDATE_NOTIFIER guards as `checkForUpdates()`.
+ */
+export async function coldStartUpdateCheck(
+  updatePolicy: 'notify' | 'auto' | 'off',
+): Promise<UpdateInfo | null> {
+  if (updatePolicy === 'off') return null;
+  if (env.NO_UPDATE_NOTIFIER) return null;
+  if (env.CI) return null;
+
+  const latest = await fetchLatestVersion(COLD_START_TIMEOUT_MS);
+  if (latest === undefined) {
+    // Inline fetch failed or timed out — fall back to the detached background
+    // refresh so the NEXT launch at least has a warm cache to render from.
+    spawnBackgroundCheck();
+    return null;
+  }
+
+  writeUpdateCache(latest);
+
+  const currentVersion = getVersion();
+  if (isNewerVersion(currentVersion, latest)) {
+    return { currentVersion, latestVersion: latest };
+  }
   return null;
 }
 
@@ -177,6 +227,31 @@ export function writePendingUpdateMarker(targetVersion: string): void {
     );
   } catch {
     // best-effort — confirmation is a nicety
+  }
+}
+
+/**
+ * Overwrite the update-check cache with a version learned directly from the
+ * registry — used by `afk update` / `afk update --check`, which fetch the
+ * latest version out-of-band (bypassing the cache). Without this, a manual
+ * update leaves the passive notifier's cache frozen at its previous value
+ * until the next TTL-driven background refresh, so the banner logic keeps
+ * comparing against a stale `latestVersion`. Keeping the cache in sync here
+ * makes the notifier honest immediately after a manual update.
+ */
+export function writeUpdateCache(latestVersion: string): void {
+  if (!SEMVER_RE.test(latestVersion)) return;
+  try {
+    ensureCacheDir();
+    writeFileSync(
+      cachePath(),
+      JSON.stringify({
+        latestVersion,
+        checkedAt: Date.now(),
+      }),
+    );
+  } catch {
+    // best-effort — a stale cache only affects notifier freshness
   }
 }
 


### PR DESCRIPTION
## Problem

The startup **"update available"** banner under-reports: it frequently stays silent when a newer version *is* published.

## Root cause

The banner is rendered purely from a cached `latestVersion` (`src/cli/update-checker.ts`), with three compounding staleness mechanisms:

1. **≤24h blind spot** — `checkForUpdates()` only spawns a background registry refresh when the cache is missing or **>24h old**. Any release published inside that window is invisible until it elapses.
2. **Always one run behind** — the refresh runs in a *detached* child that writes the cache **after** the current process already read it and returned, so a freshly-fetched version is never seen by the run that fetched it (and a cold cache returns `null` outright).
3. **`afk update` left the cache stale** — the update command fetches latest out-of-band and writes only the pending marker, never the notifier cache.

With this repo shipping several releases a day (e.g. `5.28.0 → 5.29.1` = 6 releases in ~15h), a 24h TTL simply can't track the cadence.

## Fixes

- **A — TTL 24h → 3h** (`update-checker.ts`): the passive banner now tracks a several-releases-per-day cadence while still bounding background registry hits to at most one per window.
- **B — refresh cache on `afk update` / `--check`** (new `writeUpdateCache()`, called from `commands/update.ts`): a manual update keeps the notifier honest immediately. Guarded so an explicit `--pin` (which may target an older version) can't poison the cache.
- **C — cold-start inline fetch** (new `coldStartUpdateCheck()` + `hasUpdateCache()`, wired in `cli/index.ts`): on the first run with no cache, `await` one bounded **800ms** registry fetch so the banner appears on that first run instead of only on a second invocation. Warm cache keeps the fully-synchronous fast path; the same `off`/`CI`/`NO_UPDATE_NOTIFIER` guards apply; on fetch failure it falls back to the detached background refresh.

## Verification

- `pnpm lint` (strict `tsc --noEmit`): clean
- Full suite: **11,214 passed**, 0 failed (14 pre-existing skips)
- **+13 new unit tests**: TTL boundary (×2), `writeUpdateCache` (×3), `hasUpdateCache` (×2), `coldStartUpdateCheck` (×6, incl. off/CI/NO_UPDATE_NOTIFIER guards); plus `writeUpdateCache` assertions folded into the `afk update` tests
- CI gates: `audit:env:check` 0 violations, `scan:env:check` in sync