### PR TITLE
fix(trace): seal witness trace only from the top-level session

### DIFF
--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -1179,17 +1179,19 @@ export class AgentSession implements IAgentSession {
       finalCostUsd: this.sessionRunningCostUsd,
       runningTokens: this.sessionRunningTokens,
     }).catch(() => {});
-    // Invariant: only the TOP-LEVEL session (no parent) may seal the writer.
+    // Invariant: only the TOP-LEVEL session (no fork marker) may seal the writer.
     // A session tree shares ONE TraceWriter by reference (forkSubagent threads
     // the parent's writer into every descendant), and seal() is one-shot /
     // idempotent (NdjsonTraceWriter). If a subagent sealed on its own close(),
     // the FIRST descendant torn down would seal the whole shared file while the
     // top-level is still mid-run — stranding every later ancestor event as the
     // "started without terminal" gap (a nested grandchild's end_turn sealing the
-    // root trace 30+ min before the real session ends). Subagents still emit
-    // their own `closure` record above; if the top-level never runs close(), the
-    // process-exit backstop (NdjsonTraceWriter.sealOnProcessExit) still seals.
-    if (this.config.parentSessionId === undefined) {
+    // root trace 30+ min before the real session ends). The seal owner gate uses
+    // forkSubagent's explicit fork marker, not parentSessionId: stub-parent skill
+    // forks can have no parent session id while still sharing the root writer.
+    // Subagents still emit their own `closure` record above; if the top-level
+    // never runs close(), the process-exit backstop still seals.
+    if (this.config.subagentToolOutputCapBytes === undefined) {
       await sealTraceWriter(this.config.traceWriter, {
         ...signals,
         finalTurnCount: this.turnCount,

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -1164,7 +1164,8 @@ export class AgentSession implements IAgentSession {
     //      WHY the session ended (model_end_turn, abort, budget_exceeded,
     //      timeout). Carries the final cost / token tuple + last stopReason.
     //   2. Seal the trace via session_sealed — the sealed-clean terminal
-    //      record. Sealing happens BEFORE the SessionEnd hook fires so a
+    //      record — but ONLY for the top-level session (see the ownership
+    //      guard below). Sealing happens BEFORE the SessionEnd hook fires so a
     //      hook-thrown exception cannot leave the trace `sealed-crashed`
     //      on the normal close path (a hook crash would surface as a
     //      separate `hook_decision: block` record, not erase the seal).
@@ -1178,14 +1179,26 @@ export class AgentSession implements IAgentSession {
       finalCostUsd: this.sessionRunningCostUsd,
       runningTokens: this.sessionRunningTokens,
     }).catch(() => {});
-    await sealTraceWriter(this.config.traceWriter, {
-      ...signals,
-      finalTurnCount: this.turnCount,
-      finalCostUsd: this.sessionRunningCostUsd,
-      subagentCompletedCount: this.subagentCompletedCount,
-      subagentRunningTokens: this.subagentRunningTokens,
-      subagentRunningCostUsd: this.subagentRunningCostUsd,
-    }).catch(() => {});
+    // Invariant: only the TOP-LEVEL session (no parent) may seal the writer.
+    // A session tree shares ONE TraceWriter by reference (forkSubagent threads
+    // the parent's writer into every descendant), and seal() is one-shot /
+    // idempotent (NdjsonTraceWriter). If a subagent sealed on its own close(),
+    // the FIRST descendant torn down would seal the whole shared file while the
+    // top-level is still mid-run — stranding every later ancestor event as the
+    // "started without terminal" gap (a nested grandchild's end_turn sealing the
+    // root trace 30+ min before the real session ends). Subagents still emit
+    // their own `closure` record above; if the top-level never runs close(), the
+    // process-exit backstop (NdjsonTraceWriter.sealOnProcessExit) still seals.
+    if (this.config.parentSessionId === undefined) {
+      await sealTraceWriter(this.config.traceWriter, {
+        ...signals,
+        finalTurnCount: this.turnCount,
+        finalCostUsd: this.sessionRunningCostUsd,
+        subagentCompletedCount: this.subagentCompletedCount,
+        subagentRunningTokens: this.subagentRunningTokens,
+        subagentRunningCostUsd: this.subagentRunningCostUsd,
+      }).catch(() => {});
+    }
     await dispatchSessionEnd(
       this._hookRegistry,
       {

--- a/src/agent/session/subagent-seal-ownership.test.ts
+++ b/src/agent/session/subagent-seal-ownership.test.ts
@@ -10,8 +10,8 @@
  * thus reported a clean success for a session that hung and was cancelled, and
  * every subsequent ancestor event hit the sealed writer and was swallowed.
  *
- * Fix: `dispatchSessionEndOnce` gates `sealTraceWriter(...)` on
- * `this.config.parentSessionId === undefined` (top-level only). Subagents still
+ * Fix: `dispatchSessionEndOnce` gates `sealTraceWriter(...)` on the explicit
+ * fork marker (`subagentToolOutputCapBytes` absent ⇒ top-level). Subagents still
  * emit their own `closure` record; the process-exit backstop still seals an
  * orphaned top-level trace if close() never runs.
  *
@@ -75,6 +75,7 @@ describe('witness seal ownership', () => {
         provider,
         depth: 1,
         parentSessionId: 'parent-abc',
+        subagentToolOutputCapBytes: 100_000,
         traceWriter: writer,
       });
 
@@ -90,4 +91,32 @@ describe('witness seal ownership', () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it('stub-parent fork close() does NOT seal even without parentSessionId', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-seal-own-stub-sub-'));
+    try {
+      const writer = new NdjsonTraceWriter({ traceDir: dir });
+      const provider = createMockProvider({ sessionId: `seal-stub-sub-${Date.now()}` });
+      const session = new AgentSession({
+        model: 'sonnet',
+        provider,
+        depth: 1,
+        // Stub-parent skill forks may not have a real parent session id, but
+        // forkSubagent still stamps the explicit fork marker below. That marker,
+        // not parentSessionId, owns trace-seal gating.
+        subagentToolOutputCapBytes: 100_000,
+        traceWriter: writer,
+      });
+
+      await drainTurn(session, 'stub child work');
+      await session.close();
+
+      const kinds = readTrace(dir).map((e) => e.kind);
+      expect(kinds).toContain('closure');
+      expect(kinds).not.toContain('session_sealed');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/src/agent/session/subagent-seal-ownership.test.ts
+++ b/src/agent/session/subagent-seal-ownership.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression: only the TOP-LEVEL session may seal the shared witness trace.
+ *
+ * Symptom (observed 2026-07-21, session afb74e27): a session tree shares ONE
+ * TraceWriter by reference. Because every `AgentSession.close()` sealed that
+ * writer unconditionally — and `seal()` is one-shot/idempotent — the FIRST
+ * descendant torn down (a nested grandchild git-investigator) sealed the whole
+ * file with status "succeeded" ~34 min BEFORE the top-level `agent` dispatch
+ * actually ended (it was still mid-tool-use, later aborted). The witness trace
+ * thus reported a clean success for a session that hung and was cancelled, and
+ * every subsequent ancestor event hit the sealed writer and was swallowed.
+ *
+ * Fix: `dispatchSessionEndOnce` gates `sealTraceWriter(...)` on
+ * `this.config.parentSessionId === undefined` (top-level only). Subagents still
+ * emit their own `closure` record; the process-exit backstop still seals an
+ * orphaned top-level trace if close() never runs.
+ *
+ * Invariant locked here: a subagent's close() emits `closure` but does NOT
+ * append `session_sealed`; a top-level's close() appends both.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-seal-own-home-'));
+process.env['AFK_HOME'] = tmpHome;
+
+import { AgentSession } from './agent-session.js';
+import { createMockProvider } from '../__fixtures__/mock-provider.js';
+import { NdjsonTraceWriter } from '../trace/writer.js';
+
+async function drainTurn(session: AgentSession, text: string): Promise<void> {
+  for await (const event of session.sendMessageStream(text)) {
+    if (event.type === 'done' || event.type === 'error') break;
+  }
+}
+
+function readTrace(dir: string): Array<{ kind: string; payload: Record<string, unknown> }> {
+  const content = fs.readFileSync(path.join(dir, 'trace.jsonl'), 'utf8');
+  return content
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((l) => JSON.parse(l) as { kind: string; payload: Record<string, unknown> });
+}
+
+describe('witness seal ownership', () => {
+  it('top-level session close() seals the trace (closure + session_sealed)', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-seal-own-top-'));
+    try {
+      const writer = new NdjsonTraceWriter({ traceDir: dir });
+      const provider = createMockProvider({ sessionId: `seal-top-${Date.now()}` });
+      const session = new AgentSession({ model: 'sonnet', provider, traceWriter: writer });
+
+      await drainTurn(session, 'hello');
+      await session.close();
+
+      const kinds = readTrace(dir).map((e) => e.kind);
+      expect(kinds).toContain('closure');
+      expect(kinds).toContain('session_sealed');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('subagent session close() emits closure but does NOT seal the shared trace', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'afk-seal-own-sub-'));
+    try {
+      const writer = new NdjsonTraceWriter({ traceDir: dir });
+      const provider = createMockProvider({ sessionId: `seal-sub-${Date.now()}` });
+      const session = new AgentSession({
+        model: 'sonnet',
+        provider,
+        depth: 1,
+        parentSessionId: 'parent-abc',
+        traceWriter: writer,
+      });
+
+      await drainTurn(session, 'child work');
+      await session.close();
+
+      const kinds = readTrace(dir).map((e) => e.kind);
+      // The subagent's own end is still recorded...
+      expect(kinds).toContain('closure');
+      // ...but it must NOT seal the writer it shares with its still-live parent.
+      expect(kinds).not.toContain('session_sealed');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What

A session tree (top-level session + child + nested grandchild subagents) shares **one** `TraceWriter` by reference. `writer.seal()` is one-shot/idempotent, and **every** `AgentSession.close()` — including a subagent's — sealed it unconditionally. So the **first descendant torn down** (often a nested grandchild) sealed the whole shared trace file.

Observed while diagnosing session `afb74e27`: a grandchild `git-investigator` finished and its `close()` sealed the trace `status: "succeeded"` at 20:22 — while the top-level `agent` dispatch was still mid-tool-use. That call hung and was operator-aborted at 20:56. Result: the witness trace **claimed a clean success ~34 min before the session actually ended (aborted)**, and every ancestor event after the seal hit the sealed writer and was silently swallowed (the "started-without-terminal" gap).

## Fix

Gate the seal on `this.config.parentSessionId === undefined` (top-level only) in `dispatchSessionEndOnce`, reusing the discriminant already used for ledger/actor/injectContext gating (`agent-session.ts:222/356`).

- Subagents still emit their own `closure` record — only the **seal** is gated.
- The process-exit backstop (`NdjsonTraceWriter.sealOnProcessExit`) still seals an orphaned top-level trace if `close()` never runs, so this cannot regress the unsealed-orphan class.

## Test

`src/agent/session/subagent-seal-ownership.test.ts`:
- top-level `close()` -> trace has `closure` **and** `session_sealed`
- subagent `close()` -> `closure` present, `session_sealed` **absent**

## Verification

- `pnpm lint` (tsc --noEmit, strict) clean
- Full suite: **12,589 passed / 0 failed**; existing `subagent-terminal-seal-race.test.ts` stays green

## Context / follow-ups (not in this PR)

This fell out of diagnosing that 44-min session. Two sibling defects are deliberately **separate** follow-ups:
- **Model mislabel** — `session_init_start` records the construction-time model alias, not the served provider (emit-side fix; needs a resume/launch-swap mechanism trace first).
- **Subagent hang** — the correct fix is the post-first-token idle watchdog already scoped as a TODO in `subagent.ts:103` (quick alternatives are unsafe: a hardcoded client timeout kills long streams; lowering the 45-min cap re-introduces the PR #610 regression).
