### PR TITLE
feat(trace): surface OAuth usage-limit pause/resume as witness trace phases

### DIFF
--- a/src/agent/providers/anthropic-direct/query-auth-retry.test.ts
+++ b/src/agent/providers/anthropic-direct/query-auth-retry.test.ts
@@ -22,6 +22,7 @@ import {
   AnthropicDirectProvider,
   __setAnthropicClientFactory,
 } from './index.js';
+import { InMemoryTraceWriter } from '../../trace/writer.js';
 
 // --- Mock SDK plumbing ---
 
@@ -678,6 +679,47 @@ describe('AnthropicDirectProvider — turnWithUsageLimitRetry', () => {
     expect(types).toContain('turn.completed');
     expect(events.filter((e) => e.type === 'error')).toHaveLength(0);
     expect(messagesCreateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('records usage_limit_pause + usage_limit_resume trace phases across the park', async () => {
+    // Same happy-path 429+ts → paused → resumed cycle, but assert the WITNESS
+    // TRACE now brackets the park. Before this fix the multi-hour pause left no
+    // trace event — the turn just stopped emitting (the documented silent gap).
+    let callIdx = 0;
+    messagesCreateMock.mockImplementation(() => {
+      callIdx += 1;
+      if (callIdx === 1) throw make429UsageLimitError(5 * 60 * 1_000);
+      return fromArray(makeTextStream('resumed successfully'));
+    });
+
+    const traceWriter = new InMemoryTraceWriter();
+    const provider = new AnthropicDirectProvider();
+    const query = provider.query({
+      prompt: singleInput('hello'),
+      config: {
+        model: 'claude-sonnet-5',
+        apiKey: 'sk-ant-oat01-test',
+        autoResumeOnUsageLimit: true,
+        traceWriter,
+      },
+    });
+
+    const collectPromise = collect(query);
+    await vi.runAllTimersAsync();
+    await collectPromise;
+
+    const phases: string[] = [];
+    let resumeDurationMs: number | undefined;
+    for (const e of traceWriter.events) {
+      if (e.kind !== 'session_phase') continue;
+      phases.push(e.payload.phase);
+      if (e.payload.phase === 'usage_limit_resume') resumeDurationMs = e.payload.durationMs;
+    }
+    expect(phases).toContain('usage_limit_pause');
+    expect(phases).toContain('usage_limit_resume');
+    // The resume phase carries the parked duration (>= 0, mirrors *_done events).
+    expect(resumeDurationMs).toBeTypeOf('number');
+    expect(resumeDurationMs).toBeGreaterThanOrEqual(0);
   });
 
   it('auto-resume=false: 429+ts → paused → original error, no resumed', async () => {

--- a/src/agent/providers/anthropic-direct/query/retry-layer.ts
+++ b/src/agent/providers/anthropic-direct/query/retry-layer.ts
@@ -321,6 +321,19 @@ export class RetryLayer {
     if (noTimestamp) {
       const accountId = parseAccountIdentifier(loadClaudeCodeOauthToken() ?? '');
       yield { type: 'paused', reason: 'usage-limit', accountId, autoResume: this.autoResumeOnUsageLimit };
+      // Witness layer: a usage-limit park is otherwise invisible in the trace —
+      // the turn simply stops emitting for up to two hours. Record it so the
+      // stall is legible (mirrors the `rate_limit` phase for transient backoff).
+      // Fire-and-forget; trace latency must never stall the pause/resume.
+      void emitSessionPhase(runInput.traceWriter, {
+        phase: 'usage_limit_pause',
+        metadata: {
+          reason: 'usage-limit',
+          source: 'retry-layer',
+          hasResetTimestamp: false,
+          autoResume: this.autoResumeOnUsageLimit,
+        },
+      });
 
       if (!this.autoResumeOnUsageLimit) {
         yield pendingErrorEvent;
@@ -384,6 +397,11 @@ export class RetryLayer {
           }
           if (!resumeEmitted) {
             yield { type: 'resumed', hotSwapped: noTsResult === 'hot-swap', accountId: resumedAccountId };
+            void emitSessionPhase(runInput.traceWriter, {
+              phase: 'usage_limit_resume',
+              durationMs: Date.now() - startedAt,
+              metadata: { source: 'retry-layer', hotSwapped: noTsResult === 'hot-swap' },
+            });
             resumeEmitted = true;
           }
           yield event;
@@ -413,6 +431,7 @@ export class RetryLayer {
     }
 
     const accountId = parseAccountIdentifier(loadClaudeCodeOauthToken() ?? '');
+    const pausedAt = Date.now();
     // External constraint: this event must carry `autoResume` BEFORE the
     // autoResumeOnUsageLimit branch below decides what comes next, so the UI
     // layer can render truthful copy on the very first paint of the panel.
@@ -425,6 +444,18 @@ export class RetryLayer {
       accountId,
       autoResume: this.autoResumeOnUsageLimit,
     };
+    // Witness layer: bracket the park so `afk trace show` explains the stall
+    // (see the no-ts pause above). Carries the reset deadline for context.
+    void emitSessionPhase(runInput.traceWriter, {
+      phase: 'usage_limit_pause',
+      metadata: {
+        reason: 'usage-limit',
+        source: 'retry-layer',
+        hasResetTimestamp: true,
+        autoResume: this.autoResumeOnUsageLimit,
+        resetsAt: resetsAt.toISOString(),
+      },
+    });
 
     if (!this.autoResumeOnUsageLimit) {
       yield pendingErrorEvent;
@@ -467,6 +498,11 @@ export class RetryLayer {
       randomUUID(),
     );
     yield { type: 'resumed', hotSwapped: result === 'hot-swap', accountId: resumedAccountId };
+    void emitSessionPhase(runInput.traceWriter, {
+      phase: 'usage_limit_resume',
+      durationMs: Date.now() - pausedAt,
+      metadata: { source: 'retry-layer', hotSwapped: result === 'hot-swap' },
+    });
 
     yield* this.turnWithAuthRetry(runInput, isClosed);
   }

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -396,6 +396,8 @@ export const SessionPhaseNameSchema = z.enum([
   'loop_end',
   'model_ttfb',
   'rate_limit',
+  'usage_limit_pause',
+  'usage_limit_resume',
 ]);
 
 export const SessionPhasePayloadSchema = z.object({

--- a/src/agent/trace/session-phase.test.ts
+++ b/src/agent/trace/session-phase.test.ts
@@ -137,6 +137,33 @@ describe('session_phase payload schema — acceptance', () => {
       SessionPhasePayloadSchema.parse({ phase: 'loop_end', durationMs: 0 }),
     ).not.toThrow();
   });
+
+  it('accepts the usage_limit_pause / usage_limit_resume phases', () => {
+    // Pause: no durationMs, park metadata (both the reset-ts and no-ts shapes).
+    expect(() =>
+      SessionPhasePayloadSchema.parse({
+        phase: 'usage_limit_pause',
+        metadata: {
+          reason: 'usage-limit',
+          source: 'retry-layer',
+          hasResetTimestamp: true,
+          autoResume: true,
+          resetsAt: new Date().toISOString(),
+        },
+      }),
+    ).not.toThrow();
+    // Resume: carries the parked durationMs + hot-swap flag.
+    expect(() =>
+      SessionPhasePayloadSchema.parse({
+        phase: 'usage_limit_resume',
+        durationMs: 300_000,
+        metadata: { source: 'retry-layer', hotSwapped: false },
+      }),
+    ).not.toThrow();
+    // Bare name-schema acceptance.
+    expect(() => SessionPhaseNameSchema.parse('usage_limit_pause')).not.toThrow();
+    expect(() => SessionPhaseNameSchema.parse('usage_limit_resume')).not.toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -636,7 +636,15 @@ export type SessionPhaseName =
   | 'loop_start'
   | 'loop_end'
   | 'model_ttfb'
-  | 'rate_limit';
+  | 'rate_limit'
+  // OAuth subscription usage-limit park/unpark. Unlike `rate_limit` (a short,
+  // bounded retry-after backoff), these bracket a potentially multi-HOUR pause
+  // while the turn waits for the subscription window to reset (or a keychain
+  // hot-swap). `usage_limit_resume` carries the parked `durationMs`. Emitted as
+  // a pair, but a pause may end without a resume (auto-resume off, abort, or the
+  // 2-hour cap surfacing the error) — so a lone `usage_limit_pause` is expected.
+  | 'usage_limit_pause'
+  | 'usage_limit_resume';
 
 export interface SessionPhasePayload {
   /** Which lifecycle milestone this record marks. */

--- a/src/cli/commands/trace.test.ts
+++ b/src/cli/commands/trace.test.ts
@@ -258,6 +258,35 @@ describe('formatTrace — rate_limit is high-signal (shown by default)', () => {
   });
 });
 
+describe('formatTrace — usage-limit pause/resume is high-signal (shown by default)', () => {
+  // A usage-limit park is the highest-signal stall of all: a multi-HOUR OAuth
+  // subscription pause. Like rate_limit, it must render WITHOUT --all so the
+  // trace explains the otherwise-invisible gap (the turn just stops emitting).
+  const events: EventObj[] = [
+    { ts: '2026-06-05T12:30:00.000Z', seq: 0, kind: 'session_phase', payload: { phase: 'usage_limit_pause', metadata: { reason: 'usage-limit', source: 'retry-layer', hasResetTimestamp: true, autoResume: true, resetsAt: '2026-06-05T14:30:00.000Z' } } },
+    { ts: '2026-06-05T14:30:05.000Z', seq: 1, kind: 'session_phase', payload: { phase: 'usage_limit_resume', durationMs: 7_205_000, metadata: { source: 'retry-layer', hotSwapped: false } } },
+    { ts: '2026-06-05T14:35:00.000Z', seq: 2, kind: 'session_sealed', payload: { status: 'succeeded', finalCostUsd: 0.01, finalTurnCount: 1, closedAt: '2026-06-05T14:35:00.000Z' } },
+  ];
+  const out = formatTrace('s', '/p', parseTrace(toJsonl(events)));
+
+  it('renders the pause in the DEFAULT view with its reset deadline', () => {
+    expect(out).toContain('paused');
+    expect(out).toContain('usage-limit');
+    expect(out).toContain('resets 2026-06-05T14:30:00.000Z');
+  });
+
+  it('renders the resume in the DEFAULT view with the parked duration', () => {
+    expect(out).toContain('resumed');
+    expect(out).toContain('parked');
+  });
+
+  it('still hides the low-signal model_ttfb phase by default', () => {
+    // Same isolation guarantee as the rate_limit block: high-signal pause/resume
+    // surface, ordinary latency phases stay behind --all.
+    expect(out).not.toContain('model_ttfb');
+  });
+});
+
 describe('formatTrace — closure stop_reason rendering', () => {
   const seal: EventObj = {
     ts: '2026-06-05T12:35:00.500Z',

--- a/src/cli/commands/trace.ts
+++ b/src/cli/commands/trace.ts
@@ -449,6 +449,21 @@ function renderEvent(event: TraceEvent, ctx: RenderContext): string | null {
         const head = reason !== undefined ? String(reason) : 'throttled';
         return line('throttle', `${head}${statusBit}${wait}${srcBit}`);
       }
+      // Usage-limit park/unpark is the highest-signal stall of all — a
+      // multi-hour subscription pause, not a per-minute backoff. Render in the
+      // DEFAULT view (before the showAll gate) so the trace explains the gap.
+      if (p.phase === 'usage_limit_pause') {
+        const md = p.metadata ?? {};
+        const resetsAt = md['resetsAt'];
+        const resetBit = resetsAt !== undefined ? `  resets ${resetsAt}` : '  no reset ts';
+        return line('paused', `usage-limit${resetBit}`);
+      }
+      if (p.phase === 'usage_limit_resume') {
+        const md = p.metadata ?? {};
+        const parked = p.durationMs !== undefined ? `  parked ${fmtDuration(p.durationMs)}` : '';
+        const hotSwap = md['hotSwapped'] === true ? '  (hot-swap)' : '';
+        return line('resumed', `usage-limit${parked}${hotSwap}`);
+      }
       if (!ctx.showAll) return null; // latency waterfall — low signal by default
       const dur = p.durationMs !== undefined ? `  ${fmtDuration(p.durationMs)}` : '';
       // Prefer the operator alias (session_init_start); fall back to the


### PR DESCRIPTION
## What

Make an OAuth **usage-limit pause legible in the witness trace**. Today, when Anthropic returns a subscription-cap 429, the retry layer parks the turn for up to two hours (waiting for the window to reset, or a keychain hot-swap) and then resumes — but `afk trace show` emits **no event** for any of it. The turn just stops emitting. AFK.md documents this exact gap: *"a usage-limit pause has no event (silent gap)."*

This PR emits two new `session_phase` events from `RetryLayer`, bracketing the park:

| phase | emitted at | payload |
|-------|-----------|---------|
| `usage_limit_pause` | both pause points — reset-timestamp path (`retry-layer.ts`) **and** no-timestamp path | `metadata: { reason, source, hasResetTimestamp, autoResume, resetsAt? }` |
| `usage_limit_resume` | both resume points | `durationMs` (parked time) + `metadata: { source, hotSwapped }` |

Both are **fire-and-forget** (`void emitSessionPhase(...)`) so trace latency can never stall the pause/resume, mirroring the `rate_limit` phase the transient-429 backoff path already emits (`retry-layer.ts:285`).

`afk trace show` renders both as **high-signal** — in the default view, before the `--all` gate — because a multi-hour park is the single most important stall to surface:

```
paused    usage-limit  resets 2026-06-05T14:30:00.000Z
resumed   usage-limit  parked 2.0h
```

## Why this shape

- **Dedicated phases, not overloaded `rate_limit`.** A 2-hour subscription park and a 5-second retry-after backoff are semantically different; folding both into `rate_limit` would conflate them in the throttle counter and the renderer. Resume also has no natural `rate_limit` meaning.
- **Additive / backward-compatible.** New names added to both `SessionPhaseName` (`trace/types.ts`) and its `z.enum` (`trace/events.ts`). These are **trace-internal** — NOT the frozen cross-surface JSONL provenance schema — so this is a safe additive change. No new `@anthropic-ai/sdk` imports; no env changes.
- A pause may legitimately end **without** a resume (auto-resume off, abort, or the 2-hour cap surfacing the error), so a lone `usage_limit_pause` is expected and documented inline.

## Context

Part of the agent-experience (AX) error-legibility arc (model-as-user / harness-as-app). Follows #635 (silent stream truncation). Closes the "usage-limit pause emits no trace event" finding.

## Testing

- `session-phase.test.ts` — schema acceptance for both new phases (payload + bare name schema).
- `query-auth-retry.test.ts` — drives the real `429+ts -> paused -> resumed` cycle with an `InMemoryTraceWriter` and asserts both phases land, with a numeric `durationMs` on resume. This exercises the actual retry-layer wiring, not a mock.
- `trace.test.ts` — asserts both phases render in the **default** view (no `--all`) with reset deadline / parked duration, and that ordinary latency phases stay hidden.

Gates (local, off `origin/main` @ v5.55.0):
- `tsc --noEmit` (strict) — clean
- 642 tests green across `src/agent/trace/` + `src/agent/providers/anthropic-direct/`
- `audit:sdk:check` OK (no new SDK symbols) · `audit:env:check` OK (0 violations)
