### PR TITLE
feat(trace): tag forked-child tool_call events with subagentId (#612)

### DIFF
--- a/src/agent/hooks-integration.test.ts
+++ b/src/agent/hooks-integration.test.ts
@@ -494,6 +494,41 @@ describe('SubagentManager — hook integration', () => {
     );
   });
 
+  it('stamps the fork\'s own id onto child config.subagentId, equal to the handle id (issue #612)', async () => {
+    // The child's provider loop reads AgentConfig.subagentId to tag every
+    // tool_call trace event so a fork's work is attributable in the shared
+    // parent trace. The stamped id MUST equal the returned handle id (the id
+    // used by subagent_lifecycle.started), or a reader could not correlate a
+    // tagged tool_call with the child that emitted it.
+    const mgr = new SubagentManager();
+    shared.lastConfig = null;
+    const handle = await mgr.forkSubagent({
+      parent: { sessionId: 'parent-xyz' },
+      config: { model: 'sonnet' },
+    });
+
+    expect(shared.lastConfig).toEqual(
+      expect.objectContaining({ subagentId: handle.id }),
+    );
+  });
+
+  it('the fork-assigned subagentId wins over any inherited config.subagentId (nested fork safety)', async () => {
+    // A nested fork (child forks grandchild) must not inherit the parent's
+    // subagentId via the `...options.config` spread — the manager-assigned id
+    // is authoritative. Simulate a config that already carries a stale id.
+    const mgr = new SubagentManager();
+    shared.lastConfig = null;
+    const handle = await mgr.forkSubagent({
+      parent: { sessionId: 'parent-xyz' },
+      config: { model: 'sonnet', subagentId: 'stale-parent-id' },
+    });
+
+    expect((shared.lastConfig as { subagentId?: string } | null)?.subagentId).toBe(handle.id);
+    expect((shared.lastConfig as { subagentId?: string } | null)?.subagentId).not.toBe(
+      'stale-parent-id',
+    );
+  });
+
   it('child config.hookRegistry takes precedence over manager-level registry', async () => {
     const managerRegistry = createHookRegistry();
     const childRegistry = createHookRegistry();

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -920,6 +920,7 @@ export class AnthropicDirectProvider implements ModelProvider {
       ...(resolvedEffort !== undefined ? { effort: resolvedEffort } : {}),
       ...(localMode ? { baseUrl: config.baseUrl } : {}),
       ...(config.traceWriter ? { traceWriter: config.traceWriter } : {}),
+      ...(config.subagentId !== undefined ? { subagentId: config.subagentId } : {}),
       ...(config.autoResumeOnUsageLimit !== undefined
         ? { autoResumeOnUsageLimit: config.autoResumeOnUsageLimit }
         : {}),

--- a/src/agent/providers/anthropic-direct/loop.trace.test.ts
+++ b/src/agent/providers/anthropic-direct/loop.trace.test.ts
@@ -273,6 +273,99 @@ describe('loop.ts runTurn — witness-layer tool_call emission', () => {
     await new Promise((resolve) => setImmediate(resolve));
     expect(writer.events).toHaveLength(0);
   });
+
+  // Issue #612: a forked child resumes the parent's sessionId and writes into
+  // the SHARED parent trace file, so its tool_call events must carry the fork's
+  // `subagentId` to be attributable in `afk trace show`. `RunTurnInput.subagentId`
+  // is the loop-level end of the thread AgentConfig.subagentId → provider query.
+  it('tags tool_call started+completed with subagentId when the loop runs inside a fork', async () => {
+    const { InMemoryTraceWriter } = await import('../../trace/writer.js');
+    const writer = new InMemoryTraceWriter();
+
+    let callIdx = 0;
+    const streams = [
+      () => fromArray(makeToolUseStream('tu_child', 'bash', '{}')),
+      () => fromArray(makeTextStream('done', 'end_turn')),
+    ];
+    const client: AnthropicClientLike = {
+      messages: {
+        create: vi.fn(() => streams[callIdx++ % streams.length]!()),
+      },
+    };
+    const dispatcher = makeDispatcher(async () => ({ content: 'ok', isError: false }));
+
+    await collect(
+      runTurn({
+        client,
+        messages: [{ role: 'user', content: 'run the suite' }],
+        system: null,
+        tools: [{ name: 'bash', input_schema: { type: 'object' } }],
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 1024,
+        headers: {},
+        signal: new AbortController().signal,
+        ctx,
+        traceWriter: writer,
+        subagentId: 'research-agent-1700000000000-3',
+      }),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const toolCalls = writer.events.filter((e) => e.kind === 'tool_call');
+    expect(toolCalls).toHaveLength(2);
+    if (toolCalls[0]?.kind !== 'tool_call' || toolCalls[1]?.kind !== 'tool_call') {
+      throw new Error('unreachable');
+    }
+    // Both phases carry the fork id, so a reader can attribute the started AND
+    // completed halves of the same call to the child that made it.
+    expect(toolCalls[0].payload.subagentId).toBe('research-agent-1700000000000-3');
+    expect(toolCalls[1].payload.subagentId).toBe('research-agent-1700000000000-3');
+  });
+
+  it('omits subagentId from tool_call events for a top-level (non-fork) loop', async () => {
+    const { InMemoryTraceWriter } = await import('../../trace/writer.js');
+    const writer = new InMemoryTraceWriter();
+
+    let callIdx = 0;
+    const streams = [
+      () => fromArray(makeToolUseStream('tu_root', 'search', '{}')),
+      () => fromArray(makeTextStream('done', 'end_turn')),
+    ];
+    const client: AnthropicClientLike = {
+      messages: {
+        create: vi.fn(() => streams[callIdx++ % streams.length]!()),
+      },
+    };
+    const dispatcher = makeDispatcher(async () => ({ content: 'r', isError: false }));
+
+    await collect(
+      runTurn({
+        client,
+        messages: [{ role: 'user', content: 'x' }],
+        system: null,
+        tools: [{ name: 'search', input_schema: { type: 'object' } }],
+        toolDispatcher: dispatcher,
+        model: 'claude-test',
+        maxTokens: 1024,
+        headers: {},
+        signal: new AbortController().signal,
+        ctx,
+        traceWriter: writer,
+        // subagentId omitted intentionally — this is a root session.
+      }),
+    );
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const toolCalls = writer.events.filter((e) => e.kind === 'tool_call');
+    expect(toolCalls).toHaveLength(2);
+    for (const tc of toolCalls) {
+      if (tc.kind !== 'tool_call') throw new Error('unreachable');
+      // The key must be ABSENT (not present-with-undefined) so JSONL lines stay
+      // clean and the reader renders no orphan `[subagentId]` on root calls.
+      expect('subagentId' in tc.payload).toBe(false);
+    }
+  });
 });
 
 describe('loop.ts runTurn — render-only diff sidecar', () => {

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -784,6 +784,7 @@ export async function* runTurn(
         toolUseId: block.id,
         name: block.name,
         inputBytes: Buffer.byteLength(JSON.stringify(block.input ?? {}), 'utf8'),
+        ...(input.subagentId !== undefined ? { subagentId: input.subagentId } : {}),
       });
       yield {
         type: 'tool.use.start',
@@ -868,6 +869,7 @@ export async function* runTurn(
         ...(typeof result.batchIndex === 'number' && typeof result.batchSize === 'number'
           ? { batchIndex: result.batchIndex, batchSize: result.batchSize }
           : {}),
+        ...(input.subagentId !== undefined ? { subagentId: input.subagentId } : {}),
       });
 
       yield {

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -144,6 +144,13 @@ export interface AnthropicDirectQueryOptions {
   /** Witness-layer trace writer threaded into each per-turn run. */
   traceWriter?: import('../../trace/index.js').TraceWriter;
   /**
+   * Owning subagent id when this query runs inside a forked child
+   * (`AgentConfig.subagentId`). Threaded into `RunTurnInput.subagentId` so the
+   * loop's `tool_call` events are attributable in the shared parent trace.
+   * Absent for a top-level session. See issue #612.
+   */
+  subagentId?: string;
+  /**
    * When true (default), the query automatically waits for the OAuth
    * subscription reset and replays the in-flight turn on 429 usage-limit
    * errors instead of surfacing them immediately.
@@ -232,6 +239,8 @@ export class AnthropicDirectQuery implements ProviderQuery {
   private readonly baseUrl?: string;
   private readonly maxToolUseIterations?: number;
   private readonly traceWriter?: import('../../trace/index.js').TraceWriter;
+  /** Owning subagent id (fork only); stamped onto tool_call trace events. */
+  private readonly subagentId?: string;
 
   /**
    * Per-session mutable state — see {@link SessionState}. Held as a
@@ -281,6 +290,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
     if (opts.maxToolUseIterations !== undefined)
       this.maxToolUseIterations = opts.maxToolUseIterations;
     this.traceWriter = opts.traceWriter;
+    if (opts.subagentId !== undefined) this.subagentId = opts.subagentId;
     this.cwdDependentsFactory = opts.cwdDependentsFactory;
     this.onPermissionMode = opts.onPermissionMode;
     this.mcpManager = opts.mcpManager;
@@ -414,6 +424,7 @@ export class AnthropicDirectQuery implements ProviderQuery {
             ? { maxToolUseIterations: this.maxToolUseIterations }
             : {}),
           ...(this.traceWriter ? { traceWriter: this.traceWriter } : {}),
+          ...(this.subagentId !== undefined ? { subagentId: this.subagentId } : {}),
           ...(this.throttleQueue ? { throttleQueue: this.throttleQueue } : {}),
           onUsageProgress: (usage) => { this.state.lastUsage = usage; },
         };

--- a/src/agent/providers/anthropic-direct/types.ts
+++ b/src/agent/providers/anthropic-direct/types.ts
@@ -248,6 +248,13 @@ export interface RunTurnInput {
    *  after each result. See `docs/philosophy/afk-contract.md`. */
   traceWriter?: import('../../trace/index.js').TraceWriter;
   /**
+   * This loop's owning subagent id, present only when the loop runs inside a
+   * forked child (`AgentConfig.subagentId`). Stamped onto every `tool_call`
+   * started/completed event so a fork's tool calls are attributable in the
+   * shared parent trace. Absent for a top-level session — its tool calls stay
+   * untagged. See issue #612. */
+  subagentId?: string;
+  /**
    * Optional hook fired once per completed round (both tool-use rounds
    * and the terminal end_turn round) with the cumulative usage so far,
    * so the REPL status line can show live mid-turn context usage. The

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -2505,6 +2505,52 @@ describe('OpenAICompatibleQuery — witness-layer trace emission', () => {
     expect(completed.payload.truncated).toBe(false);
     expect(completed.payload.durationMs).toBeGreaterThanOrEqual(0);
     expect(completed.payload.resultBytes).toBeGreaterThan(0);
+
+    // Issue #612: a top-level session must NOT tag its tool_call events — the
+    // key stays absent so the reader renders no orphan `[subagentId]`.
+    expect('subagentId' in started.payload).toBe(false);
+    expect('subagentId' in completed.payload).toBe(false);
+  });
+
+  // Issue #612: when the query runs inside a forked child, `config.subagentId`
+  // is set at the fork site (subagent.ts) and must flow onto every tool_call
+  // trace event so the child's work is attributable in the shared parent trace.
+  it('tags tool_call events with config.subagentId when running inside a fork', async () => {
+    const { InMemoryTraceWriter } = await import('../../trace/writer.js');
+    const writer = new InMemoryTraceWriter();
+
+    installToolThenTextClient('call_bash_1', 'bash', '{"cmd":"pnpm test"}');
+
+    const { dispatcher } = makeDispatcherForPR2();
+    (dispatcher as unknown as { handlers: Map<string, unknown> }).handlers?.set(
+      'bash',
+      async () => ({ content: 'suite passed' }),
+    );
+
+    const q = new OpenAICompatibleQuery({
+      auth: { apiKey: 'sk-test', source: 'env:OPENAI_API_KEY' },
+      model: 'gpt-4o-mini',
+      synthesizedSessionId: 'parent-session',
+      promptStream: singleInput('run the suite'),
+      // A forked child carries its own subagentId on the config.
+      config: {
+        model: 'gpt-4o-mini',
+        apiKey: 'sk-test',
+        subagentId: 'research-agent-1700000000000-3',
+      } as AgentConfig,
+      toolDispatcher: dispatcher,
+      traceWriter: writer,
+    });
+
+    await collect(q);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const toolCallEvents = writer.events.filter((e) => e.kind === 'tool_call');
+    expect(toolCallEvents).toHaveLength(2);
+    for (const e of toolCallEvents) {
+      if (e.kind !== 'tool_call') throw new Error('unreachable');
+      expect(e.payload.subagentId).toBe('research-agent-1700000000000-3');
+    }
   });
 
   it('emits session_phase loop_start and loop_end for each turn', async () => {

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -820,6 +820,10 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       traceWriter: this.traceWriter,
       priorTurns: this.priorTurns,
       sessionId: this.initSessionId,
+      // Owning subagent id (fork only) so tool_call trace events are
+      // attributable in the shared parent trace — issue #612. Read from
+      // config, the same source this query reads autoCompact/permissionMode.
+      subagentId: this.opts.config.subagentId,
     });
   }
 

--- a/src/agent/providers/openai-compatible/query/dispatch-append.ts
+++ b/src/agent/providers/openai-compatible/query/dispatch-append.ts
@@ -25,6 +25,13 @@ export interface DispatchAndAppendInput {
   traceWriter: TraceWriter | undefined;
   priorTurns: OpenAIMessage[];
   sessionId: string;
+  /**
+   * Owning subagent id when this dispatch runs inside a forked child
+   * (`AgentConfig.subagentId`). Stamped onto every `tool_call` started/completed
+   * event so a fork's tool calls are attributable in the shared parent trace
+   * (a child resumes the parent's sessionId). Absent for a top-level session.
+   * See issue #612. */
+  subagentId?: string | undefined;
 }
 
 /**
@@ -47,6 +54,7 @@ export async function* dispatchAndAppendToolCalls({
   traceWriter,
   priorTurns,
   sessionId,
+  subagentId,
 }: DispatchAndAppendInput): AsyncGenerator<ProviderEvent, ToolResult | undefined> {
   if (!toolDispatcher) {
     // Shouldn't reach here — runIteration won't return needsToolDispatch=true
@@ -91,6 +99,7 @@ export async function* dispatchAndAppendToolCalls({
       toolUseId: call.id,
       name: call.name,
       inputBytes: Buffer.byteLength(JSON.stringify(call.input ?? {}), 'utf8'),
+      ...(subagentId !== undefined ? { subagentId } : {}),
     });
     yield {
       type: 'tool.use.start',
@@ -185,6 +194,7 @@ export async function* dispatchAndAppendToolCalls({
         ...(typeof result.batchIndex === 'number' && typeof result.batchSize === 'number'
           ? { batchIndex: result.batchIndex, batchSize: result.batchSize }
           : {}),
+        ...(subagentId !== undefined ? { subagentId } : {}),
       });
 
       yield {

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -671,6 +671,16 @@ export class SubagentManager {
       ...options.config,
       resume,
       forkSession: resume ? true : options.config.forkSession,
+      // Witness attribution: stamp THIS fork's own id onto its config so the
+      // child's provider loop tags every `tool_call` started/completed event
+      // with `subagentId: id`. Placed AFTER the `...options.config` spread so
+      // the manager-assigned `id` (line ~550) always wins — it is authoritative
+      // and MUST match the id on the `subagent_lifecycle.started` emit below,
+      // or a trace reader could not correlate a tool call with its child. A
+      // child resumes the parent's sessionId and writes into the SHARED parent
+      // trace file, so without this tag the parent trace cannot say which fork
+      // ran which tool (issue #612).
+      subagentId: id,
       abortSignal: childController.signal,
       // Invariant (cross-provider credential anti-leak): the parent-credential
       // fallback below must never hand a credential across the provider

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -527,6 +527,19 @@ export interface AgentConfig {
   /** Parent session ID when this session was forked as a subagent. */
   parentSessionId?: string;
 
+  /**
+   * This session's own subagent id when it was forked as a subagent — the
+   * `SubagentHandle.id` assigned by `SubagentManager.forkSubagent`. Set on the
+   * child config at the fork site (subagent.ts); undefined for a top-level
+   * session. Threaded into the provider loop so the witness `tool_call`
+   * started/completed events emitted by this session carry `subagentId`,
+   * letting `afk trace show` attribute which child ran which tool when a fork
+   * writes into the shared parent trace file (a child resumes the parent's
+   * sessionId, so `sessionId` alone cannot disambiguate). Matches the id on the
+   * `subagent_lifecycle.started` event for cross-correlation.
+   */
+  subagentId?: string;
+
   /** Nesting depth assigned at fork (0-indexed). Top-level → undefined. */
   depth?: number;
 

--- a/src/cli/commands/trace.test.ts
+++ b/src/cli/commands/trace.test.ts
@@ -178,6 +178,43 @@ describe('formatTrace — subagent timeout markers', () => {
   });
 });
 
+describe('formatTrace — subagentId attribution on tool_call (issue #612)', () => {
+  // A forked child resumes the parent's sessionId and writes into the shared
+  // parent trace, so `afk trace show` must render `[subagentId]` on the child's
+  // tool_call lines — otherwise a timed-out child's actual work is unattributable.
+  it('renders [subagentId] on a completed tool_call emitted by a fork', () => {
+    const events: EventObj[] = [
+      { ts: '2026-06-05T12:30:00.000Z', seq: 0, kind: 'tool_call', payload: { phase: 'completed', toolUseId: 'tu-child', name: 'bash', resultBytes: 40, isError: false, truncated: false, durationMs: 20, subagentId: 'research-agent-1700000000000-3' } },
+    ];
+    const out = formatTrace('s', '/p', parseTrace(toJsonl(events)));
+    expect(out).toContain('bash');
+    expect(out).toContain('[research-agent-1700000000000-3]');
+  });
+
+  it('renders an orphan started tool_call from a fork with its [subagentId]', () => {
+    // An orphaned `started` (no matching completed) is shown by default — the
+    // exact "child crashed/timed out mid-tool" case issue #612 is about.
+    const events: EventObj[] = [
+      { ts: '2026-06-05T12:30:00.000Z', seq: 0, kind: 'tool_call', payload: { phase: 'started', toolUseId: 'tu-orphan', name: 'bash', inputBytes: 30, subagentId: 'research-agent-1700000000000-3' } },
+    ];
+    const out = formatTrace('s', '/p', parseTrace(toJsonl(events)));
+    expect(out).toContain('started (no completion recorded)');
+    expect(out).toContain('[research-agent-1700000000000-3]');
+  });
+
+  it('renders no [subagentId] suffix for a root (non-fork) tool_call', () => {
+    const events: EventObj[] = [
+      { ts: '2026-06-05T12:30:00.000Z', seq: 0, kind: 'tool_call', payload: { phase: 'completed', toolUseId: 'tu-root', name: 'read_file', resultBytes: 40, isError: false, truncated: false, durationMs: 20 } },
+    ];
+    const out = formatTrace('s', '/p', parseTrace(toJsonl(events)));
+    // Target the tool line specifically — the header may legitimately contain
+    // brackets, but a root tool_call line must carry no `[id]` suffix.
+    const toolLine = out.split('\n').find((l) => l.includes('read_file'));
+    expect(toolLine).toBeDefined();
+    expect(toolLine).not.toContain('[');
+  });
+});
+
 describe('formatTrace — rate_limit is high-signal (shown by default)', () => {
   // Regression: a rate_limit event is a session_phase, and session_phase is
   // hidden by default (latency waterfall). But throttling is the whole reason a


### PR DESCRIPTION
Closes #612.

## Problem

A forked sub-agent **resumes the parent's `sessionId`** and writes into the **shared parent `trace.jsonl`** (`effectiveTraceWriter` inheritance, `subagent.ts:573`). So `sessionId` alone cannot tell you *which* child ran a given tool. PR #610 added `subagentId` to `subagent_lifecycle.started` and **pre-provisioned** the field on `ToolCallStartedPayload`/`ToolCallCompletedPayload` (+ the Zod validator in `trace/events.ts` + the reader render in `cli/commands/trace.ts`), but **deferred the per-tool-call emission**. Net effect: `afk trace show` rendered a fork's tool calls with no `[subagentId]`, so a timed-out child's actual work (e.g. reconstructing #607: "ran `pnpm test` 30x in 20 min") was operator inference, not a captured log.

This closes the emission gap — the last hop of the observability chain the schema/reader were already waiting for.

## Fix

Thread the fork's own `SubagentHandle.id` from the fork site to both providers' `tool_call` emit sites, mirroring exactly how `traceWriter` already flows:

- **`AgentConfig.subagentId`** (new, optional; `undefined` for top-level sessions).
- **Fork site** (`subagent.ts`) stamps `subagentId: id` onto `childConfig` **after** the `...options.config` spread, so the manager-assigned id is authoritative and **matches the id on `subagent_lifecycle.started`** (correlation invariant — a reader can line up a `[subagentId]` tool call with the child's lifecycle event).
- **anthropic-direct**: `config` -> `query()` -> `AnthropicDirectQueryOptions` -> `RunTurnInput.subagentId` -> `emitToolCall` (started + completed).
- **openai-compatible**: read `this.opts.config.subagentId` (the same source the query already reads `autoCompact`/`permissionMode` from) -> `DispatchAndAppendInput` -> emit.

Root-session tool calls stay **untagged** (key omitted, not present-with-`undefined`) so JSONL lines stay clean and the reader renders no orphan suffix. **No schema change** (payload + Zod already accept it); **no new SDK or env surface** (`audit:sdk:check`, `audit:env:check`, `scan:env:check` all green).

## Ask #2 — parent-trace seal investigation (session `1e4fae55`)

Investigated whether foreground subagents dispatched in a later REPL turn are covered by the parent trace. **Finding: the parent trace stays OPEN across REPL turns and child lifecycles — no code change needed.** One `NdjsonTraceWriter` is created once at REPL bootstrap and reused; it seals only at REPL exit / `/clear` / `/resume` / an init-phase provider error. A fork's `onTerminal` never seals the parent, and `subagent-terminal-seal-race.test.ts` already locks that a child's terminal lifecycle event is durably written before `runToResult` resolves. There is **no in-process early-seal bug**. The `1e4fae55` trace is no longer on disk, so the originally-observed gap most plausibly traces to the **pre-#610 state** (fork trace writer unwired) or a mid-session `/clear`/`/resume` — not a defect in the current per-turn path. (Residual not chased here: exact `/resume`-swap seal/rebind behavior.)

## Tests (all additive)

- **Fork site** (`hooks-integration.test.ts`): `childConfig.subagentId` equals the returned handle id; the fork-assigned id **wins over an inherited stale `config.subagentId`** (nested-fork safety).
- **anthropic-direct** (`loop.trace.test.ts`): tags started + completed with `subagentId` inside a fork; omits the key entirely for a root loop.
- **openai-compatible** (`query.test.ts`): tags tool_call events from `config.subagentId`; omits on a top-level session.
- **Reader** (`trace.test.ts`): `afk trace show` renders `[subagentId]` on a fork's completed **and orphaned-started** tool_call; renders no suffix on a root tool_call.

`InMemoryTraceWriter.write()` runs the same `TraceEventInputSchema.parse()` as the on-disk writer, so the passing emit tests also prove the Zod schema accepts the field on-disk.

## Verification

`pnpm lint` clean; `audit:sdk:check` / `audit:env:check` / `scan:env:check` all green. Targeted suites green: trace (239), providers (915), subagent (67), improve/scan (269), session (317), hooks-integration (45), trace CLI (34) — 0 failures.
