### PR TITLE
fix(cli): eliminate end-of-turn report/table void on overlay collapse

### DIFF
--- a/docs/proposals/tui-compositor-rewrite.md
+++ b/docs/proposals/tui-compositor-rewrite.md
@@ -1,0 +1,146 @@
+# Proposal: unify the compositor commit model to dissolve the scrollback-gap class
+
+**Status:** Stage 0 VALIDATED — real-terminal A/B (iTerm2) confirmed the fix (void gone, header
+present, report contiguous). This PR ships the **minimal A2 core** (~15 LOC in `commit-mode.ts`: retain
+against `maxBandModel`, not the tall-frame room). Stages 2–3 (stateless render-instead-of-repin, single
+end-of-turn flush) remain OPTIONAL future hardening — not required for this fix.
+**Author:** session 8831d316 (diagnosis + design). All claims cited to code read this session.
+**Supersedes intent of:** the "separate, larger item" flagged in `docs/scrollback.md:404`.
+
+---
+
+## 1. Context — the bug and why it recurs
+
+Symptom (user-reported, reproduced deterministically): a streamed report ending in a table renders with a
+multi-row **void** between content stranded in scrollback and the band hugging the frame; earliest rows can be
+lost. Probe buffer (100×40, 22-row overlay): `PROSE-01..05` in scrollback, 25 blank rows, then `PROSE-06`+table
+hugging the frame; `HEADER-MARKER` absent.
+
+This is one instance of a **failure class**. ~12 regression tests circle it: `shrink-gap`, `scrollback-gap`,
+`overflow-gap`, `multi-commit-gap`, `commit-collapse-wrap-gap`, `band-hold-perline-gap`, `endturn-overflow-gap`,
+`banner-commit-gap`, `wrap-gap`, `pad-decay-straddle`, `two-table-overflow`. That density is the signal: the model
+is fighting the medium.
+
+## 2. The two hard constraints any design must respect
+
+**(C1) Scrollback is append-only via full-screen scroll — you cannot reposition a committed line.**
+`docs/scrollback.md:20-67`: pushing a line to scrollback requires a *full-screen* DECSTBM scroll (cursor at the
+bottom margin + `\n`). Sub-region scrolls discard displaced lines. Once a line is in native scrollback its row is
+frozen forever.
+
+**(C2) The frame is unconditionally bottom-pinned, on purpose.**
+`frame.ts:230-253` (`targetBottomRow === absoluteBottom`, "unconditional bottom-pinning") and
+`bottom-pin.test.ts:21,63` ("frame stays bottom-pinned … so the dropdown has headroom"). The frame will **not**
+float up to meet sparse content — the autocomplete dropdown / picker rely on the input sitting at the bottom with
+headroom above it.
+
+**(V) The automated suite cannot verify real-terminal behavior.** `docs/scrollback.md:9-13,108-111`: mock/headless
+tests confirm bytes were *written* but not that they *reached scrollback* — that is a property of the real PTY's
+scroll engine. **Prior fixes (6d7cb90, 9690b9f) shipped green and were broken in reality.** Ground truth = a human
+running afk in iTerm2 / Apple Terminal / xterm and scrolling up. This is the dominant risk for this whole effort
+and is a hard dependency on a human (see §8).
+
+## 3. Root cause (precise)
+
+The compositor has **three** interacting mechanisms for getting committed content on screen:
+
+1. **Eager fits-path commit** (original): a block that fits the room above the *current* frame is pushed to
+   scrollback immediately via a full-screen scroll, and painted above the frame.
+2. **Band-hold** (`docs:426-448`): a block that overflows the *current tall* frame but fits the *collapsed* screen
+   is retained in an in-memory `committedBand` model (capped at `maxBandModel` = rows above a minimal frame),
+   painted partially, archived to scrollback only past the cap.
+3. **Re-pin** (`committed-band-repin.ts`): on frame geometry change, the painted band is *repositioned* to hug the
+   new frame top.
+
+The void arises because the **eager fits-path (1) sizes its keep-vs-archive decision against the room above the
+TALL overlay (~12 rows), not the room above the COLLAPSED frame (`maxBandModel` ~34).** Content that *would* fit
+post-collapse gets prematurely archived to scrollback (C1: now frozen). On collapse, re-pin (3) drops the surviving
+band down to the bottom-pinned frame (C2), leaving the prematurely-archived rows stranded above → the void.
+Many-small-commits (each fitting the tall frame) never trigger band-hold (2), so they all take path (1) → the
+common real-world trigger.
+
+`overflow-gap.test.ts:198-205` and `docs:400-405` already document this exact geometry as **out of scope / a
+separate, larger item** — which is why 416 headless tests stay green while reality breaks.
+
+## 4. Decision drivers
+
+- Dissolve the **class**, not patch instance N+1 (the 12-test density says patching loses).
+- Respect C1 (never need to reposition scrollback) and C2 (keep bottom-pin / dropdown headroom).
+- Keep the public `TerminalCompositor` API stable (input stack, lifecycle, picker, autocomplete unchanged).
+- Minimize real-terminal risk under V (fewer distinct scroll code-paths = fewer places reality can diverge).
+
+## 5. Options considered
+
+### A1 — "Ink model": float the live region, commit-on-finalize, delete the band
+Live region (overlay+input) floats directly below finalized content; finalized blocks commit to scrollback in
+final position; on collapse the region shrinks in place — no re-pin, no void. **Rejected as primary:** violates C2
+(kills unconditional bottom-pin → removes dropdown headroom, `bottom-pin.test.ts:63`), a deliberate UX property.
+Larger blast radius and a visible prompt-position UX change. Keep as a "someday, if we revisit bottom-pin" note.
+
+### A2 — "Unified retained model" (RECOMMENDED)
+Collapse the three mechanisms into **one**. Keep bottom-pin.
+
+- All mid-turn committed content lives in a single ordered in-memory `turnModel: string[]`.
+- **Routing:** every `commitAbove` appends to `turnModel`. Nothing takes an "eager fits-path" scroll just because
+  it fits the current tall frame. (Deletes mechanism 1.)
+- **Archive threshold uses the COLLAPSED-frame room (`maxBandModel`), never the current tall-frame room.** Only the
+  true overflow — lines beyond the bottom `maxBandModel` — is archived to scrollback, and only ever from the *top*
+  of the model, contiguously, so C1 never requires repositioning.
+- **Render, don't re-pin:** each repaint paints the visible window (`turnModel.slice(-room)`) fresh at the current
+  geometry via the existing CUP erase-and-paint primitive (`eraseAndPaintRow`, no `\n`, no scroll — C1 safe),
+  hugging the bottom-pinned frame. Collapse is just "render at the new, larger `room`." (Replaces mechanism 3's
+  incremental reposition with a stateless re-render — gap-free by construction.)
+- **Single flush at turn-end:** when the turn finalizes (geometry stable), flush the remaining model to scrollback
+  once, contiguously, via the full-screen-scroll commit — the only place C1's scroll is used besides true overflow.
+
+Why it dissolves the class: content only ever reaches scrollback (a) as true top-overflow during the turn or
+(b) as the final flush — in both cases contiguous and never repositioned. The visible band is always a fresh
+render, so there is no scrollback-adjacent band to re-pin and no seam to mismanage.
+
+### C — Document as a known limitation (status quo). Already effectively in place (`docs:400-405`). No.
+
+## 6. Blast radius (A2)
+
+**Reworked (~1,200 LOC):** `committed-band-commit.ts` (750 — unify routing, drop eager fits-path),
+`committed-band-repin.ts` (146 — replace incremental reposition with stateless window re-render),
+`frame-preserve.ts` (332 — eviction logic folds into the single archive threshold). **Preserved:** `frame.ts`,
+`render.ts`, `cup-frame-renderer.ts`, `lifecycle.ts`, the entire input stack (`input-dispatch`, `input-mode`,
+`paste`, `autocomplete`, `picker`, `caret`), and the public API. So this is a **bounded refactor of the commit
+model, not a ground-up compositor rewrite** — the earlier "2–4k LOC rewrite" estimate was pessimistic.
+
+## 7. Migration stages (each gated; spike first)
+
+- **Stage 0 — Spike (throwaway, in a worktree).** Prototype `turnModel` + render-window + collapsed-room archive
+  threshold behind a flag. Prove on the 100×40 repro that the void is gone AND a representative slice
+  (`multi-commit-gap`, `overflow-gap`, `scrollback-gap`, `shrink-gap`) stays green. **Human visually validates the
+  spike in a real terminal.** If it doesn't hold, we learned cheaply and stop. ← de-risks §2-V before real spend.
+- **Stage 1 — Unify routing.** Route all commits through `turnModel`; delete the eager fits-path; archive at
+  `maxBandModel`. Full suite green.
+- **Stage 2 — Render-not-repin.** Replace `repositionCommittedBand` with the stateless window re-render. Full suite.
+- **Stage 3 — Single end-of-turn flush.** Full suite + new deterministic regression tests (the 100×40 void, the
+  many-small-commits trigger, the header-loss case).
+- **Stage 4 — Real-terminal validation matrix** (human): iTerm2 / Apple Terminal / xterm × {short report, long
+  report+table, resize mid-turn, overlay grow→collapse, dropdown headroom, picker}. Only after this passes is it
+  "done."
+
+## 8. Risks & dependencies
+
+- **[HARD] Human visual validation (V).** The suite cannot certify correctness; I cannot see a real terminal. This
+  rewrite is *not shippable* on green tests alone. Requires the operator (or a human) to run the Stage-0 spike and
+  the Stage-4 matrix and eyeball scrollback. Without this commitment, the honest ceiling is "headless-green,
+  reality-unverified" — no better guarantee than the fixes that already shipped broken.
+- **Flicker (re-render each frame).** Stateless window re-render writes more bytes than incremental reposition.
+  Mitigation: only repaint on model/geometry change (not per spinner tick); add cell-diffing later if needed.
+- **`maxBandModel` memory for pathological turns.** Bounded by the cap; true overflow still archives. No regression
+  vs today.
+- **Hidden coupling.** `committedBandBottomRow` is read by ~10 sites assuming band-adjacency
+  (`committed-band-commit.ts:191,607-608,687`). Stage 2 removes the incremental band, so these collapse into the
+  render path — must be migrated together, not piecemeal.
+
+## 9. Open questions / not yet verified
+
+- Whether `HEADER-MARKER`'s disappearance in the probe is true content loss (repin void-erase,
+  `committed-band-repin.ts:117-119`) or a harness artifact — confirm in Stage 0.
+- Exact `maxBandModel` derivation under non-zero `extraRows` + soft-wrapped frame lines (`measure()` path).
+- Whether any caller depends on mid-turn scrollback *scrollability* of not-yet-final content (A2 keeps only
+  true-overflow scrollable mid-turn; the rest becomes scrollable at end-of-turn flush). Believed acceptable; confirm.

