### PR TITLE
Update README for daemon persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,11 @@ afk chat "hello"
 - **Background subagent jobs** — dispatch a subagent with `mode:'background'`; results auto-deliver into the model's context when they finish. `/bgsub` lists running and completed jobs, `/bgsub:join <id>` replays a result manually.
 
 ## Four surfaces, one session manager
-
 | Command | Surface |
 |---|---|
 | `afk chat "..."` | One-shot (fire & forget) turn — pipe-friendly, scripts well |
 | `afk` (alias of `afk interactive`) | REPL with slash commands, streaming, plan mode, image paste |
-| `afk daemon` | Long-running headless agent, cron-friendly |
+| `afk daemon` | Long-running headless agent, cron-friendly. For persistence across reboot and crash, use `/service-setup` (launchd on macOS, systemd `--user` on Linux) instead of running in a bare tmux pane. |
 | `afk telegram start` | Telegram bot — same tools, same memory, on your phone |
 
 ## Configuration


### PR DESCRIPTION
## What was broken
The README did not provide clear instructions for keeping a long-running afk daemon or Telegram bot alive across reboot and crash.
## What changed
Added a note to the README explaining the importance of using /service-setup for daemon persistence.
## How to test
Verify that the README now includes instructions for using /service-setup and that the instructions are clear and accurate.

---
_Opened by autonomous agent. Human review required before merge._