### PR TITLE
fix(tools): decouple bash/grep output kill-cap from model budget; keep head+tail

### DIFF
--- a/src/agent/subagent/result.ts
+++ b/src/agent/subagent/result.ts
@@ -75,13 +75,12 @@ export interface SubagentToolResult {
   toolUseId: string;
   isError?: boolean;
   /**
-   * `true` when the tool handler reported a byte-cap overflow (e.g. bash
-   * or grep killed mid-stream because output exceeded 100KB). Reflects the
-   * structured `ToolResult.truncated` flag set by the handler — not the
-   * cosmetic 80-char display preview clip. Parent agents can use this to
-   * distinguish "subagent's bash got 100KB of legitimate output" from
-   * "subagent's bash got 100KB then was killed" without substring-scanning
-   * tool output for the `[output truncated …]` sentinel.
+   * `true` when the tool handler reduced its output to fit the model budget
+   * (e.g. bash/grep output larger than ~100KB returned as a head+tail slice,
+   * or a runaway killed at the multi-MB hard cap). Reflects the structured
+   * `ToolResult.truncated` flag set by the handler — not the cosmetic 80-char
+   * display preview clip. Parent agents use this to detect truncated tool
+   * output without substring-scanning for a sentinel.
    */
   truncated?: boolean;
   sizeBytes?: number;

--- a/src/agent/tools/handlers/_output-cap.ts
+++ b/src/agent/tools/handlers/_output-cap.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared output-capping primitives for the shell-facing tool handlers
+ * (`bash`, `grep`).
+ *
+ * Two independent thresholds — deliberately decoupled, because the single
+ * 100KB cap they replace conflated two unrelated concerns and resolved both
+ * by SIGKILLing the child process the instant output crossed 100KB:
+ *
+ *   1. {@link HARD_CAP_BYTES} — the accumulator + mid-stream-kill threshold.
+ *      Its ONLY job is to bound the in-memory JS string so a genuine runaway
+ *      producer (`yes`, an accidental `cat` of a huge binary) cannot grow a
+ *      single string past V8's ~512MB max-string-length limit and crash the
+ *      host with `RangeError: Invalid string length`. Set far above any
+ *      legitimate command's output so the mid-stream kill is a true
+ *      runaway circuit-breaker, not a routine event. 8MB leaves ~64x
+ *      headroom under the V8 ceiling even with a combined stdout+stderr
+ *      counter and several tool calls running concurrently.
+ *
+ *   2. {@link MODEL_CAP_BYTES} — the budget of output actually fed back to
+ *      the model. A soft context-cost limit, unchanged from the prior 100KB.
+ *
+ * Why this matters: the prior design killed the child at 100KB, so a verbose
+ * but legitimate command (a full `pnpm test` run, a large `git diff`, a broad
+ * grep) was terminated mid-flight — the agent never saw the real exit code
+ * and lost the *tail* of the output (head-only truncation keeps the least
+ * useful 100KB, while test/build summaries and final errors live at the END).
+ * Raising the kill threshold lets such commands run to completion; capping the
+ * model-facing view with {@link headAndTail} keeps the decisive start AND end.
+ *
+ * @module agent/tools/handlers/_output-cap
+ */
+
+/**
+ * Accumulator + mid-stream SIGKILL threshold, in bytes (8MB).
+ *
+ * The child is killed only when combined stdout+stderr crosses this — a
+ * genuine runaway. Legitimate verbose output (well under 8MB) runs to
+ * completion so the real exit code and tail survive.
+ */
+export const HARD_CAP_BYTES = 8_000_000;
+
+/**
+ * Model-facing output budget, in bytes (100KB). Output larger than this is
+ * reduced to head+tail via {@link headAndTail}; the underlying command is
+ * NOT affected. Matches the prior model-context cost.
+ */
+export const MODEL_CAP_BYTES = 100_000;
+
+/**
+ * Truncate a UTF-8 Buffer to at most `maxBytes` from the FRONT without
+ * splitting a multi-byte code point. Walks back off any trailing
+ * continuation byte (0x80–0xBF). Returns a zero-copy subarray view.
+ */
+function utf8SafeHead(buf: Buffer, maxBytes: number): Buffer {
+  if (buf.length <= maxBytes) return buf;
+  let end = maxBytes;
+  while (end > 0 && (buf[end]! & 0xc0) === 0x80) end--;
+  return buf.subarray(0, end);
+}
+
+/**
+ * Keep at most `maxBytes` from the END of a UTF-8 Buffer without splitting a
+ * multi-byte code point. Advances the start offset forward off any leading
+ * continuation byte so the retained tail begins on a code-point boundary.
+ */
+function utf8SafeTail(buf: Buffer, maxBytes: number): Buffer {
+  if (buf.length <= maxBytes) return buf;
+  let start = buf.length - maxBytes;
+  while (start < buf.length && (buf[start]! & 0xc0) === 0x80) start++;
+  return buf.subarray(start);
+}
+
+/**
+ * Reserve (bytes) held back from the byte budget for the elision marker, so
+ * the returned string still fits within `maxBytes`. The marker embeds three
+ * decimal integers (elided count + head/tail lengths); 160 bytes covers even
+ * 10-digit values plus the surrounding text.
+ */
+const MARKER_RESERVE_BYTES = 160;
+
+/**
+ * Reduce `text` to at most ~`maxBytes` UTF-8 bytes while preserving BOTH
+ * ends, joined by a one-line marker naming how many bytes were elided from
+ * the middle. Returns `text` unchanged when it already fits.
+ *
+ * The dominant large-output producers (test runners, builds, `git diff`) put
+ * the decisive signal — pass/fail counts, the final error — at the END, so
+ * head-only truncation discards exactly what the agent needs. Keeping head +
+ * tail rescues it. UTF-8 safe at both cut points.
+ */
+export function headAndTail(text: string, maxBytes: number): string {
+  const buf = Buffer.from(text, 'utf8');
+  if (buf.length <= maxBytes) return text;
+
+  const budget = Math.max(0, maxBytes - MARKER_RESERVE_BYTES);
+  const headBudget = Math.ceil(budget / 2);
+  const tailBudget = budget - headBudget;
+
+  const head = utf8SafeHead(buf, headBudget);
+  const tail = utf8SafeTail(buf, tailBudget);
+  const elided = buf.length - head.length - tail.length;
+
+  const marker = `\n\n… [${elided} bytes truncated: showing first ${head.length} + last ${tail.length} of ${buf.length}] …\n\n`;
+  return head.toString('utf8') + marker + tail.toString('utf8');
+}
+
+/**
+ * Cap arbitrary tool output for model consumption. Returns the capped
+ * `content` (head+tail when over budget) and a `truncated` flag callers plumb
+ * into `ToolResult.truncated` — the structured signal non-model consumers
+ * (subagent traces, hooks) read instead of substring-scanning `content`.
+ */
+export function capForModel(text: string): { content: string; truncated: boolean } {
+  if (Buffer.byteLength(text, 'utf8') <= MODEL_CAP_BYTES) {
+    return { content: text, truncated: false };
+  }
+  return { content: headAndTail(text, MODEL_CAP_BYTES), truncated: true };
+}
+
+/**
+ * The in-band sentinel appended to model-facing content when the mid-stream
+ * hard cap fired and the child was SIGKILL'd (i.e. the command did NOT finish
+ * — its exit code is unavailable and its true tail was never produced).
+ * Starts with `[output truncated` so existing consumers keying on that prefix
+ * still match.
+ */
+export const HARD_CAP_KILL_NOTE = `\n[output truncated — command exceeded the ${HARD_CAP_BYTES}-byte output cap and was terminated]`;

--- a/src/agent/tools/handlers/bash.test.ts
+++ b/src/agent/tools/handlers/bash.test.ts
@@ -316,7 +316,7 @@ describe('bashHandler', () => {
       expect(result.content).toContain('truncated');
     });
 
-    it('includes truncation notice when output exceeds 100KB', async () => {
+    it('includes a head+tail truncation notice when output exceeds the model cap', async () => {
       const largeLine = 'x'.repeat(105_000);
       const result = await bashHandler(
         { command: `printf "${largeLine}"` },
@@ -324,15 +324,15 @@ describe('bashHandler', () => {
       );
 
       expect(result.isError).toBeFalsy();
-      expect(result.content).toContain('[output truncated — exceeded 100KB]');
+      // The command completed well under the 8MB hard cap, so the close path
+      // reduced its output to a head+tail view with a middle elision marker.
+      expect(result.content).toContain('bytes truncated');
     });
 
     // Regression: subagents (and any caller) must be able to detect
-    // overflow without substring-scanning content. Before this flag,
-    // distinguishing "got 100KB of legitimate output" from "got 100KB then
-    // killed" required matching the sentinel string — fragile because the
-    // bash and grep sentinels differ ("exceeded 100KB" vs bare), and
-    // because handlers are free to emit content containing the literal
+    // truncation without substring-scanning content. Matching a sentinel
+    // string is fragile — the wording varies by path (head+tail elision
+    // marker vs hard-cap kill note), and handlers may emit the literal
     // string "truncated" in legitimate output (e.g. a log line about
     // database truncation). The structured flag is unambiguous.
     it('sets ToolResult.truncated=true when output exceeds 100KB', async () => {
@@ -359,78 +359,73 @@ describe('bashHandler', () => {
     });
 
     // Regression: V8 max-string-length crash (RangeError: Invalid string
-    // length). Pre-fix, `stdout += chunk.toString()` accumulated
-    // unboundedly with the 100KB cap applied only post-close. A command
-    // emitting >~512MB before exiting (`yes | head -c 600MB`, an
-    // accidental `cat` of a binary, a runaway log dump) would overflow
-    // V8's max string length synchronously inside the data callback,
-    // crashing the process. The fix adds a mid-stream byte counter that
-    // SIGKILLs the child and settles as soon as the threshold is crossed.
-    //
-    // This test proves the kill happened BEFORE the process finished —
-    // we emit 150KB of 'a', then sleep 3s, then emit 150KB of 'b'. If
-    // the kill works, we never see the 'b' chunk and the call returns
-    // well under the 3s sleep. If only the post-close cap fires, the
-    // call would wait the full sleep duration and the content would
-    // include both 'a' and 'b'.
-    it('mid-stream byte cap: kills the process before the post-output sleep (V8 overflow guard)', async () => {
+    // length). The accumulator is bounded at HARD_CAP_BYTES (8MB) and the
+    // child is SIGKILL'd the instant combined output crosses it — a
+    // genuine-runaway circuit-breaker (a `cat` of a huge binary, a runaway
+    // `yes`). This proves the mid-stream kill fires BEFORE the process
+    // finishes: we emit >8MB of 'q', then sleep 3s, then emit 'z'. If the
+    // kill works, the child is terminated during the 'q' flood (before the
+    // sleep), so we never see 'z', the call returns fast, and the hard-cap
+    // kill sentinel ("… was terminated") is present. If the guard regressed
+    // to letting the command complete, the close path would run instead —
+    // emitting the ordinary head+tail marker (no "terminated" sentinel)
+    // only after waiting out the 3s sleep. NB: 'q'/'z' are the phase markers
+    // because neither letter appears in the truncation marker text — 'b',
+    // for one, collides with the word "bytes".
+    it('mid-stream hard cap: SIGKILLs a runaway before it completes (V8 overflow guard)', async () => {
       const start = Date.now();
       const result = await bashHandler(
         {
-          // `head -c 150000 /dev/zero | tr '\0' 'a'` emits 150,000 'a's.
-          // Portable on macOS + Linux without bash brace-expansion or
-          // node/python sidecars.
+          // 9MB of 'q' crosses the 8MB hard cap; the kill fires mid-flood,
+          // before the sleep and the 'z' emission are ever reached. Portable
+          // on macOS + Linux without bash brace-expansion or sidecars.
           command:
-            "head -c 150000 /dev/zero | tr '\\0' 'a'; sleep 3; head -c 150000 /dev/zero | tr '\\0' 'b'",
-          timeout_ms: 15_000,
+            "head -c 9000000 /dev/zero | tr '\\0' 'q'; sleep 3; head -c 9000000 /dev/zero | tr '\\0' 'z'",
+          timeout_ms: 20_000,
         },
         createSignal(),
       );
       const elapsedMs = Date.now() - start;
 
       expect(result.isError).toBeFalsy();
-      expect(result.content).toContain('[output truncated — exceeded 100KB]');
+      // Hard-cap kill sentinel — ONLY the overflow-kill path emits this, so
+      // it discriminates "killed mid-flood" from "ran to completion".
+      expect(result.content).toContain('was terminated');
       // Structured truncation flag is the load-bearing signal for callers
-      // (subagent traces, hooks). The sentinel string in `content` stays
-      // for the model's in-band context — both must be set on the
-      // mid-stream kill path.
+      // (subagent traces, hooks).
       expect(result.truncated).toBe(true);
-      // Phase-1 marker must be present (we got some output before the
-      // kill).
-      expect(result.content).toContain('a');
-      // Phase-2 marker must be absent (kill fired before the post-sleep
-      // emission). If this assertion fails, the mid-stream guard didn't
-      // fire and the post-close path took over.
-      expect(result.content).not.toContain('b');
-      // Returned well before the 3s sleep would have completed. 5000ms
-      // bound gives ample headroom for slow CI without losing
-      // discrimination from a "waited for the sleep" failure mode.
-      expect(elapsedMs).toBeLessThan(5_000);
-    }, 20_000);
+      // Got some 'q' before the kill; never reached the post-sleep 'z'.
+      expect(result.content).toContain('q');
+      expect(result.content).not.toContain('z');
+      // Kill fired during the 'q' flood, before the 3s sleep elapsed.
+      // Reading 8MB off a pipe is sub-second; 3000ms cleanly separates the
+      // kill path from a "waited for the sleep" regression.
+      expect(elapsedMs).toBeLessThan(3_000);
+    }, 25_000);
 
-    // Companion test: same byte cap protects stderr accumulation. Many
+    // Companion test: the same hard cap protects stderr accumulation. Many
     // long-running commands write progress to stderr (e.g. `find /` with
     // permission errors), so a stderr-only flood must also trigger the
     // mid-stream kill.
-    it('mid-stream byte cap: protects stderr from unbounded accumulation', async () => {
+    it('mid-stream hard cap: protects stderr from unbounded accumulation', async () => {
       const start = Date.now();
       const result = await bashHandler(
         {
           command:
-            "head -c 150000 /dev/zero | tr '\\0' 'a' >&2; sleep 3; head -c 150000 /dev/zero | tr '\\0' 'b' >&2",
-          timeout_ms: 15_000,
+            "head -c 9000000 /dev/zero | tr '\\0' 'q' >&2; sleep 3; head -c 9000000 /dev/zero | tr '\\0' 'z' >&2",
+          timeout_ms: 20_000,
         },
         createSignal(),
       );
       const elapsedMs = Date.now() - start;
 
       expect(result.isError).toBeFalsy();
-      expect(result.content).toContain('[output truncated — exceeded 100KB]');
+      expect(result.content).toContain('was terminated');
       expect(result.truncated).toBe(true);
-      expect(result.content).toContain('a');
-      expect(result.content).not.toContain('b');
-      expect(elapsedMs).toBeLessThan(5_000);
-    }, 20_000);
+      expect(result.content).toContain('q');
+      expect(result.content).not.toContain('z');
+      expect(elapsedMs).toBeLessThan(3_000);
+    }, 25_000);
   });
 
   describe('edge cases', () => {

--- a/src/agent/tools/handlers/bash.ts
+++ b/src/agent/tools/handlers/bash.ts
@@ -1,12 +1,15 @@
 /**
  * Bash tool handler.
  *
- * Executes shell commands using `child_process.spawn`. Output is capped at
- * 100KB via TWO independent guards: a mid-stream byte counter that kills the
- * child via SIGKILL as soon as combined stdout+stderr cross the threshold
- * (prevents V8 max-string-length overflow when a command emits hundreds of MB
- * of output before exiting), and a post-close length cap as a safety net.
- * Respects timeout and signal-based cancellation. Strips ANSI escape sequences.
+ * Executes shell commands using `child_process.spawn`. Output is governed by
+ * TWO decoupled thresholds (see `_output-cap.ts`): the accumulator is bounded
+ * at HARD_CAP_BYTES (8MB) with a mid-stream SIGKILL only when combined
+ * stdout+stderr cross it — a genuine-runaway circuit-breaker that keeps a
+ * single JS string under V8's ~512MB limit — while the model-facing view is
+ * reduced to head+tail at MODEL_CAP_BYTES (100KB). Legitimate verbose commands
+ * (test runs, builds, large diffs) therefore run to completion, so the real
+ * exit code and the output tail (where summaries live) survive. Respects
+ * timeout and signal-based cancellation. Strips ANSI escape sequences.
  *
  * @module agent/tools/handlers/bash
  */
@@ -17,6 +20,7 @@ import { appendRoutingDecision } from '../../routing-telemetry.js';
 import { detectTestResult } from './test-runner-detector.js';
 import { stripEscapeSequences } from '../../../utils/terminal-sanitize.js';
 import { describeSpawnCwdError, isSpawnEnoent } from '../../../utils/spawn-cwd-error.js';
+import { HARD_CAP_BYTES, MODEL_CAP_BYTES, headAndTail, capForModel, HARD_CAP_KILL_NOTE } from './_output-cap.js';
 
 /**
  * Input shape for the bash tool (validated at runtime).
@@ -170,25 +174,18 @@ export function createBashHandler(
     let stdout = '';
     let stderr = '';
 
-    // Mid-stream byte cap. Without this, `stdout += chunk.toString()`
-    // / `stderr += chunk.toString()` accumulate unboundedly: a command
-    // that emits >~512MB before exiting (`yes | head -c 600MB`,
-    // accidental `cat` of a binary, recursive log dump) overflows V8's
-    // max string length and throws `RangeError: Invalid string length`
-    // synchronously inside this data callback — escaping every try/catch
-    // because the throw originates inside Node's Socket.emit →
-    // Readable.push chain. The 120s timeout does NOT save us: the crash
-    // is byte-driven, not time-driven, and `yes | head -c 600MB`
-    // completes well under 120s. The post-close cap does NOT save us
-    // either: `close` never fires when the throw aborts the read
-    // pipeline. So we count bytes here and kill+settle as soon as the
-    // cap is crossed. SIGKILL (not SIGTERM) so the child cannot flush
-    // more output during termination.
-    //
-    // External constraint: V8 max string length (~512MB on x64). The
-    // 100KB cap matches the post-close cap so behavior is consistent
-    // regardless of which path fires.
-    const MAX_OUTPUT_BYTES = 100_000;
+    // Mid-stream hard cap. Without an accumulator bound, `stdout += ...`
+    // / `stderr += ...` grow unboundedly: a command emitting >~512MB before
+    // exiting (`yes | head -c 600MB`, accidental `cat` of a binary, recursive
+    // log dump) overflows V8's max string length and throws `RangeError:
+    // Invalid string length` synchronously inside this data callback —
+    // escaping every try/catch because the throw originates inside Node's
+    // Socket.emit → Readable.push chain, and neither the 120s timeout (crash
+    // is byte-driven) nor the post-close cap (`close` never fires once the
+    // throw aborts the read pipeline) can save us. So we bound the string at
+    // HARD_CAP_BYTES and SIGKILL only when it is crossed — a genuine-runaway
+    // circuit-breaker, NOT a routine truncation. Everyday verbose output stays
+    // far below 8MB and runs to completion; only true floods are killed.
     let totalBytes = 0;
     let overflowKilled = false;
 
@@ -198,9 +195,9 @@ export function createBashHandler(
       // Check overflowKilled first so only the first caller settles.
       if (overflowKilled) return;
       if (resolved) return;
-      if (totalBytes < MAX_OUTPUT_BYTES) return;
+      if (totalBytes < HARD_CAP_BYTES) return;
       overflowKilled = true;
-      // P1: structured log so operators can observe overflow frequency in
+      // P1: structured log so operators can observe runaway kills in
       // production without grepping for RangeError crash traces.
       console.warn(
         `[bash] overflow kill: stream=${stream} totalBytes=${totalBytes} command="${command}"`,
@@ -218,35 +215,24 @@ export function createBashHandler(
         stream,
       });
       proc.kill('SIGKILL');
-      let combined = (stdout + stderr).trimEnd();
-      combined = stripEscapeSequences(combined);
-      // Test-runner detection runs on the truncated buffer (we cannot
-      // wait for more data — the child is being killed). If the result
-      // marker is in the first ~100KB it will still be picked up; if it
-      // is past the cap it is unrecoverable, which is the same boundary
-      // as any other 100KB-truncated command.
+      const combined = stripEscapeSequences((stdout + stderr).trimEnd());
+      // Test-runner detection runs on the (up to 8MB) buffer we captured
+      // before the kill — the true tail past 8MB is unrecoverable.
       const testResult = detectTestResult(combined) ?? undefined;
-      // The process was SIGKILL'd because output exceeded the byte cap —
-      // we always truncate here. Slice the display string to the byte cap
-      // (the primary guard already capped incoming buffers, so this is
-      // belt-and-suspenders for the string-layer), then append the sentinel
-      // unconditionally so the model sees the in-band signal. The
-      // structured `truncated: true` flag below is the parallel signal for
-      // non-model consumers (subagent traces, hooks, caller code) — they
-      // should not need to substring-scan `content` for the sentinel.
-      if (combined.length > MAX_OUTPUT_BYTES) {
-        combined = combined.slice(0, MAX_OUTPUT_BYTES);
-      }
-      combined += '\n[output truncated — exceeded 100KB]';
-      settle({ content: combined, truncated: true, ...(testResult !== undefined ? { testResult } : {}) });
+      // The child was SIGKILL'd for exceeding the hard cap. Give the model a
+      // head+tail view of what we captured plus the kill sentinel; the
+      // structured `truncated: true` flag is the parallel signal for non-model
+      // consumers (subagent traces, hooks) — they should not substring-scan.
+      const content = headAndTail(combined, MODEL_CAP_BYTES) + HARD_CAP_KILL_NOTE;
+      settle({ content, truncated: true, ...(testResult !== undefined ? { testResult } : {}) });
     }
 
     proc.stdout!.on('data', (chunk: Buffer) => {
       // H1 + M1: slice at the Buffer layer BEFORE .toString() so a single
-      // oversized chunk (>= MAX_OUTPUT_BYTES) never allocates a full V8
+      // oversized chunk (>= HARD_CAP_BYTES) never allocates a full V8
       // string. Remaining budget is computed in bytes (not UTF-16 code
       // units) so truncation always lands on a valid byte boundary.
-      const remaining = MAX_OUTPUT_BYTES - totalBytes;
+      const remaining = HARD_CAP_BYTES - totalBytes;
       const safe = chunk.length <= remaining ? chunk : chunk.subarray(0, Math.max(0, remaining));
       totalBytes += safe.length;
       stdout += safe.toString('utf8');
@@ -255,7 +241,7 @@ export function createBashHandler(
 
     proc.stderr!.on('data', (chunk: Buffer) => {
       // H1 + M1: same Buffer-layer guard as stdout handler above.
-      const remaining = MAX_OUTPUT_BYTES - totalBytes;
+      const remaining = HARD_CAP_BYTES - totalBytes;
       const safe = chunk.length <= remaining ? chunk : chunk.subarray(0, Math.max(0, remaining));
       totalBytes += safe.length;
       stderr += safe.toString('utf8');
@@ -293,10 +279,13 @@ export function createBashHandler(
 
       if (code !== null && code !== 0) {
         // Non-zero exit: name the failure mode and include collected output.
-        const detail = stderr.trimEnd() || stdout.trimEnd();
+        // The detail may be up to HARD_CAP_BYTES (8MB) now that the
+        // accumulator bound was raised, so cap it to the model budget.
+        const capped = capForModel(stderr.trimEnd() || stdout.trimEnd());
         settle({
-          content: `Command exited with code ${code}${detail ? '\n' + detail : ''}`,
+          content: `Command exited with code ${code}${capped.content ? '\n' + capped.content : ''}`,
           isError: true,
+          ...(capped.truncated ? { truncated: true } : {}),
         });
         return;
       }
@@ -305,25 +294,19 @@ export function createBashHandler(
       // round-trip; nothing more to do.
       if (overflowKilled) return;
 
-      let combined = (stdout + stderr).trimEnd();
-      combined = stripEscapeSequences(combined);
+      const combined = stripEscapeSequences((stdout + stderr).trimEnd());
 
       // Detect test-runner results BEFORE truncation so patterns near the
       // end of long output are not missed. External constraint: detection
-      // runs on the full ANSI-stripped output; the 100KB cap applied below
-      // is for model-context cost only — it must not silently hide test
-      // summaries from the structured result.
+      // runs on the full ANSI-stripped output (up to 8MB); the model-budget
+      // head+tail applied below is for context cost only — it must not
+      // silently hide test summaries from the structured result.
       const testResult = detectTestResult(combined) ?? undefined;
 
-      let truncatedHere = false;
-      if (combined.length > MAX_OUTPUT_BYTES) {
-        combined = combined.slice(0, MAX_OUTPUT_BYTES) + '\n[output truncated — exceeded 100KB]';
-        truncatedHere = true;
-      }
-
+      const capped = capForModel(combined);
       settle({
-        content: combined,
-        ...(truncatedHere ? { truncated: true } : {}),
+        content: capped.content,
+        ...(capped.truncated ? { truncated: true } : {}),
         ...(testResult !== undefined ? { testResult } : {}),
       });
     });

--- a/src/agent/tools/handlers/grep.test.ts
+++ b/src/agent/tools/handlers/grep.test.ts
@@ -264,7 +264,9 @@ describe('grepHandler', () => {
 
   describe('output truncation', () => {
     it('truncates output at 100KB', async () => {
-      // Create a file with many matching lines to exceed 100KB
+      // Create a file with many matching lines to exceed 100KB (but well
+      // under the 8MB hard cap, so grep completes and the close path reduces
+      // the output to a head+tail view).
       const largeLine = 'hello ' + 'x'.repeat(1000);
       const lines = Array(120).fill(largeLine).join('\n');
       writeFileSync(join(tempDir, 'large.txt'), lines);
@@ -276,14 +278,14 @@ describe('grepHandler', () => {
 
       expect(result.isError).toBeFalsy();
       expect(result.content.length).toBeLessThanOrEqual(100_000 + 50);
-      expect(result.content).toContain('[output truncated]');
+      expect(result.content).toContain('bytes truncated');
     });
 
-    // Regression: subagents must distinguish "got 100KB of legitimate
-    // matches" from "got 100KB then killed" via a structured flag, not by
-    // substring-scanning content. The bash and grep sentinels diverge
-    // ("exceeded 100KB" vs bare) so any caller doing exact-match string
-    // detection would silently miss one tool's truncated output.
+    // Regression: subagents must distinguish "got a head+tail slice of
+    // legitimate matches" from any other state via the structured `truncated`
+    // flag, not by substring-scanning content. Sentinel wording varies by
+    // path (head+tail elision marker vs hard-cap kill note), so any caller
+    // doing exact-match string detection would silently miss cases.
     it('sets ToolResult.truncated=true when output exceeds 100KB', async () => {
       const largeLine = 'hello ' + 'x'.repeat(1000);
       const lines = Array(120).fill(largeLine).join('\n');
@@ -313,21 +315,15 @@ describe('grepHandler', () => {
     });
 
     // Regression: V8 max-string-length crash (RangeError: Invalid string
-    // length). Pre-fix, `stdout += chunk.toString()` accumulated
-    // unboundedly with the 100KB cap applied only post-close. A grep
-    // emitting >~512MB of matches would overflow V8's max string length
-    // synchronously inside the data callback, crashing the process. The
-    // fix adds a mid-stream byte counter that kills the child and
-    // settles as soon as the threshold is crossed.
-    //
-    // We exercise the guard with ~10MB of matching output — large
-    // enough that the mid-stream cap fires before the close handler
-    // would, while keeping the test fast. The behavior is identical
-    // either way (truncated to 100KB with the truncation marker), but
-    // crossing the threshold this far above 100KB makes it implausible
-    // for the close handler to be the path that fired.
+    // length). The accumulator is bounded at HARD_CAP_BYTES (8MB) and the
+    // child is SIGKILL'd when combined output crosses it — a genuine-runaway
+    // guard (an unconstrained recursive search across `node_modules`). We
+    // exercise it with >8MB of matching output so the mid-stream kill fires
+    // and emits the hard-cap sentinel; the model-facing view is reduced to a
+    // ~100KB head+tail regardless.
     it('handles matching output orders of magnitude above the cap (V8 overflow guard)', async () => {
-      // ~10MB of matching content: 10,000 lines × ~1010 bytes/line.
+      // ~10MB of matching content: 10,000 lines × ~1010 bytes/line — well
+      // past the 8MB hard cap.
       const largeLine = 'hello ' + 'x'.repeat(1000);
       const lines = Array(10_000).fill(largeLine).join('\n');
       writeFileSync(join(tempDir, 'huge.txt'), lines);
@@ -340,42 +336,37 @@ describe('grepHandler', () => {
       const elapsedMs = Date.now() - start;
 
       expect(result.isError).toBeFalsy();
-      expect(result.content.length).toBeLessThanOrEqual(100_000 + 50);
-      expect(result.content).toContain('[output truncated]');
+      // Head+tail model view (≤100KB) plus the short hard-cap kill sentinel.
+      expect(result.content.length).toBeLessThanOrEqual(100_000 + 200);
+      expect(result.content).toContain('was terminated');
       // Structured flag is the load-bearing signal for non-model
       // consumers (subagent traces, hooks). Sentinel string remains for
       // the model's in-band context — both must be set on the mid-stream
       // kill path.
       expect(result.truncated).toBe(true);
-      // Tightened from 15_000 to 5_000: should complete well under 5s
-      // once the mid-stream kill fires (streaming 10MB naturally takes
-      // longer; 5s is generous for CI load but discriminates from no-kill).
+      // Reading 8MB off the pipe is sub-second; 5s is generous for CI load
+      // but discriminates from a "ran the full scan to completion" path.
       expect(elapsedMs).toBeLessThan(5_000);
     }, 30_000);
 
-    // Companion proof-of-kill test: two ~150KB files where either alone
-    // overflows the 100KB cap. If the mid-stream guard fires correctly,
-    // grep is killed after exhausting one file's matches into stdout — the
-    // other file is never opened. If the guard failed and only the
-    // post-close cap fired, grep would have run to completion and both
-    // files' content would have been emitted to stdout.
+    // Companion proof-of-kill test: two files, each on its own larger than
+    // the 8MB hard cap. The mid-stream kill fires while grep is still
+    // emitting matches from whichever file it opened first, so that file's
+    // content is (partially) captured and the other is never reached.
     //
     // F3: assertions are order-agnostic. `grep -r` traversal order is
     // filesystem-dependent — BSD grep on macOS uses readdir() inode order,
-    // not lexical (verified: `ls -i` shows inode order ≠ alphabetical
-    // when files are created in non-creation order, and `grep -rn`
-    // returns matches in inode order). So we cannot rely on first.txt
-    // being read before second.txt. Instead we assert "exactly one of
-    // {hello a, hello b} appears" — preserves the discriminating signal
-    // (kill fired between files) without depending on which file grep
-    // happened to open first.
-    it('mid-stream byte cap: kills grep after one file but before the other (V8 overflow guard)', async () => {
+    // not lexical — so we cannot rely on first.txt being read before
+    // second.txt. Instead we assert "exactly one of {hello a, hello b}
+    // appears" — preserving the discriminating signal (kill fired
+    // mid-traversal) without depending on which file grep opened first.
+    it('mid-stream hard cap: kills grep mid-traversal, capturing only one file (V8 overflow guard)', async () => {
       const aLine = 'hello a' + 'x'.repeat(993); // ~1001 bytes/line
-      const firstContent = Array(150).fill(aLine).join('\n'); // ~150KB
+      const firstContent = Array(9000).fill(aLine).join('\n'); // ~9MB > 8MB cap
       writeFileSync(join(tempDir, 'first.txt'), firstContent);
 
       const bLine = 'hello b' + 'x'.repeat(993);
-      const secondContent = Array(150).fill(bLine).join('\n'); // ~150KB
+      const secondContent = Array(9000).fill(bLine).join('\n'); // ~9MB
       writeFileSync(join(tempDir, 'second.txt'), secondContent);
 
       const start = Date.now();
@@ -386,23 +377,20 @@ describe('grepHandler', () => {
       const elapsedMs = Date.now() - start;
 
       expect(result.isError).toBeFalsy();
-      expect(result.content).toContain('[output truncated]');
+      expect(result.content).toContain('was terminated');
       expect(result.truncated).toBe(true);
 
       const hasA = result.content.includes('hello a');
       const hasB = result.content.includes('hello b');
-      // Exactly one file's content survived in the truncated output —
-      // proves the kill fired between file boundaries. If both were
-      // present, grep read both files to completion and the mid-stream
-      // guard never fired. If neither was present, something else broke
-      // (the truncation marker assertion above would also fail in that case).
+      // Exactly one file's content survived — the kill fired before grep
+      // finished the first file and opened the second. If both appear, the
+      // mid-stream guard never fired; if neither, the sentinel assertion
+      // above would also have failed.
       expect(hasA || hasB).toBe(true);
       expect(hasA && hasB).toBe(false);
-      // Timing proof: a full scan of both 150KB files takes measurably
-      // longer. 2000ms gives ample headroom for slow CI without losing
-      // discrimination from a "waited for full grep exit" failure mode.
-      expect(elapsedMs).toBeLessThan(2_000);
-    }, 20_000);
+      // Killed after ~8MB, well before a full scan of both 9MB files.
+      expect(elapsedMs).toBeLessThan(5_000);
+    }, 30_000);
   });
 
   describe('input validation', () => {

--- a/src/agent/tools/handlers/grep.ts
+++ b/src/agent/tools/handlers/grep.ts
@@ -9,11 +9,13 @@
  * tool must not silently reinterpret it. To keep the BRE `|`-is-literal footgun
  * from masquerading as proven absence, the no-match path appends a self-correcting
  * ERE hint when the pattern contains an unescaped `|` (see the `close` handler).
- * Respects signal-based cancellation and truncates output at 100KB. The 100KB
- * cap is enforced TWICE: a mid-stream byte counter kills the child as soon as
- * the threshold is crossed (prevents V8 max-string-length overflow on
- * pathologically large output), and the post-close handler re-applies the same
- * length cap as a safety net. Strips ANSI escape sequences.
+ * Respects signal-based cancellation. Output is governed by two decoupled
+ * thresholds (see `_output-cap.ts`): the accumulator is bounded at
+ * HARD_CAP_BYTES (8MB) with a mid-stream SIGKILL only when it is crossed — a
+ * genuine-runaway guard against V8 max-string-length overflow — while the
+ * model-facing view is reduced to head+tail at MODEL_CAP_BYTES (100KB). A
+ * broad-but-legitimate search therefore runs to completion. Strips ANSI escape
+ * sequences.
  *
  * @module agent/tools/handlers/grep
  */
@@ -24,6 +26,7 @@ import { appendRoutingDecision } from '../../routing-telemetry.js';
 import { resolveAndContain } from './_cwd-utils.js';
 import { stripEscapeSequences } from '../../../utils/terminal-sanitize.js';
 import { describeSpawnCwdError, isSpawnEnoent } from '../../../utils/spawn-cwd-error.js';
+import { HARD_CAP_BYTES, MODEL_CAP_BYTES, headAndTail, capForModel, HARD_CAP_KILL_NOTE } from './_output-cap.js';
 
 /**
  * Input shape for the grep tool (validated at runtime).
@@ -167,22 +170,16 @@ export function createGrepHandler(cwd?: string): ToolHandler {
     let stdout = '';
     let stderr = '';
 
-    // Mid-stream byte cap. Without this, `stdout += chunk.toString()`
-    // accumulates unboundedly: a grep that emits >~512MB of stdout
-    // (e.g. an unconstrained recursive search across `node_modules`)
-    // overflows V8's max string length and throws `RangeError: Invalid
-    // string length` synchronously inside this data callback — escaping
-    // every try/catch because the throw originates inside Node's
-    // Socket.emit → Readable.push chain. The post-close 100KB cap
-    // cannot save us because `close` never fires when the throw aborts
-    // the read pipeline. So we count bytes here and kill+settle as soon
-    // as the cap is crossed. SIGKILL (not SIGTERM) so the child cannot
-    // flush more output during termination.
-    //
-    // External constraint: V8 max string length (~512MB on x64). The
-    // 100KB cap is identical to the post-close cap so behavior is
-    // consistent regardless of which path fires.
-    const MAX_OUTPUT_BYTES = 100_000;
+    // Mid-stream hard cap. Without an accumulator bound, `stdout += ...`
+    // grows unboundedly: a grep emitting >~512MB of stdout (an unconstrained
+    // recursive search across `node_modules`) overflows V8's max string
+    // length and throws `RangeError: Invalid string length` synchronously
+    // inside this data callback — escaping every try/catch because the throw
+    // originates inside Node's Socket.emit → Readable.push chain, and the
+    // post-close cap cannot save us (`close` never fires once the throw
+    // aborts the read pipeline). So we bound the string at HARD_CAP_BYTES and
+    // SIGKILL only when it is crossed — a genuine-runaway circuit-breaker.
+    // Broad-but-legitimate searches (well under 8MB) run to completion.
     let totalBytes = 0;
     let overflowKilled = false;
 
@@ -192,9 +189,9 @@ export function createGrepHandler(cwd?: string): ToolHandler {
       // Check overflowKilled FIRST so only the first caller settles.
       if (overflowKilled) return;
       if (resolved) return;
-      if (totalBytes < MAX_OUTPUT_BYTES) return;
+      if (totalBytes < HARD_CAP_BYTES) return;
       overflowKilled = true;
-      // P1: structured log so operators can observe overflow frequency in
+      // P1: structured log so operators can observe runaway kills in
       // production without grepping for RangeError crash traces.
       console.warn(
         `[grep] overflow kill: stream=${stream} totalBytes=${totalBytes} pattern=${pattern} path=${path}`,
@@ -213,37 +210,22 @@ export function createGrepHandler(cwd?: string): ToolHandler {
       });
       proc.kill('SIGKILL');
       // F1 + F2: combine stdout + stderr (mirror bash.ts) and hard-code
-      // isError: false. The earlier H2/M2 design picked one stream based
-      // on which crossed the threshold first, which (a) silently discarded
-      // valid stdout matches when stderr happened to drive overflow, and
-      // (b) set isError on a byte-cap event, conflating "overflow fired"
-      // with "grep reported an error" (exit code 2) — the post-close path
-      // keeps those distinct. The triggering stream is preserved in the
-      // P1 console.warn above, so operators still see which stream filled
-      // the buffer. Callers detect overflow via the structured
-      // `truncated: true` flag below (model-facing sentinel kept in
-      // `content` for the in-band signal the model sees).
-      let combined = (stdout + stderr).trimEnd();
-      combined = stripEscapeSequences(combined);
-      // The process was SIGKILL'd because output exceeded the byte cap —
-      // we always truncate here. Slice the display string to the byte cap
-      // (the primary guard already capped incoming buffers, so this is
-      // belt-and-suspenders for the string-layer), then append the sentinel
-      // unconditionally so the model sees the in-band signal. Non-model
-      // consumers read `truncated: true` below instead.
-      if (combined.length > MAX_OUTPUT_BYTES) {
-        combined = combined.slice(0, MAX_OUTPUT_BYTES);
-      }
-      combined += '\n[output truncated]';
-      settle({ content: combined, truncated: true });
+      // isError: false — a byte-cap event is distinct from a grep error
+      // (exit code 2), which the post-close path keeps separate. The child
+      // was SIGKILL'd for exceeding the hard cap; give the model a head+tail
+      // view plus the kill sentinel, and signal non-model consumers via the
+      // structured `truncated: true` flag.
+      const combined = stripEscapeSequences((stdout + stderr).trimEnd());
+      const content = headAndTail(combined, MODEL_CAP_BYTES) + HARD_CAP_KILL_NOTE;
+      settle({ content, truncated: true });
     }
 
     proc.stdout!.on('data', (chunk: Buffer) => {
       // H1 + M1: slice at the Buffer layer BEFORE .toString() so a single
-      // oversized chunk (>= MAX_OUTPUT_BYTES) never allocates a full V8
+      // oversized chunk (>= HARD_CAP_BYTES) never allocates a full V8
       // string. Remaining budget is computed in bytes (not UTF-16 code
       // units) so truncation always lands on a valid byte boundary.
-      const remaining = MAX_OUTPUT_BYTES - totalBytes;
+      const remaining = HARD_CAP_BYTES - totalBytes;
       const safe = chunk.length <= remaining ? chunk : chunk.subarray(0, Math.max(0, remaining));
       totalBytes += safe.length;
       stdout += safe.toString('utf8');
@@ -252,7 +234,7 @@ export function createGrepHandler(cwd?: string): ToolHandler {
 
     proc.stderr!.on('data', (chunk: Buffer) => {
       // H1 + M1: same Buffer-layer guard as stdout handler above.
-      const remaining = MAX_OUTPUT_BYTES - totalBytes;
+      const remaining = HARD_CAP_BYTES - totalBytes;
       const safe = chunk.length <= remaining ? chunk : chunk.subarray(0, Math.max(0, remaining));
       totalBytes += safe.length;
       stderr += safe.toString('utf8');
@@ -294,20 +276,20 @@ export function createGrepHandler(cwd?: string): ToolHandler {
       }
 
       if (code === 2) {
-        settle({ content: `grep error: ${stderr.trim()}`, isError: true });
+        // stderr may accumulate up to HARD_CAP_BYTES (e.g. `-r` across a tree
+        // with many unreadable files), so cap it to the model budget.
+        const capped = capForModel(stderr.trim());
+        settle({
+          content: `grep error: ${capped.content}`,
+          isError: true,
+          ...(capped.truncated ? { truncated: true } : {}),
+        });
         return;
       }
 
-      let combined = stdout.trimEnd();
-      combined = stripEscapeSequences(combined);
-
-      let truncatedHere = false;
-      if (combined.length > MAX_OUTPUT_BYTES) {
-        combined = combined.slice(0, MAX_OUTPUT_BYTES) + '\n[output truncated]';
-        truncatedHere = true;
-      }
-
-      settle({ content: combined, ...(truncatedHere ? { truncated: true } : {}) });
+      const combined = stripEscapeSequences(stdout.trimEnd());
+      const capped = capForModel(combined);
+      settle({ content: capped.content, ...(capped.truncated ? { truncated: true } : {}) });
     });
 
     proc.on('error', (err) => {

--- a/src/agent/tools/handlers/overflow-telemetry.test.ts
+++ b/src/agent/tools/handlers/overflow-telemetry.test.ts
@@ -2,9 +2,9 @@
  * Tool-overflow telemetry tests.
  *
  * Asserts that the `tool.overflow_kill` event is emitted to
- * routing-decisions.jsonl when bash or grep hit the 100KB cap and SIGKILL the
- * child process. Mocks `routing-telemetry` to capture calls without touching
- * the real ~/.afk file.
+ * routing-decisions.jsonl when bash or grep cross the 8MB hard cap and SIGKILL
+ * the child process. Mocks `routing-telemetry` to capture calls without
+ * touching the real ~/.afk file.
  *
  * Privacy boundary (audit §G.4/G.5): tests assert that payloads do NOT
  * contain the grep pattern, search path, or shell command — only the
@@ -67,7 +67,7 @@ describe('tool.overflow_kill telemetry — grep', () => {
 
     // Sanity: the overflow path actually fired (otherwise telemetry isn't
     // expected to be emitted either).
-    expect(result.content).toContain('[output truncated]');
+    expect(result.content).toContain('was terminated');
 
     const evt = findEvent('tool.overflow_kill');
     expect(evt).toBeDefined();
@@ -91,7 +91,7 @@ describe('tool.overflow_kill telemetry — grep', () => {
       { pattern: secretPattern, path: tempDir },
       createSignal(),
     );
-    expect(result.content).toContain('[output truncated]');
+    expect(result.content).toContain('was terminated');
 
     const serialized = JSON.stringify(appendRoutingDecision.mock.calls);
     expect(serialized).not.toContain(secretPattern);
@@ -119,12 +119,13 @@ describe('tool.overflow_kill telemetry — bash', () => {
     appendRoutingDecision.mockClear();
   });
 
-  it('emits tool.overflow_kill with operational fields when bash crosses 100KB', async () => {
-    // Fast generator: head -c 600000 from /dev/zero is well over 100KB and
-    // exits within seconds. Pipe through tr to make the bytes printable so
-    // the buffer accumulation path is identical to a real noisy command.
+  it('emits tool.overflow_kill with operational fields when bash crosses the hard cap', async () => {
+    // Fast generator: head -c 9000000 from /dev/zero crosses the 8MB hard
+    // cap and exits within seconds. Pipe through tr to make the bytes
+    // printable so the buffer accumulation path is identical to a real
+    // noisy command.
     const result = await bashHandler(
-      { command: 'head -c 600000 /dev/zero | tr "\\0" "x"', timeout_ms: 30_000 },
+      { command: 'head -c 9000000 /dev/zero | tr "\\0" "x"', timeout_ms: 30_000 },
       createSignal(),
     );
 
@@ -142,7 +143,7 @@ describe('tool.overflow_kill telemetry — bash', () => {
     // Distinctive marker we can scan for in the serialized mock calls.
     const result = await bashHandler(
       {
-        command: 'echo SECRET-BASH-MARKER-7 && head -c 600000 /dev/zero | tr "\\0" "x"',
+        command: 'echo SECRET-BASH-MARKER-7 && head -c 9000000 /dev/zero | tr "\\0" "x"',
         timeout_ms: 30_000,
       },
       createSignal(),

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -18,7 +18,7 @@ export const bashTool: AnthropicToolDef = {
     'Execute a shell command and return its stdout and stderr. ' +
     'Use for running programs, installing packages, git operations, and any task that requires a shell. ' +
     'Commands run in the user\'s default shell. Long-running commands should use timeout_ms. ' +
-    'Output is capped at ~100KB; excess is truncated with a notice. ' +
+    'Output is capped to a ~100KB head+tail view (the start and end are kept, the middle elided with a notice), so the command still runs to completion and you keep the real exit code and the tail (test/build summaries, final errors). For the full body of a verbose command, filter it (`| tail -n`, `--quiet`, narrower flags) or redirect to a file and read slices. Commands emitting extreme output (>8MB) are terminated. ' +
     'For reading or writing files — especially anything sensitive — prefer the typed file tools ' +
     '(read_file, write_file, edit_file): they support per-call user approval, and interpreter ' +
     'one-liners (python -c, node -e, sh -c, ...) that reference credential paths (SSH keys, cloud ' +
@@ -161,7 +161,9 @@ export const grepTool: AnthropicToolDef = {
     'Runs `grep -rn` in basic-regex (BRE) mode by default, where `|` is a LITERAL pipe — not ' +
     'alternation; set extended: true for extended-regex (ERE) alternation. A no-match result on a ' +
     'pattern containing `|` is often a false negative — re-read the returned hint. Output is capped ' +
-    'to prevent overflow. Use for finding symbols, strings, or patterns across the codebase.',
+    'to a ~100KB head+tail view; if a search is truncated, narrow it (a more specific pattern, an ' +
+    '`include` glob, or a subdirectory `path`) rather than re-running the same broad query. ' +
+    'Use for finding symbols, strings, or patterns across the codebase.',
   input_schema: {
     type: 'object',
     properties: {

--- a/src/agent/tools/system-prompt.ts
+++ b/src/agent/tools/system-prompt.ts
@@ -18,7 +18,7 @@ export const TOOL_SYSTEM_PROMPT_BASE = `You have access to tools for working wit
 - Quote file paths that contain spaces with double quotes.
 - Do not run destructive shell commands (rm -rf, git reset --hard, etc.) unless the user explicitly asks.
 - Use glob and grep to discover files before reading individual files.
-- When bash output is very long, it may be truncated. If you need the full output, redirect to a file and read it.
+- When bash/grep output is long it is capped to a head+tail view (start and end kept, middle elided) — the command still completes, so you keep the exit code and the tail. If you need the elided middle, filter the command (\`| tail -n\`, \`--quiet\`, a narrower grep pattern/path) or redirect to a file and read slices; don't just re-run the same broad command.
 - Use absolute paths for file operations.
 - Prefer \`agent\` (and \`skill\`) for multi-file investigation, verification, parallel hypotheses, and any work that would otherwise consume large amounts of inline context. The main session is the coordinator; subagents are the investigators.`;
 


### PR DESCRIPTION
## Problem

`bash`, `grep`, and the `!`-passthrough streamer share a single hardcoded **100KB output cap that `SIGKILL`s the child process** the instant combined stdout+stderr crosses it.

Telemetry (`~/.afk/agent-framework/routing-decisions.jsonl`) shows this firing **853 times** since 2026-05-26 (ongoing daily; a spike of 75 during a SWE-bench run), split **440 `bash` / 413 `grep`**, every one at exactly `total_bytes: 100000`. The dominant triggers are verbose but *legitimate* commands — full `pnpm test` runs, `tsc`, large `git diff`, broad `grep`. Killing them mid-flight means the agent:

- never sees the command's **real exit code**,
- loses the output **tail** — head-only truncation keeps the least useful 100KB, while test/build summaries and final errors live at the *end*,
- may leave side effects half-done.

## Root cause

The 100KB cap conflates two unrelated concerns and resolves both by killing the process:

1. **V8 crash safety** — a runaway producer (`yes`, `cat` of a huge binary) must not grow a single JS string past V8's ~512MB `RangeError: Invalid string length` limit. *Hard* limit.
2. **Model-context cost** — don't feed the model a huge blob. *Soft*, tunable limit.

The `SIGKILL` is **not required for V8 safety**: the accumulator string is already clamped at the Buffer layer (`bash.ts:249-252`, `grep.ts:246-249`), so it can never grow past the cap whether or not the child is killed. Killing is a redundant, destructive over-reaction that discards the command's real result for zero safety benefit.

*(This root cause survived an adversarial devil's-advocate review; the winning fix below is the pragmatist alternative — the original proposal to "drain to 64MB" was dropped because it reintroduced event-loop starvation under grep's 8-way concurrency and a wedged-child-to-timeout regression.)*

## Fix

New `src/agent/tools/handlers/_output-cap.ts` splits the one cap into two decoupled thresholds:

- **`HARD_CAP_BYTES` (8MB)** — accumulator bound + mid-stream `SIGKILL` threshold. A genuine-runaway circuit-breaker, far above any legitimate output, so verbose commands now **run to completion** and keep their real exit code. Only true floods (>8MB) are killed.
- **`MODEL_CAP_BYTES` (100KB)** — model-facing budget, reduced to **head + tail** (first ~50KB + last ~50KB, UTF-8 safe) via `headAndTail()` so end-of-output summaries survive.
- `capForModel()` is applied to **every** model-facing settle path in `bash.ts`/`grep.ts` (overflow-kill, non-zero exit, success) — required because the raised accumulator bound means any path could now hold up to 8MB.
- Strengthened the bash/grep **tool descriptions** + tool **system-prompt** to name the head+tail behavior and steer toward `| tail`, `--quiet`, redirect, and narrower grep instead of re-running the same broad command (the near-free guidance lever; the prior generic hint clearly wasn't landing given 853 events).

### Behavior change
A command emitting >100KB now runs to completion (bounded by `timeout_ms`) instead of dying early, so tool latency reflects the command's real runtime. The `tool.overflow_kill` telemetry event now fires only for genuine >8MB runaways.

### Deliberately out of scope
The `!`-passthrough streamer (`src/agent/shell-jobs/streamer.ts`) shares the same design but contributes **0** of the 853 events (user-initiated, output already shown live on screen). Left for a consistency follow-up to keep this PR's blast radius on the actual problem.

## Tests
- Rewrote the mid-stream-kill tests in `bash.test.ts` / `grep.test.ts` / `overflow-telemetry.test.ts` for the 8MB threshold and the new head+tail / kill-note markers.
- Phase markers switched from `a`/`b` to `q`/`z` because `b` collides with the word "**b**ytes" in the elision marker.
- **Full suite green: 619 files, 11214 passed, 14 skipped.** `pnpm lint` (tsc --noEmit) clean.
