### PR TITLE
feat(tui): badge NESTING roots in committed scrollback (#532)

### DIFF
--- a/src/cli/commands/interactive/tool-lane-render-agent.ts
+++ b/src/cli/commands/interactive/tool-lane-render-agent.ts
@@ -16,6 +16,40 @@ import { getGlyphs, clampLineToTerminal } from './tool-lane-render.js';
 import { renderFlushChildren } from './tool-lane-render-children.js';
 
 /**
+ * Append the concurrency-batch badge (` ∥i/N`) to a NESTING root's
+ * result-summary — the `Done (…)` closer line — when the root ran in a parallel
+ * wave (`agent.result.batchSize > 1`). Returns the summary unchanged (badge
+ * included only when applicable) or `undefined`/empty as-is so no phantom closer
+ * is synthesized (`addResultSummarySynthetic` skips a falsy summary).
+ *
+ * Contract (issue #532 — scrollback NESTING-root badge): the closer, NOT the
+ * head row, is the correct anchor for a NESTING root's badge in committed
+ * scrollback:
+ *  - A NESTING head row (`◉ → agent(…)`) carries NO outcome — the outcome lives
+ *    on the `agentResultSummary` closer, so the closer is the nesting-root analog
+ *    of a flat root's outcome row (where the badge already lives after #520).
+ *  - The head row may be committed EAGERLY by {@link formatAgentHeader} (via
+ *    flushSource's ancestor walk) BEFORE the root completes, when `batchSize` is
+ *    not yet known; that path sets `headerEmitted=true` and routes the completion
+ *    emit to {@link formatAgentChildren} (closer only, no head row). The closer is
+ *    the one row emitted at completion time in BOTH the headerEmitted=false
+ *    ({@link formatAgentSummary}) and headerEmitted=true ({@link formatAgentChildren})
+ *    paths, and `agent.result.batchSize` is available at that point.
+ *  - `batchBadge` returns `''` for singleton batches (batchSize<=1) and when
+ *    `result` is absent, so a sequential dispatch is never badged (parity with
+ *    flat roots / bash).
+ *
+ * The badge is a trailing dim text suffix on the closer's content — it changes
+ * no indent, connector, or spine glyph, so the severed-spine dual-encoding
+ * invariant between formatAgentHeader/formatAgentSummary is untouched.
+ */
+function summaryWithBatchBadge(agent: ToolEntry): string | undefined {
+  return agent.agentResultSummary
+    ? agent.agentResultSummary + batchBadge(agent.result)
+    : agent.agentResultSummary;
+}
+
+/**
  * Render an Agent (subagent) entry plus its tree of children as a scrollback
  * block.
  *
@@ -101,7 +135,9 @@ function formatAgentSummary(
     children,
     childMap,
     homeDir,
-    agent.agentResultSummary,
+    // #532: badge the closer (Done line) when this NESTING root ran in a
+    // parallel wave. See summaryWithBatchBadge for why the closer, not the head.
+    summaryWithBatchBadge(agent),
     getTerminalWidth(),
     externalAncestors,
     g,
@@ -188,7 +224,11 @@ function formatAgentChildren(
     children,
     childMap,
     homeDir,
-    agent.agentResultSummary,
+    // #532: badge the closer (Done line) when this NESTING root ran in a
+    // parallel wave. In this (headerEmitted) path the head row was already
+    // committed eagerly by formatAgentHeader without the badge (batchSize was
+    // unknown then), so the closer is the only completion-time anchor.
+    summaryWithBatchBadge(agent),
     getTerminalWidth(),
     externalAncestors,
     g,

--- a/src/cli/commands/interactive/tool-lane-render-agent.ts
+++ b/src/cli/commands/interactive/tool-lane-render-agent.ts
@@ -16,11 +16,23 @@ import { getGlyphs, clampLineToTerminal } from './tool-lane-render.js';
 import { renderFlushChildren } from './tool-lane-render-children.js';
 
 /**
- * Append the concurrency-batch badge (` ∥i/N`) to a NESTING root's
- * result-summary — the `Done (…)` closer line — when the root ran in a parallel
- * wave (`agent.result.batchSize > 1`). Returns the summary unchanged (badge
- * included only when applicable) or `undefined`/empty as-is so no phantom closer
- * is synthesized (`addResultSummarySynthetic` skips a falsy summary).
+ * Compose a NESTING root's committed-scrollback closer — the `Done (…)` line —
+ * as a fully-styled string: the dimmed result-summary followed by the
+ * concurrency-batch badge (` ∥i/N`) when the root ran in a parallel wave
+ * (`agent.result.batchSize > 1`). Returns `undefined`/empty as-is for a falsy
+ * summary so no phantom closer is synthesized (`addResultSummarySynthetic` skips
+ * a falsy summary).
+ *
+ * Styling ownership (why this dims the base HERE): the render sites in
+ * tool-lane-render-children.ts emit a `resultSummary` sibling's `.summary`
+ * VERBATIM — they no longer wrap it in `palette.dim()`. A NESTING closer has two
+ * differently-styled parts (a dim base + a self-dimmed badge from `batchBadge`),
+ * so a single outer dim would nest the badge's own dim codes. Dimming the base
+ * here and letting `batchBadge` self-dim keeps each part dimmed exactly once.
+ * `summaryWithBatchBadge` is the SOLE feeder of `addResultSummarySynthetic` (via
+ * renderFlushChildren), so the "summary is pre-styled" invariant holds for every
+ * `resultSummary` item. For a non-parallel closer `batchBadge` returns `''`, so
+ * the output is `palette.dim(summary)` — byte-identical to the prior behavior.
  *
  * Contract (issue #532 — scrollback NESTING-root badge): the closer, NOT the
  * head row, is the correct anchor for a NESTING root's badge in committed
@@ -39,13 +51,13 @@ import { renderFlushChildren } from './tool-lane-render-children.js';
  *    `result` is absent, so a sequential dispatch is never badged (parity with
  *    flat roots / bash).
  *
- * The badge is a trailing dim text suffix on the closer's content — it changes
- * no indent, connector, or spine glyph, so the severed-spine dual-encoding
- * invariant between formatAgentHeader/formatAgentSummary is untouched.
+ * The badge changes no indent, connector, or spine glyph — it is text appended
+ * to the closer's content only, so the severed-spine dual-encoding invariant
+ * between formatAgentHeader/formatAgentSummary is untouched.
  */
 function summaryWithBatchBadge(agent: ToolEntry): string | undefined {
   return agent.agentResultSummary
-    ? agent.agentResultSummary + batchBadge(agent.result)
+    ? palette.dim(agent.agentResultSummary) + batchBadge(agent.result)
     : agent.agentResultSummary;
 }
 

--- a/src/cli/commands/interactive/tool-lane-render-children.ts
+++ b/src/cli/commands/interactive/tool-lane-render-children.ts
@@ -151,7 +151,9 @@ function renderOverlayChildren(
     } else if (item.kind === 'resultSummary') {
       // resultSummary synthetics are not added for the overlay path (no
       // agentResultSummary in the overlay context), but handle gracefully.
-      lines.push(clampLineToTerminal(indentColored + connector + palette.dim(item.summary), cols));
+      // `.summary` is PRE-STYLED by summaryWithBatchBadge (dim base + self-dim
+      // batch badge) — emit verbatim; re-dimming would nest the badge's dim.
+      lines.push(clampLineToTerminal(indentColored + connector + item.summary, cols));
     } else {
       const child = item;
       const grandchildren = childMap.get(child.toolUseId);
@@ -392,7 +394,9 @@ function renderFlushChildren(
       lines.push(clampLineToTerminal(indentColored + connector + palette.dim(item.text), cols));
     } else if (item.kind === 'resultSummary') {
       // LAST connector from assignConnectors — not a hardcoded '⎿' (that was Bug #5).
-      lines.push(clampLineToTerminal(indentColored + connector + palette.dim(item.summary), cols));
+      // `.summary` is PRE-STYLED by summaryWithBatchBadge (dim base + self-dim
+      // batch badge) — emit verbatim; re-dimming would nest the badge's dim.
+      lines.push(clampLineToTerminal(indentColored + connector + item.summary, cols));
     } else if (item.kind === 'group') {
       lines.push(clampLineToTerminal(indentColored + connector + formatGroupedSibling(item), cols));
     } else {

--- a/src/cli/commands/interactive/tool-lane-render-grouping.ts
+++ b/src/cli/commands/interactive/tool-lane-render-grouping.ts
@@ -22,7 +22,13 @@ interface GroupedSibling {
   entries: ToolEntry[];
 }
 
-/** Synthetic result-summary placeholder produced by {@link addResultSummarySynthetic}. */
+/**
+ * Synthetic result-summary placeholder produced by {@link addResultSummarySynthetic}.
+ *
+ * Invariant: `summary` is PRE-STYLED by its sole feeder `summaryWithBatchBadge`
+ * (dim base + self-dimmed `∥i/N` batch badge). Render sites emit it verbatim and
+ * MUST NOT re-wrap it in `palette.dim()` — re-dimming nests the badge's own dim.
+ */
 interface ResultSummarySibling {
   kind: 'resultSummary';
   summary: string;

--- a/src/cli/commands/interactive/tool-lane.test.ts
+++ b/src/cli/commands/interactive/tool-lane.test.ts
@@ -65,6 +65,75 @@ describe('ToolLane — batch (parallel-wave) badge on root rows', () => {
     expect(overlay).toContain('∥1/2');
     expect(overlay).toContain('∥2/2');
   });
+
+  // ── NESTING-root badge in committed scrollback (issue #532) ──────────────
+  //
+  // #520 badged flat roots in both overlay and scrollback, and NESTING roots
+  // (agent/skill/compose) in the live overlay only. These assert the deferred
+  // path: a NESTING root that ran in a parallel wave carries the badge once
+  // committed to scrollback, on its `Done (…)` closer line (the nesting-root
+  // analog of a flat root's badged outcome row). The head row is NOT the anchor
+  // — it may be committed eagerly before batchSize is known (see
+  // summaryWithBatchBadge in tool-lane-render-agent.ts).
+
+  it('flush() badges a NESTING root closer with ∥i/N for a parallel wave (formatAgentSummary path)', () => {
+    const lane = new ToolLane();
+    // Two agent roots dispatched together (batchSize=2), each with a child +
+    // a Done summary. No flushSource ran, so each root commits via
+    // formatAgentSummary (headerEmitted=false) with result+batchSize present.
+    lane.addStartWithAgentContext('agent-1', 'Agent', '(researcher)', undefined);
+    lane.addStartWithAgentContext('c1', 'Read', '("a.ts")', 'agent-1');
+    lane.addResult('c1', makeResult('10 lines'));
+    lane.setAgentResultSummary('agent-1', 'Done (1 tool · 2.0s)');
+    lane.addResult('agent-1', batchResult('done', 1, 2));
+
+    lane.addStartWithAgentContext('agent-2', 'Agent', '(verifier)', undefined);
+    lane.addStartWithAgentContext('c2', 'Grep', '("foo")', 'agent-2');
+    lane.addResult('c2', makeResult('3 matches'));
+    lane.setAgentResultSummary('agent-2', 'Done (1 tool · 1.5s)');
+    lane.addResult('agent-2', batchResult('done', 2, 2));
+
+    const joined = stripAnsi(lane.flush().join('\n'));
+    // Badge lands on the Done closer of each nesting root, not the head row.
+    expect(joined).toMatch(/Done \(1 tool · 2\.0s\) ∥1\/2/);
+    expect(joined).toMatch(/Done \(1 tool · 1\.5s\) ∥2\/2/);
+  });
+
+  it('flush() does NOT badge a singleton NESTING root (batchSize === 1)', () => {
+    const lane = new ToolLane();
+    lane.addStartWithAgentContext('agent-1', 'Agent', '(researcher)', undefined);
+    lane.addStartWithAgentContext('c1', 'Read', '("a.ts")', 'agent-1');
+    lane.addResult('c1', makeResult('10 lines'));
+    lane.setAgentResultSummary('agent-1', 'Done (1 tool · 2.0s)');
+    lane.addResult('agent-1', batchResult('done', 1, 1));
+
+    expect(stripAnsi(lane.flush().join('\n'))).not.toContain('∥');
+  });
+
+  it('eager-header (flushSource) path: NESTING root badge lands on the closer via formatAgentChildren', () => {
+    const lane = new ToolLane();
+    // skill root dispatched in a parallel wave (batchSize=2) with an agent child
+    // that itself owns a tool. The agent completes first → flushSource walks up
+    // and EAGERLY emits skill-1's header (headerEmitted=true, no badge yet —
+    // skill-1 has not completed, batchSize unknown). skill-1 then completes and
+    // flushes via formatAgentChildren (closer only), which carries the badge.
+    lane.addStartWithAgentContext('skill-1', 'skill', '(review)', undefined);
+    lane.addStartWithAgentContext('agent-a', 'Agent', '(reviewer)', 'skill-1');
+    lane.addStartWithAgentContext('c1', 'Read', '("a.ts")', 'agent-a');
+    lane.addResult('c1', makeResult('10 lines'));
+    lane.setAgentResultSummary('agent-a', 'Done (1 tool)');
+    lane.addResult('agent-a', makeResult('done'));
+
+    const eager = stripAnsi(lane.flushSource('agent-a').join('\n'));
+    // The eagerly-committed skill-1 head row is unbadged (batchSize not yet known).
+    expect(eager).not.toContain('∥');
+
+    lane.setAgentResultSummary('skill-1', 'Done (1 subagent · 3.0s)');
+    lane.addResult('skill-1', batchResult('done', 1, 2));
+    const rest = stripAnsi(lane.flush().join('\n'));
+    // Badge lands on skill-1's Done closer, committed at completion time.
+    expect(rest).toMatch(/Done \(1 subagent · 3\.0s\) ∥1\/2/);
+  });
 });
 
 describe('ToolLane.addStartWithAgentContext', () => {


### PR DESCRIPTION
Closes #532. Completes the deferred scope of #520.

## Problem

#520 added the dim `∥i/N` batch badge that distinguishes a genuine parallel dispatch wave (`batchSize > 1`) from back-to-back sequential dispatch. It badged **flat roots** in both the live overlay and committed scrollback, but **NESTING roots** (agent/skill/compose) only in the **live overlay** — so the parallel-vs-sequential distinction was lost in the durable transcript for agent/skill/compose roots.

That path was deferred in #520 because the NESTING head row is emitted **eagerly** (via `formatAgentHeader`, from `flushSource`'s ancestor walk) *before* the root completes — at which point `batchSize` is not yet known — and naively badging it there risks the severed-spine class of bug.

## Fix

Badge the NESTING root's **`Done (…)` closer line**, not the head row.

- The head row (`◉ → agent(…)`) carries **no outcome** — a NESTING root's outcome lives on the `agentResultSummary` closer, so the closer is the nesting-root analog of a flat root's badged outcome row.
- The closer is the one row emitted at **completion time** in **both** commit paths — `formatAgentSummary` (headerEmitted=false, the common top-level case) and `formatAgentChildren` (headerEmitted=true, when a descendant flushed first and eagerly committed the head row) — and `agent.result.batchSize` is available there.
- Implemented as a small `summaryWithBatchBadge(agent)` helper that appends `batchBadge(agent.result)` to the summary. `batchBadge` returns `''` for singleton batches and when `result` is absent, so a sequential dispatch is never badged (parity with flat roots / bash).

The badge is a trailing dim **text suffix** on the closer's content — it changes no indent, connector, or spine glyph, so the `formatAgentHeader`/`formatAgentSummary` dual-encoding (severed-spine) invariant is untouched.

### Rendered (scrollback)

```
◉ → Agent(researcher) [subagent]
│ ╰─ Done (1 tool · 2.0s) ∥1/2
◉ → Agent(verifier) [subagent]
│ ╰─ Done (1 tool · 1.5s) ∥2/2
```

A singleton NESTING root (ran alone) shows no badge, same as `bash`.

## Acceptance criteria

- [x] A NESTING root dispatched in a parallel wave (`batchSize > 1`) carries its `∥i/N` badge in committed scrollback.
- [x] A NESTING root that ran alone (`batchSize === 1`) shows no badge (parity with flat roots / bash).
- [x] Severed-spine invariant preserved — badge is a text suffix only; existing severed-spine / skill-frame tests unchanged and green.
- [x] Test coverage: scrollback-render tests asserting the badge appears for a parallel wave and is absent for a singleton.

## Tests

Added to `tool-lane.test.ts` (batch-badge describe block):
- `flush()` badges a NESTING root closer for a parallel wave — `formatAgentSummary` (headerEmitted=false) path.
- `flush()` does **not** badge a singleton NESTING root (`batchSize === 1`).
- eager-header (`flushSource`) path — badge lands on the closer via `formatAgentChildren` (headerEmitted=true); the eagerly-committed head row stays unbadged.

Full tool-lane suite (296 tests across 5 files) + `tsc --noEmit` clean. Full repo suite (11,456) green.

## Scope

- Not badged: the `×N` grouped header (already signals multiplicity — avoids a double-signal), consistent with #520.

## References

- Follow-up from #520 (introduced the badge; deferred this path).
- Related: #516 — live "during-pending" parallel-batch indicator (Phase 2).
