### PR TITLE
fix(cli): make the REPL status line legible — visible context bar, brand caret, tiered tones

### DIFF
--- a/src/cli/commands/interactive/repl-loop-shared.test.ts
+++ b/src/cli/commands/interactive/repl-loop-shared.test.ts
@@ -11,7 +11,9 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import chalk from 'chalk';
 import { buildPrompt } from './repl-loop-shared.js';
+import { palette } from '../../palette.js';
 
 const BROAD_ANSI_RE = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
 
@@ -50,6 +52,21 @@ describe('buildPrompt', () => {
   it('always ends with the caret', () => {
     for (const mode of ['default', 'plan', 'autonomous', 'bypassPermissions'] as const) {
       expect(strip(buildPrompt(mode))).toMatch(/› $/);
+    }
+  });
+
+  it('renders the caret in the brand tone, not dim', () => {
+    // The caret was lifted from `dim` to `brand` so the input point reads as a
+    // deliberate affordance. Lock the tone (glyph is covered by the tests above)
+    // so a future change cannot silently re-dim it back to receding chrome.
+    const prev = chalk.level;
+    chalk.level = 3;
+    try {
+      const out = buildPrompt('default');
+      expect(out).toContain(palette.brand('  › '));
+      expect(out).not.toContain(palette.dim('  › '));
+    } finally {
+      chalk.level = prev;
     }
   });
 });

--- a/src/cli/commands/interactive/repl-loop-shared.ts
+++ b/src/cli/commands/interactive/repl-loop-shared.ts
@@ -78,5 +78,9 @@ export function buildPrompt(mode: PermissionMode): string {
     mode === 'autonomous' ? palette.info(' ◐') :
     mode === 'bypassPermissions' ? palette.bypass(' ⚡ bp') :
     '';
-  return base + marker + palette.dim('  › ');
+  // Caret is brand-toned (not dim) so the input point reads as a deliberate
+  // affordance rather than receding chrome — matches the "the caret carries the
+  // brand" intent above. Glyph unchanged (`›`) so piped/stripped transcripts and
+  // the strip-based buildPrompt tests are unaffected.
+  return base + marker + palette.brand('  › ');
 }

--- a/src/cli/context-bar.test.ts
+++ b/src/cli/context-bar.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import chalk from 'chalk';
 import { formatContextBar } from './context-bar.js';
