### PR TITLE
feat(trace): observe-only suspected_loop telemetry for forked subagents

### DIFF
--- a/src/agent/tools/dispatcher.test.ts
+++ b/src/agent/tools/dispatcher.test.ts
@@ -1439,6 +1439,50 @@ describe('SessionToolDispatcher — repeat-loop circuit breaker', () => {
   });
 });
 
+describe('SessionToolDispatcher — suspected-loop telemetry coexists with the repeat breaker (OBSERVE-ONLY)', () => {
+  // The observe-only suspected_loop signal shares the sequential pre-execution
+  // path with the repeat circuit breaker. These tests lock in that (a) it does
+  // NOT perturb the top-level session (which is out of its forked-only scope),
+  // and (b) it emits — without ever changing a result — for a forked child.
+
+  it('top-level session: no suspected_loop event and repeat-breaker behavior is unchanged', async () => {
+    const writer = new InMemoryTraceWriter();
+    // makeDispatcher() sets no parentSessionId → a top-level session.
+    const dispatcher = makeDispatcher({ traceWriter: writer });
+    for (let i = 0; i < REPEAT_CIRCUIT_BREAKER_THRESHOLD - 1; i++) {
+      expect((await dispatcher.execute(makeCall())).isError).toBeUndefined();
+    }
+    // The repeat breaker still trips at its threshold, exactly as before.
+    const tripped = await dispatcher.execute(makeCall());
+    expect(tripped.isError).toBe(true);
+    expect(tripped.circuitBreaker).toBe(true);
+    // And no observe-only loop signal is emitted for a top-level session.
+    const loopEvents = writer.events.filter(
+      (e) => e.kind === 'session_phase' && e.payload.phase === 'suspected_loop',
+    );
+    expect(loopEvents).toHaveLength(0);
+  });
+
+  it('forked child: emits suspected_loop but returns the normal tool result', async () => {
+    const writer = new InMemoryTraceWriter();
+    const dispatcher = makeDispatcher({ parentSessionId: 'parent-1', traceWriter: writer });
+    let last;
+    // Below the repeat-breaker threshold (8) so the calls actually run; the
+    // suspected-loop threshold (5) is crossed first, purely as telemetry.
+    for (let i = 0; i < 5; i++) {
+      last = await dispatcher.execute(makeCall());
+    }
+    // OBSERVE-ONLY: the result is the real handler output — no error/breaker flag.
+    expect(last?.isError).toBeUndefined();
+    expect(last?.content).toBe('hello');
+    expect(last?.circuitBreaker).toBeUndefined();
+    const loopEvents = writer.events.filter(
+      (e) => e.kind === 'session_phase' && e.payload.phase === 'suspected_loop',
+    );
+    expect(loopEvents).toHaveLength(1);
+  });
+});
+
 describe('SessionToolDispatcher — canUseTool (Dim 8 in-process permission policy)', () => {
   const allowAll: CanUseTool = async () => ({ behavior: 'allow' });
 

--- a/src/agent/tools/dispatcher.ts
+++ b/src/agent/tools/dispatcher.ts
@@ -28,7 +28,7 @@ import { classifyBashCommand } from './readonly-bash.js';
 import { headAndTail } from './handlers/_output-cap.js';
 import { PathGrantManager, type GrantSnapshot } from './grant-manager.js';
 import type { GrantManager } from '../../cli/slash/commands/allow-dir.js';
-import { emitHookDecision } from '../trace/emit.js';
+import { emitHookDecision, emitSessionPhase } from '../trace/emit.js';
 import type { TraceWriter } from '../trace/index.js';
 import { defaultConcurrencyClassifier, partitionIntoBatches } from './dispatch-batching.js';
 import { repeatCallFingerprint } from './repeat-circuit-breaker.js';
@@ -40,6 +40,13 @@ import {
   extractDeniedReadPath,
   buildDenialBreakerMessage,
 } from './denial-circuit-breaker.js';
+import {
+  createSuspectedLoopWindow,
+  fingerprintToolCall,
+  observeToolCall,
+  SUSPECTED_LOOP_WINDOW_SIZE,
+  type SuspectedLoopWindow,
+} from './suspected-loop-detector.js';
 
 // Re-exported for backward compatibility: external importers (dispatcher.test.ts,
 // schema-classification.test.ts) historically import this from './dispatcher.js'.
@@ -271,6 +278,21 @@ export class SessionToolDispatcher implements ToolDispatcher {
    * has been seen since the last success. See {@link recordForkReadDenial}.
    */
   private denialBreaker: { count: number; deniedPaths: string[] } | null = null;
+
+  /**
+   * OBSERVE-ONLY suspected-loop telemetry window (see
+   * {@link import('./suspected-loop-detector.js')}). Per-dispatcher (one per
+   * forked `query()`), so it tracks the last {@link SUSPECTED_LOOP_WINDOW_SIZE}
+   * tool-call fingerprints within a single turn and resets between turns via
+   * dispatcher reconstruction — exactly like the two breakers above.
+   *
+   * Lazily created on the first FORKED tool call (see
+   * {@link observeSuspectedLoop}); stays `null` for top-level sessions, which are
+   * never observed. Its ONLY effect is emitting a `suspected_loop` session-phase
+   * event on first detection — it NEVER aborts, sets a failureClass, or alters a
+   * result. This is pure data-gathering, not enforcement.
+   */
+  private suspectedLoopWindow: SuspectedLoopWindow | null = null;
 
   /**
    * Shared grant-state machine (issues #361/#362). The hooks bind the
@@ -568,6 +590,53 @@ export class SessionToolDispatcher implements ToolDispatcher {
   }
 
   /**
+   * OBSERVE-ONLY suspected-loop telemetry (see
+   * {@link import('./suspected-loop-detector.js')}). Pushes this call's
+   * normalized fingerprint into the per-dispatcher sliding window and, on the
+   * FIRST time a fingerprint recurs past the threshold within the window,
+   * fire-and-forgets a `suspected_loop` session-phase event carrying
+   * `{ tool, count, windowSize }`.
+   *
+   * CRITICAL INVARIANT — this method has NO effect on dispatch. It returns
+   * `void`, never a `ToolResult`; it never aborts, never sets a `failureClass`,
+   * never mutates or delays the tool result, and never changes control flow.
+   * The trace write is `void`-ed (fire-and-forget) so a slow witness write can
+   * never delay a tool call. It exists purely to gather data on whether real
+   * (tool, args) busy-loops occur in forked sub-agents.
+   *
+   * Scope: FORKED children only (`parentSessionId` set), mirroring the denial
+   * breaker — interactive sessions, where the operator drives repetition, are
+   * never observed and the window stays `null`.
+   *
+   * Placement: called once per tool call on the sequential pre-execution path
+   * (execute() step 2d and executeBatch() phase 1), AFTER the repeat breaker —
+   * so a call the repeat breaker already short-circuited is not double-counted
+   * here, and the fingerprint order reflects real call order. Because it is
+   * observe-only, it does not matter whether the underlying call later succeeds
+   * or errors; we are measuring the REPETITION, not the outcome.
+   */
+  private observeSuspectedLoop(call: ToolCall): void {
+    // Top-level sessions are out of scope: never observed, no window allocated.
+    if (this.parentSessionId === undefined) return;
+    if (this.suspectedLoopWindow === null) {
+      this.suspectedLoopWindow = createSuspectedLoopWindow();
+    }
+    const fingerprint = fingerprintToolCall(call);
+    const observation = observeToolCall(this.suspectedLoopWindow, fingerprint);
+    if (!observation.fired) return;
+    // Fire-and-forget: emission must never delay or perturb dispatch, and
+    // emitSessionPhase already swallows writer errors internally.
+    void emitSessionPhase(this.traceWriter, {
+      phase: 'suspected_loop',
+      metadata: {
+        tool: call.name,
+        count: observation.count,
+        windowSize: SUSPECTED_LOOP_WINDOW_SIZE,
+      },
+    });
+  }
+
+  /**
    * Denial circuit breaker (#546). Called from the `HookBlockedError` catch with
    * the block `reason` and the just-built `hook-block` result. Counts the denial
    * ONLY when ALL of:
@@ -746,6 +815,13 @@ export class SessionToolDispatcher implements ToolDispatcher {
     const repeatBlock = this.checkRepeatCircuitBreaker(call);
     if (repeatBlock) return repeatBlock;
 
+    // 2d. OBSERVE-ONLY suspected-loop telemetry (forked children only). Records
+    // the fingerprint and emits a `suspected_loop` trace signal on first
+    // recurrence past threshold. Pure observability — never blocks, never
+    // alters the result, never changes control flow. Runs after the repeat
+    // breaker so a short-circuited call is not counted twice.
+    this.observeSuspectedLoop(call);
+
     // 3. Agent routing + handler dispatch + PostToolUse. Delegates to
     // executeCore() — the shared core executeBatch() already calls per-tool
     // (see lines ~936/972). execute() previously inlined a verbatim copy of
@@ -859,6 +935,14 @@ export class SessionToolDispatcher implements ToolDispatcher {
         blocked.add(i);
         continue;
       }
+
+      // OBSERVE-ONLY suspected-loop telemetry (forked children only). Same
+      // placement as execute() step 2d — after the repeat breaker, on the
+      // sequential phase-1 path so the fingerprint window sees every
+      // non-short-circuited call in real order. Never blocks: it does not set
+      // `results[i]`, add to `blocked`, or `continue`; the call proceeds to
+      // phase-2 execution exactly as before.
+      this.observeSuspectedLoop(call);
     }
 
     // Phase 2: partition non-blocked calls into batches and execute.

--- a/src/agent/tools/suspected-loop-detector.test.ts
+++ b/src/agent/tools/suspected-loop-detector.test.ts
@@ -1,0 +1,352 @@
+import { describe, expect, it } from 'vitest';
+import { SessionToolDispatcher } from './dispatcher.js';
+import { builtinToolSchemas } from './schemas.js';
+import type { ToolCall, ToolHandler } from './types.js';
+import { InMemoryTraceWriter } from '../trace/writer.js';
+import type { TraceEvent } from '../trace/types.js';
+import {
+  SUSPECTED_LOOP_THRESHOLD,
+  SUSPECTED_LOOP_WINDOW_SIZE,
+  createSuspectedLoopWindow,
+  fingerprintToolCall,
+  countInWindow,
+  observeToolCall,
+} from './suspected-loop-detector.js';
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+function call(name: string, input: unknown): ToolCall {
+  return { id: `${name}-1`, name, input, signal: new AbortController().signal };
+}
+
+describe('suspected-loop-detector pure helpers', () => {
+  it('thresholds are small fixed positive constants, window >= threshold', () => {
+    expect(SUSPECTED_LOOP_THRESHOLD).toBe(5);
+    expect(SUSPECTED_LOOP_WINDOW_SIZE).toBe(20);
+    // The predicate can only ever fire when the window can hold `threshold` hits.
+    expect(SUSPECTED_LOOP_WINDOW_SIZE).toBeGreaterThanOrEqual(SUSPECTED_LOOP_THRESHOLD);
+  });
+
+  it('fingerprintToolCall is a stable 64-hex sha256 and identical calls collide', () => {
+    const a = fingerprintToolCall(call('read_file', { file_path: '/a.ts' }));
+    const b = fingerprintToolCall(call('read_file', { file_path: '/a.ts' }));
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+    expect(a).toBe(b);
+  });
+
+  it('different tool names or args yield different fingerprints', () => {
+    const base = fingerprintToolCall(call('read_file', { file_path: '/a.ts' }));
+    expect(fingerprintToolCall(call('grep', { file_path: '/a.ts' }))).not.toBe(base);
+    expect(fingerprintToolCall(call('read_file', { file_path: '/b.ts' }))).not.toBe(base);
+  });
+
+  it('normalizes object key ORDER so semantically-identical calls collide', () => {
+    // The whole point of a telemetry fingerprint: the SAME logical call recurs
+    // regardless of incidental key serialization order.
+    const one = fingerprintToolCall(call('grep', { pattern: 'x', path: '/p' }));
+    const two = fingerprintToolCall(call('grep', { path: '/p', pattern: 'x' }));
+    expect(one).toBe(two);
+  });
+
+  it('normalizes NESTED object key order too, but preserves array order', () => {
+    const one = fingerprintToolCall(call('t', { a: { x: 1, y: 2 }, list: [1, 2] }));
+    const two = fingerprintToolCall(call('t', { a: { y: 2, x: 1 }, list: [1, 2] }));
+    expect(one).toBe(two);
+    // Array order is semantic → different order is a different fingerprint.
+    const three = fingerprintToolCall(call('t', { a: { x: 1, y: 2 }, list: [2, 1] }));
+    expect(three).not.toBe(one);
+  });
+
+  it('does not throw on odd inputs (observe-only must never perturb dispatch)', () => {
+    expect(() => fingerprintToolCall(call('t', undefined))).not.toThrow();
+    expect(() => fingerprintToolCall(call('t', null))).not.toThrow();
+    expect(() => fingerprintToolCall(call('t', 42))).not.toThrow();
+  });
+
+  it('countInWindow counts occurrences of a fingerprint', () => {
+    expect(countInWindow(['a', 'b', 'a', 'a'], 'a')).toBe(3);
+    expect(countInWindow(['a', 'b'], 'z')).toBe(0);
+    expect(countInWindow([], 'a')).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// observeToolCall — window mutation, threshold, debounce
+// ---------------------------------------------------------------------------
+
+describe('observeToolCall (pure window rule)', () => {
+  it('fires exactly once, on the round the count first reaches threshold', () => {
+    const w = createSuspectedLoopWindow();
+    const fp = 'deadbeef';
+    for (let i = 1; i < SUSPECTED_LOOP_THRESHOLD; i++) {
+      const obs = observeToolCall(w, fp);
+      expect(obs.fired).toBe(false);
+      expect(obs.count).toBe(i);
+    }
+    // Threshold-th occurrence: first (and only) fire.
+    const trip = observeToolCall(w, fp);
+    expect(trip.fired).toBe(true);
+    expect(trip.count).toBe(SUSPECTED_LOOP_THRESHOLD);
+  });
+
+  it('debounces: never fires again for the same fingerprint in the same window', () => {
+    const w = createSuspectedLoopWindow();
+    const fp = 'cafef00d';
+    for (let i = 0; i < SUSPECTED_LOOP_THRESHOLD; i++) observeToolCall(w, fp);
+    // Many more recurrences past the threshold — all silent.
+    for (let i = 0; i < SUSPECTED_LOOP_WINDOW_SIZE * 2; i++) {
+      expect(observeToolCall(w, fp).fired).toBe(false);
+    }
+  });
+
+  it('detects an INTERLEAVED loop the consecutive repeat breaker would miss', () => {
+    // A B A C A D A E A pattern: `A` recurs 5× within the window while never
+    // appearing consecutively. This is precisely the gap this signal fills.
+    const w = createSuspectedLoopWindow();
+    const others = ['B', 'C', 'D', 'E'];
+    let fired = false;
+    // A once up front, then (other, A) pairs. A hits its 5th occurrence on the
+    // 4th pair.
+    observeToolCall(w, 'A');
+    for (let i = 0; i < others.length; i++) {
+      observeToolCall(w, others[i]!);
+      const obs = observeToolCall(w, 'A');
+      if (obs.fired) {
+        fired = true;
+        expect(obs.count).toBe(SUSPECTED_LOOP_THRESHOLD);
+      }
+    }
+    expect(fired).toBe(true);
+  });
+
+  it('does NOT fire when a fingerprint ages out of the sliding window', () => {
+    // Space `A` occurrences more than `window` apart with filler so no window
+    // ever holds `threshold` copies at once.
+    const w = createSuspectedLoopWindow();
+    let everFired = false;
+    for (let round = 0; round < SUSPECTED_LOOP_THRESHOLD; round++) {
+      if (observeToolCall(w, 'A').fired) everFired = true;
+      // Flood the window with unique fillers to evict the A before the next A.
+      for (let f = 0; f < SUSPECTED_LOOP_WINDOW_SIZE; f++) {
+        if (observeToolCall(w, `filler-${round}-${f}`).fired) everFired = true;
+      }
+    }
+    expect(everFired).toBe(false);
+  });
+
+  it('bounds retained state to the window size (ring buffer eviction)', () => {
+    const w = createSuspectedLoopWindow();
+    for (let i = 0; i < SUSPECTED_LOOP_WINDOW_SIZE * 3; i++) {
+      observeToolCall(w, `fp-${i}`);
+    }
+    expect(w.recent.length).toBe(SUSPECTED_LOOP_WINDOW_SIZE);
+  });
+
+  it('distinct-arg fan-out never fires (each round is a unique fingerprint)', () => {
+    // Models the /review per-citation trap: same tool, DIFFERENT args each call.
+    const w = createSuspectedLoopWindow();
+    let everFired = false;
+    for (let i = 0; i < SUSPECTED_LOOP_WINDOW_SIZE * 2; i++) {
+      const fp = fingerprintToolCall(call('read_file', { file_path: `/cite-${i}.ts` }));
+      if (observeToolCall(w, fp).fired) everFired = true;
+    }
+    expect(everFired).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispatcher integration — OBSERVE-ONLY invariant
+// ---------------------------------------------------------------------------
+
+const PARENT = 'parent-session-1';
+
+function echoHandler(): ToolHandler {
+  return async (input: unknown) => ({
+    content: String((input as { message?: string }).message ?? 'ok'),
+  });
+}
+
+/** A dispatcher wired like a forked child (parentSessionId set) by default. */
+function makeDispatcher(opts?: {
+  fork?: boolean;
+  writer?: InMemoryTraceWriter;
+}): SessionToolDispatcher {
+  return new SessionToolDispatcher({
+    handlers: new Map<string, ToolHandler>([
+      ['echo', echoHandler()],
+      ['echo2', echoHandler()],
+    ]),
+    schemas: [...builtinToolSchemas],
+    permissions: { allowedTools: ['echo', 'echo2'] },
+    ...(opts?.fork !== false ? { parentSessionId: PARENT } : {}),
+    ...(opts?.writer ? { traceWriter: opts.writer } : {}),
+  });
+}
+
+function echoCall(message: string, name = 'echo'): ToolCall {
+  return { id: `${name}-${message}`, name, input: { message }, signal: new AbortController().signal };
+}
+
+function suspectedLoopEvents(writer: InMemoryTraceWriter): TraceEvent[] {
+  return writer.events.filter(
+    (e) => e.kind === 'session_phase' && e.payload.phase === 'suspected_loop',
+  );
+}
+
+describe('suspected-loop detector — dispatcher integration (OBSERVE-ONLY)', () => {
+  it('emits ONE suspected_loop trace event on the threshold-th identical forked call', async () => {
+    const writer = new InMemoryTraceWriter();
+    const d = makeDispatcher({ writer });
+
+    // The first THRESHOLD-1 identical calls: no emission yet.
+    for (let i = 0; i < SUSPECTED_LOOP_THRESHOLD - 1; i++) {
+      const r = await d.execute(echoCall('same'));
+      expect(r.isError).toBeUndefined();
+      expect(r.content).toBe('same');
+    }
+    expect(suspectedLoopEvents(writer)).toHaveLength(0);
+
+    // Threshold-th call: exactly one emission, carrying { tool, count, windowSize }.
+    const trip = await d.execute(echoCall('same'));
+    const events = suspectedLoopEvents(writer);
+    expect(events).toHaveLength(1);
+    const ev = events[0]!;
+    if (ev.kind !== 'session_phase') throw new Error('unreachable');
+    expect(ev.payload.metadata).toEqual({
+      tool: 'echo',
+      count: SUSPECTED_LOOP_THRESHOLD,
+      windowSize: SUSPECTED_LOOP_WINDOW_SIZE,
+    });
+
+    // OBSERVE-ONLY: the tripping call still ran the handler and returned the
+    // normal result — no error, no failureClass, content unchanged.
+    expect(trip.isError).toBeUndefined();
+    expect(trip.content).toBe('same');
+    expect(trip.failureClass).toBeUndefined();
+    expect(trip.circuitBreaker).toBeUndefined();
+  });
+
+  it('debounces: further identical calls after the first fire emit nothing more', async () => {
+    const writer = new InMemoryTraceWriter();
+    const d = makeDispatcher({ writer });
+    // Interleave a distinct filler tool so the CONSECUTIVE repeat circuit
+    // breaker (an orthogonal mechanism, threshold 8) never trips — this test
+    // isolates the windowed observe-only signal, which must fire exactly once
+    // for echo("same") no matter how many more times it recurs.
+    for (let i = 0; i < (SUSPECTED_LOOP_THRESHOLD + 10) * 2; i++) {
+      const r =
+        i % 2 === 0
+          ? await d.execute(echoCall('same'))
+          : await d.execute(echoCall(`filler-${i}`, 'echo2'));
+      // Every call keeps returning the real result — never blocked.
+      expect(r.isError).toBeUndefined();
+    }
+    expect(suspectedLoopEvents(writer)).toHaveLength(1);
+  });
+
+  it('NEVER emits for a top-level (non-forked) session, no matter how many repeats', async () => {
+    const writer = new InMemoryTraceWriter();
+    const d = makeDispatcher({ fork: false, writer });
+    // Interleave a filler so the consecutive repeat breaker does not trip; the
+    // point of this test is that even sustained windowed repetition emits no
+    // suspected_loop signal for a top-level session (it is forked-only scoped).
+    for (let i = 0; i < SUSPECTED_LOOP_WINDOW_SIZE * 2; i++) {
+      const r =
+        i % 2 === 0
+          ? await d.execute(echoCall('same'))
+          : await d.execute(echoCall(`filler-${i}`, 'echo2'));
+      expect(r.isError).toBeUndefined();
+    }
+    expect(suspectedLoopEvents(writer)).toHaveLength(0);
+  });
+
+  it('detects an INTERLEAVED loop across tool rounds (echo … echo2 … echo …)', async () => {
+    const writer = new InMemoryTraceWriter();
+    const d = makeDispatcher({ writer });
+    // echo("same") once, then (echo2, echo("same")) pairs. echo("same") hits its
+    // THRESHOLD-th occurrence within the window even though never consecutive.
+    await d.execute(echoCall('same'));
+    for (let i = 0; i < SUSPECTED_LOOP_THRESHOLD; i++) {
+      await d.execute(echoCall(`filler-${i}`, 'echo2'));
+      await d.execute(echoCall('same'));
+    }
+    const events = suspectedLoopEvents(writer);
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    const ev = events[0]!;
+    if (ev.kind !== 'session_phase') throw new Error('unreachable');
+    expect(ev.payload.metadata?.['tool']).toBe('echo');
+  });
+
+  it('does NOT emit for distinct-arg fan-out (same tool, different input each call)', async () => {
+    const writer = new InMemoryTraceWriter();
+    const d = makeDispatcher({ writer });
+    for (let i = 0; i < SUSPECTED_LOOP_WINDOW_SIZE * 2; i++) {
+      await d.execute(echoCall(`distinct-${i}`));
+    }
+    expect(suspectedLoopEvents(writer)).toHaveLength(0);
+  });
+
+  it('normalizes key order: {a,b} and {b,a} count as the SAME fingerprint', async () => {
+    const writer = new InMemoryTraceWriter();
+    const d = makeDispatcher({ writer });
+    // Alternate key order every call; all THRESHOLD count as one fingerprint.
+    for (let i = 0; i < SUSPECTED_LOOP_THRESHOLD; i++) {
+      const input = i % 2 === 0 ? { message: 'x', extra: 1 } : { extra: 1, message: 'x' };
+      await d.execute({
+        id: `k-${i}`,
+        name: 'echo',
+        input,
+        signal: new AbortController().signal,
+      });
+    }
+    expect(suspectedLoopEvents(writer)).toHaveLength(1);
+  });
+
+  it('works with no traceWriter attached — never throws, still observe-only', async () => {
+    // No writer: emission is a silent no-op (emitSessionPhase early-returns).
+    // Stay at THRESHOLD+2 consecutive identical calls: enough to cross the
+    // suspected-loop threshold (5) and exercise the fire path, but under the
+    // orthogonal repeat circuit breaker's consecutive limit (8) so results are
+    // the real handler output.
+    const d = makeDispatcher();
+    for (let i = 0; i < SUSPECTED_LOOP_THRESHOLD + 2; i++) {
+      const r = await d.execute(echoCall('same'));
+      expect(r.content).toBe('same');
+      expect(r.isError).toBeUndefined();
+    }
+  });
+
+  it('fires on the batch path too, without altering any batched result', async () => {
+    const writer = new InMemoryTraceWriter();
+    const d = makeDispatcher({ writer });
+    const calls = Array.from({ length: SUSPECTED_LOOP_THRESHOLD }, (_, i) => ({
+      id: `b-${i}`,
+      name: 'echo',
+      input: { message: 'same' },
+      signal: new AbortController().signal,
+    }));
+    const results = await d.executeBatch(calls);
+    // Every batched call returned its real result — observe-only never blocks.
+    for (const r of results) {
+      expect(r?.content).toBe('same');
+      expect(r?.isError).toBeUndefined();
+      expect(r?.failureClass).toBeUndefined();
+    }
+    expect(suspectedLoopEvents(writer)).toHaveLength(1);
+  });
+
+  it('a fresh dispatcher (next turn) starts with a clean window', async () => {
+    const w1 = new InMemoryTraceWriter();
+    const d1 = makeDispatcher({ writer: w1 });
+    for (let i = 0; i < SUSPECTED_LOOP_THRESHOLD; i++) await d1.execute(echoCall('same'));
+    expect(suspectedLoopEvents(w1)).toHaveLength(1);
+
+    // New dispatcher == new query/turn: window resets, so the count restarts.
+    const w2 = new InMemoryTraceWriter();
+    const d2 = makeDispatcher({ writer: w2 });
+    for (let i = 0; i < SUSPECTED_LOOP_THRESHOLD - 1; i++) await d2.execute(echoCall('same'));
+    expect(suspectedLoopEvents(w2)).toHaveLength(0);
+  });
+});

--- a/src/agent/tools/suspected-loop-detector.ts
+++ b/src/agent/tools/suspected-loop-detector.ts
@@ -1,0 +1,201 @@
+/**
+ * OBSERVE-ONLY suspected-loop telemetry for forked sub-agents.
+ *
+ * A forked child can get stuck issuing the SAME tool call with the SAME
+ * (normalized) arguments over and over inside a single turn — a genuine
+ * busy-loop that makes no progress. The two enforcing breakers do NOT measure
+ * this class as data:
+ *   - the repeat breaker ({@link import('./repeat-circuit-breaker.js')}) only
+ *     catches CONSECUTIVE byte-identical calls (an A A A run), and it ABORTS;
+ *   - the denial breaker ({@link import('./denial-circuit-breaker.js')}) only
+ *     catches consecutive path-approval read denials, and it ABORTS.
+ *
+ * This detector closes an OBSERVABILITY gap, not an enforcement one. It flags a
+ * fingerprint that recurs within a sliding window even when interleaved with
+ * other calls (an A B A C A … pattern the consecutive repeat breaker misses),
+ * and its ONLY effect is a `suspected_loop` trace emission on the witness side
+ * channel. It is pure data-gathering to answer "do real busy-loops happen in
+ * practice?" BEFORE deciding whether an enforcing loop-detector is ever
+ * warranted.
+ *
+ * THE CRITICAL INVARIANT — OBSERVE-ONLY. This module and its dispatcher wiring
+ * MUST NEVER abort the fork, NEVER set a `failureClass`, NEVER alter or delay a
+ * tool result, and NEVER change control flow. Everything here is a pure
+ * predicate over a bounded ring buffer plus a debounce flag; the sole side
+ * effect (a fire-and-forget trace write) lives at the dispatcher call site.
+ *
+ * The stateful window (per-dispatcher, so per-forked-query) lives on
+ * `SessionToolDispatcher` as a {@link SuspectedLoopWindow}; the pure fingerprint
+ * function, the recurrence predicate, the window mutator, and the fixed
+ * thresholds live here. Mirrors the fixed-constant + pure-helper style of the
+ * two breaker files.
+ *
+ * Scope: the dispatcher gates this to FORKED children only (a `parentSessionId`
+ * check, exactly like the denial breaker) so interactive sessions — where the
+ * operator drives the loop and legitimate repetition is common — never emit.
+ *
+ * NOTE ON WHAT THIS DELIBERATELY DOES NOT CATCH: distinct-arg fan-out. The
+ * documented `/review` per-citation trap issues a fresh call with DIFFERENT args
+ * each round, so no fingerprint recurs — it never fires here, and that is
+ * correct. That trap is budget-shaped and handled elsewhere; this signal
+ * targets GENUINE (tool, args) repetition only.
+ *
+ * @module agent/tools/suspected-loop-detector
+ */
+
+import { createHash } from 'node:crypto';
+import type { ToolCall } from '../providers/anthropic-direct/types.js';
+
+/**
+ * Recurrence count that constitutes a "suspected loop": a fingerprint seen this
+ * many times within the last {@link SUSPECTED_LOOP_WINDOW_SIZE} tool rounds.
+ * Fixed constant, in the style of `REPEAT_CIRCUIT_BREAKER_THRESHOLD` /
+ * `DENIAL_CIRCUIT_BREAKER_THRESHOLD`.
+ *
+ * Chosen at 5 (within a window of 20): high enough that ordinary, legitimate
+ * repetition (a couple of re-reads of the same file, a retried grep) never
+ * trips, while still catching a fork that keeps returning to the exact same
+ * no-progress call several times across a 20-round window. Because this is
+ * OBSERVE-ONLY, a mildly conservative threshold is the right default — a missed
+ * marginal loop costs nothing, whereas a noisy false positive would pollute the
+ * very telemetry this exists to gather. Tune only against real trace data.
+ */
+export const SUSPECTED_LOOP_THRESHOLD = 5;
+
+/**
+ * Sliding-window size, in tool rounds, over which {@link SUSPECTED_LOOP_THRESHOLD}
+ * recurrences are counted. Fixed constant. At 20 rounds the window is wide
+ * enough to span an interleaved loop (A B A C A D A … — which the CONSECUTIVE
+ * repeat breaker cannot see) yet bounded so retained state is O(20) fingerprints
+ * per dispatcher and the signal reflects RECENT behavior, not the whole turn.
+ * Must be >= {@link SUSPECTED_LOOP_THRESHOLD} for the predicate to ever be able
+ * to fire.
+ */
+export const SUSPECTED_LOOP_WINDOW_SIZE = 20;
+
+/**
+ * Per-dispatcher mutable state for the observe-only detector. Held on
+ * `SessionToolDispatcher` (one per forked `query()`, so this is per-turn and
+ * resets between turns via dispatcher reconstruction — exactly like the two
+ * breakers' state).
+ *
+ * - `recent` is a bounded ring buffer (FIFO, capped at
+ *   {@link SUSPECTED_LOOP_WINDOW_SIZE}) of the most recent fingerprints.
+ * - `firedFingerprints` records the fingerprints already reported this turn so
+ *   the signal emits AT MOST ONCE per detected loop (debounce) rather than on
+ *   every round once the threshold is first crossed. Once a fingerprint fires,
+ *   its later recurrences within the same turn are silent.
+ */
+export interface SuspectedLoopWindow {
+  /** FIFO of recent fingerprints, oldest first, length <= window size. */
+  recent: string[];
+  /** Fingerprints already emitted this turn (debounce set). */
+  firedFingerprints: Set<string>;
+}
+
+/** A fresh, empty detector window. */
+export function createSuspectedLoopWindow(): SuspectedLoopWindow {
+  return { recent: [], firedFingerprints: new Set<string>() };
+}
+
+/**
+ * Stable fingerprint of a tool call for recurrence detection: sha256 over
+ * `name \0 canonicalJSON(input)`. Hashing bounds retained state to 64 hex chars
+ * regardless of input size.
+ *
+ * Unlike {@link import('./repeat-circuit-breaker.js').repeatCallFingerprint},
+ * which relies on the model serializing byte-identical tool_use blocks
+ * identically, this NORMALIZES the argument object by sorting keys recursively
+ * before stringifying. Two calls that are semantically the same but differ only
+ * in key order (`{a,b}` vs `{b,a}`) therefore collide — the right behavior for a
+ * telemetry signal whose whole point is detecting the SAME logical call
+ * recurring, independent of incidental serialization order.
+ */
+export function fingerprintToolCall(call: ToolCall): string {
+  let input: string;
+  try {
+    input = canonicalStringify(call.input);
+  } catch {
+    // Defensive: a value that cannot be canonicalized (unexpected shape,
+    // circular ref) still yields a stable-ish string. Never throws — an
+    // observe-only path must not perturb dispatch.
+    input = String(call.input);
+  }
+  return createHash('sha256').update(call.name).update('\u0000').update(input).digest('hex');
+}
+
+/**
+ * Deterministic JSON stringify with recursively sorted object keys, so
+ * key-order differences never change the fingerprint. Arrays keep their order
+ * (order is semantic there); primitives stringify as normal JSON. Falls back to
+ * `JSON.stringify` semantics for `undefined`/functions (dropped) to stay a pure
+ * value→string map.
+ */
+function canonicalStringify(value: unknown): string {
+  return JSON.stringify(sortDeep(value)) ?? 'null';
+}
+
+/** Recursively sort object keys; leave arrays and primitives structurally intact. */
+function sortDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortDeep);
+  if (value !== null && typeof value === 'object') {
+    const src = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(src).sort()) {
+      out[key] = sortDeep(src[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Outcome of pushing one fingerprint into the window. */
+export interface SuspectedLoopObservation {
+  /**
+   * True only on the FIRST round where `fingerprint` crosses
+   * {@link SUSPECTED_LOOP_THRESHOLD} within the window AND has not already been
+   * reported this turn. This is the single edge the caller emits on; it can be
+   * true at most once per fingerprint per turn (debounce).
+   */
+  fired: boolean;
+  /** Occurrences of `fingerprint` within the current window (post-push). */
+  count: number;
+}
+
+/**
+ * Pure recurrence predicate: count how many times `fingerprint` appears in the
+ * current window contents. Exported for direct unit testing of the core rule.
+ */
+export function countInWindow(recent: readonly string[], fingerprint: string): number {
+  let n = 0;
+  for (const f of recent) if (f === fingerprint) n += 1;
+  return n;
+}
+
+/**
+ * Push `fingerprint` into the bounded window and evaluate the observe-only
+ * suspected-loop rule. Mutates `window` in place:
+ *   1. append the fingerprint, evicting the oldest if the ring is full;
+ *   2. count its occurrences in the resulting window;
+ *   3. report `fired: true` iff the count is at or above the threshold AND this
+ *      fingerprint has not already fired this turn (then latch it so later
+ *      recurrences stay silent — the debounce).
+ *
+ * PURELY observational: returns a verdict; performs no I/O, no abort, no result
+ * mutation. The caller owns the (fire-and-forget) trace emission.
+ */
+export function observeToolCall(
+  window: SuspectedLoopWindow,
+  fingerprint: string,
+): SuspectedLoopObservation {
+  window.recent.push(fingerprint);
+  if (window.recent.length > SUSPECTED_LOOP_WINDOW_SIZE) {
+    window.recent.shift();
+  }
+  const count = countInWindow(window.recent, fingerprint);
+  if (count >= SUSPECTED_LOOP_THRESHOLD && !window.firedFingerprints.has(fingerprint)) {
+    window.firedFingerprints.add(fingerprint);
+    return { fired: true, count };
+  }
+  return { fired: false, count };
+}

--- a/src/agent/trace/events.ts
+++ b/src/agent/trace/events.ts
@@ -399,6 +399,7 @@ export const SessionPhaseNameSchema = z.enum([
   'usage_limit_pause',
   'usage_limit_resume',
   'idle_watchdog_fired',
+  'suspected_loop',
 ]);
 
 export const SessionPhasePayloadSchema = z.object({

--- a/src/agent/trace/session-phase.test.ts
+++ b/src/agent/trace/session-phase.test.ts
@@ -189,6 +189,21 @@ describe('session_phase payload schema — acceptance', () => {
     // Bare name-schema acceptance.
     expect(() => SessionPhaseNameSchema.parse('idle_watchdog_fired')).not.toThrow();
   });
+
+  it('accepts the suspected_loop phase with its OBSERVE-ONLY loop metadata', () => {
+    // Emitted by SessionToolDispatcher for a FORKED child on first detection of
+    // a recurring (tool, args) fingerprint. Single event (no paired *_start);
+    // carries the loop diagnostics as metadata. Pure observability — never
+    // aborts the fork or alters a result.
+    expect(() =>
+      SessionPhasePayloadSchema.parse({
+        phase: 'suspected_loop',
+        metadata: { tool: 'read_file', count: 5, windowSize: 20 },
+      }),
+    ).not.toThrow();
+    // Bare name-schema acceptance.
+    expect(() => SessionPhaseNameSchema.parse('suspected_loop')).not.toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -222,6 +237,7 @@ describe('SessionPhaseName union ↔ SessionPhaseNameSchema parity', () => {
     usage_limit_pause: true,
     usage_limit_resume: true,
     idle_watchdog_fired: true,
+    suspected_loop: true,
   };
 
   it('the Zod enum contains exactly the union members (no drift either way)', () => {

--- a/src/agent/trace/types.ts
+++ b/src/agent/trace/types.ts
@@ -651,7 +651,19 @@ export type SessionPhaseName =
   // start); carries `idleTimeoutMs`, `elapsedSinceLastProgressMs`, and
   // `lastEventType` in `metadata`. Distinct from `rate_limit`/`usage_limit_*`,
   // which mark LEGITIMATE waits — this marks an unexplained stall that fired.
-  | 'idle_watchdog_fired';
+  | 'idle_watchdog_fired'
+  // OBSERVE-ONLY loop telemetry (see tools/suspected-loop-detector.ts): a
+  // FORKED sub-agent issued the same (tool, normalized-args) fingerprint
+  // >= N times within the last M tool rounds on one dispatcher (per-turn).
+  // A single event (no paired start), emitted AT MOST ONCE per detected loop
+  // (debounced), carrying `tool`, `count`, and `windowSize` in `metadata`.
+  // PURE OBSERVABILITY: unlike the repeat/denial circuit breakers, this NEVER
+  // aborts the fork, sets a failureClass, or alters a tool result — it only
+  // records that a genuine (tool,args) repetition was observed, so we can
+  // measure whether real busy-loops occur before deciding if an enforcing
+  // detector is ever warranted. Distinct from `idle_watchdog_fired` (a stall
+  // with NO output) — this marks the opposite: a fork actively repeating work.
+  | 'suspected_loop';
 
 export interface SessionPhasePayload {
   /** Which lifecycle milestone this record marks. */


### PR DESCRIPTION
## What

Adds an **observe-only** `suspected_loop` trace signal. When a **forked** subagent issues the same tool call with the same normalized args ≥N times within a sliding window (N=5 within M=20 rounds), the dispatcher emits a `suspected_loop` session phase carrying `{ tool, count, windowSize }`.

**Observe-only — the load-bearing invariant:** `observeSuspectedLoop(call): void` never aborts the fork, never sets a `failureClass`, never alters or delays a tool result, never touches control flow. The trace write is fire-and-forget (`void emitSessionPhase(...)`). Scoped to forked children only (mirrors the denial circuit-breaker's `parentSessionId` guard), so interactive sessions are unaffected.

## Why

**Layer 1** of the "trapped subagent" follow-ups: pure data-gathering to measure whether genuine `(tool, args)` repetition loops actually occur in practice — **before** deciding whether an *enforcing* loop-detector is ever warranted. A devils-advocate wave rejected shipping an aborting detector outright: it's mis-tunable, risks false-aborting legit build→test→fix / paginated-search cycles, and wouldn't even have fired on the documented `/review` per-citation trap (distinct args each call). Telemetry-first lets us tune N/M against real traces instead of guessing.

Deliberately does **not** fire on distinct-arg fan-out — that's budget-shaped and handled by the `general-purpose` cap (#673). Complements the idle watchdog (silence) with a signal for activity-without-progress.

## Stacked on #672

Base branch is `afk/idle-watchdog` (PR #672) — this reuses the trace-phase machinery that PR added (`idle_watchdog_fired`), adding `suspected_loop` in lockstep to the `SessionPhaseName` union + Zod enum + the parity test. GitHub retargets this to `main` when #672 merges.

## Follow-up (not here)

No `afk trace show` rendering for the new phase yet (emission only) — a small reader-side addition once we've seen it land in real traces.

## Test / verification

- `pnpm lint` (tsc --noEmit, strict) — PASS
- `suspected-loop-detector.test.ts` (22), `dispatcher.test.ts` (103), `session-phase.test.ts` (47) — PASS
- Full `pnpm test` — **12778 passed / 14 skipped / 0 failed** (691 files)
- Observe-only invariant confirmed by grep: the detector module contains no abort/throw/failureClass/isError; `observeSuspectedLoop` returns `void` and is called as a standalone (non-gating) statement.

Files: new `suspected-loop-detector.ts` (+ test), `dispatcher.ts` (window state + fire-and-forget observe), `trace/types.ts` + `events.ts` (phase lockstep), `session-phase.test.ts` + `dispatcher.test.ts`.
