### PR TITLE
feat(subagent): fail-fast denial circuit breaker for forked read-denial spins (#546)

### DIFF
--- a/src/agent/providers/anthropic-direct/loop.denial-breaker.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.denial-breaker.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import type { MessageParam } from '@anthropic-ai/sdk/resources';
+import { runTurn } from './loop.js';
+import type { ToolCall, ToolResult } from './types.js';
+import { DenialCircuitBreakerError } from '../../../utils/errors.js';
+import { DENIAL_BREAKER_FAILURE_CLASS } from '../../tools/denial-circuit-breaker.js';
+import {
+  fromArray,
+  collect,
+  ctx,
+  makeTextStream,
+  makeToolUseStream,
+  makeClient,
+  makeBatchDispatcher,
+} from './loop.test-helpers.js';
+
+// #546: when the dispatcher trips the denial circuit breaker it tags the
+// tool result `failureClass: 'denial-breaker'`. The loop MUST surface that as a
+// loud terminal `error` event (→ DenialCircuitBreakerError, rethrown into a
+// structured failure by the shared subagent handle) and STOP — never silently
+// continue looping to the wall-clock budget, and never dress it as a success.
+describe('loop.ts — denial circuit breaker fail-loud', () => {
+  it('yields a terminal DenialCircuitBreakerError event and stops the loop on a denial-breaker result', async () => {
+    let callIdx = 0;
+    const client = makeClient(() => {
+      callIdx += 1;
+      // Round 1: the model issues a read. Round 2 (a text answer) must NEVER be
+      // reached — tripping the breaker ends the turn immediately.
+      if (callIdx === 1) {
+        return fromArray(makeToolUseStream('toolu_r', 'read_file', '{"file_path":"/out-of-scope/x.ts"}'));
+      }
+      return fromArray(makeTextStream('this second round should never run'));
+    });
+
+    const DENIAL_MSG =
+      'Denial circuit breaker: this forked sub-agent hit 5 consecutive path-approval read denials';
+    const dispatcher = makeBatchDispatcher(
+      async (calls: ToolCall[]): Promise<ToolResult[]> =>
+        calls.map(() => ({
+          content: DENIAL_MSG,
+          isError: true,
+          failureClass: DENIAL_BREAKER_FAILURE_CLASS,
+        })),
+    );
+
+    const messages: MessageParam[] = [{ role: 'user', content: 'read a bunch of files' }];
+    const events = await collect(
+      runTurn({
+        client,
+        messages,
+        system: null,
+        tools: [{ name: 'read_file', input_schema: { type: 'object' } }],
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 1024,
+        headers: {},
+        signal: new AbortController().signal,
+        ctx,
+      }),
+    );
+
+    // 1. A loud error event was emitted, carrying the actionable message.
+    const errorEvent = events.find((e) => e.type === 'error');
+    expect(errorEvent).toBeDefined();
+    if (errorEvent?.type === 'error') {
+      expect(errorEvent.error).toBeInstanceOf(DenialCircuitBreakerError);
+      expect(errorEvent.error.message).toContain('Denial circuit breaker');
+    }
+
+    // 2. The loop STOPPED — the model was called exactly once, never looping to
+    //    a second round (which is the wall-clock-budget burn #546 kills).
+    expect(client.messages.create).toHaveBeenCalledTimes(1);
+
+    // 3. Fail LOUD, not a silent success: no clean turn.completed after the trip.
+    expect(events.some((e) => e.type === 'turn.completed')).toBe(false);
+  });
+});

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -63,6 +63,8 @@ import {
   resolveMaxToolIterations,
   shouldWindDown,
 } from '../shared/tool-loop-cap.js';
+import { DENIAL_BREAKER_FAILURE_CLASS } from '../../tools/denial-circuit-breaker.js';
+import { DenialCircuitBreakerError } from '../../../utils/errors.js';
 
 // Re-exported from the provider-neutral `shared/tool-loop-cap.ts` (single
 // source of truth shared with openai-compatible). Kept exported here so
@@ -853,6 +855,22 @@ export async function* runTurn(
       content: toolResultBlocks as ContentBlockParam[],
     };
     input.messages.push(toolResultTurn);
+
+    // Denial circuit breaker (#546): the dispatcher tagged a result
+    // `denial-breaker` after a forked child hit N consecutive path-approval
+    // read denials with no progress. Surface it as a LOUD `error` event — never
+    // a silent partial — so the shared subagent handle rethrows it into a
+    // structured `buildResultFromError` failure the parent can act on (mirrors
+    // the TimeoutError teardown). History is already consistent here (assistant
+    // `tool_use` + matching `tool_result` blocks both pushed above), so
+    // returning is safe; the fork is done. A dispatcher throw would instead be
+    // swallowed by the executeBatch/execute catch above and the loop would keep
+    // spinning — which is the exact failure this breaker exists to prevent.
+    const denialTrip = results.find((r) => r.failureClass === DENIAL_BREAKER_FAILURE_CLASS);
+    if (denialTrip) {
+      yield { type: 'error', error: new DenialCircuitBreakerError(denialTrip.content) };
+      return;
+    }
     } catch (err) {
       // Rollback the orphaned assistant `tool_use` push above so the next
       // turn's API call does not 400 with "tool_use ids were found without

--- a/src/agent/providers/openai-compatible/query.denial-breaker.test.ts
+++ b/src/agent/providers/openai-compatible/query.denial-breaker.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type OpenAI from 'openai';
+import type { ProviderEvent, ProviderUserTurn } from '../../provider.js';
+import type { AgentConfig } from '../../types/config-types.js';
+import type { OpenAIChunk } from './translate.js';
+import type { ToolCall, ToolResult } from '../anthropic-direct/types.js';
+import { __setOpenAIClientFactory, OpenAICompatibleQuery, type OpenAIClientFactory } from './query.js';
+import { SessionToolDispatcher } from '../../tools/dispatcher.js';
+import { builtinToolSchemas } from '../../tools/schemas.js';
+import { createHookRegistry } from '../../hooks.js';
+import type { ToolHandler } from '../../tools/types.js';
+import { DenialCircuitBreakerError } from '../../../utils/errors.js';
+import {
+  DENIAL_BREAKER_FAILURE_CLASS,
+  DENIAL_CIRCUIT_BREAKER_THRESHOLD,
+} from '../../tools/denial-circuit-breaker.js';
+
+// #546: the openai-compatible provider is the SECOND half wired for the denial
+// circuit breaker (query.ts + query/dispatch-append.ts). When the dispatcher
+// tags a tool result `failureClass: 'denial-breaker'`, dispatchAndAppend hands
+// the tripping ToolResult back up through its widened generator return type
+// (`AsyncGenerator<ProviderEvent, ToolResult | undefined>`, read via the nested
+// `{ call, result }` shape), and query.ts surfaces a LOUD terminal `error`
+// event (→ DenialCircuitBreakerError), nulls its abortController, and STOPS the
+// loop — never looping to the wall-clock budget, never a silent success. This
+// file is the openai analog of anthropic-direct/loop.denial-breaker.test.ts and
+// additionally proves the REAL dispatcher trips end-to-end through this loop.
+
+// ---- minimal scripted-client harness (mirrors query.test.ts) --------------
+
+let createCalls: Array<{ args: unknown }> = [];
+let scriptedTurns: Array<{ chunks: OpenAIChunk[] }> = [];
+let scriptedTurnIndex = 0;
+
+function installScriptedClient(): void {
+  const factory: OpenAIClientFactory = () =>
+    ({
+      chat: {
+        completions: {
+          create: async (args: { stream?: boolean }) => {
+            createCalls.push({ args });
+            if (!args.stream) throw new Error('test mock only supports streaming');
+            const script = scriptedTurns[scriptedTurnIndex++];
+            if (!script) throw new Error(`scripted turn ${scriptedTurnIndex - 1} not defined`);
+            const chunks = script.chunks.slice();
+            return (async function* () {
+              for (const c of chunks) yield c;
+            })();
+          },
+        },
+      },
+    }) as unknown as OpenAI;
+  __setOpenAIClientFactory(factory);
+}
+
+async function collect(query: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  for await (const ev of query) out.push(ev);
+  return out;
+}
+
+async function* singleInput(content: string): AsyncIterable<ProviderUserTurn> {
+  yield { content };
+}
+
+function baseConfig(over: Partial<AgentConfig> = {}): AgentConfig {
+  return { model: 'gpt-4o-mini', apiKey: 'sk-test-key', ...over } as AgentConfig;
+}
+
+/** One scripted round in which the model issues a single read_file tool call. */
+function readRound(id: string, filePath: string): { chunks: OpenAIChunk[] } {
+  return {
+    chunks: [
+      {
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id,
+                  type: 'function',
+                  function: { name: 'read_file', arguments: JSON.stringify({ file_path: filePath }) },
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+        usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+      },
+    ],
+  };
+}
+
+/** A trailing text round the loop must NEVER reach once the breaker trips. */
+const NEVER_REACHED_TEXT_ROUND: { chunks: OpenAIChunk[] } = {
+  chunks: [
+    {
+      choices: [{ delta: { content: 'this round must never run' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    },
+  ],
+};
+
+const DENIAL_MSG =
+  'Denial circuit breaker: this forked sub-agent hit 5 consecutive path-approval read denials';
+
+beforeEach(() => {
+  createCalls = [];
+  scriptedTurns = [];
+  scriptedTurnIndex = 0;
+  installScriptedClient();
+});
+
+afterEach(() => {
+  __setOpenAIClientFactory(null);
+});
+
+// ---------------------------------------------------------------------------
+
+describe('openai-compatible query.ts — denial circuit breaker fail-loud', () => {
+  it('yields a terminal DenialCircuitBreakerError and STOPS the loop on a denial-breaker result', async () => {
+    // Round 1: model issues a read; the dispatcher tags it denial-breaker.
+    // Round 2 (text) must NEVER be requested — tripping ends the turn.
+    scriptedTurns = [readRound('r1', '/out-of-scope/x.ts'), NEVER_REACHED_TEXT_ROUND];
+
+    // A dispatcher that returns a denial-breaker result (like the real one on the
+    // Nth consecutive fork read denial). Implements both entry points because
+    // dispatchAndAppend prefers executeBatch, falling back to execute.
+    const denialDispatcher = {
+      execute: async (): Promise<ToolResult> => ({
+        content: DENIAL_MSG,
+        isError: true,
+        failureClass: DENIAL_BREAKER_FAILURE_CLASS,
+      }),
+      executeBatch: async (calls: ToolCall[]): Promise<ToolResult[]> =>
+        calls.map(() => ({
+          content: DENIAL_MSG,
+          isError: true,
+          failureClass: DENIAL_BREAKER_FAILURE_CLASS,
+        })),
+    };
+
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'k', source: 'config', last4: 'test' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'sid',
+      promptStream: singleInput('read a bunch of files'),
+      config: baseConfig(),
+      toolDispatcher: denialDispatcher,
+    });
+    const events = await collect(q);
+
+    // 1. A loud error event carrying the actionable message.
+    const errorEvent = events.find((e) => e.type === 'error');
+    expect(errorEvent).toBeDefined();
+    if (errorEvent?.type === 'error') {
+      expect(errorEvent.error).toBeInstanceOf(DenialCircuitBreakerError);
+      expect(errorEvent.error.message).toContain('Denial circuit breaker');
+    }
+
+    // 2. The loop STOPPED — only round 1 was requested; the wall-clock burn #546
+    //    kills never happens (round 2's text turn is never consumed).
+    expect(createCalls).toHaveLength(1);
+
+    // 3. Fail LOUD, not silent success: no clean turn.completed after the trip.
+    expect(events.some((e) => e.type === 'turn.completed')).toBe(false);
+  });
+
+  it('trips end-to-end through the REAL dispatcher + openai loop on the Nth fork read denial', async () => {
+    // THRESHOLD rounds, each issuing a DISTINCT out-of-scope read (so the
+    // byte-identical repeat breaker never fires — only THIS breaker can catch
+    // it), plus a trailing text round that must never be requested.
+    scriptedTurns = [
+      ...Array.from({ length: DENIAL_CIRCUIT_BREAKER_THRESHOLD }, (_, i) =>
+        readRound(`rr${i}`, `/out-of-scope/f${i}.ts`),
+      ),
+      NEVER_REACHED_TEXT_ROUND,
+    ];
+
+    // Real path-approval-style PreToolUse hook: auto-denies fork reads with the
+    // genuine containment reason (the prefix the breaker gates on).
+    const hookRegistry = createHookRegistry();
+    hookRegistry.register('PreToolUse', async (ctx) => {
+      if (ctx.event === 'PreToolUse' && ctx.toolName === 'read_file') {
+        const filePath = (ctx.input as { file_path?: string }).file_path ?? '<unknown>';
+        return {
+          decision: 'block' as const,
+          reason: `Sub-agent path access denied: ${filePath} is outside the session's granted read roots.`,
+        };
+      }
+      return {};
+    });
+    const dispatcher = new SessionToolDispatcher({
+      handlers: new Map<string, ToolHandler>(),
+      schemas: [...builtinToolSchemas],
+      permissions: { allowedTools: ['read_file'] },
+      hookRegistry,
+      parentSessionId: 'parent-e2e', // wired like a forked child
+    });
+
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'k', source: 'config', last4: 'test' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'sid',
+      promptStream: singleInput('read files'),
+      config: baseConfig(),
+      toolDispatcher: dispatcher,
+    });
+    const events = await collect(q);
+
+    // The real dispatcher tripped and the loop surfaced it loudly.
+    const errorEvent = events.find((e) => e.type === 'error');
+    expect(errorEvent?.type).toBe('error');
+    if (errorEvent?.type === 'error') {
+      expect(errorEvent.error).toBeInstanceOf(DenialCircuitBreakerError);
+      // Actionable: the accumulated denied paths are named in the message.
+      expect(errorEvent.error.message).toContain('/out-of-scope/f0.ts');
+    }
+
+    // Exactly THRESHOLD rounds were requested — the Nth tripped, so the trailing
+    // text round was never reached (no wall-clock burn).
+    expect(createCalls).toHaveLength(DENIAL_CIRCUIT_BREAKER_THRESHOLD);
+    expect(events.some((e) => e.type === 'turn.completed')).toBe(false);
+  });
+});

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -80,13 +80,14 @@ import { translateResponsesEvent, type ResponsesStreamEvent } from './responses-
 import { resolveWireMode, envFlagEnabled, isClaudeFamilyModel, type WireMode } from './responses-config.js';
 import { env } from '../../../config/env.js';
 import type { ToolDispatcher } from '../anthropic-direct/tool-dispatcher.js';
