### PR TITLE
feat(improve): detect forked sub-agent read auto-denials

### DIFF
--- a/src/cli/commands/improve.ts
+++ b/src/cli/commands/improve.ts
@@ -73,6 +73,7 @@ import { scanWitness, parseDuration } from '../../improve/scan/reader.js';
 import { DEFAULT_MIN_REPEATS } from '../../improve/scan/detectors/repeated-tool-use.js';
 import { DEFAULT_CLOSURE_ANOMALY_MIN_OCCURRENCES } from '../../improve/scan/detectors/closure-anomaly.js';
 import { DEFAULT_SUBAGENT_BLOCK_MIN_OCCURRENCES } from '../../improve/scan/detectors/subagent-block.js';
+import { DEFAULT_SUBAGENT_READ_DENIAL_MIN_OCCURRENCES } from '../../improve/scan/detectors/subagent-read-denial.js';
 import {
   DEFAULT_TOOL_FAILURE_MIN_FAILURES,
   DEFAULT_TOOL_FAILURE_MIN_RATE,
@@ -171,6 +172,11 @@ function registerScanSubcommand(improve: Command): void {
       String(DEFAULT_SUBAGENT_BLOCK_MIN_OCCURRENCES),
     )
     .option(
+      '--read-denial-min-occurrences <n>',
+      `subagent-read-denial threshold (default ${DEFAULT_SUBAGENT_READ_DENIAL_MIN_OCCURRENCES})`,
+      String(DEFAULT_SUBAGENT_READ_DENIAL_MIN_OCCURRENCES),
+    )
+    .option(
       '--tool-failure-min-failures <n>',
       `tool-failure-density absolute count threshold (default ${DEFAULT_TOOL_FAILURE_MIN_FAILURES})`,
       String(DEFAULT_TOOL_FAILURE_MIN_FAILURES),
@@ -196,6 +202,7 @@ function registerScanSubcommand(improve: Command): void {
         minRepeats: string;
         closureMinOccurrences: string;
         blockMinOccurrences: string;
+        readDenialMinOccurrences: string;
         toolFailureMinFailures: string;
         toolFailureMinRate: string;
         only?: string;
@@ -209,6 +216,11 @@ function registerScanSubcommand(improve: Command): void {
             1,
           );
           const blockMin = parsePositiveInt(opts.blockMinOccurrences, 'block-min-occurrences', 1);
+          const readDenialMin = parsePositiveInt(
+            opts.readDenialMinOccurrences,
+            'read-denial-min-occurrences',
+            1,
+          );
           const tfMinFailures = parsePositiveInt(
             opts.toolFailureMinFailures,
             'tool-failure-min-failures',
@@ -247,6 +259,7 @@ function registerScanSubcommand(improve: Command): void {
             minRepeats,
             closureAnomalyMinOccurrences: closureMin,
             subagentBlockMinOccurrences: blockMin,
+            subagentReadDenialMinOccurrences: readDenialMin,
             toolFailureMinFailures: tfMinFailures,
             toolFailureMinRate: tfMinRate,
           };

--- a/src/improve/propose/template-engine.ts
+++ b/src/improve/propose/template-engine.ts
@@ -216,6 +216,70 @@ const TEMPLATES: Record<FailureCard['pattern'], PatternTemplate> = {
   },
 
   // -------------------------------------------------------------------------
+  // subagent-read-denial
+  // -------------------------------------------------------------------------
+  'subagent-read-denial': {
+    rootCauseClass: 'dispatcher-bug',
+    hypothesis: (card) => {
+      const denialCount = typeof card.detail['denialCount'] === 'number' ? card.detail['denialCount'] : '?';
+      const distinctSessions = typeof card.detail['distinctSessions'] === 'number' ? card.detail['distinctSessions'] : '?';
+      const tools = Array.isArray(card.detail['blockedTools']) ? (card.detail['blockedTools'] as unknown[]).join(', ') : '?';
+      return (
+        `The path-approval PreToolUse hook auto-denied a forked sub-agent's READ (${tools}) ${denialCount} times across ${distinctSessions} session(s) — the resolved path fell outside the fork's granted READ roots and a fork cannot prompt to approve. ` +
+        `The child then retries the read and spins until a wall-clock timeout. Root cause is almost always a read-scope grant that is NARROWER than the parent's: the fork was given a concrete cwd but not the parent's read reach (main repo, sibling .afk-worktrees/*, ~/.afk/state).`
+      );
+    },
+    fixSketch: () => {
+      return [
+        '## Candidate fixes (human picks)',
+        '',
+        "**Option A — widen the fork's inherited read scope (usual fix).** A forked read-only sub-agent must be able to READ everything its parent could; only WRITES stay confined. The inheritance rule lives in `computeInheritedReadRoots` (`src/agent/subagent-read-scope.ts`), applied at the fork choke point in `SubagentManager.forkSubagent` (`src/agent/subagent.ts`). Confirm an unconfined parent yields a read-open child and a confined parent yields union(childCwd, parentRoots, worktreeMainRoot).",
+        '',
+        '**Option B — verify the `afk farm` guardrail still holds.** A caller that pins `readRoots` (branch workers) must keep suppressing inheritance so a deliberately-confined worker is never widened. Guard with the regression test in `subagent-worktree-readroot.test.ts`.',
+        '',
+        '**Option C — fail fast instead of hanging.** If a denial is legitimate (genuinely out-of-scope), the fork should abort with an actionable message after N identical denials rather than retry to a wall-clock timeout. Separate hardening from the scope fix.',
+      ].join('\n');
+    },
+    likelyFiles: [
+      {
+        path: 'src/agent/subagent-read-scope.ts',
+        rationale: 'The read-scope inheritance rule (computeInheritedReadRoots). The usual fix site.',
+        riskTier: 'moderate',
+        confidence: 'high',
+      },
+      {
+        path: 'src/agent/subagent.ts',
+        rationale: 'forkSubagent applies the inherited read roots at the fork choke point.',
+        riskTier: 'moderate',
+        confidence: 'medium',
+      },
+      {
+        path: 'src/agent/tools/hooks/path-approval-hook.ts',
+        rationale: 'The PreToolUse hook that auto-denies out-of-root reads. Touch only to change the fail-fast behavior (Option C), not the grant.',
+        riskTier: 'high',
+        confidence: 'low',
+      },
+    ],
+    riskFloor: 'medium',
+    validationPlan: {
+      unitTests: [
+        'pnpm test -- src/agent/subagent-read-scope',
+        'pnpm test -- src/agent/subagent-worktree-readroot',
+        'pnpm test -- src/improve/scan/detectors/subagent-read-denial',
+      ],
+      evalCases: [],
+      smokeChecks: [
+        'pnpm lint',
+        'afk improve scan --only subagent-read-denial --since 7d  # after fix, read-denials should not recur',
+      ],
+      manualChecks: [
+        'Open the trace at the evidence seqs; confirm the denied paths are ones the parent could read (main repo / sibling worktree / ~/.afk/state).',
+        'Run a fan-out (e.g. /diagnose) that dispatches read-only forks and confirm they can read across the workspace.',
+      ],
+    },
+  },
+
+  // -------------------------------------------------------------------------
   // tool-failure-density
   // -------------------------------------------------------------------------
   'tool-failure-density': {

--- a/src/improve/scan/detectors/index.test.ts
+++ b/src/improve/scan/detectors/index.test.ts
@@ -54,6 +54,15 @@ function blockLine(reason: string): string {
   });
 }
 
+function readDenialLine(reason: string, blockedTool: string): string {
+  return JSON.stringify({
+    ts: new Date(1_700_000_000_000 + seqCounter * 1000).toISOString(),
+    seq: seqCounter++,
+    kind: 'hook_decision',
+    payload: { hookEvent: 'PreToolUse', decision: 'block', reason, blockedTool },
+  });
+}
+
 function toolPair(toolUseId: string, name: string): string[] {
   const started = JSON.stringify({
     ts: new Date(1_700_000_000_000 + seqCounter * 1000).toISOString(),
@@ -93,8 +102,8 @@ function makeSession(sessionId: string, lines: string[]): SessionRead {
 // ---------------------------------------------------------------------------
 
 describe('DETECTOR_REGISTRY', () => {
-  it('lists four detectors', () => {
-    expect(DETECTOR_REGISTRY).toHaveLength(4);
+  it('lists five detectors', () => {
+    expect(DETECTOR_REGISTRY).toHaveLength(5);
   });
 
   it('all registry names match a value in FailurePatternSchema', () => {
@@ -116,6 +125,7 @@ describe('DETECTOR_REGISTRY', () => {
       'closure-anomaly',
       'subagent-block',
       'tool-failure-density',
+      'subagent-read-denial',
     ]);
   });
 });
@@ -137,6 +147,10 @@ function makeAllPatternSession(id: string): SessionRead {
   // 2 SubagentStart blocks with same reason → subagent-block
   lines.push(blockLine('test block reason'));
   lines.push(blockLine('test block reason'));
+  // 2 PreToolUse read-denials, DIFFERENT paths + tools but same normalized
+  // reason → subagent-read-denial (verifies path-normalization aggregation)
+  lines.push(readDenialLine("Sub-agent path access denied: /a/b.ts is outside the session's granted read roots", 'read_file'));
+  lines.push(readDenialLine("Sub-agent path access denied: /c/d.ts is outside the session's granted read roots", 'grep'));
   // 1 budget_exceeded closure → closure-anomaly
   lines.push(closureLine('budget_exceeded'));
   return makeSession(id, lines);
@@ -190,6 +204,7 @@ describe('runAllDetectors', () => {
         'closure-anomaly',
         'subagent-block',
         'tool-failure-density',
+        'subagent-read-denial',
       ]),
     );
   });
@@ -276,8 +291,8 @@ describe('defaultEnabledDetectorNames', () => {
 });
 
 describe('disabledByDefaultDetectorNames', () => {
-  it('contains closure-anomaly, subagent-block (in any order)', () => {
+  it('contains closure-anomaly, subagent-block, subagent-read-denial (in any order)', () => {
     const names = new Set(disabledByDefaultDetectorNames());
-    expect(names).toEqual(new Set(['closure-anomaly', 'subagent-block']));
+    expect(names).toEqual(new Set(['closure-anomaly', 'subagent-block', 'subagent-read-denial']));
   });
 });

--- a/src/improve/scan/detectors/index.ts
+++ b/src/improve/scan/detectors/index.ts
@@ -56,6 +56,10 @@ import {
   DEFAULT_TOOL_FAILURE_MIN_FAILURES,
   DEFAULT_TOOL_FAILURE_MIN_RATE,
 } from './tool-failure-density.js';
+import {
+  detectSubagentReadDenial,
+  DEFAULT_SUBAGENT_READ_DENIAL_MIN_OCCURRENCES,
+} from './subagent-read-denial.js';
 
 /**
  * Shared option bag passed to every detector. Detectors only read the
@@ -68,6 +72,8 @@ export interface DetectorOptions {
   closureAnomalyMinOccurrences?: number;
   /** subagent-block: minimum SubagentStart blocks sharing the same reason. */
   subagentBlockMinOccurrences?: number;
+  /** subagent-read-denial: minimum PreToolUse read-denials sharing the same normalized reason. */
+  subagentReadDenialMinOccurrences?: number;
   /** tool-failure-density: minimum absolute failure count per tool. */
   toolFailureMinFailures?: number;
   /** tool-failure-density: minimum failure rate (failures / total calls) per tool. */
@@ -135,6 +141,19 @@ export const DETECTOR_REGISTRY: readonly DetectorEntry[] = Object.freeze([
       detectToolFailureDensity(sessions, {
         minFailures: opts.toolFailureMinFailures ?? DEFAULT_TOOL_FAILURE_MIN_FAILURES,
         minFailureRate: opts.toolFailureMinRate ?? DEFAULT_TOOL_FAILURE_MIN_RATE,
+      }),
+  },
+  {
+    name: 'subagent-read-denial',
+    description: `Forked sub-agent read auto-denied (PreToolUse block, path outside granted read roots) recurring across ≥N events (default ${DEFAULT_SUBAGENT_READ_DENIAL_MIN_OCCURRENCES})`,
+    // Opt-in like subagent-block: read-denials can fire during legitimate
+    // worktree confinement or active bug-fixing, so surface on demand via
+    // `--only subagent-read-denial` rather than in the default noise floor.
+    enabledByDefault: false,
+    run: (sessions, opts): DetectorResult[] =>
+      detectSubagentReadDenial(sessions, {
+        minOccurrences:
+          opts.subagentReadDenialMinOccurrences ?? DEFAULT_SUBAGENT_READ_DENIAL_MIN_OCCURRENCES,
       }),
   },
 ] satisfies DetectorEntry[]);

--- a/src/improve/scan/detectors/subagent-read-denial.test.ts
+++ b/src/improve/scan/detectors/subagent-read-denial.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for `improve/scan/detectors/subagent-read-denial.ts`.
+ *
+ * Coverage:
+ *   - PreToolUse + read-family blockedTool + block → detection; other
+ *     hookEvents / decisions don't.
+ *   - WRITE / mutating blockedTools are NOT detected (by-design confinement).
+ *   - Path normalization: denials with DIFFERENT paths but the same structural
+ *     reason merge into ONE detection.
+ *   - Structurally-different reasons produce separate detections.
+ *   - `blockedTools` detail records the distinct read tools seen.
+ *   - minOccurrences threshold + default (2).
+ *   - Severity ladder (denial count + distinct sessions).
+ *   - Slug deterministic + FailureCardSchema regex; fingerprint stable + path-
+ *     insensitive.
+ *   - DetectorResult parses against the schema; evidence capped at 8.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseTraceContent, type SessionRead } from '../reader.js';
+import {
+  detectSubagentReadDenial,
+  computeFingerprint,
+  makeSlug,
+  normalizeReason,
+  DEFAULT_SUBAGENT_READ_DENIAL_MIN_OCCURRENCES,
+} from './subagent-read-denial.js';
+import { DetectorResultSchema, FailureCardSchema } from '../../schemas.js';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+let seqCounter = 0;
+function resetSeq(): void {
+  seqCounter = 0;
+}
+
+interface HookSpec {
+  hookEvent:
+    | 'PreToolUse'
+    | 'PostToolUse'
+    | 'SessionStart'
+    | 'SessionEnd'
+    | 'SubagentStart'
+    | 'SubagentStop';
+  decision?: 'block' | 'approve';
+  reason?: string;
+  blockedTool?: string;
+}
+
+function hookLine(spec: HookSpec): string {
+  const payload: Record<string, unknown> = { hookEvent: spec.hookEvent };
+  if (spec.decision !== undefined) payload['decision'] = spec.decision;
+  if (spec.reason !== undefined) payload['reason'] = spec.reason;
+  if (spec.blockedTool !== undefined) payload['blockedTool'] = spec.blockedTool;
+  return JSON.stringify({
+    ts: new Date(1_700_000_000_000 + seqCounter * 1000).toISOString(),
+    seq: seqCounter++,
+    kind: 'hook_decision',
+    payload,
+  });
+}
+
+function makeSession(sessionId: string, lines: string[]): SessionRead {
+  return parseTraceContent({
+    sessionId,
+    tracePath: `/abs/witness/${sessionId}/trace.jsonl`,
+    relativeTracePath: `state/witness/${sessionId}/trace.jsonl`,
+    content: lines.join('\n'),
+    sessionMtimeMs: 1_700_000_000_000,
+  });
+}
+
+/** A path-access denial reason with the given offending path. */
+function denial(path: string): string {
+  return `Sub-agent path access denied: ${path} is outside the session's granted read roots`;
+}
+const PATH_A = '/Users/x/proj/src/a.ts';
+const PATH_B = '/Users/x/proj/.afk-worktrees/wt/src/b.ts';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('detectSubagentReadDenial — what triggers a detection', () => {
+  it('detects a PreToolUse read_file block when minOccurrences=1', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'read_file' }),
+      ]),
+    ];
+    const results = detectSubagentReadDenial(sessions, { minOccurrences: 1 });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.pattern).toBe('subagent-read-denial');
+    expect(results[0]?.detail['blockedTools']).toEqual(['read_file']);
+  });
+
+  it('does NOT detect non-PreToolUse hook events', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'SubagentStart', decision: 'block', reason: denial(PATH_A), blockedTool: 'read_file' }),
+        hookLine({ hookEvent: 'PostToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'read_file' }),
+      ]),
+    ];
+    expect(detectSubagentReadDenial(sessions, { minOccurrences: 1 })).toEqual([]);
+  });
+
+  it('does NOT detect WRITE / mutating blockedTools (by-design confinement)', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'write_file' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'edit_file' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'bash' }),
+      ]),
+    ];
+    expect(detectSubagentReadDenial(sessions, { minOccurrences: 1 })).toEqual([]);
+  });
+
+  it('does NOT detect approve / undefined decisions or missing blockedTool', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'approve', reason: denial(PATH_A), blockedTool: 'read_file' }),
+        hookLine({ hookEvent: 'PreToolUse', reason: denial(PATH_A), blockedTool: 'read_file' }), // decision undefined
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A) }), // no blockedTool
+      ]),
+    ];
+    expect(detectSubagentReadDenial(sessions, { minOccurrences: 1 })).toEqual([]);
+  });
+
+  it('default threshold is 2 — single denial does not fire', () => {
+    expect(DEFAULT_SUBAGENT_READ_DENIAL_MIN_OCCURRENCES).toBe(2);
+    resetSeq();
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'read_file' }),
+      ]),
+    ];
+    expect(detectSubagentReadDenial(sessions)).toEqual([]);
+  });
+});
+
+describe('detectSubagentReadDenial — path normalization + grouping', () => {
+  it('merges denials with DIFFERENT paths + tools but same structural reason', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'read_file' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_B), blockedTool: 'grep' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial('/tmp'), blockedTool: 'glob' }),
+      ]),
+    ];
+    const results = detectSubagentReadDenial(sessions);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.detail['denialCount']).toBe(3);
+    expect(results[0]?.detail['blockedTools']).toEqual(['glob', 'grep', 'read_file']);
+    expect(results[0]?.evidence).toHaveLength(3);
+  });
+
+  it('merges across sessions and counts distinct sessions', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'read_file' }),
+      ]),
+      makeSession('s2', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_B), blockedTool: 'read_file' }),
+      ]),
+    ];
+    const results = detectSubagentReadDenial(sessions);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.detail['denialCount']).toBe(2);
+    expect(results[0]?.detail['distinctSessions']).toBe(2);
+  });
+
+  it('produces separate detections for structurally-different reasons', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'read_file' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_B), blockedTool: 'read_file' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: 'Blocked by policy: interpreter path guard', blockedTool: 'grep' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: 'Blocked by policy: interpreter path guard', blockedTool: 'grep' }),
+      ]),
+    ];
+    const results = detectSubagentReadDenial(sessions);
+    expect(results).toHaveLength(2);
+  });
+});
+
+describe('detectSubagentReadDenial — threshold + severity', () => {
+  function nDenials(n: number, session = 's1'): SessionRead {
+    resetSeq();
+    const lines = Array.from({ length: n }, (_, i) =>
+      hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(`/p/${i}.ts`), blockedTool: 'read_file' }),
+    );
+    return makeSession(session, lines);
+  }
+
+  it('honors minOccurrences', () => {
+    const s = nDenials(2);
+    expect(detectSubagentReadDenial([s], { minOccurrences: 2 })).toHaveLength(1);
+    expect(detectSubagentReadDenial([s], { minOccurrences: 3 })).toHaveLength(0);
+  });
+
+  it('rejects minOccurrences < 1', () => {
+    expect(() => detectSubagentReadDenial([], { minOccurrences: 0 })).toThrow(
+      /minOccurrences must be >= 1/,
+    );
+  });
+
+  it('2 → low, 3 → medium, 6 → high', () => {
+    expect(detectSubagentReadDenial([nDenials(2)])[0]?.severity).toBe('low');
+    expect(detectSubagentReadDenial([nDenials(3)])[0]?.severity).toBe('medium');
+    expect(detectSubagentReadDenial([nDenials(6)])[0]?.severity).toBe('high');
+  });
+
+  it('3 distinct sessions → high', () => {
+    resetSeq();
+    const mk = (id: string): SessionRead =>
+      makeSession(id, [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'read_file' }),
+      ]);
+    const r = detectSubagentReadDenial([mk('s1'), mk('s2'), mk('s3')], { minOccurrences: 1 })[0]!;
+    expect(r.severity).toBe('high');
+  });
+});
+
+describe('detectSubagentReadDenial — fingerprint, slug, schema', () => {
+  it('normalizeReason collapses absolute paths (posix + ~-relative)', () => {
+    expect(normalizeReason(denial(PATH_A))).toBe(normalizeReason(denial(PATH_B)));
+    expect(normalizeReason('read /Users/me/.afk/state/x.diff please')).toBe('read <path> please');
+    expect(normalizeReason('read ~/.afk/state/x.diff')).toBe('read <path>');
+  });
+
+  it('fingerprint is deterministic and path-insensitive', () => {
+    const a = computeFingerprint({ hookEvent: 'PreToolUse', normalizedReason: normalizeReason(denial(PATH_A)) });
+    const b = computeFingerprint({ hookEvent: 'PreToolUse', normalizedReason: normalizeReason(denial(PATH_B)) });
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('makeSlug satisfies the FailureCardSchema slug regex', () => {
+    const fp = computeFingerprint({ hookEvent: 'PreToolUse', normalizedReason: 'x' });
+    expect(makeSlug(fp)).toMatch(/^[a-z0-9][a-z0-9-]*$/);
+    expect(makeSlug(fp)).toBe(`subagent-read-denial-${fp.slice(0, 12)}`);
+  });
+
+  it('produces a DetectorResult that parses against the schema', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'read_file' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_B), blockedTool: 'grep' }),
+      ]),
+    ];
+    const r = detectSubagentReadDenial(sessions)[0]!;
+    expect(DetectorResultSchema.safeParse(r).success).toBe(true);
+  });
+
+  it('caps evidence at 8 rows when denial count exceeds it', () => {
+    resetSeq();
+    const lines = Array.from({ length: 20 }, (_, i) =>
+      hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(`/p/${i}.ts`), blockedTool: 'read_file' }),
+    );
+    const r = detectSubagentReadDenial([makeSession('s1', lines)])[0]!;
+    expect(r.evidence).toHaveLength(8);
+    expect(r.detail['denialCount']).toBe(20);
+  });
+
+  it('detection survives merge into a FailureCard', () => {
+    resetSeq();
+    const sessions = [
+      makeSession('s1', [
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_A), blockedTool: 'read_file' }),
+        hookLine({ hookEvent: 'PreToolUse', decision: 'block', reason: denial(PATH_B), blockedTool: 'read_file' }),
+      ]),
+    ];
+    const r = detectSubagentReadDenial(sessions)[0]!;
+    const card = {
+      schemaVersion: 1 as const,
+      slug: r.slug,
+      title: r.title,
+      pattern: r.pattern,
+      severity: r.severity,
+      status: 'open' as const,
+      firstSeen: r.observedAt,
+      lastSeen: r.observedAt,
+      occurrenceCount: r.evidence.length,
+      evidence: r.evidence,
+      detail: r.detail,
+      notes: [],
+    };
+    expect(FailureCardSchema.safeParse(card).success).toBe(true);
+  });
+});

