### PR TITLE
feat(tui): distinguish parallel vs sequential tool dispatch with ∥i/N batch badge

### DIFF
--- a/src/agent/provider.ts
+++ b/src/agent/provider.ts
@@ -157,6 +157,16 @@ export type ProviderEvent =
        * preview path.
        */
       toolName?: string;
+      /**
+       * Concurrency-batch membership, plumbed from `ToolResult.batchIndex` /
+       * `.batchSize` (set by the dispatcher's `executeBatch`). `batchSize > 1`
+       * means this call ran in a parallel wave; `=== 1` (or absent) means it
+       * ran alone. The interactive tool-lane reads these to badge a parallel
+       * wave distinctly from back-to-back sequential dispatch. Optional: absent
+       * on the single-tool `execute()` path and on providers that don't batch.
+       */
+      batchIndex?: number;
+      batchSize?: number;
     }
   | {
       /**

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -655,6 +655,9 @@ export async function* runTurn(
         durationMs,
         ...(result.circuitBreaker === true ? { circuitBreaker: true } : {}),
         ...(result.failureClass ? { failureClass: result.failureClass } : {}),
+        ...(typeof result.batchIndex === 'number' && typeof result.batchSize === 'number'
+          ? { batchIndex: result.batchIndex, batchSize: result.batchSize }
+          : {}),
       });
 
       yield {

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -667,6 +667,9 @@ export async function* runTurn(
         content: result.content,
         ...(result.isError === true ? { isError: true } : {}),
         ...(truncated ? { truncated: true } : {}),
+        ...(typeof result.batchIndex === 'number' && typeof result.batchSize === 'number'
+          ? { batchIndex: result.batchIndex, batchSize: result.batchSize }
+          : {}),
         sessionId: input.ctx.sessionId,
       };
 

--- a/src/agent/providers/anthropic-direct/types.ts
+++ b/src/agent/providers/anthropic-direct/types.ts
@@ -105,6 +105,26 @@ export interface ToolResult {
    * See {@link import('../../trace/types.js').ToolFailureClass}.
    */
   failureClass?: ToolFailureClass;
+  /**
+   * 1-based position and total size of the concurrency batch this call was
+   * dispatched in, stamped by {@link SessionToolDispatcher.executeBatch}.
+   * `batchSize > 1` means the call ran in a parallel wave alongside
+   * `batchSize - 1` sibling calls; `batchSize === 1` (or absent) means it ran
+   * alone in its own sequential batch — which is the case for EVERY
+   * concurrency-unsafe tool (bash, write_file, edit_file, …), since the
+   * partitioner isolates each into a singleton batch.
+   *
+   * Render-only + trace metadata, never forwarded to the model. Lets the TUI
+   * and `afk trace show` distinguish a genuine parallel wave from back-to-back
+   * sequential dispatches, which are otherwise visually identical once
+   * committed to scrollback. Note `batchSize` is the number of calls
+   * DISPATCHED together, not the number that ran at literally the same instant:
+   * a safe batch wider than `maxConcurrentSafeCalls` drains through the pool in
+   * sub-waves, but is one logical batch here. Absent when the dispatcher ran
+   * the non-batching `execute()` path (single-tool fallback).
+   */
+  batchIndex?: number;
+  batchSize?: number;
   render?: RenderHints;
   /**
    * Structured test-runner result parsed from bash output by

--- a/src/agent/providers/openai-compatible/query/dispatch-append.ts
+++ b/src/agent/providers/openai-compatible/query/dispatch-append.ts
@@ -176,6 +176,9 @@ export async function* dispatchAndAppendToolCalls({
         durationMs,
         ...(result.circuitBreaker === true ? { circuitBreaker: true } : {}),
         ...(result.failureClass ? { failureClass: result.failureClass } : {}),
+        ...(typeof result.batchIndex === 'number' && typeof result.batchSize === 'number'
+          ? { batchIndex: result.batchIndex, batchSize: result.batchSize }
+          : {}),
       });
 
       yield {

--- a/src/agent/providers/openai-compatible/query/dispatch-append.ts
+++ b/src/agent/providers/openai-compatible/query/dispatch-append.ts
@@ -188,6 +188,13 @@ export async function* dispatchAndAppendToolCalls({
         content: result.content,
         ...(result.isError === true ? { isError: true } : {}),
         ...(result.truncated === true ? { truncated: true } : {}),
+        // Plumb concurrency-batch membership onto the render-facing event, not
+        // just the trace event above, so the TUI `∥i/N` badge works here too.
+        // Parity with anthropic-direct/loop.ts's tool.output yield — omitting it
+        // silently drops the badge for every openai-compatible session.
+        ...(typeof result.batchIndex === 'number' && typeof result.batchSize === 'number'
+          ? { batchIndex: result.batchIndex, batchSize: result.batchSize }
+          : {}),
         sessionId,
       };
       if (result.render?.diff) {

--- a/src/agent/providers/openai-compatible/tool-dispatch.test.ts
+++ b/src/agent/providers/openai-compatible/tool-dispatch.test.ts
@@ -22,7 +22,7 @@ import type { AgentConfig } from '../../types/config-types.js';
 import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { createHookRegistry } from '../../hooks.js';
 import type { AnthropicToolDef } from '../anthropic-direct/types.js';
-import type { ToolHandler } from '../../tools/types.js';
+import type { ToolHandler, ConcurrencyClassifier } from '../../tools/types.js';
 import {
   __setOpenAIClientFactory,
   OpenAICompatibleQuery,
@@ -90,7 +90,10 @@ interface DispatcherFixture {
   postHookFired: string[];
 }
 
-function makeDispatcher(opts?: { allowedTools?: string[] }): DispatcherFixture {
+function makeDispatcher(opts?: {
+  allowedTools?: string[];
+  concurrencyClassifier?: ConcurrencyClassifier;
+}): DispatcherFixture {
   const handlerCalls: DispatcherFixture['handlerCalls'] = [];
   const preHookFired: string[] = [];
   const postHookFired: string[] = [];
@@ -137,6 +140,9 @@ function makeDispatcher(opts?: { allowedTools?: string[] }): DispatcherFixture {
   };
   if (opts?.allowedTools !== undefined) {
     dispatcherOpts.permissions = { allowedTools: opts.allowedTools };
+  }
+  if (opts?.concurrencyClassifier !== undefined) {
+    dispatcherOpts.concurrencyClassifier = opts.concurrencyClassifier;
   }
 
   const dispatcher = new SessionToolDispatcher(dispatcherOpts);
@@ -601,6 +607,61 @@ describe('OpenAICompatibleQuery — tool dispatch (slice 3)', () => {
     const toolMsgs = turn2Messages.filter((m) => m.role === 'tool');
     expect(toolMsgs).toHaveLength(2);
     expect(toolMsgs.map((m) => m.tool_call_id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('stamps batchIndex/batchSize onto tool.output for a parallel safe wave (badge parity with anthropic-direct)', async () => {
+    // Regression guard for the render-path plumbing: the dispatcher stamps
+    // batch membership on each ToolResult, but the TUI `∥i/N` badge only
+    // renders if the provider forwards those fields onto the `tool.output`
+    // event. A `() => true` classifier makes both echo calls concurrency-safe
+    // so they partition into ONE batch of size 2 (batchSize > 1 = a real
+    // parallel wave). Without the forwarding, batchIndex/batchSize are absent
+    // and the badge silently vanishes for every openai-compatible session.
+    const fixture = makeDispatcher({ concurrencyClassifier: () => true });
+    scriptedTurns = [
+      {
+        chunks: [
+          {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    { index: 0, id: 'a', type: 'function', function: { name: 'echo', arguments: '{"msg":"first"}' } },
+                    { index: 1, id: 'b', type: 'function', function: { name: 'echo', arguments: '{"msg":"second"}' } },
+                  ],
+                },
+              },
+            ],
+          },
+          { choices: [{ delta: {}, finish_reason: 'tool_calls' }], usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 } },
+        ],
+      },
+      {
+        chunks: [
+          { choices: [{ delta: { content: 'done' }, finish_reason: 'stop' }], usage: { prompt_tokens: 30, completion_tokens: 1, total_tokens: 31 } },
+        ],
+      },
+    ];
+
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'sk', source: 'config' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'sid',
+      promptStream: singleInput('echo two things'),
+      config: baseConfig(),
+      toolDispatcher: fixture.dispatcher,
+    });
+    const events = await collect(q);
+
+    const toolOutputs = events.filter((e) => e.type === 'tool.output');
+    expect(toolOutputs).toHaveLength(2);
+    // Emission order mirrors call order (i=0 → 'a', i=1 → 'b'), so batchIndex is
+    // a stable 1-based ordinal within the size-2 wave.
+    for (const [pos, ev] of toolOutputs.entries()) {
+      if (ev.type !== 'tool.output') throw new Error('unreachable');
+      expect(ev.batchSize).toBe(2);
+      expect(ev.batchIndex).toBe(pos + 1);
+    }
   });
 
   it('sums usage across iterations into a single turn.completed event', async () => {

--- a/src/agent/session/stream-consumer.ts
+++ b/src/agent/session/stream-consumer.ts
@@ -193,6 +193,16 @@ function buildToolOutputEvent(
       : renderToolResult(event.toolName, event.content);
   const displayPassthrough = display !== null ? { display } : {};
 
+  // Plumb concurrency-batch membership through to the ToolResultChunk so the
+  // tool-lane render can badge a parallel wave (batchSize>1) distinctly from
+  // sequential dispatch. Both are present or both absent (stamped together by
+  // executeBatch); the `typeof` guard keeps the type honest for providers that
+  // don't batch.
+  const batchPassthrough =
+    typeof event.batchIndex === 'number' && typeof event.batchSize === 'number'
+      ? { batchIndex: event.batchIndex, batchSize: event.batchSize }
+      : {};
+
   const parsed = parsePersistedOutput(event.content);
   if (parsed) {
     return {
@@ -206,6 +216,7 @@ function buildToolOutputEvent(
         sizeBytes: parsed.sizeBytes,
         sizeLabel: parsed.sizeLabel,
         ...displayPassthrough,
+        ...batchPassthrough,
       },
     };
   }
@@ -234,6 +245,7 @@ function buildToolOutputEvent(
       ...(event.truncated === true && { truncated: true }),
       ...(lineCount !== undefined && { lineCount }),
       ...displayPassthrough,
+      ...batchPassthrough,
     },
   };
 }

--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -609,6 +609,58 @@ describe('SessionToolDispatcher', () => {
       expect(order.indexOf('grep')).toBeGreaterThan(order.indexOf('bash'));
     });
 
+    it('stamps batchIndex/batchSize reflecting the partition', async () => {
+      const track = (name: string): ToolHandler => async () => ({ content: name });
+      const dispatcher = makeDispatcher({
+        handlers: new Map([
+          ['read_file', track('read')],
+          ['glob', track('glob')],
+          ['bash', track('bash')],
+          ['grep', track('grep')],
+        ]),
+        permissions: { allowedTools: ['read_file', 'glob', 'bash', 'grep'] },
+      });
+
+      // [safe, safe, unsafe, safe] → batches {read,glob}, {bash}, {grep}.
+      const results = await dispatcher.executeBatch([
+        makeBatchCall('read_file'),
+        makeBatchCall('glob'),
+        makeBatchCall('bash'),
+        makeBatchCall('grep'),
+      ]);
+
+      // Parallel wave of 2: 1-based index within a size-2 batch.
+      expect(results[0]).toMatchObject({ batchIndex: 1, batchSize: 2 });
+      expect(results[1]).toMatchObject({ batchIndex: 2, batchSize: 2 });
+      // bash is concurrency-unsafe → its own singleton batch (never badged).
+      expect(results[2]).toMatchObject({ batchIndex: 1, batchSize: 1 });
+      // The trailing safe call is severed from the first wave by bash, so it
+      // is a singleton too — proving batchSize tracks the partition, not the
+      // tool's mere safety class.
+      expect(results[3]).toMatchObject({ batchIndex: 1, batchSize: 1 });
+    });
+
+    it('stamps a whole safe fan-out as one batch', async () => {
+      const track = (name: string): ToolHandler => async () => ({ content: name });
+      const dispatcher = makeDispatcher({
+        handlers: new Map([
+          ['read_file', track('read')],
+          ['glob', track('glob')],
+          ['grep', track('grep')],
+        ]),
+        permissions: { allowedTools: ['read_file', 'glob', 'grep'] },
+      });
+
+      const results = await dispatcher.executeBatch([
+        makeBatchCall('read_file'),
+        makeBatchCall('glob'),
+        makeBatchCall('grep'),
+      ]);
+
+      expect(results.map((r) => r.batchSize)).toEqual([3, 3, 3]);
+      expect(results.map((r) => r.batchIndex)).toEqual([1, 2, 3]);
+    });
+
     it('collects all results when one tool fails in a safe batch', async () => {
       const ok: ToolHandler = async () => ({ content: 'ok' });
       const fail: ToolHandler = async () => { throw new Error('boom'); };

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -798,6 +798,26 @@ export class SessionToolDispatcher implements ToolDispatcher {
           results[originalIndex] = await this.executeCore(call);
         }
       }
+
+      // Stamp batch membership onto each result so downstream consumers
+      // (TUI tool-lane render + `tool_call` completed trace event) can tell a
+      // genuine parallel wave apart from back-to-back sequential dispatches —
+      // which are otherwise indistinguishable once a fast root commits to
+      // scrollback ahead of a slow one. 1-based `batchIndex` = ordinal within
+      // the batch; `batchSize` = number of calls dispatched together. A
+      // concurrency-unsafe tool (bash, write_file, …) is always its own
+      // singleton batch, so it lands batchSize=1 and is never badged. Blocked
+      // / short-circuited calls (permission, read-only-bash gate, circuit
+      // breaker) are excluded from `executableCalls`, so they correctly carry
+      // no batch info at all.
+      const batchSize = batch.indices.length;
+      batch.indices.forEach((batchIdx, pos) => {
+        const r = results[executableCalls[batchIdx]!.originalIndex];
+        if (r) {
+          r.batchIndex = pos + 1;
+          r.batchSize = batchSize;
+        }
+      });
     }
 
     return results;

--- a/src/agent/trace/events.test.ts
+++ b/src/agent/trace/events.test.ts
@@ -81,6 +81,38 @@ describe('tool_call payload', () => {
     ).toThrow();
   });
 
+  it('accepts and preserves batchIndex/batchSize on the completed phase', () => {
+    const parsed = ToolCallPayloadSchema.parse({
+      phase: 'completed',
+      toolUseId: 't1',
+      name: 'read_file',
+      resultBytes: 64,
+      isError: false,
+      truncated: false,
+      durationMs: 5,
+      batchIndex: 2,
+      batchSize: 3,
+    });
+    expect(parsed).toMatchObject({ batchIndex: 2, batchSize: 3 });
+  });
+
+  it('rejects a non-positive or non-integer batchIndex/batchSize', () => {
+    for (const bad of [{ batchIndex: 0, batchSize: 2 }, { batchIndex: 1, batchSize: 1.5 }, { batchIndex: -1, batchSize: 2 }]) {
+      expect(() =>
+        ToolCallPayloadSchema.parse({
+          phase: 'completed',
+          toolUseId: 't1',
+          name: 'grep',
+          resultBytes: 0,
+          isError: false,
+          truncated: false,
+          durationMs: 1,
+          ...bad,
+        }),
+      ).toThrow();
+    }
+  });
+
   it('rejects unknown phase', () => {
     expect(() =>
       ToolCallPayloadSchema.parse({

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -48,6 +48,11 @@ export const ToolCallCompletedPayloadSchema = z.object({
   circuitBreaker: z.boolean().optional(),
   /** Coarse failure classification when `isError` is true. Absent otherwise. */
   failureClass: ToolFailureClassSchema.optional(),
+  /** Concurrency-batch membership (1-based index + total size). `batchSize > 1`
+   *  ⇒ ran in a parallel wave; `=== 1` ⇒ ran alone. Absent on the single-tool
+   *  `execute()` path and on blocked/short-circuited calls. */
+  batchIndex: z.number().int().positive().optional(),
+  batchSize: z.number().int().positive().optional(),
   subagentId: z.string().optional(),
 });
 

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -104,6 +104,18 @@ export interface ToolCallCompletedPayload {
   /** Coarse failure classification when `isError` is true. Absent on success
    *  and on unclassified failures. See {@link ToolFailureClass}. */
   failureClass?: ToolFailureClass;
+  /**
+   * Concurrency-batch membership: 1-based position (`batchIndex`) and total
+   * size (`batchSize`) of the batch this call was dispatched in, set by the
+   * dispatcher's `executeBatch`. `batchSize > 1` means the call ran in a
+   * parallel wave; `batchSize === 1` means it ran alone in its own sequential
+   * batch (always the case for concurrency-unsafe tools like bash). Lets
+   * `afk trace show` and failure-analysis distinguish real parallelism from
+   * back-to-back sequential dispatch. Absent on the single-tool `execute()`
+   * path and on blocked/short-circuited calls.
+   */
+  batchIndex?: number;
+  batchSize?: number;
   subagentId?: string;
 }
 

