### PR TITLE
feat(daemon): opt-in "Done" verification — downgrade unbacked daemon completion pushes (daemon.verifyDone)

### DIFF
--- a/src/agent/daemon.ts
+++ b/src/agent/daemon.ts
@@ -52,6 +52,13 @@ export interface DaemonOptions {
   /** Optional callback fired after every telemetry record is written. */
   onTaskComplete?: SchedulerOptions['onTaskComplete'];
   /**
+   * "Done"-verification probe. Injected by the CLI daemon wiring (where the
+   * `parseTerminalState` + `doneHasCorroboratingEvidence` reusables are legally
+   * importable — `src/agent/` must not import `src/cli/`). Flows into
+   * `CronScheduler`. See `SchedulerOptions.doneUnverifiedProbe`.
+   */
+  doneUnverifiedProbe?: SchedulerOptions['doneUnverifiedProbe'];
+  /**
    * Poll interval (ms) for pull-trigger mode. When set and > 0, the daemon
    * will call `scheduler.startPullLoop()` after construction and dequeue one
    * task per tick from `queueDir` when idle.
@@ -100,6 +107,7 @@ export async function startDaemon(options: DaemonOptions = {}): Promise<DaemonHa
     ...(options.cooldownMs !== undefined ? { cooldownMs: options.cooldownMs } : {}),
     ...(options.now !== undefined ? { now: options.now } : {}),
     ...(options.onTaskComplete !== undefined ? { onTaskComplete: options.onTaskComplete } : {}),
+    ...(options.doneUnverifiedProbe !== undefined ? { doneUnverifiedProbe: options.doneUnverifiedProbe } : {}),
     ...(options.pullPollIntervalMs !== undefined ? { pullPollIntervalMs: options.pullPollIntervalMs } : {}),
     ...(options.queueDir !== undefined ? { queueDir: options.queueDir } : {}),
   });

--- a/src/agent/daemon/scheduler.test.ts
+++ b/src/agent/daemon/scheduler.test.ts
@@ -27,6 +27,11 @@ vi.mock('../default-hook-registry.js', () => ({
 }));
 
 import { CronScheduler, daemonTraceLabel, resolveWorktreePruneRoot } from './scheduler.js';
+// Reusables imported here (test-only — tests are not bound by the
+// src/agent → src/cli layering invariant that the scheduler source honours) so
+// the injected probe mirrors the production `doneUnverifiedProbe` in daemon.ts.
+import { parseTerminalState } from '../../cli/commands/interactive/terminal-state.js';
+import { DONE_EVIDENCE_TOOLS } from '../../cli/commands/interactive/afk-push.js';
 import { getTraceDir } from '../../paths.js';
 import { AgentSession } from '../session/agent-session.js';
 import { McpManager } from '../mcp/index.js';
@@ -65,13 +70,22 @@ afterEach(() => {
 
 /**
  * Build a minimal fake AgentSession whose sendMessage() either resolves or
- * rejects with the given Error.
+ * rejects with the given Error. `metadata` (e.g. `successfulToolNames`) is
+ * attached to the resolved Message so Done-verification paths can be exercised.
  */
-function makeSession(opts: { throws?: Error; response?: string }): AgentSession {
+function makeSession(opts: {
+  throws?: Error;
+  response?: string;
+  metadata?: Record<string, unknown>;
+}): AgentSession {
   return {
     sendMessage: opts.throws
       ? () => Promise.reject(opts.throws)
-      : () => Promise.resolve({ content: opts.response ?? '' }),
+      : () =>
+          Promise.resolve({
+            content: opts.response ?? '',
+            ...(opts.metadata !== undefined ? { metadata: opts.metadata } : {}),
+          }),
     close: () => Promise.resolve(),
   } as unknown as AgentSession;
 }
@@ -316,6 +330,144 @@ describe('CronScheduler telemetry — errorMessage redaction', () => {
     await scheduler.stop();
   });
 });
