### PR TITLE
test(tui): real-PTY scrollback harness for the compositor (#541)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,42 @@ jobs:
           path: coverage/
           retention-days: 14
 
+  # Real-PTY scrollback harness (issue #541). Isolated from the main `test` job
+  # because it depends on the native `node-pty` module (compiled from source on
+  # Linux via pnpm.onlyBuiltDependencies — the same path better-sqlite3 already
+  # uses) and drives a real pseudo-terminal, which is slower and timing-
+  # sensitive. It is a real gate (not continue-on-error) but runs serially with
+  # in-suite retries (vitest.pty.config.ts). If PTY flakiness ever destabilises
+  # CI, mark this job `continue-on-error: true` to quarantine it without losing
+  # the signal. See tests/pty/ and docs/scrollback.md.
+  test-pty:
+    name: Test (real PTY scrollback)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          dest: ${{ runner.temp }}/setup-pnpm
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        # Builds node-pty from source (no Linux prebuild ships) via
+        # pnpm.onlyBuiltDependencies; ubuntu-latest has the C++/python toolchain.
+        run: pnpm install --frozen-lockfile
+
+      - name: Test (real PTY scrollback harness)
+        run: pnpm test:pty
+
   # The docs site under website/ is a standalone npm app (Fumadocs/Next.js)
   # with its own tsconfig and dependency tree — not part of the root pnpm
   # workspace. This job catches TypeScript errors and broken Next.js builds

--- a/docs/scrollback.md
+++ b/docs/scrollback.md
@@ -8,7 +8,9 @@ This is the single hardest-to-debug mechanism in the TUI because:
 
 - Mock-stdout unit tests can verify bytes were *written* but cannot verify
   they actually *reached scrollback* — that's a property of the real PTY's
-  scroll engine, not of our code.
+  scroll engine, not of our code. (The `tests/pty/` harness closes this gap by
+  driving the compositor through a real pseudo-terminal and asserting on an
+  xterm emulator's scrollback buffer — see "Empirical verification" below.)
 - Multiple prior fixes (6d7cb90, 9690b9f) were validated on byte-level tests
   that passed even though the real-terminal behavior was broken.
 - The mismatch between VT100 sub-region and full-screen DECSTBM scroll
@@ -635,10 +637,18 @@ and `SCROLLBACK_TEST_B` with cursor at `rows` (post-fix behavior). Scroll
 up after the script exits. Only `SCROLLBACK_TEST_B` should appear in
 scrollback.
 
-For future regression-detection in CI: a `node-pty` + `xterm.js`-headless
-integration test could pipe agent-afk output through a real terminal
-emulator and assert that committed lines appear in the emulator's
-scrollback buffer. None exists today.
+For regression-detection in CI: a `node-pty` + `@xterm/headless` integration
+harness drives the real `TerminalCompositor` through a real pseudo-terminal,
+pipes its output into an xterm emulator, and asserts that committed lines
+appear in the emulator's **scrollback** buffer (not just that bytes were
+written). It lives in `tests/pty/` — `scenarios.ts` defines the gap-class
+geometries (multi-commit, collapse-void #539, overflow-gap, shrink-gap,
+first-turn banner echo #509), `harness.ts` spawns the pty and reconstructs the
+emulator buffer, and `compositor-scrollback.pty.test.ts` asserts on the
+scrollback/viewport. Run it with `pnpm test:pty`; CI runs it as the dedicated
+`test-pty` job (kept out of the default `pnpm test` run because it needs the
+native node-pty build). This is the real-terminal net that the two prior
+byte-level failures (6d7cb90, 9690b9f) lacked (issue #541).
 
 ## Don't change without reading this
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest watch",
+    "test:pty": "vitest run --config vitest.pty.config.ts",
     "lint": "tsc --noEmit",
     "audit:sdk": "tsx scripts/audit-sdk-dependency.ts",
     "audit:sdk:check": "tsx scripts/audit-sdk-dependency.ts --check",
@@ -98,7 +99,8 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "better-sqlite3"
+      "better-sqlite3",
+      "node-pty"
     ]
   },
   "dependencies": {
@@ -134,6 +136,7 @@
     "@vitest/coverage-v8": "^2.1.8",
     "@xterm/headless": "^6.0.0",
     "esbuild": "^0.28.0",
+    "node-pty": "^1.1.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -1652,6 +1655,9 @@ packages:
     resolution: {integrity: sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==}
     engines: {node: '>=10'}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-cron@4.2.1:
     resolution: {integrity: sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==}
     engines: {node: '>=6.0.0'}
@@ -1664,6 +1670,9 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3524,11 +3533,17 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  node-addon-api@7.1.1: {}
+
   node-cron@4.2.1: {}
 
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
 
   object-assign@4.1.1: {}
 

--- a/tests/pty/compositor-scrollback.pty.test.ts
+++ b/tests/pty/compositor-scrollback.pty.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Real-PTY scrollback integration suite for TerminalCompositor (issue #541).
+ *
+ * Runs OUTSIDE the default `pnpm test` run (excluded by the `*.pty.test.ts`
+ * glob in vitest.config.ts) and only via `pnpm test:pty` (vitest.pty.config.ts)
+ * or the dedicated CI job — because it depends on the native `node-pty` module
+ * and a real pseudo-terminal, which can be flaky and needs serial execution.
+ *
+ * Each scenario in tests/pty/scenarios.ts drives the real compositor through a
+ * gap-class geometry inside a real pty; here we reconstruct the emulator buffer
+ * and assert against the SCROLLBACK / viewport — the ground truth that the
+ * in-process @xterm/headless unit tests cannot certify (docs/scrollback.md).
+ *
+ * Gating: node-pty is a native dep in `pnpm.onlyBuiltDependencies`, so it is
+ * present after `pnpm install`. In CI (or with AFK_PTY_REQUIRED=1) a missing
+ * node-pty is a hard failure; locally it degrades to a skip so a dev who has
+ * not built the native module is not blocked.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SCENARIOS, type PtyExpect } from './scenarios.js';
+import { runScenarioInPty, nodePtyAvailable, maxBlankRun, type PtyRunResult } from './harness.js';
+
+const ci = process.env['CI'];
+const mustRun = (ci != null && ci !== '' && ci !== 'false' && ci !== '0') || process.env['AFK_PTY_REQUIRED'] === '1';
+const avail = nodePtyAvailable();
+
+function countAll(lines: string[], needle: string): number {
+  return lines.filter((l) => l.includes(needle)).length;
+}
+function firstIndex(lines: string[], needle: string): number {
+  return lines.findIndex((l) => l.includes(needle));
+}
+
+function assertExpectations(res: PtyRunResult, exp: PtyExpect): void {
+  const dump = res.dump();
+
+  // The driver must have reached the sentinel (final frame fully rendered).
+  expect(res.sawSentinel, `driver did not emit completion sentinel (exit=${res.exitCode}):\n${dump}`).toBe(true);
+
+  for (const needle of exp.inScrollback ?? []) {
+    const hit = res.scrollback.some((l) => l.includes(needle));
+    expect(hit, `"${needle}" expected in SCROLLBACK (baseY=${res.baseY}):\n${dump}`).toBe(true);
+  }
+  for (const needle of exp.inViewport ?? []) {
+    const hit = res.viewport.some((l) => l.includes(needle));
+    expect(hit, `"${needle}" expected in VIEWPORT:\n${dump}`).toBe(true);
+  }
+  for (const needle of exp.exactlyOnce ?? []) {
+    const n = countAll(res.lines, needle);
+    expect(n, `"${needle}" must appear exactly once across the whole buffer (found ${n}):\n${dump}`).toBe(1);
+  }
+  for (const needle of exp.absent ?? []) {
+    const n = countAll(res.lines, needle);
+    expect(n, `"${needle}" must NOT appear anywhere (found ${n}):\n${dump}`).toBe(0);
+  }
+  for (const [a, b] of exp.order ?? []) {
+    const ia = firstIndex(res.lines, a);
+    const ib = firstIndex(res.lines, b);
+    expect(ia, `order anchor "${a}" not found:\n${dump}`).toBeGreaterThanOrEqual(0);
+    expect(ib, `order anchor "${b}" not found:\n${dump}`).toBeGreaterThanOrEqual(0);
+    expect(ia, `"${a}" must appear above "${b}" (idx ${ia} vs ${ib}):\n${dump}`).toBeLessThan(ib);
+  }
+  if (exp.maxViewportBlankRun !== undefined) {
+    // Measure blank runs strictly BETWEEN committed content rows (first content
+    // → last content anchor), so live-frame chrome below never counts as a void.
+    const anchors = [...(exp.inViewport ?? []), ...(exp.exactlyOnce ?? [])];
+    const firstContent = res.viewport.findIndex((l) => l.trim() !== '');
+    let lastAnchor = -1;
+    for (let i = res.viewport.length - 1; i >= 0; i--) {
+      if (anchors.some((a) => (res.viewport[i] ?? '').includes(a))) { lastAnchor = i; break; }
+    }
+    if (firstContent >= 0 && lastAnchor > firstContent) {
+      const run = maxBlankRun(res.viewport, firstContent, lastAnchor);
+      expect(
+        run,
+        `blank void of ${run} rows between committed content and frame (limit ${exp.maxViewportBlankRun}):\n${dump}`,
+      ).toBeLessThanOrEqual(exp.maxViewportBlankRun);
+    }
+  }
+}
+
+describe('TerminalCompositor scrollback over a real pty (issue #541)', () => {
+  if (!avail.ok) {
+    if (mustRun) {
+      it('node-pty must be installed and functional in CI', () => {
+        throw new Error(
+          `node-pty is unavailable but required (CI or AFK_PTY_REQUIRED=1): ${(avail as { reason: string }).reason}. ` +
+            'Ensure "node-pty" is in pnpm.onlyBuiltDependencies and the native build succeeded.',
+        );
+      });
+    } else {
+      it.skip(`node-pty unavailable locally — skipping pty suite (${(avail as { reason: string }).reason})`, () => {});
+    }
+    return;
+  }
+
+  for (const [name, scenario] of Object.entries(SCENARIOS)) {
+    it(`${name}: ${scenario.description}`, async () => {
+      const res = await runScenarioInPty({ name, cols: scenario.cols, rows: scenario.rows });
+      assertExpectations(res, scenario.expect);
+    }, 45_000);
+  }
+});

--- a/tests/pty/compositor-scrollback.pty.test.ts
+++ b/tests/pty/compositor-scrollback.pty.test.ts
@@ -64,7 +64,11 @@ function assertExpectations(res: PtyRunResult, exp: PtyExpect): void {
   if (exp.maxViewportBlankRun !== undefined) {
     // Measure blank runs strictly BETWEEN committed content rows (first content
     // → last content anchor), so live-frame chrome below never counts as a void.
-    const anchors = [...(exp.inViewport ?? []), ...(exp.exactlyOnce ?? [])];
+    // Prefer a scenario-declared content-only anchor set so live-frame chrome
+    // (e.g. a StatusLine model id present in exactlyOnce) can't pull lastAnchor
+    // down into the frame and widen the void scan. Falls back to the general
+    // anchor sets when a scenario declares none (safe iff they hold no chrome).
+    const anchors = exp.contentAnchors ?? [...(exp.inViewport ?? []), ...(exp.exactlyOnce ?? [])];
     const firstContent = res.viewport.findIndex((l) => l.trim() !== '');
     let lastAnchor = -1;
     for (let i = res.viewport.length - 1; i >= 0; i--) {

--- a/tests/pty/constants.ts
+++ b/tests/pty/constants.ts
@@ -1,0 +1,13 @@
+/**
+ * PTY harness constants shared by the in-pty driver and the parent harness
+ * (issue #541). Kept side-effect-free so the parent can import the sentinel
+ * without executing the driver's top-level `main()`.
+ */
+
+/**
+ * Completion marker emitted by the driver once a scenario has rendered its
+ * final frame. An APC string (ESC _ ... ESC \): xterm ignores APC entirely, so
+ * it produces no glyphs and triggers no scroll. The parent captures only the
+ * bytes BEFORE this marker, so it never perturbs the geometry under test.
+ */
+export const PTY_DONE_SENTINEL = '\x1b_AFK_PTY_DONE\x1b\\';

--- a/tests/pty/driver.ts
+++ b/tests/pty/driver.ts
@@ -1,0 +1,60 @@
+/**
+ * PTY scrollback harness — in-pty driver (issue #541).
+ *
+ * Runs INSIDE the pseudo-terminal spawned by tests/pty/harness.ts, launched as:
+ *
+ *     node --import tsx tests/pty/driver.ts <scenario-name>
+ *
+ * It picks the named scenario from tests/pty/scenarios.ts, drives the real
+ * TerminalCompositor against `process.stdout` (a genuine TTY inside the pty),
+ * then emits the completion SENTINEL so the parent can snapshot the emulator
+ * buffer at the exact final live-frame state.
+ *
+ * SENTINEL: an APC string (ESC _ ... ESC \). xterm ignores APC entirely — no
+ * glyphs, no scroll — and the parent captures only the bytes BEFORE it, so the
+ * sentinel never perturbs the geometry under test. It is emitted AFTER the
+ * scenario's final repaint and BEFORE any teardown; the driver deliberately
+ * does NOT disarm the compositor, because disarm would clear the live frame and
+ * destroy the very state the parent needs to inspect.
+ */
+
+import { SCENARIOS } from './scenarios.js';
+import { PTY_DONE_SENTINEL } from './constants.js';
+
+async function main(): Promise<void> {
+  const name = process.argv[2];
+  if (!name) {
+    process.stderr.write('driver: missing scenario name (argv[2])\n');
+    process.exit(64);
+  }
+  const scenario = SCENARIOS[name];
+  if (!scenario) {
+    process.stderr.write(`driver: unknown scenario "${name}"; known: ${Object.keys(SCENARIOS).join(', ')}\n`);
+    process.exit(65);
+  }
+
+  const stdout = process.stdout;
+  const stdin = process.stdin;
+  if (!stdout.isTTY) {
+    // The whole point is a real TTY; refuse if the parent didn't give us one.
+    process.stderr.write('driver: process.stdout is not a TTY — must run inside a pty\n');
+    process.exit(66);
+  }
+
+  try {
+    await scenario.drive({ stdout, stdin });
+  } catch (err) {
+    process.stderr.write(`driver: scenario "${name}" threw: ${(err as Error)?.stack ?? String(err)}\n`);
+    process.exit(1);
+  }
+
+  // Let the final frame's writes flush through the kernel pty to the parent,
+  // THEN mark completion. Bytes arrive in order, so once the parent sees the
+  // sentinel it already holds every preceding (compositor) byte.
+  await new Promise((r) => setTimeout(r, 60));
+  stdout.write(PTY_DONE_SENTINEL);
+  await new Promise((r) => setTimeout(r, 40));
+  process.exit(0);
+}
+
+void main();

--- a/tests/pty/harness.ts
+++ b/tests/pty/harness.ts
@@ -1,0 +1,207 @@
+/**
+ * PTY scrollback harness — parent-side spawn/capture/reconstruct machinery
+ * (issue #541). Imported by tests/pty/compositor-scrollback.pty.test.ts.
+ *
+ * Pipeline:
+ *   1. Spawn `node --import tsx tests/pty/driver.ts <scenario>` inside a REAL
+ *      pseudo-terminal (node-pty) sized to the scenario's cols×rows.
+ *   2. Accumulate the child's byte stream until the driver's APC sentinel.
+ *   3. Replay the captured bytes (everything BEFORE the sentinel) into an
+ *      @xterm/headless emulator sized to the same geometry.
+ *   4. Return the parsed buffer split into scrollback (rows above baseY) and
+ *      viewport (the visible rows), so tests can assert on real scrollback.
+ *
+ * Why real pty + real emulator, not the in-process mock: docs/scrollback.md
+ * (9-13, 108-111) is explicit that mock-stdout tests confirm bytes were
+ * WRITTEN but cannot confirm they reached SCROLLBACK — that is a property of a
+ * real terminal's scroll engine driven over a real pty (real isTTY, real
+ * winsize, real kernel flush), not of the bytes alone.
+ */
+
+import { createRequire } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { existsSync, chmodSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { PTY_DONE_SENTINEL } from './constants.js';
+
+const require = createRequire(import.meta.url);
+const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
+const DRIVER_PATH = fileURLToPath(new URL('./driver.ts', import.meta.url));
+
+/** Minimal shape of the bits of node-pty we use (avoids a type dependency). */
+interface IPtyProcess {
+  onData(cb: (data: string) => void): void;
+  onExit(cb: (e: { exitCode: number; signal?: number }) => void): void;
+  kill(signal?: string): void;
+}
+interface NodePtyModule {
+  spawn(file: string, args: string[], opts: Record<string, unknown>): IPtyProcess;
+}
+
+/**
+ * node-pty ships a `spawn-helper` executable next to its native binary. pnpm's
+ * content-addressable store extraction drops the file's executable bit on macOS
+ * (a known node-pty + pnpm interaction), which makes posix_spawnp fail. Restore
+ * it (idempotent; no-op where already +x, e.g. Linux source builds). This is
+ * self-healing so the harness works regardless of how node-pty was installed.
+ */
+export function ensureNodePtyExecutable(): void {
+  let pkgDir: string;
+  try {
+    pkgDir = dirname(require.resolve('node-pty/package.json'));
+  } catch {
+    return; // node-pty not installed; loadNodePty() will surface the real error.
+  }
+  const candidates: string[] = [join(pkgDir, 'build', 'Release', 'spawn-helper')];
+  const prebuilds = join(pkgDir, 'prebuilds');
+  if (existsSync(prebuilds)) {
+    for (const entry of readdirSync(prebuilds)) {
+      candidates.push(join(prebuilds, entry, 'spawn-helper'));
+    }
+  }
+  for (const p of candidates) {
+    try {
+      if (existsSync(p) && statSync(p).isFile()) chmodSync(p, 0o755);
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+let cachedPty: NodePtyModule | null = null;
+/** Load node-pty (self-healing the spawn-helper bit first). Throws if absent. */
+export function loadNodePty(): NodePtyModule {
+  if (cachedPty) return cachedPty;
+  ensureNodePtyExecutable();
+  cachedPty = require('node-pty') as NodePtyModule;
+  return cachedPty;
+}
+
+/** Is node-pty importable and functional? Used to gate the suite locally. */
+export function nodePtyAvailable(): { ok: true } | { ok: false; reason: string } {
+  try {
+    loadNodePty();
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, reason: (err as Error)?.message ?? String(err) };
+  }
+}
+
+export interface PtyRunResult {
+  /** Bytes captured up to (not including) the sentinel — fed to the emulator. */
+  raw: string;
+  /** Whether the sentinel was seen (vs. capturing everything up to exit). */
+  sawSentinel: boolean;
+  exitCode: number | 'timeout';
+  /** All emulator buffer lines, top (oldest scrollback) → bottom. */
+  lines: string[];
+  /** First visible row index — lines[0..baseY) are scrollback. */
+  baseY: number;
+  /** Scrollback region (rows above the viewport), blank rows preserved. */
+  scrollback: string[];
+  /** Viewport region (the visible rows). */
+  viewport: string[];
+  /** Pretty numbered dump of every line, for failure messages. */
+  dump(): string;
+}
+
+export interface RunScenarioOpts {
+  name: string;
+  cols: number;
+  rows: number;
+  timeoutMs?: number;
+}
+
+/** Spawn a scenario in a real pty and reconstruct its emulator buffer. */
+export async function runScenarioInPty(opts: RunScenarioOpts): Promise<PtyRunResult> {
+  const { name, cols, rows, timeoutMs = 20_000 } = opts;
+  const pty = loadNodePty();
+  const xterm = await import(pathToFileURL(require.resolve('@xterm/headless')).href);
+  const Terminal = (xterm as { Terminal?: unknown }).Terminal
+    ?? (xterm as { default?: { Terminal?: unknown } }).default?.Terminal;
+  if (typeof Terminal !== 'function') throw new Error('@xterm/headless: Terminal constructor not found');
+
+  const child = pty.spawn(process.execPath, ['--import', 'tsx', DRIVER_PATH, name], {
+    name: 'xterm-256color',
+    cols,
+    rows,
+    cwd: REPO_ROOT,
+    env: { ...process.env, TERM: 'xterm-256color' },
+  });
+
+  let buf = '';
+  let captured: string | null = null;
+  child.onData((d) => {
+    buf += d;
+    if (captured === null) {
+      const idx = buf.indexOf(PTY_DONE_SENTINEL);
+      if (idx >= 0) captured = buf.slice(0, idx);
+    }
+  });
+
+  const exitCode = await new Promise<number | 'timeout'>((resolve) => {
+    let done = false;
+    const timer = setTimeout(() => {
+      if (done) return;
+      done = true;
+      try { child.kill(); } catch { /* already gone */ }
+      resolve('timeout');
+    }, timeoutMs);
+    child.onExit(({ exitCode }) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      resolve(exitCode);
+    });
+  });
+
+  const sawSentinel = captured !== null;
+  const raw = captured ?? buf;
+
+  // Real pty output already carries CRLF (kernel ONLCR), so do NOT set
+  // convertEol — that would double-translate and desync every row.
+  const term = new (Terminal as new (o: Record<string, unknown>) => {
+    write(d: string, cb: () => void): void;
+    buffer: { active: { baseY: number; length: number; getLine(i: number): { translateToString(trim: boolean): string } | undefined } };
+    dispose(): void;
+  })({ cols, rows, scrollback: 1000, allowProposedApi: true });
+  await new Promise<void>((r) => term.write(raw, r));
+
+  const b = term.buffer.active;
+  const baseY = b.baseY;
+  const lines: string[] = [];
+  for (let i = 0; i < b.length; i++) {
+    const l = b.getLine(i);
+    lines.push(l ? l.translateToString(true).replace(/\s+$/, '') : '');
+  }
+  term.dispose();
+
+  const scrollback = lines.slice(0, baseY);
+  const viewport = lines.slice(baseY);
+
+  return {
+    raw,
+    sawSentinel,
+    exitCode,
+    lines,
+    baseY,
+    scrollback,
+    viewport,
+    dump(): string {
+      return lines
+        .map((l, i) => `[${i < baseY ? 'SB' : 'VP'} ${String(i).padStart(3)}] ${JSON.stringify(l)}`)
+        .join('\n');
+    },
+  };
+}
+
+/** Count the largest run of consecutive blank rows within lines[from..to]. */
+export function maxBlankRun(lines: string[], from: number, to: number): number {
+  let cur = 0;
+  let max = 0;
+  for (let i = Math.max(0, from); i <= Math.min(lines.length - 1, to); i++) {
+    if ((lines[i] ?? '').trim() === '') { cur += 1; max = Math.max(max, cur); }
+    else cur = 0;
+  }
+  return max;
+}

--- a/tests/pty/scenarios.ts
+++ b/tests/pty/scenarios.ts
@@ -50,6 +50,16 @@ export interface PtyExpect {
    */
   maxViewportBlankRun?: number;
   /**
+   * Content-only anchors marking the LAST committed content row, used solely
+   * to bound the maxViewportBlankRun window. Declare this when a scenario's
+   * `exactlyOnce`/`inViewport` sets carry live-frame CHROME strings (e.g. a
+   * StatusLine model id): the blank-run window must end at the last committed
+   * CONTENT row, never at a chrome row below it, or the void scan spills into
+   * the frame and over-counts on correct output. When unset, the window falls
+   * back to `inViewport ∪ exactlyOnce` (correct only when those hold no chrome).
+   */
+  contentAnchors?: string[];
+  /**
    * Substring pairs [a, b] where the first row containing `a` must appear
    * strictly above the first row containing `b` across the whole buffer.
    */
@@ -143,6 +153,10 @@ export const SCENARIOS: Record<string, PtyScenario> = {
         'TOOL_OUTPUT_00', 'TOOL_OUTPUT_05', 'TOOL_OUTPUT_11', 'TOOL_OUTPUT_17',
         'Done (114 tools)', 'STATUSMODELXYZ',
       ],
+      // 'STATUSMODELXYZ' above is the StatusLine model id (live-frame chrome).
+      // Bound the void scan by committed CONTENT only, so lastAnchor lands on
+      // the rollup tail — not the chrome status row below the frame.
+      contentAnchors: ['TOOL_OUTPUT_17', 'Done (114 tools)'],
       maxViewportBlankRun: 1,
     },
   },
@@ -314,6 +328,11 @@ export const SCENARIOS: Record<string, PtyScenario> = {
       await settle();
     },
     expect: {
+      // Banner rows written before arm overflow past baseY (observed baseY=13)
+      // into real scrollback — the property this scenario is named for. Assert
+      // the REGION (not just whole-buffer presence via exactlyOnce/order), so a
+      // regression that left the banner in the viewport would fail here.
+      inScrollback: ['BANNER_LINE_0', 'BANNER_LINE_10'],
       exactlyOnce: [
         'DUPCHECK', 'india', 'RESPONSE_OK',
         'BANNER_LINE_0', 'BANNER_LINE_5', 'BANNER_LINE_10',

--- a/tests/pty/scenarios.ts
+++ b/tests/pty/scenarios.ts
@@ -1,0 +1,326 @@
+/**
+ * PTY scrollback harness — scenario definitions (issue #541).
+ *
+ * Each scenario drives the REAL `TerminalCompositor` through one of the
+ * gap-class geometries that the byte-level `@xterm/headless` unit tests
+ * (src/cli/terminal-compositor.*.test.ts) cover in-process. Here the SAME
+ * geometries run inside a real OS pseudo-terminal (node-pty): the compositor
+ * sees a genuine TTY, real winsize, and real async flush through the kernel
+ * pty, and its output is reconstructed by an xterm emulator so assertions can
+ * read the emulator's SCROLLBACK buffer — the property docs/scrollback.md:9-13
+ * says mock-stdout tests cannot certify. See tests/pty/harness.ts for the
+ * spawn/capture machinery and tests/pty/driver.ts for the in-pty entry point.
+ *
+ * A scenario's `drive()` runs INSIDE the pty child (via tsx). Its `expect`
+ * block is evaluated by the vitest parent against the parsed emulator buffer.
+ * `drive()` deliberately does NOT `disarm()` — the parent snapshots the final
+ * LIVE frame state (content above a bottom-pinned frame), which is the exact
+ * geometry the regressions are about.
+ */
+
+import { TerminalCompositor } from '../../src/cli/terminal-compositor.js';
+import { StatusLine } from '../../src/cli/status-line.js';
+import { LoopStageBar } from '../../src/cli/commands/interactive/loop-stage.js';
+import { renderMarkdownToTerminal } from '../../src/cli/formatter.js';
+import { formatSubmittedEcho } from '../../src/cli/input/echo.js';
+
+/** Runtime handed to a scenario's drive() from inside the pty child. */
+export interface PtyDriveCtx {
+  stdout: NodeJS.WriteStream;
+  stdin: NodeJS.ReadStream;
+}
+
+/**
+ * Expectations checked by the parent against the reconstructed emulator buffer.
+ * Every field is optional; a scenario uses the subset relevant to its geometry.
+ */
+export interface PtyExpect {
+  /** Substrings that MUST appear in the emulator scrollback (above baseY). */
+  inScrollback?: string[];
+  /** Substrings that MUST appear in the viewport, above the live frame. */
+  inViewport?: string[];
+  /** Substrings that MUST appear exactly once across the WHOLE buffer. */
+  exactlyOnce?: string[];
+  /** Substrings that MUST NOT appear anywhere in the buffer. */
+  absent?: string[];
+  /**
+   * Max run of consecutive blank rows between the first content row and the
+   * live frame in the viewport. One blank is the legit rhythm separator; a
+   * larger run is the "void" regression. Default (undefined) = not checked.
+   */
+  maxViewportBlankRun?: number;
+  /**
+   * Substring pairs [a, b] where the first row containing `a` must appear
+   * strictly above the first row containing `b` across the whole buffer.
+   */
+  order?: [string, string][];
+}
+
+export interface PtyScenario {
+  /** One-line description surfaced in the test name and failure dumps. */
+  description: string;
+  /** pty + emulator geometry. */
+  cols: number;
+  rows: number;
+  /** Reference to the in-process regression this mirrors (for humans). */
+  ref: string;
+  drive(ctx: PtyDriveCtx): Promise<void> | void;
+  expect: PtyExpect;
+}
+
+/** Let the frame's async spinner/flush settle before the next step. */
+const settle = (ms = 40): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Cast to reach the compositor's internal repaint() (as the unit tests do). */
+type Repaintable = { repaint(): void };
+
+/** Production footer wiring: StatusLine + LoopStageBar + after-scroll restore. */
+function wireProductionFooter(stdout: NodeJS.WriteStream, model: string): StatusLine {
+  const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+  statusLine.start();
+  statusLine.repaint({ model, cost: 0, tokens: 0, contextPct: 0 });
+  const loopStageBar = new LoopStageBar({ getExtraRows: () => statusLine.getExtraRows(), stream: stdout });
+  loopStageBar.setRowCountChangeHandler(() => statusLine.setExtraRows(1));
+  statusLine.setAfterScrollRestore(() => loopStageBar.redraw());
+  loopStageBar.start();
+  return statusLine;
+}
+
+/** Minimal StatusLine-only scroll region (collapse-void / overflow-gap style). */
+function wireStatusLine(stdout: NodeJS.WriteStream, model: string): StatusLine {
+  const statusLine = new StatusLine({ stream: stdout, force: true, throttleMs: 0 });
+  statusLine.start();
+  statusLine.repaint({ model, cost: 0, tokens: 0, contextPct: 0 });
+  return statusLine;
+}
+
+const TABLE_MD = [
+  '| # | Change | File | Nature |',
+  '|---|--------|------|--------|',
+  '| 1 | pass cwd to scheduler | scheduler.ts | behavior |',
+  '| 2 | load config from cwd | config-loader.ts | behavior |',
+  '| 3 | thread cwd through daemon | daemon.ts | plumbing |',
+].join('\n');
+
+export const SCENARIOS: Record<string, PtyScenario> = {
+  // ─────────────────────────────────────────────────────────────────────────
+  // multi-commit: many commitAbove calls under a held tall overlay overflow the
+  // screen — the OLDEST lines must land in the emulator SCROLLBACK, each row
+  // exactly once (no duplication, no loss), with no void above the frame. This
+  // is the scenario that proves "committed lines reach scrollback", not just
+  // "bytes were written". Mirrors terminal-compositor.multi-commit-gap.test.ts.
+  // ─────────────────────────────────────────────────────────────────────────
+  'multi-commit-gap': {
+    description: 'many commits under a held overlay overflow into scrollback with no loss/dup/void',
+    cols: 80,
+    rows: 24,
+    ref: 'terminal-compositor.multi-commit-gap.test.ts',
+    async drive({ stdout, stdin }): Promise<void> {
+      const statusLine = wireProductionFooter(stdout, 'STATUSMODELXYZ');
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: () => {}, scrollRegion: statusLine, anchorRow: 1 });
+      await c.arm();
+      const ix = c as unknown as Repaintable;
+      c.setSpinner({ enabled: true });
+      // 18 single-line tool outputs, each under a persistent 10-line overlay
+      // (the tall-frame trigger) — enough content to overflow rows=24.
+      for (let k = 0; k < 18; k++) {
+        c.setOverlay(Array.from({ length: 10 }, (_, i) => `stream ${k}.${i}`).join('\n'));
+        c.commitAbove(`TOOL_OUTPUT_${String(k).padStart(2, '0')}\n`);
+      }
+      c.commitAbove('memory_search — done\nbash x37 — done\nDone (114 tools)\n');
+      c.setOverlay('');
+      ix.repaint();
+      ix.repaint();
+      await settle();
+    },
+    expect: {
+      // Oldest committed lines overflowed above the viewport → scrollback.
+      inScrollback: ['TOOL_OUTPUT_00', 'TOOL_OUTPUT_01'],
+      // The rollup tail re-pins adjacent to the collapsed frame.
+      inViewport: ['Done (114 tools)'],
+      // Every committed row present exactly once across scrollback + viewport.
+      exactlyOnce: [
+        'TOOL_OUTPUT_00', 'TOOL_OUTPUT_05', 'TOOL_OUTPUT_11', 'TOOL_OUTPUT_17',
+        'Done (114 tools)', 'STATUSMODELXYZ',
+      ],
+      maxViewportBlankRun: 1,
+    },
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // collapse-void (#539): a tall overlay held across a streamed report, then
+  // the overlay collapses at end-of-turn. The whole report must re-pin as ONE
+  // contiguous block hugging the frame — no multi-row void, no lost HEADER, no
+  // duplicated rows. Mirrors terminal-compositor.collapse-void.test.ts.
+  // ─────────────────────────────────────────────────────────────────────────
+  'collapse-void': {
+    description: 'tall overlay collapse re-pins the report contiguously (no void, no lost header)',
+    cols: 100,
+    rows: 40,
+    ref: '#539 · terminal-compositor.collapse-void.test.ts',
+    async drive({ stdout, stdin }): Promise<void> {
+      const statusLine = wireStatusLine(stdout, 'M');
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: () => {}, scrollRegion: statusLine, anchorRow: 1 });
+      await c.arm();
+      statusLine.setExtraRows(1);
+      c.setSpinner({ enabled: true });
+      const overlay = Array.from({ length: 22 }, (_, i) => `thinking ${i} keeping the frame tall`).join('\n');
+      const commit = (s: string): void => { c.setOverlay(overlay); c.commitAbove(s); };
+      commit('HEADER-MARKER Diagnosis summary\n\n');
+      for (let i = 1; i <= 6; i++) commit(`PROSE-${String(i).padStart(2, '0')} report line\n\n`);
+      const table = renderMarkdownToTerminal(TABLE_MD, { maxWidth: 100 - 2 }).replace(/\n+$/, '');
+      commit(`${table}\nBODY-TAIL-ROW final line of report\n\n`);
+      c.setSpinner({ enabled: false });
+      c.setOverlay('');
+      const ix = c as unknown as Repaintable;
+      ix.repaint();
+      ix.repaint();
+      await settle();
+    },
+    expect: {
+      inViewport: ['HEADER-MARKER', 'PROSE-01', 'PROSE-06', 'BODY-TAIL-ROW', 'pass cwd to scheduler'],
+      exactlyOnce: [
+        'HEADER-MARKER', 'PROSE-01', 'PROSE-03', 'PROSE-06',
+        'BODY-TAIL-ROW', 'pass cwd to scheduler', 'thread cwd through daemon',
+        'Nature', // table header cell — guards the duplicate-header regression
+      ],
+      maxViewportBlankRun: 1,
+      order: [['HEADER-MARKER', 'PROSE-01'], ['PROSE-06', 'BODY-TAIL-ROW']],
+    },
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // overflow-gap: a multi-line markdown table committed under a tall overlay
+  // (extraRows=2 production footer geometry), then collapse. The table header
+  // must appear EXACTLY ONCE (pre-fix: one scrollback copy + one truncated
+  // on-screen copy) with the body intact and no void. Mirrors
+  // terminal-compositor.overflow-gap.test.ts.
+  // ─────────────────────────────────────────────────────────────────────────
+  'overflow-gap': {
+    description: 'table committed under a tall overlay collapses with no duplicate header and no void',
+    cols: 120,
+    rows: 24,
+    ref: 'terminal-compositor.overflow-gap.test.ts',
+    async drive({ stdout, stdin }): Promise<void> {
+      const statusLine = wireStatusLine(stdout, 'M');
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: () => {}, scrollRegion: statusLine, anchorRow: 1 });
+      await c.arm();
+      statusLine.setExtraRows(2); // StatusLine + LoopStageBar + VerdictLedger
+      c.setSpinner({ enabled: true });
+      const tableText = renderMarkdownToTerminal(TABLE_MD, { width: 120 }).replace(/\n$/, '');
+      const tallOverlay = Array.from({ length: 14 }, (_, i) => `thinking ${i} — dispatched subagent, verifying claim ${i}`).join('\n');
+      c.setOverlay(tallOverlay); c.commitAbove('Diagnosis complete\n\n');
+      c.setOverlay(tallOverlay); c.commitAbove('What I diagnosed: the TUI rendering defect in your screenshot.\n\n');
+      c.setOverlay(tallOverlay); c.commitAbove(tableText + '\n\n');
+      c.setOverlay(tallOverlay); c.commitAbove('Evidence (deterministic, reproduced): header + divider render, then a gap.\n\n');
+      c.setOverlay('');
+      const ix = c as unknown as Repaintable;
+      ix.repaint();
+      ix.repaint();
+      await settle();
+    },
+    expect: {
+      inViewport: ['pass cwd to scheduler', 'load config from cwd', 'thread cwd through daemon', 'Diagnosis complete'],
+      // "Nature" is the table header cell — appears once iff the header is not
+      // duplicated (the exact pre-fix symptom: one scrollback + one on-screen copy).
+      exactlyOnce: ['pass cwd to scheduler', 'load config from cwd', 'thread cwd through daemon', 'Diagnosis complete', 'Nature'],
+      maxViewportBlankRun: 1,
+    },
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // shrink-gap: a committed line above a tall overlay; then the overlay
+  // collapses while a spinner appears (a shrink). The committed line must
+  // re-pin adjacent to the frame — not stranded with a blank void below it.
+  // Mirrors terminal-compositor.shrink-gap.test.ts.
+  // ─────────────────────────────────────────────────────────────────────────
+  'shrink-gap': {
+    description: 'committed line re-pins adjacent to the frame after the overlay shrinks (no gap)',
+    cols: 80,
+    rows: 24,
+    ref: 'terminal-compositor.shrink-gap.test.ts',
+    async drive({ stdout, stdin }): Promise<void> {
+      // shrink-gap.test.ts uses a minimal scroll region, not a StatusLine.
+      const scrollRegion = {
+        withFullScrollRegion<T>(fn: () => T): T {
+          stdout.write('\x1b[s');
+          stdout.write('\x1b[r');
+          stdout.write('\x1b[u');
+          try {
+            return fn();
+          } finally {
+            const rows = stdout.rows ?? 24;
+            stdout.write('\x1b[s');
+            stdout.write(`\x1b[1;${rows}r`);
+            stdout.write('\x1b[u');
+          }
+        },
+        getExtraRows(): number { return 0; },
+      };
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: () => {}, scrollRegion, anchorRow: 1 });
+      await c.arm();
+      const tall = Array.from({ length: 12 }, (_, i) => `stream line ${i}`).join('\n');
+      c.setOverlay(tall);
+      c.commitAbove('COMMITTED_TOOL_OUTPUT_LINE\n');
+      c.setSpinner({ enabled: true });
+      c.setOverlay('');
+      const ix = c as unknown as Repaintable;
+      ix.repaint();
+      ix.repaint();
+      await settle();
+    },
+    expect: {
+      inViewport: ['COMMITTED_TOOL_OUTPUT_LINE'],
+      exactlyOnce: ['COMMITTED_TOOL_OUTPUT_LINE'],
+      maxViewportBlankRun: 1,
+    },
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // first-turn-image-echo (#509): the FIRST commitAbove after arm, following a
+  // pre-arm banner and a pre-submit chrome cycle. The echoed submit card must
+  // commit exactly once (no orphan/duplicate copies), its body must survive
+  // streaming growth, and every banner row must remain intact. Mirrors
+  // terminal-compositor.first-turn-banner-echo.test.ts.
+  // ─────────────────────────────────────────────────────────────────────────
+  'first-turn-image-echo': {
+    description: 'first commit after banner echoes the submit card once and preserves banner + body',
+    cols: 80,
+    rows: 24,
+    ref: '#509 · terminal-compositor.first-turn-banner-echo.test.ts',
+    async drive({ stdout, stdin }): Promise<void> {
+      const BANNER_ROWS = 11;
+      const MESSAGE = 'Reply with only the word ok and nothing else. DUPCHECK alpha bravo charlie delta echo foxtrot golf hotel india';
+      for (let i = 0; i < BANNER_ROWS; i++) stdout.write(`BANNER_LINE_${i}\n`);
+      const statusLine = wireProductionFooter(stdout, 'M');
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: () => {}, scrollRegion: statusLine, anchorRow: BANNER_ROWS + 1 });
+      await c.arm();
+      const ix = c as unknown as Repaintable;
+      // Pre-submit chrome cycle: transient chrome then collapse back to idle.
+      c.setOverlay('preflight-line');
+      c.setOverlay('');
+      const echo = formatSubmittedEcho({ buffer: MESSAGE, promptText: 'afk (haiku)  › ', isTTY: true, terminalWidth: 80 });
+      for (const line of echo.split('\n')) c.commitAbove(line);
+      c.commitAbove('');
+      c.setSpinner({ enabled: true });
+      for (let g = 2; g <= 14; g += 3) {
+        c.setOverlay(Array.from({ length: g }, (_, i) => `stream-row ${g}.${i}`).join('\n'));
+      }
+      c.commitAbove('RESPONSE_OK');
+      c.setSpinner({ enabled: false });
+      c.setOverlay('');
+      ix.repaint();
+      ix.repaint();
+      await settle();
+    },
+    expect: {
+      exactlyOnce: [
+        'DUPCHECK', 'india', 'RESPONSE_OK',
+        'BANNER_LINE_0', 'BANNER_LINE_5', 'BANNER_LINE_10',
+      ],
+      order: [['BANNER_LINE_10', 'DUPCHECK'], ['DUPCHECK', 'india'], ['india', 'RESPONSE_OK']],
+    },
+  },
+};
+
+export type ScenarioName = keyof typeof SCENARIOS;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,7 +25,10 @@ export default defineConfig({
     // Exclude live/network tests from the default run — they require RUN_LIVE_API=1
     // and real credentials. Run them explicitly:
     //   RUN_LIVE_API=1 pnpm vitest run src/agent/providers/anthropic-direct.live.test.ts
-    exclude: ['**/node_modules/**', '**/dist/**', '**/*.live.test.ts'],
+    // Exclude the real-PTY harness (*.pty.test.ts) — it needs the native
+    // node-pty build and a real pseudo-terminal; run it via `pnpm test:pty`
+    // (vitest.pty.config.ts). See tests/pty/ and issue #541.
+    exclude: ['**/node_modules/**', '**/dist/**', '**/*.live.test.ts', '**/*.pty.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/vitest.pty.config.ts
+++ b/vitest.pty.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Dedicated config for the real-PTY scrollback harness (issue #541).
+ *
+ * These tests spawn a native pseudo-terminal (node-pty) per scenario and drive
+ * the real TerminalCompositor through it, then assert on a reconstructed xterm
+ * emulator's SCROLLBACK buffer. They are split out of the default `pnpm test`
+ * run (which excludes the pty-test glob) because:
+ *   - they need the native node-pty build (not required by the rest of the suite),
+ *   - pty timing can be flaky → `retry`, and
+ *   - concurrent ptys contend → serial execution.
+ *
+ * Run with: `pnpm test:pty`.
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    setupFiles: [
+      './src/__test-utils__/stdin-claim-reset.ts',
+      './src/__test-utils__/redirect-paths-env.ts',
+      './src/__test-utils__/clean-config-env.ts',
+    ],
+    include: ['tests/pty/**/*.pty.test.ts'],
+    exclude: ['**/node_modules/**', '**/dist/**'],
+    // Real ptys are timing-sensitive; a spawn/flush hiccup should retry, not
+    // fail the gate. Two retries is enough to absorb transient CI jitter.
+    retry: 2,
+    // Never run two ptys at once — they contend on stdin/stdout scheduling.
+    fileParallelism: false,
+    maxConcurrency: 1,
+    // Each test spawns node+tsx+native build; give the harness generous headroom.
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});


### PR DESCRIPTION
## Summary

Closes #541. Adds a `node-pty` + `@xterm/headless` integration harness that drives the **real** `TerminalCompositor` through a **real pseudo-terminal** and asserts committed lines land in the emulator's **scrollback** buffer — the property that mock-stdout / in-process xterm tests cannot certify (`docs/scrollback.md:9-13,108-111`).

Two prior scrollback fixes (`6d7cb90`, `9690b9f`) shipped green and were broken in reality; the #539 collapse-void fix needed manual iTerm2 A/B validation (`scripts/visual-void-repro.ts`). This harness is the missing net that turns "green but maybe broken" into "green means correct" for the whole gap-class and every future compositor change.

## Acceptance criteria

- [x] `node-pty` dev-dep + a `test:pty` harness driving a real PTY into xterm
- [x] Assertions read the emulator **scrollback** buffer, not raw bytes
- [x] Covers collapse-void (#539), multi-commit-gap, overflow-gap, shrink-gap, first-turn image echo (#509)
- [x] Wired into CI (dedicated, quarantinable `test-pty` job)

## How it works (`tests/pty/`)

| File | Role |
|------|------|
| `scenarios.ts` | 5 gap-class geometries driven against the real compositor, each with an `expect` block (`inScrollback` / `inViewport` / `exactlyOnce` / `order` / `maxViewportBlankRun`). |
| `driver.ts` | In-pty entry (`node --import tsx`) that runs one scenario and emits an APC completion sentinel (ignored by xterm → never perturbs the geometry). Deliberately does **not** `disarm()`, so the parent snapshots the final live frame. |
| `harness.ts` | Spawns the pty (node-pty), captures output up to the sentinel, replays it into `@xterm/headless`, and splits the buffer into scrollback (rows above `baseY`) / viewport. |
| `compositor-scrollback.pty.test.ts` | Per-scenario assertions on the reconstructed buffer. |

Two scenarios exercise genuine scrollback depth (observed while building): `multi-commit-gap` overflows the oldest committed lines into scrollback (`baseY=2`), and `first-turn-image-echo` pushes all 11 banner rows into scrollback (`baseY=13`). All five prove no void / duplication / loss across the collapse geometries.

## Wiring

- `node-pty` → `devDependencies` **and** `pnpm.onlyBuiltDependencies` (the same native-build path `better-sqlite3` already uses — Linux compiles from source, macOS uses the shipped prebuild).
- `test:pty` script + `vitest.pty.config.ts` (serial, `retry: 2`, 60s timeout).
- Excluded from the default `pnpm test` run via the `*.pty.test.ts` glob (needs the native build).
- New CI job `test-pty` (real gate; a comment documents flipping it to `continue-on-error` if PTY flakiness ever destabilises CI).
- `docs/scrollback.md` updated — the "None exists today" note now points at `tests/pty/`.

## Reviewer notes

- **CRLF:** real pty output already carries CRLF (kernel ONLCR), so the emulator must **not** set `convertEol` — unlike the in-process `@xterm/headless` tests, which feed raw LF-only captured bytes.
- **spawn-helper:** the harness self-heals node-pty's `spawn-helper` executable bit, which pnpm's prebuild extraction strips on macOS (`posix_spawnp failed` otherwise). Idempotent; no-op on Linux source builds.
- **Gate:** node-pty missing is a hard failure in CI (`CI` env) or with `AFK_PTY_REQUIRED=1`; locally it degrades to a skip so a dev without the native build isn't blocked.
- No `src/` changes — this is test infrastructure only.

## Verification (local, all green)

`pnpm lint` · `pnpm test` (634 files, 11527 passed, 0 failed) · `pnpm test:pty` (5/5, incl. after `pnpm install --frozen-lockfile`) · `pnpm build` · `pnpm build:dist` · `pnpm audit:sdk:check` · `pnpm audit:env:check` · `pnpm scan:env:check` · `pnpm audit:deps`
