### PR TITLE
fix(tui): coalesce post-ESC type-ahead across the teardown boundary (kill lone-"." input lag)

### DIFF
--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -109,14 +109,15 @@ export interface KeyDispatchHost {
   /** Once-only soft-stop guard for ESC in streaming mode. */
   softStopped: boolean;
   /**
-   * Snapshot of `pendingSubmissions.length` taken at ESC soft-stop time
-   * (handleEscape). Entries at indices `0..softStopQueueBase-1` were queued
-   * BEFORE esc and are contract-protected (handleEscape comment lines 318-327):
-   * "Already-queued messages: left untouched." Post-ESC Enters coalesce by
-   * MERGING everything at/above this base into one payload, so neither the
-   * pre-ESC queue nor earlier post-ESC messages are ever silently dropped.
+   * Post-ESC coalesce epoch — armed at ESC soft-stop, held until the coalesced
+   * redirect payload drains (authoritative field docs on the class in
+   * terminal-compositor.ts). While true, handleEnter MERGES each new message
+   * into {@link postEscPayload} rather than pushing a separate FIFO entry, so
+   * post-ESC pokes fold into ONE next turn instead of stranding one-per-turn.
    */
-  softStopQueueBase: number;
+  postEscCoalesce: boolean;
+  /** Merge target for the {@link postEscCoalesce} epoch (by reference), or null before the first post-ESC Enter / after it drains. */
+  postEscPayload: SubmissionPayload | null;
   /** Hard-abort flag set by Ctrl+C in streaming mode. */
   canceled: boolean;
   /** Once-only guard for Ctrl+B background in streaming mode. */
@@ -338,10 +339,15 @@ function handleEscape(self: KeyDispatchHost, key: KeyInfo): boolean {
   // committing it would fling it as a turn the user never submitted. Ctrl+C
   // (handleInterrupt below) follows the same no-auto-commit rule.
   self.softStopped = true;
-  // Snapshot the queue length so post-ESC coalesce (handleEnter) can merge
-  // everything at/above this base — preserving pre-ESC payloads per the
-  // contract above while folding post-ESC messages into one next turn.
-  self.softStopQueueBase = self.pendingSubmissions.length;
+  // Arm the post-ESC coalesce epoch. Unlike `softStopped` (cleared at the first
+  // teardown → idle), this is held until the coalesced redirect payload drains,
+  // so pokes typed AFTER teardown but before the redirect runs still merge in
+  // (the residual the softStopped-window coalesce missed — the lone-"." symptom).
+  // A fresh epoch starts with NO merge target: any pre-ESC payloads already on
+  // the FIFO stay as their own entries (handleEscape contract — "already-queued
+  // messages: left untouched"), and the first post-ESC Enter creates the target.
+  self.postEscCoalesce = true;
+  self.postEscPayload = null;
   if (self.onSoftStop) self.onSoftStop();
   return true;
 }
@@ -669,40 +675,49 @@ function handleEnter(self: KeyDispatchHost, key: KeyInfo, sequence: string): boo
     expandedText === displayText
       ? { text: expandedText, attachments }
       : { text: expandedText, displayText, attachments };
-  // Invariant: during the ESC soft-stop window — `softStopped` is set by
-  // handleEscape and cleared only at the post-soft-stop `→ idle` transition
-  // (setInputMode, terminal-compositor.input-mode.ts) — Enter must NOT
-  // accumulate a type-ahead backlog. That window is the async turn-teardown
-  // gap: for a subagent turn, cancelActiveForeground() (subagent-executor.ts)
-  // resolves the parent `await` only after the child settles — seconds for a
-  // deep/wide wave — and the compositor lingers in 'streaming' the whole time.
-  // Each Enter would otherwise push onto the FIFO, which drains ONE payload per
-  // turn (the `→ idle` flush), stranding the user one turn behind: the "it
-  // doesn't send, then I keep sending characters to catch up" report. So during
-  // a soft-stop, all post-ESC messages COALESCE into a single payload that runs
-  // as exactly one next turn — no backlog.
+  // Invariant: after an ESC soft-stop, Enter must NOT accumulate a type-ahead
+  // backlog. The teardown gap — the async window between ESC and the turn loop
+  // actually breaking (for a subagent turn, cancelActiveForeground() in
+  // subagent-executor.ts resolves the parent `await` only after the child
+  // settles, seconds for a deep/wide wave) — keeps the compositor in 'streaming'
+  // while the user, seeing no new turn, types a redirect and pokes ".". If each
+  // Enter pushed its own FIFO entry, the queue would drain ONE payload per turn
+  // (the `→ idle` flush), stranding the user one turn behind: the "it doesn't
+  // send, then I keep sending characters to catch up" report — the lone-"."
+  // messages. So across the whole post-ESC epoch, messages COALESCE into a
+  // single payload that runs as exactly one next turn — no backlog.
   //
-  // Coalesce = MERGE, not last-wins. The original #403 fix kept only the
-  // latest post-ESC message, which silently DROPPED earlier ones: a user who
-  // typed a real instruction during the settle window and then poked with "."
-  // (because nothing appeared to send) had the instruction replaced by the "."
-  // — the "message → no response → retype it" report, round 2. Merging joins
-  // the post-ESC texts with newlines (and concatenates attachments) so the
-  // user's full post-stop intent survives while the no-backlog invariant —
-  // exactly ONE next turn — still holds.
+  // Epoch, not just the softStopped window. `postEscCoalesce` is armed at ESC
+  // and held until the coalesced payload DRAINS (setInputMode's `→ idle` shift),
+  // NOT cleared at the first teardown `→ idle` the way `softStopped` is. This
+  // covers the residual #81/#403/#467 missed: a poke that lands AFTER teardown
+  // (softStopped already false) but before the redirect visibly starts. It used
+  // to strand as a separate turn; now it merges.
   //
-  // Contract preservation: `softStopQueueBase` was snapshotted by handleEscape
-  // at ESC time, capturing the count of pre-ESC payloads already on the FIFO.
-  // Entries below the base are pre-ESC turns and are left untouched (they
-  // drain as their own sequential turns via the `→ idle` flush), so the
-  // handleEscape contract — "Already-queued messages: left untouched" — holds.
-  // Only entries at/above the base participate in the merge. Normal mid-turn
-  // type-ahead (softStopped === false) still accumulates: sequential-turn
-  // delivery is the intended contract there (the "NO ESC" regression tests).
-  if (self.softStopped) {
-    const postEsc = self.pendingSubmissions.slice(self.softStopQueueBase);
-    self.pendingSubmissions.length = self.softStopQueueBase;
-    self.pendingSubmissions.push(mergeSubmissionPayloads([...postEsc, payload]));
+  // Merge target by REFERENCE (`postEscPayload`), not a FIFO index. Any pre-ESC
+  // payloads stay their own entries (handleEscape leaves postEscPayload null, so
+  // they are never the merge target) and drain as their own sequential turns —
+  // the handleEscape contract ("already-queued messages: left untouched") holds.
+  // A reference survives those pre-ESC entries draining ahead of it, whereas the
+  // old index (`softStopQueueBase`) went stale after any `shift()`.
+  //
+  // Merge joins texts with newlines + concatenates attachments (never last-wins,
+  // which silently dropped earlier post-ESC messages — the #467 regression).
+  // Normal mid-turn type-ahead (no ESC, postEscCoalesce === false) still
+  // accumulates one payload per message: sequential-turn delivery is the intended
+  // contract there (the "NO ESC" regression tests).
+  if (self.postEscCoalesce && self.postEscPayload !== null) {
+    // Merge into the still-pending redirect in place (same FIFO slot) so the
+    // whole post-stop burst becomes ONE next turn.
+    const idx = self.pendingSubmissions.indexOf(self.postEscPayload);
+    const merged = mergeSubmissionPayloads([self.postEscPayload, payload]);
+    if (idx >= 0) self.pendingSubmissions[idx] = merged;
+    else self.pendingSubmissions.push(merged); // defensive: target already drained
+    self.postEscPayload = merged;
+  } else if (self.postEscCoalesce) {
+    // First post-ESC message this epoch — it becomes the merge target.
+    self.postEscPayload = payload;
+    self.pendingSubmissions.push(payload);
   } else {
     self.pendingSubmissions.push(payload);
   }

--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -23,6 +23,7 @@ import { isSoftNewlineEnter, endsWithBackslashContinuation } from './input/enter
 import { readClipboardImage } from './input/clipboard-image.js';
 import { MAX_DROPDOWN_ROWS } from './terminal-compositor.autocomplete.js';
 import * as Paste from './terminal-compositor.paste.js';
+import { env } from '../config/env.js';
 import type { AutocompleteState } from './input/autocomplete-state.js';
 import type { IHistoryRing } from './input/types.js';
 import type { ImageAttachment } from './input/attachments.js';
@@ -711,19 +712,55 @@ function handleEnter(self: KeyDispatchHost, key: KeyInfo, sequence: string): boo
   // Normal mid-turn type-ahead (no ESC, postEscCoalesce === false) still
   // accumulates one payload per message: sequential-turn delivery is the intended
   // contract there (the "NO ESC" regression tests).
-  if (self.postEscCoalesce && self.postEscPayload !== null) {
-    // Merge into the still-pending redirect in place (same FIFO slot) so the
-    // whole post-stop burst becomes ONE next turn.
-    const idx = self.pendingSubmissions.indexOf(self.postEscPayload);
-    const merged = mergeSubmissionPayloads([self.postEscPayload, payload]);
-    if (idx >= 0) self.pendingSubmissions[idx] = merged;
-    else self.pendingSubmissions.push(merged); // defensive: target already drained
-    self.postEscPayload = merged;
-  } else if (self.postEscCoalesce) {
-    // First post-ESC message this epoch — it becomes the merge target.
-    self.postEscPayload = payload;
-    self.pendingSubmissions.push(payload);
+  if (self.postEscCoalesce) {
+    // Invariant: while the coalesce epoch is armed, `postEscPayload` is either
+    // null (no target committed yet this epoch) OR a reference that is PRESENT
+    // in `pendingSubmissions`. Every site that removes the tracked payload
+    // clears this reference — with DELIBERATELY asymmetric epoch semantics that
+    // must NOT be collapsed into one shared helper:
+    //   • ↑-recall pop (handleVerticalNav) clears `postEscPayload` ONLY and
+    //     leaves the epoch armed, so the edited draft re-establishes a fresh
+    //     target on re-Enter.
+    //   • drain shift (input-mode `→ idle`) clears BOTH — the target is now a
+    //     running turn, so the epoch is over.
+    //   • resetState clears everything on disarm/rearm.
+    // Therefore a NON-null `postEscPayload` that is ABSENT from the queue is an
+    // invariant violation (a future removal site that forgot to clear it),
+    // never a normal state. We must NOT feed an absent reference back into
+    // mergeSubmissionPayloads — doing so resurrects stale, already-recalled text
+    // (the exact PR #644 ↑-recall bug). So: merge only a target that is actually
+    // present; otherwise start a FRESH target. Worst case under a future
+    // violation is a stranded extra turn — never resurrected text.
+    const target = self.postEscPayload;
+    const idx = target !== null ? self.pendingSubmissions.indexOf(target) : -1;
+    if (target !== null && idx >= 0) {
+      // Live target present — merge in place (same FIFO slot) so the whole
+      // post-stop burst becomes ONE next turn. Merge joins texts with newlines +
+      // concatenates attachments (never last-wins, which silently dropped
+      // earlier post-ESC messages — the #467 regression).
+      const merged = mergeSubmissionPayloads([target, payload]);
+      self.pendingSubmissions[idx] = merged;
+      self.postEscPayload = merged;
+    } else {
+      // Either the first message this epoch (target === null — the normal case)
+      // or, under a FUTURE invariant violation, a dangling reference. Fail loud
+      // in dev/test so CI catches the offending removal site; production
+      // degrades safely by starting a fresh target rather than re-merging the
+      // absent reference.
+      if (target !== null && env.NODE_ENV !== 'production') {
+        throw new Error(
+          'terminal-compositor: post-ESC coalesce reference is dangling ' +
+            '(postEscPayload non-null but absent from pendingSubmissions) — a ' +
+            'pendingSubmissions removal site failed to clear the epoch reference.',
+        );
+      }
+      self.postEscPayload = payload;
+      self.pendingSubmissions.push(payload);
+    }
   } else {
+    // Normal mid-turn type-ahead (no ESC, postEscCoalesce === false): accumulate
+    // one payload per message — sequential-turn delivery is the intended
+    // contract there (the "NO ESC" regression tests).
     self.pendingSubmissions.push(payload);
   }
   self.queued = true; // maintained mirror: pendingSubmissions is now non-empty

--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -448,6 +448,11 @@ function handleVerticalNav(self: KeyDispatchHost, key: KeyInfo): boolean {
     // commit time are restored to the live list so re-Enter re-captures them.
     if (self.pendingSubmissions.length > 0 && self.input.buffer.length === 0) {
       const payload = self.pendingSubmissions.pop()!;
+      // If this was the post-ESC epoch's merge target, clear the reference so
+      // the next Enter treats the edited buffer as a FRESH payload (the `else
+      // if (postEscCoalesce)` branch) instead of re-merging this stale, now-
+      // popped text via the `idx < 0` defensive path. The epoch itself stays armed.
+      if (payload === self.postEscPayload) self.postEscPayload = null;
       self.queued = self.pendingSubmissions.length > 0; // maintain the mirror
       self.attachments = [...payload.attachments];
       self.history?.resetRecall();

--- a/src/cli/terminal-compositor.input-mode.ts
+++ b/src/cli/terminal-compositor.input-mode.ts
@@ -42,8 +42,11 @@ export interface InputModeHost {
   /** Once-only ESC soft-stop guard. */
   softStopped: boolean;
 
-  /** Queue-length snapshot at ESC time; coalesce boundary for post-ESC Enters. */
-  softStopQueueBase: number;
+  /** Post-ESC coalesce epoch — held until the coalesced redirect drains (authoritative field docs in terminal-compositor.ts). */
+  postEscCoalesce: boolean;
+
+  /** Merge target for the post-ESC coalesce epoch (by reference), or null before the first post-ESC Enter / after it drains. */
+  postEscPayload: SubmissionPayload | null;
 
   /** Hard-abort flag (Ctrl+C in streaming mode). */
   canceled: boolean;
@@ -176,7 +179,12 @@ export function setInputMode(self: InputModeHost, mode: CompositorInputMode): vo
     self.canceled = false;
     self.backgrounded = false;
     self.softStopped = false;
-    self.softStopQueueBase = 0;
+    // Clear the post-ESC coalesce epoch ONLY when no coalesced redirect is still
+    // pending (postEscPayload === null): a fresh user turn — or a stale ESC where
+    // the user never typed a post-ESC message — must start clean, but a pre-ESC
+    // payload draining ahead of the redirect must NOT drop the epoch (the redirect
+    // is still queued and later pokes should keep merging into it).
+    if (self.postEscPayload === null) self.postEscCoalesce = false;
     // Reset autocomplete at the idle→streaming transition so any
     // open dropdown rows are not rendered into the first streaming
     // frame. Mirrors the reset in the idle Enter handler above.
@@ -214,7 +222,12 @@ export function setInputMode(self: InputModeHost, mode: CompositorInputMode): vo
   // keeps an EMPTY-buffer ESC from leaving it armed into the idle period.
   if (mode === 'idle' && self.softStopped) {
     self.softStopped = false;
-    self.softStopQueueBase = 0;
+    // Deliberately do NOT clear `postEscCoalesce` / `postEscPayload` here. The
+    // epoch must survive this teardown → idle so a poke typed after teardown
+    // (softStopped now false) but before the redirect drains still merges into
+    // it — the residual the old softStopped-window coalesce missed (the lone-"."
+    // symptom). The epoch is ended where the coalesced payload actually drains
+    // (the flush branch below) or at idle→streaming when nothing is pending.
     // No early return: fall through so a queued buffer flushes via the branch
     // below when onSubmit is installed (readLine→idle), or — at the
     // dispose→idle transition where onSubmit is still null — stays queued for
@@ -242,6 +255,13 @@ export function setInputMode(self: InputModeHost, mode: CompositorInputMode): vo
     // the already-consumed queue and cannot double-fire the same payload.
     const payload = self.pendingSubmissions.shift()!;
     self.queued = self.pendingSubmissions.length > 0;
+    // The coalesced post-ESC redirect is now draining to a running turn — end
+    // the epoch so input typed against the NEW turn is normal (sequential)
+    // type-ahead again, not folded into an already-running redirect.
+    if (payload === self.postEscPayload) {
+      self.postEscCoalesce = false;
+      self.postEscPayload = null;
+    }
     self.repaint();
     handler(payload);
     return;

--- a/src/cli/terminal-compositor.keypress.test.ts
+++ b/src/cli/terminal-compositor.keypress.test.ts
@@ -866,6 +866,53 @@ describe('TerminalCompositor — keypress + history + buffer + spinner', () => {
         expect(onSubmit).toHaveBeenCalledTimes(1);
         expect(onSubmit).toHaveBeenCalledWith({ text: 'redirectX', attachments: [] });
       });
+
+      it('dangling post-ESC merge target: loud in dev/test, safe-degrade in prod (invariant guard)', async () => {
+        // Defense-in-depth for the #644 class. The merge branch must NEVER feed
+        // an ABSENT postEscPayload back through mergeSubmissionPayloads — that
+        // resurrects stale text. All real removal sites (pop/shift/reset) clear
+        // the reference, so this dangling state is unreachable via normal input;
+        // we FORCE it by setting the (module-internal) field directly to prove
+        // the guard behaves — this tests the invariant guard, not a real path.
+        const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
+        await c.arm();
+        c.setInputMode('idle');
+        c.setInputMode('streaming'); // turn arm
+
+        // Arm the epoch via a real ESC, then force a DANGLING target: a payload
+        // reference that is NOT present in pendingSubmissions (simulating a
+        // future removal site that popped/shifted it without clearing the ref).
+        stdin.emit('keypress', undefined, { name: 'escape' });
+        c.postEscPayload = { text: 'ghost', attachments: [] };
+
+        // Dev/test: the next committing Enter must THROW (loud CI signal) rather
+        // than silently merge the ghost text.
+        stdin.emit('keypress', 'x', { name: 'x', sequence: 'x' });
+        expect(() => stdin.emit('keypress', undefined, { name: 'return' })).toThrow(/dangling/);
+        c.disarm();
+
+        // Production: the SAME dangling state degrades safely — no throw, a fresh
+        // target, and the ghost text is NEVER resurrected into the submission.
+        vi.stubEnv('NODE_ENV', 'production');
+        try {
+          const c2 = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
+          await c2.arm();
+          c2.setInputMode('idle');
+          c2.setInputMode('streaming');
+          stdin.emit('keypress', undefined, { name: 'escape' });
+          c2.postEscPayload = { text: 'ghost', attachments: [] };
+          stdin.emit('keypress', 'x', { name: 'x', sequence: 'x' });
+          stdin.emit('keypress', undefined, { name: 'return' });
+          const onSubmit = vi.fn();
+          c2.setOnSubmit(onSubmit);
+          c2.setInputMode('idle');
+          expect(onSubmit).toHaveBeenCalledTimes(1);
+          expect(onSubmit).toHaveBeenCalledWith({ text: 'x', attachments: [] });
+          c2.disarm();
+        } finally {
+          vi.unstubAllEnvs();
+        }
+      });
     });
 
     it('printable chars grow buffer', async () => {

--- a/src/cli/terminal-compositor.keypress.test.ts
+++ b/src/cli/terminal-compositor.keypress.test.ts
@@ -826,6 +826,46 @@ describe('TerminalCompositor — keypress + history + buffer + spinner', () => {
         }
         expect(c.getPendingCount()).toBe(2); // sequential — not coalesced into one
       });
+
+      it('↑-recall of the post-ESC merge target does NOT resurrect stale text on re-send', async () => {
+        // Regression guard (P2/medium review finding on PR #644): popping a
+        // payload off pendingSubmissions for ↑-recall left postEscPayload
+        // pointing at it. Without the fix, the re-Enter below hits the merge
+        // branch's `idx < 0` defensive path (the popped payload is no longer
+        // in the queue) and resurrects the stale pre-edit text, submitting
+        // "redirect\nredirectX" instead of just the edited "redirectX".
+        const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
+        await c.arm();
+        c.setInputMode('idle');
+        c.setInputMode('streaming'); // turn arm
+
+        stdin.emit('keypress', undefined, { name: 'escape' });
+        for (const ch of 'redirect') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+        stdin.emit('keypress', undefined, { name: 'return' });
+        expect(c.getPendingCount()).toBe(1);
+
+        // ↑ recalls the just-committed payload (also the epoch's merge target)
+        // back into the live buffer for editing; the FIFO empties.
+        stdin.emit('keypress', undefined, { name: 'up' });
+        expect(c.getBuffer().text).toBe('redirect');
+        expect(c.getPendingCount()).toBe(0);
+
+        // Edit the recalled draft (grow the buffer — the exact suffix doesn't
+        // matter, only that the re-sent text differs from the popped one).
+        stdin.emit('keypress', 'X', { name: 'X', sequence: 'X' });
+
+        // Re-Enter: still inside the post-ESC epoch (postEscCoalesce stays
+        // armed). Fixed behavior: postEscPayload was cleared on pop above, so
+        // this becomes a fresh single entry — NOT a merge with the stale text.
+        stdin.emit('keypress', undefined, { name: 'return' });
+        expect(c.getPendingCount()).toBe(1);
+
+        const onSubmit = vi.fn();
+        c.setOnSubmit(onSubmit);
+        c.setInputMode('idle');
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit).toHaveBeenCalledWith({ text: 'redirectX', attachments: [] });
+      });
     });
 
     it('printable chars grow buffer', async () => {

--- a/src/cli/terminal-compositor.keypress.test.ts
+++ b/src/cli/terminal-compositor.keypress.test.ts
@@ -554,9 +554,10 @@ describe('TerminalCompositor — keypress + history + buffer + spinner', () => {
         // `pendingSubmissions = [payload]` reassignment silently dropped any
         // message committed via Enter BEFORE pressing ESC — violating the
         // handleEscape contract ("Already-queued messages: left untouched").
-        // The fix snapshots the queue length at ESC time (softStopQueueBase)
-        // and truncates back to that base before pushing, so pre-ESC payloads
-        // drain as their own turns while post-ESC type-ahead still coalesces.
+        // The fix leaves pre-ESC payloads as their own FIFO entries (they are
+        // never the post-ESC merge target — handleEscape arms the epoch with a
+        // null target), so they drain as their own turns while post-ESC
+        // type-ahead coalesces into one payload.
         const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
         await c.arm();
         c.setInputMode('idle');
@@ -567,10 +568,10 @@ describe('TerminalCompositor — keypress + history + buffer + spinner', () => {
         stdin.emit('keypress', undefined, { name: 'return' });
         expect(c.getPendingCount()).toBe(1);
 
-        // 2. ESC → softStopped=true, softStopQueueBase=1, queue untouched.
+        // 2. ESC → softStopped=true, post-ESC epoch armed (no merge target yet), queue untouched.
         stdin.emit('keypress', undefined, { name: 'escape' });
 
-        // 3. Enter "msg2" during linger → truncate-to-base(1) + push → queue=[msg1, msg2].
+        // 3. Enter "msg2" during linger → becomes the epoch merge target, pushed → queue=[msg1, msg2].
         for (const ch of 'msg2') stdin.emit('keypress', ch, { name: ch, sequence: ch });
         stdin.emit('keypress', undefined, { name: 'return' });
         expect(c.getPendingCount()).toBe(2); // pre-ESC msg1 is NOT dropped
@@ -608,8 +609,8 @@ describe('TerminalCompositor — keypress + history + buffer + spinner', () => {
           for (const ch of msg) stdin.emit('keypress', ch, { name: ch, sequence: ch });
           stdin.emit('keypress', undefined, { name: 'return' });
         }
-        // pre-ESC "pre" survives (base=1); three post-ESC Enters coalesce into
-        // ONE merged payload → total queue = 2, NOT 1 (pre not dropped) and NOT 4.
+        // pre-ESC "pre" survives (never the merge target); three post-ESC Enters
+        // coalesce into ONE merged payload → total queue = 2, NOT 1 (pre not dropped) and NOT 4.
         expect(c.getPendingCount()).toBe(2);
 
         c.setInputMode('idle'); // dispose → no drain (onSubmit null)
@@ -760,6 +761,70 @@ describe('TerminalCompositor — keypress + history + buffer + spinner', () => {
         expect(onSubmit).toHaveBeenCalledTimes(1);
         expect(onSubmit).toHaveBeenCalledWith({ text: 'next', attachments: [] });
         expect(c.getBuffer()).toEqual({ text: '', queued: false });
+      });
+
+      it('post-ESC poke typed AFTER the teardown → idle still MERGES into the redirect (no stranded turn)', async () => {
+        // The residual #81/#403/#467 missed (the lone-"." field report): softStopped
+        // clears at the first → idle, but the user is still WAITING for the redirect
+        // to run. A poke ("." to test liveness) typed after that boundary used to push
+        // a SEPARATE payload → a one-drain-per-turn backlog → the lone-"." turns. The
+        // post-ESC coalesce EPOCH persists until the redirect actually drains, so the
+        // poke merges in. Pre-fix: getPendingCount() === 2 here; post-fix: 1.
+        const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
+        await c.arm();
+        c.setInputMode('idle');
+        c.setInputMode('streaming'); // turn arm
+
+        // ESC + a real redirect during the interrupt window (softStopped true).
+        stdin.emit('keypress', undefined, { name: 'escape' });
+        for (const ch of 'redirect') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+        stdin.emit('keypress', undefined, { name: 'return' });
+        expect(c.getPendingCount()).toBe(1);
+
+        // Teardown completes: dispose → idle CLEARS softStopped (existing contract).
+        c.setInputMode('idle');
+
+        // The redirect has NOT drained yet (onSubmit null). softStopped is now false —
+        // a poke typed here previously stranded as a 2nd payload (one turn behind).
+        stdin.emit('keypress', '.', { name: '.', sequence: '.' });
+        stdin.emit('keypress', undefined, { name: 'return' });
+        // FIXED: the poke merges into the still-pending redirect → ONE payload.
+        expect(c.getPendingCount()).toBe(1);
+
+        const onSubmit = vi.fn();
+        c.setOnSubmit(onSubmit);
+        c.setInputMode('idle');
+        expect(onSubmit).toHaveBeenCalledTimes(1);
+        expect(onSubmit).toHaveBeenCalledWith({ text: 'redirect\n.', attachments: [] });
+      });
+
+      it('post-ESC epoch ENDS when the redirect drains — later type-ahead is sequential again (no leak)', async () => {
+        // The epoch must not leak past the redirect. Once the coalesced payload
+        // drains to a running turn, subsequent mid-turn type-ahead accumulates one
+        // payload per message again (normal sequential delivery) — NOT folded into
+        // the already-running redirect.
+        const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn(), onSoftStop: vi.fn() });
+        await c.arm();
+        c.setInputMode('idle');
+        c.setInputMode('streaming'); // turn arm
+
+        stdin.emit('keypress', undefined, { name: 'escape' });
+        for (const ch of 'redirect') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+        stdin.emit('keypress', undefined, { name: 'return' });
+
+        // Drain the redirect → it runs as a turn (idle→streaming), ending the epoch.
+        const onSubmit = vi.fn();
+        c.setOnSubmit(onSubmit);
+        c.setInputMode('idle'); // drain redirect
+        expect(onSubmit).toHaveBeenNthCalledWith(1, { text: 'redirect', attachments: [] });
+        c.setInputMode('streaming'); // the redirect's turn starts
+
+        // Two fresh mid-turn messages (no new ESC) must accumulate as TWO payloads.
+        for (const msg of ['one', 'two']) {
+          for (const ch of msg) stdin.emit('keypress', ch, { name: ch, sequence: ch });
+          stdin.emit('keypress', undefined, { name: 'return' });
+        }
+        expect(c.getPendingCount()).toBe(2); // sequential — not coalesced into one
       });
     });
 

--- a/src/cli/terminal-compositor.reset.ts
+++ b/src/cli/terminal-compositor.reset.ts
@@ -32,7 +32,8 @@ export interface ResetStateHost {
   canceled: boolean;
   backgrounded: boolean;
   softStopped: boolean;
-  softStopQueueBase: number;
+  postEscCoalesce: boolean;
+  postEscPayload: SubmissionPayload | null;
   paused: boolean;
   activeGhost: string | null;
   anchorRow: number | undefined;
@@ -65,7 +66,8 @@ export function resetState(self: ResetStateHost): void {
   self.canceled = false;
   self.backgrounded = false;
   self.softStopped = false;
-  self.softStopQueueBase = 0;
+  self.postEscCoalesce = false;
+  self.postEscPayload = null;
   self.paused = false;
   // Clear active ghost — stale suggestions must not survive a disarm/rearm
   // cycle. The engine itself is NOT disposed here (only in disarm) since

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -82,13 +82,29 @@ export class TerminalCompositor {
    */
   softStopped = false;
   /**
-   * Snapshot of `pendingSubmissions.length` at ESC soft-stop time. Post-ESC
-   * Enters merge everything at/above this base into one payload, so pre-ESC
-   * payloads are preserved (handleEscape contract) while post-ESC type-ahead
-   * coalesces into a single merged next turn. Reset alongside `softStopped`.
+   * Post-ESC coalesce epoch. Armed by an ESC soft-stop (handleEscape) and — unlike
+   * {@link softStopped}, which is cleared at the first teardown `→ idle` — held
+   * until the coalesced redirect payload actually DRAINS to a running turn
+   * ({@link ./terminal-compositor.input-mode.ts | setInputMode}'s `→ idle` shift).
+   * While armed, every streaming-mode Enter MERGES into {@link postEscPayload}
+   * instead of pushing a separate FIFO entry, so a user who ESCs then types a
+   * redirect + "." pokes (because the redirect hasn't visibly started yet) gets ONE
+   * next turn — not a one-drain-per-turn backlog stranded one turn behind. This is
+   * the residual #81/#403/#467 never covered: those coalesced only within the
+   * narrow softStopped window, so a poke landing after teardown stranded as its own
+   * turn (the lone-"." symptom). Reset in `resetState()` and on idle→streaming.
    * @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost).
    */
-  softStopQueueBase = 0;
+  postEscCoalesce = false;
+  /**
+   * Merge target for the {@link postEscCoalesce} epoch: the single coalesced
+   * post-ESC payload currently in {@link pendingSubmissions}, or null before the
+   * first post-ESC Enter / after it drains. Tracked by REFERENCE (not a FIFO
+   * index) so it survives pre-ESC payloads draining ahead of it — the index-based
+   * `softStopQueueBase` it replaces went stale after any `shift()`.
+   * @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost).
+   */
+  postEscPayload: SubmissionPayload | null = null;
   /** @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost). */
   onBackground?: () => void;
   /**


### PR DESCRIPTION
## Symptom

ESC to stop a turn → your next message appears not to send → you poke with `.` to force it. Today's REPL transcripts are littered with lone-`.` user turns (session `bb44050a` alone has **10 separate `{"user":"."}` turns**, spanning minutes).

## Root cause (diagnosed, not guessed)

**This is _not_ a reverted fix.** `#467`'s coalesce-merge is present and byte-unchanged since `064ea20` (`git log 064ea20..HEAD` on both input files is empty across 238 commits). It's a **design-scope gap** all three prior fixes (#81 → #403 → #467) shared:

- The post-ESC coalesce is gated on `softStopped`, which is **cleared at the first teardown `→ idle`** (`terminal-compositor.input-mode.ts`).
- But `session.interrupt()` is an **async abort-request**, not a synchronous stream halt: `agent-session.ts:744` → `anthropic-direct/query.ts:604` `requestAbort()` → trips an `AbortController`; the stream loop only breaks on its **next signal-poll** (`loop.ts`). For subagent/skill turns, `cancelActiveForeground()` awaits each child's settle — **seconds**. The compositor lingers in `'streaming'` the whole time.
- A poke typed **after** `softStopped` clears but **before** the redirect drains hit the plain `pendingSubmissions.push()` path and **stranded one-turn-behind** — a separate turn per poke, draining one per `→ idle`. That's the lone-`.` backlog.

The old coalesce also keyed the merge on an **index** (`softStopQueueBase`) that went stale after any FIFO `shift()`.

<details><summary>Evidence (all 4 load-bearing claims independently re-derived via <code>/shadow-verify</code>)</summary>

| Claim | Verdict | Proof |
|---|---|---|
| #467 present & unchanged | ✅ | `064ea20` ancestor of HEAD; empty diff across 238 commits |
| `softStopped` set once (`:340`), cleared at both turn boundaries; coalesce gated on it; drains one-per-turn | ✅ | `input-dispatch.ts:340/702/707`, `input-mode.ts:178/216/243` |
| `interrupt()` is async abort-request | ✅ | `agent-session.ts:744` → `query.ts:604` → `abort-coordinator.ts:124`; loop-break at `loop.ts:595…` |
| The `.` messages were separate turns, not merged | ✅ | 10 discrete `{"user":"."}` objects in `bb44050a`, zero merged `.\n.` blobs |

</details>

## Fix

Replace the `softStopped`-gated, index-based coalesce with a **payload-reference coalesce _epoch_**:

- `postEscCoalesce` is armed at ESC and **held until the coalesced redirect payload actually drains** to a running turn — not cleared at the teardown `→ idle`.
- `postEscPayload` tracks the single merge target **by reference**, so it survives pre-ESC payloads draining ahead of it.

Post-ESC pokes now merge into the pending redirect across the teardown boundary → **one next turn, no backlog**. Pre-ESC payloads are never the merge target, so they still drain as their own sequential turns; normal no-ESC type-ahead is untouched (sequential-turn delivery preserved).

## Verification

- **New regression test** (`terminal-compositor.keypress.test.ts`): fails on HEAD (`getPendingCount() === 2`, stranded) and passes with the fix (`1`, merged as `redirect\n.`) — the bug is reproduced, then closed.
- **Leak-guard test**: the epoch ends when the redirect drains (later type-ahead is sequential again).
- All **12 existing soft-stop invariants** pass unchanged (pre-ESC preservation, merge-not-last-wins, NO-ESC accumulation, empty-ESC idle flush, …).
- **424 compositor + turn-handler + loop-iteration tests** pass; strict `tsc --noEmit` clean.
- Full suite: 12278 pass. The 1 failure (`agent/trace/writer.test.ts` subprocess-spawn e2e) is **pre-existing and environmental** — it fails identically on pristine HEAD with zero changes, and this PR touches no `agent/trace` code.

## Scope / residual (maintainer decision)

This closes the verified defect: pokes typed **while waiting for the redirect to start** now fold into it. One residual remains that this PR intentionally does **not** change: if the redirect has already drained and its turn is running *long*, further pokes are normal type-ahead again and queue separately. Fully eliminating lone-`.` there needs either (a) prompt ESC→idle teardown (async lifecycle work, larger blast radius) or (b) a more aggressive "coalesce until a genuinely idle prompt" policy. Flagged for your live-TTY judgment rather than baked in here.

🤖 Diagnosed + fixed via agent-afk (`/diagnose` → `/shadow-verify`).
