### PR TITLE
docs(hooks): document Stop shell-hook additionalContext reaching the next-turn prompt

### DIFF
--- a/src/agent/hooks/command-executor.ts
+++ b/src/agent/hooks/command-executor.ts
@@ -15,6 +15,12 @@
  *   `decision: "block", reason: "…"`          → block with explanation
  *   `hookSpecificOutput.additionalContext`     → `injectContext` in result
  *
+ * This module is event-agnostic: it maps `additionalContext` into
+ * `HookDecision.injectContext` regardless of which event triggered it. What
+ * happens to that value next is caller-defined per event — see `../hooks.js`
+ * for the full contract (notably `Stop`, where a config-driven shell hook's
+ * `additionalContext` ends up prepended to the *next* turn's prompt).
+ *
  * @module agent/hooks/command-executor
  */
 

--- a/src/agent/hooks/config-bridge.ts
+++ b/src/agent/hooks/config-bridge.ts
@@ -7,6 +7,13 @@
  * if it is false, no handlers are registered and a warning naming the skipped
  * hooks is emitted.
  *
+ * A handler registered here for `'Stop'` inherits the harness `Stop` →
+ * next-turn `injectContext` delivery documented in `../hooks.js`: a `Stop`
+ * shell hook's `hookSpecificOutput.additionalContext` (mapped in
+ * `./command-executor.js`) is prepended to the *next* turn's prompt by the
+ * REPL loop. Pre-existing primitive, gated by the trust check above — not a
+ * new trust boundary.
+ *
  * @module agent/hooks/config-bridge
  */
 

--- a/website/content/docs/configuration/overview.mdx
+++ b/website/content/docs/configuration/overview.mdx
@@ -316,12 +316,20 @@ user-global file.
 | `SessionEnd` | When a session finishes. | `hook_event_name`, `session_id`, `reason` | All |
 | `SubagentStart` | When a subagent session is forked. | `hook_event_name`, `session_id` | All |
 | `SubagentStop` | When a subagent session finishes. `hookSpecificOutput.additionalContext` injects text into the parent session. | `hook_event_name`, `session_id` | All |
-| `Stop` | After a main-session turn completes (end of one agent turn). Dispatched from the REPL turn loop only — subagents do not fire it. | `hook_event_name`, `session_id` | REPL only |
-| `UserPromptSubmit` | When the user submits a prompt in the REPL, after shell injection and forward-manifest stitching but before `runTurn`. Handler can return `injectContext` to prepend text to the prompt. | `hook_event_name`, `session_id`, `prompt` | REPL only |
+| `Stop` | After a main-session turn completes (end of one agent turn). Dispatched from the REPL turn loop only — subagents do not fire it. `hookSpecificOutput.additionalContext` is stashed and prepended to the **next** turn's prompt — the same next-turn delivery contract as `UserPromptSubmit` below, but fired from the turn-completion boundary rather than the submission boundary. | `hook_event_name`, `session_id` | REPL only |
+| `UserPromptSubmit` | When the user submits a prompt in the REPL, after shell injection and forward-manifest stitching but before `runTurn`. Handler can return `injectContext` (`hookSpecificOutput.additionalContext`) to prepend text to the prompt. | `hook_event_name`, `session_id`, `prompt` | REPL only |
 | `PreCompact` | Before context compaction runs. `trigger` is `"manual"` (via `/compact` command) or `"auto"` (threshold-based, reserved for future wiring). | `hook_event_name`, `session_id`, `trigger` (`null` when unset) | All |
 | `PostToolUseFailure` | After a tool call throws an error. Distinct from `PostToolUse` — only one fires per call. `tool_input` is intentionally not forwarded to shell hooks to avoid exposing sensitive inputs to arbitrary scripts. | `hook_event_name`, `session_id`, `tool_name`, `error` | All |
 
 Every event's payload also includes `cwd` and `transcript_path` (the latter is `null` when no transcript file is tracked).
+
+**A `Stop` hook's output reaches the model.** Because `Stop` fires after every
+REPL turn, a `Stop` shell hook that returns `hookSpecificOutput.additionalContext`
+feeds that text into the **next** turn's prompt — the same channel
+`UserPromptSubmit` uses. This is the general `injectContext` primitive (see
+`src/agent/hooks.ts`) applied to a config-driven shell hook; it introduces no
+new trust boundary, since it only fires when you have already opted a `Stop`
+hook in under the `enableShellHooks` gate below.
 
 #### Matcher group fields
 
@@ -342,7 +350,7 @@ Every event's payload also includes `cwd` and `transcript_path` (the latter is `
 
 | Exit code | Meaning |
 |-----------|---------|
-| `0` | Continue. Optional JSON stdout may carry `{ "decision": "block", "reason": "…" }` to block, or `{ "hookSpecificOutput": { "additionalContext": "…" } }` for `SubagentStop` context injection. |
+| `0` | Continue. Optional JSON stdout may carry `{ "decision": "block", "reason": "…" }` to block, or `{ "hookSpecificOutput": { "additionalContext": "…" } }` for context injection. Effect depends on the event — see `SubagentStop`, `Stop`, and `UserPromptSubmit` in the Event keys table above. |
 | `2` | Block the operation. `stderr` becomes the reason shown to users. |
 | other | Non-blocking error — logged, operation continues. |
 


### PR DESCRIPTION
## Summary

Closes #566. #557 made the REPL loop capture the `Stop` hook dispatch's
return value instead of discarding it. Because config-driven shell hooks
can register on the `Stop` event (`src/agent/hooks/config-bridge.ts:69`)
and their JSON stdout `hookSpecificOutput.additionalContext` maps to
`injectContext` (`src/agent/hooks/command-executor.ts:319-323`), a `Stop`
shell hook's `additionalContext` now reaches the **next-turn prompt**
where it was previously dropped silently.

This is the pre-existing `injectContext` primitive working as designed
(not a defect) and it's gated behind the same human-tier
`enableShellHooks` flag as every other shell hook — no new trust
boundary. It just wasn't documented anywhere, so an operator authoring a
`Stop` shell hook had no way to know its stdout now feeds the model.

## What changed

- **`website/content/docs/configuration/overview.mdx`** (the operator
  reference for `enableShellHooks` / the `hooks` config block):
  - The `Stop` row in the Event keys table now states that
    `hookSpecificOutput.additionalContext` is prepended to the next
    turn's prompt (same delivery contract as `UserPromptSubmit`).
  - The exit-code `0` row no longer implies `additionalContext` only
    matters for `SubagentStop` — it now points at all three events that
    honor it (`SubagentStop`, `Stop`, `UserPromptSubmit`).
  - Added a short callout directly under the event table spelling out
    the next-turn delivery and the "no new trust boundary" framing.
- **`src/agent/hooks/config-bridge.ts`** and
  **`src/agent/hooks/command-executor.ts`**: added cross-reference
  comments (the two files the issue cites as the mechanism) pointing at
  `hooks.ts`'s per-event `injectContext` contract, so a source reader
  lands on the same explanation the operator docs give.

No runtime behavior changes — comments and docs only.

## How was this tested?

- `pnpm lint` (`tsc --noEmit --strict`) — clean.
- `pnpm test` — full suite green: 642 files / 11728 passed, 14 skipped,
  0 failed.
- `cd website && npm run typecheck && npm run build` — the docs site
  typechecks and builds cleanly with the edited MDX (mirrors the `docs`
  CI job).

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the DCO
- [x] No secrets, tokens, or private paths in the diff

---
_Opened by autonomous agent (AFK). Human review welcome before merge._
