### PR TITLE
feat(telegram): per-target chat selection for send_telegram + scheduled tasks

### DIFF
--- a/docs/env-registry.json
+++ b/docs/env-registry.json
@@ -1079,10 +1079,10 @@
     },
     {
       "name": "TELEGRAM_VERBOSE",
-      "description": "Set to 1 to log per-message details from the Telegram bot — chat IDs, message text, latency.",
+      "description": "Set to 'true' to log per-message details from the Telegram bot — chat IDs, message text, latency. (The code checks the literal string 'true'.)",
       "type": "boolean",
       "required": false,
-      "example": "1",
+      "example": "true",
       "category": "telegram"
     },
     {

--- a/docs/env-registry.md
+++ b/docs/env-registry.md
@@ -78,7 +78,7 @@ To add a var: edit `src/config/env.ts` (add a getter on `env` + an entry in `ENV
 | `AFK_TELEGRAM_TAG_ONLY_CHAT_IDS` | string |  |  | `-100987654321,123456789` | Comma-separated list of Telegram chat IDs where the bot answers only when addressed (a reply to the bot, an @mention of the bot, or a text_mention resolving to the bot). Slash-commands are unaffected; chats not listed behave as usual. The afk.config.json telegram.tagOnlyChats block takes precedence. Requires Telegram privacy mode OFF (BotFather /setprivacy Disable) for non-addressed group messages to reach the bot. |
 | `TELEGRAM_BOT_TOKEN` | string |  |  |  | Telegram bot token from @BotFather. Required to run the Telegram bot surface. |
 | `TELEGRAM_DATA_DIR` | string |  |  |  | Override the directory where Telegram bot state is stored. Defaults to ~/.afk/state/telegram/. |
-| `TELEGRAM_VERBOSE` | boolean |  |  | `1` | Set to 1 to log per-message details from the Telegram bot — chat IDs, message text, latency. |
+| `TELEGRAM_VERBOSE` | boolean |  |  | `true` | Set to 'true' to log per-message details from the Telegram bot — chat IDs, message text, latency. (The code checks the literal string 'true'.) |
 
 ## Paths
 

--- a/src/agent/daemon.test.ts
+++ b/src/agent/daemon.test.ts
@@ -722,6 +722,66 @@ describe('POST /tasks and DELETE /tasks/:id routes', () => {
     expect(res.status).toBe(400);
   });
 
+  it('POST /tasks preserves a numeric notifyChat through GET /tasks', async () => {
+    const h = await spinDaemon();
+    const res = await fetch(`http://localhost:${h.port}/tasks`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        taskId: 'nc-task',
+        command: '/cmd',
+        cron: '* * * * *',
+        notifyChat: -1001234567890,
+      }),
+    });
+    expect(res.status).toBe(201);
+
+    const listRes = await fetch(`http://localhost:${h.port}/tasks`);
+    const tasks = (await listRes.json()) as Array<{ taskId: string; notifyChat?: number | string }>;
+    const task = tasks.find((t) => t.taskId === 'nc-task');
+    expect(task?.notifyChat).toBe(-1001234567890);
+  });
+
+  it('POST /tasks preserves a string (alias) notifyChat', async () => {
+    const h = await spinDaemon();
+    const res = await fetch(`http://localhost:${h.port}/tasks`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        taskId: 'nc-alias-task',
+        command: '/cmd',
+        cron: '* * * * *',
+        notifyChat: 'ops',
+      }),
+    });
+    expect(res.status).toBe(201);
+
+    const listRes = await fetch(`http://localhost:${h.port}/tasks`);
+    const tasks = (await listRes.json()) as Array<{ taskId: string; notifyChat?: number | string }>;
+    const task = tasks.find((t) => t.taskId === 'nc-alias-task');
+    expect(task?.notifyChat).toBe('ops');
+  });
+
+  it('POST /tasks ignores a non-number/non-string notifyChat (default routing)', async () => {
+    const h = await spinDaemon();
+    const res = await fetch(`http://localhost:${h.port}/tasks`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        taskId: 'nc-bad-task',
+        command: '/cmd',
+        cron: '* * * * *',
+        notifyChat: { nope: true },
+      }),
+    });
+    expect(res.status).toBe(201);
+
+    const listRes = await fetch(`http://localhost:${h.port}/tasks`);
+    const tasks = (await listRes.json()) as Array<{ taskId: string; notifyChat?: number | string }>;
+    const task = tasks.find((t) => t.taskId === 'nc-bad-task');
+    expect(task?.notifyChat).toBeUndefined();
+  });
+
   it('DELETE /tasks/:id for registered task → 200', async () => {
     const h = await spinDaemon();
     // Register first
@@ -835,6 +895,106 @@ describe('notifyOn filter in CronScheduler', () => {
     await scheduler.tick('t');
 
     expect(callback).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('notifyChat threading in CronScheduler', () => {
+  let telemetryPath: string;
+  let scheduler: CronScheduler;
+
+  beforeEach(() => {
+    telemetryPath = tmpTelemetryFile();
+  });
+
+  afterEach(async () => {
+    await scheduler.stop();
+    rmSync(telemetryPath, { force: true });
+  });
+
+  it("threads the task's numeric notifyChat onto TaskCompletionDetails", async () => {
+    const callback = vi.fn();
+    scheduler = new CronScheduler({
+      telemetryPath,
+      onTaskComplete: callback,
+      sessionFactory: (_config: AgentConfig) =>
+        makeFakeSession('ok') as unknown as ReturnType<SessionFactoryReturn>,
+    });
+    scheduler.register({
+      taskId: 't',
+      command: 'x',
+      trigger: 'cron',
+      cronExpression: '* * * * *',
+      notifyChat: -1001234567890,
+    });
+    await scheduler.tick('t');
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    const details = callback.mock.calls[0]![1] as { notifyChat?: number | string } | undefined;
+    expect(details?.notifyChat).toBe(-1001234567890);
+  });
+
+  it("threads the task's string (alias) notifyChat onto TaskCompletionDetails", async () => {
+    const callback = vi.fn();
+    scheduler = new CronScheduler({
+      telemetryPath,
+      onTaskComplete: callback,
+      sessionFactory: (_config: AgentConfig) =>
+        makeFakeSession('ok') as unknown as ReturnType<SessionFactoryReturn>,
+    });
+    scheduler.register({
+      taskId: 't',
+      command: 'x',
+      trigger: 'cron',
+      cronExpression: '* * * * *',
+      notifyChat: 'ops',
+    });
+    await scheduler.tick('t');
+
+    const details = callback.mock.calls[0]![1] as { notifyChat?: number | string } | undefined;
+    expect(details?.notifyChat).toBe('ops');
+  });
+
+  it('leaves notifyChat undefined when the task has none (default routing)', async () => {
+    const callback = vi.fn();
+    scheduler = new CronScheduler({
+      telemetryPath,
+      onTaskComplete: callback,
+      sessionFactory: (_config: AgentConfig) =>
+        makeFakeSession('ok') as unknown as ReturnType<SessionFactoryReturn>,
+    });
+    scheduler.register({
+      taskId: 't',
+      command: 'x',
+      trigger: 'cron',
+      cronExpression: '* * * * *',
+    });
+    await scheduler.tick('t');
+
+    const details = callback.mock.calls[0]![1] as { notifyChat?: number | string } | undefined;
+    expect(details?.notifyChat).toBeUndefined();
+  });
+
+  it('threads notifyChat on the error path too', async () => {
+    const callback = vi.fn();
+    scheduler = new CronScheduler({
+      telemetryPath,
+      onTaskComplete: callback,
+      sessionFactory: (_config: AgentConfig) =>
+        makeFakeSession(new Error('boom')) as unknown as ReturnType<SessionFactoryReturn>,
+    });
+    scheduler.register({
+      taskId: 't',
+      command: 'x',
+      trigger: 'cron',
+      cronExpression: '* * * * *',
+      notifyChat: 555,
+    });
+    await scheduler.tick('t');
+
+    const record = callback.mock.calls[0]![0] as { status: string };
+    const details = callback.mock.calls[0]![1] as { notifyChat?: number | string } | undefined;
+    expect(record.status).toBe('error');
+    expect(details?.notifyChat).toBe(555);
   });
 });
 

--- a/src/agent/daemon.ts
+++ b/src/agent/daemon.ts
@@ -261,6 +261,7 @@ async function handleRequestAsync(
       );
       return;
     }
+    const notifyChatRaw = obj['notifyChat'];
     const task: ScheduledTask = {
       taskId: obj['taskId'] as string,
       command: obj['command'] as string,
@@ -268,6 +269,9 @@ async function handleRequestAsync(
       cronExpression: cronValue,
       ...(obj['notifyOn'] !== undefined
         ? { notifyOn: obj['notifyOn'] as ScheduledTask['notifyOn'] }
+        : {}),
+      ...(typeof notifyChatRaw === 'number' || typeof notifyChatRaw === 'string'
+        ? { notifyChat: notifyChatRaw }
         : {}),
     };
     try {

--- a/src/agent/daemon/schedule-store.test.ts
+++ b/src/agent/daemon/schedule-store.test.ts
@@ -180,6 +180,45 @@ describe('addSchedule', () => {
     const loaded = loadSchedules(path);
     expect(loaded[0]?.notifyOn).toBe('always');
   });
+
+  it('round-trips a numeric notifyChat', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'schedule-store-'));
+    const path = join(tmpDir, 'schedules.json');
+    const config = addSchedule(
+      { name: 'Group Task', command: '/cmd', cron: '* * * * *', enabled: true, notifyChat: -1001234567890 },
+      path,
+    );
+
+    expect(config.notifyChat).toBe(-1001234567890);
+    const loaded = loadSchedules(path);
+    expect(loaded[0]?.notifyChat).toBe(-1001234567890);
+  });
+
+  it('round-trips a string (alias) notifyChat', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'schedule-store-'));
+    const path = join(tmpDir, 'schedules.json');
+    const config = addSchedule(
+      { name: 'Ops Task', command: '/cmd', cron: '* * * * *', enabled: true, notifyChat: 'ops' },
+      path,
+    );
+
+    expect(config.notifyChat).toBe('ops');
+    const loaded = loadSchedules(path);
+    expect(loaded[0]?.notifyChat).toBe('ops');
+  });
+
+  it('omits notifyChat when not provided (default routing)', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'schedule-store-'));
+    const path = join(tmpDir, 'schedules.json');
+    const config = addSchedule(
+      { name: 'Default Task', command: '/cmd', cron: '* * * * *', enabled: true },
+      path,
+    );
+
+    expect(config.notifyChat).toBeUndefined();
+    const loaded = loadSchedules(path);
+    expect(loaded[0]?.notifyChat).toBeUndefined();
+  });
 });
 
 // ── removeSchedule ───────────────────────────────────────────────────────────
