### PR TITLE
feat(cli): show stopping state + queued count on ESC soft-stop

### DIFF
--- a/src/cli/_lib/stream-renderer-lifecycle.test.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.test.ts
@@ -11,6 +11,7 @@ import { formatInterruptAffordance, registerOverlaySlots } from './stream-render
 import { OverlayComposer } from './overlay-composer.js';
 import { ThinkingLane } from '../commands/interactive/thinking-lane.js';
 import { stripAnsi } from '../display.js';
+import type { ProgressEvent } from '../../agent/types.js';
 
 describe('formatInterruptAffordance', () => {
   it('returns an empty string when not interrupting (slot occupies no space)', () => {
@@ -46,6 +47,7 @@ describe('registerOverlaySlots — thinking-live slot', () => {
       toolLane: { hasPending: () => false, getOverlay: () => '' },
       lastProgressByTask: new Map(),
       getInterrupting: () => false,
+      getSoftStopping: () => false,
     } as unknown as Parameters<typeof registerOverlaySlots>[1]);
     return { captured, composer };
   }
@@ -69,6 +71,98 @@ describe('registerOverlaySlots — thinking-live slot', () => {
     thinkingLane.collapse();
     expect(thinkingLane.hasBufferedContent()).toBe(true);
     expect(thinkingLane.isActive()).toBe(false);
+    composer.invalidate();
+    composer.flush();
+    expect(captured.at(-1)).toBe('');
+  });
+});
+
+describe('registerOverlaySlots — progress-banner stopping wiring', () => {
+  // Build a composer whose only active producer is the progress-banner slot.
+  // `getSoftStopping` and the progress map are caller-controlled so we can
+  // assert the slot flips to the stopping banner when the accessor returns true
+  // — this is the wiring seam between the ESC handler and the banner render.
+  function makeComposer(
+    lastProgressByTask: Map<string, ProgressEvent>,
+    getSoftStopping: () => boolean,
+  ): { captured: string[]; composer: OverlayComposer } {
+    const captured: string[] = [];
+    const composer = new OverlayComposer({ setOverlay: (t) => captured.push(t) }, [
+      'thinking-live',
+      'markdown-pending',
+      'tool-lane',
+      'progress-banner',
+      'interrupt',
+    ]);
+    registerOverlaySlots(composer, {
+      stageTracker: undefined,
+      thinkingMode: 'summary',
+      thinkingLane: new ThinkingLane(),
+      streamingMarkdownRef: { current: null },
+      toolLane: { hasPending: () => false, getOverlay: () => '' },
+      lastProgressByTask,
+      getInterrupting: () => false,
+      getSoftStopping,
+    } as unknown as Parameters<typeof registerOverlaySlots>[1]);
+    return { captured, composer };
+  }
+
+  const mkProgress = (): ProgressEvent => ({
+    taskId: 't1',
+    description: 'Tool-use loop',
+    summary: 'round 3: bash ls',
+    lastToolName: 'Bash',
+    totalTokens: 1200,
+    toolUses: 5,
+    durationMs: 4500,
+  });
+
+  it('does NOT show the stopping indicator during normal streaming', () => {
+    const progress = new Map([['t1', mkProgress()]]);
+    const { captured, composer } = makeComposer(progress, () => false);
+    composer.invalidate();
+    composer.flush();
+    const overlay = stripAnsi(captured.at(-1) ?? '');
+    expect(overlay).toContain('Tool-use loop');
+    expect(overlay).not.toContain('stopping…');
+    // Normal streaming keeps the tool clause (the "what it's doing" signal).
+    // NB: the composed overlay is clamped to the test terminal width, so the
+    // trailing `esc to interrupt` hint can be truncated — the full-width hint
+    // contract lives in progress-banner.test.ts. Here we assert the negative
+    // (no stopping clause) plus that the live activity/tool clause survives.
+    expect(overlay).toContain('via');
+  });
+
+  it('flips the banner to the stopping state when getSoftStopping() is true', () => {
+    const progress = new Map([['t1', mkProgress()]]);
+    let stopping = false;
+    const { captured, composer } = makeComposer(progress, () => stopping);
+
+    composer.invalidate();
+    composer.flush();
+    expect(stripAnsi(captured.at(-1) ?? '')).not.toContain('stopping…');
+
+    // ESC handled → the accessor now reports stopping. Next recompose paints it.
+    stopping = true;
+    composer.markDirty('progress-banner');
+    composer.flush();
+    const overlay = stripAnsi(captured.at(-1) ?? '');
+    expect(overlay).toContain('stopping…');
+    // The stale tool/activity clause is replaced by the stopping indicator.
+    expect(overlay).not.toContain('round 3: bash ls');
+  });
+
+  it('synthesizes a stopping banner even when no progress event is live (text-only turn)', () => {
+    // A text-only turn never emits a `progress` event, so lastProgressByTask is
+    // empty — but ESC must still give visible feedback.
+    const { captured, composer } = makeComposer(new Map(), () => true);
+    composer.invalidate();
+    composer.flush();
+    expect(stripAnsi(captured.at(-1) ?? '')).toContain('stopping…');
+  });
+
+  it('renders no banner at all when idle (no progress, not stopping)', () => {
+    const { captured, composer } = makeComposer(new Map(), () => false);
     composer.invalidate();
     composer.flush();
     expect(captured.at(-1)).toBe('');

--- a/src/cli/_lib/stream-renderer-lifecycle.ts
+++ b/src/cli/_lib/stream-renderer-lifecycle.ts
@@ -70,6 +70,14 @@ export function registerOverlaySlots(
   ctx: Readonly<Pick<LifecycleContext, 'stageTracker' | 'thinkingMode' | 'thinkingLane' | 'streamingMarkdownRef' | 'toolLane' | 'lastProgressByTask'>> & {
     /** Live interrupt state — true while a Ctrl+C interrupt is being processed. */
     getInterrupting: () => boolean;
+    /**
+     * Live soft-stop state — true once ESC has requested a soft-stop but the
+     * turn has not finished tearing down. Reads the StreamRenderer's
+     * `softStopping` flag (mirrors {@link getInterrupting}); drives the progress
+     * banner's `stopping…` swap so ESC gives visible feedback on the next
+     * repaint. See stream-renderer's `setSoftStopping`.
+     */
+    getSoftStopping: () => boolean;
   },
 ): void {
   // Register overlay slots (thinking-live, markdown-pending, tool-lane,
@@ -123,13 +131,29 @@ export function registerOverlaySlots(
     key: 'progress-banner',
     render: () => {
       const bannerLines: string[] = [];
+      const stopping = ctx.getSoftStopping();
       // Grounded activity: the model's in-flight thinking clause (current
       // uncommitted phase only — peekPhase clears at each seal boundary, so
       // a stale clause never outlives the phase that produced it). Falls
       // back to the event's tool-derived summary inside formatProgressBanner.
       const activity = deriveProgressActivity(ctx.thinkingLane.peekPhase());
       for (const progress of ctx.lastProgressByTask.values()) {
-        bannerLines.push(...formatProgressBanner(progress, undefined, activity));
+        bannerLines.push(...formatProgressBanner(progress, undefined, activity, stopping));
+      }
+      // ESC soft-stop must give visible feedback even on a text-only turn that
+      // never emitted a `progress` event (lastProgressByTask empty). Synthesize
+      // a minimal banner so the `stopping…` state always paints; the synthetic
+      // event carries no stats, so formatProgressBanner renders just the glyph +
+      // description + stopping clause.
+      if (stopping && bannerLines.length === 0) {
+        bannerLines.push(
+          ...formatProgressBanner(
+            { taskId: '__soft_stop__', description: 'Turn', totalTokens: 0, toolUses: 0, durationMs: 0 },
+            undefined,
+            undefined,
+            true,
+          ),
+        );
       }
       return bannerLines.length > 0 ? bannerLines.join('\n') : '';
     },

--- a/src/cli/_lib/stream-renderer-subagent-paragraph.test.ts
+++ b/src/cli/_lib/stream-renderer-subagent-paragraph.test.ts
@@ -101,6 +101,7 @@ function setup() {
     toolLane,
     lastProgressByTask: new Map(),
     getInterrupting: () => false,
+    getSoftStopping: () => false,
   });
 
   // Build a minimal OrchestratorCtx so subagent handlers can call

--- a/src/cli/_lib/stream-renderer.test.ts
+++ b/src/cli/_lib/stream-renderer.test.ts
@@ -1963,6 +1963,26 @@ describe('StreamRenderer — setInterrupting', () => {
   });
 });
 
+describe('StreamRenderer — dispose() resets softStopping', () => {
+  // Regression for the Codex review comment on stream-renderer-lifecycle.ts:155
+  // (PR #646, dispose()/soft-stop interaction). Root cause: dispose() cleared
+  // lastProgressByTask but left softStopping untouched, so a borrowed-
+  // compositor's post-dispose overlay flush (which recomposes with
+  // lastProgressByTask now empty) still saw getSoftStopping() === true and hit
+  // the 'progress-banner' slot's synthetic fallback — repainting a fresh
+  // `Turn / stopping…` banner into what should be a cleared idle frame.
+  type PrivateRenderer = { softStopping: boolean };
+
+  it('resets the softStopping flag during dispose() so a late ESC cannot leak into the idle frame', async () => {
+    const { writer } = makeWriter();
+    const r = new StreamRenderer({ out: writer, forceNonTty: true });
+    r.setSoftStopping(true);
+    expect((r as unknown as PrivateRenderer).softStopping).toBe(true);
+    await r.dispose();
+    expect((r as unknown as PrivateRenderer).softStopping).toBe(false);
+  });
+});
+
 describe('StreamRenderer — AFK_PLAIN_OUTPUT full render opt-out (Lever 2)', () => {
   // Regression for the "--plain doesn't suppress the mid-turn overlay" bug.
   // Root cause: AFK_PLAIN_OUTPUT was only read by createReplRenderer()

--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -756,6 +756,17 @@ export class StreamRenderer {
     // overlay flushes below never repaint a stale progress banner.
     this.lastProgressByTask.clear();
 
+    // Reset the soft-stop flag too — without this, an ESC that landed just
+    // before dispose() leaves `softStopping=true` past teardown. The
+    // borrowed-compositor path below invalidates + flushes the overlay
+    // composer to clear the live frame; with lastProgressByTask now empty but
+    // getSoftStopping() still true, the 'progress-banner' slot's synthetic
+    // fallback (stream-renderer-lifecycle.ts) recreates a `Turn / stopping…`
+    // banner instead of contributing '' — painting a stale banner into the
+    // idle prompt until the next unrelated repaint overwrites it. Clearing
+    // here BEFORE that flush guarantees the slot renders empty.
+    this.softStopping = false;
+
     // CommitCoordinator.flushAll() is the single async owner at turn end.
     // It drains all scheduled commit batches in fixed anchor order:
     //   1. before-content (orchestrator tool-lane entries that precede prose)

--- a/src/cli/_lib/stream-renderer.ts
+++ b/src/cli/_lib/stream-renderer.ts
@@ -241,6 +241,9 @@ export class StreamRenderer {
   /** Live interrupt state — flipped by {@link setInterrupting} on Ctrl+C. */
   private interrupting = false;
 
+  /** Live soft-stop state — flipped by {@link setSoftStopping} on ESC. */
+  private softStopping = false;
+
   /**
    * Single ordering authority for all scrollback writes during this turn.
    * Constructed fresh per-StreamRenderer-instance (= per-turn). Drains via
@@ -460,6 +463,7 @@ export class StreamRenderer {
       toolLane: this.toolLane,
       lastProgressByTask: this.lastProgressByTask,
       getInterrupting: () => this.interrupting,
+      getSoftStopping: () => this.softStopping,
     });
 
     // Reduced-motion suppresses the spinner ticker at the source. State-transition
@@ -500,6 +504,29 @@ export class StreamRenderer {
     this.interrupting = active;
     if (this.overlayComposer) {
       this.overlayComposer.markDirty('interrupt');
+      this.overlayComposer.flush();
+    }
+  }
+
+  /**
+   * Flip the live "stopping…" progress-banner state. Called from the REPL's
+   * ESC soft-stop handler (turn-handler.ts) the instant ESC is handled, so the
+   * banner shows the stop was accepted on the NEXT repaint — before the turn
+   * finishes tearing down (which can take seconds while subagents cancel).
+   *
+   * Invariant: the OverlayComposer is the single overlay owner — this flips the
+   * renderer's `softStopping` flag (read by the 'progress-banner' slot's
+   * render() via the `getSoftStopping` accessor) and triggers exactly one
+   * composed flush rather than writing the compositor overlay directly (the
+   * corruption-fix contract). Order: mutate state, THEN recompose. Mirrors
+   * {@link setInterrupting} — the Ctrl+C affordance's sibling. A no-op after
+   * dispose so a late ESC that lands during teardown can't touch a torn frame.
+   */
+  setSoftStopping(active: boolean): void {
+    if (this.disposed) return;
+    this.softStopping = active;
+    if (this.overlayComposer) {
+      this.overlayComposer.markDirty('progress-banner');
       this.overlayComposer.flush();
     }
   }

--- a/src/cli/commands/interactive/progress-banner.test.ts
+++ b/src/cli/commands/interactive/progress-banner.test.ts
@@ -114,6 +114,79 @@ describe('progress-banner — terminal width clamping', () => {
     });
   });
 
+  // Regression: ESC soft-stop must give immediate visible feedback. When the
+  // banner is asked to render in the stopping state (soft-stop requested but the
+  // turn hasn't finished tearing down), it must swap to a clear "stopping…"
+  // indicator and drop the now-misleading "esc to interrupt" hint — the
+  // interrupt has already been accepted. Normal streaming must be untouched.
+  describe('formatProgressBanner — stopping state', () => {
+    it('shows a "stopping…" indicator when the stopping flag is set', () => {
+      const lines = formatProgressBanner(
+        mkEvent({ description: 'Tool-use loop', summary: 'round 3: bash ls', lastToolName: 'Bash', toolUses: 5 }),
+        Infinity,
+        undefined,
+        true,
+      );
+      const joined = stripAnsi(lines.join('\n'));
+      expect(joined).toContain('stopping…');
+    });
+
+    it('drops the "esc to interrupt" hint in the stopping state (interrupt already accepted)', () => {
+      const lines = formatProgressBanner(
+        mkEvent({ description: 'Tool-use loop', lastToolName: 'Bash', toolUses: 5 }),
+        Infinity,
+        undefined,
+        true,
+      );
+      const joined = stripAnsi(lines.join('\n'));
+      expect(joined).not.toContain('esc to interrupt');
+    });
+
+    it('replaces the activity/summary clause with "stopping…" (does not show the stale tool clause)', () => {
+      const lines = formatProgressBanner(
+        mkEvent({ description: 'Tool-use loop', summary: 'round 3: bash ls' }),
+        Infinity,
+        'Now checking the config loader',
+        true,
+      );
+      const joined = stripAnsi(lines.join('\n'));
+      expect(joined).toContain('stopping…');
+      // The in-flight activity clause and tool summary are the "what it WAS
+      // doing" signal — suppressed once the user has asked it to stop.
+      expect(joined).not.toContain('Now checking the config loader');
+      expect(joined).not.toContain('round 3: bash ls');
+    });
+
+    it('does NOT show the stopping indicator during normal streaming (flag unset)', () => {
+      const lines = formatProgressBanner(
+        mkEvent({ description: 'Tool-use loop', summary: 'round 3: bash ls', lastToolName: 'Bash', toolUses: 5 }),
+        Infinity,
+      );
+      const joined = stripAnsi(lines.join('\n'));
+      expect(joined).not.toContain('stopping…');
+      // Normal streaming keeps the interrupt hint.
+      expect(joined).toContain('esc to interrupt · ctrl+b background');
+    });
+
+    it('does NOT show the stopping indicator when the flag is explicitly false', () => {
+      const lines = formatProgressBanner(
+        mkEvent({ description: 'Tool-use loop', lastToolName: 'Bash' }),
+        Infinity,
+        undefined,
+        false,
+      );
+      expect(stripAnsi(lines.join('\n'))).not.toContain('stopping…');
+    });
+
+    it('clamps the stopping banner to the provided column width', () => {
+      const cols = 40;
+      const lines = formatProgressBanner(mkEvent({ description: LONG }), cols, undefined, true);
+      for (const line of lines) {
+        expect(displayWidth(stripAnsi(line))).toBeLessThanOrEqual(cols);
+      }
+    });
+  });
+
   describe('formatProgressBanner — sanitization (LLM-sourced fields)', () => {
     it('strips ANSI escapes injected via description', () => {
       const lines = formatProgressBanner(

--- a/src/cli/commands/interactive/progress-banner.ts
+++ b/src/cli/commands/interactive/progress-banner.ts
@@ -100,11 +100,27 @@ export function formatRateLimitActivity(retryAfterMs?: number): string {
  * Each returned line is clamped to the terminal width (or `columns` when
  * provided) so long descriptions and summaries never wrap onto a second row
  * and corrupt multi-line REPL layout.
+ *
+ * Contract (stopping state): when `stopping` is true the user has pressed ESC
+ * to soft-stop the turn and the teardown is still in flight (which can take
+ * seconds while subagents cancel). The banner then swaps its glyph to `◌` and
+ * replaces the per-tick detail — the model's in-flight activity clause and the
+ * tool-derived summary, i.e. the "what it WAS doing" signal — with a
+ * `stopping…` clause rendered in the warning tone, and DROPS the
+ * `esc to interrupt` hint (the interrupt has already been accepted; re-offering
+ * it is misleading). The stats tail (tokens/tools/duration) is preserved so
+ * the frozen progress numbers stay visible while the turn winds down. `stopping`
+ * is a pure render input — the caller (the progress-banner overlay slot) reads
+ * the StreamRenderer's live `softStopping` flag (set by `setSoftStopping` from
+ * the ESC handler) and passes it through, so the flip lands on the first
+ * repaint after the ESC keypress. See stream-renderer's `setSoftStopping` and
+ * the soft-stop handler in turn-handler.ts.
  */
 export function formatProgressBanner(
   event: ProgressEvent,
   columns?: number,
   activity?: string,
+  stopping?: boolean,
 ): string[] {
   const { description, summary, lastToolName, totalTokens, toolUses, durationMs } = event;
   const stats: string[] = [];
@@ -116,21 +132,30 @@ export function formatProgressBanner(
   if (toolUses) stats.push(formatToolCallStat(toolUses));
   if (totalTokens) stats.push(`${formatTokens(totalTokens)} tok`);
   if (durationMs) stats.push(formatDuration(durationMs));
-  stats.push('esc to interrupt · ctrl+b background');
+  // Drop the interrupt hint once a stop is already in flight — the ESC has been
+  // accepted, so "esc to interrupt" would misrepresent the current state.
+  if (!stopping) stats.push('esc to interrupt · ctrl+b background');
 
   const statsStr = stats.length > 0 ? ` (${stats.join(' · ')})` : '';
 
+  const glyph = stopping ? '◌' : '◦';
   const cleanDescription = sanitizeLabel(description);
-  const detailRaw = activity?.trim() ? activity : summary;
-  const detail = detailRaw ? sanitizeLabel(detailRaw) : '';
+  // In the stopping state the detail clause becomes the stop indicator (warning
+  // tone), overriding whatever activity/summary the turn was last showing.
+  const detail = stopping
+    ? palette.warning('stopping…')
+    : (() => {
+        const detailRaw = activity?.trim() ? activity : summary;
+        return detailRaw ? sanitizeLabel(detailRaw) : '';
+      })();
 
   if (detail) {
     return [
-      clampToTerminal(palette.dim(`  ◦ ${cleanDescription}`), columns),
+      clampToTerminal(palette.dim(`  ${glyph} ${cleanDescription}`), columns),
       clampToTerminal(palette.dim(`    ${detail}${statsStr}`), columns),
     ];
   }
-  return [clampToTerminal(palette.dim(`  ◦ ${cleanDescription}${statsStr}`), columns)];
+  return [clampToTerminal(palette.dim(`  ${glyph} ${cleanDescription}${statsStr}`), columns)];
 }
 
 /**

--- a/src/cli/commands/interactive/turn-handler.test.ts
+++ b/src/cli/commands/interactive/turn-handler.test.ts
@@ -1675,6 +1675,98 @@ describe('runTurn — ESC soft-stop', () => {
     expect(setInFlight).toHaveBeenCalledWith(false);
     expect(session.interrupt).not.toHaveBeenCalled();
   });
+
+  // ---------------------------------------------------------------------------
+  // Queued-count in the stop notice
+  // ---------------------------------------------------------------------------
+  //
+  // Spec: the ESC soft-stop preserves Enter-committed type-ahead messages. The
+  // teardown notice must surface how many are queued so the user knows work is
+  // waiting. Count comes from the persistent (borrowed) compositor's
+  // getPendingCount(); the notice reads `⏸ Stopped · N queued …`. Zero pending
+  // omits the suffix.
+  // ---------------------------------------------------------------------------
+
+  /** Stub compositor exposing a fixed pending count for the notice path. */
+  function makeStubCompositorWithPending(pending: number) {
+    return {
+      isArmed: () => true,
+      commitAbove: vi.fn(),
+      getPendingCount: () => pending,
+      setInputMode: vi.fn(),
+      setSpinner: vi.fn(),
+      setOverlay: vi.fn(),
+    };
+  }
+
+  /**
+   * Run a soft-stopped turn with a borrowed compositor reporting `pending`
+   * queued submissions, capturing the completionWriter output. Fires ESC after
+   * the first stream event (before done) via the installed soft-stop handler.
+   */
+  async function runSoftStoppedTurnCapturing(pending: number): Promise<string[]> {
+    const events: OutputEvent[] = [
+      { type: 'chunk', chunk: { type: 'content', content: 'partial' } },
+      { type: 'done', metadata: { durationMs: 5 } },
+    ];
+    const session = streamFrom(events);
+
+    let installedHandler: (() => void) | null = null;
+    const setSoftStopHandler = vi.fn((hh: (() => void) | null) => {
+      if (hh !== null) installedHandler = hh;
+    });
+
+    let callCount = 0;
+    const realStream = session.sendMessageStream;
+    session.sendMessageStream = async function* (payload: unknown) {
+      for await (const event of (realStream as typeof session.sendMessageStream).call(session, payload)) {
+        yield event;
+        callCount++;
+        if (callCount === 1 && installedHandler) installedHandler();
+      }
+    };
+
+    const writerCalls: string[] = [];
+    const completionWriter = { fn: (line: string) => { writerCalls.push(line); } };
+    const { h } = makeHandles();
+    const handles: TurnHandles = {
+      ...h,
+      setSoftStopHandler,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getCompositor: () => makeStubCompositorWithPending(pending) as any,
+    };
+
+    await runTurn(
+      { text: 'q', attachments: [] },
+      session,
+      makeStats(),
+      handles,
+      'summary',
+      completionWriter,
+    );
+    return writerCalls;
+  }
+
+  it("stop notice includes '1 queued' when a single submission is pending", async () => {
+    const writerCalls = await runSoftStoppedTurnCapturing(1);
+    const notice = writerCalls.find((l) => l.includes('Stopped'));
+    expect(notice).toBeDefined();
+    expect(notice).toContain('1 queued');
+  });
+
+  it("stop notice includes 'N queued' when multiple submissions are pending", async () => {
+    const writerCalls = await runSoftStoppedTurnCapturing(3);
+    const notice = writerCalls.find((l) => l.includes('Stopped'));
+    expect(notice).toBeDefined();
+    expect(notice).toContain('3 queued');
+  });
+
+  it('stop notice OMITS the queued suffix when nothing is pending', async () => {
+    const writerCalls = await runSoftStoppedTurnCapturing(0);
+    const notice = writerCalls.find((l) => l.includes('Stopped'));
+    expect(notice).toBeDefined();
+    expect(notice).not.toContain('queued');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/cli/commands/interactive/turn-handler.ts
+++ b/src/cli/commands/interactive/turn-handler.ts
@@ -259,6 +259,14 @@ export async function runTurn(
     if (h.setSoftStopHandler) {
       h.setSoftStopHandler(() => {
         softStopRequested = true;
+        // Immediate visible feedback: flip the live progress banner to its
+        // "stopping…" state on the SAME frame this handler runs, so the user
+        // sees the ESC was accepted before teardown completes (which can take
+        // seconds while subagents cancel). setSoftStopping recomposes the
+        // overlay once (mirrors the Ctrl+C setInterrupting affordance). The
+        // closure dereferences `renderer` so it targets the live renderer even
+        // after a paused→resumed hot-swap; a no-op if the renderer is disposed.
+        renderer.setSoftStopping(true);
         // Fire interrupt() synchronously on ESC instead of waiting for the
         // for-await loop below to observe `softStopRequested`. During a long
         // tool call the loop is blocked awaiting the stream's next event, so a
@@ -654,11 +662,21 @@ export async function runTurn(
     // same session.")
     if (softStopRequested) {
       const write = completionWriter ? completionWriter.fn : console.log;
+      // Surface how many type-ahead messages are still queued (Enter-committed
+      // pendingSubmissions preserved across the soft-stop per the ESC contract).
+      // The authoritative count is the persistent compositor's getPendingCount()
+      // — `borrowedCompositor` is the same instance the input dispatcher queues
+      // into; null on non-TTY surfaces, where there's no input row to type-ahead
+      // into, so the suffix is simply omitted. Singular/plural handled.
+      const queuedCount = borrowedCompositor ? borrowedCompositor.getPendingCount() : 0;
+      const queuedSuffix = queuedCount > 0
+        ? ` · ${queuedCount} queued`
+        : '';
       // Invariant (TUI rhythm contract): the soft-stop notice owns ONE
       // trailing blank line. The predecessor (last committed paragraph
       // or tool block) already emitted its own trailing blank, so a
       // leading blank here would double-up. See docs/tui-rhythm.md.
-      write(palette.warning('⏸ Stopped — work so far kept.') +
+      write(palette.warning(`⏸ Stopped${queuedSuffix} — work so far kept.`) +
         palette.dim('  Send a message to continue.'));
       write('');
     }


### PR DESCRIPTION
## Summary
ESC soft-stop during a streaming turn previously produced no visible feedback until teardown finished (seconds when subagents cancel) — the top complaint behind "ESC feels laggy." The progress banner now flips to a `stopping…` state on the same frame ESC is handled, and the final stop notice surfaces the preserved type-ahead queue count.

## Changes
- `progress-banner.ts`: `stopping` state — glyph swap, `stopping…` clause (palette.warning), drops the now-moot `esc to interrupt` hint; stats tail preserved.
- `stream-renderer.ts` / `stream-renderer-lifecycle.ts`: `setSoftStopping()` mirroring the existing Ctrl+C `setInterrupting` affordance (flag → markDirty → flush); banner slot reads it; synthesizes a minimal banner when no progress event exists yet (text-only turns still get feedback).
- `turn-handler.ts`: ESC handler calls `renderer.setSoftStopping(true)` synchronously; teardown notice becomes `⏸ Stopped · N queued — work so far kept.` via `compositor.getPendingCount()` (omitted at zero).
- Ctrl+C, Ctrl+B, queue-drain semantics, and handleEscape's dropdown/idle branches untouched.

## Verification
- `pnpm lint` clean; gate green: progress-banner (43), interactive-progress-banner (12), queue (5), turn-handler (58), stream-renderer-lifecycle (7) — independently re-run by the orchestrator: 118 passed.

## Notes for reviewer
- `softStopping` is never reset within a renderer instance — relies on the per-turn fresh `StreamRenderer`; the paused→resumed hot-swap builds a fresh renderer.
- Legacy `setComposedOverlay` fallback (no OverlayComposer) doesn't show the stopping state — unreachable in the TTY REPL.
- Known cross-PR overlap: `turn-handler.ts` also touched (adjacent block) by the title/notify PR.
