### PR TITLE
fix(cli): reserve cyan for user identity (dropdown selection + inline code)

### DIFF
--- a/src/cli/formatter.test.ts
+++ b/src/cli/formatter.test.ts
@@ -520,6 +520,11 @@ describe('renderMarkdownToTerminal', () => {
       const m = tagged.match(/^(\x1b\[[0-9;]*m)/);
       return m ? m[1] : null;
     };
+    const getToolEscape = () => {
+      const tagged = palette.tool('SENTINEL');
+      const m = tagged.match(/^(\x1b\[[0-9;]*m)/);
+      return m ? m[1] : null;
+    };
     const userEscape = '\x1b[36m'; // chalk.cyan is always \x1b[36m at any level ≥ 1
 
     it('codespan containing a slash command gets brand color, not cyan', () => {
@@ -534,11 +539,16 @@ describe('renderMarkdownToTerminal', () => {
       expect(stripAnsi(out).trim()).toBe('/mint');
     });
 
-    it('codespan without slash keeps cyan color', () => {
+    it('codespan without slash gets tool color, not cyan', () => {
       const out = renderMarkdownToTerminal('`someFunction`');
       const brandEscape = getBrandEscape();
-      // Must contain cyan escape
-      expect(out).toContain(userEscape);
+      const toolEscape = getToolEscape();
+      // Must contain the tool ANSI escape (cyan is reserved for user identity;
+      // non-slash codespans now share the fenced-code/function tone).
+      expect(toolEscape).not.toBeNull();
+      expect(out).toContain(toolEscape!);
+      // Must NOT contain cyan escape
+      expect(out).not.toContain(userEscape);
       // Must not contain brand color
       if (brandEscape) {
         expect(out).not.toContain(brandEscape);

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -31,7 +31,7 @@ function renderInlineTokens(tokens?: Tokens.Generic[]): string {
     switch (token.type) {
       case 'codespan': {
         const csText = (token as Tokens.Codespan).text;
-        return SLASH_CODESPAN_RE.test(csText) ? palette.brand(csText) : palette.user(csText);
+        return SLASH_CODESPAN_RE.test(csText) ? palette.brand(csText) : palette.tool(csText);
       }
       case 'strong': {
         const strong = token as Tokens.Strong;
@@ -192,7 +192,7 @@ export function renderMarkdownToTerminal(text: string, opts: RenderMarkdownOptio
         }
         case 'codespan': {
           const raw = (token as Tokens.Codespan).text;
-          return SLASH_CODESPAN_RE.test(raw) ? palette.brand(raw) : palette.user(raw);
+          return SLASH_CODESPAN_RE.test(raw) ? palette.brand(raw) : palette.tool(raw);
         }
         case 'strong': {
           const strong = token as Tokens.Strong;

--- a/src/cli/input/dropdown.ts
+++ b/src/cli/input/dropdown.ts
@@ -41,12 +41,18 @@ export function formatDropdownRow(
   const truncated = truncateToWidth(combined, maxWidth - 4);
 
   const row = `  ${marker} ${truncated}`;
-  // Single muted base tone across trigger kinds. The earlier yellow accent for
-  // flag rows clashed with the cyan inverse on the selected row and the orange
-  // brand prompt above the dropdown — uniform gray reads as a quiet menu chrome
-  // and lets the selection highlight be the only thing competing for attention.
+  // Selection style mirrors the arrow-key picker (src/cli/render/picker.ts):
+  // a brand-orange marker + bold label, NOT a reverse-video fill band. Cyan is
+  // reserved for user identity only (see palette.ts) — the previous
+  // `inverse(user(...))` borrowed it for menu chrome, which both broke that
+  // rule and diverged from the picker's selection idiom. Unselected rows stay
+  // uniform muted gray so the selected row is the only thing competing for
+  // attention; the earlier per-trigger-kind yellow accent was dropped for the
+  // same salience reason.
   void triggerKind;
-  return isSelected ? palette.inverse(palette.user(row)) : palette.meta(row);
+  return isSelected
+    ? `  ${palette.brand(marker)} ${palette.bold(truncated)}`
+    : palette.meta(row);
 }
 
 /**

--- a/src/cli/palette.ts
+++ b/src/cli/palette.ts
@@ -69,7 +69,7 @@ export const palette = {
   bold: chalk.bold,
   /** Italic — used for emphasized prose; also paired with thinking tone. */
   italic: chalk.italic,
-  /** Inverse — reverse-video (swaps fg/bg); used for the selected row in the @-file autocomplete dropdown. A modifier alias so the render layer never reaches for raw chalk. */
+  /** Inverse — reverse-video (swaps fg/bg). A modifier alias so the render layer never reaches for raw chalk. Currently unused: the @-file autocomplete dropdown that formerly used it now matches the arrow-key picker's brand-marker + bold-label selection idiom. */
   inverse: chalk.inverse,
   /** Diff insertion — green, used for `+` lines in render-only diff blocks. */
   diffAdd: chalk.green,


### PR DESCRIPTION
## What
Two palette-coherence fixes so cyan (`palette.user`) is used only for user identity, per `src/cli/palette.ts` ("Cyan is reserved for user identity ONLY — never for chrome or structure").

1. **Dropdown selection** (`src/cli/input/dropdown.ts`): the selected row used `palette.inverse(palette.user(row))` — a cyan reverse-video band, i.e. identity-cyan as menu chrome. Now matches the arrow-key picker (`src/cli/render/picker.ts:175,187`): brand-orange marker + bold label, no fill band. Unifies the CLI's two list-selection idioms.
2. **Inline code spans** (`src/cli/formatter.ts`, 2 sites): non-slash `` `code` `` was rendered cyan (`palette.user`), scattering the identity color across nearly all output. Switched to `palette.tool` (`#DCDCAA`), the existing fenced-code/function tone, so cyan is freed for identity.

## Why
- `palette.ts` reserves cyan for user identity; both sites violated it (chrome + agent-output code).
- In-tree precedent: the picker selection already uses brand-orange + bold (no cyan), so the dropdown was the outlier.
- Convention: a saturated cyan/teal selection band is the minority pattern among polished CLIs (fzf, fish, gh, telescope, Catppuccin/gruvbox favor a neutral row + accent on glyph/text); warm-orange brand + cool-cyan accent clash when both are frequent.

## Scope / risk
Cosmetic-only, fully reversible, no behavior change. Two independent commits so either can be reverted alone.

## Testing
- `pnpm lint` (`tsc --noEmit`): **pass**, zero errors.
- `pnpm test src/cli/formatter.test.ts`: **67/67 pass**. One pre-existing test (`codespan without slash keeps cyan color`) asserted the old cyan expectation for non-slash codespans — updated it to assert `palette.tool`'s escape instead (added a `getToolEscape()` helper mirroring the existing `getBrandEscape()` pattern) while keeping the "does not contain cyan" and "does not contain brand" structural assertions intact. Included in the formatter commit.
- `pnpm test src/cli/terminal-compositor.dropdown-render.test.ts`: **12/12 pass**, no edits needed (no color/style assertions on the selected row in this file).
- `pnpm test src/cli/input/dropdown.test.ts`: **5/5 pass**, no edits needed (this file only covers `formatHintRow`, a different function; it never asserted on `formatDropdownRow`'s selection styling).
- Combined run of all three suites together: **84/84 pass**.
