### PR TITLE
security(bash): best-effort readRoots/writeRoots path scan + ADR (closes #354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Added
+- **C4** `bash` handler now runs a best-effort, advisory-only `readRoots`/`writeRoots` path-containment scan before spawning: absolute and home-relative path tokens are extracted from the command and checked against the session's write roots, emitting a one-time `[security]` warning + `tool.bash_path_escape` telemetry (counts only, no command string) when one escapes — but never blocking execution (warn-only, to preserve the top-level `afk -w` bypass workflow). Rationale, threat model, and residual gaps documented in `docs/decisions/0001-bash-tool-path-containment.md`. Full `execFile`/sandbox containment remains deferred (tracked C4). (#354)
+
 ## [5.37.2] - 2026-07-13
 
 ### Fixed

--- a/docs/decisions/0001-bash-tool-path-containment.md
+++ b/docs/decisions/0001-bash-tool-path-containment.md
@@ -93,6 +93,9 @@ work.
   before the containment check.
 - Quoted path tokens and paths abutting common shell punctuation
   (`;`, `,`, `)`).
+- Paths glued to a leading redirection/pipe operator with no space
+  (`>/etc/passwd`, `>>~/.bashrc`, `2>/tmp/err`, `|/tmp/x`) — the leading
+  operator run (and any fd prefix) is stripped before the containment check.
 
 **Not covered** (documented limitations — the reason this is advisory, not a
 boundary):
@@ -100,8 +103,8 @@ boundary):
 - Command / arithmetic substitution: `$(printf /etc/hosts)`, backticks.
 - Environment-variable indirection: `$HOME/.ssh`, `${SECRET_DIR}`.
 - Glob and brace expansion: `/etc/*`, `/a/{b,c}`.
-- Paths synthesized across tokens, here-docs, or quoted paths containing
-  whitespace.
+- Here-docs (`<<EOF`), paths synthesized across tokens, or quoted paths
+  containing whitespace.
 
 Operational impact: a confined session that references an out-of-root path via
 bash still runs, but the operator sees a one-time `[security]` warning and a

