### PR TITLE
fix: classify AFK gate writes by tool cwd (port afk-workshop#836)

### DIFF
--- a/src/agent/afk-mode-gate.test.ts
+++ b/src/agent/afk-mode-gate.test.ts
@@ -171,6 +171,33 @@ describe('createAfkModeGate', () => {
     expect(result.decision).toBeUndefined();
   });
 
+  it('classifies subagent writes against the per-call cwd when hook registry is shared', async () => {
+    // A forked subagent shares the parent hook registry but runs in a sibling
+    // worktree. The per-call cwd (context.cwd, from the child dispatcher's
+    // resolveBase) must classify the child's in-worktree write as inside its
+    // workspace, while an absolute write escaping into the parent tree stays
+    // blocked — proving the gate reads context.cwd ahead of the static cwd.
+    const { gate } = makeGate('autonomous', '/Users/dev/project');
+
+    const allowed = await gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: 'src/feature.ts' },
+      parentSessionId: 'parent-session-123',
+      cwd: '/Users/dev/project/.afk-worktrees/fix-201',
+    });
+    expect(allowed.decision).toBeUndefined();
+
+    const blocked = await gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: '/Users/dev/project/src/feature.ts' },
+      parentSessionId: 'parent-session-123',
+      cwd: '/Users/dev/project/.afk-worktrees/fix-201',
+    });
+    expect(blocked.decision).toBe('block');
+  });
+
   it('getter-at-call-time: gate respects mode changes after construction', async () => {
     const { gate, setMode } = makeGate('autonomous');
     expect(

--- a/src/agent/afk-mode-gate.test.ts
+++ b/src/agent/afk-mode-gate.test.ts
@@ -198,6 +198,79 @@ describe('createAfkModeGate', () => {
     expect(blocked.decision).toBe('block');
   });
 
+  // ---- SECURITY: per-call cwd must not widen the containment ceiling ---------
+  it('SECURITY: refuses a subagent write anchored at an untrusted per-call cwd', async () => {
+    // A forked subagent's cwd is caller-supplied via the `agent` tool and only
+    // format-validated. A child dispatched at an out-of-tree absolute path
+    // (`/tmp`) must NOT have that path trusted as the containment boundary — its
+    // writes are measured against the trusted session root, escape it, and are
+    // flagged high (blocked; subagents never prompt).
+    const { gate } = makeGate('autonomous', '/Users/dev/project');
+
+    // relative write resolves under the untrusted /tmp base → escapes session root
+    const relative = await gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: 'evil.sh' },
+      parentSessionId: 'parent-session-123',
+      cwd: '/tmp',
+    });
+    expect(relative.decision).toBe('block');
+
+    // absolute write under the untrusted base → escapes session root
+    const absolute = await gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: '/tmp/evil.sh' },
+      parentSessionId: 'parent-session-123',
+      cwd: '/tmp',
+    });
+    expect(absolute.decision).toBe('block');
+  });
+
+  it('SECURITY: refuses a per-call cwd spoofing an .afk-worktrees/ tree of another repo', async () => {
+    // isTrustedChildRoot must not trust ANY path containing an `.afk-worktrees/`
+    // segment — only a sibling under the SAME worktrees dir as the session. A
+    // child cwd at `/tmp/.afk-worktrees/evil` (a different repo family) is
+    // untrusted, so its write is measured against the session root and blocked.
+    const { gate } = makeGate('autonomous', '/Users/dev/project');
+    const spoofed = await gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: 'evil.sh' },
+      parentSessionId: 'parent-session-123',
+      cwd: '/tmp/.afk-worktrees/evil',
+    });
+    expect(spoofed.decision).toBe('block');
+  });
+
+  it('classifies a sibling managed-worktree write as in-workspace when the parent runs in a worktree', async () => {
+    // isolation:"worktree" case: the parent session itself runs in a worktree
+    // (/repo/.afk-worktrees/parent) and dispatches a child into a SIBLING worktree
+    // (/repo/.afk-worktrees/child). The child is not a descendant of the parent
+    // but shares the same .afk-worktrees/ dir, so its in-worktree write is trusted
+    // (allowed) while an escape into the parent's tree stays blocked.
+    const { gate } = makeGate('autonomous', '/repo/.afk-worktrees/parent');
+
+    const inSibling = await gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: 'src/feature.ts' },
+      parentSessionId: 'parent-session-123',
+      cwd: '/repo/.afk-worktrees/child',
+    });
+    expect(inSibling.decision).toBeUndefined();
+
+    const escaping = await gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: '/repo/.afk-worktrees/parent/src/feature.ts' },
+      parentSessionId: 'parent-session-123',
+      cwd: '/repo/.afk-worktrees/child',
+    });
+    expect(escaping.decision).toBe('block');
+  });
+
   it('getter-at-call-time: gate respects mode changes after construction', async () => {
     const { gate, setMode } = makeGate('autonomous');
     expect(

--- a/src/agent/afk-mode-gate.test.ts
+++ b/src/agent/afk-mode-gate.test.ts
@@ -229,7 +229,7 @@ describe('createAfkModeGate', () => {
   });
 
   it('SECURITY: refuses a per-call cwd spoofing an .afk-worktrees/ tree of another repo', async () => {
-    // isTrustedChildRoot must not trust ANY path containing an `.afk-worktrees/`
+    // trustedChildRoot must not trust ANY path containing an `.afk-worktrees/`
     // segment — only a sibling under the SAME worktrees dir as the session. A
     // child cwd at `/tmp/.afk-worktrees/evil` (a different repo family) is
     // untrusted, so its write is measured against the session root and blocked.
@@ -267,6 +267,78 @@ describe('createAfkModeGate', () => {
       input: { file_path: '/repo/.afk-worktrees/parent/src/feature.ts' },
       parentSessionId: 'parent-session-123',
       cwd: '/repo/.afk-worktrees/child',
+    });
+    expect(escaping.decision).toBe('block');
+  });
+
+  it('contains a subagent to its whole worktree when the per-call cwd is a sub-directory of it', async () => {
+    // Regression (over-restriction): when the child's per-call cwd is a SUB-DIR of
+    // a sibling managed worktree, the containment boundary must normalize to the
+    // worktree ROOT (not the sub-dir), so a legitimate write elsewhere in the same
+    // worktree is allowed rather than wrongly flagged high. Before the normalization
+    // the boundary was the raw sub-dir cwd and this write was blocked.
+    const { gate } = makeGate('autonomous', '/repo/.afk-worktrees/parent');
+
+    // absolute write OUTSIDE the sub-dir cwd but INSIDE the child worktree
+    const inWorktree = await gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: '/repo/.afk-worktrees/child/other.ts' },
+      parentSessionId: 'parent-session-123',
+      cwd: '/repo/.afk-worktrees/child/packages/app',
+    });
+    expect(inWorktree.decision).toBeUndefined();
+
+    // escape out of the child worktree entirely stays blocked
+    const escaping = await gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: '/repo/.afk-worktrees/parent/x.ts' },
+      parentSessionId: 'parent-session-123',
+      cwd: '/repo/.afk-worktrees/child/packages/app',
+    });
+    expect(escaping.decision).toBe('block');
+  });
+
+  it('SECURITY: refuses a foreign-repo .afk-worktrees/ child even when the session runs in a worktree', async () => {
+    // Exercises the sibling branch's real dirname-inequality path (not the
+    // sessionWt===undefined short-circuit): the session itself runs in a worktree,
+    // and the child cwd sits in a DIFFERENT repo's `.afk-worktrees/` dir. The two
+    // worktree parents differ, so the child is untrusted, its write is measured
+    // against the session root, escapes it, and is blocked.
+    const { gate } = makeGate('autonomous', '/repo/.afk-worktrees/parent');
+    const foreign = await gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: 'evil.sh' },
+      parentSessionId: 'parent-session-123',
+      cwd: '/other-repo/.afk-worktrees/evil',
+    });
+    expect(foreign.decision).toBe('block');
+  });
+
+  it('classifies a top-level write against the session root when the per-call cwd equals it', async () => {
+    // perCall === sessionRoot (the top-level session, where context.cwd tracks
+    // getCwd() in lockstep): the trust check short-circuits on child===root, the
+    // boundary is the session root, so an in-tree write is allowed and an absolute
+    // escape out of the session tree is blocked.
+    const { gate } = makeGate('autonomous', '/Users/dev/project');
+
+    const inTree = await gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: 'src/feature.ts' },
+      parentSessionId: 'parent-session-123',
+      cwd: '/Users/dev/project',
+    });
+    expect(inTree.decision).toBeUndefined();
+
+    const escaping = await gate({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: '/Users/dev/elsewhere/evil.ts' },
+      parentSessionId: 'parent-session-123',
+      cwd: '/Users/dev/project',
     });
     expect(escaping.decision).toBe('block');
   });

