### PR TITLE
fix(agent): fail closed on unknown parent provider in fork credential fallback (#438)

### DIFF
--- a/src/agent/subagent.test.ts
+++ b/src/agent/subagent.test.ts
@@ -316,9 +316,13 @@ describe('SubagentManager', () => {
       );
     });
 
-    it('lets an OpenAI-shaped parent key flow to an OpenAI-routed child (same-provider inheritance)', async () => {
+    it('lets an OpenAI-shaped parent key flow to an OpenAI-routed child when parentModel marks the parent OpenAI (same-provider inheritance)', async () => {
+      // parentModel is what every production manager supplies (chat/bootstrap/
+      // telegram/compose all pass it): it makes parentProvider exact so the
+      // same-provider inheritance is allowed. Without it, inheritance fails
+      // closed — see the #438 test below.
       shared.lastConfig = null;
-      const mgr = new SubagentManager({ apiKey: 'sk-proj-PARENT' });
+      const mgr = new SubagentManager({ apiKey: 'sk-proj-PARENT', parentModel: 'gpt-5.5' });
       await mgr.forkSubagent({
         parent: { sessionId: 'p' },
         config: { model: 'gpt-5.5' },
@@ -328,6 +332,32 @@ describe('SubagentManager', () => {
       expect(shared.lastConfig).toEqual(
         expect.objectContaining({ apiKey: 'sk-proj-PARENT' }),
       );
+    });
+
+    it('fails closed when an OpenAI-shaped parent key has no parentModel — no inherit in either direction (#438)', async () => {
+      // Without parentModel the manager cannot prove the parent's provider, so a
+      // non-sk-ant key is never inherited: this closes the reverse
+      // (openai→anthropic) leak AND refuses the same-provider case until
+      // parentModel is supplied. Both children below must be credential-less.
+      shared.lastConfig = null;
+      const mgrOpenAiChild = new SubagentManager({ apiKey: 'sk-proj-PARENT' });
+      await mgrOpenAiChild.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'gpt-5.5' },
+        idPrefix: 'inherit-check',
+        agentType: 'inherit-check',
+      });
+      expect((shared.lastConfig as Record<string, unknown>)['apiKey']).toBeUndefined();
+
+      shared.lastConfig = null;
+      const mgrAnthropicChild = new SubagentManager({ apiKey: 'sk-proj-PARENT' });
+      await mgrAnthropicChild.forkSubagent({
+        parent: { sessionId: 'p' },
+        config: { model: 'sonnet' },
+        idPrefix: 'inherit-check',
+        agentType: 'inherit-check',
+      });
+      expect((shared.lastConfig as Record<string, unknown>)['apiKey']).toBeUndefined();
     });
 
     it('still inherits the Anthropic parent apiKey + baseUrl for an Anthropic-routed child', async () => {

--- a/src/agent/tools/child-credential.test.ts
+++ b/src/agent/tools/child-credential.test.ts
@@ -163,17 +163,21 @@ describe('applyManagerApiKeyFallback', () => {
     ).toBe(ANTHROPIC_OAUTH);
   });
 
-  it('lets an OpenAI-shaped parent credential flow to an OpenAI-routed child (same-provider inheritance)', () => {
+  it('fails closed for an OpenAI-shaped parent key with no parentProvider — even to an OpenAI child (#438)', () => {
+    // Without parentProvider the parent's provider is unknowable (a bare/sk-proj
+    // key could be OpenAI OR a local Anthropic-shim), so inheritance is refused
+    // even though the child here is OpenAI. Callers enable same-provider
+    // inheritance by supplying parentModel — see the provider-identity gate below.
     expect(
       applyManagerApiKeyFallback({
         childModel: OPENAI_CHILD,
         configApiKey: undefined,
         parentApiKey: OPENAI_KEY,
       }),
-    ).toBe(OPENAI_KEY);
+    ).toBeUndefined();
   });
 
-  it('lets the parent credential flow to an Anthropic-routed child (pre-existing inheritance path)', () => {
+  it('lets an sk-ant parent credential flow to an Anthropic-routed child (forward key-shape path, no parentProvider)', () => {
     expect(
       applyManagerApiKeyFallback({
         childModel: ANTHROPIC_CHILD,
@@ -267,5 +271,71 @@ describe('applyManagerApiKeyFallback — provider-identity gate (parentProvider)
         parentProvider: 'openai-compatible',
       }),
     ).toBe(ANTHROPIC_API);
+  });
+});
+
+// Fail-closed contract (#438): when the manager is built WITHOUT parentModel,
+// `parentProvider` is undefined. For a non-`sk-ant` parent key the provider is
+// then unknowable, so inheritance is refused outright — this makes the
+// reverse-direction (OpenAI parent key → Anthropic child) leak guard hold even
+// for callers that never supplied parentModel. The `sk-ant-` forward path is
+// deliberately retained.
+describe('applyManagerApiKeyFallback — fail-closed on unknown provider (#438)', () => {
+  // A local-Anthropic-shim key: not sk-ant-shaped, so with no parentProvider its
+  // provider cannot be proven and it must NOT be inherited across the boundary.
+  const LOCAL_SHIM_KEY = 'local-shim-secret-123';
+
+  it('refuses a non-sk-ant parent key for an Anthropic child when parentProvider is absent (the #438 reverse leak)', () => {
+    // The core bug: an OpenAI parent key with no parentProvider used to inherit
+    // unconditionally into an Anthropic child. It must now resolve to undefined.
+    expect(
+      applyManagerApiKeyFallback({
+        childModel: ANTHROPIC_CHILD,
+        configApiKey: undefined,
+        parentApiKey: OPENAI_KEY,
+      }),
+    ).toBeUndefined();
+    // Same for an unrecognizable local-shim-shaped key: without parentProvider
+    // we cannot prove it belongs to the Anthropic provider, so fail closed.
+    expect(
+      applyManagerApiKeyFallback({
+        childModel: ANTHROPIC_CHILD,
+        configApiKey: undefined,
+        parentApiKey: LOCAL_SHIM_KEY,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('still inherits an sk-ant parent key for an Anthropic child without parentProvider (forward key-shape path retained)', () => {
+    expect(
+      applyManagerApiKeyFallback({
+        childModel: ANTHROPIC_CHILD,
+        configApiKey: undefined,
+        parentApiKey: ANTHROPIC_OAUTH,
+      }),
+    ).toBe(ANTHROPIC_OAUTH);
+  });
+
+  it('re-enables same-provider inheritance once parentModel (→ parentProvider) is supplied', () => {
+    // The OpenAI→OpenAI case that now fails closed above resolves correctly the
+    // moment the caller supplies parentProvider (derived from parentModel).
+    expect(
+      applyManagerApiKeyFallback({
+        childModel: OPENAI_CHILD,
+        configApiKey: undefined,
+        parentApiKey: OPENAI_KEY,
+        parentProvider: 'openai-compatible',
+      }),
+    ).toBe(OPENAI_KEY);
+    // And a non-sk-ant local-shim key inherits into an Anthropic child when the
+    // provider is known — proving fail-closed only blocks the UNKNOWN case.
+    expect(
+      applyManagerApiKeyFallback({
+        childModel: ANTHROPIC_CHILD,
+        configApiKey: undefined,
+        parentApiKey: LOCAL_SHIM_KEY,
+        parentProvider: 'anthropic-direct',
+      }),
+    ).toBe(LOCAL_SHIM_KEY);
   });
 });

--- a/src/agent/tools/child-credential.ts
+++ b/src/agent/tools/child-credential.ts
@@ -78,10 +78,13 @@ export function applyParentCredentialFallback(args: {
  *
  * Fallback when `parentProvider` is absent (legacy callers / direct
  * construction that didn't pass `parentModel`): infer `'anthropic-direct'`
- * from an `sk-ant-` key so the forward guard still holds, and otherwise leave
- * it unknowable and inherit — exactly the pre-`parentModel` behavior, so no
- * existing caller regresses. The reverse-direction protection activates only
- * where the manager supplies `parentProvider`.
+ * from an `sk-ant-` key so the forward Anthropic-inheritance path still holds;
+ * for any other key the parent provider is unknowable, so FAIL CLOSED — do not
+ * inherit (#438). The pre-#438 fallback inherited here on key-shape, which
+ * silently disabled the reverse-direction (openai→anthropic) leak guard for any
+ * fork whose manager was built without `parentModel`. Refusing instead makes
+ * that guard hold unconditionally; a caller wanting same-provider inheritance
+ * in the unknown-key case must supply `parentModel`.
  *
  * Invariant: `parentProvider` and `providerForModel(childModel)` are both
  * canonical provider names (`'anthropic-direct'` / `'openai-compatible'`), so
@@ -99,6 +102,12 @@ export function applyManagerApiKeyFallback(args: {
   if (parentApiKey === undefined) return undefined;
   const effectiveParent =
     parentProvider ?? (isAnthropicCredential(parentApiKey) ? 'anthropic-direct' : undefined);
-  if (effectiveParent === undefined) return parentApiKey;
+  // Fail closed (#438): provider identity unknowable (no `parentModel`, and a
+  // non-`sk-ant` key whose shape reveals nothing) → do NOT inherit. Returning
+  // `parentApiKey` here (the pre-#438 behavior) silently disabled the
+  // reverse-direction (openai→anthropic) leak guard for any manager built
+  // without `parentModel`; refusing leaves the child credential-less (a loud
+  // pre-flight failure) rather than risk shipping a foreign-provider key.
+  if (effectiveParent === undefined) return undefined;
   return providerForModel(childModel) === effectiveParent ? parentApiKey : undefined;
 }


### PR DESCRIPTION
Closes #438.

## Problem
`applyManagerApiKeyFallback` (`src/agent/tools/child-credential.ts`) gated fork-time credential inheritance on `parentProvider === providerForModel(childModel)`, where `parentProvider` is derived once in the `SubagentManager` ctor from the optional `parentModel`. When a caller **omitted `parentModel`**, `parentProvider` was `undefined` and the fallback degraded to key-shape inference:

```ts
const effectiveParent =
  parentProvider ?? (isAnthropicCredential(parentApiKey) ? 'anthropic-direct' : undefined);
if (effectiveParent === undefined) return parentApiKey;   // <-- inherited UNCONDITIONALLY
```

A non-`sk-ant` parent key (bare `sk-` OpenAI key, or a local Anthropic-shim key) with `parentProvider` absent yielded `effectiveParent = undefined` and inherited unconditionally — turning **off** the reverse-direction (openai→anthropic) leak guard added by #374/#377 for that fork.

## Fix
Change the unknown-provider branch to **fail closed** (`return undefined`). The child is left credential-less (a loud pre-flight failure) rather than risk shipping a foreign-provider key across the boundary. This makes the reverse-leak guard hold unconditionally, even for a manager built without `parentModel`.

- The `sk-ant-` forward-inheritance path is deliberately **retained** (keychain-auth / local-shim Anthropic setups still inherit).
- A caller wanting same-provider inheritance for a *non-`sk-ant`* key must supply `parentModel` — which every production manager already does (`chat`, `bootstrap`, `telegram`, `compose-executor`, `skill-executor/fork-dispatch`, `mint/parallelize-dispatch`).

Chose fail-closed over threading `parentModel` through every call site: it's a one-line, reversible change that resolves the whole class of "forgot `parentModel`" regressions with a small blast radius, and states a cleaner contract (inheritance requires known provider identity) instead of a hidden key-shape fallback.

## Reachability (why no live caller regresses)
The fallback short-circuits at `if (parentApiKey === undefined) return undefined`, and `parentApiKey` is the manager's own `apiKey` (`subagent.ts:347,646`). Every manager that passes a non-`sk-ant` `apiKey` also passes `parentModel`; the managers that omit `parentModel` (the two nested child managers, all `mint` phases, `farm`, `user-skills`) pass **no** `apiKey`, so `parentApiKey` is `undefined` and the branch is never reached. Confirmed by running the full suite (see below).

## Tests
- Unit (`child-credential.test.ts`): flipped the one assertion that documented inherit-on-unknown (OpenAI→OpenAI, no `parentProvider`), and added a dedicated `#438` fail-closed `describe` block covering the reverse leak, the retained `sk-ant` forward path, and re-enabled inheritance once `parentProvider` is supplied.
- Integration (`subagent.test.ts`): updated the OpenAI→OpenAI inheritance test to pass `parentModel` (production-realistic) and added a fail-closed integration test asserting both an OpenAI child and an Anthropic child stay credential-less when the OpenAI-shaped parent key has no `parentModel`.

## Verification
- `pnpm lint` (tsc --noEmit, strict): clean
- `pnpm test`: **637 files, 11,638 passed, 14 skipped, 0 failed**
- `pnpm audit:sdk:check`, `pnpm audit:env:check`, `pnpm scan:env:check`: all OK

Note: this closes the *fallback logic* gap. The reachability analysis above (no live caller passes a non-`sk-ant` `apiKey` without `parentModel`) was done by reading every `new SubagentManager` site, not by exhaustive runtime enumeration — the fail-closed change makes the guard hold regardless.