### PR TITLE
fix(tui): Stage 3 logical-line scrollback flush — dissolve width-resize fragmentation (#540)

### DIFF
--- a/src/cli/terminal-compositor.band-reflow.ts
+++ b/src/cli/terminal-compositor.band-reflow.ts
@@ -27,6 +27,7 @@
  */
 
 import { hardWrapToWidth } from './wrap.js';
+import type { BandRowMeta } from './terminal-compositor.types.js';
 
 /**
  * Invariant (painted/pending boundary survives reflow): `committedBand`'s
@@ -49,6 +50,20 @@ import { hardWrapToWidth } from './wrap.js';
 export interface BandReflowResult {
   rows: string[];
   paintedRows: number;
+  /**
+   * Per-physical-row provenance for `rows`, index-aligned 1:1 (#540 axis-2).
+   * Re-wrapping a physical row into more (narrower) or the same (wider) rows
+   * PRESERVES each row's `logicalText` — the original pre-hard-wrap line the
+   * row is a fragment of, unchanged by any width — and recomputes `isHead` so
+   * only the first sub-row of a re-split row that was itself a logical-line
+   * head stays a head. This is what lets a widened resize rejoin a
+   * hard-wrapped line at the SCROLLBACK flush sites even though the on-screen
+   * physical rows keep their (now stale) narrow break points: the logical
+   * source rides through reflow intact. Absent-meta input degrades to
+   * reconstructing `logicalText` from the physical row itself (each row treated
+   * as its own logical line) — lossy for rejoin but never for content.
+   */
+  meta: BandRowMeta[];
 }
 
 /**
@@ -59,21 +74,49 @@ export interface BandReflowResult {
  * an already-`width`-fitting row at the SAME width returns it unchanged (so a
  * steady-width repeat call is a no-op even without the cache in
  * {@link reflowCommittedBandToWidth}).
+ *
+ * `meta` (index-aligned 1:1 with `band`) is re-split in lockstep: each source
+ * row's `logicalText` propagates to all its re-wrapped sub-rows so the retained
+ * logical form survives arbitrary reflows (#540 axis-2). When omitted, the
+ * physical row itself is used as the logical source (pre-#540 behavior — the
+ * band's re-wrapped rows are treated as their own logical lines).
  */
 export function reflowBandSplit(
   band: readonly string[],
   paintedRows: number,
   width: number,
+  meta?: readonly BandRowMeta[],
 ): BandReflowResult {
-  if (band.length === 0) return { rows: [], paintedRows: 0 };
+  if (band.length === 0) return { rows: [], paintedRows: 0, meta: [] };
   const clampedPainted = Math.max(0, Math.min(paintedRows, band.length));
-  const pendingPrefix = band.slice(0, band.length - clampedPainted);
-  const paintedSuffix = band.slice(band.length - clampedPainted);
-  const reflow = (lines: readonly string[]): string[] =>
-    lines.flatMap((line) => hardWrapToWidth(line, width).split('\n'));
-  const reflowedSuffix = reflow(paintedSuffix);
-  const rows = [...reflow(pendingPrefix), ...reflowedSuffix];
-  return { rows, paintedRows: reflowedSuffix.length };
+  const splitAt = band.length - clampedPainted;
+  // Re-wrap a [start, end) slice of the band, emitting the new physical rows
+  // and their meta together so the two arrays stay index-aligned. Each source
+  // row band[k] contributes its wrapped sub-rows, all carrying band[k]'s
+  // logicalText (from `meta`, or the row text itself as a fallback); only the
+  // first sub-row is a head, and only if the source row was a head.
+  const reflowSlice = (start: number, end: number): { rows: string[]; meta: BandRowMeta[] } => {
+    const outRows: string[] = [];
+    const outMeta: BandRowMeta[] = [];
+    for (let k = start; k < end; k++) {
+      const source = band[k] ?? '';
+      const logicalText = meta?.[k]?.logicalText ?? source;
+      const sourceIsHead = meta?.[k]?.isHead ?? true;
+      const subRows = hardWrapToWidth(source, width).split('\n');
+      subRows.forEach((sub, i) => {
+        outRows.push(sub);
+        outMeta.push({ logicalText, isHead: i === 0 && sourceIsHead });
+      });
+    }
+    return { rows: outRows, meta: outMeta };
+  };
+  const pending = reflowSlice(0, splitAt);
+  const painted = reflowSlice(splitAt, band.length);
+  return {
+    rows: [...pending.rows, ...painted.rows],
+    paintedRows: painted.rows.length,
+    meta: [...pending.meta, ...painted.meta],
+  };
 }
 
 /**
@@ -91,6 +134,8 @@ export interface BandReflowCache {
 /** Narrowest state slice {@link reflowCommittedBandToWidth} touches. */
 export interface BandReflowHost {
   committedBand: string[];
+  /** Per-physical-row logical provenance, index-aligned 1:1 with committedBand (#540). */
+  committedBandMeta: BandRowMeta[];
   committedBandPaintedRows: number;
   bandReflowCache: BandReflowCache | null;
 }
@@ -128,8 +173,14 @@ export function reflowCommittedBandToWidth(self: BandReflowHost, width: number):
   ) {
     return; // already reflowed to this width from this exact band+boundary
   }
-  const { rows, paintedRows } = reflowBandSplit(self.committedBand, self.committedBandPaintedRows, width);
+  const { rows, paintedRows, meta } = reflowBandSplit(
+    self.committedBand,
+    self.committedBandPaintedRows,
+    width,
+    self.committedBandMeta,
+  );
   self.committedBand = rows;
+  self.committedBandMeta = meta;
   self.committedBandPaintedRows = paintedRows;
   self.bandReflowCache = { band: rows, paintedRows, width };
 }

--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -13,10 +13,16 @@
  * borrows them through the host interface.
  */
 
-import type { LogUpdateFn, CompositorScrollRegionGuard } from './terminal-compositor.types.js';
-import { eraseAndPaintRow } from './terminal-compositor.types.js';
+import type { LogUpdateFn, CompositorScrollRegionGuard, BandRowMeta } from './terminal-compositor.types.js';
+import {
+  eraseAndPaintRow,
+  buildBandMeta,
+  scrollbackFlushLines,
+  buildScrollbackArchiveEscape,
+  snapFlushCountToLogicalBoundary,
+} from './terminal-compositor.types.js';
 import { hardWrapToWidth } from './wrap.js';
