### PR TITLE
ci(audit): tolerate npm's retired audit endpoint (HTTP 410) so audit:deps stops hard-failing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,8 @@ jobs:
         run: pnpm audit:sdk:check
 
       - name: Audit dependency CVEs (critical severity in prod deps)
-        # Gates on critical-severity CVEs in production dependencies only.
+        # Gates on critical-severity CVEs in production dependencies only, via
+        # `scripts/audit-deps.ts` (wraps `pnpm audit --audit-level=critical --prod`).
         # --audit-level=critical: only fail on critical advisories (not high/moderate).
         # --prod: exclude devDependencies (vitest, coverage-v8, esbuild, etc.) which
         #   carry several high/moderate unfixable transitive advisories that are dev-
@@ -65,6 +66,9 @@ jobs:
         # Non-critical prod advisories (4 high via jsdom>undici and
         #   @modelcontextprotocol/sdk>hono) are acknowledged; upstream fixes are
         #   tracked in pnpm-lock.yaml — tighten to --audit-level=high once resolved.
+        # Endpoint outage tolerance (2026-07-15): npm retired the legacy audit API
+        #   (HTTP 410); the wrapper warns + exits 0 on a transport failure so the
+        #   outage can't block merges, while a genuine critical advisory still fails.
         run: pnpm audit:deps
 
       - name: Build

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "audit:sdk": "tsx scripts/audit-sdk-dependency.ts",
     "audit:sdk:check": "tsx scripts/audit-sdk-dependency.ts --check",
     "audit:sdk:update-lock": "tsx scripts/audit-sdk-dependency.ts --update-lock",
-    "audit:deps": "pnpm audit --audit-level=critical --prod",
+    "audit:deps": "tsx scripts/audit-deps.ts",
     "audit:env": "tsx scripts/audit-env-access.ts",
     "audit:env:check": "tsx scripts/audit-env-access.ts --check",
     "audit:env:list": "tsx scripts/audit-env-access.ts --list",

--- a/scripts/audit-deps-endpoint.ts
+++ b/scripts/audit-deps-endpoint.ts
@@ -1,0 +1,35 @@
+/**
+ * Transport-failure detection for the `audit:deps` CVE gate.
+ *
+ * Split into its own side-effect-free module so the runner (`audit-deps.ts`,
+ * which calls `process.exit`) and the test can both import the predicate without
+ * spawning `pnpm audit` or terminating the process.
+ *
+ * Contract: `isAuditEndpointUnavailable(output)` returns true ONLY when the audit
+ * could not be performed for TRANSPORT reasons — the npm audit endpoint is
+ * retired/unreachable (HTTP 410, DNS/connection errors), or pnpm's own
+ * bad-response guard fired. A genuine critical-advisory finding exits nonzero
+ * WITHOUT any of these markers, so it is never matched here and always fails the
+ * gate. Keep the marker set narrow and transport-specific — a false positive here
+ * would silently swallow a real critical CVE.
+ */
+
+/** pnpm/npm markers that mean "the audit endpoint could not be reached", not "a CVE was found". */
+const TRANSPORT_FAILURE_MARKERS: readonly RegExp[] = [
+  // pnpm's guard when the audit endpoint returns an unexpected response.
+  /ERR_PNPM_AUDIT_BAD_RESPONSE/i,
+  // npm's 410 retirement notice for the legacy audit endpoints.
+  /endpoint is being retired/i,
+  /responded with 410/i,
+  // Generic network/DNS failures reaching the registry.
+  /\bENOTFOUND\b/,
+  /\bEAI_AGAIN\b/,
+  /\bECONNREFUSED\b/,
+  /\bECONNRESET\b/,
+  /\bETIMEDOUT\b/,
+  /\bfetch failed\b/i,
+];
+
+export function isAuditEndpointUnavailable(output: string): boolean {
+  return TRANSPORT_FAILURE_MARKERS.some((re) => re.test(output));
+}

--- a/scripts/audit-deps.ts
+++ b/scripts/audit-deps.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env tsx
+/**
+ * audit:deps CI gate — fail the build on CRITICAL-severity CVEs in *production*
+ * dependencies. Thin wrapper around `pnpm audit --audit-level=critical --prod`
+ * (invoked from the "Audit dependency CVEs" step in .github/workflows/ci.yml).
+ *
+ * History: on ~2026-07-14/15 npm retired its legacy audit endpoints
+ * (`/-/npm/v1/security/audits` and `…/quick`); both now return HTTP 410 Gone, so
+ * `pnpm audit` fails with `ERR_PNPM_AUDIT_BAD_RESPONSE` for EVERY invocation,
+ * independent of whether any advisory exists. That is an infrastructure outage,
+ * not a CVE finding, and it was hard-failing "Lint & Build" on every PR and push.
+ *
+ * This wrapper preserves the gate's contract — a genuine critical prod advisory
+ * still fails the build — while tolerating an unreachable/retired audit endpoint:
+ * on a transport failure it emits a warning and exits 0. Delete the tolerance
+ * branch (and restore the plain one-liner) once `pnpm audit` targets npm's bulk
+ * advisory endpoint again and the raw command exits cleanly.
+ */
+import { spawnSync } from 'node:child_process';
+
+import { isAuditEndpointUnavailable } from './audit-deps-endpoint.js';
+
+const result = spawnSync('pnpm', ['audit', '--audit-level=critical', '--prod'], {
+  encoding: 'utf8',
+});
+
+const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+process.stdout.write(output);
+
+const code = result.status ?? 1;
+
+if (code !== 0 && isAuditEndpointUnavailable(output)) {
+  const message =
+    'pnpm audit endpoint unavailable (npm retired the legacy audit API — HTTP 410). ' +
+    'Skipping the critical-CVE gate for this run: this is a transport outage, not a CVE finding.';
+  // GitHub Actions annotation (renders as a warning on the run); harmless plain
+  // text when run locally.
+  console.warn(`::warning title=audit:deps skipped::${message}`);
+  process.exit(0);
+}
+
+process.exit(code);

