### PR TITLE
fix(telegram): reserve claimedChats in processOne to close drain-path TOCTOU (#603)

### DIFF
--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -257,7 +257,16 @@ export class TelegramBot {
     // `runDetached`'s .catch is only a last-resort guard against an unhandled
     // rejection (e.g. a reply that throws after the bot is stopped).
     const runDetached = (work: Promise<void>): void => {
-      void work.catch((err) => this.log('Detached update handler error:', err));
+      void work.catch((err) => {
+        // Redact any embedded bot token before logging — getFileLink() URLs
+        // (https://api.telegram.org/file/bot<TOKEN>/<path>) can ride along in
+        // an error string, and this last-resort catch would otherwise leak the
+        // live token to the log. Same pattern handlePhoto's own catch applies
+        // (#603 Item 2). Stringify safely first: `err` may be a non-Error.
+        const rawErrStr = err instanceof Error ? err.message : String(err);
+        const sanitizedErr = rawErrStr.replace(/\/bot[^/]+\//g, '/bot[REDACTED]/');
+        this.log('Detached update handler error:', sanitizedErr);
+      });
     };
     this.bot.on('text', (ctx) => runDetached(this.messageHandler.handle(ctx)));
 

--- a/src/telegram/handlers/message.test.ts
+++ b/src/telegram/handlers/message.test.ts
@@ -6,7 +6,7 @@
  * the session message queue or processOne.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Context } from 'telegraf';
 import type { Message } from 'telegraf/types';
 
@@ -231,6 +231,15 @@ describe('MessageHandler concurrent same-chat dispatch (TOCTOU regression — PR
     mockStreamResponse.mockClear();
   });
 
+  // Restore the shared mock's implementation unconditionally — the drain-race
+  // test below installs a blocking mockImplementation, and if any of its
+  // assertions throw first, an inline restore would be skipped and the blocking
+  // gate would leak into later suites (hang). afterEach always runs.
+  afterEach(() => {
+    mockStreamResponse.mockReset();
+    mockStreamResponse.mockImplementation(async () => { /* no-op */ });
+  });
+
   it('a second concurrent update for the same chat is queued, not processed concurrently', async () => {
     // getSession always resolves { state: 'idle' } — never reflects a real
     // busy transition — so this reproduces exactly the unprotected window:
@@ -274,6 +283,101 @@ describe('MessageHandler concurrent same-chat dispatch (TOCTOU regression — PR
     await handler.handle(ctx2);
     expect(mockStreamResponse).toHaveBeenCalledTimes(2);
     expect(replies2).toHaveLength(0);
+  });
+
+  // Residual drain-path TOCTOU (#603 Item 1): a turn dispatched by
+  // processOne's un-awaited `finally → drainQueue` used to run WITHOUT a
+  // claimedChats reservation of its own. handle() reserved only for the FIRST
+  // turn and released in its finally, but that finally fires while the drained
+  // turn is still between getSession() and its lazy sendMessageStream flipping
+  // `session.state` to 'streaming'. A fresh handle() landing in that gap saw
+  // both `state === 'idle'` (getSession here always resolves idle) AND an empty
+  // claim, so it wrongly entered processOne concurrently with the drained turn.
+  //
+  // With Item 1, processOne reserves the slot synchronously at entry and
+  // releases it only AFTER firing drainQueue, so the drained turn's own
+  // reservation is live before the outer turn's release drops the count — the
+  // slot never goes empty while the drained turn is in flight, and the fresh
+  // handle() is serialized (queued) instead of racing into streamResponse.
+  //
+  // Red/green: without the processOne reservation this asserts streamResponse
+  // runs concurrently (maxConcurrentStreams === 2) and fires 3 times; with it,
+  // the fresh handle enqueues, so streams never overlap (max 1) and fire twice.
+  it('a fresh handle racing a detached drain turn does not enter streamResponse concurrently', async () => {
+    const handler = makeHandler();
+    const sessionManager = (handler as unknown as {
+      sessionManager: { getSession: ReturnType<typeof vi.fn> };
+    }).sessionManager;
+
+    // First inbound message is enqueued (getSession reports busy exactly once),
+    // so a drain target exists; every later getSession resolves idle — modeling
+    // the window where `session.state` never reflects the in-flight turn and
+    // only the claimedChats reservation can serialize dispatch.
+    sessionManager.getSession
+      .mockResolvedValueOnce({ state: 'streaming' })
+      .mockResolvedValue({ state: 'idle' });
+
+    let concurrentStreams = 0;
+    let maxConcurrentStreams = 0;
+    let releaseDrainedTurn: (() => void) | undefined;
+    const drainedTurnEntered = new Promise<void>((resolve) => {
+      // The drained (second) streamResponse call blocks here so it stays
+      // in flight while we fire the fresh handle() below.
+      mockStreamResponse.mockImplementation(async () => {
+        concurrentStreams += 1;
+        maxConcurrentStreams = Math.max(maxConcurrentStreams, concurrentStreams);
+        const callIndex = mockStreamResponse.mock.calls.length;
+        if (callIndex === 1) {
+          // Winner turn: resolve immediately so its finally fires drainQueue.
+          concurrentStreams -= 1;
+          return;
+        }
+        // Drained turn (and, in the buggy path, the fresh turn) block on the
+        // gate so overlap is observable.
+        resolve();
+        await new Promise<void>((r) => { releaseDrainedTurn = r; });
+        concurrentStreams -= 1;
+      });
+    });
+
+    // Enqueue a message while "busy" (getSession → streaming) — becomes the
+    // drain target.
+    const { ctx: queuedCtx } = makeMessageCtx(CHAT_ID, 'queued');
+    await handler.handle(queuedCtx);
+    expect(mockStreamResponse).not.toHaveBeenCalled();
+
+    // Winner turn: idle session → processOne → streamResponse[0] resolves →
+    // finally fires drainQueue un-awaited → processOne(drained) reserves its
+    // slot and enters streamResponse[1] (blocks on the gate).
+    const { ctx: winnerCtx } = makeMessageCtx(CHAT_ID, 'winner');
+    await handler.handle(winnerCtx);
+    await drainedTurnEntered; // the drained turn is now in flight (gated)
+
+    // Fresh message for the SAME chat, dispatched WITHOUT awaiting — exactly
+    // the detached-drain idle-window the fix must cover. With Item 1 the claim
+    // from the drained turn serializes this into the queue; without it, this
+    // races into streamResponse concurrently.
+    const { ctx: freshCtx, replies: freshReplies } = makeMessageCtx(CHAT_ID, 'fresh');
+    void handler.handle(freshCtx);
+    // Let the fresh handle() run its full synchronous + microtask path.
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // Core assertion: the fresh handle must NOT have entered streamResponse
+    // while the drained turn is still in flight.
+    expect(maxConcurrentStreams).toBe(1);
+    // Only the winner + drained turns reached streamResponse; the fresh handle
+    // was queued (a "#1" reply), not processed.
+    expect(mockStreamResponse).toHaveBeenCalledTimes(2);
+    expect(freshReplies.some((r) => r.includes('#1'))).toBe(true);
+
+    // Release the gated drained turn and let everything settle so no timer or
+    // pending promise leaks into the next test. The shared mock's
+    // implementation is restored by the describe's afterEach (runs even if an
+    // assertion above throws).
+    releaseDrainedTurn?.();
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
   });
 });
 

