### PR TITLE
refactor(prompt): move # Agent AFK doctrine before memory and skills in assembled prompt

### DIFF
--- a/src/agent/memory/memory-loader.ts
+++ b/src/agent/memory/memory-loader.ts
@@ -36,12 +36,21 @@ export function loadHotMemory(): string | null {
 }
 
 /**
- * Inject HOT.md into an AgentConfig's system prompt.
+ * Inject HOT.md into an AgentConfig as the dedicated `hotMemory` field.
  *
  * If HOT.md doesn't exist or is empty, returns the config unchanged.
- * Otherwise, wraps the hot memory in `<cross-session-memory>` tags
- * and prepends (or appends, depending on systemPrompt shape) to the
- * config's systemPrompt field.
+ * Otherwise, wraps the hot memory in `<cross-session-memory>` tags and stores
+ * it on `config.hotMemory` — a field the provider places in the
+ * cross-session-memory region of the assembled system prompt (after the memory
+ * instructions).
+ *
+ * Invariant: hot memory is carried as its own field rather than prepended into
+ * `systemPrompt`. `systemPrompt` holds the `# Agent AFK` doctrine + operator
+ * overlay + routing/end-of-turn directives, which the provider now places
+ * EARLY (right after the tool conventions); welding hot memory onto the front
+ * of that string would drag the cross-session-memory block ahead of the
+ * doctrine. Keeping the two separate lets the assembler order them
+ * independently. See `providers/anthropic-direct/query/system-prompt.ts`.
  *
  * Does not mutate the original config — returns a shallow copy.
  */