+import { palette } from './palette.js';
 
 /** Strip ANSI escape sequences from output. */
 function stripAnsi(s: string): string {
@@ -59,9 +60,22 @@ describe('formatContextBar', () => {
     expect(result).toContain('\x1b[33m');
   });
 
-  it('includes dim color code when ratio <= 0.5', () => {
+  it('keeps the empty track dim (meta) at a low ratio', () => {
     const result = formatContextBar({ ratio: 0.2, width: 200 });
-    // Should contain dim ANSI code (90m is the standard bright-black/dim)
+    // The brackets + empty track always recede in the dim `meta` tone
+    // (90m = bright-black), regardless of ratio.
+    expect(result).toContain('\x1b[90m');
+  });
+
+  it('renders the filled run in a visible tone distinct from the track at a low ratio', () => {
+    // Regression: a low-context bar used to wrap the ENTIRE `[bar] NN% counts`
+    // string in the dimmest `meta` tone, so e.g. 6% looked like an empty box.
+    // The filled run + percent now carry a visible `chrome` tone while only the
+    // brackets/track recede, so a nearly-empty bar still reads as a real control.
+    const result = formatContextBar({ ratio: 0.06, used: 62400, limit: 1_000_000, width: 200 });
+    // filled = round(0.06 * 20) = 1 → exactly one '█' wrapped in the chrome tone.
+    expect(result).toContain(palette.chrome('█'));
+    // …and the track stays dim, so fill and track are visually distinguishable.
     expect(result).toContain('\x1b[90m');
   });
 

--- a/src/cli/context-bar.ts
+++ b/src/cli/context-bar.ts
@@ -21,7 +21,9 @@ export interface ContextBarOpts {
  * Format a context-usage progress bar.
  *
  * Behavior:
- * - Color: ratio > 0.8 → red; > 0.5 → orange; else dim
+ * - Color: the filled run + percent are threshold-toned (chrome when ratio ≤ 0.5,
+ *   orange > 0.5, red > 0.8); the brackets + empty track always recede in dim
+ *   `meta`, so even a low-ratio bar reads as a real control instead of an empty box
  * - Bar: 20 cells of █ filled vs ░ empty proportional to ratio, wrapped in [ ]
  * - Counts: formatTokens(used) + '/' + formatTokens(limit)
  * - Width-adaptive degradation:
@@ -35,33 +37,52 @@ export function formatContextBar(opts: ContextBarOpts): string {
   // Clamp ratio to [0, 1]
   const ratio = Math.max(0, Math.min(1, opts.ratio));
 
-  // Determine color based on ratio threshold
-  const color =
-    ratio > 0.8
-      ? palette.error    // red
-      : ratio > 0.5
-      ? palette.warning  // yellow/orange
-      : palette.meta;    // bright-black
+  // Contract: the bar is composed from TWO tones rather than wrapped in one.
+  // The filled run carries a threshold-graded "signal" tone that stays VISIBLE
+  // even at a low ratio (so a nearly-empty bar reads as a real control, not an
+  // empty box), while the brackets + empty track recede in `meta`. Previously
+  // the whole `[bar] NN% counts` string was wrapped in a single `color` that
+  // collapsed to near-invisible `meta` for every ratio <= 0.5 — that is what
+  // made a low-context bar look broken/unfinished. All tones are EXISTING
+  // palette roles (no new hardcoded hex): chrome (calm, ratio <= 0.5), warning
+  // (> 0.5), error (> 0.8).
+  const fillTone =
+    ratio > 0.8 ? palette.error : ratio > 0.5 ? palette.warning : palette.chrome;
+  const trackTone = palette.meta;
 
-  // Render bar: 20 cells, proportional fill
+  // Render bar: 20 cells, proportional fill. Geometry unchanged — only the
+  // per-run coloring differs (filled = signal tone, brackets/track = recessive).
   const barWidth = 20;
   const filled = Math.round(ratio * barWidth);
   const empty = barWidth - filled;
-  const bar = '[' + '█'.repeat(filled) + '░'.repeat(empty) + ']';
+  const bar =
+    trackTone('[') +
+    fillTone('█'.repeat(filled)) +
+    trackTone('░'.repeat(empty)) +
+    trackTone(']');
 
-  // Format percent
-  const percent = Math.round(ratio * 100) + '%';
+  // Percent shares the fill's threshold tone (a near-full context glows red);
+  // counts stay recessive. The `*Plain` variants below drive the width math and
+  // must stay ANSI-free so displayWidth measures the real cell count.
+  const percentPlain = Math.round(ratio * 100) + '%';
+  const percent = fillTone(percentPlain);
 
-  // Format counts if provided
-  let counts = '';
+  let countsPlain = '';
   if (opts.used !== undefined && opts.limit !== undefined) {
-    counts = formatTokens(opts.used) + '/' + formatTokens(opts.limit);
+    countsPlain = formatTokens(opts.used) + '/' + formatTokens(opts.limit);
   }
+  const counts = palette.meta(countsPlain);
 
   // Build plain (uncolored) forms to calculate widths
-  const fullFormPlain = counts ? `${bar} ${percent} ${counts}` : `${bar} ${percent}`;
-  const degradedFormPlain = `${bar} ${percent}`;
-  const minimalFormPlain = `ctx ${percent}`;
+  const barPlain = '[' + '█'.repeat(filled) + '░'.repeat(empty) + ']';
+  const fullFormPlain = countsPlain ? `${barPlain} ${percentPlain} ${countsPlain}` : `${barPlain} ${percentPlain}`;
+  const degradedFormPlain = `${barPlain} ${percentPlain}`;
+  const minimalFormPlain = `ctx ${percentPlain}`;
+
+  // Colored assemblies mirroring each plain form 1:1.
+  const fullForm = countsPlain ? `${bar} ${percent} ${counts}` : `${bar} ${percent}`;
+  const degradedForm = `${bar} ${percent}`;
+  const minimalForm = palette.meta('ctx ') + percent;
 
   // Sparkline is always dimly colored with meta (blackBright) tone
   const sparklinePrefix = opts.sparkline ? palette.meta(opts.sparkline) + ' ' : '';
@@ -77,27 +98,27 @@ export function formatContextBar(opts: ContextBarOpts): string {
 
   // Try full form first (requires generous margin)
   if (displayWidth(fullFormPlain) <= contentWidth && contentWidth > 90) {
-    return sparklinePrefix + color(fullFormPlain);
+    return sparklinePrefix + fullForm;
   }
 
   // Try degraded form (with bar, no counts)
   // Requires sufficient margin; 26-char form needs width > ~32 to feel comfortable
   if (displayWidth(degradedFormPlain) <= contentWidth && contentWidth > 32) {
-    return sparklinePrefix + color(degradedFormPlain);
+    return sparklinePrefix + degradedForm;
   }
 
   // Fall back to minimal form (no bar)
   if (displayWidth(minimalFormPlain) <= contentWidth) {
-    return sparklinePrefix + color(minimalFormPlain);
+    return sparklinePrefix + minimalForm;
   }
 
   // If even the minimal form doesn't fit, try truncating it
   if (opts.width > 0) {
-    const minimalWithSparkline = sparklinePrefix + color(minimalFormPlain);
+    const minimalWithSparkline = sparklinePrefix + minimalForm;
     return truncateDisplayWidth(minimalWithSparkline, opts.width);
   }
 
   // Last resort: return just the percent as a bare minimum,
   // even if width is too constrained to fit nicely
-  return color(percent);
+  return percent;
 }

--- a/src/cli/status-line.ts
+++ b/src/cli/status-line.ts
@@ -378,6 +378,16 @@ export class StatusLine {
       droppablePriority?: number; // undefined = never drop, higher = drop first
     }
 
+    // Tone hierarchy (all existing palette roles — no new hex): the row earns a
+    // "finished" read from CONTRAST between tiers, not uniform brightness.
+    //   primary   — model (brand) + mode chip (plan/AFK/bypass): already colored.
+    //   secondary — branch, cost, tokens, context %: readable `chrome` slate
+    //               (lifted from near-invisible `meta`/`dim`) so they're legible.
+    //   recessive — cwd path, separators, `⎇`/bar-track glyphs: stay `dim`/`meta`.
+    // cwd deliberately stays recessive: it is the longest field, and lifting it
+    // too would flatten the hierarchy back into a wash and compete with the
+    // conversation above. Tone is width-neutral (ANSI is stripped by displayWidth),
+    // so none of the drop/truncate math below is affected.
     let parts: Part[] = [];
     const maxW = Math.max(4, (this.stream.columns ?? 80) - 2);
 
@@ -425,7 +435,7 @@ export class StatusLine {
       // forcing the final blind truncation to shear the model off the right
       // edge. Drop-last means the location sheds before the model is ever cut.
       const branchText = truncateDisplayWidth(f.branch!, 30);
-      let gitText = `${palette.dim('⎇')} ${palette.dim(branchText)}`;
+      let gitText = `${palette.dim('⎇')} ${palette.chrome(branchText)}`;
       if (f.pr !== undefined) gitText += ` ${palette.meta(`#${f.pr}`)}`;
       parts.push({ text: gitText, droppablePriority: 1 }); // drop last among droppables — matches the plain branch; keeps the model never-drop
     } else {
@@ -443,7 +453,7 @@ export class StatusLine {
       // line; the whole segment is droppable (lowest priority ⇒ dropped last).
       if (f.branch) {
         const branchText = truncateDisplayWidth(f.branch, 30);
-        let gitText = `${palette.dim('⎇')} ${palette.dim(branchText)}`;
+        let gitText = `${palette.dim('⎇')} ${palette.chrome(branchText)}`;
         if (f.pr !== undefined) gitText += ` ${palette.meta(`#${f.pr}`)}`;
         parts.push({ text: gitText, droppablePriority: 1 }); // drop last among droppables
       }
@@ -480,11 +490,11 @@ export class StatusLine {
     }
 
     if (f.cost !== undefined) {
-      parts.push({ text: palette.meta(`$${f.cost.toFixed(2)}`), droppablePriority: 3 }); // drop 2nd
+      parts.push({ text: palette.chrome(`$${f.cost.toFixed(2)}`), droppablePriority: 3 }); // drop 2nd
     }
 
     if (f.tokens !== undefined) {
-      parts.push({ text: palette.meta(`${formatTokens(f.tokens)} tok`), droppablePriority: 4 }); // drop 1st
+      parts.push({ text: palette.chrome(`${formatTokens(f.tokens)} tok`), droppablePriority: 4 }); // drop 1st
     }
 
     // Join with separator and measure the result.


### PR DESCRIPTION
## Problem

The persistent bottom-of-terminal chrome (prompt line, loop rail, status line) read as *"doesn't stand out enough and looks kinda unfinished."* Two root causes:

- **~everything rendered in near-invisible gray** — `palette.meta` (blackBright) or `dim`. Only the model (brand) and mode chip (bypass) carried color, so the row looked like scaffolding.
- **The context bar looked like an empty box at low usage.** `formatContextBar` wrapped the *entire* `[bar] NN% counts` string in one tone, which collapsed to the dimmest `meta` for every ratio ≤ 0.5 — so at 6% the single filled cell and the 19 empty cells were the same near-black tone.

## Fix — contrast + hierarchy, not louder chrome

- **context-bar** (`src/cli/context-bar.ts`): compose the bar from **two** tones instead of one wrap. The filled run + percent carry a threshold tone (`chrome` ≤ 0.5, `warning` > 0.5, `error` > 0.8); the brackets + empty track recede in `meta`. A nearly-empty bar now reads as a real control. Bar geometry and the width-degradation ladder are unchanged.
- **status-line** (`src/cli/status-line.ts`): lift `branch`, `cost`, `tokens` from near-invisible `meta`/`dim` to the readable `chrome` slate, establishing a tier — brand model + colored mode chip (primary) → chrome metrics (secondary) → dim cwd/separators (recessive). `cwd` stays dim on purpose so the hierarchy doesn't flatten back into a wash.
- **prompt** (`repl-loop-shared.ts`): caret `›` lifted from dim → brand tone. Glyph unchanged, so piped transcripts and the strip-based `buildPrompt` tests are unaffected.

All styling uses **existing palette roles** — no new hardcoded hex, no raw chalk (`audit:chalk:check` clean). Every tone change is **width-neutral** (`displayWidth` strips ANSI), so the status-line drop/truncate algorithm is untouched.

## Deliberately excluded (rejected after a `/devils-advocate` pass)

- **Two-zone right-flushed metrics** — the right-edge gap recomputes every repaint as token/cost digit-widths change, so the metrics block would jitter horizontally; and there's rarely slack at typical widths anyway.
- **A new mid-gray palette role** — `palette.ts` is 100% dark-tuned hex; a fresh hardcoded gray just relocates the theme fragility. Reused existing `chrome` instead.
- **A ✓ completed-stage loop rail** — would assert stage completion the runtime can't prove (`loop-stage.ts` invariant: *"does not invent state the runtime cannot prove"*; the loop isn't strictly linear), and green already belongs to the `○ default` badge. Rail left unchanged.

Follow-up worth considering: theme-aware contrast tiers (so tones track the terminal background) + framing prompt/rail/status as one grouped footer panel. That's the real fix for "finished across *all* themes" and is out of scope here.

## Verification

- `tsc --noEmit` (lint) clean.
- Full `src/cli` suite green: **269 files / 4547 tests**.
- New regression tests: context-bar (visible filled tone distinct from the dim track at low ratio) + buildPrompt (caret is brand-toned, not dim).
- `audit:chalk:check`: 0 violations.
