### PR TITLE
fix(subagent): inherit parent read scope for forked sub-agents

### DIFF
--- a/src/agent/subagent-read-scope.test.ts
+++ b/src/agent/subagent-read-scope.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { computeInheritedReadRoots, readOpenRootFor } from './subagent-read-scope.js';
+
+const FS_ROOT = path.parse(path.resolve('.')).root || path.sep;
+
+describe('readOpenRootFor', () => {
+  it('returns the volume root for an absolute path', () => {
+    expect(readOpenRootFor('/Users/x/proj/.afk-worktrees/wt')).toBe(FS_ROOT);
+  });
+  it('falls back to process.cwd volume root when base is undefined', () => {
+    expect(readOpenRootFor(undefined)).toBe(FS_ROOT);
+  });
+});
+
+describe('computeInheritedReadRoots', () => {
+  describe('unconfined parent (the common top-level `afk`/`afk i` case)', () => {
+    it('grants read-open when parent has no readRoots and no cwd', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: undefined,
+        childCwd: '/repo/.afk-worktrees/iso-1',
+      });
+      expect(roots).toEqual([FS_ROOT]);
+    });
+
+    it('read-open root lexically contains sibling worktrees AND ~/.afk paths', () => {
+      const [root] = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: undefined,
+        childCwd: '/repo/.afk-worktrees/iso-1',
+      })!;
+      // A path is admitted iff path.relative(root, target) does not escape.
+      for (const target of [
+        '/repo/.afk-worktrees/other-wt/src/x.ts',
+        '/Users/me/.afk/state/skill-preflight/pr-1.diff',
+        '/repo/src/agent/subagent.ts',
+      ]) {
+        expect(path.relative(root!, target).startsWith('..')).toBe(false);
+      }
+    });
+  });
+
+  describe('confined parent', () => {
+    it('unions child cwd + parent cwd + worktree main root', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: '/repo',
+        childCwd: '/repo/.afk-worktrees/iso-1',
+        worktreeMainRoot: '/repo',
+      });
+      expect(new Set(roots)).toEqual(new Set(['/repo/.afk-worktrees/iso-1', '/repo']));
+    });
+
+    it('inherits explicit parent readRoots (transitive propagation)', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: ['/repo', '/extra/allowed-dir'],
+        parentCwd: '/repo',
+        childCwd: '/repo/.afk-worktrees/iso-2',
+      });
+      expect(new Set(roots)).toEqual(
+        new Set(['/repo/.afk-worktrees/iso-2', '/repo', '/extra/allowed-dir']),
+      );
+    });
+
+    it('propagates a read-open parent transitively (grandchild stays read-open)', () => {
+      // A read-open child's effective readRoots is [FS_ROOT]; when it forks, that
+      // value arrives here as the (explicit) parentReadRoots.
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: [FS_ROOT],
+        parentCwd: '/repo/.afk-worktrees/iso-1',
+        childCwd: '/repo/.afk-worktrees/iso-1/sub',
+      });
+      expect(roots).toContain(FS_ROOT); // grandchild remains read-open
+    });
+
+    it('never narrows below the parent scope', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: ['/a', '/b'],
+        parentCwd: '/a',
+        childCwd: '/a/child',
+      })!;
+      expect(roots).toEqual(expect.arrayContaining(['/a', '/b']));
+    });
+
+    it('returns undefined when the only root is the child cwd (== provider default, no broadening)', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: '/repo',
+        childCwd: '/repo',
+        worktreeMainRoot: undefined,
+      });
+      // Nothing broader than [cwd] → leave provider default untouched.
+      expect(roots).toBeUndefined();
+    });
+
+    it('returns undefined when worktree main root equals the child cwd (defensive)', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: '/repo/.afk-worktrees/wt',
+        childCwd: '/repo/.afk-worktrees/wt',
+        worktreeMainRoot: '/repo/.afk-worktrees/wt',
+      });
+      expect(roots).toBeUndefined();
+    });
+  });
+
+  describe('degenerate inputs', () => {
+    it('returns undefined when confined parent has no usable roots (leave provider default)', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: [],
+        parentCwd: undefined,
+        childCwd: undefined,
+      });
+      expect(roots).toBeUndefined();
+    });
+
+    it('returns undefined for an unconfined parent when the child also has no cwd (naturally unconfined)', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: undefined,
+        childCwd: undefined,
+      });
+      expect(roots).toBeUndefined();
+    });
+  });
+});

