### PR TITLE
fix(provider): surface stream-incomplete as an error, not a silent truncated turn

### DIFF
--- a/src/agent/providers/anthropic-direct/translate.test.ts
+++ b/src/agent/providers/anthropic-direct/translate.test.ts
@@ -495,4 +495,68 @@ describe('anthropic-direct translateMessageStream', () => {
     expect(u.output_tokens).toBe(25);
     expect(u.cache_read_input_tokens).toBe(50);
   });
+
+  it('stream ending with no message_stop and no stop_reason surfaces an error (P0: no silent truncation)', async () => {
+    // Regression guard for the parent-facing "silent truncation" gap: when a
+    // model stream is cut off before completion (e.g. an intermediary gracefully
+    // closing the connection mid-response), neither `message_stop` nor a
+    // `message_delta` stop_reason arrives. Before the fix, translate yielded a
+    // `turn-result` with stopReason=null carrying the partial text, so the turn
+    // was delivered as a clean, complete answer. It must surface an error so the
+    // partial is never silently presented as final.
+    async function* cutOff(): AsyncIterable<RawMessageStreamEvent> {
+      yield messageStart();
+      yield textBlockStart(0);
+      yield textDelta(0, 'Partial answer that got ');
+      // stream ends here — NO message_delta, NO message_stop
+    }
+
+    const out = await collect(
+      translateMessageStream(cutOff(), { sessionId: SESSION_ID }),
+    );
+
+    // The partial text still streams as a delta event...
+    const textDeltas = out.filter(
+      (o) => o.kind === 'event' && o.event.type === 'delta.text',
+    );
+    expect(textDeltas).toHaveLength(1);
+
+    // ...but the turn must NOT resolve as a (silent) turn-result.
+    const turnResults = out.filter((o) => o.kind === 'turn-result');
+    expect(turnResults).toHaveLength(0);
+
+    // It surfaces as an error event instead.
+    const last = out[out.length - 1];
+    if (!last || last.kind !== 'event' || last.event.type !== 'error') {
+      throw new Error('expected an error event when the stream ends without a terminal signal');
+    }
+    expect(last.event.error).toBeInstanceOf(Error);
+    expect(last.event.error.message).toMatch(/message_stop|incomplete|cut off/i);
+  });
+
+  it('stream that loses only message_stop but has a real stop_reason still yields a turn-result', async () => {
+    // Negative guard: the incomplete-detection must NOT false-positive when the
+    // model DID signal completion (message_delta carried a stop_reason) and only
+    // the framing `message_stop` event was lost. That turn is substantively
+    // complete and must resolve normally.
+    const events: RawMessageStreamEvent[] = [
+      messageStart(),
+      textBlockStart(0),
+      textDelta(0, 'Complete answer'),
+      blockStop(0),
+      messageDelta('end_turn'),
+      // NO message_stop
+    ];
+
+    const out = await collect(
+      translateMessageStream(fromArray(events), { sessionId: SESSION_ID }),
+    );
+
+    const last = out[out.length - 1];
+    if (!last || last.kind !== 'turn-result') {
+      throw new Error('expected a turn-result when a real stop_reason was received');
+    }
+    expect(last.result.stopReason).toBe('end_turn');
+    expect(last.result.text).toBe('Complete answer');
+  });
 });

--- a/src/agent/providers/anthropic-direct/translate.ts
+++ b/src/agent/providers/anthropic-direct/translate.ts
@@ -21,6 +21,7 @@ import type {
 } from '@anthropic-ai/sdk/resources';
 import type { TranslateCtx, TranslateOutput, TurnResult } from './types.js';
 import { env } from '../../../config/env.js';
