### PR TITLE
fix(cli): restore worktree cwd when resuming or forking a session

### DIFF
--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -62,7 +62,7 @@ import { createDefaultTraceWriter } from '../../../agent/trace/factory.js';
 import { emitSessionPhase } from '../../../agent/trace/emit.js';
 import { palette } from '../../palette.js';
 import { performResumeSwap, resumeConfigFor } from './resume-swap.js';
-import { reseedStatsFromStored } from './shared.js';
+import { reseedStatsFromStored, resolveResumeCwd } from './shared.js';
 
 /**
  * Dependencies for constructing a fresh `AgentSession`. Captures everything
@@ -159,6 +159,18 @@ export async function bootstrapSession(
   const bootstrapStartedAt = Date.now();
   const resumeTarget = resolveResumeTarget(options);
   const resumeConfig = resumeConfigFor(resumeTarget);
+  // Resume cwd restoration: a resumed session should run in the directory it
+  // was saved in (e.g. an `afk --worktree` session that was later /fork'd or
+  // --resume'd), not wherever the shell happens to be. Precedence: an explicit
+  // --worktree override (extras.cwd) always wins; otherwise fall back to the
+  // stored cwd IFF it still exists on disk — a cleaned-up worktree degrades
+  // safely to process.cwd(). `effectiveCwd` is threaded through every
+  // cwd-purpose usage below (stats stamp, hook/session cwd, subagent/skill/
+  // compose/MCP cwd) so resumed worktree sessions AND their children anchor
+  // correctly. Defaults to `extras?.cwd` when there is no resume override, so
+  // this is a safe drop-in: behavior only changes for a resume whose stored
+  // cwd still exists.
+  const effectiveCwd = resolveResumeCwd(extras?.cwd, resumeTarget?.stored?.cwd);
   const sessionModel = resumeTarget?.stored?.model ?? options.model;
   // Fail fast on an unconfigured capability tier (e.g. `afk i -m local` with no
   // AFK_MODEL_LOCAL) before building the REPL session — an empty id would
@@ -223,7 +235,7 @@ export async function bootstrapSession(
     // subagents resolve relative paths like `src/foo.ts` against the parent
     // repo and the `read_file` handler returns parent-repo contents instead
     // of the worktree's. Mirrors `chat.ts:163` for the one-shot path.
-    ...(extras?.cwd !== undefined ? { cwd: extras.cwd } : {}),
+    ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
     // Witness layer: manager-level writer so `agent`-tool forks (which never
     // set config.traceWriter) still emit subagent_lifecycle events and hand
     // the writer to their handles. Skill forks already thread it via
@@ -306,7 +318,7 @@ export async function bootstrapSession(
   // + project .afk/agents & .claude/agents). Enables `agent_type` dispatch
   // on the `agent` tool at every depth of this REPL session.
   const agentRegistry = loadAgentRegistry({
-    ...(extras?.cwd !== undefined ? { cwd: extras.cwd } : {}),
+    ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
     pluginAgents: discoverPluginAgents(),
   });
 
@@ -320,8 +332,9 @@ export async function bootstrapSession(
     // Worktree cwd propagates into every depth of the skill-executor chain
     // (grandchild SkillExecutor → its per-call SubagentManager → forked
     // subagent config). Without this, depth ≥ 1 skill children silently
-    // lose worktree isolation.
-    extras?.cwd,
+    // lose worktree isolation. `effectiveCwd` also carries a resumed
+    // session's restored cwd (see resolveResumeCwd above).
+    effectiveCwd,
     // Per-model credential resolver: resolves credentials by child model
     // rather than forwarding the parent's captured apiKey — fixes Anthropic
     // children starving when the main model is OpenAI-routed.
@@ -368,7 +381,7 @@ export async function bootstrapSession(
     // Worktree isolation for depth ≥ 2 `agent` dispatch — `rootManager`
     // already carries cwd for depth-1, but the per-call childManager
     // constructed inside SubagentExecutor.execute() needs cwd too.
-    ...(extras?.cwd !== undefined ? { cwd: extras.cwd } : {}),
+    ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
     // Named-agent dispatch: registry + the session model as the `inherit`
     // anchor for named-agent model resolution.
     agentRegistry,
@@ -411,7 +424,7 @@ export async function bootstrapSession(
     // executor. Without forwarding cwd here, every `/diagnose`, `/mint`,
     // etc. runs its first-tier subagents against the host repo even when
     // `--worktree` was set.
-    ...(extras?.cwd !== undefined ? { cwd: extras.cwd } : {}),
+    ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
   });
 
   // Pass the raw base prompt (pre-assembly) so compose subagents do not
@@ -427,7 +440,7 @@ export async function bootstrapSession(
     resolveApiKeyForModel: getApiKeyForModel,
     ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
     // Anchor DAG nodes to the worktree (re-anchored via composeExecutor.setCwd).
-    ...(extras?.cwd !== undefined ? { cwd: extras.cwd } : {}),
+    ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
     systemPrompt: basePrompt ?? '',
     // Session identity for routing-decision rows (REPL → cli).
     surface: 'cli',
@@ -453,7 +466,7 @@ export async function bootstrapSession(
     // Use the worktree cwd for project-local `.mcp.json` resolution so each
     // worktree can carry its own MCP config (matching how the worktree
     // already isolates everything else under `worktreeCwd`).
-    const projectCwd = extras?.cwd ?? process.cwd();
+    const projectCwd = effectiveCwd ?? process.cwd();
     // Imported MCP servers from trusted source binaries (`importFrom`). Only
     // JSON-format configs (Claude Code) are loadable today; they enter as the
     // lowest-priority layer so AFK's own config always wins. MCP import is
@@ -587,17 +600,29 @@ export async function bootstrapSession(
     stats.thinkingUi = options.thinkingUi;
   }
   // Stamp the effective working directory on stats so the status line can
-  // render it. We capture the same cwd the provider will see: the explicit
-  // `extras.cwd` override (e.g. from `--worktree`) when present, else
+  // render it. We capture the same cwd the provider will see: `effectiveCwd`
+  // (the explicit `--worktree` override when present, else a resumed session's
+  // restored cwd — see resolveResumeCwd above), falling back to
   // `process.cwd()`. Captured once at bootstrap — sessions don't `chdir`
   // mid-run, and the status line treats this as a fixed identity field.
-  stats.cwd = extras?.cwd ?? process.cwd();
+  stats.cwd = effectiveCwd ?? process.cwd();
 
   // Trace was opened earlier (before the executor) so the
   // BackgroundAgentRegistry could be constructed with the writer. Surface
   // the path here so the startup banner ordering is preserved.
   if (trace) {
     console.log(palette.dim(`  trace: ${trace.tracePath}`));
+  }
+  // Make a restored resume cwd legible: only when the cwd came from the stored
+  // session (not an explicit --worktree, which the banner already implies) and
+  // differs from where the shell launched. Printed in the same dim-log style
+  // as the trace line above, before the compositor is armed.
+  if (
+    extras?.cwd === undefined &&
+    effectiveCwd !== undefined &&
+    effectiveCwd !== process.cwd()
+  ) {
+    console.log(palette.dim(`  ↪ resuming in ${effectiveCwd}`));
   }
 
   // Both slots default to `console.log` here; `runReplLoop` mutates them
@@ -626,9 +651,9 @@ export async function bootstrapSession(
     'cli',
     sharedMemoryStore,
     () => stats.permissionMode,
-    loadHooksConfig({ cwd: extras?.cwd }),
-    { cwd: extras?.cwd, ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}) },
-    () => extras?.cwd ?? process.cwd(),
+    loadHooksConfig({ cwd: effectiveCwd }),
+    { cwd: effectiveCwd, ...(trace?.writer !== undefined ? { traceWriter: trace.writer } : {}) },
+    () => effectiveCwd ?? process.cwd(),
   );
   const hookRegistry = hookRegistryBundle.registry;
   const pathApprovalGrantRef = hookRegistryBundle.pathApprovalGrantRef;
@@ -647,7 +672,7 @@ export async function bootstrapSession(
     providerFactory,
     hookRegistry,
     traceWriter: trace?.writer,
-    cwd: extras?.cwd,
+    cwd: effectiveCwd,
     maxTurns: parseInt(options.maxTurns, 10),
     autoResumeOnUsageLimit: cliConfig.autoResumeOnUsageLimit,
     ...(initialPermissionMode !== undefined ? { permissionMode: initialPermissionMode } : {}),

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -1,4 +1,5 @@
 import * as readline from 'node:readline';
+import { resolve } from 'node:path';
 import { elicitationRouter } from '../../../agent/elicitation-router.js';
 import { makeReplElicitationHandler } from '../../elicitation-repl.js';
 import { AgentSession } from '../../../agent/session.js';
@@ -163,13 +164,13 @@ export async function bootstrapSession(
   // was saved in (e.g. an `afk --worktree` session that was later /fork'd or
   // --resume'd), not wherever the shell happens to be. Precedence: an explicit
   // --worktree override (extras.cwd) always wins; otherwise fall back to the
-  // stored cwd IFF it still exists on disk — a cleaned-up worktree degrades
-  // safely to process.cwd(). `effectiveCwd` is threaded through every
-  // cwd-purpose usage below (stats stamp, hook/session cwd, subagent/skill/
-  // compose/MCP cwd) so resumed worktree sessions AND their children anchor
-  // correctly. Defaults to `extras?.cwd` when there is no resume override, so
-  // this is a safe drop-in: behavior only changes for a resume whose stored
-  // cwd still exists.
+  // stored cwd IFF it still exists on disk as a directory — a cleaned-up
+  // worktree degrades safely to process.cwd(). `effectiveCwd` is threaded
+  // through every cwd-purpose usage below (stats stamp, hook/session cwd,
+  // subagent/skill/compose/MCP cwd) so resumed worktree sessions AND their
+  // children anchor correctly. Defaults to `extras?.cwd` when there is no
+  // resume override, so this is a safe drop-in: behavior only changes for a
+  // resume whose stored cwd still exists.
   const effectiveCwd = resolveResumeCwd(extras?.cwd, resumeTarget?.stored?.cwd);
   const sessionModel = resumeTarget?.stored?.model ?? options.model;
   // Fail fast on an unconfigured capability tier (e.g. `afk i -m local` with no
@@ -620,7 +621,7 @@ export async function bootstrapSession(
   if (
     extras?.cwd === undefined &&
     effectiveCwd !== undefined &&
-    effectiveCwd !== process.cwd()
+    resolve(effectiveCwd) !== resolve(process.cwd())
   ) {
     console.log(palette.dim(`  ↪ resuming in ${effectiveCwd}`));
   }

--- a/src/cli/commands/interactive/shared.test.ts
+++ b/src/cli/commands/interactive/shared.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { printResumeBanner, resolveResumeCwd } from './shared.js';
@@ -346,6 +346,13 @@ describe('resolveResumeCwd — resume cwd precedence', () => {
     tmp = mkdtempSync(join(tmpdir(), 'afk-resume-cwd-'));
     // No --worktree override → fall back to the (existing) stored cwd.
     expect(resolveResumeCwd(undefined, tmp)).toBe(tmp);
+  });
+
+  it('falls back (undefined) when the stored cwd exists but is a regular file, not a directory', () => {
+    tmp = mkdtempSync(join(tmpdir(), 'afk-resume-cwd-'));
+    const file = join(tmp, 'not-a-dir');
+    writeFileSync(file, 'x');
+    expect(resolveResumeCwd(undefined, file)).toBeUndefined();
   });
 
   it('falls back (undefined) when the stored cwd no longer exists', () => {

--- a/src/cli/commands/interactive/shared.test.ts
+++ b/src/cli/commands/interactive/shared.test.ts
@@ -11,8 +11,11 @@
  *   - Picks the LAST turn from a multi-turn array
  */
 
