### PR TITLE
test(tui): cover first-turn image-echo in both headless + real-PTY harness

### DIFF
--- a/src/cli/terminal-compositor.first-turn-echo-image.test.ts
+++ b/src/cli/terminal-compositor.first-turn-echo-image.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Regression coverage for the FIRST-TURN user-message echo when the message
+ * carries an image attachment (`[image attached]` summary row).
+ *
+ * ## Why this file exists (investigation, 2026-07)
+ * A user reported their first REPL message rendering TWICE in scrollback: a
+ * shorter copy WITHOUT the dim "[image attached]" summary, then the full card
+ * WITH it. The session transcript proved the message was submitted exactly
+ * ONCE, with its image (`## User … [+ 1 image]`), and the model answered using
+ * the screenshot — so the duplication is a COSMETIC scrollback-render artifact,
+ * not a double-submit or a lost image.
+ *
+ * A 108-geometry headless sweep (cols × rows × banner-height × stream-growth)
+ * of the EXACT production commit path found the committed-band logic produces a
+ * single correct copy at every geometry. That is consistent with the standing
+ * observation in this subsystem (see `echo.ts` and `render/card.ts` last-column
+ * invariants, and `first-turn-banner-echo.test.ts`): the visible triplicate /
+ * duplicate echo is a real-terminal DECAWM deferred-wrap artifact
+ * (iTerm2 / Ghostty / Kitty / WezTerm / tmux flush a pending wrap
+ * inconsistently) that `@xterm/headless` — which implements autowrap
+ * correctly — cannot reproduce. The mitigation the codebase relies on is
+ * LAST-COLUMN SAFETY: no committed echo row may place a printable glyph in the
+ * terminal's final column.
+ *
+ * ## What these tests lock
+ *  1. PRODUCTION FIDELITY: the echo is committed as ONE block via
+ *     `commitBlockAbove` (matching input-surface.ts:492), NOT per-line. The
+ *     sibling `first-turn-banner-echo.test.ts` commits per-line — a stale
+ *     mirror of production; this file exercises the real single-block path.
+ *  2. SINGLE-COPY: after the first-turn commit + streaming growth + collapse,
+ *     the separator, each body row, the `[image attached]` summary, and the
+ *     response each appear EXACTLY ONCE in the rendered buffer.
+ *  3. LAST-COLUMN SAFETY (the DECAWM proxy): every physical row of the echo —
+ *     card rows AND the appended attachment-summary row — has a display width
+ *     ≤ cols - 1, so nothing lands in the wrap-sensitive final column. This is
+ *     the machine-checkable guarantee that guards the real-terminal artifact;
+ *     a regression here is what resurfaces the "prompt echoed 3×" report.
+ *
+ * NOTE: these are GREEN guards. They do not reproduce the user-visible
+ * duplication (impossible in the correct-autowrap headless terminal); they pin
+ * the invariants whose violation would CAUSE it, for the exact echo shape
+ * (multi-line card + attachment-summary trailer) that the prior suite missed.
+ * The same single-block image-echo shape is ALSO driven end-to-end over a real
+ * pseudo-terminal by the `first-turn-image-echo` scenario in tests/pty (#553),
+ * which certifies the committed rows reach REAL scrollback exactly once — a
+ * property mock-stdout cannot. That harness replays into @xterm/headless too,
+ * so it likewise cannot surface the terminal-only DECAWM artifact; last-column
+ * safety (test 2 below) stays the machine-checkable mitigation for that.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { StatusLine } from './status-line.js';
+import { LoopStageBar } from './commands/interactive/loop-stage.js';
+import { formatSubmittedEcho } from './input/echo.js';
+import { commitBlockAbove } from './_lib/commit-block.js';
+import { displayWidth } from './display.js';
+import { __resetStdinClaimForTests } from './input/stdin-claim.js';
+
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin = NodeJS.ReadStream & { isTTY: boolean; isRaw: boolean; setRawMode: ReturnType<typeof vi.fn> };
+
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true; s.columns = cols; s.rows = rows; return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true; s.isRaw = false; s.setRawMode = vi.fn((r: boolean) => { s.isRaw = r; return s; }); return s;
+}
+function collect(stream: MockStdout): () => string { const c: string[] = []; stream.on('data', (x) => c.push(String(x))); return () => c.join(''); }
+function termWrite(t: HeadlessTerminal, d: string): Promise<void> { return new Promise((r) => t.write(d, r)); }
+function lines(t: HeadlessTerminal): string[] {
+  const b = t.buffer.active; const o: string[] = [];
+  for (let i = 0; i < b.length; i++) { const l = b.getLine(i); if (l) o.push(l.translateToString(true)); }
+  return o;
+}
+function wireFooter(stdout: MockStdout): StatusLine {
+  const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+  statusLine.start();
+  statusLine.repaint({ model: 'MODELXYZ', cost: 0, tokens: 0, contextPct: 0 });
+  const loopStageBar = new LoopStageBar({ getExtraRows: () => statusLine.getExtraRows(), stream: stdout });
+  loopStageBar.setRowCountChangeHandler(() => statusLine.setExtraRows(1));
+  statusLine.setAfterScrollRestore(() => loopStageBar.redraw());
+  loopStageBar.start();
+  return statusLine;
+}
+
+const COLS = 80;
+const ROWS = 24;
+const BANNER_ROWS = 11; // live geometry from first-turn-banner-echo.test.ts: anchorRow = 12
+const SUMMARY = '[image attached]';
+
+// A message long enough to wrap into a multi-row user card. DUPCHECK marks the
+// first body region, `india` the tail — both must appear exactly once.
+const MESSAGE =
+  'these awa-private research agents being used are they actually from awa-private DUPCHECK ' +
+  'or just titled that in agent-afk do we have our own research agents what tools india';
+
+describe('first-turn echo with image attachment (single-block production path)', () => {
+  it('commits the card + [image attached] summary exactly once and survives streaming growth', async () => {
+    __resetStdinClaimForTests();
+    const stdout = makeStdout(COLS, ROWS);
+    const stdin = makeStdin();
+    const all = collect(stdout);
+
+    // Pre-arm banner, exactly like the interactive surface.
+    for (let i = 0; i < BANNER_ROWS; i++) stdout.write(`BANNER_LINE_${i}\n`);
+
+    const statusLine = wireFooter(stdout);
+    const c = new TerminalCompositor({
+      stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: BANNER_ROWS + 1,
+    });
+    await c.arm();
+    const internals = c as unknown as { repaint(): void };
+
+    // Pre-submit chrome collapse (spinner/hint/preflight → idle) — the 1-row
+    // shrink-pad delta that reproduces the live first-commit geometry.
+    c.setOverlay('preflight-line');
+    c.setOverlay('');
+
+    // First turn: build the echo the SAME way input-surface.ts does — a
+    // multi-line user card PLUS the dim `[image attached]` summary row — and
+    // commit it as ONE block via commitBlockAbove (input-surface.ts:492).
+    const echo = formatSubmittedEcho({
+      buffer: MESSAGE,
+      promptText: 'afk (opus)  › ',
+      isTTY: true,
+      terminalWidth: COLS,
+      attachmentSummary: SUMMARY,
+    });
+    const echoRows = echo.split('\n');
+    // separator + ≥2 body rows + summary row.
+    expect(echoRows.length).toBeGreaterThanOrEqual(4);
+    expect(echoRows[echoRows.length - 1]).toContain(SUMMARY);
+    commitBlockAbove(c, echoRows);
+    c.commitAbove(''); // blank terminator (turn-handler.ts:236)
+
+    // Streaming: spinner + overlay growth past the band, then a response
+    // commit and collapse back to idle (the opus thinking → answer arc).
+    c.setSpinner({ enabled: true });
+    for (let g = 2; g <= 14; g += 3) {
+      c.setOverlay(Array.from({ length: g }, (_, i) => `stream-row ${g}.${i}`).join('\n'));
+    }
+    c.commitAbove('RESPONSE_OK');
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    internals.repaint();
+    internals.repaint();
+
+    const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 800, allowProposedApi: true, convertEol: true });
+    await termWrite(term, all());
+    const ls = lines(term);
+    const dump = ls.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l)}`).join('\n');
+
+    // SINGLE-COPY: every distinct echo artifact appears exactly once.
+    expect(ls.filter((l) => /─{10,}/.test(l)), `separator duplicated:\n${dump}`).toHaveLength(1);
+    expect(ls.filter((l) => l.includes('DUPCHECK')), `body head duplicated/lost:\n${dump}`).toHaveLength(1);
+    expect(ls.filter((l) => l.includes('india')), `body tail duplicated/lost:\n${dump}`).toHaveLength(1);
+    expect(ls.filter((l) => l.includes(SUMMARY)), `attachment summary duplicated/lost:\n${dump}`).toHaveLength(1);
+    expect(ls.filter((l) => l.includes('RESPONSE_OK')), `response duplicated:\n${dump}`).toHaveLength(1);
+
+    // ORDER: banner → separator → body head → body tail → summary → response.
+    const idx = (pred: (l: string) => boolean): number => ls.findIndex(pred);
+    const lastBanner = ls.reduce((acc, l, i) => (l.includes('BANNER_LINE_') ? i : acc), -1);
+    expect(lastBanner).toBeGreaterThanOrEqual(0);
+    expect(idx((l) => /─{10,}/.test(l))).toBeGreaterThan(lastBanner);
+    expect(idx((l) => l.includes('DUPCHECK'))).toBeGreaterThan(idx((l) => /─{10,}/.test(l)));
+    expect(idx((l) => l.includes('india'))).toBeGreaterThan(idx((l) => l.includes('DUPCHECK')));
+    expect(idx((l) => l.includes(SUMMARY))).toBeGreaterThan(idx((l) => l.includes('india')));
+    expect(idx((l) => l.includes('RESPONSE_OK'))).toBeGreaterThan(idx((l) => l.includes(SUMMARY)));
+
+    statusLine.stop();
+    c.disarm();
+  });
+
+  it('every echo row (card + attachment summary) is last-column safe (DECAWM proxy)', () => {
+    // The real-terminal duplication is a DECAWM deferred-wrap artifact triggered
+    // by a printable glyph in the final column. The generator's guarantee is
+    // that NO physical echo row reaches the last column. Assert it directly on
+    // the produced echo for the image-attachment shape across representative
+    // widths — the exact case the prior suite never exercised.
+    //
+    // Fidelity: production calls formatSubmittedEcho WITHOUT `terminalWidth`
+    // (input-surface.ts), so echo.ts's summary/separator padding AND card()'s
+    // body wrap BOTH read the live `getTerminalWidth()` (= process.stdout.columns).
+    // Drive that single source per width so the two stay consistent exactly as
+    // they do on a real terminal — passing `terminalWidth` to only one of them
+    // would desync the card wrap from the summary pad and fabricate a failure.
+    const origColumns = process.stdout.columns;
+    try {
+      for (const cols of [40, 60, 80, 100, 120]) {
+        Object.defineProperty(process.stdout, 'columns', { value: cols, configurable: true });
+        const echo = formatSubmittedEcho({
+          buffer: MESSAGE,
+          promptText: 'afk (opus)  › ',
+          isTTY: true,
+          attachmentSummary: SUMMARY,
+        });
+        for (const row of echo.split('\n')) {
+          expect(
+            displayWidth(row),
+            `echo row exceeds last-column-safe width at cols=${cols}: ${JSON.stringify(row)}`,
+          ).toBeLessThanOrEqual(cols - 1);
+        }
+      }
+    } finally {
+      Object.defineProperty(process.stdout, 'columns', { value: origColumns, configurable: true });
+    }
+  });
+});

--- a/tests/pty/scenarios.ts
+++ b/tests/pty/scenarios.ts
@@ -23,6 +23,7 @@ import { StatusLine } from '../../src/cli/status-line.js';
 import { LoopStageBar } from '../../src/cli/commands/interactive/loop-stage.js';
 import { renderMarkdownToTerminal } from '../../src/cli/formatter.js';
 import { formatSubmittedEcho } from '../../src/cli/input/echo.js';
+import { commitBlockAbove } from '../../src/cli/_lib/commit-block.js';
 
 /** Runtime handed to a scenario's drive() from inside the pty child. */
 export interface PtyDriveCtx {
@@ -291,17 +292,26 @@ export const SCENARIOS: Record<string, PtyScenario> = {
   },
 
   // ─────────────────────────────────────────────────────────────────────────
-  // first-turn-image-echo (#509): the FIRST commitAbove after arm, following a
-  // pre-arm banner and a pre-submit chrome cycle. The echoed submit card must
-  // commit exactly once (no orphan/duplicate copies), its body must survive
-  // streaming growth, and every banner row must remain intact. Mirrors
-  // terminal-compositor.first-turn-banner-echo.test.ts.
+  // first-turn-image-echo (#509): the FIRST commit after arm, following a
+  // pre-arm banner and a pre-submit chrome cycle, for a message carrying an
+  // IMAGE ATTACHMENT. Faithful to production (input-surface.ts:492): the echo —
+  // a multi-line user card PLUS the dim `[image attached]` summary row — is
+  // committed as ONE block via commitBlockAbove, NOT per-line (per-line forces N
+  // independent geometry decisions and is the void-prone path; see
+  // src/cli/_lib/commit-block.ts:13-24). The card body, the `[image attached]`
+  // summary, and the response must each land EXACTLY ONCE and in order (no
+  // orphan/duplicate copies — the reported double-render), and every banner row
+  // must reach real scrollback intact. Real-TTY sibling of the headless
+  // single-block guard in terminal-compositor.first-turn-echo-image.test.ts;
+  // the whole-buffer xterm replay still can't reproduce the terminal-only DECAWM
+  // deferred-wrap artifact, but it certifies the single-copy committed-band
+  // property over a real pty, which the mock-stdout path cannot.
   // ─────────────────────────────────────────────────────────────────────────
   'first-turn-image-echo': {
-    description: 'first commit after banner echoes the submit card once and preserves banner + body',
+    description: 'first commit after banner echoes the image card + [image attached] once, block-committed',
     cols: 80,
     rows: 24,
-    ref: '#509 · terminal-compositor.first-turn-banner-echo.test.ts',
+    ref: '#509 · terminal-compositor.first-turn-echo-image.test.ts',
     async drive({ stdout, stdin }): Promise<void> {
       const BANNER_ROWS = 11;
       const MESSAGE = 'Reply with only the word ok and nothing else. DUPCHECK alpha bravo charlie delta echo foxtrot golf hotel india';
@@ -313,8 +323,17 @@ export const SCENARIOS: Record<string, PtyScenario> = {
       // Pre-submit chrome cycle: transient chrome then collapse back to idle.
       c.setOverlay('preflight-line');
       c.setOverlay('');
-      const echo = formatSubmittedEcho({ buffer: MESSAGE, promptText: 'afk (haiku)  › ', isTTY: true, terminalWidth: 80 });
-      for (const line of echo.split('\n')) c.commitAbove(line);
+      // Image-attachment echo shape: multi-line card + dim `[image attached]`
+      // trailer, committed as ONE block via commitBlockAbove — the exact
+      // production path (input-surface.ts:492), NOT the per-line loop.
+      const echo = formatSubmittedEcho({
+        buffer: MESSAGE,
+        promptText: 'afk (haiku)  › ',
+        isTTY: true,
+        terminalWidth: 80,
+        attachmentSummary: '[image attached]',
+      });
+      commitBlockAbove(c, echo.split('\n'));
       c.commitAbove('');
       c.setSpinner({ enabled: true });
       for (let g = 2; g <= 14; g += 3) {
@@ -334,10 +353,15 @@ export const SCENARIOS: Record<string, PtyScenario> = {
       // regression that left the banner in the viewport would fail here.
       inScrollback: ['BANNER_LINE_0', 'BANNER_LINE_10'],
       exactlyOnce: [
-        'DUPCHECK', 'india', 'RESPONSE_OK',
+        'DUPCHECK', 'india', '[image attached]', 'RESPONSE_OK',
         'BANNER_LINE_0', 'BANNER_LINE_5', 'BANNER_LINE_10',
       ],
-      order: [['BANNER_LINE_10', 'DUPCHECK'], ['DUPCHECK', 'india'], ['india', 'RESPONSE_OK']],
+      order: [
+        ['BANNER_LINE_10', 'DUPCHECK'],
+        ['DUPCHECK', 'india'],
+        ['india', '[image attached]'],
+        ['[image attached]', 'RESPONSE_OK'],
+      ],
     },
   },
 };


### PR DESCRIPTION
## What & why

Coverage hardening for a reported REPL rendering bug: the **first** message with an attached image renders **twice** in scrollback — a shorter copy *without* the dim `[image attached]` summary, then the full card *with* it.

**Rescoped (2026-07-13):** originally this PR added a *headless-only* guard and noted the real bug couldn't be reproduced without a live terminal. The real-PTY scrollback harness (#553) has since merged, so this PR now lands the coverage in **both** layers — the fast headless suite *and* the real-pseudo-terminal harness — using the true production single-block commit path.

### Diagnosis (unchanged, durable evidence)
- **Cosmetic, data-safe.** The message was submitted **exactly once** with its image (transcript: single `## User … [+ 1 image]`; the model answered *using* the screenshot). A scrollback-render artifact — **not** a double-submit and **not** a lost image.
- **The committed-band logic is single-copy-correct** across a 108-geometry headless sweep of the production `formatSubmittedEcho` → `commitBlockAbove` path.
- **Real-terminal-only.** The visible duplicate/triplicate echo is a **DECAWM deferred-wrap** artifact (tmux / iTerm2 / Ghostty / Kitty / WezTerm flush a pending wrap inconsistently) that a correct-autowrap emulator cannot reproduce. Mitigation the codebase relies on: **last-column safety** — no committed echo row may put a printable glyph in the final column.

