### PR TITLE
fix(redact): stop redacting git object names (SHAs) as opaque secrets

### DIFF
--- a/src/agent/background-summarizer.test.ts
+++ b/src/agent/background-summarizer.test.ts
@@ -613,6 +613,21 @@ describe('redactSecrets', () => {
     expect(redactSecrets(`DB_PASSWORD=${hex40}`)).toContain('[REDACTED]');
   });
 
+  it('STILL redacts non-allowlisted assignment names at git-SHA width (allowlist boundary)', () => {
+    // isGitObjectName's NAME=<sha> carve-out is an ALLOWLIST (REF/SHA/COMMIT/
+    // BASE only), not a denylist of secret-sounding words — so a name that is
+    // neither git-plausible nor obviously secret-shaped (COOKIE, SESSION,
+    // BEARER, PAT, DATA) must still be redacted. Pins the boundary: only the
+    // four allowlisted names are spared, everything else at the same 40-hex
+    // width is not.
+    const hex40 = 'a1b2c3d4e5f6789012345678901234567890abcd';
+    expect(redactSecrets(`COOKIE=${hex40}`)).toContain('[REDACTED]');
+    expect(redactSecrets(`SESSION=${hex40}`)).toContain('[REDACTED]');
+    expect(redactSecrets(`BEARER=${hex40}`)).toContain('[REDACTED]');
+    expect(redactSecrets(`PAT=${hex40}`)).toContain('[REDACTED]');
+    expect(redactSecrets(`DATA=${hex40}`)).toContain('[REDACTED]');
+  });
+
   it('STILL redacts an UPPERCASE-hex 40-char run (git object names are lowercase)', () => {
     // A carve-out this narrow only spares lowercase hex — an uppercase-hex blob
     // of the same length is not a git object name and stays redacted.

--- a/src/agent/background-summarizer.test.ts
+++ b/src/agent/background-summarizer.test.ts
@@ -560,4 +560,72 @@ describe('redactSecrets', () => {
     const p = '/opt/SomeVeryLongDirectoryNameWithoutAnyDigits/bin';
     expect(redactSecrets(`ls ${p}`)).toBe(`ls ${p}`);
   });
+
+  // -------------------------------------------------------------------------
+  // Git object names — a full 40/64-char lowercase-hex SHA is byte-identical
+  // in shape to a long hex secret, so the generic rule used to redact
+  // `git show <sha>` to `git show [REDACTED]`. isGitObjectName carves them
+  // back out. Two real-session shapes: a bare SHA arg and a `REF=<sha>`
+  // assignment. Secret-named assignments (TOKEN=/KEY=) stay redacted.
+  // -------------------------------------------------------------------------
+  it('does not redact a bare 40-char SHA-1 git object name', () => {
+    const sha = 'a1b2c3d4e5f6789012345678901234567890abcd';
+    expect(redactSecrets(`git cat-file -t ${sha}`)).toBe(`git cat-file -t ${sha}`);
+  });
+
+  it('does not redact a bare 64-char SHA-256 git object name', () => {
+    const sha = 'a'.repeat(64);
+    expect(redactSecrets(`git show ${sha}`)).toBe(`git show ${sha}`);
+  });
+
+  it('does not redact a 40-char SHA embedded before a `:path` (git show <sha>:file)', () => {
+    // The `:` is outside the token class, so the run is the bare 40-hex SHA.
+    const sha = 'abcdef1234567890abcdef1234567890abcdef12';
+    const out = redactSecrets(`git show ${sha}:src/index.ts`);
+    expect(out).toBe(`git show ${sha}:src/index.ts`);
+    expect(out).not.toContain('[REDACTED]');
+  });
+
+  it('does not redact a REF=<sha> shell assignment (git ref variable)', () => {
+    // `=` is inside the generic token class, so `REF=<sha>` matches whole; it
+    // must be recognized as a git object name, not a secret.
+    const sha = 'abcdef1234567890abcdef1234567890abcdef12';
+    const out = redactSecrets(`REF=${sha} && git show $REF:src/index.ts`);
+    expect(out).toBe(`REF=${sha} && git show $REF:src/index.ts`);
+    expect(out).not.toContain('[REDACTED]');
+  });
+
+  it('does not redact SHA=/COMMIT=/BASE= git-ish assignments', () => {
+    const sha = '0123456789abcdef0123456789abcdef01234567';
+    expect(redactSecrets(`SHA=${sha}`)).toBe(`SHA=${sha}`);
+    expect(redactSecrets(`COMMIT=${sha}`)).toBe(`COMMIT=${sha}`);
+    expect(redactSecrets(`BASE=${sha}`)).toBe(`BASE=${sha}`);
+  });
+
+  it('STILL redacts a secret-named assignment at git-SHA width (TOKEN=/KEY=/token=)', () => {
+    // Same 40-hex shape as a SHA, but the variable name advertises a secret —
+    // the carve-out must not spare it. Closes the GITHUB_TOKEN=<40hex> hole and
+    // keeps the existing `token=<40hex>` pinned assertion above green.
+    const hex40 = 'a1b2c3d4e5f6789012345678901234567890abcd';
+    expect(redactSecrets(`TOKEN=${hex40}`)).toContain('[REDACTED]');
+    expect(redactSecrets(`GITHUB_TOKEN=${hex40}`)).toContain('[REDACTED]');
+    expect(redactSecrets(`API_KEY=${hex40}`)).toContain('[REDACTED]');
+    expect(redactSecrets(`DB_PASSWORD=${hex40}`)).toContain('[REDACTED]');
+  });
+
+  it('STILL redacts an UPPERCASE-hex 40-char run (git object names are lowercase)', () => {
+    // A carve-out this narrow only spares lowercase hex — an uppercase-hex blob
+    // of the same length is not a git object name and stays redacted.
+    const upper = 'A1B2C3D4E5F6789012345678901234567890ABCD';
+    const out = redactSecrets(`token=${upper}`);
+    expect(out).not.toContain(upper);
+    expect(out).toContain('[REDACTED]');
+  });
+
+  it('STILL redacts an off-width (48-char) bare hex blob (not a 40/64 SHA)', () => {
+    const hex48 = 'a'.repeat(48);
+    const out = redactSecrets(`echo ${hex48}`);
+    expect(out).not.toContain(hex48);
+    expect(out).toContain('[REDACTED]');
+  });
 });