--- a/src/improve/scan/detectors/subagent-read-denial.ts
+++ b/src/improve/scan/detectors/subagent-read-denial.ts
@@ -1,0 +1,226 @@
+/**
+ * Detector: recurring forked sub-agent READ auto-denials.
+ *
+ * The path-approval `PreToolUse` hook auto-denies a forked child's file read
+ * when the resolved path falls outside the fork's granted READ roots — a fork
+ * cannot prompt a human to approve, so the hook hard-blocks with
+ * `decision: 'block'`, `blockedTool ∈ {read_file, grep, glob, …}`, and a
+ * `reason` beginning "Sub-agent path access denied: <path> is outside …". The
+ * child then retries the read and spins until a wall-clock timeout.
+ *
+ * Invariant: this detector flags ONLY read-family denials. A WRITE auto-deny
+ * (write_file / edit_file / mutating bash outside the worktree) is BY DESIGN —
+ * worktree isolation confines writes and reports back to the parent — so
+ * folding writes in here would drown the real signal in expected noise.
+ *
+ * Why a distinct detector from `subagent-block`: that one flags a subagent
+ * DISPATCH refused before it ran (`hookEvent: 'SubagentStart'`); this flags a
+ * RUNNING fork whose read was refused (`hookEvent: 'PreToolUse'`). Different
+ * lifecycle stage, different remediation — so a distinct card pattern.
+ *
+ * ## Fingerprint
+ *
+ * Stable SHA-256 over `(hookEvent | normalizedReason)`. The reason is
+ * NORMALIZED (absolute paths → `<path>`) before hashing because the denial
+ * message embeds the specific offending path, which varies per denial; without
+ * normalization each path would split into its own card and the class ("this
+ * fork keeps failing to read") would never aggregate. `blockedTool` is
+ * deliberately NOT in the fingerprint — a read_file / grep / glob denial of the
+ * same structural cause is one pattern, not three; the distinct tools are
+ * recorded in `detail.blockedTools` instead.
+ *
+ * @module improve/scan/detectors/subagent-read-denial
+ */
+
+import { createHash } from 'crypto';
+import type { DetectorResult, FailureEvidence, Severity } from '../../schemas.js';
+import type { SessionRead } from '../reader.js';
+
+/** Default minimum read-denials sharing a normalized reason before a card fires. */
+export const DEFAULT_SUBAGENT_READ_DENIAL_MIN_OCCURRENCES = 2;
+
+const FINGERPRINT_ALGORITHM = 'v1-pretooluse-read-normreason';
+const MAX_EVIDENCE_PER_CARD = 8;
+
+/**
+ * Read-family tool names whose PreToolUse block is a pathological read-scope
+ * denial. Both afk-native (lowercase) and Claude-style (capitalized) names are
+ * included so the detector is robust across surfaces. WRITE / mutating tools
+ * are intentionally absent — their denial is by-design worktree confinement.
+ */
+const READ_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'read_file',
+  'grep',
+  'glob',
+  'list_directory',
+  'Read',
+  'Grep',
+  'Glob',
+  'LS',
+  'NotebookRead',
+]);
+
+export interface SubagentReadDenialOptions {
+  minOccurrences?: number;
+}
+
+interface DenialSighting {
+  sessionId: string;
+  relativeTracePath: string;
+  seq: number;
+  rawLine: string;
+  reason: string;
+  normalizedReason: string;
+  blockedTool: string;
+}
+
+/**
+ * Collapse absolute filesystem paths in a denial reason to `<path>` so
+ * structurally-identical denials aggregate. Matches a leading `/` followed by
+ * path characters — `/Users/x/foo.ts`, `/tmp`, `~/.afk/state/x.diff` (the
+ * `~`-relative form is also normalized). Conservative character class avoids
+ * eating ordinary prose.
+ */
+export function normalizeReason(reason: string): string {
+  return reason.replace(/~?\/[\w.\-/]+/g, '<path>');
+}
+
+/**
+ * Run the detector. Pure function — no I/O. One {@link DetectorResult} per
+ * distinct normalized-reason fingerprint that meets the threshold.
+ */
+export function detectSubagentReadDenial(
+  sessions: SessionRead[],
+  options: SubagentReadDenialOptions = {},
+): DetectorResult[] {
+  const minOccurrences =
+    options.minOccurrences ?? DEFAULT_SUBAGENT_READ_DENIAL_MIN_OCCURRENCES;
+  if (minOccurrences < 1) {
+    throw new Error(`minOccurrences must be >= 1 (got ${minOccurrences})`);
+  }
+
+  const byFingerprint = new Map<string, DenialSighting[]>();
+
+  for (const session of sessions) {
+    for (const item of session.events) {
+      const ev = item.event;
+      if (ev.kind !== 'hook_decision') continue;
+      if (ev.payload.hookEvent !== 'PreToolUse') continue;
+      if (ev.payload.decision !== 'block') continue;
+      const blockedTool = ev.payload.blockedTool;
+      if (blockedTool === undefined || !READ_TOOL_NAMES.has(blockedTool)) continue;
+
+      const reason = ev.payload.reason ?? '';
+      const normalizedReason = normalizeReason(reason);
+      const fingerprint = computeFingerprint({ hookEvent: ev.payload.hookEvent, normalizedReason });
+
+      const sighting: DenialSighting = {
+        sessionId: session.sessionId,
+        relativeTracePath: session.relativeTracePath,
+        seq: ev.seq,
+        rawLine: item.rawLine,
+        reason,
+        normalizedReason,
+        blockedTool,
+      };
+
+      const bucket = byFingerprint.get(fingerprint);
+      if (bucket) {
+        bucket.push(sighting);
+      } else {
+        byFingerprint.set(fingerprint, [sighting]);
+      }
+    }
+  }
+
+  const results: DetectorResult[] = [];
+  for (const [fingerprint, sightings] of byFingerprint.entries()) {
+    if (sightings.length < minOccurrences) continue;
+    results.push(buildResult(fingerprint, sightings));
+  }
+  return results;
+}
+
+/**
+ * Stable hash over the `(hookEvent, normalizedReason)` tuple. Exported for
+ * tests asserting slug stability across detector runs.
+ */
+export function computeFingerprint(args: { hookEvent: string; normalizedReason: string }): string {
+  const tuple = [args.hookEvent, args.normalizedReason].join('|');
+  return createHash('sha256').update(tuple).digest('hex');
+}
+
+/** Slug pattern: `subagent-read-denial-<first 12 hex of fingerprint>`. */
+export function makeSlug(fingerprint: string): string {
+  return `subagent-read-denial-${fingerprint.slice(0, 12)}`;
+}
+
+function buildResult(fingerprint: string, sightings: DenialSighting[]): DetectorResult {
+  const first = sightings[0];
+  if (!first) {
+    throw new Error('subagent-read-denial: empty sighting bucket');
+  }
+  const slug = makeSlug(fingerprint);
+  const observedAt = new Date().toISOString();
+
+  const capped = sightings.slice(0, MAX_EVIDENCE_PER_CARD);
+  const evidence: FailureEvidence[] = capped.map((s) => ({
+    sessionId: s.sessionId,
+    tracePath: s.relativeTracePath,
+    eventIndices: [s.seq],
+    excerpt: clampExcerpt(s.rawLine),
+    annotation: buildAnnotation(s),
+  }));
+
+  const distinctSessions = new Set(sightings.map((s) => s.sessionId)).size;
+  const blockedTools = [...new Set(sightings.map((s) => s.blockedTool))].sort();
+
+  return {
+    slug,
+    title: buildTitle(sightings.length, distinctSessions),
+    pattern: 'subagent-read-denial',
+    severity: severityFor(sightings.length, distinctSessions),
+    observedAt,
+    evidence,
+    detail: {
+      detector: 'subagent-read-denial@v1',
+      fingerprintAlgorithm: FINGERPRINT_ALGORITHM,
+      fingerprint,
+      hookEvent: 'PreToolUse',
+      normalizedReason: first.normalizedReason,
+      reason: first.reason,
+      blockedTools,
+      denialCount: sightings.length,
+      distinctSessions,
+      sessionIds: [...new Set(sightings.map((s) => s.sessionId))],
+      seqs: sightings.map((s) => s.seq),
+    },
+  };
+}
+
+/**
+ * Severity ladder (mirrors subagent-block):
+ *   - ≥6 denials OR ≥3 distinct sessions → high.
+ *   - ≥3 denials → medium.
+ *   - else → low.
+ */
+function severityFor(denialCount: number, distinctSessions: number): Severity {
+  if (denialCount >= 6 || distinctSessions >= 3) return 'high';
+  if (denialCount >= 3) return 'medium';
+  return 'low';
+}
+
+function buildTitle(count: number, sessions: number): string {
+  return `Forked sub-agent read auto-denied ${count}× across ${sessions} session${sessions === 1 ? '' : 's'} (path outside granted read roots)`;
+}
+
+function buildAnnotation(s: DenialSighting): string {
+  const parts = [`seq ${s.seq}`, `blockedTool=${s.blockedTool}`];
+  if (s.reason) parts.push(`reason="${s.reason.slice(0, 200)}"`);
+  return parts.join(' · ');
+}
+
+function clampExcerpt(rawLine: string): string {
+  if (rawLine.length <= 2000) return rawLine;
+  return rawLine.slice(0, 1997) + '...';
+}

