### PR TITLE
fix(subagent): env-configurable timeout + raise default to 45m; observable forked children

### DIFF
--- a/AFK.md
+++ b/AFK.md
@@ -10,8 +10,9 @@ Standalone TypeScript CLI + daemon + Telegram bot built on `@anthropic-ai/sdk`. 
 pnpm install                                       # pnpm exclusively
 pnpm build                                         # tsc + copy *.md prompts → dist/
 pnpm test                                          # vitest run (all)
-pnpm test -- src/agent/session.test.ts             # single file
-pnpm test -- -t "sends a message"                  # single test by name
+pnpm test src/agent/session.test.ts                # single file (NO --; pnpm 10 drops args after -- and runs ALL files)
+pnpm test src/agent/session.test.ts -t "sends a message"   # single test by name (scope to a file, then filter by -t)
+pnpm test:file src/agent/session.test.ts           # --proof alias for a scoped run (script: vitest run)
 pnpm test:watch                                    # vitest watch
 pnpm lint                                          # tsc --noEmit (strict)
 

--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -583,6 +583,15 @@
       "category": "paths"
     },
     {
+      "name": "AFK_SUBAGENT_TIMEOUT_MS",
+      "description": "Foreground forked-subagent wall-clock budget in ms; 0 disables the cap; explicit per-fork config.timeoutMs and the 60-min background mode still win. Bounds how long a single forked child turn may run before `withTimeout` aborts its controller (cascading through the AbortGraph to descendants) and the parent receives a legible TimeoutError tool_result instead of hanging. Default 2700000 (45 min ≈ headroom over the longest healthy review/research agent observed in production). Unset, empty, or unparseable input falls back to the default; a negative value is treated as invalid and also falls back. Set to 0 to opt a whole session back into unbounded child turns. Does NOT affect the background dispatch budget (SUBAGENT_BACKGROUND_TIMEOUT_MS) or a per-fork config.timeoutMs — both take precedence.",
+      "type": "number",
+      "required": false,
+      "default": "2700000",
+      "example": "3600000",
+      "category": "model"
+    },
+    {
       "name": "AFK_SUGGEST_ENABLED",
       "description": "Enable the LLM-backed ghost-text suggestion tier in the interactive REPL. Set to 1/true/yes/on to activate. Off by default.",
       "type": "boolean",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**124 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**125 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 
@@ -39,6 +39,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_OPENAI_USE_RESPONSES` | boolean |  |  | `1` | Opt the OpenAI-compatible provider into the OpenAI Responses API instead of Chat Completions for API-key sessions. Truthy values: 1, true, yes, on. The ChatGPT-subscription OAuth path uses Responses automatically regardless of this flag. |
 | `AFK_PROMPT_CACHE_TTL` | string |  | `1h` | `1h` | TTL for Anthropic prompt-cache blocks. Accepts 5m or 1h. |
 | `AFK_PROVIDER` | string |  |  | `openai-compatible` | Force provider selection (anthropic \| anthropic-direct \| openai \| openai-compatible \| openai-codex). Overrides the model-name heuristic. Same surface as the --provider CLI flag; CLI flag wins when both are set. |
+| `AFK_SUBAGENT_TIMEOUT_MS` | number |  | `2700000` | `3600000` | Foreground forked-subagent wall-clock budget in ms; 0 disables the cap; explicit per-fork config.timeoutMs and the 60-min background mode still win. Bounds how long a single forked child turn may run before `withTimeout` aborts its controller (cascading through the AbortGraph to descendants) and the parent receives a legible TimeoutError tool_result instead of hanging. Default 2700000 (45 min ≈ headroom over the longest healthy review/research agent observed in production). Unset, empty, or unparseable input falls back to the default; a negative value is treated as invalid and also falls back. Set to 0 to opt a whole session back into unbounded child turns. Does NOT affect the background dispatch budget (SUBAGENT_BACKGROUND_TIMEOUT_MS) or a per-fork config.timeoutMs — both take precedence. |
 | `AFK_SUGGEST_ENABLED` | boolean |  |  |  | Enable the LLM-backed ghost-text suggestion tier in the interactive REPL. Set to 1/true/yes/on to activate. Off by default. |
 | `AFK_SUGGEST_GHOST` | boolean |  | `1` | `0` | Enable REPL ghost-text inline suggestions (Tier-1 history/dropdown + optional Tier-2 LLM). 1 = on (default), 0 = off. Set 0/false/off/no to disable all ghost text. Tier-2 LLM is separately gated by AFK_SUGGEST_ENABLED. |
 | `AFK_SUGGEST_MODEL` | string |  |  |  | Override the small model used for REPL ghost-text suggestions. Falls back to AFK_COMPACT_MODEL or haiku-class for anthropic, or the session model for other providers. |

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "telegram:restart": "node dist/cli/index.js telegram restart",
     "telegram:logs": "node dist/cli/index.js telegram logs",
     "test": "vitest run",
+    "test:file": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest watch",
     "test:pty": "vitest run --config vitest.pty.config.ts",

--- a/src/agent/agents/builtins.ts
+++ b/src/agent/agents/builtins.ts
@@ -111,6 +111,13 @@ export function builtinAgents(): Map<string, RegisteredAgent> {
         prompt: vendoredPromptBody(gitInvestigator.systemPrompt),
         tools: [...gitInvestigator.allowedTools],
         model: gitInvestigator.model,
+        // Same anti-runaway bound as research-agent / Explore: git-investigator
+        // is a read-only git-archaeology leaf (dispatched by research-agent),
+        // so it never needs an unbounded tool-use loop. Without a cap it can
+        // spin on a hard task until an external wall-clock cutoff kills it
+        // mid-loop and it surfaces as an opaque failure rather than a graceful
+        // capped-partial wind-down. See READONLY_AGENT_MAX_TOOL_USE_ITERATIONS.
+        maxToolUseIterations: READONLY_AGENT_MAX_TOOL_USE_ITERATIONS,
       },
       // The vendored definition grants Bash for git archaeology; its contract
       // is read-only ("Runs git commands only — no mutations"). Enforce that

--- a/src/agent/agents/registry.test.ts
+++ b/src/agent/agents/registry.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { loadAgentRegistry } from './registry.js';
+import { builtinAgents } from './builtins.js';
 
 let tmp: string;
 let prevAfkHome: string | undefined;
@@ -58,9 +59,45 @@ describe('loadAgentRegistry', () => {
     // cannot let them loop forever and die opaquely when cut off mid-run.
     expect(registry.get('research-agent')?.definition.maxToolUseIterations).toBe(50);
     expect(registry.get('Explore')?.definition.maxToolUseIterations).toBe(50);
+    // git-investigator is a read-only git-archaeology leaf (dispatched by
+    // research-agent) and must carry the same cap.
+    expect(registry.get('git-investigator')?.definition.maxToolUseIterations).toBe(50);
     // general-purpose stays UNBOUNDED — a real multi-step worker legitimately
     // needs an uncapped loop, so it must NOT gain the read-only bound.
     expect(registry.get('general-purpose')?.definition.maxToolUseIterations).toBeUndefined();
+  });
+
+  // Drift-catcher: iterate the BUILTIN registry (not the vendored consts) so a
+  // newly-added read-only builtin that forgets the anti-runaway cap fails here.
+  // Structural predicate (no hardcoded per-agent list): a builtin with an
+  // explicit `tools` allowlist is a restricted/read-only leaf and MUST carry
+  // maxToolUseIterations; a builtin that OMITS `tools` (inherit-all, the full
+  // tool surface — only general-purpose today) is the uncapped exemption.
+  it('every read-only builtin (explicit tools) carries the anti-runaway cap; inherit-all exempt', () => {
+    const builtins = builtinAgents();
+    // Guard the guard: ensure we actually iterated real builtins and covered
+    // BOTH arms (at least one capped read-only leaf and the inherit-all worker),
+    // so a future refactor that empties the map can't make this vacuously pass.
+    let sawRestricted = false;
+    let sawInheritAll = false;
+    for (const [name, entry] of builtins) {
+      const hasExplicitTools = entry.definition.tools !== undefined;
+      if (hasExplicitTools) {
+        sawRestricted = true;
+        expect(
+          entry.definition.maxToolUseIterations,
+          `read-only builtin ${name} (explicit tools) is missing the anti-runaway cap`,
+        ).toBe(50);
+      } else {
+        sawInheritAll = true;
+        expect(
+          entry.definition.maxToolUseIterations,
+          `inherit-all builtin ${name} must stay uncapped (full tool surface)`,
+        ).toBeUndefined();
+      }
+    }
+    expect(sawRestricted, 'expected ≥1 restricted read-only builtin').toBe(true);
+    expect(sawInheritAll, 'expected the inherit-all worker (general-purpose)').toBe(true);
   });
 
   it('strips vendored frontmatter from builtin prompts (body-only system prompt)', () => {

--- a/src/agent/subagent.test.ts
+++ b/src/agent/subagent.test.ts
@@ -3,7 +3,7 @@
  * Zod output schemas, transitive cancel.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { z } from 'zod';
 import type { Message } from './types.js';
 
@@ -81,6 +81,7 @@ import {
   SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS,
   SUBAGENT_DEFAULT_TIMEOUT_MS,
   SUBAGENT_BACKGROUND_TIMEOUT_MS,
+  resolveSubagentTimeoutMs,
 } from './subagent.js';
 
 function lastSessionState(): SessionState {
@@ -741,8 +742,15 @@ describe('SubagentManager', () => {
     // wedged stream, a slow-grinding tool loop — park its parent at
     // `await runToResult` indefinitely (observed in production: 4 parallel
     // children spun 29 minutes under a 429 cascade until manually cancelled).
-    it('pins the fork budget defaults (20 min foreground / 60 min background)', () => {
-      expect(SUBAGENT_DEFAULT_TIMEOUT_MS).toBe(20 * 60_000);
+    it('pins the fork budget defaults (45 min foreground / 60 min background)', () => {
+      // Raised 20m → 45m (PR: env-configurable timeout): the 20-min wall
+      // guillotined genuinely-working read-only research/review children
+      // (e.g. /review's research-agent nesting git-investigator on a large
+      // diff). 45m gives headroom over the longest healthy child observed
+      // while still guaranteeing every fork terminates. Background is
+      // unchanged. The foreground default is now also env-tunable via
+      // AFK_SUBAGENT_TIMEOUT_MS (see resolveSubagentTimeoutMs tests below).
+      expect(SUBAGENT_DEFAULT_TIMEOUT_MS).toBe(45 * 60_000);
       expect(SUBAGENT_BACKGROUND_TIMEOUT_MS).toBe(60 * 60_000);
     });
 
@@ -759,7 +767,11 @@ describe('SubagentManager', () => {
         const signal = lastSessionAbortSignal();
 
         const run = h.run('slow');
-        const rejection = expect(run).rejects.toThrow(/timed out after 1200000ms/);
+        // Reference the constant so this stays in lockstep with the default
+        // (was hardcoded 1200000ms for the 20-min default; now 2700000ms).
+        const rejection = expect(run).rejects.toThrow(
+          new RegExp(`timed out after ${SUBAGENT_DEFAULT_TIMEOUT_MS}ms`),
+        );
         await vi.advanceTimersByTimeAsync(SUBAGENT_DEFAULT_TIMEOUT_MS);
         await rejection;
         expect(signal.aborted).toBe(true);
@@ -786,6 +798,136 @@ describe('SubagentManager', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    // resolveSubagentTimeoutMs is the DEFAULT resolver consulted by the fork
+    // site (`config.timeoutMs ?? resolveSubagentTimeoutMs()`). Pure-function
+    // contract, mirroring resolveTtfbTimeoutMs: unset/empty/invalid → default,
+    // valid finite int >= 0 → that value, 0 → 0 (unbounded).
+    describe('resolveSubagentTimeoutMs (AFK_SUBAGENT_TIMEOUT_MS)', () => {
+      const KEY = 'AFK_SUBAGENT_TIMEOUT_MS';
+      let original: string | undefined;
+      beforeEach(() => {
+        original = process.env[KEY];
+        delete process.env[KEY];
+      });
+      afterEach(() => {
+        if (original !== undefined) process.env[KEY] = original;
+        else delete process.env[KEY];
+      });
+
+      it('returns SUBAGENT_DEFAULT_TIMEOUT_MS when unset', () => {
+        expect(resolveSubagentTimeoutMs()).toBe(SUBAGENT_DEFAULT_TIMEOUT_MS);
+      });
+
+      it('returns SUBAGENT_DEFAULT_TIMEOUT_MS when empty / whitespace', () => {
+        process.env[KEY] = '';
+        expect(resolveSubagentTimeoutMs()).toBe(SUBAGENT_DEFAULT_TIMEOUT_MS);
+        process.env[KEY] = '   ';
+        expect(resolveSubagentTimeoutMs()).toBe(SUBAGENT_DEFAULT_TIMEOUT_MS);
+      });
+
+      it('parses a valid integer', () => {
+        process.env[KEY] = '600000';
+        expect(resolveSubagentTimeoutMs()).toBe(600_000);
+      });
+
+      it('treats 0 as the explicit unbounded escape hatch', () => {
+        process.env[KEY] = '0';
+        expect(resolveSubagentTimeoutMs()).toBe(0);
+      });
+
+      it('falls back to the default on a negative value', () => {
+        process.env[KEY] = '-1';
+        expect(resolveSubagentTimeoutMs()).toBe(SUBAGENT_DEFAULT_TIMEOUT_MS);
+      });
+
+      it('falls back to the default on unparseable garbage', () => {
+        process.env[KEY] = 'not-a-number';
+        expect(resolveSubagentTimeoutMs()).toBe(SUBAGENT_DEFAULT_TIMEOUT_MS);
+      });
+    });
+
+    // Fork-site precedence: the env default is consulted ONLY when the caller
+    // omits config.timeoutMs. An explicit config.timeoutMs (including 0 and the
+    // background SUBAGENT_BACKGROUND_TIMEOUT_MS) still wins via the `??`.
+    describe('AFK_SUBAGENT_TIMEOUT_MS at the fork site', () => {
+      const KEY = 'AFK_SUBAGENT_TIMEOUT_MS';
+      let original: string | undefined;
+      beforeEach(() => {
+        original = process.env[KEY];
+      });
+      afterEach(() => {
+        if (original !== undefined) process.env[KEY] = original;
+        else delete process.env[KEY];
+      });
+
+      it('applies the env override as the fork default when config omits timeoutMs', async () => {
+        vi.useFakeTimers();
+        try {
+          process.env[KEY] = '5000'; // 5s — far below the 45m default
+          const mgr = new SubagentManager();
+          const h = await mgr.forkSubagent({
+            parent: { sessionId: 'p' },
+            config: { model: 'sonnet' }, // no timeoutMs → env override applies
+          });
+          // Never replies within the env budget.
+          lastSessionState().replyDelayMs = 60_000;
+          const signal = lastSessionAbortSignal();
+
+          const run = h.run('slow');
+          const rejection = expect(run).rejects.toThrow(/timed out after 5000ms/);
+          await vi.advanceTimersByTimeAsync(5000);
+          await rejection;
+          expect(signal.aborted).toBe(true);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('lets an explicit config.timeoutMs win over the env override', async () => {
+        vi.useFakeTimers();
+        try {
+          process.env[KEY] = '5000'; // env says 5s…
+          const mgr = new SubagentManager();
+          const h = await mgr.forkSubagent({
+            parent: { sessionId: 'p' },
+            config: { model: 'sonnet', timeoutMs: 20_000 }, // …explicit 20s wins
+          });
+          // Reply lands after the env budget but before the explicit one.
+          lastSessionState().replyDelayMs = 10_000;
+
+          const run = h.run('slow');
+          // Advancing past the env budget (5s) must NOT time out — explicit wins.
+          await vi.advanceTimersByTimeAsync(11_000);
+          const msg = await run;
+          expect(msg.content).toBe('ok:slow');
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('leaves the background carve-out unaffected (explicit 0 stays unbounded)', async () => {
+        vi.useFakeTimers();
+        try {
+          process.env[KEY] = '5000'; // small env default…
+          const mgr = new SubagentManager();
+          const h = await mgr.forkSubagent({
+            parent: { sessionId: 'p' },
+            // Background dispatch stamps timeoutMs:0 (unbounded) — env must not
+            // re-cap it. (0 is the SubagentExecutor's carve-out for bg mode.)
+            config: { model: 'sonnet', timeoutMs: 0 },
+          });
+          lastSessionState().replyDelayMs = 60_000;
+
+          const run = h.run('slow');
+          await vi.advanceTimersByTimeAsync(61_000);
+          const msg = await run;
+          expect(msg.content).toBe('ok:slow');
+        } finally {
+          vi.useRealTimers();
+        }
+      });
     });
   });
 

--- a/src/agent/subagent.test.ts
+++ b/src/agent/subagent.test.ts
@@ -83,6 +83,7 @@ import {
   SUBAGENT_BACKGROUND_TIMEOUT_MS,
   resolveSubagentTimeoutMs,
 } from './subagent.js';
+import { ENV_REGISTRY } from '../config/env.js';
 
 function lastSessionState(): SessionState {
   return shared.sessions[shared.sessions.length - 1].state;
@@ -846,6 +847,14 @@ describe('SubagentManager', () => {
         process.env[KEY] = 'not-a-number';
         expect(resolveSubagentTimeoutMs()).toBe(SUBAGENT_DEFAULT_TIMEOUT_MS);
       });
+
+      it('keeps the ENV_REGISTRY documented default in lockstep with the constant', () => {
+        // Guards against SUBAGENT_DEFAULT_TIMEOUT_MS drifting from the registry
+        // `default` string that feeds docs/env-registry.{json,md}. A mismatch
+        // means the published default no longer matches the code default.
+        const entry = ENV_REGISTRY.find((e) => e.name === 'AFK_SUBAGENT_TIMEOUT_MS');
+        expect(entry?.default).toBe(String(SUBAGENT_DEFAULT_TIMEOUT_MS));
+      });
     });
 
     // Fork-site precedence: the env default is consulted ONLY when the caller
@@ -907,17 +916,47 @@ describe('SubagentManager', () => {
         }
       });
 
-      it('leaves the background carve-out unaffected (explicit 0 stays unbounded)', async () => {
+      it('lets an explicit timeoutMs:0 stay unbounded regardless of the env override', async () => {
         vi.useFakeTimers();
         try {
           process.env[KEY] = '5000'; // small env default…
           const mgr = new SubagentManager();
           const h = await mgr.forkSubagent({
             parent: { sessionId: 'p' },
-            // Background dispatch stamps timeoutMs:0 (unbounded) — env must not
-            // re-cap it. (0 is the SubagentExecutor's carve-out for bg mode.)
+            // Explicit `0` is the caller's unbounded escape hatch — the env
+            // override must not re-cap it: `0 ?? resolveSubagentTimeoutMs()`
+            // short-circuits on the explicit value, and withTimeout(0) installs
+            // no timer.
             config: { model: 'sonnet', timeoutMs: 0 },
           });
+          lastSessionState().replyDelayMs = 60_000;
+
+          const run = h.run('slow');
+          await vi.advanceTimersByTimeAsync(61_000);
+          const msg = await run;
+          expect(msg.content).toBe('ok:slow');
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('does not let the env override re-cap the background carve-out (SUBAGENT_BACKGROUND_TIMEOUT_MS wins)', async () => {
+        // The real background carve-out: the SubagentExecutor stamps
+        // config.timeoutMs = SUBAGENT_BACKGROUND_TIMEOUT_MS (60 min) for
+        // background dispatches. That explicit value must win over a small
+        // AFK_SUBAGENT_TIMEOUT_MS via the fork-site `??`, so a background child
+        // is NOT guillotined at the (far smaller) env budget. (Distinct from the
+        // explicit-0 case above — background is BOUNDED at 60 min, not unbounded.)
+        vi.useFakeTimers();
+        try {
+          process.env[KEY] = '5000'; // 5s env default — far below the 60-min bg budget
+          const mgr = new SubagentManager();
+          const h = await mgr.forkSubagent({
+            parent: { sessionId: 'p' },
+            config: { model: 'sonnet', timeoutMs: SUBAGENT_BACKGROUND_TIMEOUT_MS },
+          });
+          // Reply lands at 60s — well past the 5s env budget but far inside the
+          // 60-min background budget. Had env re-capped, this would abort at 5s.
           lastSessionState().replyDelayMs = 60_000;
 
           const run = h.run('slow');

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -198,6 +198,16 @@ export interface ForkSubagentOptions<T = unknown> {
    */
   parentId?: string;
   /**
+   * Optional first-80-chars slice of the dispatch prompt, forwarded verbatim
+   * into the `subagent_lifecycle.started` trace event's `promptHead` field for
+   * at-a-glance forensics (WHAT was the child asked to do). The prompt itself
+   * is not a `forkSubagent` argument — it arrives later via `handle.run(prompt)`
+   * — so the raw agent-dispatch site (which HAS the prompt) passes this
+   * pre-sliced hint. Purely observational: never affects execution. Omitted for
+   * fork sites with no prompt in scope.
+   */
+  promptHead?: string;
+  /**
    * When true, overrides `config.onElicitation` with `DENY_ELICITATION` so
    * background subagents never stall on an interactive permission prompt.
    * Propagates transitively: a bg parent's DENY_ELICITATION is inherited by
@@ -893,6 +903,15 @@ export class SubagentManager {
       ...(childConfig.tools?.allowedTools
         ? { allowedTools: [...childConfig.tools.allowedTools] }
         : {}),
+      // Observability: WHAT was this child asked to do + WHICH role. promptHead
+      // is the caller-supplied prompt slice (re-clamped to 80 to honour the
+      // payload contract regardless of caller input); agentType is the already-
+      // computed effective render label. Both omitted when unavailable so the
+      // schema's `.optional()` fields stay absent rather than empty-valued.
+      ...(options.promptHead && options.promptHead.trim() !== ''
+        ? { promptHead: options.promptHead.slice(0, 80) }
+        : {}),
+      ...(effectiveAgentType ? { agentType: effectiveAgentType } : {}),
     });
 
     await appendRoutingDecision({

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -38,6 +38,7 @@ import { touchWorktreeOccupancy } from './worktree-occupancy.js';
 import { resolveWorktreeMainRoot } from './worktree-read-root.js';
 import { computeInheritedReadRoots, type ReadScopeInputs } from './subagent-read-scope.js';
 import { getAfkStateDir } from '../paths.js';
+import { env } from '../config/env.js';
 import { buildPhaseRestrictedProvider, type PhaseRole } from './tools/nesting.js';
 import { applyManagerApiKeyFallback } from './tools/child-credential.js';
 import { providerForModel, type BundledProviderName } from './providers/index.js';
@@ -82,14 +83,48 @@ export const SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS = 50;
  * its parent at `await runToResult` indefinitely (observed 2026-07-07: four
  * parallel children spun 29 minutes under a 429 cascade until the operator
  * manually cancelled). The tool-iteration cap above bounds ROUNDS but not
- * TIME — throttled rounds can each take minutes. 20 minutes is ~2× the
- * longest healthy child observed in production traces (~10 min review
- * agents). On expiry `withTimeout` aborts the child's controller, cascading
- * through the AbortGraph to its descendants, and the parent receives a
- * legible TimeoutError tool_result instead of hanging. Callers may override
- * per-fork via `config.timeoutMs` (`0` restores unbounded).
+ * TIME — throttled rounds can each take minutes. On expiry `withTimeout`
+ * aborts the child's controller, cascading through the AbortGraph to its
+ * descendants, and the parent receives a legible TimeoutError tool_result
+ * instead of hanging.
+ *
+ * 45 minutes (raised from an earlier 20 min): the 20-min cap was a BLUNT wall
+ * that guillotined genuinely-working read-only research/review children —
+ * `/review`'s `research-agent` (which nests `git-investigator`) does continuous
+ * grep/read archaeology that legitimately exceeds 20 min on a large diff, so a
+ * healthy child was being killed mid-work rather than a hung one relieved.
+ * 45 min gives real headroom over the longest healthy child observed while
+ * still guaranteeing every fork terminates. Operators can tune per-environment
+ * via `AFK_SUBAGENT_TIMEOUT_MS` (see {@link resolveSubagentTimeoutMs}); callers
+ * may override per-fork via `config.timeoutMs` (`0` restores unbounded).
+ *
+ * NOTE: a follow-up will add a progress-aware idle watchdog (reset the budget
+ * on observable child progress) so an ACTIVELY-working child is never cut off
+ * regardless of total wall-clock; this raised blunt cap is the interim relief.
  */
-export const SUBAGENT_DEFAULT_TIMEOUT_MS = 20 * 60_000;
+export const SUBAGENT_DEFAULT_TIMEOUT_MS = 45 * 60_000;
+
+/**
+ * Resolve the foreground forked-subagent wall-clock budget from
+ * `AFK_SUBAGENT_TIMEOUT_MS`.
+ *
+ * Mirrors {@link resolveTtfbTimeoutMs}: returns the parsed value when it is a
+ * finite integer `>= 0`. A value of `0` is the explicit disable escape hatch
+ * (returned as `0` = unbounded). Unset, empty, or unparseable input falls back
+ * to {@link SUBAGENT_DEFAULT_TIMEOUT_MS}; negative values are treated as invalid
+ * and also fall back to the default.
+ *
+ * Only consulted for the DEFAULT budget: an explicit per-fork `config.timeoutMs`
+ * (including the background {@link SUBAGENT_BACKGROUND_TIMEOUT_MS} set by the
+ * SubagentExecutor) still wins via the `??` at the fork site.
+ */
+export function resolveSubagentTimeoutMs(): number {
+  const raw = env.AFK_SUBAGENT_TIMEOUT_MS;
+  if (raw === undefined || raw.trim() === '') return SUBAGENT_DEFAULT_TIMEOUT_MS;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return SUBAGENT_DEFAULT_TIMEOUT_MS;
+  return n;
+}
 
 /**
  * Wall-clock budget for BACKGROUND-mode agent dispatches (fire-and-forget
@@ -801,8 +836,13 @@ export class SubagentManager {
       this.abortGraph,
       options.outputSchema,
       // Wall-clock budget for the child's turn (see SUBAGENT_DEFAULT_TIMEOUT_MS
-      // above). Explicit caller values win, including `0` for unbounded.
-      options.config.timeoutMs ?? SUBAGENT_DEFAULT_TIMEOUT_MS,
+      // above). Explicit caller values win, including `0` for unbounded and the
+      // background SUBAGENT_BACKGROUND_TIMEOUT_MS the SubagentExecutor stamps —
+      // `??` preserves that precedence. The default is env-tunable via
+      // AFK_SUBAGENT_TIMEOUT_MS (resolveSubagentTimeoutMs); an unset/invalid
+      // env value returns SUBAGENT_DEFAULT_TIMEOUT_MS, so behaviour is unchanged
+      // when the var is not set.
+      options.config.timeoutMs ?? resolveSubagentTimeoutMs(),
       registry,
       () => {
         this.active.delete(id);

--- a/src/agent/subagent/handle-streaming.test.ts
+++ b/src/agent/subagent/handle-streaming.test.ts
@@ -825,6 +825,191 @@ describe('SubagentHandle streaming', () => {
       expect(result.status).toBe('cancelled');
       expect(handle.status).toBe('cancelled');
     });
+
+    // Canonical-timeout guard (PR: env-configurable timeout + observability).
+    // Two invariants the trace consumers depend on:
+    //   1. OWN wall-clock budget expiry → transition:'failed' + failureClass:
+    //      'timeout' (a legible guillotined-by-budget signal, still 'failed' so
+    //      the notifier injects the error).
+    //   2. CASCADED ancestor-timeout → transition:'cancelled' + timeout:true
+    //      (torn down externally; NOT reclassified to 'failed').
+    // The classification (failed vs cancelled) is asserted elsewhere; here we
+    // pin the ADDED annotations on the emitted lifecycle payloads.
+
+    it("emits failed + failureClass:'timeout' when the handle blows its OWN budget", async () => {
+      vi.useFakeTimers();
+      try {
+        const localGraph = new AbortGraph();
+        const controller = new AbortController();
+        localGraph.register('own-budget-child', controller);
+
+        // Session that hangs forever — only the handle's own withTimeout timer
+        // aborts it. No cascade (no ancestor in the graph aborts it).
+        const session = {
+          sessionId: 'mock-session',
+          state: 'idle',
+          abortSignal: controller.signal,
+          async sendMessage() {
+            return { role: 'assistant', content: '', timestamp: new Date() };
+          },
+          async *sendMessageStream() {
+            await new Promise<void>((resolve, reject) => {
+              controller.signal.addEventListener(
+                'abort',
+                () => reject(controller.signal.reason ?? new Error('aborted')),
+                { once: true },
+              );
+              // never resolves on its own
+              void resolve;
+            });
+          },
+          async interrupt() {},
+          async close() {},
+          async reset() {},
+          async setModel() {},
+          async setPermissionMode() {},
+          waitForInitialization: async () => ({ sessionId: 'mock-session', model: 'm', persistSession: true }),
+          getSessionIdentity: () => ({ persistSession: true }),
+          getSessionMetadata: () => ({ sessionId: 'mock-session', model: 'm', persistSession: true }),
+          getQuery: () => { throw new Error('not implemented'); },
+          getLastResponseMetadata: () => null,
+          getOutputStream: async function* () {},
+          getInputStreamRef: () => ({ pushUserMessage: vi.fn() }),
+          supportedCommands: async () => [],
+          supportedModels: async () => [],
+          supportedAgents: async () => [],
+          getContextUsage: async () => ({ contextLimitTokens: 0, contextUsedTokens: 0 }),
+          mcpServerStatus: async () => [],
+          accountInfo: async () => ({ name: 'test', email: 'test@example.com' }),
+        } as unknown as IAgentSession;
+
+        const events: Array<{ kind: string; payload: Record<string, unknown> }> = [];
+        const traceWriter = {
+          write: vi.fn(async (e: { kind: string; payload: Record<string, unknown> }) => {
+            events.push(e);
+          }),
+          getTracePath: () => 'in-memory://trace',
+        } as unknown as import('../trace/writer.js').TraceWriter;
+
+        const handle = new SubagentHandleImpl(
+          'own-budget-child',
+          session,
+          controller,
+          localGraph,
+          undefined,
+          1000, // small OWN budget → withTimeout fires
+          undefined,
+          vi.fn(),
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          traceWriter, // position 14
+        );
+
+        const resultPromise = handle.runToResult('test');
+        await vi.advanceTimersByTimeAsync(1000);
+        const result = await resultPromise;
+
+        expect(result.status).toBe('failed');
+        expect(handle.status).toBe('failed');
+        const failed = events.find(
+          (e) => e.kind === 'subagent_lifecycle' && e.payload.transition === 'failed',
+        );
+        expect(failed).toBeDefined();
+        expect(failed!.payload.failureClass).toBe('timeout');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('emits cancelled + timeout:true when a cascaded ancestor timeout tears it down', async () => {
+      let holdResolve: () => void = () => {};
+      const localGraph = new AbortGraph();
+      const parentController = new AbortController();
+      const childController = new AbortController();
+      localGraph.register('cascade-to-parent', parentController);
+      localGraph.register('cascade-to-child', childController);
+      localGraph.linkChild('cascade-to-parent', 'cascade-to-child');
+
+      const session = {
+        sessionId: 'mock-session',
+        state: 'idle',
+        abortSignal: childController.signal,
+        async sendMessage() {
+          return { role: 'assistant', content: '', timestamp: new Date() };
+        },
+        async *sendMessageStream() {
+          await new Promise<void>((resolve) => {
+            holdResolve = resolve;
+          });
+          if (childController.signal.aborted) {
+            throw childController.signal.reason ?? new Error('aborted');
+          }
+        },
+        async interrupt() {},
+        async close() {},
+        async reset() {},
+        async setModel() {},
+        async setPermissionMode() {},
+        waitForInitialization: async () => ({ sessionId: 'mock-session', model: 'm', persistSession: true }),
+        getSessionIdentity: () => ({ persistSession: true }),
+        getSessionMetadata: () => ({ sessionId: 'mock-session', model: 'm', persistSession: true }),
+        getQuery: () => { throw new Error('not implemented'); },
+        getLastResponseMetadata: () => null,
+        getOutputStream: async function* () {},
+        getInputStreamRef: () => ({ pushUserMessage: vi.fn() }),
+        supportedCommands: async () => [],
+        supportedModels: async () => [],
+        supportedAgents: async () => [],
+        getContextUsage: async () => ({ contextLimitTokens: 0, contextUsedTokens: 0 }),
+        mcpServerStatus: async () => [],
+        accountInfo: async () => ({ name: 'test', email: 'test@example.com' }),
+      } as unknown as IAgentSession;
+
+      const events: Array<{ kind: string; payload: Record<string, unknown> }> = [];
+      const traceWriter = {
+        write: vi.fn(async (e: { kind: string; payload: Record<string, unknown> }) => {
+          events.push(e);
+        }),
+        getTracePath: () => 'in-memory://trace',
+      } as unknown as import('../trace/writer.js').TraceWriter;
+
+      const handle = new SubagentHandleImpl(
+        'cascade-to-child',
+        session,
+        childController,
+        localGraph,
+        undefined,
+        5000, // large OWN budget so only the cascade aborts it
+        undefined,
+        vi.fn(),
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        traceWriter, // position 14
+      );
+
+      const resultPromise = handle.runToResult('test');
+      await new Promise((r) => setImmediate(r));
+      // Cascade an ANCESTOR wall-clock timeout: BFS marks child cascading=true
+      // and aborts childController with this TimeoutError reason.
+      localGraph.abort('cascade-to-parent', new TimeoutError('parent budget', 1000), 'timeout');
+      holdResolve();
+
+      const result = await resultPromise;
+      expect(result.status).toBe('cancelled');
+      expect(handle.status).toBe('cancelled');
+      const cancelled = events.find(
+        (e) => e.kind === 'subagent_lifecycle' && e.payload.transition === 'cancelled',
+      );
+      expect(cancelled).toBeDefined();
+      expect(cancelled!.payload.source).toBe('cascade');
+      expect(cancelled!.payload.timeout).toBe(true);
+    });
   });
 
   describe('Error event in stream propagates', () => {

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -286,10 +286,19 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
         // seal that lands before this write is enqueued would drop the terminal
         // record. Awaiting guarantees the event is persisted first.
         if (this.controller.signal.aborted && timeoutReason === undefined) {
+          // Annotate a timeout-driven cascade: `timeoutReason` is undefined here
+          // (this branch's guard), so a TimeoutError on the signal means the
+          // origin guard above classified it as CASCADED (isCascading true) —
+          // i.e. an ANCESTOR's wall-clock budget expired and the abort came down
+          // to us. Flag it so a trace reader can tell a timeout cascade from an
+          // ordinary parent/explicit cancel. Not our own budget → still
+          // 'cancelled', not 'failed'.
+          const cascadeTimedOut = this.controller.signal.reason instanceof TimeoutError;
           await emitSubagentLifecycle(this.traceWriter, {
             transition: 'cancelled',
             subagentId: this.id,
             source: 'cascade',
+            ...(cascadeTimedOut ? { timeout: true } : {}),
           });
           this.currentStatus = 'cancelled';
           this.latestTerminalStatus = 'cancelled';
@@ -300,6 +309,12 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
             errorClass: surfacedErr instanceof Error ? surfacedErr.constructor.name : 'Unknown',
             errorMessage: surfacedErr instanceof Error ? surfacedErr.message : String(surfacedErr),
             partialOutputBytes: Buffer.byteLength(this.lastStreamedContent, 'utf8'),
+            // Classify our OWN wall-clock budget expiry as a timeout failure.
+            // `timeoutReason` is set (see the origin-guarded detection above)
+            // exactly when THIS handle's controller was aborted with a
+            // TimeoutError that is NOT a cascade — the guillotined-by-budget
+            // case #583/this PR targets. Absent for any other failure.
+            ...(timeoutReason !== undefined ? { failureClass: 'timeout' as const } : {}),
           });
           this.currentStatus = 'failed';
           this.latestTerminalStatus = 'failed';

--- a/src/agent/tools/subagent-executor.test.ts
+++ b/src/agent/tools/subagent-executor.test.ts
@@ -28,6 +28,7 @@ import type { AgentConfig } from '../types/config-types.js';
 import type { ToolCall } from './types.js';
 import type { ModelProvider } from '../provider.js';
 import { SubagentExecutor, DEFAULT_MAX_NESTING_DEPTH, type SubagentExecutorContext } from './subagent-executor.js';
+import { stripEscapeSequences } from '../../utils/terminal-sanitize.js';
 
 function mockHandle(
   overrides?: Partial<{
@@ -1440,17 +1441,20 @@ describe('SubagentExecutor', () => {
   // but previously never passed at any production call site).
   describe('promptHead wiring (PR #610)', () => {
     it('forwards a non-empty, sanitized 80-char promptHead slice to forkSubagent', async () => {
-      // Prompt > 80 chars with a leading ANSI escape + embedded newline so the
-      // assertion exercises the full sanitize pipeline (strip ANSI, collapse
-      // newlines, slice to 80, trim) — the same derivation as agentType but at 80.
+      // Prompt > 80 chars mixing a non-SGR OSC escape (set-window-title,
+      // BEL-terminated) with SGR color codes and an embedded newline, so the
+      // assertion exercises the FULL sanitize pipeline (strip ALL escape
+      // families, collapse newlines, slice to 80, trim). The OSC prefix is the
+      // load-bearing part: a weaker SGR-only stripper would leave its \x1b in
+      // the slice and fail the no-escape assertion below — this guards against
+      // a stripper downgrade at the production site.
       const prompt =
-        '\x1b[31mInvestigate the failing auth test\x1b[0m\nand report the root cause with file:line citations plus a recommended fix';
-      // Expected = the first 80 sanitized chars, derived by the same transform
-      // the production site applies (strip ANSI, collapse newlines, slice 80,
-      // trim). Computed here rather than hand-counted so the expectation cannot
-      // silently drift from the code under test.
-      const expected = prompt
-        .replace(/\x1b\[[0-9;]*m/g, '') // eslint-disable-line no-control-regex
+        '\x1b]0;title\x07\x1b[31mInvestigate the failing auth test\x1b[0m\nand report the root cause with file:line citations plus a recommended fix';
+      // Expected = the first 80 chars under the SAME production transform
+      // (stripEscapeSequences → collapse newlines → slice 80 → trim), derived
+      // via the real shared stripper (not a hand-rolled regex) so this oracle
+      // can never be weaker than the code under test.
+      const expected = stripEscapeSequences(prompt)
         .replace(/[\r\n]+/g, ' ')
         .slice(0, 80)
         .trim();

--- a/src/agent/tools/subagent-executor.test.ts
+++ b/src/agent/tools/subagent-executor.test.ts
@@ -1432,6 +1432,49 @@ describe('SubagentExecutor', () => {
     });
   });
 
+  // promptHead wiring (PR #610 review): the agent-tool dispatch site must
+  // forward a sanitized/sliced promptHead into forkSubagent so the
+  // subagent_lifecycle.started event carries WHAT the child was asked to do in
+  // real CLI/daemon dispatches — not just the render label. Guards against the
+  // field silently regressing to absent (schematized + unit-tested downstream,
+  // but previously never passed at any production call site).
+  describe('promptHead wiring (PR #610)', () => {
+    it('forwards a non-empty, sanitized 80-char promptHead slice to forkSubagent', async () => {
+      // Prompt > 80 chars with a leading ANSI escape + embedded newline so the
+      // assertion exercises the full sanitize pipeline (strip ANSI, collapse
+      // newlines, slice to 80, trim) — the same derivation as agentType but at 80.
+      const prompt =
+        '\x1b[31mInvestigate the failing auth test\x1b[0m\nand report the root cause with file:line citations plus a recommended fix';
+      // Expected = the first 80 sanitized chars, derived by the same transform
+      // the production site applies (strip ANSI, collapse newlines, slice 80,
+      // trim). Computed here rather than hand-counted so the expectation cannot
+      // silently drift from the code under test.
+      const expected = prompt
+        .replace(/\x1b\[[0-9;]*m/g, '') // eslint-disable-line no-control-regex
+        .replace(/[\r\n]+/g, ' ')
+        .slice(0, 80)
+        .trim();
+
+      const handle = mockHandle();
+      mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
+
+      await executor.execute(makeCall({ input: { prompt } }));
+
+      const forkArg = (mockSubagentMgr.forkSubagent as ReturnType<typeof vi.fn>).mock.calls[0]![0] as {
+        promptHead: string;
+      };
+      // Core regression guard: the field actually reaches forkSubagent non-empty.
+      expect(forkArg.promptHead.length).toBeGreaterThan(0);
+      // Matches the first 80 sanitized chars of the dispatch prompt.
+      expect(forkArg.promptHead).toBe(expected);
+      expect(forkArg.promptHead.length).toBeLessThanOrEqual(80);
+      // Sanitized: no raw ANSI escape or newline survives into the slice.
+      // eslint-disable-next-line no-control-regex
+      expect(forkArg.promptHead).not.toMatch(/\x1b/);
+      expect(forkArg.promptHead).not.toMatch(/[\r\n]/);
+    });
+  });
+
   // -----------------------------------------------------------------------
   // mode: 'background'
   //

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -608,6 +608,11 @@ export class SubagentExecutor implements SubagentControl {
           : (parsed.id_prefix && parsed.id_prefix !== 'agent-tool')
             ? stripEscapeSequences(parsed.id_prefix).replace(/[\r\n]+/g, ' ').trim() || 'agent'
             : stripEscapeSequences(parsed.prompt).replace(/[\r\n]+/g, ' ').slice(0, 40).trim() || 'agent',
+        // Forensic prompt slice for the `subagent_lifecycle.started` event: sanitized
+        // like agentType but kept at 80 chars (the emit in subagent.ts re-clamps to
+        // 80 and drops it when blank), so real CLI/daemon dispatches carry WHAT the
+        // child was asked to do — not just the render label.
+        promptHead: stripEscapeSequences(parsed.prompt).replace(/[\r\n]+/g, ' ').slice(0, 80).trim(),
         // A forked sub-agent has no human relationship of its own: it returns
         // findings (including Blocked/Asking) to its PARENT, which owns the
         // operator surface. Deny MCP elicitation for BOTH foreground and

--- a/src/agent/trace/events.test.ts
+++ b/src/agent/trace/events.test.ts
@@ -256,6 +256,57 @@ describe('subagent_lifecycle payload', () => {
       }),
     ).toThrow();
   });
+
+  // Observability additions (PR: env-configurable timeout + observable forks).
+  it('accepts started variant with promptHead + agentType', () => {
+    const parsed = SubagentLifecyclePayloadSchema.parse({
+      transition: 'started',
+      subagentId: 'child-1',
+      parentId: 'root',
+      model: 'claude-sonnet-4',
+      promptHead: 'Investigate the failing auth test and report root cause',
+      agentType: 'research-agent',
+    });
+    expect(parsed).toMatchObject({
+      promptHead: 'Investigate the failing auth test and report root cause',
+      agentType: 'research-agent',
+    });
+  });
+
+  it("accepts failed variant with failureClass 'timeout'", () => {
+    const parsed = SubagentLifecyclePayloadSchema.parse({
+      transition: 'failed',
+      subagentId: 'child-1',
+      errorClass: 'TimeoutError',
+      errorMessage: 'timed out after 2700000ms',
+      partialOutputBytes: 42,
+      failureClass: 'timeout',
+    });
+    expect(parsed).toMatchObject({ failureClass: 'timeout' });
+  });
+
+  it('rejects an unknown failureClass on the failed variant', () => {
+    expect(() =>
+      SubagentLifecyclePayloadSchema.parse({
+        transition: 'failed',
+        subagentId: 'child-1',
+        errorClass: 'Error',
+        errorMessage: 'boom',
+        partialOutputBytes: 0,
+        failureClass: 'made-up-class',
+      }),
+    ).toThrow();
+  });
+
+  it('accepts cancelled variant with the timeout flag', () => {
+    const parsed = SubagentLifecyclePayloadSchema.parse({
+      transition: 'cancelled',
+      subagentId: 'child-1',
+      source: 'cascade',
+      timeout: true,
+    });
+    expect(parsed).toMatchObject({ source: 'cascade', timeout: true });
+  });
 });
 
 describe('budget payload', () => {

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -104,6 +104,8 @@ export const SubagentStartedPayloadSchema = z.object({
   model: z.string(),
   allowedTools: z.array(z.string()).readonly().optional(),
   systemPromptHash: z.string().optional(),
+  promptHead: z.string().optional(),
+  agentType: z.string().optional(),
 });
 
 export const SubagentSucceededPayloadSchema = z.object({
@@ -122,12 +124,14 @@ export const SubagentFailedPayloadSchema = z.object({
   errorClass: z.string(),
   errorMessage: z.string(),
   partialOutputBytes: z.number().int().nonnegative(),
+  failureClass: ToolFailureClassSchema.optional(),
 });
 
 export const SubagentCancelledPayloadSchema = z.object({
   transition: z.literal('cancelled'),
   subagentId: z.string(),
   source: z.enum(['cascade', 'explicit']),
+  timeout: z.boolean().optional(),
 });
 
 export const SubagentLifecyclePayloadSchema = z.discriminatedUnion('transition', [

--- a/src/agent/trace/subagent-lifecycle.test.ts
+++ b/src/agent/trace/subagent-lifecycle.test.ts
@@ -130,6 +130,53 @@ describe('subagent_lifecycle trace events', () => {
       expect(started.payload.allowedTools).toEqual(['bash', 'read_file']);
     });
 
+    // Observability: promptHead + agentType (PR: observable forked children).
+    it('records agentType and a re-clamped promptHead when supplied', async () => {
+      const writer = new InMemoryTraceWriter();
+      const mgr = new SubagentManager();
+      // 100-char prompt head; the emit re-clamps to 80 to honour the payload
+      // contract regardless of caller input.
+      const longHead = 'x'.repeat(100);
+      await mgr.forkSubagent({
+        parent: { sessionId: 'parent-3' },
+        config: { model: 'sonnet', traceWriter: writer },
+        agentType: 'research-agent',
+        promptHead: longHead,
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const started = writer.events.find(
+        (e) => e.kind === 'subagent_lifecycle' && e.payload.transition === 'started',
+      );
+      if (started?.kind !== 'subagent_lifecycle' || started.payload.transition !== 'started') {
+        throw new Error('expected started event');
+      }
+      expect(started.payload.agentType).toBe('research-agent');
+      expect(started.payload.promptHead).toBe('x'.repeat(80));
+      expect(started.payload.promptHead?.length).toBe(80);
+    });
+
+    it('omits promptHead when blank/whitespace and agentType when unset', async () => {
+      const writer = new InMemoryTraceWriter();
+      const mgr = new SubagentManager();
+      await mgr.forkSubagent({
+        parent: { sessionId: 'parent-4' },
+        config: { model: 'sonnet', traceWriter: writer },
+        promptHead: '   ', // whitespace-only → treated as absent
+        // no agentType
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const started = writer.events.find(
+        (e) => e.kind === 'subagent_lifecycle' && e.payload.transition === 'started',
+      );
+      if (started?.kind !== 'subagent_lifecycle' || started.payload.transition !== 'started') {
+        throw new Error('expected started event');
+      }
+      expect(started.payload.promptHead).toBeUndefined();
+      expect(started.payload.agentType).toBeUndefined();
+    });
+
     it('falls back to manager rootId when parent has no sessionId', async () => {
       const writer = new InMemoryTraceWriter();
       const mgr = new SubagentManager();

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -73,7 +73,14 @@ export const TOOL_FAILURE_CLASSES = [
  *
  * Set at the site that produced the error:
  *   - `policy-refusal`       — browser handler refused nav (domain allowlist). NOT a bug.
- *   - `timeout`              — browser navigation/action exceeded its deadline.
+ *   - `timeout`              — a bounded operation exceeded its deadline: a browser
+ *                              navigation/action past its per-action timeout, OR a
+ *                              forked sub-agent whose own wall-clock budget
+ *                              (SUBAGENT_DEFAULT_TIMEOUT_MS / config.timeoutMs) expired
+ *                              and `withTimeout` aborted its controller. Annotated on the
+ *                              subagent_lifecycle `failed` payload (own-budget expiry)
+ *                              and, for a cascaded ancestor-timeout, via the `cancelled`
+ *                              payload's `timeout` flag.
  *   - `permission-denied`    — permission gate or read-only-skill bash gate denied the call.
  *   - `hook-block`           — a PreToolUse hook returned `decision: 'block'`.
  *   - `abort`                — the call's AbortSignal was already fired.
@@ -187,6 +194,21 @@ export interface SubagentStartedPayload {
   allowedTools?: readonly string[];
   /** SHA-256 hex digest of the child's system prompt, for audit. */
   systemPromptHash?: string;
+  /**
+   * First 80 chars of the dispatch prompt, for at-a-glance forensics — lets a
+   * trace reader see WHAT a child was asked to do without opening the child's
+   * own transcript. Absent when the fork site had no prompt in scope (e.g. a
+   * skill/compose fork whose prompt is threaded later). Truncated at the
+   * emit site.
+   */
+  promptHead?: string;
+  /**
+   * The effective agent type / render label for this fork (e.g. a named
+   * `research-agent`, a compose node label, or a prompt-derived slice). Present
+   * so a reader can attribute a lifecycle event to a role without cross-refing
+   * the routing telemetry. Absent when no label was resolved.
+   */
+  agentType?: string;
 }
 
 export interface SubagentSucceededPayload {
@@ -212,6 +234,14 @@ export interface SubagentFailedPayload {
   errorMessage: string;
   /** 0 when no partial output was captured before the failure. */
   partialOutputBytes: number;
+  /**
+   * Coarse failure classification, mirroring {@link ToolFailureClass}. Set to
+   * `'timeout'` when this failure is the handle's OWN wall-clock budget expiry
+   * (a `TimeoutError` abort on its controller that is NOT a cascade) — lets a
+   * trace reader tell a guillotined-by-budget child apart from a genuine error.
+   * Absent for unclassified failures (the pre-classification default).
+   */
+  failureClass?: ToolFailureClass;
 }
 
 export interface SubagentCancelledPayload {
@@ -222,6 +252,14 @@ export interface SubagentCancelledPayload {
    * - `'explicit'` — `cancel()` was called directly on this handle.
    */
   source: 'cascade' | 'explicit';
+  /**
+   * `true` when the cascade that cancelled this handle originated from a
+   * `TimeoutError` (an ANCESTOR's wall-clock budget expired and the abort
+   * cascaded down to this descendant). Distinguishes a timeout-driven cascade
+   * cancel from an ordinary explicit/parent cancel. Only ever set on
+   * `source: 'cascade'`; absent otherwise.
+   */
+  timeout?: boolean;
 }
 
 export type SubagentLifecyclePayload =

--- a/src/cli/commands/daemon-session-factory.test.ts
+++ b/src/cli/commands/daemon-session-factory.test.ts
@@ -185,4 +185,44 @@ describe('buildDaemonSessionFactory', () => {
     expect(typeof session.sendMessage).toBe('function');
     void session.close().catch(() => undefined);
   });
+
+  // Surface-parity guard (PR: observable forked children). The scheduler
+  // (scheduler.ts:spawnSession) opens a per-tick trace and threads it in as
+  // config.traceWriter. The daemon factory must forward THAT SAME instance into
+  // its fork executors + root manager (mirroring bootstrap.ts) — otherwise
+  // daemon-forked children emit zero subagent_lifecycle events and the new
+  // timeout/prompt-head observability is invisible on the AFK surface where it
+  // matters most. Regression guard against a reintroduction of the old
+  // `traceWriter: undefined` wiring.
+  it('threads config.traceWriter into the fork executors and root manager', () => {
+    const traceWriter = {
+      write: async () => undefined,
+      getTracePath: () => 'in-memory://trace',
+      seal: async () => undefined,
+    } as unknown as NonNullable<AgentConfig['traceWriter']>;
+
+    const factory = buildDaemonSessionFactory({ model: 'sonnet', apiKey: TEST_API_KEY });
+    const session = factory(makeConfig({ traceWriter }));
+    const internals = session as unknown as { config?: { provider?: unknown } };
+    const provider = internals.config?.provider as AnthropicDirectProvider;
+    expect(provider).toBeInstanceOf(AnthropicDirectProvider);
+
+    // Each executor stores its context as `this.ctx`, whose `traceWriter` field
+    // is the writer forwarded at construction.
+    const subExec = readSubagentExecutor(provider) as { ctx?: { traceWriter?: unknown; subagentManager?: unknown } };
+    const skillExec = readSkillExecutor(provider) as { ctx?: { traceWriter?: unknown } };
+    const composeExec = readComposeExecutor(provider) as { ctx?: { traceWriter?: unknown } };
+
+    expect(subExec.ctx?.traceWriter, 'SubagentExecutor traceWriter').toBe(traceWriter);
+    expect(skillExec.ctx?.traceWriter, 'SkillExecutor traceWriter').toBe(traceWriter);
+    expect(composeExec.ctx?.traceWriter, 'ComposeExecutor traceWriter').toBe(traceWriter);
+
+    // The load-bearing path: the root SubagentManager's parentTraceWriter is
+    // what forkSubagent hands to every depth-1 `agent`-tool child's handle
+    // (subagent.ts: effectiveTraceWriter = config.traceWriter ?? parentTraceWriter).
+    const mgr = subExec.ctx?.subagentManager as { parentTraceWriter?: unknown } | undefined;
+    expect(mgr?.parentTraceWriter, 'root SubagentManager parentTraceWriter').toBe(traceWriter);
+
+    void session.close().catch(() => undefined);
+  });
 });

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -99,6 +99,15 @@ export function buildDaemonSessionFactory(
       parentModel: opts.model,
       ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
       ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+      // Witness layer: manager-level writer so daemon-forked `agent`-tool
+      // children (which never set config.timeoutMs / config.traceWriter) still
+      // emit subagent_lifecycle events and hand the writer to their handles.
+      // The scheduler (scheduler.ts:spawnSession) already opened a per-tick
+      // trace and threaded it in as config.traceWriter — reuse THAT SAME
+      // instance here (do not create a duplicate). Mirrors bootstrap.ts:246.
+      // Undefined under AFK_TRACE_DISABLED=1, in which case the spread is
+      // absent and behaviour is unchanged.
+      ...(config.traceWriter !== undefined ? { traceWriter: config.traceWriter } : {}),
       // Origin attribution: the daemon is a `daemon` entrypoint. Thread the
       // surface so forked `agent`-tool children inherit origin 'daemon' (not
       // 'unknown') via forkSubagent's parentSurface fill. Mirrors farm.ts.
@@ -121,8 +130,10 @@ export function buildDaemonSessionFactory(
       opts.apiKey,
       childProviderFactory,
       opts.baseUrl,
-      // traceWriter: daemon has no trace writer — pass undefined
-      undefined,
+      // traceWriter: reuse the scheduler's per-tick writer (threaded in as
+      // config.traceWriter) so depth>0 skill forks stay visible in the witness
+      // trace. Undefined under AFK_TRACE_DISABLED=1. Mirrors bootstrap.ts:333.
+      config.traceWriter,
       // backgroundRegistry: daemon has no background registry — pass undefined
       undefined,
       opts.cwd,
@@ -161,6 +172,11 @@ export function buildDaemonSessionFactory(
       // Named-agent dispatch: registry + `inherit` anchor.
       agentRegistry,
       parentModel: opts.model,
+      // Witness layer: thread the scheduler's per-tick writer so depth ≥ 2
+      // `agent` forks (nested child managers built inside execute()) stay
+      // visible. Depth-1 forks are covered by rootManager above. Mirrors
+      // bootstrap.ts:395.
+      ...(config.traceWriter !== undefined ? { traceWriter: config.traceWriter } : {}),
     });
 
     const skillExecutor = new SkillExecutor({
@@ -179,6 +195,10 @@ export function buildDaemonSessionFactory(
       ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
       ...(opts.openaiBaseUrl !== undefined ? { openaiBaseUrl: opts.openaiBaseUrl } : {}),
       ...(opts.cwd !== undefined ? { cwd: opts.cwd } : {}),
+      // Witness layer: without this, daemon skill-forked subagents (every
+      // /forge-friction, /review, etc. fired by a task) emit zero trace events,
+      // making subagent failures undebuggable from disk. Mirrors bootstrap.ts:424.
+      ...(config.traceWriter !== undefined ? { traceWriter: config.traceWriter } : {}),
       // Read-scope inheritance (#547): skill-forked children inherit the parent
       // session's read scope via the root manager. See bootstrap.ts.
       getReadScopeInputs: () => rootManager.getReadScopeInputs(),
@@ -201,6 +221,9 @@ export function buildDaemonSessionFactory(
       // Session identity for routing-decision rows (daemon/scheduler → daemon).
       surface: 'daemon',
       depth: 0,
+      // Witness layer: DAG nodes emit subagent_lifecycle into the session
+      // trace. Reuses the scheduler's per-tick writer. Mirrors bootstrap.ts:460.
+      ...(config.traceWriter !== undefined ? { traceWriter: config.traceWriter } : {}),
     });
 
     memoryStore ??= new MemoryStore();

--- a/src/cli/commands/trace.test.ts
+++ b/src/cli/commands/trace.test.ts
@@ -130,6 +130,54 @@ describe('formatTrace — default human view', () => {
   });
 });
 
+describe('formatTrace — subagent timeout markers', () => {
+  // PR (observable forked children): the reader must surface the new lifecycle
+  // timeout signals — `[timeout]` on a failed child that blew its OWN budget
+  // (failureClass:'timeout'), and `(timeout)` on a cancelled child whose
+  // ancestor's budget expired (source:'cascade' + timeout:true).
+  it("renders [timeout] on a failed subagent with failureClass 'timeout'", () => {
+    const events: EventObj[] = [
+      { ts: '2026-06-05T12:30:00.000Z', seq: 0, kind: 'subagent_lifecycle', payload: { transition: 'failed', subagentId: 'sub-to', errorClass: 'TimeoutError', errorMessage: 'timed out after 2700000ms', partialOutputBytes: 12, failureClass: 'timeout' } },
+      { ts: '2026-06-05T12:35:00.000Z', seq: 1, kind: 'session_sealed', payload: { status: 'succeeded', finalCostUsd: 0.01, finalTurnCount: 1, closedAt: '2026-06-05T12:35:00.000Z' } },
+    ];
+    const out = formatTrace('s', '/p', parseTrace(toJsonl(events)));
+    expect(out).toContain('FAILED');
+    expect(out).toContain('[timeout]');
+    expect(out).toContain('[sub-to]');
+  });
+
+  it('does NOT render [timeout] on an ordinary failed subagent (no failureClass)', () => {
+    const events: EventObj[] = [
+      { ts: '2026-06-05T12:30:00.000Z', seq: 0, kind: 'subagent_lifecycle', payload: { transition: 'failed', subagentId: 'sub-err', errorClass: 'Error', errorMessage: 'boom', partialOutputBytes: 0 } },
+      { ts: '2026-06-05T12:35:00.000Z', seq: 1, kind: 'session_sealed', payload: { status: 'failed', finalCostUsd: 0, finalTurnCount: 1, closedAt: '2026-06-05T12:35:00.000Z' } },
+    ];
+    const out = formatTrace('s', '/p', parseTrace(toJsonl(events)));
+    expect(out).toContain('FAILED');
+    expect(out).not.toContain('[timeout]');
+  });
+
+  it('renders (timeout) on a cascade-cancelled subagent with the timeout flag', () => {
+    const events: EventObj[] = [
+      { ts: '2026-06-05T12:30:00.000Z', seq: 0, kind: 'subagent_lifecycle', payload: { transition: 'cancelled', subagentId: 'sub-casc', source: 'cascade', timeout: true } },
+      { ts: '2026-06-05T12:35:00.000Z', seq: 1, kind: 'session_sealed', payload: { status: 'succeeded', finalCostUsd: 0.01, finalTurnCount: 1, closedAt: '2026-06-05T12:35:00.000Z' } },
+    ];
+    const out = formatTrace('s', '/p', parseTrace(toJsonl(events)));
+    expect(out).toContain('cancelled (cascade)');
+    expect(out).toContain('(timeout)');
+    expect(out).toContain('[sub-casc]');
+  });
+
+  it('does NOT render (timeout) on an ordinary cancel (no timeout flag)', () => {
+    const events: EventObj[] = [
+      { ts: '2026-06-05T12:30:00.000Z', seq: 0, kind: 'subagent_lifecycle', payload: { transition: 'cancelled', subagentId: 'sub-cx', source: 'explicit' } },
+      { ts: '2026-06-05T12:35:00.000Z', seq: 1, kind: 'session_sealed', payload: { status: 'succeeded', finalCostUsd: 0.01, finalTurnCount: 1, closedAt: '2026-06-05T12:35:00.000Z' } },
+    ];
+    const out = formatTrace('s', '/p', parseTrace(toJsonl(events)));
+    expect(out).toContain('cancelled (explicit)');
+    expect(out).not.toContain('(timeout)');
+  });
+});
+
 describe('formatTrace — rate_limit is high-signal (shown by default)', () => {
   // Regression: a rate_limit event is a session_phase, and session_phase is
   // hidden by default (latency waterfall). But throttling is the whole reason a

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -336,13 +336,22 @@ function renderEvent(event: TraceEvent, ctx: RenderContext): string | null {
             `succeeded  ${fmtDuration(p.durationMs)}  ${p.turnCount} turns  ${fmtBytes(p.outputBytes)}${cost}  [${p.subagentId}]`,
           );
         }
-        case 'failed':
+        case 'failed': {
+          // `[timeout]` marks a child killed by its own wall-clock budget
+          // (failureClass:'timeout') vs an ordinary error — see the subagent
+          // lifecycle failed payload.
+          const to = p.failureClass === 'timeout' ? '  [timeout]' : '';
           return line(
             'subagent',
-            `FAILED  ${p.errorClass}: ${truncate(p.errorMessage, 80)}  [${p.subagentId}]`,
+            `FAILED  ${p.errorClass}: ${truncate(p.errorMessage, 80)}${to}  [${p.subagentId}]`,
           );
-        case 'cancelled':
-          return line('subagent', `cancelled (${p.source})  [${p.subagentId}]`);
+        }
+        case 'cancelled': {
+          // `(timeout)` marks a cascade that originated from an ancestor's
+          // wall-clock budget expiry vs an ordinary parent/explicit cancel.
+          const to = p.timeout ? ' (timeout)' : '';
+          return line('subagent', `cancelled (${p.source})${to}  [${p.subagentId}]`);
+        }
       }
       return null;
     }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -275,6 +275,25 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     category: 'model',
   },
   {
+    name: 'AFK_SUBAGENT_TIMEOUT_MS',
+    description:
+      'Foreground forked-subagent wall-clock budget in ms; 0 disables the cap; explicit ' +
+      'per-fork config.timeoutMs and the 60-min background mode still win. Bounds how long a ' +
+      'single forked child turn may run before `withTimeout` aborts its controller (cascading ' +
+      'through the AbortGraph to descendants) and the parent receives a legible TimeoutError ' +
+      'tool_result instead of hanging. Default 2700000 (45 min ≈ headroom over the longest ' +
+      'healthy review/research agent observed in production). Unset, empty, or unparseable input ' +
+      'falls back to the default; a negative value is treated as invalid and also falls back. ' +
+      'Set to 0 to opt a whole session back into unbounded child turns. Does NOT affect the ' +
+      'background dispatch budget (SUBAGENT_BACKGROUND_TIMEOUT_MS) or a per-fork ' +
+      'config.timeoutMs — both take precedence.',
+    type: 'number',
+    required: false,
+    default: '2700000',
+    example: '3600000',
+    category: 'model',
+  },
+  {
     name: 'AFK_VISION_MODELS',
     description: 'Comma-separated override for image (vision) capability detection on the openai-compatible provider. Each token force-enables a model id by exact or substring match (e.g. "qwen2.5-vl" matches a local VL id); prefix a token with "!" to force-disable. Use to send images to a local vision-language model AFK does not recognise by name, or to blacklist a mis-detected id. Built-in detection already covers gpt-4o/4.1/5.x, o1/o3/o4-mini, Claude, and common VL families.',
     type: 'string',
@@ -1259,6 +1278,7 @@ export const env = {
   get AFK_SUGGEST_ENABLED(): string | undefined { return process.env['AFK_SUGGEST_ENABLED']; },
   get AFK_SUGGEST_GHOST(): string | undefined { return process.env['AFK_SUGGEST_GHOST']; },
   get AFK_SUGGEST_MODEL(): string | undefined { return process.env['AFK_SUGGEST_MODEL']; },
+  get AFK_SUBAGENT_TIMEOUT_MS(): string | undefined { return process.env['AFK_SUBAGENT_TIMEOUT_MS']; },
   get AFK_TASK_BUDGET(): string | undefined { return process.env['AFK_TASK_BUDGET']; },
   get AFK_TEMPERATURE(): string | undefined { return process.env['AFK_TEMPERATURE']; },
   get AFK_THINKING(): string | undefined { return process.env['AFK_THINKING']; },


### PR DESCRIPTION
# fix(subagent): env-configurable timeout + raise default to 45m; observable forked children

## Problem (verified diagnosis)

Forked sub-agents run under a single **blunt wall-clock cap** — `SUBAGENT_DEFAULT_TIMEOUT_MS`, previously **20 minutes**. That cap is time-based only: the existing tool-iteration cap bounds *rounds*, not *wall-clock*, and throttled rounds can each take minutes.

The 20-minute wall was **guillotining genuinely-working read-only children**, not relieving hung ones. `/review`'s `research-agent` (which nests `git-investigator`) does continuous grep/read/git archaeology that legitimately exceeds 20 minutes on a large diff. When the wall fired mid-work, the child was aborted and surfaced to the parent as an opaque failure. Key properties of the diagnosis:

- **Usage-independent** — the cap is a fixed timer, unaffected by token budget or model.
- **Cross-surface** — it bites the same way in the REPL, one-shot, telegram, and daemon paths.
- **Observability gap** — even when a child *did* hit its budget, the witness trace recorded a generic `failed`/`cancelled` with no signal that a *timeout* was the cause, and daemon-forked children emitted **no lifecycle events at all** (the daemon wired its executors with `traceWriter: undefined`). Reference trace: `fe69562a`.

## Design decision

Two options were considered:

- **Option A — progress-aware idle watchdog.** Reset the budget on observable child progress so an *actively-working* child is never cut off regardless of total wall-clock. Correct long-term answer, but larger surface area (needs a progress signal wired through the handle). **Deferred.**
- **Option B — env-configurable cap + raise the default (this PR).** Raise the foreground default `20m → 45m` (real headroom over the longest healthy child observed while still guaranteeing every fork terminates) and make it tunable per-environment via a new `AFK_SUBAGENT_TIMEOUT_MS`. Ship the interim relief now; make timeouts *legible* in the trace so Option A can be designed against real data.

This PR ships **Option B** and lays the observability groundwork (timeout classification in the trace) that Option A will build on.

Precedence is strictly preserved at the fork site (`config.timeoutMs ?? resolveSubagentTimeoutMs()`): an explicit per-fork `config.timeoutMs`, the `0` unbounded escape hatch, and the 60-min background carve-out (`SUBAGENT_BACKGROUND_TIMEOUT_MS`) all still win. `general-purpose`'s uncapped tool-iteration policy is untouched; vendored prompt bytes are untouched.

## Changes (grouped)

**Config — `AFK_SUBAGENT_TIMEOUT_MS` + 45m default** (`src/config/env.ts`, `src/agent/subagent.ts`)
- Register `AFK_SUBAGENT_TIMEOUT_MS` (number, default `2700000`) in `ENV_REGISTRY` + getter.
- Raise `SUBAGENT_DEFAULT_TIMEOUT_MS` `20m → 45m`.
- Add `resolveSubagentTimeoutMs()` mirroring `resolveTtfbTimeoutMs`: finite int `>= 0`; `0` = unbounded escape hatch; unset/empty/negative/garbage → default. Consulted only for the DEFAULT budget.

**Agents — cap git-investigator** (`src/agent/agents/builtins.ts`)
- `git-investigator` was the only read-only builtin missing the anti-runaway `maxToolUseIterations` cap that `research-agent`/`Explore` already carry. Set it to `READONLY_AGENT_MAX_TOOL_USE_ITERATIONS` (50). `general-purpose` stays uncapped.

**Trace — timeout classification + forensic fields** (`src/agent/trace/types.ts`, `src/agent/trace/events.ts`, `src/agent/subagent/handle.ts`, `src/agent/subagent.ts`, `src/cli/commands/trace.ts`)
- New optional payload fields (interface + Zod schema): `promptHead` + `agentType` on `started`, `failureClass` on `failed`, `timeout` on `cancelled`.
- `handle.ts`: **annotate** (never reclassify) the two timeout paths — own wall-clock budget expiry stays `failed` and gains `failureClass:'timeout'`; a cascaded ancestor-timeout stays `cancelled` (`source:'cascade'`) and gains `timeout:true`. Branch selection unchanged.
- `subagent.ts`: emit `promptHead` (re-clamped to 80) + `agentType` on `subagent_lifecycle.started`.
- `trace.ts` reader: render `[timeout]` on a timeout-failed child and `(timeout)` on a cascade-cancelled child.

**Daemon — thread the trace writer into fork executors** (`src/cli/commands/daemon.ts`)
- The daemon built its `SubagentManager` + `SubagentExecutor`/`SkillExecutor`/`ComposeExecutor` + `childSkillExecutorFactory` with **no** `traceWriter`, so daemon-forked children emitted zero lifecycle events. The scheduler (`scheduler.ts:spawnSession`) already opens a per-tick trace and threads it in as `config.traceWriter`; this reuses **that same instance** at all 5 sites (mirroring `bootstrap.ts`), guarded by `config.traceWriter !== undefined` so `AFK_TRACE_DISABLED=1` is unchanged. The root-manager wiring is the load-bearing one — it's what `forkSubagent` hands to every depth-1 `agent` child's handle.

**Docs** (`docs/env-registry.{json,md}`)
- Regenerated via `pnpm scan:env` (required — new env var). Only the new var row + the total-count line change.

## Regression guards (tests)

- **resolveSubagentTimeoutMs**: default when unset / parses int / `0`→0 / negative or garbage → default.
- **Fork-site precedence**: env override applies as the default when `config.timeoutMs` is omitted; an explicit `config.timeoutMs` wins over the env; the background `0` carve-out is unaffected. Pinned default updated `20m → 45m`; the timeout-message regex now references the constant (no more hardcoded `1200000ms`).
- **Canonical-timeout guard**: own-budget expiry emits `failed` + `failureClass:'timeout'`; cascaded timeout emits `cancelled` (`source:'cascade'`) + `timeout:true` — asserted against captured lifecycle payloads.
- **Cap-coverage drift-catcher**: iterates `builtinAgents()` (not vendored consts) with a *structural* predicate — a builtin with an explicit `tools` allowlist must carry `maxToolUseIterations`; the inherit-all worker (`general-purpose`) must not. Both arms are asserted non-vacuous, so a future read-only builtin that forgets the cap fails here.
- **Surface-parity guard**: the daemon factory threads `config.traceWriter` into all three fork executors and the root `SubagentManager.parentTraceWriter` — regression guard against the old `traceWriter: undefined` wiring.
- **Schema/emit coverage**: the new payload fields round-trip through the Zod schema (and an unknown `failureClass` is rejected); the `started` emit records a re-clamped(80) `promptHead` + `agentType`, omitting both when blank/unset; the trace reader renders/omits the `[timeout]`/`(timeout)` markers correctly.

## Gates (all green)

`pnpm scan:env` (docs regenerated + committed) → `pnpm lint` (tsc) → `pnpm audit:env:check` (0 violations) → `pnpm scan:env:check` (in sync) → `pnpm test:coverage` (**661 files, 12080 passed | 14 pre-existing skipped, 0 failed**).

## Follow-ups

- **Option A — progress-aware idle watchdog**: reset the budget on observable child progress so an actively-working child is never cut off regardless of total wall-clock. This PR's `failureClass:'timeout'` annotation is the signal that path will be designed against.
- **awa-private agent caps**: apply the same read-only anti-runaway cap to `awa-private` agents — separate (private) repo, out of scope here.
- **subagentId per-tool-call tagging** in the trace reader: only worthwhile as a clean single-site change; not attempted in this PR (would be a broader reader refactor).
