### PR TITLE
feat(telegram): multi-session support — session-registry foundation + /sessions switcher

### DIFF
--- a/src/agent/session/session-registry.test.ts
+++ b/src/agent/session/session-registry.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for the surface-agnostic session registry.
+ *
+ * Encodes the identity contract from session-registry-architecture.md:
+ *   - handle.id is registry-minted + stable; sdkSessionId is late-bound.
+ *   - resolve(surface, key) routes by binding; many bindings → one handle.
+ *   - archive frees keys; accessors return snapshots; mutators fail loud.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  InMemorySessionRegistry,
+  createSessionRegistry,
+  asHandleId,
+  SessionRegistryError,
+  type SessionRegistry,
+} from './session-registry.js';
+
+/** A registry with a controllable clock for deterministic lastActiveAt ordering. */
+function makeReg(start = 1000): { reg: SessionRegistry; tick: (by?: number) => number } {
+  let t = start;
+  const reg = createSessionRegistry({ now: () => t });
+  return { reg, tick: (by = 1) => (t += by) };
+}
+
+describe('create / get', () => {
+  it('mints a stable id, defaults to active, no sdkSessionId', () => {
+    const { reg } = makeReg();
+    const h = reg.create({ surface: 'telegram', model: 'sonnet', key: '42' });
+    expect(h.id).toBeTruthy();
+    expect(h.status).toBe('active');
+    expect(h.sdkSessionId).toBeUndefined();
+    expect(h.bindings).toEqual([
+      { surface: 'telegram', key: '42', boundAt: 1000, lastActiveAt: 1000 },
+    ]);
+    expect(reg.get(h.id)?.id).toBe(h.id);
+  });
+
+  it('two distinct keys on the same chat produce two isolated handles', () => {
+    const { reg } = makeReg();
+    const a = reg.create({ surface: 'telegram', model: 'sonnet', key: '42' });
+    const b = reg.create({ surface: 'telegram', model: 'sonnet', key: '42:7' });
+    expect(a.id).not.toBe(b.id);
+    expect(reg.resolve('telegram', '42')?.id).toBe(a.id);
+    expect(reg.resolve('telegram', '42:7')?.id).toBe(b.id);
+  });
+
+  it('honors a rehydration id + createdAt and rejects a duplicate id', () => {
+    const { reg } = makeReg();
+    const id = asHandleId('fixed-id');
+    const h = reg.create({ surface: 'cli', model: 'opus', key: 'resume-me', id, createdAt: 5 });
+    expect(h.id).toBe(id);
+    expect(h.createdAt).toBe(5);
+    expect(() => reg.create({ surface: 'cli', model: 'opus', key: 'other', id })).toThrow(
+      SessionRegistryError,
+    );
+  });
+
+  it('carries optional name / cwd / sdkSessionId through create', () => {
+    const { reg } = makeReg();
+    const h = reg.create({
+      surface: 'daemon',
+      model: 'haiku',
+      key: 'task-1',
+      name: 'nightly',
+      cwd: '/repo',
+      sdkSessionId: 'sdk-1',
+    });
+    expect(h.name).toBe('nightly');
+    expect(h.cwd).toBe('/repo');
+    expect(reg.getBySdkSessionId('sdk-1')?.id).toBe(h.id);
+  });
+});
+
+describe('resolve', () => {
+  it('returns undefined for an unbound key', () => {
+    const { reg } = makeReg();
+    reg.create({ surface: 'telegram', model: 'sonnet', key: '42' });
+    expect(reg.resolve('telegram', '999')).toBeUndefined();
+    expect(reg.resolve('cli', '42')).toBeUndefined(); // surface is part of the key
+  });
+});
+
+describe('bind — many bindings → one handle (cross-surface)', () => {
+  it('a second binding resolves to the same handle', () => {
+    const { reg } = makeReg();
+    const h = reg.create({ surface: 'cli', model: 'sonnet', key: 'repl-abc' });
+    reg.bind(h.id, { surface: 'telegram', key: '42:7' });
+    expect(reg.resolve('cli', 'repl-abc')?.id).toBe(h.id);
+    expect(reg.resolve('telegram', '42:7')?.id).toBe(h.id);
+    expect(reg.get(h.id)?.bindings).toHaveLength(2);
+  });
+
+  it('re-binding an existing key refreshes rather than duplicating', () => {
+    const { reg, tick } = makeReg();
+    const h = reg.create({ surface: 'telegram', model: 'sonnet', key: '42' });
+    tick(50);
+    reg.bind(h.id, { surface: 'telegram', key: '42' });
+    const got = reg.get(h.id)!;
+    expect(got.bindings).toHaveLength(1);
+    expect(got.bindings[0]!.lastActiveAt).toBe(1050);
+    expect(got.bindings[0]!.boundAt).toBe(1000);
+  });
+
+  it('re-points a key away from a prior owner (last-writer-wins)', () => {
+    const { reg } = makeReg();
+    const a = reg.create({ surface: 'telegram', model: 'sonnet', key: '42' });
+    const b = reg.create({ surface: 'telegram', model: 'sonnet', key: '99' });
+    reg.bind(b.id, { surface: 'telegram', key: '42' }); // steal '42' from a
+    expect(reg.resolve('telegram', '42')?.id).toBe(b.id);
+    expect(reg.get(a.id)?.bindings).toHaveLength(0); // a lost the binding
+    expect(reg.get(b.id)?.bindings).toHaveLength(2);
+  });
+});
+
+describe('unbind', () => {
+  it('removes the binding from its owner and stops resolving', () => {
+    const { reg } = makeReg();
+    const h = reg.create({ surface: 'telegram', model: 'sonnet', key: '42' });
+    reg.unbind('telegram', '42');
+    expect(reg.resolve('telegram', '42')).toBeUndefined();
+    expect(reg.get(h.id)?.bindings).toHaveLength(0);
+  });
+
+  it('is a no-op for an unknown key', () => {
+    const { reg } = makeReg();
+    expect(() => reg.unbind('telegram', 'nope')).not.toThrow();
+  });
+});
+
+describe('attachSdkSessionId — late binding', () => {
+  it('indexes for reverse lookup and updates on re-attach', () => {
+    const { reg } = makeReg();
+    const h = reg.create({ surface: 'telegram', model: 'sonnet', key: '42' });
+    reg.attachSdkSessionId(h.id, 'sdk-1');
+    expect(reg.getBySdkSessionId('sdk-1')?.id).toBe(h.id);
+    reg.attachSdkSessionId(h.id, 'sdk-2');
+    expect(reg.getBySdkSessionId('sdk-1')).toBeUndefined(); // stale index dropped
+    expect(reg.getBySdkSessionId('sdk-2')?.id).toBe(h.id);
+    expect(reg.get(h.id)?.sdkSessionId).toBe('sdk-2');
+  });
+});
+
+describe('rename', () => {
+  it('sets the human label', () => {
+    const { reg } = makeReg();
+    const h = reg.create({ surface: 'telegram', model: 'sonnet', key: '42' });
+    reg.rename(h.id, 'fix-the-thing');
+    expect(reg.get(h.id)?.name).toBe('fix-the-thing');
+  });
+});
+
+describe('archive', () => {
+  it('frees keys (resolve misses) but retains the handle for get/list', () => {
+    const { reg } = makeReg();
+    const h = reg.create({ surface: 'telegram', model: 'sonnet', key: '42' });
+    reg.archive(h.id);
+    expect(reg.resolve('telegram', '42')).toBeUndefined();
+    expect(reg.get(h.id)?.status).toBe('archived');
+    expect(reg.list({ status: 'archived' }).map((x) => x.id)).toContain(h.id);
+  });
+
+  it('a new session can reclaim an archived handle key', () => {
+    const { reg } = makeReg();
+    const a = reg.create({ surface: 'telegram', model: 'sonnet', key: '42' });
+    reg.archive(a.id);
+    const b = reg.create({ surface: 'telegram', model: 'sonnet', key: '42' });
+    expect(reg.resolve('telegram', '42')?.id).toBe(b.id);
+    expect(b.id).not.toBe(a.id);
+  });
+});
+
+describe('list', () => {
+  it('filters by surface + status and sorts by lastActiveAt desc', () => {
+    const { reg, tick } = makeReg();
+    const a = reg.create({ surface: 'telegram', model: 'sonnet', key: '1' });
+    tick(10);
+    const b = reg.create({ surface: 'telegram', model: 'sonnet', key: '2' });
+    tick(10);
+    reg.create({ surface: 'cli', model: 'sonnet', key: 'x' });
+    tick(10);
+    reg.touch(a.id); // a is now the most recently active
+
+    const tg = reg.list({ surface: 'telegram' });
+    expect(tg.map((h) => h.id)).toEqual([a.id, b.id]);
+    expect(reg.list({ surface: 'cli' })).toHaveLength(1);
+    expect(reg.list()).toHaveLength(3);
+  });
+});
+
+describe('snapshot isolation', () => {
+  it('mutating a returned handle does not affect registry state', () => {
+    const { reg } = makeReg();
+    const h = reg.create({ surface: 'telegram', model: 'sonnet', key: '42' });
+    h.bindings.push({ surface: 'cli', key: 'evil', boundAt: 0, lastActiveAt: 0 });
+    h.name = 'mutated';
+    expect(reg.get(h.id)?.bindings).toHaveLength(1);
+    expect(reg.get(h.id)?.name).toBeUndefined();
+    expect(reg.resolve('cli', 'evil')).toBeUndefined();
+  });
+});
+
+describe('fail-loud mutators', () => {
+  it('throw SessionRegistryError on an unknown id', () => {
+    const reg = new InMemorySessionRegistry();
+    const ghost = asHandleId('ghost');
+    expect(() => reg.bind(ghost, { surface: 'cli', key: 'k' })).toThrow(SessionRegistryError);
+    expect(() => reg.rename(ghost, 'x')).toThrow(SessionRegistryError);
+    expect(() => reg.touch(ghost)).toThrow(SessionRegistryError);
+    expect(() => reg.archive(ghost)).toThrow(SessionRegistryError);
+    expect(() => reg.attachSdkSessionId(ghost, 's')).toThrow(SessionRegistryError);
+  });
+});

--- a/src/agent/session/session-registry.test.ts
+++ b/src/agent/session/session-registry.test.ts
@@ -14,7 +14,21 @@ import {
   asHandleId,
   SessionRegistryError,
   type SessionRegistry,
+  type SessionHandle,
 } from './session-registry.js';
+
+/** Build a fully-formed handle for load() rehydration tests. */
+function makeHandle(over: Partial<SessionHandle> & Pick<SessionHandle, 'id'>): SessionHandle {
+  return {
+    surface: 'telegram',
+    model: 'sonnet',
+    createdAt: 1,
+    lastActiveAt: 1,
+    status: 'active',
+    bindings: [{ surface: 'telegram', key: '42', boundAt: 1, lastActiveAt: 1 }],
+    ...over,
+  };
+}
 
 /** A registry with a controllable clock for deterministic lastActiveAt ordering. */
 function makeReg(start = 1000): { reg: SessionRegistry; tick: (by?: number) => number } {
@@ -209,5 +223,57 @@ describe('fail-loud mutators', () => {
     expect(() => reg.touch(ghost)).toThrow(SessionRegistryError);
     expect(() => reg.archive(ghost)).toThrow(SessionRegistryError);
     expect(() => reg.attachSdkSessionId(ghost, 's')).toThrow(SessionRegistryError);
+  });
+});
+
+describe('load — rehydration from persistence', () => {
+  it('indexes an active handle by every binding + id + sdk id', () => {
+    const { reg } = makeReg();
+    reg.load(
+      makeHandle({
+        id: asHandleId('h1'),
+        sdkSessionId: 'sdk-1',
+        bindings: [
+          { surface: 'telegram', key: '42', boundAt: 1, lastActiveAt: 1 },
+          { surface: 'cli', key: 'my-repl', boundAt: 1, lastActiveAt: 1 },
+        ],
+      }),
+    );
+    expect(reg.resolve('telegram', '42')?.id).toBe('h1');
+    expect(reg.resolve('cli', 'my-repl')?.id).toBe('h1');
+    expect(reg.get(asHandleId('h1'))?.id).toBe('h1');
+    expect(reg.getBySdkSessionId('sdk-1')?.id).toBe('h1');
+  });
+
+  it('an archived handle loads without indexing its keys for routing', () => {
+    const { reg } = makeReg();
+    reg.load(makeHandle({ id: asHandleId('old'), status: 'archived' }));
+    expect(reg.resolve('telegram', '42')).toBeUndefined();
+    expect(reg.get(asHandleId('old'))?.status).toBe('archived');
+    expect(reg.list({ status: 'archived' }).map((h) => h.id)).toContain('old');
+  });
+
+  it('throws on a duplicate id', () => {
+    const { reg } = makeReg();
+    reg.load(makeHandle({ id: asHandleId('dup') }));
+    expect(() => reg.load(makeHandle({ id: asHandleId('dup') }))).toThrow(SessionRegistryError);
+  });
+
+  it('takes a private snapshot (mutating the passed handle is inert)', () => {
+    const { reg } = makeReg();
+    const h = makeHandle({ id: asHandleId('snap') });
+    reg.load(h);
+    h.bindings.push({ surface: 'cli', key: 'evil', boundAt: 0, lastActiveAt: 0 });
+    expect(reg.resolve('cli', 'evil')).toBeUndefined();
+    expect(reg.get(asHandleId('snap'))?.bindings).toHaveLength(1);
+  });
+
+  it('round-trips a created handle snapshot through a fresh registry', () => {
+    const { reg: a } = makeReg();
+    const h = a.create({ surface: 'telegram', model: 'opus', key: '42:7', name: 'x' });
+    const { reg: b } = makeReg();
+    b.load(h); // h is a snapshot from create()
+    expect(b.resolve('telegram', '42:7')?.id).toBe(h.id);
+    expect(b.get(h.id)?.name).toBe('x');
   });
 });

