### PR TITLE
fix(path-approval): honor unconfined resolveBase in the hook + add read-denylist floor

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -473,6 +473,14 @@
       "category": "model"
     },
     {
+      "name": "AFK_READ_DENYLIST",
+      "description": "Colon-separated list of additional absolute paths the read_file/grep/glob/list_directory tools refuse to read. Built-in credential entries (~/.ssh, ~/.aws, ~/.afk/config, …) always apply on top and cannot be removed.",
+      "type": "string",
+      "required": false,
+      "example": "/Users/me/project/.env:/Users/me/secrets",
+      "category": "misc"
+    },
+    {
       "name": "AFK_RUN_RECEIPT_DISABLED",
       "description": "Disable the post-session run receipt (state/receipts/<label>.json and .md). Set to 1 to skip receipt writes; the underlying witness trace is unaffected. Receipts are also implicitly off when AFK_TRACE_DISABLED=1 (no trace to summarize).",
       "type": "boolean",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**120 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**121 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 
@@ -178,6 +178,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_DEMO_CLEAN` | boolean |  |  | `1` | Explicit opt-in to capture-mode. When set to 1, suppresses high-frequency repaint drivers (spinner ticker, live thinking-preview) so recorded artifacts contain each state once instead of once per timer tick. |
 | `AFK_DIFF_LINES` | number |  |  | `50` | Maximum number of diff lines shown in the inline diff render during write_file tool calls. Set to 0 for no cap. Non-integer values are silently ignored and the default applies. |
 | `AFK_MEMORY_EVIDENCE_GATE` | boolean |  |  | `1` | Opt-in (set to 1) evidence gate for durable memory writes. When enabled, a codebase fact (memory_update category "convention") stored without an `evidence` citation is recalled as [unverified], and memory_search results carry a verification verdict. User preferences and agent reflections are never gated. Default off — memory behaves identically to legacy when unset. |
+| `AFK_READ_DENYLIST` | string |  |  | `/Users/me/project/.env:/Users/me/secrets` | Colon-separated list of additional absolute paths the read_file/grep/glob/list_directory tools refuse to read. Built-in credential entries (~/.ssh, ~/.aws, ~/.afk/config, …) always apply on top and cannot be removed. |
 | `AFK_SHELL_PASSTHROUGH` | boolean |  | `1` | `0` | Enable the interactive REPL `!cmd` / `!&cmd` shell-passthrough feature. On by default. Set to 0, false, off, or no (case-insensitive) to disable, so inputs beginning with ! are sent to the model as literal text instead of being executed as shell commands. Equivalent to the --no-shell-passthrough flag. |
 | `AFK_SHOW_DIFFS` | boolean |  |  |  | Show inline diffs in the tool-lane output for edit/write tool calls. 1 = on, 0 = off. |
 | `AFK_SPINNER_TIPS` | boolean |  |  |  | Show rotating tips in the loading spinner during long calls. 1 = on, 0 = off. |

--- a/src/agent/tools/handlers/_cwd-utils.ts
+++ b/src/agent/tools/handlers/_cwd-utils.ts
@@ -11,6 +11,7 @@
 import path from 'path';
 import { realpathSync } from 'fs';
 import type { ToolHandlerContext } from '../types.js';
+import { isReadDenied } from './read-denylist.js';
 
 // Invariant: symlink containment must be resolved at the filesystem level, not
 // lexically. A symlink that lives INSIDE a granted root but points OUTSIDE it
@@ -96,6 +97,24 @@ export function resolveAndContain(
   const abs = path.isAbsolute(inputPath)
     ? inputPath
     : path.resolve(resolveBase ?? process.cwd(), inputPath);
+
+  // Unconditional read-denylist floor: credential/secret paths (~/.ssh,
+  // ~/.afk/config, …) are never readable by a typed file tool — regardless of
+  // confinement, bypass mode, or fork status. This closes the read/write
+  // asymmetry (writes are gated by write-denylist.ts; reads had NO floor) and
+  // backstops the `allowAll` + unconfined fast-paths below, which would
+  // otherwise admit a credential read. Checked here because all four read
+  // handlers funnel through resolveAndContain. Writes keep their own floor in
+  // write-file.ts / edit-file.ts.
+  if (mode === 'read') {
+    const denied = isReadDenied(abs);
+    if (denied.denied) {
+      throw new Error(
+        `Path \`${inputPath}\` is a protected credential/secret path ` +
+          `(read-denylist entry: \`${denied.matched}\`) and cannot be read.`,
+      );
+    }
+  }
 
   // Bypass mode: the session runs in `bypassPermissions`, which disables all
   // path containment. Admit any path (no throw). This is the same switch the

