### PR TITLE
feat(tui): opt-in plain/append-only output mode (AFK_PLAIN_OUTPUT / --plain)

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -465,6 +465,14 @@
       "category": "model"
     },
     {
+      "name": "AFK_PLAIN_OUTPUT",
+      "description": "Force the interactive REPL to use the append-only plain-stdout renderer instead of the TerminalCompositor live overlay, even when stdout is a TTY. Same code path already used for non-TTY surfaces (pipes, CI). Reliability escape hatch for tmux/SSH/multiplexer sessions where cursor-up redraws and DECSTBM scroll regions misbehave. Opt-in — default TTY behavior (live overlay) is unchanged. Truthy values: 1, true (case-insensitive).",
+      "type": "boolean",
+      "required": false,
+      "example": "1",
+      "category": "misc"
+    },
+    {
       "name": "AFK_PROMPT_CACHE_TTL",
       "description": "TTL for Anthropic prompt-cache blocks. Accepts 5m or 1h.",
       "type": "string",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**122 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**123 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 
@@ -179,6 +179,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_DEMO_CLEAN` | boolean |  |  | `1` | Explicit opt-in to capture-mode. When set to 1, suppresses high-frequency repaint drivers (spinner ticker, live thinking-preview) so recorded artifacts contain each state once instead of once per timer tick. |
 | `AFK_DIFF_LINES` | number |  |  | `50` | Maximum number of diff lines shown in the inline diff render during write_file tool calls. Set to 0 for no cap. Non-integer values are silently ignored and the default applies. |
 | `AFK_MEMORY_EVIDENCE_GATE` | boolean |  |  | `1` | Opt-in (set to 1) evidence gate for durable memory writes. When enabled, a codebase fact (memory_update category "convention") stored without an `evidence` citation is recalled as [unverified], and memory_search results carry a verification verdict. User preferences and agent reflections are never gated. Default off — memory behaves identically to legacy when unset. |
+| `AFK_PLAIN_OUTPUT` | boolean |  |  | `1` | Force the interactive REPL to use the append-only plain-stdout renderer instead of the TerminalCompositor live overlay, even when stdout is a TTY. Same code path already used for non-TTY surfaces (pipes, CI). Reliability escape hatch for tmux/SSH/multiplexer sessions where cursor-up redraws and DECSTBM scroll regions misbehave. Opt-in — default TTY behavior (live overlay) is unchanged. Truthy values: 1, true (case-insensitive). |
 | `AFK_READ_DENYLIST` | string |  |  | `/Users/me/project/.env:/Users/me/secrets` | Colon-separated list of additional absolute paths the read_file/grep/glob/list_directory tools refuse to read. Built-in credential entries (~/.ssh, ~/.aws, ~/.afk/config, …) always apply on top and cannot be removed. |
 | `AFK_SHELL_PASSTHROUGH` | boolean |  | `1` | `0` | Enable the interactive REPL `!cmd` / `!&cmd` shell-passthrough feature. On by default. Set to 0, false, off, or no (case-insensitive) to disable, so inputs beginning with ! are sent to the model as literal text instead of being executed as shell commands. Equivalent to the --no-shell-passthrough flag. |
 | `AFK_SHOW_DIFFS` | boolean |  |  |  | Show inline diffs in the tool-lane output for edit/write tool calls. 1 = on, 0 = off. |

--- a/src/cli/commands/interactive.ts
+++ b/src/cli/commands/interactive.ts
@@ -223,9 +223,16 @@ export function registerInteractiveCommand(program: Command): void {
       '--mcp-config <path>',
       'Path to an additional MCP config file (highest priority — merges over ~/.afk/config/mcp.json, project-local .mcp.json, and plugin-contributed configs). File format identical to mcp.json.',
     )
+    .option(
+      '--plain',
+      'Force append-only plain-stdout output instead of the live-overlay renderer, even on a TTY. Reliability escape hatch for tmux/SSH/multiplexer sessions. Also: AFK_PLAIN_OUTPUT=1. Non-TTY sessions (pipes, CI) already use this path by default.',
+    )
     .action(async (input: string[], options: CliOptions) => {
       if (options.debug) {
         process.env['AFK_DEBUG'] = '1';
+      }
+      if (options.plain) {
+        process.env['AFK_PLAIN_OUTPUT'] = '1';
       }
 
       // --- prompt-dump activation ---

--- a/src/cli/commands/interactive/repl-renderer.test.ts
+++ b/src/cli/commands/interactive/repl-renderer.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { createReplRenderer } from './repl-renderer.js';
 
 function makeStdout(isTTY: boolean) {
   const write = vi.fn();
   return { write, isTTY } as unknown as NodeJS.WriteStream & { write: ReturnType<typeof vi.fn> };
 }
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe('createReplRenderer', () => {
   describe('armed compositor routing', () => {
@@ -73,6 +77,67 @@ describe('createReplRenderer', () => {
       const renderer = createReplRenderer(stdout);
       renderer.writeLine('');
       expect(stdout.write).toHaveBeenCalledWith('\n');
+    });
+  });
+
+  describe('AFK_PLAIN_OUTPUT opt-in', () => {
+    it('selects the plain path on a TTY when AFK_PLAIN_OUTPUT=1, bypassing the compositor', () => {
+      vi.stubEnv('AFK_PLAIN_OUTPUT', '1');
+      const stdout = makeStdout(true);
+      const commitAbove = vi.fn();
+      const compositor = { isArmed: () => true, commitAbove };
+      const renderer = createReplRenderer(stdout);
+      renderer.setCompositor(compositor);
+
+      renderer.writeLine('hello');
+
+      expect(stdout.write).toHaveBeenCalledWith('hello\n');
+      expect(commitAbove).not.toHaveBeenCalled();
+    });
+
+    it('selects the plain path on a TTY when AFK_PLAIN_OUTPUT=true (case-insensitive)', () => {
+      vi.stubEnv('AFK_PLAIN_OUTPUT', 'TRUE');
+      const stdout = makeStdout(true);
+      const renderer = createReplRenderer(stdout);
+
+      renderer.writeLine('hello');
+
+      expect(stdout.write).toHaveBeenCalledWith('hello\n');
+    });
+
+    it('setCompositor is a no-op on the plain path forced by AFK_PLAIN_OUTPUT', () => {
+      vi.stubEnv('AFK_PLAIN_OUTPUT', '1');
+      const stdout = makeStdout(true);
+      const renderer = createReplRenderer(stdout);
+      expect(() => renderer.setCompositor(null)).not.toThrow();
+    });
+
+    it('does not force the plain path for unrecognized values (e.g. "0")', () => {
+      vi.stubEnv('AFK_PLAIN_OUTPUT', '0');
+      const stdout = makeStdout(true);
+      const commitAbove = vi.fn();
+      const compositor = { isArmed: () => true, commitAbove };
+      const renderer = createReplRenderer(stdout);
+      renderer.setCompositor(compositor);
+
+      renderer.writeLine('hello');
+
+      expect(commitAbove).toHaveBeenCalledWith('hello');
+      expect(stdout.write).not.toHaveBeenCalled();
+    });
+
+    it('leaves the default TTY live-overlay path unchanged when AFK_PLAIN_OUTPUT is unset', () => {
+      vi.stubEnv('AFK_PLAIN_OUTPUT', undefined as unknown as string);
+      const stdout = makeStdout(true);
+      const commitAbove = vi.fn();
+      const compositor = { isArmed: () => true, commitAbove };
+      const renderer = createReplRenderer(stdout);
+      renderer.setCompositor(compositor);
+
+      renderer.writeLine('hello');
+
+      expect(commitAbove).toHaveBeenCalledWith('hello');
+      expect(stdout.write).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/cli/commands/interactive/repl-renderer.ts
+++ b/src/cli/commands/interactive/repl-renderer.ts
@@ -10,11 +10,27 @@
  * xterm-derived terminals silently discards lines that exit the top of
  * the active region).
  *
- * Non-TTY surfaces (pipes, CI) get a simple stdout-only variant.
+ * Non-TTY surfaces (pipes, CI) get a simple stdout-only variant. The same
+ * plain variant is also selected on a TTY when `AFK_PLAIN_OUTPUT` is truthy
+ * — an opt-in escape hatch for tmux/SSH/multiplexer sessions where the live
+ * overlay's cursor-up redraws and DECSTBM reserved rows misbehave. Default
+ * TTY behavior (the live overlay) is unchanged unless this var is set.
  *
  * The compositor is bound lazily via setCompositor() — mirrors the
  * CompletionWriter pattern already used in shared.ts / turn-handler.ts.
  */
+
+import { env } from '../../../config/env.js';
+
+/** Truthy values recognized for `AFK_PLAIN_OUTPUT`, matching the "1"/"true"
+ *  convention used by other boolean-ish opt-in vars in this codebase (see
+ *  AFK_AUTO_ROUTING in env-tier.ts). Case-insensitive. */
+function isPlainOutputRequested(): boolean {
+  const raw = env.AFK_PLAIN_OUTPUT;
+  if (raw === undefined) return false;
+  const v = raw.trim().toLowerCase();
+  return v === '1' || v === 'true';
+}
 
 interface CompositorRef {
   isArmed(): boolean;
@@ -50,13 +66,17 @@ export function createReplRenderer(
   stdout: NodeJS.WriteStream,
   opts: CreateReplRendererOpts = {},
 ): ReplRenderer {
-  if (!stdout.isTTY) {
+  // Plain/append-only path: non-TTY surfaces (pipes, CI) always take it;
+  // AFK_PLAIN_OUTPUT lets a real TTY opt into the same path (reliability
+  // escape hatch — see module doc above). Strictly additive: this OR only
+  // ever widens which sessions get the plain path, never narrows it.
+  if (!stdout.isTTY || isPlainOutputRequested()) {
     return {
       writeLine: (text) => {
         stdout.write(text + '\n');
       },
       setCompositor: () => {
-        // no-op on non-TTY surfaces
+        // no-op on the plain path — there is no live overlay to bind to.
       },
     };
   }

--- a/src/cli/commands/interactive/shared.ts
+++ b/src/cli/commands/interactive/shared.ts
@@ -328,6 +328,12 @@ export interface CliOptions {
    * layers. The file format is identical to `~/.afk/config/mcp.json`.
    */
   mcpConfig?: string;
+  /**
+   * `--plain` — activates AFK_PLAIN_OUTPUT for this session, forcing the
+   * REPL's append-only stdout renderer even when stdout is a TTY. See
+   * `repl-renderer.ts` for the routing decision this flag feeds.
+   */
+  plain?: boolean;
 }
 
 /**

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -848,6 +848,19 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     category: 'misc',
   },
   {
+    name: 'AFK_PLAIN_OUTPUT',
+    description:
+      'Force the interactive REPL to use the append-only plain-stdout renderer instead of the ' +
+      'TerminalCompositor live overlay, even when stdout is a TTY. Same code path already used ' +
+      'for non-TTY surfaces (pipes, CI). Reliability escape hatch for tmux/SSH/multiplexer ' +
+      'sessions where cursor-up redraws and DECSTBM scroll regions misbehave. Opt-in — default TTY ' +
+      'behavior (live overlay) is unchanged. Truthy values: 1, true (case-insensitive).',
+    type: 'boolean',
+    required: false,
+    example: '1',
+    category: 'misc',
+  },
+  {
     name: 'AFK_SPINNER_TIPS',
     description: 'Show rotating tips in the loading spinner during long calls. 1 = on, 0 = off.',
     type: 'boolean',
@@ -1304,6 +1317,7 @@ export const env = {
 
   // UI / output
   get AFK_BANNER_PLAIN(): string | undefined { return process.env['AFK_BANNER_PLAIN']; },
+  get AFK_PLAIN_OUTPUT(): string | undefined { return process.env['AFK_PLAIN_OUTPUT']; },
   get AFK_SPINNER_TIPS(): string | undefined { return process.env['AFK_SPINNER_TIPS']; },
   get AFK_SHOW_DIFFS(): string | undefined { return process.env['AFK_SHOW_DIFFS']; },
   get AFK_SKILL_STREAM_VERBOSE(): string | undefined { return process.env['AFK_SKILL_STREAM_VERBOSE']; },


### PR DESCRIPTION
## Why
From a UX audit of the REPL: the live `TerminalCompositor` overlay is the single most fragile, most-fixed part of the codebase (recurring committed-block loss / gap / duplication), and its cursor-up redraws + DECSTBM reserved rows misbehave under tmux/SSH/multiplexers — the failure class that makes agent CLIs "practically unusable" over remote sessions. A plain-stdout fallback already existed for non-TTY surfaces (pipes/CI), but there was no way to opt into it on a real TTY.

## What
A strictly opt-in append-only output mode that **reuses the existing non-TTY plain path** (no new renderer):
- New env var `AFK_PLAIN_OUTPUT` (truthy `1`/`true`, case-insensitive).
- New `--plain` flag on `afk interactive` (mirrors the existing `--debug` → env pattern).
- The renderer takes the plain path when `!stdout.isTTY` **OR** the flag/env is set — a purely additive OR that only ever *widens* which sessions get the plain path, never narrows it. Default TTY behavior (the live overlay) is unchanged.

## Non-goals (deliberately deferred)
- Does **not** rewrite / "harden" the `TerminalCompositor` commit model — that's a separate, higher-risk refactor. This ships the tractable, low-risk half (a reliable escape hatch) now.

## Verification
- `pnpm lint` clean (tsc --noEmit, strict).
- `npx vitest run repl-renderer.test.ts` → **11/11** (5 new: TTY+truthy → plain, case-insensitivity, no-op setCompositor, `0` not forced, unset → overlay).
- `pnpm audit:env:check` (0 violations) + `pnpm scan:env:check` (`docs/env-registry.*` in sync).

## Reviewer focus
- The decision point in `repl-renderer.ts` (the OR-in).
- `--plain` writing `process.env.AFK_PLAIN_OUTPUT` in `interactive.ts` (matches the `--debug` precedent).

🤖 Built via parallel afk subagent + orchestrator verification.