+import { StreamIncompleteError } from '../../../utils/errors.js';
 
 /**
  * Per-block accumulator. The block kind dictates which fields are populated
@@ -299,6 +300,34 @@ export async function* translateMessageStream(
     if (traceEnabled) console.log('[translate] SDK iteration threw:', (err as Error).message);
     const error = err instanceof Error ? err : new Error(String(err));
     yield { kind: 'event', event: { type: 'error', error } };
+    return;
+  }
+
+  // Invariant: a stream that ends with NO terminal signal — neither a
+  // `message_stop` event (`stopped`) NOR a `stop_reason` from `message_delta`
+  // (`stopReason`) — was cut off mid-response (typically an intermediary such as
+  // a proxy/gateway/LB gracefully closing the connection before completion; the
+  // raw SDK Stream ends cleanly without throwing, so the catch above never
+  // fires). Yielding a turn-result here would present the partial as a clean,
+  // complete answer: silent truncation. Surface an error instead so the
+  // incomplete turn is legible to BOTH the top-level session and the subagent
+  // consumer (which routes it through its StreamIncompleteError → status:'failed'
+  // handling), mirroring the #628 "fail loudly, don't silently succeed" fix.
+  // Guard is `stopReason === null` (not merely `!stopped`) so a stream that
+  // delivered a real stop_reason but lost only the framing `message_stop` — the
+  // model DID signal why it stopped — is still treated as complete.
+  if (!stopped && stopReason === null) {
+    yield {
+      kind: 'event',
+      event: {
+        type: 'error',
+        error: new StreamIncompleteError(
+          'the model stream ended without a terminal message (no message_stop ' +
+            'and no stop_reason): the response was cut off mid-stream, typically ' +
+            'an intermediary closing the connection. The turn is incomplete.',
+        ),
+      },
+    };
     return;
   }
 

--- a/src/agent/providers/openai-compatible/query/stream-drive.test.ts
+++ b/src/agent/providers/openai-compatible/query/stream-drive.test.ts
@@ -1,13 +1,18 @@
 /**
- * Tests for driveStream's zero-output stream-incomplete guard.
+ * Tests for driveStream's stream-incomplete guard.
  *
- * A stream that ends cleanly (no throw) having produced NO content and NO
- * terminal finish_reason must surface an error rather than a silent empty turn
+ * A stream that ends cleanly (no throw) with NO terminal finish_reason and NO
+ * DISPATCHABLE response must surface an error rather than a silent empty turn
  * (the OpenAI-compatible analog of the anthropic-direct silent-truncation fix).
+ * "No dispatchable response" covers three truncation shapes, all exercised
+ * below: truly-empty streams, reasoning-only cut-offs (reasoning deltas but no
+ * visible answer), and non-dispatchable partial tool calls (a call missing its
+ * id or name).
  *
  * Critically, the guard must NOT false-positive on the common case where a
  * local shim (MLX / llama.cpp) completes a real turn but omits finish_reason —
- * that turn HAS content, so it must still resolve as a clean completion.
+ * a turn that produced VISIBLE TEXT or a DISPATCHABLE tool call must still
+ * resolve as a clean completion.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -96,5 +101,104 @@ describe('driveStream — zero-output stream-incomplete guard', () => {
     expect(result).not.toBeNull();
     expect(result?.text).toBe('a complete answer');
     expect(result?.needsToolDispatch).toBe(false);
+  });
+
+  it('surfaces an error on a reasoning-only cut-off (reasoning deltas, no answer, no finish_reason)', async () => {
+    // A reasoning model streams reasoning deltas, then the connection is cut off
+    // before any visible answer and before finish_reason. reasoningText is
+    // non-empty but there is no dispatchable response — the pre-fix zero-output
+    // guard (which also required reasoningText.length === 0) let this through as a
+    // silent empty success. It must now fail loudly.
+    const strategy: StreamDriveStrategy<{ reasoning: string }> = {
+      createStream: async () =>
+        (async function* (): AsyncIterable<{ reasoning: string }> {
+          yield { reasoning: 'let me work through this step by step...' };
+        })(),
+      translate: (event, state: StreamState) => {
+        state.reasoningText += event.reasoning;
+        return [];
+      },
+      clarifyError: (e) => (e instanceof Error ? e : new Error(String(e))),
+    };
+
+    const { events, result } = await drive(makeCtx(), strategy);
+
+    expect(result).toBeNull();
+    const errs = events.filter((e) => e.type === 'error');
+    expect(errs).toHaveLength(1);
+    const err = errs[0];
+    if (!err || err.type !== 'error') throw new Error('expected an error event');
+    expect(err.error).toBeInstanceOf(Error);
+    expect(err.error.message).toMatch(/finish_reason|output|incomplete|dispatchable|cut off/i);
+  });
+
+  it('surfaces an error on a non-dispatchable partial tool call (no name, no finish_reason)', async () => {
+    // A tool-call stream cut off mid-delta: the accumulated call has an id but the
+    // name never arrived, so isToolCallStop() is false and needsToolDispatch is
+    // false. With no finish_reason and no visible answer, the pre-fix guard (which
+    // required toolCallsByIndex.size === 0) let this through as a silent empty
+    // success. It must now fail loudly.
+    const strategy: StreamDriveStrategy<{ index: number; id: string }> = {
+      createStream: async () =>
+        (async function* (): AsyncIterable<{ index: number; id: string }> {
+          yield { index: 0, id: 'call_abc123' };
+        })(),
+      translate: (event, state: StreamState) => {
+        state.toolCallsByIndex.set(event.index, {
+          index: event.index,
+          id: event.id,
+          name: '', // name never arrived → non-dispatchable partial call
+          argumentsRaw: '',
+          startEmitted: false,
+        });
+        return [];
+      },
+      clarifyError: (e) => (e instanceof Error ? e : new Error(String(e))),
+    };
+
+    const { events, result } = await drive(makeCtx(), strategy);
+
+    expect(result).toBeNull();
+    const errs = events.filter((e) => e.type === 'error');
+    expect(errs).toHaveLength(1);
+    const err = errs[0];
+    if (!err || err.type !== 'error') throw new Error('expected an error event');
+    expect(err.error).toBeInstanceOf(Error);
+  });
+
+  it('does NOT flag a dispatchable tool call that omitted finish_reason (shim-safe)', async () => {
+    // A shim completes a real tool-call turn (complete id + name) but omits
+    // finish_reason. isToolCallStop()'s no-finish_reason fallback treats it as a
+    // tool stop, so needsToolDispatch is true — it must resolve as a clean
+    // completion, guarding against over-broadening the incomplete-stream guard.
+    const strategy: StreamDriveStrategy<{
+      index: number;
+      id: string;
+      name: string;
+      args: string;
+    }> = {
+      createStream: async () =>
+        (async function* () {
+          yield { index: 0, id: 'call_abc123', name: 'get_weather', args: '{"city":"NYC"}' };
+        })(),
+      translate: (event, state: StreamState) => {
+        state.toolCallsByIndex.set(event.index, {
+          index: event.index,
+          id: event.id,
+          name: event.name,
+          argumentsRaw: event.args,
+          startEmitted: false,
+        });
+        return [];
+      },
+      clarifyError: (e) => (e instanceof Error ? e : new Error(String(e))),
+    };
+
+    const { events, result } = await drive(makeCtx(), strategy);
+
+    const errs = events.filter((e) => e.type === 'error');
+    expect(errs).toHaveLength(0);
+    expect(result).not.toBeNull();
+    expect(result?.needsToolDispatch).toBe(true);
   });
 });

--- a/src/agent/providers/openai-compatible/query/stream-drive.test.ts
+++ b/src/agent/providers/openai-compatible/query/stream-drive.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for driveStream's zero-output stream-incomplete guard.
+ *
+ * A stream that ends cleanly (no throw) having produced NO content and NO
+ * terminal finish_reason must surface an error rather than a silent empty turn
+ * (the OpenAI-compatible analog of the anthropic-direct silent-truncation fix).
+ *
+ * Critically, the guard must NOT false-positive on the common case where a
+ * local shim (MLX / llama.cpp) completes a real turn but omits finish_reason —
+ * that turn HAS content, so it must still resolve as a clean completion.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  driveStream,
+  type StreamDriveContext,
+  type StreamDriveStrategy,
+  type IterationResult,
+} from './stream-drive.js';
+import type { ProviderEvent } from '../../../provider.js';
+import type { StreamState } from '../translate.js';
+
+function makeCtx(): StreamDriveContext {
+  return {
+    controller: new AbortController(),
+    traceWriter: undefined,
+    initSessionId: 'sess-test',
+    currentModel: 'test-model',
+    isClosed: () => false,
+  };
+}
+
+async function drive<T>(
+  ctx: StreamDriveContext,
+  strategy: StreamDriveStrategy<T>,
+): Promise<{ events: ProviderEvent[]; result: IterationResult | null }> {
+  const gen = driveStream(ctx, strategy);
+  const events: ProviderEvent[] = [];
+  let result: IterationResult | null = null;
+  for (;;) {
+    const step = await gen.next();
+    if (step.done) {
+      result = step.value;
+      break;
+    }
+    events.push(step.value);
+  }
+  return { events, result };
+}
+
+describe('driveStream — zero-output stream-incomplete guard', () => {
+  it('surfaces an error when the stream ends with no output and no finish_reason', async () => {
+    // Empty stream: connection opens, yields zero chunks, ends without throwing.
+    const strategy: StreamDriveStrategy<unknown> = {
+      createStream: async () =>
+        (async function* (): AsyncIterable<unknown> {
+          /* yields nothing */
+        })(),
+      translate: () => [],
+      clarifyError: (e) => (e instanceof Error ? e : new Error(String(e))),
+    };
+
+    const { events, result } = await drive(makeCtx(), strategy);
+
+    // No silent clean completion.
+    expect(result).toBeNull();
+    // An error event was surfaced.
+    const errs = events.filter((e) => e.type === 'error');
+    expect(errs).toHaveLength(1);
+    const err = errs[0];
+    if (!err || err.type !== 'error') throw new Error('expected an error event');
+    expect(err.error).toBeInstanceOf(Error);
+    expect(err.error.message).toMatch(/finish_reason|output|incomplete|empty|cut off/i);
+  });
+
+  it('does NOT flag a clean end that produced text but omitted finish_reason (shim-safe)', async () => {
+    // Some OpenAI-compatible shims (MLX / llama.cpp) complete a real turn without
+    // sending finish_reason. That turn HAS content and must resolve normally —
+    // the guard must not treat it as incomplete.
+    const strategy: StreamDriveStrategy<{ text: string }> = {
+      createStream: async () =>
+        (async function* (): AsyncIterable<{ text: string }> {
+          yield { text: 'a complete answer' };
+        })(),
+      translate: (event, state: StreamState) => {
+        state.assistantText += event.text;
+        return [];
+      },
+      clarifyError: (e) => (e instanceof Error ? e : new Error(String(e))),
+    };
+
+    const { events, result } = await drive(makeCtx(), strategy);
+
+    const errs = events.filter((e) => e.type === 'error');
+    expect(errs).toHaveLength(0);
+    expect(result).not.toBeNull();
+    expect(result?.text).toBe('a complete answer');
+    expect(result?.needsToolDispatch).toBe(false);
+  });
+});

