### PR TITLE
fix(subagent): resolve path-approval grants per executing session (#435/#514)

### DIFF
--- a/src/agent/hooks.ts
+++ b/src/agent/hooks.ts
@@ -42,6 +42,7 @@
 
 import { createHookRegistryImpl } from './hook-registry.js';
 import type { SubagentTrace } from './subagent/result.js';
+import type { GrantManager } from '../cli/slash/commands/allow-dir.js';
 
 export type HarnessHookEvent =
   | 'SessionStart'
@@ -159,6 +160,17 @@ export interface PreToolUseContext {
   parentSessionId?: string;
   toolName: string;
   input?: unknown;
+  /**
+   * Live grant manager of the session EXECUTING this call — the provider that
+   * built the dispatcher dispatching this hook. Injected per-call by
+   * {@link SessionToolDispatcher} so path-scoped hooks (path-approval,
+   * bash-restriction) resolve the ACTUAL session's grants: a forked child's own
+   * cwd/readRoots/writeRoots rather than a process-global ref pinned to the
+   * top-level session (the #435/#514 write-confinement gap). When absent
+   * (non-dispatcher-originated dispatch, unit tests), those hooks fall back to
+   * their `opts.getGrantManager()` ref, preserving prior behavior.
+   */
+  grantManager?: GrantManager;
 }
 
 export interface PostToolUseContext {
@@ -181,6 +193,13 @@ export interface PostToolUseContext {
    */
   input?: unknown;
   output?: unknown;
+  /**
+   * Live grant manager of the executing session — see
+   * {@link PreToolUseContext.grantManager}. Injected so the "Once"-grant revoke
+   * in the path-approval PostToolUse hook mutates the SAME grant manager the
+   * PreToolUse containment check consulted.
+   */
+  grantManager?: GrantManager;
 }
 
 export interface PreCompactContext {

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -432,6 +432,14 @@ export class AnthropicDirectProvider implements ModelProvider {
     }
     return new SessionToolDispatcher({
       handlers,
+      // This provider IS the session's GrantManager. Passing it here lets the
+      // dispatcher inject it onto PreToolUse/PostToolUse contexts, so the
+      // path-approval + bash-restriction hooks resolve THIS session's live
+      // grants (a forked child's own writeRoots) rather than the process-global
+      // ref pinned to the top-level session (#435/#514). getGrants() reads the
+      // same _sharedReadRoots/_sharedWriteRoots the dispatcher shares by
+      // reference, so hook and handler stay in lockstep.
+      sessionGrantManager: this,
       // Path-containment bypass: bypassPermissions (explicit) AND autonomous
       // (AFK) both carry allowAll:true so path containment + the path-approval
       // prompt are disabled per-call. In AFK the afk-mode-gate is the safety

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -491,6 +491,12 @@ export class OpenAICompatibleProvider implements ModelProvider {
     // Path-containment bypass: bypassPermissions (explicit) + autonomous (AFK)
     // both disable path containment for every per-call context.
     dispatcherOpts.allowAll = pathContainmentBypassed(permissionMode);
+    // This provider IS the session's GrantManager — parity with
+    // AnthropicDirectProvider.buildDispatcher. The dispatcher injects it onto
+    // PreToolUse/PostToolUse contexts so path-scoped hooks resolve THIS
+    // session's live grants (a forked child's own writeRoots), not the
+    // process-global ref pinned to the top-level session (#435/#514).
+    dispatcherOpts.sessionGrantManager = this;
 
     return new SessionToolDispatcher(dispatcherOpts);
   }

--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -76,6 +76,43 @@ describe('SessionToolDispatcher', () => {
     });
   });
 
+  describe('sessionGrantManager injection (#514)', () => {
+    // The provider passes itself as sessionGrantManager; the dispatcher must
+    // surface it on the PreToolUse context so path-scoped hooks resolve THIS
+    // session's grants (a forked child's own writeRoots) instead of the
+    // process-global ref pinned to the top-level session.
+    const fakeGM = {
+      getGrants: () => ({ resolveBase: undefined, readRoots: [], writeRoots: [] }),
+      addReadRoot: () => {},
+      addWriteRoot: () => {},
+      revokeRoot: () => {},
+    };
+
+    it('injects sessionGrantManager onto the PreToolUse context', async () => {
+      let captured: unknown = 'unset';
+      const registry = createHookRegistryImpl();
+      registry.register('PreToolUse', (ctx) => {
+        if (ctx.event === 'PreToolUse') captured = ctx.grantManager;
+        return {};
+      });
+      const dispatcher = makeDispatcher({ hookRegistry: registry, sessionGrantManager: fakeGM });
+      await dispatcher.execute(makeCall());
+      expect(captured).toBe(fakeGM);
+    });
+
+    it('leaves context.grantManager undefined when no sessionGrantManager is provided', async () => {
+      let captured: unknown = 'unset';
+      const registry = createHookRegistryImpl();
+      registry.register('PreToolUse', (ctx) => {
+        if (ctx.event === 'PreToolUse') captured = ctx.grantManager;
+        return {};
+      });
+      const dispatcher = makeDispatcher({ hookRegistry: registry });
+      await dispatcher.execute(makeCall());
+      expect(captured).toBeUndefined();
+    });
+  });
+
   it('returns isError for unknown tool', async () => {
     const dispatcher = makeDispatcher({
       permissions: { allowedTools: ['echo', 'nonexistent'] },

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -26,6 +26,7 @@ import { checkToolPermission, type ToolPermissionConfig } from './permissions.js
 import type { CanUseTool, PermissionResult } from '../types/sdk-types.js';
 import { classifyBashCommand } from './readonly-bash.js';
 import { PathGrantManager, type GrantSnapshot } from './grant-manager.js';
+import type { GrantManager } from '../../cli/slash/commands/allow-dir.js';
 import { emitHookDecision } from '../trace/emit.js';
 import type { TraceWriter } from '../trace/index.js';
 import { defaultConcurrencyClassifier, partitionIntoBatches } from './dispatch-batching.js';
@@ -144,6 +145,17 @@ export interface SessionToolDispatcherOptions {
    * calls. Undefined for top-level sessions.
    */
   parentSessionId?: string;
+  /**
+   * The PROVIDER that owns this dispatcher (it implements {@link GrantManager}).
+   * The provider's `buildDispatcher` passes `this`; the dispatcher injects it
+   * onto every PreToolUse/PostToolUse context as `context.grantManager` so
+   * path-scoped hooks resolve THIS session's live grants instead of the
+   * process-global `pathApprovalGrantRef` — which is pinned to the top-level
+   * session and blind to a forked child's own writeRoots (#435/#514). Optional:
+   * test dispatchers that construct directly leave it unset and the hooks fall
+   * back to their ref, preserving prior behavior.
+   */
+  sessionGrantManager?: GrantManager;
   /** Witness-layer trace writer. When provided, every PreToolUse and
    *  PostToolUse dispatch records a `hook_decision` event. */
   traceWriter?: TraceWriter;
@@ -198,6 +210,12 @@ export class SessionToolDispatcher implements ToolDispatcher {
   private readonly _env: Record<string, string> | undefined;
   private readonly sessionId: string | undefined;
   private readonly parentSessionId: string | undefined;
+  /**
+   * Provider that owns this dispatcher (implements GrantManager). Injected onto
+   * PreToolUse/PostToolUse contexts so path-scoped hooks read THIS session's
+   * live grants. See {@link SessionToolDispatcherOptions.sessionGrantManager}.
+   */
+  private readonly sessionGrantManager: GrantManager | undefined;
   private readonly traceWriter: TraceWriter | undefined;
   /** When true, mutating `bash` commands are blocked (read-only skill child). */
   private readonly readOnlyBash: boolean;
@@ -238,6 +256,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
     this._env = opts.env;
     this.sessionId = opts.sessionId;
     this.parentSessionId = opts.parentSessionId;
+    this.sessionGrantManager = opts.sessionGrantManager;
     this.traceWriter = opts.traceWriter;
     this.readOnlyBash = opts.readOnlyBash === true;
     this._allowAll = opts.allowAll === true;
@@ -567,6 +586,11 @@ export class SessionToolDispatcher implements ToolDispatcher {
         ...(this.parentSessionId !== undefined
           ? { parentSessionId: this.parentSessionId }
           : {}),
+        // Inject THIS session's provider so path-scoped hooks resolve the real
+        // (possibly forked-child) grants instead of the process-global ref.
+        ...(this.sessionGrantManager !== undefined
+          ? { grantManager: this.sessionGrantManager }
+          : {}),
       };
       try {
         await dispatchPreToolUse(this.hookRegistry, preCtx, {
@@ -655,6 +679,10 @@ export class SessionToolDispatcher implements ToolDispatcher {
           input: call.input,
           ...(this.parentSessionId !== undefined
             ? { parentSessionId: this.parentSessionId }
+            : {}),
+          // See execute(): inject THIS session's provider grant manager.
+          ...(this.sessionGrantManager !== undefined
+            ? { grantManager: this.sessionGrantManager }
             : {}),
         };
         try {
@@ -931,6 +959,11 @@ export class SessionToolDispatcher implements ToolDispatcher {
       output,
       ...(input !== undefined ? { input } : {}),
       ...(this.parentSessionId !== undefined ? { parentSessionId: this.parentSessionId } : {}),
+      // Mirror PreToolUse so the path-approval "Once"-grant revoke mutates the
+      // SAME grant manager the Pre containment check consulted.
+      ...(this.sessionGrantManager !== undefined
+        ? { grantManager: this.sessionGrantManager }
+        : {}),
     };
     void dispatchPostToolUse(this.hookRegistry, postCtx, {
       signal,

--- a/src/agent/tools/hooks/bash-restriction-hook.test.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.test.ts
@@ -329,6 +329,64 @@ describe('createBashRestrictionHook — grant containment direction (F4 regressi
   });
 });
 
+describe('createBashRestrictionHook — context.grantManager precedence (#514)', () => {
+  // #514: SessionToolDispatcher injects the EXECUTING session's provider as
+  // context.grantManager (bash-restriction-hook.ts:229 —
+  // `context.grantManager ?? opts.getGrantManager()`), mirroring the same
+  // precedence path-approval-hook.test.ts pins in its own "#514" describe
+  // block ("context.grantManager takes precedence over opts.getGrantManager").
+  // Before this hook read context.grantManager at all, a forked child's
+  // restricted-root view was blind to its OWN grants and pinned to whichever
+  // session's ref happened to construct the hook closure.
+  const home = homedir();
+  const sshPath = `${home}/.ssh`;
+
+  function grantsGranting(extraRoot: string): GrantManager {
+    return {
+      addReadRoot: () => {},
+      addWriteRoot: () => {},
+      revokeRoot: () => {},
+      getGrants() {
+        return {
+          resolveBase: '/tmp/repo',
+          readRoots: ['/tmp/repo', extraRoot],
+          writeRoots: ['/tmp/repo'],
+        };
+      },
+    };
+  }
+
+  it('uses context.grantManager over opts.getGrantManager (the ref) for the restricted-root view (#514)', () => {
+    // Ref (opts.getGrantManager) grants ~/.ssh — permissive: if the hook fell
+    // back to the ref, `.ssh` would be dropped from restrictedSubstrings and
+    // the command would pass through unblocked.
+    const refMgr = grantsGranting(sshPath);
+    // Injected (context.grantManager) grants an UNRELATED root — `.ssh`
+    // remains restricted under its view.
+    const injectedMgr = grantsGranting('/some/other/granted-root');
+    const hook = createBashRestrictionHook({ getGrantManager: () => refMgr });
+
+    // Sanity check: using the ref alone (no injected context), this same
+    // command is NOT blocked — confirms the ref really is the permissive one.
+    const refOnlyDecision = hook(ctx(`cat ${sshPath}/id_rsa`));
+    expect(refOnlyDecision.decision).not.toBe('block');
+
+    // Now fire with the INJECTED (restrictive) manager on the context. If it
+    // wins over the ref, `.ssh` is still restricted under its own grants and
+    // the command blocks — proving the injected manager, not the ref, drove
+    // the decision.
+    const decision = hook({
+      event: 'PreToolUse',
+      toolName: 'bash',
+      input: { command: `cat ${sshPath}/id_rsa` },
+      grantManager: injectedMgr,
+    });
+
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toMatch(/restricted path/);
+  });
+});
+
 describe('createBashRestrictionHook — wiring failsafes', () => {
   it('fails open when grant manager is undefined (bootstrap race)', () => {
     const hook = createBashRestrictionHook({ getGrantManager: () => undefined });

--- a/src/agent/tools/hooks/bash-restriction-hook.ts
+++ b/src/agent/tools/hooks/bash-restriction-hook.ts
@@ -153,7 +153,12 @@ export function createBashRestrictionHook(opts: BashRestrictionHookOptions) {
     // approval path exists that the model can be redirected to. Headless
     // surfaces (afk chat, daemon, threads, subagents of headless sessions)
     // never wire it.
-    const grantManager = opts.getGrantManager();
+    //
+    // Prefer the dispatcher-injected grant manager (this session's provider)
+    // over the process-global ref so a forked child's restricted-root view is
+    // derived from ITS own grants, not the top-level session's (#435/#514).
+    // The ref remains the fallback when no dispatcher injected one.
+    const grantManager = context.grantManager ?? opts.getGrantManager();
     const interactiveSurface = grantManager !== undefined;
 
     // Precompute the sensitive-path view ONCE — both checks below consume it.

--- a/src/agent/tools/hooks/path-approval-hook.test.ts
+++ b/src/agent/tools/hooks/path-approval-hook.test.ts
@@ -336,6 +336,45 @@ describe('createPathApprovalHook — outcome mapping', () => {
     expect(mgr._events.map((e) => e.op)).toEqual(['addRead', 'revoke']);
   });
 
+  it('once: revoke targets the injected context.grantManager, not the ref (#514)', async () => {
+    // #514 PostToolUse mirror: the dispatcher injects the executing session's
+    // provider as context.grantManager on BOTH Pre and Post. The "Once"-grant
+    // must be added to — and revoked from — that SAME injected manager, never
+    // the process-global ref (opts.getGrantManager). Here the ref and the
+    // injected manager are DISTINCT instances: if the Post revoke hit the ref
+    // instead of the injected manager, the once-grant would leak on the
+    // injected manager (its writeRoots/readRoots would keep the granted path).
+    elicitationRouter.install(async () => ({ action: 'accept', content: { choice: 'once' } }));
+    const refMgr = makeMockGrantManager();
+    const injectedMgr = makeMockGrantManager();
+    const { preToolUse, postToolUse } = createPathApprovalHook({
+      getGrantManager: () => refMgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    // Pre: approve "once" against the INJECTED manager (context.grantManager).
+    const decision = await preToolUse({
+      ...preCtx('read_file', { file_path: '/etc/hosts' }),
+      grantManager: injectedMgr,
+    });
+    expect(decision).toEqual({});
+    expect(injectedMgr._readRoots).toContain('/etc/hosts');
+    // The ref was never consulted or mutated for the add.
+    expect(refMgr._events).toHaveLength(0);
+
+    // Post: revoke must land on the SAME injected manager the Pre check mutated.
+    postToolUse({
+      ...postCtx('read_file', { file_path: '/etc/hosts' }),
+      grantManager: injectedMgr,
+    });
+    expect(injectedMgr._readRoots).not.toContain('/etc/hosts');
+    expect(injectedMgr._events.map((e) => e.op)).toEqual(['addRead', 'revoke']);
+    // The ref remained untouched throughout — proving the injected manager
+    // (not opts.getGrantManager) drove BOTH the add and the revoke.
+    expect(refMgr._events).toHaveLength(0);
+  });
+
   it('session: adds to readRoots and caches; second call does not re-prompt', async () => {
     const handler = vi.fn(async () => ({ action: 'accept', content: { choice: 'session' } }));
     elicitationRouter.install(handler);

--- a/src/agent/tools/hooks/path-approval-hook.test.ts
+++ b/src/agent/tools/hooks/path-approval-hook.test.ts
@@ -108,6 +108,112 @@ describe('createPathApprovalHook — typed-tool gating', () => {
   });
 });
 
+describe('createPathApprovalHook — session-scoped grants via context.grantManager (#514)', () => {
+  // #514: the dispatcher injects the EXECUTING session's provider as
+  // context.grantManager. For a forked child that is the CHILD's own grant
+  // manager (with its composed writeRoots) — NOT the process-global ref, which
+  // is pinned to the top-level session. So a writeRoots-granted sibling write
+  // must be ALLOWED even though the parent ref (opts.getGrantManager) does not
+  // grant it. This is the interactive-surface gap PR 514 left open: it composed
+  // writeRoots into the child config but the hook still checked the parent ref.
+  const SIBLING = '/sibling/repo';
+
+  it('ALLOWS a forked-child write to a path in its INJECTED writeRoots (parent ref would deny)', async () => {
+    // Parent ref grants only BASE — on its own it would auto-deny the sibling.
+    const parentRef = makeMockGrantManager({ writeRoots: [BASE] });
+    // Child provider (injected via context) grants BASE + the sibling.
+    const childMgr = makeMockGrantManager({ writeRoots: [BASE, SIBLING] });
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => parentRef,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: `${SIBLING}/out.txt`, content: 'x' },
+      sessionId: 'child-1',
+      parentSessionId: 'parent-1',
+      grantManager: childMgr,
+    });
+
+    // Not blocked: the child's own grants permit the write, so the `!restricted`
+    // early-return fires BEFORE the parentSessionId auto-deny. The remedy the
+    // PR advertised is now real on interactive surfaces.
+    expect(decision).toEqual({});
+    // The parent ref was never consulted for the decision.
+    expect(parentRef._events).toHaveLength(0);
+  });
+
+  it('STILL auto-denies a forked-child write OUTSIDE its injected grants (confinement preserved)', async () => {
+    const childMgr = makeMockGrantManager({ writeRoots: [BASE] });
+    const { preToolUse } = createPathApprovalHook({
+      // Even a permissive parent ref must not widen the child.
+      getGrantManager: () => makeMockGrantManager({ writeRoots: [BASE, SIBLING] }),
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: '/etc/hosts', content: 'x' },
+      sessionId: 'child-1',
+      parentSessionId: 'parent-1',
+      grantManager: childMgr,
+    });
+
+    // /etc/hosts is outside the CHILD's writeRoots → restricted → fork auto-deny.
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toContain('Sub-agent path access denied');
+  });
+
+  it('context.grantManager takes precedence over opts.getGrantManager (the ref)', async () => {
+    // Ref grants the sibling; the injected (child) manager does NOT. If the
+    // injected manager wins, the fork write is restricted → auto-deny.
+    const refMgr = makeMockGrantManager({ writeRoots: [BASE, SIBLING] });
+    const injectedMgr = makeMockGrantManager({ writeRoots: [BASE] });
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => refMgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse({
+      event: 'PreToolUse',
+      toolName: 'write_file',
+      input: { file_path: `${SIBLING}/out.txt`, content: 'x' },
+      sessionId: 'child-1',
+      parentSessionId: 'parent-1',
+      grantManager: injectedMgr,
+    });
+
+    expect(decision.decision).toBe('block'); // the restrictive injected manager won
+  });
+
+  it('falls back to opts.getGrantManager when no grantManager is injected (prior behavior)', async () => {
+    // Top-level session, no injected manager: the ref grants the path, so the
+    // hook resolves exactly as before — no prompt, no block.
+    const refMgr = makeMockGrantManager({ readRoots: [BASE, SIBLING] });
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => refMgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+
+    const decision = await preToolUse({
+      event: 'PreToolUse',
+      toolName: 'read_file',
+      input: { file_path: `${SIBLING}/in.txt` },
+      sessionId: 'sess-1',
+      // no parentSessionId, no grantManager
+    });
+
+    expect(decision).toEqual({});
+  });
+});
+
 describe('createPathApprovalHook — sub-agent auto-deny (PR1)', () => {
   // A forked sub-agent (parentSessionId set) must never prompt the operator for
   // out-of-root access — the prompt would surface on the parent's handler with

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -183,7 +183,14 @@ async function preToolUseImpl(
   // Reproduce the handler's containment check. cwd / readRoots / writeRoots
   // are sampled from the grant manager using the same fresh-snapshot pattern
   // the dispatcher uses on every handler call.
-  const grantManager = opts.getGrantManager();
+  //
+  // Prefer the grant manager injected by the executing session's dispatcher
+  // (context.grantManager) over the process-global ref: for a forked child the
+  // ref is pinned to the TOP-LEVEL session and blind to the child's own
+  // writeRoots, so a writeRoots-granted sibling write would be auto-denied even
+  // though the child's grants permit it (#435/#514). The ref remains the
+  // fallback for non-dispatcher-originated dispatch (tests, SessionEnd).
+  const grantManager = context.grantManager ?? opts.getGrantManager();
   if (!grantManager) {
     // Failsafe — no wired grant manager (headless, one-shot, daemon). Skip
     // the approval pre-check and let the handler's own resolveAndContain
@@ -293,7 +300,9 @@ function postToolUseImpl(
     ? 'write'
     : 'read';
 
-  const grantManager = opts.getGrantManager();
+  // Prefer the dispatcher-injected grant manager (same session as PreToolUse)
+  // so the "Once"-grant revoke targets the manager the Pre check mutated.
+  const grantManager = context.grantManager ?? opts.getGrantManager();
   if (!grantManager) return {};
   const grants = grantManager.getGrants();
 

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -223,11 +223,13 @@ async function preToolUseImpl(
   // the operator for out-of-root access — the prompt would surface on the
   // parent's REPL/Telegram handler (the elicitation router is process-wide),
   // interleaved into the parent's turn with no attribution. Auto-deny instead.
-  // The sub-agent inherits the parent's grants (this hook and its grant-manager
-  // closure are shared via the inherited registry), so any path the parent
-  // already approved still passes the `!restricted` check above; only a
-  // genuinely NEW out-of-root path reaches here, and the sub-agent reports the
-  // requirement back to its parent, which owns the surface and can grant it.
+  // The fork resolves path containment against its OWN grant manager (injected
+  // as `context.grantManager` by the executing session's dispatcher) — the
+  // child's own composed write/read roots, not the parent's. So a path inside
+  // the child's own granted roots still passes the `!restricted` check above;
+  // only a path outside the child's own grants reaches here, and the sub-agent
+  // reports the requirement back to its parent, which owns the surface and can
+  // grant it.
   // Mirrors the `parentSessionId` self-skip used by the memory + plan-mode hooks.
   if (context.parentSessionId !== undefined) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary

Follow-up to #514 (now merged): closes the interactive-surface gap #514 left open for #435.

**The gap #514 left:** #514 composes an `agent`-tool `writeRoots` grant into a forked child's config, but the `path-approval` PreToolUse hook — which auto-denies forked children — reads grants from a process-global `pathApprovalGrantRef` pinned once to the **top-level** session's provider (`bootstrap.ts` / `telegram.ts`) and never re-pointed per fork. So on a default-permission REPL/Telegram session, a child dispatched with `writeRoots:['/sibling']` (a path the parent itself wasn't granted) is **auto-denied by the hook before the file handler — which honors `writeRoots` — ever runs.** The remedy #514 advertised ("re-dispatch with `writeRoots:[…]`") silently dead-ended on exactly the interactive surfaces it targeted. The same single ref also collides across concurrent sessions that share a hook bundle.

**The fix:** each per-query `SessionToolDispatcher` now carries its owning provider (which implements `GrantManager`) as `sessionGrantManager` and injects it onto every `PreToolUse`/`PostToolUse` context as `context.grantManager`. The `path-approval` and `bash-restriction` hooks prefer `context.grantManager` over the process-global ref, so they resolve the grants of the session **actually executing** the call — a forked child's own `cwd`/`readRoots`/`writeRoots` — instead of the top-level session's.

### Design notes

- Uses the **provider's** grant manager, not the dispatcher's own, to preserve the `resolveBase` divergence the hook relies on (providers protect the session's INITIAL resolveBase; the dispatcher the CURRENT one — see `grant-manager.ts` divergence #2).
- The process-global ref remains the **fallback** for non-dispatcher-originated dispatch (`SessionEnd`, unit tests), so top-level behavior is unchanged (the injected manager *is* the provider the ref points to) and headless/one-shot surfaces still fail open.
- **Confinement preserved:** a child write to a genuinely out-of-grant path is still auto-denied with the #435 remedy. A child gets only what its own `writeRoots` already intend — no new capability, no escalation.
- No `sessionId` threading, no keyed map, no eviction lifecycle; no changes to bootstrap/telegram/subagent wiring.
- Fixes the concurrent-top-level-session ref collision as a side effect (each call resolves via its own dispatcher's provider).

## How was this tested?

Run on this exact tree, rebased on current `main`:

- `pnpm lint` (tsc --noEmit, strict) — clean
- `pnpm test` — **11243 passed / 14 skipped / 0 failed** (619 files)
- `pnpm audit:sdk:check` — OK (no new SDK symbols) · `pnpm audit:env:check` — 0 violations · `pnpm scan:env:check` — in sync

New coverage:

- `path-approval-hook.test.ts` — the end-to-end case #514 lacked: a forked child **allowed** to write a path in its injected `writeRoots` (parent ref would deny); **still auto-denied** outside them (confinement); `context.grantManager` precedence over the ref; ref fallback.
- `dispatcher.test.ts` — `sessionGrantManager` is injected onto the `PreToolUse` context; absent when not provided.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the DCO
- [x] No secrets, tokens, or private paths in the diff
