### PR TITLE
feat(contract): non-convergence stop criterion in sub-agent contract

### DIFF
--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -40,7 +40,7 @@ const PINNED_HASHES = {
   // vendored byte-equal, so no INTENTIONAL_DIFFS entry is needed. Drift row is
   // wired in UPSTREAM_PATHS below (skips until example-plugin is co-located).
   automate: '93380f58316e607f6b95b27a9c2375f0a5403f3a42eb695d0490b50225d8838c',
-  contract: 'a91fc35497b58cf7032bd6c3c8104bab2497461fa78a54370c3e88f6ff7f3545',
+  contract: '0ea822d8124f5fc55103a3e5e6d0fcb43889bf3f089bc722350da02ecf4f960f',
   // Hash re-bumped during PR #187 review: the Merge section now routes the
   // second convergence condition (≥2 critics agree on the same alternative) to
   // Wave 3.5 — prose-consistency fix only; no behavior change to the guard.

--- a/src/bundled-plugins/awa-bundled/bundled.test.ts
+++ b/src/bundled-plugins/awa-bundled/bundled.test.ts
@@ -40,7 +40,7 @@ const PINNED_HASHES = {
   // vendored byte-equal, so no INTENTIONAL_DIFFS entry is needed. Drift row is
   // wired in UPSTREAM_PATHS below (skips until example-plugin is co-located).
   automate: '93380f58316e607f6b95b27a9c2375f0a5403f3a42eb695d0490b50225d8838c',
-  contract: '748eaf01deda592913f463b23c81a6be3a89ae3b316f31f531a8488dc5bc1a7c',
+  contract: 'a91fc35497b58cf7032bd6c3c8104bab2497461fa78a54370c3e88f6ff7f3545',
   // Hash re-bumped during PR #187 review: the Merge section now routes the
   // second convergence condition (≥2 critics agree on the same alternative) to
   // Wave 3.5 — prose-consistency fix only; no behavior change to the guard.

--- a/src/bundled-plugins/awa-bundled/skills/contract/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/contract/SKILL.md
@@ -17,6 +17,8 @@ For each sub-agent you plan to dispatch, define a schema before the call:
 
 Embed the schema at the top of every sub-agent's prompt and require results in that exact shape. Instruct each sub-agent explicitly: "Return ONLY the schema fields. No preamble, no analysis prose, no explanation — begin your response with the first schema field." When sub-agents return, validate field-by-field. If any artifact is missing, malformed, or wrapped in prose, re-dispatch only the failing sub-agent with the gap cited. Merge only schema-valid responses.
 
+Also instruct each sub-agent to stop on non-convergence: if repeated attempts at the same sub-goal stop making progress after a few tries, do not keep retrying — return the best partial result via `failure_modes` with what could not be resolved. Activity is not progress.
+
 ## Epistemic confidence
 
 Recommended for all sub-agents. Add to your return schema:

--- a/src/bundled-plugins/awa-bundled/skills/contract/SKILL.md
+++ b/src/bundled-plugins/awa-bundled/skills/contract/SKILL.md
@@ -17,7 +17,7 @@ For each sub-agent you plan to dispatch, define a schema before the call:
 
 Embed the schema at the top of every sub-agent's prompt and require results in that exact shape. Instruct each sub-agent explicitly: "Return ONLY the schema fields. No preamble, no analysis prose, no explanation — begin your response with the first schema field." When sub-agents return, validate field-by-field. If any artifact is missing, malformed, or wrapped in prose, re-dispatch only the failing sub-agent with the gap cited. Merge only schema-valid responses.
 
-Also instruct each sub-agent to stop on non-convergence: if repeated attempts at the same sub-goal stop making progress after a few tries, do not keep retrying — return the best partial result via `failure_modes` with what could not be resolved. Activity is not progress.
+Also instruct each sub-agent to stop on non-convergence: if repeated attempts at the same sub-goal stop making progress after a few tries, do not keep retrying — return the best partial result through the schema's designated failure/partial channel (`failure_modes`, or whatever blocked/`unverified` field that agent's schema defines), naming what could not be resolved. Activity is not progress.
 
 ## Epistemic confidence
 

--- a/src/skills/_agents/prompts/contract.md
+++ b/src/skills/_agents/prompts/contract.md
@@ -16,6 +16,8 @@ For each sub-agent you plan to dispatch, define a schema before the call:
 
 Embed the schema at the top of every sub-agent's prompt and require results in that exact shape. Instruct each sub-agent explicitly: "Return ONLY the schema fields. No preamble, no analysis prose, no explanation — begin your response with the first schema field." When sub-agents return, validate field-by-field. If any artifact is missing, malformed, or wrapped in prose, re-dispatch only the failing sub-agent with the gap cited. Merge only schema-valid responses.
 
+Also instruct each sub-agent to stop on non-convergence: if repeated attempts at the same sub-goal stop making progress after a few tries, do not keep retrying — return the best partial result via `failure_modes` with what could not be resolved. Activity is not progress.
+
 ## Epistemic confidence
 
 Recommended for all sub-agents. Add to your return schema:

--- a/src/skills/_agents/prompts/contract.md
+++ b/src/skills/_agents/prompts/contract.md
@@ -16,7 +16,7 @@ For each sub-agent you plan to dispatch, define a schema before the call:
 
 Embed the schema at the top of every sub-agent's prompt and require results in that exact shape. Instruct each sub-agent explicitly: "Return ONLY the schema fields. No preamble, no analysis prose, no explanation — begin your response with the first schema field." When sub-agents return, validate field-by-field. If any artifact is missing, malformed, or wrapped in prose, re-dispatch only the failing sub-agent with the gap cited. Merge only schema-valid responses.
 
-Also instruct each sub-agent to stop on non-convergence: if repeated attempts at the same sub-goal stop making progress after a few tries, do not keep retrying — return the best partial result via `failure_modes` with what could not be resolved. Activity is not progress.
+Also instruct each sub-agent to stop on non-convergence: if repeated attempts at the same sub-goal stop making progress after a few tries, do not keep retrying — return the best partial result through the schema's designated failure/partial channel (`failure_modes`, or whatever blocked/`unverified` field that agent's schema defines), naming what could not be resolved. Activity is not progress.
 
 ## Epistemic confidence
 

