### PR TITLE
feat(service): Linux systemd --user support behind a platform-neutral ServiceManager

### DIFF
--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -1,75 +1,75 @@
 /**
  * `afk service` command group — install AFK long-running processes as
- * macOS LaunchAgents so they auto-start on login and relaunch on crash.
+ * OS-supervised services so they auto-start on login and relaunch on
+ * crash. Backend is chosen per platform by `serviceManagerFor()`:
+ *   - macOS → launchd LaunchAgents (`~/Library/LaunchAgents/`)
+ *   - Linux → systemd `--user` units (`~/.config/systemd/user/`)
  *
  * Subcommands:
- *   afk service install <name>     — write plist + bootstrap into launchctl
- *   afk service uninstall <name>   — bootout + remove plist
+ *   afk service install <name>     — write config + register with supervisor
+ *   afk service uninstall <name>   — deregister + remove config
  *   afk service status [name]      — show running PID + last exit + log path
  *   afk service list               — show all services and whether installed
+ *   afk service restart <name>     — restart the service
  *
- * `<name>` ∈ { telegram, daemon }. See `src/service/launchd.ts` for the
- * rationale on per-user scope (vs. system-wide LaunchDaemons), WatchPaths
- * auto-restart heuristics, and why launchd runs the entrypoints directly
- * instead of the `afk telegram start` / `afk daemon` CLI wrappers.
+ * `<name>` ∈ { telegram, daemon }. See `src/service/types.ts` for the
+ * backend-neutral contract and `src/service/{launchd,systemd}/` for the
+ * per-OS rationale (per-user scope, auto-restart heuristics, why the
+ * entrypoints are run directly instead of the CLI wrappers).
  *
  * @module cli/commands/service
  */
 
 import { Command } from 'commander';
 import chalk from 'chalk';
-import { execFileSync } from 'child_process';
-import { existsSync } from 'fs';
 import { palette } from '../palette.js';
 import { handleCommandError } from '../errors/index.js';
 import {
   SERVICE_NAMES,
-  installService,
-  labelFor,
-  plistPath,
-  serviceLogPath,
-  serviceStatus,
-  uninstallService,
+  SUPPORTED_SERVICE_PLATFORMS,
+  serviceManagerFor,
+  type ServiceManager,
   type ServiceName,
-  type ServiceStatusSnapshot,
-} from '../../service/launchd.js';
+  type ServiceStatus,
+} from '../../service/index.js';
 
