### PR TITLE
fix(skills): resolve stale plugin-namespaced contract ref in research-agent prompt

### DIFF
--- a/src/skills/_agents/prompts/research-agent.md
+++ b/src/skills/_agents/prompts/research-agent.md
@@ -11,7 +11,7 @@ Your tool surface is a hard allowlist enforced by Claude Code: `Read, Grep, Glob
 You can dispatch exactly one subagent type — `git-investigator` — for git queries. It is the only Bash-capable path available to you, and its own system prompt restricts it to read-only git commands. You may not dispatch any other subagent type.
 
 ## Contract
-/agent-workflow-amplifiers:contract
+/contract
 
 ## Behavior
 

--- a/src/skills/_agents/vendored.test.ts
+++ b/src/skills/_agents/vendored.test.ts
@@ -10,7 +10,7 @@ const __dirname = dirname(__filename);
 
 // Pinned hashes — guard against undocumented edits to the vendored copy
 const PINNED_HASHES = {
-  'research-agent': 'de1c6bedaf07f0fb7a159be3af3a13e27d31ee3c0e73dbcd34a741661f5abc04',
+  'research-agent': '80993a5f28dbcc9fd447a5bf022fc2ae14307d4af21fcaa0900a0b135515db0a',
   contract: '0b7febafec024e8dd4404f75e84d21ee72b1b1846d6e2610aaa82ba77f9d6f2d',
   'git-investigator': 'd1f186b82574641a4cb616990cee70a36f95a109b3688f59c07d12d26de60c03',
 } as const;


### PR DESCRIPTION
## Summary
- Fixes a stale plugin-namespaced `/agent-workflow-amplifiers:contract` reference in the vendored `research-agent` sub-agent prompt's `## Contract` section to the bare `/contract`, matching the co-located `contract.md`'s own self-description and how every other consumer of the co-vendored contract convention resolves it in this repo.
- Bumps the corresponding pinned SHA-256 guard hash for `research-agent` in `vendored.test.ts` (line 13, `PINNED_HASHES['research-agent']`) to match the new prompt content — this hash intentionally guards against undocumented edits to the vendored copy, so a deliberate content change must update it in the same commit (the documented "bump it" path, not a workaround).

## Test results
- `pnpm test src/skills/_agents/vendored.test.ts`: passed, 20/20 (was 1 failed / 19 passed with only the prompt edit applied and the old hash still in place — confirms the hash bump is the correct, required pairing).
- `pnpm test src/skills` (full directory): passed, 21 files / 350 tests.
- `pnpm lint` (`tsc --noEmit`, strict): clean, exit 0.

## Verification
No adversarial verify requested (diff is 4 lines total, well under the 100-line threshold). A full `/review` (light regime) was already run on the prompt-file diff prior to the hash bump: findings were low/nit only, no security/api-compat/correctness blockers. The recorded merge recommendation was "DO NOT MERGE (as-is)" solely because the pinned-hash test was still failing at that point — this PR resolves that by bumping the hash alongside the content change.
