### PR TITLE
fix(telegram): failed cleanFinal delivery no longer re-sends a contradictory overflow tail (#623)

### DIFF
--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -469,6 +469,110 @@ describe('streamResponse', () => {
     // …and the failure is announced, not silent.
     expect(replies.some((r) => r.includes('Telegram dropped'))).toBe(true);
   });
+
+  it('cleanFinal: a long-answer first-chunk failure does NOT re-send a contradictory chunks[1..] fragment (#623)', async () => {
+    // Regression (#623, medium): on a LONG cleanFinal answer, if deliverClean's FIRST
+    // fresh chunk fails past retries it posts the truncation notice and returns
+    // delivered=false, leaving `sentMessage` set. The post-loop overflow branch used to
+    // fire on ANY terminal exit with a surviving preview and re-send chunks[1..] of the
+    // noisy `accumulated` buffer — immediately contradicting the "dropped, ask me to
+    // resend" notice it had just posted. Gating that branch on `!cleanFinal` keeps the
+    // cleanFinal failure path from falling through to it. The pre-existing short
+    // first-chunk-fail test could not catch this: a single-chunk answer never satisfies
+    // the overflow branch's `chunks.length > 1` guard.
+    const { ctx, replies, deletes } = makeCtx();
+    const transportError = new TelegramError({ error_code: 400, description: 'Bad Request: message is too long' });
+    let htmlReplies = 0;
+    (ctx.reply as ReturnType<typeof vi.fn>).mockImplementation(async (text: string, extra?: { parse_mode?: string }) => {
+      if (extra?.parse_mode === 'HTML') {
+        htmlReplies++;
+        // Reply #1 creates the live preview (must succeed so a preview exists); reply #2
+        // is deliverClean's FIRST fresh chunk — fail it (and everything after) so nothing
+        // clean lands and the frozen preview must survive.
+        if (htmlReplies >= 2) throw transportError;
+      }
+      replies.push(text);
+      return { message_id: replies.length, text, chat: { id: 12345, type: 'private' as const }, date: 0 };
+    });
+    const first = `first ${'a'.repeat(4080)}`;
+    const second = `second ${'b'.repeat(200)}`;
+    const longAnswer = [first, second].join('\n');
+    const session = makeSession(async function* () {
+      yield { type: 'chunk', chunk: { type: 'content', content: longAnswer } };
+      yield { type: 'done', metadata: undefined };
+    });
+
+    await expect(streamResponse(ctx, session, 'go', undefined, { cleanFinal: true })).resolves.toBeUndefined();
+
+    // The frozen preview survives (nothing clean replaced it)…
+    expect(deletes.length).toBe(0);
+    // …and the failure is announced EXACTLY once. The buggy overflow re-send posted a
+    // SECOND contradictory notice (and re-delivered chunks[1..] of the noisy buffer).
+    expect(replies.filter((r) => r.includes('Telegram dropped'))).toHaveLength(1);
+  });
+
+  it('default (no cleanFinal): a multi-chunk answer delivers chunks[1..] as fresh replies (tail not dropped)', async () => {
+    // Guard for the #623 fix CHOICE. `sendOrEdit` only ever renders chunk[0] into the
+    // single preview message, so on the non-cleanFinal `done` path (sawTerminalEvent=true)
+    // chunks[1..] can reach the user ONLY via the post-loop overflow branch. Gating that
+    // branch on `!sawTerminalEvent` (the rejected alternative fix) makes it dead code and
+    // silently drops the tail — reintroducing the #620 bug. Gating on `!cleanFinal` keeps
+    // it reachable here. This test fails under `!sawTerminalEvent` and passes under
+    // `!cleanFinal`.
+    const { ctx, replies, deletes } = makeCtx();
+    const first = `first ${'a'.repeat(4080)}`;
+    const second = `second ${'b'.repeat(200)}`;
+    const longAnswer = [first, second].join('\n');
+    const session = makeSession(async function* () {
+      yield { type: 'chunk', chunk: { type: 'content', content: longAnswer } };
+      yield { type: 'done', metadata: undefined };
+    });
+
+    await expect(streamResponse(ctx, session, 'go')).resolves.toBeUndefined();
+
+    // The overflow tail was delivered as a fresh reply (not stranded in the preview)…
+    expect(replies.some((r) => r.startsWith('second '))).toBe(true);
+    // …and the non-cleanFinal path never deletes the preview.
+    expect(deletes.length).toBe(0);
+  });
+
+  it('default (no cleanFinal): a failed overflow tail chunk posts a visible notice and never rethrows', async () => {
+    // Coverage gap (#623): the non-cleanFinal overflow catch — which posts
+    // DELIVERY_TRUNCATED_NOTICE when a chunks[1..] send fails — had NO test; every
+    // throwing-reply test used cleanFinal. Here a multi-chunk answer reaches `done`,
+    // chunk[0] sits in the preview, and the overflow send fails with a transport error:
+    // the notice must post and nothing may rethrow uncaught into the finally.
+    const { ctx, replies, edits, deletes } = makeCtx();
+    const transportError = new TelegramError({ error_code: 400, description: 'Bad Request: message is too long' });
+    let htmlReplies = 0;
+    (ctx.reply as ReturnType<typeof vi.fn>).mockImplementation(async (text: string, extra?: { parse_mode?: string }) => {
+      if (extra?.parse_mode === 'HTML') {
+        htmlReplies++;
+        // Reply #1 creates the preview (chunk[0], must succeed); reply #2 is the overflow
+        // chunks[1] send — fail it so the non-cleanFinal notice branch runs.
+        if (htmlReplies >= 2) throw transportError;
+      }
+      replies.push(text);
+      return { message_id: replies.length, text, chat: { id: 12345, type: 'private' as const }, date: 0 };
+    });
+    const first = `first ${'a'.repeat(4080)}`;
+    const second = `second ${'b'.repeat(200)}`;
+    const longAnswer = [first, second].join('\n');
+    const session = makeSession(async function* () {
+      yield { type: 'chunk', chunk: { type: 'content', content: longAnswer } };
+      yield { type: 'done', metadata: undefined };
+    });
+
+    // A transport failure on the overflow tail is handled, not thrown.
+    await expect(streamResponse(ctx, session, 'go')).resolves.toBeUndefined();
+
+    // chunk[0] is rendered into the preview via edit (the non-cleanFinal path edits
+    // the live message rather than re-sending it), and the dropped tail is announced…
+    expect(edits.some((e) => e.startsWith('first '))).toBe(true);
+    expect(replies.filter((r) => r.includes('Telegram dropped'))).toHaveLength(1);
+    // …and the non-cleanFinal path never deletes the preview.
+    expect(deletes.length).toBe(0);
+  });
 });
 
 describe('generator finalizer cleanup', () => {

--- a/src/telegram/streaming.test.ts
+++ b/src/telegram/streaming.test.ts
@@ -573,6 +573,57 @@ describe('streamResponse', () => {
     // …and the non-cleanFinal path never deletes the preview.
     expect(deletes.length).toBe(0);
   });
+
+  it('cleanFinal: a progress-only turn (no assistant answer) still delivers a long accumulated buffer\'s overflow tail (#623 follow-up)', async () => {
+    // Regression (#623 follow-up — flagged independently by this repo's own review
+    // pipeline AND by Codex on PR #626): when cleanFinal===true but the turn produces
+    // NO final assistant text (a subagent-heavy turn with only `◦` progress lines,
+    // `answerText` stays ''), the `done` handler's `if (cleanFinal && answerText.trim())`
+    // guard is false, so it falls to `sendOrEdit(accumulated, true)` — which, like the
+    // non-cleanFinal path, renders only chunk[0] into the preview. The post-loop overflow
+    // branch must still fire to deliver chunks[1..] of that (long, progress-only)
+    // `accumulated` buffer. Gating that branch on bare `!cleanFinal` (the original #623
+    // fix) wrongly excluded this case too, silently truncating the tail. The refined gate
+    // — the exact negation of the `done` handler's own `cleanFinal && answerText.trim()`
+    // guard — restores delivery here while still suppressing the original #623
+    // contradictory-resend bug (see the cleanFinal first-chunk-failure test above).
+    const { ctx, replies, deletes } = makeCtx();
+    const firstDescription = `first ${'a'.repeat(4080)}`;
+    const secondDescription = 'second progress marker';
+    const session = makeSession(async function* () {
+      yield {
+        type: 'progress',
+        progress: {
+          taskId: 't1',
+          description: firstDescription,
+          totalTokens: 100,
+          toolUses: 1,
+          durationMs: 100,
+        },
+      };
+      yield {
+        type: 'progress',
+        progress: {
+          taskId: 't2',
+          description: secondDescription,
+          totalTokens: 100,
+          toolUses: 1,
+          durationMs: 100,
+        },
+      };
+      yield { type: 'done', metadata: undefined };
+    });
+
+    await expect(streamResponse(ctx, session, 'go', undefined, { cleanFinal: true })).resolves.toBeUndefined();
+
+    // No clean answer text ever existed to replace the preview, so it is never deleted…
+    expect(deletes.length).toBe(0);
+    // …but the overflow tail — the second progress line — still reaches the user as a
+    // fresh reply instead of being silently stranded behind the frozen chunk[0] preview.
+    expect(replies.some((r) => r.includes(secondDescription))).toBe(true);
+    // Nothing failed, so no truncation notice fires.
+    expect(replies.some((r) => r.includes('Telegram dropped'))).toBe(false);
+  });
 });
 
 describe('generator finalizer cleanup', () => {

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -661,10 +661,11 @@ export async function streamResponse(
       //
       // The in-place preview is edited under EDIT_THROTTLE_MS and Telegram edit
       // flood-control, so it can freeze mid-stream and show LESS than what actually
-      // streamed. A `done` event already handled delivery above: on the cleanFinal
-      // path deliverClean ran and (on success) nulled `sentMessage`; on the legacy
-      // non-cleanFinal path `sendOrEdit(accumulated)` edited chunk[0] into the preview
-      // and only chunks[1..] remain to send. Any OTHER exit — `sawTerminalEvent` false:
+      // streamed. A `done` event already handled delivery above: when `cleanFinal` had
+      // non-empty `answerText`, `deliverClean` ran and (on success) nulled `sentMessage`;
+      // otherwise (plain non-cleanFinal, OR a cleanFinal turn with empty `answerText`)
+      // `sendOrEdit(accumulated)` edited only chunk[0] into the preview and chunks[1..]
+      // remain to send. Any OTHER exit — `sawTerminalEvent` false:
       // the provider closed the stream without a terminal event, or an early break —
       // previously stranded the user on that frozen, partial preview (the long-reply
       // "cut off mid-sentence" bug). Re-deliver everything as fresh message(s) so
@@ -688,15 +689,24 @@ export async function streamResponse(
             sentMessage = null;
           }
         }
-      } else if (!cleanFinal && accumulated && preview) {
-        // Legacy non-cleanFinal overflow: `done` fired (`sawTerminalEvent` true, so the
-        // branch above is skipped) and `sendOrEdit` left only chunk[0] in the preview —
-        // send the remaining chunks[1..] here. Gated on `!cleanFinal`: on the cleanFinal
-        // path a FAILED deliverClean (first chunk fails past retries) posts the truncation
-        // notice and leaves `sentMessage` set, which would otherwise re-fire this branch and
-        // re-send chunks[1..] of the noisy `accumulated` buffer — directly contradicting the
-        // "dropped, ask me to resend" notice just posted (issue #623). cleanFinal owns its own
-        // delivery + notice entirely, so it must never fall through to this legacy path.
+      } else if (!(cleanFinal && answerText.trim()) && accumulated && preview) {
+        // Overflow send: `done` fired (`sawTerminalEvent` true, so the branch above is
+        // skipped) and the `done` handler used `sendOrEdit`, which only ever renders
+        // chunk[0] into the preview — send the remaining chunks[1..] here.
+        //
+        // The gate is the exact negation of the `done` handler's own
+        // `cleanFinal && answerText.trim()` guard: it fires for every case where that
+        // handler took its `sendOrEdit` branch instead of `deliverClean` — the plain
+        // non-cleanFinal path, AND a cleanFinal turn whose `answerText` is empty (e.g. a
+        // progress-only turn that produced no final assistant text, only accumulated `◦`
+        // status lines). A bare `!cleanFinal` gate (the original #623 fix) wrongly excluded
+        // that second case too, silently truncating a long progress-only cleanFinal turn to
+        // chunk[0] — flagged independently by this repo's own review pipeline and Codex
+        // (PR #626 review). It still correctly excludes a FAILED deliverClean (first chunk
+        // fails past retries): that case has `cleanFinal && answerText.trim()` true
+        // regardless of delivery outcome, so `!(...)` is false and this branch is skipped —
+        // preserving the original #623 fix (no contradictory resend after the truncation
+        // notice `deliverClean` already posted).
         const chunks = splitLongMessage(markdownToTelegramHtml(accumulated));
         if (chunks.length > 1) {
           const reply = (t: string, extra?: { parse_mode?: 'HTML' }): Promise<unknown> => ctx.reply(t, extra);

--- a/src/telegram/streaming.ts
+++ b/src/telegram/streaming.ts
@@ -661,13 +661,14 @@ export async function streamResponse(
       //
       // The in-place preview is edited under EDIT_THROTTLE_MS and Telegram edit
       // flood-control, so it can freeze mid-stream and show LESS than what actually
-      // streamed. A `done` event already handled delivery above (clean-final nulls
-      // `sentMessage`; the legacy branch left chunk[0] in the preview and needs only
-      // chunks[1..]). Any OTHER exit — `sawTerminalEvent` false: the provider closed
-      // the stream without a terminal event, or an early break — previously stranded
-      // the user on that frozen, partial preview (the long-reply "cut off mid-sentence"
-      // bug). Re-deliver everything as fresh message(s) so nothing that streamed is
-      // lost to a stale preview, then remove the preview.
+      // streamed. A `done` event already handled delivery above: on the cleanFinal
+      // path deliverClean ran and (on success) nulled `sentMessage`; on the legacy
+      // non-cleanFinal path `sendOrEdit(accumulated)` edited chunk[0] into the preview
+      // and only chunks[1..] remain to send. Any OTHER exit — `sawTerminalEvent` false:
+      // the provider closed the stream without a terminal event, or an early break —
+      // previously stranded the user on that frozen, partial preview (the long-reply
+      // "cut off mid-sentence" bug). Re-deliver everything as fresh message(s) so
+      // nothing that streamed is lost to a stale preview, then remove the preview.
 
       // Snapshot the preview ref. `sentMessage` is assigned only inside the
       // `sendOrEdit` closure (invisible to linear CFA), so post-loop TS narrows it to
@@ -687,7 +688,15 @@ export async function streamResponse(
             sentMessage = null;
           }
         }
-      } else if (accumulated && preview) {
+      } else if (!cleanFinal && accumulated && preview) {
+        // Legacy non-cleanFinal overflow: `done` fired (`sawTerminalEvent` true, so the
+        // branch above is skipped) and `sendOrEdit` left only chunk[0] in the preview —
+        // send the remaining chunks[1..] here. Gated on `!cleanFinal`: on the cleanFinal
+        // path a FAILED deliverClean (first chunk fails past retries) posts the truncation
+        // notice and leaves `sentMessage` set, which would otherwise re-fire this branch and
+        // re-send chunks[1..] of the noisy `accumulated` buffer — directly contradicting the
+        // "dropped, ask me to resend" notice just posted (issue #623). cleanFinal owns its own
+        // delivery + notice entirely, so it must never fall through to this legacy path.
         const chunks = splitLongMessage(markdownToTelegramHtml(accumulated));
         if (chunks.length > 1) {
           const reply = (t: string, extra?: { parse_mode?: 'HTML' }): Promise<unknown> => ctx.reply(t, extra);


### PR DESCRIPTION
Fixes #623.

## Problem
On the interactive `cleanFinal` path, if `deliverClean(answerText)`'s **first** chunk fails past retries (a flood-control 429 outliving `MAX_FLOOD_RETRIES`, or another transport error), `deliverClean` posts `DELIVERY_TRUNCATED_NOTICE` and returns `delivered = false`, leaving `sentMessage` non-null.

Post-loop, `if (preview && !sawTerminalEvent)` is skipped (`sawTerminalEvent === true` after `done`), so `else if (accumulated && preview)` **fires** and re-delivers `chunks[1..]` of the raw `accumulated` buffer. On a long answer the user sees: frozen preview → a "dropped part of this reply … ask me to resend it" notice → an immediate headless fragment of the *noisy* `accumulated` buffer, contradicting the notice just posted.

Not data loss (content is over-delivered, strictly better than the pre-#620 silent tail-drop), but confusing/contradictory UX.

## Fix
Gate the legacy overflow branch on `!cleanFinal`:

```ts
} else if (!cleanFinal && accumulated && preview) {
```

`cleanFinal` owns its own delivery + notice entirely and must never fall through to the legacy overflow path.

## Fix-choice note — diverges from the issue's *headline* suggestion
The issue proposed `!sawTerminalEvent` as the headline fix (with `!cleanFinal` as a parenthetical alternative). I used `!cleanFinal`, because `!sawTerminalEvent` is subtly wrong:

- The overflow branch is only **reachable** when `sawTerminalEvent === true` — the preceding `if (preview && !sawTerminalEvent)` already captures the `false` case (given `preview` is truthy). So adding `!sawTerminalEvent` to its condition makes the branch **dead code**.
- `sendOrEdit` only ever renders `chunk[0]` into the single preview message (it edits one message; it never fans out). So the legitimate **non-`cleanFinal` multi-chunk `done`** path relies on this branch to send `chunks[1..]`. Killing it drops the tail — reintroducing the #620 "cut off mid-sentence" bug.

## Tests (`src/telegram/streaming.test.ts`, +3)
1. **cleanFinal long-answer first-chunk-fail** — preview survives and the notice posts **exactly once** (the buggy code posts a second contradictory notice and re-sends `chunks[1..]`). Fails on the pre-fix code.
2. **non-cleanFinal multi-chunk** — `chunks[1..]` are still delivered as fresh replies (tail not dropped). Fails under the rejected `!sawTerminalEvent` gate.
3. **non-cleanFinal overflow tail-chunk failure** — posts a visible notice and never rethrows, closing the previously-uncovered non-cleanFinal notice branch (the test gap called out in the issue).

## Verification
Ran each gate variant against the suite to confirm the tests discriminate:

| Gate | #623 repro (test 1) | non-cleanFinal tail (tests 2, 3) |
|------|---------------------|-----------------------------------|
| `accumulated && preview` (original, buggy) | fails | pass |
| `!sawTerminalEvent && …` (issue headline) | pass | **fails** (dead code, tail dropped) |
| `!cleanFinal && …` (this PR) | pass | pass |

- `pnpm test src/telegram/streaming.test.ts` → 32 passed
- `pnpm test` (full suite) → 668 files, 12198 passed, 14 skipped, 0 failed
- `pnpm lint` (`tsc --noEmit`) → clean
