### PR TITLE
fix(subagent): grant ~/.afk/state to confined forks; harden worktree main-root fallback

### DIFF
--- a/src/agent/subagent-read-scope.test.ts
+++ b/src/agent/subagent-read-scope.test.ts
@@ -124,4 +124,75 @@ describe('computeInheritedReadRoots', () => {
       expect(roots).toBeUndefined();
     });
   });
+
+  describe('afkStateRoot grant (confined forks reach ~/.afk/state — Gap A)', () => {
+    const STATE = '/Users/me/.afk/state';
+
+    it('folds the AFK state dir into a confined worktree fork union', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: '/repo/.afk-worktrees/wt',
+        childCwd: '/repo/.afk-worktrees/wt',
+        worktreeMainRoot: '/repo',
+        afkStateRoot: STATE,
+      })!;
+      expect(new Set(roots)).toEqual(
+        new Set(['/repo/.afk-worktrees/wt', '/repo', STATE]),
+      );
+      // A skill-preflight staged input under the state dir is now admitted
+      // (containment is lexical: path.relative does not escape the root).
+      expect(
+        path.relative(STATE, `${STATE}/skill-preflight/pr-548.diff`).startsWith('..'),
+      ).toBe(false);
+    });
+
+    it('grants [cwd, state] even with no worktree main root (state lifts the fork out of the [cwd] default)', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: '/plain/repo',
+        childCwd: '/plain/repo',
+        worktreeMainRoot: undefined,
+        afkStateRoot: STATE,
+      });
+      // Without afkStateRoot this is the "only root is cwd" case → undefined.
+      expect(new Set(roots)).toEqual(new Set(['/plain/repo', STATE]));
+    });
+
+    it('is ignored for an unconfined (read-open) parent — read-open already covers state', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: undefined,
+        childCwd: '/repo/.afk-worktrees/wt',
+        afkStateRoot: STATE,
+      });
+      expect(roots).toEqual([FS_ROOT]); // read-open, not [.., STATE]
+    });
+
+    it('omitting afkStateRoot preserves the pre-fix behaviour (back-compat)', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: '/repo',
+        childCwd: '/repo',
+        worktreeMainRoot: undefined,
+      });
+      expect(roots).toBeUndefined();
+    });
+
+    it('never derives ~/.afk/config — only the exact state root passed', () => {
+      const roots = computeInheritedReadRoots({
+        parentReadRoots: undefined,
+        parentCwd: '/repo/.afk-worktrees/wt',
+        childCwd: '/repo/.afk-worktrees/wt',
+        worktreeMainRoot: '/repo',
+        afkStateRoot: STATE,
+      })!;
+      const CONFIG = '/Users/me/.afk/config';
+      // The credential dir is a sibling of state; it must never be granted, and
+      // no granted root may lexically admit a config path.
+      expect(roots.some((r) => path.resolve(r) === CONFIG)).toBe(false);
+      expect(
+        roots.every((r) => path.relative(r, `${CONFIG}/afk.env`).startsWith('..')),
+      ).toBe(true);
+    });
+  });
 });

