### PR TITLE
refactor(anthropic-direct): unify system-prompt assembly — finish index.ts split (#362)

### DIFF
--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -78,11 +78,11 @@ import {
   createGetRuntimeStateHandler,
   wrapDispatcherWithRuntimeState,
   buildRuntimeStateSource,
-  formatEnvironmentFragment,
   type RuntimeStateSource,
 } from '../../awareness/index.js';
 import { registerPresenceLifecycle } from './query/presence-lifecycle.js';
 import { createCwdDependentsFactory } from './query/cwd-dependents.js';
+import { assembleSystemPrompt, buildStableSystemPrefix } from './query/system-prompt.js';
 
 const PROVIDER_NAME = 'anthropic-direct';
 const DEFAULT_MODEL = 'claude-sonnet-5';
@@ -757,31 +757,28 @@ export class AnthropicDirectProvider implements ModelProvider {
     // instructions for memory_update / procedure_write — keeps the model from
     // being told about tools it does not have.
     const memoryPrompt = resolveMemorySystemPrompt(this.readOnlyMemory);
-    const systemParts = [toolBase, memoryPrompt];
-    // Awareness layer (Phase 1 + 2): session identity fragment + workspace line.
-    // `formatEnvironmentFragment` always emits `- Working directory: <cwd>`
-    // (existing behavior), conditionally appends `- Session: <id> (...)` when
-    // at least one identity field is known, and (Phase 2) conditionally appends
-    // `- Workspace: <branch> @ <sha> (clean|N dirty)` when git state is available.
-    systemParts.push(
-      formatEnvironmentFragment({
-        cwd,
-        ...(config.sessionId !== undefined ? { sessionId: config.sessionId } : {}),
-        surface: this.surface,
-        ...(config.depth !== undefined ? { depth: config.depth } : {}),
-        ...(config.maxDepth !== undefined ? { maxDepth: config.maxDepth } : {}),
-        workspace: runtimeStateSource.getWorkspace(),
-      }),
-    );
-    if (manifest.length > 0) systemParts.push(manifest);
-    if (userSystem) systemParts.push(userSystem);
-    const toolSystemAppend = systemParts.join('\n\n');
 
-    // Stable parts of the system prompt that don't change when cwd changes.
-    // Used by the cwdDependentsFactory closure below.
-    const stableSystemPrefix = [toolBase, memoryPrompt];
-    if (manifest.length > 0) stableSystemPrefix.push(manifest);
-    if (userSystem) stableSystemPrefix.push(userSystem);
+    // Awareness identity fields interleaved into the `# Environment` fragment
+    // (Phase 1 + 2). Stable across cwd swaps — only `cwd` changes on setCwd().
+    const environmentIdentity = {
+      surface: this.surface,
+      sessionId: config.sessionId,
+      depth: config.depth,
+      maxDepth: config.maxDepth,
+      workspace: runtimeStateSource.getWorkspace(),
+    };
+
+    // Stable (cwd-independent) parts of the system prompt. The cwd-dependent
+    // `# Environment` fragment is spliced in by assembleSystemPrompt — the same
+    // helper the cwdDependentsFactory below uses on a cwd change, so the
+    // first-turn and rebuilt prompts can never drift.
+    const stableSystemPrefix = buildStableSystemPrefix({
+      toolBase,
+      memoryPrompt,
+      manifest,
+      userSystem,
+    });
+    const toolSystemAppend = assembleSystemPrompt(stableSystemPrefix, cwd, environmentIdentity);
 
     // Dump prompt debug info if AFK_DUMP_PROMPT is set (wired via --dump-prompt CLI flag).
     dumpIfEnabled({

--- a/src/agent/providers/anthropic-direct/query/cwd-dependents.ts
+++ b/src/agent/providers/anthropic-direct/query/cwd-dependents.ts
@@ -14,7 +14,8 @@ import type { SubagentExecutor } from '../../../tools/subagent-executor.js';
 import type { SkillExecutor } from '../../../tools/skill-executor.js';
 import type { ComposeExecutor } from '../../../tools/compose-executor.js';
 import type { ToolDispatcher } from '../tool-dispatcher.js';
-import { formatEnvironmentFragment, type RuntimeStateSource } from '../../../awareness/index.js';
+import type { RuntimeStateSource } from '../../../awareness/index.js';
+import { assembleSystemPrompt } from './system-prompt.js';
 
 export type CwdDependentsFactory = (newCwd: string) => {
   userSystem: string;
@@ -83,25 +84,18 @@ export function createCwdDependentsFactory(args: CwdDependentsFactoryArgs): CwdD
     args.skillExecutor?.setCwd(newCwd);
     args.composeExecutor?.setCwd(newCwd);
 
-    // 2. Rebuild system-prompt fragment with the new `# Environment` line.
-    //    Build a fresh copy each invocation — splice mutates in place.
-    //    Awareness identity fields (sessionId/surface/depth/maxDepth)
-    //    are stable across cwd swaps, so we reuse the config snapshot.
-    const newSystemParts = [
-      args.stableSystemPrefix[0]!,
-      args.stableSystemPrefix[1]!,
-      formatEnvironmentFragment({
-        cwd: newCwd,
-        ...(args.config.sessionId !== undefined ? { sessionId: args.config.sessionId } : {}),
-        surface: args.surface,
-        ...(args.config.depth !== undefined ? { depth: args.config.depth } : {}),
-        ...(args.config.maxDepth !== undefined ? { maxDepth: args.config.maxDepth } : {}),
-        // Workspace is stable across cwd swaps (captured at session start).
-        workspace: args.runtimeStateSource.getWorkspace(),
-      }),
-      ...args.stableSystemPrefix.slice(2),
-    ];
-    const newUserSystem = newSystemParts.join('\n\n');
+    // 2. Rebuild the system prompt with the new `# Environment` line via the
+    //    SAME assembler the first-turn path uses (query/system-prompt.ts), so
+    //    the two can never drift. Awareness identity fields
+    //    (sessionId/surface/depth/maxDepth/workspace) are stable across cwd
+    //    swaps, so we reuse the config snapshot; only `newCwd` changes.
+    const newUserSystem = assembleSystemPrompt(args.stableSystemPrefix, newCwd, {
+      surface: args.surface,
+      sessionId: args.config.sessionId,
+      depth: args.config.depth,
+      maxDepth: args.config.maxDepth,
+      workspace: args.runtimeStateSource.getWorkspace(),
+    });
 
     // 3. Build the new dispatcher. Its bash/grep/glob handlers close over
     //    `newCwd` so future fall-through reads (where context is absent)

--- a/src/agent/providers/anthropic-direct/query/system-prompt.test.ts
+++ b/src/agent/providers/anthropic-direct/query/system-prompt.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for the shared system-prompt assembler
+ * (query/system-prompt.ts). These lock the seam that closes the
+ * "assembled twice" duplication (#362): the first-turn path (index.ts) and the
+ * on-cwd-change rebuild (cwd-dependents.ts) both route through
+ * `assembleSystemPrompt`, so the env fragment lands at the same position and
+ * the stable prefix is built identically on both paths.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  assembleSystemPrompt,
+  buildStableSystemPrefix,
+  type EnvironmentIdentity,
+} from './system-prompt.js';
+
+const IDENTITY: EnvironmentIdentity = {
+  surface: 'cli',
+  sessionId: undefined,
+  depth: undefined,
+  maxDepth: undefined,
+  workspace: null,
+};
+
+describe('buildStableSystemPrefix', () => {
+  it('always includes toolBase + memoryPrompt in order', () => {
+    const parts = buildStableSystemPrefix({
+      toolBase: 'TOOL',
+      memoryPrompt: 'MEM',
+      manifest: '',
+      userSystem: null,
+    });
+    expect(parts).toEqual(['TOOL', 'MEM']);
+  });
+
+  it('omits empty manifest and null/empty userSystem', () => {
+    expect(
+      buildStableSystemPrefix({ toolBase: 'T', memoryPrompt: 'M', manifest: '', userSystem: '' }),
+    ).toEqual(['T', 'M']);
+    expect(
+      buildStableSystemPrefix({ toolBase: 'T', memoryPrompt: 'M', manifest: '', userSystem: null }),
+    ).toEqual(['T', 'M']);
+  });
+
+  it('appends manifest then userSystem when present, in that order', () => {
+    const parts = buildStableSystemPrefix({
+      toolBase: 'T',
+      memoryPrompt: 'M',
+      manifest: 'MANIFEST',
+      userSystem: 'USER',
+    });
+    expect(parts).toEqual(['T', 'M', 'MANIFEST', 'USER']);
+  });
+});
+
+describe('assembleSystemPrompt', () => {
+  it('splices the # Environment fragment at index 2 (between memoryPrompt and the rest)', () => {
+    const prefix = buildStableSystemPrefix({
+      toolBase: 'TOOL',
+      memoryPrompt: 'MEM',
+      manifest: 'MANIFEST',
+      userSystem: 'USER',
+    });
+    const out = assembleSystemPrompt(prefix, '/tmp/work', IDENTITY);
+    const sections = out.split('\n\n');
+    expect(sections[0]).toBe('TOOL');
+    expect(sections[1]).toBe('MEM');
+    // formatEnvironmentFragment always emits the working-directory line.
+    expect(sections[2]).toContain('Working directory: /tmp/work');
+    expect(sections[3]).toBe('MANIFEST');
+    expect(sections[4]).toBe('USER');
+  });
+
+  it('reflects the cwd in the environment fragment (only the env line changes across cwds)', () => {
+    const prefix = buildStableSystemPrefix({
+      toolBase: 'TOOL',
+      memoryPrompt: 'MEM',
+      manifest: '',
+      userSystem: null,
+    });
+    const a = assembleSystemPrompt(prefix, '/repo/a', IDENTITY);
+    const b = assembleSystemPrompt(prefix, '/repo/b', IDENTITY);
+    expect(a).toContain('Working directory: /repo/a');
+    expect(b).toContain('Working directory: /repo/b');
+    // Stable parts are byte-identical; only the env fragment differs.
+    expect(a.split('\n\n')[0]).toBe(b.split('\n\n')[0]);
+    expect(a.split('\n\n')[1]).toBe(b.split('\n\n')[1]);
+    expect(a).not.toBe(b);
+  });
+
+  it('handles a minimal prefix (toolBase + memoryPrompt only)', () => {
+    const prefix = buildStableSystemPrefix({
+      toolBase: 'TOOL',
+      memoryPrompt: 'MEM',
+      manifest: '',
+      userSystem: null,
+    });
+    const out = assembleSystemPrompt(prefix, '/x', IDENTITY);
+    const sections = out.split('\n\n');
+    expect(sections).toHaveLength(3);
+    expect(sections[0]).toBe('TOOL');
+    expect(sections[1]).toBe('MEM');
+    expect(sections[2]).toContain('Working directory: /x');
+  });
+
+  it('appends a Session line when an identity field is known', () => {
+    const prefix = buildStableSystemPrefix({
+      toolBase: 'T',
+      memoryPrompt: 'M',
+      manifest: '',
+      userSystem: null,
+    });
+    const out = assembleSystemPrompt(prefix, '/x', { ...IDENTITY, sessionId: 'sess-123' });
+    expect(out).toContain('sess-123');
+  });
+});

--- a/src/agent/providers/anthropic-direct/query/system-prompt.ts
+++ b/src/agent/providers/anthropic-direct/query/system-prompt.ts
@@ -1,0 +1,80 @@
+/**
+ * System-prompt assembly for {@link AnthropicDirectProvider.query}.
+ *
+ * The first-turn assembly (in `index.ts`) and the on-cwd-change re-assembly (in
+ * `cwd-dependents.ts`) build the SAME structure — `[toolBase, memoryPrompt,
+ * <# Environment fragment>, manifest?, userSystem?]` joined by blank lines.
+ * Only the `# Environment` fragment varies with cwd. Centralizing both paths
+ * here closes the "assembled twice" duplication so they can never drift.
+ *
+ * @module agent/providers/anthropic-direct/query/system-prompt
+ */
+
+import { formatEnvironmentFragment, type RuntimeStateSource } from '../../../awareness/index.js';
+
+/** The cwd-independent system-prompt parts feeding both assembly paths. */
+export interface StableSystemPromptInputs {
+  toolBase: string;
+  memoryPrompt: string;
+  /** Skill/agent manifest block; empty string when none. */
+  manifest: string;
+  /** Operator system-prompt overlay; empty string or null when none. */
+  userSystem: string | null;
+}
+
+/**
+ * The cwd-independent prefix, in order: `[toolBase, memoryPrompt, manifest?,
+ * userSystem?]`. The cwd-dependent `# Environment` fragment is deliberately NOT
+ * included — {@link assembleSystemPrompt} splices it in at index 2 so it can be
+ * recomputed on every cwd change without rebuilding the stable parts.
+ */
+export function buildStableSystemPrefix(i: StableSystemPromptInputs): string[] {
+  const parts = [i.toolBase, i.memoryPrompt];
+  if (i.manifest.length > 0) parts.push(i.manifest);
+  if (i.userSystem) parts.push(i.userSystem);
+  return parts;
+}
+
+/**
+ * Awareness identity fields interleaved into the `# Environment` fragment.
+ * These are stable across cwd swaps (captured at session start); only `cwd`
+ * itself changes on a `setCwd()`.
+ */
+export interface EnvironmentIdentity {
+  surface: string;
+  sessionId: string | undefined;
+  depth: number | undefined;
+  maxDepth: number | undefined;
+  workspace: ReturnType<RuntimeStateSource['getWorkspace']>;
+}
+
+/**
+ * Assemble the full system prompt: splice the cwd-dependent `# Environment`
+ * fragment into position 2 of the stable prefix and join with blank lines.
+ *
+ * `formatEnvironmentFragment` always emits `- Working directory: <cwd>`,
+ * conditionally appends `- Session: <id> (...)` when an identity field is
+ * known, and conditionally appends `- Workspace: <branch> @ <sha> (...)` when
+ * git state is available. Used by the first-turn path (`index.ts`) and by every
+ * cwd rebuild (`cwd-dependents.ts`) so the two never diverge.
+ */
+export function assembleSystemPrompt(
+  stableSystemPrefix: string[],
+  cwd: string,
+  identity: EnvironmentIdentity,
+): string {
+  const parts = [
+    stableSystemPrefix[0]!,
+    stableSystemPrefix[1]!,
+    formatEnvironmentFragment({
+      cwd,
+      ...(identity.sessionId !== undefined ? { sessionId: identity.sessionId } : {}),
+      surface: identity.surface,
+      ...(identity.depth !== undefined ? { depth: identity.depth } : {}),
+      ...(identity.maxDepth !== undefined ? { maxDepth: identity.maxDepth } : {}),
+      workspace: identity.workspace,
+    }),
+    ...stableSystemPrefix.slice(2),
+  ];
+  return parts.join('\n\n');
+}


### PR DESCRIPTION
Closes #362. Part of the large-file split initiative (#360). Finishes the `anthropic-direct/index.ts` decomposition — grant-manager (#489) and cwd-dependents (#452) were already extracted, so this is the tail.

## What

The first-turn system-prompt assembly (`index.ts`) and the on-cwd-change rebuild (`query/cwd-dependents.ts`) built the **same** structure — `[toolBase, memoryPrompt, <# Environment fragment>, manifest?, userSystem?]` joined by blank lines — as **two independent copies**. This unifies both into a single shared builder, closing the "assembled twice" duplication the issue flagged.

- **New `query/system-prompt.ts`** (mirrors the existing `query/*.ts` concern-module pattern):
  - `buildStableSystemPrefix()` — the cwd-independent parts `[toolBase, memoryPrompt, manifest?, userSystem?]`.
  - `assembleSystemPrompt()` — splices the cwd-dependent `# Environment` fragment in at position 2, then joins.
- **Both paths now route through `assembleSystemPrompt()`**, so the first-turn and rebuilt prompts can never drift.
- **New `query/system-prompt.test.ts`** (7 tests) locks the seam: env-fragment placement, empty-manifest / null-userSystem omission, per-cwd variance with stable parts held byte-identical.

`index.ts`: 942 → 939. `cwd-dependents.ts`: 135 → 129. (The line delta is small by design — this issue was re-scoped to the last inline block + the dedup; the value is one testable source of truth, not two divergent copies.)

**Behavior-preserving refactor — no functional change.**

## Verification

- `tsc --noEmit` clean; `audit:sdk:check` / `audit:env:check` / `scan:env:check` green.
- **Full suite + coverage:** 620 files, **11230 passed | 14 skipped, 0 failed** (baseline 11223 + 7 new tests); coverage 86.25 / 84.2 / 91.13 / 86.25 vs thresholds 74 / 79 / 82 / 74.
- **Independent read-only auditor: `CLEAN`** — `assembleSystemPrompt` reproduces byte-identical output to both original sites for all input permutations (env-fragment ordering at index 2, conditional-spread guards for `sessionId`/`depth`/`maxDepth`, unconditional `surface`/`workspace`, `\n\n` join, `slice(2)` tail all preserved), verified against pre-refactor HEAD. Corroborated by the passing `plan-mode-system-payload` + `read-only-memory` suites, which assert on assembled system-prompt content.

## Suspected findings (report-only)

- `EnvironmentIdentity.sessionId` is typed `string | undefined`; a hypothetical `null` would spread `sessionId: null` but has **no output impact** (`formatEnvironmentFragment` gates on `typeof === 'string'`) and matches the original's identical `!== undefined` guard — not a regression. Noted, not fixed (per the split protocol).
