### PR TITLE
feat(subagent): add additive readRoots param to the agent tool (#662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ auto-release workflow to deduplicate commits across successive runs.
 ## [Unreleased]
 
 ### Added
-- additive `readRoots` param on the `agent` (subagent-dispatch) tool: grant a forked child READ access to absolute paths outside its repo/worktree (e.g. `~/Downloads`, a scratch dir), composed WITH (never replacing) its inherited read scope — writes stay confined, grandchildren must be re-granted. Hardened at parse time (rejects filesystem roots, the home dir / its ancestors, and read-denylisted credential paths) and, unlike `writeRoots`, permitted alongside `isolation:"worktree"`. Flows through the distinct `AgentConfig.extraReadRoots` field so the `afk farm` read-scope pin is untouched. (#662)
+- additive `readRoots` param on the `agent` (subagent-dispatch) tool: grant a forked child READ access to absolute paths outside its repo/worktree (e.g. `~/Downloads`, a scratch dir), composed WITH (never replacing) its inherited read scope — writes stay confined, grandchildren must be re-granted. Hardened at parse time (rejects filesystem roots, the home dir / its ancestors, and read-denylisted credential paths — evaluated on symlink-resolved targets, so a symlink to a broad dir can't slip past the lexical check) and, unlike `writeRoots`, permitted alongside `isolation:"worktree"`. Flows through the distinct `AgentConfig.extraReadRoots` field so the `afk farm` read-scope pin is untouched. (#662)
 
 ## [5.59.2] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ auto-release workflow to deduplicate commits across successive runs.
 
 ## [Unreleased]
 
+### Added
+- additive `readRoots` param on the `agent` (subagent-dispatch) tool: grant a forked child READ access to absolute paths outside its repo/worktree (e.g. `~/Downloads`, a scratch dir), composed WITH (never replacing) its inherited read scope — writes stay confined, grandchildren must be re-granted. Hardened at parse time (rejects filesystem roots, the home dir / its ancestors, and read-denylisted credential paths) and, unlike `writeRoots`, permitted alongside `isolation:"worktree"`. Flows through the distinct `AgentConfig.extraReadRoots` field so the `afk farm` read-scope pin is untouched. (#662)
+
 ## [5.59.2] - 2026-07-19
 
 ### Fixed

--- a/src/agent/subagent-worktree-readroot.test.ts
+++ b/src/agent/subagent-worktree-readroot.test.ts
@@ -238,3 +238,116 @@ describe('forkSubagent — explicit write-root pre-grant (#435)', () => {
     expect(cfg?.writeRoots).toBeUndefined();
   });
 });
+
+describe('forkSubagent — additive read-root pre-grant (extraReadRoots, #662)', () => {
+  const EXTRA = '/scratch/data';
+
+  beforeEach(() => {
+    shared.lastConfig = null;
+    mockedResolve.mockReset();
+    mockedResolve.mockResolvedValue(undefined);
+  });
+
+  it('composes extraReadRoots with a CONFINED fork inherited scope (union, inherited PRESERVED)', async () => {
+    // Confined worktree parent → inherited scope = [WORKTREE, MAIN, STATE].
+    // extraReadRoots widens it to the union: the out-of-repo dir is present AND
+    // the inherited roots (cwd/main/state) are STILL present (no suppression).
+    mockedResolve.mockResolvedValue(MAIN);
+    const mgr = new SubagentManager({ cwd: WORKTREE });
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k', extraReadRoots: [EXTRA] }));
+
+    const cfg = shared.lastConfig as { readRoots?: string[] } | null;
+    expect(new Set(cfg?.readRoots)).toEqual(new Set([WORKTREE, MAIN, STATE, EXTRA]));
+  });
+
+  it('composes extraReadRoots when the fork is confined by cwd alone (no distinct main root)', async () => {
+    // A plain (non-worktree) confined parent → inherited = [cwd, STATE]; the
+    // extra dir joins the union without dropping cwd or state.
+    mockedResolve.mockResolvedValue(undefined);
+    const mgr = new SubagentManager({ cwd: '/plain/repo' });
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k', extraReadRoots: [EXTRA] }));
+
+    const cfg = shared.lastConfig as { readRoots?: string[] } | null;
+    expect(new Set(cfg?.readRoots)).toEqual(new Set(['/plain/repo', STATE, EXTRA]));
+  });
+
+  it('does NOT confine an already-unconfined child (invariant #2 — stays read-open)', async () => {
+    // No manager cwd AND no per-call cwd → UNCONFINED parent → child is
+    // read-open (readRoots undefined → resolveBase undefined → reads anywhere).
+    // extraReadRoots must NOT turn that into a finite list (which would REGRESS
+    // the child from read-open to confined). The child can already read EXTRA.
+    const mgr = new SubagentManager(); // no cwd → UNCONFINED
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k', extraReadRoots: [EXTRA] }));
+
+    const cfg = shared.lastConfig as { readRoots?: string[] } | null;
+    expect(cfg?.readRoots).toBeUndefined();
+    expect(mockedResolve).not.toHaveBeenCalled();
+  });
+
+  it('confines+widens an unconfined parent when the child has an explicit cwd (read-open would be regressed, so cwd wins)', async () => {
+    // An unconfined parent with a per-call cwd yields a read-OPEN child
+    // ([FS_ROOT]) by inheritance. Since inheritedReadRoots is then defined
+    // (=[FS_ROOT]), extraReadRoots composes with it — read-open already covers
+    // EXTRA, so the union stays effectively read-open (FS_ROOT present).
+    const mgr = new SubagentManager(); // unconfined parent
+    await mgr.forkSubagent(
+      forkOpts({ model: 'sonnet', apiKey: 'k', cwd: WORKTREE, extraReadRoots: [EXTRA] }),
+    );
+
+    const cfg = shared.lastConfig as { readRoots?: string[] } | null;
+    // FS_ROOT (read-open) is preserved; the extra dir is folded in but redundant.
+    expect(cfg?.readRoots).toContain(FS_ROOT);
+    expect(cfg?.readRoots).toContain(path.resolve(EXTRA));
+  });
+
+  it('dedupes when extraReadRoots already contains an inherited root', async () => {
+    // Granting a root already in the inherited scope is a no-op (Set dedup).
+    mockedResolve.mockResolvedValue(MAIN);
+    const mgr = new SubagentManager({ cwd: WORKTREE });
+    await mgr.forkSubagent(
+      forkOpts({ model: 'sonnet', apiKey: 'k', extraReadRoots: [MAIN, EXTRA] }),
+    );
+
+    const cfg = shared.lastConfig as { readRoots?: string[] } | null;
+    expect(new Set(cfg?.readRoots)).toEqual(new Set([WORKTREE, MAIN, STATE, EXTRA]));
+    // MAIN appears once despite being in both inherited scope and extraReadRoots.
+    expect(cfg?.readRoots?.filter((r) => r === MAIN)).toHaveLength(1);
+  });
+
+  it('does not grant a write root — writes stay confined (invariant #4)', async () => {
+    // The extra READ grant must never leak into writeRoots.
+    mockedResolve.mockResolvedValue(MAIN);
+    const mgr = new SubagentManager({ cwd: WORKTREE });
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k', extraReadRoots: [EXTRA] }));
+
+    const cfg = shared.lastConfig as { readRoots?: string[]; writeRoots?: string[] } | null;
+    expect(cfg?.readRoots).toContain(EXTRA);
+    expect(cfg?.writeRoots).toBeUndefined();
+  });
+
+  it('does not touch readRoots when extraReadRoots is an empty array', async () => {
+    // Empty grant is a no-op: the inherited scope stands unchanged.
+    mockedResolve.mockResolvedValue(MAIN);
+    const mgr = new SubagentManager({ cwd: WORKTREE });
+    await mgr.forkSubagent(forkOpts({ model: 'sonnet', apiKey: 'k', extraReadRoots: [] }));
+
+    const cfg = shared.lastConfig as { readRoots?: string[] } | null;
+    expect(cfg?.readRoots).toEqual([WORKTREE, MAIN, STATE]);
+  });
+
+  it('does NOT override a caller-pinned readRoots (farm pin) — extraReadRoots composes only with inheritance', async () => {
+    // Invariant #1: config.readRoots is the farm pin — it SUPPRESSES inheritance
+    // entirely. When both the pin and extraReadRoots are (pathologically) set,
+    // the pin wins and inheritedReadRoots stays undefined, so the extra grant
+    // does not compose. (child-config.ts never sets both; this guards the seam.)
+    const mgr = new SubagentManager({ cwd: WORKTREE });
+    await mgr.forkSubagent(
+      forkOpts({ model: 'sonnet', apiKey: 'k', readRoots: [WORKTREE], extraReadRoots: [EXTRA] }),
+    );
+
+    const cfg = shared.lastConfig as { readRoots?: string[] } | null;
+    // Pin stands; extra did NOT compose (inheritance was suppressed).
+    expect(cfg?.readRoots).toEqual([WORKTREE]);
+    expect(mockedResolve).not.toHaveBeenCalled();
+  });
+});

--- a/src/agent/subagent.ts
+++ b/src/agent/subagent.ts
@@ -38,6 +38,7 @@ import { touchWorktreeOccupancy } from './worktree-occupancy.js';
 import { resolveWorktreeMainRoot } from './worktree-read-root.js';
 import { computeInheritedReadRoots, type ReadScopeInputs } from './subagent-read-scope.js';
 import { getAfkStateDir } from '../paths.js';
+import path from 'path';
 import { env } from '../config/env.js';
 import { buildPhaseRestrictedProvider, type PhaseRole } from './tools/nesting.js';
 import { applyManagerApiKeyFallback } from './tools/child-credential.js';
@@ -652,6 +653,32 @@ export class SubagentManager {
         // already read-open, so this is a confined-parent-only grant.
         ...(parentUnconfined ? {} : { afkStateRoot: getAfkStateDir() }),
       });
+    }
+
+    // #662: additive read roots from the `readRoots` agent-tool param. Compose with
+    // the inherited scope so the child keeps its repo/worktree/state reach AND gains
+    // the named out-of-repo dirs. Mirrors composedWriteRoots (#435). Two guards:
+    //   - Invariant #1 (farm pin untouched): only compose when the caller did NOT
+    //     pin `config.readRoots`. A pin ("confine to exactly these" — `afk farm`)
+    //     suppresses inheritance entirely (the `=== undefined` gate above), so
+    //     `inheritedReadRoots` stays undefined; composing here would silently
+    //     override the pin at the childConfig literal. extraReadRoots flows through
+    //     the DISTINCT `extraReadRoots` field precisely so the pin is never touched.
+    //   - Invariant #2 (never confine an unconfined child): only compose when the
+    //     child is (or will be) CONFINED. An unconfined child (no inherited roots
+    //     AND no cwd -> resolveBase undefined -> read-open) can already read these
+    //     paths; turning its read scope into a finite list would REGRESS it from
+    //     read-open to confined.
+    if (
+      options.config.readRoots === undefined &&
+      options.config.extraReadRoots !== undefined &&
+      options.config.extraReadRoots.length > 0
+    ) {
+      const willBeConfined = inheritedReadRoots !== undefined || effectiveChildCwd !== undefined;
+      if (willBeConfined) {
+        const base = inheritedReadRoots ?? (effectiveChildCwd !== undefined ? [effectiveChildCwd] : []);
+        inheritedReadRoots = [...new Set([...base, ...options.config.extraReadRoots.map((r) => path.resolve(r))])];
+      }
     }
 
     // Explicit write-root pre-grant (#435): when the caller passed writeRoots on

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -405,6 +405,12 @@ export const agentTool: AnthropicToolDef = {
         description:
           'Optional extra write roots to pre-grant to the forked child. By default a fork can only write inside its cwd/worktree; out-of-root writes are auto-denied. Each entry must be an absolute path with no `..` segments. Composed WITH (never replaces) the child cwd. Mutually exclusive with isolation:"worktree".',
       },