-import { describe, it, expect } from 'vitest';
-import { printResumeBanner } from './shared.js';
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { printResumeBanner, resolveResumeCwd } from './shared.js';
 import type { SessionStats, TurnRecord } from '../../slash/types.js';
 import type { CompletionWriter } from './shared.js';
 
@@ -318,5 +321,52 @@ describe('printResumeBanner', () => {
     // No ellipsis means no truncation happened.
     expect(line).not.toContain('…');
     expect(line).toBe('  Last: ' + '🎉'.repeat(80));
+  });
+});
+
+/**
+ * Tests for `resolveResumeCwd` — the precedence helper that lets a resumed
+ * interactive session run in the directory it was saved in (the fork/resume
+ * cwd-restore fix), without clobbering an explicit `--worktree` override.
+ *
+ * Precedence under test:
+ *   (a) stored cwd that EXISTS on disk is used
+ *   (b) stored cwd that does NOT exist falls back (returns undefined)
+ *   (c) an explicit extras.cwd (--worktree) always wins over stored cwd
+ */
+describe('resolveResumeCwd — resume cwd precedence', () => {
+  let tmp: string | undefined;
+
+  afterEach(() => {
+    if (tmp !== undefined) rmSync(tmp, { recursive: true, force: true });
+    tmp = undefined;
+  });
+
+  it('uses the stored cwd when it still exists on disk', () => {
+    tmp = mkdtempSync(join(tmpdir(), 'afk-resume-cwd-'));
+    // No --worktree override → fall back to the (existing) stored cwd.
+    expect(resolveResumeCwd(undefined, tmp)).toBe(tmp);
+  });
+
+  it('falls back (undefined) when the stored cwd no longer exists', () => {
+    // A cleaned-up worktree: the stored path is gone. The helper returns
+    // undefined so the caller degrades to process.cwd().
+    const gone = join(tmpdir(), `afk-resume-cwd-missing-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    expect(resolveResumeCwd(undefined, gone)).toBeUndefined();
+  });
+
+  it('lets an explicit extras.cwd (--worktree) win over the stored cwd', () => {
+    tmp = mkdtempSync(join(tmpdir(), 'afk-resume-cwd-'));
+    // Even though the stored cwd exists, the explicit override takes priority
+    // and is returned WITHOUT an existsSync check.
+    expect(resolveResumeCwd('/explicit/worktree', tmp)).toBe('/explicit/worktree');
+  });
+
+  it('returns undefined when neither an override nor a stored cwd is present', () => {
+    expect(resolveResumeCwd(undefined, undefined)).toBeUndefined();
+  });
+
+  it('returns the explicit override even when there is no stored cwd', () => {
+    expect(resolveResumeCwd('/explicit/worktree', undefined)).toBe('/explicit/worktree');
   });
 });

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -1,4 +1,5 @@
 import * as readline from 'node:readline';
+import { existsSync } from 'node:fs';
 import type { HookRegistry } from '../../../agent/hooks.js';
 import type { SessionRef } from '../../../agent/session-ref.js';
 import type { MemoryStore } from '../../../agent/memory/index.js';
@@ -52,6 +53,35 @@ export function reseedStatsFromStored(
   // was added lack the field, deserializing as undefined despite the type.
   // Default to now so the status-line duration is 0, not NaN.
   stats.sessionStartTime = stored.startedAt ?? Date.now();
+}
+
+/**
+ * Resolve the effective working directory for a (possibly resumed) interactive
+ * session. Precedence:
+ *   1. An explicit `--worktree` override (`extrasCwd`) ALWAYS wins.
+ *   2. Otherwise, fall back to the resumed session's stored cwd — but ONLY when
+ *      it still exists on disk. A resumed session should run in the directory
+ *      it was saved in (e.g. an `afk --worktree` session later `/fork`'d or
+ *      `--resume`'d), not wherever the shell happens to be. A cleaned-up
+ *      worktree degrades safely (the stored cwd is ignored, caller falls back
+ *      to `process.cwd()`).
+ *
+ * Returns `undefined` when neither source applies, so callers keep their
+ * existing `?? process.cwd()` fallback. Because it defaults to `extrasCwd` when
+ * there is no resume override, this is a safe drop-in — behavior only changes
+ * for a resume whose stored cwd still exists.
+ *
+ * Extracted as a pure helper (rather than inlined in bootstrap) so the
+ * precedence contract is unit-testable in isolation from the heavy session
+ * construction path.
+ */
+export function resolveResumeCwd(
+  extrasCwd: string | undefined,
+  storedCwd: string | undefined,
+): string | undefined {
+  if (extrasCwd !== undefined) return extrasCwd;
+  if (storedCwd !== undefined && existsSync(storedCwd)) return storedCwd;
+  return undefined;
 }
 
 /**

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -1,5 +1,5 @@
 import * as readline from 'node:readline';
-import { existsSync } from 'node:fs';
+import { statSync } from 'node:fs';
 import type { HookRegistry } from '../../../agent/hooks.js';
 import type { SessionRef } from '../../../agent/session-ref.js';
 import type { MemoryStore } from '../../../agent/memory/index.js';
@@ -56,15 +56,29 @@ export function reseedStatsFromStored(
 }
 
 /**
+ * True iff `p` exists AND is a directory. A stored cwd that resolved to a
+ * regular file (or a broken symlink) must NOT be used as a working directory,
+ * so we stat rather than existsSync. Any stat error (ENOENT, EACCES, race)
+ * degrades to false, so the caller falls back to process.cwd().
+ */
+function isExistingDir(p: string): boolean {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Resolve the effective working directory for a (possibly resumed) interactive
  * session. Precedence:
  *   1. An explicit `--worktree` override (`extrasCwd`) ALWAYS wins.
  *   2. Otherwise, fall back to the resumed session's stored cwd — but ONLY when
- *      it still exists on disk. A resumed session should run in the directory
- *      it was saved in (e.g. an `afk --worktree` session later `/fork`'d or
- *      `--resume`'d), not wherever the shell happens to be. A cleaned-up
- *      worktree degrades safely (the stored cwd is ignored, caller falls back
- *      to `process.cwd()`).
+ *      it still exists on disk as a directory. A resumed session should run in
+ *      the directory it was saved in (e.g. an `afk --worktree` session later
+ *      `/fork`'d or `--resume`'d), not wherever the shell happens to be. A
+ *      cleaned-up worktree degrades safely (the stored cwd is ignored, caller
+ *      falls back to `process.cwd()`).
  *
  * Returns `undefined` when neither source applies, so callers keep their
  * existing `?? process.cwd()` fallback. Because it defaults to `extrasCwd` when
@@ -80,7 +94,7 @@ export function resolveResumeCwd(
   storedCwd: string | undefined,
 ): string | undefined {
   if (extrasCwd !== undefined) return extrasCwd;
-  if (storedCwd !== undefined && existsSync(storedCwd)) return storedCwd;
+  if (storedCwd !== undefined && isExistingDir(storedCwd)) return storedCwd;
   return undefined;
 }
 

--- a/src/cli/session-store.test.ts
+++ b/src/cli/session-store.test.ts
@@ -272,6 +272,25 @@ describe('session-store', () => {
       expect(found).toBeDefined();
       expect(found!.id).toBe(id);
     });
+
+    it('preserves the session cwd so the fork resumes in the same directory', () => {
+      const stats = createSessionStats('sonnet');
+      recordTurn(stats, 'q', 'a', { sessionId: 'p' });
+      stats.cwd = '/some/worktree';
+      const { id } = forkStoredSession(stats);
+      const forked = loadSession(id);
+      expect(forked!.cwd).toBe('/some/worktree');
+    });
+
+    it('omits cwd when the session has none', () => {
+      const stats = createSessionStats('sonnet');
+      recordTurn(stats, 'q', 'a', { sessionId: 'p' });
+      expect(stats.cwd).toBeUndefined();
+      const { id } = forkStoredSession(stats);
+      const forked = loadSession(id);
+      expect(forked!.cwd).toBeUndefined();
+      expect('cwd' in (forked as object)).toBe(false);
+    });
   });
 });
 

--- a/src/cli/session-store.ts
+++ b/src/cli/session-store.ts
@@ -186,6 +186,10 @@ export function forkStoredSession(
     totalTokens: stats.totalTokens,
     totalDurationMs: stats.totalDurationMs,
     turns: [...stats.turns],
+    // Preserve the session's cwd so a forked sidecar records where it was
+    // running (e.g. an `afk --worktree` session). Without this, resuming the
+    // fork lands in the launch cwd instead of the worktree. Mirrors saveSession.
+    ...(stats.cwd ? { cwd: stats.cwd } : {}),
     ...(stats.sessionId ? { forkedFrom: stats.sessionId } : {}),
     forkedAt: Date.now(),
   };


### PR DESCRIPTION
## Problem

When a user `/fork`s (or plain `--resume`s) an interactive session that was started with `afk --worktree`, the continued session does **not** run in the worktree — it lands in the launch cwd (repo root).

Root cause is a latent gap (not a regression — `cwd` was added in 3ba3674 for `/resume` list-filtering only, never wired into fork/resume):

1. **`forkStoredSession` dropped `cwd`** (`src/cli/session-store.ts`) — the fork sidecar was written without `cwd`, even though the sibling `saveSession` records it.
2. **Resume never restored a stored `cwd`** — `resumeConfigFor` returns only `resume`/`sessionId`/`resumeHistory`, and bootstrap's effective cwd is `extras?.cwd ?? process.cwd()`, where `extras.cwd` is populated **only** by `--worktree`. On a `--resume` run there is no `--worktree`, so the session silently used `process.cwd()`.

This bit hardest on the printed/clipboard resume command (`afk interactive --resume <id>`, no `cd`) and on any terminal where `/fork`'s best-effort tab-spawn can't run (VS Code, Alacritty, Hyper, unknown, Linux Ghostty).

## Fix

- **`forkStoredSession`** now preserves `cwd` (`...(stats.cwd ? { cwd: stats.cwd } : {})`), mirroring `saveSession`.
- **Interactive bootstrap** restores a resumed session's cwd via a new pure helper `resolveResumeCwd(extrasCwd, storedCwd)`. Precedence: an explicit `--worktree` override always wins → else the stored cwd **iff it still exists on disk** (a cleaned-up worktree degrades safely to `process.cwd()`) → else `undefined` (callers keep their `?? process.cwd()` fallback). `effectiveCwd` is threaded through every cwd-purpose usage (session, stats stamp, hooks config/registry/getter, subagent/skill/compose executors, MCP project cwd) so a resumed worktree session **and its children** anchor correctly. Adds a dim `↪ resuming in <path>` notice on restore.

Because `resolveResumeCwd` defaults to `extras?.cwd` when there is no resume override, this is a safe drop-in — behavior changes only for a resume whose stored cwd still exists. **Telegram/daemon paths and `formatResumeCommand` are untouched.**

## Test plan

- New: `forkStoredSession` preserves `cwd` (and omits it when absent) — `session-store.test.ts`.
- New: `resolveResumeCwd` precedence — exists→used, missing→fallback, `--worktree` override wins — `shared.test.ts`.
- `pnpm lint` clean; targeted `session-store` + `shared` + `fork` suites green (69 tests); full suite green (11387 passed) on the pre-rebase base.

🤖 Diagnosed and validated via `/diagnose`.
