### PR TITLE
fix(worktree-sweep): count commits vs main HEAD when meta has no baseSha

### DIFF
--- a/src/agent/worktree-sweep.test.ts
+++ b/src/agent/worktree-sweep.test.ts
@@ -611,6 +611,110 @@ describe('base-sha-fallback', () => {
     const verdict = result.candidates[0]?.verdict;
     expect(['empty', 'stale-clean', 'stale-dirty', 'active', 'locked']).toContain(verdict);
   });
+
+  it('preserves a baseSha-less worktree that holds unmerged commits (counts against main HEAD, not self)', async () => {
+    // Regression guard: a meta with no `baseSha` (exactly what
+    // touchWorktreeOccupancy writes when it adopts a hand-created
+    // `git worktree add` tree) must NOT self-compare its HEAD to itself —
+    // that always yields 0 commits ahead and makes a tree holding real
+    // unmerged work look `empty`, force-removing the checkout.
+    const worktreePath = join(afkWorktreesDir, 'afk-nobase-ahead');
+    await fs.mkdir(worktreePath, { recursive: true });
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({
+        owner: 'agent',
+        createdAt: new Date(Date.now() - 2 * 3_600_000).toISOString(), // 2h old
+      }),
+    );
+
+    const mainBlock = worktreeBlock({ path: repoRoot, head: 'mainsha111' });
+    const wtBlock = worktreeBlock({
+      path: worktreePath,
+      head: 'wtsha222', // differs from main HEAD
+      branch: 'refs/heads/afk/nobase-ahead',
+    });
+    const porcelainOut = `${mainBlock}\n\n${wtBlock}\n`;
+
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: porcelainOut, stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' }; // clean
+      }
+      if (args.includes('rev-list') && args.includes('--count')) {
+        // The fix counts commits reachable from the worktree HEAD but NOT from
+        // main (`--not`). The old self-comparing fallback (base === head) would
+        // instead resolve to 0 here and misclassify the tree as empty.
+        return args.includes('--not')
+          ? { stdout: '2\n', stderr: '' }
+          : { stdout: '0\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+    });
+
+    const verdict = result.candidates.find((c) => c.path === worktreePath)?.verdict;
+    expect(verdict).not.toBe('empty');
+    expect(verdict).not.toBe('dead-owner');
+    expect(result.removed).not.toContain(worktreePath);
+  });
+
+  it('still reaps a baseSha-less worktree with no commits (sitting at main HEAD)', async () => {
+    // Complement of the previous test: the fallback must not over-preserve.
+    // A baseSha-less tree that sits at main's HEAD is genuinely empty and
+    // remains reapable.
+    const worktreePath = join(afkWorktreesDir, 'afk-nobase-empty');
+    await fs.mkdir(worktreePath, { recursive: true });
+    await fs.writeFile(
+      join(worktreePath, '.afk-worktree-meta.json'),
+      JSON.stringify({
+        owner: 'agent',
+        createdAt: new Date(Date.now() - 2 * 3_600_000).toISOString(), // 2h old
+      }),
+    );
+
+    const mainBlock = worktreeBlock({ path: repoRoot, head: 'samesha000' });
+    const wtBlock = worktreeBlock({
+      path: worktreePath,
+      head: 'samesha000', // identical to main HEAD → nothing ahead
+      branch: 'refs/heads/afk/nobase-empty',
+    });
+    const porcelainOut = `${mainBlock}\n\n${wtBlock}\n`;
+
+    const mock = makeMock(async ({ args }) => {
+      if (args.includes('list') && args.includes('--porcelain')) {
+        return { stdout: porcelainOut, stderr: '' };
+      }
+      if (args.includes('status') && args.includes('--porcelain')) {
+        return { stdout: '', stderr: '' }; // clean
+      }
+      if (args.includes('rev-list') && args.includes('--count')) {
+        return { stdout: '0\n', stderr: '' };
+      }
+      return { stdout: '', stderr: '' };
+    });
+
+    const result = await runSweep({
+      execFile: mock as ExecFileFn,
+      repoRoot,
+      lockPath: lockFile,
+      dryRun: false,
+      telemetryPath: telemetryFile,
+    });
+
+    const verdict = result.candidates.find((c) => c.path === worktreePath)?.verdict;
+    expect(verdict).toBe('empty');
+    expect(result.removed).toContain(worktreePath);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/agent/worktree-sweep.ts
+++ b/src/agent/worktree-sweep.ts
@@ -521,6 +521,9 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
     // Process registered worktrees (skip main/bare)
     let hasOrphanedRegistrations = false;
     const mainPath = parsed[0]?.path;
+    // The main worktree's HEAD is the fallback base for the commits-ahead
+    // count when a candidate's meta has no recorded `baseSha` (see below).
+    const mainHead = parsed[0]?.head;
 
     for (const entry of parsed) {
       // Skip main worktree and bare repos
@@ -576,10 +579,34 @@ export async function runSweep(options: SweepOptions): Promise<SweepResult> {
       } catch { isDirty = true; /* treat as dirty — safe fallback */ }
 
       if (!isDirty && entry.head) {
-        const baseSha = meta?.baseSha ?? entry.head;
+        // Contract: `commitsAhead > 0` marks a worktree as holding unmerged
+        // committed work, which the classifier preserves (`stale-clean`) and
+        // never reaps. Getting this count right is load-bearing for not
+        // destroying work.
+        //
+        // Invariant: when meta has NO `baseSha`, we must NOT fall back to
+        // `entry.head` as the base. `rev-list HEAD..HEAD` is always 0, so a
+        // baseSha-less worktree that actually holds commits would look empty
+        // and be force-removed by the `empty`/`dead-owner` verdicts. Meta is
+        // absent/minimal exactly for hand-created `git worktree add` trees
+        // adopted by touchWorktreeOccupancy (which writes `{owner:'agent'}`
+        // with no baseSha). Fall back to the main worktree's HEAD and count
+        // commits reachable from this tree but not from main — the true
+        // "unmerged work" signal.
         try {
-          const countResult = await execFile('git', ['-C', repoRoot, 'rev-list', `${baseSha}..${entry.head}`, '--count']);
-          commitsAhead = parseInt(countResult.stdout.trim(), 10) || 0;
+          const revListArgs =
+            meta?.baseSha !== undefined
+              ? ['-C', repoRoot, 'rev-list', `${meta.baseSha}..${entry.head}`, '--count']
+              : mainHead !== undefined && mainHead !== entry.head
+                ? ['-C', repoRoot, 'rev-list', entry.head, '--not', mainHead, '--count']
+                : undefined;
+          // `revListArgs === undefined` means no recorded base AND the tree
+          // sits at the main worktree's commit (or main HEAD is unknown) —
+          // genuinely nothing ahead, so leave commitsAhead at 0.
+          if (revListArgs !== undefined) {
+            const countResult = await execFile('git', revListArgs);
+            commitsAhead = parseInt(countResult.stdout.trim(), 10) || 0;
+          }
         } catch { commitsAhead = 0; }
       }
 


### PR DESCRIPTION
## What

When a worktree's `.afk-worktree-meta.json` has **no `baseSha`**, the sweep engine computed commits-ahead as:

```ts
const baseSha = meta?.baseSha ?? entry.head;
rev-list `${baseSha}..${entry.head}` --count   // → HEAD..HEAD → always 0
```

Self-comparing `HEAD..HEAD` is **always 0**, so a baseSha-less worktree that actually holds unmerged commits is scored `commitsAhead === 0` → classified `empty` (or `dead-owner`) → its **checkout is force-removed**. The branch ref survives, but the checkout (and any gitignored setup like `node_modules`) is destroyed — i.e. an in-use worktree gets reaped.

Meta is absent/minimal precisely for **hand-created `git worktree add` trees** later adopted by `touchWorktreeOccupancy`, which writes `{ owner: 'agent' }` with no `baseSha`. That's the exact shape the documented crash-recovery workflow produces when resuming a swept branch.

## Fix

When `meta.baseSha` is undefined, fall back to the **main worktree's HEAD** and count commits reachable from the candidate but not from main:

```ts
rev-list <entry.head> --not <mainHead> --count   // true unmerged-work signal
```

- Worktrees that **do** record a `baseSha` are unchanged (same `baseSha..head` count).
- A baseSha-less tree that sits **at main's HEAD** is still `0`-ahead and remains reapable — no over-preservation.

Net effect: the sweep stops misclassifying baseSha-less worktrees that hold real work as `empty`. Strictly more conservative (only ever *preserves* more); no worktree that was correctly reaped before is preserved now.

## Tests

Two cases added to the `base-sha-fallback` suite in `worktree-sweep.test.ts`:
1. baseSha-less tree with unmerged commits → **not** `empty`/`dead-owner`, **not** removed (fails without the fix — the self-compare path returns 0).
2. baseSha-less tree at main HEAD → still `empty`, still removed (guards against over-preserving).

## Gates
- `pnpm test src/agent/worktree-sweep.test.ts` → 33/33
- `pnpm lint` (tsc --noEmit strict) → clean
- adjacent suites (boot-prune, scheduler, worktree-managed, worktree) → 78/78

## Context / scope (why this specific change)

This is the one *pure-win* fix that came out of a root-cause investigation into "active worktrees keep getting reaped." The broader findings, for reviewer context:

- The sweep is otherwise **well-targeted**: it only reaps worktrees with **no commits and no dirty files**. Committed work (`stale-clean`) and uncommitted work (`stale-dirty`) are always preserved. This baseSha bug was the sole path by which committed work could be misread as empty.
- **Deliberately NOT changed:** the `dead-owner` verdict's lack of an age gate. That is intentional (#380, and asserted by an existing test) — it fast-reaps genuinely-empty ghost worktrees, which is low-harm (nothing committed/dirty is lost). Gating it would revert that decision, so it's left alone.
- The historical mid-session reaping of top-level `afk -w` worktrees was closed earlier by presence-cwd tracking + the `empty` liveness gate; not touched here.

### Out of scope (flagged, not fixed here)
- **Worktree sprawl** (e.g. 27 worktrees / 6.1 GB in one checkout) is *preserved committed-but-unmerged work* the auto-sweep correctly won't touch — it needs explicit `worktree` prune/remove, not the auto-sweep.
- The **daemon cron sweep is unconfigured** on at least one machine (runs from a non-repo cwd; `AFK_WORKTREE_SWEEP_ROOT` unset), so it has never actually run there. That's an ops/config item, not a code change.
