### PR TITLE
feat(tui): surface provider rate-limit/backoff live in the progress banner

### DIFF
--- a/src/agent/provider.ts
+++ b/src/agent/provider.ts
@@ -209,6 +209,36 @@ export type ProviderEvent =
       type: 'stream.retry';
       sessionId?: string;
     }
+  | {
+      /**
+       * Live rate-limit / backoff signal. Emitted when the Anthropic provider
+       * is throttled (HTTP 429/503/529 with a `retry-after` header) and the
+       * SDK is about to sleep-and-retry INSIDE a single `messages.create`
+       * call. Because that backoff happens deep inside the wrapped `fetch`
+       * (see `providers/anthropic-direct/tracing-fetch.ts`), the per-turn loop
+       * is blocked awaiting the SDK and yields nothing — so a healthy session
+       * waiting out a 70s `retry-after` (retried twice ≈ 140s) looks frozen.
+       * This event is pushed out-of-band from the fetch throttle callback into
+       * the loop's yield stream so the UI can surface a live
+       * `rate-limited · retrying in ~70s` banner during the wait; the normal
+       * activity resumes once the retried request streams.
+       *
+       * Distinct from `stream.retry` (a MID-stream 529 re-drive that discards
+       * partial text) — this is a CONNECTION-phase throttle observed from
+       * inside fetch, and it does NOT invalidate any already-streamed text. It
+       * is purely observational: the SDK still owns the retry policy and
+       * timing (this feature does not change either). Consumers that don't
+       * render a live banner may ignore it. `retryAfterMs` is the parsed
+       * `retry-after` value when present; `status` is the throttled HTTP
+       * status; `attempt` is the 1-based throttle count within the call when
+       * the emitter can supply it.
+       */
+      type: 'rate_limit';
+      sessionId: string;
+      retryAfterMs?: number;
+      status?: number;
+      attempt?: number;
+    }
   | { type: 'error'; error: Error }
   | {
       type: 'paused';

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -35,6 +35,7 @@ import {
 } from './auth.js';
 import { oneShotCompletion, type OneShotInput } from './oneshot.js';
 import { makeTracingFetch } from './tracing-fetch.js';
+import { ThrottleQueue } from './throttle-queue.js';
 import { refreshClaudeCodeOauthToken } from '../../auth/keychain.js';
 import { AnthropicDirectQuery } from './query.js';
 import { pathContainmentBypassed } from '../../permission-policy.js';
@@ -602,16 +603,34 @@ export class AnthropicDirectProvider implements ModelProvider {
       );
     }
     const authMode = detectAuthMode(token);
+    // Live-throttle mailbox: the wrapped fetch pushes a signal onto this queue
+    // for every 429/503/529 the SDK sleep-and-retries INSIDE a single
+    // `messages.create`; the per-turn loop drains it to surface a `rate_limit`
+    // ProviderEvent LIVE (the loop is otherwise parked awaiting the SDK and
+    // cannot yield during the backoff). Installed only when the tracing fetch
+    // is (non-local-shim + a trace writer OR a live surface would consume it) —
+    // here it rides alongside the existing trace-writer gate so the queue and
+    // the wrapper share the same lifetime. The SAME instance is handed to the
+    // query below so the fetch producer and the loop consumer meet.
+    const throttleQueue =
+      !localMode && config.traceWriter ? new ThrottleQueue() : undefined;
     const clientOpts = buildClientOptions(
       token,
       authMode,
       config.baseUrl,
-      // Observability: route SDK HTTP through a wrapper that records 429/503/529
-      // throttling into the witness trace, so the SDK's otherwise-silent
-      // retry-after backoff is legible in `afk trace show`. Skipped in
-      // local-shim mode (not Anthropic's billing surface) and when no trace
-      // writer is attached.
-      !localMode && config.traceWriter ? makeTracingFetch(config.traceWriter) : undefined,
+      // Observability: route SDK HTTP through a wrapper that (1) records
+      // 429/503/529 throttling into the witness trace so the SDK's
+      // otherwise-silent retry-after backoff is legible in `afk trace show`,
+      // and (2) pushes a live signal onto `throttleQueue` so the progress
+      // banner can show the backoff as it happens. Skipped in local-shim mode
+      // (not Anthropic's billing surface) and when no trace writer is attached.
+      !localMode && config.traceWriter
+        ? makeTracingFetch(
+            config.traceWriter,
+            undefined,
+            throttleQueue ? (info) => throttleQueue.push(info) : undefined,
+          )
+        : undefined,
     );
     const factory = this.providerFactory ?? clientFactory;
     const client = factory ? factory(clientOpts) : new Anthropic(clientOpts);
@@ -825,10 +844,17 @@ export class AnthropicDirectProvider implements ModelProvider {
           freshToken,
           'oauth',
           config.baseUrl,
-          // Preserve throttle observability across an OAuth account swap — the
-          // rebuilt client must keep the tracing-fetch wrapper. localMode is
-          // false in this branch (see the guard above).
-          config.traceWriter ? makeTracingFetch(config.traceWriter) : undefined,
+          // Preserve throttle observability AND the live-banner signal across an
+          // OAuth account swap — the rebuilt client must keep the same
+          // tracing-fetch wrapper wired to the same `throttleQueue`. localMode
+          // is false in this branch (see the guard above).
+          config.traceWriter
+            ? makeTracingFetch(
+                config.traceWriter,
+                undefined,
+                throttleQueue ? (info) => throttleQueue.push(info) : undefined,
+              )
+            : undefined,
         );
         return factory ? factory(opts) : new Anthropic(opts);
       };
@@ -913,6 +939,9 @@ export class AnthropicDirectProvider implements ModelProvider {
       // we reuse config.hookRegistry directly here — the query stores it
       // separately from the dispatcher and dispatches only PreCompact events.
       ...(config.hookRegistry !== undefined ? { hookRegistry: config.hookRegistry } : {}),
+      // Live-throttle mailbox: the SAME instance wired to the client fetch
+      // callback above, so the loop's consumer meets the fetch producer.
+      ...(throttleQueue !== undefined ? { throttleQueue } : {}),
     });
   }
 }