@@ -285,6 +324,50 @@ describe('toScheduledTask', () => {
     };
     const task = toScheduledTask(config);
     expect((task as { notifyOn?: string }).notifyOn).toBe('failure');
+  });
+
+  it('maps a numeric notifyChat when present', () => {
+    const config: ScheduledTaskConfig = {
+      id: 'nc-num',
+      name: 'NC Num',
+      command: '/nc',
+      cron: '* * * * *',
+      enabled: true,
+      notifyChat: -100777,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    const task = toScheduledTask(config);
+    expect(task.notifyChat).toBe(-100777);
+  });
+
+  it('maps a string (alias) notifyChat when present', () => {
+    const config: ScheduledTaskConfig = {
+      id: 'nc-alias',
+      name: 'NC Alias',
+      command: '/nc',
+      cron: '* * * * *',
+      enabled: true,
+      notifyChat: 'family',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    const task = toScheduledTask(config);
+    expect(task.notifyChat).toBe('family');
+  });
+
+  it('omits notifyChat when absent', () => {
+    const config: ScheduledTaskConfig = {
+      id: 'nc-none',
+      name: 'NC None',
+      command: '/nc',
+      cron: '* * * * *',
+      enabled: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    const task = toScheduledTask(config);
+    expect('notifyChat' in task).toBe(false);
   });
 
   it('saveSchedules + loadSchedules round-trips correctly', () => {

--- a/src/agent/daemon/schedule-store.ts
+++ b/src/agent/daemon/schedule-store.ts
@@ -42,6 +42,14 @@ export interface ScheduledTaskConfig {
    * Omitting preserves legacy behavior (callback always fires).
    */
   notifyOn?: 'failure' | 'always' | 'never';
+  /**
+   * Optional explicit chat target for this task's completion notification.
+   * A number is a raw Telegram chat id; a string is either a numeric id or a
+   * name resolved via afk.config.json `telegram.chatAliases`. Threaded through
+   * to `ScheduledTask.notifyChat`; the daemon resolves + allowlist-gates it at
+   * completion-push time. Omitting it preserves default routing.
+   */
+  notifyChat?: number | string;
   /** ISO 8601 creation timestamp. */
   createdAt: string;
   /** ISO 8601 last-update timestamp. */
@@ -178,5 +186,6 @@ export function toScheduledTask(config: ScheduledTaskConfig): ScheduledTask {
     trigger: config.trigger ?? 'cron',
     ...(config.cron !== undefined ? { cronExpression: config.cron } : {}),
     ...(config.notifyOn !== undefined ? { notifyOn: config.notifyOn } : {}),
+    ...(config.notifyChat !== undefined ? { notifyChat: config.notifyChat } : {}),
   };
 }

--- a/src/agent/daemon/scheduler.ts
+++ b/src/agent/daemon/scheduler.ts
@@ -175,6 +175,17 @@ export interface TaskCompletionDetails {
    * `src/cli/commands/daemon.ts`. Never persisted to telemetry.
    */
   doneUnverified?: boolean;
+  /**
+   * Explicit chat target for this task's completion notification, copied from
+   * the triggering `ScheduledTask.notifyChat`. A number is a raw chat id; a
+   * string is a numeric id or an alias name (resolved by the CLI push wiring
+   * against `telegram.chatAliases`). The scheduler itself does NOT resolve or
+   * validate it — routing/allowlist enforcement lives in the injected
+   * `onTaskComplete` callback (`src/cli/commands/daemon.ts`), preserving the
+   * `src/agent/` → no-`src/cli/`-import layering invariant. Absent when the task
+   * has no `notifyChat` (default routing). Never persisted to telemetry.
+   */
+  notifyChat?: number | string;
 }
 
 interface RegisteredEntry {
@@ -702,10 +713,20 @@ export class CronScheduler {
       if (task.notifyOn === 'failure' && record.status !== 'error') return;
       // 'always' or undefined (legacy behavior) falls through
     }
+    // Thread the task's explicit chat target (if any) onto the details so the
+    // injected callback can route the push. Merged here — rather than at every
+    // writeTelemetry call site — because this is the single funnel every
+    // completion path flows through, and the scheduler must not resolve/validate
+    // the target itself (layering: no src/cli import). An explicit
+    // details.notifyChat (should never happen today) is preserved.
+    const effectiveDetails: TaskCompletionDetails | undefined =
+      task?.notifyChat !== undefined
+        ? { ...(details ?? {}), notifyChat: details?.notifyChat ?? task.notifyChat }
+        : details;
     // Fire-and-forget. Notification callbacks must not block telemetry
     // writes or crash the scheduler — every error is swallowed and logged.
     try {
-      const result = cb(record, details);
+      const result = cb(record, effectiveDetails);
       if (result instanceof Promise) {
         void result.catch((err: unknown) => {
           const msg = err instanceof Error ? err.message : String(err);

--- a/src/agent/daemon/triggers.ts
+++ b/src/agent/daemon/triggers.ts
@@ -39,6 +39,19 @@ export interface ScheduledTask {
    * Omitting this field preserves existing behavior (callback always fires).
    */
   notifyOn?: 'failure' | 'always' | 'never';
+  /**
+   * Optional explicit chat target for this task's completion notification.
+   * A number is a raw Telegram chat id; a string is either a numeric id or a
+   * name looked up in afk.config.json `telegram.chatAliases`. When set (and
+   * allowlisted), the daemon delivers this task's completion push to THIS chat
+   * instead of the configured default notify target. When omitted, routing is
+   * unchanged (resolveConfiguredNotifyTargets). The resolved chat must be in the
+   * inbound allowlist or the override is refused and delivery falls back to the
+   * default — see the daemon `onTaskComplete` wiring in
+   * `src/cli/commands/daemon.ts`. Independent of `notifyOn` (which only decides
+   * WHETHER to notify; this decides WHERE).
+   */
+  notifyChat?: number | string;
 }
 
 /**

--- a/src/agent/tools/handlers/schedules.ts
+++ b/src/agent/tools/handlers/schedules.ts
@@ -57,6 +57,14 @@ export const createScheduleHandler: ToolHandler = async (input, _signal) => {
     };
   }
 
+  const notifyChat = obj['notifyChat'];
+  if (notifyChat !== undefined && typeof notifyChat !== 'number' && typeof notifyChat !== 'string') {
+    return {
+      content: 'Invalid input: notifyChat must be a number (chat id) or string (chat id or alias name)',
+      isError: true,
+    };
+  }
+
   const config = addSchedule({
     name: obj['name'] as string,
     command: obj['command'] as string,
@@ -64,6 +72,7 @@ export const createScheduleHandler: ToolHandler = async (input, _signal) => {
     trigger:
       (obj['trigger'] as 'cron' | 'sessionstart' | 'both' | undefined) ?? 'cron',
     notifyOn: obj['notifyOn'] as 'failure' | 'always' | 'never' | undefined,
+    ...(notifyChat !== undefined ? { notifyChat: notifyChat as number | string } : {}),
     enabled: typeof obj['enabled'] === 'boolean' ? obj['enabled'] : true,
   });
 
@@ -78,6 +87,7 @@ export const createScheduleHandler: ToolHandler = async (input, _signal) => {
         cron: config.cron,
         trigger: config.trigger,
         notifyOn: config.notifyOn,
+        ...(config.notifyChat !== undefined ? { notifyChat: config.notifyChat } : {}),
       })
     : await trySyncToDaemon('DELETE', `/tasks/${config.id}`);
 

--- a/src/agent/tools/handlers/send-telegram.test.ts
+++ b/src/agent/tools/handlers/send-telegram.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createSendTelegramHandler } from './send-telegram.js';
 import type { PushOptions, PushResult } from '../../../telegram/push.js';
+import { loadTelegramConfig } from '../../../cli/config.js';
 
 // loadTelegramConfig reads afk.config.json; mock it so target resolution is
 // driven purely by the env vars the harness sets (hermetic). The pure resolver
-// is exhaustively covered in src/telegram/notify-routing.test.ts.
+// is exhaustively covered in src/telegram/notify-routing.test.ts. The mock is
+// per-test-overridable so we can inject telegram.chatAliases for alias tests.
 vi.mock('../../../cli/config.js', () => ({ loadTelegramConfig: vi.fn(() => ({})) }));
+
+const mockLoadTelegramConfig = vi.mocked(loadTelegramConfig);
 
 type PushFn = (options: PushOptions) => Promise<PushResult>;
 
@@ -21,11 +25,17 @@ function makeHarness(opts: {
   allowed?: string;
   /** Sets AFK_TELEGRAM_NOTIFY_MODE — `broadcast` restores the legacy fan-out. */
   mode?: string;
+  /** Injected telegram.chatAliases (name → chat id) for alias-resolution tests. */
+  aliases?: Record<string, number>;
   pushFn?: PushFn;
 } = {}) {
   setOrDelete('TELEGRAM_BOT_TOKEN', opts.token);
   setOrDelete('AFK_TELEGRAM_ALLOWED_CHAT_IDS', opts.allowed);
   setOrDelete('AFK_TELEGRAM_NOTIFY_MODE', opts.mode);
+
+  mockLoadTelegramConfig.mockReturnValue(
+    opts.aliases !== undefined ? { chatAliases: opts.aliases } : {},
+  );
 
   const pushFn = vi.fn<PushFn>(opts.pushFn ?? (async () => OK_RESULT));
   const handler = createSendTelegramHandler(pushFn);
@@ -46,10 +56,12 @@ describe('send_telegram handler', () => {
       orig[k] = process.env[k];
       delete process.env[k];
     }
+    mockLoadTelegramConfig.mockReturnValue({});
   });
 
   afterEach(() => {
     for (const k of ENV_KEYS) setOrDelete(k, orig[k]);
+    vi.clearAllMocks();
   });
 
   const signal = new AbortController().signal;
@@ -161,6 +173,96 @@ describe('send_telegram handler', () => {
       expect(r.isError).toBeUndefined();
       expect(pushFn).toHaveBeenCalledOnce();
       expect(pushFn).toHaveBeenCalledWith({ token: 't', chatId: -100123, text: 'group ping' });
+    });
+  });
+
+  describe('per-call chat targeting', () => {
+    it('rejects a chat that is neither number nor string', async () => {
+      const { handler, pushFn } = makeHarness({ token: 't', allowed: '111' });
+      const r = await handler({ message: 'hi', chat: { id: 1 } }, signal);
+      expect(r.isError).toBe(true);
+      expect(r.content).toMatch(/chat must be a number/);
+      expect(pushFn).not.toHaveBeenCalled();
+    });
+
+    it('sends to an explicit numeric chat id when allowlisted', async () => {
+      const { handler, pushFn } = makeHarness({ token: 't', allowed: '111,222,333' });
+      const r = await handler({ message: 'to 222', chat: 222 }, signal);
+      expect(r.isError).toBeUndefined();
+      expect(pushFn).toHaveBeenCalledOnce();
+      expect(pushFn).toHaveBeenCalledWith({ token: 't', chatId: 222, text: 'to 222' });
+      expect(r.content).toMatch(/Sent Telegram message to chat 222/);
+    });
+
+    it('accepts a numeric STRING chat id', async () => {
+      const { handler, pushFn } = makeHarness({ token: 't', allowed: '111,-100999' });
+      const r = await handler({ message: 'to group', chat: '-100999' }, signal);
+      expect(r.isError).toBeUndefined();
+      expect(pushFn).toHaveBeenCalledWith({ token: 't', chatId: -100999, text: 'to group' });
+    });
+
+    it('resolves a chat ALIAS from telegram.chatAliases', async () => {
+      const { handler, pushFn } = makeHarness({
+        token: 't',
+        allowed: '111,-1001234567890',
+        aliases: { ops: -1001234567890 },
+      });
+      const r = await handler({ message: 'alert ops', chat: 'ops' }, signal);
+      expect(r.isError).toBeUndefined();
+      expect(pushFn).toHaveBeenCalledOnce();
+      expect(pushFn).toHaveBeenCalledWith({ token: 't', chatId: -1001234567890, text: 'alert ops' });
+    });
+
+    it('errors on an unresolvable alias and lists the available names', async () => {
+      const { handler, pushFn } = makeHarness({
+        token: 't',
+        allowed: '111',
+        aliases: { ops: -100200, family: 999 },
+      });
+      const r = await handler({ message: 'x', chat: 'nope' }, signal);
+      expect(r.isError).toBe(true);
+      expect(r.content).toMatch(/Unknown chat alias "nope"/);
+      expect(r.content).toMatch(/ops/);
+      expect(r.content).toMatch(/family/);
+      expect(pushFn).not.toHaveBeenCalled();
+    });
+
+    it('FAILS CLOSED: rejects a numeric chat NOT in the allowlist', async () => {
+      const { handler, pushFn } = makeHarness({ token: 't', allowed: '111,222' });
+      const r = await handler({ message: 'x', chat: 999 }, signal);
+      expect(r.isError).toBe(true);
+      expect(r.content).toMatch(/chat 999 is not in the allowlist/);
+      expect(r.content).toMatch(/111, 222/);
+      expect(pushFn).not.toHaveBeenCalled();
+    });
+
+    it('FAILS CLOSED: rejects an alias that resolves to a non-allowlisted chat', async () => {
+      const { handler, pushFn } = makeHarness({
+        token: 't',
+        allowed: '111',
+        aliases: { rogue: -100500 },
+      });
+      const r = await handler({ message: 'x', chat: 'rogue' }, signal);
+      expect(r.isError).toBe(true);
+      expect(r.content).toMatch(/chat -100500 is not in the allowlist/);
+      expect(pushFn).not.toHaveBeenCalled();
+    });
+
+    it('does NOT re-gate default routing: omitted chat behaves identically to legacy', async () => {
+      // Broadcast (custom-style fan-out) is allowlist-independent by design; the
+      // fail-closed gate only applies to an EXPLICIT chat target.
+      const { handler, pushFn } = makeHarness({ token: 't', allowed: '111,222,333', mode: 'broadcast' });
+      const r = await handler({ message: 'ping' }, signal);
+      expect(r.isError).toBeUndefined();
+      expect(pushFn).toHaveBeenCalledTimes(3);
+    });
+
+    it('explicit chat overrides broadcast mode (single send, not fan-out)', async () => {
+      const { handler, pushFn } = makeHarness({ token: 't', allowed: '111,222,333', mode: 'broadcast' });
+      const r = await handler({ message: 'just 222', chat: 222 }, signal);
+      expect(r.isError).toBeUndefined();
+      expect(pushFn).toHaveBeenCalledOnce();
+      expect(pushFn).toHaveBeenCalledWith({ token: 't', chatId: 222, text: 'just 222' });
     });
   });
 

--- a/src/agent/tools/handlers/send-telegram.ts
+++ b/src/agent/tools/handlers/send-telegram.ts
@@ -11,7 +11,12 @@
 import { env } from '../../../config/env.js';
 import { push, type PushOptions, type PushResult } from '../../../telegram/push.js';
 import type { ToolHandler } from '../types.js';
-import { resolveConfiguredNotifyTargets } from '../../../telegram/notify-routing.js';
+import {
+  resolveConfiguredNotifyTargets,
+  resolveChatTarget,
+  loadChatAliases,
+} from '../../../telegram/notify-routing.js';
+import { parseAllowedChatIds, isChatAllowed } from '../../../telegram/allowlist.js';
 
 const TELEGRAM_MAX_MESSAGE_LENGTH = 4096;
 
@@ -27,9 +32,17 @@ export function createSendTelegramHandler(
 
     const obj = input as Record<string, unknown>;
     const message = obj['message'];
+    const chat = obj['chat'];
 
     if (typeof message !== 'string') {
       return { content: 'Invalid input: message must be a string', isError: true };
+    }
+
+    if (chat !== undefined && typeof chat !== 'number' && typeof chat !== 'string') {
+      return {
+        content: 'Invalid input: chat must be a number (chat id) or string (chat id or alias name)',
+        isError: true,
+      };
     }
 
     if (message.length === 0) {
@@ -55,7 +68,38 @@ export function createSendTelegramHandler(
       };
     }
 
-    const targets = resolveConfiguredNotifyTargets();
+    // Target resolution.
+    //   - `chat` omitted → default routing (byte-identical to legacy behavior):
+    //     resolveConfiguredNotifyTargets() (primary/broadcast/custom).
+    //   - `chat` present → resolve the alias/number to a single id, then
+    //     FAIL-CLOSED against the inbound allowlist. This gate does NOT apply to
+    //     the default path, so custom-mode broadcast targets keep their
+    //     intentional allowlist-independence.
+    let targets: number[];
+    if (chat !== undefined) {
+      const resolved = resolveChatTarget(chat, loadChatAliases());
+      if (!resolved.ok) {
+        return { content: resolved.message, isError: true };
+      }
+      const allowlist = parseAllowedChatIds(env.AFK_TELEGRAM_ALLOWED_CHAT_IDS);
+      if (!isChatAllowed(resolved.id, allowlist)) {
+        const allowed = [...allowlist];
+        return {
+          content:
+            `Refusing to send: chat ${resolved.id} is not in the allowlist ` +
+            `(AFK_TELEGRAM_ALLOWED_CHAT_IDS). ` +
+            (allowed.length > 0
+              ? `Allowed chat id(s): ${allowed.join(', ')}. `
+              : 'The allowlist is empty or unset. ') +
+            'Add the chat id to the allowlist before targeting it.',
+          isError: true,
+        };
+      }
+      targets = [resolved.id];
+    } else {
+      targets = resolveConfiguredNotifyTargets();
+    }
+
     if (targets.length === 0) {
       return {
         content:

--- a/src/agent/tools/schemas.ts
+++ b/src/agent/tools/schemas.ts
@@ -230,7 +230,12 @@ export const sendTelegramTool: AnthropicToolDef = {
     'Use sparingly: this is a real push notification to a human. Reserve for terminal states ' +
     '(Done/Blocked/Asking) and material progress, not running commentary. ' +
     'When running inside the Telegram bot, prefer replying normally — your response already ' +
-    'reaches the operator through the bot. Use this tool only from CLI or daemon sessions.',
+    'reaches the operator through the bot. Use this tool only from CLI or daemon sessions.\n\n' +
+    'Optionally set `chat` to route to a SPECIFIC chat instead of the default primary target: ' +
+    'pass a numeric chat id (e.g. -1001234567890 for a group) or a chat alias name defined in ' +
+    'afk.config.json `telegram.chatAliases` (e.g. "ops"). An explicitly-targeted chat must be ' +
+    'in the inbound allowlist (AFK_TELEGRAM_ALLOWED_CHAT_IDS) — a non-allowlisted target is ' +
+    'rejected (fail-closed). Omit `chat` for the default behavior (unchanged).',
   input_schema: {
     type: 'object',
     properties: {
@@ -239,6 +244,15 @@ export const sendTelegramTool: AnthropicToolDef = {
         description:
           'Plain-text message body to send to the operator. ' +
           'Max 4096 characters (Telegram API limit). Must be non-empty.',
+      },
+      chat: {
+        type: ['number', 'string'],
+        description:
+          'Optional. Target a specific chat instead of the default primary target. ' +
+          'A number (or numeric string) is a raw Telegram chat id; a non-numeric string is ' +
+          'looked up as a name in afk.config.json `telegram.chatAliases`. The resolved chat ' +
+          'must be allowlisted (AFK_TELEGRAM_ALLOWED_CHAT_IDS) or the send is rejected. ' +
+          'Omit to send to the configured default (primary DM chat / notify targets).',
       },
     },
     required: ['message'],
@@ -573,6 +587,15 @@ export const createScheduleTool: AnthropicToolDef = {
         type: 'string',
         enum: ['failure', 'always', 'never'],
         description: 'When to push Telegram notifications. Default: failure.',
+      },
+      notifyChat: {
+        type: ['number', 'string'],
+        description:
+          'Optional. Route this task\'s completion notification to a SPECIFIC chat instead of ' +
+          'the default primary target. A number (or numeric string) is a raw Telegram chat id; ' +
+          'a non-numeric string is a chat alias name from afk.config.json `telegram.chatAliases`. ' +
+          'The resolved chat must be allowlisted (AFK_TELEGRAM_ALLOWED_CHAT_IDS) — otherwise the ' +
+          'daemon ignores the override and uses the default target. Omit for default routing.',
       },
       enabled: {
         type: 'boolean',

--- a/src/cli/commands/daemon.test.ts
+++ b/src/cli/commands/daemon.test.ts
@@ -27,6 +27,10 @@ vi.mock('../config.js', () => ({
     temperature: 1.0,
     updatePolicy: 'notify',
   })),
+  // Consumed transitively by notify-routing's loadChatAliases() (pulled in via
+  // daemon.ts → resolveNotifyChatTarget). Mock it so alias resolution is
+  // hermetic; overridable per-test with mockLoadTelegramConfig.
+  loadTelegramConfig: vi.fn(() => ({})),
 }));
 
 vi.mock('../../agent/daemon.js', () => ({
@@ -72,8 +76,8 @@ vi.mock('../errors/index.js', () => ({
 
 import { startDaemon } from '../../agent/daemon.js';
 import { pushIfConfigured } from '../../telegram/push.js';
-import { loadConfig } from '../config.js';
-import { formatTaskCompletion, registerDaemonCommand } from './daemon.js';
+import { loadConfig, loadTelegramConfig } from '../config.js';
+import { formatTaskCompletion, registerDaemonCommand, resolveNotifyChatTarget } from './daemon.js';
 import {
   resolveTriggerMode,
   resolveDefaultTask,
@@ -85,6 +89,7 @@ import {
 const mockStartDaemon = vi.mocked(startDaemon);
 const mockLoadConfig = vi.mocked(loadConfig);
 const mockPushIfConfigured = vi.mocked(pushIfConfigured);
+const mockLoadTelegramConfig = vi.mocked(loadTelegramConfig);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -317,6 +322,59 @@ describe('afk daemon (CLI integration)', () => {
       { markdown: true },
     );
   });
+
+  it('routes the completion push to an allowlisted notifyChat via target override', async () => {
+    process.env['AFK_TELEGRAM_ALLOWED_CHAT_IDS'] = '111,-100200';
+    try {
+      await runDaemon();
+      const opts = mockStartDaemon.mock.calls[0]?.[0];
+      opts?.onTaskComplete?.(
+        {
+          taskId: 'grp',
+          command: 'run',
+          trigger: 'cron',
+          triggeredAt: new Date(0).toISOString(),
+          durationMs: 10,
+          status: 'success',
+          responseExcerpt: 'done',
+        },
+        { responseText: 'done', notifyChat: -100200 },
+      );
+      expect(mockPushIfConfigured).toHaveBeenCalledWith(
+        expect.stringContaining('done'),
+        { markdown: true, target: -100200 },
+      );
+    } finally {
+      delete process.env['AFK_TELEGRAM_ALLOWED_CHAT_IDS'];
+    }
+  });
+
+  it('falls back to default routing (no target) when notifyChat is not allowlisted', async () => {
+    process.env['AFK_TELEGRAM_ALLOWED_CHAT_IDS'] = '111';
+    try {
+      await runDaemon();
+      const opts = mockStartDaemon.mock.calls[0]?.[0];
+      opts?.onTaskComplete?.(
+        {
+          taskId: 'grp',
+          command: 'run',
+          trigger: 'cron',
+          triggeredAt: new Date(0).toISOString(),
+          durationMs: 10,
+          status: 'success',
+          responseExcerpt: 'done',
+        },
+        { responseText: 'done', notifyChat: -100999 },
+      );
+      // Not allowlisted → no target key → default routing, byte-identical to legacy.
+      expect(mockPushIfConfigured).toHaveBeenCalledWith(
+        expect.stringContaining('done'),
+        { markdown: true },
+      );
+    } finally {
+      delete process.env['AFK_TELEGRAM_ALLOWED_CHAT_IDS'];
+    }
+  });
 });
 
 describe('formatTaskCompletion — "Done" verification downgrade', () => {
@@ -371,5 +429,65 @@ describe('formatTaskCompletion — "Done" verification downgrade', () => {
       true,
     );
     expect(explicitFalse).not.toContain('unverified');
+  });
+});
+
+describe('resolveNotifyChatTarget', () => {
+  const ENV_KEY = 'AFK_TELEGRAM_ALLOWED_CHAT_IDS';
+  let savedAllowed: string | undefined;
+
+  beforeEach(() => {
+    savedAllowed = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+    mockLoadTelegramConfig.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    if (savedAllowed === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedAllowed;
+    vi.clearAllMocks();
+  });
+
+  it('returns undefined when notifyChat is undefined (default routing)', () => {
+    process.env[ENV_KEY] = '111';
+    expect(resolveNotifyChatTarget(undefined, 't')).toBeUndefined();
+  });
+
+  it('resolves a numeric notifyChat that is allowlisted', () => {
+    process.env[ENV_KEY] = '111,-100200';
+    expect(resolveNotifyChatTarget(-100200, 't')).toBe(-100200);
+  });
+
+  it('resolves a numeric-string notifyChat that is allowlisted', () => {
+    process.env[ENV_KEY] = '111,222';
+    expect(resolveNotifyChatTarget('222', 't')).toBe(222);
+  });
+
+  it('resolves an alias notifyChat that is allowlisted', () => {
+    process.env[ENV_KEY] = '111,-100500';
+    mockLoadTelegramConfig.mockReturnValue({ chatAliases: { ops: -100500 } });
+    expect(resolveNotifyChatTarget('ops', 't')).toBe(-100500);
+  });
+
+  it('FAILS CLOSED: returns undefined for a numeric chat NOT in the allowlist', () => {
+    process.env[ENV_KEY] = '111,222';
+    expect(resolveNotifyChatTarget(999, 't')).toBeUndefined();
+  });
+
+  it('FAILS CLOSED: returns undefined for an alias resolving to a non-allowlisted chat', () => {
+    process.env[ENV_KEY] = '111';
+    mockLoadTelegramConfig.mockReturnValue({ chatAliases: { rogue: -100999 } });
+    expect(resolveNotifyChatTarget('rogue', 't')).toBeUndefined();
+  });
+
+  it('returns undefined for an unresolvable alias (falls back to default)', () => {
+    process.env[ENV_KEY] = '111';
+    mockLoadTelegramConfig.mockReturnValue({ chatAliases: { ops: 111 } });
+    expect(resolveNotifyChatTarget('nope', 't')).toBeUndefined();
+  });
+
+  it('returns undefined when the allowlist is empty (fail-closed)', () => {
+    // no AFK_TELEGRAM_ALLOWED_CHAT_IDS set
+    expect(resolveNotifyChatTarget(123, 't')).toBeUndefined();
   });
 });

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -7,6 +7,8 @@ import os from 'os';
 import { startDaemon } from '../../agent/daemon.js';
 import { getQueueDir } from '../../paths.js';
 import { pushIfConfigured } from '../../telegram/push.js';
+import { resolveChatTarget, loadChatAliases } from '../../telegram/notify-routing.js';
+import { parseAllowedChatIds, isChatAllowed } from '../../telegram/allowlist.js';
 import { parseTerminalState } from './interactive/terminal-state.js';
 import { DONE_EVIDENCE_TOOLS } from './interactive/afk-push.js';
 import type { TaskCompletionDetails, TelemetryRecord } from '../../agent/daemon/scheduler.js';
@@ -287,6 +289,38 @@ const DAEMON_DONE_UNVERIFIED_CAVEAT =
   '⚠️ Unverified: no file write/edit or successful command recorded this turn — confirm before relying on this.';
 
 /**
+ * Resolve a scheduled task's `notifyChat` to a concrete, allowlisted chat id for
+ * the completion push, or `undefined` to fall back to the default notify routing.
+ *
+ * Two-step, both FAIL-CLOSED to the default target (never drops the notification):
+ *   1. Resolve the alias/number via `telegram.chatAliases` (`resolveChatTarget`).
+ *   2. Enforce the inbound allowlist (`isChatAllowed`) — the agent may only push
+ *      to a chat the operator has already authorized.
+ * A resolution or allowlist failure logs one stderr warning (so a misconfigured
+ * notifyChat is visible in daemon logs) and returns `undefined`, letting
+ * `pushIfConfigured` deliver to the configured default instead.
+ */
+export function resolveNotifyChatTarget(
+  notifyChat: number | string | undefined,
+  taskId: string,
+): number | undefined {
+  if (notifyChat === undefined) return undefined;
+  const resolved = resolveChatTarget(notifyChat, loadChatAliases());
+  if (!resolved.ok) {
+    // eslint-disable-next-line no-console
+    console.error(`[daemon] task ${taskId}: ignoring notifyChat — ${resolved.message} Falling back to default routing.`);
+    return undefined;
+  }
+  const allowlist = parseAllowedChatIds(env.AFK_TELEGRAM_ALLOWED_CHAT_IDS);
+  if (!isChatAllowed(resolved.id, allowlist)) {
+    // eslint-disable-next-line no-console
+    console.error(`[daemon] task ${taskId}: ignoring notifyChat ${resolved.id} — not in AFK_TELEGRAM_ALLOWED_CHAT_IDS. Falling back to default routing.`);
+    return undefined;
+  }
+  return resolved.id;
+}
+
+/**
  * Format a daemon telemetry record for an out-of-band notification
  * (e.g. Telegram push). Short, scannable, status-first.
  *
@@ -557,9 +591,17 @@ export function registerDaemonCommand(program: Command): void {
             // showing their literal markers (plain-text fallback on parse error).
             // config.daemon?.verifyDone gates the opt-in Done-verification
             // downgrade; when unset/false the formatted message is unchanged.
+            //
+            // notifyChat routing: when the triggering task set an explicit
+            // notifyChat, resolve it (alias/number) and FAIL-CLOSED against the
+            // allowlist here — the scheduler deliberately doesn't (layering).
+            // A resolvable, allowlisted target overrides the default routing;
+            // anything else logs a warning and falls back to the default target
+            // (never silently drops the completion notification).
+            const target = resolveNotifyChatTarget(details?.notifyChat, record.taskId);
             void pushIfConfigured(
               formatTaskCompletion(record, details, config.daemon?.verifyDone === true),
-              { markdown: true },
+              { markdown: true, ...(target !== undefined ? { target } : {}) },
             ).catch(() => undefined);
           },
         });

--- a/src/cli/config.test.ts
+++ b/src/cli/config.test.ts
@@ -754,6 +754,35 @@ describe('Config Loader', () => {
       mockConfig({ telegram: { tagOnlyChats: [-100123], someFutureKnob: true } });
       expect(loadConfig().telegram?.tagOnlyChats).toEqual([-100123]);
     });
+
+    it('parses telegram.chatAliases as a name→id map', () => {
+      mockConfig({ telegram: { chatAliases: { ops: -1001234567890, me: 42 } } });
+      expect(loadConfig().telegram?.chatAliases).toEqual({ ops: -1001234567890, me: 42 });
+    });
+
+    it('drops non-numeric, non-finite, and zero alias values', () => {
+      mockConfig({
+        telegram: {
+          chatAliases: { ok: 111, bad: 'nope', zero: 0, nan: NaN, nul: null, good: -100200 },
+        },
+      });
+      expect(loadConfig().telegram?.chatAliases).toEqual({ ok: 111, good: -100200 });
+    });
+
+    it('defaults chatAliases to undefined when absent', () => {
+      mockConfig({ telegram: { notify: { mode: 'primary' } } });
+      expect(loadConfig().telegram?.chatAliases).toBeUndefined();
+    });
+
+    it('drops an all-invalid chatAliases map to undefined (no empty object)', () => {
+      mockConfig({ telegram: { chatAliases: { a: 'x', b: 0 } } });
+      expect(loadConfig().telegram?.chatAliases).toBeUndefined();
+    });
+
+    it('ignores a non-object chatAliases (defensive parse → undefined)', () => {
+      mockConfig({ telegram: { chatAliases: [1, 2, 3] } });
+      expect(loadConfig().telegram?.chatAliases).toBeUndefined();
+    });
   });
 
   describe('enforceDoneEvidence (afk.config.json parsing)', () => {

--- a/src/cli/config/json-tier.ts
+++ b/src/cli/config/json-tier.ts
@@ -194,6 +194,23 @@ export function loadJsonConfig(): {
             );
             if (tagOnly.length > 0) telegram.tagOnlyChats = tagOnly;
           }
+          // chatAliases: name → chat-id map. Drop non-numeric, non-finite, and
+          // zero values (0 is the sentinel for "no chat" throughout routing).
+          if (
+            json.telegram.chatAliases &&
+            typeof json.telegram.chatAliases === 'object' &&
+            !Array.isArray(json.telegram.chatAliases)
+          ) {
+            const aliases: Record<string, number> = {};
+            for (const [name, id] of Object.entries(
+              json.telegram.chatAliases as Record<string, unknown>,
+            )) {
+              if (typeof id === 'number' && Number.isFinite(id) && id !== 0) {
+                aliases[name] = id;
+              }
+            }
+            if (Object.keys(aliases).length > 0) telegram.chatAliases = aliases;
+          }
           config.telegram = telegram;
         }
 

--- a/src/cli/config/types.ts
+++ b/src/cli/config/types.ts
@@ -138,6 +138,18 @@ export interface CliConfig {
      * moot. Env override: `AFK_TELEGRAM_TAG_ONLY_CHAT_IDS` (config value wins).
      */
     tagOnlyChats?: number[];
+    /**
+     * Named-chat aliases for outbound targeting. Maps a human-friendly name
+     * (e.g. `"ops"`, `"family"`) to a Telegram chat ID. Consulted when a
+     * caller targets a specific chat by name — the `send_telegram` tool's
+     * `chat` param and a scheduled task's `notifyChat` both accept an alias
+     * from this map in place of a raw numeric ID. Strictly additive: when a
+     * caller omits an explicit target, aliases are never consulted and routing
+     * is unchanged (see `resolveConfiguredNotifyTargets`). An explicitly-targeted
+     * send must still resolve to an allowlisted chat ID (fail-closed) — see
+     * `isChatAllowed` in `src/telegram/allowlist.ts`.
+     */
+    chatAliases?: Record<string, number>;
   };
   /**
    * `afk interactive` defaults.
@@ -349,6 +361,8 @@ export interface ConfigFileSchema {
     verifyDone?: boolean;
     /** Opt-in per-chat "tag-only" response policy. See `CliConfig.telegram.tagOnlyChats`. */
     tagOnlyChats?: number[];
+    /** Named-chat aliases for outbound targeting. See `CliConfig.telegram.chatAliases`. */
+    chatAliases?: Record<string, number>;
   };
   interactive?: {
     worktreeAutoname?: boolean;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -702,10 +702,10 @@ export const ENV_REGISTRY: readonly EnvVarMeta[] = [
   },
   {
     name: 'TELEGRAM_VERBOSE',
-    description: 'Set to 1 to log per-message details from the Telegram bot — chat IDs, message text, latency.',
+    description: "Set to 'true' to log per-message details from the Telegram bot — chat IDs, message text, latency. (The code checks the literal string 'true'.)",
     type: 'boolean',
     required: false,
-    example: '1',
+    example: 'true',
     category: 'telegram',
   },
   {

--- a/src/telegram/allowlist.test.ts
+++ b/src/telegram/allowlist.test.ts
@@ -3,6 +3,7 @@ import type { Context } from 'telegraf';
 import {
   parseAllowedChatIds,
   createAllowlistMiddleware,
+  isChatAllowed,
 } from './allowlist';
 
 function ctxWithChat(id: number | undefined): Context {
@@ -114,6 +115,38 @@ describe('tag-only chat resolution precedence', () => {
 
   test('neither set → empty set (policy applies to no chat)', () => {
     expect(resolveTagOnlyChats(undefined, undefined).size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isChatAllowed — the OUTBOUND allowlist predicate (fail-closed). Used to gate
+// explicitly-targeted send_telegram sends and scheduled-task notifyChat routing.
+// No outbound enforcement existed before this; these tests lock the contract.
+// ---------------------------------------------------------------------------
+
+describe('isChatAllowed (outbound targeting)', () => {
+  test('true when id is a member', () => {
+    expect(isChatAllowed(123, new Set([123, 456]))).toBe(true);
+  });
+
+  test('false when id is not a member', () => {
+    expect(isChatAllowed(999, new Set([123, 456]))).toBe(false);
+  });
+
+  test('fail-closed on an empty allowlist', () => {
+    expect(isChatAllowed(123, new Set())).toBe(false);
+  });
+
+  test('supports negative (group/channel) ids', () => {
+    expect(isChatAllowed(-100987654321, new Set([-100987654321]))).toBe(true);
+    expect(isChatAllowed(-100987654321, new Set([-1]))).toBe(false);
+  });
+
+  test('composes with parseAllowedChatIds end-to-end (outbound gate)', () => {
+    const allowlist = parseAllowedChatIds('111, 222 ,-100333');
+    expect(isChatAllowed(222, allowlist)).toBe(true);
+    expect(isChatAllowed(-100333, allowlist)).toBe(true);
+    expect(isChatAllowed(444, allowlist)).toBe(false);
   });
 });
 

--- a/src/telegram/allowlist.ts
+++ b/src/telegram/allowlist.ts
@@ -38,6 +38,20 @@ export function parseAllowedChatIds(
 }
 
 /**
+ * Fail-closed membership check for outbound targeting. Returns `true` only when
+ * `id` is a member of the allowlist. Mirrors the inbound middleware's contract
+ * (an empty allowlist rejects everything) but is reusable off the Telegraf path
+ * — used to gate EXPLICITLY-targeted `send_telegram` sends and scheduled-task
+ * `notifyChat` routing so the agent can only push to a chat the operator has
+ * already authorized. Note: this does NOT retro-constrain `telegram.notify`
+ * custom-mode broadcast targets (those are intentionally allowlist-independent —
+ * see `resolveNotifyTargets`); it only guards a caller's explicit target.
+ */
+export function isChatAllowed(id: number, allowlist: ReadonlySet<number>): boolean {
+  return allowlist.has(id);
+}
+
+/**
  * Build a Telegraf middleware that drops updates from chat IDs outside the
  * allowlist. Missing `ctx.chat?.id` is also rejected — fail-closed.
  *

--- a/src/telegram/notify-routing.test.ts
+++ b/src/telegram/notify-routing.test.ts
@@ -13,8 +13,11 @@ import {
   parseMode,
   loadNotifyConfig,
   resolveConfiguredNotifyTargets,
+  resolveChatTarget,
+  loadChatAliases,
   type TelegramNotifyConfig,
 } from './notify-routing.js';
+import { isChatAllowed, parseAllowedChatIds } from './allowlist.js';
 import { loadTelegramConfig } from '../cli/config.js';
 
 const mockLoadTelegramConfig = vi.mocked(loadTelegramConfig);
@@ -208,4 +211,122 @@ describe('loadNotifyConfig + resolveConfiguredNotifyTargets (IO)', () => {
 
   const _typecheck: TelegramNotifyConfig = { mode: 'primary' };
   void _typecheck;
+});
+
+describe('resolveChatTarget (pure)', () => {
+  const aliases = { ops: -1001234567890, family: 999, zero: 0 } as Record<string, number>;
+
+  it('accepts a positive numeric chat id verbatim', () => {
+    expect(resolveChatTarget(42)).toEqual({ ok: true, id: 42 });
+  });
+
+  it('accepts a negative numeric chat id (group/channel)', () => {
+    expect(resolveChatTarget(-100200)).toEqual({ ok: true, id: -100200 });
+  });
+
+  it('rejects a zero numeric chat id', () => {
+    const r = resolveChatTarget(0);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('invalid');
+  });
+
+  it('rejects a non-finite numeric chat id', () => {
+    const r = resolveChatTarget(Number.NaN);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('invalid');
+  });
+
+  it('parses a numeric string as a raw chat id', () => {
+    expect(resolveChatTarget('-100987654321')).toEqual({ ok: true, id: -100987654321 });
+  });
+
+  it('parses a whitespace-padded numeric string', () => {
+    expect(resolveChatTarget('  42  ')).toEqual({ ok: true, id: 42 });
+  });
+
+  it('rejects an empty string', () => {
+    const r = resolveChatTarget('   ');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('invalid');
+  });
+
+  it('resolves a known alias name to its chat id', () => {
+    expect(resolveChatTarget('ops', aliases)).toEqual({ ok: true, id: -1001234567890 });
+  });
+
+  it('resolves a positive-id alias', () => {
+    expect(resolveChatTarget('family', aliases)).toEqual({ ok: true, id: 999 });
+  });
+
+  it('rejects an unknown alias and lists available names', () => {
+    const r = resolveChatTarget('nope', aliases);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('unknown-alias');
+      expect(r.message).toMatch(/Unknown chat alias "nope"/);
+      expect(r.message).toMatch(/ops/);
+      expect(r.message).toMatch(/family/);
+    }
+  });
+
+  it('rejects an alias mapped to zero (defensive; treated as unknown)', () => {
+    const r = resolveChatTarget('zero', aliases);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('unknown-alias');
+  });
+
+  it('reports no configured aliases when the map is empty', () => {
+    const r = resolveChatTarget('ops', {});
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toMatch(/No chat aliases are configured/);
+  });
+
+  it('does not treat a numeric-looking value as an alias even if a same-named alias exists', () => {
+    // "999" is numeric → parsed as chat id 999, NOT looked up as alias name.
+    expect(resolveChatTarget('999', { '999': -1 })).toEqual({ ok: true, id: 999 });
+  });
+});
+
+describe('isChatAllowed (pure)', () => {
+  it('returns true for a member of the allowlist', () => {
+    expect(isChatAllowed(123, new Set([123, 456]))).toBe(true);
+  });
+
+  it('returns false for a non-member', () => {
+    expect(isChatAllowed(789, new Set([123, 456]))).toBe(false);
+  });
+
+  it('fails closed on an empty allowlist', () => {
+    expect(isChatAllowed(123, new Set())).toBe(false);
+  });
+
+  it('handles negative (group/channel) ids', () => {
+    expect(isChatAllowed(-100200, new Set([-100200]))).toBe(true);
+    expect(isChatAllowed(-100200, new Set([-100999]))).toBe(false);
+  });
+
+  it('composes with parseAllowedChatIds end-to-end', () => {
+    const allowlist = parseAllowedChatIds('111, 222 ,-100333');
+    expect(isChatAllowed(222, allowlist)).toBe(true);
+    expect(isChatAllowed(-100333, allowlist)).toBe(true);
+    expect(isChatAllowed(444, allowlist)).toBe(false);
+  });
+});
+
+describe('loadChatAliases (IO)', () => {
+  beforeEach(() => {
+    mockLoadTelegramConfig.mockReturnValue({});
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns {} when no aliases are configured', () => {
+    expect(loadChatAliases()).toEqual({});
+  });
+
+  it('returns the configured alias map', () => {
+    mockLoadTelegramConfig.mockReturnValue({ chatAliases: { ops: -100123, me: 42 } });
+    expect(loadChatAliases()).toEqual({ ops: -100123, me: 42 });
+  });
 });

--- a/src/telegram/notify-routing.ts
+++ b/src/telegram/notify-routing.ts
@@ -86,6 +86,69 @@ export function resolveNotifyTargets(
   return primary !== undefined ? [primary] : [];
 }
 
+/**
+ * Result of resolving an explicit chat target (`send_telegram`'s `chat` param
+ * or a scheduled task's `notifyChat`). Discriminated on `ok` so callers can
+ * surface a precise, actionable error instead of silently dropping the send.
+ */
+export type ChatTargetResolution =
+  | { ok: true; id: number }
+  | { ok: false; reason: 'invalid' | 'unknown-alias'; message: string };
+
+/**
+ * Resolve an explicit chat target to a numeric chat id.
+ *
+ * - `number` → used verbatim (must be finite and non-zero).
+ * - numeric string (`"-100123"`, `" 42 "`) → parsed as a chat id.
+ * - any other string → looked up as a NAME in `aliases`
+ *   (`telegram.chatAliases`), returning the mapped id or an `unknown-alias`
+ *   error that lists the available names.
+ *
+ * Pure — never reads env or files. Allowlist enforcement is a SEPARATE step the
+ * caller applies (`isChatAllowed`); this function only turns a name/number into
+ * an id (or a typed error).
+ */
+export function resolveChatTarget(
+  chat: number | string,
+  aliases: Readonly<Record<string, number>> = {},
+): ChatTargetResolution {
+  if (typeof chat === 'number') {
+    if (!Number.isFinite(chat) || chat === 0) {
+      return { ok: false, reason: 'invalid', message: `Invalid chat id: ${chat}` };
+    }
+    return { ok: true, id: chat };
+  }
+
+  const trimmed = chat.trim();
+  if (trimmed.length === 0) {
+    return { ok: false, reason: 'invalid', message: 'Invalid chat: empty string' };
+  }
+
+  // A numeric string is a raw chat id; anything else is an alias NAME.
+  const asId = parseChatId(trimmed);
+  if (asId !== undefined) {
+    return { ok: true, id: asId };
+  }
+
+  const aliasNames = Object.keys(aliases);
+  const mapped = Object.prototype.hasOwnProperty.call(aliases, trimmed)
+    ? aliases[trimmed]
+    : undefined;
+  if (mapped !== undefined && Number.isFinite(mapped) && mapped !== 0) {
+    return { ok: true, id: mapped };
+  }
+
+  const available =
+    aliasNames.length > 0
+      ? `Available aliases: ${aliasNames.join(', ')}.`
+      : 'No chat aliases are configured (set telegram.chatAliases in afk.config.json).';
+  return {
+    ok: false,
+    reason: 'unknown-alias',
+    message: `Unknown chat alias "${trimmed}". ${available}`,
+  };
+}
+
 /** Parse a single chat id from an env string. Returns undefined when absent/invalid. */
 export function parseChatId(raw: string | undefined): number | undefined {
   if (!raw) return undefined;
@@ -126,4 +189,14 @@ export function loadNotifyConfig(): TelegramNotifyConfig {
 export function resolveConfiguredNotifyTargets(): number[] {
   const allowlist = parseAllowedChatIds(env.AFK_TELEGRAM_ALLOWED_CHAT_IDS);
   return resolveNotifyTargets(allowlist, loadNotifyConfig());
+}
+
+/**
+ * IO convenience: read the named-chat alias map (`telegram.chatAliases`) from
+ * afk.config.json. Returns `{}` when unset. Consumed by the `send_telegram`
+ * handler and the daemon's `notifyChat` resolution to turn an alias name into a
+ * chat id via {@link resolveChatTarget}.
+ */
+export function loadChatAliases(): Record<string, number> {
+  return loadTelegramConfig().chatAliases ?? {};
 }

--- a/src/telegram/push.test.ts
+++ b/src/telegram/push.test.ts
@@ -385,4 +385,45 @@ describe('pushIfConfigured', () => {
       }
     }
   });
+
+  test('target override routes to the explicit chat, ignoring notify config', async () => {
+    process.env['TELEGRAM_BOT_TOKEN'] = 't';
+    // Broadcast would normally fan out to all three; target overrides that.
+    process.env['AFK_TELEGRAM_ALLOWED_CHAT_IDS'] = '111,222,333';
+    process.env['AFK_TELEGRAM_NOTIFY_MODE'] = 'broadcast';
+    const fetchImpl = makeFetchOk();
+    const result = await pushIfConfigured('hi', { fetchImpl, target: -100999 });
+    expect(result).toHaveLength(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(JSON.parse((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1].body).chat_id).toBe(-100999);
+  });
+
+  test('target override accepts an array of chat ids', async () => {
+    process.env['TELEGRAM_BOT_TOKEN'] = 't';
+    process.env['AFK_TELEGRAM_ALLOWED_CHAT_IDS'] = '111';
+    const fetchImpl = makeFetchOk();
+    const result = await pushIfConfigured('hi', { fetchImpl, target: [222, 333] });
+    expect(result).toHaveLength(2);
+    const calls = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.map((c) => JSON.parse(c[1].body).chat_id)).toEqual([222, 333]);
+  });
+
+  test('empty/invalid target falls back to default notify routing', async () => {
+    process.env['TELEGRAM_BOT_TOKEN'] = 't';
+    process.env['AFK_TELEGRAM_ALLOWED_CHAT_IDS'] = '111';
+    const fetchImpl = makeFetchOk();
+    // 0 is filtered out → override empty → fall back to primary (111).
+    const result = await pushIfConfigured('hi', { fetchImpl, target: 0 });
+    expect(result).toHaveLength(1);
+    expect(JSON.parse((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1].body).chat_id).toBe(111);
+  });
+
+  test('omitted target preserves default routing (byte-identical to legacy)', async () => {
+    process.env['TELEGRAM_BOT_TOKEN'] = 't';
+    process.env['AFK_TELEGRAM_ALLOWED_CHAT_IDS'] = '111,222,333';
+    process.env['AFK_TELEGRAM_NOTIFY_MODE'] = 'broadcast';
+    const fetchImpl = makeFetchOk();
+    const result = await pushIfConfigured('hi', { fetchImpl });
+    expect(result).toHaveLength(3);
+  });
 });

--- a/src/telegram/push.ts
+++ b/src/telegram/push.ts
@@ -171,11 +171,27 @@ export async function pushIfConfigured(
     markdown?: boolean;
     replyMarkup?: PushOptions['replyMarkup'];
     fetchImpl?: typeof fetch;
+    /**
+     * Explicit delivery target(s) that OVERRIDE the configured notify routing.
+     * When provided (and non-empty), the push goes to exactly these chat ids
+     * instead of `resolveConfiguredNotifyTargets()`. Callers are responsible for
+     * having already resolved aliases and enforced the allowlist (fail-closed) —
+     * `pushIfConfigured` does not re-validate. Used by the daemon to route a
+     * scheduled task's completion push to its `notifyChat`. Omit/empty for
+     * default routing (unchanged behavior).
+     */
+    target?: number | readonly number[];
   } = {},
 ): Promise<PushResult[] | null> {
   const token = env.TELEGRAM_BOT_TOKEN;
   if (!token) return null;
-  const chatIds = resolveConfiguredNotifyTargets();
+  const override =
+    opts.target === undefined
+      ? []
+      : (typeof opts.target === 'number' ? [opts.target] : [...opts.target]).filter(
+          (id) => Number.isFinite(id) && id !== 0,
+        );
+  const chatIds = override.length > 0 ? override : resolveConfiguredNotifyTargets();
   if (chatIds.length === 0) return null;
 
   // Split the RAW markdown first, then render each chunk — splitting already


### PR DESCRIPTION
## What & why

Today `send_telegram` always routes to the default notify target (the operator's DM) via `resolveConfiguredNotifyTargets()` — there is no way to pick a specific chat or group, and scheduled daemon tasks can only choose *whether* to notify (`notifyOn`), never *where*. This PR adds **per-target chat selection** to both surfaces, plus **named-chat aliases**, with **fail-closed allowlist enforcement** on every explicitly-targeted send.

Motivating uses: page an on-call *group* from a scheduled health check, DM a specific person, or route different tasks to different chats — without changing the global notify routing.

## Design decisions

- **`chat` param + alias resolution.** `send_telegram` gains an optional `chat` accepting a `number` (raw chat id), a numeric string, or a **non-numeric alias name** resolved against a new `telegram.chatAliases` config map. Resolution is a single pure function `resolveChatTarget(chat, aliases)` (in `notify-routing.ts`) returning a discriminated `{ ok: true, id } | { ok: false, reason, message }`; an unresolvable alias returns an error that **lists the available alias names**. A numeric-looking string is always parsed as an id (never looked up as an alias), so `"999"` means chat 999.

- **Allowlist fail-closed.** New reusable predicate `isChatAllowed(id, allowlist)` (in `allowlist.ts` — the inbound gate's home, but off the Telegraf path). **Any explicitly-targeted send must resolve to an allowlisted chat id**; a non-allowlisted target is rejected with a clear `isError` message naming the allowed ids. This gate applies **only** to explicit targets — `telegram.notify` custom-mode broadcast targets keep their intentional allowlist-independence (unchanged).

- **Backward compatibility.** When `chat` is omitted, the handler takes the exact prior path (`resolveConfiguredNotifyTargets()`) — byte-identical behavior. `chatAliases` is strictly additive / default-absent; when no caller targets a chat, aliases are never consulted.

- **`notifyChat` threading (scheduled tasks).** New optional `notifyChat?: number | string` on `ScheduledTaskConfig` + `ScheduledTask`, threaded end-to-end: `create_schedule` tool schema → handler → `addSchedule` (persistence) → daemon `POST /tasks` payload → daemon HTTP body parse → `ScheduledTask` → `toScheduledTask` (boot-time load). At completion, the scheduler copies `task.notifyChat` onto `TaskCompletionDetails` in the single `fireOnTaskComplete` funnel (covering success **and** error paths) — deliberately **not** resolving it there, to preserve the `src/agent/` → no-`src/cli/`-import layering invariant. The CLI `onTaskComplete` callback resolves + allowlist-gates it (`resolveNotifyChatTarget`) and routes via a widened `pushIfConfigured({ target })`. A non-allowlisted or unresolvable `notifyChat` logs a warning and **falls back to default routing** — the completion notification is never silently dropped.

- **`TELEGRAM_VERBOSE` doc fix.** The code checks `env.TELEGRAM_VERBOSE === 'true'` but the `ENV_REGISTRY` entry said "Set to 1" with `example: '1'`. Fixed the registry description + example to `'true'` (and regenerated `docs/env-registry.{json,md}`). **Code unchanged** — flipping the check would break anyone already exporting `'true'`. (`src/telegram/README.md:111` already said `true`, so it needed no change.)

## Files changed (24)

**Source (12)**
- `src/agent/tools/schemas.ts` — `send_telegram` `chat` param + `create_schedule` `notifyChat` param (+ docs)
- `src/agent/tools/handlers/send-telegram.ts` — `chat` validation, alias resolution, fail-closed allowlist gate
- `src/agent/tools/handlers/schedules.ts` — `notifyChat` validation + thread into `addSchedule` and daemon payload
- `src/telegram/notify-routing.ts` — `resolveChatTarget`, `ChatTargetResolution`, `loadChatAliases`
- `src/telegram/allowlist.ts` — `isChatAllowed` outbound predicate
- `src/telegram/push.ts` — `pushIfConfigured` `target` override
- `src/agent/daemon/triggers.ts` — `ScheduledTask.notifyChat`
- `src/agent/daemon/schedule-store.ts` — `ScheduledTaskConfig.notifyChat` + `toScheduledTask` threading
- `src/agent/daemon/scheduler.ts` — `TaskCompletionDetails.notifyChat` + thread from task in `fireOnTaskComplete`
- `src/agent/daemon.ts` — parse `notifyChat` in `POST /tasks`
- `src/cli/commands/daemon.ts` — `resolveNotifyChatTarget` + wire `target` into the completion push
- `src/cli/config/types.ts` — `chatAliases` on `CliConfig.telegram` + `ConfigFileSchema.telegram`
- `src/cli/config/json-tier.ts` — defensive parse of `chatAliases`
- `src/config/env.ts` — `TELEGRAM_VERBOSE` doc fix

**Tests (8)**: `send-telegram.test.ts`, `notify-routing.test.ts`, `allowlist.test.ts`, `push.test.ts`, `schedule-store.test.ts`, `daemon.test.ts` (agent), `daemon.test.ts` (cli/commands), `config.test.ts`

**Generated docs (2)**: `docs/env-registry.json`, `docs/env-registry.md`

## Test evidence

All gates green:

```
pnpm lint            → tsc --noEmit (maximally strict): PASS
pnpm build           → tsc && copy-prompts: PASS
pnpm test            → Test Files 692 passed (692)
                       Tests 12879 passed | 14 skipped (12893)
pnpm scan:env:check  → docs/env-registry.{json,md} in sync (137 vars)
pnpm audit:env:check → 686 files scanned, 0 violations
pnpm audit:sdk:check → OK. Lock matches current imports.
```

New/extended coverage includes: `chat` = numeric / numeric-string / alias / unresolvable-alias / non-allowlisted-rejected / omitted-default; `resolveChatTarget` + `isChatAllowed` + `loadChatAliases`; the outbound-allowlist predicate (none existed before); `pushIfConfigured` target override (single/array/empty-fallback/omitted); `notifyChat` round-trips through `addSchedule`/`toScheduledTask`/`POST /tasks`; scheduler threading of `notifyChat` onto `TaskCompletionDetails` (success + error); `resolveNotifyChatTarget` fail-closed cases; and an e2e `onTaskComplete` → `pushIfConfigured({ target })` routing assertion.

## How to use

**1) `send_telegram` with a chat alias**

Add aliases to `afk.config.json` (the chat ids must also be in `AFK_TELEGRAM_ALLOWED_CHAT_IDS`):

```json
{
  "telegram": {
    "chatAliases": { "ops": -1001234567890, "me": 123456789 }
  }
}
```

Then target by name (or raw id):

```json
{ "message": "🚨 Prod deploy failed — see CI", "chat": "ops" }
```

- `chat: "ops"` → resolves to `-1001234567890`.
- `chat: -1001234567890` or `chat: "-1001234567890"` → same, verbatim id.
- Omit `chat` → unchanged default routing (primary DM / notify targets).
- A non-allowlisted target or unknown alias returns `isError: true` (the error lists the available alias names / allowed ids).

**2) `create_schedule` with `notifyChat` targeting a group**

```json
{
  "name": "Nightly health check",
  "command": "/health-check --auto",
  "cron": "0 3 * * *",
  "notifyOn": "always",
  "notifyChat": "ops"
}
```

The daemon delivers **this task's** completion push to the `ops` group (must be allowlisted) instead of the default target. `notifyChat` also accepts a raw id (`-1001234567890`). Omit it for default routing. If the resolved chat is not allowlisted, the daemon logs a warning and falls back to the default target (the notification is never dropped). `notifyOn` still controls *whether* to notify; `notifyChat` controls *where*.
