### PR TITLE
fix(trace): thread surface into skill-fork managers so forked skills get correct trace origin (#469)

### DIFF
--- a/src/agent/tools/skill-executor.test.ts
+++ b/src/agent/tools/skill-executor.test.ts
@@ -1059,6 +1059,83 @@ describe('SkillExecutor', () => {
     });
   });
 
+  describe('trace origin surface threading (#469)', () => {
+    // Regression (follow-up to #468): skill-forked subagents recorded
+    // origin:'unknown' in the witness trace because the owning surface was
+    // never threaded into the per-call fork manager (fork-dispatch.ts). The
+    // manager must inherit `surface` like traceWriter/cwd so forkSubagent's
+    // parentSurface fill (subagent.ts) stamps the skill subagent's
+    // config.surface → deriveOrigin returns the real cli/telegram/daemon
+    // instead of 'unknown'. Mirrors child-config.test.ts's #468 surface tests.
+    function setupSurfaceCapture(): () => SubagentManager | undefined {
+      registerSkill({
+        name: 'fork-skill-surface',
+        description: 'test',
+        context: 'fork',
+        handler: vi.fn(),
+      });
+      vi.spyOn(promptLoader, 'loadSkillPrompts').mockReturnValue({
+        'system.md': 'fake-system-prompt',
+      });
+      let capturedManager: SubagentManager | undefined;
+      vi.spyOn(SubagentManager.prototype, 'forkSubagent').mockImplementation(
+        function (this: SubagentManager) {
+          capturedManager = this;
+          return Promise.resolve({
+            id: 'h',
+            runToResult: vi.fn().mockResolvedValue({
+              status: 'succeeded',
+              message: { content: 'ok' },
+            }),
+            teardown: vi.fn().mockResolvedValue(undefined),
+          }) as any;
+        } as any,
+      );
+      vi.spyOn(SubagentManager.prototype, 'teardownAll').mockResolvedValue(undefined);
+      return () => capturedManager;
+    }
+
+    it('forwards the owning surface to the per-call fork manager', async () => {
+      const getManager = setupSurfaceCapture();
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'parent-123',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        defaultModel: 'sonnet',
+        surface: 'cli',
+      });
+
+      const result = await executor.execute(makeCall({ name: 'fork-skill-surface' }));
+
+      expect(result.isError).toBeUndefined();
+      // parentSurface === 'cli' is what lets forkSubagent fill the skill
+      // subagent's config.surface, so deriveOrigin('cli') → 'cli' in the trace
+      // rather than deriveOrigin(undefined) → 'unknown' (the #469 bug).
+      expect((getManager() as unknown as { parentSurface: string | undefined }).parentSurface)
+        .toBe('cli');
+    });
+
+    it('omits surface from the fork manager when the host surface is unset', async () => {
+      const getManager = setupSurfaceCapture();
+      const executor = new SkillExecutor({
+        parentSession: {
+          sessionId: 'parent-123',
+          getInputStreamRef: () => ({ pushUserMessage: () => {} }),
+          abortSignal,
+        },
+        defaultModel: 'sonnet',
+      });
+
+      const result = await executor.execute(makeCall({ name: 'fork-skill-surface' }));
+
+      expect(result.isError).toBeUndefined();
+      expect((getManager() as unknown as { parentSurface: unknown }).parentSurface)
+        .toBeUndefined();
+    });
+  });
+
   describe('getPluginSkillBody — cwd cache invalidation (regression)', () => {
     // Regression: PR #418 threaded cwd into the FIRST population of the
     // lazy `pluginBodies` cache but did not invalidate it on setCwd(), so a

--- a/src/agent/tools/skill-executor/fork-child-config.ts
+++ b/src/agent/tools/skill-executor/fork-child-config.ts
@@ -127,6 +127,11 @@ export function buildForkedChildConfig(
   const childManager = new SubagentManager({
     parentAbortSignal: signal,
     ...(ctx.traceWriter !== undefined ? { traceWriter: ctx.traceWriter } : {}),
+    // Trace origin (#469): inherit the owning surface like traceWriter/cwd so
+    // grandchild forks made directly off this manager report the real origin.
+    // The recursive SubagentExecutor ctx below already carries surface (:157);
+    // this keeps the manager itself consistent, mirroring subagent/child-config.ts.
+    ...(ctx.surface !== undefined ? { surface: ctx.surface } : {}),
     // Worktree isolation: forward cwd so when the skill-forked child
     // dispatches its own `agent` calls (grandchild forks), the manager's
     // forkSubagent injects cwd into the grandchild's config. Mirrors

--- a/src/agent/tools/skill-executor/fork-dispatch.ts
+++ b/src/agent/tools/skill-executor/fork-dispatch.ts
@@ -95,6 +95,12 @@ export async function executeForkedRegistrySkill(
     parentModel: skillChildModel,
     ...(ctx.baseUrl !== undefined ? { baseUrl: ctx.baseUrl } : {}),
     ...(ctx.traceWriter !== undefined ? { traceWriter: ctx.traceWriter } : {}),
+    // Trace origin (#469): thread the owning surface so this manager's
+    // forkSubagent fills the skill subagent's config.surface (subagent.ts
+    // parentSurface fill). Without it the fork's session_init records
+    // origin:'unknown' instead of cli/telegram/daemon — the same class #468
+    // fixed for agent-tool/compose forks and deliberately left as a follow-up.
+    ...(ctx.surface !== undefined ? { surface: ctx.surface } : {}),
     progressSink: getCurrentSink(),
     // Worktree isolation: this manager forks the skill subagent. cwd
     // forwarding here is what gives the skill subagent's bash/grep/file
@@ -192,6 +198,8 @@ export async function executePluginSkill(
     parentModel: pluginChildModel,
     ...(ctx.baseUrl !== undefined ? { baseUrl: ctx.baseUrl } : {}),
     ...(ctx.traceWriter !== undefined ? { traceWriter: ctx.traceWriter } : {}),
+    // Trace origin (#469) — same rationale as executeForkedRegistrySkill above.
+    ...(ctx.surface !== undefined ? { surface: ctx.surface } : {}),
     progressSink: getCurrentSink(),
     // Worktree isolation — same rationale as executeForkedRegistrySkill above.
     ...(currentCwd !== undefined ? { cwd: currentCwd } : {}),


### PR DESCRIPTION
Closes #469.

## Problem
Skill-forked subagents recorded `origin: "unknown"` in the witness trace instead of the owning surface (`cli`/`telegram`/`daemon`) — the same class of bug #468 fixed for `agent`-tool and `compose` forks, and deliberately left as a follow-up there.

## Root cause
The per-call `SubagentManager` that forks each skill subagent never received `surface`, so `SubagentManager.parentSurface` was `undefined` and `forkSubagent`s origin fill no-oped → `deriveOrigin(undefined)` → `unknown`:
- `skill-executor/fork-dispatch.ts` — `executeForkedRegistrySkill` (registry fork manager)
- `skill-executor/fork-dispatch.ts` — `executePluginSkill` (plugin fork manager)
- `skill-executor/fork-child-config.ts` — `buildForkedChildConfig` grandchild manager (its recursive executor ctx already carried `surface`, but the manager itself did not)

## Fix
Thread `...(ctx.surface !== undefined ? { surface: ctx.surface } : {})` into all three constructions, mirroring how `traceWriter`/`cwd` are already inherited and how #468 fixed the analogous `agent`-tool paths (`subagent/child-config.ts`).

## Tests
Two regression tests analogous to the #468 `child-config.test.ts` surface tests: capture the per-call fork manager via a `forkSubagent` spy and assert `parentSurface === "cli"` when the host surface is set, `undefined` when unset. Negative control confirmed the test fails (`parentSurface` → `undefined`) without the fix.

## Verify
- `pnpm lint` (strict `tsc --noEmit`): clean
- Full suite: 11634 passed / 0 failed
- `afk trace show` on a session that dispatches a skill now shows the skill subagent`s `session_init` with the real origin, not `unknown`.