### PR TITLE
test(subagent): lock in injectContext throw-path keep-drop decision (#392)

### DIFF
--- a/src/agent/tools/skill-executor/fork-dispatch.ts
+++ b/src/agent/tools/skill-executor/fork-dispatch.ts
@@ -348,7 +348,9 @@ export async function runForkedSkillToResult(
     if (handle) await handle.teardown({ deferInjectContextToCaller: true }).catch(debugLog);
     // In-turn append: only when this run produced a completion ToolResult.
     // The catch path leaves toolResult unset — nothing to append to, note
-    // dropped for that stop by design (the error string is the signal).
+    // dropped for that stop by design (the error string is the signal;
+    // keep-drop confirmed in #392, queue-fallback rejected — rationale in
+    // inject-context.ts).
     const injectContext = handle?.getLastStopInjectContext?.();
     appendInjectContext(toolResult, injectContext);
     await childManager?.teardownAll();

--- a/src/agent/tools/subagent-executor.test.ts
+++ b/src/agent/tools/subagent-executor.test.ts
@@ -2016,6 +2016,58 @@ describe('SubagentExecutor', () => {
       expect(payload.status).toBe('failed');
       expect(payload.error).toBe('kaboom');
     });
+
+    // THROW PATH (runToResult rejects, toolResult stays unset): the recorded
+    // SubagentStop note is dropped for that stop BY DESIGN (#392 keep-drop).
+    // foreground-promotion.ts's catch re-throws, leaving `toolResult`
+    // undefined, so `appendInjectContext` has no result to ride; and because
+    // teardown ran with `deferInjectContextToCaller: true` the queue push was
+    // suppressed at source — so the note reaches NEITHER channel. The throw is
+    // the parent's signal; a supplemental nudge to "verify these findings" is
+    // meaningless when the run threw before producing findings.
+    //
+    // Mirror of skill-executor.test.ts "does NOT append when runToResult
+    // throws" — keeps the two in-turn-delivery suites in symmetry (they differ
+    // only in that the skill catch returns a plain error string while the
+    // `agent` catch re-throws, so here we assert the throw propagates and the
+    // note is delivered through neither channel rather than inspecting content).
+    it('drops the injectContext note when runToResult throws (dropped by design, #392)', async () => {
+      const nudge = 'verify: should not appear';
+      const queueSpy = vi.fn();
+      const pushSpy = vi.fn();
+      const handle: Partial<SubagentHandle> = {
+        id: 'child-throw-inject',
+        status: 'failed' as any,
+        runToResult: vi.fn().mockRejectedValue(new Error('Response timeout')),
+        cancel: vi.fn().mockResolvedValue(undefined),
+        teardown: vi.fn().mockResolvedValue(undefined),
+        // The note IS recorded/available — the drop is deliberate, not absence.
+        getLastStopInjectContext: vi.fn().mockReturnValue(nudge),
+      };
+      mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
+
+      const exec = new SubagentExecutor({
+        subagentManager: mockSubagentMgr as any,
+        parentSession: {
+          sessionId: 'parent',
+          getInputStreamRef: () => ({ pushUserMessage: pushSpy, queueFrameworkContext: queueSpy }),
+          abortSignal: new AbortController().signal,
+        } as any,
+        defaultConfig: mockConfig,
+        depth: 0,
+      });
+
+      // The throw propagates (re-throw contract preserved) ...
+      await expect(exec.execute(makeCall())).rejects.toThrow('Response timeout');
+      // ... teardown still ran with the defer flag (queue push suppressed at
+      // source) and the note was looked at — proving it was available ...
+      expect(handle.teardown).toHaveBeenCalledWith({ deferInjectContextToCaller: true });
+      expect(handle.getLastStopInjectContext).toHaveBeenCalled();
+      // ... yet it reached NEITHER channel: no tool_result to append to (execute
+      // threw) and the executor never pushed to the parent queue.
+      expect(queueSpy).not.toHaveBeenCalled();
+      expect(pushSpy).not.toHaveBeenCalled();
+    });
   });
 
   // ── Cancellation (soft-stop via SubagentControl) ──────────────────────────

--- a/src/agent/tools/subagent/foreground-promotion.ts
+++ b/src/agent/tools/subagent/foreground-promotion.ts
@@ -327,11 +327,13 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
       // In-turn append: only when this foreground run produced a completion
       // ToolResult (success or structured failure). The error-rethrow path
       // leaves toolResult unset — nothing to append to, note is dropped for
