### PR TITLE
refactor(session): split agent-session.ts — extract closure-emitter, ledger-lifecycle, plan-exit-bridge (#364)

### DIFF
--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -13,8 +13,8 @@
 
 import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
 import { debugLog } from '../../utils/debug.js';
-import { AbortError, BudgetExceededError, TimeoutError } from '../../utils/errors.js';
-import { emitClosure, emitSessionPhase } from '../trace/emit.js';
+import { AbortError } from '../../utils/errors.js';
+import { emitSessionPhase } from '../trace/emit.js';
 import type { HookRegistry } from '../hooks.js';
 import { resolveProvider, providerForModel } from '../providers/index.js';
 import { ProviderRouter } from '../providers/router/provider-router.js';
@@ -23,8 +23,11 @@ import type { ProviderCompactResult, ProviderEvent, ProviderQuery } from '../pro
 import { DEFAULT_SESSION_TIMEOUT_MS, RESET_DRAIN_TIMEOUT_MS, withTimeout } from '../timeout.js';
 import { dispatchSessionEnd, dispatchSessionStart } from './hooks-dispatch.js';
 import { HookBlockedError } from '../../utils/errors.js';
-import { classifyClosureReason } from './closure-reason.js';
-import { buildClosureGuidance } from './closure-guidance.js';
+import {
+  emitClosureEvent,
+  sealTraceWriter,
+  type ClosureSignals,
+} from './closure-emitter.js';
 import { extractStructuredOutput } from '../output-extractor.js';
 import { z, type ZodType } from 'zod';
 import type {
@@ -50,10 +53,9 @@ import type {
   StructuredMessageOptions,
 } from '../types.js';
 import { QueryInputStream } from './input-iterable.js';
-import { SessionLedgerWriter } from '../session-ledger.js';
-import { sessionLabelFromTracePath } from '../../paths.js';
+import { LedgerLifecycle } from './ledger-lifecycle.js';
+import { PlanExitBridge } from './plan-exit-bridge.js';
 import type { ElicitationRequest } from '../types/sdk-types.js';
-import { env } from '../../config/env.js';
 import { resolveModelId } from './model-resolution.js';
 import { deriveOrigin, deriveActor } from './session-identity.js';
 import { updatePresenceCwd } from '../awareness/presence.js';
@@ -76,42 +78,13 @@ import {
 export class AgentSession implements IAgentSession {
   private config: AgentConfig;
   /**
-   * Pending plan-exit implement-turn queued by an approved `exit_plan_mode`
-   * tool call (via the injected {@link PlanExitControls}). The REPL drains it
-   * with {@link takePendingPlanExitSeed} after the current turn, which atomically
-   * applies the deferred permission-mode flip and returns the seed message.
-   * Stores both the message and the approved mode so the flip can be deferred to
-   * the post-turn boundary — closing the mid-turn TOCTOU window.
-   * Lives on the session (not the per-turn dispatcher) so it survives from the
-   * mid-turn tool call to the post-turn REPL boundary.
+   * Plan-mode-exit state machine: the pending implement-turn seed, the captured
+   * pre-plan mode to restore, and the transient Shift+Tab ring-gesture memory.
+   * Lives on the session (not the per-turn dispatcher) so it survives from a
+   * mid-turn `exit_plan_mode` tool call to the post-turn REPL boundary. See
+   * {@link PlanExitBridge} for the ring-gesture rescue invariants.
    */
-  private _pendingPlanExitSeed: { message: string; mode: PermissionMode } | undefined;
-  /**
-   * The permission mode the session was in immediately BEFORE entering plan
-   * mode. Captured by {@link setPermissionMode} on the transition INTO 'plan'
-   * (covering every entry path — `/plan`, free-text `/plan`, Shift+Tab) and read
-   * by an approved plan-exit ({@link getPrePlanMode}) so the implement-turn
-   * restores it instead of forcing 'default'. `undefined` until the first
-   * plan-entry, and reset to `undefined` when the prior mode was 'autonomous'
-   * (AFK is not restorable by a bare flip) so restore falls back to 'default'.
-   */
-  private _prePlanPermissionMode: PermissionMode | undefined;
-  /**
-   * Ring-gesture memory for the Shift+Tab permission cycle
-   * (`default → plan → bypassPermissions`, see `cli/permission-mode-cycle.ts`).
-   * `plan`'s only ring-predecessor is `default`, so cycling from a privileged
-   * working mode (e.g. bypass) INTO plan necessarily passes through a TRANSIENT
-   * `default` hop: bypass → default → plan. Without this, {@link setPermissionMode}
-   * would capture that transient `default` as the pre-plan mode and an approved
-   * exit would drop the user to `default` instead of restoring their real working
-   * mode. So on a `<privileged> → default` transition we stash the mode left
-   * behind here; the very next `default → plan` transition restores it as the
-   * pre-plan mode. Cleared at every turn boundary (see `sendMessageStreamInternal`)
-   * so it survives ONLY an uninterrupted Shift+Tab gesture — a genuine rest in
-   * `default` (which submits a turn) clears it, keeping the restore safe: it never
-   * escalates back to bypass after the user actually worked in `default`.
-   */
-  private _modeBeforeDefault: PermissionMode | undefined;
+  private readonly planExit = new PlanExitBridge();
   private currentState: SessionState = 'idle';
   private providerQuery!: ProviderQuery;
   private providerIterator!: AsyncIterator<ProviderEvent>;
@@ -190,11 +163,10 @@ export class AgentSession implements IAgentSession {
    * Created lazily on the first turn once the provider has issued a session id.
    * Top-level sessions only — subagents are observable via the bg-job log and
    * witness traces; mirroring them here would multiply files per session.
-   * Null when disabled (env opt-out), gated off (subagent), or after close.
+   * Inert (no writer) when disabled (env opt-out), gated off (subagent), or
+   * after close. Lifecycle glue lives in {@link LedgerLifecycle}.
    */
-  private ledger: SessionLedgerWriter | null = null;
-  /** Set true once ledger creation has been attempted (success or not). */
-  private ledgerInitAttempted = false;
+  private readonly ledger = new LedgerLifecycle();
 
   constructor(config: AgentConfig) {
     // Wire the plan-exit control bridge for top-level sessions only (plan mode
@@ -209,10 +181,9 @@ export class AgentSession implements IAgentSession {
             ...config,
             planExitControls: {
               setPermissionMode: (mode) => this.setPermissionMode(mode),
-              requestImplementSeed: (message, mode) => {
-                this._pendingPlanExitSeed = { message, mode };
-              },
-              getPrePlanMode: () => this._prePlanPermissionMode,
+              requestImplementSeed: (message, mode) =>
+                this.planExit.requestImplementSeed(message, mode),
+              getPrePlanMode: () => this.planExit.getPrePlanMode(),
             },
           }
         : config;
@@ -632,8 +603,8 @@ export class AgentSession implements IAgentSession {
     // user actually RESTED in the current mode, so a transient-default stash
     // from `setPermissionMode` must not survive into a later `default → plan`
     // (which would wrongly restore bypass after real work in default). See
-    // {@link _modeBeforeDefault}.
-    this._modeBeforeDefault = undefined;
+    // {@link PlanExitBridge}.
+    this.planExit.clearModeBeforeDefault();
 
     // Fold queued hook context into THIS message so it rides along with the
     // user's text instead of becoming a turn of its own — see
@@ -653,7 +624,7 @@ export class AgentSession implements IAgentSession {
     // constructor) because the provider-issued session id only exists after
     // `session.init` — which `initPromise` above has just drained.
     this.ensureLedger();
-    this.ledger?.recordUser(historySummary);
+    this.ledger.recordUser(historySummary);
 
     const deps = this.buildTransformDeps();
 
@@ -677,7 +648,7 @@ export class AgentSession implements IAgentSession {
             // `succeeded` / `model_end_turn` to `failed` / `abort`.
             this.sawProviderError = true;
           }
-          this.ledger?.recordEvent(output);
+          this.ledger.recordEvent(output);
           yield output;
           if (output.type === 'done' || output.type === 'error') break;
         }
@@ -688,53 +659,21 @@ export class AgentSession implements IAgentSession {
   }
 
   /**
-   * Create the session ledger writer on first use.
-   *
-   * Gates (all must pass):
-   *   - top-level session (subagents: `depth`/`parentSessionId` set at fork);
-   *   - `AFK_SESSION_LEDGER_DISABLED` is not `'1'`;
-   *   - the provider has issued a session id.
-   *
-   * One attempt per lifecycle: if the id is unavailable or unsafe the first
-   * time, the session simply runs unledgered — never throws, never retries
-   * per-event (the `ledgerInitAttempted` latch keeps the hot path cheap).
+   * Create the session ledger writer on first use, deferring to
+   * {@link LedgerLifecycle.ensure}. Deferred to the first turn (not the
+   * constructor) because the provider-issued session id only exists after
+   * `session.init`. Metadata is passed as a lazy accessor so it is read only
+   * when a writer is actually created, not on the per-turn no-op path.
    */
   private ensureLedger(): void {
-    if (this.ledgerInitAttempted) return;
-    this.ledgerInitAttempted = true;
-    if (this.config.depth !== undefined || this.config.parentSessionId !== undefined) return;
-    if (env.AFK_SESSION_LEDGER_DISABLED === '1') return;
-    const id = this.sessionId;
-    if (!id) return;
-    const writer = new SessionLedgerWriter(id);
-    if (!writer.active) return;
-    this.ledger = writer;
-    const meta = this.getSessionMetadata();
-    writer.record({
-      kind: 'meta',
-      sessionId: id,
-      model: meta.model ?? String(this.config.model),
-      ...(meta.cwd !== undefined ? { cwd: meta.cwd } : {}),
-      // Correlate this id-keyed ledger to its witness trace: fresh sessions
-      // label the trace dir with a random UUID (not the session id), so the
-      // ledger is the durable id→label bridge. `null` when tracing is
-      // disabled/unwired, so absence is explicit rather than silent.
-      traceLabel: sessionLabelFromTracePath(this.config.traceWriter?.getTracePath()),
+    this.ledger.ensure({
+      depth: this.config.depth,
+      parentSessionId: this.config.parentSessionId,
+      sessionId: this.sessionId,
+      fallbackModel: String(this.config.model),
+      tracePath: this.config.traceWriter?.getTracePath(),
+      getMetadata: () => this.getSessionMetadata(),
     });
-  }
-
-  /**
-   * Seal the ledger with a terminal record and flush. Idempotent.
-   * `close()`/`reset()` await the returned promise so tailers see the
-   * terminal record before teardown completes; the abort path
-   * fire-and-forgets it (abort handlers cannot block on disk I/O).
-   */
-  private sealLedger(reason: string): Promise<void> {
-    const ledger = this.ledger;
-    if (!ledger) return Promise.resolve();
-    this.ledger = null;
-    this.ledgerInitAttempted = false;
-    return ledger.close(reason);
   }
 
   /**
@@ -751,7 +690,7 @@ export class AgentSession implements IAgentSession {
    * existing path.
    */
   recordLedgerElicitation(reqId: string, request: ElicitationRequest): void {
-    this.ledger?.record({ kind: 'elicitation', reqId, request });
+    this.ledger.recordElicitation(reqId, request);
   }
 
   private summarizeContentBlocks(blocks: ContentBlockParam[]): string {
@@ -822,7 +761,7 @@ export class AgentSession implements IAgentSession {
     }
 
     await this.dispatchSessionEndOnce('reset');
-    await this.sealLedger('reset');
+    await this.ledger.seal('reset');
 
     try {
       await this.providerQuery.close();
@@ -873,7 +812,7 @@ export class AgentSession implements IAgentSession {
   }
 
   private async onAbort(): Promise<void> {
-    void this.sealLedger('abort');
+    void this.ledger.seal('abort');
     try {
       await this.providerQuery.interrupt();
     } catch {
@@ -897,38 +836,11 @@ export class AgentSession implements IAgentSession {
   }
 
   async setPermissionMode(mode: PermissionMode): Promise<void> {
-    // Capture the mode being LEFT on the transition INTO plan, so an approved
-    // exit (exit_plan_mode tool or `/plan off`) can restore it instead of
-    // forcing 'default'. Read the live mode BEFORE flipping. Guard on the
-    // non-plan → plan edge only: a redundant plan → plan flip must not overwrite
-    // the real pre-plan mode with 'plan'. 'autonomous' (AFK) is reset to
-    // undefined — it carries dedicated enter/exit machinery (toggleAfkMode) and
-    // is not safe to re-enter by a bare flip — so restore falls back to 'default'.
+    // Capture the plan bookkeeping (pre-plan mode to restore, Shift+Tab ring-
+    // gesture memory) BEFORE flipping — the live mode is read here, the
+    // transition rules live in PlanExitBridge. Then apply the actual flip.
     const current = this.stateManager.getSessionMetadata().permissionMode;
-    if (mode === 'plan') {
-      if (current !== 'plan') {
-        // Ring-gesture rescue: the Shift+Tab cycle reaches plan only via a
-        // TRANSIENT `default` hop off a privileged mode (bypass → default → plan).
-        // When we're entering plan FROM that transient default, restore the mode
-        // stashed on the hop instead of the default itself. `_modeBeforeDefault`
-        // is turn-scoped, so this only fires for an uninterrupted gesture.
-        const effectivePrev =
-          current === 'default' && this._modeBeforeDefault !== undefined
-            ? this._modeBeforeDefault
-            : current;
-        this._prePlanPermissionMode = effectivePrev === 'autonomous' ? undefined : effectivePrev;
-      }
-    } else if (mode === 'default') {
-      // Stash the privileged mode being left so the NEXT `default → plan` press
-      // in the same Shift+Tab gesture can see past this transient default. Only
-      // privileged non-plan modes are worth restoring; default/plan are not.
-      this._modeBeforeDefault =
-        current !== 'default' && current !== 'plan' ? current : undefined;
-    } else {
-      // Landing on a concrete working mode (bypass / acceptEdits / …) ends any
-      // in-flight ring gesture toward plan — drop the transient-default memory.
-      this._modeBeforeDefault = undefined;
-    }
+    this.planExit.recordModeTransition(mode, current);
     await this.providerQuery.setPermissionMode(mode);
     this.stateManager.setSessionMetadata((prev) => ({ ...prev, permissionMode: mode }));
   }
@@ -937,10 +849,10 @@ export class AgentSession implements IAgentSession {
    * The permission mode the session was in immediately before entering plan
    * mode, or `undefined` if none was captured (never entered plan, or the prior
    * mode was 'autonomous'). An approved plan-exit restores this; callers fall
-   * back to 'default' on `undefined`. See {@link _prePlanPermissionMode}.
+   * back to 'default' on `undefined`. See {@link PlanExitBridge}.
    */
   getPrePlanMode(): PermissionMode | undefined {
-    return this._prePlanPermissionMode;
+    return this.planExit.getPrePlanMode();
   }
 
   /**
@@ -972,8 +884,7 @@ export class AgentSession implements IAgentSession {
    * plan mode and can retry `exit_plan_mode`.
    */
   async takePendingPlanExitSeed(): Promise<{ message: string; mode: PermissionMode } | undefined> {
-    const seed = this._pendingPlanExitSeed;
-    this._pendingPlanExitSeed = undefined;
+    const seed = this.planExit.takeSeed();
     if (seed === undefined) return undefined;
     try {
       await this.setPermissionMode(seed.mode);
@@ -1189,7 +1100,7 @@ export class AgentSession implements IAgentSession {
   async close(): Promise<void> {
     if (this.currentState === 'closed') return;
     this.currentState = 'closed';
-    await this.sealLedger('close');
+    await this.ledger.seal('close');
     if (!this.abortController.signal.aborted) {
       this.abortController.abort('closed');
     }
@@ -1232,8 +1143,21 @@ export class AgentSession implements IAgentSession {
     //   3. Dispatch the SessionEnd hook.
     // Both 1 and 2 swallow writer errors so a broken sink never masks the
     // real session-end reason from observers downstream.
-    await this.emitClosure(reason).catch(() => {});
-    await this.sealTraceWriter(reason).catch(() => {});
+    const signals = this.closureSignals(reason);
+    await emitClosureEvent(this.config.traceWriter, {
+      ...signals,
+      finalTurnCount: this.turnCount,
+      finalCostUsd: this.sessionRunningCostUsd,
+      runningTokens: this.sessionRunningTokens,
+    }).catch(() => {});
+    await sealTraceWriter(this.config.traceWriter, {
+      ...signals,
+      finalTurnCount: this.turnCount,
+      finalCostUsd: this.sessionRunningCostUsd,
+      subagentCompletedCount: this.subagentCompletedCount,
+      subagentRunningTokens: this.subagentRunningTokens,
+      subagentRunningCostUsd: this.subagentRunningCostUsd,
+    }).catch(() => {});
     await dispatchSessionEnd(
       this._hookRegistry,
       {
@@ -1255,122 +1179,19 @@ export class AgentSession implements IAgentSession {
   }
 
   /**
-   * Emit the `closure` trace event with the session's terminal
-   * classification. Delegates the precedence rules to the pure
-   * {@link classifyClosureReason} (`./closure-reason.ts`), which maps the
-   * `dispatchSessionEndOnce` reason, the terminal-cause flags (`maxTurnsHit`,
-   * `hookBlocked`), the pre-classified abort reason, and the last provider
-   * stop reason into a {@link ClosureReason}.
-   *
-   * Wired reasons: `model_end_turn`, `truncated`, `abort`, `timeout`,
-   * `budget_exceeded`, `hook_blocked`, `max_turns_exceeded`. `iteration_cap`
-   * remains deferred — it is wired alongside the tool-use loop cap that
-   * produces it.
+   * Snapshot the terminal-cause signals the closure emitters read. `reason` is
+   * the `dispatchSessionEndOnce` string (close/reset/error) and doubles as the
+   * seal reason. The derivation rules live in `./closure-emitter.ts`.
    */
-  private async emitClosure(dispatchReason: string): Promise<void> {
-    const writer = this.config.traceWriter;
-    if (!writer) return;
-    const reasonValue = this.deriveClosureReason(dispatchReason);
-    const finalTokens: {
-      input?: number;
-      output?: number;
-      cacheRead?: number;
-      cacheCreation?: number;
-    } = {};
-    if (this.sessionRunningTokens.input > 0) finalTokens.input = this.sessionRunningTokens.input;
-    if (this.sessionRunningTokens.output > 0) finalTokens.output = this.sessionRunningTokens.output;
-    if (this.sessionRunningTokens.cacheRead > 0) finalTokens.cacheRead = this.sessionRunningTokens.cacheRead;
-    if (this.sessionRunningTokens.cacheCreation > 0)
-      finalTokens.cacheCreation = this.sessionRunningTokens.cacheCreation;
-
-    // closure-anomaly guardrail: attach an actionable recovery hint for an
-    // anomalous reason so the closure event names not just WHY it ended but
-    // what to do next. Null (benign / not-yet-covered reasons) → field omitted.
-    const guidance = buildClosureGuidance(reasonValue);
-
-    await emitClosure(writer, {
-      reason: reasonValue,
-      finalTurnCount: this.turnCount,
-      finalCostUsd: this.sessionRunningCostUsd,
-      finalTokens,
-      ...(this.lastStopReason !== undefined ? { lastStopReason: this.lastStopReason } : {}),
-      ...(guidance !== null ? { guidance } : {}),
-    });
-  }
-
-  private deriveClosureReason(dispatchReason: string): import('../trace/index.js').ClosureReason {
-    // Pre-classify the abort-signal reason here (needs the concrete error
-    // classes); the precedence decision tree lives in the pure
-    // classifyClosureReason so it is unit-testable without a live session.
-    let abort: 'budget_exceeded' | 'timeout' | 'abort' | null = null;
-    const signal = this.abortController.signal;
-    if (signal.aborted && signal.reason !== 'closed') {
-      const r = signal.reason;
-      if (r instanceof BudgetExceededError) abort = 'budget_exceeded';
-      else if (r instanceof TimeoutError) abort = 'timeout';
-      // Some abort paths pass the error's message string rather than the
-      // error instance — match the well-known prefixes as a fallback so the
-      // classification stays accurate when the abort reason was stringified.
-      else if (typeof r === 'string' && r.startsWith('Budget ')) abort = 'budget_exceeded';
-      else if (typeof r === 'string' && r.includes('timed out')) abort = 'timeout';
-      else abort = 'abort';
-    }
-    return classifyClosureReason({
-      dispatchReason,
+  private closureSignals(reason: string): ClosureSignals {
+    return {
+      dispatchReason: reason,
+      signal: this.abortController.signal,
       maxTurnsHit: this.maxTurnsHit,
       hookBlocked: this.hookBlocked,
-      abort,
       lastStopReason: this.lastStopReason,
       sawProviderError: this.sawProviderError,
-    });
-  }
-
-  /**
-   * Map a session-end {@link dispatchSessionEndOnce} reason to the
-   * `session_sealed` payload and ask the configured trace writer to
-   * seal. No-op when the writer is absent.
-   *
-   * Status mapping:
-   *  - reason `'close'` or `'reset'` while not aborted → `'succeeded'`
-   *  - reason `'error'` → `'failed'`
-   *  - any reason with an aborted signal → `'cancelled'` (abort beats
-   *    the reason string, matching the abort-precedence invariant in
-   *    `abort-graph.ts`)
-   */
-  private async sealTraceWriter(reason: string): Promise<void> {
-    const writer = this.config.traceWriter;
-    if (!writer) return;
-    const status = this.deriveSealStatus(reason);
-
-    // Build the optional subagent rollup fields — only present when at
-    // least one subagent completed and reported data.
-    const subagentCount =
-      this.subagentCompletedCount > 0 ? this.subagentCompletedCount : undefined;
-
-    const tok = this.subagentRunningTokens;
-    const hasSubagentTokens =
-      tok.input > 0 || tok.output > 0 || tok.cacheRead > 0 || tok.cacheCreation > 0;
-    const subagentTokens = hasSubagentTokens
-      ? {
-          ...(tok.input > 0 ? { input: tok.input } : {}),
-          ...(tok.output > 0 ? { output: tok.output } : {}),
-          ...(tok.cacheRead > 0 ? { cacheRead: tok.cacheRead } : {}),
-          ...(tok.cacheCreation > 0 ? { cacheCreation: tok.cacheCreation } : {}),
-        }
-      : undefined;
-
-    const subagentCostUsd =
-      this.subagentRunningCostUsd > 0 ? this.subagentRunningCostUsd : undefined;
-
-    await writer.seal({
-      status,
-      finalCostUsd: this.sessionRunningCostUsd,
-      finalTurnCount: this.turnCount,
-      closedAt: new Date().toISOString(),
-      ...(subagentCount !== undefined ? { subagentCount } : {}),
-      ...(subagentTokens !== undefined ? { subagentTokens } : {}),
-      ...(subagentCostUsd !== undefined ? { subagentCostUsd } : {}),
-    });
+    };
   }
 
   /**
@@ -1411,24 +1232,6 @@ export class AgentSession implements IAgentSession {
     if (typeof costUsd === 'number' && Number.isFinite(costUsd) && costUsd > 0) {
       this.subagentRunningCostUsd += costUsd;
     }
-  }
-
-  private deriveSealStatus(reason: string): 'succeeded' | 'failed' | 'cancelled' {
-    if (reason === 'error') return 'failed';
-    // `close()` itself aborts the internal controller with reason
-    // `'closed'` as part of normal teardown — that is NOT a cancellation.
-    // Only an abort whose reason came from somewhere else (external
-    // AbortSignal, budget-trip, hook-block routed through abort) counts
-    // as cancelled.
-    const signal = this.abortController.signal;
-    if (signal.aborted && signal.reason !== 'closed') return 'cancelled';
-    // A provider error (HTTP / auth / stream failure) that ended the final
-    // turn is a failure even when the surface then closed the session cleanly.
-    // Checked AFTER the abort branch so a genuine cancel/budget/timeout (which
-    // also emits an error event) keeps its more-specific `cancelled` status.
-    // Without this, a 0-turn/0-token error run seals as a silent `succeeded`.
-    if (this.sawProviderError) return 'failed';
-    return 'succeeded';
   }
 
   private assertCanSend(): void {

--- a/src/agent/session/closure-emitter.ts
+++ b/src/agent/session/closure-emitter.ts
@@ -1,0 +1,193 @@
+/**
+ * Session-closure trace emission, extracted from {@link AgentSession}.
+ *
+ * These are the terminal-classification + trace-seal helpers that
+ * `AgentSession.dispatchSessionEndOnce` fires when a session ends: they map the
+ * session's accumulated run counters and terminal-cause flags into the
+ * `closure` and `session_sealed` witness records.
+ *
+ * Kept as free functions taking an explicit deps snapshot (mirroring
+ * `stream-consumer.ts`'s `transformProviderEvent(deps)`) rather than lifted
+ * into a stateful owner: the counters they read (`sessionRunningTokens`,
+ * `sessionRunningCostUsd`, the terminal-cause flags) are mutated across several
+ * AgentSession sites — construction/reset, the `buildTransformDeps` callback,
+ * and the per-turn stream loop — so moving the state here would widen the
+ * shared-mutable-state surface, not shrink it. The session keeps ownership of
+ * the fields and passes a read snapshot at seal time.
+ *
+ * @module agent/session/closure-emitter
+ */
+
+import { BudgetExceededError, TimeoutError } from '../../utils/errors.js';
+import { emitClosure } from '../trace/emit.js';
+import type { ClosureReason } from '../trace/index.js';
+import type { TraceWriter } from '../trace/writer.js';
+import { buildClosureGuidance } from './closure-guidance.js';
+import { classifyClosureReason } from './closure-reason.js';
+
+/** Cumulative token tuple mirrored into the `closure` / `session_sealed` payloads. */
+export interface ClosureTokenCounters {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheCreation: number;
+}
+
+/**
+ * Terminal-cause snapshot shared by closure-reason and seal-status derivation.
+ * `dispatchReason` doubles as the seal `reason` — both derivations receive the
+ * identical string `dispatchSessionEndOnce` was called with (close/reset/error).
+ */
+export interface ClosureSignals {
+  /** The reason string passed to `dispatchSessionEndOnce` (close/reset/error). */
+  dispatchReason: string;
+  /** The session's internal abort signal; its `.aborted`/`.reason` drive classification. */
+  signal: AbortSignal;
+  maxTurnsHit: boolean;
+  hookBlocked: boolean;
+  lastStopReason: string | undefined;
+  sawProviderError: boolean;
+}
+
+/**
+ * Pre-classify the abort-signal reason (this needs the concrete error classes
+ * in scope), then delegate the precedence decision tree to the pure
+ * {@link classifyClosureReason}. Wired reasons: `model_end_turn`, `truncated`,
+ * `abort`, `timeout`, `budget_exceeded`, `hook_blocked`, `max_turns_exceeded`.
+ */
+export function deriveClosureReason(s: ClosureSignals): ClosureReason {
+  let abort: 'budget_exceeded' | 'timeout' | 'abort' | null = null;
+  const signal = s.signal;
+  if (signal.aborted && signal.reason !== 'closed') {
+    const r = signal.reason;
+    if (r instanceof BudgetExceededError) abort = 'budget_exceeded';
+    else if (r instanceof TimeoutError) abort = 'timeout';
+    // Some abort paths pass the error's message string rather than the error
+    // instance — match the well-known prefixes as a fallback so the
+    // classification stays accurate when the abort reason was stringified.
+    else if (typeof r === 'string' && r.startsWith('Budget ')) abort = 'budget_exceeded';
+    else if (typeof r === 'string' && r.includes('timed out')) abort = 'timeout';
+    else abort = 'abort';
+  }
+  return classifyClosureReason({
+    dispatchReason: s.dispatchReason,
+    maxTurnsHit: s.maxTurnsHit,
+    hookBlocked: s.hookBlocked,
+    abort,
+    lastStopReason: s.lastStopReason,
+    sawProviderError: s.sawProviderError,
+  });
+}
+
+/**
+ * Map a session-end reason to the `session_sealed` status.
+ *  - reason `'error'` → `'failed'`
+ *  - any reason with an aborted signal (reason !== `'closed'`) → `'cancelled'`
+ *    (abort beats the reason string, matching the abort-precedence invariant)
+ *  - a final-turn provider error → `'failed'` (checked after abort so a genuine
+ *    cancel/budget/timeout keeps its more-specific `cancelled` status)
+ *  - otherwise → `'succeeded'`
+ * `close()` aborts its own controller with reason `'closed'` as normal
+ * teardown — that is NOT a cancellation.
+ */
+export function deriveSealStatus(s: ClosureSignals): 'succeeded' | 'failed' | 'cancelled' {
+  if (s.dispatchReason === 'error') return 'failed';
+  const signal = s.signal;
+  if (signal.aborted && signal.reason !== 'closed') return 'cancelled';
+  if (s.sawProviderError) return 'failed';
+  return 'succeeded';
+}
+
+/** Session-run counters read into the terminal `closure` / `session_sealed` payloads. */
+export interface ClosureTotals {
+  finalTurnCount: number;
+  finalCostUsd: number;
+}
+
+/** Inputs for {@link emitClosureEvent}: terminal signals + session-run totals. */
+export interface EmitClosureInput extends ClosureSignals, ClosureTotals {
+  runningTokens: ClosureTokenCounters;
+}
+
+/**
+ * Emit the `closure` trace event with the session's terminal classification.
+ * No-op when the writer is absent. Attaches a recovery `guidance` hint for
+ * anomalous reasons (benign reasons omit the field).
+ */
+export async function emitClosureEvent(
+  writer: TraceWriter | undefined,
+  input: EmitClosureInput,
+): Promise<void> {
+  if (!writer) return;
+  const reasonValue = deriveClosureReason(input);
+  const finalTokens: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheCreation?: number;
+  } = {};
+  const t = input.runningTokens;
+  if (t.input > 0) finalTokens.input = t.input;
+  if (t.output > 0) finalTokens.output = t.output;
+  if (t.cacheRead > 0) finalTokens.cacheRead = t.cacheRead;
+  if (t.cacheCreation > 0) finalTokens.cacheCreation = t.cacheCreation;
+
+  const guidance = buildClosureGuidance(reasonValue);
+
+  await emitClosure(writer, {
+    reason: reasonValue,
+    finalTurnCount: input.finalTurnCount,
+    finalCostUsd: input.finalCostUsd,
+    finalTokens,
+    ...(input.lastStopReason !== undefined ? { lastStopReason: input.lastStopReason } : {}),
+    ...(guidance !== null ? { guidance } : {}),
+  });
+}
+
+/** Inputs for {@link sealTraceWriter}: terminal signals + totals + subagent rollup. */
+export interface SealTraceInput extends ClosureSignals, ClosureTotals {
+  subagentCompletedCount: number;
+  subagentRunningTokens: ClosureTokenCounters;
+  subagentRunningCostUsd: number;
+}
+
+/**
+ * Seal the trace writer with the terminal `session_sealed` record. No-op when
+ * the writer is absent. The optional subagent-rollup fields are present only
+ * when at least one subagent completed and reported the corresponding data.
+ */
+export async function sealTraceWriter(
+  writer: TraceWriter | undefined,
+  input: SealTraceInput,
+): Promise<void> {
+  if (!writer) return;
+  const status = deriveSealStatus(input);
+
+  const subagentCount =
+    input.subagentCompletedCount > 0 ? input.subagentCompletedCount : undefined;
+
+  const tok = input.subagentRunningTokens;
+  const hasSubagentTokens =
+    tok.input > 0 || tok.output > 0 || tok.cacheRead > 0 || tok.cacheCreation > 0;
+  const subagentTokens = hasSubagentTokens
+    ? {
+        ...(tok.input > 0 ? { input: tok.input } : {}),
+        ...(tok.output > 0 ? { output: tok.output } : {}),
+        ...(tok.cacheRead > 0 ? { cacheRead: tok.cacheRead } : {}),
+        ...(tok.cacheCreation > 0 ? { cacheCreation: tok.cacheCreation } : {}),
+      }
+    : undefined;
+
+  const subagentCostUsd =
+    input.subagentRunningCostUsd > 0 ? input.subagentRunningCostUsd : undefined;
+
+  await writer.seal({
+    status,
+    finalCostUsd: input.finalCostUsd,
+    finalTurnCount: input.finalTurnCount,
+    closedAt: new Date().toISOString(),
+    ...(subagentCount !== undefined ? { subagentCount } : {}),
+    ...(subagentTokens !== undefined ? { subagentTokens } : {}),
+    ...(subagentCostUsd !== undefined ? { subagentCostUsd } : {}),
+  });
+}

--- a/src/agent/session/ledger-lifecycle.ts
+++ b/src/agent/session/ledger-lifecycle.ts
@@ -1,0 +1,108 @@
+/**
+ * Durable per-session event ledger glue, extracted from {@link AgentSession}.
+ *
+ * Owns the lazy lifecycle around a {@link SessionLedgerWriter}: create-on-first-
+ * use (once the provider has issued a session id), pass-through record calls,
+ * and an idempotent terminal seal. The session delegates to a single instance
+ * held for its whole lifetime — {@link LedgerLifecycle.seal} resets the internal
+ * writer + attempt latch so the same instance is reused cleanly across a
+ * `reset()` (`/clear`) cycle, matching the original in-class behavior.
+ *
+ * @module agent/session/ledger-lifecycle
+ */
+
+import { env } from '../../config/env.js';
+import { sessionLabelFromTracePath } from '../../paths.js';
+import { SessionLedgerWriter } from '../session-ledger.js';
+import type { OutputEvent } from '../types.js';
+import type { ElicitationRequest } from '../types/sdk-types.js';
+
+/**
+ * Inputs for {@link LedgerLifecycle.ensure}. `getMetadata` is a lazy accessor so
+ * session metadata is read only when a writer is actually created — never on the
+ * per-turn no-op path once the attempt latch is set.
+ */
+export interface LedgerEnsureContext {
+  /** Subagent-fork markers — either being set gates the ledger off. */
+  depth: number | undefined;
+  parentSessionId: string | undefined;
+  /** Provider-issued session id; absent until `session.init` drained. */
+  sessionId: string | undefined;
+  /** Fallback model id (`String(config.model)`) when metadata carries none. */
+  fallbackModel: string;
+  /** The witness trace path, if tracing is wired (for the id→label bridge). */
+  tracePath: string | undefined;
+  /** Lazy metadata read — invoked only when the writer is created. */
+  getMetadata: () => { model?: string; cwd?: string };
+}
+
+export class LedgerLifecycle {
+  private writer: SessionLedgerWriter | null = null;
+  /** Set true once ledger creation has been attempted (success or not). */
+  private initAttempted = false;
+
+  /**
+   * Create the ledger writer on first use.
+   *
+   * Gates (all must pass): top-level session (`depth`/`parentSessionId` unset);
+   * `AFK_SESSION_LEDGER_DISABLED` is not `'1'`; the provider has issued a
+   * session id. One attempt per lifecycle: if the id is unavailable or unsafe
+   * the first time, the session runs unledgered — never throws, never retries
+   * per-event (the `initAttempted` latch keeps the hot path cheap).
+   */
+  ensure(ctx: LedgerEnsureContext): void {
+    if (this.initAttempted) return;
+    this.initAttempted = true;
+    if (ctx.depth !== undefined || ctx.parentSessionId !== undefined) return;
+    if (env.AFK_SESSION_LEDGER_DISABLED === '1') return;
+    const id = ctx.sessionId;
+    if (!id) return;
+    const writer = new SessionLedgerWriter(id);
+    if (!writer.active) return;
+    this.writer = writer;
+    const meta = ctx.getMetadata();
+    writer.record({
+      kind: 'meta',
+      sessionId: id,
+      model: meta.model ?? ctx.fallbackModel,
+      ...(meta.cwd !== undefined ? { cwd: meta.cwd } : {}),
+      // Correlate this id-keyed ledger to its witness trace: fresh sessions
+      // label the trace dir with a random UUID (not the session id), so the
+      // ledger is the durable id→label bridge. `null` when tracing is
+      // disabled/unwired, so absence is explicit rather than silent.
+      traceLabel: sessionLabelFromTracePath(ctx.tracePath),
+    });
+  }
+
+  /** Record the outbound user message summary. No-op when unledgered. */
+  recordUser(text: string): void {
+    this.writer?.recordUser(text);
+  }
+
+  /** Record a transformed provider output event. No-op when unledgered. */
+  recordEvent(event: OutputEvent): void {
+    this.writer?.recordEvent(event);
+  }
+
+  /**
+   * Append an AFK remote-control `elicitation` record. No-op when the session
+   * is unledgered (subagent, ledger disabled, or no provider session id yet).
+   */
+  recordElicitation(reqId: string, request: ElicitationRequest): void {
+    this.writer?.record({ kind: 'elicitation', reqId, request });
+  }
+
+  /**
+   * Seal the ledger with a terminal record and flush. Idempotent. Resets the
+   * internal writer + attempt latch so the instance is reusable after a
+   * `reset()` cycle. Callers on the close/reset paths await the returned
+   * promise; the abort path fire-and-forgets it.
+   */
+  seal(reason: string): Promise<void> {
+    const writer = this.writer;
+    if (!writer) return Promise.resolve();
+    this.writer = null;
+    this.initAttempted = false;
+    return writer.close(reason);
+  }
+}

--- a/src/agent/session/plan-exit-bridge.ts
+++ b/src/agent/session/plan-exit-bridge.ts
@@ -1,0 +1,134 @@
+/**
+ * Plan-mode-exit state machine, extracted from {@link AgentSession}.
+ *
+ * Owns the small cluster of state that survives from a mid-turn model-callable
+ * `exit_plan_mode` tool call to the post-turn REPL boundary: the pending
+ * implement-turn seed, the captured pre-plan permission mode to restore, and
+ * the transient Shift+Tab ring-gesture memory. Pure bookkeeping — all provider
+ * / metadata I/O stays on the session, which calls
+ * {@link PlanExitBridge.recordModeTransition} for the plan capture and drains
+ * the seed via {@link PlanExitBridge.takeSeed}.
+ *
+ * Lives on the session (not the per-turn dispatcher) so it survives from the
+ * mid-turn tool call to the post-turn REPL boundary.
+ *
+ * @module agent/session/plan-exit-bridge
+ */
+
+import type { PermissionMode } from '../types.js';
+
+export class PlanExitBridge {
+  /**
+   * Pending plan-exit implement-turn queued by an approved `exit_plan_mode`
+   * tool call. The REPL drains it with {@link takeSeed} after the current turn,
+   * which atomically applies the deferred permission-mode flip and returns the
+   * seed message. Stores both the message and the approved mode so the flip can
+   * be deferred to the post-turn boundary — closing the mid-turn TOCTOU window.
+   */
+  private pendingSeed: { message: string; mode: PermissionMode } | undefined;
+
+  /**
+   * The permission mode the session was in immediately BEFORE entering plan
+   * mode. Captured by {@link recordModeTransition} on the transition INTO
+   * 'plan' (covering every entry path — `/plan`, free-text `/plan`, Shift+Tab)
+   * and read by an approved plan-exit ({@link getPrePlanMode}) so the
+   * implement-turn restores it instead of forcing 'default'. `undefined` until
+   * the first plan-entry, and reset to `undefined` when the prior mode was
+   * 'autonomous' (AFK is not restorable by a bare flip) so restore falls back
+   * to 'default'.
+   */
+  private prePlanMode: PermissionMode | undefined;
+
+  /**
+   * Ring-gesture memory for the Shift+Tab permission cycle
+   * (`default → plan → bypassPermissions`, see `cli/permission-mode-cycle.ts`).
+   * `plan`'s only ring-predecessor is `default`, so cycling from a privileged
+   * working mode (e.g. bypass) INTO plan necessarily passes through a TRANSIENT
+   * `default` hop: bypass → default → plan. Without this,
+   * {@link recordModeTransition} would capture that transient `default` as the
+   * pre-plan mode and an approved exit would drop the user to `default` instead
+   * of restoring their real working mode. So on a `<privileged> → default`
+   * transition we stash the mode left behind here; the very next
+   * `default → plan` transition restores it as the pre-plan mode. Cleared at
+   * every turn boundary (see {@link clearModeBeforeDefault}) so it survives ONLY
+   * an uninterrupted Shift+Tab gesture — a genuine rest in `default` (which
+   * submits a turn) clears it, keeping the restore safe: it never escalates back
+   * to bypass after the user actually worked in `default`.
+   */
+  private modeBeforeDefault: PermissionMode | undefined;
+
+  /**
+   * Record the plan bookkeeping for a permission-mode transition. Pure state
+   * update — the caller applies the actual provider/metadata flip. `current` is
+   * the live mode read BEFORE the flip.
+   *
+   * Captures the mode being LEFT on the transition INTO plan, so an approved
+   * exit can restore it. Guards on the non-plan → plan edge only: a redundant
+   * plan → plan flip must not overwrite the real pre-plan mode with 'plan'.
+   * 'autonomous' (AFK) is reset to undefined — it carries dedicated enter/exit
+   * machinery and is not safe to re-enter by a bare flip — so restore falls
+   * back to 'default'.
+   */
+  recordModeTransition(mode: PermissionMode, current: PermissionMode | undefined): void {
+    if (mode === 'plan') {
+      if (current !== 'plan') {
+        // Ring-gesture rescue: the Shift+Tab cycle reaches plan only via a
+        // TRANSIENT `default` hop off a privileged mode (bypass → default → plan).
+        // When we're entering plan FROM that transient default, restore the mode
+        // stashed on the hop instead of the default itself. `modeBeforeDefault`
+        // is turn-scoped, so this only fires for an uninterrupted gesture.
+        const effectivePrev =
+          current === 'default' && this.modeBeforeDefault !== undefined
+            ? this.modeBeforeDefault
+            : current;
+        this.prePlanMode = effectivePrev === 'autonomous' ? undefined : effectivePrev;
+      }
+    } else if (mode === 'default') {
+      // Stash the privileged mode being left so the NEXT `default → plan` press
+      // in the same Shift+Tab gesture can see past this transient default. Only
+      // privileged non-plan modes are worth restoring; default/plan are not.
+      this.modeBeforeDefault =
+        current !== 'default' && current !== 'plan' ? current : undefined;
+    } else {
+      // Landing on a concrete working mode (bypass / acceptEdits / …) ends any
+      // in-flight ring gesture toward plan — drop the transient-default memory.
+      this.modeBeforeDefault = undefined;
+    }
+  }
+
+  /**
+   * End any in-flight Shift+Tab ring gesture. Called at every turn boundary:
+   * submitting a turn means the user actually RESTED in the current mode, so a
+   * transient-default stash must not survive into a later `default → plan`
+   * (which would wrongly restore bypass after real work in default).
+   */
+  clearModeBeforeDefault(): void {
+    this.modeBeforeDefault = undefined;
+  }
+
+  /**
+   * The permission mode the session was in immediately before entering plan
+   * mode, or `undefined` if none was captured (never entered plan, or the prior
+   * mode was 'autonomous'). An approved plan-exit restores this; callers fall
+   * back to 'default' on `undefined`.
+   */
+  getPrePlanMode(): PermissionMode | undefined {
+    return this.prePlanMode;
+  }
+
+  /** Queue the deferred implement-turn from an approved `exit_plan_mode` call. */
+  requestImplementSeed(message: string, mode: PermissionMode): void {
+    this.pendingSeed = { message, mode };
+  }
+
+  /**
+   * Return and CLEAR the pending plan-exit seed, or `undefined` if none is
+   * pending. Single-shot: a second call returns `undefined` until the next
+   * approval. The caller applies the deferred permission-mode flip.
+   */
+  takeSeed(): { message: string; mode: PermissionMode } | undefined {
+    const seed = this.pendingSeed;
+    this.pendingSeed = undefined;
+    return seed;
+  }
+}


### PR DESCRIPTION
Closes #364. Part of the large-file split initiative (#360).

## What

`src/agent/session/agent-session.ts` is a god-class: beyond its turn-loop coordination job it also owned closure/seal classification, the durable-ledger lifecycle, and a plan-mode-exit state machine. This extracts each into a focused sibling module — a continuation of the existing `agent-session.ts` decomposition (`closure-reason.ts`, `session-setup.ts`, `session-state.ts`, `stream-consumer.ts`), not a new pattern.

**Pure internal refactor: no public API change, no behavior change.**

| New module | What moved | Shape |
|---|---|---|
| `closure-emitter.ts` | `deriveClosureReason`, `deriveSealStatus`, `emitClosureEvent`, `sealTraceWriter` | deps-taking free functions (mirrors `transformProviderEvent(deps)`) |
| `ledger-lifecycle.ts` | `ensure`/`seal`/`recordUser`/`recordEvent`/`recordElicitation` + `writer`/`initAttempted` state | `LedgerLifecycle` class |
| `plan-exit-bridge.ts` | pending implement-seed, pre-plan mode restore, Shift+Tab ring-gesture memory + transition logic | `PlanExitBridge` class |

`agent-session.ts`: **1450 → 1253 lines** (−197). New modules: closure-emitter 193, ledger-lifecycle 108, plan-exit-bridge 134.

## Design note (the issue's stated risk)

The issue flagged that the session-run counters (`sessionRunningTokens`, `sessionRunningCostUsd`, the terminal-cause flags) cross the closure boundary. They are mutated across ~6 sites (construction/reset, the `buildTransformDeps` callback, the per-turn stream loop), so **lifting them into a separate owner would widen the shared-mutable-state surface, not shrink it.** Instead the counters stay owned by `AgentSession`, which passes a read snapshot (`closureSignals(reason)`) at seal time — the exact pattern `stream-consumer.ts` already uses. The self-contained subagent accumulators (written in one method, read in one) travel the same way. Exported names `deriveClosureReason`/`deriveSealStatus`/`sealTraceWriter` are preserved so cross-file doc references stay valid.

## Verification

- `tsc --noEmit` clean; `audit:sdk:check` (no new SDK imports), `audit:env:check` (0 violations), `scan:env:check` (in sync) all green.
- **Full suite + coverage:** 619 files, **11223 passed | 14 skipped, 0 failed**; coverage 86.25 / 84.21 / 91.13 / 86.25 vs thresholds 74 / 79 / 82 / 74. Zero test files changed, so the identical test set passing = behavioral parity.
- **Independent read-only move-fidelity auditor: `CLEAN`** — all three extractions verified byte-identical moves (abort pre-classification, seal-status precedence, ensure-gate ordering, ring-gesture rescue, close-vs-reset seal ordering all preserved). The one semantic shift — `this.ledger?.` → `this.ledger.` at call sites — is provably safe: `ledger` is now always a `LedgerLifecycle` instance, with null-safety re-homed to `this.writer?.` inside the class.

## Suspected findings (report-only)

Per the split protocol (report-never-fix), noted but not addressed here — both **pre-existing** and faithfully carried across:

- `closedAt` uses `new Date().toISOString()` at seal time, not true session-end time (cosmetic).
- Ledger `record*` calls are silently dropped when unledgered (intended per docstring).
