### PR TITLE
fix(anthropic-direct): ESC interrupt halts promptly and never strands the next turn

### DIFF
--- a/src/agent/providers/anthropic-direct/abortable-stream.test.ts
+++ b/src/agent/providers/anthropic-direct/abortable-stream.test.ts
@@ -46,6 +46,30 @@ describe('abortableStream', () => {
     await expect(pull).rejects.toMatchObject({ name: 'AbortError', message: 'interrupted' });
   });
 
+  it('does not wait for iterator cleanup after abort wins the race', async () => {
+    const ac = new AbortController();
+    const source: AsyncIterable<number> = {
+      [Symbol.asyncIterator]() {
+        return {
+          next() {
+            return new Promise<IteratorResult<number>>(() => {
+              /* parked read */
+            });
+          },
+          return() {
+            return new Promise<IteratorResult<number>>(() => {
+              /* cleanup is stuck behind the parked read */
+            });
+          },
+        };
+      },
+    };
+    const gen = abortableStream(source, ac.signal);
+    const pull = gen.next();
+    ac.abort('interrupted');
+    await expect(pull).rejects.toMatchObject({ name: 'AbortError', message: 'interrupted' });
+  });
+
   it('passes values through in order and ends cleanly on done', async () => {
     const ac = new AbortController();
     const out: number[] = [];

--- a/src/agent/providers/anthropic-direct/abortable-stream.test.ts
+++ b/src/agent/providers/anthropic-direct/abortable-stream.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression tests for the interrupt-lag fix.
+ *
+ * The bug: on ESC the turn signal aborts, but the SDK's SSE async-iterator only
+ * surfaces the abort when its pending read settles — so a mid-stream
+ * extended-thinking (Opus) turn kept "streaming" for seconds after ESC, and the
+ * user's next message landed a turn late (they learned to poke "." to force it).
+ * `abortableStream` makes the halt deterministic by racing each pull against the
+ * signal. The load-bearing case is `throws promptly when a read is parked`.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { abortableStream } from './abortable-stream.js';
+
+async function* fromArray<T>(arr: T[]): AsyncIterable<T> {
+  for (const x of arr) yield x;
+}
+
+/** A source whose `next()` never resolves — models a parked SSE read. */
+function parkedSource(returnSpy?: () => void): AsyncIterable<number> {
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next() {
+          return new Promise<IteratorResult<number>>(() => {
+            /* never resolves — the read is parked awaiting the next SSE frame */
+          });
+        },
+        return() {
+          returnSpy?.();
+          return Promise.resolve({ value: undefined as unknown as number, done: true });
+        },
+      };
+    },
+  };
+}
+
+describe('abortableStream', () => {
+  it('throws promptly when the signal aborts while a read is parked (the interrupt-lag bug)', async () => {
+    const ac = new AbortController();
+    const gen = abortableStream(parkedSource(), ac.signal);
+    const pull = gen.next();
+    // Without the abort race this pull would hang forever (the bug). The abort
+    // must win the race and reject on the next microtasks — not after a timeout.
+    ac.abort('interrupted');
+    await expect(pull).rejects.toMatchObject({ name: 'AbortError', message: 'interrupted' });
+  });
+
+  it('passes values through in order and ends cleanly on done', async () => {
+    const ac = new AbortController();
+    const out: number[] = [];
+    for await (const v of abortableStream(fromArray([1, 2, 3]), ac.signal)) out.push(v);
+    expect(out).toEqual([1, 2, 3]);
+  });
+
+  it('halts mid-stream: yields what arrived before ESC, then throws on abort', async () => {
+    const ac = new AbortController();
+    let deliver!: (r: IteratorResult<number>) => void;
+    const source: AsyncIterable<number> = {
+      [Symbol.asyncIterator]() {
+        return {
+          next() {
+            return new Promise<IteratorResult<number>>((resolve) => {
+              deliver = resolve;
+            });
+          },
+        };
+      },
+    };
+    const gen = abortableStream(source, ac.signal);
+    const first = gen.next();
+    deliver({ value: 7, done: false });
+    expect(await first).toEqual({ value: 7, done: false });
+    // Second read parks; ESC aborts before the next frame arrives.
+    const second = gen.next();
+    ac.abort('interrupted');
+    await expect(second).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('throws before touching the source when the signal is already aborted', async () => {
+    const ac = new AbortController();
+    ac.abort('interrupted');
+    let pulled = false;
+    const source: AsyncIterable<number> = {
+      [Symbol.asyncIterator]() {
+        return {
+          next() {
+            pulled = true;
+            return Promise.resolve({ value: 1, done: false });
+          },
+        };
+      },
+    };
+    const gen = abortableStream(source, ac.signal);
+    await expect(gen.next()).rejects.toMatchObject({ name: 'AbortError' });
+    expect(pulled).toBe(false);
+  });
+
+  it('propagates a source error unchanged (never masks a real error as an abort)', async () => {
+    const ac = new AbortController();
+    const boom = new Error('stream failed');
+    const source: AsyncIterable<number> = {
+      [Symbol.asyncIterator]() {
+        return {
+          next() {
+            return Promise.reject(boom);
+          },
+        };
+      },
+    };
+    await expect(
+      (async () => {
+        for await (const _v of abortableStream(source, ac.signal)) {
+          /* drain */
+        }
+      })(),
+    ).rejects.toBe(boom);
+  });
+
+  it('closes the source iterator on abort so the transport is released', async () => {
+    const ac = new AbortController();
+    const returnSpy = vi.fn();
+    const gen = abortableStream(parkedSource(returnSpy), ac.signal);
+    const pull = gen.next();
+    ac.abort();
+    await expect(pull).rejects.toMatchObject({ name: 'AbortError' });
+    expect(returnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows the abandoned read rejection so it cannot surface as unhandledRejection', async () => {
+    const ac = new AbortController();
+    let rejectRead!: (e: unknown) => void;
+    const source: AsyncIterable<number> = {
+      [Symbol.asyncIterator]() {
+        return {
+          next() {
+            return new Promise<IteratorResult<number>>((_resolve, reject) => {
+              rejectRead = reject;
+            });
+          },
+        };
+      },
+    };
+    const gen = abortableStream(source, ac.signal);
+    const pull = gen.next();
+    ac.abort('interrupted');
+    await expect(pull).rejects.toMatchObject({ name: 'AbortError' });
+    // The transport now rejects the abandoned read; the wrapper's no-op catch
+    // must absorb it. Reaching the end without an unhandled rejection is the test.
+    rejectRead(new Error('aborted read'));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(true).toBe(true);
+  });
+});

--- a/src/agent/providers/anthropic-direct/abortable-stream.ts
+++ b/src/agent/providers/anthropic-direct/abortable-stream.ts
@@ -1,0 +1,84 @@
+/**
+ * Contract: wraps a source async-iterable so consumption stops PROMPTLY when
+ * `signal` fires — within the current event-loop turn — instead of waiting for
+ * the source's in-flight `next()` (e.g. a parked SSE read) to settle. Each pull
+ * is raced against the abort; when the abort wins, the wrapper throws an
+ * AbortError and abandons the in-flight read. The abandoned read's eventual
+ * rejection is swallowed so it can never surface as an `unhandledRejection`
+ * (the underlying transport is already being cancelled via the SAME `signal`,
+ * which the caller also handed to `messages.create`). On any exit the wrapper
+ * closes the source iterator via `return()` so the HTTP stream is released.
+ *
+ * Non-abort behaviour is transparent: values pass through unchanged, `done`
+ * ends the generator, and a source rejection propagates unchanged (only an
+ * abort-won race swallows the trailing read — real errors are never masked).
+ *
+ * Why this exists: the anthropic-direct streaming loop passes the turn signal
+ * to the SDK's `messages.create`, so an abort DOES cancel the fetch — but the
+ * SDK's SSE async-iterator only surfaces that abort when its pending read
+ * rejects, which for a mid-stream extended-thinking (Opus) response can lag
+ * seconds behind the ESC keypress (there is no per-delta abort check in the
+ * translate loop). Racing each pull against the signal makes the halt
+ * deterministic regardless of the transport's read cadence. See the
+ * interrupt-halt regression tests alongside this module.
+ */
+export async function* abortableStream<T>(
+  source: AsyncIterable<T>,
+  signal: AbortSignal,
+): AsyncGenerator<T> {
+  // Already aborted before the first pull — never touch the source.
+  if (signal.aborted) throw abortErrorFrom(signal);
+
+  const iterator = source[Symbol.asyncIterator]();
+
+  // Single long-lived abort listener for the whole stream (not per-event: a
+  // high-frequency thinking-delta stream would otherwise add/remove a listener
+  // per token). `aborted` resolves at most once, with the ABORTED sentinel, and
+  // is re-raced against a fresh `next()` promise on every iteration.
+  const ABORTED = Symbol('aborted');
+  let onAbort!: () => void;
+  const aborted = new Promise<typeof ABORTED>((resolve) => {
+    onAbort = () => resolve(ABORTED);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+
+  try {
+    while (true) {
+      const nextP = iterator.next();
+      const result = await Promise.race([nextP, aborted]);
+      if (result === ABORTED) {
+        // Abandon the in-flight read; the transport is already aborting via the
+        // same `signal`. Attach a no-op catch so the abandoned read's eventual
+        // rejection cannot crash the process as an unhandledRejection.
+        void Promise.resolve(nextP).catch(() => { /* transport aborting */ });
+        throw abortErrorFrom(signal);
+      }
+      if (result.done) return;
+      yield result.value;
+    }
+  } finally {
+    signal.removeEventListener('abort', onAbort);
+    // Best-effort: signal the source we are done so the SDK closes the HTTP
+    // stream instead of leaking a dangling connection. `return()` is optional
+    // on the async-iterator protocol; swallow if absent or if it rejects.
+    await Promise.resolve(iterator.return?.()).catch(() => { /* best-effort */ });
+  }
+}
+
+/**
+ * Contract: derive a throwable Error from an aborted signal's reason. Reuses the
+ * reason when it is already an Error (preserving the original stack/identity);
+ * otherwise synthesizes an `AbortError` whose message is the string reason (e.g.
+ * `'interrupted'` from the ESC soft-stop) or a generic fallback. The provider's
+ * loop distinguishes an interrupt from a real error via `signal.aborted`, not
+ * the error identity, so the exact shape here is for logs/debuggability.
+ */
+function abortErrorFrom(signal: AbortSignal): Error {
+  const reason: unknown = signal.reason;
+  if (reason instanceof Error) return reason;
+  const err = new Error(
+    typeof reason === 'string' && reason.length > 0 ? reason : 'The operation was aborted',
+  );
+  err.name = 'AbortError';
+  return err;
+}

--- a/src/agent/providers/anthropic-direct/abortable-stream.ts
+++ b/src/agent/providers/anthropic-direct/abortable-stream.ts
@@ -30,6 +30,7 @@ export async function* abortableStream<T>(
   if (signal.aborted) throw abortErrorFrom(signal);
 
   const iterator = source[Symbol.asyncIterator]();
+  let abortWonRace = false;
 
   // Single long-lived abort listener for the whole stream (not per-event: a
   // high-frequency thinking-delta stream would otherwise add/remove a listener
@@ -51,6 +52,7 @@ export async function* abortableStream<T>(
         // same `signal`. Attach a no-op catch so the abandoned read's eventual
         // rejection cannot crash the process as an unhandledRejection.
         void Promise.resolve(nextP).catch(() => { /* transport aborting */ });
+        abortWonRace = true;
         throw abortErrorFrom(signal);
       }
       if (result.done) return;
@@ -60,8 +62,16 @@ export async function* abortableStream<T>(
     signal.removeEventListener('abort', onAbort);
     // Best-effort: signal the source we are done so the SDK closes the HTTP
     // stream instead of leaking a dangling connection. `return()` is optional
-    // on the async-iterator protocol; swallow if absent or if it rejects.
-    await Promise.resolve(iterator.return?.()).catch(() => { /* best-effort */ });
+    // on the async-iterator protocol; swallow if absent or if it rejects. When
+    // abort won the race, do not await cleanup: async-generator-style sources
+    // can keep `return()` blocked behind the same parked read that this wrapper
+    // bypasses, so awaiting it would reintroduce interrupt lag.
+    const closeP = Promise.resolve(iterator.return?.()).catch(() => { /* best-effort */ });
+    if (abortWonRace) {
+      void closeP;
+    } else {
+      await closeP;
+    }
   }
 }
 

--- a/src/agent/providers/anthropic-direct/interrupt-resume.test.ts
+++ b/src/agent/providers/anthropic-direct/interrupt-resume.test.ts
@@ -238,6 +238,74 @@ describe('AnthropicDirectQuery — interrupt mid-turn then resume', () => {
     await it.return?.();
   });
 
+  it('emits exactly ONE terminal event on interrupt so the next turn is not wasted (the "poke to start" bug)', async () => {
+    // Distinct from the test above: that one drains PAST the abort error to the
+    // turn.completed, hiding the leftover-terminal bug. AgentSession's real
+    // consumer (sendMessageStreamInternal) breaks on the FIRST terminal event
+    // (`done` OR `error`, agent-session.ts). If the abort path yields BOTH an
+    // `error` and a `turn.completed`, the consumer stops on the error and the
+    // trailing turn.completed is stranded — the NEXT turn's first pull consumes
+    // it as a no-op `done`, so the user's next message runs a full turn late.
+    // That is exactly "I type a message after ESC, nothing happens, so I poke
+    // '.' to make the turn start."
+    const prompts = createPushStream<{ content: string }>();
+    let queryRef: { interrupt(): Promise<void> } | null = null;
+    let turnIdx = 0;
+
+    messagesCreateMock.mockImplementation(() => {
+      turnIdx += 1;
+      if (turnIdx === 1) {
+        return (async function* (): AsyncGenerator<RawMessageStreamEvent> {
+          await queryRef!.interrupt();
+          throw makeAbortError();
+        })();
+      }
+      return fromArray(makeTextStream('resumed reply'));
+    });
+
+    const provider = new AnthropicDirectProvider();
+    const query = provider.query({
+      prompt: prompts.iterable,
+      config: { model: 'claude-sonnet-5', apiKey: 'sk-ant-oat01-test' },
+    });
+    queryRef = query;
+    const it = (query as AsyncIterable<ProviderEvent>)[Symbol.asyncIterator]();
+
+    // session.init handshake.
+    await it.next();
+
+    // Turn 1 — drive until the FIRST terminal event, exactly as AgentSession does.
+    prompts.push({ content: 'first' });
+    const isTerminal = (t: string): boolean => t === 'turn.completed' || t === 'error';
+    let r = await it.next();
+    while (!r.done && !isTerminal((r.value as ProviderEvent).type)) {
+      r = await it.next();
+    }
+    expect(r.done).toBe(false);
+    // The aborted turn's FIRST (and only) terminal must be turn.completed — never
+    // an `error` that strands a trailing turn.completed for the next turn to eat.
+    expect((r.value as ProviderEvent).type).toBe('turn.completed');
+
+    // Turn 2 — the real message must run THIS turn, not a turn late.
+    prompts.push({ content: 'second' });
+    let assistantText = '';
+    r = await it.next();
+    while (!r.done) {
+      const ev = r.value as ProviderEvent;
+      if (ev.type === 'delta.text') assistantText += ev.text;
+      if (ev.type === 'turn.completed') break;
+      r = await it.next();
+    }
+    // No wasted turn: the model was actually called again (turnIdx===2) and the
+    // reply streamed. Pre-fix this failed — Turn 2 consumed the stranded
+    // turn.completed as a no-op and turnIdx stayed 1.
+    expect(assistantText).toContain('resumed reply');
+    expect(turnIdx).toBe(2);
+
+    prompts.close();
+    await it.return?.();
+  });
+
   it('a real (non-abort) error still terminates the generator with an error event', async () => {
     // Guards against over-correction: only interrupts keep the session alive.
     // A genuine error (no abort signal) must still surface as an `error` event

--- a/src/agent/providers/anthropic-direct/loop.ts
+++ b/src/agent/providers/anthropic-direct/loop.ts
@@ -48,6 +48,7 @@ import {
   withMessagesBreakpoint,
 } from './cache-policy.js';
 import { translateMessageStream } from './translate.js';
+import { abortableStream } from './abortable-stream.js';
 import { emitToolCall, emitSessionPhase } from '../../trace/emit.js';
 import { extractRawToolInput } from '../../facets/raw-input.js';
 import { env } from '../../../config/env.js';
@@ -450,8 +451,18 @@ export async function* runTurn(
     let ttfbEmitted = false;
     try {
       if (env.AFK_TELEGRAM_TRACE) console.log('[loop] awaiting translateMessageStream events');
+      // Race every SSE pull against the turn signal so an ESC interrupt halts
+      // the stream PROMPTLY (same event-loop turn) instead of waiting for the
+      // SDK's parked read to settle — which for a mid-stream Opus thinking
+      // response lags seconds behind the keypress (there is no per-delta abort
+      // check downstream). On abort the wrapper throws an AbortError, which
+      // `translateMessageStream`'s catch converts to an in-band `error` event;
+      // the error branch below then sees `input.signal.aborted` and breaks
+      // WITHOUT yielding, so the post-loop `turnResult === null` path emits a
+      // single clean `turn.completed`. Uses `input.signal` (the user/turn
+      // interrupt), NOT `ttfb.signal`, so the TTFB stall-timer path is untouched.
       for await (const out of translateMessageStream(
-        events as Parameters<typeof translateMessageStream>[0],
+        abortableStream(events, input.signal) as Parameters<typeof translateMessageStream>[0],
         input.ctx,
       )) {
         // First-byte boundary = the first NON-error translated output (a real
@@ -515,6 +526,24 @@ export async function* runTurn(
               !input.signal.aborted
             ) {
               retryOverload = true;
+              break;
+            }
+            // User interrupt (ESC soft-stop): translate.ts converted the abort
+            // throw into this in-band `error` event, but on an interrupt the
+            // "error" IS the abort — not a real failure. Do NOT yield it. If we
+            // did, the turn would emit TWO terminal events (this error AND the
+            // `turn.completed` from the `turnResult === null` path below), and a
+            // consumer that breaks on the FIRST terminal (AgentSession's
+            // sendMessageStreamInternal breaks on `done`|`error`) would strand
+            // the trailing turn.completed — the NEXT turn's first pull then eats
+            // it as a no-op `done`, so the user's next message runs a full turn
+            // late (the "type after ESC → nothing happens → poke '.' to start it"
+            // bug). Break WITHOUT yielding + WITHOUT setting translatorErrored so
+            // the post-loop `turnResult === null` branch emits exactly ONE
+            // terminal turn.completed. `sawProviderError` correctly stays false —
+            // an interrupt seals as cancelled, not failed. Real (non-abort)
+            // errors fall through to the yield below unchanged.
+            if (input.signal.aborted) {
               break;
             }
             yield out.event;

--- a/src/cli/terminal-compositor.input-mode.ts
+++ b/src/cli/terminal-compositor.input-mode.ts
@@ -207,15 +207,28 @@ export function setInputMode(self: InputModeHost, mode: CompositorInputMode): vo
   // buffer to an editable draft that required a SECOND explicit Enter, which
   // read as "looks like it sends but no turn starts, and I have to send again."
   //
-  // Why this is safe now: the soft-stop handler fires session.interrupt()
-  // SYNCHRONOUSLY on ESC (turn-handler.ts / run-skill-dispatch-turn.ts), so
-  // the stream halts promptly. The "perpetual input-lag-of-one" this branch
-  // previously guarded against came from the OLD deferred-interrupt window —
-  // the compositor lingered in streaming mode for a network round-trip, so
-  // every Enter queued instead of submitting and each message landed one turn
-  // late. With the synchronous interrupt that window is gone, so auto-flushing
-  // the queued buffer is just normal sequential-turn submission, not a phantom
-  // unconfirmed turn.
+  // Why this is safe now: the soft-stop handler CALLS session.interrupt()
+  // synchronously on ESC (turn-handler.ts / run-skill-dispatch-turn.ts), but
+  // interrupt() itself only fires an AbortController — it does NOT synchronously
+  // stop the model stream. Two provider-side fixes make the halt actually prompt
+  // and single-turn (without them this branch reopened the very lag it claims to
+  // close — the reason ESC "input lag" persisted across releases):
+  //   1. abortable-stream.ts races each SSE pull against the turn signal, so the
+  //      stream halts within an event-loop turn instead of lagging until the
+  //      SDK's parked read settles (seconds, for a mid-stream Opus thinking
+  //      response). Without it the turn lingered in 'streaming' and every Enter
+  //      queued instead of submitting — the "landed one turn late" symptom.
+  //   2. loop.ts suppresses the abort's in-band `error` event so an interrupted
+  //      turn emits EXACTLY ONE terminal (turn.completed). Without it the turn
+  //      emitted [error, turn.completed]; AgentSession breaks on the first, and
+  //      the stranded turn.completed was eaten by the NEXT turn's first pull as a
+  //      no-op — so the post-ESC message ran a full turn late (the "type after
+  //      ESC → nothing happens → poke to start it" bug).
+  // Caveat: a turn parked on a SUBAGENT await still tears down only after the
+  // child cancels (see the teardown-gap note in terminal-compositor.input-
+  // dispatch.ts) — but that path also ends in a single terminal, so it delays
+  // the flush without stranding a turn. With both fixes, auto-flushing the queued
+  // buffer is normal sequential-turn submission, not a phantom unconfirmed turn.
   //
   // `softStopped` is set only by ESC; its remaining roles are the second-ESC
   // no-op (handleEscape) and the idle→streaming reset above. Clearing it here


### PR DESCRIPTION
## Problem

ESC soft-stop felt laggy and **ate the user's next message** — the reported "type a message after ESC, nothing happens, so I poke `.` to make the turn start." Worst on Opus extended-thinking turns.

Diagnosed as **two independent mechanisms** (both re-derived via shadow-verify, both proven with red→green tests):

1. **Halt latency.** `interrupt()` only fires an `AbortController`; the anthropic-direct stream loop had **no per-event abort check** (`translate.ts`), so the turn kept streaming until the SDK's *parked SSE read* settled — seconds behind the keypress for a thinking stream. Turn 1 lingered in `streaming`, so the next message queued instead of submitting.
2. **Wasted turn.** On abort, `loop.ts` yielded **two** terminal events (`error` *and* `turn.completed`). `AgentSession` breaks on the first (`agent-session.ts`), stranding the `turn.completed` — which the **next** turn's first pull consumed as a no-op `done`. So the post-ESC message ran a **full turn late**; the `.` poke is what advanced it.

The compositor's post-ESC auto-flush was even documented as safe *"because interrupt is synchronous"* — a false premise that reopened the very lag it claimed to close.

## Fix

- **`abortable-stream.ts` (new):** races each SSE pull against the turn signal → the stream halts within one event-loop turn regardless of the SDK's read cadence (fixes #1).
- **`loop.ts`:** wire `abortableStream(events, input.signal)`; on abort, suppress the in-band `error` event so an interrupted turn emits **exactly one** terminal `turn.completed` (fixes #2). Real (non-abort) errors are unchanged.
- **`terminal-compositor.input-mode.ts`:** corrected the false "interrupt is synchronous" comment to describe the real (now-prompt) behavior + the remaining subagent-teardown caveat.

Uses `input.signal` (user interrupt), **not** `ttfb.signal`, so the TTFB stall-timer path is untouched.

## Tests

- `abortable-stream.test.ts` (new, 7) — load-bearing case: throws promptly on a **parked** read instead of hanging.
- `interrupt-resume.test.ts` — new regression for the leftover-terminal/wasted-turn bug (**red on old code:** `'error' ≠ 'turn.completed'`; green after).
- **Full suite: 690 files, 12,726 passed, 0 failed;** `tsc --noEmit` clean.

## Follow-ups (stacked PR)

- Halt-latency **trace event** (field telemetry for interrupt→halt).
- **openai-compatible provider parity** — its query loop has the same shape and likely both mechanisms.
