### PR TITLE
fix(mint): resolve parallelize-dispatch subagent credential per child model (#444)

### DIFF
--- a/src/skills/mint-parallelize-dispatch.test.ts
+++ b/src/skills/mint-parallelize-dispatch.test.ts
@@ -16,6 +16,10 @@
  *   5. succeeded but no message    → failed
  *   6. dispatch throws            → failed
  *   7. caller in index.ts distinguishes skipped vs failed via history entries
+ *   8. #444 — the fork's credential is resolved per-model
+ *      (resolveCredentialForModel), not off the ambient top-level model,
+ *      and the manager constructor receives neither `apiKey` nor
+ *      `parentModel` — matching the 7 sibling phases #431 converted.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -36,9 +40,15 @@ let forkBehavior: () => Promise<{
 });
 let forkShouldThrow = false;
 
+// Captures the `forkSubagent` call arg so tests can inspect `config.apiKey`
+// alongside the `SubagentManager` constructor arg (read via
+// `vi.mocked(SubagentManager).mock.calls[0][0]`) — see #444.
+let lastForkSubagentArg: Record<string, unknown> | undefined;
+
 vi.mock('../agent/subagent.js', () => ({
   SubagentManager: vi.fn(() => ({
-    forkSubagent: vi.fn(async () => {
+    forkSubagent: vi.fn(async (arg: Record<string, unknown>) => {
+      lastForkSubagentArg = arg;
       if (forkShouldThrow) throw new Error('synthetic fork failure');
       return {
         id: 'mint-parallelize',
@@ -57,9 +67,17 @@ vi.mock('../agent/tools/skill-bridge.js', () => ({
   discoverPluginSkillBodies: () => pluginBodies,
 }));
 
-vi.mock('../cli/shared-helpers.js', () => ({
-  getApiKey: () => 'test-api-key',
-  getModel: () => 'sonnet',
+// #444: parallelize-dispatch resolves the fork's credential off the CHILD's
+// own model via resolveCredentialForModel, not the ambient top-level model
+// (getApiKey()/getModel() from shared-helpers.js — no longer imported).
+// Sentinel derived from the arg so tests can assert per-model selection.
+// vi.hoisted is required because vi.mock factories are hoisted above
+// top-level locals (same pattern as subagent-executor.test.ts).
+const resolveCredentialForModel = vi.hoisted(() =>
+  vi.fn((m: string | undefined) => `resolved-key::${m}`),
+);
+vi.mock('../agent/auth/credential-resolver.js', () => ({
+  resolveCredentialForModel,
 }));
 
 // Mutable registry hit for getSkill('parallelize').
@@ -82,6 +100,7 @@ import {
   runParallelizeDispatch,
   type ParallelizeDispatchResult,
 } from './mint/_phases/parallelize-dispatch.js';
+import { SubagentManager } from '../agent/subagent.js';
 
 function mockSession(): IAgentSession {
   return {
@@ -110,6 +129,7 @@ describe('runParallelizeDispatch — discriminated union', () => {
       ['parallelize', { body: 'PARALLELIZE_BODY_STUB', pluginPath: '/fake/plugin' }],
     ]);
     registryParallelize = null;
+    lastForkSubagentArg = undefined;
   });
 
   afterEach(() => {
@@ -238,6 +258,38 @@ describe('runParallelizeDispatch — discriminated union', () => {
     const THREE_FILES_PROSE = 'Touch src/a.ts, src/b.ts, and src/c.ts please.';
     const result = await runParallelizeDispatch(THREE_FILES_PROSE, mockSession());
     expect(result.kind).toBe('plan');
+  });
+
+  // #444 invariant: parallelize-dispatch resolves the fork's credential off
+  // the CHILD's own model (resolveCredentialForModel), not the ambient
+  // top-level model — matching the 7 sibling mint phases #431 converted.
+  // Uses 'haiku' (distinct from the 'sonnet' default) so the assertion is
+  // meaningful — it proves the CHILD model drives resolution, not a default.
+  it('resolves the forked subagent credential from the child model, not the manager (#444)', async () => {
+    const result = await runParallelizeDispatch(
+      MANY_FILES_PLAN,
+      mockSession(),
+      undefined,
+      'haiku',
+    );
+    expect(result.kind).toBe('plan');
+
+    // (1) resolveCredentialForModel was called with the CHILD's model.
+    expect(resolveCredentialForModel).toHaveBeenCalledWith('haiku');
+
+    // (2) the forkSubagent config carries the resolved sentinel credential.
+    expect(lastForkSubagentArg).toBeDefined();
+    const config = lastForkSubagentArg?.['config'] as { apiKey?: string } | undefined;
+    expect(config?.apiKey).toBe('resolved-key::haiku');
+
+    // (3) the SubagentManager constructor arg has NEITHER `apiKey` NOR
+    // `parentModel` — the credential lives on the fork, not the manager.
+    const managerCtorArg = vi.mocked(SubagentManager).mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(managerCtorArg).toBeDefined();
+    expect(managerCtorArg).not.toHaveProperty('apiKey');
+    expect(managerCtorArg).not.toHaveProperty('parentModel');
   });
 
   it('caller can distinguish skipped from failed at the type level', () => {

--- a/src/skills/mint/_phases/parallelize-dispatch.ts
+++ b/src/skills/mint/_phases/parallelize-dispatch.ts
@@ -17,7 +17,7 @@
 import { getSkill } from '../../index.js';
 import { discoverPluginSkillBodies } from '../../../agent/tools/skill-bridge.js';
 import { SubagentManager } from '../../../agent/subagent.js';
-import { getApiKey, getModel } from '../../../cli/shared-helpers.js';
+import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import type { AgentModelInput, IAgentSession } from '../../../agent/types.js';
 
 export type ParallelizeDispatchResult =
@@ -105,11 +105,6 @@ export async function runParallelizeDispatch(
     // surprise if it ever shells out to inspect the working tree.
     const manager = new SubagentManager({
       parentAbortSignal: parentSession.abortSignal,
-      apiKey: getApiKey(),
-      // `getApiKey()` keys off `getModel()` (AFK_MODEL), so the parent key's
-      // provider is `providerForModel(getModel())` — the source of truth for
-      // the fork-time credential fallback (see SubagentManager.parentProvider).
-      parentModel: getModel(),
       ...(parentSession.cwd !== undefined ? { cwd: parentSession.cwd } : {}),
       ...(parentReadRoots !== undefined ? { parentReadRoots } : {}),
     });
@@ -131,6 +126,12 @@ export async function runParallelizeDispatch(
           model: defaultSubagentModel,
           systemPrompt: skill.body,
           env: { PLUGIN_ROOT: skill.pluginPath },
+          // Resolve the child's credential off ITS OWN model, not the ambient
+          // top-level model — matches the other 7 mint phase forks (#431/#378).
+          // Fixes #444: this was the last site still keying off getApiKey()/
+          // AFK_MODEL, which left the fork credential-less under a cross-provider
+          // operator and silently degraded parallelize to single-lane.
+          apiKey: resolveCredentialForModel(defaultSubagentModel),
         },
         idPrefix: 'mint-parallelize',
         agentType: 'mint-parallelize',


### PR DESCRIPTION
## What / why

`src/skills/mint/_phases/parallelize-dispatch.ts` was the **last** mint fork site still resolving its subagent credential off the ambient top-level model (`getApiKey()`/`getModel()` from `AFK_MODEL`, via a manager-level `parentModel`/`apiKey` fallback on `SubagentManager`) instead of resolving the **child's own model** credential.

PR #431 (fixing #378) converted the other 7 mint phase forks — `build`, `research`, `plan`, `verify`, `ship`, `heal`, `spec` — to `config.apiKey: resolveCredentialForModel(defaultSubagentModel)`. This PR brings `parallelize-dispatch` onto that same pattern, closing the gap identified in #444.

**Not a live leak.** `SubagentManager`'s provider-identity gate already prevented a wrong-provider credential from being shipped here, so under a cross-provider operator the parallelize fork just ended up **credential-less** and silently degraded to single-lane execution. This is a consistency/completeness fix, not a security fix.

## Sibling-pattern consistency

Verified by direct inspection of all 7 converted phases: none of them pass a manager-level `apiKey` or `parentModel` to `new SubagentManager({...})` — the credential is resolved per-model and attached only to the `forkSubagent(...)` `config`. This PR makes `parallelize-dispatch.ts` match that shape exactly (see `build.ts` lines ~7-9, 54-64 for the canonical reference).

## Deviation from the issue's suggested fix

The issue text's suggested-fix bullet says *"Remove the now-unused `getApiKey` import (`getModel` stays — still needed for `parentModel`)."* This is **incorrect** relative to the established sibling pattern: none of the 7 already-converted phases pass `parentModel` (or a manager-level `apiKey`) at all — `parentModel` here only ever existed to drive the very credential fallback being removed. This PR drops **both** `parentModel` and the `getModel` import (both become fully unused), matching siblings exactly rather than partially.

## Changes

- `src/skills/mint/_phases/parallelize-dispatch.ts`:
  - Replace the `getApiKey, getModel` import from `cli/shared-helpers.js` with `resolveCredentialForModel` from `agent/auth/credential-resolver.js`.
  - Remove the manager-level `apiKey: getApiKey()` and `parentModel: getModel()` fields (and their explanatory comment) from `new SubagentManager({...})`.
  - Add `apiKey: resolveCredentialForModel(defaultSubagentModel)` to the `forkSubagent(...)` `config` object, with a comment referencing #444/#431.
- `src/skills/mint-parallelize-dispatch.test.ts`:
  - Remove the now-dead `vi.mock('../cli/shared-helpers.js', ...)`.
  - Add a `resolveCredentialForModel` spy mock returning a distinctive sentinel (`resolved-key::<model>`).
  - Capture the `forkSubagent` call arg alongside the existing `SubagentManager` constructor arg.
  - Add one focused test asserting: (1) `resolveCredentialForModel` is called with the child model (`'haiku'`, distinct from the `'sonnet'` default), (2) the fork's `config.apiKey` is the resolved sentinel, and (3) the `SubagentManager` constructor arg has **neither** `apiKey` **nor** `parentModel`.

## Verification

- `pnpm lint` (`tsc --noEmit`, strict — `noUnusedLocals`/`noUnusedParameters`): **clean**, no errors.
- `pnpm test -- src/skills/mint-parallelize-dispatch.test.ts`: **13/13 passed** (12 pre-existing + 1 new).
- `pnpm test -- src/skills/mint-failed-parallelize.test.ts`: **2/2 passed** (regression guard, unaffected).
- Full suite (`pnpm test`): **637 files, 11633 passed, 14 skipped** (pre-existing skips, unrelated to this change).
- `git status --porcelain` confirms only the two files above are modified; no SDK import or `process.env` read added (`.sdk-dependency.lock.json` / env registry untouched).

Closes #444.