--- a/src/agent/subagent-read-scope.ts
+++ b/src/agent/subagent-read-scope.ts
@@ -1,0 +1,126 @@
+/**
+ * Read-scope inheritance for forked sub-agents (#416/#441 successor).
+ *
+ * Invariant: a forked read-only sub-agent must be able to READ everything its
+ * parent could read. Writes are a separate, stricter axis (a fork stays
+ * write-confined to its own cwd / worktree / explicit writeRoots) — this module
+ * governs ONLY the read allow-list.
+ *
+ * History: the prior fix (#416) granted a worktree fork the main-repo root as a
+ * read root, but only when `resolveWorktreeMainRoot` succeeded — it fails
+ * silently on any `git rev-parse` error, re-confining the child to `[cwd]`
+ * (#441 added a debug log but not a fix). Meanwhile a fork under an *unconfined*
+ * top-level session (a plain `afk`/`afk i` with no `-w` → `resolveBase`
+ * undefined → reads anywhere) got a concrete cwd and became confined to that
+ * cwd, so it could no longer read sibling `.afk-worktrees/*` trees NOR
+ * `~/.afk/state` paths that pervade its prompt/context — every such read was
+ * hard-blocked by the path-approval hook (forks cannot prompt), and the child
+ * spun on retried denials until a wall-clock timeout. This module replaces the
+ * fragile single-grant with a uniform "child read scope ⊇ parent read scope"
+ * rule that also covers the unconfined-parent case.
+ *
+ * The single source of truth is {@link computeInheritedReadRoots}, a pure
+ * function called at the fork choke point (`SubagentManager.forkSubagent`) and,
+ * for transitive correctness, when a child builds the manager for its own
+ * grandchildren (`buildChildConfig`).
+ *
+ * @module agent/subagent-read-scope
+ */
+
+import path from 'path';
+
+/**
+ * A read root that admits any path on the volume — the honest expression of
+ * "inherit an unconfined parent's read scope". `resolveAndContain` treats a
+ * path as allowed iff it is inside SOME read root; the filesystem root contains
+ * every absolute path, so this grants read-open (writes remain governed by the
+ * separate writeRoots list). Derived from a base path so the volume root is
+ * correct cross-platform (`/` on posix, `C:\` on win32).
+ */
+export function readOpenRootFor(base: string | undefined): string {
+  const resolved = path.resolve(base ?? process.cwd());
+  return path.parse(resolved).root || path.sep;
+}
+
+export interface InheritedReadRootsArgs {
+  /**
+   * The parent session's explicit read roots, or `undefined` to derive the
+   * parent's scope from {@link parentCwd}. A caller that pins `readRoots`
+   * (e.g. `afk farm`, which deliberately confines each branch worker) is
+   * handled UPSTREAM — this function is only invoked when the child left
+   * `readRoots` unset — so an explicit value here always means "the parent is
+   * confined to exactly these roots" (used for transitive propagation).
+   */
+  parentReadRoots: string[] | undefined;
+  /**
+   * The parent session's cwd. `undefined` signals an UNCONFINED parent (a
+   * top-level session with no worktree → `resolveBase` undefined → reads
+   * anywhere); a defined value is the parent's containment base.
+   */
+  parentCwd: string | undefined;
+  /** The child fork's effective cwd (its own tree). */
+  childCwd: string | undefined;
+  /**
+   * The main-repo root when {@link childCwd} is inside a linked git worktree,
+   * else undefined. Folded into the union so a worktree fork can read the main
+   * checkout and — since sibling worktrees live under `<mainRoot>/.afk-worktrees/`
+   * and containment is lexical — every sibling worktree too.
+   */
+  worktreeMainRoot?: string | undefined;
+}
+
+/**
+ * Compute the read roots a forked child should inherit, or `undefined` to leave
+ * the provider default (`[childCwd]`) in place.
+ *
+ * Rules:
+ *  - Parent UNCONFINED (`parentReadRoots` undefined AND `parentCwd` undefined):
+ *    the child inherits read-open — `[readOpenRootFor(childCwd)]`. Writes stay
+ *    confined to the child's own cwd/writeRoots.
+ *  - Parent CONFINED (explicit `parentReadRoots`, or a defined `parentCwd`):
+ *    the child gets the UNION of the parent's roots, its own cwd, and the
+ *    worktree main root — never narrower than the parent (child read scope ⊇
+ *    parent read scope), never write-relevant.
+ *
+ * Returns a de-duplicated, resolved array. `undefined` only when there is
+ * genuinely nothing to grant (no child cwd, no parent scope) — the caller then
+ * leaves the provider default untouched.
+ */
+export function computeInheritedReadRoots(args: InheritedReadRootsArgs): string[] | undefined {
+  const { parentReadRoots, parentCwd, childCwd, worktreeMainRoot } = args;
+  const resolvedChildCwd =
+    childCwd !== undefined && childCwd !== '' ? path.resolve(childCwd) : undefined;
+
+  // Unconfined parent (no explicit roots AND no cwd) → child inherits read-open.
+  // A confined child would be NARROWER than its parent, which is the bug this
+  // module exists to prevent.
+  if (parentReadRoots === undefined && parentCwd === undefined) {
+    // A child with no cwd is ALREADY unconfined — its resolveBase is undefined,
+    // which bypasses containment entirely (see _cwd-utils.ts) — so leave
+    // readRoots unset. Only a child WITH a cwd (whose reads would otherwise be
+    // confined to `[cwd]`) needs the explicit read-open grant to match the
+    // parent's reach.
+    return resolvedChildCwd !== undefined ? [readOpenRootFor(resolvedChildCwd)] : undefined;
+  }
+
+  // Confined parent → union(childCwd, parent roots, worktree main root).
+  const parentRoots = parentReadRoots ?? (parentCwd !== undefined ? [parentCwd] : []);
+  const roots = new Set<string>();
+  if (resolvedChildCwd !== undefined) roots.add(resolvedChildCwd);
+  for (const r of parentRoots) {
+    if (r !== undefined && r !== '') roots.add(path.resolve(r));
+  }
+  if (worktreeMainRoot !== undefined && worktreeMainRoot !== '') {
+    roots.add(path.resolve(worktreeMainRoot));
+  }
+
+  // Nothing to grant, OR the only root is the child's own cwd (which equals the
+  // provider's `[cwd]` default) → leave readRoots unset so the default stands.
+  // This keeps the change surgical: a fork that inherits nothing broader than
+  // its own cwd is byte-for-byte unchanged from the pre-fix behaviour.
+  if (roots.size === 0) return undefined;
+  if (roots.size === 1 && resolvedChildCwd !== undefined && roots.has(resolvedChildCwd)) {
+    return undefined;
+  }
+  return [...roots];
+}

