### PR TITLE
fix(subagent): explicit writeRoots grant + truthful deny for forked children (#435)

### DIFF
--- a/src/agent/subagent-worktree-readroot.test.ts
+++ b/src/agent/subagent-worktree-readroot.test.ts
@@ -164,3 +164,42 @@ describe('forkSubagent — worktree main-repo read-root grant', () => {
     expect(mockedResolve).not.toHaveBeenCalled();
   });
 });
+
+describe('forkSubagent — explicit write-root pre-grant (#435)', () => {
+  beforeEach(() => {
+    shared.lastConfig = null;
+    mockedResolve.mockReset();
+    mockedResolve.mockResolvedValue(undefined);
+  });
+
+  it('composes config.writeRoots with the child cwd (deduped)', async () => {
+    const mgr = new SubagentManager({ cwd: WORKTREE });
+    await mgr.forkSubagent(
+      forkOpts({ model: 'sonnet', apiKey: 'k', writeRoots: ['/sibling/repo'] }),
+    );
+
+    const cfg = shared.lastConfig as { writeRoots?: string[] } | null;
+    // cwd is always included so the child keeps write access to its own tree.
+    expect(cfg?.writeRoots).toEqual([WORKTREE, '/sibling/repo']);
+  });
+
+  it('dedupes when config.writeRoots already contains the cwd', async () => {
+    const mgr = new SubagentManager({ cwd: WORKTREE });
+    await mgr.forkSubagent(
+      forkOpts({ model: 'sonnet', apiKey: 'k', writeRoots: [WORKTREE, '/sibling'] }),
+    );
+
+    const cfg = shared.lastConfig as { writeRoots?: string[] } | null;
+    // Set dedup: WORKTREE appears once even though both base and writeRoots include it.
+    expect(cfg?.writeRoots).toEqual([WORKTREE, '/sibling']);
+  });
+
+  it('does not override writeRoots when config.writeRoots is absent', async () => {
+    const mgr = new SubagentManager({ cwd: WORKTREE });
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' }));
+
+    const cfg = shared.lastConfig as { writeRoots?: string[] } | null;
+    // No explicit writeRoots → provider defaults to [cwd].
+    expect(cfg?.writeRoots).toBeUndefined();
+  });
+});

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -538,6 +538,19 @@ export class SubagentManager {
       }
     }
 