--- a/src/agent/tools/handlers/read-denylist.test.ts
+++ b/src/agent/tools/handlers/read-denylist.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for the read-denylist shared utility.
+ *
+ * Covers:
+ * - Credential stores (~/.ssh, ~/.aws, ~/.gnupg, ~/.afk/config, ~/.npmrc,
+ *   ~/.docker/config.json) are read-denied.
+ * - Deliberate divergence from the WRITE denylist: ~/.afk/STATE is NOT denied
+ *   (forks must read skill-preflight/todos/transcripts — #544/#547/#554), and
+ *   /etc is not blanket-denied (only specific secret files).
+ * - Symlink bypass is blocked: a symlink pointing into ~/.ssh is dereferenced.
+ * - Custom AFK_READ_DENYLIST entries are applied (with cache reset).
+ *
+ * @module agent/tools/handlers/read-denylist.test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, symlinkSync, existsSync } from 'fs';
+import { join } from 'path';
+import { homedir, tmpdir } from 'os';
+import {
+  isReadDenied,
+  assertNotReadDenied,
+  getReadDenylist,
+  BUILTIN_READ_DENYLIST,
+  _resetReadDenylistCacheForTests,
+} from './read-denylist.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  _resetReadDenylistCacheForTests();
+  tmpDir = join(tmpdir(), `afk-read-denylist-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  delete process.env['AFK_READ_DENYLIST'];
+  _resetReadDenylistCacheForTests();
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('isReadDenied — credential stores', () => {
+  const credPaths = [
+    join(homedir(), '.ssh', 'id_rsa'),
+    join(homedir(), '.aws', 'credentials'),
+    join(homedir(), '.gnupg', 'secring.gpg'),
+    join(homedir(), '.afk', 'config', 'afk.env'),
+    join(homedir(), '.npmrc'),
+    join(homedir(), '.docker', 'config.json'),
+  ];
+
+  for (const p of credPaths) {
+    it(`denies ${p.replace(homedir(), '~')}`, () => {
+      expect(isReadDenied(p).denied).toBe(true);
+    });
+  }
+
+  it('every BUILTIN_READ_DENYLIST entry triggers the guard', () => {
+    for (const entry of BUILTIN_READ_DENYLIST) {
+      expect(isReadDenied(join(entry, 'probe')).denied).toBe(true);
+    }
+  });
+});
+
+describe('isReadDenied — deliberate divergence from the write denylist', () => {
+  it('does NOT deny ~/.afk/state (forks must read skill-preflight/todos/transcripts)', () => {
+    expect(isReadDenied(join(homedir(), '.afk', 'state', 'skill-preflight', 's', 'pr.diff')).denied).toBe(false);
+    expect(isReadDenied(join(homedir(), '.afk', 'state', 'todos', 't.json')).denied).toBe(false);
+  });
+
+  it('DOES deny ~/.afk/config (afk.env credentials)', () => {
+    expect(isReadDenied(join(homedir(), '.afk', 'config', 'afk.env')).denied).toBe(true);
+    expect(isReadDenied(join(homedir(), '.afk', 'config', 'mcp.json')).denied).toBe(true);
+  });
+
+  it('does NOT blanket-deny /etc (ordinary system reads stay allowed)', () => {
+    expect(isReadDenied('/etc/hosts').denied).toBe(false);
+    expect(isReadDenied('/etc/resolv.conf').denied).toBe(false);
+  });
+
+  it('DOES deny the enumerated secret system files', () => {
+    expect(isReadDenied('/etc/shadow').denied).toBe(true);
+    expect(isReadDenied('/etc/sudoers').denied).toBe(true);
+  });
+
+  it('does NOT deny an ordinary project path', () => {
+    expect(isReadDenied(join(tmpDir, 'src', 'index.ts')).denied).toBe(false);
+    expect(isReadDenied('/tmp/some-repo/package.json').denied).toBe(false);
+  });
+});
+
+describe('assertNotReadDenied', () => {
+  it('throws for a credential path, with the handler name in the message', () => {
+    expect(() => assertNotReadDenied(join(homedir(), '.ssh', 'id_rsa'), 'grep')).toThrow(/grep/);
+    expect(() => assertNotReadDenied(join(homedir(), '.ssh', 'id_rsa'))).toThrow(
+      /refusing to read protected path/,
+    );
+  });
+
+  it('does not throw for a normal path', () => {
+    expect(() => assertNotReadDenied(join(tmpDir, 'ok.ts'))).not.toThrow();
+  });
+});
+
+describe('read-denylist — symlink dereference', () => {
+  it('blocks a read through a symlink that resolves to ~/.ssh', () => {
+    const sshDir = join(homedir(), '.ssh');
+    if (!existsSync(sshDir)) return; // dangling symlink can't resolve — vacuous on this runner
+    const linkPath = join(tmpDir, 'ssh-link');
+    symlinkSync(sshDir, linkPath);
+    expect(isReadDenied(join(linkPath, 'id_rsa')).denied).toBe(true);
+  });
+});
+
+describe('read-denylist — AFK_READ_DENYLIST extras', () => {
+  it('applies a custom colon-separated denylist entry (built-ins still apply)', () => {
+    const projectSecret = join(tmpDir, 'secrets');
+    mkdirSync(projectSecret, { recursive: true });
+    process.env['AFK_READ_DENYLIST'] = projectSecret;
+    _resetReadDenylistCacheForTests();
+
+    expect(isReadDenied(join(projectSecret, '.env')).denied).toBe(true);
+    // Built-ins are unaffected by the custom list.
+    expect(isReadDenied(join(homedir(), '.ssh', 'id_rsa')).denied).toBe(true);
+    // The resolved list contains the custom entry.
+    expect(getReadDenylist().some((p) => p.includes('secrets'))).toBe(true);
+  });
+});

--- a/src/agent/tools/handlers/read-denylist.test.ts
+++ b/src/agent/tools/handlers/read-denylist.test.ts
@@ -3,11 +3,13 @@
  *
  * Covers:
  * - Credential stores (~/.ssh, ~/.aws, ~/.gnupg, ~/.afk/config, ~/.npmrc,
- *   ~/.docker/config.json) are read-denied.
+ *   ~/.docker/config.json) plus git/gh/k8s token files (~/.git-credentials,
+ *   ~/.netrc, ~/.config/gh/hosts.yml, ~/.kube/config) are read-denied.
  * - Deliberate divergence from the WRITE denylist: ~/.afk/STATE is NOT denied
  *   (forks must read skill-preflight/todos/transcripts — #544/#547/#554), and
  *   /etc is not blanket-denied (only specific secret files).
- * - Symlink bypass is blocked: a symlink pointing into ~/.ssh is dereferenced.
+ * - Symlink bypass is blocked: a symlink into a denylisted dir is dereferenced
+ *   (via a tmpdir fixture that always runs, not gated on ~/.ssh existing).
  * - Custom AFK_READ_DENYLIST entries are applied (with cache reset).
  *
  * @module agent/tools/handlers/read-denylist.test
@@ -47,6 +49,11 @@ describe('isReadDenied — credential stores', () => {
     join(homedir(), '.afk', 'config', 'afk.env'),
     join(homedir(), '.npmrc'),
     join(homedir(), '.docker', 'config.json'),
+    // Git/HTTP credential stores and CLI OAuth tokens (read-exfil hardening).
+    join(homedir(), '.git-credentials'),
+    join(homedir(), '.netrc'),
+    join(homedir(), '.config', 'gh', 'hosts.yml'),
+    join(homedir(), '.kube', 'config'),
   ];
 
   for (const p of credPaths) {
@@ -103,9 +110,33 @@ describe('assertNotReadDenied', () => {
 });
 
 describe('read-denylist — symlink dereference', () => {
-  it('blocks a read through a symlink that resolves to ~/.ssh', () => {
+  // Robust fixture: build a real denylisted dir inside tmpDir (registered via
+  // AFK_READ_DENYLIST) and point a symlink at it, so the dereference path is
+  // exercised UNCONDITIONALLY — not gated on ~/.ssh existing on the runner
+  // (the prior test silently returned when it didn't, asserting nothing).
+  it('blocks a read through a symlink that resolves into a denylisted dir', () => {
+    const secretDir = join(tmpDir, 'real-secret');
+    mkdirSync(secretDir, { recursive: true });
+    process.env['AFK_READ_DENYLIST'] = secretDir;
+    _resetReadDenylistCacheForTests();
+
+    const linkPath = join(tmpDir, 'secret-link');
+    symlinkSync(secretDir, linkPath);
+
+    // Reading THROUGH the symlink must be denied (safeRealpath dereferences it
+    // to the denylisted target before the prefix comparison).
+    const via = isReadDenied(join(linkPath, 'token.txt'));
+    expect(via.denied).toBe(true);
+    // And the innocuous symlink path is not what matched — the resolved target is.
+    expect(via.matched).not.toBe(linkPath);
+  });
+
+  it('dereferences a symlink into a built-in denylisted dir when it exists', () => {
+    // Bonus real-world case against a built-in (~/.ssh). Kept guarded because
+    // the runner may lack ~/.ssh; the tmpdir fixture above is the authoritative
+    // dereference assertion, so skipping here never leaves the suite vacuous.
     const sshDir = join(homedir(), '.ssh');
-    if (!existsSync(sshDir)) return; // dangling symlink can't resolve — vacuous on this runner
+    if (!existsSync(sshDir)) return;
     const linkPath = join(tmpDir, 'ssh-link');
     symlinkSync(sshDir, linkPath);
     expect(isReadDenied(join(linkPath, 'id_rsa')).denied).toBe(true);

--- a/src/agent/tools/handlers/read-denylist.ts
+++ b/src/agent/tools/handlers/read-denylist.ts
@@ -1,0 +1,122 @@
+/**
+ * Shared read-denylist utilities for file-reading tool handlers.
+ *
+ * Reads had NO secret-path floor while writes did (see `write-denylist.ts`) —
+ * an asymmetry that let any UNCONFINED session (and its forks) read credential
+ * stores via `read_file` / `grep` / `glob` / `list_directory`. This module
+ * closes that gap: it is enforced unconditionally in `resolveAndContain`
+ * (before the `allowAll` and unconfined fast-paths) and in the path-approval
+ * PreToolUse hook, so no confinement mode — bypass, unconfined, or a forked
+ * sub-agent — can reach a denylisted path.
+ *
+ * Divergence from the WRITE denylist is deliberate:
+ *   - `~/.afk/config` (afk.env API keys, mcp.json) IS denied — as for writes.
+ *   - `~/.afk/state` is NOT denied — sub-agents legitimately READ skill-preflight
+ *     inputs, todos, transcripts, and session ledgers there (#544/#547/#554);
+ *     denying it would re-introduce the very read failures those fixes closed.
+ *   - `/etc`, `/System`, … are NOT blanket-denied for reads (unlike writes):
+ *     legitimate reads of `/etc/hosts` etc. are common, and the truly-secret
+ *     system files are enumerated individually below.
+ *
+ * Symlink safety is inherited from `safeRealpath` (write-denylist.ts): a
+ * symlink `~/link → ~/.ssh` is dereferenced before the prefix comparison.
+ *
+ * @module agent/tools/handlers/read-denylist
+ */
+
+import { env } from '../../../config/env.js';
+import { resolve } from 'path';
+import { homedir } from 'os';
+import { safeRealpath } from './write-denylist.js';
+
+/**
+ * Paths that `read_file` / `grep` / `glob` / `list_directory` must never read —
+ * credential stores and secret files. Each entry is matched against the real
+ * (symlink-resolved) target path as a prefix.
+ *
+ * Extend via `AFK_READ_DENYLIST` (colon-separated absolute paths). As with the
+ * write denylist, the built-in entries always apply on top of any custom list;
+ * there is intentionally no way to remove a built-in via env.
+ */
+export const BUILTIN_READ_DENYLIST: readonly string[] = [
+  `${homedir()}/.ssh`,
+  `${homedir()}/.aws`,
+  `${homedir()}/.gnupg`,
+  `${homedir()}/.config/gcloud`,
+  // AFK's own credential/config tree (afk.env API keys, mcp.json).
+  // Invariant: only `.../config` — NEVER `.../state`, which forked sub-agents
+  // must be able to read (skill-preflight inputs, todos, transcripts). Adding
+  // `.../state` here would re-break #544/#547/#554.
+  `${homedir()}/.afk/config`,
+  // npm publish tokens and Docker registry credentials.
+  `${homedir()}/.npmrc`,
+  `${homedir()}/.docker/config.json`,
+  // Classic system secret stores. Enumerated individually (not the whole /etc)
+  // so ordinary /etc reads still work; these are usually root-only anyway.
+  '/etc/shadow',
+  '/etc/sudoers',
+  '/private/etc/master.passwd',
+];
+
+// Memoized resolved denylist, keyed by the AFK_READ_DENYLIST value so a test
+// that changes the env re-resolves. Reads are a hot path (every grep/glob/
+// read_file call routes through resolveAndContain), so resolving the ~10
+// built-in entries' symlinks on every call is avoided. Threat-model note: a
+// denylist entry's symlink is assumed stable within a process (mirrors the
+// rootRealpathCache assumption in _cwd-utils.ts).
+let cached: { key: string; list: readonly string[] } | undefined;
+
+/**
+ * Return the effective read denylist (built-in + any `AFK_READ_DENYLIST`
+ * extras), each as a real (symlink-resolved) absolute path.
+ */
+export function getReadDenylist(): readonly string[] {
+  const key = env.AFK_READ_DENYLIST ?? '';
+  if (cached && cached.key === key) return cached.list;
+  const extras: string[] = key
+    ? key.split(':').map((p) => safeRealpath(resolve(p))).filter(Boolean)
+    : [];
+  const list = [...BUILTIN_READ_DENYLIST.map((p) => safeRealpath(resolve(p))), ...extras];
+  cached = { key, list };
+  return list;
+}
+
+/**
+ * Test-only: clear the memoized denylist so suites that mutate
+ * `AFK_READ_DENYLIST` or repoint a denylisted symlink don't see a stale list.
+ */
+export function _resetReadDenylistCacheForTests(): void {
+  cached = undefined;
+}
+
+/**
+ * Return whether `filePath` resolves (symlink-dereferenced) inside a
+ * read-denylisted prefix. Never throws.
+ */
+export function isReadDenied(filePath: string): { denied: boolean; matched?: string } {
+  const real = safeRealpath(resolve(filePath));
+  for (const blocked of getReadDenylist()) {
+    if (real === blocked || real.startsWith(blocked + '/')) {
+      return { denied: true, matched: blocked };
+    }
+  }
+  return { denied: false };
+}
+
+/**
+ * Throw if the resolved (symlink-dereferenced) path falls inside a
+ * read-denylisted prefix. Mirrors `assertNotDenylisted` for writes.
+ *
+ * @param filePath    - The raw path as supplied by the model.
+ * @param handlerName - Tool name for the error message.
+ */
+export function assertNotReadDenied(filePath: string, handlerName = 'read_file'): void {
+  const { denied, matched } = isReadDenied(filePath);
+  if (denied) {
+    const real = safeRealpath(resolve(filePath));
+    throw new Error(
+      `${handlerName}: refusing to read protected path: ${real}` +
+        ` (matches read-denylist entry: ${matched})`,
+    );
+  }
+}

--- a/src/agent/tools/handlers/read-denylist.ts
+++ b/src/agent/tools/handlers/read-denylist.ts
@@ -17,6 +17,11 @@
  *   - `/etc`, `/System`, … are NOT blanket-denied for reads (unlike writes):
  *     legitimate reads of `/etc/hosts` etc. are common, and the truly-secret
  *     system files are enumerated individually below.
+ *   - Conversely, this list floors a few high-value credential files the WRITE
+ *     denylist does not yet cover (~/.git-credentials, ~/.netrc, gh hosts.yml,
+ *     ~/.kube/config): read-exfiltration of a live token is the acute risk for
+ *     an agent that runs git/gh, so reads are floored first. Mirroring these
+ *     into BUILTIN_WRITE_DENYLIST is a reasonable follow-up.
  *
  * Symlink safety is inherited from `safeRealpath` (write-denylist.ts): a
  * symlink `~/link → ~/.ssh` is dereferenced before the prefix comparison.
@@ -51,6 +56,15 @@ export const BUILTIN_READ_DENYLIST: readonly string[] = [
   // npm publish tokens and Docker registry credentials.
   `${homedir()}/.npmrc`,
   `${homedir()}/.docker/config.json`,
+  // Git/HTTP credential stores and CLI OAuth tokens. This agent does heavy
+  // git/gh work, so a leaked token here would let an exfiltrator push to the
+  // operator's repos — highest-value reads to floor. File-level (not whole-dir)
+  // so ordinary reads of sibling non-secret config (~/.kube/cache, gh config.yml)
+  // still work; extend via AFK_READ_DENYLIST for non-default token locations.
+  `${homedir()}/.git-credentials`,
+  `${homedir()}/.netrc`,
+  `${homedir()}/.config/gh/hosts.yml`,
+  `${homedir()}/.kube/config`,
   // Classic system secret stores. Enumerated individually (not the whole /etc)
   // so ordinary /etc reads still work; these are usually root-only anyway.
   '/etc/shadow',
@@ -60,8 +74,8 @@ export const BUILTIN_READ_DENYLIST: readonly string[] = [
 
 // Memoized resolved denylist, keyed by the AFK_READ_DENYLIST value so a test
 // that changes the env re-resolves. Reads are a hot path (every grep/glob/
-// read_file call routes through resolveAndContain), so resolving the ~10
-// built-in entries' symlinks on every call is avoided. Threat-model note: a
+// read_file call routes through resolveAndContain), so resolving the built-in
+// entries' symlinks on every call is avoided. Threat-model note: a
 // denylist entry's symlink is assumed stable within a process (mirrors the
 // rootRealpathCache assumption in _cwd-utils.ts).
 let cached: { key: string; list: readonly string[] } | undefined;

--- a/src/agent/tools/hooks/path-approval-hook.test.ts
+++ b/src/agent/tools/hooks/path-approval-hook.test.ts
@@ -16,8 +16,12 @@
  */
 
 import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { homedir } from 'os';
 import { elicitationRouter } from '../../elicitation-router.js';
 import { createPathApprovalHook } from './path-approval-hook.js';
+import { resolveAndContain } from '../handlers/_cwd-utils.js';
+import { _resetReadDenylistCacheForTests } from '../handlers/read-denylist.js';
+import type { ToolHandlerContext } from '../types.js';
 import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
 import type { PreToolUseContext, PostToolUseContext } from '../../hooks.js';
 import * as permissionsStore from '../../permissions-store.js';
@@ -27,6 +31,14 @@ const BASE = '/tmp/repo';
 function makeMockGrantManager(initial?: {
   readRoots?: string[];
   writeRoots?: string[];
+  /**
+   * Pass `undefined` explicitly to model an UNCONFINED session (a plain
+   * `afk i` with no worktree). Omitting the key entirely defaults to BASE
+   * (a confined session), preserving every pre-existing caller unchanged.
+   */
+  resolveBase?: string | undefined;
+  /** Session in bypassPermissions → getGrants().allowAll === true. */
+  allowAll?: boolean;
 }): GrantManager & {
   _readRoots: string[];
   _writeRoots: string[];
@@ -34,6 +46,8 @@ function makeMockGrantManager(initial?: {
 } {
   const readRoots = initial?.readRoots?.slice() ?? [BASE];
   const writeRoots = initial?.writeRoots?.slice() ?? [BASE];
+  const resolveBase = initial && 'resolveBase' in initial ? initial.resolveBase : BASE;
+  const allowAll = initial?.allowAll === true;
   const events: Array<{ op: string; path: string }> = [];
 
   return {
@@ -57,7 +71,12 @@ function makeMockGrantManager(initial?: {
       events.push({ op: 'revoke', path: p });
     },
     getGrants() {
-      return { resolveBase: BASE, readRoots: readRoots.slice(), writeRoots: writeRoots.slice() };
+      return {
+        resolveBase,
+        readRoots: readRoots.slice(),
+        writeRoots: writeRoots.slice(),
+        ...(allowAll ? { allowAll: true } : {}),
+      };
     },
   };
 }
@@ -703,4 +722,197 @@ describe('createPathApprovalHook — M5: audit log line emitted per decision', (
     expect(logLine).toContain('tool=write_file');
     expect(logLine).toContain('outcome=deny');
   });
+});
+
+describe('createPathApprovalHook — unconfined-session forks (deny-all regression)', () => {
+  // Regression for the sub-agent deny-all bug. A plain `afk i` REPL (no -w, no
+  // resume) is UNCONFINED: getGrants().resolveBase === undefined. But the REPL
+  // wires getCwd to a CONCRETE dir (bootstrap.ts: effectiveCwd ?? process.cwd()).
+  // A no-cwd fork of that session inherits an EMPTY readRoots. The old hook did
+  // `resolveBase: grants.resolveBase ?? cwd` → concrete base + [] roots →
+  // wouldBeRestricted flagged EVERY path (`[] ?? [base]` stays `[]`) → the fork
+  // (which cannot prompt) auto-denied all reads. The HANDLER (resolveAndContain)
+  // always ALLOWED these reads, so the two layers disagreed. These tests pin the
+  // hook to the handler for the unconfined case.
+  const REPO = '/tmp/unconfined-repo';
+
+  it('does NOT block a fork reading a repo file when the parent is unconfined', async () => {
+    const mgr = makeMockGrantManager({ resolveBase: undefined, readRoots: [] });
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => REPO, // REPL fabricates a concrete cwd even when unconfined
+      surface: 'repl',
+    });
+    const decision = await preToolUse({
+      event: 'PreToolUse',
+      toolName: 'read_file',
+      input: { file_path: `${REPO}/package.json` },
+      sessionId: 'child-1',
+      parentSessionId: 'parent-1', // a FORK
+      grantManager: mgr,
+    });
+    expect(decision).toEqual({}); // allowed — the bug would have blocked it
+  });
+
+  it('does NOT block a fork glob/grep of an arbitrary absolute path when unconfined', async () => {
+    const mgr = makeMockGrantManager({ resolveBase: undefined, readRoots: [] });
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => REPO,
+      surface: 'repl',
+    });
+    for (const [tool, input] of [
+      ['glob', { pattern: '**/*.ts', path: '/some/other/tree' }],
+      ['grep', { pattern: 'x', path: '/yet/another/tree' }],
+    ] as const) {
+      const decision = await preToolUse({
+        event: 'PreToolUse',
+        toolName: tool,
+        input,
+        sessionId: 'child-1',
+        parentSessionId: 'parent-1',
+        grantManager: mgr,
+      });
+      expect(decision).toEqual({});
+    }
+  });
+
+  it('does NOT block a fork reading ~/.afk/state (skill-preflight inputs — #554 must not regress)', async () => {
+    const mgr = makeMockGrantManager({ resolveBase: undefined, readRoots: [] });
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => REPO,
+      surface: 'repl',
+    });
+    const decision = await preToolUse({
+      event: 'PreToolUse',
+      toolName: 'read_file',
+      input: { file_path: `${homedir()}/.afk/state/skill-preflight/s/pr-553.diff` },
+      sessionId: 'child-1',
+      parentSessionId: 'parent-1',
+      grantManager: mgr,
+    });
+    expect(decision).toEqual({});
+  });
+});
+
+describe('createPathApprovalHook — read-denylist floor', () => {
+  beforeEach(() => _resetReadDenylistCacheForTests());
+
+  const CREDS = [
+    `${homedir()}/.ssh/id_rsa`,
+    `${homedir()}/.afk/config/afk.env`,
+    `${homedir()}/.aws/credentials`,
+  ];
+
+  for (const p of CREDS) {
+    it(`blocks a fork reading credential path ${p.replace(homedir(), '~')}`, async () => {
+      const mgr = makeMockGrantManager({ resolveBase: undefined, readRoots: [] });
+      const { preToolUse } = createPathApprovalHook({
+        getGrantManager: () => mgr,
+        getCwd: () => '/tmp/x',
+        surface: 'repl',
+      });
+      const decision = await preToolUse({
+        event: 'PreToolUse',
+        toolName: 'read_file',
+        input: { file_path: p },
+        sessionId: 'child-1',
+        parentSessionId: 'parent-1',
+        grantManager: mgr,
+      });
+      expect(decision.decision).toBe('block');
+      expect(decision.reason).toContain('protected credential/secret path');
+    });
+  }
+
+  it('blocks a credential read even in bypass (allowAll) mode', async () => {
+    const mgr = makeMockGrantManager({ allowAll: true });
+    const { preToolUse } = createPathApprovalHook({
+      getGrantManager: () => mgr,
+      getCwd: () => BASE,
+      surface: 'repl',
+    });
+    const decision = await preToolUse(
+      preCtx('read_file', { file_path: `${homedir()}/.ssh/id_rsa` }),
+    );
+    expect(decision.decision).toBe('block');
+    expect(decision.reason).toContain('protected credential/secret path');
+  });
+
+  it('does NOT deny ~/.afk/state but DOES deny ~/.afk/config (handler floor)', () => {
+    _resetReadDenylistCacheForTests();
+    const unconfined = { resolveBase: undefined } as unknown as ToolHandlerContext;
+    expect(() =>
+      resolveAndContain(`${homedir()}/.afk/state/x/y.diff`, unconfined, 'read'),
+    ).not.toThrow();
+    expect(() =>
+      resolveAndContain(`${homedir()}/.afk/config/afk.env`, unconfined, 'read'),
+    ).toThrow(/credential\/secret/);
+  });
+});
+
+describe('path-approval hook ↔ handler parity (the divergence six PRs kept re-introducing)', () => {
+  // Invariant: the hook's read verdict must match the handler's resolveAndContain
+  // verdict. The bug was a DIVERGENCE — the hook blocked reads the handler would
+  // allow. This matrix turns "the two layers must agree" into a CI tripwire.
+  beforeEach(() => _resetReadDenylistCacheForTests());
+
+  const CWD = '/tmp/matrix-repo';
+  type Grants = {
+    resolveBase: string | undefined;
+    readRoots: string[];
+    writeRoots: string[];
+    allowAll?: boolean;
+  };
+  const cases: Array<{ name: string; grants: Grants; path: string }> = [
+    { name: 'unconfined + empty roots (the bug), repo file', grants: { resolveBase: undefined, readRoots: [], writeRoots: [] }, path: `${CWD}/pkg.json` },
+    { name: 'unconfined + empty roots, /etc/hosts', grants: { resolveBase: undefined, readRoots: [], writeRoots: [] }, path: '/etc/hosts' },
+    { name: 'confined, path inside root', grants: { resolveBase: CWD, readRoots: [CWD], writeRoots: [CWD] }, path: `${CWD}/src/a.ts` },
+    { name: 'confined, path OUTSIDE root', grants: { resolveBase: CWD, readRoots: [CWD], writeRoots: [CWD] }, path: '/tmp/other/x.ts' },
+    { name: 'bypass mode, out-of-root path', grants: { resolveBase: CWD, readRoots: [CWD], writeRoots: [CWD], allowAll: true }, path: '/var/log/x' },
+  ];
+
+  for (const c of cases) {
+    it(`hook allows iff handler allows — ${c.name}`, async () => {
+      const mgr = makeMockGrantManager({
+        resolveBase: c.grants.resolveBase,
+        readRoots: c.grants.readRoots,
+        writeRoots: c.grants.writeRoots,
+        ...(c.grants.allowAll ? { allowAll: true } : {}),
+      });
+      const { preToolUse } = createPathApprovalHook({
+        getGrantManager: () => mgr,
+        getCwd: () => CWD,
+        surface: 'repl',
+      });
+
+      // Handler verdict: does resolveAndContain throw?
+      const handlerCtx = {
+        resolveBase: c.grants.resolveBase,
+        readRoots: c.grants.readRoots,
+        writeRoots: c.grants.writeRoots,
+        ...(c.grants.allowAll ? { allowAll: true } : {}),
+      } as unknown as ToolHandlerContext;
+      let handlerAllows = true;
+      try {
+        resolveAndContain(c.path, handlerCtx, 'read');
+      } catch {
+        handlerAllows = false;
+      }
+
+      // Hook verdict for a FORK (deterministic: no prompt — allow ⇒ {}, restrict ⇒ block).
+      const decision = await preToolUse({
+        event: 'PreToolUse',
+        toolName: 'read_file',
+        input: { file_path: c.path },
+        sessionId: 'child-1',
+        parentSessionId: 'parent-1',
+        grantManager: mgr,
+      });
+      const hookAllows = Object.keys(decision).length === 0;
+
+      expect(hookAllows).toBe(handlerAllows);
+    });
+  }
 });

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -54,9 +54,11 @@
  * @module agent/tools/hooks/path-approval-hook
  */
 
+import path from 'path';
 import { elicitationRouter } from '../../elicitation-router.js';
 import type { GrantManager } from '../../../cli/slash/commands/allow-dir.js';
 import { wouldBeRestricted, realpathSafe } from '../handlers/_cwd-utils.js';
+import { isReadDenied } from '../handlers/read-denylist.js';
 import { appendGrant } from '../../permissions-store.js';
 import type { HookContext, HookDecision, HookHandler } from '../../hooks.js';
 
@@ -203,20 +205,66 @@ async function preToolUseImpl(
   // so a cwd change between Pre and Post (worktree rename, /cwd command)
   // cannot cause the revoke to miss the correct key.
   const cwd = opts.getCwd();
+
+  // Resolve the candidate to an absolute path the SAME way resolveAndContain
+  // will (grants.resolveBase, then cwd) — used for the denylist floor below.
+  // Note `cwd` only anchors a RELATIVE candidate here; it is NOT a confinement
+  // base (see the unconfined short-circuit below).
+  const resolvedAbs = path.isAbsolute(candidate)
+    ? candidate
+    : path.resolve(grants.resolveBase ?? cwd ?? process.cwd(), candidate);
+
+  // (1) Unconditional read-denylist floor. Secret/credential paths (~/.ssh,
+  // ~/.afk/config, …) are blocked outright for reads — never prompted, never
+  // bypassed — for top-level sessions and forks alike. Mirrors the floor in
+  // resolveAndContain (_cwd-utils.ts) so the hook blocks cleanly instead of
+  // prompting-then-letting-the-handler-throw. `~/.afk/state` is intentionally
+  // NOT denied (forks legitimately read skill-preflight/todos/transcripts).
+  if (mode === 'read') {
+    const denied = isReadDenied(resolvedAbs);
+    if (denied.denied) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[path-approval] surface=${opts.surface} tool=${context.toolName} path=${resolvedAbs} outcome=read-denylist`,
+      );
+      return {
+        decision: 'block',
+        reason:
+          `Access denied: ${resolvedAbs} is a protected credential/secret path ` +
+          `(read-denylist entry: ${denied.matched}). This path is never readable — ` +
+          `it holds credentials, not task data; do not retry.`,
+      };
+    }
+  }
+
+  // (2) Bypass mode (bypassPermissions): no containment prompt.
+  if (grants.allowAll === true) return {};
+
+  // (3) Unconfined session: `resolveBase` is deliberately unset — a top-level
+  // `afk`/`afk i` with no worktree, or a fork inheriting that read-open scope.
+  // The file-tool HANDLER (resolveAndContain, _cwd-utils.ts:107-119) bypasses
+  // containment for exactly this case, so the hook MUST agree. The prior
+  // `resolveBase: grants.resolveBase ?? cwd` fabricated a concrete base from
+  // getCwd() (the REPL wires it to `effectiveCwd ?? process.cwd()`,
+  // bootstrap.ts), turning an unconfined session into a confined one whose
+  // readRoots were `[]` — so EVERY typed-file read was "restricted", and forks
+  // (which cannot prompt) auto-denied all of them. Honoring undefined
+  // resolveBase here — matching the handler's own documented invariant — is the
+  // fix for the sub-agent deny-all.
+  if (grants.resolveBase === undefined) return {};
+
+  // (4) Confined session: reproduce the handler's containment verdict. Pass
+  // grants.resolveBase directly (no `?? cwd`); it is defined on this branch.
   const result = wouldBeRestricted(
     candidate,
     {
       cwd,
-      resolveBase: grants.resolveBase ?? cwd,
+      resolveBase: grants.resolveBase,
       readRoots: grants.readRoots,
       writeRoots: grants.writeRoots,
-      ...(grants.allowAll === true ? { allowAll: true } : {}),
     },
     mode,
   );
