### PR TITLE
test(tui): terminal-state gate integration + /clear-budget doc + firing observability (#565)

### DIFF
--- a/src/cli/commands/interactive/loop-iteration.test.ts
+++ b/src/cli/commands/interactive/loop-iteration.test.ts
@@ -120,6 +120,10 @@ import * as slashMod from '../../slash/registry.js';
 import { createHookRegistry } from '../../../agent/hooks.js';
 import { HookBlockedError } from '../../../utils/errors.js';
 import { HookHandlerTimeoutError } from '../../../agent/hook-registry.js';
+import {
+  createTerminalStateGate,
+  TERMINAL_STATE_GATE_CORRECTION,
+} from './terminal-state-gate.js';
 
 function makeCtx(overrides?: Partial<InteractiveCtx>): InteractiveCtx {
   return {
@@ -831,5 +835,184 @@ describe('runReplLoop — UserPromptSubmit hook integration', () => {
     expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(1);
     const firstArg = vi.mocked(runTurn).mock.calls[0]?.[0] as { text: string };
     expect(firstArg.text).toBe('normal prompt');
+  });
+});
+
+// Item 2 (#565): integration coverage for the REAL terminal-state gate driven
+// through the registered Stop path (runReplLoop → runInputLoop → hookRegistry
+// dispatch), not the stub Stop handler the tests above use. This exercises the
+// actual `createTerminalStateGate` closure — the gate whose behavior ships —
+// through the loop's onTerminalState → StopContext → injectContext wiring, and
+// pins the /clear-budget decision chosen in Item 1 (the process-lifetime budget
+// is NOT reset by /clear).
+describe('runReplLoop — terminal-state gate integration (#565)', () => {
+  /**
+   * Make a turn self-certify `Done` with no corroborating evidence, exactly as
+   * the real turn-handler does when it parses an unbacked Done: it invokes the
+   * loop's `onTerminalState` callback with a `done` verdict and
+   * `doneHasCorroboratingEvidence: false`. The loop carries those onto the Stop
+   * context the gate reads.
+   */
+  function mockUnbackedDoneTurn(): void {
+    vi.mocked(runTurn).mockImplementationOnce(
+      async (_input: unknown, _session: unknown, _stats: unknown, handlers: unknown) => {
+        (handlers as { onTerminalState?: (s: unknown, m?: unknown) => void }).onTerminalState?.(
+          { kind: 'done', rawBody: '' },
+          { doneHasCorroboratingEvidence: false },
+        );
+      },
+    );
+  }
+
+  it('the registered gate injects its correction into the next turn on an unbacked Done', async () => {
+    // Turn 1 self-certifies an unbacked Done → the REAL gate fires and stashes
+    // its correction; turn 2 must carry TERMINAL_STATE_GATE_CORRECTION as a
+    // prepended framework note (user text preserved at the tail).
+    surfaceState.readLineQueue = [
+      { text: 'ship it', attachments: [] },
+      { text: 'next turn', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+    mockUnbackedDoneTurn();
+
+    const registry = createHookRegistry();
+    // The gate as it ships: enabled + autonomous, reading the live permission
+    // mode off ctx.stats (matching bootstrap.ts's `() => stats.permissionMode`).
+    const ctx = makeCtx();
+    ctx.stats.permissionMode = 'autonomous';
+    registry.register(
+      'Stop',
+      createTerminalStateGate({
+        getPermissionMode: () => ctx.stats.permissionMode,
+        isEnabled: () => true,
+      }),
+    );
+    ctx.hookRegistry = registry;
+
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(2);
+    const firstText = (vi.mocked(runTurn).mock.calls[0]?.[0] as { text: string }).text;
+    const secondText = (vi.mocked(runTurn).mock.calls[1]?.[0] as { text: string }).text;
+    // Turn 1 ran clean (the gate acts AFTER, on the Stop dispatch).
+    expect(firstText).toBe('ship it');
+    // Turn 2 carries the real gate's correction, user text preserved at the tail.
+    expect(secondText).toContain(TERMINAL_STATE_GATE_CORRECTION);
+    expect(secondText.trimEnd().endsWith('next turn')).toBe(true);
+  });
+
+  it('the registered gate stays silent outside autonomous mode (human watching)', async () => {
+    // Same unbacked-Done shape, but the session is in 'default' mode — the gate
+    // must NOT fire (it is autonomous-only), so the next turn is clean. This
+    // proves the integration path honors the mode gate, not just the unit test.
+    surfaceState.readLineQueue = [
+      { text: 'ship it', attachments: [] },
+      { text: 'next turn', attachments: [] },
+      { text: '/exit', attachments: [] },
+    ];
+    mockUnbackedDoneTurn();
+
+    const registry = createHookRegistry();
+    const ctx = makeCtx();
+    ctx.stats.permissionMode = 'default';
+    registry.register(
+      'Stop',
+      createTerminalStateGate({
+        getPermissionMode: () => ctx.stats.permissionMode,
+        isEnabled: () => true,
+      }),
+    );
+    ctx.hookRegistry = registry;
+
+    await runReplLoop(ctx, makeTranscript() as never, makeTurnState(), vi.fn());
+
+    const secondText = (vi.mocked(runTurn).mock.calls[1]?.[0] as { text: string }).text;
+    expect(secondText).toBe('next turn');
+    expect(secondText).not.toContain(TERMINAL_STATE_GATE_CORRECTION);
+  });
+
+  it('does NOT reset the gate injection budget across /clear (Item 1 decision pinned)', async () => {
+    // Item 1 (#565): the gate's injection budget is PROCESS-LIFETIME scoped and
+    // deliberately NOT reset by /clear. Pin that here through the real loop:
+    //
+    //   Turn 1 (unbacked Done) → gate returns injectContext, budget spent (cap=1).
+    //   /clear                 → rotates transcript, resets the conversation-
+    //                            scoped verdictLedger + pendingStopInjection,
+    //                            but must NOT refund the gate's budget closure.
+    //   Turn 2 (unbacked Done) → SAME gate instance, over budget → returns {}.
+    //
+    // We assert on the GATE'S RETURN VALUE per Stop dispatch (via a spy wrapping
+    // the real gate), NOT on the delivered prompt: /clear intentionally wipes
+    // `pendingStopInjection`, so turn 1's injection never reaches turn 2's prompt
+    // regardless of the budget — the prompt cannot isolate the budget decision.
+    // The gate's own return value can. If /clear reset the budget (deferred
+    // option (b)), turn 2's gate call would return injectContext again and the
+    // `secondCorrection` assertion below would fail — so this is a true guard.
+    surfaceState.readLineQueue = [
+      { text: 'first done', attachments: [] }, // turn 1 → gate injects
+      { text: '/clear', attachments: [] }, // reset conversation state, not budget
+      { text: 'second done', attachments: [] }, // turn 2 → over budget, gate silent
+      { text: '/exit', attachments: [] },
+    ];
+    // Both real turns self-certify an unbacked Done.
+    mockUnbackedDoneTurn();
+    mockUnbackedDoneTurn();
+
+    // /clear must reach the reset branch: dispatch returns handled + a non-submit
+    // result so the loop rotates the transcript and continues (see loop-iteration
+    // ~L386). '/exit' ends the loop; everything else falls through to the model.
+    vi.mocked(slashMod.dispatch).mockImplementation(async (text: string) => {
+      if (text === '/exit') return { handled: true, result: 'exit' as const };
+      if (text === '/clear') return { handled: true, result: null };
+      return { handled: false as const };
+    });
+
+    const ctx = makeCtx();
+    ctx.stats.permissionMode = 'autonomous';
+    // The real gate, cap=1. Wrap it in a spy so we can read what it RETURNS on
+    // each Stop dispatch — the direct observable for the budget decision.
+    const realGate = createTerminalStateGate({
+      getPermissionMode: () => ctx.stats.permissionMode,
+      isEnabled: () => true,
+      maxInjectionsPerSession: 1, // single-slot budget: exhausted by turn 1
+    });
+    const gateReturns: Array<string | undefined> = [];
+    const registry = createHookRegistry();
+    registry.register('Stop', async (hookCtx) => {
+      const decision = await realGate(hookCtx);
+      // Record the gate's verdict only for the Stop dispatches that carry an
+      // unbacked Done (the ones the gate acts on) — i.e. every turn here.
+      if ((hookCtx as { terminalState?: string }).terminalState === 'done') {
+        gateReturns.push(decision.injectContext);
+      }
+      return decision;
+    });
+    ctx.hookRegistry = registry;
+
+    const transcript = makeTranscript();
+    await runReplLoop(ctx, transcript as never, makeTurnState(), vi.fn());
+
+    // Two model turns ran (the /clear iteration continues without a runTurn).
+    expect(vi.mocked(runTurn)).toHaveBeenCalledTimes(2);
+    // Sanity: /clear actually hit its reset branch (transcript rotated).
+    expect(transcript.rotateOnClear).toHaveBeenCalledTimes(1);
+    // Sanity: the gate was consulted for exactly the two unbacked-Done turns.
+    expect(gateReturns).toHaveLength(2);
+
+    // Turn 1's Stop: the gate spent its single-slot budget and returned the
+    // correction.
+    expect(gateReturns[0]).toBe(TERMINAL_STATE_GATE_CORRECTION);
+    // Turn 2's Stop, AFTER /clear: the SAME gate instance was over budget and
+    // returned no correction — the budget was NOT refunded by /clear. This is
+    // the crux of the Item 1 decision (a budget reset would make this the
+    // correction string again).
+    expect(gateReturns[1]).toBeUndefined();
+
+    // Secondary: turn 2's delivered prompt is clean (belt-and-suspenders — true
+    // here both because the budget is spent AND because /clear wiped any pending
+    // injection; the gate-return assertions above are what isolate the budget).
+    const secondText = (vi.mocked(runTurn).mock.calls[1]?.[0] as { text: string }).text;
+    expect(secondText).toBe('second done');
+    expect(secondText).not.toContain(TERMINAL_STATE_GATE_CORRECTION);
   });
 });

--- a/src/cli/commands/interactive/terminal-state-gate.test.ts
+++ b/src/cli/commands/interactive/terminal-state-gate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   createTerminalStateGate,
   TERMINAL_STATE_GATE_CORRECTION,
@@ -110,5 +110,77 @@ describe('createTerminalStateGate', () => {
     enabled = true;
     mode = AUTONOMOUS;
     expect((await unbacked()).injectContext).toBe(TERMINAL_STATE_GATE_CORRECTION);
+  });
+});
+
+// Item 3 (#565): the gate emits a debug log on BOTH injection and
+// cap-exhaustion, via the shared `debugLog` facility (console.log gated on
+// AFK_DEBUG/DEBUG). These pin that observability — inert unless debug is on,
+// tagged with the gate's `[terminal-state gate]` prefix and carrying the
+// sessionId — without changing the gate's decision behavior.
+describe('createTerminalStateGate — firing observability (#565)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env['AFK_DEBUG'];
+  });
+
+  it('logs a debug line naming the budget position on each injection', async () => {
+    process.env['AFK_DEBUG'] = '1';
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const gate = armedGate({ maxInjectionsPerSession: 3 });
+
+    await gate(stop({ terminalState: 'done', doneHasCorroboratingEvidence: false }));
+    await gate(stop({ terminalState: 'done', doneHasCorroboratingEvidence: false }));
+
+    // One log per injection, tagged + carrying the sessionId; the budget
+    // position (n/cap) advances across calls so an operator can see the count.
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('[terminal-state gate] injecting Done-evidence correction (1/3)'),
+      expect.objectContaining({ sessionId: 's' }),
+    );
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('[terminal-state gate] injecting Done-evidence correction (2/3)'),
+      expect.objectContaining({ sessionId: 's' }),
+    );
+  });
+
+  it('logs a distinct debug line when the budget is exhausted (fail open)', async () => {
+    process.env['AFK_DEBUG'] = '1';
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const gate = armedGate({ maxInjectionsPerSession: 1 });
+    const unbacked = () => gate(stop({ terminalState: 'done', doneHasCorroboratingEvidence: false }));
+
+    await unbacked(); // spends the single-slot budget (logs the injection)
+    log.mockClear();
+    const decision = await unbacked(); // over budget now
+
+    // The Done stands (fail open) AND the exhaustion is observable.
+    expect(decision.injectContext).toBeUndefined();
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('[terminal-state gate] injection budget exhausted (cap=1)'),
+      expect.objectContaining({ sessionId: 's' }),
+    );
+  });
+
+  it('emits NO log when AFK_DEBUG is unset (debugLog is inert)', async () => {
+    delete process.env['AFK_DEBUG'];
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const gate = armedGate({ maxInjectionsPerSession: 1 });
+    const unbacked = () => gate(stop({ terminalState: 'done', doneHasCorroboratingEvidence: false }));
+
+    await unbacked(); // injection
+    await unbacked(); // exhaustion
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('does not log for a no-op decision (disabled gate never touches the budget)', async () => {
+    process.env['AFK_DEBUG'] = '1';
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const gate = createTerminalStateGate({
+      getPermissionMode: () => AUTONOMOUS,
+      isEnabled: () => false,
+    });
+    await gate(stop({ terminalState: 'done', doneHasCorroboratingEvidence: false }));
+    expect(log).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/commands/interactive/terminal-state-gate.ts
+++ b/src/cli/commands/interactive/terminal-state-gate.ts
@@ -30,8 +30,10 @@
  *   - **Opt-in, default off.** Gated on the human-tier `enforceDoneEvidence`
  *     config key (a self-honesty check the agent must not disable on its own —
  *     same rationale as `telegram.verifyDone`).
- *   - **Loop-guarded.** Bounded corrections per session; once exhausted the gate
- *     lets the `Done` stand (fails open) rather than burning turns re-injecting.
+ *   - **Loop-guarded.** Bounded corrections; once exhausted the gate lets the
+ *     `Done` stand (fails open) rather than burning turns re-injecting. The budget
+ *     is process-lifetime scoped and is deliberately NOT reset by `/clear` — see
+ *     the `Invariant:` note on {@link createTerminalStateGate} (issue #565).
  *
  * The gate NEVER blocks the turn and never throws — the worst case is one extra
  * framework note on the next prompt.
@@ -41,6 +43,7 @@
 
 import type { HookContext, HookDecision, HookHandler } from '../../../agent/hooks.js';
 import type { PermissionMode } from '../../../agent/types/sdk-types.js';
+import { debugLog } from '../../../utils/debug.js';
 
 /**
  * Default per-session cap on injected corrections. Bounds the "re-prompts too
@@ -96,6 +99,27 @@ export interface TerminalStateGateOptions {
  */
 export function createTerminalStateGate(opts: TerminalStateGateOptions): HookHandler {
   const cap = opts.maxInjectionsPerSession ?? DEFAULT_MAX_TERMINAL_STATE_INJECTIONS;
+  // Invariant: the injection budget (`injections`) is PROCESS-LIFETIME scoped, not
+  // per-conversation. This counter is created once when the gate is constructed
+  // (bootstrap.ts registers the gate once per process, on the shared hookRegistry)
+  // and persists for the life of the process. `/clear` — which rotates the
+  // transcript and resets the conversation-scoped `verdictLedger` and
+  // `pendingStopInjection` in loop-iteration.ts — deliberately does NOT reset this
+  // budget: the gate has no /clear hook, and none is wired.
+  //
+  // This is an intentional decision (issue #565), not an oversight. The gate's
+  // "bounded corrections per session" contract is read as per-PROCESS here. The
+  // failure direction is safe: an unreset counter can only make the gate go quiet
+  // EARLIER (fewer corrections after several unbacked-`Done`s across /clears),
+  // which fails toward the gate's existing fail-open model — it never injects more
+  // than `cap` times per process, never blocks, never loops. A conversation reset
+  // does not "refund" correction budget.
+  //
+  // Alternative deferred to the maintainer (issue #565 option (b)): reset
+  // `injections = 0` from the /clear branch in loop-iteration.ts (e.g. via a
+  // reset callback exposed on the gate), making the budget per-conversation. That
+  // is a behavior change — a fresh conversation would regain the full correction
+  // budget — and is intentionally NOT implemented in this PR.
   let injections = 0;
 
   return (context: HookContext): HookDecision => {
@@ -109,8 +133,26 @@ export function createTerminalStateGate(opts: TerminalStateGateOptions): HookHan
     if (context.doneHasCorroboratingEvidence !== false) return {};
     // Loop-guard: bounded corrections per session. Once spent, let the Done
     // stand rather than re-injecting forever.
-    if (injections >= cap) return {};
+    if (injections >= cap) {
+      // Observability (#565): the budget is spent — this unbacked `Done` stands
+      // (fail open). Logged so an operator diagnosing a slipped-through `Done`
+      // can see the gate deliberately went quiet rather than never firing.
+      debugLog(
+        `[terminal-state gate] injection budget exhausted (cap=${cap}); ` +
+          `letting unbacked Done stand (fail open)`,
+        { sessionId: context.sessionId },
+      );
+      return {};
+    }
     injections += 1;
+    // Observability (#565): the gate is bouncing this unbacked `Done` back into
+    // the next turn. Mirrors sibling debug-log convention (`[module-tag] …`,
+    // structured payload) — inert unless AFK_DEBUG/DEBUG is set.
+    debugLog(
+      `[terminal-state gate] injecting Done-evidence correction ` +
+        `(${injections}/${cap})`,
+      { sessionId: context.sessionId },
+    );
     return { injectContext: TERMINAL_STATE_GATE_CORRECTION };
   };
 }


### PR DESCRIPTION
Closes #565. Addresses all three follow-ups from the #557 review (no functional bug).

## Item 1 — /clear budget scope: **chose option (a)** (document, no behavior change)
Added an `// Invariant:` block on `createTerminalStateGate` documenting that the injection budget is **process-lifetime scoped and deliberately NOT reset by `/clear`**. The failure direction is safe (fail-open: an unreset counter can only make the gate go quiet *earlier*).

**Option (b)** — resetting the counter from the `/clear` branch to make the budget per-conversation — is a behavior change and is **intentionally deferred to the maintainer** (named explicitly in the doc comment). Say the word if you'd prefer (b) and I'll wire it.

## Item 2 — integration + branch coverage
- One integration test drives the **registered** gate through the real `runReplLoop → runInputLoop → hookRegistry` Stop path (asserts the correction reaches the next turn's prompt on an unbacked `Done`), plus a mode-gate companion.
- A `/clear`-budget pin test asserts the gate instance stays over-budget after `/clear` (budget not refunded), keyed on the gate's own return value.

## Item 3 — observability
`debugLog` calls on **both** injection (`(n/cap)`) and cap-exhaustion, using the existing `utils/debug.js` facility (no new dependency), tagged `[terminal-state gate]`, carrying `sessionId`. Inert unless `AFK_DEBUG`/`DEBUG` is set. 4 unit tests pin the log behavior.

## Production change is doc-comment + debug-log only
Control flow is byte-identical: both `if (injections >= cap)` branches still return the same, the counter logic is unchanged, no signature change. Verified via mutation testing (a "never injects" mutant fails the integration tests; a "budget refunded" mutant fails the /clear-budget test).

## Verification
- `pnpm test src/cli/commands/interactive/terminal-state-gate.test.ts src/cli/commands/interactive/loop-iteration.test.ts` → **42 passed**
- `pnpm test src/cli/commands/interactive/` → **876 passed** (no regressions)
- `pnpm exec tsc --noEmit` → clean
