### PR TITLE
feat(plugins): mirror source enabled/disabled state for imported plugins

### DIFF
--- a/docs/specs/imported-plugin-enabled-state.md
+++ b/docs/specs/imported-plugin-enabled-state.md
@@ -1,0 +1,172 @@
+# Spec: Honor Source Enabled/Disabled State for Imported Plugins
+
+**Type:** Feature (behavioral fix + small config-shape change)
+**Repo:** Public core (`griffinwork40/agent-afk`) — land directly in the public checkout
+**Branch:** `afk/imported-plugin-enabled-state` (off `origin/main`)
+**Status:** Implemented — v1 (Claude-only, pure-mirror). Full suite green; opened as a PR. Design refined from the draft during implementation (AFK-index override dropped — see §3/§4).
+
+---
+
+## 1. Problem Statement
+
+When a user trusts Claude Code (or Codex) via `afk migrate`, AFK live-scans that tool's plugin directory on **every** session and loads **every** plugin it finds — including plugins the user has explicitly **disabled** in the source tool. The disabled state is silently ignored.
+
+Verified mechanism:
+
+- `afk migrate` writes only an `importFrom` trust-flag block into `afk.config.json`; it copies nothing (`src/cli/commands/migrate.ts:6-10`). So "the plugins" are never brought into `~/.afk` — they are read in place.
+- Each session, `scanAllPluginRoots()` scans four roots and reads the imported roots with `trustAll: true` (`src/agent/tools/skill-bridge.ts:351-358`).
+- `trustAll` bypasses the enabled-gate entirely (`src/agent/plugins-scanner.ts:135-146`): for a trusted root, every directory containing `.claude-plugin/plugin.json` is loaded unconditionally. The scan never reads Claude Code's `enabledPlugins` or Codex's `[plugins]` state (zero `enabledPlugins` references repo-wide).
+- `trustAll` was a deliberate design ("the user opted into the whole binary; AFK has no index to consult" — `plugins-scanner.ts:68-74`). Honoring the *source's own* disabled state simply fell outside that model. This is an oversight, not intent. No test covers a source-disabled plugin.
+
+Impact: a plugin the user turned off in Claude Code still injects its skills/commands/agents into every AFK session — surprising, and (for a plugin the user disabled deliberately) unwanted.
+
+---
+
+## 2. Goals
+
+1. When scanning a **trusted imported root**, skip plugins that are **disabled in the source tool**, so AFK mirrors the source's enabled/disabled state ("state stays the same"). The source tool (Claude Code) is the single source of truth for its own plugins' enabled state; AFK follows it.
+2. Ship with tests for the source-disabled path (there are none today).
+
+## 3. Non-Goals
+
+- **No copying of plugin files** into `~/.afk`. The live-scan-in-place model stays; we only add a filter.
+- **No AFK-side override for imported plugins (as-built refinement).** Foreign plugins live in the source tool's dir and are not in AFK's `.index.json`; adding an AFK toggle would create two competing sources of truth. The user manages an imported plugin's enabled state **in its home tool** (toggle in Claude Code → AFK mirrors it next session). AFK's own `~/.afk/plugins` plugins keep their existing `afk plugin enable|disable`, unchanged.
+- **Codex is out of scope for v1.** Codex plugin import is detection-only today (`migrate.ts:165`); its enabled-state format is known (`~/.codex/config.toml` → `[plugins."name@marketplace"].enabled`) but wiring it is a follow-up phase.
+- **No new persistence model.** No writes at all on the scan path — the filter is read-only.
+- **No project/local/managed Claude settings.** Only the user-global `~/.claude/settings.json` is read (matches AFK's home-dir, cwd-independent import model — `import-sources.ts:147-156`). Repo-scoped `enabledPlugins` is not consulted.
+
+---
+
+## 4. Approach & Key Decisions
+
+**Chosen approach (as-built): pure source-state mirroring for imported roots.** During implementation the "AFK-index override" from the original draft was dropped (see Non-Goals) — imported plugins aren't in AFK's index, so an override would create two sources of truth. The source tool stays authoritative; AFK reads and follows it. This is a smaller, read-only change than the drafted mirror+override.
+
+Resolution order for a plugin in a trusted imported root (in `walk`, trusted branch):
+
+1. **Mirror the source.** Read the source tool's enabled-map; if the plugin key is present and `false` → skip. If present and `true` → load.
+2. **Else default enabled.** No source signal (no `settings.json`, plugin absent from `enabledPlugins`, empty map, or a binary with no enable-state) → load. Preserves today's behavior; backward compatible (fail-open).
+
+### Key decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | v1 = Claude Code only; Codex deferred | Codex import is detection-only today; Claude is where the pain is. |
+| D2 | Pure mirror; source tool is the single source of truth for imported plugins | Matches operator's "keep state the same"; avoids two competing toggles; keeps the scan path read-only. |
+| D3 | Reuse `indexKeyForPath` (`plugins-scanner.ts:218`) to derive the plugin key | It already yields `<marketplace>:<pluginName>` for cache layout — the exact pieces needed to build Claude's `<pluginName>@<marketplace>` lookup key. No new parsing. |
+| D4 | Absent-from-`enabledPlugins` ⇒ enabled (v1) | Claude's true semantics fall back to the plugin's `defaultEnabled` (default `true`). v1 approximates with "absent = enabled" and documents the edge; resolving real `defaultEnabled` per `plugin.json` is a hardening follow-up (see Open Questions). |
+| D5 | Malformed/unreadable `settings.json` ⇒ fail **open** (load all) | Never let a bad source file break plugin loading; matches the defensive posture of `loadImportFromConfig` (`import-sources.ts:166-169`). |
+| D6 | Tag `resolveImportedRoots().pluginRoots` with its source binary | The scanner must know which source config to consult per root. Mirror the existing `skillRoots: { dir, origin }[]` pattern (`import-sources.ts:211-216`) rather than re-deriving the binary from the path inside the scanner. |
+
+### Format-transform (the matching key — D3)
+
+- AFK cache-layout key (from `indexKeyForPath`): `"<marketplace>:<pluginName>"`.
+- Claude `enabledPlugins` key: `"<pluginName>@<marketplace>"` (`~/.claude/settings.json`, values are booleans).
+- Transform: `mp:name` ⟷ `name@mp`. Build the lookup key from the scanner's already-computed marketplace + name.
+
+---
+
+## 5. Interface
+
+### 5.1 New: source enabled-state reader (`src/config/import-sources.ts`)
+
+```ts
+/** Map of source-tool plugin key → enabled. Key format is the SOURCE tool's
+ *  native format (Claude: "<pluginName>@<marketplace>"). Absent key ⇒ no signal. */
+export type SourceEnabledMap = ReadonlyMap<string, boolean>;
+
+/** Read a trusted binary's own plugin enabled/disabled state. v1 implements
+ *  claude-code (reads ~/.claude/settings.json `enabledPlugins`); other binaries
+ *  return an empty map (no signal ⇒ default-enabled). Fail-open on any error. */
+export function readSourceEnabledState(
+  binary: ImportSourceBinary,
+  home?: string,        // injectable for tests
+): SourceEnabledMap;
+```
+
+Add a `pluginEnabledState?: (home: string) => SourceEnabledMap` field to `SourcePathMap` / `SOURCE_MAPS` (`import-sources.ts:62-92`) so the reader is table-driven per binary, consistent with `pluginRoots` / `mcpConfigCandidates`.
+
+### 5.2 Changed: tag plugin roots by binary (`src/config/import-sources.ts`)
+
+`ResolvedImportRoots.pluginRoots` changes from `string[]` to:
+
+```ts
+pluginRoots: { dir: string; binary: ImportSourceBinary }[];
+```
+
+Populated in `resolveImportedRoots` (`import-sources.ts:206-210`), mirroring `skillRoots`. **Consumer to update:** `src/agent/tools/skill-bridge.ts:356-357` (the only `.pluginRoots` consumer — `.mcpConfigs` / `.skillRoots` consumers are unaffected).
+
+### 5.3 Changed: scanner accepts a source enabled-map (`src/agent/plugins-scanner.ts`)
+
+```ts
+export function scanLocalPlugins(
+  dir?: string,
+  opts?: { trustAll?: boolean; sourceEnabled?: SourceEnabledMap },
+): SdkPluginConfig[];
+```
+
+- Thread `sourceEnabled` into `walk()`.
+- In the trusted-root branch (was the `if (!trustAll)` bypass), the trusted path now gets its own block: build the source key via `sourceEnabledKey(indexKeyForPath(...))` (`mp:name` → `name@mp`); skip only when `sourceEnabled.get(key) === false`; else load. No AFK-index read on the trusted path (pure mirror).
+- **Cache-key fix:** fold a stable digest of `sourceEnabled` into the scan cache key so a trusted scan with a source-disabled plugin doesn't alias a prior unfiltered result. (Within a session the map is stable, so this is a correctness guard, not a perf hit.)
+
+### 5.4 Reused as-is (no change)
+
+- `indexKeyForPath()` (`plugins-scanner.ts`) — key derivation, plus a new tiny `sourceEnabledKey()` helper for the `mp:name` → `name@mp` transform.
+- `readIndex()` (`index-store.ts`) — unchanged; the trusted path no longer consults it (AFK's index does not track foreign plugins). `index-store.ts` and `plugin.ts` are **not touched** by this change.
+
+---
+
+## 6. File Map
+
+| File | Change |
+|------|--------|
+| `src/config/import-sources.ts` | Add `SourceEnabledMap`, `readSourceEnabledState`, Claude `settings.json` `enabledPlugins` parser; add `pluginEnabledState` to `SourcePathMap`; change `pluginRoots` shape to `{dir,binary}[]`. |
+| `src/config/import-sources.test.ts` | Tests for the reader (present/absent/disabled/malformed) + new `pluginRoots` shape. |
+| `src/agent/plugins-scanner.ts` | Add `sourceEnabled` opt; apply resolution order in the trusted-root branch; fold into cache key. |
+| `src/agent/plugins-scanner.test.ts` | Tests for source-disabled skip, source-enabled load, absent-default, per-plugin mirroring, cache-key non-aliasing, flat-layout key, empty-map fail-open. |
+| `src/agent/tools/skill-bridge.ts` | Update the `.pluginRoots` consumer to pass `{ trustAll: true, sourceEnabled: readSourceEnabledState(binary) }` per root. |
+| `docs/specs/imported-plugin-enabled-state.md` | This spec. |
+| `docs/env-registry.*` | No change expected (no new env var). Run `pnpm scan:env:check` to confirm. |
+
+---
+
+## 7. Test Plan
+
+Functional (new coverage — none existed before) — **all implemented & green**:
+
+- [x] A cache plugin the source tool disabled is **not** loaded from a trusted root.
+- [x] A cache plugin the source tool enabled **is** loaded.
+- [x] A plugin **absent** from the source map is loaded (no signal ⇒ default-enabled).
+- [x] Per-plugin mirroring in one scan (one enabled loads, one disabled skips).
+- [x] `sourceEnabled` is folded into the cache key so a filtered scan does not alias a prior unfiltered trusted scan.
+- [x] A flat-layout trusted plugin the source disabled is skipped (key = dir name).
+- [x] An empty `sourceEnabled` map disables nothing (fail-open).
+- [x] Reader: `enabledPlugins` parsed to a `name@mp → bool` map; missing / malformed / non-object / non-boolean all fail-open; Codex returns empty.
+
+Quality gates — **all passing**:
+
+- [x] Full suite green: 626 files, 11,389 passed / 14 skipped / 0 failed (`vitest run`).
+- [x] `tsc --noEmit` clean (strict).
+- [x] `pnpm audit:sdk:check` + `audit:env:check` + `scan:env:check` all pass.
+- [x] No `@anthropic-ai/sdk` runtime import added (only a `type`-only import of `SourceEnabledMap` into the scanner).
+
+---
+
+## 8. Open Questions
+
+1. **Q1 — `defaultEnabled` fidelity (D4).** v1 treats "absent from `enabledPlugins`" as enabled. True Claude semantics resolve absent → the plugin's `defaultEnabled` (from `plugin.json` / marketplace, default `true`, Claude ≥ v2.1.154). Ship v1 with "absent = enabled" and document, or read `defaultEnabled` per plugin now? (Recommendation: ship approximation, hardening follow-up.)
+2. **Q2 — RESOLVED (docs + issue evidence).** Claude Code copies **installed** plugins to `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/.claude-plugin/plugin.json` (docs: "copies it to `~/.claude/plugins/cache`"; anthropics/claude-code#8, #14815) and keys `enabledPlugins` as `<plugin>@<marketplace>`, where the cache dir-name IS the marketplace token (#17061: `cache/superpowers-dev/` ↔ `superpowers@superpowers-dev`). This is exactly AFK's `indexKeyForPath` cache layout (`cache/<mp>/<plugin>[/<version>]` → `mp:plugin`), so the `mp:name` → `name@mp` transform matches real installs. Locked by a real-layout test. The empty `~/.claude/plugins/marketplaces/` dir is the marketplace *catalog clone*, not the installed-plugin cache (see the new observation below). Still not validated against a machine with an actually-disabled plugin (this dev machine has zero installed Claude plugins), but the path/key contract is now doc-confirmed.
+3. **Q3 — RESOLVED (as-built).** The AFK-side override for imported plugins was dropped; the source tool is authoritative (see Non-Goals). No `setEnabled`/`upsertPlugin` on the scan path, so the "first-time override throws" problem no longer applies. Revisit only if a per-AFK override is later requested.
+4. **Q4 — surfacing in `afk plugin list`.** Should imported (foreign-root) plugins appear in `afk plugin list` with an origin tag and their mirrored state? Nice-to-have for discoverability; not required for the core fix. Deferred.
+5. **Q5 — Codex phase.** Scope the follow-up: `~/.codex/config.toml` `[plugins."name@mp"].enabled` + `features.plugins` master switch, gated on Codex plugin import graduating past detection-only.
+6. **Q6 — `marketplaces/` catalog over-inclusion (pre-existing, separate).** Observed during validation: `~/.claude/plugins/marketplaces/<mp>/` is a full clone of the marketplace repo (its `plugins/<name>/` may contain `.claude-plugin/plugin.json` for *non-installed* catalog entries). The existing `trustAll` scan may therefore already load catalog plugins that were never installed — independent of enabled state. This fix does not address it (a plugin under `marketplaces/…` derives a flat key, not `<name>@<mp>`, so it isn't matched against `enabledPlugins`). Not a regression from this change; flagged as a distinct follow-up (the scan arguably should only descend `cache/`, not `marketplaces/`, for imported Claude roots).
+
+---
+
+## 9. Epistemic Confidence
+
+- **High** — the current mechanism and every cited file:line (scan path, `trustAll` bypass, existing enable/disable infra, key derivation). Read directly from source this session.
+- **High** — source formats: Claude `~/.claude/settings.json` `enabledPlugins: {"name@marketplace": bool}` and Codex `config.toml` `[plugins]` (official docs + Codex Rust source `config_toml.rs`).
+- **High (upgraded from Medium)** — the `marketplace` token equivalence (Q2). Claude's own docs confirm installed plugins live at `~/.claude/plugins/cache/<mp>/<plugin>/<version>/` and issue #17061 shows the cache dir-name is the `@<marketplace>` token in `enabledPlugins` — exactly AFK's cache-layout key. Locked by a real-layout unit test. Residual: not exercised against a machine with an actually-disabled installed plugin (none on this dev box); failure mode is fail-open (over-inclusion), never a crash.
+- **Observation** — `~/.claude/plugins/marketplaces/` (catalog clone) vs `cache/` (installed) distinction surfaced a separate pre-existing over-inclusion question (Q6), out of scope here.
+- **Time-sensitive** — both plugin systems are evolving; field *names* are stable but *precedence* rules are in flux (Claude project/local/managed scopes; Codex curated/remote account-synced state). v1 deliberately scopes to user-global Claude only to sidestep this.
+- **Human judgment needed** — Q1 (defaultEnabled fidelity vs. ship-now) and Q4 (list surfacing) are product calls, not code-forced.

--- a/src/agent/plugins-scanner.test.ts
+++ b/src/agent/plugins-scanner.test.ts
@@ -357,4 +357,93 @@ describe('plugins-scanner', () => {
     const result = scanLocalPlugins(tmpHome);
     expect(result.map((p) => p.path)).toEqual([join(tmpHome, 'still-here')]);
   });
+
+  // ── Imported-root mirroring: trustAll + sourceEnabled ──────────────────────
+  // A trusted imported root (e.g. ~/.claude/plugins) has no AFK index; instead
+  // of loading everything, the scan mirrors the SOURCE tool's own enabled state.
+
+  it('trustAll + sourceEnabled: skips a cache plugin the source tool disabled', () => {
+    const pluginDir = join(tmpHome, 'cache', 'some-market', 'some-plugin');
+    writePluginManifest(pluginDir);
+    const sourceEnabled = new Map([['some-plugin@some-market', false]]);
+    expect(scanLocalPlugins(tmpHome, { trustAll: true, sourceEnabled })).toEqual([]);
+  });
+
+  it('trustAll + sourceEnabled: loads a cache plugin the source tool enabled', () => {
+    const pluginDir = join(tmpHome, 'cache', 'some-market', 'some-plugin');
+    writePluginManifest(pluginDir);
+    const sourceEnabled = new Map([['some-plugin@some-market', true]]);
+    expect(scanLocalPlugins(tmpHome, { trustAll: true, sourceEnabled })).toEqual([
+      { type: 'local', path: pluginDir },
+    ]);
+  });
+
+  it('trustAll + sourceEnabled: loads a plugin absent from the map (no signal ⇒ enabled)', () => {
+    const pluginDir = join(tmpHome, 'cache', 'some-market', 'some-plugin');
+    writePluginManifest(pluginDir);
+    const sourceEnabled = new Map([['unrelated@other', false]]);
+    expect(scanLocalPlugins(tmpHome, { trustAll: true, sourceEnabled })).toEqual([
+      { type: 'local', path: pluginDir },
+    ]);
+  });
+
+  it('trustAll + sourceEnabled: mirrors per-plugin (enabled loads, disabled skips) in one scan', () => {
+    writePluginManifest(join(tmpHome, 'cache', 'mp', 'keep'));
+    writePluginManifest(join(tmpHome, 'cache', 'mp', 'drop'));
+    const sourceEnabled = new Map([
+      ['keep@mp', true],
+      ['drop@mp', false],
+    ]);
+    const result = scanLocalPlugins(tmpHome, { trustAll: true, sourceEnabled });
+    expect(result.map((p) => p.path)).toEqual([join(tmpHome, 'cache', 'mp', 'keep')]);
+  });
+
+  it('folds sourceEnabled into the cache key so filtered/unfiltered scans do not alias', () => {
+    const pluginDir = join(tmpHome, 'cache', 'mp', 'p');
+    writePluginManifest(pluginDir);
+    // Unfiltered trusted scan loads it and memoizes under its own key…
+    expect(scanLocalPlugins(tmpHome, { trustAll: true })).toEqual([
+      { type: 'local', path: pluginDir },
+    ]);
+    // …a source-filtered scan (disabled) must NOT return the cached unfiltered result.
+    const sourceEnabled = new Map([['p@mp', false]]);
+    expect(scanLocalPlugins(tmpHome, { trustAll: true, sourceEnabled })).toEqual([]);
+  });
+
+  it('trustAll + sourceEnabled: skips a flat-layout plugin the source disabled (key = dir name)', () => {
+    writePluginManifest(join(tmpHome, 'flat-plugin'));
+    const sourceEnabled = new Map([['flat-plugin', false]]);
+    expect(scanLocalPlugins(tmpHome, { trustAll: true, sourceEnabled })).toEqual([]);
+  });
+
+  it('an empty sourceEnabled map disables nothing (fail-open)', () => {
+    const pluginDir = join(tmpHome, 'cache', 'mp', 'p');
+    writePluginManifest(pluginDir);
+    const sourceEnabled = new Map<string, boolean>();
+    expect(scanLocalPlugins(tmpHome, { trustAll: true, sourceEnabled })).toEqual([
+      { type: 'local', path: pluginDir },
+    ]);
+  });
+
+  it("matches Claude's real installed layout cache/<mp>/<plugin>/<version> ↔ <plugin>@<mp>", () => {
+    // Claude Code copies installed plugins to
+    // `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/` and keys
+    // `enabledPlugins` as `<plugin>@<marketplace>` — e.g. the cache dir
+    // `cache/superpowers-dev/` pairs with `superpowers@superpowers-dev`
+    // (anthropics/claude-code#8, #14815, #17061). This locks the derivation
+    // against the real on-disk shape, not just a synthetic fixture.
+    const pluginDir = join(tmpHome, 'cache', 'superpowers-dev', 'superpowers', '4.0.3');
+    writePluginManifest(pluginDir);
+
+    // Disabled in Claude → skipped in AFK.
+    const disabled = new Map([['superpowers@superpowers-dev', false]]);
+    expect(scanLocalPlugins(tmpHome, { trustAll: true, sourceEnabled: disabled })).toEqual([]);
+
+    // Enabled in Claude → loaded.
+    _resetPluginScanCache();
+    const enabled = new Map([['superpowers@superpowers-dev', true]]);
+    expect(scanLocalPlugins(tmpHome, { trustAll: true, sourceEnabled: enabled })).toEqual([
+      { type: 'local', path: pluginDir },
+    ]);
+  });
 });

--- a/src/agent/plugins-scanner.ts
+++ b/src/agent/plugins-scanner.ts
@@ -17,6 +17,7 @@
  */
 
 import type { SdkPluginConfig } from './types/sdk-types.js';
+import type { SourceEnabledMap } from '../config/import-sources.js';
 import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs';
 import { join, resolve as resolvePath } from 'path';
 import { getPluginsDir, getPluginsIndexPath } from '../paths.js';
@@ -74,10 +75,22 @@ export function _resetPluginScanCache(): void {
  */
 export function scanLocalPlugins(
   dir: string = getPluginsDir(),
-  opts: { trustAll?: boolean } = {},
+  opts: { trustAll?: boolean; sourceEnabled?: SourceEnabledMap } = {},
 ): SdkPluginConfig[] {
   const trustAll = opts.trustAll === true;
-  const cacheKey = trustAll ? `${dir}\u0000trustAll` : dir;
+  const sourceEnabled = opts.sourceEnabled;
+  let cacheKey = trustAll ? `${dir}\u0000trustAll` : dir;
+  // Fold the source enabled-state into the trusted-scan cache key so a mirrored
+  // (source-filtered) scan of an imported root never aliases a prior unfiltered
+  // trusted scan of the same dir. The map is small (a few plugins), so the
+  // digest is cheap; order-independent via sort.
+  if (trustAll && sourceEnabled && sourceEnabled.size > 0) {
+    const digest = [...sourceEnabled.entries()]
+      .map(([k, v]) => `${k}=${v ? 1 : 0}`)
+      .sort()
+      .join(',');
+    cacheKey = `${cacheKey}\u0000${digest}`;
+  }
   if (!scanCache) scanCache = new Map();
   const cached = scanCache.get(cacheKey);
   if (cached) {
@@ -93,7 +106,7 @@ export function scanLocalPlugins(
   const indexPath = dir === getPluginsDir() ? getPluginsIndexPath() : join(dir, '.index.json');
   const index = readIndex(indexPath);
   const plugins: SdkPluginConfig[] = [];
-  walk(dir, dir, 0, plugins, new Set<string>(), index.plugins, trustAll);
+  walk(dir, dir, 0, plugins, new Set<string>(), index.plugins, trustAll, sourceEnabled);
   scanCache.set(cacheKey, plugins);
   return [...plugins];
 }
@@ -106,6 +119,7 @@ function walk(
   seen: Set<string>,
   indexPlugins: Record<string, { enabled: boolean }>,
   trustAll: boolean,
+  sourceEnabled: SourceEnabledMap | undefined,
 ): void {
   if (depth > MAX_SCAN_DEPTH) return;
   // Key `seen` on the realpath so two string-distinct symlinks to the same
@@ -128,14 +142,21 @@ function walk(
       pushPlugin(out, dir);
       return;
     }
+    if (trustAll) {
+      // Trusted imported root (e.g. `~/.claude/plugins`): the whole binary was
+      // opted into via `importFrom` and AFK keeps no index for foreign
+      // plugins. Mirror the SOURCE tool's OWN enabled/disabled state — a plugin
+      // the user disabled in Claude Code must not load here. No signal (no
+      // source map, or key absent from it) defaults to enabled.
+      if (sourceEnabled && sourceEnabled.get(sourceEnabledKey(key)) === false) return;
+      pushPlugin(out, dir);
+      return;
+    }
     if (key.layout === 'cache') {
-      // Cache-layout plugins must be explicitly installed — UNLESS this is a
-      // trusted imported root, where the whole binary was opted into and there
-      // is no AFK index to consult.
-      if (!trustAll) {
-        const entry = indexPlugins[key.key];
-        if (!entry || entry.enabled === false) return;
-      }
+      // Cache-layout plugins must be explicitly installed (present + enabled in
+      // AFK's own index).
+      const entry = indexPlugins[key.key];
+      if (!entry || entry.enabled === false) return;
       pushPlugin(out, dir);
       return;
     }
@@ -162,7 +183,8 @@ function walk(
     } catch {
       continue;
     }
-    if (stat.isDirectory()) walk(root, full, depth + 1, out, seen, indexPlugins, trustAll);
+    if (stat.isDirectory())
+      walk(root, full, depth + 1, out, seen, indexPlugins, trustAll, sourceEnabled);
   }
 }
 
@@ -195,6 +217,22 @@ function readPluginMain(dir: string): string | undefined {
 function pushPlugin(out: SdkPluginConfig[], dir: string): void {
   const main = readPluginMain(dir);
   out.push(main !== undefined ? { type: 'local', path: dir, main } : { type: 'local', path: dir });
+}
+
+/**
+ * Translate the AFK scanner's index key into the SOURCE tool's native
+ * enabled-state key. AFK keys a cache-layout plugin as `<marketplace>:<name>`;
+ * Claude Code keys the same plugin as `<name>@<marketplace>` in its
+ * `enabledPlugins` map. Flat-layout keys (`<name>`) pass through unchanged.
+ * Splits on the FIRST `:` so a plugin name containing `:` is preserved.
+ */
+function sourceEnabledKey(key: { layout: 'flat' | 'cache'; key: string }): string {
+  if (key.layout !== 'cache') return key.key;
+  const sep = key.key.indexOf(':');
+  if (sep <= 0) return key.key;
+  const marketplace = key.key.slice(0, sep);
+  const name = key.key.slice(sep + 1);
+  return `${name}@${marketplace}`;
 }
 
 /**

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -45,7 +45,11 @@ import {
   getSkillsDir,
 } from '../../paths.js';
 import { env } from '../../config/env.js';
-import { loadImportFromConfig, resolveImportedRoots } from '../../config/import-sources.js';
+import {
+  loadImportFromConfig,
+  resolveImportedRoots,
+  readSourceEnabledState,
+} from '../../config/import-sources.js';
 
 
 export interface SkillManifestEntry {
@@ -353,8 +357,11 @@ export function scanAllPluginRoots(opts?: CollectSkillEntriesOptions): SdkPlugin
     ...scanLocalPlugins(getProjectPluginsDir(opts?.cwd)),
     ...scanLocalPlugins(),
     ...scanLocalPlugins(getBundledPluginsDir()),
-    ...resolveImportedRoots(loadImportFromConfig()).pluginRoots.flatMap((root) =>
-      scanLocalPlugins(root, { trustAll: true }),
+    ...resolveImportedRoots(loadImportFromConfig()).pluginRoots.flatMap(({ dir, binary }) =>
+      // Mirror the source tool's own enabled/disabled state: a plugin disabled
+      // in Claude Code (its `~/.claude/settings.json` `enabledPlugins`) is
+      // skipped here rather than loaded into every AFK session.
+      scanLocalPlugins(dir, { trustAll: true, sourceEnabled: readSourceEnabledState(binary) }),
     ),
   ];
 }

--- a/src/config/import-sources.test.ts
+++ b/src/config/import-sources.test.ts
@@ -14,6 +14,7 @@ import {
   loadImportFromConfig,
   parseImportFromConfig,
   readMcpServers,
+  readSourceEnabledState,
   resolveImportedRoots,
 } from './import-sources.js';
 
@@ -93,7 +94,7 @@ describe('resolveImportedRoots', () => {
       { 'claude-code': { plugins: true, skills: true, mcp: false } },
       home,
     );
-    expect(resolved.pluginRoots).toEqual([claudePlugins]);
+    expect(resolved.pluginRoots).toEqual([{ dir: claudePlugins, binary: 'claude-code' }]);
     expect(resolved.skillRoots).toEqual([{ dir: claudeSkills, origin: 'imported:claude-code' }]);
     expect(resolved.mcpConfigs).toEqual([]); // mcp disabled
   });
@@ -115,6 +116,56 @@ describe('resolveImportedRoots', () => {
     expect(resolved.pluginRoots).toEqual([]);
     expect(resolved.skillRoots).toEqual([]);
     expect(resolved.mcpConfigs).toEqual([]);
+  });
+});
+
+describe('readSourceEnabledState', () => {
+  function writeClaudeSettings(content: unknown): void {
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    writeFileSync(join(home, '.claude', 'settings.json'), JSON.stringify(content));
+  }
+
+  it('reads Claude Code enabledPlugins as a name@marketplace → bool map', () => {
+    writeClaudeSettings({
+      enabledPlugins: { 'foo@mp': true, 'bar@mp': false },
+      otherKey: 'ignored',
+    });
+    const map = readSourceEnabledState('claude-code', home);
+    expect(map.get('foo@mp')).toBe(true);
+    expect(map.get('bar@mp')).toBe(false);
+    expect(map.size).toBe(2);
+  });
+
+  it('returns an empty map when settings.json is missing', () => {
+    expect(readSourceEnabledState('claude-code', home).size).toBe(0);
+  });
+
+  it('returns an empty map when settings.json is malformed JSON (fail-open)', () => {
+    mkdirSync(join(home, '.claude'), { recursive: true });
+    writeFileSync(join(home, '.claude', 'settings.json'), '{ not valid json');
+    expect(readSourceEnabledState('claude-code', home).size).toBe(0);
+  });
+
+  it('returns an empty map when enabledPlugins is absent or not a plain object', () => {
+    writeClaudeSettings({ someOtherSetting: true });
+    expect(readSourceEnabledState('claude-code', home).size).toBe(0);
+    writeClaudeSettings({ enabledPlugins: ['foo@mp'] });
+    expect(readSourceEnabledState('claude-code', home).size).toBe(0);
+  });
+
+  it('ignores non-boolean enabledPlugins values', () => {
+    writeClaudeSettings({ enabledPlugins: { 'a@mp': true, 'b@mp': 'yes', 'c@mp': 1 } });
+    const map = readSourceEnabledState('claude-code', home);
+    expect(map.get('a@mp')).toBe(true);
+    expect(map.has('b@mp')).toBe(false);
+    expect(map.has('c@mp')).toBe(false);
+  });
+
+  it('returns an empty map for codex (plugin import is detection-only)', () => {
+    // Even with a config.toml present, v1 reads no Codex plugin-enable state.
+    mkdirSync(join(home, '.codex'), { recursive: true });
+    writeFileSync(join(home, '.codex', 'config.toml'), '[plugins."x@mp"]\nenabled = false\n');
+    expect(readSourceEnabledState('codex', home).size).toBe(0);
   });
 });
 

--- a/src/config/import-sources.ts
+++ b/src/config/import-sources.ts
@@ -57,6 +57,19 @@ export type ImportedSkillOrigin = `imported:${ImportSourceBinary}`;
 /** Format of a source binary's MCP config file. */
 export type McpConfigFormat = 'json' | 'toml';
 
+/**
+ * A source tool's OWN plugin enabled/disabled state, keyed in that tool's
+ * native key format. For Claude Code the key is `<pluginName>@<marketplace>`
+ * (from `~/.claude/settings.json` `enabledPlugins`). A key ABSENT from the map
+ * means "no signal" — the scanner defaults such a plugin to enabled. An EMPTY
+ * map (missing/malformed source config, or a binary with no plugin-enable
+ * concept) disables nothing — fail-open by design.
+ */
+export type SourceEnabledMap = ReadonlyMap<string, boolean>;
+
+/** Shared fail-open sentinel: no source signal ⇒ disables no plugins. */
+const EMPTY_SOURCE_ENABLED: SourceEnabledMap = new Map();
+
 // ── Source path maps ───────────────────────────────────────────────────────
 
 interface SourcePathMap {
@@ -66,6 +79,12 @@ interface SourcePathMap {
   /** Candidate MCP config paths in priority order — first existing wins. */
   mcpConfigCandidates: (home: string) => string[];
   mcpFormat: McpConfigFormat;
+  /**
+   * Read the binary's OWN plugin enabled/disabled state (in its native key
+   * format) so an imported-root scan can mirror it. Returns an empty map when
+   * the binary exposes no such state or its config is missing/malformed.
+   */
+  pluginEnabledState: (home: string) => SourceEnabledMap;
 }
 
 const SOURCE_MAPS: Record<ImportSourceBinary, SourcePathMap> = {
@@ -81,6 +100,7 @@ const SOURCE_MAPS: Record<ImportSourceBinary, SourcePathMap> = {
       join(home, '.claude', 'claude-code', 'mcp.json'),
     ],
     mcpFormat: 'json',
+    pluginEnabledState: (home) => readClaudeEnabledPlugins(home),
   },
   codex: {
     label: 'Codex',
@@ -88,6 +108,9 @@ const SOURCE_MAPS: Record<ImportSourceBinary, SourcePathMap> = {
     skillRoots: (home) => [join(home, '.codex', 'skills')],
     mcpConfigCandidates: (home) => [join(home, '.codex', 'config.toml')],
     mcpFormat: 'toml',
+    // Codex plugin import is detection-only today (see `afk migrate`), so
+    // there is no enabled-state read yet — a follow-up phase.
+    pluginEnabledState: () => EMPTY_SOURCE_ENABLED,
   },
 };
 
@@ -178,8 +201,12 @@ export function loadImportFromConfig(
 
 /** Resolved scan roots derived from a trusted `importFrom` config. */
 export interface ResolvedImportRoots {
-  /** Plugin dirs to scan with trust-all semantics (no AFK index required). */
-  pluginRoots: string[];
+  /**
+   * Plugin dirs to scan with trust-all semantics (no AFK index required),
+   * each tagged with its source binary so the scanner can mirror that tool's
+   * own enabled/disabled state via {@link readSourceEnabledState}.
+   */
+  pluginRoots: Array<{ dir: string; binary: ImportSourceBinary }>;
   /** Skill dirs to scan, tagged with their per-binary import origin. */
   skillRoots: Array<{ dir: string; origin: ImportedSkillOrigin }>;
   /** MCP config files to load as lowest-priority layers. */
@@ -205,7 +232,7 @@ export function resolveImportedRoots(
     const map = SOURCE_MAPS[binary];
     if (toggles.plugins) {
       for (const root of map.pluginRoots(home)) {
-        if (existsSync(root)) out.pluginRoots.push(root);
+        if (existsSync(root)) out.pluginRoots.push({ dir: root, binary });
       }
     }
     if (toggles.skills) {
@@ -220,6 +247,21 @@ export function resolveImportedRoots(
     }
   }
   return out;
+}
+
+/**
+ * Read a trusted source binary's OWN plugin enabled/disabled state so an
+ * imported-root scan can mirror it — a plugin the user disabled in Claude Code
+ * should not load in AFK. `home` is injectable for tests. Fail-open: any
+ * missing/unreadable/malformed source config yields an empty map (disables
+ * nothing). v1 implements `claude-code`; `codex` returns empty (its plugin
+ * import is detection-only).
+ */
+export function readSourceEnabledState(
+  binary: ImportSourceBinary,
+  home: string = homedir(),
+): SourceEnabledMap {
+  return SOURCE_MAPS[binary].pluginEnabledState(home);
 }
 
 // ── Detection (consumed by `afk migrate` + doctor) ──────────────────────────
@@ -283,6 +325,35 @@ function firstExisting(candidates: string[]): string | null {
     if (existsSync(c)) return c;
   }
   return null;
+}
+
+/**
+ * Parse Claude Code's own plugin enable/disable state from
+ * `~/.claude/settings.json` `enabledPlugins` — an object map of
+ * `"<pluginName>@<marketplace>": boolean`. Only the user-global settings file
+ * is consulted; project/local/managed scopes are deliberately out of scope
+ * (AFK's import model is home-dir and cwd-independent). Fail-open: a missing
+ * or malformed file, or a non-boolean value, contributes no signal.
+ */
+function readClaudeEnabledPlugins(home: string): SourceEnabledMap {
+  const settingsPath = join(home, '.claude', 'settings.json');
+  if (!existsSync(settingsPath)) return EMPTY_SOURCE_ENABLED;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+  } catch {
+    return EMPTY_SOURCE_ENABLED;
+  }
+  if (!raw || typeof raw !== 'object') return EMPTY_SOURCE_ENABLED;
+  const enabledPlugins = (raw as { enabledPlugins?: unknown }).enabledPlugins;
+  if (!enabledPlugins || typeof enabledPlugins !== 'object' || Array.isArray(enabledPlugins)) {
+    return EMPTY_SOURCE_ENABLED;
+  }
+  const map = new Map<string, boolean>();
+  for (const [key, val] of Object.entries(enabledPlugins as Record<string, unknown>)) {
+    if (typeof val === 'boolean') map.set(key, val);
+  }
+  return map;
 }
 
 /** Read a plugin manifest's `name` field. Inlined to avoid an agent-layer import. */


### PR DESCRIPTION
## Problem

When a user trusts Claude Code / Codex via `afk migrate`, AFK live-scans that tool's plugin dir on **every** session and loads **every** plugin — including ones the user **disabled** in the source tool. Reported as: *"it scans claude and codex by default but it seems like it includes disabled plugins as well."*

Verified mechanism: imported roots are scanned with `trustAll: true` (`skill-bridge.ts`), which bypasses the enabled-gate in `plugins-scanner.ts` and never reads the source tool's own enabled state. (Nothing is copied to `~/.afk` — `afk migrate` only writes an `importFrom` trust flag; the plugins are read in place.)

## Fix

Mirror the source tool's own enabled/disabled state during the imported-root scan. The **source tool stays the single source of truth** for its own plugins — a plugin disabled in Claude Code is skipped in AFK; toggling it back in Claude re-enables it next session. AFK's own `~/.afk/plugins` plugins are unaffected (their existing `afk plugin enable|disable` still works).

- **`import-sources.ts`** — `SourceEnabledMap` + `readSourceEnabledState(binary)`; parses Claude's `~/.claude/settings.json` `enabledPlugins` (`"<plugin>@<marketplace>": bool`). Tags `resolveImportedRoots().pluginRoots` with its source binary.
- **`plugins-scanner.ts`** — `scanLocalPlugins` accepts a `sourceEnabled` map; a trusted root mirrors it (`indexKeyForPath` `<mp>:<name>` → source key `<name>@<mp>`). Folds the map into the scan cache key so filtered/unfiltered scans never alias.
- **`skill-bridge.ts`** — passes `readSourceEnabledState(binary)` per imported root.

### Design notes
- **Pure mirror, no AFK-side override.** Foreign plugins aren't in AFK's `.index.json`; an AFK-side toggle would create two competing sources of truth. Manage imported plugins in their home tool.
- **Fail-open.** Missing / malformed `settings.json`, absent key, empty map, or a non-source root ⇒ plugin loads (today's behavior). Backward compatible.
- **v1 = Claude Code.** Codex plugin import is detection-only today; deferred (see spec).
- **Real-layout confirmed.** Claude copies installed plugins to `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/`, and the cache dir-name is the `@<marketplace>` token in `enabledPlugins` (docs + anthropics/claude-code#8, #14815, #17061) — exactly AFK's cache-layout key. A test mirrors this real layout.

## Verification
- Full suite green: **626 files, 11,389 passed / 14 skipped / 0 failed**.
- `tsc --noEmit` clean; `pnpm audit:sdk:check` + `audit:env:check` + `scan:env:check` all pass.
- +9 tests (scanner mirroring incl. real Claude cache layout; `enabledPlugins` parser edge cases).

## Scope / follow-ups (in spec §8)
- Q1 `defaultEnabled` fidelity (v1 treats absent = enabled).
- Q6 pre-existing: the scan also descends `~/.claude/plugins/marketplaces/` (catalog clone), which may load non-installed catalog plugins — separate issue, not a regression here.
- Not yet exercised against a machine with an actually-disabled installed plugin (this dev box has zero installed Claude plugins); failure mode is fail-open, never a crash.

Full spec: `docs/specs/imported-plugin-enabled-state.md`.

🤖 Generated with agent-afk
