### PR TITLE
feat(repl): edit a previous message — /rewind + double-Esc conversation rewind

### DIFF
--- a/src/agent/provider.ts
+++ b/src/agent/provider.ts
@@ -321,6 +321,26 @@ export interface ProviderQuery extends AsyncIterable<ProviderEvent> {
    */
   compact?(): Promise<ProviderCompactResult>;
   /**
+   * Optional. Enumerate the genuine user-text turns in the current
+   * conversation, newest-first, for the "rewind to a previous message"
+   * picker. Each entry carries an opaque `turnIndex` handle the provider
+   * maps back to its internal history, plus a short single-line `preview`.
+   * Pure read — no mutation. Providers whose backend manages history
+   * opaquely leave this undefined; the harness returns an empty list.
+   */
+  listRewindTargets?(): RewindTarget[];
+  /**
+   * Optional. Rewind the conversation to a `turnIndex` returned by
+   * {@link listRewindTargets}: discard that user turn and everything after
+   * it, repairing any orphaned tool_use at the new tail so the Messages API
+   * contract holds. Returns the removed message's text as `reloadText` so
+   * the surface can reload it into the input for editing. In-place history
+   * mutation guarded by the same idle interlock as {@link compact} — a no-op
+   * (`rewound: false`) mid-turn. Providers that manage history opaquely leave
+   * this undefined; the harness surfaces a `not-supported` result.
+   */
+  rewindConversation?(turnIndex: number): Promise<ProviderRewindConversationResult>;
+  /**
    * Optional. Update the working directory used by the system prompt and
    * tool handlers for all **subsequent** turns in this query's lifetime.
    *
@@ -417,6 +437,40 @@ export interface ProviderCompactResult {
   messagesAfter: number;
   /** Best-effort estimate of input tokens saved on subsequent turns. */
   tokensSavedEstimate?: number;
+}
+
+/**
+ * One rewindable user turn, surfaced to the "edit a previous message" picker
+ * by {@link ProviderQuery.listRewindTargets}.
+ */
+export interface RewindTarget {
+  /**
+   * Opaque handle the provider maps back to its internal history position.
+   * For {@link ProviderQuery.rewindConversation}. Callers must not assume it
+   * is a contiguous 0..N index — treat it as a token from `listRewindTargets`.
+   */
+  turnIndex: number;
+  /** Short, single-line preview of the user message text (already truncated). */
+  preview: string;
+}
+
+/**
+ * Result of a {@link ProviderQuery.rewindConversation} call.
+ *
+ * `rewound: false` is not necessarily an error — it signals a deliberate no-op
+ * (session busy, turn in flight, invalid target, or provider doesn't support
+ * it). `reason` carries a short identifier the surface can render.
+ */
+export interface ProviderRewindConversationResult {
+  rewound: boolean;
+  reason?: string;
+  /**
+   * Text of the discarded user message, for reloading into the input box so
+   * the user can edit and resend. Present only when `rewound: true`.
+   */
+  reloadText?: string;
+  messagesBefore: number;
+  messagesAfter: number;
 }
 
 /**

--- a/src/agent/providers/anthropic-direct/query.ts
+++ b/src/agent/providers/anthropic-direct/query.ts
@@ -42,9 +42,11 @@ import type {
   ProviderMcpServerStatus,
   ProviderModelInfo,
   ProviderQuery,
+  ProviderRewindConversationResult,
   ProviderRewindResult,
   ProviderSessionInfo,
   ProviderUserTurn,
+  RewindTarget,
 } from '../../provider.js';
 import { buildRequestHeaders } from './auth.js';
 import {
@@ -70,6 +72,7 @@ import { type SessionState, createSessionState } from './query/session-state.js'
 import { AbortCoordinator } from './query/abort-coordinator.js';
 import { RetryLayer } from './query/retry-layer.js';
 import { compactHistory } from './query/compact-handler.js';
+import { listUserTurns, rewindConversationHistory } from './query/rewind-conversation.js';
 import { contextWindowTokensUsed, shouldAutoCompact, buildContextUsageFields } from './query/auto-compact.js';
 import type { HookRegistry } from '../../hooks.js';
 import { HookBlockedError } from '../../../utils/errors.js';
@@ -822,6 +825,28 @@ export class AnthropicDirectQuery implements ProviderQuery {
       initSessionId: this.initSessionId,
       ...(this.traceWriter ? { traceWriter: this.traceWriter } : {}),
     });
+  }
+
+  /**
+   * Enumerate genuine user-text turns (newest-first) for the rewind picker.
+   * See `query/rewind-conversation.ts`.
+   */
+  listRewindTargets(): RewindTarget[] {
+    return listUserTurns(this.state.messages);
+  }
+
+  /**
+   * Discard a chosen user turn and everything after it, returning the removed
+   * message's text for reload-and-edit. In-place, idle-guarded (same interlock
+   * as {@link compact}). See `query/rewind-conversation.ts`.
+   */
+  async rewindConversation(
+    turnIndex: number,
+  ): Promise<ProviderRewindConversationResult> {
+    return rewindConversationHistory(
+      { state: this.state, abort: this.abort },
+      turnIndex,
+    );
   }
 
   close(): void {

--- a/src/agent/providers/anthropic-direct/query/rewind-conversation.test.ts
+++ b/src/agent/providers/anthropic-direct/query/rewind-conversation.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for the conversation-rewind helpers — the provider half of the
+ * REPL "press Esc-Esc to edit a previous message" feature.
+ *
+ * Covers turn enumeration (newest-first, tool_result turns excluded), the
+ * guard paths (closed / turn-in-flight / invalid target), in-place truncation
+ * with array-identity preservation, reloadText extraction, and the
+ * tool_use/tool_result boundary repair after a splice.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { ContentBlockParam, MessageParam } from '@anthropic-ai/sdk/resources';
+import { listUserTurns, rewindConversationHistory } from './rewind-conversation.js';
+import type { SessionState } from './session-state.js';
+import type { AbortCoordinator } from './abort-coordinator.js';
+
+function makeState(messages: MessageParam[], closed = false): SessionState {
+  // The handler only reads `messages` + `closed`; the rest of SessionState is
+  // irrelevant here. Structural stub (tests are not type-checked by tsc).
+  return { messages, closed } as unknown as SessionState;
+}
+
+const idleAbort = { isIdle: () => true } as unknown as AbortCoordinator;
+const busyAbort = { isIdle: () => false } as unknown as AbortCoordinator;
+
+const toolUse = (id: string): ContentBlockParam[] => [
+  { type: 'tool_use', id, name: 'x', input: {} },
+];
+const toolResult = (id: string): ContentBlockParam[] => [
+  { type: 'tool_result', tool_use_id: id, content: 'ok' },
+];
+
+/** A realistic 3-turn conversation with one tool round in the middle. */
+function sampleHistory(): MessageParam[] {
+  return [
+    { role: 'user', content: 'first question' },          // 0  genuine
+    { role: 'assistant', content: toolUse('t1') },         // 1
+    { role: 'user', content: toolResult('t1') },           // 2  tool_result (NOT genuine)
+    { role: 'assistant', content: 'first answer' },        // 3
+    { role: 'user', content: 'second question' },          // 4  genuine
+    { role: 'assistant', content: 'second answer' },       // 5
+    { role: 'user', content: 'third question' },           // 6  genuine
+    { role: 'assistant', content: 'third answer' },        // 7
+  ];
+}
+
+describe('listUserTurns', () => {
+  it('enumerates only genuine user-text turns, newest-first', () => {
+    const targets = listUserTurns(sampleHistory());
+    expect(targets.map((t) => t.turnIndex)).toEqual([6, 4, 0]);
+    expect(targets.map((t) => t.preview)).toEqual([
+      'third question',
+      'second question',
+      'first question',
+    ]);
+  });
+
+  it('excludes pure tool_result user messages', () => {
+    const targets = listUserTurns(sampleHistory());
+    // index 2 is a tool_result user message — must not appear.
+    expect(targets.some((t) => t.turnIndex === 2)).toBe(false);
+  });
+
+  it('handles string and text-block user content', () => {
+    const messages: MessageParam[] = [
+      { role: 'user', content: 'plain string' },
+      { role: 'assistant', content: 'a' },
+      { role: 'user', content: [{ type: 'text', text: 'block text' }] as ContentBlockParam[] },
+      { role: 'assistant', content: 'b' },
+    ];
+    expect(listUserTurns(messages).map((t) => t.preview)).toEqual([
+      'block text',
+      'plain string',
+    ]);
+  });
+
+  it('collapses whitespace and truncates long previews', () => {
+    const long = 'word '.repeat(40); // 200 chars
+    const targets = listUserTurns([{ role: 'user', content: long }]);
+    expect(targets[0]!.preview.length).toBeLessThanOrEqual(72);
+    expect(targets[0]!.preview.endsWith('…')).toBe(true);
+    expect(targets[0]!.preview).not.toContain('  '); // whitespace collapsed
+  });
+
+  it('returns empty for a history with no genuine user turns', () => {
+    expect(listUserTurns([])).toEqual([]);
+    expect(listUserTurns([{ role: 'assistant', content: 'hi' }])).toEqual([]);
+    expect(listUserTurns([{ role: 'user', content: toolResult('t1') }])).toEqual([]);
+  });
+});
+
+describe('rewindConversationHistory', () => {
+  it('truncates to just before the chosen turn and returns its text', () => {
+    const state = makeState(sampleHistory());
+    const before = state.messages;
+
+    const result = rewindConversationHistory({ state, abort: idleAbort }, 4);
+
+    expect(result.rewound).toBe(true);
+    expect(result.reloadText).toBe('second question');
+    expect(result.messagesBefore).toBe(8);
+    expect(result.messagesAfter).toBe(4);
+    // Kept [0,4): the previous turn is fully resolved (ends on an assistant).
+    expect(state.messages.map((m) => m.role)).toEqual([
+      'user',
+      'assistant',
+      'user',
+      'assistant',
+    ]);
+    // Mutated IN PLACE — array identity preserved (loop holds this reference).
+    expect(state.messages).toBe(before);
+  });
+
+  it('rewinding to the most-recent turn drops just that turn', () => {
+    const state = makeState(sampleHistory());
+    const result = rewindConversationHistory({ state, abort: idleAbort }, 6);
+    expect(result.rewound).toBe(true);
+    expect(result.reloadText).toBe('third question');
+    expect(state.messages).toHaveLength(6);
+  });
+
+  it('rewinding to the first turn yields an empty history', () => {
+    const state = makeState(sampleHistory());
+    const result = rewindConversationHistory({ state, abort: idleAbort }, 0);
+    expect(result.rewound).toBe(true);
+    expect(result.reloadText).toBe('first question');
+    expect(state.messages).toHaveLength(0);
+  });
+
+  it('repairs an orphaned tool_use left at the new tail (API contract)', () => {
+    // Contrived tail: truncating at the genuine user turn strands an assistant
+    // tool_use with no following tool_result. repairOrphanToolUses must append
+    // a synthetic error tool_result so the next Messages API call is valid.
+    const messages: MessageParam[] = [
+      { role: 'assistant', content: toolUse('t9') },
+      { role: 'user', content: 'redo from here' },
+    ];
+    const state = makeState(messages);
+
+    const result = rewindConversationHistory({ state, abort: idleAbort }, 1);
+
+    expect(result.rewound).toBe(true);
+    const last = state.messages[state.messages.length - 1]!;
+    expect(last.role).toBe('user');
+    const blocks = last.content as ContentBlockParam[];
+    expect(blocks[0]?.type).toBe('tool_result');
+    expect((blocks[0] as { tool_use_id?: string }).tool_use_id).toBe('t9');
+  });
+
+  it('no-ops when the session is closed', () => {
+    const state = makeState(sampleHistory(), /* closed */ true);
+    const result = rewindConversationHistory({ state, abort: idleAbort }, 4);
+    expect(result.rewound).toBe(false);
+    expect(result.reason).toBe('session-closed');
+    expect(state.messages).toHaveLength(8); // untouched
+  });
+
+  it('no-ops when a turn is in flight (idle interlock)', () => {
+    const state = makeState(sampleHistory());
+    const result = rewindConversationHistory({ state, abort: busyAbort }, 4);
+    expect(result.rewound).toBe(false);
+    expect(result.reason).toBe('turn-in-flight');
+    expect(state.messages).toHaveLength(8);
+  });
+
+  it('rejects an out-of-range index', () => {
+    const state = makeState(sampleHistory());
+    for (const bad of [-1, 8, 99, 1.5]) {
+      const result = rewindConversationHistory({ state, abort: idleAbort }, bad);
+      expect(result.rewound).toBe(false);
+      expect(result.reason).toBe('invalid-target');
+    }
+    expect(state.messages).toHaveLength(8);
+  });
+
+  it('rejects a non-user-turn target (assistant / tool_result)', () => {
+    const state = makeState(sampleHistory());
+    // 3 = assistant, 2 = tool_result user message.
+    expect(rewindConversationHistory({ state, abort: idleAbort }, 3).reason).toBe('invalid-target');
+    expect(rewindConversationHistory({ state, abort: idleAbort }, 2).reason).toBe('invalid-target');
+    expect(state.messages).toHaveLength(8);
+  });
+});

--- a/src/agent/providers/anthropic-direct/query/rewind-conversation.ts
+++ b/src/agent/providers/anthropic-direct/query/rewind-conversation.ts
@@ -1,0 +1,137 @@
+/**
+ * Conversation-rewind handler for {@link AnthropicDirectQuery} — the
+ * provider half of the REPL "press Esc-Esc to edit a previous message"
+ * feature.
+ *
+ * Two pure operations over `state.messages`:
+ *
+ *   - {@link listUserTurns} — enumerate the genuine user-text turns
+ *     (skipping pure `tool_result` user messages), newest-first, with a
+ *     short single-line preview. Read-only.
+ *
+ *   - {@link rewindConversationHistory} — discard a chosen user turn and
+ *     everything after it, then run {@link repairOrphanToolUses} so the new
+ *     tail never ends on an assistant `tool_use` without its `tool_result`
+ *     (Anthropic API contract). Returns the removed message's text so the
+ *     surface can reload it into the input for editing.
+ *
+ * # Why in-place splice is safe here
+ *
+ * Invariant: this mutates `state.messages` in place (`splice`) rather than
+ * reassigning — identical to how `compact-handler.ts` applies compaction —
+ * so the loop's held array reference and the identity-based tests stay
+ * valid. The race that would make an unguarded splice dangerous (auto-compact
+ * splicing the SAME array after a turn) is closed by the same `abort.isIdle()`
+ * interlock `compact()` uses: rewind only proceeds when no turn is in flight.
+ * The REPL only offers rewind at the idle prompt, so this is belt-and-braces.
+ *
+ * @module agent/providers/anthropic-direct/query/rewind-conversation
+ */
+
+import type { ContentBlockParam, MessageParam } from '@anthropic-ai/sdk/resources';
+import type {
+  ProviderRewindConversationResult,
+  RewindTarget,
+} from '../../../provider.js';
+import { repairOrphanToolUses } from './repair-orphan-tool-uses.js';
+import type { SessionState } from './session-state.js';
+import type { AbortCoordinator } from './abort-coordinator.js';
+
+const PREVIEW_MAX_CHARS = 72;
+
+/** Concatenate the text blocks of a user message into a single string. */
+function extractUserText(content: MessageParam['content']): string {
+  if (typeof content === 'string') return content;
+  const parts: string[] = [];
+  for (const block of content as ContentBlockParam[]) {
+    if (block.type === 'text' && typeof block.text === 'string') {
+      parts.push(block.text);
+    }
+  }
+  return parts.join(' ');
+}
+
+/**
+ * A "genuine" user turn is one the user actually typed — role `user` with at
+ * least one non-empty text block. Pure `tool_result` user messages (the
+ * synthetic turns that carry tool output back to the model) are excluded:
+ * they are not rewind targets and truncating at one would strand the paired
+ * `tool_use`.
+ */
+function isGenuineUserTurn(message: MessageParam): boolean {
+  if (message.role !== 'user') return false;
+  return extractUserText(message.content).trim().length > 0;
+}
+
+/** Collapse whitespace to single spaces and truncate for a one-line preview. */
+function toPreview(text: string): string {
+  const flat = text.replace(/\s+/g, ' ').trim();
+  if (flat.length <= PREVIEW_MAX_CHARS) return flat;
+  return flat.slice(0, PREVIEW_MAX_CHARS - 1) + '…';
+}
+
+/**
+ * Enumerate the genuine user-text turns, newest-first. `turnIndex` is the
+ * message's index in `messages` — the handle {@link rewindConversationHistory}
+ * consumes. Pure; does not mutate.
+ */
+export function listUserTurns(messages: readonly MessageParam[]): RewindTarget[] {
+  const targets: RewindTarget[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    if (message && isGenuineUserTurn(message)) {
+      targets.push({ turnIndex: i, preview: toPreview(extractUserText(message.content)) });
+    }
+  }
+  // Newest-first so the most-recent prompt sits at the top of the picker.
+  return targets.reverse();
+}
+
+/** Injected collaborators for {@link rewindConversationHistory}. */
+export interface RewindHandlerDeps {
+  state: SessionState;
+  abort: AbortCoordinator;
+}
+
+/**
+ * Rewind to `turnIndex`: discard that user turn and everything after it.
+ * Mutates `state.messages` in place on success; leaves history untouched on
+ * every no-op path (closed, in-flight, out-of-range, not-a-user-turn).
+ */
+export function rewindConversationHistory(
+  deps: RewindHandlerDeps,
+  turnIndex: number,
+): ProviderRewindConversationResult {
+  const { state, abort } = deps;
+  const messagesBefore = state.messages.length;
+
+  if (state.closed) {
+    return { rewound: false, reason: 'session-closed', messagesBefore, messagesAfter: messagesBefore };
+  }
+  if (!abort.isIdle()) {
+    return { rewound: false, reason: 'turn-in-flight', messagesBefore, messagesAfter: messagesBefore };
+  }
+  if (!Number.isInteger(turnIndex) || turnIndex < 0 || turnIndex >= messagesBefore) {
+    return { rewound: false, reason: 'invalid-target', messagesBefore, messagesAfter: messagesBefore };
+  }
+  const target = state.messages[turnIndex];
+  if (!target || !isGenuineUserTurn(target)) {
+    return { rewound: false, reason: 'invalid-target', messagesBefore, messagesAfter: messagesBefore };
+  }
+
+  const reloadText = extractUserText(target.content);
+
+  // Discard the target user turn and everything after it, in place.
+  state.messages.splice(turnIndex);
+  // Defensive: a completed turn ends with a resolved assistant message, so the
+  // new tail is normally clean — but repair covers histories restored from an
+  // older persist that leaked an orphan.
+  repairOrphanToolUses(state.messages);
+
+  return {
+    rewound: true,
+    reloadText,
+    messagesBefore,
+    messagesAfter: state.messages.length,
+  };
+}

--- a/src/agent/providers/router/provider-router.test.ts
+++ b/src/agent/providers/router/provider-router.test.ts
@@ -83,6 +83,17 @@ class FakeQuery implements ProviderQuery {
   async rewindFiles() {
     return { canRewind: false };
   }
+  listRewindTargets() {
+    return [{ turnIndex: 0, preview: `turn-${this.sessionId}` }];
+  }
+  async rewindConversation(turnIndex: number) {
+    return {
+      rewound: true,
+      reloadText: `reload-${turnIndex}`,
+      messagesBefore: 4,
+      messagesAfter: turnIndex,
+    };
+  }
   compact?(): Promise<import('../../provider.js').ProviderCompactResult>;
   close(): void {
     this.rec.closed = true;
@@ -304,6 +315,32 @@ describe('ProviderRouter', () => {
     expect(result.compacted).toBe(false);
     expect(result.reason).toMatch(/does not support/i);
     await router.close();
+  });
+
+  it('delegates listRewindTargets / rewindConversation to the active inner', async () => {
+    const { router, outer } = makeRouter({ model: 'sonnet', apiKey: 'key-anthropic' });
+    const iter = router[Symbol.asyncIterator]();
+    await pullInit(iter);
+    void outer;
+
+    const targets = router.listRewindTargets();
+    expect(targets).toHaveLength(1);
+    expect(targets[0]!.preview).toContain('anthropic-direct#0');
+
+    const result = await router.rewindConversation(2);
+    expect(result.rewound).toBe(true);
+    expect(result.reloadText).toBe('reload-2');
+    expect(result.messagesAfter).toBe(2);
+    await router.close();
+  });
+
+  it('returns empty targets / not-supported rewind before any provider is active', async () => {
+    const { router } = makeRouter({ model: 'sonnet', apiKey: 'key-anthropic' });
+    // No iteration yet → no active inner.
+    expect(router.listRewindTargets()).toEqual([]);
+    const result = await router.rewindConversation(0);
+    expect(result.rewound).toBe(false);
+    expect(result.reason).toBe('not-supported');
   });
 
   it('drops the credential entirely when the family has no resolvable key', async () => {

--- a/src/agent/providers/router/provider-router.ts
+++ b/src/agent/providers/router/provider-router.ts
@@ -54,7 +54,9 @@ import type {
   ProviderMcpServerStatus,
   ProviderAccountInfo,
   ProviderRewindResult,
+  ProviderRewindConversationResult,
   ProviderCompactResult,
+  RewindTarget,
 } from '../../provider.js';
 import type { AgentConfig, ResumeHistoryTurn } from '../../types/config-types.js';
 import { QueryInputStream } from '../../session/input-iterable.js';
@@ -435,6 +437,23 @@ export class ProviderRouter implements ProviderQuery {
     return {
       compacted: false,
       reason: 'provider does not support compaction',
+      messagesBefore: 0,
+      messagesAfter: 0,
+    };
+  }
+
+  listRewindTargets(): RewindTarget[] {
+    return this.active?.query.listRewindTargets?.() ?? [];
+  }
+
+  async rewindConversation(
+    turnIndex: number,
+  ): Promise<ProviderRewindConversationResult> {
+    const a = this.active;
+    if (a?.query.rewindConversation) return a.query.rewindConversation(turnIndex);
+    return {
+      rewound: false,
+      reason: 'not-supported',
       messagesBefore: 0,
       messagesAfter: 0,
     };

--- a/src/agent/session/agent-session.ts
+++ b/src/agent/session/agent-session.ts
@@ -19,7 +19,13 @@ import type { HookRegistry } from '../hooks.js';
 import { resolveProvider, providerForModel } from '../providers/index.js';
 import { ProviderRouter } from '../providers/router/provider-router.js';
 import { resolveCredentialForModel } from '../auth/credential-resolver.js';
-import type { ProviderCompactResult, ProviderEvent, ProviderQuery } from '../provider.js';
+import type {
+  ProviderCompactResult,
+  ProviderEvent,
+  ProviderQuery,
+  ProviderRewindConversationResult,
+  RewindTarget,
+} from '../provider.js';
 import { DEFAULT_SESSION_TIMEOUT_MS, RESET_DRAIN_TIMEOUT_MS, withTimeout } from '../timeout.js';
 import { dispatchSessionEnd, dispatchSessionStart } from './hooks-dispatch.js';
 import { HookBlockedError } from '../../utils/errors.js';
@@ -1065,6 +1071,37 @@ export class AgentSession implements IAgentSession {
     } finally {
       this.currentState = 'idle';
     }
+  }
+
+  listRewindTargets(): RewindTarget[] {
+    if (this.currentState === 'closed') return [];
+    return this.providerQuery.listRewindTargets?.() ?? [];
+  }
+
+  async rewindConversation(
+    turnIndex: number,
+  ): Promise<ProviderRewindConversationResult> {
+    if (this.currentState === 'closed') {
+      throw new Error('Cannot rewind: session is closed');
+    }
+    if (this.currentState !== 'idle') {
+      return {
+        rewound: false,
+        reason: 'session-busy',
+        messagesBefore: 0,
+        messagesAfter: 0,
+      };
+    }
+    const fn = this.providerQuery.rewindConversation?.bind(this.providerQuery);
+    if (!fn) {
+      return {
+        rewound: false,
+        reason: 'not-supported',
+        messagesBefore: 0,
+        messagesAfter: 0,
+      };
+    }
+    return fn(turnIndex);
   }
 
   getLastResponseMetadata(): ResponseMetadata | null {

--- a/src/agent/types/session-types.ts
+++ b/src/agent/types/session-types.ts
@@ -24,7 +24,12 @@ import type {
   SendMessageOptions,
   StructuredMessageOptions,
 } from './message-types.js';
-import type { ProviderCompactResult, ProviderQuery } from '../provider.js';
+import type {
+  ProviderCompactResult,
+  ProviderQuery,
+  ProviderRewindConversationResult,
+  RewindTarget,
+} from '../provider.js';
 import type { HookRegistry } from '../hooks.js';
 import type { ZodType } from 'zod';
 
@@ -294,6 +299,22 @@ export interface IAgentSession {
    * 'not-supported' }` instead of throwing.
    */
   compact(): Promise<ProviderCompactResult>;
+
+  /**
+   * Enumerate the genuine user-text turns for the "edit a previous message"
+   * rewind picker, newest-first. Empty when the provider manages history
+   * opaquely (no rewind support).
+   */
+  listRewindTargets(): RewindTarget[];
+
+  /**
+   * Rewind the conversation to a `turnIndex` from {@link listRewindTargets}:
+   * discard that user turn and everything after it, returning the removed
+   * message's text as `reloadText` for reload-and-edit. `rewound: false`
+   * (with a `reason`) on any no-op — session busy, invalid target, or a
+   * provider without rewind support.
+   */
+  rewindConversation(turnIndex: number): Promise<ProviderRewindConversationResult>;
 
   close(): Promise<void>;
 }

--- a/src/cli/commands/interactive/loop-iteration.ts
+++ b/src/cli/commands/interactive/loop-iteration.ts
@@ -159,6 +159,12 @@ export async function runInputLoop(
       ? { text: ctx.initialInput, attachments: [] }
       : undefined;
 
+  // Rewind reload-for-edit: `/rewind` (or double-Esc) returns
+  // `{ kind: 'prefill', message }` — the discarded message's text. Unlike
+  // `seedBuffer` (auto-submit), this pre-fills the NEXT readLine's editable
+  // input buffer so the user edits and presses Enter to resend. Consumed once.
+  let prefillBuffer: string | undefined;
+
   // First-use notice for ! shell passthrough: shown once per session on the
   // first `!cmd` dispatch so users who relied on `!literal text` as model
   // input are informed of the behavior change and the opt-out flag.
@@ -315,8 +321,12 @@ export async function runInputLoop(
         // onSubmit path when armed (TTY); falls back to readWithAutocomplete
         // on non-TTY surfaces. Shift+Tab and onSigint are wired ONCE at
         // armCompositor time (above) — no need to re-pass per-call.
+        // Consume a one-shot rewind prefill (editable, not auto-submitted).
+        const initialBuffer = prefillBuffer;
+        prefillBuffer = undefined;
         const result = await surface.readLine({
           promptFn: () => buildPrompt(ctx.stats.permissionMode),
+          ...(initialBuffer !== undefined ? { initialBuffer } : {}),
           onSigint: sigintHandler,
           onShiftTab: () => {
             // Shift+Tab is the keyboard speed lane: it advances the permission-
@@ -401,6 +411,18 @@ export async function runInputLoop(
             res.result.kind === 'submit'
           ) {
             seedBuffer = { text: res.result.message, attachments: attachments ?? [] };
+            ctx.statusLine.rearm();
+            continue;
+          }
+          if (
+            res.result !== null &&
+            typeof res.result === 'object' &&
+            'kind' in res.result &&
+            res.result.kind === 'prefill'
+          ) {
+            // Rewind: load the discarded message's text into the next prompt,
+            // editable. No auto-submit — the user edits and presses Enter.
+            prefillBuffer = res.result.message;
             ctx.statusLine.rearm();
             continue;
           }

--- a/src/cli/input/input-surface.ts
+++ b/src/cli/input/input-surface.ts
@@ -91,6 +91,14 @@ export interface InputSurfaceReadOpts {
   onSigint?: () => void;
   onShiftTab?: () => void;
   /**
+   * Pre-fill the editable input buffer before blocking for input (the
+   * rewind reload-for-edit path — `/rewind` / double-Esc loads a discarded
+   * message's text here to edit and resend). Distinct from an auto-submit:
+   * the text is placed in the input row and awaits an explicit Enter.
+   * Honored on both the compositor (TTY) and readline-fallback paths.
+   */
+  initialBuffer?: string;
+  /**
    * Currently-armed agent-turn compositor (if any). Today: always
    * `undefined` between turns because the compositor disarms at
    * end-of-turn. Forwarded to the underlying reader as a defensive
@@ -347,6 +355,9 @@ export class InputSurface {
     });
     await compositor.arm();
     compositor.setInputMode('idle');
+    // Double-Esc at an empty idle prompt → resolve the in-flight readLine with
+    // `/rewind` so the REPL dispatches the rewind picker between turns.
+    compositor.setOnRewindRequest(() => { this.requestRewind(); });
     this.compositor = compositor;
     this.armedStdout = stdout;
   }
@@ -531,6 +542,12 @@ export class InputSurface {
           resolve({ text: payload.text, attachments: [...payload.attachments] });
         };
         compositor.setOnSubmit(handler);
+        // Rewind reload-for-edit: seed the editable buffer BEFORE flipping to
+        // idle + repainting so the discarded message's text appears in the
+        // input row ready to edit. Mirrors history-recall's applyEdit(seed).
+        if (opts.initialBuffer !== undefined && opts.initialBuffer.length > 0) {
+          compositor.prefillInput(opts.initialBuffer);
+        }
         // Flip to idle mode. Side effects:
         //   1. The turn-handler's renderer.dispose() already flipped
         //      to idle and may have left a queued buffer (user typed
@@ -557,6 +574,7 @@ export class InputSurface {
     return readWithAutocomplete({
       rl: this.rl,
       promptFn: opts.promptFn,
+      ...(opts.initialBuffer !== undefined ? { initialBuffer: opts.initialBuffer } : {}),
       ...(opts.onSigint ? { onSigint: opts.onSigint } : {}),
       ...(opts.onShiftTab ? { onShiftTab: opts.onShiftTab } : {}),
       ...(opts.compositor ? { compositor: opts.compositor } : {}),
@@ -610,6 +628,25 @@ export class InputSurface {
     this.pendingReadReject = null;
     this.pendingReadResolve = null;
     resolve({ text: '', attachments: [] });
+  }
+
+  /**
+   * Resolve an in-flight compositor-path {@link readLine} with the text
+   * `/rewind` WITHOUT a keypress — the double-Esc rewind trigger. Mirrors
+   * {@link abortPendingRead}'s wake+cleanup (clear the one-shot onSubmit so a
+   * later Enter can't double-fire), but resolves with `/rewind` so the REPL
+   * loop dispatches the rewind command (which runs the picker between turns,
+   * where selectors are safe). No-op when no read is in flight (non-TTY, or a
+   * turn is streaming). Returns whether it fired.
+   */
+  requestRewind(): boolean {
+    if (!this.pendingReadResolve) return false;
+    this.compositor?.setOnSubmit(null);
+    const resolve = this.pendingReadResolve;
+    this.pendingReadReject = null;
+    this.pendingReadResolve = null;
+    resolve({ text: '/rewind', attachments: [] });
+    return true;
   }
 
   /**

--- a/src/cli/slash/commands/core.ts
+++ b/src/cli/slash/commands/core.ts
@@ -13,6 +13,7 @@ import { list } from '../registry.js';
 import { resetStats } from '../session-stats.js';
 import { REPL_SPINNER_OPTIONS } from '../../commands/interactive/shared.js';
 import { HookBlockedError, AbortError } from '../../../utils/errors.js';
+import { renderSelector } from '../../input/selectors.js';
 import type { SlashCommand } from '../types.js';
 
 const exitCmd: SlashCommand = {
@@ -103,6 +104,64 @@ const compactCmd: SlashCommand = {
   },
 };
 
+const rewindCmd: SlashCommand = {
+  name: '/rewind',
+  summary: 'Edit a previous message (rewind the conversation)',
+  hint: 'When you want to go back and re-ask an earlier prompt — pick a message, the conversation rewinds to it, and its text loads into the input to edit and resend. (Also: press Esc twice at an empty prompt.)',
+  async handler(ctx) {
+    const session = ctx.session.current;
+    const targets = session.listRewindTargets();
+    if (targets.length === 0) {
+      ctx.out.info('Nothing to rewind to — no earlier messages in this conversation.');
+      return 'continue';
+    }
+
+    // renderSelector drives raw stdin directly, so release the persistent
+    // compositor's keypress listener first and re-arm it after (the selector
+    // contract — see input/selectors.ts). getCompositor is null on non-TTY.
+    const compositor = ctx.getCompositor?.() ?? null;
+    compositor?.suspendInput();
+    let choice: number | ':cancel' | null;
+    try {
+      choice = await renderSelector(
+        targets.map((t) => t.preview),
+        new AbortController().signal,
+      );
+    } finally {
+      compositor?.resumeInput();
+    }
+
+    if (choice === null) {
+      ctx.out.info('Rewind requires an interactive terminal.');
+      return 'continue';
+    }
+    if (choice === ':cancel') return 'continue';
+
+    const target = targets[choice];
+    if (!target) return 'continue';
+
+    const result = await session.rewindConversation(target.turnIndex);
+    if (!result.rewound) {
+      const reason = result.reason ?? 'unknown';
+      if (reason === 'not-supported') {
+        ctx.out.warn(
+          'Rewind is not supported for this provider — use a Claude model to enable /rewind.',
+        );
+      } else if (reason === 'session-busy' || reason === 'turn-in-flight') {
+        ctx.out.info('Cannot rewind while a turn is running.');
+      } else {
+        ctx.out.info(`Cannot rewind (${reason}).`);
+      }
+      return 'continue';
+    }
+
+    ctx.out.success(
+      `Rewound ${result.messagesBefore} → ${result.messagesAfter} messages. Edit the message below and press Enter to resend.`,
+    );
+    return { kind: 'prefill', message: result.reloadText ?? '' };
+  },
+};
+
 const helpCmd: SlashCommand = {
   name: '/help',
   summary: 'Show this help',
@@ -128,4 +187,4 @@ const helpCmd: SlashCommand = {
   },
 };
 
-export const coreCommands: SlashCommand[] = [exitCmd, clearCmd, compactCmd, helpCmd];
+export const coreCommands: SlashCommand[] = [exitCmd, clearCmd, compactCmd, rewindCmd, helpCmd];

--- a/src/cli/slash/core-rewind.test.ts
+++ b/src/cli/slash/core-rewind.test.ts
@@ -1,0 +1,173 @@
+/**
+ * `/rewind` slash handler tests.
+ *
+ * Verifies the handler enumerates rewind targets, drives the arrow-key picker,
+ * calls `session.rewindConversation(turnIndex)` for the chosen turn, and
+ * returns a `{ kind: 'prefill' }` result carrying the discarded message's text
+ * for reload-and-edit. Also covers the empty / cancel / not-supported paths.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import type { SlashCommand, SlashContext, SessionStats } from './types.js';
+import { coreCommands } from './commands/core.js';
+
+vi.mock('../input/selectors.js', () => ({
+  renderSelector: vi.fn(),
+  CUSTOM_ANSWER_SENTINEL: '\u270E Type your own answer',
+}));
+import { renderSelector } from '../input/selectors.js';
+
+function makeStats(): SessionStats {
+  return {
+    totalTurns: 0,
+    totalCostUsd: 0,
+    totalTokens: 0,
+    totalDurationMs: 0,
+    sessionStartTime: Date.now(),
+    turnCosts: [],
+    turnTokens: [],
+    turns: [],
+    model: 'sonnet',
+    permissionMode: 'default',
+  };
+}
+
+interface FakeSession {
+  listRewindTargets: Mock;
+  rewindConversation: Mock;
+}
+
+function makeCtx(session: FakeSession): { ctx: SlashContext; lines: string[]; suspend: Mock; resume: Mock } {
+  const lines: string[] = [];
+  const suspend = vi.fn();
+  const resume = vi.fn();
+  const ctx: SlashContext = {
+    session: { current: session } as unknown as SlashContext['session'],
+    stats: makeStats(),
+    out: {
+      line: (t = ''): void => { lines.push(t); },
+      raw: (t): void => { lines.push(t); },
+      success: (t): void => { lines.push(`SUCCESS:${t}`); },
+      info: (t): void => { lines.push(`INFO:${t}`); },
+      warn: (t): void => { lines.push(`WARN:${t}`); },
+      error: (t): void => { lines.push(`ERROR:${t}`); },
+    },
+    ui: { clearScreen: vi.fn(), repaintStatusLine: vi.fn() },
+    getCompositor: () =>
+      ({ suspendInput: suspend, resumeInput: resume }) as unknown as ReturnType<
+        NonNullable<SlashContext['getCompositor']>
+      >,
+  };
+  return { ctx, lines, suspend, resume };
+}
+
+function getRewindCmd(): SlashCommand {
+  const cmd = coreCommands.find((c) => c.name === '/rewind');
+  if (!cmd) throw new Error('rewind command not registered');
+  return cmd;
+}
+
+describe('/rewind slash handler', () => {
+  beforeEach(() => {
+    (renderSelector as Mock).mockReset();
+  });
+
+  it('is registered in coreCommands', () => {
+    expect(coreCommands.some((c) => c.name === '/rewind')).toBe(true);
+  });
+
+  it('info + no picker when there is nothing to rewind to', async () => {
+    const session: FakeSession = {
+      listRewindTargets: vi.fn().mockReturnValue([]),
+      rewindConversation: vi.fn(),
+    };
+    const { ctx, lines } = makeCtx(session);
+
+    const result = await getRewindCmd().handler(ctx, '');
+
+    expect(result).toBe('continue');
+    expect(renderSelector).not.toHaveBeenCalled();
+    expect(session.rewindConversation).not.toHaveBeenCalled();
+    expect(lines.find((l) => l.startsWith('INFO:'))).toContain('Nothing to rewind');
+  });
+
+  it('rewinds to the chosen turn and returns a prefill result', async () => {
+    const session: FakeSession = {
+      listRewindTargets: vi.fn().mockReturnValue([
+        { turnIndex: 6, preview: 'third question' },
+        { turnIndex: 4, preview: 'second question' },
+        { turnIndex: 0, preview: 'first question' },
+      ]),
+      rewindConversation: vi.fn().mockResolvedValue({
+        rewound: true,
+        reloadText: 'second question',
+        messagesBefore: 8,
+        messagesAfter: 4,
+      }),
+    };
+    const { ctx, suspend, resume } = makeCtx(session);
+    // Pick index 1 → the { turnIndex: 4 } target.
+    (renderSelector as Mock).mockResolvedValue(1);
+
+    const result = await getRewindCmd().handler(ctx, '');
+
+    // Picker was fed the previews; compositor input suspended around it.
+    expect(renderSelector).toHaveBeenCalledWith(
+      ['third question', 'second question', 'first question'],
+      expect.anything(),
+    );
+    expect(suspend).toHaveBeenCalledTimes(1);
+    expect(resume).toHaveBeenCalledTimes(1);
+    expect(session.rewindConversation).toHaveBeenCalledWith(4);
+    expect(result).toEqual({ kind: 'prefill', message: 'second question' });
+  });
+
+  it('cancelling the picker is a no-op', async () => {
+    const session: FakeSession = {
+      listRewindTargets: vi.fn().mockReturnValue([{ turnIndex: 0, preview: 'q' }]),
+      rewindConversation: vi.fn(),
+    };
+    const { ctx, resume } = makeCtx(session);
+    (renderSelector as Mock).mockResolvedValue(':cancel');
+
+    const result = await getRewindCmd().handler(ctx, '');
+
+    expect(result).toBe('continue');
+    expect(session.rewindConversation).not.toHaveBeenCalled();
+    expect(resume).toHaveBeenCalledTimes(1); // input re-armed even on cancel
+  });
+
+  it('non-TTY picker (null) surfaces a friendly info line', async () => {
+    const session: FakeSession = {
+      listRewindTargets: vi.fn().mockReturnValue([{ turnIndex: 0, preview: 'q' }]),
+      rewindConversation: vi.fn(),
+    };
+    const { ctx, lines } = makeCtx(session);
+    (renderSelector as Mock).mockResolvedValue(null);
+
+    const result = await getRewindCmd().handler(ctx, '');
+
+    expect(result).toBe('continue');
+    expect(session.rewindConversation).not.toHaveBeenCalled();
+    expect(lines.find((l) => l.startsWith('INFO:'))).toContain('interactive terminal');
+  });
+
+  it('warns when the provider does not support rewind', async () => {
+    const session: FakeSession = {
+      listRewindTargets: vi.fn().mockReturnValue([{ turnIndex: 0, preview: 'q' }]),
+      rewindConversation: vi.fn().mockResolvedValue({
+        rewound: false,
+        reason: 'not-supported',
+        messagesBefore: 0,
+        messagesAfter: 0,
+      }),
+    };
+    const { ctx, lines } = makeCtx(session);
+    (renderSelector as Mock).mockResolvedValue(0);
+
+    const result = await getRewindCmd().handler(ctx, '');
+
+    expect(result).toBe('continue');
+    expect(lines.find((l) => l.startsWith('WARN:'))).toContain('not supported');
+  });
+});

--- a/src/cli/slash/types.ts
+++ b/src/cli/slash/types.ts
@@ -288,7 +288,8 @@ export type SlashResult =
                  // (used by plugin-skill passthrough handlers — the SDK's
                  // subprocess natively parses `/<skill>` as an invocation)
   | { rerun: string }   // dispatch another command (e.g. /help after unknown)
-  | { kind: 'submit'; message: string };  // pre-fill prompt and auto-submit
+  | { kind: 'submit'; message: string }   // pre-fill prompt and auto-submit
+  | { kind: 'prefill'; message: string };  // pre-fill prompt for editing, do NOT submit
 
 /** A registered slash command. */
 export interface SlashCommand {

--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -35,6 +35,13 @@ import type {
 } from './terminal-compositor.types.js';
 
 /**
+ * Max gap (ms) between the two Escapes of a double-Esc rewind trigger at an
+ * empty idle prompt. Short enough that a deliberate double-tap registers but a
+ * stray lone Esc followed much later by another does not.
+ */
+const DOUBLE_ESC_WINDOW_MS = 600;
+
+/**
  * Narrowest TerminalCompositor state slice the input-dispatch functions touch.
  * Buffer/flag/paste fields are mutated in place; `repaint`/`applyEdit`/
  * `updateAutocomplete`/`applyDropdownSelection`/`applyGhostAccept` are class
@@ -115,6 +122,8 @@ export interface KeyDispatchHost {
 
   /** Once-only soft-stop guard for ESC in streaming mode. */
   softStopped: boolean;
+  /** Timestamp (ms) of the last Esc at an empty idle prompt — double-tap detection. */
+  lastIdleEscAt: number;
   /**
    * Post-ESC coalesce epoch — armed at ESC soft-stop, held until the coalesced
    * redirect payload drains (authoritative field docs on the class in
@@ -136,6 +145,8 @@ export interface KeyDispatchHost {
   readonly onCancel?: () => void;
   readonly onSoftStop?: () => void;
   readonly onBackground?: () => void;
+  /** Double-Esc-at-empty-idle rewind handler — see {@link TerminalCompositor.onRewindRequest}. */
+  readonly onRewindRequest?: () => void;
   /** Submitted-line-during-pause handler — see {@link TerminalCompositorOptions.onPauseInterrupt}. */
   readonly onPauseInterrupt?: () => void;
   readonly onShiftTab?: () => void;
@@ -337,7 +348,28 @@ function handleEscape(self: KeyDispatchHost, key: KeyInfo): boolean {
     ac.candidates = [];
     self.repaint();
   }
-  if (self.inputMode === 'idle') return true;
+  if (self.inputMode === 'idle') {
+    // Idle ESC is normally a pure UI-dismissal no-op. Exception: a DOUBLE Esc
+    // at an EMPTY prompt opens the rewind picker ("edit a previous message").
+    // Detect the double-tap here; a lone Esc just arms the window. A non-empty
+    // draft disarms — ESC stays a no-op and leaves the typed text untouched
+    // (same "graceful stop preserves the draft" contract as streaming mode).
+    if (self.input.buffer.length === 0) {
+      const now = Date.now();
+      if (
+        self.lastIdleEscAt !== 0 &&
+        now - self.lastIdleEscAt <= DOUBLE_ESC_WINDOW_MS
+      ) {
+        self.lastIdleEscAt = 0;
+        if (self.onRewindRequest) self.onRewindRequest();
+      } else {
+        self.lastIdleEscAt = now;
+      }
+    } else {
+      self.lastIdleEscAt = 0;
+    }
+    return true;
+  }
   // Soft-stop: once-only per turn. Second ESC while streaming is
   // a no-op — the stream is already halting.
   if (self.softStopped) return true;

--- a/src/cli/terminal-compositor.rewind-esc.test.ts
+++ b/src/cli/terminal-compositor.rewind-esc.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the double-Esc rewind trigger in the compositor's idle-mode
+ * Escape handler (the "press Esc twice to edit a previous message" affordance).
+ *
+ * Contract:
+ *   - Two Escapes at an EMPTY idle prompt (within the double-tap window) fire
+ *     `onRewindRequest` exactly once.
+ *   - A single idle Esc only arms the window — no fire.
+ *   - Escapes with a non-empty draft never fire (and leave the draft alone).
+ *   - Streaming-mode Esc is unchanged (soft-stop, not rewind).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TerminalCompositor } from './terminal-compositor.js';
+import { __resetStdinClaimForTests } from './input/stdin-claim.js';
+import { makeMockStdout, makeMockStdin } from './terminal-compositor.test-helpers.js';
+import type { MockStdout, MockStdin } from './terminal-compositor.test-helpers.js';
+
+describe('TerminalCompositor — double-Esc rewind trigger', () => {
+  let stdout: MockStdout;
+  let stdin: MockStdin;
+
+  beforeEach(() => {
+    stdout = makeMockStdout();
+    stdin = makeMockStdin();
+    __resetStdinClaimForTests();
+  });
+
+  it('double-Esc at an empty idle prompt fires onRewindRequest once', async () => {
+    const onRewindRequest = vi.fn();
+    const c = new TerminalCompositor({ stdout, stdin });
+    await c.arm();
+    c.setInputMode('idle');
+    c.setOnRewindRequest(onRewindRequest);
+
+    stdin.emit('keypress', undefined, { name: 'escape' }); // arms
+    stdin.emit('keypress', undefined, { name: 'escape' }); // fires
+    expect(onRewindRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('a single idle Esc only arms — does not fire', async () => {
+    const onRewindRequest = vi.fn();
+    const c = new TerminalCompositor({ stdout, stdin });
+    await c.arm();
+    c.setInputMode('idle');
+    c.setOnRewindRequest(onRewindRequest);
+
+    stdin.emit('keypress', undefined, { name: 'escape' });
+    expect(onRewindRequest).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when the input buffer is non-empty', async () => {
+    const onRewindRequest = vi.fn();
+    const c = new TerminalCompositor({ stdout, stdin });
+    await c.arm();
+    c.setInputMode('idle');
+    c.setOnRewindRequest(onRewindRequest);
+
+    for (const ch of 'draft') stdin.emit('keypress', ch, { name: ch, sequence: ch });
+    stdin.emit('keypress', undefined, { name: 'escape' });
+    stdin.emit('keypress', undefined, { name: 'escape' });
+
+    expect(onRewindRequest).not.toHaveBeenCalled();
+    // The draft is untouched — idle Esc is a no-op for typed text.
+    expect(c.getBuffer().text).toBe('draft');
+  });
+
+  it('a third Esc after firing re-arms rather than double-firing', async () => {
+    const onRewindRequest = vi.fn();
+    const c = new TerminalCompositor({ stdout, stdin });
+    await c.arm();
+    c.setInputMode('idle');
+    c.setOnRewindRequest(onRewindRequest);
+
+    stdin.emit('keypress', undefined, { name: 'escape' }); // arm
+    stdin.emit('keypress', undefined, { name: 'escape' }); // fire (1)
+    stdin.emit('keypress', undefined, { name: 'escape' }); // re-arm (window reset)
+    expect(onRewindRequest).toHaveBeenCalledTimes(1);
+    stdin.emit('keypress', undefined, { name: 'escape' }); // fire (2)
+    expect(onRewindRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('streaming-mode Esc still soft-stops and never fires rewind', async () => {
+    const onRewindRequest = vi.fn();
+    const onSoftStop = vi.fn();
+    const c = new TerminalCompositor({ stdout, stdin, onSoftStop });
+    await c.arm();
+    c.setInputMode('streaming');
+    c.setOnRewindRequest(onRewindRequest);
+
+    stdin.emit('keypress', undefined, { name: 'escape' });
+    stdin.emit('keypress', undefined, { name: 'escape' });
+
+    expect(onSoftStop).toHaveBeenCalledTimes(1);
+    expect(onRewindRequest).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -108,6 +108,21 @@ export class TerminalCompositor {
   /** @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost). */
   onBackground?: () => void;
   /**
+   * Double-Esc-at-empty-idle handler — the "edit a previous message" rewind
+   * trigger. Fired by `handleEscape` when two Escapes land within
+   * {@link DOUBLE_ESC_WINDOW_MS} at an empty idle prompt. Wired via
+   * {@link setOnRewindRequest} at REPL arm time; the surface resolves the
+   * in-flight readLine with `/rewind`.
+   * @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost).
+   */
+  onRewindRequest?: () => void;
+  /**
+   * Timestamp (ms) of the last Escape at an empty idle prompt, for double-tap
+   * detection in `handleEscape`. 0 = disarmed.
+   * @internal Relaxed from `private` for the input-dispatch module (KeyDispatchHost).
+   */
+  lastIdleEscAt = 0;
+  /**
    * Per-turn pause-interrupt handler — see
    * {@link TerminalCompositorOptions.onPauseInterrupt}. Invoked when the user
    * submits a line while {@link paused} is true; ends the usage-limit wait so
@@ -660,6 +675,15 @@ export class TerminalCompositor {
   }
 
   /**
+   * Install or clear the double-Esc rewind handler (the "edit a previous
+   * message" trigger). Wired once by the persistent InputSurface at REPL arm
+   * time; fired from `handleEscape` on a double-Esc at an empty idle prompt.
+   */
+  setOnRewindRequest(handler: (() => void) | null): void {
+    this.onRewindRequest = handler ?? undefined;
+  }
+
+  /**
    * Install or clear the Shift+Tab handler — see
    * {@link TerminalCompositorOptions.onShiftTab}. The persistent
    * InputSurface typically installs this once at REPL start (the
@@ -1036,6 +1060,17 @@ export class TerminalCompositor {
    */
   applyEdit(next: InputCoreState): boolean {
     return InputDispatch.applyEdit(this, next);
+  }
+
+  /**
+   * Seed the editable input buffer with `text` (cursor at end), as if the
+   * user had typed it. Used by the rewind reload-for-edit path
+   * (`readLine({ initialBuffer })`) to load a discarded message back into the
+   * prompt. Routes through {@link applyEdit} so autocomplete/ghost/repaint
+   * refresh exactly like history recall (input-dispatch's `InputCore.seed`).
+   */
+  prefillInput(text: string): void {
+    this.applyEdit(InputCore.seed(text));
   }
 
   /**


### PR DESCRIPTION
## What

Feature parity with Claude Code's **"press Esc twice to edit a previous message."** At an empty idle prompt, a **double-Esc** (or the new **`/rewind`** command) opens an arrow-key picker of your earlier prompts. Choosing one rewinds the conversation to just before that message and reloads its text into the input — **editable** — to resend.

```
Esc Esc  (or /rewind)
  -> pick an earlier prompt   > second question
  -> conversation rewinds to that point
  -> its text loads into the prompt, editable -> Enter to resend
```

## Scope (and honest non-goals)

- **Conversation rewind only.** Claude Code couples a file-checkpoint "restore code" into the same menu; agent-afk has no working file-snapshot system (`rewindFiles` is stubbed `canRewind:false`), so that half is intentionally out of scope.
- **Provider:** fully implemented on **anthropic-direct** (the default). **openai-compatible** reports *not-supported* via the optional-method pattern (mirrors how `rewindFiles` already degrades). Its history is built per-turn from a different internal shape — parity is a clean follow-up.
- No "summarize from/up-to here" menu (Claude Code has it; `compact()` can back it later).

## Mechanism

An **`isIdle`-guarded in-place splice** of the provider's message array — the *same interlock `compact()` already uses*. Rewind only fires at the idle prompt and bails if a turn is in flight, so there's no race with an in-flight turn or auto-compaction, and no session-rebuild/banner cost (it feels seamless, not like `/clear`). `repairOrphanToolUses` runs on the new tail so a cut never strands a `tool_use` without its `tool_result` (Anthropic API contract).

> Design note: an earlier draft used a full session rebuild seeded with truncated history; rejected because `reset()` deliberately strips `resumeHistory` (a load-bearing `/clear` invariant) and would reset cost/turn counters + refire SessionStart. The guarded in-place splice is lighter and preserves session continuity.

## Changes

- **`provider.ts`** — optional `ProviderQuery.listRewindTargets()` / `rewindConversation(turnIndex)` + `RewindTarget` / `ProviderRewindConversationResult` types.
- **`anthropic-direct/query/rewind-conversation.ts`** *(new)* — pure enumerate (newest-first, `tool_result` turns excluded) + idle-guarded truncate helpers.
- **router / `IAgentSession` / `AgentSession`** — delegation with idle/closed guards and a `not-supported` fallback.
- **`/rewind` slash command** — `renderSelector` picker (compositor input suspended around it) -> `rewindConversation` -> `{ kind: 'prefill' }` reload result.
- **loop-iteration** — new `prefill` result threads `initialBuffer` into the next `readLine` (editable, **not** auto-submitted, unlike `seedBuffer`).
- **input-surface / terminal-compositor** — `initialBuffer` prefill on the compositor path + double-Esc detection at an empty idle prompt -> `onRewindRequest` -> resolves the pending `readLine` with `/rewind` (so the picker runs between turns, where selectors are safe).

## Testing

- **38 new tests**: pure rewind logic incl. the `tool_use`-boundary repair, guards, in-place identity; `/rewind` handler (picker / cancel / not-supported / prefill); double-Esc detection (arm / fire / draft-guard / streaming-unchanged); router delegation.
- Full suite green (**683 files, 12,615 passed**); `tsc --noEmit`, `audit:sdk:check`, `audit:env:check`, `scan:env:check` all pass.

## Try it

`afk i` -> type a couple of messages -> at the empty prompt press **Esc Esc** (or `/rewind`) -> pick a prior message -> edit -> Enter.
