### PR TITLE
fix(config): don't cache config past a parse failure; gate importFrom via user-global allowlist (#501)

### DIFF
--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import {
   loadConfig,
   isValidModel,
@@ -21,6 +21,8 @@ import {
   resolveModelInput,
 } from '../agent/session/model-slots.js';
 import { resolveSuggestGhost } from './commands/interactive/repl-loop.js';
+import { loadJsonConfig } from './config/json-tier.js';
+import { getJsonConfigPath } from '../paths.js';
 
 // Mock dotenv to prevent .env from polluting test env. The repo's .env
 // contains CLAUDE_MODEL=opus_1m for local dev — without this mock, the
@@ -725,6 +727,174 @@ describe('Config Loader', () => {
       mockConfig({ telegram: { verifyDone: 'yes' } });
       expect(loadConfig().telegram?.verifyDone).toBeUndefined();
     });
+  });
+});
+
+describe('loadJsonConfig() — parse-failure cache invalidation (#501-F2)', () => {
+  // A malformed cwd afk.config.json used to fall through to the user-global
+  // file AND memoize that result permanently, so a later fix to the cwd file
+  // stayed invisible until _resetConfigCache()/restart (bites long-lived
+  // daemon/telegram processes). The fix returns a post-parse-error result
+  // transiently (uncached) so the next call re-reads disk. The happy path
+  // (every tier parses) must still memoize — no perf regression.
+  const mockedExistsSync = () => vi.mocked(fs.existsSync);
+  const mockedReadFileSync = () => vi.mocked(fs.readFileSync);
+  const cwdConfigJson = join(process.cwd(), 'afk.config.json');
+  const userConfigJson = getJsonConfigPath();
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    _resetConfigCache();
+    // Capture (and silence) the "Warning: Failed to parse …" stderr line.
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errSpy.mockRestore();
+    _resetConfigCache();
+    mockedExistsSync().mockImplementation(realFsModule.__realExistsSync);
+    mockedReadFileSync().mockImplementation(realFsModule.__realReadFileSync);
+  });
+
+  // cwd + user-global both exist; cwd content is supplied via a getter so a
+  // test can "fix" the file mid-run without re-installing the mock.
+  function mockTwoTier(getCwd: () => string, userGlobal: string): void {
+    mockedExistsSync().mockImplementation((p) => {
+      const s = String(p);
+      if (s === cwdConfigJson) return true;
+      if (s === userConfigJson) return true;
+      if (s.endsWith('AFK.md') || s.endsWith('afk.config.json')) return false;
+      return realFsModule.__realExistsSync(p as fs.PathLike);
+    });
+    mockedReadFileSync().mockImplementation((p, ...args) => {
+      const s = String(p);
+      if (s === cwdConfigJson) return getCwd();
+      if (s === userConfigJson) return userGlobal;
+      return (realFsModule.__realReadFileSync as Function)(p, ...args);
+    });
+  }
+
+  it('does not cache the user-global fall-through when the cwd file is malformed (a later cwd fix is picked up without reset)', () => {
+    let cwdContent = '{ this is not valid json';
+    mockTwoTier(() => cwdContent, JSON.stringify({ maxTokens: 1111 }));
+
+    // 1st load: malformed cwd → falls through to user-global.
+    const first = loadJsonConfig();
+    expect(first.sourcePath).toBe(userConfigJson);
+    expect(first.config.maxTokens).toBe(1111);
+    expect(errSpy).toHaveBeenCalled();
+
+    // Operator fixes the cwd file — deliberately NO _resetConfigCache().
+    cwdContent = JSON.stringify({ maxTokens: 2222 });
+    const second = loadJsonConfig();
+    expect(second.sourcePath).toBe(cwdConfigJson);
+    expect(second.config.maxTokens).toBe(2222);
+  });
+
+  it('does not cache the empty terminal when the only config file is malformed', () => {
+    let cwdContent = '{{ broken';
+    mockedExistsSync().mockImplementation((p) => {
+      const s = String(p);
+      if (s === cwdConfigJson) return true;
+      if (s.endsWith('AFK.md') || s.endsWith('afk.config.json')) return false;
+      return realFsModule.__realExistsSync(p as fs.PathLike);
+    });
+    mockedReadFileSync().mockImplementation((p, ...args) => {
+      if (String(p) === cwdConfigJson) return cwdContent;
+      return (realFsModule.__realReadFileSync as Function)(p, ...args);
+    });
+
+    const first = loadJsonConfig();
+    expect(first.sourcePath).toBeUndefined();
+    expect(first.config).toEqual({});
+
+    cwdContent = JSON.stringify({ maxTokens: 5555 });
+    const second = loadJsonConfig();
+    expect(second.sourcePath).toBe(cwdConfigJson);
+    expect(second.config.maxTokens).toBe(5555);
+  });
+
+  it('memoizes a clean walk (no caching regression on the happy path)', () => {
+    let cwdContent = JSON.stringify({ maxTokens: 3333 });
+    mockTwoTier(() => cwdContent, JSON.stringify({ maxTokens: 4444 }));
+
+    expect(loadJsonConfig().config.maxTokens).toBe(3333);
+    // File changes on disk, but a clean walk was memoized — the cached value
+    // must persist without an explicit reset.
+    cwdContent = JSON.stringify({ maxTokens: 9999 });
+    expect(loadJsonConfig().config.maxTokens).toBe(3333);
+    // …and the new value is observed only after an explicit reset.
+    _resetConfigCache();
+    expect(loadJsonConfig().config.maxTokens).toBe(9999);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('loadConfig() — importFrom user-global allowlist (#501-F5)', () => {
+  // importFrom is a user-global-only trust grant. The guard now honors it via
+  // an allowlist of the user-global + legacy paths (fails closed) instead of a
+  // fragile `configPath !== join(cwd, 'afk.config.json')` denylist.
+  const mockedExistsSync = () => vi.mocked(fs.existsSync);
+  const mockedReadFileSync = () => vi.mocked(fs.readFileSync);
+  const cwdConfigJson = join(process.cwd(), 'afk.config.json');
+  const userConfigJson = getJsonConfigPath();
+
+  beforeEach(() => {
+    _resetConfigCache();
+    process.env.ANTHROPIC_API_KEY = 'test-api-key-12345';
+    delete process.env.AFK_MODEL;
+    delete process.env.CLAUDE_MODEL;
+  });
+
+  afterEach(() => {
+    _resetConfigCache();
+    delete process.env.ANTHROPIC_API_KEY;
+    mockedExistsSync().mockImplementation(realFsModule.__realExistsSync);
+    mockedReadFileSync().mockImplementation(realFsModule.__realReadFileSync);
+  });
+
+  // Make exactly one config file present, with the given JSON content.
+  function onlyFile(path: string, content: string): void {
+    mockedExistsSync().mockImplementation((p) => {
+      const s = String(p);
+      if (s === path) return true;
+      if (s.endsWith('AFK.md') || s.endsWith('afk.config.json')) return false;
+      return realFsModule.__realExistsSync(p as fs.PathLike);
+    });
+    mockedReadFileSync().mockImplementation((p, ...args) => {
+      if (String(p) === path) return content;
+      return (realFsModule.__realReadFileSync as Function)(p, ...args);
+    });
+  }
+
+  it('honors importFrom from the user-global afk.config.json', () => {
+    onlyFile(userConfigJson, JSON.stringify({ importFrom: { 'claude-code': true } }));
+    const cfg = loadConfig();
+    expect(cfg.importFrom).toBeDefined();
+    expect(cfg.importFrom?.['claude-code']).toEqual({ plugins: true, skills: true, mcp: true });
+  });
+
+  it('ignores importFrom from a project-local <cwd>/afk.config.json (allowlist denies cwd)', () => {
+    onlyFile(cwdConfigJson, JSON.stringify({ importFrom: { 'claude-code': true } }));
+    const cfg = loadConfig();
+    expect(cfg.importFrom).toBeUndefined();
+  });
+
+  it('honors importFrom when cwd IS the user-global config dir (allowlist, not the old cwd-denylist)', () => {
+    // When afk runs from inside the user-global config dir, the cwd config
+    // path string-equals the user-global path. The old denylist
+    // (`configPath !== join(cwd, 'afk.config.json')`) FALSE-DENIED this real
+    // user-global file; the allowlist correctly honors it. This is the one
+    // scenario that behaviorally distinguishes the fix from the old check.
+    const userDir = dirname(userConfigJson);
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(userDir);
+    try {
+      onlyFile(userConfigJson, JSON.stringify({ importFrom: { codex: true } }));
+      const cfg = loadConfig();
+      expect(cfg.importFrom?.codex).toEqual({ plugins: true, skills: true, mcp: true });
+    } finally {
+      cwdSpy.mockRestore();
+    }
   });
 });
 

--- a/src/cli/config/json-tier.ts
+++ b/src/cli/config/json-tier.ts
@@ -16,7 +16,7 @@ import {
 import { getJsonConfigPath, getLegacyJsonConfigPath } from '../../paths.js';
 import { validateBranchPrefix, validateBaseRef } from '../commands/interactive/worktree.js';
 import type { RawHooksConfig } from '../../agent/hooks/config-loader.js';
-import { parseImportFromConfig } from '../../config/import-sources.js';
+import { importFromConfigPaths, parseImportFromConfig } from '../../config/import-sources.js';
 import type { AutoRoutingConfig, CliConfig, ConfigFileSchema } from './types.js';
 
 /**
@@ -76,6 +76,16 @@ export function loadJsonConfig(): {
     getJsonConfigPath(),
     getLegacyJsonConfigPath(),
   ];
+
+  // Invariant: a parse failure in an earlier tier must NOT permanently
+  // memoize the fallen-through result (#501-F2). If a malformed
+  // `<cwd>/afk.config.json` falls through to the user-global file and we
+  // cached THAT, a later fix to the cwd file would stay invisible until
+  // `_resetConfigCache()`/process restart — which bites long-lived
+  // daemon/telegram processes (one-shot CLI self-heals on the next spawn).
+  // So when any file in the walk fails to parse, we return the resolved
+  // result transiently (uncached) and re-read disk on the next call.
+  let sawParseError = false;
 
   for (const configPath of configPaths) {
     if (existsSync(configPath)) {
@@ -208,13 +218,19 @@ export function loadJsonConfig(): {
         // project-local afk.config.json must NOT be able to set it, so honor it
         // only from the user-global / legacy config, never `<cwd>/afk.config.json`.
         //
+        // Gate via an ALLOWLIST of the user-global + legacy paths
+        // (`importFromConfigPaths()`, the same set the real gate reads) rather
+        // than a cwd denylist. An allowlist fails closed: any path that isn't
+        // provably one of those two files — including a symlinked or case-variant
+        // `<cwd>/afk.config.json` — is denied, closing the exact-string-compare
+        // gap the old `configPath !== join(cwd, ...)` check left open (#501-F5).
+        //
         // Note: `config.importFrom` is exposed on `CliConfig` for completeness and
         // inspection (e.g. `--dump-prompt` tooling), but runtime asset scanners
         // deliberately call `loadImportFromConfig()` directly — the agent layer
         // cannot import from `src/cli/` without a circular-dependency violation.
-        // The project-local exclusion guard below is intentional defense-in-depth
-        // that mirrors `loadImportFromConfig`'s own user-global-only path restriction.
-        if (configPath !== join(process.cwd(), 'afk.config.json')) {
+        // This guard is intentional defense-in-depth mirroring that real gate.
+        if (importFromConfigPaths().includes(configPath)) {
           const importFrom = parseImportFromConfig(json.importFrom);
           if (importFrom !== undefined) {
             config.importFrom = importFrom;
@@ -268,14 +284,20 @@ export function loadJsonConfig(): {
           }
         }
 
-        jsonConfigCache = { config, sourcePath: configPath, modelsPartial };
-        return jsonConfigCache;
+        const result = { config, sourcePath: configPath, modelsPartial };
+        // Only memoize when the walk was clean — see the sawParseError
+        // invariant above (a fall-through past a malformed earlier tier is
+        // returned but not cached, so a later fix is picked up on re-read).
+        if (!sawParseError) jsonConfigCache = result;
+        return result;
       } catch (error) {
         console.error(`Warning: Failed to parse ${configPath}:`, error);
+        sawParseError = true;
       }
     }
   }
 
-  jsonConfigCache = { config: {}, sourcePath: undefined, modelsPartial: {} };
-  return jsonConfigCache;
+  const emptyResult = { config: {}, sourcePath: undefined, modelsPartial: {} };
+  if (!sawParseError) jsonConfigCache = emptyResult;
+  return emptyResult;
 }


### PR DESCRIPTION
## What

Closes the two remaining config-tier hardening gaps from #501 (surfaced report-only during the #368 `config.ts` split, PR #493). Both live in `src/cli/config/json-tier.ts`.

Status of the five findings:

| # | Finding | This PR |
|---|---------|---------|
| 1 | `NaN` pass-through (`AFK_MAX_TOKENS`/`AFK_TEMPERATURE`) | already fixed in #534 |
| 2 | parse-failure caches the wrong tier permanently | **fixed here** |
| 3 | `json.systemPrompt` truthiness check | already fixed in #534 |
| 4 | `_resetConfigCache` dotenv flag | struck — not a bug (intentional) |
| 5 | `importFrom` cwd-exclusion exact-string compare | **fixed here** |

## F2 — don't memoize a result produced after a parse failure

`loadJsonConfig()` walks `[<cwd>/afk.config.json, user-global, legacy]` and returns the first that parses. Previously it memoized that result **unconditionally**. So a malformed `<cwd>/afk.config.json` fell through to the user-global file and cached *that* — and a later fix to the cwd file stayed invisible until `_resetConfigCache()` / process restart. This bites long-lived daemon/telegram processes (a one-shot CLI self-heals on the next spawn).

Fix: track whether any file in the walk failed to parse; when it did, return the resolved result **transiently (uncached)** so the next call re-reads disk. Clean walks still memoize exactly as before — no happy-path change.

## F5 — gate `importFrom` via a user-global allowlist, not a cwd denylist

`importFrom` is a user-global-only trust grant. The exclusion used a fragile denylist:

```ts
if (configPath !== join(process.cwd(), 'afk.config.json')) { /* honor */ }
```

Flipped to an **allowlist** of the user-global + legacy paths — `importFromConfigPaths()`, the exact set the real gate `loadImportFromConfig()` reads:

```ts
if (importFromConfigPaths().includes(configPath)) { /* honor */ }
```

An allowlist fails closed: anything not provably one of the two user-global files — including a symlinked/case-variant `<cwd>/afk.config.json` — is denied. As a bonus it fixes the false-deny that previously dropped a legitimate `importFrom` when `afk` was run from inside the user-global config dir. This remains intentional defense-in-depth; runtime asset scanners already call `loadImportFromConfig()` directly.

## Tests

New cases in `src/cli/config.test.ts`:

- **F2** — malformed cwd fall-through is re-read after a fix (no stale cache); malformed-only terminal is likewise uncached; a clean walk still memoizes (happy-path preserved).
- **F5** — `importFrom` honored from user-global, denied from cwd, and honored when cwd *is* the config dir.

The three fix-distinguishing tests were confirmed to **fail on the pre-fix `json-tier.ts`** and pass after.

## Gates (all green)

- `pnpm lint` (tsc --noEmit strict)
- `pnpm test` — 634 files / 11533 passed, 0 failed
- `pnpm audit:sdk:check` — OK (no new SDK imports)
- `pnpm scan:env:check` — in sync
- `pnpm audit:env:check` — 0 violations
