### PR TITLE
feat(openai-compatible): honor retry-after on 429/503 backoff (#536)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Added
+- openai-compatible: honor server `retry-after` / `retry-after-ms` on 429/503 backoff instead of blind exponential (parity with anthropic-direct) (#536)
+
 ## [5.33.1] - 2026-07-12
 
 ### Fixed

--- a/src/agent/providers/anthropic-direct/usage-limit.ts
+++ b/src/agent/providers/anthropic-direct/usage-limit.ts
@@ -14,6 +14,7 @@
  */
 
 import { loadClaudeCodeOauthToken } from '../../auth/keychain.js';
+import { getHeader, parseRetryAfterMs } from '../shared/retry-after.js';
 
 export type UsageLimitClassification =
   | { kind: 'oauth-limit'; resetsAt: Date }
@@ -40,61 +41,13 @@ export type UsageLimitClassification =
  */
 export const RATE_LIMIT_TRANSIENT_MAX_RETRY_AFTER_MS = 5 * 60 * 1000;
 
-/**
- * Defensive read of a single HTTP header off an error's `headers` field.
- *
- * The Anthropic SDK's `APIError.headers` has been both a web `Headers` (with
- * `.get`) and a plain record across versions, so both shapes are handled:
- * a `.get()` method is preferred, else the record is probed for the exact key
- * and its upper-cased form. Returns the header value, or `undefined` when the
- * error is not an object, has no usable `headers`, or the header is absent.
- *
- * Shared by {@link parseRetryAfterMs} and {@link classifyUsageLimitError}'s
- * unified/per-minute header reads so all header access uses one code path.
- */
-export function getHeader(error: unknown, name: string): string | undefined {
-  if (error === null || typeof error !== 'object') return undefined;
-  const headers = (error as { headers?: unknown }).headers;
-  if (headers === null || headers === undefined) return undefined;
-  const h = headers as { get?: unknown };
-  if (typeof h.get === 'function') {
-    const v = (headers as { get(n: string): string | null }).get(name);
-    return v ?? undefined;
-  }
-  if (typeof headers === 'object') {
-    const rec = headers as Record<string, unknown>;
-    const v = rec[name] ?? rec[name.toUpperCase()];
-    return typeof v === 'string' ? v : undefined;
-  }
-  return undefined;
-}
-
-/**
- * Best-effort parse of a transient-backoff hint from an error's HTTP headers.
- *
- * Reads `retry-after-ms` (milliseconds) first, then `retry-after` (seconds, or
- * an HTTP-date). Returns the delay in ms, or `undefined` when no usable header
- * is present. Header access is via the shared {@link getHeader} helper, which
- * handles both a web `Headers` (with `.get`) and a plain-record shape.
- */
-export function parseRetryAfterMs(error: unknown): number | undefined {
-  const ms = getHeader(error, 'retry-after-ms');
-  if (ms !== undefined) {
-    const n = Number(ms);
-    if (Number.isFinite(n) && n >= 0) return n;
-  }
-  const sec = getHeader(error, 'retry-after');
-  if (sec !== undefined) {
-    const n = Number(sec);
-    if (Number.isFinite(n) && n >= 0) return Math.round(n * 1000);
-    const dateMs = Date.parse(sec);
-    if (!Number.isNaN(dateMs)) {
-      const delta = dateMs - Date.now();
-      if (delta >= 0) return delta;
-    }
-  }
-  return undefined;
-}
+// `getHeader` + `parseRetryAfterMs` were lifted to
+// `providers/shared/retry-after.ts` so the openai-compatible retry path can
+// honor the same `retry-after` hint without importing across the provider
+// boundary. Re-exported here so existing importers (`tracing-fetch.ts`,
+// `usage-limit.test.ts`) and this module's public surface are unchanged;
+// `classifyUsageLimitError` below still calls them exactly as before.
+export { getHeader, parseRetryAfterMs };
 
 /** ECMAScript Date's representable range ceiling in ms (±8.64e15). */
 const MAX_ECMASCRIPT_DATE_MS = 8_640_000_000_000_000;

--- a/src/agent/providers/openai-compatible/query/retry.test.ts
+++ b/src/agent/providers/openai-compatible/query/retry.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the openai-compatible retry helpers — specifically the
+ * `retry-after` honoring added in #536, plus the pre-existing retryability
+ * predicates and backoff schedule.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  RETRY_AFTER_MAX_WAIT_MS,
+  computeBackoffDelay,
+  isRetryableConnectionError,
+  isRetryableStreamError,
+  retryAfterDelayMs,
+  __setRetryBaseDelay,
+} from './retry.js';
+
+/** Minimal APIError-shaped stub: a status + a headers bag (record or Headers). */
+function apiError(status: number, headers?: Record<string, string> | Headers): Error {
+  const e = new Error(`http ${status}`) as Error & { status: number; headers?: unknown };
+  e.status = status;
+  if (headers !== undefined) e.headers = headers;
+  return e;
+}
+
+describe('retryAfterDelayMs — server backoff-hint honoring (#536)', () => {
+  it('returns undefined when the error carries no retry-after header', () => {
+    expect(retryAfterDelayMs(apiError(429))).toBeUndefined();
+    expect(retryAfterDelayMs(apiError(503, { 'x-other': '1' }))).toBeUndefined();
+    expect(retryAfterDelayMs(null)).toBeUndefined();
+    expect(retryAfterDelayMs('nope')).toBeUndefined();
+  });
+
+  it('honors retry-after in seconds (record-shaped headers)', () => {
+    expect(retryAfterDelayMs(apiError(429, { 'retry-after': '2' }))).toBe(2_000);
+  });
+
+  it('honors retry-after-ms in milliseconds and prefers it over retry-after', () => {
+    expect(retryAfterDelayMs(apiError(429, { 'retry-after-ms': '1500' }))).toBe(1_500);
+    expect(
+      retryAfterDelayMs(apiError(429, { 'retry-after-ms': '1500', 'retry-after': '99' })),
+    ).toBe(1_500);
+  });
+
+  it('honors a Headers-object shape (not just plain records)', () => {
+    expect(retryAfterDelayMs(apiError(429, new Headers({ 'retry-after': '3' })))).toBe(3_000);
+  });
+
+  it('clamps a pathological hint to RETRY_AFTER_MAX_WAIT_MS', () => {
+    // 1 hour advised → clamped to the 120s cap so a hostile header cannot park the turn.
+    expect(retryAfterDelayMs(apiError(429, { 'retry-after': '3600' }))).toBe(RETRY_AFTER_MAX_WAIT_MS);
+    expect(RETRY_AFTER_MAX_WAIT_MS).toBe(120_000);
+  });
+
+  it('is deterministic (no jitter) so the wait is reproducible', () => {
+    const e = apiError(429, { 'retry-after': '5' });
+    expect(retryAfterDelayMs(e)).toBe(retryAfterDelayMs(e));
+    expect(retryAfterDelayMs(e)).toBe(5_000);
+  });
+});
+
+describe('retryability predicates (unchanged)', () => {
+  it('treats 429/5xx with an explicit status as retryable, status-less errors as not', () => {
+    expect(isRetryableConnectionError(apiError(429))).toBe(true);
+    expect(isRetryableConnectionError(apiError(503))).toBe(true);
+    expect(isRetryableStreamError(apiError(500))).toBe(true);
+    expect(isRetryableConnectionError(apiError(400))).toBe(false);
+    expect(isRetryableConnectionError(new Error('network drop'))).toBe(false);
+  });
+});
+
+describe('computeBackoffDelay fallback (unchanged)', () => {
+  it('is exponential in the attempt index off the base delay', () => {
+    __setRetryBaseDelay(1_000);
+    expect(computeBackoffDelay(0)).toBe(1_000);
+    expect(computeBackoffDelay(1)).toBe(2_000);
+    expect(computeBackoffDelay(2)).toBe(4_000);
+    __setRetryBaseDelay(null); // restore production default
+  });
+});

--- a/src/agent/providers/openai-compatible/query/retry.ts
+++ b/src/agent/providers/openai-compatible/query/retry.ts
@@ -12,8 +12,31 @@
  * Extracted from `query.ts` so the query module carries only the session class
  * and its turn loop; the retryability predicates + backoff schedule live here.
  *
+ * **Server backoff hints.** When a retryable error carries a `retry-after`
+ * (or OpenAI's `retry-after-ms`) header, {@link retryAfterDelayMs} honors it —
+ * clamped to {@link RETRY_AFTER_MAX_WAIT_MS} — in preference to the blind
+ * exponential schedule, so a 429 from a rate-limited endpoint (local shim,
+ * OpenRouter, DeepSeek, Together, …) waits the server-advised interval instead
+ * of guessing. Mirrors the Anthropic provider's transient-429 handling
+ * (`retry-layer.ts` `rate-limit-transient`), which likewise honors `retry-after`
+ * with a 120s cap.
+ *
+ * **Why no `paused`/`resumed` here.** The harness's `paused`/`resumed`
+ * `ProviderEvent`s model OAuth *subscription* exhaustion plus keychain
+ * account hot-swap — an Anthropic-subscription concept with no analog on a
+ * generic OpenAI-compatible endpoint. The Anthropic provider itself does NOT
+ * emit those events for a transient rate-limit 429; it reserves them for the
+ * `oauth-limit` classification and treats ordinary 429s with exactly this
+ * `retry-after` backoff. An OpenAI-compatible 429 is either a transient
+ * rate-limit (handled here) or a hard quota/billing error (correctly surfaced
+ * as an `error`, not auto-resumable), so honoring `retry-after` IS the parity
+ * with the Anthropic path — a pause/resume UI would model a state this surface
+ * does not have. See issue #536.
+ *
  * @module agent/providers/openai-compatible/query/retry
  */
+
+import { parseRetryAfterMs } from '../../shared/retry-after.js';
 
 /**
  * HTTP status codes that warrant a retry with backoff. 429 (rate limit) and
@@ -47,6 +70,31 @@ export function __setRetryBaseDelay(ms: number | null): void {
  */
 export function computeBackoffDelay(attempt: number): number {
   return retryBaseDelayMs * Math.pow(2, attempt);
+}
+
+/**
+ * Cap on a single honored `retry-after` wait. A server hint beyond this is
+ * clamped so a pathological or hostile header cannot park a turn for minutes.
+ * Matches the Anthropic provider's `RATE_LIMIT_RETRY_MAX_WAIT_MS` (120s).
+ */
+export const RETRY_AFTER_MAX_WAIT_MS = 120_000;
+
+/**
+ * Server-advised backoff for a retryable error, or `undefined` when the error
+ * carries no usable `retry-after` / `retry-after-ms` header.
+ *
+ * When present the value is clamped to {@link RETRY_AFTER_MAX_WAIT_MS}. Callers
+ * use `retryAfterDelayMs(err) ?? computeBackoffDelay(attempt)` so a server hint
+ * wins over the blind exponential schedule, falling back to exponential when no
+ * hint is given. Deterministic (no jitter) so the wait is exactly reproducible
+ * in tests and traces; parsing is delegated to the shared
+ * {@link parseRetryAfterMs}, which handles both the `Headers` and plain-record
+ * error shapes and the seconds / HTTP-date / `-ms` header variants.
+ */
+export function retryAfterDelayMs(err: unknown): number | undefined {
+  const hinted = parseRetryAfterMs(err);
+  if (hinted === undefined) return undefined;
+  return Math.min(hinted, RETRY_AFTER_MAX_WAIT_MS);
 }
 
 /**

--- a/src/agent/providers/openai-compatible/query/stream-drive.ts
+++ b/src/agent/providers/openai-compatible/query/stream-drive.ts
@@ -28,6 +28,7 @@ import {
   computeBackoffDelay,
   isRetryableConnectionError,
   isRetryableStreamError,
+  retryAfterDelayMs,
 } from './retry.js';
 
 /** Result of a single model round-trip, consumed by the tool-loop orchestrator. */
@@ -91,7 +92,23 @@ export async function* driveStream<TEvent>(
       } catch (err) {
         if (ctx.controller.signal.aborted) return null;
         if (isRetryableConnectionError(err) && attempt < MAX_CONNECTION_RETRIES) {
-          const delay = computeBackoffDelay(attempt);
+          // Honor a server `retry-after` hint (clamped) over blind exponential
+          // backoff — the endpoint's own advised interval on a 429/503.
+          const hinted = retryAfterDelayMs(err);
+          const delay = hinted ?? computeBackoffDelay(attempt);
+          // Witness layer: record the wait so it is legible in `afk trace show`
+          // (mirrors retry-layer.ts's `rate_limit` phase). Fire-and-forget so
+          // trace latency never stalls the retry.
+          void emitSessionPhase(ctx.traceWriter, {
+            phase: 'rate_limit',
+            durationMs: delay,
+            resolvedModel: ctx.currentModel,
+            metadata: {
+              source: 'connection',
+              reason: hinted !== undefined ? 'retry-after' : 'backoff',
+              attempt,
+            },
+          });
           await sleepWithAbort(delay, ctx.controller.signal);
           if (ctx.controller.signal.aborted) return null;
           continue;
@@ -133,7 +150,21 @@ export async function* driveStream<TEvent>(
       if (isRetryableStreamError(err) && streamRetries < MAX_STREAM_RETRIES) {
         streamRetries++;
         yield { type: 'stream.retry', sessionId: ctx.initSessionId };
-        await sleepWithAbort(computeBackoffDelay(streamRetries - 1), ctx.controller.signal);
+        // Honor a server `retry-after` hint (clamped) over blind exponential
+        // backoff, same as the connection phase above.
+        const hinted = retryAfterDelayMs(err);
+        const delay = hinted ?? computeBackoffDelay(streamRetries - 1);
+        void emitSessionPhase(ctx.traceWriter, {
+          phase: 'rate_limit',
+          durationMs: delay,
+          resolvedModel: ctx.currentModel,
+          metadata: {
+            source: 'stream',
+            reason: hinted !== undefined ? 'retry-after' : 'backoff',
+            attempt: streamRetries,
+          },
+        });
+        await sleepWithAbort(delay, ctx.controller.signal);
         if (ctx.controller.signal.aborted) return null;
         continue; // retry the whole iteration
       }

--- a/src/agent/providers/shared/retry-after.ts
+++ b/src/agent/providers/shared/retry-after.ts
@@ -1,0 +1,68 @@
+/**
+ * Provider-agnostic `Retry-After` header parsing.
+ *
+ * HTTP backoff-hint parsing has nothing provider-specific about it: both the
+ * Anthropic and OpenAI SDKs surface a thrown `APIError` carrying the response
+ * `headers`, and both honor the standard `retry-after` (and OpenAI's
+ * `retry-after-ms`) convention. These helpers were originally defined inside
+ * `anthropic-direct/usage-limit.ts`; they were lifted here so the
+ * `openai-compatible` retry path can honor the same hint without importing
+ * across the provider boundary or duplicating the parse. `usage-limit.ts`
+ * re-exports both names, so its existing public surface is unchanged.
+ *
+ * @module agent/providers/shared/retry-after
+ */
+
+/**
+ * Defensive read of a single HTTP header off an error's `headers` field.
+ *
+ * SDK `APIError.headers` has been both a web `Headers` (with `.get`) and a
+ * plain record across versions and across the Anthropic/OpenAI SDKs, so both
+ * shapes are handled: a `.get()` method is preferred, else the record is probed
+ * for the exact key and its upper-cased form. Returns the header value, or
+ * `undefined` when the error is not an object, has no usable `headers`, or the
+ * header is absent.
+ */
+export function getHeader(error: unknown, name: string): string | undefined {
+  if (error === null || typeof error !== 'object') return undefined;
+  const headers = (error as { headers?: unknown }).headers;
+  if (headers === null || headers === undefined) return undefined;
+  const h = headers as { get?: unknown };
+  if (typeof h.get === 'function') {
+    const v = (headers as { get(n: string): string | null }).get(name);
+    return v ?? undefined;
+  }
+  if (typeof headers === 'object') {
+    const rec = headers as Record<string, unknown>;
+    const v = rec[name] ?? rec[name.toUpperCase()];
+    return typeof v === 'string' ? v : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Best-effort parse of a transient-backoff hint from an error's HTTP headers.
+ *
+ * Reads `retry-after-ms` (milliseconds) first, then `retry-after` (seconds, or
+ * an HTTP-date). Returns the delay in ms, or `undefined` when no usable header
+ * is present. Header access is via the shared {@link getHeader} helper, which
+ * handles both a web `Headers` (with `.get`) and a plain-record shape.
+ */
+export function parseRetryAfterMs(error: unknown): number | undefined {
+  const ms = getHeader(error, 'retry-after-ms');
+  if (ms !== undefined) {
+    const n = Number(ms);
+    if (Number.isFinite(n) && n >= 0) return n;
+  }
+  const sec = getHeader(error, 'retry-after');
+  if (sec !== undefined) {
+    const n = Number(sec);
+    if (Number.isFinite(n) && n >= 0) return Math.round(n * 1000);
+    const dateMs = Date.parse(sec);
+    if (!Number.isNaN(dateMs)) {
+      const delta = dateMs - Date.now();
+      if (delta >= 0) return delta;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
Closes #536.

## Problem

The `openai-compatible` provider retried transient 429/503 responses with **blind exponential backoff** and never read the server's `retry-after` hint, where `anthropic-direct` honors it. On rate-limited OpenAI-compatible endpoints (local shims, OpenRouter, DeepSeek, Together, Fireworks, Mistral, …) this meant retrying too early and burning the small retry budget before the server was ready — silent degradation relative to the Anthropic path.

## Changes

- **Lift the retry-after parsers to `shared/`.** `getHeader` + `parseRetryAfterMs` were provider-agnostic pure functions living in `anthropic-direct/usage-limit.ts`. Moved to `providers/shared/retry-after.ts`; `usage-limit.ts` re-exports them, so its public surface is byte-identical (existing `tracing-fetch.ts` + `usage-limit.test.ts` consumers unchanged).
- **Honor `retry-after` in the OpenAI retry path.** New `retryAfterDelayMs()` (clamped to 120s, matching anthropic's `RATE_LIMIT_RETRY_MAX_WAIT_MS`) is used at both the connection-phase and mid-stream retry sites in `stream-drive.ts` via `retryAfterDelayMs(err) ?? computeBackoffDelay(attempt)` — server hint wins, exponential is the fallback. Each honored wait emits a `rate_limit` trace phase so it's legible in `afk trace show`.

## Scoping decision: no `paused`/`resumed` here (satisfies AC-2's "document why out of scope")

The harness's `paused`/`resumed` `ProviderEvent`s model **OAuth subscription exhaustion + keychain account hot-swap** — an Anthropic-subscription concept with no analog on a generic OpenAI-compatible endpoint. Notably, `anthropic-direct` itself does **not** emit those events for a transient rate-limit 429; it reserves them for the `oauth-limit` classification and handles ordinary 429s with exactly this `retry-after` backoff (`retry-layer.ts` `rate-limit-transient`). An OpenAI-compatible 429 is either a transient rate-limit (handled here) or a hard quota/billing error (correctly surfaced as an `error`, not auto-resumable). So **honoring `retry-after` _is_ the parity** — a pause/resume UI would model a state this surface doesn't have. Rationale is documented in `retry.ts`.

## Testing

- New `openai-compatible/query/retry.test.ts` — 8 cases (seconds / `-ms` / `Headers`-shape / clamp / determinism / fallback).
- `pnpm lint` (tsc --noEmit strict): clean.
- Full `pnpm test`: **627 files / 11,384 tests, 0 failures** (includes `usage-limit.test.ts` proving the re-export, and `tracing-fetch.test.ts`).
- `audit:sdk:check`, `audit:env:check`, `scan:env:check`: all green (no new SDK imports, no new `process.env` reads).

## Notes

- No behavior change when a 429 carries no `retry-after` header — it falls back to the existing exponential schedule, so this is strictly additive.
- Surfaced during a `/devils-advocate` architecture review that reframed an apparent "code duplication" question into this reliability gap.
