### PR TITLE
feat(telegram): native topics (step 6) + cross-surface CLI/daemon bindings (step 7) [stacked on #562]

### DIFF
--- a/.afk/diagnoses/2026-07-01-stale-nudge-turn-hijack.md
+++ b/.afk/diagnoses/2026-07-01-stale-nudge-turn-hijack.md
@@ -1,0 +1,113 @@
+# Diagnosis: shadow-verify nudge hijacked `/resolve` turns (session 61db02da, 2026-07-01)
+
+## Symptom
+
+REPL session `61db02da-0410-4eb7-8743-dd14a2ce4186` (afk **5.15.3** global install, model opus_1m, repo cwd):
+after `/review 353` completed (23:18→00:25Z, verdict DO NOT MERGE), the user typed `/resolve` three times:
+
+| ts (UTC) | user typed | model actually processed | reply |
+|---|---|---|---|
+| 01:50:32 | `/resolve` #1 | **queued nudge #1** | "Shadow-verify already ran … the nudge is firing on the shadow-verifiers' own output" (0 tool calls) |
+| 02:32:22 | `/resolve` #2 | **queued nudge #2** | "No new sub-agent output … this nudge is repeating" (0 tool calls) |
+| 02:32:54 | `/resolve` #3 | **`/resolve` #1 text** | resolve skill finally dispatched (02:33:07Z) and ran normally |
+
+Evidence: `~/.afk/state/sessions/61db02da-…/events.jsonl` (4 user events, 3 assistant events, tool timeline),
+`~/.afk/state/transcripts/2026-07-01T23-18-17-132Z.md`, witness trace `~/.afk/state/witness/a78a89fe-c7f2-4c74-89af-9df7c7ada819/trace.jsonl`.
+
+## Root cause — off-by-N input-queue lag (deterministic, by construction)
+
+Four pieces compose the failure:
+
+1. **SubagentStop `injectContext` is delivered as a standalone user message pushed into the parent's
+   input stream.** `src/agent/subagent/handle.ts:470-482` → `parentInputStreamRef.pushUserMessage(decision.injectContext)`;
+   ref wired from the forking parent at `src/agent/subagent.ts:509,531` → `agent-session.ts:1051`.
+
+2. **The input stream is a plain FIFO where framework messages and real user messages share one lane.**
+   `src/agent/session/input-iterable.ts:24-36` — push resolves an armed consumer or appends to `bufferedMessages`;
+   the iterator (`:44-57`) drains **one message per `next()`**.
+
+3. **The anthropic-direct provider consumes exactly one queue item per turn and never reads input mid-turn.**
+   `src/agent/providers/anthropic-direct/query.ts:309-317` (`promptIterator.next()` once per `while` iteration),
+   `:351` (that one item becomes the sole new `role:'user'` message). `loop.ts` contains zero input reads.
+   The provider is an async **generator**: after emitting `done` it stays *suspended at `yield`*
+   (`query.ts:393-407`), so it is never parked awaiting input while idle.
+
+4. **`sendMessageStreamInternal` pushes the typed text first, then pulls provider events until the first `done`,
+   assuming the events answer that text.** `src/agent/session/agent-session.ts:592` (push), `:602-626` (pull-until-done),
+   with a single persistent `providerIterator` (`:303,324`).
+
+Because the generator only reaches `promptIterator.next()` *after* the next pull, and the harness always
+pushes-before-pulling, **`pendingResolve` is never armed when a nudge arrives — every SubagentStop
+injectContext in a REPL session is guaranteed to buffer and displace a future user message by one queue
+position.** This is not a race; mid-turn vs post-turn stop timing is irrelevant.
+
+### Replay
+
+- During `/review`, the main session (plugin skill loaded into context) forked 11 `agent` children
+  (6 dimension/PoC + 5 shadow-verify wave; events.jsonl ts 23:19:41→00:23:01Z).
+- Exactly **2** of them passed all four nudge gates in `src/agent/shadow-verify-nudge.ts:102-110`
+  (≥600 chars, agentType not review/shadow-verify-tokened per `:83-90`, output not verifier-shaped `:53-59`,
+  ≥2 decision markers — review findings are marker-dense). The verifier wave self-suppressed; the other
+  dimension forks were suppressed by agentType token or content. → buffer `[nudge1, nudge2]`.
+- `/resolve` #1 → buffer `[n1,n2,r1]`, provider shifts **n1** → model sees only a bare nudge → replies to it.
+- `/resolve` #2 → `[n2,r1,r2]`, shifts **n2** → "this nudge is repeating" (literally true — the model saw a
+  second consecutive bare nudge message).
+- `/resolve` #3 → `[r1,r2,r3]`, shifts **r1** → resolve skill dispatches.
+- **Latent:** buffer still holds `[r2, r3]`. The next two submissions into that session will be answered by
+  the two stale `/resolve` dispatches. The lag is permanent (each submission enqueues 1, consumes oldest 1)
+  until those drain or the session is closed.
+
+### Why it was invisible
+
+`pushUserMessage` bypasses the ledger/witness user record — `recordUser` fires only in
+`sendMessageStreamInternal` (`agent-session.ts:596-599`) for typed text. events.jsonl shows `/resolve`;
+the nudge the model actually received is nowhere in durable state. Transcripts therefore read as
+"user: /resolve → assistant: nudge-talk", i.e. as model misbehavior instead of queue lag.
+
+### Version scope
+
+Day-one design: `input-iterable.ts` / `handle.ts` push path unchanged since initial public release
+(`0a23cff`); present in installed 5.15.3 bundle (verified: `bufferedMessages`, `pendingResolve`,
+"Skipping SubagentStop injectContext", nudge string all in `/opt/homebrew/lib/node_modules/agent-afk/dist/cli.mjs`).
+#345 (injectContext concatenation, 5.15.1) and #348 are orthogonal — single handler produced these
+injections, and 2 pushes = 2 separate SubagentStop dispatches.
+
+### Secondary finding
+
+Nudge suppression worked as designed for 9/11 forks, but any raw `agent` fork with a generic `id_prefix`
+and decision-dense output nudges — inside a skill that *is itself* the verifying orchestrator. The
+orchestrator-suppression check keys off the **child's** agentType, not the dispatching context, so
+plugin skills loaded into the main context (review, shadow-verify) get no umbrella suppression for the
+forks they instruct the main session to make.
+
+## Resolution (2026-07-01)
+
+Implemented as **PR #359** (`fix/framework-context-prepend`, commit 51c46d8, CI green):
+`AgentSession.queueFrameworkContext()` + drain-and-prepend in `sendMessageStreamInternal`;
+SubagentStop delivery prefers the queue channel with `pushUserMessage` fallback. The
+secondary bug hit during diagnosis (vendored PascalCase tool allowlists denying every
+subagent call) was already fixed upstream by **#350** (v5.15.5); this machine's global
+binary was upgraded 5.15.3 → 5.15.5 and services restarted.
+
+## Fix recommendation (as designed — implemented in PR #359)
+
+Minimal, contract-clean: **stop enqueueing framework context as standalone input-stream messages.**
+
+1. Hold SubagentStop `injectContext` in cross-turn session state (e.g. `pendingHookContext: string[]` on
+   `AgentSession`); on the next real `sendMessageStream`, prepend it to the typed content the way
+   UserPromptSubmit already does (`loop-iteration.ts:433-434` prepends to `runText`). One turn, both texts,
+   no displacement, correct attribution. (The `loop-iteration.ts:573` comment already names
+   "injectContext-into-next-turn needs cross-turn state" as the known-deferred design.)
+2. Record any injected framework context via the ledger (`recordUser` or a dedicated `recordFrameworkContext`)
+   so witness/transcripts show what the model saw.
+3. Optional hardening: tag/expire queued context by turn generation so anything stale by >1 boundary is dropped;
+   consider dispatch-context-aware suppression (parent-turn skill = verified orchestrator ⇒ suppress children).
+
+Tradeoff note: true mid-turn steering (pushing a user message while a turn runs) still uses the FIFO
+legitimately; the fix should special-case *hook-generated* context, not remove `pushUserMessage`.
+
+## Operator guidance for the live session
+
+Session 61db02da (if still open): the in-flight resolve run is legitimate — let it finish. Two stale
+`/resolve` messages remain queued; expect the next two submissions there to trigger duplicate resolve turns
+(likely no-ops, but they will consume turns). Prefer closing that REPL after the resolve run lands.