+
+describe('CronScheduler — "Done" verification (doneUnverified)', () => {
+  let dir: string;
+  let telemetryPath: string;
+
+  beforeEach(() => {
+    dir = makeTmpDir();
+    telemetryPath = join(dir, 'forge-telemetry.jsonl');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // Mirrors the production probe wired in src/cli/commands/daemon.ts: a `Done`
+  // terminal state with no corroborating evidence tool ⇒ unverified.
+  const probe = ({
+    responseText,
+    successfulToolNames,
+  }: {
+    responseText: string;
+    successfulToolNames: readonly string[];
+  }): boolean => {
+    const verdict = parseTerminalState(responseText);
+    if (verdict === null || verdict.kind !== 'done') return false;
+    return !successfulToolNames.some((name) => DONE_EVIDENCE_TOOLS.has(name));
+  };
+
+  const DONE_RESPONSE = 'Finished the task.\n\n## Done\n- What was done: shipped the change';
+  const BLOCKED_RESPONSE = 'Could not proceed.\n\n## Blocked\n- Blocked by: missing credentials';
+
+  async function runWith(opts: {
+    response: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<TaskCompletionDetails | undefined> {
+    const onTaskComplete = vi.fn();
+    const scheduler = new CronScheduler({
+      telemetryPath,
+      sessionFactory: () =>
+        makeSession({ response: opts.response, ...(opts.metadata ? { metadata: opts.metadata } : {}) }),
+      onTaskComplete,
+      doneUnverifiedProbe: probe,
+    });
+    scheduler.register({ taskId: 't', command: 'run', trigger: 'cron', cronExpression: '* * * * *' });
+    await scheduler.tick('t');
+    await scheduler.stop();
+    if (!onTaskComplete.mock.calls[0]) return undefined;
+    return onTaskComplete.mock.calls[0][1] as TaskCompletionDetails | undefined;
+  }
+
+  it('Done + no evidence → details.doneUnverified === true', async () => {
+    const details = await runWith({ response: DONE_RESPONSE, metadata: { successfulToolNames: [] } });
+    expect(details?.doneUnverified).toBe(true);
+  });
+
+  it('Done + no metadata (no tools ran) → details.doneUnverified === true', async () => {
+    // Absent metadata is the common tool-less tick; runOnce defaults to [] and
+    // the probe still flags an unbacked Done.
+    const details = await runWith({ response: DONE_RESPONSE });
+    expect(details?.doneUnverified).toBe(true);
+  });
+
+  it('Done + corroborating evidence (write_file) → doneUnverified falsy', async () => {
+    const details = await runWith({
+      response: DONE_RESPONSE,
+      metadata: { successfulToolNames: ['read_file', 'write_file'] },
+    });
+    expect(details?.doneUnverified ?? false).toBe(false);
+  });
+
+  it('Done + only read-only tools → details.doneUnverified === true', async () => {
+    const details = await runWith({
+      response: DONE_RESPONSE,
+      metadata: { successfulToolNames: ['read_file', 'grep', 'glob'] },
+    });
+    expect(details?.doneUnverified).toBe(true);
+  });
+
+  it('non-Done terminal state (Blocked) → doneUnverified falsy even with no evidence', async () => {
+    const details = await runWith({ response: BLOCKED_RESPONSE, metadata: { successfulToolNames: [] } });
+    expect(details?.doneUnverified ?? false).toBe(false);
+  });
+
+  it('no probe injected → doneUnverified never set (fail-open, opt-in)', async () => {
+    const onTaskComplete = vi.fn();
+    const scheduler = new CronScheduler({
+      telemetryPath,
+      sessionFactory: () => makeSession({ response: DONE_RESPONSE, metadata: { successfulToolNames: [] } }),
+      onTaskComplete,
+    });
+    scheduler.register({ taskId: 't', command: 'run', trigger: 'cron', cronExpression: '* * * * *' });
+    await scheduler.tick('t');
+    await scheduler.stop();
+    const details = onTaskComplete.mock.calls[0]?.[1] as TaskCompletionDetails | undefined;
+    expect(details?.doneUnverified).toBeUndefined();
+  });
+
+  it('a throwing probe never crashes the tick (guarded) and yields falsy', async () => {
+    const onTaskComplete = vi.fn();
+    const scheduler = new CronScheduler({
+      telemetryPath,
+      sessionFactory: () => makeSession({ response: DONE_RESPONSE, metadata: { successfulToolNames: [] } }),
+      onTaskComplete,
+      doneUnverifiedProbe: () => {
+        throw new Error('probe boom');
+      },
+    });
+    scheduler.register({ taskId: 't', command: 'run', trigger: 'cron', cronExpression: '* * * * *' });
+    const record = await scheduler.tick('t');
+    await scheduler.stop();
+    // Tick still succeeds; details carry no doneUnverified downgrade.
+    expect(record.status).toBe('success');
+    const details = onTaskComplete.mock.calls[0]?.[1] as TaskCompletionDetails | undefined;
+    expect(details?.doneUnverified).toBeUndefined();
+  });
+
+  it('threads the exact successfulToolNames from Message.metadata into the probe', async () => {
+    const seen: string[][] = [];
+    const scheduler = new CronScheduler({
+      telemetryPath,
+      sessionFactory: () =>
+        makeSession({ response: DONE_RESPONSE, metadata: { successfulToolNames: ['bash', 'read_file'] } }),
+      onTaskComplete: vi.fn(),
+      doneUnverifiedProbe: ({ successfulToolNames }) => {
+        seen.push([...successfulToolNames]);
+        return false;
+      },
+    });
+    scheduler.register({ taskId: 't', command: 'run', trigger: 'cron', cronExpression: '* * * * *' });
+    await scheduler.tick('t');
+    await scheduler.stop();
+    expect(seen).toEqual([['bash', 'read_file']]);
+  });
+});
+
+// TaskCompletionDetails is imported implicitly through the scheduler module's
+// exported type surface; alias it for the local casts above.
+type TaskCompletionDetails = import('./scheduler.js').TaskCompletionDetails;
 
 describe('CronScheduler — witness trace-writer wiring', () => {
   let dir: string;

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -121,6 +121,26 @@ export interface SchedulerOptions {
   pullPollIntervalMs?: number;
   /** Override the queue directory for pull-mode dequeue (defaults to `getQueueDir()`). */
   queueDir?: string;
+  /**
+   * "Done"-verification probe (opt-in; injected by the CLI daemon wiring).
+   *
+   * Given a tick's `responseText` and the names of the tools that ran
+   * successfully this turn (from `Message.metadata.successfulToolNames`),
+   * returns `true` when the response self-certifies a `Done` terminal state
+   * with NO corroborating evidence — the daemon analog of the REPL's
+   * terminal-state gate. Result is threaded onto `TaskCompletionDetails.
+   * doneUnverified` for the push formatter to act on.
+   *
+   * INJECTED (not imported) because the real implementation composes
+   * `parseTerminalState` + `doneHasCorroboratingEvidence`, both of which live in
+   * `src/cli/commands/interactive/` — and `src/agent/` must never import from
+   * `src/cli/` (layering invariant; see `agent/facets/schema.ts`). The CLI
+   * daemon command supplies the wired probe; when omitted (standalone scheduler,
+   * most tests), `runOnce` simply never computes `doneUnverified` (fail-open,
+   * push unchanged). The probe MUST be pure and MUST NOT throw — `runOnce` still
+   * guards it defensively so a bug can never crash a tick.
+   */
+  doneUnverifiedProbe?: (args: { responseText: string; successfulToolNames: readonly string[] }) => boolean;
 }
 
 export type TelemetryTrigger = 'cron' | 'sessionstart' | 'pull';
@@ -144,6 +164,17 @@ export interface TelemetryRecord {
 export interface TaskCompletionDetails {
   /** Full successful task response for out-of-band notifications; not persisted to telemetry. */
   responseText?: string;
+  /**
+   * True when this tick's response self-certified a `Done` terminal state with
+   * NO corroborating evidence this turn (no successful file write/edit or
+   * executed command — the daemon analog of the REPL's terminal-state gate).
+   * Additive/optional: absent on non-`Done` ticks, on ticks with evidence, and
+   * on any parse failure (fail-open). The push formatter downgrades the
+   * completion message to "⚠️ Done (unverified)" only when this is `true` AND
+   * `daemon.verifyDone` is enabled — see `formatTaskCompletion` in
+   * `src/cli/commands/daemon.ts`. Never persisted to telemetry.
+   */
+  doneUnverified?: boolean;
 }
 
 interface RegisteredEntry {
@@ -333,13 +364,32 @@ export class CronScheduler {
       mcpManager = spawned.mcpManager ?? null;
       const response = await session.sendMessage(task.command);
       const responseText = redactInlineSecrets(response.content);
+      // "Done"-verification probe (opt-in via injected `doneUnverifiedProbe`,
+      // ultimately gated on `daemon.verifyDone` at the push layer). Fully
+      // guarded: a probe bug or a metadata surprise must NEVER crash a tick, so
+      // any throw is swallowed and treated as "not unverified" (push unchanged,
+      // fail-open). Feeds the probe the SAME text the notification sees (already
+      // secret-redacted) plus the raw successful-tool names the stream consumer
+      // recorded on the returned Message's metadata.
+      let doneUnverified = false;
+      try {
+        const probe = this.options.doneUnverifiedProbe;
+        if (probe !== undefined) {
+          const successfulToolNames = Array.isArray(response.metadata?.successfulToolNames)
+            ? response.metadata.successfulToolNames
+            : [];
+          doneUnverified = probe({ responseText, successfulToolNames });
+        }
+      } catch {
+        doneUnverified = false;
+      }
       const record: TelemetryRecord = {
         ...baseRecord,
         durationMs: this.now() - startTimeMs,
         status: 'success',
         responseExcerpt: responseText.slice(0, 280),
       };
-      this.writeTelemetry(record, task, { responseText });
+      this.writeTelemetry(record, task, { responseText, ...(doneUnverified ? { doneUnverified: true } : {}) });
       return record;
     } catch (err) {
       const record: TelemetryRecord = {

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -382,6 +382,11 @@ export class AgentSession implements IAgentSession {
 
   private buildTransformDeps(): TransformDeps {
     return {
+      // Fresh per-turn accumulator for successful tool names (see
+      // TransformDeps._successfulToolNames). Initialized here — one deps object
+      // per turn — so it never leaks across turns; the stream consumer pushes
+      // to it on tool.output and drains it onto metadata at turn.completed.
+      _successfulToolNames: [],
       conversationHistory: this.conversationHistory,
       getSessionMetadata: () => this.stateManager.getSessionMetadata(),
       setSessionMetadata: (updater) => this.stateManager.setSessionMetadata(updater),

--- a/src/agent/session/stream-consumer-budget.test.ts
+++ b/src/agent/session/stream-consumer-budget.test.ts
@@ -86,6 +86,17 @@ function makeTurnCompleted(
   return { type: 'turn.completed', usage, sessionId };
 }
 
+/** Build a minimal `tool.output` provider event. */
+function makeToolOutput(toolName: string | undefined, isError = false): ProviderEvent {
+  return {
+    type: 'tool.output',
+    toolUseId: `tu-${toolName ?? 'x'}-${Math.random().toString(36).slice(2, 7)}`,
+    content: 'ok',
+    ...(toolName !== undefined ? { toolName } : {}),
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -202,5 +213,61 @@ describe('tool.diff event transform', () => {
         expect(result!.chunk.diff).toEqual(minimalDiff);
       }
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// successfulToolNames metadata accumulation (daemon Done-verification signal)
+// ---------------------------------------------------------------------------
+
+/** Read successfulToolNames off a `done` OutputEvent's metadata. */
+function doneToolNames(result: ReturnType<typeof transformProviderEvent>): string[] | undefined {
+  if (result?.type !== 'done') return undefined;
+  return result.metadata.successfulToolNames;
+}
+
+describe('transformProviderEvent — successfulToolNames accumulation', () => {
+  it('accumulates successful evidence-tool names in call order and stamps them on turn.completed', () => {
+    const deps = makeDeps();
+    deps._successfulToolNames = []; // buildTransformDeps() initializes this per turn
+    transformProviderEvent(makeToolOutput('write_file'), deps);
+    transformProviderEvent(makeToolOutput('bash'), deps);
+    const result = transformProviderEvent(makeTurnCompleted(0), deps);
+    expect(doneToolNames(result)).toEqual(['write_file', 'bash']);
+  });
+
+  it('records read-only tools too (policy-free — the CONSUMER decides evidence)', () => {
+    const deps = makeDeps();
+    deps._successfulToolNames = [];
+    transformProviderEvent(makeToolOutput('read_file'), deps);
+    transformProviderEvent(makeToolOutput('grep'), deps);
+    const result = transformProviderEvent(makeTurnCompleted(0), deps);
+    // The field is the raw observation; it is NOT filtered to evidence tools.
+    expect(doneToolNames(result)).toEqual(['read_file', 'grep']);
+  });
+
+  it('excludes tools whose output reported an error', () => {
+    const deps = makeDeps();
+    deps._successfulToolNames = [];
+    transformProviderEvent(makeToolOutput('write_file', true), deps); // errored — excluded
+    transformProviderEvent(makeToolOutput('bash'), deps); // ok — included
+    const result = transformProviderEvent(makeTurnCompleted(0), deps);
+    expect(doneToolNames(result)).toEqual(['bash']);
+  });
+
+  it('skips tool.output events with no toolName (e.g. some Codex-synthesized events)', () => {
+    const deps = makeDeps();
+    deps._successfulToolNames = [];
+    transformProviderEvent(makeToolOutput(undefined), deps);
+    const result = transformProviderEvent(makeTurnCompleted(0), deps);
+    // No named successful tools ⇒ field omitted (shape unchanged for such turns).
+    expect(doneToolNames(result)).toBeUndefined();
+  });
+
+  it('omits successfulToolNames when the turn ran no successful tools (shape parity)', () => {
+    const deps = makeDeps();
+    deps._successfulToolNames = [];
+    const result = transformProviderEvent(makeTurnCompleted(0), deps);
+    expect(doneToolNames(result)).toBeUndefined();
   });
 });

--- a/src/agent/session/stream-consumer.ts
+++ b/src/agent/session/stream-consumer.ts
@@ -49,6 +49,16 @@ export type TransformDeps = {
    */
   _runningCostUsd?: number;
   /**
+   * Internal per-turn accumulator: names of tools whose `tool.output` event
+   * reported success (`isError !== true`), in observed order. Mutated on each
+   * `tool.output` event and drained onto `ResponseMetadata.successfulToolNames`
+   * at `turn.completed`. Fresh per turn because `buildTransformDeps()` returns a
+   * new object each turn (unlike `_runningCostUsd`, whose cross-turn persistence
+   * is a deliberate exception owned by the same one-deps-per-turn loop), so it
+   * cannot leak across turns.
+   */
+  _successfulToolNames?: string[];
+  /**
    * Witness-layer trace writer. When provided, a `budget` event fires on
    * the same turn that crosses `maxBudgetUsd`, before `abortBudget` runs.
    * The event is the threshold-breach record; the subsequent abort + the
@@ -356,8 +366,18 @@ export function transformProviderEvent(
         },
       };
 
-    case 'tool.output':
+    case 'tool.output': {
+      // Accumulate the name of every tool that reported success this turn, in
+      // observed order, so `turn.completed` can expose them on metadata for
+      // headless surfaces (the daemon) that never see the per-chunk stream.
+      // Policy-free: the allowlist of which tools count as evidence lives with
+      // the consumer (see `doneHasCorroboratingEvidence`), NOT here. A tool with
+      // no name (some OpenAI Codex synthesized events omit it) is skipped.
+      if (event.isError !== true && event.toolName) {
+        (deps._successfulToolNames ??= []).push(event.toolName);
+      }
       return buildToolOutputEvent(event);
+    }
 
     case 'tool.diff':
       // Sidecar render-only event — passes through verbatim. The CLI
@@ -394,6 +414,12 @@ export function transformProviderEvent(
 
     case 'turn.completed': {
       const metadata = usageToMetadata(event.usage, event.sessionId ?? deps.getSessionMetadata().sessionId);
+      // Drain the per-turn successful-tool accumulator onto the metadata so the
+      // returned Message carries the raw observation (empty list ⇒ omit the
+      // field, keeping the shape identical to today for tool-less turns).
+      if (deps._successfulToolNames !== undefined && deps._successfulToolNames.length > 0) {
+        metadata.successfulToolNames = [...deps._successfulToolNames];
+      }
       deps.setLastResponseMetadata(metadata);
 
       for (let i = deps.conversationHistory.length - 1; i >= 0; i--) {

--- a/src/agent/types/message-types.ts
+++ b/src/agent/types/message-types.ts
@@ -38,6 +38,23 @@ export interface ResponseMetadata extends Record<string, unknown> {
   permissionDenials?: unknown[];
   /** Error messages (on error subtypes) */
   errors?: string[];
+  /**
+   * Names of tools whose invocation completed SUCCESSFULLY (`isError !== true`)
+   * during this turn, in call order (duplicates preserved). Populated by the
+   * stream consumer from `tool.output` events; empty/absent when the turn ran
+   * no tools or none succeeded.
+   *
+   * Deliberately POLICY-FREE: this is the raw observation, not a verdict. It
+   * exists so headless surfaces that never see the per-chunk tool stream — the
+   * daemon, which drains `sendMessage` and keeps only the final Message — can
+   * still reconstruct corroborating-evidence signals the REPL derives from its
+   * live `ToolEvent[]`. The consumer of this list owns the policy decision:
+   * e.g. the daemon feeds it through `doneHasCorroboratingEvidence`
+   * (`cli/commands/interactive/afk-push.ts`), the single source of truth for
+   * which tools count as evidence — this field intentionally does NOT bake that
+   * allowlist in.
+   */
+  successfulToolNames?: string[];
 }
 
 /** A conversation message */

--- a/src/cli/commands/daemon.test.ts
+++ b/src/cli/commands/daemon.test.ts
@@ -318,3 +318,58 @@ describe('afk daemon (CLI integration)', () => {
     );
   });
 });
+
+describe('formatTaskCompletion — "Done" verification downgrade', () => {
+  const successRecord = () => ({
+    taskId: 'nightly',
+    command: 'run',
+    trigger: 'cron' as const,
+    triggeredAt: new Date(0).toISOString(),
+    durationMs: 1200,
+    status: 'success' as const,
+    responseExcerpt: 'shipped it',
+  });
+
+  it('downgrades the header + appends the caveat when doneUnverified AND verifyDone on', () => {
+    const formatted = formatTaskCompletion(
+      successRecord(),
+      { responseText: 'shipped it', doneUnverified: true },
+      true,
+    );
+    expect(formatted).toContain('⚠️ Done (unverified)');
+    expect(formatted).toContain(
+      'no file write/edit or successful command recorded this turn',
+    );
+    // Success ✅ header must be gone (replaced by the downgrade header).
+    expect(formatted).not.toContain('✅ daemon task');
+    // The response body is still present.
+    expect(formatted).toContain('shipped it');
+  });
+
+  it('output is byte-identical to the no-flag call when verifyDone is off', () => {
+    const record = successRecord();
+    const details = { responseText: 'shipped it', doneUnverified: true };
+    // Explicit off, explicit off-via-omitted-arg, and the historical 2-arg call
+    // must all produce exactly the same string as today.
+    const off = formatTaskCompletion(record, details, false);
+    const baseline = formatTaskCompletion(record, { responseText: 'shipped it' });
+    expect(off).toBe(baseline);
+    expect(formatTaskCompletion(record, details)).toBe(baseline);
+    expect(off).not.toContain('unverified');
+    expect(off).toContain('✅ daemon task: nightly (success)');
+  });
+
+  it('does NOT downgrade when verifyDone on but doneUnverified is absent/false', () => {
+    const record = successRecord();
+    const on = formatTaskCompletion(record, { responseText: 'shipped it' }, true);
+    // No doneUnverified ⇒ identical to the plain success push.
+    expect(on).toBe(formatTaskCompletion(record, { responseText: 'shipped it' }));
+    expect(on).not.toContain('unverified');
+    const explicitFalse = formatTaskCompletion(
+      record,
+      { responseText: 'shipped it', doneUnverified: false },
+      true,
+    );
+    expect(explicitFalse).not.toContain('unverified');
+  });
+});

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -7,6 +7,8 @@ import os from 'os';
 import { startDaemon } from '../../agent/daemon.js';
 import { getQueueDir } from '../../paths.js';
 import { pushIfConfigured } from '../../telegram/push.js';
+import { parseTerminalState } from './interactive/terminal-state.js';
+import { DONE_EVIDENCE_TOOLS } from './interactive/afk-push.js';
 import type { TaskCompletionDetails, TelemetryRecord } from '../../agent/daemon/scheduler.js';
 import {
   COMPILED_DEFAULT_TASK_ID,
@@ -252,18 +254,44 @@ export function buildDaemonSessionFactory(
 }
 
 /**
+ * Caveat line appended to a downgraded "Done (unverified)" daemon push. Kept
+ * byte-identical to the REPL's afk-push wording (minus that surface's leading
+ * "• " bullet, which the daemon message shape doesn't use) so the operator sees
+ * one consistent self-honesty message across surfaces. See
+ * `formatTerminalStateForTelegram` in `interactive/afk-push.ts`.
+ */
+const DAEMON_DONE_UNVERIFIED_CAVEAT =
+  '⚠️ Unverified: no file write/edit or successful command recorded this turn — confirm before relying on this.';
+
+/**
  * Format a daemon telemetry record for an out-of-band notification
  * (e.g. Telegram push). Short, scannable, status-first.
+ *
+ * `verifyDone` gates the opt-in "Done"-verification downgrade (mirrors
+ * `daemon.verifyDone` in config). When it is `true` AND
+ * `details.doneUnverified` is `true`, the ✅ success header is downgraded to a
+ * "⚠️ Done (unverified)" header and the {@link DAEMON_DONE_UNVERIFIED_CAVEAT}
+ * line is appended. When `verifyDone` is falsy (the default), the output is
+ * byte-identical to before this feature existed — fail-open, opt-in.
  */
 export function formatTaskCompletion(
   record: TelemetryRecord,
   details: TaskCompletionDetails = {},
+  verifyDone = false,
 ): string {
+  // Downgrade only when the config gate is on AND this tick self-certified an
+  // unbacked Done. `doneUnverified` is only ever set on `status: 'success'`
+  // ticks (a `Done` response), so the header swap can't collide with the
+  // skipped/error icons.
+  const downgraded = verifyDone === true && details.doneUnverified === true;
   const icon =
     record.status === 'success' ? '✅' : record.status === 'skipped' ? '⏭️' : '❌';
   const durationSec = (record.durationMs / 1000).toFixed(1);
+  const header = downgraded
+    ? `⚠️ Done (unverified) — daemon task: ${record.taskId} (${record.status})`
+    : `${icon} daemon task: ${record.taskId} (${record.status})`;
   const lines = [
-    `${icon} daemon task: ${record.taskId} (${record.status})`,
+    header,
     `trigger=${record.trigger} duration=${durationSec}s`,
   ];
   if (record.skipReason) lines.push(`skipReason=${record.skipReason}`);
@@ -271,6 +299,9 @@ export function formatTaskCompletion(
   const responseText = details.responseText ?? record.responseExcerpt;
   if (responseText) {
     lines.push('', responseText);
+  }
+  if (downgraded) {
+    lines.push('', DAEMON_DONE_UNVERIFIED_CAVEAT);
   }
   return lines.join('\n');
 }
@@ -483,11 +514,30 @@ export function registerDaemonCommand(program: Command): void {
           ...(cooldownMs !== undefined ? { cooldownMs } : {}),
           ...(trigger === 'pull' ? { pullPollIntervalMs: 30_000, queueDir: getQueueDir() } : {}),
           tasks,
+          // "Done"-verification probe (opt-in via daemon.verifyDone; computed
+          // every tick, acted on only when the config gate is enabled). Composes
+          // the SAME reusables the REPL uses — `parseTerminalState` +
+          // `doneHasCorroboratingEvidence` semantics — so the daemon flags an
+          // unbacked `Done` identically to the interactive surface. Injected
+          // here (the CLI layer) rather than imported by the scheduler, which
+          // lives in `src/agent/` and must not depend on `src/cli/`. Pure + total
+          // (never throws); the scheduler additionally guards it.
+          doneUnverifiedProbe: ({ responseText, successfulToolNames }) => {
+            const verdict = parseTerminalState(responseText);
+            if (verdict === null || verdict.kind !== 'done') return false;
+            const hasEvidence = successfulToolNames.some((name) => DONE_EVIDENCE_TOOLS.has(name));
+            return !hasEvidence;
+          },
           onTaskComplete: (record: TelemetryRecord, details?: TaskCompletionDetails) => {
             // markdown:true — task output is agent-authored markdown; render it
             // to Telegram HTML so **bold**/`code`/headers format instead of
             // showing their literal markers (plain-text fallback on parse error).
-            void pushIfConfigured(formatTaskCompletion(record, details), { markdown: true }).catch(() => undefined);
+            // config.daemon?.verifyDone gates the opt-in Done-verification
+            // downgrade; when unset/false the formatted message is unchanged.
+            void pushIfConfigured(
+              formatTaskCompletion(record, details, config.daemon?.verifyDone === true),
+              { markdown: true },
+            ).catch(() => undefined);
           },
         });
 

--- a/src/cli/config/json-tier.ts
+++ b/src/cli/config/json-tier.ts
@@ -142,6 +142,7 @@ export function loadJsonConfig(): {
               maxAgeDaysDirty: number;
               scope: string;
             };
+            verifyDone?: boolean;
           } = {};
           if (typeof json.daemon.task === 'string') {
             daemon.task = json.daemon.task;
@@ -158,6 +159,9 @@ export function loadJsonConfig(): {
               maxAgeDaysDirty: typeof wp.maxAgeDaysDirty === 'number' ? wp.maxAgeDaysDirty : 30,
               scope: typeof wp.scope === 'string' ? wp.scope : 'all',
             };
+          }
+          if (typeof json.daemon.verifyDone === 'boolean') {
+            daemon.verifyDone = json.daemon.verifyDone;
           }
           config.daemon = daemon;
         }

--- a/src/cli/config/types.ts
+++ b/src/cli/config/types.ts
@@ -89,6 +89,18 @@ export interface CliConfig {
       maxAgeDaysDirty: number;
       scope: string;
     };
+    /**
+     * Daemon-surface "Done" verification gate (opt-in; default off when
+     * omitted). When true, a cron-tick completion push whose response
+     * self-certifies `Done` is relabelled "⚠️ Done (unverified)" (with a caveat
+     * line) unless the tick produced corroborating evidence — a successful file
+     * write/edit or executed command (see `doneHasCorroboratingEvidence` in
+     * `commands/interactive/afk-push.ts`). The daemon analog of
+     * `telegram.verifyDone` (which is REPL-only): the daemon is single-turn-per-
+     * tick, so the only honest enforcement is relabelling the outgoing push, not
+     * bouncing a next turn. Off ⇒ the push is byte-identical to today.
+     */
+    verifyDone?: boolean;
   };
   /**
    * Telegram outbound notification routing, sourced from afk.config.json
@@ -287,6 +299,7 @@ export interface ConfigFileSchema {
       maxAgeDaysDirty?: number;
       scope?: string;
     };
+    verifyDone?: boolean;
   };
   /**
    * Telegram outbound notification routing. Separate from the inbound allowlist

--- a/src/cli/daemon-config.test.ts
+++ b/src/cli/daemon-config.test.ts
@@ -120,4 +120,29 @@ describe('loadConfig — daemon block round-trip', () => {
     const config = loadConfig();
     expect(config.daemon).toBeUndefined();
   });
+
+  it('round-trips daemon.verifyDone: true', () => {
+    writeJsonConfig(JSON.stringify({ daemon: { verifyDone: true } }));
+    const config = loadConfig();
+    expect(config.daemon?.verifyDone).toBe(true);
+  });
+
+  it('round-trips daemon.verifyDone: false', () => {
+    writeJsonConfig(JSON.stringify({ daemon: { verifyDone: false } }));
+    const config = loadConfig();
+    expect(config.daemon?.verifyDone).toBe(false);
+  });
+
+  it('leaves daemon.verifyDone undefined (off) when absent', () => {
+    writeJsonConfig(JSON.stringify({ daemon: { task: '/x' } }));
+    const config = loadConfig();
+    expect(config.daemon?.task).toBe('/x');
+    expect(config.daemon?.verifyDone).toBeUndefined();
+  });
+
+  it('ignores a non-boolean daemon.verifyDone (defensive parse → undefined)', () => {
+    writeJsonConfig(JSON.stringify({ daemon: { verifyDone: 'yes' } }));
+    const config = loadConfig();
+    expect(config.daemon?.verifyDone).toBeUndefined();
+  });
 });

--- a/src/config/settable-keys.test.ts
+++ b/src/config/settable-keys.test.ts
@@ -90,6 +90,7 @@ describe('classifyConfigKey / specs', () => {
     expect(classifyConfigKey('telegram.notify.targets')).toBe('human');
     expect(classifyConfigKey('telegram.verifyDone')).toBe('human'); // self-honesty gate — agent must not disable its own verification
     expect(classifyConfigKey('enforceDoneEvidence')).toBe('human'); // self-honesty gate — agent must not disable its own enforcement
+    expect(classifyConfigKey('daemon.verifyDone')).toBe('human'); // daemon self-honesty gate — agent must not disable its own push verification
     expect(classifyConfigKey('updatePolicy')).toBe('human'); // auto self-update is scope-widening
     expect(classifyConfigKey('systemPrompt')).toBe('human');
     expect(classifyConfigKey('enableShellHooks')).toBe('human'); // trust gate — agent must not flip it
@@ -104,6 +105,16 @@ describe('coerceConfigValue', () => {
   it('booleans accept typed and string forms', () => {
     const spec = getConfigKeySpec('bgSummaries')!;
     expect(coerceConfigValue(spec, true)).toEqual({ ok: true, value: true });
+    expect(coerceConfigValue(spec, 'off')).toEqual({ ok: true, value: false });
+    expect(coerceConfigValue(spec, 'banana').ok).toBe(false);
+  });
+  it('daemon.verifyDone is a human-tier boolean (true/false/non-boolean)', () => {
+    const spec = getConfigKeySpec('daemon.verifyDone')!;
+    expect(spec.tier).toBe('human');
+    expect(spec.type).toBe('boolean');
+    expect(coerceConfigValue(spec, true)).toEqual({ ok: true, value: true });
+    expect(coerceConfigValue(spec, false)).toEqual({ ok: true, value: false });
+    expect(coerceConfigValue(spec, 'on')).toEqual({ ok: true, value: true });
     expect(coerceConfigValue(spec, 'off')).toEqual({ ok: true, value: false });
     expect(coerceConfigValue(spec, 'banana').ok).toBe(false);
   });

--- a/src/config/settable-keys.ts
+++ b/src/config/settable-keys.ts
@@ -234,6 +234,7 @@ export const CONFIG_KEY_SPECS: readonly ConfigKeySpec[] = [
   { path: 'interactive.worktreeBase', tier: 'human', type: 'string', description: 'Worktree base ref (git-flag sensitive).' },
   { path: 'daemon.task', tier: 'human', type: 'string', description: 'Daemon task prompt.' },
   { path: 'daemon.taskId', tier: 'human', type: 'string', description: 'Daemon task id.' },
+  { path: 'daemon.verifyDone', tier: 'human', type: 'boolean', description: 'Opt-in daemon-surface "Done" verification gate: a cron-tick completion push whose response self-certifies "Done" with no corroborating evidence (a successful file write/edit or executed command) is relabelled "⚠️ Done (unverified)" with a caveat line. The daemon analog of telegram.verifyDone (which is REPL-only); the daemon is single-turn-per-tick, so the only honest enforcement is relabelling the outgoing push rather than bouncing a next turn. Human-tier: a self-honesty check on the agent\'s own completion reporting — the agent must not be able to disable it on its own config, same rationale as telegram.verifyDone.' },
 ];
 
 const CONFIG_KEY_BY_PATH = new Map(CONFIG_KEY_SPECS.map((s) => [s.path, s]));


### PR DESCRIPTION
## What
Opt-in, human-tier `daemon.verifyDone` config gate (default off). When enabled, a daemon cron-tick completion push whose response self-certifies a **Done** terminal state with **no corroborating evidence** (no successful file write/edit or executed command that tick) is downgraded to a "⚠️ Done (unverified)" header + caveat line — the daemon analog of the REPL terminal-state gate (#237) and the sibling of `telegram.verifyDone`.

## Why
The unattended daemon is where a false "Done" is most costly: the operator is pinged a confident completion on their phone, away from the trace, and acts on it. Today the daemon has **no** Done-verification — `telegram.verifyDone` and the #237 gate are REPL-only. This closes that gap for the surface that needs it most.

## Design
- **Push-downgrade, not inject/block.** The daemon is single-turn-per-tick (`scheduler.ts` calls `sendMessage()` once, then `close()`), so there is no next turn to inject into and no loop to block. Relabelling the outgoing push is the only honest enforcement.
- **Real evidence signal (not a text heuristic).** Tool successes are accumulated in the stream consumer (`tool.output`, `isError !== true`) and exposed on `ResponseMetadata.successfulToolNames` (additive; omitted when empty → shape-identical for tool-less turns). The daemon reconstructs the exact REPL signal by feeding those names through `DONE_EVIDENCE_TOOLS`, the single source of truth for what counts as evidence. The metadata field is deliberately policy-free.
- **Layering respected via DI.** `parseTerminalState` + `DONE_EVIDENCE_TOOLS` live in `src/cli/`, which the scheduler (`src/agent/`) must not import — so the scheduler takes an injected `doneUnverifiedProbe`; the CLI daemon command wires it.
- **Fail-open, opt-in, byte-identical when off.** The probe is guarded (a bug can never crash a tick); the push is unchanged unless `daemon.verifyDone === true` AND the tick self-certified an unbacked Done.

## Blast radius
Core session files (`stream-consumer.ts`, `agent-session.ts`, `message-types.ts`) gain the additive, policy-free `successfulToolNames` metadata field — populated every turn, consumed only by the daemon. No existing field or behaviour changes.

## Verification
- `pnpm lint` (tsc --noEmit, strict): clean.
- Full test suite: **12034 passed / 14 skipped**, incl. new tests in `scheduler.test.ts`, `daemon.test.ts`, `daemon-config.test.ts`, `settable-keys.test.ts`, `stream-consumer-budget.test.ts`.
- `pnpm audit:sdk:check`, `audit:env:check`, `scan:env:check`: clean.
- `pnpm test:coverage` runs in CI (full coverage instrumentation exceeds a local time budget; the plain suite passes).

## Scope / follow-ups
- **v1 = caveat-the-push.** Honestly labels the completion; does not force the daemon to redo unbacked work.
- v2 (deferred): force reconciliation — re-run the tick, or build the deferred hard-block-to-force-continuation primitive (`loop-iteration.ts:700-702`).
- Also deferred: Telegram/chat surface coverage (same mechanism extends).

Built in an isolated worktree; verified before push.
