### PR TITLE
feat(cli): app-like TUI — /config settings menu + /model & /resume pickers

### DIFF
--- a/src/cli/input/trigger.test.ts
+++ b/src/cli/input/trigger.test.ts
@@ -16,7 +16,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { detectTrigger, filterFileCandidates } from './trigger.js';
+import { detectTrigger, filterFileCandidates, filterSlashCandidates } from './trigger.js';
 import { MAX_FILE_MATCHES } from '../multi-line-reader.js';
 import { resetRegistry } from '../slash/registry.js';
 import { registerAll } from '../slash/index.js';
@@ -128,5 +128,33 @@ describe('filterFileCandidates', () => {
 
   it('unreadable scan dir yields no candidates (no throw)', () => {
     expect(filterFileCandidates('/no/such/dir/x', '/nonexistent-cwd')).toEqual([]);
+  });
+});
+
+describe('filterSlashCandidates', () => {
+  it('returns prefix matches for a normal query', () => {
+    const vals = filterSlashCandidates('config').map((c) => c.value);
+    expect(vals).toContain('/config');
+  });
+
+  it('finds commands by subsequence abbreviation (cfg → /config)', () => {
+    const vals = filterSlashCandidates('cfg').map((c) => c.value);
+    expect(vals).toContain('/config');
+  });
+
+  it('ranks prefix matches ahead of subsequence-only matches', () => {
+    const keys = filterSlashCandidates('co').map((c) => c.value.slice(1).toLowerCase());
+    const firstNonPrefix = keys.findIndex((k) => !k.startsWith('co'));
+    // The prefix block is contiguous at the top: once it ends, no later
+    // entry may itself be a prefix match.
+    if (firstNonPrefix !== -1) {
+      expect(keys.slice(firstNonPrefix).every((k) => !k.startsWith('co'))).toBe(true);
+    }
+  });
+
+  it('empty query returns the full command set (unchanged prefix behaviour)', () => {
+    const vals = filterSlashCandidates('').map((c) => c.value);
+    expect(vals.length).toBeGreaterThan(0);
+    expect(vals).toContain('/config');
   });
 });

--- a/src/cli/input/trigger.ts
+++ b/src/cli/input/trigger.ts
@@ -11,6 +11,7 @@ import { join } from 'path';
 import { list as listSlashCommands, aliasEntries } from '../slash/registry.js';
 import { resolveQuery, MAX_FILE_MATCHES } from '../multi-line-reader.js';
 import type { Candidate, Trigger } from './types.js';