--- a/src/agent/types/message-types.ts
+++ b/src/agent/types/message-types.ts
@@ -109,6 +109,19 @@ export interface ToolResultChunk {
    * `truncateContent` length cap because it's already short by construction.
    */
   display?: string;
+  /**
+   * Concurrency-batch membership, plumbed from the `tool.output` provider event
+   * (originally `ToolResult.batchIndex` / `.batchSize`, stamped by the
+   * dispatcher's `executeBatch`). `batchSize > 1` ⇒ this call ran in a parallel
+   * wave of `batchSize` calls dispatched together; `=== 1` (or absent) ⇒ it ran
+   * alone in its own sequential batch (always the case for concurrency-unsafe
+   * tools like bash). The tool-lane render badges the root row with `∥i/N`
+   * only when `batchSize > 1`, making a genuine parallel wave visually distinct
+   * from back-to-back sequential dispatches that otherwise look identical once
+   * committed to scrollback.
+   */
+  batchIndex?: number;
+  batchSize?: number;
   metadata?: Record<string, unknown>;
 }
 

--- a/src/cli/commands/interactive/tool-lane-format.test.ts
+++ b/src/cli/commands/interactive/tool-lane-format.test.ts
@@ -16,6 +16,7 @@ import {
   sanitizeLabel,
   sanitizeTextParagraph,
   shortenPaths,
+  batchBadge,
   MAX_OVERLAY_DIFF_LINES,
   FLUSH_DIFF_LINES_DEFAULT,
 } from './tool-lane-format.js';
