### PR TITLE
feat(model-slots): auth-aware model availability labeling (Phase 2; follows #548, now merged)

### DIFF
--- a/docs/model-slots.md
+++ b/docs/model-slots.md
@@ -161,9 +161,33 @@ falls back to defaults + env when constructed without the CLI config loader.
   (own key) on a third.
 - Per-tier credentials via afk.config.json or the `AFK_MODEL_*` env vars.
 
+## Availability
+
+`src/agent/auth/model-availability.ts` exports a read-only, synchronous
+`modelAvailability(model, bindings?)` predicate (and its boolean shorthand
+`isModelAvailable`) used purely to **label** model picker handles with an
+auth hint — e.g. a tier bound to an OpenAI id with no `OPENAI_API_KEY`
+resolvable, or a `chatgpt-oauth` slot with no `~/.codex/auth.json` token.
+
+Guarantees:
+
+- **Additive only.** Labeling never filters, reorders, or removes a handle,
+  and never blocks selection — every alias in `MODEL_ALIASES_HINT` stays
+  listed and selectable regardless of its computed availability. Only the
+  Telegram `/model` inline-keyboard button text and the CLI `/model`
+  non-TTY alias list are annotated today; callback data / selected values
+  are unchanged. The interactive arrow-key picker (`runPicker`) is not yet
+  annotated — see the code comment at its call site in
+  `src/cli/slash/commands/info.ts`.
+- **Conservative.** Any uncertainty (an unrecognized provider shape, a
+  custom `baseUrl` endpoint whose key requirement can't be known from here,
+  or an internal error) resolves to `available: true` — a working model is
+  never hidden behind a false negative.
+
 ## See also
 
 - `src/agent/session/model-slots.ts` — bindings, resolver, defaults, config parse.
 - `src/agent/session/slot-credentials.ts` — per-slot credential application.
 - `src/agent/providers/index.ts` — `providerForModel` resolution-before-routing.
+- `src/agent/auth/model-availability.ts` — additive, conservative availability labeling.
 - `docs/env-registry.md` — `AFK_MODEL_{LOCAL,SMALL,MEDIUM,LARGE}{,_BASE_URL,_API_KEY}`.

--- a/src/agent/auth/model-availability.test.ts
+++ b/src/agent/auth/model-availability.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for `modelAvailability` / `isModelAvailable`.
+ *
+ * Mocks the two credential sources (`credential-resolver.ts`,
+ * `openai-compatible/auth.ts`) and `providerForModel` for determinism, and
+ * drives `resolveBinding` with explicit `bindings` tables rather than the
+ * process-global singleton.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const loadAnthropicCredential = vi.fn<[], string | undefined>();
+const loadOpenAICredential = vi.fn<[], string | undefined>();
+const resolveOpenAIAuth = vi.fn();
+const providerForModel = vi.fn<[string | undefined], string>();
+
+vi.mock('./credential-resolver.js', () => ({
+  loadAnthropicCredential: (...args: unknown[]) => loadAnthropicCredential(...(args as [])),
+  loadOpenAICredential: (...args: unknown[]) => loadOpenAICredential(...(args as [])),
+}));
+
+vi.mock('../providers/openai-compatible/auth.js', () => ({
+  resolveOpenAIAuth: (...args: unknown[]) => resolveOpenAIAuth(...args),
+}));
+
+vi.mock('../providers/index.js', () => ({
+  providerForModel: (...args: [string | undefined]) => providerForModel(...args),
+}));
+
+import { modelAvailability, isModelAvailable } from './model-availability.js';
+import type { ModelSlots, ModelSlotBinding } from '../session/model-slots.js';
+
+function slots(overrides: Partial<Record<keyof ModelSlots, ModelSlotBinding>> = {}): ModelSlots {
+  const base: ModelSlots = {
+    local: { id: '' },
+    small: { id: 'claude-haiku-4-5-20251001' },
+    medium: { id: 'claude-sonnet-5' },
+    large: { id: 'claude-opus-4-8' },
+  };
+  return { ...base, ...overrides } as ModelSlots;
+}
+
+describe('modelAvailability', () => {
+  beforeEach(() => {
+    loadAnthropicCredential.mockReset();
+    loadOpenAICredential.mockReset();
+    resolveOpenAIAuth.mockReset();
+    providerForModel.mockReset();
+    providerForModel.mockReturnValue('anthropic-direct');
+  });
+
+  it('treats undefined model as available/unknown', () => {
+    expect(modelAvailability(undefined)).toEqual({ available: true, needs: 'unknown' });
+  });
+
+  it('treats the "auto" sentinel (any case/whitespace) as available/unknown', () => {
+    expect(modelAvailability('auto')).toEqual({ available: true, needs: 'unknown' });
+    expect(modelAvailability(' AUTO ')).toEqual({ available: true, needs: 'unknown' });
+  });
+
+  describe('anthropic-direct tiers (sonnet/opus/haiku)', () => {
+    it('is available when loadAnthropicCredential returns a value', () => {
+      loadAnthropicCredential.mockReturnValue('sk-ant-xxx');
+      const result = modelAvailability('sonnet', slots());
+      expect(result.available).toBe(true);
+      expect(result.needs).toBe('anthropic');
+      expect(result.hint).toBeUndefined();
+    });
+
+    it('is unavailable with a hint when loadAnthropicCredential returns undefined', () => {
+      loadAnthropicCredential.mockReturnValue(undefined);
+      const result = modelAvailability('opus', slots());
+      expect(result).toEqual({
+        available: false,
+        needs: 'anthropic',
+        hint: 'needs Claude sign-in / ANTHROPIC_API_KEY',
+      });
+    });
+
+    it('checks haiku the same way', () => {
+      loadAnthropicCredential.mockReturnValue('sk-ant-xxx');
+      expect(modelAvailability('haiku', slots()).available).toBe(true);
+      loadAnthropicCredential.mockReturnValue(undefined);
+      expect(modelAvailability('haiku', slots()).available).toBe(false);
+    });
+  });
+
+  describe('chatgpt-oauth-bound tier', () => {
+    it('is available when resolveOpenAIAuth(undefined, {}, true).apiKey is non-null', () => {
+      resolveOpenAIAuth.mockReturnValue({ apiKey: 'chatgpt-token', source: 'chatgpt-oauth' });
+      const bindings = slots({ medium: { id: 'gpt-5', provider: 'chatgpt-oauth' } });
+      const result = modelAvailability('medium', bindings);
+      expect(result).toEqual({ available: true, needs: 'chatgpt-oauth' });
+      expect(resolveOpenAIAuth).toHaveBeenCalledWith(undefined, {}, true);
+    });
+
+    it('is unavailable with a hint when no ChatGPT OAuth token is found', () => {
+      resolveOpenAIAuth.mockReturnValue({ apiKey: null, source: 'no-usable-auth-forced-chatgpt-oauth' });
+      const bindings = slots({ medium: { id: 'gpt-5', provider: 'chatgpt-oauth' } });
+      const result = modelAvailability('medium', bindings);
+      expect(result).toEqual({
+        available: false,
+        needs: 'chatgpt-oauth',
+        hint: 'needs ChatGPT sign-in (~/.codex/auth.json)',
+      });
+    });
+
+    it('short-circuits on a per-slot apiKey without calling resolveOpenAIAuth', () => {
+      const bindings = slots({ medium: { id: 'gpt-5', provider: 'chatgpt-oauth', apiKey: 'preset' } });
+      const result = modelAvailability('medium', bindings);
+      expect(result).toEqual({ available: true, needs: 'chatgpt-oauth' });
+      expect(resolveOpenAIAuth).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('plain openai tier', () => {
+    beforeEach(() => {
+      providerForModel.mockReturnValue('openai-compatible');
+    });
+
+    it('is available when loadOpenAICredential returns a value', () => {
+      loadOpenAICredential.mockReturnValue('sk-openai-xxx');
+      const bindings = slots({ small: { id: 'gpt-4o-mini' } });
+      const result = modelAvailability('small', bindings);
+      expect(result).toEqual({ available: true, needs: 'openai' });
+    });
+
+    it('falls back to resolveOpenAIAuth(undefined, {}, false) when no direct env credential', () => {
+      loadOpenAICredential.mockReturnValue(undefined);
+      resolveOpenAIAuth.mockReturnValue({ apiKey: 'from-codex-cli', source: 'codex-cli' });
+      const bindings = slots({ small: { id: 'gpt-4o-mini' } });
+      const result = modelAvailability('small', bindings);
+      expect(result.available).toBe(true);
+      expect(resolveOpenAIAuth).toHaveBeenCalledWith(undefined, {}, false);
+    });
+
+    it('is unavailable with a hint when neither source has a key', () => {
+      loadOpenAICredential.mockReturnValue(undefined);
+      resolveOpenAIAuth.mockReturnValue({ apiKey: null, source: 'no-usable-auth' });
+      const bindings = slots({ small: { id: 'gpt-4o-mini' } });
+      const result = modelAvailability('small', bindings);
+      expect(result).toEqual({ available: false, needs: 'openai', hint: 'needs OPENAI_API_KEY' });
+    });
+
+    it('treats a custom baseUrl endpoint as always available (conservative — key requirement unknowable)', () => {
+      const bindings = slots({ small: { id: 'local-model', baseUrl: 'http://localhost:8080/v1' } });
+      const result = modelAvailability('small', bindings);
+      expect(result).toEqual({ available: true, needs: 'local' });
+      expect(loadOpenAICredential).not.toHaveBeenCalled();
+      expect(resolveOpenAIAuth).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('empty local slot', () => {
+    it('is unavailable with a "not configured" hint', () => {
+      const result = modelAvailability('local', slots());
+      expect(result).toEqual({
+        available: false,
+        needs: 'local',
+        hint: 'not configured (set AFK_MODEL_LOCAL / models.local)',
+      });
+    });
+  });
+
+  describe('unrecognized provider shapes', () => {
+    it('defaults to available/unknown for a provider that is neither anthropic-direct nor openai-compatible', () => {
+      providerForModel.mockReturnValue('something-else');
+      const bindings = slots({ small: { id: 'mystery-model' } });
+      const result = modelAvailability('small', bindings);
+      expect(result).toEqual({ available: true, needs: 'unknown' });
+    });
+  });
+
+  describe('conservative fallback on internal errors', () => {
+    it('returns available/unknown when a dependency throws', () => {
+      loadAnthropicCredential.mockImplementation(() => {
+        throw new Error('boom');
+      });
+      const result = modelAvailability('sonnet', slots());
+      expect(result).toEqual({ available: true, needs: 'unknown' });
+    });
+
+    it('returns available/unknown when resolveOpenAIAuth throws', () => {
+      resolveOpenAIAuth.mockImplementation(() => {
+        throw new Error('boom');
+      });
+      const bindings = slots({ medium: { id: 'gpt-5', provider: 'chatgpt-oauth' } });
+      const result = modelAvailability('medium', bindings);
+      expect(result).toEqual({ available: true, needs: 'unknown' });
+    });
+  });
+});
+
+describe('isModelAvailable', () => {
+  beforeEach(() => {
+    loadAnthropicCredential.mockReset();
+    loadOpenAICredential.mockReset();
+    resolveOpenAIAuth.mockReset();
+    providerForModel.mockReset();
+    providerForModel.mockReturnValue('anthropic-direct');
+  });
+
+  it('returns just the boolean verdict', () => {
+    loadAnthropicCredential.mockReturnValue('sk-ant-xxx');
+    expect(isModelAvailable('sonnet', slots())).toBe(true);
+    loadAnthropicCredential.mockReturnValue(undefined);
+    expect(isModelAvailable('sonnet', slots())).toBe(false);
+  });
+
+  it('is available/unknown for undefined model', () => {
+    expect(isModelAvailable(undefined)).toBe(true);
+  });
+});

--- a/src/agent/auth/model-availability.test.ts
+++ b/src/agent/auth/model-availability.test.ts
@@ -105,11 +105,27 @@ describe('modelAvailability', () => {
       });
     });
 
-    it('short-circuits on a per-slot apiKey without calling resolveOpenAIAuth', () => {
+    it('does NOT let a per-slot apiKey mask a missing ChatGPT OAuth token', () => {
+      // Runtime forces the OAuth path for a chatgpt-oauth slot and ignores any
+      // per-slot/explicit key (resolveOpenAIAuth(..., true) reads ~/.codex only),
+      // so a stale per-slot key must not short-circuit to "available" here.
+      resolveOpenAIAuth.mockReturnValue({ apiKey: null, source: 'no-usable-auth-forced-chatgpt-oauth' });
+      const bindings = slots({ medium: { id: 'gpt-5', provider: 'chatgpt-oauth', apiKey: 'preset' } });
+      const result = modelAvailability('medium', bindings);
+      expect(result).toEqual({
+        available: false,
+        needs: 'chatgpt-oauth',
+        hint: 'needs ChatGPT sign-in (~/.codex/auth.json)',
+      });
+      expect(resolveOpenAIAuth).toHaveBeenCalledWith(undefined, {}, true);
+    });
+
+    it('is available when a chatgpt-oauth slot with a per-slot key also has a resolvable OAuth token', () => {
+      resolveOpenAIAuth.mockReturnValue({ apiKey: 'chatgpt-token', source: 'chatgpt-oauth' });
       const bindings = slots({ medium: { id: 'gpt-5', provider: 'chatgpt-oauth', apiKey: 'preset' } });
       const result = modelAvailability('medium', bindings);
       expect(result).toEqual({ available: true, needs: 'chatgpt-oauth' });
-      expect(resolveOpenAIAuth).not.toHaveBeenCalled();
+      expect(resolveOpenAIAuth).toHaveBeenCalledWith(undefined, {}, true);
     });
   });
 
@@ -146,6 +162,14 @@ describe('modelAvailability', () => {
       const bindings = slots({ small: { id: 'local-model', baseUrl: 'http://localhost:8080/v1' } });
       const result = modelAvailability('small', bindings);
       expect(result).toEqual({ available: true, needs: 'local' });
+      expect(loadOpenAICredential).not.toHaveBeenCalled();
+      expect(resolveOpenAIAuth).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits to available/unknown on a per-slot apiKey (non-oauth), skipping credential resolution', () => {
+      const bindings = slots({ small: { id: 'gpt-4o-mini', apiKey: 'sk-preset' } });
+      const result = modelAvailability('small', bindings);
+      expect(result).toEqual({ available: true, needs: 'unknown' });
       expect(loadOpenAICredential).not.toHaveBeenCalled();
       expect(resolveOpenAIAuth).not.toHaveBeenCalled();
     });

--- a/src/agent/auth/model-availability.ts
+++ b/src/agent/auth/model-availability.ts
@@ -43,12 +43,23 @@ export function modelAvailability(model: string | undefined, bindings?: ModelSlo
     if (b.id === '') {
       return { available: false, needs: 'local', hint: 'not configured (set AFK_MODEL_LOCAL / models.local)' };
     }
-    if (b.apiKey) return { available: true, needs: b.provider === 'chatgpt-oauth' ? 'chatgpt-oauth' : 'unknown' };
+    // A `chatgpt-oauth` slot forces the ChatGPT-subscription OAuth path at
+    // runtime: applySlotCredentials sets `forceChatgptOAuth`, and
+    // resolveOpenAIAuth(..., true) resolves from ~/.codex/auth.json REGARDLESS
+    // of any per-slot/explicit apiKey. So this must precede the generic apiKey
+    // short-circuit below — otherwise a slot carrying a stale per-slot key but
+    // no OAuth token is mislabeled available (no sign-in hint) while the next
+    // real request fails for missing ChatGPT sign-in.
     if (b.provider === 'chatgpt-oauth') {
       const ok = resolveOpenAIAuth(undefined, {}, true).apiKey != null;
       return { available: ok, needs: 'chatgpt-oauth', hint: ok ? undefined : 'needs ChatGPT sign-in (~/.codex/auth.json)' };
     }
-    const provider = providerForModel(model);
+    if (b.apiKey) return { available: true, needs: 'unknown' };
+    // Thread the supplied `bindings` through so provider routing resolves the
+    // SAME table `resolveBinding` used above (mirrors applySlotCredentials);
+    // otherwise an explicit bindings arg diverging from the process-global
+    // singleton would be checked against the wrong credential family.
+    const provider = providerForModel(model, bindings ? { slots: bindings } : undefined);
     if (provider === 'anthropic-direct') {
       const ok = !!loadAnthropicCredential();
       return { available: ok, needs: 'anthropic', hint: ok ? undefined : 'needs Claude sign-in / ANTHROPIC_API_KEY' };

--- a/src/agent/auth/model-availability.ts
+++ b/src/agent/auth/model-availability.ts
@@ -1,0 +1,71 @@
+/**
+ * Read-only, synchronous "is this model likely usable right now?" predicate.
+ *
+ * Purely advisory: used to ANNOTATE model picker labels (Telegram `/model`,
+ * CLI `/model` list) with a hint when a tier's credential is missing —
+ * NEVER to filter, reorder, or block selection of any handle. Deliberately
+ * conservative: any uncertainty (unknown provider shape, unexpected error)
+ * resolves to `available: true` so a working model is never hidden behind a
+ * false negative. Never throws; never reads `process.env` directly (routes
+ * through the existing credential resolvers, which use the typed `env`).
+ *
+ * @module agent/auth/model-availability
+ */
+
+import { providerForModel } from '../providers/index.js';
+import { resolveBinding, type ModelSlotBinding, type ModelSlots } from '../session/model-slots.js';
+import { loadAnthropicCredential, loadOpenAICredential } from './credential-resolver.js';
+import { resolveOpenAIAuth } from '../providers/openai-compatible/auth.js';
+
+/** What kind of credential a model would need, for the hint message. */
+export type AvailabilityNeed = 'anthropic' | 'openai' | 'chatgpt-oauth' | 'local' | 'unknown';
+
+/** Result of an availability check. */
+export interface ModelAvailability {
+  /** Conservative "probably usable" verdict — true unless a credential is confirmed missing. */
+  available: boolean;
+  /** What credential family this model would draw on. */
+  needs: AvailabilityNeed;
+  /** Short human-readable reason, present only when `available` is false. */
+  hint?: string;
+}
+
+/**
+ * Determine whether `model` is likely usable given currently-resolvable
+ * credentials. Conservative: any error or unrecognized shape resolves to
+ * `{ available: true, needs: 'unknown' }` rather than a false negative.
+ */
+export function modelAvailability(model: string | undefined, bindings?: ModelSlots): ModelAvailability {
+  try {
+    if (!model || model.trim().toLowerCase() === 'auto') return { available: true, needs: 'unknown' };
+    const b: ModelSlotBinding = resolveBinding(model, bindings);
+    // Empty id (the default `local` slot) means the tier is simply unconfigured.
+    if (b.id === '') {
+      return { available: false, needs: 'local', hint: 'not configured (set AFK_MODEL_LOCAL / models.local)' };
+    }
+    if (b.apiKey) return { available: true, needs: b.provider === 'chatgpt-oauth' ? 'chatgpt-oauth' : 'unknown' };
+    if (b.provider === 'chatgpt-oauth') {
+      const ok = resolveOpenAIAuth(undefined, {}, true).apiKey != null;
+      return { available: ok, needs: 'chatgpt-oauth', hint: ok ? undefined : 'needs ChatGPT sign-in (~/.codex/auth.json)' };
+    }
+    const provider = providerForModel(model);
+    if (provider === 'anthropic-direct') {
+      const ok = !!loadAnthropicCredential();
+      return { available: ok, needs: 'anthropic', hint: ok ? undefined : 'needs Claude sign-in / ANTHROPIC_API_KEY' };
+    }
+    if (provider === 'openai-compatible') {
+      // Custom endpoint: key requirement is unknowable from here — conservative.
+      if (b.baseUrl) return { available: true, needs: 'local' };
+      const ok = !!loadOpenAICredential() || resolveOpenAIAuth(undefined, {}, false).apiKey != null;
+      return { available: ok, needs: 'openai', hint: ok ? undefined : 'needs OPENAI_API_KEY' };
+    }
+    return { available: true, needs: 'unknown' };
+  } catch {
+    return { available: true, needs: 'unknown' };
+  }
+}
+
+/** Convenience boolean form of {@link modelAvailability}. */
+export function isModelAvailable(model: string | undefined, bindings?: ModelSlots): boolean {
+  return modelAvailability(model, bindings).available;
+}

--- a/src/cli/slash/commands/info.test.ts
+++ b/src/cli/slash/commands/info.test.ts
@@ -7,6 +7,13 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+
+// Deterministic availability stub: "large"/"opus" are reported unavailable so
+// the non-TTY alias-list annotation test doesn't depend on real credentials.
+vi.mock('../../../agent/auth/model-availability.js', () => ({
+  isModelAvailable: (model: string | undefined) => model !== 'large' && model !== 'opus',
+}));
+
 import { infoCommands } from './info.js';
 import type { SlashContext, SessionStats } from '../types.js';
 import type { PickerController, TerminalCompositor } from '../../terminal-compositor.js';
@@ -133,5 +140,22 @@ describe('/model', () => {
 
     expect(setModel).not.toHaveBeenCalled();
     expect(lines.join('\n')).toMatch(/Current model/);
+  });
+
+  it('non-TTY alias list annotates unavailable handles additively (never removes them)', async () => {
+    const { ctx, lines } = makeCtx(false);
+    await modelCmd.handler(ctx, '');
+
+    const aliasLine = lines.join('\n');
+    // Unavailable (per the mock above) → annotated, but still present.
+    expect(aliasLine).toMatch(/large \(needs sign-in\)/);
+    expect(aliasLine).toMatch(/opus \(needs sign-in\)/);
+    // Available handles are listed bare, with no marker.
+    expect(aliasLine).toMatch(/(?:^|, )haiku(?:,|\s|$)/);
+    expect(aliasLine).not.toMatch(/haiku \(needs sign-in\)/);
+    // Every alias remains listed — additive-only guarantee.
+    for (const alias of ['local', 'small', 'medium', 'large', 'opus', 'sonnet', 'haiku', 'fable']) {
+      expect(aliasLine).toContain(alias);
+    }
   });
 });

--- a/src/cli/slash/commands/info.ts
+++ b/src/cli/slash/commands/info.ts
@@ -12,6 +12,7 @@ import { formatCost, formatTokens } from '../../format-utils.js';
 import { contextLimitFor, MODEL_CONTEXT_LIMITS } from '../../model-limits.js';
 import { renderDebugBanner } from '../../debug-banner.js';
 import { providerForModel } from '../../../agent/providers/index.js';
+import { isModelAvailable } from '../../../agent/auth/model-availability.js';
 import {
   MODEL_ALIASES_HINT,
   resolveBinding,
@@ -251,6 +252,11 @@ const modelCmd: SlashCommand = {
     // model + alias list on non-TTY surfaces (Telegram, daemon, tests).
     const compositor = ctx.getCompositor?.() ?? null;
     if (compositor) {
+      // P2 follow-up: runPicker's `options: readonly string[]` uses the same
+      // string as both rendered label and selected value (see `choice` below
+      // fed straight to `switchModel`), so there is no clean label≠value split
+      // to hang an availability marker on without corrupting selection — left
+      // un-annotated; picker would need a { label, value } option shape first.
       const options = [...MODEL_ALIASES_HINT];
       const currentIdx = options.indexOf(ctx.stats.model as (typeof MODEL_ALIASES_HINT)[number]);
       const picked = await runPicker(compositor, {
@@ -269,7 +275,10 @@ const modelCmd: SlashCommand = {
     }
 
     ctx.out.info(`Current model: ${palette.brand(ctx.stats.model)}`);
-    ctx.out.line(palette.dim(`  Aliases: ${MODEL_ALIASES_HINT.join(', ')}  (or any org/model HF id)`));
+    const aliasList = MODEL_ALIASES_HINT.map((alias) =>
+      isModelAvailable(alias) ? alias : `${alias} (needs sign-in)`,
+    ).join(', ');
+    ctx.out.line(palette.dim(`  Aliases: ${aliasList}  (or any org/model HF id)`));
     return 'continue';
   },
 };

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -160,6 +160,39 @@ describe('TelegramBot', () => {
       expect((options as { reply_markup?: unknown })?.reply_markup).toBeDefined();
     });
 
+    test('/model inline keyboard: annotates unavailable handles additively, callback_data unchanged', async () => {
+      const availability = await import('../agent/auth/model-availability.js');
+      const spy = vi
+        .spyOn(availability, 'isModelAvailable')
+        .mockImplementation((model) => model !== 'opus');
+
+      try {
+        const ctx = createMockContext(12345, '/model');
+        await (bot as any).handleModelSwitch(ctx);
+
+        const [, options] = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0] as [
+          string,
+          { reply_markup?: { inline_keyboard?: Array<Array<{ text: string; callback_data: string }>> } },
+        ];
+        const rows = options.reply_markup?.inline_keyboard ?? [];
+        const flat = rows.flat();
+
+        // Every alias handle is still present and selectable (additive-only).
+        expect(flat.length).toBeGreaterThan(0);
+        const opusButton = flat.find((b) => b.callback_data === 'afk:m:opus');
+        expect(opusButton).toBeDefined();
+        // Label carries the marker; callback-data used for routing is untouched.
+        expect(opusButton?.text).toBe('opus — needs sign-in');
+        expect(opusButton?.callback_data).toBe('afk:m:opus');
+
+        // An available handle (e.g. sonnet) keeps its bare label.
+        const sonnetButton = flat.find((b) => b.callback_data === 'afk:m:sonnet');
+        expect(sonnetButton?.text).toBe('sonnet');
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
     test('should handle /model command with valid model', async () => {
       const ctx = createMockContext(12345, '/model opus');
       

--- a/src/telegram/handlers/commands.ts
+++ b/src/telegram/handlers/commands.ts
@@ -22,6 +22,7 @@ import {
   formatSystemError,
 } from '../formatter.js';
 import { providerForModel } from '../../agent/providers/index.js';
+import { isModelAvailable } from '../../agent/auth/model-availability.js';
 import {
   MODEL_ALIASES_HINT,
   resolveBinding,
@@ -141,7 +142,10 @@ export async function handleModelSwitch(
   if (args.length === 0) {
     const currentModel = sessionManager.getModel(chatId);
     const buttons = MODEL_ALIASES_HINT.map(alias => [
-      Markup.button.callback(alias, `afk:m:${alias}`),
+      Markup.button.callback(
+        isModelAvailable(alias) ? alias : `${alias} — needs sign-in`,
+        `afk:m:${alias}`,
+      ),
     ]);
     await ctx.reply(
       `Current model: <b>${escapeHtml(currentModel.toUpperCase())}</b>\n\nSwitch to:`,


### PR DESCRIPTION
Phase 2 of the model-slots availability work. Originally scoped to stack on #548 (Phase 1 — per-slot ChatGPT OAuth provider), but **#548 merged into `main` while this branch was in flight** (squashed as d3cbf51, head branch deleted) — so this branch was rebased (`git rebase --onto origin/main <old-base>`) straight onto current `main` and targets `main` directly. The diff below is unchanged from the original Phase-2 scope; only the base moved.

Adds a read-only, conservative availability predicate that **labels** (never filters) model-picker handles with an auth hint.

## What this adds

- **`src/agent/auth/model-availability.ts`** — `modelAvailability(model, bindings?)` / `isModelAvailable(model, bindings?)`. Sync, read-only, no throws. Resolves a model input through `resolveBinding()`, then checks the appropriate credential source:
  - empty `local` slot -> unavailable ("not configured")
  - per-slot `apiKey` present -> available
  - `chatgpt-oauth` provider -> `resolveOpenAIAuth(undefined, {}, true).apiKey != null`
  - `anthropic-direct` -> `loadAnthropicCredential()`
  - `openai-compatible` with a custom `baseUrl` -> always available (key requirement unknowable from here — conservative)
  - `openai-compatible` otherwise -> `loadOpenAICredential()` or `resolveOpenAIAuth(undefined, {}, false)`
  - anything unrecognized, or any internal error -> `available: true, needs: 'unknown'`
- **Telegram `/model`** (`src/telegram/handlers/commands.ts`): inline-keyboard button **label** appends `" — needs sign-in"` when unavailable; `callback_data` (`afk:m:<alias>`) is unchanged.
- **CLI `/model`** non-TTY alias list (`src/cli/slash/commands/info.ts`): appends `" (needs sign-in)"` per handle in the plain-text listing.
- **Docs**: new "Availability" subsection in `docs/model-slots.md`.

## Guarantees

- **Additive only.** No handle is ever filtered, reordered, or removed; selection is never blocked. Every alias in `MODEL_ALIASES_HINT` stays listed and selectable regardless of computed availability.
- **Conservative.** Any uncertainty — unrecognized provider shape, a custom `baseUrl` endpoint whose key requirement isn't knowable from here, or an internal error — resolves to `available: true`. A working model is never hidden behind a false negative.
- Never reads `process.env` directly (routes through the existing typed-`env`-based credential resolvers); no `@anthropic-ai/sdk` import.

## P2 status: interactive arrow-key picker — skipped

`runPicker`'s `options: readonly string[]` uses the same string as both the rendered label and the value fed back to `switchModel` on selection — there's no clean label!=value split to hang a marker on without corrupting the selected value. Left un-annotated, with a one-line code comment at the call site (`src/cli/slash/commands/info.ts`) and noted here as a follow-up: the picker would need a `{ label, value }` option shape first.

## Verification (all green, re-run after the rebase onto main)

- `pnpm lint` — pass (tsc --noEmit, clean)
- `pnpm test` — pass, 644 test files, **11767 passed**, 14 skipped (pre-existing)
- `pnpm audit:sdk:check` — pass ("Lock matches current imports")
- `pnpm audit:env:check` — pass (658 files scanned, 132 legitimate accesses, 0 violations)
- `pnpm scan:env:check` — pass (docs/env-registry in sync, 122 vars)

## Files changed

- `src/agent/auth/model-availability.ts` (new)
- `src/agent/auth/model-availability.test.ts` (new, 18 cases)
- `src/telegram/handlers/commands.ts`
- `src/telegram/bot.test.ts` (+1 case)
- `src/cli/slash/commands/info.ts`
- `src/cli/slash/commands/info.test.ts` (+1 case)
- `docs/model-slots.md`