@@ -51,23 +60,5 @@ export function injectHotMemory(config: AgentConfig): AgentConfig {
 
   const sanitized = hot.replace(/<\/?cross-session-memory\b[^>]*>/gi, '');
   const memoryBlock = `<cross-session-memory>\n${sanitized}\n</cross-session-memory>`;
-  const sp = config.systemPrompt;
-
-  if (typeof sp === 'string') {
-    return { ...config, systemPrompt: `${memoryBlock}\n\n${sp}` };
-  }
-
-  if (sp && typeof sp === 'object' && 'type' in sp && sp.type === 'preset') {
-    const existingAppend = sp.append ?? '';
-    return {
-      ...config,
-      systemPrompt: {
-        ...sp,
-        append: `${memoryBlock}\n\n${existingAppend}`,
-      },
-    };
-  }
-
-  // No system prompt set — just set it as the memory block
-  return { ...config, systemPrompt: memoryBlock };
+  return { ...config, hotMemory: memoryBlock };
 }

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -802,6 +802,11 @@ export class AnthropicDirectProvider implements ModelProvider {
     const stableSystemPrefix = buildStableSystemPrefix({
       toolBase,
       memoryPrompt,
+      // Hot memory (HOT.md) rides its own config field, NOT prepended into
+      // systemPrompt, so the assembler can place it after the memory
+      // instructions rather than ahead of the # Agent AFK doctrine. Unset for
+      // child sessions (subagents never inject hot memory) → treated as absent.
+      hotMemory: config.hotMemory ?? '',
       manifest,
       userSystem,
     });

--- a/src/agent/providers/anthropic-direct/query/cwd-dependents.ts
+++ b/src/agent/providers/anthropic-direct/query/cwd-dependents.ts
@@ -15,7 +15,7 @@ import type { SkillExecutor } from '../../../tools/skill-executor.js';
 import type { ComposeExecutor } from '../../../tools/compose-executor.js';
 import type { ToolDispatcher } from '../tool-dispatcher.js';
 import type { RuntimeStateSource } from '../../../awareness/index.js';
-import { assembleSystemPrompt } from './system-prompt.js';
+import { assembleSystemPrompt, type StableSystemParts } from './system-prompt.js';
 
 export type CwdDependentsFactory = (newCwd: string) => {
   userSystem: string;
@@ -23,7 +23,7 @@ export type CwdDependentsFactory = (newCwd: string) => {
 };
 
 export interface CwdDependentsFactoryArgs {
-  stableSystemPrefix: string[];
+  stableSystemPrefix: StableSystemParts;
   config: AgentConfig;
   surface: string;
   runtimeStateSource: RuntimeStateSource;

--- a/src/agent/providers/anthropic-direct/query/system-prompt.test.ts
+++ b/src/agent/providers/anthropic-direct/query/system-prompt.test.ts
@@ -1,10 +1,15 @@
 /**
  * Unit tests for the shared system-prompt assembler
- * (query/system-prompt.ts). These lock the seam that closes the
- * "assembled twice" duplication (#362): the first-turn path (index.ts) and the
- * on-cwd-change rebuild (cwd-dependents.ts) both route through
- * `assembleSystemPrompt`, so the env fragment lands at the same position and
- * the stable prefix is built identically on both paths.
+ * (query/system-prompt.ts). These lock two things:
+ *
+ *  1. The "assembled twice" seam (#362): the first-turn path (index.ts) and the
+ *     on-cwd-change rebuild (cwd-dependents.ts) both route through
+ *     `assembleSystemPrompt`, so the env fragment lands at the same position and
+ *     the stable parts are built identically on both paths.
+ *  2. The top-level ORDER: the `# Agent AFK` doctrine (carried in `userSystem`)
+ *     appears after the tool/runtime conventions but BEFORE the cross-session
+ *     memory (instructions + `<cross-session-memory>` hot-memory block) and the
+ *     skill manifest. This is the ordering guarantee this module owns.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -22,64 +27,99 @@ const IDENTITY: EnvironmentIdentity = {
   workspace: null,
 };
 
+/** Distinct, collision-free sentinels for each top-level part. */
+const FULL = {
+  toolBase: 'TOOL',
+  memoryPrompt: 'MEM',
+  hotMemory: 'HOT',
+  manifest: 'MANIFEST',
+  userSystem: 'DOCTRINE',
+};
+
 describe('buildStableSystemPrefix', () => {
-  it('always includes toolBase + memoryPrompt in order', () => {
-    const parts = buildStableSystemPrefix({
-      toolBase: 'TOOL',
-      memoryPrompt: 'MEM',
-      manifest: '',
-      userSystem: null,
-    });
-    expect(parts).toEqual(['TOOL', 'MEM']);
-  });
-
-  it('omits empty manifest and null/empty userSystem', () => {
-    expect(
-      buildStableSystemPrefix({ toolBase: 'T', memoryPrompt: 'M', manifest: '', userSystem: '' }),
-    ).toEqual(['T', 'M']);
-    expect(
-      buildStableSystemPrefix({ toolBase: 'T', memoryPrompt: 'M', manifest: '', userSystem: null }),
-    ).toEqual(['T', 'M']);
-  });
-
-  it('appends manifest then userSystem when present, in that order', () => {
-    const parts = buildStableSystemPrefix({
-      toolBase: 'T',
-      memoryPrompt: 'M',
-      manifest: 'MANIFEST',
-      userSystem: 'USER',
-    });
-    expect(parts).toEqual(['T', 'M', 'MANIFEST', 'USER']);
+  it('captures the cwd-independent named parts', () => {
+    expect(buildStableSystemPrefix(FULL)).toEqual(FULL);
   });
 });
 
-describe('assembleSystemPrompt', () => {
-  it('splices the # Environment fragment at index 2 (between memoryPrompt and the rest)', () => {
-    const prefix = buildStableSystemPrefix({
-      toolBase: 'TOOL',
-      memoryPrompt: 'MEM',
-      manifest: 'MANIFEST',
-      userSystem: 'USER',
-    });
-    const out = assembleSystemPrompt(prefix, '/tmp/work', IDENTITY);
+describe('assembleSystemPrompt — top-level order', () => {
+  it('orders: toolBase, userSystem (doctrine), memoryPrompt, hotMemory, # Environment, manifest', () => {
+    const out = assembleSystemPrompt(buildStableSystemPrefix(FULL), '/tmp/work', IDENTITY);
+    const sections = out.split('\n\n');
+    expect(sections[0]).toBe('TOOL');
+    expect(sections[1]).toBe('DOCTRINE');
+    expect(sections[2]).toBe('MEM');
+    expect(sections[3]).toBe('HOT');
+    // formatEnvironmentFragment always emits the working-directory line.
+    expect(sections[4]).toContain('Working directory: /tmp/work');
+    expect(sections[5]).toBe('MANIFEST');
+  });
+
+  it('places the doctrine after tool conventions but before cross-session memory and the skill manifest', () => {
+    const out = assembleSystemPrompt(buildStableSystemPrefix(FULL), '/x', IDENTITY);
+    const iTool = out.indexOf('TOOL');
+    const iDoctrine = out.indexOf('DOCTRINE');
+    const iMemInstructions = out.indexOf('MEM');
+    const iHotMemory = out.indexOf('HOT');
+    const iManifest = out.indexOf('MANIFEST');
+    // after essential runtime/tool conventions
+    expect(iTool).toBeGreaterThanOrEqual(0);
+    expect(iTool).toBeLessThan(iDoctrine);
+    // before cross-session memory (instructions AND hot-memory project context)
+    expect(iDoctrine).toBeLessThan(iMemInstructions);
+    expect(iDoctrine).toBeLessThan(iHotMemory);
+    // before the skills catalog
+    expect(iDoctrine).toBeLessThan(iManifest);
+  });
+
+  it('keeps # Environment before the manifest even when userSystem/hotMemory are absent', () => {
+    const out = assembleSystemPrompt(
+      buildStableSystemPrefix({
+        toolBase: 'TOOL',
+        memoryPrompt: 'MEM',
+        hotMemory: '',
+        manifest: 'MANIFEST',
+        userSystem: null,
+      }),
+      '/x',
+      IDENTITY,
+    );
     const sections = out.split('\n\n');
     expect(sections[0]).toBe('TOOL');
     expect(sections[1]).toBe('MEM');
-    // formatEnvironmentFragment always emits the working-directory line.
-    expect(sections[2]).toContain('Working directory: /tmp/work');
+    expect(sections[2]).toContain('Working directory: /x');
     expect(sections[3]).toBe('MANIFEST');
-    expect(sections[4]).toBe('USER');
+  });
+
+  it('omits empty optional parts (userSystem, hotMemory, manifest)', () => {
+    const out = assembleSystemPrompt(
+      buildStableSystemPrefix({
+        toolBase: 'TOOL',
+        memoryPrompt: 'MEM',
+        hotMemory: '',
+        manifest: '',
+        userSystem: null,
+      }),
+      '/x',
+      IDENTITY,
+    );
+    const sections = out.split('\n\n');
+    expect(sections).toHaveLength(3);
+    expect(sections[0]).toBe('TOOL');
+    expect(sections[1]).toBe('MEM');
+    expect(sections[2]).toContain('Working directory: /x');
   });
 
   it('reflects the cwd in the environment fragment (only the env line changes across cwds)', () => {
-    const prefix = buildStableSystemPrefix({
+    const parts = buildStableSystemPrefix({
       toolBase: 'TOOL',
       memoryPrompt: 'MEM',
+      hotMemory: '',
       manifest: '',
       userSystem: null,
     });
-    const a = assembleSystemPrompt(prefix, '/repo/a', IDENTITY);
-    const b = assembleSystemPrompt(prefix, '/repo/b', IDENTITY);
+    const a = assembleSystemPrompt(parts, '/repo/a', IDENTITY);
+    const b = assembleSystemPrompt(parts, '/repo/b', IDENTITY);
     expect(a).toContain('Working directory: /repo/a');
     expect(b).toContain('Working directory: /repo/b');
     // Stable parts are byte-identical; only the env fragment differs.
@@ -88,29 +128,18 @@ describe('assembleSystemPrompt', () => {
     expect(a).not.toBe(b);
   });
 
-  it('handles a minimal prefix (toolBase + memoryPrompt only)', () => {
-    const prefix = buildStableSystemPrefix({
-      toolBase: 'TOOL',
-      memoryPrompt: 'MEM',
-      manifest: '',
-      userSystem: null,
-    });
-    const out = assembleSystemPrompt(prefix, '/x', IDENTITY);
-    const sections = out.split('\n\n');
-    expect(sections).toHaveLength(3);
-    expect(sections[0]).toBe('TOOL');
-    expect(sections[1]).toBe('MEM');
-    expect(sections[2]).toContain('Working directory: /x');
-  });
-
   it('appends a Session line when an identity field is known', () => {
-    const prefix = buildStableSystemPrefix({
-      toolBase: 'T',
-      memoryPrompt: 'M',
-      manifest: '',
-      userSystem: null,
-    });
-    const out = assembleSystemPrompt(prefix, '/x', { ...IDENTITY, sessionId: 'sess-123' });
+    const out = assembleSystemPrompt(
+      buildStableSystemPrefix({
+        toolBase: 'T',
+        memoryPrompt: 'M',
+        hotMemory: '',
+        manifest: '',
+        userSystem: null,
+      }),
+      '/x',
+      { ...IDENTITY, sessionId: 'sess-123' },
+    );
     expect(out).toContain('sess-123');
   });
 });

--- a/src/agent/providers/anthropic-direct/query/system-prompt.ts
+++ b/src/agent/providers/anthropic-direct/query/system-prompt.ts
@@ -2,10 +2,16 @@
  * System-prompt assembly for {@link AnthropicDirectProvider.query}.
  *
  * The first-turn assembly (in `index.ts`) and the on-cwd-change re-assembly (in
- * `cwd-dependents.ts`) build the SAME structure — `[toolBase, memoryPrompt,
- * <# Environment fragment>, manifest?, userSystem?]` joined by blank lines.
- * Only the `# Environment` fragment varies with cwd. Centralizing both paths
- * here closes the "assembled twice" duplication so they can never drift.
+ * `cwd-dependents.ts`) build the SAME structure via {@link assembleSystemPrompt}
+ * so the two can never drift. Only the `# Environment` fragment varies with cwd.
+ *
+ * Invariant: top-level order is
+ *   `[toolBase, userSystem?, memoryPrompt, hotMemory?, <# Environment>, manifest?]`.
+ * The `# Agent AFK` doctrine + operator overlay travel in `userSystem` and are
+ * placed EARLY — right after the tool/runtime conventions and before the
+ * cross-session memory (instructions + hot-memory project context) and the
+ * skill manifest — so the operating posture is established before the reference
+ * material.
  *
  * @module agent/providers/anthropic-direct/query/system-prompt
  */
@@ -16,6 +22,11 @@ import { formatEnvironmentFragment, type RuntimeStateSource } from '../../../awa
 export interface StableSystemPromptInputs {
   toolBase: string;
   memoryPrompt: string;
+  /**
+   * `<cross-session-memory>` hot-memory block (project context); empty string
+   * when none. Placed in the cross-session-memory region, after `memoryPrompt`.
+   */
+  hotMemory: string;
   /** Skill/agent manifest block; empty string when none. */
   manifest: string;
   /** Operator system-prompt overlay; empty string or null when none. */
@@ -23,16 +34,20 @@ export interface StableSystemPromptInputs {
 }
 
 /**
- * The cwd-independent prefix, in order: `[toolBase, memoryPrompt, manifest?,
- * userSystem?]`. The cwd-dependent `# Environment` fragment is deliberately NOT
- * included — {@link assembleSystemPrompt} splices it in at index 2 so it can be
- * recomputed on every cwd change without rebuilding the stable parts.
+ * The cwd-independent named parts, captured once and reused across every cwd
+ * rebuild. The cwd-dependent `# Environment` fragment is deliberately NOT
+ * included — {@link assembleSystemPrompt} splices it in on each cwd change
+ * without rebuilding the stable parts.
  */
-export function buildStableSystemPrefix(i: StableSystemPromptInputs): string[] {
-  const parts = [i.toolBase, i.memoryPrompt];
-  if (i.manifest.length > 0) parts.push(i.manifest);
-  if (i.userSystem) parts.push(i.userSystem);
-  return parts;
+export type StableSystemParts = StableSystemPromptInputs;
+
+/**
+ * Capture the cwd-independent named parts. A thin normalizer today; kept as the
+ * single construction point so the first-turn and cwd-rebuild paths share one
+ * shape. Ordering of the parts is owned by {@link assembleSystemPrompt}.
+ */
+export function buildStableSystemPrefix(i: StableSystemPromptInputs): StableSystemParts {
+  return i;
 }
 
 /**
@@ -49,8 +64,20 @@ export interface EnvironmentIdentity {
 }
 
 /**
- * Assemble the full system prompt: splice the cwd-dependent `# Environment`
- * fragment into position 2 of the stable prefix and join with blank lines.
+ * Assemble the full system prompt from the cwd-independent parts plus the
+ * cwd-dependent `# Environment` fragment, joined by blank lines.
+ *
+ * Order (see the module Invariant):
+ *   1. `toolBase`     — tool/runtime conventions
+ *   2. `userSystem`   — `# Agent AFK` doctrine + operator overlay + directives
+ *   3. `memoryPrompt` — cross-session-memory instructions
+ *   4. `hotMemory`    — `<cross-session-memory>` project-context block
+ *   5. `# Environment`— cwd/session/workspace (recomputed per cwd)
+ *   6. `manifest`     — skill/agent catalog
+ * Optional parts (`userSystem`, `hotMemory`, `manifest`) are skipped when
+ * empty; `# Environment` is inserted before `manifest` by name rather than a
+ * fixed index, so it stays correctly positioned regardless of which optional
+ * parts are present.
  *
  * `formatEnvironmentFragment` always emits `- Working directory: <cwd>`,
  * conditionally appends `- Session: <id> (...)` when an identity field is
@@ -59,22 +86,23 @@ export interface EnvironmentIdentity {
  * cwd rebuild (`cwd-dependents.ts`) so the two never diverge.
  */
 export function assembleSystemPrompt(
-  stableSystemPrefix: string[],
+  parts: StableSystemParts,
   cwd: string,
   identity: EnvironmentIdentity,
 ): string {
-  const parts = [
-    stableSystemPrefix[0]!,
-    stableSystemPrefix[1]!,
-    formatEnvironmentFragment({
-      cwd,
-      ...(identity.sessionId !== undefined ? { sessionId: identity.sessionId } : {}),
-      surface: identity.surface,
-      ...(identity.depth !== undefined ? { depth: identity.depth } : {}),
-      ...(identity.maxDepth !== undefined ? { maxDepth: identity.maxDepth } : {}),
-      workspace: identity.workspace,
-    }),
-    ...stableSystemPrefix.slice(2),
-  ];
-  return parts.join('\n\n');
+  const environment = formatEnvironmentFragment({
+    cwd,
+    ...(identity.sessionId !== undefined ? { sessionId: identity.sessionId } : {}),
+    surface: identity.surface,
+    ...(identity.depth !== undefined ? { depth: identity.depth } : {}),
+    ...(identity.maxDepth !== undefined ? { maxDepth: identity.maxDepth } : {}),
+    workspace: identity.workspace,
+  });
+  const ordered: string[] = [parts.toolBase];
+  if (parts.userSystem) ordered.push(parts.userSystem);
+  ordered.push(parts.memoryPrompt);
+  if (parts.hotMemory.length > 0) ordered.push(parts.hotMemory);
+  ordered.push(environment);
+  if (parts.manifest.length > 0) ordered.push(parts.manifest);
+  return ordered.join('\n\n');
 }

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -313,15 +313,25 @@ export class OpenAICompatibleProvider implements ModelProvider {
     // slash/bash) envelopes mean. The tool/memory fragments are resolved via
     // the shared helpers in tools/system-prompt.ts so the set cannot drift from
     // anthropic-direct. Ordering mirrors AnthropicDirectProvider.query():
-    // [toolBase, memoryPrompt, env, manifest?, userSystem?].
+    // [toolBase, userSystem?, memoryPrompt, hotMemory?, env, manifest?]. The
+    // `# Agent AFK` doctrine + operator overlay (`existingSys`) is placed EARLY
+    // — right after the tool conventions and before the cross-session memory
+    // (instructions + hot-memory project context) and the skill manifest. Hot
+    // memory rides `config.hotMemory` (a dedicated field), not prepended into
+    // systemPrompt, so it can sit after the memory instructions rather than
+    // ahead of the doctrine.
     const toolBase = resolveToolSystemPrompt(config.isSkillDispatch);
     const memoryPrompt = resolveMemorySystemPrompt(this.providerOpts.readOnlyMemory);
     const manifest = this.providerOpts.skillExecutor ? buildSkillManifest() : '';
+    const hotMemory = typeof config.hotMemory === 'string' ? config.hotMemory : '';
     const existingSys =
       typeof config.systemPrompt === 'string' ? config.systemPrompt : undefined;
-    const systemParts = [toolBase, memoryPrompt, envFragment];
-    if (manifest.length > 0) systemParts.push(manifest);
+    const systemParts = [toolBase];
     if (existingSys !== undefined && existingSys.length > 0) systemParts.push(existingSys);
+    systemParts.push(memoryPrompt);
+    if (hotMemory.length > 0) systemParts.push(hotMemory);
+    systemParts.push(envFragment);
+    if (manifest.length > 0) systemParts.push(manifest);
     const patchedConfig: typeof config = {
       ...config,
       systemPrompt: systemParts.join('\n\n'),

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -318,6 +318,53 @@ describe('OpenAICompatibleProvider — readOnlyMemory option', () => {
   });
 });
 
+describe('OpenAICompatibleProvider — system-prompt assembly order', () => {
+  // Mirrors the anthropic-direct assembler: the # Agent AFK doctrine
+  // (config.systemPrompt) is placed EARLY — after the tool conventions and
+  // before the cross-session memory (instructions + the <cross-session-memory>
+  // hot-memory block carried on config.hotMemory) and the # Environment
+  // reference. Manifest ordering (pushed last) is locked with deterministic
+  // sentinels in query/system-prompt.test.ts.
+  it('places the doctrine after tool conventions but before cross-session memory and hot memory', async () => {
+    pendingChunks = [
+      {
+        choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      },
+    ];
+    const provider = new OpenAICompatibleProvider();
+    const q = provider.query({
+      prompt: singleInput('hi'),
+      config: {
+        model: 'gpt-4o-mini',
+        apiKey: 'sk-test-key',
+        systemPrompt: 'DOCTRINE_SENTINEL',
+        hotMemory: 'HOT_SENTINEL',
+      } as AgentConfig,
+    });
+    await collect(q);
+
+    expect(createCalls).toHaveLength(1);
+    const args = createCalls[0]!.args as { messages: Array<{ role: string; content: string }> };
+    expect(args.messages[0]!.role).toBe('system');
+    const s = args.messages[0]!.content;
+    const iTool = s.indexOf('You have access to tools for working with the filesystem');
+    const iDoctrine = s.indexOf('DOCTRINE_SENTINEL');
+    const iMem = s.indexOf('# Cross-Session Memory');
+    const iHot = s.indexOf('HOT_SENTINEL');
+    const iEnv = s.indexOf('Working directory');
+    expect(iTool).toBeGreaterThanOrEqual(0);
+    expect(iDoctrine).toBeGreaterThanOrEqual(0);
+    expect(iMem).toBeGreaterThanOrEqual(0);
+    expect(iHot).toBeGreaterThanOrEqual(0);
+    expect(iEnv).toBeGreaterThanOrEqual(0);
+    expect(iTool).toBeLessThan(iDoctrine); // after essential runtime/tool conventions
+    expect(iDoctrine).toBeLessThan(iMem); // before cross-session memory instructions
+    expect(iDoctrine).toBeLessThan(iHot); // before hot-memory project context
+    expect(iDoctrine).toBeLessThan(iEnv); // before the # Environment reference block
+  });
+});
+
 describe('OpenAICompatibleProvider — plan-mode gate via config.hookRegistry', () => {
   // Mirrors the anthropic-direct gate-wiring regression: a provider built
   // WITHOUT a constructor-time hookRegistry (production shape) must still

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -214,6 +214,19 @@ export interface AgentConfig {
   systemPromptSource?: string;
 
   /**
+   * Hot-memory block (HOT.md wrapped in `<cross-session-memory>` tags),
+   * populated by {@link injectHotMemory} at the top-level surfaces. Carried
+   * as its own field — NOT prepended into {@link systemPrompt} — so the
+   * provider can place it in the cross-session-memory region of the assembled
+   * prompt (after the memory instructions) independently of where the
+   * `# Agent AFK` doctrine + operator overlay (`systemPrompt`) is placed.
+   *
+   * Unset for child sessions (subagents / skills never inject hot memory).
+   * Empty / whitespace is treated as absent by the provider assembler.
+   */
+  hotMemory?: string;
+
+  /**
    * MCP server config — typed entry-point for `~/.afk/config/mcp.json`.
    *
    * Populated by `loadMcpConfig()` and consumed by the bootstrap path

--- a/tests/agent/memory/memory-loader.test.ts
+++ b/tests/agent/memory/memory-loader.test.ts
@@ -1,5 +1,12 @@
 /**
- * Tests for src/agent/memory/memory-loader.ts — hot memory injection into system prompt.
+ * Tests for src/agent/memory/memory-loader.ts — hot memory injection.
+ *
+ * Invariant: hot memory (HOT.md) is carried on the dedicated `config.hotMemory`
+ * field, NOT prepended into `config.systemPrompt`. The provider assembler then
+ * places the `<cross-session-memory>` block in the cross-session-memory region
+ * (after the memory instructions) while the `# Agent AFK` doctrine + operator
+ * overlay (systemPrompt) is placed early — see
+ * `providers/anthropic-direct/query/system-prompt.ts`.
  *
  * Points HOME at a tmp dir so nothing touches the real ~/.afk.
  */
@@ -75,17 +82,18 @@ describe('loadHotMemory', () => {
 });
 
 describe('injectHotMemory', () => {
-  it('returns config unchanged when no HOT.md exists', () => {
+  it('returns config unchanged (no hotMemory) when no HOT.md exists', () => {
     const config: AgentConfig = {
       model: 'sonnet',
       systemPrompt: 'Base prompt',
     };
 
     const result = injectHotMemory(config);
-    expect(result).toEqual(config);
+    expect(result).toBe(config);
+    expect(result.hotMemory).toBeUndefined();
   });
 
-  it('prepends memory block to string systemPrompt', () => {
+  it('stores the memory block on config.hotMemory, NOT prepended into systemPrompt', () => {
     const hotPath = join(tmpHome, '.afk', 'state', 'memory', 'HOT.md');
     const hotContent = 'Previous session: user prefers brevity';
     writeFileSync(hotPath, hotContent, 'utf-8');
@@ -96,55 +104,36 @@ describe('injectHotMemory', () => {
     };
 
     const result = injectHotMemory(config);
-    expect(result.systemPrompt).toBe(
-      `<cross-session-memory>\n${hotContent}\n</cross-session-memory>\n\nBase system prompt`,
+    // Hot memory rides its own field so the assembler can place it in the
+    // cross-session-memory region rather than ahead of the # Agent AFK doctrine.
+    expect(result.hotMemory).toBe(
+      `<cross-session-memory>\n${hotContent}\n</cross-session-memory>`,
     );
+    // systemPrompt (the doctrine + operator overlay) is left untouched.
+    expect(result.systemPrompt).toBe('Base system prompt');
+    expect(result.systemPrompt).not.toContain('<cross-session-memory>');
   });
 
-  it('appends to append field when systemPrompt is preset', () => {
+  it('leaves a preset systemPrompt untouched and carries hot memory on config.hotMemory', () => {
     const hotPath = join(tmpHome, '.afk', 'state', 'memory', 'HOT.md');
     const hotContent = 'Important context from previous session';
     writeFileSync(hotPath, hotContent, 'utf-8');
 
-    const config: AgentConfig = {
-      model: 'sonnet',
-      systemPrompt: {
-        type: 'preset',
-        preset: 'claude_code',
-        append: 'Extra instructions',
-      },
+    const preset = {
+      type: 'preset' as const,
+      preset: 'claude_code' as const,
+      append: 'Extra instructions',
     };
+    const config: AgentConfig = { model: 'sonnet', systemPrompt: { ...preset } };
 
     const result = injectHotMemory(config);
-    expect(result.systemPrompt).toEqual({
-      type: 'preset',
-      preset: 'claude_code',
-      append: `<cross-session-memory>\n${hotContent}\n</cross-session-memory>\n\nExtra instructions`,
-    });
+    expect(result.systemPrompt).toEqual(preset);
+    expect(result.hotMemory).toBe(
+      `<cross-session-memory>\n${hotContent}\n</cross-session-memory>`,
+    );
   });
 
-  it('appends to append field when no append exists', () => {
-    const hotPath = join(tmpHome, '.afk', 'state', 'memory', 'HOT.md');
-    const hotContent = 'Context data';
-    writeFileSync(hotPath, hotContent, 'utf-8');
-
-    const config: AgentConfig = {
-      model: 'sonnet',
-      systemPrompt: {
-        type: 'preset',
-        preset: 'claude_code',
-      },
-    };
-
-    const result = injectHotMemory(config);
-    expect(result.systemPrompt).toEqual({
-      type: 'preset',
-      preset: 'claude_code',
-      append: `<cross-session-memory>\n${hotContent}\n</cross-session-memory>\n\n`,
-    });
-  });
-
-  it('sets systemPrompt when undefined', () => {
+  it('carries hot memory on config.hotMemory when systemPrompt is undefined (systemPrompt stays undefined)', () => {
     const hotPath = join(tmpHome, '.afk', 'state', 'memory', 'HOT.md');
     const hotContent = 'Memory block content';
     writeFileSync(hotPath, hotContent, 'utf-8');
@@ -154,9 +143,22 @@ describe('injectHotMemory', () => {
     };
 
     const result = injectHotMemory(config);
-    expect(result.systemPrompt).toBe(
+    expect(result.systemPrompt).toBeUndefined();
+    expect(result.hotMemory).toBe(
       `<cross-session-memory>\n${hotContent}\n</cross-session-memory>`,
     );
+  });
+
+  it('strips any pre-existing <cross-session-memory> tags before re-wrapping (no double-wrap)', () => {
+    const hotPath = join(tmpHome, '.afk', 'state', 'memory', 'HOT.md');
+    writeFileSync(hotPath, '<cross-session-memory>\nInner\n</cross-session-memory>', 'utf-8');
+
+    const config: AgentConfig = { model: 'sonnet', systemPrompt: 'Base' };
+    const result = injectHotMemory(config);
+    const opens = (result.hotMemory?.match(/<cross-session-memory>/g) ?? []).length;
+    const closes = (result.hotMemory?.match(/<\/cross-session-memory>/g) ?? []).length;
+    expect(opens).toBe(1);
+    expect(closes).toBe(1);
   });
 
   it('does not mutate the original config', () => {
@@ -170,9 +172,9 @@ describe('injectHotMemory', () => {
     const configBefore = JSON.stringify(config);
 
     injectHotMemory(config);
-    const configAfter = JSON.stringify(config);
 
-    expect(configBefore).toBe(configAfter);
+    expect(JSON.stringify(config)).toBe(configBefore);
+    expect(config.hotMemory).toBeUndefined();
   });
 
   it('preserves all other config fields', () => {
@@ -192,5 +194,6 @@ describe('injectHotMemory', () => {
     expect(result.apiKey).toBe('sk-test');
     expect(result.maxTurns).toBe(100);
     expect(result.timeoutMs).toBe(5000);
+    expect(result.systemPrompt).toBe('Base');
   });
 });


### PR DESCRIPTION
## Summary

Moves the complete **`# Agent AFK` operating-doctrine block** earlier in the
assembled system prompt. Previously the doctrine sat **dead last** — after the
memory instructions, the `<cross-session-memory>` hot-memory block, the
`# Environment` fragment, and the entire skills catalog. It now appears
immediately after the tool/runtime conventions, ahead of the cross-session
memory and the skills catalog.

This is **strictly an ordering change**. No doctrine, memory, or skill-description
wording was rewritten, shortened, or deduplicated. The only mechanical adjustment
was moving the hot-memory block onto its own `AgentConfig.hotMemory` field so it
can be positioned independently of the doctrine (see below).

## Why the ordering matters

The `# Agent AFK` block defines the agent's operating posture — objective states,
the observe/model/choose/act/update loop, delegation rules, constraints, and
priorities. Establishing that posture **before** the reference material
(cross-session memory, project context, the long skills catalog) means the
model reads *how to operate* before *what it can reach*, rather than wading
through ~43K characters of memory + manifest first. It also places the doctrine
in the high-attention region near the top of the prompt.

## Old vs. new high-level assembly order

Both providers (`AnthropicDirectProvider`, `OpenAICompatibleProvider`) assemble
the same top-level structure. The doctrine + operator overlay + routing/end-of-turn
directives travel together in the `systemPrompt` string (`userSystem`).

**Before**
```
1. tool/runtime conventions        (toolBase)
2. # Cross-Session Memory          (memory instructions)
3. # Environment                   (cwd/session/workspace)
4. Available skills catalog        (manifest)
5. <cross-session-memory> hot block + # Agent AFK doctrine + # Operator config
```

**After**
```
1. tool/runtime conventions        (toolBase)
2. # Agent AFK doctrine + # Operator config + directives   (userSystem)
3. # Cross-Session Memory + <cross-session-memory> hot block
4. # Environment + Available skills catalog
5. user turn
```

## How

The doctrine (`systemPrompt`) was welded to a **prepended** hot-memory block by
`injectHotMemory`, so it could not move without dragging the memory block ahead
of it. Fix:

- `injectHotMemory` now stores HOT.md on a dedicated `AgentConfig.hotMemory`
  field instead of prepending it into `systemPrompt`.
- Both provider assemblers place `userSystem` (doctrine) right after `toolBase`,
  and place `hotMemory` in the cross-session-memory region (after the memory
  instructions).
- `assembleSystemPrompt` now consumes a named-parts struct and inserts the
  cwd-dependent `# Environment` fragment **by name** (robust to optional parts),
  replacing the previous fixed index-2 splice. The cwd-rebuild path
  (`cwd-dependents.ts`) is preserved.
- Provenance (`--dump-prompt` source string) and dump behavior are unchanged.

Shared seam → the effective order changes on **every** surface that routes
through the providers: CLI one-shot, REPL, Telegram, daemon, and subagents.

## Exact files changed

| File | Change |
|------|--------|
| `src/agent/types/config-types.ts` | Add optional `hotMemory` field to `AgentConfig`. |
| `src/agent/memory/memory-loader.ts` | `injectHotMemory` sets `config.hotMemory` instead of prepending into `systemPrompt`. |
| `src/agent/providers/anthropic-direct/query/system-prompt.ts` | Add `hotMemory` to inputs; `assembleSystemPrompt` reorders + inserts env by name; `buildStableSystemPrefix` returns a named struct (`StableSystemParts`). |
| `src/agent/providers/anthropic-direct/index.ts` | Pass `config.hotMemory` into the stable prefix. |
| `src/agent/providers/anthropic-direct/query/cwd-dependents.ts` | `stableSystemPrefix` type `string[]` → `StableSystemParts`. |
| `src/agent/providers/openai-compatible/index.ts` | Reorder `systemParts`; read `config.hotMemory`. |
| `src/agent/providers/anthropic-direct/query/system-prompt.test.ts` | Rewritten for the new order + explicit relative-ordering assertion. |
| `src/agent/providers/openai-compatible/query.test.ts` | New provider-level ordering test. |
| `tests/agent/memory/memory-loader.test.ts` | Updated to the `hotMemory`-field contract. |

## Tests run and results

- Targeted: `system-prompt.test.ts` (anthropic assembler), `query.test.ts`
  (openai provider), `tests/agent/memory/memory-loader.test.ts` — all pass.
- **Full suite** (`vitest run`): **658 files, 11995 passed, 14 skipped, 0 failed.**
- `pnpm lint` (`tsc --noEmit`): clean.
- CI gates: `audit:sdk:check` OK, `audit:env:check` 0 violations, `scan:env:check` in sync.

New/updated ordering tests assert, on both providers, that the `# Agent AFK`
doctrine appears **after** the tool conventions but **before** the cross-session
memory (instructions + hot block) and the skills catalog.

## Runtime evidence (`--dump-prompt`, not just source order)

Captured the effective assembled prompt before and after via
`afk chat --provider anthropic-direct --dump-prompt` (offsets into `options.system`):

**Before**
```
 1      0  toolBase
 2   3418  # Cross-Session Memory
 3   5830  # Environment
 4   6080  Available skills
 5  47392  <cross-session-memory> hot block
 6  49181  # Agent AFK doctrine        <-- last
 7  59655  # Operator configuration
```

**After**
```
 1      0  toolBase
 2   3418  # Agent AFK doctrine         <-- now second
 3  13892  # Operator configuration
 4  26877  # Cross-Session Memory
 5  29312  <cross-session-memory> hot block
 6  31101  # Environment
 7  31353  Available skills
```

## Confirmation: wording & capability behavior otherwise unchanged

Diffing the two runtime dumps, the non-blank **line multisets are identical**
after normalizing the single dynamic `- Workspace:` line (a live git dirty-count
that legitimately differed between the two capture moments). Every doctrine,
memory, operator-config, hot-memory, and manifest passage is byte-for-byte
present in both — the prompts differ **only** in top-level order (plus one extra
`\n\n` separator now that hot memory is its own segment). No tool/skill schemas,
routing directives, or capability behavior changed.
