### PR TITLE
feat(compaction): token-aware keep-window so /compact works on short-but-full sessions

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -107,6 +107,14 @@
       "category": "model"
     },
     {
+      "name": "AFK_COMPACT_SHRINK_FRACTION",
+      "description": "Context-fullness fraction (0–1, exclusive) at/above which /compact and auto-compaction relax the keep-window so a short-but-full session (few turns, huge tool exchanges) can still be summarized instead of no-oping on turn count. Default 0.7 (see shared/compaction.ts DEFAULT_COMPACT_SHRINK_THRESHOLD).",
+      "type": "number",
+      "required": false,
+      "example": "0.8",
+      "category": "model"
+    },
+    {
       "name": "AFK_COMPANION_PRIMER",
       "description": "Opt-in: absolute path to a single companion-primer file. When set, its content is bounded (capped, fenced as <companion-primer>) and appended to the system prompt at session start for top-level sessions (chat/REPL/telegram/daemon), as lower-authority \"reflections, not facts\" context. Unset (default) = no-op. Only the one named file is ever read — never a directory or repo walk.",
       "type": "string",

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -2,7 +2,7 @@
 
 Generated from `src/config/env.ts`. Do not edit by hand — run `pnpm scan:env` after changing the registry source.
 
-**130 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
+**131 vars** across 12 categories. Every `process.env[...]` read in `src/` outside `src/config/env.ts` is a CI failure (enforced by `pnpm audit:env:check`).
 
 To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV_REGISTRY`), then run `pnpm scan:env`.
 
@@ -12,6 +12,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 |------|------|----------|---------|---------|-------------|
 | `AFK_COMPACT_KEEP_LAST_TURNS` | number |  |  | `6` | Number of recent turns the compactor keeps verbatim during /compact. Default tuned in compact-handler.ts. |
 | `AFK_COMPACT_MODEL` | string |  |  | `claude-haiku-4-5` | Override the model used by the /compact summarizer. Falls back to a cheap default (haiku-class). |
+| `AFK_COMPACT_SHRINK_FRACTION` | number |  |  | `0.8` | Context-fullness fraction (0–1, exclusive) at/above which /compact and auto-compaction relax the keep-window so a short-but-full session (few turns, huge tool exchanges) can still be summarized instead of no-oping on turn count. Default 0.7 (see shared/compaction.ts DEFAULT_COMPACT_SHRINK_THRESHOLD). |
 | `AFK_DEFAULT_SUBAGENT_MODEL` | string |  |  | `sonnet` | Override the default model used when a subagent is dispatched without an explicit model. |
 | `AFK_DISABLE_PROMPT_CACHE` | boolean |  | `0` | `1` | Disable Anthropic prompt caching when set to 1/true/yes/on. Unset = caching enabled. |
 | `AFK_EFFORT` | string |  |  | `medium` | Effort hint guiding adaptive-thinking depth, forwarded as Anthropic output_config.effort (model-gated; ignored where unsupported). Accepts low \| medium \| high \| xhigh \| max. |

--- a/src/agent/providers/anthropic-direct.test.ts
+++ b/src/agent/providers/anthropic-direct.test.ts
@@ -210,6 +210,19 @@ function makeTextStream(text: string): RawMessageStreamEvent[] {
   ];
 }
 
+/**
+ * Like {@link makeTextStream} but reports `input_tokens` high enough to cross
+ * 0.7 of the sonnet auto-compaction budget (200k), so `state.lastUsage` marks
+ * the session "full" and the adaptive compaction keep-window engages. 181k of
+ * 200k = 0.905 — comfortably above the 0.7 shrink gate.
+ */
+function makeHighUsageTextStream(text: string): RawMessageStreamEvent[] {
+  const evts = makeTextStream(text);
+  const start = evts[0] as unknown as { message: { usage: { input_tokens: number } } };
+  start.message.usage.input_tokens = 181_000;
+  return evts;
+}
+
 /** Build a stream that emits a single tool_use block, ending with stop_reason=tool_use. */
 function makeToolUseStream(
   toolId: string,
@@ -1304,6 +1317,44 @@ describe('AnthropicDirectProvider', () => {
     expect(result.reason).toBe('nothing-to-summarize');
     // No summarization call should have been made.
     expect(messagesCreateMock).toHaveBeenCalledTimes(2); // only the 2 user turns
+
+    harness.stop();
+    query.close();
+    await drive;
+  });
+
+  it('compact() summarizes a short-but-full session (2 turns, window near limit)', async () => {
+    // The mirror of the test above: the SAME 2-turn shape that returns
+    // nothing-to-summarize when the window is empty MUST compact once the
+    // window is full. Both turns report high usage (181k of the 200k sonnet
+    // budget → 0.9), so the adaptive keep-window relaxes from 2 → 1 fresh user
+    // turn and the older turn is summarized. Regression guard for the
+    // "compact refuses on a full 1-2 turn session" gap.
+    let callIdx = 0;
+    messagesCreateMock.mockImplementation(() => {
+      callIdx += 1;
+      // Calls 1-2 are the user turns (high usage); call 3 is the summarization.
+      if (callIdx <= 2) return fromArray(makeHighUsageTextStream('reply'));
+      return fromArray(makeTextStream('## Summary\n\nOlder turn compressed.'));
+    });
+    const harness = makeMultiTurnHarness(2);
+    const provider = new AnthropicDirectProvider();
+    const query = provider.query({
+      prompt: harness.prompt,
+      // No autoCompactThreshold → auto-compaction stays disabled; the only
+      // compaction is the manual compact() call below.
+      config: { model: 'claude-sonnet-5', apiKey: 'sk-ant-api03-test' },
+    });
+    const drive = drainQuery(query, harness);
+    await harness.fireTurn(0, 'u1');
+    await harness.fireTurn(1, 'u2');
+
+    const result = await query.compact!();
+    expect(result.compacted).toBe(true);
+    // The summarization request fired (3rd create call) — proof the adaptive
+    // shrink engaged rather than short-circuiting to a no-op.
+    expect(messagesCreateMock).toHaveBeenCalledTimes(3);
+    expect(result.messagesBefore).toBeGreaterThan(0);
 
     harness.stop();
     query.close();

--- a/src/agent/providers/anthropic-direct/compact.ts
+++ b/src/agent/providers/anthropic-direct/compact.ts
@@ -30,6 +30,7 @@ import {
   applyCompaction as sharedApplyCompaction,
   estimateTokensSaved as sharedEstimateTokensSaved,
   findCompactionBoundary as sharedFindCompactionBoundary,
+  findCompactionBoundaryAdaptive as sharedFindCompactionBoundaryAdaptive,
   renderTranscript as sharedRenderTranscript,
   wrapTranscriptForSummary,
   type CompactionOps,
@@ -137,6 +138,28 @@ export function findCompactionBoundary(
   keepLastN: number,
 ): number {
   return sharedFindCompactionBoundary(messages, keepLastN, anthropicCompactionOps);
+}
+
+/**
+ * Boundary selection with the token-fullness fallback. Thin adapter over the
+ * shared {@link sharedFindCompactionBoundaryAdaptive} bound to
+ * {@link anthropicCompactionOps}. See the shared docs: when the turn-count
+ * keep-window is a no-op but `usedFraction >= shrinkAtFraction`, the keep-window
+ * relaxes toward 1 turn so a short-but-full session can still be compacted.
+ */
+export function findCompactionBoundaryAdaptive(
+  messages: ReadonlyArray<MessageParam>,
+  keepLastN: number,
+  usedFraction: number,
+  shrinkAtFraction: number,
+): number {
+  return sharedFindCompactionBoundaryAdaptive(
+    messages,
+    keepLastN,
+    anthropicCompactionOps,
+    usedFraction,
+    shrinkAtFraction,
+  );
 }
 
 /**

--- a/src/agent/providers/anthropic-direct/query/auto-compact.test.ts
+++ b/src/agent/providers/anthropic-direct/query/auto-compact.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { shouldAutoCompact, computeUsedTokens, contextWindowTokensUsed, buildContextUsageFields } from './auto-compact.js';
+import { shouldAutoCompact, computeUsedTokens, contextWindowTokensUsed, contextFullnessFraction, buildContextUsageFields } from './auto-compact.js';
 
 const DEFAULT_THRESHOLD = 0.9;
 
@@ -173,6 +173,23 @@ describe('contextWindowTokensUsed', () => {
 
   it('returns 0 for an empty usage object', () => {
     expect(contextWindowTokensUsed({})).toBe(0);
+  });
+});
+
+describe('contextFullnessFraction', () => {
+  it('returns the raw used/limit ratio', () => {
+    expect(contextFullnessFraction(90_000, 180_000)).toBe(0.5);
+    expect(contextFullnessFraction(180_000, 200_000)).toBeCloseTo(0.9);
+  });
+
+  it('can exceed 1 when usage overruns the limit (never clamped)', () => {
+    expect(contextFullnessFraction(250_000, 200_000)).toBeGreaterThan(1);
+  });
+
+  it('returns 0 when usage or limit is non-positive (unknown → never looks full)', () => {
+    expect(contextFullnessFraction(0, 200_000)).toBe(0);
+    expect(contextFullnessFraction(100_000, 0)).toBe(0);
+    expect(contextFullnessFraction(-5, 200_000)).toBe(0);
   });
 });
 

--- a/src/agent/providers/anthropic-direct/query/auto-compact.ts
+++ b/src/agent/providers/anthropic-direct/query/auto-compact.ts
@@ -13,6 +13,7 @@
 export {
   computeUsedTokens,
   contextWindowTokensUsed,
+  contextFullnessFraction,
   buildContextUsageFields,
   shouldAutoCompact,
 } from '../../shared/auto-compact.js';

--- a/src/agent/providers/anthropic-direct/query/compact-handler.ts
+++ b/src/agent/providers/anthropic-direct/query/compact-handler.ts
@@ -40,8 +40,16 @@ import {
   applyCompaction,
   buildSummarizationRequest,
   estimateTokensSaved,
-  findCompactionBoundary,
+  findCompactionBoundaryAdaptive,
 } from '../compact.js';
+import {
+  DEFAULT_COMPACT_SHRINK_THRESHOLD,
+} from '../../shared/compaction.js';
+import {
+  contextFullnessFraction,
+  contextWindowTokensUsed,
+} from '../../shared/auto-compact.js';
+import { autoCompactLimitFor } from '../../../model-limits.js';
 import { emitCompaction } from '../../../trace/emit.js';
 import { resolveModelId } from '../../../session/model-resolution.js';
 import type { AnthropicClientLike } from '../types.js';
@@ -95,7 +103,22 @@ export async function compactHistory(
   }
 
   const keepLastN = readKeepLastN();
-  const boundary = findCompactionBoundary(state.messages, keepLastN);
+  // Token-fullness fallback: the keep-window is counted in whole turns, so a
+  // short-but-full session (few turns, huge tool exchanges) would otherwise
+  // no-op regardless of how full the window is. Measure fullness against the
+  // same working budget the auto-compaction trigger uses (autoCompactLimitFor,
+  // via requestedModel so the *_1m alias is honored) and let the boundary
+  // relax the keep-window when we are near the limit.
+  const usedFraction = contextFullnessFraction(
+    contextWindowTokensUsed(state.lastUsage ?? {}),
+    autoCompactLimitFor(state.requestedModel),
+  );
+  const boundary = findCompactionBoundaryAdaptive(
+    state.messages,
+    keepLastN,
+    usedFraction,
+    readShrinkFraction(),
+  );
   if (boundary < 0) {
     return {
       compacted: false,
@@ -225,6 +248,20 @@ function readKeepLastN(): number {
     if (Number.isFinite(n) && n > 0) return n;
   }
   return DEFAULT_COMPACT_KEEP_LAST_TURNS;
+}
+
+/**
+ * Fullness fraction at/above which the keep-window may shrink so a
+ * short-but-full session can still be compacted. `AFK_COMPACT_SHRINK_FRACTION`
+ * overrides it; values outside (0, 1) exclusive fall back to the default.
+ */
+function readShrinkFraction(): number {
+  const raw = env.AFK_COMPACT_SHRINK_FRACTION;
+  if (raw !== undefined && raw.length > 0) {
+    const n = Number.parseFloat(raw);
+    if (Number.isFinite(n) && n > 0 && n < 1) return n;
+  }
+  return DEFAULT_COMPACT_SHRINK_THRESHOLD;
 }
 
 function readCompactModel(): string {

--- a/src/agent/providers/openai-compatible/compact.ts
+++ b/src/agent/providers/openai-compatible/compact.ts
@@ -32,6 +32,7 @@ import type { CompactionTrigger } from '../../trace/types.js';
 import {
   COMPACT_ACK_TEXT,
   COMPACT_SUMMARY_HEADER,
+  DEFAULT_COMPACT_SHRINK_THRESHOLD,
   runCompactionCore,
   type CompactionOps,
 } from '../shared/compaction.js';
@@ -133,6 +134,20 @@ export function readKeepLastN(): number {
   return DEFAULT_COMPACT_KEEP_LAST_TURNS;
 }
 
+/**
+ * Fullness fraction at/above which the keep-window may shrink so a
+ * short-but-full session can still be compacted. `AFK_COMPACT_SHRINK_FRACTION`
+ * overrides it; values outside (0, 1) exclusive fall back to the default.
+ */
+export function readShrinkFraction(): number {
+  const raw = env.AFK_COMPACT_SHRINK_FRACTION;
+  if (raw !== undefined && raw.length > 0) {
+    const n = Number.parseFloat(raw);
+    if (Number.isFinite(n) && n > 0 && n < 1) return n;
+  }
+  return DEFAULT_COMPACT_SHRINK_THRESHOLD;
+}
+
 /** Injected collaborators for {@link compactOpenAIHistory}. */
 export interface CompactOpenAIHistoryDeps {
   /** The query's mutable running history — mutated in place on success. */
@@ -158,6 +173,15 @@ export interface CompactOpenAIHistoryDeps {
    */
   trigger?: CompactionTrigger;
   traceWriter?: TraceWriter;
+  /**
+   * Context-window fullness fraction (0–1) at compaction time. Enables the
+   * adaptive keep-window so a short-but-full session can still be compacted.
+   * See `shared/compaction.ts:findCompactionBoundaryAdaptive`. Defaults to `0`
+   * (unknown → no shrink) when omitted.
+   */
+  usedFraction?: number;
+  /** Fullness fraction at/above which the keep-window may shrink. */
+  shrinkAtFraction?: number;
 }
 
 /**
@@ -184,6 +208,8 @@ export async function compactOpenAIHistory(
       messages: deps.priorTurns,
       ops: openaiCompactionOps,
       keepLastN: readKeepLastN(),
+      usedFraction: deps.usedFraction,
+      shrinkAtFraction: deps.shrinkAtFraction,
       summarize: (transcript) => deps.summarize(transcript, controller.signal),
       isAborted: () => controller.signal.aborted,
       abortInFlight: () => controller.abort(),

--- a/src/agent/providers/openai-compatible/query.test.ts
+++ b/src/agent/providers/openai-compatible/query.test.ts
@@ -1335,9 +1335,17 @@ describe('OpenAICompatibleQuery — ProviderQuery surface', () => {
       config: baseConfig({ autoCompact: true }),
     });
     await collect(q);
-    // Exactly one compaction: history-too-short after turn 1, nothing-to-
-    // summarize after turn 2 (boundary 0), then a real splice after turn 3.
-    expect(summarizeCalls).toHaveLength(1);
+    // Each turn reports ~200k — far over the window — so the adaptive
+    // keep-window (see shared/compaction.ts:findCompactionBoundaryAdaptive)
+    // engages whenever there is an older turn to summarize:
+    //   turn 1 → still history-too-short (a single fresh user turn can't be
+    //            compacted — shrinking to keepLastN=1 lands the boundary at 0);
+    //   turn 2 → 2 fresh user turns + full window → keep-window relaxes 2→1 and
+    //            turn 1 is summarized (summarize call #1);
+    //   turn 3 → normal boundary (3 fresh user turns) → summarize call #2.
+    // Before the fullness fallback this was 1 call (compaction only at turn 3);
+    // firing earlier on a full window is the point of the feature.
+    expect(summarizeCalls).toHaveLength(2);
   });
 
   it('does NOT auto-compact when config.autoCompact is unset (default off)', async () => {

--- a/src/agent/providers/openai-compatible/query.ts
+++ b/src/agent/providers/openai-compatible/query.ts
@@ -83,13 +83,14 @@ import type { ToolDispatcher } from '../anthropic-direct/tool-dispatcher.js';
 import type { ToolResult } from '../anthropic-direct/types.js';
 import {
   contextWindowTokensUsed,
+  contextFullnessFraction,
   buildContextUsageFields,
   shouldAutoCompact,
   resolveAutoCompactThreshold,
 } from '../shared/auto-compact.js';
 import { HookBlockedError, DenialCircuitBreakerError } from '../../../utils/errors.js';
 import { COMPACT_SYSTEM_PROMPT, wrapTranscriptForSummary } from '../shared/compaction.js';
-import { compactOpenAIHistory } from './compact.js';
+import { compactOpenAIHistory, readShrinkFraction } from './compact.js';
 import { oneShotChatCompletion } from './oneshot.js';
 import { PLAN_MODE_ADDENDUM_TEXT } from '../shared/plan-mode-addendum.js';
 import { AFK_MODE_ADDENDUM_TEXT } from '../shared/afk-mode-addendum.js';
@@ -888,8 +889,18 @@ export class OpenAICompatibleQuery implements ProviderQuery {
       };
     }
     const compactModel = env.AFK_COMPACT_MODEL ?? this.currentModel;
+    // Token-fullness fallback for the adaptive keep-window (mirrors
+    // anthropic-direct/query/compact-handler.ts): measured against the same
+    // working budget the auto-compaction trigger uses, so a short-but-full
+    // session compacts instead of no-oping on turn count alone.
+    const usedFraction = contextFullnessFraction(
+      contextWindowTokensUsed(this.lastUsage ?? {}),
+      autoCompactLimitFor(this.currentModel),
+    );
     return compactOpenAIHistory({
       priorTurns: this.priorTurns,
+      usedFraction,
+      shrinkAtFraction: readShrinkFraction(),
       summarize: (transcript, signal) =>
         oneShotChatCompletion({
           client: this.client,

--- a/src/agent/providers/shared/auto-compact.ts
+++ b/src/agent/providers/shared/auto-compact.ts
@@ -131,6 +131,22 @@ export function shouldAutoCompact(
   return usedTokens / contextLimit >= threshold;
 }
 
+/**
+ * Context-window fullness as a raw fraction of a limit.
+ *
+ * Unlike {@link shouldAutoCompact} (a boolean gate against a configured
+ * threshold), this returns the magnitude for callers that need to reason about
+ * how full the window is — e.g. the compaction handlers deciding whether to
+ * shrink the keep-window on a short-but-full session (see
+ * `shared/compaction.ts:findCompactionBoundaryAdaptive`). Returns `0` when
+ * either input is non-positive (unknown usage / limit) so an unknown state
+ * never looks "full" and never triggers the shrink fallback.
+ */
+export function contextFullnessFraction(usedTokens: number, contextLimit: number): number {
+  if (contextLimit <= 0 || usedTokens <= 0) return 0;
+  return usedTokens / contextLimit;
+}
+
 /** Default auto-compaction threshold (fraction of the context window). */
 export const DEFAULT_AUTO_COMPACT_THRESHOLD = 0.9;
 

--- a/src/agent/providers/shared/compaction.test.ts
+++ b/src/agent/providers/shared/compaction.test.ts
@@ -7,9 +7,11 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   COMPACT_ACK_TEXT,
   COMPACT_SUMMARY_HEADER,
+  DEFAULT_COMPACT_SHRINK_THRESHOLD,
   applyCompaction,
   estimateTokensSaved,
   findCompactionBoundary,
+  findCompactionBoundaryAdaptive,
   renderTranscript,
   runCompactionCore,
   wrapTranscriptForSummary,
@@ -52,6 +54,60 @@ describe('findCompactionBoundary (generic)', () => {
   });
   it('returns 0 when the whole history is within the keep window', () => {
     expect(findCompactionBoundary(history(), 3, fakeOps)).toBe(0);
+  });
+});
+
+// Two fresh user turns — the "short but full" shape that the turn-count
+// keep-window (default 2) cannot compact without the fullness fallback.
+function twoTurns(): FakeMsg[] {
+  return [
+    { role: 'user', text: 'u1' },
+    { role: 'assistant', text: 'a1' },
+    { role: 'user', text: 'u2' },
+    { role: 'assistant', text: 'a2' },
+  ];
+}
+
+describe('findCompactionBoundaryAdaptive', () => {
+  const full = DEFAULT_COMPACT_SHRINK_THRESHOLD; // exactly at the gate counts as full
+  const empty = 0;
+
+  it('returns the normal boundary unchanged when the turn-count window already works', () => {
+    // history() has fresh users at 0,2,4 → keepLastN=2 lands at index 2. A full
+    // window must not change a boundary that was already > 0.
+    expect(findCompactionBoundaryAdaptive(history(), 2, fakeOps, full)).toBe(2);
+    expect(findCompactionBoundaryAdaptive(history(), 2, fakeOps, empty)).toBe(2);
+  });
+
+  it('does NOT shrink below the fullness threshold (preserves the no-op)', () => {
+    // Two turns, keepLastN=2 → base boundary 0 (nothing-to-summarize). Below the
+    // gate the boundary stays 0 so a near-empty session is left alone.
+    expect(findCompactionBoundary(twoTurns(), 2, fakeOps)).toBe(0);
+    expect(findCompactionBoundaryAdaptive(twoTurns(), 2, fakeOps, 0.5, 0.7)).toBe(0);
+  });
+
+  it('shrinks the keep-window on a short-but-full session so an older turn becomes eligible', () => {
+    // At/above the gate, keepLastN relaxes from 2 → 1, landing the boundary on
+    // the second fresh user turn (index 2) so turn 1 gets summarized.
+    expect(findCompactionBoundaryAdaptive(twoTurns(), 2, fakeOps, 0.7, 0.7)).toBe(2);
+    expect(findCompactionBoundaryAdaptive(twoTurns(), 2, fakeOps, 0.95, 0.7)).toBe(2);
+  });
+
+  it('cannot help a genuinely single-turn session even when full', () => {
+    // One fresh user turn (index 0). keepLastN=2 → -1; shrinking to 1 still lands
+    // at index 0 (not > 0), so the honest history-too-short boundary is returned.
+    const oneTurn: FakeMsg[] = [
+      { role: 'user', text: 'only' },
+      { role: 'assistant', text: 'reply' },
+    ];
+    expect(findCompactionBoundaryAdaptive(oneTurn, 2, fakeOps, 0.99, 0.7)).toBe(-1);
+  });
+
+  it('has nothing to shrink when keepLastN is already 1', () => {
+    // Base boundary 0 and the shrink loop (n from 0) never runs → stays 0.
+    expect(findCompactionBoundaryAdaptive(twoTurns(), 1, fakeOps, 0.99, 0.7)).toBe(2);
+    const oneTurn: FakeMsg[] = [{ role: 'user', text: 'only' }];
+    expect(findCompactionBoundaryAdaptive(oneTurn, 1, fakeOps, 0.99, 0.7)).toBe(0);
   });
 });
 
@@ -193,6 +249,45 @@ describe('runCompactionCore', () => {
       messages,
       ops: fakeOps,
       keepLastN: 3,
+      isAborted: () => false,
+      summarize,
+    });
+    expect(result.compacted).toBe(false);
+    expect(result.reason).toBe('nothing-to-summarize');
+    expect(summarize).not.toHaveBeenCalled();
+    expect(messages).toEqual(before);
+  });
+
+  it('compacts a short-but-full session via the adaptive keep-window (usedFraction >= threshold)', async () => {
+    // Two fresh user turns, keepLastN=2 → the turn-count boundary is 0
+    // (nothing-to-summarize). A full window relaxes the keep-window to 1 so
+    // turn 1 is summarized and spliced away.
+    const summarize = vi.fn(async () => 'COMPRESSED');
+    const messages = twoTurns();
+    const result = await runCompactionCore({
+      messages,
+      ops: fakeOps,
+      keepLastN: 2,
+      usedFraction: 0.95,
+      isAborted: () => false,
+      summarize,
+    });
+    expect(result.compacted).toBe(true);
+    expect(summarize).toHaveBeenCalledTimes(1);
+    // [user(summary), assistant(ack), u2, a2]
+    expect(messages[0]?.text).toContain('COMPRESSED');
+    expect(messages[2]?.text).toBe('u2');
+  });
+
+  it('leaves a short session untouched when usedFraction is below the threshold', async () => {
+    const summarize = vi.fn();
+    const messages = twoTurns();
+    const before = [...messages];
+    const result = await runCompactionCore({
+      messages,
+      ops: fakeOps,
+      keepLastN: 2,
+      usedFraction: 0.1,
       isAborted: () => false,
       summarize,
     });

--- a/src/agent/providers/shared/compaction.ts
+++ b/src/agent/providers/shared/compaction.ts
@@ -95,6 +95,21 @@ export function wrapTranscriptForSummary(transcript: string): string {
 export const DEFAULT_COMPACT_TIMEOUT_MS = 60_000;
 
 /**
+ * Default context-window fullness fraction (0–1) at/above which compaction
+ * shrinks its keep-window so a "short but full" session can still be summarized.
+ *
+ * The keep-window is measured in whole turns, not tokens (see
+ * {@link findCompactionBoundary}), so a session with only one or two turns whose
+ * tool exchanges have filled the window would otherwise report
+ * `history-too-short` / `nothing-to-summarize` and reclaim nothing — no matter
+ * how full it is. When usage crosses this fraction, {@link
+ * findCompactionBoundaryAdaptive} relaxes the keep-window toward 1 turn so the
+ * older turn becomes eligible. Overridable per-provider via
+ * `AFK_COMPACT_SHRINK_FRACTION`.
+ */
+export const DEFAULT_COMPACT_SHRINK_THRESHOLD = 0.7;
+
+/**
  * Provider-specific message-representation primitives. Pure — no I/O, no SDK
  * client, no logging — so they unit-test without a network. Everything a
  * provider must supply to participate in compaction lives here; the generic
@@ -150,6 +165,49 @@ export function findCompactionBoundary<M>(
     }
   }
   return -1;
+}
+
+/**
+ * Boundary selection with a token-fullness fallback — the entry point the
+ * compaction handlers use instead of {@link findCompactionBoundary} directly.
+ *
+ * Normally returns `findCompactionBoundary(messages, keepLastN, ops)`. But when
+ * that is a no-op (`<= 0`: fewer than `keepLastN` fresh user turns, or nothing
+ * older than the keep window) AND the context window is at/above
+ * `shrinkAtFraction` full, the keep-window is progressively shrunk toward 1 so
+ * an older-but-recent turn becomes eligible to summarize. This is what lets
+ * `/compact` (and auto-compaction) reclaim space on a "short but full" session —
+ * e.g. two turns whose tool exchanges have filled the window — instead of
+ * reporting `history-too-short` / `nothing-to-summarize` and shrinking nothing.
+ *
+ * Safety: every candidate is still a {@link findCompactionBoundary} result, i.e.
+ * a fresh-user-turn index, so the kept tail never *starts* with an orphaned
+ * tool_result and the provider's tool_use/tool_result pairing is preserved.
+ *
+ * A genuinely single-turn session cannot be helped (its one user turn IS the
+ * kept tail — shrinking to `keepLastN=1` still lands the boundary at 0); the
+ * base no-op boundary is returned unchanged so callers still surface the honest
+ * reason. Passing `usedFraction = 0` (unknown usage) also disables the fallback,
+ * preserving the legacy turn-count-only behavior.
+ */
+export function findCompactionBoundaryAdaptive<M>(
+  messages: ReadonlyArray<M>,
+  keepLastN: number,
+  ops: CompactionOps<M>,
+  usedFraction: number,
+  shrinkAtFraction: number = DEFAULT_COMPACT_SHRINK_THRESHOLD,
+): number {
+  const boundary = findCompactionBoundary(messages, keepLastN, ops);
+  if (boundary > 0) return boundary;
+  if (usedFraction < shrinkAtFraction) return boundary;
+  // Window is (near) full but the turn-count keep-window found nothing older to
+  // summarize. Relax it toward 1 so the newest fresh user turn becomes the kept
+  // tail and everything before it is summarized.
+  for (let n = keepLastN - 1; n >= 1; n--) {
+    const shrunk = findCompactionBoundary(messages, n, ops);
+    if (shrunk > 0) return shrunk;
+  }
+  return boundary;
 }
 
 /** Render a slice of messages as a plain-text transcript for the summarizer. */
@@ -215,6 +273,20 @@ export interface CompactionCoreDeps<M> {
   ops: CompactionOps<M>;
   keepLastN: number;
   /**
+   * Context-window fullness fraction (0–1) at compaction time. When the
+   * turn-count keep-window yields nothing to summarize but this is at/above
+   * {@link CompactionCoreDeps.shrinkAtFraction}, the keep-window is relaxed
+   * toward 1 turn so a short-but-full session can still be compacted (see
+   * {@link findCompactionBoundaryAdaptive}). Defaults to `0` (unknown usage →
+   * never shrink, i.e. legacy turn-count-only behavior).
+   */
+  usedFraction?: number;
+  /**
+   * Fullness fraction at/above which the keep-window may shrink. Defaults to
+   * {@link DEFAULT_COMPACT_SHRINK_THRESHOLD}.
+   */
+  shrinkAtFraction?: number;
+  /**
    * Turn a plain-text transcript into a summary. Backed by the provider's own
    * one-shot completion primitive. Rejection (rate limit, network, abort) is
    * caught by the core and reported as a typed no-op reason.
@@ -257,7 +329,13 @@ export async function runCompactionCore<M>(
   const messagesBefore = messages.length;
   const unchanged = { messagesBefore, messagesAfter: messagesBefore } as const;
 
-  const boundary = findCompactionBoundary(messages, keepLastN, ops);
+  const boundary = findCompactionBoundaryAdaptive(
+    messages,
+    keepLastN,
+    ops,
+    deps.usedFraction ?? 0,
+    deps.shrinkAtFraction ?? DEFAULT_COMPACT_SHRINK_THRESHOLD,
+  );
   if (boundary < 0) {
     return { compacted: false, reason: 'history-too-short', ...unchanged };
   }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -114,6 +114,14 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
     category: 'model',
   },
   {
+    name: 'AFK_COMPACT_SHRINK_FRACTION',
+    description: 'Context-fullness fraction (0–1, exclusive) at/above which /compact and auto-compaction relax the keep-window so a short-but-full session (few turns, huge tool exchanges) can still be summarized instead of no-oping on turn count. Default 0.7 (see shared/compaction.ts DEFAULT_COMPACT_SHRINK_THRESHOLD).',
+    type: 'number',
+    required: false,
+    example: '0.8',
+    category: 'model',
+  },
+  {
     name: 'AFK_DEFAULT_SUBAGENT_MODEL',
     description: 'Override the default model used when a subagent is dispatched without an explicit model.',
     type: 'string',
@@ -1286,6 +1294,7 @@ export const env = {
   // Model / agent runtime
   get AFK_COMPACT_KEEP_LAST_TURNS(): string | undefined { return process.env['AFK_COMPACT_KEEP_LAST_TURNS']; },
   get AFK_COMPACT_MODEL(): string | undefined { return process.env['AFK_COMPACT_MODEL']; },
+  get AFK_COMPACT_SHRINK_FRACTION(): string | undefined { return process.env['AFK_COMPACT_SHRINK_FRACTION']; },
   get AFK_COMPANION_PRIMER(): string | undefined { return process.env['AFK_COMPANION_PRIMER']; },
   get AFK_DEFAULT_SUBAGENT_MODEL(): string | undefined { return process.env['AFK_DEFAULT_SUBAGENT_MODEL']; },
   get AFK_DIAGNOSE_BASELINE(): string | undefined { return process.env['AFK_DIAGNOSE_BASELINE']; },


### PR DESCRIPTION
## Problem

`/compact` (and auto-compaction) refuse to do anything on a session with only 1–2 turns, **even when the context window is nearly full** — reporting *"not enough history to compact yet."* This is the exact complaint that motivated the change: a single heavy research turn (huge tool outputs, big file reads) fills the window, but `/compact` says the session is too short.

**Root cause:** compaction was gated purely on **turn count**, never token fullness.

- The compactor keeps the last `N = 2` *fresh user turns* verbatim (`DEFAULT_COMPACT_KEEP_LAST_TURNS`) and only summarizes turns **older** than them (`findCompactionBoundary`, `shared/compaction.ts`).
- Fewer than 2 fresh user turns → `history-too-short`; exactly 2 with nothing older → `nothing-to-summarize`.
- Manual `/compact` **never consulted token usage at all** (`cli/slash/commands/core.ts` only branches on the returned reason string).

So a full 1–2 turn session reclaims nothing regardless of how full it is. (Contrast: Claude Code anchors compaction on **tokens**, and its `/compact` runs regardless of turn count.)

## Fix

Add a token-fullness fallback, `findCompactionBoundaryAdaptive` (`shared/compaction.ts`):

> When the turn-count keep-window yields nothing to summarize **but** context usage is at/above a threshold (default **0.7** of the auto-compaction budget), progressively relax the keep-window toward 1 turn so an older-but-recent turn becomes eligible.

- **Safety invariant preserved:** every candidate boundary is still a `findCompactionBoundary` result — i.e. a *fresh-user-turn index* — so the kept tail never starts with an orphaned `tool_result` and `tool_use`/`tool_result` pairing stays intact. No mid-turn cuts.
- **Both providers:** `anthropic-direct` (bespoke `compact-handler.ts`) and `openai-compatible` (via `runCompactionCore`).
- **Both triggers:** manual `/compact` and auto-compaction (which already fires at ~0.9, so the shrink always applies once it triggers).
- **Fullness denominator:** `autoCompactLimitFor(requestedModel)` — the same working budget the auto trigger uses (honors the `*_1m` opt-in).
- **Backward compatible:** `usedFraction` defaults to `0` in the shared core (unknown usage → never shrink), so existing turn-count-only behavior is unchanged when fullness is unknown or below threshold.
- **New knob:** `AFK_COMPACT_SHRINK_FRACTION` (0–1 exclusive; default 0.7), registered in `env.ts` + `docs/env-registry.*`.

## Limitation / follow-up

A genuinely **single**-turn session still no-ops honestly — its one user turn *is* the kept tail, so there's nothing older to summarize. Reclaiming space inside a single fat turn needs **tool-result microcompaction** (trim old tool_result payloads in place, à la Claude Code's microcompact); that's a larger, separable change and is left as follow-up.

## Testing

- `findCompactionBoundaryAdaptive` unit tests — no-shrink below threshold, shrink on a 2-turn full session, single-turn stays a no-op, `keepLastN=1` has nothing to shrink (`shared/compaction.test.ts`).
- `contextFullnessFraction` units (`auto-compact.test.ts`).
- `runCompactionCore` adaptive cases — compacts a 2-turn session when `usedFraction >= threshold`, no-ops below (covers the OpenAI path).
- Anthropic integration test: a 2-turn session reporting 181k/200k now compacts (mirror of the existing empty-window `nothing-to-summarize` test).
- Updated one OpenAI auto-compaction test whose assertion encoded the old turn-count gate (now compacts at turn 2 instead of only turn 3 under a full window — the intended behavior).

Full suite green (`pnpm test`: 12,600 pass), `pnpm lint` clean, `scan:env` / `audit:env` / `audit:sdk` all pass. Changes were isolated on `origin/main` in a fresh worktree and re-verified (lint + 213 targeted tests + audits) independently of unrelated in-progress work.

---

🤖 Generated with agent-afk
