### PR TITLE
perf(cli): async at-file autocomplete scan with per-dir cache + stale guard

### DIFF
--- a/src/cli/input/trigger.test.ts
+++ b/src/cli/input/trigger.test.ts
@@ -12,11 +12,22 @@
  * to 12, so a cwd with >12 entries silently hid the rest.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync, existsSync, promises as fsp } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { detectTrigger, filterFileCandidates, filterSlashCandidates } from './trigger.js';
+import {
+  detectTrigger,
+  filterFileCandidates,
+  filterFileCandidatesAsync,
+  filterFileCandidatesCached,
+  filterSlashCandidates,
+  buildFileCandidates,
+  invalidateFileScanCache,
+  __fileScanCacheSize,
+  FILE_SCAN_TTL_MS,
+  type FileDirent,
+} from './trigger.js';
 import { MAX_FILE_MATCHES } from '../multi-line-reader.js';
 import { resetRegistry } from '../slash/registry.js';
 import { registerAll } from '../slash/index.js';
@@ -30,13 +41,21 @@ beforeEach(() => {
   writeFileSync(join(tmpRoot, 'beta.ts'), 'b');
   mkdirSync(join(tmpRoot, 'src'));
   writeFileSync(join(tmpRoot, 'src', 'index.ts'), 'c');
+  invalidateFileScanCache();
   resetRegistry();
   registerAll();
 });
 
 afterEach(() => {
+  invalidateFileScanCache();
+  vi.restoreAllMocks();
   if (existsSync(tmpRoot)) rmSync(tmpRoot, { recursive: true, force: true });
 });