--- a/src/improve/schemas.ts
+++ b/src/improve/schemas.ts
@@ -33,6 +33,7 @@ export const FailurePatternSchema = z.enum([
   'closure-anomaly',    // closure { reason: <anything other than 'model_end_turn'> }
   // Sprint 2 adds:
   'tool-failure-density', // tool_call completed { isError: true } above threshold rate AND count
+  'subagent-read-denial', // hook_decision { hookEvent: 'PreToolUse', decision: 'block', read-family blockedTool }
   // Future phases will add: 'schema-error-burst', 'abort-cascade',
   // 'cost-spike', 'regression'.
 ]);


### PR DESCRIPTION
## Problem

The improve-pipeline detector `subagent-block` filters `hookEvent === 'SubagentStart'` only (`src/improve/scan/detectors/subagent-block.ts:96`). It is therefore **structurally blind** to the path-approval **`PreToolUse`** hook auto-denying a forked sub-agent's **read** (`blockedTool ∈ {read_file, grep, glob, …}`, reason `"Sub-agent path access denied: <path> is outside …"`) — the failure mode where a read-only fork cannot read a path it needs, retries the denied read, and spins to a wall-clock timeout. The detector's own JSDoc admits `blockedTool` "is only set by PreToolUse blocks" yet it never processes them.

