### PR TITLE
fix(mint): hard-fail phases on incomplete subagent result (capped / stream_incomplete)

### DIFF
--- a/src/skills/mint-parallelize-dispatch.test.ts
+++ b/src/skills/mint-parallelize-dispatch.test.ts
@@ -24,6 +24,8 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { IAgentSession } from '../agent/types.js';
+import { TOOL_USE_LOOP_CAPPED } from '../agent/providers/shared/tool-loop-cap.js';
+import { STREAM_INCOMPLETE } from '../agent/subagent/result.js';
 
 // ---- Mocks ---------------------------------------------------------------
 
@@ -32,6 +34,7 @@ let forkBehavior: () => Promise<{
   id: string;
   status: string;
   message: { content: string } | undefined;
+  stopReason?: string;
   error?: { message: string };
 }> = async () => ({
   id: 'mint-parallelize',
@@ -203,6 +206,41 @@ describe('runParallelizeDispatch — discriminated union', () => {
     expect(result.kind).toBe('failed');
     if (result.kind === 'failed') {
       expect(result.error).toMatch(/no message/);
+    }
+  });
+
+  // A `succeeded` result can still be an incomplete partial — the tool-use cap
+  // fired or the stream closed without a terminal message. Its `.message.content`
+  // is a truncated placeholder, not a usable wave plan, so the phase must NOT
+  // return `{ kind: 'plan' }` — it must surface a dispatch failure. Without the
+  // isIncompleteStopReason guard this returned a "plan" built from the partial.
+  it('returns failed when subagent succeeded but the result is a tool_use_loop_capped partial', async () => {
+    forkBehavior = async () => ({
+      id: 'mint-parallelize',
+      status: 'succeeded',
+      message: { content: 'partial wave plan (truncated)' },
+      stopReason: TOOL_USE_LOOP_CAPPED,
+    });
+    const result = await runParallelizeDispatch(MANY_FILES_PLAN, mockSession());
+    expect(result.kind).toBe('failed');
+    if (result.kind === 'failed') {
+      expect(result.error).toMatch(/incomplete result/);
+      expect(result.error).toMatch(/tool_use_loop_capped/);
+    }
+  });
+
+  it('returns failed when subagent succeeded but the result is a stream_incomplete partial', async () => {
+    forkBehavior = async () => ({
+      id: 'mint-parallelize',
+      status: 'succeeded',
+      message: { content: 'partial wave plan (truncated)' },
+      stopReason: STREAM_INCOMPLETE,
+    });
+    const result = await runParallelizeDispatch(MANY_FILES_PLAN, mockSession());
+    expect(result.kind).toBe('failed');
+    if (result.kind === 'failed') {
+      expect(result.error).toMatch(/incomplete result/);
+      expect(result.error).toMatch(/stream_incomplete/);
     }
   });
 

--- a/src/skills/mint-phase-incomplete-guard.test.ts
+++ b/src/skills/mint-phase-incomplete-guard.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Guard tests: mint phase dispatchers must HARD-FAIL on an incomplete subagent
+ * result rather than forwarding a truncated placeholder as the phase output.
+ *
+ * Bug class: the subagent runtime returns a `SubagentResult` with
+ * `status: 'succeeded'` even when the run was incomplete — the tool-use cap
+ * fired (`stopReason === 'tool_use_loop_capped'`) or the stream closed without a
+ * terminal message (`stopReason === 'stream_incomplete'`). `isIncompleteStopReason`
+ * (src/agent/subagent/result.ts) flags both. A consumer that reads
+ * `result.message.content` gated ONLY on `status === 'succeeded'` silently treats
+ * the partial as real output — and in mint that partial then feeds the NEXT phase.
+ *
+ * Same class as the forge STREAM_INCOMPLETE guard, but in mint's phase pipeline,
+ * which has no qualify gate to catch a degraded phase. The fix extends each
+ * phase's existing status guard with an `isIncompleteStopReason(stopReason)`
+ * check that fires BEFORE `.message.content` is read.
+ *
+ * These tests cover the five "throw on failure" phases (spec/research/plan/ship/
+ * heal). The sixth site (parallelize-dispatch) returns a discriminated union and
+ * is covered in mint-parallelize-dispatch.test.ts.
+ *
+ * NB: `heal` wraps its dispatch in a try/catch that converts a throw into a
+ * non-healed iteration (`healed: false`, iterations incremented) — so its guard
+ * is asserted via the RETURNED value and the fact that the re-verify phase is
+ * never reached, not via a rethrown error.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TOOL_USE_LOOP_CAPPED } from '../agent/providers/shared/tool-loop-cap.js';
+import { STREAM_INCOMPLETE } from '../agent/subagent/result.js';
+import type { AgentModelInput, IAgentSession } from '../agent/types.js';
+
+// ---- Mocks ---------------------------------------------------------------
+
+// Mutable runToResult behavior, swapped per test. Defaults to a clean
+// completion (no incomplete stopReason) so the "does NOT trip on a clean
+// result" control cases pass.
+let runToResultBehavior: () => Promise<{
+  id: string;
+  status: string;
+  message: { content: string } | undefined;
+  stopReason?: string;
+  error?: { message: string };
+}> = async () => ({
+  id: 'mint-phase',
+  status: 'succeeded',
+  message: { content: 'clean phase output' },
+});
+
+vi.mock('../agent/subagent.js', () => ({
+  SubagentManager: vi.fn(() => ({
+    forkSubagent: vi.fn(async () => ({
+      id: 'mint-phase',
+      runToResult: vi.fn(async () => runToResultBehavior()),
+    })),
+    teardownAll: vi.fn(async () => undefined),
+  })),
+}));
+
+// Every phase loads its prompt via loadSkillPrompts('mint'); return a stub map
+// with all keys the phases read so the "missing prompt" guard never trips.
+vi.mock('./_lib/prompt-loader.js', () => ({
+  loadSkillPrompts: () => ({
+    'spec.md': 'SPEC_PROMPT_STUB',
+    'research.md': 'RESEARCH_PROMPT_STUB',
+    'plan.md': 'PLAN_PROMPT_STUB',
+    'ship.md': 'SHIP_PROMPT_STUB',
+    'heal.md': 'HEAL_PROMPT_STUB',
+  }),
+}));
+
+const resolveCredentialForModel = vi.hoisted(() =>
+  vi.fn((m: string | undefined) => `resolved-key::${m}`),
+);
+vi.mock('../agent/auth/credential-resolver.js', () => ({
+  resolveCredentialForModel,
+}));
+
+// heal re-runs the verify phase only when it trusts a fix landed. Mock it so we
+// can assert the incomplete guard short-circuits BEFORE any re-verify happens.
+const runVerifyPhaseSpy = vi.hoisted(() =>
+  vi.fn(async () => ({
+    testsPassed: true,
+    lintPassed: true,
+    designReviewPassed: true,
+    issues: [] as string[],
+  })),
+);
+vi.mock('./mint/_phases/verify.js', () => ({
+  runVerifyPhase: runVerifyPhaseSpy,
+}));
+
+// Import phases after mocks are wired.
+import { runSpecPhase } from './mint/_phases/spec.js';
+import { runResearchPhase } from './mint/_phases/research.js';
+import { runPlanPhase } from './mint/_phases/plan.js';
+import { runShipPhase } from './mint/_phases/ship.js';
+import { runHealPhase } from './mint/_phases/heal.js';
+import type { MintState } from './mint/index.js';
+import type { BuildResult } from './mint/_phases/build.js';
+import type { VerifyResult } from './mint/_phases/verify.js';
+
+const MODEL: AgentModelInput = 'sonnet';
+
+function incomplete(stopReason: string, content = 'truncated placeholder') {
+  return async () => ({
+    id: 'mint-phase',
+    status: 'succeeded' as const,
+    message: { content },
+    stopReason,
+  });
+}
+
+function shipState(): MintState {
+  return {
+    currentPhase: 'ship',
+    idea: 'Test feature',
+    spec: 'spec',
+    research: 'research',
+    plan: 'plan',
+    buildResults: { filesChanged: ['src/index.ts'], testsPassed: true, notes: 'built' },
+    verifyResults: { testsPassed: true, lintPassed: true, designReviewPassed: true },
+    healIterations: 0,
+    history: [],
+  };
+}
+
+function healSession(): IAgentSession {
+  return {
+    sessionId: 'sess-heal-guard',
+    sendMessage: vi.fn(),
+    interrupt: vi.fn(),
+    close: vi.fn(),
+    getInputStreamRef: vi.fn(),
+    abortSignal: new AbortController().signal,
+  };
+}
+
+const FAILING_VERIFY: VerifyResult = {
+  testsPassed: false,
+  lintPassed: false,
+  designReviewPassed: false,
+  issues: ['mocked failure'],
+};
+const BUILD: BuildResult = { filesChanged: ['src/index.ts'], testsPassed: true, notes: 'built' };
+
+describe('mint phase incomplete-result guards (isIncompleteStopReason)', () => {
+  beforeEach(() => {
+    // Reset to a clean completion before each test.
+    runToResultBehavior = async () => ({
+      id: 'mint-phase',
+      status: 'succeeded',
+      message: { content: 'clean phase output' },
+    });
+    runVerifyPhaseSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ---- spec ----------------------------------------------------------------
+
+  it('spec: throws when the result is a tool_use_loop_capped partial', async () => {
+    runToResultBehavior = incomplete(TOOL_USE_LOOP_CAPPED);
+    await expect(runSpecPhase('idea', 'sess', undefined, undefined, MODEL)).rejects.toThrow(
+      /spec phase returned an incomplete result \(stopReason=tool_use_loop_capped\)/,
+    );
+  });
+
+  it('spec: throws when the result is a stream_incomplete partial', async () => {
+    runToResultBehavior = incomplete(STREAM_INCOMPLETE);
+    await expect(runSpecPhase('idea', 'sess', undefined, undefined, MODEL)).rejects.toThrow(
+      /spec phase returned an incomplete result \(stopReason=stream_incomplete\)/,
+    );
+  });
+
+  it('spec: returns content on a clean completion (guard does not over-trip)', async () => {
+    // Default behavior is a clean succeeded result with no stopReason.
+    await expect(runSpecPhase('idea', 'sess', undefined, undefined, MODEL)).resolves.toBe(
+      'clean phase output',
+    );
+  });
+
+  // ---- research ------------------------------------------------------------
+
+  it('research: throws when the result is a tool_use_loop_capped partial', async () => {
+    runToResultBehavior = incomplete(TOOL_USE_LOOP_CAPPED);
+    await expect(
+      runResearchPhase('spec', 'sess', undefined, undefined, MODEL),
+    ).rejects.toThrow(/research phase returned an incomplete result \(stopReason=tool_use_loop_capped\)/);
+  });
+
+  it('research: returns content on a clean completion', async () => {
+    await expect(
+      runResearchPhase('spec', 'sess', undefined, undefined, MODEL),
+    ).resolves.toBe('clean phase output');
+  });
+
+  // ---- plan ----------------------------------------------------------------
+
+  it('plan: throws when the result is a stream_incomplete partial', async () => {
+    runToResultBehavior = incomplete(STREAM_INCOMPLETE);
+    await expect(
+      runPlanPhase('spec', 'research', 'sess', undefined, undefined, MODEL),
+    ).rejects.toThrow(/plan phase returned an incomplete result \(stopReason=stream_incomplete\)/);
+  });
+
+  it('plan: returns content on a clean completion', async () => {
+    await expect(
+      runPlanPhase('spec', 'research', 'sess', undefined, undefined, MODEL),
+    ).resolves.toBe('clean phase output');
+  });
+
+  // ---- ship ----------------------------------------------------------------
+
+  it('ship: throws when the result is a tool_use_loop_capped partial', async () => {
+    runToResultBehavior = incomplete(TOOL_USE_LOOP_CAPPED);
+    await expect(
+      runShipPhase(shipState(), 'sess', undefined, undefined, MODEL),
+    ).rejects.toThrow(/ship phase returned an incomplete result \(stopReason=tool_use_loop_capped\)/);
+  });
+
+  it('ship: returns content on a clean completion', async () => {
+    await expect(
+      runShipPhase(shipState(), 'sess', undefined, undefined, MODEL),
+    ).resolves.toBe('clean phase output');
+  });
+
+  // ---- heal ----------------------------------------------------------------
+  //
+  // heal's throw is caught by its own try/catch and converted to a non-healed
+  // iteration. The bug being fixed: an incomplete partial whose placeholder text
+  // happens to carry `FIX_APPLIED: true` would previously be trusted and trigger
+  // a re-verify. With the guard, the incomplete result short-circuits to
+  // `healed: false` and the re-verify phase is NEVER reached.
+
+  it('heal: an incomplete partial (with FIX_APPLIED: true text) does NOT trigger re-verify', async () => {
+    runToResultBehavior = incomplete(TOOL_USE_LOOP_CAPPED, 'FIX_APPLIED: true\n\ntruncated');
+    const result = await runHealPhase(
+      'plan',
+      BUILD,
+      FAILING_VERIFY,
+      0, // healIterations
+      healSession(),
+      undefined, // skillCallId
+      MODEL,
+    );
+    expect(result.healed).toBe(false);
+    // The guard fired before the FIX_APPLIED marker was read → no re-verify.
+    expect(runVerifyPhaseSpy).not.toHaveBeenCalled();
+    // The catch path increments the iteration counter.
+    expect(result.newHealIterations).toBe(1);
+    // Verify results are passed through unchanged.
+    expect(result.newVerifyResults).toEqual(FAILING_VERIFY);
+  });
+
+  it('heal: a stream_incomplete partial also short-circuits without re-verify', async () => {
+    runToResultBehavior = incomplete(STREAM_INCOMPLETE, 'FIX_APPLIED: true\n\ntruncated');
+    const result = await runHealPhase(
+      'plan',
+      BUILD,
+      FAILING_VERIFY,
+      1,
+      healSession(),
+      undefined,
+      MODEL,
+    );
+    expect(result.healed).toBe(false);
+    expect(runVerifyPhaseSpy).not.toHaveBeenCalled();
+    expect(result.newHealIterations).toBe(2);
+  });
+
+  it('heal: a CLEAN result with FIX_APPLIED: true DOES reach re-verify (guard does not over-trip)', async () => {
+    // Control: clean completion (no incomplete stopReason) with a fix marker
+    // must flow through to the re-verify phase, proving the guard is specific
+    // to incomplete results and not a blanket block.
+    runToResultBehavior = async () => ({
+      id: 'mint-phase',
+      status: 'succeeded',
+      message: { content: 'FIX_APPLIED: true\n\napplied the fix' },
+    });
+    const result = await runHealPhase(
+      'plan',
+      BUILD,
+      FAILING_VERIFY,
+      0,
+      healSession(),
+      undefined,
+      MODEL,
+    );
+    expect(runVerifyPhaseSpy).toHaveBeenCalledTimes(1);
+    // Mocked re-verify returns all-pass → healed true.
+    expect(result.healed).toBe(true);
+    expect(result.newHealIterations).toBe(1);
+  });
+});

--- a/src/skills/mint/_phases/heal.ts
+++ b/src/skills/mint/_phases/heal.ts
@@ -6,7 +6,7 @@
 
 import type { AgentModelInput, IAgentSession } from '../../../agent/types.js';
 import { SubagentManager } from '../../../agent/subagent.js';
-import { describeFailure } from '../../../agent/subagent/result.js';
+import { describeFailure, isIncompleteStopReason } from '../../../agent/subagent/result.js';
 import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { VerifyResult } from './verify.js';
@@ -122,6 +122,16 @@ export async function runHealPhase(
 
     if (healResult.status !== 'succeeded' || !healResult.message) {
       throw new Error(`heal phase failed: ${describeFailure(healResult)}`);
+    }
+    // A `succeeded` result can still be an incomplete partial — the tool-use cap
+    // fired or the stream closed without a terminal message. Its `.message.content`
+    // is a truncated placeholder, so the `FIX_APPLIED:` marker below cannot be
+    // trusted; hard-fail (the surrounding catch counts this as a non-healed
+    // iteration) rather than reading a partial as if a fix had landed.
+    if (isIncompleteStopReason(healResult.stopReason)) {
+      throw new Error(
+        `heal phase returned an incomplete result (stopReason=${healResult.stopReason})`,
+      );
     }
 
     // The heal prompt requires a `FIX_APPLIED: true|false` marker on the first

--- a/src/skills/mint/_phases/parallelize-dispatch.ts
+++ b/src/skills/mint/_phases/parallelize-dispatch.ts
@@ -17,6 +17,7 @@
 import { getSkill } from '../../index.js';
 import { discoverPluginSkillBodies } from '../../../agent/tools/skill-bridge.js';
 import { SubagentManager } from '../../../agent/subagent.js';
+import { isIncompleteStopReason } from '../../../agent/subagent/result.js';
 import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import type { AgentModelInput, IAgentSession } from '../../../agent/types.js';
 
@@ -138,6 +139,16 @@ export async function runParallelizeDispatch(
         ...(skillCallId ? { parentId: skillCallId } : {}),
       });
       const result = await handle.runToResult(JSON.stringify({ plan }));
+      // A `succeeded` result can still be an incomplete partial — the tool-use
+      // cap fired or the stream closed without a terminal message. Its
+      // `.message.content` is a truncated placeholder, not a usable wave plan,
+      // so surface it as a dispatch failure rather than returning the partial.
+      if (isIncompleteStopReason(result.stopReason)) {
+        return {
+          kind: 'failed',
+          error: `parallelize subagent returned an incomplete result (stopReason=${result.stopReason})`,
+        };
+      }
       if (result.status === 'succeeded' && result.message) {
         return { kind: 'plan', plan: result.message.content };
       }

--- a/src/skills/mint/_phases/plan.ts
+++ b/src/skills/mint/_phases/plan.ts
@@ -4,7 +4,7 @@
  */
 
 import { SubagentManager } from '../../../agent/subagent.js';
-import { describeFailure } from '../../../agent/subagent/result.js';
+import { describeFailure, isIncompleteStopReason } from '../../../agent/subagent/result.js';
 import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { AgentModelInput } from '../../../agent/types.js';
@@ -56,6 +56,15 @@ export async function runPlanPhase(
 
   if (planResult.status !== 'succeeded' || !planResult.message) {
     throw new Error(`plan phase failed: ${describeFailure(planResult)}`);
+  }
+  // A `succeeded` result can still be an incomplete partial — the tool-use cap
+  // fired or the stream closed without a terminal message. Its `.message.content`
+  // is a truncated placeholder, not the real plan; the phase output feeds the
+  // next phase programmatically, so hard-fail rather than forward a partial.
+  if (isIncompleteStopReason(planResult.stopReason)) {
+    throw new Error(
+      `plan phase returned an incomplete result (stopReason=${planResult.stopReason})`,
+    );
   }
 
   return planResult.message.content;

--- a/src/skills/mint/_phases/research.ts
+++ b/src/skills/mint/_phases/research.ts
@@ -4,7 +4,7 @@
  */
 
 import { SubagentManager } from '../../../agent/subagent.js';
-import { describeFailure } from '../../../agent/subagent/result.js';
+import { describeFailure, isIncompleteStopReason } from '../../../agent/subagent/result.js';
 import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { AgentModelInput } from '../../../agent/types.js';
@@ -54,6 +54,15 @@ export async function runResearchPhase(
 
   if (researchResult.status !== 'succeeded' || !researchResult.message) {
     throw new Error(`research phase failed: ${describeFailure(researchResult)}`);
+  }
+  // A `succeeded` result can still be an incomplete partial — the tool-use cap
+  // fired or the stream closed without a terminal message. Its `.message.content`
+  // is a truncated placeholder, not real research; the phase output feeds the
+  // next phase programmatically, so hard-fail rather than forward a partial.
+  if (isIncompleteStopReason(researchResult.stopReason)) {
+    throw new Error(
+      `research phase returned an incomplete result (stopReason=${researchResult.stopReason})`,
+    );
   }
 
   return researchResult.message.content;

--- a/src/skills/mint/_phases/ship.ts
+++ b/src/skills/mint/_phases/ship.ts
@@ -4,7 +4,7 @@
  */
 
 import { SubagentManager } from '../../../agent/subagent.js';
-import { describeFailure } from '../../../agent/subagent/result.js';
+import { describeFailure, isIncompleteStopReason } from '../../../agent/subagent/result.js';
 import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { AgentModelInput } from '../../../agent/types.js';
@@ -62,6 +62,15 @@ export async function runShipPhase(
 
   if (shipResult.status !== 'succeeded' || !shipResult.message) {
     throw new Error(`ship phase failed: ${describeFailure(shipResult)}`);
+  }
+  // A `succeeded` result can still be an incomplete partial — the tool-use cap
+  // fired or the stream closed without a terminal message. Its `.message.content`
+  // is a truncated placeholder, not the real ship summary, so hard-fail before
+  // emitting the card or returning the partial as the phase output.
+  if (isIncompleteStopReason(shipResult.stopReason)) {
+    throw new Error(
+      `ship phase returned an incomplete result (stopReason=${shipResult.stopReason})`,
+    );
   }
 
   const filesChanged = state.buildResults?.filesChanged.length ?? 0;

--- a/src/skills/mint/_phases/spec.ts
+++ b/src/skills/mint/_phases/spec.ts
@@ -4,7 +4,7 @@
  */
 
 import { SubagentManager } from '../../../agent/subagent.js';
-import { describeFailure } from '../../../agent/subagent/result.js';
+import { describeFailure, isIncompleteStopReason } from '../../../agent/subagent/result.js';
 import { resolveCredentialForModel } from '../../../agent/auth/credential-resolver.js';
 import { loadSkillPrompts } from '../../_lib/prompt-loader.js';
 import type { AgentModelInput } from '../../../agent/types.js';
@@ -59,6 +59,15 @@ export async function runSpecPhase(
 
   if (specResult.status !== 'succeeded' || !specResult.message) {
     throw new Error(`spec phase failed: ${describeFailure(specResult)}`);
+  }
+  // A `succeeded` result can still be an incomplete partial — the tool-use cap
+  // fired or the stream closed without a terminal message. Its `.message.content`
+  // is a truncated placeholder, not the real spec; the phase output feeds the
+  // next phase programmatically, so hard-fail rather than forward a partial.
+  if (isIncompleteStopReason(specResult.stopReason)) {
+    throw new Error(
+      `spec phase returned an incomplete result (stopReason=${specResult.stopReason})`,
+    );
   }
 
   return specResult.message.content;


### PR DESCRIPTION
## The bug

agent-afk's subagent runtime returns a `SubagentResult` with `status: 'succeeded'` **even when the run was incomplete** — either the tool-use iteration cap fired (`stopReason === 'tool_use_loop_capped'`) or the stream closed without a terminal message (`stopReason === 'stream_incomplete'`). The helper `isIncompleteStopReason(stopReason)` in `src/agent/subagent/result.ts` returns `true` for both.

`mint`'s phase dispatchers read a phase subagent's `.message.content` gated **only** on `status === 'succeeded'`, so an incomplete/placeholder partial was silently treated as the real phase output — and in mint that output is then fed programmatically into the **next** phase (spec → research → plan → build → verify → heal → ship).

This is the **same class** as the recent forge `STREAM_INCOMPLETE` guard, but it lands in mint's phase pipeline, which — unlike forge — has **no qualify gate downstream** to catch a degraded phase. A truncated spec/research/plan/heal/ship silently propagates instead of failing loudly.

## The fix

Extend each phase's existing status guard with an `isIncompleteStopReason(result.stopReason)` check that fires **before** `.message.content` is read.

- The five throw-style phases hard-fail with a clear, uniform message: `<phase> phase returned an incomplete result (stopReason=<...>)`.
- `parallelize-dispatch` returns its `{ kind: 'failed', error }` discriminated-union value (matching that file's existing idiom) instead of throwing.
- `isIncompleteStopReason` is imported via the existing relative path `../../../agent/subagent/result.js`, matching how the sibling phases already import `describeFailure` from that module.

`annotateIfIncomplete` is **deliberately not used** here. That helper is for content shown to a *model* as a tool result (see `fork-dispatch.ts`, `dag-subagent.ts`); mint consumes the content **programmatically** as the phase output, so an incomplete phase must **hard-fail**, not forward an annotated placeholder.

### The 6 fixed sites

| File | Guard style |
|------|-------------|
| `src/skills/mint/_phases/spec.ts` | throw before `return specResult.message.content` |
| `src/skills/mint/_phases/research.ts` | throw before `return researchResult.message.content` |
| `src/skills/mint/_phases/plan.ts` | throw before `return planResult.message.content` |
| `src/skills/mint/_phases/ship.ts` | throw before `emitCard` / `return shipResult.message.content` |
| `src/skills/mint/_phases/heal.ts` | throw before the `FIX_APPLIED:` regex reads `healResult.message.content` (heal's own try/catch converts the throw into a non-healed iteration — an incomplete heal is never trusted as a landed fix) |
| `src/skills/mint/_phases/parallelize-dispatch.ts` | return `{ kind: 'failed' }` before reading `result.message.content` |

## Verification

All gates run from a branch based on `main` (`166ebf7`); the diff is this single commit.

| Gate | Command | Result |
|------|---------|--------|
| Build | `pnpm build` (`tsc` + copy-prompts) | ✅ pass — no errors |
| Lint | `pnpm lint` (`tsc --noEmit`, strict) | ✅ pass — no errors |
| Tests | `pnpm test src/skills/mint` | ✅ **82 passed / 0 failed** across 4 files |

Test-file breakdown:
- `mint-phase-incomplete-guard.test.ts` — **12 passed** (new)
- `mint-parallelize-dispatch.test.ts` — **15 passed** (13 existing + 2 added)
- `mint.test.ts` — **53 passed** (unchanged)
- `mint-failed-parallelize.test.ts` — **2 passed** (unchanged)

## Added test coverage

New file `src/skills/mint-phase-incomplete-guard.test.ts` unit-tests the five throw-style phases directly (mocking `SubagentManager`, `loadSkillPrompts`, `resolveCredentialForModel`, and — for heal — `runVerifyPhase`):

- **spec / research / plan / ship**: assert the phase **rejects** with the `incomplete result (stopReason=...)` message for `tool_use_loop_capped` and/or `stream_incomplete`, and that a clean `succeeded` result (no incomplete stop reason) still returns its content — proving the guard does not over-trip.
- **heal**: asserts that an incomplete partial whose placeholder text *contains* `FIX_APPLIED: true` returns `healed: false`, increments the iteration counter, and **never reaches the re-verify phase** (`runVerifyPhase` not called) — this is the exact silent-trust path the guard closes. A control case proves a *clean* `FIX_APPLIED: true` result still flows through to re-verify.

Two cases added to `mint-parallelize-dispatch.test.ts` assert `runParallelizeDispatch` returns `{ kind: 'failed' }` (with the `incomplete result` + stop-reason in the error) for both stop reasons, mirroring the existing "succeeded but no message → failed" case.

The tests were confirmed to be non-vacuous: temporarily removing the `spec` guard makes the two spec throw-tests fail (the phase resolves with the truncated placeholder), and the guard restores them to green.

## Caveats / notes

- No caveats on coverage — every one of the 6 sites is exercised (5 via the new file, the 6th via the two added union-path cases).
- Only mint phase source + the two test files are touched; no unrelated files, no generated `dist/` (gitignored).
