### PR TITLE
fix(tui): flush logical lines to scrollback so resize reflow stops splitting words and dropping indent

### DIFF
--- a/src/cli/terminal-compositor.band-reflow.ts
+++ b/src/cli/terminal-compositor.band-reflow.ts
@@ -27,6 +27,7 @@
  */
 
 import { hardWrapToWidth } from './wrap.js';
+import type { BandRowMeta } from './terminal-compositor.types.js';
 
 /**
  * Invariant (painted/pending boundary survives reflow): `committedBand`'s
@@ -49,6 +50,20 @@ import { hardWrapToWidth } from './wrap.js';
 export interface BandReflowResult {
   rows: string[];
   paintedRows: number;
+  /**
+   * Per-physical-row provenance for `rows`, index-aligned 1:1 (#540 axis-2).
+   * Re-wrapping a physical row into more (narrower) or the same (wider) rows
+   * PRESERVES each row's `logicalText` — the original pre-hard-wrap line the
+   * row is a fragment of, unchanged by any width — and recomputes `isHead` so
+   * only the first sub-row of a re-split row that was itself a logical-line
+   * head stays a head. This is what lets a widened resize rejoin a
+   * hard-wrapped line at the SCROLLBACK flush sites even though the on-screen
+   * physical rows keep their (now stale) narrow break points: the logical
+   * source rides through reflow intact. Absent-meta input degrades to
+   * reconstructing `logicalText` from the physical row itself (each row treated
+   * as its own logical line) — lossy for rejoin but never for content.
+   */
+  meta: BandRowMeta[];
 }
 
 /**
@@ -59,21 +74,49 @@ export interface BandReflowResult {
  * an already-`width`-fitting row at the SAME width returns it unchanged (so a
  * steady-width repeat call is a no-op even without the cache in
  * {@link reflowCommittedBandToWidth}).
+ *
+ * `meta` (index-aligned 1:1 with `band`) is re-split in lockstep: each source
+ * row's `logicalText` propagates to all its re-wrapped sub-rows so the retained
+ * logical form survives arbitrary reflows (#540 axis-2). When omitted, the
+ * physical row itself is used as the logical source (pre-#540 behavior — the
+ * band's re-wrapped rows are treated as their own logical lines).
  */
 export function reflowBandSplit(
   band: readonly string[],
   paintedRows: number,
   width: number,
+  meta?: readonly BandRowMeta[],
 ): BandReflowResult {
-  if (band.length === 0) return { rows: [], paintedRows: 0 };
+  if (band.length === 0) return { rows: [], paintedRows: 0, meta: [] };
   const clampedPainted = Math.max(0, Math.min(paintedRows, band.length));
-  const pendingPrefix = band.slice(0, band.length - clampedPainted);
-  const paintedSuffix = band.slice(band.length - clampedPainted);
-  const reflow = (lines: readonly string[]): string[] =>
-    lines.flatMap((line) => hardWrapToWidth(line, width).split('\n'));
-  const reflowedSuffix = reflow(paintedSuffix);
-  const rows = [...reflow(pendingPrefix), ...reflowedSuffix];
-  return { rows, paintedRows: reflowedSuffix.length };
+  const splitAt = band.length - clampedPainted;
+  // Re-wrap a [start, end) slice of the band, emitting the new physical rows
+  // and their meta together so the two arrays stay index-aligned. Each source
+  // row band[k] contributes its wrapped sub-rows, all carrying band[k]'s
+  // logicalText (from `meta`, or the row text itself as a fallback); only the
+  // first sub-row is a head, and only if the source row was a head.
+  const reflowSlice = (start: number, end: number): { rows: string[]; meta: BandRowMeta[] } => {
+    const outRows: string[] = [];
+    const outMeta: BandRowMeta[] = [];
+    for (let k = start; k < end; k++) {
+      const source = band[k] ?? '';
+      const logicalText = meta?.[k]?.logicalText ?? source;
+      const sourceIsHead = meta?.[k]?.isHead ?? true;
+      const subRows = hardWrapToWidth(source, width).split('\n');
+      subRows.forEach((sub, i) => {
+        outRows.push(sub);
+        outMeta.push({ logicalText, isHead: i === 0 && sourceIsHead });
+      });
+    }
+    return { rows: outRows, meta: outMeta };
+  };
+  const pending = reflowSlice(0, splitAt);
+  const painted = reflowSlice(splitAt, band.length);
+  return {
+    rows: [...pending.rows, ...painted.rows],
+    paintedRows: painted.rows.length,
+    meta: [...pending.meta, ...painted.meta],
+  };
 }
 
 /**
@@ -91,6 +134,8 @@ export interface BandReflowCache {
 /** Narrowest state slice {@link reflowCommittedBandToWidth} touches. */
 export interface BandReflowHost {
   committedBand: string[];
+  /** Per-physical-row logical provenance, index-aligned 1:1 with committedBand (#540). */
+  committedBandMeta: BandRowMeta[];
   committedBandPaintedRows: number;
   bandReflowCache: BandReflowCache | null;
 }
@@ -128,8 +173,14 @@ export function reflowCommittedBandToWidth(self: BandReflowHost, width: number):
   ) {
     return; // already reflowed to this width from this exact band+boundary
   }
-  const { rows, paintedRows } = reflowBandSplit(self.committedBand, self.committedBandPaintedRows, width);
+  const { rows, paintedRows, meta } = reflowBandSplit(
+    self.committedBand,
+    self.committedBandPaintedRows,
+    width,
+    self.committedBandMeta,
+  );
   self.committedBand = rows;
+  self.committedBandMeta = meta;
   self.committedBandPaintedRows = paintedRows;
   self.bandReflowCache = { band: rows, paintedRows, width };
 }

--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -13,10 +13,16 @@
  * borrows them through the host interface.
  */
 
-import type { LogUpdateFn, CompositorScrollRegionGuard } from './terminal-compositor.types.js';
-import { eraseAndPaintRow } from './terminal-compositor.types.js';
+import type { LogUpdateFn, CompositorScrollRegionGuard, BandRowMeta } from './terminal-compositor.types.js';
+import {
+  eraseAndPaintRow,
+  buildBandMeta,
+  scrollbackFlushLines,
+  buildScrollbackArchiveEscape,
+  snapFlushCountToLogicalBoundary,
+} from './terminal-compositor.types.js';
 import { hardWrapToWidth } from './wrap.js';