--- a/src/agent/subagent-read-scope.ts
+++ b/src/agent/subagent-read-scope.ts
@@ -67,6 +67,21 @@ export interface InheritedReadRootsArgs {
    * and containment is lexical — every sibling worktree too.
    */
   worktreeMainRoot?: string | undefined;
+  /**
+   * The AFK state directory (`~/.afk/state`, or the `$AFK_STATE_DIR` override).
+   * Folded into a CONFINED fork's read union so it can reach the runtime-state
+   * paths that pervade its prompt/context — skill-preflight staged inputs (e.g.
+   * a PR diff a `/review` fan-out hands its children), todos, transcripts, and
+   * per-session ledgers — none of which a worktree/confined parent's cwd+repo
+   * roots lexically contain, so every such read was hard-denied (forks cannot
+   * prompt) until a wall-clock timeout.
+   *
+   * Pass the STATE dir ONLY — NEVER `~/.afk/config`, which holds `afk.env`
+   * credentials: read scope must not widen to secrets. Ignored by the unconfined
+   * branch (already read-open). `undefined` adds nothing, so a caller that omits
+   * it gets byte-for-byte the pre-fix behaviour.
+   */
+  afkStateRoot?: string | undefined;
 }
 
 /**
@@ -78,16 +93,17 @@ export interface InheritedReadRootsArgs {
  *    the child inherits read-open — `[readOpenRootFor(childCwd)]`. Writes stay
  *    confined to the child's own cwd/writeRoots.
  *  - Parent CONFINED (explicit `parentReadRoots`, or a defined `parentCwd`):
- *    the child gets the UNION of the parent's roots, its own cwd, and the
- *    worktree main root — never narrower than the parent (child read scope ⊇
- *    parent read scope), never write-relevant.
+ *    the child gets the UNION of the parent's roots, its own cwd, the worktree
+ *    main root, and the AFK state dir ({@link InheritedReadRootsArgs.afkStateRoot})
+ *    — never narrower than the parent (child read scope ⊇ parent read scope),
+ *    never write-relevant.
  *
  * Returns a de-duplicated, resolved array. `undefined` only when there is
  * genuinely nothing to grant (no child cwd, no parent scope) — the caller then
  * leaves the provider default untouched.
  */
 export function computeInheritedReadRoots(args: InheritedReadRootsArgs): string[] | undefined {
-  const { parentReadRoots, parentCwd, childCwd, worktreeMainRoot } = args;
+  const { parentReadRoots, parentCwd, childCwd, worktreeMainRoot, afkStateRoot } = args;
   const resolvedChildCwd =
     childCwd !== undefined && childCwd !== '' ? path.resolve(childCwd) : undefined;
 
@@ -112,6 +128,14 @@ export function computeInheritedReadRoots(args: InheritedReadRootsArgs): string[
   }
   if (worktreeMainRoot !== undefined && worktreeMainRoot !== '') {
     roots.add(path.resolve(worktreeMainRoot));
+  }
+  // The AFK state dir (~/.afk/state) — runtime state a confined fork's cwd+repo
+  // roots do not lexically contain (skill-preflight inputs, todos, transcripts,
+  // session ledgers). Callers pass the state dir only, never ~/.afk/config
+  // (credentials). Added AFTER the cwd/parent/worktree roots so the size checks
+  // below correctly see it as a broadening grant.
+  if (afkStateRoot !== undefined && afkStateRoot !== '') {
+    roots.add(path.resolve(afkStateRoot));
   }
 
   // Nothing to grant, OR the only root is the child's own cwd (which equals the

--- a/src/agent/subagent-worktree-readroot.test.ts
+++ b/src/agent/subagent-worktree-readroot.test.ts
@@ -63,10 +63,15 @@ vi.mock('./worktree-read-root.js', () => ({
 
 import { SubagentManager } from './subagent.js';
 import { resolveWorktreeMainRoot } from './worktree-read-root.js';
+import { getAfkStateDir } from '../paths.js';
 
 const WORKTREE = '/repo/.afk-worktrees/wt';
 const MAIN = '/repo';
 const FS_ROOT = path.parse(path.resolve('.')).root || path.sep;
+// A CONFINED fork is additionally granted the AFK state dir (Gap A) so it can
+// read ~/.afk/state (skill-preflight inputs, todos, transcripts). Not mocked —
+// the real resolver is deterministic for the process.
+const STATE = getAfkStateDir();
 
 const mockedResolve = vi.mocked(resolveWorktreeMainRoot);
 
@@ -86,14 +91,14 @@ describe('forkSubagent — worktree main-repo read-root grant', () => {
     mockedResolve.mockResolvedValue(undefined);
   });
 
-  it('grants [cwd, mainRoot] when the manager cwd is a linked worktree', async () => {
+  it('grants [cwd, mainRoot, state] when the manager cwd is a linked worktree', async () => {
     mockedResolve.mockResolvedValue(MAIN);
     const mgr = new SubagentManager({ cwd: WORKTREE });
     await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' }));
 
     const cfg = shared.lastConfig as { cwd?: string; readRoots?: string[] } | null;
     expect(cfg?.cwd).toBe(WORKTREE);
-    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN]);
+    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN, STATE]);
     expect(mockedResolve).toHaveBeenCalledWith(WORKTREE);
   });
 
@@ -113,15 +118,15 @@ describe('forkSubagent — worktree main-repo read-root grant', () => {
     expect(mockedResolve).not.toHaveBeenCalled();
   });
 
-  it('does NOT set readRoots when cwd is not a worktree (resolver returns undefined)', async () => {
+  it('grants [cwd, state] when cwd is not a worktree (no main root, but state still reachable — Gap A)', async () => {
     mockedResolve.mockResolvedValue(undefined);
     const mgr = new SubagentManager({ cwd: '/plain/repo' });
     await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' }));
 
     const cfg = shared.lastConfig as { cwd?: string; readRoots?: string[] } | null;
     expect(cfg?.cwd).toBe('/plain/repo');
-    // Left unset so the provider applies its own `[cwd]` default.
-    expect(cfg?.readRoots).toBeUndefined();
+    // No distinct worktree main root, but a confined fork still needs ~/.afk/state.
+    expect(cfg?.readRoots).toEqual(['/plain/repo', STATE]);
   });
 
   it('does NOT override caller-pinned readRoots (e.g. afk farm) and skips resolution', async () => {
@@ -143,8 +148,9 @@ describe('forkSubagent — worktree main-repo read-root grant', () => {
     await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' }));
 
     const cfg = shared.lastConfig as { readRoots?: string[]; writeRoots?: string[] } | null;
-    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN]);
+    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN, STATE]);
     // writeRoots untouched → provider defaults writes to [cwd] = the worktree.
+    // The read-side state grant must NOT leak into writeRoots.
     expect(cfg?.writeRoots).toBeUndefined();
   });
 
@@ -156,22 +162,41 @@ describe('forkSubagent — worktree main-repo read-root grant', () => {
     expect(mockedResolve).toHaveBeenCalledTimes(1);
   });
 
-  it('does not set readRoots when the resolved main root equals cwd (defensive)', async () => {
+  it('grants [cwd, state] when the resolved main root equals cwd (no distinct main root)', async () => {
     mockedResolve.mockResolvedValue(WORKTREE);
     const mgr = new SubagentManager({ cwd: WORKTREE });
     await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' }));
 
     const cfg = shared.lastConfig as { readRoots?: string[] } | null;
-    expect(cfg?.readRoots).toBeUndefined();
+    // No distinct main root to add, but the confined fork still gets ~/.afk/state.
+    expect(cfg?.readRoots).toEqual([WORKTREE, STATE]);
   });
 
-  it('does not resolve or set readRoots when no cwd is available anywhere', async () => {
-    const mgr = new SubagentManager(); // no cwd
+  it('does not resolve or set readRoots when no cwd is available anywhere (unconfined)', async () => {
+    const mgr = new SubagentManager(); // no cwd → UNCONFINED parent
     await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k' })); // no config.cwd
 
     const cfg = shared.lastConfig as { readRoots?: string[] } | null;
+    // Unconfined → no state grant (read-open already covers it), no resolution.
     expect(cfg?.readRoots).toBeUndefined();
     expect(mockedResolve).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the parent worktree for the main root when the child cwd does not resolve (Gap B)', async () => {
+    const CHILD = '/some/unrelated/dir';
+    // Child cwd is not a linked worktree (resolves to nothing); the PARENT is.
+    mockedResolve.mockImplementation(async (cwd?: string) =>
+      cwd === WORKTREE ? MAIN : undefined,
+    );
+    const mgr = new SubagentManager({ cwd: WORKTREE });
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k', cwd: CHILD }));
+
+    const cfg = shared.lastConfig as { readRoots?: string[] } | null;
+    // MAIN is recovered from the parent worktree even though CHILD did not resolve,
+    // so the fork can still read the main checkout + siblings (plus state).
+    expect(new Set(cfg?.readRoots)).toEqual(new Set([CHILD, WORKTREE, MAIN, STATE]));
+    expect(mockedResolve).toHaveBeenCalledWith(CHILD);
+    expect(mockedResolve).toHaveBeenCalledWith(WORKTREE);
   });
 });
 

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -37,6 +37,7 @@ import { getCurrentSink } from './_lib/skill-sink-channel.js';
 import { touchWorktreeOccupancy } from './worktree-occupancy.js';
 import { resolveWorktreeMainRoot } from './worktree-read-root.js';
 import { computeInheritedReadRoots } from './subagent-read-scope.js';
+import { getAfkStateDir } from '../paths.js';
 import { buildPhaseRestrictedProvider, type PhaseRole } from './tools/nesting.js';
 import { applyManagerApiKeyFallback } from './tools/child-credential.js';
 import { providerForModel, type BundledProviderName } from './providers/index.js';
@@ -570,20 +571,41 @@ export class SubagentManager {
       // An UNCONFINED parent yields a read-open child regardless of the worktree
       // main root, so skip the (cached) git resolution in that case — the common
       // top-level `afk` fan-out never pays for it. For a CONFINED parent the main
-      // root is best-effort; on git failure the parentCwd/parentReadRoots union
-      // still supplies the repo root, so the #441 silent-fail is no longer
-      // load-bearing.
+      // root is best-effort; on git failure we ALSO try the parent cwd (Gap B
+      // below) so a confined *worktree* parent's fork still reaches the main
+      // checkout + siblings, and the child is additionally granted the AFK state
+      // dir (Gap A below) so ~/.afk/state reads are not hard-denied.
       const parentUnconfined =
         this.parentReadRoots === undefined && this.parentCwd === undefined;
-      const worktreeMainRoot =
-        !parentUnconfined && effectiveChildCwd !== undefined
-          ? await this.resolveMainRootForCwd(effectiveChildCwd)
-          : undefined;
+      let worktreeMainRoot: string | undefined;
+      if (!parentUnconfined && effectiveChildCwd !== undefined) {
+        worktreeMainRoot = await this.resolveMainRootForCwd(effectiveChildCwd);
+        // Gap B: when the child cwd yields no distinct main root (git failure, or
+        // the child cwd is not itself a linked worktree), fall back to the PARENT
+        // cwd. A confined parent is frequently ITSELF a linked worktree (`afk -w`);
+        // resolving from it recovers the repo root, which lexically covers the main
+        // checkout AND every sibling `.afk-worktrees/*` the fork would otherwise be
+        // hard-denied. Best-effort + cached; strictly additive (only ever adds a
+        // read root when one is found).
+        if (
+          worktreeMainRoot === undefined &&
+          this.parentCwd !== undefined &&
+          this.parentCwd !== effectiveChildCwd
+        ) {
+          worktreeMainRoot = await this.resolveMainRootForCwd(this.parentCwd);
+        }
+      }
       inheritedReadRoots = computeInheritedReadRoots({
         parentReadRoots: this.parentReadRoots,
         parentCwd: this.parentCwd,
         childCwd: effectiveChildCwd,
         worktreeMainRoot,
+        // Gap A: a CONFINED fork's cwd+repo roots do not lexically contain
+        // ~/.afk/state, so skill-preflight inputs, todos, transcripts, and
+        // session ledgers were hard-denied (forks cannot prompt). Grant the STATE
+        // dir only — NEVER ~/.afk/config (credentials). Unconfined forks are
+        // already read-open, so this is a confined-parent-only grant.
+        ...(parentUnconfined ? {} : { afkStateRoot: getAfkStateDir() }),
       });
     }
 

--- a/src/agent/worktree-read-root.test.ts
+++ b/src/agent/worktree-read-root.test.ts
@@ -97,24 +97,54 @@ describe('resolveWorktreeMainRoot', () => {
     expect(exec).not.toHaveBeenCalled();
   });
 
-  it('returns undefined (never throws) when git fails', async () => {
-    const exec = failingGit();
-    await expect(resolveWorktreeMainRoot(WORKTREE, exec)).resolves.toBeUndefined();
+  it('recovers the main root lexically for an .afk-worktrees path when git fails (#544/#554 gap)', async () => {
+    // The exact failure behind the read-denial screenshot: git rev-parse throws
+    // on the fork's OWN worktree cwd (a pruned/mid-sweep admin dir). afk
+    // worktrees encode the main root in the path, so recover it WITHOUT git
+    // rather than re-confining the fork to the worktree.
+    await expect(resolveWorktreeMainRoot(WORKTREE, failingGit())).resolves.toBe(MAIN);
   });
 
-  it('logs the confinement degradation under AFK_DEBUG when git fails (#441)', async () => {
-    // The silent return re-confines a forked child to its worktree with no
-    // signal; under AFK_DEBUG=1 the degradation must be observable so an
+  it('recovers the main root for a subdir INSIDE an .afk-worktrees worktree when git fails', async () => {
+    await expect(
+      resolveWorktreeMainRoot(`${WORKTREE}/src/deep`, failingGit()),
+    ).resolves.toBe(MAIN);
+  });
+
+  it('returns undefined (never throws) when git fails for a NON-afk path', async () => {
+    await expect(
+      resolveWorktreeMainRoot('/plain/repo/sub', failingGit()),
+    ).resolves.toBeUndefined();
+  });
+
+  it('logs the confinement degradation under AFK_DEBUG when git fails for a non-afk path (#441)', async () => {
+    // A non-afk path has no lexical anchor, so the fork is genuinely confined to
+    // its worktree; under AFK_DEBUG=1 that degradation must stay observable so an
     // unexpectedly-confined subagent is diagnosable.
     const prev = process.env['AFK_DEBUG'];
     process.env['AFK_DEBUG'] = '1';
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     try {
-      const root = await resolveWorktreeMainRoot(WORKTREE, failingGit());
+      const root = await resolveWorktreeMainRoot('/plain/repo/sub', failingGit());
       expect(root).toBeUndefined();
       expect(logSpy).toHaveBeenCalledWith(
         expect.stringContaining('[worktree-read-root]'),
       );
+    } finally {
+      logSpy.mockRestore();
+      if (prev === undefined) delete process.env['AFK_DEBUG'];
+      else process.env['AFK_DEBUG'] = prev;
+    }
+  });
+
+  it('logs the lexical recovery under AFK_DEBUG when git fails for an .afk-worktrees path', async () => {
+    const prev = process.env['AFK_DEBUG'];
+    process.env['AFK_DEBUG'] = '1';
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const root = await resolveWorktreeMainRoot(WORKTREE, failingGit());
+      expect(root).toBe(MAIN);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('recovered main'));
     } finally {
       logSpy.mockRestore();
       if (prev === undefined) delete process.env['AFK_DEBUG'];

--- a/src/agent/worktree-read-root.ts
+++ b/src/agent/worktree-read-root.ts
@@ -40,10 +40,18 @@
  *   - `cwd` is not inside a git repository,
  *   - `cwd` is inside the MAIN worktree (its root or a subdir) — nothing
  *     distinct to grant,
- *   - git resolution fails for any reason.
+ *   - git resolution fails AND `cwd` is not an afk-managed worktree.
  *
- * Best-effort: never throws. A resolution failure degrades to today's behavior
- * (worktree-only read root).
+ * Git-free fallback (#544/#554 completion): when `git rev-parse` throws on an
+ * afk-managed worktree (`<mainRoot>/.afk-worktrees/<slug>`), the main root is
+ * recovered LEXICALLY from the path. This closes the gap where a pruned or
+ * mid-sweep worktree admin dir makes git fail on the fork's OWN cwd — a case
+ * re-resolving via git (from any cwd, e.g. #554's parent-cwd fallback) cannot
+ * fix — which otherwise silently re-confines the fork to `[worktree]` and hard-
+ * denies every main-repo read.
+ *
+ * Best-effort: never throws. A git failure on a NON-afk path still degrades to
+ * today's behavior (worktree-only read root).
  *
  * @module agent/worktree-read-root
  */
@@ -63,6 +71,31 @@ export type ExecFileFn = (
 
 const defaultExecFile: ExecFileFn = (cmd, args) =>
   execFilePromise(cmd, args) as Promise<{ stdout: string; stderr: string }>;
+
+/**
+ * Git-free recovery of the main-repo root for an afk-managed worktree.
+ *
+ * Invariant: afk worktrees are created at `<mainRoot>/.afk-worktrees/<slug>`
+ * (see `tools/handlers/worktree-managed.ts` and `worktree-sweep.ts`), so the
+ * main root is the path prefix preceding the `.afk-worktrees/` segment —
+ * derivable WITHOUT git. This is the load-bearing fallback for the case
+ * #544/#554 left open: when `git rev-parse` fails on the fork's OWN worktree
+ * cwd (a pruned/mid-sweep admin dir), re-resolving via git — from any cwd —
+ * cannot recover the main root, so a purely lexical path is the only remedy.
+ *
+ * Returns undefined for any path not under an `.afk-worktrees/` segment (a
+ * relocated `AFK_WORKTREE_BASE`, or a non-afk worktree), leaving today's
+ * best-effort `undefined` in place there.
+ */
+function lexicalAfkWorktreeMainRoot(cwd: string): string | undefined {
+  const resolved = path.resolve(cwd);
+  const marker = `${path.sep}.afk-worktrees${path.sep}`;
+  const idx = resolved.indexOf(marker);
+  // idx <= 0 covers "not found" (−1) and the degenerate "at the filesystem
+  // root" (0), where there is no non-empty prefix to grant.
+  if (idx <= 0) return undefined;
+  return resolved.slice(0, idx);
+}
 
 /**
  * Resolve the main repository root for a worktree at `cwd`. See the module
@@ -106,11 +139,25 @@ export async function resolveWorktreeMainRoot(
 
     return mainRoot;
   } catch (err) {
-    // Not a git repo, git missing, or any other failure — best-effort. But this
-    // silent return re-confines a forked child to `[worktree]` (the #416
-    // symptom returns) with no signal, so surface the degradation under
-    // AFK_DEBUG=1 — otherwise a subagent that unexpectedly loses main-repo read
-    // access is undiagnosable (#441).
+    // Not a git repo, git missing, or any other failure — best-effort. afk
+    // worktrees encode their main root in the path, so try a git-free lexical
+    // recovery FIRST: this is exactly the case #544/#554 left open — a
+    // pruned/mid-sweep worktree admin dir makes `git rev-parse` throw on the
+    // fork's OWN cwd, and re-resolving via git cannot help. Recovery keeps the
+    // fork's main-repo read access instead of silently re-confining it.
+    const lexical = lexicalAfkWorktreeMainRoot(cwd);
+    if (lexical !== undefined) {
+      debugLog(
+        `[worktree-read-root] git rev-parse failed for cwd=${cwd}; recovered main ` +
+          `root lexically as ${lexical} (afk worktree layout) — ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+      );
+      return lexical;
+    }
+    // Non-afk path with no lexical anchor: the silent return re-confines a
+    // forked child to `[worktree]` (the #416 symptom returns) with no signal,
+    // so surface the degradation under AFK_DEBUG=1 — otherwise a subagent that
+    // unexpectedly loses main-repo read access is undiagnosable (#441).
     debugLog(
       `[worktree-read-root] git rev-parse failed for cwd=${cwd}; child confined ` +
         `to worktree only — ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
## Summary

Completes the read-scope fix started in #544. That PR fixed forks of **unconfined** top-level sessions (`afk`/`afk i` with no worktree → read-open child), but forks of **confined** parents (worktree `-w`, skill fan-outs) still hit `PreToolUse` auto-denials. A fork cannot prompt, so any read outside its inherited `readRoots` is hard-blocked — and the child spins on retried denials until the 20-min `SUBAGENT_DEFAULT_TIMEOUT_MS`.

This is the root cause behind the `tool-failure-compose` signal (**24% of compose calls — 130/545 — completed with ≥1 failed node**, durations up to ~35 min) and live **post-#544** denials observed in running sessions: `~/.afk/state/skill-preflight/*.diff`, the main repo, and sibling worktrees.

## Two gaps closed

**Gap A — confined forks could not read `~/.afk/state`.** The confined-parent read union `{childCwd, parentRoots, worktreeMainRoot}` never included the AFK state dir, so skill-preflight staged inputs (e.g. a PR diff a `/review` fan-out hands its children), todos, transcripts, and per-session ledgers were denied. Now the **state** dir is folded into the union — **never `~/.afk/config`** (that holds `afk.env` credentials; read scope must not widen to secrets).

**Gap B — confined *worktree* parents lost the main checkout + siblings** when `resolveWorktreeMainRoot(childCwd)` returned `undefined` (git failure, or `childCwd` is not itself a linked worktree). We now fall back to resolving from the **parent** cwd — for an `afk -w` parent that is a worktree whose main root lexically covers the main checkout and every sibling `.afk-worktrees/*`.

## Safety

- Both changes are **read-only, additive** grants. Writes stay confined (separate `writeRoots` axis) — asserted by an existing test.
- **Unconfined** forks are unchanged (already read-open; the state grant is gated to confined parents only).
- Callers that **pin `readRoots`** (`afk farm`) are untouched (inheritance is skipped when `readRoots` is set).
- `~/.afk/config` is never granted — a unit test asserts no granted root admits a config path.

## Testing

- `computeInheritedReadRoots` unit tests: state dir folded into the confined union; ignored for unconfined; back-compat when omitted; guard that `~/.afk/config` is never admitted.
- `forkSubagent` manager tests: state dir present on confined forks; **Gap B** parent-cwd fallback recovers the main root when the child cwd does not resolve.
- Full suite green: **634 files, 11,539 passed, 0 failed**; `tsc --noEmit` clean; `audit:sdk:check` / `audit:env:check` / `scan:env:check` all pass.

## Files

- `src/agent/subagent-read-scope.ts` — `afkStateRoot` arg folded into the confined union
- `src/agent/subagent.ts` — pass `getAfkStateDir()` (confined only); parent-cwd worktree-main-root fallback
- `src/agent/subagent-read-scope.test.ts`, `src/agent/subagent-worktree-readroot.test.ts` — coverage

---
Diagnosis + fix authored via an AFK session; every load-bearing claim was independently re-derived by a `/shadow-verify` adversarial wave before implementation.


---

## Update — Gap B hardening (commit `a787619`)

Gap B's original parent-cwd fallback does **not** cover the most common real failure: a fork whose cwd **is** the parent's worktree (`childCwd == parentCwd` — e.g. a `/gather` fan-out with no explicit child cwd) when `git rev-parse` throws on that worktree's own admin dir (pruned/mid-sweep). The fallback is guarded by `parentCwd !== effectiveChildCwd`, so it never fires there — and re-resolving the same path via git would fail identically.

This was the **live failure** in witness session `e9f7d80d`: two `/gather` Explore forks auto-denied reading the main checkout + `src/improve` on v5.37.0 (which already shipped #544).

**Fix:** `resolveWorktreeMainRoot` now recovers the main root **lexically** from the path when git fails — afk worktrees live at `<mainRoot>/.afk-worktrees/<slug>`, so the main root is derivable without git. This is the only remedy for a broken worktree admin dir, since no git invocation from any cwd can recover it.

- Strictly additive (only ever **adds** a read root); writes stay confined (separate axis); the `afk farm` guardrail is unaffected (pinned `readRoots` short-circuit resolution before this runs).
- New `resolveWorktreeMainRoot` unit coverage: git-fails + `.afk-worktrees/` path → main root recovered (incl. a subdir inside the worktree); non-afk path → still `undefined`, degradation logged under `AFK_DEBUG` (#441); recovery also logged.
- `tsc --noEmit` clean; full suite green (**11,542 passed / 0 failed**).