--- a/.afk/diagnostics/partial-subagent-evidence-2026-07-06.md
+++ b/.afk/diagnostics/partial-subagent-evidence-2026-07-06.md
@@ -1,0 +1,49 @@
+# Partial subagent results — instance evidence (2026-07-06)
+
+Scanned all **10,933** witness traces under `~/.afk/state/witness/*/trace.jsonl`.
+Scanners: `scan-partial-subagents.mjs`, `scan-orphan-detail.mjs`, `/tmp/tiny.mjs`.
+
+## Aggregate
+- 610 traces had subagents; **1,165 subagents started**.
+- **320 orphans** (27.5%): `subagent_lifecycle.started` with NO terminal (`succeeded`/`failed`/`cancelled`).
+- **24 succeeded-tiny**: `succeeded` with `outputBytes < 200`.
+- **16 failed** total (10 `RateLimitError`, 2 TypeError, 2 APIConnectionTimeout, 1 APIConnectionError, 1 BadRequest); 12 carried `partialOutputBytes > 0`.
+- 13 cancelled; 86 background started (6 bg-orphan); 3,563 sealed traces (86 incomplete seals).
+
+## Orphans by dispatch source (orphans / started)
+| prefix | orphans | started | pct |
+|---|---|---|---|
+| skill-review | 221 | 534 | 41% |
+| skill-ship | 32 | 116 | 28% |
+| skill-ground-state | 25 | 112 | 22% |
+| skill-shadow-verify | 18 | 174 | 10% |
+| skill-distill | 8 | 49 | 16% |
+| skill-devils-advocate | 7 | 57 | 12% |
+| (others) | small | | |
+
+- Orphan sessions' **closure reason**: `model_end_turn` 283, NO_CLOSURE 31, `abort` 6.
+- Orphan↔dispatching-tool correlation: 0 orphans had a traced dispatching tool_call.completed with truncated/error flags (raw tool output isn't traced, so this is inconclusive for the correctness question — it does NOT prove results were complete).
+
+## Succeeded-tiny fingerprint (correctness signal)
+Several ran a long time with **turnCount 0** yet "succeeded" with ~100–200 bytes:
+- `skill-review-1783170275621-1` — 142 B, turnCount 0, **931,278 ms (15.5 min)** — session 9a5e2093
+- `skill-review-1783135740476-1` — 142 B, turnCount 0, **276,504 ms (4.6 min)** — session 5cffaa40
+- one case **7,568,116 ms (2.1 h)**, tiny output
+- `skill-review-1779549420826-1` — 103 B, turnCount 0, 8,270 ms — session fa775de7
+All 24 have turnCount ≤ 1; none had 0 output bytes.
+
+## Two candidate mechanisms (grounded in code)
+### M1 — Lost terminal (observability). 320 orphans, mostly clean-closure.
+- Terminal emit is fire-and-forget: `handle.ts:199` `void emitSubagentLifecycle(..., 'succeeded')` (also 237/245 for cancelled/failed).
+- Seal is awaited on a different path: `agent-session.ts:1203` `await this.sealTraceWriter()` → `writer.seal()`; post-seal `write()` rejects (`writer.ts`).
+- Race: parent/skill session seals before the `void` terminal append lands → terminal dropped → orphan. Dominant in skills because the skill executor forks, `await handle.runToResult()` (skill-executor.ts:1141), then immediately seals its short-lived session. Matches memory fact B1 (fix "flush terminal-emit before sealTraceWriter", never landed).
+
+### M2 — Partial result returned as SUCCESS (correctness). The user's actual complaint.
+- `streamToFinalMessage` (handle.ts:271–374): `for await (event of session.sendMessageStream)` accumulates `lastStreamedContent`; `turnCount++` only on `event.type==='message'` (326).
+- If the stream loop **ends without a terminal `message`/`done`/`error` event**, the post-loop fallback at **353–354** returns `lastStreamedContent` as a **normal success Message**; `run()` (190–221) sets `succeeded` and emits `succeeded`. Parent gets a mid-narration partial as a clean success, no error.
+- Fingerprint = turnCount 0 + small output + succeeded (the succeeded-tiny bucket).
+- OPEN: what makes `sendMessageStream` complete early without a terminal event — 429/rate-limit cascade (memory 2026-07-05), usage-limit pause+auto-resume (memory: pause has no event; autoResumeOnUsageLimit default true), or provider stream abnormal close. This is the primary thing to nail.
+
+## Reference sessions to pull
+- Orphan+clean: `00cddbd0-7d47-41a6-906c-85fd4107b70f` (skill-review, sealed succeeded, no succeeded terminal).
+- Succeeded-tiny/turnCount-0: `9a5e2093-2d9b-4cf2-8a9e-3bae4d63a318`, `5cffaa40-94cb-4f1d-b9f6-171960d34a64`, `fa775de7-edd3-4347-9e87-ad47a32be41f`.

--- a/.afk/diagnostics/scan-orphan-detail.mjs
+++ b/.afk/diagnostics/scan-orphan-detail.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Deep-dive on orphans: categorize by id prefix, and for each orphan correlate
+// with the tool_call.completed event for that subagent's dispatching tool
+// (skill / agent) to see if the PARENT actually got a result and whether it was
+// flagged truncated / isError.
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const HOME = process.env.AFK_HOME || join(process.env.HOME, '.afk');
+const WITNESS = join(HOME, 'state', 'witness');
+const dirs = readdirSync(WITNESS).filter((d) => { try { return statSync(join(WITNESS, d)).isDirectory(); } catch { return false; } });
+
+const prefixCounts = {};        // orphan id prefix -> count
+const prefixTotal = {};         // ALL subagent id prefix -> count (started)
+const orphanSessionsWithClosure = {}; // did orphan session have a closure event? reason dist
+// Correlate orphan subagent -> was there a completed tool_call for the dispatching tool in same session?
+let orphanWithToolCompleted = 0, orphanWithoutToolCompleted = 0, orphanToolTruncated = 0, orphanToolError = 0;
+const sampleTails = [];
+
+function prefixOf(id) {
+  // skill-review-1783122486136-1 -> skill-review ; agent-... -> agent ; else first token
+  const m = id.match(/^(skill-[a-z-]+?)-\d{6,}/);
+  if (m) return m[1];
+  const m2 = id.match(/^([a-z]+)[-_]/i);
+  return m2 ? m2[1] : id;
+}
+
+for (const d of dirs) {
+  const f = join(WITNESS, d, 'trace.jsonl');
+  if (!existsSync(f)) continue;
+  let lines;
+  try { lines = readFileSync(f, 'utf8').split('\n').filter(Boolean); } catch { continue; }
+
+  const sub = new Map();
+  const toolCompletedBySub = new Map(); // subagentId -> {truncated,isError,resultBytes}
+  let closureReason = null;
+  const evs = [];
+  for (const line of lines) { let ev; try { ev = JSON.parse(line); } catch { continue; } evs.push(ev);
+    if (ev.kind === 'subagent_lifecycle') {
+      const p = ev.payload, id = p.subagentId;
+      if (!sub.has(id)) sub.set(id, { started:false, terminal:null });
+      const s = sub.get(id);
+      if (p.transition === 'started') s.started = true; else s.terminal = p.transition;
+    } else if (ev.kind === 'tool_call' && ev.payload.phase === 'completed' && ev.payload.subagentId) {
+      toolCompletedBySub.set(ev.payload.subagentId, { truncated: ev.payload.truncated, isError: ev.payload.isError, resultBytes: ev.payload.resultBytes });
+    } else if (ev.kind === 'closure') closureReason = ev.payload.reason;
+  }
+
+  for (const [id, s] of sub) {
+    if (!s.started) continue;
+    const pfx = prefixOf(id);
+    prefixTotal[pfx] = (prefixTotal[pfx] || 0) + 1;
+    if (!s.terminal) {
+      prefixCounts[pfx] = (prefixCounts[pfx] || 0) + 1;
+      orphanSessionsWithClosure[closureReason || 'NO_CLOSURE'] = (orphanSessionsWithClosure[closureReason || 'NO_CLOSURE'] || 0) + 1;
+      const tc = toolCompletedBySub.get(id);
+      if (tc) { orphanWithToolCompleted++; if (tc.truncated) orphanToolTruncated++; if (tc.isError) orphanToolError++; }
+      else orphanWithoutToolCompleted++;
+      if (sampleTails.length < 4) {
+        // capture last 6 events mentioning this subagent id or lifecycle/closure
+        const rel = evs.filter(e => JSON.stringify(e).includes(id) || e.kind==='closure' || e.kind==='session_sealed').slice(-8);
+        sampleTails.push({ session: d, id, hasToolCompleted: !!tc, toolCompleted: tc, tail: rel });
+      }
+    }
+  }
+}
+
+console.log('=== ORPHAN COUNT by id prefix (orphans / total-started) ===');
+const rows = Object.keys(prefixTotal).map(k => ({ prefix:k, orphans: prefixCounts[k]||0, total: prefixTotal[k], pct: (((prefixCounts[k]||0)/prefixTotal[k])*100).toFixed(0)+'%' }))
+  .sort((a,b)=> b.orphans - a.orphans);
+console.table(rows);
+
+console.log('\n=== ORPHAN sessions: closure reason distribution ===');
+console.log(JSON.stringify(orphanSessionsWithClosure, null, 2));
+
+console.log('\n=== ORPHAN <-> dispatching tool_call.completed correlation ===');
+console.log(JSON.stringify({ orphanWithToolCompleted, orphanWithoutToolCompleted, orphanToolTruncated, orphanToolError }, null, 2));
+
+console.log('\n=== SAMPLE ORPHAN TAILS ===');
+console.log(JSON.stringify(sampleTails, null, 2));

--- a/.afk/diagnostics/scan-partial-subagents.mjs
+++ b/.afk/diagnostics/scan-partial-subagents.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// One-shot forensic scanner: find instances of "partial subagent results"
+// across every witness trace under $AFK_HOME/state/witness/<sid>/trace.jsonl.
+//
+// Signatures scanned:
+//  A. ORPHAN            — subagent_lifecycle 'started' with NO terminal for that subagentId
+//  B. FAILED_PARTIAL    — transition 'failed' with partialOutputBytes > 0
+//  C. FAILED_ANY        — transition 'failed' (all, grouped by errorClass)
+//  D. SUCCEEDED_TINY    — transition 'succeeded' with outputBytes < 200
+//  E. BG_ORPHAN         — background_agent 'started' with no completed/failed/cancelled
+//  F. CANCELLED         — transition 'cancelled' (by source)
+//  Also: was the SESSION sealed? incomplete seal? seal status?
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const HOME = process.env.AFK_HOME || join(process.env.HOME, '.afk');
+const WITNESS = join(HOME, 'state', 'witness');
+
+const dirs = readdirSync(WITNESS).filter((d) => {
+  try { return statSync(join(WITNESS, d)).isDirectory(); } catch { return false; }
+});
+
+const stats = {
+  totalTraces: 0,
+  tracesWithSubagents: 0,
+  totalSubagents: 0,
+  orphans: 0,
+  failedPartial: 0,
+  failedAny: 0,
+  succeededTiny: 0,
+  bgStarted: 0,
+  bgOrphan: 0,
+  cancelled: 0,
+  sealed: 0,
+  incompleteSeal: 0,
+};
+
+const errorClassCounts = {};
+const orphanExamples = [];
+const failedPartialExamples = [];
+const tinyExamples = [];
+const bgOrphanExamples = [];
+
+for (const d of dirs) {
+  const f = join(WITNESS, d, 'trace.jsonl');
+  if (!existsSync(f)) continue;
+  let lines;
+  try { lines = readFileSync(f, 'utf8').split('\n').filter(Boolean); } catch { continue; }
+  stats.totalTraces++;
+
+  // Per-subagent state
+  const sub = new Map();  // subagentId -> { started, terminal, model, outputBytes, errorClass, errorMessage, partialOutputBytes, cancelSource }
+  const bg = new Map();   // jobId -> { started, terminal }
+  let sealed = null;
+
+  for (const line of lines) {
+    let ev;
+    try { ev = JSON.parse(line); } catch { continue; }
+    if (ev.kind === 'subagent_lifecycle') {
+      const p = ev.payload;
+      const id = p.subagentId;
+      if (!sub.has(id)) sub.set(id, { started: false, terminal: null });
+      const s = sub.get(id);
+      if (p.transition === 'started') { s.started = true; s.model = p.model; s.startTs = ev.ts; }
+      else { s.terminal = p.transition; s.termTs = ev.ts;
+        if (p.transition === 'succeeded') s.outputBytes = p.outputBytes;
+        if (p.transition === 'failed') { s.errorClass = p.errorClass; s.errorMessage = p.errorMessage; s.partialOutputBytes = p.partialOutputBytes; }
+        if (p.transition === 'cancelled') s.cancelSource = p.source;
+      }
+    } else if (ev.kind === 'background_agent') {
+      const p = ev.payload;
+      const id = p.jobId;
+      if (!bg.has(id)) bg.set(id, { started: false, terminal: null });
+      const b = bg.get(id);
+      if (p.transition === 'started') b.started = true;
+      else if (['completed', 'failed', 'cancelled'].includes(p.transition)) b.terminal = p.transition;
+      else if (['joined', 'delivered'].includes(p.transition)) b.joinedOnly = p.transition;
+    } else if (ev.kind === 'session_sealed') {
+      sealed = ev.payload;
+    }
+  }
+
+  if (sub.size > 0) stats.tracesWithSubagents++;
+  if (sealed) { stats.sealed++; if (sealed.incomplete) stats.incompleteSeal++; }
+
+  for (const [id, s] of sub) {
+    if (!s.started) continue; // only count things that actually started
+    stats.totalSubagents++;
+    if (!s.terminal) {
+      stats.orphans++;
+      if (orphanExamples.length < 25) orphanExamples.push({ session: d, id, model: s.model, startTs: s.startTs, sealed: sealed ? sealed.status : 'NO_SEAL', incomplete: sealed?.incomplete || false });
+    } else if (s.terminal === 'failed') {
+      stats.failedAny++;
+      errorClassCounts[s.errorClass] = (errorClassCounts[s.errorClass] || 0) + 1;
+      if (s.partialOutputBytes > 0) {
+        stats.failedPartial++;
+        if (failedPartialExamples.length < 25) failedPartialExamples.push({ session: d, id, errorClass: s.errorClass, errorMessage: (s.errorMessage||'').slice(0,120), partialOutputBytes: s.partialOutputBytes });
+      }
+    } else if (s.terminal === 'succeeded') {
+      if (s.outputBytes < 200) {
+        stats.succeededTiny++;
+        if (tinyExamples.length < 20) tinyExamples.push({ session: d, id, outputBytes: s.outputBytes, model: s.model });
+      }
+    } else if (s.terminal === 'cancelled') {
+      stats.cancelled++;
+    }
+  }
+
+  for (const [id, b] of bg) {
+    if (!b.started) continue;
+    stats.bgStarted++;
+    if (!b.terminal) {
+      stats.bgOrphan++;
+      if (bgOrphanExamples.length < 15) bgOrphanExamples.push({ session: d, id, joinedOnly: b.joinedOnly || null });
+    }
+  }
+}
+
+console.log('=== AGGREGATE ===');
+console.log(JSON.stringify(stats, null, 2));
+console.log('\n=== FAILED errorClass distribution ===');
+console.log(JSON.stringify(Object.fromEntries(Object.entries(errorClassCounts).sort((a,b)=>b[1]-a[1])), null, 2));
+console.log('\n=== ORPHAN examples (started, no terminal) ===');
+console.log(JSON.stringify(orphanExamples, null, 2));
+console.log('\n=== FAILED_PARTIAL examples (failed with partialOutputBytes>0) ===');
+console.log(JSON.stringify(failedPartialExamples, null, 2));
+console.log('\n=== SUCCEEDED_TINY examples (outputBytes<200) ===');
+console.log(JSON.stringify(tinyExamples, null, 2));
+console.log('\n=== BG_ORPHAN examples ===');
+console.log(JSON.stringify(bgOrphanExamples, null, 2));

--- a/.afk/diagnostics/subagent-auth-shadow-verify-2026-07-02.md
+++ b/.afk/diagnostics/subagent-auth-shadow-verify-2026-07-02.md
@@ -1,0 +1,50 @@
+# Shadow verification — gpt-5.5 subagent auth failure
+
+## Claim verified
+The failed `gpt-5.5` subagent dispatch is an AFK subagent-auth/routing bug: the agent-tool executor deliberately clears `apiKey` for OpenAI-compatible children, but `SubagentManager.forkSubagent` later reintroduces the parent's `parentApiKey`, so an Anthropic `sk-ant-*` parent credential can reach the OpenAI-compatible child.
+
+## Verdict
+**CONFIRMED** for source HEAD and the agent-tool path.
+
+A secondary subclaim — "installed global v5.15.5 may differ from source HEAD in this area" — is **REFUTED**. The installed package appears to be v5.15.5 and source HEAD is effectively the same runtime code plus docs-only commits; the bug is in both/source behavior, not an installed-vs-source mismatch.
+
+## Independent verifier results
+
+### Verifier 1 — auth flow
+**CONFIRMED.**
+
+Evidence:
+- `src/agent/tools/subagent-executor.ts:554` computes `childIsOpenAI = providerForModel(childModel) === 'openai-compatible'`.
+- `src/agent/tools/subagent-executor.ts:580` sets `apiKey: childIsOpenAI ? undefined : resolvedChildApiKey`, with comments at `:546-552` explicitly saying this is to prevent forwarding a parent Anthropic key to OpenAI.
+- `src/agent/subagent.ts:420` then builds the actual child `AgentConfig` with `apiKey: options.config.apiKey || this.parentApiKey`, so the deliberate `undefined` becomes the parent credential.
+- `src/agent/providers/openai-compatible/auth.ts:117-120` treats any non-empty explicit config key as Tier-1 OpenAI auth, so an inherited `sk-ant-*` would be used as OpenAI auth.
+
+### Verifier 2 — tests
+**CONFIRMED.**
+
+Evidence:
+- `src/agent/tools/subagent-executor.test.ts:545-567` asserts the executor passes `apiKey: undefined` for an OpenAI child, but uses a mocked manager, so the real `SubagentManager.forkSubagent` fallback is not exercised.
+- `subagent.ts:420` is the missing boundary: it is downstream of the mocked boundary and reintroduces `parentApiKey`.
+- The recommended regression belongs in `subagent.test.ts` or an integration-style executor test that uses the real manager and asserts an OpenAI child never receives `sk-ant-*` after `forkSubagent` constructs the real child config.
+
+### Verifier 3 — installed dist parity
+**PARTIAL / corrected.**
+
+The verifier correctly refuted the installed-vs-source mismatch: installed global AFK is v5.15.5, and source HEAD differs by docs-only commits.
+
+However, its broader refutation of the bug is rejected because it stopped at the executor's guard and did not account for `SubagentManager.forkSubagent` applying `apiKey: options.config.apiKey || this.parentApiKey` after that guard. That is the composition boundary the first two verifiers checked.
+
+## Composition-boundary decision
+Accepted as **CONFIRMED** because the decisive boundary is executor → manager → AgentSession/provider:
+1. Executor clears OpenAI child key (`subagent-executor.ts:580`).
+2. Manager reintroduces parent key (`subagent.ts:420`).
+3. AgentSession applies slot clearing only when a matching slot exists (`agent-session.ts:238`; `slot-credentials.ts:57-77`). For raw `gpt-5.5` without a matching model-slot binding, this does not clear the leak.
+4. OpenAI auth accepts explicit `config.apiKey` before env/codex auth (`openai-compatible/auth.ts:117-120`).
+
+## Recommended fix
+Make `SubagentManager.forkSubagent`'s `apiKey` and `baseUrl` fallback provider-aware, or otherwise preserve an explicit child decision to clear credentials. For example, for OpenAI-compatible child models, do not fall back to an Anthropic parent `apiKey` or Anthropic `baseUrl`; leave them undefined so the OpenAI-compatible provider resolves its own env/Codex/ChatGPT auth.
+
+## Recommended regression tests
+1. Add a real-manager test that constructs `SubagentManager({ apiKey: 'sk-ant-oat01-PARENT' })`, forks a child with `{ model: 'gpt-5.5', apiKey: undefined }`, and asserts the resulting child `AgentConfig.apiKey` is not `sk-ant-oat01-PARENT`.
+2. Add the same shape for `baseUrl` if an Anthropic parent base URL can be inherited into OpenAI-compatible children.
+3. Keep the existing executor-boundary test, but add the manager/integration test because the existing mock test is insufficient.

--- a/.afk/diagnostics/subagent-termination-2026-07-02.md
+++ b/.afk/diagnostics/subagent-termination-2026-07-02.md
@@ -1,0 +1,58 @@
+# Subagent termination diagnosis — 2026-07-02
+
+## Scope
+Investigated why AFK subagents were getting terminated/stuck over 2026-07-01 to 2026-07-02, using recent AFK transcripts, logs, session artifacts, and source reads in `/Users/griffinlong/Projects/open_source/agent-afk`.
+
+## Confirmed issue: requested gpt-5.5 subagents failed to launch
+Three requested `gpt-5.5` diagnostic subagents failed immediately with:
+
+```text
+401 Incorrect API key provided: sk-ant-o... You can find your API key at https://platform.openai.com/account/api-keys.
+```
+
+This is a real subagent-auth/routing bug, not user error. A `gpt-5.5` child routes to the OpenAI-compatible provider, but the attempted request carried an Anthropic-shaped `sk-ant-...` credential. Either the child should inherit the same working auth context as the parent runtime when the parent is already using that backend, or it should fail before dispatch with a clear "no OpenAI-compatible auth available" diagnostic; it must not silently send an Anthropic token to the OpenAI endpoint and surface a raw 401. I completed the diagnosis inline from durable artifacts because the requested subagents could not start.
+
+## Verdict
+This is not one single failure. The last two days show several distinct classes that all look like "subagents terminated" from the UI:
+
+1. **Provider/API pressure is real and likely explains the slow/hung review subagents.**
+   - Transcript `~/.afk/state/transcripts/2026-07-01T23-28-20-360Z.md` records a live diagnosis of session `61db02da` dispatching two parallel `agent` subagents at 23:20:39; evidence showed they had opened Anthropic connections and were waiting for first response, not doing local work.
+   - Same transcript lines 166-175 conclude elevated `model_ttfb` 3.4–5.3s was a clean network-side measurement, not local AFK preflight, and `src/agent/providers/anthropic-direct/loop.ts:234-284` confirms the timer starts immediately before `createWithRetry` and stops at first translated stream event.
+   - `src/agent/providers/anthropic-direct/loop.ts:118-142` retries transient server/overload errors with backoff, so 529/503 pressure is an expected established path, not new regression behavior.
+
+2. **There is a real robustness gap: subagents have no outer deadline, and a 429 usage-limit can look like a hang for up to two hours.**
+   - `src/agent/providers/anthropic-direct/query/retry-layer.ts:49` defines `TWO_HOURS_MS`; lines 51-56 document fixed-cadence retry for 429-without-reset, bounded at two hours.
+   - Transcript `2026-07-01T23-28-20-360Z.md:169-176` flags that subagent dispatch has no deadline, so a hard usage-limit path can be indistinguishable from a silent hang.
+   - This was judged latent/not the main active case in that transcript because some subagents were progressing.
+
+3. **A shipped regression/fix mismatch broke skill subagents in old running processes: PascalCase vs snake_case tool allowlists.**
+   - Transcript `~/.afk/state/transcripts/2026-07-02T03-02-05-627Z.md:17-25` explains `/diagnose` and `/audit-fit` gates compared runtime tools like `read_file`, `grep`, `bash`, `web_scrape` to vendored Claude Code allowlists like `Read`, `Grep`, `Bash`, `WebFetch`, causing all tool calls to be denied.
+   - The same transcript states the fix is commit `0d1fca6` / PR #350 / tag `v5.15.5`, but older tmux/REPL processes that started before install still had broken gates until restarted.
+
+4. **Worktree/path containment errors were by-design denials, but presented as repeated subagent failure.**
+   - `src/agent/subagent.ts:444-450` shows forked subagents inherit the parent cwd for worktree isolation.
+   - `src/agent/tools/hooks/path-approval-hook.ts:215-234` auto-denies out-of-root path approval for subagents because they cannot safely prompt a human mid-fork.
+   - Transcript `2026-07-02T03-02-05-627Z.md:27-34` ties the failure to prompts containing main-repo absolute paths while subagents were running inside worktree roots. Mitigation: use worktree-relative paths or set `cwd` to match cited paths.
+
+5. **Foreground subagents can be converted to detached background jobs, which previously looked like a loss/termination because results did not return automatically.**
+   - Transcript `~/.afk/state/transcripts/2026-07-01T22-18-04-933Z.md:434-447` records a read-only audit subagent converted to background job `bg-mr2olxnf-9025`; the main agent could not auto-join it.
+   - Later transcript `2026-07-02T04-14-38-426Z.md:32` says background result auto-delivery was subsequently implemented, so this should be improved in newer sessions.
+
+6. **There is a newly observed local worktree-cleanup/race class causing `spawn /bin/sh ENOENT`.**
+   - Transcript `~/.afk/state/transcripts/2026-07-02T03-56-36-870Z.md:115` records live session cwd worktrees being deleted while sessions still ran, causing `spawn /bin/sh ENOENT` for the main session and a verifier subagent.
+   - `src/agent/worktree-sweep.ts:240-248` parses `git worktree list --porcelain` branch lines directly, and `worktree-sweep.ts:603-619` can remove candidate worktrees; transcript `2026-07-02T04-07-10-698Z.md:49` reports forensics around a sweep issue. This needs a dedicated issue if it recurs.
+
+## Ranking by likelihood for “today/yesterday tons of issues”
+1. Anthropic/API capacity/latency + parallel fanout pressure: high likelihood for slow/hung review subagents.
+2. Old running sessions with pre-v5.15.5 skill gate bug: high likelihood for `/diagnose`/skill subagents denied every tool.
+3. Worktree absolute-path briefing mismatch: high likelihood in worktree-based sessions.
+4. No subagent deadline + 2h 429 retry: real latent sharp edge; high impact when it fires, but not proven active in the main stall case.
+5. Background promotion result-delivery gap: explains “lost” subagents in older sessions, less likely after the auto-delivery fix.
+6. Worktree cleanup race deleting live cwd: real observed local failure, needs recurrence tracking.
+
+## Recommended next actions
+1. Restart all long-running AFK tmux/REPL/Telegram sessions so they load v5.15.5+ gate fixes.
+2. Add an explicit subagent deadline / visible 429 usage-limit status so subagents cannot silently appear terminated for up to two hours.
+3. When dispatching into worktrees, brief subagents with relative paths or pass `cwd` matching absolute paths.
+4. Open/fix the live-worktree cleanup race if `spawn /bin/sh ENOENT` recurs.
+5. Fix gpt-5.5 provider credential routing before trying gpt-5.5 subagents again; current dispatch sent an Anthropic-style key to OpenAI-compatible and failed 401.

--- a/.afk/diagnostics/terminal-resize-wrapping.md
+++ b/.afk/diagnostics/terminal-resize-wrapping.md
@@ -1,0 +1,87 @@
+# Diagnosis: "text wrapping gets wonky when the terminal resizes"
+
+_Session 2026-07-10. Investigated via `/diagnose` (its verifier fan-out timed out;
+validation redone by hand from source + git + build state)._
+
+## Answer (root cause of the bug class)
+
+The symptom is the **soft-wrap ↔ hard-wrap-at-paint desync** on unbreakable tokens.
+When a rendered line contains a token wider than the content width with no break
+opportunity — a bare **file path, URL, or long inline-code identifier** (which afk
+prints constantly) — a *soft* word-wrap (`wrapToWidth(hard:false)`) leaves that token
+overflowing past the right edge. The terminal's own autowrap (DECAWM) then hard-wraps
+it **again at the hardware level**, inserting phantom rows the compositor never counted.
+Every subsequent cursor-addressed (CUP) erase/repaint is one row off, and on **resize**
+the reflow re-splits the stored over-wide line at a *different* width — the visible
+"all wonky" wrapping.
+
+This is documented in the codebase verbatim as **"the persistent-wrap / fucky-on-resize
+bug"** (commit `227a99e`, PR #470, `src/cli/markdown-stream-format.ts` comments).
+
+## Status on your build: already fixed at every interactive surface
+
+You are running `agent-afk@5.25.11` (`/opt/homebrew/bin/afk`), and `dist/` (built
+2026-07-10 09:08) contains the fix. Three independent layers now protect against this
+class:
+
+| Layer | Mechanism | Where | Landed |
+|---|---|---|---|
+| 1. Source formatting | `breakLongWords: true` at the 3 assistant-stream sinks (`renderTextBlock`, `formatPendingBuffer`, `formatBlockForCommit`) | `src/cli/markdown-stream-format.ts:34,70,110` | #470, 2026-07-07 |
+| 2. Overlay emission | `clampLineToTerminal` → `truncateDisplayWidth` clamps every tool-lane / subagent overlay line to *current* width, per frame (~30 sites) | `src/cli/commands/interactive/tool-lane-render*.ts` | — |
+| 3. Committed scrollback | `hardWrapToWidth` breaks long tokens at commit **and** re-wraps the retained band at paint-time width on resize | `terminal-compositor.committed-band-commit.ts:162`, `terminal-compositor.band-reflow.ts:73` | #386, 2026-07-02 |
+
+Verification done this session:
+- `#470` is an ancestor of `HEAD` (15 commits back) and present in the built `dist/`.
+- Full test suite green: **597 files / 11172 tests, 0 failures**, incl. both resize
+  regression suites (`terminal-compositor.resize-stale-width.repro.test.ts`,
+  `terminal-compositor.resize-ghost.test.ts`).
+- No commit *after* #470 touched `wrap.ts` / `markdown-stream*` / `terminal-compositor*`
+  / `tool-lane*` / `stream-renderer*` — the wrap machinery is at its most-fixed state.
+
+Hypotheses the `/diagnose` run raised, and their disposition:
+- **h2** (committed-band verbatim-repaint) → **ruled out**, fix #386 present.
+- **h1** (tool-lane / subagent rows bake in width, never re-run bracket-aware) →
+  **refuted**: `tool-lane.ts:331` reads `getTerminalWidth()` fresh per frame; the
+  subagent stream subscribes to `ResizeBus` (`stream-renderer-lifecycle.ts:168`); the
+  `?? 100` fallbacks only bite on a non-TTY (undefined columns), not on resize.
+- **h3** (unguarded `wrapToWidth` sites) → **this was the real class**, and #470 fixed
+  the primary sinks. Remaining unguarded sites are either self-truncating box
+  components (`card.ts:158-179`) or the **non-TTY-only** `formatSubagentTextLines`
+  (`emitSubagentTextLines` early-returns on TTY, `stream-renderer-subagent-helpers.ts:72`)
+  — neither is a live-resize exposure.
+- **h4** (native scrollback beyond the tracked band can't reflow) → **the only thing
+  that can still look wonky on your build** (see below).
+
+## What you are most likely still seeing
+
+Because the live/current rendering is fixed, a "wonky on resize" today is almost
+certainly **already-emitted history**, not new output:
+
+1. **Native-scrollback architectural limit (h4).** Content that has scrolled *past* the
+   compositor's tracked committed-band window into the terminal's own scrollback can
+   never be reflowed — this is inherent to the cursor-relative paint model (no DECSTBM
+   scroll-region insertion). It matches how **tmux** treats hard-wrapped lines (only
+   soft-wrapped lines reflow, primary screen only). Documented as a known limitation and
+   the long-horizon direction in `docs/tui-resize-reflow.md:115-121, 129-141`.
+
+2. **Frozen pre-update render.** If you updated to 5.25.11 recently, any output painted
+   by the *older* binary (before #470, 2026-07-07) is frozen in scrollback at its old
+   width; resizing cannot retroactively fix it. A fresh session renders clean.
+
+### Self-check (distinguishes fixable bug from known limitation)
+
+Resize the window, then look at **newly streamed output** (ask the agent something so
+fresh text prints *after* the resize):
+- **New output wraps correctly** → you are seeing (1) or (2): old history that the app
+  cannot retroactively reflow. Expected, matches tmux; not a code defect. Start a fresh
+  session for clean history.
+- **New output *also* wraps wrong** → a genuine residual defect not covered above.
+  Capture `tmux capture-pane -p` (or a screenshot) of the broken region + your terminal
+  emulator + `$COLUMNS`, and reopen — that gives a reproducible surface to fix.
+
+## Recommendation
+
+No code change is warranted right now: the interactive TTY path is fixed and green, and
+every suspected residual is ruled out. The remaining cause is the documented scrollback
+architectural limit. If the self-check shows *new* output wrapping wrong, that's a fresh
+bug — capture the artifacts above and it becomes fixable.

--- a/.afk/repo-ground-20260629.json
+++ b/.afk/repo-ground-20260629.json
@@ -1,0 +1,76 @@
+{
+  "timestamp": "2026-06-29",
+  "goal": "Collapse legacy two-repo model into ONE canonical code repo (public agent-afk) + moat marketplace (awa-private). Plan: decouple-public-mirror-from-moat.md (Option B / B').",
+  "overall": "BLOCK",
+  "block_reason": "agent-afk-private cannot be retired: it holds the only copy of src/moat (~6,630 LOC, the B5 extraction source) plus 45 stashes + 7 unpushed main commits + 3 untracked files of un-triaged local-only state. Repos 1 and 2 are PASS. B5 extraction (a build task, not a remote mutation) can proceed now.",
+  "auth_probe": "SKIPPED — operator restricted recon to local-only read commands; no ls-remote/network probe run. Remote URL scheme noted as a proxy (repo1 HTTPS, repo3 SSH).",
+  "repos": [
+    {
+      "path": "/Users/griffinlong/Projects/open_source/agent-afk",
+      "role": "PUBLIC canonical (on disk)",
+      "branch": { "current": "fix/tui-endturn-overflow-scrollback-gap", "ahead": 2, "behind": 11, "tracking": "origin/main" },
+      "origin_main": "v5.10.1 @ 3a34e4b (2026-06-29)",
+      "remotes": [
+        { "name": "origin", "url": "https://github.com/griffinwork40/agent-afk" },
+        { "name": "fork", "url": "https://github.com/sorcerai/agent-afk.git" }
+      ],
+      "auth": "not-probed",
+      "dirty": true,
+      "dirty_detail": "1 modified (terminal-compositor.frame-preserve.ts) + 2 untracked (a repro test, stray testimonial.txt)",
+      "stashes": 0,
+      "moat_present": false,
+      "b_prereqs_merged": ["#298+#324 (entrypoint + DI inject, B4.5)", "#305 (16-symbol runtime API)", "#307 (loadSkillPrompts baseDir)", "#308 (surface wiring B4)"],
+      "verdict": "PASS",
+      "blockers": []
+    },
+    {
+      "path": "/Users/griffinlong/Projects/plugins/awa-private",
+      "role": "MOAT MARKETPLACE (agent-framework-private)",
+      "branch": { "current": "fix/skills-afk-framework-paths", "ahead": 1, "behind": 0, "tracking": "origin/main" },
+      "remotes": [ { "name": "origin", "url": "https://github.com/griffinwork40/awa-private.git" } ],
+      "auth": "not-probed",
+      "dirty": false,
+      "stashes": 0,
+      "hosts_plugins": ["awa-private", "awa-dev"],
+      "afk_moat_present": false,
+      "verdict": "PASS",
+      "blockers": [],
+      "note": "Clean, single-remote, well-formed. Designated home for the future afk-moat SIBLING plugin (B5), but afk-moat is not scaffolded yet."
+    },
+    {
+      "path": "/Users/griffinlong/Projects/personal_projects/agent-workspace/agent-afk-private",
+      "role": "OLD PRIVATE CANONICAL (afk-workshop) — extraction SOURCE",
+      "branch": { "current": "main", "ahead": 7, "behind": 5, "tracking": "origin/main", "ahead_commits": "all docs(plan) decouple commits, unpushed to afk-workshop" },
+      "remotes": [
+        { "name": "origin", "url": "git@github.com:griffinwork40/afk-workshop.git" },
+        { "name": "public", "url": "git@github.com:griffinwork40/agent-afk.git" }
+      ],
+      "auth": "not-probed",
+      "dirty": true,
+      "dirty_detail": "3 untracked: .afk/plans/rsi-pipeline-unclog-and-runhealth.md, scripts/harvest-probe.mts, scripts/harvest-top-n.mts",
+      "stashes": 45,
+      "local_branches": 32,
+      "branches_gone_safe_prune": 2,
+      "branches_worktree_attached": 9,
+      "stale_remote_tracking": "publocal/* (remote 'publocal' removed; refs linger)",
+      "moat_present": true,
+      "moat_loc": "~6,630 TS LOC in src/moat/ (forge, harvest, _agents/qualify, telemetry, register.ts, boundary.test.ts)",
+      "verdict": "BLOCK",
+      "blockers": [
+        "Holds the ONLY copy of src/moat — B5 extraction source, not yet extracted",
+        "45 stashes un-triaged (stash@{4} flags 111 divergent files 'NOT verified safe-to-drop')",
+        "7 unpushed main commits (the decouple plan doc updates)",
+        "3 untracked files including 2 harvest scripts that likely belong in afk-moat",
+        "stale publocal/* remote-tracking namespace (trivial prune)"
+      ]
+    }
+  ],
+  "consolidation_status": {
+    "decouple_prereqs": "COMPLETE — PR1/#298, #299, #305, #307, B4/#308, B4.5/#324 all merged to PUBLIC main (now v5.10.1). Public is moat-free, developed directly, with the DI plugin-entrypoint mechanism live.",
+    "b5_extraction": "NOT STARTED — afk-moat does not exist anywhere; src/moat/ lives only in agent-afk-private; awa-private marketplace still hosts only awa-private + awa-dev.",
+    "remotes_consolidated": false,
+    "private_carries_unique_work": "YES — src/moat (load-bearing) + plan commits + 45 stashes + untracked scripts.",
+    "architecture_decision": "B' (sibling code-backed afk-moat plugin in the awa-private marketplace, built against PUBLIC agent-afk via peerDependency, host injects PluginApi). Appears effectively decided — B4.5 (the DI enabler) already shipped to public. Confirm before starting B5.",
+    "next_action": "B5 Phase A — scaffold afk-moat as a sibling plugin in awa-private/plugins/, build against public agent-afk (peerDependency), copy src/moat/ in, rewrite core imports to `from 'agent-afk'`, delete the 2 MOAT-PRIVATE sentinel imports, move the 3 moat path helpers in, dev-install + smoke test. Plan steps 5-12 (steps 1-4 are superseded — already in public). One human gate first: the /forge nudge extension-point decision (plan recommends DROP)."
+  }
+}

--- a/.afk/skills/render-test/SKILL.md
+++ b/.afk/skills/render-test/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: render-test
+description: "Render smoke-test for the agent-afk REPL: emit one of every markdown element (headings, bold/italic/strikethrough, inline + fenced code, GFM table, bullet/numbered/task lists, blockquote, link, image, horizontal rule) plus the runtime overlays (tool-call line, +/- edit diff, thinking, error box, subagent status, interactive picker, verdict card). Use to eyeball every renderer after touching TUI/formatter code, or to demo what afk can display. Pass `markdown` to emit only the markdown elements with no side effects."
+context: load
+---
+
+# /render-test — TUI render smoke-test
+
+You are running the render smoke-test in the CURRENT session. Produce the output below so the operator can visually inspect every renderer. Best run in the interactive REPL (`afk i`); the **diff block** and **interactive picker** only render **outside plan mode** (file edits + questions are what trigger them).
+
+**Argument:** `$ARGUMENTS`
+If the argument is `markdown` or `md`, emit ONLY Section A and stop — no file edits, no questions, no subagents. Otherwise do both sections.
+
+---
+
+## Section A — markdown elements
+
+Emit each item as **live markdown** — not wrapped in a code block, not described in prose. One compact real example of each:
+
+- An H1, an H2, and an H3 heading
+- A paragraph containing **bold**, *italic*, ~~strikethrough~~, and `inline code`
+- A fenced code block tagged `python` (a ~5-line snippet) so syntax highlighting shows
+- A GFM table with 3 columns, a header row, and 2 data rows
+- A bulleted list with one nested sub-bullet
+- A numbered list that starts at 3
+- A task list with one checked `[x]` and one unchecked `[ ]` item
+- A two-line blockquote
+- An inline `[link](https://example.com)` and a bare URL on its own line
+- A markdown image: `![alt](https://example.com/x.png)`
+- A horizontal rule
+
+Do not wrap the whole reply in a fence.
+
+> For your own grounding (do not lecture the operator unless asked): in the REPL, strikethrough and images render as **literal text** while tables/lists/code/etc. render richly; on Telegram it is the reverse (strikethrough → `<s>`, but tables/lists pass through as raw text). Full verified element map with file:line cites: `${SKILL_ROOT}/reference.md`.
+
+---
+
+## Section B — runtime overlays
+
+Skip this section entirely if the argument was `markdown`/`md`. Otherwise perform these **safe, throwaway** actions so each overlay renders. Keep every artifact in the system temp dir — never write into the operator's repo.
+
+1. Run `echo render-test-ok` — shows the tool-call line + result.
+2. Run `cat /no/such/file` — shows the **error box** (a harmless, expected failure).
+3. Show the **+/- diff block**: `write_file` a throwaway file at `/tmp/afk-render-test.txt` with 3 short lines, then `edit_file` to change one line (the diff renders under the edit), then delete it with `rm /tmp/afk-render-test.txt`.
+4. Dispatch one cheap subagent (`model: haiku`, `max_turns: 1`) that returns a single-line fact — shows the `Agent(...)` status line.
+5. Ask the operator ONE multiple-choice question via `ask_question` (`type: choice`, 3 options, e.g. "looks right / has glitches / skip") so the **interactive picker overlay** renders. First check reachability: if the surface is non-interactive (daemon/subagent/one-shot `chat`), SKIP this step and say the picker was skipped because no human is reachable.
+
+Then close with your normal end-of-turn terminal-state summary — that emits the **verdict card**.
+
+Overlays you cannot force from here (mention them, don't fake them): usage-limit box (needs a real API limit), progress banner / loop-stage rail (runtime-timed). Slash-only renderables the operator triggers manually: todo panel (`/todo add …`), help table (`/help`).

--- a/.afk/skills/render-test/reference.md
+++ b/.afk/skills/render-test/reference.md
@@ -1,0 +1,102 @@
+# agent-afk — Renderable Output Reference
+
+The verified element map behind the `/render-test` skill. Everything afk can render after
+you send a prompt, split into two classes, with file:line citations into the codebase.
+All claims were cross-checked against source and shadow-verified.
+
+---
+
+## Two classes of renderable output
+
+**Class A — markdown the model writes.** A prompt produces these directly. Converted by
+`src/cli/formatter.ts` (REPL, marked `Lexer` → ANSI) and `src/telegram/formatter.ts`
+(Telegram, → HTML).
+
+**Class B — runtime overlays.** Not markdown — the runtime draws them based on what the
+agent *does* (calls a tool, edits a file, thinks, asks, errors, ends the turn). A prompt
+triggers them only by making the agent take that action.
+
+**Surface matters:** tables / lists / blockquotes / rules render richly in the REPL but
+arrive as *raw markdown text* on Telegram; strikethrough is the reverse (literal in the
+REPL, styled `<s>` on Telegram).
+
+---
+
+## Class A — markdown elements
+
+| Element | REPL | Telegram | REPL cite |
+|---|---|---|---|
+| H1 / H2 / H3+ headings | colored/bold tiers | flattened to plain text | `formatter.ts:136,150-152` · tg `:153` |
+| Bold / italic | styled | `<b>` / `<i>` | `:197,201` (inline `:36,40`) · tg `:127-138` |
+| Inline code | styled (slash-cmds → brand) | `<code>` | `:193` (inline `:32`) · tg `:120-122` |
+| Fenced code block | syntax-highlighted (`emphasize`/highlight.js), `│` gutter | `<pre>` | `:162-191`, `syntax-highlight.ts:15` · tg `:113` |
+| Table (GFM) | full box-drawing, aligned | **raw text** (not converted) | `:322-504` |
+| Bullet / numbered / nested lists | `•`, respects start index | **raw text** | `:212-292` |
+| Task list `[x]`/`[ ]` | ☑ / ☐ glyphs | **raw text** | `:235-246` |
+| Blockquote | `│` dim prefix | **raw text** | `:304-320` |
+| Link | `text (href)` | `<a href>` | `:46-53` · tg `:146-150` |
+| Horizontal rule | `─` to width | **raw text** | `:296-302` |
+| Strikethrough `~~` | **raw text** (not styled) | `<s>` | default `:60`/`:507` · tg `:141` |
+| Image `![]()` | **raw text** | **raw text** | default `:60`/`:507` |
+| HTML escaping | — | `& < >` → entities | tg `:90-93` |
+
+`~~text~~` and `![alt](url)` tokenize as `del`/`image` (marked GFM defaults) but have no case
+in either `renderTokens` or `renderInlineTokens`, so both hit `default: return token.raw`.
+
+---
+
+## Class B — runtime overlays (REPL)
+
+| Overlay | Trigger | Cite |
+|---|---|---|
+| Tool-call indicator / scrollback | agent calls any tool | `tool-lane.ts:43-70` |
+| **Diff block** (`+`green / `-`red / `@@` hunk header, stat `+N -M across K hunks`) | `edit_file` / `write_file` | `tool-lane-format-diff.ts:82-266`, `palette.ts:72-77`, wired via `tool-lane.ts:516` |
+| Subagent status `Agent(label)` | dispatch a subagent | `stream-renderer-subagent.ts` |
+| Thinking preview + `◆ thought for Xs · N tok` | reasoning/thinking | `thinking-paragraph.ts`, `thinking-lane.ts:14` |
+| **Interactive question overlay** — keyboard picker (choice/multi) or text input (text/number) | `ask_question` (5 types: text, confirm, choice, multi_choice, number) | `render/picker.ts`, `render/text-input.ts`, `elicitation/agent-question.ts:132-258`, `schemas.ts:874` |
+| Progress banner | long-running op | `progress-banner.ts:79` |
+| Loop-stage rail (Observe→Model→Choose→Act→Update) | runtime-driven | `loop-stage.ts` |
+| Skill badge | invoke a skill (`<skillname>` tag) | `stream-renderer-orchestrator.ts:93-97` |
+| Error box | a tool errors (e.g. `cat /no/such/file`) | `render/error-box.ts:23-37` |
+| Verdict card (Done / Blocked / Asking / Interrupted) | end of turn (automatic on REPL) | `verdict-card.ts:43-60` |
+| Cards (plan / status / checkpoint / diagnosis / user) | those flows emit them | `render/card.ts:35-60` |
+| Usage-limit box | hitting a real usage limit (can't force) | `render/usage-limit-box.ts:21-60` |
+| Streaming placeholders `▍ streaming code…` | transient mid-stream | `markdown-stream-format.ts:53-62` |
+| Loading-tips spinner | any turn while the model works | `loading-tips.ts` |
+| OSC 8 hyperlinks (clickable file paths) | with diffs / path labels | `tool-lane-render-agent.ts:272` |
+| "Unverified" turn warning | text-only turns with no write/command | `afk-push.ts:153` |
+
+### Slash / startup renderables (operator triggers these)
+
+| Renderable | Trigger | Cite |
+|---|---|---|
+| Todo panel (`┌─ todos …`) | `/todo add <text>` | `todo-panel.ts:83-110`, `context-pane.ts:37-58` |
+| Help table | `/help` | `render/help-table.ts` |
+| Welcome banner | REPL startup | `render/welcome-banner.ts` |
+
+---
+
+## Rendering-related env toggles
+
+| Env var | Effect | Cite |
+|---|---|---|
+| `AFK_SHOW_DIFFS` | `0`/`false`/`off`/`no` → disable diff rendering entirely | `tool-lane-format-diff.ts:65-70` |
+| `AFK_DIFF_LINES` | scrollback diff cap (default 30; `0` = no cap) | `tool-lane-format-diff.ts:45-53` |
+
+Overlay diff cap is fixed at 8 lines (`MAX_OVERLAY_DIFF_LINES`, `tool-lane-format-diff.ts:11`).
+
+---
+
+## Caveats
+
+- The **usage-limit box** can't be forced safely (needs a real API limit).
+- The **progress banner** and **loop-stage rail** are runtime-timed — may not appear on a fast turn.
+- The **diff block** and **interactive picker** need a non-plan-mode session (file edits + questions).
+- On **Telegram**, the table / lists / blockquote / rule / image show as raw markdown text — use the REPL for rich rendering.
+
+---
+
+*Paths are relative to `src/cli/` unless otherwise noted. Verified against `src/cli/formatter.ts`,
+`src/cli/commands/interactive/tool-lane-format-diff.ts`, `src/cli/render/`, `src/telegram/formatter.ts`,
+and the `ask_question` → elicitation → picker wiring. Three load-bearing claims (diff blocks,
+ask_question picker overlay, strikethrough/image fallthrough) were independently shadow-verified — all CONFIRMED.*

--- a/.afk/tui-ux-audit.md
+++ b/.afk/tui-ux-audit.md
@@ -1,0 +1,164 @@
+# TUI UX Audit — quick-win candidates
+
+Read-only audit of the interactive REPL across 5 dimensions (rendering, input,
+feedback, errors, discoverability) via parallel subagents, then high-impact
+claims verified directly. Branch: `afk/review-tui-ux-issues`. No code changed.
+
+Confidence key: **[CONFIRMED]** = I read the code / ran a test. **[REPORTED]** =
+subagent-found, plausible, not independently re-derived.
+
+---
+
+## Tier 1 — trivial fixes, high visibility (minutes each)
+
+1. **[CONFIRMED] `/tasks` loading tip points to a command that doesn't exist.**
+   `loading-tips.ts:51` tells users "find it later with /tasks" — the real
+   command is `/bgsub` (`slash/commands/bgsub.ts`). Typing `/tasks` → "Unknown
+   command (did you mean /stats?)". Dead-ends a core power feature. *Fix:* change
+   tip text to `/bgsub`, or register `/tasks` as an alias.
+
+2. **[CONFIRMED] GFM task-list checkboxes render as raw `[x]`.**
+   marked v17 emits `{type:'checkbox', raw:'[x] '}`; the list renderer
+   (`formatter.ts:214`) never inspects `item.task`/`item.checked`, and the
+   `checkbox` token hits `default: return token.raw` (`formatter.ts:401`). A
+   model checklist renders as `• [x] foo` instead of `☑ foo`. Models emit
+   checklists constantly. *Fix:* handle `item.task` in the list case (render
+   `☐`/`☑`) or add a `case 'checkbox'`.
+
+3. **[CONFIRMED] Horizontal rule `---` is hardcoded to 40 columns.**
+   `formatter.ts:276`: `palette.dim('─'.repeat(40))`. Looks stubby on wide
+   terminals, wraps (corrupting row count) on narrow ones. `render/divider.ts`
+   already does it right (`repeat(width)`). *Fix:* use terminal/content width.
+
+4. **[CONFIRMED] Context-OVER warning uses unsafe `console.log`, races the overlay.**
+   `turn-handler.ts:777` prints the *most severe* message ("model output may be
+   silently truncated") via raw `console.log`, while every sibling line uses the
+   compositor-safe `write`. The comment at line 755 explicitly warns this strands
+   output above the live overlay → the warning can be invisible exactly when it
+   matters. *Fix:* `console.log` → `write` (1 line).
+
+5. **[CONFIRMED] Autocomplete dropdown height miscounts CJK/emoji width.**
+   `terminal-compositor.render.ts:169` uses `stripAnsi(rowStr).length` (UTF-16
+   code units) to count soft-wraps, but `cols` is display columns. `displayWidth`
+   is already imported (line 12) but unused here. Wide-char candidates (CJK
+   filenames via `@`, emoji) under-count → ghost/clipped dropdown rows. *Fix:*
+   `displayWidth(stripAnsi(rowStr))`.
+
+---
+
+## Tier 2 — confirmed, slightly larger but still quick
+
+6. **[CONFIRMED] Ctrl+D and Ctrl+L are silent no-ops in the live REPL.**
+   The active compositor dispatch (`terminal-compositor.input-dispatch.ts`) binds
+   c/v/p/n/a/e/w/u/k/b/arrows but has no `d` or `l`; line 882 swallows all other
+   ctrl combos. Ctrl+D (EOF-to-exit on empty) and Ctrl+L (clear screen) are
+   strong muscle-memory. The legacy `input/reader.ts` had both. *Fix:* add Ctrl+L
+   → repaint, Ctrl+D → exit-on-empty / forward-delete.
+
+7. **[CONFIRMED] Home/End jump to buffer start/end, not line start/end.**
+   In multi-line input, `InputCore.moveHome` always goes to position 0
+   (`input-core.ts:220`) though `moveLineStart` exists (line 233). Every editor
+   does line-relative. *Fix:* route Home/End to `moveLineStart`/`moveLineEnd`.
+
+8. **[CONFIRMED] Context-window visibility is stale + late for AFK users.**
+   Status-bar context refresh is throttled to 15s (`turn-handler.ts:89`) and only
+   on `tool_result`; color thresholds first react at 50%/80% (`context-bar.ts`).
+   A user returning mid-turn can submit into a nearly-full window with no warning.
+   *Fix:* shorten interval to ~3s and/or fire a one-time notice crossing 90%.
+
+9. **[CONFIRMED] Elapsed clock hidden for first 5s.**
+   `ELAPSED_GRACE_MS = 5_000` (`terminal-compositor.types.ts:66`) — 1–4s turns
+   (the common case) show only a verb, no time signal. *Fix:* lower to ~2000ms.
+
+---
+
+## Tier 3 — reported (plausible, verify before fixing)
+
+- **[REPORTED] Error messages aren't actionable.** `unknown`-kind fallback dumps
+  raw `err.message` with `hint: undefined` (classifier ~165); `hook_blocked` names
+  the event but not how to unblock; autosave-failure warning gives no fix path
+  (`loop-iteration.ts:425`). *Fix:* add a generic hint + billing/doctor pointers.
+- **[REPORTED] `@file` token not matched when followed by punctuation** (`,`/`.`)
+  — `at-file-inject.ts:75` lookahead is `(?=\s|$)`; silent non-injection.
+- **[REPORTED] Inline `image`/`br` tokens render raw** (same `default: token.raw`
+  path in `renderInlineTokens`). Lower frequency in a terminal.
+- **[REPORTED] Multi-paragraph blockquote splits into two boxes** at interior
+  blank line (`markdown-stream-format.ts` `findBlockBoundary` has no blockquote
+  guard).
+- **[REPORTED] `formatPendingBuffer` double-wraps** the streaming overlay
+  (`markdown-stream-format.ts:58-61`) — transient flicker only.
+- **[REPORTED] Paste-placeholder atomic delete only at token boundary** — cursor
+  inside `[Pasted text …]` → char-by-char backspace.
+- **[REPORTED] No feedback at history boundary** (repeated ↑ at oldest entry).
+- **[REPORTED] ↑ on type-ahead queue is LIFO** (`pop()`); may be intentional
+  (undo mental model) — verify intent.
+
+## Discoverability polish (cheap, batchable)
+- `/help` never mentions `/keys`, `@`-file, `!cmd`, or Shift+Tab.
+- Welcome-banner hint omits `@`-file and Shift+Tab.
+- `/bgsub*`, `/worktree`, `/changelog`, `/stats`, `/allow-dir`, `/keys` lack a
+  `hint:` → never surface as loading tips.
+- Inventory: EXIST — /help /clear /compact /model /mcp /exit /quit /cost /resume
+  /history /keys. MISSING — /undo, /tasks (tip references it).
+
+## Not a bug (taste)
+- Spinner verbs are an intentional detective/noir theme ("Stalking", "Tailing",
+  "Wiretapping" — `constants.ts:5`). Only substantive note: the verb carries no
+  info about the active operation; could append the live tool name when known.
+
+## Not checked
+Non-TTY/capture-mode feedback; Telegram surface; mouse/IME; Ctrl+Z suspend;
+MCP connection-error surfacing; daemon error propagation; palette contrast in
+non-256-color terminals; full SIGWINCH repaint timing beyond committed tests.
+
+---
+
+# `/simplify` targets (complexity / duplication / dead code)
+
+Scoping probe over `src/cli` (~51k LOC non-test). No dead-code tooling
+(knip/ts-prune) is configured — adding one is itself a durable win.
+
+## A. Input layer — two parallel input stacks, manually kept in sync (HIGH value)
+The live REPL runs **two** input implementations: the between-turn reader
+(`input/reader.ts` 900 LOC → `input-box.ts`/`readWithAutocomplete`) and the
+persistent compositor (`terminal-compositor.input-dispatch.ts` 897 LOC). The
+compositor is a hand-maintained PORT of the reader — 10+ self-documented sync
+points:
+- `input-dispatch.ts:202` "Ported from reader.ts:380-430"
+- `input-dispatch.ts:355` "Ported from reader.ts:464-479"
+- `input-dispatch.ts:481` "Ported from reader.ts:697-732"
+- `input-dispatch.ts:523` "Mirrors reader.ts:734-748"
+- `input-dispatch.ts:635` "Mirrors reader.ts:677"
+- `input-dispatch.ts:663` "Ported from reader.ts:668"
+- `input-dispatch.ts:844` "matches reader.ts:769-772"
+- `input-surface.ts:251` "**parity bug** vs. reader.ts:329-330"
+- `input-surface.ts:452,460` more "same constraint / mirrors reader.ts"
+
+This manual mirroring is the root cause of the audit's divergence findings
+(Ctrl+D/Ctrl+L exist in reader.ts but not the compositor; Home/End drift).
+*Target:* `/simplify` clone + wrong-abstraction lenses over `src/cli/input/` +
+`reader.ts` + `input-box.ts` + `multi-line-reader.ts` +
+`terminal-compositor.input-dispatch.ts` + `terminal-compositor.autocomplete.ts`.
+Acting on the plan is a `/refactor` (both paths live; well-tested → verifiable).
+Effort: medium–large. **Highest leverage in the TUI.**
+
+## B. Mechanical dead code (knip, 100s run) — LOW effort, immediate
+- **`src/cli/interactive.ts` (273 LOC) is dead** — old readline REPL importing
+  `Anthropic` directly; nothing imports it (live entry is
+  `commands/interactive.ts` via `index.ts:51`). Clean deletion (+ its test).
+- **24 unused files** flagged (e.g. `utils/CircularBuffer.ts`, `utils/envUtils.ts`,
+  `utils/json.ts`, `utils/memoize.ts`, `telemetry/schemas.ts`, `web/index.ts`,
+  `telegram/example.ts`, `agent/facets/index.ts`). Verify each (some may be
+  entry/barrel false positives) then prune.
+- **84 unused exports** (60 in `src/cli`) — mix of real dead exports + barrel
+  re-exports; needs case-by-case triage.
+- **Dead devDeps: `jest`, `ts-jest`, `memfs`** (repo is vitest; grep hits are
+  runner-*detection* code, not usage). `tsx` is a false positive (used by
+  `pnpm dev`). Removing the 3 is safe.
+- *Meta-win:* wire `knip` into CI so this doesn't re-accumulate.
+
+## C. Skip for `/simplify` (deliberate, test-locked → low ROI / high risk)
+- `terminal-compositor.*` — 13 files / 4101 LOC + **20 test files**. Fragmentation
+  is intentional (each edge case isolated); behavior is locked by tests.
+- `tool-lane*` — 10 files / 3255 LOC, same story.
+Touching these risks regressions for cosmetic LOC reduction.

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -26,6 +26,7 @@ import { dequeueNext } from './queue-store.js';
 import { getQueueDir } from '../../paths.js';
 import type { ScheduledTask as CronTask } from 'node-cron';
 import { AgentSession } from '../session/agent-session.js';
+import { registerSurfaceSession } from '../session/register-surface-session.js';
 import { createDefaultHookRegistry } from '../default-hook-registry.js';
 import { loadHooksConfig } from '../hooks/config-loader.js';
 import { createDefaultTraceWriter } from '../trace/factory.js';
@@ -324,12 +325,14 @@ export class CronScheduler {
     let session: AgentSession | null = null;
     let memoryStore: MemoryStore | null = null;
     let mcpManager: McpManager | null = null;
+    let disposeRegistration: (() => void) | null = null;
     this.idleDetector.increment();
     try {
       const spawned = await this.spawnSession(task.taskId);
       session = spawned.session;
       memoryStore = spawned.memoryStore;
       mcpManager = spawned.mcpManager ?? null;
+      disposeRegistration = spawned.dispose;
       const response = await session.sendMessage(task.command);
       const responseText = redactInlineSecrets(response.content);
       const record: TelemetryRecord = {
@@ -358,6 +361,9 @@ export class CronScheduler {
           // already-closed sessions throw; ignore.
         }
       }
+      // Archive the cross-surface registry handle (frees its key) so the
+      // long-running daemon never accumulates handles. Best-effort.
+      disposeRegistration?.();
       if (mcpManager) {
         try {
           await mcpManager.disconnectAll();
@@ -472,6 +478,8 @@ export class CronScheduler {
     session: AgentSession;
     memoryStore: MemoryStore;
     mcpManager?: McpManager;
+    /** Archive the cross-surface registry handle. Called by runOnce on close. */
+    dispose: () => void;
   }> {
     // Derive a unique-per-tick sessionId (daemonTraceLabel appends a random
     // suffix, so each tick gets its own label) so hook commands receive a
@@ -597,7 +605,20 @@ export class CronScheduler {
       const session = this.options.sessionFactory
         ? this.options.sessionFactory(config)
         : new AgentSession(injectHotMemory(config));
-      return { session, memoryStore, ...(mcpManager !== undefined ? { mcpManager } : {}) };
+      // Step 7: register the daemon session in the cross-surface registry.
+      // Best-effort; dispose() (archive) is invoked by runOnce on session close
+      // so the long-running daemon never accumulates registry handles.
+      const registration = registerSurfaceSession(session, {
+        surface: 'daemon',
+        model: config.model,
+        cwd: agentCwd,
+      });
+      return {
+        session,
+        memoryStore,
+        dispose: registration.dispose,
+        ...(mcpManager !== undefined ? { mcpManager } : {}),
+      };
     } catch (err) {
       if (mcpManager) {
         await mcpManager.disconnectAll().catch(() => undefined);

--- a/src/agent/session/register-surface-session.test.ts
+++ b/src/agent/session/register-surface-session.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { registerSurfaceSession } from './register-surface-session.js';
+import { createSessionRegistry, type SessionRegistry } from './session-registry.js';
+
+/** Session with the SDK id known up front. */
+function fixedSession(sessionId?: string): { sessionId?: string; waitForInitialization(): Promise<void> } {
+  return { sessionId, async waitForInitialization() { /* immediate */ } };
+}
+
+/** Session whose SDK id only becomes available AFTER initialization (the late-bind case). */
+class LateSession {
+  private _id: string | undefined;
+  get sessionId(): string | undefined {
+    return this._id;
+  }
+  async waitForInitialization(): Promise<void> {
+    this._id = 'sdk-late';
+  }
+}
+
+describe('registerSurfaceSession', () => {
+  it('registers a handle with the surface/model and an up-front SDK id', () => {
+    const registry = createSessionRegistry();
+    const { handle } = registerSurfaceSession(fixedSession('sdk-1'), {
+      surface: 'cli',
+      model: 'sonnet',
+      sdkSessionId: 'sdk-1',
+      name: 'my-repl',
+      cwd: '/repo',
+      registry,
+    });
+    expect(handle?.surface).toBe('cli');
+    expect(handle?.model).toBe('sonnet');
+    expect(handle?.name).toBe('my-repl');
+    expect(handle?.cwd).toBe('/repo');
+    expect(handle?.sdkSessionId).toBe('sdk-1');
+    // Keyed on + reverse-lookupable by the SDK id.
+    expect(registry.resolve('cli', 'sdk-1')?.id).toBe(handle?.id);
+    expect(registry.getBySdkSessionId('sdk-1')?.id).toBe(handle?.id);
+  });
+
+  it('attaches the SDK id lazily once the session initializes', async () => {
+    const registry = createSessionRegistry();
+    const { handle } = registerSurfaceSession(new LateSession(), {
+      surface: 'daemon',
+      model: 'sonnet',
+      registry,
+    });
+    expect(handle?.sdkSessionId).toBeUndefined(); // not known at registration time
+    // Flush the waitForInitialization().then() microtask chain.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(registry.getBySdkSessionId('sdk-late')?.id).toBe(handle?.id);
+  });
+
+  it('uses a unique generated key per session when no SDK id is known', () => {
+    const registry = createSessionRegistry();
+    const a = registerSurfaceSession(fixedSession(), { surface: 'cli', model: 'sonnet', registry });
+    const b = registerSurfaceSession(fixedSession(), { surface: 'cli', model: 'sonnet', registry });
+    // Distinct handles, no key collision (both registered successfully).
+    expect(a.handle?.id).toBeDefined();
+    expect(b.handle?.id).toBeDefined();
+    expect(a.handle?.id).not.toBe(b.handle?.id);
+  });
+
+  it('dispose archives the handle and frees its key (idempotent)', () => {
+    const registry = createSessionRegistry();
+    const { handle, dispose } = registerSurfaceSession(fixedSession('sdk-x'), {
+      surface: 'cli',
+      model: 'sonnet',
+      sdkSessionId: 'sdk-x',
+      registry,
+    });
+    expect(registry.resolve('cli', 'sdk-x')?.id).toBe(handle?.id);
+    dispose();
+    expect(registry.resolve('cli', 'sdk-x')).toBeUndefined(); // key freed
+    expect(() => dispose()).not.toThrow(); // idempotent
+  });
+
+  it('is best-effort: a throwing registry never propagates', () => {
+    const throwing = {
+      create() {
+        throw new Error('boom');
+      },
+    } as unknown as SessionRegistry;
+    const reg = registerSurfaceSession(fixedSession(), { surface: 'cli', model: 'sonnet', registry: throwing });
+    expect(reg.handle).toBeUndefined();
+    expect(() => reg.dispose()).not.toThrow();
+  });
+});

--- a/src/agent/session/register-surface-session.ts
+++ b/src/agent/session/register-surface-session.ts
@@ -1,0 +1,123 @@
+/**
+ * Cross-surface session registration (step 7 of the session-registry effort).
+ *
+ * Registers a top-level session — the CLI REPL and the daemon scheduler — in the
+ * process-wide {@link sessionRegistry}, so they appear in the surface-agnostic
+ * index alongside the Telegram adapter's sessions. This closes the loop from the
+ * registry foundation to every user-facing surface.
+ *
+ * Invariant: registration and disposal are BEST-EFFORT — they must never throw
+ * into the caller. A registry hiccup can never break or abort a live session;
+ * the cross-surface index is auxiliary, not load-bearing.
+ *
+ * The SDK session id is late-bound (undefined until the provider emits it
+ * mid-first-turn — see session-registry.ts). When it is already known at
+ * registration (e.g. a CLI `--resume` target) it is passed up front and used as
+ * the binding key; otherwise it is attached asynchronously after
+ * `waitForInitialization()`, best-effort.
+ *
+ * Lifecycle: process-scoped surfaces (the CLI REPL — one process, one session)
+ * need no disposal: the in-memory registry dies with the process. Long-lived
+ * surfaces (the daemon — many sessions per process) MUST call `dispose()` on
+ * session close so the handle is archived and its binding key freed, preventing
+ * unbounded handle growth.
+ *
+ * @module agent/session/register-surface-session
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { AgentModelInput } from '../types.js';
+import {
+  sessionRegistry,
+  type SessionRegistry,
+  type SessionHandle,
+  type SessionSurface,
+} from './session-registry.js';
+
+/** Minimal session shape needed for late SDK-session-id attachment. The
+ *  init result is awaited but unused, so its type is intentionally `unknown`
+ *  (AgentSession resolves SessionMetadata; a stub may resolve void). */
+interface RegisterableSession {
+  readonly sessionId?: string;
+  waitForInitialization?(): Promise<unknown>;
+}
+
+export interface RegisterSurfaceSessionOptions {
+  surface: SessionSurface;
+  model: AgentModelInput;
+  cwd?: string;
+  name?: string;
+  /** SDK session id when already known (e.g. a --resume target); else attached lazily. */
+  sdkSessionId?: string;
+  /** Registry to register in. Defaults to the process-wide singleton (tests inject a fresh one). */
+  registry?: SessionRegistry;
+}
+
+export interface SurfaceSessionRegistration {
+  /** The created handle, or undefined when registration failed (best-effort). */
+  handle: SessionHandle | undefined;
+  /** Archive the handle (frees its binding key). Idempotent + best-effort — call on close for long-lived surfaces. */
+  dispose(): void;
+}
+
+const NOOP_REGISTRATION: SurfaceSessionRegistration = { handle: undefined, dispose: () => {} };
+
+/**
+ * Register a top-level session in the cross-surface registry. Returns the handle
+ * (or undefined on failure) plus a best-effort `dispose()` that archives it.
+ */
+export function registerSurfaceSession(
+  session: RegisterableSession,
+  opts: RegisterSurfaceSessionOptions,
+): SurfaceSessionRegistration {
+  const registry = opts.registry ?? sessionRegistry;
+
+  let handle: SessionHandle | undefined;
+  try {
+    handle = registry.create({
+      surface: opts.surface,
+      model: opts.model,
+      // Key on the SDK id when known (meaningful, reverse-lookupable); else a
+      // unique opaque key — CLI/daemon have no external routing key like a chatId.
+      key: opts.sdkSessionId ?? `${opts.surface}:${randomUUID()}`,
+      ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+      ...(opts.name !== undefined ? { name: opts.name } : {}),
+      ...(opts.sdkSessionId !== undefined ? { sdkSessionId: opts.sdkSessionId } : {}),
+    });
+  } catch {
+    // Registration is auxiliary; never surface a registry error to the session.
+    return NOOP_REGISTRATION;
+  }
+
+  const id = handle.id;
+
+  // Late-bind the SDK session id once the provider emits it (best-effort, non-blocking).
+  if (opts.sdkSessionId === undefined && typeof session.waitForInitialization === 'function') {
+    void session
+      .waitForInitialization()
+      .then(() => {
+        const sid = session.sessionId;
+        if (sid) {
+          try {
+            registry.attachSdkSessionId(id, sid);
+          } catch {
+            /* best-effort */
+          }
+        }
+      })
+      .catch(() => {
+        /* best-effort — init failure is handled by the session itself */
+      });
+  }
+
+  return {
+    handle,
+    dispose: () => {
+      try {
+        registry.archive(id);
+      } catch {
+        /* best-effort — already archived / unknown id */
+      }
+    },
+  };
+}

--- a/src/cli/commands/interactive/bootstrap.ts
+++ b/src/cli/commands/interactive/bootstrap.ts
@@ -5,6 +5,7 @@ import { makeReplElicitationHandler } from '../../elicitation-repl.js';
 import { AgentSession } from '../../../agent/session.js';
 import type { PermissionMode } from '../../../agent/types/sdk-types.js';
 import { unconfiguredSlotError } from '../../../agent/session/model-slots.js';
+import { registerSurfaceSession } from '../../../agent/session/register-surface-session.js';
 import { createDefaultHookRegistry } from '../../../agent/default-hook-registry.js';
 import { loadHooksConfig } from '../../../agent/hooks/config-loader.js';
 import { MemoryStore, injectHotMemory } from '../../../agent/memory/index.js';
@@ -688,6 +689,19 @@ export async function bootstrapSession(
   const session = buildAgentSession(sharedDeps);
   // Populate sessionRef (declared above deferredParent so the proxy works).
   sessionRef.current = session;
+
+  // Step 7: register this REPL session in the cross-surface session registry so
+  // it appears alongside Telegram/daemon sessions. Best-effort (never throws).
+  // Process-scoped — the in-memory registry dies with the REPL — so no dispose
+  // is wired here (unlike the long-running daemon, which archives on close).
+  registerSurfaceSession(session, {
+    surface: 'cli',
+    model: sharedDeps.model,
+    ...(sharedDeps.cwd !== undefined ? { cwd: sharedDeps.cwd } : {}),
+    ...(resumeTarget?.stored?.sessionId !== undefined
+      ? { sdkSessionId: resumeTarget.stored.sessionId }
+      : {}),
+  });
 
   // Witness layer: wire the subagent-success rollup so the rootManager's
   // foreground forks accumulate token/cost data into the parent session's

--- a/src/telegram/afk-two-way-roundtrip.test.ts
+++ b/src/telegram/afk-two-way-roundtrip.test.ts
@@ -46,8 +46,8 @@ function sleep(ms: number): Promise<void> {
  * two pending-resolver maps `makeTelegramElicitationHandler` populates.
  */
 function makeElicitStubs(chatId: number) {
-  const pendingElicitations = new Map<number, (text: string) => void>();
-  const ledgerOriginatedPendingChats = new Set<number>();
+  const pendingElicitations = new Map<string, (text: string) => void>();
+  const ledgerOriginatedPendingChats = new Set<string>();
   const sentMessages: string[] = [];
   const bot = {
     action: vi.fn(),
@@ -107,7 +107,7 @@ describe('two-way AFK round-trip (real daemon ↔ real REPL over one ledger)', (
 
     // The daemon tail should observe the elicitation and install the resolver.
     await sleep(300);
-    const resolver = pendingElicitations.get(chatId);
+    const resolver = pendingElicitations.get(String(chatId));
     expect(resolver).toBeDefined();
 
     // Operator answers on the phone. The daemon signs + writes back the response;

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -27,6 +27,7 @@ import { readPresenceFiles } from '../agent/awareness/presence.js';
 import { readSessionKey, signAbortRequest, freshChannelId } from '../agent/afk-channel.js';
 import { SessionLedgerWriter } from '../agent/session-ledger.js';
 import { splitLongMessage } from './formatter.js';
+import { routeFromCtx, sendOptions } from './route.js';
 
 /**
  * Bot configuration options
@@ -100,34 +101,34 @@ export class TelegramBot {
     this.bot.command('start', (ctx) => handleStart(ctx));
     this.bot.command('help', (ctx) => handleHelp(ctx, this.sessionManager));
     this.bot.command('clear', async (ctx) => {
-      const chatId = ctx.chat?.id;
-      if (!chatId) {
+      const route = routeFromCtx(ctx);
+      if (!route) {
         await ctx.reply(formatError('Could not identify chat'));
         return;
       }
-      const session = await this.sessionManager.getSession(chatId);
+      const session = await this.sessionManager.getSession(route);
       if (session.state !== 'idle') {
-        this.messageHandler.enqueueClear(chatId, ctx);
+        this.messageHandler.enqueueClear(route, ctx);
         await ctx.reply('Clear queued.');
       } else {
         await handleClear(ctx, this.sessionManager, this.registeredCommandChats, this.log.bind(this));
       }
     });
     this.bot.command('compact', async (ctx) => {
-      const chatId = ctx.chat?.id;
-      if (!chatId) {
+      const route = routeFromCtx(ctx);
+      if (!route) {
         await ctx.reply(formatError('Could not identify chat'));
         return;
       }
-      const session = await this.sessionManager.getSession(chatId);
+      const session = await this.sessionManager.getSession(route);
       if (session.state !== 'idle') {
-        this.messageHandler.enqueueCompact(chatId, ctx);
+        this.messageHandler.enqueueCompact(route, ctx);
         await ctx.reply('Compact queued.');
       } else {
         try {
           await handleCompact(ctx, this.sessionManager, this.log.bind(this));
         } finally {
-          this.messageHandler.drainQueue(chatId).catch(err => this.log('Drain error:', err));
+          this.messageHandler.drainQueue(route).catch(err => this.log('Drain error:', err));
         }
       }
     });
@@ -157,11 +158,15 @@ export class TelegramBot {
     // written by every top-level AgentSession (CLI REPL, daemon, one-shot),
     // so this is the CLI→Telegram half of cross-surface continuity.
     this.bot.command('watch', async (ctx) => {
-      const chatId = ctx.chat?.id;
-      if (!chatId) {
+      const route = routeFromCtx(ctx);
+      if (!route) {
         await ctx.reply(formatError('Could not identify chat'));
         return;
       }
+      const { chatId } = route;
+      // Pin the streamed watch output to the topic /watch was invoked from
+      // (General omits message_thread_id → default delivery, byte-identical).
+      const watchThreadOpts = sendOptions(route);
       const text = (ctx.message && 'text' in ctx.message ? ctx.message.text : '') ?? '';
       const arg = text.split(/\s+/).slice(1).join(' ').trim();
       try {
@@ -178,7 +183,7 @@ export class TelegramBot {
         }
         const send = async (msg: string): Promise<void> => {
           for (const part of splitLongMessage(msg)) {
-            await ctx.telegram.sendMessage(chatId, part);
+            await ctx.telegram.sendMessage(chatId, part, watchThreadOpts);
           }
         };
         this.watchManager.start(chatId, sessionId, send);
@@ -263,14 +268,16 @@ export class TelegramBot {
           ? (ctx.callbackQuery as { data: string }).data
           : '';
       const alias = data.replace('afk:m:', '') as AgentModelInput;
-      const chatId = ctx.chat?.id;
-      if (!chatId || !alias) return;
+      // routeFromCtx reads the thread id off callbackQuery.message (the §11 fix),
+      // so a /model tap inside a topic switches THAT topic's session, not General.
+      const route = routeFromCtx(ctx);
+      if (!route || !alias) return;
 
       // Validate alias is a known short alias (prevents arbitrary string injection)
       if (!(MODEL_ALIASES_HINT as readonly string[]).includes(alias)) return;
 
       try {
-        await this.sessionManager.switchModel(chatId, alias);
+        await this.sessionManager.switchModel(route, alias);
         const confirmText = formatModelSwitch(alias);
         await ctx.editMessageText(confirmText).catch(() => ctx.reply(confirmText));
       } catch (err) {
@@ -446,14 +453,14 @@ export class TelegramBot {
   }
 
   async handleClear(ctx: Context): Promise<void> {
-    const chatId = ctx.chat?.id;
-    if (!chatId) {
+    const route = routeFromCtx(ctx);
+    if (!route) {
       await ctx.reply(formatError('Could not identify chat'));
       return;
     }
-    const session = await this.sessionManager.getSession(chatId);
+    const session = await this.sessionManager.getSession(route);
     if (session.state !== 'idle') {
-      this.messageHandler.enqueueClear(chatId, ctx);
+      this.messageHandler.enqueueClear(route, ctx);
       await ctx.reply('Clear queued.');
     } else {
       return handleClear(ctx, this.sessionManager, this.registeredCommandChats, this.log.bind(this));

--- a/src/telegram/elicitation-handler.test.ts
+++ b/src/telegram/elicitation-handler.test.ts
@@ -86,10 +86,14 @@ interface MockCallbackCtx {
 // Test factory helpers
 // ---------------------------------------------------------------------------
 
-/** Build a minimal mock MessageHandler with a real pendingElicitations map. */
+/**
+ * Build a minimal mock MessageHandler with a real pendingElicitations map.
+ * The map is keyed by routeKey (string). For the General route these tests use
+ * (CHAT_ID with no topic), the key is String(CHAT_ID) — see ROUTE_KEY below.
+ */
 function makeMockMessageHandler() {
   return {
-    pendingElicitations: new Map<number, (text: string) => void>(),
+    pendingElicitations: new Map<string, (text: string) => void>(),
   };
 }
 
@@ -101,6 +105,8 @@ function makeMockBot() {
 }
 
 const CHAT_ID = 12345;
+/** routeKey for the General route used across these tests (String(CHAT_ID)). */
+const ROUTE_KEY = String(CHAT_ID);
 
 /** Build an AbortController wired with a controllable signal. */
 function makeAbort() {
@@ -207,10 +213,12 @@ function simulateTextReply(
   chatId: number,
   text: string,
 ) {
-  const resolver = messageHandler.pendingElicitations.get(chatId);
+  // Map is keyed by routeKey; a bare chatId here is a General route → String(chatId).
+  const rk = String(chatId);
+  const resolver = messageHandler.pendingElicitations.get(rk);
   if (!resolver) throw new Error(`No pending elicitation for chat ${chatId}`);
   // MessageHandler.handle() deletes the entry before calling the resolver.
-  messageHandler.pendingElicitations.delete(chatId);
+  messageHandler.pendingElicitations.delete(rk);
   resolver(text);
 }
 
@@ -319,7 +327,7 @@ describe('H2: abort-mid-question (text wait)', () => {
     // Allow the handler to register the pending elicitation
     await Promise.resolve();
 
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // Now abort
     ac.abort();
@@ -341,7 +349,7 @@ describe('H2: abort-mid-question (text wait)', () => {
     ac.abort();
     await resultPromise;
 
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(false);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(false);
   });
 
   it('abort during number wait resolves with { action: "decline" }', async () => {
@@ -377,7 +385,7 @@ describe('H2: number type — re-prompt on invalid then accept on valid', () => 
     // Allow handler to register and send initial prompt
     await Promise.resolve();
 
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // Send invalid input
     simulateTextReply(messageHandler, CHAT_ID, 'not-a-number');
@@ -389,10 +397,11 @@ describe('H2: number type — re-prompt on invalid then accept on valid', () => 
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/valid number/i),
+      {},
     );
 
     // Handler re-registered a new interceptor
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // Now send valid number
     simulateTextReply(messageHandler, CHAT_ID, '42');
@@ -417,8 +426,9 @@ describe('H2: number type — re-prompt on invalid then accept on valid', () => 
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/enter a number/i),
+      {},
     );
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // Clean up: cancel so the promise settles
     simulateTextReply(messageHandler, CHAT_ID, ':cancel');
@@ -442,8 +452,9 @@ describe('H2: number type — re-prompt on invalid then accept on valid', () => 
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/\u2265 10|>=\s*10|≥\s*10/),
+      {},
     );
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // Clean up
     simulateTextReply(messageHandler, CHAT_ID, ':cancel');
@@ -466,6 +477,7 @@ describe('H2: number type — re-prompt on invalid then accept on valid', () => 
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/\u2264 100|<=\s*100|≤\s*100/),
+      {},
     );
 
     simulateTextReply(messageHandler, CHAT_ID, ':cancel');
@@ -641,7 +653,7 @@ describe('H2: sendMessage failure → decline', () => {
     const ac = makeAbort();
     await handler(textRequest(), { signal: ac.signal });
 
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(false);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(false);
   });
 
   it('confirm type: sendMessage failure resolves { action: "decline" }', async () => {
@@ -789,7 +801,7 @@ describe('H1: abort race in re-prompt path', () => {
     // Allow the handler to register the initial interceptor
     await Promise.resolve();
 
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // Trigger invalid input → enters the re-prompt branch → sets resolved=false
     // → fires sendMessage (which aborts inside mock) → guard fires → no .set()
@@ -801,7 +813,7 @@ describe('H1: abort race in re-prompt path', () => {
 
     // The H1 guard must have prevented re-registration
     expect(repromptSendCount).toBeGreaterThanOrEqual(1);
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(false);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(false);
 
     // Give the promise a chance to settle (it may or may not, depending on
     // microtask ordering; we just verify it does not hang the test).
@@ -835,7 +847,7 @@ describe('H1: abort race in re-prompt path', () => {
 
     await Promise.resolve();
 
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // '1abc' is an invalid multi_choice index → re-prompt path → H1 race
     simulateTextReply(messageHandler, CHAT_ID, '1abc');
@@ -844,7 +856,7 @@ describe('H1: abort race in re-prompt path', () => {
     await Promise.resolve();
 
     expect(repromptSendCount).toBeGreaterThanOrEqual(1);
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(false);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(false);
 
     await Promise.race([
       resultPromise,
@@ -877,8 +889,9 @@ describe('M2/M3: multi_choice — invalid index format → re-prompt', () => {
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/invalid selection/i),
+      {},
     );
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     // Clean up
     simulateTextReply(messageHandler, CHAT_ID, ':cancel');
@@ -905,6 +918,7 @@ describe('M2/M3: multi_choice — invalid index format → re-prompt', () => {
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/invalid selection/i),
+      {},
     );
 
     simulateTextReply(messageHandler, CHAT_ID, ':cancel');
@@ -930,6 +944,7 @@ describe('M2/M3: multi_choice — invalid index format → re-prompt', () => {
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/invalid selection/i),
+      {},
     );
 
     simulateTextReply(messageHandler, CHAT_ID, ':cancel');
@@ -1086,8 +1101,9 @@ describe('text type — :cancel and allow_skip', () => {
     expect(sendMessage).toHaveBeenCalledWith(
       CHAT_ID,
       expect.stringMatching(/please enter a response|:cancel/i),
+      {},
     );
-    expect(messageHandler.pendingElicitations.has(CHAT_ID)).toBe(true);
+    expect(messageHandler.pendingElicitations.has(ROUTE_KEY)).toBe(true);
 
     simulateTextReply(messageHandler, CHAT_ID, ':cancel');
     const result = await resultPromise;
@@ -1173,7 +1189,7 @@ describe('resolved guard — no double-resolve', () => {
     await Promise.resolve();
 
     // Pull the resolver directly to simulate simultaneous delivery
-    const resolver = messageHandler.pendingElicitations.get(CHAT_ID)!;
+    const resolver = messageHandler.pendingElicitations.get(ROUTE_KEY)!;
     messageHandler.pendingElicitations.delete(CHAT_ID);
 
     // Call resolver twice (race simulation)

--- a/src/telegram/elicitation-handler.ts
+++ b/src/telegram/elicitation-handler.ts
@@ -23,6 +23,7 @@ import { Markup, Telegraf } from 'telegraf';
 import type { ElicitationHandler } from '../agent/elicitation-router.js';
 import type { ElicitationRequest, ElicitationResult } from '../agent/types/sdk-types.js';
 import type { MessageHandler } from './handlers/message.js';
+import { type TelegramRoute, routeKey, sendOptions } from './route.js';
 import {
   buildElicitationCallback,
   parseElicitationCallback,
@@ -70,33 +71,43 @@ function truncateLabel(label: string, maxBytes = 64): string {
  *
  * @param messageHandler - The message handler instance (for `pendingElicitations`).
  * @param bot - The Telegraf bot instance (for `bot.action` registration).
- * @param chatId - The Telegram chat ID to send questions to.
+ * @param target - The route to send questions to, or a bare chatId (General
+ *   topic). The route's key isolates the pending-elicitation entry from other
+ *   topics, and `sendOptions(route)` pins prompts/keyboards to the topic thread.
  * @param opts.ledgerOriginated - When true, every text-intercept entry also
- *   registers the chatId in `messageHandler.ledgerOriginatedPendingChats` so
+ *   registers the route in `messageHandler.ledgerOriginatedPendingChats` so
  *   the message handler's idle-guard fires the resolver even with no active
- *   AgentSession for this chat (the REPL session runs in a separate process).
+ *   AgentSession for this route (the REPL session runs in a separate process).
  */
 export function makeTelegramElicitationHandler(
   messageHandler: MessageHandler,
   bot: Telegraf,
-  chatId: number,
+  target: TelegramRoute | number,
   opts?: { ledgerOriginated?: boolean },
 ): ElicitationHandler {
+  // Normalize: a bare chatId is that chat's General topic. `key` isolates the
+  // pending entry per route (leak fix); `chatId` + `threadOpts` drive sends so
+  // a topic's prompt lands in the topic, not General.
+  const route: TelegramRoute = typeof target === 'number' ? { chatId: target } : target;
+  const chatId = route.chatId;
+  const key = routeKey(route);
+  const threadOpts = sendOptions(route);
+
   // Contract: ledgerOriginated elicitations bypass the session-state guard in
   // MessageHandler.handle() — the resolver fires on the next text reply
-  // regardless of whether an AgentSession exists for this chat.
+  // regardless of whether an AgentSession exists for this route.
   const ledgerOriginated = opts?.ledgerOriginated ?? false;
 
   // Helpers that keep pendingElicitations and ledgerOriginatedPendingChats in
   // sync. All text-intercept registrations and deletions must use these instead
   // of touching the maps directly, so the bypass set never drifts from reality.
   function setPending(resolver: (text: string) => void): void {
-    messageHandler.pendingElicitations.set(chatId, resolver);
-    if (ledgerOriginated) messageHandler.ledgerOriginatedPendingChats.add(chatId);
+    messageHandler.pendingElicitations.set(key, resolver);
+    if (ledgerOriginated) messageHandler.ledgerOriginatedPendingChats.add(key);
   }
   function deletePending(): void {
-    messageHandler.pendingElicitations.delete(chatId);
-    if (ledgerOriginated) messageHandler.ledgerOriginatedPendingChats.delete(chatId);
+    messageHandler.pendingElicitations.delete(key);
+    if (ledgerOriginated) messageHandler.ledgerOriginatedPendingChats.delete(key);
   }
   /**
    * H3: Single dispatch table for confirm/choice elicitations.
@@ -213,7 +224,7 @@ export function makeTelegramElicitationHandler(
           if (choiceIndex === CUSTOM_ENTRY_SENTINEL_INDEX) {
             resolved = false; // re-arm for the text intercept
             inCustomTextWait = true;
-            bot.telegram.sendMessage(chatId, '✍️ Please type your custom answer:').catch(() => {});
+            bot.telegram.sendMessage(chatId, '✍️ Please type your custom answer:', threadOpts).catch(() => {});
             if (options.signal.aborted) { resolve({ action: 'decline' }); return; }
             setPending((text: string) => {
               if (resolved) return;
@@ -242,9 +253,10 @@ export function makeTelegramElicitationHandler(
           }
         });
 
-        // Send the keyboard message
+        // Send the keyboard message (pinned to the route's topic thread).
         bot.telegram.sendMessage(chatId, displayText, {
           parse_mode: 'HTML',
+          ...threadOpts,
           reply_markup: Markup.inlineKeyboard(buttons).reply_markup,
         }).catch(() => {
           if (!resolved) {
@@ -266,8 +278,8 @@ export function makeTelegramElicitationHandler(
         resolved = true;
         // M6: log abandoned-entry cleanup so diagnostic traces surface if the
         // re-prompt race (H1) or an unanticipated path leaves a stale entry.
-        if (messageHandler.pendingElicitations.has(chatId)) {
-          console.warn('[elicitation-handler] abort: cleaning up stale pendingElicitation for chatId', chatId);
+        if (messageHandler.pendingElicitations.has(key)) {
+          console.warn('[elicitation-handler] abort: cleaning up stale pendingElicitation for route', key);
         }
         deletePending();
         resolve({ action: 'decline' });
@@ -301,7 +313,7 @@ export function makeTelegramElicitationHandler(
           if (trimmed === '' && !request.allowSkip) {
             resolved = false;
             isFirstPrompt = false;
-            bot.telegram.sendMessage(chatId, '❌ Please enter a number.').catch(() => {});
+            bot.telegram.sendMessage(chatId, '❌ Please enter a number.', threadOpts).catch(() => {});
             // H1: abort guard — if abort fired between `resolved = false` and `.set()`,
             // the promise is already settled; skip re-registration to avoid a dangling intercept.
             if (options.signal.aborted) return;
@@ -315,7 +327,7 @@ export function makeTelegramElicitationHandler(
             // Re-prompt: re-register and ask again
             resolved = false;
             isFirstPrompt = false;
-            bot.telegram.sendMessage(chatId, '❌ Please enter a valid number.').catch(() => {});
+            bot.telegram.sendMessage(chatId, '❌ Please enter a valid number.', threadOpts).catch(() => {});
             // H1: abort guard before re-registration.
             if (options.signal.aborted) return;
             setPending(handleText);
@@ -326,7 +338,7 @@ export function makeTelegramElicitationHandler(
           if (request.min !== undefined && n < request.min) {
             resolved = false;
             isFirstPrompt = false;
-            bot.telegram.sendMessage(chatId, `❌ Value must be ≥ ${request.min}.`).catch(() => {});
+            bot.telegram.sendMessage(chatId, `❌ Value must be ≥ ${request.min}.`, threadOpts).catch(() => {});
             // H1: abort guard before re-registration.
             if (options.signal.aborted) return;
             setPending(handleText);
@@ -337,7 +349,7 @@ export function makeTelegramElicitationHandler(
           if (request.max !== undefined && n > request.max) {
             resolved = false;
             isFirstPrompt = false;
-            bot.telegram.sendMessage(chatId, `❌ Value must be ≤ ${request.max}.`).catch(() => {});
+            bot.telegram.sendMessage(chatId, `❌ Value must be ≤ ${request.max}.`, threadOpts).catch(() => {});
             // H1: abort guard before re-registration.
             if (options.signal.aborted) return;
             setPending(handleText);
@@ -373,6 +385,7 @@ export function makeTelegramElicitationHandler(
               bot.telegram.sendMessage(
                 chatId,
                 `❌ Invalid selection. Enter comma-separated numbers between 1 and ${choices.length}.`,
+                threadOpts,
               ).catch(() => {});
               // H1: abort guard before re-registration.
               if (options.signal.aborted) return;
@@ -391,7 +404,7 @@ export function makeTelegramElicitationHandler(
         if (trimmed === '' && !request.allowSkip) {
           resolved = false;
           isFirstPrompt = false;
-          bot.telegram.sendMessage(chatId, '❌ Please enter a response (or type :cancel to skip).').catch(() => {});
+          bot.telegram.sendMessage(chatId, '❌ Please enter a response (or type :cancel to skip).', threadOpts).catch(() => {});
           // H1: abort guard before re-registration.
           if (options.signal.aborted) return;
           setPending(handleText);
@@ -433,13 +446,13 @@ export function makeTelegramElicitationHandler(
         }
       }
 
-      bot.telegram.sendMessage(chatId, promptText, { parse_mode: 'HTML' }).catch(() => {
+      bot.telegram.sendMessage(chatId, promptText, { parse_mode: 'HTML', ...threadOpts }).catch(() => {
         if (!resolved) {
           resolved = true;
           options.signal.removeEventListener('abort', onAbort);
           // M6: log sendMessage failure so callers can diagnose silent declines
           // without a visible error (e.g., MarkdownV2 parse failure, network error).
-          console.warn('[elicitation-handler] sendMessage failed; declining elicitation for chatId', chatId);
+          console.warn('[elicitation-handler] sendMessage failed; declining elicitation for route', key);
           deletePending();
           resolve({ action: 'decline' });
         }

--- a/src/telegram/handlers/commands.ts
+++ b/src/telegram/handlers/commands.ts
@@ -26,6 +26,7 @@ import { slotForInput, unconfiguredSlotError } from '../../agent/session/model-s
 import type { AgentModelInput } from '../../agent/types.js';
 import { slugifySessionName } from '../../cli/session-name.js';
 import { formatResumeCommand } from '../../cli/resume-command.js';
+import { routeFromCtx } from '../route.js';
 
 type LogFn = (...args: unknown[]) => void;
 
@@ -41,15 +42,16 @@ export async function handleClear(
   registeredCommandChats: Set<number>,
   log: LogFn
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
 
   try {
-    await sessionManager.resetSession(chatId);
-    registeredCommandChats.delete(chatId);
+    await sessionManager.resetSession(route);
+    // Command re-registration is chat-scoped (setMyCommands per chat).
+    registeredCommandChats.delete(route.chatId);
     await ctx.reply(formatClear());
   } catch (error) {
     log('Clear error:', error);
@@ -67,14 +69,14 @@ export async function handleCompact(
   sessionManager: SessionManager,
   log: LogFn
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
 
   try {
-    const session = await sessionManager.getSession(chatId);
+    const session = await sessionManager.getSession(route);
     const hookRegistry = session.hookRegistry;
     // Keep the "typing…" indicator alive across the PreCompact hook and the
     // model-call compaction, which can outlast the ~5s one-shot expiry.
@@ -120,8 +122,8 @@ export async function handleModelSwitch(
   sessionManager: SessionManager,
   log: LogFn
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
@@ -130,7 +132,7 @@ export async function handleModelSwitch(
   const args = text.split(/\s+/).slice(1);
 
   if (args.length === 0) {
-    const currentModel = sessionManager.getModel(chatId);
+    const currentModel = sessionManager.getModel(route);
     const buttons = MODEL_ALIASES_HINT.map(alias => [
       Markup.button.callback(alias, `afk:m:${alias}`),
     ]);
@@ -172,7 +174,7 @@ export async function handleModelSwitch(
   }
 
   try {
-    await sessionManager.switchModel(chatId, model);
+    await sessionManager.switchModel(route, model);
     await ctx.reply(formatModelSwitch(model));
   } catch (error) {
     log('Model switch error:', error);
@@ -221,8 +223,8 @@ export async function handleCwd(
   sessionManager: SessionManager,
   log: LogFn,
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
@@ -237,7 +239,7 @@ export async function handleCwd(
   // which would orphan a streaming turn. Match the switchModel precedent
   // (unconditional close); the user can re-issue if they hit a race.
   if (args.length === 0) {
-    const currentCwd = sessionManager.getCwd(chatId);
+    const currentCwd = sessionManager.getCwd(route);
     await ctx.reply(formatCwdCurrent(currentCwd));
     return;
   }
@@ -248,7 +250,7 @@ export async function handleCwd(
     return;
   }
 
-  const base = sessionManager.getCwd(chatId) ?? process.cwd();
+  const base = sessionManager.getCwd(route) ?? process.cwd();
   const resolved = resolveCwdInput(pathArg, base);
 
   // Validate BEFORE persisting — a stat failure here means the next
@@ -274,7 +276,7 @@ export async function handleCwd(
   }
 
   try {
-    await sessionManager.setCwd(chatId, resolved);
+    await sessionManager.setCwd(route, resolved);
     await ctx.reply(formatCwdSwitch(resolved));
   } catch (error) {
     log('Cwd switch error:', error);
@@ -303,8 +305,8 @@ export async function handleName(
   sessionManager: SessionManager,
   log: LogFn,
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
@@ -314,7 +316,7 @@ export async function handleName(
 
   // No arg → report the current name.
   if (!raw) {
-    await ctx.reply(formatNameCurrent(sessionManager.getSessionName(chatId)));
+    await ctx.reply(formatNameCurrent(sessionManager.getSessionName(route)));
     return;
   }
 
@@ -325,9 +327,9 @@ export async function handleName(
   }
 
   try {
-    const { persisted } = sessionManager.setSessionName(chatId, slug);
+    const { persisted } = sessionManager.setSessionName(route, slug);
     const resumeCommand = persisted
-      ? formatResumeCommand(slug, sessionManager.getModel(chatId))
+      ? formatResumeCommand(slug, sessionManager.getModel(route))
       : undefined;
     await ctx.reply(formatNameSet(slug, resumeCommand));
   } catch (error) {

--- a/src/telegram/handlers/message-compaction.test.ts
+++ b/src/telegram/handlers/message-compaction.test.ts
@@ -166,7 +166,7 @@ describe('MessageHandler — compaction queuing', () => {
       expect(mockStreamResponse).not.toHaveBeenCalled();
 
       // Now drain (simulates what happens after compact() finishes)
-      await handler.drainQueue(chatId);
+      await handler.drainQueue({ chatId });
 
       expect(mockStreamResponse).toHaveBeenCalledOnce();
       expect(mockStreamResponse).toHaveBeenCalledWith(
@@ -199,10 +199,10 @@ describe('MessageHandler — compaction queuing', () => {
       );
 
       const { ctx } = makeCompactCtx(chatId);
-      handler.enqueueCompact(chatId, ctx);
+      handler.enqueueCompact({ chatId }, ctx);
 
       // Drain the queue — processCompactDirect should call session.compact()
-      await handler.drainQueue(chatId);
+      await handler.drainQueue({ chatId });
 
       expect(idleSession.compact).toHaveBeenCalledOnce();
     });
@@ -239,16 +239,16 @@ describe('MessageHandler — compaction queuing', () => {
       );
 
       const { ctx, replies } = makeCompactCtx(chatId);
-      handler.enqueueCompact(chatId, ctx);
-      await handler.drainQueue(chatId);
+      handler.enqueueCompact({ chatId }, ctx);
+      await handler.drainQueue({ chatId });
 
       // compact() was attempted once and returned session-busy
       expect(busySession.compact).toHaveBeenCalledOnce();
       // No misleading no-op reply surfaced to the user
       expect(replies).toHaveLength(0);
       // The compact item is still queued, awaiting the next drain
-      expect((handler as any).messageQueues.get(chatId)).toHaveLength(1);
-      expect((handler as any).messageQueues.get(chatId)[0].type).toBe('compact');
+      expect((handler as any).messageQueues.get(String(chatId))).toHaveLength(1);
+      expect((handler as any).messageQueues.get(String(chatId))[0].type).toBe('compact');
     });
 
     it('completes the re-enqueued compact on a subsequent drain once the session is idle', async () => {
@@ -280,19 +280,19 @@ describe('MessageHandler — compaction queuing', () => {
       );
 
       const { ctx, replies } = makeCompactCtx(chatId);
-      handler.enqueueCompact(chatId, ctx);
+      handler.enqueueCompact({ chatId }, ctx);
 
       // First drain: busy → re-enqueue, no reply.
-      await handler.drainQueue(chatId);
+      await handler.drainQueue({ chatId });
       expect(replies).toHaveLength(0);
 
       // Second drain (session now idle): compact succeeds, success reply sent.
-      await handler.drainQueue(chatId);
+      await handler.drainQueue({ chatId });
       expect(session.compact).toHaveBeenCalledTimes(2);
       expect(replies).toHaveLength(1);
       expect(replies[0]).toContain('📦');
       // Queue is now empty.
-      expect((handler as any).messageQueues.get(chatId) ?? []).toHaveLength(0);
+      expect((handler as any).messageQueues.get(String(chatId)) ?? []).toHaveLength(0);
     });
   });
 });

--- a/src/telegram/handlers/message.test.ts
+++ b/src/telegram/handlers/message.test.ts
@@ -114,7 +114,7 @@ describe('MessageHandler.pendingElicitations intercept', () => {
     const resolvedValues: string[] = [];
 
     // Pre-seed the intercept
-    handler.pendingElicitations.set(chatId, (text) => {
+    handler.pendingElicitations.set(String(chatId), (text) => {
       resolvedValues.push(text);
     });
 
@@ -124,7 +124,7 @@ describe('MessageHandler.pendingElicitations intercept', () => {
     // Resolver must have been called with the message text
     expect(resolvedValues).toEqual(['my answer']);
     // Entry must be deleted after consumption
-    expect(handler.pendingElicitations.has(chatId)).toBe(false);
+    expect(handler.pendingElicitations.has(String(chatId))).toBe(false);
     // streamResponse (processOne) must NOT have been called
     expect(mockStreamResponse).not.toHaveBeenCalled();
     // ctx.reply must NOT have been called (no "Message queued" etc.)
@@ -138,7 +138,7 @@ describe('MessageHandler.pendingElicitations intercept', () => {
 
     // streamResponse may or may not be called depending on session state mocking,
     // but pendingElicitations must not have been modified
-    expect(handler.pendingElicitations.has(chatId)).toBe(false);
+    expect(handler.pendingElicitations.has(String(chatId))).toBe(false);
   });
 
   it('pendingElicitations is a public Map initialized to empty', () => {
@@ -150,13 +150,13 @@ describe('MessageHandler.pendingElicitations intercept', () => {
     const chatId = 7;
     let callCount = 0;
 
-    handler.pendingElicitations.set(chatId, () => { callCount += 1; });
+    handler.pendingElicitations.set(String(chatId), () => { callCount += 1; });
 
     // First message — consumed by resolver
     const { ctx: ctx1 } = makeMessageCtx(chatId, 'first');
     await handler.handle(ctx1);
     expect(callCount).toBe(1);
-    expect(handler.pendingElicitations.has(chatId)).toBe(false);
+    expect(handler.pendingElicitations.has(String(chatId))).toBe(false);
 
     // Second message — NOT intercepted (normal flow)
     const { ctx: ctx2 } = makeMessageCtx(chatId, 'second');
@@ -237,8 +237,8 @@ describe('MessageHandler.ledgerOriginatedPendingChats bypass (C3)', () => {
     const resolved: string[] = [];
 
     // Pre-seed as ledger-originated (as makeTelegramElicitationHandler would do).
-    handler.pendingElicitations.set(chatId, (text) => resolved.push(text));
-    handler.ledgerOriginatedPendingChats.add(chatId);
+    handler.pendingElicitations.set(String(chatId), (text) => resolved.push(text));
+    handler.ledgerOriginatedPendingChats.add(String(chatId));
 
     const { ctx } = makeMessageCtx(chatId, 'ledger answer');
     await handler.handle(ctx);
@@ -246,8 +246,8 @@ describe('MessageHandler.ledgerOriginatedPendingChats bypass (C3)', () => {
     // Resolver must fire even though there is no active session.
     expect(resolved).toEqual(['ledger answer']);
     // Both maps must be cleaned up after consumption.
-    expect(handler.pendingElicitations.has(chatId)).toBe(false);
-    expect(handler.ledgerOriginatedPendingChats.has(chatId)).toBe(false);
+    expect(handler.pendingElicitations.has(String(chatId))).toBe(false);
+    expect(handler.ledgerOriginatedPendingChats.has(String(chatId))).toBe(false);
   });
 
   it('fires a ledger-originated pending resolver even when session is idle', async () => {
@@ -272,15 +272,15 @@ describe('MessageHandler.ledgerOriginatedPendingChats bypass (C3)', () => {
     const chatId = 56;
     const resolved: string[] = [];
 
-    handler.pendingElicitations.set(chatId, (text) => resolved.push(text));
-    handler.ledgerOriginatedPendingChats.add(chatId);
+    handler.pendingElicitations.set(String(chatId), (text) => resolved.push(text));
+    handler.ledgerOriginatedPendingChats.add(String(chatId));
 
     const { ctx } = makeMessageCtx(chatId, 'idle session answer');
     await handler.handle(ctx);
 
     expect(resolved).toEqual(['idle session answer']);
-    expect(handler.pendingElicitations.has(chatId)).toBe(false);
-    expect(handler.ledgerOriginatedPendingChats.has(chatId)).toBe(false);
+    expect(handler.pendingElicitations.has(String(chatId))).toBe(false);
+    expect(handler.ledgerOriginatedPendingChats.has(String(chatId))).toBe(false);
   });
 
   it('still drops a genuinely stale session-local entry (no ledger-origin flag) when session is idle', async () => {
@@ -306,7 +306,7 @@ describe('MessageHandler.ledgerOriginatedPendingChats bypass (C3)', () => {
     let resolverCalled = false;
 
     // Pre-seed WITHOUT the ledger-origin flag (session-local, now stale).
-    handler.pendingElicitations.set(chatId, () => { resolverCalled = true; });
+    handler.pendingElicitations.set(String(chatId), () => { resolverCalled = true; });
     // ledgerOriginatedPendingChats NOT set — this is the stale-session path.
 
     const { ctx } = makeMessageCtx(chatId, 'stale reply');
@@ -315,7 +315,7 @@ describe('MessageHandler.ledgerOriginatedPendingChats bypass (C3)', () => {
     // Resolver must NOT fire — the stale-session guard must drop it.
     expect(resolverCalled).toBe(false);
     // The stale entry must be cleaned up.
-    expect(handler.pendingElicitations.has(chatId)).toBe(false);
+    expect(handler.pendingElicitations.has(String(chatId))).toBe(false);
   });
 
   it('ledgerOriginatedPendingChats is a public Set initialized to empty', () => {

--- a/src/telegram/handlers/message.ts
+++ b/src/telegram/handlers/message.ts
@@ -12,6 +12,7 @@ import { withTypingIndicator } from '../typing-indicator.js';
 import { StreamTimeoutError } from '../stream-timeout-error.js';
 import { registerChatCommands } from './registration.js';
 import { HookBlockedError } from '../../utils/errors.js';
+import { type TelegramRoute, routeFromCtx, routeKey } from '../route.js';
 import type { ContentBlockParam } from '@anthropic-ai/sdk/resources';
 
 type QueueItem =
@@ -110,28 +111,40 @@ export class MessageHandler {
   private static readonly MAX_QUEUE_DEPTH = 5;
 
   private sessionManager: SessionManager;
-  private messageQueues = new Map<number, Array<QueueItem>>();
+  /**
+   * Per-ROUTE message queues. Keyed by `routeKey(route)` — General / topics-off
+   * normalizes to `String(chatId)` (byte-identical to the pre-topics key), a
+   * real topic to `${chatId}:${threadId}`. This is a leak-critical map: a
+   * message queued in topic A must never drain into topic B's session.
+   */
+  private messageQueues = new Map<string, Array<QueueItem>>();
+  /** Chats (NOT routes) with dynamic commands registered — Telegram scopes setMyCommands per chat, not per topic. */
   private registeredCommandChats: Set<number>;
   private log: LogFn;
   private bot: Telegraf;
 
   /**
    * Active ask_question elicitations waiting for a text reply.
-   * Keys are chat IDs; values are resolver functions that consume
-   * the next plain-text message from that chat.
+   * Keys are ROUTE keys (`routeKey(route)`); values are resolver functions
+   * that consume the next plain-text message from that route.
+   *
+   * Invariant (leak fix): keying by route — not by chatId — is what isolates
+   * topics. An elicitation raised in topic A registers under A's routeKey and
+   * is resolved ONLY by a message whose route also resolves to A; a message in
+   * topic B (or General) resolves to a different key and cannot consume it.
    *
    * Answer consumed by active ask_question elicitation — never reaches
    * session message queue.
    */
-  public pendingElicitations = new Map<number, (text: string) => void>();
+  public pendingElicitations = new Map<string, (text: string) => void>();
 
   /**
-   * Chat IDs whose active pendingElicitations entry was registered by a
+   * Route keys whose active pendingElicitations entry was registered by a
    * ledger-originated (daemon-watch) elicitation rather than a session-local
    * ask_question call.
    *
    * Invariant: the idle-guard in handle() must fire the resolver for these
-   * chats even when no AgentSession is active for the chat (the REPL session
+   * routes even when no AgentSession is active for the route (the REPL session
    * lives in a different process). Without this bypass, every phone reply to a
    * ledger-originated elicitation is silently dropped because the guard sees
    * no in-flight session and treats the pending entry as stale.
@@ -141,7 +154,7 @@ export class MessageHandler {
    * the watch loop), and deleted when the resolver fires or is aborted — exactly
    * mirroring the pendingElicitations Map lifecycle.
    */
-  public ledgerOriginatedPendingChats = new Set<number>();
+  public ledgerOriginatedPendingChats = new Set<string>();
 
   constructor(
     bot: Telegraf,
@@ -166,11 +179,12 @@ export class MessageHandler {
    * implemented here.
    */
   async handlePhoto(ctx: Context): Promise<void> {
-    const chatId = ctx.chat?.id;
+    const route = routeFromCtx(ctx);
+    const chatId = route?.chatId;
     const msg = ctx.message as Message.PhotoMessage | undefined;
     const photo = msg?.photo;
 
-    if (!chatId || !photo?.length) {
+    if (!route || !chatId || !photo?.length) {
       this.log(`Photo handling: missing chatId or photo array for chat ${chatId ?? '(unknown)'}`);
       return;
     }
@@ -202,9 +216,10 @@ export class MessageHandler {
       // M3+M6: session lookup and queue-depth check happen before getFileLink /
       // download so that allowlist-burst rejections don't burn Telegram API quota
       // or trigger a full CDN download for a message that will be dropped anyway.
-      const session = await this.sessionManager.getSession(chatId);
+      const session = await this.sessionManager.getSession(route);
 
-      // Register dynamic commands for this chat (non-blocking)
+      // Register dynamic commands for this chat (non-blocking). Chat-scoped, so
+      // keyed by chatId even when the message arrived in a topic.
       registerChatCommands(this.bot, chatId, session, this.registeredCommandChats, this.log).catch(err =>
         this.log('Failed to register chat commands:', err)
       );
@@ -212,7 +227,7 @@ export class MessageHandler {
       if (session.state !== 'idle') {
         // Check queue capacity before downloading: if the queue is already full we
         // can reject immediately without spending Telegram API quota on getFileLink.
-        const queue = this.messageQueues.get(chatId);
+        const queue = this.messageQueues.get(routeKey(route));
         if ((queue?.length ?? 0) >= MessageHandler.MAX_QUEUE_DEPTH) {
           await ctx.reply('⏳ Queue full. Please wait for your messages to be processed.');
           return;
@@ -318,12 +333,12 @@ export class MessageHandler {
       });
 
       if (session.state !== 'idle') {
-        const depth = this.enqueuePhoto(chatId, ctx, contentBlocks);
+        const depth = this.enqueuePhoto(route, ctx, contentBlocks);
         if (depth !== false) await ctx.reply(formatQueued(depth));
         return;
       }
 
-      await this.processOne(chatId, ctx, contentBlocks);
+      await this.processOne(route, ctx, contentBlocks);
     } catch (error) {
       // Redact any embedded bot token before logging: getFileLink() returns URLs of the form
       // https://api.telegram.org/file/bot<TOKEN>/<path>, and HTTP client errors frequently
@@ -351,12 +366,14 @@ export class MessageHandler {
    * Handle user text messages
    */
   async handle(ctx: Context): Promise<void> {
-    const chatId = ctx.chat?.id;
+    const route = routeFromCtx(ctx);
+    const chatId = route?.chatId;
     const messageText = (ctx.message as Message.TextMessage).text;
 
-    if (!chatId || !messageText) {
+    if (!route || !chatId || !messageText) {
       return;
     }
+    const key = routeKey(route);
 
     this.log(`📬 Message from chat ID: ${chatId}`);
 
@@ -385,25 +402,28 @@ export class MessageHandler {
     //      live session state here catches that case: a freshly-created session
     //      is always 'idle', so we delete the stale entry and fall through to
     //      processOne instead of routing to a dead resolver.
-    const elicitResolver = this.pendingElicitations.get(chatId);
+    // Resolve the elicitation by ROUTE key — this is the topic-isolation seam:
+    // a topic-A elicitation registered under A's key is never consumed by a
+    // topic-B message (which resolves to a different key).
+    const elicitResolver = this.pendingElicitations.get(key);
     if (elicitResolver) {
       // Case 1: ledger-originated bypass — fire resolver without session check.
-      if (this.ledgerOriginatedPendingChats.has(chatId)) {
-        this.pendingElicitations.delete(chatId);
-        this.ledgerOriginatedPendingChats.delete(chatId);
+      if (this.ledgerOriginatedPendingChats.has(key)) {
+        this.pendingElicitations.delete(key);
+        this.ledgerOriginatedPendingChats.delete(key);
         elicitResolver(messageText);
         return;
       }
       // Case 2: session-local — fire only when the session is genuinely busy.
-      const existingSession = this.sessionManager.getSessionIfExists(chatId);
+      const existingSession = this.sessionManager.getSessionIfExists(route);
       if (existingSession && existingSession.state !== 'idle') {
-        this.pendingElicitations.delete(chatId);
+        this.pendingElicitations.delete(key);
         elicitResolver(messageText);
         return;
       }
       // Stale entry — session was reset while elicitation was in flight.
-      this.log('[message] dropping stale pendingElicitation for chatId', chatId);
-      this.pendingElicitations.delete(chatId);
+      this.log('[message] dropping stale pendingElicitation for route', key);
+      this.pendingElicitations.delete(key);
     }
 
     try {
@@ -411,20 +431,20 @@ export class MessageHandler {
       // instant feedback even while a prior turn is still streaming and this
       // message is queued. Mirrors the best-effort typing-indicator pattern.
       await ctx.react?.('👀').catch(() => {});
-      const session = await this.sessionManager.getSession(chatId);
+      const session = await this.sessionManager.getSession(route);
 
-      // Register dynamic commands for this chat (non-blocking)
+      // Register dynamic commands for this chat (non-blocking). Chat-scoped.
       registerChatCommands(this.bot, chatId, session, this.registeredCommandChats, this.log).catch(err =>
         this.log('Failed to register chat commands:', err)
       );
 
       if (session.state !== 'idle') {
-        const depth = this.enqueueMessage(chatId, ctx, messageText);
+        const depth = this.enqueueMessage(route, ctx, messageText);
         if (depth !== false) await ctx.reply(formatQueued(depth));
         return;
       }
 
-      await this.processOne(chatId, ctx, messageText);
+      await this.processOne(route, ctx, messageText);
     } catch (error) {
       this.log('Message handling error:', error);
       // Note: 'session is busy' is no longer handled here — that race is covered
@@ -443,12 +463,15 @@ export class MessageHandler {
   }
 
   /**
-   * Process clear command when already idle (called from handlers)
+   * Process clear command when already idle (called from handlers).
+   * Resets the session for THIS route only; the chat's other topics are
+   * untouched. Command re-registration is chat-scoped (registeredCommandChats
+   * keyed by chatId).
    */
-  async processClearDirect(chatId: number, ctx: Context): Promise<void> {
+  async processClearDirect(route: TelegramRoute, ctx: Context): Promise<void> {
     try {
-      await this.sessionManager.resetSession(chatId);
-      this.registeredCommandChats.delete(chatId);
+      await this.sessionManager.resetSession(route);
+      this.registeredCommandChats.delete(route.chatId);
       await ctx.reply(formatClear());
     } catch (error) {
       this.log('Clear error:', error);
@@ -469,13 +492,13 @@ export class MessageHandler {
    * actually runs once the session is idle, instead of surfacing the misleading
    * "Nothing to compact (session-busy)" no-op and dropping the request.
    */
-  private async processCompactDirect(chatId: number, ctx: Context): Promise<void> {
+  private async processCompactDirect(route: TelegramRoute, ctx: Context): Promise<void> {
     // See processOne: when we re-enqueue because the session is busy, the active
     // turn's own finally will drain the item we pushed. Draining here too would
     // shift that item and re-enter immediately → busy-spin cascade.
     let reEnqueued = false;
     try {
-      const session = await this.sessionManager.getSession(chatId);
+      const session = await this.sessionManager.getSession(route);
       const hookRegistry = session.hookRegistry;
       // Keep the "typing…" indicator alive across the PreCompact hook and the
       // model-call compaction, which can outlast the ~5s one-shot expiry.
@@ -493,7 +516,7 @@ export class MessageHandler {
       if (result.reason === 'session-busy') {
         // Session became busy between drain-start and our compact() call (TOCTOU).
         // Re-enqueue so the compact isn't silently dropped with a confusing no-op.
-        this.enqueueCompact(chatId, ctx);
+        this.enqueueCompact(route, ctx);
         reEnqueued = true;
         return;
       }
@@ -519,21 +542,28 @@ export class MessageHandler {
       // Only drain when we did NOT re-enqueue — the active turn's finally will
       // drain the re-enqueued compact; draining here too causes a cascade.
       if (!reEnqueued) {
-        this.drainQueue(chatId).catch(err => this.log('Drain error:', err));
+        this.drainQueue(route).catch(err => this.log('Drain error:', err));
       }
     }
+  }
+
+  /** The queue for a route, creating it on first use. Keyed by routeKey. */
+  private queueFor(route: TelegramRoute): Array<QueueItem> {
+    const key = routeKey(route);
+    let queue = this.messageQueues.get(key);
+    if (!queue) {
+      queue = [];
+      this.messageQueues.set(key, queue);
+    }
+    return queue;
   }
 
   /**
    * Enqueue a text message for later processing.
    * Returns the 1-based queue depth on success, or false if the queue is full.
    */
-  private enqueueMessage(chatId: number, ctx: Context, text: string): number | false {
-    let queue = this.messageQueues.get(chatId);
-    if (!queue) {
-      queue = [];
-      this.messageQueues.set(chatId, queue);
-    }
+  private enqueueMessage(route: TelegramRoute, ctx: Context, text: string): number | false {
+    const queue = this.queueFor(route);
     if (queue.length >= MessageHandler.MAX_QUEUE_DEPTH) {
       ctx.reply('⏳ Queue full. Please wait for your messages to be processed.').catch(() => {});
       return false;
@@ -546,12 +576,8 @@ export class MessageHandler {
    * Enqueue a photo message for later processing.
    * Returns the 1-based queue depth on success, or false if the queue is full.
    */
-  private enqueuePhoto(chatId: number, ctx: Context, content: ContentBlockParam[]): number | false {
-    let queue = this.messageQueues.get(chatId);
-    if (!queue) {
-      queue = [];
-      this.messageQueues.set(chatId, queue);
-    }
+  private enqueuePhoto(route: TelegramRoute, ctx: Context, content: ContentBlockParam[]): number | false {
+    const queue = this.queueFor(route);
     if (queue.length >= MessageHandler.MAX_QUEUE_DEPTH) {
       ctx.reply('⏳ Queue full. Please wait for your messages to be processed.').catch(() => {});
       return false;
@@ -563,25 +589,15 @@ export class MessageHandler {
   /**
    * Enqueue a clear command for later processing
    */
-  enqueueClear(chatId: number, ctx: Context): void {
-    let queue = this.messageQueues.get(chatId);
-    if (!queue) {
-      queue = [];
-      this.messageQueues.set(chatId, queue);
-    }
-    queue.push({ type: 'clear', ctx });
+  enqueueClear(route: TelegramRoute, ctx: Context): void {
+    this.queueFor(route).push({ type: 'clear', ctx });
   }
 
   /**
    * Enqueue a compact command for later processing
    */
-  enqueueCompact(chatId: number, ctx: Context): void {
-    let queue = this.messageQueues.get(chatId);
-    if (!queue) {
-      queue = [];
-      this.messageQueues.set(chatId, queue);
-    }
-    queue.push({ type: 'compact', ctx });
+  enqueueCompact(route: TelegramRoute, ctx: Context): void {
+    this.queueFor(route).push({ type: 'compact', ctx });
   }
 
   /**
@@ -592,7 +608,7 @@ export class MessageHandler {
    * and this method's own getSession call (TOCTOU). Catching it here ensures the
    * item is re-enqueued regardless of which caller triggered processOne.
    */
-  private async processOne(chatId: number, ctx: Context, content: string | ContentBlockParam[]): Promise<void> {
+  private async processOne(route: TelegramRoute, ctx: Context, content: string | ContentBlockParam[]): Promise<void> {
     // Guard against a busy-spin cascade: if the catch block re-enqueues the item
     // because the session is busy, we must NOT also drain — the re-enqueued item will
     // be picked up by the active session's own drain cycle. Without this flag, the
@@ -600,7 +616,7 @@ export class MessageHandler {
     // which shifts the item we just pushed and calls processOne again → cascade.
     let reEnqueued = false;
     try {
-      const session = await this.sessionManager.getSession(chatId);
+      const session = await this.sessionManager.getSession(route);
       // User text for the stored turn record: joined text blocks (caption) for
       // content-block (photo) messages, the raw string otherwise.
       const userText = typeof content === 'string'
@@ -614,7 +630,7 @@ export class MessageHandler {
           // Record the completed turn into the shared session store so the CLI
           // can `--resume <name>` this Telegram conversation. Best-effort inside.
           onComplete: (assistantText, metadata) => {
-            this.sessionManager.recordTelegramTurn(chatId, userText, assistantText, metadata);
+            this.sessionManager.recordTelegramTurn(route, userText, assistantText, metadata);
           },
         }),
       );
@@ -625,8 +641,8 @@ export class MessageHandler {
         // Session became busy between the caller's idle-check and our getSession call.
         // Re-enqueue the item so it isn't silently dropped.
         const depth = typeof content === 'string'
-          ? this.enqueueMessage(chatId, ctx, content)
-          : this.enqueuePhoto(chatId, ctx, content);
+          ? this.enqueueMessage(route, ctx, content)
+          : this.enqueuePhoto(route, ctx, content);
         if (depth !== false) await ctx.reply(formatQueued(depth));
         reEnqueued = true;
         return;
@@ -651,27 +667,27 @@ export class MessageHandler {
       // Only drain when we did NOT just re-enqueue — the active session's own finally
       // will drain the item we pushed; calling drain here too causes a cascade.
       if (!reEnqueued) {
-        this.drainQueue(chatId).catch(err => this.log('Drain error:', err));
+        this.drainQueue(route).catch(err => this.log('Drain error:', err));
       }
     }
   }
 
   /**
-   * Process the next queued item for this chat, if any.
+   * Process the next queued item for this route, if any.
    * Public so bot.ts can call it directly after /compact completes.
    */
-  async drainQueue(chatId: number): Promise<void> {
-    const queue = this.messageQueues.get(chatId);
+  async drainQueue(route: TelegramRoute): Promise<void> {
+    const queue = this.messageQueues.get(routeKey(route));
     if (!queue?.length) return;
     const item = queue.shift()!;
     if (item.type === 'message') {
-      await this.processOne(chatId, item.ctx, item.text);
+      await this.processOne(route, item.ctx, item.text);
     } else if (item.type === 'photo') {
-      await this.processOne(chatId, item.ctx, item.content);
+      await this.processOne(route, item.ctx, item.content);
     } else if (item.type === 'compact') {
-      await this.processCompactDirect(chatId, item.ctx);
+      await this.processCompactDirect(route, item.ctx);
     } else {
-      await this.processClearDirect(chatId, item.ctx);
+      await this.processClearDirect(route, item.ctx);
     }
   }
 }

--- a/src/telegram/handlers/sessions.test.ts
+++ b/src/telegram/handlers/sessions.test.ts
@@ -136,7 +136,8 @@ describe('session switcher handlers', () => {
       const { ctx, reply } = makeCtx(710);
       await handleNew(ctx, manager, registered, log);
 
-      expect(spy).toHaveBeenCalledWith(710);
+      // Handler derives a General route (routeFromCtx) — bare chat, no topic.
+      expect(spy).toHaveBeenCalledWith({ chatId: 710 });
       expect(registered.has(710)).toBe(false);
       expect(String(reply.mock.calls[0]![0])).toContain('fresh session');
       // Previous conversation is preserved as resumable.
@@ -164,7 +165,7 @@ describe('session switcher handlers', () => {
 
       await handleSwitchCallback(ctx, manager, log);
 
-      expect(spy).toHaveBeenCalledWith(720, 'sdk-A');
+      expect(spy).toHaveBeenCalledWith({ chatId: 720 }, 'sdk-A');
       const confirmed = String(editMessageText.mock.calls[0]?.[0] ?? reply.mock.calls[0]?.[0] ?? '');
       expect(confirmed).toContain('Switched');
       // sdk-A is now the active conversation.

--- a/src/telegram/handlers/sessions.ts
+++ b/src/telegram/handlers/sessions.ts
@@ -15,6 +15,7 @@
 
 import { Context, Markup } from 'telegraf';
 import { SessionManager } from '../session-manager.js';
+import { type TelegramRoute, routeFromCtx } from '../route.js';
 import {
   formatError,
   formatSessionsList,
@@ -40,9 +41,9 @@ function callbackData(ctx: Context): string {
   return typeof cq === 'object' && cq !== null && 'data' in cq ? (cq as { data: string }).data : '';
 }
 
-/** True when the chat has a live session that is NOT idle (mid-turn). */
-function isBusy(sessionManager: SessionManager, chatId: number): boolean {
-  const live = sessionManager.getSessionIfExists(chatId);
+/** True when the route has a live session that is NOT idle (mid-turn). */
+function isBusy(sessionManager: SessionManager, route: TelegramRoute): boolean {
+  const live = sessionManager.getSessionIfExists(route);
   return live !== undefined && live.state !== 'idle';
 }
 
@@ -56,13 +57,13 @@ export async function handleSessions(
   sessionManager: SessionManager,
   _log: LogFn,
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
 
-  const sessions = sessionManager.listChatSessions(chatId);
+  const sessions = sessionManager.listChatSessions(route);
   if (sessions.length === 0) {
     await ctx.reply(formatNoSessions());
     return;
@@ -98,19 +99,19 @@ export async function handleNew(
   registeredCommandChats: Set<number>,
   log: LogFn,
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
-  if (!chatId) {
+  const route = routeFromCtx(ctx);
+  if (!route) {
     await ctx.reply(formatError('Could not identify chat'));
     return;
   }
-  if (isBusy(sessionManager, chatId)) {
+  if (isBusy(sessionManager, route)) {
     await ctx.reply(formatSessionBusy());
     return;
   }
   try {
-    await sessionManager.newSession(chatId);
+    await sessionManager.newSession(route);
     // Force per-chat command re-registration for the fresh session (mirrors /clear).
-    registeredCommandChats.delete(chatId);
+    registeredCommandChats.delete(route.chatId);
     await ctx.reply(formatNewSession());
   } catch (error) {
     log('New session error:', error);
@@ -132,26 +133,28 @@ export async function handleSwitchCallback(
   sessionManager: SessionManager,
   log: LogFn,
 ): Promise<void> {
-  const chatId = ctx.chat?.id;
+  // routeFromCtx reads the thread id off callbackQuery.message (the §11 fix),
+  // so a switch tapped inside a topic operates on THAT topic's session.
+  const route = routeFromCtx(ctx);
   const data = callbackData(ctx);
   const targetSessionId = data.startsWith(SWITCH_CALLBACK_PREFIX)
     ? data.slice(SWITCH_CALLBACK_PREFIX.length)
     : '';
-  if (!chatId || !targetSessionId) return;
+  if (!route || !targetSessionId) return;
 
-  if (isBusy(sessionManager, chatId)) {
+  if (isBusy(sessionManager, route)) {
     await ctx.reply(formatSessionBusy());
     return;
   }
 
   try {
-    const res = await sessionManager.switchToSession(chatId, targetSessionId);
+    const res = await sessionManager.switchToSession(route, targetSessionId);
     if (!res.ok) {
       await ctx.reply(res.reason === 'already-active' ? formatAlreadyActive() : formatSwitchNotFound());
       return;
     }
     const name = sessionManager
-      .listChatSessions(chatId)
+      .listChatSessions(route)
       .find((s) => s.sessionId === targetSessionId)?.name;
     const confirm = formatSwitched(name !== undefined ? { name } : {});
     // Edit the /sessions message in place (fall back to a fresh reply).

--- a/src/telegram/session-manager.test.ts
+++ b/src/telegram/session-manager.test.ts
@@ -912,3 +912,77 @@ describe('SessionManager — session switcher (/sessions, /switch, /new)', () =>
     expect(manager.listChatSessions(805).map((s) => s.sessionId).sort()).toEqual(['sdk-fresh', 'sdk-old']);
   });
 });
+
+describe('SessionManager — per-route isolation (native topics)', () => {
+  // Step 6: two topics in one chat are concurrent, fully-isolated sessions.
+  // RouteTarget = TelegramRoute | number; a bare number === General topic, so
+  // General must stay byte-identical to the pre-topics behavior.
+  useUnsetAfkHome();
+
+  class MockSessionWithId implements IAgentSession {
+    state: SessionState = 'idle';
+    constructor(readonly sessionId?: string) {}
+    async sendMessage(content: string) {
+      return { role: 'assistant' as const, content: `Echo: ${content}`, timestamp: new Date() };
+    }
+    async *getOutputStream() { yield { type: 'done' as const }; }
+    abort(_reason: string): void { /* no-op */ }
+    async close() { /* no-op */ }
+    async reset() { /* no-op */ }
+  }
+
+  let testDataDir: string;
+  let tmpHome: string;
+  let originalHome: string | undefined;
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    const entropy = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    testDataDir = join(tmpdir(), `afk-tg-iso-data-${entropy}`);
+    originalHome = process.env['HOME'];
+    tmpHome = join(tmpdir(), `afk-tg-iso-home-${entropy}`);
+    process.env['HOME'] = tmpHome;
+    let n = 0;
+    manager = new SessionManager({
+      dataDir: testDataDir,
+      apiKey: 'test-key',
+      defaultModel: 'sonnet',
+      createSession: async () => new MockSessionWithId(`sdk-live-${n++}`),
+    });
+  });
+
+  afterEach(async () => {
+    await manager.closeAll().catch(() => {});
+    if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+    if (existsSync(testDataDir)) rmSync(testDataDir, { recursive: true, force: true });
+    if (originalHome !== undefined) process.env['HOME'] = originalHome;
+  });
+
+  test('two topics in one chat get distinct, concurrent sessions', async () => {
+    const general = { chatId: 900 };
+    const topic = { chatId: 900, threadId: 7 };
+
+    const sGeneral = await manager.getSession(general);
+    const sTopic = await manager.getSession(topic);
+
+    // Distinct live sessions coexist for the same chat — no cross-topic sharing.
+    expect(sGeneral).not.toBe(sTopic);
+    // Both stay live simultaneously (opening the topic did not tear down General).
+    expect(await manager.getSession(general)).toBe(sGeneral);
+    expect(manager.getSessionIfExists(topic)).toBe(sTopic);
+  });
+
+  test('per-route turns persist as separate resumable sidecars under the same chat', () => {
+    manager.recordTelegramTurn({ chatId: 900 }, 'general work', 'a', { sessionId: 'sdk-gen' });
+    manager.recordTelegramTurn({ chatId: 900, threadId: 7 }, 'topic work', 'b', { sessionId: 'sdk-top' });
+
+    // Both belong to chat 900 (listed together) but are distinct conversations.
+    expect(manager.listChatSessions(900).map((s) => s.sessionId).sort()).toEqual(['sdk-gen', 'sdk-top']);
+  });
+
+  test('General route is back-compat with the bare chatId (number === { chatId })', () => {
+    manager.recordTelegramTurn(901, 'hello', 'hi', { sessionId: 'sdk-901' });
+    // The explicit General route resolves the same chat's sessions as the bare number.
+    expect(manager.listChatSessions({ chatId: 901 }).map((s) => s.sessionId)).toEqual(['sdk-901']);
+  });
+});

--- a/src/telegram/session-manager.test.ts
+++ b/src/telegram/session-manager.test.ts
@@ -162,9 +162,11 @@ describe('SessionManager', () => {
       expect(successCallCount).toBe(1);
 
       // lastActivity must have been refreshed (>= before timestamp).
+      // sessionData is now keyed by routeKey (string); a General route for
+      // chatId 22222 keys as "22222" (byte-identical to the legacy chatId key).
       const lastActivity = Date.parse(
-        (succeedingManager as unknown as { sessionData: Map<number, { lastActivity: string }> })
-          .sessionData.get(22222)!.lastActivity
+        (succeedingManager as unknown as { sessionData: Map<string, { lastActivity: string }> })
+          .sessionData.get('22222')!.lastActivity
       );
       expect(lastActivity).toBeGreaterThanOrEqual(before);
 

--- a/src/telegram/session-manager.ts
+++ b/src/telegram/session-manager.ts
@@ -14,14 +14,44 @@ import { injectHotMemory } from '../agent/memory/index.js';
 import { createSessionStats, recordTurn } from '../cli/slash/session-stats.js';
 import { saveSession, loadSession, listSessions } from '../cli/session-store.js';
 import type { SessionStats } from '../cli/slash/types.js';
+import { type TelegramRoute, routeKey } from './route.js';
 import { promises as fs } from 'fs';
 import { join } from 'path';
+
+/**
+ * Public methods that used to take a bare `chatId: number` now take a route
+ * target. A bare `number` is accepted as shorthand for that chat's General
+ * topic — `{ chatId: n }` — so every pre-topics caller (and the entire existing
+ * telegram test suite) is byte-identical: `routeKey({ chatId: n })` === the
+ * legacy `String(n)` key. A real topic passes a full `TelegramRoute` with a
+ * `threadId`, which keys as `${chatId}:${threadId}` and isolates that topic's
+ * session/queue/elicitation from every other topic in the same chat.
+ */
+export type RouteTarget = TelegramRoute | number;
+
+/** Normalize a RouteTarget to a full route. A bare number is the General topic. */
+function toRoute(target: RouteTarget): TelegramRoute {
+  return typeof target === 'number' ? { chatId: target } : target;
+}
 
 /**
  * Session data for persistence
  */
 interface SessionData {
+  /**
+   * Telegram chat id — retained for provenance and outbound sends
+   * (`stats.telegramChatId`, `bot.telegram.sendMessage(chatId, …)`). The
+   * in-memory maps and the on-disk sidecar are keyed by the ROUTE (see
+   * `routeKey`), not this field: General topics key as `String(chatId)`
+   * (unchanged on disk for existing users), a real topic as `${chatId}:${threadId}`.
+   */
   chatId: number;
+  /**
+   * Topic thread id when this session belongs to a non-General topic; absent
+   * for General / topics-off. Persisted so a per-topic sidecar round-trips its
+   * route on reload (the routeKey is otherwise recoverable only from the filename).
+   */
+  threadId?: number;
   model: AgentModelInput;
   createdAt: string;
   lastActivity: string;
@@ -98,39 +128,46 @@ export interface SessionManagerOptions {
 }
 
 /**
- * Manages Telegram chat sessions
- * One AgentSession per chat ID
+ * Manages Telegram chat sessions.
+ *
+ * Invariant: every live-session map is keyed by `routeKey(route)`, NOT a bare
+ * chatId. General / topics-off routes normalize to `String(chatId)` (so an
+ * existing single-session user is byte-identical to the pre-topics bot), while a
+ * real Telegram topic keys as `${chatId}:${threadId}` — giving one fully-isolated
+ * AgentSession per topic inside a single chat. Public methods accept a
+ * `RouteTarget` (a full `TelegramRoute`, or a bare `number` treated as that chat's
+ * General topic) and compute the routeKey internally.
  */
 export class SessionManager {
-  private sessions = new Map<number, IAgentSession>();
-  /** In-flight creation promises — prevent duplicate session spawns on concurrent messages. */
-  private pendingSessions = new Map<number, Promise<IAgentSession>>();
-  private sessionData = new Map<number, SessionData>();
+  private sessions = new Map<string, IAgentSession>();
+  /** In-flight creation promises — prevent duplicate session spawns on concurrent messages (per route). */
+  private pendingSessions = new Map<string, Promise<IAgentSession>>();
+  private sessionData = new Map<string, SessionData>();
   /**
-   * Per-chat accumulating session stats (turns, totals, name, sessionId).
+   * Per-route accumulating session stats (turns, totals, name, sessionId).
    * Recorded on each completed turn and written to the shared session store
    * so the CLI can `--resume <name>` a Telegram conversation. Reset whenever
    * the underlying AgentSession is torn down (/clear, model switch, /cd) so a
    * fresh sessionId and name are captured for the rebuilt session.
    */
-  private sessionStats = new Map<number, SessionStats>();
+  private sessionStats = new Map<string, SessionStats>();
   /**
-   * Chats that have already logged an autosave failure this conversation.
+   * Routes that have already logged an autosave failure this conversation.
    * Per-turn autosave is best-effort, but a persistent failure (EACCES,
    * ENOSPC) would otherwise be silently swallowed every turn while the user
-   * assumes the chat is resumable from the CLI. Log the FIRST failure per chat
+   * assumes the chat is resumable from the CLI. Log the FIRST failure per route
    * and stay quiet afterwards; the entry is cleared on _resetStats so a fresh
    * conversation gets a fresh warning.
    */
-  private autosaveFailureLogged = new Set<number>();
+  private autosaveFailureLogged = new Set<string>();
   /**
-   * Chats with a staged `/switch` resume target (SDK session id). Consumed once
+   * Routes with a staged `/switch` resume target (SDK session id). Consumed once
    * by the next getSession() to build the rebuilt session with `config.resume`
    * so it continues the chosen prior conversation. Cleared on any teardown
    * (/clear, model switch, /cd) via _resetStats so those start fresh, never
    * resuming a stale target.
    */
-  private pendingResume = new Map<number, string>();
+  private pendingResume = new Map<string, string>();
   private options: Required<Omit<SessionManagerOptions, 'createSession' | 'settingSources' | 'thinking' | 'effort' | 'botCwd'>> &
     Pick<SessionManagerOptions, 'createSession' | 'settingSources' | 'thinking' | 'effort' | 'botCwd'>;
 
@@ -148,51 +185,51 @@ export class SessionManager {
   }
 
   /**
-   * Get existing session for a chat without creating one.
+   * Get existing session for a route without creating one.
    * Used e.g. to read SDK-native slash commands for /help.
    */
-  getSessionIfExists(chatId: number): IAgentSession | undefined {
-    return this.sessions.get(chatId);
+  getSessionIfExists(target: RouteTarget): IAgentSession | undefined {
+    return this.sessions.get(routeKey(toRoute(target)));
   }
 
   /**
-   * Get or create a session for a chat.
+   * Get or create a session for a route (chat + optional topic thread).
    *
-   * Concurrent calls for the same `chatId` that arrive before the first
+   * Concurrent calls for the same route that arrive before the first
    * session is fully initialised (e.g. two Telegram messages arriving within
    * milliseconds of each other) all share a single in-flight creation promise
-   * rather than spawning duplicate sessions.
+   * rather than spawning duplicate sessions. Different topics in the same chat
+   * are distinct routes → distinct sessions, never shared.
    *
-   * @param chatId - Telegram chat ID
+   * @param target - Route (chat + optional topic) or a bare chatId (General topic)
    * @returns Agent session
    */
-  async getSession(chatId: number): Promise<IAgentSession> {
-    const existing = this.sessions.get(chatId);
+  async getSession(target: RouteTarget): Promise<IAgentSession> {
+    const route = toRoute(target);
+    const key = routeKey(route);
+
+    const existing = this.sessions.get(key);
     if (existing) {
-      this._touchActivity(chatId);
+      this._touchActivity(key);
       return existing;
     }
 
-    // If there is already an in-flight creation for this chatId, wait for it.
+    // If there is already an in-flight creation for this route, wait for it.
     // Use try/finally so _touchActivity runs on both success and rejection —
     // invariant: callers must not observe a stale lastActivity on retry after a failure.
-    const inflight = this.pendingSessions.get(chatId);
+    const inflight = this.pendingSessions.get(key);
     if (inflight) {
       try {
         const session = await inflight;
         return session;
       } finally {
-        this._touchActivity(chatId);
+        this._touchActivity(key);
       }
     }
 
-    // No session and no pending creation — start one.
-    const data = this.sessionData.get(chatId) ?? {
-      chatId,
-      model: this.options.defaultModel,
-      createdAt: new Date().toISOString(),
-      lastActivity: new Date().toISOString(),
-    };
+    // No session and no pending creation — start one. New SessionData carries
+    // the chatId (provenance/sends) and the topic threadId (route round-trip).
+    const data = this.sessionData.get(key) ?? this._newData(route);
 
     const creationPromise = (async (): Promise<IAgentSession> => {
       const config: AgentConfig = {
@@ -218,31 +255,43 @@ export class SessionManager {
 
       // /switch: continue a staged prior conversation instead of starting fresh.
       // Consumed once here — a later /clear (via _resetStats) drops any stale target.
-      const resumeTarget = this.pendingResume.get(chatId);
+      const resumeTarget = this.pendingResume.get(key);
       if (resumeTarget !== undefined) {
         config.resume = resumeTarget;
-        this.pendingResume.delete(chatId);
+        this.pendingResume.delete(key);
       }
 
       const session = await this.options.createSession(injectHotMemory(config));
-      this.sessions.set(chatId, session);
-      this.sessionData.set(chatId, data);
+      this.sessions.set(key, session);
+      this.sessionData.set(key, data);
       return session;
     })();
 
-    this.pendingSessions.set(chatId, creationPromise);
+    this.pendingSessions.set(key, creationPromise);
     try {
       const session = await creationPromise;
-      this._touchActivity(chatId);
+      this._touchActivity(key);
       return session;
     } finally {
       // Always clean up the in-flight entry regardless of success or failure.
-      this.pendingSessions.delete(chatId);
+      this.pendingSessions.delete(key);
     }
   }
 
-  private _touchActivity(chatId: number): void {
-    const data = this.sessionData.get(chatId);
+  /** Build a fresh SessionData for a route, carrying chatId + topic threadId. */
+  private _newData(route: TelegramRoute): SessionData {
+    const data: SessionData = {
+      chatId: route.chatId,
+      model: this.options.defaultModel,
+      createdAt: new Date().toISOString(),
+      lastActivity: new Date().toISOString(),
+    };
+    if (route.threadId !== undefined) data.threadId = route.threadId;
+    return data;
+  }
+
+  private _touchActivity(key: string): void {
+    const data = this.sessionData.get(key);
     if (data) data.lastActivity = new Date().toISOString();
   }
 
@@ -257,16 +306,18 @@ export class SessionManager {
    * persistence failures never disrupt the chat.
    */
   recordTelegramTurn(
-    chatId: number,
+    target: RouteTarget,
     userText: string,
     assistantText: string,
     metadata?: ResponseMetadata,
   ): void {
-    const stats = this._getOrCreateStats(chatId);
+    const route = toRoute(target);
+    const key = routeKey(route);
+    const stats = this._getOrCreateStats(route);
 
     // Capture the SDK sessionId from the live session if the turn metadata
     // didn't carry one (recordTurn also sets it from metadata when present).
-    const live = this.sessions.get(chatId);
+    const live = this.sessions.get(key);
     if (!stats.sessionId && live?.sessionId) stats.sessionId = live.sessionId;
 
     recordTurn(stats, userText, assistantText, metadata);
@@ -274,7 +325,7 @@ export class SessionManager {
     if (!stats.sessionId && live?.sessionId) stats.sessionId = live.sessionId;
 
     // Mirror the captured sessionId into SessionData so it survives bot restart.
-    const data = this.sessionData.get(chatId);
+    const data = this.sessionData.get(key);
     if (data && stats.sessionId) data.sessionId = stats.sessionId;
 
     // Persist to the shared store. Requires a sessionId to key the file;
@@ -285,13 +336,13 @@ export class SessionManager {
         saveSession(stats);
       } catch (err) {
         // Best-effort — never break the chat on a persistence failure. Surface
-        // the FIRST failure per chat (autosaveFailureLogged) so a persistent
+        // the FIRST failure per route (autosaveFailureLogged) so a persistent
         // EACCES/ENOSPC isn't silently swallowed every turn while the user
         // assumes the conversation is resumable from `afk i --resume`.
-        if (!this.autosaveFailureLogged.has(chatId)) {
-          this.autosaveFailureLogged.add(chatId);
+        if (!this.autosaveFailureLogged.has(key)) {
+          this.autosaveFailureLogged.add(key);
           console.error(
-            `[session-manager] autosave failed for chat ${chatId} — conversation may not be resumable:`,
+            `[session-manager] autosave failed for chat ${route.chatId} — conversation may not be resumable:`,
             err,
           );
         }
@@ -316,19 +367,22 @@ export class SessionManager {
    * prior-conversation stats (sessionId, turns, totals), so a rename persists
    * in-place without forking a duplicate sidecar and turn counts are preserved.
    */
-  private _hydrateStatsFromStore(chatId: number): void {
+  private _hydrateStatsFromStore(route: TelegramRoute): void {
+    const key = routeKey(route);
     // Never clobber live in-memory stats — this is a post-restart-only repair.
-    if (this.sessionStats.has(chatId)) return;
+    if (this.sessionStats.has(key)) return;
 
-    const sessionId = this.sessionData.get(chatId)?.sessionId;
+    const sessionId = this.sessionData.get(key)?.sessionId;
     if (!sessionId) return;
 
     const stored = loadSession(sessionId);
     if (!stored) return;
 
     // Only hydrate telegram sidecars that belong to THIS chat — prevent
-    // accidentally adopting a CLI sidecar or a different chat's sidecar.
-    if (stored.source !== 'telegram' || stored.telegramChatId !== chatId) return;
+    // accidentally adopting a CLI sidecar or a different chat's sidecar. The
+    // per-route sidecar is keyed by SDK sessionId, so a topic can only hydrate
+    // its own conversation (each topic's session has a distinct sessionId).
+    if (stored.source !== 'telegram' || stored.telegramChatId !== route.chatId) return;
 
     // Map StoredSession → SessionStats.
     // Critical rename: stored.startedAt === SessionStats.sessionStartTime.
@@ -354,10 +408,10 @@ export class SessionManager {
       turnTokens: [],
       permissionMode: 'default',
     };
-    // Carry forward the per-chat cwd override if one was set via /cd.
-    const chatCwd = this.sessionData.get(chatId)?.cwd;
+    // Carry forward the per-route cwd override if one was set via /cd.
+    const chatCwd = this.sessionData.get(key)?.cwd;
     if (chatCwd !== undefined) stats.cwd = chatCwd;
-    this.sessionStats.set(chatId, stats);
+    this.sessionStats.set(key, stats);
   }
 
   /**
@@ -374,9 +428,10 @@ export class SessionManager {
    * _getOrCreateStats — that would fabricate an empty stats entry for a
    * genuinely new chat that has never had a session.
    */
-  getSessionName(chatId: number): string | undefined {
-    this._hydrateStatsFromStore(chatId);
-    return this.sessionStats.get(chatId)?.name;
+  getSessionName(target: RouteTarget): string | undefined {
+    const route = toRoute(target);
+    this._hydrateStatsFromStore(route);
+    return this.sessionStats.get(routeKey(route))?.name;
   }
 
   /**
@@ -397,20 +452,22 @@ export class SessionManager {
    * @throws Propagates a `saveSession` failure so the caller can report that
    *   the name was set but the immediate persist failed (retries on next turn).
    */
-  setSessionName(chatId: number, slug: string): { persisted: boolean } {
-    const stats = this._getOrCreateStats(chatId);
+  setSessionName(target: RouteTarget, slug: string): { persisted: boolean } {
+    const route = toRoute(target);
+    const key = routeKey(route);
+    const stats = this._getOrCreateStats(route);
     stats.name = slug;
 
     // Capture the live session's id if the stats don't carry one yet, so the
     // persisted sidecar is keyed the same way the per-turn autosave keys it.
-    const live = this.sessions.get(chatId);
+    const live = this.sessions.get(key);
     if (!stats.sessionId && live?.sessionId) stats.sessionId = live.sessionId;
 
     if (stats.totalTurns > 0 && stats.sessionId) {
       // Mirror the captured sessionId into SessionData BEFORE saveSession so
       // the data.sessionId update is guaranteed even if saveSession throws.
       // The throw still propagates to the caller so it can report the failure.
-      const data = this.sessionData.get(chatId);
+      const data = this.sessionData.get(key);
       if (data) data.sessionId = stats.sessionId;
       saveSession(stats);
       return { persisted: true };
@@ -427,87 +484,89 @@ export class SessionManager {
    * (via _hydrateStatsFromStore) so setSessionName and recordTelegramTurn
    * see the full prior-conversation state instead of fresh empty stats.
    */
-  private _getOrCreateStats(chatId: number): SessionStats {
+  private _getOrCreateStats(route: TelegramRoute): SessionStats {
+    const key = routeKey(route);
     // Repair post-restart: if sessionData has a sessionId but sessionStats is
     // empty, hydrate from the persisted sidecar before the get-or-create.
-    this._hydrateStatsFromStore(chatId);
+    this._hydrateStatsFromStore(route);
 
-    let stats = this.sessionStats.get(chatId);
+    let stats = this.sessionStats.get(key);
     if (!stats) {
-      stats = createSessionStats(this.getModel(chatId));
+      stats = createSessionStats(this.getModel(route));
       stats.source = 'telegram';
-      stats.telegramChatId = chatId;
-      const cwd = this.getCwd(chatId);
+      // Provenance stays the chatId (topics in one chat share it); the route's
+      // isolation lives in the routeKey the maps + sidecar filename key on.
+      stats.telegramChatId = route.chatId;
+      const cwd = this.getCwd(route);
       if (cwd) stats.cwd = cwd;
-      this.sessionStats.set(chatId, stats);
+      this.sessionStats.set(key, stats);
     }
     return stats;
   }
 
   /**
-   * Drop the accumulating stats and stale sessionId for a chat. Called when
+   * Drop the accumulating stats and stale sessionId for a route. Called when
    * the underlying AgentSession is torn down (/clear, model switch, /cd) so
    * the rebuilt session captures a fresh sessionId and auto-name rather than
    * appending to the previous conversation's sidecar.
    */
-  private _resetStats(chatId: number): void {
-    this.sessionStats.delete(chatId);
+  private _resetStats(key: string): void {
+    this.sessionStats.delete(key);
     // Fresh conversation → allow the autosave-failure notice to fire again.
-    this.autosaveFailureLogged.delete(chatId);
+    this.autosaveFailureLogged.delete(key);
     // Drop any staged /switch resume so a teardown always starts fresh.
-    this.pendingResume.delete(chatId);
-    const data = this.sessionData.get(chatId);
+    this.pendingResume.delete(key);
+    const data = this.sessionData.get(key);
     if (data) delete data.sessionId;
   }
 
   /**
-   * Reset a chat session (clear history)
-   * 
-   * @param chatId - Telegram chat ID
+   * Reset a route's session (clear history).
+   *
+   * @param target - Route (chat + optional topic) or a bare chatId (General topic)
    */
-  async resetSession(chatId: number): Promise<void> {
-    const oldSession = this.sessions.get(chatId);
+  async resetSession(target: RouteTarget): Promise<void> {
+    const key = routeKey(toRoute(target));
+    const oldSession = this.sessions.get(key);
     if (oldSession) {
       await oldSession.close();
-      this.sessions.delete(chatId);
+      this.sessions.delete(key);
     }
     // New conversation → drop accumulated stats + stale sessionId so the
     // rebuilt session is recorded as a fresh sidecar, not appended to the old.
-    this._resetStats(chatId);
+    this._resetStats(key);
 
     // Keep session data but create new session on next request
-    const data = this.sessionData.get(chatId);
+    const data = this.sessionData.get(key);
     if (data) {
       data.lastActivity = new Date().toISOString();
     }
   }
 
   /**
-   * Switch model for a chat session
-   * 
-   * @param chatId - Telegram chat ID
+   * Switch model for a route's session.
+   *
+   * @param target - Route (chat + optional topic) or a bare chatId (General topic)
    * @param model - New model to use
    */
-  async switchModel(chatId: number, model: AgentModelInput): Promise<void> {
+  async switchModel(target: RouteTarget, model: AgentModelInput): Promise<void> {
+    const route = toRoute(target);
+    const key = routeKey(route);
     // Close old session
-    const oldSession = this.sessions.get(chatId);
+    const oldSession = this.sessions.get(key);
     if (oldSession) {
       await oldSession.close();
-      this.sessions.delete(chatId);
+      this.sessions.delete(key);
     }
     // Model switch rebuilds the session with a new sessionId → fresh sidecar.
-    this._resetStats(chatId);
+    this._resetStats(key);
 
     // Update session data
-    let data = this.sessionData.get(chatId);
+    let data = this.sessionData.get(key);
     if (!data) {
-      data = {
-        chatId,
-        model,
-        createdAt: new Date().toISOString(),
-        lastActivity: new Date().toISOString(),
-      };
-      this.sessionData.set(chatId, data);
+      data = this._newData(route);
+      data.model = model;
+      this.sessionData.set(key, data);
     } else {
       data.model = model;
       data.lastActivity = new Date().toISOString();
@@ -517,13 +576,13 @@ export class SessionManager {
   }
 
   /**
-   * Get current model for a chat
-   * 
-   * @param chatId - Telegram chat ID
+   * Get current model for a route.
+   *
+   * @param target - Route (chat + optional topic) or a bare chatId (General topic)
    * @returns Current model
    */
-  getModel(chatId: number): AgentModelInput {
-    const data = this.sessionData.get(chatId);
+  getModel(target: RouteTarget): AgentModelInput {
+    const data = this.sessionData.get(routeKey(toRoute(target)));
     return data?.model || this.options.defaultModel;
   }
 
@@ -537,30 +596,27 @@ export class SessionManager {
    * Callers are responsible for validating that `cwd` exists and is a
    * directory before calling — this method does not stat the filesystem.
    *
-   * @param chatId - Telegram chat ID
+   * @param target - Route (chat + optional topic) or a bare chatId (General topic)
    * @param cwd - Absolute path to the new working directory
    */
-  async setCwd(chatId: number, cwd: string): Promise<void> {
+  async setCwd(target: RouteTarget, cwd: string): Promise<void> {
+    const route = toRoute(target);
+    const key = routeKey(route);
     // Close old session — next getSession() call rebuilds it with the
     // new cwd threaded through to the AgentSession + SubagentManager.
-    const oldSession = this.sessions.get(chatId);
+    const oldSession = this.sessions.get(key);
     if (oldSession) {
       await oldSession.close();
-      this.sessions.delete(chatId);
+      this.sessions.delete(key);
     }
     // cwd change rebuilds the session with a new sessionId → fresh sidecar.
-    this._resetStats(chatId);
+    this._resetStats(key);
 
-    let data = this.sessionData.get(chatId);
+    let data = this.sessionData.get(key);
     if (!data) {
-      data = {
-        chatId,
-        model: this.options.defaultModel,
-        createdAt: new Date().toISOString(),
-        lastActivity: new Date().toISOString(),
-        cwd,
-      };
-      this.sessionData.set(chatId, data);
+      data = this._newData(route);
+      data.cwd = cwd;
+      this.sessionData.set(key, data);
     } else {
       data.cwd = cwd;
       data.lastActivity = new Date().toISOString();
@@ -568,17 +624,17 @@ export class SessionManager {
   }
 
   /**
-   * Get the effective working directory for a chat: per-session override
+   * Get the effective working directory for a route: per-session override
    * (set via `/cd`) if present, otherwise the bot-global fallback.
    *
    * Returns undefined when neither is set — callers that need a real
    * path should fall back to `process.cwd()`.
    *
-   * @param chatId - Telegram chat ID
+   * @param target - Route (chat + optional topic) or a bare chatId (General topic)
    * @returns Effective cwd, or undefined when no override is configured
    */
-  getCwd(chatId: number): string | undefined {
-    const data = this.sessionData.get(chatId);
+  getCwd(target: RouteTarget): string | undefined {
+    const data = this.sessionData.get(routeKey(toRoute(target)));
     return data?.cwd ?? this.options.botCwd;
   }
 
@@ -586,16 +642,22 @@ export class SessionManager {
    * List this chat's resumable conversations for the `/sessions` switcher,
    * newest-active first. Sourced from the shared sidecar store (telegram
    * sidecars for this chatId) — the durable record of every conversation the
-   * chat has held — with the currently-active one flagged.
+   * chat has held — with the route's currently-active one flagged.
+   *
+   * Provenance is the chatId, so this lists every conversation the chat has
+   * held (across General and any topics). The `active` flag reflects the
+   * requesting route's own live session id — the conversation the switcher
+   * would replace on that route.
    *
    * A brand-new conversation with no recorded turn yet has no sidecar and so
    * does not appear until its first turn is saved.
    */
-  listChatSessions(chatId: number): ChatSessionInfo[] {
-    const activeId = this.sessionData.get(chatId)?.sessionId;
+  listChatSessions(target: RouteTarget): ChatSessionInfo[] {
+    const route = toRoute(target);
+    const activeId = this.sessionData.get(routeKey(route))?.sessionId;
     return listSessions()
       .filter(
-        (s) => s.source === 'telegram' && s.telegramChatId === chatId && s.sessionId !== undefined,
+        (s) => s.source === 'telegram' && s.telegramChatId === route.chatId && s.sessionId !== undefined,
       )
       .map((s) => {
         const info: ChatSessionInfo = {
@@ -624,48 +686,46 @@ export class SessionManager {
    *   is missing / not a telegram sidecar for this chat, or already active.
    */
   async switchToSession(
-    chatId: number,
+    target: RouteTarget,
     targetSessionId: string,
   ): Promise<{ ok: true } | { ok: false; reason: 'not-found' | 'already-active' }> {
+    const route = toRoute(target);
+    const key = routeKey(route);
     // Already the live active conversation → no-op (avoid a needless rebuild).
-    if (this.sessions.has(chatId) && this.sessionData.get(chatId)?.sessionId === targetSessionId) {
+    if (this.sessions.has(key) && this.sessionData.get(key)?.sessionId === targetSessionId) {
       return { ok: false, reason: 'already-active' };
     }
 
     const stored = loadSession(targetSessionId);
-    if (!stored || stored.source !== 'telegram' || stored.telegramChatId !== chatId) {
+    if (!stored || stored.source !== 'telegram' || stored.telegramChatId !== route.chatId) {
       return { ok: false, reason: 'not-found' };
     }
 
     // Close the current live session (sidecar already persisted per-turn).
-    const old = this.sessions.get(chatId);
+    const old = this.sessions.get(key);
     if (old) {
       await old.close();
-      this.sessions.delete(chatId);
+      this.sessions.delete(key);
     }
     // Drop in-memory stats so the resumed session hydrates the TARGET's stats
     // (name/turns/sessionId) from its sidecar on next access — never the
     // previous conversation's. autosave-failure notice re-arms for the switch.
-    this.sessionStats.delete(chatId);
-    this.autosaveFailureLogged.delete(chatId);
+    this.sessionStats.delete(key);
+    this.autosaveFailureLogged.delete(key);
 
     // Adopt the target's identity + model/cwd and stage the resume.
-    let data = this.sessionData.get(chatId);
+    let data = this.sessionData.get(key);
     if (!data) {
-      data = {
-        chatId,
-        model: stored.model,
-        createdAt: new Date().toISOString(),
-        lastActivity: new Date().toISOString(),
-      };
-      this.sessionData.set(chatId, data);
+      data = this._newData(route);
+      data.model = stored.model;
+      this.sessionData.set(key, data);
     } else {
       data.model = stored.model;
       data.lastActivity = new Date().toISOString();
     }
     data.sessionId = targetSessionId;
     if (stored.cwd !== undefined) data.cwd = stored.cwd;
-    this.pendingResume.set(chatId, targetSessionId);
+    this.pendingResume.set(key, targetSessionId);
     return { ok: true };
   }
 
@@ -676,15 +736,35 @@ export class SessionManager {
    * to it. Behaviorally this is resetSession (close + fresh sessionId), exposed
    * under a name that reflects the switcher intent.
    */
-  async newSession(chatId: number): Promise<void> {
+  async newSession(target: RouteTarget): Promise<void> {
     // resetSession → _resetStats already clears pendingResume; explicit here too
     // so intent is local and obvious.
-    this.pendingResume.delete(chatId);
-    await this.resetSession(chatId);
+    this.pendingResume.delete(routeKey(toRoute(target)));
+    await this.resetSession(target);
   }
 
   /**
-   * Load session data from disk
+   * The on-disk sidecar filename for a route's SessionData.
+   *
+   * Invariant: a General route's file is `<chatId>.json` — byte-identical to
+   * the pre-topics layout, so an existing user's session data loads unchanged.
+   * A topic route uses its routeKey (`<chatId>:<threadId>`). The `:` separator
+   * is legal on the macOS/Linux targets AFK supports; the loader recomputes the
+   * map key from the data's chatId+threadId, so it never relies on the filename.
+   */
+  private sidecarFileName(data: SessionData): string {
+    const route: TelegramRoute = { chatId: data.chatId };
+    if (data.threadId !== undefined) route.threadId = data.threadId;
+    return `${routeKey(route)}.json`;
+  }
+
+  /**
+   * Load session data from disk.
+   *
+   * Keys the in-memory map by the route recomputed from each file's payload
+   * (chatId + optional threadId), NOT the filename — so a legacy `<chatId>.json`
+   * (no threadId) loads to the General key `String(chatId)` exactly as before,
+   * and a topic sidecar loads to `<chatId>:<threadId>`.
    */
   async loadSessions(): Promise<void> {
     try {
@@ -696,7 +776,9 @@ export class SessionManager {
           const filePath = join(this.options.dataDir, file);
           const content = await fs.readFile(filePath, 'utf-8');
           const data: SessionData = JSON.parse(content);
-          this.sessionData.set(data.chatId, data);
+          const route: TelegramRoute = { chatId: data.chatId };
+          if (data.threadId !== undefined) route.threadId = data.threadId;
+          this.sessionData.set(routeKey(route), data);
         }
       }
     } catch (error) {
@@ -708,14 +790,14 @@ export class SessionManager {
   }
 
   /**
-   * Save session data to disk
+   * Save session data to disk, one file per route (General → `<chatId>.json`).
    */
   async saveSessions(): Promise<void> {
     try {
       await fs.mkdir(this.options.dataDir, { recursive: true });
       
-      for (const [chatId, data] of this.sessionData.entries()) {
-        const filePath = join(this.options.dataDir, `${chatId}.json`);
+      for (const data of this.sessionData.values()) {
+        const filePath = join(this.options.dataDir, this.sidecarFileName(data));
         await fs.writeFile(filePath, JSON.stringify(data, null, 2));
       }
     } catch (error) {

--- a/src/telegram/watch.test.ts
+++ b/src/telegram/watch.test.ts
@@ -234,8 +234,8 @@ describe('SessionWatchManager', () => {
  */
 function makeElicitStubs(chatId: number) {
   // Track the pending resolver installed by the elicitation handler.
-  const pendingElicitations = new Map<number, (text: string) => void>();
-  const ledgerOriginatedPendingChats = new Set<number>();
+  const pendingElicitations = new Map<string, (text: string) => void>();
+  const ledgerOriginatedPendingChats = new Set<string>();
 
   const sentMessages: string[] = [];
   const bot = {
@@ -295,7 +295,7 @@ describe('SessionWatchManager — elicitation intercept + signed write-back (cri
 
     // Simulate the operator typing an answer into Telegram (the message handler
     // fires the resolver, which is what handle() would do when it sees a text).
-    const resolver = pendingElicitations.get(chatId);
+    const resolver = pendingElicitations.get(String(chatId));
     expect(resolver).toBeDefined();
     resolver!('Alice');
 
@@ -355,7 +355,7 @@ describe('SessionWatchManager — elicitation intercept + signed write-back (cri
     await sleep(200);
 
     // Answer the pending resolver.
-    const resolver = pendingElicitations.get(chatId);
+    const resolver = pendingElicitations.get(String(chatId));
     expect(resolver).toBeDefined();
     resolver!('any answer');
 


### PR DESCRIPTION
> **Stacked on #562** (base branch `feat/telegram-session-registry`). Review/merge #562 first; this PR's diff is only the Steps 6–7 delta. **Draft** until #562 merges (the full CI pipeline only runs on PRs targeting `main` — see *CI note*).

## Summary

Builds on the #562 foundation to deliver the remaining two steps of the multi-session effort:

- **Step 6 — native Telegram "topics in private chats":** concurrent, fully-isolated sessions within one bot chat, one per topic (`message_thread_id`). Closes the latent cross-session leak (an elicitation raised in topic A can no longer be consumed by a message in topic B).
- **Step 7 — cross-surface bindings:** the CLI REPL and the daemon now register in the process-wide session registry, so all three surfaces (Telegram, CLI, daemon) share one surface-agnostic index.

## Step 6 — native topics (complete + tested)

- **Per-route re-key.** `SessionManager`'s five live maps + `pendingResume` are keyed by `routeKey` (route = `{chatId, threadId?}`). Public methods take `RouteTarget = TelegramRoute | number` — a **bare `number` is that chat's General topic**, so every existing caller and all pre-topics behavior is preserved unchanged.
- **Back-compat invariant.** General (`no thread` / thread 1) → `routeKey === String(chatId)`, sidecar stays `<chatId>.json` byte-for-byte; a real topic → `${chatId}:${threadId}` → `<chatId>:<threadId>.json`.
- **Ingress.** `bot.ts`, `message.ts`, and every command + switcher handler derive a `TelegramRoute` via `routeFromCtx(ctx)` and thread it through.
- **Leak fix.** `message.ts`'s `messageQueues` / `pendingElicitations` / `ledgerOriginatedPendingChats` are re-keyed to `Map<string>`/`Set<string>` by `routeKey` — topic A and topic B never cross-route.
- **Topic-pinned replies.** `sendOptions(route).message_thread_id` is threaded into the chat-id-targeted sends (elicitation prompts/keyboards, `/watch` output); General omits it (default delivery — byte-identical). `ctx.reply` auto-threads.
- **Tests.** Per-route isolation suite (two topics → distinct concurrent sessions, separate sidecars, General back-compat) + updated switcher/handler tests.

## Step 7 — cross-surface bindings (complete + tested)

- `registerSurfaceSession(session, { surface, model, cwd?, name?, sdkSessionId? })` (`src/agent/session/register-surface-session.ts`) creates a registry handle for a top-level session. **Best-effort — never throws into the caller** (the index is auxiliary, not load-bearing). The late-bound SDK session id is attached after `waitForInitialization()` when not known up front (a `--resume` target supplies it immediately).
- **CLI REPL** (`bootstrap.ts`): registered once per session; process-scoped, so no dispose (the in-memory registry dies with the REPL).
- **Daemon** (`scheduler.ts`): registered per spawned session; `runOnce` archives the handle on close (`dispose()` frees the binding key), so the long-running daemon never accumulates handles.

## Commits (on top of #562)
- `32dbda2` re-key SessionManager maps by routeKey
- `97b1a3d` thread route through ingress + re-key MessageHandler (+ topic-pinned sends)
- `8937c36` route-thread command + switcher handlers
- `5a19e5a` per-route (topic) isolation tests + General back-compat
- `a740940` register CLI + daemon sessions in the cross-surface registry

## Verification

Local gates green: full suite **11,653 passed / 14 skipped (639 files)**; `tsc --noEmit`, `audit:env:check`, `audit:sdk:check` all clean.

**CI note:** `ci.yml` triggers `pull_request` only on `branches: [main]`, so the full pipeline does **not** run on this stacked PR (base = a feature branch) — only Vercel does. It runs once #562 merges and this PR retargets `main`. Local gates are the verification meanwhile.

## Caveats

- **Paid feature:** Telegram "topics in private chats" is a paid capability; real topics can't be exercised in CI. Isolation is verified with **synthetic routes** (`TelegramRoute` with a `threadId`) at the `SessionManager` level — routing/keying correctness is covered; end-to-end behavior against a live paid account is unverified.
- **Provenance:** Step 6 was implemented largely by a delegated subagent that hit a tool time limit mid-edit; the work was then recovered, greened (two stale switcher test-assertions fixed), and the isolation tests + Step 7 were added by the main session before publishing.