--- a/src/agent/providers/anthropic-direct/loop.throttle.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.throttle.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Live-throttle surfacing tests for loop.ts.
+ *
+ * Contract: the SDK retries 429/503/529 responses INSIDE a single
+ * `messages.create` promise, so the loop is parked on that await and cannot
+ * yield during the backoff. The wrapped fetch pushes a signal onto
+ * {@link ThrottleQueue}; the loop RACES its create await against the queue and
+ * yields a `rate_limit` ProviderEvent for each drained signal — LIVE, before
+ * the stream events. These tests drive that race with a hand-controlled create
+ * promise so the interleaving is deterministic (no real timers, no real SDK).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { RawMessageStreamEvent, MessageParam } from '@anthropic-ai/sdk/resources';
+import { runTurn } from './loop.js';
+import type { AnthropicClientLike } from './types.js';
+import { ThrottleQueue } from './throttle-queue.js';
+import {
+  fromArray,
+  collect,
+  ctx,
+  makeTextStream,
+  makeDispatcher,
+} from './loop.test-helpers.js';
+
+describe('runTurn — live throttle surfacing', () => {
+  it('yields a rate_limit event (with retryAfterMs) pushed while messages.create is pending', async () => {
+    const queue = new ThrottleQueue();
+
+    // Hand-controlled create promise: resolves only after we push a throttle
+    // signal, so the loop is provably parked on the await when the signal lands.
+    let resolveCreate!: (v: AsyncIterable<RawMessageStreamEvent>) => void;
+    const createGate = new Promise<AsyncIterable<RawMessageStreamEvent>>((res) => {
+      resolveCreate = res;
+    });
+    const client: AnthropicClientLike = {
+      messages: { create: vi.fn(() => createGate) },
+    };
+    const dispatcher = makeDispatcher(() => Promise.resolve({ content: 'ok' }));
+    const messages: MessageParam[] = [{ role: 'user', content: 'hi' }];
+
+    const resultPromise = collect(
+      runTurn({
+        client,
+        messages,
+        system: null,
+        tools: null,
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 1024,
+        headers: {},
+        signal: new AbortController().signal,
+        ctx,
+        throttleQueue: queue,
+      }),
+    );
+
+    // Let the loop reach the create await, then simulate the wrapped fetch
+    // observing a 429 with a 70s retry-after DURING the backoff.
+    await Promise.resolve();
+    queue.push({ status: 429, retryAfterMs: 70_000 });
+    // Give the race a tick to drain + yield the rate_limit event, then let the
+    // create settle with a normal text stream.
+    await Promise.resolve();
+    resolveCreate(fromArray(makeTextStream('done')));
+
+    const events = await resultPromise;
+
+    const rl = events.find((e) => e.type === 'rate_limit');
+    expect(rl).toBeDefined();
+    if (rl?.type === 'rate_limit') {
+      expect(rl.retryAfterMs).toBe(70_000);
+      expect(rl.status).toBe(429);
+      expect(rl.attempt).toBe(1);
+      expect(rl.sessionId).toBe(ctx.sessionId);
+    }
+    // The turn still completes normally once the (retried) request streams.
+    expect(events.some((e) => e.type === 'turn.completed')).toBe(true);
+    // The rate_limit event precedes turn.completed (it was surfaced live).
+    const rlIdx = events.findIndex((e) => e.type === 'rate_limit');
+    const doneIdx = events.findIndex((e) => e.type === 'turn.completed');
+    expect(rlIdx).toBeGreaterThanOrEqual(0);
+    expect(rlIdx).toBeLessThan(doneIdx);
+  });
+
+  it('surfaces multiple throttle attempts with incrementing attempt numbers', async () => {
+    const queue = new ThrottleQueue();
+    let resolveCreate!: (v: AsyncIterable<RawMessageStreamEvent>) => void;
+    const createGate = new Promise<AsyncIterable<RawMessageStreamEvent>>((res) => {
+      resolveCreate = res;
+    });
+    const client: AnthropicClientLike = {
+      messages: { create: vi.fn(() => createGate) },
+    };
+    const dispatcher = makeDispatcher(() => Promise.resolve({ content: 'ok' }));
+    const messages: MessageParam[] = [{ role: 'user', content: 'hi' }];
+
+    const resultPromise = collect(
+      runTurn({
+        client,
+        messages,
+        system: null,
+        tools: null,
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 1024,
+        headers: {},
+        signal: new AbortController().signal,
+        ctx,
+        throttleQueue: queue,
+      }),
+    );
+
+    await Promise.resolve();
+    queue.push({ status: 429, retryAfterMs: 10_000 });
+    await Promise.resolve();
+    queue.push({ status: 503 }); // no retry-after header this time
+    await Promise.resolve();
+    resolveCreate(fromArray(makeTextStream('done')));
+
+    const events = await resultPromise;
+    const rls = events.filter((e) => e.type === 'rate_limit');
+    expect(rls).toHaveLength(2);
+    if (rls[0]?.type === 'rate_limit' && rls[1]?.type === 'rate_limit') {
+      expect(rls[0].attempt).toBe(1);
+      expect(rls[0].retryAfterMs).toBe(10_000);
+      expect(rls[1].attempt).toBe(2);
+      expect(rls[1].status).toBe(503);
+      expect(rls[1].retryAfterMs).toBeUndefined();
+    }
+  });
+
+  it('is a no-op passthrough when no throttleQueue is wired (no rate_limit events)', async () => {
+    const client: AnthropicClientLike = {
+      messages: { create: vi.fn(() => fromArray(makeTextStream('hello'))) },
+    };
+    const dispatcher = makeDispatcher(() => Promise.resolve({ content: 'ok' }));
+    const messages: MessageParam[] = [{ role: 'user', content: 'hi' }];
+
+    const events = await collect(
+      runTurn({
+        client,
+        messages,
+        system: null,
+        tools: null,
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 1024,
+        headers: {},
+        signal: new AbortController().signal,
+        ctx,
+        // no throttleQueue
+      }),
+    );
+
+    expect(events.some((e) => e.type === 'rate_limit')).toBe(false);
+    expect(events.some((e) => e.type === 'turn.completed')).toBe(true);
+  });
+});

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -177,6 +177,79 @@ async function* emitTtfbRetry(
 }
 
 /**
+ * Await `createWithRetry` while surfacing LIVE throttle (rate-limit/backoff)
+ * signals from the out-of-band {@link RunTurnInput.throttleQueue}.
+ *
+ * Invariant: the SDK retries 429/503/529 responses INSIDE the single
+ * `messages.create` promise `createWithRetry` returns, sleeping out
+ * `retry-after` between attempts. During that sleep the loop is parked on this
+ * await and can `yield` nothing — so a healthy session waiting ~70s (retried
+ * twice ≈ 140s) looks frozen. The wrapped `fetch` pushes a `ThrottleSignal`
+ * onto the queue as each throttled response lands; here we race the create
+ * promise against `queue.waitForItem()` and yield a `rate_limit` ProviderEvent
+ * for every drained signal, so the banner updates DURING the wait. When the
+ * create promise finally settles we yield any last-drained signals, then RETURN
+ * the resolved events iterable (or re-throw the create error) via the
+ * generator's return value.
+ *
+ * When `throttleQueue` is absent this degrades to a bare `await` (one extra
+ * microtask), so non-throttling paths and unit tests are unaffected.
+ */
+async function* awaitCreateWithThrottleSignals(
+  createPromise: Promise<AsyncIterable<unknown>>,
+  input: RunTurnInput,
+): AsyncGenerator<ProviderEvent, AsyncIterable<unknown>, void> {
+  const queue = input.throttleQueue;
+  if (!queue) {
+    // No live seam wired — plain await. `createPromise` rejection propagates to
+    // the caller's try/catch exactly as a direct `await createWithRetry` would.
+    return await createPromise;
+  }
+  // Reset the per-call attempt counter so `attempt` numbers reflect throttles
+  // within THIS messages.create (mirrors the SDK's per-call retry budget).
+  queue.resetAttempts();
+
+  // Sentinel so `Promise.race` can tell "create settled" apart from "a throttle
+  // signal arrived" without leaking the create result into the race's value.
+  const CREATE_DONE = Symbol('create-done');
+  // Track settlement so a throttle wake after the create resolves doesn't loop.
+  let settled = false;
+  const guarded = createPromise.then(
+    (v) => { settled = true; return v; },
+    (e) => { settled = true; throw e; },
+  );
+
+  for (;;) {
+    // Drain and surface anything already queued before parking again.
+    for (const sig of queue.takeAll()) {
+      yield {
+        type: 'rate_limit',
+        sessionId: input.ctx.sessionId,
+        status: sig.status,
+        attempt: sig.attempt,
+        ...(sig.retryAfterMs !== undefined ? { retryAfterMs: sig.retryAfterMs } : {}),
+      };
+    }
+    if (settled) {
+      // Return the resolved iterable (or re-throw the create rejection). A
+      // final drain above already surfaced any late signals.
+      return await guarded;
+    }
+    // Park until EITHER the create settles OR a new throttle signal lands.
+    const outcome = await Promise.race([
+      guarded.then(() => CREATE_DONE, () => CREATE_DONE),
+      queue.waitForItem().then(() => undefined),
+    ]);
+    if (outcome === CREATE_DONE) {
+      // Loop once more to drain any signals pushed right before settlement,
+      // then the `settled` branch returns/throws.
+      continue;
+    }
+    // A throttle signal woke us — loop to drain it.
+  }
+}
+
+/**
  * Run one user turn through the model + tool dispatcher loop. Yields
  * `ProviderEvent`s as the model streams; on completion of the turn (the model
  * stops with anything other than `tool_use`, or the iteration cap is hit),
@@ -311,12 +384,21 @@ export async function* runTurn(
     // try/catch + continue, hence the assertion.
     let events!: AsyncIterable<unknown>;
     try {
-      events = await createWithRetry(
-        input.client,
-        params,
-        input.headers,
-        ttfb.signal,
-        input.signal,
+      // Race the create await against the out-of-band throttle queue so a
+      // 429/503/529 backoff the SDK sleeps out INSIDE this call surfaces as a
+      // LIVE `rate_limit` event (see awaitCreateWithThrottleSignals). Without
+      // the queue this is a plain `await createWithRetry(...)`. The generator's
+      // return value is the resolved stream iterable; a create rejection
+      // propagates here exactly as a direct await would.
+      events = yield* awaitCreateWithThrottleSignals(
+        createWithRetry(
+          input.client,
+          params,
+          input.headers,
+          ttfb.signal,
+          input.signal,
+        ),
+        input,
       );
     } catch (err) {
       // A TTFB timeout aborts before the first byte (connection-phase stall).

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -194,6 +194,16 @@ export interface AnthropicDirectQueryOptions {
    * turn without surfacing an error to the caller.
    */
   hookRegistry?: HookRegistry;