+    // Explicit write-root pre-grant (#435): when the caller passed writeRoots on
+    // the agent tool, COMPOSE them with the child's own cwd so the child never
+    // loses write access to its own tree — the provider REPLACES the default
+    // [cwd] write root with config.writeRoots on first init (see
+    // anthropic-direct/index.ts ensureSharedRoots). Unlike the #416 read grant
+    // this is never automatic: writing outside the worktree breaks isolation, so
+    // it requires explicit parent intent.
+    let composedWriteRoots: string[] | undefined;
+    if (options.config.writeRoots !== undefined && options.config.writeRoots.length > 0) {
+      const base = effectiveChildCwd !== undefined ? [effectiveChildCwd] : [];
+      composedWriteRoots = [...new Set([...base, ...options.config.writeRoots])];
+    }
+
     const childConfig: AgentConfig = {
       ...options.config,
       resume,
@@ -626,6 +639,11 @@ export class SubagentManager {
       // readRoots unset; otherwise the `...options.config` spread's readRoots
       // (or the provider's `[cwd]` default) stands.
       ...(worktreeReadRoots !== undefined ? { readRoots: worktreeReadRoots } : {}),
+      // Explicit write-root pre-grant (#435): composed with cwd above. When
+      // writeRoots is absent, composedWriteRoots is undefined and the
+      // `...options.config` spread's writeRoots (or the provider's `[cwd]`
+      // default) stands.
+      ...(composedWriteRoots !== undefined ? { writeRoots: composedWriteRoots } : {}),
       // Invariant: a forked child's trace origin comes from its inherited
       // parent surface, not from any actor-role value (see session-identity.ts).
       // Inherit traceWriter + surface from the manager so every worker session

--- a/src/agent/tools/hooks/path-approval-hook.test.ts
+++ b/src/agent/tools/hooks/path-approval-hook.test.ts
@@ -137,6 +137,52 @@ describe('createPathApprovalHook — sub-agent auto-deny (PR1)', () => {
     expect(mgr._events).toHaveLength(0);
   });
 
+  // #435: the deny message must name the concrete remedy (mode-specific).
+  it('mentions writeRoots in the deny reason for a write-mode fork', async () => {
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: '/etc/hosts', content: 'x' },
+      sessionId: 'child-1',
+      parentSessionId: 'parent-1',
+    });
+
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toContain('Sub-agent path access denied');
+    expect(decision.reason).toContain('write');
+    expect(decision.reason).toContain('writeRoots');
+  });
+
+  it('mentions read roots in the deny reason for a read-mode fork', async () => {
+    const mgr = makeMockGrantManager();
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse({
+      event: 'PreToolUse',
+      toolName: 'read_file',
+      input: { file_path: '/etc/hosts' },
+      sessionId: 'child-1',
+      parentSessionId: 'parent-1',
+    });
+
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toContain('Sub-agent path access denied');
+    expect(decision.reason).toContain('read');
+    // Read-mode remedy should NOT mention writeRoots.
+    expect(decision.reason).not.toContain('writeRoots');
+  });
+
   it('leaves inherited in-root access untouched for a sub-agent (no prompt, no block)', async () => {
     const handler = vi.fn(async () => ({ action: 'accept', content: { choice: 'session' } }));
     elicitationRouter.install(handler);

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -227,12 +227,25 @@ async function preToolUseImpl(
     console.error(
       `[path-approval] surface=${opts.surface} tool=${context.toolName} path=${result.resolved} outcome=subagent-autodeny`,
     );
+    // #435: name the concrete remedy rather than implying a grant mechanism the
+    // fork does not have. A fork cannot elicit, so the recovery actor is always
+    // the PARENT: for writes it can re-dispatch with an explicit writeRoots
+    // grant on the `agent` tool (or do the write itself); for reads it owns the
+    // operator surface and can widen readRoots or re-dispatch with the path in cwd.
+    const remedy =
+      mode === 'write'
+        ? `Writes are confined to this fork's granted write roots by design ` +
+          `(worktree isolation). To allow it, the parent must re-dispatch you via ` +
+          `the \`agent\` tool with \`writeRoots: [${JSON.stringify(result.resolved)}]\`, ` +
+          `or perform the write itself. Return this exact path requirement to your parent.`
+        : `Reads are confined to this fork's granted read roots. Return this exact ` +
+          `path requirement to your parent, which owns the operator surface and can ` +
+          `grant access (widen readRoots or re-dispatch with the path inside cwd).`;
     return {
       decision: 'block',
       reason:
-        `Sub-agents cannot access paths outside the session's granted roots ` +
-        `(${result.resolved}). Report this path requirement to the parent ` +
-        `session, which owns the operator surface and can grant access.`,
+        `Sub-agent path access denied: ${result.resolved} is outside the ` +
+        `session's granted ${mode} roots. ${remedy}`,
     };
   }
 

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -399,6 +399,12 @@ export const agentTool: AnthropicToolDef = {
           'further nested subagents — each `agent` call must specify `cwd` ' +
           'explicitly to operate in a worktree.',
       },
+      writeRoots: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Optional extra write roots to pre-grant to the forked child. By default a fork can only write inside its cwd/worktree; out-of-root writes are auto-denied. Each entry must be an absolute path with no `..` segments. Composed WITH (never replaces) the child cwd. Mutually exclusive with isolation:"worktree".',
+      },
       isolation: {
         type: 'string',
         enum: ['none', 'worktree'],

--- a/src/agent/tools/subagent/child-config.ts
+++ b/src/agent/tools/subagent/child-config.ts
@@ -266,6 +266,9 @@ export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigRe
     // resolveBase + read/write roots anchor at this path. When omitted,
     // the parent inheritance chain stays intact.
     ...(parsed.cwd !== undefined ? { cwd: parsed.cwd } : {}),
+    // #435: pass raw writeRoots through; SubagentManager.forkSubagent composes
+    // them with the child's effective cwd so the child never loses its own tree.
+    ...(parsed.writeRoots !== undefined ? { writeRoots: parsed.writeRoots } : {}),
   } as AgentConfig;
 
   // Wire nesting: give the child its own executor + provider so it can

--- a/src/agent/tools/subagent/input-parse.test.ts
+++ b/src/agent/tools/subagent/input-parse.test.ts
@@ -363,6 +363,65 @@ describe('parseAgentInput', () => {
     });
   });
 
