### PR TITLE
feat(router): notify the model when its provider is swapped mid-session

### DIFF
--- a/src/agent/providers/router/provider-router.test.ts
+++ b/src/agent/providers/router/provider-router.test.ts
@@ -247,6 +247,62 @@ describe('ProviderRouter', () => {
     await router.close();
   });
 
+  it('injects a one-turn model-switch notice into the first turn a swapped inner serves', async () => {
+    const { router, outer } = makeRouter({ model: 'sonnet', apiKey: 'key-anthropic' });
+    const iter = router[Symbol.asyncIterator]();
+    await pullInit(iter);
+
+    await driveTurn(iter, outer, 'first'); // anthropic
+    await router.setModel('gpt-5.5'); // cross-family
+    const events = await driveTurn(iter, outer, 'second'); // swaps to openai
+
+    // The FakeQuery echoes the pushed user content, so the notice + real text
+    // both surface in the swapped inner's first-turn output.
+    const delta = events.find((e) => e.type === 'delta.text');
+    const text = delta && delta.type === 'delta.text' ? delta.text : '';
+    expect(text).toContain('Your model was switched');
+    expect(text).toContain('sonnet → gpt-5.5');
+    expect(text).toContain('anthropic-direct → openai-compatible');
+    // The user's real message still rides the same turn, after the notice.
+    expect(text).toContain('second');
+    await router.close();
+  });
+
+  it('does NOT inject a switch notice on a same-family forward (no rebuild)', async () => {
+    const { router, outer } = makeRouter({ model: 'sonnet', apiKey: 'key-anthropic' });
+    const iter = router[Symbol.asyncIterator]();
+    await pullInit(iter);
+
+    await driveTurn(iter, outer, 'first');
+    await router.setModel('opus'); // same family (anthropic) → forwarded, not rebuilt
+    const events = await driveTurn(iter, outer, 'second');
+
+    const delta = events.find((e) => e.type === 'delta.text');
+    const text = delta && delta.type === 'delta.text' ? delta.text : '';
+    expect(text).not.toContain('Your model was switched');
+    expect(text).toContain('second'); // plain user turn forwarded unchanged
+    await router.close();
+  });
+
+  it('keeps the switch notice out of the carried shadow history (records user text only)', async () => {
+    const { router, outer, anthropic } = makeRouter({ model: 'sonnet', apiKey: 'key-anthropic' });
+    const iter = router[Symbol.asyncIterator]();
+    await pullInit(iter);
+
+    await driveTurn(iter, outer, 'alpha'); // anthropic#0
+    await router.setModel('gpt-5.5');
+    await driveTurn(iter, outer, 'beta'); // swap → openai#0 (notice injected on this turn)
+    await router.setModel('sonnet');
+    await driveTurn(iter, outer, 'gamma'); // swap → anthropic#1 (seeded from shadow history)
+
+    // The rebuilt anthropic inner is seeded with prior turns as TEXT. The 'beta'
+    // turn must be recorded as the user's real text, never the injected notice.
+    const seeded = anthropic.queries[1]!.rec.config.resumeHistory ?? [];
+    expect(seeded.find((t) => t.user === 'beta'), 'beta recorded as clean user text').toBeDefined();
+    expect(seeded.some((t) => t.user.includes('Your model was switched'))).toBe(false);
+    await router.close();
+  });
+
   it('resolves credentials per-family on swap and never leaks the anthropic key to openai', async () => {
     const { router, outer, anthropic, openai } = makeRouter({ model: 'sonnet', apiKey: 'key-anthropic' });
     const iter = router[Symbol.asyncIterator]();

--- a/src/agent/providers/router/provider-router.ts
+++ b/src/agent/providers/router/provider-router.ts
@@ -110,6 +110,50 @@ function stringifyUserContent(content: ProviderUserTurn['content']): string {
     .join('\n');
 }
 
+/**
+ * Build the one-turn "your model was switched" system context prepended to the
+ * first turn a freshly-swapped inner serves.
+ *
+ * Motivation: an inner rebuild is otherwise INVISIBLE to the model — the new
+ * inner's `session.init` is swallowed (so no re-init is surfaced) and the
+ * carried conversation is anonymous prose (the module-level cross-family
+ * invariant). Without this notice the switched-to model has no in-context signal
+ * that (a) it is a different model than the one that produced earlier turns, or
+ * (b) prior structured tool/thinking content was flattened to text — which
+ * invites it to over-trust or misattribute the history (e.g. narrate its own
+ * identity from a stale premise). The notice is descriptive context, NOT an
+ * instruction, and rides only the swap turn — it expires after one turn like any
+ * framework nudge.
+ */
+function buildSwitchNotice(
+  previousModel: string,
+  currentModel: string,
+  previousFamily: string | undefined,
+  currentFamily: string,
+): string {
+  const familyClause =
+    previousFamily && previousFamily !== currentFamily
+      ? ` (provider ${previousFamily} → ${currentFamily})`
+      : '';
+  return (
+    `[System context — not from the user. Your model was switched at the start of this turn: ` +
+    `${previousModel} → ${currentModel}${familyClause}. Earlier turns in this conversation were produced ` +
+    `by ${previousModel}; the history carried across the switch is plain text only, so any prior tool ` +
+    `calls and extended reasoning are now prose — treat their structure as lost, not authoritative.]`
+  );
+}
+
+/** Prepend a synthetic notice as a leading text block (or line) to outbound turn content. */
+function prependNotice(
+  content: ProviderUserTurn['content'],
+  notice: string,
+): ProviderUserTurn['content'] {
+  if (typeof content === 'string') {
+    return content.length > 0 ? `${notice}\n\n${content}` : notice;
+  }
+  return [{ type: 'text' as const, text: notice }, ...content];
+}
+
 export class ProviderRouter implements ProviderQuery {
   private readonly outerIterator: AsyncIterator<ProviderUserTurn>;
   private readonly baseConfig: AgentConfig;
@@ -291,20 +335,42 @@ export class ProviderRouter implements ProviderQuery {
         const needSwap =
           !this.active ||
           (modelChanged && this.resolveInner(this.currentModel).signature !== this.active.signature);
+        // Capture the outgoing identity BEFORE `activeModel` is overwritten, so a
+        // swap can tell the new inner which model/family it succeeded.
+        const previousModel = this.activeModel;
+        const previousFamily = this.active?.family;
         this.activeModel = this.currentModel;
+        let switchNotice: string | undefined;
         if (needSwap) {
           await this.closeActive();
           this.active = this.buildInner(this.currentModel, /* seed */ true);
           debugLog(`🔀 ProviderRouter: switched inner provider → ${this.active.family} (model=${this.currentModel})`);
+          // A rebuild is otherwise invisible to the model (init swallowed, history
+          // carried as anonymous prose). On a genuine model change, prepend a
+          // one-turn notice so the new inner knows it was switched and that the
+          // carried history lost its structure. Guarded on a real prior model so
+          // the first inner construction never emits one.
+          if (previousModel !== undefined && previousModel !== this.currentModel) {
+            switchNotice = buildSwitchNotice(
+              previousModel,
+              this.currentModel ?? '(unset)',
+              previousFamily,
+              this.active.family,
+            );
+          }
           // Swallow the new inner's session.init; propagate a construction error.
           const failed = yield* this.driveUntilInit(/* swallow */ true);
           if (failed) break;
         }
 
-        // Route the user turn to the active inner and pump until turn end.
+        // Route the user turn to the active inner and pump until turn end. The
+        // shadow history records the user's REAL text (no notice); only the
+        // outbound content handed to a freshly-swapped inner carries the notice.
         this.pendingUserText = stringifyUserContent(turn.content);
         this.pendingAssistantText = '';
-        this.active!.input.pushUserMessage(turn.content);
+        this.active!.input.pushUserMessage(
+          switchNotice ? prependNotice(turn.content, switchNotice) : turn.content,
+        );
 
         while (true) {
           const r = await this.active!.iterator.next();


### PR DESCRIPTION
## What

When the model is switched mid-session across a provider boundary (`/model gpt-5.x` from a Claude session, or a same-family switch onto a different endpoint), `ProviderRouter` tears down the active inner and rebuilds a new one seeded with a **text-only shadow history**. That rebuild is currently **invisible to the switched-to model**:

- the new inner's `session.init` is swallowed (by design — no re-init surfaced), and
- the carried conversation arrives as anonymous prose (`{user, assistant}` text pairs), with tool-call structure, thinking blocks, and images dropped.

So the new model has **no in-context signal** that (a) it's a different model than the one that produced earlier turns, or (b) the history it inherited lost its structure. In practice this invites identity confabulation (the model narrating its own identity from a stale premise) and over-trusting the flattened history.

## Change

Prepend a **one-turn** "your model was switched" system-context note to the first turn a freshly-swapped inner serves:

> `[System context — not from the user. Your model was switched at the start of this turn: sonnet → gpt-5.5 (provider anthropic-direct → openai-compatible). Earlier turns in this conversation were produced by sonnet; the history carried across the switch is plain text only, so any prior tool calls and extended reasoning are now prose — treat their structure as lost, not authoritative.]`

- **Gated on a genuine rebuild** — fires only when the router actually swaps the inner (signature change: cross-family OR cross-endpoint). Never on a same-signature same-family forward, and never on the first inner construction.
- **Kept out of the shadow history** — the carried user text stays clean; only the outbound content handed to the new inner carries the note.
- **Descriptive, not an instruction**, and **expires after one turn** like any framework nudge.

## Why here (router seam, not `setModel`)

The router is the only layer that knows a rebuild *actually happened* (`needSwap`), and it already owns the swap seam and the outbound push. `setModel` merely records the target string; it can't tell whether the deferred swap will materialize.

## Scope / out of scope

- Additive and reversible; no behavior change when no swap occurs (unchanged sessions pay nothing).
- Does **not** attempt to restore history fidelity — it makes the loss *legible*, not repaired.
- A sibling change (subagent-result provenance header — surfacing which model produced a subagent finding) is intended as a **separate** follow-up PR.

## Tests

`src/agent/providers/router/provider-router.test.ts` (+3):
- notice injected on a cross-family swap (asserts model + provider transition + the real user turn still rides after it);
- **no** notice on a same-family forward (no rebuild);
- notice excluded from the carried shadow history (records the user's real text only.

Full suite green locally: **674 files, 12,346 passed, 0 failed**;  clean.
BODY
)