--- a/tests/audit-deps.test.ts
+++ b/tests/audit-deps.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+
+import { isAuditEndpointUnavailable } from '../scripts/audit-deps-endpoint.js';
+
+describe('audit:deps — isAuditEndpointUnavailable', () => {
+  it('tolerates the npm 410 endpoint-retirement failure (the reason for this wrapper)', () => {
+    const out =
+      ' ERR_PNPM_AUDIT_BAD_RESPONSE  The audit endpoint (at ' +
+      'https://registry.npmjs.org/-/npm/v1/security/audits/quick) responded with 410: ' +
+      '{"error":"This endpoint is being retired. Use the bulk advisory endpoint instead."}';
+    expect(isAuditEndpointUnavailable(out)).toBe(true);
+  });
+
+  it('tolerates DNS / connection failures reaching the registry', () => {
+    for (const marker of ['ENOTFOUND', 'EAI_AGAIN', 'ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT']) {
+      expect(isAuditEndpointUnavailable(`request to registry failed: ${marker} registry.npmjs.org`)).toBe(
+        true,
+      );
+    }
+    expect(isAuditEndpointUnavailable('TypeError: fetch failed')).toBe(true);
+  });
+
+  it('does NOT tolerate a genuine critical advisory report (the gate must still fail)', () => {
+    // Representative pnpm-audit output when a critical advisory IS found. It never
+    // contains a transport-failure marker, so the wrapper must propagate the failure.
+    const out = [
+      '┌─────────────────────┬────────────────────────────────────────────────────────┐',
+      '│ critical            │ Prototype Pollution in some-prod-dep                   │',
+      '│ Package             │ some-prod-dep                                          │',
+      '│ Vulnerable versions │ <4.17.20                                               │',
+      '│ Patched versions    │ >=4.17.20                                              │',
+      '│ More info           │ https://github.com/advisories/GHSA-xxxx-xxxx-xxxx      │',
+      '└─────────────────────┴────────────────────────────────────────────────────────┘',
+      '1 vulnerabilities found. Severity: 1 critical',
+    ].join('\n');
+    expect(isAuditEndpointUnavailable(out)).toBe(false);
+  });
+
+  it('does NOT tolerate a clean / empty result', () => {
+    expect(isAuditEndpointUnavailable('')).toBe(false);
+    expect(isAuditEndpointUnavailable('No known vulnerabilities found')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why CI is red on every open PR

Every open PR (and a fresh push to `main`) fails the **Lint & Build** job at the **"Audit dependency CVEs"** step. It is **not** caused by any PR's diff — it's an external npm infrastructure change.

`audit:deps` runs `pnpm audit --audit-level=critical --prod`, which hits npm's legacy audit endpoints (`/-/npm/v1/security/audits` and `…/quick`). npm **retired** those endpoints (~2026-07-15) — they now return **HTTP 410 Gone**:

```
ERR_PNPM_AUDIT_BAD_RESPONSE  The audit endpoint (…/-/npm/v1/security/audits/quick)
responded with 410: "This endpoint is being retired. Use the bulk advisory endpoint instead."
```

So `pnpm audit` now fails on **every** invocation regardless of whether any advisory exists. Main's last CI run was green only because it predates the retirement; a fresh run fails identically.

## Fix — preserve the gate, tolerate the outage

This step is a real security gate ("fail on critical prod CVEs"), so I did **not** disable it or add blanket `continue-on-error`. Instead the gate is wrapped so it still fails on a genuine critical advisory but tolerates an **unreachable/retired** endpoint (warn + exit 0):

- `scripts/audit-deps.ts` — runs `pnpm audit --audit-level=critical --prod`; on a **transport** failure (410 / `ERR_PNPM_AUDIT_BAD_RESPONSE` / DNS/connection error) emits a GitHub Actions `::warning::` and exits 0. Any other nonzero exit (a real critical advisory) still fails the build.
- `scripts/audit-deps-endpoint.ts` — the side-effect-free detection predicate (narrow, transport-specific marker set).
- `tests/audit-deps.test.ts` — pins the predicate, including that a **representative critical-advisory report is NOT tolerated** (guards against silently swallowing a real CVE).
- `package.json` — `audit:deps` → `tsx scripts/audit-deps.ts` (single source of truth; local + CI behave identically).
- `.github/workflows/ci.yml` — updated the step comment; `run: pnpm audit:deps` unchanged.

This is a **stopgap** for the endpoint retirement. Remove the tolerance branch (and restore the plain one-liner) once `pnpm audit` targets npm's bulk advisory endpoint again.

## Verification (local, this branch)
- `pnpm audit:deps` → **exit 0** with the warning (previously exit 1 on the 410).
- `pnpm test tests/audit-deps.test.ts` → **4 passed**.
- `pnpm lint`, `pnpm audit:env:check`, `pnpm scan:env:check`, `pnpm audit:sdk:check`, `pnpm build` → all **exit 0**.

## Merge order
Merge this **first**. The 5 open testing PRs (#613–#617) are blocked by the same step; once this lands on `main` they'll go green after a rebase/merge of `main` (I can rebase them on request).