## What this PR changes (no behavior change — tests only)

**1. Headless guard** — `src/cli/terminal-compositor.first-turn-echo-image.test.ts`
- **Production fidelity:** commits the first-turn echo as **one block** via `commitBlockAbove` (`input-surface.ts:492`) **with** an `[image attached]` summary — the shape the sibling `first-turn-banner-echo.test.ts` (per-line, no image) never covered.
- **Single-copy:** separator / body head / body tail / `[image attached]` / response each appear exactly once after streaming growth + collapse.
- **Last-column safety (DECAWM proxy):** every echo row (card + summary) has display width ≤ `cols-1` across widths 40–120.
- Runs in the default `pnpm test`.

**2. Real-PTY scenario fix** — `tests/pty/scenarios.ts` `first-turn-image-echo`
The scenario #553 added under this name **attached no image** and committed **per-line** (the void-prone path per `_lib/commit-block.ts:13-24`). It now:
- attaches a real `[image attached]` summary,
- commits as **one block** via `commitBlockAbove` (production path),
- asserts `[image attached]` appears **exactly once** and **in order** (`india → [image attached] → RESPONSE_OK`),
- keeps the banner-in-real-scrollback region assertion.

So the single-copy committed-band property for the image-echo shape is now **certified over a real pseudo-terminal**, not just pinned headlessly.

## Scope
Does **not** reproduce or fix the user-visible DECAWM duplication — both suites replay into `@xterm/headless`, so neither surfaces the terminal-only deferred-wrap artifact; last-column safety stays its machine-checkable mitigation. The structural fix that dissolves the whole scrollback-gap class lives in **#540**.

## Test
- `pnpm lint` → clean
- `npx vitest run src/cli/terminal-compositor.first-turn-echo-image.test.ts` → 2 passed
- `pnpm test:pty` → 5/5 passed (real pty, darwin-arm64), incl. rescoped `first-turn-image-echo`
