### PR TITLE
feat(cli): seed the REPL from a launch argument (`afk "prompt"` / `afk /review`)

### DIFF
--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -181,6 +181,11 @@ export function registerInteractiveCommand(program: Command): void {
   program
     .command('interactive', { isDefault: true })
     .description('Start interactive chat session')
+    .argument(
+      '[input...]',
+      'Optional first message — or a /slash-command — auto-submitted as the opening turn. ' +
+        'E.g. `afk "what does this project do"` or `afk /review`. A bare `afk` starts an empty REPL.',
+    )
     .option(
       '-m, --model <model>',
       'Model to use. Short aliases: opus|opus_1m|sonnet|sonnet_1m|haiku. ' +
@@ -218,7 +223,7 @@ export function registerInteractiveCommand(program: Command): void {
       '--mcp-config <path>',
       'Path to an additional MCP config file (highest priority — merges over ~/.afk/config/mcp.json, project-local .mcp.json, and plugin-contributed configs). File format identical to mcp.json.',
     )
-    .action(async (options: CliOptions) => {
+    .action(async (input: string[], options: CliOptions) => {
       if (options.debug) {
         process.env['AFK_DEBUG'] = '1';
       }
@@ -387,6 +392,16 @@ export function registerInteractiveCommand(program: Command): void {
         spinner.fail('Invalid options');
         handleCommandError(err);
       }
+
+      // Seed the opening turn from the launch argument (`afk "prompt"` or
+      // `afk /review foo`). Variadic operands are joined so an unquoted
+      // slash-command's args survive (`/review foo` → "/review foo"); a bare
+      // `afk` yields "" and seeds nothing. The REPL loop promotes a non-empty
+      // seed into its seedBuffer fast-path (see loop-iteration.ts), so a plain
+      // prompt runs a turn and a /command routes through the slash dispatcher —
+      // identical to the user typing it as the first line.
+      const seed = input.join(' ').trim();
+      if (seed) ctx.initialInput = seed;
 
       // First-turn worktree hook — born-named creation. Wired only on the
       // deferred path (set above iff auto-named `-w` + autoname enabled +

--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -215,6 +215,61 @@ describe('runReplLoop — seed-buffer auto-submit fast-path (multi-iteration)', 
   });
 });
 
+describe('runReplLoop — launch-argument seed (afk "prompt" / afk /command)', () => {
+  it('auto-submits a plain-text launch arg as the opening turn without a readLine', async () => {
+    // ctx.initialInput simulates `afk "what does this project do"`. The loop
+    // pre-seeds seedBuffer from it, so iteration 1 takes the fast-path (echo +
+    // runTurn) with NO readLine; iteration 2 reads the (empty) queue → '/exit'.
+    const ctx = makeCtx({ initialInput: 'what does this project do' });
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    // The turn ran once with the launch prompt (not a readLine value).
+    expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
+    const firstArg = vi.mocked(runTurn).mock.calls[0]?.[0] as { text: string };
+    expect(firstArg.text).toBe('what does this project do');
+    // Plain text is NOT routed through the slash dispatcher — only the later
+    // '/exit' read reaches it, never the seed.
+    const dispatchInputs = vi.mocked(slashMod.dispatch).mock.calls.map((c) => c[0]);
+    expect(dispatchInputs).not.toContain('what does this project do');
+    // Only ONE readLine — the exit read; iteration 1 consumed the pre-seed.
+    expect(surfaceState.readLineCalls).toBe(1);
+    // The launch prompt was echoed to the renderer (auto-submit affordance).
+    const echoes = vi.mocked(ctx.replRenderer.writeLine).mock.calls.map((c) => String(c[0]));
+    expect(echoes.some((line) => line.includes('what does this project do'))).toBe(true);
+  });
+
+  it('routes a /slash launch arg through the slash dispatcher on the opening turn', async () => {
+    // ctx.initialInput simulates `afk /review`. The pre-seed fast-path echoes
+    // it and, because it starts with '/', hands it to the slash dispatcher —
+    // exactly as if the user typed `/review` as their first line.
+    const ctx = makeCtx({ initialInput: '/review' });
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    // The launch arg reached the slash dispatcher first, before any readLine.
+    const dispatchInputs = vi.mocked(slashMod.dispatch).mock.calls.map((c) => c[0]);
+    expect(dispatchInputs[0]).toBe('/review');
+    // No readLine was needed to dispatch the seed; readLine #1 is the exit read.
+    expect(surfaceState.readLineCalls).toBe(1);
+  });
+
+  it('a bare launch (no initialInput) reads the first turn from input as before', async () => {
+    // Regression guard: absent initialInput, the loop must NOT auto-submit —
+    // iteration 1 reads from the surface exactly as a plain `afk` launch does.
+    surfaceState.readLineQueue = [
+      { text: 'typed first turn', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+    const ctx = makeCtx();
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
+    const firstArg = vi.mocked(runTurn).mock.calls[0]?.[0] as { text: string };
+    expect(firstArg.text).toBe('typed first turn');
+    // Both lines were read — nothing was pre-seeded.
+    expect(surfaceState.readLineCalls).toBe(2);
+  });
+});
+
 describe('runReplLoop — exit_plan_mode drain mirrors the applied mode onto stats (#495)', () => {
   it('after draining an approved plan-exit seed, stats.permissionMode reflects the flipped mode', async () => {
     // Regression for #495. takePendingPlanExitSeed applies the deferred flip to

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -127,7 +127,16 @@ export async function runInputLoop(
   // (user types + Enters mid-turn) was retired in Stage 3e because the
   // persistent compositor now handles that natively (queued buffer →
   // setInputMode('idle') flush via the surface's onSubmit handler).
-  let seedBuffer: { text: string; attachments: readonly ImageAttachment[] } | undefined;
+  //
+  // Pre-seeded from `ctx.initialInput` when the session was launched with a
+  // first-message argument (`afk "prompt"` / `afk /review`): the first loop
+  // iteration takes the same fast-path, so the launch arg is echoed and
+  // dispatched (slash command or model turn) exactly as if the user had typed
+  // it and pressed Enter.
+  let seedBuffer: { text: string; attachments: readonly ImageAttachment[] } | undefined =
+    ctx.initialInput !== undefined
+      ? { text: ctx.initialInput, attachments: [] }
+      : undefined;
 
   // First-use notice for ! shell passthrough: shown once per session on the
   // first `!cmd` dispatch so users who relied on `!literal text` as model

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -350,6 +350,15 @@ export interface InteractiveCtx {
    */
   firstTurnHook?: (firstMessage: string) => Promise<void>;
   /**
+   * Optional first message seeded from the launch argument — set when the user
+   * runs `afk "prompt"` or `afk /slash args` (the interactive command's
+   * variadic `[input...]` positional). When present, the REPL loop promotes it
+   * into its `seedBuffer` fast-path and auto-submits it as the opening turn,
+   * echoed and dispatched exactly as if typed: a plain prompt runs a turn, a
+   * `/command` routes through the slash dispatcher. Absent for a bare `afk`.
+   */
+  initialInput?: string;
+  /**
    * Returns true while a turn is in flight. Set by `interactive.ts` after
    * building `turnState` so the swap closure can refuse mid-turn swaps.
    * Defaults to false when absent.

--- a/src/cli/index-integration.test.ts
+++ b/src/cli/index-integration.test.ts
@@ -50,6 +50,22 @@ describe('CLI integration', () => {
     expect(program.commands.find((c) => c.name() === 'status')?.aliases()).toContain('s');
   });
 
+  it('interactive declares a variadic [input...] arg so `afk "prompt"` / `afk /cmd` seed the REPL', () => {
+    // The default command must carry an optional variadic positional. Without
+    // it, commander v12 silently DROPS a launch argument (`afk "hi"` starts the
+    // REPL but loses "hi"); with it, the arg is captured and seeded as the
+    // opening turn. This guards the commander-level half of that feature.
+    const program = new Command();
+    registerInteractiveCommand(program);
+    const interactive = program.commands.find((c) => c.name() === 'interactive');
+    expect(interactive).toBeDefined();
+    const args = interactive!.registeredArguments;
+    expect(args).toHaveLength(1);
+    expect(args[0]?.name()).toBe('input');
+    expect(args[0]?.variadic).toBe(true);
+    expect(args[0]?.required).toBe(false);
+  });
+
   it('supports help text configuration and commands are visible in help', () => {
     const program = new Command();
     registerChatCommand(program);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -144,8 +144,10 @@ program.addHelpText(
   `
 Examples:
   $ afk                          # start interactive REPL
+  $ afk "what does this do?"     # REPL, auto-submits the prompt as the first turn
+  $ afk /review                  # REPL, runs a slash command / skill on launch
   $ afk --model opus             # REPL with specific model
-  $ afk chat "What is 2+2?"     # one-shot message
+  $ afk chat "What is 2+2?"     # one-shot message (prints and exits)
   $ afk status --format json`,
 );
 


### PR DESCRIPTION
## What & why

Running `afk` with a positional argument now **starts the interactive REPL and auto-submits that argument as the opening turn** — matching Claude Code's `claude "query"` / `claude /command` behavior.

- `afk "what does this project do"` → REPL boots, prompt runs as turn 1.
- `afk /review` → REPL boots, the slash command / skill runs on launch.
- `afk /review src/foo.ts` → seeded as `"/review src/foo.ts"` (variadic operands joined).

Previously commander v12 **silently dropped** the argument: `afk "hi"` opened an empty REPL and lost `"hi"`, because the default `interactive` command declared no positional. This is purely additive — there was no error behavior to preserve, just a lost argument to start honoring.

## Behavior matrix

| Invocation | Result |
|---|---|
| `afk` | empty REPL (unchanged) |
| `afk "prompt"` | REPL + auto-submit `prompt` as turn 1 |
| `afk /review [args]` | REPL + dispatch the slash command/skill on launch |
| `afk chat "hi"` | one-shot, prints & exits (unchanged — named command wins) |
| `afk status`, `afk i`, … | named commands/aliases unchanged |
| `afk i "seed"` | alias also seeds |

## Implementation

Reuses the REPL loop's existing `seedBuffer` fast-path — a launch seed becomes byte-identical to the user typing that line first and pressing Enter, so every downstream nuance (UserPromptSubmit hook, worktree first-turn hook, plugin-forward vs native-command dispatch, history) already behaves correctly.

- `interactive` command gains a variadic `[input...]` positional; the action joins + trims it and stashes a non-empty value on `ctx.initialInput` (`src/cli/commands/interactive.ts`).
- `runInputLoop` pre-seeds `seedBuffer` from `ctx.initialInput` (`src/cli/commands/interactive/loop-iteration.ts`). The existing fall-through then echoes it and routes `/slash` via the dispatcher or plain text via `runTurn` — no new slash-vs-prose branching.
- Action signature changes `(options)` → `(input, options)` (required once commander has a declared argument).
- `--help` examples updated to show the new forms and the REPL-vs-one-shot split.

## Edge cases

- **`afk -w "prompt"`**: because `-w [branch]` takes an *optional* value, commander binds `"prompt"` as the branch name. Use `afk "prompt" -w` (prompt first) or `afk -w -- "prompt"`. All other flag orders parse correctly (`afk --model opus "prompt"`, `afk "prompt" --model opus`).
- **Unquoted first word matching a subcommand** (`afk chat about x`) routes to the `chat` command — inherent, and matches Claude Code; quoting is the robust form.

## Testing

- `pnpm lint` (tsc --noEmit) ✓, `pnpm build` ✓, full `pnpm test` ✓ (619 files / 11,217 tests).
- New loop coverage in `loop-iteration.test.ts`: plain-text seed auto-submits without a readLine; `/slash` seed routes through the dispatcher; bare launch (no seed) reads input as before.
- New guard in `index-integration.test.ts`: the interactive command declares the variadic optional `[input...]` arg (locks the commander-level half — prevents silent-drop regression).