### PR TITLE
fix(tools): give read/write/edit/list the factory-cwd resolve tier glob/grep have (#434)

### DIFF
--- a/src/agent/tools/handlers/_cwd-utils.test.ts
+++ b/src/agent/tools/handlers/_cwd-utils.test.ts
@@ -241,3 +241,37 @@ describe('symlink containment', () => {
     expect(() => resolveAndContain(outsideFile, c)).toThrow(/outside the allowed/);
   });
 });
+
+describe('fallbackBase — factory-cwd resolve tier (issue #434)', () => {
+  // A context with NO resolveBase/cwd — the out-of-dispatcher invocation shape.
+  const baseless = {
+    cwd: undefined,
+    resolveBase: undefined,
+    readRoots: undefined,
+    writeRoots: undefined,
+  } as ToolHandlerContext;
+
+  it('anchors a relative path to fallbackBase when context carries no base', () => {
+    // Without fallbackBase this resolves against process.cwd(); with it, BASE.
+    expect(resolveAndContain('src/foo.ts', baseless, 'read', BASE)).toBe(INSIDE);
+  });
+
+  it('enforces containment against [fallbackBase] when context carries no base', () => {
+    expect(() => resolveAndContain(OUTSIDE, baseless, 'read', BASE)).toThrow(/outside the allowed/);
+    expect(wouldBeRestricted(OUTSIDE, baseless, 'read', BASE).restricted).toBe(true);
+    expect(wouldBeRestricted(INSIDE, baseless, 'read', BASE).restricted).toBe(false);
+  });
+
+  it('context base wins over fallbackBase (no-op on the dispatcher path)', () => {
+    // context.resolveBase = BASE; a bogus fallbackBase must be ignored.
+    expect(resolveAndContain('src/foo.ts', ctx(), 'read', '/tmp/other')).toBe(INSIDE);
+    expect(wouldBeRestricted(INSIDE, ctx(), 'read', '/tmp/other').restricted).toBe(false);
+  });
+
+  it('undefined fallbackBase preserves the unconfined fall-through (invariant guard)', () => {
+    // No context base AND no fallbackBase → resolveBase undefined → no enforcement.
+    // This is the load-bearing top-level-session invariant; do not "fix" it.
+    expect(resolveAndContain(OUTSIDE, baseless, 'read', undefined)).toBe(OUTSIDE);
+    expect(wouldBeRestricted(OUTSIDE, baseless, 'read', undefined).restricted).toBe(false);
+  });
+});

--- a/src/agent/tools/handlers/_cwd-utils.ts
+++ b/src/agent/tools/handlers/_cwd-utils.ts
@@ -70,16 +70,27 @@ export function _resetRootRealpathCacheForTests(): void {
  *                      back-compat callers that provide no context).
  * @param mode        - `'read'` or `'write'` — affects the error message noun
  *                      only; the containment logic is identical.
+ * @param fallbackBase - Optional session cwd closed over by a handler factory
+ *                      (e.g. `createReadFileHandler(cwd)`). Used as the LAST
+ *                      resolve-base tier — after `context.resolveBase` /
+ *                      `context.cwd`, before `process.cwd()` — so a factory
+ *                      handler invoked WITHOUT a dispatcher context still
+ *                      anchors relative paths to (and confines them within)
+ *                      its session tree instead of the host launch dir. Mirrors
+ *                      the `?? sessionCwd` tier grep/glob already carry. On the
+ *                      dispatcher path it is a no-op: `context.cwd` and the
+ *                      factory cwd are the same value, so `context` wins.
  * @returns The resolved absolute path.