-  // Bypass mode: `allowAll` makes wouldBeRestricted return not-restricted, so
-  // this returns {} here — no prompt. (Belt-and-suspenders with the explicit
-  // flag pass-through above.)
   if (!result.restricted) return {};
 
   // A forked sub-agent has no human relationship of its own and must not prompt

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1068,6 +1068,14 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     category: 'misc',
   },
   {
+    name: 'AFK_READ_DENYLIST',
+    description: 'Colon-separated list of additional absolute paths the read_file/grep/glob/list_directory tools refuse to read. Built-in credential entries (~/.ssh, ~/.aws, ~/.afk/config, …) always apply on top and cannot be removed.',
+    type: 'string',
+    required: false,
+    example: '/Users/me/project/.env:/Users/me/secrets',
+    category: 'misc',
+  },
+  {
     name: 'AFK_WRITE_DIFF',
     description: 'Show a diff preview before each write_file tool call. Defaults provider-controlled when unset.',
     type: 'boolean',
@@ -1313,6 +1321,7 @@ export const env = {
 
   // Filesystem
   get AFK_WRITE_DENYLIST(): string | undefined { return process.env['AFK_WRITE_DENYLIST']; },
+  get AFK_READ_DENYLIST(): string | undefined { return process.env['AFK_READ_DENYLIST']; },
   get AFK_WRITE_DIFF(): string | undefined { return process.env['AFK_WRITE_DIFF']; },
 
   // CLI / capture-mode


### PR DESCRIPTION
## Summary

Forked sub-agents got **every** typed file-tool call (`read_file` / `glob` / `grep`) auto-denied by the PreToolUse path-approval hook whenever the top-level session was **unconfined** — a plain `afk i` REPL with no `-w` and no resume. Sub-agents fell back to reading via `bash`, silently degrading `/review`, `/diagnose`, and every read-only fan-out. This is the failure the last several read-scope PRs were chasing.

## Root cause: two enforcement layers disagreed on `resolveBase === undefined`

- The file-tool **handler** (`resolveAndContain`, `_cwd-utils.ts`) treats an undefined `resolveBase` as **unconfined → allow** — a documented invariant (issue #434): _"Do NOT 'fix' this by defaulting resolveBase to `process.cwd()`… would reject ALL paths."_
- The **hook** did exactly that: `resolveBase: grants.resolveBase ?? cwd`, and the REPL wires `getCwd` to `effectiveCwd ?? process.cwd()` (`bootstrap.ts`), so it **fabricated a concrete base** for an unconfined session.

A no-cwd fork of an unconfined parent inherits an **empty** `readRoots` (`ensureSharedRoots(undefined) → []`). With a fabricated concrete base and `[] ?? [base]` staying `[]`, **every** path was "restricted" — and forks can't prompt, so all reads auto-denied (deny-all).

The six prior read-scope PRs (#416 / #441 / #514 / #544 / #547 / #554) only widened the **confined-parent** `readRoots` union — a path an unconfined-parent fork never takes (`computeInheritedReadRoots` returns `undefined` for a no-cwd child), so they never engaged with this failure. The bug was in the **enforcement** layer, not the grant layer.

Confirmed by reproducing the real `createPathApprovalHook` under the REPL's exact conditions (concrete `getCwd`, unconfined child grants, `parentSessionId` set): block reasons were byte-identical to the failing witness trace.

## Fix

1. **Align the hook to the handler.** When `grants.resolveBase === undefined` (and not `allowAll`), the hook now treats the session as unconfined and skips typed-file containment — matching `resolveAndContain`. The `?? cwd` fabrication is gone.
2. **Add a read-denylist floor** (`read-denylist.ts`), enforced unconditionally in `resolveAndContain` **and** the hook, *before* the `allowAll`/unconfined fast-paths. This closes a **pre-existing read/write asymmetry**: writes were denylisted (`write-denylist.ts`) but reads had **no** secret-path floor, so any unconfined session — and, after fix #1, its forks — could read credential stores (SSH keys, cloud credentials, the `afk.env` config tree).
   - The AFK **state** dir stays **readable** (forks legitimately read skill-preflight inputs, todos, transcripts — #544/#547/#554). Only the **config** tree is denied.
   - `/etc` is **not** blanket-denied (ordinary system reads keep working); only enumerated secret files are.
   - Extendable via the new `AFK_READ_DENYLIST` env var.

## Tests

- **hook ↔ handler parity matrix** — asserts the hook's verdict equals `resolveAndContain`'s across a grants matrix (unconfined/confined/bypass, in/out of root). Turns _"the two layers must agree"_ into a CI tripwire so this class of divergence can't silently return.
- **deny-all regression** — an unconfined fork can read a repo file, glob/grep arbitrary trees, and read the AFK state dir.
- **read-denylist floor** — credential paths blocked for forks and in bypass mode; state dir allowed, config tree denied.
- **read-denylist unit tests** — credential coverage, symlink dereference, `AFK_READ_DENYLIST` extras, the state-vs-config divergence.

Full suite: **635 files, 11571 passed, 14 skipped**; `tsc --noEmit`, `scan:env:check`, `audit:env:check` all green.

## Deliberately out of scope

Forked children don't inherit the parent's `permissionMode` (a child defaults to `'default'` while the parent may be `bypass`) — that's why `main` (bypass → `allowAll`) reads fine while the children hit the deny. It's a separate concern with its own security implications and is **not** bundled here.
