### PR TITLE
feat(agents): bound general-purpose subagent with a generous tool-use ceiling

### DIFF
--- a/src/agent/agents/builtins.ts
+++ b/src/agent/agents/builtins.ts
@@ -57,8 +57,7 @@ Reply compactly: the answer first, then evidence as file:line citations, then op
  * resolves a named dispatch's `maxToolUseIterations` to 0 (no cap) when neither
  * the call-site nor the definition sets one, deliberately bypassing
  * SubagentManager's `SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS` (50) — which only
- * guards internal skill/compose forks. Unbounded is defensible for a real
- * multi-step worker (`general-purpose`), but a READ-ONLY research/review agent
+ * guards internal skill/compose forks. A READ-ONLY research/review agent
  * never legitimately needs many rounds; without a bound it can loop on a hard
  * task until an external cutoff aborts it mid-loop, surfacing as an opaque
  * failure. Bounding it routes a runaway through the graceful capped-partial
@@ -67,6 +66,25 @@ Reply compactly: the answer first, then evidence as file:line citations, then op
  * graph — same rationale as the KNOWN_AFK_TOOL_NAMES dup in resolve.ts.
  */
 const READONLY_AGENT_MAX_TOOL_USE_ITERATIONS = 50;
+
+/**
+ * Anti-runaway ceiling for the inherit-all worker (`general-purpose`).
+ *
+ * general-purpose does exploration AND action across many dependent steps, so
+ * it legitimately needs more rounds than a read-only leaf — it was previously
+ * left UNCAPPED on the (uncapped-by-default) agent-tool dispatch path. But
+ * "uncapped" means a busy, non-converging worker (one that keeps tool-calling
+ * without making progress) has no bound short of the 45-min wall-clock and
+ * dies opaquely there. This generous ceiling (3× the read-only cap) bounds
+ * such a runaway through the SAME graceful capped-partial wind-down, while
+ * staying well above any legitimate multi-step dispatch's round count so real
+ * work is never cut off. A caller with a genuinely longer task opts out
+ * per-dispatch via an explicit `max_tool_use_iterations` (including `0` =
+ * uncapped) — see `child-config.ts`. The cap is PER-TURN, so a single-shot
+ * fork gets one budget for its whole task, which is why it is deliberately
+ * generous rather than matching the read-only 50.
+ */
+const GENERAL_PURPOSE_MAX_TOOL_USE_ITERATIONS = 150;
 
 /**
  * Build the built-in agents, keyed by name.
@@ -134,6 +152,12 @@ export function builtinAgents(): Map<string, RegisteredAgent> {
           'multiple dependent steps, not just research.',
         prompt: GENERAL_PURPOSE_PROMPT,
         // No `tools` — inherit-all (Claude Code parity for general-purpose).
+        // Generous anti-runaway ceiling (see GENERAL_PURPOSE_MAX_TOOL_USE_ITERATIONS):
+        // bounds a busy, non-converging worker to a graceful capped-partial
+        // wind-down instead of the 45-min wall-clock, without cutting legit
+        // multi-step work. Opt out per-dispatch with an explicit
+        // max_tool_use_iterations (`0` = uncapped).
+        maxToolUseIterations: GENERAL_PURPOSE_MAX_TOOL_USE_ITERATIONS,
       },
     },
     {

--- a/src/agent/agents/registry.test.ts
+++ b/src/agent/agents/registry.test.ts
@@ -62,18 +62,23 @@ describe('loadAgentRegistry', () => {
     // git-investigator is a read-only git-archaeology leaf (dispatched by
     // research-agent) and must carry the same cap.
     expect(registry.get('git-investigator')?.definition.maxToolUseIterations).toBe(50);
-    // general-purpose stays UNBOUNDED — a real multi-step worker legitimately
-    // needs an uncapped loop, so it must NOT gain the read-only bound.
-    expect(registry.get('general-purpose')?.definition.maxToolUseIterations).toBeUndefined();
+    // general-purpose now carries a GENEROUS ceiling (not the read-only 50): a
+    // full-tool multi-step worker needs headroom, but leaving it "uncapped" let
+    // a busy, non-converging worker run to the 45-min wall-clock. 150 bounds a
+    // runaway to the graceful capped-partial wind-down while clearing legit
+    // multi-step work; opt out per-dispatch via explicit max_tool_use_iterations.
+    expect(registry.get('general-purpose')?.definition.maxToolUseIterations).toBe(150);
   });
 
   // Drift-catcher: iterate the BUILTIN registry (not the vendored consts) so a
-  // newly-added read-only builtin that forgets the anti-runaway cap fails here.
-  // Structural predicate (no hardcoded per-agent list): a builtin with an
-  // explicit `tools` allowlist is a restricted/read-only leaf and MUST carry
-  // maxToolUseIterations; a builtin that OMITS `tools` (inherit-all, the full
-  // tool surface — only general-purpose today) is the uncapped exemption.
-  it('every read-only builtin (explicit tools) carries the anti-runaway cap; inherit-all exempt', () => {
+  // newly-added builtin that forgets its anti-runaway cap fails here.
+  // Structural predicate (no hardcoded per-agent list): EVERY builtin must be
+  // bounded — a builtin with an explicit `tools` allowlist is a
+  // restricted/read-only leaf capped at 50; a builtin that OMITS `tools`
+  // (inherit-all, the full tool surface — only general-purpose today) is the
+  // multi-step worker, capped at the generous worker ceiling (150), never
+  // uncapped.
+  it('every builtin is bounded: read-only leaves cap at 50, the inherit-all worker at the generous ceiling', () => {
     const builtins = builtinAgents();
     // Guard the guard: ensure we actually iterated real builtins and covered
     // BOTH arms (at least one capped read-only leaf and the inherit-all worker),
@@ -92,8 +97,8 @@ describe('loadAgentRegistry', () => {
         sawInheritAll = true;
         expect(
           entry.definition.maxToolUseIterations,
-          `inherit-all builtin ${name} must stay uncapped (full tool surface)`,
-        ).toBeUndefined();
+          `inherit-all builtin ${name} must carry the generous worker ceiling (never uncapped)`,
+        ).toBe(150);
       }
     }
     expect(sawRestricted, 'expected ≥1 restricted read-only builtin').toBe(true);


### PR DESCRIPTION
## What

Gives the `general-purpose` builtin subagent a **generous tool-use round ceiling** (`GENERAL_PURPOSE_MAX_TOOL_USE_ITERATIONS = 150`, 3× the read-only cap). It was the only builtin left **uncapped** on the `agent`-tool dispatch path — the read-only agents (`research-agent`, `git-investigator`, `Explore`) each carry `READONLY_AGENT_MAX_TOOL_USE_ITERATIONS = 50`, but `general-purpose` had none.

- Overridable per-dispatch via an explicit `max_tool_use_iterations` (`0` = uncapped) — precedence unchanged (`child-config.ts`: explicit call-site > agent definition > default 0).
- Replaces the `inherit-all ⇒ uncapped` exemption (the actual hole) with `inherit-all ⇒ generous ceiling` in the registry drift-catcher test.

## Why

A busy, **non-converging** `general-purpose` fork — one that keeps issuing tool calls without making progress (fix→test→fix, search fan-out, retry-under-throttle) — had no bound short of the 45-min wall-clock (`SUBAGENT_DEFAULT_TIMEOUT_MS`) and died opaquely there. Round caps bound *work done*; this is the missing bound for the write-capable worker that can do the most damage in a loop.

This is the **"trapped" (activity-without-progress)** half of the subagent-hang class. It complements the idle watchdog (#672), which catches the **"silent"** half (no output for N minutes) — a watchdog resets on every `OutputEvent`, so a busy loop never trips it; only a round budget catches it.

150 is deliberately generous: the boundary check found **no bundled caller** dispatches `general-purpose` for more than a handful of rounds today, and a capped result is a **graceful capped-partial wind-down** (status `succeeded` with `partialOutput`, via the existing `tool_use_loop_capped` path), not a hard failure. The cap is per-turn, so a single-shot fork gets one budget for its whole task — hence generous, not the read-only 50.

## Scope (what this deliberately is *not*)

This is the minimal mechanical floor. It is **not** an aborting runtime loop-detector — that was proposed and **rejected** in a devils-advocate wave because (a) it would not have fired on the one documented trap (the `/review` per-citation `git show` fan has *distinct* args each call, not a recurring fingerprint), and (b) a normalized-arg fingerprint that aborts is mis-tunable, gameable, and adds stateful logic to the hot dispatch path with false-positive risk on legitimate build→test→fix / paginated-search cycles.

Tracked follow-ups (not in this PR): observe-only `suspected_loop` telemetry to gather real data before ever enforcing a loop-detector; and a skill/prompt-layer **convergence criterion** (agent self-reports "no progress in K rounds → stop, return partial") that addresses the root cause a blunt cap only approximates.

## Test / verification

- `pnpm lint` (tsc --noEmit, strict) — PASS
- `pnpm test src/agent/agents/registry.test.ts` — 17 passed (updated: the two assertions that pinned `general-purpose` as uncapped now assert the 150 ceiling; the structural drift-catcher now requires **every** builtin to be bounded — read-only leaves at 50, the inherit-all worker at the generous ceiling — removing the uncapped-exemption footgun).
- **Full `pnpm test` — 12718 passed / 14 skipped / 0 failed (689 files).** Behavioral change to every `general-purpose` fork; no regression (no skill/compose test depends on it being uncapped).

Additive, backward-compatible (opt-out via `max_tool_use_iterations`), no migration. Two files: `src/agent/agents/builtins.ts` + `registry.test.ts`.