+  /**
+   * Out-of-band mailbox for live throttle (rate-limit/backoff) signals. The
+   * SAME instance is wired to the SDK client's `fetch` throttle callback at
+   * query construction (`index.ts`); threaded into each per-turn `runTurn`
+   * via `RunTurnInput.throttleQueue` so the loop can surface a `rate_limit`
+   * ProviderEvent LIVE while parked on a throttled `messages.create`. Absent
+   * for local-shim / external-dispatcher paths where the tracing fetch is not
+   * installed.
+   */
+  throttleQueue?: import('./throttle-queue.js').ThrottleQueue;
 }
 
 /**
@@ -256,6 +266,8 @@ export class AnthropicDirectQuery implements ProviderQuery {
   private readonly onPermissionMode?: (mode: string) => void;
   private readonly mcpManager?: import('../../mcp/index.js').McpManager;
   private readonly hookRegistry?: HookRegistry;
+  /** Shared live-throttle mailbox; wired to the client fetch callback. See options doc. */
+  private readonly throttleQueue?: import('./throttle-queue.js').ThrottleQueue;
 
   constructor(opts: AnthropicDirectQueryOptions) {
     this.initSessionId = opts.sessionId ?? randomUUID();
@@ -273,6 +285,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
     this.onPermissionMode = opts.onPermissionMode;
     this.mcpManager = opts.mcpManager;
     if (opts.hookRegistry !== undefined) this.hookRegistry = opts.hookRegistry;
+    if (opts.throttleQueue !== undefined) this.throttleQueue = opts.throttleQueue;
     this.retry = new RetryLayer({
       client: opts.client,
       authMode: opts.authMode,
@@ -401,6 +414,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
             ? { maxToolUseIterations: this.maxToolUseIterations }
             : {}),
           ...(this.traceWriter ? { traceWriter: this.traceWriter } : {}),
+          ...(this.throttleQueue ? { throttleQueue: this.throttleQueue } : {}),
           onUsageProgress: (usage) => { this.state.lastUsage = usage; },
         };
 

--- a/src/agent/providers/anthropic-direct/throttle-queue.ts
+++ b/src/agent/providers/anthropic-direct/throttle-queue.ts
@@ -1,0 +1,99 @@
+/**
+ * Out-of-band mailbox for live throttle (rate-limit / backoff) signals.
+ *
+ * Invariant: the anthropic-direct per-turn loop (`loop.ts`) is BLOCKED on a
+ * single `await client.messages.create(...)` while the SDK retries a throttled
+ * request (429/503/529) internally, honoring `retry-after`. It therefore cannot
+ * `yield` a `rate_limit` ProviderEvent during that backoff — the very window in
+ * which the user most needs a "still alive, waiting ~70s" signal. The wrapped
+ * `fetch` (`tracing-fetch.ts`) is the ONLY code that runs during that wait: it
+ * sees each throttled HTTP response as the SDK retries. This queue is the seam
+ * that carries a signal from that fetch callback (constructed at query time)
+ * across to the per-turn loop (constructed per turn), so the loop can drain and
+ * yield it WHILE still awaiting the same `messages.create`.
+ *
+ * Contract: a single logical producer (the fetch throttle callback) calls
+ * {@link push}; a single consumer (the loop, via a race against the SDK
+ * promise) calls {@link takeAll} to drain queued items without blocking, or
+ * awaits {@link waitForItem} to be woken the instant a new item lands. The
+ * queue is unbounded but bounded in practice by the SDK's per-call retry count
+ * (≈3), so no backpressure is needed. Draining is level-triggered: items pushed
+ * before a `waitForItem` call resolve it immediately.
+ *
+ * Deliberately tiny and dependency-free — it holds plain payloads, not
+ * ProviderEvents, so it does not couple this provider-internal seam to the
+ * harness event union.
+ *
+ * @module agent/providers/anthropic-direct/throttle-queue
+ */
+
+/** A single throttle observation pushed from the wrapped fetch. */
+export interface ThrottleSignal {
+  /** Throttled HTTP status (429/503/529). */
+  status: number;
+  /** Parsed `retry-after` in ms, when the header was present. */
+  retryAfterMs?: number;
+  /** 1-based count of throttles observed within the current call. */
+  attempt: number;
+}
+
+/**
+ * Minimal single-consumer async mailbox. Not exported as a general utility on
+ * purpose: its wake semantics are tuned for the loop's drain-then-await race
+ * and it is intentionally provider-local.
+ */
+export class ThrottleQueue {
+  private readonly items: ThrottleSignal[] = [];
+  /** Resolver for the pending {@link waitForItem} promise, if any. */
+  private waiter: (() => void) | null = null;
+  private attempts = 0;
+
+  /**
+   * Enqueue a throttle observation and wake any pending consumer. The
+   * `attempt` counter is assigned here (monotonic across the queue's life) so
+   * the producer callback stays stateless. Safe to call from the fetch path;
+   * never throws.
+   */
+  push(info: { status: number; retryAfterMs?: number }): void {
+    this.attempts += 1;
+    const signal: ThrottleSignal = {
+      status: info.status,
+      attempt: this.attempts,
+      ...(info.retryAfterMs !== undefined ? { retryAfterMs: info.retryAfterMs } : {}),
+    };
+    this.items.push(signal);
+    // Wake a pending consumer exactly once; it re-arms via waitForItem().
+    const w = this.waiter;
+    this.waiter = null;
+    if (w) w();
+  }
+
+  /** Synchronously drain every queued item (may be empty). */
+  takeAll(): ThrottleSignal[] {
+    if (this.items.length === 0) return [];
+    return this.items.splice(0, this.items.length);
+  }
+
+  /**
+   * Resolve when at least one item is available. If items are already queued,
+   * resolves on the next microtask (level-triggered). Only one consumer may
+   * await at a time — a second concurrent call replaces the first waiter's
+   * resolver, which is fine here because the loop awaits serially.
+   */
+  waitForItem(): Promise<void> {
+    if (this.items.length > 0) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      this.waiter = resolve;
+    });
+  }
+
+  /**
+   * Reset the per-call attempt counter. Called by the loop at the start of
+   * each new `messages.create` so the `attempt` numbering reflects throttles
+   * within THAT call (mirrors the SDK's per-call retry budget), not a running
+   * total across the whole turn.
+   */
+  resetAttempts(): void {
+    this.attempts = 0;
+  }
+}