## Change

A dedicated **`subagent-read-denial`** detector (distinct from `subagent-block`: that flags a *dispatch* refused before start; this flags a *running fork's read* refused — different lifecycle, different remediation):

- **Read-only filter.** PreToolUse `decision:'block'` with a read-family `blockedTool`. **Write/mutating denials are excluded** — worktree write-confinement is by design and would drown the signal.
- **Path normalization.** Denial reasons embed the specific offending path, which varies per denial; the fingerprint hashes a normalized reason (absolute paths → `<path>`) so structurally-identical denials aggregate into one card instead of one-card-per-path.
- **Opt-in** (`enabledByDefault: false`), like `subagent-block` — read-denials can fire during legitimate confinement or active bug-fixing.

Wired end-to-end: `FailurePattern` schema, detector registry + `DetectorOptions`, propose template (`dispatcher-bug` class, points at the read-scope machinery), and a `--read-denial-min-occurrences` CLI flag.

## Files

| File | Change |
|---|---|
| `src/improve/scan/detectors/subagent-read-denial.ts` | **new** — detector + `normalizeReason` |
| `src/improve/scan/detectors/subagent-read-denial.test.ts` | **new** — 20 unit tests (incl. write-exclusion + normalization) |
| `src/improve/schemas.ts` | add `'subagent-read-denial'` to `FailurePatternSchema` |
| `src/improve/scan/detectors/index.ts` | registry entry + option |
| `src/improve/scan/detectors/index.test.ts` | registry count/name assertions + fixture |
| `src/improve/propose/template-engine.ts` | propose template for the new pattern |
| `src/cli/commands/improve.ts` | `--read-denial-min-occurrences` flag |

## Validation on real traces

```
$ afk improve scan --only subagent-read-denial --since all
Scanned 11280 sessions
Detections: 11
  ↳ subagent-read-denial: 11   (9 high, 2 low)
```

These are read-denials the pre-existing detector set surfaced **zero** of. (The originating class is fixed separately in the read-scope-inheritance PR; this detector makes the class observable if it ever recurs.)

## Verification

- `pnpm lint` (tsc --noEmit strict): **clean**
- Full suite: **11,486 passed / 0 failed** (14 skipped)
