### PR TITLE
perf(cli): coalesce same-tick keystroke repaints with sync flush

### DIFF
--- a/src/cli/input/emit-keypress.ts
+++ b/src/cli/input/emit-keypress.ts
@@ -1,17 +1,20 @@
 import { emitKeypressEvents, type Interface } from 'readline';
 
 /**
- * Tuned `escapeCodeTimeout` for `readline.emitKeypressEvents` so a lone ESC
- * fires on the FIRST press without misreading split escape sequences.
+ * Sets `escapeCodeTimeout` to 50ms (see {@link LONE_ESC_TIMEOUT_MS}) for
+ * `readline.emitKeypressEvents`, so a lone ESC fires on the FIRST press
+ * without misreading split escape sequences. 50ms is the ONLY value AFK ships;
+ * the 500ms mentioned below is Node's DEFAULT, which this module overrides.
  *
- * History: ESC is the soft-stop / cancel affordance across AFK's TTY
- * surfaces (compositor stream-stop, reader, elicitation prompts). Node's
- * readline buffers a chunk-trailing `\x1b` for `escapeCodeTimeout`
- * (default 500ms, the GNU readline keyseq-timeout) to disambiguate a lone
- * ESC from the start of an escape sequence (arrows, alt-keys): the `escape`
- * keypress fires only after that timeout OR when the next key arrives. The
- * 500ms delay is why ESC "needs two presses" — pressing ESC again flushes
- * the first buffered ESC.
+ * History: ESC is the soft-stop / cancel affordance across AFK's TTY surfaces
+ * (compositor stream-stop, reader, elicitation prompts). Node's readline
+ * buffers a chunk-trailing `\x1b` for `escapeCodeTimeout` — whose default is
+ * 500ms (the GNU readline keyseq-timeout) — to disambiguate a lone ESC from
+ * the start of an escape sequence (arrows, alt-keys): the `escape` keypress
+ * fires only after that timeout OR when the next key arrives. Under Node's
+ * 500ms default ESC "needs two presses" (the second press flushes the first
+ * buffered ESC); overriding it to 50ms below is what makes a single ESC
+ * register.
  *
  * Why a small NONZERO timeout (not 0): the disambiguation window only needs
  * to drop below human perception (~100ms) to fix the double-press bug — it

--- a/src/cli/terminal-compositor.dropdown-render.test.ts
+++ b/src/cli/terminal-compositor.dropdown-render.test.ts
@@ -410,6 +410,14 @@ describe('TerminalCompositor — formatInputBuffer callback', () => {
     stdin.emit('keypress', undefined, { name: 'left' });
     stdin.emit('keypress', undefined, { name: 'left' });
 
+    // Same-tick keystroke repaints coalesce: only the leading edge painted
+    // synchronously (rendering an intermediate buffer state), and the rest of
+    // this synchronous burst deferred to one trailing microtask paint. Drain
+    // it so the FINAL render — cursor on 'b', pre='a', post='c' — runs and
+    // invokes the formatter with both segment shapes. (See the same-tick
+    // coalescing block in terminal-compositor.keypress.test.ts.)
+    await Promise.resolve();
+
     // The formatter must have been called with both segment shapes by the
     // final render — 'a' as the pre-cursor segment and 'c' as the post-cursor
     // segment after the second left arrow.
@@ -446,6 +454,10 @@ describe('TerminalCompositor — formatInputBuffer callback', () => {
     stdin.emit('keypress', 'a', { name: 'a', sequence: 'a' });
     stdin.emit('keypress', 'b', { name: 'b', sequence: 'b' });
     stdin.emit('keypress', undefined, { name: 'left' });
+    // Same-tick keystroke repaints coalesce — drain the trailing microtask so
+    // the FINAL frame (buffer='ab', cursor=1) renders and its formatter calls
+    // land in `seen`. (See terminal-compositor.keypress.test.ts.)
+    await Promise.resolve();
     // Now buffer='ab', cursor=1 → cursorText='b', before='a', after=''
     // The formatter must have received 'a' and '' but never 'b' (the cursor char).
     const lastTwoCalls = seen.slice(-2);

--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -45,8 +45,14 @@ import type {
  * mutated/invoked through it).
  */
 export interface KeyDispatchHost {
-  /** Re-render the live frame. */
+  /** Re-render the live frame synchronously. */
   repaint(): void;
+  /**
+   * Coalescing repaint for the per-keystroke edit path: leading edge paints
+   * synchronously, subsequent same-tick edits defer to one trailing microtask
+   * paint. See {@link TerminalCompositor.scheduleRepaint}.
+   */
+  scheduleRepaint(): void;
   /**
    * Clear the terminal viewport (erase entire screen + cursor home) and
    * repaint the live compositor frame. Used by the Ctrl+L binding.
@@ -160,7 +166,14 @@ export function applyEdit(self: KeyDispatchHost, next: InputCoreState): boolean 
   // guard), so this per-character ghost refresh never fires mid-paste —
   // it would be stale by paste end anyway.
   self.updateGhost();
-  self.repaint();
+  // Coalesce per-keystroke repaints: the first edit in an event-loop tick
+  // paints synchronously (leading edge — buffer STATE is already mutated above,
+  // so single-keystroke sync contracts hold); subsequent edits in the same tick
+  // defer to ONE trailing microtask paint. A rapid-typing burst of N keys thus
+  // costs 2 frame writes instead of N. Autocomplete/ghost state is updated
+  // synchronously above regardless, so a coalesced frame always renders the
+  // latest buffer + dropdown state.
+  self.scheduleRepaint();
   return true;
 }
 
@@ -377,9 +390,12 @@ function handleClipboardImageKey(self: KeyDispatchHost, key: KeyInfo): boolean {
   // for users on terminals where bracketed-paste is disabled or who
   // prefer the keyboard binding. Ported from reader.ts:464-479.
   // In-flight guard prevents concurrent osascript spawns from key
-  // repeats. schedulePaint() in reader.ts is replaced here by
-  // self.repaint() because the compositor's log-update frame is
-  // burst-coalesced internally.
+  // repeats. reader.ts's schedulePaint() is replaced here by a plain
+  // self.repaint(): this paint fires from the clipboard probe's async
+  // `.then` (its own event-loop turn, one probe at a time via the
+  // in-flight guard), so there is no synchronous burst to coalesce — a
+  // direct repaint is correct. (Per-keystroke TYPING repaints ARE
+  // coalesced, but through applyEdit → scheduleRepaint, not this path.)
   if (key?.ctrl && key?.name === 'v') {
     if (!self.clipboardInFlight) {
       self.clipboardInFlight = true;

--- a/src/cli/terminal-compositor.keypress.test.ts
+++ b/src/cli/terminal-compositor.keypress.test.ts
@@ -975,6 +975,153 @@ describe('TerminalCompositor — keypress + history + buffer + spinner', () => {
     });
   });
 
+  // ── Same-tick keystroke repaint coalescing (perf) ──────────────────────
+  //
+  // A synchronous burst of keypresses (rapid typing delivered in one
+  // event-loop tick — the common paste-into-a-non-bracketed-paste-terminal
+  // and fast-typist case) used to cost one FULL-frame repaint per key. The
+  // compositor now coalesces: the FIRST edit in a tick paints synchronously
+  // (leading edge — every single-keystroke sync contract above is preserved),
+  // and subsequent edits in the SAME tick mark the frame dirty and defer to a
+  // single trailing repaint on a microtask. A burst of N keys therefore costs
+  // 2 physical frame writes (1 leading + 1 trailing) instead of N.
+  //
+  // Physical frames are counted via the synchronized-output start marker
+  // (`\x1b[?2026h`), which CupFrameRenderer.render() emits exactly once per
+  // frame write (mock stdout is a TTY, so sync output is on). Buffer STATE
+  // stays fully synchronous — getBuffer() reads self.input, mutated per key —
+  // so the deferral is invisible to every existing state assertion.
+  describe('same-tick repaint coalescing', () => {
+    const SYNC_FRAME = '\x1b[?2026h';
+    const countFrames = (s: string): number => s.split(SYNC_FRAME).length - 1;
+
+    it('a same-tick burst of ≥3 keypresses produces ≤2 frame paints', async () => {
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+      await c.arm();
+      writes.clear(); // isolate the paints produced by the burst alone
+      // Five printable keys delivered synchronously (one libuv read tick).
+      for (const ch of 'hello') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+      // Synchronously (before any await drains the microtask): the leading
+      // edge painted once; the other four coalesced into at most one pending
+      // trailing paint that has not fired yet. So ≤1 frame is on the wire now.
+      const framesSync = countFrames(writes.all());
+      expect(framesSync).toBeLessThanOrEqual(1);
+      // State is fully synchronous regardless of paint deferral.
+      expect(c.getBuffer().text).toBe('hello');
+      // Drain the microtask so the trailing repaint fires.
+      await Promise.resolve();
+      const framesAfterFlush = countFrames(writes.all());
+      // ≤2 total: one leading + one trailing. Far fewer than the 5 a
+      // per-key repaint would have produced.
+      expect(framesAfterFlush).toBeLessThanOrEqual(2);
+      expect(framesAfterFlush).toBeGreaterThanOrEqual(1);
+      c.disarm();
+    });
+
+    it('the final coalesced frame reflects the LAST keystroke of the burst', async () => {
+      const chalkModule = await import('chalk');
+      const priorLevel = chalkModule.default.level;
+      chalkModule.default.level = 1;
+      try {
+        const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+        await c.arm();
+        for (const ch of 'abcde') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+        // Isolate the trailing repaint: clear everything painted synchronously,
+        // then drain the microtask so ONLY the coalesced trailing frame lands.
+        writes.clear();
+        await Promise.resolve();
+        const frame = writes.all();
+        // The trailing frame renders the full buffer including the last key.
+        expect(frame).toContain('abcde');
+        // Buffer state matches the painted frame.
+        expect(c.getBuffer().text).toBe('abcde');
+        c.disarm();
+      } finally {
+        chalkModule.default.level = priorLevel;
+      }
+    });
+
+    it('a lone keystroke still paints synchronously (leading edge, no deferral needed)', async () => {
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+      await c.arm();
+      writes.clear();
+      stdin.emit('keypress', 'z', { name: 'z', sequence: 'z' });
+      // Single key = first-in-tick = leading edge: the frame is on the wire
+      // immediately, no await required (preserves the synchronous-write
+      // contract the caret/queue suites rely on).
+      expect(countFrames(writes.all())).toBe(1);
+      expect(c.getBuffer().text).toBe('z');
+      c.disarm();
+    });
+
+    it('flushPendingRepaint() forces the coalesced trailing frame synchronously', async () => {
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+      await c.arm();
+      writes.clear();
+      for (const ch of 'sync') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+      // Leading edge painted once; trailing is pending on the microtask.
+      writes.clear();
+      // flushPendingRepaint drains the pending trailing paint WITHOUT waiting
+      // for the microtask — the synchronous flush lifecycle points rely on.
+      c.flushPendingRepaint();
+      expect(countFrames(writes.all())).toBe(1);
+      // A second flush is a no-op — nothing is pending anymore (idempotent).
+      writes.clear();
+      c.flushPendingRepaint();
+      expect(writes.all()).toBe('');
+      // And the microtask that was already queued must not double-paint.
+      await Promise.resolve();
+      expect(writes.all()).toBe('');
+      c.disarm();
+    });
+
+    it('flushPendingRepaint() is idempotent and safe with nothing pending', async () => {
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+      await c.arm();
+      writes.clear();
+      // No burst — nothing pending. Flushing must not paint or throw.
+      expect(() => c.flushPendingRepaint()).not.toThrow();
+      expect(writes.all()).toBe('');
+      c.disarm();
+    });
+
+    it('flushPendingRepaint() is safe after disarm and a stale pending paint never fires', async () => {
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+      await c.arm();
+      // Start a burst so a trailing paint is pending, then tear down BEFORE
+      // the microtask drains — the classic use-after-teardown hazard.
+      for (const ch of 'abc') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+      c.disarm();
+      writes.clear();
+      // Explicit flush after disarm must be a no-op (never paints a torn-down
+      // compositor, never throws).
+      expect(() => c.flushPendingRepaint()).not.toThrow();
+      expect(writes.all()).toBe('');
+      // The microtask queued during the burst now drains — it must NOT paint
+      // either (the disarm cancelled the pending trailing repaint).
+      await Promise.resolve();
+      expect(writes.all()).toBe('');
+      expect(c.isArmed()).toBe(false);
+    });
+
+    it('a printable keystroke bumps repaintCount exactly once (coalesced-away paint still counts)', async () => {
+      // The caret-blink un-hide logic keys off repaintCount to tell whether
+      // dispatchKey already painted this keystroke. A coalesced (deferred)
+      // paint must still register as a logical paint so the caret logic stays
+      // coherent — otherwise every non-leading key in a burst would trigger a
+      // spurious synchronous un-hide repaint, defeating the coalescing.
+      const c = new TerminalCompositor({ stdout, stdin, onCancel: vi.fn() });
+      await c.arm();
+      // Second key in the tick is the coalesced case.
+      stdin.emit('keypress', 'a', { name: 'a', sequence: 'a' });
+      const before = c.repaintCount;
+      stdin.emit('keypress', 'b', { name: 'b', sequence: 'b' });
+      // Exactly one logical paint for the coalesced key — no extra un-hide frame.
+      expect(c.repaintCount - before).toBe(1);
+      c.disarm();
+    });
+  });
+
   describe('history navigation', () => {
     function makeHistory(entries: string[]): {
       back(draft: string): string | null;

--- a/src/cli/terminal-compositor.repaint.test.ts
+++ b/src/cli/terminal-compositor.repaint.test.ts
@@ -38,6 +38,11 @@ describe('TerminalCompositor — repaint + commitAbove + anchorRow', () => {
       writes.clear();
       stdin.emit('keypress', 'h', { name: 'h', sequence: 'h' });
       stdin.emit('keypress', 'i', { name: 'i', sequence: 'i' });
+      // Same-tick keystroke repaints coalesce: 'h' paints on the leading edge,
+      // 'i' defers to one trailing microtask paint. Drain it so the assertion
+      // observes the final frame that reflects the full buffer. (See the
+      // same-tick coalescing block in terminal-compositor.keypress.test.ts.)
+      await Promise.resolve();
       expect(writes.all()).toContain('hi');
     });
 

--- a/src/cli/terminal-compositor.reset.ts
+++ b/src/cli/terminal-compositor.reset.ts
@@ -34,6 +34,8 @@ export interface ResetStateHost {
   softStopped: boolean;
   softStopQueueBase: number;
   paused: boolean;
+  pendingTrailingRepaint: boolean;
+  burstActive: boolean;
   activeGhost: string | null;
   anchorRow: number | undefined;
   hasCommitted: boolean;
@@ -67,6 +69,13 @@ export function resetState(self: ResetStateHost): void {
   self.softStopped = false;
   self.softStopQueueBase = 0;
   self.paused = false;
+  // Cancel any pending coalesced keystroke repaint and close the burst window
+  // so a trailing microtask queued in the previous arm cycle cannot paint a
+  // fresh/torn-down frame. disarm() sets armed=false before calling resetState,
+  // so flushPendingRepaint would already short-circuit — clearing the flags
+  // here also keeps a rearm's first keystroke on the leading edge.
+  self.pendingTrailingRepaint = false;
+  self.burstActive = false;
   // Clear active ghost — stale suggestions must not survive a disarm/rearm
   // cycle. The engine itself is NOT disposed here (only in disarm) since
   // resetState() is called by both disarm() AND internal state-resets that

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -301,15 +301,43 @@ export class TerminalCompositor {
    */
   readonly caretBlinkController: CaretBlinkController;
   /**
-   * Monotonic frame counter, bumped once per {@link repaint}. Read by the
+   * Monotonic LOGICAL-paint counter, bumped once per repaint REQUEST — both an
+   * immediate {@link repaint} and a coalesced {@link scheduleRepaint} (whose
+   * physical frame write is deferred to a microtask) increment it. Read by the
    * lifecycle keypress handler (`LifecycleHost.repaintCount`) to tell whether
-   * dispatchKey already painted a frame this keystroke, so the caret-blink
+   * dispatchKey already requested a paint this keystroke, so the caret-blink
    * un-hide repaint is issued only when nothing else painted — avoiding a double
-   * frame on an off-phase keystroke. Plain counter; wraparound is unreachable in
-   * a session (Number.MAX_SAFE_INTEGER frames).
+   * frame on an off-phase keystroke. Counting the coalesced request here (not
+   * just the physical write) is what keeps a deferred edit-paint registering as
+   * "painted" for caret purposes, so a burst's non-leading keys don't each
+   * trigger a spurious synchronous un-hide repaint. Plain counter; wraparound is
+   * unreachable in a session (Number.MAX_SAFE_INTEGER frames).
    * @internal Relaxed from `private` for the lifecycle module (LifecycleHost).
    */
   repaintCount = 0;
+  // Contract (same-tick keystroke repaint coalescing): a synchronous burst of
+  // keypresses (rapid typing in one event-loop tick) must cost 2 physical frame
+  // writes, not one-per-key. The FIRST edit-repaint in a tick paints
+  // synchronously (leading edge — preserves every single-keystroke synchronous
+  // write/getBuffer contract the test suite asserts); subsequent edit-repaints
+  // in the SAME tick set `pendingTrailingRepaint` and coalesce into ONE trailing
+  // paint fired on a queueMicrotask. `burstActive` marks that a microtask window
+  // is open for the current tick; it is reset when that microtask drains. Only
+  // the keystroke edit path (applyEdit → scheduleRepaint) coalesces — every
+  // other caller (spinner tick, setOverlay, commitAbove, resize, mode
+  // transitions, Ctrl+L, dropdown/ghost apply) calls repaint() directly and
+  // stays synchronous. Any direct repaint() clears `pendingTrailingRepaint`
+  // (buffer STATE is always mutated synchronously, so a direct paint of current
+  // state supersedes a pending coalesced one). flushPendingRepaint() is the
+  // synchronous escape hatch lifecycle points call to force the trailing paint
+  // before an await; it is idempotent and a no-op once disarmed, so a stale
+  // pending paint can never fire against a torn-down compositor. Both flags are
+  // cleared by resetState() (disarm/rearm) so a stale burst window never
+  // survives a lifecycle boundary.
+  /** @internal Relaxed from `private` for the lifecycle module (LifecycleHost). */
+  pendingTrailingRepaint = false;
+  /** @internal Relaxed from `private` for the lifecycle module (LifecycleHost). */
+  burstActive = false;
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   committing = false;
   /**
@@ -659,6 +687,12 @@ export class TerminalCompositor {
    * for the full ordered-operation and flush-semantics invariants.
    */
   setInputMode(mode: CompositorInputMode): void {
+    // A mode transition is a lifecycle boundary: the → idle drain hands a
+    // payload to a (potentially reentrant, await-crossing) onSubmit, and turn
+    // arm/teardown callers expect the on-screen frame to be current. Flush any
+    // pending coalesced keystroke paint synchronously first so no deferred
+    // edit-frame is stranded behind the transition. No-op when nothing pends.
+    this.flushPendingRepaint();
     InputMode.setInputMode(this, mode);
   }
 
@@ -720,6 +754,12 @@ export class TerminalCompositor {
   // test suite reaches into it; these delegators forward to the module.
 
   commitAbove(text: string): void {
+    // Materialize any pending coalesced keystroke frame FIRST: commitAbove
+    // clears + re-tracks the live frame region, and the on-screen input line
+    // must reflect the current buffer (not a mid-burst intermediate) before it
+    // is captured/re-pinned. flushPendingRepaint is a no-op when nothing is
+    // pending, so this is free on the common (non-typing) commit path.
+    this.flushPendingRepaint();
     CommittedBand.commitAbove(this, text);
   }
 
@@ -857,6 +897,62 @@ export class TerminalCompositor {
     // Bump BEFORE painting so the lifecycle keypress handler's post-dispatch
     // comparison sees the increment from any repaint dispatchKey triggered.
     this.repaintCount++;
+    // A direct (synchronous) paint always renders CURRENT state, which
+    // supersedes any pending coalesced edit-paint — clear the pending flag so
+    // the trailing microtask does not fire a redundant second frame.
+    this.pendingTrailingRepaint = false;
+    Frame.repaint(this);
+  }
+
+  /**
+   * Coalescing entry point for the per-keystroke edit path (applyEdit). The
+   * FIRST call in an event-loop tick paints synchronously (leading edge);
+   * subsequent calls in the SAME tick defer to ONE trailing paint on a
+   * microtask, so a burst of N keystrokes costs 2 physical frame writes instead
+   * of N. See the Contract on {@link pendingTrailingRepaint}. Every logical
+   * request bumps {@link repaintCount} (caret-blink coherence); only the leading
+   * edge and the single trailing flush perform a physical {@link Frame.repaint}.
+   * @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost).
+   */
+  scheduleRepaint(): void {
+    // Logical paint request — always counted so the caret-blink un-hide check
+    // in the lifecycle keypress handler treats a coalesced paint as "painted".
+    this.repaintCount++;
+    if (!this.burstActive) {
+      // Leading edge: first edit-repaint this tick paints immediately, and we
+      // open a microtask window that will flush any trailing paint at tick end.
+      this.burstActive = true;
+      this.pendingTrailingRepaint = false;
+      Frame.repaint(this);
+      queueMicrotask(() => {
+        this.burstActive = false;
+        this.flushPendingRepaint();
+      });
+      return;
+    }
+    // Subsequent edit-repaint in the same tick: mark dirty; the open microtask
+    // window will paint the final frame once.
+    this.pendingTrailingRepaint = true;
+  }
+
+  /**
+   * Force the pending coalesced trailing repaint to fire NOW, synchronously.
+   * Lifecycle points that must observe a current frame before yielding to an
+   * await (mode transitions, commit, resize, teardown) call this so a deferred
+   * edit-paint is not stranded behind the await. Idempotent (a no-op when
+   * nothing is pending) and disarm-safe (a no-op once torn down), so a stale
+   * pending paint can never render against a disarmed compositor.
+   * @internal Public for the lifecycle/input-mode modules and test casts.
+   */
+  flushPendingRepaint(): void {
+    if (!this.pendingTrailingRepaint) return;
+    this.pendingTrailingRepaint = false;
+    // Disarm-safety: never paint a torn-down compositor. Frame.repaint guards
+    // on `armed` too, but clearing the flag above + this early return make the
+    // cancellation explicit and keep the method a pure no-op post-disarm.
+    if (!this.armed) return;
+    // Physical paint of the already-counted trailing request — do NOT re-bump
+    // repaintCount (the logical request was counted at scheduleRepaint time).
     Frame.repaint(this);
   }
 


### PR DESCRIPTION
## Summary
Coalesces per-keystroke frame repaints in the terminal compositor. Previously every keypress ran a synchronous full-frame `CupFrameRenderer.render()`; a same-tick burst of N keys now costs 2 physical frame writes (leading-edge sync paint + one trailing microtask paint) instead of N, while single keystrokes remain observably synchronous.

## Changes
- `terminal-compositor.ts`: `scheduleRepaint()` / `flushPendingRepaint()` (idempotent, disarm-safe), pending-flag plumbing; flushes at `setInputMode` / `commitAbove` lifecycle boundaries; `repaintCount` stays coherent for caret-blink logic.
- `terminal-compositor.input-dispatch.ts`: `applyEdit` → `scheduleRepaint`; corrected the stale "burst-coalesced internally" comment.
- `terminal-compositor.reset.ts`: pending flags cleared on reset so a stale burst cannot survive disarm/rearm.
- `input/emit-keypress.ts`: comment rewritten to describe present behavior (50ms escapeCodeTimeout; 500ms was Node's overridden default).
- Tests: +7 in `keypress.test.ts` (burst ≤2 paints, final frame = last keystroke, lone-key sync contract, flush idempotence/disarm-safety, repaintCount coherence); minimal microtask-drain updates in `repaint.test.ts` / `dropdown-render.test.ts`.

## Verification
- `pnpm lint` clean.
- Scoped compositor gate green; **full suite in this worktree: 673 test files / 12,284 tests passed**.

## Notes for reviewer
- Spinner/overlay/resize/dropdown paths still call `repaint()` directly (synchronous) — coalescing is scoped to the keystroke edit path only.
- Known cross-PR overlap: `input-dispatch.ts` + `keypress.test.ts` also touched by the ESC-stop-feedback and /editor PRs — trivial rebase for whichever merges later.
