### PR TITLE
feat(cli): /search over session turns with jump-to-last-error

### DIFF
--- a/src/cli/slash/commands/search.test.ts
+++ b/src/cli/slash/commands/search.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for the /search slash command — searches the CURRENT session's
+ * conversation turns and provides a jump-to-last-error affordance.
+ *
+ * Contract under test:
+ *  (a) `/search <term>` matches a case-insensitive substring across BOTH the
+ *      user prompt AND the assistant response of each turn.
+ *  (b) Each hit renders a trimmed (~200 char) snippet around the first match,
+ *      with the matched substring visually emphasized (a non-cyan palette tone
+ *      — cyan is reserved for user identity, see commit "reserve cyan for user
+ *      identity"). We strip ANSI and assert on the emphasis wrapper's presence.
+ *  (c) Results are capped at the 20 most recent matches with a trailing
+ *      "…and N more" line when more exist.
+ *  (d) `/search --error` (and `-e`) locates the LAST tool event with
+ *      isError across all turns and reports turn ordinal + tool name + snippet.
+ *  (e) No-match and no-args paths emit friendly one-liners (never throw, never
+ *      mutate state).
+ *
+ * The command is read-only: these tests also assert it never mutates the
+ * turns array it is given.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import chalk from 'chalk';
+import type { SlashContext, SessionStats, TurnRecord } from '../types.js';
+import { searchCmd } from './search.ts';
+
+// The palette binds chalk color fns at import; chalk checks its `level` at call
+// time, so bumping the level here makes those bound fns emit real ANSI even
+// though the test process is not a TTY (default level 0 = identity, which would
+// make the "emphasis is non-cyan" assertion vacuous). Restored after each test.
+let origChalkLevel: number;
+beforeEach(() => { origChalkLevel = chalk.level; chalk.level = 1; });
+afterEach(() => { chalk.level = origChalkLevel; });
+
+/** Build a SessionStats with the supplied turns (other fields are inert). */
+function makeStats(turns: TurnRecord[]): SessionStats {
+  return {
+    totalTurns: turns.length,
+    totalCostUsd: 0,
+    totalTokens: 0,
+    totalDurationMs: 0,
+    sessionStartTime: Date.now(),
+    turnCosts: [],
+    turnTokens: [],
+    turns,
+    model: 'sonnet',
+    permissionMode: 'default',
+  } as unknown as SessionStats;
+}
+
+/** Capture every writer call as a tagged line so tests can assert on output. */
+function makeCtx(turns: TurnRecord[]): { ctx: SlashContext; lines: string[]; stats: SessionStats } {
+  const lines: string[] = [];
+  const stats = makeStats(turns);
+  const ctx = {
+    session: { current: {} },
+    stats,
+    out: {
+      line: (t = ''): void => { lines.push(`LINE:${t}`); },
+      raw: (t: string): void => { lines.push(`RAW:${t}`); },
+      success: (t: string): void => { lines.push(`SUCCESS:${t}`); },
+      info: (t: string): void => { lines.push(`INFO:${t}`); },
+      warn: (t: string): void => { lines.push(`WARN:${t}`); },
+      error: (t: string): void => { lines.push(`ERROR:${t}`); },
+    },
+    ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
+  } as unknown as SlashContext;
+  return { ctx, lines, stats };
+}
+
+function turn(user: string, assistant: string, toolEvents?: TurnRecord['toolEvents']): TurnRecord {
+  return { user, assistant, timestamp: Date.now(), toolEvents };
+}
+
+/** Join the captured writer lines, stripping ANSI so assertions see plain text. */
+function plain(lines: string[]): string {
+  // eslint-disable-next-line no-control-regex
+  return lines.join('\n').replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+describe('/search slash command', () => {
+  describe('substring matching across user + assistant text', () => {
+    it('matches a term found in the USER prompt, case-insensitively', async () => {
+      const { ctx, lines } = makeCtx([
+        turn('How do I configure Webpack bundling?', 'You edit the config file.'),
+        turn('unrelated', 'unrelated'),
+      ]);
+      const res = await searchCmd.handler(ctx, 'webpack');
+      expect(res).toBe('continue');
+      const out = plain(lines);
+      expect(out).toContain('Webpack');
+      // The unrelated turn must not appear.
+      expect(out).not.toContain('unrelated');
+    });
+
+    it('matches a term found in the ASSISTANT response, case-insensitively', async () => {
+      const { ctx, lines } = makeCtx([
+        turn('what happened', 'The build threw a TypeError during compilation.'),
+      ]);
+      const res = await searchCmd.handler(ctx, 'TYPEERROR');
+      expect(res).toBe('continue');
+      expect(plain(lines)).toContain('TypeError');
+    });
+
+    it('reports the turn ordinal (1-based) and a role tag for each hit', async () => {
+      const { ctx, lines } = makeCtx([
+        turn('first turn no match here', 'nope'),
+        turn('second turn has the needle token', 'assistant reply'),
+      ]);
+      await searchCmd.handler(ctx, 'needle');
+      const out = plain(lines);
+      // 1-based ordinal of the matching (second) turn.
+      expect(out).toContain('#2');
+      // A role tag naming which side matched (user / assistant).
+      expect(out.toLowerCase()).toMatch(/user|assistant/);
+    });
+  });
+
+  describe('snippet trimming + emphasis', () => {
+    it('trims a long turn to a window around the first match (~200 chars)', async () => {
+      const filler = 'x'.repeat(400);
+      const { ctx, lines } = makeCtx([
+        turn(`${filler} NEEDLE ${filler}`, 'reply'),
+      ]);
+      await searchCmd.handler(ctx, 'needle');
+      const out = plain(lines);
+      // The rendered snippet must be far shorter than the 800+ char source.
+      const snippetLine = lines.find((l) => l.includes('NEEDLE'));
+      expect(snippetLine).toBeDefined();
+      // eslint-disable-next-line no-control-regex
+      const width = snippetLine!.replace(/\u001b\[[0-9;]*m/g, '').length;
+      expect(width).toBeLessThan(320); // ~200 char window + tag/prefix chrome
+      // Elision marker indicates trimming occurred on at least one side.
+      expect(out).toContain('…');
+    });
+
+    it('emphasizes the matched substring with a non-cyan palette tone', async () => {
+      const { ctx, lines } = makeCtx([
+        turn('the MATCHME token is here', 'reply'),
+      ]);
+      await searchCmd.handler(ctx, 'matchme');
+      const joined = lines.join('\n');
+      // The command uses palette.warning (yellow) for emphasis. Assert the
+      // exact wrapper is present around the matched text — and that it is NOT
+      // cyan (palette.user), which is reserved for user identity.
+      const emphasized = chalk.yellow('MATCHME');
+      expect(joined).toContain(emphasized);
+      const cyan = chalk.cyan('MATCHME');
+      expect(joined).not.toContain(cyan);
+    });
+  });
+
+  describe('cap + "and N more"', () => {
+    it('caps at the 20 most recent matches and prints a remainder line', async () => {
+      // 25 matching turns → 20 shown, 5 elided.
+      const turns = Array.from({ length: 25 }, (_, i) => turn(`match token turn ${i}`, 'reply'));
+      const { ctx, lines } = makeCtx(turns);
+      await searchCmd.handler(ctx, 'token');
+      const out = plain(lines);
+      // 25 total matches, capped to 20 → "and 5 more".
+      expect(out).toMatch(/and 5 more/i);
+      // Shows the MOST RECENT matches: the last turn (#25) must be present,
+      // the earliest (#1) must be dropped. Count the per-hit ordinal lines
+      // (shape `#N  ▶/◆ role`) — the header line carries no `#`.
+      // eslint-disable-next-line no-control-regex
+      const stripped = lines.map((l) => l.replace(/\u001b\[[0-9;]*m/g, ''));
+      const hitLines = stripped.filter((l) => /#\d+\s+[▶◆]/.test(l));
+      expect(hitLines.length).toBe(20);
+      expect(out).toContain('#25');
+      expect(out).not.toMatch(/#1\b/);
+    });
+
+    it('does not print a remainder line when matches fit under the cap', async () => {
+      const turns = Array.from({ length: 3 }, (_, i) => turn(`match ${i}`, 'reply'));
+      const { ctx, lines } = makeCtx(turns);
+      await searchCmd.handler(ctx, 'match');
+      expect(plain(lines)).not.toMatch(/more/i);
+    });
+  });
+
+  describe('--error / -e (jump to last error)', () => {
+    it('finds the LAST tool event with isError across all turns', async () => {
+      const { ctx, lines } = makeCtx([
+        turn('t1', 'a1', [
+          { toolName: 'read_file', toolUseId: 'u1', input: '{}', isError: true, result: 'ENOENT first error' },
+        ]),
+        turn('t2', 'a2', [
+          { toolName: 'bash', toolUseId: 'u2', input: '{}', isError: false, result: 'ok' },
+          { toolName: 'edit_file', toolUseId: 'u3', input: '{}', isError: true, result: 'patch did not apply LAST error' },
+        ]),
+        turn('t3', 'a3', [
+          { toolName: 'grep', toolUseId: 'u4', input: '{}', isError: false, result: 'match' },
+        ]),
+      ]);
+      const res = await searchCmd.handler(ctx, '--error');
+      expect(res).toBe('continue');
+      const out = plain(lines);
+      // Reports the LAST error (turn #2, edit_file), not the first (read_file).
+      expect(out).toContain('#2');
+      expect(out).toContain('edit_file');
+      expect(out).toContain('patch did not apply');
+      expect(out).not.toContain('ENOENT first error');
+    });
+
+    it('accepts the -e short flag', async () => {
+      const { ctx, lines } = makeCtx([
+        turn('t1', 'a1', [
+          { toolName: 'bash', toolUseId: 'u1', input: '{}', isError: true, result: 'boom' },
+        ]),
+      ]);
+      await searchCmd.handler(ctx, '-e');
+      const out = plain(lines);
+      expect(out).toContain('bash');
+      expect(out).toContain('boom');
+    });
+
+    it('says so when no error events exist', async () => {
+      const { ctx, lines } = makeCtx([
+        turn('t1', 'a1', [{ toolName: 'bash', toolUseId: 'u1', input: '{}', isError: false, result: 'ok' }]),
+        turn('t2', 'a2'),
+      ]);
+      await searchCmd.handler(ctx, '--error');
+      expect(plain(lines).toLowerCase()).toMatch(/no.*error/);
+    });
+  });
+
+  describe('no-match and no-args paths', () => {
+    it('emits a friendly one-liner when nothing matches', async () => {
+      const { ctx, lines } = makeCtx([turn('hello', 'world')]);
+      const res = await searchCmd.handler(ctx, 'zzz-not-present');
+      expect(res).toBe('continue');
+      expect(plain(lines).toLowerCase()).toMatch(/no match/);
+    });
+
+    it('prints a usage line when called with no args', async () => {
+      const { ctx, lines } = makeCtx([turn('hello', 'world')]);
+      const res = await searchCmd.handler(ctx, '');
+      expect(res).toBe('continue');
+      expect(plain(lines)).toContain('/search');
+    });
+
+    it('reports an empty session gracefully', async () => {
+      const { ctx, lines } = makeCtx([]);
+      const res = await searchCmd.handler(ctx, 'anything');
+      expect(res).toBe('continue');
+      expect(plain(lines).toLowerCase()).toMatch(/no turns|no match/);
+    });
+  });
+
+  describe('read-only invariant', () => {
+    it('does not mutate the turns array', async () => {
+      const turns = [turn('alpha', 'beta'), turn('gamma', 'delta')];
+      const snapshot = JSON.parse(JSON.stringify(turns));
+      const { ctx } = makeCtx(turns);
+      await searchCmd.handler(ctx, 'alpha');
+      await searchCmd.handler(ctx, '--error');
+      expect(turns).toEqual(snapshot);
+    });
+  });
+
+  describe('registration metadata', () => {
+    it('has a name, summary, and usage for /help + dropdown', () => {
+      expect(searchCmd.name).toBe('/search');
+      expect(searchCmd.summary.length).toBeGreaterThan(0);
+      expect(searchCmd.usage).toContain('/search');
+    });
+  });
+});

--- a/src/cli/slash/commands/search.ts
+++ b/src/cli/slash/commands/search.ts
@@ -1,0 +1,200 @@
+/**
+ * /search — search the CURRENT session's conversation turns.
+ *
+ * Two modes:
+ *   • `/search <term>`      — case-insensitive substring match over each turn's
+ *                             user prompt AND assistant response. Prints one
+ *                             block per matching turn (ordinal, role tag, and a
+ *                             trimmed snippet around the first match with the
+ *                             match emphasized), capped at the 20 most recent
+ *                             matches with a "…and N more" tail.
+ *   • `/search --error`/`-e` — locate the LAST tool event with `isError` across
+ *                             all turns and print its turn ordinal, tool name,
+ *                             and error snippet.
+ *
+ * Read-only: reads `ctx.stats.turns` and writes via `ctx.out` only. It never
+ * mutates session state, files, or history.
+ *
+ * Emphasis tone: the matched substring is highlighted with `palette.warning`
+ * (yellow). Cyan (`palette.user`) is reserved for user identity, so it is
+ * deliberately NOT used for structural emphasis here.
+ */
+
+import { palette } from '../../palette.js';
+import { divider } from '../../render.js';
+import type { SlashCommand, SlashContext, TurnRecord } from '../types.js';
+
+/** How many characters of context to show around the first match. */
+const SNIPPET_RADIUS = 90;
+/** Maximum matching turns rendered before the "…and N more" tail. */
+const MAX_MATCHES = 20;
+/** Longest error snippet shown for `--error`. */
+const ERROR_SNIPPET_MAX = 300;
+
+/** Which side of a turn a match was found on — drives the printed role tag. */
+type Role = 'user' | 'assistant';
+
+interface Match {
+  /** 1-based turn ordinal, matching /history's `#N` numbering. */
+  ordinal: number;
+  role: Role;
+  /** Rendered snippet with the match emphasized (already colorized). */
+  snippet: string;
+}
+
+/**
+ * Build a colorized snippet: a window of `SNIPPET_RADIUS` characters on each
+ * side of the first (case-insensitive) occurrence of `term` in `text`, with
+ * the matched substring wrapped in `palette.warning`. Leading/trailing
+ * ellipses mark where text was elided. Newlines are collapsed to spaces so a
+ * multi-line turn renders as a single scannable line.
+ *
+ * Precondition: `term` occurs in `text` (callers gate on `indexOf(...) >= 0`).
+ * Returns the whitespace-collapsed original if, defensively, it does not.
+ */
+function buildSnippet(text: string, term: string): string {
+  const flat = text.replace(/\s+/g, ' ').trim();
+  const lowerFlat = flat.toLowerCase();
+  const idx = lowerFlat.indexOf(term.toLowerCase());
+  if (idx < 0) return flat;
+
+  const start = Math.max(0, idx - SNIPPET_RADIUS);
+  const end = Math.min(flat.length, idx + term.length + SNIPPET_RADIUS);
+
+  const before = flat.slice(start, idx);
+  const hit = flat.slice(idx, idx + term.length);
+  const after = flat.slice(idx + term.length, end);
+
+  const lead = start > 0 ? '…' : '';
+  const trail = end < flat.length ? '…' : '';
+
+  return `${lead}${before}${palette.warning(hit)}${after}${trail}`;
+}
+
+/**
+ * Scan `turns` for a case-insensitive substring `term`. A turn matches if the
+ * term appears in its user prompt OR its assistant response; the role tag
+ * reflects where the FIRST match was found (user side preferred when both
+ * match, since the user prompt is the more common search anchor). Returns
+ * matches in turn order (oldest first) — callers slice the most recent.
+ */
+function findMatches(turns: readonly TurnRecord[], term: string): Match[] {
+  const needle = term.toLowerCase();
+  const out: Match[] = [];
+  for (let i = 0; i < turns.length; i++) {
+    const t = turns[i]!;
+    const userHit = (t.user ?? '').toLowerCase().includes(needle);
+    const asstHit = (t.assistant ?? '').toLowerCase().includes(needle);
+    if (!userHit && !asstHit) continue;
+    const role: Role = userHit ? 'user' : 'assistant';
+    const source = userHit ? t.user : t.assistant;
+    out.push({ ordinal: i + 1, role, snippet: buildSnippet(source, term) });
+  }
+  return out;
+}
+
+interface LastError {
+  ordinal: number;
+  toolName: string;
+  snippet: string;
+}
+
+/**
+ * Find the LAST tool event flagged `isError` across all turns, scanning turns
+ * newest-first and, within a turn, its `toolEvents` last-first so the returned
+ * event is the most recent failure in the session. Returns null when no error
+ * event exists.
+ */
+function findLastError(turns: readonly TurnRecord[]): LastError | null {
+  for (let i = turns.length - 1; i >= 0; i--) {
+    const events = turns[i]!.toolEvents;
+    if (!events || events.length === 0) continue;
+    for (let j = events.length - 1; j >= 0; j--) {
+      const ev = events[j]!;
+      if (ev.isError !== true) continue;
+      const raw = (ev.result ?? '').replace(/\s+/g, ' ').trim();
+      const snippet = raw.length > ERROR_SNIPPET_MAX ? raw.slice(0, ERROR_SNIPPET_MAX - 1) + '…' : raw;
+      return { ordinal: i + 1, toolName: ev.toolName, snippet };
+    }
+  }
+  return null;
+}
+
+/** Colored role tag for a match block. Neither branch uses cyan (user identity). */
+function roleTag(role: Role): string {
+  return role === 'user'
+    ? `${palette.brand('▶')} ${palette.meta('user')}`
+    : `${palette.brand('◆')} ${palette.meta('assistant')}`;
+}
+
+/** Render the `--error` path: last failing tool event, or a friendly miss. */
+function printLastError(ctx: SlashContext): void {
+  const { stats, out } = ctx;
+  const found = findLastError(stats.turns);
+  if (!found) {
+    out.info('No tool errors recorded in this session.');
+    return;
+  }
+  out.line();
+  out.line(palette.bold('Last tool error'));
+  out.line(divider());
+  const header = `  ${palette.meta(`#${found.ordinal}`)}  ${palette.warning(found.toolName)}`;
+  out.line(header);
+  out.line(`  ${found.snippet ? palette.dim(found.snippet) : palette.dim('(no error output captured)')}`);
+  out.line();
+}
+
+/** Render the `<term>` search path. */
+function printSearch(ctx: SlashContext, term: string): void {
+  const { stats, out } = ctx;
+  if (stats.turns.length === 0) {
+    out.info('No turns yet in this session.');
+    return;
+  }
+
+  const all = findMatches(stats.turns, term);
+  if (all.length === 0) {
+    out.info(`No matches for "${term}".`);
+    return;
+  }
+
+  // Show the MOST RECENT matches: matches come back oldest-first, so the tail
+  // slice is the newest MAX_MATCHES. The remainder count reflects the elided
+  // (older) matches.
+  const shown = all.slice(-MAX_MATCHES);
+  const remainder = all.length - shown.length;
+
+  out.line();
+  out.line(palette.bold(`Search: "${term}"  (${all.length} match${all.length === 1 ? '' : 'es'})`));
+  out.line(divider());
+  for (const m of shown) {
+    out.line(`  ${palette.meta(`#${m.ordinal}`)}  ${roleTag(m.role)}`);
+    out.line(`     ${m.snippet}`);
+  }
+  if (remainder > 0) {
+    out.line();
+    out.line(palette.dim(`  …and ${remainder} more (showing the ${shown.length} most recent)`));
+  }
+  out.line();
+}
+
+export const searchCmd: SlashCommand = {
+  name: '/search',
+  usage: '/search <term> | /search --error',
+  summary: 'Search this session\'s turns (or --error to jump to the last tool error)',
+  hint: 'Find where something was said this session: /search <term> matches your prompts and the assistant\'s replies; /search --error jumps to the most recent tool failure.',
+  flags: ['--error'],
+  async handler(ctx, args) {
+    const trimmed = args.trim();
+    if (trimmed === '--error' || trimmed === '-e') {
+      printLastError(ctx);
+      return 'continue';
+    }
+    if (trimmed === '') {
+      ctx.out.info('Usage: /search <term>   (or /search --error to jump to the last tool error)');
+      return 'continue';
+    }
+    printSearch(ctx, trimmed);
+    return 'continue';
+  },
+};

--- a/src/cli/slash/index.ts
+++ b/src/cli/slash/index.ts
@@ -27,6 +27,7 @@ import { keysCmd } from './commands/keys.js';
 import { worktreeCmd } from './commands/worktree.js';
 import { reauthCmd } from './commands/reauth.js';
 import { transcriptCmd } from './commands/transcript.js';
+import { searchCmd } from './commands/search.js';
 import { configDoctorCommands } from './commands/config-doctor.js';
 import { registerStaticPluginSkillCommands } from './plugin-skills.js';
 import { registerStaticPluginAgentCommands } from './plugin-agents.js';
@@ -55,6 +56,7 @@ export function registerAll(): void {
   register(worktreeCmd);
   register(reauthCmd);
   register(transcriptCmd);
+  register(searchCmd);
   for (const cmd of configDoctorCommands) register(cmd);
   // Placeholders for plugin-backed commands. The real lists get registered
   // after `session.waitForInitialization()` resolves, via


### PR DESCRIPTION
## Summary
Adds `/search` — find text in the current session and jump to the last tool error. Closes a transcript-navigation gap (previously only the external-pager `/transcript` existed).

## Changes
- New `slash/commands/search.ts` (+ registration in `slash/index.ts`, shows in `/help` with usage/hint/flag completion).
- `/search <term>`: case-insensitive substring over user + assistant text per turn; prints `#N` ordinal (consistent with `/history`), role tag, ~180-char snippet with the hit emphasized in `palette.warning` (yellow — cyan stays reserved for user identity per repo convention); caps at 20 most recent matches with an `…and N more` line.
- `/search --error` / `-e`: newest-first walk to the LAST `toolEvents[].isError`; prints ordinal, tool name, trimmed error.
- Read-only: no session/file/history mutation.

## Verification
- `pnpm lint` clean; 15 new tests + slash-registry + slash-commands suites: 3 files / 80 tests green.

## Notes for reviewer
- Snippet slicing is char-based (consistent with `/history`), not grapheme-aware — fine for previews.
- Trivial add-adjacent overlap with the /editor PR in `slash/index.ts` (both append one registration line).
