### PR TITLE
feat(agents): self-reported convergence/stop criterion for general-purpose

### DIFF
--- a/src/agent/agents/builtins.ts
+++ b/src/agent/agents/builtins.ts
@@ -57,8 +57,7 @@ Reply compactly: the answer first, then evidence as file:line citations, then op
  * resolves a named dispatch's `maxToolUseIterations` to 0 (no cap) when neither
  * the call-site nor the definition sets one, deliberately bypassing
  * SubagentManager's `SUBAGENT_DEFAULT_MAX_TOOL_USE_ITERATIONS` (50) — which only
- * guards internal skill/compose forks. Unbounded is defensible for a real
- * multi-step worker (`general-purpose`), but a READ-ONLY research/review agent
+ * guards internal skill/compose forks. A READ-ONLY research/review agent
  * never legitimately needs many rounds; without a bound it can loop on a hard
  * task until an external cutoff aborts it mid-loop, surfacing as an opaque
  * failure. Bounding it routes a runaway through the graceful capped-partial
@@ -67,6 +66,25 @@ Reply compactly: the answer first, then evidence as file:line citations, then op
  * graph — same rationale as the KNOWN_AFK_TOOL_NAMES dup in resolve.ts.
  */
 const READONLY_AGENT_MAX_TOOL_USE_ITERATIONS = 50;