--- a/src/agent/providers/openai-compatible/query/stream-drive.ts
+++ b/src/agent/providers/openai-compatible/query/stream-drive.ts
@@ -177,34 +177,54 @@ export async function* driveStream<TEvent>(
       return null;
     }
 
+    // Tool-dispatch intent, computed once: the incomplete-stream guard below and
+    // the clean-completion return value both key off it. `isToolCallStop` is a
+    // pure read of the now-fully-accumulated `state`.
+    const needsToolDispatch = isToolCallStop(state) && state.toolCallsByIndex.size > 0;
+
     // Invariant: the stream iterator completed WITHOUT throwing but produced no
-    // content AND no terminal finish_reason — nothing was generated and the wire
-    // never signaled completion (a stream cut off before any output arrived, e.g.
-    // an intermediary closing the connection at a graceful boundary; a hard drop
-    // would have thrown and been surfaced above). Returning a clean completion
-    // here delivers an empty turn as success — a silent failure. Surface an error
-    // instead, mirroring anthropic-direct's stream-incomplete handling and the
-    // #628 "fail loudly, don't silently succeed" fix.
+    // DISPATCHABLE response AND no terminal finish_reason — the wire never
+    // signaled completion and nothing usable was generated (a stream cut off
+    // before the answer arrived, e.g. an intermediary closing the connection at a
+    // graceful boundary; a hard drop would have thrown and been surfaced above).
+    // Returning a clean completion here delivers an empty turn as success — a
+    // silent failure. Surface an error instead, mirroring anthropic-direct's
+    // stream-incomplete handling and the #628 "fail loudly, don't silently
+    // succeed" fix.
     //
