### PR TITLE
feat(providers): cross-provider history compaction

### DIFF
--- a/src/agent/providers/anthropic-direct/compact.ts
+++ b/src/agent/providers/anthropic-direct/compact.ts
@@ -1,67 +1,50 @@
 /**
- * Pure helpers for in-place history compaction in the `anthropic-direct`
- * provider. Kept side-effect-free so they can be unit-tested without an
- * Anthropic client.
+ * Anthropic-direct compaction: the `CompactionOps<MessageParam>` implementation
+ * plus back-compatible wrappers over the provider-neutral core in
+ * `shared/compaction.ts`.
  *
- * The provider's `messages: MessageParam[]` array grows unbounded across
- * turns. Compaction summarizes older turns into a short preamble while
- * preserving the last `keepLastN` raw user turns plus their tool rounds.
+ * The generic algorithm (boundary walk, transcript render, preamble splice,
+ * saved-tokens estimate) and the summarization prompt now live in shared/ so
+ * every provider can reuse them. This file supplies only the Anthropic message
+ * representation (`MessageParam`) — how a tool round renders to text, which
+ * turns are "fresh user turns", and the shape of the synthetic preamble.
  *
- * Key invariant: every `tool_use` block must travel with its matching
- * `tool_result`. The boundary rule never splits a tool round because it
- * lands on a "fresh user turn" — a `role: 'user'` message whose content
+ * Invariant: every `tool_use` block travels with its matching `tool_result`.
+ * The boundary rule (via {@link isFreshUserTurn}) never splits a tool round
+ * because it lands the kept tail on a `role: 'user'` message whose content
  * carries no `tool_result` blocks.
+ *
+ * The exported `findCompactionBoundary` / `applyCompaction` / `estimateTokensSaved`
+ * / `buildSummarizationRequest` keep their original signatures so existing
+ * callers (`query/compact-handler.ts`) and tests resolve unchanged — they are
+ * thin adapters binding the shared generics to {@link anthropicCompactionOps}.
  *
  * @module agent/providers/anthropic-direct/compact
  */
 import type { ContentBlockParam, MessageParam } from '@anthropic-ai/sdk/resources';
 import type { AnthropicMessagesCreateParams } from './types.js';
