### PR TITLE
refactor(tui): retire committedBand* adjacency-coupling reads in frame-preserve (advances #540)

### DIFF
--- a/src/cli/terminal-compositor.frame-preserve.ts
+++ b/src/cli/terminal-compositor.frame-preserve.ts
@@ -97,8 +97,20 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
     ) {
       const overflow = bandLen - room;
       let out = '';
-      // Erase the old painted position (only the materialized suffix).
-      for (let r = Math.max(1, self.committedBandTopRow); r <= self.committedBandBottomRow; r++) {
+      // Invariant (#540 — erase from the geometric floor, not the tracked band
+      // top): clear the above-frame content region from the anchor floor (row 1
+      // here, `!hasBanner` ⇒ anchorFloor === 1 per the branch invariant above)
+      // down through the band's tracked bottom, rather than reading
+      // `committedBandTopRow` for the loop start. This mirrors the Stage-2-core
+      // repin change (#552, committed-band-repin.ts): the FULL model is repainted
+      // top-aligned at [1, bandLen] on the very next lines of the SAME batched
+      // `out` write, so any rows in [1, committedBandTopRow) the widened erase
+      // touches are re-covered with real band content before stdout sees them —
+      // observable output is unchanged (byte-for-byte where committedBandTopRow
+      // was already ≤ 1; a repainted-over transient otherwise). This retires the
+      // `committedBandTopRow` adjacency-coupling READ; the tracked `bottom` stays
+      // (it is the vacated-tail boundary, not derivable from geometry pre-Stage-3).
+      for (let r = 1; r <= self.committedBandBottomRow; r++) {
         out += eraseAndPaintRow(r);
       }
       // Paint the FULL model top-aligned at [1, bandLen] so the scroll evicts
@@ -138,7 +150,11 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
     // real content, never blank rows — into scrollback. The frame render that
     // follows repaints its own (lower) footprint; survivors sit above it.
     let out = '';
-    for (let r = Math.max(1, self.committedBandTopRow); r <= self.committedBandBottomRow; r++) {
+    // #540: erase from the geometric floor (row 1; `!hasBanner` ⇒ anchorFloor
+    // === 1), not the tracked `committedBandTopRow`. The [1, bandLen] repaint
+    // below re-covers the widened prefix on the same `out` write — see the full
+    // invariant on the pending-overflow eviction above.
+    for (let r = 1; r <= self.committedBandBottomRow; r++) {
       out += eraseAndPaintRow(r);
     }
     for (let i = 0; i < bandLen; i++) {
@@ -211,8 +227,14 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
   ) {
     const overflow = bandLenBanner - roomBanner;
     let out = '';
-    // Erase the old painted position (only the materialized suffix).
-    for (let r = Math.max(floorBanner, self.committedBandTopRow); r <= self.committedBandBottomRow; r++) {
+    // #540: erase from the geometric floor (`floorBanner` = max(anchorRow, 1)),
+    // not the tracked `committedBandTopRow`. The banner/anchor rows ABOVE
+    // `floorBanner` are still never touched (the loop starts AT floorBanner); the
+    // top-aligned [floorBanner, floorBanner+bandLen-1] repaint below re-covers the
+    // widened prefix on the same `out` write — see the full invariant on the
+    // !hasBanner pending-overflow eviction above. Retires the adjacency-coupling
+    // READ; the tracked `bottom` (vacated-tail boundary) stays.
+    for (let r = floorBanner; r <= self.committedBandBottomRow; r++) {
       out += eraseAndPaintRow(r);
     }
     // Paint the FULL model top-aligned at [floor, floor+bandLen-1] so the


### PR DESCRIPTION
## Summary

**Part of #540. Advances #540 — does NOT close it** (Stage 3 remains, see below).

Continues #552's **Stage 2** work (`render-not-repin`: erase the committed band from the anchor **floor**, not the tracked top). #552 landed that move in `repositionCommittedBand`; this PR applies the *same* geometric-floor move to the three erase loops in `preserveRowsBeforeFrameRender`, retiring their `committedBandTopRow` adjacency-coupling **reads**.

This is a **behavior-preserving internal refactor**. The rendered escape output is unchanged; the full test suite is byte-for-byte identical before and after (same pass/skip counts).

**Scope:** coupling removal only. **Stage 3 (single end-of-turn flush / retained `turnModel`) is explicitly OUT OF SCOPE and not implemented here.**

## What changed

One file: `src/cli/terminal-compositor.frame-preserve.ts` (+27 / −5; the bulk is explanatory in-code invariants — the logic delta is three loop-bound tokens).

Each of the three eviction branches erases the band's old footprint, then **immediately repaints the FULL band top-aligned on the next lines of the SAME batched `out` write** (one `stdout.write`). So widening the erase *start* from the tracked band top to the geometric floor is safe: any extra rows the widened erase touches are re-covered with real band content before stdout sees them.

### Retired (adjacency-coupling reads removed)

| Branch | Before | After |
|---|---|---|
| `!hasBanner` pending-overflow eviction | `for (r = Math.max(1, committedBandTopRow); …)` | `for (r = 1; …)` |
| `!hasBanner` legacy-growth eviction | `for (r = Math.max(1, committedBandTopRow); …)` | `for (r = 1; …)` |
| banner-path pending-overflow eviction | `for (r = Math.max(floorBanner, committedBandTopRow); …)` | `for (r = floorBanner; …)` |

`floorBanner = max(anchorRow, 1)`, `anchorFloor === 1` in the `!hasBanner` branches. The banner/anchor rows **above** `floorBanner` are still never touched (the banner-path loop starts *at* `floorBanner`, not row 1). This mirrors the `render-not-repin.test.ts` invariant #552 established.

### Kept — load-bearing / require Stage 3 (deliberately NOT retired)

Coupling removal is **not** cleanly separable from the retained-model rewrite at every site. A **partial** retirement is the correct, expected outcome here:

- **`committedBandBottomRow` erase-loop upper bounds** (lines 101/141/215): the band's *old on-screen bottom* — the vacated-tail boundary that must be blanked before the scroll. Not derivable from `(floor, targetBottom, bandLen)` without the retained model, because the top-aligned repaint only covers `[…, bandLen]`; a longer old float would leave a ghost tail.
- **Deficit-path guards** (`committedBandTopRow < floor` → `slice`/drop; `committedBandBottomRow < floor` → `clearCommittedBand()`): pure retained-position bookkeeping, no geometry substitute pre-Stage-3.
- **All `committedBand*` reads in `committed-band-commit.ts`** (0 retired): the `committedBandBottomRow + 1` floor (the `bandFloor` / `phase1EffectiveFrameTop` correction) fixes `logUpdate.topRow`'s **shrink-padding artifact** — a transient lower-than-real top that `measure()` geometry cannot reconstruct pre-Phase-2; and the merge-soundness **contiguity checks** (`committedBandBottomRow === newTopRow - 1`, and the `committedBandBottomRow` input fed to `decideCommitMode`) are inherently retained-model equality tests. The proposal flags these explicitly: `docs/proposals/tui-compositor-rewrite.md` §8 — *"read by ~10 sites assuming band-adjacency … Stage 2 removes the incremental band, so these collapse into the render path — **must be migrated together, not piecemeal.**"*
- **All field WRITES**: the `committedBand*Row` fields stay maintained for the commit/eviction paths that read them (per `committed-band-repin.ts` doc: *"still MAINTAINED here … removing that coupling entirely, plus the Stage 3 single end-of-turn flush, remain follow-ups"*).

### Phase-1 enumeration (81× across 7 non-test files)

| File | Reads retired | Load-bearing reads kept | Writes / decls | Comment-only |
|---|---|---|---|---|
| `committed-band-commit.ts` (36) | 0 | 8 (the `+1` floor ×3, contiguity ×3, `decideCommitMode` input, orphan-erase) | 10 | 18 |
| `frame-preserve.ts` (15) | **3** (loop lower bounds) | 3 (bottom bounds are load-bearing; deficit guards ×2) | 8 | — |
| `committed-band-repin.ts` (13) | 0 (Stage-2 core already done in #552) | reads for `moved`/`renderErasedBand` flicker guard | — | rest |
| `commit-mode.ts` (7) | 0 | `committedBandBottomRow` is a pure-function input param | — | — |
| `lifecycle.ts` (4) | 0 | reads for SIGWINCH ghost-erase snapshot + pending-flush | — | — |
| `terminal-compositor.ts` (3) | 0 | field declarations + doc | 2 | — |
| `frame.ts` (3) | 0 | FrameHost interface decls | — | — |

## Verdict: **PARTIAL** (retired the safe subset; kept the rest with justification)

3 reads retired in `frame-preserve.ts`; every other read is load-bearing or requires Stage 3.

## `git diff --stat`

```
 src/cli/terminal-compositor.frame-preserve.ts | 32 ++++++++++++++++++++++-----
 1 file changed, 27 insertions(+), 5 deletions(-)
```

## Test / lint / audit results

| Gate | Result |
|---|---|
| `pnpm test` | **637 files, 11632 passed / 14 skipped / 0 failed** (identical to pre-change baseline) |
| `pnpm lint` (`tsc --noEmit`, strict) | **exit 0** — no dead code / unused-var fallout |
| `pnpm audit:sdk:check` | **OK** — lock matches (no SDK import changes) |
| `pnpm audit:env:check` | **653 files, 0 violations** |
| `pnpm scan:env:check` | **in sync** (121 vars) |

Gap-class safety net specifically verified green (16 files / 44 tests): shrink-gap, scrollback-gap, overflow-gap, band-hold-perline-gap, endturn-overflow-gap, banner-endturn-overflow, two-table-overflow, resize-stale-width, **collapse-void**, **render-not-repin**, commit-mode.

## ⚠️ REQUIRED merge gate — real-terminal validation matrix (why this is a DRAFT)

**This PR is NOT mergeable on green tests alone.** The headless (`@xterm/headless`) suite confirms bytes were *written* and what the emulator buffer *shows*, but **cannot** certify real-PTY scrollback behavior — that is a property of the real terminal's scroll engine. **Two prior fixes (6d7cb90, 9690b9f) shipped green and were broken in a real terminal** (`docs/scrollback.md`). This is marked **draft precisely because that human gate is unmet at open time.**

A human must run, before this merges — reusing #552's harness:

**A/B repro (main vs. this branch), all four scenarios:**
```
pnpm exec tsx scripts/visual-void-repro.ts long
pnpm exec tsx scripts/visual-void-repro.ts short
pnpm exec tsx scripts/visual-void-repro.ts grow-collapse
pnpm exec tsx scripts/visual-void-repro.ts resize
```

**Plus interactive eyeball in iTerm2 / Apple Terminal / xterm:**
- dropdown headroom (open the slash-command menu on a fresh session — prompt must stay bottom-pinned, no downward shove)
- picker (arrow-key selector) rendering
- scroll up after a long turn with committed content — confirm no blank void between scrollback content and the frame, no duplicated/lost lines

Since the retired reads only affect the *erase footprint* of the eviction branches (not scroll count or scroll timing) and the output is headless-identical, the expected real-terminal delta is **none** — but that must be confirmed by eye, not assumed.

## Residual risk / what was NOT done

- **Stage 3 not implemented** (out of scope): the residual single-blank-row-between-scrollback-entries cosmetic (`docs/scrollback.md` residual (a)) and the remaining `committedBand*` reads in `committed-band-commit.ts` are still deferred to the retained-`turnModel` rewrite.
- **Real-terminal matrix un-run by the agent** (cannot see a terminal) — the hard human dependency above.
- Change is intentionally minimal — behavior preservation was prioritized over completeness per #540's guardrail.