--- a/docs/decisions/0001-bash-tool-path-containment.md
+++ b/docs/decisions/0001-bash-tool-path-containment.md
@@ -1,0 +1,119 @@
+# ADR 0001 — Bash tool path containment
+
+Status: **Accepted**
+
+Tracked as **C4** (see [`CHANGELOG.md`](../../CHANGELOG.md)). Closes issue #354.
+
+---
+
+## Context
+
+Every typed filesystem handler (`read_file`, `write_file`, `edit_file`, `glob`,
+`grep`, `list_directory`) routes each path argument through
+`resolveAndContain` in
+[`src/agent/tools/handlers/_cwd-utils.ts`](../../src/agent/tools/handlers/_cwd-utils.ts).
+That function resolves the path (following symlinks via `realpathSafe`) and
+throws when it falls outside the session's `readRoots` / `writeRoots`. This is
+how a confined session — an `afk -w` worktree, or a forked sub-agent — is kept
+from reading or writing outside its granted roots.
+
+The bash handler
+([`src/agent/tools/handlers/bash.ts`](../../src/agent/tools/handlers/bash.ts))
+did **not** participate in this containment. It spawns commands with
+`shell: true` and only set the child's `cwd`; it never consulted
+`readRoots` / `writeRoots` and never routed anything through containment. The
+gap is structural, not an oversight: with `shell: true` the command is an
+**opaque string** interpreted by the OS shell. There is no reliable, general
+way to know which paths a command will touch — pipes, redirections, subshell
+and arithmetic substitution (`$(…)`, backticks), environment-variable
+indirection (`$HOME`), and globbing can all synthesize paths at runtime. A
+model running inside an isolated worktree could therefore still read or write
+outside it via bash (e.g. `cat /etc/hosts`, `echo x > ~/.ssh/authorized_keys`),
+even though the typed file tools would have refused.
+
+Issue #354 offered two acceptance paths: (1) have the bash handler enforce/scan
+the roots for absolute paths it can extract, or (2) document an architectural
+decision explaining why the gap is accepted. This ADR does **both** — it adopts
+a best-effort scan *and* records the reasoning and residual limits.
+
+## Decision
+
+1. **Adopt best-effort, advisory path scanning now.** Before spawning, the
+   handler extracts absolute and home-relative path tokens from the command
+   string (`extractCandidatePaths`) and checks each against the session's
+   **write** roots via `wouldBeRestricted(…, 'write', …)`. `writeRoots` is the
+   stricter and most relevant boundary for the "escape the worktree" threat, and
+   in practice `readRoots ⊇ writeRoots` for confined forks. On the first
+   out-of-root reference the handler emits one `[security]` `console.warn`
+   naming the escaping resolved paths and one `tool.bash_path_escape` telemetry
+   row (counts + `mode` only — never the raw command string, per the audit
+   §G.4 privacy rule already followed for overflow-kill telemetry).
+
+2. **Warn-only — never refuse.** The scan does not block execution. Issue #354
+   floated a "Tier-1" idea: refuse to run bash when `writeRoots` is set *and*
+   `permissionMode === bypassPermissions`. We explicitly **reject** that
+   fail-closed refusal. A top-level `afk -w` session runs under
+   `bypassPermissions` **and** carries a non-empty effective
+   `writeRoots = [worktree]`, so a refusal keyed on that condition would break
+   the primary human-driven worktree workflow. Forked sub-agents run
+   `permissionMode = 'default'` (they do **not** inherit bypass), so they would
+   never be refused anyway — meaning the refusal would only ever fire on the
+   legitimate top-level session. Warn-only preserves the workflow while making
+   the risk observable in logs and telemetry.
+
+3. **Defer full containment.** A full `execFile`-based refactor that disables
+   the shell (and could then contain paths precisely), or an OS-level sandbox,
+   remains the long-term fix and is still tracked under C4. Building a shell
+   parser to close the substitution/indirection gaps is a deliberate non-goal —
+   issue #354 calls it a rathole, and a partial parser would give a false sense
+   of containment.
+
+Under `allowAll` (bypass) `wouldBeRestricted` short-circuits to
+not-restricted, and an unconfined session (no `resolveBase`) is likewise never
+restricted — so those sessions produce zero warnings without any special-casing
+in the handler.
+
+## Threat model accepted
+
+The accepted model, per the issue, is **single-user-on-laptop with trusted task
+descriptions**: the human operator drives the session and is assumed not to be
+feeding it adversarial prompts crafted to exfiltrate their own files. Under that
+model the residual gap is an advisory concern (catch accidental out-of-worktree
+writes, keep the risk surface visible) rather than a hard security boundary. AFK
+is **not** hardened for running fully untrusted, adversarial task input through
+bash in `bypassPermissions`; that would require the deferred execFile/sandbox
+work.
+
+## Consequences
+
+**Covered** by the best-effort scan:
+
+- Direct absolute path references (`/etc/hosts`, `/tmp/outside/x`).
+- Home-relative references (`~/…` and a bare `~`), expanded to `os.homedir()`
+  before the containment check.
+- Quoted path tokens and paths abutting common shell punctuation
+  (`;`, `,`, `)`).
+
+**Not covered** (documented limitations — the reason this is advisory, not a
+boundary):
+
+- Command / arithmetic substitution: `$(printf /etc/hosts)`, backticks.
+- Environment-variable indirection: `$HOME/.ssh`, `${SECRET_DIR}`.
+- Glob and brace expansion: `/etc/*`, `/a/{b,c}`.
+- Paths synthesized across tokens, here-docs, or quoted paths containing
+  whitespace.
+
+Operational impact: a confined session that references an out-of-root path via
+bash still runs, but the operator sees a one-time `[security]` warning and a
+`tool.bash_path_escape` row in `routing-decisions.jsonl`. Bypass and unconfined
+sessions are unaffected (no warnings). No existing bash behavior changes.
+
+## References
+
+- [`src/agent/tools/handlers/bash.ts`](../../src/agent/tools/handlers/bash.ts) —
+  `createBashHandler`, `scanPathsBestEffort`.
+- [`src/agent/tools/handlers/_cwd-utils.ts`](../../src/agent/tools/handlers/_cwd-utils.ts) —
+  `extractCandidatePaths`, `wouldBeRestricted`, `resolveAndContain`.
+- [`CHANGELOG.md`](../../CHANGELOG.md) — C4 entries.
+- Issue #354 — "security: bash tool has no readRoots/writeRoots containment
+  (tracked C4)".