--- a/src/telegram/handlers/message.ts
+++ b/src/telegram/handlers/message.ts
@@ -117,18 +117,58 @@ export class MessageHandler {
 
   /**
    * Invariant: chat IDs with a turn claimed by an in-flight handle()/
-   * handlePhoto() call not yet reflected in `session.state`. bot.ts now runs
+   * handlePhoto()/drain call not yet reflected in `session.state`. bot.ts runs
    * 'text'/'photo' detached, so a second same-chat update can be dispatched
-   * while the first is still between `getSession()` and the point deep in
-   * `sendMessageStream` where `currentState` actually flips (streaming.ts
-   * sends the "Thinking…" placeholder — a real Telegram round-trip — before
-   * that generator body ever runs `assertCanSend()`). `session.state` alone
-   * misses that window: both updates would see 'idle' and race out of
-   * arrival order (PR #602 review — Codex P1). Checked-and-added
-   * synchronously (no `await` in between) so only the first arrival wins;
-   * released in `finally` once that call's own turn concludes.
+   * while the first is still between `getSession()` and the point where
+   * `currentState` actually flips to 'streaming'.
+   *
+   * That flip is deferred because `session.sendMessageStream` is a LAZY
+   * `async*` generator: its body — `assertCanSend()` then
+   * `currentState = 'streaming'` (agent-session.ts) — runs only on the
+   * consumer's first `iter.next()`, not when the generator is constructed.
+   * streaming.ts constructs the generator, awaits the "Thinking…" placeholder
+   * (a real Telegram round-trip), and only then pulls the first value — so the
+   * state flip lands well after `getSession()` returns. `session.state` alone
+   * misses that window: two updates would both see 'idle' and race out of
+   * arrival order (PR #602 review — Codex P1).
+   *
+   * Reference-counted (chatId → live claim count) rather than a plain Set so
+   * the reservation survives the hand-off across `processOne`'s un-awaited
+   * `finally → drainQueue`: the drained turn takes its own +1 synchronously
+   * before the outer turn's release drops back to 0, so the slot is never
+   * momentarily empty while a detached drain turn is still in flight (#603
+   * Item 1). Reserved/released synchronously (no `await` in between) via the
+   * claim* helpers below, so only the first arrival wins; `isClaimed` sees any
+   * live count. See {@link reserveClaim}/{@link releaseClaim}.
    */
-  private claimedChats = new Set<number>();
+  private claimedChats = new Map<number, number>();
+
+  /**
+   * Reserve this chat's turn slot (synchronous). Increments the live claim
+   * count so overlapping reservations — handle()'s outer guard plus
+   * processOne's own reservation plus a drain re-entry — compose instead of
+   * clobbering a single boolean flag. Must be called with NO `await` between
+   * the deciding `isClaimed` read and this call.
+   */
+  private reserveClaim(chatId: number): void {
+    this.claimedChats.set(chatId, (this.claimedChats.get(chatId) ?? 0) + 1);
+  }
+
+  /**
+   * Release one reservation taken by {@link reserveClaim}. Deletes the entry
+   * once the count reaches zero so `isClaimed` reports false again. Balanced:
+   * each reserveClaim has exactly one releaseClaim on every code path.
+   */
+  private releaseClaim(chatId: number): void {
+    const next = (this.claimedChats.get(chatId) ?? 0) - 1;
+    if (next <= 0) this.claimedChats.delete(chatId);
+    else this.claimedChats.set(chatId, next);
+  }
+
+  /** True while any turn holds a slot for this chat (see {@link claimedChats}). */
+  private isClaimed(chatId: number): boolean {
+    return (this.claimedChats.get(chatId) ?? 0) > 0;
+  }
 
   /**
    * Active ask_question elicitations waiting for a text reply.
@@ -216,13 +256,16 @@ export class MessageHandler {
     let alreadyClaimed = false;
     try {
       // Invariant: reserve this chat's turn slot SYNCHRONOUSLY (no `await`
-      // between the check and the add), before the async `getSession()` call
-      // below — see the `claimedChats` field doc for the exact race this
+      // between the check and the reserve), before the async `getSession()`
+      // call below — see the `claimedChats` field doc for the exact race this
       // closes. Photos widen the pre-fix race further than text messages
       // (the CDN download + base64 encode below is a much larger gap than
-      // `ctx.react`), so this check matters even more here.
-      alreadyClaimed = this.claimedChats.has(chatId);
-      if (!alreadyClaimed) this.claimedChats.add(chatId);
+      // `ctx.react`), so this check matters even more here. Only reserve when
+      // not already claimed so a losing concurrent call doesn't inflate the
+      // count it never releases; processOne takes its own reservation for the
+      // turn it actually runs (drain-path coverage, #603 Item 1).
+      alreadyClaimed = this.isClaimed(chatId);
+      if (!alreadyClaimed) this.reserveClaim(chatId);
 
       // M3+M6: session lookup and queue-depth check happen before getFileLink /
       // download so that allowlist-burst rejections don't burn Telegram API quota
@@ -371,8 +414,10 @@ export class MessageHandler {
       }
     } finally {
       // Only the call that actually reserved the slot releases it — see the
-      // matching comment in handle().
-      if (!alreadyClaimed) this.claimedChats.delete(chatId);
+      // matching comment in handle(). processOne holds its own reservation for
+      // the turn it runs, so releasing this outer guard here never drops the
+      // slot out from under an in-flight (possibly drained) turn.
+      if (!alreadyClaimed) this.releaseClaim(chatId);
     }
   }
 
@@ -443,13 +488,17 @@ export class MessageHandler {
       await ctx.react?.('👀').catch(() => {});
 
       // Invariant: reserve this chat's turn slot SYNCHRONOUSLY (no `await`
-      // between the check and the add) before the async `session.state` check
-      // below. See the `claimedChats` field doc for the exact race this
+      // between the check and the reserve) before the async `session.state`
+      // check below. See the `claimedChats` field doc for the exact race this
       // closes. `ctx.react` above is side-effect-free w.r.t. session state, so
       // reserving after it (rather than at function entry) is equivalent and
-      // keeps the reaction-ack behavior unchanged for a losing call.
-      alreadyClaimed = this.claimedChats.has(chatId);
-      if (!alreadyClaimed) this.claimedChats.add(chatId);
+      // keeps the reaction-ack behavior unchanged for a losing call. Only
+      // reserve when not already claimed so a losing concurrent call doesn't
+      // inflate a count it never releases; processOne takes its own
+      // reservation for the turn it actually runs (drain-path coverage,
+      // #603 Item 1).
+      alreadyClaimed = this.isClaimed(chatId);
+      if (!alreadyClaimed) this.reserveClaim(chatId);
 
       const session = await this.sessionManager.getSession(chatId);
 
@@ -482,8 +531,10 @@ export class MessageHandler {
     } finally {
       // Only the call that actually reserved the slot releases it — a losing
       // (already-claimed) call never owned it and must not clear the winner's
-      // still-in-flight claim out from under it.
-      if (!alreadyClaimed) this.claimedChats.delete(chatId);
+      // still-in-flight claim out from under it. processOne holds its own
+      // reservation for the turn it runs, so this release never drops the slot
+      // while a turn (first or drained) is still streaming.
+      if (!alreadyClaimed) this.releaseClaim(chatId);
     }
   }
 
@@ -636,8 +687,24 @@ export class MessageHandler {
    * can transition from idle → busy in the window between the caller's state-check
    * and this method's own getSession call (TOCTOU). Catching it here ensures the
    * item is re-enqueued regardless of which caller triggered processOne.
+   *
+   * Invariant: processOne reserves a `claimedChats` slot SYNCHRONOUSLY at entry
+   * (below) and releases it only AFTER firing `drainQueue` in its finally. This
+   * is what makes drain-dispatched turns get the same one-turn-at-a-time slot as
+   * first turns (#603 Item 1): drainQueue is fired un-awaited from the finally,
+   * so the drained turn's own processOne reservation must be taken (its
+   * synchronous entry runs during the fire) BEFORE this turn's release drops the
+   * count — otherwise the slot would be momentarily empty between the outer
+   * turn's release and the drained turn flipping `session.state`, and a fresh
+   * handle() landing in that gap would double-enter. Reference counting (see the
+   * claimedChats field doc) composes this turn's reservation with the outer
+   * handle()/handlePhoto() guard and any drain re-entry.
    */
   private async processOne(chatId: number, ctx: Context, content: string | ContentBlockParam[]): Promise<void> {
+    // Reserve this turn's slot synchronously, before the first `await` below, so
+    // the slot is held continuously from dispatch through the finally's drain
+    // hand-off. Paired 1:1 with the releaseClaim in the finally.
+    this.reserveClaim(chatId);
     // Guard against a busy-spin cascade: if the catch block re-enqueues the item
     // because the session is busy, we must NOT also drain — the re-enqueued item will
     // be picked up by the active session's own drain cycle. Without this flag, the
@@ -693,11 +760,21 @@ export class MessageHandler {
         await ctx.reply(formatInternalError());
       }
     } finally {
-      // Only drain when we did NOT just re-enqueue — the active session's own finally
-      // will drain the item we pushed; calling drain here too causes a cascade.
+      // Order matters (#603 Item 1): fire drainQueue FIRST, then release. The
+      // fire is un-awaited, so it runs the drained turn's own processOne up to
+      // its first `await` — including that turn's synchronous reserveClaim —
+      // before releaseClaim below drops this turn's count. Reference counting
+      // means the slot stays held (count > 0) across the hand-off, so a fresh
+      // handle() arriving while the drained turn is still starting sees the
+      // chat as claimed and enqueues instead of double-entering.
+      //
+      // Only drain when we did NOT just re-enqueue — the active session's own
+      // finally will drain the item we pushed; calling drain here too causes a
+      // cascade.
       if (!reEnqueued) {
         this.drainQueue(chatId).catch(err => this.log('Drain error:', err));
       }
+      this.releaseClaim(chatId);
     }
   }
 


