### PR TITLE
fix(subagent): resolve zero-output stream-incomplete run as failed, not succeeded

### DIFF
--- a/src/agent/subagent/handle-streaming.test.ts
+++ b/src/agent/subagent/handle-streaming.test.ts
@@ -207,13 +207,56 @@ describe('SubagentHandle streaming', () => {
       expect(handle.status).toBe('succeeded');
     });
 
-    it('returns a stream-incomplete partial (not a throw) when the stream ends with neither message nor streamed content', async () => {
-      // Degradation contract: an empty cut-off stream (no terminal message, no
-      // buffered text, no error, and NOT the tool-use cap) must NOT throw an
-      // opaque "produced no terminal message". It returns a STREAM_INCOMPLETE
-      // partial (status 'succeeded') carrying a cut-off marker, so the parent
-      // gets an actionable incomplete result — annotateIfIncomplete flags it at
-      // the consumption boundary — instead of a bare delegation failure.
+    it('BUFFERED-PARTIAL branch STILL resolves SUCCEEDED (partial) with stopReason preserved — regression guard', async () => {
+      // Regression guard for the false-success fix: the fix throws ONLY on the
+      // ZERO-OUTPUT branch. A stream that ended with real buffered text but no
+      // terminal `message` event (a cut-off mid-output) MUST keep its prior
+      // contract — status:'succeeded' with stopReason:STREAM_INCOMPLETE — so its
+      // partial work is salvaged and flagged (via annotateIfIncomplete) at the
+      // consumption boundary, NOT reclassified as a failure. Only the
+      // empty-buffer case became a failure.
+      const events: OutputEvent[] = [
+        { type: 'chunk', chunk: { type: 'content', content: 'salvageable ' } },
+        { type: 'chunk', chunk: { type: 'content', content: 'partial findings' } },
+        { type: 'done' },
+      ];
+      const session = createDeterministicMockSession(events, {
+        role: 'assistant',
+        content: 'unused',
+        timestamp: new Date(),
+      });
+      const handle = new SubagentHandleImpl(
+        'subagent-buffered-partial-test',
+        session,
+        controller,
+        abortGraph,
+        undefined,
+        5000,
+        undefined,
+        vi.fn(),
+      );
+
+      const result = await handle.runToResult('p');
+      expect(result.status).toBe('succeeded');
+      expect(result.stopReason).toBe(STREAM_INCOMPLETE);
+      // The buffered text is preserved as the (partial) message content.
+      expect(result.message?.content).toBe('salvageable partial findings');
+      // Not a failure — no error attached on the succeeded-partial path.
+      expect(result.error).toBeUndefined();
+    });
+
+    it('resolves a ZERO-OUTPUT cut-off run as FAILED with stopReason preserved (not a false success)', async () => {
+      // False-success contract fix: an empty cut-off stream (no terminal
+      // message, no buffered text, no error, and NOT the tool-use cap — e.g. a
+      // first-token/TTFB timeout guillotines a connection stalled in the
+      // provider SDK's retry-backoff) must NOT resolve as status:'succeeded'.
+      // A zero-output timeout previously fell through to a synthetic-placeholder
+      // RETURN, which set status:'succeeded' — fooling every consumer whose only
+      // gate is `status === 'succeeded'`. It now THROWS a distinct
+      // StreamIncompleteError, so runToResult builds a status:'failed' result
+      // that carries the informative error message AND preserves
+      // stopReason:'stream_incomplete'. A consumer's natural `status !==
+      // 'succeeded'` check now catches it.
       const events: OutputEvent[] = [{ type: 'done' }];
       const session = createDeterministicMockSession(events, {
         role: 'assistant',
@@ -232,21 +275,31 @@ describe('SubagentHandle streaming', () => {
       );
 
       const result = await handle.runToResult('p');
-      expect(result.status).toBe('succeeded');
+      expect(result.status).toBe('failed');
+      // stopReason must survive on the failed result so callers can distinguish
+      // a stream-incomplete failure from an ordinary error.
       expect(result.stopReason).toBe(STREAM_INCOMPLETE);
-      expect(result.message?.content).toMatch(/without producing a final message/);
+      // The failure cause is informative (describeFailure(result) reads sensibly),
+      // not an opaque "produced no terminal message".
+      expect(result.error).toBeDefined();
+      expect(result.error?.name).toBe('StreamIncompleteError');
+      expect(result.error?.message).toMatch(/produced no output/);
+      // Zero output => no partial to salvage.
+      expect(result.partialOutput).toBeUndefined();
+      // The handle's own terminal status agrees.
+      expect(handle.status).toBe('failed');
     });
 
-    it('overwrites a clean terminal stopReason with STREAM_INCOMPLETE on an empty cut-off run', async () => {
-      // Codex PR #597 P2 regression guard. An empty-text turn that ends with a
-      // CLEAN terminal reason (end_turn / max_tokens) is dropped by the stream
-      // consumer before a `message` event is emitted (`assistant.message`:
-      // `if (event.text)`), so the empty-fallback branch is reached with
-      // lastStopReason already set to that clean reason. It MUST be overwritten
-      // to STREAM_INCOMPLETE (assignment, not `??=`): the returned content is a
-      // synthetic "no findings" placeholder, and preserving `end_turn` would let
-      // annotateIfIncomplete report that placeholder as a clean completion with
-      // no partial marker — the exact silent-success this branch exists to kill.
+    it('resolves FAILED with stopReason overwritten to STREAM_INCOMPLETE even when a clean terminal reason was set', async () => {
+      // Codex PR #597 P2 regression guard, updated for the failed-semantics fix.
+      // An empty-text turn that ends with a CLEAN terminal reason (end_turn /
+      // max_tokens) is dropped by the stream consumer before a `message` event
+      // is emitted (`assistant.message`: `if (event.text)`), so the zero-output
+      // branch is reached with lastStopReason already set to that clean reason.
+      // It MUST be overwritten to STREAM_INCOMPLETE (assignment, not `??=`)
+      // before the throw, so the FAILED result surfaces stopReason
+      // 'stream_incomplete' — never a clean 'end_turn' that would misreport the
+      // zero-output cutoff as a completed turn.
       const events: OutputEvent[] = [{ type: 'done', metadata: { stopReason: 'end_turn' } }];
       const session = createDeterministicMockSession(events, {
         role: 'assistant',
@@ -265,10 +318,10 @@ describe('SubagentHandle streaming', () => {
       );
 
       const result = await handle.runToResult('p');
-      expect(result.status).toBe('succeeded');
+      expect(result.status).toBe('failed');
       expect(result.stopReason).toBe(STREAM_INCOMPLETE);
       expect(result.stopReason).not.toBe('end_turn');
-      expect(result.message?.content).toMatch(/without producing a final message/);
+      expect(result.error?.name).toBe('StreamIncompleteError');
     });
 
     it('returns a capped partial result (not a throw) when the tool-use cap fires with no message', async () => {

--- a/src/agent/subagent/handle.ts
+++ b/src/agent/subagent/handle.ts
@@ -10,7 +10,7 @@
 import type { ZodType } from 'zod';
 import { AbortGraph } from '../abort-graph.js';
 import { debugLog } from '../../utils/debug.js';
-import { TimeoutError } from '../../utils/errors.js';
+import { StreamIncompleteError, TimeoutError } from '../../utils/errors.js';
 import type { HookRegistry } from '../hooks.js';
 import { withTimeout } from '../timeout.js';
 import type { IAgentSession, Message } from '../types.js';
@@ -455,40 +455,57 @@ export class SubagentHandleImpl<T> implements SubagentHandle<T> {
     //     throw so run()'s catch classifies the termination as 'cancelled' —
     //     not a success, not a plain failure.
     //   - Otherwise (an abnormal provider-stream close, or a mid-loop cutoff
-    //     with an empty buffer — the failure mode of an unbounded read-only
-    //     agent that tool-loops without ever emitting a final turn): degrade to
-    //     a STREAM_INCOMPLETE partial, the same treatment the buffered-text
-    //     branch above gives, so the consumption boundary (annotateIfIncomplete)
-    //     marks it as an incomplete result the parent can act on (retry / fall
-    //     back) instead of an opaque "produced no terminal message" delegation
-    //     failure after (often) a long run.
+    //     with an empty buffer — e.g. the first-token/TTFB timeout guillotines a
+    //     connection stalled in the provider SDK's internal 429/503/529
+    //     retry-backoff, or an unbounded read-only agent tool-loops without ever
+    //     emitting a final turn): throw a distinct StreamIncompleteError (below)
+    //     so run()'s catch classifies the termination as 'failed' — NOT a
+    //     succeeded-partial. See the History note below.
     if (this.controller.signal.aborted || this.currentStatus === 'cancelled') {
       throw new Error(`Subagent ${this.id} produced no terminal message`);
     }
-    // Invariant: this fallback stamps STREAM_INCOMPLETE UNCONDITIONALLY (`=`,
-    // not `??=`) — the content below is a synthetic placeholder, never the
-    // model's real output, so its stop reason must mark it incomplete. This
-    // differs from the buffered-text branch above, which uses `??=` deliberately:
-    // a capped run that also streamed text reaches there with
-    // `tool_use_loop_capped` already set and must keep it. Nothing worth
-    // preserving can reach HERE — the cap case returned at the
+    // History: this ZERO-OUTPUT branch previously stamped STREAM_INCOMPLETE and
+    // RETURNED a synthetic "[… ended without producing a final message …]"
+    // placeholder assistant message. Because it RETURNED (not threw), run()'s
+    // success path set currentStatus 'succeeded' and runToResult built a
+    // status:'succeeded' result — a zero-output timeout reported as a SUCCESS.
+    // That false success fooled every consumer whose only gate is
+    // `status === 'succeeded'` (it bit the forge skill and mint's phases); the
+    // sole thing protecting core consumers was the opt-in annotateIfIncomplete
+    // helper. Fix: THROW a distinct, non-opaque StreamIncompleteError. run()'s
+    // catch (signal NOT aborted here, status still 'running') takes its
+    // non-cascade `else` branch → currentStatus 'failed', and runToResult →
+    // buildResultFromError carries this error's message + the preserved
+    // stopReason. A consumer's natural `status !== 'succeeded'` check now catches
+    // the zero-output run, while describeFailure(result) still reads sensibly.
+    //
+    // Invariant: stamp STREAM_INCOMPLETE UNCONDITIONALLY (`=`, not `??=`) before
+    // the throw so buildResultFromError surfaces stopReason:'stream_incomplete'
+    // on the failed result (letting callers distinguish a stream-incomplete
+    // failure from an ordinary error). This differs from the buffered-text branch
+    // above, which uses `??=` deliberately: a capped run that also streamed text
+    // reaches there with `tool_use_loop_capped` already set and must keep it.
+    // Nothing worth preserving can reach HERE — the cap case returned at the
     // tool_use_loop_capped branch, and cancel/abort threw just above. Any
-    // stopReason still set is therefore a clean terminal one (end_turn /
-    // max_tokens / interrupted), none of which isIncompleteStopReason flags,
-    // reached via an empty-text turn the stream consumer drops before emitting a
-    // `message` event (see stream-consumer 'assistant.message': `if (event.text)`).
-    // Preserving it would let annotateIfIncomplete report this synthetic
-    // "no findings" placeholder as a clean completion — defeating the whole
-    // point of this branch. Overwrite it.
+    // stopReason still set is a clean terminal one (end_turn / max_tokens /
+    // interrupted) reached via an empty-text turn the stream consumer drops
+    // before emitting a `message` event (see stream-consumer 'assistant.message':
+    // `if (event.text)`); none of those describe this zero-output cutoff, so
+    // overwrite it.
+    //
+    // Do NOT downgrade this to a returned placeholder to "keep return, don't
+    // throw" — throwing is precisely what makes the run classify 'failed'. The
+    // original authors' concern (an OPAQUE failure the parent can't act on) is
+    // met by StreamIncompleteError's informative, actionable message, not by
+    // masking the failure as a success.
     this.lastStopReason = STREAM_INCOMPLETE;
-    return {
-      role: 'assistant',
-      content:
-        `[subagent ${this.id} ended without producing a final message or any ` +
-        `streamed output — it was cut off mid-run (an abnormal stream close), ` +
-        `so no findings were produced.]`,
-      timestamp: new Date(),
-    };
+    throw new StreamIncompleteError(
+      `subagent ${this.id} produced no output — its model stream ended without a ` +
+        `terminal message (stream_incomplete), and no partial text was streamed. ` +
+        `This is typically a first-token timeout while the provider was overloaded ` +
+        `(the connection was aborted mid retry-backoff). No findings were produced; ` +
+        `the parent should retry or fall back.`,
+    );
   }
 
   async runToResult(prompt: string, sinkOverride?: SubagentProgressSink): Promise<SubagentResult<T>> {

--- a/src/agent/subagent/result.ts
+++ b/src/agent/subagent/result.ts
@@ -16,24 +16,43 @@ import { TOOL_USE_LOOP_CAPPED } from '../providers/shared/tool-loop-cap.js';
 export type SubagentStatus = 'idle' | 'running' | 'succeeded' | 'failed' | 'cancelled';
 
 /**
- * Synthetic `stopReason` set by {@link SubagentHandle} when a run resolves with
- * partial assistant text but NO terminal `message` event — i.e. the child was
- * cut off mid-output (an abort, an early/abnormal provider-stream close, or a
- * provider that ended the stream without a final message). Distinct from
- * {@link TOOL_USE_LOOP_CAPPED} (the tool-use iteration cap). Both mean the
- * result the parent receives is an INCOMPLETE partial, not a final answer.
+ * Synthetic `stopReason` set by {@link SubagentHandle} when a run ends with NO
+ * terminal `message` event — the child was cut off mid-output (an abort, an
+ * early/abnormal provider-stream close, or a provider that ended the stream
+ * without a final message). Distinct from {@link TOOL_USE_LOOP_CAPPED} (the
+ * tool-use iteration cap).
+ *
+ * It surfaces on the result in TWO distinct shapes, split by whether any text
+ * was streamed before the cutoff:
+ *
+ *   - BUFFERED PARTIAL (`status: 'succeeded'`): the child streamed real
+ *     assistant text before being cut off. The partial work is salvaged and the
+ *     result stays succeeded; consumers prepend a parent-visible marker via
+ *     {@link annotateIfIncomplete} so the model treats it as an incomplete
+ *     intermediate finding rather than a final answer.
+ *   - ZERO OUTPUT (`status: 'failed'`): the stream ended with an EMPTY buffer
+ *     (no terminal message, no streamed text) and the run was NOT
+ *     cancelled/cascade-aborted — e.g. a first-token/TTFB timeout guillotines a
+ *     connection stalled in the provider SDK's retry-backoff. There is nothing
+ *     to salvage, so the run resolves FAILED (via a thrown
+ *     {@link import('../../utils/errors.js').StreamIncompleteError}) with this
+ *     stopReason preserved. A consumer's `status !== 'succeeded'` check catches
+ *     it; {@link describeFailure} reads the actionable error message.
  *
  * Kept a distinct sentinel (not a provider stop reason) so callers can
- * recognise it: a clean turn always sets a real terminal message, so this
- * value only ever appears on a genuinely truncated run.
+ * recognise it: a clean turn always sets a real terminal message, so this value
+ * only ever appears on a genuinely truncated run.
  */
 export const STREAM_INCOMPLETE = 'stream_incomplete';
 
 /**
  * True when `stopReason` indicates the subagent did NOT reach a clean final
- * answer — it was capped by the tool-use budget or cut off mid-stream. A
- * `status: 'succeeded'` result with such a stopReason carries partial content
- * that consumers must NOT present to the parent model as a complete answer.
+ * answer — it was capped by the tool-use budget ({@link TOOL_USE_LOOP_CAPPED})
+ * or cut off mid-stream ({@link STREAM_INCOMPLETE}). Applies to a
+ * `status: 'succeeded'` result whose content is a partial that consumers must
+ * NOT present to the parent model as a complete answer. Note: the ZERO-OUTPUT
+ * {@link STREAM_INCOMPLETE} case resolves `status: 'failed'` (nothing to
+ * salvage) and so is surfaced through the failure path — not annotated here.
  */
 export function isIncompleteStopReason(stopReason: string | undefined): boolean {
   return stopReason === TOOL_USE_LOOP_CAPPED || stopReason === STREAM_INCOMPLETE;
@@ -44,8 +63,10 @@ export function isIncompleteStopReason(stopReason: string | undefined): boolean 
  * {@link isIncompleteStopReason}), prepend a parent-visible marker so the model
  * consuming the tool result treats the text as a truncated intermediate finding
  * rather than a conclusion. No-op for clean completions — returns `content`
- * unchanged. This is the single consumption-boundary fix for the
- * "subagent returns a partial result reported as success" class.
+ * unchanged. This is the consumption-boundary fix for the "subagent returns a
+ * partial result reported as success" class (the buffered-partial case). The
+ * zero-output {@link STREAM_INCOMPLETE} case resolves `status: 'failed'` and is
+ * handled by each caller's failure path, not by this annotate helper.
  */
 export function annotateIfIncomplete(content: string, stopReason: string | undefined): string {
   if (!isIncompleteStopReason(stopReason)) return content;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -36,6 +36,35 @@ export class HookBlockedError extends Error {
 }
 
 /**
+ * Thrown by a forked sub-agent's `streamToFinalMessage` when its model stream
+ * ends with NO terminal assistant message AND an EMPTY streamed buffer, and the
+ * run was NOT user-cancelled or cascade-aborted (e.g. the first-token/TTFB
+ * timeout guillotines a connection stalled inside the provider SDK's internal
+ * 429/503/529 retry-backoff). The child produced zero output, so there is
+ * nothing to salvage as a partial.
+ *
+ * This is thrown — not returned as a synthetic-placeholder "success" — so the
+ * termination classifies as `status: 'failed'` (via `run()`'s catch → the
+ * non-cascade `else` branch), letting any consumer's natural `status !==
+ * 'succeeded'` check catch the zero-output timeout instead of being fooled by a
+ * false success. It is deliberately DISTINCT from `AbortError` (which the catch
+ * would classify `'cancelled'`) and carries an actionable, non-opaque message
+ * so the parent can act (retry / fall back) rather than see a bare failure.
+ * `SubagentResult.stopReason` is preserved as `'stream_incomplete'` alongside
+ * this error (see {@link import('../agent/subagent/result.js').STREAM_INCOMPLETE}).
+ *
+ * Contrast: a stream that ended with buffered partial text (real streamed
+ * output) is NOT this — it stays a succeeded-partial so its work is salvaged
+ * and annotated at the consumption boundary.
+ */
+export class StreamIncompleteError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StreamIncompleteError";
+  }
+}
+
+/**
  * Thrown by {@link consumeSdkStream} when the session's cumulative cost
  * crosses the `maxBudgetUsd` ceiling. The throw propagates through
  * `runSessionLifecycle`'s catch block, which ensures `messageQueue` is


### PR DESCRIPTION
## The bug (false-success contract)

When a forked subagent's model turn ends with **no terminal assistant message and an empty buffer** — e.g. the ~180s first-token/TTFB timeout aborts a connection stalled in the Anthropic SDK's internal 429/503/529 retry-backoff — and the run was **not** user-cancelled, `streamToFinalMessage` in `src/agent/subagent/handle.ts` fell through to a final synthetic-placeholder branch. That branch stamped `stopReason = stream_incomplete` and **RETURNED** a placeholder assistant message.

Because it **returned** (did not throw), the success path set `currentStatus = 'succeeded'` and `runToResult` → `buildResultFromMessage(id, 'succeeded', …, stopReason='stream_incomplete')`. Result: **a zero-output timeout was reported as `status:'succeeded'`, turnCount 0.** This "false success" fools any consumer that checks only `status === 'succeeded'` — it already bit the **forge** skill and **mint**'s phases. The only thing protecting core consumers was the opt-in `annotateIfIncomplete` helper.

## The fix (exact semantic change)

The **zero-output** synthetic-placeholder branch now **throws a distinct, informative `StreamIncompleteError`** (new class in `src/utils/errors.ts`) instead of returning a placeholder:

- `run()`'s catch runs with the signal **not** aborted and status still `running`, so it takes its **non-cascade `else` branch** → `currentStatus = 'failed'`.
- `runToResult` → `buildResultFromError` carries the error's actionable message **and preserves `stopReason: 'stream_incomplete'`** on the failed result.
- A consumer's natural `status !== 'succeeded'` check now catches the zero-output run, and `describeFailure(result)` reads sensibly — **not** an opaque failure. The class is deliberately **not** an `AbortError`, so the run is never misclassified `'cancelled'` (that stays reserved for user/cascade aborts).

**Deliberately unchanged:**
- **BUFFERED-PARTIAL branch** (real streamed text, `lastStreamedContent.length > 0`): still resolves **succeeded-partial** with `stopReason` `stream_incomplete` (kept via `??=`), so its partial work is salvaged + annotated at the consumption boundary. A regression-guard test pins this.
- **tool-use-cap branch** (`tool_use_loop_capped`) and the **cancel/abort throw** are untouched.

### Which approach (a vs b) and why

Chose **approach (b): throw a distinct non-cancel error.** Rationale:

- **(a)** (set `currentStatus='failed'` and return the placeholder) yields a failed result carrying a `message` + `stopReason` but **no `error`** — so `describeFailure(result)` would read just `"failed"` (uninformative), and the four failure paths that read `result.error?.message` would fall back to generic strings. Making it informative would require modifying the shared `buildResultFromMessage` to synthesize an error for the failed+incomplete case, which risks the existing schema-mismatch path (also `status:'failed'` with an error) — larger blast radius.
- **(b)** yields `status:'failed'` + preserved `stopReason` + an **informative `error.message`** via the existing `buildResultFromError`, with the change localized to `handle.ts` + one new error class. `describeFailure` reads `"failed: subagent … produced no output …"`. `partialOutput` is correctly absent (there is none). Smallest blast radius, least test churn, honors the original authors' "return, don't throw an *opaque* failure" intent by throwing an **informative** one.

## Blast radius — the four `annotateIfIncomplete` sites

They only annotate on `status === 'succeeded'`. A zero-output run is now `status:'failed'`, so each takes its **failure** path (audited, all sensible — no crash, no silent drop, no unintended parent abort):

| Site | Behavior now on a failed zero-output result |
|---|---|
| `agent/tools/skill-executor/fork-dispatch.ts:357` | `errorMessage = result.error?.message ?? noOutputError` resolves to the `StreamIncompleteError` message → `{ content, isError: true }` |
| `agent/tools/subagent/foreground-promotion.ts:246` | emits `subagent.failed` telemetry → `buildFailurePayload({status:'failed', errorMessage, …})` → `{ content: JSON.stringify(payload), isError: true }` |
| `agent/dag-subagent.ts:160` | `status !== 'succeeded'` → throws `result.error` (decorated via `attachSubagentContext`) → DAG node rejects → `failFast` aborts the DAG (fails fast, downstream skipped) |
| `cli/commands/interactive/bg-result-notifier.ts:91` | `job.status==='failed'` is NOT notice-only (only `cancelled` is) → **injected** into the parent's next turn as `Subagent failed — StreamIncompleteError: <msg>` |

The **buffered-partial** case still hits the annotate/success path (unchanged). Two further consumers **improve** automatically (they were previously fooled by the false success): `agent/subagent/wave.ts` `failFast` and `skills/mint/_phases/parallelize-dispatch.ts` now correctly fail-fast on a zero-output run.

## Tests

- Updated the two `handle-streaming.test.ts` tests that asserted the old `succeeded`+placeholder behavior → now assert `status:'failed'`, preserved `stopReason:'stream_incomplete'`, an informative `StreamIncompleteError`, and absent `partialOutput`.
- Added a **regression guard** asserting the BUFFERED-PARTIAL branch STILL yields `succeeded` + `stopReason:'stream_incomplete'` (partial work preserved, no error).
- Updated doc comments in `result.ts` (`STREAM_INCOMPLETE`, `isIncompleteStopReason`, `annotateIfIncomplete`) and the `Invariant:`/`History:` blocks in `handle.ts` to the new failed semantics.

## Files changed

- `src/utils/errors.ts` — new `StreamIncompleteError` class (+ doc).
- `src/agent/subagent/handle.ts` — zero-output branch throws instead of returning; comments updated.
- `src/agent/subagent/result.ts` — doc comments reflect the failed-vs-succeeded-partial split.
- `src/agent/subagent/handle-streaming.test.ts` — updated 2 tests + added 1 regression guard.

## Verification (all green)

| Gate | Result |
|---|---|
| `pnpm install` | OK (fresh worktree; benign postinstall MODULE_NOT_FOUND pre-build) |
| `pnpm build` (`tsc && copy-prompts`) | ✅ exit 0 |
| `pnpm lint` (`tsc --noEmit`, strict) | ✅ exit 0 |
| `pnpm test` (full suite) | ✅ **668 files, 12196 passed, 14 skipped, 0 failed** |
| `pnpm test:coverage` (CI gate, hard thresholds) | ✅ exit 0 (thresholds met; `src/utils/errors.ts` 100%) |
| `pnpm audit:sdk:check` | ✅ "Lock matches current imports" |
| `pnpm scan:env:check` | ✅ "in sync" |

## Reviewer notes / caveats

- No public API signature changed; `SubagentResult` shape is unchanged (the `failed` result simply now populates `error` + `stopReason` for this case). No SDK import added; no env change.
- Behavior change reviewers should know: any caller that *relied on* the old false-success (treating a zero-output timeout as a usable succeeded result) will now see a `failed` result. That is the intended correction — the four core sites and the two `failFast` consumers all handle it correctly, surfacing the actionable error.
