### PR TITLE
fix(cli): label subagent tool-call tallies "N tool calls" not "N tools"

### DIFF
--- a/src/agent/providers/anthropic-direct.test.ts
+++ b/src/agent/providers/anthropic-direct.test.ts
@@ -260,6 +260,65 @@ function makeToolUseStream(
   ];
 }
 
+/**
+ * Build a stream where a SINGLE assistant turn emits multiple parallel
+ * `tool_use` blocks (distinct content-block indices), ending with
+ * stop_reason=tool_use. Models this scenario: one round batches N tool calls.
+ */
+function makeParallelToolUseStream(
+  calls: Array<{ id: string; name: string; inputJson: string }>,
+): RawMessageStreamEvent[] {
+  const events: RawMessageStreamEvent[] = [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_par',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-5',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 7,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+  ];
+  calls.forEach((call, index) => {
+    events.push(
+      {
+        type: 'content_block_start',
+        index,
+        content_block: { type: 'tool_use', id: call.id, name: call.name, input: {} },
+      } as unknown as RawMessageStreamEvent,
+      {
+        type: 'content_block_delta',
+        index,
+        delta: { type: 'input_json_delta', partial_json: call.inputJson },
+      } as unknown as RawMessageStreamEvent,
+      {
+        type: 'content_block_stop',
+        index,
+      } as unknown as RawMessageStreamEvent,
+    );
+  });
+  events.push(
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'tool_use', stop_sequence: null },
+      usage: { output_tokens: 9 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  );
+  return events;
+}
+
 // --- Tests ---
 
 describe('AnthropicDirectProvider', () => {
@@ -883,6 +942,53 @@ describe('AnthropicDirectProvider', () => {
     expect(second.progress.summary).toContain('round 2');
     expect(second.progress.summary).toContain('write_file');
     expect(second.progress.taskId).toBe(first.progress.taskId);
+  });
+
+  // Regression (PR 508 codex review, P2): a single round that batches multiple
+  // parallel tool_use blocks must report `toolUses` as the actual number of
+  // tool CALLS — not "1" (the round/iteration count). Before the fix `toolUses`
+  // carried the round counter, so 3 parallel calls in round 1 rendered as
+  // "1 tool call".
+  it('progress.toolUses reflects actual tool-call count when a round batches parallel calls', async () => {
+    let callIdx = 0;
+    messagesCreateMock.mockImplementation(() => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        // Round 1: THREE parallel tool_use blocks in a single assistant turn.
+        return fromArray(
+          makeParallelToolUseStream([
+            { id: 'toolu_a', name: 'read_file', inputJson: '{"path":"a"}' },
+            { id: 'toolu_b', name: 'read_file', inputJson: '{"path":"b"}' },
+            { id: 'toolu_c', name: 'read_file', inputJson: '{"path":"c"}' },
+          ]),
+        );
+      }
+      return fromArray(makeTextStream('Done.'));
+    });
+
+    const dispatcher: ToolDispatcher = {
+      async execute(): Promise<ToolResult> {
+        return { content: 'ok' };
+      },
+    };
+
+    const provider = new AnthropicDirectProvider({ tools: dispatcher });
+    const query = provider.query({
+      prompt: singleInput('read three files'),
+      config: { model: 'claude-sonnet-5', apiKey: 'sk-ant-api03-test' },
+    });
+    const events = await collect(query);
+
+    const progressEvents = events.filter((e) => e.type === 'progress') as Array<
+      Extract<ProviderEvent, { type: 'progress' }>
+    >;
+    // One progress event (one round), but it dispatched 3 calls.
+    expect(progressEvents.length).toBe(1);
+    const only = progressEvents[0]!;
+    // The fix: toolUses is the cumulative CALL count (3), not the round (1).
+    expect(only.progress.toolUses).toBe(3);
+    // The human-readable summary still names the ROUND, unchanged.
+    expect(only.progress.summary).toContain('round 1');
   });
 
   it('single text response emits no progress events', async () => {

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -168,6 +168,13 @@ export async function* runTurn(
   const maxIterations = resolveMaxToolIterations(input.maxToolUseIterations);
   let accumulatedUsage: ProviderUsage = { stopReason: null };
   let iterations = 0;
+  // Cumulative count of tool CALLS dispatched across the whole turn — distinct
+  // from `iterations` (the round counter). A single round can batch several
+  // parallel tool_use blocks (turnResult.toolUseBlocks is an array, dispatched
+  // at ~line 547), so rounds ≠ calls. Emitted as the progress event's
+  // `toolUses` so the CLI's formatToolCallStat renders a truthful "N tool calls"
+  // even when a round runs multiple calls (PR 508 codex review, P2).
+  let toolCallCount = 0;
   // Set once the tool-use iteration cap is reached. The loop then runs ONE
   // final "wind-down" round with tools stripped (see the params build and the
   // cap-exit block below) so the model produces a real answer from what it
@@ -538,6 +545,12 @@ export async function* runTurn(
     });
     try {
 
+    // Accumulate the cumulative tool-call tally BEFORE dispatch so the progress
+    // emit below reports calls-so-far including this round's batch. One round
+    // can carry N parallel tool_use blocks, so this advances by the block count,
+    // not by 1.
+    toolCallCount += turnResult.toolUseBlocks.length;
+
     // Build all tool calls and emit start events upfront.
     const calls: ToolCall[] = [];
     // Per-call start timestamps keyed by toolUseId so the completed
@@ -741,7 +754,11 @@ export async function* runTurn(
         summary: `round ${iterations}: ${lastToolHeadline}`,
         lastToolName: lastTool?.name,
         totalTokens: accumulatedUsage.totalTokens ?? 0,
-        toolUses: iterations,
+        // Contract: `toolUses` is the cumulative COUNT OF TOOL CALLS so far in
+        // this turn (not the round number), so downstream formatToolCallStat
+        // renders "N tool calls" truthfully even when a round batched parallel
+        // calls. The `summary` above legitimately names the ROUND — leave it.
+        toolUses: toolCallCount,
         durationMs: Date.now() - loopStartTime,
       },
       sessionId: input.ctx.sessionId,

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -1526,6 +1526,64 @@ describe('OpenAICompatibleQuery — progress events (I2)', () => {
     }
   });
 
+  // Regression (PR 508 codex review, P2): a single round that batches multiple
+  // parallel tool_calls must report `toolUses` as the actual number of tool
+  // CALLS — not "1" (the round count). Before the fix `toolUses` carried the
+  // round counter, so 2 parallel calls in round 1 rendered as "1 tool call".
+  it('progress.toolUses reflects actual tool-call count when a round batches parallel calls', async () => {
+    const { dispatcher } = makeDispatcherForPR2();
+    scriptedTurns = [
+      {
+        // Round 1: TWO parallel tool_calls (indices 0 and 1) in one turn.
+        chunks: [
+          {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    { index: 0, id: 'q1', type: 'function', function: { name: 'echo', arguments: '{"msg":"a"}' } },
+                    { index: 1, id: 'q2', type: 'function', function: { name: 'echo', arguments: '{"msg":"b"}' } },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+            usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+          },
+        ],
+      },
+      {
+        chunks: [
+          {
+            choices: [{ delta: { content: 'all done' }, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 20, completion_tokens: 2, total_tokens: 22 },
+          },
+        ],
+      },
+    ];
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'k', source: 'config', last4: 'test' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'sid',
+      promptStream: singleInput('go'),
+      config: baseConfig(),
+      toolDispatcher: dispatcher,
+    });
+    const events = await collect(q);
+    const progressEvents = events.filter((e) => e.type === 'progress');
+    // One progress event (one round), but it dispatched 2 calls.
+    expect(progressEvents).toHaveLength(1);
+    const only = progressEvents[0];
+    if (only?.type === 'progress') {
+      // The fix: toolUses is the cumulative CALL count (2), not the round (1).
+      expect(only.progress.toolUses).toBe(2);
+      // The human-readable summary still names the ROUND, unchanged.
+      expect(only.progress.summary).toContain('round 1');
+    }
+  });
+
   it('includes totalTokens from accumulated usage in progress event', async () => {
     const { dispatcher } = makeDispatcherForPR2();
     scriptedTurns = [

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -410,6 +410,14 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     // via shared/tool-loop-cap.ts so the two providers cannot drift apart.
     let capReached = false;
     let round = 0;
+    // Cumulative count of tool CALLS dispatched across the whole turn — distinct
+    // from `round`. `result.state` is a FRESH StreamState per iteration (see
+    // runIteration → createStreamState), so finalizedToolCalls(result.state)
+    // returns only THIS round's calls; a round can batch several, so we
+    // accumulate. Emitted as the progress event's `toolUses` (below) so the
+    // CLI's formatToolCallStat renders a truthful "N tool calls" (PR 508 codex
+    // review, P2).
+    let toolCallCount = 0;
 
     for (;;) {
       if (controller.signal.aborted) {
@@ -468,7 +476,12 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       round += 1;
 
       {
-        const lastCall = finalizedToolCalls(result.state).at(-1);
+        // `result.state` is per-round (fresh each runIteration), so this array
+        // is THIS round's dispatched calls. Accumulate its length into the
+        // running total — a round can batch multiple parallel calls.
+        const roundCalls = finalizedToolCalls(result.state);
+        toolCallCount += roundCalls.length;
+        const lastCall = roundCalls.at(-1);
         const lastToolName = lastCall?.name;
         // Semantic summary — mirror anthropic-direct/loop.ts: tool name +
         // most informative argument via summarizeToolInput, so the progress
@@ -493,7 +506,12 @@ export class OpenAICompatibleQuery implements ProviderQuery {
             summary: `round ${round}: ${lastToolHeadline}`,
             lastToolName,
             totalTokens: accumulatedUsage.totalTokens ?? 0,
-            toolUses: round,
+            // Contract: `toolUses` is the cumulative COUNT OF TOOL CALLS so far
+            // in this turn (not the round number), so downstream
+            // formatToolCallStat renders "N tool calls" truthfully even when a
+            // round batched parallel calls. The `summary` above legitimately
+            // names the ROUND — leave it.
+            toolUses: toolCallCount,
             durationMs: Date.now() - turnStartTime,
           },
           sessionId: this.initSessionId,

--- a/src/cli/_lib/stream-renderer-source.test.ts
+++ b/src/cli/_lib/stream-renderer-source.test.ts
@@ -25,7 +25,7 @@ describe('formatDoneSummary', () => {
     source.responseMetadata = { durationMs: 2000 } as unknown as typeof source.responseMetadata;
     source.stats.toolUses = 3;
     const summary = formatDoneSummary(source);
-    expect(summary).toMatch(/3 tools/);
+    expect(summary).toMatch(/3 tool calls/);
     expect(summary).toMatch(/2s/);
     // Wall ≈ provider, no surfacing.
     expect(summary).not.toMatch(/wall/);

--- a/src/cli/_lib/stream-renderer-source.ts
+++ b/src/cli/_lib/stream-renderer-source.ts
@@ -8,7 +8,7 @@
 
 import type { ResponseMetadata, ToolResultChunk } from '../../agent/types/message-types.js';
 import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
-import { formatDuration, formatTokens } from '../format-utils.js';
+import { formatDuration, formatTokens, formatToolCallStat } from '../format-utils.js';
 
 const ORCHESTRATOR_SOURCE_KEY = '__main__';
 
@@ -109,7 +109,7 @@ function formatDoneSummary(source: SourceState): string {
   // Reads source.stats.toolUses — the increment-only authoritative counter.
   // Never reads progressReportedToolUses (advisory only). Post-2c invariant.
   if (source.stats.toolUses) {
-    stats.push(`${source.stats.toolUses} tool${source.stats.toolUses === 1 ? '' : 's'}`);
+    stats.push(formatToolCallStat(source.stats.toolUses));
   }
   if (source.stats.tokens) stats.push(`${formatTokens(source.stats.tokens)} tok`);
   const durationMs = source.responseMetadata?.['durationMs'];

--- a/src/cli/commands/interactive/__snapshots__/tool-lane.test.ts.snap
+++ b/src/cli/commands/interactive/__snapshots__/tool-lane.test.ts.snap
@@ -18,10 +18,10 @@ exports[`Snapshot pins — tool-lane-render.ts representative outputs > scenario
 `;
 
 exports[`Snapshot pins — tool-lane-render.ts representative outputs > scenario 5 — subagent Agent entry with overflow (4 children, MAX=3) 1`] = `
-"◉ → Agent(snap-overflower) [subagent] — 4 tools
+"◉ → Agent(snap-overflower) [subagent] — 4 tool calls
 │ ├─ … +1 (1 Read)
 │ ├─ $ Bash("snap1.ts") — ✓ snap-result-1
 │ ├─ ● Grep("snap2.ts") — ✓ snap-result-2
 │ ├─ ● Glob("snap3.ts") — ✓ snap-result-3
-│ ╰─ Done (4 tools · 4.0s)"
+│ ╰─ Done (4 tool calls · 4.0s)"
 `;

--- a/src/cli/commands/interactive/progress-banner.ts
+++ b/src/cli/commands/interactive/progress-banner.ts
@@ -3,7 +3,7 @@ import type { ProgressEvent } from '../../../agent/types.js';
 import type { CompletionWriter } from './shared.js';
 import { extractLatestThinkingClause } from '../../_lib/stream-renderer-subagent-helpers.js';
 import { truncateDisplayWidth } from '../../display.js';
-import { formatDuration, formatTokens } from '../../format-utils.js';
+import { formatDuration, formatTokens, formatToolCallStat } from '../../format-utils.js';
 import { palette } from '../../palette.js';
 import { getTerminalWidth } from '../../terminal-size.js';
 import { styleForToolName } from '../../tool-category.js';
@@ -88,7 +88,7 @@ export function formatProgressBanner(
     const { color, glyph } = styleForToolName(lastToolName);
     stats.push(`via ${color(`${glyph} ${sanitizeLabel(lastToolName)}`)}`);
   }
-  if (toolUses) stats.push(`${toolUses} tool${toolUses === 1 ? '' : 's'}`);
+  if (toolUses) stats.push(formatToolCallStat(toolUses));
   if (totalTokens) stats.push(`${formatTokens(totalTokens)} tok`);
   if (durationMs) stats.push(formatDuration(durationMs));
   stats.push('esc to interrupt · ctrl+b background');
@@ -116,7 +116,7 @@ export function formatProgressBanner(
 export function formatProgressSummary(event: ProgressEvent, columns?: number): string {
   const { description, totalTokens, toolUses, durationMs } = event;
   const stats: string[] = [];
-  if (toolUses) stats.push(`${toolUses} tool${toolUses === 1 ? '' : 's'}`);
+  if (toolUses) stats.push(formatToolCallStat(toolUses));
   if (totalTokens) stats.push(`${formatTokens(totalTokens)} tok`);
   if (durationMs) stats.push(formatDuration(durationMs));
   const statsStr = stats.length > 0 ? ` (${stats.join(' · ')})` : '';

--- a/src/cli/commands/interactive/tool-lane-render-agent.ts
+++ b/src/cli/commands/interactive/tool-lane-render-agent.ts
@@ -1,6 +1,7 @@
 import { palette } from '../../palette.js';
 import { styleForToolName } from '../../tool-category.js';
 import { getTerminalWidth } from '../../terminal-size.js';
+import { formatToolCallStat } from '../../format-utils.js';
 import {
   MAX_VISIBLE_CHILDREN,
   formatOutcome,
@@ -54,7 +55,7 @@ function formatAgentSummary(
   // increments source.stats.toolUses (both increment-only paths).
   const stats: string[] = [];
   if (toolChildren.length > MAX_VISIBLE_CHILDREN) {
-    stats.push(`${toolChildren.length} tools`);
+    stats.push(formatToolCallStat(toolChildren.length));
     if (totalLines > 0) stats.push(`${totalLines} lines`);
   }
 

--- a/src/cli/commands/interactive/tool-lane.test.ts
+++ b/src/cli/commands/interactive/tool-lane.test.ts
@@ -854,11 +854,11 @@ describe('Bug #5 — agentResultSummary must use └ tree connector and appear a
     }
 
     // Attach the Done summary (as finalizeSubagent does)
-    lane.setAgentResultSummary(agentId, 'Done (4 tools · 2.5s)');
+    lane.setAgentResultSummary(agentId, 'Done (4 tool calls · 2.5s)');
     lane.addResult(agentId, {
       type: 'tool_result',
       toolUseId: 'synthetic',
-      content: 'Done (4 tools · 2.5s)',
+      content: 'Done (4 tool calls · 2.5s)',
       isError: false,
     });
 
@@ -869,7 +869,7 @@ describe('Bug #5 — agentResultSummary must use └ tree connector and appear a
     // Find overflow line: matches "… +N" pattern from formatCategoricalOverflow
     const overflowIdx = allLines.findIndex((l) => /….*\+\d+/.test(l));
     // Find result summary line
-    const doneIdx = allLines.findIndex((l) => l.includes('Done (4 tools'));
+    const doneIdx = allLines.findIndex((l) => l.includes('Done (4 tool calls'));
 
     // Both lines must exist
     expect(overflowIdx, 'overflow ellipsis line must exist').toBeGreaterThanOrEqual(0);
@@ -894,7 +894,7 @@ describe('Bug #5 — agentResultSummary must use └ tree connector and appear a
     expect(overflowLine.indexOf('├')).toBe(2);
     expect(overflowLine.indexOf('…')).toBe(5);
     expect(doneLine.indexOf('╰')).toBe(2);
-    expect(doneLine.indexOf('Done (4 tools')).toBe(5);
+    expect(doneLine.indexOf('Done (4 tool calls')).toBe(5);
 
     // Assertion 4 (full-topology snapshot): locks the entire overlay shape.
     // Any structural drift — column position, sibling ordering, glyph
@@ -902,12 +902,12 @@ describe('Bug #5 — agentResultSummary must use └ tree connector and appear a
     // as a visible inline-snapshot diff instead of slipping past a
     // single-glyph toContain. Populated by `pnpm test -u` on first run.
     expect(stripped).toMatchInlineSnapshot(`
-      "◉ → Agent(overflow-tester) [subagent] — 4 tools
+      "◉ → Agent(overflow-tester) [subagent] — 4 tool calls
       │ ├─ … +1 (1 Read)
       │ ├─ $ Bash("file1.ts") — ✓ result1
       │ ├─ ● Grep("file2.ts") — ✓ result2
       │ ├─ ● Glob("file3.ts") — ✓ result3
-      │ ╰─ Done (4 tools · 2.5s)"
+      │ ╰─ Done (4 tool calls · 2.5s)"
     `);
   });
 
@@ -1551,9 +1551,9 @@ describe('Snapshot pins — tool-lane-render.ts representative outputs', () => {
       lane.addStartWithAgentContext(`sc${i}`, names[i]!, `("snap${i}.ts")`, agentId);
       lane.addResult(`sc${i}`, makeResult(`snap-result-${i}`));
     }
-    lane.setAgentResultSummary(agentId, 'Done (4 tools · 4.0s)');
+    lane.setAgentResultSummary(agentId, 'Done (4 tool calls · 4.0s)');
     lane.addResult(agentId, {
-      type: 'tool_result', toolUseId: 'synthetic', content: 'Done (4 tools · 4.0s)', isError: false,
+      type: 'tool_result', toolUseId: 'synthetic', content: 'Done (4 tool calls · 4.0s)', isError: false,
     });
     expect(stripAnsi(lane.flush().join('\n'))).toMatchSnapshot();
   });

--- a/src/cli/format-utils.test.ts
+++ b/src/cli/format-utils.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { formatTokens } from './format-utils.js';
+import { formatTokens, formatToolCallStat } from './format-utils.js';
 
 describe('formatTokens', () => {
   it('renders "0" for non-finite inputs (undefined / NaN / Infinity) instead of "NaNm"', () => {
@@ -36,5 +36,22 @@ describe('formatTokens', () => {
   it('formats millions with an m suffix', () => {
     expect(formatTokens(1_000_000)).toBe('1m');
     expect(formatTokens(1_500_000)).toBe('1.5m');
+  });
+});
+
+describe('formatToolCallStat', () => {
+  it('pluralizes the noun on the count (1 is singular, everything else plural)', () => {
+    expect(formatToolCallStat(1)).toBe('1 tool call');
+    expect(formatToolCallStat(0)).toBe('0 tool calls');
+    expect(formatToolCallStat(2)).toBe('2 tool calls');
+    expect(formatToolCallStat(29)).toBe('29 tool calls');
+  });
+
+  it('uses "tool call(s)" wording — the count of CALLS made, not the tool allowlist size', () => {
+    // Guards the disambiguation this helper exists for: `/info` renders "N tools"
+    // for the AVAILABLE-tool count, so tool-CALL tallies must read "tool calls"
+    // (matching `afk trace show`) to avoid the two metrics colliding on one word.
+    expect(formatToolCallStat(58)).toContain('tool call');
+    expect(formatToolCallStat(58)).not.toBe('58 tools');
   });
 });

--- a/src/cli/format-utils.ts
+++ b/src/cli/format-utils.ts
@@ -23,6 +23,15 @@ export function formatCost(usd: number): string {
   return `$${usd.toFixed(2)}`;
 }
 
+export function formatToolCallStat(count: number): string {
+  // Renders a subagent/turn tool-invocation tally as "N tool call(s)" — the
+  // count of tool CALLS made, NOT the size of the tool allowlist. The distinct
+  // wording ("tool calls", matching `afk trace show`) disambiguates from
+  // `/info`'s "N tools" line, which counts AVAILABLE tool definitions. Single
+  // source of truth for the four interactive stat-line renderers.
+  return `${count} tool call${count === 1 ? '' : 's'}`;
+}
+
 export function formatTokens(count: number): string {
   // Defensive backstop: a non-finite count (undefined/NaN slipping through a
   // loosely-typed usage payload) must never render as "NaNm". Render "0"

--- a/src/cli/interactive-progress-banner.test.ts
+++ b/src/cli/interactive-progress-banner.test.ts
@@ -66,7 +66,7 @@ describe('interactive REPL — progress banner rendering', () => {
     expect(joined).toMatch(/◦ Researching codebase/);
     // `via {glyph} {ToolName}` — Grep is read-category (● glyph)
     expect(joined).toContain('via ● Grep');
-    expect(joined).toContain('3 tools');
+    expect(joined).toContain('3 tool calls');
     expect(joined).toContain('1.2k tok');
     expect(joined).toContain('5s');
   });
@@ -150,7 +150,7 @@ describe('interactive REPL — progress banner rendering', () => {
     expect(strip(lines[1]!)).toContain('Reading package.json');
     // Read is read-category (● glyph)
     expect(strip(lines[1]!)).toContain('via ● Read');
-    expect(strip(lines[1]!)).toContain('2 tools');
+    expect(strip(lines[1]!)).toContain('2 tool calls');
   });
 
   it('colorizes the via segment by tool category and uses a category-specific glyph', () => {
@@ -207,7 +207,7 @@ describe('formatProgressSummary — one-line summary committed on task completio
     });
     const line = strip(formatProgressSummary(event));
     expect(line).toMatch(/◦ Researching codebase/);
-    expect(line).toContain('7 tools');
+    expect(line).toContain('7 tool calls');
     expect(line).toContain('12k tok');
     expect(line).toContain('15s');
   });
@@ -221,7 +221,7 @@ describe('formatProgressSummary — one-line summary committed on task completio
   it('uses singular tool form for a single tool use', () => {
     const event = mkEvent({ taskId: 't1', description: 'Quick check', toolUses: 1 });
     const line = strip(formatProgressSummary(event));
-    expect(line).toContain('1 tool)');
+    expect(line).toContain('1 tool call)');
     expect(line).not.toContain('1 tools');
   });
 
@@ -237,6 +237,6 @@ describe('formatProgressSummary — one-line summary committed on task completio
     const line = strip(formatProgressSummary(event));
     expect(line).not.toContain('Read');
     expect(line).not.toContain('via');
-    expect(line).toContain('3 tools');
+    expect(line).toContain('3 tool calls');
   });
 });


### PR DESCRIPTION
## Problem

The interactive TUI renders subagent / turn tool-invocation counts as **"N tools"** (e.g. `Agent(research-agent) [subagent] — 29 tools`, `Done (58 tools · 6.8k tok · 1m 33s)`). That reads as *the size of the tool allowlist* — but it is actually the count of tool **calls made**.

Worse, the word is **overloaded within the same CLI**: `/info` already uses "N tools" for the *available* tool-definition count (`src/cli/slash/commands/info.ts:96,99`), while `afk trace show` uses the unambiguous "N tool calls" (`src/cli/commands/trace.ts:606`). Same word, two different metrics — the call-count usage misled a reader into thinking a read-only subagent (5-tool surface) had ~29 tools available.

## Change

Introduce a single shared helper and route the four call-count render sites through it, emitting **"N tool call(s)"** to match `afk trace show`. `/info`'s available-tool "tools" is deliberately left untouched — that resolves the overload rather than relocating it.

- `format-utils.ts` — new `formatToolCallStat(count)` (single source of truth, alongside `formatDuration`/`formatTokens`)
- `tool-lane-render-agent.ts:57`, `_lib/stream-renderer-source.ts:112`, and `commands/interactive/progress-banner.ts` (×2) now render through it
- unit test for the helper; updated literal assertions + regenerated the two overflow snapshots (header **and** the localized `Done (…)` fixtures harmonized so the snapshots stay internally consistent)

No behavior change beyond the label wording; the underlying counter (`source.stats.toolUses`) is unchanged.

## Verification

- `pnpm lint` (tsc --noEmit, strict) — clean
- `pnpm test` — 619 files / 11203 tests pass, 14 skipped
- Confirmed no remaining `${n} tools` call-count template in `src/cli`; `info.ts` available-tool "tools" untouched
- Composition-boundary check: no code parses the rendered literal; width-clamped lines (`progress-banner`, `tool-lane-render-children`) absorb the +5-char delta

## Why (analysis trail)

Surfaced during a `/shadow-verify` + `/devils-advocate` review of how AFK's research-agent subagents are tool-restricted. Verification confirmed the restriction is enforced correctly — the only real defect was this label ambiguity, which the devils-advocate architect lens escalated from "cosmetic" to "confirmed overload" after finding the `/info` collision.
