### PR TITLE
test(tui): real-PTY width-resize harness + RED axis-2 fragmentation guards (#540, #541)

### DIFF
--- a/tests/pty/compositor-scrollback.pty.test.ts
+++ b/tests/pty/compositor-scrollback.pty.test.ts
@@ -82,6 +82,37 @@ function assertExpectations(res: PtyRunResult, exp: PtyExpect): void {
       ).toBeLessThanOrEqual(exp.maxViewportBlankRun);
     }
   }
+  if (exp.logicalSpan) {
+    const { from, to, minNonWrappedRows, maxNonWrappedRows, minSpanRows } = exp.logicalSpan;
+    const fromIdx = firstIndex(res.lines, from);
+    expect(fromIdx, `logicalSpan.from "${from}" not found:\n${dump}`).toBeGreaterThanOrEqual(0);
+    const toIdx = res.lines.findIndex((l, i) => i >= fromIdx && l.includes(to));
+    expect(toIdx, `logicalSpan.to "${to}" not found at/after "${from}":\n${dump}`).toBeGreaterThanOrEqual(fromIdx);
+    const spanRows = toIdx - fromIdx + 1;
+    if (minSpanRows !== undefined) {
+      expect(
+        spanRows,
+        `logical span ["${from}".."${to}"] should occupy >=${minSpanRows} rows (proves the resize took effect) but had ${spanRows}:\n${dump}`,
+      ).toBeGreaterThanOrEqual(minSpanRows);
+    }
+    // Count rows in the [from..to] span that are NOT soft-wrap continuations.
+    // One = the terminal reflowed a single logical line cleanly (tmux -J rejoins
+    // it); ≥2 = interior app hard-newlines fragmented it (the axis-2 bug).
+    let nonWrapped = 0;
+    for (let i = fromIdx; i <= toIdx; i++) if (!(res.wrapped[i] ?? false)) nonWrapped += 1;
+    if (minNonWrappedRows !== undefined) {
+      expect(
+        nonWrapped,
+        `logical line ["${from}".."${to}"] should have >=${minNonWrappedRows} non-wrapped (hard-break) rows — the axis-2 fragmentation RED guard (#540); found ${nonWrapped}. If this dropped to 1 the flush now emits logical lines: flip minNonWrappedRows -> maxNonWrappedRows: 1.\n${dump}`,
+      ).toBeGreaterThanOrEqual(minNonWrappedRows);
+    }
+    if (maxNonWrappedRows !== undefined) {
+      expect(
+        nonWrapped,
+        `logical line ["${from}".."${to}"] should rejoin to <=${maxNonWrappedRows} non-wrapped row(s) but had ${nonWrapped}:\n${dump}`,
+      ).toBeLessThanOrEqual(maxNonWrappedRows);
+    }
+  }
 }
 
 describe('TerminalCompositor scrollback over a real pty (issue #541)', () => {

--- a/tests/pty/constants.ts
+++ b/tests/pty/constants.ts
@@ -11,3 +11,53 @@
  * bytes BEFORE this marker, so it never perturbs the geometry under test.
  */
 export const PTY_DONE_SENTINEL = '\x1b_AFK_PTY_DONE\x1b\\';
+
+// Invariant (resize handshake — the parent owns the winsize, the driver owns
+// the timing): a scenario that wants a MID-STREAM width resize emits this APC
+// marker at the exact point it wants the geometry changed, carrying the target
+// `<cols>x<rows>`. Like the DONE sentinel it is an APC string, so xterm emits no
+// glyphs and no scroll for it. The parent watches the byte stream, and on the
+// FIRST complete marker (a) calls node-pty `child.resize(cols, rows)` — which
+// SIGWINCHes the driver so its own `process.stdout` 'resize' fires and the
+// compositor re-renders — and (b) records the marker's byte OFFSET so replay
+// can split the captured stream into a pre-resize half (written at the OLD
+// geometry) and a post-resize half (written after the emulator is resized).
+// Faithful reflow requires constructing the emulator at the OLD width, writing
+// the pre-bytes, calling emulator.resize(), THEN writing the post-bytes — a
+// terminal reflows scrollback on resize, so building at the new width and
+// writing old-width bytes would NOT model the real width-change under test.
+const PTY_RESIZE_PREFIX = '\x1b_AFK_PTY_RESIZE:';
+const PTY_RESIZE_SUFFIX = '\x1b\\';
+
+/** Build the resize-handshake marker for a `<cols>x<rows>` target geometry. */
+export function buildResizeMarker(cols: number, rows: number): string {
+  return `${PTY_RESIZE_PREFIX}${cols}x${rows}${PTY_RESIZE_SUFFIX}`;
+}
+
+/** A located resize marker: its target geometry and byte span within the stream. */
+export interface ResizeMarker {
+  cols: number;
+  rows: number;
+  /** Byte offset of the marker's first char (split point for pre-resize bytes). */
+  start: number;
+  /** Byte offset one past the marker (split point for post-resize bytes). */
+  end: number;
+}
+
+/**
+ * Find the FIRST complete resize marker in `buf`, or null if none has fully
+ * arrived yet (the marker may be split across pty read chunks — the caller
+ * scans the ACCUMULATED buffer each chunk, so a partial marker simply resolves
+ * on a later chunk). Malformed payloads (no `<n>x<n>`) are treated as absent.
+ */
+export function findResizeMarker(buf: string): ResizeMarker | null {
+  const start = buf.indexOf(PTY_RESIZE_PREFIX);
+  if (start < 0) return null;
+  const payloadStart = start + PTY_RESIZE_PREFIX.length;
+  const suffixStart = buf.indexOf(PTY_RESIZE_SUFFIX, payloadStart);
+  if (suffixStart < 0) return null; // suffix not arrived yet — try again next chunk
+  const payload = buf.slice(payloadStart, suffixStart);
+  const m = /^(\d+)x(\d+)$/.exec(payload);
+  if (!m || m[1] === undefined || m[2] === undefined) return null;
+  return { cols: Number(m[1]), rows: Number(m[2]), start, end: suffixStart + PTY_RESIZE_SUFFIX.length };
+}

--- a/tests/pty/harness.ts
+++ b/tests/pty/harness.ts
@@ -22,7 +22,7 @@ import { createRequire } from 'node:module';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { existsSync, chmodSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { PTY_DONE_SENTINEL } from './constants.js';
+import { PTY_DONE_SENTINEL, findResizeMarker, type ResizeMarker } from './constants.js';
 
 const require = createRequire(import.meta.url);
 const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
@@ -32,6 +32,8 @@ const DRIVER_PATH = fileURLToPath(new URL('./driver.ts', import.meta.url));
 interface IPtyProcess {
   onData(cb: (data: string) => void): void;
   onExit(cb: (e: { exitCode: number; signal?: number }) => void): void;
+  /** Change the pty winsize — SIGWINCHes the child (drives the resize handshake). */
+  resize(cols: number, rows: number): void;
   kill(signal?: string): void;
 }
 interface NodePtyModule {
@@ -95,6 +97,16 @@ export interface PtyRunResult {
   exitCode: number | 'timeout';
   /** All emulator buffer lines, top (oldest scrollback) → bottom. */
   lines: string[];
+  /**
+   * Per-line soft-wrap flag, index-aligned with {@link lines}: true when the
+   * emulator marked the row a soft-wrap CONTINUATION of the row above (xterm
+   * `IBufferLine.isWrapped`). A logical line the terminal reflowed cleanly is
+   * ONE non-wrapped head row followed by wrapped continuations — exactly what
+   * `tmux capture-pane -J` rejoins. An app hard-newline is never `isWrapped`,
+   * so interior non-wrapped rows inside one logical line are the width-resize
+   * fragmentation signature (issue #540 axis-2).
+   */
+  wrapped: boolean[];
   /** First visible row index — lines[0..baseY) are scrollback. */
   baseY: number;
   /** Scrollback region (rows above the viewport), blank rows preserved. */
@@ -131,8 +143,20 @@ export async function runScenarioInPty(opts: RunScenarioOpts): Promise<PtyRunRes
 
   let buf = '';
   let captured: string | null = null;
+  // The FIRST resize marker seen in the stream: on detection we SIGWINCH the
+  // child (child.resize) so the driver's own 'resize' fires and the compositor
+  // re-renders, and we keep the marker's byte span so the emulator replay below
+  // can split the captured stream into old-width / new-width halves.
+  let resizeAt: ResizeMarker | null = null;
   child.onData((d) => {
     buf += d;
+    if (resizeAt === null) {
+      const marker = findResizeMarker(buf);
+      if (marker) {
+        resizeAt = marker;
+        try { child.resize(marker.cols, marker.rows); } catch { /* child already gone */ }
+      }
+    }
     if (captured === null) {
       const idx = buf.indexOf(PTY_DONE_SENTINEL);
       if (idx >= 0) captured = buf.slice(0, idx);
@@ -159,20 +183,34 @@ export async function runScenarioInPty(opts: RunScenarioOpts): Promise<PtyRunRes
   const raw = captured ?? buf;
 
   // Real pty output already carries CRLF (kernel ONLCR), so do NOT set
-  // convertEol — that would double-translate and desync every row.
+  // convertEol — that would double-translate and desync every row. The emulator
+  // is constructed at the scenario's ORIGINAL geometry; a mid-stream resize is
+  // modelled by writing pre-resize bytes, calling term.resize() (which reflows
+  // the buffer exactly as a real terminal does), then writing post-resize bytes.
   const term = new (Terminal as new (o: Record<string, unknown>) => {
     write(d: string, cb: () => void): void;
-    buffer: { active: { baseY: number; length: number; getLine(i: number): { translateToString(trim: boolean): string } | undefined } };
+    resize(cols: number, rows: number): void;
+    buffer: { active: { baseY: number; length: number; getLine(i: number): { translateToString(trim: boolean): string; isWrapped: boolean } | undefined } };
     dispose(): void;
   })({ cols, rows, scrollback: 1000, allowProposedApi: true });
-  await new Promise<void>((r) => term.write(raw, r));
+  if (resizeAt) {
+    const pre = raw.slice(0, resizeAt.start);
+    const post = raw.slice(resizeAt.end); // marker bytes themselves are dropped
+    await new Promise<void>((r) => term.write(pre, r));
+    term.resize(resizeAt.cols, resizeAt.rows);
+    await new Promise<void>((r) => term.write(post, r));
+  } else {
+    await new Promise<void>((r) => term.write(raw, r));
+  }
 
   const b = term.buffer.active;
   const baseY = b.baseY;
   const lines: string[] = [];
+  const wrapped: boolean[] = [];
   for (let i = 0; i < b.length; i++) {
     const l = b.getLine(i);
     lines.push(l ? l.translateToString(true).replace(/\s+$/, '') : '');
+    wrapped.push(l ? l.isWrapped : false);
   }
   term.dispose();
 
@@ -184,12 +222,15 @@ export async function runScenarioInPty(opts: RunScenarioOpts): Promise<PtyRunRes
     sawSentinel,
     exitCode,
     lines,
+    wrapped,
     baseY,
     scrollback,
     viewport,
     dump(): string {
+      // '↩' marks a soft-wrap continuation row (isWrapped) so a fragmentation
+      // failure message shows at a glance where hard breaks fall.
       return lines
-        .map((l, i) => `[${i < baseY ? 'SB' : 'VP'} ${String(i).padStart(3)}] ${JSON.stringify(l)}`)
+        .map((l, i) => `[${i < baseY ? 'SB' : 'VP'} ${String(i).padStart(3)}]${wrapped[i] ? '↩' : ' '}${JSON.stringify(l)}`)
         .join('\n');
     },
   };

--- a/tests/pty/scenarios.ts
+++ b/tests/pty/scenarios.ts
@@ -24,6 +24,7 @@ import { LoopStageBar } from '../../src/cli/commands/interactive/loop-stage.js';
 import { renderMarkdownToTerminal } from '../../src/cli/formatter.js';
 import { formatSubmittedEcho } from '../../src/cli/input/echo.js';
 import { commitBlockAbove } from '../../src/cli/_lib/commit-block.js';
+import { buildResizeMarker } from './constants.js';
 
 /** Runtime handed to a scenario's drive() from inside the pty child. */
 export interface PtyDriveCtx {
@@ -65,6 +66,20 @@ export interface PtyExpect {
    * strictly above the first row containing `b` across the whole buffer.
    */
   order?: [string, string][];
+  /**
+   * Soft-wrap rejoinability of ONE logical line (issue #540 axis-2). The parent
+   * takes the buffer span from the first row containing `from` to the first row
+   * at/after it containing `to`, and counts rows that are NOT soft-wrap
+   * continuations (emulator isWrapped=false). A logical line the terminal
+   * reflowed cleanly has exactly ONE such row (its head) → `tmux -J` rejoins it;
+   * an app-hard-wrapped line flushed to scrollback shows interior non-wrapped
+   * rows. `maxNonWrappedRows` asserts the rejoined property (1 = clean);
+   * `minNonWrappedRows` asserts the fragmented property (2+ = the axis-2 bug).
+   * `minSpanRows` asserts the span occupies >= N rows — used to PROVE a resize
+   * actually took effect (e.g. a line that is 1 row wide but must become 2 rows
+   * once the pane narrows), so a silently no-op'd resize handshake fails loudly.
+   */
+  logicalSpan?: { from: string; to: string; maxNonWrappedRows?: number; minNonWrappedRows?: number; minSpanRows?: number };
 }
 
 export interface PtyScenario {
@@ -81,6 +96,35 @@ export interface PtyScenario {
 
 /** Let the frame's async spinner/flush settle before the next step. */
 const settle = (ms = 40): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Request a mid-scenario width resize from INSIDE the pty child. Emits the
+ * resize-handshake marker (which the parent watches for → calls node-pty
+ * child.resize → SIGWINCH), then waits for this process's OWN 'resize' event
+ * (how the driver learns the new winsize landed) before returning, so the
+ * caller can repaint at the new geometry. A 2s timeout guards against a parent
+ * that never resizes (e.g. a non-resize run) so drive() can never hang.
+ */
+async function requestResize(ctx: PtyDriveCtx, cols: number, rows: number): Promise<void> {
+  const { stdout } = ctx;
+  const landed = new Promise<void>((resolve) => {
+    let done = false;
+    const finish = (): void => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      stdout.removeListener('resize', finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, 2000);
+    stdout.once('resize', finish);
+  });
+  stdout.write(buildResizeMarker(cols, rows));
+  await landed;
+  // Give the compositor's own SIGWINCH handler a beat to re-render at the new
+  // width before the caller repaints / the driver emits the DONE sentinel.
+  await settle(60);
+}
 
 /** Cast to reach the compositor's internal repaint() (as the unit tests do). */
 type Repaintable = { repaint(): void };
@@ -362,6 +406,138 @@ export const SCENARIOS: Record<string, PtyScenario> = {
         ['india', '[image attached]'],
         ['[image attached]', 'RESPONSE_OK'],
       ],
+    },
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // width-resize-reflow-sanity: HARNESS SELF-CHECK for the resize handshake
+  // (#541 extension). A SHORT committed line (fits at both widths → always one
+  // row) scrolls into scrollback, then the pane WIDENS mid-scenario. It must
+  // survive the resize as exactly one rejoinable row. This is GREEN before AND
+  // after the axis-2 fix — it certifies the resize marker → child.resize →
+  // emulator.resize replay path moves content faithfully, so a broken handshake
+  // fails HERE (loudly) rather than silently masking the RED guards below.
+  // ─────────────────────────────────────────────────────────────────────────
+  'width-resize-reflow-sanity': {
+    description: 'harness resize handshake: a scrolled-off line that fits wide re-wraps to 2 rows when narrowed',
+    cols: 80,
+    rows: 24,
+    ref: '#541 resize-handshake self-check',
+    async drive(ctx): Promise<void> {
+      const { stdout, stdin } = ctx;
+      const statusLine = wireProductionFooter(stdout, 'M');
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: () => {}, scrollRegion: statusLine, anchorRow: 1 });
+      await c.arm();
+      const ix = c as unknown as Repaintable;
+      c.setSpinner({ enabled: true });
+      const overlay = Array.from({ length: 12 }, (_, i) => `thinking ${i}`).join('\n');
+      // ~62 cols: ONE row at 80 (fits, so afk stores it un-hard-wrapped — this
+      // property is stable across PR 2), but must soft-wrap to 2 rows at 40.
+      c.setOverlay(overlay); c.commitAbove(`SANITYSTART_${'y'.repeat(40)}_SANITYEND\n`);
+      for (let k = 0; k < 24; k++) { c.setOverlay(overlay); c.commitAbove(`PAD_${String(k).padStart(2, '0')}\n`); }
+      c.setOverlay(''); ix.repaint(); ix.repaint();
+      await settle();
+      await requestResize(ctx, 40, 24); // NARROW 80 → 40
+      ix.repaint(); ix.repaint();
+      await settle();
+    },
+    expect: {
+      inScrollback: ['SANITYSTART'], // precondition: the line scrolled off screen
+      // maxNonWrappedRows:1 = the terminal cleanly soft-wrapped it (rejoinable);
+      // minSpanRows:2 = it actually re-wrapped, PROVING child.resize fired (a
+      // no-op'd resize would leave it 1 row at width 80 and fail here).
+      logicalSpan: { from: 'SANITYSTART', to: 'SANITYEND', maxNonWrappedRows: 1, minSpanRows: 2 },
+    },
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // width-resize-fragment-narrow (#540 axis-2 · RED GUARD): a long LOGICAL line
+  // committed WIDE (100 cols) is hard-wrapped to physical rows at commit time
+  // (terminal-compositor.committed-band-commit.ts:165) and flushed to native
+  // scrollback as hard-newline rows. On a NARROWER resize the terminal reflows
+  // each hard row independently, so the one logical line shows ≥2 non-wrapped
+  // (isWrapped=false) rows in its span — it is NOT `tmux -J`-rejoinable. This is
+  // the user's screenshot. It is GREEN NOW (documents the bug); when PR 2 (#540
+  // Stage 3 logical flush) makes the flush emit logical lines, the count drops
+  // to 1 and THIS ASSERTION WILL FAIL — the signal to flip minNonWrappedRows →
+  // maxNonWrappedRows: 1 and retire this as the GREEN regression guard.
+  // ─────────────────────────────────────────────────────────────────────────
+  'width-resize-fragment-narrow': {
+    description: 'wide-committed logical line in scrollback fragments on a NARROWER resize (RED guard, #540 axis-2)',
+    cols: 120,
+    rows: 24,
+    ref: '#540 axis-2 · terminal-compositor.committed-band-commit.ts:165',
+    async drive(ctx): Promise<void> {
+      const { stdout, stdin } = ctx;
+      const statusLine = wireProductionFooter(stdout, 'M');
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: () => {}, scrollRegion: statusLine, anchorRow: 1 });
+      await c.arm();
+      const ix = c as unknown as Repaintable;
+      c.setSpinner({ enabled: true });
+      const overlay = Array.from({ length: 12 }, (_, i) => `thinking ${i} keeping the frame tall`).join('\n');
+      // One long logical line (186 cols, no interior break points) → hard-wraps
+      // to 2 physical rows at 120 cols ([120,66]); committed first so it
+      // overflows to scrollback under the tall overlay. Target width 68 is NOT a
+      // divisor of 120, so the char-100 hard break lands mid-wrap → a visibly
+      // ragged short row, exactly the user's screenshot.
+      const longLine = `LOGSTART_${'x'.repeat(170)}_LOGEND`;
+      c.setOverlay(overlay); c.commitAbove(longLine + '\n');
+      for (let k = 0; k < 24; k++) { c.setOverlay(overlay); c.commitAbove(`FILLER_${String(k).padStart(2, '0')}\n`); }
+      c.setOverlay(''); ix.repaint(); ix.repaint();
+      await settle();
+      await requestResize(ctx, 68, 24); // NARROW 120 → 68 (non-divisor → ragged)
+      ix.repaint(); ix.repaint();
+      await settle();
+    },
+    expect: {
+      inScrollback: ['LOGSTART'], // precondition: the long line scrolled off screen
+      // minSpanRows:3 PROVES the narrow fired (the line is 2 rows at 120, 3 at
+      // 68) and is stable across PR 2; minNonWrappedRows:2 is the RED flip signal.
+      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', minNonWrappedRows: 2, minSpanRows: 3 },
+    },
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // width-resize-fragment-widen (#540 axis-2 · RED GUARD): the widen twin. A
+  // long logical line committed NARROW (50 cols) hard-wraps to several physical
+  // rows and flushes to scrollback. On a WIDER resize the terminal cannot rejoin
+  // app hard-newlines, so the rows stay ragged/short — ≥2 non-wrapped rows in
+  // the span (each afk row is ≤50 ≤100 so none even soft-wraps). GREEN NOW; flips
+  // to FAIL when PR 2 emits one logical line (which the widen reflows to fewer
+  // rows with a single non-wrapped head). See the narrow twin's note.
+  // ─────────────────────────────────────────────────────────────────────────
+  'width-resize-fragment-widen': {
+    description: 'narrow-committed logical line in scrollback stays ragged on a WIDER resize (RED guard, #540 axis-2)',
+    cols: 48,
+    rows: 24,
+    ref: '#540 axis-2 · terminal-compositor.committed-band-commit.ts:165',
+    async drive(ctx): Promise<void> {
+      const { stdout, stdin } = ctx;
+      const statusLine = wireProductionFooter(stdout, 'M');
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: () => {}, scrollRegion: statusLine, anchorRow: 1 });
+      await c.arm();
+      const ix = c as unknown as Repaintable;
+      c.setSpinner({ enabled: true });
+      const overlay = Array.from({ length: 12 }, (_, i) => `thinking ${i} tall`).join('\n');
+      // 186 cols → hard-wraps to 4 physical rows at 48 cols. On a WIDEN to 110
+      // those 4 rows stay separate (each <=48 fits at 110, so the terminal never
+      // rejoins the app hard-newlines) → 4 ragged non-wrapped rows.
+      const longLine = `LOGSTART_${'x'.repeat(170)}_LOGEND`;
+      c.setOverlay(overlay); c.commitAbove(longLine + '\n');
+      for (let k = 0; k < 24; k++) { c.setOverlay(overlay); c.commitAbove(`FILLER_${String(k).padStart(2, '0')}\n`); }
+      c.setOverlay(''); ix.repaint(); ix.repaint();
+      await settle();
+      await requestResize(ctx, 110, 24); // WIDEN 48 → 110
+      ix.repaint(); ix.repaint();
+      await settle();
+    },
+    expect: {
+      inScrollback: ['LOGSTART'],
+      // minNonWrappedRows:2 is the RED flip signal (4 ragged rows now → 1 after
+      // PR 2 rejoins the logical line). The resize MECHANISM is certified by the
+      // sanity scenario; a widen cannot prove itself via row count (it is
+      // unchanged pre-fix), so no minSpanRows here.
+      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', minNonWrappedRows: 2 },
     },
   },
 };


### PR DESCRIPTION
## What

PR 1 of the TUI width-resize fix. Extends the real-PTY scrollback harness (issue #541) with a **mid-stream width resize**, so the width-resize scrollback-fragmentation class (#540 "axis 2" — the ragged/fragmented wrapping in the reported screenshot) is reproducible in CI, and adds guards that lock the bug until the fix lands.

**This PR ships test infrastructure + a failing-behavior guard only. No `src/` changes, no behavior change.**

## Why (the diagnosis, verified)

Committed content is hard-wrapped to the width-at-commit (`src/cli/terminal-compositor.committed-band-commit.ts:165`, `hardWrapToWidth(l, cols)`) and flushed into native scrollback as **hard-newline rows**. A terminal only reflows its own soft-wraps on resize — never app hard-newlines (VT100/DECAWM) — so once content is in native scrollback a later width change re-fragments it (narrow) or leaves it ragged (widen). Confirmed terminal-independent (tmux + Terminal.app + Ghostty) and **cosmetic — no data loss** (`tmux capture-pane -J` rejoins every char). The prior merged work (#539/#552/#573) fixed the *height*-event void class (axis 1); this width class is not covered by it.

## How the harness resize works

- **`constants.ts`** — `PTY_RESIZE` APC marker protocol (`buildResizeMarker`/`findResizeMarker`). A scenario emits the marker at the point it wants the geometry changed, carrying `<cols>x<rows>`; xterm ignores APC, so it never perturbs the buffer.
- **`harness.ts`** — `IPtyProcess.resize()`; `runScenarioInPty` watches the byte stream, on the first marker calls `child.resize()` (SIGWINCH) and records the byte offset, then on replay **splits the stream**: construct the emulator at the *old* geometry → write pre-bytes → `emulator.resize()` (which reflows) → write post-bytes. Building at the new width and writing old-width bytes would not model reflow. Also exposes per-line `isWrapped`.
- **`scenarios.ts`** — `requestResize()` driver helper (emit marker, await the driver's own `'resize'`); `PtyExpect.logicalSpan` asserts soft-wrap rejoinability (the `tmux -J` property) via `isWrapped` counts, plus `minSpanRows` to prove a resize actually fired.

## Scenarios

Existing 5 scenarios are **unchanged** — the resize is marker-driven, so `runScenarioInPty({name, cols, rows})` keeps its signature.

- `width-resize-reflow-sanity` — **GREEN and stable across the fix.** A line that fits at the wide width must re-wrap to 2 rows when narrowed; certifies the resize handshake actually fires (a silently no-op'd `child.resize` fails here).
- `width-resize-fragment-narrow` / `width-resize-fragment-widen` — **GREEN now, RED guards.** A logical line committed at one width, flushed to scrollback as hard rows, shows **≥2 non-wrapped rows** after a resize (not `tmux -J`-rejoinable). Verified genuine: asserting the fixed property (`maxNonWrappedRows: 1`) fails today with `expected 2 to be <= 1`.

**The flip:** when PR 2 (#540 Stage 3 — the single end-of-turn flush emitting *logical* soft-wrappable lines) lands, the count drops to 1 and these assertions start failing — the signal to flip `minNonWrappedRows` → `maxNonWrappedRows: 1`, converting them to GREEN regression guards.

## Gates

- `pnpm test:pty` — **8/8 green** (5 existing + 3 new)
- `pnpm lint` (`tsc --noEmit`, strict) — clean

## Not in this PR

PR 2 — the fix itself (retain logical form through to a single end-of-turn logical flush; ~1,200 LOC in `committed-band-commit.ts` / `committed-band-repin.ts` / `frame-preserve.ts`). A Stage-0 spike confirmed the crux is *retaining* the pre-wrap logical form (the flat `committedBand: string[]` cannot be reconstructed — `reflowBandSplit` re-wraps each row independently, so widening never rejoins). PR 2 is gated on a human real-terminal matrix (iTerm2 / Terminal.app / Ghostty) — prior fixes shipped green and were broken in reality.

Refs #540, #541.
