### PR TITLE
feat(repl): feed redacted session context to Tier-2 ghost-text suggester

### DIFF
--- a/src/cli/commands/interactive/surface-setup.ts
+++ b/src/cli/commands/interactive/surface-setup.ts
@@ -154,8 +154,26 @@ export async function setupSurface(
                   ? top.value
                   : null;
               },
-              getTranscriptTail: () => '',
-              getRecentCommands: () => [],
+              getTranscriptTail: () => {
+                // Last 1-2 completed turns, newest-first so the freshest
+                // exchange wins buildUser's 200-char context budget. slice(-2)
+                // returns a fresh array, so reverse() never mutates stats.turns.
+                // Secrets are scrubbed downstream at the suggester egress
+                // boundary (buildUser -> redactSecrets), not here.
+                const turns = ctx.stats.turns;
+                if (turns.length === 0) return '';
+                return turns
+                  .slice(-2)
+                  .reverse()
+                  .map((t) => `user: ${t.user}\nassistant: ${t.assistant}`)
+                  .join('\n');
+              },
+              getRecentCommands: () => {
+                // Reuse the same ReplHistory ring as getHistory above
+                // (getEntries() is newest-first); buildUser slices to 5.
+                const ring = surface.history as { getEntries?: () => readonly string[] };
+                return ring.getEntries ? [...ring.getEntries()] : [];
+              },
               // Parse as a boolean, not raw truthiness: only the documented
               // activations (1/true/yes/on — see docs/env-registry.md) enable the
               // Tier-2 LLM. A non-empty falsy value like `0` or `false` must keep

--- a/src/cli/input/suggest.test.ts
+++ b/src/cli/input/suggest.test.ts
@@ -250,6 +250,48 @@ describe('getGhost – Tier 2 enabled with injected provider', () => {
   });
 });
 