-function assertMacOS(): void {
-  if (process.platform !== 'darwin') {
+/** Resolve the platform's service backend, or fail with a clear message. */
+function resolveManager(): ServiceManager {
+  const mgr = serviceManagerFor();
+  if (!mgr) {
     throw new Error(
-      `'afk service' uses macOS launchd and is only supported on darwin. Detected: ${process.platform}.`,
+      `'afk service' is not supported on ${process.platform}. Supported: ${SUPPORTED_SERVICE_PLATFORMS}.`,
     );
   }
+  return mgr;
 }
 
 function parseServiceName(input: string): ServiceName {
   const lower = input.toLowerCase();
   if ((SERVICE_NAMES as readonly string[]).includes(lower)) return lower as ServiceName;
-  throw new Error(
-    `Unknown service '${input}'. Supported: ${SERVICE_NAMES.join(', ')}.`,
-  );
+  throw new Error(`Unknown service '${input}'. Supported: ${SERVICE_NAMES.join(', ')}.`);
 }
 
 export function registerServiceCommand(program: Command): void {
   const service = program
     .command('service')
-    .description('Manage AFK background services via macOS launchd (always-on, auto-restart)');
+    .description('Manage AFK background services (launchd on macOS, systemd --user on Linux) — always-on, auto-restart');
 
   service
     .command('install <name>')
-    .description(`Install <${SERVICE_NAMES.join('|')}> as a LaunchAgent that starts on login and relaunches on crash`)
-    .option('--no-watch', 'Disable WatchPaths (no auto-restart on rebuild)')
-    .option('--dry-run', 'Write the plist but do not call launchctl', false)
+    .description(`Install <${SERVICE_NAMES.join('|')}> as an OS service that starts on login and relaunches on crash`)
+    .option('--no-watch', 'Disable auto-restart-on-rebuild (launchd WatchPaths / systemd .path unit)')
+    .option('--dry-run', 'Write the config file but do not register with the supervisor', false)
     .action((nameArg: string, opts: { watch?: boolean; dryRun?: boolean }) => {
       try {
-        assertMacOS();
+        const mgr = resolveManager();
         const name = parseServiceName(nameArg);
-        const result = installService(name, {
+        const result = mgr.install(name, {
           noWatch: opts.watch === false,
-          skipBootstrap: Boolean(opts.dryRun),
+          dryRun: Boolean(opts.dryRun),
         });
         if (result.kind === 'already-installed') {
-          console.log(chalk.yellow(`⚠ ${result.label} already installed at ${result.plistPath}`));
+          console.log(chalk.yellow(`⚠ ${result.label} already installed at ${result.configPath}`));
           console.log(palette.meta(`  Run 'afk service uninstall ${name}' first to reinstall.`));
           process.exit(1);
         }
@@ -78,21 +78,17 @@ export function registerServiceCommand(program: Command): void {
           process.exit(1);
         }
         console.log(chalk.green(`✓ Installed ${result.label}`));
-        console.log(palette.meta(`  Plist:   ${result.plistPath}`));
-        console.log(palette.meta(`  Log:     ${serviceLogPath(name)}`));
-        if (result.watchPathsActive) {
-          console.log(palette.meta(`  WatchPaths: active — service auto-restarts on rebuild.`));
+        console.log(palette.meta(`  Config:  ${result.configPath}  (${mgr.configKind})`));
+        console.log(palette.meta(`  Log:     ${mgr.logPath(name)}`));
+        if (result.autoRestartOnRebuild) {
+          console.log(palette.meta(`  Auto-restart on rebuild: on`));
         } else {
-          console.log(palette.meta(`  WatchPaths: off — manual 'afk service restart' needed after updates.`));
+          console.log(palette.meta(`  Auto-restart on rebuild: off — run 'afk service restart ${name}' after updates.`));
         }
-        if (opts.dryRun) {
-          // M-10: interpolate the real uid so the copy-paste command works
-          // on this machine. `$(id -u)` would only expand inside a shell,
-          // but we're printing a raw string to the terminal.
-          const uid = process.getuid?.() ?? 501;
-          console.log(palette.info(`  (dry-run) launchctl bootstrap was skipped; service is NOT yet running.`));
-          console.log(palette.meta(`  Load manually: launchctl bootstrap gui/${uid} ${result.plistPath}`));
-        } else {
+        for (const note of result.notes ?? []) {
+          console.log(palette.info(`  ${note}`));
+        }
+        if (!opts.dryRun) {
           console.log(palette.meta(`  Status:  afk service status ${name}`));
         }
       } catch (err) {
@@ -102,22 +98,22 @@ export function registerServiceCommand(program: Command): void {
 
   service
     .command('uninstall <name>')
-    .description('Stop the service and remove its LaunchAgent plist')
+    .description('Stop the service and remove its config (LaunchAgent plist / systemd unit)')
     .action((nameArg: string) => {
       try {
-        assertMacOS();
+        const mgr = resolveManager();
         const name = parseServiceName(nameArg);
-        const result = uninstallService(name);
+        const result = mgr.uninstall(name);
         if (result.kind === 'not-installed') {
-          console.log(chalk.yellow(`⚠ ${labelFor(name)} is not installed (no plist at ${result.plistPath})`));
+          console.log(chalk.yellow(`⚠ ${mgr.label(name)} is not installed (no config at ${result.configPath})`));
           return;
         }
         if (result.kind === 'failed') {
           console.error(chalk.red(`✗ Uninstall failed: ${result.reason}`));
           process.exit(1);
         }
-        console.log(chalk.green(`✓ Uninstalled ${labelFor(name)}`));
-        console.log(palette.meta(`  Removed: ${result.plistPath}`));
+        console.log(chalk.green(`✓ Uninstalled ${mgr.label(name)}`));
+        console.log(palette.meta(`  Removed: ${result.configPath}`));
       } catch (err) {
         handleCommandError(err);
       }
@@ -128,14 +124,13 @@ export function registerServiceCommand(program: Command): void {
     .description('Show running PID, last exit status, and log file for one or all services')
     .action((nameArg: string | undefined) => {
       try {
-        assertMacOS();
+        const mgr = resolveManager();
         if (nameArg) {
-          const snapshot = serviceStatus(parseServiceName(nameArg));
-          printStatus(snapshot);
+          printStatus(mgr.status(parseServiceName(nameArg)), mgr.configKind);
           return;
         }
         for (const name of SERVICE_NAMES) {
-          printStatus(serviceStatus(name));
+          printStatus(mgr.status(name), mgr.configKind);
           console.log('');
         }
       } catch (err) {
@@ -148,14 +143,13 @@ export function registerServiceCommand(program: Command): void {
     .description('List recognised service names and whether each is installed')
     .action(() => {
       try {
-        assertMacOS();
-        console.log(chalk.bold('AFK services:'));
+        const mgr = resolveManager();
+        console.log(chalk.bold(`AFK services (${mgr.backend}):`));
         for (const name of SERVICE_NAMES) {
-          const path = plistPath(name);
-          const installed = existsSync(path);
+          const installed = mgr.isInstalled(name);
           const marker = installed ? chalk.green('●') : chalk.dim('○');
           const tag = installed ? palette.meta('installed') : palette.meta('not installed');
-          console.log(`  ${marker} ${name.padEnd(10)}  ${tag}  ${palette.meta(path)}`);
+          console.log(`  ${marker} ${name.padEnd(10)}  ${tag}  ${palette.meta(mgr.configPath(name))}`);
         }
       } catch (err) {
         handleCommandError(err);
@@ -164,54 +158,32 @@ export function registerServiceCommand(program: Command): void {
 
   service
     .command('restart <name>')
-    .description('Restart the service (launchctl kickstart -k)')
+    .description('Restart the service (launchctl kickstart -k / systemctl --user restart)')
     .action((nameArg: string) => {
       try {
-        assertMacOS();
+        const mgr = resolveManager();
         const name = parseServiceName(nameArg);
-        const path = plistPath(name);
-        if (!existsSync(path)) {
-          console.error(chalk.red(`✗ ${labelFor(name)} is not installed. Run 'afk service install ${name}' first.`));
+        const result = mgr.restart(name);
+        if (result.kind === 'not-installed') {
+          console.error(chalk.red(`✗ ${mgr.label(name)} is not installed. Run 'afk service install ${name}' first.`));
           process.exit(1);
         }
-        // We deliberately shell out here rather than wrap in launchd.ts:
-        // restart is a one-line launchctl call and packaging it in
-        // launchd.ts would proliferate I/O surface beyond the install
-        // lifecycle that module is centred on.
-        //
-        // M-5: assert getuid is available rather than silently falling
-        // back to a wrong uid (501). process.getuid is undefined on
-        // Windows; on macOS this can never happen, but we make the
-        // assumption explicit so the stack trace points here rather than
-        // at a confusing launchctl error about a non-existent domain.
-        if (typeof process.getuid !== 'function') {
-          throw new Error(
-            'process.getuid is unavailable — afk service restart requires a POSIX system.',
-          );
-        }
-        const uid = process.getuid();
-        try {
-          execFileSync(
-            'launchctl',
-            ['kickstart', '-k', `gui/${uid}/${labelFor(name)}`],
-            { stdio: ['ignore', 'pipe', 'pipe'], timeout: 8_000 },
-          );
-          console.log(chalk.green(`✓ Restarted ${labelFor(name)}`));
-        } catch (e) {
-          console.error(chalk.red(`✗ Restart failed: ${(e as Error).message}`));
+        if (result.kind === 'failed') {
+          console.error(chalk.red(`✗ Restart failed: ${result.reason}`));
           process.exit(1);
         }
+        console.log(chalk.green(`✓ Restarted ${result.label}`));
       } catch (err) {
         handleCommandError(err);
       }
     });
 }
 
-function printStatus(s: ServiceStatusSnapshot): void {
+function printStatus(s: ServiceStatus, configKind: string): void {
   console.log(chalk.bold(`${s.label}`));
   if (!s.installed) {
     console.log(`  ${chalk.dim('○')} Not installed`);
-    console.log(palette.meta(`  Plist:   ${s.plistPath}`));
+    console.log(palette.meta(`  Config:  ${s.configPath}  (${configKind})`));
     console.log(palette.meta(`  Install: afk service install ${s.name}`));
     return;
   }
@@ -223,6 +195,6 @@ function printStatus(s: ServiceStatusSnapshot): void {
       console.log(palette.meta(`  Last exit status: ${s.lastExitStatus}`));
     }
   }
-  console.log(palette.meta(`  Plist:   ${s.plistPath}`));
+  console.log(palette.meta(`  Config:  ${s.configPath}  (${configKind})`));
   console.log(palette.meta(`  Log:     ${s.logFile}`));
 }

--- a/src/service/index.test.ts
+++ b/src/service/index.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Tests for the platform-dispatch factory `serviceManagerFor`. Follows the
+ * clipboard.ts model: platform is an injected argument, so each branch is
+ * asserted deterministically without stubbing `process.platform`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { serviceManagerFor } from './index.js';
+
+describe('serviceManagerFor', () => {
+  it('selects the launchd backend on darwin', () => {
+    const mgr = serviceManagerFor('darwin');
+    expect(mgr).not.toBeNull();
+    expect(mgr?.backend).toBe('launchd');
+    expect(mgr?.configKind).toBe('LaunchAgent plist');
+  });
+
+  it('selects the systemd backend on linux', () => {
+    const mgr = serviceManagerFor('linux');
+    expect(mgr).not.toBeNull();
+    expect(mgr?.backend).toBe('systemd');
+    expect(mgr?.configKind).toBe('systemd user unit');
+  });
+
+  it('returns null for an unsupported platform (win32)', () => {
+    expect(serviceManagerFor('win32')).toBeNull();
+  });
+
+  it('exposes the same neutral label/path surface on both backends', () => {
+    const launchd = serviceManagerFor('darwin');
+    const systemd = serviceManagerFor('linux');
+    // launchd: reverse-DNS label + LaunchAgents plist path.
+    expect(launchd?.label('telegram')).toBe('com.afk.telegram');
+    expect(launchd?.configPath('telegram')).toContain('Library/LaunchAgents/com.afk.telegram.plist');
+    // systemd: unit-name label + user-unit path.
+    expect(systemd?.label('telegram')).toBe('afk-telegram.service');
+    expect(systemd?.configPath('telegram')).toContain('.config/systemd/user/afk-telegram.service');
+  });
+});

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Service-manager entry point. `serviceManagerFor(platform)` selects the
+ * backend for the host OS, replacing the old single `assertMacOS()` gate
+ * in `cli/commands/service.ts`.
+ *
+ * Platform is a parameter defaulting to `process.platform` — the same
+ * injected-platform shape `src/cli/clipboard.ts` uses — so the dispatch is
+ * unit-testable without stubbing globals.
+ *
+ * @module service
+ */
+
+import { launchdManager } from './launchd/manager.js';
+import { systemdManager } from './systemd/manager.js';
+import type { ServiceManager } from './types.js';
+
+export * from './types.js';
+
+/**
+ * Return the {@link ServiceManager} for `platform`, or `null` when AFK
+ * has no service backend for it (e.g. win32). Callers render a clear
+ * "not supported on <platform>" message on null.
+ */
+export function serviceManagerFor(platform: NodeJS.Platform = process.platform): ServiceManager | null {
+  switch (platform) {
+    case 'darwin':
+      return launchdManager;
+    case 'linux':
+      return systemdManager;
+    default:
+      return null;
+  }
+}
+
+/** Human-readable list of supported platforms, for CLI error copy. */
+export const SUPPORTED_SERVICE_PLATFORMS = 'macOS (launchd) and Linux (systemd --user)';

--- a/src/service/launchd/manager.ts
+++ b/src/service/launchd/manager.ts
@@ -1,0 +1,125 @@
+/**
+ * launchd backend for the platform-neutral {@link ServiceManager} contract
+ * (darwin).
+ *
+ * Thin adapter: delegates to the existing launchd free-functions in this
+ * folder (unchanged) and maps their launchd-flavoured result types
+ * (`plistPath`, `watchPathsActive`) onto the neutral shapes in
+ * `../types.ts`. Keeping the delegation here means `launchd/{install,status,
+ * plist,paths}.ts` and their 776-line test-suite need no changes.
+ *
+ * The `restart` implementation is lifted verbatim from the old
+ * `cli/commands/service.ts` inline `launchctl kickstart -k` call, so the
+ * CLI can now treat restart as just another backend method.
+ *
+ * @module service/launchd/manager
+ */
+
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import type {
+  ServiceInstallOptions,
+  ServiceInstallOutcome,
+  ServiceManager,
+  ServiceName,
+  ServiceRestartOutcome,
+  ServiceStatus,
+  ServiceUninstallOutcome,
+} from '../types.js';
+import { guiDomain, LAUNCHCTL_TIMEOUT_MS, labelFor, plistPath, serviceLogPath } from './paths.js';
+import { installService, readPlistFile, uninstallService } from './install.js';
+import { serviceStatus } from './status.js';
+
+export const launchdManager: ServiceManager = {
+  backend: 'launchd',
+  configKind: 'LaunchAgent plist',
+
+  install(name: ServiceName, opts: ServiceInstallOptions = {}): ServiceInstallOutcome {
+    const result = installService(name, {
+      noWatch: opts.noWatch ?? false,
+      skipBootstrap: opts.dryRun ?? false,
+      ...(opts.environment ? { environment: opts.environment } : {}),
+    });
+    if (result.kind === 'already-installed') {
+      return { kind: 'already-installed', configPath: result.plistPath, label: result.label };
+    }
+    if (result.kind === 'failed') {
+      return { kind: 'failed', reason: result.reason };
+    }
+    const notes: string[] = [];
+    if (opts.dryRun) {
+      // M-10: interpolate the real uid so the copy-paste command works on
+      // this machine ($(id -u) would only expand inside a shell).
+      const uid = process.getuid?.() ?? 501;
+      notes.push('(dry-run) launchctl bootstrap was skipped; service is NOT yet running.');
+      notes.push(`Load manually: launchctl bootstrap gui/${uid} ${result.plistPath}`);
+    }
+    return {
+      kind: 'installed',
+      configPath: result.plistPath,
+      label: result.label,
+      autoRestartOnRebuild: result.watchPathsActive,
+      ...(notes.length > 0 ? { notes } : {}),
+    };
+  },
+
+  uninstall(name: ServiceName): ServiceUninstallOutcome {
+    const result = uninstallService(name);
+    if (result.kind === 'failed') return { kind: 'failed', reason: result.reason };
+    return { kind: result.kind, configPath: result.plistPath };
+  },
+
+  status(name: ServiceName): ServiceStatus {
+    const s = serviceStatus(name);
+    return {
+      name: s.name,
+      label: s.label,
+      installed: s.installed,
+      configPath: s.plistPath,
+      logFile: s.logFile,
+      ...(s.pid !== undefined ? { pid: s.pid } : {}),
+      ...(s.lastExitStatus !== undefined ? { lastExitStatus: s.lastExitStatus } : {}),
+    };
+  },
+
+  restart(name: ServiceName): ServiceRestartOutcome {
+    if (!this.isInstalled(name)) {
+      return { kind: 'not-installed', configPath: plistPath(name) };
+    }
+    // M-5: process.getuid is undefined on non-POSIX; on darwin it always
+    // exists, but assert explicitly so a misuse surfaces here rather than
+    // as a confusing launchctl "no such domain" error.
+    if (typeof process.getuid !== 'function') {
+      return { kind: 'failed', reason: 'process.getuid is unavailable — restart requires a POSIX system.' };
+    }
+    try {
+      execFileSync('launchctl', ['kickstart', '-k', `${guiDomain()}/${labelFor(name)}`], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: LAUNCHCTL_TIMEOUT_MS,
+      });
+      return { kind: 'restarted', label: labelFor(name) };
+    } catch (e) {
+      return { kind: 'failed', reason: (e as Error).message };
+    }
+  },
+
+  isInstalled(name: ServiceName): boolean {
+    return existsSync(plistPath(name));
+  },
+
+  configPath(name: ServiceName): string {
+    return plistPath(name);
+  },
+
+  logPath(name: ServiceName): string {
+    return serviceLogPath(name);
+  },
+
+  label(name: ServiceName): string {
+    return labelFor(name);
+  },
+
+  readConfigFile(name: ServiceName): string | undefined {
+    return readPlistFile(name);
+  },
+};

--- a/src/service/systemd.test.ts
+++ b/src/service/systemd.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for the systemd `--user` backend (`src/service/systemd/*`).
+ *
+ * Pure parts (unit-file generation, `systemctl show` parsing) are tested
+ * directly. The I/O-bearing parts (install/uninstall) run against a real
+ * per-test tmpdir pointed at via `HOME` + `AFK_HOME` — the same pattern
+ * `launchd.test.ts` uses (cheaper to reason about than vi.mock('fs') and
+ * it exercises the real atomic-write + rename path). `execFileSync` is the
+ * only mock; `systemctl` never runs in CI.
+ *
+ * Mirrors `launchd.test.ts`: if any systemd sub-module is relocated, the
+ * `vi.mock('../telegram/manager.js')` specifier below must track the SUT's
+ * import path — vi.mock resolves by module ID, not by test-side import.
+ */
+
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { homedir, tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockExecFileSync, telegram } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
+  // Mutable so a test can point the resolved entrypoint at a dev-tree path
+  // (under $HOME) to exercise the .path-unit auto-restart branch.
+  telegram: { entrypoint: '/fake/dist/telegram.mjs' },
+}));
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return { ...actual, execFileSync: mockExecFileSync };
+});
+vi.mock('../telegram/manager.js', () => ({
+  resolveEntrypoint: () => telegram.entrypoint,
+}));
+
+// SUT imported after mocks are declared.
+import {
+  installSystemdService,
+  readUnitFile,
+  uninstallSystemdService,
+} from './systemd/install.js';
+import { pathUnitPath, unitPath } from './systemd/paths.js';
+import { parseSystemctlShow } from './systemd/status.js';
+import { renderPathUnit, renderServiceUnit } from './systemd/unit.js';
+
+// ─────────────────────────────────────────────────────────────────────────
+// Pure: unit-file generation
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('renderServiceUnit', () => {
+  it('emits the three sections with KeepAlive-equivalent + start-on-login invariants', () => {
+    const unit = renderServiceUnit({
+      description: 'AFK telegram service',
+      execStart: ['/usr/bin/node', '/home/u/dist/telegram.mjs'],
+      workingDirectory: '/home/u',
+      logFile: '/home/u/.afk/logs/service-telegram.log',
+      environmentVariables: { PATH: '/opt/node/bin:/usr/bin' },
+    });
+    expect(unit).toContain('[Unit]');
+    expect(unit).toContain('[Service]');
+    expect(unit).toContain('[Install]');
+    expect(unit).toContain('Type=simple');
+    expect(unit).toContain('Restart=always');
+    expect(unit).toContain('WantedBy=default.target');
+    expect(unit).toContain('ExecStart="/usr/bin/node" "/home/u/dist/telegram.mjs"');
+    expect(unit).toContain('StandardOutput=append:/home/u/.afk/logs/service-telegram.log');
+    expect(unit).toContain('Environment="PATH=/opt/node/bin:/usr/bin"');
+    expect(unit.endsWith('\n')).toBe(true);
+  });
+
+  it('sorts environment keys for stable diffs', () => {
+    const unit = renderServiceUnit({
+      description: 'd',
+      execStart: ['/x'],
+      workingDirectory: '/',
+      logFile: '/l',
+      environmentVariables: { ZED: '1', ALPHA: '2', MIKE: '3' },
+    });
+    const order = ['ALPHA', 'MIKE', 'ZED'].map((k) => unit.indexOf(`Environment="${k}=`));
+    expect(order[0]).toBeLessThan(order[1]!);
+    expect(order[1]).toBeLessThan(order[2]!);
+  });
+
+  it('omits Environment lines when none provided', () => {
+    const unit = renderServiceUnit({ description: 'd', execStart: ['/x'], workingDirectory: '/', logFile: '/l' });
+    expect(unit).not.toContain('Environment=');
+  });
+
+  it('escapes double quotes and backslashes in exec args and env values', () => {
+    const unit = renderServiceUnit({
+      description: 'd',
+      execStart: ['/bin/x', 'a "b" c', 'back\\slash'],
+      workingDirectory: '/',
+      logFile: '/l',
+      environmentVariables: { K: 'v"q\\z' },
+    });
+    expect(unit).toContain('"a \\"b\\" c"');
+    expect(unit).toContain('"back\\\\slash"');
+    expect(unit).toContain('Environment="K=v\\"q\\\\z"');
+  });
+});
+
+describe('renderPathUnit', () => {
+  it('emits [Path] with PathModified + paired Unit + install target', () => {
+    const unit = renderPathUnit({
+      description: 'AFK telegram rebuild watch',
+      pathModified: ['/home/u/dev/dist/telegram.mjs'],
+      unit: 'afk-telegram.service',
+    });
+    expect(unit).toContain('[Path]');
+    expect(unit).toContain('PathModified=/home/u/dev/dist/telegram.mjs');
+    expect(unit).toContain('Unit=afk-telegram.service');
+    expect(unit).toContain('WantedBy=default.target');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Pure: systemctl show parsing
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('parseSystemctlShow', () => {
+  it('extracts pid when MainPID > 0', () => {
+    const r = parseSystemctlShow('MainPID=4242\nExecMainStatus=0\nActiveState=active\nLoadState=loaded\n');
+    expect(r.pid).toBe(4242);
+    expect(r.lastExitStatus).toBe(0);
+    expect(r.activeState).toBe('active');
+    expect(r.loadState).toBe('loaded');
+  });
+
+  it('omits pid when MainPID=0 (stopped) but keeps last exit status', () => {
+    const r = parseSystemctlShow('MainPID=0\nExecMainStatus=3\nActiveState=failed\n');
+    expect(r.pid).toBeUndefined();
+    expect(r.lastExitStatus).toBe(3);
+    expect(r.activeState).toBe('failed');
+  });
+
+  it('tolerates blank lines and unknown keys', () => {
+    const r = parseSystemctlShow('\nFoo=bar\nMainPID=7\n\nBaz=\n');
+    expect(r.pid).toBe(7);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// I/O: install / uninstall against a real tmpdir
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('install / uninstall I/O', () => {
+  let tmpHome: string;
+  let prevHome: string | undefined;
+  let prevAfkHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'afk-systemd-test-'));
+    prevHome = process.env['HOME'];
+    prevAfkHome = process.env['AFK_HOME'];
+    process.env['HOME'] = tmpHome;
+    process.env['AFK_HOME'] = join(tmpHome, '.afk');
+    mockExecFileSync.mockReset();
+    mockExecFileSync.mockReturnValue(Buffer.from(''));
+    telegram.entrypoint = '/fake/dist/telegram.mjs';
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = prevHome;
+    if (prevAfkHome === undefined) delete process.env['AFK_HOME'];
+    else process.env['AFK_HOME'] = prevAfkHome;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('writes the .service unit, runs daemon-reload + enable --now, returns installed', () => {
+    const result = installSystemdService('telegram', { _entrypointExistsCheck: () => true });
+    expect(result.kind).toBe('installed');
+    if (result.kind !== 'installed') return;
+    expect(result.label).toBe('afk-telegram.service');
+    expect(result.autoRestartOnRebuild).toBe(false);
+
+    const p = unitPath('telegram');
+    expect(existsSync(p)).toBe(true);
+    const content = readFileSync(p, 'utf-8');
+    expect(content).toContain('[Service]');
+    expect(content).toContain('Restart=always');
+    expect(content).toContain('/fake/dist/telegram.mjs');
+
+    const calls = mockExecFileSync.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    expect(calls.some((a) => a.includes('--user daemon-reload'))).toBe(true);
+    expect(calls.some((a) => a.includes('--user enable --now afk-telegram.service'))).toBe(true);
+    // linger advice surfaced
+    expect(result.notes?.some((n) => n.includes('enable-linger'))).toBe(true);
+  });
+
+  it('returns already-installed if the unit exists, without touching systemctl', () => {
+    const p = unitPath('telegram');
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, 'stale');
+    const result = installSystemdService('telegram', { _entrypointExistsCheck: () => true });
+    expect(result.kind).toBe('already-installed');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('dry-run writes the unit but skips systemctl and returns manual-load + linger notes', () => {
+    const result = installSystemdService('telegram', { dryRun: true, _entrypointExistsCheck: () => true });
+    expect(result.kind).toBe('installed');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+    expect(existsSync(unitPath('telegram'))).toBe(true);
+    if (result.kind === 'installed') {
+      expect(result.notes?.some((n) => n.includes('systemctl --user daemon-reload'))).toBe(true);
+      expect(result.notes?.some((n) => n.includes('enable-linger'))).toBe(true);
+    }
+  });
+
+  it('emits a companion .path unit + enables it for a dev-tree entrypoint', () => {
+    telegram.entrypoint = join(homedir(), 'dev', 'agent-afk', 'dist', 'telegram.mjs');
+    const result = installSystemdService('telegram', { _entrypointExistsCheck: () => true });
+    expect(result.kind).toBe('installed');
+    if (result.kind === 'installed') expect(result.autoRestartOnRebuild).toBe(true);
+    const pp = pathUnitPath('telegram');
+    expect(existsSync(pp)).toBe(true);
+    const content = readFileSync(pp, 'utf-8');
+    expect(content).toContain('[Path]');
+    expect(content).toContain('Unit=afk-telegram.service');
+    const calls = mockExecFileSync.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    expect(calls.some((a) => a.includes('--user enable --now afk-telegram.path'))).toBe(true);
+  });
+
+  it('uninstall disables the unit, removes the file, daemon-reloads, returns uninstalled', () => {
+    const p = unitPath('telegram');
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, 'unit');
+    const result = uninstallSystemdService('telegram');
+    expect(result.kind).toBe('uninstalled');
+    expect(existsSync(p)).toBe(false);
+    const calls = mockExecFileSync.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    expect(calls.some((a) => a.includes('--user disable --now afk-telegram.service'))).toBe(true);
+    expect(calls.some((a) => a.includes('--user daemon-reload'))).toBe(true);
+  });
+
+  it('uninstall returns not-installed when no unit file exists', () => {
+    const result = uninstallSystemdService('telegram');
+    expect(result.kind).toBe('not-installed');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('readUnitFile returns contents when installed, undefined otherwise', () => {
+    expect(readUnitFile('telegram')).toBeUndefined();
+    const p = unitPath('telegram');
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, 'hello-unit');
+    expect(readUnitFile('telegram')).toBe('hello-unit');
+  });
+});

--- a/src/service/systemd.test.ts
+++ b/src/service/systemd.test.ts
@@ -38,9 +38,10 @@ import {
   readUnitFile,
   uninstallSystemdService,
 } from './systemd/install.js';
-import { pathUnitPath, unitPath } from './systemd/paths.js';
+import { systemdManager } from './systemd/manager.js';
+import { pathUnitPath, restartUnitPath, unitPath } from './systemd/paths.js';
 import { parseSystemctlShow } from './systemd/status.js';
-import { renderPathUnit, renderServiceUnit } from './systemd/unit.js';
+import { renderPathUnit, renderRestartUnit, renderServiceUnit } from './systemd/unit.js';
 
 // ─────────────────────────────────────────────────────────────────────────
 // Pure: unit-file generation
@@ -97,6 +98,19 @@ describe('renderServiceUnit', () => {
     expect(unit).toContain('"back\\\\slash"');
     expect(unit).toContain('Environment="K=v\\"q\\\\z"');
   });
+
+  it('escapes literal % and embedded newlines (unit-value hardening, item 2)', () => {
+    const unit = renderServiceUnit({
+      description: 'd',
+      execStart: ['/bin/x', '100%done', 'line1\nline2'],
+      workingDirectory: '/',
+      logFile: '/l',
+      environmentVariables: { K: 'a%b\r\nc' },
+    });
+    expect(unit).toContain('"100%%done"');
+    expect(unit).toContain('"line1\\nline2"');
+    expect(unit).toContain('Environment="K=a%%b\\r\\nc"');
+  });
 });
 
 describe('renderPathUnit', () => {
@@ -110,6 +124,22 @@ describe('renderPathUnit', () => {
     expect(unit).toContain('PathModified=/home/u/dev/dist/telegram.mjs');
     expect(unit).toContain('Unit=afk-telegram.service');
     expect(unit).toContain('WantedBy=default.target');
+  });
+});
+
+describe('renderRestartUnit', () => {
+  it('emits a oneshot with no [Install] section that restarts the target unit', () => {
+    const unit = renderRestartUnit({
+      description: 'AFK telegram rebuild restart',
+      systemctlPath: '/usr/bin/systemctl',
+      targetUnit: 'afk-telegram.service',
+    });
+    expect(unit).toContain('[Unit]');
+    expect(unit).toContain('[Service]');
+    expect(unit).toContain('Type=oneshot');
+    expect(unit).toContain('ExecStart=/usr/bin/systemctl --user restart afk-telegram.service');
+    expect(unit).not.toContain('[Install]');
+    expect(unit.endsWith('\n')).toBe(true);
   });
 });
 
@@ -217,9 +247,33 @@ describe('install / uninstall I/O', () => {
     expect(existsSync(pp)).toBe(true);
     const content = readFileSync(pp, 'utf-8');
     expect(content).toContain('[Path]');
-    expect(content).toContain('Unit=afk-telegram.service');
+    // Item 3: the .path unit now triggers the oneshot restart-helper unit,
+    // NOT the service directly (`start` on an already-active
+    // Restart=always unit is a no-op — see renderRestartUnit).
+    expect(content).toContain('Unit=afk-telegram-restart.service');
     const calls = mockExecFileSync.mock.calls.map((c) => (c[1] as string[]).join(' '));
     expect(calls.some((a) => a.includes('--user enable --now afk-telegram.path'))).toBe(true);
+
+    const rp = restartUnitPath('telegram');
+    expect(existsSync(rp)).toBe(true);
+    const restartContent = readFileSync(rp, 'utf-8');
+    expect(restartContent).toContain('Type=oneshot');
+    expect(restartContent).toContain('restart afk-telegram.service');
+  });
+
+  it('rolls back ALL written unit files when `systemctl enable --now` fails (item 1)', () => {
+    telegram.entrypoint = join(homedir(), 'dev', 'agent-afk', 'dist', 'telegram.mjs');
+    mockExecFileSync.mockImplementation((_cmd, args) => {
+      if ((args as string[]).join(' ').includes('enable --now afk-telegram.service')) {
+        throw new Error('Failed to connect to bus');
+      }
+      return Buffer.from('');
+    });
+    const result = installSystemdService('telegram', { _entrypointExistsCheck: () => true });
+    expect(result.kind).toBe('failed');
+    expect(existsSync(unitPath('telegram'))).toBe(false);
+    expect(existsSync(pathUnitPath('telegram'))).toBe(false);
+    expect(existsSync(restartUnitPath('telegram'))).toBe(false);
   });
 
   it('uninstall disables the unit, removes the file, daemon-reloads, returns uninstalled', () => {
@@ -246,5 +300,61 @@ describe('install / uninstall I/O', () => {
     mkdirSync(dirname(p), { recursive: true });
     writeFileSync(p, 'hello-unit');
     expect(readUnitFile('telegram')).toBe('hello-unit');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// I/O: systemdManager.restart()
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('systemdManager.restart()', () => {
+  let tmpHome: string;
+  let prevHome: string | undefined;
+  let prevAfkHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'afk-systemd-restart-test-'));
+    prevHome = process.env['HOME'];
+    prevAfkHome = process.env['AFK_HOME'];
+    process.env['HOME'] = tmpHome;
+    process.env['AFK_HOME'] = join(tmpHome, '.afk');
+    mockExecFileSync.mockReset();
+    mockExecFileSync.mockReturnValue(Buffer.from(''));
+    telegram.entrypoint = '/fake/dist/telegram.mjs';
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env['HOME'];
+    else process.env['HOME'] = prevHome;
+    if (prevAfkHome === undefined) delete process.env['AFK_HOME'];
+    else process.env['AFK_HOME'] = prevAfkHome;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it('returns not-installed when no unit file exists', () => {
+    const result = systemdManager.restart('telegram');
+    expect(result.kind).toBe('not-installed');
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('returns restarted when installed and systemctl succeeds', () => {
+    const p = unitPath('telegram');
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, 'unit');
+    const result = systemdManager.restart('telegram');
+    expect(result.kind).toBe('restarted');
+    const calls = mockExecFileSync.mock.calls.map((c) => (c[1] as string[]).join(' '));
+    expect(calls.some((a) => a.includes('--user restart afk-telegram.service'))).toBe(true);
+  });
+
+  it('returns failed when installed but systemctl throws', () => {
+    const p = unitPath('telegram');
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, 'unit');
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('Failed to connect to bus');
+    });
+    const result = systemdManager.restart('telegram');
+    expect(result.kind).toBe('failed');
   });
 });

--- a/src/service/systemd/install.ts
+++ b/src/service/systemd/install.ts
@@ -1,0 +1,229 @@
+/**
+ * systemd `--user` install / uninstall I/O — the Linux analog of
+ * `launchd/install.ts`.
+ *
+ * Reuses the platform-neutral binary/entrypoint resolvers from
+ * `../launchd/plist.js` (`resolveProgramArguments`, `resolveServicePath`,
+ * `resolveWatchPaths`) — they resolve node/afk/the telegram entrypoint and
+ * build the injected PATH with zero launchctl coupling, so both backends
+ * share them. (A future refactor may hoist them to `service/resolve.ts`.)
+ *
+ * @module service/systemd/install
+ */
+
+import { execFileSync } from 'child_process';
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { dirname } from 'path';
+import type { ServiceInstallOptions, ServiceInstallOutcome, ServiceName, ServiceUninstallOutcome } from '../types.js';
+import { resolveProgramArguments, resolveServicePath, resolveWatchPaths } from '../launchd/plist.js';
+import {
+  SYSTEMCTL_TIMEOUT_MS,
+  pathUnitFileName,
+  pathUnitPath,
+  serviceLogPath,
+  systemdUserDir,
+  unitFileName,
+  unitPath,
+} from './paths.js';
+import { renderPathUnit, renderServiceUnit } from './unit.js';
+
+/** Internal install opts — adds a test seam over the neutral options. */
+export interface SystemdInstallOptions extends ServiceInstallOptions {
+  /**
+   * Override the `existsSync` used to validate the resolved entrypoint
+   * before writing the unit. For tests that stub the telegram manager to
+   * return a fake path. Production callers omit it.
+   */
+  _entrypointExistsCheck?: (p: string) => boolean;
+}
+
+/** Run a `systemctl --user` subcommand, surfacing stderr on failure. */
+function systemctlUser(args: string[]): void {
+  execFileSync('systemctl', ['--user', ...args], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: SYSTEMCTL_TIMEOUT_MS,
+  });
+}
+
+/** Extract the most actionable message from an execFileSync error. */
+function errorDetail(err: unknown): string {
+  const stderr = (err as { stderr?: Buffer | string }).stderr;
+  const text = stderr ? stderr.toString().trim() : '';
+  return text || (err as Error).message;
+}
+
+/**
+ * Atomic file write: tmp sibling with `O_EXCL` (`flag: 'wx'`) + explicit
+ * `mode: 0o600` (unit files may embed API keys/tokens via Environment=),
+ * then `renameSync` into place. Mirrors the launchd installer's threat
+ * model — see `launchd/install.ts`. Returns an error string on failure.
+ */
+function atomicWrite(path: string, content: string): string | undefined {
+  const tmpPath = `${path}.tmp`;
+  try {
+    writeFileSync(tmpPath, content, { encoding: 'utf-8', flag: 'wx', mode: 0o600 });
+  } catch (err) {
+    return `Failed to write unit (tmp ${tmpPath}): ${(err as Error).message}`;
+  }
+  try {
+    renameSync(tmpPath, path);
+  } catch (err) {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // Ignore — the rename error is the actionable one.
+    }
+    return `Failed to install unit (rename ${tmpPath} → ${path}): ${(err as Error).message}`;
+  }
+  return undefined;
+}
+
+const LINGER_NOTE =
+  "Always-on across logout/reboot needs lingering: run 'loginctl enable-linger' (or 'sudo loginctl enable-linger <user>').";
+
+/**
+ * Write the `.service` unit (and, for dev-tree installs, a companion
+ * `.path` unit) and register it with `systemctl --user`.
+ *
+ * Constraint ordering: the unit file MUST exist on disk before
+ * `systemctl --user daemon-reload` + `enable --now`, otherwise enable
+ * fails with "unit not found". So write → daemon-reload → enable, never
+ * the inverse.
+ */
+export function installSystemdService(name: ServiceName, opts: SystemdInstallOptions = {}): ServiceInstallOutcome {
+  const path = unitPath(name);
+  if (existsSync(path)) {
+    return { kind: 'already-installed', configPath: path, label: unitFileName(name) };
+  }
+
+  let args: string[];
+  try {
+    args = resolveProgramArguments(name, opts._entrypointExistsCheck);
+  } catch (err) {
+    return { kind: 'failed', reason: (err as Error).message };
+  }
+  const watchPaths = opts.noWatch ? undefined : resolveWatchPaths(name, opts._entrypointExistsCheck);
+  const logFile = serviceLogPath(name);
+
+  mkdirSync(systemdUserDir(), { recursive: true });
+  mkdirSync(dirname(logFile), { recursive: true });
+
+  // A `--user` unit does not inherit an interactive shell's PATH; inject
+  // one led by the installer's node dir so a `#!/usr/bin/env node` shebang
+  // resolves (same failure launchd's minimal bootstrap PATH causes).
+  // Caller-supplied env wins.
+  const environmentVariables: Record<string, string> = {
+    PATH: resolveServicePath(),
+    ...(opts.environment ?? {}),
+  };
+
+  const unit = renderServiceUnit({
+    description: `AFK ${name} service`,
+    execStart: args,
+    workingDirectory: homedir(),
+    logFile,
+    environmentVariables,
+  });
+  const serviceWriteErr = atomicWrite(path, unit);
+  if (serviceWriteErr) return { kind: 'failed', reason: serviceWriteErr };
+
+  let pathUnitActive = false;
+  if (watchPaths && watchPaths.length > 0) {
+    const pathUnit = renderPathUnit({
+      description: `AFK ${name} rebuild watch`,
+      pathModified: watchPaths,
+      unit: unitFileName(name),
+    });
+    const pathWriteErr = atomicWrite(pathUnitPath(name), pathUnit);
+    if (pathWriteErr) {
+      // Roll back the service unit so a half-install doesn't linger.
+      rmSync(path, { force: true });
+      return { kind: 'failed', reason: pathWriteErr };
+    }
+    pathUnitActive = true;
+  }
+
+  if (opts.dryRun) {
+    return {
+      kind: 'installed',
+      configPath: path,
+      label: unitFileName(name),
+      autoRestartOnRebuild: pathUnitActive,
+      notes: [
+        `(dry-run) systemctl was skipped; service is NOT yet running.`,
+        `Load manually: systemctl --user daemon-reload && systemctl --user enable --now ${unitFileName(name)}`,
+        LINGER_NOTE,
+      ],
+    };
+  }
+
+  try {
+    systemctlUser(['daemon-reload']);
+    systemctlUser(['enable', '--now', unitFileName(name)]);
+    if (pathUnitActive) {
+      systemctlUser(['enable', '--now', pathUnitFileName(name)]);
+    }
+  } catch (err) {
+    return { kind: 'failed', reason: `systemctl enable failed: ${errorDetail(err)}` };
+  }
+
+  return {
+    kind: 'installed',
+    configPath: path,
+    label: unitFileName(name),
+    autoRestartOnRebuild: pathUnitActive,
+    notes: [LINGER_NOTE],
+  };
+}
+
+/**
+ * Disable the unit(s) and remove the unit file(s).
+ *
+ * Constraint ordering: `systemctl --user disable --now` MUST run before
+ * `rm` of the unit file, otherwise we leave a phantom-loaded job whose
+ * unit is gone. So disable → rm → daemon-reload.
+ */
+export function uninstallSystemdService(name: ServiceName): ServiceUninstallOutcome {
+  const path = unitPath(name);
+  if (!existsSync(path)) {
+    return { kind: 'not-installed', configPath: path };
+  }
+  const pPath = pathUnitPath(name);
+  const hadPathUnit = existsSync(pPath);
+
+  // disable failures are usually "not loaded" — non-fatal; keep going so
+  // the files get removed either way.
+  try {
+    if (hadPathUnit) systemctlUser(['disable', '--now', pathUnitFileName(name)]);
+  } catch {
+    // ignore
+  }
+  try {
+    systemctlUser(['disable', '--now', unitFileName(name)]);
+  } catch {
+    // ignore
+  }
+
+  try {
+    rmSync(path, { force: true });
+    if (hadPathUnit) rmSync(pPath, { force: true });
+  } catch (err) {
+    return { kind: 'failed', reason: `Failed to remove unit: ${(err as Error).message}` };
+  }
+
+  // Best-effort reload so systemd forgets the removed unit immediately.
+  try {
+    systemctlUser(['daemon-reload']);
+  } catch {
+    // ignore
+  }
+  return { kind: 'uninstalled', configPath: path };
+}
+
+/** Read the on-disk `.service` unit contents, if installed. */
+export function readUnitFile(name: ServiceName): string | undefined {
+  const path = unitPath(name);
+  if (!existsSync(path)) return undefined;
+  return readFileSync(path, 'utf-8');
+}

--- a/src/service/systemd/install.ts
+++ b/src/service/systemd/install.ts
@@ -21,12 +21,14 @@ import {
   SYSTEMCTL_TIMEOUT_MS,
   pathUnitFileName,
   pathUnitPath,
+  restartUnitFileName,
+  restartUnitPath,
   serviceLogPath,
   systemdUserDir,
   unitFileName,
   unitPath,
 } from './paths.js';
-import { renderPathUnit, renderServiceUnit } from './unit.js';
+import { renderPathUnit, renderRestartUnit, renderServiceUnit } from './unit.js';
 
 /** Internal install opts — adds a test seam over the neutral options. */
 export interface SystemdInstallOptions extends ServiceInstallOptions {
@@ -51,6 +53,23 @@ function errorDetail(err: unknown): string {
   const stderr = (err as { stderr?: Buffer | string }).stderr;
   const text = stderr ? stderr.toString().trim() : '';
   return text || (err as Error).message;
+}
+
+/** Candidate absolute paths checked before falling back to a bare lookup. */
+const SYSTEMCTL_CANDIDATES: readonly string[] = ['/usr/bin/systemctl', '/bin/systemctl'];
+
+/**
+ * Resolve an absolute `systemctl` path for baking into the restart oneshot's
+ * `ExecStart=`. Absolute paths are preferred so the unit doesn't depend on
+ * whatever PATH the (possibly minimal) systemd manager environment has;
+ * falls back to the bare command name, which systemd ≥239 resolves via its
+ * own search of `$PATH` at execution time.
+ */
+function resolveSystemctlPath(existsCheck: (p: string) => boolean = existsSync): string {
+  for (const c of SYSTEMCTL_CANDIDATES) {
+    if (existsCheck(c)) return c;
+  }
+  return 'systemctl';
 }
 
 /**
@@ -83,8 +102,23 @@ const LINGER_NOTE =
   "Always-on across logout/reboot needs lingering: run 'loginctl enable-linger' (or 'sudo loginctl enable-linger <user>').";
 
 /**
+ * Remove every unit file written so far during a failed install. Single
+ * rollback path shared by a path/restart-unit write failure and an
+ * `enable --now` failure — without it, `atomicWrite`'s `O_EXCL` means a
+ * later reinstall attempt hits the top-level `existsSync(path)` guard and
+ * reports `already-installed` for a unit systemd never actually loaded,
+ * wedging the operator until a manual `rm`.
+ */
+function rollbackWrittenUnits(paths: readonly string[]): void {
+  for (const p of paths) {
+    rmSync(p, { force: true });
+  }
+}
+
+/**
  * Write the `.service` unit (and, for dev-tree installs, a companion
- * `.path` unit) and register it with `systemctl --user`.
+ * `.path` unit plus its oneshot restart-helper unit) and register it with
+ * `systemctl --user`.
  *
  * Constraint ordering: the unit file MUST exist on disk before
  * `systemctl --user daemon-reload` + `enable --now`, otherwise enable
@@ -128,19 +162,41 @@ export function installSystemdService(name: ServiceName, opts: SystemdInstallOpt
   const serviceWriteErr = atomicWrite(path, unit);
   if (serviceWriteErr) return { kind: 'failed', reason: serviceWriteErr };
 
+  // Every unit file written so far — rolled back in full on any failure
+  // below (restart-unit write, path-unit write, or `systemctl enable`).
+  const writtenUnits: string[] = [path];
+
   let pathUnitActive = false;
   if (watchPaths && watchPaths.length > 0) {
+    // Resolve the restart oneshot BEFORE the `.path` unit so the `.path`
+    // unit's `Unit=` target (written next) can name it.
+    const systemctlPath = resolveSystemctlPath();
+    const restartUnit = renderRestartUnit({
+      description: `AFK ${name} rebuild restart`,
+      systemctlPath,
+      targetUnit: unitFileName(name),
+    });
+    const restartWriteErr = atomicWrite(restartUnitPath(name), restartUnit);
+    if (restartWriteErr) {
+      rollbackWrittenUnits(writtenUnits);
+      return { kind: 'failed', reason: restartWriteErr };
+    }
+    writtenUnits.push(restartUnitPath(name));
+
     const pathUnit = renderPathUnit({
       description: `AFK ${name} rebuild watch`,
       pathModified: watchPaths,
-      unit: unitFileName(name),
+      // Target the restart oneshot, not the service itself: `start` on an
+      // already-active Restart=always service is a no-op, so a rebuild
+      // would never actually be picked up (see renderRestartUnit).
+      unit: restartUnitFileName(name),
     });
     const pathWriteErr = atomicWrite(pathUnitPath(name), pathUnit);
     if (pathWriteErr) {
-      // Roll back the service unit so a half-install doesn't linger.
-      rmSync(path, { force: true });
+      rollbackWrittenUnits(writtenUnits);
       return { kind: 'failed', reason: pathWriteErr };
     }
+    writtenUnits.push(pathUnitPath(name));
     pathUnitActive = true;
   }
 
@@ -164,7 +220,10 @@ export function installSystemdService(name: ServiceName, opts: SystemdInstallOpt
     if (pathUnitActive) {
       systemctlUser(['enable', '--now', pathUnitFileName(name)]);
     }
+    // The restart oneshot is never enabled — it has no [Install] section
+    // and is only ever activated on demand by the `.path` unit.
   } catch (err) {
+    rollbackWrittenUnits(writtenUnits);
     return { kind: 'failed', reason: `systemctl enable failed: ${errorDetail(err)}` };
   }
 
@@ -191,6 +250,8 @@ export function uninstallSystemdService(name: ServiceName): ServiceUninstallOutc
   }
   const pPath = pathUnitPath(name);
   const hadPathUnit = existsSync(pPath);
+  const rPath = restartUnitPath(name);
+  const hadRestartUnit = existsSync(rPath);
 
   // disable failures are usually "not loaded" — non-fatal; keep going so
   // the files get removed either way.
@@ -204,10 +265,13 @@ export function uninstallSystemdService(name: ServiceName): ServiceUninstallOutc
   } catch {
     // ignore
   }
+  // The restart oneshot is never enabled (no [Install] section, only
+  // activated on demand by the .path unit) — no `disable` needed, just rm.
 
   try {
     rmSync(path, { force: true });
     if (hadPathUnit) rmSync(pPath, { force: true });
+    if (hadRestartUnit) rmSync(rPath, { force: true });
   } catch (err) {
     return { kind: 'failed', reason: `Failed to remove unit: ${(err as Error).message}` };
   }

--- a/src/service/systemd/manager.ts
+++ b/src/service/systemd/manager.ts
@@ -1,0 +1,76 @@
+/**
+ * systemd backend for the platform-neutral {@link ServiceManager} contract
+ * (linux). Thin wiring over `./install.ts`, `./status.ts`, and a
+ * `systemctl --user restart` for restart.
+ *
+ * @module service/systemd/manager
+ */
+
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import type {
+  ServiceInstallOptions,
+  ServiceInstallOutcome,
+  ServiceManager,
+  ServiceName,
+  ServiceRestartOutcome,
+  ServiceStatus,
+  ServiceUninstallOutcome,
+} from '../types.js';
+import { SYSTEMCTL_TIMEOUT_MS, serviceLogPath, systemdLabel, unitFileName, unitPath } from './paths.js';
+import { installSystemdService, readUnitFile, uninstallSystemdService } from './install.js';
+import { systemdStatus } from './status.js';
+
+export const systemdManager: ServiceManager = {
+  backend: 'systemd',
+  configKind: 'systemd user unit',
+
+  install(name: ServiceName, opts: ServiceInstallOptions = {}): ServiceInstallOutcome {
+    return installSystemdService(name, opts);
+  },
+
+  uninstall(name: ServiceName): ServiceUninstallOutcome {
+    return uninstallSystemdService(name);
+  },
+
+  status(name: ServiceName): ServiceStatus {
+    return systemdStatus(name);
+  },
+
+  restart(name: ServiceName): ServiceRestartOutcome {
+    if (!existsSync(unitPath(name))) {
+      return { kind: 'not-installed', configPath: unitPath(name) };
+    }
+    try {
+      execFileSync('systemctl', ['--user', 'restart', unitFileName(name)], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: SYSTEMCTL_TIMEOUT_MS,
+      });
+      return { kind: 'restarted', label: systemdLabel(name) };
+    } catch (e) {
+      const stderr = (e as { stderr?: Buffer | string }).stderr;
+      const reason = stderr ? stderr.toString().trim() || (e as Error).message : (e as Error).message;
+      return { kind: 'failed', reason };
+    }
+  },
+
+  isInstalled(name: ServiceName): boolean {
+    return existsSync(unitPath(name));
+  },
+
+  configPath(name: ServiceName): string {
+    return unitPath(name);
+  },
+
+  logPath(name: ServiceName): string {
+    return serviceLogPath(name);
+  },
+
+  label(name: ServiceName): string {
+    return systemdLabel(name);
+  },
+
+  readConfigFile(name: ServiceName): string | undefined {
+    return readUnitFile(name);
+  },
+};

--- a/src/service/systemd/paths.ts
+++ b/src/service/systemd/paths.ts
@@ -36,6 +36,17 @@ export function pathUnitFileName(name: ServiceName): string {
   return `afk-${name}.path`;
 }
 
+/**
+ * Oneshot restart-helper unit filename triggered by the `.path` unit. A
+ * plain `start` on an already-active `Restart=always` service is a no-op,
+ * so the `.path` unit activates this oneshot instead, which runs
+ * `systemctl --user restart` on the real service. See `unit.ts`'s
+ * `renderRestartUnit`.
+ */
+export function restartUnitFileName(name: ServiceName): string {
+  return `afk-${name}-restart.service`;
+}
+
 /** Absolute path of the `.service` unit file. */
 export function unitPath(name: ServiceName, home: string = homedir()): string {
   return join(systemdUserDir(home), unitFileName(name));
@@ -44,6 +55,11 @@ export function unitPath(name: ServiceName, home: string = homedir()): string {
 /** Absolute path of the companion `.path` unit file. */
 export function pathUnitPath(name: ServiceName, home: string = homedir()): string {
   return join(systemdUserDir(home), pathUnitFileName(name));
+}
+
+/** Absolute path of the oneshot restart-helper unit file. */
+export function restartUnitPath(name: ServiceName, home: string = homedir()): string {
+  return join(systemdUserDir(home), restartUnitFileName(name));
 }
 
 /** Unit label used in CLI output and `systemctl --user` targets. */

--- a/src/service/systemd/paths.ts
+++ b/src/service/systemd/paths.ts
@@ -1,0 +1,68 @@
+/**
+ * systemd `--user` path + label helpers — the Linux analog of
+ * `launchd/paths.ts`.
+ *
+ * Units live in the per-user generator dir `~/.config/systemd/user/`
+ * (XDG default; `$XDG_CONFIG_HOME` is not yet honoured — tracked as a
+ * follow-up). Per-user (not `/etc/systemd/system/`) for the same reasons
+ * launchd uses LaunchAgents over LaunchDaemons: the services read secrets
+ * from `~/.afk/config/afk.env` ($HOME) and write PID/logs/sessions under
+ * `~/.afk/`, so a root/system unit with no $HOME would break them.
+ *
+ * @module service/systemd/paths
+ */
+
+import { homedir } from 'os';
+import { join } from 'path';
+import { getLogsDir } from '../../paths.js';
+import type { ServiceName } from '../types.js';
+
+/** Per-user systemd generator directory. Never `/etc/systemd/system`. */
+export function systemdUserDir(home: string = homedir()): string {
+  return join(home, '.config', 'systemd', 'user');
+}
+
+/** `.service` unit filename for a service, e.g. `afk-telegram.service`. */
+export function unitFileName(name: ServiceName): string {
+  return `afk-${name}.service`;
+}
+
+/**
+ * `.path` unit filename — the systemd equivalent of launchd `WatchPaths`.
+ * A `.path` unit with `PathModified=` restarts the paired `.service` when
+ * the watched file changes (auto-restart-on-rebuild in a dev tree).
+ */
+export function pathUnitFileName(name: ServiceName): string {
+  return `afk-${name}.path`;
+}
+
+/** Absolute path of the `.service` unit file. */
+export function unitPath(name: ServiceName, home: string = homedir()): string {
+  return join(systemdUserDir(home), unitFileName(name));
+}
+
+/** Absolute path of the companion `.path` unit file. */
+export function pathUnitPath(name: ServiceName, home: string = homedir()): string {
+  return join(systemdUserDir(home), pathUnitFileName(name));
+}
+
+/** Unit label used in CLI output and `systemctl --user` targets. */
+export function systemdLabel(name: ServiceName): string {
+  return unitFileName(name);
+}
+
+/**
+ * Per-service log file under `~/.afk/logs/`. Identical to the launchd
+ * backend's log path so `afk service status` reports the same file
+ * regardless of platform.
+ */
+export function serviceLogPath(name: ServiceName): string {
+  return join(getLogsDir(), `service-${name}.log`);
+}
+
+/**
+ * Hard cap on any `systemctl --user` invocation. Mirrors launchd's
+ * LAUNCHCTL_TIMEOUT_MS rationale: a wedged DBus/user-manager handshake
+ * must not hang the AFK CLI forever.
+ */
+export const SYSTEMCTL_TIMEOUT_MS = 8_000;

--- a/src/service/systemd/status.ts
+++ b/src/service/systemd/status.ts
@@ -1,0 +1,85 @@
+/**
+ * systemd status introspection — the Linux analog of
+ * `launchd/status.ts`. Parses `systemctl --user show` key=value output.
+ *
+ * @module service/systemd/status
+ */
+
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import type { ServiceName, ServiceStatus } from '../types.js';
+import { SYSTEMCTL_TIMEOUT_MS, serviceLogPath, systemdLabel, unitFileName, unitPath } from './paths.js';
+
+/** Properties we request from `systemctl show` and the parse we extract. */
+export interface SystemctlShowResult {
+  pid?: number;
+  lastExitStatus?: number;
+  activeState?: string;
+  loadState?: string;
+}
+
+/**
+ * Parse `systemctl --user show <unit> --property=...` output. The output
+ * is newline-separated `Key=Value` lines. A stopped-but-loaded unit
+ * reports `MainPID=0` and its last `ExecMainStatus`; a not-found unit
+ * reports `LoadState=not-found`.
+ *
+ * Returns finite `pid` only when `MainPID > 0`.
+ */
+export function parseSystemctlShow(output: string): SystemctlShowResult {
+  const out: SystemctlShowResult = {};
+  for (const line of output.split('\n')) {
+    const eq = line.indexOf('=');
+    if (eq < 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1).trim();
+    switch (key) {
+      case 'MainPID': {
+        const pid = Number.parseInt(value, 10);
+        if (Number.isFinite(pid) && pid > 0) out.pid = pid;
+        break;
+      }
+      case 'ExecMainStatus': {
+        const status = Number.parseInt(value, 10);
+        if (Number.isFinite(status)) out.lastExitStatus = status;
+        break;
+      }
+      case 'ActiveState':
+        if (value) out.activeState = value;
+        break;
+      case 'LoadState':
+        if (value) out.loadState = value;
+        break;
+      default:
+        break;
+    }
+  }
+  return out;
+}
+
+/** Read live status from systemctl. Side-effecting; not used in unit tests. */
+export function systemdStatus(name: ServiceName): ServiceStatus {
+  const path = unitPath(name);
+  const snapshot: ServiceStatus = {
+    name,
+    label: systemdLabel(name),
+    installed: existsSync(path),
+    configPath: path,
+    logFile: serviceLogPath(name),
+  };
+  if (!snapshot.installed) return snapshot;
+  try {
+    const output = execFileSync(
+      'systemctl',
+      ['--user', 'show', unitFileName(name), '--property=MainPID,ExecMainStatus,ActiveState,LoadState'],
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout: SYSTEMCTL_TIMEOUT_MS },
+    );
+    const parsed = parseSystemctlShow(output);
+    if (parsed.pid !== undefined) snapshot.pid = parsed.pid;
+    if (parsed.lastExitStatus !== undefined) snapshot.lastExitStatus = parsed.lastExitStatus;
+  } catch {
+    // systemctl missing, no user manager, timed out, or errored — the
+    // installed flag is the source of truth; leave pid undefined.
+  }
+  return snapshot;
+}

--- a/src/service/systemd/unit.ts
+++ b/src/service/systemd/unit.ts
@@ -34,18 +34,54 @@ export interface PathUnitOptions {
   unit: string;
 }
 
+/** Inputs for the oneshot restart-helper unit (see `renderRestartUnit`). */
+export interface RestartUnitOptions {
+  description: string;
+  /** Absolute path to `systemctl` (falls back to the bare command; see `install.ts`). */
+  systemctlPath: string;
+  /** The `.service` unit to restart, e.g. `afk-telegram.service`. */
+  targetUnit: string;
+}
+
+/**
+ * Shared escaping for any value embedded in a systemd unit file, used by
+ * both `quoteArg` (ExecStart=) and `escapeEnvValue` (Environment="K=V").
+ *
+ * Order matters and is deliberate:
+ *   1. `\` → `\\`   — backslash FIRST so the escapes added below aren't
+ *      themselves re-escaped by this same replace pass.
+ *   2. `"` → `\"`   — keeps the value safe inside a double-quoted token.
+ *   3. `\n` → `\\n` and `\r` → `\\r` — a raw newline/CR would start a new
+ *      unit-file line and could inject a directive (e.g. a rogue
+ *      `ExecStart=` or `[Section]`); systemd's C-style unquoting
+ *      understands `\n`/`\r` escapes so the value round-trips.
+ *   4. `%` → `%%` LAST — systemd expands `%`-specifiers (`%h`, `%u`, …) at
+ *      load time; escaping earlier could double-escape a literal `%`
+ *      introduced by a prior step (none currently emit one, but ordering
+ *      it last keeps the invariant obviously correct rather than
+ *      incidentally correct). See systemd.service(5) "Specifiers".
+ */
+function escapeUnitValue(s: string): string {
+  return s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/%/g, '%%');
+}
+
 /**
  * Quote one ExecStart argument. systemd splits ExecStart on whitespace;
  * double-quoted args are unquoted with C-style escapes. Quoting every arg
  * is safe and keeps paths containing spaces intact.
  */
 function quoteArg(s: string): string {
-  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  return `"${escapeUnitValue(s)}"`;
 }
 
 /** Escape a value for use inside a double-quoted `Environment="K=V"`. */
 function escapeEnvValue(s: string): string {
-  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  return escapeUnitValue(s);
 }
 
 /**
@@ -103,5 +139,26 @@ export function renderPathUnit(opts: PathUnitOptions): string {
   lines.push('');
   lines.push('[Install]');
   lines.push('WantedBy=default.target');
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Render the oneshot restart-helper unit the `.path` unit triggers.
+ *
+ * `start` on an already-active `Restart=always` service is a no-op — the
+ * rebuilt code would never be loaded (unlike launchd's WatchPaths, which
+ * relaunches). So the `.path` unit targets THIS oneshot instead, which
+ * shells out to `systemctl --user restart <targetUnit>` to force an
+ * actual reload. Deliberately has NO `[Install]` section: it must never be
+ * enabled or started at boot, only activated on demand by the path unit.
+ */
+export function renderRestartUnit(opts: RestartUnitOptions): string {
+  const lines: string[] = [];
+  lines.push('[Unit]');
+  lines.push(`Description=${opts.description}`);
+  lines.push('');
+  lines.push('[Service]');
+  lines.push('Type=oneshot');
+  lines.push(`ExecStart=${opts.systemctlPath} --user restart ${opts.targetUnit}`);
   return lines.join('\n') + '\n';
 }

--- a/src/service/systemd/unit.ts
+++ b/src/service/systemd/unit.ts
@@ -1,0 +1,107 @@
+/**
+ * Pure systemd unit-file generation — the Linux analog of
+ * `launchd/plist.ts`'s `renderPlist`. No I/O; deterministic output
+ * (sorted env keys) so test snapshots are stable across machines.
+ *
+ * @module service/systemd/unit
+ */
+
+/** Inputs that fully determine a generated `.service` unit. Pure data. */
+export interface ServiceUnitOptions {
+  /** `[Unit] Description=`. */
+  description: string;
+  /** Argv to exec. First element is the executable (absolute path). */
+  execStart: string[];
+  /** `[Service] WorkingDirectory=`. */
+  workingDirectory: string;
+  /** Stdout+stderr sink; appended (`append:` needs systemd ≥ 240). */
+  logFile: string;
+  /**
+   * Extra env vars. A `PATH` led by the installer's node dir is injected
+   * by the caller for the same reason launchd needs it — a `--user` unit
+   * does not inherit an interactive shell's PATH, so a bare
+   * `#!/usr/bin/env node` shebang can fail to resolve node.
+   */
+  environmentVariables?: Record<string, string>;
+}
+
+/** Inputs for a companion `.path` unit (the WatchPaths equivalent). */
+export interface PathUnitOptions {
+  description: string;
+  /** Files whose modification restarts the paired service. */
+  pathModified: string[];
+  /** The `.service` unit this path unit activates, e.g. `afk-telegram.service`. */
+  unit: string;
+}
+
+/**
+ * Quote one ExecStart argument. systemd splits ExecStart on whitespace;
+ * double-quoted args are unquoted with C-style escapes. Quoting every arg
+ * is safe and keeps paths containing spaces intact.
+ */
+function quoteArg(s: string): string {
+  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/** Escape a value for use inside a double-quoted `Environment="K=V"`. */
+function escapeEnvValue(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
+ * Render an `afk-<name>.service` unit as a UTF-8 string.
+ *
+ * Invariants (mirror the launchd plist):
+ *   - `Restart=always` ≈ launchd `KeepAlive` — relaunch on any exit.
+ *   - `WantedBy=default.target` ≈ `RunAtLoad` — start on (graphical) login.
+ *   - `After/Wants=network-online.target` — the telegram bot needs the network.
+ */
+export function renderServiceUnit(opts: ServiceUnitOptions): string {
+  const lines: string[] = [];
+  lines.push('[Unit]');
+  lines.push(`Description=${opts.description}`);
+  lines.push('After=network-online.target');
+  lines.push('Wants=network-online.target');
+  lines.push('');
+  lines.push('[Service]');
+  lines.push('Type=simple');
+  lines.push(`ExecStart=${opts.execStart.map(quoteArg).join(' ')}`);
+  lines.push(`WorkingDirectory=${opts.workingDirectory}`);
+  lines.push('Restart=always');
+  lines.push('RestartSec=2');
+  lines.push(`StandardOutput=append:${opts.logFile}`);
+  lines.push(`StandardError=append:${opts.logFile}`);
+  if (opts.environmentVariables && Object.keys(opts.environmentVariables).length > 0) {
+    // Stable key order — unit-file diff hygiene matters when users
+    // version-control or inspect them.
+    for (const k of Object.keys(opts.environmentVariables).sort()) {
+      const v = opts.environmentVariables[k] ?? '';
+      lines.push(`Environment="${k}=${escapeEnvValue(v)}"`);
+    }
+  }
+  lines.push('');
+  lines.push('[Install]');
+  lines.push('WantedBy=default.target');
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Render an `afk-<name>.path` unit — restarts the paired `.service` when
+ * any `PathModified=` file changes. Only emitted for dev-tree installs
+ * (see `resolveWatchPaths`), matching launchd's WatchPaths heuristic.
+ */
+export function renderPathUnit(opts: PathUnitOptions): string {
+  const lines: string[] = [];
+  lines.push('[Unit]');
+  lines.push(`Description=${opts.description}`);
+  lines.push('');
+  lines.push('[Path]');
+  for (const p of opts.pathModified) {
+    lines.push(`PathModified=${p}`);
+  }
+  lines.push(`Unit=${opts.unit}`);
+  lines.push('');
+  lines.push('[Install]');
+  lines.push('WantedBy=default.target');
+  return lines.join('\n') + '\n';
+}

--- a/src/service/types.ts
+++ b/src/service/types.ts
@@ -1,0 +1,116 @@
+/**
+ * Platform-neutral service-manager contract.
+ *
+ * AFK installs its long-running processes (the Telegram bot, the daemon)
+ * as OS-supervised services so they survive logout, reboot, OOM, and
+ * crash. macOS uses launchd LaunchAgents; Linux uses systemd `--user`
+ * units. This module defines the backend-agnostic interface both
+ * implementations satisfy, plus the neutral result shapes the CLI renders.
+ *
+ * Why a neutral layer: `src/cli/commands/service.ts` used to import the
+ * launchd free-functions directly and hard-throw on non-darwin. That
+ * coupled the whole `afk service` surface to macOS. The `ServiceManager`
+ * interface here + the `serviceManagerFor(platform)` factory in
+ * `./index.ts` replace that single darwin gate with a platform dispatch,
+ * mirroring the injected-`platform` pattern `src/cli/clipboard.ts` uses.
+ *
+ * The launchd backend keeps its own launchd-flavoured result types
+ * (`plistPath` fields, etc.) unchanged — a thin adapter
+ * (`./launchd/manager.ts`) maps them onto these neutral shapes, so the
+ * existing launchd test-suite is untouched.
+ *
+ * @module service/types
+ */
+
+/**
+ * Service kinds AFK can register. Mirrors `launchd/paths.ts`'s ServiceName
+ * (kept as a separate declaration so the launchd module and its test-suite
+ * stay byte-stable); the two 2-member unions are structurally identical
+ * and freely assignable.
+ */
+export type ServiceName = 'telegram' | 'daemon';
+
+/** All recognised service names. Single source of truth for CLI validation. */
+export const SERVICE_NAMES: readonly ServiceName[] = ['telegram', 'daemon'];
+
+/** Options accepted by {@link ServiceManager.install}. */
+export interface ServiceInstallOptions {
+  /** Disable auto-restart-on-rebuild even if the dev-tree heuristic would enable it. */
+  noWatch?: boolean;
+  /** Write the unit/plist file but do NOT register it with the supervisor. */
+  dryRun?: boolean;
+  /** Extra environment variables to bake into the unit/plist. */
+  environment?: Record<string, string>;
+}
+
+/** Outcome of {@link ServiceManager.install}. */
+export type ServiceInstallOutcome =
+  | {
+      kind: 'installed';
+      /** Absolute path of the written config (LaunchAgent plist or systemd unit). */
+      configPath: string;
+      label: string;
+      /** True when the backend emitted an auto-restart-on-rebuild trigger (launchd WatchPaths / systemd .path unit). */
+      autoRestartOnRebuild: boolean;
+      /** Backend-specific post-install advice for the operator (e.g. enable lingering). */
+      notes?: string[];
+    }
+  | { kind: 'already-installed'; configPath: string; label: string }
+  | { kind: 'failed'; reason: string };
+
+/** Outcome of {@link ServiceManager.uninstall}. */
+export type ServiceUninstallOutcome =
+  | { kind: 'uninstalled'; configPath: string }
+  | { kind: 'not-installed'; configPath: string }
+  | { kind: 'failed'; reason: string };
+
+/** Outcome of {@link ServiceManager.restart}. */
+export type ServiceRestartOutcome =
+  | { kind: 'restarted'; label: string }
+  | { kind: 'not-installed'; configPath: string }
+  | { kind: 'failed'; reason: string };
+
+/** Neutral status snapshot rendered by `afk service status`. */
+export interface ServiceStatus {
+  name: ServiceName;
+  label: string;
+  installed: boolean;
+  /** Absolute path of the config file (LaunchAgent plist or systemd unit). */
+  configPath: string;
+  /** Running PID if the supervisor reports the job as loaded with an active process. */
+  pid?: number;
+  /** Last exit status reported by the supervisor (0 = clean). */
+  lastExitStatus?: number;
+  /** Log file path AFK redirects the service's stdout+stderr to. */
+  logFile: string;
+}
+
+/**
+ * Backend-agnostic service supervisor. One implementation per platform:
+ *   - `./launchd/manager.ts` (darwin)
+ *   - `./systemd/manager.ts` (linux)
+ *
+ * Selected at the CLI boundary by `serviceManagerFor(process.platform)`.
+ */
+export interface ServiceManager {
+  /** Which supervisor this manager drives. */
+  readonly backend: 'launchd' | 'systemd';
+  /** Human-readable name of the config artifact, for CLI copy ("LaunchAgent plist" / "systemd user unit"). */
+  readonly configKind: string;
+
+  install(name: ServiceName, opts?: ServiceInstallOptions): ServiceInstallOutcome;
+  uninstall(name: ServiceName): ServiceUninstallOutcome;
+  status(name: ServiceName): ServiceStatus;
+  restart(name: ServiceName): ServiceRestartOutcome;
+
+  /** Cheap installed-or-not check (config file present) without querying the supervisor. */
+  isInstalled(name: ServiceName): boolean;
+  /** Absolute path of the config file for a service. */
+  configPath(name: ServiceName): string;
+  /** Absolute path of the service's log file. */
+  logPath(name: ServiceName): string;
+  /** Reverse-DNS / unit label for a service. */
+  label(name: ServiceName): string;
+  /** Read the on-disk config file contents, if installed. */
+  readConfigFile(name: ServiceName): string | undefined;
+}

--- a/src/skills/get-started/prompts/system.md
+++ b/src/skills/get-started/prompts/system.md
@@ -41,7 +41,7 @@ Then give a 4–6 line intro, e.g.:
 **3b. Optional capabilities.** Offer only the ones not already configured:
 - **Exa Search** (web research/grounding): if `EXA_API_KEY` is unset, tell them to set it in `~/.afk/config/afk.env`; offer to explain how.
 - **Telegram** (drive/monitor AFK from your phone): if unconfigured, dispatch the `skill` tool with `/telegram-setup`.
-- **Background service** (always-on bot/daemon): **macOS only** — first check the platform (e.g. `uname` → `Darwin`). If not macOS, skip and say service mode is macOS-only today. On macOS, if they want it, dispatch the `skill` tool with `/service-setup`.
+- **Background service** (always-on bot/daemon): **macOS + Linux** — first check the platform (`uname` → `Darwin` for launchd, `Linux` for systemd `--user`). On other platforms (e.g. Windows), skip and say service mode isn't supported there. Otherwise, if they want it, dispatch the `skill` tool with `/service-setup`.
 
 Don't push all three — suggest based on what they said they want. Re-check the relevant signal after each so you can confirm ✓.
 

--- a/src/skills/service-setup/index.test.ts
+++ b/src/skills/service-setup/index.test.ts
@@ -30,9 +30,12 @@ describe('service-setup skill registration', () => {
     expect(skill.whenToUse).toMatch(/always-on|service|launchd|auto-start/i);
   });
 
-  test('description names the macOS LaunchAgent surface and pre-flight intent', () => {
+  test('description names both service backends (launchd + systemd) and pre-flight intent', () => {
     const skill = getSkill('service-setup');
     expect(skill.description).toMatch(/launchagent|launchd|macOS/i);
+    // Cross-platform: the skill now supports Linux via systemd, so the
+    // description must name that backend too (issue #494).
+    expect(skill.description).toMatch(/systemd|linux/i);
     // Surfaces to the model that pre-flight prevents crash loops — if this
     // ever drifts, the prompt's hard-rule contract may be at risk.
     expect(skill.description).toMatch(/pre-flight|crash|token|valid/i);

--- a/src/skills/service-setup/index.ts
+++ b/src/skills/service-setup/index.ts
@@ -1,7 +1,8 @@
 /**
  * /service-setup skill — walks the user through installing an AFK background
- * process (telegram bot, daemon) as a macOS LaunchAgent so it auto-starts on
- * login and relaunches on crash.
+ * process (telegram bot, daemon) as an OS-supervised service (macOS launchd
+ * LaunchAgent / Linux systemd `--user` unit) so it auto-starts on login and
+ * relaunches on crash.
  *
  * This is the natural companion to the `afk service` CLI surface introduced
  * in PR #346. The CLI itself is one-shot and assumes you know what you want.
@@ -15,8 +16,9 @@
  *   token produces an infinite KeepAlive crash loop. The skill checks
  *   `afk telegram check-token` first and routes to `/telegram-setup` if
  *   the token isn't valid.
- * - macOS-only — the skill surfaces a clean error on non-Darwin instead of
- *   relying on commander's `assertMacOS()` to fire mid-pipeline.
+ * - macOS + Linux — the skill checks `uname` up front and surfaces a clean
+ *   error on unsupported platforms (e.g. Windows) instead of relying on the
+ *   CLI's platform dispatch to fail mid-pipeline.
  * - Parallel to `/telegram-setup` (which configures the token) — together
  *   they cover the full "make this thing always-on" flow.
  *
@@ -46,7 +48,7 @@ async function handler(): Promise<unknown> {
 export const serviceSetupSkill: SkillMetadata = {
   name: 'service-setup',
   description:
-    'Install an AFK background process (telegram bot or daemon) as a macOS LaunchAgent so it auto-starts on login and relaunches on crash. Runs pre-flight checks (e.g., refuses to install the telegram service with an invalid token, which would otherwise crash-loop under KeepAlive), invokes `afk service install`, verifies with `afk service status`, and surfaces the management cheatsheet. macOS-only — gracefully refuses on other platforms.',
+    'Install an AFK background process (telegram bot or daemon) as an OS-supervised service — a launchd LaunchAgent on macOS or a systemd `--user` unit on Linux — so it auto-starts on login and relaunches on crash. Runs pre-flight checks (e.g., refuses to install the telegram service with an invalid token, which would otherwise crash-loop under KeepAlive/Restart=always), invokes `afk service install`, verifies with `afk service status`, and surfaces the management cheatsheet (including the `loginctl enable-linger` step on Linux). macOS + Linux — gracefully refuses on other platforms.',
   handler,
   context: 'fork',
   whenToUse:

--- a/src/skills/service-setup/prompts/system.md
+++ b/src/skills/service-setup/prompts/system.md
@@ -1,9 +1,9 @@
-You are installing an AFK background process (telegram bot or daemon) as a macOS LaunchAgent so it auto-starts on login and relaunches on crash. The user-facing surface is the `afk service` command group; you orchestrate its lifecycle and refuse to install in states that would produce a `KeepAlive` crash loop.
+You are installing an AFK background process (telegram bot or daemon) as an OS-supervised service so it auto-starts on login and relaunches on crash. The backend is chosen per platform: macOS uses a launchd LaunchAgent (`~/Library/LaunchAgents/`), Linux uses a systemd `--user` unit (`~/.config/systemd/user/`). The user-facing surface is the `afk service` command group; you orchestrate its lifecycle and refuse to install in states that would produce a crash loop (launchd `KeepAlive` / systemd `Restart=always`).
 
 ## Hard rules
 
-1. **macOS only.** Before doing anything, run `uname` and confirm output is `Darwin`. On anything else, tell the user `afk service` is macOS-only (uses `launchctl` and `~/Library/LaunchAgents/`) and stop. Do not attempt a workaround.
-2. **Use only the sanctioned subcommands.** Never invoke `launchctl` directly, never write to `~/Library/LaunchAgents/` yourself, never read `~/.afk/config/afk.env`. The sanctioned surface:
+1. **macOS or Linux only.** Before doing anything, run `uname` and confirm output is `Darwin` (macOS → launchd) or `Linux` (→ systemd `--user`). On anything else (e.g. Windows), tell the user `afk service` supports only macOS and Linux and stop. Do not attempt a workaround.
+2. **Use only the sanctioned subcommands.** Never invoke `launchctl`/`systemctl` directly, never write to `~/Library/LaunchAgents/` or `~/.config/systemd/user/` yourself, never read `~/.afk/config/afk.env`. The sanctioned surface:
    - `afk service install <telegram|daemon> [--no-watch] [--dry-run]`
    - `afk service uninstall <name>`
    - `afk service status [name]`
@@ -30,11 +30,15 @@ Wait for their answer. Anything outside the two values: re-ask once, then bail w
 
 ### Step 2 — Platform check
 
-Run `uname`. If the trimmed stdout is not `Darwin`, tell the user:
+Run `uname`. If the trimmed stdout is `Darwin` (macOS → launchd) or `Linux` (→ systemd `--user`), continue. Otherwise tell the user:
 
-> `afk service` only works on macOS — it uses `launchctl` and `~/Library/LaunchAgents/`. On Linux you'd want a systemd user unit (not yet shipped). Detected platform: `<output>`.
+> `afk service` supports only macOS (launchd) and Linux (systemd `--user`). Detected platform: `<output>`.
 
 Then stop.
+
+On **Linux**, also note once (systemd `--user` services stop at logout without lingering):
+
+> Heads up — on Linux, a systemd `--user` service only survives logout/reboot if user lingering is enabled. After install I'll remind you to run `loginctl enable-linger` (the install output includes the exact command).
 
 ### Step 3 — Check current install state
 
@@ -80,11 +84,11 @@ Then continue.
 
 Run `afk service install <name>`. Read the human-formatted output:
 
-- `✓ Installed com.afk.<name>` → success. Note the WatchPaths line from the output (telegram only). Continue to Step 6.
+- `✓ Installed <label>` → success (label is `com.afk.<name>` on launchd, `afk-<name>.service` on systemd). Note the `Auto-restart on rebuild` line (telegram dev-tree only) and any post-install notes (on Linux this includes the `loginctl enable-linger` command — surface it to the user). Continue to Step 6.
 - `⚠ ... already installed` → race with Step 3 (or the user installed manually between steps). Re-run status; do not force-reinstall.
 - `✗ Install failed: <reason>` → surface the exact reason verbatim. Common causes worth naming when you see them:
-  - "Telegram entrypoint resolved to a `.ts` file" → user is running from source without building. Tell them to run `pnpm build` first; launchd needs the compiled `.mjs` entrypoint.
-  - "Already bootstrapped" → orphan plist from a prior install. Run `afk service uninstall <name>` and retry once.
+  - "Telegram entrypoint resolved to a `.ts` file" → user is running from source without building. Tell them to run `pnpm build` first; the supervisor runs the compiled `.mjs` entrypoint directly (no tsx/loader).
+  - "Already bootstrapped" (launchd) / "unit already exists" (systemd) → orphan config from a prior install. Run `afk service uninstall <name>` and retry once.
 
   Then stop. Don't loop indefinitely.
 
@@ -92,7 +96,7 @@ Run `afk service install <name>`. Read the human-formatted output:
 
 Run `afk service status <name>` again. If the output shows `Running  (PID <n>)`:
 
-> ✓ `<name>` is now running as a LaunchAgent (PID <n>). It will auto-start on login and relaunch if it crashes.
+> ✓ `<name>` is now running as an OS service (PID <n>). It will auto-start on login and relaunch if it crashes.
 
 If it still shows `Installed but not running` after install:
 
@@ -111,19 +115,20 @@ End with the management commands the user will need later:
 > Management:
 > - `afk service status <name>` — check running state, PID, last exit
 > - `afk service restart <name>` — bounce after config changes
-> - `afk service uninstall <name>` — stop and remove the plist
+> - `afk service uninstall <name>` — stop and remove the service config
 > - Logs: `~/.afk/logs/service-<name>.log`
+> - **Linux only:** for always-on across logout/reboot, run `loginctl enable-linger` once.
 >
-> Note: `afk telegram status` reports "stopped" when launchd is the supervisor — that's expected. Use `afk service status telegram` to introspect the LaunchAgent-managed instance.
+> Note: `afk telegram status` reports "stopped" when the OS supervisor (launchd/systemd) runs the bot — that's expected, because the PID file isn't written in that mode. Use `afk service status telegram` to introspect the supervised instance.
 
 Then stop.
 
 ## Tone
 
-Terse and operational. One line per step confirmation. Use `✓` / `✗` markers. Code-fence any command the user should run. Don't narrate the launchd internals unless asked — the user wants the service running, not a tutorial.
+Terse and operational. One line per step confirmation. Use `✓` / `✗` markers. Code-fence any command the user should run. Don't narrate the launchd/systemd internals unless asked — the user wants the service running, not a tutorial.
 
 ## Surface awareness
 
 If the user is reaching you over Telegram (mentioned phone, or session metadata indicates so), note once at Step 1:
 
-> Heads up — `afk service` installs a per-user LaunchAgent on the machine where AFK is installed. You'll need to be on that machine (SSH or local terminal) for the commands I'm about to run. I can still walk through them, but the install happens there.
+> Heads up — `afk service` installs a per-user OS service (launchd LaunchAgent on macOS, systemd `--user` unit on Linux) on the machine where AFK is installed. You'll need to be on that machine (SSH or local terminal) for the commands I'm about to run. I can still walk through them, but the install happens there.


### PR DESCRIPTION
## Summary

Makes `afk service` cross-platform. It was hard-gated to macOS via a single `assertMacOS()` throw + direct launchd imports; this extracts a backend-neutral seam and adds a first-class Linux **systemd `--user`** backend.

**Part of #494 (Linux compatibility) — Phase 1: the service-layer blocker.** Does not fully close #494; the secondary untested-Linux-branch touchpoints are a tracked follow-up (below).

## What's in it

- **`service/types.ts`** — `ServiceManager` interface + neutral result shapes (`configPath`, `autoRestartOnRebuild`, `notes[]`, `backend`/`configKind`). The de-leaked contract both backends satisfy.
- **`service/index.ts`** — `serviceManagerFor(platform = process.platform)` factory (`darwin`→launchd, `linux`→systemd, else→`null`). The CLI renders a clear "not supported on <platform>" message on `null` instead of throwing mid-pipeline.
- **`service/launchd/manager.ts`** — thin adapter delegating to the **existing, unchanged** launchd free-functions and mapping `plistPath`→`configPath` etc. The 776-line launchd test suite is untouched.
- **`service/systemd/`** — full `--user` backend: `.service` + companion `.path` unit generation (`unit.ts`), atomic install with `daemon-reload` + `enable --now` and rollback (`install.ts`), `systemctl show` parsing (`status.ts`), XDG-default paths (`paths.ts`), restart via `systemctl --user restart` (`manager.ts`). Surfaces the `loginctl enable-linger` requirement as an install note.
- **`service/cli/commands/service.ts`** — every subcommand dispatches through the resolved manager.
- **`service-setup` + `get-started` skills** — docs/metadata now name both backends (launchd + systemd) and the Linux lingering step.

Resolves the two design decisions from the scope: ship a companion `.path` unit for the WatchPaths equivalent, and *surface* (not auto-enable) lingering.

## Verification

- `pnpm lint` (`tsc --noEmit`, strict) — clean.
- Full `vitest` suite — **11,233 passed / 14 skipped / 0 failed**, including new `src/service/index.test.ts` (factory dispatch) + `src/service/systemd.test.ts` (unit/path rendering, `systemctl show` parse). launchd suite unchanged and green.
- Built + verified on macOS; the systemd runtime path (real `systemctl --user`) is unit-tested but **not yet smoke-tested on a live Linux box** — see follow-ups.

## Follow-ups (not in this PR)

- **Phase 2 — secondary touchpoints** with untested Linux branches: telegram `readProcessMeta` `/proc` parse, `mcp/oauth` `defaultBackend` credential store, browser `detectChromeMajorVersion`, `terminal-font-size` `discoverEditors`.
- **Real-Linux smoke test**: install/status/restart, reboot persistence under `enable-linger`, telegram bot under systemd.
- **Minor**: `resolveAfkBinary` trusted-prefix allowlist lacks `~/.local/bin` + version-manager dirs common on Linux; `XDG_CONFIG_HOME` not yet honored; hoist the shared resolvers out of `launchd/plist.ts` into `service/resolve.ts`.
