### PR TITLE
feat(hooks): discover and run Claude Code plugin hooks.json (#70)

### DIFF
--- a/src/agent/hooks/command-executor.test.ts
+++ b/src/agent/hooks/command-executor.test.ts
@@ -355,6 +355,45 @@ fi
     expect(result.decision.decision).toBe('approve');
   });
 
+  it('CLAUDE_PLUGIN_ROOT is set to pluginRoot for a plugin-contributed hook', async () => {
+    const pluginDir = join(tmp, 'demo-plugin');
+    const scriptPath = join(tmp, 'check-plugin-root.sh');
+    writeFileSync(
+      scriptPath,
+      `#!/bin/sh
+if [ "$CLAUDE_PLUGIN_ROOT" = "${pluginDir}" ]; then
+  echo '{"decision":"approve"}'
+else
+  echo "wrong root: $CLAUDE_PLUGIN_ROOT" >&2
+  exit 2
+fi
+`,
+      'utf-8',
+    );
+    chmodSync(scriptPath, 0o755);
+    const result = await executeCommand({ ...makeOpts(scriptPath), pluginRoot: pluginDir });
+    expect(result.decision.decision).toBe('approve');
+  });
+
+  it('CLAUDE_PLUGIN_ROOT is NOT set for a non-plugin hook (no pluginRoot)', async () => {
+    const scriptPath = join(tmp, 'check-no-plugin-root.sh');
+    writeFileSync(
+      scriptPath,
+      `#!/bin/sh
+if [ -z "$CLAUDE_PLUGIN_ROOT" ]; then
+  echo '{"decision":"approve"}'
+else
+  echo "unexpected root: $CLAUDE_PLUGIN_ROOT" >&2
+  exit 2
+fi
+`,
+      'utf-8',
+    );
+    chmodSync(scriptPath, 0o755);
+    const result = await executeCommand(makeOpts(scriptPath));
+    expect(result.decision.decision).toBe('approve');
+  });
+
   // -----------------------------------------------------------------------
   // F2 regression: secret env vars must NOT be forwarded to hook subprocess
   // -----------------------------------------------------------------------

--- a/src/agent/hooks/command-executor.test.ts
+++ b/src/agent/hooks/command-executor.test.ts
@@ -375,15 +375,34 @@ fi
     expect(result.decision.decision).toBe('approve');
   });
 