-import { capBandModel, decideCommitMode } from './commit-mode.js';
+import { decideCommitMode } from './commit-mode.js';
 import {
   reflowCommittedBandToWidth,
   type BandReflowCache,
@@ -35,6 +41,8 @@ export interface CommittedBandHost {
   debugLog(stage: string, extra?: Record<string, unknown>): void;
   /** The full contiguous on-screen committed run adjacent to the frame top. */
   committedBand: string[];
+  /** Per-physical-row logical provenance, index-aligned 1:1 with committedBand (#540). */
+  committedBandMeta: BandRowMeta[];
   committedBandTopRow: number;
   committedBandBottomRow: number;
   /** Real unpadded frame top from the last repaint's measure() — see the field
@@ -164,6 +172,14 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   // by the next commit's paint, and the band-hold row math is exact.
   const contentLines = logicalLines.flatMap((l) => hardWrapToWidth(l, cols).split('\n'));
   const contentLineCount = Math.max(1, contentLines.length);
+  // #540 axis-2 (retained logical source): the per-physical-row provenance for
+  // `contentLines`, index-aligned 1:1. Recorded from the SAME logical lines +
+  // width that produced the physical rows above, so the scrollback-flush sites
+  // can later emit the logical line (terminal-soft-wrapped, reflow-clean)
+  // instead of these pre-hard-wrapped rows. The separator blank row (added to
+  // textLines/bandTextLines below) is its own logical line ''.
+  const contentMeta = buildBandMeta(logicalLines, cols);
+  const separatorMeta: BandRowMeta = { logicalText: '', isHead: true };
 
   const extraRows = self.scrollRegion?.getExtraRows() ?? 0;
   // Invariant (one geometry per commit): the room/scroll/band math below must
@@ -298,6 +314,7 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   const paintSeparator =
     hasTrailingSeparator && fitsAboveFrame && contentLineCount < aboveFrameRoomForSeparator;
   const textLines = paintSeparator ? [...contentLines, ''] : contentLines;
+  const textMeta = paintSeparator ? [...contentMeta, separatorMeta] : contentMeta;
   const lineCount = contentLineCount + (paintSeparator ? 1 : 0);
 
   // Band-hold routing (pure, tested in commit-mode.test.ts): keep a block that
@@ -313,10 +330,12 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   // the separator) so a 1-content-line block with trailing separator counts as 2
   // model rows, correctly routing it to band-hold when room=1.
   const bandTextLines = hasTrailingSeparator ? [...contentLines, ''] : contentLines;
+  const bandTextMeta = hasTrailingSeparator ? [...contentMeta, separatorMeta] : contentMeta;
   const bandLineCount = bandTextLines.length;
   const {
     useBandHold,
     overflowRun,
+    overflowPriorContiguous,
     maxBandModel,
   } = decideCommitMode({
     prevTopRow,
@@ -332,6 +351,31 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     committedBandPaintedRows: self.committedBandPaintedRows,
     geometryStale: self.bandGeometryStale,
   });
+  // #540 axis-2: the per-physical-row provenance for `overflowRun`, rebuilt
+  // here to stay 1:1 with it — decideCommitMode is a pure geometry helper and
+  // is left untouched. Mirrors its `overflowRun = overflowPriorContiguous ?
+  // [...committedBand, ...bandTextLines] : bandTextLines` exactly, using the
+  // same-order meta arrays (self.committedBandMeta is kept 1:1 with
+  // self.committedBand; bandTextMeta with bandTextLines).
+  const overflowRunMeta: BandRowMeta[] = overflowPriorContiguous
+    ? [...self.committedBandMeta, ...bandTextMeta]
+    : bandTextMeta;
+  // #540 axis-2: how many oldest PHYSICAL rows of overflowRun the band-hold
+  // path archives to scrollback this commit — decideCommitMode's raw
+  // `overflowRun.length - maxBandModel`, but SNAPPED DOWN to a logical-line
+  // boundary so a multi-row logical line is never archived one physical row per
+  // commit (which would emit it verbatim each time and re-fragment it). The
+  // straddling line (and everything after) is RETAINED in the band model until
+  // a later commit's overflow covers all its rows, then it archives whole as
+  // one soft-wrappable line. Phase 1 (archive) and Phase 3 (model = the
+  // retained suffix) both split overflowRun at this same index so archived and
+  // retained stay disjoint and complete.
+  const rawGenuineOverflow = Math.max(0, overflowRun.length - maxBandModel);
+  const archiveCount = snapFlushCountToLogicalBoundary(
+    overflowRunMeta,
+    rawGenuineOverflow,
+    overflowRun.length,
+  );
 
   // Suppress the shrink re-pin for the whole commit; Phase 3 sets the band.
   // Re-armed at the top of every commitAbove, so a throw on a dying TTY (the
@@ -428,20 +472,26 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
         // Band-hold Phase 1: scroll NOTHING for the rows the model keeps (they
         // are "pending" — painted by repositionCommittedBand on collapse). Only
         // the genuine overflow (oldest rows beyond maxBandModel) is archived to
-        // scrollback as REAL content, via the proven top-write-then-scroll
-        // mechanism, chunked by screen height so a run taller than the terminal
-        // still archives every row. The archived prefix is disjoint from the
+        // scrollback as REAL content. The archived prefix is disjoint from the
         // suffix Phase 3 keeps — no duplication.
-        const genuineOverflow = Math.max(0, overflowRun.length - maxBandModel);
-        if (genuineOverflow > 0) {
-          const chunkMax = Math.max(1, rows - anchorFloor + 1);
-          for (let start = 0; start < genuineOverflow; start += chunkMax) {
-            const chunk = overflowRun.slice(start, Math.min(start + chunkMax, genuineOverflow));
-            const topWrite = chunk
-              .map((l, i) => eraseAndPaintRow(anchorFloor + i, l))
-              .join('');
-            self.stdout.write(`${topWrite}\x1b[${rows};1H${'\n'.repeat(chunk.length)}`);
-          }
+        //
+        // #540 axis-2 (logical-line flush): archive the overflow prefix as
+        // SOFT-WRAPPABLE logical lines, not the pre-hard-wrapped physical rows,
+        // so a later width resize reflows scrolled-off content cleanly instead
+        // of re-fragmenting it. `archiveCount` (computed above) is the raw
+        // overflow SNAPPED to a logical-line boundary, so no logical line is
+        // ever split across two archive events; scrollbackFlushLines therefore
+        // emits whole logical lines, and buildScrollbackArchiveEscape paints
+        // them top-aligned with autowrap ON and scrolls their total physical
+        // height off the top into history (the terminal owns the wrap → its
+        // continuation rows are soft-wrap continuations that rejoin on resize).
+        // Autowrap is load-bearing here (opposite of the on-screen band paint's
+        // withAutowrapDisabled). Phase 3's model keeps overflowRun[archiveCount:]
+        // (see capBandModel call) so archived + retained are disjoint + complete.
+        if (archiveCount > 0) {
+          const archiveLines = scrollbackFlushLines(overflowRun, overflowRunMeta, archiveCount);
+          const escape = buildScrollbackArchiveEscape(archiveLines, anchorFloor, rows, cols);
+          if (escape.length > 0) self.stdout.write(escape);
         }
       } else if (fitsAboveFrame) {
         if (bandOverflow > 0) {
@@ -536,12 +586,24 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     const postScrollFloor = Math.max(self.anchorRow ?? 1, 1);
     const maxRun = Math.max(0, newTopRow - postScrollFloor);
     if (useBandHold) {
-      // Band-hold Phase 3: track the full committed run (capped at maxBandModel)
-      // as the band model, but paint only the bottom paintedCount rows that fit
-      // above the current frame. The rest are "pending" — in the model, not yet
-      // on screen, not in scrollback. repositionCommittedBand paints the whole
-      // model contiguously above the frame on the next shrink/collapse.
-      const model = capBandModel(overflowRun, maxBandModel);
+      // Band-hold Phase 3: track the committed run's RETAINED suffix as the band
+      // model, but paint only the bottom paintedCount rows that fit above the
+      // current frame. The rest are "pending" — in the model, not yet on screen,
+      // not in scrollback. repositionCommittedBand paints the whole model
+      // contiguously above the frame on the next shrink/collapse.
+      //
+      // #540: the retained suffix is overflowRun[archiveCount:], the exact
+      // complement of what Phase 1 archived. archiveCount is capBandModel's
+      // `overflowRun.length - maxBandModel` SNAPPED DOWN to a logical-line
+      // boundary, so the model may retain up to (one logical line's height − 1)
+      // rows BEYOND maxBandModel — a straddling logical line is kept whole here
+      // rather than archived half now / half later (which re-fragments it). The
+      // extra pending rows are painted on collapse / flushed on disarm like any
+      // pending rows; the bound is one logical line, so the model never grows
+      // unboundedly.
+      const model = overflowRun.slice(archiveCount);
+      // #540: slice the provenance at the SAME index so it stays 1:1 with `model`.
+      const modelMeta = overflowRunMeta.slice(archiveCount);
       const paintedCount = Math.min(model.length, maxRun);
       const bandTop = newTopRow - paintedCount;
       let out = '';
@@ -556,6 +618,7 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
         });
       }
       self.committedBand = model;
+      self.committedBandMeta = modelMeta;
       self.committedBandBottomRow = newTopRow - 1;
       self.committedBandTopRow = bandTop;
       // Only the bottom `paintedCount` rows reached the terminal; the rest of
@@ -571,6 +634,8 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
       // bottom left boxes rendered un-closed. In the fits path newPainted ===
       // lineCount, so this is the whole array (no behavior change there).
       const newLines = textLines.slice(textLines.length - newPainted);
+      // #540: the new block's provenance, sliced in lockstep with newLines.
+      const newMeta = textMeta.slice(textMeta.length - newPainted);
       // "Whole block painted" = newPainted === textLines.length (no lines
       // dropped to overflow). Compare against textLines.length, NOT lineCount:
       // lineCount is the WRAP-AWARE physical row count (measure()), which can
@@ -607,10 +672,15 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
         (self.committedBandBottomRow === newTopRow - 1 ||
           self.committedBandBottomRow === phase1EffectiveFrameTop - 1);
       const run = contiguousPriorBand ? [...self.committedBand, ...newLines] : newLines;
+      // #540: the merged run's provenance, 1:1 with `run` (same merge decision,
+      // same-order arrays — self.committedBandMeta is 1:1 with self.committedBand).
+      const runMeta = contiguousPriorBand ? [...self.committedBandMeta, ...newMeta] : newMeta;
       // Cap at the room between the anchor floor and the frame top. maxRun >=
       // newPainted always (the new lines fit by construction), so they are
       // never dropped; only prior-band lines that scroll above the floor are.
       const capped = run.length > maxRun ? run.slice(run.length - maxRun) : run;
+      // #540: cap the provenance by the SAME row count so it stays 1:1 with `capped`.
+      const cappedMeta = run.length > maxRun ? runMeta.slice(runMeta.length - maxRun) : runMeta;
       const bandTop = newTopRow - capped.length;
       // Stale band rows above bandTop: when the extended contiguity arm fires, the
       // old band's tracked top (self.committedBandTopRow) may be ABOVE the new
@@ -684,6 +754,7 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
         });
       }
       self.committedBand = capped;
+      self.committedBandMeta = cappedMeta;
       self.committedBandBottomRow = newTopRow - 1;
       self.committedBandTopRow = bandTop;
       // The whole `capped` run is materialized: the fits arm CUP-paints all of
@@ -701,9 +772,14 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     // FULLY PENDING; repositionCommittedBand paints it on the next shrink/collapse.
     // committedBandBottomRow = collapsedFrameTop - 1 (NOT a 0 sentinel) lets a
     // subsequent full-viewport commit satisfy overflowPriorContiguous and MERGE.
-    const model = capBandModel(overflowRun, maxBandModel);
+    // #540: the retained suffix is overflowRun[archiveCount:], the exact
+    // complement of Phase 1's logical-boundary-snapped archive (same reasoning
+    // as the newTopRow>1 band-hold arm above).
+    const model = overflowRun.slice(archiveCount);
+    const modelMeta = overflowRunMeta.slice(archiveCount);
     const collapsedFrameTop = Math.max(1, rows - 1 - extraRows);
     self.committedBand = model;
+    self.committedBandMeta = modelMeta;
     self.committedBandBottomRow = Math.max(0, collapsedFrameTop - 1);
     self.committedBandTopRow = Math.max(anchorFloor, collapsedFrameTop - model.length);
     // Nothing was painted to the terminal: the whole model is PENDING until
@@ -720,6 +796,7 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
 
 export function clearCommittedBand(self: CommittedBandHost): void {
   self.committedBand = [];
+  self.committedBandMeta = [];
   self.committedBandTopRow = 0;
   self.committedBandBottomRow = 0;
   self.committedBandPaintedRows = 0;

--- a/src/cli/terminal-compositor.frame-preserve.ts
+++ b/src/cli/terminal-compositor.frame-preserve.ts
@@ -6,6 +6,27 @@
  *
  * `import type` for FrameHost keeps this a TYPE-ONLY dependency on frame.ts
  * so there is no runtime circular import between the two siblings.
+ *
+ * #540 axis-2 scope note (logical-line scrollback flush): the two OTHER sites
+ * that push committed content into native scrollback — the band-hold archive
+ * (committed-band-commit.ts) and disarm's flushPendingCommittedBand
+ * (lifecycle.ts) — now emit SOFT-WRAPPABLE logical lines (via committedBandMeta
+ * + buildScrollbackArchiveEscape) so scrolled-off content reflows cleanly on a
+ * width change. The eviction paths HERE deliberately still emit pre-wrapped
+ * PHYSICAL rows: they are the load-bearing height/void-class machinery
+ * (#539/#552/#573), and their paint-full-band-then-scroll mechanism is tightly
+ * coupled to repositionCommittedBand's stateless re-pin and the exact
+ * painted/pending accounting — converting them to the top-paint-logical-then-
+ * scroll mechanism regressed the verdict-card overflow case (the card's closing
+ * border was dropped on a growth eviction). The band-hold archive is the site
+ * that actually carries the width-resize content in practice (verified by
+ * instrumenting the #540 PTY guards), so retaining physical emission here does
+ * NOT reintroduce the fragmentation those guards check. The committedBandMeta
+ * array IS still sliced in lockstep at every eviction below so the 1:1
+ * band↔meta invariant (relied on by reflow and the two logical-flush sites)
+ * holds. A full turnModel rewrite (docs/proposals/tui-compositor-rewrite.md §5
+ * A2) would unify all three sites onto one logical archive; that is the
+ * documented follow-up, out of scope for this targeted fix.
  */
 
 import type { FrameHost } from './terminal-compositor.frame.js';
@@ -134,6 +155,7 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
       evictRowsToScrollback(self, overflow);
       // Survivors physically shifted to [1, room] by the scroll.
       self.committedBand = self.committedBand.slice(overflow);
+      self.committedBandMeta = self.committedBandMeta.slice(overflow); // #540: keep 1:1
       self.committedBandTopRow = 1;
       self.committedBandBottomRow = room;
       self.committedBandPaintedRows = self.committedBand.length;
@@ -173,6 +195,7 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
     // hugging the new frame top (growRoom === desiredTopRow - 1). Record that so a
     // later shrink re-pins from the right place.
     self.committedBand = self.committedBand.slice(growOverflow);
+    self.committedBandMeta = self.committedBandMeta.slice(growOverflow); // #540: keep 1:1
     self.committedBandTopRow = 1;
     self.committedBandBottomRow = growRoom;
     // The full band was re-painted top-aligned above before the scroll, so
@@ -256,6 +279,7 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
     evictRowsToScrollback(self, overflow);
     // Survivors physically shifted to [floor, floor+room-1] by the scroll.
     self.committedBand = self.committedBand.slice(overflow);
+    self.committedBandMeta = self.committedBandMeta.slice(overflow); // #540: keep 1:1
     self.committedBandTopRow = floorBanner;
     self.committedBandBottomRow = floorBanner + roomBanner - 1;
     self.committedBandPaintedRows = self.committedBand.length;
@@ -292,6 +316,7 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
       if (self.committedBandTopRow < floor) {
         const lost = floor - self.committedBandTopRow;
         self.committedBand = self.committedBand.slice(lost);
+        self.committedBandMeta = self.committedBandMeta.slice(lost); // #540: keep 1:1
         self.committedBandTopRow = floor;
       }
       if (self.committedBand.length === 0 || self.committedBandBottomRow < floor) {

--- a/src/cli/terminal-compositor.frame.ts
+++ b/src/cli/terminal-compositor.frame.ts
@@ -23,6 +23,7 @@ import { palette } from './palette.js';
 import { renderStatusLine, type ImageAttachment } from './input/attachments.js';
 import type { SpinnerController } from './input/spinner.js';
 import type {
+  BandRowMeta,
   CompositorInputMode,
   CompositorScrollRegionGuard,
   LogUpdateFn,
@@ -70,6 +71,8 @@ export interface FrameHost {
   clipboardFailureMsg: string | null;
   // ── committed-band tracking (mutated by preserveRowsBeforeFrameRender) ──
   committedBand: string[];
+  /** #540: per-physical-row logical provenance, index-aligned 1:1 with committedBand. */
+  committedBandMeta: BandRowMeta[];
   committedBandTopRow: number;
   committedBandBottomRow: number;
   /** Real unpadded frame top; written here by repaint(), read by commitAbove's

--- a/src/cli/terminal-compositor.lifecycle.ts
+++ b/src/cli/terminal-compositor.lifecycle.ts
@@ -15,11 +15,12 @@ import type { SpinnerController } from './input/spinner.js';
 import type { CaretBlinkController } from './input/caret-blink.js';
 import type { SuggestEngine } from './terminal-compositor.types.js';
 import type {
+  BandRowMeta,
   CompositorScrollRegionGuard,
   KeyInfo,
   LogUpdateFn,
 } from './terminal-compositor.types.js';
-import { eraseAndPaintRow } from './terminal-compositor.types.js';
+import { scrollbackFlushLines, buildScrollbackArchiveEscape } from './terminal-compositor.types.js';
 import * as InputDispatch from './terminal-compositor.input-dispatch.js';
 import type { KeyDispatchHost } from './terminal-compositor.input-dispatch.js';
 
@@ -69,6 +70,10 @@ export interface LifecycleHost {
   lastKnownRows: number;
   pendingResizeErase: { top: number; bottom: number } | null;
   readonly committedBand: string[];
+  // #540: per-physical-row logical provenance, index-aligned 1:1 with
+  // committedBand. Read by flushPendingCommittedBand to archive the pending
+  // prefix as soft-wrappable logical lines instead of pre-wrapped physical rows.
+  readonly committedBandMeta: BandRowMeta[];
   readonly committedBandTopRow: number;
   // Read by disarm() to flush genuinely-unpainted committed-band rows to
   // scrollback before teardown. See committedBandPaintedRows on the class.
@@ -437,12 +442,19 @@ export function disarm(self: LifecycleHost): void {
  * this is a no-op and the on-screen rows are left exactly as they are — never
  * re-emitted (HARD CONSTRAINT #1: no duplicate in scrollback).
  *
- * Mechanism: the proven top-write-then-scroll the band-hold Phase-1 archive
- * uses (committed-band-commit.ts) — CUP+EL each pending row at the anchor floor,
- * then a CUP to the physical bottom + `\n`×count to scroll them into history.
- * Chunked by screen height so a pending run taller than the terminal still
- * archives every row. Wrapped in `withFullScrollRegion` (no-op when no status
- * line is started) so the `\n` produces a FULL-screen scroll that enters
+ * Mechanism (#540 axis-2 logical-line flush): the pending prefix is archived as
+ * SOFT-WRAPPABLE logical lines, not pre-hard-wrapped physical rows, so a later
+ * width resize reflows this scrolled-off content cleanly. scrollbackFlushLines
+ * maps the `pendingCount` physical rows to logical lines — reading the FULL
+ * band + meta (not just the prefix) so a logical line STRADDLING the
+ * pending/painted boundary emits its pending rows verbatim rather than
+ * duplicating the on-screen (painted) tail. buildScrollbackArchiveEscape writes
+ * each line at the physical bottom margin with autowrap ON + a trailing `\n`,
+ * so the TERMINAL owns the wrap and the `\n` scrolls it into history; the
+ * terminal re-derives the same per-line physical-row count, so a pending run
+ * taller than the terminal still archives every row (each line scrolls at the
+ * bottom margin independently). Wrapped in `withFullScrollRegion` (no-op when no
+ * status line is started) so the `\n` produces a FULL-screen scroll that enters
  * scrollback rather than a DECSTBM sub-region scroll that silently drops the
  * displaced top line. Best-effort: a throwing stdout means the process is
  * exiting anyway and the next teardown step tears us down.
@@ -450,18 +462,14 @@ export function disarm(self: LifecycleHost): void {
 function flushPendingCommittedBand(self: LifecycleHost): void {
   const pendingCount = self.committedBand.length - self.committedBandPaintedRows;
   if (pendingCount <= 0) return;
-  const pending = self.committedBand.slice(0, pendingCount);
   const rows = Math.max(1, self.stdout.rows ?? 24);
+  const cols = Math.max(1, self.stdout.columns ?? 80);
   const anchorFloor = Math.max(self.anchorRow ?? 1, 1);
+  const archiveLines = scrollbackFlushLines(self.committedBand, self.committedBandMeta, pendingCount);
+  const escape = buildScrollbackArchiveEscape(archiveLines, anchorFloor, rows, cols);
+  if (escape.length === 0) return;
   const write = (): void => {
-    const chunkMax = Math.max(1, rows - anchorFloor + 1);
-    for (let start = 0; start < pending.length; start += chunkMax) {
-      const chunk = pending.slice(start, Math.min(start + chunkMax, pending.length));
-      const topWrite = chunk
-        .map((l, i) => eraseAndPaintRow(anchorFloor + i, l))
-        .join('');
-      self.stdout.write(`${topWrite}\x1b[${rows};1H${'\n'.repeat(chunk.length)}`);
-    }
+    self.stdout.write(escape);
   };
   try {
     if (self.scrollRegion) {

--- a/src/cli/terminal-compositor.logical-flush.test.ts
+++ b/src/cli/terminal-compositor.logical-flush.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for the #540 axis-2 logical-line scrollback-flush primitives:
+ * BandRowMeta construction, prefix→scrollback line translation (whole logical
+ * lines vs straddler/orphan verbatim rows), the logical-boundary snap, the
+ * archive-escape builder, and reflowBandSplit's meta propagation.
+ *
+ * These are the pure core of the fix that makes committed content reach native
+ * scrollback as SOFT-WRAPPABLE logical lines (which the terminal reflows cleanly
+ * on a width change) instead of pre-hard-wrapped physical rows (which fragment).
+ * The end-to-end behavior is certified over a real pty by the width-resize-*
+ * scenarios in tests/pty/; these lock the piece-wise invariants and the
+ * duplication/loss guards that the straddle rule depends on.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildBandMeta,
+  scrollbackFlushLines,
+  snapFlushCountToLogicalBoundary,
+  buildScrollbackArchiveEscape,
+  type BandRowMeta,
+} from './terminal-compositor.types.js';
+import { reflowBandSplit } from './terminal-compositor.band-reflow.js';
+import { hardWrapToWidth } from './wrap.js';
+
+// A logical line 186 cols wide (no interior break points) — the #540 shape:
+// hard-wraps to 2 physical rows at 120, 4 at 48, reflows to 1 head + N wrapped.
+const LONG = `LOGSTART_${'x'.repeat(170)}_LOGEND`;
+
+describe('buildBandMeta', () => {
+  it('records one head row per short logical line', () => {
+    const meta = buildBandMeta(['alpha', 'bravo', 'charlie'], 80);
+    expect(meta).toEqual([
+      { logicalText: 'alpha', isHead: true },
+      { logicalText: 'bravo', isHead: true },
+      { logicalText: 'charlie', isHead: true },
+    ]);
+  });
+
+  it('records head + continuation rows for a wide logical line, 1:1 with the physical rows', () => {
+    const width = 120;
+    const physicalCount = hardWrapToWidth(LONG, width).split('\n').length;
+    const meta = buildBandMeta([LONG], width);
+    expect(meta.length).toBe(physicalCount); // 1:1 with what committedBand holds
+    expect(meta[0]).toEqual({ logicalText: LONG, isHead: true });
+    for (let i = 1; i < meta.length; i++) {
+      expect(meta[i]).toEqual({ logicalText: LONG, isHead: false });
+    }
+  });
+
+  it('treats a blank separator line as its own single head row', () => {
+    const meta = buildBandMeta(['body', ''], 80);
+    expect(meta).toEqual([
+      { logicalText: 'body', isHead: true },
+      { logicalText: '', isHead: true },
+    ]);
+  });
+
+  it('stays index-aligned with the physical rows across a mix of wide + short lines', () => {
+    const width = 40;
+    const logical = [LONG, 'short', LONG];
+    const rows = logical.flatMap((l) => hardWrapToWidth(l, width).split('\n'));
+    const meta = buildBandMeta(logical, width);
+    expect(meta.length).toBe(rows.length);
+    // Every head index begins a run whose logicalText matches, and the count of
+    // heads equals the number of logical lines.
+    expect(meta.filter((m) => m.isHead).length).toBe(logical.length);
+  });
+});
+
+describe('scrollbackFlushLines', () => {
+  const width = 120;
+  // A band of [LONG (2 rows @120), 'tail'] → physical rows + aligned meta.
+  const rows = [LONG, 'tail'].flatMap((l) => hardWrapToWidth(l, width).split('\n'));
+  const meta = buildBandMeta([LONG, 'tail'], width);
+
+  it('emits a whole logical line ONCE when all its physical rows are in the prefix', () => {
+    // Flush the whole band: LONG collapses back to one logical line, tail stays 1.
+    const out = scrollbackFlushLines(rows, meta, rows.length);
+    expect(out).toEqual([LONG, 'tail']);
+  });
+
+  it('emits straddler rows VERBATIM when a logical line spans the flush boundary', () => {
+    // Flush only 1 row — the head of LONG, whose 2nd physical row is retained.
+    // Emitting the whole logical line would duplicate the retained tail once it
+    // reflowed, so the in-prefix physical row is emitted verbatim instead.
+    const out = scrollbackFlushLines(rows, meta, 1);
+    expect(out).toEqual([rows[0]]); // the physical head row, NOT the logical LONG
+    expect(out[0]).not.toBe(LONG);
+  });
+
+  it('emits an orphaned continuation row (head already sliced away) verbatim', () => {
+    // Simulate a band whose FIRST row is a continuation (its head was archived
+    // by an earlier flush): meta[0].isHead === false.
+    const orphanRows = rows.slice(1); // [LONG-row1(cont), 'tail']
+    const orphanMeta = meta.slice(1);
+    expect(orphanMeta[0]?.isHead).toBe(false);
+    const out = scrollbackFlushLines(orphanRows, orphanMeta, 1);
+    expect(out).toEqual([orphanRows[0]]); // verbatim continuation fragment
+  });
+
+  it('falls back to verbatim physical rows when meta is missing or short (never loses content)', () => {
+    expect(scrollbackFlushLines(rows, undefined, rows.length)).toEqual(rows);
+    expect(scrollbackFlushLines(rows, meta.slice(0, 1), rows.length)).toEqual(rows);
+  });
+
+  it('accounts for every physical row exactly once across a mixed prefix', () => {
+    // [short, LONG(2 rows), short2]; flush the first 3 rows (short + both LONG
+    // rows) → whole `short` + whole LONG; short2 retained.
+    const logical = ['short', LONG, 'short2'];
+    const r = logical.flatMap((l) => hardWrapToWidth(l, width).split('\n'));
+    const m = buildBandMeta(logical, width);
+    const out = scrollbackFlushLines(r, m, 3);
+    expect(out).toEqual(['short', LONG]);
+  });
+
+  it('clamps count to the row array length', () => {
+    const out = scrollbackFlushLines(rows, meta, 999);
+    expect(out).toEqual([LONG, 'tail']);
+  });
+});
+
+describe('snapFlushCountToLogicalBoundary', () => {
+  const width = 120;
+  const logical = [LONG, 'a', 'b']; // rows: [L0, L1, a, b]  heads at 0,2,3
+  const meta = buildBandMeta(logical, width);
+  const total = meta.length; // 4
+
+  it('snaps a mid-logical-line count DOWN to the previous head (retain the straddler whole)', () => {
+    // count=1 lands inside LONG (rows 0,1); the only head at/below is index 0 → snap to 0.
+    expect(snapFlushCountToLogicalBoundary(meta, 1, total)).toBe(0);
+  });
+
+  it('keeps a count that already sits on a logical boundary', () => {
+    // index 2 is a head ('a') → LONG (2 rows) is whole below it.
+    expect(snapFlushCountToLogicalBoundary(meta, 2, total)).toBe(2);
+    expect(snapFlushCountToLogicalBoundary(meta, 3, total)).toBe(3);
+  });
+
+  it('returns the full total unchanged (whole band is always a clean boundary)', () => {
+    expect(snapFlushCountToLogicalBoundary(meta, total, total)).toBe(total);
+    expect(snapFlushCountToLogicalBoundary(meta, 999, total)).toBe(total);
+  });
+
+  it('returns the raw count when meta is missing/short (verbatim fallback path)', () => {
+    expect(snapFlushCountToLogicalBoundary(undefined, 2, total)).toBe(2);
+    expect(snapFlushCountToLogicalBoundary(meta.slice(0, 1), 2, total)).toBe(2);
+  });
+
+  it('returns 0 for a non-positive count', () => {
+    expect(snapFlushCountToLogicalBoundary(meta, 0, total)).toBe(0);
+    expect(snapFlushCountToLogicalBoundary(meta, -3, total)).toBe(0);
+  });
+});
+
+describe('buildScrollbackArchiveEscape', () => {
+  it('returns empty string for no lines', () => {
+    expect(buildScrollbackArchiveEscape([], 1, 24, 80)).toBe('');
+  });
+
+  it('paints at the floor, flows lines with CRLF, and scrolls the total physical height', () => {
+    const esc = buildScrollbackArchiveEscape(['a', 'b'], 1, 24, 80);
+    // Two 1-row lines → paint at row 1, join with \r\n, then CUP to bottom (24)
+    // and scroll 2 rows.
+    expect(esc).toContain('\x1b[1;1H'); // CUP to the floor
+    expect(esc).toContain('\x1b[2Ka'); // erase + line a
+    expect(esc).toContain('\x1b[2Kb');
+    expect(esc).toContain('\r\n'); // lines flow with CRLF so each starts fresh
+    expect(esc).toContain('\x1b[24;1H'); // CUP to the physical bottom margin
+    expect(esc.endsWith('\n\n')).toBe(true); // scroll 2 physical rows
+  });
+
+  it('scrolls a wide logical line by its WRAPPED physical height, not 1', () => {
+    const width = 120;
+    const h = hardWrapToWidth(LONG, width).split('\n').length; // 2 at 120
+    const esc = buildScrollbackArchiveEscape([LONG], 1, 24, width);
+    // The trailing scroll is `\n` × h.
+    const scrollTail = esc.slice(esc.lastIndexOf('\x1b[24;1H') + '\x1b[24;1H'.length);
+    expect(scrollTail).toBe('\n'.repeat(h));
+    expect(h).toBeGreaterThan(1);
+  });
+
+  it('chunks a block taller than the paint region into multiple paint+scroll passes', () => {
+    // 30 one-row lines into a 24-row terminal with floor 1 → chunkMax=24, so it
+    // splits into 2 chunks (24 + 6) each with its own bottom-CUP + scroll.
+    const lines = Array.from({ length: 30 }, (_, i) => `row${i}`);
+    const esc = buildScrollbackArchiveEscape(lines, 1, 24, 80);
+    const bottomCups = esc.split('\x1b[24;1H').length - 1;
+    expect(bottomCups).toBe(2); // one scroll per chunk
+  });
+});
+
+describe('reflowBandSplit — meta propagation (#540)', () => {
+  it('propagates logicalText through a NARROWING re-wrap and recomputes isHead', () => {
+    // One logical line committed at 120 (2 physical rows), painted (suffix).
+    const width0 = 120;
+    const band0 = hardWrapToWidth(LONG, width0).split('\n');
+    const meta0 = buildBandMeta([LONG], width0);
+    expect(band0.length).toBe(2);
+
+    // Narrow to 68: re-wrap. Physical row count grows; logicalText is preserved
+    // on every sub-row; exactly one head remains.
+    const res = reflowBandSplit(band0, band0.length, 68, meta0);
+    expect(res.rows.length).toBe(res.meta.length); // 1:1 invariant
+    expect(res.meta.every((m) => m.logicalText === LONG)).toBe(true);
+    expect(res.meta.filter((m) => m.isHead).length).toBe(1);
+    expect(res.meta[0]?.isHead).toBe(true);
+    // paintedRows tracks the re-wrapped suffix count (whole band was painted).
+    expect(res.paintedRows).toBe(res.rows.length);
+  });
+
+  it('preserves the pending/painted split point across the re-wrap', () => {
+    // Band = [pendingShort, LONG(painted)]; paintedRows counts LONG's rows only.
+    const width0 = 120;
+    const longRows = hardWrapToWidth(LONG, width0).split('\n');
+    const band0 = ['pendingShort', ...longRows];
+    const meta0 = buildBandMeta(['pendingShort', LONG], width0);
+    const paintedRows0 = longRows.length; // the painted SUFFIX is LONG's rows
+
+    const res = reflowBandSplit(band0, paintedRows0, 68, meta0);
+    // pending prefix is still just the one short line (1 row at any width < it);
+    // painted suffix is LONG re-wrapped at 68.
+    const expectedPaintedRows = hardWrapToWidth(LONG, 68).split('\n').length;
+    expect(res.paintedRows).toBe(expectedPaintedRows);
+    // The pending prefix's provenance is intact.
+    expect(res.meta[0]).toEqual({ logicalText: 'pendingShort', isHead: true });
+  });
+
+  it('falls back to the physical row as its own logicalText when meta is omitted', () => {
+    const band0 = hardWrapToWidth(LONG, 120).split('\n');
+    const res = reflowBandSplit(band0, band0.length, 68); // no meta arg
+    expect(res.rows.length).toBe(res.meta.length);
+    // Each pre-existing physical row is treated as its own logical line: the
+    // fallback records the row text as logicalText and isHead=true per source row.
+    expect(res.meta.filter((m) => m.isHead).length).toBe(band0.length);
+  });
+
+  it('returns empty for an empty band', () => {
+    expect(reflowBandSplit([], 0, 80, [])).toEqual({ rows: [], paintedRows: 0, meta: [] });
+  });
+
+  it('widening keeps the retained logicalText so a later flush can rejoin the line', () => {
+    // Committed narrow (48 → 4 rows), then WIDEN to 110. Re-wrapping physical
+    // rows independently keeps their (stale) break points on screen, but the
+    // retained logicalText is the whole line — which the scrollback flush emits.
+    const band0 = hardWrapToWidth(LONG, 48).split('\n');
+    const meta0 = buildBandMeta([LONG], 48);
+    expect(band0.length).toBe(4);
+    const res = reflowBandSplit(band0, band0.length, 110, meta0);
+    // Whatever the on-screen physical rows become, the logical source is intact
+    // and single, so scrollbackFlushLines(res.rows, res.meta, all) === [LONG].
+    const flushed = scrollbackFlushLines(res.rows, res.meta, res.rows.length);
+    expect(flushed).toEqual([LONG]);
+  });
+});

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -25,6 +25,7 @@ import { SpinnerController } from './input/spinner.js';
 import { CaretBlinkController, DEFAULT_CARET_BLINK_INTERVAL_MS } from './input/caret-blink.js';
 import type { StdinClaimHandle } from './input/stdin-claim.js';
 import {
+  type BandRowMeta,
   type CompositorInputMode,
   type CompositorScrollRegionGuard,
   type KeyInfo,
@@ -343,6 +344,24 @@ export class TerminalCompositor {
   // 1-based screen positions; 0 means "unset". See repositionCommittedBand().
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   committedBand: string[] = [];
+  // #540 axis-2 (retained logical source): per-physical-row provenance, index-
+  // aligned 1:1 with committedBand (committedBandMeta.length === committedBand
+  // .length, always). Each entry is the FULL pre-hard-wrap logical line that
+  // physical row is a fragment of, plus an isHead flag marking a logical line's
+  // first physical row (see BandRowMeta). committedBand stays POST-hard-wrap
+  // physical rows for the LIVE band's one-terminal-row-per-entry math; this
+  // retains the logical form the physical rows cannot reconstruct (a soft-wrap
+  // break and a hard paragraph break are indistinguishable once flattened), so
+  // the three scrollback-flush sites (committed-band-commit band-hold archive,
+  // frame-preserve eviction, lifecycle flushPendingCommittedBand) can emit
+  // LOGICAL lines — which the terminal soft-wraps and reflows cleanly on a
+  // width change — instead of pre-wrapped physical rows that fragment
+  // (docs/tui-resize-reflow.md, the width-resize-fragment-* PTY guards). Kept
+  // in lockstep with committedBand at every mutation: reflow re-derives it,
+  // commit Phase 3 merge/cap slices it in parallel, frame-preserve eviction
+  // slices it in parallel. clearCommittedBand()/resetState() empty it.
+  /** @internal Relaxed from `private` for the committed-band + frame + reflow modules. */
+  committedBandMeta: BandRowMeta[] = [];
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   committedBandTopRow = 0;
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */

--- a/src/cli/terminal-compositor.types.ts
+++ b/src/cli/terminal-compositor.types.ts
@@ -8,6 +8,7 @@
  */
 
 import { palette } from './palette.js';
+import { hardWrapToWidth } from './wrap.js';
 import { displayWidth, truncateDisplayWidth } from './display.js';
 import type { LoadingTip } from './loading-tips.js';
 import type { ImageAttachment } from './input/attachments.js';
@@ -90,6 +91,239 @@ export function formatElapsed(startedAt: number): string {
  */
 export function eraseAndPaintRow(row: number, line?: string): string {
   return `\x1b[${row};1H\x1b[2K${line ?? ''}`;
+}
+
+/**
+ * Per-physical-row provenance for the committed band (#540 axis-2).
+ *
+ * `committedBand` holds POST-hard-wrap PHYSICAL rows — one terminal row per
+ * entry — because the LIVE band's CUP/scroll row math needs exactly one
+ * terminal row per array element (a wide logical line's wrapped tail must not
+ * be "eaten" by the next commit's paint). But the pre-wrap LOGICAL form is not
+ * reconstructible from those physical rows: a soft-wrap break and a hard
+ * paragraph break are indistinguishable once flattened, so joining rows back
+ * would fuse genuinely separate lines and a widen could never re-wrap them.
+ *
+ * We therefore retain the logical source PER PHYSICAL ROW, index-aligned 1:1
+ * with `committedBand` (`committedBandMeta.length === committedBand.length`,
+ * always). `logicalText` is the FULL logical line this physical row is a
+ * fragment of; `isHead` marks the FIRST physical row of that logical line.
+ * The 1:1 alignment makes every band mutation a parallel slice — the cap /
+ * eviction / reflow paths that slice `committedBand` mirror the slice on the
+ * meta with identical index math, so the retention can never desync even when
+ * a slice lands mid-logical-line (the surviving continuation rows keep
+ * `isHead:false`, which the scrollback-flush helper reads to emit them
+ * verbatim rather than re-emitting the whole logical line — see
+ * {@link scrollbackFlushLines}).
+ *
+ * The scrollback-flush sites consult this to emit LOGICAL lines (which the
+ * terminal soft-wraps and can later reflow cleanly on a width change) instead
+ * of the pre-hard-wrapped physical rows (which the terminal can only reflow
+ * per-row → the width-resize fragmentation of #540). The LIVE band keeps using
+ * the physical `committedBand` rows unchanged.
+ */
+export interface BandRowMeta {
+  /** The full logical (pre-hard-wrap) line this physical row is a fragment of. */
+  logicalText: string;
+  /** True iff this is the FIRST physical row of its logical line. */
+  isHead: boolean;
+}
+
+/**
+ * Build the {@link BandRowMeta} array for a list of LOGICAL lines hard-wrapped
+ * at `width` — the inverse-recording of the same
+ * `logicalLines.flatMap((l) => hardWrapToWidth(l, width).split('\n'))` that
+ * produces the physical `committedBand` rows, so the returned meta is
+ * index-aligned 1:1 with those rows. A logical line that fits in `width` is a
+ * single head row; one that overflows contributes a head row + N-1 continuation
+ * rows all carrying the same `logicalText`.
+ */
+export function buildBandMeta(logicalLines: readonly string[], width: number): BandRowMeta[] {
+  const meta: BandRowMeta[] = [];
+  for (const logical of logicalLines) {
+    const physicalCount = hardWrapToWidth(logical, width).split('\n').length;
+    for (let i = 0; i < physicalCount; i++) {
+      meta.push({ logicalText: logical, isHead: i === 0 });
+    }
+  }
+  return meta;
+}
+
+/**
+ * Translate the first `count` PHYSICAL rows of a band (the prefix being
+ * scrolled off into native scrollback) into the lines to WRITE to scrollback,
+ * emitting LOGICAL lines where a whole logical line lies within the prefix and
+ * PHYSICAL rows verbatim where a logical line straddles the flush boundary
+ * (#540 axis-2).
+ *
+ * Why: writing a raw logical line to the terminal with autowrap ON makes the
+ * terminal own the wrapping, so its continuation rows are soft-wrap
+ * continuations (isWrapped) that reflow cleanly on a later resize. Writing the
+ * pre-hard-wrapped physical rows instead lands N hard-newline rows the terminal
+ * can only reflow independently — the fragmentation bug.
+ *
+ * The straddle rule prevents both DUPLICATION and LOSS: if only some of a
+ * logical line's physical rows are in the flush prefix (the rest stay on
+ * screen), emitting the whole logical line would duplicate the on-screen tail
+ * in scrollback once it reflowed to full height. So a straddling line's
+ * in-prefix rows are emitted verbatim as physical rows (they stay
+ * hard-newlined — acceptable, since the surviving on-screen tail can never
+ * rejoin them anyway). A prefix whose first row is a continuation (`isHead:
+ * false` at index 0 — a logical line whose head was sliced away by an earlier
+ * eviction/cap) is likewise emitted verbatim. Every physical row in
+ * `[0, count)` is accounted for exactly once, so the physical-row COUNT the
+ * caller scrolls is unchanged whether a run emits as one logical line or as
+ * verbatim rows — the terminal re-derives the same number of physical rows from
+ * the logical line via its own autowrap (hardWrapToWidth is defined to match
+ * the terminal's char-level wrap).
+ *
+ * `meta` must be index-aligned 1:1 with `rows` (see {@link BandRowMeta}).
+ * Falls back to verbatim physical rows if `meta` is missing/short (defensive:
+ * never lose content to a meta desync).
+ */
+export function scrollbackFlushLines(
+  rows: readonly string[],
+  meta: readonly BandRowMeta[] | undefined,
+  count: number,
+): string[] {
+  const end = Math.max(0, Math.min(count, rows.length));
+  if (!meta || meta.length < rows.length) {
+    // No reliable provenance — emit the physical rows verbatim (pre-fix
+    // behavior); correctness (content present) over rejoinability.
+    return rows.slice(0, end);
+  }
+  const out: string[] = [];
+  let i = 0;
+  while (i < end) {
+    if (!meta[i]?.isHead) {
+      // A continuation row whose head is not in this prefix (sliced away
+      // earlier): emit verbatim — its logical line is already fragmented.
+      out.push(rows[i] ?? '');
+      i += 1;
+      continue;
+    }
+    // A logical-line head: find the extent of this logical line (until the
+    // next head or the end of the array — NOT bounded by `count`, so we can
+    // detect a straddle past the flush boundary).
+    let j = i + 1;
+    while (j < rows.length && !meta[j]?.isHead) j += 1;
+    if (j <= end) {
+      // The whole logical line is within the flush prefix → emit it ONCE as a
+      // logical line (the terminal soft-wraps it; reflows cleanly on resize).
+      out.push(meta[i]!.logicalText);
+    } else {
+      // Straddle: only rows [i, end) of this logical line are being flushed;
+      // its tail stays on screen. Emit the in-prefix physical rows verbatim so
+      // the on-screen tail is never duplicated in scrollback.
+      for (let k = i; k < end; k++) out.push(rows[k] ?? '');
+    }
+    i = j;
+  }
+  return out;
+}
+
+/**
+ * Snap a physical-row flush count DOWN to the nearest LOGICAL-line boundary
+ * (#540 axis-2) so a scrollback archive never splits one logical line across
+ * two archive events — which is what re-introduces the fragmentation even with
+ * logical-line emission (a line archived one physical row at a time is emitted
+ * verbatim each time, never as a whole soft-wrappable line).
+ *
+ * Given `meta` (per-physical-row provenance) and a desired `count` of leading
+ * physical rows to flush, returns the largest `n <= count` such that either
+ * `n === 0`, `n === meta.length`, or `meta[n]` is a logical-line head (i.e. the
+ * cut falls exactly between two logical lines, never mid-line). The caller
+ * archives `[0, n)` as whole logical lines and RETAINS the straddling line (and
+ * everything after it) in the band model until a later flush covers all of its
+ * rows. Returns `count` unchanged when `meta` is missing/short (the verbatim
+ * fallback in {@link scrollbackFlushLines} then applies).
+ */
+export function snapFlushCountToLogicalBoundary(
+  meta: readonly BandRowMeta[] | undefined,
+  count: number,
+  total: number,
+): number {
+  const c = Math.max(0, Math.min(count, total));
+  if (!meta || meta.length < total) return c;
+  if (c >= total) return total; // whole band flushes — always a clean boundary
+  // Walk DOWN from c to the nearest logical-line head (a clean cut point).
+  for (let n = c; n > 0; n--) {
+    if (meta[n]?.isHead) return n;
+  }
+  return 0;
+}
+
+/**
+ * Build the escape string that archives `lines` to native scrollback as
+ * SOFT-WRAPPABLE content (#540 axis-2).
+ *
+ * Mechanism (verified against @xterm/headless + real pty): paint the lines at
+ * the anchor floor as a normal top-of-screen text stream — each line CUP-less
+ * after the first, separated by `\r\n`, with autowrap ON so the terminal wraps
+ * an over-wide LOGICAL line itself (its continuation rows carry the terminal's
+ * soft-wrap flag → reflow-clean on a later resize) — then CUP to the physical
+ * bottom margin and emit `\n` × (total physical rows) to scroll the whole
+ * painted block up and OFF the top into native scrollback. Writing at the
+ * bottom-margin-only (the naive approach) leaves the content in the VIEWPORT,
+ * never scrollback; writing at the top then scrolling the exact painted height
+ * is what carries it into history. A line that fits the width is one physical
+ * row and contributes one scroll — byte-equivalent outcome to the pre-#540
+ * physical-row archive; a wide line contributes its wrapped height and rejoins
+ * cleanly.
+ *
+ * Chunked by the paintable height (`rows - anchorFloor + 1`) so a block taller
+ * than the terminal still archives every row: each chunk is painted top-aligned
+ * and scrolled by its own physical height before the next chunk, so the paint
+ * never itself overflows the bottom margin and auto-scrolls (which would
+ * double-count). `width` is needed to compute each line's physical (wrapped)
+ * height; it MUST equal the terminal's current column count so hardWrapToWidth's
+ * split matches what the terminal's autowrap will do.
+ *
+ * MUST run with autowrap ENABLED (the default) and inside the caller's
+ * full-screen scroll region — the opposite of the on-screen band paint, which
+ * runs inside `withAutowrapDisabled`. Autowrap is load-bearing HERE: it is what
+ * makes the terminal, not the app, own the wrap so scrollback can later reflow.
+ *
+ * Returns '' for an empty list (caller writes nothing).
+ */
+export function buildScrollbackArchiveEscape(
+  lines: readonly string[],
+  anchorFloor: number,
+  bottomRow: number,
+  width: number,
+): string {
+  if (lines.length === 0) return '';
+  const floor = Math.max(1, anchorFloor);
+  const bottom = Math.max(1, bottomRow);
+  const chunkMax = Math.max(1, bottom - floor + 1);
+  const physicalHeight = (line: string): number =>
+    Math.max(1, hardWrapToWidth(line, width).split('\n').length);
+  let out = '';
+  let chunk: string[] = [];
+  let chunkRows = 0;
+  const flushChunk = (): void => {
+    if (chunk.length === 0) return;
+    // Paint the chunk top-aligned at the floor, flowing with \r\n so each
+    // logical line starts on a fresh row and autowrap owns intra-line wrapping.
+    out += `\x1b[${floor};1H`;
+    out += chunk.map((l) => `\x1b[2K${l}`).join('\r\n');
+    // Scroll the exact painted physical height off the top into scrollback.
+    out += `\x1b[${bottom};1H${'\n'.repeat(chunkRows)}`;
+    chunk = [];
+    chunkRows = 0;
+  };
+  for (const line of lines) {
+    const h = physicalHeight(line);
+    // A single line taller than the whole paint region: give it its own chunk
+    // (it will scroll fully; the terminal handles the intra-paint autowrap
+    // scroll for the overflow beyond the region, and the explicit scroll count
+    // still equals its physical height).
+    if (chunkRows > 0 && chunkRows + h > chunkMax) flushChunk();
+    chunk.push(line);
+    chunkRows += h;
+  }
+  flushChunk();
+  return out;
 }
 
 /**

--- a/tests/pty/compositor-scrollback.pty.test.ts
+++ b/tests/pty/compositor-scrollback.pty.test.ts
@@ -82,6 +82,37 @@ function assertExpectations(res: PtyRunResult, exp: PtyExpect): void {
       ).toBeLessThanOrEqual(exp.maxViewportBlankRun);
     }
   }
+  if (exp.logicalSpan) {
+    const { from, to, minNonWrappedRows, maxNonWrappedRows, minSpanRows } = exp.logicalSpan;
+    const fromIdx = firstIndex(res.lines, from);
+    expect(fromIdx, `logicalSpan.from "${from}" not found:\n${dump}`).toBeGreaterThanOrEqual(0);
+    const toIdx = res.lines.findIndex((l, i) => i >= fromIdx && l.includes(to));
+    expect(toIdx, `logicalSpan.to "${to}" not found at/after "${from}":\n${dump}`).toBeGreaterThanOrEqual(fromIdx);
+    const spanRows = toIdx - fromIdx + 1;
+    if (minSpanRows !== undefined) {
+      expect(
+        spanRows,
+        `logical span ["${from}".."${to}"] should occupy >=${minSpanRows} rows (proves the resize took effect) but had ${spanRows}:\n${dump}`,
+      ).toBeGreaterThanOrEqual(minSpanRows);
+    }
+    // Count rows in the [from..to] span that are NOT soft-wrap continuations.
+    // One = the terminal reflowed a single logical line cleanly (tmux -J rejoins
+    // it); ≥2 = interior app hard-newlines fragmented it (the axis-2 bug).
+    let nonWrapped = 0;
+    for (let i = fromIdx; i <= toIdx; i++) if (!(res.wrapped[i] ?? false)) nonWrapped += 1;
+    if (minNonWrappedRows !== undefined) {
+      expect(
+        nonWrapped,
+        `logical line ["${from}".."${to}"] should have >=${minNonWrappedRows} non-wrapped (hard-break) rows — the axis-2 fragmentation RED guard (#540); found ${nonWrapped}. If this dropped to 1 the flush now emits logical lines: flip minNonWrappedRows -> maxNonWrappedRows: 1.\n${dump}`,
+      ).toBeGreaterThanOrEqual(minNonWrappedRows);
+    }
+    if (maxNonWrappedRows !== undefined) {
+      expect(
+        nonWrapped,
+        `logical line ["${from}".."${to}"] should rejoin to <=${maxNonWrappedRows} non-wrapped row(s) but had ${nonWrapped}:\n${dump}`,
+      ).toBeLessThanOrEqual(maxNonWrappedRows);
+    }
+  }
 }
 
 describe('TerminalCompositor scrollback over a real pty (issue #541)', () => {

--- a/tests/pty/constants.ts
+++ b/tests/pty/constants.ts
@@ -11,3 +11,53 @@
  * bytes BEFORE this marker, so it never perturbs the geometry under test.
  */
 export const PTY_DONE_SENTINEL = '\x1b_AFK_PTY_DONE\x1b\\';
+
+// Invariant (resize handshake — the parent owns the winsize, the driver owns
+// the timing): a scenario that wants a MID-STREAM width resize emits this APC
+// marker at the exact point it wants the geometry changed, carrying the target
+// `<cols>x<rows>`. Like the DONE sentinel it is an APC string, so xterm emits no
+// glyphs and no scroll for it. The parent watches the byte stream, and on the
+// FIRST complete marker (a) calls node-pty `child.resize(cols, rows)` — which
+// SIGWINCHes the driver so its own `process.stdout` 'resize' fires and the
+// compositor re-renders — and (b) records the marker's byte OFFSET so replay
+// can split the captured stream into a pre-resize half (written at the OLD
+// geometry) and a post-resize half (written after the emulator is resized).
+// Faithful reflow requires constructing the emulator at the OLD width, writing
+// the pre-bytes, calling emulator.resize(), THEN writing the post-bytes — a
+// terminal reflows scrollback on resize, so building at the new width and
+// writing old-width bytes would NOT model the real width-change under test.
+const PTY_RESIZE_PREFIX = '\x1b_AFK_PTY_RESIZE:';
+const PTY_RESIZE_SUFFIX = '\x1b\\';
+
+/** Build the resize-handshake marker for a `<cols>x<rows>` target geometry. */
+export function buildResizeMarker(cols: number, rows: number): string {
+  return `${PTY_RESIZE_PREFIX}${cols}x${rows}${PTY_RESIZE_SUFFIX}`;
+}
+
+/** A located resize marker: its target geometry and byte span within the stream. */
+export interface ResizeMarker {
+  cols: number;
+  rows: number;
+  /** Byte offset of the marker's first char (split point for pre-resize bytes). */
+  start: number;
+  /** Byte offset one past the marker (split point for post-resize bytes). */
+  end: number;
+}
+
+/**
+ * Find the FIRST complete resize marker in `buf`, or null if none has fully
+ * arrived yet (the marker may be split across pty read chunks — the caller
+ * scans the ACCUMULATED buffer each chunk, so a partial marker simply resolves
+ * on a later chunk). Malformed payloads (no `<n>x<n>`) are treated as absent.
+ */
+export function findResizeMarker(buf: string): ResizeMarker | null {
+  const start = buf.indexOf(PTY_RESIZE_PREFIX);
+  if (start < 0) return null;
+  const payloadStart = start + PTY_RESIZE_PREFIX.length;
+  const suffixStart = buf.indexOf(PTY_RESIZE_SUFFIX, payloadStart);
+  if (suffixStart < 0) return null; // suffix not arrived yet — try again next chunk
+  const payload = buf.slice(payloadStart, suffixStart);
+  const m = /^(\d+)x(\d+)$/.exec(payload);
+  if (!m || m[1] === undefined || m[2] === undefined) return null;
+  return { cols: Number(m[1]), rows: Number(m[2]), start, end: suffixStart + PTY_RESIZE_SUFFIX.length };
+}

--- a/tests/pty/harness.ts
+++ b/tests/pty/harness.ts
@@ -22,7 +22,7 @@ import { createRequire } from 'node:module';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { existsSync, chmodSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { PTY_DONE_SENTINEL } from './constants.js';
+import { PTY_DONE_SENTINEL, findResizeMarker, type ResizeMarker } from './constants.js';
 
 const require = createRequire(import.meta.url);
 const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
@@ -32,6 +32,8 @@ const DRIVER_PATH = fileURLToPath(new URL('./driver.ts', import.meta.url));
 interface IPtyProcess {
   onData(cb: (data: string) => void): void;
   onExit(cb: (e: { exitCode: number; signal?: number }) => void): void;
+  /** Change the pty winsize — SIGWINCHes the child (drives the resize handshake). */
+  resize(cols: number, rows: number): void;
   kill(signal?: string): void;
 }
 interface NodePtyModule {
@@ -95,6 +97,16 @@ export interface PtyRunResult {
   exitCode: number | 'timeout';
   /** All emulator buffer lines, top (oldest scrollback) → bottom. */
   lines: string[];
+  /**
+   * Per-line soft-wrap flag, index-aligned with {@link lines}: true when the
+   * emulator marked the row a soft-wrap CONTINUATION of the row above (xterm
+   * `IBufferLine.isWrapped`). A logical line the terminal reflowed cleanly is
+   * ONE non-wrapped head row followed by wrapped continuations — exactly what
+   * `tmux capture-pane -J` rejoins. An app hard-newline is never `isWrapped`,
+   * so interior non-wrapped rows inside one logical line are the width-resize
+   * fragmentation signature (issue #540 axis-2).
+   */
+  wrapped: boolean[];
   /** First visible row index — lines[0..baseY) are scrollback. */
   baseY: number;
   /** Scrollback region (rows above the viewport), blank rows preserved. */
@@ -131,8 +143,20 @@ export async function runScenarioInPty(opts: RunScenarioOpts): Promise<PtyRunRes
 
   let buf = '';
   let captured: string | null = null;
+  // The FIRST resize marker seen in the stream: on detection we SIGWINCH the
+  // child (child.resize) so the driver's own 'resize' fires and the compositor
+  // re-renders, and we keep the marker's byte span so the emulator replay below
+  // can split the captured stream into old-width / new-width halves.
+  let resizeAt: ResizeMarker | null = null;
   child.onData((d) => {
     buf += d;
+    if (resizeAt === null) {
+      const marker = findResizeMarker(buf);
+      if (marker) {
+        resizeAt = marker;
+        try { child.resize(marker.cols, marker.rows); } catch { /* child already gone */ }
+      }
+    }
     if (captured === null) {
       const idx = buf.indexOf(PTY_DONE_SENTINEL);
       if (idx >= 0) captured = buf.slice(0, idx);
@@ -159,20 +183,34 @@ export async function runScenarioInPty(opts: RunScenarioOpts): Promise<PtyRunRes
   const raw = captured ?? buf;
 
   // Real pty output already carries CRLF (kernel ONLCR), so do NOT set
-  // convertEol — that would double-translate and desync every row.
+  // convertEol — that would double-translate and desync every row. The emulator
+  // is constructed at the scenario's ORIGINAL geometry; a mid-stream resize is
+  // modelled by writing pre-resize bytes, calling term.resize() (which reflows
+  // the buffer exactly as a real terminal does), then writing post-resize bytes.
   const term = new (Terminal as new (o: Record<string, unknown>) => {
     write(d: string, cb: () => void): void;
-    buffer: { active: { baseY: number; length: number; getLine(i: number): { translateToString(trim: boolean): string } | undefined } };
+    resize(cols: number, rows: number): void;
+    buffer: { active: { baseY: number; length: number; getLine(i: number): { translateToString(trim: boolean): string; isWrapped: boolean } | undefined } };
     dispose(): void;
   })({ cols, rows, scrollback: 1000, allowProposedApi: true });
-  await new Promise<void>((r) => term.write(raw, r));
+  if (resizeAt) {
+    const pre = raw.slice(0, resizeAt.start);
+    const post = raw.slice(resizeAt.end); // marker bytes themselves are dropped
+    await new Promise<void>((r) => term.write(pre, r));
+    term.resize(resizeAt.cols, resizeAt.rows);
+    await new Promise<void>((r) => term.write(post, r));
+  } else {
+    await new Promise<void>((r) => term.write(raw, r));
+  }
 
   const b = term.buffer.active;
   const baseY = b.baseY;
   const lines: string[] = [];
+  const wrapped: boolean[] = [];
   for (let i = 0; i < b.length; i++) {
     const l = b.getLine(i);
     lines.push(l ? l.translateToString(true).replace(/\s+$/, '') : '');
+    wrapped.push(l ? l.isWrapped : false);
   }
   term.dispose();
 
@@ -184,12 +222,15 @@ export async function runScenarioInPty(opts: RunScenarioOpts): Promise<PtyRunRes
     sawSentinel,
     exitCode,
     lines,
+    wrapped,
     baseY,
     scrollback,
     viewport,
     dump(): string {
+      // '↩' marks a soft-wrap continuation row (isWrapped) so a fragmentation
+      // failure message shows at a glance where hard breaks fall.
       return lines
-        .map((l, i) => `[${i < baseY ? 'SB' : 'VP'} ${String(i).padStart(3)}] ${JSON.stringify(l)}`)
+        .map((l, i) => `[${i < baseY ? 'SB' : 'VP'} ${String(i).padStart(3)}]${wrapped[i] ? '↩' : ' '}${JSON.stringify(l)}`)
         .join('\n');
     },
   };

--- a/tests/pty/scenarios.ts
+++ b/tests/pty/scenarios.ts
@@ -451,22 +451,25 @@ export const SCENARIOS: Record<string, PtyScenario> = {
   },
 
   // ─────────────────────────────────────────────────────────────────────────
-  // width-resize-fragment-narrow (#540 axis-2 · RED GUARD): a long LOGICAL line
-  // committed WIDE (100 cols) is hard-wrapped to physical rows at commit time
-  // (terminal-compositor.committed-band-commit.ts:165) and flushed to native
-  // scrollback as hard-newline rows. On a NARROWER resize the terminal reflows
-  // each hard row independently, so the one logical line shows ≥2 non-wrapped
-  // (isWrapped=false) rows in its span — it is NOT `tmux -J`-rejoinable. This is
-  // the user's screenshot. It is GREEN NOW (documents the bug); when PR 2 (#540
-  // Stage 3 logical flush) makes the flush emit logical lines, the count drops
-  // to 1 and THIS ASSERTION WILL FAIL — the signal to flip minNonWrappedRows →
-  // maxNonWrappedRows: 1 and retire this as the GREEN regression guard.
+  // width-resize-fragment-narrow (#540 axis-2 · GREEN regression guard): a long
+  // LOGICAL line committed WIDE (120 cols) is hard-wrapped to physical rows for
+  // the LIVE band's row math (terminal-compositor.committed-band-commit.ts:172),
+  // but PR 2 (#540 Stage 3 logical flush) archives it to native scrollback as a
+  // single SOFT-WRAPPABLE logical line (retained via committedBandMeta and
+  // emitted by buildScrollbackArchiveEscape at the band-hold archive site). On a
+  // NARROWER resize the terminal reflows that one logical line cleanly, so its
+  // span shows exactly ONE non-wrapped (isWrapped=false) head row — it IS
+  // `tmux -J`-rejoinable. This was RED-first (asserted minNonWrappedRows: 2, the
+  // fragmentation bug from the user's screenshot); the src change made scrollback
+  // hold logical lines, so it now asserts the FIXED rejoined property
+  // (maxNonWrappedRows: 1). A regression that reverts to physical-row flushing
+  // re-fragments the line and fails here.
   // ─────────────────────────────────────────────────────────────────────────
   'width-resize-fragment-narrow': {
-    description: 'wide-committed logical line in scrollback fragments on a NARROWER resize (RED guard, #540 axis-2)',
+    description: 'wide-committed logical line rejoins cleanly in scrollback on a NARROWER resize (GREEN guard, #540 axis-2)',
     cols: 120,
     rows: 24,
-    ref: '#540 axis-2 · terminal-compositor.committed-band-commit.ts:165',
+    ref: '#540 axis-2 · committed-band-commit.ts band-hold archive (logical flush)',
     async drive(ctx): Promise<void> {
       const { stdout, stdin } = ctx;
       const statusLine = wireProductionFooter(stdout, 'M');
@@ -492,25 +495,28 @@ export const SCENARIOS: Record<string, PtyScenario> = {
     expect: {
       inScrollback: ['LOGSTART'], // precondition: the long line scrolled off screen
       // minSpanRows:3 PROVES the narrow fired (the line is 2 rows at 120, 3 at
-      // 68) and is stable across PR 2; minNonWrappedRows:2 is the RED flip signal.
-      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', minNonWrappedRows: 2, minSpanRows: 3 },
+      // 68) and is stable across PR 2; maxNonWrappedRows:1 asserts the FIXED
+      // rejoined property (was minNonWrappedRows:2 pre-fix — the RED guard).
+      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', maxNonWrappedRows: 1, minSpanRows: 3 },
     },
   },
 
   // ─────────────────────────────────────────────────────────────────────────
-  // width-resize-fragment-widen (#540 axis-2 · RED GUARD): the widen twin. A
-  // long logical line committed NARROW (50 cols) hard-wraps to several physical
-  // rows and flushes to scrollback. On a WIDER resize the terminal cannot rejoin
-  // app hard-newlines, so the rows stay ragged/short — ≥2 non-wrapped rows in
-  // the span (each afk row is ≤50 ≤100 so none even soft-wraps). GREEN NOW; flips
-  // to FAIL when PR 2 emits one logical line (which the widen reflows to fewer
-  // rows with a single non-wrapped head). See the narrow twin's note.
+  // width-resize-fragment-widen (#540 axis-2 · GREEN regression guard): the
+  // widen twin. A long logical line committed NARROW (48 cols) hard-wraps to
+  // several physical rows for the live band, but PR 2 archives it to scrollback
+  // as a single SOFT-WRAPPABLE logical line. On a WIDER resize the terminal
+  // reflows that one logical line to fewer rows with a single non-wrapped head —
+  // rejoinable. This was RED-first (asserted minNonWrappedRows: 2: pre-fix the
+  // terminal could not rejoin app hard-newlines, leaving ≥2 ragged rows); the
+  // src change made scrollback hold logical lines, so it now asserts the FIXED
+  // rejoined property (maxNonWrappedRows: 1). See the narrow twin's note.
   // ─────────────────────────────────────────────────────────────────────────
   'width-resize-fragment-widen': {
-    description: 'narrow-committed logical line in scrollback stays ragged on a WIDER resize (RED guard, #540 axis-2)',
+    description: 'narrow-committed logical line rejoins cleanly in scrollback on a WIDER resize (GREEN guard, #540 axis-2)',
     cols: 48,
     rows: 24,
-    ref: '#540 axis-2 · terminal-compositor.committed-band-commit.ts:165',
+    ref: '#540 axis-2 · committed-band-commit.ts band-hold archive (logical flush)',
     async drive(ctx): Promise<void> {
       const { stdout, stdin } = ctx;
       const statusLine = wireProductionFooter(stdout, 'M');
@@ -533,11 +539,12 @@ export const SCENARIOS: Record<string, PtyScenario> = {
     },
     expect: {
       inScrollback: ['LOGSTART'],
-      // minNonWrappedRows:2 is the RED flip signal (4 ragged rows now → 1 after
-      // PR 2 rejoins the logical line). The resize MECHANISM is certified by the
-      // sanity scenario; a widen cannot prove itself via row count (it is
-      // unchanged pre-fix), so no minSpanRows here.
-      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', minNonWrappedRows: 2 },
+      // maxNonWrappedRows:1 asserts the FIXED rejoined property (was
+      // minNonWrappedRows:2 pre-fix — 4 ragged rows → 1 non-wrapped head after
+      // the logical-line flush). The resize MECHANISM is certified by the sanity
+      // scenario; a widen cannot prove itself via row count (a rejoined line
+      // occupies FEWER rows), so no minSpanRows here.
+      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', maxNonWrappedRows: 1 },
     },
   },
 };

--- a/tests/pty/scenarios.ts
+++ b/tests/pty/scenarios.ts
@@ -24,6 +24,7 @@ import { LoopStageBar } from '../../src/cli/commands/interactive/loop-stage.js';
 import { renderMarkdownToTerminal } from '../../src/cli/formatter.js';
 import { formatSubmittedEcho } from '../../src/cli/input/echo.js';
 import { commitBlockAbove } from '../../src/cli/_lib/commit-block.js';
+import { buildResizeMarker } from './constants.js';
 
 /** Runtime handed to a scenario's drive() from inside the pty child. */
 export interface PtyDriveCtx {
@@ -65,6 +66,20 @@ export interface PtyExpect {
    * strictly above the first row containing `b` across the whole buffer.
    */
   order?: [string, string][];
+  /**
+   * Soft-wrap rejoinability of ONE logical line (issue #540 axis-2). The parent
+   * takes the buffer span from the first row containing `from` to the first row
+   * at/after it containing `to`, and counts rows that are NOT soft-wrap
+   * continuations (emulator isWrapped=false). A logical line the terminal
+   * reflowed cleanly has exactly ONE such row (its head) → `tmux -J` rejoins it;
+   * an app-hard-wrapped line flushed to scrollback shows interior non-wrapped
+   * rows. `maxNonWrappedRows` asserts the rejoined property (1 = clean);
+   * `minNonWrappedRows` asserts the fragmented property (2+ = the axis-2 bug).
+   * `minSpanRows` asserts the span occupies >= N rows — used to PROVE a resize
+   * actually took effect (e.g. a line that is 1 row wide but must become 2 rows
+   * once the pane narrows), so a silently no-op'd resize handshake fails loudly.
+   */
+  logicalSpan?: { from: string; to: string; maxNonWrappedRows?: number; minNonWrappedRows?: number; minSpanRows?: number };
 }
 
 export interface PtyScenario {
@@ -81,6 +96,35 @@ export interface PtyScenario {
 
 /** Let the frame's async spinner/flush settle before the next step. */
 const settle = (ms = 40): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Request a mid-scenario width resize from INSIDE the pty child. Emits the
+ * resize-handshake marker (which the parent watches for → calls node-pty
+ * child.resize → SIGWINCH), then waits for this process's OWN 'resize' event
+ * (how the driver learns the new winsize landed) before returning, so the
+ * caller can repaint at the new geometry. A 2s timeout guards against a parent
+ * that never resizes (e.g. a non-resize run) so drive() can never hang.
+ */
+async function requestResize(ctx: PtyDriveCtx, cols: number, rows: number): Promise<void> {
+  const { stdout } = ctx;
+  const landed = new Promise<void>((resolve) => {
+    let done = false;
+    const finish = (): void => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      stdout.removeListener('resize', finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, 2000);
+    stdout.once('resize', finish);
+  });
+  stdout.write(buildResizeMarker(cols, rows));
+  await landed;
+  // Give the compositor's own SIGWINCH handler a beat to re-render at the new
+  // width before the caller repaints / the driver emits the DONE sentinel.
+  await settle(60);
+}
 
 /** Cast to reach the compositor's internal repaint() (as the unit tests do). */
 type Repaintable = { repaint(): void };
@@ -362,6 +406,138 @@ export const SCENARIOS: Record<string, PtyScenario> = {
         ['india', '[image attached]'],
         ['[image attached]', 'RESPONSE_OK'],
       ],
+    },
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // width-resize-reflow-sanity: HARNESS SELF-CHECK for the resize handshake
+  // (#541 extension). A SHORT committed line (fits at both widths → always one
+  // row) scrolls into scrollback, then the pane WIDENS mid-scenario. It must
+  // survive the resize as exactly one rejoinable row. This is GREEN before AND
+  // after the axis-2 fix — it certifies the resize marker → child.resize →
+  // emulator.resize replay path moves content faithfully, so a broken handshake
+  // fails HERE (loudly) rather than silently masking the RED guards below.
+  // ─────────────────────────────────────────────────────────────────────────
+  'width-resize-reflow-sanity': {
+    description: 'harness resize handshake: a scrolled-off line that fits wide re-wraps to 2 rows when narrowed',
+    cols: 80,
+    rows: 24,
+    ref: '#541 resize-handshake self-check',
+    async drive(ctx): Promise<void> {
+      const { stdout, stdin } = ctx;
+      const statusLine = wireProductionFooter(stdout, 'M');
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: () => {}, scrollRegion: statusLine, anchorRow: 1 });
+      await c.arm();
+      const ix = c as unknown as Repaintable;
+      c.setSpinner({ enabled: true });
+      const overlay = Array.from({ length: 12 }, (_, i) => `thinking ${i}`).join('\n');
+      // ~62 cols: ONE row at 80 (fits, so afk stores it un-hard-wrapped — this
+      // property is stable across PR 2), but must soft-wrap to 2 rows at 40.
+      c.setOverlay(overlay); c.commitAbove(`SANITYSTART_${'y'.repeat(40)}_SANITYEND\n`);
+      for (let k = 0; k < 24; k++) { c.setOverlay(overlay); c.commitAbove(`PAD_${String(k).padStart(2, '0')}\n`); }
+      c.setOverlay(''); ix.repaint(); ix.repaint();
+      await settle();
+      await requestResize(ctx, 40, 24); // NARROW 80 → 40
+      ix.repaint(); ix.repaint();
+      await settle();
+    },
+    expect: {
+      inScrollback: ['SANITYSTART'], // precondition: the line scrolled off screen
+      // maxNonWrappedRows:1 = the terminal cleanly soft-wrapped it (rejoinable);
+      // minSpanRows:2 = it actually re-wrapped, PROVING child.resize fired (a
+      // no-op'd resize would leave it 1 row at width 80 and fail here).
+      logicalSpan: { from: 'SANITYSTART', to: 'SANITYEND', maxNonWrappedRows: 1, minSpanRows: 2 },
+    },
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // width-resize-fragment-narrow (#540 axis-2 · RED GUARD): a long LOGICAL line
+  // committed WIDE (100 cols) is hard-wrapped to physical rows at commit time
+  // (terminal-compositor.committed-band-commit.ts:165) and flushed to native
+  // scrollback as hard-newline rows. On a NARROWER resize the terminal reflows
+  // each hard row independently, so the one logical line shows ≥2 non-wrapped
+  // (isWrapped=false) rows in its span — it is NOT `tmux -J`-rejoinable. This is
+  // the user's screenshot. It is GREEN NOW (documents the bug); when PR 2 (#540
+  // Stage 3 logical flush) makes the flush emit logical lines, the count drops
+  // to 1 and THIS ASSERTION WILL FAIL — the signal to flip minNonWrappedRows →
+  // maxNonWrappedRows: 1 and retire this as the GREEN regression guard.
+  // ─────────────────────────────────────────────────────────────────────────
+  'width-resize-fragment-narrow': {
+    description: 'wide-committed logical line in scrollback fragments on a NARROWER resize (RED guard, #540 axis-2)',
+    cols: 120,
+    rows: 24,
+    ref: '#540 axis-2 · terminal-compositor.committed-band-commit.ts:165',
+    async drive(ctx): Promise<void> {
+      const { stdout, stdin } = ctx;
+      const statusLine = wireProductionFooter(stdout, 'M');
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: () => {}, scrollRegion: statusLine, anchorRow: 1 });
+      await c.arm();
+      const ix = c as unknown as Repaintable;
+      c.setSpinner({ enabled: true });
+      const overlay = Array.from({ length: 12 }, (_, i) => `thinking ${i} keeping the frame tall`).join('\n');
+      // One long logical line (186 cols, no interior break points) → hard-wraps
+      // to 2 physical rows at 120 cols ([120,66]); committed first so it
+      // overflows to scrollback under the tall overlay. Target width 68 is NOT a
+      // divisor of 120, so the char-100 hard break lands mid-wrap → a visibly
+      // ragged short row, exactly the user's screenshot.
+      const longLine = `LOGSTART_${'x'.repeat(170)}_LOGEND`;
+      c.setOverlay(overlay); c.commitAbove(longLine + '\n');
+      for (let k = 0; k < 24; k++) { c.setOverlay(overlay); c.commitAbove(`FILLER_${String(k).padStart(2, '0')}\n`); }
+      c.setOverlay(''); ix.repaint(); ix.repaint();
+      await settle();
+      await requestResize(ctx, 68, 24); // NARROW 120 → 68 (non-divisor → ragged)
+      ix.repaint(); ix.repaint();
+      await settle();
+    },
+    expect: {
+      inScrollback: ['LOGSTART'], // precondition: the long line scrolled off screen
+      // minSpanRows:3 PROVES the narrow fired (the line is 2 rows at 120, 3 at
+      // 68) and is stable across PR 2; minNonWrappedRows:2 is the RED flip signal.
+      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', minNonWrappedRows: 2, minSpanRows: 3 },
+    },
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // width-resize-fragment-widen (#540 axis-2 · RED GUARD): the widen twin. A
+  // long logical line committed NARROW (50 cols) hard-wraps to several physical
+  // rows and flushes to scrollback. On a WIDER resize the terminal cannot rejoin
+  // app hard-newlines, so the rows stay ragged/short — ≥2 non-wrapped rows in
+  // the span (each afk row is ≤50 ≤100 so none even soft-wraps). GREEN NOW; flips
+  // to FAIL when PR 2 emits one logical line (which the widen reflows to fewer
+  // rows with a single non-wrapped head). See the narrow twin's note.
+  // ─────────────────────────────────────────────────────────────────────────
+  'width-resize-fragment-widen': {
+    description: 'narrow-committed logical line in scrollback stays ragged on a WIDER resize (RED guard, #540 axis-2)',
+    cols: 48,
+    rows: 24,
+    ref: '#540 axis-2 · terminal-compositor.committed-band-commit.ts:165',
+    async drive(ctx): Promise<void> {
+      const { stdout, stdin } = ctx;
+      const statusLine = wireProductionFooter(stdout, 'M');
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: () => {}, scrollRegion: statusLine, anchorRow: 1 });
+      await c.arm();
+      const ix = c as unknown as Repaintable;
+      c.setSpinner({ enabled: true });
+      const overlay = Array.from({ length: 12 }, (_, i) => `thinking ${i} tall`).join('\n');
+      // 186 cols → hard-wraps to 4 physical rows at 48 cols. On a WIDEN to 110
+      // those 4 rows stay separate (each <=48 fits at 110, so the terminal never
+      // rejoins the app hard-newlines) → 4 ragged non-wrapped rows.
+      const longLine = `LOGSTART_${'x'.repeat(170)}_LOGEND`;
+      c.setOverlay(overlay); c.commitAbove(longLine + '\n');
+      for (let k = 0; k < 24; k++) { c.setOverlay(overlay); c.commitAbove(`FILLER_${String(k).padStart(2, '0')}\n`); }
+      c.setOverlay(''); ix.repaint(); ix.repaint();
+      await settle();
+      await requestResize(ctx, 110, 24); // WIDEN 48 → 110
+      ix.repaint(); ix.repaint();
+      await settle();
+    },
+    expect: {
+      inScrollback: ['LOGSTART'],
+      // minNonWrappedRows:2 is the RED flip signal (4 ragged rows now → 1 after
+      // PR 2 rejoins the logical line). The resize MECHANISM is certified by the
+      // sanity scenario; a widen cannot prove itself via row count (it is
+      // unchanged pre-fix), so no minSpanRows here.
+      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', minNonWrappedRows: 2 },
     },
   },
 };


### PR DESCRIPTION
> **Draft / stacked on #621** — base branch is `afk/tmux-test-wrapping-fix` (PR 1), not `main`. Review/merge #621 first. **Not mergeable until the Stage-4 human real-terminal matrix passes** (see bottom).

## What

PR 2 (the fix) for #540 "axis 2" — the width-resize scrollback fragmentation in the reported screenshot. PR 1 (#621) added the real-PTY resize harness and RED guards; this PR makes the fix and flips those guards to GREEN.

## The bug

Committed content is hard-wrapped to the width-at-commit (`terminal-compositor.committed-band-commit.ts:165`) and flushed into native scrollback as **hard-newline rows**. Terminals reflow only their own soft-wraps on resize, never app hard-newlines — so scrolled-off content re-fragments (narrow) / stays ragged (widen). Cosmetic, no data loss, terminal-independent.

## The fix

The end-of-turn / disarm flush now archives the pending committed band as **soft-wrappable logical lines** instead of pre-hard-wrapped physical rows, so the terminal owns wrapping and reflows scrollback cleanly on any width change — `docs/tui-resize-reflow.md` "sound pattern (a): make native scrollback authoritative."

**Mechanism — retain, don't reconstruct.** The flat `committedBand: string[]` loses logical-line boundaries (`reflowBandSplit` re-wraps each row independently, so joining rows can't recover them). So:
- `committedBandMeta: BandRowMeta[]` — per-physical-row logical provenance, index-aligned 1:1 with `committedBand`, maintained across commit / reflow / eviction / repin.
- `flushPendingCommittedBand` → `scrollbackFlushLines` maps the pending physical rows back to logical lines, reading the full band+meta so a logical line **straddling** the pending/painted boundary emits only its pending rows (no scrollback duplication — HARD CONSTRAINT #1). `buildScrollbackArchiveEscape` writes each line at the bottom margin with **autowrap ON** + trailing `\n`, so the terminal wraps and scrolls it into history.
- The **live band keeps hard-wrapped physical rows** for exact row math (unchanged); only the scrollback archival path emits logical lines.

Flips PR 1's `width-resize-fragment-narrow`/`-widen` guards to `maxNonWrappedRows: 1` — they pass because behavior changed, not because assertions were weakened (harness unchanged).

## Gates (all green, verified locally)

- `pnpm lint` (tsc --noEmit, strict) — clean
- `pnpm test:pty` — **8/8** (the 2 flipped guards now assert the rejoined property and pass)
- headless compositor suite — **363/363** (no regression to the #539/#552/#573 height/void class)
- `pnpm test:coverage` — green (thresholds met; includes new `terminal-compositor.logical-flush.test.ts`)

## Provenance / caveats

Implemented by a delegated subagent; the diff and every gate above were **independently re-run and reviewed** by the dispatching session before this PR was opened. Automated gates only certify the emulator model.

## REQUIRED before merge — Stage-4 human real-terminal matrix

`@xterm/headless` cannot reproduce every terminal-only DECAWM artifact, and **prior fixes in this code shipped green and broke in reality.** Before merge, run `afk` in **iTerm2 / Apple Terminal / Ghostty** and exercise: resize narrower mid-turn; widen then scroll up to old output; long report + table; overlay grow→collapse; dropdown headroom; picker. This gate is the whole ballgame — hence draft.

Refs #540. Stacks on #621.