### PR DESCRIPTION
Closes #603.

Follow-ups from the `/review` of #602 (*run agent turn detached so mid-turn elicitations don't deadlock the poller*). All four review items in one scoped change.

## What & why

### 1 · `medium` correctness — close the drain-path `claimedChats` TOCTOU
`handle()`/`handlePhoto()` reserved `claimedChats` only for the **first** turn and released it in their `finally`. But `processOne`'s `finally` fires `drainQueue` **un-awaited**, so the outer `finally` deleted the claim *before* the drained turn flipped `session.state` (that flip is deferred to the lazy `async* sendMessageStream`'s first `iter.next()`). A fresh same-chat message arriving in that gap saw `state === 'idle'` **and** an empty claim → it could enter `processOne` concurrently with the drained turn.

**Fix:** `processOne` now reserves a slot **synchronously at entry** and releases it **after** firing `drainQueue`, so the drained turn's own reservation is live before the outer turn's release drops the count — the slot is never momentarily empty while a detached drain turn is in flight.

`claimedChats` is changed from `Set<number>` to a **reference-counted `Map<number, number>`** (with `reserveClaim`/`releaseClaim`/`isClaimed` helpers). This is required, not incidental: with a plain `Set`, the outer guard and `processOne` both hold the *same* entry, so `processOne`'s release would clobber the entry the drained turn still needs during the hand-off. Ref-counting lets the overlapping reservations (outer guard + `processOne` + drain re-entry) compose so the count stays `> 0` continuously across the gap. The existing concurrent-`handle()` guarantee and the busy-recovery re-enqueue contract are preserved; each `reserveClaim` is balanced 1:1 with a `releaseClaim` on every path.