--- a/src/agent/session/session-registry.ts
+++ b/src/agent/session/session-registry.ts
@@ -1,0 +1,306 @@
+/**
+ * Surface-agnostic session registry — AFK's durable session-identity layer.
+ *
+ * The registry is the single source of truth for "what sessions exist and how
+ * each surface reaches them". It holds durable METADATA + BINDINGS only; the
+ * live `IAgentSession` objects stay owned by each surface adapter (e.g. the
+ * Telegram `SessionManager`), keyed by `SessionHandle.id`. This keeps the
+ * registry pure, testable, and persistable.
+ *
+ * Identity model:
+ *   - `SessionHandle.id` is the registry's own primary key, minted at create()
+ *     time (UUID) and STABLE for the session's life. Live-session maps key on
+ *     this — NOT on the SDK sessionId, which is late-bound (undefined until the
+ *     provider stream emits it mid-first-turn; see session-state.ts
+ *     `updateSessionIdentity`).
+ *   - `SessionHandle.sdkSessionId` is that late-bound attribute, attached via
+ *     `attachSdkSessionId()` once known. Used only for the sidecar filename and
+ *     `--resume` continuity — never for routing.
+ *   - A `SessionBinding` maps an opaque, adapter-owned `key` on a `surface` to a
+ *     handle. MANY bindings can point at ONE handle (a CLI REPL and a Telegram
+ *     tab tailing the same session). `resolve(surface, key)` is the router.
+ *
+ * This module is intentionally dependency-light (no `AgentSession` import) so it
+ * can back telemetry, the Telegram adapter, and the CLI resume path without
+ * pulling in the heavy session runtime. Step 1 ships an in-memory impl; a
+ * persistence-backed impl (over the sidecar store) implements the same
+ * `SessionRegistry` interface in a later step.
+ *
+ * @module agent/session/session-registry
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { AgentModelInput } from '../types.js';
+
+/** User-facing surface that owns a binding. Aligns with session-identity's TraceOrigin (minus 'unknown'). */
+export type SessionSurface = 'cli' | 'telegram' | 'daemon';
+
+/** Lifecycle state of a handle. `archived` handles never `resolve()` for routing. */
+export type SessionStatus = 'active' | 'archived';
+
+/**
+ * Branded primary key for a registry handle. Distinct from a bare `string` (and
+ * from a Telegram `chatId: number`) so a cross-session mis-key is a type error,
+ * not a runtime leak. Construct via {@link asHandleId} or `create()`.
+ */
+export type HandleId = string & { readonly __brand: 'HandleId' };
+
+/** Assert an opaque string is a HandleId (rehydration from persistence, tests). */
+export function asHandleId(id: string): HandleId {
+  return id as HandleId;
+}
+
+/** An adapter's routing reference: an opaque `key` scoped to a `surface`. */
+export interface BindingRef {
+  surface: SessionSurface;
+  key: string;
+}
+
+/** A stored binding: a {@link BindingRef} plus registry-managed timestamps. */
+export interface SessionBinding extends BindingRef {
+  boundAt: number;
+  lastActiveAt: number;
+}
+
+/** The durable record for one session. Metadata + bindings; no live runtime state. */
+export interface SessionHandle {
+  /** Registry primary key — minted at create(), stable for life. */
+  id: HandleId;
+  /** Late-bound SDK/provider session id (sidecar filename + --resume). Absent until attached. */
+  sdkSessionId?: string;
+  /** Origin surface that created the handle. */
+  surface: SessionSurface;
+  /** Human-readable label (auto from first turn, or set via a /name-style command). */
+  name?: string;
+  model: AgentModelInput;
+  cwd?: string;
+  createdAt: number;
+  lastActiveAt: number;
+  status: SessionStatus;
+  /** ≥1 while active. Many bindings may point at this one handle (cross-surface). */
+  bindings: SessionBinding[];
+}
+
+/** Options for {@link SessionRegistry.create}. */
+export interface CreateSessionOptions {
+  surface: SessionSurface;
+  model: AgentModelInput;
+  /** Initial binding key on `surface` (e.g. Telegram routeKey, CLI resume-name). */
+  key: string;
+  cwd?: string;
+  name?: string;
+  sdkSessionId?: string;
+  /** Rehydration only: reuse a persisted id instead of minting one. */
+  id?: HandleId;
+  /** Rehydration only: reuse a persisted creation time instead of now(). */
+  createdAt?: number;
+}
+
+/** Filter for {@link SessionRegistry.list}. */
+export interface ListFilter {
+  surface?: SessionSurface;
+  status?: SessionStatus;
+}
+
+/**
+ * Surface-agnostic session registry. All accessors return SNAPSHOTS (deep-ish
+ * clones); callers mutate registry state only through the mutator methods.
+ */
+export interface SessionRegistry {
+  create(opts: CreateSessionOptions): SessionHandle;
+  get(id: HandleId): SessionHandle | undefined;
+  getBySdkSessionId(sdkSessionId: string): SessionHandle | undefined;
+  /** Router: the active handle bound to (surface, key), or undefined. Never resolves an archived handle. */
+  resolve(surface: SessionSurface, key: string): SessionHandle | undefined;
+  /** Add or refresh a binding on a handle. Re-points the key away from any prior owner (last-writer-wins). */
+  bind(id: HandleId, ref: BindingRef): void;
+  /** Remove a binding by (surface, key) from whichever handle owns it. */
+  unbind(surface: SessionSurface, key: string): void;
+  /** Attach (or update) the late-bound SDK session id and index it for reverse lookup. */
+  attachSdkSessionId(id: HandleId, sdkSessionId: string): void;
+  rename(id: HandleId, name: string): void;
+  /** Bump lastActiveAt (e.g. on each turn) for list ordering. */
+  touch(id: HandleId): void;
+  /** Mark archived and free all its binding keys (so future messages create a fresh handle). Handle is retained for list/resume. */
+  archive(id: HandleId): void;
+  list(filter?: ListFilter): SessionHandle[];
+}
+
+/** Thrown when a mutator targets an id that is not registered. */
+export class SessionRegistryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SessionRegistryError';
+  }
+}
+
+/** In-memory {@link SessionRegistry}. The Step-1 impl; persistence backs it later. */
+export class InMemorySessionRegistry implements SessionRegistry {
+  private readonly byId = new Map<HandleId, SessionHandle>();
+  private readonly byBinding = new Map<string, HandleId>();
+  private readonly bySdk = new Map<string, HandleId>();
+  private readonly now: () => number;
+
+  constructor(opts?: { now?: () => number }) {
+    this.now = opts?.now ?? Date.now;
+  }
+
+  create(opts: CreateSessionOptions): SessionHandle {
+    const now = this.now();
+    const id = opts.id ?? asHandleId(randomUUID());
+    if (this.byId.has(id)) {
+      throw new SessionRegistryError(`session handle already exists: ${id}`);
+    }
+    const binding: SessionBinding = {
+      surface: opts.surface,
+      key: opts.key,
+      boundAt: now,
+      lastActiveAt: now,
+    };
+    const handle: SessionHandle = {
+      id,
+      surface: opts.surface,
+      model: opts.model,
+      createdAt: opts.createdAt ?? now,
+      lastActiveAt: now,
+      status: 'active',
+      bindings: [binding],
+    };
+    if (opts.name !== undefined) handle.name = opts.name;
+    if (opts.cwd !== undefined) handle.cwd = opts.cwd;
+    if (opts.sdkSessionId !== undefined) handle.sdkSessionId = opts.sdkSessionId;
+
+    this.byId.set(id, handle);
+    this.pointBinding(this.bindingKey(binding.surface, binding.key), id);
+    if (handle.sdkSessionId !== undefined) this.bySdk.set(handle.sdkSessionId, id);
+    return this.clone(handle);
+  }
+
+  get(id: HandleId): SessionHandle | undefined {
+    const h = this.byId.get(id);
+    return h ? this.clone(h) : undefined;
+  }
+
+  getBySdkSessionId(sdkSessionId: string): SessionHandle | undefined {
+    const id = this.bySdk.get(sdkSessionId);
+    if (id === undefined) return undefined;
+    const h = this.byId.get(id);
+    return h ? this.clone(h) : undefined;
+  }
+
+  resolve(surface: SessionSurface, key: string): SessionHandle | undefined {
+    const id = this.byBinding.get(this.bindingKey(surface, key));
+    if (id === undefined) return undefined;
+    const h = this.byId.get(id);
+    // Invariant: archived handles never route. archive() frees their keys, but
+    // guard here too so a stale index entry can never cross-route a message.
+    if (!h || h.status !== 'active') return undefined;
+    return this.clone(h);
+  }
+
+  bind(id: HandleId, ref: BindingRef): void {
+    const h = this.require(id);
+    const now = this.now();
+    const k = this.bindingKey(ref.surface, ref.key);
+    const existing = h.bindings.find((b) => this.bindingKey(b.surface, b.key) === k);
+    if (existing) {
+      existing.lastActiveAt = now;
+    } else {
+      h.bindings.push({ surface: ref.surface, key: ref.key, boundAt: now, lastActiveAt: now });
+    }
+    this.pointBinding(k, id);
+    h.lastActiveAt = now;
+  }
+
+  unbind(surface: SessionSurface, key: string): void {
+    const k = this.bindingKey(surface, key);
+    const id = this.byBinding.get(k);
+    this.byBinding.delete(k);
+    if (id === undefined) return;
+    const h = this.byId.get(id);
+    if (h) h.bindings = h.bindings.filter((b) => this.bindingKey(b.surface, b.key) !== k);
+  }
+
+  attachSdkSessionId(id: HandleId, sdkSessionId: string): void {
+    const h = this.require(id);
+    if (h.sdkSessionId !== undefined && h.sdkSessionId !== sdkSessionId) {
+      if (this.bySdk.get(h.sdkSessionId) === id) this.bySdk.delete(h.sdkSessionId);
+    }
+    h.sdkSessionId = sdkSessionId;
+    this.bySdk.set(sdkSessionId, id);
+    h.lastActiveAt = this.now();
+  }
+
+  rename(id: HandleId, name: string): void {
+    const h = this.require(id);
+    h.name = name;
+    h.lastActiveAt = this.now();
+  }
+
+  touch(id: HandleId): void {
+    const h = this.require(id);
+    h.lastActiveAt = this.now();
+  }
+
+  archive(id: HandleId): void {
+    const h = this.require(id);
+    h.status = 'archived';
+    h.lastActiveAt = this.now();
+    // Free every key this handle held so a future message on the same route
+    // creates a fresh handle instead of resolving the archived one. bindings[]
+    // is retained on the handle as a historical record.
+    for (const b of h.bindings) {
+      const k = this.bindingKey(b.surface, b.key);
+      if (this.byBinding.get(k) === id) this.byBinding.delete(k);
+    }
+  }
+
+  list(filter?: ListFilter): SessionHandle[] {
+    const out: SessionHandle[] = [];
+    for (const h of this.byId.values()) {
+      if (filter?.surface !== undefined && h.surface !== filter.surface) continue;
+      if (filter?.status !== undefined && h.status !== filter.status) continue;
+      out.push(this.clone(h));
+    }
+    out.sort((a, b) => b.lastActiveAt - a.lastActiveAt);
+    return out;
+  }
+
+  private bindingKey(surface: SessionSurface, key: string): string {
+    // NUL separator — cannot appear in a surface literal or a sane binding key.
+    return `${surface}\u0000${key}`;
+  }
+
+  private require(id: HandleId): SessionHandle {
+    const h = this.byId.get(id);
+    if (!h) throw new SessionRegistryError(`unknown session handle: ${id}`);
+    return h;
+  }
+
+  /** Point a binding key at `id`, detaching it from any different prior owner. */
+  private pointBinding(k: string, id: HandleId): void {
+    const prev = this.byBinding.get(k);
+    if (prev !== undefined && prev !== id) {
+      const prevHandle = this.byId.get(prev);
+      if (prevHandle) {
+        prevHandle.bindings = prevHandle.bindings.filter(
+          (b) => this.bindingKey(b.surface, b.key) !== k,
+        );
+      }
+    }
+    this.byBinding.set(k, id);
+  }
+
+  /** Return a snapshot so callers can never mutate internal state directly. */
+  private clone(h: SessionHandle): SessionHandle {
+    return { ...h, bindings: h.bindings.map((b) => ({ ...b })) };
+  }
+}
+
+/** Construct an isolated registry (tests, DI). */
+export function createSessionRegistry(opts?: { now?: () => number }): SessionRegistry {
+  return new InMemorySessionRegistry(opts);
+}
+
+/** Process-wide default registry singleton (used by surface adapters). */
+export const sessionRegistry: SessionRegistry = new InMemorySessionRegistry();

