### PR TITLE
refactor(cli): /simplify wins for the terminal-compositor pair (#682)

### DIFF
--- a/src/cli/terminal-compositor.input-dispatch.ts
+++ b/src/cli/terminal-compositor.input-dispatch.ts
@@ -836,18 +836,49 @@ function handleEnter(self: KeyDispatchHost, key: KeyInfo, sequence: string): boo
   return true;
 }
 
+/**
+ * The buffer-edit commit contract shared by the "transform, commit only if it
+ * changed" bindings (meta word-delete, Ctrl+W/U/K kills): apply a pure
+ * InputCore transition only when it actually changes the buffer, resetting
+ * history recall FIRST on a real edit (the convention documented in
+ * handleCursorAndEdit). Returns `true` so a handled binding can tail-call it
+ * as `return commitIfChanged(self, InputCore.x(self.input))`.
+ */
+function commitIfChanged(self: KeyDispatchHost, next: InputCoreState): true {
+  if (next !== self.input) {
+    self.history?.resetRecall();
+    self.applyEdit(next);
+  }
+  return true;
+}
+
+/**
+ * Atomic paste-placeholder delete shared by Backspace (backward) and Delete
+ * (forward): when the cursor abuts a `[Pasted text #N +M lines]` token, the
+ * whole token (and its side-table entry) is removed in one keystroke. Returns
+ * `true` when a token was consumed (caller stops), `false` to fall through to
+ * the normal character delete.
+ */
+function applyAtomicPlaceholderDelete(
+  self: KeyDispatchHost,
+  direction: 'backward' | 'forward',
+): boolean {
+  const atomic = Paste.maybeAtomicPlaceholderDelete(self, direction);
+  if (atomic) {
+    self.history?.resetRecall();
+    self.applyEdit(atomic);
+    return true;
+  }
+  return false;
+}
+
 function handleBackspace(self: KeyDispatchHost, key: KeyInfo): boolean {
   if (key?.name !== 'backspace') return false;
   // Option+Delete on macOS → meta+backspace: delete previous word.
   // Mirrors reader.ts:677 so word-erase is consistent across both
   // input surfaces.
   if (key?.meta) {
-    const next = InputCore.deleteWordBackward(self.input);
-    if (next !== self.input) {
-      self.history?.resetRecall();
-      self.applyEdit(next);
-    }
-    return true;
+    return commitIfChanged(self, InputCore.deleteWordBackward(self.input));
   }
   // Atomic placeholder delete — when the cursor sits at the
   // trailing `]` of a `[Pasted text #N +M lines]` token, single
@@ -855,12 +886,7 @@ function handleBackspace(self: KeyDispatchHost, key: KeyInfo): boolean {
   // entry). Without this, deleting a freshly-pasted blob requires
   // ~30 backspaces. Run BEFORE the InputCore.backspace fallback
   // so the atomic path wins when both would fire.
-  const atomic = Paste.maybeAtomicPlaceholderDelete(self, 'backward');
-  if (atomic) {
-    self.history?.resetRecall();
-    self.applyEdit(atomic);
-    return true;
-  }
+  if (applyAtomicPlaceholderDelete(self, 'backward')) return true;
   const next = InputCore.backspace(self.input);
   if (next !== self.input) {
     self.history?.resetRecall();
@@ -941,35 +967,20 @@ function handleCursorAndEdit(self: KeyDispatchHost, key: KeyInfo): boolean {
 
   // Ctrl+W → delete word backward (readline `backward-kill-word`).
   if (key?.ctrl && key?.name === 'w') {
-    const next = InputCore.deleteWordBackward(self.input);
-    if (next !== self.input) {
-      self.history?.resetRecall();
-      self.applyEdit(next);
-    }
-    return true;
+    return commitIfChanged(self, InputCore.deleteWordBackward(self.input));
   }
 
   // Ctrl+U → delete from cursor to start of current line
   // (readline `backward-kill-line`). Also fires on Cmd+Delete in
   // iTerm2 profiles that remap it to ^U.
   if (key?.ctrl && key?.name === 'u') {
-    const next = InputCore.deleteToLineStart(self.input);
-    if (next !== self.input) {
-      self.history?.resetRecall();
-      self.applyEdit(next);
-    }
-    return true;
+    return commitIfChanged(self, InputCore.deleteToLineStart(self.input));
   }
 
   // Ctrl+K → delete from cursor to end of current line
   // (readline `kill-line`). Symmetric counterpart to Ctrl+U.
   if (key?.ctrl && key?.name === 'k') {
-    const next = InputCore.deleteToLineEnd(self.input);
-    if (next !== self.input) {
-      self.history?.resetRecall();
-      self.applyEdit(next);
-    }
-    return true;
+    return commitIfChanged(self, InputCore.deleteToLineEnd(self.input));
   }
 
   // Ctrl+L → clear screen and repaint the live frame.
@@ -1041,23 +1052,13 @@ function handleCursorAndEdit(self: KeyDispatchHost, key: KeyInfo): boolean {
   if (key?.name === 'delete') {
     // Option+Fn-Delete → meta+delete: delete next word.
     if (key?.meta) {
-      const next = InputCore.deleteWordForward(self.input);
-      if (next !== self.input) {
-        self.history?.resetRecall();
-        self.applyEdit(next);
-      }
-      return true;
+      return commitIfChanged(self, InputCore.deleteWordForward(self.input));
     }
     // Atomic placeholder delete (forward) — symmetric counterpart
     // to the backspace branch above. When the cursor sits at the
     // leading `[` of a placeholder, Delete removes the whole
     // token.
-    const atomic = Paste.maybeAtomicPlaceholderDelete(self, 'forward');
-    if (atomic) {
-      self.history?.resetRecall();
-      self.applyEdit(atomic);
-      return true;
-    }
+    if (applyAtomicPlaceholderDelete(self, 'forward')) return true;
     self.history?.resetRecall();
     self.applyEdit(InputCore.deleteForward(self.input));
     return true;

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -656,16 +656,6 @@ export class TerminalCompositor {
   }
 
   /**
-   * Install or clear the soft-stop handler — see
-   * {@link TerminalCompositorOptions.onSoftStop}. Wired once at REPL
-   * startup via InputSurface.armCompositor; no per-turn swap needed
-   * because the once-only `softStopped` guard handles idempotency.
-   */
-  setOnSoftStop(handler: (() => void) | null): void {
-    this.onSoftStop = handler ?? undefined;
-  }
-
-  /**
    * Install or clear the background handler — see
    * {@link TerminalCompositorOptions.onBackground}. Typically cleared
    * in idle mode (Ctrl+B has no meaningful between-turn semantics).
@@ -681,16 +671,6 @@ export class TerminalCompositor {
    */
   setOnRewindRequest(handler: (() => void) | null): void {
     this.onRewindRequest = handler ?? undefined;
-  }
-
-  /**
-   * Install or clear the Shift+Tab handler — see
-   * {@link TerminalCompositorOptions.onShiftTab}. The persistent
-   * InputSurface typically installs this once at REPL start (the
-   * plan-mode toggle is REPL-global, not per-turn).
-   */
-  setOnShiftTab(handler: (() => void) | null): void {
-    this.onShiftTab = handler ?? undefined;
   }
 
   /**


### PR DESCRIPTION
## What this does

Addresses #682 — a gated `/simplify` reduction pass over the TUI terminal-compositor pair
(`terminal-compositor.ts` + `terminal-compositor.input-dispatch.ts`). Two behavior-preserving commits:

1. **Centralize the "commit-if-changed" edit contract** in `input-dispatch.ts`. The idiom
   *"apply a pure `InputCore` transition only when it changes the buffer, resetting history recall
   first on a real edit"* was hand-repeated at 5 key bindings (meta+Backspace, Ctrl+W/U/K,
   meta+Delete); the atomic paste-placeholder-delete guard at 2 more (Backspace/Delete). Extracted
   two named helpers — `commitIfChanged()` and `applyAtomicPlaceholderDelete()` — following the
   file's existing free-functions-on-host pattern. Each call site is a 1:1 substitution.
2. **Remove two dead setters** `setOnSoftStop` / `setOnShiftTab`. Both have zero call sites in the
   tree and zero in all git history (pickaxe). The underlying handlers are wired via the
   constructor (`opts.onSoftStop` / `opts.onShiftTab`), so soft-stop and Shift+Tab behavior is
   unchanged — only the never-used redundant post-construction mutators are gone.

**This is not a LOC reduction** (verbose house-style JSDoc on the helpers offsets the call-site
savings). The win is *contract centralization*: the resetRecall-before-edit invariant now lives in
one named place a new binding can't silently forget.

## Why the PR is small (the honest finding)

The issue framed the pair as "~2.2k LOC ... a classic home for accreted special-cases." A four-lens
read-only pass (duplication / dead-code / complexity / wrong-abstraction) found that **the large
structural win the issue imagined has already happened**: the compositor is decomposed into ~15
sibling modules — render/frame/scrollback-eviction live in `terminal-compositor.frame.ts`,
`.committed-band-commit.ts`, `.render.ts`, etc. `terminal-compositor.ts` is the state-hub/delegator,
`input-dispatch.ts` the keystroke dispatcher; both are **mostly essential complexity**.

Three lenses independently returned "essential — do not touch" for the biggest functions
(`handleEnter`, `handleCursorAndEdit`, `handleVerticalNav` — all carry explicit anti-refactor
invariants encoding regressions #403/#467/#644). The net clear-win surface was only what this PR
lands. Two corollaries worth recording:

- The old `afk/split-compositor-frame-render` branch is **dead** (far behind main; its split already
  landed differently) — no collision.
- **`size ≠ complexity` held up**: the remaining LOC is largely earned. Consider updating #682 to
  reflect that the big structural target is already addressed.

## Deliberately deferred (NOT in this PR)

- **`setOnBackground` — possible latent bug, not deleted.** It's also uncalled, but its JSDoc *and*
  `src/cli/input/input-surface.ts:131` both claim a per-turn swap happens "via `setOnBackground`"
  that no code performs. That's a possible wiring gap (idle-mode Ctrl+B background handler not
  cleared between turns), not clean dead code — flagged for a separate `/diagnose` rather than
  silently removed. Good follow-up issue candidate.
- **Tier 2 structural extractions** (`handleEscape` double-Esc block, `handleEnter` guard phases) —
  adjacent to the #403/#467/#644 regression lineage, ~0 net LOC, real risk. Not worth it.

## Verification

- `pnpm lint` (tsc --noEmit, strict) — clean.
- **Full suite: 692 files, 12,879 passed, 14 skipped, 0 failures** — including the compositor tests
  that directly exercise this change: `word-nav` (asserts per-binding `resetRecall` counts),
  `keypress`, `paste`.
- Each commit is independently reviewable/revertable; behavior-preserving throughout.

Closes nothing automatically — leaving #682 open for the maintainer to close or to retarget at the
`setOnBackground` follow-up.