--- a/docs/scrollback.md
+++ b/docs/scrollback.md
@@ -394,15 +394,25 @@ through `@xterm/headless`, and asserts every committed line survives exactly onc
 in commit order and that committed lines in scrollback have no >1-row blank gap.
 It fails hard on the pre-fix code (early markers found 0 times) and passes after.
 
-**Known residuals (NOT fixed here).** (a) Phase 1 still emits one `\n` per commit
-(unchanged), so a band that has not yet filled the viewport leaves at most a
-single blank row between some scrollback entries — cosmetic line-spacing, not a
-massive gap. (b) When content scrolled into scrollback during a tall phase and
-the frame later collapses, the bottom-anchored band can sit below the
-scrolled-off content with blank viewport rows between them. That live-viewport
-"boundary gap" is the bottom-anchored-frame design tension (the frame does not
-float up to meet sparse content) and is a separate, larger item — but see the
-band-hold fix below, which closes the most common manifestation.
+**Known residuals.** (a) Phase 1 still emits one `\n` per commit (unchanged), so a
+band that has not yet filled the viewport leaves at most a single blank row between
+some scrollback entries — cosmetic line-spacing, not a massive gap. (Subsumed by the
+single end-of-turn flush proposed in #540.) (b) **[FIXED — PR #539]** When content
+scrolled into scrollback during a tall phase and the frame later collapsed, the
+bottom-anchored band could sit below the scrolled-off content with blank viewport
+rows between them — the live-viewport "boundary gap." Root cause: the eager
+fits-path archived committed rows to (append-only) scrollback based on the room
+above the *current tall* frame, not the *collapsed* frame; on collapse the surviving
+band re-pinned down to the bottom-pinned frame and stranded the prematurely-archived
+rows. Fixed in `commit-mode.ts`: any run exceeding the current tall-frame room now
+routes through band-hold (retained, capped at `maxBandModel` = the rows that fit
+above the collapsed frame) instead of eager-scrolling, so content that will fit
+post-collapse is retained and painted contiguously; only genuine overflow beyond
+`maxBandModel` is archived, from the top, contiguously. Regression:
+`terminal-compositor.collapse-void.test.ts`; real-PTY A/B: `scripts/visual-void-repro.ts`.
+The fuller commit-model unification that dissolves the whole gap-class
+(render-not-repin + single end-of-turn flush) is tracked in #540; a real-PTY CI
+harness to make this CI-verifiable is #541.
 
 ### Fixed: multi-line block committed under a tall overlay (the overflow path)
 

--- a/scripts/visual-void-repro.ts
+++ b/scripts/visual-void-repro.ts
@@ -1,0 +1,80 @@
+/**
+ * Visual A/B repro for the collapse-void bug (run in a REAL terminal — iTerm2 /
+ * Apple Terminal / xterm). The headless suite cannot certify real-PTY scrollback
+ * (docs/scrollback.md:108-111), so this is the ground-truth check.
+ *
+ *   pnpm exec tsx scripts/visual-void-repro.ts
+ *
+ * A/B:
+ *   git checkout main                        # BEFORE  → expect a big blank VOID
+ *   pnpm exec tsx scripts/visual-void-repro.ts
+ *   git checkout spike/compositor-retained-model   # AFTER → report contiguous
+ *   pnpm exec tsx scripts/visual-void-repro.ts
+ *
+ * What you should see AFTER the fix: the whole report (HEADER + PROSE-01..06 +
+ * the table + BODY-TAIL) sits as ONE contiguous block hugging the input prompt,
+ * with NO multi-row blank gap in the middle, and the HEADER present (not lost).
+ * BEFORE the fix: PROSE rows stranded up top, then a tall blank void, then the
+ * table hugging the prompt — and the HEADER missing.
+ *
+ * The script renders, holds 6s so you can look + scroll up, then restores the
+ * terminal and exits.
+ */
+import { TerminalCompositor } from '../src/cli/terminal-compositor.js';
+import { StatusLine } from '../src/cli/status-line.js';
+import { renderMarkdownToTerminal } from '../src/cli/formatter.js';
+
+async function main(): Promise<void> {
+  const stdout = process.stdout;
+  if (!stdout.isTTY) {
+    // eslint-disable-next-line no-console
+    console.error('Not a TTY — run this directly in iTerm2 / Terminal / xterm, not through a pipe.');
+    process.exit(2);
+  }
+  const cols = stdout.columns ?? 100;
+
+  const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+  statusLine.start();
+  statusLine.repaint({ model: 'visual-repro', cost: 0, tokens: 0, contextPct: 0 });
+  const c = new TerminalCompositor({
+    stdout,
+    stdin: process.stdin,
+    onCancel: () => {},
+    scrollRegion: statusLine,
+    anchorRow: 1,
+  });
+  await c.arm();
+  statusLine.setExtraRows(1);
+  c.setSpinner({ enabled: true });
+
+  // Tall overlay held across many small commits (the diagnose fan-out lane).
+  const overlay = Array.from({ length: 22 }, (_, i) => `  thinking ${i} — held overlay keeping the frame tall`).join('\n');
+  const commit = (s: string): void => { c.setOverlay(overlay); c.commitAbove(s); };
+
+  commit('HEADER-MARKER  Diagnosis summary\n\n');
+  for (let i = 1; i <= 6; i++) commit(`PROSE-${String(i).padStart(2, '0')}  report line of the streamed diagnosis\n\n`);
+  const TABLE_MD = [
+    '| # | Change | File | Nature |',
+    '|---|--------|------|--------|',
+    '| 1 | pass cwd to scheduler | scheduler.ts | behavior |',
+    '| 2 | load config from cwd | config-loader.ts | behavior |',
+    '| 3 | thread cwd through daemon | daemon.ts | plumbing |',
+  ].join('\n');
+  const table = renderMarkdownToTerminal(TABLE_MD, { maxWidth: cols - 2 }).replace(/\n+$/, '');
+  commit(`${table}\nBODY-TAIL-ROW  final line of the report\n\n`);
+
+  // Collapse: turn ends → spinner stops, overlay clears → minimal frame.
+  c.setSpinner({ enabled: false });
+  c.setOverlay('');
+  const ix = c as unknown as { repaint(): void };
+  ix.repaint();
+  ix.repaint();
+
+  await new Promise((r) => setTimeout(r, 6000));
+  c.disarm();
+  statusLine.stop();
+  stdout.write('\n[visual-void-repro done — scroll up to inspect scrollback]\n');
+  process.exit(0);
+}
+
+void main();

--- a/src/cli/commit-mode.ts
+++ b/src/cli/commit-mode.ts
@@ -202,7 +202,21 @@ export function decideCommitMode(input: CommitModeInput): CommitMode {
   // committedBand empty, so repositionCommittedBand had nothing to re-pin when
   // the overlay collapsed — the freed viewport rows stayed blank (the
   // "end-of-turn viewport void" bug, terminal-compositor.endturn-overflow-gap).
-  const useBandHold = overflowHasPending || (!fitsAboveFrame && maxBandModel > 0);
+  // A2 (spike — unified retained model): retain against the COLLAPSED-frame
+  // budget (maxBandModel), not the current tall-frame room. The eager fits-path
+  // scrolls the band overflow into scrollback whenever the accumulated run
+  // exceeds `room` (the room above the CURRENT, possibly tall, frame) — even
+  // when those rows would fit above the collapsed frame. Once in native
+  // scrollback they are frozen (C1), so on collapse the re-pinned short band
+  // strands them → the void. Routing every run that exceeds the current room
+  // through band-hold (capped at maxBandModel) keeps them in the model until
+  // collapse, where the whole run paints contiguously. Only the genuine
+  // overflow beyond maxBandModel is archived, from the top, contiguously.
+  const runExceedsCurrentRoom = overflowRun.length > room;
+  const useBandHold =
+    overflowHasPending ||
+    (!fitsAboveFrame && maxBandModel > 0) ||
+    (runExceedsCurrentRoom && maxBandModel > 0);
 
   return {
     fitsAboveFrame,

--- a/src/cli/terminal-compositor.band-hold-perline-gap.repro.test.ts
+++ b/src/cli/terminal-compositor.band-hold-perline-gap.repro.test.ts
@@ -15,10 +15,11 @@
  * *-gap.repro suites). Validated against the real @xterm/headless scroll engine
  * (mock-stdout byte tests cannot observe true scrollback — see docs/scrollback.md).
  *
- * HARD GATE: each gap-prone geometry asserts the per-line loop produces a gap
- * (span > N-1 or a drop) AND the batched commit is present + single-copy +
- * contiguous. If commitBlockAbove ever regresses to per-line, the batched
- * assertions fail.
+ * HARD GATE: the batched commit lands present + single-copy + contiguous at
+ * every gap-prone geometry. (Historically a "discriminator" case asserted the
+ * per-line loop was gappy to prove the batched path mattered; the retained-model
+ * routing fix — commit-mode.ts — since fixed the root cause, so the per-line
+ * path is now contiguous too and that case asserts contiguity instead.)
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -130,17 +131,23 @@ describe('band-hold per-line flush gap → commitBlockAbove (TUI weird gaps)', (
     }, 20_000);
   }
 
-  it('per-line loop is genuinely gappy at the partial-room geometry (discriminator)', async () => {
-    // Guards the test's own power: if the per-line loop did NOT gap here, the
-    // batched assertions above would prove nothing. loopH=16 reproduced span=29
-    // (vs want 13) during investigation.
+  it('per-line loop is now ALSO contiguous — the retained-model fix addressed the root cause commitBlockAbove worked around', async () => {
+    // HISTORY: this was a "discriminator" asserting the per-line loop is
+    // genuinely gappy at loopH=16 (reproduced span=29 vs want 13), to prove the
+    // batched commitBlockAbove path fixed something. The retained-model routing
+    // fix (commit-mode.ts: hold a run that exceeds the CURRENT tall-frame room
+    // in the band model, capped at maxBandModel, instead of eager-scrolling it
+    // into frozen native scrollback) fixed the ROOT cause — so per-line commits
+    // now land contiguously too (span == want, zero drops). commitBlockAbove
+    // remains as a single-geometry-decision hardening, but is no longer
+    // load-bearing for correctness at this geometry.
     const block = mkBlock(14, 'Pl');
     const perLine = await flushUnderTallOverlay(block, 16, false);
-    const gappyOrDropped = perLine.span > perLine.want || perLine.missing.length > 0;
+    expect(perLine.missing, `per-line dropped rows:\n${perLine.dump}`).toEqual([]);
     expect(
-      gappyOrDropped,
-      `expected the per-line loop to gap/drop at loopH=16 but it was clean (span=${perLine.span}, want=${perLine.want}, missing=${perLine.missing.length}):\n${perLine.dump}`,
-    ).toBe(true);
+      perLine.span,
+      `per-line not contiguous (span=${perLine.span}, want=${perLine.want}):\n${perLine.dump}`,
+    ).toBe(perLine.want);
   }, 20_000);
 
   it('a block taller than the collapsed screen still lands every row contiguously (scrollback + viewport)', async () => {

--- a/src/cli/terminal-compositor.collapse-void.test.ts
+++ b/src/cli/terminal-compositor.collapse-void.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression (the "tables render fucky" report): many SMALL blocks committed
+ * under a TALL overlay each fit the current tall-frame room, so they take the
+ * eager fits-path and scroll into native scrollback. On collapse the surviving
+ * band re-pins DOWN to the bottom-pinned frame while the prematurely-archived
+ * rows stay frozen in scrollback → a multi-row VOID between them, and the
+ * earliest row can be lost entirely.
+ *
+ * This is the collapsed-frame-height boundary gap that overflow-gap.test.ts
+ * (isolation note ~198-205) and docs/scrollback.md:400-405 deliberately left
+ * out of scope. Geometry: 100x40, a 22-row overlay held across the commits, a
+ * report ending in a rendered wide table, then a minimal-frame collapse whose
+ * above-frame room (~37) is much larger than the surviving band (~12).
+ *
+ * FIX INVARIANT (A2 — unified retained model): while the geometry is still
+ * mutable (tall overlay up) content that would fit above the COLLAPSED frame is
+ * RETAINED in the band model, not eagerly archived. On collapse the whole run
+ * paints contiguously hugging the frame. So: every committed row present
+ * exactly once, no >=2-row void between content and frame, run hugs the frame.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'node:stream';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { StatusLine } from './status-line.js';
+import { renderMarkdownToTerminal } from './formatter.js';
+
+type MockStdout = NodeJS.WriteStream & { isTTY: boolean; columns: number; rows: number };
+type MockStdin = NodeJS.ReadStream & { isTTY: boolean; isRaw: boolean; setRawMode: ReturnType<typeof vi.fn> };
+function makeStdout(cols: number, rows: number): MockStdout {
+  const s = new PassThrough() as unknown as MockStdout;
+  s.isTTY = true; s.columns = cols; s.rows = rows; return s;
+}
+function makeStdin(): MockStdin {
+  const s = new PassThrough() as unknown as MockStdin;
+  s.isTTY = true; s.isRaw = false; s.setRawMode = vi.fn((r: boolean) => { s.isRaw = r; return s; }); return s;
+}
+function collect(stream: MockStdout): () => string { const c: string[] = []; stream.on('data', (x) => c.push(String(x))); return () => c.join(''); }
+function termWrite(t: HeadlessTerminal, d: string): Promise<void> { return new Promise((r) => t.write(d, r)); }
+function allLines(t: HeadlessTerminal): string[] {
+  const b = t.buffer.active; const o: string[] = [];
+  for (let i = 0; i < b.length; i++) { const l = b.getLine(i); if (l) o.push(l.translateToString(true)); }
+  return o;
+}
+
+const COLS = 100, ROWS = 40;
+const FRAME_RE = /\u23af/; // input rule glyph on a minimal (spinner-stopped) frame
+
+describe('collapse void: many small commits under a tall overlay', () => {
+  it('keeps the whole report contiguous and hugging the frame after collapse (no void, no lost rows)', async () => {
+    const stdout = makeStdout(COLS, ROWS);
+    const stdin = makeStdin();
+    const all = collect(stdout);
+    const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+    statusLine.start();
+    statusLine.repaint({ model: 'M', cost: 0, tokens: 0, contextPct: 0 });
+    const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), scrollRegion: statusLine, anchorRow: 1 });
+    await c.arm();
+    statusLine.setExtraRows(1);
+    c.setSpinner({ enabled: true });
+
+    const overlay = Array.from({ length: 22 }, (_, i) => `thinking ${i} keeping the frame tall`).join('\n');
+    const commit = (s: string): void => { c.setOverlay(overlay); c.commitAbove(s); };
+
+    const reportRows = ['HEADER-MARKER Diagnosis summary'];
+    commit('HEADER-MARKER Diagnosis summary\n\n');
+    for (let i = 1; i <= 6; i++) { const r = `PROSE-${String(i).padStart(2, '0')} report line`; reportRows.push(r); commit(`${r}\n\n`); }
+    const TABLE_MD = [
+      '| # | Change | File | Nature |',
+      '|---|--------|------|--------|',
+      '| 1 | pass cwd to scheduler | scheduler.ts | behavior |',
+      '| 2 | load config from cwd | config-loader.ts | behavior |',
+      '| 3 | thread cwd through daemon | daemon.ts | plumbing |',
+    ].join('\n');
+    const table = renderMarkdownToTerminal(TABLE_MD, { maxWidth: COLS - 2 }).replace(/\n+$/, '');
+    reportRows.push('BODY-TAIL-ROW final line of report');
+    commit(`${table}\nBODY-TAIL-ROW final line of report\n\n`);
+
+    // Collapse to a minimal frame (spinner off) so the above-frame room is large.
+    c.setSpinner({ enabled: false });
+    c.setOverlay('');
+    const internals = c as unknown as { repaint(): void };
+    internals.repaint();
+    internals.repaint();
+
+    const term = new HeadlessTerminal({ cols: COLS, rows: ROWS, scrollback: 800, allowProposedApi: true, convertEol: true });
+    await termWrite(term, all());
+    const lines = allLines(term);
+    const dump = lines.map((l, i) => `[${String(i).padStart(3)}] ${JSON.stringify(l.replace(/\s+$/, ''))}`).join('\n');
+
+    const frameAbs = lines.findIndex((l) => FRAME_RE.test(l));
+    expect(frameAbs, `frame not found:\n${dump}`).toBeGreaterThanOrEqual(0);
+
+    // (1) NO LOST / DUPLICATE ROWS: every committed report row present exactly once.
+    for (const row of reportRows) {
+      const label = (row.match(/HEADER-MARKER|PROSE-\d\d|BODY-TAIL-ROW/) ?? [row])[0];
+      const hits = lines.filter((l) => l.includes(label)).length;
+      expect(hits, `row "${label}" must appear exactly once (found ${hits}):\n${dump}`).toBe(1);
+    }
+
+    // (2) NO VOID: no run of >=2 blank rows between the first content row and the frame.
+    const firstContentAbs = lines.findIndex((l) => l.trim() !== '');
+    let maxBlankRun = 0, cur = 0;
+    for (let i = Math.max(0, firstContentAbs); i < frameAbs; i++) {
+      if ((lines[i] ?? '').trim() === '') { cur++; maxBlankRun = Math.max(maxBlankRun, cur); } else cur = 0;
+    }
+    expect(maxBlankRun, `void of ${maxBlankRun} blank rows between content and frame:\n${dump}`).toBeLessThanOrEqual(1);
+
+    // (3) HUGS THE FRAME: last content row is within one rhythm-blank of the frame.
+    let lastContentAbs = -1;
+    for (let i = frameAbs - 1; i >= 0; i--) if ((lines[i] ?? '').trim() !== '') { lastContentAbs = i; break; }
+    expect(frameAbs - lastContentAbs, `run does not hug the frame:\n${dump}`).toBeLessThanOrEqual(2);
+
+    term.dispose(); statusLine.stop(); c.disarm();
+  }, 20_000);
+});


### PR DESCRIPTION
## The bug ("tables render fucky")

A streamed report ending in a table, rendered beneath a tall overlay (the diagnose/subagent lane), collapses at end-of-turn into a multi-row **blank void** between content stranded in scrollback and the band hugging the input — and the earliest rows (the report header) are **lost entirely**.

## Root cause

Many small blocks committed under a tall overlay each fit the room above the **current tall** frame, so they take the eager fits-path and scroll into native scrollback. Scrollback is append-only via a full-screen scroll (`docs/scrollback.md:20-67`) — those rows freeze there. On collapse the surviving band re-pins down to the (deliberately) bottom-pinned frame (`frame.ts:230`, `bottom-pin.test.ts:63` — dropdown headroom) while the frozen rows strand above it → the void + lost header.

This is the collapsed-frame boundary gap that `overflow-gap.test.ts:198-205` and `docs/scrollback.md:400-405` explicitly left out of scope, which is why the suite stayed green while reality broke.

## The fix (~15 LOC, `commit-mode.ts`)

Route any run whose accumulated height exceeds the **current tall-frame room** through band-hold (retained model, capped at `maxBandModel` = the rows that fit above the **collapsed** frame) instead of eager-scrolling. Content that will fit post-collapse is retained until collapse and painted contiguously; only genuine overflow beyond `maxBandModel` is archived, from the top, contiguously. Respects both hard constraints: scrollback stays append-only, the frame stays bottom-pinned.

## Validation

- **Full suite green: 11386 passed / 14 skipped / 0 failed.** `pnpm lint` clean.
- New `terminal-compositor.collapse-void.test.ts` — deterministic 100×40 repro (header present, no ≥2-row void, run hugs the frame). Red before, green after.
- The `band-hold-perline-gap` discriminator **flipped**: it asserted the per-line commit loop was "genuinely gappy" (to justify `commitBlockAbove`); the retained-model fix addresses that root cause too, so per-line is now contiguous (`span 13/13`, zero drops). Updated to assert the new invariant.
- **Real-terminal A/B (iTerm2), the only ground truth per `docs/scrollback.md:108-111`:** before = void + missing header; after = full report contiguous, header present. Repro: `pnpm exec tsx scripts/visual-void-repro.ts` on `main` vs this branch.

## Scope / future work

This ships the **minimal A2 core** only. `docs/proposals/tui-compositor-rewrite.md` documents the optional fuller unification (stateless render-instead-of-repin + single end-of-turn flush) as separate, no-rush hardening — not required for this fix.

## Test plan
- [x] `pnpm test` (full suite)
- [x] `pnpm lint`
- [x] real-terminal A/B in iTerm2