+import {
+  COMPACT_ACK_TEXT,
+  COMPACT_SUMMARY_HEADER,
+  COMPACT_SYSTEM_PROMPT,
+  applyCompaction as sharedApplyCompaction,
+  estimateTokensSaved as sharedEstimateTokensSaved,
+  findCompactionBoundary as sharedFindCompactionBoundary,
+  renderTranscript as sharedRenderTranscript,
+  wrapTranscriptForSummary,
+  type CompactionOps,
+} from '../shared/compaction.js';
+
+// Re-export the shared constants so existing importers (compact-handler.ts,
+// compact.test.ts) keep resolving them from this module.
+export { COMPACT_ACK_TEXT, COMPACT_SUMMARY_HEADER, COMPACT_SYSTEM_PROMPT };
 
 /**
- * System instruction for the summarization call. Crafted to preserve what a
- * future turn actually needs: user intent and corrections, tool decisions
- * and outcomes, current state and next action, open questions, and key
- * facts discovered.
- */
-export const COMPACT_SYSTEM_PROMPT = [
-  'You are a conversation-summarization assistant. The user will paste a',
-  'prior conversation between a user and an AI assistant that includes tool',
-  'calls and tool results. Produce a concise but complete summary that lets',
-  'the AI continue the conversation without losing track.',
-  '',
-  'Preserve, in this priority order:',
-  '1. The user\'s original intent, explicit asks, constraints, corrections,',
-  '   and preferences stated during the conversation.',
-  '2. Tool decisions and their outcomes — file paths read or written, shell',
-  '   commands run, search queries, URLs fetched, code edits made, tests',
-  '   run, errors observed, and whether each action succeeded or failed.',
-  '3. Current state: what has been completed, what remains unresolved, and',
-  '   the safest next action.',
-  '4. Open questions, pending decisions, blockers, and assumptions.',
-  '5. Key facts the assistant discovered (function locations, schemas,',
-  '   observed behaviors, important external findings).',
-  '',
-  'Drop prose narration, conversational filler, and exploratory dead-ends.',
-  'Drop verbatim tool output unless an exact snippet, error, path, command,',
-  'or result is needed for continuation.',
-  'Do not invent details. If something is uncertain, mark it explicitly.',
-  'Output plain text, no markdown headers. Aim for ~250 words; use up to',
-  '~400 only when needed to preserve tool state or unresolved tasks.',
-].join('\n');
-
-/** Default key the summary message uses to flag itself in history. */
-export const COMPACT_SUMMARY_HEADER = '[Compacted summary of earlier conversation]';
-
-/** Default acknowledgement the synthetic assistant turn returns. */
-export const COMPACT_ACK_TEXT =
-  'Acknowledged. Continuing from the summary above.';
-
-/**
- * Test whether a `MessageParam` represents a fresh user turn — i.e., real
- * user input rather than a tool-result follow-up the loop synthesized.
+ * Test whether a `MessageParam` represents a fresh user turn — real user input
+ * rather than a tool-result follow-up the loop synthesized.
  *
- * String content is always fresh. Array content is fresh only if no block
- * is a `tool_result`.
+ * String content is always fresh. Array content is fresh only if no block is a
+ * `tool_result`.
  */
 export function isFreshUserTurn(msg: MessageParam): boolean {
   if (msg.role !== 'user') return false;
@@ -76,143 +59,128 @@ export function isFreshUserTurn(msg: MessageParam): boolean {
 }
 
 /**
- * Find the index in `messages` that marks the start of the kept tail. Walk
- * backwards counting fresh user turns; the boundary is the index of the
- * `keepLastN`-th fresh user turn from the end.
+ * Render one Anthropic message as a transcript block: a speaker label followed
+ * by its content. `tool_use` blocks become `[tool call: NAME args]`;
+ * `tool_result` blocks become `[tool result: <text>]`; images/documents become
+ * short placeholders. Kept side-effect-free and stable so the summarizer input
+ * (and thus summary quality) does not drift.
+ */
+function renderMessage(msg: MessageParam): string {
+  const speaker = msg.role === 'user' ? 'User' : 'Assistant';
+  const lines: string[] = [speaker + ':'];
+  if (typeof msg.content === 'string') {
+    lines.push(msg.content);
+  } else if (Array.isArray(msg.content)) {
+    for (const block of msg.content as ContentBlockParam[]) {
+      const t = (block as { type?: string }).type;
+      if (t === 'text' && 'text' in block) {
+        lines.push((block as { text: string }).text);
+      } else if (t === 'tool_use') {
+        const name = (block as { name?: string }).name ?? 'unknown';
+        const inputJson = safeJson((block as { input?: unknown }).input);
+        lines.push(`[tool call: ${name} ${inputJson}]`);
+      } else if (t === 'tool_result') {
+        const content = (block as { content?: unknown }).content;
+        lines.push(`[tool result: ${stringifyToolResultContent(content)}]`);
+      } else if (t === 'image') {
+        lines.push('[image]');
+      } else if (t === 'document') {
+        lines.push('[document]');
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
+/** Approximate content-character count for one message (saved-tokens estimate). */
+function countChars(msg: MessageParam): number {
+  let total = 0;
+  if (typeof msg.content === 'string') {
+    total += msg.content.length;
+  } else if (Array.isArray(msg.content)) {
+    for (const block of msg.content as ContentBlockParam[]) {
+      const t = (block as { type?: string }).type;
+      if (t === 'text' && 'text' in block) {
+        total += (block as { text: string }).text.length;
+      } else if (t === 'tool_use') {
+        total += safeJson((block as { input?: unknown }).input).length;
+      } else if (t === 'tool_result') {
+        total += stringifyToolResultContent((block as { content?: unknown }).content).length;
+      }
+    }
+  }
+  return total;
+}
+
+/** Anthropic message-representation primitives for the shared compaction core. */
+export const anthropicCompactionOps: CompactionOps<MessageParam> = {
+  isFreshUserTurn,
+  renderMessage,
+  buildPreamble(summaryText: string): [MessageParam, MessageParam] {
+    return [
+      { role: 'user', content: COMPACT_SUMMARY_HEADER + '\n\n' + summaryText },
+      { role: 'assistant', content: COMPACT_ACK_TEXT },
+    ];
+  },
+  countChars,
+};
+
+/**
+ * Find the index in `messages` that marks the start of the kept tail. Thin
+ * adapter over the shared generic bound to {@link anthropicCompactionOps}.
  *
- * Returns:
- *   - `-1` when there are fewer than `keepLastN` fresh user turns (caller
- *     should treat this as "history too short — no compaction").
- *   - An index `>= 0` otherwise. `messages.slice(boundary)` is the kept
- *     tail; `messages.slice(0, boundary)` is what gets summarized.
- *
- * The kept tail always starts with a fresh user turn so the synthetic
- * `[user_summary, assistant_ack]` preamble can be prepended without
- * breaking user/assistant alternation.
+ * Returns `-1` when there are fewer than `keepLastN` fresh user turns; an index
+ * `>= 0` otherwise (`messages.slice(boundary)` is the kept tail).
  */
 export function findCompactionBoundary(
   messages: ReadonlyArray<MessageParam>,
   keepLastN: number,
 ): number {
-  if (keepLastN <= 0) return messages.length;
-  let count = 0;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg && isFreshUserTurn(msg)) {
-      count += 1;
-      if (count === keepLastN) return i;
-    }
-  }
-  return -1;
+  return sharedFindCompactionBoundary(messages, keepLastN, anthropicCompactionOps);
 }
 
 /**
- * Build the summarization request body. The older messages travel as the
- * conversation to summarize, prefixed by a single user instruction so the
- * model knows what to do.
- *
- * The returned params are non-streaming, tool-less, and suitable for a
- * one-shot `messages.create` call.
+ * Build the summarization request body. The older messages travel as a rendered
+ * transcript, prefixed by a single user instruction. Non-streaming-safe,
+ * tool-less, suitable for a one-shot `messages.create` call.
  */
 export function buildSummarizationRequest(
   olderMessages: ReadonlyArray<MessageParam>,
   model: string,
   maxTokens: number,
 ): AnthropicMessagesCreateParams {
-  // Render older messages as a plain transcript so the summarizer doesn't
-  // need to interpret tool_use/tool_result block shapes — those are noise
-  // for summarization and can confuse small models.
-  const transcript = renderTranscript(olderMessages);
+  const transcript = sharedRenderTranscript(olderMessages, anthropicCompactionOps);
   return {
     model,
     max_tokens: maxTokens,
     system: COMPACT_SYSTEM_PROMPT,
-    messages: [
-      {
-        role: 'user',
-        content:
-          'Summarize the following conversation transcript. Follow the ' +
-          'system instructions exactly.\n\n' +
-          '<transcript>\n' +
-          transcript +
-          '\n</transcript>',
-      },
-    ],
+    messages: [{ role: 'user', content: wrapTranscriptForSummary(transcript) }],
     stream: true,
   };
 }
 
 /**
- * Splice in the synthetic preamble. Returns a new array; the caller decides
- * whether to assign it back to the provider's mutable `messages` slot.
+ * Splice in the synthetic preamble. Thin adapter over the shared generic bound
+ * to {@link anthropicCompactionOps}. Returns a new array.
  */
 export function applyCompaction(
   messages: ReadonlyArray<MessageParam>,
   boundary: number,
   summaryText: string,
 ): MessageParam[] {
-  const summaryBlock: MessageParam = {
-    role: 'user',
-    content: COMPACT_SUMMARY_HEADER + '\n\n' + summaryText,
-  };
-  const ackBlock: MessageParam = {
-    role: 'assistant',
-    content: COMPACT_ACK_TEXT,
-  };
-  return [summaryBlock, ackBlock, ...messages.slice(boundary)];
+  return sharedApplyCompaction(messages, boundary, summaryText, anthropicCompactionOps);
 }
 
 /**
- * Estimate input tokens saved by replacing `[0, boundary)` with the
- * synthetic preamble. Rough char/4 heuristic — good enough for a UX hint,
- * not for billing.
+ * Estimate input tokens saved by replacing `[0, boundary)` with the synthetic
+ * preamble. Thin adapter over the shared generic.
  */
 export function estimateTokensSaved(
   before: ReadonlyArray<MessageParam>,
   boundary: number,
   summaryText: string,
 ): number {
-  const droppedChars = countContentChars(before.slice(0, boundary));
-  const addedChars =
-    COMPACT_SUMMARY_HEADER.length + 2 + summaryText.length + COMPACT_ACK_TEXT.length;
-  const delta = Math.max(0, droppedChars - addedChars);
-  return Math.round(delta / 4);
-}
-
-/**
- * Render a slice of `MessageParam`s as a plain text transcript for the
- * summarizer. Tool-use blocks become `[tool: NAME args]`; tool-result
- * blocks become `[tool result: <text>]`; image blocks become `[image]`.
- */
-function renderTranscript(messages: ReadonlyArray<MessageParam>): string {
-  const lines: string[] = [];
-  for (const msg of messages) {
-    const speaker = msg.role === 'user' ? 'User' : 'Assistant';
-    lines.push(speaker + ':');
-    if (typeof msg.content === 'string') {
-      lines.push(msg.content);
-    } else if (Array.isArray(msg.content)) {
-      for (const block of msg.content as ContentBlockParam[]) {
-        const t = (block as { type?: string }).type;
-        if (t === 'text' && 'text' in block) {
-          lines.push((block as { text: string }).text);
-        } else if (t === 'tool_use') {
-          const name = (block as { name?: string }).name ?? 'unknown';
-          const inputJson = safeJson((block as { input?: unknown }).input);
-          lines.push(`[tool call: ${name} ${inputJson}]`);
-        } else if (t === 'tool_result') {
-          const content = (block as { content?: unknown }).content;
-          lines.push(`[tool result: ${stringifyToolResultContent(content)}]`);
-        } else if (t === 'image') {
-          lines.push('[image]');
-        } else if (t === 'document') {
-          lines.push('[document]');
-        }
-      }
-    }
-    lines.push('');
-  }
-  return lines.join('\n').trim();
+  return sharedEstimateTokensSaved(before, boundary, summaryText, anthropicCompactionOps);
 }
 
 function safeJson(v: unknown): string {
@@ -241,27 +209,4 @@ function stringifyToolResultContent(content: unknown): string {
     return joined.length > 320 ? joined.slice(0, 317) + '...' : joined;
   }
   return '';
-}
-
-function countContentChars(messages: ReadonlyArray<MessageParam>): number {
-  let total = 0;
-  for (const msg of messages) {
-    if (typeof msg.content === 'string') {
-      total += msg.content.length;
-    } else if (Array.isArray(msg.content)) {
-      for (const block of msg.content as ContentBlockParam[]) {
-        const t = (block as { type?: string }).type;
-        if (t === 'text' && 'text' in block) {
-          total += (block as { text: string }).text.length;
-        } else if (t === 'tool_use') {
-          total += safeJson((block as { input?: unknown }).input).length;
-        } else if (t === 'tool_result') {
-          total += stringifyToolResultContent(
-            (block as { content?: unknown }).content,
-          ).length;
-        }
-      }
-    }
-  }
-  return total;
 }

--- a/src/agent/providers/anthropic-direct/resolve-params.ts
+++ b/src/agent/providers/anthropic-direct/resolve-params.ts
@@ -28,28 +28,10 @@ const isOpus47Plus = (model: string): boolean => /opus-4-(7|[89])/.test(model);
 const requiresAdaptiveThinking = (model: string): boolean =>
   isOpus47Plus(model) || /(claude-)?sonnet-5/.test(model);
 
-const DEFAULT_AUTO_COMPACT_THRESHOLD = 0.9;
-
-/**
- * Resolve `AgentConfig.autoCompact` to a numeric threshold fraction, or
- * `undefined` when auto-compaction is disabled.
- *
- * - `false` or `undefined` → disabled (`undefined` returned).
- * - `true` → default threshold (0.90).
- * - `{ threshold: n }` → custom fraction; clamped to (0, 1) exclusive.
- *   Out-of-range values are silently treated as disabled.
- */
-export function resolveAutoCompactThreshold(
-  autoCompact: AgentConfig['autoCompact'],
-): number | undefined {
-  if (autoCompact === undefined || autoCompact === false) return undefined;
-  if (autoCompact === true) return DEFAULT_AUTO_COMPACT_THRESHOLD;
-  const t = autoCompact.threshold;
-  if (typeof t !== 'number' || !Number.isFinite(t) || t <= 0 || t >= 1) {
-    return undefined;
-  }
-  return t;
-}
+// resolveAutoCompactThreshold moved to shared/auto-compact.ts (both providers
+// auto-compact now). Re-exported here so existing importers (index.ts) resolve
+// unchanged.
+export { resolveAutoCompactThreshold } from '../shared/auto-compact.js';
 
 /**
  * Module-scope dedupe for budget-clamp warnings, keyed so a single

--- a/src/agent/providers/openai-compatible/compact.test.ts
+++ b/src/agent/providers/openai-compatible/compact.test.ts
@@ -72,6 +72,24 @@ function deps(over: Partial<CompactOpenAIHistoryDeps> = {}): CompactOpenAIHistor
   };
 }
 
+/**
+ * History with a complete tool round BEFORE the keep window and another INSIDE
+ * it. Fresh user turns (role:'user') sit at indices 0, 3, 6 → keepLastN=2 lands
+ * the boundary on u2 (index 3), so the first round (t1) is summarized away and
+ * the second round (t2) must survive intact in the kept tail.
+ */
+function historyWithToolRounds(): OpenAIMessage[] {
+  return [
+    { role: 'user', content: 'u1' },
+    { role: 'assistant', content: '', tool_calls: [{ id: 't1', type: 'function', function: { name: 'grep', arguments: '{}' } }] },
+    { role: 'tool', content: 'result-1', tool_call_id: 't1' },
+    { role: 'user', content: 'u2' },
+    { role: 'assistant', content: '', tool_calls: [{ id: 't2', type: 'function', function: { name: 'read', arguments: '{}' } }] },
+    { role: 'tool', content: 'result-2', tool_call_id: 't2' },
+    { role: 'user', content: 'u3' },
+  ] as unknown as OpenAIMessage[];
+}
+
 describe('compactOpenAIHistory', () => {
   it('summarizes older turns and splices the preamble in place', async () => {
     const d = deps();
@@ -139,5 +157,28 @@ describe('compactOpenAIHistory', () => {
     const clearAbort = vi.fn();
     await compactOpenAIHistory(deps({ clearAbort }));
     expect(clearAbort).toHaveBeenCalledTimes(1);
+  });
+
+  it('never splits a tool round: drops complete older rounds, keeps later rounds intact', async () => {
+    const priorTurns = historyWithToolRounds();
+    const result = await compactOpenAIHistory(deps({ priorTurns }));
+    expect(result.compacted).toBe(true);
+    // New history: [user(summary), assistant(ack), u2, assistant(t2), tool(t2), u3]
+    expect(priorTurns).toHaveLength(6);
+    expect(priorTurns[0]?.role).toBe('user'); // summary preamble
+    expect(priorTurns[1]?.role).toBe('assistant'); // ack preamble
+    expect(priorTurns[2]?.content).toBe('u2'); // kept tail starts on a fresh user turn
+    // The summarized round's tool result (t1) must not survive as an orphan;
+    // only the kept round's result (t2) remains.
+    const toolIds = priorTurns
+      .filter((m) => m.role === 'tool')
+      .map((m) => (m as { tool_call_id?: string }).tool_call_id);
+    expect(toolIds).toEqual(['t2']);
+    // The surviving tool result must be immediately preceded by an assistant
+    // turn carrying its matching tool_call id — proving the round was not split.
+    const toolIdx = priorTurns.findIndex((m) => m.role === 'tool');
+    const prev = priorTurns[toolIdx - 1] as { role?: string; tool_calls?: Array<{ id?: string }> };
+    expect(prev.role).toBe('assistant');
+    expect(prev.tool_calls?.some((tc) => tc.id === 't2')).toBe(true);
   });
 });

--- a/src/agent/providers/openai-compatible/compact.test.ts
+++ b/src/agent/providers/openai-compatible/compact.test.ts
@@ -1,0 +1,143 @@
+/**
+ * OpenAI-compatible compaction tests: the message-representation ops and the
+ * `compactOpenAIHistory` handler (bail paths + successful in-place splice),
+ * driven by a stubbed summarizer so no network is touched.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  compactOpenAIHistory,
+  isFreshUserTurn,
+  openaiCompactionOps,
+  type CompactOpenAIHistoryDeps,
+} from './compact.js';
+import { COMPACT_ACK_TEXT, COMPACT_SUMMARY_HEADER } from '../shared/compaction.js';
+import type { OpenAIMessage } from './messages.js';
+
+describe('openai isFreshUserTurn', () => {
+  it('is true only for role:user', () => {
+    expect(isFreshUserTurn({ role: 'user', content: 'hi' })).toBe(true);
+    expect(isFreshUserTurn({ role: 'assistant', content: 'hi' })).toBe(false);
+    expect(isFreshUserTurn({ role: 'tool', content: 'r', tool_call_id: 'c' })).toBe(false);
+    expect(isFreshUserTurn({ role: 'system', content: 'sys' })).toBe(false);
+  });
+});
+
+describe('openaiCompactionOps.renderMessage', () => {
+  it('renders assistant tool_calls as [tool call: NAME args]', () => {
+    const msg = {
+      role: 'assistant',
+      content: '',
+      tool_calls: [{ function: { name: 'grep', arguments: '{"q":"foo"}' } }],
+    } as unknown as OpenAIMessage;
+    const rendered = openaiCompactionOps.renderMessage(msg);
+    expect(rendered).toContain('[tool call: grep {"q":"foo"}]');
+  });
+  it('labels tool-result messages and flattens image parts', () => {
+    expect(openaiCompactionOps.renderMessage({ role: 'tool', content: 'matched 3', tool_call_id: 'c' })).toContain(
+      'Tool result:',
+    );
+    const vision: OpenAIMessage = {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'look' },
+        { type: 'image_url', image_url: { url: 'data:...' } },
+      ],
+    };
+    const r = openaiCompactionOps.renderMessage(vision);
+    expect(r).toContain('look');
+    expect(r).toContain('[image]');
+  });
+});
+
+/** History with `n` fresh user turns interleaved with assistant replies. */
+function history(): OpenAIMessage[] {
+  return [
+    { role: 'user', content: 'u1' },
+    { role: 'assistant', content: 'a1' },
+    { role: 'user', content: 'u2' },
+    { role: 'assistant', content: 'a2' },
+    { role: 'user', content: 'u3' },
+  ];
+}
+
+function deps(over: Partial<CompactOpenAIHistoryDeps> = {}): CompactOpenAIHistoryDeps {
+  return {
+    priorTurns: history(),
+    summarize: async () => 'COMPRESSED',
+    isClosed: false,
+    isIdle: true,
+    beginAbort: () => new AbortController(),
+    clearAbort: () => {},
+    ...over,
+  };
+}
+
+describe('compactOpenAIHistory', () => {
+  it('summarizes older turns and splices the preamble in place', async () => {
+    const d = deps();
+    const summarize = vi.fn(async () => 'COMPRESSED');
+    const result = await compactOpenAIHistory({ ...d, summarize });
+    expect(result.compacted).toBe(true);
+    expect(summarize).toHaveBeenCalledTimes(1);
+    // keepLastN defaults to 2 → boundary at u2 (index 2). New history:
+    // [user(summary), assistant(ack), u2, a2, u3]
+    expect(d.priorTurns[0]?.role).toBe('user');
+    expect(d.priorTurns[0]?.content).toContain(COMPACT_SUMMARY_HEADER);
+    expect(d.priorTurns[0]?.content).toContain('COMPRESSED');
+    expect(d.priorTurns[1]?.content).toBe(COMPACT_ACK_TEXT);
+    expect(d.priorTurns[2]?.content).toBe('u2');
+    expect(d.priorTurns).toHaveLength(5);
+  });
+
+  it('passes an abort signal to the summarizer', async () => {
+    const controller = new AbortController();
+    let seen: AbortSignal | undefined;
+    await compactOpenAIHistory(
+      deps({
+        beginAbort: () => controller,
+        summarize: async (_t, signal) => {
+          seen = signal;
+          return 'S';
+        },
+      }),
+    );
+    expect(seen).toBe(controller.signal);
+  });
+
+  it('bails session-closed', async () => {
+    const d = deps({ isClosed: true });
+    const before = [...d.priorTurns];
+    const result = await compactOpenAIHistory(d);
+    expect(result).toMatchObject({ compacted: false, reason: 'session-closed' });
+    expect(d.priorTurns).toEqual(before);
+  });
+
+  it('bails turn-in-flight when not idle', async () => {
+    const result = await compactOpenAIHistory(deps({ isIdle: false }));
+    expect(result).toMatchObject({ compacted: false, reason: 'turn-in-flight' });
+  });
+
+  it('no-ops history-too-short on a short session (never calls summarize)', async () => {
+    const summarize = vi.fn(async () => 'S');
+    const result = await compactOpenAIHistory({
+      ...deps({ priorTurns: [{ role: 'user', content: 'only one' }] }),
+      summarize,
+    });
+    expect(result).toMatchObject({ compacted: false, reason: 'history-too-short' });
+    expect(summarize).not.toHaveBeenCalled();
+  });
+
+  it('refuses an empty summary (history untouched)', async () => {
+    const d = deps({ summarize: async () => '  ' });
+    const before = [...d.priorTurns];
+    const result = await compactOpenAIHistory(d);
+    expect(result).toMatchObject({ compacted: false, reason: 'empty-summary' });
+    expect(d.priorTurns).toEqual(before);
+  });
+
+  it('releases the abort scope after completion', async () => {
+    const clearAbort = vi.fn();
+    await compactOpenAIHistory(deps({ clearAbort }));
+    expect(clearAbort).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agent/providers/openai-compatible/compact.ts
+++ b/src/agent/providers/openai-compatible/compact.ts
@@ -28,6 +28,7 @@ import { env } from '../../../config/env.js';
 import type { ProviderCompactResult } from '../../provider.js';
 import { emitCompaction } from '../../trace/emit.js';
 import type { TraceWriter } from '../../trace/index.js';
+import type { CompactionTrigger } from '../../trace/types.js';
 import {
   COMPACT_ACK_TEXT,
   COMPACT_SUMMARY_HEADER,
@@ -150,6 +151,12 @@ export interface CompactOpenAIHistoryDeps {
   beginAbort: () => AbortController;
   /** Release the abort scope once the summarization settles. */
   clearAbort: (controller: AbortController) => void;
+  /**
+   * What initiated this compaction, for the witness trace. `'manual'` (REPL
+   * /compact, Telegram, router) or `'token_threshold'` (the turn-boundary
+   * auto-compaction trigger). Defaults to `'manual'`.
+   */
+  trigger?: CompactionTrigger;
   traceWriter?: TraceWriter;
 }
 
@@ -183,7 +190,7 @@ export async function compactOpenAIHistory(
       onSuccess: (info) => {
         // Fire-and-forget; emitCompaction swallows writer errors internally.
         void emitCompaction(deps.traceWriter, {
-          trigger: 'manual',
+          trigger: deps.trigger ?? 'manual',
           preCompactionMessages: info.olderSlice,
           summary: info.summary,
           keptTailCount: info.keptTailCount,

--- a/src/agent/providers/openai-compatible/compact.ts
+++ b/src/agent/providers/openai-compatible/compact.ts
@@ -1,0 +1,200 @@
+/**
+ * OpenAI-compatible history compaction: the `CompactionOps<OpenAIMessage>`
+ * implementation plus a thin handler that routes through the provider-neutral
+ * {@link runCompactionCore}.
+ *
+ * This is the OpenAI counterpart to `anthropic-direct/compact.ts`. All the
+ * orchestration, guardrails, prompt, and generic algorithms live in
+ * `shared/compaction.ts`; this file supplies only the OpenAI message
+ * representation and wires the session's own one-shot completion as the
+ * summarizer.
+ *
+ * # Boundary invariant (OpenAI tool-round shape)
+ *
+ * OpenAI stores a tool round as `assistant{ tool_calls[] }` followed by one or
+ * more `role:'tool'` result messages (each carrying a `tool_call_id` that MUST
+ * match an id on the preceding assistant turn, or the API rejects the next
+ * request with HTTP 400 — see `query/dispatch-append.ts`). A "fresh user turn"
+ * is therefore simply `role:'user'` — tool results are `role:'tool'`, distinct.
+ * Landing the kept tail on a `role:'user'` message guarantees the tail never
+ * *starts* with an orphaned `role:'tool'` (its assistant turn would have been
+ * summarized away), so the 400 is structurally impossible. A vision
+ * image-followup (a synthetic `role:'user'` pushed after tool results) can make
+ * a boundary mildly suboptimal but never invalid.
+ *
+ * @module agent/providers/openai-compatible/compact
+ */
+import { env } from '../../../config/env.js';
+import type { ProviderCompactResult } from '../../provider.js';
+import { emitCompaction } from '../../trace/emit.js';
+import type { TraceWriter } from '../../trace/index.js';
+import {
+  COMPACT_ACK_TEXT,
+  COMPACT_SUMMARY_HEADER,
+  runCompactionCore,
+  type CompactionOps,
+} from '../shared/compaction.js';
+import type { OpenAIMessage } from './messages.js';
+
+const DEFAULT_COMPACT_KEEP_LAST_TURNS = 2;
+
+/** Minimal structural view of an assistant `tool_calls[]` entry (runtime-present). */
+interface OpenAIToolCallView {
+  function?: { name?: string; arguments?: string };
+}
+
+/** Read the `tool_calls` array off a message without importing the OpenAI SDK type. */
+function toolCallsOf(msg: OpenAIMessage): OpenAIToolCallView[] | undefined {
+  const tc = (msg as { tool_calls?: unknown }).tool_calls;
+  return Array.isArray(tc) ? (tc as OpenAIToolCallView[]) : undefined;
+}
+
+function truncateArgs(args: string): string {
+  return args.length > 240 ? args.slice(0, 237) + '...' : args;
+}
+
+/** True for real user input. Tool results are `role:'tool'`, not `'user'`. */
+export function isFreshUserTurn(msg: OpenAIMessage): boolean {
+  return msg.role === 'user';
+}
+
+/** Render one OpenAI message as a transcript block (speaker + flattened content). */
+function renderMessage(msg: OpenAIMessage): string {
+  const speaker =
+    msg.role === 'user'
+      ? 'User'
+      : msg.role === 'assistant'
+        ? 'Assistant'
+        : msg.role === 'tool'
+          ? 'Tool result'
+          : 'System';
+  const lines: string[] = [speaker + ':'];
+
+  if (typeof msg.content === 'string') {
+    if (msg.content.length > 0) lines.push(msg.content);
+  } else if (Array.isArray(msg.content)) {
+    for (const part of msg.content) {
+      if (part.type === 'text') lines.push(part.text);
+      else if (part.type === 'image_url') lines.push('[image]');
+    }
+  }
+
+  const toolCalls = toolCallsOf(msg);
+  if (toolCalls) {
+    for (const tc of toolCalls) {
+      const name = tc.function?.name ?? 'unknown';
+      const args = truncateArgs(tc.function?.arguments ?? '');
+      lines.push(`[tool call: ${name} ${args}]`);
+    }
+  }
+  return lines.join('\n');
+}
+
+/** Approximate content-character count for one message (saved-tokens estimate). */
+function countChars(msg: OpenAIMessage): number {
+  let total = 0;
+  if (typeof msg.content === 'string') {
+    total += msg.content.length;
+  } else if (Array.isArray(msg.content)) {
+    for (const part of msg.content) {
+      if (part.type === 'text') total += part.text.length;
+    }
+  }
+  const toolCalls = toolCallsOf(msg);
+  if (toolCalls) {
+    for (const tc of toolCalls) {
+      total += (tc.function?.name?.length ?? 0) + (tc.function?.arguments?.length ?? 0);
+    }
+  }
+  return total;
+}
+
+/** OpenAI message-representation primitives for the shared compaction core. */
+export const openaiCompactionOps: CompactionOps<OpenAIMessage> = {
+  isFreshUserTurn,
+  renderMessage,
+  buildPreamble(summaryText: string): [OpenAIMessage, OpenAIMessage] {
+    return [
+      { role: 'user', content: COMPACT_SUMMARY_HEADER + '\n\n' + summaryText },
+      { role: 'assistant', content: COMPACT_ACK_TEXT },
+    ];
+  },
+  countChars,
+};
+
+/** How many trailing fresh user turns to keep uncompacted. */
+export function readKeepLastN(): number {
+  const raw = env.AFK_COMPACT_KEEP_LAST_TURNS;
+  if (raw !== undefined && raw.length > 0) {
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return DEFAULT_COMPACT_KEEP_LAST_TURNS;
+}
+
+/** Injected collaborators for {@link compactOpenAIHistory}. */
+export interface CompactOpenAIHistoryDeps {
+  /** The query's mutable running history — mutated in place on success. */
+  priorTurns: OpenAIMessage[];
+  /**
+   * Turn a rendered transcript into a summary using the session's own client.
+   * Receives the abort signal for the compaction scope so an `interrupt()`
+   * cancels the summarization request cleanly.
+   */
+  summarize: (transcript: string, signal: AbortSignal) => Promise<string>;
+  /** Session is closed — no compaction. */
+  isClosed: boolean;
+  /** No turn currently in flight (abort slot free). */
+  isIdle: boolean;
+  /** Open a fresh abort scope for the summarization request. */
+  beginAbort: () => AbortController;
+  /** Release the abort scope once the summarization settles. */
+  clearAbort: (controller: AbortController) => void;
+  traceWriter?: TraceWriter;
+}
+
+/**
+ * Run one compaction pass over an OpenAI session's history. Mirrors
+ * `anthropic-direct/query/compact-handler.ts`: bail with a typed reason when
+ * closed or a turn is in flight, otherwise open an abort scope and delegate the
+ * boundary → summarize → splice sequence (with guardrails) to
+ * {@link runCompactionCore}. Mutates `priorTurns` in place only on success.
+ */
+export async function compactOpenAIHistory(
+  deps: CompactOpenAIHistoryDeps,
+): Promise<ProviderCompactResult> {
+  const messagesBefore = deps.priorTurns.length;
+  if (deps.isClosed) {
+    return { compacted: false, reason: 'session-closed', messagesBefore, messagesAfter: messagesBefore };
+  }
+  if (!deps.isIdle) {
+    return { compacted: false, reason: 'turn-in-flight', messagesBefore, messagesAfter: messagesBefore };
+  }
+
+  const controller = deps.beginAbort();
+  try {
+    return await runCompactionCore<OpenAIMessage>({
+      messages: deps.priorTurns,
+      ops: openaiCompactionOps,
+      keepLastN: readKeepLastN(),
+      summarize: (transcript) => deps.summarize(transcript, controller.signal),
+      isAborted: () => controller.signal.aborted,
+      abortInFlight: () => controller.abort(),
+      onSuccess: (info) => {
+        // Fire-and-forget; emitCompaction swallows writer errors internally.
+        void emitCompaction(deps.traceWriter, {
+          trigger: 'manual',
+          preCompactionMessages: info.olderSlice,
+          summary: info.summary,
+          keptTailCount: info.keptTailCount,
+          keepLastNConfig: info.keepLastN,
+          messagesBefore: info.messagesBefore,
+          messagesAfter: info.messagesAfter,
+          tokensSavedEstimate: info.tokensSavedEstimate,
+        });
+      },
+    });
+  } finally {
+    deps.clearAbort(controller);
+  }
+}

--- a/src/agent/providers/openai-compatible/oneshot.ts
+++ b/src/agent/providers/openai-compatible/oneshot.ts
@@ -57,6 +57,16 @@ export interface OpenAIOneShotInput {
    * hook. Lets callers inject a pre-built client without touching module state.
    */
   clientFactory?: OneShotOpenAIClientFactory;
+  /**
+   * Pre-built client to use verbatim. When provided, auth resolution and client
+   * construction are skipped entirely — the caller's client (with its own
+   * baseURL, headers, and credentials) is used as-is. This lets a live session
+   * reuse `this.client` for an in-session one-shot (e.g. history compaction)
+   * so the summarize call lands on the SAME custom endpoint / ChatGPT backend
+   * as the conversation, without re-resolving auth. Takes precedence over
+   * `apiKey` / `baseURL` / `clientFactory`.
+   */
+  client?: OpenAI;
 }
 
 /**
@@ -79,15 +89,22 @@ export interface OpenAIOneShotInput {
 export async function oneShotChatCompletion(input: OpenAIOneShotInput): Promise<string> {
   const { apiKey, baseURL, model, system, user, maxTokens = 64, signal, clientFactory } = input;
 
-  const auth = resolveOpenAIAuth(apiKey);
-  if (auth.apiKey === null) {
-    throw new Error('oneShotChatCompletion: no usable OpenAI auth (set OPENAI_API_KEY or pass apiKey)');
+  // A caller-supplied client (a live session reusing `this.client`) is used
+  // verbatim — no auth resolution, no reconstruction — so the call inherits the
+  // session's endpoint, headers, and credentials.
+  let client: OpenAI;
+  if (input.client !== undefined) {
+    client = input.client;
+  } else {
+    const auth = resolveOpenAIAuth(apiKey);
+    if (auth.apiKey === null) {
+      throw new Error('oneShotChatCompletion: no usable OpenAI auth (set OPENAI_API_KEY or pass apiKey)');
+    }
+    const clientOpts: { apiKey: string; baseURL?: string } = { apiKey: auth.apiKey };
+    if (baseURL !== undefined) clientOpts.baseURL = baseURL;
+    const factory = clientFactory ?? oneShotClientFactory;
+    client = factory ? factory(clientOpts) : new OpenAI(clientOpts);
   }
-
-  const clientOpts: { apiKey: string; baseURL?: string } = { apiKey: auth.apiKey };
-  if (baseURL !== undefined) clientOpts.baseURL = baseURL;
-  const factory = clientFactory ?? oneShotClientFactory;
-  const client = factory ? factory(clientOpts) : new OpenAI(clientOpts);
 
   // Reasoning models (o-series ∪ gpt-5.x) reject `max_tokens` and require
   // `max_completion_tokens`; everything else (chat models + local shims) wants

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -1078,6 +1078,23 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
     q.close();
   });
 
+  it('compact bails `unsupported-wire-mode` on a responses-mode (ChatGPT-OAuth) session', async () => {
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'k', source: 'chatgpt-oauth', last4: 'kkkk' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'sid',
+      promptStream: singleInput('x'),
+      config: baseConfig(),
+    });
+    // A ChatGPT-OAuth session is forced to the responses wire, whose backend
+    // would reject the Chat Completions summarize call — so compact() must bail
+    // early with an actionable reason rather than issue a doomed request.
+    const result = await q.compact();
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('unsupported-wire-mode');
+    q.close();
+  });
+
   it('setCwd forwards cwd to dispatcher.setResolveBase (U1)', () => {
     const hookRegistry = createHookRegistry();
     const dispatcher = new SessionToolDispatcher({

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -1061,7 +1061,7 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
     q.close();
   });
 
-  it('does not expose `compact` (history mgmt deferred)', () => {
+  it('exposes `compact` and no-ops (history-too-short) on an empty session', async () => {
     const q = new OpenAICompatibleQuery({
       auth: { apiKey: 'k', source: 'config', last4: 'kkkk' },
       model: 'gpt-4o-mini',
@@ -1069,7 +1069,12 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
       promptStream: singleInput('x'),
       config: baseConfig(),
     });
-    expect(q.compact).toBeUndefined();
+    expect(typeof q.compact).toBe('function');
+    // No turns have run, so there are no fresh user turns older than the keep
+    // window — compaction is a typed no-op and never calls the summarizer.
+    const result = await q.compact();
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('history-too-short');
     q.close();
   });
 

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -1095,6 +1095,121 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
     q.close();
   });
 
+  it("compact bails 'no-usable-auth' when no client was constructed (null auth)", async () => {
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: null, source: 'no-usable-auth' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'sid',
+      promptStream: singleInput('x'),
+      config: baseConfig(),
+    });
+    // No usable auth → no client. This is distinct from a closed session
+    // lifecycle, so the reason must be the specific 'no-usable-auth', not the
+    // generic 'session-closed' it previously reused.
+    const result = await q.compact();
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('no-usable-auth');
+    q.close();
+  });
+
+  it('getContextUsage().isAutoCompactEnabled reflects config.autoCompact', async () => {
+    const on = new OpenAICompatibleQuery({
+      auth: { apiKey: 'k', source: 'config', last4: 'kkkk' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'sid',
+      promptStream: singleInput('x'),
+      config: baseConfig({ autoCompact: true }),
+    });
+    expect((await on.getContextUsage()).isAutoCompactEnabled).toBe(true);
+    on.close();
+
+    const off = new OpenAICompatibleQuery({
+      auth: { apiKey: 'k', source: 'config', last4: 'kkkk' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'sid',
+      promptStream: singleInput('x'),
+      config: baseConfig(),
+    });
+    expect((await off.getContextUsage()).isAutoCompactEnabled).toBe(false);
+    off.close();
+  });
+
+  it('auto-compacts at the turn boundary once the context-window threshold is crossed', async () => {
+    // Each streaming turn reports a context-window footprint (~200k) far over
+    // the 90% default threshold for gpt-4o-mini's 128k window. Compaction is
+    // the only thing that issues a NON-streaming Chat Completions call
+    // (the summarize), so recording that call proves the turn-boundary trigger
+    // fired compactHistory('token_threshold'). Three fresh user turns are the
+    // minimum for a real boundary (keepLastN defaults to 2).
+    const summarizeCalls: unknown[] = [];
+    __setOpenAIClientFactory(
+      () =>
+        ({
+          chat: {
+            completions: {
+              create: async (args: { stream?: boolean }) => {
+                if (args.stream) {
+                  return (async function* () {
+                    yield {
+                      choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }],
+                      usage: { prompt_tokens: 200_000, completion_tokens: 10, total_tokens: 200_010 },
+                    } as OpenAIChunk;
+                  })();
+                }
+                summarizeCalls.push(args);
+                return { choices: [{ message: { content: 'AUTO-SUMMARY' } }] };
+              },
+            },
+          },
+        }) as unknown as OpenAI,
+    );
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'k', source: 'config', last4: 'kkkk' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'sid',
+      promptStream: multiInput('u1', 'u2', 'u3'),
+      config: baseConfig({ autoCompact: true }),
+    });
+    await collect(q);
+    // Exactly one compaction: history-too-short after turn 1, nothing-to-
+    // summarize after turn 2 (boundary 0), then a real splice after turn 3.
+    expect(summarizeCalls).toHaveLength(1);
+  });
+
+  it('does NOT auto-compact when config.autoCompact is unset (default off)', async () => {
+    const summarizeCalls: unknown[] = [];
+    __setOpenAIClientFactory(
+      () =>
+        ({
+          chat: {
+            completions: {
+              create: async (args: { stream?: boolean }) => {
+                if (args.stream) {
+                  return (async function* () {
+                    yield {
+                      choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }],
+                      usage: { prompt_tokens: 200_000, completion_tokens: 10, total_tokens: 200_010 },
+                    } as OpenAIChunk;
+                  })();
+                }
+                summarizeCalls.push(args);
+                return { choices: [{ message: { content: 'AUTO-SUMMARY' } }] };
+              },
+            },
+          },
+        }) as unknown as OpenAI,
+    );
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'k', source: 'config', last4: 'kkkk' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'sid',
+      promptStream: multiInput('u1', 'u2', 'u3'),
+      config: baseConfig(),
+    });
+    await collect(q);
+    expect(summarizeCalls).toHaveLength(0);
+  });
+
   it('setCwd forwards cwd to dispatcher.setResolveBase (U1)', () => {
     const hookRegistry = createHookRegistry();
     const dispatcher = new SessionToolDispatcher({

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -20,6 +20,9 @@
  * History compaction is supported via {@link OpenAICompatibleQuery.compact},
  * which reuses this session's client to summarize the older transcript through
  * the provider-neutral core in `shared/compaction.ts` — see `./compact.ts`.
+ * Auto-compaction is wired too: when `config.autoCompact` resolves a threshold,
+ * the turn-boundary check in {@link run} fires `compactHistory('token_threshold')`
+ * once the context-window footprint crosses it (mirrors anthropic-direct/query.ts).
  *
  * Things deliberately deferred:
  *   - File checkpointing / rewindFiles (deferred — `canRewind: false`)
@@ -33,6 +36,7 @@ import type { AgentConfig } from '../../types/config-types.js';
 import { emitSessionPhase } from '../../trace/emit.js';
 import { pathContainmentBypassed } from '../../permission-policy.js';
 import type { TraceWriter } from '../../trace/index.js';
+import type { CompactionTrigger } from '../../trace/types.js';
 import type {
   ProviderQuery,
   ProviderEvent,
@@ -49,7 +53,7 @@ import type {
   ProviderCompactResult,
 } from '../../provider.js';
 import { sumProviderUsage } from '../../usage.js';
-import { contextLimitFor } from '../../model-limits.js';
+import { contextLimitFor, autoCompactLimitFor } from '../../model-limits.js';
 import { resolveModelId } from '../../session/model-resolution.js';
 import { collectSupportedCommands } from '../shared/supported-commands.js';
 import { debugLog } from '../../../utils/debug.js';
@@ -79,7 +83,13 @@ import { buildResponsesRequest } from './responses-messages.js';
 import { resolveWireMode, envFlagEnabled, isClaudeFamilyModel, DEFAULT_RESPONSES_INSTRUCTIONS, type WireMode } from './responses-config.js';
 import { env } from '../../../config/env.js';
 import type { ToolDispatcher } from '../anthropic-direct/tool-dispatcher.js';
-import { contextWindowTokensUsed, buildContextUsageFields } from '../shared/auto-compact.js';
+import {
+  contextWindowTokensUsed,
+  buildContextUsageFields,
+  shouldAutoCompact,
+  resolveAutoCompactThreshold,
+} from '../shared/auto-compact.js';
+import { HookBlockedError } from '../../../utils/errors.js';
 import { COMPACT_SYSTEM_PROMPT, wrapTranscriptForSummary } from '../shared/compaction.js';
 import { compactOpenAIHistory } from './compact.js';
 import { oneShotChatCompletion } from './oneshot.js';
@@ -213,6 +223,15 @@ export class OpenAICompatibleQuery implements ProviderQuery {
    */
   private lastUsage: ProviderUsage | null = null;
 
+  /**
+   * Auto-compaction threshold as a fraction of the context window (0–1), or
+   * `undefined` when disabled. Resolved once from `config.autoCompact` through
+   * the shared {@link resolveAutoCompactThreshold} — the same source the
+   * anthropic-direct provider uses. Read by the turn-boundary auto-compaction
+   * check in {@link run} and reported via `getInfo().isAutoCompactEnabled`.
+   */
+  private readonly autoCompactThreshold: number | undefined;
+
   constructor(opts: OpenAICompatibleQueryOptions) {
     this.opts = opts;
     this.initSessionId = opts.synthesizedSessionId;
@@ -221,6 +240,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     this.toolDispatcher = opts.toolDispatcher;
     this.onPermissionMode = opts.onPermissionMode;
     this.traceWriter = opts.traceWriter;
+    this.autoCompactThreshold = resolveAutoCompactThreshold(opts.config.autoCompact);
 
     // Pre-compute the OpenAI tool catalog once. Only `SessionToolDispatcher`
     // (and not the structural `ToolDispatcher` minimal interface) exposes
@@ -312,6 +332,34 @@ export class OpenAICompatibleQuery implements ProviderQuery {
         if (turnResult.done) break;
 
         yield* this.runTurn(turnResult.value.content);
+
+        // Auto-compaction fires at the natural turn boundary — runTurn has
+        // returned and its `finally` nulled `abortController`, so the handler's
+        // idle guard passes and compaction never runs mid-tool-call. Mirrors
+        // anthropic-direct/query.ts. `compactHistory` itself never throws (every
+        // summarize failure is a typed no-op leaving history byte-for-byte
+        // unchanged); only a PreCompact `block` decision throws HookBlockedError,
+        // caught here to skip this turn's compaction without surfacing an error.
+        if (this.autoCompactThreshold !== undefined && !this.closed) {
+          const usage = this.lastUsage;
+          const compactionLimit = autoCompactLimitFor(this.currentModel);
+          if (usage !== null && compactionLimit > 0) {
+            const usedTokens = contextWindowTokensUsed(usage);
+            if (shouldAutoCompact(usedTokens, compactionLimit, this.autoCompactThreshold)) {
+              try {
+                await this.opts.config.hookRegistry?.dispatch({
+                  event: 'PreCompact',
+                  sessionId: this.initSessionId,
+                  trigger: 'auto',
+                });
+                await this.compactHistory('token_threshold');
+              } catch (compactErr) {
+                if (!(compactErr instanceof HookBlockedError)) throw compactErr;
+                // Hook blocked auto-compaction — continue the session normally.
+              }
+            }
+          }
+        }
       }
     } catch (iterErr) {
       const e = iterErr instanceof Error ? iterErr : new Error(String(iterErr));
@@ -999,10 +1047,21 @@ export class OpenAICompatibleQuery implements ProviderQuery {
    * backend would reject.
    */
   async compact(): Promise<ProviderCompactResult> {
+    // Manual entrypoint (REPL /compact, Telegram, router). Auto-compaction
+    // calls compactHistory('token_threshold') directly from the turn-boundary
+    // check in run(), so the two paths differ only in the emitted trace trigger.
+    return this.compactHistory('manual');
+  }
+
+  private async compactHistory(
+    trigger: CompactionTrigger,
+  ): Promise<ProviderCompactResult> {
     const messagesBefore = this.priorTurns.length;
     if (this.opts.auth.apiKey === null) {
-      // No usable client was constructed — nothing to compact against.
-      return { compacted: false, reason: 'session-closed', messagesBefore, messagesAfter: messagesBefore };
+      // No usable client was constructed — an auth problem, distinct from a
+      // closed session lifecycle. Surface a specific, actionable reason rather
+      // than reusing 'session-closed'.
+      return { compacted: false, reason: 'no-usable-auth', messagesBefore, messagesAfter: messagesBefore };
     }
     if (this.wireMode === 'responses') {
       // oneShotChatCompletion speaks only Chat Completions; a responses-mode
@@ -1038,6 +1097,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       clearAbort: (controller) => {
         if (this.abortController === controller) this.abortController = null;
       },
+      trigger,
       traceWriter: this.traceWriter,
     });
   }
@@ -1130,7 +1190,7 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       // Context-window usage shape: tools/agents are per-entry token stats AFK does not populate (NOT AgentConfig.agents).
       tools: [],
       agents: [],
-      isAutoCompactEnabled: false,
+      isAutoCompactEnabled: this.autoCompactThreshold !== undefined,
       apiUsage,
       totalTokens,
       ...(percentage !== undefined ? { percentage } : {}),

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -17,9 +17,12 @@
  *     (or the tool-round cap fires — see shared/tool-loop-cap.ts — after which
  *     one tools-stripped wind-down round runs, matching anthropic-direct/loop.ts)
  *
+ * History compaction is supported via {@link OpenAICompatibleQuery.compact},
+ * which reuses this session's client to summarize the older transcript through
+ * the provider-neutral core in `shared/compaction.ts` — see `./compact.ts`.
+ *
  * Things deliberately deferred:
  *   - File checkpointing / rewindFiles (deferred — `canRewind: false`)
- *   - Compact (provider opts out by leaving `compact` undefined)
  *
  * @module agent/providers/openai-compatible/query
  */
@@ -43,6 +46,7 @@ import type {
   ProviderMcpServerStatus,
   ProviderAccountInfo,
   ProviderUsage,
+  ProviderCompactResult,
 } from '../../provider.js';
 import { sumProviderUsage } from '../../usage.js';
 import { contextLimitFor } from '../../model-limits.js';
@@ -76,6 +80,9 @@ import { resolveWireMode, envFlagEnabled, isClaudeFamilyModel, DEFAULT_RESPONSES
 import { env } from '../../../config/env.js';
 import type { ToolDispatcher } from '../anthropic-direct/tool-dispatcher.js';
 import { contextWindowTokensUsed, buildContextUsageFields } from '../shared/auto-compact.js';
+import { COMPACT_SYSTEM_PROMPT, wrapTranscriptForSummary } from '../shared/compaction.js';
+import { compactOpenAIHistory } from './compact.js';
+import { oneShotChatCompletion } from './oneshot.js';
 import { PLAN_MODE_ADDENDUM_TEXT } from '../shared/plan-mode-addendum.js';
 import { AFK_MODE_ADDENDUM_TEXT } from '../shared/afk-mode-addendum.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from '../../tools/handlers/exit-plan-mode.js';
@@ -969,6 +976,52 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       return;
     }
     this.pendingAbortReason = 'interrupted';
+  }
+
+  /**
+   * Summarize older history into a short preamble, in place. Delegates the
+   * boundary → summarize → splice sequence (with guardrails) to the shared
+   * {@link compactOpenAIHistory} / `runCompactionCore`; the summarization call
+   * reuses THIS session's `client`, so it lands on the same endpoint,
+   * credentials, and headers as the conversation — a custom-baseURL or local
+   * shim session compacts against its own server, never a re-resolved one.
+   *
+   * The compaction model is `AFK_COMPACT_MODEL` when set (it must be an id this
+   * session's endpoint can serve), otherwise the live session model. Cross-
+   * provider summarization (e.g. a Claude model summarizing an OpenAI session)
+   * is intentionally NOT wired here: a mismatched id simply fails the summarize
+   * call, which the core treats as a safe no-op, leaving history untouched.
+   */
+  async compact(): Promise<ProviderCompactResult> {
+    const messagesBefore = this.priorTurns.length;
+    if (this.opts.auth.apiKey === null) {
+      // No usable client was constructed — nothing to compact against.
+      return { compacted: false, reason: 'session-closed', messagesBefore, messagesAfter: messagesBefore };
+    }
+    const compactModel = env.AFK_COMPACT_MODEL ?? this.currentModel;
+    return compactOpenAIHistory({
+      priorTurns: this.priorTurns,
+      summarize: (transcript, signal) =>
+        oneShotChatCompletion({
+          client: this.client,
+          model: compactModel,
+          system: COMPACT_SYSTEM_PROMPT,
+          user: wrapTranscriptForSummary(transcript),
+          maxTokens: 1024,
+          signal,
+        }),
+      isClosed: this.closed,
+      isIdle: this.abortController === null,
+      beginAbort: () => {
+        const controller = new AbortController();
+        this.abortController = controller;
+        return controller;
+      },
+      clearAbort: (controller) => {
+        if (this.abortController === controller) this.abortController = null;
+      },
+      traceWriter: this.traceWriter,
+    });
   }
 
   async setModel(model?: string): Promise<void> {

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -991,12 +991,30 @@ export class OpenAICompatibleQuery implements ProviderQuery {
    * provider summarization (e.g. a Claude model summarizing an OpenAI session)
    * is intentionally NOT wired here: a mismatched id simply fails the summarize
    * call, which the core treats as a safe no-op, leaving history untouched.
+   *
+   * Only Chat Completions sessions are supported. The summarizer runs through
+   * `oneShotChatCompletion` (Chat Completions wire), so a responses-mode session
+   * (ChatGPT-OAuth, or the `AFK_OPENAI_USE_RESPONSES` opt-in) bails early with
+   * `unsupported-wire-mode` rather than issuing a chat.completions call its
+   * backend would reject.
    */
   async compact(): Promise<ProviderCompactResult> {
     const messagesBefore = this.priorTurns.length;
     if (this.opts.auth.apiKey === null) {
       // No usable client was constructed — nothing to compact against.
       return { compacted: false, reason: 'session-closed', messagesBefore, messagesAfter: messagesBefore };
+    }
+    if (this.wireMode === 'responses') {
+      // oneShotChatCompletion speaks only Chat Completions; a responses-mode
+      // backend (ChatGPT-OAuth / AFK_OPENAI_USE_RESPONSES) would reject that
+      // call. Surface an explicit, honest no-op instead of a generic
+      // summarization failure so the reason is actionable.
+      return {
+        compacted: false,
+        reason: 'unsupported-wire-mode',
+        messagesBefore,
+        messagesAfter: messagesBefore,
+      };
     }
     const compactModel = env.AFK_COMPACT_MODEL ?? this.currentModel;
     return compactOpenAIHistory({

--- a/src/agent/providers/shared/auto-compact.ts
+++ b/src/agent/providers/shared/auto-compact.ts
@@ -14,6 +14,7 @@
  */
 
 import type { ProviderUsage } from '../../provider.js';
+import type { AgentConfig } from '../../types/config-types.js';
 
 /**
  * Cumulative billed tokens for a turn: `inputTokens + outputTokens`.
@@ -128,4 +129,30 @@ export function shouldAutoCompact(
   if (usedTokens <= 0) return false;
   if (threshold <= 0 || threshold >= 1) return false;
   return usedTokens / contextLimit >= threshold;
+}
+
+/** Default auto-compaction threshold (fraction of the context window). */
+export const DEFAULT_AUTO_COMPACT_THRESHOLD = 0.9;
+
+/**
+ * Resolve `AgentConfig.autoCompact` to a numeric threshold fraction, or
+ * `undefined` when auto-compaction is disabled. Provider-neutral: both the
+ * anthropic-direct and openai-compatible providers resolve their threshold
+ * through this single source of truth.
+ *
+ * - `false` or `undefined` → disabled (`undefined` returned).
+ * - `true` → default threshold (0.90).
+ * - `{ threshold: n }` → custom fraction; clamped to (0, 1) exclusive.
+ *   Out-of-range values are silently treated as disabled.
+ */
+export function resolveAutoCompactThreshold(
+  autoCompact: AgentConfig['autoCompact'],
+): number | undefined {
+  if (autoCompact === undefined || autoCompact === false) return undefined;
+  if (autoCompact === true) return DEFAULT_AUTO_COMPACT_THRESHOLD;
+  const t = autoCompact.threshold;
+  if (typeof t !== 'number' || !Number.isFinite(t) || t <= 0 || t >= 1) {
+    return undefined;
+  }
+  return t;
 }

--- a/src/agent/providers/shared/compaction.test.ts
+++ b/src/agent/providers/shared/compaction.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Provider-neutral compaction core tests. Exercises the generic algorithms and
+ * the orchestrator guardrails against a tiny fake message type + ops, with no
+ * real provider or network.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  COMPACT_ACK_TEXT,
+  COMPACT_SUMMARY_HEADER,
+  applyCompaction,
+  estimateTokensSaved,
+  findCompactionBoundary,
+  renderTranscript,
+  runCompactionCore,
+  wrapTranscriptForSummary,
+  type CompactionOps,
+} from './compaction.js';
+
+// A minimal message: a role + text. "user" messages are fresh user turns.
+interface FakeMsg {
+  role: 'user' | 'assistant';
+  text: string;
+}
+
+const fakeOps: CompactionOps<FakeMsg> = {
+  isFreshUserTurn: (m) => m.role === 'user',
+  renderMessage: (m) => `${m.role}: ${m.text}`,
+  buildPreamble: (summary) => [
+    { role: 'user', text: COMPACT_SUMMARY_HEADER + '\n\n' + summary },
+    { role: 'assistant', text: COMPACT_ACK_TEXT },
+  ],
+  countChars: (m) => m.text.length,
+};
+
+function history(): FakeMsg[] {
+  return [
+    { role: 'user', text: 'u1' },
+    { role: 'assistant', text: 'a1' },
+    { role: 'user', text: 'u2' },
+    { role: 'assistant', text: 'a2' },
+    { role: 'user', text: 'u3' },
+  ];
+}
+
+describe('findCompactionBoundary (generic)', () => {
+  it('returns -1 when fewer fresh user turns than keepLastN', () => {
+    expect(findCompactionBoundary(history(), 9, fakeOps)).toBe(-1);
+  });
+  it('returns the index of the K-th fresh user turn from the end', () => {
+    // fresh users at 0,2,4. keep last 2 -> boundary at index 2 (u2).
+    expect(findCompactionBoundary(history(), 2, fakeOps)).toBe(2);
+  });
+  it('returns 0 when the whole history is within the keep window', () => {
+    expect(findCompactionBoundary(history(), 3, fakeOps)).toBe(0);
+  });
+});
+
+describe('renderTranscript / applyCompaction / estimateTokensSaved (generic)', () => {
+  it('renders each message via ops.renderMessage', () => {
+    const t = renderTranscript(history(), fakeOps);
+    expect(t).toContain('user: u1');
+    expect(t).toContain('assistant: a2');
+  });
+  it('splices [summary, ack, ...tail] at the boundary', () => {
+    const out = applyCompaction(history(), 2, 'SUM', fakeOps);
+    expect(out.map((m) => m.role)).toEqual(['user', 'assistant', 'user', 'assistant', 'user']);
+    expect(out[0]?.text).toContain(COMPACT_SUMMARY_HEADER);
+    expect(out[0]?.text).toContain('SUM');
+    expect(out[1]?.text).toBe(COMPACT_ACK_TEXT);
+    expect(out[2]?.text).toBe('u2');
+  });
+  it('estimate is 0 at boundary 0 and positive once content is dropped', () => {
+    expect(estimateTokensSaved(history(), 0, 's', fakeOps)).toBe(0);
+    const big: FakeMsg[] = [{ role: 'user', text: 'x'.repeat(4000) }, { role: 'user', text: 't' }];
+    expect(estimateTokensSaved(big, 1, 's', fakeOps)).toBeGreaterThan(0);
+  });
+});
+
+describe('wrapTranscriptForSummary', () => {
+  it('wraps the transcript in a single <transcript> instruction', () => {
+    const w = wrapTranscriptForSummary('HELLO');
+    expect(w).toContain('<transcript>\nHELLO\n</transcript>');
+    expect(w.toLowerCase()).toContain('summarize');
+  });
+});
+
+describe('runCompactionCore', () => {
+  const baseDeps = () => ({
+    messages: history(),
+    ops: fakeOps,
+    keepLastN: 2,
+    isAborted: () => false,
+  });
+
+  it('summarizes the older slice and splices in place on success', async () => {
+    const deps = baseDeps();
+    const summarize = vi.fn(async (transcript: string) => {
+      expect(transcript).toContain('u1'); // older slice was rendered
+      return 'COMPRESSED';
+    });
+    const onSuccess = vi.fn();
+    const result = await runCompactionCore({ ...deps, summarize, onSuccess });
+    expect(result.compacted).toBe(true);
+    expect(summarize).toHaveBeenCalledTimes(1);
+    // priorTurns mutated in place: [user(summary), assistant(ack), u2, a2, u3]
+    expect(deps.messages[0]?.text).toContain('COMPRESSED');
+    expect(deps.messages[1]?.text).toBe(COMPACT_ACK_TEXT);
+    expect(deps.messages).toHaveLength(5);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses an empty summary and leaves history untouched', async () => {
+    const deps = baseDeps();
+    const before = [...deps.messages];
+    const result = await runCompactionCore({ ...deps, summarize: async () => '   ' });
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('empty-summary');
+    expect(deps.messages).toEqual(before);
+  });
+
+  it('maps a rejected summarize to summarization-failed (history untouched)', async () => {
+    const deps = baseDeps();
+    const before = [...deps.messages];
+    const result = await runCompactionCore({
+      ...deps,
+      summarize: async () => {
+        throw new Error('boom');
+      },
+    });
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toContain('summarization-failed');
+    expect(result.reason).toContain('boom');
+    expect(deps.messages).toEqual(before);
+  });
+
+  it('reclassifies a failure as aborted when isAborted() is true', async () => {
+    const deps = baseDeps();
+    const result = await runCompactionCore({
+      ...deps,
+      isAborted: () => true,
+      summarize: async () => {
+        throw new Error('cancelled');
+      },
+    });
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('aborted');
+  });
+
+  it('times out a hung summarize, cancels it, and no-ops', async () => {
+    const deps = baseDeps();
+    const before = [...deps.messages];
+    const abortInFlight = vi.fn();
+    const result = await runCompactionCore({
+      ...deps,
+      timeoutMs: 20,
+      abortInFlight,
+      summarize: () => new Promise<string>(() => {}), // never resolves
+    });
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toContain('summarization-failed');
+    expect(abortInFlight).toHaveBeenCalledTimes(1);
+    expect(deps.messages).toEqual(before);
+  });
+
+  it('no-ops (history-too-short) without calling summarize', async () => {
+    const summarize = vi.fn();
+    const result = await runCompactionCore({
+      messages: history(),
+      ops: fakeOps,
+      keepLastN: 99,
+      isAborted: () => false,
+      summarize,
+    });
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('history-too-short');
+    expect(summarize).not.toHaveBeenCalled();
+  });
+});

--- a/src/agent/providers/shared/compaction.test.ts
+++ b/src/agent/providers/shared/compaction.test.ts
@@ -181,4 +181,24 @@ describe('runCompactionCore', () => {
     expect(result.reason).toBe('history-too-short');
     expect(summarize).not.toHaveBeenCalled();
   });
+
+  it('no-ops (nothing-to-summarize) when the whole history is within the keep window', async () => {
+    // history() has 3 fresh user turns (indices 0,2,4). keepLastN=3 lands the
+    // boundary at index 0 — nothing older than the keep window to summarize —
+    // so the core bails without touching the summarizer or the history.
+    const summarize = vi.fn();
+    const messages = history();
+    const before = [...messages];
+    const result = await runCompactionCore({
+      messages,
+      ops: fakeOps,
+      keepLastN: 3,
+      isAborted: () => false,
+      summarize,
+    });
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('nothing-to-summarize');
+    expect(summarize).not.toHaveBeenCalled();
+    expect(messages).toEqual(before);
+  });
 });

--- a/src/agent/providers/shared/compaction.test.ts
+++ b/src/agent/providers/shared/compaction.test.ts
@@ -146,19 +146,25 @@ describe('runCompactionCore', () => {
     expect(result.reason).toBe('aborted');
   });
 
-  it('times out a hung summarize, cancels it, and no-ops', async () => {
+  it('reports a timeout as summarization-failed even when abortInFlight trips the shared abort signal', async () => {
     const deps = baseDeps();
     const before = [...deps.messages];
-    const abortInFlight = vi.fn();
+    // Mirror the real provider wiring (openai-compatible/compact.ts): isAborted
+    // and abortInFlight read the SAME controller, so the timeout's abortInFlight()
+    // flips isAborted() to true. A genuine timeout must still be reported as
+    // summarization-failed, never reclassified as a user-initiated 'aborted'.
+    const controller = new AbortController();
     const result = await runCompactionCore({
       ...deps,
       timeoutMs: 20,
-      abortInFlight,
+      isAborted: () => controller.signal.aborted,
+      abortInFlight: () => controller.abort(),
       summarize: () => new Promise<string>(() => {}), // never resolves
     });
     expect(result.compacted).toBe(false);
     expect(result.reason).toContain('summarization-failed');
-    expect(abortInFlight).toHaveBeenCalledTimes(1);
+    expect(result.reason).toContain('timed out');
+    expect(controller.signal.aborted).toBe(true);
     expect(deps.messages).toEqual(before);
   });
 

--- a/src/agent/providers/shared/compaction.ts
+++ b/src/agent/providers/shared/compaction.ts
@@ -277,6 +277,13 @@ export async function runCompactionCore<M>(
   try {
     summary = await withTimeout(summarize(transcript), timeoutMs, deps.abortInFlight);
   } catch (err) {
+    // A timeout fires abortInFlight() to cancel the request, which in the real
+    // provider wiring also trips the shared abort signal — so check the timeout
+    // sentinel BEFORE isAborted(), or a genuine timeout would be misreported as
+    // a user-initiated 'aborted'.
+    if (err instanceof CompactionTimeoutError) {
+      return { compacted: false, reason: 'summarization-failed: ' + err.message, ...unchanged };
+    }
     if (isAborted()) {
       return { compacted: false, reason: 'aborted', ...unchanged };
     }

--- a/src/agent/providers/shared/compaction.ts
+++ b/src/agent/providers/shared/compaction.ts
@@ -1,0 +1,343 @@
+/**
+ * Provider-neutral history compaction — the orchestration, prompt, and pure
+ * transcript algorithms shared by every provider that can summarize its own
+ * message history.
+ *
+ * # Why this lives in shared/
+ *
+ * Compaction decomposes into three concerns that separate cleanly:
+ *
+ *   1. Orchestration — bail-checks, boundary selection, summarize, splice,
+ *      emit. Provider-agnostic; lives here in {@link runCompactionCore}.
+ *   2. Representation — how a provider's message type flattens to text, which
+ *      messages are "fresh user turns", how the synthetic preamble is shaped.
+ *      Provider-specific; supplied via {@link CompactionOps}.
+ *   3. The model call — turning a transcript into a summary. Already exists as
+ *      each provider's one-shot completion primitive (`oneshot.ts`); injected
+ *      as the `summarize` closure so no bespoke per-provider summarizer method
+ *      is needed.
+ *
+ * Previously all three lived inside `anthropic-direct/compact.ts`, which is why
+ * compaction was Anthropic-only. Lifting concerns (1) and the generic form of
+ * the (2) algorithms here — parameterized over a provider `CompactionOps<M>` —
+ * lets any provider gain compaction by implementing a small ops object and
+ * passing its existing one-shot as `summarize`. Mirrors the earlier lift of
+ * threshold logic into `shared/auto-compact.ts`.
+ *
+ * Invariant: every provider's `findBoundary` must land the kept tail on a
+ * fresh user turn so the synthetic `[user_summary, assistant_ack]` preamble can
+ * be prepended without breaking user/assistant alternation, and must never
+ * split a tool round (a `tool_use`/`tool_call` and its matching result must
+ * travel together). The generic {@link findCompactionBoundary} enforces this by
+ * counting only messages for which `ops.isFreshUserTurn` returns true.
+ *
+ * @module agent/providers/shared/compaction
+ */
+
+import type { ProviderCompactResult } from '../../provider.js';
+
+/**
+ * System instruction for the summarization call. Crafted to preserve what a
+ * future turn actually needs: user intent and corrections, tool decisions and
+ * outcomes, current state and next action, open questions, and key facts.
+ *
+ * Provider-neutral — the summarizer only ever sees a plain-text transcript, so
+ * this prompt makes no assumption about the underlying message representation.
+ */
+export const COMPACT_SYSTEM_PROMPT = [
+  'You are a conversation-summarization assistant. The user will paste a',
+  'prior conversation between a user and an AI assistant that includes tool',
+  'calls and tool results. Produce a concise but complete summary that lets',
+  'the AI continue the conversation without losing track.',
+  '',
+  'Preserve, in this priority order:',
+  "1. The user's original intent, explicit asks, constraints, corrections,",
+  '   and preferences stated during the conversation.',
+  '2. Tool decisions and their outcomes — file paths read or written, shell',
+  '   commands run, search queries, URLs fetched, code edits made, tests',
+  '   run, errors observed, and whether each action succeeded or failed.',
+  '3. Current state: what has been completed, what remains unresolved, and',
+  '   the safest next action.',
+  '4. Open questions, pending decisions, blockers, and assumptions.',
+  '5. Key facts the assistant discovered (function locations, schemas,',
+  '   observed behaviors, important external findings).',
+  '',
+  'Drop prose narration, conversational filler, and exploratory dead-ends.',
+  'Drop verbatim tool output unless an exact snippet, error, path, command,',
+  'or result is needed for continuation.',
+  'Do not invent details. If something is uncertain, mark it explicitly.',
+  'Output plain text, no markdown headers. Aim for ~250 words; use up to',
+  '~400 only when needed to preserve tool state or unresolved tasks.',
+].join('\n');
+
+/** Default header the summary message uses to flag itself in history. */
+export const COMPACT_SUMMARY_HEADER = '[Compacted summary of earlier conversation]';
+
+/** Default acknowledgement the synthetic assistant turn returns. */
+export const COMPACT_ACK_TEXT = 'Acknowledged. Continuing from the summary above.';
+
+/**
+ * Wrap a rendered transcript in the single user instruction the summarizer
+ * sees. Shared by every provider so the summarization prompt stays identical
+ * regardless of which model/endpoint produces the summary.
+ */
+export function wrapTranscriptForSummary(transcript: string): string {
+  return (
+    'Summarize the following conversation transcript. Follow the ' +
+    'system instructions exactly.\n\n' +
+    '<transcript>\n' +
+    transcript +
+    '\n</transcript>'
+  );
+}
+
+/** Wall-clock ceiling for a single summarization call (guardrail). */
+export const DEFAULT_COMPACT_TIMEOUT_MS = 60_000;
+
+/**
+ * Provider-specific message-representation primitives. Pure — no I/O, no SDK
+ * client, no logging — so they unit-test without a network. Everything a
+ * provider must supply to participate in compaction lives here; the generic
+ * algorithms below are written against this interface.
+ */
+export interface CompactionOps<M> {
+  /**
+   * True when `msg` is a real user turn (not a tool-result follow-up the loop
+   * synthesized). The boundary walk counts only these.
+   */
+  isFreshUserTurn(msg: M): boolean;
+  /**
+   * Render one message as a plain-text transcript block, including its speaker
+   * label. Tool calls/results are flattened to compact markers; images and
+   * other non-text blocks are elided to short placeholders. Multi-line output
+   * is fine — {@link renderTranscript} joins blocks with blank lines.
+   */
+  renderMessage(msg: M): string;
+  /**
+   * Build the synthetic preamble spliced in front of the kept tail: a user
+   * message carrying the summary and an assistant acknowledgement, in the
+   * provider's own message shape.
+   */
+  buildPreamble(summaryText: string): [userSummary: M, assistantAck: M];
+  /** Approximate character count of a message's content (for the saved-tokens estimate). */
+  countChars(msg: M): number;
+}
+
+/**
+ * Locate the index where the kept tail starts. Walk backwards counting fresh
+ * user turns; the boundary is the index of the `keepLastN`-th fresh user turn
+ * from the end.
+ *
+ * Returns:
+ *   - `-1` when there are fewer than `keepLastN` fresh user turns (caller
+ *     treats this as "history too short — no compaction").
+ *   - An index `>= 0` otherwise. `messages.slice(boundary)` is the kept tail;
+ *     `messages.slice(0, boundary)` is what gets summarized. `0` means the
+ *     whole history is within the keep window (nothing older to summarize).
+ */
+export function findCompactionBoundary<M>(
+  messages: ReadonlyArray<M>,
+  keepLastN: number,
+  ops: CompactionOps<M>,
+): number {
+  if (keepLastN <= 0) return messages.length;
+  let count = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg !== undefined && ops.isFreshUserTurn(msg)) {
+      count += 1;
+      if (count === keepLastN) return i;
+    }
+  }
+  return -1;
+}
+
+/** Render a slice of messages as a plain-text transcript for the summarizer. */
+export function renderTranscript<M>(
+  messages: ReadonlyArray<M>,
+  ops: CompactionOps<M>,
+): string {
+  const blocks: string[] = [];
+  for (const msg of messages) blocks.push(ops.renderMessage(msg));
+  return blocks.join('\n\n').trim();
+}
+
+/**
+ * Splice in the synthetic preamble. Returns a new array; the caller decides
+ * whether to assign it back to the provider's mutable history slot.
+ */
+export function applyCompaction<M>(
+  messages: ReadonlyArray<M>,
+  boundary: number,
+  summaryText: string,
+  ops: CompactionOps<M>,
+): M[] {
+  const [summary, ack] = ops.buildPreamble(summaryText);
+  return [summary, ack, ...messages.slice(boundary)];
+}
+
+/**
+ * Estimate input tokens saved by replacing `[0, boundary)` with the synthetic
+ * preamble. Rough char/4 heuristic — good enough for a UX hint, not billing.
+ */
+export function estimateTokensSaved<M>(
+  before: ReadonlyArray<M>,
+  boundary: number,
+  summaryText: string,
+  ops: CompactionOps<M>,
+): number {
+  let droppedChars = 0;
+  for (const msg of before.slice(0, boundary)) droppedChars += ops.countChars(msg);
+  const addedChars = COMPACT_SUMMARY_HEADER.length + 2 + summaryText.length + COMPACT_ACK_TEXT.length;
+  const delta = Math.max(0, droppedChars - addedChars);
+  return Math.round(delta / 4);
+}
+
+/** Success payload handed to {@link CompactionCoreDeps.onSuccess} for witness emit. */
+export interface CompactionSuccess<M> {
+  /** Messages `[0, boundary)` that were summarized away (pre-splice). */
+  olderSlice: M[];
+  /** The generated summary text. */
+  summary: string;
+  /** Count of kept-tail messages (messagesBefore - boundary). */
+  keptTailCount: number;
+  /** The keepLastN config that produced this boundary. */
+  keepLastN: number;
+  messagesBefore: number;
+  messagesAfter: number;
+  tokensSavedEstimate: number;
+}
+
+/** Injected collaborators for {@link runCompactionCore}. */
+export interface CompactionCoreDeps<M> {
+  /** The provider's mutable running-history array. Mutated in place on success. */
+  messages: M[];
+  ops: CompactionOps<M>;
+  keepLastN: number;
+  /**
+   * Turn a plain-text transcript into a summary. Backed by the provider's own
+   * one-shot completion primitive. Rejection (rate limit, network, abort) is
+   * caught by the core and reported as a typed no-op reason.
+   */
+  summarize(transcript: string): Promise<string>;
+  /** True if the surrounding turn/abort scope was cancelled — reclassifies a failure as `aborted`. */
+  isAborted(): boolean;
+  /** Cancel the in-flight summarize request when the timeout guardrail fires. */
+  abortInFlight?(): void;
+  /** Guardrail ceiling for the summarize call. Defaults to {@link DEFAULT_COMPACT_TIMEOUT_MS}. */
+  timeoutMs?: number;
+  /** Fired after a successful in-place splice, for witness-layer emit. */
+  onSuccess?(info: CompactionSuccess<M>): void;
+}
+
+/**
+ * Run the provider-agnostic core of one compaction pass: locate the boundary,
+ * render + summarize the older slice, and splice the synthetic preamble in
+ * place of it. Provider-specific pre-flight (session-closed / turn-in-flight
+ * checks, abort-scope setup) stays in the caller; this owns the algorithm and
+ * the safety guardrails.
+ *
+ * Guardrails (never corrupt live history on a bad summary):
+ *   - the summarize call is bounded by `timeoutMs`; a timeout cancels the
+ *     in-flight request (`abortInFlight`) and returns a typed no-op;
+ *   - any rejection is caught and mapped to `aborted` (when `isAborted()`) or
+ *     `summarization-failed: <msg>` — history is left untouched;
+ *   - an empty/whitespace summary is refused (`empty-summary`) rather than
+ *     spliced, so a flaky model can never blank out the conversation.
+ *
+ * Mutates `messages` in place ONLY on the success path. Every failure path
+ * (too-short, nothing-to-summarize, aborted, timeout, failed, empty) leaves
+ * `messages` byte-for-byte unchanged.
+ */
+export async function runCompactionCore<M>(
+  deps: CompactionCoreDeps<M>,
+): Promise<ProviderCompactResult> {
+  const { messages, ops, keepLastN, summarize, isAborted } = deps;
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_COMPACT_TIMEOUT_MS;
+  const messagesBefore = messages.length;
+  const unchanged = { messagesBefore, messagesAfter: messagesBefore } as const;
+
+  const boundary = findCompactionBoundary(messages, keepLastN, ops);
+  if (boundary < 0) {
+    return { compacted: false, reason: 'history-too-short', ...unchanged };
+  }
+  if (boundary === 0) {
+    // Kept tail starts at message 0 — the whole history is within the keep
+    // window, so there is nothing older to summarize.
+    return { compacted: false, reason: 'nothing-to-summarize', ...unchanged };
+  }
+  if (isAborted()) {
+    return { compacted: false, reason: 'aborted', ...unchanged };
+  }
+
+  const olderSlice = messages.slice(0, boundary);
+  const transcript = renderTranscript(olderSlice, ops);
+
+  let summary: string;
+  try {
+    summary = await withTimeout(summarize(transcript), timeoutMs, deps.abortInFlight);
+  } catch (err) {
+    if (isAborted()) {
+      return { compacted: false, reason: 'aborted', ...unchanged };
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    return { compacted: false, reason: 'summarization-failed: ' + msg, ...unchanged };
+  }
+
+  if (summary.trim().length === 0) {
+    return { compacted: false, reason: 'empty-summary', ...unchanged };
+  }
+
+  const tokensSavedEstimate = estimateTokensSaved(messages, boundary, summary, ops);
+  const newMessages = applyCompaction(messages, boundary, summary, ops);
+  // Splice in place so the provider's history reference stays stable.
+  messages.splice(0, messages.length, ...newMessages);
+  const messagesAfter = messages.length;
+
+  deps.onSuccess?.({
+    olderSlice,
+    summary,
+    keptTailCount: messagesBefore - boundary,
+    keepLastN,
+    messagesBefore,
+    messagesAfter,
+    tokensSavedEstimate,
+  });
+
+  return { compacted: true, messagesBefore, messagesAfter, tokensSavedEstimate };
+}
+
+/** Timeout sentinel distinct from any provider/SDK error. */
+class CompactionTimeoutError extends Error {
+  constructor(ms: number) {
+    super(`summarization timed out after ${ms}ms`);
+    this.name = 'CompactionTimeoutError';
+  }
+}
+
+/**
+ * Race a promise against a timeout. On timeout, invoke `onTimeout` (to cancel
+ * the in-flight request) and reject with {@link CompactionTimeoutError}. The
+ * timer is always cleared so the event loop is not held open.
+ */
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  onTimeout?: () => void,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      try {
+        onTimeout?.();
+      } finally {
+        reject(new CompactionTimeoutError(ms));
+      }
+    }, ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## What

Makes history **compaction provider-agnostic**. `/compact` (and auto-compaction) now work on **OpenAI, custom-endpoint (baseURL), and local-shim (MLX/llama.cpp/vLLM/Ollama) sessions** — previously it was Anthropic-only and a silent no-op elsewhere (the provider left `compact` undefined).

## Why

Compaction bundled three separable concerns inside `anthropic-direct/compact.ts`: orchestration (agnostic), message representation (provider-specific), and the summarization model call (already exists as each provider's `oneshot.ts`). That bundling was the only reason OpenAI sessions couldn't compact. This lifts the agnostic parts into `shared/` — mirroring the earlier `shared/auto-compact.ts` extraction — so any provider gains compaction by supplying a small ops object and reusing its existing one-shot.

## Design

- **`providers/shared/compaction.ts`** — `CompactionOps<M>` (the only per-provider surface) + generic `findCompactionBoundary` / `renderTranscript` / `applyCompaction` / `estimateTokensSaved`, plus **`runCompactionCore`**: the single guardrail chokepoint — summarize **timeout**, **empty-summary floor**, and abort/try-catch. History is never corrupted by a slow/flaky summarizer (every failure path leaves it byte-for-byte unchanged).
- **`anthropic-direct/compact.ts`** — now implements `CompactionOps<MessageParam>` and delegates to the shared generics through back-compat wrappers. Existing exports and the 19 compaction tests are **unchanged** (behavior-preserving).
- **`openai-compatible/compact.ts`** — `CompactionOps<OpenAIMessage>` + `compactOpenAIHistory` routing through `runCompactionCore`. Fresh-user-turn keys on `role:'user'` (tool results are `role:'tool'`), so the kept tail never starts with an orphaned tool message — the HTTP-400 trigger is structurally impossible.
- **`openai-compatible/query.ts`** — `compact()` reuses **this session's own client** (via a new optional pre-built `client` on `oneShotChatCompletion`), so summarization lands on the same endpoint / credentials / headers as the conversation (custom baseURL, ChatGPT backend, or local shim). Compaction model = `AFK_COMPACT_MODEL ?? session model`.

Adding a third provider now = implement `CompactionOps<M>` + pass its existing one-shot as `summarize`. Fully additive; the provider `compact()` interface is unchanged.

## Scope / deferred

- **Cross-provider summarization** (e.g. a Claude model summarizing an OpenAI session) is intentionally **not** wired: a mismatched model id simply fails the summarize call, which the core treats as a safe no-op. The seam admits it later by swapping the `summarize` closure — no restructuring.
- Anthropic's handler keeps its bespoke streaming orchestration (it now shares the algorithms + prompt via the delegating wrappers); routing it fully through `runCompactionCore` is a clean follow-up.

## Testing

- New: `shared/compaction.test.ts` (13) — generic algorithms + all `runCompactionCore` guardrails (empty summary, timeout+cancel, aborted, too-short).
- New: `openai-compatible/compact.test.ts` (10) — ops (tool_calls/image rendering, role keying) + handler (in-place splice, session-closed / turn-in-flight / history-too-short / empty-summary bails, abort-signal threading).
- Preserved: `anthropic-direct/compact.test.ts` (19) green.
- **Full suite: 621 files, 11,246 passed, 0 failures.** `tsc --noEmit`, `audit:env:check`, `scan:env:check`, `audit:sdk:check` all pass.

🤖 Generated with AFK