+import type { SlashCommand } from '../slash/types.js';
 
 /**
  * Detect the trigger kind and query from the buffer at the cursor position.
@@ -67,34 +68,65 @@ export function detectTrigger(buffer: string, cursorCol: number): Trigger | null
 }
 
 /**
- * Filter slash commands by query prefix.
+ * True when every character of `needle` appears in `haystack` in order (not
+ * necessarily contiguous). Used for the subsequence fallback so an abbreviation
+ * like `cfg` matches `config`. Both inputs are expected pre-lowercased.
+ */
+function isSubsequence(needle: string, haystack: string): boolean {
+  if (needle.length === 0) return true;
+  let i = 0;
+  for (let j = 0; j < haystack.length && i < needle.length; j++) {
+    if (haystack[j] === needle[i]) i += 1;
+  }
+  return i === needle.length;
+}
+
+/**
+ * Filter slash commands for the autocomplete dropdown.
+ *
+ * Ranking: prefix matches first (preserving the historical `startsWith`
+ * behaviour and its alphabetical ordering), then subsequence matches — e.g.
+ * `cfg` → `/config` — appended below, so abbreviations resolve without
+ * displacing the common prefix case. Matching is case-insensitive. Canonical
+ * commands and aliases (e.g. `/quit` → `/exit`, which borrow their canonical
+ * command's summary) share the same ranking. Capped at 20.
  */
 export function filterSlashCandidates(query: string): Candidate[] {
   const cmds = listSlashCommands();
-  const canonical: Candidate[] = cmds
-    .filter((cmd) => cmd.name.slice(1).startsWith(query)) // cmd.name includes '/'
-    .map((cmd) => ({
-      value: cmd.name,
-      summary: cmd.summary,
-      ...(cmd.hint ? { hint: cmd.hint } : {}),
-    }));
-  // Aliases (e.g. `/quit` → `/exit`) live in a separate map; surface them here
-  // so they show up in the dropdown alongside canonical commands. They borrow
-  // their canonical command's summary so users see what the alias does.
-  const aliasMatches: Candidate[] = aliasEntries()
-    .filter((entry) => entry.alias.slice(1).startsWith(query))
-    .map((entry) => {
-      const canonicalCmd = cmds.find((c) => c.name === entry.canonical);
-      return {
-        value: entry.alias,
-        summary: entry.summary,
-        ...(canonicalCmd?.hint ? { hint: canonicalCmd.hint } : {}),
-      };
-    });
-  const matches = [...canonical, ...aliasMatches].sort((a, b) =>
-    a.value.localeCompare(b.value),
-  );
-  return matches.slice(0, 20);
+  const q = query.toLowerCase();
+
+  const canonicalCand = (cmd: SlashCommand): Candidate => ({
+    value: cmd.name,
+    summary: cmd.summary,
+    ...(cmd.hint ? { hint: cmd.hint } : {}),
+  });
+  const aliasCand = (entry: { alias: string; canonical: string; summary: string }): Candidate => {
+    const canonicalCmd = cmds.find((c) => c.name === entry.canonical);
+    return {
+      value: entry.alias,
+      summary: entry.summary,
+      ...(canonicalCmd?.hint ? { hint: canonicalCmd.hint } : {}),
+    };
+  };
+
+  // (searchKey without leading slash, candidate) universe over commands + aliases.
+  const universe: Array<{ key: string; cand: Candidate }> = [
+    ...cmds.map((cmd) => ({ key: cmd.name.slice(1).toLowerCase(), cand: canonicalCand(cmd) })),
+    ...aliasEntries().map((entry) => ({ key: entry.alias.slice(1).toLowerCase(), cand: aliasCand(entry) })),
+  ];
+
+  const prefix = universe.filter((u) => u.key.startsWith(q));
+  const prefixValues = new Set(prefix.map((u) => u.cand.value));
+  const subseq =
+    q.length === 0
+      ? []
+      : universe.filter((u) => !prefixValues.has(u.cand.value) && isSubsequence(q, u.key));
+
+  const byValue = (a: { cand: Candidate }, b: { cand: Candidate }): number =>
+    a.cand.value.localeCompare(b.cand.value);
+  prefix.sort(byValue);
+  subseq.sort(byValue);
+  return [...prefix, ...subseq].map((u) => u.cand).slice(0, 20);
 }
 
 /**

--- a/src/cli/render/config-menu.test.ts
+++ b/src/cli/render/config-menu.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for the /config interactive settings menu (render/config-menu.ts).
+ *
+ * Pure helpers (categorisation, formatting, editor planning, validation) are
+ * tested directly. The orchestrator is exercised against scripted fake overlays
+ * + a recording io — no real compositor and no disk writes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  CATEGORY_ORDER,
+  categoryOf,
+  buildCategories,
+  formatValue,
+  keyRowLabel,
+  editorFor,
+  makeValidator,
+  runConfigMenu,
+  type MenuOverlays,
+  type MenuIo,
+} from './config-menu.js';
+import { CONFIG_KEY_SPECS, getConfigKeySpec, type ConfigKeySpec } from '../../config/settable-keys.js';
+
+// ── Fakes ────────────────────────────────────────────────────────────────────
+
+class FakeOverlays implements MenuOverlays {
+  pickCalls: Array<{ header: readonly string[]; options: readonly string[] }> = [];
+  textCalls: Array<{ header: readonly string[]; initial: string; help: string }> = [];
+  emits: string[] = [];
+  lastValidator: ((v: string) => string | null) | null = null;
+  private picks: Array<number | null>;
+  private texts: Array<string | null>;
+
+  constructor(picks: Array<number | null>, texts: Array<string | null> = []) {
+    this.picks = [...picks];
+    this.texts = [...texts];
+  }
+
+  async pick(header: readonly string[], options: readonly string[]): Promise<number | null> {
+    this.pickCalls.push({ header, options });
+    return this.picks.length > 0 ? this.picks.shift()! : null;
+  }
+
+  async editText(
+    header: readonly string[],
+    initial: string,
+    help: string,
+    validate: (v: string) => string | null,
+  ): Promise<string | null> {
+    this.textCalls.push({ header, initial, help });
+    this.lastValidator = validate;
+    return this.texts.length > 0 ? this.texts.shift()! : null;
+  }
+
+  emit(line: string): void {
+    this.emits.push(line);
+  }
+}
+
+class FakeIo implements MenuIo {
+  writes: Array<{ path: string; value: string; human: boolean }> = [];
+  throwOn: string | null = null;
+  private specList: readonly ConfigKeySpec[];
+  private values: Record<string, unknown>;
+
+  constructor(specList: readonly ConfigKeySpec[], values: Record<string, unknown> = {}) {
+    this.specList = specList;
+    this.values = values;
+  }
+
+  specs(): readonly ConfigKeySpec[] {
+    return this.specList;
+  }
+
+  current(path: string): unknown {
+    return this.values[path];
+  }
+
+  write(path: string, rawValue: string, allowHuman: boolean): string {
+    if (this.throwOn === path) throw new Error(`refused: ${path}`);
+    this.writes.push({ path, value: rawValue, human: allowHuman });
+    return rawValue;
+  }
+}
+
+const TWO_KEY_SPECS: ConfigKeySpec[] = [
+  { path: 'temperature', tier: 'agent', type: 'number', clamp: { min: 0, max: 2 }, description: 'Sampling temperature.' },
+  { path: 'permissionMode', tier: 'human', type: 'enum', enumValues: ['default', 'plan'], description: 'Perm mode.' },
+];
+
+// ── Pure helpers ───────────────────────────────────────────────────────────
+
+describe('categoryOf', () => {
+  it('maps every CONFIG_KEY_SPECS path into a known category', () => {
+    for (const spec of CONFIG_KEY_SPECS) {
+      expect(CATEGORY_ORDER).toContain(categoryOf(spec.path));
+    }
+  });
+
+  it('maps representative paths correctly', () => {
+    expect(categoryOf('model')).toBe('Model & routing');
+    expect(categoryOf('models.large')).toBe('Model & routing');
+    expect(categoryOf('temperature')).toBe('Model & routing');
+    expect(categoryOf('autoRouting.chat')).toBe('Model & routing');
+    expect(categoryOf('interactive.suggestGhost')).toBe('Interactive');
+    expect(categoryOf('telegram.notify.mode')).toBe('Telegram');
+    expect(categoryOf('permissionMode')).toBe('Advanced');
+    expect(categoryOf('daemon.task')).toBe('Advanced');
+    expect(categoryOf('bgSummaries')).toBe('Session');
+  });
+});
+
+describe('buildCategories', () => {
+  it('places every spec into exactly one category (no loss, no duplication)', () => {
+    const cats = buildCategories(CONFIG_KEY_SPECS);
+    const total = cats.reduce((n, c) => n + c.keys.length, 0);
+    expect(total).toBe(CONFIG_KEY_SPECS.length);
+  });
+
+  it('emits categories in CATEGORY_ORDER and never empty', () => {
+    const cats = buildCategories(CONFIG_KEY_SPECS);
+    const order = cats.map((c) => CATEGORY_ORDER.indexOf(c.name));
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+    for (const c of cats) expect(c.keys.length).toBeGreaterThan(0);
+  });
+});
+
+describe('formatValue', () => {
+  it('renders unset / arrays / primitives cleanly', () => {
+    expect(formatValue(undefined)).toBe('(unset)');
+    expect(formatValue(true)).toBe('true');
+    expect(formatValue(0.7)).toBe('0.7');
+    expect(formatValue([1, 2, 3])).toBe('1,2,3');
+    expect(formatValue([])).toBe('(empty)');
+  });
+});
+
+describe('keyRowLabel', () => {
+  it('prefixes a lock glyph on human-tier keys and none on agent-tier', () => {
+    const [temp, perm] = TWO_KEY_SPECS;
+    expect(keyRowLabel(temp!, 1.0, 14)).not.toContain('🔒');
+    expect(keyRowLabel(perm!, 'plan', 14)).toContain('🔒');
+    expect(keyRowLabel(temp!, 1.0, 14)).toContain('temperature');
+    expect(keyRowLabel(temp!, 1.0, 14)).toContain('(number)');
+  });
+});
+
+describe('editorFor', () => {
+  it('booleans and enums become fixed-option pickers', () => {
+    const boolSpec = getConfigKeySpec('bgSummaries')!;
+    expect(editorFor(boolSpec)).toEqual({ kind: 'pick', options: ['true', 'false'] });
+
+    const perm = getConfigKeySpec('permissionMode')!;
+    const plan = editorFor(perm);
+    expect(plan.kind).toBe('pick');
+    if (plan.kind === 'pick') {
+      expect(plan.options).toEqual(['default', 'plan', 'autonomous', 'bypassPermissions']);
+    }
+  });
+
+  it('numbers become a text editor whose help shows the clamp range', () => {
+    const temp = getConfigKeySpec('temperature')!;
+    const plan = editorFor(temp);
+    expect(plan.kind).toBe('text');
+    if (plan.kind === 'text') expect(plan.help).toContain('[0..2]');
+  });
+
+  it('strings become a plain text editor', () => {
+    const sys = getConfigKeySpec('systemPrompt')!;
+    expect(editorFor(sys).kind).toBe('text');
+  });
+});
+
+describe('makeValidator', () => {
+  it('accepts valid values and rejects invalid ones (wraps coerceConfigValue)', () => {
+    const temp = getConfigKeySpec('temperature')!;
+    const vTemp = makeValidator(temp);
+    expect(vTemp('1.5')).toBeNull();
+    expect(vTemp('abc')).not.toBeNull();
+
+    const perm = getConfigKeySpec('permissionMode')!;
+    const vPerm = makeValidator(perm);
+    expect(vPerm('plan')).toBeNull();
+    expect(vPerm('nope')).not.toBeNull();
+  });
+});
+
+// ── Orchestrator ─────────────────────────────────────────────────────────────
+
+describe('runConfigMenu', () => {
+  it('writes an agent-tier key via the text editor (no confirm) and echoes the restart note', async () => {
+    // cat=Model&routing(0) → key=temperature(0) → text "1.5" → key esc → cat esc
+    const ov = new FakeOverlays([0, 0, null, null], ['1.5']);
+    const io = new FakeIo(TWO_KEY_SPECS, { temperature: 1.0 });
+
+    await runConfigMenu(ov, io);
+
+    expect(io.writes).toEqual([{ path: 'temperature', value: '1.5', human: false }]);
+    expect(ov.emits.length).toBe(1);
+    expect(ov.emits[0]).toContain('temperature');
+    expect(ov.emits[0]).toContain('✓');
+    expect(ov.emits[0]).toContain('restart');
+    // The validator handed to the text overlay really rejects bad input.
+    expect(ov.lastValidator).not.toBeNull();
+    expect(ov.lastValidator!('abc')).not.toBeNull();
+    expect(ov.lastValidator!('1.5')).toBeNull();
+  });
+
+  it('requires an explicit confirm before writing a human-tier key (Yes → write with allowHuman)', async () => {
+    // cat=Advanced(1) → key=permissionMode(0) → enum pick "plan"(1) → confirm Yes(0) → key esc → cat esc
+    const ov = new FakeOverlays([1, 0, 1, 0, null, null]);
+    const io = new FakeIo(TWO_KEY_SPECS);
+
+    await runConfigMenu(ov, io);
+
+    expect(io.writes).toEqual([{ path: 'permissionMode', value: 'plan', human: true }]);
+  });
+
+  it('does not write a human-tier key when the confirm is declined', async () => {
+    // ... confirm No(1) instead of Yes
+    const ov = new FakeOverlays([1, 0, 1, 1, null, null]);
+    const io = new FakeIo(TWO_KEY_SPECS);
+
+    await runConfigMenu(ov, io);
+
+    expect(io.writes).toEqual([]);
+  });
+
+  it('closes immediately with no writes when Esc is pressed at the top level', async () => {
+    const ov = new FakeOverlays([null]);
+    const io = new FakeIo(TWO_KEY_SPECS);
+
+    await runConfigMenu(ov, io);
+
+    expect(io.writes).toEqual([]);
+    expect(ov.pickCalls.length).toBe(1);
+  });
+
+  it('surfaces a write failure without throwing and keeps the menu alive', async () => {
+    const ov = new FakeOverlays([0, 0, null, null], ['1.5']);
+    const io = new FakeIo(TWO_KEY_SPECS, { temperature: 1.0 });
+    io.throwOn = 'temperature';
+
+    await expect(runConfigMenu(ov, io)).resolves.toBeUndefined();
+
+    expect(io.writes).toEqual([]);
+    expect(ov.emits.length).toBe(1);
+    expect(ov.emits[0]).toContain('✗');
+    expect(ov.emits[0]).toContain('refused');
+  });
+});

--- a/src/cli/render/config-menu.ts
+++ b/src/cli/render/config-menu.ts
@@ -1,0 +1,303 @@
+/**
+ * Interactive settings menu for `/config` — a navigable editor over
+ * {@link CONFIG_KEY_SPECS}, composed from the existing overlay primitives
+ * (`runPicker` + `runTextInput`) rather than a new TUI framework.
+ *
+ * Design (see `.afk/plans/app-like-tui-config-menu.md`):
+ *   - This is a THIRD consumer of `TerminalCompositor.enterPickerMode`, joining
+ *     `runPicker` and `runTextInput`. It never touches raw mode / stdin itself
+ *     (single-consumer-stdin invariant — see render/picker.ts header, PR #511).
+ *   - Overlays are driven by SEQUENTIAL `await`s (category → key → value), never
+ *     nested, so the single-overlay guard (terminal-compositor.input-mode.ts:95)
+ *     always holds — each overlay `exitPickerMode`s before the next enters.
+ *
+ * Value semantics: writes go through `setConfigValue`, which persists to
+ * afk.config.json but is CACHED AT LOAD — the running session is unchanged until
+ * restart (mutate.ts:19-21). Every write echoes `RESTART_NOTE` so the user is
+ * never surprised.
+ *
+ * Security: config keys are only tier 'agent' | 'human' — never `secret` (secrets
+ * are env-only). So editing config keys in-REPL cannot leak a credential.
+ * Human-tier keys require an explicit in-menu confirm before writing (mirrors the
+ * `afk config set --allow` gate); `/config` is a human surface (the agent cannot
+ * type slash commands), so this does not widen the `config_set` agent-tool path.
+ * Env-var editing (which involves secret masking) is deliberately OUT of the
+ * interactive menu — it stays on `afk config env set` and the read-only dump.
+ *
+ * Testability: all overlay + io effects are injected via {@link MenuOverlays} /
+ * {@link MenuIo}, so the orchestrator is unit-tested with scripted fakes and no
+ * real compositor or disk. `overlaysFromCompositor` / `defaultIo` wire the real
+ * implementations for the slash handler.
+ */
+
+import { palette } from '../palette.js';
+import { runPicker } from './picker.js';
+import { runTextInput } from './text-input.js';
+import type { TerminalCompositor } from '../terminal-compositor.js';
+import {
+  CONFIG_KEY_SPECS,
+  coerceConfigValue,
+  type ConfigKeySpec,
+} from '../../config/settable-keys.js';
+import { setConfigValue, getConfigValue, RESTART_NOTE } from '../../config/mutate.js';
+
+// ── Categorisation (pure) ───────────────────────────────────────────────────
+
+/** Display order for categories. Any category not listed here is dropped. */
+export const CATEGORY_ORDER = [
+  'Model & routing',
+  'Interactive',
+  'Session',
+  'Telegram',
+  'Advanced',
+] as const;
+
+/**
+ * Map a config key path to its menu category. Total over every path in
+ * CONFIG_KEY_SPECS (asserted by a test) — a new spec that matches nothing here
+ * lands in 'Session' rather than vanishing, but the test will flag it so the
+ * author can place it deliberately.
+ */
+export function categoryOf(path: string): (typeof CATEGORY_ORDER)[number] {
+  if (
+    path === 'model' ||
+    path.startsWith('models.') ||
+    path === 'temperature' ||
+    path === 'maxTokens' ||
+    path.startsWith('autoRouting.')
+  ) {
+    return 'Model & routing';
+  }
+  if (path.startsWith('interactive.')) return 'Interactive';
+  if (path.startsWith('telegram.')) return 'Telegram';
+  if (path.startsWith('daemon.')) return 'Advanced';
+  if (
+    path === 'systemPrompt' ||
+    path === 'permissionMode' ||
+    path === 'enableShellHooks' ||
+    path === 'updatePolicy'
+  ) {
+    return 'Advanced';
+  }
+  return 'Session';
+}
+
+export interface MenuCategory {
+  name: (typeof CATEGORY_ORDER)[number];
+  keys: readonly ConfigKeySpec[];
+}
+
+/** Group specs into ordered, non-empty categories. */
+export function buildCategories(specs: readonly ConfigKeySpec[]): MenuCategory[] {
+  const byCat = new Map<string, ConfigKeySpec[]>();
+  for (const spec of specs) {
+    const cat = categoryOf(spec.path);
+    const bucket = byCat.get(cat);
+    if (bucket) bucket.push(spec);
+    else byCat.set(cat, [spec]);
+  }
+  const out: MenuCategory[] = [];
+  for (const name of CATEGORY_ORDER) {
+    const keys = byCat.get(name);
+    if (keys && keys.length > 0) out.push({ name, keys });
+  }
+  return out;
+}
+
+// ── Value formatting + validation (pure) ─────────────────────────────────────
+
+/** Render a persisted config value as a compact display string. */
+export function formatValue(v: unknown): string {
+  if (v === undefined) return '(unset)';
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return v.length === 0 ? '(empty)' : v.join(',');
+  if (typeof v === 'object') return JSON.stringify(v);
+  return String(v);
+}
+
+/** One key row: `🔒 path            value  (type)` — lock glyph on human-tier keys. */
+export function keyRowLabel(spec: ConfigKeySpec, current: unknown, pad: number): string {
+  const lock = spec.tier === 'human' ? '🔒 ' : '   ';
+  return `${lock}${spec.path.padEnd(pad)}  ${formatValue(current)}  (${spec.type})`;
+}
+
+/**
+ * Editor shape for a key: a fixed-option picker (boolean/enum) or a free-text
+ * overlay (everything else), with a help line describing the accepted input.
+ */
+export type EditorPlan =
+  | { kind: 'pick'; options: string[] }
+  | { kind: 'text'; help: string };
+
+export function editorFor(spec: ConfigKeySpec): EditorPlan {
+  if (spec.type === 'boolean') return { kind: 'pick', options: ['true', 'false'] };
+  if (spec.type === 'enum' && spec.enumValues && spec.enumValues.length > 0) {
+    return { kind: 'pick', options: [...spec.enumValues] };
+  }
+  let help = 'enter to save · esc to cancel';
+  if (spec.type === 'number' && spec.clamp) {
+    const range = `[${spec.clamp.min}..${spec.clamp.max}]${spec.clamp.integer ? ' integer' : ''}`;
+    help = `number ${range} · enter to save · esc to cancel`;
+  } else if (spec.type === 'number') {
+    help = 'number · enter to save · esc to cancel';
+  } else if (spec.type === 'number-array') {
+    help = 'comma-separated numbers · enter to save · esc to cancel';
+  } else if (spec.type === 'model-slot') {
+    help = 'model id (e.g. sonnet) · enter to save · esc to cancel';
+  }
+  return { kind: 'text', help };
+}
+
+/** A synchronous validator for the text overlay — wraps `coerceConfigValue`. */
+export function makeValidator(spec: ConfigKeySpec): (raw: string) => string | null {
+  return (raw: string): string | null => {
+    const r = coerceConfigValue(spec, raw);
+    return r.ok ? null : r.error;
+  };
+}
+
+// ── Injected effects (for testability) ───────────────────────────────────────
+
+export interface MenuOverlays {
+  /** Show a single-select picker; resolve with the chosen index, or null on Esc. */
+  pick(header: readonly string[], options: readonly string[]): Promise<number | null>;
+  /** Show a text editor; resolve with the typed string, or null on Esc. */
+  editText(
+    header: readonly string[],
+    initial: string,
+    help: string,
+    validate: (v: string) => string | null,
+  ): Promise<string | null>;
+  /** Write a durable line to scrollback (above the input region). */
+  emit(line: string): void;
+}
+
+export interface MenuIo {
+  specs(): readonly ConfigKeySpec[];
+  /** Current persisted value for a key (undefined when unset). */
+  current(path: string): unknown;
+  /** Persist a value; return the display form of what was written, or throw. */
+  write(path: string, rawValue: string, allowHuman: boolean): string;
+}
+
+// ── Orchestrator ─────────────────────────────────────────────────────────────
+
+const TITLE = '⚙  Settings';
+
+/**
+ * Run the interactive settings menu to completion. Returns when the user closes
+ * the top-level category picker (Esc). Never throws — write failures are echoed
+ * and the menu continues.
+ */
+export async function runConfigMenu(ov: MenuOverlays, io: MenuIo): Promise<void> {
+  const cats = buildCategories(io.specs());
+  if (cats.length === 0) return;
+
+  // Category level.
+  for (;;) {
+    const catHeader = [
+      palette.bold(TITLE),
+      palette.dim('Changes apply on the next restart'),
+      '',
+    ];
+    const ci = await ov.pick(
+      catHeader,
+      cats.map((c) => `${c.name}  ·  ${c.keys.length} setting${c.keys.length === 1 ? '' : 's'}`),
+    );
+    if (ci === null) return; // Esc closes the menu
+    const cat = cats[ci];
+    if (!cat) return;
+
+    // Key level.
+    const pad = Math.min(28, Math.max(...cat.keys.map((k) => k.path.length)));
+    for (;;) {
+      const keyHeader = [palette.bold(`${TITLE} › ${cat.name}`), ''];
+      const ki = await ov.pick(
+        keyHeader,
+        cat.keys.map((k) => keyRowLabel(k, io.current(k.path), pad)),
+      );
+      if (ki === null) break; // Esc → back to categories
+      const spec = cat.keys[ki];
+      if (!spec) break;
+      await editKey(ov, io, spec);
+    }
+  }
+}
+
+async function editKey(ov: MenuOverlays, io: MenuIo, spec: ConfigKeySpec): Promise<void> {
+  const current = io.current(spec.path);
+  const header = [
+    palette.bold(`${TITLE} › ${spec.path}`),
+    palette.dim(spec.description),
+    palette.dim(`current: ${formatValue(current)}`),
+    '',
+  ];
+  const plan = editorFor(spec);
+
+  let rawValue: string;
+  if (plan.kind === 'pick') {
+    const idx = await ov.pick(header, plan.options);
+    if (idx === null) return; // Esc → back to key list
+    const picked = plan.options[idx];
+    if (picked === undefined) return;
+    rawValue = picked;
+  } else {
+    const initial = current === undefined ? '' : formatValue(current);
+    const typed = await ov.editText(header, initial, plan.help, makeValidator(spec));
+    if (typed === null) return; // Esc / cancel → back to key list
+    rawValue = typed;
+  }
+
+  // Human-tier keys are CLI-gated; require an explicit confirm on this human
+  // surface before opting past the gate.
+  let allowHuman = false;
+  if (spec.tier === 'human') {
+    const confirmIdx = await ov.pick(
+      [
+        palette.warning(`Apply human-tier change to ${spec.path}?`),
+        palette.dim('This setting is normally changed via `afk config` on the CLI.'),
+        '',
+      ],
+      [`Yes — set to "${rawValue}"`, 'No — cancel'],
+    );
+    if (confirmIdx !== 0) return; // No / Esc → abandon
+    allowHuman = true;
+  }
+
+  try {
+    const display = io.write(spec.path, rawValue, allowHuman);
+    ov.emit(`${palette.success('  ✓')} ${spec.path} = ${palette.bold(display)}  ${palette.dim(`— ${RESTART_NOTE}`)}`);
+  } catch (err) {
+    ov.emit(`${palette.error('  ✗')} ${palette.error(err instanceof Error ? err.message : String(err))}`);
+  }
+}
+
+// ── Real adapters ────────────────────────────────────────────────────────────
+
+/** Bind the overlay primitives to a live compositor (the slash-handler path). */
+export function overlaysFromCompositor(c: TerminalCompositor): MenuOverlays {
+  return {
+    async pick(header, options) {
+      const result = await runPicker(c, { header, options });
+      if (!result || result.length === 0) return null;
+      const idx = options.indexOf(result[0]!);
+      return idx >= 0 ? idx : null;
+    },
+    async editText(header, initial, help, validate) {
+      return runTextInput(c, { header, initial, help, validate });
+    },
+    emit(line) {
+      c.commitAbove(line);
+    },
+  };
+}
+
+/** Real io backed by the config-mutation engine. */
+export function defaultIo(): MenuIo {
+  return {
+    specs: () => CONFIG_KEY_SPECS,
+    current: (path) => getConfigValue(path).value,
+    write: (path, rawValue, allowHuman) =>
+      String(setConfigValue(path, rawValue, allowHuman ? { allowHumanOnly: true } : undefined).value),
+  };
+}

