### PR TITLE
AFK mode: let an away operator actually go AFK (elicitation fixes + Telegram-native host v1)

### DIFF
--- a/docs/afk-telegram-native-host.md
+++ b/docs/afk-telegram-native-host.md
@@ -1,0 +1,58 @@
+# AFK Telegram-native host (architecture "D") — feasibility + risk brief
+
+**Status:** Design + risk record. The v1 slice below is IMPLEMENTED (gate wired for Telegram, `/afk` command, high-risk hard-refuse); the v2 items remain deferred. 2026-07-14. Branch `afk/afk-mode-cli-telegram`.
+**Question:** should AFK sessions run *natively inside the always-on Telegram bot* (one persistent process owns both the agent loop and phone I/O), instead of the CLI-REPL + ledger-relay + separate-watcher design the F-series audit patched?
+
+## Verdict (one line)
+
+**Feasible and architecturally right — it deletes the whole class of bugs the audit patched — but it must be staged and safety-gated: there is one CRITICAL blocker (the AFK risk ceiling is not wired on Telegram), a durability gap (restart loses a pending question), and a containment gap (no trusted narrow root).**
+
+## Why D is attractive
+
+The audited failures (F1 relay buttons, F3 silent phone-leg failures, F5 reply dead-end) are all artifacts of the **two-process ledger bridge**. In D there is no bridge: elicitations use the **native** Telegram handler (already correct), so:
+- **F1 doesn't exist** — the native path composes `askHandler + formHandler`; approve/deny forms render as `afk:pa:` buttons and return `content.choice`, which the gate reads. (`bot.ts:352`, `elicitation-telegram.ts:197,315`, `afk-mode-gate.ts:227`.) D bypasses the relay by construction.
+- **"Answer whenever" is FREE within a process lifetime** — the bot has **no session idle/TTL** (`session-manager.ts`, in-memory `Map`), dispatches every update **detached** (`bot.ts:252-260`) with a per-chat queue (`handlers/message.ts:113`), so one chat blocked on a question holds it open indefinitely while other chats keep working. On an always-on host, "close the laptop, answer later" works.
+
+## Feasibility by dimension (all read-only, cited)
+
+1. **Promote a Telegram session to `autonomous`:** trivial at the API layer — `AgentSession.setPermissionMode('autonomous')` (`agent-session.ts:838` → provider `query.ts:628`); no provider self-escalation guard. `settable-keys.ts:228` marks `permissionMode` human-tier but that only blocks the `config_set` *tool*, not a host call (same as the REPL's `afk-mode-toggle.ts:58`). Telegram builds sessions with `permissionMode` omitted → `'default'` (`telegram.ts:425-437,476`).
+
+2. **CRITICAL BLOCKER — the AFK safety ceiling is NOT registered on Telegram.** `createDefaultHookRegistry` registers the plan-mode AND afk-mode gates only inside `if (getPermissionMode !== undefined)` (`default-hook-registry.ts:141-162`). Telegram passes `undefined` for that arg (`telegram.ts:429` arg4; codex branch `:493`). **Verified directly.** So a naive "promote to autonomous" on Telegram today = an autonomous agent with **no risk-classifier ceiling** — and since `autonomous` also bypasses path-approval via `allowAll` (`permission-policy.ts:36-40`), there would be *zero* path containment. This must be fixed *before* any autonomous promotion is allowed on Telegram.
+
+3. **Durability across bot restart — NOT free.** A pending elicitation is an in-memory `Promise` closure (`handlers/message.ts:141`); on process restart it is lost. Only *completed* turns persist (per-turn `saveSession`), so a conversation resumes but the *pending question* does not. Restart-survival would require porting the ledger `elicitation`/`elicitation_response` protocol (`session-ledger.ts:80-82`, already built for the watch path) into the hosted-session path. (v2.)
+
+4. **Containment — weak.** The gate's workspace-escape rule needs a trusted `workspaceRoot`; on Telegram the root is just the session cwd (`data.cwd` via `/cd` ?? `AFK_TELEGRAM_CWD` ?? default; `session-manager.ts:563-603`), never a narrow managed worktree. A broad cwd (`$HOME`, `/`) makes the escape ceiling nearly toothless (the `~/.ssh` / `/etc` / `.git` denylist still fires — `risk-classifier.ts:174-183` — but little else). `getCwd` handed to Telegram is a *static* closure (`telegram.ts:435`); acceptable only because `/cd` rebuilds the session.
+
+5. **Initiation UX:** adding a `/afk [task]` command is mechanically trivial (`bot.command` + `setMyCommands`), but it is **not UI-only** — it requires wiring the gate (dimension 2) first. No permission-mode toggle exists on Telegram today (REPL-only).
+
+## Risks (ranked; blast-radius of a persistent autonomous phone-driven agent)
+
+1. **Single-tap approval of irreversible ops with near-zero context** — the approval prompt shows tool name + a 300-char redacted preview (`afk-mode-gate.ts:311-315`), no diff/dry-run/2FA. One phone tap could authorize `rm`, `git push --force`, `dd`, MCP `delete`/`deploy`, schedule mutations. This is the genuinely new/scary delta vs laptop-REPL AFK.
+2. **Weak/broad containment root** (dimension 4) — the sole path-safety layer in AFK, near-inert under a broad cwd.
+3. **Persistence multiplies exposure** — always-on service, `data.cwd` survives restart (`session-manager.ts:41-42`); an allowlisted chat is a *standing* capability, not a session-bounded one. Auto-subscribe already makes the phone a live control surface (`bot.ts:538-583`).
+4. **Approval-context confusion across concurrent chats** — one process, many chats, shared module-scope `elicitationRouter`; a phone prompt may be hard to attribute to the right chat/task.
+5. **Coarse shared allowlist** — any allowlisted chat can `/afk`, `/cd` anywhere, approve anything; no per-chat capability tiers (`allowlist.ts:20-56`).
+6. **Bash gate is best-effort, not a sandbox** (`afk-mode-gate.ts:72-75`).
+
+## Recommendation
+
+**Pursue D, staged, with a safety-first v1.** This also revises the earlier "keep-and-fix" fork *for the D context*:
+
+- **v1 (the safe, high-value slice):**
+  1. **Wire the gate for Telegram** — thread a real `getPermissionMode` (per-chat mode mirror, surviving restart) + the live `getCwd` into the two `createDefaultHookRegistry` call sites (`telegram.ts:429,493`). NON-NEGOTIABLE and must land *before* autonomous is reachable on Telegram.
+  2. **Add `/afk` on Telegram** — promote/demote the chat's session; mirror mode onto `SessionStats.permissionMode` and persist it.
+  3. **Hard-refuse high-risk in the persistent host** — set `promptForApproval: false` (`afk-mode-gate.ts:104-106,297`) so high-risk/irreversible ops degrade to hard-block + Asking summary rather than a phone tap. i.e. **keep-and-fix stays for the laptop REPL; the always-on host gets fail-closed.** Rationale: a phone tap from a standing always-on allowlisted chat with a possibly-broad root removes every mitigating assumption keep-and-fix relied on (bounded session, deliberate arming, trusted narrow worktree, present operator with full context).
+  4. "Answer whenever" for *questions* is inherited free (no TTL + persistent host).
+
+- **v2 (hardening, only if remote high-risk approval is wanted):** trusted narrow per-chat worktree root; per-chat autonomous/approve capability tiers; richer approval context (diff/dry-run, unambiguous chat attribution); restart-durable pending elicitations (port the ledger protocol).
+
+## Open decisions for the operator
+1. Green-light D v1 (gate-wiring + `/afk`-on-Telegram + **hard-refuse** high-risk)?
+2. Safety posture: accept hard-refuse-high-risk in the always-on host (recommended), or insist on phone-approval there (requires v2 hardening first)?
+3. Require AFK-on-Telegram to run in a narrow trusted cwd/worktree (mitigates the toothless-ceiling risk)?
+
+## Not verified (spike limits)
+- No runtime execution / tests run.
+- Codex/openai-compatible Telegram branch line-verified only at the head (`telegram.ts:465+`); shares the same `getPermissionMode=undefined` rationale comment.
+- `resumeHistory` fidelity (tool-call/subagent state on resume) — likely text-only (`resume-session.ts:58-61`).
+- git history of the "permissionMode omitted (post-C2 fix)" decision.

--- a/src/agent/afk-mode-gate.test.ts
+++ b/src/agent/afk-mode-gate.test.ts
@@ -596,6 +596,52 @@ describe('createAfkModeGate — high-risk approval round-trip (v1.5)', () => {
       const [event] = calls.mock.calls[0] as [{ kind: string; payload: Record<string, unknown> }];
       expect(event.payload['approvalOutcome']).toBe('unrecognised');
     });
+
+    it('emits hook_decision with approvalOutcome:hard-block when promptForApproval:false (no prompt)', async () => {
+      // The always-on Telegram-host posture: high-risk ops hard-refuse WITHOUT
+      // soliciting an approval. Regression guard for the forensic gap — before
+      // this the hard-block branch returned before requestApproval's decide(),
+      // so an unattended refusal left no durable hook_decision record.
+      const { writer, calls } = fakeWriter();
+      const route = vi.fn(
+        async (): Promise<ElicitationResult> => ({ action: 'accept', content: { choice: 'approve' } }),
+      );
+      const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
+        route,
+        promptForApproval: false,
+        traceWriter: writer,
+      });
+      const result = await gate({ ...HIGH_RISK });
+      expect(result.decision).toBe('block');
+      expect(route).not.toHaveBeenCalled(); // never solicited an approval
+      expect(calls).toHaveBeenCalledTimes(1);
+      const [event] = calls.mock.calls[0] as [{ kind: string; payload: Record<string, unknown> }];
+      expect(event.kind).toBe('hook_decision');
+      expect(event.payload['approvalOutcome']).toBe('hard-block');
+      expect(event.payload['decision']).toBe('block');
+      expect(typeof event.payload['blockedTool']).toBe('string');
+      expect(typeof event.payload['durationMs']).toBe('number');
+    });
+
+    it('emits hook_decision with approvalOutcome:hard-block for a high-risk SUBAGENT op (parentSessionId set)', async () => {
+      // The sub-agent branch shares the same no-prompt hard-block and needs the
+      // same audit record — a forked agent's refused high-risk op must not be
+      // invisible on resume either.
+      const { writer, calls } = fakeWriter();
+      const route = vi.fn(
+        async (): Promise<ElicitationResult> => ({ action: 'accept', content: { choice: 'approve' } }),
+      );
+      const gate = createAfkModeGate(() => 'autonomous' as PermissionMode, undefined, undefined, {
+        route,
+        traceWriter: writer,
+      });
+      const result = await gate({ ...HIGH_RISK, parentSessionId: 'parent-1' });
+      expect(result.decision).toBe('block');
+      expect(route).not.toHaveBeenCalled();
+      expect(calls).toHaveBeenCalledTimes(1);
+      const [event] = calls.mock.calls[0] as [{ kind: string; payload: Record<string, unknown> }];
+      expect(event.payload['approvalOutcome']).toBe('hard-block');
+    });
   });
 
   // Finding 2: deny-on-timeout timer starts only after onActive fires

