### PR TITLE
feat(subagent): stamp a provenance header on cross-model subagent results

### DIFF
--- a/src/agent/tools/subagent-executor.test.ts
+++ b/src/agent/tools/subagent-executor.test.ts
@@ -646,6 +646,45 @@ describe('SubagentExecutor', () => {
       expect(() => JSON.parse(result.content)).toThrow();
     });
 
+    it('stamps a provenance header when the child model differs from the parent model', async () => {
+      // Parent on opus, child inherits the sonnet default → mixed-model fan-out.
+      const exec = new SubagentExecutor({
+        subagentManager: mockSubagentMgr as any,
+        parentSession: mockParentSession as any,
+        defaultConfig: mockConfig,
+        depth: 0,
+        parentModel: 'opus',
+      });
+      const handle = mockHandle({
+        message: { role: 'assistant', content: 'child finding', timestamp: new Date() },
+      });
+      mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
+
+      const result = await exec.execute(makeCall());
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toBe('[subagent result · model=sonnet (parent: opus)]\n\nchild finding');
+    });
+
+    it('omits the provenance header when the child model equals the parent model', async () => {
+      // Parent AND child on sonnet → header is pure noise, so it is not added.
+      const exec = new SubagentExecutor({
+        subagentManager: mockSubagentMgr as any,
+        parentSession: mockParentSession as any,
+        defaultConfig: mockConfig,
+        depth: 0,
+        parentModel: 'sonnet',
+      });
+      const handle = mockHandle({
+        message: { role: 'assistant', content: 'same-model finding', timestamp: new Date() },
+      });
+      mockSubagentMgr.forkSubagent = vi.fn().mockResolvedValue(handle);
+
+      const result = await exec.execute(makeCall());
+
+      expect(result.content).toBe('same-model finding');
+    });
+
     // T-1 (review finding C-1): when the SDK returns a ContentBlock[] array
     // instead of a plain string, the executor must serialize it to a string
     // so ToolResult.content is always a valid string.

