### PR TITLE
perf(web): lazy-load jsdom to cut ~35% off CLI cold-start

### DIFF
--- a/src/web/extract.test.ts
+++ b/src/web/extract.test.ts
@@ -5,6 +5,13 @@
  * the markdown / title / fallback outputs. The key behaviors are (a) main
  * content isolation strips chrome, (b) markdown formatting is faithful, and
  * (c) sparse pages degrade to a flagged whole-body fallback.
+ *
+ * `extractReadableMarkdown()` is async (it lazily imports jsdom/Readability/
+ * Turndown on first call — see extract.ts) so every call site here awaits it.
+ * The static `Readability` import below is only for `vi.spyOn` in the last
+ * describe block; it resolves to the same module instance extract.ts's
+ * dynamic `import()` loads, since Node's module cache is keyed by resolved
+ * specifier regardless of import style.
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -36,8 +43,8 @@ function articlePage(): string {
 }
 
 describe('extractReadableMarkdown — main content isolation', () => {
-  it('isolates the article and strips nav/sidebar/footer chrome', () => {
-    const out = extractReadableMarkdown(articlePage(), 'https://example.com/post');
+  it('isolates the article and strips nav/sidebar/footer chrome', async () => {
+    const out = await extractReadableMarkdown(articlePage(), 'https://example.com/post');
     expect(out.usedFallback).toBe(false);
     expect(out.markdown).toContain('main article body');
     // Chrome should be gone.
@@ -46,24 +53,24 @@ describe('extractReadableMarkdown — main content isolation', () => {
     expect(out.markdown).not.toContain('About');
   });
 
-  it('derives the title', () => {
-    const out = extractReadableMarkdown(articlePage(), 'https://example.com/post');
+  it('derives the title', async () => {
+    const out = await extractReadableMarkdown(articlePage(), 'https://example.com/post');
     expect(out.title).toBe('The Real Title');
   });
 
-  it('reports a non-trivial textLength above the thin threshold', () => {
-    const out = extractReadableMarkdown(articlePage(), 'https://example.com/post');
+  it('reports a non-trivial textLength above the thin threshold', async () => {
+    const out = await extractReadableMarkdown(articlePage(), 'https://example.com/post');
     expect(out.textLength).toBeGreaterThan(THIN_CONTENT_CHARS);
   });
 
-  it('resolves relative links to absolute URLs', () => {
-    const out = extractReadableMarkdown(articlePage(), 'https://example.com/post');
+  it('resolves relative links to absolute URLs', async () => {
+    const out = await extractReadableMarkdown(articlePage(), 'https://example.com/post');
     expect(out.markdown).toContain('https://example.com/relative/link');
   });
 });
 
 describe('extractReadableMarkdown — markdown formatting', () => {
-  it('emits ATX headings and fenced code blocks', () => {
+  it('emits ATX headings and fenced code blocks', async () => {
     const html = `<!DOCTYPE html><html><head><title>Doc</title></head><body><article>
       <h2>Heading Two</h2>
       <p>Intro paragraph with enough text to be considered an article body by the
@@ -72,7 +79,7 @@ describe('extractReadableMarkdown — markdown formatting', () => {
       <pre><code>const x = 1;</code></pre>
       <ul><li>first</li><li>second</li></ul>
     </article></body></html>`;
-    const out = extractReadableMarkdown(html, 'https://example.com/doc');
+    const out = await extractReadableMarkdown(html, 'https://example.com/doc');
     expect(out.markdown).toMatch(/^#+ Heading Two/m);
     expect(out.markdown).toContain('```');
     expect(out.markdown).toContain('const x = 1;');
@@ -82,10 +89,10 @@ describe('extractReadableMarkdown — markdown formatting', () => {
 });
 
 describe('extractReadableMarkdown — thin / fallback paths', () => {
-  it('reports a thin textLength for a JS-gated app shell (escalation signal)', () => {
+  it('reports a thin textLength for a JS-gated app shell (escalation signal)', async () => {
     const html = `<!DOCTYPE html><html><head><title>App Shell</title></head>
       <body><div id="root"><p>Loading…</p></div></body></html>`;
-    const out = extractReadableMarkdown(html, 'https://example.com/app');
+    const out = await extractReadableMarkdown(html, 'https://example.com/app');
     expect(out.title).toBe('App Shell');
     expect(out.markdown).toContain('Loading');
     // The escalation signal is a thin extraction — Readability may or may not
@@ -94,20 +101,20 @@ describe('extractReadableMarkdown — thin / fallback paths', () => {
     expect(out.textLength).toBeLessThan(THIN_CONTENT_CHARS);
   });
 
-  it('drops script and style content in the fallback path', () => {
+  it('drops script and style content in the fallback path', async () => {
     const html = `<!DOCTYPE html><html><head><title>X</title></head><body>
       <script>console.log('should not appear');</script>
       <style>.a{color:red}</style>
       <div>visible text</div>
     </body></html>`;
-    const out = extractReadableMarkdown(html, 'https://example.com/x');
+    const out = await extractReadableMarkdown(html, 'https://example.com/x');
     expect(out.markdown).toContain('visible text');
     expect(out.markdown).not.toContain('should not appear');
     expect(out.markdown).not.toContain('color:red');
   });
 
-  it('handles an empty document without throwing', () => {
-    const out = extractReadableMarkdown('<html></html>', 'https://example.com/empty');
+  it('handles an empty document without throwing', async () => {
+    const out = await extractReadableMarkdown('<html></html>', 'https://example.com/empty');
     expect(out.usedFallback).toBe(true);
     expect(out.markdown).toBe('');
     expect(out.textLength).toBe(0);
@@ -115,8 +122,8 @@ describe('extractReadableMarkdown — thin / fallback paths', () => {
 });
 
 describe('extractReadableMarkdown — Readability.parse() throws (safeExtract catch branch)', () => {
-  it('falls back to whole-body content when Readability.parse() throws', () => {
-    // Branch: extract.ts lines 84-89 — the try/catch around `new Readability(clone).parse()`.
+  it('falls back to whole-body content when Readability.parse() throws', async () => {
+    // Branch: extract.ts's try/catch around `new Readability(clone).parse()`.
     // When parse() throws (degenerate DOM or internal error), article is set to
     // null and the function falls through to the whole-body fallback path.
     // We spy on Readability.prototype.parse to simulate the throw deterministically.
@@ -129,7 +136,7 @@ describe('extractReadableMarkdown — Readability.parse() throws (safeExtract ca
     const html = `<!DOCTYPE html><html><head><title>Throws Doc</title></head>
       <body><div>fallback body content</div></body></html>`;
 
-    const out = extractReadableMarkdown(html, 'https://example.com/throws');
+    const out = await extractReadableMarkdown(html, 'https://example.com/throws');
 
     // The throw was swallowed; we fell back to the whole-body path.
     expect(out.usedFallback).toBe(true);

--- a/src/web/extract.ts
+++ b/src/web/extract.ts
@@ -17,15 +17,22 @@
  *   4. If Readability finds no article (landing pages, apps, sparse markup),
  *      fall back to converting the whole `<body>` and flag `usedFallback`.
  *
- * Pure module: no network, no browser, no filesystem. Fully unit-testable on
- * HTML string fixtures.
+ * jsdom, Readability, and Turndown are only ever needed together (there's no
+ * caller that wants one without the other two), and jsdom alone costs
+ * ~350-450ms to import — about 30% of `afk`'s cold-start (see #581) — even
+ * though extraction only runs when `web_scrape` is actually invoked. All
+ * three are deferred behind one lazy `import()` on first call instead of
+ * loaded eagerly for every `afk` invocation, mirroring the
+ * `getBrowserProvider()` lazy-load + coalesce pattern in
+ * `src/browser/registry.ts`.
+ *
+ * Otherwise pure: no network, no browser, no filesystem. Fully unit-testable
+ * on HTML string fixtures — only the first call in a process pays the import
+ * cost.
  *
  * @module web/extract
  */
 
-import { JSDOM } from 'jsdom';
-import { Readability } from '@mozilla/readability';
-import TurndownService from 'turndown';
 import type { ExtractedContent } from './types.js';
 
 /**
@@ -35,20 +42,51 @@ import type { ExtractedContent } from './types.js';
  */
 export const THIN_CONTENT_CHARS = 200;
 
-// Invariant: one Turndown instance is safe to reuse across calls — it holds no
-// per-document state between `.turndown()` calls. Configured for ATX headings
-// (`# h1`) and fenced code blocks, which render more cleanly in chat surfaces
-// than the setext/indented defaults.
-const turndown = new TurndownService({
-  headingStyle: 'atx',
-  codeBlockStyle: 'fenced',
-  bulletListMarker: '-',
-});
+// ---------------------------------------------------------------------------
+// Lazy-loaded extraction dependencies
+// ---------------------------------------------------------------------------
 
-// Drop elements that never carry readable content. Readability removes most of
-// these already, but the fallback path (whole-body conversion) needs its own
-// guard so we don't emit script bodies or style sheets as markdown.
-turndown.remove(['script', 'style', 'noscript', 'iframe']);
+/**
+ * Imports jsdom, Readability, and Turndown, and constructs the shared
+ * Turndown instance. Not called directly by extraction logic — go through
+ * `getExtractDeps()`, which caches this promise at module scope.
+ */
+async function importExtractDeps() {
+  const [{ JSDOM }, { Readability }, { default: TurndownService }] = await Promise.all([
+    import('jsdom'),
+    import('@mozilla/readability'),
+    import('turndown'),
+  ]);
+
+  // Invariant: one Turndown instance is safe to reuse across calls — it holds
+  // no per-document state between `.turndown()` calls. Configured for ATX
+  // headings (`# h1`) and fenced code blocks, which render more cleanly in
+  // chat surfaces than the setext/indented defaults.
+  const turndown = new TurndownService({
+    headingStyle: 'atx',
+    codeBlockStyle: 'fenced',
+    bulletListMarker: '-',
+  });
+  // Drop elements that never carry readable content. Readability removes most
+  // of these already, but the fallback path (whole-body conversion) needs its
+  // own guard so we don't emit script bodies or style sheets as markdown.
+  turndown.remove(['script', 'style', 'noscript', 'iframe']);
+
+  return { JSDOM, Readability, turndown };
+}
+
+let depsPromise: ReturnType<typeof importExtractDeps> | null = null;
+
+// Invariant: coalesce concurrent first-call imports so multiple concurrent
+// extractions in flight before the first resolves share one import() + one
+// TurndownService construction rather than racing (mirrors the `constructing`
+// coalescing in src/browser/registry.ts).
+function getExtractDeps(): ReturnType<typeof importExtractDeps> {
+  if (depsPromise === null) {
+    depsPromise = importExtractDeps();
+  }
+  return depsPromise;
+}
 
 /** Collapse 3+ blank lines to a single blank line and trim edges. */
 function tidyMarkdown(md: string): string {
@@ -70,9 +108,12 @@ function textLengthOf(node: { textContent: string | null } | null | undefined): 
  * @returns     Title, markdown, extracted-text length, and a fallback flag.
  *              Never throws for well-formed HTML; a jsdom parse failure on
  *              pathological input propagates to the caller, which degrades
- *              gracefully.
+ *              gracefully. The first call in a process also pays the
+ *              one-time cost of importing jsdom/Readability/Turndown.
  */
-export function extractReadableMarkdown(html: string, url: string): ExtractedContent {
+export async function extractReadableMarkdown(html: string, url: string): Promise<ExtractedContent> {
+  const { JSDOM, Readability, turndown } = await getExtractDeps();
+
   const dom = new JSDOM(html, { url });
   const doc = dom.window.document;
   const docTitle = (doc.title ?? '').trim();
@@ -80,14 +121,15 @@ export function extractReadableMarkdown(html: string, url: string): ExtractedCon
   // Contract: Readability MUTATES the document it is given (it strips nodes
   // in place). We clone first so the fallback path below still has the
   // original body to convert when Readability returns null.
-  let article: ReturnType<Readability['parse']> = null;
-  try {
-    const clone = doc.cloneNode(true) as Document;
-    article = new Readability(clone).parse();
-  } catch {
-    // Readability can throw on degenerate DOMs — fall through to whole-body.
-    article = null;
-  }
+  const article = (() => {
+    try {
+      const clone = doc.cloneNode(true) as Document;
+      return new Readability(clone).parse();
+    } catch {
+      // Readability can throw on degenerate DOMs — fall through to whole-body.
+      return null;
+    }
+  })();
 
   if (article && typeof article.content === 'string' && article.content.trim().length > 0) {
     const markdown = tidyMarkdown(turndown.turndown(article.content));

--- a/src/web/scrape.test.ts
+++ b/src/web/scrape.test.ts
@@ -221,6 +221,61 @@ describe('scrapeToMarkdown — cancellation', () => {
       }),
     ).rejects.toThrow(/render aborted/);
   });
+
+  it('honors an abort that fires during the fetch-path extraction await', async () => {
+    // Regression for the lazy-jsdom async boundary (PR #587): safeExtract /
+    // extractReadableMarkdown do not observe the signal, so an abort landing
+    // while the fetched HTML is being extracted must be caught by the post-await
+    // guard. Here fetch resolves normally with rich (non-thin) HTML but the
+    // signal aborts as the body is read; without the guard scrapeToMarkdown
+    // would return a successful result after cancellation.
+    const ac = new AbortController();
+    const fetchFn = vi.fn(async () => {
+      const res = makeResponse({ contentType: 'text/html', body: richHtml() });
+      (res as { text: () => Promise<string> }).text = async () => {
+        ac.abort(new Error('cancelled during extraction'));
+        return richHtml();
+      };
+      return res;
+    });
+    const renderFn = vi.fn<RenderFn>(async () => ({ html: '', finalUrl: '', httpStatus: 200 }));
+
+    await expect(
+      scrapeToMarkdown('https://example.com/a', {
+        fetchFn: fetchFn as unknown as typeof fetch,
+        renderFn,
+        timeoutMs: 5000,
+        signal: ac.signal,
+      }),
+    ).rejects.toThrow();
+    // The abort must short-circuit before any render escalation.
+    expect(renderFn).not.toHaveBeenCalled();
+  });
+
+  it('honors an abort that fires during the render-path extraction await', async () => {
+    // Regression for the lazy-jsdom async boundary (PR #587), Phase 3: the thin
+    // fetch escalates to render, render resolves normally with rich HTML, but
+    // the signal aborts around the render/extraction boundary. Only the
+    // post-await guard catches this — the existing catch fires solely when
+    // render or extraction throws. Without the guard the rich render result
+    // would be returned as a success after cancellation.
+    const ac = new AbortController();
+    const fetchFn = vi.fn(async () => makeResponse({ contentType: 'text/html', body: SHELL_HTML }));
+    const renderFn = vi.fn<RenderFn>(async () => {
+      ac.abort(new Error('cancelled during render extraction'));
+      return { html: richHtml('rendered'), finalUrl: 'https://example.com/a', httpStatus: 200 };
+    });
+
+    await expect(
+      scrapeToMarkdown('https://example.com/a', {
+        fetchFn: fetchFn as unknown as typeof fetch,
+        renderFn,
+        timeoutMs: 5000,
+        signal: ac.signal,
+      }),
+    ).rejects.toThrow();
+    expect(renderFn).toHaveBeenCalledOnce();
+  });
 });
 
 describe('scrapeToMarkdown — render produces fewer chars than thin fetch', () => {

--- a/src/web/scrape.ts
+++ b/src/web/scrape.ts
@@ -66,9 +66,9 @@ export interface ScrapeResult {
 }
 
 /** Run extraction without throwing — degenerate DOMs yield empty content. */
-function safeExtract(html: string, url: string): ExtractedContent {
+async function safeExtract(html: string, url: string): Promise<ExtractedContent> {
   try {
-    return extractReadableMarkdown(html, url);
+    return await extractReadableMarkdown(html, url);
   } catch (err) {
     debugLog('[web/scrape] extraction failed', { url, err });
     return { title: '', markdown: '', textLength: 0, usedFallback: true };
@@ -131,7 +131,7 @@ export async function scrapeToMarkdown(url: string, opts: ScrapeOptions): Promis
         return { title: '', markdown: body.trim(), finalUrl: fetchedUrl, usedRender: false };
       }
       // HTML or unknown content-type → extraction pipeline.
-      fetched = safeExtract(body, fetchedUrl);
+      fetched = await safeExtract(body, fetchedUrl);
     }
   } catch (err) {
     // Abort is terminal — propagate so the handler reports cancellation.
@@ -158,7 +158,7 @@ export async function scrapeToMarkdown(url: string, opts: ScrapeOptions): Promis
   // ---- Phase 3: render escalation -------------------------------------------
   try {
     const rendered = await renderFn(url, { timeoutMs: opts.timeoutMs, signal: opts.signal });
-    const renderedContent = safeExtract(rendered.html, rendered.finalUrl);
+    const renderedContent = await safeExtract(rendered.html, rendered.finalUrl);
     // Prefer the render result when it has at least as much text as the fetch.
     if (fetched === null || renderedContent.textLength >= fetched.textLength) {
       return {

--- a/src/web/scrape.ts
+++ b/src/web/scrape.ts
@@ -132,6 +132,12 @@ export async function scrapeToMarkdown(url: string, opts: ScrapeOptions): Promis
       }
       // HTML or unknown content-type → extraction pipeline.
       fetched = await safeExtract(body, fetchedUrl);
+      // Extraction is an async boundary (lazy jsdom/Readability/Turndown import
+      // on first call, then parse) that does NOT observe the signal. Re-check
+      // after it resolves so a cancel/timeout that fired during the await is
+      // honored — the catch below turns this into a terminal abort instead of
+      // returning a stale successful result.
+      if (opts.signal.aborted) throw opts.signal.reason ?? new Error('aborted');
     }
   } catch (err) {
     // Abort is terminal — propagate so the handler reports cancellation.
@@ -159,6 +165,10 @@ export async function scrapeToMarkdown(url: string, opts: ScrapeOptions): Promis
   try {
     const rendered = await renderFn(url, { timeoutMs: opts.timeoutMs, signal: opts.signal });
     const renderedContent = await safeExtract(rendered.html, rendered.finalUrl);
+    // Same async-boundary abort re-check as the fetch path above: extraction
+    // does not observe the signal, so honor a cancel/timeout that landed during
+    // it. The catch below re-throws when aborted rather than degrading.
+    if (opts.signal.aborted) throw opts.signal.reason ?? new Error('aborted');
     // Prefer the render result when it has at least as much text as the fetch.
     if (fetched === null || renderedContent.textLength >= fetched.textLength) {
       return {


### PR DESCRIPTION
## Summary

Fixes #581. `jsdom` was loaded on every `afk` invocation via a static top-level import in `src/web/extract.ts`, even though it's only needed by the `web_scrape` tool's markdown-extraction path. This defers `jsdom` + `@mozilla/readability` + `turndown` behind a single lazy `import()` on first use, mirroring the existing `getBrowserProvider()` lazy-load pattern in `src/browser/registry.ts`.

- `src/web/extract.ts`: removed the static imports; added `importExtractDeps()` + `getExtractDeps()` (module-scope cached promise, coalesces concurrent first-call imports). `extractReadableMarkdown()` is now `async`; output shape (`{title, markdown, textLength, usedFallback}`) is unchanged.
- `src/web/scrape.ts`: `safeExtract()` is now `async` and awaits extraction; both call sites in `scrapeToMarkdown()` (already async) now `await` it.
- `src/web/extract.test.ts`: all `it()` blocks await the now-async function; assertions unchanged.

Scope matches the issue exactly: jsdom (+its always-co-loaded readability/turndown neighbors) only. Did not touch the OpenAI SDK import per the issue's explicit "not worth the call-site churn" note.

## How was this tested?

- `pnpm lint` — clean, 0 errors.
- `pnpm test:coverage` — 642 files / 11728 tests passed, 0 failed, coverage floor intact.
- Verified the production bundle actually defers the import: built `dist/cli.mjs` via `pnpm build:dist` and confirmed `grep -o 'import("jsdom")\|from"jsdom"' dist/cli.mjs` → exactly one dynamic `import("jsdom")`, zero static imports.
- Measured cold-start before/after on the same machine, same build pipeline, n=25 each (`node dist/cli.mjs --version`):

  | | median |
  |---|--:|
  | before (static import) | 550.3ms |
  | after (lazy import) | 357.2ms |

  ~193ms / ~35% faster. This is smaller than the issue's ~350-450ms *isolated* import-cost estimate (measuring jsdom alone in a bare `node -e` process) — inside the full bundle some of jsdom's transitive cost overlaps with other eager work, so the marginal saving in context is less than the standalone cost. Still a clear, reproducible, honestly-reported win. Reran twice for stability (357.2ms and 358.1ms medians across two independent 25-run passes).
- Confirmed the first `web_scrape` call still works correctly and pays the deferred cost once — exercised via the existing extraction test suite (all real jsdom/readability/turndown instances, not mocked, under vitest's node environment) plus the module-scope cache being hit repeatedly across the 9 test cases in `extract.test.ts`.

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/)
- [x] No secrets, tokens, or private paths in the diff