--- a/src/agent/afk-mode-gate.ts
+++ b/src/agent/afk-mode-gate.ts
@@ -270,16 +270,20 @@ export function createAfkModeGate(
     // child dispatched at `/tmp` or `/` would else classify every write under it
     // as in-workspace, bypassing the sole path-safety layer (path-approval is
     // allowAll in AFK). We therefore resolve relative paths against context.cwd
-    // but anchor the boundary to it ONLY when it is provably inside the session's
-    // trust domain (isTrustedChildRoot); otherwise fall back to the trusted
-    // session root so an out-of-tree child write escapes and is flagged high.
+    // but anchor the boundary ONLY when the per-call cwd is provably inside the
+    // session's trust domain (trustedChildRoot). trustedChildRoot returns the
+    // NORMALIZED boundary — the child's managed-worktree root, not the raw
+    // (possibly sub-directory) cwd — so a child dispatched in a sub-dir of its
+    // worktree stays contained to the whole worktree instead of being over-
+    // narrowed to that sub-dir. An untrusted cwd (`/tmp`, `/`, a spoofed cross-
+    // repo `.afk-worktrees/`) returns undefined and we fall back to the trusted
+    // session root, so an out-of-tree child write escapes and is flagged high.
     const sessionRoot = getCwd?.() ?? cwd ?? process.cwd();
     const perCall = context.cwd;
     const resolveBase = perCall ?? sessionRoot;
-    const workspaceRoot =
-      perCall !== undefined && isTrustedChildRoot(perCall, sessionRoot)
-        ? perCall
-        : sessionRoot;
+    const trustedRoot =
+      perCall !== undefined ? trustedChildRoot(perCall, sessionRoot) : undefined;
+    const workspaceRoot = trustedRoot ?? sessionRoot;
     const risk = classifyRisk(toolName, context.input, {
       cwd: resolveBase,
       workspaceRoot,
@@ -365,30 +369,39 @@ function blockDecision(toolName: string, why: string): HookDecision {
 }
 
 /**
- * Whether a forked subagent's per-call cwd (`context.cwd`) may be trusted as the
- * workspace containment boundary. The `agent` tool's `cwd` is caller-supplied and
- * only format-validated (absolute, no `..`), so an arbitrary absolute path like
- * `/tmp` must NOT silently become the boundary. `perCall` is trusted only when it
- * is provably within the session's trust domain:
- *   - the session root itself, or a descendant of it (the common case: a child
- *     worktree under the session's own tree, and the top-level session where
- *     perCall === sessionRoot), or
+ * Resolve the trusted workspace-containment boundary for a forked subagent's
+ * per-call cwd (`context.cwd`), or `undefined` when the cwd is not within the
+ * session's trust domain. The `agent` tool's `cwd` is caller-supplied and only
+ * format-validated (absolute, no `..`), so an arbitrary absolute path like `/tmp`
+ * must NOT silently become the boundary. `perCall` is trusted only when it is
+ * provably within the session's trust domain:
+ *   - the session root itself → returns the session root, or
+ *   - a descendant of it (the common case: a child worktree under the session's
+ *     own tree) → returns the child's managed-worktree ROOT when the descendant
+ *     sits inside one, else the descendant itself, so a sub-directory cwd stays
+ *     contained to the whole worktree rather than being over-narrowed, or
  *   - a sibling managed worktree under the SAME `<repoRoot>/.afk-worktrees/` dir
  *     as the session (the isolation:"worktree" case where the PARENT itself runs
- *     in a worktree, so the child is a sibling rather than a descendant).
+ *     in a worktree, so the child is a sibling rather than a descendant) → returns
+ *     the sibling's worktree root.
  * Any other path (`/tmp`, `/`, or an `.afk-worktrees/` tree of a different repo)
- * is untrusted. Pure lexical path computation, mirroring worktreeRootFor — no
- * filesystem access.
+ * is untrusted → `undefined`. Pure lexical path computation, mirroring
+ * worktreeRootFor — no filesystem access.
  */
-function isTrustedChildRoot(perCall: string, sessionRoot: string): boolean {
+function trustedChildRoot(perCall: string, sessionRoot: string): string | undefined {
   const child = path.resolve(perCall);
   const root = path.resolve(sessionRoot);
-  if (child === root) return true;
+  if (child === root) return root;
   // Descendant of the session root (relative path stays within — no `..` escape).
+  // Normalize to the containing managed-worktree root when the child sits inside
+  // one, so a sub-directory cwd is not over-narrowed below the worktree boundary.
   const rel = path.relative(root, child);
-  if (rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel)) return true;
+  if (rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel)) {
+    return worktreeRootFor(child) ?? child;
+  }
   // Sibling managed worktree: same `.afk-worktrees/` parent dir as the session's
   // own worktree. Only reachable when the session itself runs inside a worktree.
+  // Anchor to the sibling's worktree root, not the raw cwd (which may be a sub-dir).
   const sessionWt = worktreeRootFor(root);
   const childWt = worktreeRootFor(child);
   if (
@@ -396,7 +409,7 @@ function isTrustedChildRoot(perCall: string, sessionRoot: string): boolean {
     childWt !== undefined &&
     path.dirname(sessionWt) === path.dirname(childWt)
   ) {
-    return true;
+    return childWt;
   }
-  return false;
+  return undefined;
 }

--- a/src/agent/afk-mode-gate.ts
+++ b/src/agent/afk-mode-gate.ts
@@ -251,11 +251,20 @@ export function createAfkModeGate(
 
     // Single source of truth for risk. `workspaceRoot` is set to the session
     // cwd so writes that escape it are flagged `high` (classifyRisk's workspace
-    // boundary rule). Prefer the live getCwd() (tracks a mid-session /cwd
-    // change) over the static construction-time cwd; fall back to process.cwd()
-    // when both are unknown. This matters because in AFK the path-approval
-    // prompt is disabled (allowAll), so this gate is the SOLE path-safety layer.
-    const root = getCwd?.() ?? cwd ?? process.cwd();
+    // boundary rule). Resolution order, most-specific first:
+    //   1. context.cwd — the dispatcher's per-call resolve base. Load-bearing
+    //      for forked subagents: they intentionally share the parent hook
+    //      registry, but their dispatcher runs in a sibling worktree, so the
+    //      per-call cwd classifies a child's in-worktree write correctly instead
+    //      of against the parent session's cwd. For the top-level session this
+    //      tracks /cwd in lockstep with getCwd() (updateCwdDependents keeps the
+    //      main dispatcher's resolveBase synced), so the two agree there.
+    //   2. getCwd() — the live session cwd (tracks a mid-session /cwd change),
+    //      preferred over the static construction-time cwd.
+    //   3. the static construction-time cwd, then process.cwd().
+    // This matters because in AFK the path-approval prompt is disabled
+    // (allowAll), so this gate is the SOLE path-safety layer.
+    const root = context.cwd ?? getCwd?.() ?? cwd ?? process.cwd();
     const risk = classifyRisk(toolName, context.input, {
       cwd: root,
       workspaceRoot: root,

--- a/src/agent/afk-mode-gate.ts
+++ b/src/agent/afk-mode-gate.ts
@@ -81,10 +81,12 @@ import type { HookContext, HookDecision, HookHandler } from './hooks.js';
 import type { PermissionMode } from './types/sdk-types.js';
 import type { ElicitationRequest, ElicitationResult } from './types/sdk-types.js';
 import type { TraceWriter } from './trace/index.js';
+import path from 'path';
 import { classifyRisk } from './risk-classifier.js';
 import { elicitationRouter } from './elicitation-router.js';
 import { emitHookDecision } from './trace/emit.js';
 import { redactInlineSecrets } from './session/prompt-dump.js';
+import { worktreeRootFor } from './worktree-occupancy.js';
 
 /** Default deny-on-timeout window for a high-risk approval (ms). */
 const DEFAULT_APPROVAL_TIMEOUT_MS = 300_000;
@@ -249,25 +251,38 @@ export function createAfkModeGate(
     // surface Asking states from an unattended run.
     if (toolName === 'send_telegram') return {};
 
-    // Single source of truth for risk. `workspaceRoot` is set to the session
-    // cwd so writes that escape it are flagged `high` (classifyRisk's workspace
-    // boundary rule). Resolution order, most-specific first:
-    //   1. context.cwd — the dispatcher's per-call resolve base. Load-bearing
-    //      for forked subagents: they intentionally share the parent hook
-    //      registry, but their dispatcher runs in a sibling worktree, so the
-    //      per-call cwd classifies a child's in-worktree write correctly instead
-    //      of against the parent session's cwd. For the top-level session this
-    //      tracks /cwd in lockstep with getCwd() (updateCwdDependents keeps the
-    //      main dispatcher's resolveBase synced), so the two agree there.
-    //   2. getCwd() — the live session cwd (tracks a mid-session /cwd change),
-    //      preferred over the static construction-time cwd.
-    //   3. the static construction-time cwd, then process.cwd().
-    // This matters because in AFK the path-approval prompt is disabled
-    // (allowAll), so this gate is the SOLE path-safety layer.
-    const root = context.cwd ?? getCwd?.() ?? cwd ?? process.cwd();
+    // Invariant: the AFK workspace-escape ceiling must be anchored to a TRUSTED
+    // root. classifyRisk takes two path inputs with distinct roles:
+    //   - `cwd`: the base RELATIVE file paths resolve against. MUST equal the
+    //     dispatcher's actual resolve base (context.cwd) or the classified path
+    //     diverges from where the write lands — defeating the gate for relative
+    //     paths.
+    //   - `workspaceRoot`: the containment BOUNDARY. A write resolving outside it
+    //     is flagged `high` (classifyRisk's workspace-escape rule).
+    // context.cwd is the per-call resolve base. For a forked subagent it is the
+    // child's (possibly sibling-worktree) cwd — load-bearing, since subagents
+    // share the parent hook registry, so without it a child's in-worktree write
+    // is measured against the PARENT cwd and wrongly flagged high. For the top-
+    // level session it tracks /cwd in lockstep with getCwd().
+    // SECURITY: a subagent's cwd is caller-supplied — the `agent` tool's `cwd` is
+    // only format-validated (parseAgentInput: absolute, no `..`), never contained
+    // to a trusted root. So context.cwd must NOT be trusted as the BOUNDARY: a
+    // child dispatched at `/tmp` or `/` would else classify every write under it
+    // as in-workspace, bypassing the sole path-safety layer (path-approval is
+    // allowAll in AFK). We therefore resolve relative paths against context.cwd
+    // but anchor the boundary to it ONLY when it is provably inside the session's
+    // trust domain (isTrustedChildRoot); otherwise fall back to the trusted
+    // session root so an out-of-tree child write escapes and is flagged high.
+    const sessionRoot = getCwd?.() ?? cwd ?? process.cwd();
+    const perCall = context.cwd;
+    const resolveBase = perCall ?? sessionRoot;
+    const workspaceRoot =
+      perCall !== undefined && isTrustedChildRoot(perCall, sessionRoot)
+        ? perCall
+        : sessionRoot;
     const risk = classifyRisk(toolName, context.input, {
-      cwd: root,
-      workspaceRoot: root,
+      cwd: resolveBase,
+      workspaceRoot,
     });
 
     if (risk !== 'high') return {};
@@ -347,4 +362,41 @@ function blockDecision(toolName: string, why: string): HookDecision {
       `and ${why}. Push an Asking summary to Telegram (send_telegram) and stop, ` +
       `or have the operator run /afk off and take over.`,
   };
+}
+
+/**
+ * Whether a forked subagent's per-call cwd (`context.cwd`) may be trusted as the
+ * workspace containment boundary. The `agent` tool's `cwd` is caller-supplied and
+ * only format-validated (absolute, no `..`), so an arbitrary absolute path like
+ * `/tmp` must NOT silently become the boundary. `perCall` is trusted only when it
+ * is provably within the session's trust domain:
+ *   - the session root itself, or a descendant of it (the common case: a child
+ *     worktree under the session's own tree, and the top-level session where
+ *     perCall === sessionRoot), or
+ *   - a sibling managed worktree under the SAME `<repoRoot>/.afk-worktrees/` dir
+ *     as the session (the isolation:"worktree" case where the PARENT itself runs
+ *     in a worktree, so the child is a sibling rather than a descendant).
+ * Any other path (`/tmp`, `/`, or an `.afk-worktrees/` tree of a different repo)
+ * is untrusted. Pure lexical path computation, mirroring worktreeRootFor — no
+ * filesystem access.
+ */
+function isTrustedChildRoot(perCall: string, sessionRoot: string): boolean {
+  const child = path.resolve(perCall);
+  const root = path.resolve(sessionRoot);
+  if (child === root) return true;
+  // Descendant of the session root (relative path stays within — no `..` escape).
+  const rel = path.relative(root, child);
+  if (rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel)) return true;
+  // Sibling managed worktree: same `.afk-worktrees/` parent dir as the session's
+  // own worktree. Only reachable when the session itself runs inside a worktree.
+  const sessionWt = worktreeRootFor(root);
+  const childWt = worktreeRootFor(child);
+  if (
+    sessionWt !== undefined &&
+    childWt !== undefined &&
+    path.dirname(sessionWt) === path.dirname(childWt)
+  ) {
+    return true;
+  }
+  return false;
 }

--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -157,6 +157,13 @@ export interface PreToolUseContext {
    * conversation-level affordance) use it to skip subagent tool calls.
    */
   parentSessionId?: string;
+  /**
+   * Effective cwd for this specific tool call, when known. Dispatchers set this
+   * from their current resolve base so shared hook registries can classify
+   * forked subagent calls against the child's worktree rather than the parent
+   * session's construction-time cwd.
+   */
+  cwd?: string;
   toolName: string;
   input?: unknown;
 }

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -564,6 +564,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
         event: 'PreToolUse',
         toolName: call.name,
         input: call.input,
+        ...(this.resolveBase !== undefined ? { cwd: this.resolveBase } : {}),
         ...(this.parentSessionId !== undefined
           ? { parentSessionId: this.parentSessionId }
           : {}),
@@ -653,6 +654,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
           event: 'PreToolUse',
           toolName: call.name,
           input: call.input,
+          ...(this.resolveBase !== undefined ? { cwd: this.resolveBase } : {}),
           ...(this.parentSessionId !== undefined
             ? { parentSessionId: this.parentSessionId }
             : {}),

--- a/src/agent/tools/skill-load-mode.test.ts
+++ b/src/agent/tools/skill-load-mode.test.ts
@@ -294,9 +294,8 @@ describe('context: load — plugin skills', () => {
     // Regression: the previous /\$\{?PLUGIN_ROOT\}?/g regex matched only
     // `${PLUGIN_ROOT` of the Claude-Code fallback idiom and left `:-${CLAUDE_
     // PLUGIN_ROOT}}` dangling, producing a broken path. Skills using the
-    // portable `${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}` form (forge-gate-check,
-    // distill, forge-l2-eval, ceiling-test) failed their python3 invocations
-    // in load mode as a result.
+    // portable `${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}` form (several load-mode
+    // plugin skills) failed their python3 invocations in load mode as a result.
     const mockFork = spyNoFork();
     const executor = makeExecutor();
     const PLUGIN_PATH = '/home/user/.afk/plugins/my-plugin';

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -36,7 +36,7 @@ const __dirname = dirname(__filename);
 // developer to look at both copies.
 const PINNED_HASHES = {
   // automate: afk-native scheduled-run skill (create_schedule + send_telegram +
-  // `afk service install daemon`). Mirrors the awa-dev upstream (→ framework);
+  // `afk service install daemon`). Mirrors the upstream framework plugin;
   // vendored byte-equal, so no INTENTIONAL_DIFFS entry is needed. Drift row is
   // wired in UPSTREAM_PATHS below (skips until example-plugin is co-located).
   automate: '93380f58316e607f6b95b27a9c2375f0a5403f3a42eb695d0490b50225d8838c',


### PR DESCRIPTION
## Source

Moat-scrubbed port of **afk-workshop#836** — https://github.com/griffinwork40/afk-workshop/pull/836
(private→public via the `afk-port` pipeline; this is a scrubbed port, not a 1:1 copy). Addresses the private tracking issue afk-workshop#201.

## Ported (public-safe)

Makes the AFK-mode safety gate classify a **forked subagent's** writes against the child's own cwd instead of the shared parent session's:

- `src/agent/hooks.ts` — add optional `cwd?: string` to `PreToolUseContext` (the effective cwd for a specific tool call).
- `src/agent/tools/dispatcher.ts` — populate that `cwd` from the dispatcher's `resolveBase` at both `PreToolUse` construction sites.
- `src/agent/afk-mode-gate.ts` — prefer the per-call cwd when computing the workspace-escape root.
- `src/agent/afk-mode-gate.test.ts` — regression test: a subagent's in-worktree write is allowed while an absolute write escaping into the parent tree stays blocked.

**Why:** forked subagents intentionally share the parent hook registry, but their dispatcher may run in a sibling worktree. Without a per-call cwd, the gate classified their legitimate in-worktree writes against the parent's cwd and blocked them.

## Merge decision (reviewer note)

Public `main` had **diverged** from the private source here: it already resolves the risk root via a live `getCwd()` (tracks a mid-session `/cwd` change — the sole path-safety layer in AFK). The initial hand-merge added the per-call cwd at highest precedence and used it as **both** the resolve base and the containment boundary:

```
const root = context.cwd ?? getCwd?.() ?? cwd ?? process.cwd();  // ⚠ superseded — see below
```

**That intermediate form was unsafe** and was flagged **P1 by Codex**: the `agent` tool's `cwd` is caller-supplied and only format-validated (`parseAgentInput`: absolute, no `..`), so a child dispatched at `cwd: "/tmp"` or `"/"` would make that path the boundary and classify every write under it as in-workspace — bypassing the escape ceiling (path-approval is `allowAll` in AFK, so this gate is the sole path-safety layer).

**Shipped design (`85b8a3d`):** the per-call cwd is honored as the *resolve base* for relative paths, but the containment *boundary* is anchored to it only when the cwd is provably inside the session's trust domain (the session root, a descendant, or a sibling managed worktree under the same `<repoRoot>/.afk-worktrees/` dir). An arbitrary caller-supplied cwd (`/tmp`, `/`, or a spoofed cross-repo `.afk-worktrees/` path) falls back to the trusted session root, so an out-of-tree subagent write escapes and is flagged high:

```
const resolveBase   = perCall ?? sessionRoot;                                        // relative-path base
const trustedRoot   = perCall !== undefined ? trustedChildRoot(perCall, sessionRoot) : undefined;
const workspaceRoot = trustedRoot ?? sessionRoot;                                    // containment boundary
```

**Follow-up (`bdc03df`, post-review):** `trustedChildRoot` returns the *normalized* boundary — the child's managed-worktree root (via `worktreeRootFor`), not the raw cwd — so a child dispatched in a **sub-directory** of its worktree stays contained to the whole worktree instead of being over-narrowed to that sub-dir (a fail-safe over-restriction). Regression tests now also cover the sub-dir normalization, a foreign-repo `.afk-worktrees/` child with a worktree-resident session (the real dirname-inequality branch), and the top-level `perCall === sessionRoot` case. Post-follow-up: `tsc --noEmit` clean; full suite **11221 passed / 0 failed**; `audit:sdk` / `audit:env` / `scan:env` gates clean.

## Incidental moat scrub (required for the gate)

Two **pre-existing** public-`main` test comments named private framework skills/plugins (they predate this port — one shipped with the earlier PLUGIN_ROOT port). Genericized so the moat gate passes honestly and public source stops leaking those names:

- `src/agent/tools/skill-load-mode.test.ts` — replaced a parenthetical list of private skill names with "several load-mode plugin skills".
- `src/bundled-plugins/awa-bundled/bundled.test.ts` — replaced a private upstream-plugin name with "the upstream framework plugin".

Comment-only edits; no test logic changed.

## Dropped

Nothing. The entire source PR was public-safe (all changes in `src/agent/`); no moat hunks were excluded.

## Verification

- `pnpm lint` clean · `pnpm test` **11215 passed / 0 failed** · `pnpm build` + `pnpm build:dist` clean · `pnpm fix:pins:check` clean.
- Deterministic moat guard: **CLEAN** (0 HARD-denylist hits across tree + built `dist/`, 0 structural).
- Independent adversarial moat audit (read-only re-derivation): **CLEAN**.

## Do not merge automatically — left for human review.