-      // that stop by design (the throw is the parent's signal). Attribution:
-      // the note is appended to THIS subagent's own result, so a parent
-      // batching multiple `agent` calls sees each nudge next to its result.
-      // Optional-chain: real SubagentHandleImpl always defines this; the
-      // `?.()` tolerates narrow handle doubles (returns undefined = no note).
+      // that stop by design (the throw is the parent's signal; keep-drop
+      // confirmed in #392, queue-fallback rejected — rationale in
+      // inject-context.ts). Attribution: the note is appended to THIS
+      // subagent's own result, so a parent batching multiple `agent` calls
+      // sees each nudge next to its result. Optional-chain: real
+      // SubagentHandleImpl always defines this; the `?.()` tolerates narrow
+      // handle doubles (returns undefined = no note).
       const injectContext = handle.getLastStopInjectContext?.();
       appendInjectContext(toolResult, injectContext);
 

--- a/src/agent/tools/subagent/inject-context.ts
+++ b/src/agent/tools/subagent/inject-context.ts
@@ -17,6 +17,15 @@ import type { ToolResult } from '../types.js';
  * non-empty string — the error/rethrow paths leave `toolResult` unset, so the
  * note is dropped for that stop by design (the error is the parent's signal).
  * Mutates `toolResult.content` in place.
+ *
+ * Keep-drop confirmed in #392 (follow-up to #387). A queue fallback for the
+ * true-throw path was considered and rejected: it would deliver a stale,
+ * caller-detached note on a LATER parent turn (re-opening the one-position
+ * displacement hazard the queue channel warns about in handle.ts), and the
+ * canonical producer (shadow-verify nudge) is output-gated on the subagent's
+ * findings — so it cannot fire on a throw that produced none anyway. The
+ * throw-path drop is pinned by tests in subagent-executor.test.ts and
+ * skill-executor.test.ts ("... when runToResult throws").
  */
 export function appendInjectContext(
   toolResult: ToolResult | undefined,


### PR DESCRIPTION
Resolves #392 (follow-up to #387).

## Decision: KEEP-DROP

On the genuine unexpected-**throw** path of the `agent` foreground fork
(`foreground-promotion.ts`) and the `skill` fork (`fork-dispatch.ts`), a
`SubagentStop.injectContext` note recorded for in-turn delivery is
**intentionally dropped** — the throw/error is the parent's signal. This PR
confirms the existing by-design behavior and makes it durable + guarded.
**No runtime behavior change.**

### Why keep-drop, not a queue fallback

1. **The canonical producer can't even fire here.** The framework's own
   `injectContext` producer — the shadow-verify nudge — is *output-gated* on
   the subagent's findings (`lastMessage` ≥600 chars + ≥2 decision markers,
   `shadow-verify-nudge.ts:146-150`). A true-throw path produces no findings,
   so the note is never populated for framework use. The nudge text itself
   ("before acting on **these conclusions**") is meaningless when the run threw
   before producing conclusions.
2. **A queue fallback is strictly worse than a clean drop.** It would deliver a
   stale, caller-detached note on a *later* parent turn, re-opening the
   one-position displacement hazard the queue channel explicitly warns about in
   `handle.ts:598-606`. The residual case (a custom SubagentStop hook that
   returns context unconditionally) is better served by a documented clean drop
   than by a detached, out-of-context delivery.

## Changes (test + comments only)

- **Add the missing symmetry regression test** on the `agent` foreground throw
  path (`subagent-executor.test.ts`): note recorded + `runToResult` throws ⇒
  the note is delivered through **neither** channel (no `tool_result` to append
  to, and the queue push stays suppressed). The `skill` path already had its
  throw-path drop test (`skill-executor.test.ts:1517`); this restores parity
  between the two in-turn-delivery suites and guards against a future
  queue-fallback silently landing. The assertion fails if anyone wires the note
  to the parent queue on this path.
- **Record the decision** in the three by-design comments — `inject-context.ts`
  is the single source of truth (full rationale + rejected alternative);
  `foreground-promotion.ts` and `fork-dispatch.ts` cite #392 and point to it.

## Acceptance criteria (from #392)

- [x] Decision recorded (**keep-drop**) — in the commit body, this PR, and the
  three by-design comments.
- [x] keep-drop path: the three by-design comments are retained and
  strengthened with the #392 rationale; a regression test now pins the drop on
  **both** throw paths.
- [ ] ~queue-fallback~ — not taken (see rationale above).

## Verification

- `pnpm test` — 634 files, **11528 passed**, 14 skipped, 0 failures.
- `pnpm lint` (`tsc --noEmit`, strict) — clean.