--- a/src/agent/subagent-worktree-readroot.test.ts
+++ b/src/agent/subagent-worktree-readroot.test.ts
@@ -1,21 +1,25 @@
 /**
- * Regression tests: forkSubagent grants the MAIN repo root as a read root to
- * subagents whose cwd is a linked git worktree.
+ * Regression tests: forkSubagent derives a forked child's READ roots by
+ * inheriting the parent session's read scope (see ./subagent-read-scope).
  *
- * Bug (pre-fix): a subagent forked from an `afk -w` worktree session inherits
- * the worktree cwd but no read roots, so its dispatcher defaults to
- * `readRoots = [worktree]`. Any `read_file <mainRepo>/…` is rejected as
- * "outside the allowed read roots", and the subagent cannot approve it (the
- * path-approval hook auto-denies forked children). This locks subagents out of
- * main-repo paths that pervade their context.
+ * Bug (pre-fix, #416/#441): a fork inherited a concrete cwd but its read roots
+ * either defaulted to `[worktree]` or relied on a main-root grant that vanished
+ * silently on any `git rev-parse` failure. Any read outside `[cwd]` — a sibling
+ * `.afk-worktrees/*` tree, a `~/.afk/state` path, the main repo — was rejected
+ * as "outside the allowed read roots", and the fork could not approve it (the
+ * path-approval hook auto-denies forked children), so it spun on retried
+ * denials to a wall-clock timeout.
  *
- * Fix: forkSubagent resolves the worktree's main-repo root (best-effort, via
- * ./worktree-read-root) and sets `childConfig.readRoots = [cwd, mainRoot]` when
- * the caller did not pin its own read roots. These tests capture the config
- * handed to the child AgentSession and assert the grant.
+ * Fix (Option A): child read scope ⊇ parent read scope. An UNCONFINED parent
+ * (top-level `afk` with no worktree → reads anywhere) yields a read-open child;
+ * a CONFINED parent yields the union of its roots, the child's cwd, and the
+ * worktree main root. Writes stay confined (separate writeRoots axis). A caller
+ * that pins `readRoots` (e.g. `afk farm`) suppresses inheritance. These tests
+ * capture the config handed to the child AgentSession and assert the scope.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'path';
 import type { Message } from './types.js';
 
 type CapturedConfig = Record<string, unknown> | null;
@@ -62,6 +66,7 @@ import { resolveWorktreeMainRoot } from './worktree-read-root.js';
 
 const WORKTREE = '/repo/.afk-worktrees/wt';
 const MAIN = '/repo';
+const FS_ROOT = path.parse(path.resolve('.')).root || path.sep;
 
 const mockedResolve = vi.mocked(resolveWorktreeMainRoot);
 
@@ -92,15 +97,20 @@ describe('forkSubagent — worktree main-repo read-root grant', () => {
     expect(mockedResolve).toHaveBeenCalledWith(WORKTREE);
   });
 
-  it('grants [cwd, mainRoot] when cwd comes from per-call config (agent tool cwd)', async () => {
+  it('grants READ-OPEN when the parent is unconfined (no manager cwd), even with a per-call worktree cwd', async () => {
+    // A top-level `afk`/`afk i` with no `-w` is unconfined (reads anywhere).
+    // A fork given an explicit worktree cwd must inherit that reach — a
+    // read-open root — not be re-confined to [cwd, mainRoot]. (Writes stay
+    // confined to the worktree via the separate writeRoots axis.)
     mockedResolve.mockResolvedValue(MAIN);
-    const mgr = new SubagentManager(); // no manager cwd
+    const mgr = new SubagentManager(); // no manager cwd → UNCONFINED parent
     await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k', cwd: WORKTREE }));
 
     const cfg = shared.lastConfig as { cwd?: string; readRoots?: string[] } | null;
     expect(cfg?.cwd).toBe(WORKTREE);
-    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN]);
-    expect(mockedResolve).toHaveBeenCalledWith(WORKTREE);
+    expect(cfg?.readRoots).toEqual([FS_ROOT]);
+    // Read-open ignores the worktree main root → no git resolution is paid for.
+    expect(mockedResolve).not.toHaveBeenCalled();
   });
 
   it('does NOT set readRoots when cwd is not a worktree (resolver returns undefined)', async () => {

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -36,6 +36,7 @@ import { appendRoutingDecision } from './routing-telemetry.js';
 import { getCurrentSink } from './_lib/skill-sink-channel.js';
 import { touchWorktreeOccupancy } from './worktree-occupancy.js';
 import { resolveWorktreeMainRoot } from './worktree-read-root.js';
+import { computeInheritedReadRoots } from './subagent-read-scope.js';
 import { buildPhaseRestrictedProvider, type PhaseRole } from './tools/nesting.js';
 import { applyManagerApiKeyFallback } from './tools/child-credential.js';
 import { providerForModel, type BundledProviderName } from './providers/index.js';
@@ -259,6 +260,18 @@ export interface SubagentManagerOptions {
    */
   cwd?: string;
   /**
+   * The parent session's effective READ roots, used to derive a forked child's
+   * inherited read scope (see ./subagent-read-scope). `undefined` means "derive
+   * from {@link cwd}": a defined `cwd` is treated as the parent's containment
+   * base, an undefined `cwd` as an UNCONFINED parent (reads anywhere → read-open
+   * child). Pass an explicit array only when the parent is confined to roots
+   * that differ from its cwd — chiefly to propagate a read-open or `/allow-dir`-
+   * widened scope transitively to grandchildren. A caller (e.g. `afk farm`) that
+   * pins each fork's `config.readRoots` suppresses inheritance entirely, so this
+   * never widens a deliberately-confined worker.
+   */
+  parentReadRoots?: string[];
+  /**
    * Witness-layer trace writer. Threaded into the manager's {@link AbortGraph}
    * so cascade aborts emit `abort` events, AND auto-inherited by every forked
    * child whose `config.traceWriter` is unset — so all worker sessions write
@@ -306,6 +319,10 @@ export class SubagentManager {
   // `afk -w` worktree is created mid-session. Read at fork time (forkSubagent),
   // so updating it makes every subsequent fork inherit the new worktree cwd.
   private parentCwd: string | undefined;
+  // The parent session's effective read roots, for read-scope inheritance
+  // (see ./subagent-read-scope). `undefined` = derive from parentCwd
+  // (defined → confined base; undefined → unconfined parent → read-open child).
+  private readonly parentReadRoots: string[] | undefined;
   // Per-cwd cache of the resolved main-repo root for worktree children (see
   // `resolveWorktreeMainRoot`). Forks overwhelmingly share one cwd, so this
   // collapses N git subprocesses to one per distinct cwd for the whole
@@ -331,6 +348,7 @@ export class SubagentManager {
     this.parentProvider =
       options.parentModel !== undefined ? providerForModel(options.parentModel) : undefined;
     this.parentCwd = options.cwd;
+    this.parentReadRoots = options.parentReadRoots;
     this.parentTraceWriter = options.traceWriter;
     this.parentSurface = options.surface;
     this.onSubagentSucceededCb = options.onSubagentSucceeded;
@@ -404,6 +422,19 @@ export class SubagentManager {
     // the cache (#441). setCwd is rare (born-named worktree creation on turn 1),
     // so forcing one re-resolution on the next fork costs nothing.
     this.worktreeMainRootCache.delete(cwd);
+  }
+
+  /**
+   * The read-scope inputs this manager applies to its forks — the parent's
+   * `readRoots` (may be undefined = derive from cwd) and `cwd`. Used to
+   * propagate read scope transitively: a forked child that builds its OWN
+   * manager for grandchildren computes its inherited read roots from these
+   * inputs (via {@link computeInheritedReadRoots}) and passes the result as the
+   * grandchild manager's `parentReadRoots`, so a read-open (or `/allow-dir`-
+   * widened) scope is not silently re-narrowed one nesting level down.
+   */
+  getReadScopeInputs(): { parentReadRoots: string[] | undefined; parentCwd: string | undefined } {
+    return { parentReadRoots: this.parentReadRoots, parentCwd: this.parentCwd };
   }
 
   /**
@@ -520,22 +551,40 @@ export class SubagentManager {
     this.abortGraph.register(id, childController);
     this.abortGraph.linkChild(this.rootId, id);
 
-    // Worktree read-root grant: when the child runs in a linked git worktree
-    // and the caller did not pin its own read roots, add the MAIN repo root as
-    // a READ root (never a write root — writes stay confined to the worktree).
-    // Without this, a subagent is confined to `[cwd]` and cannot read main-repo
-    // absolute paths that pervade its context (system prompt, skill prompts,
-    // parent messages), yet it cannot approve them interactively either — the
-    // path-approval hook auto-denies forked children. See ./worktree-read-root.
-    // A caller that pins `readRoots` (e.g. `afk farm`, which deliberately
-    // confines each branch worker) is left untouched.
+    // Read-scope inheritance (#416/#441 successor — see ./subagent-read-scope).
+    // Invariant: a forked read-only sub-agent must be able to READ everything
+    // its parent could; writes stay confined (writeRoots, below). When the
+    // caller did NOT pin `readRoots` — a caller that pins (e.g. `afk farm`,
+    // which deliberately confines each branch worker) is left untouched — derive
+    // the child's read roots from the parent's scope:
+    //   - UNCONFINED parent (top-level `afk`/`afk i` with no worktree →
+    //     resolveBase undefined → reads anywhere) → read-open child.
+    //   - CONFINED parent → union(child cwd, parent roots, worktree main root);
+    //     the main root lexically covers sibling `.afk-worktrees/*`.
+    // This replaces the prior single main-root grant that vanished silently on
+    // any `git rev-parse` failure, re-confining the child to `[cwd]` (#441) and
+    // hard-blocking every out-of-cwd read until a wall-clock timeout.
     const effectiveChildCwd = options.config.cwd ?? this.parentCwd;
-    let worktreeReadRoots: string[] | undefined;
-    if (options.config.readRoots === undefined && effectiveChildCwd !== undefined) {
-      const mainRoot = await this.resolveMainRootForCwd(effectiveChildCwd);
-      if (mainRoot !== undefined && mainRoot !== effectiveChildCwd) {
-        worktreeReadRoots = [effectiveChildCwd, mainRoot];
-      }
+    let inheritedReadRoots: string[] | undefined;
+    if (options.config.readRoots === undefined) {
+      // An UNCONFINED parent yields a read-open child regardless of the worktree
+      // main root, so skip the (cached) git resolution in that case — the common
+      // top-level `afk` fan-out never pays for it. For a CONFINED parent the main
+      // root is best-effort; on git failure the parentCwd/parentReadRoots union
+      // still supplies the repo root, so the #441 silent-fail is no longer
+      // load-bearing.
+      const parentUnconfined =
+        this.parentReadRoots === undefined && this.parentCwd === undefined;
+      const worktreeMainRoot =
+        !parentUnconfined && effectiveChildCwd !== undefined
+          ? await this.resolveMainRootForCwd(effectiveChildCwd)
+          : undefined;
+      inheritedReadRoots = computeInheritedReadRoots({
+        parentReadRoots: this.parentReadRoots,
+        parentCwd: this.parentCwd,
+        childCwd: effectiveChildCwd,
+        worktreeMainRoot,
+      });
     }
 
     // Explicit write-root pre-grant (#435): when the caller passed writeRoots on
@@ -634,11 +683,10 @@ export class SubagentManager {
       ...(options.config.cwd === undefined && this.parentCwd !== undefined
         ? { cwd: this.parentCwd }
         : {}),
-      // Worktree read-root grant (see the computation above the literal). Only
-      // set when the child runs in a linked worktree AND the caller left
-      // readRoots unset; otherwise the `...options.config` spread's readRoots
-      // (or the provider's `[cwd]` default) stands.
-      ...(worktreeReadRoots !== undefined ? { readRoots: worktreeReadRoots } : {}),
+      // Inherited read scope (see the computation above the literal). Only set
+      // when the caller left readRoots unset; otherwise the `...options.config`
+      // spread's readRoots (or the provider's `[cwd]` default) stands.
+      ...(inheritedReadRoots !== undefined ? { readRoots: inheritedReadRoots } : {}),
       // Explicit write-root pre-grant (#435): composed with cwd above. When
       // writeRoots is absent, composedWriteRoots is undefined and the
       // `...options.config` spread's writeRoots (or the provider's `[cwd]`

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -9,6 +9,7 @@
  */
 
 import { SubagentManager, SUBAGENT_BACKGROUND_TIMEOUT_MS } from '../subagent.js';