--- a/src/skills/_agents/vendored.test.ts
+++ b/src/skills/_agents/vendored.test.ts
@@ -11,7 +11,7 @@ const __dirname = dirname(__filename);
 // Pinned hashes — guard against undocumented edits to the vendored copy
 const PINNED_HASHES = {
   'research-agent': '80993a5f28dbcc9fd447a5bf022fc2ae14307d4af21fcaa0900a0b135515db0a',
-  contract: '623bae5adafb8fb995e88114540a9603ed38ab9c5b075e13d54d7bd11e8b2ccb',
+  contract: 'a5e3cbd6cc71ecb45afe677ecaaf95768cf2545fdb616e6b8f57c8ff5db4df4b',
   'git-investigator': 'd1f186b82574641a4cb616990cee70a36f95a109b3688f59c07d12d26de60c03',
 } as const;
 

--- a/src/skills/_agents/vendored.test.ts
+++ b/src/skills/_agents/vendored.test.ts
@@ -11,7 +11,7 @@ const __dirname = dirname(__filename);
 // Pinned hashes — guard against undocumented edits to the vendored copy
 const PINNED_HASHES = {
   'research-agent': '80993a5f28dbcc9fd447a5bf022fc2ae14307d4af21fcaa0900a0b135515db0a',
-  contract: '0b7febafec024e8dd4404f75e84d21ee72b1b1846d6e2610aaa82ba77f9d6f2d',
+  contract: '623bae5adafb8fb995e88114540a9603ed38ab9c5b075e13d54d7bd11e8b2ccb',
   'git-investigator': 'd1f186b82574641a4cb616990cee70a36f95a109b3688f59c07d12d26de60c03',
 } as const;
 


### PR DESCRIPTION
## What

Adds a non-convergence **stop criterion** to the sub-agent `/contract` convention (a new paragraph after the "Instruct each sub-agent explicitly" directive, tied to the existing `failure_modes` field):

> Also instruct each sub-agent to stop on non-convergence: if repeated attempts at the same sub-goal stop making progress after a few tries, do not keep retrying — return the best partial result via `failure_modes` with what could not be resolved. Activity is not progress.

Applied to both in-repo copies (kept byte-identical): `src/bundled-plugins/awa-bundled/skills/contract/SKILL.md` and `src/skills/_agents/prompts/contract.md`, with the two pinned hashes bumped (`bundled.test.ts`, `vendored.test.ts`).

## Why

`/contract` is loaded by the orchestration skills (review, devils-advocate, shadow-verify, research, refactor, ship, …) and its directives get baked into the dispatch prompts those orchestrators write. So this clause reaches the **orchestration-dispatched research-agent leaves** — the population that actually trapped in the #669 incident (review dimension agents verifying citations) — a population the `general-purpose`-prompt convergence clause (#675) does **not** reach.

Layer map for the "trapped subagent" root cause (agents have an activity signal but no convergence signal):
- `general-purpose` prompt (#675) — direct/ad-hoc `general-purpose` dispatches.
- **This PR (`/contract`)** — orchestration-dispatched leaves, via the orchestrator's dispatch prompt.
- Both pair with the mechanical bounds: the `general-purpose` round cap (#673) and the idle watchdog (#672).

It's a soft (prompt-compliance) signal by nature — the same mechanism that already makes critics return the contract's I/O schema.

## Companion change

The identical clause is mirrored into the upstream `awa-private` marketplace (`plugins/awa-dev/skills/contract/SKILL.md`) in a companion PR — byte-identical (verified: same sha256 across all three copies), so the bundled↔upstream drift comparison stays clean. The afk-workshop (private superset) vendored copy is the remaining routine mirror.

## Test / verification

- `pnpm lint` — PASS
- `pnpm test src/bundled-plugins/awa-bundled/bundled.test.ts` — 17 passed / 12 skipped (drift-comparison skips: `example-plugin` not co-located; the pinned-hash guard still runs)
- `pnpm test src/skills/_agents/vendored.test.ts` — 20 passed
- Full `pnpm test` — 12718 passed / 14 skipped / 0 failed (689 files)
- The two contract copies still differ only by the pre-existing `context: load` frontmatter line.
