### PR TITLE
feat(cli): OSC 52 clipboard fallback for SSH+tmux (closes #563)

### DIFF
--- a/src/cli/clipboard.test.ts
+++ b/src/cli/clipboard.test.ts
@@ -1,13 +1,36 @@
 /**
  * Tests for src/cli/clipboard.ts
  *
- * Selection logic is tested deterministically (no spawning). The spawn path
- * is exercised only via the never-throws contract — a bogus platform must
- * still resolve to a boolean rather than crash a caller like /fork.
+ * Selection logic and the OSC 52 encoder / DCS wrapper / $TMUX gating / TTY
+ * gating are tested deterministically (no spawning, no real terminal — the
+ * write sink is injected). The external-tool spawn path is exercised only via
+ * the never-throws contract — a bogus platform must still resolve to a boolean
+ * rather than crash a caller like /fork.
  */
 
 import { describe, it, expect } from 'vitest';
-import { clipboardToolsFor, copyToClipboard } from './clipboard.js';
+import {
+  clipboardToolsFor,
+  copyToClipboard,
+  copyViaOsc52,
+  osc52ClipboardSequence,
+  osc52Copy,
+  wrapTmuxPassthrough,
+  type Osc52Sink,
+} from './clipboard.js';
+
+/** A recording write sink; `isTTY` controls the OSC 52 gate. */
+function makeSink(isTTY: boolean | undefined): Osc52Sink & { chunks: string[] } {
+  const chunks: string[] = [];
+  return {
+    isTTY,
+    chunks,
+    write(s: string): boolean {
+      chunks.push(s);
+      return true;
+    },
+  };
+}
 
 describe('clipboardToolsFor', () => {
   it('uses pbcopy on macOS', () => {
@@ -26,6 +49,94 @@ describe('clipboardToolsFor', () => {
   });
 });
 
+describe('osc52Copy (OSC 52 encoder)', () => {
+  it('encodes text as base64 in a "c"-selection sequence terminated by BEL', () => {
+    // 'hi' → base64 'aGk=' ; wire format ESC ] 52 ; c ; <b64> BEL.
+    expect(osc52Copy('hi')).toBe('\x1b]52;c;aGk=\x07');
+  });
+
+  it('base64 round-trips arbitrary utf8 (newlines, spaces, unicode)', () => {
+    const text = 'line1\nlíne2 🚀';
+    const seq = osc52Copy(text);
+    const m = /^\x1b\]52;c;(.*)\x07$/.exec(seq);
+    expect(m).not.toBeNull();
+    expect(Buffer.from(m![1]!, 'base64').toString('utf8')).toBe(text);
+  });
+
+  it('carries exactly one ESC (the introducer) — base64 + BEL add none', () => {
+    // Load-bearing for tmux passthrough: only the leading ESC needs doubling.
+    expect(osc52Copy('anything at all').split('\x1b')).toHaveLength(2);
+  });
+});
+
+describe('wrapTmuxPassthrough (DCS envelope)', () => {
+  it('wraps a sequence in ESC P tmux ; … ESC \\ and doubles the ESC', () => {
+    expect(wrapTmuxPassthrough('\x1b]52;c;aGk=\x07')).toBe(
+      '\x1bPtmux;\x1b\x1b]52;c;aGk=\x07\x1b\\',
+    );
+  });
+
+  it('doubles every ESC byte in a multi-ESC payload', () => {
+    expect(wrapTmuxPassthrough('\x1bA\x1bB')).toBe('\x1bPtmux;\x1b\x1bA\x1b\x1bB\x1b\\');
+  });
+});
+
+describe('osc52ClipboardSequence ($TMUX gating)', () => {
+  it('returns the bare OSC 52 sequence when $TMUX is unset', () => {
+    expect(osc52ClipboardSequence('hi', {})).toBe(osc52Copy('hi'));
+  });
+
+  it('wraps in the tmux DCS passthrough envelope when $TMUX is set', () => {
+    expect(osc52ClipboardSequence('hi', { TMUX: '/tmp/tmux-1000/default,123,0' })).toBe(
+      wrapTmuxPassthrough(osc52Copy('hi')),
+    );
+  });
+
+  it('treats an empty-string $TMUX as "not in tmux" (matches detectTerminal truthiness)', () => {
+    expect(osc52ClipboardSequence('hi', { TMUX: '' })).toBe(osc52Copy('hi'));
+  });
+});
+
+describe('copyViaOsc52 (TTY-gated emitter)', () => {
+  it('writes the bare sequence to a TTY sink and returns true (no tmux)', () => {
+    const sink = makeSink(true);
+    expect(copyViaOsc52('hi', {}, sink)).toBe(true);
+    expect(sink.chunks.join('')).toBe(osc52Copy('hi'));
+  });
+
+  it('writes the tmux-wrapped sequence when $TMUX is set', () => {
+    const sink = makeSink(true);
+    expect(copyViaOsc52('hi', { TMUX: 'x' }, sink)).toBe(true);
+    expect(sink.chunks.join('')).toBe(wrapTmuxPassthrough(osc52Copy('hi')));
+  });
+
+  it('is a no-op (false, writes nothing) when isTTY is undefined — piped output', () => {
+    const sink = makeSink(undefined);
+    expect(copyViaOsc52('hi', {}, sink)).toBe(false);
+    expect(sink.chunks).toHaveLength(0);
+  });
+
+  it('is a no-op when isTTY is false', () => {
+    const sink = makeSink(false);
+    expect(copyViaOsc52('hi', {}, sink)).toBe(false);
+    expect(sink.chunks).toHaveLength(0);
+  });
+
+  it('never throws — a write() that throws resolves to false', () => {
+    const throwingSink: Osc52Sink = {
+      isTTY: true,
+      write(): boolean {
+        throw new Error('backpressure explosion');
+      },
+    };
+    let result: unknown;
+    expect(() => {
+      result = copyViaOsc52('hi', {}, throwingSink);
+    }).not.toThrow();
+    expect(result).toBe(false);
+  });
+});
+
 describe('copyToClipboard', () => {
   it('always returns a boolean and never throws (best-effort contract)', () => {
     // Platform-agnostic: whatever the host, a missing utility resolves to
@@ -37,4 +148,28 @@ describe('copyToClipboard', () => {
     }).not.toThrow();
     expect(typeof result).toBe('boolean');
   });
+
+  // The win32 tool (`clip`) is absent on the POSIX test hosts (CI = ubuntu,
+  // dev = macOS), so the external-tool loop exhausts and the OSC 52 fallback
+  // fires deterministically. Skipped on Windows, where a real `clip` would
+  // intercept before the fallback is reached.
+  it.skipIf(process.platform === 'win32')(
+    'falls back to OSC 52 when no local tool succeeds',
+    () => {
+      const sink = makeSink(true);
+      const ok = copyToClipboard('hi', 'win32', {}, sink);
+      expect(ok).toBe(true);
+      expect(sink.chunks.join('')).toBe(osc52Copy('hi'));
+    },
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'does not emit OSC 52 into a non-TTY sink (piped output stays clean)',
+    () => {
+      const sink = makeSink(false);
+      const ok = copyToClipboard('hi', 'win32', {}, sink);
+      expect(sink.chunks).toHaveLength(0);
+      expect(ok).toBe(false);
+    },
+  );
 });

--- a/src/cli/clipboard.ts
+++ b/src/cli/clipboard.ts
@@ -5,13 +5,44 @@
  * (e.g. /fork) always print the value too. `copyToClipboard` therefore never
  * throws: a missing utility, a headless box, or a non-zero exit all resolve to
  * `false`, and the caller falls back to the printed text.
+ *
+ * Two mechanisms, tried in order:
+ *   1. Local OS utilities (pbcopy / clip / wl-copy / xclip / xsel). Preferred
+ *      when present because they hit the machine's real clipboard directly.
+ *   2. OSC 52 escape sequence written to the TTY. This is the *remote* path:
+ *      over SSH (and SSH+tmux) the local utilities either don't exist or reach
+ *      only the remote box, so a copy silently no-ops. OSC 52 instead rides the
+ *      terminal's own byte stream back to the outer emulator (iTerm2, kitty,
+ *      WezTerm, …), which owns the real clipboard. Inside tmux the sequence is
+ *      wrapped in a DCS passthrough envelope; that path additionally requires
+ *      `set -g allow-passthrough on` (and `set -g set-clipboard on`) in the
+ *      user's tmux config, since passthrough is off by default in some tmux
+ *      versions.
+ *
+ * env-access note: the OSC 52 path detects tmux by delegating to
+ * `detectTerminal()` (the canonical $TMUX check, reused rather than
+ * re-implemented), reading env via an injectable `NodeJS.ProcessEnv` parameter
+ * defaulting to `process.env` — the same injectable-test-seam pattern as
+ * `src/cli/hyperlink.ts` and `src/cli/terminal-spawn/`. The audit script skips
+ * default-param seams, and TMUX is an OS-level var outside the AFK domain,
+ * intentionally not in ENV_REGISTRY.
  */
 
 import { spawnSync } from 'node:child_process';
+import { detectTerminal } from './terminal-spawn/detect.js';
 
 interface ClipboardTool {
   cmd: string;
   args: string[];
+}
+
+/**
+ * Minimal writable-TTY seam so the OSC 52 emitter is unit-testable without a
+ * real terminal. `process.stdout` satisfies it structurally.
+ */
+export interface Osc52Sink {
+  write(chunk: string): boolean;
+  isTTY?: boolean;
 }
 
 /**
@@ -36,10 +67,82 @@ export function clipboardToolsFor(platform: NodeJS.Platform): ClipboardTool[] {
 }
 
 /**
- * Copy `text` to the system clipboard. Returns true if a utility accepted it,
- * false otherwise. `platform` is injectable for testing.
+ * Encode `text` as an OSC 52 clipboard-write sequence targeting the "c"
+ * (clipboard) selection. Wire format: `ESC ] 52 ; c ; <base64> BEL`. The BEL
+ * (`\x07`) terminator — rather than ST (`ESC \`) — keeps the sequence free of
+ * interior ESC bytes, which simplifies the tmux passthrough escaping in
+ * {@link wrapTmuxPassthrough}.
  */
-export function copyToClipboard(text: string, platform: NodeJS.Platform = process.platform): boolean {
+export function osc52Copy(text: string): string {
+  const b64 = Buffer.from(text, 'utf8').toString('base64');
+  return `\x1b]52;c;${b64}\x07`;
+}
+
+/**
+ * Wrap an escape `sequence` in tmux's DCS passthrough envelope so it reaches
+ * the *outer* terminal instead of being swallowed by tmux. Wire format:
+ * `ESC P tmux ; <payload> ESC \`, where every ESC byte in the payload is
+ * doubled — tmux's passthrough escaping rule (the Neovim / tmux-yank approach).
+ * Requires `set -g allow-passthrough on` in the user's tmux config.
+ */
+export function wrapTmuxPassthrough(sequence: string): string {
+  const escaped = sequence.replace(/\x1b/g, '\x1b\x1b');
+  return `\x1bPtmux;${escaped}\x1b\\`;
+}
+
+/**
+ * Build the OSC 52 clipboard sequence for `text`, DCS-wrapped for tmux iff
+ * we're inside tmux (`detectTerminal` returns `'tmux'`, i.e. `$TMUX` is set).
+ * Pure: emission and TTY-gating live in {@link copyViaOsc52}.
+ */
+export function osc52ClipboardSequence(
+  text: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const seq = osc52Copy(text);
+  return detectTerminal(env) === 'tmux' ? wrapTmuxPassthrough(seq) : seq;
+}
+
+/**
+ * Emit the OSC 52 clipboard sequence for `text` to a TTY. Returns true if the
+ * sequence was written, false if the sink is not a TTY (piped/redirected — we
+ * must never inject escape bytes into non-terminal output) or the write throws.
+ *
+ * "Written" is not "confirmed landed": OSC 52 has no acknowledgement, and an
+ * outer terminal lacking OSC 52 support (or a tmux without passthrough enabled)
+ * silently drops it. That is acceptable under the best-effort contract —
+ * callers always print the text as a backup regardless.
+ */
+export function copyViaOsc52(
+  text: string,
+  env: NodeJS.ProcessEnv = process.env,
+  sink: Osc52Sink = process.stdout,
+): boolean {
+  if (sink.isTTY !== true) return false;
+  try {
+    // Ignore the write() backpressure boolean: a `false` return means "buffered"
+    // (still queued), not "failed". Only a throw signals a real failure.
+    sink.write(osc52ClipboardSequence(text, env));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Copy `text` to the system clipboard. Returns true if a mechanism accepted it,
+ * false otherwise. `platform`, `env`, and `sink` are injectable for testing.
+ *
+ * Order: local OS utilities first (they own the real clipboard when present),
+ * then an OSC 52 fallback for the SSH / SSH+tmux case where no local utility
+ * reaches the user's clipboard. The fallback is TTY-gated and never throws.
+ */
+export function copyToClipboard(
+  text: string,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+  sink: Osc52Sink = process.stdout,
+): boolean {
   for (const tool of clipboardToolsFor(platform)) {
     try {
       const res = spawnSync(tool.cmd, tool.args, { input: text });
@@ -50,5 +153,7 @@ export function copyToClipboard(text: string, platform: NodeJS.Platform = proces
       // Defensive: try the next tool on any unexpected throw.
     }
   }
-  return false;
+  // Local utilities are absent or failed (the SSH / SSH+tmux case). Fall back
+  // to OSC 52 over the terminal's own channel.
+  return copyViaOsc52(text, env, sink);
 }

--- a/src/cli/slash/commands/fork.test.ts
+++ b/src/cli/slash/commands/fork.test.ts
@@ -11,11 +11,27 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { existsSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+
+// Mocked so tests never touch the real system clipboard or attempt to spawn a
+// real terminal tab — and so the interactive-surface gating (the fix for the
+// PR #582 Codex review finding, below) is deterministically observable.
+vi.mock('../../clipboard.js', () => ({
+  copyToClipboard: vi.fn(),
+}));
+vi.mock('../../terminal-spawn/index.js', () => ({
+  trySpawnTab: vi.fn(),
+}));
+
 import { forkCmd, forkSpawnLines } from './fork.js';
 import { listSessions, loadSession } from '../../session-store.js';
 import { createSessionStats, recordTurn } from '../session-stats.js';
+import { copyToClipboard } from '../../clipboard.js';
+import { trySpawnTab } from '../../terminal-spawn/index.js';
 import type { SlashContext, SessionStats } from '../types.js';
 import type { SpawnOutcome } from '../../terminal-spawn/index.js';
+
+const mockedCopyToClipboard = vi.mocked(copyToClipboard);
+const mockedTrySpawnTab = vi.mocked(trySpawnTab);
 
 let tmpHome: string;
 let originalHome: string | undefined;
@@ -24,14 +40,24 @@ beforeEach(() => {
   originalHome = process.env['HOME'];
   tmpHome = join(tmpdir(), `afk-fork-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   process.env['HOME'] = tmpHome;
+
+  // Default: mirror the real trySpawnTab behavior for a non-interactive ctx
+  // (no requestResume) — spawn refuses, clipboard would be the only fallback.
+  mockedTrySpawnTab.mockReturnValue({ spawned: false, kind: 'unknown', capability: 'none', reason: 'non-interactive-surface' });
+  mockedCopyToClipboard.mockReturnValue(false);
 });
 
 afterEach(() => {
   if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
   if (originalHome !== undefined) process.env['HOME'] = originalHome;
+  vi.clearAllMocks();
+  Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: undefined });
 });
 
-function makeCtx(stats: SessionStats): { ctx: SlashContext; lines: string[] } {
+function makeCtx(
+  stats: SessionStats,
+  opts: { interactive?: boolean } = {},
+): { ctx: SlashContext; lines: string[] } {
   const lines: string[] = [];
   const push = (t = ''): void => { lines.push(t); };
   const ctx: SlashContext = {
@@ -39,6 +65,9 @@ function makeCtx(stats: SessionStats): { ctx: SlashContext; lines: string[] } {
     stats,
     out: { line: push, raw: push, success: push, info: push, warn: push, error: push },
     ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
+    // requestResume is the established local-interactive-REPL marker — absent
+    // for Telegram/daemon ctx (see /resume and /fork's own interactive check).
+    ...(opts.interactive ? { requestResume: vi.fn() } : {}),
   } as unknown as SlashContext;
   return { ctx, lines };
 }
@@ -94,6 +123,45 @@ describe('/fork', () => {
 
     // The fork never swaps the running session: its sessionId is unchanged.
     expect(ctx.stats.sessionId).toBe('live-id');
+  });
+});
+
+// Regression coverage for the PR #582 Codex review finding: the OSC 52
+// clipboard fallback must be gated on the same local-interactive-REPL check as
+// the tab spawn. Without the gate, a Telegram/daemon-invoked /fork on a host
+// process that still has its own TTY would write escape bytes to that host's
+// terminal while telling the remote caller "(copied to clipboard)" — a copy
+// that landed on the wrong machine reported as a success.
+describe('/fork clipboard fallback — interactive-surface gating', () => {
+  it('never calls copyToClipboard on a non-interactive surface, even when the host process has a TTY', async () => {
+    const stats = createSessionStats('sonnet');
+    recordTurn(stats, 'q', 'a', { sessionId: 'live-id' });
+    const { ctx, lines } = makeCtx(stats); // no requestResume => non-interactive (Telegram/daemon shape)
+
+    // The exact scenario from the review comment: the bot/daemon host has its
+    // own TTY, and the clipboard write would succeed if it were attempted.
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
+    mockedCopyToClipboard.mockReturnValue(true);
+
+    await forkCmd.handler(ctx, '');
+
+    expect(mockedCopyToClipboard).not.toHaveBeenCalled();
+    expect(lines.join('\n')).not.toContain('copied to clipboard');
+  });
+
+  it('falls back to the clipboard on the local interactive REPL when the tab spawn does not happen', async () => {
+    const stats = createSessionStats('sonnet');
+    recordTurn(stats, 'q', 'a', { sessionId: 'live-id' });
+    const { ctx, lines } = makeCtx(stats, { interactive: true });
+
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
+    mockedTrySpawnTab.mockReturnValue({ spawned: false, kind: 'unknown', capability: 'none', reason: 'no-tab-mechanism' });
+    mockedCopyToClipboard.mockReturnValue(true);
+
+    await forkCmd.handler(ctx, '');
+
+    expect(mockedCopyToClipboard).toHaveBeenCalledTimes(1);
+    expect(lines.join('\n')).toContain('copied to clipboard');
   });
 });
 

--- a/src/cli/slash/commands/fork.ts
+++ b/src/cli/slash/commands/fork.ts
@@ -7,11 +7,12 @@
  * history, resumable via `afk interactive --resume <new-id>`.
  *
  * Two layers, decoupled:
- *   - Always: write the fork + print the resume command + best-effort
- *     clipboard copy. This is the contract that can never fail silently.
- *   - Best-effort: on a local interactive REPL, detect the terminal and open
- *     the fork in a new tab/window. Any failure degrades to the printed
- *     command — never a false success.
+ *   - Always: write the fork + print the resume command. This is the
+ *     contract that can never fail silently.
+ *   - Best-effort, local-interactive-REPL only: detect the terminal and open
+ *     the fork in a new tab/window, or (if that doesn't happen) copy the
+ *     resume command to the clipboard. Both degrade to the printed command —
+ *     never a false success, and never fired for Telegram/daemon callers.
  */
 
 import { palette } from '../../palette.js';
@@ -87,12 +88,18 @@ export const forkCmd: SlashCommand = {
     const command = formatResumeCommand(id, ctx.stats.model);
     const cwd = ctx.stats.cwd ?? process.cwd();
 
-    // Best-effort tab spawn. Only on the local interactive REPL (requestResume
-    // is the established marker — absent on Telegram/daemon, see /resume) and a
-    // real TTY. Never blocks or throws; failure falls through to the print path.
+    // Best-effort tab spawn AND clipboard fallback. Both are gated on the same
+    // local-interactive-REPL check (requestResume is the established marker —
+    // absent on Telegram/daemon, see /resume) and a real TTY. Without this
+    // gate, a Telegram/daemon-invoked /fork on a host that still has its own
+    // TTY (e.g. the bot run directly in a terminal rather than as a service)
+    // would fall through to the OSC 52 path and write escape bytes into the
+    // *host's* terminal while reporting "(copied to clipboard)" to the remote
+    // caller — copying to the wrong machine's clipboard while claiming success.
+    // Never blocks or throws; failure falls through to the print path.
     const interactive = typeof ctx.requestResume === 'function' && process.stdout.isTTY === true;
     const spawn = trySpawnTab({ forkId: id, model: ctx.stats.model, cwd, interactive });
-    const copied = !spawn.spawned && copyToClipboard(command);
+    const copied = !spawn.spawned && interactive && copyToClipboard(command);
 
     ctx.out.success(palette.success('Forked') + palette.dim(`  ${path}`));
     ctx.out.line();


### PR DESCRIPTION
## Summary

Closes #563.

`copyToClipboard` previously wrote only via local OS utilities (`pbcopy` / `clip` / `wl-copy` / `xclip` / `xsel`). Over **SSH** (and **SSH+tmux**) none of these reach the *local* machine's clipboard, so a copy silently no-op'd — dead in exactly the remote-dev setup where it's most wanted (it failed *closed*: callers print the text as a backup, so nothing broke).

This adds an **OSC 52** fallback, tried **after** the local external tools are absent or fail, so it rides the terminal's own byte stream back to the outer emulator (iTerm2, kitty, WezTerm, …) that owns the real clipboard.

## What changed

`src/cli/clipboard.ts` — three small pure/seam functions + wiring:

- **`osc52Copy(text)`** — encodes `ESC ] 52 ; c ; <base64> BEL`. The **BEL** terminator (not ST) keeps the payload free of interior `ESC` bytes, which simplifies tmux escaping.
- **`wrapTmuxPassthrough(seq)`** — wraps in tmux's **DCS passthrough** envelope (`ESC P tmux ; <payload> ESC \`, every `ESC` doubled) — the Neovim / tmux-yank approach.
- **`osc52ClipboardSequence(text, env)`** — applies the DCS wrap **only when inside tmux**, detected by **reusing `detectTerminal()`** (the canonical `$TMUX` check, per the issue).
- **`copyViaOsc52(text, env, sink)`** — TTY-gated emitter: never injects escape bytes into piped / non-TTY output (Telegram/daemon stay clean), never throws.
- **`copyToClipboard`** now falls back to `copyViaOsc52` after the external-tool loop. `env`/`sink` are added as defaulted, injectable test seams; the sole caller (`/fork`, one arg) is unaffected — and now gains OSC 52 over SSH automatically.

## Acceptance criteria

- [x] Copying over SSH+tmux (with `allow-passthrough on`) lands in the local clipboard — DCS-wrapped OSC 52 emitted to the TTY.
- [x] Local (non-SSH) behavior unchanged — external tools still win when present (fallback only fires on their failure).
- [x] DCS wrapper applied only when `$TMUX` is set; graceful no-op + text-print preserved when neither path works (TTY gate → `false`, caller prints the text).
- [x] Unit coverage for the OSC 52 encoder and the `$TMUX`-gated DCS wrapping (19 tests total: encoder, DCS wrap, `$TMUX` gating, TTY gating, external-fail → fallback wiring).

## Notes

- The tmux path requires `set -g allow-passthrough on` (and `set -g set-clipboard on`); documented inline in the module header — it can't be auto-detected, and OSC 52 has no acknowledgement, so `copyViaOsc52` returning `true` means "written," not "confirmed landed." That's fine under the best-effort contract (callers always print the text too).
- `env` is read only via the injectable default-param seam and through `detectTerminal()`; `pnpm audit:env:check` passes with no new `ENV_REGISTRY` entry (consistent with `hyperlink.ts` / `terminal-spawn/`).

## Verification

Local, on this branch:

- `pnpm lint` (tsc --noEmit, strict) ✓
- `pnpm test` — 637 files, 11649 passed / 14 skipped ✓
- `pnpm test:coverage` — gate passes; `clipboard.ts` 98.3% stmts / 100% funcs ✓
- `pnpm audit:env:check` ✓ · `pnpm scan:env:check` ✓ · `pnpm audit:sdk:check` ✓ · `pnpm build` ✓