+import { computeInheritedReadRoots } from '../subagent-read-scope.js';
 import { BackgroundAgentRegistry } from '../background-registry.js';
 import type { ModelProvider } from '../provider.js';
 import type { AgentModelInput, IAgentSession } from '../types.js';
@@ -475,6 +476,27 @@ export class SubagentExecutor implements SubagentControl {
         ? { origin: deriveOrigin(this.ctx.surface), actor: actorFromDepth(depth) }
         : {};
 
+    // Transitive read-scope propagation (see ../subagent-read-scope): compute
+    // THIS child's inherited read roots from the manager that will fork it, so
+    // the nested manager the child builds for its OWN grandchildren starts from
+    // the child's scope — not a cwd-only proxy that would silently re-confine a
+    // read-open (or /allow-dir-widened) child one nesting level down.
+    // `getReadScopeInputs` is a required method on the real SubagentManager (the
+    // `subagentManager: SubagentManager` type enforces it exists — deleting it
+    // would fail tsc here); the `?.()` guards only the runtime VALUE so the many
+    // `as any`-cast test doubles that predate this method fall back to "no
+    // explicit parent scope" (→ cwd-derivation) instead of throwing. Production
+    // always takes the real branch.
+    const childScopeInputs = this.ctx.subagentManager.getReadScopeInputs?.() ?? {
+      parentReadRoots: undefined,
+      parentCwd: undefined,
+    };
+    const childInheritedReadRoots = computeInheritedReadRoots({
+      parentReadRoots: childScopeInputs.parentReadRoots,
+      parentCwd: childScopeInputs.parentCwd,
+      childCwd: parsed.cwd ?? this.currentCwd,
+    });
+
     // Build the child config + nested-dispatch wiring. All context this needs
     // is passed explicitly; the recursive child executor is injected as a
     // factory so child-config.ts never imports this class at runtime.
@@ -484,6 +506,7 @@ export class SubagentExecutor implements SubagentControl {
       depth,
       maxDepth,
       currentCwd: this.currentCwd,
+      ...(childInheritedReadRoots !== undefined ? { childInheritedReadRoots } : {}),
       signal: call.signal,
       defaultConfig: this.ctx.defaultConfig,
       ...(this.ctx.resolveApiKeyForModel !== undefined

--- a/src/agent/tools/subagent/child-config.ts
+++ b/src/agent/tools/subagent/child-config.ts
@@ -58,6 +58,14 @@ export interface BuildChildConfigArgs {
   depth: number;
   maxDepth: number;
   currentCwd: string | undefined;
+  /**
+   * This child's own inherited read roots, precomputed by the dispatching
+   * executor from the manager that forks it (see ../subagent-read-scope). Passed
+   * to the nested grandchild {@link SubagentManager} as its `parentReadRoots` so
+   * a read-open (or `/allow-dir`-widened) read scope propagates transitively
+   * instead of being silently re-narrowed to the child's cwd one level down.
+   */
+  childInheritedReadRoots?: string[];
   /** The dispatching tool-call's abort signal (owns the child manager lifetime). */
   signal: AbortSignal;
   defaultConfig: Pick<AgentConfig, 'apiKey' | 'systemPrompt' | 'baseUrl' | 'openaiBaseUrl'>;
@@ -290,6 +298,12 @@ export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigRe
     childManager = new SubagentManager({
       parentAbortSignal: signal,
       ...(currentCwd !== undefined ? { cwd: currentCwd } : {}),
+      // Transitive read-scope: seed the grandchild manager with THIS child's
+      // inherited read roots (see ../subagent-read-scope) so a read-open child
+      // does not re-confine its own grandchildren to `[cwd]`.
+      ...(args.childInheritedReadRoots !== undefined
+        ? { parentReadRoots: args.childInheritedReadRoots }
+        : {}),
       // Witness layer: without this, depth-2+ `agent` forks emit no
       // subagent_lifecycle events — the nested manager had no writer and
       // agent-tool dispatches never set config.traceWriter. Mirrors the


### PR DESCRIPTION
## Problem

A forked sub-agent (`agent` tool, `/diagnose` fan-out, etc.) inherited a concrete `cwd` but its **read** roots were either confined to `[cwd]` or relied on a main-repo grant that vanished silently on any `git rev-parse` failure (the `#416`/`#441` line of work). Any read outside `[cwd]` — a sibling `.afk-worktrees/*` tree, a `~/.afk/state` path, or the main checkout itself — was **auto-denied by the path-approval hook** (a forked child cannot prompt to approve). The child then **spun on retried read denials until its wall-clock timeout** instead of failing fast.

Observed concretely across one `/diagnose` fan-out — 5 sessions, **~114 read denials, 0 write denials**, every denied path inside a managed worktree or the main checkout the fork could no longer reach.

## Fix

Replace the fragile single main-root grant with a uniform rule — **child read scope ⊇ parent read scope** — in a new pure module `computeInheritedReadRoots` (`src/agent/subagent-read-scope.ts`):

- **Unconfined parent** (top-level `afk`/`afk i`, no worktree → reads anywhere) → **read-open child** (`[FS_ROOT]`, which lexically covers the worktree *and* `~/.afk/state`). The child's read scope *equals* the parent's — not privilege escalation.
- **Confined parent** → `union(childCwd, parentRoots, worktreeMainRoot)`; the main root lexically covers sibling `.afk-worktrees/*` trees.

Invariants preserved:
- **Writes stay confined** (separate `writeRoots` axis — a worktree fork still writes only its own tree).
- **`afk farm` guardrail**: a caller that pins `readRoots` suppresses inheritance, so a deliberately-confined branch worker is never widened (regression test in `subagent-worktree-readroot.test.ts`).
- **Transitive**: read scope propagates via `getReadScopeInputs → childInheritedReadRoots` so a read-open child does not silently re-confine its own grandchildren.

## Files

| File | Change |
|---|---|
| `src/agent/subagent-read-scope.ts` | **new** — `computeInheritedReadRoots` + `readOpenRootFor` |
| `src/agent/subagent-read-scope.test.ts` | **new** — 12 unit tests |
| `src/agent/subagent.ts` | fork choke point derives child read roots from parent scope |
| `src/agent/tools/subagent-executor.ts` | transitive propagation to the grandchild manager |
| `src/agent/tools/subagent/child-config.ts` | seed grandchild manager `parentReadRoots` |
| `src/agent/subagent-worktree-readroot.test.ts` | regression tests (incl. `afk farm` guardrail) |

## Verification

- `pnpm lint` (tsc --noEmit strict): **clean**
- Full suite: **11,468 passed / 0 failed** (14 skipped)
- Read-scope units 23/23; fork/executor/worktree/farm blast-radius 417/417

## Deferred (separate follow-ups, not required for this fix)

- **Fail-fast loop-break**: the specific 20-min hang is resolved here (reads now succeed), but there is still no loop-break for a *genuinely* out-of-scope read denial. Behavior change, own PR.
- **Telemetry tripwire**: the improve-pipeline detector (`subagent-block.ts`) filters `SubagentStart` only and cannot see these `PreToolUse` read-denials (`blockedTool ∈ {read_file, grep, glob}`). Follow-up PR.