+  describe('writeRoots', () => {
+    it('is undefined (key omitted) when not supplied', () => {
+      const result = parseAgentInput({ prompt: 'p' });
+      expect(result.writeRoots).toBeUndefined();
+      expect('writeRoots' in result).toBe(false);
+    });
+
+    it('accepts an array of absolute paths', () => {
+      const result = parseAgentInput({ prompt: 'p', writeRoots: ['/abs/a', '/abs/b'] });
+      expect(result.writeRoots).toEqual(['/abs/a', '/abs/b']);
+    });
+
+    it('throws when writeRoots is not an array (string)', () => {
+      expect(() => parseAgentInput({ prompt: 'p', writeRoots: '/abs/a' })).toThrow(
+        /writeRoots must be an array/,
+      );
+    });
+
+    it('throws when an entry is a relative path', () => {
+      expect(() => parseAgentInput({ prompt: 'p', writeRoots: ['relative/path'] })).toThrow(
+        /writeRoots entries must be absolute paths/,
+      );
+    });
+
+    it("throws when an entry contains a '..' segment", () => {
+      expect(() =>
+        parseAgentInput({ prompt: 'p', writeRoots: ['/tmp/../escape'] }),
+      ).toThrow(/writeRoots entries must not contain '\.\.' segments/);
+    });
+
+    it('throws when an entry is an empty string', () => {
+      expect(() => parseAgentInput({ prompt: 'p', writeRoots: [''] })).toThrow(
+        /writeRoots entries must be non-empty strings/,
+      );
+    });
+
+    it('normalizes an empty array to undefined (field absent)', () => {
+      const result = parseAgentInput({ prompt: 'p', writeRoots: [] });
+      expect(result.writeRoots).toBeUndefined();
+      expect('writeRoots' in result).toBe(false);
+    });
+
+    it('throws when writeRoots and isolation:worktree are both supplied (mutually exclusive)', () => {
+      expect(() =>
+        parseAgentInput({ prompt: 'p', writeRoots: ['/abs/a'], isolation: 'worktree' }),
+      ).toThrow(/writeRoots and isolation are mutually exclusive/);
+    });
+
+    it('accepts writeRoots together with cwd (the main use case)', () => {
+      const result = parseAgentInput({
+        prompt: 'p',
+        cwd: '/tmp/wt/x',
+        writeRoots: ['/sibling/repo'],
+      });
+      expect(result.cwd).toBe('/tmp/wt/x');
+      expect(result.writeRoots).toEqual(['/sibling/repo']);
+    });
+  });
+
   describe('isolation', () => {
     it('defaults to omitted (no field) when absent', () => {
       const result = parseAgentInput({ prompt: 'p' });

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -63,6 +63,19 @@ export interface AgentInput {
    */
   cwd?: string;
   /**
+   * Optional extra write roots to pre-grant to the forked child (#435). By
+   * default a fork's writes are confined to its cwd/worktree; the path-approval
+   * hook auto-denies any write outside it and a fork cannot elicit. Passing
+   * writeRoots here lets the PARENT deliberately grant additional write roots.
+   * Composed WITH the child's cwd (never replaces it), so the child keeps write
+   * access to its own tree. Each entry must be an absolute path with no `..`
+   * segments. Mutually exclusive with `isolation:'worktree'` (isolation's
+   * contract is total confinement). Unlike the #416 read grant this is never
+   * automatic — writing outside the worktree breaks isolation, so it requires
+   * explicit parent intent.
+   */
+  writeRoots?: string[];
+  /**
    * Filesystem-isolation mode. When `'worktree'`, the executor forks the child
    * inside a fresh afk-managed git worktree (`.afk-worktrees/<slug>` on a new
    * branch) and sets the child's cwd to it, so parallel write-capable
@@ -210,6 +223,39 @@ export function parseAgentInput(input: unknown): AgentInput {
     cwd = cwdValue;
   }
 
+  // writeRoots: optional array of absolute paths pre-granted as extra write
+  // roots to the fork (#435). Same per-entry rules as cwd (non-empty, absolute,
+  // no '..' segments). An empty array normalizes to undefined (no-op grant).
+  let writeRoots: string[] | undefined;
+  const writeRootsValue = agentInput['writeRoots'];
+  if (writeRootsValue !== undefined) {
+    if (!Array.isArray(writeRootsValue)) {
+      throw new Error(
+        `Agent tool writeRoots must be an array of absolute paths, got: ${JSON.stringify(writeRootsValue)}`,
+      );
+    }
+    const roots: string[] = [];
+    for (const entry of writeRootsValue) {
+      if (typeof entry !== 'string' || entry.length === 0) {
+        throw new Error(
+          `Agent tool writeRoots entries must be non-empty strings, got: ${JSON.stringify(entry)}`,
+        );
+      }
+      if (!isAbsolute(entry)) {
+        throw new Error(
+          `Agent tool writeRoots entries must be absolute paths, got: ${JSON.stringify(entry)}`,
+        );
+      }
+      if (entry.split(/[/\\]/).includes('..')) {
+        throw new Error(
+          `Agent tool writeRoots entries must not contain '..' segments, got: ${JSON.stringify(entry)}`,
+        );
+      }
+      roots.push(entry);
+    }
+    if (roots.length > 0) writeRoots = roots;
+  }
+
   // isolation: optional enum. 'none' (or omitted) is a no-op and normalizes to
   // undefined so the executor's `=== 'worktree'` check is total. 'worktree'
   // asks the executor to fork the child inside a fresh managed git worktree.
@@ -232,6 +278,11 @@ export function parseAgentInput(input: unknown): AgentInput {
         'Agent tool cwd and isolation are mutually exclusive — pass one or the other',
       );
     }
+    if (writeRoots !== undefined) {
+      throw new Error(
+        'Agent tool writeRoots and isolation are mutually exclusive — a worktree-isolated child is fully confined by design',
+      );
+    }
     if (mode === 'background') {
       throw new Error(
         'Agent tool isolation:"worktree" is not supported with mode:"background" yet',
@@ -251,6 +302,7 @@ export function parseAgentInput(input: unknown): AgentInput {
     mode,
     ...(agent_type !== undefined ? { agent_type } : {}),
     ...(cwd !== undefined ? { cwd } : {}),
+    ...(writeRoots !== undefined ? { writeRoots } : {}),
     ...(isolation !== undefined ? { isolation } : {}),
   };
 }


### PR DESCRIPTION
## Summary

Closes #435 — the write-side sibling of #416.

Forked worktree subagents were auto-denied on **any** write outside their worktree (`path-approval-hook` `parentSessionId` auto-deny), and because forked children are non-interactive they couldn't elicit — so the write dead-ended silently with a deny message that named no real remedy. #416 granted the main repo root as a *read* root for forks but deliberately left write confined to `[worktree]`; there was no mechanism for a parent to widen a fork's write scope.

This lands the full agreed fix:

- **(a) opt-in `writeRoots` param on the `agent` tool.** Additional absolute directories a forked child may write to. It is **composed with** the child's cwd (`[cwd, ...writeRoots]`, deduped) — never replaces it, so a fork can't lose the ability to write its own tree. Validated per-entry (absolute, non-empty, no `..`), and **mutually exclusive with `isolation: 'worktree'`** (mirrors the existing `cwd`+`isolation` rejection — punching a write hole out of an isolated worktree breaks the merge/teardown contract).
- **(b) truthful, mode-aware deny message.** Instead of a silent dead-end, the deny now names the concrete remedy: for a write, re-dispatch with `writeRoots: [path]`; for a read, widen `readRoots`.
- **(c) docs.** Tool schema + code comments state that writes anchor to the child's cwd/worktree by default and out-of-tree writes are denied.

**Policy preserved:** write-confinement stays the default. `writeRoots` is **never auto-granted** (unlike the #416 read grant) — the main root is safe to auto-grant for reads but not writes, since auto-granting writes would reintroduce the cross-writer collisions worktree isolation exists to prevent. Both providers (`anthropic-direct`, `openai-compatible`) already consume `config.writeRoots` on fork init, so the grant works end-to-end for both.

## How was this tested?

Run on this exact tree (`d764554`):

- `pnpm lint` (tsc --noEmit, strict) — clean
- `pnpm test` — **11228 passed / 14 skipped / 0 failed** (619 files)
- `pnpm audit:sdk:check` — OK (no unlocked SDK symbols)
- `pnpm audit:env:check` — 0 violations

New unit coverage added:
- `input-parse.test.ts` — `writeRoots` parse/validation + `isolation` mutual-exclusion
- `path-approval-hook.test.ts` — mode-aware deny remedy text
- `subagent-worktree-readroot.test.ts` — `[cwd, ...writeRoots]` composition (child never loses its own tree)

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the DCO
- [x] No secrets, tokens, or private paths in the diff
