### PR TITLE
fix(redact): stop redacting long filesystem paths as opaque secrets

### DIFF
--- a/src/agent/background-summarizer.test.ts
+++ b/src/agent/background-summarizer.test.ts
@@ -505,6 +505,32 @@ describe('redactSecrets', () => {
     expect(redactSecrets(text)).toBe(text);
   });
 
+  it('does not redact a long absolute filesystem path (path false-positive regression)', () => {
+    // A bare `cd <long absolute path>` argument is a run of ≥32 chars drawn
+    // entirely from the generic token class ([A-Za-z0-9+/=_-]); it used to be
+    // redacted to `cd [REDACTED]` in tool-lane labels. A path is not a secret.
+    const path = '/Users/griffinlong/Projects/open_source/agent-afk';
+    expect(path.length).toBeGreaterThanOrEqual(32);
+    expect(redactSecrets(`cd ${path} && echo hi`)).toBe(`cd ${path} && echo hi`);
+  });
+
+  it('still redacts a base64 blob with slashes when it carries +/= (not a path)', () => {
+    // Classic base64 with a `/` but also `+`/`=` must NOT be mistaken for a
+    // path — the path guard only spares `/`-runs free of base64 signal chars.
+    const b64 = 'a1b2c3d4e5f6g7h8+i9j0k1l2m3n4/o5p6q7r8s9t0=';
+    const out = redactSecrets(`X ${b64}`);
+    expect(out).not.toContain(b64);
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('still redacts a base64url token with no slash (path guard does not apply)', () => {
+    // base64url uses -/_ and no `/`, so the path guard never spares it.
+    const token = 'abcABC123_-abcABC123_-abcABC123_-abcABC12';
+    const out = redactSecrets(`X-Token: ${token}`);
+    expect(out).not.toContain(token);
+    expect(out).toContain('[REDACTED]');
+  });
+
   it('does not redact 16-char base32 strings without an AWS prefix', () => {
     // Looks like the back-half of an AKIA but without the prefix — should
     // not be flagged. (Floor is 32 chars for generic patterns.)

--- a/src/agent/background-summarizer.test.ts
+++ b/src/agent/background-summarizer.test.ts
@@ -537,4 +537,27 @@ describe('redactSecrets', () => {
     const text = 'random IOSFODNN7EXAMPLE9 token';
     expect(redactSecrets(text)).toBe(text);
   });
+
+  it('redacts an opaque base64url token fused into a path segment (PR #533 review med)', () => {
+    // A ≥32-char opaque token as a path segment is still a secret even though the
+    // whole run contains `/` and no +/=. The per-segment guard catches it.
+    const token = 'abcABC123_-abcABC123_-abcABC123_-abcABC12';
+    const out = redactSecrets(`cat /tmp/uploads/${token}`);
+    expect(out).not.toContain(token);
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('redacts a long hex token fused into a path segment', () => {
+    const token = '0123456789abcdef0123456789abcdef0123';
+    const out = redactSecrets(`cat /var/data/${token}`);
+    expect(out).not.toContain(token);
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('preserves a long DIGITLESS descriptive path segment (not an opaque token)', () => {
+    // A long path segment with no digits is a descriptive name, not a secret —
+    // it must survive. Guards against over-redacting real long directory names.
+    const p = '/opt/SomeVeryLongDirectoryNameWithoutAnyDigits/bin';
+    expect(redactSecrets(`ls ${p}`)).toBe(`ls ${p}`);
+  });
 });

--- a/src/agent/providers/shared/tool-input-summary.test.ts
+++ b/src/agent/providers/shared/tool-input-summary.test.ts
@@ -99,6 +99,18 @@ describe('summarizeToolInput — inline secret redaction (codex P1 on #511)', ()
     expect(out).toContain('export ANTHROPIC_API_KEY=');
   });
 
+  it('does not redact a long absolute path in a `cd` argument (path false-positive)', () => {
+    // The exact screenshot shape: a subagent running `cd <long abs path> && …`
+    // rendered as `$ bash cd [REDACTED] echo …` because the generic token rule
+    // swallowed the path. The path must survive so the operator can read it.
+    const out = summarizeToolInput('bash', {
+      command:
+        'cd /Users/griffinlong/Projects/open_source/agent-afk && echo "===== HookDecision ====="',
+    });
+    expect(out).toContain('/Users/griffinlong/Projects/open_source/agent-afk');
+    expect(out).not.toContain('[REDACTED]');
+  });
+
   it('leaves an ordinary git commit command intact (verb + message survive)', () => {
     // Proves redaction does not break derive.ts commit detection, which reads
     // this summary and keys on the `git commit` verb.

--- a/src/agent/redact-secrets.ts
+++ b/src/agent/redact-secrets.ts
@@ -33,7 +33,8 @@
  *     that consist entirely of hex or base64 alphabet characters (heuristic).
  *     Runs shaped like a filesystem/URL path are excluded — see
  *     `looksLikeFilesystemPath` — so a long bare `cd <path>` argument is not
- *     mistaken for a secret.
+ *     mistaken for a secret. An opaque token fused into a path segment
+ *     (`/tmp/uploads/<token>`) is still redacted (rule 3 of that guard).
  *
  * Explicit patterns run BEFORE the generic length rule so short or
  * dot-separated tokens get redacted regardless of the 32-char floor.
@@ -59,7 +60,8 @@ export function redactSecrets(text: string): string {
     // does NOT stop the class from swallowing `/`, so a long bare path argument
     // (`cd /Users/me/Projects/open_source/agent-afk`) matched as one contiguous
     // token and was redacted to `[REDACTED]`. The path-shape guard below carves
-    // real paths back out; genuine opaque tokens are still redacted.
+    // real paths back out; genuine opaque tokens — including one fused into a
+    // path segment (`/tmp/uploads/<token>`, rule 3) — are still redacted.
     .replace(/(?<![/.\w])[A-Za-z0-9+/=_-]{32,}(?![/.\w])/g, (m) =>
       looksLikeFilesystemPath(m) ? m : '[REDACTED]');
 }
@@ -69,15 +71,31 @@ export function redactSecrets(text: string): string {
  * secret. The generic token class includes `/`, `_`, `-` — the characters a
  * path is built from — so a long bare path would otherwise be redacted.
  *
- * Heuristic: a run is a path when it contains a `/` separator AND none of
- * base64's exclusive characters (`+`, `=`). base64url (JWTs, most modern API
- * tokens) uses `-`/`_` and hex/alphanumeric keys have no `/` at all, so those
- * still match and are redacted; classic base64 carries `+`/`=`, so it is still
- * redacted even with a `/`. Accepted gap: a classic-base64 blob containing `/`
- * but neither `+` nor `=` is preserved — the high-value named secrets (sk-ant,
- * Bearer, JWT, AWS) are already covered by the explicit rules that run first,
- * and this generic rule is only a heuristic backstop.
+ * A run is a path only when ALL hold:
+ *   1. it contains a `/` separator, and
+ *   2. it carries none of base64's exclusive chars (`+`, `=`) — classic base64
+ *      (JWT sigs aside) is a secret, not a path, so a run with `+`/`=` is redacted;
+ *   3. no single `/`-delimited segment is itself a long opaque token — i.e. a
+ *      secret fused into a path segment (`/tmp/uploads/<44-char token>`) is
+ *      redacted, not spared. "Long opaque token" = ≥32 chars, mixing letters
+ *      and digits, with no dotted extension. (The generic-rule class excludes
+ *      `.`, so a matched run never contains one; the dot check is defensive for
+ *      standalone use.)
+ *
+ * base64url tokens (JWTs, most modern API keys) use `-`/`_` and have no `/`, so
+ * they never reach this guard and are redacted by the generic rule; a token
+ * fused into a path is caught by rule 3.
+ *
+ * Accepted residual gap: an unusually long (≥32-char) DOTLESS path segment that
+ * mixes letters and digits — a raw hash directory or a UUID-without-dashes — is
+ * over-redacted (treated as a token). Rare and cosmetic; it fails safe, and the
+ * common case (short word segments, e.g. `/Users/me/Projects/open_source/agent-afk`)
+ * is preserved. The high-value NAMED secrets (sk-ant, Bearer, JWT, AWS) are
+ * covered by the explicit rules that run first, regardless of path context.
  */
 function looksLikeFilesystemPath(run: string): boolean {
-  return run.includes('/') && !/[+=]/.test(run);
+  if (!run.includes('/') || /[+=]/.test(run)) return false;
+  const isOpaqueTokenSegment = (seg: string): boolean =>
+    seg.length >= 32 && !seg.includes('.') && /[A-Za-z]/.test(seg) && /[0-9]/.test(seg);
+  return !run.split('/').some(isOpaqueTokenSegment);
 }

--- a/src/agent/redact-secrets.ts
+++ b/src/agent/redact-secrets.ts
@@ -30,8 +30,10 @@
  *     (AKIA = long-lived, ASIA = STS, AROA = role, AIDA = user, ...) — below
  *     the generic 32-char floor so they need explicit coverage.
  *   - Generic long opaque tokens           ≥32 contiguous non-whitespace chars
- *     that consist entirely of hex or base64 alphabet characters
- *     (heuristic; avoids redacting prose words or file paths)
+ *     that consist entirely of hex or base64 alphabet characters (heuristic).
+ *     Runs shaped like a filesystem/URL path are excluded — see
+ *     `looksLikeFilesystemPath` — so a long bare `cd <path>` argument is not
+ *     mistaken for a secret.
  *
  * Explicit patterns run BEFORE the generic length rule so short or
  * dot-separated tokens get redacted regardless of the 32-char floor.
@@ -52,7 +54,30 @@ export function redactSecrets(text: string): string {
     // (AROA), user (AIDA), group (AGPA), instance profile (AIPA), managed
     // policy (ANPA/ANVA), public key (APKA), server cert (ABIA), context (ACCA).
     .replace(/\b(?:AKIA|ASIA|AROA|AIDA|AGPA|AIPA|ANPA|ANVA|APKA|ABIA|ACCA)[A-Z0-9]{16}\b/g, '[REDACTED]')
-    // Generic long hex/base64 secrets (≥32 chars of [A-Za-z0-9+/=_-])
-    // Anchored to word-boundary so paths like /usr/local/bin don't match.
-    .replace(/(?<![/.\w])[A-Za-z0-9+/=_-]{32,}(?![/.\w])/g, '[REDACTED]');
+    // Generic long hex/base64 secrets (≥32 chars of [A-Za-z0-9+/=_-]).
+    // The word-boundary lookaround only guards where a match may START — it
+    // does NOT stop the class from swallowing `/`, so a long bare path argument
+    // (`cd /Users/me/Projects/open_source/agent-afk`) matched as one contiguous
+    // token and was redacted to `[REDACTED]`. The path-shape guard below carves
+    // real paths back out; genuine opaque tokens are still redacted.
+    .replace(/(?<![/.\w])[A-Za-z0-9+/=_-]{32,}(?![/.\w])/g, (m) =>
+      looksLikeFilesystemPath(m) ? m : '[REDACTED]');
+}
+
+/**
+ * True when a generic-rule match is a filesystem/URL path rather than an opaque
+ * secret. The generic token class includes `/`, `_`, `-` — the characters a
+ * path is built from — so a long bare path would otherwise be redacted.
+ *
+ * Heuristic: a run is a path when it contains a `/` separator AND none of
+ * base64's exclusive characters (`+`, `=`). base64url (JWTs, most modern API
+ * tokens) uses `-`/`_` and hex/alphanumeric keys have no `/` at all, so those
+ * still match and are redacted; classic base64 carries `+`/`=`, so it is still
+ * redacted even with a `/`. Accepted gap: a classic-base64 blob containing `/`
+ * but neither `+` nor `=` is preserved — the high-value named secrets (sk-ant,
+ * Bearer, JWT, AWS) are already covered by the explicit rules that run first,
+ * and this generic rule is only a heuristic backstop.
+ */
+function looksLikeFilesystemPath(run: string): boolean {
+  return run.includes('/') && !/[+=]/.test(run);
 }


### PR DESCRIPTION
## Problem

Long absolute filesystem paths were being redacted to `[REDACTED]` in tool-lane labels, `events.jsonl`, and Telegram — e.g. a subagent running `cd <repo> && …` rendered as:

    $ bash cd [REDACTED] echo "===== HookDecision ====="

### Root cause

The generic long-token rule in `redactSecrets()` (`src/agent/redact-secrets.ts`) is the catch-all backstop for opaque ≥32-char secrets. Its character class includes `/`, `_`, and `-` — exactly the characters an absolute path is built from — so a bare path argument like `/Users/griffinlong/Projects/open_source/agent-afk` matched as a single "token" and was scrubbed. This is **over-redaction, not a leak** — the real command still ran with the true path; only the display/telemetry label was scrubbed.

## Fix

Add a path-shape guard to the generic rule (`looksLikeFilesystemPath`): a matched run is left intact only when

1. it contains a `/` separator, **and**
2. it carries none of base64's exclusive characters (`+`, `=`), **and**
3. no single `/`-delimited segment is itself a long opaque token — ≥32 chars, mixing letters and digits, with no dotted extension.

Rule 3 (added after review of PR #533) means an opaque token fused into a path segment (e.g. `cat /tmp/uploads/<44-char token>`) is **still redacted** — the guard fails safe toward redaction. Named high-value secrets (Anthropic keys, `Authorization: Bearer`, JWT, AWS IDs) are matched by the explicit rules that run **before** this one, so they are unaffected regardless of surrounding path context.

- base64url tokens (JWTs, most modern API keys) use `-`/`_` and have no `/` → redacted by the generic rule.
- Classic base64 carries `+`/`=` → redacted (rule 2).
- Opaque token as a path segment → redacted (rule 3).

**Accepted residual gap** (documented in-code): an unusually long (≥32-char) *dotless* path segment mixing letters and digits — a raw hash directory or a UUID-without-dashes — is over-redacted (treated as a token). Rare, cosmetic, and fails safe; the common case (short word segments) is preserved and the motivating `cd <repo>` case renders intact.

## Tests

- `background-summarizer.test.ts` (`redactSecrets` block): long absolute path preserved; base64 blob with `/`+`=` redacted; base64url token (no `/`) redacted; **opaque token fused into a path segment (base64url and hex) redacted**; long *digitless* descriptive path segment preserved.
- `tool-input-summary.test.ts`: the exact screenshot shape — `cd <long abs path> && echo …` — renders with the path intact and no `[REDACTED]`.

## Verification

- `pnpm lint` (tsc --noEmit, strict) — clean
- `pnpm test -- src/agent/background-summarizer.test.ts src/agent/providers/shared/tool-input-summary.test.ts` — 41 passed / 0 failed (background-summarizer.test.ts: 26 tests; tool-input-summary.test.ts: 15 tests)