--- a/src/agent/afk-mode-gate.ts
+++ b/src/agent/afk-mode-gate.ts
@@ -247,6 +247,10 @@ export function createAfkModeGate(
 
     const { toolName } = context;
 
+    // Wall-clock start for the hook_decision audit trace (gate entry → decision),
+    // parity with requestApproval's own timing on the prompt paths.
+    const start = Date.now();
+
     // The operator's channel is never gated — the posture relies on it to
     // surface Asking states from an unattended run.
     if (toolName === 'send_telegram') return {};
@@ -295,7 +299,23 @@ export function createAfkModeGate(
     // prompt would surface on the parent's surface with no attribution), and the
     // approval path can be opted out — both degrade to the legacy hard block.
     if (context.parentSessionId !== undefined || !promptForApproval) {
-      return blockDecision(toolName, 'AFK mode runs autonomously without a human watching');
+      const decision = blockDecision(toolName, 'AFK mode runs autonomously without a human watching');
+      // Emit the audit trace on the no-prompt refusal too. requestApproval's
+      // decide() helper centralises the emit for the prompt paths, but this
+      // branch returns BEFORE requestApproval — so without this emit an always-on
+      // Telegram host (afkPromptForApproval:false) or a sub-agent hard-refusing a
+      // high-risk op left NO durable hook_decision record, exactly the forensic
+      // gap an away operator needs on resume. approvalOutcome:'hard-block' marks
+      // it as an automatic ceiling refusal, distinct from an operator 'denied'.
+      void emitHookDecision(traceWriter, {
+        hookEvent: 'PreToolUse',
+        decision: 'block',
+        ...(decision.reason !== undefined ? { reason: decision.reason } : {}),
+        blockedTool: toolName,
+        durationMs: Date.now() - start,
+        approvalOutcome: 'hard-block',
+      });
+      return decision;
     }
 
     // Main session: ask the operator to approve/deny (deny-on-timeout). Returns

--- a/src/agent/default-hook-registry.ts
+++ b/src/agent/default-hook-registry.ts
@@ -98,7 +98,7 @@ export function createDefaultHookRegistry(
   memoryStore?: MemoryStore,
   getPermissionMode?: () => PermissionMode,
   hookConfig?: LoadedHooksConfig,
-  agentOptions?: { cwd?: string; sessionId?: string; traceWriter?: TraceWriter },
+  agentOptions?: { cwd?: string; sessionId?: string; traceWriter?: TraceWriter; afkPromptForApproval?: boolean },
   getCwd?: () => string | undefined,
 ): DefaultHookRegistryResult {
   const registry = createHookRegistry();
@@ -152,6 +152,16 @@ export function createDefaultHookRegistry(
       // via allowAll for 'autonomous'; see agent/permission-policy.ts).
       createAfkModeGate(getPermissionMode, agentOptions?.cwd, getCwd, {
         ...(agentOptions?.traceWriter !== undefined ? { traceWriter: agentOptions.traceWriter } : {}),
+        // Surface-scoped approval posture. The REPL leaves this default (true =
+        // keep-and-fix: a high-risk op is approvable from phone/keyboard for a
+        // bounded, deliberately-armed laptop session in a trusted worktree). The
+        // always-on Telegram host passes false → high-risk / irreversible ops
+        // HARD-REFUSE + Asking summary instead of being one-tap-approvable from a
+        // standing phone surface with a possibly-broad cwd (no bounded scope, no
+        // deliberate arming). See docs/afk-telegram-native-host.md.
+        ...(agentOptions?.afkPromptForApproval !== undefined
+          ? { promptForApproval: agentOptions.afkPromptForApproval }
+          : {}),
       }),
       // Longrunning: on a high-risk op the gate awaits an operator approve/deny
       // via elicitationRouter.route() (deny-on-timeout). Bypass the 30s per-

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -90,7 +90,9 @@ export const HookDecisionPayloadSchema = z.object({
   /** Set only by the AFK high-risk approval gate. Wall-clock ms from gate entry to decision. */
   durationMs: z.number().nonnegative().optional(),
   /** Set only by the AFK high-risk approval gate. Fine-grained approval outcome. */
-  approvalOutcome: z.enum(['approved', 'denied', 'unrecognised', 'timeout', 'decline', 'cancel']).optional(),
+  approvalOutcome: z
+    .enum(['approved', 'denied', 'unrecognised', 'timeout', 'decline', 'cancel', 'hard-block'])
+    .optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -146,6 +146,13 @@ export type HookEventName =
 /**
  * Fine-grained outcome of the AFK high-risk approval gate. Set only by that
  * gate; absent on all other hook_decision events.
+ *
+ * `hard-block` is the no-prompt refusal: the op was blocked WITHOUT soliciting
+ * an operator approval at all — either a forked sub-agent (which must never
+ * prompt, for lack of attribution) or the always-on Telegram host
+ * (`afkPromptForApproval:false`). It is distinct from `denied` (operator saw the
+ * prompt and rejected) so async review can tell a deliberate human deny from an
+ * automatic ceiling refusal.
  */
 export type AfkApprovalOutcome =
   | 'approved'
@@ -153,7 +160,8 @@ export type AfkApprovalOutcome =
   | 'unrecognised'
   | 'timeout'
   | 'decline'
-  | 'cancel';
+  | 'cancel'
+  | 'hard-block';
 
 export interface HookDecisionPayload {
   hookEvent: HookEventName;

--- a/src/cli/afk-mode-toggle.test.ts
+++ b/src/cli/afk-mode-toggle.test.ts
@@ -261,8 +261,8 @@ describe('toggleAfkMode — AFK ledger channel wiring (scope.lock criterion 1)',
     expect(makeLedgerChannelHandler).not.toHaveBeenCalled();
   });
 
-  it('degrades to keyboard-only when the provider session id is not yet known', async () => {
-    const { ctx, swapCalls } = makeCtx({
+  it('degrades to keyboard-only AND warns when the provider session id is not yet known', async () => {
+    const { ctx, swapCalls, lines } = makeCtx({
       stats: makeStats({ permissionMode: 'default' }),
       // no sessionId → e.g. /afk on before the first turn issued an id
       withChannel: true,
@@ -274,6 +274,29 @@ describe('toggleAfkMode — AFK ledger channel wiring (scope.lock criterion 1)',
     expect(swapCalls).toHaveLength(0);
     expect(setPresenceAfk).not.toHaveBeenCalled();
     // AFK still entered — channel is additive, the keyboard stays live.
+    expect(ctx.stats.permissionMode).toBe('autonomous');
+    // F3 guard: the silent skip is gone — the operator is explicitly warned the
+    // phone relay is NOT armed (and told to re-toggle after a turn), so they
+    // don't walk away trusting a dead phone leg.
+    expect(lines.some((l) => l.startsWith('ERROR:') && /phone relay NOT armed/i.test(l))).toBe(true);
+  });
+
+  it('F3: warns about the missing signing key but STILL arms the channel', async () => {
+    ensureSessionKey.mockReturnValueOnce(null);
+    const { ctx, swapCalls, lines } = makeCtx({
+      stats: makeStats({ permissionMode: 'default' }),
+      sessionId: 's-nokey',
+      withChannel: true,
+    });
+
+    await toggleAfkMode(ctx, true);
+
+    // Warned that phone replies / remote abort won't work without a key ...
+    expect(lines.some((l) => l.startsWith('ERROR:') && /signing key/i.test(l))).toBe(true);
+    // ... but the channel is STILL installed (keyboard fallback races) and AFK
+    // is entered — a null key must not silently disable AFK.
+    expect(makeLedgerChannelHandler).toHaveBeenCalledTimes(1);
+    expect(swapCalls).toHaveLength(1);
     expect(ctx.stats.permissionMode).toBe('autonomous');
   });
 

--- a/src/cli/afk-mode-toggle.ts
+++ b/src/cli/afk-mode-toggle.ts
@@ -73,6 +73,18 @@ export async function toggleAfkMode(
       const fallback = ctx.stdinElicitationHandler;
       if (id && swap && fallback) {
         const key = ensureSessionKey(id);
+        if (key === null) {
+          // F3 guard: with no per-session HMAC key we cannot verify a phone reply
+          // or a remote /abort, so the ledger channel silently ignores both
+          // (afk-ledger-channel.ts key===null branch). Install the channel anyway
+          // (the keyboard fallback still races) but WARN — otherwise the operator
+          // believes the phone can answer/abort when it cannot. Usually means the
+          // AFK state dir is unwritable.
+          ctx.out.error(
+            'AFK: could not establish a signing key — phone replies and remote ' +
+            '/abort will NOT work (keyboard only). Check that the AFK state dir is writable.',
+          );
+        }
         const ledgerHandler = makeLedgerChannelHandler({
           sessionId: id,
           key,
@@ -89,6 +101,19 @@ export async function toggleAfkMode(
           onAbort: (reason) => sess.abort(reason),
         });
         void setPresenceAfk(id, true);
+      } else {
+        // F3 guard: the ledger channel binds to the provider session id, which is
+        // unknown until the first turn completes. Toggling AFK before the first
+        // turn leaves the session KEYBOARD-ONLY — no phone relay, no abort-watcher,
+        // no presence marker — while "AFK mode ON" still prints below, silently
+        // stranding an operator who walks away trusting the phone. Warn explicitly
+        // and say how to arm it. (swap/fallback are always wired in the REPL, so
+        // in practice this branch means "no session id yet".)
+        ctx.out.error(
+          'AFK: phone relay NOT armed — the session has no id until your first ' +
+          'message completes. Running keyboard-only; re-run /afk on after a turn to ' +
+          'enable phone questions/approvals and remote /abort.',
+        );
       }
       ctx.out.success(
         palette.info('◐ AFK mode ON') +

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -422,16 +422,29 @@ async function main() {
           ? assembleSystemPrompt(rawPromptInner, telegramAutoRoutingInner, 'telegram')
           : rawPromptInner;
 
-        // permissionMode is intentionally omitted here: AgentSession defaults
-        // to 'default' (post-C2 fix), which is the correct mode for Telegram
-        // sessions that run under the operator's explicit allowedTools list.
+        // permissionMode is omitted from session CONSTRUCTION: AgentSession
+        // defaults to 'default'. A Telegram session becomes 'autonomous' only via
+        // an explicit `/afk on` (handlers/afk.ts) calling setPermissionMode —
+        // never at construction. The hook registry below now receives a LIVE mode
+        // getter (reading the session's own metadata) so the afk-mode safety gate
+        // is actually registered on Telegram and tracks that toggle; without it
+        // (the prior `undefined`) the gate was never registered and an autonomous
+        // Telegram session would have had NO risk ceiling. afkPromptForApproval:
+        // false makes the always-on host HARD-REFUSE high-risk / irreversible ops
+        // (+ Asking summary) rather than accept a one-tap phone approval — see
+        // docs/afk-telegram-native-host.md.
+        let telegramSessionForMode: AgentSession | undefined;
         const telegramHookBundle = createDefaultHookRegistry(
           undefined,
           'telegram',
           sharedMemoryStore,
-          undefined,
+          () => telegramSessionForMode?.getSessionMetadata().permissionMode ?? 'default',
           loadHooksConfig(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
-          { cwd: sessionCwd !== undefined && sessionCwd.length > 0 ? sessionCwd : undefined, ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}) },
+          {
+            cwd: sessionCwd !== undefined && sessionCwd.length > 0 ? sessionCwd : undefined,
+            ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}),
+            afkPromptForApproval: false,
+          },
           () => sessionCwd,
         );
         const session = attachMcpCleanup(constructTelegramSession({
@@ -451,6 +464,10 @@ async function main() {
           provider: directProvider,
           hookRegistry: telegramHookBundle.registry,
         }, { traceWriter: telegramTraceWriter }), mcpManager);
+        // Late-bind the mode source so the registry's getPermissionMode getter
+        // (built above, before the session existed) reads this session's LIVE
+        // permission mode — flipped by /afk on (handlers/afk.ts).
+        telegramSessionForMode = session;
         returnedSession = session;
         // Wire the path-approval grant ref to the provider so elicitation
         // approvals mutate readRoots / writeRoots on the right backend.
@@ -490,13 +507,22 @@ async function main() {
         surface: 'telegram',
         ...(mcpManager !== undefined ? { mcpManager } : {}),
       });
+      // See the Anthropic branch above: a LIVE mode getter registers the
+      // afk-mode safety gate on Telegram and tracks `/afk on`; afkPromptForApproval
+      // false makes the always-on host hard-refuse high-risk ops rather than accept
+      // a one-tap phone approval (docs/afk-telegram-native-host.md).
+      let codexSessionForMode: AgentSession | undefined;
       const codexHookBundle = createDefaultHookRegistry(
         undefined,
         'telegram',
         sharedMemoryStore,
-        undefined,
+        () => codexSessionForMode?.getSessionMetadata().permissionMode ?? 'default',
         loadHooksConfig(codexSessionCwd !== undefined && codexSessionCwd.length > 0 ? { cwd: codexSessionCwd } : {}),
-        { cwd: codexSessionCwd !== undefined && codexSessionCwd.length > 0 ? codexSessionCwd : undefined, ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}) },
+        {
+          cwd: codexSessionCwd !== undefined && codexSessionCwd.length > 0 ? codexSessionCwd : undefined,
+          ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}),
+          afkPromptForApproval: false,
+        },
         () => codexSessionCwd,
       );
       const session = attachMcpCleanup(constructTelegramSession({
@@ -518,6 +544,9 @@ async function main() {
         provider: codexProvider,
         hookRegistry: codexHookBundle.registry,
       }, { traceWriter: telegramTraceWriter }), mcpManager);
+      // Late-bind the mode source (see Anthropic branch) so the gate's getter
+      // reads this session's live permission mode.
+      codexSessionForMode = session;
       returnedSession = session;
       // Wire the path-approval grant ref + seed persisted `persist` grants so
       // the OpenAI Telegram surface gets the same restricted-path prompts and

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -35,9 +35,8 @@ import { parseAllowedChatIds } from './telegram/allowlist.js';
 import { validateBotToken } from './telegram/setup-wizard.js';
 import { AgentSession } from './agent/session.js';
 import { constructTelegramSession, createTelegramTraceWriter } from './telegram/construct-session.js';
-import { createDefaultHookRegistry } from './agent/default-hook-registry.js';
+import { createTelegramAfkHookBundle } from './telegram/afk-hook-bundle.js';
 import { seedPersistedGrants } from './agent/permissions-store.js';
-import { loadHooksConfig } from './agent/hooks/config-loader.js';
 import { MemoryStore } from './agent/memory/index.js';
 import { providerForModel, AnthropicDirectProvider, OpenAICompatibleProvider } from './agent/providers/index.js';
 import { detectAuthMode } from './agent/providers/anthropic-direct/auth.js';
@@ -425,28 +424,17 @@ async function main() {
         // permissionMode is omitted from session CONSTRUCTION: AgentSession
         // defaults to 'default'. A Telegram session becomes 'autonomous' only via
         // an explicit `/afk on` (handlers/afk.ts) calling setPermissionMode —
-        // never at construction. The hook registry below now receives a LIVE mode
-        // getter (reading the session's own metadata) so the afk-mode safety gate
-        // is actually registered on Telegram and tracks that toggle; without it
-        // (the prior `undefined`) the gate was never registered and an autonomous
-        // Telegram session would have had NO risk ceiling. afkPromptForApproval:
-        // false makes the always-on host HARD-REFUSE high-risk / irreversible ops
-        // (+ Asking summary) rather than accept a one-tap phone approval — see
-        // docs/afk-telegram-native-host.md.
+        // never at construction. The hook bundle carries the AFK autonomous-safety
+        // wiring (live mode getter → registers the afk-mode gate + tracks `/afk
+        // on`; afkPromptForApproval:false → hard-refuse high-risk ops) — see
+        // createTelegramAfkHookBundle + docs/afk-telegram-native-host.md.
         let telegramSessionForMode: AgentSession | undefined;
-        const telegramHookBundle = createDefaultHookRegistry(
-          undefined,
-          'telegram',
-          sharedMemoryStore,
-          () => telegramSessionForMode?.getSessionMetadata().permissionMode ?? 'default',
-          loadHooksConfig(sessionCwd !== undefined && sessionCwd.length > 0 ? { cwd: sessionCwd } : {}),
-          {
-            cwd: sessionCwd !== undefined && sessionCwd.length > 0 ? sessionCwd : undefined,
-            ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}),
-            afkPromptForApproval: false,
-          },
-          () => sessionCwd,
-        );
+        const telegramHookBundle = createTelegramAfkHookBundle({
+          memoryStore: sharedMemoryStore,
+          getSession: () => telegramSessionForMode,
+          cwd: sessionCwd,
+          traceWriter: telegramTraceWriter,
+        });
         const session = attachMcpCleanup(constructTelegramSession({
           ...(sessionConfig.apiKey !== undefined ? { apiKey: sessionConfig.apiKey } : {}),
           model: sessionConfig.model,
@@ -507,24 +495,17 @@ async function main() {
         surface: 'telegram',
         ...(mcpManager !== undefined ? { mcpManager } : {}),
       });
-      // See the Anthropic branch above: a LIVE mode getter registers the
-      // afk-mode safety gate on Telegram and tracks `/afk on`; afkPromptForApproval
-      // false makes the always-on host hard-refuse high-risk ops rather than accept
-      // a one-tap phone approval (docs/afk-telegram-native-host.md).
+      // Same AFK autonomous-safety wiring as the Anthropic branch above (live
+      // mode getter registers the afk-mode gate + tracks `/afk on`;
+      // afkPromptForApproval:false hard-refuses high-risk ops) — see
+      // createTelegramAfkHookBundle + docs/afk-telegram-native-host.md.
       let codexSessionForMode: AgentSession | undefined;
-      const codexHookBundle = createDefaultHookRegistry(
-        undefined,
-        'telegram',
-        sharedMemoryStore,
-        () => codexSessionForMode?.getSessionMetadata().permissionMode ?? 'default',
-        loadHooksConfig(codexSessionCwd !== undefined && codexSessionCwd.length > 0 ? { cwd: codexSessionCwd } : {}),
-        {
-          cwd: codexSessionCwd !== undefined && codexSessionCwd.length > 0 ? codexSessionCwd : undefined,
-          ...(telegramTraceWriter !== null ? { traceWriter: telegramTraceWriter } : {}),
-          afkPromptForApproval: false,
-        },
-        () => codexSessionCwd,
-      );
+      const codexHookBundle = createTelegramAfkHookBundle({
+        memoryStore: sharedMemoryStore,
+        getSession: () => codexSessionForMode,
+        cwd: codexSessionCwd,
+        traceWriter: telegramTraceWriter,
+      });
       const session = attachMcpCleanup(constructTelegramSession({
         ...(sessionConfig.apiKey !== undefined ? { apiKey: sessionConfig.apiKey } : {}),
         model: sessionConfig.model,

--- a/src/telegram/afk-hook-bundle.test.ts
+++ b/src/telegram/afk-hook-bundle.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for createTelegramAfkHookBundle (afk-hook-bundle.ts) — the AFK
+ * autonomous-safety wiring EXTRACTED from telegram.ts main() so it is testable.
+ * main() is module-self-invoked (`main().catch(...)`) and unreachable from a
+ * test, so before this extraction the two load-bearing safety args had ZERO
+ * coverage and could silently regress. These pin them at the exact factory
+ * telegram.ts calls:
+ *   1. a LIVE permission-mode getter → the afk-mode gate is REGISTERED and tracks
+ *      the session's current mode (a regression to `undefined` = no risk ceiling);
+ *   2. afkPromptForApproval:false → high-risk ops HARD-REFUSE, never phone-approve.
+ *
+ * An out-of-workspace `write_file` is the cleanest afk-gate-only trigger: in
+ * 'autonomous' mode path-approval is allowAll-bypassed, so ONLY the afk gate can
+ * refuse it. dispatch() throws HookBlockedError on a block decision.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createTelegramAfkHookBundle } from './afk-hook-bundle.js';
+import { _resetWarningForTests } from '../agent/default-hook-registry.js';
+import { HookBlockedError } from '../utils/errors.js';
+import { elicitationRouter } from '../agent/elicitation-router.js';
+import type { AgentSession } from '../agent/session.js';
+import type { PermissionMode } from '../agent/types/sdk-types.js';
+
+/** Minimal AgentSession stub exposing only the metadata the getter reads. */
+function fakeSession(mode: PermissionMode | undefined): AgentSession {
+  return {
+    getSessionMetadata: () => ({ permissionMode: mode }),
+  } as unknown as AgentSession;
+}
+
+describe('createTelegramAfkHookBundle — AFK autonomous safety wiring', () => {
+  let tmp: string;
+  beforeEach(() => {
+    _resetWarningForTests();
+    tmp = mkdtempSync(join(tmpdir(), 'afk-tg-bundle-'));
+  });
+  afterEach(() => {
+    // Router is module-scope global — clear any handler a test installed.
+    elicitationRouter.uninstall();
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  const outOfWorkspaceWrite = () => ({
+    event: 'PreToolUse' as const,
+    toolName: 'write_file',
+    input: { file_path: join(tmpdir(), `afk-outside-${Date.now()}-${Math.random()}.txt`), content: 'x' },
+  });
+
+  it('autonomous session → HARD-REFUSES a high-risk op (gate registered + afkPromptForApproval:false)', async () => {
+    const bundle = createTelegramAfkHookBundle({
+      memoryStore: undefined,
+      getSession: () => fakeSession('autonomous'),
+      cwd: tmp, // trusted workspace root
+      traceWriter: null,
+    });
+    await expect(bundle.registry.dispatch(outOfWorkspaceWrite())).rejects.toBeInstanceOf(HookBlockedError);
+  });
+
+  it('hard-refuse does NOT prompt the operator: the elicitation handler is never called', async () => {
+    // If afkPromptForApproval:false were not threaded, the gate would default to
+    // promptForApproval:true, CALL this handler, get 'approve', and ALLOW the op.
+    const handler = vi.fn(async () => ({ action: 'accept' as const, content: { choice: 'approve' } }));
+    elicitationRouter.install(handler);
+    const bundle = createTelegramAfkHookBundle({
+      memoryStore: undefined,
+      getSession: () => fakeSession('autonomous'),
+      cwd: tmp,
+      traceWriter: null,
+    });
+    await expect(bundle.registry.dispatch(outOfWorkspaceWrite())).rejects.toBeInstanceOf(HookBlockedError);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('session not yet late-bound (getSession→undefined) → mode falls back to \'default\', op NOT afk-refused', async () => {
+    // The `?? 'default'` fallback is fail-safe: before late-bind the gate no-ops
+    // (mode !== 'autonomous') and unwired path-approval fails open ⇒ dispatch resolves.
+    const bundle = createTelegramAfkHookBundle({
+      memoryStore: undefined,
+      getSession: () => undefined,
+      cwd: tmp,
+      traceWriter: null,
+    });
+    await expect(bundle.registry.dispatch(outOfWorkspaceWrite())).resolves.toBeDefined();
+  });
+
+  it('the mode getter is LIVE — a /afk on flip AFTER construction is observed on the next dispatch', async () => {
+    // Proves the late-bind contract: the getter reads the current value each call,
+    // not a snapshot taken at registry-build time.
+    let mode: PermissionMode = 'default';
+    const bundle = createTelegramAfkHookBundle({
+      memoryStore: undefined,
+      getSession: () => fakeSession(mode),
+      cwd: tmp,
+      traceWriter: null,
+    });
+    // 'default': afk gate no-ops → op resolves.
+    await expect(bundle.registry.dispatch(outOfWorkspaceWrite())).resolves.toBeDefined();
+    // `/afk on` flips the live mode → the SAME op now hard-refuses.
+    mode = 'autonomous';
+    await expect(bundle.registry.dispatch(outOfWorkspaceWrite())).rejects.toBeInstanceOf(HookBlockedError);
+  });
+
+  it('autonomous still ALLOWS a reversible (safe) op — read inside the workspace', async () => {
+    const bundle = createTelegramAfkHookBundle({
+      memoryStore: undefined,
+      getSession: () => fakeSession('autonomous'),
+      cwd: tmp,
+      traceWriter: null,
+    });
+    await expect(
+      bundle.registry.dispatch({
+        event: 'PreToolUse' as const,
+        toolName: 'read_file',
+        input: { file_path: join(tmp, 'in-workspace.ts') },
+      }),
+    ).resolves.toBeDefined();
+  });
+});

--- a/src/telegram/afk-hook-bundle.ts
+++ b/src/telegram/afk-hook-bundle.ts
@@ -1,0 +1,77 @@
+/**
+ * AFK autonomous-safety hook wiring for the always-on Telegram host.
+ *
+ * `telegram.ts main()` builds two structurally identical hook registries (the
+ * Anthropic-direct branch and the OpenAI-compatible "codex" branch). Both encode
+ * two load-bearing safety invariants; this factory is the single home for them:
+ *
+ *   1. A LIVE per-session permission-mode getter. Passing a real getter (never
+ *      `undefined`) is what REGISTERS the afk-mode safety gate on Telegram —
+ *      `createDefaultHookRegistry` only wires the gate when `getPermissionMode`
+ *      is defined, so the prior `undefined` meant an autonomous Telegram session
+ *      had NO risk ceiling. Reading the session's LIVE mode lets the gate track a
+ *      runtime `/afk on` flip (handlers/afk.ts). The `?? 'default'` fallback is
+ *      fail-safe: before the session is late-bound the mode reads as the fully
+ *      path-contained 'default', never 'autonomous'.
+ *   2. `afkPromptForApproval: false`. On the persistent, always-on phone host a
+ *      high-risk / irreversible op HARD-REFUSES (+ Asking summary) rather than
+ *      being one-tap-approvable from a standing surface with a possibly-broad
+ *      cwd. See docs/afk-telegram-native-host.md.
+ *
+ * Extracted from `main()` — which is module-self-invoked (`telegram.ts` ends with
+ * `main().catch(...)`) and therefore unreachable from any test — precisely so
+ * these two safety args are UNIT-TESTABLE and cannot silently regress to
+ * phone-approvable / gate-unregistered. Contract pinned by afk-hook-bundle.test.ts.
+ */
+
+import {
+  createDefaultHookRegistry,
+  type DefaultHookRegistryResult,
+} from '../agent/default-hook-registry.js';
+import { loadHooksConfig } from '../agent/hooks/config-loader.js';
+import type { MemoryStore } from '../agent/memory/index.js';
+import type { AgentSession } from '../agent/session.js';
+import type { TraceWriter } from '../agent/trace/index.js';
+
+export interface TelegramAfkHookBundleParams {
+  /** Shared cross-session memory store (3rd positional arg of the registry). */
+  memoryStore: MemoryStore | undefined;
+  /**
+   * Late-bound accessor for THIS chat's session. The registry's mode getter is
+   * built before the session exists (the session's hookRegistry IS this bundle),
+   * so the accessor closes over a `let` the caller assigns post-construction —
+   * `() => session` reads the live value once bound.
+   */
+  getSession: () => AgentSession | undefined;
+  /** Session cwd (AFK_TELEGRAM_CWD / sessionConfig.cwd), or undefined. */
+  cwd: string | undefined;
+  /** Telegram trace writer, or null when tracing is disabled. */
+  traceWriter: TraceWriter | null;
+}
+
+/**
+ * Build the Telegram hook registry with the AFK autonomous-safety wiring. Byte-
+ * equivalent to the two former inline `createDefaultHookRegistry(...)` calls in
+ * `telegram.ts main()`; both branches now call this.
+ */
+export function createTelegramAfkHookBundle(
+  params: TelegramAfkHookBundleParams,
+): DefaultHookRegistryResult {
+  const { memoryStore, getSession, cwd, traceWriter } = params;
+  return createDefaultHookRegistry(
+    undefined,
+    'telegram',
+    memoryStore,
+    // Live getter: registers the afk-mode gate AND tracks `/afk on`; falls back
+    // to the fully-contained 'default' until the session is late-bound.
+    () => getSession()?.getSessionMetadata().permissionMode ?? 'default',
+    loadHooksConfig(cwd !== undefined && cwd.length > 0 ? { cwd } : {}),
+    {
+      cwd: cwd !== undefined && cwd.length > 0 ? cwd : undefined,
+      ...(traceWriter !== null ? { traceWriter } : {}),
+      // Always-on host posture: hard-refuse high-risk ops, never phone-approve.
+      afkPromptForApproval: false,
+    },
+    () => cwd,
+  );
+}

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -10,6 +10,7 @@ import { handleStart } from './handlers/start.js';
 import { handleHelp } from './handlers/help.js';
 import { handleClear, handleCompact, handleCwd, handleModelSwitch, handleName, MODEL_ALIASES_HINT } from './handlers/commands.js';
 import { handleSessions, handleNew, handleSwitchCallback } from './handlers/sessions.js';
+import { handleAfk } from './handlers/afk.js';
 import type { AgentModelInput } from '../agent/types.js';
 import { handleFarmCallback } from './handlers/farm-callbacks.js';
 import { MessageHandler } from './handlers/message.js';
@@ -141,6 +142,12 @@ export class TelegramBot {
     );
     this.bot.command('name', (ctx) =>
       handleName(ctx, this.sessionManager, this.log.bind(this))
+    );
+    // /afk [on|off] — toggle autonomous mode for this chat's session. On the
+    // always-on host, high-risk ops hard-refuse (not phone-approvable); see
+    // handlers/afk.ts + docs/afk-telegram-native-host.md.
+    this.bot.command('afk', (ctx) =>
+      handleAfk(ctx, this.sessionManager, this.log.bind(this))
     );
     // /sessions — list this chat's resumable conversations with tap-to-switch
     // buttons; /new — start a fresh conversation (previous preserved). One
@@ -372,6 +379,7 @@ export class TelegramBot {
       { command: 'model', description: 'Switch Claude model (opus/sonnet/haiku)' },
       { command: 'cd', description: 'Show or change session working directory' },
       { command: 'name', description: 'Show or set the session name' },
+      { command: 'afk', description: 'Toggle autonomous (AFK) mode for this chat' },
       { command: 'watch', description: 'Live-tail a CLI session from this chat' },
       { command: 'unwatch', description: 'Stop watching a session' },
     ]);

--- a/src/telegram/handlers/afk.test.ts
+++ b/src/telegram/handlers/afk.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for the Telegram `/afk` command handler (handlers/afk.ts).
+ *
+ * Verifies the toggle flips the chat session's permission mode via
+ * setPermissionMode, is a no-op when already in the requested state, and
+ * surfaces the hard-refuse safety posture in the ON copy.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Context } from 'telegraf';
+import { handleAfk } from './afk.js';
+import type { SessionManager } from '../session-manager.js';
+
+function makeCtx(text: string): { ctx: Context; replies: string[] } {
+  const replies: string[] = [];
+  const ctx = {
+    chat: { id: 555 },
+    message: { text },
+    reply: (t: string) => {
+      replies.push(t);
+      return Promise.resolve({ message_id: replies.length });
+    },
+  };
+  return { ctx: ctx as unknown as Context, replies };
+}
+
+function makeSession(mode: 'default' | 'autonomous') {
+  let current = mode;
+  const setPermissionMode = vi.fn(async (m: 'default' | 'autonomous') => {
+    current = m;
+  });
+  const session = {
+    getSessionMetadata: () => ({ permissionMode: current }),
+    setPermissionMode,
+  };
+  return { session, setPermissionMode };
+}
+
+function makeSM(session: unknown): SessionManager {
+  return { getSession: vi.fn(async () => session) } as unknown as SessionManager;
+}
+
+describe('handleAfk (/afk on Telegram)', () => {
+  it('/afk on flips a default session to autonomous and surfaces the hard-refuse posture', async () => {
+    const s = makeSession('default');
+    const { ctx, replies } = makeCtx('/afk on');
+
+    await handleAfk(ctx, makeSM(s.session), () => {});
+
+    expect(s.setPermissionMode).toHaveBeenCalledWith('autonomous');
+    const joined = replies.join('\n');
+    expect(joined).toMatch(/AFK mode ON/i);
+    // The ON copy must make clear high-risk ops are NOT one-tap approvable here.
+    expect(joined).toMatch(/REFUSED/);
+  });
+
+  it('/afk off restores default', async () => {
+    const s = makeSession('autonomous');
+    const { ctx, replies } = makeCtx('/afk off');
+
+    await handleAfk(ctx, makeSM(s.session), () => {});
+
+    expect(s.setPermissionMode).toHaveBeenCalledWith('default');
+    expect(replies.join('\n')).toMatch(/AFK mode OFF/i);
+  });
+
+  it('bare /afk toggles based on the current mode', async () => {
+    const s = makeSession('default');
+    const { ctx } = makeCtx('/afk');
+
+    await handleAfk(ctx, makeSM(s.session), () => {});
+
+    expect(s.setPermissionMode).toHaveBeenCalledWith('autonomous');
+  });
+
+  it('/afk on when already ON is a no-op with a notice (no setPermissionMode call)', async () => {
+    const s = makeSession('autonomous');
+    const { ctx, replies } = makeCtx('/afk on');
+
+    await handleAfk(ctx, makeSM(s.session), () => {});
+
+    expect(s.setPermissionMode).not.toHaveBeenCalled();
+    expect(replies.join('\n')).toMatch(/already ON/i);
+  });
+});

--- a/src/telegram/handlers/afk.test.ts
+++ b/src/telegram/handlers/afk.test.ts
@@ -82,4 +82,27 @@ describe('handleAfk (/afk on Telegram)', () => {
     expect(s.setPermissionMode).not.toHaveBeenCalled();
     expect(replies.join('\n')).toMatch(/already ON/i);
   });
+
+  it('restart safe-degrades to default: a fresh session for the same chat needs re-arming (handler holds no cross-restart mode state)', async () => {
+    // handlers/afk.ts documents the mode is runtime-only and NOT persisted, so a
+    // bot restart brings the chat back to 'default' and never silently resumes
+    // autonomous. Model a restart of the SAME chat (id 555): arm session1, then
+    // hand /afk a FRESH session at 'default' (exactly what constructTelegramSession
+    // yields — permissionMode omitted). It must RE-ARM (call setPermissionMode +
+    // print the ON copy), NOT report "already ON". A regression that cached the
+    // flip in module/chat state would wrongly short-circuit here.
+    const armed = makeSession('default');
+    await handleAfk(makeCtx('/afk on').ctx, makeSM(armed.session), () => {});
+    expect(armed.setPermissionMode).toHaveBeenCalledWith('autonomous');
+
+    // --- bot restart: a brand-new session for the same chat, mode 'default' ---
+    const afterRestart = makeSession('default');
+    const { ctx, replies } = makeCtx('/afk on');
+    await handleAfk(ctx, makeSM(afterRestart.session), () => {});
+
+    expect(afterRestart.setPermissionMode).toHaveBeenCalledWith('autonomous');
+    const joined = replies.join('\n');
+    expect(joined).toMatch(/AFK mode ON/i);
+    expect(joined).not.toMatch(/already ON/i);
+  });
 });

--- a/src/telegram/handlers/afk.ts
+++ b/src/telegram/handlers/afk.ts
@@ -1,0 +1,68 @@
+/**
+ * `/afk [on|off]` — toggle AFK (autonomous) mode for THIS chat's session.
+ *
+ * Telegram-host analogue of the REPL `/afk` (src/cli/afk-mode-toggle.ts). Flips
+ * the chat session's permission mode to 'autonomous' (raised autonomy: works
+ * without asking on reversible work) or back to 'default'. The afk-mode safety
+ * gate — now registered on Telegram (see the hook-registry wiring in
+ * src/telegram.ts) — enforces the ceiling and reads the session's live mode.
+ *
+ * SAFETY POSTURE (deliberately differs from the laptop REPL): on the persistent,
+ * always-on Telegram host, high-risk / irreversible ops HARD-REFUSE
+ * (afkPromptForApproval:false in the registry wiring) and are surfaced as an
+ * Asking summary — they are NOT one-tap-approvable from a standing phone
+ * surface. Decision record: docs/afk-telegram-native-host.md.
+ *
+ * Restart posture: the mode is runtime-only and NOT persisted — a bot restart
+ * safe-degrades the chat back to 'default' (it never silently resumes autonomous
+ * after a crash). Re-run /afk on to re-arm.
+ */
+
+import type { Context } from 'telegraf';
+import type { Message } from 'telegraf/types';
+import { SessionManager } from '../session-manager.js';
+import { formatError } from '../formatter.js';
+
+type LogFn = (...args: unknown[]) => void;
+
+const AFK_ON_COPY =
+  '◐ AFK mode ON — I\'ll work autonomously on reversible tasks and report here. ' +
+  'High-risk / irreversible ops are REFUSED (not one-tap approvable) and surfaced ' +
+  'as an Asking summary for you to handle deliberately. Send /afk off to stop.';
+
+const AFK_OFF_COPY = '○ AFK mode OFF — default permissions restored.';
+
+export async function handleAfk(
+  ctx: Context,
+  sessionManager: SessionManager,
+  log: LogFn,
+): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) {
+    await ctx.reply(formatError('Could not identify chat'));
+    return;
+  }
+
+  const text = (ctx.message as Message.TextMessage).text ?? '';
+  const arg = text.split(/\s+/).slice(1).join(' ').trim().toLowerCase();
+
+  try {
+    // getSession lazily constructs the chat's session if needed — which also
+    // binds the hook-registry mode getter to it (src/telegram.ts), so the gate
+    // observes the flip below on the very next tool call.
+    const session = await sessionManager.getSession(chatId);
+    const current = session.getSessionMetadata().permissionMode === 'autonomous';
+    const desired = arg === 'on' ? true : arg === 'off' ? false : !current;
+
+    if (desired === current) {
+      await ctx.reply(desired ? '◐ AFK mode is already ON.' : '○ AFK mode is already OFF.');
+      return;
+    }
+
+    await session.setPermissionMode(desired ? 'autonomous' : 'default');
+    await ctx.reply(desired ? AFK_ON_COPY : AFK_OFF_COPY);
+  } catch (error) {
+    log('AFK toggle error:', error);
+    await ctx.reply(formatError('Could not toggle AFK mode'));
+  }
+}

--- a/src/telegram/hook-wiring.test.ts
+++ b/src/telegram/hook-wiring.test.ts
@@ -29,6 +29,8 @@ import {
 import { AnthropicDirectProvider, OpenAICompatibleProvider } from '../agent/providers/index.js';
 import type { GrantManager } from '../cli/slash/commands/allow-dir.js';
 import { seedPersistedGrants, generateUlid, type PermissionsFile } from '../agent/permissions-store.js';
+import { HookBlockedError } from '../utils/errors.js';
+import { elicitationRouter } from '../agent/elicitation-router.js';
 
 function writePermissionsFile(dir: string, absPath: string): string {
   const file = join(dir, 'permissions.json');
@@ -103,4 +105,104 @@ describe('Telegram hook wiring — path-approval grant ref (PR #202 H1/L4)', () 
       expect(provider.getGrants().readRoots).toContain(granted);
     });
   }
+});
+
+// ---------------------------------------------------------------------------
+// D v1: AFK autonomous safety wiring on Telegram
+// ---------------------------------------------------------------------------
+
+/**
+ * The always-on Telegram host must (a) actually REGISTER the afk-mode safety
+ * gate when a session is autonomous — before D v1 it passed getPermissionMode
+ * `undefined`, so the gate was never registered and an autonomous Telegram
+ * session had NO risk ceiling — and (b) HARD-REFUSE high-risk/irreversible ops
+ * (afkPromptForApproval:false) rather than accept a one-tap phone approval.
+ *
+ * An out-of-workspace `write_file` is the cleanest afk-gate-only trigger: in
+ * 'autonomous' mode path-approval is allowAll-bypassed, so ONLY the afk gate can
+ * refuse it. `dispatch()` throws HookBlockedError on a block decision.
+ */
+describe('Telegram AFK autonomous safety wiring (D v1)', () => {
+  let tmp: string;
+  beforeEach(() => {
+    _resetWarningForTests();
+    tmp = mkdtempSync(join(tmpdir(), 'afk-tg-afk-'));
+  });
+  afterEach(() => {
+    // Router is module-scope global — clear any handler a test installed.
+    elicitationRouter.uninstall();
+    try { rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
+  });
+
+  const outOfWorkspaceWrite = () => ({
+    event: 'PreToolUse' as const,
+    toolName: 'write_file',
+    input: { file_path: join(tmpdir(), `afk-outside-${Date.now()}-${Math.random()}.txt`), content: 'x' },
+  });
+
+  it('autonomous + afkPromptForApproval:false HARD-REFUSES a high-risk op (no phone approval)', async () => {
+    const bundle = createDefaultHookRegistry(
+      undefined,
+      'telegram',
+      undefined,
+      () => 'autonomous', // D v1: the mode getter is now wired
+      undefined,
+      { afkPromptForApproval: false }, // always-on host posture: hard-refuse
+      () => tmp, // trusted workspace root
+    );
+    await expect(bundle.registry.dispatch(outOfWorkspaceWrite())).rejects.toBeInstanceOf(HookBlockedError);
+  });
+
+  it('regression: with NO mode getter (old wiring) the afk gate is absent, so the same op is NOT refused', async () => {
+    const bundle = createDefaultHookRegistry(
+      undefined,
+      'telegram',
+      undefined,
+      undefined, // getPermissionMode undefined → afk gate never registered
+      undefined,
+      undefined,
+      () => tmp,
+    );
+    // No afk gate + unwired (fail-open) path-approval ⇒ dispatch resolves, no block.
+    await expect(bundle.registry.dispatch(outOfWorkspaceWrite())).resolves.toBeDefined();
+  });
+
+  it('hard-refuse does NOT prompt the operator: the elicitation handler is never called', async () => {
+    // If afkPromptForApproval:false were NOT threaded through the registry, the
+    // gate would default to promptForApproval:true, CALL this handler, get an
+    // 'approve', and ALLOW the op (dispatch resolves). Threaded correctly, the
+    // op hard-blocks WITHOUT ever asking — this is the always-on-host posture.
+    const handler = vi.fn(async () => ({ action: 'accept' as const, content: { choice: 'approve' } }));
+    elicitationRouter.install(handler);
+    const bundle = createDefaultHookRegistry(
+      undefined,
+      'telegram',
+      undefined,
+      () => 'autonomous',
+      undefined,
+      { afkPromptForApproval: false },
+      () => tmp,
+    );
+    await expect(bundle.registry.dispatch(outOfWorkspaceWrite())).rejects.toBeInstanceOf(HookBlockedError);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('autonomous still allows a reversible (safe) op — read inside the workspace', async () => {
+    const bundle = createDefaultHookRegistry(
+      undefined,
+      'telegram',
+      undefined,
+      () => 'autonomous',
+      undefined,
+      { afkPromptForApproval: false },
+      () => tmp,
+    );
+    await expect(
+      bundle.registry.dispatch({
+        event: 'PreToolUse' as const,
+        toolName: 'read_file',
+        input: { file_path: join(tmp, 'in-workspace.ts') },
+      }),
+    ).resolves.toBeDefined();
+  });
 });

--- a/src/telegram/watch.test.ts
+++ b/src/telegram/watch.test.ts
@@ -424,6 +424,194 @@ describe('SessionWatchManager — elicitation intercept + signed write-back (cri
 });
 
 // ---------------------------------------------------------------------------
+// F1 regression: high-risk approval FORM must render as buttons over the relay
+// ---------------------------------------------------------------------------
+
+/**
+ * Like makeElicitStubs, but also captures sendMessage OPTIONS (reply_markup) and
+ * the bot.action registrations, so a form-mode elicitation's inline keyboard and
+ * its button-tap round-trip can be asserted.
+ *
+ * Regression guard: the ledger relay (watch.ts) once installed the ask-ONLY
+ * handler. An untyped `mode:'form'` request (what afk-mode-gate.buildApprovalRequest
+ * emits) then defaulted to a plain text prompt (NO buttons) and returned
+ * content.value, which the afk-mode-gate consumer (reads content.choice) rejected
+ * as 'unrecognised' — so an away operator could not approve a high-risk op from
+ * Telegram. The relay must install the COMPOSED handler (like bot.ts) so form
+ * requests render via the afk:pa: enum keyboard and return content.choice.
+ */
+function makeFormElicitStubs(chatId: number) {
+  const pendingElicitations = new Map<number, (text: string) => void>();
+  const ledgerOriginatedPendingChats = new Set<number>();
+  const sent: Array<{ text: string; options?: { reply_markup?: unknown } }> = [];
+  const actions: Array<{ matcher: unknown; handler: (ctx: unknown) => unknown }> = [];
+  const bot = {
+    action: vi.fn().mockImplementation((matcher: unknown, handler: (ctx: unknown) => unknown) => {
+      actions.push({ matcher, handler });
+    }),
+    telegram: {
+      sendMessage: vi.fn().mockImplementation(
+        (_chatId: number, text: string, options?: { reply_markup?: unknown }) => {
+          sent.push({ text, options });
+          return Promise.resolve({ message_id: sent.length });
+        },
+      ),
+    },
+  };
+  const messageHandler = {
+    pendingElicitations,
+    ledgerOriginatedPendingChats,
+  } as unknown as MessageHandler;
+  return { bot, messageHandler, sent, actions, chatId };
+}
+
+interface InlineButton { text: string; callback_data: string }
+
+describe('SessionWatchManager — F1 regression: form-mode approval renders buttons', () => {
+  it('renders a mode:form approval as an inline keyboard and writes back content.choice', async () => {
+    const id = freshId();
+    const chatId = 77;
+    const key = ensureSessionKey(id);
+    expect(key).toBeTruthy();
+
+    const { bot, messageHandler, sent, actions } = makeFormElicitStubs(chatId);
+
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('setup');
+    await sleep(50);
+
+    const manager = new SessionWatchManager(
+      () => {},
+      bot as unknown as import('telegraf').Telegraf,
+      messageHandler,
+    );
+    manager.start(chatId, id, async () => {});
+    await sleep(100);
+
+    // The exact shape afk-mode-gate.buildApprovalRequest emits: mode:'form',
+    // enum approve/deny, NO `type`.
+    const reqId = freshChannelId();
+    writer.record({
+      kind: 'elicitation',
+      reqId,
+      request: {
+        serverName: 'agent-afk',
+        message: 'AFK: `bash` is high-risk / irreversible. Approve this single call?',
+        mode: 'form',
+        title: 'AFK high-risk approval',
+        requestedSchema: {
+          type: 'object',
+          properties: {
+            choice: { type: 'string', title: 'Approve?', enum: ['approve', 'deny'] },
+          },
+          required: ['choice'],
+        },
+      },
+    });
+
+    await sleep(250);
+
+    // ASSERTION 1: the prompt rendered with an inline keyboard whose buttons carry
+    // afk:pa: callback_data. The ask-only handler would send a plain text prompt
+    // with NO reply_markup — this find() would be undefined and the test fails.
+    const formMsg = sent.find((m) => m.options?.reply_markup !== undefined);
+    expect(formMsg, 'form-mode approval must render with an inline keyboard (buttons)').toBeDefined();
+    const keyboard = (formMsg!.options!.reply_markup as { inline_keyboard: InlineButton[][] }).inline_keyboard;
+    const buttons = keyboard.flat();
+    const approveBtn = buttons.find((b) => b.callback_data.endsWith(':approve'));
+    expect(approveBtn, 'must offer an Approve button').toBeDefined();
+    expect(approveBtn!.callback_data.startsWith('afk:pa:')).toBe(true);
+
+    // Simulate the operator tapping "Approve": invoke the afk:pa: action handler.
+    const paAction = actions.find(
+      (a) => a.matcher instanceof RegExp && (a.matcher as RegExp).test('afk:pa:x:approve'),
+    );
+    expect(paAction, 'the afk:pa: action handler must be registered').toBeDefined();
+    const answerCbQuery = vi.fn().mockResolvedValue(undefined);
+    await paAction!.handler({ callbackQuery: { data: approveBtn!.callback_data }, answerCbQuery });
+
+    await sleep(200);
+
+    // ASSERTION 2: the written-back response carries content.choice (what
+    // afk-mode-gate reads) — NOT content.value. Under the ask-only handler this
+    // would be content.value and the gate would refuse the op.
+    const ledgerPath = path.join(tmpDir, 'state', 'sessions', id, 'events.jsonl');
+    const lines = fs.readFileSync(ledgerPath, 'utf8').trim().split('\n');
+    const responseRecord = lines
+      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
+      .find((r) => r?.kind === 'elicitation_response');
+    expect(responseRecord).toBeDefined();
+    expect(responseRecord.reqId).toBe(reqId);
+    const result: ElicitationResult = responseRecord.result;
+    expect(result.action).toBe('accept');
+    expect((result.content as { choice?: string } | undefined)?.choice).toBe('approve');
+
+    // HMAC verifies with the real verifier.
+    const readKey = readSessionKey(id);
+    expect(readKey).toBeTruthy();
+    const valid = verifyElicitationResponse(readKey!, id, reqId, result, responseRecord.hmac);
+    expect(valid).toBe(true);
+
+    await writer.close();
+    manager.stop(chatId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keep-alive: heartbeat for a pending elicitation (answer-whenever, no cutoff)
+// ---------------------------------------------------------------------------
+
+describe('SessionWatchManager — keep-alive heartbeat for a pending elicitation', () => {
+  it('re-nudges (capped) while pending without cutting off the wait, and stops after the answer', async () => {
+    const id = freshId();
+    const chatId = 88;
+    ensureSessionKey(id);
+
+    const { bot, messageHandler, pendingElicitations } = makeElicitStubs(chatId);
+
+    const writer = new SessionLedgerWriter(id);
+    writer.recordUser('setup');
+    await sleep(50);
+
+    const sent: string[] = [];
+    // Tiny heartbeat interval (25ms) so the test doesn't wait 15 minutes.
+    const manager = new SessionWatchManager(
+      () => {},
+      bot as unknown as import('telegraf').Telegraf,
+      messageHandler,
+      25,
+    );
+    manager.start(chatId, id, async (text) => { sent.push(text); });
+    await sleep(100);
+
+    writer.record({
+      kind: 'elicitation',
+      reqId: 'req-hb',
+      request: { type: 'text', message: 'name?' },
+    });
+
+    // Wait through many heartbeat intervals WITHOUT answering.
+    await sleep(400);
+    const nudges = () => sent.filter((t) => /still waiting/i.test(t)).length;
+    // Fired at least once, but capped (MAX_ELICIT_NUDGES = 4) — never spams forever ...
+    expect(nudges()).toBeGreaterThanOrEqual(1);
+    expect(nudges()).toBeLessThanOrEqual(4);
+    // ... and the wait is STILL open — answer whenever (resolver live, NOT cut off).
+    const resolver = pendingElicitations.get(chatId);
+    expect(resolver).toBeDefined();
+
+    // Answer → the wait resolves, the heartbeat is cleared, nudges stop.
+    const beforeAnswer = nudges();
+    resolver!('Alice');
+    await sleep(150);
+    expect(nudges()).toBe(beforeAnswer);
+
+    await writer.close();
+    manager.stop(chatId);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Criterion 4: getWatched() getter + daemon abort-record signing
 // ---------------------------------------------------------------------------
 

--- a/src/telegram/watch.ts
+++ b/src/telegram/watch.ts
@@ -25,6 +25,7 @@ import { findSession, listSessions } from '../cli/session-store.js';
 import { readPresenceFiles } from '../agent/awareness/presence.js';
 import { readSessionKey, signElicitationResponse } from '../agent/afk-channel.js';
 import { makeTelegramElicitationHandler } from './elicitation-handler.js';
+import { createTelegramElicitationHandler, composeTelegramElicitation } from './elicitation-telegram.js';
 import type { MessageHandler } from './handlers/message.js';
 import type { Telegraf } from 'telegraf';
 
@@ -37,6 +38,19 @@ const FLUSH_INTERVAL_MS = 1_500;
 const WATCH_TEXT_PREVIEW = 700;
 /** Max characters of a tool input preview shown per record. */
 const WATCH_TOOL_PREVIEW = 160;
+
+/**
+ * Keep-alive heartbeat for a PENDING AFK elicitation. AFK deliberately imposes
+ * NO deadline on the operator's answer (elicitation-router.ts) — they may be
+ * away for minutes or hours and must be able to answer WHENEVER. But a silent
+ * multi-hour wait reads like a hang, so while a question is pending we re-nudge
+ * the chat on this interval: reassurance that the run is parked ON the operator,
+ * not stuck, and the prompt resurfaces above newer chatter. The nudges TAPER
+ * (cap below) and NEVER shorten or cancel the wait — only remind.
+ */
+const DEFAULT_ELICIT_HEARTBEAT_MS = 15 * 60_000;
+/** Max keep-alive nudges before going quiet (the wait itself stays uncapped). */
+const MAX_ELICIT_NUDGES = 4;
 
 function preview(text: string, max: number): string {
   const flat = text.replace(/\s+/g, ' ').trim();
@@ -154,11 +168,18 @@ export class SessionWatchManager {
   private readonly log: LogFn;
   private readonly bot: Telegraf | undefined;
   private readonly messageHandler: MessageHandler | undefined;
+  private readonly elicitHeartbeatMs: number;
 
-  constructor(log: LogFn = () => {}, bot?: Telegraf, messageHandler?: MessageHandler) {
+  constructor(
+    log: LogFn = () => {},
+    bot?: Telegraf,
+    messageHandler?: MessageHandler,
+    elicitHeartbeatMs: number = DEFAULT_ELICIT_HEARTBEAT_MS,
+  ) {
     this.log = log;
     this.bot = bot;
     this.messageHandler = messageHandler;
+    this.elicitHeartbeatMs = elicitHeartbeatMs;
   }
 
   /** The session id this chat is watching, if any. */
@@ -216,18 +237,35 @@ export class SessionWatchManager {
     let flushTimer: NodeJS.Timeout | null = null;
     let sending = Promise.resolve();
 
-    // Contract: build a per-run elicitation handler only when bot + messageHandler
-    // are available (they are injected from bot.ts but absent in legacy tests).
-    // The handler is created lazily once and reused across multiple elicitation
-    // records in the same watch run so the wildcard bot.action dispatch table
-    // is only registered once.
-    // ledgerOriginated:true tells the handler to register the chatId in
-    // messageHandler.ledgerOriginatedPendingChats alongside pendingElicitations,
-    // so the message-handler idle-guard fires the resolver even with no active
-    // AgentSession for this chat (the REPL runs in a separate process).
+    // Invariant: the ledger relay MUST mirror bot.ts's native install — a
+    // COMPOSED handler, not the ask handler alone. ask_question shapes carry a
+    // `type` and route to the ask handler (confirm/choice→buttons; text/number/
+    // multi_choice→typed reply). But the afk-mode-gate high-risk approval prompt
+    // and MCP form/url elicitations carry mode:'form' with NO `type`: the ask
+    // handler defaults those to a free-text prompt (no buttons) and returns
+    // content.value, while the afk-mode-gate consumer reads content.choice →
+    // 'unrecognised' → the op is refused. So an away operator literally could not
+    // approve a high-risk op from the phone. The form handler (afk:pa: enum
+    // keyboard) renders tappable buttons and returns content.choice. Composing
+    // them (disjoint afk:e: / afk:pa: callback prefixes) is exactly what bot.ts
+    // does for the native surface — the relay must not diverge. Built only when
+    // bot + messageHandler are present (absent in legacy tests); reused across
+    // records in the run so each factory's wildcard bot.action registers once.
+    // ledgerOriginated:true keeps the ask handler's typed-reply idle-guard firing
+    // with no local AgentSession (the REPL runs in a separate process); the form
+    // handler resolves via bot.action button taps and needs no such wiring.
     const elicitHandler =
       this.bot !== undefined && this.messageHandler !== undefined
-        ? makeTelegramElicitationHandler(this.messageHandler, this.bot, chatId, { ledgerOriginated: true })
+        ? composeTelegramElicitation(
+            makeTelegramElicitationHandler(this.messageHandler, this.bot, chatId, {
+              ledgerOriginated: true,
+            }),
+            createTelegramElicitationHandler(
+              this.bot,
+              new Set([chatId]),
+              (...args) => this.log('[elicitation]', ...args),
+            ),
+          )
         : undefined;
 
     const flush = (): void => {
@@ -258,7 +296,36 @@ export class SessionWatchManager {
           // Await the operator's answer (or abort). The per-run signal bounds
           // the wait: if the user /unwatches or the bot shuts down, the abort
           // propagates through the handler and we get { action: 'decline' }.
-          const result = await elicitHandler(rec.request, { signal });
+          //
+          // Keep-alive: AFK imposes NO time deadline on the answer (the operator
+          // may be away for hours and must answer WHENEVER), so while we await we
+          // re-nudge the chat on a heartbeat — reassurance the run is parked ON
+          // the operator, not hung. The nudges taper (MAX_ELICIT_NUDGES) and
+          // NEVER shorten the wait; the interval is unref'd so it can't hold the
+          // process open, and is always cleared when the answer settles.
+          const elicitStartedAt = Date.now();
+          let nudges = 0;
+          const heartbeat = setInterval(() => {
+            if (nudges >= MAX_ELICIT_NUDGES) {
+              clearInterval(heartbeat);
+              return;
+            }
+            nudges += 1;
+            const mins = Math.round((Date.now() - elicitStartedAt) / 60_000);
+            void send(
+              `⏳ Still waiting on your answer (${mins}m elapsed). Reply above, or send /abort to cancel.`,
+            ).catch(() => {});
+          }, this.elicitHeartbeatMs);
+          heartbeat.unref?.();
+          // IIFE keeps `result` const with its inferred type AND guarantees the
+          // heartbeat is cleared on every exit path (answer, decline, or throw).
+          const result = await (async () => {
+            try {
+              return await elicitHandler(rec.request, { signal });
+            } finally {
+              clearInterval(heartbeat);
+            }
+          })();
 
           // Invariant: write-back MUST be HMAC-signed (invariant #4). If the
           // key is absent (REPL has not enabled AFK mode), skip silently — an

--- a/src/telegram/watch.ts
+++ b/src/telegram/watch.ts
@@ -313,7 +313,11 @@ export class SessionWatchManager {
             nudges += 1;
             const mins = Math.round((Date.now() - elicitStartedAt) / 60_000);
             void send(
-              `⏳ Still waiting on your answer (${mins}m elapsed). Reply above, or send /abort to cancel.`,
+              // NB: do NOT advertise /abort here — over the watch relay /abort only
+              // writes an abort_request to the ledger for the REPL; it does NOT
+              // settle this awaited elicitation (only /unwatch or shutdown fires the
+              // per-run signal → decline). Advertising it would wedge the chat.
+              `⏳ Still waiting on your answer (${mins}m elapsed) — no deadline, reply above whenever you're ready. (Send /unwatch to stop watching this session.)`,
             ).catch(() => {});
           }, this.elicitHeartbeatMs);
           heartbeat.unref?.();


### PR DESCRIPTION
## Why

An audit of AFK mode found it did **not** reliably let an away operator stay away: high-risk approvals couldn't be answered from the phone, questions could hang the run for hours, some phone-leg failures were silent, and end-of-turn "Asking" pushes were reply dead-ends. This PR fixes the current CLI-REPL path and adds a native Telegram host so you can truly go AFK.

Design + risk record: `docs/afk-telegram-native-host.md`.

## What's in it (2 commits)

### 1. `fix(afk)` — let an away operator answer from Telegram (CLI-REPL + ledger relay)
- **F1 — high-risk approvals now render as buttons on the phone.** The ledger relay (`watch.ts`) installed the *ask-only* handler, so the AFK approve/deny form (`mode:'form'`, no `type`) rendered as a plain text prompt and returned `content.value` while the gate reads `content.choice` → `unrecognised` → refused. It now installs the **composed** handler (like `bot.ts`) → `afk:pa:` buttons + `content.choice`. Regression test negative-verified (fails under the old handler).
- **F3 — no more silent phone-leg failures.** `/afk on` now warns when the relay can't be armed (toggled before the first turn → no session id; null HMAC key) instead of printing "AFK ON" over a dead phone leg.
- **keep-alive** — a pending AFK elicitation re-nudges the chat on a tapering, unref'd heartbeat so a long *answer-whenever* wait reads as parked-on-you, not hung. Never shortens the wait (AFK keeps its deliberate no-deadline).

### 2. `feat(afk)` — run AFK natively in the always-on Telegram host (D v1)
- **Registers the AFK safety gate on Telegram.** `createDefaultHookRegistry` only wires the afk-mode/plan-mode gates when `getPermissionMode` is provided; both Telegram branches passed `undefined`, so an autonomous Telegram session would have had **no risk ceiling**. Now threads a live mode getter (reads the session's own metadata) into both branches.
- **Hard-refuse high-risk ops in the always-on host.** New `afkPromptForApproval` option, passed `false` for Telegram: high-risk/irreversible ops hard-block + surface an Asking summary rather than being one-tap-approvable from a standing phone surface. (The laptop REPL keeps approve-from-phone — bounded, deliberately armed, trusted worktree.)
- **`/afk [on|off]` on Telegram** flips the chat session between autonomous/default; runtime-only (a bot restart safe-degrades to default, never silently resumes autonomous).

Native elicitations use the composed ask+form handler, so the ledger-relay button bug doesn't exist here; "answer whenever" is inherited free within a process lifetime (no session TTL, detached per-chat concurrency).

## Safety posture
`keep-and-fix` (phone can approve high-risk) for the **laptop REPL** only. The **always-on Telegram host hard-refuses** high-risk/irreversible ops (persistent + phone-tap + possibly-broad root removes the REPL's mitigating assumptions). Deferred to v2: trusted narrow per-chat worktree root, per-chat capability tiers, richer approval context, restart-durable pending elicitations.

## Testing
- New: `hook-wiring.test.ts` (gate registered under a mode getter; hard-refuse does **not** prompt — negative-verified against the threading) and `handlers/afk.test.ts` (toggle semantics).
- Full suite green: **12005 passed / 14 skipped / 0 failed**. `tsc --noEmit` clean. `audit:env:check`, `scan:env:check`, `audit:sdk:check` all pass.