--- a/src/agent/routing-telemetry.ts
+++ b/src/agent/routing-telemetry.ts
@@ -114,6 +114,13 @@ export interface RoutingDecisionEntry {
   total_bytes?: number | undefined;
   /** Source stream when the event is stream-scoped: "stdout" | "stderr". */
   stream?: string | undefined;
+  /**
+   * Count of command-referenced paths found outside the allowed roots on a
+   * `tool.bash_path_escape` event. Operational metric only — the escaping
+   * paths themselves and the raw command string are deliberately NOT emitted
+   * (tool input; audit §G.4).
+   */
+  restricted_count?: number | undefined;
 }
 
 /**

--- a/src/agent/tools/handlers/_cwd-utils.test.ts
+++ b/src/agent/tools/handlers/_cwd-utils.test.ts
@@ -299,6 +299,15 @@ describe('extractCandidatePaths', () => {
     expect(extractCandidatePaths('cat `echo /etc/hosts`').length).toBeGreaterThan(0);
   });
 
+  it('strips a leading redirection/pipe operator glued to a path (#354)', () => {
+    // Operator glued directly to the path with no space — a common redirect
+    // form the earlier extractor dropped (leading `>` failed the `/`/`~` test).
+    expect(extractCandidatePaths('echo x >/etc/passwd')).toEqual(['/etc/passwd']);
+    expect(extractCandidatePaths('echo x >>~/.bashrc')).toEqual(['~/.bashrc']);
+    expect(extractCandidatePaths('cat foo 2>/tmp/err')).toEqual(['/tmp/err']);
+    expect(extractCandidatePaths('a |/tmp/x')).toEqual(['/tmp/x']);
+  });
+
   it('returns an empty array for a command with no path-like tokens', () => {
     expect(extractCandidatePaths('git status')).toEqual([]);
     expect(extractCandidatePaths('')).toEqual([]);

--- a/src/agent/tools/handlers/_cwd-utils.test.ts
+++ b/src/agent/tools/handlers/_cwd-utils.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, expect, it, afterEach } from 'vitest';
-import { resolveAndContain, wouldBeRestricted } from './_cwd-utils.js';
+import { resolveAndContain, wouldBeRestricted, extractCandidatePaths } from './_cwd-utils.js';
 import type { ToolHandlerContext } from '../types.js';
 import os from 'os';
 import fs from 'fs';
@@ -239,6 +239,69 @@ describe('symlink containment', () => {
     // Outside: wouldBeRestricted=true, resolveAndContain throws.
     expect(wouldBeRestricted(outsideFile, c).restricted).toBe(true);
     expect(() => resolveAndContain(outsideFile, c)).toThrow(/outside the allowed/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractCandidatePaths — best-effort path token extractor for the bash
+// handler's advisory containment scan (issue #354). Explicitly NOT a shell
+// parser; these tests pin the documented best-effort contract.
+// ---------------------------------------------------------------------------
+describe('extractCandidatePaths', () => {
+  it('extracts absolute path tokens', () => {
+    expect(extractCandidatePaths('cat /etc/hosts')).toEqual(['/etc/hosts']);
+  });
+
+  it('extracts home-relative tokens (~/… and bare ~)', () => {
+    expect(extractCandidatePaths('cat ~/.ssh/id_rsa')).toEqual(['~/.ssh/id_rsa']);
+    expect(extractCandidatePaths('ls ~')).toEqual(['~']);
+  });
+
+  it('extracts multiple distinct paths and dedupes repeats', () => {
+    expect(extractCandidatePaths('cp /a/b /c/d')).toEqual(['/a/b', '/c/d']);
+    expect(extractCandidatePaths('diff /a /a')).toEqual(['/a']);
+  });
+
+  it('ignores relative tokens, flags, and non-path words', () => {
+    expect(extractCandidatePaths('ls -la src/foo.ts ./bar --color=auto')).toEqual([]);
+    expect(extractCandidatePaths('echo hello world')).toEqual([]);
+  });
+
+  it('strips surrounding quotes from a path token', () => {
+    expect(extractCandidatePaths('cat "/etc/hosts"')).toEqual(['/etc/hosts']);
+    expect(extractCandidatePaths("cat '/etc/hosts'")).toEqual(['/etc/hosts']);
+  });
+
+  it('trims trailing shell punctuation abutting a path', () => {
+    expect(extractCandidatePaths('cd /tmp/foo; ls')).toEqual(['/tmp/foo']);
+    expect(extractCandidatePaths('cat /a/b, /c/d')).toEqual(['/a/b', '/c/d']);
+    expect(extractCandidatePaths('(cat /etc/hosts)')).toEqual(['/etc/hosts']);
+  });
+
+  it('does NOT understand shell constructs (documented best-effort gap)', () => {
+    // The extractor does not resolve/expand shell semantics — it only sees
+    // literal tokens. This is the whole reason the scan is advisory-only.
+    //
+    // env-var indirection: the synthesized path is invisible (no leading / or ~).
+    expect(extractCandidatePaths('cat $HOME/.ssh/id_rsa')).toEqual([]);
+    expect(extractCandidatePaths('cat ${SECRET_DIR}/key')).toEqual([]);
+    // A path whose VALUE is produced by substitution (e.g. `$(cat pathfile)`)
+    // is NOT understood — the extractor cannot see the runtime value:
+    expect(extractCandidatePaths('cat $(cat pathfile)')).toEqual([]);
+  });
+
+  it('picks up literal path tokens inside shell constructs (harmless false-positive)', () => {
+    // Conversely, a LITERAL path appearing inside a $()/backticks IS picked up
+    // naively — the extractor does not know it is inside a substitution. This
+    // is a harmless over-report: it would at worst produce one advisory warning.
+    // It is documented behavior, NOT a guarantee that $()/backticks are parsed.
+    expect(extractCandidatePaths('cat $(printf /etc/hosts)')).toContain('/etc/hosts');
+    expect(extractCandidatePaths('cat `echo /etc/hosts`').length).toBeGreaterThan(0);
+  });
+
+  it('returns an empty array for a command with no path-like tokens', () => {
+    expect(extractCandidatePaths('git status')).toEqual([]);
+    expect(extractCandidatePaths('')).toEqual([]);
   });
 });
 

--- a/src/agent/tools/handlers/_cwd-utils.ts
+++ b/src/agent/tools/handlers/_cwd-utils.ts
@@ -213,17 +213,18 @@ export function wouldBeRestricted(
  * Extracts, by whitespace tokenization:
  *   - Absolute paths (tokens beginning with `/`), and
  *   - Home-relative paths (tokens beginning with `~/`, or a bare `~`).
- * Surrounding single/double quotes are stripped, and trailing shell
- * punctuation commonly abutting a path in a command line (`;`, `,`, `)`,
- * `"`, `'`) is trimmed from the tail. Relative tokens, flags (`-x`,
- * `--flag`), and everything else are ignored.
+ * A leading shell redirection/pipe operator glued to the path (`>`, `>>`,
+ * `<`, `|`, `&`, and fd-prefixed forms like `2>`) is stripped first, then a
+ * surrounding single/double quote, then trailing shell punctuation commonly
+ * abutting a path in a command line (`;`, `,`, `)`, `"`, `'`). Relative
+ * tokens, flags (`-x`, `--flag`), and everything else are ignored.
  *
  * EXPLICITLY best-effort. This is NOT a shell parser and deliberately does
  * NOT resolve or catch:
  *   - command/arithmetic substitution: `$(printf /etc/hosts)`, backticks
  *   - environment-variable indirection: `$HOME`, `${SECRET_DIR}`
  *   - glob expansion: `/etc/*`, brace expansion `/a/{b,c}`
- *   - here-docs, redirections split across tokens, or quoted paths
+ *   - here-docs (`<<EOF`), paths synthesized across tokens, or quoted paths
  *     containing whitespace.
  * Building a real shell parser to close those gaps is a deliberate non-goal
  * (issue #354 calls it a rathole). The residual gap is the reason the bash
@@ -238,9 +239,14 @@ export function extractCandidatePaths(command: string): string[] {
   const out: string[] = [];
   for (const rawToken of command.split(/\s+/)) {
     if (rawToken.length === 0) continue;
-    // Strip a matching leading quote and any trailing quote/shell punctuation
-    // that commonly abuts a path token on a command line.
-    let token = rawToken.replace(/^['"]/, '').replace(/['";,)]+$/, '');
+    // Strip a leading shell redirection/pipe operator glued to the path
+    // (`>`, `>>`, `<`, `|`, `&`, and fd-prefixed forms like `2>`), then a
+    // matching leading quote, then any trailing quote/shell punctuation that
+    // commonly abuts a path token on a command line.
+    let token = rawToken
+      .replace(/^\d*[<>|&]+/, '')
+      .replace(/^['"]/, '')
+      .replace(/['";,)]+$/, '');
     if (token.length === 0) continue;
     const isAbsolute = token.startsWith('/');
     const isHomeRelative = token === '~' || token.startsWith('~/');

--- a/src/agent/tools/handlers/_cwd-utils.ts
+++ b/src/agent/tools/handlers/_cwd-utils.ts
@@ -205,3 +205,49 @@ export function wouldBeRestricted(
 
   return { restricted: true, resolved: abs, roots };
 }
+
+/**
+ * Best-effort extraction of filesystem path candidates from a raw shell
+ * command string, for the bash handler's advisory containment scan.
+ *
+ * Extracts, by whitespace tokenization:
+ *   - Absolute paths (tokens beginning with `/`), and
+ *   - Home-relative paths (tokens beginning with `~/`, or a bare `~`).
+ * Surrounding single/double quotes are stripped, and trailing shell
+ * punctuation commonly abutting a path in a command line (`;`, `,`, `)`,
+ * `"`, `'`) is trimmed from the tail. Relative tokens, flags (`-x`,
+ * `--flag`), and everything else are ignored.
+ *
+ * EXPLICITLY best-effort. This is NOT a shell parser and deliberately does
+ * NOT resolve or catch:
+ *   - command/arithmetic substitution: `$(printf /etc/hosts)`, backticks
+ *   - environment-variable indirection: `$HOME`, `${SECRET_DIR}`
+ *   - glob expansion: `/etc/*`, brace expansion `/a/{b,c}`
+ *   - here-docs, redirections split across tokens, or quoted paths
+ *     containing whitespace.
+ * Building a real shell parser to close those gaps is a deliberate non-goal
+ * (issue #354 calls it a rathole). The residual gap is the reason the bash
+ * containment scan is advisory-only, documented in
+ * `docs/decisions/0001-bash-tool-path-containment.md`.
+ *
+ * @param command - The raw command string from the bash tool input.
+ * @returns Deduplicated candidate path tokens (order-preserving).
+ */
+export function extractCandidatePaths(command: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const rawToken of command.split(/\s+/)) {
+    if (rawToken.length === 0) continue;
+    // Strip a matching leading quote and any trailing quote/shell punctuation
+    // that commonly abuts a path token on a command line.
+    let token = rawToken.replace(/^['"]/, '').replace(/['";,)]+$/, '');
+    if (token.length === 0) continue;
+    const isAbsolute = token.startsWith('/');
+    const isHomeRelative = token === '~' || token.startsWith('~/');
+    if (!isAbsolute && !isHomeRelative) continue;
+    if (seen.has(token)) continue;
+    seen.add(token);
+    out.push(token);
+  }
+  return out;
+}

--- a/src/agent/tools/handlers/bash.test.ts
+++ b/src/agent/tools/handlers/bash.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs, mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import * as os from 'node:os';
@@ -841,6 +841,112 @@ describe('bash SIGKILL — S10', () => {
     },
     5000, // vitest per-test timeout: 5 s (handler kills at 300 ms + 100 ms reap window + headroom)
   );
+});
+
+// ---------------------------------------------------------------------------
+// C4 (#354): best-effort readRoots/writeRoots path-containment scan.
+//
+// The scan is ADVISORY-ONLY: when a command references an absolute/home-relative
+// path outside the session's writeRoots it emits one `[security]` console.warn
+// (and a telemetry row) but STILL executes the command — it never blocks. These
+// tests assert both halves: the warning fires (or is suppressed) as specified,
+// AND the command runs to completion either way.
+//
+// NB: appendRoutingDecision is a no-op under vitest (env.VITEST guard), so we
+// spy on console.warn — the reliable, synchronous signal that the escape path
+// was taken. `warnIfBypassPermissions` also writes a `[security]` line, so we
+// match specifically on the path-escape substring to disambiguate.
+// ---------------------------------------------------------------------------
+describe('bash path-containment scan — C4 (#354)', () => {
+  function createSignal(): AbortSignal {
+    return new AbortController().signal;
+  }
+
+  const ESCAPE_MARKER = 'command references path(s) outside writeRoots';
+
+  let root: string;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Real temp dir so realpathSafe (inside wouldBeRestricted) resolves.
+    root = realpathSync(mkdtempSync(join(tmpdir(), 'bash-contain-')));
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    try { rmSync(root, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  function escapeWarnings(): string[] {
+    return warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes(ESCAPE_MARKER));
+  }
+
+  it('warns AND still executes when a command references a path outside writeRoots', async () => {
+    // 'default' mode → allowAll is NOT set, so containment is enforced/advised.
+    const handler = createBashHandler('default', root);
+    const result = await handler(
+      { command: 'echo hi /etc/hosts' },
+      createSignal(),
+      { resolveBase: root, readRoots: [root], writeRoots: [root], allowAll: false },
+    );
+
+    // Warned about the escape…
+    const warnings = escapeWarnings();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('/etc/hosts');
+    expect(warnings[0]).toContain('best-effort');
+
+    // …but the command STILL ran (advisory-only, not a block).
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain('hi');
+  });
+
+  it('does NOT warn when allowAll (bypass) is set, even for an out-of-root path', async () => {
+    const handler = createBashHandler('default', root);
+    const result = await handler(
+      { command: 'echo hi /etc/hosts' },
+      createSignal(),
+      { resolveBase: root, readRoots: [root], writeRoots: [root], allowAll: true },
+    );
+
+    expect(escapeWarnings()).toHaveLength(0);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain('hi');
+  });
+
+  it('does NOT warn when the command references only in-root paths', async () => {
+    const inRoot = join(root, 'file.txt');
+    const handler = createBashHandler('default', root);
+    const result = await handler(
+      { command: `echo hi ${inRoot}` },
+      createSignal(),
+      { resolveBase: root, readRoots: [root], writeRoots: [root], allowAll: false },
+    );
+
+    expect(escapeWarnings()).toHaveLength(0);
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain('hi');
+  });
+
+  it('warns at most once per handler instance (one-time latch)', async () => {
+    const handler = createBashHandler('default', root);
+    const ctx = { resolveBase: root, readRoots: [root], writeRoots: [root], allowAll: false };
+    await handler({ command: 'cat /etc/hosts' }, createSignal(), ctx);
+    await handler({ command: 'cat /etc/passwd' }, createSignal(), ctx);
+
+    // Latch means the second escaping command does not re-warn.
+    expect(escapeWarnings()).toHaveLength(1);
+  });
+
+  it('does NOT warn when no context is supplied (inline/back-compat call)', async () => {
+    const handler = createBashHandler('default', root);
+    const result = await handler({ command: 'echo hi /etc/hosts' }, createSignal());
+    expect(escapeWarnings()).toHaveLength(0);
+    expect(result.isError).toBeFalsy();
+  });
 });
 
 

--- a/src/agent/tools/handlers/bash.test.ts
+++ b/src/agent/tools/handlers/bash.test.ts
@@ -904,6 +904,26 @@ describe('bash path-containment scan — C4 (#354)', () => {
     expect(result.content).toContain('hi');
   });
 
+  it('expands ~/… and warns when a home-relative path escapes writeRoots', async () => {
+    // End-to-end exercise of scanPathsBestEffort's ~ / ~/… expansion branch:
+    // `~/.ssh/id_rsa` expands to os.homedir()/.ssh/id_rsa — outside the temp-dir
+    // writeRoots — so it warns (and still executes). Had expansion NOT fired, the
+    // token would anchor to resolveBase (in-root) and produce zero warnings, so
+    // the single warning is itself proof the expansion happened.
+    const handler = createBashHandler('default', root);
+    const result = await handler(
+      { command: 'echo hi ~/.ssh/id_rsa' },
+      createSignal(),
+      { resolveBase: root, readRoots: [root], writeRoots: [root], allowAll: false },
+    );
+
+    const warnings = escapeWarnings();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(join(os.homedir(), '.ssh/id_rsa'));
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain('hi');
+  });
+
   it('does NOT warn when allowAll (bypass) is set, even for an out-of-root path', async () => {
     const handler = createBashHandler('default', root);
     const result = await handler(

--- a/src/agent/tools/handlers/bash.ts
+++ b/src/agent/tools/handlers/bash.ts
@@ -15,12 +15,14 @@
  */
 
 import { spawn } from 'child_process';
+import os from 'os';
 import type { ToolHandler, ToolHandlerContext } from '../types.js';
 import { appendRoutingDecision } from '../../routing-telemetry.js';
 import { detectTestResult } from './test-runner-detector.js';
 import { stripEscapeSequences } from '../../../utils/terminal-sanitize.js';
 import { describeSpawnCwdError, isSpawnEnoent } from '../../../utils/spawn-cwd-error.js';
 import { HARD_CAP_BYTES, MODEL_CAP_BYTES, headAndTail, capForModel, HARD_CAP_KILL_NOTE } from './_output-cap.js';
+import { extractCandidatePaths, wouldBeRestricted } from './_cwd-utils.js';
 
 /**
  * Input shape for the bash tool (validated at runtime).
@@ -86,12 +88,30 @@ function parseBashInput(input: unknown): { command: string; timeout_ms: number }
  * full `execFile`-based refactor that disables the shell is tracked as a
  * separate work item. For now we emit a one-time warning at startup so the
  * risk surface is explicit in logs.
+ *
+ * Path containment (advisory-only): unlike the typed filesystem handlers,
+ * which route every path through `resolveAndContain` and hard-reject writes
+ * outside `writeRoots`, bash cannot reliably know which paths a `shell: true`
+ * command will touch — the command string is opaque. So instead of blocking,
+ * the handler runs a BEST-EFFORT scan before spawning: it extracts absolute
+ * and home-relative path tokens (`extractCandidatePaths`) and checks each
+ * against the session's write roots (`wouldBeRestricted`, `mode: 'write'`).
+ * If any references a path outside the roots it emits a ONE-TIME advisory
+ * `console.warn` plus a `tool.bash_path_escape` telemetry row, then spawns
+ * normally — it never refuses execution. Refusing would break the primary
+ * human-driven `afk -w` worktree flow (a top-level bypass session legitimately
+ * carries a non-empty `writeRoots`), and `wouldBeRestricted` already returns
+ * not-restricted under `allowAll`, so bypass sessions produce no noise. The
+ * scan is deliberately not a shell parser: it does not catch `$()`, env-var
+ * indirection, backticks, or globs. Rationale and the accepted threat model
+ * are documented in `docs/decisions/0001-bash-tool-path-containment.md`.
  */
 export function createBashHandler(
   permissionMode: string,
   cwd?: string,
 ): ToolHandler {
   let _shellModeWarned = false;
+  let _pathEscapeWarned = false;
 
   function warnIfBypassPermissions(): void {
     if (_shellModeWarned) return;
@@ -105,6 +125,59 @@ export function createBashHandler(
     }
   }
 
+  /**
+   * Best-effort, ADVISORY-ONLY containment scan (never blocks execution).
+   *
+   * Extracts absolute / home-relative path tokens from the raw command and
+   * checks each against the session's WRITE roots — the stricter, most
+   * relevant boundary for the "escape the worktree" threat, and in practice
+   * `readRoots ⊇ writeRoots` for confined forks. Home-relative tokens are
+   * expanded to `os.homedir()` first so `wouldBeRestricted` (which anchors
+   * non-absolute inputs to `resolveBase`) sees a true absolute path.
+   *
+   * On the first out-of-root reference (per handler instance) it emits one
+   * `console.warn` naming the escaping resolved paths and one
+   * `tool.bash_path_escape` telemetry row (counts + mode only — never the raw
+   * command string; audit §G.4). Then it returns and the caller spawns as
+   * normal. `wouldBeRestricted` short-circuits to not-restricted under
+   * `allowAll` (bypass) and when no `resolveBase` is set (unconfined session),
+   * so those sessions naturally produce zero warnings — intended, not
+   * special-cased here.
+   */
+  function scanPathsBestEffort(command: string, context: ToolHandlerContext): void {
+    if (_pathEscapeWarned) return; // one-time per handler instance
+    const fallbackBase = context.resolveBase ?? context.cwd ?? cwd;
+    const home = os.homedir();
+    const escaping: string[] = [];
+    for (const candidate of extractCandidatePaths(command)) {
+      // Expand ~ / ~/… to an absolute path so wouldBeRestricted does not
+      // anchor it to resolveBase and mis-resolve it as in-root.
+      const expanded =
+        candidate === '~'
+          ? home
+          : candidate.startsWith('~/')
+            ? home + candidate.slice(1)
+            : candidate;
+      const verdict = wouldBeRestricted(expanded, context, 'write', fallbackBase);
+      if (verdict.restricted) escaping.push(verdict.resolved);
+    }
+    if (escaping.length === 0) return;
+    _pathEscapeWarned = true;
+    console.warn(
+      `[security] bash: command references path(s) outside writeRoots: ${escaping.join(', ')} — ` +
+        'bash containment is best-effort (tracked C4); use file tools for contained writes.',
+    );
+    // Telemetry: counts + mode only. The raw command string and the escaping
+    // paths list are tool input and stay out of the JSONL (audit §G.4) — same
+    // privacy rule as the overflow-kill path above.
+    void appendRoutingDecision({
+      event: 'tool.bash_path_escape',
+      tool: 'bash',
+      restricted_count: escaping.length,
+      mode: 'write',
+    });
+  }
+
   return async (input: unknown, signal: AbortSignal, context?: ToolHandlerContext) => {
     let { command, timeout_ms } = parseBashInput(input);
 
@@ -113,6 +186,13 @@ export function createBashHandler(
     }
 
     warnIfBypassPermissions();
+
+    // Advisory-only containment scan (warn + telemetry, never blocks). Only
+    // runs when a context is present — inline/back-compat calls without one
+    // have no roots to check against.
+    if (context !== undefined) {
+      scanPathsBestEffort(command, context);
+    }
 
   return new Promise((resolve) => {
     let resolved = false;

--- a/src/agent/tools/handlers/bash.ts
+++ b/src/agent/tools/handlers/bash.ts
@@ -189,9 +189,15 @@ export function createBashHandler(
 
     // Advisory-only containment scan (warn + telemetry, never blocks). Only
     // runs when a context is present — inline/back-compat calls without one
-    // have no roots to check against.
+    // have no roots to check against. Wrapped in try/catch so a scan-internal
+    // throw (e.g. os.homedir() failing) can never invert the "never blocks"
+    // guarantee: an advisory failure must not stop the command from spawning.
     if (context !== undefined) {
-      scanPathsBestEffort(command, context);
+      try {
+        scanPathsBestEffort(command, context);
+      } catch {
+        /* advisory-only — swallow and spawn regardless */
+      }
     }
 
   return new Promise((resolve) => {


### PR DESCRIPTION
Closes #354.

## What

Adds **best-effort, advisory-only** `readRoots`/`writeRoots` path containment to the `bash` tool handler, plus an ADR documenting the accepted residual gap. Satisfies **both** acceptance criteria in #354 (enforce/scan extractable paths *and* a documented architectural decision).

## Why this shape (and why NOT fail-closed)

The `bash` handler spawns via `shell: true` and, unlike the six typed filesystem handlers (which all route through `resolveAndContain`), never consulted the session roots — the widest containment gap in the toolset (tracked **C4**).

The issue floats a fail-closed idea: *refuse bash when `writeRoots` is set AND `bypassPermissions`*. **Rejected** — verified that a top-level `afk -w` session runs under `bypassPermissions` with a non-empty effective `writeRoots=[worktree]`, so that refusal would break the primary human-driven worktree workflow. (Sub-agent forks run `permissionMode='default'` and never inherit bypass, so they wouldn't be refused anyway — the refusal would *only* ever hit the legitimate top-level session.) So the scan is **warn-only: it never blocks execution.**

## How

- New `extractCandidatePaths(command)` in `_cwd-utils.ts`: best-effort tokenizer pulling absolute (`/…`) and home-relative (`~`, `~/…`) tokens, quote-stripped. Explicitly **not** a shell parser — does not see `$()`, backticks, env-var indirection, or globs (that limitation is the whole reason the ADR exists; the issue calls a real parser a rathole).
- `bash.ts`: `scanPathsBestEffort()` runs before spawn, expands `~`, calls the existing non-throwing `wouldBeRestricted(path, context, 'write', …)` per candidate. On an out-of-root reference it emits a one-time `[security]` `console.warn` naming the escaping resolved paths + a `tool.bash_path_escape` telemetry row (counts + mode only — **never** the raw command string, matching the existing overflow-telemetry privacy rule), then spawns normally. `wouldBeRestricted` already short-circuits to not-restricted under `allowAll`, so bypass sessions produce no noise.
- `docs/decisions/0001-bash-tool-path-containment.md`: ADR (Accepted) — context, the warn-only decision, the fail-closed rejection rationale, the accepted threat model (single-user-on-laptop, trusted task descriptions), covered vs. uncovered cases, references.
- `CHANGELOG.md`: C4 entry under Unreleased.

## Verification

- `tsc --noEmit` (repo `lint`): **clean (exit 0)**
- `vitest run`: **96/96 pass** — `bash.test.ts` (60), `_cwd-utils.test.ts` (31), `routing-telemetry.test.ts` (5)
- New tests cover: extractor tokenization (absolute/home/quoted/dedup, ignores relative+flags); out-of-root path → warns **and still executes** (not an error); `allowAll` → no warning; in-root → no warning; one-time warn latch; no-context path.

## Notes

Full `execFile`/sandbox containment remains deferred (still tracked C4) — out of scope by design per the issue's staging. Residual best-effort limitations are documented in the ADR and pinned by tests.