--- a/src/agent/providers/shared/tool-input-summary.test.ts
+++ b/src/agent/providers/shared/tool-input-summary.test.ts
@@ -119,6 +119,26 @@ describe('summarizeToolInput — inline secret redaction (codex P1 on #511)', ()
     });
     expect(out).toBe(' git commit -m "fix: flatten multi-line bash summaries"');
   });
+
+  it('leaves a bare git SHA arg intact (git cat-file -t <sha> — real-session shape)', () => {
+    // A full 40-hex SHA is byte-identical to a hex secret; it used to render as
+    // `git cat-file -t [REDACTED]`, hiding the id the operator needs to read.
+    const sha = 'a1b2c3d4e5f6789012345678901234567890abcd';
+    const out = summarizeToolInput('bash', { command: `git cat-file -t ${sha}` });
+    expect(out).toBe(` git cat-file -t ${sha}`);
+    expect(out).not.toContain('[REDACTED]');
+  });
+
+  it('leaves a REF=<sha> assignment intact through the flattener (real-session shape)', () => {
+    // Exact shape observed in events.jsonl: `cd <dir> && REF=<sha> && git show
+    // $REF:<file>` rendered as `cd <dir> && [REDACTED] && git show $REF:<file>`.
+    const sha = 'abcdef1234567890abcdef1234567890abcdef12';
+    const out = summarizeToolInput('bash', {
+      command: `cd repo && REF=${sha} && git show $REF:src/index.ts | sed -n '1,40p'`,
+    });
+    expect(out).toContain(`REF=${sha}`);
+    expect(out).not.toContain('[REDACTED]');
+  });
 });
 
 describe('summarizeToolInput — other tool shapes unchanged', () => {

--- a/src/agent/providers/shared/tool-input-summary.test.ts
+++ b/src/agent/providers/shared/tool-input-summary.test.ts
@@ -139,6 +139,18 @@ describe('summarizeToolInput — inline secret redaction (codex P1 on #511)', ()
     expect(out).toContain(`REF=${sha}`);
     expect(out).not.toContain('[REDACTED]');
   });
+
+  it('redacts a non-allowlisted NAME=<sha> assignment through the flattener (allowlist boundary)', () => {
+    // Symmetric to the REF= test above: same 40-hex width, but PAT is not on the
+    // isGitObjectName allowlist, so it must be redacted end-to-end through the
+    // flatten+redact pipeline, not just at the pure redactSecrets unit level.
+    const sha = 'abcdef1234567890abcdef1234567890abcdef12';
+    const out = summarizeToolInput('bash', {
+      command: `cd repo && PAT=${sha} && curl -H "Authorization: token $PAT" https://api`,
+    });
+    expect(out).not.toContain(`PAT=${sha}`);
+    expect(out).toContain('[REDACTED]');
+  });
 });
 
 describe('summarizeToolInput — other tool shapes unchanged', () => {

--- a/src/agent/redact-secrets.ts
+++ b/src/agent/redact-secrets.ts
@@ -38,8 +38,9 @@
  *     Git object names (40/64-char lowercase-hex SHA-1/SHA-256, including a
  *     `NAME=<sha>` shell assignment) are also excluded — see `isGitObjectName`
  *     — so `git show <sha>` and `REF=<sha>` render legibly in tool-lane labels
- *     instead of `git show [REDACTED]`. A secret-named assignment
- *     (`TOKEN=<sha>`, `API_KEY=<sha>`) is still redacted.
+ *     instead of `git show [REDACTED]`. Only an exact-match allowlist of
+ *     git-ish names (`REF`, `SHA`, `COMMIT`, `BASE`) is spared; any other
+ *     assignment (`TOKEN=<sha>`, `COOKIE=<sha>`) is still redacted.
  *
  * Explicit patterns run BEFORE the generic length rule so short or
  * dot-separated tokens get redacted regardless of the 32-char floor.
@@ -107,46 +108,28 @@ function looksLikeFilesystemPath(run: string): boolean {
 
 /**
  * True when a generic-rule match is a git object name (a SHA-1 or SHA-256
- * commit/tree/blob id) rather than an opaque secret. A full git SHA is
- * byte-identical in shape to a long hex secret, so the generic rule redacted
- * `git show <40-hex-sha>` to `git show [REDACTED]`, hiding exactly the id the
- * operator needs to read in a tool-lane label. Real-session evidence shows two
- * shapes: a bare SHA arg (`git cat-file -t <sha>`) and a `NAME=<sha>` shell
- * assignment (`REF=<sha> && git show $REF:…`, matched whole because `=` is in
- * the token class). Both are spared here.
+ * commit/tree/blob id) rather than an opaque secret — same hex shape, so the
+ * generic rule used to redact `git show <sha>` to `git show [REDACTED]`. Two
+ * shapes are spared: a bare SHA arg (`git cat-file -t <sha>`), and a
+ * `NAME=<sha>` shell assignment (`REF=<sha> && git show $REF:…`, matched whole
+ * because `=` is in the token class).
  *
- * Spared only when EXACTLY 40 (SHA-1) or 64 (SHA-256) lowercase-hex — git
- * object names are always lowercase, so an uppercase-hex or off-width run stays
- * redacted, keeping the carve-out narrow. For the assignment form, the variable
- * name must NOT advertise a secret (see `looksLikeSecretName`), so `REF=<sha>`
- * and `COMMIT=<sha>` are spared while `TOKEN=<sha>` / `GITHUB_TOKEN=<sha>` /
- * `API_KEY=<sha>` remain redacted.
+ * Spared only when EXACTLY 40/64-char lowercase-hex (uppercase/off-width stays
+ * redacted). For the assignment form, NAME must EXACT-match (case-insensitive)
+ * an ALLOWLIST — `REF`, `SHA`, `COMMIT`, `BASE` — not a denylist of
+ * secret-sounding words: a denylist defaults to *spared* for any unrecognized
+ * name (`COOKIE=`, `SESSION=`, `BEARER=`, `PAT=` all slipped through an
+ * earlier version of this check); this allowlist defaults to *redacted*.
  *
- * Accepted residual risk (documented, narrow): a BARE 40/64-char lowercase-hex
- * secret (e.g. a legacy 40-hex GitHub PAT, or `openssl rand -hex 20/32` output)
- * or a non-secret-named `NAME=<sha>` assignment (`PAT=<sha>`) is no longer
- * redacted on the two sinks that use this helper (transcript tail → Haiku;
- * bash tool-lane label → events.jsonl/telegram). All high-value NAMED secrets
- * (sk-ant, Bearer, JWT, AWS key ids, and any base64/base64url/mixed-case blob)
- * are still caught by the explicit rules that run BEFORE the generic rule.
+ * Accepted residual risk (narrow): a BARE 40/64-char lowercase-hex secret
+ * (e.g. a legacy 40-hex GitHub PAT, or `openssl rand -hex 20/32` output) is
+ * still spared by the unnamed branch above — the allowlist only gates the
+ * `NAME=<sha>` form. Named high-value secrets (sk-ant, Bearer, JWT, AWS key
+ * ids, base64/base64url/mixed-case blobs) are still caught by the explicit
+ * rules that run BEFORE the generic rule.
  */
 function isGitObjectName(run: string): boolean {
   if (/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(run)) return true;
   const assign = /^([A-Za-z_][A-Za-z0-9_]*)=(?:[0-9a-f]{40}|[0-9a-f]{64})$/.exec(run);
-  if (assign) {
-    const name = assign[1] ?? '';
-    if (!looksLikeSecretName(name)) return true;
-  }
-  return false;
-}
-
-/**
- * True when a shell variable name advertises that its value is a secret, so a
- * `NAME=<40/64-hex>` assignment must NOT be spared as a git object name. Errs
- * toward over-matching (fails safe: a false hit only over-redacts). Substring,
- * case-insensitive — `GITHUB_TOKEN`, `MY_API_KEY`, `DB_PASSWORD`, `AUTH`,
- * `CREDENTIAL`, `PRIVATE_KEY` all match; `REF`, `SHA`, `COMMIT`, `BASE` do not.
- */
-function looksLikeSecretName(name: string): boolean {
-  return /token|secret|key|pass|pwd|auth|cred|private/i.test(name);
+  return assign !== null && /^(?:ref|sha|commit|base)$/i.test(assign[1] ?? '');
 }

--- a/src/agent/redact-secrets.ts
+++ b/src/agent/redact-secrets.ts
@@ -35,6 +35,11 @@
  *     `looksLikeFilesystemPath` — so a long bare `cd <path>` argument is not
  *     mistaken for a secret. An opaque token fused into a path segment
  *     (`/tmp/uploads/<token>`) is still redacted (rule 3 of that guard).
+ *     Git object names (40/64-char lowercase-hex SHA-1/SHA-256, including a
+ *     `NAME=<sha>` shell assignment) are also excluded — see `isGitObjectName`
+ *     — so `git show <sha>` and `REF=<sha>` render legibly in tool-lane labels
+ *     instead of `git show [REDACTED]`. A secret-named assignment
+ *     (`TOKEN=<sha>`, `API_KEY=<sha>`) is still redacted.
  *
  * Explicit patterns run BEFORE the generic length rule so short or
  * dot-separated tokens get redacted regardless of the 32-char floor.
@@ -63,7 +68,7 @@ export function redactSecrets(text: string): string {
     // real paths back out; genuine opaque tokens — including one fused into a
     // path segment (`/tmp/uploads/<token>`, rule 3) — are still redacted.
     .replace(/(?<![/.\w])[A-Za-z0-9+/=_-]{32,}(?![/.\w])/g, (m) =>
-      looksLikeFilesystemPath(m) ? m : '[REDACTED]');
+      looksLikeFilesystemPath(m) || isGitObjectName(m) ? m : '[REDACTED]');
 }
 
 /**
@@ -98,4 +103,50 @@ function looksLikeFilesystemPath(run: string): boolean {
   const isOpaqueTokenSegment = (seg: string): boolean =>
     seg.length >= 32 && !seg.includes('.') && /[A-Za-z]/.test(seg) && /[0-9]/.test(seg);
   return !run.split('/').some(isOpaqueTokenSegment);
+}
+
+/**
+ * True when a generic-rule match is a git object name (a SHA-1 or SHA-256
+ * commit/tree/blob id) rather than an opaque secret. A full git SHA is
+ * byte-identical in shape to a long hex secret, so the generic rule redacted
+ * `git show <40-hex-sha>` to `git show [REDACTED]`, hiding exactly the id the
+ * operator needs to read in a tool-lane label. Real-session evidence shows two
+ * shapes: a bare SHA arg (`git cat-file -t <sha>`) and a `NAME=<sha>` shell
+ * assignment (`REF=<sha> && git show $REF:…`, matched whole because `=` is in
+ * the token class). Both are spared here.
+ *
+ * Spared only when EXACTLY 40 (SHA-1) or 64 (SHA-256) lowercase-hex — git
+ * object names are always lowercase, so an uppercase-hex or off-width run stays
+ * redacted, keeping the carve-out narrow. For the assignment form, the variable
+ * name must NOT advertise a secret (see `looksLikeSecretName`), so `REF=<sha>`
+ * and `COMMIT=<sha>` are spared while `TOKEN=<sha>` / `GITHUB_TOKEN=<sha>` /
+ * `API_KEY=<sha>` remain redacted.
+ *
+ * Accepted residual risk (documented, narrow): a BARE 40/64-char lowercase-hex
+ * secret (e.g. a legacy 40-hex GitHub PAT, or `openssl rand -hex 20/32` output)
+ * or a non-secret-named `NAME=<sha>` assignment (`PAT=<sha>`) is no longer
+ * redacted on the two sinks that use this helper (transcript tail → Haiku;
+ * bash tool-lane label → events.jsonl/telegram). All high-value NAMED secrets
+ * (sk-ant, Bearer, JWT, AWS key ids, and any base64/base64url/mixed-case blob)
+ * are still caught by the explicit rules that run BEFORE the generic rule.
+ */
+function isGitObjectName(run: string): boolean {
+  if (/^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(run)) return true;
+  const assign = /^([A-Za-z_][A-Za-z0-9_]*)=(?:[0-9a-f]{40}|[0-9a-f]{64})$/.exec(run);
+  if (assign) {
+    const name = assign[1] ?? '';
+    if (!looksLikeSecretName(name)) return true;
+  }
+  return false;
+}
+
+/**
+ * True when a shell variable name advertises that its value is a secret, so a
+ * `NAME=<40/64-hex>` assignment must NOT be spared as a git object name. Errs
+ * toward over-matching (fails safe: a false hit only over-redacts). Substring,
+ * case-insensitive — `GITHUB_TOKEN`, `MY_API_KEY`, `DB_PASSWORD`, `AUTH`,
+ * `CREDENTIAL`, `PRIVATE_KEY` all match; `REF`, `SHA`, `COMMIT`, `BASE` do not.
+ */
+function looksLikeSecretName(name: string): boolean {
+  return /token|secret|key|pass|pwd|auth|cred|private/i.test(name);
 }


### PR DESCRIPTION
## Why

Git SHAs kept showing up as `[REDACTED]` in bash tool-lane labels — e.g. `git cat-file -t [REDACTED]` and `cd … && [REDACTED] && git show \$REF:…`. These are the exact object ids the operator needs to read, not secrets.

**Root cause:** `redactSecrets`'s generic "opaque token" rule (`redact-secrets.ts:65`) matches any ≥32-char run of `[A-Za-z0-9+/=_-]`. A full 40-char SHA-1 / 64-char SHA-256 is byte-identical to that shape. PR #533 added `looksLikeFilesystemPath()` but only spared `/`-bearing paths — a bare hex SHA has no `/`, so that guard never applied.

Two real-world shapes were confirmed in `events.jsonl`:
- bare SHA arg — `git cat-file -t <40-hex>`
- shell assignment — `REF=<40-hex> && git show \$REF:…` (matched whole because `=` is in the token class)

## What changed

Added `isGitObjectName()` beside `looksLikeFilesystemPath()` in the generic-rule replacer. A run is spared when it is **exactly 40 or 64 lowercase-hex**, or a `NAME=<sha>` assignment whose name is **not** secret-advertising (`looksLikeSecretName`: `token|secret|key|pass|pwd|auth|cred|private`).

Net effect:

| Input | Before | After |
|---|---|---|
| `git cat-file -t <40-hex-sha>` | `[REDACTED]` | ✅ shown |
| `REF=<sha> && git show $REF:…` | `[REDACTED]` | ✅ shown |
| `git show <sha>:path` | `[REDACTED]` | ✅ shown |
| `GITHUB_TOKEN=<40-hex>` | `[REDACTED]` | ✅ still `[REDACTED]` |
| `token=<40-hex>` (pinned test) | `[REDACTED]` | ✅ still `[REDACTED]` |
| uppercase-hex / off-width (48) hex | `[REDACTED]` | ✅ still `[REDACTED]` |

## Security posture

Blast radius = the helper's **two** runtime consumers: transcript tail → Haiku (`background-summarizer.ts`) and bash label → `events.jsonl`/telegram (`tool-input-summary.ts`). The browser code uses a separate `redactSecrets`.

Keeping secret-named assignments redacted preserves the existing `token=<40hex>` pinned assertion **and** closes the `GITHUB_TOKEN=<40hex>` leak vector — so this is *not* a straight loosening.

**Documented residual risk** (narrow, fails toward the rare case): a *bare* 40/64-char lowercase-hex secret (legacy 40-hex GitHub PAT, `openssl rand -hex 20/32`) or a non-secret-named `PAT=<sha>` assignment is no longer redacted on those two sinks. All NAMED high-value secrets — `sk-ant`, `Bearer`, JWT, AWS key ids, and any base64/base64url/mixed-case blob — are still caught by the explicit rules that run *before* the generic rule.

## Tests

9 new cases (all green; full suite 11537 passed / 0 failed, `pnpm lint` clean):
- `redactSecrets` unit: bare SHA-1, bare SHA-256, `<sha>:path`, `REF=`/`SHA=`/`COMMIT=`/`BASE=` spared; `TOKEN=`/`GITHUB_TOKEN=`/`API_KEY=`/`DB_PASSWORD=`, uppercase-hex, off-width(48) still redacted.
- `summarizeToolInput` integration: bare `git cat-file -t <sha>` and the exact `cd … && REF=<sha> && git show $REF:…` events.jsonl shape render legibly.