### PR TITLE
fix(telegram): stop long replies being silently truncated mid-sentence

### DIFF
--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -435,6 +435,40 @@ describe('streamResponse', () => {
     expect(replies.some((r) => r.startsWith('first '))).toBe(true);
     expect(replies.some((r) => r.includes('Telegram dropped'))).toBe(true);
   });
+
+  it('cleanFinal: does NOT delete the frozen preview when the FIRST clean chunk fails (never zero content)', async () => {
+    // Regression (PR #620 review, High): deliverClean posted the truncation notice
+    // and returned on a transport error, but both callers deleted the live preview
+    // unconditionally. So if the VERY FIRST fresh chunk failed, the user was left
+    // with the preview gone AND zero answer content. deliverClean now reports
+    // whether anything landed; the preview must survive when nothing replaced it.
+    const { ctx, replies, deletes } = makeCtx();
+    const transportError = new TelegramError({ error_code: 400, description: 'Bad Request: message is too long' });
+    let htmlReplies = 0;
+    (ctx.reply as ReturnType<typeof vi.fn>).mockImplementation(async (text: string, extra?: { parse_mode?: string }) => {
+      if (extra?.parse_mode === 'HTML') {
+        htmlReplies++;
+        // Reply #1 is the live-preview creation (must succeed so a preview exists);
+        // reply #2 is deliverClean's FIRST fresh chunk — fail it so nothing lands.
+        if (htmlReplies >= 2) throw transportError;
+      }
+      replies.push(text);
+      return { message_id: replies.length, text, chat: { id: 12345, type: 'private' as const }, date: 0 };
+    });
+    const answer = 'Complete answer that must survive as the frozen preview.';
+    const session = makeSession(async function* () {
+      yield { type: 'chunk', chunk: { type: 'content', content: answer } };
+      yield { type: 'done', metadata: undefined };
+    });
+
+    // Never rejects — a first-chunk transport failure is handled, not thrown.
+    await expect(streamResponse(ctx, session, 'go', undefined, { cleanFinal: true })).resolves.toBeUndefined();
+
+    // Nothing replaced the preview, so it must NOT be deleted (user keeps content)…
+    expect(deletes.length).toBe(0);
+    // …and the failure is announced, not silent.
+    expect(replies.some((r) => r.includes('Telegram dropped'))).toBe(true);
+  });
 });
 
 describe('generator finalizer cleanup', () => {

--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { streamResponse, StreamTimeoutError, renderSubagentFooter } from './streaming.js';
+import { streamResponse, StreamTimeoutError, renderSubagentFooter, replyWithFloodRetry } from './streaming.js';
 import { TelegramError } from 'telegraf';
 import type { Context } from 'telegraf';
 import type { IAgentSession, OutputEvent } from '../agent/types.js';
@@ -383,6 +383,58 @@ describe('streamResponse', () => {
     // No fresh-send swap, no preview deletion.
     expect(deletes.length).toBe(0);
   });
+
+  it('no `done` event: delivers the full streamed answer as a fresh message and removes the frozen preview', async () => {
+    // Regression (long-reply cutoff): if the provider stream ends WITHOUT a
+    // terminal `done` event, the clean-final delivery never ran and the user was
+    // stranded on the in-place preview — which is edit-throttled + edit-flood-
+    // controlled, so it can freeze mid-stream and show LESS than what streamed.
+    // The fix finalizes on ANY non-terminal exit: re-deliver the full answer as a
+    // fresh message and delete the preview.
+    const { ctx, replies, deletes } = makeCtx();
+    const answerNoDone = makeSession(async function* () {
+      yield { type: 'chunk', chunk: { type: 'content', content: 'Complete answer that never received a done event.' } };
+      // NO done event — the generator simply returns (provider closed the stream).
+    });
+
+    await streamResponse(ctx, answerNoDone, 'go', undefined, { cleanFinal: true });
+
+    // The full streamed text is delivered as a fresh reply, not left in the preview…
+    expect(replies.some((r) => r.includes('Complete answer that never received a done event.'))).toBe(true);
+    // …and the frozen preview was removed so the chat doesn't end on stale content.
+    expect(deletes.length).toBe(1);
+  });
+
+  it('cleanFinal: surfaces a visible truncation notice instead of silently dropping the tail on a transport error', async () => {
+    // Regression (silent tail-drop): a long reply fans out into several sends; if
+    // Telegram refuses a chunk mid-delivery (flood-control 429 past our retries, or
+    // another transport error), the old code re-threw and the handler swallowed it
+    // silently — the tail vanished with no indication. The fix keeps the delivered
+    // chunks and posts a visible notice.
+    const { ctx, replies } = makeCtx();
+    const transportError = new TelegramError({ error_code: 400, description: 'Bad Request: message is too long' });
+    (ctx.reply as ReturnType<typeof vi.fn>).mockImplementation(async (text: string, extra?: { parse_mode?: string }) => {
+      // Fail the tail chunk ("second …") — a non-parse-entities transport error, so
+      // it exercises the visible-notice branch (not the plaintext-fallback branch).
+      if (extra?.parse_mode === 'HTML' && text.startsWith('second ')) throw transportError;
+      replies.push(text);
+      return { message_id: replies.length, text, chat: { id: 12345, type: 'private' as const }, date: 0 };
+    });
+    const first = `first ${'a'.repeat(4080)}`;
+    const second = `second ${'b'.repeat(200)}`;
+    const longAnswer = [first, second].join('\n');
+    const session = makeSession(async function* () {
+      yield { type: 'chunk', chunk: { type: 'content', content: longAnswer } };
+      yield { type: 'done', metadata: undefined };
+    });
+
+    // Never rejects — a transport failure mid-delivery is handled, not thrown.
+    await expect(streamResponse(ctx, session, 'go', undefined, { cleanFinal: true })).resolves.toBeUndefined();
+
+    // The first chunk landed, and the dropped tail is announced (not silent).
+    expect(replies.some((r) => r.startsWith('first '))).toBe(true);
+    expect(replies.some((r) => r.includes('Telegram dropped'))).toBe(true);
+  });
 });
 
 describe('generator finalizer cleanup', () => {
@@ -652,4 +704,43 @@ describe('provider-turn interrupt on incomplete exit (stale-buffer guard)', () =
       vi.useRealTimers();
     }
   }, 15_000);
