### PR TITLE
fix(review): bound git-investigator to one batched pass per agent

### DIFF
--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -85,7 +85,14 @@ const PINNED_HASHES = {
   // ~/.afk/skills/ if it drifts back.
   refactor: '3adf801b9a61eba80afd34fef1e8c78a892ec07256dabb073370622a62d1b40f',
   research: 'abe79d75a5f3c74696ef002293dbe8714e446f8955de97089d1005f1e70bc269',
-  review: 'f313e3779af068a623692473abab2300938db8da3ebf3e2998d47fcb21ee9627',
+  // Hash bumped: added a "Bounded git access" directive to the citation block —
+  // re-read only file-state citations (skip diff-context), batch all re-reads into
+  // a single git-investigator dispatch, at most one per agent. Load-reduction
+  // mitigation for the review git-investigator fan-out (a FULL review ran ~43 min
+  // then 429'd with no output); citation integrity unchanged (Wave 1.5 backstop).
+  // BACK-PORT GAP: mirror this into the upstream example-plugin review SKILL.md
+  // (not co-located here, so the drift test skips) — see workflow above.
+  review: '6ae1d3b497101f4114cf149ec2645761d84cfc417c7eb4d583d4728121dacc5a',
   // Hash bumped 2026-06-09 (PR #52): records the confidence-trigger enhancement
   // landed in this branch's commit 1e35850 — adds high-confidence language
   // ("confident", "certain", "clearly", ≥80%) as a verification trigger in its

--- a/src/bundled-plugins/awa-bundled/skills/review/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/review/SKILL.md
@@ -55,6 +55,11 @@ Each agent receives: full diff + file tree + triage header + **reviewed ref (SHA
 2. Distinguish `diff-context` citations (line visible in the diff hunk, no re-read required) from `file-state` citations (line in the post-merge file, re-read required before quoting).
 3. If the line does not exist at that ref, omit the finding entirely — do not paraphrase or reconstruct from memory.
 
+**Bounded git access (per agent — overrides the general "multiple parallel queries" dispatch guidance for reviews).** Keep citation verification to one short pass:
+- Re-read **only** `file-state` citations at the reviewed ref. A `diff-context` citation is already grounded in the diff hunk — do **not** issue a git re-read for it.
+- Collect every needed re-read and resolve them in a **single** `git-investigator` dispatch (batch the queries). Never re-dispatch `git-investigator` per finding, and never run more than one `git-investigator` per agent.
+- This bounds a full review to one brief git pass per agent instead of an open-ended archaeology loop — the pattern that let a review balloon to tens of minutes and exhaust the API rate limit with no output.
+
 Banned words: "ensure", "consider", "may", "could". No `file:line` citation → omit the finding.
 
 **Spec-compliance assessment (mandatory framing for the spec-compliance dimension).** Judge the diff against the `stated-intent` — not against the diff's own apparent goals, and not against the repo's global constraints:


### PR DESCRIPTION
## What

Bounds the bundled `/review` skill's git-investigator usage to **one short batched pass per dimension agent**. Adds a "Bounded git access" directive to the citation-requirement block in `awa-bundled/skills/review/SKILL.md`:

- Re-read **only** `file-state` citations at the reviewed ref (a `diff-context` citation is already grounded in the diff hunk — no re-read).
- Collect all needed re-reads into a **single** `git-investigator` dispatch; never re-dispatch per finding, never more than one `git-investigator` per agent. Explicitly overrides the general "multiple parallel queries" guidance for the review use case.

Pinned hash in `bundled.test.ts` bumped accordingly (per the documented workflow).

## Why

A FULL review of a small PR was observed running ~43 min: 2 review dimension agents each dispatched a git-investigator that ran 52 / 23 git commands (each hit the 50-round `READONLY_AGENT_MAX_TOOL_USE_ITERATIONS` cap), and both dimensions then hit HTTP 429 on a single account and returned **zero** output.

**Scope (honest):** this is a **load-reduction mitigation** — fewer git-investigator dispatches + fewer `git show` re-reads per review lowers tokens/requests-per-review, so the rate-limit is far less likely to trigger. It does **not** fix the underlying *hang*, which is a throttled model call with no idle/progress watchdog (`SUBAGENT_DEFAULT_TIMEOUT_MS` is a blunt 45-min wall-clock; the progress-aware idle watchdog noted in `subagent.ts` is the real fix and is tracked separately). Citation integrity is preserved — verification still runs (Wave 1.5 remains the backstop); only redundant diff-context re-reads and iterative per-finding dispatches are removed.

## Test / risk

- `pnpm test src/bundled-plugins/awa-bundled/bundled.test.ts` → 17 passed, 12 skipped (drift-comparison tests skip when example-plugin isn't co-located).
- Prompt-only change to one SKILL.md + a pinned-hash bump. Read-only skill contract unchanged. Trivially revertible.

## Back-port gap

The same change should be mirrored into the upstream `example-plugin` review SKILL.md (not co-located in this checkout, so the drift test skips). Noted inline at the hash entry. A parallel private-plugin PR (awa-private#75) carries the equivalent edit.