@@ -41,6 +42,35 @@ function makeResult(opts: {
     ...(opts.display !== undefined ? { display: opts.display } : {}),
   };
 }
+
+describe('batchBadge — parallel-wave indicator', () => {
+  const chunk = (over: Partial<ToolResultChunk>): ToolResultChunk => ({
+    type: 'tool_result',
+    toolUseId: 'u',
+    content: 'ok',
+    isError: false,
+    ...over,
+  });
+
+  it('renders ∥i/N when the call ran in a parallel wave (batchSize > 1)', () => {
+    expect(stripAnsi(batchBadge(chunk({ batchIndex: 1, batchSize: 2 })))).toBe(' ∥1/2');
+    expect(stripAnsi(batchBadge(chunk({ batchIndex: 3, batchSize: 3 })))).toBe(' ∥3/3');
+  });
+
+  it('is empty for a singleton batch (batchSize === 1) — e.g. bash always runs alone', () => {
+    expect(batchBadge(chunk({ batchIndex: 1, batchSize: 1 }))).toBe('');
+  });
+
+  it('is empty when batch metadata is absent (single-tool path / non-batching provider)', () => {
+    expect(batchBadge(chunk({}))).toBe('');
+    expect(batchBadge(undefined)).toBe('');
+  });
+
+  it('is empty when only one of the index/size pair is present (defensive)', () => {
+    expect(batchBadge(chunk({ batchSize: 2 }))).toBe('');
+    expect(batchBadge(chunk({ batchIndex: 1 }))).toBe('');
+  });
+});
 
 describe('summarizeToolArgs — bash cd-prefix stripping', () => {
   it('strips a single leading `cd <dir> && ` and surfaces the real command', () => {

--- a/src/cli/commands/interactive/tool-lane-format.ts
+++ b/src/cli/commands/interactive/tool-lane-format.ts
@@ -124,6 +124,33 @@ export function formatOutcome(
 }
 
 /**
+ * Concurrency-batch badge for a root tool row: ` ∥i/N` (dim) when the call ran
+ * in a parallel wave of N>1 calls dispatched together, else `''`.
+ *
+ * Sourced from the dispatcher's authoritative post-partition batch (via
+ * `ToolResultChunk.batchIndex`/`.batchSize`), so it is collision-incapable: it
+ * can only appear on a call that genuinely shared a batch, never on a
+ * back-to-back sequential dispatch. Every concurrency-unsafe tool (bash,
+ * write_file, …) is its own singleton batch (batchSize=1) and is never badged.
+ * This is the one signal that tells a parallel wave apart from sequential
+ * dispatch once both have committed to append-only scrollback — where they are
+ * otherwise visually identical (a done ◉ row followed by an in-flight ◉ row).
+ * The `∥` (U+2225 PARALLEL TO) reads as "ran in parallel"; `i/N` is the 1-based
+ * position within the wave.
+ */
+export function batchBadge(chunk: ToolResultChunk | undefined): string {
+  if (
+    !chunk ||
+    typeof chunk.batchSize !== 'number' ||
+    typeof chunk.batchIndex !== 'number' ||
+    chunk.batchSize <= 1
+  ) {
+    return '';
+  }
+  return palette.dim(` ∥${chunk.batchIndex}/${chunk.batchSize}`);
+}
+
+/**
  * Format tool output as a two-line block (emitted together so both render
  * reliably). When `toolPrefix` is present the first line shows the tool
  * call; the second shows the outcome with a `⎿` connector.

--- a/src/cli/commands/interactive/tool-lane-render-agent.ts
+++ b/src/cli/commands/interactive/tool-lane-render-agent.ts
@@ -9,6 +9,7 @@ import {
   doneGlyph,
   sanitizeLabel,
   shortenPaths,
+  batchBadge,
 } from './tool-lane-format.js';
 import type { ToolEntry, Entry } from './tool-lane-render.js';
 import { getGlyphs, clampLineToTerminal } from './tool-lane-render.js';
@@ -210,7 +211,7 @@ function renderGroupedRootTools(
     if (entries.length === 1) {
       const e = entries[0]!;
       if (e.result) {
-        lines.push('  ' + e.prefix + palette.dim(' — ') + doneGlyph(e.result.isError) + ' ' + formatOutcome(e.result, homeDir, 60, e.toolName));
+        lines.push('  ' + e.prefix + palette.dim(' — ') + doneGlyph(e.result.isError) + ' ' + formatOutcome(e.result, homeDir, 60, e.toolName) + batchBadge(e.result));
         if (e.diff && !e.result.isError) {
           // Root-level scrollback diff: indent 4 spaces so it sits under
           // the outcome line (2 for the row indent, 2 more to clear the

--- a/src/cli/commands/interactive/tool-lane.test.ts
+++ b/src/cli/commands/interactive/tool-lane.test.ts
@@ -24,6 +24,49 @@ function makeResult(content: string, isError = false): ToolResultChunk {
   };
 }
 
+describe('ToolLane — batch (parallel-wave) badge on root rows', () => {
+  const batchResult = (content: string, batchIndex: number, batchSize: number): ToolResultChunk => ({
+    type: 'tool_result',
+    toolUseId: 'unused',
+    content,
+    isError: false,
+    batchIndex,
+    batchSize,
+  });
+
+  it('flush() badges each root of a parallel safe wave with ∥i/N', () => {
+    const lane = new ToolLane();
+    lane.addStart('r1', 'Read', '("a.ts")');
+    lane.addStart('g1', 'Grep', '("foo")');
+    lane.addResult('r1', batchResult('10 lines', 1, 2));
+    lane.addResult('g1', batchResult('3 matches', 2, 2));
+
+    const joined = stripAnsi(lane.flush().join('\n'));
+    expect(joined).toContain('∥1/2');
+    expect(joined).toContain('∥2/2');
+  });
+
+  it('does NOT badge a singleton batch (batchSize === 1) — the sequential-dispatch case', () => {
+    const lane = new ToolLane();
+    lane.addStart('b1', 'Bash', '("echo hi")');
+    lane.addResult('b1', batchResult('hi', 1, 1));
+
+    expect(stripAnsi(lane.flush().join('\n'))).not.toContain('∥');
+  });
+
+  it('badges the live overlay too, not just committed scrollback', () => {
+    const lane = new ToolLane();
+    lane.addStart('r1', 'Read', '("a.ts")');
+    lane.addStart('g1', 'Grep', '("foo")');
+    lane.addResult('r1', batchResult('10 lines', 1, 2));
+    lane.addResult('g1', batchResult('3 matches', 2, 2));
+
+    const overlay = stripAnsi(lane.getOverlay());
+    expect(overlay).toContain('∥1/2');
+    expect(overlay).toContain('∥2/2');
+  });
+});
+
 describe('ToolLane.addStartWithAgentContext', () => {
   it('creates an entry with the given agentContext (does not consult agentIdStack)', () => {
     const lane = new ToolLane();

--- a/src/cli/commands/interactive/tool-lane.ts
+++ b/src/cli/commands/interactive/tool-lane.ts
@@ -1,7 +1,7 @@
 import type { ToolResultChunk } from '../../../agent/types/message-types.js';
 import { palette } from '../../palette.js';
 import { SUBAGENT_TOOLS, NESTING_TOOLS, SKILL_TOOLS } from '../../tool-category.js';
-import { formatToolLine, formatToolResultLine, formatOutcome, formatDiffBlock, doneGlyph, sanitizeLabel } from './tool-lane-format.js';
+import { formatToolLine, formatToolResultLine, formatOutcome, formatDiffBlock, doneGlyph, sanitizeLabel, batchBadge } from './tool-lane-format.js';
 import type { DiffPayload } from '../../../utils/diff.js';
 import { getTerminalWidth } from '../../terminal-size.js';
 import { truncateDisplayWidth, stripAnsi } from '../../display.js';
@@ -496,7 +496,7 @@ export class ToolLane {
         // never carries a `diff` payload (diffs originate from edit/write
         // tool_diff chunks), so no diff block is rendered here.
         if (entry.result) {
-          lines.push(clamp(palette.dim(g.turnRoot) + entry.prefix + palette.dim(' — ') + doneGlyph(entry.result.isError) + ' ' + formatOutcome(entry.result, undefined, 60, entry.toolName)));
+          lines.push(clamp(palette.dim(g.turnRoot) + entry.prefix + palette.dim(' — ') + doneGlyph(entry.result.isError) + ' ' + formatOutcome(entry.result, undefined, 60, entry.toolName) + batchBadge(entry.result)));
         } else {
           lines.push(clamp(palette.dim(g.turnRoot) + entry.prefix + palette.dim(' …')));
         }
@@ -509,7 +509,7 @@ export class ToolLane {
         }
       } else {
         if (entry.result) {
-          lines.push(clamp(flatRootLead + entry.prefix + palette.dim(' — ') + doneGlyph(entry.result.isError) + ' ' + formatOutcome(entry.result, undefined, 60, entry.toolName)));
+          lines.push(clamp(flatRootLead + entry.prefix + palette.dim(' — ') + doneGlyph(entry.result.isError) + ' ' + formatOutcome(entry.result, undefined, 60, entry.toolName) + batchBadge(entry.result)));
           if (entry.diff && !entry.result.isError) {
             // Diff hangs under the outcome line, indented one level deeper
             // (4 spaces) so it visually attaches to this tool entry.


### PR DESCRIPTION
## Problem

Sequential and parallel tool dispatch are **visually indistinguishable** in the TUI. The tool-lane renders roots by emission-order topology + done/in-flight lifecycle, but never encodes *batch membership*. So a fast root that finishes and commits to append-only scrollback, followed by a slow root still spinning below it, looks identical whether the two ran **concurrently** (one safe batch) or **back-to-back** (two sequential batches). This repeatedly reads as "these ran in parallel" when they were actually sequential (e.g. an `agent` that finished, then a `bash` that started after it).

The distinguishing signal is temporal (two roots spinning at the same instant), which a static frame — or scrollback — cannot capture.

## Approach

Carry the dispatcher's **already-known** batch membership on each result and render it, rather than trying to infer concurrency from liveness (which over-reports: all start-events fire before partitioning, and `bash` always splits into its own batch).

**Data source** — `SessionToolDispatcher.executeBatch` stamps `batchIndex` (1-based) + `batchSize` (calls dispatched together) onto each `ToolResult`, sourced from the authoritative post-partition batch. `batchSize > 1` ⇒ ran in a parallel wave; `== 1` ⇒ ran alone (always the case for concurrency-unsafe tools like `bash`). Follows the existing `failureClass`/`circuitBreaker` metadata precedent exactly.

**Trace** — threaded onto the `tool_call` completed event (both providers) + schema, so the distinction is machine-verifiable via `afk trace show` and telemetry.

**TUI** — plumbed through `tool.output` → stream-consumer → `ToolResultChunk`, rendered as a dim `∥i/N` suffix on root rows whose `batchSize > 1`.

Because the badge is sourced from the real batch, it is **collision-incapable**: it can only appear on a call that genuinely shared a batch, never on a sequential dispatch.

### Rendered

```
  ● Read("dispatcher.ts") — ✓ 970 lines ∥1/3
  ● Grep("batchSize") — ✓ 12 matches ∥2/3
  ● Glob("**/*.ts") — ✓ 44 paths ∥3/3

  $ Bash("pnpm test") — ✓ 42 lines          ← singleton batch, never badged
```

## Scope

- **Badged:** flat roots (live overlay + committed scrollback) and NESTING roots (agent/skill/compose) in the live overlay.
- **Deferred:** NESTING-root badge in committed **scrollback**. The agent head row is governed by the `formatAgentSummary`/`formatAgentHeader` dual-encoding invariant, and `batchSize` isn't available at eager-head-emit time (the agent hasn't completed yet) — badging it there risks the severed-spine class of bug. Tracked as a follow-up.
- **Not badged:** the `×N` grouped header (already signals multiplicity — avoids a double-signal).

## Testing

- `executeBatch` stamping (mixed partition + full safe fan-out)
- `batchBadge` unit tests (parallel/singleton/absent/defensive)
- End-to-end lane render — badge reaches rendered root rows in both overlay and flush; singleton shows no badge
- Trace-schema acceptance/rejection of `batchIndex`/`batchSize`
- Full affected subtree green: **7228 tests**, `tsc --noEmit` clean
- Visually confirmed the `∥` glyph renders (shown above)

Additive/back-compat throughout: absent on the single-tool `execute()` path and on blocked/short-circuited calls; badge is invisible unless `batchSize > 1`.

## Follow-ups
- #516 — live "during-pending" parallel indicator (Phase 2)
- Scrollback NESTING-root badge (deferred above)
