### PR TITLE
refactor(openai-compatible): dedupe runIteration wire branches — finish query.ts split (#365)

### DIFF
--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -58,11 +58,9 @@ import {
 import { buildMessages, buildUserContent, type OpenAIMessage } from './messages.js';
 import { supportsVision } from '../../model-capabilities.js';
 import {
-  createStreamState,
   translateChunk,
   usageFromState,
   finalizedToolCalls,
-  isToolCallStop,
   type OpenAIChunk,
   type StreamState,
 } from './translate.js';
@@ -71,15 +69,13 @@ import {
   type OpenAIFunctionTool,
 } from './loop.js';
 import { translateResponsesEvent, type ResponsesStreamEvent } from './responses-translate.js';
-import { buildResponsesRequest } from './responses-messages.js';
-import { resolveWireMode, envFlagEnabled, isClaudeFamilyModel, DEFAULT_RESPONSES_INSTRUCTIONS, type WireMode } from './responses-config.js';
+import { resolveWireMode, envFlagEnabled, isClaudeFamilyModel, type WireMode } from './responses-config.js';
 import { env } from '../../../config/env.js';
 import type { ToolDispatcher } from '../anthropic-direct/tool-dispatcher.js';
 import { contextWindowTokensUsed, buildContextUsageFields } from '../shared/auto-compact.js';
 import { PLAN_MODE_ADDENDUM_TEXT } from '../shared/plan-mode-addendum.js';
 import { AFK_MODE_ADDENDUM_TEXT } from '../shared/afk-mode-addendum.js';
 import { EXIT_PLAN_MODE_TOOL_NAME } from '../../tools/handlers/exit-plan-mode.js';
-import { sleepWithAbort } from '../shared/sleep-with-abort.js';
 import { summarizeToolInput } from '../shared/tool-input-summary.js';
 import { dispatchAndAppendToolCalls } from './query/dispatch-append.js';
 import {
@@ -89,19 +85,15 @@ import {
   shouldWindDown,
 } from '../shared/tool-loop-cap.js';
 import {
-  MAX_CONNECTION_RETRIES,
-  MAX_STREAM_RETRIES,
-  isRetryableConnectionError,
-  isRetryableStreamError,
-  computeBackoffDelay,
-} from './query/retry.js';
-import {
-  resolveEffectiveMaxOutputTokens,
-  resolveStreamingMaxTokens,
   normalizePermissionMode,
   resolveReasoningEffort,
 } from './query/model-params.js';
 import { resolveClientFactory } from './query/client.js';
+import { driveStream, type IterationResult } from './query/stream-drive.js';
+import {
+  buildChatCompletionsRequestBody,
+  buildResponsesRequestBody,
+} from './query/request-body.js';
 
 // Re-exported from the extracted query/ submodules so existing import sites
 // (sibling tests + index.ts) keep resolving these from './query.js'.
@@ -163,15 +155,6 @@ export interface OpenAICompatibleQueryOptions {
 }
 
 /** Internal record used to drive the per-turn iteration loop. */
-interface IterationResult {
-  state: StreamState;
-  events: ProviderEvent[];
-  /** Final assistant text accumulated this iteration. */
-  text: string;
-  /** True when this iteration ended in tool_calls (we need to dispatch and loop). */
-  needsToolDispatch: boolean;
-}
-
 export class OpenAICompatibleQuery implements ProviderQuery {
   private readonly client: OpenAI;
   private readonly opts: OpenAICompatibleQueryOptions;
@@ -671,6 +654,18 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     }
     const activeTools = windDown ? undefined : this.activeOpenAITools();
 
+    // Shared context for the retry/stream-drive skeleton (query/stream-drive.ts).
+    // Both wire branches build their request body, then hand off to driveStream
+    // with a per-wire strategy — the connection/mid-stream retry, once-only
+    // model_ttfb emission, and clean-completion return live in one place.
+    const driveCtx = {
+      controller,
+      traceWriter: this.traceWriter,
+      initSessionId: this.initSessionId,
+      currentModel: this.currentModel,
+      isClosed: () => this.closed,
+    };
+
     if (this.wireMode === 'responses') {
       const isChatGptBackend = this.opts.auth.source === 'chatgpt-oauth';
 
@@ -692,250 +687,50 @@ export class OpenAICompatibleQuery implements ProviderQuery {
         return null;
       }
 
-      // Responses API path. `messages` (built + plan-mode-adjusted above) is
-      // converted to the Responses input shape; the system prompt becomes
-      // `instructions`, tool calls/results become function_call/_output items.
-      const req = buildResponsesRequest(messages, activeTools);
-      const requestBody: Record<string, unknown> = {
-        model: this.currentModel,
-        input: req.input,
-        stream: true,
-      };
-      // Output-token cap. The Responses API uses `max_output_tokens` — NOT Chat
-      // Completions' `max_tokens`/`max_completion_tokens`. The private ChatGPT/
-      // Codex subscription backend rejects *every* output-cap parameter with an
-      // opaque HTTP 400 (`{"detail":"Unsupported parameter: max_tokens"}`, and
-      // likewise for `max_output_tokens`), so omit the cap there entirely and
-      // let the backend apply its own limit. (Sending `max_tokens` here is what
-      // made every ChatGPT-subscription request fail.)
-      if (!isChatGptBackend) {
-        requestBody['max_output_tokens'] = resolveEffectiveMaxOutputTokens(
-          this.currentModel,
-          this.opts.config.maxOutputTokens,
-        );
-      }
-      // The private ChatGPT backend (subscription path) has two hard
-      // requirements the public Responses API does not: a non-empty
-      // `instructions`, and `store: false`. Scope both to that path so the
-      // public API-key path keeps its defaults.
-      const instructions =
-        req.instructions ?? (isChatGptBackend ? DEFAULT_RESPONSES_INSTRUCTIONS : undefined);
-      if (instructions !== undefined) requestBody['instructions'] = instructions;
-      if (isChatGptBackend) requestBody['store'] = false;
-      if (req.tools && req.tools.length > 0) requestBody['tools'] = req.tools;
-      // Forward reasoning effort for o-series models on the Responses API.
-      // Uses the `reasoning: { effort }` shape per OpenAI's Responses API spec.
-      const responsesEffort = resolveReasoningEffort(this.opts.config.effort, this.currentModel);
-      if (responsesEffort !== undefined) {
-        requestBody['reasoning'] = { effort: responsesEffort };
-      }
-
-      // Retry loop: connection-phase + mid-stream retry with exponential
-      // backoff. Mirrors the Anthropic provider's createWithRetry + overload
-      // retry pattern (see `anthropic-direct/loop.ts`). State is reset on each
-      // retry so the re-driven request starts from a clean slate.
-      let streamRetries = 0;
-      for (;;) {
-        const state = createStreamState();
-
-        // Witness layer: stamp request-initiation time for model_ttfb below.
-        const requestStartedAt = Date.now();
-
-        // ── Connection-phase retry ──────────────────────────────────────
-        let stream: AsyncIterable<ResponsesStreamEvent>;
-        let connectionError: unknown = null;
-        for (let attempt = 0; ; attempt++) {
-          try {
-            stream = (await this.client.responses.create(requestBody as never, {
-              signal: controller.signal,
-            })) as unknown as AsyncIterable<ResponsesStreamEvent>;
-            break; // connection succeeded
-          } catch (err) {
-            if (controller.signal.aborted) return null;
-            if (isRetryableConnectionError(err) && attempt < MAX_CONNECTION_RETRIES) {
-              const delay = computeBackoffDelay(attempt);
-              await sleepWithAbort(delay, controller.signal);
-              if (controller.signal.aborted) return null;
-              continue;
-            }
-            connectionError = err;
-            break;
-          }
-        }
-
-        if (connectionError !== null) {
-          yield { type: 'error', error: this.clarifyResponsesError(connectionError, isChatGptBackend) };
-          return null;
-        }
-
-        // ── Mid-stream consumption with retry ───────────────────────────
-        let streamError: unknown = null;
-        // Witness layer: emit model_ttfb exactly once per API call, on the
-        // first translated stream event. Reset per for(;;) iteration so each
-        // retry-driven call reports its own time-to-first-byte. Mirrors
-        // anthropic-direct/loop.ts:307–327.
-        let ttfbEmitted = false;
-        try {
-          for await (const event of stream!) {
-            if (this.closed) return null;
-            for (const ev of translateResponsesEvent(event, state, this.initSessionId)) {
-              if (!ttfbEmitted) {
-                ttfbEmitted = true;
-                void emitSessionPhase(this.traceWriter, {
-                  phase: 'model_ttfb',
-                  durationMs: Date.now() - requestStartedAt,
-                  resolvedModel: this.currentModel,
-                });
-              }
-              yield ev;
-            }
-          }
-        } catch (err) {
-          if (controller.signal.aborted) return null;
-          if (isRetryableStreamError(err) && streamRetries < MAX_STREAM_RETRIES) {
-            streamRetries++;
-            yield { type: 'stream.retry', sessionId: this.initSessionId };
-            await sleepWithAbort(
-              computeBackoffDelay(streamRetries - 1),
-              controller.signal,
-            );
-            if (controller.signal.aborted) return null;
-            continue; // retry the whole iteration
-          }
-          streamError = err;
-        }
-
-        if (streamError !== null) {
-          yield { type: 'error', error: this.clarifyResponsesError(streamError, isChatGptBackend) };
-          return null;
-        }
-
-        // Clean completion — return the result.
-        return {
-          state,
-          events: [],
-          text: state.assistantText,
-          needsToolDispatch: isToolCallStop(state) && state.toolCallsByIndex.size > 0,
-        };
-      }
-    } else {
-      const requestBody: Record<string, unknown> = {
+      // Responses API path. Request-body assembly (incl. the ChatGPT-backend
+      // quirks) lives in query/request-body.ts.
+      const requestBody = buildResponsesRequestBody({
         model: this.currentModel,
         messages,
-        stream: true,
-        stream_options: { include_usage: true },
-      };
-      // Thread the output-token cap into the streaming request so callers can
-      // bound output length (parity with Anthropic's always-forwarded
-      // max_tokens).  Reuses the o-series field-selection logic from
-      // oneshot.ts:91–96.
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      Object.assign(requestBody, resolveStreamingMaxTokens(
-        this.currentModel,
-        this.opts.config.maxOutputTokens,
-      ));
-      // Only attach `tools` when there are any to advertise THIS turn — empty
-      // arrays make some providers reject the request. `activeOpenAITools()`
-      // drops the plan-exit tool on non-plan turns (resident-but-gated); on a
-      // wind-down round `activeTools` is undefined (tools stripped, see above).
-      if (activeTools && activeTools.length > 0) {
-        requestBody['tools'] = activeTools;
-      }
-      // Forward reasoning effort for o-series models on Chat Completions.
-      // Uses the `reasoning_effort` field per OpenAI's Chat Completions API spec.
-      const chatEffort = resolveReasoningEffort(this.opts.config.effort, this.currentModel);
-      if (chatEffort !== undefined) {
-        requestBody['reasoning_effort'] = chatEffort;
-      }
+        activeTools,
+        maxOutputTokens: this.opts.config.maxOutputTokens,
+        effort: this.opts.config.effort,
+        isChatGptBackend,
+      });
 
-      // Retry loop: connection-phase + mid-stream retry with exponential
-      // backoff. Same pattern as the Responses path above.
-      let streamRetries = 0;
-      for (;;) {
-        const state = createStreamState();
+      // Retry / stream-drive is shared with the Chat-Completions branch — see
+      // query/stream-drive.ts. Only the four per-wire deltas differ here:
+      // client call, event type, translator, and error clarification.
+      return yield* driveStream<ResponsesStreamEvent>(driveCtx, {
+        createStream: async (signal) =>
+          (await this.client.responses.create(requestBody as never, {
+            signal,
+          })) as unknown as AsyncIterable<ResponsesStreamEvent>,
+        translate: (event, state) => translateResponsesEvent(event, state, this.initSessionId),
+        clarifyError: (err) => this.clarifyResponsesError(err, isChatGptBackend),
+      });
+    } else {
+      // Chat Completions path. Request-body assembly lives in
+      // query/request-body.ts.
+      const requestBody = buildChatCompletionsRequestBody({
+        model: this.currentModel,
+        messages,
+        activeTools,
+        maxOutputTokens: this.opts.config.maxOutputTokens,
+        effort: this.opts.config.effort,
+      });
 
-        // Witness layer: stamp request-initiation time for model_ttfb below.
-        const requestStartedAt = Date.now();
-
-        // ── Connection-phase retry ──────────────────────────────────────
-        let stream: AsyncIterable<OpenAIChunk>;
-        let connectionError: unknown = null;
-        for (let attempt = 0; ; attempt++) {
-          try {
-            stream = (await this.client.chat.completions.create(requestBody as never, {
-              signal: controller.signal,
-            })) as unknown as AsyncIterable<OpenAIChunk>;
-            break; // connection succeeded
-          } catch (err) {
-            if (controller.signal.aborted) return null;
-            if (isRetryableConnectionError(err) && attempt < MAX_CONNECTION_RETRIES) {
-              const delay = computeBackoffDelay(attempt);
-              await sleepWithAbort(delay, controller.signal);
-              if (controller.signal.aborted) return null;
-              continue;
-            }
-            connectionError = err;
-            break;
-          }
-        }
-
-        if (connectionError !== null) {
-          const e = connectionError instanceof Error ? connectionError : new Error(String(connectionError));
-          yield { type: 'error', error: e };
-          return null;
-        }
-
-        // ── Mid-stream consumption with retry ───────────────────────────
-        let streamError: unknown = null;
-        // Witness layer: emit model_ttfb exactly once per API call, on the
-        // first translated stream event. Reset per for(;;) iteration so each
-        // retry-driven call reports its own time-to-first-byte. Mirrors
-        // anthropic-direct/loop.ts:307–327.
-        let ttfbEmitted = false;
-        try {
-          for await (const chunk of stream!) {
-            if (this.closed) return null;
-            for (const ev of translateChunk(chunk, state, this.initSessionId)) {
-              if (!ttfbEmitted) {
-                ttfbEmitted = true;
-                void emitSessionPhase(this.traceWriter, {
-                  phase: 'model_ttfb',
-                  durationMs: Date.now() - requestStartedAt,
-                  resolvedModel: this.currentModel,
-                });
-              }
-              yield ev;
-            }
-          }
-        } catch (err) {
-          if (controller.signal.aborted) return null;
-          if (isRetryableStreamError(err) && streamRetries < MAX_STREAM_RETRIES) {
-            streamRetries++;
-            yield { type: 'stream.retry', sessionId: this.initSessionId };
-            await sleepWithAbort(
-              computeBackoffDelay(streamRetries - 1),
-              controller.signal,
-            );
-            if (controller.signal.aborted) return null;
-            continue; // retry the whole iteration
-          }
-          streamError = err;
-        }
-
-        if (streamError !== null) {
-          const e = streamError instanceof Error ? streamError : new Error(String(streamError));
-          yield { type: 'error', error: e };
-          return null;
-        }
-
-        // Clean completion — return the result.
-        return {
-          state,
-          events: [],
-          text: state.assistantText,
-          needsToolDispatch: isToolCallStop(state) && state.toolCallsByIndex.size > 0,
-        };
-      }
+      // Retry / stream-drive is shared with the Responses branch — see
+      // query/stream-drive.ts. This wire differs only in the client call, the
+      // event type, the translator, and plain Error coercion (no clarify step).
+      return yield* driveStream<OpenAIChunk>(driveCtx, {
+        createStream: async (signal) =>
+          (await this.client.chat.completions.create(requestBody as never, {
+            signal,
+          })) as unknown as AsyncIterable<OpenAIChunk>,
+        translate: (event, state) => translateChunk(event, state, this.initSessionId),
+        clarifyError: (err) => (err instanceof Error ? err : new Error(String(err))),
+      });
     }
   }
 

--- a/src/agent/providers/openai-compatible/query/request-body.test.ts
+++ b/src/agent/providers/openai-compatible/query/request-body.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for the extracted per-wire request-body builders (#365).
+ * Lock the wire-specific body shapes — especially the private ChatGPT/Codex
+ * backend gating (no output cap; forced instructions + store:false) — that used
+ * to live inline in runIteration.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { OpenAIMessage } from '../messages.js';
+import type { OpenAIFunctionTool } from '../loop.js';
+import { buildChatCompletionsRequestBody, buildResponsesRequestBody } from './request-body.js';
+
+const MESSAGES: OpenAIMessage[] = [
+  { role: 'system', content: 'sys' },
+  { role: 'user', content: 'hi' },
+];
+
+const TOOLS = [
+  { type: 'function', function: { name: 'do_thing', parameters: { type: 'object', properties: {} } } },
+] as unknown as OpenAIFunctionTool[];
+
+describe('buildChatCompletionsRequestBody', () => {
+  it('always sets model, messages, stream, and usage-inclusive stream_options', () => {
+    const body = buildChatCompletionsRequestBody({
+      model: 'gpt-4o',
+      messages: MESSAGES,
+      activeTools: undefined,
+      maxOutputTokens: 1024,
+      effort: undefined,
+    });
+    expect(body['model']).toBe('gpt-4o');
+    expect(body['messages']).toBe(MESSAGES);
+    expect(body['stream']).toBe(true);
+    expect(body['stream_options']).toEqual({ include_usage: true });
+  });
+
+  it('attaches tools only when non-empty', () => {
+    const withTools = buildChatCompletionsRequestBody({
+      model: 'gpt-4o',
+      messages: MESSAGES,
+      activeTools: TOOLS,
+      maxOutputTokens: undefined,
+      effort: undefined,
+    });
+    expect(withTools['tools']).toBe(TOOLS);
+
+    const noTools = buildChatCompletionsRequestBody({
+      model: 'gpt-4o',
+      messages: MESSAGES,
+      activeTools: [],
+      maxOutputTokens: undefined,
+      effort: undefined,
+    });
+    expect('tools' in noTools).toBe(false);
+  });
+});
+
+describe('buildResponsesRequestBody', () => {
+  it('builds the Responses shape (input + stream) with an output cap on the public path', () => {
+    const body = buildResponsesRequestBody({
+      model: 'gpt-4o',
+      messages: MESSAGES,
+      activeTools: undefined,
+      maxOutputTokens: 2048,
+      effort: undefined,
+      isChatGptBackend: false,
+    });
+    expect(body['stream']).toBe(true);
+    expect('input' in body).toBe(true);
+    // Public API-key path applies the output cap and does NOT force store/instructions.
+    expect('max_output_tokens' in body).toBe(true);
+    expect('store' in body).toBe(false);
+  });
+
+  it('omits the output cap and forces store:false + instructions on the ChatGPT backend', () => {
+    const body = buildResponsesRequestBody({
+      model: 'gpt-5.5',
+      messages: MESSAGES,
+      activeTools: undefined,
+      maxOutputTokens: 2048,
+      effort: undefined,
+      isChatGptBackend: true,
+    });
+    // The subscription backend 400s on every output-cap param — must be absent.
+    expect('max_output_tokens' in body).toBe(false);
+    expect(body['store']).toBe(false);
+    // A non-empty instructions is required on this backend.
+    expect(typeof body['instructions']).toBe('string');
+    expect((body['instructions'] as string).length).toBeGreaterThan(0);
+  });
+});

--- a/src/agent/providers/openai-compatible/query/request-body.ts
+++ b/src/agent/providers/openai-compatible/query/request-body.ts
@@ -1,0 +1,101 @@
+/**
+ * Per-wire streaming request-body assembly for
+ * {@link OpenAICompatibleQuery.runIteration}.
+ *
+ * The Responses-API and Chat-Completions wires build different request bodies
+ * (`input` + `max_output_tokens` + `reasoning:{effort}` vs `messages` +
+ * `max_tokens` + `reasoning_effort`), with the Responses path carrying the
+ * private ChatGPT/Codex subscription-backend quirks. Both were inline in
+ * `runIteration`; extracting them here keeps that method focused on the shared
+ * retry/stream-drive handoff. Pure functions — no I/O, no control flow.
+ *
+ * @module agent/providers/openai-compatible/query/request-body
+ */
+
+import type { EffortLevel } from '../../../types/sdk-types.js';
+import type { OpenAIMessage } from '../messages.js';
+import type { OpenAIFunctionTool } from '../loop.js';
+import { buildResponsesRequest } from '../responses-messages.js';
+import { DEFAULT_RESPONSES_INSTRUCTIONS } from '../responses-config.js';
+import {
+  resolveEffectiveMaxOutputTokens,
+  resolveReasoningEffort,
+  resolveStreamingMaxTokens,
+} from './model-params.js';
+
+/** Inputs common to both wire request-body builders. */
+export interface RequestBodyInputs {
+  model: string;
+  messages: OpenAIMessage[];
+  /** Tools to advertise this turn; undefined on a wind-down round (tools stripped). */
+  activeTools: OpenAIFunctionTool[] | undefined;
+  maxOutputTokens: number | undefined;
+  effort: EffortLevel | undefined;
+}
+
+/**
+ * Build the Responses-API streaming request body. `messages` (built +
+ * plan-mode-adjusted upstream) is converted to the Responses input shape; the
+ * system prompt becomes `instructions`, tool calls/results become
+ * function_call/_output items.
+ *
+ * `isChatGptBackend` scopes the private subscription-path quirks: it rejects
+ * *every* output-cap parameter with an opaque HTTP 400, so the cap is omitted
+ * there; and it requires a non-empty `instructions` plus `store: false`, which
+ * the public API-key path does not.
+ */
+export function buildResponsesRequestBody(
+  args: RequestBodyInputs & { isChatGptBackend: boolean },
+): Record<string, unknown> {
+  const req = buildResponsesRequest(args.messages, args.activeTools);
+  const requestBody: Record<string, unknown> = {
+    model: args.model,
+    input: req.input,
+    stream: true,
+  };
+  // Output-token cap. The Responses API uses `max_output_tokens` — NOT Chat
+  // Completions' `max_tokens`/`max_completion_tokens`. Omit it entirely on the
+  // ChatGPT/Codex subscription backend (it 400s on every output-cap param).
+  if (!args.isChatGptBackend) {
+    requestBody['max_output_tokens'] = resolveEffectiveMaxOutputTokens(args.model, args.maxOutputTokens);
+  }
+  const instructions =
+    req.instructions ?? (args.isChatGptBackend ? DEFAULT_RESPONSES_INSTRUCTIONS : undefined);
+  if (instructions !== undefined) requestBody['instructions'] = instructions;
+  if (args.isChatGptBackend) requestBody['store'] = false;
+  if (req.tools && req.tools.length > 0) requestBody['tools'] = req.tools;
+  // Forward reasoning effort for o-series models via the Responses API's
+  // `reasoning: { effort }` shape.
+  const responsesEffort = resolveReasoningEffort(args.effort, args.model);
+  if (responsesEffort !== undefined) {
+    requestBody['reasoning'] = { effort: responsesEffort };
+  }
+  return requestBody;
+}
+
+/** Build the Chat-Completions streaming request body. */
+export function buildChatCompletionsRequestBody(args: RequestBodyInputs): Record<string, unknown> {
+  const requestBody: Record<string, unknown> = {
+    model: args.model,
+    messages: args.messages,
+    stream: true,
+    stream_options: { include_usage: true },
+  };
+  // Thread the output-token cap into the streaming request (parity with
+  // Anthropic's always-forwarded max_tokens); reuses the o-series
+  // field-selection logic.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  Object.assign(requestBody, resolveStreamingMaxTokens(args.model, args.maxOutputTokens));
+  // Only attach `tools` when there are any to advertise — empty arrays make
+  // some providers reject the request.
+  if (args.activeTools && args.activeTools.length > 0) {
+    requestBody['tools'] = args.activeTools;
+  }
+  // Forward reasoning effort for o-series models via Chat Completions'
+  // `reasoning_effort` field.
+  const chatEffort = resolveReasoningEffort(args.effort, args.model);
+  if (chatEffort !== undefined) {
+    requestBody['reasoning_effort'] = chatEffort;
+  }
+  return requestBody;
+}

--- a/src/agent/providers/openai-compatible/query/stream-drive.ts
+++ b/src/agent/providers/openai-compatible/query/stream-drive.ts
@@ -1,0 +1,156 @@
+/**
+ * Shared retry / stream-drive skeleton for
+ * {@link OpenAICompatibleQuery.runIteration}.
+ *
+ * The Responses-API and Chat-Completions wire branches ran two near-identical
+ * copies of the same three-phase scaffolding — build request body (done by the
+ * caller), connection-phase retry, mid-stream consume with once-only
+ * `model_ttfb` emission + stream-retry, and a clean-completion return. Only four
+ * things differed per wire: how the stream is opened, its raw event type, how a
+ * raw event is translated, and how an error is surfaced. This module holds the
+ * one shared driver, parameterized by a {@link StreamDriveStrategy}; each wire
+ * branch now just builds its request body and calls {@link driveStream}.
+ *
+ * Behavior is identical to the two former inline copies (retry counts, abort
+ * checks, TTFB-once semantics, and the return shape are preserved verbatim).
+ *
+ * @module agent/providers/openai-compatible/query/stream-drive
+ */
+
+import type { ProviderEvent } from '../../../provider.js';
+import { emitSessionPhase } from '../../../trace/emit.js';
+import type { TraceWriter } from '../../../trace/index.js';
+import { sleepWithAbort } from '../../shared/sleep-with-abort.js';
+import { createStreamState, isToolCallStop, type StreamState } from '../translate.js';
+import {
+  MAX_CONNECTION_RETRIES,
+  MAX_STREAM_RETRIES,
+  computeBackoffDelay,
+  isRetryableConnectionError,
+  isRetryableStreamError,
+} from './retry.js';
+
+/** Result of a single model round-trip, consumed by the tool-loop orchestrator. */
+export interface IterationResult {
+  state: StreamState;
+  events: ProviderEvent[];
+  /** Final assistant text accumulated this iteration. */
+  text: string;
+  /** True when this iteration ended in tool_calls (we need to dispatch and loop). */
+  needsToolDispatch: boolean;
+}
+
+/** The four per-wire deltas the shared driver is parameterized over. */
+export interface StreamDriveStrategy<TEvent> {
+  /** Open the streaming connection for this wire (throws on connection failure). */
+  createStream: (signal: AbortSignal) => Promise<AsyncIterable<TEvent>>;
+  /** Translate one raw wire event into zero or more ProviderEvents, mutating `state`. */
+  translate: (event: TEvent, state: StreamState) => Iterable<ProviderEvent>;
+  /** Coerce a connection- or stream-phase error into the Error surfaced for this wire. */
+  clarifyError: (err: unknown) => Error;
+}
+
+/** Session-scoped context the driver needs but does not own. */
+export interface StreamDriveContext {
+  controller: AbortController;
+  traceWriter: TraceWriter | undefined;
+  initSessionId: string;
+  currentModel: string;
+  /** Live liveness check — the query sets this true on close(). */
+  isClosed: () => boolean;
+}
+
+/**
+ * Drive one iteration's streaming round-trip with connection + mid-stream retry.
+ * Yields the translated {@link ProviderEvent}s and returns the
+ * {@link IterationResult} on clean completion, or `null` on abort / close /
+ * surfaced error (after yielding the `error` event in the error case).
+ */
+export async function* driveStream<TEvent>(
+  ctx: StreamDriveContext,
+  strategy: StreamDriveStrategy<TEvent>,
+): AsyncGenerator<ProviderEvent, IterationResult | null> {
+  // Retry loop: connection-phase + mid-stream retry with exponential backoff.
+  // Mirrors the Anthropic provider's createWithRetry + overload retry pattern
+  // (see `anthropic-direct/loop.ts`). State is reset on each retry so the
+  // re-driven request starts from a clean slate.
+  let streamRetries = 0;
+  for (;;) {
+    const state = createStreamState();
+
+    // Witness layer: stamp request-initiation time for model_ttfb below.
+    const requestStartedAt = Date.now();
+
+    // ── Connection-phase retry ──────────────────────────────────────
+    let stream: AsyncIterable<TEvent>;
+    let connectionError: unknown = null;
+    for (let attempt = 0; ; attempt++) {
+      try {
+        stream = await strategy.createStream(ctx.controller.signal);
+        break; // connection succeeded
+      } catch (err) {
+        if (ctx.controller.signal.aborted) return null;
+        if (isRetryableConnectionError(err) && attempt < MAX_CONNECTION_RETRIES) {
+          const delay = computeBackoffDelay(attempt);
+          await sleepWithAbort(delay, ctx.controller.signal);
+          if (ctx.controller.signal.aborted) return null;
+          continue;
+        }
+        connectionError = err;
+        break;
+      }
+    }
+
+    if (connectionError !== null) {
+      yield { type: 'error', error: strategy.clarifyError(connectionError) };
+      return null;
+    }
+
+    // ── Mid-stream consumption with retry ───────────────────────────
+    let streamError: unknown = null;
+    // Witness layer: emit model_ttfb exactly once per API call, on the first
+    // translated stream event. Reset per for(;;) iteration so each
+    // retry-driven call reports its own time-to-first-byte. Mirrors
+    // anthropic-direct/loop.ts:307–327.
+    let ttfbEmitted = false;
+    try {
+      for await (const event of stream!) {
+        if (ctx.isClosed()) return null;
+        for (const ev of strategy.translate(event, state)) {
+          if (!ttfbEmitted) {
+            ttfbEmitted = true;
+            void emitSessionPhase(ctx.traceWriter, {
+              phase: 'model_ttfb',
+              durationMs: Date.now() - requestStartedAt,
+              resolvedModel: ctx.currentModel,
+            });
+          }
+          yield ev;
+        }
+      }
+    } catch (err) {
+      if (ctx.controller.signal.aborted) return null;
+      if (isRetryableStreamError(err) && streamRetries < MAX_STREAM_RETRIES) {
+        streamRetries++;
+        yield { type: 'stream.retry', sessionId: ctx.initSessionId };
+        await sleepWithAbort(computeBackoffDelay(streamRetries - 1), ctx.controller.signal);
+        if (ctx.controller.signal.aborted) return null;
+        continue; // retry the whole iteration
+      }
+      streamError = err;
+    }
+
+    if (streamError !== null) {
+      yield { type: 'error', error: strategy.clarifyError(streamError) };
+      return null;
+    }
+
+    // Clean completion — return the result.
+    return {
+      state,
+      events: [],
+      text: state.assistantText,
+      needsToolDispatch: isToolCallStop(state) && state.toolCallsByIndex.size > 0,
+    };
+  }
+}


### PR DESCRIPTION
Closes #365. Part of the large-file split initiative (#360). Finishes the `openai-compatible/query.ts` split (retry predicates #407 and tool-dispatch #453 were already extracted; this is the tail).

## What

`runIteration` ran **two near-mirror copies** of the retry/stream-drive scaffolding — one for the Responses API, one for Chat Completions — that differed only in four call sites. This extracts the shared skeleton and the per-wire request-body assembly into the existing `query/` submodule.

- **New `query/stream-drive.ts`** — `driveStream(ctx, strategy)` holds the one shared three-phase scaffolding (connection-phase retry → mid-stream consume with once-only `model_ttfb` + stream-retry → clean-completion return), parameterized by a `StreamDriveStrategy` over the only 4 per-wire deltas: `createStream`, `translate`, event type, `clarifyError`. Both branches now `return yield* driveStream(...)`. `IterationResult` moved here (it's what the driver returns).
- **New `query/request-body.ts`** — `buildResponsesRequestBody` / `buildChatCompletionsRequestBody`, pure per-wire body assembly, keeping the ChatGPT/Codex subscription-backend quirks (no output cap; forced `instructions` + `store:false`) with the Responses builder.
- **`query.ts`: 1158 → 953 lines (−205).** `runIteration` is now: build messages → (per wire) build request body → hand off to the shared driver.
- **New `query/request-body.test.ts`** (4 tests) locks the wire-specific body shapes incl. the ChatGPT-backend gating. No standalone stream-drive test — it's covered end-to-end by `query.test.ts`'s 74 tests (retry, streaming, both wires, ChatGPT backend, effort).

**Behavior-preserving structural extraction — no functional change.** Retry counts, abort checks, TTFB-once semantics, `stream.retry` yields, and the return shape are preserved verbatim.

## Verification

- `tsc --noEmit` clean; `audit:sdk:check` / `audit:env:check` / `scan:env:check` green.
- **Full suite + coverage:** 620 files, **11227 passed | 14 skipped, 0 failed** (baseline 11223 + 4 new tests); coverage 86.28 / 84.24 / 91.12 / 86.28 vs thresholds 74 / 79 / 82 / 74.
- **Independent read-only auditor: `CLEAN`** — line-by-line comparison against the pre-refactor commit confirmed all retry/abort/TTFB/return semantics byte-identical across both wires. Adversarial sweep for the regression-hiding spots (dropped abort checks, flipped `<`/`<=` bounds, `streamRetries`/`attempt` off-by-one, TTFB outside the once-guard, missing `stream.retry` yield, changed request-body presence-conditions) found **none**. `return yield*` correctly propagates both yielded events and the `IterationResult | null` return.

## Acceptance (#365)

- ✅ `runIteration` no longer contains two copies of the retry/stream-drive scaffolding — the shared skeleton lives in one place and both wire modes call it.
- ✅ `query.ts` line count drops materially (1158 → 953, target ~950).
- ✅ No behavioral change — existing openai-compatible provider tests pass unmodified.
