### PR TITLE
fix(#661): bound web_scrape + tool output to prevent subagent context overflow

### DIFF
--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -53,7 +53,6 @@ import type { ToolDispatcher } from './tool-dispatcher.js';
 import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { PathGrantManager } from '../../tools/grant-manager.js';
 import { createBuiltinHandlers } from '../../tools/handlers/index.js';
-import { MODEL_CAP_BYTES } from '../../tools/handlers/_output-cap.js';
 import {
   exitPlanModeTool,
   createExitPlanModeHandler,
@@ -344,6 +343,13 @@ export class AnthropicDirectProvider implements ModelProvider {
       env?: Record<string, string>;
       sessionId?: string;
       parentSessionId?: string;
+      /**
+       * Explicit "this session is a forked subagent" signal carrying the
+       * per-result output-cap budget (#661). Set to MODEL_CAP_BYTES by
+       * `SubagentManager.forkSubagent` for EVERY fork; undefined on a top-level
+       * session. Arms the dispatcher's `maxOutputBytes` backstop declaratively.
+       */
+      subagentToolOutputCapBytes?: number;
       traceWriter?: TraceWriter;
       /**
        * Live source for the `get_runtime_state` tool. Constructed per-query
@@ -486,14 +492,21 @@ export class AnthropicDirectProvider implements ModelProvider {
       ...(opts?.env !== undefined ? { env: opts.env } : {}),
       sessionId: opts?.sessionId,
       parentSessionId: opts?.parentSessionId,
-      // Central output-cap backstop (#661), FORK-SCOPED. A forked child is the
-      // only session that carries a `parentSessionId`; the top-level session
-      // leaves it undefined. Enabling the cap exactly when parentSessionId is
-      // set means every FORKED child bounds each tool result at MODEL_CAP_BYTES
-      // (100KB) via headAndTail — containing the whole overflow crash class
-      // (MCP dumps, browser output, read_file of a huge file) for the actual
-      // victims — while the top-level session's behavior is UNCHANGED (no cap).
-      ...(opts?.parentSessionId !== undefined ? { maxOutputBytes: MODEL_CAP_BYTES } : {}),
+      // Central output-cap backstop (#661), FORK-SCOPED. Armed from the
+      // explicit `subagentToolOutputCapBytes` signal that
+      // `SubagentManager.forkSubagent` stamps (as MODEL_CAP_BYTES = 100KB) on
+      // EVERY forked child — the single choke point for the agent-tool, skill,
+      // and compose fork paths. A value here means "forked child" ⇒ bound each
+      // tool result at that budget via headAndTail, containing the whole
+      // overflow crash class (MCP dumps, browser output, read_file of a huge
+      // file). The top-level session is built directly (never via forkSubagent),
+      // leaves this unset, and is therefore UNCAPPED (behavior unchanged). This
+      // replaces the prior `parentSessionId !== undefined` gate, which missed
+      // skill-forked descendants whose parent carries no sessionId (a stub
+      // parent) and were left silently exposed.
+      ...(opts?.subagentToolOutputCapBytes !== undefined
+        ? { maxOutputBytes: opts.subagentToolOutputCapBytes }
+        : {}),
       ...(opts?.traceWriter ? { traceWriter: opts.traceWriter } : {}),
       // Read-only-skill bash gate: forwarded from the provider's stored flag
       // (set by createChildProviderFactory / buildReadOnlyReconProvider) so a
@@ -735,6 +748,12 @@ export class AnthropicDirectProvider implements ModelProvider {
           ...(config.env !== undefined ? { env: config.env } : {}),
           sessionId: config.sessionId,
           parentSessionId: config.parentSessionId,
+          // Fork-scoped central output cap (#661): forwarded from the child
+          // config that forkSubagent stamped, arming maxOutputBytes for forks
+          // only (top-level leaves it unset).
+          ...(config.subagentToolOutputCapBytes !== undefined
+            ? { subagentToolOutputCapBytes: config.subagentToolOutputCapBytes }
+            : {}),
           traceWriter: config.traceWriter,
           runtimeStateSource,
           hookRegistry: config.hookRegistry,

--- a/src/agent/providers/anthropic-direct/index.ts
+++ b/src/agent/providers/anthropic-direct/index.ts
@@ -53,6 +53,7 @@ import type { ToolDispatcher } from './tool-dispatcher.js';
 import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { PathGrantManager } from '../../tools/grant-manager.js';
 import { createBuiltinHandlers } from '../../tools/handlers/index.js';
+import { MODEL_CAP_BYTES } from '../../tools/handlers/_output-cap.js';
 import {
   exitPlanModeTool,
   createExitPlanModeHandler,
@@ -485,6 +486,14 @@ export class AnthropicDirectProvider implements ModelProvider {
       ...(opts?.env !== undefined ? { env: opts.env } : {}),
       sessionId: opts?.sessionId,
       parentSessionId: opts?.parentSessionId,
+      // Central output-cap backstop (#661), FORK-SCOPED. A forked child is the
+      // only session that carries a `parentSessionId`; the top-level session
+      // leaves it undefined. Enabling the cap exactly when parentSessionId is
+      // set means every FORKED child bounds each tool result at MODEL_CAP_BYTES
+      // (100KB) via headAndTail — containing the whole overflow crash class
+      // (MCP dumps, browser output, read_file of a huge file) for the actual
+      // victims — while the top-level session's behavior is UNCHANGED (no cap).
+      ...(opts?.parentSessionId !== undefined ? { maxOutputBytes: MODEL_CAP_BYTES } : {}),
       ...(opts?.traceWriter ? { traceWriter: opts.traceWriter } : {}),
       // Read-only-skill bash gate: forwarded from the provider's stored flag
       // (set by createChildProviderFactory / buildReadOnlyReconProvider) so a

--- a/src/agent/providers/anthropic-direct/output-cap-wiring.test.ts
+++ b/src/agent/providers/anthropic-direct/output-cap-wiring.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Regression test for the fork-scoped central output-cap wiring (#661).
+ *
+ * `subagent-output-cap.test.ts` proves that `SubagentManager.forkSubagent`
+ * STAMPS the explicit `AgentConfig.subagentToolOutputCapBytes` signal on every
+ * fork (even a stub-parent skill fork). This file proves the OTHER half: that
+ * `AnthropicDirectProvider.buildDispatcher` ARMS the dispatcher's
+ * `maxOutputBytes` backstop from that signal — so a forked child's tool output
+ * is actually bounded — and, critically, that it is keyed on the NEW field, not
+ * the leaky `parentSessionId` heuristic it replaced.
+ *
+ * Observation point: the `tool.output` ProviderEvent. When the cap is armed and
+ * a tool returns content over budget, the dispatcher reduces it to head+tail
+ * (the truncation marker) and the observed content is ≤ the cap. When the cap
+ * is not armed, the full content rides through untouched.
+ *
+ * Mirrors the mock-Anthropic + query({config}) shape of
+ * plan-mode-gate-wiring.test.ts so this exercises the REAL provider→dispatcher
+ * path (not a hand-built dispatcher).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { z } from 'zod';
+import type Anthropic from '@anthropic-ai/sdk';
+import type { RawMessageStreamEvent } from '@anthropic-ai/sdk/resources';
+import type { ProviderEvent } from '../../provider.js';
+import { AnthropicDirectProvider, __setAnthropicClientFactory } from './index.js';
+import { tool } from '../../tools/custom-tool.js';
+import { MODEL_CAP_BYTES } from '../../tools/handlers/_output-cap.js';
+
+// --- Mock Anthropic Messages-API plumbing (mirrors plan-mode-gate-wiring.test.ts) ---
+
+const messagesCreateMock = vi.fn();
+
+class MockAnthropic {
+  public messages: { create: typeof messagesCreateMock };
+  constructor() {
+    this.messages = { create: messagesCreateMock };
+  }
+}
+
+function installFactory(): void {
+  __setAnthropicClientFactory(() => new MockAnthropic() as unknown as Anthropic);
+}
+
+async function* singleInput(content: string): AsyncIterable<{ content: string }> {
+  yield { content };
+}
+
+async function* fromArray<T>(arr: T[]): AsyncIterable<T> {
+  for (const x of arr) yield x;
+}
+
+async function collect(query: AsyncIterable<ProviderEvent>): Promise<ProviderEvent[]> {
+  const out: ProviderEvent[] = [];
+  for await (const ev of query) out.push(ev);
+  return out;
+}
+
+function makeToolUseStream(toolId: string, toolName: string, inputJson: string): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_t',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-5',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 7,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'tool_use', id: toolId, name: toolName, input: {} },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'input_json_delta', partial_json: inputJson },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'tool_use', stop_sequence: null },
+      usage: { output_tokens: 9 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+function makeTextStream(text: string): RawMessageStreamEvent[] {
+  return [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_done',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-sonnet-5',
+        stop_reason: null,
+        stop_sequence: null,
+        usage: {
+          input_tokens: 5,
+          output_tokens: 0,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          server_tool_use: null,
+          service_tier: null,
+        },
+      },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_start',
+      index: 0,
+      content_block: { type: 'text', text: '', citations: [] },
+    } as unknown as RawMessageStreamEvent,
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'content_block_stop', index: 0 } as unknown as RawMessageStreamEvent,
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: { output_tokens: 4 },
+    } as unknown as RawMessageStreamEvent,
+    { type: 'message_stop' } as unknown as RawMessageStreamEvent,
+  ];
+}
+
+/** UTF-8 byte size that comfortably exceeds MODEL_CAP_BYTES (100KB). */
+const OVERSIZE_BYTES = MODEL_CAP_BYTES + 50_000;
+const TRUNC_MARKER = /… \[\d+ bytes truncated: showing first \d+ \+ last \d+ of \d+\] …/;
+
+/** A custom tool that returns `OVERSIZE_BYTES` of content, unconditionally. */
+const bigTool = tool(
+  'big_output',
+  'Returns a large blob of text for output-cap testing.',
+  z.object({}),
+  async () => ({ content: 'A'.repeat(OVERSIZE_BYTES) }),
+);
+
+function toolOutputOf(events: ProviderEvent[]): { content: string; isError?: boolean } {
+  const ev = events.find((e) => e.type === 'tool.output');
+  if (!ev || ev.type !== 'tool.output') {
+    throw new Error('expected a tool.output event');
+  }
+  return { content: ev.content, ...(ev.isError !== undefined ? { isError: ev.isError } : {}) };
+}
+
+describe('AnthropicDirectProvider — central output cap armed from config.subagentToolOutputCapBytes (#661)', () => {
+  beforeEach(() => {
+    messagesCreateMock.mockReset();
+    __setAnthropicClientFactory(null);
+    installFactory();
+    let callIdx = 0;
+    messagesCreateMock.mockImplementation(() => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        return fromArray(makeToolUseStream('toolu_big', 'big_output', '{}'));
+      }
+      return fromArray(makeTextStream('done'));
+    });
+  });
+
+  it('CAPS a forked child (subagentToolOutputCapBytes set) even when parentSessionId is UNDEFINED', async () => {
+    // The exact leaky-gate case: a skill-forked descendant has no
+    // parentSessionId (stub parent) but IS a fork. The explicit signal must arm
+    // the cap regardless.
+    const provider = new AnthropicDirectProvider({ customTools: [bigTool] });
+    const query = provider.query({
+      prompt: singleInput('call the tool'),
+      config: {
+        model: 'claude-sonnet-5',
+        apiKey: 'sk-ant-oat01-test',
+        // Fork signal present; parentSessionId deliberately ABSENT.
+        subagentToolOutputCapBytes: MODEL_CAP_BYTES,
+      },
+    });
+
+    const out = toolOutputOf(await collect(query));
+    expect(out.content).toMatch(TRUNC_MARKER);
+    expect(Buffer.byteLength(out.content, 'utf8')).toBeLessThanOrEqual(MODEL_CAP_BYTES);
+    // Head preserved (head+tail, not tail-only).
+    expect(out.content.startsWith('A')).toBe(true);
+  });
+
+  it('does NOT cap a top-level session (no subagentToolOutputCapBytes, no parentSessionId)', async () => {
+    // Top-level sessions are built via `new AgentSession(...)` directly and
+    // never carry the fork signal ⇒ uncapped, full output passes through.
+    const provider = new AnthropicDirectProvider({ customTools: [bigTool] });
+    const query = provider.query({
+      prompt: singleInput('call the tool'),
+      config: {
+        model: 'claude-sonnet-5',
+        apiKey: 'sk-ant-oat01-test',
+      },
+    });
+
+    const out = toolOutputOf(await collect(query));
+    expect(out.content).not.toMatch(TRUNC_MARKER);
+    expect(Buffer.byteLength(out.content, 'utf8')).toBe(OVERSIZE_BYTES);
+  });
+
+  it('does NOT cap when only parentSessionId is set (proves the cap no longer keys on parentSessionId)', async () => {
+    // Regression guard for the fix's core change: a config that carries a
+    // parentSessionId but NOT the explicit signal must NOT be capped by the
+    // central backstop. This pins that the arming condition migrated off
+    // `parentSessionId` — a session wired with parentSessionId but without the
+    // fork-cap field (a shape the manager no longer produces, asserted here as
+    // a pure provider-contract guard) is left uncapped.
+    const provider = new AnthropicDirectProvider({ customTools: [bigTool] });
+    const query = provider.query({
+      prompt: singleInput('call the tool'),
+      config: {
+        model: 'claude-sonnet-5',
+        apiKey: 'sk-ant-oat01-test',
+        parentSessionId: 'parent-session-123',
+        // subagentToolOutputCapBytes intentionally UNSET.
+      },
+    });
+
+    const out = toolOutputOf(await collect(query));
+    expect(out.content).not.toMatch(TRUNC_MARKER);
+    expect(Buffer.byteLength(out.content, 'utf8')).toBe(OVERSIZE_BYTES);
+  });
+});

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -30,7 +30,6 @@ import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { PathGrantManager } from '../../tools/grant-manager.js';
 import { pathContainmentBypassed } from '../../permission-policy.js';
 import { createBuiltinHandlers } from '../../tools/handlers/index.js';
-import { MODEL_CAP_BYTES } from '../../tools/handlers/_output-cap.js';
 import {
   exitPlanModeTool,
   createExitPlanModeHandler,
@@ -241,6 +240,12 @@ export class OpenAICompatibleProvider implements ModelProvider {
           ...(this._sharedWriteRoots !== undefined ? { writeRoots: this._sharedWriteRoots } : {}),
           ...(config.sessionId !== undefined ? { sessionId: config.sessionId } : {}),
           ...(config.parentSessionId !== undefined ? { parentSessionId: config.parentSessionId } : {}),
+          // Fork-scoped central output cap (#661): forwarded from the child
+          // config that forkSubagent stamped, arming maxOutputBytes for forks
+          // only (top-level leaves it unset). Parity with anthropic-direct.
+          ...(config.subagentToolOutputCapBytes !== undefined
+            ? { subagentToolOutputCapBytes: config.subagentToolOutputCapBytes }
+            : {}),
           ...(config.traceWriter !== undefined ? { traceWriter: config.traceWriter } : {}),
           runtimeStateSource,
           ...(config.isSkillDispatch ? { isSkillDispatch: true } : {}),
@@ -354,6 +359,14 @@ export class OpenAICompatibleProvider implements ModelProvider {
       writeRoots?: string[];
       sessionId?: string;
       parentSessionId?: string;
+      /**
+       * Explicit "this session is a forked subagent" signal carrying the
+       * per-result output-cap budget (#661) — parity with
+       * `anthropic-direct/index.ts:buildDispatcher`. Set to MODEL_CAP_BYTES by
+       * `SubagentManager.forkSubagent` for EVERY fork; undefined on a top-level
+       * session. Arms the dispatcher's `maxOutputBytes` backstop declaratively.
+       */
+      subagentToolOutputCapBytes?: number;
       traceWriter?: import('../../trace/index.js').TraceWriter;
       /**
        * Live source for the `get_runtime_state` tool — see the matching
@@ -495,11 +508,16 @@ export class OpenAICompatibleProvider implements ModelProvider {
     if (opts.sessionId !== undefined) dispatcherOpts.sessionId = opts.sessionId;
     if (opts.parentSessionId !== undefined) dispatcherOpts.parentSessionId = opts.parentSessionId;
     // Central output-cap backstop (#661), FORK-SCOPED — parity with
-    // AnthropicDirectProvider.buildDispatcher. `parentSessionId` is set only for
-    // FORKED children; enabling maxOutputBytes exactly then bounds every tool
-    // result at MODEL_CAP_BYTES (100KB) via headAndTail, containing the overflow
-    // crash class for forks while leaving the top-level session uncapped.
-    if (opts.parentSessionId !== undefined) dispatcherOpts.maxOutputBytes = MODEL_CAP_BYTES;
+    // AnthropicDirectProvider.buildDispatcher. Armed from the explicit
+    // `subagentToolOutputCapBytes` signal that `SubagentManager.forkSubagent`
+    // stamps (as MODEL_CAP_BYTES = 100KB) on EVERY forked child; a value here
+    // means "forked child" ⇒ bound each tool result at that budget via
+    // headAndTail, containing the overflow crash class for forks. The top-level
+    // session is built directly (never via forkSubagent), leaves this unset, and
+    // stays UNCAPPED. Replaces the prior `parentSessionId !== undefined` gate,
+    // which missed skill-forked descendants whose parent carries no sessionId.
+    if (opts.subagentToolOutputCapBytes !== undefined)
+      dispatcherOpts.maxOutputBytes = opts.subagentToolOutputCapBytes;
     if (opts.traceWriter !== undefined) dispatcherOpts.traceWriter = opts.traceWriter;
     // Read-only-skill bash gate — parity with anthropic-direct. Forwarded from
     // the provider's construction-time flag so a read-only skill's forked

--- a/src/agent/providers/openai-compatible/index.ts
+++ b/src/agent/providers/openai-compatible/index.ts
@@ -30,6 +30,7 @@ import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { PathGrantManager } from '../../tools/grant-manager.js';
 import { pathContainmentBypassed } from '../../permission-policy.js';
 import { createBuiltinHandlers } from '../../tools/handlers/index.js';
+import { MODEL_CAP_BYTES } from '../../tools/handlers/_output-cap.js';
 import {
   exitPlanModeTool,
   createExitPlanModeHandler,
@@ -493,6 +494,12 @@ export class OpenAICompatibleProvider implements ModelProvider {
     if (opts.writeRoots !== undefined) dispatcherOpts.writeRoots = opts.writeRoots;
     if (opts.sessionId !== undefined) dispatcherOpts.sessionId = opts.sessionId;
     if (opts.parentSessionId !== undefined) dispatcherOpts.parentSessionId = opts.parentSessionId;
+    // Central output-cap backstop (#661), FORK-SCOPED — parity with
+    // AnthropicDirectProvider.buildDispatcher. `parentSessionId` is set only for
+    // FORKED children; enabling maxOutputBytes exactly then bounds every tool
+    // result at MODEL_CAP_BYTES (100KB) via headAndTail, containing the overflow
+    // crash class for forks while leaving the top-level session uncapped.
+    if (opts.parentSessionId !== undefined) dispatcherOpts.maxOutputBytes = MODEL_CAP_BYTES;
     if (opts.traceWriter !== undefined) dispatcherOpts.traceWriter = opts.traceWriter;
     // Read-only-skill bash gate — parity with anthropic-direct. Forwarded from
     // the provider's construction-time flag so a read-only skill's forked

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -25,6 +25,9 @@ import type { OpenAIChunk } from './translate.js';
 import { SessionToolDispatcher } from '../../tools/dispatcher.js';
 import { createHookRegistry, type HookRegistry } from '../../hooks.js';
 import { createPlanModeGate } from '../../plan-mode-gate.js';
+import { tool } from '../../tools/custom-tool.js';
+import { MODEL_CAP_BYTES } from '../../tools/handlers/_output-cap.js';
+import { z } from 'zod';
 import type { AnthropicToolDef } from '../anthropic-direct/types.js';
 import type { ToolHandler } from '../../tools/types.js';
 import { PLAN_MODE_ADDENDUM_TEXT } from '../anthropic-direct/plan-mode-addendum.js';
@@ -460,6 +463,120 @@ describe('OpenAICompatibleProvider — plan-mode gate via config.hookRegistry', 
     if (out?.type === 'tool.output') {
       expect(out.content).not.toContain('plan mode');
       expect(out.content).not.toContain('blocked by PreToolUse hook');
+    }
+  });
+});
+
+describe('OpenAICompatibleProvider — central output cap armed from config.subagentToolOutputCapBytes (#661)', () => {
+  // Parity with anthropic-direct/output-cap-wiring.test.ts. Proves the openai
+  // provider's buildDispatcher arms the dispatcher's maxOutputBytes from the
+  // explicit fork signal (not the leaky parentSessionId), so a forked child's
+  // tool output is bounded while a top-level session is not.
+  const OVERSIZE_BYTES = MODEL_CAP_BYTES + 50_000;
+  const TRUNC_MARKER = /… \[\d+ bytes truncated: showing first \d+ \+ last \d+ of \d+\] …/;
+
+  // Custom tool that returns oversized content, registered on the provider so
+  // it flows through the REAL buildDispatcher path (not a hand-built dispatcher).
+  const bigTool = tool(
+    'big_output',
+    'Returns a large blob of text for output-cap testing.',
+    z.object({}),
+    async () => ({ content: 'A'.repeat(OVERSIZE_BYTES) }),
+  );
+
+  function scriptBigOutputThenDone(): void {
+    installScriptedClient();
+    scriptedTurns = [
+      {
+        chunks: [
+          {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'call_big',
+                      type: 'function',
+                      function: { name: 'big_output', arguments: '{}' },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+            usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+          },
+        ],
+      },
+      {
+        chunks: [
+          {
+            choices: [{ delta: { content: 'done' }, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 10, completion_tokens: 1, total_tokens: 11 },
+          },
+        ],
+      },
+    ];
+  }
+
+  beforeEach(() => {
+    scriptedTurns = [];
+    scriptedTurnIndex = 0;
+  });
+
+  it('CAPS a forked child (subagentToolOutputCapBytes set) even when parentSessionId is UNDEFINED', async () => {
+    scriptBigOutputThenDone();
+    const provider = new OpenAICompatibleProvider({ customTools: [bigTool] });
+    const q = provider.query({
+      prompt: singleInput('call the tool'),
+      // Fork signal present; parentSessionId deliberately ABSENT.
+      config: baseConfig({ subagentToolOutputCapBytes: MODEL_CAP_BYTES }),
+    });
+    const events = await collect(q);
+
+    const out = events.find((e) => e.type === 'tool.output');
+    expect(out?.type).toBe('tool.output');
+    if (out?.type === 'tool.output') {
+      expect(out.content).toMatch(TRUNC_MARKER);
+      expect(Buffer.byteLength(out.content, 'utf8')).toBeLessThanOrEqual(MODEL_CAP_BYTES);
+    }
+  });
+
+  it('does NOT cap a top-level session (no subagentToolOutputCapBytes, no parentSessionId)', async () => {
+    scriptBigOutputThenDone();
+    const provider = new OpenAICompatibleProvider({ customTools: [bigTool] });
+    const q = provider.query({
+      prompt: singleInput('call the tool'),
+      config: baseConfig(),
+    });
+    const events = await collect(q);
+
+    const out = events.find((e) => e.type === 'tool.output');
+    expect(out?.type).toBe('tool.output');
+    if (out?.type === 'tool.output') {
+      expect(out.content).not.toMatch(TRUNC_MARKER);
+      expect(Buffer.byteLength(out.content, 'utf8')).toBe(OVERSIZE_BYTES);
+    }
+  });
+
+  it('does NOT cap when only parentSessionId is set (proves the cap no longer keys on parentSessionId)', async () => {
+    scriptBigOutputThenDone();
+    const provider = new OpenAICompatibleProvider({ customTools: [bigTool] });
+    const q = provider.query({
+      prompt: singleInput('call the tool'),
+      // parentSessionId set, but the explicit fork-cap signal is NOT.
+      config: baseConfig({ parentSessionId: 'parent-session-123' }),
+    });
+    const events = await collect(q);
+
+    const out = events.find((e) => e.type === 'tool.output');
+    expect(out?.type).toBe('tool.output');
+    if (out?.type === 'tool.output') {
+      expect(out.content).not.toMatch(TRUNC_MARKER);
+      expect(Buffer.byteLength(out.content, 'utf8')).toBe(OVERSIZE_BYTES);
     }
   });
 });

--- a/src/agent/subagent-output-cap.test.ts
+++ b/src/agent/subagent-output-cap.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression tests for the fork-scoped central output-cap signal (#661).
+ *
+ * Background:
+ *   The #661 backstop bounds EVERY tool result at MODEL_CAP_BYTES (100KB) for
+ *   forked subagents, containing the tool-output-overflow crash class (MCP
+ *   dumps, browser output, read_file of a huge file). The provider arms the
+ *   dispatcher's `maxOutputBytes` from a signal on the child AgentConfig.
+ *
+ *   The ORIGINAL wiring keyed that signal on `parentSessionId !== undefined`.
+ *   That gate is LEAKY: `parentSessionId` is undefined for forks whose parent
+ *   carries no sessionId — the skill-fork path builds its nested executor with
+ *   `createStubParentSession` (`{ sessionId: undefined }`, nesting.ts:66) and
+ *   never backfills the id, so a subagent dispatched by a skill-forked child
+ *   (grandchildren and deeper) had `parentSessionId: undefined` and the cap was
+ *   NOT armed — leaving those descendants exposed to the overflow crash class.
+ *
+ *   The fix replaces that heuristic with an EXPLICIT value-carrying field,
+ *   `AgentConfig.subagentToolOutputCapBytes`, that `SubagentManager.forkSubagent`
+ *   — the single choke point for the agent-tool, skill, and compose fork paths —
+ *   stamps UNCONDITIONALLY (as MODEL_CAP_BYTES) on every child config. The
+ *   top-level session is built via `new AgentSession(...)` directly at the entry
+ *   points (never through forkSubagent), so it never carries the field and is
+ *   never capped.
+ *
+ * These tests pin two claims:
+ *   (1) forkSubagent stamps `subagentToolOutputCapBytes = MODEL_CAP_BYTES` on
+ *       the child config EVEN when the parent is a stub (`sessionId: undefined`)
+ *       — the exact case the old `parentSessionId` gate missed.
+ *   (2) The field is set ONLY by the fork path, so a top-level (non-forked)
+ *       session leaves it undefined ⇒ dispatcher `maxOutputBytes` unset ⇒ no
+ *       central capping (behavior unchanged).
+ *
+ * Companion: dispatcher.test.ts proves `maxOutputBytes` → head+tail truncation;
+ * this file proves the fork → `subagentToolOutputCapBytes` → provider wiring
+ * that ARMS it. Provider-level arming (config field → dispatcher option) is
+ * covered by the buildDispatcher parity assertions below.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Message } from './types.js';
+
+type CapturedConfig = Record<string, unknown> | null;
+
+const shared = vi.hoisted(() => ({
+  lastConfig: null as CapturedConfig,
+}));
+
+vi.mock('./session.js', () => {
+  class MockAgentSession {
+    public readonly sessionId?: string;
+    public sendMessage: ReturnType<typeof vi.fn>;
+    public sendMessageStream: ReturnType<typeof vi.fn>;
+    public interrupt = vi.fn(async () => undefined);
+    public close = vi.fn(async () => undefined);
+    constructor(config: Record<string, unknown>) {
+      shared.lastConfig = config;
+      // Mirror the stub-parent case: the child resumes no parent sessionId, so
+      // the constructed session's own id is a fresh manager-side value (a real
+      // AgentSession would mint one). The key assertion is on the CONFIG, not
+      // this id.
+      this.sessionId = (config.sessionId as string | undefined) ?? 'child-session-id';
+      this.sendMessage = vi.fn(async (content: string): Promise<Message> => ({
+        role: 'assistant',
+        content: `ok:${content}`,
+        timestamp: new Date(),
+      }));
+      this.sendMessageStream = vi.fn(async function* (this: MockAgentSession, content: string) {
+        const result = await this.sendMessage(content);
+        yield { type: 'message', message: result };
+        yield { type: 'done' };
+      }.bind(this));
+    }
+    get abortSignal(): AbortSignal {
+      return new AbortController().signal;
+    }
+  }
+  return { AgentSession: MockAgentSession };
+});
+
+import { SubagentManager } from './subagent.js';
+import { MODEL_CAP_BYTES } from './tools/handlers/_output-cap.js';
+
+describe('forkSubagent — fork-scoped central output-cap signal (#661)', () => {
+  it('stamps subagentToolOutputCapBytes = MODEL_CAP_BYTES on a fork with a STUB parent (sessionId: undefined)', async () => {
+    // This is the leaky-gate case: the skill-fork path forks off a stub parent
+    // whose sessionId is undefined (createStubParentSession). The OLD gate keyed
+    // the cap on `parentSessionId !== undefined`, so this fork was left uncapped.
+    shared.lastConfig = null;
+    const mgr = new SubagentManager();
+    await mgr.forkSubagent({
+      // Stub parent — exactly what fork-child-config.ts passes for skill forks.
+      parent: { sessionId: undefined },
+      config: { model: 'sonnet', apiKey: 'k' },
+    });
+
+    const childConfig = shared.lastConfig;
+    expect(childConfig).not.toBeNull();
+    // The explicit fork-cap signal is present regardless of the parent's id.
+    expect(childConfig?.subagentToolOutputCapBytes).toBe(MODEL_CAP_BYTES);
+    // And the leaky heuristic it replaced is genuinely absent here: no
+    // parentSessionId was derivable from the stub parent, so a gate keyed on it
+    // would NOT have armed the cap.
+    expect(childConfig?.parentSessionId).toBeUndefined();
+  });
+
+  it('stamps subagentToolOutputCapBytes = MODEL_CAP_BYTES on a fork with a REAL parent too (unconditional)', async () => {
+    // The agent-tool path forks off a parent that DOES carry a sessionId. The
+    // signal must be set here as well — it is stamped unconditionally, so both
+    // the previously-covered case and the previously-leaky case are now capped.
+    shared.lastConfig = null;
+    const mgr = new SubagentManager();
+    await mgr.forkSubagent({
+      parent: { sessionId: 'parent-session-abc' },
+      config: { model: 'sonnet', apiKey: 'k' },
+    });
+
+    const childConfig = shared.lastConfig;
+    expect(childConfig?.subagentToolOutputCapBytes).toBe(MODEL_CAP_BYTES);
+    // Sanity: the fork DID derive a parentSessionId here (real parent) — so
+    // this is the case the old gate already covered; it stays covered.
+    expect(childConfig?.parentSessionId).toBe('parent-session-abc');
+  });
+
+  it('a caller-supplied subagentToolOutputCapBytes does NOT override the fork backstop', async () => {
+    // The cap is a non-negotiable fork backstop: forkSubagent sets it AFTER the
+    // `...options.config` spread, so a caller cannot weaken/disable it by
+    // passing their own value on config.
+    shared.lastConfig = null;
+    const mgr = new SubagentManager();
+    await mgr.forkSubagent({
+      parent: { sessionId: undefined },
+      // Attempt to disable the cap via a bogus caller value.
+      config: { model: 'sonnet', apiKey: 'k', subagentToolOutputCapBytes: 0 },
+    });
+
+    const childConfig = shared.lastConfig;
+    expect(childConfig?.subagentToolOutputCapBytes).toBe(MODEL_CAP_BYTES);
+  });
+});

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -40,6 +40,7 @@ import { computeInheritedReadRoots, type ReadScopeInputs } from './subagent-read
 import { getAfkStateDir } from '../paths.js';
 import { env } from '../config/env.js';
 import { buildPhaseRestrictedProvider, type PhaseRole } from './tools/nesting.js';
+import { MODEL_CAP_BYTES } from './tools/handlers/_output-cap.js';
 import { applyManagerApiKeyFallback } from './tools/child-credential.js';
 import { providerForModel, type BundledProviderName } from './providers/index.js';
 import {
@@ -681,6 +682,23 @@ export class SubagentManager {
       // trace file, so without this tag the parent trace cannot say which fork
       // ran which tool (issue #612).
       subagentId: id,
+      // Central output-cap signal (#661), stamped UNCONDITIONALLY on EVERY
+      // fork. forkSubagent is the single choke point through which the
+      // agent-tool, skill, and compose paths all create their child session
+      // (subagent-executor.ts, skill-executor/fork-dispatch.ts, and
+      // dag-subagent.ts all converge here), and the top-level session is always
+      // built via `new AgentSession(...)` directly at the entry points — never
+      // here — so this value marks "forked child" and its absence marks
+      // "top-level". The provider's buildDispatcher arms the dispatcher's
+      // `maxOutputBytes` backstop from this field, bounding every tool result
+      // at MODEL_CAP_BYTES (100KB) via headAndTail and containing the
+      // tool-output-overflow crash class (#661) for ALL forks — including
+      // skill-forked descendants whose `parentSessionId` is undefined (a stub
+      // parent carries no sessionId), which the prior `parentSessionId`-keyed
+      // gate left uncapped. Set here (not left to the `...options.config`
+      // spread) so it cannot be omitted by any fork path; a caller override is
+      // intentionally NOT honored — the cap is a non-negotiable fork backstop.
+      subagentToolOutputCapBytes: MODEL_CAP_BYTES,
       abortSignal: childController.signal,
       // Invariant (cross-provider credential anti-leak): the parent-credential
       // fallback below must never hand a credential across the provider

--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -1618,3 +1618,107 @@ describe('SessionToolDispatcher — canUseTool (Dim 8 in-process permission poli
     expect(writer.events.filter((e) => e.kind === 'hook_decision')).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// maxOutputBytes — central fork-scoped output-cap backstop (#661)
+//
+// A forked child's dispatcher is constructed with maxOutputBytes set (to
+// MODEL_CAP_BYTES) so EVERY tool result — MCP bridges, browser dumps,
+// read_file of a huge file — is bounded before it re-enters the child's
+// context, containing the whole overflow crash class. The top-level session
+// leaves maxOutputBytes undefined ⇒ no central capping ⇒ behavior unchanged.
+// ---------------------------------------------------------------------------
+
+describe('SessionToolDispatcher — maxOutputBytes central output cap (#661)', () => {
+  const TRUNC_MARKER = /… \[\d+ bytes truncated: showing first \d+ \+ last \d+ of \d+\] …/;
+
+  /** A handler that returns `content` of a caller-chosen size. */
+  function bigContentHandler(bytes: number): ToolHandler {
+    return async () => ({ content: 'A'.repeat(bytes) });
+  }
+
+  function makeCapDispatcher(
+    handler: ToolHandler,
+    maxOutputBytes: number | undefined,
+  ): SessionToolDispatcher {
+    return new SessionToolDispatcher({
+      handlers: new Map([['big', handler]]),
+      schemas: [],
+      permissions: { allowedTools: ['big'] },
+      ...(maxOutputBytes !== undefined ? { maxOutputBytes } : {}),
+    });
+  }
+
+  it('truncates an over-budget tool result and sets truncated:true when maxOutputBytes is set', async () => {
+    const d = makeCapDispatcher(bigContentHandler(5000), 500);
+    const r = await d.execute(makeCall({ name: 'big', input: {} }));
+    expect(r.isError).toBeUndefined();
+    expect(r.truncated).toBe(true);
+    expect(r.content).toMatch(TRUNC_MARKER);
+    // Output bounded by the cap (marker reserve makes it slightly under).
+    expect(Buffer.byteLength(r.content, 'utf8')).toBeLessThanOrEqual(500);
+    // Head is preserved (head+tail, not a tail-only slice).
+    expect(r.content.startsWith('A')).toBe(true);
+  });
+
+  it('leaves content untouched (no truncated flag) when maxOutputBytes is undefined', async () => {
+    const original = 'A'.repeat(5000);
+    const d = makeCapDispatcher(bigContentHandler(5000), undefined);
+    const r = await d.execute(makeCall({ name: 'big', input: {} }));
+    expect(r.content).toBe(original);
+    expect(r.content).not.toMatch(TRUNC_MARKER);
+    expect(r.truncated).toBeUndefined();
+  });
+
+  it('does NOT truncate content already within the cap (idempotent, no double-truncation)', async () => {
+    const small = 'A'.repeat(50);
+    const d = makeCapDispatcher(bigContentHandler(50), 500);
+    const r = await d.execute(makeCall({ name: 'big', input: {} }));
+    expect(r.content).toBe(small);
+    expect(r.truncated).toBeUndefined();
+  });
+
+  it('preserves result.image while capping the text content', async () => {
+    const withImage: ToolHandler = async () => ({
+      content: 'A'.repeat(5000),
+      image: { mediaType: 'image/png' as const, data: 'BASE64DATA' },
+    });
+    const d = makeCapDispatcher(withImage, 500);
+    const r = await d.execute(makeCall({ name: 'big', input: {} }));
+    expect(r.truncated).toBe(true);
+    expect(r.content).toMatch(TRUNC_MARKER);
+    // The screenshot rides through untouched — the cap governs text only.
+    expect(r.image).toEqual({ mediaType: 'image/png', data: 'BASE64DATA' });
+  });
+
+  it('caps over-budget results dispatched through executeBatch too (shared executeCore path)', async () => {
+    // Two safe calls in one batch → executeBatch → executeCore per call, so the
+    // cap must apply on the batched path exactly as on the single-call path.
+    const d = new SessionToolDispatcher({
+      handlers: new Map([['big', bigContentHandler(5000)]]),
+      schemas: [{ name: 'big', input_schema: { type: 'object' }, concurrencySafe: true }],
+      permissions: { allowedTools: ['big'] },
+      maxOutputBytes: 500,
+    });
+    const results = await d.executeBatch([
+      makeCall({ id: 'a', name: 'big', input: {} }),
+      makeCall({ id: 'b', name: 'big', input: {} }),
+    ]);
+    expect(results).toHaveLength(2);
+    for (const r of results) {
+      expect(r.truncated).toBe(true);
+      expect(r.content).toMatch(TRUNC_MARKER);
+      expect(Buffer.byteLength(r.content, 'utf8')).toBeLessThanOrEqual(500);
+    }
+  });
+
+  it('ignores non-positive / non-finite maxOutputBytes (cap stays off)', async () => {
+    const original = 'A'.repeat(5000);
+    for (const bad of [0, -100, Number.NaN]) {
+      const d = makeCapDispatcher(bigContentHandler(5000), bad);
+      const r = await d.execute(makeCall({ name: 'big', input: {} }));
+      expect(r.content).toBe(original);
+      expect(r.truncated).toBeUndefined();
+    }
+  });
+});

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -25,6 +25,7 @@ import type { ToolHandler, ToolHandlerContext, ConcurrencyClassifier } from './t
 import { checkToolPermission, type ToolPermissionConfig } from './permissions.js';
 import type { CanUseTool, PermissionResult } from '../types/sdk-types.js';
 import { classifyBashCommand } from './readonly-bash.js';
+import { headAndTail } from './handlers/_output-cap.js';
 import { PathGrantManager, type GrantSnapshot } from './grant-manager.js';
 import type { GrantManager } from '../../cli/slash/commands/allow-dir.js';
 import { emitHookDecision } from '../trace/emit.js';
@@ -179,6 +180,24 @@ export interface SessionToolDispatcherOptions {
    * Defaults to false.
    */
   readOnlyBash?: boolean;
+  /**
+   * Central per-result output cap, in UTF-8 bytes. When set, `executeCore`
+   * reduces any tool result whose `content` exceeds this to head+tail via
+   * {@link headAndTail} (and stamps `truncated: true`) as the FINAL step before
+   * returning — a crash-class backstop that bounds EVERY tool's output (MCP
+   * bridges, browser dumps, read_file of a huge file, …), not just the ones
+   * that self-cap. Idempotent: content already within budget (e.g. web_scrape
+   * already capped it) is returned unchanged, so there is no double-truncation.
+   * Never touches `result.image`.
+   *
+   * Fork-scoped by design: the SubagentManager/provider path sets this to
+   * {@link import('./handlers/_output-cap.js').MODEL_CAP_BYTES} for FORKED
+   * children only (keyed on `parentSessionId`). The TOP-LEVEL session leaves it
+   * `undefined` ⇒ no central capping ⇒ behavior unchanged. Because a forked
+   * child that overflows its context window crashes the whole turn (issue #661),
+   * containing the class at the child dispatcher is the narrow, high-value fix.
+   */
+  maxOutputBytes?: number;
 }
 
 export class SessionToolDispatcher implements ToolDispatcher {
@@ -227,6 +246,13 @@ export class SessionToolDispatcher implements ToolDispatcher {
   private readonly traceWriter: TraceWriter | undefined;
   /** When true, mutating `bash` commands are blocked (read-only skill child). */
   private readonly readOnlyBash: boolean;
+  /**
+   * Central per-result output byte cap (see
+   * {@link SessionToolDispatcherOptions.maxOutputBytes}). `undefined` ⇒ no
+   * central capping (top-level default). Set to MODEL_CAP_BYTES for forked
+   * children so the whole tool-output-overflow crash class is contained (#661).
+   */
+  private readonly maxOutputBytes: number | undefined;
   /**
    * Repeat-loop circuit breaker state. The dispatcher is built per `query()`,
    * so this naturally tracks CONSECUTIVE byte-identical calls within a single
@@ -278,6 +304,15 @@ export class SessionToolDispatcher implements ToolDispatcher {
     this.sessionGrantManager = opts.sessionGrantManager;
     this.traceWriter = opts.traceWriter;
     this.readOnlyBash = opts.readOnlyBash === true;
+    // Central output cap: only a positive finite number arms the backstop; any
+    // other value (undefined, 0, negative, NaN) leaves it off — matching the
+    // top-level default of "no central capping".
+    this.maxOutputBytes =
+      typeof opts.maxOutputBytes === 'number' &&
+      Number.isFinite(opts.maxOutputBytes) &&
+      opts.maxOutputBytes > 0
+        ? opts.maxOutputBytes
+        : undefined;
     this._allowAll = opts.allowAll === true;
 
     // When caller passes arrays by reference (provider sharing pattern), use
@@ -940,11 +975,54 @@ export class SessionToolDispatcher implements ToolDispatcher {
   }
 
   /**
-   * Core execution: agent routing + handler dispatch + PostToolUse hook.
-   * Shared by both `execute()` (single-tool path) and `executeBatch()`
-   * (after pre-hooks and permissions are already handled).
+   * Core execution + central output-cap backstop. The single result path both
+   * `execute()` and `executeBatch()` call per tool, so applying the cap here
+   * (after {@link executeCoreInner} has run the handler AND fired PostToolUse)
+   * bounds EVERY tool result exactly once, regardless of which entry path
+   * dispatched it. See {@link SessionToolDispatcherOptions.maxOutputBytes}.
+   *
+   * Ordering rationale: the cap is applied AFTER `executeCoreInner` returns —
+   * i.e. after PostToolUse has already observed the full, uncapped `content`
+   * (fired fire-and-forget inside the inner method). Hooks and the model see
+   * consistent truncation: the model-facing `content` is the capped view, and
+   * `truncated: true` is the structured signal for non-model consumers.
    */
   private async executeCore(call: ToolCall): Promise<ToolResult> {
+    const result = await this.executeCoreInner(call);
+    return this.applyOutputCap(result);
+  }
+
+  /**
+   * Reduce `result.content` to head+tail when a central `maxOutputBytes` cap is
+   * armed AND the content exceeds it; otherwise return the result untouched.
+   *
+   * - No-op when `this.maxOutputBytes` is undefined (top-level default) or the
+   *   content already fits — {@link headAndTail} itself returns short input
+   *   byte-for-byte, so this is idempotent and never double-truncates content a
+   *   handler (e.g. web_scrape) already capped.
+   * - NEVER touches `result.image`: the cap governs the text budget only; an
+   *   attached screenshot rides through unchanged.
+   * - Mutates and returns the same object (results are freshly constructed per
+   *   call, never shared), setting `truncated: true` — the same structured flag
+   *   bash/web_scrape set — so trace/hook consumers need not scan `content`.
+   */
+  private applyOutputCap(result: ToolResult): ToolResult {
+    const cap = this.maxOutputBytes;
+    if (cap === undefined) return result;
+    if (Buffer.byteLength(result.content, 'utf8') <= cap) return result;
+    result.content = headAndTail(result.content, cap);
+    result.truncated = true;
+    return result;
+  }
+
+  /**
+   * Core execution: agent routing + handler dispatch + PostToolUse hook.
+   * Shared by both `execute()` (single-tool path) and `executeBatch()`
+   * (after pre-hooks and permissions are already handled). Wrapped by
+   * {@link executeCore}, which applies the central output-cap backstop to
+   * whatever result this returns.
+   */
+  private async executeCoreInner(call: ToolCall): Promise<ToolResult> {
     // Agent tool — provider-level dispatch
     if (call.name === 'agent') {
       if (!this.subagentExecutor) {

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -1009,9 +1009,25 @@ export class SessionToolDispatcher implements ToolDispatcher {
   private applyOutputCap(result: ToolResult): ToolResult {
     const cap = this.maxOutputBytes;
     if (cap === undefined) return result;
-    if (Buffer.byteLength(result.content, 'utf8') <= cap) return result;
+    const originalBytes = Buffer.byteLength(result.content, 'utf8');
+    if (originalBytes <= cap) return result;
     result.content = headAndTail(result.content, cap);
     result.truncated = true;
+    // Observability (#661): fork-side truncation is otherwise invisible — the
+    // `truncated` flag is a structured signal for downstream consumers, but the
+    // ORIGINAL-vs-capped byte delta (how much a fork's tool actually
+    // overflowed) is dropped. Emit it via the file's existing lightweight
+    // logger (debugLog, gated on AFK_DEBUG/DEBUG). Deliberately NOT a witness
+    // trace event: no existing trace kind carries an original+capped byte pair,
+    // and adding one would expand the closed trace schema (types.ts + events.ts
+    // zod union + tests) for a non-blocking diagnostic — out of scope here. The
+    // per-call `tool_call.completed` trace event already records the final
+    // (capped) `resultBytes` + `truncated`; this line adds the original size
+    // the cap ate, which that event does not carry.
+    debugLog(
+      `[output-cap #661] fork tool result capped: original=${originalBytes}B ` +
+        `capped=${Buffer.byteLength(result.content, 'utf8')}B (cap=${cap}B)`,
+    );
     return result;
   }
 

--- a/src/agent/tools/handlers/web-scrape.test.ts
+++ b/src/agent/tools/handlers/web-scrape.test.ts
@@ -283,31 +283,77 @@ describe('web_scrape handler — search mode (Exa)', () => {
 });
 
 describe('web_scrape handler — truncation', () => {
-  it('truncates body exceeding max_bytes and appends a marker (raw mode)', async () => {
+  // The shared headAndTail primitive emits `… [N bytes truncated: …] …` and
+  // keeps BOTH ends, so truncation is asserted via the marker + the fact that
+  // the head is preserved (not a trailing-only slice).
+  const TRUNC_MARKER = /… \[\d+ bytes truncated: showing first \d+ \+ last \d+ of \d+\] …/;
+
+  it('truncates body exceeding max_bytes to head+tail with a marker and truncated:true (raw mode)', async () => {
     const big = 'x'.repeat(5000);
     const fetchFn = makeFetch(() => makeResponse({ body: big }));
     const handler = createWebScrapeHandler({ fetchFn, env: {} });
-    const r = await handler({ mode: 'raw', url: 'https://example.com', max_bytes: 100 }, signal());
+    // 500 > the marker's ~160-byte reserve, so head AND tail are non-empty and
+    // head-preservation is observable (a cap below the reserve degenerates to
+    // marker-only, which is a headAndTail edge case, not what we assert here).
+    const r = await handler({ mode: 'raw', url: 'https://example.com', max_bytes: 500 }, signal());
     expect(r.isError).toBeUndefined();
-    expect(r.content).toMatch(/\[…truncated by agent-afk web_scrape\]$/);
-    expect(r.content.startsWith('x'.repeat(100))).toBe(true);
+    expect(r.content).toMatch(TRUNC_MARKER);
+    expect(r.truncated).toBe(true);
+    // Output is bounded by max_bytes (marker reserve makes it slightly under).
+    expect(Buffer.byteLength(r.content, 'utf8')).toBeLessThanOrEqual(500);
+    // Head is preserved (starts with the original leading bytes) — head+tail,
+    // not a tail-only slice.
+    expect(r.content.startsWith('x')).toBe(true);
   });
 
-  it('does NOT truncate body smaller than max_bytes', async () => {
+  it('does NOT truncate body smaller than max_bytes (no marker, no truncated flag)', async () => {
     const small = 'hello world';
     const fetchFn = makeFetch(() => makeResponse({ body: small }));
     const handler = createWebScrapeHandler({ fetchFn, env: {} });
     const r = await handler({ mode: 'raw', url: 'https://example.com', max_bytes: 1000 }, signal());
     expect(r.content).toBe(small);
+    expect(r.truncated).toBeUndefined();
   });
 
-  it('handles multi-byte UTF-8 cleanly (no garbage at the cut point)', async () => {
-    const body = '🎉'.repeat(10);
+  it('handles multi-byte UTF-8 cleanly (no garbage at the cut points)', async () => {
+    const body = '🎉'.repeat(200); // 800 bytes; cut at 200 keeps head+tail of whole emoji
     const fetchFn = makeFetch(() => makeResponse({ body }));
     const handler = createWebScrapeHandler({ fetchFn, env: {} });
-    const r = await handler({ mode: 'raw', url: 'https://example.com', max_bytes: 6 }, signal());
+    const r = await handler({ mode: 'raw', url: 'https://example.com', max_bytes: 200 }, signal());
+    // Head begins on a code-point boundary and the tail ends on one — no U+FFFD.
     expect(r.content.startsWith('🎉')).toBe(true);
-    expect(r.content).toMatch(/\[…truncated by agent-afk web_scrape\]$/);
+    expect(r.content.endsWith('🎉')).toBe(true);
+    expect(r.content).not.toContain('\uFFFD');
+    expect(r.content).toMatch(TRUNC_MARKER);
+    expect(r.truncated).toBe(true);
+  });
+
+  it('truncates a body larger than the DEFAULT max_bytes to <= default with a marker and truncated:true', async () => {
+    // No explicit max_bytes → the 100KB default applies. A 150KB body must be
+    // reduced below the default so a default web_scrape can never overflow a
+    // (sub)agent context window (issue #661).
+    const big = 'y'.repeat(150_000);
+    const fetchFn = makeFetch(() => makeResponse({ body: big }));
+    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const r = await handler({ mode: 'raw', url: 'https://example.com' }, signal());
+    expect(r.isError).toBeUndefined();
+    expect(r.truncated).toBe(true);
+    expect(r.content).toMatch(TRUNC_MARKER);
+    expect(Buffer.byteLength(r.content, 'utf8')).toBeLessThanOrEqual(100_000);
+  });
+
+  it('clamps an explicit max_bytes above the 1MB ceiling down to 1MB', async () => {
+    // Request 5MB (above the 1MB hard ceiling). A ~2MB body must therefore be
+    // truncated to <= 1MB rather than passed through — this is the exact class
+    // of caller-raised cap that let a 4MB body crash a child before #661.
+    const twoMb = 'z'.repeat(2_000_000);
+    const fetchFn = makeFetch(() => makeResponse({ body: twoMb }));
+    const handler = createWebScrapeHandler({ fetchFn, env: {} });
+    const r = await handler({ mode: 'raw', url: 'https://example.com', max_bytes: 5_000_000 }, signal());
+    expect(r.isError).toBeUndefined();
+    expect(r.truncated).toBe(true);
+    expect(r.content).toMatch(TRUNC_MARKER);
+    expect(Buffer.byteLength(r.content, 'utf8')).toBeLessThanOrEqual(1_000_000);
   });
 });
 

--- a/src/agent/tools/handlers/web-scrape.ts
+++ b/src/agent/tools/handlers/web-scrape.ts
@@ -34,6 +34,7 @@ import { scrapeToMarkdown } from '../../../web/scrape.js';
 import { resolveSearchBackend, formatSearchResults } from '../../../web/search.js';
 import { retryFetch } from '../../../web/retryFetch.js';
 import type { RenderFn } from '../../../web/types.js';
+import { headAndTail } from './_output-cap.js';
 
 // External constraint: Node 20+ ships `fetch` as a global. Older runtimes
 // would throw before reaching this handler because tsconfig targets >=20.
@@ -41,9 +42,16 @@ type FetchFn = typeof fetch;
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_TIMEOUT_MS = 120_000;
-const DEFAULT_MAX_BYTES = 1_000_000; // 1 MB
-const MAX_MAX_BYTES = 10_000_000; // 10 MB hard ceiling
-const TRUNC_MARKER = '\n\n[…truncated by agent-afk web_scrape]';
+// Default model-facing byte budget (100KB). Aligned with MODEL_CAP_BYTES so a
+// default web_scrape can never overflow a (sub)agent context window the way a
+// 1MB body could (~286K tokens > 200K/1M limits — see issue #661). `max_bytes`
+// remains a real, caller-overridable knob within the ceiling below.
+const DEFAULT_MAX_BYTES = 100_000; // 100 KB
+// Hard ceiling on any caller-supplied `max_bytes` (1MB). A caller that raised
+// this toward the old 10MB ceiling let a ~4MB body through, translating to
+// >1M tokens and crashing the child (#661); 1MB caps the worst case well under
+// even the smallest context window.
+const MAX_MAX_BYTES = 1_000_000; // 1 MB hard ceiling
 const DEFAULT_SEARCH_LIMIT = 10;
 
 // Hints in a thrown error message that mean the optional Playwright peer dep
@@ -132,14 +140,20 @@ function parseInput(raw: unknown): ParsedInput | { error: string } {
   return { mode, url, query, timeoutMs, maxBytes };
 }
 
-function truncateUtf8(body: string, maxBytes: number): string {
-  // External constraint: maxBytes is a UTF-8 byte ceiling, but `.subarray()`
-  // can split a multi-byte sequence. Convert to Buffer, slice, decode with
-  // 'utf8' which replaces a partial trailing code point with U+FFFD rather
-  // than emitting garbage.
-  const buf = Buffer.from(body, 'utf8');
-  if (buf.byteLength <= maxBytes) return body;
-  return buf.subarray(0, maxBytes).toString('utf8') + TRUNC_MARKER;
+/**
+ * Cap `body` to at most `maxBytes` UTF-8 bytes for model consumption via the
+ * shared {@link headAndTail} primitive (keeps head+tail with an explicit
+ * `… [N bytes truncated: …] …` marker, UTF-8 safe at both cut points). Returns
+ * the capped content plus a `truncated` flag the caller plumbs onto
+ * `ToolResult.truncated` — the structured signal non-model consumers read
+ * instead of substring-scanning `content`. Idempotent: content already within
+ * budget is returned byte-for-byte unchanged with `truncated: false`.
+ */
+function capBody(body: string, maxBytes: number): { content: string; truncated: boolean } {
+  if (Buffer.byteLength(body, 'utf8') <= maxBytes) {
+    return { content: body, truncated: false };
+  }
+  return { content: headAndTail(body, maxBytes), truncated: true };
 }
 
 /** Did this error (or its cause chain) signal a missing Playwright install? */
@@ -236,7 +250,8 @@ export function createWebScrapeHandler(opts: WebScrapeOptions = {}): ToolHandler
             isError: true,
           };
         }
-        return { content: truncateUtf8(body, parsed.maxBytes) };
+        const capped = capBody(body, parsed.maxBytes);
+        return { content: capped.content, ...(capped.truncated ? { truncated: true } : {}) };
       }
 
       // ---- markdown mode: fetch-first scrape + render escalation ------------
@@ -254,7 +269,8 @@ export function createWebScrapeHandler(opts: WebScrapeOptions = {}): ToolHandler
               isError: true,
             };
           }
-          return { content: truncateUtf8(result.markdown, parsed.maxBytes) };
+          const capped = capBody(result.markdown, parsed.maxBytes);
+          return { content: capped.content, ...(capped.truncated ? { truncated: true } : {}) };
         } catch (err) {
           if (ac.signal.aborted) return { content: `web_scrape aborted: ${abortMessage()}`, isError: true };
           const base = err instanceof Error ? err.message : String(err);
@@ -279,7 +295,8 @@ export function createWebScrapeHandler(opts: WebScrapeOptions = {}): ToolHandler
           timeoutMs: parsed.timeoutMs,
           signal: ac.signal,
         });
-        return { content: truncateUtf8(formatSearchResults(parsed.query!, results), parsed.maxBytes) };
+        const capped = capBody(formatSearchResults(parsed.query!, results), parsed.maxBytes);
+        return { content: capped.content, ...(capped.truncated ? { truncated: true } : {}) };
       } catch (err) {
         if (ac.signal.aborted) return { content: `web_scrape aborted: ${abortMessage()}`, isError: true };
         return {

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -265,8 +265,10 @@ export const webScrapeTool: AnthropicToolDef = {
     'you need to FIND a URL, not read one. Provide `query` instead of `url`. ' +
     'Requires `EXA_API_KEY` (free tier at https://exa.ai); ' +
     'the handler returns a clear error if it is unset.\n\n' +
-    'Outputs are capped at `max_bytes` UTF-8 bytes (default 1MB, ceiling 10MB) ' +
-    'and the request is aborted after `timeout_ms` (default 30000, ceiling 120000).',
+    'Outputs are capped at `max_bytes` UTF-8 bytes (default 100KB, ceiling 1MB); ' +
+    'content over the cap is reduced to head+tail with a `… [N bytes truncated: …] …` ' +
+    'marker so both ends survive. The request is aborted after `timeout_ms` ' +
+    '(default 30000, ceiling 120000).',
   input_schema: {
     type: 'object',
     properties: {
@@ -291,8 +293,8 @@ export const webScrapeTool: AnthropicToolDef = {
       max_bytes: {
         type: 'number',
         description:
-          'Maximum UTF-8 bytes returned. Content beyond this is truncated with a marker. ' +
-          'Default 1000000, clamped to 10000000.',
+          'Maximum UTF-8 bytes returned. Content beyond this is reduced to head+tail ' +
+          'with a truncation marker (both ends preserved). Default 100000, clamped to 1000000.',
       },
     },
     required: [],

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -540,6 +540,31 @@ export interface AgentConfig {
    */
   subagentId?: string;
 
+  /**
+   * Central per-result tool-output byte cap for THIS session's dispatcher, in
+   * UTF-8 bytes (#661). Set UNCONDITIONALLY to {@link
+   * import('../tools/handlers/_output-cap.js').MODEL_CAP_BYTES} by
+   * `SubagentManager.forkSubagent` for EVERY forked child — the single choke
+   * point through which the agent-tool, skill, and compose fork paths all
+   * create their child session — so the provider's `buildDispatcher` can arm
+   * the dispatcher's `maxOutputBytes` backstop declaratively from this value.
+   *
+   * This is the explicit "I am a forked subagent" signal that REPLACES the
+   * prior `parentSessionId !== undefined` heuristic: `parentSessionId` is
+   * undefined for forks whose parent carries no sessionId (a skill-forked
+   * child built with `createStubParentSession`, plus every subagent it in turn
+   * dispatches), so keying the cap on it left those descendants uncapped and
+   * exposed to the tool-output-overflow crash class. Because `forkSubagent` is
+   * the sole path to a child `AgentSession` and the top-level session is
+   * ALWAYS constructed via `new AgentSession(...)` directly at the entry
+   * points (never through `forkSubagent`), a value here means "forked child"
+   * and its absence means "top-level" — so the top-level session is never
+   * capped. Fork-only, like `subagentId`/`depth`/`isNonInteractive` above;
+   * undefined on a top-level session ⇒ dispatcher `maxOutputBytes` unset ⇒ no
+   * central capping (behavior unchanged).
+   */
+  subagentToolOutputCapBytes?: number;
+
   /** Nesting depth assigned at fork (0-indexed). Top-level → undefined. */
   depth?: number;
 


### PR DESCRIPTION
Fixes #661

## Root cause

`web_scrape` could load a response large enough to overflow a (sub)agent's context window and crash it (observed: a ~4MB JSON body → 1,065,401 tokens > 1,000,000 limit). The tool's byte-cap default (1MB) and ceiling (10MB) translated to token counts (≈286K / ≈2.5M) that exceed context windows, and a caller that raised `max_bytes` toward the 10MB ceiling let a 4MB body straight through. More broadly, this is a **generic crash class**: the dispatcher pushes every tool result's `content` verbatim into the next model request with no size guard, so MCP-bridged tools, browser dumps, `read_file` of a huge file, etc. can overflow a child's context identically.

## The fix (two layers)

### Part A — `web_scrape` uses the shared truncation primitive
- `DEFAULT_MAX_BYTES` 1MB → **100KB**; `MAX_MAX_BYTES` 10MB → **1MB**.
- Replaced the local `truncateUtf8`/`TRUNC_MARKER` (head-only slice) with the shared, tested `headAndTail` from `_output-cap.ts` — head+tail with an explicit `… [N bytes truncated: …] …` marker, UTF-8 safe at both cut points. bash/grep already use these primitives.
- All three return sites (raw, markdown, search) now cap at `parsed.maxBytes` and set `ToolResult.truncated: true` when the body exceeded the cap. `max_bytes` remains a real, caller-overridable knob — now within safe bounds.
- Updated the tool schema doc + `max_bytes` description to the new 100KB/1MB bounds and head+tail marker.

### Part C — central fork-scoped backstop (default OFF, main session unchanged)
- Added an optional `maxOutputBytes?: number` to `SessionToolDispatcher`. When set, the shared result path reduces any tool result whose `content` exceeds it to head+tail via `headAndTail` (and stamps `truncated: true`) as the **final step after `PostToolUse` fires** — so hooks still observe the full content, the model sees the capped view, and non-model consumers read the structured flag. It is **idempotent** (content already within budget is returned unchanged, so no double-truncation with web_scrape's own cap) and **never touches `result.image`**. Implemented by splitting the shared `executeCore` into `executeCoreInner` (existing body) + a thin `executeCore` wrapper that applies the cap, so both `execute()` and `executeBatch()` bound every result exactly once.
- **Wired for forks only:** both providers' `buildDispatcher` enable `maxOutputBytes = MODEL_CAP_BYTES` (100KB) exactly when `opts.parentSessionId` is set — which is true only for forked children. The **top-level session leaves it `undefined` ⇒ no central capping ⇒ behavior is unchanged.** `parentSessionId` is already threaded end-to-end from `AgentConfig` to both dispatcher construction sites, so **no new session-config plumbing was required** — the fork auto-wiring is complete (escape hatch NOT taken).

Part A alone closes the observed crash; Part C contains the whole class for the actual victims (forked children, which crash the entire turn on overflow) while keeping the primary session's behavior byte-for-byte identical.

## Alternatives considered
- **Pragmatist** — reuse the existing shared `headAndTail`/`MODEL_CAP_BYTES` primitive rather than inventing a new truncation path (Part A). Chosen: zero new surface, already tested, matches bash/grep.
- **Paranoid** — narrow the blast radius: enable the central cap only for forks (keyed on `parentSessionId`), never the top-level session, so a human-driven session's tool output is never silently truncated. Chosen for Part C's scoping.
- **Architect** — a central dispatcher backstop that bounds the entire tool-output-overflow crash class in one place, rather than patching each overflow-prone tool (MCP, browser, read_file) individually. Chosen as the Part C mechanism.
- **Deferred** — a per-model byte/token budget (cap derived from the child's actual context window). Higher value but needs model-context plumbing; the flat 100KB fork cap is the safe, minimal fix now and can be refined later.

## Testing

`pnpm lint` (`tsc --noEmit`): **pass, zero errors.**

```
✓ src/agent/tools/handlers/web-scrape.test.ts (30 tests) — 30 passed
✓ src/agent/tools/dispatcher.test.ts (102 tests | 1 skipped) — 101 passed, 1 pre-existing skip
```

New coverage:
- web_scrape: a body over the default is truncated to ≤ default with `truncated:true`; an explicit `max_bytes` above the 1MB ceiling is clamped to 1MB; multi-byte UTF-8 stays clean at both cut points.
- dispatcher: `maxOutputBytes:500` truncates an over-budget result + sets `truncated:true`; `undefined` leaves content untouched; content within budget is not truncated (idempotent); `result.image` is preserved; the cap also applies on the `executeBatch` path; non-positive/non-finite values leave the cap off.

Regression check (fork path + dispatcher-adjacent, all green): `plan-mode-gate-wiring`, `openai-compatible/query`, `hook-registry-contract`, `subagent-phase-role`, `tools/integration`, `denial-circuit-breaker` — **144 passed**.