--- a/src/agent/providers/anthropic-direct/tracing-fetch.test.ts
+++ b/src/agent/providers/anthropic-direct/tracing-fetch.test.ts
@@ -77,4 +77,56 @@ describe('makeTracingFetch', () => {
     expect(events).toHaveLength(1);
     expect(events[0]!.payload['durationMs']).toBeUndefined();
   });
+
+  it('invokes onThrottle with status + parsed retryAfterMs, AND still writes the trace', async () => {
+    const { writer, events } = mockWriter();
+    const seen: Array<{ status: number; retryAfterMs?: number }> = [];
+    const base = vi.fn(async () => res(429, { 'retry-after': '70' })) as unknown as typeof fetch;
+    const r = await makeTracingFetch(writer, base, (info) => seen.push(info))('u');
+    await Promise.resolve();
+    expect(r.status).toBe(429);
+    // Live callback fired with the parsed values.
+    expect(seen).toEqual([{ status: 429, retryAfterMs: 70_000 }]);
+    // Trace emission is UNCHANGED (both channels fire).
+    expect(events).toHaveLength(1);
+    expect(events[0]!.payload['phase']).toBe('rate_limit');
+  });
+
+  it('omits retryAfterMs in the onThrottle payload when the header is absent', async () => {
+    const seen: Array<{ status: number; retryAfterMs?: number }> = [];
+    const base = vi.fn(async () => res(503)) as unknown as typeof fetch;
+    await makeTracingFetch(undefined, base, (info) => seen.push(info))('u');
+    await Promise.resolve();
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.status).toBe(503);
+    expect('retryAfterMs' in seen[0]!).toBe(false);
+  });
+
+  it('wraps fetch when only onThrottle is provided (no writer) and does NOT fire on 200', async () => {
+    const seen: unknown[] = [];
+    const base = vi.fn(async () => res(200)) as unknown as typeof fetch;
+    const wrapped = makeTracingFetch(undefined, base, (info) => seen.push(info));
+    expect(wrapped).not.toBe(base); // wrapped because a live observer wants throttles
+    const r = await wrapped('u');
+    expect(r.status).toBe(200);
+    await Promise.resolve();
+    expect(seen).toHaveLength(0);
+  });
+
+  it('a throwing onThrottle never disturbs the request path (response still returned)', async () => {
+    const { writer, events } = mockWriter();
+    const base = vi.fn(async () => res(429, { 'retry-after': '5' })) as unknown as typeof fetch;
+    const r = await makeTracingFetch(writer, base, () => {
+      throw new Error('observer boom');
+    })('u');
+    await Promise.resolve();
+    // The throttled response is returned unchanged and the trace still fires.
+    expect(r.status).toBe(429);
+    expect(events).toHaveLength(1);
+  });
+
+  it('returns the base fetch unchanged only when BOTH writer and onThrottle are undefined', () => {
+    const base = vi.fn() as unknown as typeof fetch;
+    expect(makeTracingFetch(undefined, base, undefined)).toBe(base);
+  });
 });