-    // Scope: ZERO-OUTPUT only. We deliberately do NOT flag a clean end that
-    // produced text / tool-calls but no finish_reason: some OpenAI-compatible
+    // Scope: NO VISIBLE ANSWER AND NO DISPATCHABLE TOOL CALL (with no
+    // finish_reason). This catches three truncation shapes that all reduce to
+    // "empty turn presented as success":
+    //   1. truly-empty streams (no content at all);
+    //   2. reasoning-only cut-offs — reasoning deltas arrived but the stream was
+    //      cut before any visible answer (reasoningText > 0, assistantText empty);
+    //   3. cut-off / non-dispatchable partial tool calls — an accumulated call is
+    //      missing its id or name, so isToolCallStop() is false (see
+    //      translate.ts:218) and it can never round-trip.
+    // All three leave runTurn with text === '' and needsToolDispatch === false,
+    // so it would otherwise emit an empty assistant.message + turn.completed as a
+    // clean success — the exact silent-truncation failure this guard exists to
+    // prevent.
+    //
+    // We deliberately do NOT flag a clean end that produced VISIBLE TEXT or a
+    // DISPATCHABLE tool call but omitted finish_reason: some OpenAI-compatible
     // endpoints (local MLX / llama.cpp shims) legitimately OMIT finish_reason on