- * @throws  When a `resolveBase` is set and the resolved path falls outside
+ * @throws  When a resolve base is set and the resolved path falls outside
  *          every allowed root.
  */
 export function resolveAndContain(
   inputPath: string,
   context: ToolHandlerContext | undefined,
   mode: 'read' | 'write' = 'read',
+  fallbackBase?: string,
 ): string {
-  const resolveBase = context?.resolveBase ?? context?.cwd;
+  const resolveBase = context?.resolveBase ?? context?.cwd ?? fallbackBase;
 
   // Resolve to absolute, anchoring relative paths against resolveBase.
   const abs = path.isAbsolute(inputPath)
@@ -93,7 +104,16 @@ export function resolveAndContain(
     return abs;
   }
 
-  // No base set — no containment enforcement.
+  // Invariant: `resolveBase === undefined` marks an UNCONFINED session — a
+  // top-level `afk chat`/`interactive` run with no worktree, where `config.cwd`
+  // is deliberately unset (dispatcher does `this.resolveBase = opts.cwd`). We
+  // disable containment here on purpose so such a session can read/write
+  // anywhere (config files, /tmp, absolute paths). Do NOT "fix" this by
+  // defaulting resolveBase to `process.cwd()`: that confines every top-level
+  // session to its launch dir, and — because the emitted `readRoots`/`writeRoots`
+  // are `[]` for a no-cwd session (`[] ?? [base]` stays `[]`) — would reject ALL
+  // paths. Confinement is opt-in via a set cwd (worktree/fork) or an explicit
+  // `fallbackBase`, never a default. See docs/issue #434.
   if (resolveBase === undefined) {
     return abs;
   }
@@ -146,8 +166,9 @@ export function wouldBeRestricted(
   inputPath: string,
   context: ToolHandlerContext | undefined,
   mode: 'read' | 'write' = 'read',
+  fallbackBase?: string,
 ): { restricted: boolean; resolved: string; roots: string[] } {
-  const resolveBase = context?.resolveBase ?? context?.cwd;
+  const resolveBase = context?.resolveBase ?? context?.cwd ?? fallbackBase;
 
   const abs = path.isAbsolute(inputPath)
     ? inputPath
@@ -160,7 +181,8 @@ export function wouldBeRestricted(
   }
 
   if (resolveBase === undefined) {
-    // No containment enforcement — never restricted.
+    // Unconfined session — no containment enforcement, never restricted.
+    // Same load-bearing invariant documented in `resolveAndContain`.
     return { restricted: false, resolved: abs, roots: [] };
   }
 

--- a/src/agent/tools/handlers/edit-file.ts
+++ b/src/agent/tools/handlers/edit-file.ts
@@ -86,10 +86,11 @@ function countOccurrences(text: string, substring: string): number {
 /**
  * Execute a string replacement on a file.
  */
-export const editFileHandler: ToolHandler = async (
+const editFileImpl = async (
   input: unknown,
   signal: AbortSignal,
-  context?: ToolHandlerContext,
+  context: ToolHandlerContext | undefined,
+  cwd: string | undefined,
 ): Promise<{ content: string; isError?: boolean }> => {
   // Check if aborted before we start.
   if (signal.aborted) {
@@ -103,7 +104,7 @@ export const editFileHandler: ToolHandler = async (
 
   let file_path: string;
   try {
-    file_path = resolveAndContain(rawFilePath, context, 'write');
+    file_path = resolveAndContain(rawFilePath, context, 'write', cwd);
   } catch (err) {
     return { content: err instanceof Error ? err.message : String(err), isError: true };
   }
@@ -179,3 +180,15 @@ export const editFileHandler: ToolHandler = async (
     };
   }
 };
+
+/**
+ * Create an `edit_file` handler closed over a session-specific base path.
+ * See `createReadFileHandler` — `cwd` is the last resolve-base tier for
+ * out-of-context invocations; a no-op on the dispatcher path. Issue #434.
+ */
+export function createEditFileHandler(cwd?: string): ToolHandler {
+  return (input, signal, context) => editFileImpl(input, signal, context, cwd);
+}
+
+/** Bare `edit_file` handler with no session cwd (`createEditFileHandler()`). */
+export const editFileHandler: ToolHandler = createEditFileHandler();

--- a/src/agent/tools/handlers/fs-handler-factory-cwd.test.ts
+++ b/src/agent/tools/handlers/fs-handler-factory-cwd.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Factory-cwd fallback tier for the four bare FS handlers (issue #434).
+ *
+ * read_file / write_file / edit_file / list_directory, when built via their
+ * `create*Handler(cwd)` factory, must anchor a RELATIVE path to that session
+ * cwd — and confine it there — even when invoked WITHOUT a dispatcher context.
+ * This is the safety net glob/grep already had. The last case locks the
+ * load-bearing "undefined base = unconfined top-level session" invariant so a
+ * future change cannot silently confine top-level sessions.
+ *
+ * @module agent/tools/handlers/fs-handler-factory-cwd.test
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createReadFileHandler, readFileHandler } from './read-file.js';
+import { createWriteFileHandler } from './write-file.js';
+import { createEditFileHandler } from './edit-file.js';
+import { createListDirectoryHandler } from './list-directory.js';
+
+describe('FS handler factory cwd fallback (issue #434)', () => {
+  let tmpDir: string;
+  const sig = () => new AbortController().signal;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(join(tmpdir(), 'fs-factory-cwd-'));
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tmpDir, { recursive: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it('createReadFileHandler(cwd) resolves a relative path against cwd (no context)', async () => {
+    await fs.writeFile(join(tmpDir, 'rel.txt'), 'hello-434\n');
+    const result = await createReadFileHandler(tmpDir)({ file_path: 'rel.txt' }, sig());
+    expect(result.isError).not.toBe(true);
+    expect(result.content).toContain('hello-434');
+  });
+
+  it('createWriteFileHandler(cwd) writes a relative path under cwd (no context)', async () => {
+    const result = await createWriteFileHandler(tmpDir)(
+      { file_path: 'out/new.txt', content: 'written-434' },
+      sig(),
+    );
+    expect(result.isError).not.toBe(true);
+    const written = await fs.readFile(join(tmpDir, 'out/new.txt'), 'utf-8');
+    expect(written).toBe('written-434');
+  });
+
+  it('createEditFileHandler(cwd) edits a relative path under cwd (no context)', async () => {
+    await fs.writeFile(join(tmpDir, 'edit.txt'), 'before\n');
+    const result = await createEditFileHandler(tmpDir)(
+      { file_path: 'edit.txt', old_string: 'before', new_string: 'after' },
+      sig(),
+    );
+    expect(result.isError).not.toBe(true);
+    expect(await fs.readFile(join(tmpDir, 'edit.txt'), 'utf-8')).toBe('after\n');
+  });
+
+  it('createListDirectoryHandler(cwd) lists a relative path under cwd (no context)', async () => {
+    await fs.writeFile(join(tmpDir, 'a.txt'), 'x');
+    await fs.mkdir(join(tmpDir, 'sub'));
+    const result = await createListDirectoryHandler(tmpDir)({ path: '.' }, sig());
+    expect(result.isError).not.toBe(true);
+    expect(result.content).toContain('a.txt');
+    expect(result.content).toContain('sub/');
+  });
+
+  it('confines a relative escape attempt to the factory cwd (no context)', async () => {
+    // With a factory cwd but no dispatcher context, containment is now enforced
+    // against [cwd] — an upward escape is rejected before any fs access.
+    const escape = '../'.repeat(20) + 'etc/passwd';
+    const result = await createReadFileHandler(tmpDir)({ file_path: escape }, sig());
+    expect(result.isError).toBe(true);
+    expect(result.content).toMatch(/outside the allowed/);
+  });
+
+  it('bare handler with no factory cwd and no context stays UNCONFINED (top-level invariant)', async () => {
+    // resolveBase is undefined here (no factory cwd, no context) → containment
+    // is intentionally disabled, so an absolute path outside any root is admitted.
+    // Regression guard: do NOT "fix" #434 by confining this path.
+    await fs.writeFile(join(tmpDir, 'abs.txt'), 'abs-ok\n');
+    const result = await readFileHandler({ file_path: join(tmpDir, 'abs.txt') }, sig());
+    expect(result.isError).not.toBe(true);
+    expect(result.content).toContain('abs-ok');
+  });
+});

--- a/src/agent/tools/handlers/index.ts
+++ b/src/agent/tools/handlers/index.ts
@@ -9,12 +9,12 @@
 
 import type { ToolHandler } from '../types.js';
 import { bashHandler, createBashHandler } from './bash.js';
-import { readFileHandler } from './read-file.js';
-import { writeFileHandler } from './write-file.js';
-import { editFileHandler } from './edit-file.js';
+import { readFileHandler, createReadFileHandler } from './read-file.js';
+import { writeFileHandler, createWriteFileHandler } from './write-file.js';
+import { editFileHandler, createEditFileHandler } from './edit-file.js';
 import { globHandler, createGlobHandler } from './glob.js';
 import { grepHandler, createGrepHandler } from './grep.js';
-import { listDirectoryHandler } from './list-directory.js';
+import { listDirectoryHandler, createListDirectoryHandler } from './list-directory.js';
 import { sendTelegramHandler } from './send-telegram.js';
 import { webScrapeHandler } from './web-scrape.js';
 import {
@@ -47,10 +47,13 @@ import { browserCloseHandler } from './browser-close.js';
  * @param cwd - The session's working directory (typically a worktree path
  *   from `afk interactive -w`). When supplied, bash/grep spawn child
  *   processes with this cwd, and glob/grep use it as the default search
- *   path when the model omits one. Without this, concurrent sessions in
- *   different worktrees all spawn against the host's `process.cwd()` —
- *   causing `git stash`, `git checkout`, etc. to clobber each other.
- *   The Node process's `process.cwd()` is never mutated.
+ *   path when the model omits one. read_file/write_file/edit_file/
+ *   list_directory close over it as their last resolve-base tier (issue
+ *   #434), so a context-less invocation still anchors and confines relative
+ *   paths to this tree instead of the host launch dir. Without this,
+ *   concurrent sessions in different worktrees all spawn against the host's
+ *   `process.cwd()` — causing `git stash`, `git checkout`, etc. to clobber
+ *   each other. The Node process's `process.cwd()` is never mutated.
  */
 export function createBuiltinHandlers(
   permissionMode?: string,
@@ -61,16 +64,23 @@ export function createBuiltinHandlers(
     : (cwd !== undefined ? createBashHandler('default', cwd) : bashHandler);
   const glob = cwd !== undefined ? createGlobHandler(cwd) : globHandler;
   const grep = cwd !== undefined ? createGrepHandler(cwd) : grepHandler;
+  // read/write/edit/list close over cwd as their resolve-base fallback tier
+  // (issue #434) — parity with glob/grep. No-op on the dispatcher path, where
+  // context.resolveBase already carries this same value.
+  const readFile = cwd !== undefined ? createReadFileHandler(cwd) : readFileHandler;
+  const writeFile = cwd !== undefined ? createWriteFileHandler(cwd) : writeFileHandler;
+  const editFile = cwd !== undefined ? createEditFileHandler(cwd) : editFileHandler;
+  const listDirectory = cwd !== undefined ? createListDirectoryHandler(cwd) : listDirectoryHandler;
   const terminalFontSize = createTerminalFontSizeHandler();
   const worktree = createWorktreeHandler(cwd);
   return new Map<string, ToolHandler>([
     ['bash', bash],
-    ['read_file', readFileHandler],
-    ['write_file', writeFileHandler],
-    ['edit_file', editFileHandler],
+    ['read_file', readFile],
+    ['write_file', writeFile],
+    ['edit_file', editFile],
     ['glob', glob],
     ['grep', grep],
-    ['list_directory', listDirectoryHandler],
+    ['list_directory', listDirectory],
     ['send_telegram', sendTelegramHandler],
     ['web_scrape', webScrapeHandler],
     ['create_schedule', createScheduleHandler],

--- a/src/agent/tools/handlers/list-directory.ts
+++ b/src/agent/tools/handlers/list-directory.ts
@@ -30,7 +30,12 @@ import { resolveAndContain } from './_cwd-utils.js';
  * file2.ts
  * ```
  */
-export const listDirectoryHandler: ToolHandler = async (input, _signal, context?: ToolHandlerContext) => {
+const listDirectoryImpl = async (
+  input: unknown,
+  _signal: AbortSignal,
+  context: ToolHandlerContext | undefined,
+  cwd: string | undefined,
+) => {
   // Validate input shape
   if (!input || typeof input !== 'object') {
     throw new Error('Invalid input: expected an object');
@@ -46,7 +51,7 @@ export const listDirectoryHandler: ToolHandler = async (input, _signal, context?
 
   let resolvedPath: string;
   try {
-    resolvedPath = resolveAndContain(rawPath, context, 'read');
+    resolvedPath = resolveAndContain(rawPath, context, 'read', cwd);
   } catch (err) {
     return { content: err instanceof Error ? err.message : String(err), isError: true };
   }
@@ -93,3 +98,15 @@ export const listDirectoryHandler: ToolHandler = async (input, _signal, context?
     return { content: 'Unknown error listing directory', isError: true };
   }
 };
+
+/**
+ * Create a `list_directory` handler closed over a session-specific base path.
+ * See `createReadFileHandler` — `cwd` is the last resolve-base tier for
+ * out-of-context invocations; a no-op on the dispatcher path. Issue #434.
+ */
+export function createListDirectoryHandler(cwd?: string): ToolHandler {
+  return (input, signal, context) => listDirectoryImpl(input, signal, context, cwd);
+}
+
+/** Bare `list_directory` handler with no session cwd (`createListDirectoryHandler()`). */
+export const listDirectoryHandler: ToolHandler = createListDirectoryHandler();

--- a/src/agent/tools/handlers/read-file.ts
+++ b/src/agent/tools/handlers/read-file.ts
@@ -30,7 +30,12 @@ import { resolveAndContain } from './_cwd-utils.js';
  *    2\tnext line
  * ```
  */
-export const readFileHandler: ToolHandler = async (input, _signal, context?: ToolHandlerContext) => {
+const readFileImpl = async (
+  input: unknown,
+  _signal: AbortSignal,
+  context: ToolHandlerContext | undefined,
+  cwd: string | undefined,
+) => {
   // Validate input shape
   if (!input || typeof input !== 'object') {
     return { content: 'Invalid input: expected an object', isError: true };
@@ -57,7 +62,7 @@ export const readFileHandler: ToolHandler = async (input, _signal, context?: Too
 
   let filePath: string;
   try {
-    filePath = resolveAndContain(rawFilePath, context, 'read');
+    filePath = resolveAndContain(rawFilePath, context, 'read', cwd);
   } catch (err) {
     return { content: err instanceof Error ? err.message : String(err), isError: true };
   }
@@ -136,3 +141,20 @@ export const readFileHandler: ToolHandler = async (input, _signal, context?: Too
     return { content: 'Unknown error reading file', isError: true };
   }
 };
+
+/**
+ * Create a `read_file` handler closed over a session-specific base path.
+ *
+ * When invoked without a dispatcher context (or one lacking `resolveBase`/
+ * `cwd`), `cwd` becomes the resolve base — so a handler built for a worktree
+ * session anchors and confines relative paths to that tree instead of the host
+ * `process.cwd()`. `cwd === undefined` preserves the legacy unconfined behavior.
+ * Mirrors `createGlobHandler`/`createGrepHandler` so all six filesystem handlers
+ * share one session-cwd fallback tier. See issue #434.
+ */
+export function createReadFileHandler(cwd?: string): ToolHandler {
+  return (input, signal, context) => readFileImpl(input, signal, context, cwd);
+}
+
+/** Bare `read_file` handler with no session cwd (`createReadFileHandler()`). */
+export const readFileHandler: ToolHandler = createReadFileHandler();

--- a/src/agent/tools/handlers/write-file.ts
+++ b/src/agent/tools/handlers/write-file.ts
@@ -57,10 +57,11 @@ function parseWriteFileInput(input: unknown): {
  * Returns an error result for permission issues.
  * Throws for invalid input (caught by the dispatcher).
  */
-export const writeFileHandler: ToolHandler = async (
+const writeFileImpl = async (
   input: unknown,
   signal: AbortSignal,
-  context?: ToolHandlerContext,
+  context: ToolHandlerContext | undefined,
+  cwd: string | undefined,
 ) => {
   if (signal.aborted) {
     return {
@@ -73,7 +74,7 @@ export const writeFileHandler: ToolHandler = async (
 
   let file_path: string;
   try {
-    file_path = resolveAndContain(rawFilePath, context, 'write');
+    file_path = resolveAndContain(rawFilePath, context, 'write', cwd);
   } catch (err) {
     return { content: err instanceof Error ? err.message : String(err), isError: true };
   }
@@ -181,3 +182,15 @@ export const writeFileHandler: ToolHandler = async (
     };
   }
 };
+
+/**
+ * Create a `write_file` handler closed over a session-specific base path.
+ * See `createReadFileHandler` — `cwd` is the last resolve-base tier for
+ * out-of-context invocations; a no-op on the dispatcher path. Issue #434.
+ */
+export function createWriteFileHandler(cwd?: string): ToolHandler {
+  return (input, signal, context) => writeFileImpl(input, signal, context, cwd);
+}
+
+/** Bare `write_file` handler with no session cwd (`createWriteFileHandler()`). */
+export const writeFileHandler: ToolHandler = createWriteFileHandler();


### PR DESCRIPTION
## Summary

Closes #434 — the structural sibling of #416/#435, found in the same tool/subagent/worktree audit.

`read_file`, `write_file`, `edit_file`, and `list_directory` were registered as **bare** handlers with no cwd closure, unlike `glob`/`grep` which get `createGlobHandler(cwd)` / `createGrepHandler(cwd)`. The four bare handlers relied entirely on the dispatcher populating `context.resolveBase`; a context-less invocation fell through to `process.cwd()` in `resolveAndContain` and resolved **relative** paths against the host launch dir with **no containment**.

This is **latent today** — the dispatcher always threads `config.cwd`, so on the production path the fallback is unreachable — but it's a real asymmetry and a silent footgun for any non-dispatcher caller (a plugin, a direct import, a future code path).

### The fix — corrected option (a)

- **`create{Read,Write,Edit}FileHandler` / `createListDirectoryHandler` factories** that close over a session cwd, registered with the same `cwd !== undefined ? createX(cwd) : xHandler` tier as glob/grep. **Bare exports are preserved** (each = factory with no cwd), so existing callers/tests are untouched.
- **New optional `fallbackBase` param on `resolveAndContain` / `wouldBeRestricted`** — the *last* resolve-base tier, after `context.resolveBase` / `context.cwd`, before `process.cwd()`. Mirrors the `?? sessionCwd` tier grep/glob already carry. It is a **no-op on the dispatcher path** (the factory cwd and `context.resolveBase` are the same value, so `context` wins), so **zero behavior change on any live path** — it only bites a context-less non-dispatcher call, where it now anchors *and confines* relative paths to the session tree instead of the host launch dir.
- **An `// Invariant:` comment** in `_cwd-utils.ts` documenting that `resolveBase === undefined` marks an *unconfined top-level session*.

### Why not the issue's preferred option (b)?

The issue proposed option (b): "assert `resolveBase` is always populated at the dispatcher boundary." On inspection that's unsafe. `resolveBase === undefined` is **load-bearing**: it's the signal that *disables* containment for a top-level `afk chat`/`interactive` run (those launch with `config.cwd` unset → `dispatcher.resolveBase = undefined`, which is why they can read `~/.afk`, `/tmp`, absolute paths). Forcing `resolveBase` defined would confine every top-level session to its launch dir — and because a no-cwd session emits `readRoots`/`writeRoots` of `[]` (`[] ?? [base]` stays `[]`), it would reject **all** paths. Option (a) is the additive, backward-compatible fix that closes the asymmetry without touching that invariant. (The invariant is now documented so it isn't "fixed" into a regression later.)

## How was this tested?

Run on this tree (`30917d6`), branched off `origin/main`:

- `pnpm lint` (tsc --noEmit, strict) — clean
- `pnpm test` — **11233 passed / 14 skipped / 0 failed** (620 files)
- `pnpm audit:sdk:check` — OK (no unlocked SDK symbols)
- `pnpm audit:env:check` — 0 violations
- `pnpm scan:env:check` — env registry in sync

New unit coverage:
- `fs-handler-factory-cwd.test.ts` — each of the four factories anchors a relative path to its cwd with no context; a relative escape is confined to the cwd; and the **bare handler with no cwd + no context stays unconfined** (regression guard on the top-level invariant).
- `_cwd-utils.test.ts` — `fallbackBase` tier: anchors when context has no base, enforces `[fallbackBase]` containment, `context` base wins over `fallbackBase`, and `undefined fallbackBase` preserves the unconfined fall-through.

## Notes

- Independent of PR #514 (#435): zero file overlap. 514's correctness silently relies on the dispatcher-always-threads-`resolveBase` invariant; this PR makes that invariant explicit but is not a prerequisite.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the DCO
- [x] No secrets, tokens, or private paths in the diff
