### PR TITLE
fix(telegram): run agent turn detached so mid-turn elicitations don't deadlock the poller

### DIFF
--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -266,6 +266,72 @@ describe('TelegramBot', () => {
     });
   });
 
+  describe('polling loop is not blocked by an in-flight turn (elicitation deadlock regression)', () => {
+    test('the registered text update handler returns before the turn completes', async () => {
+      // Regression for the path-approval "buttons do nothing" deadlock:
+      // Telegraf's long-poll loop awaits every handler in a batch before it
+      // fetches the next getUpdates batch. If the 'text' handler AWAITS the agent
+      // turn, a turn wedged on a mid-turn elicitation (waiting for a button tap /
+      // text reply that only arrives on a LATER update) freezes the poller — the
+      // resolving update can never be fetched. The turn must run DETACHED so
+      // handleUpdate resolves immediately and the poller keeps polling.
+      const neverResolves = new Promise<void>(() => {
+        /* a turn blocked forever on an unanswerable elicitation */
+      });
+      const handleSpy = vi
+        .spyOn((bot as any).messageHandler, 'handle')
+        .mockReturnValue(neverResolves);
+
+      // Pre-seed botInfo so Telegraf's handleUpdate does not call getMe() over
+      // the network (offline test) before running the middleware chain.
+      (bot as any).bot.botInfo = {
+        id: 42,
+        is_bot: true,
+        first_name: 'Test',
+        username: 'test_bot',
+        can_join_groups: true,
+        can_read_all_group_messages: false,
+        supports_inline_queries: false,
+      };
+
+      const update = {
+        update_id: 1,
+        message: {
+          message_id: 1,
+          text: 'read /tmp/x',
+          date: Math.floor(Date.now() / 1000),
+          chat: { id: 12345, type: 'private' },
+          from: { id: 12345, is_bot: false, first_name: 'T' },
+        },
+      };
+
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const guard = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new Error(
+                'handleUpdate blocked on the in-flight turn — polling deadlock regression',
+              ),
+            ),
+          500,
+        );
+      });
+      try {
+        // If the handler awaited the turn, this race would reject via `guard`.
+        await expect(
+          Promise.race([(bot as any).bot.handleUpdate(update), guard]),
+        ).resolves.toBeUndefined();
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+
+      // The turn WAS dispatched (not dropped) — just not awaited by the poller.
+      expect(handleSpy).toHaveBeenCalledTimes(1);
+      handleSpy.mockRestore();
+    });
+  });
+
   describe('error handling', () => {
     test('should detect rate limit errors', () => {
       const error = new Error('Rate limit exceeded');

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -233,12 +233,31 @@ export class TelegramBot {
       await ctx.reply(`✋ Abort sent to session ${sessionId}.`);
     });
 
-    this.bot.on('text', (ctx) => this.messageHandler.handle(ctx));
+    // Invariant: a message update handler MUST NOT await the agent turn.
+    // Telegraf's long-poll loop is `for await (updates) await Promise.all(
+    // updates.map(handleUpdate))` (telegraf/lib/core/network/polling.js): it does
+    // NOT fetch the next getUpdates batch until every handler in the current
+    // batch settles. Awaiting the full turn here froze the poller for the turn's
+    // entire lifetime, so a mid-turn elicitation (path-approval / ask_question)
+    // could never receive the callback_query (button tap) or the text reply that
+    // resolves it — the turn blocked on an update the frozen poller refused to
+    // fetch, a deadlock broken only when the streaming watchdog timed the turn
+    // out (~11 min later). Running the turn DETACHED frees the poller immediately;
+    // per-chat ordering + one-turn-at-a-time are still enforced by
+    // MessageHandler's queue + session busy-state (message.ts), exactly as they
+    // already are for turns dispatched from processOne's finally→drainQueue.
+    // handle()/handlePhoto() own their user-facing error handling, so
+    // `runDetached`'s .catch is only a last-resort guard against an unhandled
+    // rejection (e.g. a reply that throws after the bot is stopped).
+    const runDetached = (work: Promise<void>): void => {
+      void work.catch((err) => this.log('Detached update handler error:', err));
+    };
+    this.bot.on('text', (ctx) => runDetached(this.messageHandler.handle(ctx)));
 
     // Photo updates carry `message.photo[]` not `message.text` — they require
     // their own listener since Telegraf's filter is exact (a photo update never
     // matches the 'text' filter even if the user added a caption).
-    this.bot.on('photo', (ctx) => this.messageHandler.handlePhoto(ctx));
+    this.bot.on('photo', (ctx) => runDetached(this.messageHandler.handlePhoto(ctx)));
     // Note: documents, voice notes, video, and stickers remain unhandled.
     // They can be added with the same pattern (download → build content blocks → processOne).
 

--- a/src/telegram/handlers/message-photo.test.ts
+++ b/src/telegram/handlers/message-photo.test.ts
@@ -250,6 +250,53 @@ describe('handlePhoto: session busy — enqueue', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// TOCTOU regression: two near-simultaneous same-chat photo updates must not
+// both become the active turn (PR #602 review — Codex P1).
+//
+// bot.ts now dispatches the Telegraf 'photo' handler detached, so a second
+// photo update for the same chat can be fetched and run concurrently with
+// the first, before the first's `session.state` has actually flipped away
+// from 'idle'. The download + base64-encode pipeline here widens that window
+// far beyond the text path's `ctx.react`, so this is the more realistic
+// trigger for the race. `getSession` below always resolves the SAME idle
+// session regardless of call count — modeling that window — so without the
+// synchronous `claimedChats` reservation, BOTH concurrent handlePhoto() calls
+// would see 'idle' and both would reach processOne/streamResponse.
+// ---------------------------------------------------------------------------
+
+describe('handlePhoto: concurrent same-chat dispatch (TOCTOU regression — PR #602 Codex P1)', () => {
+  it('a second concurrent photo update for the same chat is queued, not processed concurrently', async () => {
+    const session = makeSession('idle');
+    const handler = makeHandler(session);
+    const { ctx: ctx1, replies: replies1 } = makePhotoCtx({ caption: 'first' });
+    const { ctx: ctx2, replies: replies2 } = makePhotoCtx({ caption: 'second' });
+
+    // Dispatch both without awaiting between them — exactly what bot.ts's
+    // runDetached now allows via two back-to-back polling batches.
+    await Promise.all([handler.handlePhoto(ctx1), handler.handlePhoto(ctx2)]);
+
+    // Exactly one of the two `handlePhoto()` calls must have gone straight to
+    // processOne; the other must have been queued (a "Queued #1" reply) —
+    // never both racing into processOne directly from their own idle-check.
+    // (The queued item may then be drained and processed SEQUENTIALLY once
+    // the winner's turn finishes — that pre-existing drainQueue behavior is
+    // expected and is not what this test guards against; only CONCURRENT
+    // double-entry from two independent handlePhoto() calls is the regression.)
+    const queuedReplies = [...replies1, ...replies2].filter((r) => r.includes('#1'));
+    expect(queuedReplies).toHaveLength(1);
+
+    // The winning call's own replies stay empty — handlePhoto()'s
+    // direct-process path never calls ctx.reply itself (only the
+    // enqueue/error paths do).
+    const winnerReplies = queuedReplies[0] && replies1.includes(queuedReplies[0]) ? replies2 : replies1;
+    expect(winnerReplies).toHaveLength(0);
+
+    // streamResponse must have fired at least once (the winner's own turn).
+    expect(mockStreamResponse).toHaveBeenCalled();
+  });
+});
+
 describe('handlePhoto: chat undefined (early return)', () => {
   it('returns silently without reply when ctx.chat is undefined', async () => {
     const session = makeSession('idle');

--- a/src/telegram/handlers/message.test.ts
+++ b/src/telegram/handlers/message.test.ts
@@ -210,6 +210,74 @@ describe('MessageHandler queue-depth acknowledgment', () => {
 });
 
 // ---------------------------------------------------------------------------
+// TOCTOU regression: two near-simultaneous same-chat updates must not both
+// become the active turn (PR #602 review — Codex P1).
+//
+// bot.ts now dispatches the Telegraf 'text'/'photo' handlers detached, so a
+// second update for the same chat can be fetched and run concurrently with
+// the first, before the first's `session.state` has actually flipped away
+// from 'idle' (that flip happens deep inside sendMessageStream, after
+// getSession() and streaming.ts's "Thinking…" placeholder send). The mocked
+// sessionManager here always resolves `{ state: 'idle' }` regardless of how
+// many times it is called — exactly modeling that window — so without the
+// synchronous `claimedChats` reservation, BOTH concurrent handle() calls
+// would see 'idle' and both would reach processOne/streamResponse.
+// ---------------------------------------------------------------------------
+
+describe('MessageHandler concurrent same-chat dispatch (TOCTOU regression — PR #602 Codex P1)', () => {
+  const CHAT_ID = 2002;
+
+  beforeEach(() => {
+    mockStreamResponse.mockClear();
+  });
+
+  it('a second concurrent update for the same chat is queued, not processed concurrently', async () => {
+    // getSession always resolves { state: 'idle' } — never reflects a real
+    // busy transition — so this reproduces exactly the unprotected window:
+    // only the claimedChats guard (not session.state) can serialize these.
+    const handler = makeHandler();
+    const { ctx: ctx1, replies: replies1 } = makeMessageCtx(CHAT_ID, 'first');
+    const { ctx: ctx2, replies: replies2 } = makeMessageCtx(CHAT_ID, 'second');
+
+    // Dispatch both without awaiting between them — exactly what bot.ts's
+    // runDetached now allows via two back-to-back polling batches.
+    await Promise.all([handler.handle(ctx1), handler.handle(ctx2)]);
+
+    // Exactly one of the two `handle()` calls must have gone straight to
+    // processOne; the other must have been queued (a "Queued #1" reply) —
+    // never both racing into processOne directly from their own idle-check.
+    // (The queued item may then be drained and processed SEQUENTIALLY once
+    // the winner's turn finishes — that pre-existing drainQueue behavior is
+    // expected and is not what this test guards against; only CONCURRENT
+    // double-entry from two independent handle() calls is the regression.)
+    const queuedReplies = [...replies1, ...replies2].filter((r) => r.includes('#1'));
+    expect(queuedReplies).toHaveLength(1);
+
+    // The winning call's own replies stay empty — handle()'s direct-process
+    // path never calls ctx.reply itself (only the enqueue path does).
+    const winnerReplies = queuedReplies[0] && replies1.includes(queuedReplies[0]) ? replies2 : replies1;
+    expect(winnerReplies).toHaveLength(0);
+
+    // streamResponse must have fired at least once (the winner's own turn).
+    expect(mockStreamResponse).toHaveBeenCalled();
+  });
+
+  it('releases the claim after the turn completes so a later message for the same chat still processes normally', async () => {
+    const handler = makeHandler();
+    const { ctx: ctx1 } = makeMessageCtx(CHAT_ID, 'first');
+    await handler.handle(ctx1);
+    expect(mockStreamResponse).toHaveBeenCalledTimes(1);
+
+    // A subsequent, non-concurrent message must process normally — the
+    // claim must not leak past the turn that reserved it.
+    const { ctx: ctx2, replies: replies2 } = makeMessageCtx(CHAT_ID, 'second');
+    await handler.handle(ctx2);
+    expect(mockStreamResponse).toHaveBeenCalledTimes(2);
+    expect(replies2).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Criterion 3 (C3): ledger-originated pending resolver bypass (idle-guard fix)
 // ---------------------------------------------------------------------------
 

--- a/src/telegram/handlers/message.ts
+++ b/src/telegram/handlers/message.ts
@@ -116,6 +116,21 @@ export class MessageHandler {
   private bot: Telegraf;
 
   /**
+   * Invariant: chat IDs with a turn claimed by an in-flight handle()/
+   * handlePhoto() call not yet reflected in `session.state`. bot.ts now runs
+   * 'text'/'photo' detached, so a second same-chat update can be dispatched
+   * while the first is still between `getSession()` and the point deep in
+   * `sendMessageStream` where `currentState` actually flips (streaming.ts
+   * sends the "Thinking…" placeholder — a real Telegram round-trip — before
+   * that generator body ever runs `assertCanSend()`). `session.state` alone
+   * misses that window: both updates would see 'idle' and race out of
+   * arrival order (PR #602 review — Codex P1). Checked-and-added
+   * synchronously (no `await` in between) so only the first arrival wins;
+   * released in `finally` once that call's own turn concludes.
+   */
+  private claimedChats = new Set<number>();
+
+  /**
    * Active ask_question elicitations waiting for a text reply.
    * Keys are chat IDs; values are resolver functions that consume
    * the next plain-text message from that chat.
@@ -198,7 +213,17 @@ export class MessageHandler {
 
     const caption = msg?.caption;
 
+    let alreadyClaimed = false;
     try {
+      // Invariant: reserve this chat's turn slot SYNCHRONOUSLY (no `await`
+      // between the check and the add), before the async `getSession()` call
+      // below — see the `claimedChats` field doc for the exact race this
+      // closes. Photos widen the pre-fix race further than text messages
+      // (the CDN download + base64 encode below is a much larger gap than
+      // `ctx.react`), so this check matters even more here.
+      alreadyClaimed = this.claimedChats.has(chatId);
+      if (!alreadyClaimed) this.claimedChats.add(chatId);
+
       // M3+M6: session lookup and queue-depth check happen before getFileLink /
       // download so that allowlist-burst rejections don't burn Telegram API quota
       // or trigger a full CDN download for a message that will be dropped anyway.
@@ -209,7 +234,7 @@ export class MessageHandler {
         this.log('Failed to register chat commands:', err)
       );
 
-      if (session.state !== 'idle') {
+      if (session.state !== 'idle' || alreadyClaimed) {
         // Check queue capacity before downloading: if the queue is already full we
         // can reject immediately without spending Telegram API quota on getFileLink.
         const queue = this.messageQueues.get(chatId);
@@ -317,7 +342,7 @@ export class MessageHandler {
         source: { type: 'base64', media_type, data: base64 },
       });
 
-      if (session.state !== 'idle') {
+      if (session.state !== 'idle' || alreadyClaimed) {
         const depth = this.enqueuePhoto(chatId, ctx, contentBlocks);
         if (depth !== false) await ctx.reply(formatQueued(depth));
         return;
@@ -344,6 +369,10 @@ export class MessageHandler {
       } else {
         await ctx.reply(formatInternalError());
       }
+    } finally {
+      // Only the call that actually reserved the slot releases it — see the
+      // matching comment in handle().
+      if (!alreadyClaimed) this.claimedChats.delete(chatId);
     }
   }
 
@@ -406,11 +435,22 @@ export class MessageHandler {
       this.pendingElicitations.delete(chatId);
     }
 
+    let alreadyClaimed = false;
     try {
       // Ack the inbound message immediately (best-effort) so the user gets
       // instant feedback even while a prior turn is still streaming and this
       // message is queued. Mirrors the best-effort typing-indicator pattern.
       await ctx.react?.('👀').catch(() => {});
+
+      // Invariant: reserve this chat's turn slot SYNCHRONOUSLY (no `await`
+      // between the check and the add) before the async `session.state` check
+      // below. See the `claimedChats` field doc for the exact race this
+      // closes. `ctx.react` above is side-effect-free w.r.t. session state, so
+      // reserving after it (rather than at function entry) is equivalent and
+      // keeps the reaction-ack behavior unchanged for a losing call.
+      alreadyClaimed = this.claimedChats.has(chatId);
+      if (!alreadyClaimed) this.claimedChats.add(chatId);
+
       const session = await this.sessionManager.getSession(chatId);
 
       // Register dynamic commands for this chat (non-blocking)
@@ -418,7 +458,7 @@ export class MessageHandler {
         this.log('Failed to register chat commands:', err)
       );
 
-      if (session.state !== 'idle') {
+      if (session.state !== 'idle' || alreadyClaimed) {
         const depth = this.enqueueMessage(chatId, ctx, messageText);
         if (depth !== false) await ctx.reply(formatQueued(depth));
         return;
@@ -439,6 +479,11 @@ export class MessageHandler {
       } else {
         await ctx.reply(formatInternalError());
       }
+    } finally {
+      // Only the call that actually reserved the slot releases it — a losing
+      // (already-claimed) call never owned it and must not clear the winner's
+      // still-in-flight claim out from under it.
+      if (!alreadyClaimed) this.claimedChats.delete(chatId);
     }
   }
 


### PR DESCRIPTION
## Symptom

In the Telegram bot, a **"Path access approval"** prompt (inline buttons `✅ Once` / `🔁 Session` / `💾 Always` / `❌ Deny`) did **nothing** when tapped — the tool call was never approved, the session hung, the user's follow-up messages were ignored, and ~11 min later the bot replied *"⏱️ Response timed out."*

## Root cause — head-of-line-blocking deadlock

The bot **awaits the entire agent turn** inside the Telegraf update handler:

```ts
this.bot.on('text', (ctx) => this.messageHandler.handle(ctx)); // handle() awaits the full turn
```

Telegraf's long-poll loop (`telegraf/lib/core/network/polling.js`) is:

```js
for await (const updates of this)
    await Promise.all(updates.map(handleUpdate));   // ← next getUpdates waits for the batch to settle
```

It does **not fetch the next batch of updates until every handler in the current batch settles**. A path-approval / `ask_question` elicitation blocks the turn waiting for the operator's response — but that response arrives as a **later update** (the button-tap `callback_query`, or a text reply) that the frozen poller can never fetch. The turn waits for an update; fetching the update requires the turn to end. **Deadlock.**

The turn only unblocked when the streaming watchdog fired `StreamTimeoutError` — the `MAX_TOOL_INFLIGHT_MS = 660_000` (11 min) ceiling in `streaming.ts`, matching the observed 11:29 → 11:40 gap. Messages the user sent meanwhile (`/sessions`, `/new`) were also frozen and only drained after the timeout — the tell-tale signature.

This affected **any mid-turn elicitation on a native, in-process Telegram session** (path-approval buttons, `ask_question` buttons, and `ask_question` text replies alike). It worked in the watched-CLI/AFK-mode case only because there the turn runs in a *separate* process, leaving the bot's poller free. Unit tests missed it because they invoke handlers directly, never the real polling loop.

## Fix

Run the turn **detached** at the Telegraf registration boundary so `handleUpdate` resolves immediately and the poller keeps polling:

```ts
const runDetached = (work: Promise<void>): void => {
  void work.catch((err) => this.log('Detached update handler error:', err));
};
this.bot.on('text', (ctx) => runDetached(this.messageHandler.handle(ctx)));
this.bot.on('photo', (ctx) => runDetached(this.messageHandler.handlePhoto(ctx)));
```

- **No ordering guarantee is lost.** Per-chat ordering + one-turn-at-a-time are already enforced by `MessageHandler`'s queue + `session.state` busy-check, and queued turns *already* dispatch detached via `processOne`'s `finally → drainQueue`. This just makes the first turn consistent with the queued ones.
- **No new shutdown semantics.** `stop() → sessionManager.closeAll()` aborts in-flight turns by closing their sessions (same as today for queued turns).
- `handle()` / `handlePhoto()` keep their awaited contract for direct callers and existing tests — only the update-handler *registration* changes.

## Testing

- New regression test dispatches a real update through Telegraf's `handleUpdate` with a turn that never resolves, and asserts the handler returns without blocking the loop. **Verified it fails with the old awaited form** (`handleUpdate blocked on the in-flight turn — polling deadlock regression`) and passes detached.
- `pnpm lint` ✅ · full suite `pnpm test` ✅ (658 files, 11,991 passed) · `pnpm audit:sdk:check` / `scan:env:check` / `audit:env:check` ✅ (no SDK/env changes).

## Out of scope (follow-ups)

- Idle `/compact` and `/clear` still run compaction awaited in their command handlers, briefly blocking the poller during compaction (no turn is in flight then, so no elicitation deadlock). Could be detached the same way.
- Optional: track in-flight detached turns so `stop()` can *drain* (not just abort) them for a fully graceful shutdown.