+      readRoots: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Optional extra read roots to pre-grant to the forked child. Use when the task data lives OUTSIDE the repo — e.g. `~/Downloads`, a scratch data dir. Each entry must be an absolute path with no `..` segments (and not a filesystem root or your home dir). Composed WITH (never replaces) the fork\'s inherited read scope, so the child keeps its repo/worktree/state reach AND gains the named dirs. Writes stay confined. Grandchildren must be re-granted (not inherited). Unlike writeRoots, NOT mutually exclusive with isolation:"worktree" — widening reads inside an isolated worktree is legitimate.',
+      },
       isolation: {
         type: 'string',
         enum: ['none', 'worktree'],

--- a/src/agent/tools/subagent/child-config.test.ts
+++ b/src/agent/tools/subagent/child-config.test.ts
@@ -286,6 +286,23 @@ describe('buildChildConfig', () => {
     });
   });
 
+  describe('readRoots → extraReadRoots mapping (#662)', () => {
+    it('maps parsed.readRoots to the DISTINCT childConfig.extraReadRoots field', () => {
+      const { childConfig } = buildChildConfig(
+        baseArgs({ parsed: parsed({ readRoots: ['/scratch/data', '/abs/b'] }) }),
+      );
+      expect(childConfig.extraReadRoots).toEqual(['/scratch/data', '/abs/b']);
+      // Invariant #1: must NOT set `readRoots` (the farm pin that suppresses
+      // read-scope inheritance in forkSubagent) — only `extraReadRoots`.
+      expect(Object.prototype.hasOwnProperty.call(childConfig, 'readRoots')).toBe(false);
+    });
+
+    it('omits extraReadRoots entirely when parsed.readRoots is absent', () => {
+      const { childConfig } = buildChildConfig(baseArgs({ parsed: parsed() }));
+      expect(Object.prototype.hasOwnProperty.call(childConfig, 'extraReadRoots')).toBe(false);
+    });
+  });
+
   describe('credential wiring (deterministic slice)', () => {
     it('resolves the child apiKey via the injected resolver, keyed by the child model', () => {
       const resolveApiKeyForModel = vi.fn((_m: string) => 'child-resolved-key');

--- a/src/agent/tools/subagent/child-config.ts
+++ b/src/agent/tools/subagent/child-config.ts
@@ -284,6 +284,10 @@ export function buildChildConfig(args: BuildChildConfigArgs): BuildChildConfigRe
     // #435: pass raw writeRoots through; SubagentManager.forkSubagent composes
     // them with the child's effective cwd so the child never loses its own tree.
     ...(parsed.writeRoots !== undefined ? { writeRoots: parsed.writeRoots } : {}),
+    // #662: pass readRoots through as the DISTINCT `extraReadRoots` field (never
+    // `readRoots`, which is the farm pin that SUPPRESSES inheritance).
+    // forkSubagent composes these with the child's inherited read scope.
+    ...(parsed.readRoots !== undefined ? { extraReadRoots: parsed.readRoots } : {}),
   } as AgentConfig;
 
   // Wire nesting: give the child its own executor + provider so it can

--- a/src/agent/tools/subagent/input-parse.test.ts
+++ b/src/agent/tools/subagent/input-parse.test.ts
@@ -12,6 +12,8 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
 import { parseAgentInput, type AgentInput } from './input-parse.js';
 
 describe('parseAgentInput', () => {
@@ -419,6 +421,111 @@ describe('parseAgentInput', () => {
       });
       expect(result.cwd).toBe('/tmp/wt/x');
       expect(result.writeRoots).toEqual(['/sibling/repo']);
+    });
+  });
+
+  describe('readRoots (#662)', () => {
+    // A concrete, non-broad, non-denylisted absolute path (mirrors the
+    // writeRoots test style). Not a filesystem root, not the home dir nor an
+    // ancestor of it, and not inside the read-denylist.
+    const SAFE = '/abs/data';
+
+    it('is undefined (key omitted) when not supplied', () => {
+      const result = parseAgentInput({ prompt: 'p' });
+      expect(result.readRoots).toBeUndefined();
+      expect('readRoots' in result).toBe(false);
+    });
+
+    it('accepts an array of absolute paths', () => {
+      const result = parseAgentInput({ prompt: 'p', readRoots: ['/abs/a', '/abs/b'] });
+      expect(result.readRoots).toEqual(['/abs/a', '/abs/b']);
+    });
+
+    it('throws when readRoots is not an array (string)', () => {
+      expect(() => parseAgentInput({ prompt: 'p', readRoots: '/abs/a' })).toThrow(
+        /readRoots must be an array/,
+      );
+    });
+
+    it('throws when an entry is a relative path', () => {
+      expect(() => parseAgentInput({ prompt: 'p', readRoots: ['relative/path'] })).toThrow(
+        /readRoots entries must be absolute paths/,
+      );
+    });
+
+    it("throws when an entry contains a '..' segment", () => {
+      expect(() =>
+        parseAgentInput({ prompt: 'p', readRoots: ['/tmp/../escape'] }),
+      ).toThrow(/readRoots entries must not contain '\.\.' segments/);
+    });
+
+    it('throws when an entry is an empty string', () => {
+      expect(() => parseAgentInput({ prompt: 'p', readRoots: [''] })).toThrow(
+        /readRoots entries must be non-empty strings/,
+      );
+    });
+
+    it('normalizes an empty array to undefined (field absent)', () => {
+      const result = parseAgentInput({ prompt: 'p', readRoots: [] });
+      expect(result.readRoots).toBeUndefined();
+      expect('readRoots' in result).toBe(false);
+    });
+
+    // --- Hardening: breadth rejection ---
+    it('throws when an entry is a filesystem root', () => {
+      const FS_ROOT = path.parse(path.resolve('.')).root || path.sep;
+      expect(() => parseAgentInput({ prompt: 'p', readRoots: [FS_ROOT] })).toThrow(
+        /must not be a filesystem root, your home directory, or an ancestor/,
+      );
+    });
+
+    it('throws when an entry is the home directory', () => {
+      expect(() => parseAgentInput({ prompt: 'p', readRoots: [os.homedir()] })).toThrow(
+        /must not be a filesystem root, your home directory, or an ancestor/,
+      );
+    });
+
+    it('throws when an entry is an ancestor of the home directory', () => {
+      // The parent of homedir (e.g. /Users or /home) lexically CONTAINS homedir,
+      // so granting it would over-grant the whole user tree.
+      const parentOfHome = path.dirname(os.homedir());
+      expect(() => parseAgentInput({ prompt: 'p', readRoots: [parentOfHome] })).toThrow(
+        /must not be a filesystem root, your home directory, or an ancestor/,
+      );
+    });
+
+    // --- Hardening: denylist rejection ---
+    it('throws when an entry targets a read-denylisted credential path (~/.ssh)', () => {
+      const ssh = path.join(os.homedir(), '.ssh');
+      expect(() => parseAgentInput({ prompt: 'p', readRoots: [ssh] })).toThrow(
+        /must not target a protected\/credential path/,
+      );
+    });
+
+    it('throws when an entry targets the AFK config (credential) dir', () => {
+      const afkConfig = path.join(os.homedir(), '.afk', 'config');
+      expect(() => parseAgentInput({ prompt: 'p', readRoots: [afkConfig] })).toThrow(
+        /must not target a protected\/credential path/,
+      );
+    });
+
+    // --- Deliberate divergence from writeRoots ---
+    it('is ALLOWED together with isolation:worktree (does NOT throw — divergence from writeRoots)', () => {
+      // Widening a confined worktree fork's READS is legitimate; only WRITES
+      // break isolation. This is the deliberate #662 divergence.
+      const result = parseAgentInput({
+        prompt: 'p',
+        readRoots: [SAFE],
+        isolation: 'worktree',
+      });
+      expect(result.readRoots).toEqual([SAFE]);
+      expect(result.isolation).toBe('worktree');
+    });
+
+    it('accepts readRoots together with cwd (the main use case)', () => {
+      const result = parseAgentInput({ prompt: 'p', cwd: '/tmp/wt/x', readRoots: [SAFE] });
+      expect(result.cwd).toBe('/tmp/wt/x');
+      expect(result.readRoots).toEqual([SAFE]);
     });
   });
 

--- a/src/agent/tools/subagent/input-parse.test.ts
+++ b/src/agent/tools/subagent/input-parse.test.ts
@@ -14,6 +14,7 @@
 import { describe, expect, it } from 'vitest';
 import os from 'node:os';
 import path from 'node:path';
+import fs from 'node:fs';
 import { parseAgentInput, type AgentInput } from './input-parse.js';
 
 describe('parseAgentInput', () => {
@@ -492,6 +493,54 @@ describe('parseAgentInput', () => {
       expect(() => parseAgentInput({ prompt: 'p', readRoots: [parentOfHome] })).toThrow(
         /must not be a filesystem root, your home directory, or an ancestor/,
       );
+    });
+
+    // --- Hardening: breadth rejection resolves symlinks (#664 Codex P1) ---
+    // The lexical breadth check alone is bypassable: a symlink whose target is
+    // `/` or the home dir is not itself broad, but the containment layer
+    // realpaths granted roots, so it becomes a broad real root at read time.
+    // The breadth check must therefore run on the symlink-resolved target too.
+    it('throws when an entry is a symlink pointing at the filesystem root (#664)', () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-sym-'));
+      const link = path.join(dir, 'broad-link');
+      const fsRoot = path.parse(dir).root || path.sep;
+      try {
+        fs.symlinkSync(fsRoot, link, 'dir');
+        expect(() => parseAgentInput({ prompt: 'p', readRoots: [link] })).toThrow(
+          /must not be a filesystem root, your home directory, or an ancestor/,
+        );
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('throws when an entry is a symlink pointing at the home directory (#664)', () => {
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-sym-'));
+      const link = path.join(dir, 'home-link');
+      try {
+        fs.symlinkSync(os.homedir(), link, 'dir');
+        expect(() => parseAgentInput({ prompt: 'p', readRoots: [link] })).toThrow(
+          /must not be a filesystem root, your home directory, or an ancestor/,
+        );
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('accepts an entry that is a symlink pointing at a safe (non-broad) subdirectory', () => {
+      // The symlink pass must not OVER-reject: a link to an ordinary subdir is a
+      // legitimate grant and its stored value stays the original entry.
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-sym-'));
+      const target = path.join(dir, 'data');
+      const link = path.join(dir, 'data-link');
+      try {
+        fs.mkdirSync(target);
+        fs.symlinkSync(target, link, 'dir');
+        const result = parseAgentInput({ prompt: 'p', readRoots: [link] });
+        expect(result.readRoots).toEqual([link]);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     // --- Hardening: denylist rejection ---

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -11,6 +11,7 @@
 import { isAbsolute, parse as parsePath, resolve as resolvePath, relative as relativePath } from 'node:path';
 import { homedir } from 'node:os';
 import { isReadDenied } from '../handlers/read-denylist.js';
+import { realpathSafe } from '../handlers/_cwd-utils.js';
 
 export type AgentExecutionMode = 'foreground' | 'background';
 
@@ -285,6 +286,10 @@ export function parseAgentInput(input: unknown): AgentInput {
   // cannot over-grant or shadow the credential floor:
   //   (a) BREADTH — reject a filesystem root, os.homedir(), or an ANCESTOR of
   //       homedir (homedir inside the entry). Blocks `/`, `~`, `/Users`, `/home`.
+  //       Checked on BOTH the lexical path AND its symlink-resolved target: the
+  //       containment layer realpaths granted roots (realpathRoot, _cwd-utils),
+  //       so a symlink to `/`/home would otherwise pass a lexical-only check and
+  //       become a broad real root at read time (#664 Codex P1).
   //   (b) DENYLIST — reject any entry that resolves into the read-denylist
   //       (isReadDenied: ~/.ssh, ~/.afk/config, …). isReadDenied is a pure,
   //       string/realpath-based, non-throwing check (safeRealpath swallows fs
@@ -301,6 +306,20 @@ export function parseAgentInput(input: unknown): AgentInput {
       );
     }
     const home = homedir();
+    // Check against BOTH the lexical home and its realpath: if the home dir is
+    // itself behind a symlink, a symlink-resolved candidate would otherwise slip
+    // past a lexical-only home comparison.
+    const homeTargets = [...new Set([home, realpathSafe(home)])];
+    // A candidate root is "too broad" to pre-grant when it is a filesystem root,
+    // the home dir itself, or an ANCESTOR of home (home lexically inside it →
+    // relative(candidate, home) neither escapes with '..' nor is absolute).
+    const isTooBroad = (candidate: string): boolean => {
+      if (candidate === parsePath(candidate).root) return true;
+      return homeTargets.some((h) => {
+        const rel = relativePath(candidate, h);
+        return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+      });
+    };
     const roots: string[] = [];
     for (const entry of readRootsValue) {
       if (typeof entry !== 'string' || entry.length === 0) {
@@ -318,21 +337,26 @@ export function parseAgentInput(input: unknown): AgentInput {
           `Agent tool readRoots entries must not contain '..' segments, got: ${JSON.stringify(entry)}`,
         );
       }
-      // (a) Breadth rejection. Resolve once so `~`-shaped inputs and trailing
-      // separators normalize before the comparisons. A filesystem root, the
-      // home dir itself, or any ANCESTOR of the home dir (homedir lexically
-      // inside the entry → `relative(entry, home)` neither escapes nor is
-      // absolute) is too broad to pre-grant.
+      // (a) Breadth rejection. Resolve lexically (normalizes `~`-shaped inputs
+      // and trailing separators) AND to the symlink target, then reject if
+      // EITHER is too broad. The symlink pass is load-bearing: the containment
+      // layer realpaths granted roots before comparison (realpathRoot,
+      // _cwd-utils.ts), so a symlink to `/` or the home dir would pass a
+      // lexical-only check yet grant the confined child a broad real root at
+      // read time (#664 Codex P1). realpathSafe resolves existing symlinks and
+      // falls back to the nearest existing ancestor for a not-yet-created path.
       const resolved = resolvePath(entry);
-      const rel = relativePath(resolved, home);
-      const homeInsideEntry = rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
-      if (resolved === parsePath(resolved).root || homeInsideEntry) {
+      const realResolved = realpathSafe(resolved);
+      if (isTooBroad(resolved) || isTooBroad(realResolved)) {
         throw new Error(
           `Agent tool readRoots entries must not be a filesystem root, your home directory, ` +
-            `or an ancestor of it — grant a specific subdirectory instead, got: ${JSON.stringify(entry)}`,
+            `or an ancestor of it (checked after resolving symlinks) — grant a specific ` +
+            `subdirectory instead, got: ${JSON.stringify(entry)}`,
         );
       }
       // (b) Denylist rejection — never let a grant target the credential floor.
+      // isReadDenied realpaths internally, so a symlinked credential path is
+      // caught here too.
       const denied = isReadDenied(resolved);
       if (denied.denied) {
         throw new Error(

--- a/src/agent/tools/subagent/input-parse.ts
+++ b/src/agent/tools/subagent/input-parse.ts
@@ -8,7 +8,9 @@
  * @module agent/tools/subagent/input-parse
  */
 
-import { isAbsolute } from 'node:path';
+import { isAbsolute, parse as parsePath, resolve as resolvePath, relative as relativePath } from 'node:path';
+import { homedir } from 'node:os';
+import { isReadDenied } from '../handlers/read-denylist.js';
 
 export type AgentExecutionMode = 'foreground' | 'background';
 
@@ -75,6 +77,27 @@ export interface AgentInput {
    * explicit parent intent.
    */
   writeRoots?: string[];
+  /**
+   * Optional extra READ roots to pre-grant to the forked child (#662). Mirrors
+   * {@link writeRoots} but on the read axis: lets the PARENT grant the fork read
+   * access to absolute paths OUTSIDE the repo/worktree it is confined to (e.g.
+   * `~/Downloads`, a scratch data dir). ADDITIVE — composed WITH (never replaces)
+   * the child's normally-inherited read scope in `forkSubagent`, so the child
+   * keeps its repo/worktree/state reach AND gains the named dirs. Writes stay
+   * confined. Grandchildren must be re-granted (not inherited).
+   *
+   * Per-entry rules (parse-time): non-empty absolute path, no `..` segment. PLUS
+   * two hardening rejections: (a) breadth — a filesystem root, the home dir, or
+   * an ancestor of the home dir is refused (the model must not over-grant a broad
+   * root); (b) denylist — an entry that resolves into the credential floor
+   * (`isReadDenied`: ~/.ssh, ~/.afk/config, …) is refused, so a grant can never
+   * even attempt to shadow secrets. This is defense-in-depth ON TOP of the
+   * read-time floor in `resolveAndContain` / the path-approval hook.
+   *
+   * Deliberately NOT mutually exclusive with `isolation:'worktree'` — widening a
+   * confined worktree fork's READS is legitimate (only WRITES break isolation).
+   */
+  readRoots?: string[];
   /**
    * Filesystem-isolation mode. When `'worktree'`, the executor forks the child
    * inside a fresh afk-managed git worktree (`.afk-worktrees/<slug>` on a new
@@ -256,6 +279,72 @@ export function parseAgentInput(input: unknown): AgentInput {
     if (roots.length > 0) writeRoots = roots;
   }
 
+  // readRoots: optional array of absolute paths pre-granted as extra READ roots
+  // to the fork (#662). Same per-entry format rules as writeRoots (non-empty,
+  // absolute, no '..' segments), PLUS two hardening rejections so the model
+  // cannot over-grant or shadow the credential floor:
+  //   (a) BREADTH — reject a filesystem root, os.homedir(), or an ANCESTOR of
+  //       homedir (homedir inside the entry). Blocks `/`, `~`, `/Users`, `/home`.
+  //   (b) DENYLIST — reject any entry that resolves into the read-denylist
+  //       (isReadDenied: ~/.ssh, ~/.afk/config, …). isReadDenied is a pure,
+  //       string/realpath-based, non-throwing check (safeRealpath swallows fs
+  //       errors), so it is safe to call at parse time. Defense-in-depth ON TOP
+  //       of the read-time floor in resolveAndContain / the path-approval hook.
+  // An empty array normalizes to undefined (no-op grant). Deliberately NOT
+  // mutually exclusive with isolation:'worktree' (that constraint is write-only).
+  let readRoots: string[] | undefined;
+  const readRootsValue = agentInput['readRoots'];
+  if (readRootsValue !== undefined) {
+    if (!Array.isArray(readRootsValue)) {
+      throw new Error(
+        `Agent tool readRoots must be an array of absolute paths, got: ${JSON.stringify(readRootsValue)}`,
+      );
+    }
+    const home = homedir();
+    const roots: string[] = [];
+    for (const entry of readRootsValue) {
+      if (typeof entry !== 'string' || entry.length === 0) {
+        throw new Error(
+          `Agent tool readRoots entries must be non-empty strings, got: ${JSON.stringify(entry)}`,
+        );
+      }
+      if (!isAbsolute(entry)) {
+        throw new Error(
+          `Agent tool readRoots entries must be absolute paths, got: ${JSON.stringify(entry)}`,
+        );
+      }
+      if (entry.split(/[/\\]/).includes('..')) {
+        throw new Error(
+          `Agent tool readRoots entries must not contain '..' segments, got: ${JSON.stringify(entry)}`,
+        );
+      }
+      // (a) Breadth rejection. Resolve once so `~`-shaped inputs and trailing
+      // separators normalize before the comparisons. A filesystem root, the
+      // home dir itself, or any ANCESTOR of the home dir (homedir lexically
+      // inside the entry → `relative(entry, home)` neither escapes nor is
+      // absolute) is too broad to pre-grant.
+      const resolved = resolvePath(entry);
+      const rel = relativePath(resolved, home);
+      const homeInsideEntry = rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+      if (resolved === parsePath(resolved).root || homeInsideEntry) {
+        throw new Error(
+          `Agent tool readRoots entries must not be a filesystem root, your home directory, ` +
+            `or an ancestor of it — grant a specific subdirectory instead, got: ${JSON.stringify(entry)}`,
+        );
+      }
+      // (b) Denylist rejection — never let a grant target the credential floor.
+      const denied = isReadDenied(resolved);
+      if (denied.denied) {
+        throw new Error(
+          `Agent tool readRoots entries must not target a protected/credential path ` +
+            `(matches read-denylist entry: ${denied.matched}), got: ${JSON.stringify(entry)}`,
+        );
+      }
+      roots.push(entry);
+    }
+    if (roots.length > 0) readRoots = roots;
+  }
+
   // isolation: optional enum. 'none' (or omitted) is a no-op and normalizes to
   // undefined so the executor's `=== 'worktree'` check is total. 'worktree'
   // asks the executor to fork the child inside a fresh managed git worktree.
@@ -303,6 +392,7 @@ export function parseAgentInput(input: unknown): AgentInput {
     ...(agent_type !== undefined ? { agent_type } : {}),
     ...(cwd !== undefined ? { cwd } : {}),
     ...(writeRoots !== undefined ? { writeRoots } : {}),
+    ...(readRoots !== undefined ? { readRoots } : {}),
     ...(isolation !== undefined ? { isolation } : {}),
   };
 }

--- a/src/agent/types/config-types.ts
+++ b/src/agent/types/config-types.ts
@@ -296,6 +296,17 @@ export interface AgentConfig {
   writeRoots?: string[];
 
   /**
+   * Additive extra READ roots from the `agent`-tool `readRoots` param (#662).
+   * DISTINCT from {@link readRoots}: `readRoots` PINS the read scope (the
+   * `afk farm` "confine to exactly these roots" path — setting it SUPPRESSES
+   * read-scope inheritance in `forkSubagent`). This field instead COMPOSES with
+   * the child's inherited read scope (union, in `forkSubagent`), so the fork
+   * keeps its repo/worktree/state reach AND gains the named out-of-repo dirs.
+   * Writes stay confined. Not the farm pin — never suppresses inheritance.
+   */
+  extraReadRoots?: string[];
+
+  /**
    * Extra environment variables to inject into Bash-tool subprocess spawns
    * for THIS session. Merged into the child's env on top of `process.env`,
    * with these entries winning on collision.


### PR DESCRIPTION
Closes #662.

## Problem
A **confined** orchestrator (running in a worktree, i.e. `resolveBase` is set) that forks a subagent to analyze data living **outside** the repo — e.g. `~/Downloads`, a scratch/workspace dir — hits a silent read-denial. Forks can't prompt the operator, so the orchestrator only learns after a wasted dispatch and must re-dispatch with `cwd` repointed at the data dir (losing the repo as anchor) or abuse `writeRoots` (which grants *write* only — reads stay denied, since read/write roots are independent lists). The `agent` tool exposed `cwd`, `writeRoots`, `isolation` — but no way to grant extra **read** scope.

(Unconfined top-level sessions are already read-open, so this only ever affected confined/worktree forks.)

## Change
Add an additive `readRoots` param to the `agent` tool, mirroring `writeRoots` on the read axis: list absolute paths the fork may **additionally read**, composed **with** (never replacing) its inherited read scope. Writes stay confined.

Net child read scope = `union(cwd, parentRoots, worktreeMainRoot, afkStateRoot, readRoots)`.

## Design (the load-bearing bits — please review carefully)
This is path-containment code, so two invariants are guarded explicitly:

1. **Farm pin untouched.** The param flows through a **distinct** `AgentConfig.extraReadRoots` field — *not* `config.readRoots`. Setting `config.readRoots` *suppresses* read-scope inheritance entirely (it's the `afk farm` "pin exactly these roots" path, gated by `options.config.readRoots === undefined` in `forkSubagent`). Composition is additionally gated on that pin being absent, so a pinned scope is never overridden.
2. **Never confine an unconfined child.** Composition only fires when the child is/will-be confined. An already-read-open child can already read the paths; turning its scope into a finite list would *regress* it.

**Parse-time hardening** (defense-in-depth on top of the existing non-bypassable read-time floor in `resolveAndContain` / the path-approval hook):
- rejects a filesystem root, the home dir, or any **ancestor** of the home dir (blocks `/`, `~`, `/Users`, `/home`) — the model must not over-grant a broad root;
- rejects any entry resolving into the credential read-denylist (`~/.ssh`, `~/.afk/config`, ...), so a grant can't even *attempt* to shadow secrets;
- per-entry: non-empty, absolute, no `..` (same as `writeRoots`).

Unlike `writeRoots`, `readRoots` is **not** mutually exclusive with `isolation:"worktree"` — widening reads inside an isolated worktree is legitimate; only writes break isolation. Grandchildren are not auto-granted (matching the `cwd` non-propagation precedent).

## Not in this PR (deliberate)
Auto-granting paths quoted verbatim in the dispatch prompt (issue #662 option 3 variant) would kill the "orchestrator forgets to grant" miss-rate entirely, but it's regex/heuristic-based and belongs in its own reviewable PR rather than bundled into containment code. The issue's "clearer error message" option is already shipped — the sub-agent denial already names the remedy.

## Files
- `schemas.ts` — `readRoots` schema property on the `agent` tool
- `input-parse.ts` — parse + hardening validation
- `types/config-types.ts` — distinct `extraReadRoots` field
- `child-config.ts` — map `readRoots` to `extraReadRoots` (never `readRoots`)
- `subagent.ts` — union composition at the fork choke point
- tests: `input-parse.test.ts`, `subagent-worktree-readroot.test.ts`, `child-config.test.ts`
- `CHANGELOG.md`

## Verification
- `pnpm lint` (tsc --noEmit, strict) — clean
- affected tests — 151 pass
- full tool-layer suite `src/agent/tools/` — 1802 pass (2 pre-existing skips)
- full `src/agent/` suite — 5512 pass, 0 regressions