--- a/src/cli/render/config-menu.ts
+++ b/src/cli/render/config-menu.ts
@@ -82,7 +82,7 @@ export function categoryOf(path: string): (typeof CATEGORY_ORDER)[number] {
   return 'Session';
 }
 
-export interface MenuCategory {
+interface MenuCategory {
   name: (typeof CATEGORY_ORDER)[number];
   keys: readonly ConfigKeySpec[];
 }
@@ -125,7 +125,7 @@ export function keyRowLabel(spec: ConfigKeySpec, current: unknown, pad: number):
  * Editor shape for a key: a fixed-option picker (boolean/enum) or a free-text
  * overlay (everything else), with a help line describing the accepted input.
  */
-export type EditorPlan =
+type EditorPlan =
   | { kind: 'pick'; options: string[] }
   | { kind: 'text'; help: string };
 

--- a/src/cli/slash/commands/config-doctor.test.ts
+++ b/src/cli/slash/commands/config-doctor.test.ts
@@ -134,6 +134,55 @@ describe('/config slash command', () => {
 });
 
 // ---------------------------------------------------------------------------
+// /config fast-paths (view / set / unknown-arg / non-TTY fallback)
+// ---------------------------------------------------------------------------
+
+describe('/config fast-paths', () => {
+  const configCmd = configDoctorCommands.find((c) => c.name === '/config')!;
+
+  it('/config view renders the read-only dump', async () => {
+    const { ctx, lines } = makeCtx();
+    const result = await configCmd.handler(ctx, 'view');
+    expect(result).toBe('continue');
+    expect(lines.join('\n')).toMatch(/model|provider/i);
+  });
+
+  it('/config set with no value warns about usage', async () => {
+    const { ctx, lines } = makeCtx();
+    await configCmd.handler(ctx, 'set');
+    expect(lines.join('\n')).toMatch(/WARN:.*Usage/i);
+  });
+
+  it('/config set <unknown-key> errors and writes nothing', async () => {
+    const { ctx, lines } = makeCtx();
+    await configCmd.handler(ctx, 'set definitely_not_a_key 1');
+    expect(lines.join('\n')).toMatch(/ERROR:.*[Uu]nknown/);
+  });
+
+  it('/config set <human-tier> refuses (points to the menu/CLI, no write)', async () => {
+    const { ctx, lines } = makeCtx();
+    await configCmd.handler(ctx, 'set permissionMode plan');
+    expect(lines.join('\n')).toMatch(/WARN:.*human-tier/i);
+  });
+
+  it('unknown argument warns and still shows the dump', async () => {
+    const { ctx, lines } = makeCtx();
+    await configCmd.handler(ctx, 'wat');
+    const body = lines.join('\n');
+    expect(body).toMatch(/WARN:.*Unknown argument/i);
+    expect(body).toMatch(/model|provider/i);
+  });
+
+  it('falls back to the read-only view when no compositor is available (non-TTY)', async () => {
+    const { ctx, lines } = makeCtx();
+    // makeCtx() supplies no getCompositor → the interactive branch must fall back.
+    const result = await configCmd.handler(ctx, '');
+    expect(result).toBe('continue');
+    expect(lines.join('\n')).toContain('ANTHROPIC_API_KEY');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // /doctor handler
 // ---------------------------------------------------------------------------
 

--- a/src/cli/slash/commands/config-doctor.test.ts
+++ b/src/cli/slash/commands/config-doctor.test.ts
@@ -13,7 +13,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import type { SlashContext, SessionStats } from '../types.js';
+import type { PickerController, TerminalCompositor } from '../../terminal-compositor.js';
 import { configDoctorCommands } from './config-doctor.ts';
 import { registerAll } from '../index.js';
 import { resetRegistry, lookup } from '../registry.js';
@@ -224,5 +228,70 @@ describe('/doctor slash command', () => {
     expect(doctorCmd.summary.length).toBeGreaterThan(0);
     expect(doctorCmd.hint).toBeDefined();
     expect(doctorCmd.hint!.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /config interactive menu — malformed-config resilience
+// ---------------------------------------------------------------------------
+
+/** Minimal picker host: captures the controller so a test can drive keys. */
+class FakeHost {
+  controller: PickerController | null = null;
+  enterPickerMode(controller: PickerController): void {
+    this.controller = controller;
+  }
+  exitPickerMode(): void {
+    this.controller = null;
+  }
+  repaintPicker(): void {}
+  press(name: string): void {
+    if (!this.controller) throw new Error('FakeHost: no controller installed');
+    this.controller.onKey(undefined, { name, ctrl: false, shift: false });
+  }
+}
+
+describe('/config interactive menu — malformed config', () => {
+  const configCmd = configDoctorCommands.find((c) => c.name === '/config')!;
+  let tmpHome: string;
+  let originalHome: string | undefined;
+  let originalAfkHome: string | undefined;
+
+  beforeEach(() => {
+    originalHome = process.env['HOME'];
+    originalAfkHome = process.env['AFK_HOME'];
+    // AFK_HOME (if set in the runner env) would win over HOME — clear it so the
+    // config path resolves under our temp HOME.
+    delete process.env['AFK_HOME'];
+    tmpHome = join(tmpdir(), `afk-cfg-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    process.env['HOME'] = tmpHome;
+    const cfgDir = join(tmpHome, '.afk', 'config');
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(join(cfgDir, 'afk.config.json'), '{ this is : not valid json', 'utf-8');
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+    if (originalHome !== undefined) process.env['HOME'] = originalHome;
+    else delete process.env['HOME'];
+    if (originalAfkHome !== undefined) process.env['AFK_HOME'] = originalAfkHome;
+  });
+
+  it('degrades to the read-only view (no throw) when afk.config.json is malformed', async () => {
+    const { ctx, lines } = makeCtx();
+    const host = new FakeHost();
+    ctx.getCompositor = (): TerminalCompositor => host as unknown as TerminalCompositor;
+
+    const p = configCmd.handler(ctx, '');
+    // The category picker renders without reading config; selecting a category
+    // triggers key-row rendering → getConfigValue throws MalformedConfigError.
+    host.press('return');
+    const result = await p;
+
+    expect(result).toBe('continue');
+    const body = lines.join('\n');
+    expect(body).toMatch(/ERROR:.*settings menu/i);
+    // Read-only dump fallback still renders.
+    expect(body).toContain('ANTHROPIC_API_KEY');
   });
 });

--- a/src/cli/slash/commands/config-doctor.ts
+++ b/src/cli/slash/commands/config-doctor.ts
@@ -168,7 +168,23 @@ const configCmd: SlashCommand = {
       return 'continue';
     }
 
-    await runConfigMenu(overlaysFromCompositor(compositor), defaultIo());
+    // A malformed afk.config.json makes defaultIo().current (getConfigValue)
+    // throw MalformedConfigError while the menu renders its key rows. The
+    // normal config loader tolerates a bad file by warning and continuing
+    // (config/json-tier.ts), and the `/config set` fast-path already catches
+    // its own writes — mirror that tolerance here so a bad file degrades to the
+    // read-only view with an actionable error instead of escaping dispatch()
+    // (registry.ts) into the REPL loop, which has no catch and would tear the
+    // session down.
+    try {
+      await runConfigMenu(overlaysFromCompositor(compositor), defaultIo());
+    } catch (err) {
+      ctx.out.error(
+        `Could not open the settings menu: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      ctx.out.line(palette.dim('  Showing the read-only view instead:'));
+      renderConfigView(ctx.out);
+    }
     return 'continue';
   },
 };

--- a/src/cli/slash/commands/config-doctor.ts
+++ b/src/cli/slash/commands/config-doctor.ts
@@ -1,15 +1,16 @@
 /**
- * /config and /doctor slash commands — read-only REPL equivalents of the
- * top-level `afk config` and `afk doctor` CLI commands.
+ * /config and /doctor slash commands.
  *
- * Both commands are strictly introspective: they never mutate session state
- * and never call process.exit(). Output is written via ctx.out so it works
- * identically on every surface (REPL, Telegram, tests).
+ * /config — interactive settings menu on a TTY (browse + edit config keys via
+ *   arrow keys), with a read-only `view` dump and a scriptable `set` fast-path
+ *   that work on every surface. The interactive editor is composed from the
+ *   existing overlay primitives (see render/config-menu.ts) — no new TUI stack.
+ * /doctor — read-only system health checks (unchanged).
  *
- * Reuse strategy:
- *   /config — calls the same env/provider helpers as config-command.ts.
- *   /doctor — calls runDoctorChecks() from doctor-checks.ts, which is also
- *             used by the refactored CLI action in doctor.ts.
+ * Both remain non-destructive to session state and never call process.exit().
+ * Output is written via ctx.out so it works identically on every surface (REPL,
+ * Telegram, tests). The interactive menu additionally borrows the REPL's live
+ * compositor via ctx.getCompositor(); non-TTY surfaces fall back to the dump.
  */
 
 import { env } from '../../../config/env.js';
@@ -18,80 +19,156 @@ import { divider } from '../../render.js';
 import { providerForModel } from '../../../agent/providers/index.js';
 import { resolveCliPermissionMode } from '../../config.js';
 import { runDoctorChecks } from '../../commands/doctor-checks.js';
-import type { SlashCommand } from '../types.js';
+import { getConfigKeySpec } from '../../../config/settable-keys.js';
+import { setConfigValue, RESTART_NOTE } from '../../../config/mutate.js';
+import { runConfigMenu, overlaysFromCompositor, defaultIo } from '../../render/config-menu.js';
+import type { SlashCommand, SlashContext, Writer } from '../types.js';
 
 // ---------------------------------------------------------------------------
-// /config
+// /config — read-only view (shared by `/config view`, the non-TTY fallback,
+// and unknown-argument handling)
+// ---------------------------------------------------------------------------
+
+/** Render the resolved-configuration dump (model, provider, keys, env vars). */
+function renderConfigView(out: Writer): void {
+  const modelRaw = env.AFK_MODEL ?? env.CLAUDE_MODEL;
+  const model = modelRaw ?? 'sonnet';
+  const provider = providerForModel(modelRaw);
+
+  const anthropicApiKey = env.ANTHROPIC_API_KEY || env.CLAUDE_CODE_OAUTH_TOKEN;
+  const openaiKey = env.OPENAI_API_KEY || env.CODEX_API_KEY;
+  const apiKey = provider === 'anthropic' ? anthropicApiKey : openaiKey;
+
+  out.line();
+  out.line(palette.bold('Configuration'));
+  out.line(divider());
+
+  out.line(`  model       ${palette.info(modelRaw ? model : `${model} (default)`)}`);
+  out.line(`  provider    ${palette.plan(provider)}`);
+
+  if (provider === 'anthropic') {
+    const keyStatus = apiKey
+      ? palette.success('✓ set  (ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN)')
+      : palette.warning('⚠ not set — subprocess falls back to OAuth / keychain');
+    out.line(`  api key     ${keyStatus}`);
+  } else {
+    const openaiSource = env.OPENAI_API_KEY ? 'OPENAI_API_KEY' : 'CODEX_API_KEY';
+    const keyStatus = apiKey
+      ? palette.success(`✓ set  (${openaiSource})`)
+      : palette.warning('⚠ not set — falling back to `codex login` state');
+    out.line(`  api key     ${keyStatus}`);
+  }
+
+  out.line(
+    `  thinking    ${env.AFK_THINKING ? palette.info(env.AFK_THINKING) : palette.dim('(unset — SDK default)')}`,
+  );
+  out.line(
+    `  effort      ${env.AFK_EFFORT ? palette.info(env.AFK_EFFORT) : palette.dim('(unset — SDK default)')}`,
+  );
+  const permissionMode = resolveCliPermissionMode();
+  out.line(
+    `  perm mode   ${permissionMode === 'bypassPermissions'
+      ? palette.warning(`${permissionMode} (bypass — containment off)`)
+      : palette.info(`${permissionMode} (containment on)`)}`,
+  );
+
+  out.line();
+  out.line(palette.bold('Environment variables'));
+  out.line(divider());
+
+  const envRows: Array<[string, string]> = [
+    ['AFK_MODEL', env.AFK_MODEL ?? palette.dim('unset')],
+    ['CLAUDE_MODEL', env.CLAUDE_MODEL ?? palette.dim('unset')],
+    ['ANTHROPIC_API_KEY', env.ANTHROPIC_API_KEY ? palette.success('set') : palette.dim('unset')],
+    ['CLAUDE_CODE_OAUTH_TOKEN', env.CLAUDE_CODE_OAUTH_TOKEN ? palette.success('set') : palette.dim('unset')],
+    ['OPENAI_API_KEY', env.OPENAI_API_KEY ? palette.success('set') : palette.dim('unset')],
+    ['CODEX_API_KEY', env.CODEX_API_KEY ? palette.success('set') : palette.dim('unset')],
+    ['AFK_THINKING', env.AFK_THINKING ?? palette.dim('unset')],
+    ['AFK_EFFORT', env.AFK_EFFORT ?? palette.dim('unset')],
+  ];
+  const keyWidth = Math.max(...envRows.map(([k]) => k.length)) + 2;
+  for (const [k, v] of envRows) {
+    out.line(`  ${palette.meta(k.padEnd(keyWidth))} ${v}`);
+  }
+  out.line();
+}
+
+// ---------------------------------------------------------------------------
+// /config set <key> <value> — scriptable fast-path (agent-tier keys only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle `/config set <key> <value>`. Writes agent-tier config keys directly;
+ * refuses human-tier keys (they require the interactive confirm or the CLI) and
+ * unknown keys. Works on every surface (no compositor needed).
+ */
+function handleConfigSet(ctx: SlashContext, rest: string): 'continue' {
+  const trimmed = rest.trim();
+  const sp = trimmed.indexOf(' ');
+  if (sp === -1) {
+    ctx.out.warn('Usage: /config set <key> <value>');
+    return 'continue';
+  }
+  const path = trimmed.slice(0, sp).trim();
+  const value = trimmed.slice(sp + 1).trim();
+
+  const spec = getConfigKeySpec(path);
+  if (!spec) {
+    ctx.out.error(`Unknown config key: ${path}  (type /config to browse settings)`);
+    return 'continue';
+  }
+  if (spec.tier === 'human') {
+    ctx.out.warn(
+      `${path} is human-tier — set it from the interactive menu (/config) or \`afk config set ${path} <value>\`.`,
+    );
+    return 'continue';
+  }
+  try {
+    const r = setConfigValue(path, value);
+    ctx.out.success(`✓ set ${path} = ${String(r.value)} — ${RESTART_NOTE}`);
+  } catch (err) {
+    ctx.out.error(err instanceof Error ? err.message : String(err));
+  }
+  return 'continue';
+}
+
+// ---------------------------------------------------------------------------
+// /config — command
 // ---------------------------------------------------------------------------
 
 const configCmd: SlashCommand = {
   name: '/config',
-  summary: 'View resolved configuration (model, provider, API keys, env vars)',
-  hint: 'When you want to confirm which model and API key the session is using, or check what env vars are active — same as `afk config` but available mid-session.',
-  async handler(ctx) {
-    const { out } = ctx;
+  summary: 'View or edit configuration — interactive settings menu on a TTY',
+  usage: '/config [view | set <key> <value>]',
+  hint: 'Browse and edit config mid-session in an arrow-key settings menu. `/config view` prints the resolved configuration; `/config set <key> <value>` sets one agent-tier key. Changes apply on the next restart — same store as `afk config`.',
+  async handler(ctx, args) {
+    const a = args.trim();
 
-    const modelRaw = env.AFK_MODEL ?? env.CLAUDE_MODEL;
-    const model = modelRaw ?? 'sonnet';
-    const provider = providerForModel(modelRaw);
-
-    const anthropicApiKey = env.ANTHROPIC_API_KEY || env.CLAUDE_CODE_OAUTH_TOKEN;
-    const openaiKey = env.OPENAI_API_KEY || env.CODEX_API_KEY;
-    const apiKey = provider === 'anthropic' ? anthropicApiKey : openaiKey;
-
-    out.line();
-    out.line(palette.bold('Configuration'));
-    out.line(divider());
-
-    out.line(`  model       ${palette.info(modelRaw ? model : `${model} (default)`)}`);
-    out.line(`  provider    ${palette.plan(provider)}`);
-
-    if (provider === 'anthropic') {
-      const keyStatus = apiKey
-        ? palette.success('✓ set  (ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN)')
-        : palette.warning('⚠ not set — subprocess falls back to OAuth / keychain');
-      out.line(`  api key     ${keyStatus}`);
-    } else {
-      const openaiSource = env.OPENAI_API_KEY ? 'OPENAI_API_KEY' : 'CODEX_API_KEY';
-      const keyStatus = apiKey
-        ? palette.success(`✓ set  (${openaiSource})`)
-        : palette.warning('⚠ not set — falling back to `codex login` state');
-      out.line(`  api key     ${keyStatus}`);
+    if (a === 'view') {
+      renderConfigView(ctx.out);
+      return 'continue';
+    }
+    if (a === 'set' || a.startsWith('set ')) {
+      return handleConfigSet(ctx, a === 'set' ? '' : a.slice(4));
+    }
+    if (a.length > 0 && a !== 'edit' && a !== 'menu') {
+      ctx.out.warn(`Unknown argument: ${a}  (usage: /config [view | set <key> <value>])`);
+      renderConfigView(ctx.out);
+      return 'continue';
     }
 
-    out.line(
-      `  thinking    ${env.AFK_THINKING ? palette.info(env.AFK_THINKING) : palette.dim('(unset — SDK default)')}`,
-    );
-    out.line(
-      `  effort      ${env.AFK_EFFORT ? palette.info(env.AFK_EFFORT) : palette.dim('(unset — SDK default)')}`,
-    );
-    const permissionMode = resolveCliPermissionMode();
-    out.line(
-      `  perm mode   ${permissionMode === 'bypassPermissions'
-        ? palette.warning(`${permissionMode} (bypass — containment off)`)
-        : palette.info(`${permissionMode} (containment on)`)}`,
-    );
-
-    out.line();
-    out.line(palette.bold('Environment variables'));
-    out.line(divider());
-
-    const envRows: Array<[string, string]> = [
-      ['AFK_MODEL', env.AFK_MODEL ?? palette.dim('unset')],
-      ['CLAUDE_MODEL', env.CLAUDE_MODEL ?? palette.dim('unset')],
-      ['ANTHROPIC_API_KEY', env.ANTHROPIC_API_KEY ? palette.success('set') : palette.dim('unset')],
-      ['CLAUDE_CODE_OAUTH_TOKEN', env.CLAUDE_CODE_OAUTH_TOKEN ? palette.success('set') : palette.dim('unset')],
-      ['OPENAI_API_KEY', env.OPENAI_API_KEY ? palette.success('set') : palette.dim('unset')],
-      ['CODEX_API_KEY', env.CODEX_API_KEY ? palette.success('set') : palette.dim('unset')],
-      ['AFK_THINKING', env.AFK_THINKING ?? palette.dim('unset')],
-      ['AFK_EFFORT', env.AFK_EFFORT ?? palette.dim('unset')],
-    ];
-    const keyWidth = Math.max(...envRows.map(([k]) => k.length)) + 2;
-    for (const [k, v] of envRows) {
-      out.line(`  ${palette.meta(k.padEnd(keyWidth))} ${v}`);
+    // Interactive menu (no args, or `edit`/`menu`). Requires a live compositor;
+    // non-TTY surfaces (Telegram, daemon, tests) fall back to the read-only view.
+    const compositor = ctx.getCompositor?.() ?? null;
+    if (!compositor) {
+      renderConfigView(ctx.out);
+      ctx.out.line(
+        palette.dim('  Interactive editing needs a TTY. Use `/config set <key> <value>` or `afk config`.'),
+      );
+      return 'continue';
     }
-    out.line();
 
+    await runConfigMenu(overlaysFromCompositor(compositor), defaultIo());
     return 'continue';
   },
 };

--- a/src/cli/slash/commands/info.test.ts
+++ b/src/cli/slash/commands/info.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the /model slash command's interactive picker + text-arg paths.
+ *
+ * The picker is exercised against a FakeHost that captures the PickerController
+ * installed by runPicker and drives it synchronously (mirrors picker.test.ts).
+ * No real compositor and no network — setModel is a spy.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { infoCommands } from './info.js';
+import type { SlashContext, SessionStats } from '../types.js';
+import type { PickerController, TerminalCompositor } from '../../terminal-compositor.js';
+
+class FakeHost {
+  controller: PickerController | null = null;
+  enterCalls = 0;
+  exitCalls = 0;
+
+  enterPickerMode(controller: PickerController): void {
+    this.enterCalls += 1;
+    this.controller = controller;
+  }
+  exitPickerMode(): void {
+    this.exitCalls += 1;
+    this.controller = null;
+  }
+  repaintPicker(): void {}
+
+  press(name: string): void {
+    if (!this.controller) throw new Error('FakeHost: no controller installed');
+    this.controller.onKey(undefined, { name, ctrl: false, shift: false });
+  }
+}
+
+function makeStats(): SessionStats {
+  return {
+    totalTurns: 0,
+    totalCostUsd: 0,
+    totalTokens: 0,
+    totalDurationMs: 0,
+    sessionStartTime: Date.now(),
+    turnCosts: [],
+    turnTokens: [],
+    turns: [],
+    model: 'sonnet',
+    permissionMode: 'default',
+  };
+}
+
+function makeCtx(withCompositor: boolean): {
+  ctx: SlashContext;
+  lines: string[];
+  setModel: ReturnType<typeof vi.fn>;
+  host: FakeHost;
+} {
+  const lines: string[] = [];
+  const setModel = vi.fn(async () => {});
+  const host = new FakeHost();
+  const ctx = {
+    session: {
+      current: { setModel, sessionId: undefined } as unknown as SlashContext['session']['current'],
+    } as SlashContext['session'],
+    stats: makeStats(),
+    out: {
+      line: (t = ''): void => { lines.push(t); },
+      raw: (t: string): void => { lines.push(t); },
+      success: (t: string): void => { lines.push(`SUCCESS:${t}`); },
+      info: (t: string): void => { lines.push(`INFO:${t}`); },
+      warn: (t: string): void => { lines.push(`WARN:${t}`); },
+      error: (t: string): void => { lines.push(`ERROR:${t}`); },
+    },
+    ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
+    ...(withCompositor ? { getCompositor: (): TerminalCompositor => host as unknown as TerminalCompositor } : {}),
+  } as unknown as SlashContext;
+  return { ctx, lines, setModel, host };
+}
+
+const modelCmd = infoCommands.find((c) => c.name === '/model')!;
+
+describe('/model', () => {
+  it('bare /model opens a picker and switches to the selected model (TTY)', async () => {
+    const { ctx, setModel, host } = makeCtx(true);
+    // current = sonnet (index 6); two downs → haiku (index 8).
+    const p = modelCmd.handler(ctx, '');
+    host.press('down');
+    host.press('down');
+    host.press('return');
+    await p;
+
+    expect(host.enterCalls).toBe(1);
+    expect(host.exitCalls).toBe(1);
+    expect(setModel).toHaveBeenCalledTimes(1);
+    expect(setModel).toHaveBeenCalledWith('haiku');
+  });
+
+  it('cancelling the picker (Esc) switches nothing', async () => {
+    const { ctx, setModel, host } = makeCtx(true);
+    const p = modelCmd.handler(ctx, '');
+    host.press('escape');
+    await p;
+
+    expect(host.exitCalls).toBe(1);
+    expect(setModel).not.toHaveBeenCalled();
+  });
+
+  it('/model <name> switches without opening a picker', async () => {
+    const { ctx, setModel, host } = makeCtx(true);
+    await modelCmd.handler(ctx, 'haiku');
+
+    expect(setModel).toHaveBeenCalledWith('haiku');
+    expect(host.enterCalls).toBe(0);
+  });
+
+  it('bare /model on a non-TTY surface prints the current model (no picker)', async () => {
+    const { ctx, lines, setModel } = makeCtx(false);
+    await modelCmd.handler(ctx, '');
+
+    expect(setModel).not.toHaveBeenCalled();
+    expect(lines.join('\n')).toMatch(/Current model/);
+  });
+});

--- a/src/cli/slash/commands/info.ts
+++ b/src/cli/slash/commands/info.ts
@@ -13,7 +13,8 @@ import { contextLimitFor, MODEL_CONTEXT_LIMITS } from '../../model-limits.js';
 import { renderDebugBanner } from '../../debug-banner.js';
 import { providerForModel } from '../../../agent/providers/index.js';
 import { slotForInput, unconfiguredSlotError } from '../../../agent/session/model-slots.js';
-import type { SlashCommand } from '../types.js';
+import { runPicker } from '../../render/picker.js';
+import type { SlashCommand, SlashContext } from '../types.js';
 import type { AgentModelInput } from '../../../agent/types.js';
 
 /** Display hint only — not used for validation. Full model IDs (org/model) are also accepted. */
@@ -192,45 +193,76 @@ const historyCmd: SlashCommand = {
   },
 };
 
+/**
+ * Validate + apply a model target (mid-session, live). Shared by the text-arg
+ * path (`/model <name>`) and the interactive picker (bare `/model` on a TTY).
+ * Writes all user-facing output via ctx.out; never throws.
+ */
+async function switchModel(ctx: SlashContext, target: string): Promise<void> {
+  // Accept slot tier names / configured custom names, known Claude aliases,
+  // OR full HF-style org/model ids (routed openai-compatible). Bare unknown
+  // strings (e.g. typos) are rejected — they'd silently fall through to
+  // anthropic-direct and produce an unhelpful API error at turn time.
+  const isKnownAlias = MODEL_ALIASES_HINT.includes(target as (typeof MODEL_ALIASES_HINT)[number]);
+  const isSlotName = slotForInput(target) !== undefined;
+  const isHFStyleId = providerForModel(target) === 'openai-compatible';
+  if (!isKnownAlias && !isSlotName && !isHFStyleId) {
+    ctx.out.warn(`Unknown model: ${target}. Aliases: ${MODEL_ALIASES_HINT.join(', ')}  (or org/model for local/OpenAI-compatible)`);
+    return;
+  }
+  // Reject an unconfigured capability tier (e.g. an empty `local` slot) at the
+  // point of selection — otherwise the empty id reaches the provider as an
+  // opaque empty-model error or a silent cloud fallback.
+  const unconfigured = unconfiguredSlotError(target);
+  if (unconfigured) {
+    ctx.out.warn(unconfigured);
+    return;
+  }
+  try {
+    await ctx.session.current.setModel(target as AgentModelInput);
+    ctx.stats.model = target as AgentModelInput;
+    ctx.ui.repaintStatusLine();
+    ctx.out.success(`Model switched to ${palette.brand(target)}`);
+  } catch (err) {
+    ctx.out.error(`Failed to switch model: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 const modelCmd: SlashCommand = {
   name: '/model',
-  usage: '/model <local|small|medium|large|opus|sonnet|haiku|fable|org/model>',
+  usage: '/model [local|small|medium|large|opus|sonnet|haiku|fable|org/model]',
   summary: 'Switch the active model mid-session',
-  hint: 'Switch the capability tier (local/small/medium/large — or your configured names) or pass a full model id. Upgrade to large for a hard problem, downshift to small for cheap iteration — context carries over. Also accepts HuggingFace-style ids (e.g. mlx-community/Qwen3-30B-A3B-4bit).',
+  hint: 'Switch the capability tier (local/small/medium/large — or your configured names) or pass a full model id. Bare `/model` opens an interactive picker on a TTY. Upgrade to large for a hard problem, downshift to small for cheap iteration — context carries over. Also accepts HuggingFace-style ids (e.g. mlx-community/Qwen3-30B-A3B-4bit).',
   async handler(ctx, args) {
     const target = args.trim().toLowerCase();
-    if (!target) {
-      ctx.out.info(`Current model: ${palette.brand(ctx.stats.model)}`);
-      ctx.out.line(palette.dim(`  Aliases: ${MODEL_ALIASES_HINT.join(', ')}  (or any org/model HF id)`));
+    if (target) {
+      await switchModel(ctx, target);
       return 'continue';
     }
-    // Accept slot tier names / configured custom names, known Claude aliases,
-    // OR full HF-style org/model ids (routed openai-compatible). Bare unknown
-    // strings (e.g. typos) are rejected — they'd silently fall through to
-    // anthropic-direct and produce an unhelpful API error at turn time.
-    const isKnownAlias = MODEL_ALIASES_HINT.includes(target as (typeof MODEL_ALIASES_HINT)[number]);
-    const isSlotName = slotForInput(target) !== undefined;
-    const isHFStyleId = providerForModel(target) === 'openai-compatible';
-    if (!isKnownAlias && !isSlotName && !isHFStyleId) {
-      ctx.out.warn(`Unknown model: ${target}. Aliases: ${MODEL_ALIASES_HINT.join(', ')}  (or org/model for local/OpenAI-compatible)`);
+
+    // No argument: open an arrow-key picker on a TTY; fall back to the current
+    // model + alias list on non-TTY surfaces (Telegram, daemon, tests).
+    const compositor = ctx.getCompositor?.() ?? null;
+    if (compositor) {
+      const options = [...MODEL_ALIASES_HINT];
+      const currentIdx = options.indexOf(ctx.stats.model as (typeof MODEL_ALIASES_HINT)[number]);
+      const picked = await runPicker(compositor, {
+        header: [
+          palette.bold('Switch model'),
+          palette.dim(`current: ${ctx.stats.model}`),
+          palette.dim('or type a full id: /model <org/model>'),
+          '',
+        ],
+        options,
+        initialIndex: currentIdx >= 0 ? currentIdx : 0,
+      });
+      const choice = picked?.[0];
+      if (choice) await switchModel(ctx, choice);
       return 'continue';
     }
-    // Reject an unconfigured capability tier (e.g. an empty `local` slot) at the
-    // point of selection — otherwise the empty id reaches the provider as an
-    // opaque empty-model error or a silent cloud fallback.
-    const unconfigured = unconfiguredSlotError(target);
-    if (unconfigured) {
-      ctx.out.warn(unconfigured);
-      return 'continue';
-    }
-    try {
-      await ctx.session.current.setModel(target as AgentModelInput);
-      ctx.stats.model = target as AgentModelInput;
-      ctx.ui.repaintStatusLine();
-      ctx.out.success(`Model switched to ${palette.brand(target)}`);
-    } catch (err) {
-      ctx.out.error(`Failed to switch model: ${err instanceof Error ? err.message : String(err)}`);
-    }
+
+    ctx.out.info(`Current model: ${palette.brand(ctx.stats.model)}`);
+    ctx.out.line(palette.dim(`  Aliases: ${MODEL_ALIASES_HINT.join(', ')}  (or any org/model HF id)`));
     return 'continue';
   },
 };

--- a/src/cli/slash/commands/resume.test.ts
+++ b/src/cli/slash/commands/resume.test.ts
@@ -258,6 +258,56 @@ describe('/resume interactive picker', () => {
     expect(requestResumeSpy).not.toHaveBeenCalled();
   });
 
+  it('resumes the highlighted row when two sessions share an identical label', async () => {
+    // Two sessions with the same name/model/turns/origin saved in the same
+    // minute render an IDENTICAL pickLabel. runPicker returns the selected
+    // *label* string; without unique options the label→row mapping (indexOf)
+    // resolves both rows to the first match, so selecting row 2 would wrongly
+    // resume session 1. The uniquePickLabels disambiguator must keep each row
+    // distinct so the highlighted session is the one resumed.
+    const save = (sdkId: string): void => {
+      const s = createSessionStats('sonnet');
+      s.cwd = '/proj/dup';
+      recordTurn(s, 'work', 'done', {
+        sessionId: sdkId,
+        totalCostUsd: 0.01,
+        durationMs: 10,
+        usage: { input_tokens: 5, output_tokens: 5 },
+      });
+      s.name = 'dup-name';
+      saveSession(s);
+    };
+    save('sdk-dup-1');
+    save('sdk-dup-2');
+
+    const resumeRow = async (downPresses: number): Promise<string | undefined> => {
+      let captured: ResolvedResumeTarget | undefined;
+      const { ctx } = makeCtx('sdk-live', async (t) => {
+        captured = t;
+        return { ok: true as const, sessionId: 'new' };
+      });
+      ctx.stats.cwd = '/proj/dup';
+      const host = new FakeHost();
+      ctx.getCompositor = (): TerminalCompositor => host as unknown as TerminalCompositor;
+      const p = resumeCmd.handler(ctx, '');
+      for (let i = 0; i < downPresses; i++) host.press('down');
+      host.press('return');
+      await p;
+      return captured?.resumeId;
+    };
+
+    const row1 = await resumeRow(0);
+    const row2 = await resumeRow(1);
+
+    expect(row1).toBeDefined();
+    expect(row2).toBeDefined();
+    // The collision bug resumed the first match for BOTH rows — distinct rows
+    // must resolve to distinct sessions.
+    expect(row1).not.toBe(row2);
+    expect(['sdk-dup-1', 'sdk-dup-2']).toContain(row1);
+    expect(['sdk-dup-1', 'sdk-dup-2']).toContain(row2);
+  });
+
   it('bare /resume on a non-TTY surface lists sessions without resuming', async () => {
     const stats = createSessionStats('sonnet');
     stats.cwd = '/proj/txt';

--- a/src/cli/slash/commands/resume.test.ts
+++ b/src/cli/slash/commands/resume.test.ts
@@ -21,6 +21,28 @@ import { createSessionStats, recordTurn } from '../session-stats.js';
 import type { SlashContext, SessionStats } from '../types.js';
 import type { ResolvedResumeTarget } from '../../resume-session.js';
 import type { ResumeSwapResult } from '../../commands/interactive/shared.js';
+import type { PickerController, TerminalCompositor } from '../../terminal-compositor.js';
+
+class FakeHost {
+  controller: PickerController | null = null;
+  enterCalls = 0;
+  exitCalls = 0;
+
+  enterPickerMode(controller: PickerController): void {
+    this.enterCalls += 1;
+    this.controller = controller;
+  }
+  exitPickerMode(): void {
+    this.exitCalls += 1;
+    this.controller = null;
+  }
+  repaintPicker(): void {}
+
+  press(name: string): void {
+    if (!this.controller) throw new Error('FakeHost: no controller installed');
+    this.controller.onKey(undefined, { name, ctrl: false, shift: false });
+  }
+}
 
 let tmpHome: string;
 let originalHome: string | undefined;
@@ -182,5 +204,77 @@ describe('/resume — no-arg CWD filtering', () => {
     await resumeCmd.handler(ctx, sidecarId);
 
     expect(requestResumeSpy).toHaveBeenCalledOnce();
+  });
+});
+
+describe('/resume interactive picker', () => {
+  it('bare /resume opens a picker and resumes the selected session (TTY)', async () => {
+    const stats = createSessionStats('sonnet');
+    stats.cwd = '/proj/pick';
+    recordTurn(stats, 'pick work', 'done', {
+      sessionId: 'sdk-pick',
+      totalCostUsd: 0.01,
+      durationMs: 10,
+      usage: { input_tokens: 5, output_tokens: 5 },
+    });
+    stats.name = 'session-pick';
+    saveSession(stats);
+
+    const { ctx, requestResumeSpy } = makeCtx('sdk-live');
+    ctx.stats.cwd = '/proj/pick';
+    const host = new FakeHost();
+    ctx.getCompositor = (): TerminalCompositor => host as unknown as TerminalCompositor;
+
+    const p = resumeCmd.handler(ctx, '');
+    host.press('return'); // select the first (only) entry
+    await p;
+
+    expect(host.enterCalls).toBe(1);
+    expect(host.exitCalls).toBe(1);
+    expect(requestResumeSpy).toHaveBeenCalledOnce();
+  });
+
+  it('cancelling the picker (Esc) resumes nothing', async () => {
+    const stats = createSessionStats('sonnet');
+    stats.cwd = '/proj/pick2';
+    recordTurn(stats, 'pick work', 'done', {
+      sessionId: 'sdk-pick2',
+      totalCostUsd: 0.01,
+      durationMs: 10,
+      usage: { input_tokens: 5, output_tokens: 5 },
+    });
+    stats.name = 'session-pick2';
+    saveSession(stats);
+
+    const { ctx, requestResumeSpy } = makeCtx('sdk-live');
+    ctx.stats.cwd = '/proj/pick2';
+    const host = new FakeHost();
+    ctx.getCompositor = (): TerminalCompositor => host as unknown as TerminalCompositor;
+
+    const p = resumeCmd.handler(ctx, '');
+    host.press('escape');
+    await p;
+
+    expect(requestResumeSpy).not.toHaveBeenCalled();
+  });
+
+  it('bare /resume on a non-TTY surface lists sessions without resuming', async () => {
+    const stats = createSessionStats('sonnet');
+    stats.cwd = '/proj/txt';
+    recordTurn(stats, 'txt work', 'done', {
+      sessionId: 'sdk-txt',
+      totalCostUsd: 0.01,
+      durationMs: 10,
+      usage: { input_tokens: 5, output_tokens: 5 },
+    });
+    stats.name = 'session-txt';
+    saveSession(stats);
+
+    const { ctx, lines, requestResumeSpy } = makeCtx(undefined);
+    ctx.stats.cwd = '/proj/txt';
+    await resumeCmd.handler(ctx, '');
+
+    expect(lines.join('\n')).toContain('session-txt');
+    expect(requestResumeSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/slash/commands/resume.ts
+++ b/src/cli/slash/commands/resume.ts
@@ -2,12 +2,15 @@
  * /resume [id] — list saved sessions, or perform a mid-session swap to a
  * stored one.
  *
- * With no argument: lists recent saves and their metadata.
  * With an id: atomically swaps the current AgentSession for the stored one
  * (tears down the outgoing session, builds a fresh one from the stored
  * config, mutates the shared SessionRef, reseeds stats, and prints a
  * "Resuming…" banner). Falls back to printing the launch command if the
  * requestResume capability is not available in the current context.
+ *
+ * With no argument: opens an arrow-key picker of recent saves on a TTY (the
+ * hint's long-promised interactive path); on non-TTY surfaces (Telegram,
+ * daemon, tests) it prints the read-only table and asks for `/resume <name>`.
  */
 
 import { palette } from '../../palette.js';
@@ -15,8 +18,11 @@ import { divider } from '../../render.js';
 import { findSession, listSessions } from '../../session-store.js';
 import { formatCost } from '../../format-utils.js';
 import { formatResumeCommand } from '../../resume-command.js';
+import { runPicker } from '../../render/picker.js';
 import type { ResolvedResumeTarget } from '../../resume-session.js';
-import type { SlashCommand } from '../types.js';
+import type { SlashCommand, SlashContext } from '../types.js';
+
+type SessionEntry = ReturnType<typeof listSessions>[number];
 
 function fmtWhen(ts: number): string {
   if (typeof ts !== 'number' || !Number.isFinite(ts)) return '      —       ';
@@ -34,6 +40,73 @@ function resolveFromFound(found: NonNullable<ReturnType<typeof findSession>>): R
   };
 }
 
+/** Plain (un-coloured) one-line label for a session, used as a picker option. */
+function pickLabel(e: SessionEntry): string {
+  const model = e.model.padEnd(7);
+  const turns = `${e.totalTurns} turn${e.totalTurns === 1 ? '' : 's'}`.padEnd(9);
+  const origin = e.source === 'telegram' ? 'tg' : '  ';
+  return `${fmtWhen(e.savedAt)}  ${model}  ${turns}  ${origin}  ${e.name ?? e.id}`;
+}
+
+/**
+ * Resume a resolved session: guard against resuming into the live session,
+ * then swap via requestResume, or (when that capability is absent) print the
+ * launch command. Writes all output via ctx.out; never throws.
+ */
+async function resumeFound(
+  ctx: SlashContext,
+  found: NonNullable<ReturnType<typeof findSession>>,
+): Promise<void> {
+  // Prefer the human name over the UUID in all user-facing messages.
+  const label = found.data.name ?? found.id;
+
+  if (typeof ctx.requestResume === 'function') {
+    // Guard against resuming into the live session (PR #355 C2). The swap would
+    // otherwise tear down and rebuild the current session from the last on-disk
+    // snapshot, silently dropping any turn data accumulated since the last
+    // /save. Match on the SDK session id when available (canonical), falling
+    // back to the saved file id.
+    // External constraint: this comparison is the only barrier between /resume
+    // and unintended data loss for users who select their current session.
+    const currentSdkId = ctx.session.current.sessionId;
+    const targetSdkId = found.data.sessionId;
+    const isSameSession =
+      (currentSdkId !== undefined && targetSdkId !== undefined && currentSdkId === targetSdkId) ||
+      (currentSdkId !== undefined && currentSdkId === found.id);
+    if (isSameSession) {
+      ctx.out.warn(`Already on session ${label}.`);
+      return;
+    }
+
+    ctx.out.info(`Resuming session ${label} …`);
+    const result = await ctx.requestResume(resolveFromFound(found));
+    if (result.ok) {
+      ctx.out.success(`Resumed ${label}  (sdk id: ${result.sessionId})`);
+    } else {
+      ctx.out.warn(result.reason);
+    }
+    return;
+  }
+
+  // Fallback: requestResume not available (e.g. daemon, Telegram).
+  // Print the launch command so the user knows how to resume manually.
+  const loaded = found.data;
+  const resumeTarget = loaded.name ?? loaded.sessionId ?? found.id;
+  ctx.out.line();
+  ctx.out.line(palette.bold(`Session ${loaded.name ?? found.id}`));
+  ctx.out.line(divider());
+  ctx.out.line(`  name        ${palette.brand(loaded.name ?? '—')}`);
+  ctx.out.line(`  source      ${palette.brand(loaded.source ?? 'cli')}`);
+  ctx.out.line(`  model       ${palette.brand(loaded.model)}`);
+  ctx.out.line(`  turns       ${palette.meta(String(loaded.totalTurns))}`);
+  ctx.out.line(`  cost        ${palette.meta(formatCost(loaded.totalCostUsd))}`);
+  ctx.out.line(`  sdk id      ${palette.meta(loaded.sessionId ?? '—')}`);
+  ctx.out.line();
+  ctx.out.line(palette.dim('  Resume with:'));
+  ctx.out.line(palette.brand(`    ${formatResumeCommand(resumeTarget, loaded.model)}`));
+  ctx.out.line();
+}
+
 export const resumeCmd: SlashCommand = {
   name: '/resume',
   usage: '/resume [id]',
@@ -47,56 +120,7 @@ export const resumeCmd: SlashCommand = {
         ctx.out.warn(`No saved session: ${target}`);
         return 'continue';
       }
-      // Prefer the human name over the UUID in all user-facing messages.
-      const label = found.data.name ?? found.id;
-
-      if (typeof ctx.requestResume === 'function') {
-        // Guard against resuming into the live session (PR #355 C2).
-        // The 12-step swap would otherwise tear down and rebuild the current
-        // session from the last on-disk snapshot, silently dropping any turn
-        // data accumulated since the last /save. Match on the SDK session id
-        // when available (canonical), falling back to the saved file id.
-        // External constraint: this comparison is the only barrier between
-        // /resume and unintended data loss for users who type their current
-        // session id by accident.
-        const currentSdkId = ctx.session.current.sessionId;
-        const targetSdkId = found.data.sessionId;
-        const isSameSession =
-          (currentSdkId !== undefined && targetSdkId !== undefined && currentSdkId === targetSdkId) ||
-          (currentSdkId !== undefined && currentSdkId === found.id);
-        if (isSameSession) {
-          ctx.out.warn(`Already on session ${label}.`);
-          return 'continue';
-        }
-
-        // Mid-session swap path.
-        ctx.out.info(`Resuming session ${label} …`);
-        const result = await ctx.requestResume(resolveFromFound(found));
-        if (result.ok) {
-          ctx.out.success(`Resumed ${label}  (sdk id: ${result.sessionId})`);
-        } else {
-          ctx.out.warn(result.reason);
-        }
-        return 'continue';
-      }
-
-      // Fallback: requestResume not available (e.g. daemon, Telegram).
-      // Print the launch command so the user knows how to resume manually.
-      const loaded = found.data;
-      const resumeTarget = loaded.name ?? loaded.sessionId ?? found.id;
-      ctx.out.line();
-      ctx.out.line(palette.bold(`Session ${loaded.name ?? found.id}`));
-      ctx.out.line(divider());
-      ctx.out.line(`  name        ${palette.brand(loaded.name ?? '—')}`);
-      ctx.out.line(`  source      ${palette.brand(loaded.source ?? 'cli')}`);
-      ctx.out.line(`  model       ${palette.brand(loaded.model)}`);
-      ctx.out.line(`  turns       ${palette.meta(String(loaded.totalTurns))}`);
-      ctx.out.line(`  cost        ${palette.meta(formatCost(loaded.totalCostUsd))}`);
-      ctx.out.line(`  sdk id      ${palette.meta(loaded.sessionId ?? '—')}`);
-      ctx.out.line();
-      ctx.out.line(palette.dim('  Resume with:'));
-      ctx.out.line(palette.brand(`    ${formatResumeCommand(resumeTarget, loaded.model)}`));
-      ctx.out.line();
+      await resumeFound(ctx, found);
       return 'continue';
     }
 
@@ -109,6 +133,34 @@ export const resumeCmd: SlashCommand = {
     const localEntries = entries.filter((e) => e.cwd === currentCwd);
     const isFiltered = localEntries.length > 0;
     const displayEntries = isFiltered ? localEntries : entries;
+
+    // Interactive picker on a TTY: select a session to resume it directly.
+    const compositor = ctx.getCompositor?.() ?? null;
+    if (compositor) {
+      const shown = displayEntries.slice(0, 20);
+      const options = shown.map(pickLabel);
+      const picked = await runPicker(compositor, {
+        header: [
+          palette.bold(`Resume a session  (${shown.length})`),
+          palette.dim(isFiltered ? 'saved in this directory' : 'all directories (none saved here)'),
+          '',
+        ],
+        options,
+      });
+      const choice = picked?.[0];
+      if (choice) {
+        const idx = options.indexOf(choice);
+        const entry = idx >= 0 ? shown[idx] : undefined;
+        if (entry) {
+          const found = findSession(entry.id);
+          if (found) await resumeFound(ctx, found);
+          else ctx.out.warn(`No saved session: ${entry.name ?? entry.id}`);
+        }
+      }
+      return 'continue';
+    }
+
+    // Non-TTY fallback: read-only table + the manual resume hint.
     const header = isFiltered
       ? palette.bold(`Saved sessions  (${displayEntries.length})`)
       : palette.bold(`Saved sessions — all (none in this directory)`);

--- a/src/cli/slash/commands/resume.ts
+++ b/src/cli/slash/commands/resume.ts
@@ -49,6 +49,29 @@ function pickLabel(e: SessionEntry): string {
 }
 
 /**
+ * Picker option strings for a set of entries, guaranteed unique.
+ *
+ * Invariant: `runPicker` resolves with the selected *label string*, and the
+ * caller maps it back to a row via `options.indexOf(label)`. Two entries can
+ * render an identical `pickLabel` — duplicate session names are allowed and
+ * `fmtWhen` truncates the timestamp to the minute — in which case `indexOf`
+ * would resolve BOTH highlighted rows to the first match and resume the wrong
+ * session. Appending the (unique) sidecar id to any colliding label keeps
+ * every option distinct so the label→row mapping stays exact.
+ */
+function uniquePickLabels(entries: readonly SessionEntry[]): string[] {
+  const counts = new Map<string, number>();
+  for (const e of entries) {
+    const l = pickLabel(e);
+    counts.set(l, (counts.get(l) ?? 0) + 1);
+  }
+  return entries.map((e) => {
+    const l = pickLabel(e);
+    return (counts.get(l) ?? 0) > 1 ? `${l}  ${palette.dim(e.id)}` : l;
+  });
+}
+
+/**
  * Resume a resolved session: guard against resuming into the live session,
  * then swap via requestResume, or (when that capability is absent) print the
  * launch command. Writes all output via ctx.out; never throws.
@@ -138,7 +161,7 @@ export const resumeCmd: SlashCommand = {
     const compositor = ctx.getCompositor?.() ?? null;
     if (compositor) {
       const shown = displayEntries.slice(0, 20);
-      const options = shown.map(pickLabel);
+      const options = uniquePickLabels(shown);
       const picked = await runPicker(compositor, {
         header: [
           palette.bold(`Resume a session  (${shown.length})`),


### PR DESCRIPTION
## Summary

Make the interactive REPL feel more "app-like" — a real in-session settings menu and arrow-key pickers for the highest-traffic commands — by **reusing the existing overlay primitives** rather than adopting a TUI framework (Ink/blessed). No new stdin ownership, no render-layer rewrite.

## What changed

- **`/config` — interactive settings menu** (new `src/cli/render/config-menu.ts`). Bare `/config` on a TTY opens a `category → key → value` navigator composed from `runPicker` + `runTextInput`. Writes go through the existing `setConfigValue` engine and echo the restart note (config is cached at load). Adds scriptable `/config view` and `/config set <key> <value>` fast-paths; non-TTY surfaces (Telegram/daemon) fall back to the read-only dump.
- **`/model` — picker.** Bare `/model` on a TTY opens an arrow-key picker over the tier aliases (cursor pre-placed on the current model); selection switches live mid-session. `/model <id>` (alias / slot / HF id) and non-TTY behaviour unchanged.
- **`/resume` — picker.** Bare `/resume` on a TTY opens a picker of recent saves; selecting one resumes it directly (the same-session data-loss guard is preserved). This finally delivers the behaviour the command's own hint already advertised. `/resume <id>` and the non-TTY table unchanged.
- **Slash palette — fuzzy matching.** `filterSlashCandidates` now ranks prefix matches first, then appends subsequence matches (`/cfg` → `/config`), case-insensitive. The common prefix path is unchanged.

## Approach & key invariants

All three menus are additional consumers of `TerminalCompositor.enterPickerMode` (joining `runPicker` and `runTextInput`). Overlays are opened via awaited, **never-nested** calls, so the single-overlay guard and the single-consumer-stdin invariant (PR #511) hold. Each command keeps its text-arg and non-TTY fallbacks.

## Notable decisions

- **Secrets are never editable in the menu** — config keys are only `agent`/`human` tier, never `secret` (secrets are env-only), so nothing routes a credential into scrollback.
- **Human-tier keys require an explicit in-menu confirm** before writing (mirrors `afk config set --allow`); `/config` is a human surface (the agent cannot type slash commands), so this does not widen the `config_set` agent-tool path.
- **Restart semantics surfaced honestly** — every config write echoes "effective on the next restart"; `/model` / `/resume` act live.

## Testing

- Full suite green: **11,215 passed / 14 skipped** (`vitest run`).
- `tsc --noEmit` (strict) clean; no new `process.env` reads and no new SDK symbols, so the env/SDK audit gates are unaffected.
- New coverage: `config-menu.test.ts` (15), `info.test.ts` (4), +6 `/config` fast-path tests, +3 `/resume` picker tests, +4 `filterSlashCandidates` tests. Interactive flows are driven via a scripted `FakePickerHost`.

## Deferred / follow-ups

- Dropdown **visual** polish (inline summaries in the `/` dropdown, framed chrome, adaptive row count) — wants a look on a real terminal; intentionally not in this PR.
- Other text-only commands that could adopt the picker later: `/thinking`, `/mcp`, `/save`, `/worktree`.

## Verification note

Menu logic is covered by unit tests + the already-tested `runPicker` / `runTextInput`, but I have **not** driven a live TTY keypress session (headless env). A ~30-second manual spin in `afk interactive` (`/config`, `/model`, `/resume`) is recommended before merge.