+});
+
+describe('replyWithFloodRetry (flood-control 429 backoff)', () => {
+  const flood429 = (retryAfter: number) =>
+    new TelegramError({
+      error_code: 429,
+      description: `Too Many Requests: retry after ${retryAfter}`,
+      parameters: { retry_after: retryAfter },
+    });
+
+  it('retries a 429 (honoring retry_after) then succeeds', async () => {
+    const sleeps: number[] = [];
+    let calls = 0;
+    const reply = vi.fn(async () => {
+      calls++;
+      if (calls === 1) throw flood429(2);
+      return {};
+    });
+    await replyWithFloodRetry(reply, 'hi', undefined, { sleep: async (ms) => { sleeps.push(ms); } });
+    expect(calls).toBe(2);
+    expect(sleeps).toEqual([2000]); // honored retry_after=2s (converted to ms)
+  });
+
+  it('throws after exhausting retries on a persistent 429', async () => {
+    const reply = vi.fn(async () => { throw flood429(1); });
+    await expect(
+      replyWithFloodRetry(reply, 'hi', undefined, { maxRetries: 2, sleep: async () => {} }),
+    ).rejects.toBeInstanceOf(TelegramError);
+    expect(reply).toHaveBeenCalledTimes(3); // initial attempt + 2 retries
+  });
+
+  it('propagates a non-429 error immediately without retrying', async () => {
+    const err = new TelegramError({ error_code: 400, description: "Bad Request: can't parse entities" });
+    const reply = vi.fn(async () => { throw err; });
+    await expect(
+      replyWithFloodRetry(reply, 'hi', { parse_mode: 'HTML' }, { sleep: async () => {} }),
+    ).rejects.toBe(err);
+    expect(reply).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -53,6 +53,70 @@ const MAX_SUBAGENT_PREVIEW_LINES = 4;
 // module keep working.
 export { StreamTimeoutError };
 
+/** Max flood-control (429) retries per outbound message before giving up. */
+const MAX_FLOOD_RETRIES = 2;
+/** Upper bound on how long we honor a single Telegram `retry_after`. */
+const MAX_RETRY_AFTER_MS = 30_000;
+/** Fallback backoff when a 429 carries no `retry_after`. */
+const DEFAULT_FLOOD_BACKOFF_MS = 1_000;
+
+/** Real wall-clock sleep; injectable in tests via `replyWithFloodRetry` opts. */
+const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Shown as a fresh message when Telegram refuses part of a multi-message reply
+ * (flood-control that outlived our retries, or another transport failure) so the
+ * dropped tail is VISIBLE instead of silently lost — the long-reply cutoff bug.
+ */
+const DELIVERY_TRUNCATED_NOTICE =
+  '⚠️ Telegram dropped part of this reply (rate limit) — ask me to resend it.';
+
+/**
+ * Telegram flood-control (429) retry-after in ms, or `null` when `e` is not a
+ * 429. Prefers the structured `parameters.retry_after`, falls back to parsing
+ * the "retry after N" description, then to a small default — always capped.
+ */
+function floodRetryAfterMs(e: unknown): number | null {
+  if (!(e instanceof TelegramError) || e.code !== 429) return null;
+  const fromParams = e.parameters?.retry_after;
+  const fromText = Number(/retry after (\d+)/i.exec(e.description ?? '')?.[1]);
+  const secs =
+    typeof fromParams === 'number' && fromParams > 0
+      ? fromParams
+      : Number.isFinite(fromText) && fromText > 0
+        ? fromText
+        : 0;
+  return Math.min(secs > 0 ? secs * 1_000 : DEFAULT_FLOOD_BACKOFF_MS, MAX_RETRY_AFTER_MS);
+}
+
+/**
+ * Send one message via `reply`, retrying on Telegram flood-control (429) up to
+ * `maxRetries` times and honoring the server's `retry_after`. A long reply fans
+ * out into several back-to-back sends; without this a single 429 aborted the
+ * whole delivery and the tail was dropped silently. Non-429 errors (including the
+ * 400 "can't parse entities" the caller handles specially) propagate immediately.
+ * Exported for unit tests; `sleep` is injectable so tests never wait real seconds.
+ */
+export async function replyWithFloodRetry(
+  reply: (text: string, extra?: { parse_mode?: 'HTML' }) => Promise<unknown>,
+  text: string,
+  extra?: { parse_mode?: 'HTML' },
+  opts: { maxRetries?: number; sleep?: (ms: number) => Promise<void> } = {},
+): Promise<void> {
+  const maxRetries = opts.maxRetries ?? MAX_FLOOD_RETRIES;
+  const sleep = opts.sleep ?? realSleep;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await reply(text, extra);
+      return;
+    } catch (e) {
+      const waitMs = floodRetryAfterMs(e);
+      if (waitMs === null || attempt >= maxRetries) throw e;
+      await sleep(waitMs);
+    }
+  }
+}
+
 /**
  * Render a compact, BOUNDED footer summarizing sub-agent tool activity for the
  * live preview. Returns '' when there is no activity. Pure + exported for unit
@@ -220,17 +284,29 @@ export async function streamResponse(
 
   // Deliver `text` as one or more fresh messages (used for cleanFinal). Mirrors
   // sendOrEdit's HTML-then-plaintext fallback so a formatter bug can never
-  // swallow the final answer.
+  // swallow the final answer, and retries flood-control (429) so a long reply's
+  // back-to-back sends aren't dropped mid-way. If Telegram still refuses a chunk
+  // (retries exhausted, or another non-recoverable transport error), the chunks
+  // already sent stand and a VISIBLE truncation notice is posted — never the old
+  // silent `throw` that dropped the tail and showed the user nothing.
   const deliverClean = async (text: string): Promise<void> => {
+    const reply = (t: string, extra?: { parse_mode?: 'HTML' }): Promise<unknown> => ctx.reply(t, extra);
     for (const chunk of splitLongMessage(text)) {
       if (!chunk) continue;
       try {
         for (const htmlChunk of splitLongMessage(markdownToTelegramHtml(chunk))) {
-          if (htmlChunk) await ctx.reply(htmlChunk, { parse_mode: 'HTML' });
+          if (htmlChunk) await replyWithFloodRetry(reply, htmlChunk, { parse_mode: 'HTML' });
         }
       } catch (e) {
         if (e instanceof TelegramError && e.code === 400 && /can't parse entities/i.test(e.description)) {
-          await ctx.reply(chunk).catch(() => {});
+          // Malformed HTML from the formatter — resend the raw chunk plain.
+          await replyWithFloodRetry(reply, chunk).catch(() => {});
+        } else if (e instanceof TelegramError) {
+          // Flood-control that outlived our retries, or another Telegram transport
+          // failure: the chunks before this one are delivered; the tail is not.
+          // Announce it instead of silently dropping, then stop.
+          await ctx.reply(DELIVERY_TRUNCATED_NOTICE).catch(() => {});
+          return;
         } else {
           throw e;
         }
@@ -560,17 +636,41 @@ export async function streamResponse(
       }
       }); // end runWithSink
 
-      // Send overflow chunks BEFORE closing the generator so the session's
-      // currentState stays 'streaming' while Telegram messages are in flight.
-      // Moving this inside the try block (before the finally) prevents the race
-      // where a new user message sees state='idle' and bypasses the queue while
-      // overflow chunks are still being delivered.
-      if (accumulated && sentMessage) {
+      // Invariant: finalize BEFORE closing the generator so the session's
+      // currentState stays 'streaming' while Telegram messages are in flight —
+      // running this inside the try (before the finally) prevents the race where a
+      // new user message sees state='idle' and bypasses the queue mid-delivery.
+      //
+      // The in-place preview is edited under EDIT_THROTTLE_MS and Telegram edit
+      // flood-control, so it can freeze mid-stream and show LESS than what actually
+      // streamed. A `done` event already handled delivery above (clean-final nulls
+      // `sentMessage`; the legacy branch left chunk[0] in the preview and needs only
+      // chunks[1..]). Any OTHER exit — `sawTerminalEvent` false: the provider closed
+      // the stream without a terminal event, or an early break — previously stranded
+      // the user on that frozen, partial preview (the long-reply "cut off mid-sentence"
+      // bug). Re-deliver everything as fresh message(s) so nothing that streamed is
+      // lost to a stale preview, then remove the preview.
+
+      // Snapshot the preview ref. `sentMessage` is assigned only inside the
+      // `sendOrEdit` closure (invisible to linear CFA), so post-loop TS narrows it to
+      // literal `null` — which would type `preview` as `never` in the branch below.
+      // The `as` re-anchors it to its true DECLARED type (a sound no-op cast), and the
+      // `const` keeps the narrowing across the awaits below.
+      const preview = sentMessage as Message.TextMessage | null;
+      if (preview && !sawTerminalEvent) {
+        const full = cleanFinal && answerText.trim() ? answerText : accumulated;
+        if (full.trim()) {
+          await deliverClean(full);
+          await ctx.telegram.deleteMessage?.(chatId, preview.message_id).catch(() => {});
+          sentMessage = null;
+        }
+      } else if (accumulated && preview) {
         const chunks = splitLongMessage(markdownToTelegramHtml(accumulated));
         if (chunks.length > 1) {
+          const reply = (t: string, extra?: { parse_mode?: 'HTML' }): Promise<unknown> => ctx.reply(t, extra);
           for (let i = 1; i < chunks.length; i++) {
             const chunk = chunks[i];
-            if (chunk) await ctx.reply(chunk, { parse_mode: 'HTML' });
+            if (chunk) await replyWithFloodRetry(reply, chunk, { parse_mode: 'HTML' });
           }
         }
       }

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -241,7 +241,7 @@ export async function streamResponse(
       try {
         sentMessage = await ctx.reply(chunks[0] ?? '…', { parse_mode: 'HTML' });
       } catch (e) {
-        if (e instanceof TelegramError && e.code === 400 && /can't parse entities/i.test(e.description)) {
+        if (e instanceof TelegramError && e.code === 400 && /can't parse entities/i.test(e.description ?? '')) {
           // Malformed HTML from formatter — retry without parse_mode using raw text as fallback
           sentMessage = await ctx.reply(text || '…');
         } else {
@@ -265,7 +265,7 @@ export async function streamResponse(
         { parse_mode: 'HTML' }
       );
     } catch (e) {
-      if (e instanceof TelegramError && e.code === 400 && /can't parse entities/i.test(e.description)) {
+      if (e instanceof TelegramError && e.code === 400 && /can't parse entities/i.test(e.description ?? '')) {
         // Malformed HTML from formatter — retry without parse_mode using raw text as fallback
         try {
           await ctx.telegram.editMessageText(
@@ -289,29 +289,44 @@ export async function streamResponse(
   // (retries exhausted, or another non-recoverable transport error), the chunks
   // already sent stand and a VISIBLE truncation notice is posted — never the old
   // silent `throw` that dropped the tail and showed the user nothing.
-  const deliverClean = async (text: string): Promise<void> => {
+  //
+  // Returns whether ANY content actually landed. Callers use this to gate
+  // deleting the live preview: if the very first chunk fails, `delivered` is
+  // still false and the preview must survive so the user is never left with
+  // zero visible content (see the `done` and non-terminal-exit call sites).
+  const deliverClean = async (text: string): Promise<boolean> => {
+    let delivered = false;
     const reply = (t: string, extra?: { parse_mode?: 'HTML' }): Promise<unknown> => ctx.reply(t, extra);
     for (const chunk of splitLongMessage(text)) {
       if (!chunk) continue;
       try {
         for (const htmlChunk of splitLongMessage(markdownToTelegramHtml(chunk))) {
-          if (htmlChunk) await replyWithFloodRetry(reply, htmlChunk, { parse_mode: 'HTML' });
+          if (htmlChunk) {
+            await replyWithFloodRetry(reply, htmlChunk, { parse_mode: 'HTML' });
+            delivered = true;
+          }
         }
       } catch (e) {
-        if (e instanceof TelegramError && e.code === 400 && /can't parse entities/i.test(e.description)) {
+        if (e instanceof TelegramError && e.code === 400 && /can't parse entities/i.test(e.description ?? '')) {
           // Malformed HTML from the formatter — resend the raw chunk plain.
-          await replyWithFloodRetry(reply, chunk).catch(() => {});
+          try {
+            await replyWithFloodRetry(reply, chunk);
+            delivered = true;
+          } catch {
+            // plain retry failed; ignore
+          }
         } else if (e instanceof TelegramError) {
           // Flood-control that outlived our retries, or another Telegram transport
           // failure: the chunks before this one are delivered; the tail is not.
           // Announce it instead of silently dropping, then stop.
           await ctx.reply(DELIVERY_TRUNCATED_NOTICE).catch(() => {});
-          return;
+          return delivered;
         } else {
           throw e;
         }
       }
     }
+    return delivered;
   };
 
   // Live preview = answer/content buffer + bounded sub-agent footer. Used for
@@ -601,9 +616,12 @@ export async function streamResponse(
           }
           if (cleanFinal && answerText.trim()) {
             // Deliver the answer as a fresh, noise-free message, then remove the
-            // live preview so the conversation ends on a single clean reply.
-            await deliverClean(answerText);
-            if (sentMessage) {
+            // live preview so the conversation ends on a single clean reply. Only
+            // delete the preview if something actually landed — if the very first
+            // chunk failed, `delivered` is false and the frozen preview must
+            // survive so the user is never left with zero visible content.
+            const delivered = await deliverClean(answerText);
+            if (delivered && sentMessage) {
               await ctx.telegram.deleteMessage?.(chatId, sentMessage.message_id).catch(() => {});
               // Null the preview ref so the post-loop overflow block (which would
               // otherwise re-send the noisy `accumulated` buffer) is skipped.
@@ -660,17 +678,35 @@ export async function streamResponse(
       if (preview && !sawTerminalEvent) {
         const full = cleanFinal && answerText.trim() ? answerText : accumulated;
         if (full.trim()) {
-          await deliverClean(full);
-          await ctx.telegram.deleteMessage?.(chatId, preview.message_id).catch(() => {});
-          sentMessage = null;
+          // Only delete the preview if delivery actually produced content — a
+          // failed first chunk must leave the frozen preview in place rather
+          // than removing it and showing the user nothing.
+          const delivered = await deliverClean(full);
+          if (delivered) {
+            await ctx.telegram.deleteMessage?.(chatId, preview.message_id).catch(() => {});
+            sentMessage = null;
+          }
         }
       } else if (accumulated && preview) {
         const chunks = splitLongMessage(markdownToTelegramHtml(accumulated));
         if (chunks.length > 1) {
           const reply = (t: string, extra?: { parse_mode?: 'HTML' }): Promise<unknown> => ctx.reply(t, extra);
-          for (let i = 1; i < chunks.length; i++) {
-            const chunk = chunks[i];
-            if (chunk) await replyWithFloodRetry(reply, chunk, { parse_mode: 'HTML' });
+          try {
+            for (let i = 1; i < chunks.length; i++) {
+              const chunk = chunks[i];
+              if (chunk) await replyWithFloodRetry(reply, chunk, { parse_mode: 'HTML' });
+            }
+          } catch (e) {
+            if (e instanceof TelegramError) {
+              // Flood-control that outlived our retries, or another Telegram
+              // transport failure: chunk[0] already lives in the (undeleted)
+              // preview, so announce the dropped tail instead of throwing it
+              // uncaught into the `finally` and silently losing it — the exact
+              // bug this PR set out to kill, for the non-cleanFinal path.
+              await ctx.reply(DELIVERY_TRUNCATED_NOTICE).catch(() => {});
+            } else {
+              throw e;
+            }
           }
         }
       }


### PR DESCRIPTION
## Problem

Long Telegram bot replies sometimes end **mid-sentence** with no error shown (e.g. a reply that just stops at "Want me to open an"). The truncation is **not** in the chunk-splitter (`splitLongMessage`) — a normally-completed turn delivers the full answer. It comes from the delivery layer in `src/telegram/streaming.ts`. Two distinct, length-correlated causes:

### 1. Full-answer delivery was gated on the `done` event
Interactive replies use `cleanFinal: true` (`handlers/message.ts`), and the robust re-delivery `deliverClean(answerText)` ran **only** inside the `event.type === 'done'` branch. If the provider stream ended any other way — the async iterator returned without ever emitting `done`, or an early break — `deliverClean` never ran and the post-loop fallback only shipped `chunks[1..]`. The user was stranded on the **in-place live preview**, which is edit-throttled (`EDIT_THROTTLE_MS`) and subject to Telegram *edit* flood-control, so it can freeze mid-stream and show **less** than what actually streamed.

### 2. A flood-control 429 mid-delivery dropped the tail silently
A long reply fans out into several back-to-back `ctx.reply` sends. If Telegram returned a flood-control **429** partway through, `deliverClean` re-threw it; `processOne`'s catch classified it via `isTelegramTransportError` and handled it in an **empty branch** — no user-facing message, remaining chunks dropped, and **no `retry_after` / backoff** anywhere in the send path.

## Fix (`src/telegram/streaming.ts`)

1. **Finalize on any non-terminal exit** — when the loop exits without a terminal `done` event, re-deliver the full `answerText`/`accumulated` as fresh message(s) via `deliverClean` and delete the frozen preview, instead of leaving stale partial preview content.
2. **`replyWithFloodRetry` helper** — retries 429s up to `MAX_FLOOD_RETRIES`, honoring the server's `retry_after` (bounded by `MAX_RETRY_AFTER_MS`); non-429 errors propagate immediately. Used by `deliverClean` and the legacy overflow path.
3. **Never drop silently** — if delivery still fails after retries (or another transport error), the chunks already sent stand and a **visible** truncation notice is posted (`DELIVERY_TRUNCATED_NOTICE`) rather than vanishing.

All additive and backward-compatible; no behavior change on the happy path.

## Tests (`src/telegram/streaming.test.ts`)
- `no 'done' event`: delivers the full streamed answer as a fresh message and removes the frozen preview.
- `cleanFinal`: surfaces a visible truncation notice (not silent) when Telegram refuses a chunk mid-delivery.
- `replyWithFloodRetry`: retries a 429 honoring `retry_after` → succeeds; throws after exhausting retries; propagates a non-429 immediately (injected `sleep`, no real waits).

## Verification
- `pnpm test src/telegram/` → 603 passed
- `pnpm lint` (tsc --noEmit, strict) → clean
- `pnpm audit:sdk:check` / `pnpm audit:env:check` → OK (no new SDK imports, no `process.env` reads)

## Not covered / out of scope
- The **upstream** trigger for a specific mid-stream stop (why a provider stream ends without `done` — provider close, detached-turn race, etc.) is separate; this PR makes the delivery layer robust to it so nothing that streamed is lost or dropped without notice.
- The out-of-band push path (`push.ts` `send_telegram` / daemon notifications) has an analogous raw-`push()` 4096 slice; left as a follow-up to keep this PR scoped to the interactive-reply path.