### PR TITLE
feat(cli): auto-resume idle REPL when a background subagent completes

### DIFF
--- a/src/cli/commands/interactive/bg-result-notifier.test.ts
+++ b/src/cli/commands/interactive/bg-result-notifier.test.ts
@@ -215,6 +215,48 @@ describe('BgResultNotifier', () => {
     notifier.drainInjections();
     expect(spy).toHaveBeenCalledWith(job.jobId);
   });
+
+  // ── onInjectable wake hook (auto-resume trigger) ──────────────────────────
+  // The REPL loop wires `onInjectable` to its auto-resume path. It must fire
+  // exactly for results that produced an injection — so a woken turn always
+  // has an envelope to drain — and stay silent otherwise.
+
+  it('onInjectable fires once when an injectable job settles', () => {
+    const spy = vi.fn();
+    notifier.onInjectable = spy;
+    const { handle, fireTerminal } = makeBgHandle('sub-k');
+    registry.register({ handle, prompt: 'wake me', model: 'sonnet' });
+    fireTerminal(succeed('sub-k', 'result'));
+    expect(spy).toHaveBeenCalledTimes(1);
+    // And an injection is genuinely buffered for the woken turn to drain.
+    expect(notifier.drainInjections()).not.toBe('');
+  });
+
+  it('onInjectable does NOT fire for a cancelled job (notice-only, nothing to resume on)', async () => {
+    const spy = vi.fn();
+    notifier.onInjectable = spy;
+    const { handle, fireTerminal } = makeBgHandle('sub-l');
+    const job = registry.register({ handle, prompt: 'cancel me', model: 'sonnet' });
+    await registry.cancelJob(job.jobId);
+    fireTerminal({ id: 'sub-l', status: 'cancelled' } as SubagentResult);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('onInjectable does NOT fire when AFK_BG_AUTO_DELIVER=0 (natural off-switch)', () => {
+    process.env['AFK_BG_AUTO_DELIVER'] = '0';
+    const spy = vi.fn();
+    notifier.onInjectable = spy;
+    const { handle, fireTerminal } = makeBgHandle('sub-m');
+    registry.register({ handle, prompt: 'opted out', model: 'sonnet' });
+    fireTerminal(succeed('sub-m', 'invisible'));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('a settle with no onInjectable wired does not throw (default null)', () => {
+    const { handle, fireTerminal } = makeBgHandle('sub-n');
+    registry.register({ handle, prompt: 'no hook', model: 'sonnet' });
+    expect(() => fireTerminal(succeed('sub-n', 'ok'))).not.toThrow();
+  });
 });
 
 describe('isAutoDeliverEnabled', () => {

--- a/src/cli/commands/interactive/bg-result-notifier.ts
+++ b/src/cli/commands/interactive/bg-result-notifier.ts
@@ -161,6 +161,17 @@ export class BgResultNotifier {
   /** Buffer of settled jobs awaiting a one-line completion notice. */
   private pendingNotifications: PendingBgAgentNotification[] = [];
 
+  /**
+   * Optional wake hook, fired once AFTER an injectable (non-cancelled,
+   * auto-deliver-on) result is buffered. The REPL loop wires this to its
+   * auto-resume trigger so an idle prompt can wake without a keystroke.
+   * Injectability is decided HERE (past the auto-deliver + cancelled gates)
+   * so the loop's handler never re-derives it; the handler owns only the
+   * wake POLICY (idle / empty-buffer / session-budget) and is a no-op when
+   * any of those gates fail. Null when nothing is wired (no behavior change).
+   */
+  onInjectable: (() => void) | null = null;
+
   private readonly onSettled = (job: BackgroundJob): void => {
     if (!isAutoDeliverEnabled(env.AFK_BG_AUTO_DELIVER)) return;
     this.pendingNotifications.push({ job });
@@ -174,6 +185,10 @@ export class BgResultNotifier {
     if (this.pendingInjections.length > MAX_PENDING) {
       this.pendingInjections.shift();
     }
+    // A real injectable result just landed — nudge the wake hook (if wired)
+    // so an idle REPL can auto-resume. Fired last so the buffer is already
+    // populated when the handler drains on the woken turn.
+    this.onInjectable?.();
   };
 
   constructor(private readonly registry: BackgroundAgentRegistry) {

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -15,6 +15,7 @@ import { isDebugEnabled, debugLog } from '../../../utils/debug.js';
 import { sanitizeForDisplay } from '../../../utils/terminal-sanitize.js';
 import { env } from '../../../config/env.js';
 import { palette } from '../../palette.js';
+import { ringBellIfEnabled } from '../../_lib/capture-mode.js';
 import { cyclePermissionMode } from '../../permission-mode-cycle.js';
 import {
   autoRegisterPluginPassthroughs,
@@ -37,6 +38,26 @@ import type { FooterSubsystems } from './footer-subsystems.js';
  *  registry default (HOOK_HANDLER_TIMEOUT_MS = 30s) because Stop fires every
  *  REPL turn — a notification hook must not stall the prompt for 30s × N handlers. */
 const STOP_HOOK_HANDLER_TIMEOUT_MS = 5_000;
+
+/**
+ * Session-wide cap on autonomous auto-resumes — an idle REPL woken by a settled
+ * background subagent (see the `onInjectable` wiring below). Circuit breaker
+ * against a self-perpetuating loop: a woken turn can itself dispatch another
+ * background job that settles and re-wakes the session. This bounds that chain;
+ * once hit, further results still deliver on the user's next manual turn.
+ * Mirrors the per-session budget precedent in `background-summarizer.ts`.
+ */
+const MAX_AUTO_RESUMES_PER_SESSION = 3;
+
+/**
+ * User-message text seeded when a background result auto-resumes an idle REPL.
+ * The settled-result envelope is prepended at drain time (`runText = envelope +
+ * this`), so the model sees the finished result followed by an explicit, honest
+ * continue instruction — never a spoofed empty turn. The `[auto-resume]` tag
+ * also makes the woken turn legible when scrolling back through history.
+ */
+const AUTO_RESUME_DIRECTIVE =
+  '[auto-resume] The background task above has finished. Continue the work it was dispatched for.';
 
 async function runFirstTurnHookIfNeeded(ctx: InteractiveCtx, text: string): Promise<void> {
   // First-turn hook — awaited before any first-turn side effect that relies on
@@ -149,6 +170,30 @@ export async function runInputLoop(
   // conversation is resumable. Surface the FIRST failure per session; stay
   // quiet afterwards so a broken disk doesn't spam the transcript every turn.
   let autosaveFailureLogged = false;
+
+  // Auto-resume: wake an idle prompt when a background subagent result lands so
+  // the session continues its work without waiting for a keystroke. Fires only
+  // for injectable results (the notifier gates on AFK_BG_AUTO_DELIVER + skips
+  // cancels before invoking this), and only when the prompt is genuinely idle —
+  // blocked on readLine (isAwaitingInput) with an empty input buffer, so a
+  // half-typed line is never clobbered and a result that lands mid-turn just
+  // delivers on the next drain. Bounded by MAX_AUTO_RESUMES_PER_SESSION as a
+  // circuit breaker. TTY-only: isAwaitingInput() is false on the non-TTY reader.
+  let autoResumeCount = 0;
+  bgResultNotifier.onInjectable = () => {
+    if (autoResumeCount >= MAX_AUTO_RESUMES_PER_SESSION) return;
+    if (!surface.isAwaitingInput() || !surface.bufferIsEmpty()) return;
+    autoResumeCount++;
+    // Audible cue (no-op unless AFK_BELL=1 + TTY) before the seeded turn takes
+    // over the prompt — the human-facing "your background work resumed" signal.
+    ringBellIfEnabled(process.stdout);
+    // Set the function-scope seed FIRST, then wake. abortPendingRead resolves
+    // the in-flight readLine with an empty payload, tripping the empty-input
+    // `continue` below; the next iteration's seed fast-path fires the directive
+    // and the drain prepends the result envelope (runText = envelope + directive).
+    seedBuffer = { text: AUTO_RESUME_DIRECTIVE, attachments: [] };
+    surface.abortPendingRead();
+  };
 
   while (true) {
       if (pendingInitMeta) {

--- a/src/cli/input/input-surface.test.ts
+++ b/src/cli/input/input-surface.test.ts
@@ -624,4 +624,108 @@ describe('InputSurface', () => {
       await surface.dispose();
     });
   });
+
+  /**
+   * Auto-resume wake support — the seam that lets a settled background
+   * subagent wake an idle prompt without a keystroke (see
+   * loop-iteration.ts `onInjectable` wiring). `abortPendingRead()` resolves
+   * an in-flight compositor read with an EMPTY payload; `isAwaitingInput()`
+   * and `bufferIsEmpty()` gate that wake so it never clobbers a half-typed
+   * line or fires when no read is blocked.
+   */
+  describe('auto-resume wake support (abortPendingRead / isAwaitingInput / bufferIsEmpty)', () => {
+    it('isAwaitingInput() tracks the in-flight compositor read: false → true → false', async () => {
+      const stdout = makeMockStdout();
+      const stdin = makeMockStdin();
+      const surface = new InputSurface({ rl: makeRl(), history: makeHistory() });
+      await surface.armCompositor({ promptFn: () => 'afk › ', onCancel: () => {}, stdout, stdin });
+
+      expect(surface.isAwaitingInput()).toBe(false);
+      const readPromise = surface.readLine({ promptFn: () => 'afk › ' });
+      expect(surface.isAwaitingInput()).toBe(true);
+
+      surface.abortPendingRead();
+      await readPromise;
+      expect(surface.isAwaitingInput()).toBe(false);
+
+      await surface.dispose();
+    });
+
+    it('abortPendingRead() resolves the in-flight read with an empty payload (no keypress)', async () => {
+      const stdout = makeMockStdout();
+      const stdin = makeMockStdin();
+      const surface = new InputSurface({ rl: makeRl(), history: makeHistory() });
+      await surface.armCompositor({ promptFn: () => 'afk › ', onCancel: () => {}, stdout, stdin });
+
+      const readPromise = surface.readLine({ promptFn: () => 'afk › ' });
+      surface.abortPendingRead();
+      const result = await readPromise;
+
+      expect(result).toEqual({ text: '', attachments: [] });
+      await surface.dispose();
+    });
+
+    it('abortPendingRead() clears onSubmit so a later Enter cannot double-fire, and the NEXT read works normally', async () => {
+      const stdout = makeMockStdout();
+      const stdin = makeMockStdin();
+      const surface = new InputSurface({ rl: makeRl(), history: makeHistory() });
+      await surface.armCompositor({ promptFn: () => 'afk › ', onCancel: () => {}, stdout, stdin });
+
+      // Wake-abort the first read.
+      const first = surface.readLine({ promptFn: () => 'afk › ' });
+      surface.abortPendingRead();
+      expect(await first).toEqual({ text: '', attachments: [] });
+
+      // A stray Enter arriving before the next read must be a no-op (onSubmit
+      // was cleared by abortPendingRead) — it must not resolve anything.
+      stdin.emit('keypress', undefined, { name: 'return' });
+
+      // The next real read wires a fresh handler and resolves with typed text.
+      const second = surface.readLine({ promptFn: () => 'afk › ' });
+      for (const ch of 'again') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+      stdin.emit('keypress', undefined, { name: 'return' });
+      expect((await second).text).toBe('again');
+
+      await surface.dispose();
+    });
+
+    it('abortPendingRead() is a no-op when no read is in flight', async () => {
+      const stdout = makeMockStdout();
+      const stdin = makeMockStdin();
+      const surface = new InputSurface({ rl: makeRl(), history: makeHistory() });
+      await surface.armCompositor({ promptFn: () => 'afk › ', onCancel: () => {}, stdout, stdin });
+
+      // No readLine outstanding — must not throw.
+      expect(() => surface.abortPendingRead()).not.toThrow();
+      expect(surface.isAwaitingInput()).toBe(false);
+
+      await surface.dispose();
+    });
+
+    it('bufferIsEmpty() is true on a fresh idle prompt and false once text is typed', async () => {
+      const stdout = makeMockStdout();
+      const stdin = makeMockStdin();
+      const surface = new InputSurface({ rl: makeRl(), history: makeHistory() });
+      await surface.armCompositor({ promptFn: () => 'afk › ', onCancel: () => {}, stdout, stdin });
+
+      const readPromise = surface.readLine({ promptFn: () => 'afk › ' });
+      expect(surface.bufferIsEmpty()).toBe(true);
+
+      for (const ch of 'half') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+      expect(surface.bufferIsEmpty()).toBe(false);
+
+      // Cleanup: dispose rejects the in-flight read.
+      await surface.dispose();
+      await expect(readPromise).rejects.toThrow('disposed');
+    });
+
+    it('isAwaitingInput() and bufferIsEmpty() are inert on a never-armed (non-TTY) surface', () => {
+      const surface = new InputSurface({ rl: makeRl(), history: makeHistory() });
+      // No compositor: no wake seam. isAwaitingInput must be false (so the
+      // wake path self-gates off) and bufferIsEmpty defaults true.
+      expect(surface.isAwaitingInput()).toBe(false);
+      expect(surface.bufferIsEmpty()).toBe(true);
+      expect(() => surface.abortPendingRead()).not.toThrow();
+    });
+  });
 });

--- a/src/cli/input/input-surface.ts
+++ b/src/cli/input/input-surface.ts
@@ -243,6 +243,18 @@ export class InputSurface {
   private pendingReadReject: ((reason: Error) => void) | null = null;
 
   /**
+   * Resolve callback for the currently-pending readLine Promise (if any) —
+   * the twin of {@link pendingReadReject}. Set inside `readLine()` alongside
+   * the reject, cleared once the Promise settles. Used by
+   * {@link abortPendingRead} to resolve an in-flight read with an EMPTY
+   * payload from outside the keypress loop (the auto-resume wake path), so a
+   * settled background subagent can wake an idle prompt without a keystroke.
+   * Non-null only on the compositor (TTY) path — the non-TTY reader resolves
+   * through `readWithAutocomplete` and cannot be externally woken.
+   */
+  private pendingReadResolve: ((value: ReadWithAutocompleteResult) => void) | null = null;
+
+  /**
    * Live-registry adapter — queried fresh via `listSlashCommands()` on
    * every call so plugins that register slash commands mid-session
    * colorize correctly. Held as a class field (not an `armCompositor`
@@ -340,6 +352,7 @@ export class InputSurface {
       this.compositor.setOnSubmit(null);
       const reject = this.pendingReadReject;
       this.pendingReadReject = null;
+      this.pendingReadResolve = null;
       reject(new Error('InputSurface disposed while readLine was in progress'));
     }
     try { this.compositor.disarm(); } catch { /* best effort */ }
@@ -435,8 +448,11 @@ export class InputSurface {
       const compositor = this.compositor;
       return new Promise<ReadWithAutocompleteResult>((resolve, reject) => {
         // Store the reject so dispose() can abort this Promise if
-        // the surface is torn down before the user presses Enter.
+        // the surface is torn down before the user presses Enter, and the
+        // resolve so abortPendingRead() can wake it with an empty payload
+        // (auto-resume) without a keypress.
         this.pendingReadReject = reject;
+        this.pendingReadResolve = resolve;
 
         const handler = (payload: SubmissionPayload) => {
           // One-shot: clear the handler after fire so the next
@@ -445,9 +461,11 @@ export class InputSurface {
           // keeps the compositor's invariant that submission state
           // is cleared BEFORE the handler runs intact.
           compositor.setOnSubmit(null);
-          // Settled — clear the dispose-abort ref so a subsequent
-          // dispose() doesn't try to reject an already-resolved Promise.
+          // Settled — clear the dispose-abort + wake refs so a subsequent
+          // dispose()/abortPendingRead() doesn't touch an already-resolved
+          // Promise.
           this.pendingReadReject = null;
+          this.pendingReadResolve = null;
 
           // Visual parity with `readWithAutocomplete`: commit the
           // submitted message to scrollback above the live overlay.
@@ -527,6 +545,52 @@ export class InputSurface {
       autocompleteState: this.autocompleteState,
       ...(this.statusLine ? { statusLine: this.statusLine } : {}),
     });
+  }
+
+  /**
+   * Whether a compositor-path {@link readLine} Promise is currently in
+   * flight (idle prompt, blocked awaiting Enter). False on the non-TTY
+   * reader path, which cannot be externally woken. Read by the REPL loop's
+   * auto-resume trigger to gate {@link abortPendingRead}.
+   */
+  isAwaitingInput(): boolean {
+    return this.pendingReadResolve !== null;
+  }
+
+  /**
+   * Whether the compositor's live input buffer holds no pending user intent
+   * — empty text AND no queued submission. Gates the auto-resume wake so it
+   * never clobbers a half-typed line or a submission queued mid-stream.
+   * Returns true when no compositor is armed (non-TTY), but the
+   * {@link isAwaitingInput} gate makes that case unreachable on the wake path.
+   */
+  bufferIsEmpty(): boolean {
+    const buf = this.compositor?.getBuffer();
+    if (!buf) return true;
+    return buf.text.length === 0 && !buf.queued;
+  }
+
+  /**
+   * Resolve an in-flight compositor-path {@link readLine} with an EMPTY
+   * payload WITHOUT a keypress — the external-wake twin of the
+   * {@link dispose} abort path (resolve instead of reject). Clears the
+   * one-shot `onSubmit` handler first (mirror the submit handler) so a
+   * later Enter cannot double-fire, then resolves. No-op when no read is in
+   * flight or on the non-TTY path.
+   *
+   * The empty payload trips the REPL loop's empty-input guard (`continue`),
+   * which re-enters the top of the loop where the caller's queued
+   * `seedBuffer` drives the actual turn. See
+   * `loop-iteration.ts` and
+   * `.afk/plans/auto-resume-repl-on-background-completion.md`.
+   */
+  abortPendingRead(): void {
+    if (!this.pendingReadResolve) return;
+    this.compositor?.setOnSubmit(null);
+    const resolve = this.pendingReadResolve;
+    this.pendingReadReject = null;
+    this.pendingReadResolve = null;
+    resolve({ text: '', attachments: [] });
   }
 
   /**


### PR DESCRIPTION
## Problem

When the interactive REPL dispatched a background subagent (`agent` tool, `mode:"background"`) and then went idle at the prompt, a completed result was **only** delivered by being prepended to the next human-typed turn — the session never woke on its own. So a background job could finish and the promised follow-up work (verify → push → open PR, etc.) would silently wait until the operator typed something.

## What this does

Auto-resumes the idle REPL when a background result lands: the session runs **one turn** on the finished result without a keystroke.

Reuses existing seams — **no new infrastructure, no `Promise.race`, no edit to the every-turn empty-input guard:**

- **`BgResultNotifier`** gains an optional `onInjectable` hook, fired after it buffers an injectable result (past the `AFK_BG_AUTO_DELIVER` + cancelled gates, so a woken turn always has an envelope to drain).
- **`InputSurface`** gains `abortPendingRead()` — a resolve-with-empty twin of the existing `pendingReadReject` dispose seam — plus `isAwaitingInput()` / `bufferIsEmpty()` gates.
- **The REPL loop** wires the hook: on a genuinely idle prompt it seeds an honest `[auto-resume]` continue directive and resolves the blocked `readLine` with an empty payload. The empty-input `continue` re-enters the loop, the existing seed fast-path fires, and the drain prepends the result envelope → `runText = envelope + directive`.

The model therefore sees the finished-result envelope followed by an explicit, honest continue instruction — never a spoofed empty turn.

## Safety rails (default behavior, no flag)

Per maintainer decision, there's no new env var / config key — the feature's natural off-switch is the existing `AFK_BG_AUTO_DELIVER=0` (the hook only fires when auto-deliver has buffered something).

- **`MAX_AUTO_RESUMES_PER_SESSION = 3`** — circuit breaker against a self-perpetuating wake loop (a woken turn dispatching another background job that re-wakes the session). Mirrors the per-session budget precedent in `background-summarizer.ts`.
- **Idle-only** — wakes only when `isAwaitingInput()` (blocked on `readLine`) **and** the input buffer is empty/unqueued, so a half-typed line is never clobbered. A result that lands mid-turn just delivers on the next drain, as today.
- **Never wakes on cancelled jobs.**
- **TTY-only** — the non-TTY reader path (`readWithAutocomplete`) is unaffected.

## UX

On the woken iteration the operator sees the existing completion notice plus the echoed directive, e.g.:

```
  ✓ [bg-xxxx] subagent completed · 42s · <label>
afk › [auto-resume] The background task above has finished. Continue the work it was dispatched for.
```

## Testing

- **+10 unit tests**: `InputSurface` wake seam (`abortPendingRead` resolves empty, no double-fire, idle/buffer gates, non-TTY inert) and `BgResultNotifier.onInjectable` gating (fires for injectable; not for cancelled; not when `AFK_BG_AUTO_DELIVER=0`; null-safe).
- `pnpm lint` clean; **full suite green — 619 files, 11,233 passed, 14 skipped**.

## Known minor / follow-ups

- The `[auto-resume]` directive enters the ↑/↓ history ring (consistent with existing plan-exit / slash-submit seeds).
- A result settling *during* a woken turn delivers on the next turn rather than chaining a second auto-resume.
- Shell-passthrough (`!&cmd`) has the identical latent idle-wake gap; the wake vehicle here is producer-agnostic, so wiring it later is a cheap follow-on (not done here).