--- a/src/agent/providers/anthropic-direct/tracing-fetch.ts
+++ b/src/agent/providers/anthropic-direct/tracing-fetch.ts
@@ -1,14 +1,20 @@
 /**
  * Observability wrapper for the Anthropic SDK's `fetch` client option.
  *
- * The SDK retries transient failures (429 rate limit, 503/529 overload)
- * internally, honoring the `retry-after` header — but that backoff is
- * completely SILENT: it happens inside a single `messages.create` call, emits
- * no event, and surfaces only as an abnormally long `model_ttfb` in the trace
- * (a 429 with a 70s `retry-after`, retried twice, looks like a ~140s "stuck"
- * turn with no explanation). This wrapper sits under the SDK and records every
- * throttled response into the witness trace as a `rate_limit` session-phase
- * event, so `afk trace show` explains the stall instead of hiding it.
+ * Invariant: the SDK retries transient failures (429 rate limit, 503/529
+ * overload) internally, honoring the `retry-after` header — but that backoff is
+ * otherwise SILENT: it happens inside a single `messages.create` call, and
+ * surfaces only as an abnormally long `model_ttfb` in the trace (a 429 with a
+ * 70s `retry-after`, retried twice, looks like a ~140s "stuck" turn with no
+ * explanation). This wrapper sits under the SDK and does TWO things on every
+ * throttled response, both purely observational:
+ *   1. Records it into the witness trace as a `rate_limit` session-phase event,
+ *      so `afk trace show` explains the stall after the fact.
+ *   2. Invokes the optional {@link makeTracingFetch} `onThrottle` callback so a
+ *      live surface (the interactive progress banner) can show the backoff AS
+ *      IT HAPPENS. This is the only hook that fires DURING the SDK's blocking
+ *      retry loop — the per-turn loop is parked awaiting `messages.create`, so
+ *      without this callback the banner cannot update until the wait is over.
  *
  * Purely observational: it forwards the request unchanged and returns the
  * Response untouched (only `res.headers` is read, which does not consume the
@@ -25,15 +31,31 @@ import { parseRetryAfterMs } from './usage-limit.js';
 const THROTTLE_STATUSES = new Set([429, 503, 529]);
 
 /**
+ * Structured throttle observation handed to the {@link makeTracingFetch}
+ * `onThrottle` callback. `retryAfterMs` is the parsed `retry-after` header when
+ * present; `status` is the throttled HTTP status.
+ */
+export interface ThrottleInfo {
+  status: number;
+  retryAfterMs?: number;
+}
+
+/**
  * Wrap a `fetch` implementation so throttled responses (429/503/529) emit a
- * `rate_limit` trace event. Returns the wrapped fetch; when `writer` is
+ * `rate_limit` trace event AND (when provided) invoke `onThrottle` for a live
+ * surface. Returns the wrapped fetch; when BOTH `writer` and `onThrottle` are
  * undefined the base fetch is returned unchanged (no overhead).
+ *
+ * `onThrottle` is fire-and-forget from the caller's perspective — this wrapper
+ * guards it with try/catch so a throwing callback can never disturb the request
+ * path or the SDK's retry loop.
  */
 export function makeTracingFetch(
   writer: TraceWriter | undefined,
   baseFetch: typeof fetch = fetch,
+  onThrottle?: (info: ThrottleInfo) => void,
 ): typeof fetch {
-  if (!writer) return baseFetch;
+  if (!writer && !onThrottle) return baseFetch;
   return async (
     input: Parameters<typeof fetch>[0],
     init?: Parameters<typeof fetch>[1],
@@ -41,19 +63,34 @@ export function makeTracingFetch(
     const res = await baseFetch(input, init);
     if (THROTTLE_STATUSES.has(res.status)) {
       const retryAfterMs = parseRetryAfterMs({ headers: res.headers });
-      const metadata: Record<string, string | number | boolean> = {
-        status: res.status,
-        reason: res.status === 429 ? 'rate-limit' : 'overloaded',
-        source: 'sdk-fetch',
-      };
-      if (retryAfterMs !== undefined) metadata['retryAfterMs'] = retryAfterMs;
-      // Fire-and-forget: a broken trace writer must never disturb the request
-      // path. emitSessionPhase already swallows writer errors internally.
-      void emitSessionPhase(writer, {
-        phase: 'rate_limit',
-        ...(retryAfterMs !== undefined ? { durationMs: retryAfterMs } : {}),
-        metadata,
-      });
+      // Live signal FIRST so the banner updates with minimal latency; the
+      // trace write below is async fire-and-forget. Guarded so a throwing
+      // observer can never break the request path.
+      if (onThrottle) {
+        try {
+          onThrottle({
+            status: res.status,
+            ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+          });
+        } catch {
+          // A broken live observer must never disturb the SDK retry loop.
+        }
+      }
+      if (writer) {
+        const metadata: Record<string, string | number | boolean> = {
+          status: res.status,
+          reason: res.status === 429 ? 'rate-limit' : 'overloaded',
+          source: 'sdk-fetch',
+        };
+        if (retryAfterMs !== undefined) metadata['retryAfterMs'] = retryAfterMs;
+        // Fire-and-forget: a broken trace writer must never disturb the request
+        // path. emitSessionPhase already swallows writer errors internally.
+        void emitSessionPhase(writer, {
+          phase: 'rate_limit',
+          ...(retryAfterMs !== undefined ? { durationMs: retryAfterMs } : {}),
+          metadata,
+        });
+      }
     }
     return res;
   };

--- a/src/agent/providers/anthropic-direct/types.ts
+++ b/src/agent/providers/anthropic-direct/types.ts
@@ -257,6 +257,18 @@ export interface RunTurnInput {
    * the loop never awaits it.
    */
   onUsageProgress?: (usage: ProviderUsage) => void;
+  /**
+   * Optional out-of-band mailbox for live throttle (rate-limit/backoff)
+   * signals pushed from the wrapped `fetch` (see `tracing-fetch.ts`). When
+   * present, the loop RACES its `messages.create` await against this queue so
+   * a 429/503/529 backoff observed INSIDE the SDK call surfaces as a
+   * `rate_limit` ProviderEvent LIVE — the loop is otherwise parked on the
+   * await and cannot yield during the wait. The same queue instance is wired
+   * to the client's fetch callback at query construction. Absent for the
+   * external-dispatcher / local-shim paths and in unit tests that don't
+   * exercise throttling.
+   */
+  throttleQueue?: import('./throttle-queue.js').ThrottleQueue;
 }
 
 /**

--- a/src/agent/session/stream-consumer-rate-limit.test.ts
+++ b/src/agent/session/stream-consumer-rate-limit.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for the `rate_limit` ProviderEvent → OutputEvent mapping in
+ * {@link transformProviderEvent}.
+ *
+ * Contract: the provider emits `rate_limit` (with a `retryAfterMs` parsed from
+ * the throttled response's `retry-after` header) while the SDK sleeps out a
+ * 429/503/529 backoff. The stream consumer must forward it as an OutputEvent
+ * carrying `retryAfterMs` so the interactive surface can render a live
+ * `rate-limited · retrying in ~Ns` banner. Trace-only fields (status/attempt)
+ * are intentionally dropped at this boundary.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ProviderEvent } from '../provider.js';
+import { transformProviderEvent, type TransformDeps } from './stream-consumer.js';
+import type { Message, SessionMetadata } from '../types.js';
+
+/**
+ * Minimal deps stub — the `rate_limit` branch is a pure passthrough (no side
+ * effects), so the callbacks are never invoked. Provided so the required
+ * fields on {@link TransformDeps} are satisfied without pulling in a full
+ * session harness.
+ */
+function stubDeps(): TransformDeps {
+  return {
+    conversationHistory: [] as Message[],
+    getSessionMetadata: () => ({}) as SessionMetadata,
+    setSessionMetadata: () => {},
+    updateSessionIdentity: () => {},
+    resolveInitialization: () => {},
+    setLastResponseMetadata: () => {},
+  };
+}
+
+describe('transformProviderEvent — rate_limit', () => {
+  it('maps rate_limit with retryAfterMs to a rate_limit OutputEvent carrying the delay', () => {
+    const evt: ProviderEvent = {
+      type: 'rate_limit',
+      sessionId: 's1',
+      status: 429,
+      attempt: 1,
+      retryAfterMs: 70_000,
+    };
+    const out = transformProviderEvent(evt, stubDeps());
+    expect(out).toEqual({ type: 'rate_limit', retryAfterMs: 70_000 });
+  });
+
+  it('omits retryAfterMs when the provider event has none (header absent)', () => {
+    const evt: ProviderEvent = {
+      type: 'rate_limit',
+      sessionId: 's1',
+      status: 529,
+      attempt: 2,
+    };
+    const out = transformProviderEvent(evt, stubDeps());
+    expect(out).toEqual({ type: 'rate_limit' });
+    // Explicitly assert the key is absent, not just undefined-valued.
+    expect(out && 'retryAfterMs' in out).toBe(false);
+  });
+
+  it('drops the trace-only status/attempt fields at the surface boundary', () => {
+    const evt: ProviderEvent = {
+      type: 'rate_limit',
+      sessionId: 's1',
+      status: 503,
+      attempt: 3,
+      retryAfterMs: 5_000,
+    };
+    const out = transformProviderEvent(evt, stubDeps());
+    expect(out).not.toBeNull();
+    expect(out && 'status' in out).toBe(false);
+    expect(out && 'attempt' in out).toBe(false);
+  });
+});

--- a/src/agent/session/stream-consumer.ts
+++ b/src/agent/session/stream-consumer.ts
@@ -468,6 +468,15 @@ export function transformProviderEvent(
     case 'stream.retry':
       return { type: 'stream_retry' };
 
+    case 'rate_limit':
+      // Live backoff signal — pass the retry-after through so the surface can
+      // render `rate-limited · retrying in ~Ns`. Fields beyond retryAfterMs
+      // (status/attempt) are trace-only and intentionally dropped here.
+      return {
+        type: 'rate_limit',
+        ...(event.retryAfterMs !== undefined ? { retryAfterMs: event.retryAfterMs } : {}),
+      };
+
     default:
       return null;
   }

--- a/src/agent/types/session-types.ts
+++ b/src/agent/types/session-types.ts
@@ -98,6 +98,13 @@ export type OutputEvent =
   // on this event so the re-streamed text does not visibly duplicate. See
   // ProviderEvent 'stream.retry' for the full contract.
   | { type: 'stream_retry' }
+  // Live rate-limit / backoff marker. Emitted while the anthropic-direct
+  // provider is throttled (429/503/529 + retry-after) and the SDK is sleeping
+  // out the backoff inside a single request. Surfaces that render a live status
+  // banner show `rate-limited · retrying in ~Ns` for the duration; unlike
+  // `stream_retry` it does NOT invalidate already-streamed text. See
+  // ProviderEvent 'rate_limit' for the full contract.
+  | { type: 'rate_limit'; retryAfterMs?: number }
   // Skill-emitted panel/card payload. Skills call `emitCard(spec)` from
   // `src/skills/_lib/emit-card.ts`; the renderer flushes pending content
   // and renders via `card(spec)` from `src/cli/render.ts`.

--- a/src/cli/_lib/stream-renderer-orchestrator.test.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.test.ts
@@ -1302,3 +1302,113 @@ describe('handleOrchestratorEvent — cross-flush tool grouping (run accumulatio
     expect(scrollback.toLowerCase()).toContain('thought for');
   });
 });
