### PR TITLE
fix(subagent): propagate parent read scope to skill/inline/compose forks (#547)

### DIFF
--- a/src/agent/subagent-read-scope.test.ts
+++ b/src/agent/subagent-read-scope.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import path from 'path';
-import { computeInheritedReadRoots, readOpenRootFor } from './subagent-read-scope.js';
+import {
+  computeInheritedReadRoots,
+  readOpenRootFor,
+  resolveChildManagerReadRoots,
+} from './subagent-read-scope.js';
 
 const FS_ROOT = path.parse(path.resolve('.')).root || path.sep;
 
@@ -123,5 +127,66 @@ describe('computeInheritedReadRoots', () => {
       });
       expect(roots).toBeUndefined();
     });
+  });
+});
+
+// #547: the choke point skill / inline-skill / compose managers use to derive
+// their parentReadRoots from the parent session's scope + the child's cwd.
+describe('resolveChildManagerReadRoots', () => {
+  const WORKTREE = '/repo/.afk-worktrees/wt';
+
+  it('grants read-open when the parent session is unconfined and the child has a cwd', () => {
+    // THE #547 fix: a skill fork operating in a worktree under an unconfined
+    // (read-open) parent session must inherit read-open — NOT be re-confined to
+    // [worktree, mainRoot] the way bare cwd-derivation would. Matches the
+    // `agent`-tool behaviour (subagent-worktree-readroot.test.ts).
+    const roots = resolveChildManagerReadRoots(
+      { parentReadRoots: undefined, parentCwd: undefined },
+      WORKTREE,
+    );
+    expect(roots).toEqual([FS_ROOT]);
+  });
+
+  it('unions the child cwd with a confined parent cwd (child ⊇ parent)', () => {
+    const roots = resolveChildManagerReadRoots(
+      { parentReadRoots: undefined, parentCwd: '/repo' },
+      WORKTREE,
+    );
+    expect(roots).toEqual([WORKTREE, '/repo']);
+  });
+
+  it('propagates an explicit (e.g. /allow-dir-widened) parent read scope', () => {
+    const roots = resolveChildManagerReadRoots(
+      { parentReadRoots: ['/repo', '/tmp/data'], parentCwd: '/repo' },
+      WORKTREE,
+    );
+    expect(roots).toEqual([WORKTREE, '/repo', '/tmp/data']);
+  });
+
+  it('returns undefined when child cwd equals the confined parent cwd (leave cwd-derivation)', () => {
+    // The common inline case (e.g. /mint): the child worktree IS the session
+    // cwd, so there is nothing broader to grant — the manager's own
+    // cwd-derivation ([cwd, mainRoot]) already equals the parent scope.
+    const roots = resolveChildManagerReadRoots(
+      { parentReadRoots: undefined, parentCwd: WORKTREE },
+      WORKTREE,
+    );
+    expect(roots).toBeUndefined();
+  });
+
+  it('returns undefined when the parent scope is unknown (unwired ctx — back-compat)', () => {
+    // `undefined` parentScope = "getReadScopeInputs not wired" (test stub /
+    // legacy surface), NOT "parent unconfined". Must leave the manager's
+    // cwd-derivation untouched rather than granting read-open.
+    expect(resolveChildManagerReadRoots(undefined, WORKTREE)).toBeUndefined();
+    expect(resolveChildManagerReadRoots(undefined, undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for a known-unconfined parent when the child also has no cwd', () => {
+    const roots = resolveChildManagerReadRoots(
+      { parentReadRoots: undefined, parentCwd: undefined },
+      undefined,
+    );
+    expect(roots).toBeUndefined();
   });
 });

--- a/src/agent/subagent-read-scope.ts
+++ b/src/agent/subagent-read-scope.ts
@@ -42,6 +42,59 @@ export function readOpenRootFor(base: string | undefined): string {
   return path.parse(resolved).root || path.sep;
 }
 
+/**
+ * The parent session's read-scope inputs, as returned by
+ * {@link SubagentManager.getReadScopeInputs}. Threaded through the skill /
+ * inline-skill / compose dispatch contexts so those paths compute a forked
+ * child's read scope the same way the `agent` tool does (see
+ * {@link resolveChildManagerReadRoots}). `undefined` in either field carries
+ * the same meaning it does for {@link computeInheritedReadRoots}.
+ */
+export interface ReadScopeInputs {
+  parentReadRoots: string[] | undefined;
+  parentCwd: string | undefined;
+}
+
+/**
+ * Compute the `parentReadRoots` a skill- / inline- / compose-built
+ * {@link SubagentManager} should carry, given the parent session's read scope
+ * ({@link ReadScopeInputs}, from `getReadScopeInputs`) and the child manager's
+ * own cwd.
+ *
+ * This is the single choke point that keeps skill/inline dispatch SYMMETRIC
+ * with the `agent` tool: `subagent-executor.ts` reads `getReadScopeInputs()`
+ * off the parent manager and threads the result through `child-config.ts` as a
+ * grandchild manager's `parentReadRoots`. Skill managers historically passed
+ * only `cwd`, so their forks derived read scope from cwd alone and silently
+ * NARROWED whenever the parent session was read-open (or `/allow-dir`-widened)
+ * beyond `[cwd, mainRoot]` — the residual of #544 this closes (#547). Seeding a
+ * child manager's `parentReadRoots` with the result propagates the parent's
+ * full read scope transitively; `forkSubagent` still folds in the worktree main
+ * root, so callers need not resolve it here.
+ *
+ * Returns `undefined` when there is nothing broader than the child's own cwd to
+ * grant (the caller then omits `parentReadRoots` and the manager's existing
+ * cwd-derivation stands, byte-for-byte unchanged).
+ */
+export function resolveChildManagerReadRoots(
+  parentScope: ReadScopeInputs | undefined,
+  childCwd: string | undefined,
+): string[] | undefined {
+  // `parentScope === undefined` means the caller could not determine the parent
+  // session's scope (getReadScopeInputs unwired — a test stub or a surface that
+  // predates this wiring), NOT that the parent is unconfined. Distinguish the
+  // two: return undefined so the manager's existing cwd-derivation stands
+  // (byte-for-byte pre-#547 behaviour). Only a KNOWN unconfined parent
+  // (`{ parentReadRoots: undefined, parentCwd: undefined }`) yields a read-open
+  // child, via computeInheritedReadRoots below.
+  if (parentScope === undefined) return undefined;
+  return computeInheritedReadRoots({
+    parentReadRoots: parentScope.parentReadRoots,
+    parentCwd: parentScope.parentCwd,
+    childCwd,
+  });
+}
+
 export interface InheritedReadRootsArgs {
   /**
    * The parent session's explicit read roots, or `undefined` to derive the

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -36,7 +36,7 @@ import { appendRoutingDecision } from './routing-telemetry.js';
 import { getCurrentSink } from './_lib/skill-sink-channel.js';
 import { touchWorktreeOccupancy } from './worktree-occupancy.js';
 import { resolveWorktreeMainRoot } from './worktree-read-root.js';
-import { computeInheritedReadRoots } from './subagent-read-scope.js';
+import { computeInheritedReadRoots, type ReadScopeInputs } from './subagent-read-scope.js';
 import { buildPhaseRestrictedProvider, type PhaseRole } from './tools/nesting.js';
 import { applyManagerApiKeyFallback } from './tools/child-credential.js';
 import { providerForModel, type BundledProviderName } from './providers/index.js';
@@ -433,7 +433,7 @@ export class SubagentManager {
    * grandchild manager's `parentReadRoots`, so a read-open (or `/allow-dir`-
    * widened) scope is not silently re-narrowed one nesting level down.
    */
-  getReadScopeInputs(): { parentReadRoots: string[] | undefined; parentCwd: string | undefined } {
+  getReadScopeInputs(): ReadScopeInputs {
     return { parentReadRoots: this.parentReadRoots, parentCwd: this.parentCwd };
   }
 

--- a/src/agent/tools/compose-executor.ts
+++ b/src/agent/tools/compose-executor.ts
@@ -12,6 +12,7 @@
 import { mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { SubagentManager } from '../subagent.js';
+import { resolveChildManagerReadRoots, type ReadScopeInputs } from '../subagent-read-scope.js';
 import { runSubagentDAG, type SubagentDAGNode } from '../dag-subagent.js';
 import { providerForModel } from '../providers/index.js';
 import type { DAGEdge, DAGRunResult } from '../dag.js';
@@ -121,6 +122,19 @@ export interface ComposeExecutorContext {
    * → `subagent`). Optional/back-compat: defaults to 0 when unset.
    */
   depth?: number;
+  /**
+   * Reads the parent session's read scope ({@link ReadScopeInputs}) at
+   * dispatch time (wired to the root
+   * {@link SubagentManager.getReadScopeInputs}). Used to seed the per-call
+   * compose {@link SubagentManager}'s `parentReadRoots` via
+   * {@link resolveChildManagerReadRoots} so every DAG node inherits the parent
+   * session's full read scope — the `child ⊇ parent` invariant the `agent`
+   * tool enforces (#544), extended to compose dispatch (#547). Without it,
+   * nodes derive read scope from cwd alone and silently narrow when the parent
+   * session is read-open or `/allow-dir`-widened. Optional/back-compat: when
+   * unset, nodes fall back to cwd-only derivation, unchanged.
+   */
+  getReadScopeInputs?: () => ReadScopeInputs;
 }
 
 interface ComposeNodeInput {
@@ -574,6 +588,15 @@ export class ComposeExecutor {
       }
     };
 
+    // Read-scope inheritance (#547): derive the DAG nodes' parentReadRoots from
+    // the parent session's read scope + this executor's cwd, mirroring the
+    // `agent` tool (subagent-executor.ts). Without it, nodes inherit read scope
+    // from cwd alone and silently narrow when the parent session is read-open
+    // or `/allow-dir`-widened beyond `[cwd, mainRoot]`. Writes stay confined.
+    const nodeReadRoots = resolveChildManagerReadRoots(
+      this.ctx.getReadScopeInputs?.(),
+      this.currentCwd,
+    );
     manager = new SubagentManager({
       parentAbortSignal: call.signal,
       apiKey: this.ctx.apiKey,
@@ -587,6 +610,9 @@ export class ComposeExecutor {
       // setCwd). Without this the manager's parentCwd is undefined and nodes
       // fall back to the host's process.cwd() (subagent.ts fork fallback).
       ...(this.currentCwd !== undefined ? { cwd: this.currentCwd } : {}),
+      // Read-scope inheritance (#547): seed parentReadRoots so each DAG node's
+      // read scope ⊇ the parent session's. See nodeReadRoots above.
+      ...(nodeReadRoots !== undefined ? { parentReadRoots: nodeReadRoots } : {}),
       // Witness layer: manager-level writer so every DAG node fork emits
       // subagent_lifecycle events into the session trace (compose nodes never
       // set config.traceWriter). See ComposeExecutorContext.traceWriter.

--- a/src/agent/tools/nesting.ts
+++ b/src/agent/tools/nesting.ts
@@ -12,6 +12,7 @@ import type { IAgentSession } from '../types.js';
 import type { ModelProvider } from '../provider.js';
 import type { AgentModelInput } from '../types.js';
 import type { Surface } from '../awareness/types.js';
+import type { ReadScopeInputs } from '../subagent-read-scope.js';
 import { AnthropicDirectProvider } from '../providers/anthropic-direct/index.js';
 import { OpenAICompatibleProvider } from '../providers/openai-compatible/index.js';
 import { providerForModel } from '../providers/index.js';
@@ -297,13 +298,20 @@ export function createChildSkillExecutorFactory(
   // child's restricted/depth-cap provider builders point at the configured
   // endpoint. Trailing optional — legacy positional callers stay valid.
   openaiBaseUrl?: string,
-): (depth: number, maxDepth: number, signal: AbortSignal, inheritedCwd?: string) => SkillExecutor {
-  const factory: (depth: number, maxDepth: number, signal: AbortSignal, inheritedCwd?: string) => SkillExecutor = (
-    depth,
-    maxDepth,
-    signal,
-    inheritedCwd,
-  ) => {
+): (
+  depth: number,
+  maxDepth: number,
+  signal: AbortSignal,
+  inheritedCwd?: string,
+  inheritedReadScope?: ReadScopeInputs,
+) => SkillExecutor {
+  const factory: (
+    depth: number,
+    maxDepth: number,
+    signal: AbortSignal,
+    inheritedCwd?: string,
+    inheritedReadScope?: ReadScopeInputs,
+  ) => SkillExecutor = (depth, maxDepth, signal, inheritedCwd, inheritedReadScope) => {
     // Invariant: the closure-captured `cwd` is frozen at bootstrap. For
     // born-named `afk -w` worktrees it is `undefined` (the worktree is
     // created on turn 1 via worktree-autoname, after bootstrap). A later
@@ -370,6 +378,18 @@ export function createChildSkillExecutorFactory(
       // Named-agent registry propagates so nested skill children can
       // dispatch `agent_type`-named sub-agents at any depth.
       ...(agentRegistry !== undefined ? { agentRegistry } : {}),
+      // Read-scope inheritance (#547): the depth-1 caller
+      // (fork-child-config.ts / child-config.ts) passes THIS skill child's
+      // inherited read scope so its own skill forks (great-grandchildren)
+      // inherit ⊇ it, not the frozen bootstrap session scope. Unlike the
+      // top-level SkillExecutors (wired directly to the root manager's
+      // getReadScopeInputs), grandchild executors have no manager reference —
+      // the scope is threaded through this factory param instead. Frozen at
+      // call time via a closure, mirroring how `inheritedCwd` overrides the
+      // stale closure `cwd`.
+      ...(inheritedReadScope !== undefined
+        ? { getReadScopeInputs: () => inheritedReadScope }
+        : {}),
     });
   };
   return factory;

--- a/src/agent/tools/skill-executor.ts
+++ b/src/agent/tools/skill-executor.ts
@@ -320,6 +320,13 @@ export class SkillExecutor {
           ...(this.ctx.traceWriter !== undefined
             ? { traceWriter: this.ctx.traceWriter }
             : {}),
+          // Forward the parent session's read-scope reader so inline handlers
+          // that fork their own SubagentManager (e.g. /mint phases, /audit-fit)
+          // seed each fork's parentReadRoots — the child ⊇ parent read-scope
+          // invariant (#547). See SkillExecutionContext.getReadScopeInputs.
+          ...(this.ctx.getReadScopeInputs !== undefined
+            ? { getReadScopeInputs: this.ctx.getReadScopeInputs }
+            : {}),
         },
       );
     } catch (err) {

--- a/src/agent/tools/skill-executor/fork-child-config.ts
+++ b/src/agent/tools/skill-executor/fork-child-config.ts
@@ -12,6 +12,7 @@
  */
 
 import { SubagentManager } from '../../subagent.js';
+import { resolveChildManagerReadRoots } from '../../subagent-read-scope.js';
 import type { AgentConfig } from '../../types/config-types.js';
 import {
   DEFAULT_MAX_NESTING_DEPTH,
@@ -112,6 +113,17 @@ export function buildForkedChildConfig(
     return { childConfig, childManager: undefined };
   }
 
+  // Read-scope inheritance (#547): THIS skill child's inherited read roots,
+  // computed from the parent session scope + the child's cwd — the same value
+  // the child's own fork manager (fork-dispatch.ts) carries. Seeded as the
+  // grandchild manager's parentReadRoots so a read-open (or `/allow-dir`-
+  // widened) scope propagates transitively to grandchild `agent` forks —
+  // notably the hypothesis agents `/diagnose` dispatches via the `agent` tool
+  // with per-call worktree cwds. Mirrors subagent/child-config.ts:305.
+  const childInheritedReadRoots = resolveChildManagerReadRoots(
+    ctx.getReadScopeInputs?.(),
+    currentCwd,
+  );
   const childManager = new SubagentManager({
     parentAbortSignal: signal,
     ...(ctx.traceWriter !== undefined ? { traceWriter: ctx.traceWriter } : {}),
@@ -120,6 +132,10 @@ export function buildForkedChildConfig(
     // forkSubagent injects cwd into the grandchild's config. Mirrors
     // subagent-executor.ts:294.
     ...(currentCwd !== undefined ? { cwd: currentCwd } : {}),
+    // Read-scope inheritance (#547): see childInheritedReadRoots above.
+    ...(childInheritedReadRoots !== undefined
+      ? { parentReadRoots: childInheritedReadRoots }
+      : {}),
   });
   const childExecutor = new SubagentExecutor({
     subagentManager: childManager,
@@ -182,7 +198,13 @@ export function buildForkedChildConfig(
     ...(childConfig.model !== undefined ? { parentModel: childConfig.model } : {}),
   });
   const childSkillExecutor = ctx.childSkillExecutorFactory
-    ? ctx.childSkillExecutorFactory(depth + 1, maxDepth, signal, currentCwd)
+    ? ctx.childSkillExecutorFactory(depth + 1, maxDepth, signal, currentCwd, {
+        // Read-scope inheritance (#547): hand the grandchild SkillExecutor
+        // THIS child's read scope so its own skill forks (great-grandchildren)
+        // inherit ⊇ it instead of the frozen bootstrap session scope.
+        parentReadRoots: childInheritedReadRoots,
+        parentCwd: currentCwd,
+      })
     : undefined;
   // Pass `model` so the factory routes between AnthropicDirect /
   // OpenAICompatible per `providerForModel(model)`. Without this, every

--- a/src/agent/tools/skill-executor/fork-dispatch.ts
+++ b/src/agent/tools/skill-executor/fork-dispatch.ts
@@ -13,6 +13,7 @@
  */
 
 import { SubagentManager } from '../../subagent.js';
+import { resolveChildManagerReadRoots } from '../../subagent-read-scope.js';
 import { annotateIfIncomplete } from '../../subagent/result.js';
 import { appendInjectContext } from '../subagent/inject-context.js';
 import type { ToolCall, ToolResult } from '../types.js';
@@ -78,6 +79,13 @@ export async function executeForkedRegistrySkill(
     parentApiKey: ctx.apiKey,
   });
 
+  // Read-scope inheritance (#547): the skill-forked child's read scope ⊇ the
+  // parent session's, mirroring the `agent` tool (subagent-executor.ts). Seed
+  // parentReadRoots from the session scope + this fork's cwd; forkSubagent
+  // folds in the worktree main root. Without it the fork derived read scope
+  // from cwd alone and narrowed whenever the parent was read-open /
+  // `/allow-dir`-widened. Writes stay confined to the worktree.
+  const childReadRoots = resolveChildManagerReadRoots(ctx.getReadScopeInputs?.(), currentCwd);
   const manager = new SubagentManager({
     parentAbortSignal: call.signal,
     apiKey: skillChildApiKey,
@@ -93,6 +101,8 @@ export async function executeForkedRegistrySkill(
     // tools the worktree anchor. Without it, every `/diagnose`, `/mint`,
     // etc. run their first-tier subagents against the host repo.
     ...(currentCwd !== undefined ? { cwd: currentCwd } : {}),
+    // Read-scope inheritance (#547): see childReadRoots above.
+    ...(childReadRoots !== undefined ? { parentReadRoots: childReadRoots } : {}),
   });
 
   // Thread traceWriter into the child's AgentConfig so its tool_use, hook,
@@ -171,6 +181,8 @@ export async function executePluginSkill(
     parentApiKey: ctx.apiKey,
   });
 
+  // Read-scope inheritance (#547) — same rationale as executeForkedRegistrySkill.
+  const childReadRoots = resolveChildManagerReadRoots(ctx.getReadScopeInputs?.(), currentCwd);
   const manager = new SubagentManager({
     parentAbortSignal: call.signal,
     apiKey: pluginChildApiKey,
@@ -183,6 +195,8 @@ export async function executePluginSkill(
     progressSink: getCurrentSink(),
     // Worktree isolation — same rationale as executeForkedRegistrySkill above.
     ...(currentCwd !== undefined ? { cwd: currentCwd } : {}),
+    // Read-scope inheritance (#547): see childReadRoots above.
+    ...(childReadRoots !== undefined ? { parentReadRoots: childReadRoots } : {}),
   });
 
   // PLUGIN_ROOT is injected here so shell commands in the plugin SKILL.md

--- a/src/agent/tools/skill-executor/read-scope.test.ts
+++ b/src/agent/tools/skill-executor/read-scope.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression tests (#547): the `skill` tool's forked-dispatch paths seed each
+ * per-call SubagentManager's `parentReadRoots` from the parent session's read
+ * scope, so a skill-forked child's read scope ⊇ the parent session's — the same
+ * invariant #544 established for the `agent` tool (subagent-worktree-readroot.test.ts).
+ *
+ * Before this fix, `executeForkedRegistrySkill` / `executePluginSkill` built
+ * their managers with `cwd` only, so a fork under an UNCONFINED (read-open)
+ * parent operating in a worktree was silently re-confined to [worktree, mainRoot]
+ * — narrower than the parent, the residual gap of #544.
+ *
+ * The test exercises the REAL fork-dispatch code (not the manager in isolation):
+ * it spies `SubagentManager.prototype.forkSubagent` and, inside the spy, reads
+ * back `this.getReadScopeInputs()` — which returns the `parentReadRoots` the
+ * REAL constructor received from fork-dispatch. Writes stay confined (a separate
+ * axis, unchanged here).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'path';
+
+// Keep the credential resolver off the live keychain/env.
+vi.mock('../../auth/credential-resolver.js', () => ({
+  resolveCredentialForModel: vi.fn(() => 'resolved-test-credential' as string | undefined),
+  loadAnthropicCredential: vi.fn(() => 'resolved-test-credential'),
+  loadOpenAICredential: vi.fn(() => undefined),
+}));
+
+import { SkillExecutor } from '../skill-executor.js';
+import { registerSkill, _resetRegistry } from '../../../skills/index.js';
+import { SubagentManager } from '../../subagent.js';
+import type { ReadScopeInputs } from '../../subagent-read-scope.js';
+import * as promptLoader from '../../../skills/_lib/prompt-loader.js';
+
+const abortSignal = new AbortController().signal;
+const FS_ROOT = path.parse(path.resolve('.')).root || path.sep;
+const WORKTREE = '/repo/.afk-worktrees/wt';
+
+function makeCall(input: unknown) {
+  return { id: 'test-call', name: 'skill', input, signal: abortSignal };
+}
+
+/**
+ * Register a `context: fork` registry skill, stub its prompts, and spy
+ * forkSubagent so it (a) captures the manager's read-scope inputs and (b)
+ * returns a minimal succeeding handle. Returns a getter for the captured scope.
+ */
+function armForkCapture(): { getCaptured: () => ReadScopeInputs | undefined } {
+  let captured: ReadScopeInputs | undefined;
+  registerSkill({
+    name: 'fork-skill',
+    description: 'test',
+    context: 'fork',
+    handler: vi.fn(),
+  });
+  vi.spyOn(promptLoader, 'loadSkillPrompts').mockReturnValue({
+    'system.md': 'fake-system-prompt',
+  });
+  vi.spyOn(SubagentManager.prototype, 'forkSubagent').mockImplementation(
+    async function (this: SubagentManager) {
+      // The real constructor already ran with fork-dispatch's options, so this
+      // reflects the parentReadRoots/​parentCwd that were actually passed.
+      captured = this.getReadScopeInputs();
+      return {
+        id: 'child',
+        runToResult: vi.fn().mockResolvedValue({
+          status: 'succeeded',
+          message: { content: 'ok' },
+        }),
+        teardown: vi.fn().mockResolvedValue(undefined),
+      } as unknown as Awaited<ReturnType<SubagentManager['forkSubagent']>>;
+    },
+  );
+  vi.spyOn(SubagentManager.prototype, 'teardownAll').mockResolvedValue(undefined);
+  return { getCaptured: () => captured };
+}
+
+function makeExecutor(opts: {
+  cwd?: string;
+  getReadScopeInputs?: () => ReadScopeInputs;
+}): SkillExecutor {
+  return new SkillExecutor({
+    parentSession: {
+      sessionId: 'parent-123',
+      getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+      abortSignal,
+    },
+    defaultModel: 'sonnet',
+    ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+    ...(opts.getReadScopeInputs !== undefined
+      ? { getReadScopeInputs: opts.getReadScopeInputs }
+      : {}),
+  });
+}
+
+describe('skill fork read-scope inheritance (#547)', () => {
+  beforeEach(() => {
+    _resetRegistry();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('grants read-open to a worktree skill fork under an UNCONFINED parent session', async () => {
+    const { getCaptured } = armForkCapture();
+    const executor = makeExecutor({
+      cwd: WORKTREE,
+      getReadScopeInputs: () => ({ parentReadRoots: undefined, parentCwd: undefined }),
+    });
+
+    const result = await executor.execute(makeCall({ name: 'fork-skill' }));
+    expect(result.isError).toBeUndefined();
+
+    // THE fix: read-open (filesystem root), not re-confined to [worktree, mainRoot].
+    expect(getCaptured()?.parentReadRoots).toEqual([FS_ROOT]);
+  });
+
+  it('unions the worktree with a CONFINED parent session cwd (child ⊇ parent)', async () => {
+    const { getCaptured } = armForkCapture();
+    const executor = makeExecutor({
+      cwd: WORKTREE,
+      getReadScopeInputs: () => ({ parentReadRoots: undefined, parentCwd: '/repo' }),
+    });
+
+    await executor.execute(makeCall({ name: 'fork-skill' }));
+
+    expect(getCaptured()?.parentReadRoots).toEqual([WORKTREE, '/repo']);
+  });
+
+  it('propagates an explicit /allow-dir-widened parent read scope to the fork', async () => {
+    const { getCaptured } = armForkCapture();
+    const executor = makeExecutor({
+      cwd: WORKTREE,
+      getReadScopeInputs: () => ({
+        parentReadRoots: ['/repo', '/tmp/shared'],
+        parentCwd: '/repo',
+      }),
+    });
+
+    await executor.execute(makeCall({ name: 'fork-skill' }));
+
+    expect(getCaptured()?.parentReadRoots).toEqual([WORKTREE, '/repo', '/tmp/shared']);
+  });
+
+  it('leaves cwd-derivation untouched when getReadScopeInputs is unwired (back-compat)', async () => {
+    const { getCaptured } = armForkCapture();
+    // No getReadScopeInputs → parentReadRoots must NOT be set; the manager's own
+    // cwd-derivation (its parentCwd = WORKTREE) then produces [worktree, mainRoot].
+    const executor = makeExecutor({ cwd: WORKTREE });
+
+    await executor.execute(makeCall({ name: 'fork-skill' }));
+
+    const captured = getCaptured();
+    expect(captured?.parentReadRoots).toBeUndefined();
+    // cwd still flows through as the manager's parentCwd (worktree isolation).
+    expect(captured?.parentCwd).toBe(WORKTREE);
+  });
+});

--- a/src/agent/tools/skill-executor/types.ts
+++ b/src/agent/tools/skill-executor/types.ts
@@ -20,6 +20,7 @@ import type { BackgroundAgentRegistry } from '../../background-registry.js';
 import type { SdkPluginConfig } from '../../types/sdk-types.js';
 import type { ChildProviderFactoryArgs } from '../nesting.js';
 import type { Surface } from '../../awareness/types.js';
+import type { ReadScopeInputs } from '../../subagent-read-scope.js';
 import type { SkillExecutor } from '../skill-executor.js';
 
 export interface SkillExecutorContext {
@@ -91,7 +92,13 @@ export interface SkillExecutorContext {
    * skill child can in turn dispatch sibling skills. Mirrors
    * {@link SubagentExecutorContext.childSkillExecutorFactory}.
    */
-  childSkillExecutorFactory?: (depth: number, maxDepth: number, signal: AbortSignal, inheritedCwd?: string) => SkillExecutor;
+  childSkillExecutorFactory?: (
+    depth: number,
+    maxDepth: number,
+    signal: AbortSignal,
+    inheritedCwd?: string,
+    inheritedReadScope?: ReadScopeInputs,
+  ) => SkillExecutor;
   /**
    * Witness-layer trace writer. When provided, the per-call
    * {@link SubagentManager} that wraps each skill fork is constructed with
@@ -142,6 +149,23 @@ export interface SkillExecutorContext {
    * Optional: surfaces without a worktree (telegram) leave this unset.
    */
   cwd?: string;
+  /**
+   * Reads the parent session's read scope ({@link ReadScopeInputs}) at
+   * dispatch time. Wired at each surface to the root
+   * {@link SubagentManager.getReadScopeInputs}, so a skill-forked child
+   * inherits the parent session's full read scope — the same invariant #544
+   * established for the `agent` tool, now applied to `skill`-tool dispatch
+   * (#547). Every `new SubagentManager(...)` this executor builds
+   * (fork-dispatch.ts, fork-child-config.ts) computes its `parentReadRoots`
+   * via {@link resolveChildManagerReadRoots} from this callback's result and
+   * the child's cwd.
+   *
+   * A callback (not a snapshot) so it reflects mid-session `setCwd` re-anchors
+   * — matching the `agent` tool, which reads `getReadScopeInputs()` fresh on
+   * every dispatch. Optional/back-compat: when unset (older wiring, test
+   * stubs), the fork paths fall back to cwd-only derivation, unchanged.
+   */
+  getReadScopeInputs?: () => ReadScopeInputs;
   /**
    * Session-wide named-agent registry, forwarded to the child
    * {@link SubagentExecutor}s this executor constructs so skill-forked

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -9,7 +9,7 @@
  */
 
 import { SubagentManager, SUBAGENT_BACKGROUND_TIMEOUT_MS } from '../subagent.js';
-import { computeInheritedReadRoots } from '../subagent-read-scope.js';
+import { computeInheritedReadRoots, type ReadScopeInputs } from '../subagent-read-scope.js';
 import { BackgroundAgentRegistry } from '../background-registry.js';
 import type { ModelProvider } from '../provider.js';
 import type { AgentModelInput, IAgentSession } from '../types.js';
@@ -94,7 +94,13 @@ export interface SubagentExecutorContext {
    */
   defaultSubagentModel?: AgentModelInput;
   childProviderFactory?: (args: ChildProviderFactoryArgs) => ModelProvider;
-  childSkillExecutorFactory?: (depth: number, maxDepth: number, signal: AbortSignal, inheritedCwd?: string) => SkillExecutor;
+  childSkillExecutorFactory?: (
+    depth: number,
+    maxDepth: number,
+    signal: AbortSignal,
+    inheritedCwd?: string,
+    inheritedReadScope?: ReadScopeInputs,
+  ) => SkillExecutor;
   /**
    * Nesting depth this executor sits at. **Required** — pass explicit `0`
    * at top-level wiring sites (CLI, telegram, threads) and `parent.depth + 1`

--- a/src/agent/tools/subagent/child-config.ts
+++ b/src/agent/tools/subagent/child-config.ts
@@ -20,6 +20,7 @@
  */
 
 import { SubagentManager } from '../../subagent.js';
+import type { ReadScopeInputs } from '../../subagent-read-scope.js';
 import type { ModelProvider } from '../../provider.js';
 import type { AgentModelInput, IAgentSession } from '../../types.js';
 import type { AgentConfig } from '../../types/config-types.js';
@@ -72,7 +73,13 @@ export interface BuildChildConfigArgs {
   resolveApiKeyForModel?: (model: string) => string | undefined;
   defaultSubagentModel?: AgentModelInput;
   childProviderFactory?: (args: ChildProviderFactoryArgs) => ModelProvider;
-  childSkillExecutorFactory?: (depth: number, maxDepth: number, signal: AbortSignal, inheritedCwd?: string) => SkillExecutor;
+  childSkillExecutorFactory?: (
+    depth: number,
+    maxDepth: number,
+    signal: AbortSignal,
+    inheritedCwd?: string,
+    inheritedReadScope?: ReadScopeInputs,
+  ) => SkillExecutor;
   surface?: Surface;
   allowedTools?: string[];
   readOnlyBash?: boolean;
@@ -365,7 +372,14 @@ export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigRe
       parentModel: childModel,
     });
     const childSkillExecutor = args.childSkillExecutorFactory
-      ? args.childSkillExecutorFactory(depth + 1, maxDepth, signal, currentCwd)
+      ? args.childSkillExecutorFactory(depth + 1, maxDepth, signal, currentCwd, {
+          // Read-scope inheritance (#547): hand the grandchild SkillExecutor
+          // this child's inherited read scope (same value seeded on the
+          // grandchild manager above) so a skill dispatched by an `agent`-tool
+          // child inherits ⊇ the child's scope, not the frozen session scope.
+          parentReadRoots: args.childInheritedReadRoots,
+          parentCwd: currentCwd,
+        })
       : undefined;
     // Pass `model` so the factory routes between AnthropicDirect /
     // OpenAICompatible per `providerForModel(model)`. Without this, every

--- a/src/cli/commands/chat.ts
+++ b/src/cli/commands/chat.ts
@@ -586,6 +586,9 @@ export function registerChatCommand(program: Command): void {
           // Worktree isolation for skill-dispatched subagents. See
           // bootstrap.ts for the same wiring.
           ...(worktreeCwd !== undefined ? { cwd: worktreeCwd } : {}),
+          // Read-scope inheritance (#547): skill-forked children inherit the
+          // parent session's read scope via the root manager. See bootstrap.ts.
+          getReadScopeInputs: () => rootManager.getReadScopeInputs(),
         });
 
         // Pass the raw base prompt (pre-assembly) so compose subagents do not
@@ -599,6 +602,9 @@ export function registerChatCommand(program: Command): void {
           apiKey,
           // Per-model credential resolver — mirrors #640 for the compose fork-path.
           resolveApiKeyForModel: getApiKeyForModel,
+          // Read-scope inheritance (#547): DAG nodes inherit the parent session's
+          // read scope via the root manager. See bootstrap.ts.
+          getReadScopeInputs: () => rootManager.getReadScopeInputs(),
           ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
           // Anchor DAG nodes to the worktree (re-anchored via composeExecutor.setCwd).
           ...(worktreeCwd !== undefined ? { cwd: worktreeCwd } : {}),

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -176,6 +176,9 @@ export function buildDaemonSessionFactory(
       ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
       ...(opts.openaiBaseUrl !== undefined ? { openaiBaseUrl: opts.openaiBaseUrl } : {}),
       ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+      // Read-scope inheritance (#547): skill-forked children inherit the parent
+      // session's read scope via the root manager. See bootstrap.ts.
+      getReadScopeInputs: () => rootManager.getReadScopeInputs(),
     });
 
     const composeExecutor = new ComposeExecutor({
@@ -185,6 +188,9 @@ export function buildDaemonSessionFactory(
       ...(opts.apiKey !== undefined ? { apiKey: opts.apiKey } : {}),
       // Per-model credential resolver — mirrors #640 for the compose fork-path.
       resolveApiKeyForModel: getApiKeyForModel,
+      // Read-scope inheritance (#547): DAG nodes inherit the parent session's
+      // read scope via the root manager. See bootstrap.ts.
+      getReadScopeInputs: () => rootManager.getReadScopeInputs(),
       ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
       // Anchor DAG nodes to the worktree (re-anchored via composeExecutor.setCwd).
       ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -426,6 +426,11 @@ export async function bootstrapSession(
     // etc. runs its first-tier subagents against the host repo even when
     // `--worktree` was set.
     ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),
+    // Read-scope inheritance (#547): skill-forked children inherit the parent
+    // session's read scope via the root manager — symmetric with the `agent`
+    // tool (subagentManager: rootManager above). Read fresh so mid-session
+    // setCwd re-anchors are reflected.
+    getReadScopeInputs: () => rootManager.getReadScopeInputs(),
   });
 
   // Pass the raw base prompt (pre-assembly) so compose subagents do not
@@ -439,6 +444,9 @@ export async function bootstrapSession(
     apiKey,
     // Per-model credential resolver — mirrors #640 for the compose fork-path.
     resolveApiKeyForModel: getApiKeyForModel,
+    // Read-scope inheritance (#547): DAG nodes inherit the parent session's
+    // read scope via the root manager, symmetric with the `agent`/`skill` tools.
+    getReadScopeInputs: () => rootManager.getReadScopeInputs(),
     ...(cliConfig.baseUrl !== undefined ? { baseUrl: cliConfig.baseUrl } : {}),
     // Anchor DAG nodes to the worktree (re-anchored via composeExecutor.setCwd).
     ...(effectiveCwd !== undefined ? { cwd: effectiveCwd } : {}),

--- a/src/skills/audit-fit/index.ts
+++ b/src/skills/audit-fit/index.ts
@@ -344,6 +344,15 @@ async function handler(
   // Forward the parent's witness writer (when ctx supplies one) so the
   // inspector forks below inherit it and their `canUseTool` permission-denials
   // land in the parent trace. See skills/index.ts SkillExecutionContext.traceWriter.
+  //
+  // Read-scope note (#547): this manager DELIBERATELY passes no `cwd` and no
+  // `parentReadRoots`. Its inspectors roam `~/.afk` user/plugin artifacts that
+  // live OUTSIDE any repo, so a cwd-less manager (→ read-open forks) is
+  // required. Read-open already satisfies the child ⊇ parent read-scope
+  // invariant (#544/#547) for ANY parent, so this is compliant, not a gap:
+  // seeding parentReadRoots from a CONFINED session (e.g. `afk -w`) would
+  // narrow inspectors to the worktree and break `~/.afk` discovery. Do not add
+  // it here — the omission is correct.
   const manager = new SubagentManager({
     apiKey,
     // `apiKey` is `ctx.apiKey` — resolved by the parent session for

--- a/src/skills/index.ts
+++ b/src/skills/index.ts
@@ -8,6 +8,7 @@
 
 import type { AgentModelInput, IAgentSession } from '../agent/types.js';
 import type { TraceWriter } from '../agent/trace/index.js';
+import type { ReadScopeInputs } from '../agent/subagent-read-scope.js';
 
 /**
  * Execution context handed to inline-registry skill handlers by the
@@ -81,6 +82,24 @@ export interface SkillExecutionContext {
    * do not provide it). In that case forking proceeds untraced, as before.
    */
   traceWriter?: TraceWriter;
+  /**
+   * Reads the parent session's read scope ({@link ReadScopeInputs}) at
+   * dispatch time (wired to the root
+   * {@link SubagentManager.getReadScopeInputs}). Inline handlers that fork
+   * sub-agents via their OWN `new SubagentManager(...)` (e.g. `/mint` phases,
+   * `/audit-fit`) MUST use this to seed each manager's `parentReadRoots` via
+   * {@link resolveChildManagerReadRoots}, so the forked sub-agent inherits the
+   * parent session's full read scope — the same `child ⊇ parent` invariant the
+   * `agent` tool enforces (#544), extended to inline-skill dispatch (#547).
+   * Without it, an inline fork derives read scope from its cwd alone and
+   * silently narrows whenever the parent session is read-open or
+   * `/allow-dir`-widened beyond `[cwd, mainRoot]`.
+   *
+   * Optional: callers must handle `undefined` (older SkillExecutor versions or
+   * test stubs). In that case forking falls back to cwd-only derivation, as
+   * before.
+   */
+  getReadScopeInputs?: () => ReadScopeInputs;
 }
 
 export interface SkillMetadata {

--- a/src/skills/mint/_phases/build.ts
+++ b/src/skills/mint/_phases/build.ts
@@ -36,6 +36,10 @@ export async function runBuildPhase(
   // skill's tool-lane entry. See skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
   defaultSubagentModel: AgentModelInput = 'sonnet',
+  // Read-scope inheritance (#547): parent session's read roots (resolved once
+  // by the mint handler); seeds the fork manager's parentReadRoots so the phase
+  // subagent's reads ⊇ the parent session's. Undefined leaves cwd-derivation.
+  parentReadRoots?: string[],
 ): Promise<BuildResult> {
   const prompts = loadSkillPrompts('mint');
   const buildPrompt = prompts['build.md'];
@@ -47,9 +51,10 @@ export async function runBuildPhase(
   // Propagate parent worktree to the build subagent so its bash/grep
   // run in the right working tree — critical here because build is the
   // phase that actually mutates files and runs git commands.
-  const manager = new SubagentManager(
-    parentCwd !== undefined ? { cwd: parentCwd } : {},
-  );
+  const manager = new SubagentManager({
+    ...(parentCwd !== undefined ? { cwd: parentCwd } : {}),
+    ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+  });
   const buildHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {

--- a/src/skills/mint/_phases/heal.ts
+++ b/src/skills/mint/_phases/heal.ts
@@ -30,6 +30,11 @@ export async function runHealPhase(
   // callers/tests without a skill-dispatch context degrade gracefully — the
   // heal sub-agent then diagnoses the failures itself from the issue list.
   dispatchSkill?: (name: string, args?: string) => Promise<string>,
+  // Read-scope inheritance (#547): parent session's read roots (resolved once
+  // by the mint handler); seeds the heal fork manager's parentReadRoots and is
+  // forwarded to the re-run verify phase so both inherit reads ⊇ the parent
+  // session's. Undefined leaves cwd-derivation intact.
+  parentReadRoots?: string[],
 ): Promise<{
   healed: boolean;
   newHealIterations: number;
@@ -89,9 +94,10 @@ export async function runHealPhase(
 
     // Propagate parent worktree — heal subagent applies file edits
     // and re-runs tests; must operate on the right working tree.
-    const manager = new SubagentManager(
-      parentSession.cwd !== undefined ? { cwd: parentSession.cwd } : {},
-    );
+    const manager = new SubagentManager({
+      ...(parentSession.cwd !== undefined ? { cwd: parentSession.cwd } : {}),
+      ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+    });
     const healHandle = await manager.forkSubagent({
       parent: { sessionId: parentSession.sessionId },
       config: {
@@ -147,6 +153,7 @@ export async function runHealPhase(
       parentSession.cwd,
       skillCallId,
       defaultSubagentModel,
+      parentReadRoots,
     );
 
     return {

--- a/src/skills/mint/_phases/parallelize-dispatch.ts
+++ b/src/skills/mint/_phases/parallelize-dispatch.ts
@@ -57,6 +57,11 @@ export async function runParallelizeDispatch(
   // mint skill's tool-lane entry. See skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
   defaultSubagentModel: AgentModelInput = 'sonnet',
+  // Read-scope inheritance (#547): parent session's read roots (resolved once
+  // by the mint handler); seeds the fork manager's parentReadRoots so the
+  // parallelize subagent's reads ⊇ the parent session's. Undefined leaves
+  // cwd-derivation intact.
+  parentReadRoots?: string[],
 ): Promise<ParallelizeDispatchResult> {
   const fileCount = countFileReferences(plan);
 
@@ -106,6 +111,7 @@ export async function runParallelizeDispatch(
       // the fork-time credential fallback (see SubagentManager.parentProvider).
       parentModel: getModel(),
       ...(parentSession.cwd !== undefined ? { cwd: parentSession.cwd } : {}),
+      ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
     });
     try {
       // PLUGIN_ROOT injection mirrors `executePluginSkill` — see

--- a/src/skills/mint/_phases/plan.ts
+++ b/src/skills/mint/_phases/plan.ts
@@ -18,6 +18,10 @@ export async function runPlanPhase(
   // skill's tool-lane entry. See skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
   defaultSubagentModel: AgentModelInput = 'sonnet',
+  // Read-scope inheritance (#547): parent session's read roots (resolved once
+  // by the mint handler); seeds the fork manager's parentReadRoots so the phase
+  // subagent's reads ⊇ the parent session's. Undefined leaves cwd-derivation.
+  parentReadRoots?: string[],
 ): Promise<string> {
   const prompts = loadSkillPrompts('mint');
   const planPrompt = prompts['plan.md'];
@@ -27,9 +31,10 @@ export async function runPlanPhase(
   }
 
   // Propagate parent worktree to subagent — see spec.ts for rationale.
-  const manager = new SubagentManager(
-    parentCwd !== undefined ? { cwd: parentCwd } : {},
-  );
+  const manager = new SubagentManager({
+    ...(parentCwd !== undefined ? { cwd: parentCwd } : {}),
+    ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+  });
   const planHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {

--- a/src/skills/mint/_phases/research.ts
+++ b/src/skills/mint/_phases/research.ts
@@ -18,6 +18,10 @@ export async function runResearchPhase(
   // block both nest correctly. See skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
   defaultSubagentModel: AgentModelInput = 'sonnet',
+  // Read-scope inheritance (#547): parent session's read roots (resolved once
+  // by the mint handler); seeds the fork manager's parentReadRoots so the phase
+  // subagent's reads ⊇ the parent session's. Undefined leaves cwd-derivation.
+  parentReadRoots?: string[],
 ): Promise<string> {
   const prompts = loadSkillPrompts('mint');
   const researchPrompt = prompts['research.md'];
@@ -27,9 +31,10 @@ export async function runResearchPhase(
   }
 
   // Propagate parent worktree to subagent — see spec.ts for rationale.
-  const manager = new SubagentManager(
-    parentCwd !== undefined ? { cwd: parentCwd } : {},
-  );
+  const manager = new SubagentManager({
+    ...(parentCwd !== undefined ? { cwd: parentCwd } : {}),
+    ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+  });
   const researchHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {

--- a/src/skills/mint/_phases/ship.ts
+++ b/src/skills/mint/_phases/ship.ts
@@ -19,6 +19,10 @@ export async function runShipPhase(
   // skill's tool-lane entry. See skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
   defaultSubagentModel: AgentModelInput = 'sonnet',
+  // Read-scope inheritance (#547): parent session's read roots (resolved once
+  // by the mint handler); seeds the fork manager's parentReadRoots so the phase
+  // subagent's reads ⊇ the parent session's. Undefined leaves cwd-derivation.
+  parentReadRoots?: string[],
 ): Promise<string> {
   const prompts = loadSkillPrompts('mint');
   const shipPrompt = prompts['ship.md'];
@@ -29,9 +33,10 @@ export async function runShipPhase(
 
   // Propagate parent worktree — ship subagent may run `git status`/`git
   // log` and needs to see the right working tree.
-  const manager = new SubagentManager(
-    parentCwd !== undefined ? { cwd: parentCwd } : {},
-  );
+  const manager = new SubagentManager({
+    ...(parentCwd !== undefined ? { cwd: parentCwd } : {}),
+    ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+  });
   const shipHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {

--- a/src/skills/mint/_phases/spec.ts
+++ b/src/skills/mint/_phases/spec.ts
@@ -17,6 +17,13 @@ export async function runSpecPhase(
   // under the mint skill's tool-lane entry — see runResearchPhase / skills/index.ts.
   skillCallId?: string,
   defaultSubagentModel: AgentModelInput = 'sonnet',
+  // Read-scope inheritance (#547): the parent session's read roots, resolved
+  // once by the mint handler (resolveChildManagerReadRoots). Seeded as the fork
+  // manager's parentReadRoots so the phase subagent's read scope ⊇ the parent
+  // session's — the same child ⊇ parent invariant the `agent` tool enforces
+  // (#544). Undefined (the common case, where the mint worktree IS the session
+  // cwd) leaves the manager's cwd-derivation intact.
+  parentReadRoots?: string[],
 ): Promise<string> {
   const prompts = loadSkillPrompts('mint');
   const specPrompt = prompts['spec.md'];
@@ -29,9 +36,12 @@ export async function runSpecPhase(
   // so its bash/grep run in the right working tree. Without this, two
   // concurrent `afk interactive -w` terminals running /mint would have
   // their spec subagents both spawn against the host's process.cwd().
-  const manager = new SubagentManager(
-    parentCwd !== undefined ? { cwd: parentCwd } : {},
-  );
+  // `parentReadRoots` (#547) widens the READ axis to the parent session's
+  // scope; writes stay confined to cwd.
+  const manager = new SubagentManager({
+    ...(parentCwd !== undefined ? { cwd: parentCwd } : {}),
+    ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+  });
   const specHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {

--- a/src/skills/mint/_phases/verify.ts
+++ b/src/skills/mint/_phases/verify.ts
@@ -37,12 +37,17 @@ async function forkVerifyMode(
   // under the mint skill's tool-lane entry. See skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
   defaultSubagentModel: AgentModelInput = 'sonnet',
+  // Read-scope inheritance (#547): parent session's read roots (resolved once
+  // by the mint handler); seeds the fork manager's parentReadRoots so the phase
+  // subagent's reads ⊇ the parent session's. Undefined leaves cwd-derivation.
+  parentReadRoots?: string[],
 ): Promise<{ passed: boolean; issues?: string[] }> {
   // Propagate parent worktree — verify subagents run tests/lint/grep in
   // the right working tree.
-  const manager = new SubagentManager(
-    parentCwd !== undefined ? { cwd: parentCwd } : {},
-  );
+  const manager = new SubagentManager({
+    ...(parentCwd !== undefined ? { cwd: parentCwd } : {}),
+    ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
+  });
   const verifyHandle = await manager.forkSubagent({
     parent: { sessionId: parentSessionId },
     config: {
@@ -97,6 +102,10 @@ export async function runVerifyPhase(
   // under the mint skill's tool-lane entry. See skills/index.ts SkillExecutionContext.callId.
   skillCallId?: string,
   defaultSubagentModel: AgentModelInput = 'sonnet',
+  // Read-scope inheritance (#547): forwarded to each parallel forkVerifyMode so
+  // every verify subagent's reads ⊇ the parent session's. Undefined leaves
+  // cwd-derivation intact.
+  parentReadRoots?: string[],
 ): Promise<VerifyResult> {
   const prompts = loadSkillPrompts('mint');
   const verifyPrompt = prompts['verify.md'];
@@ -107,9 +116,9 @@ export async function runVerifyPhase(
 
   // Run test, lint, and design-review in parallel
   const [testResult, lintResult, designResult] = await Promise.all([
-    forkVerifyMode('test', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel),
-    forkVerifyMode('lint', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel),
-    forkVerifyMode('design-review', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel),
+    forkVerifyMode('test', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots),
+    forkVerifyMode('lint', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots),
+    forkVerifyMode('design-review', plan, buildResults, parentSessionId, verifyPrompt, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots),
   ]);
 
   const allIssues: string[] = [];

--- a/src/skills/mint/index.ts
+++ b/src/skills/mint/index.ts
@@ -18,6 +18,10 @@
 
 import { registerSkill, type SkillExecutionContext, type SkillMetadata } from '../index.js';
 import type { AgentModelInput, IAgentSession } from '../../agent/types.js';
+import {
+  resolveChildManagerReadRoots,
+  type ReadScopeInputs,
+} from '../../agent/subagent-read-scope.js';
 import { runSpecPhase } from './_phases/spec.js';
 import { runResearchPhase } from './_phases/research.js';
 import { runPlanPhase } from './_phases/plan.js';
@@ -179,6 +183,13 @@ async function runPhasesAfterSpec(
   // resume/autoApprove paths and tests without a dispatch context degrade
   // gracefully — heal then self-diagnoses from the verification issues.
   dispatchSkill?: (name: string, args?: string) => Promise<string>,
+  // Read-scope inheritance (#547): the parent session's read scope, from
+  // ctx.getReadScopeInputs() at the handler. Resolved once here (with the mint
+  // worktree as the child cwd) and threaded to every phase so their forked
+  // subagents inherit reads ⊇ the parent session's — the same child ⊇ parent
+  // invariant the `agent` tool enforces (#544). Optional so resume/test paths
+  // without a ctx degrade to cwd-derivation, unchanged.
+  parentReadScope?: ReadScopeInputs,
 ): Promise<MintResult> {
   if (!parentSession.sessionId) {
     throw new Error('runPhasesAfterSpec requires parentSession.sessionId');
@@ -189,13 +200,18 @@ async function runPhasesAfterSpec(
   // falls back to the Node host's process.cwd() — which is shared across
   // concurrent sessions and defeats worktree isolation.
   const parentCwd = parentSession.cwd;
+  // Read-scope inheritance (#547): resolve the phase forks' parentReadRoots
+  // once (child cwd = the mint worktree = parentCwd). Undefined in the common
+  // case (session read scope == [parentCwd, mainRoot]); non-undefined only when
+  // the parent session is read-open or `/allow-dir`-widened beyond its cwd.
+  const parentReadRoots = resolveChildManagerReadRoots(parentReadScope, parentCwd);
   try {
     state.currentPhase = 'research';
-    state.research = await runResearchPhase(state.spec!, parentSessionId, parentCwd, skillCallId, defaultSubagentModel);
+    state.research = await runResearchPhase(state.spec!, parentSessionId, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots);
     appendHistory(state, 'research', state.research);
 
     state.currentPhase = 'plan';
-    state.plan = await runPlanPhase(state.spec!, state.research, parentSessionId, parentCwd, skillCallId, defaultSubagentModel);
+    state.plan = await runPlanPhase(state.spec!, state.research, parentSessionId, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots);
     appendHistory(state, 'plan', state.plan);
 
     state.currentPhase = 'parallelize';
@@ -204,6 +220,7 @@ async function runPhasesAfterSpec(
       parentSession,
       skillCallId,
       defaultSubagentModel,
+      parentReadRoots,
     );
     if (parallelizeResult.kind === 'plan') {
       state.waveOrchestrationPlan = parallelizeResult.plan;
@@ -251,6 +268,7 @@ async function runPhasesAfterSpec(
       parentCwd,
       skillCallId,
       defaultSubagentModel,
+      parentReadRoots,
     );
     appendHistory(state, 'build', JSON.stringify(state.buildResults));
 
@@ -262,6 +280,7 @@ async function runPhasesAfterSpec(
       parentCwd,
       skillCallId,
       defaultSubagentModel,
+      parentReadRoots,
     );
     appendHistory(state, 'verify', JSON.stringify(state.verifyResults));
 
@@ -282,6 +301,7 @@ async function runPhasesAfterSpec(
         skillCallId,
         defaultSubagentModel,
         dispatchSkill,
+        parentReadRoots,
       );
       state.healIterations = healResult.newHealIterations;
       state.verifyResults = healResult.newVerifyResults;
@@ -305,7 +325,7 @@ async function runPhasesAfterSpec(
     }
 
     state.currentPhase = 'ship';
-    const artifact = await runShipPhase(state, parentSessionId, parentCwd, skillCallId, defaultSubagentModel);
+    const artifact = await runShipPhase(state, parentSessionId, parentCwd, skillCallId, defaultSubagentModel, parentReadRoots);
     appendHistory(state, 'ship', artifact);
 
     return { completed: true, artifact, state };
@@ -353,7 +373,7 @@ async function handler(
         'mint: no paused spec found for this session to continue. Run /mint <idea> first, then /mint --continue approved.',
       );
     }
-    const result = await runPhasesAfterSpec(resumeState, parentSession, skillCallId, defaultSubagentModel, ctx?.dispatchSkill);
+    const result = await runPhasesAfterSpec(resumeState, parentSession, skillCallId, defaultSubagentModel, ctx?.dispatchSkill, ctx?.getReadScopeInputs?.());
     return finalizeAfterSpec(parentSessionId, result);
   }
 
@@ -393,7 +413,7 @@ async function handler(
     return pausedResult;
   }
 
-  const result = await runPhasesAfterSpec(state, parentSession, skillCallId, defaultSubagentModel, ctx?.dispatchSkill);
+  const result = await runPhasesAfterSpec(state, parentSession, skillCallId, defaultSubagentModel, ctx?.dispatchSkill, ctx?.getReadScopeInputs?.());
   return finalizeAfterSpec(parentSessionId, result);
 }
 

--- a/src/skills/user-skills.ts
+++ b/src/skills/user-skills.ts
@@ -159,6 +159,14 @@ function makeUserSkillHandler(parsed: ParsedSkillMd): SkillMetadata['handler'] {
       // user-skill's forked sub-agent inherits it and its tool activity —
       // including any permission-denials a restricted user SKILL.md produces —
       // lands in the parent trace. See skills/index.ts SkillExecutionContext.traceWriter.
+      //
+      // Read-scope note (#547): this manager passes no `cwd`, so its fork is
+      // read-open — which already satisfies the child ⊇ parent read-scope
+      // invariant (#544/#547) for any parent. Seeding parentReadRoots from a
+      // CONFINED session would only NARROW the fork (an arbitrary user SKILL.md
+      // may legitimately read outside the worktree, e.g. its own
+      // `~/.afk/skills/<name>` dir), so it is intentionally omitted. Worktree
+      // isolation for user skills (passing cwd) is a separate, pre-existing gap.
       ...(ctx?.traceWriter !== undefined ? { traceWriter: ctx.traceWriter } : {}),
     });
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -369,6 +369,9 @@ async function main() {
           resolveApiKeyForModel: getApiKeyForModel,
           ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
           ...(telegramOpenaiBaseUrl !== undefined ? { openaiBaseUrl: telegramOpenaiBaseUrl } : {}),
+          // Read-scope inheritance (#547): skill-forked children inherit the
+          // parent session's read scope via the root manager. See bootstrap.ts.
+          getReadScopeInputs: () => rootManager.getReadScopeInputs(),
         });
 
         // Compose subagents inherit the framework base + operator overlay
@@ -382,6 +385,9 @@ async function main() {
           apiKey: telegramApiKey,
           // Per-model credential resolver — mirrors #640 for the compose fork-path.
           resolveApiKeyForModel: getApiKeyForModel,
+          // Read-scope inheritance (#547): DAG nodes inherit the parent session's
+          // read scope via the root manager. See bootstrap.ts.
+          getReadScopeInputs: () => rootManager.getReadScopeInputs(),
           ...(telegramBaseUrl !== undefined ? { baseUrl: telegramBaseUrl } : {}),
           // Anchor DAG nodes to the worktree (re-anchored via composeExecutor.setCwd).
           ...(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),


### PR DESCRIPTION
Closes #547.

## Problem

The read-scope inheritance fix (#544) wired transitive read-scope propagation into the **`agent` tool** executor only (`subagent-executor.ts` → `getReadScopeInputs()` → `computeInheritedReadRoots` → `child-config.ts`). The **`skill` tool**, **inline-skill** handlers, and **`compose`** build their own `SubagentManager`s and **never passed `parentReadRoots`**, so they derived a forked child's read scope from `cwd` alone.

That silently **narrows** a child below its parent whenever the parent session is read-open (unconfined) or `/allow-dir`-widened beyond `[cwd, mainRoot]` — the same class of bug #544 fixed, in the other dispatch paths. The mechanism was asymmetric and fragile: `child ⊇ parent` held only by coincidence (child cwd == session cwd via `dispatcher.setCwd` lockstep) and broke the moment cwd diverged or read-widening landed.

## Fix — make skill/inline/compose dispatch symmetric with the `agent` tool

- **`subagent-read-scope.ts`**: add `ReadScopeInputs` + `resolveChildManagerReadRoots(parentScope, childCwd)` — one choke point that reuses `computeInheritedReadRoots` (no rule reimplementation). An `undefined` `parentScope` (unwired ctx / test stub) preserves cwd-derivation **byte-for-byte**; only a *known-unconfined* parent yields a read-open child.
- **Contexts**: thread a `getReadScopeInputs?()` callback through `SkillExecutorContext`, `SkillExecutionContext`, and `ComposeExecutorContext`; wire it at all four surfaces (`bootstrap`/`chat`/`daemon`/`telegram`) to the root manager, **read fresh** so mid-session `setCwd` re-anchors are reflected (matching the `agent` tool).
- **Seed `parentReadRoots`** at every skill/inline/compose manager: `fork-dispatch` (registry + plugin), the grandchild manager in `fork-child-config`, `compose-executor`, and all **8 mint phases**. Extend the `childSkillExecutorFactory` signature with `inheritedReadScope` so grandchild skill executors inherit the child's scope transitively (depth ≥ 2).
- **`audit-fit` and `user-skills`** are intentionally left cwd-less (read-open) — that already satisfies `child ⊇ parent`, and seeding `parentReadRoots` from a *confined* session would only **narrow** them (regression, e.g. audit-fit losing `~/.afk` discovery). Documented inline.

**Write confinement is unchanged** — only the READ axis widens to match the parent session.

## Resolves the issue's open verification question

`/diagnose` is a `context: fork` plugin skill: it forks an orchestrator (`fork-dispatch`) which dispatches its hypothesis agents via the **`agent` tool with per-call worktree `cwd`**. Those read `getReadScopeInputs()` off the **grandchild manager** (`fork-child-config`) — now seeded here — so the per-call-cwd hypothesis agents inherit the full parent read scope.

## Tests

- `subagent-read-scope.test.ts`: unit tests for `resolveChildManagerReadRoots` (read-open under unconfined parent + worktree child; union under a confined parent; `/allow-dir` propagation; same-cwd → no-op; unwired → back-compat no-op).
- `skill-executor/read-scope.test.ts` (new): exercises the **real** `executeForkedRegistrySkill` path and asserts the manager's actual `parentReadRoots` via a `forkSubagent` spy — read-open under an unconfined parent, union under a confined one, `/allow-dir` propagation, and back-compat when unwired. Parallel to `subagent-worktree-readroot.test.ts`.

## Verification

- `pnpm lint` (tsc strict) ✓
- `pnpm audit:sdk:check` (no new SDK symbols) ✓, `pnpm audit:env:check` / `pnpm scan:env:check` ✓
- Full suite: **11,537 passing**, 0 real failures (the lone `trace/writer.test.ts` miss is a worktree env artifact — it spawns `<worktree>/node_modules/.bin/tsx`, absent in the partial worktree install; passes once `tsx` is present, and this PR touches no `trace/` code).

## Acceptance criteria (#547)

- [x] Skill-forked child read scope ⊇ parent session read scope, across `skill`-tool and inline-skill dispatch
- [x] Write confinement (worktree isolation) unchanged
- [x] Regression test asserting skill-fork read roots, parallel to `subagent-worktree-readroot.test.ts`
- [x] Reuses `computeInheritedReadRoots` (no rule reimplementation)