### 2 · `low` security — redact bot token in `runDetached`'s last-resort log
`bot.ts`'s `runDetached` forwarded the raw `err` to `this.log` without the `/bot<TOKEN>/` redaction `handlePhoto`'s own catch applies — a `getFileLink` URL reaching this catch could leak the live token. Now stringifies safely and applies the same `.replace(/\/bot[^/]+\//g, '/bot[REDACTED]/')` before logging.

### 3 · `low` test-coverage — regression test for the residual drain-idle-window race
New test in `message.test.ts`: gates the drained turn's `streamResponse` in-flight, then fires a fresh un-awaited `handle()` in the idle-window and asserts it does **not** enter `streamResponse` concurrently (`maxConcurrentStreams === 1`, exactly 2 stream calls, fresh message gets a `#1` queued reply). Red without Item 1 (`maxConcurrentStreams === 2`, 3 stream calls), green with it. Adds an `afterEach` mock-reset so the blocking gate can't leak into later suites.

### 4 · `nit` docs — correct the `claimedChats` field-doc mechanism
The field doc attributed the deferred `session.state` flip to the "Thinking…" placeholder ordering. Corrected: the flip is deferred because `sendMessageStream` is a **lazy `async*` generator** whose body (`assertCanSend()` + `state = 'streaming'`) runs only on the consumer's first `iter.next()`; the placeholder widens, but does not cause, the window.

## Verification
- `pnpm lint` (`tsc --noEmit`) — clean.
- `pnpm test src/telegram/handlers/message.test.ts src/telegram/handlers/message-photo.test.ts` — **31 passed**.
- Full `src/telegram` suite — **609 passed** (32 files).
- Red/green of the new test confirmed by temporarily reverting the `processOne` reservation.

Scoped to #603 — no drive-by changes. Branch rebased on current `main`.
