### PR TITLE
fix(skills): restrict read-only depth-cap forks to declared tools + honor plugin model: (#499)

### DIFF
--- a/src/agent/plugins/tool-injector.test.ts
+++ b/src/agent/plugins/tool-injector.test.ts
@@ -313,6 +313,84 @@ Content`
     expect(skills[0]!.readOnly).toBeUndefined();
   });
 
+  it('should parse model: frontmatter into metadata.model (issue #499 finding 3)', () => {
+    const skillDir = join(tmpDir, 'skills');
+    const fs = require('fs');
+    fs.mkdirSync(skillDir, { recursive: true });
+
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: pinned-skill
+description: A skill pinned to a specific model
+context: fork
+model: opus
+---
+Content`
+    );
+
+    const skills = extractPluginSkills(tmpDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0]!.model).toBe('opus');
+  });
+
+  it('should strip surrounding quotes from a quoted model: value', () => {
+    const skillDir = join(tmpDir, 'skills');
+    const fs = require('fs');
+    fs.mkdirSync(skillDir, { recursive: true });
+
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: quoted-model-skill
+description: A skill with a quoted model id
+model: "claude-opus-4-20250514"
+---
+Content`
+    );
+
+    const skills = extractPluginSkills(tmpDir);
+    expect(skills[0]!.model).toBe('claude-opus-4-20250514');
+  });
+
+  it('should leave model undefined when frontmatter omits it', () => {
+    const skillDir = join(tmpDir, 'skills');
+    const fs = require('fs');
+    fs.mkdirSync(skillDir, { recursive: true });
+
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: no-model-skill
+description: A skill with no model override
+---
+Content`
+    );
+
+    const skills = extractPluginSkills(tmpDir);
+    expect(skills[0]!.model).toBeUndefined();
+  });
+
+  it('should leave model undefined for a bare (empty) model: line', () => {
+    const skillDir = join(tmpDir, 'skills');
+    const fs = require('fs');
+    fs.mkdirSync(skillDir, { recursive: true });
+
+    writeFileSync(
+      join(skillDir, 'SKILL.md'),
+      `---
+name: empty-model-skill
+description: A skill with an empty model value
+model:
+---
+Content`
+    );
+
+    const skills = extractPluginSkills(tmpDir);
+    // A bare `model:` must fall through to the session default, not set "".
+    expect(skills[0]!.model).toBeUndefined();
+  });
+
   it('should parse quoted YAML values', () => {
     const skillDir = join(tmpDir, 'skills');
     const fs = require('fs');

--- a/src/agent/plugins/tool-injector.ts
+++ b/src/agent/plugins/tool-injector.ts
@@ -49,6 +49,15 @@ export interface PluginSkillMetadata {
    * dispatcher's `readOnlyBash` gate.
    */
   readOnly?: boolean;
+  /**
+   * Per-skill model override from the `model:` frontmatter field. When present,
+   * a forked subagent for this skill runs on this model instead of the session
+   * default. Mirrors the registry-skill `model` field (see `SkillMetadata` in
+   * `src/skills/index.ts`); the forked plugin path resolves
+   * `model ?? defaultSubagentModel ?? defaultModel ?? 'sonnet'`. Absent → the
+   * session-default resolution applies unchanged.
+   */
+  model?: string;
   /** Markdown content after the frontmatter closing `---`. */
   body?: string;
   /**
@@ -343,6 +352,14 @@ function parseSkillMetadata(
         // child's write tools.
         const raw = value.replace(/^["']|["']$/g, '').trim();
         if (raw === 'true') metadata.readOnly = true;
+      } else if (key === 'model') {
+        // Per-skill model override. Strip surrounding quotes and only assign a
+        // non-empty value so a bare `model:` line falls through to the session
+        // default. No allow-list validation — an arbitrary id flows to
+        // providerForModel()/the credential resolver exactly like the
+        // registry-skill `model` field, which is also unvalidated.
+        const raw = value.replace(/^["']|["']$/g, '').trim();
+        if (raw.length > 0) metadata.model = raw;
       }
     }
 

--- a/src/agent/tools/nesting.test.ts
+++ b/src/agent/tools/nesting.test.ts
@@ -169,6 +169,49 @@ describe('RECON_ALLOWED_TOOLS (read-only skill child allowlist)', () => {
   });
 });
 
+describe('buildReadOnlyReconProvider allowlist override (issue #499 finding 2)', () => {
+  // Both provider classes store the resolved allowlist, readOnlyBash, and
+  // readOnlyMemory as private fields. Introspect them directly — the same
+  // no-network seam the baseURL tests use for `providerOpts`.
+  const allowedOf = (provider: unknown): string[] =>
+    (provider as { permissions: { allowedTools: string[] } }).permissions.allowedTools;
+  const readOnlyBashOf = (provider: unknown): boolean =>
+    (provider as { readOnlyBash: boolean }).readOnlyBash;
+  const readOnlyMemoryOf = (provider: unknown): boolean =>
+    (provider as { readOnlyMemory: boolean }).readOnlyMemory;
+
+  it('defaults to the full RECON set when no allowlist is passed (backward compat)', () => {
+    const provider = buildReadOnlyReconProvider('sonnet');
+    expect(allowedOf(provider)).toEqual([...RECON_ALLOWED_TOOLS]);
+  });
+
+  it('restricts to the passed allowlist instead of the full RECON superset', () => {
+    // A `read-only: true` + `tools: [bash]` skill forked at the depth cap must
+    // get ONLY [bash] — not the whole RECON set (which would grant web_scrape
+    // egress, read_file, etc. the SKILL.md never declared).
+    const provider = buildReadOnlyReconProvider('sonnet', undefined, ['bash']);
+    expect(allowedOf(provider)).toEqual(['bash']);
+    expect(allowedOf(provider)).not.toContain('web_scrape');
+    expect(allowedOf(provider)).not.toContain('read_file');
+  });
+
+  it('preserves the readOnlyBash + readOnlyMemory gates when narrowed', () => {
+    // Least-privilege must NOT come at the cost of the mutating-bash gate: a
+    // narrowed `tools: [bash]` child still needs readOnlyBash so the dispatcher
+    // blocks mutating shell commands.
+    const provider = buildReadOnlyReconProvider('sonnet', undefined, ['bash']);
+    expect(readOnlyBashOf(provider)).toBe(true);
+    expect(readOnlyMemoryOf(provider)).toBe(true);
+  });
+
+  it('materializes a fresh array so caller mutation cannot bleed across siblings', () => {
+    const shared = ['read_file', 'bash'];
+    const provider = buildReadOnlyReconProvider('sonnet', undefined, shared);
+    shared.push('write_file');
+    expect(allowedOf(provider)).toEqual(['read_file', 'bash']);
+  });
+});
+
 describe('DEFAULT_READ_ONLY_SKILLS', () => {
   it("contains 'ground-state'", () => {
     expect(DEFAULT_READ_ONLY_SKILLS.has('ground-state')).toBe(true);

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -206,7 +206,11 @@ export function createChildProviderFactory(
  * silently defeating read-only enforcement.
  *
  * This helper builds a minimal provider with:
- *   - `permissions.allowedTools = RECON_ALLOWED_TOOLS` (no write_file/edit_file)
+ *   - `permissions.allowedTools = allowedTools ?? RECON_ALLOWED_TOOLS`
+ *     (no write_file/edit_file — the caller passes the read-only-intersected
+ *     `tools:` allowlist so the child is never granted tools the SKILL.md never
+ *     declared; falls back to the full RECON set when the skill declares no
+ *     `tools:`)
  *   - `readOnlyBash: true` (dispatcher blocks mutating bash)
  *   - `readOnlyMemory: true` (consistency with the factory path)
  *   - NO `subagentExecutor` / `skillExecutor` — at the depth cap the child
@@ -222,10 +226,18 @@ export function buildReadOnlyReconProvider(
   // an OpenAICompatibleProvider with no baseURL and POSTs to api.openai.com
   // (defense-in-depth with openai-compatible/base-url.ts's query-time fallback).
   openaiBaseUrl?: string,
+  // Effective read-only allowlist. When the read-only skill declared a `tools:`
+  // list, the caller passes its intersection with RECON_ALLOWED_TOOLS here so
+  // the depth-cap child is restricted to the declared subset — NOT the full
+  // RECON superset (issue #499, finding 2: least-privilege). Undefined → the
+  // full RECON set (a read-only skill with no `tools:` declaration). Every
+  // value is already a subset of RECON, so readOnlyBash/readOnlyMemory below
+  // still hold regardless of what is passed.
+  allowedTools?: readonly string[],
 ): ModelProvider {
   // Materialize the allowlist per call so test/runtime mutation of the shared
   // array doesn't bleed across siblings (mirrors buildPhaseRestrictedProvider).
-  const permissions = { allowedTools: [...RECON_ALLOWED_TOOLS] };
+  const permissions = { allowedTools: [...(allowedTools ?? RECON_ALLOWED_TOOLS)] };
   const route = providerForModel(typeof model === 'string' ? model : undefined);
   if (route === 'openai-compatible') {
     return new OpenAICompatibleProvider({

--- a/src/agent/tools/skill-bridge.ts
+++ b/src/agent/tools/skill-bridge.ts
@@ -246,6 +246,13 @@ export interface PluginSkillBody {
    * Absent → historical full-write fork.
    */
   readOnly?: boolean;
+  /**
+   * Per-skill model override from SKILL.md frontmatter `model:`. When present,
+   * `executePluginSkill` resolves the forked child's model as
+   * `model ?? defaultSubagentModel ?? defaultModel ?? 'sonnet'` — matching the
+   * registry fork path (`executeForkedRegistrySkill`). Absent → session default.
+   */
+  model?: string;
 }
 
 /**
@@ -282,6 +289,7 @@ export function discoverPluginSkillBodies(
           ...(skill.allowedTools !== undefined ? { allowedTools: skill.allowedTools } : {}),
           ...(skill.context !== undefined ? { context: skill.context } : {}),
           ...(skill.readOnly === true ? { readOnly: true } : {}),
+          ...(skill.model !== undefined ? { model: skill.model } : {}),
         });
       }
     }

--- a/src/agent/tools/skill-executor.test.ts
+++ b/src/agent/tools/skill-executor.test.ts
@@ -2573,8 +2573,54 @@ describe('SkillExecutor', () => {
       expect(result.isError).toBeUndefined();
       // readOnly wins: the recon provider (which keeps readOnlyBash) is used, and
       // the bare restricted provider that would drop the bash gate is NOT.
-      expect(reconSpy).toHaveBeenCalledWith('sonnet', undefined);
+      //
+      // issue #499 finding 2: the cap path now threads the EFFECTIVE allowlist —
+      // the RECON intersection of the declared `tools:` — as the third arg, so
+      // the child is restricted to the declared subset (`write_file` dropped: not
+      // in RECON) instead of silently receiving the full RECON superset. The
+      // readOnlyBash + readOnlyMemory gates are still baked in by the builder.
+      expect(reconSpy).toHaveBeenCalledWith('sonnet', undefined, ['read_file', 'bash']);
       expect(restrictedSpy).not.toHaveBeenCalled();
+    });
+
+    it('read-only skill with NO tools: at the depth cap gets the FULL RECON set (backward compat)', async () => {
+      // issue #499 finding 2 (companion to the test above): a read-only skill
+      // that declares no `tools:` must still get the whole RECON allowlist at
+      // the cap — the narrowing only kicks in when a `tools:` list was declared.
+      vi.spyOn(SubagentManager.prototype, 'forkSubagent').mockResolvedValue({
+        runToResult: vi.fn().mockResolvedValue({
+          status: 'succeeded',
+          message: { content: 'recon output' },
+        }),
+        teardown: vi.fn().mockResolvedValue(undefined),
+      } as never);
+      vi.spyOn(SubagentManager.prototype, 'teardownAll').mockResolvedValue(undefined);
+
+      const reconSpy = vi.spyOn(nestingModule, 'buildReadOnlyReconProvider');
+
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'test',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        defaultModel: 'sonnet',
+      });
+
+      const skillBody: PluginSkillBody = {
+        body: 'You are a read-only auditor.',
+        pluginPath: '/fake/plugin',
+        context: 'fork',
+        readOnly: true,
+        // no allowedTools — effectiveAllowed resolves to the full RECON set.
+      };
+      (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies =
+        new Map([['recon-no-tools', skillBody]]);
+
+      const result = await executor.execute(makeCall({ name: 'recon-no-tools' }));
+
+      expect(result.isError).toBeUndefined();
+      expect(reconSpy).toHaveBeenCalledWith('sonnet', undefined, [...RECON_ALLOWED_TOOLS]);
     });
 
     it('does NOT call buildSkillRestrictedProvider when allowedTools is absent', async () => {
@@ -2652,6 +2698,83 @@ describe('SkillExecutor', () => {
         'sonnet',
         false,
         undefined,
+      );
+    });
+  });
+
+  describe('plugin skill model: override (issue #499 finding 3)', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    function capturePluginFork(skillName: string, body: PluginSkillBody, ctx?: Partial<{ defaultModel: string; defaultSubagentModel: string }>) {
+      const mockForkSubagent = vi.fn().mockResolvedValue({
+        runToResult: vi.fn().mockResolvedValue({
+          status: 'succeeded',
+          message: { content: 'ok' },
+        }),
+        teardown: vi.fn().mockResolvedValue(undefined),
+      });
+      vi.spyOn(SubagentManager.prototype, 'forkSubagent').mockImplementation(mockForkSubagent);
+      vi.spyOn(SubagentManager.prototype, 'teardownAll').mockResolvedValue(undefined);
+
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'test',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        ...(ctx?.defaultModel !== undefined ? { defaultModel: ctx.defaultModel } : {}),
+        ...(ctx?.defaultSubagentModel !== undefined ? { defaultSubagentModel: ctx.defaultSubagentModel } : {}),
+      });
+      (executor as unknown as { pluginBodies: Map<string, PluginSkillBody> | null }).pluginBodies =
+        new Map([[skillName, body]]);
+      return { executor, mockForkSubagent };
+    }
+
+    it('forks the plugin skill on its declared model: override', async () => {
+      // Before the fix, executePluginSkill resolved
+      // `defaultSubagentModel ?? defaultModel ?? 'sonnet'` only — the SKILL.md
+      // `model:` was silently ignored. It must now win, mirroring the registry
+      // fork path (executeForkedRegistrySkill honors skill.model).
+      const { executor, mockForkSubagent } = capturePluginFork(
+        'pinned-plugin',
+        { body: 'body', pluginPath: '/fake/plugin', context: 'fork', model: 'opus' },
+        { defaultModel: 'sonnet', defaultSubagentModel: 'haiku' },
+      );
+
+      await executor.execute(makeCall({ name: 'pinned-plugin' }));
+
+      expect(mockForkSubagent).toHaveBeenCalledWith(
+        expect.objectContaining({ config: expect.objectContaining({ model: 'opus' }) }),
+      );
+    });
+
+    it('falls back to defaultSubagentModel when the plugin skill declares no model:', async () => {
+      const { executor, mockForkSubagent } = capturePluginFork(
+        'no-model-plugin',
+        { body: 'body', pluginPath: '/fake/plugin', context: 'fork' },
+        { defaultModel: 'opus', defaultSubagentModel: 'haiku' },
+      );
+
+      await executor.execute(makeCall({ name: 'no-model-plugin' }));
+
+      expect(mockForkSubagent).toHaveBeenCalledWith(
+        expect.objectContaining({ config: expect.objectContaining({ model: 'haiku' }) }),
+      );
+    });
+
+    it('falls back to defaultModel when neither model: nor defaultSubagentModel is set', async () => {
+      const { executor, mockForkSubagent } = capturePluginFork(
+        'default-model-plugin',
+        { body: 'body', pluginPath: '/fake/plugin', context: 'fork' },
+        { defaultModel: 'opus' },
+      );
+
+      await executor.execute(makeCall({ name: 'default-model-plugin' }));
+
+      expect(mockForkSubagent).toHaveBeenCalledWith(
+        expect.objectContaining({ config: expect.objectContaining({ model: 'opus' }) }),
       );
     });
   });

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -198,6 +198,7 @@ export class SkillExecutor {
           call,
           readOnly,
           pluginSkill.allowedTools,
+          pluginSkill.model,
         );
       }
       // Default: in-context LOAD (2026-06 load-by-default flip). No readOnly —

--- a/src/agent/tools/skill-executor/fork-child-config.ts
+++ b/src/agent/tools/skill-executor/fork-child-config.ts
@@ -84,12 +84,21 @@ export function buildForkedChildConfig(
     // dropping that gate here would re-open mutating bash even at the cap.
     if (readOnly) {
       // readOnly (with OR without a tools: list): buildReadOnlyReconProvider
-      // carries readOnlyBash + readOnlyMemory + RECON_ALLOWED_TOOLS. The
-      // tools: intersection (effectiveAllowed) is a subset of RECON, so RECON
-      // is a safe read-only superset and — crucially — the mutating-bash gate
-      // is preserved. This closes the cap-path readOnlyBash fail-open for a
+      // carries readOnlyBash + readOnlyMemory. Pass effectiveAllowed so a
+      // read-only skill that DECLARED `tools:` is restricted to its declared
+      // subset (the RECON intersection) instead of the full RECON superset —
+      // matching the factory path below (issue #499, finding 2: the cap path
+      // previously ignored effectiveAllowed and granted the whole RECON set,
+      // e.g. web_scrape egress to a `tools: [bash]` skill). When the skill
+      // declared no `tools:`, effectiveAllowed is the full RECON set, so the
+      // historical behavior is unchanged. Either branch preserves the
+      // mutating-bash gate, closing the cap-path readOnlyBash fail-open for a
       // `read-only: true` + `tools: bash` skill forked at the depth cap.
-      childConfig.provider = buildReadOnlyReconProvider(childConfig.model, ctx.openaiBaseUrl);
+      childConfig.provider = buildReadOnlyReconProvider(
+        childConfig.model,
+        ctx.openaiBaseUrl,
+        effectiveAllowed,
+      );
     } else if (effectiveAllowed !== undefined) {
       // Non-readOnly tools: allowlist at the cap. Restrict to the declared
       // tools (no readOnlyBash — the skill did not declare read-only).

--- a/src/agent/tools/skill-executor/fork-dispatch.ts
+++ b/src/agent/tools/skill-executor/fork-dispatch.ts
@@ -143,6 +143,9 @@ export async function executePluginSkill(
   // body's `readOnly` frontmatter OR DEFAULT_READ_ONLY_SKILLS membership.
   readOnly = false,
   allowedTools?: string[],
+  // Per-skill model override from the SKILL.md `model:` frontmatter field.
+  // Threaded from `pluginSkill.model` at the call site (skill-executor.ts).
+  model?: string,
 ): Promise<ToolResult> {
   const { ctx, currentCwd } = internals;
   if (call.signal.aborted) {
@@ -153,7 +156,13 @@ export async function executePluginSkill(
   // executeForkedRegistrySkill) so we can derive the correct credential.
   // The resolver is now available directly from the agent layer
   // (resolveCredentialForModel), so no injection is required.
-  const pluginChildModel = ctx.defaultSubagentModel ?? ctx.defaultModel ?? 'sonnet';
+  //
+  // The SKILL.md `model:` override (`model`) wins over the session defaults —
+  // mirroring the registry fork path (executeForkedRegistrySkill:72
+  // `skill.model ?? ...`). Without the leading `model ??` term a plugin skill
+  // pinned to e.g. `model: opus` was silently downgraded to the session
+  // default subagent model.
+  const pluginChildModel = model ?? ctx.defaultSubagentModel ?? ctx.defaultModel ?? 'sonnet';
   const pluginChildApiKey = applyParentCredentialFallback({
     childModel: pluginChildModel,
     resolved: ctx.resolveApiKeyForModel


### PR DESCRIPTION
Fixes the two remaining latent `skill-executor` bugs from #499 (surfaced report-only during the #363 split; all predate it). **Finding 1** (`execute()` swallowing execution errors) was already fixed in #534, so this PR covers **Findings 2 & 3**.

## Finding 2 — read-only depth-cap fallback widened the declared `tools:` allowlist (least-privilege)

At the nesting cap (no `childProviderFactory`), a `read-only: true` + `tools: [...]` plugin skill was forked with the **full RECON tool set** rather than the intersection with its declared `tools:` — granting tools the SKILL.md never declared (e.g. `web_scrape` egress to a `tools: [bash]` skill). The factory (non-cap) path already restricted to `effectiveAllowed`; the cap path silently ignored it.

- `buildReadOnlyReconProvider` now accepts an optional effective-allowlist arg (defaults to the full RECON set for backward compat).
- The cap branch in `buildForkedChildConfig` threads `effectiveAllowed`, making it consistent with the factory path.
- The `readOnlyBash` + `readOnlyMemory` gates are still baked in by the builder regardless of the allowlist, so the mutating-bash gate is preserved.

## Finding 3 — plugin fork path ignored per-skill `model:`

`executePluginSkill` resolved `defaultSubagentModel ?? defaultModel ?? 'sonnet'` only, silently downgrading a plugin skill pinned to e.g. `model: opus`. The registry fork path already honored `skill.model`.

- SKILL.md `model:` frontmatter is now parsed (`tool-injector.ts`), surfaced on `PluginSkillBody` (`skill-bridge.ts`), threaded through `executePluginSkill`, and wins the resolution (`model ?? defaultSubagentModel ?? defaultModel ?? 'sonnet'`) — mirroring `executeForkedRegistrySkill`.
- No allow-list validation (an arbitrary id flows to `providerForModel()` / the credential resolver exactly like the unvalidated registry-skill `model` field). A bare/empty `model:` line falls through to the session default.

## Tests
- `tool-injector.test.ts`: `model:` parsing — value, quoted value (quote-strip), empty (falls through), absent.
- `nesting.test.ts`: `buildReadOnlyReconProvider` allowlist override — narrows to the passed set, defaults to full RECON, preserves `readOnlyBash`/`readOnlyMemory`, materializes a fresh array.
- `skill-executor.test.ts`: cap-path RECON-intersection (updated existing guard) + full-RECON-when-no-`tools:`; plugin `model:` override + `defaultSubagentModel`/`defaultModel` fallbacks.

## Verification
- `pnpm lint` (tsc --noEmit, strict) — clean
- `pnpm test` — full suite green (11468 passed, 14 skipped)
- `pnpm audit:sdk:check`, `pnpm audit:env:check`, `pnpm scan:env:check` — all pass

Closes #499