-    // complete turns (see translate.ts:isToolCallStop), so treating "content
-    // present + no finish_reason" as incomplete would false-positive real
-    // completions. finish_reason is not a reliable terminal signal on this wire
-    // (unlike anthropic-direct's protocol-guaranteed message_stop), so the
-    // partial-truncation case cannot be safely distinguished here.
+    // complete turns, so treating "usable content present + no finish_reason" as
+    // incomplete would false-positive real completions. finish_reason is not a
+    // reliable terminal signal on this wire (unlike anthropic-direct's
+    // protocol-guaranteed message_stop), so the content-present partial-truncation
+    // case still cannot be safely distinguished here and is left unflagged.
     if (
       state.finishReason === null &&
       state.assistantText.length === 0 &&
-      state.reasoningText.length === 0 &&
-      state.toolCallsByIndex.size === 0
+      !needsToolDispatch
     ) {
       yield {
         type: 'error',
         error: new StreamIncompleteError(
-          'the model stream ended without producing any output and without a ' +
-            'finish_reason: the response was empty or cut off before any content ' +
+          'the model stream ended without a finish_reason and without a ' +
+            'dispatchable response (no visible answer text and no complete tool ' +
+            'call): the response was empty or cut off before any usable content ' +
             'arrived. The turn is incomplete.',
         ),
       };
@@ -216,7 +236,7 @@ export async function* driveStream<TEvent>(
       state,
       events: [],
       text: state.assistantText,
-      needsToolDispatch: isToolCallStop(state) && state.toolCallsByIndex.size > 0,
+      needsToolDispatch,
     };
   }
 }

--- a/src/agent/providers/openai-compatible/query/stream-drive.ts
+++ b/src/agent/providers/openai-compatible/query/stream-drive.ts
@@ -22,6 +22,7 @@ import { emitSessionPhase } from '../../../trace/emit.js';
 import type { TraceWriter } from '../../../trace/index.js';
 import { sleepWithAbort } from '../../shared/sleep-with-abort.js';
 import { createStreamState, isToolCallStop, type StreamState } from '../translate.js';
