### PR TITLE
fix(test): eliminate scheduler.test.ts cron-timer leak causing flaky duplicate mcp_connect_done (#657)

### DIFF
--- a/src/agent/daemon/scheduler.test.ts
+++ b/src/agent/daemon/scheduler.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as traceEmit from '../trace/emit.js';
+import * as nodeCron from 'node-cron';
 
 const schedulerTestState = vi.hoisted(() => ({ cleanupOrder: [] as string[] }));
 
@@ -24,6 +25,25 @@ vi.mock('../default-hook-registry.js', () => ({
     registry: undefined,
     memoryStore: { close: () => schedulerTestState.cleanupOrder.push('memory.close') },
   }),
+}));
+
+// Invariant: these unit tests exercise the scheduler exclusively through the
+// explicit `scheduler.tick(...)` seam, which invokes `runOnce` directly and
+// never needs a live wall-clock cron. node-cron auto-STARTS a real timer at
+// register(); under full-suite load a genuine minute-boundary tick can fire a
+// background `runOnce` whose slow `McpManager.fromConfig` outlives `stop()`
+// (which cancels the timer but never awaits an in-flight run) and leaks its
+// fire-and-forget `mcp_connect_done` into a sibling test's module-level
+// `emitSessionPhase` spy — the intermittent duplicate in issue #657. Stubbing
+// `schedule()` so register() arms no real timer removes that source entirely;
+// every assertion below stays exact.
+vi.mock('node-cron', () => ({
+  schedule: vi.fn(() => ({
+    start: () => {},
+    stop: () => {},
+    destroy: () => {},
+    getStatus: () => 'stopped',
+  })),
 }));
 
 import { CronScheduler, daemonTraceLabel, resolveWorktreePruneRoot } from './scheduler.js';
@@ -867,6 +887,35 @@ describe('CronScheduler — mcp_connect_* trace phases', () => {
     },
     { timeout: 15_000 },
   );
+});
+
+describe('CronScheduler — cron-timer isolation (#657)', () => {
+  it('register() routes cron scheduling through the stubbed node-cron so tests arm no live wall-clock timer', () => {
+    // Regression guard for the flaky duplicate `mcp_connect_done` in issue #657.
+    // If this file's `vi.mock('node-cron', …)` stub is ever removed, register()
+    // would arm a real minute-boundary timer whose background `runOnce` can leak
+    // a fire-and-forget trace phase into a sibling test's `emitSessionPhase` spy
+    // under full-suite load. Assert the stub is in effect AND load-bearing.
+    expect(vi.isMockFunction(nodeCron.schedule)).toBe(true);
+
+    const dir = makeTmpDir();
+    try {
+      const scheduler = new CronScheduler({ telemetryPath: join(dir, 'forge-telemetry.jsonl') });
+      scheduler.register({
+        taskId: 'isolation-guard-657',
+        command: 'noop',
+        trigger: 'cron',
+        cronExpression: '* * * * *',
+      });
+      expect(nodeCron.schedule).toHaveBeenCalledWith(
+        '* * * * *',
+        expect.any(Function),
+        expect.objectContaining({ name: 'isolation-guard-657' }),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('daemonTraceLabel', () => {


### PR DESCRIPTION
Closes #657.

## Problem
`src/agent/daemon/scheduler.test.ts > CronScheduler — mcp_connect_* trace phases` intermittently failed under full-suite CI load with an extra duplicate `mcp_connect_done` (no extra `mcp_connect_start`), while passing 29/29 reliably in isolation.

## Root cause — a test-isolation defect, not a production bug
- `register()` (`scheduler.ts:211`) calls `cron.schedule('* * * * *', …)`. node-cron v4 **auto-starts** the task, arming a **live wall-clock timer**.
- These unit tests only ever execute via the explicit `await scheduler.tick(...)` seam (`scheduler.ts:242`), which calls `runOnce` directly and **bypasses cron** — so the armed live timer is pure noise.
- Under CPU contention, a genuine minute-boundary tick fires a background `runOnce` whose slow `await McpManager.fromConfig(...)` (real subprocess spawn) **outlives `stop()`** — `stop()`/`unregister()` cancel the cron timer but never await an in-flight run.
- That leaked background tick's fire-and-forget `mcp_connect_done` (emitted in the `finally` **after** the slow await) lands in a **sibling test's** module-level `vi.spyOn(traceEmit, 'emitSessionPhase')` capture. Its paired `mcp_connect_start` was emitted before that test's spy existed → **done-only duplicate**, exactly the observed symptom.
- Production is correct: each `spawnSession` opens its **own** trace writer (`scheduler.ts:540`), so real on-disk traces never double-count. The contamination exists only because a *test* spies on the shared module singleton and thus captures foreign-session emissions. vitest per-file isolation rules out cross-file leaks, so the source is entirely within this file.

## Fix (test layer — the correct layer)
File-wide `vi.mock('node-cron')` whose `schedule()` returns an inert task, so `register()` arms **no** real timer. This removes the background-tick source for **every** test in the file, eliminating the whole class of leak.

- **The flaky assertion is unchanged** — still `expect(emitted).toEqual([{start,1},{done,1}])` exactly. No weakening (no `toContainEqual`/dedupe/length checks), per the issue's explicit request not to paper over the bug.
- **No production code touched.** (`stop()` not awaiting in-flight ticks is a real but separate wart; making it drain would risk hanging real daemon shutdown behind a long tick — deliberately left as a possible follow-up, out of scope here.)
- Adds a **deterministic regression guard** (`CronScheduler — cron-timer isolation (#657)`) that fails if the stub is ever removed.

## Verification
- `pnpm test src/agent/daemon/scheduler.test.ts` → **30/30** (29 original + new guard)
- `pnpm test src/agent/daemon/` → **128/128** across 10 files (file-scoped mock; siblings unaffected)
- `pnpm lint` (`tsc --noEmit`) → clean (exit 0)

Diff: 1 file, +49 lines (test-only).