### PR TITLE
docs/skills: scope test commands in fix briefs + templates (avoid pnpm test -- footgun) (#611)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,8 @@ agent-afk is a standalone TypeScript CLI + daemon + Telegram bot that uses `@ant
 pnpm install              # Use pnpm exclusively — lockfile is pnpm-specific
 pnpm build                # tsc + copies *.md prompt files into dist/
 pnpm test                 # vitest run (all tests)
-pnpm test -- src/agent/session.test.ts            # single test file (unit tests co-located with src)
-pnpm test -- -t "sends a message"                 # single test by name
+pnpm test src/agent/session.test.ts               # single test file (unit tests co-located with src)
+pnpm test -t "sends a message"                     # single test by name
 pnpm test:watch           # vitest watch mode
 pnpm lint                 # tsc --noEmit (strict, no unused locals/params)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,12 +18,12 @@ pnpm lint           # tsc --noEmit (strict type-check, no emit)
 
 Run a single test file:
 ```bash
-pnpm test -- src/agent/session.test.ts
+pnpm test src/agent/session.test.ts
 ```
 
 Run a single test by name:
 ```bash
-pnpm test -- -t "sends a message"
+pnpm test -t "sends a message"
 ```
 
 ## TypeScript — strict mode

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,8 +68,8 @@ Tests are colocated as `*.test.ts` next to the implementation under `src/`, plus
 
 ```bash
 pnpm test                                   # all
-pnpm test -- src/agent/session.test.ts      # single file
-pnpm test -- -t "sends a message"           # single test by name
+pnpm test src/agent/session.test.ts         # single file
+pnpm test -t "sends a message"              # single test by name
 pnpm test:watch                             # watch
 pnpm test:coverage                          # with coverage
 ```

--- a/docs/specs/phase-2-rendering-refactor.md
+++ b/docs/specs/phase-2-rendering-refactor.md
@@ -329,8 +329,8 @@ Grepped all readers of `stats.toolUses` across `src/`. Four readers, all safe:
 In the Phase 1 commit, add `toMatchSnapshot()` assertions on representative `tool-lane-render.ts` outputs (≥5 scenarios: single tool, multi-tool, overflow, error result, subagent with children). These pin the visual baseline. Run existing tests and confirm green.
 
 ```
-pnpm test -- src/cli/commands/interactive/tool-lane.test.ts
-pnpm test -- src/cli/commands/interactive/tool-lane-format.test.ts
+pnpm test src/cli/commands/interactive/tool-lane.test.ts
+pnpm test src/cli/commands/interactive/tool-lane-format.test.ts
 ```
 
 ### Phase 1: Write failing tests (RED commit)

--- a/src/agent/providers/openai-compatible/openai-compatible.live.test.ts
+++ b/src/agent/providers/openai-compatible/openai-compatible.live.test.ts
@@ -7,7 +7,7 @@
  *
  * To run manually:
  *
- *   OPENAI_API_KEY=sk-... pnpm test -- src/agent/providers/openai-compatible/openai-compatible.live.test.ts
+ *   OPENAI_API_KEY=sk-... pnpm test src/agent/providers/openai-compatible/openai-compatible.live.test.ts
  *
  * What this verifies that the stubbed tests cannot:
  *   - The OpenAI SDK actually accepts the request shape we build

--- a/src/agent/providers/openai-compatible/openai-compatible.live.test.ts
+++ b/src/agent/providers/openai-compatible/openai-compatible.live.test.ts
@@ -5,9 +5,10 @@
  * `OPENAI_API_KEY` is set (the most common case) OR when `~/.codex/auth.json`
  * contains an API key. Network access required; not part of CI by default.
  *
- * To run manually:
+ * To run manually (RUN_LIVE_API=1 lifts the config-level *.live.test.ts
+ * exclude — a bare `pnpm test <file>` can't, and prints "No test files found"):
  *
- *   OPENAI_API_KEY=sk-... pnpm test src/agent/providers/openai-compatible/openai-compatible.live.test.ts
+ *   RUN_LIVE_API=1 OPENAI_API_KEY=sk-... pnpm vitest run src/agent/providers/openai-compatible/openai-compatible.live.test.ts
  *
  * What this verifies that the stubbed tests cannot:
  *   - The OpenAI SDK actually accepts the request shape we build

--- a/src/agent/tools/child-credential.test.ts
+++ b/src/agent/tools/child-credential.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the fork-time child credential fallback.
  *
- * Run with: pnpm test -- src/agent/tools/child-credential.test.ts
+ * Run with: pnpm test src/agent/tools/child-credential.test.ts
  */
 
 import { describe, expect, it } from 'vitest';

--- a/src/agent/tools/handlers/glob.test.ts
+++ b/src/agent/tools/handlers/glob.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the glob tool handler.
  *
- * Run with: pnpm test -- tests/agent/tools/handlers/glob.test.ts
+ * Run with: pnpm test src/agent/tools/handlers/glob.test.ts
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -77,7 +77,13 @@ const PINNED_HASHES = {
     'be8b2a301fe35d86d96d4be6f8418bf497dd9050767a3837cf057d7d5a1cd719',
   // refactor is bundled-only (no upstream example-plugin counterpart); verbatim
   // copy of the user-scope /refactor at ~/.afk/skills/.
-  refactor: '9cb84710ddf2cf63e1a648460a64656d3f4a9aae8e21753b031556070740c51e',
+  // Hash bumped (#611): the contract-extractor's `test_commands` example was
+  // changed from the pnpm footgun form `pnpm test -- --grep "AuthService"` (under
+  // pnpm 10 the `--` drops the arg and runs the FULL suite) to scoped forms
+  // (`pnpm test <file>` / `pnpm test -t "AuthService"`) plus a note to never emit
+  // the `--` form. Bundled-only — mirror into the user-scope /refactor at
+  // ~/.afk/skills/ if it drifts back.
+  refactor: '3adf801b9a61eba80afd34fef1e8c78a892ec07256dabb073370622a62d1b40f',
   research: 'abe79d75a5f3c74696ef002293dbe8714e446f8955de97089d1005f1e70bc269',
   review: 'f313e3779af068a623692473abab2300938db8da3ebf3e2998d47fcb21ee9627',
   // Hash bumped 2026-06-09 (PR #52): records the confidence-trigger enhancement

--- a/src/bundled-plugins/awa-bundled/skills/refactor/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/refactor/SKILL.md
@@ -50,7 +50,7 @@ Dispatch both agents simultaneously in a single response turn.
 - inputs: site list (from site-finder, passed inline if available; if not yet available, derive from change type + scope)
 - artifacts:
   - `contracts`: array of `{symbol, signature_before, exported_by, consumed_by[]}`
-  - `test_commands`: array of shell commands that exercise the affected contracts (e.g., `pnpm test -- --grep "AuthService"`)
+  - `test_commands`: array of shell commands that SCOPE to the affected contracts — target the specific test files or a name pattern, never the whole suite (e.g., `pnpm test src/auth/auth-service.test.ts` or `pnpm test -t "AuthService"`). Under pnpm, `pnpm test -- <file>` drops the file arg and runs the entire suite — never emit that form.
   - `test_coverage_verdict`: "adequate" | "partial" | "absent"
   - `confidence`: low | medium | high
   - `coverage_gaps`: test paths not reachable by the identified commands

--- a/src/improve/propose/template-engine.ts
+++ b/src/improve/propose/template-engine.ts
@@ -121,8 +121,8 @@ const TEMPLATES: Record<FailureCard['pattern'], PatternTemplate> = {
     riskFloor: 'medium',
     validationPlan: {
       unitTests: [
-        'pnpm test -- src/improve/scan/detectors/repeated-tool-use',
-        'pnpm test -- src/agent/providers/anthropic-direct',
+        'pnpm test src/improve/scan/detectors/repeated-tool-use',
+        'pnpm test src/agent/providers/anthropic-direct',
       ],
       evalCases: [],
       smokeChecks: [
@@ -199,9 +199,9 @@ const TEMPLATES: Record<FailureCard['pattern'], PatternTemplate> = {
     riskFloor: 'medium',
     validationPlan: {
       unitTests: [
-        'pnpm test -- src/agent/hooks',
-        'pnpm test -- src/agent/subagent-hooks',
-        'pnpm test -- src/improve/scan/detectors/subagent-block',
+        'pnpm test src/agent/hooks',
+        'pnpm test src/agent/subagent-hooks',
+        'pnpm test src/improve/scan/detectors/subagent-block',
       ],
       evalCases: [],
       smokeChecks: [
@@ -263,9 +263,9 @@ const TEMPLATES: Record<FailureCard['pattern'], PatternTemplate> = {
     riskFloor: 'medium',
     validationPlan: {
       unitTests: [
-        'pnpm test -- src/agent/subagent-read-scope',
-        'pnpm test -- src/agent/subagent-worktree-readroot',
-        'pnpm test -- src/improve/scan/detectors/subagent-read-denial',
+        'pnpm test src/agent/subagent-read-scope',
+        'pnpm test src/agent/subagent-worktree-readroot',
+        'pnpm test src/improve/scan/detectors/subagent-read-denial',
       ],
       evalCases: [],
       smokeChecks: [
@@ -350,8 +350,8 @@ const TEMPLATES: Record<FailureCard['pattern'], PatternTemplate> = {
     riskFloor: 'medium',
     validationPlan: {
       unitTests: [
-        'pnpm test -- src/improve/scan/detectors/tool-failure-density',
-        'pnpm test -- src/agent/tools/dispatcher',
+        'pnpm test src/improve/scan/detectors/tool-failure-density',
+        'pnpm test src/agent/tools/dispatcher',
       ],
       evalCases: [],
       smokeChecks: [
@@ -421,8 +421,8 @@ const TEMPLATES: Record<FailureCard['pattern'], PatternTemplate> = {
     riskFloor: 'medium',
     validationPlan: {
       unitTests: [
-        'pnpm test -- src/agent/session',
-        'pnpm test -- src/improve/scan/detectors/closure-anomaly',
+        'pnpm test src/agent/session',
+        'pnpm test src/improve/scan/detectors/closure-anomaly',
       ],
       evalCases: [],
       smokeChecks: ['pnpm lint'],

--- a/src/skills/mint/prompts/build.md
+++ b/src/skills/mint/prompts/build.md
@@ -22,9 +22,13 @@ You are given:
 4. Run tests and type-checks frequently
 
 **Verification:**
-- Run all specified test commands
+- Run the specified test commands, but SCOPE each run to the files you changed — pass the test path directly: `pnpm test <path>` (or `pnpm test:file <path>` / `pnpm exec vitest run <path>`). Under pnpm, `pnpm test -- <path>` DROPS the path arg and silently runs the entire suite — never use that form.
+- Never re-run the full test suite as your iteration loop. Scope verification to the changed files; run the full suite (if at all) only once at the end, not on every edit.
 - Run linting and type-checking
 - Build the project if applicable
+
+**Commit incrementally:**
+- Commit working increments as you go (a passing module, a green test file) rather than saving one big commit for the end. If the phase is interrupted or times out, committed work is preserved instead of lost.
 
 ## Output
 
@@ -38,7 +42,7 @@ Respond with a single fenced JSON code block and no prose outside it. The JSON m
   "tests_passed": true,
   "build_passed": true,
   "verification_passed": true,
-  "notes": "Built the X module. Ran `pnpm test -- src/x.test.ts` → 12 passed, exit 0. Ran `pnpm lint` → exit 0. Ran `pnpm build` → exit 0."
+  "notes": "Built the X module. Ran `pnpm test src/x.test.ts` → 12 passed, exit 0. Ran `pnpm lint` → exit 0. Ran `pnpm build` → exit 0."
 }
 ```
 

--- a/src/skills/mint/prompts/heal.md
+++ b/src/skills/mint/prompts/heal.md
@@ -18,7 +18,9 @@ You are given:
 **Healing strategy:**
 - Fix one issue at a time when possible.
 - Prefer small, surgical changes over large refactors.
-- Test immediately after each fix.
+- Test immediately after each fix, but SCOPE the run to the changed file(s): `pnpm test <path>` (or `pnpm test:file <path>` / `pnpm exec vitest run <path>`). Under pnpm, `pnpm test -- <path>` DROPS the path arg and runs the entire suite — never use that form.
+- Never re-run the full test suite as your iteration loop — that turns each fix into a multi-minute wait and burns the iteration budget. Scope verification to the files you touched; only after the scoped tests are green should you run any broader check.
+- Commit each fix that lands green before moving to the next. This phase runs under a time budget; committing incrementally means a timeout preserves the fixes already applied instead of discarding all of them.
 
 **Constraints:**
 - This phase runs at most 2 times. After 2 iterations, if issues remain, the run exits as `heal-failed`.

--- a/src/telegram/README.md
+++ b/src/telegram/README.md
@@ -153,7 +153,7 @@ Resolution (`src/telegram/notify-routing.ts`), highest precedence first:
 
 ```bash
 # All telegram unit tests
-pnpm test -- tests/telegram
+pnpm test tests/telegram
 
 # Integration tests
 pnpm test:integration

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,13 +22,20 @@ export default defineConfig({
     // A 15s ceiling still catches real hangs without false-positive timeouts.
     testTimeout: 15_000,
     include: ['src/**/*.test.ts', 'tests/**/*.test.ts'],
-    // Exclude live/network tests from the default run — they require RUN_LIVE_API=1
-    // and real credentials. Run them explicitly:
-    //   RUN_LIVE_API=1 pnpm vitest run src/agent/providers/anthropic-direct.live.test.ts
     // Exclude the real-PTY harness (*.pty.test.ts) — it needs the native
     // node-pty build and a real pseudo-terminal; run it via `pnpm test:pty`
     // (vitest.pty.config.ts). See tests/pty/ and issue #541.
-    exclude: ['**/node_modules/**', '**/dist/**', '**/*.live.test.ts', '**/*.pty.test.ts'],
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      // Live/network tests (*.live.test.ts) need real credentials + network, so
+      // they are excluded from the default run. Opt in with RUN_LIVE_API=1 — a
+      // bare `pnpm test <file>` / `pnpm vitest run <file>` can't override a
+      // config-level exclude, so the env flag is the supported way in, e.g.
+      //   RUN_LIVE_API=1 OPENAI_API_KEY=sk-... pnpm vitest run src/agent/providers/openai-compatible/openai-compatible.live.test.ts
+      ...(process.env['RUN_LIVE_API'] === '1' ? [] : ['**/*.live.test.ts']),
+      '**/*.pty.test.ts',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
Closes #611.

Under pnpm 10, `pnpm test -- <file>` **drops the arg after `--` and runs the full ~12k-test suite** (verified empirically in this repo) — the exact footgun that made a fix subagent time out at 20 min with zero committed work (#607 review; see #610). This audits the in-repo fix/verify briefs and templates and replaces every instruction-form occurrence with a scoped form.

## Changes
- `src/improve/propose/template-engine.ts` — 12 hardcoded `pnpm test -- <path>` verification-command strings → scoped `pnpm test <path>` (pure arg-drop, no semantic change).
- `src/skills/mint/prompts/build.md` — fixed the example command + added scoped-verify guidance, a "never re-run the full suite as an iteration loop" note, and a **Commit incrementally** section.
- `src/skills/mint/prompts/heal.md` — added scoped-verify + footgun warning + "commit each fix that lands green" (so a timeout preserves partial work).
- `src/bundled-plugins/awa-bundled/skills/refactor/SKILL.md` — `test_commands` example `pnpm test -- --grep …` → scoped forms; `bundled.test.ts` pinned hash bumped accordingly (documented in-file).
- Stray header-comment / doc footguns fixed: `child-credential.test.ts`, `glob.test.ts` (also corrected a stale path), `openai-compatible.live.test.ts`, `telegram/README.md`.

Instruction-form `pnpm test -- ` occurrences: **18 → 0**. The 4 remaining matches are intentional *anti-pattern* references inside the new warnings, not instructions.

## Out-of-repo remainder
The issue names `/fix-pr` and `/resolve`, but neither is defined in this repo (confirmed by exhaustive search — they're user-scope/plugin skills under `~/.afk/`). If they carry the same incantation they need a separate pass there; this PR covers everything in-repo (including `heal`).

## Verification
- `pnpm test src/improve/propose src/bundled-plugins/awa-bundled/bundled.test.ts` → **60 passed / 12 skipped** (skips are env-gated + pre-existing)
- `pnpm test tests/copy-bundled-plugins.test.ts src/skills/mint.test.ts` → **57 passed**
- `pnpm exec tsc --noEmit` → clean
