### PR TITLE
fix(subagent): bound read-only research agents + degrade empty no-terminal run to a marked partial

### DIFF
--- a/src/agent/agents/builtins.ts
+++ b/src/agent/agents/builtins.ts
@@ -51,6 +51,24 @@ Rules:
 Reply compactly: the answer first, then evidence as file:line citations, then open questions or paths not checked. No preamble.`;
 
 /**
+ * Anti-runaway tool-use-round bound for the read-only research/review builtins.
+ *
+ * The `agent`-tool dispatch path is unlimited-by-default: `child-config.ts`
+ * resolves a named dispatch's `maxToolUseIterations` to 0 (no cap) when neither
+ * the call-site nor the definition sets one, deliberately bypassing
+ * SubagentManager's `SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS` (50) — which only
+ * guards internal skill/compose forks. Unbounded is defensible for a real
+ * multi-step worker (`general-purpose`), but a READ-ONLY research/review agent
+ * never legitimately needs many rounds; without a bound it can loop on a hard
+ * task until an external cutoff aborts it mid-loop, surfacing as an opaque
+ * failure. Bounding it routes a runaway through the graceful capped-partial
+ * wind-down instead. Value mirrors `SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS`;
+ * duplicated (not imported) to keep `agents/` off the `subagent.ts` module
+ * graph — same rationale as the KNOWN_AFK_TOOL_NAMES dup in resolve.ts.
+ */
+const READONLY_AGENT_MAX_TOOL_USE_ITERATIONS = 50;
+
+/**
  * Build the built-in agents, keyed by name.
  *
  * A fresh map per call — callers merge it into a mutable registry under
@@ -78,6 +96,11 @@ export function builtinAgents(): Map<string, RegisteredAgent> {
         // research-agent to dispatching ONLY git-investigator (no bare/other
         // dispatch), so the read-only contract can't be escalated.
         tools: [...researchAgent.allowedTools, 'Agent(git-investigator)'],
+        // Anti-runaway bound (see READONLY_AGENT_MAX_TOOL_USE_ITERATIONS): a
+        // read-only research/review agent that keeps tool-calling without ever
+        // emitting a final message otherwise runs unbounded on the (uncapped)
+        // agent-tool dispatch path and dies opaquely when cut off mid-loop.
+        maxToolUseIterations: READONLY_AGENT_MAX_TOOL_USE_ITERATIONS,
       },
     },
     {
@@ -117,6 +140,9 @@ export function builtinAgents(): Map<string, RegisteredAgent> {
         prompt: EXPLORE_PROMPT,
         tools: ['Read', 'Grep', 'Glob', 'list_directory'],
         model: 'haiku',
+        // Same anti-runaway bound as research-agent: Explore is a read-only
+        // search leaf, so it never needs an unbounded tool-use loop.
+        maxToolUseIterations: READONLY_AGENT_MAX_TOOL_USE_ITERATIONS,
       },
     },
   ];

--- a/src/agent/agents/registry.test.ts
+++ b/src/agent/agents/registry.test.ts
@@ -53,6 +53,14 @@ describe('loadAgentRegistry', () => {
       'WebSearch',
       'Agent(git-investigator)',
     ]);
+    // Anti-runaway bound: the read-only research/review builtins carry an
+    // explicit tool-use-round cap so the uncapped agent-tool dispatch path
+    // cannot let them loop forever and die opaquely when cut off mid-run.
+    expect(registry.get('research-agent')?.definition.maxToolUseIterations).toBe(50);
+    expect(registry.get('Explore')?.definition.maxToolUseIterations).toBe(50);
+    // general-purpose stays UNBOUNDED — a real multi-step worker legitimately
+    // needs an uncapped loop, so it must NOT gain the read-only bound.
+    expect(registry.get('general-purpose')?.definition.maxToolUseIterations).toBeUndefined();
   });
 
   it('strips vendored frontmatter from builtin prompts (body-only system prompt)', () => {

--- a/src/agent/subagent/handle-streaming.test.ts
+++ b/src/agent/subagent/handle-streaming.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { IAgentSession, Message, OutputEvent } from '../types.js';
 import { SubagentHandleImpl } from './handle.js';
+import { STREAM_INCOMPLETE } from './result.js';
 import { AbortGraph } from '../abort-graph.js';
 import { runWithSink, getCurrentSink } from '../_lib/skill-sink-channel.js';
 
@@ -205,7 +206,13 @@ describe('SubagentHandle streaming', () => {
       expect(handle.status).toBe('succeeded');
     });
 
-    it('throws when stream ends with neither message nor streamed content', async () => {
+    it('returns a stream-incomplete partial (not a throw) when the stream ends with neither message nor streamed content', async () => {
+      // Degradation contract: an empty cut-off stream (no terminal message, no
+      // buffered text, no error, and NOT the tool-use cap) must NOT throw an
+      // opaque "produced no terminal message". It returns a STREAM_INCOMPLETE
+      // partial (status 'succeeded') carrying a cut-off marker, so the parent
+      // gets an actionable incomplete result — annotateIfIncomplete flags it at
+      // the consumption boundary — instead of a bare delegation failure.
       const events: OutputEvent[] = [{ type: 'done' }];
       const session = createDeterministicMockSession(events, {
         role: 'assistant',
@@ -223,7 +230,10 @@ describe('SubagentHandle streaming', () => {
         vi.fn(),
       );
 
-      await expect(handle.run('p')).rejects.toThrow(/produced no terminal message/);
+      const result = await handle.runToResult('p');
+      expect(result.status).toBe('succeeded');
+      expect(result.stopReason).toBe(STREAM_INCOMPLETE);
+      expect(result.message?.content).toMatch(/without producing a final message/);
     });
 
     it('returns a capped partial result (not a throw) when the tool-use cap fires with no message', async () => {

--- a/src/agent/subagent/handle-streaming.test.ts
+++ b/src/agent/subagent/handle-streaming.test.ts
@@ -236,6 +236,40 @@ describe('SubagentHandle streaming', () => {
       expect(result.message?.content).toMatch(/without producing a final message/);
     });
 
+    it('overwrites a clean terminal stopReason with STREAM_INCOMPLETE on an empty cut-off run', async () => {
+      // Codex PR #597 P2 regression guard. An empty-text turn that ends with a
+      // CLEAN terminal reason (end_turn / max_tokens) is dropped by the stream
+      // consumer before a `message` event is emitted (`assistant.message`:
+      // `if (event.text)`), so the empty-fallback branch is reached with
+      // lastStopReason already set to that clean reason. It MUST be overwritten
+      // to STREAM_INCOMPLETE (assignment, not `??=`): the returned content is a
+      // synthetic "no findings" placeholder, and preserving `end_turn` would let
+      // annotateIfIncomplete report that placeholder as a clean completion with
+      // no partial marker — the exact silent-success this branch exists to kill.
+      const events: OutputEvent[] = [{ type: 'done', metadata: { stopReason: 'end_turn' } }];
+      const session = createDeterministicMockSession(events, {
+        role: 'assistant',
+        content: 'unused',
+        timestamp: new Date(),
+      });
+      const handle = new SubagentHandleImpl(
+        'subagent-empty-cleanreason-test',
+        session,
+        controller,
+        abortGraph,
+        undefined,
+        5000,
+        undefined,
+        vi.fn(),
+      );
+
+      const result = await handle.runToResult('p');
+      expect(result.status).toBe('succeeded');
+      expect(result.stopReason).toBe(STREAM_INCOMPLETE);
+      expect(result.stopReason).not.toBe('end_turn');
+      expect(result.message?.content).toMatch(/without producing a final message/);
+    });
+
     it('returns a capped partial result (not a throw) when the tool-use cap fires with no message', async () => {
       // Anti-hang contract: a forked child that hits its tool-use-iteration cap
       // ends the turn with a `tool_use_loop_capped` done and no assistant

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -414,7 +414,22 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     if (this.controller.signal.aborted || this.currentStatus === 'cancelled') {
       throw new Error(`Subagent ${this.id} produced no terminal message`);
     }
-    this.lastStopReason ??= STREAM_INCOMPLETE;
+    // Invariant: this fallback stamps STREAM_INCOMPLETE UNCONDITIONALLY (`=`,
+    // not `??=`) — the content below is a synthetic placeholder, never the
+    // model's real output, so its stop reason must mark it incomplete. This
+    // differs from the buffered-text branch above, which uses `??=` deliberately:
+    // a capped run that also streamed text reaches there with
+    // `tool_use_loop_capped` already set and must keep it. Nothing worth
+    // preserving can reach HERE — the cap case returned at the
+    // tool_use_loop_capped branch, and cancel/abort threw just above. Any
+    // stopReason still set is therefore a clean terminal one (end_turn /
+    // max_tokens / interrupted), none of which isIncompleteStopReason flags,
+    // reached via an empty-text turn the stream consumer drops before emitting a
+    // `message` event (see stream-consumer 'assistant.message': `if (event.text)`).
+    // Preserving it would let annotateIfIncomplete report this synthetic
+    // "no findings" placeholder as a clean completion — defeating the whole
+    // point of this branch. Overwrite it.
+    this.lastStopReason = STREAM_INCOMPLETE;
     return {
       role: 'assistant',
       content:

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -395,7 +395,34 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
         timestamp: new Date(),
       };
     }
-    throw new Error(`Subagent ${this.id} produced no terminal message`);
+    // Invariant: a cancelled subagent must NEVER resolve as a succeeded partial.
+    // Reaching here means no terminal message, no buffered text, no stream
+    // error, and not the tool-use cap — two sub-cases, split by whether the run
+    // was cancelled/aborted (mirroring run()'s own catch classification):
+    //   - CANCELLED/ABORTED (explicit cancel() sets currentStatus 'cancelled';
+    //     an ancestor cascade sets controller.signal.aborted): preserve the
+    //     throw so run()'s catch classifies the termination as 'cancelled' —
+    //     not a success, not a plain failure.
+    //   - Otherwise (an abnormal provider-stream close, or a mid-loop cutoff
+    //     with an empty buffer — the failure mode of an unbounded read-only
+    //     agent that tool-loops without ever emitting a final turn): degrade to
+    //     a STREAM_INCOMPLETE partial, the same treatment the buffered-text
+    //     branch above gives, so the consumption boundary (annotateIfIncomplete)
+    //     marks it as an incomplete result the parent can act on (retry / fall
+    //     back) instead of an opaque "produced no terminal message" delegation
+    //     failure after (often) a long run.
+    if (this.controller.signal.aborted || this.currentStatus === 'cancelled') {
+      throw new Error(`Subagent ${this.id} produced no terminal message`);
+    }
+    this.lastStopReason ??= STREAM_INCOMPLETE;
+    return {
+      role: 'assistant',
+      content:
+        `[subagent ${this.id} ended without producing a final message or any ` +
+        `streamed output — it was cut off mid-run (an abnormal stream close), ` +
+        `so no findings were produced.]`,
+      timestamp: new Date(),
+    };
   }
 
   async runToResult(prompt: string, sinkOverride?: SubagentProgressSink): Promise<SubagentResult<T>> {


### PR DESCRIPTION
## Problem

`awa-private:research-agent` dispatches in the hourly PR-review daemon reliably fail: the subagent runs 80–106 tool calls over ~15 min, then returns with no output (a red ×) and the orchestrator falls back. The underlying error is the opaque `Subagent … produced no terminal message`.

## Root cause (shadow-verified)

Two stacked defects:

1. **Unbounded tool loop.** The `agent`-tool dispatch path resolves `maxToolUseIterations` to `0` (unlimited) when neither the call-site nor the agent definition sets one — `child-config.ts:230-234,266-269` — deliberately bypassing `SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS = 50` (`subagent.ts:74,675-676`), which now only guards internal skill/compose forks. A read-only research/review agent therefore has no anti-hang bound and can tool-loop indefinitely.
2. **Opaque failure on cutoff.** When such a run is cut off mid-loop with an empty buffer, `handle.ts` threw `produced no terminal message` — an opaque hard failure with nothing to salvage — instead of degrading. The adjacent *buffered-text* branch already degrades to a `STREAM_INCOMPLETE` partial; the no-text case did not.

(The builtin `research-agent` and plugin `awa-private:research-agent` are otherwise identical — byte-identical prompt, same `Agent(git-investigator)` grant; the only difference is the plugin's `model: sonnet` pin vs the builtin's inherit.)

## Fix

- **Bound the read-only research/review builtins** (`research-agent`, `Explore`) with `maxToolUseIterations = 50` in `builtins.ts`, so a runaway winds down through the graceful capped-partial path. `general-purpose` stays **unbounded** (a real multi-step worker legitimately needs a long loop) — no blanket cap.
- **Degrade the empty no-terminal stream end** in `handle.ts` to a `STREAM_INCOMPLETE` partial (marked at every consumption boundary by `annotateIfIncomplete`), so the parent gets an actionable, clearly-flagged incomplete result instead of an opaque throw. **Explicit `cancel()` / cascade-abort still throw**, so a cancelled subagent is never mislabeled a succeeded partial.

## Testing

- `pnpm lint` clean.
- Full `pnpm test` suite green (649 files, 11846 tests).
- `handle-streaming.test.ts`: empty stream now asserts a marked partial; the abort test still asserts rejection.
- `registry.test.ts`: asserts research-agent/Explore bounded at 50 and general-purpose left unbounded.

## Blast radius

- The degradation only changes the `handle.ts` terminal that previously threw with zero salvage; cancel/abort classification is unchanged.
- Bounding is limited to the two read-only search/review builtins.

## Follow-up (separate, private repo)

`awa-private:research-agent`'s own frontmatter should get the same `maxToolUseIterations` bound in `agent-framework-private` so it also winds down early like the builtin. (This PR's `handle.ts` degradation already makes its runaway fail *gracefully* rather than opaquely in the meantime.) Optionally drop its `model: sonnet` pin to match the model-inheriting builtin.
