### PR TITLE
test(session): unit tests for closure-emitter + ledger-lifecycle (#526)

### DIFF
--- a/src/agent/session/closure-emitter.test.ts
+++ b/src/agent/session/closure-emitter.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Unit tests for the terminal-classification + trace-seal helpers in
+ * `closure-emitter.ts`.
+ *
+ * Scope split from the sibling `closure-reason.test.ts`: that file exercises the
+ * pure precedence DECISION TREE (`classifyClosureReason`). This file covers the
+ * parts of `closure-emitter.ts` that the tree does NOT — the abort-SIGNAL
+ * pre-classification layer inside {@link deriveClosureReason} (the
+ * `instanceof`/string-prefix error detection + the benign-`'closed'` skip),
+ * the {@link deriveSealStatus} mapping, and the writer-driven payload shaping of
+ * {@link emitClosureEvent} / {@link sealTraceWriter}. To avoid duplicating the
+ * decision-tree coverage, `deriveClosureReason` is tested only for the
+ * signal→abort classification it owns plus one delegation touchpoint.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BudgetExceededError, TimeoutError } from '../../utils/errors.js';
+import { InMemoryTraceWriter } from '../trace/writer.js';
+import {
+  deriveClosureReason,
+  deriveSealStatus,
+  emitClosureEvent,
+  sealTraceWriter,
+  type ClosureSignals,
+  type ClosureTokenCounters,
+} from './closure-emitter.js';
+import { CLOSURE_ABORT_RECOVERY_HINT } from './closure-guidance.js';
+
+// A never-aborted signal — the common clean-close case.
+const cleanSignal = new AbortController().signal;
+
+/** Build a fired abort signal carrying `reason`. */
+function abortedSignal(reason: unknown): AbortSignal {
+  const c = new AbortController();
+  c.abort(reason);
+  return c.signal;
+}
+
+const baseSignals: ClosureSignals = {
+  dispatchReason: 'close',
+  signal: cleanSignal,
+  maxTurnsHit: false,
+  hookBlocked: false,
+  lastStopReason: undefined,
+  sawProviderError: false,
+};
+
+const zeroTokens: ClosureTokenCounters = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheCreation: 0,
+};
+
+// ---------------------------------------------------------------------------
+// deriveClosureReason — abort-signal PRE-classification layer
+// (the decision tree itself is covered in closure-reason.test.ts)
+// ---------------------------------------------------------------------------
+
+describe('deriveClosureReason', () => {
+  it('classifies a BudgetExceededError abort-signal reason as budget_exceeded', () => {
+    const signal = abortedSignal(new BudgetExceededError(1, 0.5));
+    expect(deriveClosureReason({ ...baseSignals, signal })).toBe('budget_exceeded');
+  });
+
+  it('classifies a TimeoutError abort-signal reason as timeout', () => {
+    const signal = abortedSignal(new TimeoutError('turn timed out', 1000));
+    expect(deriveClosureReason({ ...baseSignals, signal })).toBe('timeout');
+  });
+
+  it('falls back to string-prefix matching when the reason was stringified', () => {
+    // Some abort paths pass the error MESSAGE (not the instance). The
+    // well-known prefixes must still classify accurately.
+    expect(
+      deriveClosureReason({ ...baseSignals, signal: abortedSignal('Budget ceiling reached: $1') }),
+    ).toBe('budget_exceeded');
+    expect(
+      deriveClosureReason({ ...baseSignals, signal: abortedSignal('operation timed out') }),
+    ).toBe('timeout');
+  });
+
+  it('maps an unrecognised abort-signal reason to a generic abort', () => {
+    expect(
+      deriveClosureReason({ ...baseSignals, signal: abortedSignal(new Error('boom')) }),
+    ).toBe('abort');
+    expect(deriveClosureReason({ ...baseSignals, signal: abortedSignal('whatever') })).toBe('abort');
+  });
+
+  it('treats the benign "closed" teardown reason as NOT an abort', () => {
+    // close() aborts its own controller with reason 'closed' as normal
+    // teardown — that must not surface as a cancellation-flavored reason.
+    const reason = deriveClosureReason({ ...baseSignals, signal: abortedSignal('closed') });
+    expect(reason).toBe('model_end_turn');
+  });
+
+  it('returns model_end_turn for a never-aborted clean close', () => {
+    expect(deriveClosureReason(baseSignals)).toBe('model_end_turn');
+  });
+
+  it('delegates precedence to the decision tree (a classified abort wins over the signal path)', () => {
+    // maxTurnsHit is checked FIRST in classifyClosureReason, so it must win
+    // even though the signal would otherwise classify as budget_exceeded.
+    // This confirms deriveClosureReason forwards its inputs to the tree.
+    const signal = abortedSignal(new BudgetExceededError(1, 0.5));
+    expect(deriveClosureReason({ ...baseSignals, signal, maxTurnsHit: true })).toBe(
+      'max_turns_exceeded',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveSealStatus — closure → seal-status mapping + precedence
+// ---------------------------------------------------------------------------
+
+describe('deriveSealStatus', () => {
+  it("maps dispatchReason 'error' to failed", () => {
+    expect(deriveSealStatus({ ...baseSignals, dispatchReason: 'error' })).toBe('failed');
+  });
+
+  it('maps a fired abort signal (reason !== "closed") to cancelled', () => {
+    expect(deriveSealStatus({ ...baseSignals, signal: abortedSignal('user') })).toBe('cancelled');
+    expect(
+      deriveSealStatus({ ...baseSignals, signal: abortedSignal(new TimeoutError('t', 1)) }),
+    ).toBe('cancelled');
+  });
+
+  it('maps a lone provider error (no abort, not dispatch=error) to failed', () => {
+    expect(deriveSealStatus({ ...baseSignals, sawProviderError: true })).toBe('failed');
+  });
+
+  it('maps an otherwise-clean close to succeeded', () => {
+    expect(deriveSealStatus(baseSignals)).toBe('succeeded');
+  });
+
+  it('treats the benign "closed" abort reason as succeeded, not cancelled', () => {
+    expect(deriveSealStatus({ ...baseSignals, signal: abortedSignal('closed') })).toBe('succeeded');
+  });
+
+  it("prefers failed when dispatchReason is 'error' even if the signal aborted", () => {
+    // 'error' is checked before the signal, so it wins.
+    expect(
+      deriveSealStatus({ ...baseSignals, dispatchReason: 'error', signal: abortedSignal('x') }),
+    ).toBe('failed');
+  });
+
+  it('prefers cancelled over a provider error (abort beats sawProviderError)', () => {
+    // A genuine cancel/budget/timeout abort also emits an error event; the
+    // more-specific cancelled status must win over the failed fallback.
+    expect(
+      deriveSealStatus({ ...baseSignals, signal: abortedSignal('user'), sawProviderError: true }),
+    ).toBe('cancelled');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// emitClosureEvent — writer no-op + closure payload shaping
+// ---------------------------------------------------------------------------
+
+describe('emitClosureEvent', () => {
+  it('is a no-op when the writer is undefined', async () => {
+    // Must simply resolve without throwing.
+    await expect(
+      emitClosureEvent(undefined, {
+        ...baseSignals,
+        finalTurnCount: 1,
+        finalCostUsd: 0,
+        runningTokens: zeroTokens,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('emits a closure event carrying the derived reason and totals', async () => {
+    const writer = new InMemoryTraceWriter();
+    await emitClosureEvent(writer, {
+      ...baseSignals,
+      finalTurnCount: 3,
+      finalCostUsd: 0.25,
+      runningTokens: { input: 100, output: 50, cacheRead: 0, cacheCreation: 0 },
+    });
+
+    expect(writer.events).toHaveLength(1);
+    const ev = writer.events[0];
+    expect(ev?.kind).toBe('closure');
+    if (ev?.kind === 'closure') {
+      expect(ev.payload.reason).toBe('model_end_turn');
+      expect(ev.payload.finalTurnCount).toBe(3);
+      expect(ev.payload.finalCostUsd).toBe(0.25);
+      // Only positive token fields are included.
+      expect(ev.payload.finalTokens).toEqual({ input: 100, output: 50 });
+    }
+  });
+
+  it('omits every zero-valued token field and the guidance for benign closes', async () => {
+    const writer = new InMemoryTraceWriter();
+    await emitClosureEvent(writer, {
+      ...baseSignals,
+      finalTurnCount: 0,
+      finalCostUsd: 0,
+      runningTokens: zeroTokens,
+    });
+
+    const ev = writer.events[0];
+    if (ev?.kind === 'closure') {
+      expect(ev.payload.finalTokens).toEqual({});
+      expect(ev.payload.guidance).toBeUndefined();
+      expect(ev.payload.lastStopReason).toBeUndefined();
+    }
+  });
+
+  it('attaches the recovery guidance hint for an abort closure', async () => {
+    const writer = new InMemoryTraceWriter();
+    await emitClosureEvent(writer, {
+      ...baseSignals,
+      signal: abortedSignal(new Error('boom')),
+      finalTurnCount: 1,
+      finalCostUsd: 0,
+      runningTokens: zeroTokens,
+    });
+
+    const ev = writer.events[0];
+    if (ev?.kind === 'closure') {
+      expect(ev.payload.reason).toBe('abort');
+      expect(ev.payload.guidance).toBe(CLOSURE_ABORT_RECOVERY_HINT);
+    }
+  });
+
+  it('includes lastStopReason when present', async () => {
+    const writer = new InMemoryTraceWriter();
+    await emitClosureEvent(writer, {
+      ...baseSignals,
+      lastStopReason: 'max_tokens',
+      finalTurnCount: 1,
+      finalCostUsd: 0,
+      runningTokens: zeroTokens,
+    });
+
+    const ev = writer.events[0];
+    if (ev?.kind === 'closure') {
+      // max_tokens on an otherwise-clean close classifies as truncated.
+      expect(ev.payload.reason).toBe('truncated');
+      expect(ev.payload.lastStopReason).toBe('max_tokens');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sealTraceWriter — writer no-op + session_sealed payload shaping
+// ---------------------------------------------------------------------------
+
+describe('sealTraceWriter', () => {
+  const sealBase = {
+    ...baseSignals,
+    finalTurnCount: 2,
+    finalCostUsd: 0.1,
+    subagentCompletedCount: 0,
+    subagentRunningTokens: zeroTokens,
+    subagentRunningCostUsd: 0,
+  };
+
+  it('is a no-op when the writer is undefined', async () => {
+    await expect(sealTraceWriter(undefined, sealBase)).resolves.toBeUndefined();
+  });
+
+  it('seals with the derived status and core totals', async () => {
+    const writer = new InMemoryTraceWriter();
+    await sealTraceWriter(writer, sealBase);
+
+    const sealed = writer.events.find((e) => e.kind === 'session_sealed');
+    expect(sealed).toBeDefined();
+    if (sealed?.kind === 'session_sealed') {
+      expect(sealed.payload.status).toBe('succeeded');
+      expect(sealed.payload.finalTurnCount).toBe(2);
+      expect(sealed.payload.finalCostUsd).toBe(0.1);
+      expect(typeof sealed.payload.closedAt).toBe('string');
+      // No subagent activity → all rollup fields omitted.
+      expect(sealed.payload.subagentCount).toBeUndefined();
+      expect(sealed.payload.subagentTokens).toBeUndefined();
+      expect(sealed.payload.subagentCostUsd).toBeUndefined();
+    }
+  });
+
+  it('propagates a cancelled status from a fired abort signal', async () => {
+    const writer = new InMemoryTraceWriter();
+    await sealTraceWriter(writer, { ...sealBase, signal: abortedSignal('user') });
+
+    const sealed = writer.events.find((e) => e.kind === 'session_sealed');
+    if (sealed?.kind === 'session_sealed') {
+      expect(sealed.payload.status).toBe('cancelled');
+    }
+  });
+
+  it('includes subagent rollup fields only when non-zero', async () => {
+    const writer = new InMemoryTraceWriter();
+    await sealTraceWriter(writer, {
+      ...sealBase,
+      subagentCompletedCount: 2,
+      subagentRunningTokens: { input: 10, output: 5, cacheRead: 0, cacheCreation: 0 },
+      subagentRunningCostUsd: 0.03,
+    });
+
+    const sealed = writer.events.find((e) => e.kind === 'session_sealed');
+    if (sealed?.kind === 'session_sealed') {
+      expect(sealed.payload.subagentCount).toBe(2);
+      // Only positive token sub-fields are present.
+      expect(sealed.payload.subagentTokens).toEqual({ input: 10, output: 5 });
+      expect(sealed.payload.subagentCostUsd).toBe(0.03);
+    }
+  });
+
+  it('omits subagentTokens entirely when every sub-count is zero but a subagent completed', async () => {
+    const writer = new InMemoryTraceWriter();
+    await sealTraceWriter(writer, {
+      ...sealBase,
+      subagentCompletedCount: 1,
+      subagentRunningTokens: zeroTokens,
+      subagentRunningCostUsd: 0,
+    });
+
+    const sealed = writer.events.find((e) => e.kind === 'session_sealed');
+    if (sealed?.kind === 'session_sealed') {
+      expect(sealed.payload.subagentCount).toBe(1);
+      expect(sealed.payload.subagentTokens).toBeUndefined();
+      expect(sealed.payload.subagentCostUsd).toBeUndefined();
+    }
+  });
+});

--- a/src/agent/session/ledger-lifecycle.test.ts
+++ b/src/agent/session/ledger-lifecycle.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Unit tests for {@link LedgerLifecycle} — the lazy create-on-first-use +
+ * pass-through + idempotent-seal wrapper the session holds around a
+ * {@link SessionLedgerWriter}.
+ *
+ * Scope split from the siblings: `session-ledger.test.ts` covers the WRITER
+ * (record/close/read round-trips) and `session-ledger-integration.test.ts`
+ * covers the wiring through a live AgentSession. This file covers the
+ * LIFECYCLE WRAPPER's own contract in isolation — the `ensure()` gates and its
+ * one-attempt latch, the "silently dropped when unledgered" invariant on every
+ * record method (per the method docstrings), the meta record it writes on
+ * creation, and the idempotent `seal()` that resets the instance for a
+ * `reset()` cycle.
+ *
+ * Uses a temp AFK_HOME per suite run so no real ~/.afk/state is touched (same
+ * pattern as session-ledger.test.ts — env must be set before import).
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-ledger-lifecycle-test-'));
+process.env['AFK_HOME'] = tmpDir;
+
+// Import after env is set so path helpers resolve into the temp dir.
+import { LedgerLifecycle, type LedgerEnsureContext } from './ledger-lifecycle.js';
+import { readLedger, type LedgerRecord } from '../session-ledger.js';
+import { getSessionLedgerPath } from '../../paths.js';
+import type { OutputEvent } from '../types.js';
+import type { ElicitationRequest } from '../types/sdk-types.js';
+
+let seq = 0;
+function freshId(): string {
+  return `lifecycle-test-${Date.now()}-${seq++}`;
+}
+
+async function collect(sessionId: string): Promise<LedgerRecord[]> {
+  const out: LedgerRecord[] = [];
+  for await (const r of readLedger(sessionId)) out.push(r);
+  return out;
+}
+
+/** A fully-ledgerable context (top-level, valid id, no trace, minimal meta). */
+function ledgeredCtx(sessionId: string, over: Partial<LedgerEnsureContext> = {}): LedgerEnsureContext {
+  return {
+    depth: undefined,
+    parentSessionId: undefined,
+    sessionId,
+    fallbackModel: 'sonnet',
+    tracePath: undefined,
+    getMetadata: () => ({}),
+    ...over,
+  };
+}
+
+const assistantEvent = (content: string): OutputEvent => ({
+  type: 'message',
+  message: { role: 'assistant', content, timestamp: new Date() },
+});
+
+const elicitationRequest: ElicitationRequest = {
+  serverName: 'agent',
+  origin: 'agent',
+  type: 'choice',
+  message: 'Pick one',
+  choices: ['a', 'b'],
+};
+
+// ---------------------------------------------------------------------------
+// ensure() — gates + one-attempt latch
+// ---------------------------------------------------------------------------
+
+describe('LedgerLifecycle.ensure', () => {
+  it('creates a ledger on first use and writes a meta record', async () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    life.ensure(
+      ledgeredCtx(id, { fallbackModel: 'sonnet', getMetadata: () => ({ cwd: '/tmp/work' }) }),
+    );
+    await life.seal('close');
+
+    const records = await collect(id);
+    expect(records[0]).toMatchObject({
+      kind: 'meta',
+      sessionId: id,
+      model: 'sonnet',
+      cwd: '/tmp/work',
+    });
+    // No trace wired → the id→label bridge is an explicit null.
+    expect(records[0]).toMatchObject({ traceLabel: null });
+  });
+
+  it('prefers metadata.model over the fallback model', async () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    life.ensure(ledgeredCtx(id, { fallbackModel: 'sonnet', getMetadata: () => ({ model: 'opus' }) }));
+    await life.seal('close');
+
+    const records = await collect(id);
+    expect(records[0]).toMatchObject({ kind: 'meta', model: 'opus' });
+  });
+
+  it('reads metadata lazily — never invoked on the no-op path once latched', () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    let metaCalls = 0;
+    const ctx = ledgeredCtx(id, {
+      getMetadata: () => {
+        metaCalls++;
+        return {};
+      },
+    });
+    life.ensure(ctx);
+    life.ensure(ctx);
+    life.ensure(ctx);
+    // Created once → metadata read exactly once, not per ensure() call.
+    expect(metaCalls).toBe(1);
+  });
+
+  it('is idempotent: a second ensure() after creation is a no-op (single meta record)', async () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    life.ensure(ledgeredCtx(id));
+    life.ensure(ledgeredCtx(id));
+    await life.seal('close');
+
+    const records = await collect(id);
+    expect(records.filter((r) => r.kind === 'meta')).toHaveLength(1);
+  });
+
+  it('latches after a FAILED attempt: never retries even if inputs later become valid', async () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    // First attempt has no session id → runs unledgered and sets the latch.
+    life.ensure(ledgeredCtx(id, { sessionId: undefined }));
+    // A later call with a valid id must NOT create a writer (latch is sticky).
+    life.ensure(ledgeredCtx(id));
+    life.recordUser('should be dropped');
+    await life.seal('close');
+
+    expect(fs.existsSync(getSessionLedgerPath(id))).toBe(false);
+  });
+
+  it('gates off subagent forks (depth set)', () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    life.ensure(ledgeredCtx(id, { depth: 1 }));
+    life.recordUser('child');
+    expect(fs.existsSync(getSessionLedgerPath(id))).toBe(false);
+  });
+
+  it('gates off subagent forks (parentSessionId set)', () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    life.ensure(ledgeredCtx(id, { parentSessionId: 'parent-123' }));
+    life.recordUser('child');
+    expect(fs.existsSync(getSessionLedgerPath(id))).toBe(false);
+  });
+
+  it('honors AFK_SESSION_LEDGER_DISABLED=1', () => {
+    const id = freshId();
+    process.env['AFK_SESSION_LEDGER_DISABLED'] = '1';
+    try {
+      const life = new LedgerLifecycle();
+      life.ensure(ledgeredCtx(id));
+      life.recordUser('silent');
+      expect(fs.existsSync(getSessionLedgerPath(id))).toBe(false);
+    } finally {
+      delete process.env['AFK_SESSION_LEDGER_DISABLED'];
+    }
+  });
+
+  it('runs unledgered when no provider session id is available yet', () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    life.ensure(ledgeredCtx(id, { sessionId: undefined }));
+    life.recordUser('no id');
+    expect(fs.existsSync(getSessionLedgerPath(id))).toBe(false);
+  });
+
+  it('runs unledgered for an unsafe (path-traversal) session id', () => {
+    // SessionLedgerWriter.active is false for an unsafe id → writer discarded.
+    const life = new LedgerLifecycle();
+    life.ensure(ledgeredCtx('../../evil'));
+    // Recording must be a silent no-op and touch nothing.
+    life.recordUser('x');
+    life.recordEvent(assistantEvent('y'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// record* — silently dropped when unledgered (per docstring contract)
+// ---------------------------------------------------------------------------
+
+describe('LedgerLifecycle record methods when unledgered', () => {
+  it('drops recordUser / recordEvent / recordElicitation before ensure() (no writer)', async () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    // No ensure() call at all → writer is null → every record is a no-op.
+    life.recordUser('dropped');
+    life.recordEvent(assistantEvent('dropped'));
+    life.recordElicitation('r1', elicitationRequest);
+    await life.seal('close');
+
+    expect(fs.existsSync(getSessionLedgerPath(id))).toBe(false);
+    expect(await collect(id)).toEqual([]);
+  });
+
+  it('drops records when the session was gated off (subagent)', async () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    life.ensure(ledgeredCtx(id, { depth: 2 }));
+    life.recordUser('dropped');
+    life.recordEvent(assistantEvent('dropped'));
+    life.recordElicitation('r1', elicitationRequest);
+    await life.seal('close');
+
+    expect(fs.existsSync(getSessionLedgerPath(id))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// record* — written correctly when ledgered
+// ---------------------------------------------------------------------------
+
+describe('LedgerLifecycle record methods when ledgered', () => {
+  it('records a user turn', async () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    life.ensure(ledgeredCtx(id));
+    life.recordUser('do the thing');
+    await life.seal('close');
+
+    const records = await collect(id);
+    expect(records.find((r) => r.kind === 'user')).toMatchObject({
+      kind: 'user',
+      text: 'do the thing',
+    });
+  });
+
+  it('records a projected assistant output event', async () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    life.ensure(ledgeredCtx(id));
+    life.recordEvent(assistantEvent('done!'));
+    await life.seal('close');
+
+    const records = await collect(id);
+    expect(records.find((r) => r.kind === 'assistant')).toMatchObject({
+      kind: 'assistant',
+      text: 'done!',
+    });
+  });
+
+  it('does not record output events the ledger projection skips (content deltas)', async () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    life.ensure(ledgeredCtx(id));
+    // A content-delta chunk projects to null → recordEvent is a no-op.
+    life.recordEvent({ type: 'chunk', chunk: { type: 'content', content: 'tok' } });
+    await life.seal('close');
+
+    const records = await collect(id);
+    expect(records.some((r) => r.kind === 'assistant')).toBe(false);
+    // Only meta + closed remain.
+    expect(records.map((r) => r.kind)).toEqual(['meta', 'closed']);
+  });
+
+  it('records an elicitation request', async () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    life.ensure(ledgeredCtx(id));
+    life.recordElicitation('req-42', elicitationRequest);
+    await life.seal('close');
+
+    const records = await collect(id);
+    const elic = records.find((r) => r.kind === 'elicitation');
+    expect(elic).toBeDefined();
+    if (elic && elic.kind === 'elicitation') {
+      expect(elic.reqId).toBe('req-42');
+      expect(elic.request.type).toBe('choice');
+      expect(elic.request.choices).toEqual(['a', 'b']);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seal() — idempotent terminal record + reset-for-reuse
+// ---------------------------------------------------------------------------
+
+describe('LedgerLifecycle.seal', () => {
+  it('writes a terminal closed record carrying the reason', async () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    life.ensure(ledgeredCtx(id));
+    life.recordUser('hi');
+    await life.seal('close');
+
+    const records = await collect(id);
+    expect(records.at(-1)).toMatchObject({ kind: 'closed', reason: 'close' });
+  });
+
+  it('is a no-op (resolves) when the session was never ledgered', async () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    // No ensure() → no writer → seal resolves without creating a file.
+    await expect(life.seal('close')).resolves.toBeUndefined();
+    expect(fs.existsSync(getSessionLedgerPath(id))).toBe(false);
+  });
+
+  it('handles a double-seal gracefully — a second seal is a no-op', async () => {
+    const id = freshId();
+    const life = new LedgerLifecycle();
+    life.ensure(ledgeredCtx(id));
+    life.recordUser('hi');
+    await life.seal('close');
+    // Second seal: writer already cleared → resolves, writes nothing more.
+    await expect(life.seal('close')).resolves.toBeUndefined();
+
+    const records = await collect(id);
+    expect(records.filter((r) => r.kind === 'closed')).toHaveLength(1);
+  });
+
+  it('resets the instance so a reset() cycle re-ledgers with a fresh writer', async () => {
+    // The session reuses ONE LedgerLifecycle across a /clear (reset) cycle:
+    // seal() must clear the writer AND the latch so the next ensure() creates
+    // a new ledger. Distinct ids stand in for the fresh provider session id a
+    // real reset would issue.
+    const life = new LedgerLifecycle();
+
+    const idA = freshId();
+    life.ensure(ledgeredCtx(idA));
+    life.recordUser('cycle A');
+    await life.seal('reset');
+
+    const idB = freshId();
+    life.ensure(ledgeredCtx(idB));
+    life.recordUser('cycle B');
+    await life.seal('close');
+
+    const a = await collect(idA);
+    expect(a.find((r) => r.kind === 'user')).toMatchObject({ text: 'cycle A' });
+    expect(a.at(-1)).toMatchObject({ kind: 'closed', reason: 'reset' });
+
+    const b = await collect(idB);
+    expect(b.find((r) => r.kind === 'meta')).toBeDefined();
+    expect(b.find((r) => r.kind === 'user')).toMatchObject({ text: 'cycle B' });
+    expect(b.at(-1)).toMatchObject({ kind: 'closed', reason: 'close' });
+  });
+});


### PR DESCRIPTION
Closes #526.

Adds dedicated unit tests for two modules extracted from `agent-session.ts` in PR #519, which previously had only indirect coverage.

## What's added (test-only)
- `src/agent/session/closure-emitter.test.ts` (24 tests) — abort-signal pre-classification, `deriveSealStatus` mapping + precedence, and `emitClosureEvent`/`sealTraceWriter` payload shaping (via an in-memory trace writer).
- `src/agent/session/ledger-lifecycle.test.ts` (20 tests) — `ensure` gate/latch, `seal` idempotency + reset-for-reuse, and silent-drop-when-unledgered vs. correct-write-when-ledgered for `recordUser`/`recordEvent`/`recordElicitation`.

## Dedup note
The issue's framing of `deriveClosureReason` (reserved strings like `sigint`/`usage-limit`) didn't match the actual code — that decision tree lives in `classifyClosureReason` and is already fully covered by the existing `closure-reason.test.ts`. To avoid duplication, `closure-emitter.test.ts` covers only the genuinely-uncovered surface: the signal pre-classification layer that delegates to that tree, plus `deriveSealStatus` (which had no coverage). `plan-exit-bridge` was skipped per the issue's "lower priority" guidance — it's already exercised via `plan-mode-restore-ring.test.ts`.

## Verification
- `pnpm test src/agent/session/closure-emitter.test.ts src/agent/session/ledger-lifecycle.test.ts` → **44 passed**
- `pnpm test src/agent/session/` → **268 passed** (no regressions in the directory)
- `pnpm exec tsc --noEmit` → clean
- **No production-code changes.**
