### PR TITLE
fix(telegram): replay saved transcript on /sessions switch (thread resumeHistory + sessionId)

### DIFF
--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -438,8 +438,18 @@ async function main() {
           ...(sessionConfig.apiKey !== undefined ? { apiKey: sessionConfig.apiKey } : {}),
           model: sessionConfig.model,
           // /switch resumes a prior conversation: thread the target SDK session
-          // id so the AgentSession continues it (see SessionManager.switchToSession).
+          // id AND the saved transcript so the AgentSession actually replays it
+          // (see SessionManager.switchToSession + resumeConfigFor). Forwarding
+          // only `resume` (the SDK id) resumes an EMPTY conversation — the
+          // provider replays prior turns solely from resumeHistory
+          // (anthropic-direct/index.ts resumeHistoryToMessages). sessionId is
+          // threaded too because the provider prefers config.sessionId over
+          // config.resume as the resumed id.
           ...(sessionConfig.resume !== undefined ? { resume: sessionConfig.resume } : {}),
+          ...(sessionConfig.sessionId !== undefined ? { sessionId: sessionConfig.sessionId } : {}),
+          ...(sessionConfig.resumeHistory !== undefined
+            ? { resumeHistory: sessionConfig.resumeHistory }
+            : {}),
           ...(systemPromptInner !== undefined ? { systemPrompt: systemPromptInner } : {}),
           maxTurns: 100,
           ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
@@ -502,8 +512,15 @@ async function main() {
       const session = attachMcpCleanup(constructTelegramSession({
         ...(sessionConfig.apiKey !== undefined ? { apiKey: sessionConfig.apiKey } : {}),
         model: sessionConfig.model,
-        // /switch resume: continue the target SDK session (parity with the Anthropic branch).
+        // /switch resume: continue the target SDK session AND replay its saved
+        // transcript (parity with the Anthropic branch). The openai-compatible
+        // provider seeds prior turns from resumeHistory (messages.ts / query.ts),
+        // so omitting it resumes an empty conversation.
         ...(sessionConfig.resume !== undefined ? { resume: sessionConfig.resume } : {}),
+        ...(sessionConfig.sessionId !== undefined ? { sessionId: sessionConfig.sessionId } : {}),
+        ...(sessionConfig.resumeHistory !== undefined
+          ? { resumeHistory: sessionConfig.resumeHistory }
+          : {}),
         ...(systemPrompt !== undefined ? { systemPrompt } : {}),
         maxTurns: 100,
         ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),

--- a/src/telegram/session-manager.test.ts
+++ b/src/telegram/session-manager.test.ts
@@ -879,12 +879,20 @@ describe('SessionManager — session switcher (/sessions, /switch, /new)', () =>
     // The rebuilt session continues the chosen conversation: config.resume === target.
     await manager.getSession(801);
     expect(lastConfig?.resume).toBe('sdk-1');
+    // ...AND the saved transcript is threaded through so the provider actually
+    // replays prior turns. Forwarding only `resume` (the SDK id) resumes an
+    // EMPTY conversation — the provider seeds history solely from resumeHistory
+    // (see anthropic-direct/index.ts resumeHistoryToMessages). Guards the bug
+    // where the Telegram createSession closure dropped resumeHistory/sessionId.
+    expect(lastConfig?.sessionId).toBe('sdk-1');
+    expect(lastConfig?.resumeHistory).toEqual([{ user: 'first convo', assistant: 'a' }]);
 
     // A subsequent /clear starts fresh — the staged resume is dropped.
     await manager.resetSession(801);
     lastConfig = undefined;
     await manager.getSession(801);
     expect(lastConfig?.resume).toBeUndefined();
+    expect(lastConfig?.resumeHistory).toBeUndefined();
   });
 
   test('switchToSession rejects an unknown or cross-chat target', async () => {


### PR DESCRIPTION
## Summary

- **Symptom:** tapping a session in the `/sessions` switcher reports "Switched to X" but the resumed agent comes up with an **empty transcript** — no memory of prior turns.
- **Root cause:** the `createSession` closure in `src/telegram.ts` cherry-picked config fields into `constructTelegramSession()`, forwarding only `resume` (the SDK id) and dropping `resumeHistory` + `sessionId`. Providers replay prior turns solely from `config.resumeHistory` (`src/agent/providers/anthropic-direct/index.ts:864` `resumeHistoryToMessages`; `src/agent/providers/openai-compatible/messages.ts:233`), so history never reached the model — exactly the failure the code comment at `src/telegram/session-manager.ts:228` warned about.
- **Divergence:** the CLI resume path spreads the full `resumeConfig` wholesale (`src/cli/commands/interactive/bootstrap.ts:133`, `src/cli/commands/chat.ts:739`); the Telegram path enumerated fields individually and silently omitted the newer ones.
- **Fix:** thread `sessionId` + `resumeHistory` in both provider branches of the `telegram.ts` `createSession` closure (Anthropic-direct ~442, openai-compatible ~506).
- **Tests:** strengthened `session-manager.test.ts` — the switcher test previously asserted only `.resume` at the upstream `createSession` seam, never `resumeHistory` (why the bug shipped unnoticed) — to assert both fields reach the config, and that both are dropped on `/clear`.

## Test results
- `pnpm lint` (tsc --noEmit, strict): clean, no errors
- `pnpm exec vitest run src/telegram`: 582 passed (582), 30 test files
- `pnpm test` (full suite): 11994 passed, 14 skipped (pre-existing/unrelated), 0 failed, 658 test files

## Verification
No adversarial verify wave requested — diff is 2 files / 27 inserted / 2 deleted, well under the 100-line threshold, and every claim above was independently re-derived against the current source (not taken on faith from the task description):
- `resumeHistoryToMessages` call confirmed at `anthropic-direct/index.ts:864`.
- `resumeHistory` consumption confirmed at `openai-compatible/messages.ts:233`.
- The wholesale `...resumeConfig` / `...deps.resumeConfig` spreads confirmed at `chat.ts:739` and `bootstrap.ts:133`.
- The warning comment confirmed at `session-manager.ts:228`.
- Pre-fix `telegram.ts` lines 442/506 confirmed (via `git show HEAD:src/telegram.ts`) to be the two enumerated-field call sites this PR patches.

## Out of scope
None — this is a targeted two-file fix (production code + its regression test). No moat/scrub concerns (public-repo core fix, no private-framework references touched).