--- a/src/agent/session/session-registry.ts
+++ b/src/agent/session/session-registry.ts
@@ -108,6 +108,12 @@ export interface ListFilter {
  */
 export interface SessionRegistry {
   create(opts: CreateSessionOptions): SessionHandle;
+  /**
+   * Insert a fully-formed handle — rehydration from persistence. Throws on a
+   * duplicate id. An archived handle loads WITHOUT indexing its keys for
+   * routing (its bindings are retained as history but never resolve).
+   */
+  load(handle: SessionHandle): void;
   get(id: HandleId): SessionHandle | undefined;
   getBySdkSessionId(sdkSessionId: string): SessionHandle | undefined;
   /** Router: the active handle bound to (surface, key), or undefined. Never resolves an archived handle. */
@@ -174,6 +180,23 @@ export class InMemorySessionRegistry implements SessionRegistry {
     this.pointBinding(this.bindingKey(binding.surface, binding.key), id);
     if (handle.sdkSessionId !== undefined) this.bySdk.set(handle.sdkSessionId, id);
     return this.clone(handle);
+  }
+
+  load(handle: SessionHandle): void {
+    if (this.byId.has(handle.id)) {
+      throw new SessionRegistryError(`session handle already exists: ${handle.id}`);
+    }
+    // Own a private snapshot so a caller mutating the passed handle can't reach
+    // internal state. Only ACTIVE handles index their keys for routing —
+    // archived handles' keys stay free (parity with archive()).
+    const stored = this.clone(handle);
+    this.byId.set(stored.id, stored);
+    if (stored.status === 'active') {
+      for (const b of stored.bindings) {
+        this.pointBinding(this.bindingKey(b.surface, b.key), stored.id);
+      }
+    }
+    if (stored.sdkSessionId !== undefined) this.bySdk.set(stored.sdkSessionId, stored.id);
   }
 
   get(id: HandleId): SessionHandle | undefined {

--- a/src/cli/session-store.test.ts
+++ b/src/cli/session-store.test.ts
@@ -15,6 +15,10 @@ import {
   listSessions,
   sdkSessionIdFor,
   forkStoredSession,
+  storedToHandle,
+  bindingsForStored,
+  storedFieldsFromHandle,
+  type StoredSession,
 } from './session-store.js';
 import { createSessionStats, recordTurn } from './slash/session-stats.js';
 import { useUnsetAfkHome } from '../__test-utils__/unset-afk-home.js';
@@ -480,5 +484,68 @@ describe('session-store — session identity (source / actor)', () => {
 
     const loaded = loadSession('plain-sess');
     expect(loaded!.actor).toBeUndefined();
+  });
+});
+
+describe('session-registry bridge — storedToHandle / bindingsForStored', () => {
+  function makeStored(over: Partial<StoredSession> = {}): StoredSession {
+    return {
+      model: 'sonnet',
+      startedAt: 100,
+      savedAt: 200,
+      totalTurns: 1,
+      totalCostUsd: 0,
+      totalTokens: 0,
+      totalDurationMs: 0,
+      turns: [],
+      ...over,
+    };
+  }
+
+  it('migrates a legacy telegramChatId to one telegram binding', () => {
+    const h = storedToHandle(makeStored({ source: 'telegram', telegramChatId: 42, sessionId: 'sdk-1' }), 'sidecar-1');
+    expect(h.surface).toBe('telegram');
+    expect(h.sdkSessionId).toBe('sdk-1');
+    expect(h.createdAt).toBe(100);
+    expect(h.lastActiveAt).toBe(200);
+    expect(h.bindings).toEqual([
+      { surface: 'telegram', key: '42', boundAt: 100, lastActiveAt: 200 },
+    ]);
+  });
+
+  it('prefers explicit bindings over the legacy telegramChatId', () => {
+    const explicit = [{ surface: 'telegram' as const, key: '42:7', boundAt: 5, lastActiveAt: 9 }];
+    const h = storedToHandle(makeStored({ source: 'telegram', telegramChatId: 42, bindings: explicit }), 'sc');
+    expect(h.bindings).toEqual(explicit);
+  });
+
+  it('defaults surface to cli and yields no binding for a legacy non-telegram sidecar', () => {
+    const h = storedToHandle(makeStored({ name: 'my-repl', cwd: '/repo' }), 'legacy-cli');
+    expect(h.surface).toBe('cli');
+    expect(h.name).toBe('my-repl');
+    expect(h.cwd).toBe('/repo');
+    expect(h.bindings).toEqual([]);
+    expect(h.sdkSessionId).toBeUndefined();
+  });
+
+  it('uses handleId as the id when present, else the sidecar id', () => {
+    expect(storedToHandle(makeStored({ handleId: 'H' }), 'sidecar').id).toBe('H');
+    expect(storedToHandle(makeStored(), 'sidecar').id).toBe('sidecar');
+  });
+
+  it('bindingsForStored returns copies (mutation-safe)', () => {
+    const stored = makeStored({ telegramChatId: 7 });
+    const b = bindingsForStored(stored);
+    b[0]!.key = 'mutated';
+    expect(bindingsForStored(stored)[0]!.key).toBe('7');
+  });
+
+  it('storedFieldsFromHandle round-trips id + bindings back into a StoredSession', () => {
+    const h = storedToHandle(makeStored({ source: 'telegram', telegramChatId: 42, handleId: 'H' }), 'sc');
+    const fields = storedFieldsFromHandle(h);
+    expect(fields.handleId).toBe('H');
+    const reloaded = storedToHandle(makeStored({ source: 'telegram', ...fields }), 'ignored');
+    expect(reloaded.id).toBe('H');
+    expect(reloaded.bindings).toEqual(h.bindings);
   });
 });

--- a/src/cli/session-store.ts
+++ b/src/cli/session-store.ts
@@ -218,14 +218,18 @@ export function loadSession(idOrPath: string): StoredSession | undefined {
   let path: string;
   try {
     path = safeResolvePath(idOrPath);
-  } catch {
+  } catch (err) {
+    // Path escaped the session store (traversal probe) — leave an audit trail
+    // instead of silently returning undefined.
+    console.warn(`loadSession: rejected unsafe session id ${JSON.stringify(idOrPath)}: ${(err as Error).message}`);
     return undefined;
   }
   if (!existsSync(path)) return undefined;
   try {
     const raw = readFileSync(path, 'utf-8');
     return JSON.parse(raw) as StoredSession;
-  } catch {
+  } catch (err) {
+    console.warn(`loadSession: failed to read/parse ${path}: ${(err as Error).message}`);
     return undefined;
   }
 }

--- a/src/cli/session-store.ts
+++ b/src/cli/session-store.ts
@@ -72,6 +72,8 @@ export interface SessionListEntry {
   name?: string;
   source?: 'cli' | 'telegram' | 'daemon';
   actor?: TraceActor;
+  /** Telegram chat id for telegram-sourced sidecars — lets a surface filter a chat's sessions (the /sessions switcher). */
+  telegramChatId?: number;
   model: AgentModelInput;
   startedAt: number;
   savedAt: number;
@@ -303,6 +305,7 @@ export function listSessions(): SessionListEntry[] {
         name: loaded.name,
         source: loaded.source,
         actor: loaded.actor,
+        telegramChatId: loaded.telegramChatId,
         model: loaded.model,
         startedAt: loaded.startedAt,
         savedAt: loaded.savedAt,

--- a/src/cli/session-store.ts
+++ b/src/cli/session-store.ts
@@ -21,6 +21,12 @@ import { ensureSessionsMigrated, getSessionsDir } from '../paths.js';
 import type { SessionStats, TurnRecord } from './slash/types.js';
 import type { AgentModelInput } from '../agent/types.js';
 import type { TraceActor } from '../agent/session/session-identity.js';
+import {
+  asHandleId,
+  type SessionBinding,
+  type SessionHandle,
+  type SessionSurface,
+} from '../agent/session/session-registry.js';
 
 export interface StoredSession {
   sessionId?: string;
@@ -50,6 +56,13 @@ export interface StoredSession {
    * to filter the list to sessions from the current directory. Absent on
    * legacy sidecars — those surface only in the global fallback view. */
   cwd?: string;
+  /** Session-registry handle id. Absent on pre-registry sidecars → the
+   *  sidecar's on-disk id is used as the stable handle id (see storedToHandle). */
+  handleId?: string;
+  /** Session-registry bindings (surface → opaque routing key). Absent on
+   *  pre-registry sidecars; a legacy `telegramChatId` migrates to one telegram
+   *  binding so existing Telegram conversations resolve unchanged. */
+  bindings?: SessionBinding[];
 }
 
 export interface SessionListEntry {
@@ -316,4 +329,71 @@ export function sdkSessionIdFor(idOrName: string): string | undefined {
     if (entry.name === idOrName) return entry.sessionId;
   }
   return undefined;
+}
+
+// ---- session-registry bridge -------------------------------------------------
+// Pure mappings between the persisted StoredSession sidecar and a registry
+// SessionHandle. These are the seam the session-registry loads/persists through;
+// no I/O and no production call site yet (wired when a surface routes through
+// the registry). See .afk/plans/session-registry-architecture.md step 2.
+
+/**
+ * The registry bindings for a stored session, applying the legacy migration.
+ *
+ * Precedence: an explicit `bindings[]` wins; else a legacy `telegramChatId`
+ * becomes a single telegram binding keyed by the chat id (so existing Telegram
+ * conversations resolve unchanged); else no routing binding (the session is
+ * still reachable by id / sdkSessionId until something re-binds it on resume).
+ */
+export function bindingsForStored(stored: StoredSession): SessionBinding[] {
+  if (stored.bindings && stored.bindings.length > 0) {
+    return stored.bindings.map((b) => ({ ...b }));
+  }
+  if (stored.telegramChatId !== undefined) {
+    return [
+      {
+        surface: 'telegram',
+        key: String(stored.telegramChatId),
+        boundAt: stored.startedAt,
+        lastActiveAt: stored.savedAt,
+      },
+    ];
+  }
+  return [];
+}
+
+/**
+ * Map a persisted StoredSession to a registry SessionHandle.
+ *
+ * `sidecarId` is the sidecar's stable on-disk id (filename minus `.json`); it
+ * becomes the handle id when the sidecar predates the registry (no `handleId`),
+ * keeping the handle id stable across reloads. `source` defaults to `'cli'` for
+ * legacy sidecars (matching StoredSession's documented default).
+ */
+export function storedToHandle(stored: StoredSession, sidecarId: string): SessionHandle {
+  const surface: SessionSurface = stored.source ?? 'cli';
+  const handle: SessionHandle = {
+    id: asHandleId(stored.handleId ?? sidecarId),
+    surface,
+    model: stored.model,
+    createdAt: stored.startedAt,
+    lastActiveAt: stored.savedAt,
+    status: 'active',
+    bindings: bindingsForStored(stored),
+  };
+  if (stored.sessionId !== undefined) handle.sdkSessionId = stored.sessionId;
+  if (stored.name !== undefined) handle.name = stored.name;
+  if (stored.cwd !== undefined) handle.cwd = stored.cwd;
+  return handle;
+}
+
+/**
+ * The registry-owned fields to merge onto a StoredSession when persisting a
+ * handle. (The SDK session id continues to persist as `StoredSession.sessionId`
+ * via saveSession — it is not duplicated here.)
+ */
+export function storedFieldsFromHandle(
+  handle: SessionHandle,
+): Pick<StoredSession, 'handleId' | 'bindings'> {
+  return { handleId: handle.id, bindings: handle.bindings.map((b) => ({ ...b })) };
 }

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -431,6 +431,9 @@ async function main() {
         const session = attachMcpCleanup(constructTelegramSession({
           ...(sessionConfig.apiKey !== undefined ? { apiKey: sessionConfig.apiKey } : {}),
           model: sessionConfig.model,
+          // /switch resumes a prior conversation: thread the target SDK session
+          // id so the AgentSession continues it (see SessionManager.switchToSession).
+          ...(sessionConfig.resume !== undefined ? { resume: sessionConfig.resume } : {}),
           ...(systemPromptInner !== undefined ? { systemPrompt: systemPromptInner } : {}),
           maxTurns: 100,
           ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
@@ -493,6 +496,8 @@ async function main() {
       const session = attachMcpCleanup(constructTelegramSession({
         ...(sessionConfig.apiKey !== undefined ? { apiKey: sessionConfig.apiKey } : {}),
         model: sessionConfig.model,
+        // /switch resume: continue the target SDK session (parity with the Anthropic branch).
+        ...(sessionConfig.resume !== undefined ? { resume: sessionConfig.resume } : {}),
         ...(systemPrompt !== undefined ? { systemPrompt } : {}),
         maxTurns: 100,
         ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -9,6 +9,7 @@ import { formatError, formatModelSwitch } from './formatter.js';
 import { handleStart } from './handlers/start.js';
 import { handleHelp } from './handlers/help.js';
 import { handleClear, handleCompact, handleCwd, handleModelSwitch, handleName, MODEL_ALIASES_HINT } from './handlers/commands.js';
+import { handleSessions, handleNew, handleSwitchCallback } from './handlers/sessions.js';
 import type { AgentModelInput } from '../agent/types.js';
 import { handleFarmCallback } from './handlers/farm-callbacks.js';
 import { MessageHandler } from './handlers/message.js';
@@ -141,6 +142,16 @@ export class TelegramBot {
     this.bot.command('name', (ctx) =>
       handleName(ctx, this.sessionManager, this.log.bind(this))
     );
+    // /sessions — list this chat's resumable conversations with tap-to-switch
+    // buttons; /new — start a fresh conversation (previous preserved). One
+    // active session per chat; switching stages a resume that continues on the
+    // next message (see handlers/sessions.ts + SessionManager.switchToSession).
+    this.bot.command('sessions', (ctx) =>
+      handleSessions(ctx, this.sessionManager, this.log.bind(this))
+    );
+    this.bot.command('new', (ctx) =>
+      handleNew(ctx, this.sessionManager, this.registeredCommandChats, this.log.bind(this))
+    );
     // /watch <session> — live-tail another surface's session ledger into
     // this chat. /watch with no arg lists watchable sessions. The ledger is
     // written by every top-level AgentSession (CLI REPL, daemon, one-shot),
@@ -265,6 +276,15 @@ export class TelegramBot {
       } catch (err) {
         this.log('Model action error:', err);
       }
+    });
+
+    // Inline-keyboard session-switch callbacks from the /sessions reply. Prefix
+    // afk:sw: is disjoint from afk:m: / afk:e: / afk:pa: / the farm prefix, so
+    // taps never cross-route. Allowlist-guarded like the model action.
+    this.bot.action(/^afk:sw:/, async (ctx) => {
+      await ctx.answerCbQuery().catch(() => {});
+      if (ctx.chat?.id !== undefined && !this.options.allowedChatIds.has(ctx.chat.id)) return;
+      await handleSwitchCallback(ctx, this.sessionManager, this.log.bind(this));
     });
 
     this.bot.catch((err, ctx) => {

--- a/src/telegram/formatter.test.ts
+++ b/src/telegram/formatter.test.ts
@@ -308,6 +308,8 @@ describe('formatHelp', () => {
     expect(result).toContain('/compact');
     expect(result).toContain('/model');
     expect(result).toContain('/name');
+    expect(result).toContain('/sessions');
+    expect(result).toContain('/new');
     expect(result).toContain('CLI');
   });
 

--- a/src/telegram/formatter.ts
+++ b/src/telegram/formatter.ts
@@ -467,3 +467,52 @@ function formatTokenCount(n: number): string {
   if (n >= 1000) return `${Math.round(n / 100) / 10}k`;
   return String(n);
 }
+
+/**
+ * Format the `/sessions` list body — one line per resumable conversation for
+ * this chat, active one marked. Tappable switch buttons are attached by the
+ * handler; this is the text shown above them. Structural param (a superset of
+ * SessionManager.ChatSessionInfo) keeps the formatter decoupled from that module.
+ */
+export function formatSessionsList(
+  sessions: ReadonlyArray<{ name?: string; model: string; turns: number; active: boolean }>,
+): string {
+  const lines = sessions.map((s, i) => {
+    const marker = s.active ? '✅ ' : '';
+    const label = s.name ? escapeHtml(s.name) : '(unnamed)';
+    const turns = s.turns === 1 ? '1 turn' : `${s.turns} turns`;
+    return `${i + 1}. ${marker}<b>${label}</b> · ${escapeHtml(s.model)} · ${turns}`;
+  });
+  return `🗂️ <b>Your sessions</b> (${sessions.length})\n\n${lines.join('\n')}\n\nTap one to switch. /new starts a fresh session.`;
+}
+
+/** Reply when a chat has no resumable sessions yet. */
+export function formatNoSessions(): string {
+  return '🗂️ No saved sessions yet.\n\nSend a message to start one, or /new for a fresh session.';
+}
+
+/** /switch (button) confirmation — lazy resume continues on the next message. */
+export function formatSwitched(session: { name?: string }): string {
+  const label = session.name ? `<b>${escapeHtml(session.name)}</b>` : 'that session';
+  return `↩️ Switched to ${label}. Your next message continues it.`;
+}
+
+/** /new confirmation — the previous conversation is preserved + resumable. */
+export function formatNewSession(): string {
+  return '🆕 Started a fresh session. Your previous one is saved — /sessions to switch back.';
+}
+
+/** Shown when a switch/new is attempted while the active session is mid-turn. */
+export function formatSessionBusy(): string {
+  return '⏳ Finish or wait for the current turn before switching sessions.';
+}
+
+/** Shown when a switch target can no longer be found. */
+export function formatSwitchNotFound(): string {
+  return formatError('That session could no longer be found. /sessions to see the current list.');
+}
+
+/** Shown when switching to the already-active session. */
+export function formatAlreadyActive(): string {
+  return "✅ You're already on that session.";
+}

--- a/src/telegram/formatter.ts
+++ b/src/telegram/formatter.ts
@@ -297,6 +297,8 @@ export function formatHelp(sdkCommands?: string[]): string {
     '  /model      — Switch Claude model',
     '  /cd         — Change working directory',
     '  /name       — Show or set the session name',
+    '  /sessions   — List and switch between sessions',
+    '  /new        — Start a new session (keeps the current one)',
     '  /watch      — Live-tail a CLI session from this chat',
     '  /unwatch    — Stop watching a session',
     '',

--- a/src/telegram/handlers/registration.ts
+++ b/src/telegram/handlers/registration.ts
@@ -39,6 +39,8 @@ export async function registerChatCommands(
       { command: 'model', description: 'Switch Claude model (opus/sonnet/haiku)' },
       { command: 'cd', description: 'Show or change session working directory' },
       { command: 'name', description: 'Show or set the session name' },
+      { command: 'sessions', description: 'List and switch between sessions' },
+      { command: 'new', description: 'Start a new session (keeps the current one)' },
     ];
 
     // Add SDK slash commands

--- a/src/telegram/handlers/sessions.test.ts
+++ b/src/telegram/handlers/sessions.test.ts
@@ -120,6 +120,26 @@ describe('session switcher handlers', () => {
       expect(callbackData).toEqual([`${SWITCH_CALLBACK_PREFIX}sdk-A`, `${SWITCH_CALLBACK_PREFIX}sdk-B`]);
     });
 
+    it('omits the switch button for a session whose id exceeds the callback_data cap, but still lists it', async () => {
+      const longId = 'sdk-' + 'x'.repeat(64); // 68 chars; 'afk:sw:' + id = 75 > 64-byte cap
+      manager.recordTelegramTurn(702, 'short id convo', 'a', { sessionId: 'sdk-short' });
+      await manager.resetSession(702);
+      manager.recordTelegramTurn(702, 'long id convo', 'b', { sessionId: longId });
+
+      const { ctx, reply } = makeCtx(702);
+      await handleSessions(ctx, manager, log);
+
+      const [body, opts] = reply.mock.calls[0] as [string, InlineKeyboardReply];
+      // Both sessions appear in the text list (list uses names, not ids).
+      expect(body).toContain('short-id-convo');
+      expect(body).toContain('long-id-convo');
+      // But only the short-id session gets a switch button.
+      const rows = opts.reply_markup?.inline_keyboard ?? [];
+      const callbackData = rows.map((r) => r[0]!.callback_data);
+      expect(callbackData).toEqual([`${SWITCH_CALLBACK_PREFIX}sdk-short`]);
+      expect(callbackData.some((d) => d.includes(longId))).toBe(false);
+    });
+
     it('replies "Could not identify chat" when the update has no chat', async () => {
       const { ctx, reply } = makeCtx(null);
       await handleSessions(ctx, manager, log);

--- a/src/telegram/handlers/sessions.test.ts
+++ b/src/telegram/handlers/sessions.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for src/telegram/handlers/sessions.ts — the /sessions switcher,
+ * /new, and the afk:sw: inline-button switch callback.
+ *
+ * Uses a real SessionManager over a tmp HOME (the shared sidecar store) seeded
+ * via recordTelegramTurn, mirroring the session-manager suite's harness.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Context } from 'telegraf';
+import { existsSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { handleSessions, handleNew, handleSwitchCallback, SWITCH_CALLBACK_PREFIX } from './sessions.js';
+import { SessionManager } from '../session-manager.js';
+import { useUnsetAfkHome } from '../../__test-utils__/unset-afk-home.js';
+import type { IAgentSession, AgentConfig, SessionState } from '../../agent/types.js';
+
+class MockAgentSession implements IAgentSession {
+  state: SessionState = 'idle';
+  constructor(readonly sessionId?: string) {}
+  async sendMessage(content: string) {
+    return { role: 'assistant' as const, content: `Echo: ${content}`, timestamp: new Date() };
+  }
+  async *getOutputStream() { yield { type: 'done' as const }; }
+  abort(_reason: string): void { /* no-op */ }
+  async close() { /* no-op */ }
+  async reset() { /* no-op */ }
+}
+
+interface InlineKeyboardReply {
+  reply_markup?: { inline_keyboard?: Array<Array<{ text: string; callback_data: string }>> };
+  parse_mode?: string;
+}
+
+function makeCtx(chatId: number | null = 42) {
+  const reply = vi.fn(async () => ({ message_id: 1 }));
+  const ctx = {
+    chat: chatId === null ? undefined : { id: chatId, type: 'private' as const },
+    message: { text: '/sessions' },
+    reply,
+  } as unknown as Context;
+  return { ctx, reply };
+}
+
+function makeCbCtx(data: string, chatId: number | null = 42) {
+  const reply = vi.fn(async () => ({ message_id: 1 }));
+  const editMessageText = vi.fn(async () => true);
+  const ctx = {
+    chat: chatId === null ? undefined : { id: chatId, type: 'private' as const },
+    callbackQuery: { data },
+    reply,
+    editMessageText,
+  } as unknown as Context;
+  return { ctx, reply, editMessageText };
+}
+
+describe('session switcher handlers', () => {
+  useUnsetAfkHome();
+
+  let testDataDir: string;
+  let tmpHome: string;
+  let originalHome: string | undefined;
+  let log: ReturnType<typeof vi.fn>;
+  let manager: SessionManager;
+
+  function makeManager(sessionId?: string): SessionManager {
+    return new SessionManager({
+      dataDir: testDataDir,
+      apiKey: 'test-key',
+      defaultModel: 'sonnet',
+      createSession: async (_config: AgentConfig) => new MockAgentSession(sessionId),
+    });
+  }
+
+  /** Seed two distinct resumable conversations for a chat (reset between). */
+  async function seedTwo(chatId: number): Promise<void> {
+    manager.recordTelegramTurn(chatId, 'alpha work', 'a', { sessionId: 'sdk-A' });
+    await manager.resetSession(chatId);
+    manager.recordTelegramTurn(chatId, 'beta work', 'b', { sessionId: 'sdk-B' });
+  }
+
+  beforeEach(() => {
+    const entropy = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    testDataDir = join(tmpdir(), `afk-tg-sh-data-${entropy}`);
+    originalHome = process.env['HOME'];
+    tmpHome = join(tmpdir(), `afk-tg-sh-home-${entropy}`);
+    process.env['HOME'] = tmpHome;
+    log = vi.fn();
+    manager = makeManager('sdk-live');
+  });
+
+  afterEach(async () => {
+    await manager.closeAll().catch(() => {});
+    if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+    if (existsSync(testDataDir)) rmSync(testDataDir, { recursive: true, force: true });
+    if (originalHome !== undefined) process.env['HOME'] = originalHome;
+  });
+
+  describe('handleSessions', () => {
+    it('replies with the no-sessions notice when the chat has none', async () => {
+      const { ctx, reply } = makeCtx(700);
+      await handleSessions(ctx, manager, log);
+      expect(reply).toHaveBeenCalledTimes(1);
+      expect(String(reply.mock.calls[0]![0])).toContain('No saved sessions');
+    });
+
+    it('lists sessions with a tap-to-switch button per session', async () => {
+      await seedTwo(701);
+      const { ctx, reply } = makeCtx(701);
+      await handleSessions(ctx, manager, log);
+
+      const [body, opts] = reply.mock.calls[0] as [string, InlineKeyboardReply];
+      expect(body).toContain('Your sessions');
+      expect(opts.parse_mode).toBe('HTML');
+      const rows = opts.reply_markup?.inline_keyboard ?? [];
+      expect(rows).toHaveLength(2);
+      const callbackData = rows.map((r) => r[0]!.callback_data).sort();
+      expect(callbackData).toEqual([`${SWITCH_CALLBACK_PREFIX}sdk-A`, `${SWITCH_CALLBACK_PREFIX}sdk-B`]);
+    });
+
+    it('replies "Could not identify chat" when the update has no chat', async () => {
+      const { ctx, reply } = makeCtx(null);
+      await handleSessions(ctx, manager, log);
+      expect(String(reply.mock.calls[0]![0])).toContain('Could not identify chat');
+    });
+  });
+
+  describe('handleNew', () => {
+    it('starts a fresh session and clears the command-registration cache when idle', async () => {
+      manager.recordTelegramTurn(710, 'old convo', 'a', { sessionId: 'sdk-old' });
+      const registered = new Set<number>([710]);
+      const spy = vi.spyOn(manager, 'newSession');
+
+      const { ctx, reply } = makeCtx(710);
+      await handleNew(ctx, manager, registered, log);
+
+      expect(spy).toHaveBeenCalledWith(710);
+      expect(registered.has(710)).toBe(false);
+      expect(String(reply.mock.calls[0]![0])).toContain('fresh session');
+      // Previous conversation is preserved as resumable.
+      expect(manager.listChatSessions(710).map((s) => s.sessionId)).toContain('sdk-old');
+    });
+
+    it('refuses while the active session is mid-turn', async () => {
+      const live = (await manager.getSession(711)) as MockAgentSession;
+      live.state = 'processing';
+      const spy = vi.spyOn(manager, 'newSession');
+
+      const { ctx, reply } = makeCtx(711);
+      await handleNew(ctx, manager, new Set<number>(), log);
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(String(reply.mock.calls[0]![0])).toContain('current turn');
+    });
+  });
+
+  describe('handleSwitchCallback', () => {
+    it('switches to the tapped session and confirms', async () => {
+      await seedTwo(720);
+      const spy = vi.spyOn(manager, 'switchToSession');
+      const { ctx, editMessageText, reply } = makeCbCtx(`${SWITCH_CALLBACK_PREFIX}sdk-A`, 720);
+
+      await handleSwitchCallback(ctx, manager, log);
+
+      expect(spy).toHaveBeenCalledWith(720, 'sdk-A');
+      const confirmed = String(editMessageText.mock.calls[0]?.[0] ?? reply.mock.calls[0]?.[0] ?? '');
+      expect(confirmed).toContain('Switched');
+      // sdk-A is now the active conversation.
+      expect(manager.listChatSessions(720).find((s) => s.sessionId === 'sdk-A')?.active).toBe(true);
+    });
+
+    it('reports not-found for an unknown target', async () => {
+      await seedTwo(721);
+      const { ctx, reply } = makeCbCtx(`${SWITCH_CALLBACK_PREFIX}sdk-nope`, 721);
+      await handleSwitchCallback(ctx, manager, log);
+      expect(String(reply.mock.calls[0]![0])).toContain('could no longer be found');
+    });
+
+    it('refuses while the active session is mid-turn', async () => {
+      await seedTwo(722);
+      const live = (await manager.getSession(722)) as MockAgentSession;
+      live.state = 'streaming';
+      const spy = vi.spyOn(manager, 'switchToSession');
+
+      const { ctx, reply } = makeCbCtx(`${SWITCH_CALLBACK_PREFIX}sdk-A`, 722);
+      await handleSwitchCallback(ctx, manager, log);
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(String(reply.mock.calls[0]![0])).toContain('current turn');
+    });
+
+    it('ignores a callback with no matching prefix', async () => {
+      const { ctx, reply, editMessageText } = makeCbCtx('afk:other:x', 723);
+      await handleSwitchCallback(ctx, manager, log);
+      expect(reply).not.toHaveBeenCalled();
+      expect(editMessageText).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/telegram/handlers/sessions.ts
+++ b/src/telegram/handlers/sessions.ts
@@ -1,0 +1,165 @@
+/**
+ * Telegram session-switcher command handlers — /sessions and /new, plus the
+ * inline-button switch callback (afk:sw:<sessionId>).
+ *
+ * Multi-session model: one ACTIVE conversation per chat at a time; every past
+ * conversation persists as a resumable sidecar in the shared session store
+ * (keyed by telegramChatId). `/sessions` lists them with a tappable button per
+ * session; tapping stages a resume (SessionManager.switchToSession) that
+ * continues on the next message. `/new` starts a fresh conversation, preserving
+ * the current one as resumable. Both refuse while the active session is
+ * mid-turn so a streaming reply is never orphaned.
+ *
+ * @module telegram/handlers/sessions
+ */
+
+import { Context, Markup } from 'telegraf';
+import { SessionManager } from '../session-manager.js';
+import {
+  formatError,
+  formatSessionsList,
+  formatNoSessions,
+  formatSwitched,
+  formatNewSession,
+  formatSessionBusy,
+  formatSwitchNotFound,
+  formatAlreadyActive,
+} from '../formatter.js';
+
+type LogFn = (...args: unknown[]) => void;
+
+/** callback_data prefix for a session-switch inline button (afk:sw:<sessionId>). */
+export const SWITCH_CALLBACK_PREFIX = 'afk:sw:';
+
+/** Telegram's hard limit on callback_data (bytes). */
+const CALLBACK_DATA_MAX = 64;
+
+/** Read the `data` string off a callback_query context, or '' when absent. */
+function callbackData(ctx: Context): string {
+  const cq = ctx.callbackQuery;
+  return typeof cq === 'object' && cq !== null && 'data' in cq ? (cq as { data: string }).data : '';
+}
+
+/** True when the chat has a live session that is NOT idle (mid-turn). */
+function isBusy(sessionManager: SessionManager, chatId: number): boolean {
+  const live = sessionManager.getSessionIfExists(chatId);
+  return live !== undefined && live.state !== 'idle';
+}
+
+/**
+ * /sessions — list this chat's resumable conversations, newest-active first,
+ * with a tappable switch button per session. Read-only: switching happens in
+ * the button callback (handleSwitchCallback).
+ */
+export async function handleSessions(
+  ctx: Context,
+  sessionManager: SessionManager,
+  _log: LogFn,
+): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) {
+    await ctx.reply(formatError('Could not identify chat'));
+    return;
+  }
+
+  const sessions = sessionManager.listChatSessions(chatId);
+  if (sessions.length === 0) {
+    await ctx.reply(formatNoSessions());
+    return;
+  }
+
+  // One switch button per session whose callback_data fits Telegram's 64-byte
+  // cap. SDK session ids are short (UUID-ish), so the guard is belt-and-braces:
+  // a pathological id can't throw at send time — that session still shows in the
+  // text list, just without a button.
+  const buttons = sessions
+    .filter((s) => (SWITCH_CALLBACK_PREFIX + s.sessionId).length <= CALLBACK_DATA_MAX)
+    .map((s) => [
+      Markup.button.callback(
+        `${s.active ? '✅ ' : ''}${s.name ?? '(unnamed)'} · ${s.turns} turns`,
+        `${SWITCH_CALLBACK_PREFIX}${s.sessionId}`,
+      ),
+    ]);
+
+  await ctx.reply(formatSessionsList(sessions), {
+    parse_mode: 'HTML',
+    reply_markup: Markup.inlineKeyboard(buttons).reply_markup,
+  });
+}
+
+/**
+ * /new — start a fresh conversation for this chat. The previous one is preserved
+ * as a resumable session (/sessions to switch back). Refused while the active
+ * session is mid-turn.
+ */
+export async function handleNew(
+  ctx: Context,
+  sessionManager: SessionManager,
+  registeredCommandChats: Set<number>,
+  log: LogFn,
+): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) {
+    await ctx.reply(formatError('Could not identify chat'));
+    return;
+  }
+  if (isBusy(sessionManager, chatId)) {
+    await ctx.reply(formatSessionBusy());
+    return;
+  }
+  try {
+    await sessionManager.newSession(chatId);
+    // Force per-chat command re-registration for the fresh session (mirrors /clear).
+    registeredCommandChats.delete(chatId);
+    await ctx.reply(formatNewSession());
+  } catch (error) {
+    log('New session error:', error);
+    await ctx.reply(formatError(error as Error));
+  }
+}
+
+/**
+ * Inline-button callback for /sessions — switch this chat's active conversation
+ * to the tapped session. Lazy resume: the target is staged and continues on the
+ * next message (SessionManager.switchToSession), so the callback never blocks on
+ * a potentially slow resume replay. Refused while the active session is mid-turn.
+ *
+ * The chat-allowlist check + answerCbQuery are performed by the bot.action
+ * wrapper before this is called.
+ */
+export async function handleSwitchCallback(
+  ctx: Context,
+  sessionManager: SessionManager,
+  log: LogFn,
+): Promise<void> {
+  const chatId = ctx.chat?.id;
+  const data = callbackData(ctx);
+  const targetSessionId = data.startsWith(SWITCH_CALLBACK_PREFIX)
+    ? data.slice(SWITCH_CALLBACK_PREFIX.length)
+    : '';
+  if (!chatId || !targetSessionId) return;
+
+  if (isBusy(sessionManager, chatId)) {
+    await ctx.reply(formatSessionBusy());
+    return;
+  }
+
+  try {
+    const res = await sessionManager.switchToSession(chatId, targetSessionId);
+    if (!res.ok) {
+      await ctx.reply(res.reason === 'already-active' ? formatAlreadyActive() : formatSwitchNotFound());
+      return;
+    }
+    const name = sessionManager
+      .listChatSessions(chatId)
+      .find((s) => s.sessionId === targetSessionId)?.name;
+    const confirm = formatSwitched(name !== undefined ? { name } : {});
+    // Edit the /sessions message in place (fall back to a fresh reply).
+    await ctx
+      .editMessageText(confirm, { parse_mode: 'HTML' })
+      .catch(() => ctx.reply(confirm, { parse_mode: 'HTML' }));
+  } catch (error) {
+    log('Switch callback error:', error);
+    await ctx.reply(formatError(error as Error));
+  }
+}

--- a/src/telegram/handlers/sessions.ts
+++ b/src/telegram/handlers/sessions.ts
@@ -150,10 +150,8 @@ export async function handleSwitchCallback(
       await ctx.reply(res.reason === 'already-active' ? formatAlreadyActive() : formatSwitchNotFound());
       return;
     }
-    const name = sessionManager
-      .listChatSessions(chatId)
-      .find((s) => s.sessionId === targetSessionId)?.name;
-    const confirm = formatSwitched(name !== undefined ? { name } : {});
+    // Use the name switchToSession already loaded — no second full-store rescan.
+    const confirm = formatSwitched(res.name !== undefined ? { name: res.name } : {});
     // Edit the /sessions message in place (fall back to a fresh reply).
     await ctx
       .editMessageText(confirm, { parse_mode: 'HTML' })

--- a/src/telegram/route.test.ts
+++ b/src/telegram/route.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for the Telegram routing primitive (src/telegram/route.ts).
+ *
+ * Covers the §11 leak fix: a button tap inside a topic carries its thread id on
+ * callback_query.message, not ctx.message — routeFromCtx must still find it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { Context } from 'telegraf';
+import { routeFromCtx, routeKey, sendOptions, isGeneral, GENERAL_TOPIC_ID } from './route.js';
+
+/** Build a minimal ctx-like object with just the fields routeFromCtx reads. */
+function ctx(parts: {
+  chatId?: number;
+  message?: Record<string, unknown>;
+  editedMessage?: Record<string, unknown>;
+  callbackMessage?: Record<string, unknown>;
+}): Context {
+  return {
+    chat: parts.chatId === undefined ? undefined : { id: parts.chatId, type: 'private' },
+    message: parts.message,
+    editedMessage: parts.editedMessage,
+    callbackQuery: parts.callbackMessage ? { message: parts.callbackMessage } : undefined,
+  } as unknown as Context;
+}
+
+describe('routeFromCtx', () => {
+  it('returns undefined when the update has no chat', () => {
+    expect(routeFromCtx(ctx({}))).toBeUndefined();
+  });
+
+  it('reads chat id with no thread (General / topics-off)', () => {
+    expect(routeFromCtx(ctx({ chatId: 42, message: { text: 'hi' } }))).toEqual({ chatId: 42 });
+  });
+
+  it('captures message_thread_id + is_topic_message from a text message', () => {
+    const r = routeFromCtx(ctx({ chatId: 42, message: { text: 'hi', message_thread_id: 7, is_topic_message: true } }));
+    expect(r).toEqual({ chatId: 42, threadId: 7, isTopicMessage: true });
+  });
+
+  it('captures the thread id from a callback_query message (button tap in a topic)', () => {
+    const r = routeFromCtx(ctx({ chatId: 42, callbackMessage: { message_thread_id: 7, is_topic_message: true } }));
+    expect(r).toEqual({ chatId: 42, threadId: 7, isTopicMessage: true });
+  });
+
+  it('captures the thread id from an edited message', () => {
+    const r = routeFromCtx(ctx({ chatId: 42, editedMessage: { message_thread_id: 9 } }));
+    expect(r).toEqual({ chatId: 42, threadId: 9 });
+  });
+
+  it('ignores a non-numeric message_thread_id', () => {
+    const r = routeFromCtx(ctx({ chatId: 42, message: { message_thread_id: 'x' } }));
+    expect(r).toEqual({ chatId: 42 });
+  });
+});
+
+describe('isGeneral / routeKey — General normalizes to the bare chat id', () => {
+  it('treats absent thread as General', () => {
+    expect(isGeneral({ chatId: 42 })).toBe(true);
+    expect(routeKey({ chatId: 42 })).toBe('42');
+  });
+
+  it('treats thread id 1 as General', () => {
+    expect(isGeneral({ chatId: 42, threadId: GENERAL_TOPIC_ID })).toBe(true);
+    expect(routeKey({ chatId: 42, threadId: 1 })).toBe('42');
+  });
+
+  it('keys a real topic as chatId:threadId', () => {
+    expect(isGeneral({ chatId: 42, threadId: 7 })).toBe(false);
+    expect(routeKey({ chatId: 42, threadId: 7 })).toBe('42:7');
+  });
+});
+
+describe('sendOptions', () => {
+  it('omits message_thread_id for General (byte-identical to non-topic sends)', () => {
+    expect(sendOptions({ chatId: 42 })).toEqual({});
+    expect(sendOptions({ chatId: 42, threadId: GENERAL_TOPIC_ID })).toEqual({});
+  });
+
+  it('pins the reply to a real topic', () => {
+    expect(sendOptions({ chatId: 42, threadId: 7 })).toEqual({ message_thread_id: 7 });
+  });
+});

--- a/src/telegram/route.ts
+++ b/src/telegram/route.ts
@@ -1,0 +1,96 @@
+/**
+ * Telegram routing primitive — the ingress side of the session registry.
+ *
+ * A `TelegramRoute` identifies WHICH conversation an update belongs to inside a
+ * single bot DM: the chat plus, when Telegram "topics in private chats" is in
+ * play, the topic's `message_thread_id`. `routeKey()` turns a route into the
+ * opaque string the session registry binds on (`resolve('telegram', key)`).
+ *
+ * Invariant: the General topic (`message_thread_id` absent OR === 1) normalizes
+ * to the bare-chatId key, so a chat with topics disabled — and every existing
+ * single-session user — maps to the SAME key the pre-registry bot used and the
+ * Step-2 legacy migration synthesizes (`String(chatId)`). Topics are additive.
+ *
+ * Leak fix (see session-registry-architecture.md §11): the thread id is read
+ * from whichever update part carries it — a normal `message`, an
+ * `edited_message`, OR a `callback_query`'s attached message (a button tapped
+ * inside a topic carries its thread id on `callbackQuery.message`, NOT on
+ * `ctx.message`). Reading only `ctx.message` would misroute button taps to
+ * General. Extraction is defensive (no reliance on Telegraf's evolving Message
+ * typing) and never throws.
+ *
+ * @module telegram/route
+ */
+
+import type { Context } from 'telegraf';
+
+/** The General/root topic id. Messages here (or with no thread) share the chat's default session. */
+export const GENERAL_TOPIC_ID = 1;
+
+/** Which conversation an update belongs to within one bot chat. */
+export interface TelegramRoute {
+  /** Telegram chat id (in a private DM this equals the user's account id). */
+  chatId: number;
+  /** Topic thread id when in a non-General topic; absent for General / topics-off. */
+  threadId?: number;
+  /** True when Telegram flagged the source as a topic message. */
+  isTopicMessage?: boolean;
+}
+
+interface ExtractedThread {
+  threadId?: number;
+  isTopic?: boolean;
+}
+
+/** Defensively read message_thread_id / is_topic_message off any update part. */
+function readThread(source: unknown): ExtractedThread {
+  if (source === null || typeof source !== 'object') return {};
+  const rec = source as Record<string, unknown>;
+  const tid = rec['message_thread_id'];
+  const isTopic = rec['is_topic_message'];
+  return {
+    ...(typeof tid === 'number' ? { threadId: tid } : {}),
+    ...(isTopic === true ? { isTopic: true } : {}),
+  };
+}
+
+/**
+ * Derive the route for an incoming update, or `undefined` when it carries no
+ * chat (nothing to route). The thread id is sourced from `message`,
+ * `edited_message`, or `callback_query.message` — whichever is present.
+ */
+export function routeFromCtx(ctx: Context): TelegramRoute | undefined {
+  const chatId = ctx.chat?.id;
+  if (typeof chatId !== 'number') return undefined;
+
+  const source = ctx.message ?? ctx.editedMessage ?? ctx.callbackQuery?.message;
+  const { threadId, isTopic } = readThread(source);
+
+  const route: TelegramRoute = { chatId };
+  if (threadId !== undefined) route.threadId = threadId;
+  if (isTopic) route.isTopicMessage = true;
+  return route;
+}
+
+/** True when the route addresses the General topic (or topics are off). */
+export function isGeneral(route: TelegramRoute): boolean {
+  return route.threadId === undefined || route.threadId === GENERAL_TOPIC_ID;
+}
+
+/**
+ * The opaque registry binding key for a route. General normalizes to the bare
+ * chat id (back-compat with the pre-registry key + the Step-2 legacy binding);
+ * a real topic keys as `${chatId}:${threadId}`.
+ */
+export function routeKey(route: TelegramRoute): string {
+  return isGeneral(route) ? String(route.chatId) : `${route.chatId}:${route.threadId}`;
+}
+
+/**
+ * Telegram send options that pin a reply to the route's topic. General/absent
+ * omits `message_thread_id` (Telegram delivers to General by default), so
+ * existing non-topic sends are byte-identical.
+ */
+export function sendOptions(route: TelegramRoute): { message_thread_id?: number } {
+  return isGeneral(route) ? {} : { message_thread_id: route.threadId };
+}

--- a/src/telegram/session-manager.test.ts
+++ b/src/telegram/session-manager.test.ts
@@ -948,4 +948,102 @@ describe('SessionManager — session switcher (/sessions, /switch, /new)', () =>
     expect(lastConfig?.resume).toBe('sdk-target');
     await m.closeAll().catch(() => {});
   });
+
+  test('a staged resume survives a createSession failure and is retried on the next build', async () => {
+    // Regression guard for the resume-drop bug: switchToSession stages the
+    // resume, but the FIRST session build throws. The staged resume must NOT be
+    // consumed by the failed build — the next getSession must still resume the
+    // target. (Before the fix, getSession deleted pendingResume BEFORE the
+    // fallible createSession, so the failed build silently dropped the resume
+    // and the next build started a fresh conversation — this assertion caught it.)
+    let created = 0;
+    const m = new SessionManager({
+      dataDir: testDataDir,
+      apiKey: 'test-key',
+      defaultModel: 'sonnet',
+      createSession: async (config: AgentConfig) => {
+        lastConfig = config;
+        created += 1;
+        // First build throws; every build afterwards succeeds.
+        if (created === 1) throw new Error('creation failed');
+        return new MockSessionWithId('sdk-rebuilt');
+      },
+    });
+    // Persist the switch TARGET sidecar with no live session so the passed
+    // metadata id ('sdk-target') sticks, then clear any live session.
+    m.recordTelegramTurn(906, 'target convo', 'b', { sessionId: 'sdk-target' });
+    await m.resetSession(906); // no live session; clears data.sessionId
+
+    // Stage the resume via /switch — succeeds (no live session to close).
+    expect((await m.switchToSession(906, 'sdk-target')).ok).toBe(true);
+
+    // First getSession: the build throws → rejects. The staged resume must be
+    // left intact (consumed only after a successful build).
+    await expect(m.getSession(906)).rejects.toThrow('creation failed');
+
+    // Second getSession: succeeds AND still carries the staged resume.
+    lastConfig = undefined;
+    await m.getSession(906);
+    expect(lastConfig?.resume).toBe('sdk-target');
+
+    await m.closeAll().catch(() => {});
+  });
+
+  test('a switch during an in-flight creation does not silently revert', async () => {
+    // Regression guard for the in-flight-revert bug: a getSession creation is in
+    // flight when switchToSession runs. Without the fix, switchToSession would
+    // inspect/close the live session BEFORE the in-flight promise resolved, then
+    // the in-flight promise would set the pre-switch session as live AFTER the
+    // switch adopted the target — silently reverting it. switchToSession now
+    // awaits the in-flight creation first, so the built session is evicted by the
+    // close path and the switch sticks.
+    //
+    // Deterministic (no timing race): the first createSession returns a DEFERRED
+    // promise, so the first build stays parked until we release it. switchToSession
+    // awaits that same in-flight promise, so its continuation is gated on the
+    // release — a promise-settle dependency, not a wall-clock sleep.
+    let created = 0;
+    let releaseFirst: (session: IAgentSession) => void = () => {};
+    const firstBuilt = new MockSessionWithId('sdk-live-default');
+    const m = new SessionManager({
+      dataDir: testDataDir,
+      apiKey: 'test-key',
+      defaultModel: 'sonnet',
+      createSession: async (config: AgentConfig) => {
+        lastConfig = config;
+        created += 1;
+        if (created === 1) {
+          // Park the first build until releaseFirst() is called below.
+          return await new Promise<IAgentSession>((resolve) => {
+            releaseFirst = resolve;
+          });
+        }
+        return new MockSessionWithId('sdk-rebuilt');
+      },
+    });
+    // Persist the switch TARGET sidecar with no live session so 'sdk-target' sticks.
+    m.recordTelegramTurn(907, 'target convo', 'b', { sessionId: 'sdk-target' });
+    await m.resetSession(907); // clears data.sessionId; no live session
+
+    // Start the first creation WITHOUT awaiting — it parks on the deferred, and
+    // getSession has already populated pendingSessions by the time it yields.
+    const inflightGet = m.getSession(907);
+
+    // Switch while the first build is in flight. switchToSession must await the
+    // in-flight promise; kick it off, then release the build so both settle.
+    const switchPromise = m.switchToSession(907, 'sdk-target');
+    releaseFirst(firstBuilt);
+
+    // The switch resolved successfully — it did not observe a reverted state.
+    expect((await switchPromise).ok).toBe(true);
+    await inflightGet; // the parked first creation resolves cleanly
+
+    // The staged resume points at the target: the next build resumes it, proving
+    // the switch stuck (the in-flight build's session was evicted, not adopted).
+    lastConfig = undefined;
+    await m.getSession(907);
+    expect(lastConfig?.resume).toBe('sdk-target');
+
+    await m.closeAll().catch(() => {});
+  });
 });

--- a/src/telegram/session-manager.test.ts
+++ b/src/telegram/session-manager.test.ts
@@ -873,7 +873,7 @@ describe('SessionManager — session switcher (/sessions, /switch, /new)', () =>
     manager.recordTelegramTurn(801, 'second convo', 'b', { sessionId: 'sdk-2' });
 
     const res = await manager.switchToSession(801, 'sdk-1');
-    expect(res).toEqual({ ok: true });
+    expect(res).toEqual({ ok: true, name: 'first-convo' });
     expect(manager.listChatSessions(801).find((s) => s.sessionId === 'sdk-1')?.active).toBe(true);
 
     // The rebuilt session continues the chosen conversation: config.resume === target.
@@ -908,5 +908,44 @@ describe('SessionManager — session switcher (/sessions, /switch, /new)', () =>
     manager.recordTelegramTurn(805, 'new convo', 'b', { sessionId: 'sdk-fresh' });
 
     expect(manager.listChatSessions(805).map((s) => s.sessionId).sort()).toEqual(['sdk-fresh', 'sdk-old']);
+  });
+
+  test('a rejecting close() during switch still deletes the stale session and rebuilds on next getSession', async () => {
+    class RejectingCloseSession extends MockSessionWithId {
+      override async close() { throw new Error('close boom'); }
+    }
+    let created = 0;
+    const m = new SessionManager({
+      dataDir: testDataDir,
+      apiKey: 'test-key',
+      defaultModel: 'sonnet',
+      createSession: async (config: AgentConfig) => {
+        lastConfig = config;
+        created += 1;
+        // The FIRST built session (the one live at switch-time) rejects on
+        // close; the post-switch rebuild closes cleanly. This isolates the
+        // rejecting close to switchToSession's close path (ITEM 3's fix).
+        return created === 1 ? new RejectingCloseSession('sdk-live-default') : new MockSessionWithId('sdk-rebuilt');
+      },
+    });
+    // Record the switch TARGET sidecar with no live session so the passed
+    // metadata id ('sdk-target') sticks — a live session's own sessionId would
+    // otherwise shadow it (recordTelegramTurn copies live.sessionId into stats).
+    m.recordTelegramTurn(900, 'target convo', 'b', { sessionId: 'sdk-target' });
+    await m.resetSession(900); // no live session to close; clears data.sessionId
+    // Establish the live session switchToSession will close — build #1, whose
+    // close() rejects. Its own turn keys it to 'sdk-live-default'.
+    const stale = await m.getSession(900);
+    m.recordTelegramTurn(900, 'live convo', 'a', { sessionId: 'sdk-live-default' });
+
+    const res = await m.switchToSession(900, 'sdk-target');
+    expect(res.ok).toBe(true);
+
+    lastConfig = undefined;
+    const rebuilt = await m.getSession(900);
+    // The stale (reject-on-close) session was still evicted → getSession rebuilt.
+    expect(rebuilt).not.toBe(stale);
+    expect(lastConfig?.resume).toBe('sdk-target');
+    await m.closeAll().catch(() => {});
   });
 });

--- a/src/telegram/session-manager.test.ts
+++ b/src/telegram/session-manager.test.ts
@@ -796,3 +796,117 @@ describe('SessionManager — session naming (/name)', () => {
     await m2.closeAll().catch(() => {});
   });
 });
+
+describe('SessionManager — session switcher (/sessions, /switch, /new)', () => {
+  // Same unset-AFK_HOME contract as the recordTelegramTurn suite: the shared
+  // sidecar store (listSessions/loadSession) resolves under this suite's tmp HOME.
+  useUnsetAfkHome();
+
+  class MockSessionWithId implements IAgentSession {
+    state: SessionState = 'idle';
+    constructor(readonly sessionId?: string) {}
+    async sendMessage(content: string) {
+      return { role: 'assistant' as const, content: `Echo: ${content}`, timestamp: new Date() };
+    }
+    async *getOutputStream() { yield { type: 'done' as const }; }
+    abort(_reason: string): void { /* no-op */ }
+    async close() { /* no-op */ }
+    async reset() { /* no-op */ }
+  }
+
+  let testDataDir: string;
+  let tmpHome: string;
+  let originalHome: string | undefined;
+  let lastConfig: AgentConfig | undefined;
+  let manager: SessionManager;
+
+  function makeManager(sessionId?: string): SessionManager {
+    return new SessionManager({
+      dataDir: testDataDir,
+      apiKey: 'test-key',
+      defaultModel: 'sonnet',
+      createSession: async (config: AgentConfig) => {
+        lastConfig = config;
+        return new MockSessionWithId(sessionId);
+      },
+    });
+  }
+
+  beforeEach(() => {
+    const entropy = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    testDataDir = join(tmpdir(), `afk-tg-sw-data-${entropy}`);
+    originalHome = process.env['HOME'];
+    tmpHome = join(tmpdir(), `afk-tg-sw-home-${entropy}`);
+    process.env['HOME'] = tmpHome;
+    lastConfig = undefined;
+    manager = makeManager('sdk-live-default');
+  });
+
+  afterEach(async () => {
+    await manager.closeAll().catch(() => {});
+    if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+    if (existsSync(testDataDir)) rmSync(testDataDir, { recursive: true, force: true });
+    if (originalHome !== undefined) process.env['HOME'] = originalHome;
+  });
+
+  test('listChatSessions lists this chat\'s telegram sidecars, excluding other chats', async () => {
+    // Two distinct conversations for chat 800 (reset between so each gets its own sidecar).
+    manager.recordTelegramTurn(800, 'alpha work', 'a', { sessionId: 'sdk-A' });
+    await manager.resetSession(800);
+    manager.recordTelegramTurn(800, 'beta work', 'b', { sessionId: 'sdk-B' });
+    // A different chat's sidecar must NOT leak into 800's list.
+    manager.recordTelegramTurn(999, 'other chat', 'x', { sessionId: 'sdk-other' });
+
+    const list = manager.listChatSessions(800);
+    expect(list.map((s) => s.sessionId).sort()).toEqual(['sdk-A', 'sdk-B']);
+    // No live/active session was established for 800 → nothing flagged active.
+    expect(list.every((s) => s.active === false)).toBe(true);
+    const alpha = list.find((s) => s.sessionId === 'sdk-A');
+    expect(alpha?.name).toBe('alpha-work');
+    expect(alpha?.turns).toBe(1);
+    expect(alpha?.model).toBe('sonnet');
+  });
+
+  test('switchToSession stages resume, marks the target active, and the next getSession resumes it', async () => {
+    manager.recordTelegramTurn(801, 'first convo', 'a', { sessionId: 'sdk-1' });
+    await manager.resetSession(801);
+    manager.recordTelegramTurn(801, 'second convo', 'b', { sessionId: 'sdk-2' });
+
+    const res = await manager.switchToSession(801, 'sdk-1');
+    expect(res).toEqual({ ok: true });
+    expect(manager.listChatSessions(801).find((s) => s.sessionId === 'sdk-1')?.active).toBe(true);
+
+    // The rebuilt session continues the chosen conversation: config.resume === target.
+    await manager.getSession(801);
+    expect(lastConfig?.resume).toBe('sdk-1');
+
+    // A subsequent /clear starts fresh — the staged resume is dropped.
+    await manager.resetSession(801);
+    lastConfig = undefined;
+    await manager.getSession(801);
+    expect(lastConfig?.resume).toBeUndefined();
+  });
+
+  test('switchToSession rejects an unknown or cross-chat target', async () => {
+    manager.recordTelegramTurn(802, 'my convo', 'a', { sessionId: 'sdk-802' });
+
+    expect(await manager.switchToSession(802, 'does-not-exist')).toEqual({ ok: false, reason: 'not-found' });
+    // sdk-802 belongs to chat 802, so switching chat 803 to it must be refused.
+    expect(await manager.switchToSession(803, 'sdk-802')).toEqual({ ok: false, reason: 'not-found' });
+  });
+
+  test('switchToSession no-ops when the target is already the live active session', async () => {
+    await manager.getSession(804);
+    manager.recordTelegramTurn(804, 'hi', 'yo', { sessionId: 'sdk-live-default' });
+    const res = await manager.switchToSession(804, 'sdk-live-default');
+    expect(res).toEqual({ ok: false, reason: 'already-active' });
+  });
+
+  test('newSession preserves the previous conversation as resumable and starts fresh', async () => {
+    manager.recordTelegramTurn(805, 'old convo', 'a', { sessionId: 'sdk-old' });
+    await manager.newSession(805);
+    manager.recordTelegramTurn(805, 'new convo', 'b', { sessionId: 'sdk-fresh' });
+
+    expect(manager.listChatSessions(805).map((s) => s.sessionId).sort()).toEqual(['sdk-fresh', 'sdk-old']);
+  });
+});

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -13,6 +13,7 @@ import { injectHotMemory } from '../agent/memory/index.js';
 // only telegram→cli edge and there is no import cycle (they never import telegram).
 import { createSessionStats, recordTurn } from '../cli/slash/session-stats.js';
 import { saveSession, loadSession, listSessions } from '../cli/session-store.js';
+import { resumeConfigFor } from '../cli/resume-session.js';
 import type { SessionStats } from '../cli/slash/types.js';
 import { promises as fs } from 'fs';
 import { join } from 'path';
@@ -218,10 +219,22 @@ export class SessionManager {
 
       // /switch: continue a staged prior conversation instead of starting fresh.
       // Consumed once here — a later /clear (via _resetStats) drops any stale target.
+      // Load the target sidecar and populate the SAME resume fields the CLI does
+      // (resume + sessionId + resumeHistory) so the providers actually replay the
+      // saved transcript. Forwarding only config.resume (the SDK id) resumes an
+      // empty conversation. Mirrors resumeConfigFor (src/cli/resume-session.ts).
       const resumeTarget = this.pendingResume.get(chatId);
       if (resumeTarget !== undefined) {
-        config.resume = resumeTarget;
         this.pendingResume.delete(chatId);
+        const stored = loadSession(resumeTarget);
+        Object.assign(
+          config,
+          resumeConfigFor({
+            id: resumeTarget,
+            resumeId: stored?.sessionId ?? resumeTarget,
+            stored,
+          }),
+        );
       }
 
       const session = await this.options.createSession(injectHotMemory(config));
@@ -626,7 +639,7 @@ export class SessionManager {
   async switchToSession(
     chatId: number,
     targetSessionId: string,
-  ): Promise<{ ok: true } | { ok: false; reason: 'not-found' | 'already-active' }> {
+  ): Promise<{ ok: true; name?: string } | { ok: false; reason: 'not-found' | 'already-active' }> {
     // Already the live active conversation → no-op (avoid a needless rebuild).
     if (this.sessions.has(chatId) && this.sessionData.get(chatId)?.sessionId === targetSessionId) {
       return { ok: false, reason: 'already-active' };
@@ -640,7 +653,10 @@ export class SessionManager {
     // Close the current live session (sidecar already persisted per-turn).
     const old = this.sessions.get(chatId);
     if (old) {
-      await old.close();
+      // Guard the close (mirrors closeAll): a throwing close() must never block
+      // the delete + target-state adoption below, or the stale session stays keyed
+      // in this.sessions and the next getSession returns it unrebuilt.
+      await old.close().catch((err) => console.error('Error closing session on switch:', err));
       this.sessions.delete(chatId);
     }
     // Drop in-memory stats so the resumed session hydrates the TARGET's stats
@@ -664,9 +680,13 @@ export class SessionManager {
       data.lastActivity = new Date().toISOString();
     }
     data.sessionId = targetSessionId;
+    // Adopt the target's cwd, or CLEAR a stale per-chat override when the target
+    // has none — otherwise the resumed session runs + autosaves under the
+    // previously-active conversation's directory (getSession uses data.cwd ?? botCwd).
     if (stored.cwd !== undefined) data.cwd = stored.cwd;
+    else delete data.cwd;
     this.pendingResume.set(chatId, targetSessionId);
-    return { ok: true };
+    return stored.name !== undefined ? { ok: true, name: stored.name } : { ok: true };
   }
 
   /**

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -218,14 +218,15 @@ export class SessionManager {
       }
 
       // /switch: continue a staged prior conversation instead of starting fresh.
-      // Consumed once here — a later /clear (via _resetStats) drops any stale target.
+      // Consumed after a successful build below — a failed createSession leaves it
+      // staged so the next getSession retries the resume; teardown via _resetStats
+      // (/clear, model switch, /cd) still clears any stale target.
       // Load the target sidecar and populate the SAME resume fields the CLI does
       // (resume + sessionId + resumeHistory) so the providers actually replay the
       // saved transcript. Forwarding only config.resume (the SDK id) resumes an
       // empty conversation. Mirrors resumeConfigFor (src/cli/resume-session.ts).
       const resumeTarget = this.pendingResume.get(chatId);
       if (resumeTarget !== undefined) {
-        this.pendingResume.delete(chatId);
         const stored = loadSession(resumeTarget);
         Object.assign(
           config,
@@ -240,6 +241,10 @@ export class SessionManager {
       const session = await this.options.createSession(injectHotMemory(config));
       this.sessions.set(chatId, session);
       this.sessionData.set(chatId, data);
+      // Consume the staged resume only after a successful build: a thrown
+      // createSession must leave it staged so the next getSession retries the
+      // resume instead of silently starting a fresh conversation.
+      if (resumeTarget !== undefined) this.pendingResume.delete(chatId);
       return session;
     })();
 
@@ -640,6 +645,17 @@ export class SessionManager {
     chatId: number,
     targetSessionId: string,
   ): Promise<{ ok: true; name?: string } | { ok: false; reason: 'not-found' | 'already-active' }> {
+    // If a session creation is in flight for this chat, let it settle before we
+    // inspect and close the live session. Otherwise the in-flight promise sets
+    // the pre-switch session as live AFTER we adopt the target below, silently
+    // reverting the switch. Awaiting materializes it so the close path evicts it
+    // normally; a failed creation leaves this.sessions empty, which the `old`
+    // guard already handles.
+    const inflight = this.pendingSessions.get(chatId);
+    if (inflight !== undefined) {
+      await inflight.catch(() => undefined);
+    }
+
     // Already the live active conversation → no-op (avoid a needless rebuild).
     if (this.sessions.has(chatId) && this.sessionData.get(chatId)?.sessionId === targetSessionId) {
       return { ok: false, reason: 'already-active' };

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -12,7 +12,7 @@ import { injectHotMemory } from '../agent/memory/index.js';
 // future cleanup could relocate them to a neutral module — for now this is the
 // only telegram→cli edge and there is no import cycle (they never import telegram).
 import { createSessionStats, recordTurn } from '../cli/slash/session-stats.js';
-import { saveSession, loadSession } from '../cli/session-store.js';
+import { saveSession, loadSession, listSessions } from '../cli/session-store.js';
 import type { SessionStats } from '../cli/slash/types.js';
 import { promises as fs } from 'fs';
 import { join } from 'path';
@@ -39,6 +39,24 @@ interface SessionData {
    * Persisted to disk so the cwd survives bot restart.
    */
   cwd?: string;
+}
+
+/**
+ * One resumable conversation for a chat, surfaced by the `/sessions` switcher.
+ * Derived from the shared sidecar store (telegram sidecars for this chatId).
+ */
+export interface ChatSessionInfo {
+  /** SDK session id — the resume target passed to `/switch`. */
+  sessionId: string;
+  /** Human-readable name (auto or via `/name`), when set. */
+  name?: string;
+  model: AgentModelInput;
+  /** Recorded turns in the conversation. */
+  turns: number;
+  /** Sidecar `savedAt` (ms) — most-recent activity; list is sorted by this desc. */
+  lastActive: number;
+  /** True when this is the chat's currently-active conversation. */
+  active: boolean;
 }
 
 /**
@@ -105,6 +123,14 @@ export class SessionManager {
    * conversation gets a fresh warning.
    */
   private autosaveFailureLogged = new Set<number>();
+  /**
+   * Chats with a staged `/switch` resume target (SDK session id). Consumed once
+   * by the next getSession() to build the rebuilt session with `config.resume`
+   * so it continues the chosen prior conversation. Cleared on any teardown
+   * (/clear, model switch, /cd) via _resetStats so those start fresh, never
+   * resuming a stale target.
+   */
+  private pendingResume = new Map<number, string>();
   private options: Required<Omit<SessionManagerOptions, 'createSession' | 'settingSources' | 'thinking' | 'effort' | 'botCwd'>> &
     Pick<SessionManagerOptions, 'createSession' | 'settingSources' | 'thinking' | 'effort' | 'botCwd'>;
 
@@ -188,6 +214,14 @@ export class SessionManager {
       const effectiveCwd = data.cwd ?? this.options.botCwd;
       if (effectiveCwd !== undefined && effectiveCwd.length > 0) {
         config.cwd = effectiveCwd;
+      }
+
+      // /switch: continue a staged prior conversation instead of starting fresh.
+      // Consumed once here — a later /clear (via _resetStats) drops any stale target.
+      const resumeTarget = this.pendingResume.get(chatId);
+      if (resumeTarget !== undefined) {
+        config.resume = resumeTarget;
+        this.pendingResume.delete(chatId);
       }
 
       const session = await this.options.createSession(injectHotMemory(config));
@@ -420,6 +454,8 @@ export class SessionManager {
     this.sessionStats.delete(chatId);
     // Fresh conversation → allow the autosave-failure notice to fire again.
     this.autosaveFailureLogged.delete(chatId);
+    // Drop any staged /switch resume so a teardown always starts fresh.
+    this.pendingResume.delete(chatId);
     const data = this.sessionData.get(chatId);
     if (data) delete data.sessionId;
   }
@@ -544,6 +580,107 @@ export class SessionManager {
   getCwd(chatId: number): string | undefined {
     const data = this.sessionData.get(chatId);
     return data?.cwd ?? this.options.botCwd;
+  }
+
+  /**
+   * List this chat's resumable conversations for the `/sessions` switcher,
+   * newest-active first. Sourced from the shared sidecar store (telegram
+   * sidecars for this chatId) — the durable record of every conversation the
+   * chat has held — with the currently-active one flagged.
+   *
+   * A brand-new conversation with no recorded turn yet has no sidecar and so
+   * does not appear until its first turn is saved.
+   */
+  listChatSessions(chatId: number): ChatSessionInfo[] {
+    const activeId = this.sessionData.get(chatId)?.sessionId;
+    return listSessions()
+      .filter(
+        (s) => s.source === 'telegram' && s.telegramChatId === chatId && s.sessionId !== undefined,
+      )
+      .map((s) => {
+        const info: ChatSessionInfo = {
+          sessionId: s.sessionId as string,
+          model: s.model,
+          turns: s.totalTurns,
+          lastActive: s.savedAt,
+          active: s.sessionId === activeId,
+        };
+        if (s.name !== undefined) info.name = s.name;
+        return info;
+      })
+      .sort((a, b) => b.lastActive - a.lastActive);
+  }
+
+  /**
+   * Switch the chat's active conversation to a previously-persisted session
+   * (the `/switch` command). Closes the current live session — its sidecar is
+   * already persisted per-turn, so it stays resumable — drops in-memory stats so
+   * the target's name/turns re-hydrate from its sidecar, adopts the target's
+   * model + cwd, and stages the SDK session id for resume. The next
+   * getSession(chatId) rebuilds the session with `config.resume` so it continues
+   * the chosen conversation; callers wanting it warmed can await getSession after.
+   *
+   * @returns `{ ok: true }` on success; `{ ok: false, reason }` when the target
+   *   is missing / not a telegram sidecar for this chat, or already active.
+   */
+  async switchToSession(
+    chatId: number,
+    targetSessionId: string,
+  ): Promise<{ ok: true } | { ok: false; reason: 'not-found' | 'already-active' }> {
+    // Already the live active conversation → no-op (avoid a needless rebuild).
+    if (this.sessions.has(chatId) && this.sessionData.get(chatId)?.sessionId === targetSessionId) {
+      return { ok: false, reason: 'already-active' };
+    }
+
+    const stored = loadSession(targetSessionId);
+    if (!stored || stored.source !== 'telegram' || stored.telegramChatId !== chatId) {
+      return { ok: false, reason: 'not-found' };
+    }
+
+    // Close the current live session (sidecar already persisted per-turn).
+    const old = this.sessions.get(chatId);
+    if (old) {
+      await old.close();
+      this.sessions.delete(chatId);
+    }
+    // Drop in-memory stats so the resumed session hydrates the TARGET's stats
+    // (name/turns/sessionId) from its sidecar on next access — never the
+    // previous conversation's. autosave-failure notice re-arms for the switch.
+    this.sessionStats.delete(chatId);
+    this.autosaveFailureLogged.delete(chatId);
+
+    // Adopt the target's identity + model/cwd and stage the resume.
+    let data = this.sessionData.get(chatId);
+    if (!data) {
+      data = {
+        chatId,
+        model: stored.model,
+        createdAt: new Date().toISOString(),
+        lastActivity: new Date().toISOString(),
+      };
+      this.sessionData.set(chatId, data);
+    } else {
+      data.model = stored.model;
+      data.lastActivity = new Date().toISOString();
+    }
+    data.sessionId = targetSessionId;
+    if (stored.cwd !== undefined) data.cwd = stored.cwd;
+    this.pendingResume.set(chatId, targetSessionId);
+    return { ok: true };
+  }
+
+  /**
+   * Start a fresh conversation for the chat (the `/new` command), preserving the
+   * previous one as a resumable session — its sidecar was persisted per-turn and
+   * is never deleted here, so `/sessions` still lists it and `/switch` can return
+   * to it. Behaviorally this is resetSession (close + fresh sessionId), exposed
+   * under a name that reflects the switcher intent.
+   */
+  async newSession(chatId: number): Promise<void> {
+    // resetSession → _resetStats already clears pendingResume; explicit here too
+    // so intent is local and obvious.
+    this.pendingResume.delete(chatId);
+    await this.resetSession(chatId);
   }
 
   /**


### PR DESCRIPTION
## Summary

Foundational multi-session support for the Telegram surface, delivered in two coherent layers:

1. **Session-registry foundation** (steps 1–3) — a surface-agnostic session-identity layer + a Telegram routing primitive, additive and fully unit-tested.
2. **Free session switcher** (steps 4–5) — user-facing `/sessions` (tap to switch) and `/new`, so one Telegram chat can hold many independent conversations and jump between them.

One active session per chat at a time; every past conversation persists as a resumable sidecar. No breaking changes — existing single-session behavior is byte-identical.

Design doc: `.afk/plans/session-registry-architecture.md`.

## What ships

| Commit | What |
|---|---|
| `eff1706` | **Registry core** (`session-registry.ts`) — `SessionHandle` model, opaque surface→handle bindings, `resolve`/`create`/`bind`/`archive`. `handle.id` is registry-minted + stable; `sdkSessionId` is a **late-bound** attribute (undefined until the provider stream emits it), never a routing key. Branded `HandleId` makes a raw-`chatId` mis-key a type error. |
| `a40a11f` | **Persistence bridge** — `StoredSession.{handleId,bindings}` (optional, back-compat) + pure `storedToHandle`/`bindingsForStored`/`storedFieldsFromHandle` mappings, incl. the legacy `telegramChatId → telegram binding` migration; `registry.load()` for rehydration. |
| `35ff346` | **Route primitive** (`route.ts`) — `routeFromCtx`/`routeKey`/`sendOptions`. Reads a topic `message_thread_id` off `message`, `edited_message`, **and** `callback_query.message` (a button tapped in a topic carries its thread id on the callback, not `ctx.message`). General normalizes to the bare-chatId key, so topics-off users are unchanged. |
| `dde025d` | **SessionManager capability** — `switchToSession` (close live session, stage resume, adopt target model/cwd), `listChatSessions` (a chat's resumable sidecars, active flagged), `newSession`. `pendingResume` is consumed once by `getSession` and cleared on every teardown. `telegram.ts` threads `resume` into both session-construction branches. |
| `af5ee93` | **Switcher UX** — `/sessions` (inline tap-to-switch buttons, callback `afk:sw:<sessionId>`), `/new`. Both refuse while the active session is mid-turn; switching stages a **lazy** resume that continues on the next message (the callback never blocks on a resume replay). |
| `b7bd2d3` | `/help` + command-menu discoverability. |

## Key design decisions

- **Late-bound `sdkSessionId`.** The registry mints its own stable `HandleId` synchronously at `create()`; the SDK session id is attached later. This sidesteps the "id is undefined at construction" footgun and keeps live-session maps keyed on a stable value.
- **Switcher rides the sidecar store + `resume`, not a live-map re-key.** Because only one session is active per chat, `SessionManager`'s existing `chatId`-keyed maps are untouched (low blast radius). A chat's session list comes from the shared sidecar store (already keyed by `telegramChatId`); switching is close-active + `config.resume=<target>` — the same mechanism the CLI `--resume` uses.
- **The registry is not yet in the switcher hot path.** Its binding model (one active binding per key) is the right primitive for *routing* (native topics, cross-surface), which is where it becomes load-bearing — see Deferred. It ships now as the tested foundation the architecture was committed to.

## Intentionally deferred (follow-up PRs)

- **Step 6 — native Telegram "topics in private chats".** Concurrent sessions in one chat (one per topic) via `routeFromCtx`. This is the only path that needs re-keying `message.ts`'s `pendingElicitations`/`messageQueues` by session identity (the latent cross-session-leak fix). Gated on a product decision: topics appear to be a paid (Telegram Stars) feature. The `route.ts` primitive here is that step's ingress.
- **Step 7 — cross-surface bindings** (CLI/daemon route through the same registry).

## Testing

- **+40 unit tests** across registry (`load`, bridge mappings), route primitive (incl. the callback-thread leak-fix case), `SessionManager` switch/list/resume, and the `/sessions`+`/new`+switch-callback handlers.
- Full suite green: **11,645 passed / 14 skipped (638 files)**.
- `tsc --noEmit`, `audit:env:check`, `audit:sdk:check`, `scan:env:check` all clean.

## Back-compat / risk

- All changes additive; existing Telegram flows unchanged and fully covered by the pre-existing suite (which passes unmodified).
- `/switch` and `/new` refuse mid-turn, so no streaming reply is orphaned.
- Resume is provider-dependent (same contract as CLI `--resume`); the wiring is verified, context-restoration is the provider's job.
