### PR TITLE
chore(agents): remove inert `model:` frontmatter from vendored agent prompts

### DIFF
--- a/src/skills/_agents/prompts/git-investigator.md
+++ b/src/skills/_agents/prompts/git-investigator.md
@@ -1,7 +1,6 @@
 ---
 name: git-investigator
 description: Read-only git specialist. Dispatched by research-agent (or any research-shaped caller) when a finding requires git history, reflog, diff, blame, branch/remote state, or merge-base analysis. Runs git commands only — no mutations, no shell escapes.
-model: sonnet
 tools: Bash, Read, Grep, Glob
 ---
 

--- a/src/skills/_agents/prompts/research-agent.md
+++ b/src/skills/_agents/prompts/research-agent.md
@@ -1,7 +1,6 @@
 ---
 name: research-agent
 description: Read-only sub-agent for research, validation, verification, and codebase inspection. Mechanically locked to Read, Grep, Glob, WebFetch, WebSearch — cannot Edit, Write, Bash, commit, or push. Delegates git queries to `git-investigator`. Use when the dispatched task is findings-only.
-model: sonnet
 tools: Read, Grep, Glob, WebFetch, WebSearch, Agent(git-investigator)
 ---
 

--- a/src/skills/_agents/vendored.test.ts
+++ b/src/skills/_agents/vendored.test.ts
@@ -10,9 +10,9 @@ const __dirname = dirname(__filename);
 
 // Pinned hashes — guard against undocumented edits to the vendored copy
 const PINNED_HASHES = {
-  'research-agent': '141b2859797bd538f01293b5570643b5757cb7a96438cc9be0d97106e3eb92bd',
+  'research-agent': 'de1c6bedaf07f0fb7a159be3af3a13e27d31ee3c0e73dbcd34a741661f5abc04',
   contract: '0b7febafec024e8dd4404f75e84d21ee72b1b1846d6e2610aaa82ba77f9d6f2d',
-  'git-investigator': 'c31560bdb80d84c42f25938facdb883aa8120df2e6ec1d341bfb61bfac4769da',
+  'git-investigator': 'd1f186b82574641a4cb616990cee70a36f95a109b3688f59c07d12d26de60c03',
 } as const;
 
 type AgentName = keyof typeof PINNED_HASHES;


### PR DESCRIPTION
## What

Removes the `model: sonnet` line from the vendored `research-agent` and `git-investigator` agent prompts, and re-pins the drift hashes in `vendored.test.ts`.

## Why

This `model:` frontmatter is **inert for routing**:

- The vendored prompt is consumed via `vendoredPromptBody()`, which strips YAML frontmatter before it becomes the system prompt.
- The bundled agents' registered definitions in `src/agent/agents/builtins.ts` do not read frontmatter `model` for `research-agent`.

So the line implied a model pin that has no effect on this path — misleading to readers. Removing it aligns the bundled `research-agent` with the plugin copy (which carries no `model` line) and leaves the subagent model choice to the dispatcher/parent.

## Scope / caveat

- `git-investigator`'s **effective** model is still pinned via `src/skills/_agents/git-investigator.ts` (`model: 'sonnet' as const`) → `builtins.ts`. This PR removes only the inert `.md` frontmatter and does **not** change git-investigator's actual routing.
- Pure cleanup — no runtime behavior change.

## Test

`pnpm test src/skills/_agents/vendored.test.ts` → **20/20 pass** (drift hashes re-pinned for both prompts).