-  it('CLAUDE_PLUGIN_ROOT is NOT set for a non-plugin hook (no pluginRoot)', async () => {
+  it('CLAUDE_PROJECT_DIR is set to agentCwd for a plugin-contributed hook', async () => {
+    const scriptPath = join(tmp, 'check-project-dir.sh');
+    writeFileSync(
+      scriptPath,
+      `#!/bin/sh
+if [ "$CLAUDE_PROJECT_DIR" = "${tmp}" ]; then
+  echo '{"decision":"approve"}'
+else
+  echo "wrong project dir: $CLAUDE_PROJECT_DIR" >&2
+  exit 2
+fi
+`,
+      'utf-8',
+    );
+    chmodSync(scriptPath, 0o755);
+    const result = await executeCommand({ ...makeOpts(scriptPath), pluginRoot: join(tmp, 'demo-plugin') });
+    expect(result.decision.decision).toBe('approve');
+  });
+
+  it('CLAUDE_PLUGIN_ROOT and CLAUDE_PROJECT_DIR are NOT set for a non-plugin hook (no pluginRoot)', async () => {
     const scriptPath = join(tmp, 'check-no-plugin-root.sh');
     writeFileSync(
       scriptPath,
       `#!/bin/sh
-if [ -z "$CLAUDE_PLUGIN_ROOT" ]; then
+if [ -z "$CLAUDE_PLUGIN_ROOT" ] && [ -z "$CLAUDE_PROJECT_DIR" ]; then
   echo '{"decision":"approve"}'
 else
-  echo "unexpected root: $CLAUDE_PLUGIN_ROOT" >&2
+  echo "unexpected plugin vars: root=$CLAUDE_PLUGIN_ROOT dir=$CLAUDE_PROJECT_DIR" >&2
   exit 2
 fi
 `,

--- a/src/agent/hooks/command-executor.ts
+++ b/src/agent/hooks/command-executor.ts
@@ -39,6 +39,14 @@ export interface ExecuteCommandOptions {
   agentCwd: string;
   sessionId?: string;
   timeoutMs: number;
+  /**
+   * Absolute plugin root for a plugin-contributed hook (Claude Code compat).
+   * When set, the executor exports `CLAUDE_PLUGIN_ROOT` and `CLAUDE_PROJECT_DIR`
+   * so plugin hook commands referencing `${CLAUDE_PLUGIN_ROOT}` resolve their
+   * bundled script paths. Undefined for user-global / project-local config
+   * hooks (they use AFK's own `AFK_PROJECT_DIR`).
+   */
+  pluginRoot?: string;
 }
 
 export interface CommandExecutorResult {
@@ -154,6 +162,14 @@ export async function executeCommand(
   childEnv['AFK_SESSION_ID'] = sessionId ?? '';
   childEnv['AFK_HOOK_EVENT'] = context.event;
   childEnv['AFK_TOOL_NAME'] = toolName;
+  // Claude Code plugin-hook compatibility: when this hook was contributed by a
+  // plugin, export the documented plugin path vars so `${CLAUDE_PLUGIN_ROOT}`
+  // (and `${CLAUDE_PROJECT_DIR}`) in the command resolve. These are non-secret
+  // paths, safe to forward, and set only for plugin-sourced hooks.
+  if (opts.pluginRoot !== undefined) {
+    childEnv['CLAUDE_PLUGIN_ROOT'] = opts.pluginRoot;
+    childEnv['CLAUDE_PROJECT_DIR'] = agentCwd;
+  }
   // Deliberate omission: no AFK_TOOL_ERROR env var for PostToolUseFailure.
   // The error string is available in the stdin JSON payload under the 'error'
   // key. Injecting it as an env var risks shell-injection if the error message

--- a/src/agent/hooks/config-bridge.test.ts
+++ b/src/agent/hooks/config-bridge.test.ts
@@ -34,6 +34,7 @@ function makeEnabledConfig(overrides: Partial<LoadedHooksConfig> = {}): LoadedHo
     hooks: {},
     userGlobalEnabled: true,
     allowProjectHooks: false,
+    pluginHooksEnabled: false,
     sources: [],
     warnings: [],
     ...overrides,
@@ -45,6 +46,7 @@ function makeDisabledConfig(overrides: Partial<LoadedHooksConfig> = {}): LoadedH
     hooks: {},
     userGlobalEnabled: false,
     allowProjectHooks: false,
+    pluginHooksEnabled: false,
     sources: [],
     warnings: [],
     ...overrides,
@@ -53,8 +55,8 @@ function makeDisabledConfig(overrides: Partial<LoadedHooksConfig> = {}): LoadedH
 
 /** Helper: build a ResolvedMatcherGroup with a default tier. */
 function makeGroup(
-  hooks: Array<{ type: 'command'; command: string; timeoutMs: number }>,
-  opts: { matcher?: string; tier?: 'user-global' | 'project-local' } = {},
+  hooks: Array<{ type: 'command'; command: string; timeoutMs: number; pluginRoot?: string }>,
+  opts: { matcher?: string; tier?: 'user-global' | 'project-local' | 'plugin' } = {},
 ) {
   return {
     ...(opts.matcher !== undefined ? { matcher: opts.matcher } : {}),
@@ -456,5 +458,82 @@ describe('createDefaultHookRegistry integration', () => {
       { cwd: projectCwd },
     );
     expect(registry.count('SessionStart')).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Plugin-tier hooks (Claude Code compat) — independent of enableShellHooks
+// ---------------------------------------------------------------------------
+
+describe('plugin-tier hooks', () => {
+  it('plugin-tier group registers even when userGlobalEnabled is false', () => {
+    const registry = createHookRegistry();
+    const config = makeDisabledConfig({
+      pluginHooksEnabled: true,
+      hooks: {
+        SessionStart: [
+          makeGroup(
+            [{ type: 'command', command: 'exit 0', timeoutMs: 3000 }],
+            { tier: 'plugin' },
+          ),
+        ],
+      },
+    });
+    loadAndRegisterConfigHooks(registry, config, { cwd: tmp });
+    expect(registry.count('SessionStart')).toBe(1);
+  });
+
+  it('non-plugin hooks stay gated while a plugin hook registers (mixed config)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const registry = createHookRegistry();
+    const config = makeDisabledConfig({
+      pluginHooksEnabled: true,
+      hooks: {
+        SessionStart: [
+          // user-global group — gated behind enableShellHooks (off) → skipped
+          makeGroup([{ type: 'command', command: 'echo shell', timeoutMs: 3000 }], {
+            tier: 'user-global',
+          }),
+          // plugin group — registers regardless
+          makeGroup([{ type: 'command', command: 'exit 0', timeoutMs: 3000 }], {
+            tier: 'plugin',
+          }),
+        ],
+      },
+    });
+    loadAndRegisterConfigHooks(registry, config, { cwd: tmp });
+    // Only the plugin hook registered; the shell hook was skipped.
+    expect(registry.count('SessionStart')).toBe(1);
+    // Warning names the skipped shell hook (not the plugin one).
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('echo shell'));
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('exit 0'));
+  });
+
+  it('CLAUDE_PLUGIN_ROOT is exported to a plugin hook command', async () => {
+    const pluginRoot = join(tmp, 'demo-plugin');
+    // Script echoes $CLAUDE_PLUGIN_ROOT back as additionalContext.
+    const scriptPath = writeScript(
+      'emit-root.sh',
+      '#!/bin/sh\necho "{\\"hookSpecificOutput\\":{\\"additionalContext\\":\\"$CLAUDE_PLUGIN_ROOT\\"}}"\n',
+    );
+    const registry = createHookRegistry();
+    const config = makeDisabledConfig({
+      pluginHooksEnabled: true,
+      hooks: {
+        SubagentStop: [
+          makeGroup(
+            [{ type: 'command', command: scriptPath, timeoutMs: 5000, pluginRoot }],
+            { tier: 'plugin' },
+          ),
+        ],
+      },
+    });
+    loadAndRegisterConfigHooks(registry, config, { cwd: tmp });
+    const result = await registry.dispatch({
+      event: 'SubagentStop',
+      subagentId: 'sa-1',
+      status: 'succeeded',
+    });
+    expect(result.injectContext).toBe(pluginRoot);
   });
 });

--- a/src/agent/hooks/config-bridge.ts
+++ b/src/agent/hooks/config-bridge.ts
@@ -30,39 +30,23 @@ export interface AgentConfigForBridge {
 /**
  * Register all config-driven shell hooks with `registry`.
  *
- * Returns without registering if `hookConfig.userGlobalEnabled` is false —
- * a `console.warn` lists all skipped hooks so the user can diagnose why their
- * hooks are not running.
+ * Two independent trust tiers:
+ *  - Non-plugin hooks (user-global / project-local, `tier !== 'plugin'`) are
+ *    gated behind `hookConfig.userGlobalEnabled` (`enableShellHooks`). When it
+ *    is false they are skipped and a `console.warn` lists them so the user can
+ *    diagnose why their `afk.config.json` hooks are not running.
+ *  - Plugin hooks (`tier === 'plugin'`) are pre-filtered by the loader —
+ *    present only when `enablePluginHooks` is set — and register regardless of
+ *    `enableShellHooks`, since they are a distinct third-party trust decision.
  */
 export function loadAndRegisterConfigHooks(
   registry: HookRegistry,
   hookConfig: LoadedHooksConfig,
   agentConfig: AgentConfigForBridge,
 ): void {
-  if (!hookConfig.userGlobalEnabled) {
-    // Collect skipped hook descriptions for the warning.
-    const skipped: string[] = [];
-    for (const event of Object.keys(hookConfig.hooks) as HarnessHookEvent[]) {
-      const groups = hookConfig.hooks[event];
-      if (groups === undefined) continue;
-      for (const group of groups) {
-        for (const hook of group.hooks) {
-          skipped.push(`${event}: ${hook.command}`);
-        }
-      }
-    }
-    if (skipped.length > 0) {
-      console.warn(
-        `[hooks] shell hooks are disabled (enableShellHooks not set in user-global config).\n` +
-          `Skipped ${skipped.length} hook(s):\n` +
-          skipped.map((s) => `  - ${s}`).join('\n'),
-      );
-    }
-    return;
-  }
-
   const agentCwd = agentConfig.cwd ?? process.cwd();
   const sessionId = agentConfig.sessionId;
+  const userGlobalEnabled = hookConfig.userGlobalEnabled;
 
   const validEvents: HarnessHookEvent[] = [
     'SessionStart',
@@ -77,17 +61,48 @@ export function loadAndRegisterConfigHooks(
     'UserPromptSubmit',
   ];
 
+  // When shell hooks are disabled, warn about the skipped NON-plugin hooks so
+  // the user can diagnose why their afk.config.json hooks are not running.
+  // Plugin hooks (tier 'plugin') still register below and are never "skipped"
+  // here — they cleared their own enablePluginHooks gate in the loader.
+  if (!userGlobalEnabled) {
+    const skipped: string[] = [];
+    for (const event of validEvents) {
+      const groups = hookConfig.hooks[event];
+      if (groups === undefined) continue;
+      for (const group of groups) {
+        if (group.tier === 'plugin') continue;
+        for (const hook of group.hooks) {
+          skipped.push(`${event}: ${hook.command}`);
+        }
+      }
+    }
+    if (skipped.length > 0) {
+      console.warn(
+        `[hooks] shell hooks are disabled (enableShellHooks not set in user-global config).\n` +
+          `Skipped ${skipped.length} hook(s):\n` +
+          skipped.map((s) => `  - ${s}`).join('\n'),
+      );
+    }
+  }
+
   for (const event of validEvents) {
     const groups = hookConfig.hooks[event];
     if (groups === undefined || groups.length === 0) continue;
 
     for (const group of groups) {
+      // Skip non-plugin groups when shell hooks are disabled. Plugin groups
+      // register regardless — their enablePluginHooks gate was enforced by the
+      // loader, which only emits plugin-tier groups when it is set.
+      if (group.tier !== 'plugin' && !userGlobalEnabled) continue;
+
       // Compile the matcher once per group — not per dispatch.
       const matchFn = compileMatcher(group.matcher);
 
       for (const hook of group.hooks) {
         const hookCommand = hook.command;
         const hookTimeoutMs = hook.timeoutMs;
+        const hookPluginRoot = hook.pluginRoot;
 
         const handler = async (context: HookContext): Promise<HookDecision> => {
           // For tool-scoped events, check the matcher against the tool name.
@@ -107,6 +122,7 @@ export function loadAndRegisterConfigHooks(
             agentCwd,
             sessionId,
             timeoutMs: hookTimeoutMs,
+            ...(hookPluginRoot !== undefined ? { pluginRoot: hookPluginRoot } : {}),
           });
 
           return result.decision;

--- a/src/agent/hooks/config-loader.test.ts
+++ b/src/agent/hooks/config-loader.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -13,6 +13,7 @@ import {
   compileMatcher,
   discoverPluginHooksConfigs,
 } from './config-loader.js';
+import { _resetPluginScanCache } from '../plugins-scanner.js';
 
 let tmp: string;
 
@@ -590,6 +591,8 @@ describe('discoverPluginHooksConfigs', () => {
   let root: string;
   beforeEach(() => {
     root = mkdtempSync(join(tmpdir(), 'plugin-hooks-'));
+    // scanLocalPlugins memoizes per-dir; reset so per-test fixtures aren't stale.
+    _resetPluginScanCache();
   });
   afterEach(() => {
     rmSync(root, { recursive: true, force: true });
@@ -606,6 +609,11 @@ describe('discoverPluginHooksConfigs', () => {
     return pluginDir;
   }
 
+  /** Write a v2 plugin index at `<base>/.index.json` (mirrors scanLocalPlugins). */
+  function writeIndex(base: string, plugins: Record<string, { enabled: boolean }>): void {
+    writeFileSync(join(base, '.index.json'), JSON.stringify({ version: 2, plugins }), 'utf-8');
+  }
+
   it('returns empty when plugins root is missing', () => {
     expect(discoverPluginHooksConfigs(join(root, 'absent'))).toEqual([]);
   });
@@ -617,9 +625,11 @@ describe('discoverPluginHooksConfigs', () => {
     ]);
   });
 
-  it('finds plugins under the marketplace-cache layout', () => {
-    const base = join(root, 'cache', 'official', 'plugins');
-    const pluginDir = makePlugin(base, 'remote-plug', true);
+  it('finds an installed marketplace-cache plugin (enabled in the index)', () => {
+    // Cache-layout plugins must be explicitly enabled in .index.json — unlike
+    // flat layout, which defaults to enabled. Mirrors scanLocalPlugins.
+    const pluginDir = makePlugin(join(root, 'cache', 'mp1'), 'plugin-a', true);
+    writeIndex(root, { 'mp1:plugin-a': { enabled: true } });
     expect(discoverPluginHooksConfigs(root)).toEqual([
       { path: join(pluginDir, 'hooks', 'hooks.json'), pluginRoot: pluginDir },
     ]);
@@ -637,6 +647,38 @@ describe('discoverPluginHooksConfigs', () => {
     writeFileSync(join(root, 'not-a-plugin', 'hooks', 'hooks.json'), '{}', 'utf-8');
     expect(discoverPluginHooksConfigs(root)).toEqual([]);
   });
+
+  it('does NOT load hooks from a plugin disabled in the index (PR 607 P1)', () => {
+    // `afk plugin disable <name>` leaves the dir on disk with enabled:false;
+    // its hooks must not run.
+    makePlugin(root, 'off-plugin', true);
+    writeIndex(root, { 'off-plugin': { enabled: false } });
+    expect(discoverPluginHooksConfigs(root)).toEqual([]);
+  });
+
+  it('does NOT load hooks from an uninstalled marketplace-cache plugin (PR 607 P1)', () => {
+    // A marketplace clone drops every listed plugin on disk; only user-installed
+    // (index-enabled) cache plugins may contribute hooks. No index entry → skip.
+    makePlugin(join(root, 'cache', 'mp1'), 'not-installed', true);
+    expect(discoverPluginHooksConfigs(root)).toEqual([]);
+  });
+
+  it('follows a symlinked plugin directory and finds its hooks (PR 607 P2)', () => {
+    // Local plugin installs are symlinked into the plugins root; discovery must
+    // follow directory symlinks (statSync), not skip them (lstatSync).
+    const realBase = mkdtempSync(join(tmpdir(), 'plugin-hooks-real-'));
+    try {
+      const target = makePlugin(realBase, 'linked-plugin', true);
+      const linkPath = join(root, 'linked-plugin');
+      symlinkSync(target, linkPath, 'dir');
+      const found = discoverPluginHooksConfigs(root);
+      expect(found).toHaveLength(1);
+      expect(found[0]!.path).toBe(join(linkPath, 'hooks', 'hooks.json'));
+      expect(found[0]!.pluginRoot).toBe(linkPath);
+    } finally {
+      rmSync(realBase, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -650,6 +692,7 @@ describe('loadHooksConfig — plugin hooks gate', () => {
   let originalAfkHome: string | undefined;
 
   beforeEach(() => {
+    _resetPluginScanCache();
     afkHome = join(tmp, 'afk-home');
     projectCwd = join(tmp, 'project');
     pluginsDir = join(tmp, 'plugins');

--- a/src/agent/hooks/config-loader.test.ts
+++ b/src/agent/hooks/config-loader.test.ts
@@ -11,6 +11,7 @@ import {
   loadHooksConfigFile,
   loadHooksConfig,
   compileMatcher,
+  discoverPluginHooksConfigs,
 } from './config-loader.js';
 
 let tmp: string;
@@ -578,5 +579,149 @@ describe('orphan root settings warning', () => {
     expect(result.userGlobalEnabled).toBe(true);
     expect(result.hooks.SessionStart).toHaveLength(1);
     expect(result.warnings.some((w) => w.includes('AFK-home root'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Plugin-contributed hook discovery (Claude Code compat)
+// ---------------------------------------------------------------------------
+
+describe('discoverPluginHooksConfigs', () => {
+  let root: string;
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'plugin-hooks-'));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function makePlugin(base: string, name: string, withHooks: boolean): string {
+    const pluginDir = join(base, name);
+    mkdirSync(join(pluginDir, '.claude-plugin'), { recursive: true });
+    writeFileSync(join(pluginDir, '.claude-plugin', 'plugin.json'), '{}', 'utf-8');
+    if (withHooks) {
+      mkdirSync(join(pluginDir, 'hooks'), { recursive: true });
+      writeFileSync(join(pluginDir, 'hooks', 'hooks.json'), '{"hooks":{}}', 'utf-8');
+    }
+    return pluginDir;
+  }
+
+  it('returns empty when plugins root is missing', () => {
+    expect(discoverPluginHooksConfigs(join(root, 'absent'))).toEqual([]);
+  });
+
+  it('finds <plugin>/hooks/hooks.json in flat layout with pluginRoot', () => {
+    const pluginDir = makePlugin(root, 'my-plugin', true);
+    expect(discoverPluginHooksConfigs(root)).toEqual([
+      { path: join(pluginDir, 'hooks', 'hooks.json'), pluginRoot: pluginDir },
+    ]);
+  });
+
+  it('finds plugins under the marketplace-cache layout', () => {
+    const base = join(root, 'cache', 'official', 'plugins');
+    const pluginDir = makePlugin(base, 'remote-plug', true);
+    expect(discoverPluginHooksConfigs(root)).toEqual([
+      { path: join(pluginDir, 'hooks', 'hooks.json'), pluginRoot: pluginDir },
+    ]);
+  });
+
+  it('skips a plugin manifest that ships no hooks/hooks.json', () => {
+    makePlugin(root, 'plain-plugin', false);
+    expect(discoverPluginHooksConfigs(root)).toEqual([]);
+  });
+
+  it('ignores a hooks/hooks.json under a dir with no plugin.json manifest', () => {
+    // A bare directory that happens to contain hooks/hooks.json but is NOT a
+    // plugin (no .claude-plugin/plugin.json) must not be treated as one.
+    mkdirSync(join(root, 'not-a-plugin', 'hooks'), { recursive: true });
+    writeFileSync(join(root, 'not-a-plugin', 'hooks', 'hooks.json'), '{}', 'utf-8');
+    expect(discoverPluginHooksConfigs(root)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Plugin hooks gate (enablePluginHooks) — loadHooksConfig integration
+// ---------------------------------------------------------------------------
+
+describe('loadHooksConfig — plugin hooks gate', () => {
+  let afkHome: string;
+  let projectCwd: string;
+  let pluginsDir: string;
+  let originalAfkHome: string | undefined;
+
+  beforeEach(() => {
+    afkHome = join(tmp, 'afk-home');
+    projectCwd = join(tmp, 'project');
+    pluginsDir = join(tmp, 'plugins');
+    mkdirSync(join(afkHome, 'config'), { recursive: true });
+    mkdirSync(projectCwd, { recursive: true });
+    // Plant a plugin that ships a SessionStart command hook.
+    const pluginDir = join(pluginsDir, 'demo-plugin');
+    mkdirSync(join(pluginDir, '.claude-plugin'), { recursive: true });
+    writeFileSync(join(pluginDir, '.claude-plugin', 'plugin.json'), '{}', 'utf-8');
+    mkdirSync(join(pluginDir, 'hooks'), { recursive: true });
+    writeFileSync(
+      join(pluginDir, 'hooks', 'hooks.json'),
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            { hooks: [{ type: 'command', command: 'echo plugin-hook' }] },
+          ],
+        },
+      }),
+      'utf-8',
+    );
+    originalAfkHome = process.env['AFK_HOME'];
+    process.env['AFK_HOME'] = afkHome;
+  });
+
+  afterEach(() => {
+    if (originalAfkHome === undefined) delete process.env['AFK_HOME'];
+    else process.env['AFK_HOME'] = originalAfkHome;
+  });
+
+  function writeUserGlobalConfig(body: unknown): void {
+    writeFileSync(join(afkHome, 'config', 'afk.config.json'), JSON.stringify(body), 'utf-8');
+  }
+
+  it('plugin hooks are dropped and a warning is emitted when enablePluginHooks is unset', () => {
+    const result = loadHooksConfig({ cwd: projectCwd, pluginsDir });
+    expect(result.pluginHooksEnabled).toBe(false);
+    expect(result.hooks.SessionStart).toBeUndefined();
+    expect(result.warnings.some((w) => w.includes('plugin hooks are disabled'))).toBe(true);
+  });
+
+  it('plugin hooks are admitted (tier=plugin, pluginRoot set) when enablePluginHooks is true', () => {
+    writeUserGlobalConfig({ enablePluginHooks: true });
+    const result = loadHooksConfig({ cwd: projectCwd, pluginsDir });
+    expect(result.pluginHooksEnabled).toBe(true);
+    const groups = result.hooks.SessionStart!;
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.tier).toBe('plugin');
+    expect(groups[0]!.hooks[0]!.command).toBe('echo plugin-hook');
+    expect(groups[0]!.hooks[0]!.pluginRoot).toBe(join(pluginsDir, 'demo-plugin'));
+    // No "disabled" warning when the gate is on.
+    expect(result.warnings.some((w) => w.includes('plugin hooks are disabled'))).toBe(false);
+  });
+
+  it('enablePluginHooks is independent of enableShellHooks', () => {
+    // Plugin gate ON, shell gate OFF → plugin hook present, userGlobalEnabled false.
+    writeUserGlobalConfig({ enablePluginHooks: true });
+    const result = loadHooksConfig({ cwd: projectCwd, pluginsDir });
+    expect(result.userGlobalEnabled).toBe(false);
+    expect(result.pluginHooksEnabled).toBe(true);
+    expect(result.hooks.SessionStart).toHaveLength(1);
+  });
+
+  it('enablePluginHooks set in a project-local file does NOT activate plugin hooks', () => {
+    // Only user-global files satisfy the gate (same rule as enableShellHooks).
+    writeFileSync(
+      join(projectCwd, 'afk.config.json'),
+      JSON.stringify({ enablePluginHooks: true }),
+      'utf-8',
+    );
+    const result = loadHooksConfig({ cwd: projectCwd, pluginsDir });
+    expect(result.pluginHooksEnabled).toBe(false);
+    expect(result.hooks.SessionStart).toBeUndefined();
   });
 });

--- a/src/agent/hooks/config-loader.test.ts
+++ b/src/agent/hooks/config-loader.test.ts
@@ -264,6 +264,10 @@ describe('loadHooksConfigFile', () => {
     // All entries in the group are invalid → group is excluded
     expect(result.hooks.PreToolUse).toBeUndefined();
     expect(result.warnings).toHaveLength(2);
+    // Reason is specific: missing command → malformed; a non-`command` but
+    // well-formed type → unsupported (not conflated with malformed).
+    expect(result.warnings.some((w) => /is malformed/.test(w))).toBe(true);
+    expect(result.warnings.some((w) => /unsupported hook type "unknown_type"/.test(w))).toBe(true);
   });
 });
 
@@ -766,5 +770,22 @@ describe('loadHooksConfig — plugin hooks gate', () => {
     const result = loadHooksConfig({ cwd: projectCwd, pluginsDir });
     expect(result.pluginHooksEnabled).toBe(false);
     expect(result.hooks.SessionStart).toBeUndefined();
+  });
+
+  it('drops a non-command plugin hook type with an "unsupported" warning', () => {
+    // Claude Code also ships http/mcp_tool/prompt/agent hooks; AFK honors only
+    // `command`, so a plugin's non-command hook must be dropped (not run) with a
+    // clear warning — verified end-to-end through the plugin discovery path.
+    writeUserGlobalConfig({ enablePluginHooks: true });
+    writeFileSync(
+      join(pluginsDir, 'demo-plugin', 'hooks', 'hooks.json'),
+      JSON.stringify({
+        hooks: { SessionStart: [{ hooks: [{ type: 'http', url: 'https://example.test' }] }] },
+      }),
+      'utf-8',
+    );
+    const result = loadHooksConfig({ cwd: projectCwd, pluginsDir });
+    expect(result.hooks.SessionStart).toBeUndefined();
+    expect(result.warnings.some((w) => /unsupported hook type "http"/.test(w))).toBe(true);
   });
 });

--- a/src/agent/hooks/config-loader.ts
+++ b/src/agent/hooks/config-loader.ts
@@ -23,12 +23,21 @@
  * This prevents a malicious `afk.config.json` in a cloned repo from running
  * arbitrary commands once the user has globally opted into shell hooks.
  *
+ * Plugin-contributed hooks (Claude Code compatibility): installed plugins may
+ * ship a `<plugin>/hooks/hooks.json` (the Claude Code layout). These are
+ * discovered under `~/.afk/plugins/`, tagged `tier: 'plugin'`, and merged
+ * LAST. Because they execute third-party code, they sit behind their OWN
+ * user-global trust gate, `enablePluginHooks: true` — independent of
+ * `enableShellHooks` (which governs the user's own `afk.config.json` hooks).
+ * Only `command`-type entries are honored; other Claude Code hook types
+ * (`http`, `mcp_tool`, `prompt`, `agent`) are skipped with a warning.
+ *
  * @module agent/hooks/config-loader
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, lstatSync } from 'node:fs';
 import { join } from 'node:path';
-import { getAfkHome, getJsonConfigPath, getSettingsPath, getProjectSettingsPath } from '../../paths.js';
+import { getAfkHome, getJsonConfigPath, getSettingsPath, getProjectSettingsPath, getPluginsDir } from '../../paths.js';
 import type { HarnessHookEvent } from '../hooks.js';
 import { HOOK_HANDLER_TIMEOUT_MS } from '../hook-registry.js';
 
@@ -62,6 +71,14 @@ export interface ResolvedCommandHook {
   type: 'command';
   command: string;
   timeoutMs: number;
+  /**
+   * Absolute plugin root, set only for hooks sourced from a plugin's
+   * `hooks/hooks.json`. Threaded into the executor as `CLAUDE_PLUGIN_ROOT`
+   * (and `CLAUDE_PROJECT_DIR`) so plugin hook commands that reference
+   * `${CLAUDE_PLUGIN_ROOT}` resolve their bundled script paths. Undefined for
+   * user-global / project-local config hooks.
+   */
+  pluginRoot?: string;
 }
 
 export interface ResolvedMatcherGroup {
@@ -72,7 +89,7 @@ export interface ResolvedMatcherGroup {
    * Always populated by {@link loadHooksConfigFile}; optional so external
    * callers (e.g. tests constructing synthetic configs) don't need to set it.
    */
-  tier?: 'user-global' | 'project-local';
+  tier?: 'user-global' | 'project-local' | 'plugin';
 }
 
 export type ResolvedHooksConfig = Partial<Record<HarnessHookEvent, ResolvedMatcherGroup[]>>;
@@ -91,6 +108,14 @@ export interface LoadedHooksConfig {
    * a cloned repo's `afk.config.json` from executing arbitrary commands.
    */
   allowProjectHooks: boolean;
+  /**
+   * True iff `enablePluginHooks: true` was found in a user-global file.
+   * When false (the default), hooks discovered in plugin `hooks/hooks.json`
+   * files are excluded from the merged output. This is an independent gate
+   * from `userGlobalEnabled` (`enableShellHooks`): plugin hooks are
+   * third-party code and get their own explicit opt-in.
+   */
+  pluginHooksEnabled: boolean;
   /** Absolute paths of every file that contributed to this config. */
   sources: string[];
   /** Non-fatal validation warnings the caller should surface. */
@@ -147,6 +172,7 @@ interface SingleFileResult {
   hooks: ResolvedHooksConfig;
   enableShellHooks: boolean;
   allowProjectHooks: boolean;
+  enablePluginHooks: boolean;
   sources: string[];
   warnings: string[];
 }
@@ -176,14 +202,15 @@ function validateHook(raw: unknown): ResolvedCommandHook | null {
  */
 export function loadHooksConfigFile(
   path: string,
-  tier: 'user-global' | 'project-local',
+  tier: 'user-global' | 'project-local' | 'plugin',
+  pluginRoot?: string,
 ): SingleFileResult {
   const warnings: string[] = [];
   const sources: string[] = [];
   const hooks: ResolvedHooksConfig = {};
 
   if (!existsSync(path)) {
-    return { hooks, enableShellHooks: false, allowProjectHooks: false, sources, warnings };
+    return { hooks, enableShellHooks: false, allowProjectHooks: false, enablePluginHooks: false, sources, warnings };
   }
   sources.push(path);
 
@@ -193,12 +220,12 @@ export function loadHooksConfigFile(
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     warnings.push(`hooks config at ${path}: parse error — ${msg}`);
-    return { hooks, enableShellHooks: false, allowProjectHooks: false, sources, warnings };
+    return { hooks, enableShellHooks: false, allowProjectHooks: false, enablePluginHooks: false, sources, warnings };
   }
 
   if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
     warnings.push(`hooks config at ${path}: top-level must be an object`);
-    return { hooks, enableShellHooks: false, allowProjectHooks: false, sources, warnings };
+    return { hooks, enableShellHooks: false, allowProjectHooks: false, enablePluginHooks: false, sources, warnings };
   }
   const file = parsed as Record<string, unknown>;
 
@@ -208,15 +235,16 @@ export function loadHooksConfigFile(
   // so the value flows cleanly.
   const enableShellHooks = file['enableShellHooks'] === true;
   const allowProjectHooks = file['allowProjectHooks'] === true;
+  const enablePluginHooks = file['enablePluginHooks'] === true;
 
   // Extract hooks block
   const rawHooks = file['hooks'];
   if (rawHooks === undefined || rawHooks === null) {
-    return { hooks, enableShellHooks, allowProjectHooks, sources, warnings };
+    return { hooks, enableShellHooks, allowProjectHooks, enablePluginHooks, sources, warnings };
   }
   if (typeof rawHooks !== 'object' || Array.isArray(rawHooks)) {
     warnings.push(`hooks config at ${path}: "hooks" must be an object`);
-    return { hooks, enableShellHooks, allowProjectHooks, sources, warnings };
+    return { hooks, enableShellHooks, allowProjectHooks, enablePluginHooks, sources, warnings };
   }
 
   const rawHooksObj = rawHooks as Record<string, unknown>;
@@ -266,6 +294,7 @@ export function loadHooksConfigFile(
           );
           continue;
         }
+        if (pluginRoot !== undefined) validated.pluginRoot = pluginRoot;
         resolvedHooks.push(validated);
       }
       if (resolvedHooks.length > 0) {
@@ -281,7 +310,74 @@ export function loadHooksConfigFile(
     }
   }
 
-  return { hooks, enableShellHooks, allowProjectHooks, sources, warnings };
+  return { hooks, enableShellHooks, allowProjectHooks, enablePluginHooks, sources, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// Plugin-contributed hook discovery (Claude Code compatibility)
+// ---------------------------------------------------------------------------
+
+const MAX_PLUGIN_SCAN_DEPTH = 5;
+
+/**
+ * Discover every plugin-contributed `hooks/hooks.json` under `~/.afk/plugins/`.
+ *
+ * A plugin contributes hooks when it ships a `<plugin>/hooks/hooks.json` file
+ * (the Claude Code layout) alongside the standard
+ * `<plugin>/.claude-plugin/plugin.json` manifest. Walks the same two layouts
+ * as `scanLocalPlugins()`:
+ *   - flat:  `<root>/<plugin>/hooks/hooks.json`
+ *   - cache: `<root>/cache/<marketplace>/<plugin>/hooks/hooks.json`
+ *
+ * Returns `{ path, pluginRoot }` pairs — `pluginRoot` is the plugin's install
+ * directory, threaded to the executor as `CLAUDE_PLUGIN_ROOT`. Missing root is
+ * silently ignored (no plugins installed).
+ */
+export function discoverPluginHooksConfigs(
+  pluginsRoot: string = getPluginsDir(),
+): Array<{ path: string; pluginRoot: string }> {
+  if (!existsSync(pluginsRoot)) return [];
+  const out: Array<{ path: string; pluginRoot: string }> = [];
+  walkForPluginHooks(pluginsRoot, 0, out, new Set<string>());
+  return out;
+}
+
+function walkForPluginHooks(
+  dir: string,
+  depth: number,
+  out: Array<{ path: string; pluginRoot: string }>,
+  seen: Set<string>,
+): void {
+  if (depth > MAX_PLUGIN_SCAN_DEPTH) return;
+  if (seen.has(dir)) return;
+  seen.add(dir);
+
+  // A directory is a plugin when it carries `.claude-plugin/plugin.json`.
+  // Check for `hooks/hooks.json` and stop descending — plugins do not nest.
+  const pluginJson = join(dir, '.claude-plugin', 'plugin.json');
+  if (existsSync(pluginJson)) {
+    const hooksJson = join(dir, 'hooks', 'hooks.json');
+    if (existsSync(hooksJson)) out.push({ path: hooksJson, pluginRoot: dir });
+    return;
+  }
+
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (name.startsWith('.')) continue;
+    const full = join(dir, name);
+    let s;
+    try {
+      s = lstatSync(full);
+    } catch {
+      continue;
+    }
+    if (s.isDirectory()) walkForPluginHooks(full, depth + 1, out, seen);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -291,6 +387,11 @@ export function loadHooksConfigFile(
 export interface LoadHooksConfigOptions {
   /** Working directory for project-local layers. Defaults to `process.cwd()`. */
   cwd?: string;
+  /**
+   * Plugins root to scan for `<plugin>/hooks/hooks.json`. Defaults to
+   * `getPluginsDir()` (`~/.afk/plugins/`). Injectable for tests.
+   */
+  pluginsDir?: string;
 }
 
 /**
@@ -313,6 +414,7 @@ export function loadHooksConfig(opts: LoadHooksConfigOptions = {}): LoadedHooksC
   const merged: ResolvedHooksConfig = {};
   let userGlobalEnabled = false;
   let allowProjectHooks = false;
+  let pluginHooksEnabled = false;
 
   const allLayers: Array<{ path: string; tier: 'user-global' | 'project-local' }> = [
     { path: getJsonConfigPath(), tier: 'user-global' },
@@ -355,6 +457,7 @@ export function loadHooksConfig(opts: LoadHooksConfigOptions = {}): LoadedHooksC
     const result = loadHooksConfigFile(layer.path, layer.tier);
     if (result.enableShellHooks) userGlobalEnabled = true;
     if (result.allowProjectHooks) allowProjectHooks = true;
+    if (result.enablePluginHooks) pluginHooksEnabled = true;
   }
 
   // Second pass: load all layers and concatenate hooks, filtering out
@@ -397,10 +500,45 @@ export function loadHooksConfig(opts: LoadHooksConfigOptions = {}): LoadedHooksC
     }
   }
 
+  // Third pass: plugin-contributed hooks (Claude Code compat). Discovered from
+  // installed plugins under the plugins root, tagged `tier: 'plugin'`, merged
+  // last. Gated by the independent `enablePluginHooks` trust flag — plugin
+  // hooks execute third-party code, so they never ride on `enableShellHooks`.
+  const pluginConfigs = discoverPluginHooksConfigs(opts.pluginsDir);
+  if (pluginConfigs.length > 0 && !pluginHooksEnabled) {
+    // Don't silently drop plugin hooks — surface the boundary so the user
+    // knows they exist and how to opt in (mirrors the config-bridge warning
+    // for disabled shell hooks).
+    allWarnings.push(
+      `found ${pluginConfigs.length} plugin hooks.json file(s) but plugin hooks are disabled; ` +
+        `set "enablePluginHooks": true in ${getJsonConfigPath()} to run them`,
+    );
+  }
+  if (pluginHooksEnabled) {
+    for (const { path, pluginRoot } of pluginConfigs) {
+      const result = loadHooksConfigFile(path, 'plugin', pluginRoot);
+      for (const src of result.sources) {
+        if (!allSources.includes(src)) allSources.push(src);
+      }
+      for (const w of result.warnings) allWarnings.push(w);
+      for (const event of validEvents) {
+        const incoming = result.hooks[event];
+        if (incoming === undefined || incoming.length === 0) continue;
+        const existing = merged[event];
+        if (existing === undefined) {
+          merged[event] = [...incoming];
+        } else {
+          merged[event] = [...existing, ...incoming];
+        }
+      }
+    }
+  }
+
   return {
     hooks: merged,
     userGlobalEnabled,
     allowProjectHooks,
+    pluginHooksEnabled,
     sources: allSources,
     warnings: allWarnings,
   };

--- a/src/agent/hooks/config-loader.ts
+++ b/src/agent/hooks/config-loader.ts
@@ -35,9 +35,10 @@
  * @module agent/hooks/config-loader
  */
 
-import { existsSync, readFileSync, readdirSync, lstatSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getAfkHome, getJsonConfigPath, getSettingsPath, getProjectSettingsPath, getPluginsDir } from '../../paths.js';
+import { scanLocalPlugins } from '../plugins-scanner.js';
 import type { HarnessHookEvent } from '../hooks.js';
 import { HOOK_HANDLER_TIMEOUT_MS } from '../hook-registry.js';
 
@@ -317,67 +318,33 @@ export function loadHooksConfigFile(
 // Plugin-contributed hook discovery (Claude Code compatibility)
 // ---------------------------------------------------------------------------
 
-const MAX_PLUGIN_SCAN_DEPTH = 5;
-
 /**
  * Discover every plugin-contributed `hooks/hooks.json` under `~/.afk/plugins/`.
  *
- * A plugin contributes hooks when it ships a `<plugin>/hooks/hooks.json` file
- * (the Claude Code layout) alongside the standard
- * `<plugin>/.claude-plugin/plugin.json` manifest. Walks the same two layouts
- * as `scanLocalPlugins()`:
- *   - flat:  `<root>/<plugin>/hooks/hooks.json`
- *   - cache: `<root>/cache/<marketplace>/<plugin>/hooks/hooks.json`
- *
- * Returns `{ path, pluginRoot }` pairs — `pluginRoot` is the plugin's install
- * directory, threaded to the executor as `CLAUDE_PLUGIN_ROOT`. Missing root is
- * silently ignored (no plugins installed).
+ * Enumeration is delegated to {@link scanLocalPlugins} — the single source of
+ * truth for "which plugins are installed and enabled" — so hook discovery
+ * inherits its enabled-index (`.index.json`) filtering (disabled and
+ * uninstalled marketplace-cache plugins contribute no hooks) and its symlink
+ * following (local installs are symlinked into the plugins root). A plugin
+ * contributes hooks when it ships `<plugin>/hooks/hooks.json` (the Claude Code
+ * layout). Returns `{ path, pluginRoot }` pairs; `pluginRoot` is the plugin's
+ * install directory, threaded to the executor as `CLAUDE_PLUGIN_ROOT`. Missing
+ * root → `[]`.
  */
 export function discoverPluginHooksConfigs(
   pluginsRoot: string = getPluginsDir(),
 ): Array<{ path: string; pluginRoot: string }> {
   if (!existsSync(pluginsRoot)) return [];
   const out: Array<{ path: string; pluginRoot: string }> = [];
-  walkForPluginHooks(pluginsRoot, 0, out, new Set<string>());
+  // Reuse scanLocalPlugins (index-honoring, symlink-following, realpath-keyed)
+  // rather than a bespoke walk — see PR 607 review: a private walk diverged on
+  // all three, running disabled/uninstalled plugins' hooks while dropping
+  // symlinked local plugins' hooks.
+  for (const plugin of scanLocalPlugins(pluginsRoot)) {
+    const hooksJson = join(plugin.path, 'hooks', 'hooks.json');
+    if (existsSync(hooksJson)) out.push({ path: hooksJson, pluginRoot: plugin.path });
+  }
   return out;
-}
-
-function walkForPluginHooks(
-  dir: string,
-  depth: number,
-  out: Array<{ path: string; pluginRoot: string }>,
-  seen: Set<string>,
-): void {
-  if (depth > MAX_PLUGIN_SCAN_DEPTH) return;
-  if (seen.has(dir)) return;
-  seen.add(dir);
-
-  // A directory is a plugin when it carries `.claude-plugin/plugin.json`.
-  // Check for `hooks/hooks.json` and stop descending — plugins do not nest.
-  const pluginJson = join(dir, '.claude-plugin', 'plugin.json');
-  if (existsSync(pluginJson)) {
-    const hooksJson = join(dir, 'hooks', 'hooks.json');
-    if (existsSync(hooksJson)) out.push({ path: hooksJson, pluginRoot: dir });
-    return;
-  }
-
-  let entries: string[];
-  try {
-    entries = readdirSync(dir);
-  } catch {
-    return;
-  }
-  for (const name of entries) {
-    if (name.startsWith('.')) continue;
-    const full = join(dir, name);
-    let s;
-    try {
-      s = lstatSync(full);
-    } catch {
-      continue;
-    }
-    if (s.isDirectory()) walkForPluginHooks(full, depth + 1, out, seen);
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/agent/hooks/config-loader.ts
+++ b/src/agent/hooks/config-loader.ts
@@ -288,10 +288,23 @@ export function loadHooksConfigFile(
       const rawHookEntries = groupObj['hooks'] as unknown[];
       const resolvedHooks: ResolvedCommandHook[] = [];
       for (let hi = 0; hi < rawHookEntries.length; hi++) {
-        const validated = validateHook(rawHookEntries[hi]);
+        const rawHookEntry = rawHookEntries[hi];
+        const validated = validateHook(rawHookEntry);
         if (validated === null) {
+          // Distinguish a well-formed but UNSUPPORTED hook type (Claude Code
+          // also ships http/mcp_tool/prompt/agent hooks; AFK honors only
+          // `command`) from a genuinely malformed entry — so a plugin author
+          // gets an accurate reason rather than a misleading "malformed".
+          const rawType =
+            rawHookEntry !== null && typeof rawHookEntry === 'object' && !Array.isArray(rawHookEntry)
+              ? (rawHookEntry as Record<string, unknown>)['type']
+              : undefined;
+          const reason =
+            typeof rawType === 'string' && rawType !== 'command'
+              ? `has unsupported hook type "${rawType}" (only "command" is honored)`
+              : 'is malformed (must have type="command" and non-empty command)';
           warnings.push(
-            `hooks config at ${path}: hooks.${event}[${gi}].hooks[${hi}] is malformed (must have type="command" and non-empty command) — skipping`,
+            `hooks config at ${path}: hooks.${event}[${gi}].hooks[${hi}] ${reason} — skipping`,
           );
           continue;
         }

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -164,6 +164,7 @@ export function loadConfig(overrides?: Partial<CliConfig>): CliConfig {
     ...(merged.interactive !== undefined ? { interactive: merged.interactive } : {}),
     ...(merged.hooks !== undefined ? { hooks: merged.hooks } : {}),
     ...(merged.enableShellHooks !== undefined ? { enableShellHooks: merged.enableShellHooks } : {}),
+    ...(merged.enablePluginHooks !== undefined ? { enablePluginHooks: merged.enablePluginHooks } : {}),
     ...(merged.enforceDoneEvidence !== undefined ? { enforceDoneEvidence: merged.enforceDoneEvidence } : {}),
     ...(merged.importFrom !== undefined ? { importFrom: merged.importFrom } : {}),
   };

--- a/src/cli/config/json-tier.ts
+++ b/src/cli/config/json-tier.ts
@@ -217,6 +217,10 @@ export function loadJsonConfig(): {
           config.enableShellHooks = json.enableShellHooks;
         }
 
+        if (typeof json.enablePluginHooks === 'boolean') {
+          config.enablePluginHooks = json.enablePluginHooks;
+        }
+
         // Security: `importFrom` is a user-global-only trust grant — it lets AFK
         // live-read/execute another tool's assets (see loadImportFromConfig). A
         // project-local afk.config.json must NOT be able to set it, so honor it

--- a/src/cli/config/types.ts
+++ b/src/cli/config/types.ts
@@ -233,6 +233,13 @@ export interface CliConfig {
    */
   enableShellHooks?: boolean;
   /**
+   * User-global trust gate for Claude Code plugin-contributed hooks
+   * (`<plugin>/hooks/hooks.json`). Independent of `enableShellHooks`. Human-tier
+   * (the agent's `config_set` cannot flip it). See
+   * `src/agent/hooks/config-loader.ts`.
+   */
+  enablePluginHooks?: boolean;
+  /**
    * Cross-tool asset import. Maps each trusted source binary to the asset
    * types AFK should live-read from that binary's install location. Populated
    * by `afk migrate`; resolved to concrete scan roots by
@@ -318,6 +325,7 @@ export interface ConfigFileSchema {
   maxSummaryCallsPerSession?: number;
   hooks?: RawHooksConfig;
   enableShellHooks?: boolean;
+  enablePluginHooks?: boolean;
   /**
    * Cross-tool asset import. Each known source binary maps to either a bare
    * `true` (shorthand: import all asset types) or an object with per-asset

--- a/src/cli/render/config-menu.ts
+++ b/src/cli/render/config-menu.ts
@@ -75,6 +75,7 @@ export function categoryOf(path: string): (typeof CATEGORY_ORDER)[number] {
     path === 'systemPrompt' ||
     path === 'permissionMode' ||
     path === 'enableShellHooks' ||
+    path === 'enablePluginHooks' ||
     path === 'updatePolicy'
   ) {
     return 'Advanced';

--- a/src/config/settable-keys.ts
+++ b/src/config/settable-keys.ts
@@ -230,6 +230,12 @@ export const CONFIG_KEY_SPECS: readonly ConfigKeySpec[] = [
   // (config-loader userGlobalEnabled). Even though the agent cannot define `hooks`,
   // it must not be able to flip the activation gate on its own config — human-only.
   { path: 'enableShellHooks', tier: 'human', type: 'boolean', description: 'Enable shell hooks (trust gate).' },
+  // enablePluginHooks is the TRUST GATE that activates Claude Code
+  // plugin-contributed hooks (<plugin>/hooks/hooks.json). It executes
+  // third-party plugin code, so — like enableShellHooks — the agent must not be
+  // able to flip it on its own config; human-only, and independent of the
+  // enableShellHooks gate.
+  { path: 'enablePluginHooks', tier: 'human', type: 'boolean', description: 'Enable Claude Code plugin-contributed hooks (trust gate for third-party plugin hooks.json; independent of enableShellHooks).' },
   { path: 'interactive.worktreeBranchPrefix', tier: 'human', type: 'string', description: 'Worktree branch prefix (git-flag sensitive).' },
   { path: 'interactive.worktreeBase', tier: 'human', type: 'string', description: 'Worktree base ref (git-flag sensitive).' },
   { path: 'daemon.task', tier: 'human', type: 'string', description: 'Daemon task prompt.' },

--- a/website/content/docs/configuration/overview.mdx
+++ b/website/content/docs/configuration/overview.mdx
@@ -377,9 +377,12 @@ Code's plugin-hook layout so plugins are portable across both runtimes.
   plugin's `hooks.json` executes third-party code. When plugin `hooks.json`
   files are present but the gate is off, AFK emits a one-line warning naming how
   to enable them (it never runs them silently). Set it with
-  `afk config set enablePluginHooks true`.
+  `afk config set enablePluginHooks true`. Because the two gates are independent,
+  **turning `enableShellHooks` off does _not_ disable plugin hooks** — to run no
+  third-party hooks, leave `enablePluginHooks` unset (or set it to `false`).
 - **Supported types.** Only `command`-type hooks run. Claude Code's other hook
-  types (`http`, `mcp_tool`, `prompt`, `agent`) are skipped.
+  types (`http`, `mcp_tool`, `prompt`, `agent`) are skipped with a warning that
+  names the unsupported type.
 - **Environment.** Plugin hook commands receive `CLAUDE_PLUGIN_ROOT` (the
   plugin's install directory) and `CLAUDE_PROJECT_DIR`, so commands like
   `python3 "${CLAUDE_PLUGIN_ROOT}/hooks/on_start.py"` resolve. The same secret

--- a/website/content/docs/configuration/overview.mdx
+++ b/website/content/docs/configuration/overview.mdx
@@ -130,6 +130,7 @@ optional; unset fields fall through to env vars or built-in defaults.
 | `bgSummaries` | `boolean` | `false` | When `true`, the REPL summarizes running background jobs and shows them in `/bgsub:list`. **Caution:** this sends transcript data to the Anthropic API — don't enable it in air-gapped or sensitive environments. |
 | `maxSummaryCallsPerSession` | `number` | `200` | Session-wide budget for background summarizer LLM calls. Clamped to `[1, 500]`. Has no effect unless `bgSummaries` is `true`. |
 | `enableShellHooks` | `boolean` | `false` | Master switch for shell-command hooks. **Must be set in a user-global file** (`~/.afk/config/afk.config.json`); project-local values are silently ignored to prevent cloned repos from auto-executing scripts. Set it with `afk config set enableShellHooks true` — it is human-gated, so the agent's `config_set` tool cannot flip it. |
+| `enablePluginHooks` | `boolean` | `false` | Master switch for **Claude Code plugin-contributed hooks** (`<plugin>/hooks/hooks.json`). Independent of `enableShellHooks`. **Must be set in a user-global file**; human-gated (the agent's `config_set` cannot flip it). See [Plugin-contributed hooks](#plugin-contributed-hooks). |
 
 ---
 
@@ -360,3 +361,29 @@ hook in under the `enableShellHooks` gate below.
 |-------|-------|-------------|
 | `enableShellHooks` | User-global only | Master switch. Without it, no shell hooks run regardless of what `hooks` defines. |
 | `allowProjectHooks` | User-global only | When `true`, hook definitions from project-local `afk.config.json` files are admitted. Defaults to `false` — without this, a cloned repo's hook definitions are silently dropped even when `enableShellHooks` is on. |
+| `enablePluginHooks` | User-global only | When `true`, hooks contributed by installed plugins (`<plugin>/hooks/hooks.json`) are discovered and run. **Independent** of `enableShellHooks` — plugin hooks are third-party code and get their own opt-in. Defaults to `false`. |
+
+#### Plugin-contributed hooks
+
+AFK discovers and runs hooks shipped by installed plugins, matching Claude
+Code's plugin-hook layout so plugins are portable across both runtimes.
+
+- **Location.** Any installed plugin under `~/.afk/plugins/` that ships a
+  `<plugin>/hooks/hooks.json` (alongside its `.claude-plugin/plugin.json`
+  manifest) contributes hooks. Both the flat and marketplace-cache layouts are
+  scanned. Plugin hooks merge **after** your own config hooks.
+- **Trust gate.** Plugin hooks run only when `enablePluginHooks: true` is set in
+  a **user-global** file — a separate opt-in from `enableShellHooks`, because a
+  plugin's `hooks.json` executes third-party code. When plugin `hooks.json`
+  files are present but the gate is off, AFK emits a one-line warning naming how
+  to enable them (it never runs them silently). Set it with
+  `afk config set enablePluginHooks true`.
+- **Supported types.** Only `command`-type hooks run. Claude Code's other hook
+  types (`http`, `mcp_tool`, `prompt`, `agent`) are skipped.
+- **Environment.** Plugin hook commands receive `CLAUDE_PLUGIN_ROOT` (the
+  plugin's install directory) and `CLAUDE_PROJECT_DIR`, so commands like
+  `python3 "${CLAUDE_PLUGIN_ROOT}/hooks/on_start.py"` resolve. The same secret
+  redaction as shell hooks applies — no API keys or tokens are forwarded.
+- **Scope.** Discovery covers user-global installed plugins only. Project-scoped
+  and bundled plugin hooks, inline `hooks` in `plugin.json`, and the non-command
+  hook types are not yet honored.


### PR DESCRIPTION
Closes #70.

## Summary

AFK now discovers and runs **Claude Code plugin-contributed hooks** — a `<plugin>/hooks/hooks.json` shipped by an installed plugin. This was the one plugin-contributed surface AFK didn't honor (skills, agents, commands, and `mcp.json` were already discovered), and it means plugins written for Claude Code are portable across both runtimes without change.

The `afk.config.json`-driven shell-hook system already existed; this adds the **plugin** layer #70 tracks, behind its own trust gate.

## What changed

- **Discovery** — `discoverPluginHooksConfigs()` walks `~/.afk/plugins/` (flat **and** marketplace-cache layouts, depth-bounded) for `<plugin>/hooks/hooks.json`, keyed on the `.claude-plugin/plugin.json` manifest. Mirrors the existing `discoverPluginMcpConfigs()` precedent.
- **Trust gate** — new user-global **`enablePluginHooks`** (default `false`), **independent** of `enableShellHooks`, and **human-tier** (the agent's `config_set` cannot flip it). Rationale: plugin `hooks.json` executes third-party code, so it gets its own explicit opt-in rather than riding on the gate that governs the user's *own* `afk.config.json` hooks — consistent with AFK's fail-closed, per-tier posture (`allowProjectHooks`, `AFK_ALLOW_PROJECT_MCP`).
- **Registration** — plugin hooks are tagged `tier:'plugin'`, merged last, and register in the bridge *independently* of the shell-hook gate.
- **Executor env** — plugin hook commands receive `CLAUDE_PLUGIN_ROOT` (the plugin's install dir) and `CLAUDE_PROJECT_DIR`, so commands like `python3 "${CLAUDE_PLUGIN_ROOT}/hooks/on_start.py"` resolve. Existing secret redaction (no API keys/tokens forwarded) still applies.
- **Not silent** — when plugin `hooks.json` are present but the gate is off, a one-line warning names how to enable them.
- **Plumbing + docs** — `settable-keys`, `json-tier`, `config`, `types`, `config-menu`, and `configuration/overview.mdx`.

## Scope

**In:** user-global installed plugins; `command`-type hooks; AFK's supported hook events.
**Out (deferred, noted in docs):** `http` / `mcp_tool` / `prompt` / `agent` hook types (AFK runs `command` only); inline `hooks` field in `plugin.json`; project-scoped & bundled-plugin hooks; `${user_config.*}` substitution.

## Behavior note

Once merged, a session that has plugin `hooks.json` present but `enablePluginHooks` unset prints a one-line "found N plugin hooks.json… set enablePluginHooks: true" warning per bootstrap — the intended "surface the boundary, don't silently drop" behavior.

## Testing

- 14 new tests: discovery walker (flat / cache / negative cases), `enablePluginHooks` gate (admit / drop-with-warning / independent-of-shell-gate / project-local-ignored), executor `CLAUDE_PLUGIN_ROOT` threading, bridge plugin-tier registration independence.
- `pnpm lint` (tsc), `pnpm build`, `audit:sdk:check`, `audit:env:check`, `scan:env:check` — all green.
- Full suite: **12026 passed / 0 failed**.
- Smoke-tested against two live plugins (`awa-dev`, `awa-private`): both `hooks.json` discovered with correct `pluginRoot`.