+import { StreamIncompleteError } from '../../../../utils/errors.js';
 import {
   MAX_CONNECTION_RETRIES,
   MAX_STREAM_RETRIES,
@@ -173,6 +174,40 @@ export async function* driveStream<TEvent>(
 
     if (streamError !== null) {
       yield { type: 'error', error: strategy.clarifyError(streamError) };
+      return null;
+    }
+
+    // Invariant: the stream iterator completed WITHOUT throwing but produced no
+    // content AND no terminal finish_reason — nothing was generated and the wire
+    // never signaled completion (a stream cut off before any output arrived, e.g.
+    // an intermediary closing the connection at a graceful boundary; a hard drop
+    // would have thrown and been surfaced above). Returning a clean completion
+    // here delivers an empty turn as success — a silent failure. Surface an error
+    // instead, mirroring anthropic-direct's stream-incomplete handling and the
+    // #628 "fail loudly, don't silently succeed" fix.
+    //
+    // Scope: ZERO-OUTPUT only. We deliberately do NOT flag a clean end that
+    // produced text / tool-calls but no finish_reason: some OpenAI-compatible
+    // endpoints (local MLX / llama.cpp shims) legitimately OMIT finish_reason on
+    // complete turns (see translate.ts:isToolCallStop), so treating "content
+    // present + no finish_reason" as incomplete would false-positive real
+    // completions. finish_reason is not a reliable terminal signal on this wire
+    // (unlike anthropic-direct's protocol-guaranteed message_stop), so the
+    // partial-truncation case cannot be safely distinguished here.
+    if (
+      state.finishReason === null &&
+      state.assistantText.length === 0 &&
+      state.reasoningText.length === 0 &&
+      state.toolCallsByIndex.size === 0
+    ) {
+      yield {
+        type: 'error',
+        error: new StreamIncompleteError(
+          'the model stream ended without producing any output and without a ' +
+            'finish_reason: the response was empty or cut off before any content ' +
+            'arrived. The turn is incomplete.',
+        ),
+      };
       return null;
     }
 


### PR DESCRIPTION
## Summary

Fixes a parent-facing **silent truncation** gap in both model providers: a model stream cut off mid-response (no terminal completion signal) was delivered to the agent as a clean, complete turn — so a truncated answer could be silently presented as final. Surfaced from an audit of agent-facing error handling. The subagent layer already guarded this class (`STREAM_INCOMPLETE`, #627/#628); the top-level provider paths did not.

## The bug

- **anthropic-direct** (`translate.ts`): afk consumes the raw `Stream<RawMessageStreamEvent>` (not the validating `MessageStream` helper), which completes cleanly — no throw — when an intermediary gracefully closes the connection before `message_stop`. `translateMessageStream` then fell through to a normal `turn-result` (`stopReason: null`) carrying the partial text → silent truncation.
- **openai-compatible** (`query/stream-drive.ts`): `driveStream` returned a clean completion even when the stream ended having produced no content and no terminal `finish_reason` → an empty turn delivered as success.

## The fix

- **anthropic-direct**: when the stream ends with `!stopped && stopReason === null` (no `message_stop` **and** no `message_delta` stop_reason), yield a `StreamIncompleteError` event instead of a `turn-result`. Reuses the existing, tested error path — both consumers already handle it (top-level surfaces the error; subagent → `status:'failed'`). Guarding on `stopReason === null` (not merely `!stopped`) avoids false-positives when only the framing `message_stop` is lost after a real stop_reason.
- **openai-compatible**: when the stream ends with no `finish_reason` **and** zero output (no text/reasoning/tool-calls), yield a `StreamIncompleteError`. **Deliberately scoped to zero-output** — some OpenAI-compatible endpoints (local MLX / llama.cpp shims) legitimately omit `finish_reason` on complete turns, so flagging "content present + no finish_reason" would false-positive real completions. `finish_reason` is not a reliable terminal signal on this wire (unlike the protocol-guaranteed `message_stop`), so the partial-truncation case can't be safely distinguished there.

## Tests

- `translate.test.ts`: positive (cut-off stream → error) + negative (lost only `message_stop` but a real stop_reason → still completes).
- `query/stream-drive.test.ts` (new): positive (empty stream → error) + negative (text but no `finish_reason` → still completes, shim-safe).
- Full suite: **12,265 pass / 14 skipped**; `tsc --noEmit` clean.

## Known limitation

The openai-compatible partial-truncation case (content present, no `finish_reason`, cut off) can't be safely distinguished from a legitimate `finish_reason`-omitting shim completion, so it is intentionally left unflagged (documented inline).