+
+/**
+ * Anti-runaway ceiling for the inherit-all worker (`general-purpose`).
+ *
+ * general-purpose does exploration AND action across many dependent steps, so
+ * it legitimately needs more rounds than a read-only leaf — it was previously
+ * left UNCAPPED on the (uncapped-by-default) agent-tool dispatch path. But
+ * "uncapped" means a busy, non-converging worker (one that keeps tool-calling
+ * without making progress) has no bound short of the 45-min wall-clock and
+ * dies opaquely there. This generous ceiling (3× the read-only cap) bounds
+ * such a runaway through the SAME graceful capped-partial wind-down, while
+ * staying well above any legitimate multi-step dispatch's round count so real
+ * work is never cut off. A caller with a genuinely longer task opts out
+ * per-dispatch via an explicit `max_tool_use_iterations` (including `0` =
+ * uncapped) — see `child-config.ts`. The cap is PER-TURN, so a single-shot
+ * fork gets one budget for its whole task, which is why it is deliberately
+ * generous rather than matching the read-only 50.
+ */
+const GENERAL_PURPOSE_MAX_TOOL_USE_ITERATIONS = 150;
 
 /**
  * Build the built-in agents, keyed by name.
@@ -134,6 +152,12 @@ export function builtinAgents(): Map<string, RegisteredAgent> {
           'multiple dependent steps, not just research.',
         prompt: GENERAL_PURPOSE_PROMPT,
         // No `tools` — inherit-all (Claude Code parity for general-purpose).
+        // Generous anti-runaway ceiling (see GENERAL_PURPOSE_MAX_TOOL_USE_ITERATIONS):
+        // bounds a busy, non-converging worker to a graceful capped-partial
+        // wind-down instead of the 45-min wall-clock, without cutting legit
+        // multi-step work. Opt out per-dispatch with an explicit
+        // max_tool_use_iterations (`0` = uncapped).
+        maxToolUseIterations: GENERAL_PURPOSE_MAX_TOOL_USE_ITERATIONS,
       },
     },
     {

--- a/src/agent/agents/builtins.ts
+++ b/src/agent/agents/builtins.ts
@@ -39,6 +39,8 @@ const GENERAL_PURPOSE_PROMPT = `You are a general-purpose sub-agent for complex,
 
 Work autonomously from the task prompt you were dispatched with: investigate, act, and verify. You have the parent session's full child tool surface. Keep intermediate exploration out of your reply.
 
+Watch for non-convergence: if repeated attempts at the same sub-goal — the same fix, the same search, the same command — stop making progress after a few tries, STOP and do not keep retrying. Activity is not progress. Return your best PARTIAL result with a clear note on what you could not resolve and why.
+
 Reply with a compressed result: answer/outcome first, then evidence with file:line citations where applicable, risks or caveats, and anything you did not check. Your final message is the only thing the dispatching session sees.`;
 
 const EXPLORE_PROMPT = `You are Explore, a fast read-only sub-agent optimized for searching and analyzing codebases.

--- a/src/agent/agents/registry.test.ts
+++ b/src/agent/agents/registry.test.ts
@@ -62,18 +62,23 @@ describe('loadAgentRegistry', () => {
     // git-investigator is a read-only git-archaeology leaf (dispatched by
     // research-agent) and must carry the same cap.
     expect(registry.get('git-investigator')?.definition.maxToolUseIterations).toBe(50);
-    // general-purpose stays UNBOUNDED — a real multi-step worker legitimately
-    // needs an uncapped loop, so it must NOT gain the read-only bound.
-    expect(registry.get('general-purpose')?.definition.maxToolUseIterations).toBeUndefined();
+    // general-purpose now carries a GENEROUS ceiling (not the read-only 50): a
+    // full-tool multi-step worker needs headroom, but leaving it "uncapped" let
+    // a busy, non-converging worker run to the 45-min wall-clock. 150 bounds a
+    // runaway to the graceful capped-partial wind-down while clearing legit
+    // multi-step work; opt out per-dispatch via explicit max_tool_use_iterations.
+    expect(registry.get('general-purpose')?.definition.maxToolUseIterations).toBe(150);
   });
 
   // Drift-catcher: iterate the BUILTIN registry (not the vendored consts) so a
-  // newly-added read-only builtin that forgets the anti-runaway cap fails here.
-  // Structural predicate (no hardcoded per-agent list): a builtin with an
-  // explicit `tools` allowlist is a restricted/read-only leaf and MUST carry
-  // maxToolUseIterations; a builtin that OMITS `tools` (inherit-all, the full
-  // tool surface — only general-purpose today) is the uncapped exemption.
-  it('every read-only builtin (explicit tools) carries the anti-runaway cap; inherit-all exempt', () => {
+  // newly-added builtin that forgets its anti-runaway cap fails here.
+  // Structural predicate (no hardcoded per-agent list): EVERY builtin must be
+  // bounded — a builtin with an explicit `tools` allowlist is a
+  // restricted/read-only leaf capped at 50; a builtin that OMITS `tools`
+  // (inherit-all, the full tool surface — only general-purpose today) is the
+  // multi-step worker, capped at the generous worker ceiling (150), never
+  // uncapped.
+  it('every builtin is bounded: read-only leaves cap at 50, the inherit-all worker at the generous ceiling', () => {
     const builtins = builtinAgents();
     // Guard the guard: ensure we actually iterated real builtins and covered
     // BOTH arms (at least one capped read-only leaf and the inherit-all worker),
@@ -92,8 +97,8 @@ describe('loadAgentRegistry', () => {
         sawInheritAll = true;
         expect(
           entry.definition.maxToolUseIterations,
-          `inherit-all builtin ${name} must stay uncapped (full tool surface)`,
-        ).toBeUndefined();
+          `inherit-all builtin ${name} must carry the generous worker ceiling (never uncapped)`,
+        ).toBe(150);
       }
     }
     expect(sawRestricted, 'expected ≥1 restricted read-only builtin').toBe(true);


### PR DESCRIPTION
## What

Adds a self-reported **convergence / stop criterion** to the `general-purpose` subagent prompt:

> Watch for non-convergence: if repeated attempts at the same sub-goal — the same fix, the same search, the same command — stop making progress after a few tries, STOP and do not keep retrying. Activity is not progress. Return your best PARTIAL result with a clear note on what you could not resolve and why.

Prompt-only: +2 lines to `GENERAL_PURPOSE_PROMPT` in `builtins.ts`; no runtime code.

## Why

**Layer 2** of the "trapped subagent" follow-ups, addressing the diagnosed **root cause**: a trapped agent has an activity signal but no *convergence* signal, so it substitutes activity for progress and never decides "this isn't working, stop." The mechanical ceiling (#673) is the hard backstop; this is the soft signal that lets the agent wind down to a useful partial *before* hitting it — and generalizes to fix→test→fix / search-fan-out loops a blunt round cap only crudely bounds.

## Stacked on #673

Base branch is `afk/general-purpose-cap` (PR #673) — this pairs the prompt guidance with the mechanical cap that PR added to the same agent. GitHub retargets to `main` when #673 merges.

## Scope (deliberately tight)

`general-purpose` prompt only — the write-capable worker most prone to these loops. Deliberately **not** touched:
- the vendored read-only prompts (`research-agent`, `git-investigator`) — byte-pinned by `vendored.test.ts` with upstream back-port obligations, and already round-capped at 50;
- the bundled `/contract` — editing it would create an undocumented bundled-vs-`example-plugin` divergence with a back-port gap the co-located drift test can't catch locally.

Both are flagged as coordinated follow-ups if a shared convergence clause is wanted across orchestration agents.

## Test / verification

- `pnpm lint` (tsc --noEmit, strict) — PASS
- `registry.test.ts` — 17 passed
- Full `pnpm test` — **12718 passed / 14 skipped / 0 failed** (689 files)
- Diff verified: exactly +2 lines to `builtins.ts`, prompt-only, nothing else changed.
