### PR TITLE
feat(tui): proactive escalating context-window warnings

### DIFF
--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { runTurn } from './turn-handler.js';
+import { runTurn, formatContextUsage } from './turn-handler.js';
 import { getCurrentSink } from '../../../agent/_lib/skill-sink-channel.js';
 import type { AgentSession } from '../../../agent/session.js';
 import type { OutputEvent } from '../../../agent/types.js';
@@ -2019,5 +2019,47 @@ describe('runTurn — mid-turn context progress', () => {
     const stats = makeStats();
 
     await expect(runTurn({ text: 'q', attachments: [] }, session, stats, h)).resolves.toBeUndefined();
+  });
+});
+
+describe('formatContextUsage — proactive escalating context tiers', () => {
+  const LIMIT = 200_000;
+
+  it('is quiet (no line) at or below 50%', () => {
+    expect(formatContextUsage(0.4, LIMIT)).toEqual({ tier: 'quiet', text: null });
+    expect(formatContextUsage(0.5, LIMIT)).toEqual({ tier: 'quiet', text: null });
+  });
+
+  it('shows a plain normal line above 50% and below 80%', () => {
+    const r = formatContextUsage(0.6, LIMIT);
+    expect(r.tier).toBe('normal');
+    expect(r.text).toContain('60% used');
+    expect(r.text).not.toContain('approaching');
+    expect(r.text).not.toContain('near limit');
+    expect(r.text).not.toContain('OVER');
+  });
+
+  it('boundary: 0.79 stays normal, 0.80 escalates to caution', () => {
+    expect(formatContextUsage(0.79, LIMIT).tier).toBe('normal');
+    const caution = formatContextUsage(0.8, LIMIT);
+    expect(caution.tier).toBe('caution');
+    expect(caution.text).toContain('80% used');
+    expect(caution.text).toContain('approaching limit');
+  });
+
+  it('boundary: 0.94 stays caution, 0.95 escalates to near with an actionable hint', () => {
+    expect(formatContextUsage(0.94, LIMIT).tier).toBe('caution');
+    const near = formatContextUsage(0.95, LIMIT);
+    expect(near.tier).toBe('near');
+    expect(near.text).toContain('near limit');
+    expect(near.text).toContain('/clear');
+  });
+
+  it('boundary: 1.00 and above is the over tier with the truncation warning', () => {
+    const over = formatContextUsage(1.0, LIMIT);
+    expect(over.tier).toBe('over');
+    expect(over.text).toContain('OVER');
+    expect(over.text).toContain('silently truncated');
+    expect(formatContextUsage(1.05, LIMIT).tier).toBe('over');
   });
 });

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -812,6 +812,45 @@ export async function runTurn(
   }
 }
 
+export type ContextTier = 'quiet' | 'normal' | 'caution' | 'near' | 'over';
+
+// Contract: maps a context-window usage ratio to an escalating footer line +
+// tier so the REPL warns *proactively* as a session approaches the model's
+// limit, not only once truncation is already happening. `text` is null for the
+// quiet tier (<=50% — no line, keeps short sessions uncluttered). The caller
+// maps tier -> palette color: over/near -> error, caution -> warning,
+// normal -> dim. Pure and color-free so it is unit-testable without a palette
+// or terminal. Thresholds are intentionally hardcoded (not config): 80% =
+// approaching, 95% = near, 100%+ = over.
+export function formatContextUsage(
+  contextPct: number,
+  contextLimit: number,
+): { tier: ContextTier; text: string | null } {
+  const pct = Math.round(contextPct * 100);
+  const limitStr = formatTokens(contextLimit);
+  if (contextPct >= 1.0) {
+    const overByTok = Math.round((contextPct - 1.0) * contextLimit);
+    const limitK = Math.round(contextLimit / 1000);
+    return {
+      tier: 'over',
+      text: `  context OVER ${limitK}k tok by ~${formatTokens(overByTok)} tok — model output may be silently truncated`,
+    };
+  }
+  if (contextPct >= 0.95) {
+    return {
+      tier: 'near',
+      text: `  context ${pct}% used of ${limitStr} — near limit; output may soon truncate (consider /clear or a fresh session)`,
+    };
+  }
+  if (contextPct >= 0.8) {
+    return { tier: 'caution', text: `  context ${pct}% used of ${limitStr} — approaching limit` };
+  }
+  if (contextPct > 0.5) {
+    return { tier: 'normal', text: `  context ${pct}% used of ${limitStr}` };
+  }
+  return { tier: 'quiet', text: null };
+}
+
 export function printTurnFooter(
   meta: { durationMs?: number; totalCostUsd?: number; usage?: Record<string, unknown> } | undefined,
   stats: SessionStats,
@@ -835,15 +874,18 @@ export function printTurnFooter(
   }
   const contextPct = contextRatio(stats);
   const contextLimit = contextLimitFor(stats.model);
-  if (contextPct >= 1.0) {
-    const overByTok = Math.round((contextPct - 1.0) * contextLimit);
-    const limitK = Math.round(contextLimit / 1000);
-    write(palette.error(
-      `  context OVER ${limitK}k tok by ~${formatTokens(overByTok)} tok — model output may be silently truncated`
-    ));
-  } else if (contextPct > 0.5) {
-    const color = contextPct > 0.8 ? palette.error : palette.warning;
-    write(color(`  context ${Math.round(contextPct * 100)}% used of ${formatTokens(contextLimit)}`));
+  const usage = formatContextUsage(contextPct, contextLimit);
+  if (usage.text !== null) {
+    // Escalation is by severity/color, not by suppression: the footer already
+    // renders once per turn, so a single tier-colored line per turn is the
+    // expected cadence (no cross-turn tier tracking needed).
+    const colorFn =
+      usage.tier === 'over' || usage.tier === 'near'
+        ? palette.error
+        : usage.tier === 'caution'
+          ? palette.warning
+          : palette.dim;
+    write(colorFn(usage.text));
   }
   write('');
 }


### PR DESCRIPTION
## Why
From the REPL UX audit: the context-window warning only escalated to a hard `context OVER … may be silently truncated` line **after** the session already exceeded the model's limit — users learned about silent truncation only once quality had already degraded. Best-in-class agent CLIs surface a proactive, escalating context meter.

## What
Extracts a pure, unit-testable `formatContextUsage(contextPct, contextLimit)` → `{ tier, text }` and rewires the turn footer to use it. Tiers:

| usage | tier | color | line |
|---|---|---|---|
| ≤50% | quiet | — | (no line — keeps short sessions uncluttered) |
| >50% | normal | dim | `context N% used of L` |
| ≥80% | caution | warning | `… approaching limit` |
| ≥95% | near | error | `… near limit; output may soon truncate (consider /clear or a fresh session)` ← previously missing |
| ≥100% | over | error | the existing hard truncation line, preserved verbatim |

Escalation is by severity/color, not frequency: the footer already renders once per turn, so no cross-turn tier tracking was added (kept non-invasive).

## Non-goals
- Signalling only — does **not** implement auto-compaction / history summarization.

## Verification
- `pnpm lint` clean.
- `npx vitest run turn-handler.test.ts` → **55/55** (5 new boundary tests: 0.79/0.80, 0.94/0.95, 1.0/1.05, quiet ≤0.5, plain normal).

## Reviewer focus
- Tier thresholds / messages in `formatContextUsage`.
- The 0.5–0.8 band color changed from `warning` → `dim` (intentional: reserve `warning` for ≥80%).

🤖 Built via afk orchestrator (implemented inline after the delegated subagent repeatedly stalled).