+
+// ────────────────────────────────────────────────────────────────────────────
+// rate_limit arm — live backoff banner via synthetic progress injection
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('handleOrchestratorEvent — rate_limit arm', () => {
+  function rateLimitEvent(retryAfterMs?: number): OutputEvent {
+    return retryAfterMs === undefined
+      ? { type: 'rate_limit' }
+      : { type: 'rate_limit', retryAfterMs };
+  }
+
+  function progressEvent(taskId: string): OutputEvent {
+    return {
+      type: 'progress',
+      progress: {
+        taskId,
+        description: 'Working',
+        summary: 'round 1: bash',
+        totalTokens: 100,
+        toolUses: 1,
+        durationMs: 500,
+      },
+    };
+  }
+
+  function ttyCtx(): { ctx: OrchestratorCtx; setOverlay: ReturnType<typeof vi.fn> } {
+    const setOverlay = vi.fn();
+    const compositor = {
+      setOverlay,
+      commitAbove: vi.fn(),
+      setSpinner: vi.fn(),
+    } as unknown as OrchestratorCtx['compositor'];
+    const ctx = makeCtx(new ToolLane(), { isTTY: true, compositor });
+    return { ctx, setOverlay };
+  }
+
+  it('injects a synthetic progress entry whose description is the formatted backoff string', () => {
+    const { ctx, setOverlay } = ttyCtx();
+    const source = freshSourceState('__main__');
+
+    handleOrchestratorEvent(rateLimitEvent(70_000), source, ctx);
+
+    // A single synthetic entry lands under the reserved key.
+    expect(ctx.lastProgressByTask.size).toBe(1);
+    const entry = ctx.lastProgressByTask.get('__rate_limit__');
+    expect(entry).toBeDefined();
+    expect(entry!.description).toBe('rate-limited · retrying in ~70s');
+    // TTY repaint fired so the banner shows immediately.
+    expect(setOverlay).toHaveBeenCalled();
+  });
+
+  it('uses the no-ETA copy when retryAfterMs is absent', () => {
+    const { ctx } = ttyCtx();
+    const source = freshSourceState('__main__');
+
+    handleOrchestratorEvent(rateLimitEvent(undefined), source, ctx);
+
+    expect(ctx.lastProgressByTask.get('__rate_limit__')!.description).toBe(
+      'rate-limited · retrying…',
+    );
+  });
+
+  it('is a no-op on non-TTY surfaces (no synthetic entry, no repaint)', () => {
+    const ctx = makeCtx(new ToolLane(), { isTTY: false });
+    const source = freshSourceState('__main__');
+
+    handleOrchestratorEvent(rateLimitEvent(70_000), source, ctx);
+
+    expect(ctx.lastProgressByTask.size).toBe(0);
+  });
+
+  it('the next real progress event evicts the synthetic backoff entry', () => {
+    const { ctx } = ttyCtx();
+    const source = freshSourceState('__main__');
+
+    handleOrchestratorEvent(rateLimitEvent(70_000), source, ctx);
+    expect(ctx.lastProgressByTask.has('__rate_limit__')).toBe(true);
+
+    // Real progress arrives once the retried request streams — its clear()+set()
+    // drops the synthetic entry and installs the genuine one.
+    handleOrchestratorEvent(progressEvent('real-task-uuid'), source, ctx);
+    expect(ctx.lastProgressByTask.has('__rate_limit__')).toBe(false);
+    expect(ctx.lastProgressByTask.has('real-task-uuid')).toBe(true);
+  });
+
+  it('stream_retry clears a stale backoff banner and repaints', () => {
+    const { ctx, setOverlay } = ttyCtx();
+    const source = freshSourceState('__main__');
+
+    handleOrchestratorEvent(rateLimitEvent(70_000), source, ctx);
+    expect(ctx.lastProgressByTask.has('__rate_limit__')).toBe(true);
+    const callsBefore = setOverlay.mock.calls.length;
+
+    handleOrchestratorEvent({ type: 'stream_retry' }, source, ctx);
+    expect(ctx.lastProgressByTask.has('__rate_limit__')).toBe(false);
+    // A repaint fired to remove the stale banner.
+    expect(setOverlay.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+
+  it('stream_retry with no active backoff banner does not force an extra repaint', () => {
+    const { ctx, setOverlay } = ttyCtx();
+    const source = freshSourceState('__main__');
+
+    const callsBefore = setOverlay.mock.calls.length;
+    handleOrchestratorEvent({ type: 'stream_retry' }, source, ctx);
+    // No synthetic entry existed → delete() returns false → no repaint.
+    expect(setOverlay.mock.calls.length).toBe(callsBefore);
+  });
+});

--- a/src/cli/_lib/stream-renderer-orchestrator.test.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.test.ts
@@ -666,6 +666,7 @@ describe('handleOrchestratorEvent — tool-use-loop scrollback (no content emiss
       thinkingLane: new ThinkingLane(),
       thinkingMode: 'off',
       streamingMarkdown: { current: null },
+      lastProgressByTask: new Map(),
     };
     const source: SourceState = freshSourceState('__main__');
 
@@ -1085,6 +1086,7 @@ function makeSkillCtx(
     thinkingLane: new ThinkingLane(),
     thinkingMode: 'off',
     streamingMarkdown: { current: null },
+    lastProgressByTask: new Map(),
     activeSkillName,
   };
 }
@@ -1386,6 +1388,29 @@ describe('handleOrchestratorEvent — rate_limit arm', () => {
     handleOrchestratorEvent(progressEvent('real-task-uuid'), source, ctx);
     expect(ctx.lastProgressByTask.has('__rate_limit__')).toBe(false);
     expect(ctx.lastProgressByTask.has('real-task-uuid')).toBe(true);
+  });
+
+  it('a resumed text-only stream (content chunk, no progress event) evicts the backoff banner and repaints', () => {
+    const { ctx, setOverlay } = ttyCtx();
+    const source = freshSourceState('__main__');
+
+    handleOrchestratorEvent(rateLimitEvent(70_000), source, ctx);
+    expect(ctx.lastProgressByTask.has('__rate_limit__')).toBe(true);
+    const callsBefore = setOverlay.mock.calls.length;
+
+    // The retried request resolves into a plain-text answer: content streams
+    // with NO preceding `progress` event (a no-tool-use turn never emits one —
+    // loop.ts yields progress only per tool-use round), so the chunk arm itself
+    // must drop the stale banner. Without this the overlay keeps reading
+    // `rate-limited · retrying…` under the streamed answer until turn-end.
+    handleOrchestratorEvent(
+      { type: 'chunk', chunk: { type: 'content', content: 'the answer' } },
+      source,
+      ctx,
+    );
+    expect(ctx.lastProgressByTask.has('__rate_limit__')).toBe(false);
+    // A repaint fired so the stale banner is removed immediately.
+    expect(setOverlay.mock.calls.length).toBeGreaterThan(callsBefore);
   });
 
   it('stream_retry clears a stale backoff banner and repaints', () => {

--- a/src/cli/_lib/stream-renderer-orchestrator.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.ts
@@ -30,7 +30,11 @@ import {
 import { stripCommandTags, extractSkillTag } from '../slash/_lib/command-tags.js';
 import { styleForCategory, SUBAGENT_TOOLS, DAG_TOOLS } from '../tool-category.js';
 import { formatThinkingParagraph } from '../commands/interactive/thinking-paragraph.js';
-import { deriveProgressActivity, formatProgressBanner } from '../commands/interactive/progress-banner.js';
+import {
+  deriveProgressActivity,
+  formatProgressBanner,
+  formatRateLimitActivity,
+} from '../commands/interactive/progress-banner.js';
 import { getTerminalWidth } from '../terminal-size.js';
 import {
   emitPanel,
@@ -48,6 +52,14 @@ export {
   emitErrorBox,
   flushToolLaneToScrollback,
 } from './stream-renderer-orchestrator-emit.js';
+
+/**
+ * Reserved `lastProgressByTask` key for the synthetic rate-limit backoff
+ * banner. Distinct from any model-minted taskId (loop.ts uses `randomUUID()`),
+ * so a real `progress` event's `clear()` evicts it and it never collides with a
+ * live tool-use loop entry. Underscore-bracketed to read as a sentinel.
+ */
+const RATE_LIMIT_TASK_ID = '__rate_limit__';
 
 /**
  * Context object passed to orchestrator event handlers. Wraps mutable fields
@@ -371,7 +383,38 @@ export function handleOrchestratorEvent(
       // already committed past a block boundary are append-only and remain.
       source.contentBuffer = '';
       ctx.streamingMarkdown.current?.discardPending();
+      // A fresh request is starting: clear any stale rate-limit backoff banner
+      // so the re-drive isn't shadowed by an ETA that no longer applies. The
+      // next real `progress` event repaints the normal banner.
+      if (ctx.lastProgressByTask.delete(RATE_LIMIT_TASK_ID) && ctx.isTTY) {
+        setComposedOverlay(ctx);
+      }
       return;
+
+    case 'rate_limit': {
+      // Live backoff signal from the provider (429/503/529 + retry-after). The
+      // per-turn loop is parked awaiting the throttled `messages.create`, so on
+      // the FIRST model call of a turn there is NO progress entry and the
+      // overlay shows only the spinner — a healthy wait looks like a hang.
+      // Inject a synthetic progress entry carrying the formatted activity in
+      // `description` (the field `formatProgressBanner` shows verbatim; the
+      // `activity`/`summary` slot is masked by deriveProgressActivity when the
+      // model is mid-thought, so `description` is the reliable channel). Keyed
+      // by a reserved taskId so we can evict it on stream_retry; the next real
+      // `progress` event's `clear()`+`set()` (see the 'progress' case) and the
+      // turn-end `lastProgressByTask.clear()` both drop it automatically, so
+      // the normal banner resumes with no extra bookkeeping.
+      if (!ctx.isTTY) return;
+      ctx.lastProgressByTask.set(RATE_LIMIT_TASK_ID, {
+        taskId: RATE_LIMIT_TASK_ID,
+        description: formatRateLimitActivity(event.retryAfterMs),
+        totalTokens: 0,
+        toolUses: 0,
+        durationMs: 0,
+      });
+      setComposedOverlay(ctx);
+      return;
+    }
 
     case 'panel':
       emitPanel(event.spec as CardSpec, source, ctx);

--- a/src/cli/_lib/stream-renderer-orchestrator.ts
+++ b/src/cli/_lib/stream-renderer-orchestrator.ts
@@ -165,6 +165,18 @@ export function handleOrchestratorEvent(
 
     case 'chunk': {
       const chunk = event.chunk;
+      // Streaming resumed: the SDK's throttle backoff (see the 'rate_limit'
+      // case) is over the instant the first stream chunk lands. On a text-only
+      // turn NO `progress` event follows to evict the synthetic backoff banner,
+      // so it would otherwise linger under the streamed answer until turn-end
+      // finalization — the status line reading `rate-limited · retrying…` while
+      // the retried response is already streaming. Drop it here on the first
+      // chunk (any type) so the banner covers only the real wait window. The
+      // `delete()` returns true only while the entry exists, so the repaint
+      // fires at most once per backoff, not on every chunk.
+      if (ctx.lastProgressByTask.delete(RATE_LIMIT_TASK_ID) && ctx.isTTY) {
+        setComposedOverlay(ctx);
+      }
       if (chunk.type === 'tool_use_detail') {
         // Thinking→acting boundary: the model has finished reasoning for the
         // moment and is dispatching a tool. Cap the thinking-duration window

--- a/src/cli/commands/interactive/progress-banner.test.ts
+++ b/src/cli/commands/interactive/progress-banner.test.ts
@@ -21,6 +21,7 @@ import {
   deriveProgressActivity,
   formatProgressBanner,
   formatProgressSummary,
+  formatRateLimitActivity,
   formatSubagentCompletion,
   emitSubagentCompletion,
 } from './progress-banner.js';
@@ -346,6 +347,38 @@ describe('progress-banner — terminal width clamping', () => {
       emitSubagentCompletion(writer, info('sa-default'));
       expect(committed).toHaveLength(1);
     });
+  });
+});
+
+describe('formatRateLimitActivity', () => {
+  it('rounds a whole-second retry-after to ~Ns', () => {
+    expect(formatRateLimitActivity(70_000)).toBe('rate-limited · retrying in ~70s');
+  });
+
+  it('rounds a fractional retry-after UP to the next whole second', () => {
+    // 70_001ms → 71s (ceil), so a partial second is never under-reported.
+    expect(formatRateLimitActivity(70_001)).toBe('rate-limited · retrying in ~71s');
+    // 29_500ms → 30s.
+    expect(formatRateLimitActivity(29_500)).toBe('rate-limited · retrying in ~30s');
+  });
+
+  it('shows ~1s for a sub-second retry-after rather than ~0s', () => {
+    expect(formatRateLimitActivity(500)).toBe('rate-limited · retrying in ~1s');
+    expect(formatRateLimitActivity(1)).toBe('rate-limited · retrying in ~1s');
+  });
+
+  it('drops the ETA when retryAfterMs is undefined', () => {
+    expect(formatRateLimitActivity(undefined)).toBe('rate-limited · retrying…');
+  });
+
+  it('drops the ETA for a zero or negative delay (no positive time to show)', () => {
+    expect(formatRateLimitActivity(0)).toBe('rate-limited · retrying…');
+    expect(formatRateLimitActivity(-5_000)).toBe('rate-limited · retrying…');
+  });
+
+  it('drops the ETA for a non-finite delay (defensive)', () => {
+    expect(formatRateLimitActivity(Number.NaN)).toBe('rate-limited · retrying…');
+    expect(formatRateLimitActivity(Number.POSITIVE_INFINITY)).toBe('rate-limited · retrying…');
   });
 });
 

--- a/src/cli/commands/interactive/progress-banner.ts
+++ b/src/cli/commands/interactive/progress-banner.ts
@@ -49,6 +49,31 @@ export function deriveProgressActivity(
 }
 
 /**
+ * Format the live rate-limit / backoff banner activity clause.
+ *
+ * Contract: converts the provider's `rate_limit` signal into the short string
+ * the progress banner shows WHILE the SDK sleeps out a `retry-after` backoff
+ * (the session is healthy-but-waiting, not hung). `retryAfterMs` is rounded up
+ * to whole seconds so a sub-second hint still reads `~1s` rather than `~0s`;
+ * when the header carried no delay the copy drops the ETA. Pure and
+ * side-effect-free so it is trivially unit-testable and safe to call at render
+ * time.
+ *
+ *   70000  → `rate-limited · retrying in ~70s`
+ *   500    → `rate-limited · retrying in ~1s`
+ *   0      → `rate-limited · retrying…`   (no positive delay to show)
+ *   undef  → `rate-limited · retrying…`
+ */
+export function formatRateLimitActivity(retryAfterMs?: number): string {
+  if (retryAfterMs === undefined || !Number.isFinite(retryAfterMs) || retryAfterMs <= 0) {
+    return 'rate-limited · retrying…';
+  }
+  // Round UP so a sub-second retry-after never displays `~0s`.
+  const seconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+  return `rate-limited · retrying in ~${seconds}s`;
+}
+
+/**
  * Render a progress event into one or two CLI lines.
  *
  * Line 0 is the task's stable description (invariant across ticks for a


### PR DESCRIPTION
## Why
From the REPL UX audit: when the Anthropic SDK is throttled (429/503/529 + `Retry-After`) it sleeps-and-retries **inside a single `messages.create()`** — so a 70s Retry-After retried twice (~140s) shows the user *nothing* live and looks like a frozen session. Until now it was only recorded in the witness trace, after the fact.

## What
Surfaces the backoff live in the progress banner (e.g. `rate-limited · retrying in ~70s`):
- New `rate_limit` `ProviderEvent` variant (`provider.ts`).
- `tracing-fetch` gains an optional `onThrottle` callback (existing `rate_limit` trace-phase emission untouched — both channels fire).
- A tiny out-of-band `ThrottleQueue` (single-producer/consumer promise mailbox) bridges the wrapped-fetch callback → the per-turn loop, which **races** its `messages.create` await against the queue and yields a `rate_limit` event per drained signal — live, *before* the response streams.
- `stream-consumer` maps it to an output event; a pure `formatRateLimitActivity(retryAfterMs?)` renders the banner string; the next real progress/done evicts it.

## Non-goals
- Does **not** change retry policy/timing (the SDK owns retries) or add model-downgrade/fallback.

## Verification
- `pnpm lint` clean; `pnpm audit:sdk:check` OK (no new SDK imports).
- Full suite **`11759 passed | 14 skipped`**; touched-file + provider/session suites green. New unit tests for the formatter + the stream-consumer mapping.

## Reviewer focus
- **The `Promise.race` / generator in `awaitCreateWithThrottleSignals` (loop.ts)** — out-of-band emission correctness: `create` rejections must re-throw to the caller's catch; no unhandled rejection; no lost/duplicated signal (level-triggered drain-then-park).
- Banner injection relies on the `lastProgressByTask` slot in the OverlayComposer path — a live TTY smoke test would confirm the paint (not exercised in CI).

🤖 Built via parallel afk subagent (opus) + orchestrator verification.
