### PR TITLE
fix(cli): elicitation URL-mode cancel guard + swallowed errors + UX cleanup (#502)

### DIFF
--- a/src/cli/elicitation-repl.test.ts
+++ b/src/cli/elicitation-repl.test.ts
@@ -92,6 +92,52 @@ describe('makeReplElicitationHandler', () => {
     expect(reader).not.toHaveBeenCalled();
   });
 
+  // Issue #502 F1: URL mode was the ONLY elicitation path with no try/catch
+  // around its readLine await — a rejection (Ctrl+C, session teardown mid-
+  // prompt) propagated out of the handler and was reinterpreted as DECLINE
+  // by the router's outer `.catch(() => DECLINE)` (elicitation-router.ts)
+  // instead of CANCEL like every other path in this module. Before the fix
+  // this test failed with an unhandled rejection, not a wrong assertion.
+  it('maps a readLine rejection to cancel — matches every other elicitation path (#502 F1)', async () => {
+    const reader = vi.fn().mockRejectedValue(new Error('SIGINT'));
+    const handler = makeReplElicitationHandler({
+      readLine: reader,
+      writer: { line: vi.fn() },
+      pendingCount: () => 0,
+    });
+    const result = await handler(urlRequest(), { signal: NO_SIGNAL });
+    expect(result.action).toBe('cancel');
+  });
+
+  // Issue #502 F2: the rejection above is still swallowed as far as the
+  // caller's return value is concerned (CANCEL is the correct, safe outcome
+  // either way) — but it must no longer be INVISIBLE. Under AFK_DEBUG=1 the
+  // underlying error is now observable, distinguishing a genuine dependency
+  // failure from a plain user cancel.
+  it('logs the underlying error via debugLog under AFK_DEBUG=1 (#502 F2)', async () => {
+    const prevDebug = process.env['AFK_DEBUG'];
+    process.env['AFK_DEBUG'] = '1';
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const reader = vi.fn().mockRejectedValue(new Error('boom'));
+      const handler = makeReplElicitationHandler({
+        readLine: reader,
+        writer: { line: vi.fn() },
+        pendingCount: () => 0,
+      });
+      const result = await handler(urlRequest(), { signal: NO_SIGNAL });
+      expect(result.action).toBe('cancel');
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[elicitation]'),
+        expect.objectContaining({ message: 'boom' }),
+      );
+    } finally {
+      logSpy.mockRestore();
+      if (prevDebug === undefined) delete process.env['AFK_DEBUG'];
+      else process.env['AFK_DEBUG'] = prevDebug;
+    }
+  });
+
   describe('form mode', () => {
     // SC1: accept happy path — all three field types coerced correctly
     it('collects string, number, and boolean fields and returns accept', async () => {
@@ -177,6 +223,36 @@ describe('makeReplElicitationHandler', () => {
       );
 
       expect(result.action).toBe('cancel');
+    });
+
+    // Issue #502 F2: the same swallowed-error observability gap existed in
+    // form mode's readLine catch. Verify the pattern was applied here too,
+    // not just in url-mode.
+    it('logs the underlying readLine error via debugLog under AFK_DEBUG=1 (#502 F2)', async () => {
+      const prevDebug = process.env['AFK_DEBUG'];
+      process.env['AFK_DEBUG'] = '1';
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        const reader = vi.fn().mockRejectedValue(new Error('dependency exploded'));
+        const handler = makeReplElicitationHandler({
+          readLine: reader,
+          writer: { line: vi.fn() },
+          pendingCount: () => 0,
+        });
+        const result = await handler(
+          formRequest({ token: { type: 'string' } }),
+          { signal: NO_SIGNAL },
+        );
+        expect(result.action).toBe('cancel');
+        expect(logSpy).toHaveBeenCalledWith(
+          expect.stringContaining('[elicitation]'),
+          expect.objectContaining({ message: 'dependency exploded' }),
+        );
+      } finally {
+        logSpy.mockRestore();
+        if (prevDebug === undefined) delete process.env['AFK_DEBUG'];
+        else process.env['AFK_DEBUG'] = prevDebug;
+      }
     });
 
     // SC4: optional-field skip — empty enter omits field, loop continues
@@ -723,6 +799,71 @@ describe('agent-question mode', () => {
     );
     expect(result.action).toBe('accept');
     expect(result.content?.['value']).toEqual(['choice-a', 'choice-c']);
+  });
+
+  // Issue #502 F8: the multi_choice numbered-list fallback omitted the \x07
+  // bell that the choice/confirm fallbacks already emit.
+  it('multi_choice type: rings the bell before the numbered fallback list (parity with choice) (#502 F8)', async () => {
+    const lines: string[] = [];
+    const handler = makeReplElicitationHandler({
+      readLine: vi.fn().mockResolvedValueOnce('1,2'),
+      writer: { line: (t = '') => lines.push(t) },
+      pendingCount: () => 0,
+    });
+    const result = await handler(
+      agentRequest({ type: 'multi_choice', choices: ['a', 'b', 'c'] }),
+      { signal: NO_SIGNAL },
+    );
+    expect(result.action).toBe('accept');
+    expect(lines).toContain('\x07');
+  });
+
+  // Issue #502 F8: the invalid-selection message omitted the custom-answer
+  // upper bound that `choice`'s equivalent message already includes.
+  it('multi_choice type: invalid-selection message includes the custom-answer slot when allowCustom is set (#502 F8)', async () => {
+    const lines: string[] = [];
+    const handler = makeReplElicitationHandler({
+      readLine: vi.fn()
+        .mockResolvedValueOnce('9')   // out of range even counting the custom slot
+        .mockResolvedValueOnce('1'),
+      writer: { line: (t = '') => lines.push(t) },
+      pendingCount: () => 0,
+    });
+    const result = await handler(
+      agentRequest({ type: 'multi_choice', choices: ['a', 'b', 'c'], allowCustom: true }),
+      { signal: NO_SIGNAL },
+    );
+    expect(result.action).toBe('accept');
+    // 3 real choices + 1 custom slot = upper bound 4 — matches `choice`'s
+    // equivalent message (`Please enter a number between 1 and 4.`).
+    expect(lines.join('\n')).toMatch(/between 1 and 4\b/);
+  });
+
+  // Issue #502 F2: same swallowed-error observability gap in agent-question's
+  // readLine catches. One representative site (the default text fallback)
+  // confirms the pattern generalizes here too.
+  it('logs the underlying readLine error via debugLog under AFK_DEBUG=1 (#502 F2)', async () => {
+    const prevDebug = process.env['AFK_DEBUG'];
+    process.env['AFK_DEBUG'] = '1';
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const reader = vi.fn().mockRejectedValue(new Error('picker dependency crashed'));
+      const handler = makeReplElicitationHandler({
+        readLine: reader,
+        writer: { line: vi.fn() },
+        pendingCount: () => 0,
+      });
+      const result = await handler(agentRequest({ type: 'text' }), { signal: NO_SIGNAL });
+      expect(result.action).toBe('cancel');
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('[elicitation]'),
+        expect.objectContaining({ message: 'picker dependency crashed' }),
+      );
+    } finally {
+      logSpy.mockRestore();
+      if (prevDebug === undefined) delete process.env['AFK_DEBUG'];
+      else process.env['AFK_DEBUG'] = prevDebug;
+    }
   });
 
   it('number type: non-numeric re-prompts then accepts valid number', async () => {
@@ -1403,7 +1544,7 @@ describe('agent-question mode — picker path', () => {
 // allow_custom — overlay path (choice/multi_choice via pickFromList)
 // ---------------------------------------------------------------------------
 
-import { CUSTOM_ANSWER_SENTINEL, renderMultiSelector } from './input/selectors.js';
+import { CUSTOM_ANSWER_SENTINEL, renderMultiSelector, renderSelector } from './input/selectors.js';
 
 describe('allow_custom — overlay path (choice)', () => {
   it('sentinel selected → readTextOverlay called → returns { value: null, custom_value }', async () => {
@@ -1769,6 +1910,27 @@ describe('allow_custom — TTY multi-selector path (renderMultiSelector)', () =>
   });
 });
 
+// Issue #502 F3: renderSelector should only ever return an index inside
+// choices[], but a genuine selector/choices-array desync previously returned
+// CANCEL with no diagnostic — indistinguishable from a normal user cancel.
+// Reuses the module-mock scaffold declared above (defaults to the real,
+// non-TTY-null implementation for every other test in this file).
+describe('TTY single-selector path (renderSelector) — out-of-range index', () => {
+  it('choice TTY selector returning an out-of-range index cancels (not a throw) (#502 F3)', async () => {
+    vi.mocked(renderSelector).mockResolvedValueOnce(99);
+    const handler = makeReplElicitationHandler({
+      readLine: vi.fn(),
+      writer: { line: vi.fn() },
+      pendingCount: () => 0,
+    });
+    const result = await handler(
+      agentRequest({ type: 'choice', choices: ['a', 'b'] }),
+      { signal: NO_SIGNAL },
+    );
+    expect(result.action).toBe('cancel');
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Form mode — picker path (enum / boolean fields + pickFromList, TTY surfaces)
 // ---------------------------------------------------------------------------
@@ -1912,5 +2074,155 @@ describe('form mode — picker path (enum/boolean)', () => {
     expect(result.content && 'mode' in result.content).toBe(false);
     // Sentinel was appended after the real options.
     expect(pickFromList.mock.calls[0]?.[0]?.options.length).toBe(3);
+  });
+
+  // Issue #502 F4: two distinct enum values can stringify/sanitize to the
+  // same display label (numeric 1 vs string "1"). Before the fix,
+  // `indexOf` always resolved to the FIRST matching label, so picking the
+  // second "1" silently returned the value at the first "1"'s index instead.
+  it('enum field with colliding labels: resolves to the ORIGINAL value at the picked index, not the first match (#502 F4)', async () => {
+    const lines: string[] = [];
+    // enumValues = [1, "1", 2] → labels before disambiguation = ["1", "1", "2"].
+    const pickFromList = vi.fn().mockImplementationOnce(async (opts: { options: readonly string[] }) => {
+      // Options are disambiguated: ["1 (1)", "1 (2)", "2"]. Pick the SECOND
+      // "1" — the one that maps back to the string enum entry, not the
+      // numeric one at index 0.
+      expect(opts.options).toEqual(['1 (1)', '1 (2)', '2']);
+      return [opts.options[1]];
+    });
+    const handler = makeReplElicitationHandler({
+      readLine: vi.fn(),
+      writer: { line: (t = '') => lines.push(t) },
+      pendingCount: () => 0,
+      pickFromList,
+    });
+
+    const result = await handler(
+      formRequest({ field: { type: 'string', enum: [1, '1', 2] } }, ['field']),
+      { signal: NO_SIGNAL },
+    );
+
+    expect(result.action).toBe('accept');
+    // Must be the STRING "1" (index 1), not the number 1 (index 0) that an
+    // indexOf-on-colliding-labels bug would have silently substituted.
+    expect(result.content?.['field']).toBe('1');
+    expect(typeof result.content?.['field']).toBe('string');
+    // The disambiguated label is what actually got echoed — documents the
+    // (unavoidable) echo-format change the fix introduces for this rare case.
+    expect(lines.some((l) => l.includes('1 (2)'))).toBe(true);
+  });
+
+  // Issue #502 F4 hardening: a raw enum value can itself look like a
+  // disambiguated suffix. A naive single-pass scheme (count original
+  // duplicates, suffix each occurrence from that count alone) suffixes the
+  // second 'dup' to 'dup (2)', which then collides with the third, distinct
+  // raw entry that already reads 'dup (2)' — reintroducing the exact
+  // ambiguity the fix exists to remove, one level deeper. Every option must
+  // stay globally unique and round-trip to its own original enum index.
+  it('enum field with a nested label collision (a raw value that already looks like a disambiguated suffix): every option stays unique (#502 F4 hardening)', async () => {
+    const pickFromList = vi.fn().mockImplementationOnce(async (opts: { options: readonly string[] }) => {
+      expect(new Set(opts.options).size).toBe(opts.options.length);
+      // Pick the LAST rendered option — it must resolve back to the LAST
+      // enum entry (the literal string 'dup (2)'), never to the second
+      // 'dup' that a naive suffix scheme would alias it with.
+      return [opts.options[opts.options.length - 1]];
+    });
+    const handler = makeReplElicitationHandler({
+      readLine: vi.fn(),
+      writer: { line: vi.fn() },
+      pendingCount: () => 0,
+      pickFromList,
+    });
+
+    const result = await handler(
+      formRequest({ field: { type: 'string', enum: ['dup', 'dup', 'dup (2)'] } }, ['field']),
+      { signal: NO_SIGNAL },
+    );
+
+    expect(result.action).toBe('accept');
+    expect(result.content?.['field']).toBe('dup (2)');
+  });
+
+  // Issue #502 F4: non-colliding enums (the overwhelming common case) must
+  // render EXACTLY as before — disambiguation should be invisible unless a
+  // collision actually exists.
+  it('enum field WITHOUT colliding labels: renders unmodified options (#502 F4 regression guard)', async () => {
+    const pickFromList = vi.fn().mockImplementationOnce(async (opts: { options: readonly string[] }) => {
+      expect(opts.options).toEqual(['once', 'session', 'persist', 'deny']);
+      return ['persist'];
+    });
+    const handler = makeReplElicitationHandler({
+      readLine: vi.fn(),
+      writer: { line: vi.fn() },
+      pendingCount: () => 0,
+      pickFromList,
+    });
+
+    const result = await handler(pathApprovalForm(), { signal: NO_SIGNAL });
+    expect(result.action).toBe('accept');
+    expect(result.content?.['choice']).toBe('persist');
+  });
+
+  // Issue #502 F4: an enum value that literally equals the FORM_SKIP_SENTINEL
+  // string made the real enum value unselectable — both it and the actual
+  // skip option rendered identically, and the code always treated a pick of
+  // that label as skip. After the fix the colliding enum entry gets a
+  // disambiguating suffix, so it is selectable and distinct from real skip.
+  it('optional enum field with a value equal to the skip sentinel: stays selectable and distinct from real skip (#502 F4)', async () => {
+    const SKIP_SENTINEL_TEXT = '\u2014 skip (optional) \u2014';
+    const pickFromList = vi.fn().mockImplementationOnce(async (opts: { options: readonly string[] }) => {
+      // 2 enum values + 1 real trailing skip sentinel.
+      expect(opts.options.length).toBe(3);
+      // The colliding enum entry must be disambiguated (not textually equal
+      // to the plain sentinel) so it never gets misread as the skip action...
+      expect(opts.options[0]).not.toBe(SKIP_SENTINEL_TEXT);
+      // ...while the TRUE trailing skip option keeps its exact, unmodified
+      // meaning.
+      expect(opts.options[2]).toBe(SKIP_SENTINEL_TEXT);
+      // Pick the disambiguated enum entry — NOT the real skip option.
+      return [opts.options[0]];
+    });
+    const handler = makeReplElicitationHandler({
+      readLine: vi.fn(),
+      writer: { line: vi.fn() },
+      pendingCount: () => 0,
+      pickFromList,
+    });
+
+    // `weird` optional (not in required[]) so the skip sentinel is appended.
+    const result = await handler(
+      formRequest({ weird: { type: 'string', enum: [SKIP_SENTINEL_TEXT, 'other'] } }),
+      { signal: NO_SIGNAL },
+    );
+
+    expect(result.action).toBe('accept');
+    // The real enum value was returned — NOT the skip/default outcome a
+    // label collision would previously have forced.
+    expect(result.content?.['weird']).toBe(SKIP_SENTINEL_TEXT);
+  });
+
+  // Issue #502 F4: the real skip action must still work when a colliding
+  // enum value has been pushed aside by disambiguation.
+  it('optional enum field with a value equal to the skip sentinel: the real skip option still skips (#502 F4)', async () => {
+    const SKIP_SENTINEL_TEXT = '\u2014 skip (optional) \u2014';
+    const pickFromList = vi.fn().mockImplementationOnce(async (opts: { options: readonly string[] }) => {
+      // Pick the LAST option — the real, unmodified skip sentinel.
+      return [opts.options[opts.options.length - 1]];
+    });
+    const handler = makeReplElicitationHandler({
+      readLine: vi.fn(),
+      writer: { line: vi.fn() },
+      pendingCount: () => 0,
+      pickFromList,
+    });
+
+    const result = await handler(
+      formRequest({ weird: { type: 'string', enum: [SKIP_SENTINEL_TEXT, 'other'] } }),
+      { signal: NO_SIGNAL },
+    );
+
+    expect(result.action).toBe('accept');
+    // Skipped optional field with no declared default is omitted entirely.
+    expect(result.content && 'weird' in result.content).toBe(false);
   });
 });

--- a/src/cli/elicitation/agent-question.ts
+++ b/src/cli/elicitation/agent-question.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ElicitationRequest, ElicitationResult } from '../../agent/types/sdk-types.js';
+import { debugLog } from '../../utils/debug.js';
 import { renderMultiSelector, renderSelector, CUSTOM_ANSWER_SENTINEL } from '../input/selectors.js';
 import { sanitizeSchemaString } from '../_lib/sanitize.js';
 import { palette } from '../palette.js';
@@ -164,7 +165,8 @@ export async function renderAgentQuestion(
         multi: qType === 'multi_choice',
         signal,
       });
-    } catch {
+    } catch (err) {
+      debugLog('[elicitation] choice/multi_choice pickFromList failed:', err);
       return CANCEL;
     }
     if (signal.aborted) return CANCEL;
@@ -223,7 +225,8 @@ export async function renderAgentQuestion(
         multi: false,
         signal,
       });
-    } catch {
+    } catch (err) {
+      debugLog('[elicitation] confirm pickFromList failed:', err);
       return CANCEL;
     }
     if (signal.aborted) return CANCEL;
@@ -251,9 +254,14 @@ export async function renderAgentQuestion(
       ? sanitizeSchemaString(result.value, 256)
       : String(result.value);
     writer.line(palette.dim('  ✓ ') + palette.brand(echo));
+    // result.value is a plain accessor here — both remaining union members
+    // (`text` and `number`; `skip` already returned above) carry a `value`
+    // property, so there is no type-narrowing reason to branch on `.tag`
+    // like the `echo` computation above does (that branch calls a
+    // DIFFERENT function per arm — sanitizeSchemaString vs String).
     return {
       action: 'accept',
-      content: { value: result.tag === 'text' ? result.value : result.value },
+      content: { value: result.value },
     };
   }
 
@@ -277,7 +285,8 @@ export async function renderAgentQuestion(
       let input: string;
       try {
         input = (await readLine(palette.dim(`  Continue? [${defaultHint}] `))).trim().toLowerCase();
-      } catch {
+      } catch (err) {
+        debugLog('[elicitation] confirm readLine failed:', err);
         return CANCEL;
       }
       if (signal.aborted) return CANCEL;
@@ -310,7 +319,12 @@ export async function renderAgentQuestion(
       // Sentinel index = original choices.length
       if (request.allowCustom && selectorResult === choices.length) {
         let input: string;
-        try { input = (await readLine(palette.dim('  Type your answer: '))).trim(); } catch { return CANCEL; }
+        try {
+          input = (await readLine(palette.dim('  Type your answer: '))).trim();
+        } catch (err) {
+          debugLog('[elicitation] custom-answer readLine failed:', err);
+          return CANCEL;
+        }
         if (input === ':cancel' || signal.aborted) return CANCEL;
         return { action: 'accept', content: { value: null, custom_value: input } };
       }
@@ -319,6 +333,13 @@ export async function renderAgentQuestion(
         writer.line(palette.dim(`  Selected: ${sanitizeSchemaString(chosen, 128)}`));
         return { action: 'accept', content: { value: chosen } };
       }
+      // Defensive: renderSelector should only ever return an index inside
+      // choices[]. Reaching this with no message previously made a genuine
+      // selector/choices-array desync indistinguishable from a normal cancel.
+      debugLog('[elicitation] choice selector returned an out-of-range index:', {
+        selectorResult,
+        choicesLength: choices.length,
+      });
       return CANCEL;
     }
 
@@ -334,14 +355,20 @@ export async function renderAgentQuestion(
       let input: string;
       try {
         input = (await readLine(palette.dim('  Enter number: '))).trim();
-      } catch {
+      } catch (err) {
+        debugLog('[elicitation] choice readLine failed:', err);
         return CANCEL;
       }
       if (signal.aborted) return CANCEL;
       if (input === ':cancel') return CANCEL;
       if (request.allowCustom && input === String(choices.length + 1)) {
         let custom: string;
-        try { custom = (await readLine(palette.dim('  Type your answer: '))).trim(); } catch { return CANCEL; }
+        try {
+          custom = (await readLine(palette.dim('  Type your answer: '))).trim();
+        } catch (err) {
+          debugLog('[elicitation] custom-answer readLine failed:', err);
+          return CANCEL;
+        }
         if (custom === ':cancel') return CANCEL;
         return { action: 'accept', content: { value: null, custom_value: custom } };
       }
@@ -356,6 +383,7 @@ export async function renderAgentQuestion(
   }
 
   if (qType === 'multi_choice') {
+    writer.line('\x07');
     const choices = request.choices ?? [];
 
     // Interactive arrow-key multi-selector (TTY path)
@@ -368,7 +396,12 @@ export async function renderAgentQuestion(
       // undefined and leaks into `values` / throws in sanitizeSchemaString.
       if (request.allowCustom && selectorResult.includes(choices.length)) {
         let input: string;
-        try { input = (await readLine(palette.dim('  Type your answer: '))).trim(); } catch { return CANCEL; }
+        try {
+          input = (await readLine(palette.dim('  Type your answer: '))).trim();
+        } catch (err) {
+          debugLog('[elicitation] custom-answer readLine failed:', err);
+          return CANCEL;
+        }
         if (input === ':cancel' || signal.aborted) return CANCEL;
         return { action: 'accept', content: { value: null, custom_value: input } };
       }
@@ -393,14 +426,20 @@ export async function renderAgentQuestion(
       let input: string;
       try {
         input = (await readLine(palette.dim('  Enter numbers (comma-separated): '))).trim();
-      } catch {
+      } catch (err) {
+        debugLog('[elicitation] multi_choice readLine failed:', err);
         return CANCEL;
       }
       if (signal.aborted) return CANCEL;
       if (input === ':cancel') return CANCEL;
       if (request.allowCustom && input === String(choices.length + 1)) {
         let custom: string;
-        try { custom = (await readLine(palette.dim('  Type your answer: '))).trim(); } catch { return CANCEL; }
+        try {
+          custom = (await readLine(palette.dim('  Type your answer: '))).trim();
+        } catch (err) {
+          debugLog('[elicitation] custom-answer readLine failed:', err);
+          return CANCEL;
+        }
         if (custom === ':cancel') return CANCEL;
         return { action: 'accept', content: { value: null, custom_value: custom } };
       }
@@ -415,7 +454,7 @@ export async function renderAgentQuestion(
       for (const part of parts) {
         const idx = parseInt(part, 10);
         if (!isFinite(idx) || String(idx) !== part || idx < 1 || idx > choices.length) {
-          writer.line(palette.warning(`  Invalid selection "${sanitizeSchemaString(part, 32)}". Enter numbers between 1 and ${choices.length}.`));
+          writer.line(palette.warning(`  Invalid selection "${sanitizeSchemaString(part, 32)}". Enter numbers between 1 and ${choices.length + (request.allowCustom ? 1 : 0)}.`));
           valid = false;
           break;
         }
@@ -442,7 +481,8 @@ export async function renderAgentQuestion(
       let input: string;
       try {
         input = (await readLine(palette.dim(`  Enter a number${boundsHint}: `))).trim();
-      } catch {
+      } catch (err) {
+        debugLog('[elicitation] number readLine failed:', err);
         return CANCEL;
       }
       if (signal.aborted) return CANCEL;
@@ -470,7 +510,8 @@ export async function renderAgentQuestion(
     let input: string;
     try {
       input = (await readLine(palette.dim('  > '))).trim();
-    } catch {
+    } catch (err) {
+      debugLog('[elicitation] text readLine failed:', err);
       return CANCEL;
     }
     if (signal.aborted) return CANCEL;

--- a/src/cli/elicitation/form-mode.ts
+++ b/src/cli/elicitation/form-mode.ts
@@ -9,10 +9,14 @@
  *   3. Coerce values to the declared type; re-prompt on invalid input.
  *   4. Required fields re-prompt on empty; optional fields skip on empty.
  *   5. User can type :cancel or :decline at any prompt to abort.
- *   6. If schema has no properties, fall back to a single free-text prompt.
+ *   6. If schema has no properties, decline — see the guard in
+ *      `repl-handler.ts` (an earlier fallback invented an undocumented
+ *      `response` key that neither the MCP spec nor the URL-mode contract
+ *      recognises; declining is safer and prompts the server to fix itself).
  */
 
 import type { ElicitationRequest } from '../../agent/types/sdk-types.js';
+import { debugLog } from '../../utils/debug.js';
 import { sanitizeSchemaString } from '../_lib/sanitize.js';
 import { palette } from '../palette.js';
 import type { ReplElicitationDeps } from './repl-shared.js';
@@ -119,6 +123,54 @@ export function renderFormHeader(
 const FORM_SKIP_SENTINEL = '\u2014 skip (optional) \u2014';
 
 /**
+ * Disambiguate a list of display labels so every one is unique — both
+ * against each other AND against any `reserved` string (the FORM_SKIP_SENTINEL
+ * appended for optional fields). Two distinct enum values can stringify /
+ * sanitize to the same label (numeric `1` vs string `"1"`, or two long values
+ * truncated identically at the 64-char `sanitizeSchemaString` cap); an enum
+ * value can also happen to literally equal the reserved skip sentinel. Either
+ * collision makes the caller's `indexOf`-based resolution ambiguous: a picked
+ * label could originate from more than one index (always resolving to the
+ * FIRST match, silently returning the wrong original value), or — for the
+ * reserved case — a real enum value becomes indistinguishable from, and
+ * therefore unselectable next to, the skip action.
+ *
+ * Only labels that actually collide are touched — the non-colliding common
+ * case renders identically to before. A colliding label is suffixed with the
+ * first `(1)`, `(2)`, … candidate not already claimed — checked against a
+ * running set, NOT just the original input — because a raw label can itself
+ * look like a suffixed form (e.g. `['dup', 'dup', 'dup (2)']`: a naive
+ * single-pass "count original duplicates, suffix each" scheme suffixes the
+ * second `dup` to `dup (2)`, which then COLLIDES with the third, unrelated
+ * raw label that already read `dup (2)` — reintroducing the exact ambiguity
+ * this function exists to remove, just one level deeper). Checking against
+ * the running set closes that gap: every emitted candidate, before being
+ * accepted, is guaranteed distinct from every reserved string AND every
+ * label already emitted earlier in this same pass.
+ */
+function disambiguateLabels(labels: readonly string[], reserved: readonly string[]): string[] {
+  const used = new Set<string>(reserved);
+  const rawCounts = new Map<string, number>();
+  for (const label of labels) rawCounts.set(label, (rawCounts.get(label) ?? 0) + 1);
+
+  const result: string[] = [];
+  for (const label of labels) {
+    const mustDisambiguate = (rawCounts.get(label) ?? 0) > 1 || used.has(label);
+    let candidate = label;
+    if (mustDisambiguate) {
+      let n = 0;
+      do {
+        n += 1;
+        candidate = `${label} (${n})`;
+      } while (used.has(candidate));
+    }
+    used.add(candidate);
+    result.push(candidate);
+  }
+  return result;
+}
+
+/**
  * Render an `enum` / `boolean` form field as an arrow-key picker — the same
  * `PickerController` overlay the `ask_question` choice path uses — instead of a
  * typed `readLine` prompt. Only reached when a `pickFromList` dep is wired
@@ -148,7 +200,10 @@ async function pickFormField(
   let resolveValue: (picked: string) => unknown;
   if (fieldDef.enum !== undefined) {
     const enumValues = fieldDef.enum.slice(0, MAX_ENUM_VALUES);
-    baseLabels = enumValues.map((v) => sanitizeSchemaString(String(v), 64));
+    const rawLabels = enumValues.map((v) => sanitizeSchemaString(String(v), 64));
+    // Disambiguate against each other AND against the skip sentinel this
+    // field will append below when optional — see disambiguateLabels for why.
+    baseLabels = disambiguateLabels(rawLabels, isRequired ? [] : [FORM_SKIP_SENTINEL]);
     resolveValue = (picked: string): unknown => {
       const idx = baseLabels.indexOf(picked);
       return idx >= 0 ? enumValues[idx] : picked;
@@ -168,7 +223,8 @@ async function pickFormField(
   let selected: readonly string[] | null;
   try {
     selected = await pickFromList({ header, options, multi: false, signal });
-  } catch {
+  } catch (err) {
+    debugLog('[elicitation] form pickFromList failed:', err);
     return { tag: 'cancel' };
   }
   if (signal.aborted) return { tag: 'cancel' };
@@ -262,7 +318,8 @@ export async function promptField(
     let input: string;
     try {
       input = await readLine(palette.dim('  > '));
-    } catch {
+    } catch (err) {
+      debugLog('[elicitation] form readLine failed:', err);
       return { tag: 'cancel' };
     }
 

--- a/src/cli/elicitation/repl-handler.ts
+++ b/src/cli/elicitation/repl-handler.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ElicitationRequest, ElicitationResult } from '../../agent/types/sdk-types.js';
+import { debugLog } from '../../utils/debug.js';
 import { ringBellIfEnabled } from '../_lib/capture-mode.js';
 import { sanitizeSchemaString } from '../_lib/sanitize.js';
 import { palette } from '../palette.js';
@@ -146,7 +147,21 @@ export function makeReplElicitationHandler(
       // URL mode (also the default when mode is omitted — most MCP OAuth
       // flows surface a URL to visit).
       renderUrlRequest(deps.writer, request);
-      const reply = (await deps.readLine(palette.dim('Continue? [y/N] '))).trim().toLowerCase();
+      // Invariant: every readLine/pickFromList await in this module maps a
+      // rejection (Ctrl+C, session teardown mid-prompt) to CANCEL — this was
+      // previously the ONLY such await left unguarded, so a rejection here
+      // propagated past this handler's `finally` and was reinterpreted as
+      // DECLINE by the router's outer `.catch(() => DECLINE)`
+      // (elicitation-router.ts) instead of CANCEL. DECLINE and CANCEL are
+      // different signals to the MCP server; an interrupted prompt must
+      // report the same outcome every other path already does.
+      let reply: string;
+      try {
+        reply = (await deps.readLine(palette.dim('Continue? [y/N] '))).trim().toLowerCase();
+      } catch (err) {
+        debugLog('[elicitation] url-mode readLine failed:', err);
+        return CANCEL;
+      }
       if (reply === '') return CANCEL;
       if (reply === 'y' || reply === 'yes') return ACCEPT;
       return DECLINE;

--- a/src/cli/elicitation/repl-shared.ts
+++ b/src/cli/elicitation/repl-shared.ts
@@ -62,7 +62,6 @@ export interface ReplElicitationDeps {
    */
   readTextOverlay?: (opts: {
     header: readonly string[];
-    initial?: string;
     help?: string;
     validate?: (value: string) => string | null;
     signal: AbortSignal;


### PR DESCRIPTION
Fixes #502 — closes out the last of the #367-split follow-up findings tracked under #360.

## What changed

**Behavior bugs (1–4 in the issue):**

1. **URL-mode `readLine` had no cancel guard** (`repl-handler.ts`) — it was the only elicitation path with no try/catch around its `readLine` await. A rejection (Ctrl+C, session teardown mid-prompt) propagated past the handler and was reinterpreted as `DECLINE` by the router's outer `.catch(() => DECLINE)` instead of `CANCEL` like every other path. Now wrapped identically to the rest of the module.
2. **Swallowed errors** — all 14 bare `catch {}` blocks across `repl-handler.ts`, `form-mode.ts`, and `agent-question.ts` now log the caught error via the existing `debugLog` utility (gated on `AFK_DEBUG=1`/`DEBUG=1`) before returning the exact same `CANCEL`-shaped result as before. A genuine dependency failure is no longer indistinguishable from a plain user cancel — with zero change to the return contract (verified: existing 96 tests pass unmodified).
3. **Silent CANCEL on undefined choice index** (`agent-question.ts`) — the choice-selector's defensive "index not in `choices[]`" branch returned `CANCEL` with no diagnostic. Now logs before returning.
4. **Enum-label collision** (`form-mode.ts`) — two failure modes in the enum picker: (a) distinct enum values that stringify/sanitize to the same display label made `indexOf`-based resolution always pick the *first* match, silently returning the wrong original value when a later duplicate was picked; (b) an enum value literally equal to the internal skip-sentinel string was unselectable (indistinguishable from, and always treated as, skip). Fixed with a new `disambiguateLabels` helper that guarantees every rendered label is globally unique. Non-colliding enums — the overwhelming common case — render identically to before.

**Cleanup (5–8 in the issue):**

5. Removed the dead ternary with identical arms in `agent-question.ts` (`result.tag === 'text' ? result.value : result.value` → `result.value`).
6. Removed the unused `readTextOverlay.initial?: string` field from `ReplElicitationDeps` — no call site in the elicitation path ever passed it (confirmed dead against every production call site, including the `config-menu.ts` consumer of the *unrelated* `runTextInput` `initial` field, which is a different type).
7. Corrected a stale doc comment in `form-mode.ts` claiming an empty schema "falls back to a single free-text prompt" — the code actually declines.
8. `multi_choice`'s numbered-list fallback was missing the `\x07` bell that `choice`'s equivalent fallback already emits, and its invalid-selection message omitted the custom-answer slot from its upper bound — both now match `choice`'s pattern.

## Why one PR (not two)

The issue's own triage comment suggested splitting behavior fixes (1–4) from cleanup (5–8) into two PRs given their different risk profiles. Since finding #4 was flagged "medium fix-risk," I kept it deliberately narrow (only touches label *display strings* inside the enum picker, gated behind an already-isolated helper function) and verified it thoroughly (see below) — closing the whole issue in one reviewed PR.

## Verification

- `pnpm lint` (`tsc --noEmit`, strict) — clean.
- Full suite: 11776/11790 passed (14 pre-existing, unrelated skips), **0 failures** — baseline was 11728 passed before this change; net +48 from an unrelated rebase onto current `main` plus **+12 new tests** added here.
- `pnpm audit:sdk:check` / `audit:env:check` / `scan:env:check` — all green.
- Independent two-wave review pass (security/api-compat + correctness/test-coverage) run against the staged diff before opening this PR. It surfaced and I fixed two real gaps before you ever saw this:
  - A **second-order label collision** in the first draft of `disambiguateLabels`: a raw enum value that already looks like a disambiguated suffix (e.g. a literal `"x (2)"` alongside two `"x"` entries) could alias the suffix a naive single-pass scheme assigns to the second `"x"`, reintroducing the exact ambiguity the fix exists to remove. Rewrote it to check every candidate against a running "already-claimed" set instead of a static pre-count. Added a regression test for this exact shape.
  - **Finding #3 was untestable-sounding but wasn't** — the file already has a `vi.mock('./input/selectors.js', ...)` scaffold (added for a prior `renderMultiSelector` fix) that I hadn't reused. Extended it to cover the out-of-range `renderSelector` index branch too.

## Test additions

12 new tests in `src/cli/elicitation-repl.test.ts`, one per finding (plus the nested-collision hardening case above), each named with its `#502 F<n>` tag for traceability back to the issue.

🤖 Generated with [AFK](https://github.com/griffinwork40/agent-afk)