--- a/src/agent/tools/subagent-executor.ts
+++ b/src/agent/tools/subagent-executor.ts
@@ -668,6 +668,7 @@ export class SubagentExecutor implements SubagentControl {
       prompt: parsed.prompt,
       idPrefix: parsed.id_prefix,
       model: childConfig.model,
+      ...(this.ctx.parentModel !== undefined ? { parentModel: this.ctx.parentModel } : {}),
       childManager,
       identity,
       depth,

--- a/src/agent/tools/subagent/foreground-promotion.test.ts
+++ b/src/agent/tools/subagent/foreground-promotion.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Unit tests for the `withProvenanceHeader` gate — the pure decision of whether
+ * a returned subagent result is stamped with its producing model.
+ */
+import { describe, it, expect } from 'vitest';
+import { withProvenanceHeader } from './foreground-promotion.js';
+
+describe('withProvenanceHeader', () => {
+  it('prepends a provenance header when the child model differs from the parent', () => {
+    expect(withProvenanceHeader('finding', 'sonnet', 'opus')).toBe(
+      '[subagent result · model=sonnet (parent: opus)]\n\nfinding',
+    );
+  });
+
+  it('returns content unchanged when the child model equals the parent', () => {
+    expect(withProvenanceHeader('finding', 'sonnet', 'sonnet')).toBe('finding');
+  });
+
+  it('returns content unchanged when the child model is unknown', () => {
+    expect(withProvenanceHeader('finding', undefined, 'opus')).toBe('finding');
+  });
+
+  it('returns content unchanged when the parent model is not wired', () => {
+    expect(withProvenanceHeader('finding', 'sonnet', undefined)).toBe('finding');
+  });
+
+  it('preserves an incomplete-partial marker beneath the provenance header', () => {
+    // Composes with annotateIfIncomplete output: the header wraps the already-
+    // annotated body, so both signals survive.
+    const annotated = '[⚠ PARTIAL RESULT — the subagent …]\n\nbody';
+    expect(withProvenanceHeader(annotated, 'haiku', 'opus')).toBe(
+      `[subagent result · model=haiku (parent: opus)]\n\n${annotated}`,
+    );
+  });
+});

--- a/src/agent/tools/subagent/foreground-promotion.ts
+++ b/src/agent/tools/subagent/foreground-promotion.ts
@@ -50,6 +50,14 @@ export interface RunForegroundArgs {
   idPrefix: string | undefined;
   /** Child model for the promotion registry record; falls back to 'sonnet'. */
   model: string | undefined;
+  /**
+   * Parent session's model. Used ONLY to decide whether to stamp a provenance
+   * header on the returned result — the header is added only when the child ran
+   * on a different model than the parent (the mixed-model fan-out case, where
+   * the parent benefits from knowing which model produced a finding). Absent in
+   * contexts that don't wire it, in which case no header is ever added.
+   */
+  parentModel?: string;
   /** Child manager to tear down in the finally (unless promoted). */
   childManager: SubagentManager | undefined;
   /** Routing-decision identity fields (empty when this executor lacks a surface). */
@@ -73,6 +81,24 @@ export interface RunForegroundArgs {
 }
 
 /**
+ * Prepend a compact provenance header naming the subagent's model — but ONLY
+ * when it differs from the parent's. That is the mixed-model fan-out case where
+ * the parent benefits from knowing which model produced a finding (trust
+ * calibration: a result from a cheaper/different model warrants independent
+ * checking). When the child inherited the parent's model the header is pure
+ * noise and is omitted, so same-model dispatches stay byte-for-byte unchanged.
+ * Descriptive metadata, not an instruction.
+ */
+export function withProvenanceHeader(
+  content: string,
+  model: string | undefined,
+  parentModel: string | undefined,
+): string {
+  if (!model || !parentModel || model === parentModel) return content;
+  return `[subagent result · model=${model} (parent: ${parentModel})]\n\n${content}`;
+}
+
+/**
  * Run the foreground branch: race the run against a promotion signal, handle
  * success/failure, and clean up in a finally. Returns the `ToolResult`, or
  * re-throws on the defense-in-depth error path.
@@ -84,6 +110,7 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
     prompt,
     idPrefix,
     model,
+    parentModel,
     childManager,
     identity,
     depth,
@@ -242,8 +269,16 @@ export async function runForegroundWithPromotion(args: RunForegroundArgs): Promi
       // Assign (don't return) so the finally can append the in-turn
       // SubagentStop injectContext after teardown. See `toolResult` above.
       // annotateIfIncomplete marks capped/stream-truncated partials so the
-      // parent model doesn't treat them as a final answer (no-op if clean).
-      toolResult = { content: annotateIfIncomplete(content, result.stopReason) };
+      // parent model doesn't treat them as a final answer (no-op if clean);
+      // withProvenanceHeader stamps the producing model on a mixed-model
+      // dispatch (no-op when child == parent).
+      toolResult = {
+        content: withProvenanceHeader(
+          annotateIfIncomplete(content, result.stopReason),
+          model,
+          parentModel,
+        ),
+      };
       return toolResult;
     }
 


### PR DESCRIPTION
## What

A foreground subagent's result returns to the parent model as an **anonymous text blob**. The producing model is recorded only in telemetry/trace — never in the `ToolResult` content the parent's model actually reads. So when the parent reasons over a confident subagent finding, it can't see that the finding came from a cheaper or different model, which is exactly the signal that should prompt independent verification.

This matters most in **mixed-model fan-out** — e.g. a `compose` DAG or an `agent` wave where nodes run on different models (haiku/sonnet/opus). Sibling PR #655 does the parent-facing half of the same idea (notify the model when *its own* provider is swapped mid-session).

## Change

Prepend a compact provenance header to the returned success content:

```
[subagent result · model=sonnet (parent: opus)]

<the subagent's finding…>
```

**Gated on the child model differing from the parent's:**
- Child inherited the parent's model → header is pure noise → **omitted** (same-model dispatches are byte-for-byte unchanged).
- `parentModel` not wired for a surface → **no header ever** (fail-safe).

The parent model flows through the **existing** `ctx.parentModel` wiring, already populated by the REPL, chat, and daemon bootstraps — no new plumbing through the session. The header composes cleanly with `annotateIfIncomplete` (a partial-result marker stays beneath the provenance header). It's descriptive metadata, not an instruction.

## Why gated (not always-on)

An always-on header would (a) add a badge to every result including the common same-model case (noise), and (b) break ~8 existing exact-`content` assertions. Gating on child≠parent targets the case where provenance actually informs a decision, and keeps blast radius near-zero: existing tests don't set `parentModel`, so they get no header and stay green.

## Scope / out of scope

- Success path only. Attaching the model to the **structured failure payload** (error path) is a deliberate, small follow-up — the failure JSON already carries `subagent_id` + status, and adding a field there touches a shared payload builder + its callers, so it's kept separate.
- Additive and reversible; no behavior change when child == parent or `parentModel` is unset.

## Tests

- `src/agent/tools/subagent/foreground-promotion.test.ts` (new): unit tests for the gate — differs, equal, unknown child, unwired parent, and composition with the incomplete-partial marker.
- `src/agent/tools/subagent-executor.test.ts` (+2): integration tests proving the header appears on a cross-model dispatch (`parent: opus`, child `sonnet`) and is omitted on a same-model one — exercising the real `ctx.parentModel` wiring.

Full suite green locally: **675 files, 12,350 passed, 0 failed**; `tsc --noEmit` clean.