+import type { ToolResult } from '../anthropic-direct/types.js';
 import {
   contextWindowTokensUsed,
   buildContextUsageFields,
   shouldAutoCompact,
   resolveAutoCompactThreshold,
 } from '../shared/auto-compact.js';
-import { HookBlockedError } from '../../../utils/errors.js';
+import { HookBlockedError, DenialCircuitBreakerError } from '../../../utils/errors.js';
 import { COMPACT_SYSTEM_PROMPT, wrapTranscriptForSummary } from '../shared/compaction.js';
 import { compactOpenAIHistory } from './compact.js';
 import { oneShotChatCompletion } from './oneshot.js';
@@ -510,7 +511,19 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       }
 
       // Tool-call path: dispatch, append history, loop.
-      yield* this.dispatchAndAppend(result.state, controller.signal, vision);
+      const denialTrip = yield* this.dispatchAndAppend(result.state, controller.signal, vision);
+      // Denial circuit breaker (#546): a forked child hit N consecutive
+      // path-approval read denials with no progress. Surface a LOUD terminal
+      // `error` event (the subagent handle rethrows it into a structured
+      // failure) and stop — never keep looping to the wall-clock budget. History
+      // was appended by dispatchAndAppend, so the transcript is consistent. Skip
+      // finishTurn: the error event is itself terminal (mirrors the stream-error
+      // path above at `result === null`).
+      if (denialTrip) {
+        if (this.abortController === controller) this.abortController = null;
+        yield { type: 'error', error: new DenialCircuitBreakerError(denialTrip.content) };
+        return;
+      }
       round += 1;
 
       {
@@ -798,8 +811,8 @@ export class OpenAICompatibleQuery implements ProviderQuery {
     state: StreamState,
     signal: AbortSignal,
     vision: boolean,
-  ): AsyncGenerator<ProviderEvent> {
-    yield* dispatchAndAppendToolCalls({
+  ): AsyncGenerator<ProviderEvent, ToolResult | undefined> {
+    return yield* dispatchAndAppendToolCalls({
       state,
       signal,
       vision,

--- a/src/agent/providers/openai-compatible/query/dispatch-append.ts
+++ b/src/agent/providers/openai-compatible/query/dispatch-append.ts
@@ -5,6 +5,7 @@ import type { ProviderEvent } from '../../../provider.js';
 import { extractRawToolInput } from '../../../facets/raw-input.js';
 import type { ToolDispatcher } from '../../anthropic-direct/tool-dispatcher.js';
 import type { ToolResult } from '../../anthropic-direct/types.js';
+import { DENIAL_BREAKER_FAILURE_CLASS } from '../../../tools/denial-circuit-breaker.js';
 import { summarizeToolInput } from '../../shared/tool-input-summary.js';
 import type { OpenAIMessage } from '../messages.js';
 import type { StreamState } from '../translate.js';
@@ -32,6 +33,11 @@ export interface DispatchAndAppendInput {
  * permission checks + the actual handler + PostToolUse hooks), then emit
  * `tool.output` per result, then append the assistant{tool_calls} +
  * tool{result} messages to running history for the next iteration.
+ *
+ * Returns the tripping {@link ToolResult} when a forked child hit the denial
+ * circuit breaker (#546) this round — the caller yields a loud `error` event
+ * and ends the turn — or `undefined` otherwise. History is appended before the
+ * return either way, so the trip surfaces on a consistent transcript.
  */
 export async function* dispatchAndAppendToolCalls({
   state,
@@ -41,12 +47,12 @@ export async function* dispatchAndAppendToolCalls({
   traceWriter,
   priorTurns,
   sessionId,
-}: DispatchAndAppendInput): AsyncGenerator<ProviderEvent> {
+}: DispatchAndAppendInput): AsyncGenerator<ProviderEvent, ToolResult | undefined> {
   if (!toolDispatcher) {
     // Shouldn't reach here — runIteration won't return needsToolDispatch=true
     // when we have no dispatcher because we don't send `tools[]` — but
     // belt-and-braces against a misbehaving model.
-    return;
+    return undefined;
   }
 
   const accumulated = finalizedToolCalls(state);
@@ -232,4 +238,9 @@ export async function* dispatchAndAppendToolCalls({
   // model lacks vision or no result carried an image. See issue #127.
   const imageFollowup = toolImageFollowupMessage(results, { vision });
   if (imageFollowup) priorTurns.push(imageFollowup);
+
+  // Denial circuit breaker (#546): if the dispatcher tripped this round, hand
+  // the tripping result back so the caller can surface a loud `error` event and
+  // stop — matching anthropic-direct/loop.ts. History is already appended above.
+  return results.find((r) => r.result.failureClass === DENIAL_BREAKER_FAILURE_CLASS)?.result;
 }

--- a/src/agent/tools/denial-circuit-breaker.test.ts
+++ b/src/agent/tools/denial-circuit-breaker.test.ts
@@ -8,9 +8,20 @@ import {
   DENIAL_CIRCUIT_BREAKER_THRESHOLD,
   DENIAL_BREAKER_FAILURE_CLASS,
   READ_PATH_TOOLS,
+  SUBAGENT_PATH_DENIAL_REASON_PREFIX,
+  isSubagentContainmentDenial,
   extractDeniedReadPath,
   buildDenialBreakerMessage,
 } from './denial-circuit-breaker.js';
+
+// Representative non-containment hook-block reasons the breaker must IGNORE.
+// Byte-for-byte prefixes of the real producers (path-approval-hook.ts's
+// credential floor; an arbitrary user-defined PreToolUse hook).
+const CREDENTIAL_DENYLIST_REASON =
+  'Access denied: /home/u/.ssh/id_rsa is a protected credential/secret path ' +
+  '(read-denylist entry: ~/.ssh). This path is never readable — it holds ' +
+  'credentials, not task data; do not retry.';
+const USER_HOOK_REASON = 'Blocked by org policy: reads of /vault/** are not allowed here.';
 
 // ---- Pure helpers ---------------------------------------------------------
 
@@ -76,21 +87,49 @@ describe('denial-circuit-breaker pure helpers', () => {
     expect(msg).toContain('readRoots'); // the grant remedy
     expect(msg).toMatch(/afk farm/i); // deliberate-confinement framing
   });
+
+  it('isSubagentContainmentDenial: TRUE only for genuine path-approval containment reasons', () => {
+    // The exact shape path-approval-hook.ts emits for a fork read outside roots.
+    expect(
+      isSubagentContainmentDenial(
+        `${SUBAGENT_PATH_DENIAL_REASON_PREFIX} /out/x.ts is outside the session's granted read roots. Reads are confined…`,
+      ),
+    ).toBe(true);
+    // Prefix is load-bearing and must stay in sync with the producer.
+    expect(SUBAGENT_PATH_DENIAL_REASON_PREFIX).toBe('Sub-agent path access denied:');
+  });
+
+  it('isSubagentContainmentDenial: FALSE for the credential/secret read-denylist floor', () => {
+    // A denylisted-secret block is never recoverable by widening readRoots
+    // ("do not retry"), so the breaker's remedy would misdirect — must not count.
+    expect(isSubagentContainmentDenial(CREDENTIAL_DENYLIST_REASON)).toBe(false);
+  });
+
+  it('isSubagentContainmentDenial: FALSE for arbitrary user-hook reasons and undefined', () => {
+    expect(isSubagentContainmentDenial(USER_HOOK_REASON)).toBe(false);
+    expect(isSubagentContainmentDenial(undefined)).toBe(false);
+    expect(isSubagentContainmentDenial('')).toBe(false);
+  });
 });
 
 // ---- Dispatcher integration ----------------------------------------------
 
 const PARENT = 'parent-session-1';
 
-/** PreToolUse hook that path-approval-denies any call whose tool ∈ blockTools. */
-function blockingHook(blockTools: ReadonlySet<string>): HookRegistry {
+/**
+ * PreToolUse hook that path-approval-denies any call whose tool ∈ blockTools.
+ * The block `reason` defaults to a genuine path-approval CONTAINMENT reason (so
+ * the breaker counts it); pass a different `reason` to model the credential
+ * read-denylist floor or a user hook (which must NOT count).
+ */
+function blockingHook(
+  blockTools: ReadonlySet<string>,
+  reason = `Sub-agent path access denied: outside the session's granted read roots`,
+): HookRegistry {
   const registry = createHookRegistryImpl();
   registry.register('PreToolUse', async (ctx) => {
     if (ctx.event === 'PreToolUse' && blockTools.has(ctx.toolName)) {
-      return {
-        decision: 'block' as const,
-        reason: `Sub-agent path access denied: outside the session's granted read roots`,
-      };
+      return { decision: 'block' as const, reason };
     }
     return {};
   });
@@ -105,12 +144,14 @@ function echoHandler(): ToolHandler {
 function makeForkDispatcher(opts: {
   blockTools: ReadonlySet<string>;
   fork?: boolean;
+  /** Custom hook-block reason (default: a genuine containment denial). */
+  reason?: string;
 }): SessionToolDispatcher {
   return new SessionToolDispatcher({
     handlers: new Map<string, ToolHandler>([['echo', echoHandler()]]),
     schemas: [...builtinToolSchemas],
     permissions: { allowedTools: ['echo', 'read_file', 'list_directory', 'glob', 'grep', 'write_file'] },
-    hookRegistry: blockingHook(opts.blockTools),
+    hookRegistry: blockingHook(opts.blockTools, opts.reason),
     ...(opts.fork !== false ? { parentSessionId: PARENT } : {}),
   });
 }
@@ -203,11 +244,66 @@ describe('denial circuit breaker — dispatcher integration', () => {
     expect(trip.failureClass).toBe(DENIAL_BREAKER_FAILURE_CLASS);
   });
 
-  it('trips through the parallel batch path too', async () => {
+  it('trips through the parallel batch path too — first N-1 stay hook-block, Nth trips', async () => {
     const d = makeForkDispatcher({ blockTools: new Set(['read_file']) });
     const calls = Array.from({ length: DENIAL_CIRCUIT_BREAKER_THRESHOLD }, (_, i) => readCall(i));
     const results = await d.executeBatch(calls);
-    // At least the tripping (Nth) call carries the denial-breaker class.
-    expect(results.some((r) => r.failureClass === DENIAL_BREAKER_FAILURE_CLASS)).toBe(true);
+    // Denials are counted in index order during phase-1, so the first N-1 stay
+    // ordinary hook-blocks and exactly the Nth (last) carries the trip. Stronger
+    // than a bare `.some(...)`: it pins WHICH call trips and that earlier ones did not.
+    for (let i = 0; i < DENIAL_CIRCUIT_BREAKER_THRESHOLD - 1; i++) {
+      expect(results[i]!.failureClass).toBe('hook-block');
+    }
+    expect(results[DENIAL_CIRCUIT_BREAKER_THRESHOLD - 1]!.failureClass).toBe(
+      DENIAL_BREAKER_FAILURE_CLASS,
+    );
+  });
+
+  it('executeBatch reset-on-success: a successful sibling restarts the consecutive count', async () => {
+    const d = makeForkDispatcher({ blockTools: new Set(['read_file']) });
+
+    // Batch 1: N-1 denials + a successful echo. N-1 < threshold so no trip, and
+    // the success fires the end-of-batch reset.
+    const batch1: ToolCall[] = [
+      ...Array.from({ length: DENIAL_CIRCUIT_BREAKER_THRESHOLD - 1 }, (_, i) => readCall(i + 1)),
+      { id: 'echo-batch', name: 'echo', input: { message: 'progress' }, signal: new AbortController().signal },
+    ];
+    const r1 = await d.executeBatch(batch1);
+    expect(r1.every((r) => r.failureClass !== DENIAL_BREAKER_FAILURE_CLASS)).toBe(true);
+    expect(r1.some((r) => r.isError === undefined)).toBe(true); // echo succeeded
+
+    // Batch 2: N-1 more denials. If the reset had NOT fired, the running count
+    // would already be N-1 and the first denial here would be the Nth → trip.
+    // It must stay below threshold, proving the reset landed.
+    const batch2 = Array.from({ length: DENIAL_CIRCUIT_BREAKER_THRESHOLD - 1 }, (_, i) => readCall(100 + i));
+    const r2 = await d.executeBatch(batch2);
+    expect(r2.every((r) => r.failureClass === 'hook-block')).toBe(true);
+  });
+
+  it('credential/secret read-denylist blocks NEVER trip — only containment denials count', async () => {
+    // A forked read hard-blocked by the credential floor ("do not retry") is not
+    // recoverable by widening readRoots, so it must not trip this breaker even
+    // well past the threshold. #546 review follow-up.
+    const d = makeForkDispatcher({
+      blockTools: new Set(['read_file']),
+      reason: CREDENTIAL_DENYLIST_REASON,
+    });
+    for (let i = 0; i < DENIAL_CIRCUIT_BREAKER_THRESHOLD * 2; i++) {
+      const r = await d.execute(readCall(i));
+      expect(r.isError).toBe(true);
+      expect(r.failureClass).toBe('hook-block'); // never 'denial-breaker'
+    }
+  });
+
+  it('arbitrary user-hook read blocks NEVER trip — framework does not presume their semantics', async () => {
+    const d = makeForkDispatcher({
+      blockTools: new Set(['read_file']),
+      reason: USER_HOOK_REASON,
+    });
+    for (let i = 0; i < DENIAL_CIRCUIT_BREAKER_THRESHOLD * 2; i++) {
+      const r = await d.execute(readCall(i));
+      expect(r.isError).toBe(true);
+      expect(r.failureClass).toBe('hook-block'); // never 'denial-breaker'
+    }
   });
 });

--- a/src/agent/tools/denial-circuit-breaker.test.ts
+++ b/src/agent/tools/denial-circuit-breaker.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest';
+import { SessionToolDispatcher } from './dispatcher.js';
+import { builtinToolSchemas } from './schemas.js';
+import type { ToolCall, ToolHandler } from './types.js';
+import { createHookRegistryImpl } from '../hook-registry.js';
+import type { HookRegistry } from '../hooks.js';
+import {
+  DENIAL_CIRCUIT_BREAKER_THRESHOLD,
+  DENIAL_BREAKER_FAILURE_CLASS,
+  READ_PATH_TOOLS,
+  extractDeniedReadPath,
+  buildDenialBreakerMessage,
+} from './denial-circuit-breaker.js';
+
+// ---- Pure helpers ---------------------------------------------------------
+
+describe('denial-circuit-breaker pure helpers', () => {
+  it('threshold is a small positive constant (fixed, mirrors the repeat breaker)', () => {
+    expect(DENIAL_CIRCUIT_BREAKER_THRESHOLD).toBe(5);
+  });
+
+  it('failure class is a distinct, non-generic tag', () => {
+    expect(DENIAL_BREAKER_FAILURE_CLASS).toBe('denial-breaker');
+  });
+
+  it('READ_PATH_TOOLS covers path-reading tools but NOT write tools', () => {
+    for (const t of ['read_file', 'list_directory', 'glob', 'grep']) {
+      expect(READ_PATH_TOOLS.has(t)).toBe(true);
+    }
+    // Write-confinement is a separate mechanism — never counted by this breaker.
+    for (const t of ['write_file', 'edit_file', 'bash']) {
+      expect(READ_PATH_TOOLS.has(t)).toBe(false);
+    }
+  });
+
+  it('extractDeniedReadPath pulls file_path for read_file', () => {
+    expect(
+      extractDeniedReadPath({
+        id: '1',
+        name: 'read_file',
+        input: { file_path: '/repo/secret.ts' },
+        signal: new AbortController().signal,
+      }),
+    ).toBe('/repo/secret.ts');
+  });
+
+  it('extractDeniedReadPath pulls path for list_directory/glob/grep', () => {
+    for (const name of ['list_directory', 'glob', 'grep']) {
+      expect(
+        extractDeniedReadPath({
+          id: '1',
+          name,
+          input: { path: '/repo/src' },
+          signal: new AbortController().signal,
+        }),
+      ).toBe('/repo/src');
+    }
+  });
+
+  it('extractDeniedReadPath falls back when no path arg is present (glob/grep default to cwd)', () => {
+    expect(
+      extractDeniedReadPath({
+        id: '1',
+        name: 'grep',
+        input: { pattern: 'foo' },
+        signal: new AbortController().signal,
+      }),
+    ).toBe('<grep with no explicit path>');
+  });
+
+  it('buildDenialBreakerMessage is loud + actionable: names count, paths, remedy, and confinement', () => {
+    const msg = buildDenialBreakerMessage(['/a/one.ts', '/b/two.ts'], 5);
+    expect(msg).toContain('5 consecutive');
+    expect(msg).toContain('/a/one.ts');
+    expect(msg).toContain('/b/two.ts');
+    expect(msg).toContain('readRoots'); // the grant remedy
+    expect(msg).toMatch(/afk farm/i); // deliberate-confinement framing
+  });
+});
+
+// ---- Dispatcher integration ----------------------------------------------
+
+const PARENT = 'parent-session-1';
+
+/** PreToolUse hook that path-approval-denies any call whose tool ∈ blockTools. */
+function blockingHook(blockTools: ReadonlySet<string>): HookRegistry {
+  const registry = createHookRegistryImpl();
+  registry.register('PreToolUse', async (ctx) => {
+    if (ctx.event === 'PreToolUse' && blockTools.has(ctx.toolName)) {
+      return {
+        decision: 'block' as const,
+        reason: `Sub-agent path access denied: outside the session's granted read roots`,
+      };
+    }
+    return {};
+  });
+  return registry;
+}
+
+function echoHandler(): ToolHandler {
+  return async (input: unknown) => ({ content: String((input as { message?: string }).message ?? 'ok') });
+}
+
+/** A dispatcher wired like a forked child (parentSessionId set) by default. */
+function makeForkDispatcher(opts: {
+  blockTools: ReadonlySet<string>;
+  fork?: boolean;
+}): SessionToolDispatcher {
+  return new SessionToolDispatcher({
+    handlers: new Map<string, ToolHandler>([['echo', echoHandler()]]),
+    schemas: [...builtinToolSchemas],
+    permissions: { allowedTools: ['echo', 'read_file', 'list_directory', 'glob', 'grep', 'write_file'] },
+    hookRegistry: blockingHook(opts.blockTools),
+    ...(opts.fork !== false ? { parentSessionId: PARENT } : {}),
+  });
+}
+
+function readCall(n: number): ToolCall {
+  return {
+    id: `read-${n}`,
+    name: 'read_file',
+    input: { file_path: `/out-of-scope/file-${n}.ts` },
+    signal: new AbortController().signal,
+  };
+}
+
+describe('denial circuit breaker — dispatcher integration', () => {
+  it('trips exactly at the threshold with an actionable denial-breaker result', async () => {
+    const d = makeForkDispatcher({ blockTools: new Set(['read_file']) });
+
+    // The first N-1 denials return the ordinary hook-block result.
+    for (let i = 1; i < DENIAL_CIRCUIT_BREAKER_THRESHOLD; i++) {
+      const r = await d.execute(readCall(i));
+      expect(r.isError).toBe(true);
+      expect(r.failureClass).toBe('hook-block');
+      expect(r.content).toContain('blocked by PreToolUse hook');
+    }
+
+    // The Nth denial trips the breaker.
+    const trip = await d.execute(readCall(DENIAL_CIRCUIT_BREAKER_THRESHOLD));
+    expect(trip.isError).toBe(true);
+    expect(trip.failureClass).toBe(DENIAL_BREAKER_FAILURE_CLASS);
+    expect(trip.content).toContain('Denial circuit breaker');
+    // Accumulated distinct denied paths are named in the loud message.
+    expect(trip.content).toContain('/out-of-scope/file-1.ts');
+    expect(trip.content).toContain(`/out-of-scope/file-${DENIAL_CIRCUIT_BREAKER_THRESHOLD}.ts`);
+  });
+
+  it('below-threshold denials do NOT trip', async () => {
+    const d = makeForkDispatcher({ blockTools: new Set(['read_file']) });
+    for (let i = 1; i < DENIAL_CIRCUIT_BREAKER_THRESHOLD; i++) {
+      const r = await d.execute(readCall(i));
+      expect(r.failureClass).toBe('hook-block');
+    }
+  });
+
+  it('WRITE denials never count — write-confinement (worktree isolation) is untouched', async () => {
+    const d = makeForkDispatcher({ blockTools: new Set(['write_file']) });
+    for (let i = 0; i < DENIAL_CIRCUIT_BREAKER_THRESHOLD * 2; i++) {
+      const r = await d.execute({
+        id: `w-${i}`,
+        name: 'write_file',
+        input: { file_path: `/out/x-${i}.ts`, content: 'x' },
+        signal: new AbortController().signal,
+      });
+      expect(r.isError).toBe(true);
+      expect(r.failureClass).toBe('hook-block'); // never 'denial-breaker'
+    }
+  });
+
+  it('interactive (non-fork) sessions never trip — only forks auto-deny', async () => {
+    const d = makeForkDispatcher({ blockTools: new Set(['read_file']), fork: false });
+    for (let i = 0; i < DENIAL_CIRCUIT_BREAKER_THRESHOLD * 2; i++) {
+      const r = await d.execute(readCall(i));
+      expect(r.isError).toBe(true);
+      expect(r.failureClass).toBe('hook-block'); // never 'denial-breaker'
+    }
+  });
+
+  it('resets on any successful tool call (counts consecutive denials, not lifetime)', async () => {
+    const d = makeForkDispatcher({ blockTools: new Set(['read_file']) });
+
+    // 4 denials (one below threshold), then a SUCCESS resets the count.
+    for (let i = 1; i < DENIAL_CIRCUIT_BREAKER_THRESHOLD; i++) {
+      const r = await d.execute(readCall(i));
+      expect(r.failureClass).toBe('hook-block');
+    }
+    const ok = await d.execute({
+      id: 'echo-1',
+      name: 'echo',
+      input: { message: 'progress' },
+      signal: new AbortController().signal,
+    });
+    expect(ok.isError).toBeUndefined();
+
+    // 4 more denials post-reset still do NOT trip (count restarted at 1).
+    for (let i = 1; i < DENIAL_CIRCUIT_BREAKER_THRESHOLD; i++) {
+      const r = await d.execute(readCall(100 + i));
+      expect(r.failureClass).toBe('hook-block');
+    }
+    // The Nth consecutive denial after the reset finally trips.
+    const trip = await d.execute(readCall(200));
+    expect(trip.failureClass).toBe(DENIAL_BREAKER_FAILURE_CLASS);
+  });
+
+  it('trips through the parallel batch path too', async () => {
+    const d = makeForkDispatcher({ blockTools: new Set(['read_file']) });
+    const calls = Array.from({ length: DENIAL_CIRCUIT_BREAKER_THRESHOLD }, (_, i) => readCall(i));
+    const results = await d.executeBatch(calls);
+    // At least the tripping (Nth) call carries the denial-breaker class.
+    expect(results.some((r) => r.failureClass === DENIAL_BREAKER_FAILURE_CLASS)).toBe(true);
+  });
+});

--- a/src/agent/tools/denial-circuit-breaker.ts
+++ b/src/agent/tools/denial-circuit-breaker.ts
@@ -66,6 +66,43 @@ export const READ_PATH_TOOLS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Stable, framework-owned prefix the path-approval `PreToolUse` hook emits on
+ * the `reason` of a forked child's CONTAINMENT auto-deny — a read whose resolved
+ * path falls outside the fork's granted read roots (path-approval-hook.ts:
+ * "Sub-agent path access denied: <path> is outside the session's granted <mode>
+ * roots. …"). This is the exact class of denial the breaker exists to catch
+ * (#546), and the only one for which its remedy ("widen the read scope /
+ * re-dispatch with the path in cwd") is correct.
+ *
+ * Mirrored here (a literal, not an import) for the same reason as {@link
+ * READ_PATH_TOOLS}: to keep the breaker decoupled from the hook module. It is
+ * already a load-bearing contract elsewhere — the `subagent-read-denial`
+ * telemetry detector keys on this same prefix, and path-approval-hook.test.ts
+ * locks the producer at three sites — so a drift in the reason text fails those
+ * tests loudly. If path-approval changes the wording, update it here too.
+ */
+export const SUBAGENT_PATH_DENIAL_REASON_PREFIX = 'Sub-agent path access denied:';
+
+/**
+ * True only for a genuine path-approval CONTAINMENT auto-deny (see {@link
+ * SUBAGENT_PATH_DENIAL_REASON_PREFIX}) — NOT for the two other reasons a forked
+ * read can be hook-blocked:
+ *   - the unconditional credential/secret read-denylist floor
+ *     ("Access denied: … protected credential/secret path … do not retry"), and
+ *   - an arbitrary user-defined `PreToolUse` hook blocking a read.
+ *
+ * The breaker counts ONLY containment denials so its "widen readRoots" remedy is
+ * always accurate: a denylisted-secret block is never recoverable by widening
+ * roots (the message even says "do not retry"), and a user-policy block has
+ * semantics the framework cannot presume. Those spins are rare and remain
+ * bounded by the byte-identical repeat breaker / the wall-clock budget; folding
+ * them in here would only misdirect the parent. `#546`.
+ */
+export function isSubagentContainmentDenial(reason: string | undefined): boolean {
+  return reason !== undefined && reason.includes(SUBAGENT_PATH_DENIAL_REASON_PREFIX);
+}
+
+/**
  * Best-effort human-readable path for a denied read call, for the abort
  * message. Mirrors path-approval-hook.ts's `extractCandidatePath`:
  * `read_file` uses `file_path`; `list_directory`/`glob`/`grep` use `path`

--- a/src/agent/tools/denial-circuit-breaker.ts
+++ b/src/agent/tools/denial-circuit-breaker.ts
@@ -1,0 +1,107 @@
+/**
+ * Denial circuit breaker: fail-fast for forked sub-agents spinning on
+ * path-approval READ denials.
+ *
+ * A forked child cannot prompt to approve an out-of-scope path, so the
+ * path-approval `PreToolUse` hook auto-denies the read (returns
+ * `decision: 'block'`). A child granted too narrow a read scope — or one
+ * genuinely reaching out-of-scope paths — then keeps issuing new (distinct)
+ * reads, each denied, making no progress until its 20-minute wall-clock budget
+ * expires (`SUBAGENT_DEFAULT_TIMEOUT_MS`). The consecutive-byte-identical
+ * repeat breaker ({@link import('./repeat-circuit-breaker.js')}) does NOT catch
+ * this: the reads target *different* paths, so they never fingerprint-collide.
+ *
+ * This breaker closes that gap. The stateful counter (per-dispatcher, so
+ * per-forked-query) lives on `SessionToolDispatcher`; the pure predicates +
+ * threshold + message builder live here. When a fork accumulates
+ * {@link DENIAL_CIRCUIT_BREAKER_THRESHOLD} consecutive read denials with no
+ * intervening successful tool call, the dispatcher tags the result
+ * `failureClass: 'denial-breaker'`; the provider tool-use loop surfaces that as
+ * a LOUD `error` event (→ `DenialCircuitBreakerError` via the shared subagent
+ * handle), never a silent partial-success.
+ *
+ * Scope guards (see {@link READ_PATH_TOOLS} + the dispatcher's `parentSessionId`
+ * check): counts READ tools only — write-denial confinement (worktree
+ * isolation, `afk farm`) is untouched — and only for forked children, so
+ * interactive sessions (which CAN approve a prompt) never trip.
+ *
+ * @module agent/tools/denial-circuit-breaker
+ */
+
+import type { ToolCall } from '../providers/anthropic-direct/types.js';
+import type { ToolFailureClass } from '../trace/types.js';
+
+/**
+ * Consecutive path-approval read denials (with no intervening successful tool
+ * call) after which a forked sub-agent is aborted fast. Fixed constant, mirror
+ * of `REPEAT_CIRCUIT_BREAKER_THRESHOLD`. The issue (#546) suggested 5–10; 5
+ * catches the observed 40-denial worst case ~8× sooner while the
+ * reset-on-success rule (see the dispatcher) keeps a fork that probes a couple
+ * of out-of-scope paths and then makes progress from ever tripping.
+ */
+export const DENIAL_CIRCUIT_BREAKER_THRESHOLD = 5;
+
+/**
+ * The `failureClass` stamped on the tool result that trips this breaker. The
+ * provider loops key on this exact value to convert the result into a loud
+ * `error` event. A member of {@link ToolFailureClass} (see `trace/types.ts`).
+ */
+export const DENIAL_BREAKER_FAILURE_CLASS: ToolFailureClass = 'denial-breaker';
+
+/**
+ * Typed file tools that READ a path. Mirrors path-approval-hook.ts's
+ * `TYPED_FILE_TOOLS` minus `WRITE_TOOLS` (the source of truth for the
+ * read/write split). Duplicated here rather than imported to avoid coupling the
+ * dispatcher to the hook module for a set of core tool names that is extremely
+ * stable; if path-approval adds a read tool, add it here too. Counting only
+ * these tools is what preserves the write-confinement invariant: a confined
+ * worker legitimately denied a WRITE still fails via its own path, not this
+ * breaker.
+ */
+export const READ_PATH_TOOLS: ReadonlySet<string> = new Set([
+  'read_file',
+  'list_directory',
+  'glob',
+  'grep',
+]);
+
+/**
+ * Best-effort human-readable path for a denied read call, for the abort
+ * message. Mirrors path-approval-hook.ts's `extractCandidatePath`:
+ * `read_file` uses `file_path`; `list_directory`/`glob`/`grep` use `path`
+ * (optional for glob/grep). Falls back to a tool-name marker when no path
+ * argument is present.
+ */
+export function extractDeniedReadPath(call: ToolCall): string {
+  const input = (call.input ?? {}) as Record<string, unknown>;
+  const raw =
+    call.name === 'read_file' ? input['file_path'] : input['path'];
+  if (typeof raw === 'string' && raw.length > 0) return raw;
+  return `<${call.name} with no explicit path>`;
+}
+
+/**
+ * Build the loud, actionable abort message. Names the accumulated denied paths
+ * and the grant remedy so the parent can re-dispatch with a corrected read
+ * scope, and explicitly calls out deliberate confinement (`afk farm`) as a
+ * possible — and expected — cause so a confined worker still fails loud + fast
+ * with the right framing rather than hanging.
+ */
+export function buildDenialBreakerMessage(
+  deniedPaths: readonly string[],
+  count: number,
+): string {
+  const pathList =
+    deniedPaths.length > 0 ? deniedPaths.map((p) => `  - ${p}`).join('\n') : '  (no path captured)';
+  return (
+    `Denial circuit breaker: this forked sub-agent hit ${count} consecutive ` +
+    `path-approval read denials with no successful tool call in between, and ` +
+    `was aborted to avoid burning its wall-clock budget. A fork cannot approve ` +
+    `its own reads. Denied paths:\n${pathList}\n\n` +
+    `Remedy: these paths are outside the fork's granted read roots. Re-dispatch ` +
+    `with the needed paths inside the child's cwd/worktree, or pass explicit ` +
+    `readRoots granting them. If this worker is deliberately confined (e.g. an ` +
+    `\`afk farm\` branch worker), this failure is expected — the paths are ` +
+    `outside its assigned scope; widen the scope or narrow the task.`
+  );
+}

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -31,6 +31,13 @@ import { emitHookDecision } from '../trace/emit.js';
 import type { TraceWriter } from '../trace/index.js';
 import { defaultConcurrencyClassifier, partitionIntoBatches } from './dispatch-batching.js';
 import { repeatCallFingerprint } from './repeat-circuit-breaker.js';
+import {
+  DENIAL_CIRCUIT_BREAKER_THRESHOLD,
+  DENIAL_BREAKER_FAILURE_CLASS,
+  READ_PATH_TOOLS,
+  extractDeniedReadPath,
+  buildDenialBreakerMessage,
+} from './denial-circuit-breaker.js';
 
 // Re-exported for backward compatibility: external importers (dispatcher.test.ts,
 // schema-classification.test.ts) historically import this from './dispatcher.js'.
@@ -226,6 +233,17 @@ export class SessionToolDispatcher implements ToolDispatcher {
    * dispatcher reconstruction. See {@link checkRepeatCircuitBreaker}.
    */
   private repeatBreaker: { fingerprint: string; count: number } | null = null;
+
+  /**
+   * Denial circuit breaker state (#546). Counts CONSECUTIVE path-approval READ
+   * denials on a FORKED child (one dispatcher per forked `query()`), reset to
+   * `null` on any successful tool result — so only a fork making zero progress
+   * trips. When `count` reaches {@link DENIAL_CIRCUIT_BREAKER_THRESHOLD} the
+   * dispatcher tags the tripping result `failureClass: 'denial-breaker'`, which
+   * the provider loop surfaces as a loud `error` event. `null` when no denial
+   * has been seen since the last success. See {@link recordForkReadDenial}.
+   */
+  private denialBreaker: { count: number; deniedPaths: string[] } | null = null;
 
   /**
    * Shared grant-state machine (issues #361/#362). The hooks bind the
@@ -514,6 +532,47 @@ export class SessionToolDispatcher implements ToolDispatcher {
   }
 
   /**
+   * Denial circuit breaker (#546). Called with the just-built path-approval
+   * block result for a PreToolUse `hook-block`. Counts the denial ONLY when it
+   * is a forked child (`parentSessionId` set — only forks auto-deny reads; an
+   * interactive session gets a prompt instead) reading via a {@link
+   * READ_PATH_TOOLS} tool (so write-confinement is never counted). Below the
+   * threshold the original block result is returned unchanged; at the threshold
+   * a `denial-breaker` result is returned instead, which the provider loop
+   * converts into a loud `error` event so the parent gets a structured,
+   * actionable failure rather than a fork that burns its wall-clock budget.
+   *
+   * Invariant: consecutive — {@link resetDenialBreaker} clears the count on any
+   * successful tool result, so a fork that probes a couple of out-of-scope
+   * paths and then makes progress never trips.
+   */
+  private recordForkReadDenial(call: ToolCall, blockResult: ToolResult): ToolResult {
+    if (this.parentSessionId === undefined || !READ_PATH_TOOLS.has(call.name)) {
+      return blockResult;
+    }
+    const breaker = this.denialBreaker ?? { count: 0, deniedPaths: [] };
+    breaker.count += 1;
+    const deniedPath = extractDeniedReadPath(call);
+    if (!breaker.deniedPaths.includes(deniedPath)) breaker.deniedPaths.push(deniedPath);
+    this.denialBreaker = breaker;
+    if (breaker.count < DENIAL_CIRCUIT_BREAKER_THRESHOLD) return blockResult;
+    return {
+      content: buildDenialBreakerMessage(breaker.deniedPaths, breaker.count),
+      isError: true,
+      failureClass: DENIAL_BREAKER_FAILURE_CLASS,
+    };
+  }
+
+  /**
+   * Clear the denial breaker's consecutive-denial count. Called on any
+   * successful tool result so the breaker tracks "read denials since the last
+   * progress", not lifetime denials. See {@link recordForkReadDenial}.
+   */
+  private resetDenialBreaker(): void {
+    this.denialBreaker = null;
+  }
+
+  /**
    * Consult the optional `canUseTool` permission callback for a single call.
    * Returns a permission-denied {@link ToolResult} to short-circuit when the
    * policy denies (or throws — fail-closed), or `null` to proceed. On an
@@ -600,11 +659,11 @@ export class SessionToolDispatcher implements ToolDispatcher {
         });
       } catch (err) {
         if (err instanceof HookBlockedError) {
-          return {
+          return this.recordForkReadDenial(call, {
             content: `Tool "${call.name}" blocked by PreToolUse hook: ${err.message}`,
             isError: true,
             failureClass: 'hook-block',
-          };
+          });
         }
         throw err;
       }
@@ -643,7 +702,11 @@ export class SessionToolDispatcher implements ToolDispatcher {
     // that body (agent/skill/compose special-cases + handler lookup +
     // PostToolUse firing); the duplicate only added drift risk with no
     // behavioral difference, so the single-call path now delegates too.
-    return this.executeCore(call);
+    const coreResult = await this.executeCore(call);
+    // Reset-on-success: a completed (non-error) tool call is progress, so the
+    // denial breaker's consecutive-denial count restarts. See recordForkReadDenial.
+    if (coreResult.isError !== true) this.resetDenialBreaker();
+    return coreResult;
   }
 
   /**
@@ -694,11 +757,11 @@ export class SessionToolDispatcher implements ToolDispatcher {
           });
         } catch (err) {
           if (err instanceof HookBlockedError) {
-            results[i] = {
+            results[i] = this.recordForkReadDenial(call, {
               content: `Tool "${call.name}" blocked by PreToolUse hook: ${err.message}`,
               isError: true,
               failureClass: 'hook-block',
-            };
+            });
             blocked.add(i);
             continue;
           }
@@ -848,6 +911,14 @@ export class SessionToolDispatcher implements ToolDispatcher {
           r.batchSize = batchSize;
         }
       });
+    }
+
+    // Reset-on-success (#546): if any call in this batch executed successfully,
+    // the fork made progress, so the denial breaker's consecutive-denial count
+    // restarts. Blocked/denied calls carry isError:true and never reset. See
+    // recordForkReadDenial.
+    if (results.some((r) => r !== undefined && r.isError !== true)) {
+      this.resetDenialBreaker();
     }
 
     return results;

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -35,6 +35,7 @@ import {
   DENIAL_CIRCUIT_BREAKER_THRESHOLD,
   DENIAL_BREAKER_FAILURE_CLASS,
   READ_PATH_TOOLS,
+  isSubagentContainmentDenial,
   extractDeniedReadPath,
   buildDenialBreakerMessage,
 } from './denial-circuit-breaker.js';
@@ -532,22 +533,36 @@ export class SessionToolDispatcher implements ToolDispatcher {
   }
 
   /**
-   * Denial circuit breaker (#546). Called with the just-built path-approval
-   * block result for a PreToolUse `hook-block`. Counts the denial ONLY when it
-   * is a forked child (`parentSessionId` set — only forks auto-deny reads; an
-   * interactive session gets a prompt instead) reading via a {@link
-   * READ_PATH_TOOLS} tool (so write-confinement is never counted). Below the
-   * threshold the original block result is returned unchanged; at the threshold
-   * a `denial-breaker` result is returned instead, which the provider loop
-   * converts into a loud `error` event so the parent gets a structured,
+   * Denial circuit breaker (#546). Called from the `HookBlockedError` catch with
+   * the block `reason` and the just-built `hook-block` result. Counts the denial
+   * ONLY when ALL of:
+   *   - it is a forked child (`parentSessionId` set — only forks auto-deny reads;
+   *     an interactive session gets a prompt instead), AND
+   *   - the tool is a {@link READ_PATH_TOOLS} read (so write-confinement is never
+   *     counted), AND
+   *   - the block is a genuine path-approval CONTAINMENT denial per {@link
+   *     isSubagentContainmentDenial} — NOT the credential/secret read-denylist
+   *     floor or an arbitrary user-defined `PreToolUse` hook, whose denials the
+   *     breaker's "widen readRoots" remedy would misdirect.
+   * Below the threshold the original block result is returned unchanged; at the
+   * threshold a `denial-breaker` result is returned instead, which the provider
+   * loop converts into a loud `error` event so the parent gets a structured,
    * actionable failure rather than a fork that burns its wall-clock budget.
    *
    * Invariant: consecutive — {@link resetDenialBreaker} clears the count on any
    * successful tool result, so a fork that probes a couple of out-of-scope
    * paths and then makes progress never trips.
    */
-  private recordForkReadDenial(call: ToolCall, blockResult: ToolResult): ToolResult {
-    if (this.parentSessionId === undefined || !READ_PATH_TOOLS.has(call.name)) {
+  private recordForkReadDenial(
+    call: ToolCall,
+    blockReason: string | undefined,
+    blockResult: ToolResult,
+  ): ToolResult {
+    if (
+      this.parentSessionId === undefined ||
+      !READ_PATH_TOOLS.has(call.name) ||
+      !isSubagentContainmentDenial(blockReason)
+    ) {
       return blockResult;
     }
     const breaker = this.denialBreaker ?? { count: 0, deniedPaths: [] };
@@ -659,7 +674,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
         });
       } catch (err) {
         if (err instanceof HookBlockedError) {
-          return this.recordForkReadDenial(call, {
+          return this.recordForkReadDenial(call, err.reason, {
             content: `Tool "${call.name}" blocked by PreToolUse hook: ${err.message}`,
             isError: true,
             failureClass: 'hook-block',
@@ -757,7 +772,7 @@ export class SessionToolDispatcher implements ToolDispatcher {
           });
         } catch (err) {
           if (err instanceof HookBlockedError) {
-            results[i] = this.recordForkReadDenial(call, {
+            results[i] = this.recordForkReadDenial(call, err.reason, {
               content: `Tool "${call.name}" blocked by PreToolUse hook: ${err.message}`,
               isError: true,
               failureClass: 'hook-block',

--- a/src/agent/tools/hooks/path-approval-hook.ts
+++ b/src/agent/tools/hooks/path-approval-hook.ts
@@ -298,6 +298,11 @@ async function preToolUseImpl(
         : `Reads are confined to this fork's granted read roots. Return this exact ` +
           `path requirement to your parent, which owns the operator surface and can ` +
           `grant access (widen readRoots or re-dispatch with the path inside cwd).`;
+    // Contract: the "Sub-agent path access denied:" prefix is load-bearing —
+    // the `subagent-read-denial` telemetry detector (improve/scan/detectors)
+    // and the denial circuit breaker (tools/denial-circuit-breaker.ts,
+    // `SUBAGENT_PATH_DENIAL_REASON_PREFIX`) both key on it to recognise this
+    // exact containment auto-deny. If you reword it, update those consumers too.
     return {
       decision: 'block',
       reason:

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -63,6 +63,7 @@ export const TOOL_FAILURE_CLASSES = [
   'hook-block',
   'abort',
   'elicitation-declined',
+  'denial-breaker',
 ] as const;
 
 /**
@@ -80,11 +81,17 @@ export const TOOL_FAILURE_CLASSES = [
  *                              cannot reach a human) or `cancel` (operator dismissed the
  *                              prompt). An unanswered question is an expected outcome on a
  *                              non-interactive or AFK surface, NOT a tool fault.
+ *   - `denial-breaker`       — a forked sub-agent tripped the denial circuit breaker
+ *                              (`denial-circuit-breaker.ts`): N consecutive path-approval
+ *                              read denials with no progress, so it was aborted fast rather
+ *                              than at its wall-clock budget. Deliberately NOT exempt below
+ *                              — a fork torn down for spinning is a review-worthy event the
+ *                              parent should act on (re-dispatch with a wider read scope).
  *
  * The `tool-failure-density` detector treats `policy-refusal`, `permission-denied`,
  * `hook-block`, `abort`, and `elicitation-declined` as "the system correctly said no" —
- * excluded from failure stats entirely — while `timeout` and unclassified failures still
- * count.
+ * excluded from failure stats entirely — while `timeout`, `denial-breaker`, and
+ * unclassified failures still count.
  */
 export type ToolFailureClass = (typeof TOOL_FAILURE_CLASSES)[number];
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -57,6 +57,24 @@ export class BudgetExceededError extends Error {
 }
 
 /**
+ * Thrown (surfaced as a loop `error` event, never a raw throw the dispatcher
+ * would swallow) when a forked sub-agent accumulates
+ * {@link import('../agent/tools/denial-circuit-breaker.js').DENIAL_CIRCUIT_BREAKER_THRESHOLD}
+ * consecutive path-approval READ denials with no intervening successful tool
+ * call. A fork cannot approve its own reads, so once it is provably spinning on
+ * unrecoverable denials, continuing only burns its wall-clock budget. The
+ * message names the accumulated denied paths + the grant remedy so the parent
+ * orchestrator can re-dispatch with a corrected read scope. See
+ * `src/agent/tools/denial-circuit-breaker.ts`.
+ */
+export class DenialCircuitBreakerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DenialCircuitBreakerError";
+  }
+}
+
+/**
  * Thrown when an AgentConfig field is set that the selected provider does
  * not support (e.g. `thinking` on the OpenAI Codex backend). The field name
  * makes it easy for CLI / bridge wrappers to translate into a friendly


### PR DESCRIPTION
## Summary

Closes #546. A forked sub-agent that accumulates repeated **path-approval READ denials** — each a *distinct* path, so the byte-identical repeat circuit breaker never fires — previously kept issuing new denied reads until its 20-minute wall-clock budget (`SUBAGENT_DEFAULT_TIMEOUT_MS`) expired. This adds a per-fork **denial circuit breaker** that aborts in *seconds* once the fork is provably spinning on unrecoverable denials, and hands the parent a **loud, structured, actionable** failure (denied paths + grant remedy) — never a silent/empty success.

This is the defense-in-depth remainder after #544/#554 fixed the most common *cause* (over-narrow fork read scope): even when a denial is genuinely correct, or a future regression reintroduces over-denial, the fork now fails *within* its budget rather than *at* it.

## Approach

The design was hardened by a `/devils-advocate` pass that caught a fatal flaw in the first draft: a **throw** from the dispatcher does **not** abort the fork — `executeCore` never propagates (`dispatcher.ts` no-throw invariant) and the loop's `executeBatch`/`execute` catch downgrades any throw into a per-round `isError` result and keeps looping. So the loud path routes through a normalized **`error` event** instead.

- **`SessionToolDispatcher`** counts *consecutive* path-approval read denials on a forked child (`parentSessionId` set), **reset on any successful tool call**. At `DENIAL_CIRCUIT_BREAKER_THRESHOLD` (5) it tags the tripping result `failureClass: 'denial-breaker'`. Mirrors the existing `repeatBreaker` (per-dispatcher = per-forked-query).
- **Both provider loops** (`anthropic-direct/loop.ts`, `openai-compatible`) detect that tag *after* pushing the round's `tool_result` blocks (transcript stays consistent) and surface it as a terminal `error` event → the shared subagent handle (`streamToFinalMessage` → `buildResultFromError`) rethrows it into the same structured, `isError: true` parent tool_result shape a timeout produces.

## Invariants preserved

- **Interactive sessions never trip** — only forks auto-deny reads (`parentSessionId` gate); an interactive session gets a prompt instead.
- **Write-confinement untouched** — only READ path-tools are counted (`read_file`/`list_directory`/`glob`/`grep`); worktree write-isolation and `afk farm` write denials are a separate mechanism.
- **Reset-on-success** — a fork that probes a couple of out-of-scope paths and then makes progress never trips; only true starvation (zero successful tool calls) does.
- **Confined-worker framing** — the abort message names deliberate confinement (`afk farm`) as a possible + expected cause, so a confined worker still fails loud + fast with the right guidance.

## Acceptance criteria (from #546)

- [x] A fork accumulating ≥N read denials aborts in **seconds**, not at the 20-min bound.
- [x] The parent receives a structured, actionable failure naming denied paths + remedy (not a silent/empty success) — via the `error` event → `buildResultFromError` chain.
- [x] Write-denial confinement behavior unchanged (READ-only counting + test).
- [x] Unit test: a simulated denial stream trips the breaker at the threshold; below-threshold denials do not.
- [ ] `subagent-read-denial` detector (#545) shows the class no longer recurring — validated post-merge against live forks (can't fully reproduce pre-merge).

## Files

| File | Change |
|------|--------|
| `src/utils/errors.ts` | new `DenialCircuitBreakerError` |
| `src/agent/tools/denial-circuit-breaker.ts` | **new** — threshold, read-tool set, path extractor, message builder |
| `src/agent/tools/dispatcher.ts` | per-fork counter, `recordForkReadDenial` + `resetDenialBreaker`, wired at both hook-block catch sites + reset-on-success |
| `src/agent/trace/types.ts` | `'denial-breaker'` added to `TOOL_FAILURE_CLASSES` (non-exempt: review-worthy) |
| `src/agent/providers/anthropic-direct/loop.ts` | detect trip → terminal `error` event |
| `src/agent/providers/openai-compatible/{query.ts,query/dispatch-append.ts}` | same, via generator return value |

## Testing

- `pnpm lint` (tsc strict) ✓ · `pnpm audit:sdk:check` (no new SDK symbols) ✓ · `pnpm scan:env:check` ✓
- `pnpm test:coverage` — full suite green, coverage thresholds met ✓
- New: `denial-circuit-breaker.test.ts` (13 tests) + `loop.denial-breaker.test.ts` (fail-loud + loop-stops).