-import { capBandModel, decideCommitMode } from './commit-mode.js';
+import { decideCommitMode } from './commit-mode.js';
 import {
   reflowCommittedBandToWidth,
   type BandReflowCache,
@@ -35,6 +41,8 @@ export interface CommittedBandHost {
   debugLog(stage: string, extra?: Record<string, unknown>): void;
   /** The full contiguous on-screen committed run adjacent to the frame top. */
   committedBand: string[];
+  /** Per-physical-row logical provenance, index-aligned 1:1 with committedBand (#540). */
+  committedBandMeta: BandRowMeta[];
   committedBandTopRow: number;
   committedBandBottomRow: number;
   /** Real unpadded frame top from the last repaint's measure() — see the field
@@ -164,6 +172,14 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   // by the next commit's paint, and the band-hold row math is exact.
   const contentLines = logicalLines.flatMap((l) => hardWrapToWidth(l, cols).split('\n'));
   const contentLineCount = Math.max(1, contentLines.length);
+  // #540 axis-2 (retained logical source): the per-physical-row provenance for
+  // `contentLines`, index-aligned 1:1. Recorded from the SAME logical lines +
+  // width that produced the physical rows above, so the scrollback-flush sites
+  // can later emit the logical line (terminal-soft-wrapped, reflow-clean)
+  // instead of these pre-hard-wrapped rows. The separator blank row (added to
+  // textLines/bandTextLines below) is its own logical line ''.
+  const contentMeta = buildBandMeta(logicalLines, cols);
+  const separatorMeta: BandRowMeta = { logicalText: '', isHead: true };
 
   const extraRows = self.scrollRegion?.getExtraRows() ?? 0;
   // Invariant (one geometry per commit): the room/scroll/band math below must
@@ -298,6 +314,7 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   const paintSeparator =
     hasTrailingSeparator && fitsAboveFrame && contentLineCount < aboveFrameRoomForSeparator;
   const textLines = paintSeparator ? [...contentLines, ''] : contentLines;
+  const textMeta = paintSeparator ? [...contentMeta, separatorMeta] : contentMeta;
   const lineCount = contentLineCount + (paintSeparator ? 1 : 0);
 
   // Band-hold routing (pure, tested in commit-mode.test.ts): keep a block that
@@ -313,10 +330,12 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
   // the separator) so a 1-content-line block with trailing separator counts as 2
   // model rows, correctly routing it to band-hold when room=1.
   const bandTextLines = hasTrailingSeparator ? [...contentLines, ''] : contentLines;
+  const bandTextMeta = hasTrailingSeparator ? [...contentMeta, separatorMeta] : contentMeta;
   const bandLineCount = bandTextLines.length;
   const {
     useBandHold,
     overflowRun,
+    overflowPriorContiguous,
     maxBandModel,
   } = decideCommitMode({
     prevTopRow,
@@ -332,6 +351,31 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     committedBandPaintedRows: self.committedBandPaintedRows,
     geometryStale: self.bandGeometryStale,
   });
+  // #540 axis-2: the per-physical-row provenance for `overflowRun`, rebuilt
+  // here to stay 1:1 with it — decideCommitMode is a pure geometry helper and
+  // is left untouched. Mirrors its `overflowRun = overflowPriorContiguous ?
+  // [...committedBand, ...bandTextLines] : bandTextLines` exactly, using the
+  // same-order meta arrays (self.committedBandMeta is kept 1:1 with
+  // self.committedBand; bandTextMeta with bandTextLines).
+  const overflowRunMeta: BandRowMeta[] = overflowPriorContiguous
+    ? [...self.committedBandMeta, ...bandTextMeta]
+    : bandTextMeta;
+  // #540 axis-2: how many oldest PHYSICAL rows of overflowRun the band-hold
+  // path archives to scrollback this commit — decideCommitMode's raw
+  // `overflowRun.length - maxBandModel`, but SNAPPED DOWN to a logical-line
+  // boundary so a multi-row logical line is never archived one physical row per
+  // commit (which would emit it verbatim each time and re-fragment it). The
+  // straddling line (and everything after) is RETAINED in the band model until
+  // a later commit's overflow covers all its rows, then it archives whole as
+  // one soft-wrappable line. Phase 1 (archive) and Phase 3 (model = the
+  // retained suffix) both split overflowRun at this same index so archived and
+  // retained stay disjoint and complete.
+  const rawGenuineOverflow = Math.max(0, overflowRun.length - maxBandModel);
+  const archiveCount = snapFlushCountToLogicalBoundary(
+    overflowRunMeta,
+    rawGenuineOverflow,
+    overflowRun.length,
+  );
 
   // Suppress the shrink re-pin for the whole commit; Phase 3 sets the band.
   // Re-armed at the top of every commitAbove, so a throw on a dying TTY (the
@@ -428,20 +472,26 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
         // Band-hold Phase 1: scroll NOTHING for the rows the model keeps (they
         // are "pending" — painted by repositionCommittedBand on collapse). Only
         // the genuine overflow (oldest rows beyond maxBandModel) is archived to
-        // scrollback as REAL content, via the proven top-write-then-scroll
-        // mechanism, chunked by screen height so a run taller than the terminal
-        // still archives every row. The archived prefix is disjoint from the
+        // scrollback as REAL content. The archived prefix is disjoint from the
         // suffix Phase 3 keeps — no duplication.
-        const genuineOverflow = Math.max(0, overflowRun.length - maxBandModel);
-        if (genuineOverflow > 0) {
-          const chunkMax = Math.max(1, rows - anchorFloor + 1);
-          for (let start = 0; start < genuineOverflow; start += chunkMax) {
-            const chunk = overflowRun.slice(start, Math.min(start + chunkMax, genuineOverflow));
-            const topWrite = chunk
-              .map((l, i) => eraseAndPaintRow(anchorFloor + i, l))
-              .join('');
-            self.stdout.write(`${topWrite}\x1b[${rows};1H${'\n'.repeat(chunk.length)}`);
-          }
+        //
+        // #540 axis-2 (logical-line flush): archive the overflow prefix as
+        // SOFT-WRAPPABLE logical lines, not the pre-hard-wrapped physical rows,
+        // so a later width resize reflows scrolled-off content cleanly instead
+        // of re-fragmenting it. `archiveCount` (computed above) is the raw
+        // overflow SNAPPED to a logical-line boundary, so no logical line is
+        // ever split across two archive events; scrollbackFlushLines therefore
+        // emits whole logical lines, and buildScrollbackArchiveEscape paints
+        // them top-aligned with autowrap ON and scrolls their total physical
+        // height off the top into history (the terminal owns the wrap → its
+        // continuation rows are soft-wrap continuations that rejoin on resize).
+        // Autowrap is load-bearing here (opposite of the on-screen band paint's
+        // withAutowrapDisabled). Phase 3's model keeps overflowRun[archiveCount:]
+        // (see capBandModel call) so archived + retained are disjoint + complete.
+        if (archiveCount > 0) {
+          const archiveLines = scrollbackFlushLines(overflowRun, overflowRunMeta, archiveCount);
+          const escape = buildScrollbackArchiveEscape(archiveLines, anchorFloor, rows, cols);
+          if (escape.length > 0) self.stdout.write(escape);
         }
       } else if (fitsAboveFrame) {
         if (bandOverflow > 0) {
@@ -536,12 +586,24 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     const postScrollFloor = Math.max(self.anchorRow ?? 1, 1);
     const maxRun = Math.max(0, newTopRow - postScrollFloor);
     if (useBandHold) {
-      // Band-hold Phase 3: track the full committed run (capped at maxBandModel)
-      // as the band model, but paint only the bottom paintedCount rows that fit
-      // above the current frame. The rest are "pending" — in the model, not yet
-      // on screen, not in scrollback. repositionCommittedBand paints the whole
-      // model contiguously above the frame on the next shrink/collapse.
-      const model = capBandModel(overflowRun, maxBandModel);
+      // Band-hold Phase 3: track the committed run's RETAINED suffix as the band
+      // model, but paint only the bottom paintedCount rows that fit above the
+      // current frame. The rest are "pending" — in the model, not yet on screen,
+      // not in scrollback. repositionCommittedBand paints the whole model
+      // contiguously above the frame on the next shrink/collapse.
+      //
+      // #540: the retained suffix is overflowRun[archiveCount:], the exact
+      // complement of what Phase 1 archived. archiveCount is capBandModel's
+      // `overflowRun.length - maxBandModel` SNAPPED DOWN to a logical-line
+      // boundary, so the model may retain up to (one logical line's height − 1)
+      // rows BEYOND maxBandModel — a straddling logical line is kept whole here
+      // rather than archived half now / half later (which re-fragments it). The
+      // extra pending rows are painted on collapse / flushed on disarm like any
+      // pending rows; the bound is one logical line, so the model never grows
+      // unboundedly.
+      const model = overflowRun.slice(archiveCount);
+      // #540: slice the provenance at the SAME index so it stays 1:1 with `model`.
+      const modelMeta = overflowRunMeta.slice(archiveCount);
       const paintedCount = Math.min(model.length, maxRun);
       const bandTop = newTopRow - paintedCount;
       let out = '';
@@ -556,6 +618,7 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
         });
       }
       self.committedBand = model;
+      self.committedBandMeta = modelMeta;
       self.committedBandBottomRow = newTopRow - 1;
       self.committedBandTopRow = bandTop;
       // Only the bottom `paintedCount` rows reached the terminal; the rest of
@@ -571,6 +634,8 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
       // bottom left boxes rendered un-closed. In the fits path newPainted ===
       // lineCount, so this is the whole array (no behavior change there).
       const newLines = textLines.slice(textLines.length - newPainted);
+      // #540: the new block's provenance, sliced in lockstep with newLines.
+      const newMeta = textMeta.slice(textMeta.length - newPainted);
       // "Whole block painted" = newPainted === textLines.length (no lines
       // dropped to overflow). Compare against textLines.length, NOT lineCount:
       // lineCount is the WRAP-AWARE physical row count (measure()), which can
@@ -607,10 +672,15 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
         (self.committedBandBottomRow === newTopRow - 1 ||
           self.committedBandBottomRow === phase1EffectiveFrameTop - 1);
       const run = contiguousPriorBand ? [...self.committedBand, ...newLines] : newLines;
+      // #540: the merged run's provenance, 1:1 with `run` (same merge decision,
+      // same-order arrays — self.committedBandMeta is 1:1 with self.committedBand).
+      const runMeta = contiguousPriorBand ? [...self.committedBandMeta, ...newMeta] : newMeta;
       // Cap at the room between the anchor floor and the frame top. maxRun >=
       // newPainted always (the new lines fit by construction), so they are
       // never dropped; only prior-band lines that scroll above the floor are.
       const capped = run.length > maxRun ? run.slice(run.length - maxRun) : run;
+      // #540: cap the provenance by the SAME row count so it stays 1:1 with `capped`.
+      const cappedMeta = run.length > maxRun ? runMeta.slice(runMeta.length - maxRun) : runMeta;
       const bandTop = newTopRow - capped.length;
       // Stale band rows above bandTop: when the extended contiguity arm fires, the
       // old band's tracked top (self.committedBandTopRow) may be ABOVE the new
@@ -684,6 +754,7 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
         });
       }
       self.committedBand = capped;
+      self.committedBandMeta = cappedMeta;
       self.committedBandBottomRow = newTopRow - 1;
       self.committedBandTopRow = bandTop;
       // The whole `capped` run is materialized: the fits arm CUP-paints all of
@@ -701,9 +772,14 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
     // FULLY PENDING; repositionCommittedBand paints it on the next shrink/collapse.
     // committedBandBottomRow = collapsedFrameTop - 1 (NOT a 0 sentinel) lets a
     // subsequent full-viewport commit satisfy overflowPriorContiguous and MERGE.
-    const model = capBandModel(overflowRun, maxBandModel);
+    // #540: the retained suffix is overflowRun[archiveCount:], the exact
+    // complement of Phase 1's logical-boundary-snapped archive (same reasoning
+    // as the newTopRow>1 band-hold arm above).
+    const model = overflowRun.slice(archiveCount);
+    const modelMeta = overflowRunMeta.slice(archiveCount);
     const collapsedFrameTop = Math.max(1, rows - 1 - extraRows);
     self.committedBand = model;
+    self.committedBandMeta = modelMeta;
     self.committedBandBottomRow = Math.max(0, collapsedFrameTop - 1);
     self.committedBandTopRow = Math.max(anchorFloor, collapsedFrameTop - model.length);
     // Nothing was painted to the terminal: the whole model is PENDING until
@@ -720,6 +796,7 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
 
 export function clearCommittedBand(self: CommittedBandHost): void {
   self.committedBand = [];
+  self.committedBandMeta = [];
   self.committedBandTopRow = 0;
   self.committedBandBottomRow = 0;
   self.committedBandPaintedRows = 0;

--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -467,7 +467,20 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
       // the overflow path archives the whole block to scrollback and floors
       // Phase 3 at the unchanged anchorFloor to avoid clobbering the banner.
       scrolledRows = fitsAboveFrame ? bandOverflow : 0;
-      self.debugLog('commitAbove:phase1', { lineCount, fitsAboveFrame, bandOverflow });
+      // #665 review: record the snap inputs/outputs too. `archiveCount === 0`
+      // with `rawGenuineOverflow > 0` means the snap retained a straddling
+      // logical line and Phase 1 archived NOTHING this commit — a state that is
+      // only observable in a real terminal (the PTY harness cannot reproduce
+      // DECAWM deferred wrap), so without these fields it leaves no trace.
+      self.debugLog('commitAbove:phase1', {
+        lineCount,
+        fitsAboveFrame,
+        bandOverflow,
+        rawGenuineOverflow,
+        archiveCount,
+        maxBandModel,
+        overflowRunLen: overflowRun.length,
+      });
       if (useBandHold) {
         // Band-hold Phase 1: scroll NOTHING for the rows the model keeps (they
         // are "pending" — painted by repositionCommittedBand on collapse). Only

--- a/src/cli/terminal-compositor.committed-band-commit.ts
+++ b/src/cli/terminal-compositor.committed-band-commit.ts
@@ -487,7 +487,8 @@ export function commitAbove(self: CommittedBandHost, text: string): void {
         // continuation rows are soft-wrap continuations that rejoin on resize).
         // Autowrap is load-bearing here (opposite of the on-screen band paint's
         // withAutowrapDisabled). Phase 3's model keeps overflowRun[archiveCount:]
-        // (see capBandModel call) so archived + retained are disjoint + complete.
+        // (see the `overflowRun.slice(archiveCount)` assignments) so archived +
+        // retained are disjoint + complete.
         if (archiveCount > 0) {
           const archiveLines = scrollbackFlushLines(overflowRun, overflowRunMeta, archiveCount);
           const escape = buildScrollbackArchiveEscape(archiveLines, anchorFloor, rows, cols);

--- a/src/cli/terminal-compositor.frame-preserve.ts
+++ b/src/cli/terminal-compositor.frame-preserve.ts
@@ -6,6 +6,27 @@
  *
  * `import type` for FrameHost keeps this a TYPE-ONLY dependency on frame.ts
  * so there is no runtime circular import between the two siblings.
+ *
+ * #540 axis-2 scope note (logical-line scrollback flush): the two OTHER sites
+ * that push committed content into native scrollback — the band-hold archive
+ * (committed-band-commit.ts) and disarm's flushPendingCommittedBand
+ * (lifecycle.ts) — now emit SOFT-WRAPPABLE logical lines (via committedBandMeta
+ * + buildScrollbackArchiveEscape) so scrolled-off content reflows cleanly on a
+ * width change. The eviction paths HERE deliberately still emit pre-wrapped
+ * PHYSICAL rows: they are the load-bearing height/void-class machinery
+ * (#539/#552/#573), and their paint-full-band-then-scroll mechanism is tightly
+ * coupled to repositionCommittedBand's stateless re-pin and the exact
+ * painted/pending accounting — converting them to the top-paint-logical-then-
+ * scroll mechanism regressed the verdict-card overflow case (the card's closing
+ * border was dropped on a growth eviction). The band-hold archive is the site
+ * that actually carries the width-resize content in practice (verified by
+ * instrumenting the #540 PTY guards), so retaining physical emission here does
+ * NOT reintroduce the fragmentation those guards check. The committedBandMeta
+ * array IS still sliced in lockstep at every eviction below so the 1:1
+ * band↔meta invariant (relied on by reflow and the two logical-flush sites)
+ * holds. A full turnModel rewrite (docs/proposals/tui-compositor-rewrite.md §5
+ * A2) would unify all three sites onto one logical archive; that is the
+ * documented follow-up, out of scope for this targeted fix.
  */
 
 import type { FrameHost } from './terminal-compositor.frame.js';
@@ -134,6 +155,7 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
       evictRowsToScrollback(self, overflow);
       // Survivors physically shifted to [1, room] by the scroll.
       self.committedBand = self.committedBand.slice(overflow);
+      self.committedBandMeta = self.committedBandMeta.slice(overflow); // #540: keep 1:1
       self.committedBandTopRow = 1;
       self.committedBandBottomRow = room;
       self.committedBandPaintedRows = self.committedBand.length;
@@ -173,6 +195,7 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
     // hugging the new frame top (growRoom === desiredTopRow - 1). Record that so a
     // later shrink re-pins from the right place.
     self.committedBand = self.committedBand.slice(growOverflow);
+    self.committedBandMeta = self.committedBandMeta.slice(growOverflow); // #540: keep 1:1
     self.committedBandTopRow = 1;
     self.committedBandBottomRow = growRoom;
     // The full band was re-painted top-aligned above before the scroll, so
@@ -256,6 +279,7 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
     evictRowsToScrollback(self, overflow);
     // Survivors physically shifted to [floor, floor+room-1] by the scroll.
     self.committedBand = self.committedBand.slice(overflow);
+    self.committedBandMeta = self.committedBandMeta.slice(overflow); // #540: keep 1:1
     self.committedBandTopRow = floorBanner;
     self.committedBandBottomRow = floorBanner + roomBanner - 1;
     self.committedBandPaintedRows = self.committedBand.length;
@@ -292,6 +316,7 @@ export function preserveRowsBeforeFrameRender(self: FrameHost, desiredTopRow: nu
       if (self.committedBandTopRow < floor) {
         const lost = floor - self.committedBandTopRow;
         self.committedBand = self.committedBand.slice(lost);
+        self.committedBandMeta = self.committedBandMeta.slice(lost); // #540: keep 1:1
         self.committedBandTopRow = floor;
       }
       if (self.committedBand.length === 0 || self.committedBandBottomRow < floor) {

--- a/src/cli/terminal-compositor.frame.ts
+++ b/src/cli/terminal-compositor.frame.ts
@@ -23,6 +23,7 @@ import { palette } from './palette.js';
 import { renderStatusLine, type ImageAttachment } from './input/attachments.js';
 import type { SpinnerController } from './input/spinner.js';
 import type {
+  BandRowMeta,
   CompositorInputMode,
   CompositorScrollRegionGuard,
   LogUpdateFn,
@@ -70,6 +71,8 @@ export interface FrameHost {
   clipboardFailureMsg: string | null;
   // ── committed-band tracking (mutated by preserveRowsBeforeFrameRender) ──
   committedBand: string[];
+  /** #540: per-physical-row logical provenance, index-aligned 1:1 with committedBand. */
+  committedBandMeta: BandRowMeta[];
   committedBandTopRow: number;
   committedBandBottomRow: number;
   /** Real unpadded frame top; written here by repaint(), read by commitAbove's

--- a/src/cli/terminal-compositor.lifecycle.ts
+++ b/src/cli/terminal-compositor.lifecycle.ts
@@ -15,11 +15,12 @@ import type { SpinnerController } from './input/spinner.js';
 import type { CaretBlinkController } from './input/caret-blink.js';
 import type { SuggestEngine } from './terminal-compositor.types.js';
 import type {
+  BandRowMeta,
   CompositorScrollRegionGuard,
   KeyInfo,
   LogUpdateFn,
 } from './terminal-compositor.types.js';
-import { eraseAndPaintRow } from './terminal-compositor.types.js';
+import { scrollbackFlushLines, buildScrollbackArchiveEscape } from './terminal-compositor.types.js';
 import * as InputDispatch from './terminal-compositor.input-dispatch.js';
 import type { KeyDispatchHost } from './terminal-compositor.input-dispatch.js';
 
@@ -69,6 +70,10 @@ export interface LifecycleHost {
   lastKnownRows: number;
   pendingResizeErase: { top: number; bottom: number } | null;
   readonly committedBand: string[];
+  // #540: per-physical-row logical provenance, index-aligned 1:1 with
+  // committedBand. Read by flushPendingCommittedBand to archive the pending
+  // prefix as soft-wrappable logical lines instead of pre-wrapped physical rows.
+  readonly committedBandMeta: BandRowMeta[];
   readonly committedBandTopRow: number;
   // Read by disarm() to flush genuinely-unpainted committed-band rows to
   // scrollback before teardown. See committedBandPaintedRows on the class.
@@ -437,12 +442,19 @@ export function disarm(self: LifecycleHost): void {
  * this is a no-op and the on-screen rows are left exactly as they are — never
  * re-emitted (HARD CONSTRAINT #1: no duplicate in scrollback).
  *
- * Mechanism: the proven top-write-then-scroll the band-hold Phase-1 archive
- * uses (committed-band-commit.ts) — CUP+EL each pending row at the anchor floor,
- * then a CUP to the physical bottom + `\n`×count to scroll them into history.
- * Chunked by screen height so a pending run taller than the terminal still
- * archives every row. Wrapped in `withFullScrollRegion` (no-op when no status
- * line is started) so the `\n` produces a FULL-screen scroll that enters
+ * Mechanism (#540 axis-2 logical-line flush): the pending prefix is archived as
+ * SOFT-WRAPPABLE logical lines, not pre-hard-wrapped physical rows, so a later
+ * width resize reflows this scrolled-off content cleanly. scrollbackFlushLines
+ * maps the `pendingCount` physical rows to logical lines — reading the FULL
+ * band + meta (not just the prefix) so a logical line STRADDLING the
+ * pending/painted boundary emits its pending rows verbatim rather than
+ * duplicating the on-screen (painted) tail. buildScrollbackArchiveEscape writes
+ * each line at the physical bottom margin with autowrap ON + a trailing `\n`,
+ * so the TERMINAL owns the wrap and the `\n` scrolls it into history; the
+ * terminal re-derives the same per-line physical-row count, so a pending run
+ * taller than the terminal still archives every row (each line scrolls at the
+ * bottom margin independently). Wrapped in `withFullScrollRegion` (no-op when no
+ * status line is started) so the `\n` produces a FULL-screen scroll that enters
  * scrollback rather than a DECSTBM sub-region scroll that silently drops the
  * displaced top line. Best-effort: a throwing stdout means the process is
  * exiting anyway and the next teardown step tears us down.
@@ -450,18 +462,14 @@ export function disarm(self: LifecycleHost): void {
 function flushPendingCommittedBand(self: LifecycleHost): void {
   const pendingCount = self.committedBand.length - self.committedBandPaintedRows;
   if (pendingCount <= 0) return;
-  const pending = self.committedBand.slice(0, pendingCount);
   const rows = Math.max(1, self.stdout.rows ?? 24);
+  const cols = Math.max(1, self.stdout.columns ?? 80);
   const anchorFloor = Math.max(self.anchorRow ?? 1, 1);
+  const archiveLines = scrollbackFlushLines(self.committedBand, self.committedBandMeta, pendingCount);
+  const escape = buildScrollbackArchiveEscape(archiveLines, anchorFloor, rows, cols);
+  if (escape.length === 0) return;
   const write = (): void => {
-    const chunkMax = Math.max(1, rows - anchorFloor + 1);
-    for (let start = 0; start < pending.length; start += chunkMax) {
-      const chunk = pending.slice(start, Math.min(start + chunkMax, pending.length));
-      const topWrite = chunk
-        .map((l, i) => eraseAndPaintRow(anchorFloor + i, l))
-        .join('');
-      self.stdout.write(`${topWrite}\x1b[${rows};1H${'\n'.repeat(chunk.length)}`);
-    }
+    self.stdout.write(escape);
   };
   try {
     if (self.scrollRegion) {

--- a/src/cli/terminal-compositor.logical-flush.test.ts
+++ b/src/cli/terminal-compositor.logical-flush.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Unit tests for the #540 axis-2 logical-line scrollback-flush primitives:
+ * BandRowMeta construction, prefix→scrollback line translation (whole logical
+ * lines vs straddler/orphan verbatim rows), the logical-boundary snap, the
+ * archive-escape builder, and reflowBandSplit's meta propagation.
+ *
+ * These are the pure core of the fix that makes committed content reach native
+ * scrollback as SOFT-WRAPPABLE logical lines (which the terminal reflows cleanly
+ * on a width change) instead of pre-hard-wrapped physical rows (which fragment).
+ * The end-to-end behavior is certified over a real pty by the width-resize-*
+ * scenarios in tests/pty/; these lock the piece-wise invariants and the
+ * duplication/loss guards that the straddle rule depends on.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildBandMeta,
+  scrollbackFlushLines,
+  snapFlushCountToLogicalBoundary,
+  buildScrollbackArchiveEscape,
+  type BandRowMeta,
+} from './terminal-compositor.types.js';
+import { reflowBandSplit } from './terminal-compositor.band-reflow.js';
+import { hardWrapToWidth } from './wrap.js';
+
+// A logical line 186 cols wide (no interior break points) — the #540 shape:
+// hard-wraps to 2 physical rows at 120, 4 at 48, reflows to 1 head + N wrapped.
+const LONG = `LOGSTART_${'x'.repeat(170)}_LOGEND`;
+
+describe('buildBandMeta', () => {
+  it('records one head row per short logical line', () => {
+    const meta = buildBandMeta(['alpha', 'bravo', 'charlie'], 80);
+    expect(meta).toEqual([
+      { logicalText: 'alpha', isHead: true },
+      { logicalText: 'bravo', isHead: true },
+      { logicalText: 'charlie', isHead: true },
+    ]);
+  });
+
+  it('records head + continuation rows for a wide logical line, 1:1 with the physical rows', () => {
+    const width = 120;
+    const physicalCount = hardWrapToWidth(LONG, width).split('\n').length;
+    const meta = buildBandMeta([LONG], width);
+    expect(meta.length).toBe(physicalCount); // 1:1 with what committedBand holds
+    expect(meta[0]).toEqual({ logicalText: LONG, isHead: true });
+    for (let i = 1; i < meta.length; i++) {
+      expect(meta[i]).toEqual({ logicalText: LONG, isHead: false });
+    }
+  });
+
+  it('treats a blank separator line as its own single head row', () => {
+    const meta = buildBandMeta(['body', ''], 80);
+    expect(meta).toEqual([
+      { logicalText: 'body', isHead: true },
+      { logicalText: '', isHead: true },
+    ]);
+  });
+
+  it('stays index-aligned with the physical rows across a mix of wide + short lines', () => {
+    const width = 40;
+    const logical = [LONG, 'short', LONG];
+    const rows = logical.flatMap((l) => hardWrapToWidth(l, width).split('\n'));
+    const meta = buildBandMeta(logical, width);
+    expect(meta.length).toBe(rows.length);
+    // Every head index begins a run whose logicalText matches, and the count of
+    // heads equals the number of logical lines.
+    expect(meta.filter((m) => m.isHead).length).toBe(logical.length);
+  });
+});
+
+describe('scrollbackFlushLines', () => {
+  const width = 120;
+  // A band of [LONG (2 rows @120), 'tail'] → physical rows + aligned meta.
+  const rows = [LONG, 'tail'].flatMap((l) => hardWrapToWidth(l, width).split('\n'));
+  const meta = buildBandMeta([LONG, 'tail'], width);
+
+  it('emits a whole logical line ONCE when all its physical rows are in the prefix', () => {
+    // Flush the whole band: LONG collapses back to one logical line, tail stays 1.
+    const out = scrollbackFlushLines(rows, meta, rows.length);
+    expect(out).toEqual([LONG, 'tail']);
+  });
+
+  it('emits straddler rows VERBATIM when a logical line spans the flush boundary', () => {
+    // Flush only 1 row — the head of LONG, whose 2nd physical row is retained.
+    // Emitting the whole logical line would duplicate the retained tail once it
+    // reflowed, so the in-prefix physical row is emitted verbatim instead.
+    const out = scrollbackFlushLines(rows, meta, 1);
+    expect(out).toEqual([rows[0]]); // the physical head row, NOT the logical LONG
+    expect(out[0]).not.toBe(LONG);
+  });
+
+  it('emits an orphaned continuation row (head already sliced away) verbatim', () => {
+    // Simulate a band whose FIRST row is a continuation (its head was archived
+    // by an earlier flush): meta[0].isHead === false.
+    const orphanRows = rows.slice(1); // [LONG-row1(cont), 'tail']
+    const orphanMeta = meta.slice(1);
+    expect(orphanMeta[0]?.isHead).toBe(false);
+    const out = scrollbackFlushLines(orphanRows, orphanMeta, 1);
+    expect(out).toEqual([orphanRows[0]]); // verbatim continuation fragment
+  });
+
+  it('falls back to verbatim physical rows when meta is missing or short (never loses content)', () => {
+    expect(scrollbackFlushLines(rows, undefined, rows.length)).toEqual(rows);
+    expect(scrollbackFlushLines(rows, meta.slice(0, 1), rows.length)).toEqual(rows);
+  });
+
+  it('accounts for every physical row exactly once across a mixed prefix', () => {
+    // [short, LONG(2 rows), short2]; flush the first 3 rows (short + both LONG
+    // rows) → whole `short` + whole LONG; short2 retained.
+    const logical = ['short', LONG, 'short2'];
+    const r = logical.flatMap((l) => hardWrapToWidth(l, width).split('\n'));
+    const m = buildBandMeta(logical, width);
+    const out = scrollbackFlushLines(r, m, 3);
+    expect(out).toEqual(['short', LONG]);
+  });
+
+  it('clamps count to the row array length', () => {
+    const out = scrollbackFlushLines(rows, meta, 999);
+    expect(out).toEqual([LONG, 'tail']);
+  });
+});
+
+describe('snapFlushCountToLogicalBoundary', () => {
+  const width = 120;
+  const logical = [LONG, 'a', 'b']; // rows: [L0, L1, a, b]  heads at 0,2,3
+  const meta = buildBandMeta(logical, width);
+  const total = meta.length; // 4
+
+  it('snaps a mid-logical-line count DOWN to the previous head (retain the straddler whole)', () => {
+    // count=1 lands inside LONG (rows 0,1); the only head at/below is index 0 → snap to 0.
+    expect(snapFlushCountToLogicalBoundary(meta, 1, total)).toBe(0);
+  });
+
+  it('keeps a count that already sits on a logical boundary', () => {
+    // index 2 is a head ('a') → LONG (2 rows) is whole below it.
+    expect(snapFlushCountToLogicalBoundary(meta, 2, total)).toBe(2);
+    expect(snapFlushCountToLogicalBoundary(meta, 3, total)).toBe(3);
+  });
+
+  it('returns the full total unchanged (whole band is always a clean boundary)', () => {
+    expect(snapFlushCountToLogicalBoundary(meta, total, total)).toBe(total);
+    expect(snapFlushCountToLogicalBoundary(meta, 999, total)).toBe(total);
+  });
+
+  it('returns the raw count when meta is missing/short (verbatim fallback path)', () => {
+    expect(snapFlushCountToLogicalBoundary(undefined, 2, total)).toBe(2);
+    expect(snapFlushCountToLogicalBoundary(meta.slice(0, 1), 2, total)).toBe(2);
+  });
+
+  it('returns 0 for a non-positive count', () => {
+    expect(snapFlushCountToLogicalBoundary(meta, 0, total)).toBe(0);
+    expect(snapFlushCountToLogicalBoundary(meta, -3, total)).toBe(0);
+  });
+});
+
+describe('buildScrollbackArchiveEscape', () => {
+  it('returns empty string for no lines', () => {
+    expect(buildScrollbackArchiveEscape([], 1, 24, 80)).toBe('');
+  });
+
+  it('paints at the floor, flows lines with CRLF, and scrolls the total physical height', () => {
+    const esc = buildScrollbackArchiveEscape(['a', 'b'], 1, 24, 80);
+    // Two 1-row lines → paint at row 1, join with \r\n, then CUP to bottom (24)
+    // and scroll 2 rows.
+    expect(esc).toContain('\x1b[1;1H'); // CUP to the floor
+    expect(esc).toContain('\x1b[2Ka'); // erase + line a
+    expect(esc).toContain('\x1b[2Kb');
+    expect(esc).toContain('\r\n'); // lines flow with CRLF so each starts fresh
+    expect(esc).toContain('\x1b[24;1H'); // CUP to the physical bottom margin
+    expect(esc.endsWith('\n\n')).toBe(true); // scroll 2 physical rows
+  });
+
+  it('scrolls a wide logical line by its WRAPPED physical height, not 1', () => {
+    const width = 120;
+    const h = hardWrapToWidth(LONG, width).split('\n').length; // 2 at 120
+    const esc = buildScrollbackArchiveEscape([LONG], 1, 24, width);
+    // The trailing scroll is `\n` × h.
+    const scrollTail = esc.slice(esc.lastIndexOf('\x1b[24;1H') + '\x1b[24;1H'.length);
+    expect(scrollTail).toBe('\n'.repeat(h));
+    expect(h).toBeGreaterThan(1);
+  });
+
+  it('chunks a block taller than the paint region into multiple paint+scroll passes', () => {
+    // 30 one-row lines into a 24-row terminal with floor 1 → chunkMax=24, so it
+    // splits into 2 chunks (24 + 6) each with its own bottom-CUP + scroll.
+    const lines = Array.from({ length: 30 }, (_, i) => `row${i}`);
+    const esc = buildScrollbackArchiveEscape(lines, 1, 24, 80);
+    const bottomCups = esc.split('\x1b[24;1H').length - 1;
+    expect(bottomCups).toBe(2); // one scroll per chunk
+  });
+});
+
+describe('reflowBandSplit — meta propagation (#540)', () => {
+  it('propagates logicalText through a NARROWING re-wrap and recomputes isHead', () => {
+    // One logical line committed at 120 (2 physical rows), painted (suffix).
+    const width0 = 120;
+    const band0 = hardWrapToWidth(LONG, width0).split('\n');
+    const meta0 = buildBandMeta([LONG], width0);
+    expect(band0.length).toBe(2);
+
+    // Narrow to 68: re-wrap. Physical row count grows; logicalText is preserved
+    // on every sub-row; exactly one head remains.
+    const res = reflowBandSplit(band0, band0.length, 68, meta0);
+    expect(res.rows.length).toBe(res.meta.length); // 1:1 invariant
+    expect(res.meta.every((m) => m.logicalText === LONG)).toBe(true);
+    expect(res.meta.filter((m) => m.isHead).length).toBe(1);
+    expect(res.meta[0]?.isHead).toBe(true);
+    // paintedRows tracks the re-wrapped suffix count (whole band was painted).
+    expect(res.paintedRows).toBe(res.rows.length);
+  });
+
+  it('preserves the pending/painted split point across the re-wrap', () => {
+    // Band = [pendingShort, LONG(painted)]; paintedRows counts LONG's rows only.
+    const width0 = 120;
+    const longRows = hardWrapToWidth(LONG, width0).split('\n');
+    const band0 = ['pendingShort', ...longRows];
+    const meta0 = buildBandMeta(['pendingShort', LONG], width0);
+    const paintedRows0 = longRows.length; // the painted SUFFIX is LONG's rows
+
+    const res = reflowBandSplit(band0, paintedRows0, 68, meta0);
+    // pending prefix is still just the one short line (1 row at any width < it);
+    // painted suffix is LONG re-wrapped at 68.
+    const expectedPaintedRows = hardWrapToWidth(LONG, 68).split('\n').length;
+    expect(res.paintedRows).toBe(expectedPaintedRows);
+    // The pending prefix's provenance is intact.
+    expect(res.meta[0]).toEqual({ logicalText: 'pendingShort', isHead: true });
+  });
+
+  it('falls back to the physical row as its own logicalText when meta is omitted', () => {
+    const band0 = hardWrapToWidth(LONG, 120).split('\n');
+    const res = reflowBandSplit(band0, band0.length, 68); // no meta arg
+    expect(res.rows.length).toBe(res.meta.length);
+    // Each pre-existing physical row is treated as its own logical line: the
+    // fallback records the row text as logicalText and isHead=true per source row.
+    expect(res.meta.filter((m) => m.isHead).length).toBe(band0.length);
+  });
+
+  it('returns empty for an empty band', () => {
+    expect(reflowBandSplit([], 0, 80, [])).toEqual({ rows: [], paintedRows: 0, meta: [] });
+  });
+
+  it('widening keeps the retained logicalText so a later flush can rejoin the line', () => {
+    // Committed narrow (48 → 4 rows), then WIDEN to 110. Re-wrapping physical
+    // rows independently keeps their (stale) break points on screen, but the
+    // retained logicalText is the whole line — which the scrollback flush emits.
+    const band0 = hardWrapToWidth(LONG, 48).split('\n');
+    const meta0 = buildBandMeta([LONG], 48);
+    expect(band0.length).toBe(4);
+    const res = reflowBandSplit(band0, band0.length, 110, meta0);
+    // Whatever the on-screen physical rows become, the logical source is intact
+    // and single, so scrollbackFlushLines(res.rows, res.meta, all) === [LONG].
+    const flushed = scrollbackFlushLines(res.rows, res.meta, res.rows.length);
+    expect(flushed).toEqual([LONG]);
+  });
+});

--- a/src/cli/terminal-compositor.logical-flush.test.ts
+++ b/src/cli/terminal-compositor.logical-flush.test.ts
@@ -185,8 +185,43 @@ describe('buildScrollbackArchiveEscape', () => {
     // splits into 2 chunks (24 + 6) each with its own bottom-CUP + scroll.
     const lines = Array.from({ length: 30 }, (_, i) => `row${i}`);
     const esc = buildScrollbackArchiveEscape(lines, 1, 24, 80);
-    const bottomCups = esc.split('\x1b[24;1H').length - 1;
-    expect(bottomCups).toBe(2); // one scroll per chunk
+    // Count SCROLL passes (bottom-CUP immediately followed by a line feed), not
+    // every CUP to the bottom row: the per-physical-row pre-erase pass (#665)
+    // also CUPs to row 24 when a chunk fills the region, and that is not a scroll.
+    const scrollPasses = esc.match(/\x1b\[24;1H\n/g)?.length ?? 0;
+    expect(scrollPasses).toBe(2); // one scroll per chunk
+  });
+
+  it('erases every RESIDENT physical row, not just each logical line head (#665)', () => {
+    // A 2-row logical line at width 120: the per-line `\x1b[2K` covers only its
+    // head row, so the continuation row must be erased by the pre-erase pass —
+    // otherwise stale glyphs to the right of the wrapped tail (the previous
+    // frame's content) scroll into native scrollback verbatim.
+    const h = hardWrapToWidth(LONG, 120).split('\n').length;
+    expect(h).toBe(2);
+    const esc = buildScrollbackArchiveEscape([LONG], 1, 24, 120);
+    expect(esc).toContain('\x1b[1;1H\x1b[2K'); // head row erased
+    expect(esc).toContain('\x1b[2;1H\x1b[2K'); // continuation row erased
+    // Rows below the painted block are NOT touched (matches the pre-#540 footprint).
+    expect(esc).not.toContain('\x1b[3;1H\x1b[2K');
+  });
+
+  it('scrolls only the RESIDENT height for a line taller than the paint region (#665)', () => {
+    // Codex P1 repro: a 7-physical-row line in a 5-row terminal (floor 1 →
+    // chunkMax 5). Painting it auto-scrolls the 2-row overflow past the bottom
+    // margin, so the explicit scroll must be 5 — emitting 7 would double-count
+    // the overflow and append 2 blank rows to history (9 archived rows, not 7).
+    const width = 10;
+    const line = 'y'.repeat(65); // 6 full rows + a 5-col remainder = 7 rows
+    const h = hardWrapToWidth(line, width).split('\n').length;
+    expect(h).toBe(7);
+    const chunkMax = 5;
+    const esc = buildScrollbackArchiveEscape([line], 1, 5, width);
+    const scrollTail = esc.slice(esc.lastIndexOf('\x1b[5;1H') + '\x1b[5;1H'.length);
+    expect(scrollTail).toBe('\n'.repeat(chunkMax));
+    // Autowrap overflow + explicit resident scroll === the line's true height,
+    // so exactly `h` rows enter scrollback and no blank rows are appended.
+    expect(h - chunkMax + scrollTail.length).toBe(h);
   });
 });
 

--- a/src/cli/terminal-compositor.logical-flush.test.ts
+++ b/src/cli/terminal-compositor.logical-flush.test.ts
@@ -288,3 +288,70 @@ describe('reflowBandSplit — meta propagation (#540)', () => {
     expect(flushed).toEqual([LONG]);
   });
 });
+
+/**
+ * #665 review — column-accounting inputs where `hardWrapToWidth`'s row count
+ * and a real terminal's DECAWM wrap can disagree. These are the cases the PTY
+ * harness cannot certify (it replays an emulator, not deferred wrap), so the
+ * piece-wise row count is locked here instead: every scroll count in the
+ * archive path is derived from `buildBandMeta`, so a row-count error at these
+ * boundaries desyncs the anchor floor from the screen.
+ */
+describe('#665 review: wrap-boundary and degenerate-width archive inputs', () => {
+  it('counts a line of exactly `width` columns as ONE physical row', () => {
+    const width = 80;
+    const line = 'x'.repeat(width);
+    expect(buildBandMeta([line], width)).toEqual([{ logicalText: line, isHead: true }]);
+  });
+
+  it('counts a line of exactly 2x width as head + one continuation', () => {
+    const width = 40;
+    const line = 'y'.repeat(width * 2);
+    const meta = buildBandMeta([line], width);
+    expect(meta.map((m) => m.isHead)).toEqual([true, false]);
+  });
+
+  it('flushes an exact-multiple line as ONE logical line (no split at the boundary)', () => {
+    const width = 40;
+    const line = 'z'.repeat(width * 2);
+    const rows = hardWrapToWidth(line, width).split('\n');
+    const meta = buildBandMeta([line], width);
+    expect(rows.length).toBe(meta.length);
+    expect(scrollbackFlushLines(rows, meta, rows.length)).toEqual([line]);
+  });
+
+  it('counts double-width CJK glyphs by DISPLAY COLUMN, not by character', () => {
+    const width = 80;
+    const line = '\u6f22'.repeat(50); // 50 glyphs = 100 display columns
+    const meta = buildBandMeta([line], width);
+    expect(meta.length).toBe(2);
+    expect(meta.map((m) => m.isHead)).toEqual([true, false]);
+  });
+
+  it('flushes a wide-glyph logical line whole, never split mid-glyph', () => {
+    const width = 80;
+    const line = '\u6f22'.repeat(50);
+    const rows = hardWrapToWidth(line, width).split('\n');
+    const meta = buildBandMeta([line], width);
+    expect(scrollbackFlushLines(rows, meta, rows.length)).toEqual([line]);
+  });
+
+  it('preserves an SGR run that spans a wrap boundary', () => {
+    const width = 40;
+    const styled = `\x1b[31m${'r'.repeat(90)}\x1b[39m`;
+    const rows = hardWrapToWidth(styled, width).split('\n');
+    const meta = buildBandMeta([styled], width);
+    expect(rows.length).toBe(meta.length);
+    expect(meta.length).toBeGreaterThan(1);
+    // The archive emits logicalText (the PRE-wrap source), so the style run
+    // reaches scrollback intact rather than re-emitted mid-sequence per row.
+    expect(scrollbackFlushLines(rows, meta, rows.length)).toEqual([styled]);
+  });
+
+  it('survives a 1-column width without throwing', () => {
+    const meta = buildBandMeta(['ab'], 1);
+    expect(meta.map((m) => m.isHead)).toEqual([true, false]);
+    const esc = buildScrollbackArchiveEscape(['ab'], 1, 3, 1);
+    expect(esc.length).toBeGreaterThan(0);
+  });
+});

--- a/src/cli/terminal-compositor.render-not-repin.test.ts
+++ b/src/cli/terminal-compositor.render-not-repin.test.ts
@@ -64,6 +64,7 @@ function makeHost(stdout: Out, over: Partial<CommittedBandHost>): CommittedBandH
     repaint: () => {},
     debugLog: () => {},
     committedBand: [],
+    committedBandMeta: [],
     committedBandTopRow: 0,
     committedBandBottomRow: 0,
     lastMeasuredFrameTop: 0,

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -25,6 +25,7 @@ import { SpinnerController } from './input/spinner.js';
 import { CaretBlinkController, DEFAULT_CARET_BLINK_INTERVAL_MS } from './input/caret-blink.js';
 import type { StdinClaimHandle } from './input/stdin-claim.js';
 import {
+  type BandRowMeta,
   type CompositorInputMode,
   type CompositorScrollRegionGuard,
   type KeyInfo,
@@ -409,6 +410,24 @@ export class TerminalCompositor {
   // 1-based screen positions; 0 means "unset". See repositionCommittedBand().
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   committedBand: string[] = [];
+  // #540 axis-2 (retained logical source): per-physical-row provenance, index-
+  // aligned 1:1 with committedBand (committedBandMeta.length === committedBand
+  // .length, always). Each entry is the FULL pre-hard-wrap logical line that
+  // physical row is a fragment of, plus an isHead flag marking a logical line's
+  // first physical row (see BandRowMeta). committedBand stays POST-hard-wrap
+  // physical rows for the LIVE band's one-terminal-row-per-entry math; this
+  // retains the logical form the physical rows cannot reconstruct (a soft-wrap
+  // break and a hard paragraph break are indistinguishable once flattened), so
+  // the three scrollback-flush sites (committed-band-commit band-hold archive,
+  // frame-preserve eviction, lifecycle flushPendingCommittedBand) can emit
+  // LOGICAL lines — which the terminal soft-wraps and reflows cleanly on a
+  // width change — instead of pre-wrapped physical rows that fragment
+  // (docs/tui-resize-reflow.md, the width-resize-fragment-* PTY guards). Kept
+  // in lockstep with committedBand at every mutation: reflow re-derives it,
+  // commit Phase 3 merge/cap slices it in parallel, frame-preserve eviction
+  // slices it in parallel. clearCommittedBand()/resetState() empty it.
+  /** @internal Relaxed from `private` for the committed-band + frame + reflow modules. */
+  committedBandMeta: BandRowMeta[] = [];
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */
   committedBandTopRow = 0;
   /** @internal Relaxed from `private` for the committed-band module (CommittedBandHost). */

--- a/src/cli/terminal-compositor.types.ts
+++ b/src/cli/terminal-compositor.types.ts
@@ -8,6 +8,7 @@
  */
 
 import { palette } from './palette.js';
+import { hardWrapToWidth } from './wrap.js';
 import { displayWidth, truncateDisplayWidth } from './display.js';
 import type { LoadingTip } from './loading-tips.js';
 import type { ImageAttachment } from './input/attachments.js';
@@ -90,6 +91,239 @@ export function formatElapsed(startedAt: number): string {
  */
 export function eraseAndPaintRow(row: number, line?: string): string {
   return `\x1b[${row};1H\x1b[2K${line ?? ''}`;
+}
+
+/**
+ * Per-physical-row provenance for the committed band (#540 axis-2).
+ *
+ * `committedBand` holds POST-hard-wrap PHYSICAL rows — one terminal row per
+ * entry — because the LIVE band's CUP/scroll row math needs exactly one
+ * terminal row per array element (a wide logical line's wrapped tail must not
+ * be "eaten" by the next commit's paint). But the pre-wrap LOGICAL form is not
+ * reconstructible from those physical rows: a soft-wrap break and a hard
+ * paragraph break are indistinguishable once flattened, so joining rows back
+ * would fuse genuinely separate lines and a widen could never re-wrap them.
+ *
+ * We therefore retain the logical source PER PHYSICAL ROW, index-aligned 1:1
+ * with `committedBand` (`committedBandMeta.length === committedBand.length`,
+ * always). `logicalText` is the FULL logical line this physical row is a
+ * fragment of; `isHead` marks the FIRST physical row of that logical line.
+ * The 1:1 alignment makes every band mutation a parallel slice — the cap /
+ * eviction / reflow paths that slice `committedBand` mirror the slice on the
+ * meta with identical index math, so the retention can never desync even when
+ * a slice lands mid-logical-line (the surviving continuation rows keep
+ * `isHead:false`, which the scrollback-flush helper reads to emit them
+ * verbatim rather than re-emitting the whole logical line — see
+ * {@link scrollbackFlushLines}).
+ *
+ * The scrollback-flush sites consult this to emit LOGICAL lines (which the
+ * terminal soft-wraps and can later reflow cleanly on a width change) instead
+ * of the pre-hard-wrapped physical rows (which the terminal can only reflow
+ * per-row → the width-resize fragmentation of #540). The LIVE band keeps using
+ * the physical `committedBand` rows unchanged.
+ */
+export interface BandRowMeta {
+  /** The full logical (pre-hard-wrap) line this physical row is a fragment of. */
+  logicalText: string;
+  /** True iff this is the FIRST physical row of its logical line. */
+  isHead: boolean;
+}
+
+/**
+ * Build the {@link BandRowMeta} array for a list of LOGICAL lines hard-wrapped
+ * at `width` — the inverse-recording of the same
+ * `logicalLines.flatMap((l) => hardWrapToWidth(l, width).split('\n'))` that
+ * produces the physical `committedBand` rows, so the returned meta is
+ * index-aligned 1:1 with those rows. A logical line that fits in `width` is a
+ * single head row; one that overflows contributes a head row + N-1 continuation
+ * rows all carrying the same `logicalText`.
+ */
+export function buildBandMeta(logicalLines: readonly string[], width: number): BandRowMeta[] {
+  const meta: BandRowMeta[] = [];
+  for (const logical of logicalLines) {
+    const physicalCount = hardWrapToWidth(logical, width).split('\n').length;
+    for (let i = 0; i < physicalCount; i++) {
+      meta.push({ logicalText: logical, isHead: i === 0 });
+    }
+  }
+  return meta;
+}
+
+/**
+ * Translate the first `count` PHYSICAL rows of a band (the prefix being
+ * scrolled off into native scrollback) into the lines to WRITE to scrollback,
+ * emitting LOGICAL lines where a whole logical line lies within the prefix and
+ * PHYSICAL rows verbatim where a logical line straddles the flush boundary
+ * (#540 axis-2).
+ *
+ * Why: writing a raw logical line to the terminal with autowrap ON makes the
+ * terminal own the wrapping, so its continuation rows are soft-wrap
+ * continuations (isWrapped) that reflow cleanly on a later resize. Writing the
+ * pre-hard-wrapped physical rows instead lands N hard-newline rows the terminal
+ * can only reflow independently — the fragmentation bug.
+ *
+ * The straddle rule prevents both DUPLICATION and LOSS: if only some of a
+ * logical line's physical rows are in the flush prefix (the rest stay on
+ * screen), emitting the whole logical line would duplicate the on-screen tail
+ * in scrollback once it reflowed to full height. So a straddling line's
+ * in-prefix rows are emitted verbatim as physical rows (they stay
+ * hard-newlined — acceptable, since the surviving on-screen tail can never
+ * rejoin them anyway). A prefix whose first row is a continuation (`isHead:
+ * false` at index 0 — a logical line whose head was sliced away by an earlier
+ * eviction/cap) is likewise emitted verbatim. Every physical row in
+ * `[0, count)` is accounted for exactly once, so the physical-row COUNT the
+ * caller scrolls is unchanged whether a run emits as one logical line or as
+ * verbatim rows — the terminal re-derives the same number of physical rows from
+ * the logical line via its own autowrap (hardWrapToWidth is defined to match
+ * the terminal's char-level wrap).
+ *
+ * `meta` must be index-aligned 1:1 with `rows` (see {@link BandRowMeta}).
+ * Falls back to verbatim physical rows if `meta` is missing/short (defensive:
+ * never lose content to a meta desync).
+ */
+export function scrollbackFlushLines(
+  rows: readonly string[],
+  meta: readonly BandRowMeta[] | undefined,
+  count: number,
+): string[] {
+  const end = Math.max(0, Math.min(count, rows.length));
+  if (!meta || meta.length < rows.length) {
+    // No reliable provenance — emit the physical rows verbatim (pre-fix
+    // behavior); correctness (content present) over rejoinability.
+    return rows.slice(0, end);
+  }
+  const out: string[] = [];
+  let i = 0;
+  while (i < end) {
+    if (!meta[i]?.isHead) {
+      // A continuation row whose head is not in this prefix (sliced away
+      // earlier): emit verbatim — its logical line is already fragmented.
+      out.push(rows[i] ?? '');
+      i += 1;
+      continue;
+    }
+    // A logical-line head: find the extent of this logical line (until the
+    // next head or the end of the array — NOT bounded by `count`, so we can
+    // detect a straddle past the flush boundary).
+    let j = i + 1;
+    while (j < rows.length && !meta[j]?.isHead) j += 1;
+    if (j <= end) {
+      // The whole logical line is within the flush prefix → emit it ONCE as a
+      // logical line (the terminal soft-wraps it; reflows cleanly on resize).
+      out.push(meta[i]!.logicalText);
+    } else {
+      // Straddle: only rows [i, end) of this logical line are being flushed;
+      // its tail stays on screen. Emit the in-prefix physical rows verbatim so
+      // the on-screen tail is never duplicated in scrollback.
+      for (let k = i; k < end; k++) out.push(rows[k] ?? '');
+    }
+    i = j;
+  }
+  return out;
+}
+
+/**
+ * Snap a physical-row flush count DOWN to the nearest LOGICAL-line boundary
+ * (#540 axis-2) so a scrollback archive never splits one logical line across
+ * two archive events — which is what re-introduces the fragmentation even with
+ * logical-line emission (a line archived one physical row at a time is emitted
+ * verbatim each time, never as a whole soft-wrappable line).
+ *
+ * Given `meta` (per-physical-row provenance) and a desired `count` of leading
+ * physical rows to flush, returns the largest `n <= count` such that either
+ * `n === 0`, `n === meta.length`, or `meta[n]` is a logical-line head (i.e. the
+ * cut falls exactly between two logical lines, never mid-line). The caller
+ * archives `[0, n)` as whole logical lines and RETAINS the straddling line (and
+ * everything after it) in the band model until a later flush covers all of its
+ * rows. Returns `count` unchanged when `meta` is missing/short (the verbatim
+ * fallback in {@link scrollbackFlushLines} then applies).
+ */
+export function snapFlushCountToLogicalBoundary(
+  meta: readonly BandRowMeta[] | undefined,
+  count: number,
+  total: number,
+): number {
+  const c = Math.max(0, Math.min(count, total));
+  if (!meta || meta.length < total) return c;
+  if (c >= total) return total; // whole band flushes — always a clean boundary
+  // Walk DOWN from c to the nearest logical-line head (a clean cut point).
+  for (let n = c; n > 0; n--) {
+    if (meta[n]?.isHead) return n;
+  }
+  return 0;
+}
+
+/**
+ * Build the escape string that archives `lines` to native scrollback as
+ * SOFT-WRAPPABLE content (#540 axis-2).
+ *
+ * Mechanism (verified against @xterm/headless + real pty): paint the lines at
+ * the anchor floor as a normal top-of-screen text stream — each line CUP-less
+ * after the first, separated by `\r\n`, with autowrap ON so the terminal wraps
+ * an over-wide LOGICAL line itself (its continuation rows carry the terminal's
+ * soft-wrap flag → reflow-clean on a later resize) — then CUP to the physical
+ * bottom margin and emit `\n` × (total physical rows) to scroll the whole
+ * painted block up and OFF the top into native scrollback. Writing at the
+ * bottom-margin-only (the naive approach) leaves the content in the VIEWPORT,
+ * never scrollback; writing at the top then scrolling the exact painted height
+ * is what carries it into history. A line that fits the width is one physical
+ * row and contributes one scroll — byte-equivalent outcome to the pre-#540
+ * physical-row archive; a wide line contributes its wrapped height and rejoins
+ * cleanly.
+ *
+ * Chunked by the paintable height (`rows - anchorFloor + 1`) so a block taller
+ * than the terminal still archives every row: each chunk is painted top-aligned
+ * and scrolled by its own physical height before the next chunk, so the paint
+ * never itself overflows the bottom margin and auto-scrolls (which would
+ * double-count). `width` is needed to compute each line's physical (wrapped)
+ * height; it MUST equal the terminal's current column count so hardWrapToWidth's
+ * split matches what the terminal's autowrap will do.
+ *
+ * MUST run with autowrap ENABLED (the default) and inside the caller's
+ * full-screen scroll region — the opposite of the on-screen band paint, which
+ * runs inside `withAutowrapDisabled`. Autowrap is load-bearing HERE: it is what
+ * makes the terminal, not the app, own the wrap so scrollback can later reflow.
+ *
+ * Returns '' for an empty list (caller writes nothing).
+ */
+export function buildScrollbackArchiveEscape(
+  lines: readonly string[],
+  anchorFloor: number,
+  bottomRow: number,
+  width: number,
+): string {
+  if (lines.length === 0) return '';
+  const floor = Math.max(1, anchorFloor);
+  const bottom = Math.max(1, bottomRow);
+  const chunkMax = Math.max(1, bottom - floor + 1);
+  const physicalHeight = (line: string): number =>
+    Math.max(1, hardWrapToWidth(line, width).split('\n').length);
+  let out = '';
+  let chunk: string[] = [];
+  let chunkRows = 0;
+  const flushChunk = (): void => {
+    if (chunk.length === 0) return;
+    // Paint the chunk top-aligned at the floor, flowing with \r\n so each
+    // logical line starts on a fresh row and autowrap owns intra-line wrapping.
+    out += `\x1b[${floor};1H`;
+    out += chunk.map((l) => `\x1b[2K${l}`).join('\r\n');
+    // Scroll the exact painted physical height off the top into scrollback.
+    out += `\x1b[${bottom};1H${'\n'.repeat(chunkRows)}`;
+    chunk = [];
+    chunkRows = 0;
+  };
+  for (const line of lines) {
+    const h = physicalHeight(line);
+    // A single line taller than the whole paint region: give it its own chunk
+    // (it will scroll fully; the terminal handles the intra-paint autowrap
+    // scroll for the overflow beyond the region, and the explicit scroll count
+    // still equals its physical height).
+    if (chunkRows > 0 && chunkRows + h > chunkMax) flushChunk();
+    chunk.push(line);
+    chunkRows += h;
+  }
+  flushChunk();
+  return out;
 }
 
 /**

--- a/src/cli/terminal-compositor.types.ts
+++ b/src/cli/terminal-compositor.types.ts
@@ -265,19 +265,22 @@ export function snapFlushCountToLogicalBoundary(
  * bottom margin and emit `\n` × (total physical rows) to scroll the whole
  * painted block up and OFF the top into native scrollback. Writing at the
  * bottom-margin-only (the naive approach) leaves the content in the VIEWPORT,
- * never scrollback; writing at the top then scrolling the exact painted height
- * is what carries it into history. A line that fits the width is one physical
+ * never scrollback; writing at the top then scrolling the resident painted
+ * height is what carries it into history. A line that fits the width is one physical
  * row and contributes one scroll — byte-equivalent outcome to the pre-#540
  * physical-row archive; a wide line contributes its wrapped height and rejoins
  * cleanly.
  *
  * Chunked by the paintable height (`rows - anchorFloor + 1`) so a block taller
  * than the terminal still archives every row: each chunk is painted top-aligned
- * and scrolled by its own physical height before the next chunk, so the paint
- * never itself overflows the bottom margin and auto-scrolls (which would
- * double-count). `width` is needed to compute each line's physical (wrapped)
- * height; it MUST equal the terminal's current column count so hardWrapToWidth's
- * split matches what the terminal's autowrap will do.
+ * and scrolled off before the next chunk. A chunk is scrolled by its RESIDENT
+ * height — `min(chunkRows, chunkMax)` — not its full physical height: a SINGLE
+ * line taller than the region cannot be split across chunks, so its paint does
+ * overflow the bottom margin and the terminal auto-scrolls the excess itself.
+ * Adding a full-height explicit scroll on top of that auto-scroll double-counts
+ * and appends blank rows to history. `width` is needed to compute each line's
+ * physical (wrapped) height; it MUST equal the terminal's current column count
+ * so hardWrapToWidth's split matches what the terminal's autowrap will do.
  *
  * MUST run with autowrap ENABLED (the default) and inside the caller's
  * full-screen scroll region — the opposite of the on-screen band paint, which
@@ -303,21 +306,37 @@ export function buildScrollbackArchiveEscape(
   let chunkRows = 0;
   const flushChunk = (): void => {
     if (chunk.length === 0) return;
+    // External constraint (DECAWM autowrap owns the wrap): a chunk taller than
+    // the paint region auto-scrolls `chunkRows - chunkMax` rows into history
+    // DURING the paint, so only the rows still RESIDENT in the region may be
+    // scrolled explicitly afterwards. `residentRows` is that count, and is the
+    // single source of truth for both the pre-erase span and the scroll count.
+    const residentRows = Math.min(chunkRows, chunkMax);
+    // Erase every PHYSICAL row the paint will occupy, before painting it. The
+    // per-line `\x1b[2K` below erases only each logical line's HEAD row; a line
+    // that autowraps leaves its continuation rows unerased, so stale glyphs to
+    // the right of the wrapped tail scroll into scrollback verbatim. Restores
+    // the pre-#540 per-physical-row `eraseAndPaintRow` erase footprint exactly
+    // (same span, no rows below the painted block touched).
+    for (let r = 0; r < residentRows; r++) out += `\x1b[${floor + r};1H\x1b[2K`;
     // Paint the chunk top-aligned at the floor, flowing with \r\n so each
     // logical line starts on a fresh row and autowrap owns intra-line wrapping.
     out += `\x1b[${floor};1H`;
     out += chunk.map((l) => `\x1b[2K${l}`).join('\r\n');
-    // Scroll the exact painted physical height off the top into scrollback.
-    out += `\x1b[${bottom};1H${'\n'.repeat(chunkRows)}`;
+    // Scroll the RESIDENT rows off the top into scrollback — not `chunkRows`:
+    // for an over-height line the autowrap overflow already scrolled the
+    // difference, and counting it twice appends `chunkRows - chunkMax` blank
+    // rows to history.
+    out += `\x1b[${bottom};1H${'\n'.repeat(residentRows)}`;
     chunk = [];
     chunkRows = 0;
   };
   for (const line of lines) {
     const h = physicalHeight(line);
-    // A single line taller than the whole paint region: give it its own chunk
-    // (it will scroll fully; the terminal handles the intra-paint autowrap
-    // scroll for the overflow beyond the region, and the explicit scroll count
-    // still equals its physical height).
+    // A single line taller than the whole paint region gets its own chunk: the
+    // terminal's autowrap scrolls the overflow beyond the region during the
+    // paint, and flushChunk explicitly scrolls only the resident remainder, so
+    // the two together carry exactly `h` rows into history.
     if (chunkRows > 0 && chunkRows + h > chunkMax) flushChunk();
     chunk.push(line);
     chunkRows += h;

--- a/tests/pty/compositor-scrollback.pty.test.ts
+++ b/tests/pty/compositor-scrollback.pty.test.ts
@@ -103,7 +103,7 @@ function assertExpectations(res: PtyRunResult, exp: PtyExpect): void {
     if (minNonWrappedRows !== undefined) {
       expect(
         nonWrapped,
-        `logical line ["${from}".."${to}"] should have >=${minNonWrappedRows} non-wrapped (hard-break) rows — the axis-2 fragmentation RED guard (#540); found ${nonWrapped}. If this dropped to 1 the flush now emits logical lines: flip minNonWrappedRows -> maxNonWrappedRows: 1.\n${dump}`,
+        `logical line ["${from}".."${to}"] should have >=${minNonWrappedRows} non-wrapped (hard-break) rows; found ${nonWrapped}. This asserts content IS fragmented — a RED-guard shape for a not-yet-fixed reflow axis. The #540 axis-2 guards already completed that transition and now assert maxNonWrappedRows: 1.\n${dump}`,
       ).toBeGreaterThanOrEqual(minNonWrappedRows);
     }
     if (maxNonWrappedRows !== undefined) {

--- a/tests/pty/scenarios.ts
+++ b/tests/pty/scenarios.ts
@@ -451,22 +451,25 @@ export const SCENARIOS: Record<string, PtyScenario> = {
   },
 
   // ─────────────────────────────────────────────────────────────────────────
-  // width-resize-fragment-narrow (#540 axis-2 · RED GUARD): a long LOGICAL line
-  // committed WIDE (100 cols) is hard-wrapped to physical rows at commit time
-  // (terminal-compositor.committed-band-commit.ts:165) and flushed to native
-  // scrollback as hard-newline rows. On a NARROWER resize the terminal reflows
-  // each hard row independently, so the one logical line shows ≥2 non-wrapped
-  // (isWrapped=false) rows in its span — it is NOT `tmux -J`-rejoinable. This is
-  // the user's screenshot. It is GREEN NOW (documents the bug); when PR 2 (#540
-  // Stage 3 logical flush) makes the flush emit logical lines, the count drops
-  // to 1 and THIS ASSERTION WILL FAIL — the signal to flip minNonWrappedRows →
-  // maxNonWrappedRows: 1 and retire this as the GREEN regression guard.
+  // width-resize-fragment-narrow (#540 axis-2 · GREEN regression guard): a long
+  // LOGICAL line committed WIDE (120 cols) is hard-wrapped to physical rows for
+  // the LIVE band's row math (terminal-compositor.committed-band-commit.ts:172),
+  // but PR 2 (#540 Stage 3 logical flush) archives it to native scrollback as a
+  // single SOFT-WRAPPABLE logical line (retained via committedBandMeta and
+  // emitted by buildScrollbackArchiveEscape at the band-hold archive site). On a
+  // NARROWER resize the terminal reflows that one logical line cleanly, so its
+  // span shows exactly ONE non-wrapped (isWrapped=false) head row — it IS
+  // `tmux -J`-rejoinable. This was RED-first (asserted minNonWrappedRows: 2, the
+  // fragmentation bug from the user's screenshot); the src change made scrollback
+  // hold logical lines, so it now asserts the FIXED rejoined property
+  // (maxNonWrappedRows: 1). A regression that reverts to physical-row flushing
+  // re-fragments the line and fails here.
   // ─────────────────────────────────────────────────────────────────────────
   'width-resize-fragment-narrow': {
-    description: 'wide-committed logical line in scrollback fragments on a NARROWER resize (RED guard, #540 axis-2)',
+    description: 'wide-committed logical line rejoins cleanly in scrollback on a NARROWER resize (GREEN guard, #540 axis-2)',
     cols: 120,
     rows: 24,
-    ref: '#540 axis-2 · terminal-compositor.committed-band-commit.ts:165',
+    ref: '#540 axis-2 · committed-band-commit.ts band-hold archive (logical flush)',
     async drive(ctx): Promise<void> {
       const { stdout, stdin } = ctx;
       const statusLine = wireProductionFooter(stdout, 'M');
@@ -492,25 +495,28 @@ export const SCENARIOS: Record<string, PtyScenario> = {
     expect: {
       inScrollback: ['LOGSTART'], // precondition: the long line scrolled off screen
       // minSpanRows:3 PROVES the narrow fired (the line is 2 rows at 120, 3 at
-      // 68) and is stable across PR 2; minNonWrappedRows:2 is the RED flip signal.
-      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', minNonWrappedRows: 2, minSpanRows: 3 },
+      // 68) and is stable across PR 2; maxNonWrappedRows:1 asserts the FIXED
+      // rejoined property (was minNonWrappedRows:2 pre-fix — the RED guard).
+      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', maxNonWrappedRows: 1, minSpanRows: 3 },
     },
   },
 
   // ─────────────────────────────────────────────────────────────────────────
-  // width-resize-fragment-widen (#540 axis-2 · RED GUARD): the widen twin. A
-  // long logical line committed NARROW (50 cols) hard-wraps to several physical
-  // rows and flushes to scrollback. On a WIDER resize the terminal cannot rejoin
-  // app hard-newlines, so the rows stay ragged/short — ≥2 non-wrapped rows in
-  // the span (each afk row is ≤50 ≤100 so none even soft-wraps). GREEN NOW; flips
-  // to FAIL when PR 2 emits one logical line (which the widen reflows to fewer
-  // rows with a single non-wrapped head). See the narrow twin's note.
+  // width-resize-fragment-widen (#540 axis-2 · GREEN regression guard): the
+  // widen twin. A long logical line committed NARROW (48 cols) hard-wraps to
+  // several physical rows for the live band, but PR 2 archives it to scrollback
+  // as a single SOFT-WRAPPABLE logical line. On a WIDER resize the terminal
+  // reflows that one logical line to fewer rows with a single non-wrapped head —
+  // rejoinable. This was RED-first (asserted minNonWrappedRows: 2: pre-fix the
+  // terminal could not rejoin app hard-newlines, leaving ≥2 ragged rows); the
+  // src change made scrollback hold logical lines, so it now asserts the FIXED
+  // rejoined property (maxNonWrappedRows: 1). See the narrow twin's note.
   // ─────────────────────────────────────────────────────────────────────────
   'width-resize-fragment-widen': {
-    description: 'narrow-committed logical line in scrollback stays ragged on a WIDER resize (RED guard, #540 axis-2)',
+    description: 'narrow-committed logical line rejoins cleanly in scrollback on a WIDER resize (GREEN guard, #540 axis-2)',
     cols: 48,
     rows: 24,
-    ref: '#540 axis-2 · terminal-compositor.committed-band-commit.ts:165',
+    ref: '#540 axis-2 · committed-band-commit.ts band-hold archive (logical flush)',
     async drive(ctx): Promise<void> {
       const { stdout, stdin } = ctx;
       const statusLine = wireProductionFooter(stdout, 'M');
@@ -533,11 +539,12 @@ export const SCENARIOS: Record<string, PtyScenario> = {
     },
     expect: {
       inScrollback: ['LOGSTART'],
-      // minNonWrappedRows:2 is the RED flip signal (4 ragged rows now → 1 after
-      // PR 2 rejoins the logical line). The resize MECHANISM is certified by the
-      // sanity scenario; a widen cannot prove itself via row count (it is
-      // unchanged pre-fix), so no minSpanRows here.
-      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', minNonWrappedRows: 2 },
+      // maxNonWrappedRows:1 asserts the FIXED rejoined property (was
+      // minNonWrappedRows:2 pre-fix — 4 ragged rows → 1 non-wrapped head after
+      // the logical-line flush). The resize MECHANISM is certified by the sanity
+      // scenario; a widen cannot prove itself via row count (a rejoined line
+      // occupies FEWER rows), so no minSpanRows here.
+      logicalSpan: { from: 'LOGSTART', to: 'LOGEND', maxNonWrappedRows: 1 },
     },
   },
 };


### PR DESCRIPTION
## Problem
Narrowing the terminal pane after long output has scrolled into native scrollback makes the terminal re-wrap that stored scrollback at the new width — splitting words mid-character (`missing` → `miss` + `ing`) and dropping continuation-line indentation to column 0.

## Root cause
AFK hard-wraps committed output to physical rows for exact live-cursor frame math, then archives those *pre-wrapped physical rows* into native scrollback with a raw newline (`terminal-compositor.committed-band-commit.ts`). Once bytes are in native scrollback the terminal owns them, so the in-memory reflow fix (`band-reflow.ts`, PR #386 / `f75d8a4`) cannot reach them. On a narrowing resize, the terminal's DECAWM autowrap hard-wraps each stored row again → mid-word splits + lost indent. `band-reflow.ts:10-22` and `docs/tui-resize-reflow.md:129-142` document this as a known out-of-scope gap.

## Fix
Retain per-row logical provenance (`committedBandMeta` / `BandRowMeta`) and, at the band-hold archive site, emit whole **soft-wrappable logical lines** via `buildScrollbackArchiveEscape` instead of pre-wrapped physical rows. Native scrollback then holds one reflow-clean logical line per logical line, which any emulator — and tmux copy-mode (`-J`) — rewraps cleanly on resize.

## Gates (rebased onto current main, zero conflicts)
- `pnpm lint` — 0 errors
- logical-flush test — 24/24
- compositor suite — 381/381
- PTY suite (`pnpm test:pty`) — 8/8 (incl. the 3 axis-2 resize guards)

## MERGE GATE — human real-terminal validation required (do NOT merge until checked)
PTY tests replay an xterm emulator and cannot reproduce terminal-only DECAWM deferred-wrap artifacts; prior fixes in this path shipped green and broke on real terminals.

- [ ] iTerm2, Terminal.app, and Ghostty
- [ ] Long single line (~150+ cols, no spaces) scrolled into scrollback
- [ ] Narrow pane (120 to 68): reflows as one continuous line, no mid-word splits
- [ ] Widen pane back (48 to 110): rejoins cleanly, no stranded fragments
- [ ] Markdown table under a collapsed "thinking" overlay: header appears once, no void above the frame
- [ ] Native scrollback: each committed line appears once, in order
- [ ] tmux copy-mode (`-J`): unbroken logical line
- [ ] Continuation-row indentation preserved after reflow

Draft opened by afk. Branch rebases cleanly onto main (verified); rebase or "Update branch" before merge.