+
+/** Build a plain FileDirent for pure-core tests (no fs). */
+function dirent(name: string, isDir = false): FileDirent {
+  return { name, isDirectory: () => isDir };
+}
 
 describe('detectTrigger — @ file paths', () => {
   it('fires for @~/ (tilde), passing the ~/ query through unchanged', () => {
@@ -156,5 +175,124 @@ describe('filterSlashCandidates', () => {
     const vals = filterSlashCandidates('').map((c) => c.value);
     expect(vals.length).toBeGreaterThan(0);
     expect(vals).toContain('/config');
+  });
+});
+
+describe('buildFileCandidates — pure core (no I/O)', () => {
+  it('filters by leaf prefix, keeps the @ prefix, and sorts', () => {
+    const entries = [dirent('beta.ts'), dirent('alpha.txt'), dirent('gamma.md')];
+    const vals = buildFileCandidates(entries, 'al', tmpRoot).map((c) => c.value);
+    expect(vals).toEqual(['@alpha.txt']);
+  });
+
+  it('appends a trailing slash for directory Dirents (from isDirectory), no statSync', () => {
+    const entries = [dirent('src', true), dirent('readme.md')];
+    const vals = buildFileCandidates(entries, '', tmpRoot).map((c) => c.value);
+    expect(vals).toContain('@src/');
+    expect(vals).toContain('@readme.md');
+  });
+
+  it('hides dotfiles unless the leaf prefix itself starts with a dot', () => {
+    const entries = [dirent('.hidden'), dirent('visible.ts')];
+    expect(buildFileCandidates(entries, '', tmpRoot).map((c) => c.value)).toEqual(['@visible.ts']);
+    expect(buildFileCandidates(entries, '.h', tmpRoot).map((c) => c.value)).toEqual(['@.hidden']);
+  });
+
+  it('is bounded by MAX_FILE_MATCHES (single upstream cap, applied after sort)', () => {
+    const entries: FileDirent[] = [];
+    for (let i = 0; i < MAX_FILE_MATCHES + 10; i++) {
+      entries.push(dirent(`f${String(i).padStart(3, '0')}.txt`));
+    }
+    expect(buildFileCandidates(entries, 'f', tmpRoot)).toHaveLength(MAX_FILE_MATCHES);
+  });
+});
+
+describe('filterFileCandidatesAsync', () => {
+  it('resolves candidates from a fresh directory scan', async () => {
+    const vals = (await filterFileCandidatesAsync('al', tmpRoot)).map((c) => c.value);
+    expect(vals).toContain('@alpha.txt');
+  });
+
+  it('directory entries get a trailing slash (Dirent-derived, no statSync)', async () => {
+    const vals = (await filterFileCandidatesAsync('sr', tmpRoot)).map((c) => c.value);
+    expect(vals).toContain('@src/');
+  });
+
+  it('fs error → empty candidates, promise does NOT reject', async () => {
+    await expect(filterFileCandidatesAsync('/no/such/dir/x', '/nonexistent-cwd')).resolves.toEqual([]);
+  });
+
+  it('caches the listing: a second query against the same dir within TTL does NOT re-read fs', async () => {
+    const spy = vi.spyOn(fsp, 'readdir');
+    // First scan populates the cache (one readdir).
+    await filterFileCandidatesAsync('al', tmpRoot);
+    expect(spy).toHaveBeenCalledTimes(1);
+    // Second scan of the SAME scanDir (different leaf prefix) is served from
+    // cache — no additional readdir.
+    const vals = (await filterFileCandidatesAsync('be', tmpRoot)).map((c) => c.value);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(vals).toContain('@beta.ts');
+  });
+
+  it('re-reads fs once the cached entry is older than the TTL', async () => {
+    const spy = vi.spyOn(fsp, 'readdir');
+    const now = 1_000_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+    await filterFileCandidatesAsync('al', tmpRoot);
+    expect(spy).toHaveBeenCalledTimes(1);
+    // Advance past the TTL — the cached entry is now stale and must be re-read.
+    nowSpy.mockReturnValue(now + FILE_SCAN_TTL_MS + 1);
+    await filterFileCandidatesAsync('al', tmpRoot);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('filterFileCandidatesCached — synchronous cache lookup', () => {
+  it('returns null on a cold cache (miss) without reading fs', () => {
+    const spy = vi.spyOn(fsp, 'readdir');
+    expect(filterFileCandidatesCached('al', tmpRoot)).toBeNull();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('returns candidates synchronously after the dir has been scanned (hit)', async () => {
+    await filterFileCandidatesAsync('al', tmpRoot);
+    const cached = filterFileCandidatesCached('be', tmpRoot);
+    expect(cached).not.toBeNull();
+    expect(cached!.map((c) => c.value)).toContain('@beta.ts');
+  });
+
+  it('returns null once the cached entry has expired (TTL)', async () => {
+    const now = 2_000_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+    await filterFileCandidatesAsync('al', tmpRoot);
+    expect(filterFileCandidatesCached('al', tmpRoot)).not.toBeNull();
+    nowSpy.mockReturnValue(now + FILE_SCAN_TTL_MS + 1);
+    expect(filterFileCandidatesCached('al', tmpRoot)).toBeNull();
+  });
+});
+
+describe('invalidateFileScanCache', () => {
+  it('clears cached listings so the next scan re-reads fs', async () => {
+    const spy = vi.spyOn(fsp, 'readdir');
+    await filterFileCandidatesAsync('al', tmpRoot);
+    expect(__fileScanCacheSize()).toBe(1);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    invalidateFileScanCache();
+    expect(__fileScanCacheSize()).toBe(0);
+
+    await filterFileCandidatesAsync('al', tmpRoot);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('filterFileCandidates — sync path warms the shared cache', () => {
+  it('a sync scan populates the cache so a later async lookup is a hit', async () => {
+    filterFileCandidates('al', tmpRoot);
+    const spy = vi.spyOn(fsp, 'readdir');
+    // Async lookup for the same dir now hits the cache the sync call warmed.
+    const vals = (await filterFileCandidatesAsync('be', tmpRoot)).map((c) => c.value);
+    expect(spy).not.toHaveBeenCalled();
+    expect(vals).toContain('@beta.ts');
   });
 });

--- a/src/cli/input/trigger.ts
+++ b/src/cli/input/trigger.ts
@@ -6,8 +6,7 @@
  * pop the dropdown and which entries to show.
  */
 
-import { readdirSync, statSync } from 'fs';
-import { join } from 'path';
+import { readdirSync, promises as fsp, type Dirent } from 'fs';
 import { list as listSlashCommands, aliasEntries } from '../slash/registry.js';
 import { resolveQuery, MAX_FILE_MATCHES } from '../multi-line-reader.js';
 import type { Candidate, Trigger } from './types.js';
@@ -130,45 +129,178 @@ export function filterSlashCandidates(query: string): Candidate[] {
 }
 
 /**
- * Filter @-file candidates. Values are returned with the leading `@`
- * preserved (e.g. `@src/index.ts`), mirroring how slash candidates keep
- * their `/` prefix. The dropdown then reads as a unified menu of
- * trigger-shaped tokens, and `applySelection` — which replaces the
- * trailing non-whitespace run (the `@token`) with the candidate's value —
- * lines up byte-for-byte with what the user typed.
+ * Contract: minimal Dirent slice the file-candidate core reads. A real
+ * `fs.Dirent` (from `readdir(dir, { withFileTypes: true })`) satisfies this
+ * structurally, and tests can supply plain objects without stubbing the
+ * whole class. Only `name` and `isDirectory()` are ever consulted.
+ */
+export interface FileDirent {
+  name: string;
+  isDirectory(): boolean;
+}
+
+/**
+ * Contract: one entry in the per-directory scan cache. `entries` is the raw
+ * directory listing (unfiltered, unsorted); `at` is the epoch-ms timestamp the
+ * scan resolved, used to expire the entry after {@link FILE_SCAN_TTL_MS}.
+ */
+interface ScanCacheEntry {
+  entries: FileDirent[];
+  at: number;
+}
+
+/**
+ * Invariant: the directory-scan cache is the ONLY place fs results are
+ * retained between keystrokes. Keyed by absolute `scanDir`, it lets the common
+ * "user types another char in the same directory" path serve candidates
+ * synchronously (see {@link filterFileCandidatesCached}) instead of hitting the
+ * filesystem on every keypress. Entries older than the TTL are treated as
+ * absent and re-scanned; `invalidateFileScanCache()` clears it wholesale when
+ * the dropdown is dismissed or a prompt is submitted, so a directory mutated
+ * between prompts is never served stale.
  *
- * `resolveQuery` (shared with the multi-line reader's tab-completer) routes
- * the query into one of three scan modes — tilde (`~/`), absolute (`/`), or
- * relative — and yields the `displayPrefix` so a `@~/foo` candidate stays
- * `@~/foo` rather than expanding to the absolute home path. `homeDir` is
- * injectable for test isolation; production lets it default to `os.homedir()`.
+ * History: replaced the previous synchronous `readdirSync` + per-entry
+ * `statSync` that ran inline on the compositor keystroke path and blocked the
+ * input thread on large / slow (network) directories.
+ */
+const scanCache = new Map<string, ScanCacheEntry>();
+
+/** Cache TTL: how long a directory listing may be served without re-reading. */
+export const FILE_SCAN_TTL_MS = 2000;
+
+/**
+ * Clear the directory-scan cache. Call when the dropdown is dismissed or a
+ * prompt is submitted so a directory mutated between prompts is re-read fresh
+ * on the next scan (belt-and-suspenders alongside the TTL).
+ */
+export function invalidateFileScanCache(): void {
+  scanCache.clear();
+}
+
+/** Test-only: current number of cached directory listings. */
+export function __fileScanCacheSize(): number {
+  return scanCache.size;
+}
+
+/**
+ * Pure core: turn a raw directory listing into ranked `@`-file candidates for
+ * `query`. No I/O — the caller supplies `entries` (from the cache or a fresh
+ * scan) so this stays trivially testable and identical across the sync and
+ * async entry points.
+ *
+ * Values keep the leading `@` (e.g. `@src/index.ts`), mirroring how slash
+ * candidates keep their `/` prefix, so `applySelection` — which replaces the
+ * trailing non-whitespace run (the `@token`) with the candidate's value —
+ * lines up byte-for-byte with what the user typed. `resolveQuery` yields the
+ * `displayPrefix` so a `@~/foo` candidate stays `@~/foo` rather than expanding
+ * to the absolute home path.
+ *
+ * Invariant: cap is MAX_FILE_MATCHES from the shared upstream source. Do NOT
+ * re-cap to a smaller number here — a secondary cap silently hides entries
+ * beyond it even when the dropdown scrolls. filter → sort → cap → decorate
+ * matches the fileMatchesFor ordering contract.
+ *
+ * Directory flag is derived from the Dirent (`isDirectory()`), NOT a follow-up
+ * `statSync`. Tradeoff: a symlink that points at a directory reports as a
+ * symlink (not a directory) and therefore loses its trailing `/`. That is an
+ * accepted cosmetic loss — dropping the per-entry stat is what keeps the scan
+ * off the blocking syscall path.
+ */
+export function buildFileCandidates(
+  entries: FileDirent[],
+  query: string,
+  rootDir: string = process.cwd(),
+  homeDir?: string,
+): Candidate[] {
+  const { leafPrefix, displayPrefix } = resolveQuery(query, rootDir, homeDir);
+  // Sort by NAME before the cap so the ≤MAX_FILE_MATCHES survivors are the
+  // alphabetically-first entries (readdir order is OS-unspecified), THEN
+  // decorate directories with a trailing '/'. Plain string `.sort()` on the
+  // bare name matches the sibling `fileMatchesFor` in multi-line-reader
+  // byte-for-byte (filter → sort names → cap → decorate) — keep them identical.
+  const dirFlag = new Map<string, boolean>();
+  const names = entries
+    .filter((entry) => entry.name.startsWith(leafPrefix))
+    .filter((entry) => !(entry.name.startsWith('.') && !leafPrefix.startsWith('.')))
+    .map((entry) => {
+      dirFlag.set(entry.name, entry.isDirectory());
+      return entry.name;
+    })
+    .sort()
+    .slice(0, MAX_FILE_MATCHES);
+  return names.map((name) => ({
+    value: '@' + displayPrefix + name + (dirFlag.get(name) ? '/' : ''),
+  }));
+}
+
+/**
+ * Synchronous cache-only lookup. Returns ranked candidates when the query's
+ * scan directory is cached and fresh (within the TTL); returns `null` on a
+ * miss so the caller can decide to dispatch the async scan. Never touches the
+ * filesystem — safe to call on the keystroke path.
+ */
+export function filterFileCandidatesCached(
+  query: string,
+  rootDir: string = process.cwd(),
+  homeDir?: string,
+): Candidate[] | null {
+  const { scanDir } = resolveQuery(query, rootDir, homeDir);
+  const hit = scanCache.get(scanDir);
+  if (!hit || Date.now() - hit.at > FILE_SCAN_TTL_MS) return null;
+  return buildFileCandidates(hit.entries, query, rootDir, homeDir);
+}
+
+/**
+ * Async @-file candidate scan. Serves from the per-directory cache when fresh
+ * (resolving without any fs call), otherwise reads the directory with
+ * `fs.promises.readdir(..., { withFileTypes: true })`, caches the listing, and
+ * builds candidates via the pure core.
+ *
+ * fs errors (unreadable / nonexistent scan dir) resolve to `[]` — the promise
+ * never rejects, preserving the historical error-swallowing behavior so the
+ * keystroke path has no unhandled rejection to catch.
+ */
+export async function filterFileCandidatesAsync(
+  query: string,
+  rootDir: string = process.cwd(),
+  homeDir?: string,
+): Promise<Candidate[]> {
+  const { scanDir } = resolveQuery(query, rootDir, homeDir);
+  const cached = scanCache.get(scanDir);
+  if (cached && Date.now() - cached.at <= FILE_SCAN_TTL_MS) {
+    return buildFileCandidates(cached.entries, query, rootDir, homeDir);
+  }
+  try {
+    const entries: Dirent[] = await fsp.readdir(scanDir, { withFileTypes: true });
+    scanCache.set(scanDir, { entries, at: Date.now() });
+    return buildFileCandidates(entries, query, rootDir, homeDir);
+  } catch {
+    // unreadable scan dir → no candidates (never rejects)
+    return [];
+  }
+}
+
+/**
+ * Synchronous @-file candidate scan (legacy user-turn reader path).
+ *
+ * The between-turn `reader.ts` repaint closure is synchronous and writes to
+ * stdout inline, so it cannot await the async scan. This keeps a blocking
+ * `readdirSync` for that surface only — the hot agent-turn compositor path
+ * uses {@link filterFileCandidatesAsync} / {@link filterFileCandidatesCached}.
+ * It reads Dirents (`withFileTypes: true`) so it shares the exact
+ * `buildFileCandidates` core (no `statSync`) and warms the same cache, so a
+ * later async lookup for the same directory is an instant cache hit.
  */
 export function filterFileCandidates(
   query: string,
   rootDir: string = process.cwd(),
   homeDir?: string,
 ): Candidate[] {
-  // Invariant: cap is MAX_FILE_MATCHES from the shared upstream source.
-  // Do NOT re-cap to a smaller number here — a secondary cap silently hides
-  // entries beyond it even when the dropdown scrolls. filter → sort → cap →
-  // stat matches the fileMatchesFor ordering contract.
-  const { scanDir, leafPrefix, displayPrefix } = resolveQuery(query, rootDir, homeDir);
+  const { scanDir } = resolveQuery(query, rootDir, homeDir);
   try {
-    const names = readdirSync(scanDir)
-      .filter((name) => name.startsWith(leafPrefix))
-      .filter((name) => !(name.startsWith('.') && !leafPrefix.startsWith('.')))
-      .sort()
-      .slice(0, MAX_FILE_MATCHES);
-    return names
-      .map((name) => {
-        let relPath = displayPrefix + name;
-        try {
-          if (statSync(join(scanDir, name)).isDirectory()) relPath += '/';
-        } catch {
-          // stat errors don't block completion
-        }
-        return { value: '@' + relPath };
-      });
+    const entries = readdirSync(scanDir, { withFileTypes: true });
+    scanCache.set(scanDir, { entries, at: Date.now() });
+    return buildFileCandidates(entries, query, rootDir, homeDir);
   } catch {
     // unreadable scan dir → no candidates
     return [];

--- a/src/cli/terminal-compositor.autocomplete.stale-guard.test.ts
+++ b/src/cli/terminal-compositor.autocomplete.stale-guard.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Stale-result guard for the async @-file dropdown scan.
+ *
+ * Contract: when a directory scan for query A resolves AFTER the user has
+ * typed on to query B, A's candidates must be discarded — a late scan may
+ * never repaint over a newer dropdown state. updateAutocomplete captures the
+ * @-file query at dispatch time and, on resolve, applies candidates only when
+ * the live trigger is still that exact query.
+ *
+ * We drive the guard deterministically by mocking `filterFileCandidatesAsync`
+ * with hand-held deferred promises: dispatch A, dispatch B, then resolve A
+ * last and assert A's result never lands. `filterFileCandidatesCached` is
+ * forced to always miss so every keystroke takes the async path.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Candidate } from './input/types.js';
+
+// Hoisted so the (also-hoisted) vi.mock factory below can close over the same
+// deferred registry + spy the test body reads. A plain top-level `const` would
+// be evaluated AFTER the hoisted factory and throw "cannot access before
+// initialization".
+const h = vi.hoisted(() => {
+  interface Deferred {
+    promise: Promise<Candidate[]>;
+    resolve: (v: Candidate[]) => void;
+  }
+  const deferreds: Deferred[] = [];
+  const asyncScan = vi.fn(() => {
+    let resolve!: (v: Candidate[]) => void;
+    const promise = new Promise<Candidate[]>((res) => { resolve = res; });
+    deferreds.push({ promise, resolve });
+    return promise;
+  });
+  return { deferreds, asyncScan };
+});
+
+vi.mock('./input/trigger.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./input/trigger.js')>();
+  return {
+    ...actual,
+    // Force every keystroke through the async path.
+    filterFileCandidatesCached: () => null,
+    filterFileCandidatesAsync: h.asyncScan,
+  };
+});
+
+import { updateAutocomplete as update, type AutocompleteHost } from './terminal-compositor.autocomplete.js';
+import { createAutocompleteState, type AutocompleteState } from './input/autocomplete-state.js';
+
+function makeHost(ac: AutocompleteState, buffer: string, repaint: () => void): AutocompleteHost {
+  return {
+    autocompleteState: ac,
+    input: { buffer, cursor: buffer.length },
+    queued: false,
+    activeGhost: null,
+    ghostEngine: undefined,
+    ghostGetContext: undefined,
+    repaint,
+  };
+}
+
+const flush = (): Promise<void> => new Promise((r) => setImmediate(r));
+
+beforeEach(() => {
+  h.deferreds.length = 0;
+  h.asyncScan.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('updateAutocomplete — stale @-file scan guard', () => {
+  it('discards query A results that resolve AFTER query B was issued', async () => {
+    const repaint = vi.fn();
+    const ac = createAutocompleteState();
+
+    // Keystroke 1: buffer is `@aa` — dispatch scan A (query "aa").
+    const host = makeHost(ac, '@aa', repaint);
+    update(host);
+    expect(h.asyncScan).toHaveBeenCalledTimes(1);
+    expect(h.asyncScan).toHaveBeenLastCalledWith('aa');
+
+    // Keystroke 2: user types on so buffer is now `@bb` — dispatch scan B.
+    // (Same host object; the input buffer advanced.)
+    host.input = { buffer: '@bb', cursor: 3 };
+    update(host);
+    expect(h.asyncScan).toHaveBeenCalledTimes(2);
+    expect(h.asyncScan).toHaveBeenLastCalledWith('bb');
+
+    // Resolve B first with its candidates — the live trigger is "bb", so
+    // these apply.
+    h.deferreds[1]!.resolve([{ value: '@bbeta.ts' }]);
+    await flush();
+    expect(ac.candidates.map((c) => c.value)).toEqual(['@bbeta.ts']);
+    const repaintsAfterB = repaint.mock.calls.length;
+
+    // Now resolve the STALE scan A. Its query ("aa") no longer matches the
+    // live trigger ("bb"), so its candidates must be dropped and NO repaint
+    // fired.
+    h.deferreds[0]!.resolve([{ value: '@aalpha.txt' }]);
+    await flush();
+    expect(ac.candidates.map((c) => c.value)).toEqual(['@bbeta.ts']);
+    expect(repaint.mock.calls.length).toBe(repaintsAfterB);
+  });
+
+  it('applies a scan when its query is still the live trigger on resolve', async () => {
+    const repaint = vi.fn();
+    const ac = createAutocompleteState();
+    const host = makeHost(ac, '@src', repaint);
+    update(host);
+    expect(h.asyncScan).toHaveBeenCalledTimes(1);
+
+    // Buffer unchanged — resolve applies.
+    h.deferreds[0]!.resolve([{ value: '@src/index.ts' }]);
+    await flush();
+    expect(ac.dropdownOpen).toBe(true);
+    expect(ac.candidates.map((c) => c.value)).toEqual(['@src/index.ts']);
+    expect(repaint).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli/terminal-compositor.autocomplete.test.ts
+++ b/src/cli/terminal-compositor.autocomplete.test.ts
@@ -8,14 +8,26 @@
  * candidates to 12. This drives the real keystroke→cwd path through
  * updateAutocomplete to prove the dropdown surfaces >12 file candidates and
  * scrolls, rather than silently truncating.
+ *
+ * The @-file scan is async + cached (see trigger.ts). updateAutocomplete
+ * serves a cache HIT synchronously and dispatches a cache MISS as a
+ * fire-and-forget async scan whose result lands behind a stale guard. Tests
+ * that assert on candidates therefore either (a) pre-warm the cache via
+ * `filterFileCandidatesAsync` so the sync cache-hit path fills candidates
+ * inline, or (b) drive a real host and flush microtasks to let the async
+ * resolution apply.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { updateAutocomplete, type AutocompleteHost, MAX_DROPDOWN_ROWS } from './terminal-compositor.autocomplete.js';
 import { createAutocompleteState, type AutocompleteState } from './input/autocomplete-state.js';
+import {
+  filterFileCandidatesAsync,
+  invalidateFileScanCache,
+} from './input/trigger.js';
 import { MAX_FILE_MATCHES } from './multi-line-reader.js';
 
 let tmpRoot: string;
@@ -25,15 +37,17 @@ beforeEach(() => {
   originalCwd = process.cwd();
   tmpRoot = join(tmpdir(), `afk-ac-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(tmpRoot, { recursive: true });
+  invalidateFileScanCache();
 });
 
 afterEach(() => {
   process.chdir(originalCwd);
+  invalidateFileScanCache();
   if (existsSync(tmpRoot)) rmSync(tmpRoot, { recursive: true, force: true });
 });
 
 /** Minimal AutocompleteHost backed by a literal buffer/cursor. */
-function makeHost(ac: AutocompleteState, buffer: string): AutocompleteHost {
+function makeHost(ac: AutocompleteState, buffer: string, repaint: () => void = () => {}): AutocompleteHost {
   return {
     autocompleteState: ac,
     input: { buffer, cursor: buffer.length },
@@ -41,17 +55,34 @@ function makeHost(ac: AutocompleteState, buffer: string): AutocompleteHost {
     activeGhost: null,
     ghostEngine: undefined,
     ghostGetContext: undefined,
-    repaint: () => {},
+    repaint,
   };
 }
 
-describe('updateAutocomplete — @-file branch', () => {
-  it('opens the dropdown with ALL matching files when more than 12 match (no re-cap to 12)', () => {
+/**
+ * Wait until `predicate` holds, polling across macro/microtask boundaries.
+ * The @-file scan awaits a real `fs.promises.readdir`, which can take more
+ * than one microtask tick to settle, so a single `setImmediate` flush is not
+ * enough — poll (bounded) until the fire-and-forget resolution has applied.
+ */
+async function waitFor(predicate: () => boolean, tries = 50): Promise<void> {
+  for (let i = 0; i < tries && !predicate(); i++) {
+    await new Promise((r) => setImmediate(r));
+  }
+}
+
+describe('updateAutocomplete — @-file branch (cache-warmed sync path)', () => {
+  it('opens the dropdown with ALL matching files when more than 12 match (no re-cap to 12)', async () => {
     // 15 prefixed files — the count the old `.slice(0, 12)` would have hidden.
     for (let i = 0; i < 15; i++) {
       writeFileSync(join(tmpRoot, `pick${String(i).padStart(2, '0')}.txt`), 'x');
     }
     process.chdir(tmpRoot);
+
+    // Warm the per-directory cache so updateAutocomplete's sync cache-hit
+    // path fills candidates inline (mirrors the steady-state keystroke where
+    // the directory was already scanned on a prior keypress).
+    await filterFileCandidatesAsync('pick');
 
     const ac = createAutocompleteState();
     updateAutocomplete(makeHost(ac, '@pick'));
@@ -66,12 +97,13 @@ describe('updateAutocomplete — @-file branch', () => {
     expect(ac.candidates.length).toBeGreaterThan(MAX_DROPDOWN_ROWS);
   });
 
-  it('is bounded by MAX_FILE_MATCHES (the single upstream cap)', () => {
+  it('is bounded by MAX_FILE_MATCHES (the single upstream cap)', async () => {
     const total = MAX_FILE_MATCHES + 8;
     for (let i = 0; i < total; i++) {
       writeFileSync(join(tmpRoot, `f${String(i).padStart(3, '0')}.txt`), 'x');
     }
     process.chdir(tmpRoot);
+    await filterFileCandidatesAsync('f');
 
     const ac = createAutocompleteState();
     updateAutocomplete(makeHost(ac, '@f'));
@@ -79,14 +111,40 @@ describe('updateAutocomplete — @-file branch', () => {
     expect(ac.candidates).toHaveLength(MAX_FILE_MATCHES);
   });
 
-  it('closes the dropdown when no file matches the prefix', () => {
+  it('closes the dropdown when no file matches the prefix', async () => {
     writeFileSync(join(tmpRoot, 'readme.md'), 'x');
     process.chdir(tmpRoot);
+    await filterFileCandidatesAsync('zzz');
 
     const ac = createAutocompleteState();
     updateAutocomplete(makeHost(ac, '@zzz'));
 
     expect(ac.dropdownOpen).toBe(false);
     expect(ac.candidates).toHaveLength(0);
+  });
+});
+
+describe('updateAutocomplete — @-file branch (async resolution)', () => {
+  it('populates candidates and repaints once the async scan resolves (cold cache)', async () => {
+    for (let i = 0; i < 3; i++) {
+      writeFileSync(join(tmpRoot, `pick${i}.txt`), 'x');
+    }
+    process.chdir(tmpRoot);
+
+    const repaint = vi.fn();
+    const ac = createAutocompleteState();
+    // Cold cache: the sync path finds nothing, so the dropdown stays closed
+    // synchronously and the scan is dispatched fire-and-forget.
+    updateAutocomplete(makeHost(ac, '@pick', repaint));
+    expect(ac.candidates).toHaveLength(0);
+    expect(ac.dropdownOpen).toBe(false);
+    expect(repaint).not.toHaveBeenCalled();
+
+    // After the scan resolves, candidates apply and a repaint fires.
+    await waitFor(() => ac.dropdownOpen);
+    expect(ac.dropdownOpen).toBe(true);
+    expect(ac.candidates).toHaveLength(3);
+    expect(ac.candidates.every((c) => c.value.startsWith('@pick'))).toBe(true);
+    expect(repaint).toHaveBeenCalled();
   });
 });

--- a/src/cli/terminal-compositor.autocomplete.test.ts
+++ b/src/cli/terminal-compositor.autocomplete.test.ts
@@ -63,10 +63,22 @@ function makeHost(ac: AutocompleteState, buffer: string, repaint: () => void = (
  * Wait until `predicate` holds, polling across macro/microtask boundaries.
  * The @-file scan awaits a real `fs.promises.readdir`, which can take more
  * than one microtask tick to settle, so a single `setImmediate` flush is not
- * enough — poll (bounded) until the fire-and-forget resolution has applied.
+ * enough — poll until the fire-and-forget resolution has applied.
+ *
+ * Bounded by WALL-CLOCK time, not a fixed iteration count. A fixed tries=N
+ * bounds against event-loop *turns*, which has no reliable relationship to
+ * real elapsed time: under CI/full-suite CPU contention a single `readdir`
+ * can take many milliseconds to actually settle even though each
+ * `setImmediate` turn itself is "instant," so a fixed small tries count can
+ * give up before the real I/O ever completes (observed in CI: "expected
+ * false to be true" on `ac.dropdownOpen` — issue #657-adjacent flake class).
+ * A time budget scales with however slow the environment actually is, while
+ * staying just as fast as before in the common case (the loop still exits
+ * the instant the predicate flips true).
  */
-async function waitFor(predicate: () => boolean, tries = 50): Promise<void> {
-  for (let i = 0; i < tries && !predicate(); i++) {
+async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) {
     await new Promise((r) => setImmediate(r));
   }
 }

--- a/src/cli/terminal-compositor.autocomplete.ts
+++ b/src/cli/terminal-compositor.autocomplete.ts
@@ -11,9 +11,11 @@
 import { InputCore, type InputCoreState } from './input-core.js';
 import {
   detectTrigger,
-  filterFileCandidates,
+  filterFileCandidatesAsync,
+  filterFileCandidatesCached,
   filterFlagCandidates,
   filterSlashCandidates,
+  invalidateFileScanCache,
 } from './input/trigger.js';
 import { stripGhostControlChars } from './input/suggest.js';
 import type { AutocompleteState } from './input/autocomplete-state.js';
@@ -42,10 +44,37 @@ export interface AutocompleteHost {
 }
 
 /**
+ * Store a freshly-computed candidate list into the dropdown state and reclamp
+ * the selection/viewport so they stay valid for the new length. Shared by the
+ * synchronous branches of {@link updateAutocomplete} and by the async @-file
+ * resolution so both apply results through identical selection math.
+ */
+function commitCandidates(ac: AutocompleteState, candidates: AutocompleteState['candidates']): void {
+  ac.candidates = candidates;
+  ac.dropdownOpen = candidates.length > 0;
+  if (ac.selectedIndex >= ac.candidates.length) {
+    ac.selectedIndex = Math.max(0, ac.candidates.length - 1);
+  }
+  if (ac.viewportStart > ac.selectedIndex) ac.viewportStart = ac.selectedIndex;
+  if (ac.selectedIndex >= ac.viewportStart + MAX_DROPDOWN_ROWS) {
+    ac.viewportStart = ac.selectedIndex - MAX_DROPDOWN_ROWS + 1;
+  }
+}
+
+/**
  * Recompute autocomplete candidates from the current buffer/cursor and
  * store results back into the shared AutocompleteState. Called on every
  * printable keypress, backspace, and left/right so the dropdown stays
  * consistent with the buffer content during the agent turn.
+ *
+ * Invariant: MUST NOT block the keystroke path. The slash and flag branches
+ * are pure/synchronous. The @-file branch reads the filesystem, so it is served
+ * from a per-directory cache synchronously when possible and otherwise scanned
+ * asynchronously (fire-and-forget) — mirroring the `getGhost().then(...)`
+ * stale-async guard in {@link updateGhost}: the async result is applied only
+ * when the buffer's trigger is still the SAME @-file query it was dispatched
+ * for, and is silently dropped otherwise so a late scan never repaints over a
+ * newer dropdown state. A repaint is scheduled only after the guard passes.
  */
 export function updateAutocomplete(self: AutocompleteHost): void {
   const ac = self.autocompleteState;
@@ -58,27 +87,50 @@ export function updateAutocomplete(self: AutocompleteHost): void {
   }
   if (ac.trigger && ac.suppressedSignature === null) {
     if (ac.trigger.kind === 'slash') {
-      ac.candidates = filterSlashCandidates(ac.trigger.query).slice(0, 12);
+      commitCandidates(ac, filterSlashCandidates(ac.trigger.query).slice(0, 12));
     } else if (ac.trigger.kind === 'file') {
-      // File candidates are bounded upstream (MAX_FILE_MATCHES) and the
-      // dropdown scrolls; do NOT re-cap to 12, or entries past the 12th
-      // (e.g. src/, tests/ in a typical cwd) become unreachable.
-      ac.candidates = filterFileCandidates(ac.trigger.query);
+      updateFileCandidates(self, ac, ac.trigger.query);
     } else {
-      ac.candidates = filterFlagCandidates(ac.trigger.command, ac.trigger.query);
+      commitCandidates(ac, filterFlagCandidates(ac.trigger.command, ac.trigger.query));
     }
-    ac.dropdownOpen = ac.candidates.length > 0;
   } else {
-    ac.dropdownOpen = false;
-    ac.candidates = [];
+    commitCandidates(ac, []);
   }
-  if (ac.selectedIndex >= ac.candidates.length) {
-    ac.selectedIndex = Math.max(0, ac.candidates.length - 1);
+}
+
+/**
+ * @-file branch of {@link updateAutocomplete}. Serves a fresh cache hit
+ * synchronously so the common same-directory keystroke stays instant; on a
+ * miss, dispatches the async scan and applies its result behind the stale
+ * guard.
+ *
+ * Note: file candidates are bounded upstream (MAX_FILE_MATCHES) and the
+ * dropdown scrolls; do NOT re-cap to 12, or entries past the 12th (e.g. src/,
+ * tests/ in a typical cwd) become unreachable.
+ */
+function updateFileCandidates(self: AutocompleteHost, ac: AutocompleteState, query: string): void {
+  const cached = filterFileCandidatesCached(query);
+  if (cached !== null) {
+    commitCandidates(ac, cached);
+    return;
   }
-  if (ac.viewportStart > ac.selectedIndex) ac.viewportStart = ac.selectedIndex;
-  if (ac.selectedIndex >= ac.viewportStart + MAX_DROPDOWN_ROWS) {
-    ac.viewportStart = ac.selectedIndex - MAX_DROPDOWN_ROWS + 1;
-  }
+
+  // Cache miss: leave the dropdown in its current (pre-scan) state — clearing
+  // to closed here would flicker an open dropdown shut for one frame on every
+  // fresh directory. Snapshot the query BEFORE dispatch; the resolve handler
+  // discards the result unless the live trigger is still this exact @-file
+  // query (stale guard), so a slow scan for query A that resolves after the
+  // user has typed on to query B never repaints A's candidates.
+  const requestedQuery = query;
+  filterFileCandidatesAsync(query)
+    .then((candidates) => {
+      const live = ac.trigger;
+      if (live?.kind === 'file' && live.query === requestedQuery && ac.suppressedSignature === null) {
+        commitCandidates(ac, candidates);
+        self.repaint();
+      }
+    })
+    .catch(() => { /* filterFileCandidatesAsync never rejects, but be defensive */ });
 }
 
 /**
@@ -185,6 +237,10 @@ export function applyDropdownSelection(self: AutocompleteHost): boolean {
   );
   if (next === self.input) return false;
   self.input = next;
+  // Accepting a candidate ends this dropdown episode — drop the directory-scan
+  // cache so a directory mutated since the scan is re-read fresh next time
+  // (explicit invalidation alongside the TTL; see invalidateFileScanCache).
+  invalidateFileScanCache();
   // Reset dropdown viewport — same as reader.ts:303-305. The follow-up
   // updateAutocomplete() call may re-open the dropdown if the new cursor
   // position still matches a trigger (e.g. after applying `/mint ` the


### PR DESCRIPTION
## Summary
`@file` autocomplete ran `readdirSync` + per-candidate `statSync` on every keystroke while an @-token was active — synchronous fs on the input thread; large or network-mounted directories froze typing. The scan is now async (`fs.promises.readdir` with `withFileTypes`, `statSync` eliminated) with a 2s per-directory cache and a stale-result guard.

## Changes
- `input/trigger.ts`: pure `buildFileCandidates` core (ordering byte-identical to `fileMatchesFor`); Dirent-based dir flag; module-level cache (TTL 2s, `invalidateFileScanCache()`); `filterFileCandidatesCached` serves fresh hits synchronously so same-dir keystrokes stay instant; async path never rejects (fs errors → `[]`).
- `terminal-compositor.autocomplete.ts`: `updateFileCandidates` snapshots the query, applies async results only if the live trigger still matches (mirrors the existing `getGhost().then` pattern), repaints on apply; cache invalidated on dropdown accept.
- Legacy sync `reader.ts` path keeps a sync (now statSync-free) variant that warms the same cache.

## Verification
- `pnpm lint` clean; gate green: trigger (+14 tests incl. cache-spy + TTL), autocomplete (converted to await, +1), new stale-guard test file (deferred-promise A-after-B discard), dropdown render/apply suites. **Full `src/cli/` suite green: 270 files / 4,564 tests.**

## Notes for reviewer
- Symlinked directories lose the trailing `/` (Dirent.isDirectory tradeoff) — documented in-code.
- Cache-miss leaves the prior dropdown for one frame (anti-flicker, matches ghost behavior).