+// ── Tier 2: egress secret redaction ───────────────────────────────────────────
+
+describe('getGhost – Tier 2 egress redaction', () => {
+  it('scrubs secrets from the assembled prompt before it reaches completeFn', async () => {
+    let capturedUser = '';
+    const engine = createSuggestEngine({
+      debounceMs: 0,
+      completeFn: async (args) => {
+        capturedUser = args.user;
+        return 'hello world';
+      },
+    });
+    // A recent command carrying an AWS access-key id (the canonical AWS example
+    // key). ReplHistory's weak deny-list would NOT catch this, so the egress
+    // boundary in buildUser() is the load-bearing scrub.
+    const ctx = makeCtx({
+      llmEnabled: () => true,
+      getRecentCommands: () => ['export AWS_KEY=AKIAIOSFODNN7EXAMPLE'],
+    });
+
+    const result = await engine.getGhost('hel', ctx);
+
+    // Normal (non-secret) completion still works end-to-end.
+    expect(result).toBe('hello world');
+    // The key must never appear in the outbound prompt; it is redacted.
+    expect(capturedUser).not.toContain('AKIAIOSFODNN7EXAMPLE');
+    expect(capturedUser).toContain('[REDACTED]');
+  });
+
+  it('does not redact the raw buffer used by the continuation guard', async () => {
+    // A plain buffer must still produce a ghost — proving redaction wraps the
+    // prompt, not the `buffer` handed to isValidContinuation().
+    const engine = createSuggestEngine({
+      debounceMs: 0,
+      completeFn: async () => 'hello world',
+    });
+    const ctx = makeCtx({ llmEnabled: () => true });
+    const result = await engine.getGhost('hel', ctx);
+    expect(result).toBe('hello world');
+  });
+});
+
 // ── Tier 1 wins over Tier 2 ───────────────────────────────────────────────────
 
 describe('getGhost – Tier 1 short-circuits Tier 2', () => {

--- a/src/cli/input/suggest.ts
+++ b/src/cli/input/suggest.ts
@@ -26,6 +26,7 @@
 
 import { providerForModel, resolveProvider, type ProviderRouteHints } from '../../agent/providers/index.js';
 import type { ModelProvider } from '../../agent/provider.js';
+import { redactSecrets } from '../../agent/redact-secrets.js';
 import { env } from '../../config/env.js';
 import { list as listSlashCommands, aliasEntries } from '../slash/registry.js';
 
@@ -109,7 +110,18 @@ function buildUser(buffer: string, ctx: SuggestContext): string {
     parts.push(`context: ${transcript.slice(0, 200)}`);
   }
   parts.push(`input: ${buffer}`);
-  return parts.join('\n');
+  // DATA-EGRESS CONTRACT: this assembled prompt is the only content sent to the
+  // Tier-2 suggestion model, which may be a cheaper model at a DIFFERENT endpoint
+  // (baseUrl override) than the session. Scrub secrets from the whole prompt —
+  // cwd + recent commands + transcript + input — before it leaves the process,
+  // mirroring background-summarizer.ts's redactSecrets() egress boundary. This is
+  // the single chokepoint covering BOTH the completeFn (test) and real-provider
+  // dispatch paths, since both build their `user` field here.
+  // Invariant: redact the RETURNED prompt only — never the raw `buffer`, which is
+  // the result-cache key and the isValidContinuation(buffer, reply) guard input.
+  // Redacting `buffer` would collapse distinct prefixes onto one poisoned cache
+  // key and make every real completion fail the prefix guard (silent no-ghost).
+  return redactSecrets(parts.join('\n'));
 }
 
 // ── Sanitization ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The REPL's optional **Tier-2 LLM ghost-text suggester** only ever saw the cwd basename + your current input line. Its two session-context getters (`getTranscriptTail`, `getRecentCommands`) were hardcoded stubs in the production wiring, so the `SuggestContext` plumbing was effectively dead.

This wires both getters **and** adds a secret-redaction chokepoint at the suggester's egress — which also closes a pre-existing leak.

## What changed

- **`surface-setup.ts`** — un-stub the two getters:
  - `getRecentCommands` reuses the existing secret-scrubbed `ReplHistory` ring (same source as `getHistory`).
  - `getTranscriptTail` renders the last 1–2 completed turns from `ctx.stats.turns`, newest-first so the freshest exchange wins `buildUser`'s 200-char budget.
- **`suggest.ts`** — `buildUser()` now wraps the whole assembled prompt in `redactSecrets()` before it leaves the process. Single chokepoint covering cwd + commands + transcript + input, across both the real-provider and injected-`completeFn` paths.

## Why it's safe

- Tier-2 routes to a possibly **cheaper model at a different endpoint** (`baseUrl` override) than the session, and `buildUser` previously had **zero** outbound redaction — only the model's *reply* was sanitized. The raw input buffer (`suggest.ts:111`) was already egressing unscrubbed; this closes that leak too.
- `redactSecrets` is the repo's established egress scrubber (already guarding the identical cheap-model transcript egress at `background-summarizer.ts:229`) and is strictly stronger than `ReplHistory`'s anchored deny-list (which misses AWS/JWT/PEM/connection-string secrets).
- **Invariant preserved:** redaction wraps the *returned prompt only*, never the raw `buffer` — that value is the result-cache key and the `isValidContinuation(buffer, reply)` guard input; redacting it would poison the cache and silently kill all completions.
- Gated behind the existing `AFK_SUGGEST_ENABLED` (off by default). **No new flag.**

## Testing

- Added egress-redaction tests: an AWS key in recent-commands is scrubbed to `[REDACTED]` before reaching `completeFn`; a plain buffer still completes (proving the buffer/guard path is untouched).
- `pnpm lint` clean; full suite green (672 files, 12263 passed).

## Design provenance

Chosen via a devil's-advocate wave over three alternatives — a single shared `redactSecrets()` egress chokepoint beat per-getter opt-in flags and a bespoke scrub, and survived a composition-boundary check against the cache/guard interaction.

## Known residual gap (non-blocking)

`redactSecrets` does not cover `postgres://user:pass@host` connection strings. Failing safe (such strings rarely land in the ~200-char window); a URI-credential rule could be added later.

## Deferred

The *value* of the transcript path (`getTranscriptTail`) is unproven — Tier-1 already prefix-matches recent history, so the marginal benefit to a haiku-class model with a 200-char budget is thin. Worth measuring the ghost-quality delta; easy to revert `getTranscriptTail` to a stub if it doesn't earn its keep.
