### PR TITLE
feat(hooks): observe-only release-boundary PreToolUse detector (gate-migration wave 1 slice 2)

### DIFF
--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -10,6 +10,7 @@ import { createHookRegistry, type HookRegistry } from './hooks.js';
 import { createShadowVerifyNudge } from './shadow-verify-nudge.js';
 import { createAskQuestionGate } from './ask-question-gate.js';
 import { createSafeDestructDetect } from './safe-destruct-detect.js';
+import { createReleaseBoundaryDetect } from './release-boundary-detect.js';
 import { MemoryStore, createMemorySessionEndHook } from './memory/index.js';
 import { createPlanModeGate } from './plan-mode-gate.js';
 import { createAfkModeGate } from './afk-mode-gate.js';
@@ -125,6 +126,17 @@ export function createDefaultHookRegistry(
   // autonomous surfaces too). See safe-destruct-detect.ts and
   // .afk/plans/friction-substrate-and-gate-migration.md §9.
   registry.register('PreToolUse', createSafeDestructDetect());
+  // Release-boundary detector (observe-only, ALL surfaces): witness — but never
+  // block — bash commands that cross a publish/deploy boundary (npm/pnpm/yarn/
+  // cargo/twine/poetry/gem publish, docker push, gh release create, terraform/
+  // kubectl apply) or a sync boundary (git push --mirror / --tags). Same
+  // `approve`-outcome catch-record mechanism as safe-destruct: ZERO blocking
+  // friction (a release is often exactly what was asked — a block would be a
+  // false positive by construction), filterable as decision==='approve', ignored
+  // by the mechanical friction detectors. Wave-1 slice 2 shadow window. See
+  // release-boundary-detect.ts and
+  // .afk/plans/friction-substrate-and-gate-migration.md §9.
+  registry.register('PreToolUse', createReleaseBoundaryDetect());
   const store = memoryStore ?? new MemoryStore();
   if (getPermissionMode !== undefined) {
     registry.register('PreToolUse', createPlanModeGate(getPermissionMode));

--- a/src/agent/hooks/config-bridge.test.ts
+++ b/src/agent/hooks/config-bridge.test.ts
@@ -369,12 +369,12 @@ describe('createDefaultHookRegistry integration', () => {
 
   it('createDefaultHookRegistry without hookConfig → 0 config hooks registered', () => {
     const { registry } = createDefaultHookRegistry();
-    // Built-in handlers exist for SubagentStop and SessionEnd, plus the TWO
-    // always-on built-in PreToolUse handlers (the ask-question gate and the
-    // observe-only safe-destruct detector), both registered unconditionally. No
-    // further PreToolUse hooks since we passed no hookConfig (path-approval
-    // disabled above).
-    expect(registry.count('PreToolUse')).toBe(2);
+    // Built-in handlers exist for SubagentStop and SessionEnd, plus the THREE
+    // always-on built-in PreToolUse handlers (the ask-question gate, the
+    // observe-only safe-destruct detector, and the observe-only release-boundary
+    // detector), all registered unconditionally. No further PreToolUse hooks
+    // since we passed no hookConfig (path-approval disabled above).
+    expect(registry.count('PreToolUse')).toBe(3);
   });
 
   it('createDefaultHookRegistry with hookConfig → config hooks ARE registered', () => {
@@ -399,8 +399,9 @@ describe('createDefaultHookRegistry integration', () => {
       hookConfig,
       { cwd: projectCwd },
     );
-    // 2 built-ins (ask-question gate + safe-destruct detector) + 1 config hook
-    expect(registry.count('PreToolUse')).toBe(3);
+    // 3 built-ins (ask-question gate + safe-destruct detector + release-boundary
+    // detector) + 1 config hook
+    expect(registry.count('PreToolUse')).toBe(4);
   });
 
   it('built-in SubagentStop handler still present when hookConfig is provided', () => {

--- a/src/agent/release-boundary-detect.test.ts
+++ b/src/agent/release-boundary-detect.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the observe-only release-boundary detector (Wave 1 slice 2,
+ * gate-migration).
+ *
+ * Three contracts:
+ *   1. `detectReleaseBoundaryCommands` matches the curated publish/deploy/sync
+ *      boundary patterns and — critically for calibration — does NOT flag
+ *      common pre-boundary near misses (`npm version`, `git tag`, a plain
+ *      `git push origin main`, `npm install`).
+ *   2. The hook returns an `approve` catch-record (never a block) only on a
+ *      `bash` PreToolUse with a boundary-crossing command; `{}` otherwise.
+ *   3. It is wired into the default registry and, dispatched end-to-end, passes
+ *      the command through (no throw) while recording `decision: 'approve'`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { HookContext, HookDecision, PreToolUseContext } from './hooks.js';
+import {
+  createReleaseBoundaryDetect,
+  detectReleaseBoundaryCommands,
+  RELEASE_BOUNDARY_DETECT_REASON_PREFIX,
+} from './release-boundary-detect.js';
+import { createDefaultHookRegistry } from './default-hook-registry.js';
+
+function preCtx(command: string, toolName = 'bash'): HookContext {
+  const ctx: PreToolUseContext = { event: 'PreToolUse', toolName, input: { command } };
+  return ctx;
+}
+
+describe('detectReleaseBoundaryCommands', () => {
+  it.each([
+    ['npm publish --provenance', 'npm-publish'],
+    ['pnpm publish --no-git-checks', 'pnpm-publish'],
+    ['yarn publish', 'yarn-publish'],
+    ['yarn npm publish', 'yarn-publish'],
+    ['cargo publish', 'cargo-publish'],
+    ['twine upload dist/*', 'pypi-twine-upload'],
+    ['poetry publish --build', 'poetry-publish'],
+    ['gem push mygem-1.0.0.gem', 'gem-push'],
+    ['docker push registry.io/app:latest', 'docker-push'],
+    ['docker image push registry.io/app:latest', 'docker-push'],
+    ['gh release create v1.2.3 --generate-notes', 'gh-release-create'],
+    ['terraform apply -auto-approve', 'terraform-apply'],
+    ['kubectl apply -f deploy.yaml', 'kubectl-apply'],
+    ['git push --mirror git@github.com:org/mirror.git', 'git-push-mirror'],
+    ['git push origin main --follow-tags', 'git-push-tags'],
+    ['git push origin --tags', 'git-push-tags'],
+  ])('flags %j → %s', (command, expectedId) => {
+    expect(detectReleaseBoundaryCommands(command)).toContain(expectedId);
+  });
+
+  it.each([
+    ['npm version patch'], // bumps + tags locally — not the publish boundary
+    ['npm install'],
+    ['npm run build'],
+    ['git tag v1.2.3'], // creating a tag is local; pushing it is the boundary
+    ['git push origin main'], // no --mirror / --tags
+    ['git commit -m "release prep"'],
+    ['cargo build --release'], // "release" the profile, not a publish
+    ['docker build -t app .'], // build, not push
+    ['gh release view v1.0.0'], // read, not create
+    ['terraform plan'], // plan, not apply
+    ['kubectl get pods'],
+    [''],
+  ])('does not flag pre-boundary/benign %j', (command) => {
+    expect(detectReleaseBoundaryCommands(command)).toEqual([]);
+  });
+
+  it('reports every distinct pattern in a compound command', () => {
+    const ids = detectReleaseBoundaryCommands('npm publish && git push origin --tags');
+    expect(ids).toContain('npm-publish');
+    expect(ids).toContain('git-push-tags');
+  });
+});
+
+describe('createReleaseBoundaryDetect (observe-only hook)', () => {
+  const hook = createReleaseBoundaryDetect();
+
+  it('returns an approve catch-record with the stable reason prefix on a boundary bash command', () => {
+    const decision = hook(preCtx('npm publish --provenance'));
+    expect(decision.decision).toBe('approve');
+    expect(decision.reason).toContain(RELEASE_BOUNDARY_DETECT_REASON_PREFIX);
+    expect(decision.reason).toContain('npm-publish');
+  });
+
+  it('NEVER blocks — no block decision, no continue:false (the interpreter-eval lesson)', () => {
+    const decision: HookDecision = hook(preCtx('git push --mirror git@github.com:org/x.git'));
+    expect(decision.decision).not.toBe('block');
+    expect(decision.continue).not.toBe(false);
+  });
+
+  it('passes through non-boundary bash commands', () => {
+    expect(hook(preCtx('git push origin main'))).toEqual({});
+    expect(hook(preCtx('npm install'))).toEqual({});
+  });
+
+  it('ignores non-bash tools', () => {
+    expect(hook(preCtx('npm publish', 'read_file'))).toEqual({});
+  });
+
+  it('ignores non-PreToolUse events', () => {
+    const stop: HookContext = { event: 'Stop', sessionId: 's1' };
+    expect(hook(stop)).toEqual({});
+  });
+
+  it('passes through when the command is absent or empty', () => {
+    const noInput: HookContext = { event: 'PreToolUse', toolName: 'bash' };
+    expect(hook(noInput)).toEqual({});
+    expect(hook(preCtx(''))).toEqual({});
+  });
+});
+
+describe('release-boundary-detect wiring in the default registry', () => {
+  it('is registered and records approve (without blocking) for a boundary bash call', async () => {
+    const { registry } = createDefaultHookRegistry(undefined, 'cli');
+    const ctx: PreToolUseContext = {
+      event: 'PreToolUse',
+      toolName: 'bash',
+      input: { command: 'npm publish --provenance' },
+    };
+    // Must not throw (a block would throw HookBlockedError through dispatch).
+    const decision = await registry.dispatch(ctx);
+    expect(decision.decision).toBe('approve');
+    expect(decision.reason).toContain(RELEASE_BOUNDARY_DETECT_REASON_PREFIX);
+  });
+
+  it('leaves non-boundary bash calls untouched through the default registry', async () => {
+    const { registry } = createDefaultHookRegistry(undefined, 'cli');
+    const ctx: PreToolUseContext = {
+      event: 'PreToolUse',
+      toolName: 'bash',
+      input: { command: 'git push origin main' },
+    };
+    const decision = await registry.dispatch(ctx);
+    expect(decision.decision).not.toBe('approve');
+    expect(decision.decision).not.toBe('block');
+  });
+});

--- a/src/agent/release-boundary-detect.ts
+++ b/src/agent/release-boundary-detect.ts
@@ -1,0 +1,146 @@
+/**
+ * Release-boundary detector — an **observe-only** PreToolUse hook.
+ *
+ * Migrates the detection half of the `release-boundary-gate` gate-skill into
+ * deterministic harness code (Wave 1 slice 2 of the friction-substrate /
+ * gate-migration program — `.afk/plans/friction-substrate-and-gate-migration.md`;
+ * sibling of `safe-destruct-detect.ts`). It watches `bash` commands for the two
+ * boundary classes the skill defines and, on a match, emits a witnessed
+ * catch-record — **without blocking the command**:
+ *   - **publish / deploy boundary** — pushing a package to a registry (npm, PyPI,
+ *     crates.io, RubyGems), a container image to a registry, cutting a GitHub
+ *     release, or deploying infra (`terraform apply`, `kubectl apply`);
+ *   - **sync boundary** — mirroring or pushing across a visibility boundary
+ *     (`git push --mirror`, release-tag pushes).
+ *
+ * # Why observe-only (the interpreter-eval lesson)
+ *
+ * This whole program exists because an over-firing PreToolUse *hard block* (the
+ * interpreter-eval guard) generated 18 nights of self-inflicted friction. The
+ * plan's de-risking rule is "shadow-window before enforcing". PreToolUse cannot
+ * `injectContext` — the harness honors that field only for `SubagentStop` /
+ * `UserPromptSubmit` (see `hooks.ts`) — and a hard block would repeat the exact
+ * mistake, at higher cost here: a release/deploy is often exactly what the user
+ * asked for, so blocking it would be a false positive by construction. So this
+ * slice changes ZERO behavior: it only records that a boundary-crossing command
+ * was attempted. The records are the shadow window; a later slice uses their
+ * real-world frequency per pattern to calibrate which (if any) warrant the
+ * skill's real value — a pre-boundary living-artifact check, not a block.
+ *
+ * # How the catch-record is emitted (the `approve` outcome)
+ *
+ * A PreToolUse handler can only `block` or pass; passing (`{}`) is not witnessed
+ * with a reason. To emit a filterable catch-record while letting the command
+ * run, this hook returns the otherwise-unused `decision: 'approve'` outcome with
+ * a structured `reason`. `approve`:
+ *   - is behaviorally identical to unset — `isBlocking()` (`hook-registry.ts`)
+ *     checks only `block` / `continue:false`, so the command proceeds and the
+ *     other PreToolUse gates (safe-destruct, afk-mode, bash-restriction, ...)
+ *     still run;
+ *   - is recorded by `dispatchPreToolUse` as a `hook_decision` event carrying
+ *     the `reason` (`subagent-hooks.ts`), which is the Wave-4 substrate signal;
+ *   - is IGNORED by the mechanical friction detectors (they count `block`
+ *     outcomes / error `failureClass`es — see `improve/scan/detectors`), so
+ *     these observations never masquerade as new friction.
+ * Only `safe-destruct-detect` also returns `approve`; the distinct `reason`
+ * prefix keeps release-boundary observations cleanly separable in the trace.
+ *
+ * Registered unconditionally on ALL surfaces (including headless/autonomous,
+ * where an unattended publish/deploy is most consequential and least observed)
+ * precisely because it never blocks — it is safe everywhere.
+ *
+ * @module agent/release-boundary-detect
+ */
+
+import type { HookContext, HookDecision } from './hooks.js';
+
+/**
+ * Stable prefix on the emitted `reason`. Exported so the telemetry substrate,
+ * tests, and `afk trace show` can match release-boundary observations by prefix.
+ */
+export const RELEASE_BOUNDARY_DETECT_REASON_PREFIX =
+  'release-boundary observe-only: publish/deploy/sync-boundary command';
+
+/**
+ * Curated publish / deploy / sync boundary command patterns.
+ *
+ * Calibration bias: high-signal only — commands that cross a real release,
+ * deploy, or visibility boundary, where the skill's living-artifact contract
+ * (changelogs, generated docs, lock files, version manifests) is structurally
+ * at risk. Routine pre-boundary steps (`npm version`, `git tag`, `git push`
+ * without `--mirror`/`--tags`) are deliberately NOT flagged. Each regex avoids
+ * nested quantifiers so the scan is linear (no ReDoS); `[^|&;\n]*` bounds a
+ * match to a single command segment.
+ *
+ * Reused by the future block/nudge slice — keep it the single source of truth.
+ */
+const RELEASE_BOUNDARY_PATTERNS: readonly { readonly id: string; readonly re: RegExp }[] = [
+  // --- package-registry publish ----------------------------------------------
+  { id: 'npm-publish', re: /\bnpm\s+publish\b/i },
+  { id: 'pnpm-publish', re: /\bpnpm\s+publish\b/i },
+  // yarn classic (`yarn publish`) and berry (`yarn npm publish`).
+  { id: 'yarn-publish', re: /\byarn\s+(?:npm\s+)?publish\b/i },
+  { id: 'cargo-publish', re: /\bcargo\s+publish\b/i },
+  { id: 'pypi-twine-upload', re: /\btwine\s+upload\b/i },
+  { id: 'poetry-publish', re: /\bpoetry\s+publish\b/i },
+  { id: 'gem-push', re: /\bgem\s+push\b/i },
+
+  // --- container registry -----------------------------------------------------
+  { id: 'docker-push', re: /\bdocker\s+(?:image\s+)?push\b/i },
+
+  // --- release cut ------------------------------------------------------------
+  { id: 'gh-release-create', re: /\bgh\s+release\s+create\b/i },
+
+  // --- infra deploy -----------------------------------------------------------
+  { id: 'terraform-apply', re: /\bterraform\s+apply\b/i },
+  { id: 'kubectl-apply', re: /\bkubectl\s+apply\b/i },
+
+  // --- sync / visibility boundary --------------------------------------------
+  // A full mirror push copies every ref across a boundary.
+  { id: 'git-push-mirror', re: /\bgit\s+push\b[^|&;\n]*--mirror\b/i },
+  // Pushing release tags is the canonical cut-a-release sync signal.
+  { id: 'git-push-tags', re: /\bgit\s+push\b[^|&;\n]*--(?:tags|follow-tags)\b/i },
+];
+
+/**
+ * Return the ids of every release-boundary pattern the command matches (empty
+ * when none). Pure and stateless — no global-flag regexes, so `.test()` is safe
+ * to call repeatedly. Exported for the block/nudge slice and for tests.
+ */
+export function detectReleaseBoundaryCommands(command: string): string[] {
+  if (!command) return [];
+  const hits: string[] = [];
+  for (const { id, re } of RELEASE_BOUNDARY_PATTERNS) {
+    if (re.test(command)) hits.push(id);
+  }
+  return hits;
+}
+
+/**
+ * Create the observe-only release-boundary PreToolUse hook.
+ *
+ * Stateless (no dedup): every boundary-crossing attempt is a distinct data
+ * point — a session that publishes twice is exactly the signal the shadow
+ * window wants to surface, so occurrences are not collapsed.
+ */
+export function createReleaseBoundaryDetect(): (context: HookContext) => HookDecision {
+  return function releaseBoundaryDetect(context: HookContext): HookDecision {
+    if (context.event !== 'PreToolUse') return {};
+    if (context.toolName !== 'bash') return {};
+
+    const input = context.input as Record<string, unknown> | undefined;
+    const command = typeof input?.['command'] === 'string' ? input['command'] : '';
+    if (!command) return {};
+
+    const matched = detectReleaseBoundaryCommands(command);
+    if (matched.length === 0) return {};
+
+    // approve == allow (never blocks; see module header) but carries a reason
+    // that lands as a `hook_decision` catch-record for the reasoning-failure
+    // substrate.
+    return {
+      decision: 'approve',
+      reason: `${RELEASE_BOUNDARY_DETECT_REASON_PREFIX} [${matched.join(', ')}]`,
+    };
+  };
+}


### PR DESCRIPTION
## What

Wave 1 **slice 2** of the friction-substrate / gate-skill→hook migration program — the direct sibling of #492 (safe-destruct). Migrates the *detection* half of the `release-boundary-gate` gate-skill into a deterministic **observe-only** PreToolUse hook.

A new hook watches `bash` for commands that cross:
- a **publish/deploy boundary** — `npm`/`pnpm`/`yarn`/`cargo`/`twine`/`poetry`/`gem` publish, `docker push`, `gh release create`, `terraform`/`kubectl apply`;
- a **sync boundary** — `git push --mirror` / `--tags` / `--follow-tags`.

On a match it emits a `hook_decision` catch-record via the otherwise-unused `decision: 'approve'` outcome — **without blocking**. Pattern classes are taken from the user-scope `release-boundary-gate` SKILL.md's two boundary tracks.

## Why observe-only (unchanged from slice 1)

PreToolUse **cannot** `injectContext` (the harness honors that field only for `SubagentStop`/`UserPromptSubmit`), and a hard block would repeat the interpreter-eval backfire that started this program — worse here, since a release/deploy is often exactly what was asked, so a block would be a false positive by construction. So this slice changes **zero behavior**: it only records that a boundary-crossing command was attempted. The records are the shadow window; a later slice uses their real-world per-pattern frequency to calibrate the skill's real value (a pre-boundary living-artifact check), not a block. The `approve` record is filterable in the trace and ignored by the mechanical friction detectors, so it never masquerades as new friction.

## Sequencing notes (for the reviewer)

- **Building release-boundary-gate, not target-lock** (the plan's next-listed item). The proven observe-only pattern is *"match a command string → `approve` record"* (stateless, deterministic). release-boundary-gate fits it cleanly; target-lock does not — the plan itself describes target-lock as *"edit/write/rm gated on a session verdict-flag"*, i.e. inherently a stateful **block** gate whose real trigger (a colloquially-named refactor target) lives in the user's prompt, invisible to a PreToolUse hook. target-lock's natural first form is a later enforce slice.
- **safe-destruct calibration deferred, not skipped** — only 3 catch-records exist across all traces since #492 merged (~1 day); that is not a calibratable dataset. It accrues passively while this independent detector banks its own shadow signal.

## Changes
- `src/agent/release-boundary-detect.ts` — detector + curated ReDoS-safe pattern table (single source of truth for the future block/nudge slice) + `createReleaseBoundaryDetect()`.
- `src/agent/default-hook-registry.ts` — registered unconditionally right after safe-destruct.
- `src/agent/release-boundary-detect.test.ts` — mirrors safe-destruct's three contracts.
- `src/agent/hooks/config-bridge.test.ts` — bump the two always-on PreToolUse built-in count assertions (2→3, 3→4) + comments.

Scope deliberately mirrors #492 exactly (no `GATE_SKILLS` roster change — that roster tags *dispatched skills* and was not touched by #492 either).

## Testing
- `pnpm lint` (tsc --noEmit) — clean
- full `vitest run` — **11260 passed / 0 failed** (14 skipped)
- `pnpm audit:sdk:check` / `audit:env:check` / `scan:env:check` — all clean

## Follow-ups
- Calibrate safe-destruct + release-boundary once real catch-records accrue.
- target-lock and the remaining Wave-1/2/3 items per `.afk/plans/friction-substrate-and-gate-migration.md`.
