### PR TITLE
fix(tui): route commitAbove on the real measured frame top, not the shrink-padded one

### DIFF
--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -37,6 +37,9 @@ export interface CommittedBandHost {
   committedBand: string[];
   committedBandTopRow: number;
   committedBandBottomRow: number;
+  /** Real unpadded frame top from the last repaint's measure() — see the field
+   *  doc on the class. Routing (prevTopRow) trusts this over logUpdate.topRow. */
+  lastMeasuredFrameTop: number;
   /** How many of committedBand's rows (its bottom suffix) are painted on screen. */
   committedBandPaintedRows: number;
   /** Memoization for reflowCommittedBandToWidth — see the field doc on the class. */
@@ -227,10 +230,26 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   // is exactly the "genuinely no known frame top" case BLOCKER-1 already
   // handles safely via band-hold.
   const rawLogUpdateTopRow = self.logUpdate.topRow ?? 0;
-  const prevTopRow =
+  // Prefer the real post-render frame top the last repaint captured via measure()
+  // (lastMeasuredFrameTop). logUpdate.topRow reports the transient shrink-PADDED
+  // top, which reads LOWER than reality after a frame shrink and makes
+  // decideCommitMode compute a wrong (too-small) fitsAboveFrame — routing a block
+  // that FITS into band-hold, which then overwrites repositioned prior content
+  // without archiving it ("two boxes + blank void" streaming-table bug;
+  // terminal-compositor.commit-geometry.test.ts + the History note at
+  // frame.ts:191-198). Take the MAX so prevTopRow can only be RAISED toward the
+  // true top, never lowered — the existing committedBandBottomRow+1 floor is
+  // preserved. Gated on !bandGeometryStale: after a SIGWINCH with no repaint
+  // since, lastMeasuredFrameTop (and the band floor) are PRE-resize values, so
+  // both are excluded and we fall through to rawLogUpdateTopRow — the BLOCKER-1
+  // band-hold safety path. When lastMeasuredFrameTop is 0 (no repaint yet) this
+  // reduces EXACTLY to the prior expression.
+  const measuredFrameTop = self.bandGeometryStale ? 0 : self.lastMeasuredFrameTop;
+  const bandFloor =
     self.committedBand.length > 0 && self.committedBandBottomRow > 0 && !self.bandGeometryStale
-      ? Math.max(rawLogUpdateTopRow, self.committedBandBottomRow + 1)
-      : rawLogUpdateTopRow;
+      ? self.committedBandBottomRow + 1
+      : 0;
+  const prevTopRow = Math.max(rawLogUpdateTopRow, measuredFrameTop, bandFloor);
   const frameTop = prevTopRow > 1 ? prevTopRow : Math.max(1, rows - 1 - extraRows);
   const anchorFloor = Math.max(self.anchorRow ?? 1, 1);
   // The block "fits" when every line can be CUP-painted at a row in

--- a/src/cli/terminal-compositor.frame.ts
+++ b/src/cli/terminal-compositor.frame.ts
@@ -72,6 +72,9 @@ export interface FrameHost {
   committedBand: string[];
   committedBandTopRow: number;
   committedBandBottomRow: number;
+  /** Real unpadded frame top; written here by repaint(), read by commitAbove's
+   *  routing. See the field doc on the class (terminal-compositor.ts). */
+  lastMeasuredFrameTop: number;
   committedBandPaintedRows: number;
   /** Memoization for reflowCommittedBandToWidth — see the field doc on the class. */
   bandReflowCache: BandReflowCache | null;
@@ -270,6 +273,9 @@ export function repaint(self: FrameHost): void {
   const desiredTopRow = self.logUpdate.measure
     ? self.logUpdate.measure(frame, targetBottomRow).topRow
     : Math.max(1, targetBottomRow - frameLines.length + 1);
+  // Record the real (unpadded) frame top for commitAbove's routing. This is the
+  // value Phase-2 will re-establish; logUpdate.topRow (shrink-padded) is not.
+  self.lastMeasuredFrameTop = desiredTopRow;
   preserveRowsBeforeFrameRender(self, desiredTopRow);
   // Capture the renderer's current top BEFORE render(): it is the first row
   // its erase pass will clear, which repositionCommittedBand() uses to detect

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -347,6 +347,18 @@ export class TerminalCompositor {
   committedBandTopRow = 0;
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   committedBandBottomRow = 0;
+  // The real (unpadded) frame top the LAST repaint() established, captured from
+  // CupFrameRenderer.measure(frame, absoluteBottom).topRow — the exact physical
+  // row Phase-2's repaint will reproduce. Unlike logUpdate.topRow (which reports
+  // the transient shrink-PADDED top and reads LOWER than reality right after a
+  // frame shrink), this is the geometry commitAbove's routing must use so
+  // decideCommitMode computes fitsAboveFrame correctly. Using the stale padded
+  // value routes a block that FITS into band-hold, which then overwrites
+  // repositioned prior content without archiving it — the "two boxes + blank
+  // void" streaming-table bug (see committed-band-commit.ts prevTopRow site +
+  // terminal-compositor.commit-geometry.test.ts). 0 until the first repaint.
+  /** @internal Relaxed from `private` for the frame + committed-band modules. */
+  lastMeasuredFrameTop = 0;
   // Invariant: committedBandPaintedRows counts how many of committedBand's rows
   // are MATERIALIZED on the terminal right now — always the BOTTOM
   // committedBandPaintedRows rows (nearest the frame), since every paint site


### PR DESCRIPTION
## Summary

Fixes the "two boxes + blank void" table rendering bug: a markdown table followed by streamed prose renders with border-less blank rows punched into the table, and the missing content is silently lost. Reproduces reliably in a live terminal (`afk i` at 120×30 rendering a wrapped table followed by paragraphs).

## Root cause

`commitAbove`'s `decideCommitMode` routing computes `prevTopRow` from `self.logUpdate.topRow`, which reports the transient shrink-**padded** frame top. Right after a frame shrink that value reads **lower** than the real top, so `fitsAboveFrame` is computed too small and a block that actually **fits** the above-frame region is routed into `band-hold`. Band-hold then overwrites prior repositioned content without archiving it to scrollback → permanent loss (the void). The downstream symptom is the cap-drop in `committed-band-commit.ts` (`capped = run.slice(run.length - maxRun)`), which drops rows on the false premise that they already reached scrollback.

This is documented by the existing `terminal-compositor.commit-geometry.test.ts` (which guards the band-exists shrink-pad scenario) and the History note at `terminal-compositor.frame.ts:191-198`.

## Fix

`repaint()` already computes the true unpadded frame top via `CupFrameRenderer.measure(frame, targetBottomRow).topRow` — the exact physical row Phase-2 re-establishes. This PR:

- stores it in a new field `lastMeasuredFrameTop` (written in `repaint()`),
- routes `commitAbove` on `Math.max(logUpdate.topRow, lastMeasuredFrameTop, bandFloor)` for `prevTopRow`.

`Math.max` means `prevTopRow` can only be **raised** toward the true top, never lowered; when `lastMeasuredFrameTop` is `0` (no repaint yet) or stale (post-SIGWINCH — gated on `!bandGeometryStale`) it reduces **exactly** to the prior expression, which is why it is regression-safe.

This is the targeted fix recommended by the compositor design doc's own Verification Addendum (over the larger declarative rewrite).

## Verification

- `tsc --noEmit` clean.
- Full compositor + commit-mode + cup-frame-renderer suite: **374/374 green** (no regression).
- Live `afk i` (haiku, 120×30) rendering a markdown table + streamed prose: **0 border-less blank rows** across two runs of differing table size — was 4–5 before the fix.

## Known coverage gap

No new **deterministic** regression test for the streaming case: the void is only reproducible in a live TTY (synthetic headless commits don't model the streaming re-render + overlay regrowth, which is why the bug persisted). `commit-geometry.test.ts` guards the adjacent shrink-pad scenario. A faithful streaming `@xterm` regression is recommended as follow-up.
