### PR TITLE
refactor(cli): drop dead setOnBackground + fix stale doc (closes #682)

### DIFF
--- a/src/cli/input/input-surface.ts
+++ b/src/cli/input/input-surface.ts
@@ -128,7 +128,9 @@ export interface InputSurfaceRefs {
 /**
  * Options for {@link InputSurface.armCompositor} — arms a persistent
  * TerminalCompositor that lives across turns. Stable refs (set once
- * at arm time); per-turn callbacks are swapped via setOnBackground.
+ * at arm time); per-turn callbacks are swapped via setBackgroundHandler
+ * (which mutates the backgroundHandler ref the arm-time onBackground
+ * closure dereferences — see line ~330).
  */
 export interface InputSurfaceArmOpts {
   /**

--- a/src/cli/terminal-compositor.ts
+++ b/src/cli/terminal-compositor.ts
@@ -656,15 +656,6 @@ export class TerminalCompositor {
   }
 
   /**
-   * Install or clear the background handler — see
-   * {@link TerminalCompositorOptions.onBackground}. Typically cleared
-   * in idle mode (Ctrl+B has no meaningful between-turn semantics).
-   */
-  setOnBackground(handler: (() => void) | null): void {
-    this.onBackground = handler ?? undefined;
-  }
-
-  /**
    * Install or clear the double-Esc rewind handler (the "edit a previous
    * message" trigger). Wired once by the persistent InputSurface at REPL arm
    * time; fired from `handleEscape` on a double-Esc at an empty idle prompt.


### PR DESCRIPTION
## What

Completes the final `/simplify` win that #684 (`afd3eda`) **deliberately deferred**, closing out #682. Behavior-preserving.

- **Remove the dead `setOnBackground` setter** (`terminal-compositor.ts`) — zero call sites in the tree, zero in git history. Parallel to the `setOnSoftStop`/`setOnShiftTab` removal #684 already did. The `onBackground` field, its constructor wiring, and the `input-dispatch.ts:1078` consumer are untouched.
- **Fix a stale JSDoc** (`input-surface.ts:131`) that named `setOnBackground` as the per-turn swap mechanism.

## Why this is safe (the "latent wiring bug" #684 flagged is resolved)

#684 left `setOnBackground` in place because its JSDoc — and `input-surface.ts:131` — claimed *"per-turn callbacks are swapped via setOnBackground,"* which no code actually does, raising the question of whether per-turn background swapping was silently broken.

Investigated → **not a bug.** Per-turn background swapping is wired via a different, working path:

- `setBackgroundHandler` (`input-surface.ts:411`) mutates the `backgroundHandler` ref;
- the compositor holds a **stable** arm-time closure `onBackground: () => this.backgroundHandler?.()` (`input-surface.ts:332`, comment at `:330`) that dereferences the current ref on each call;
- `turn-handler.ts` sets it at turn start (`:330-331`) and clears it at turn end (`:846`), via `loop-iteration.ts:694`;
- there's even a dedicated test (`input-surface.test.ts:182`).

So `setOnBackground` is redundant dead code and the doc line was simply stale — no functional bug.

## Context

The bulk of #682's gated `/simplify` pass already shipped in **#684** (`afd3eda`): contract centralization (`commitIfChanged`/`applyAtomicPlaceholderDelete`) + dead-setter removal. A fresh survey of the pair found the reducible surface otherwise exhausted — `terminal-compositor.ts` is a thin orchestrator (mostly one-line delegators) and the input-dispatch complexity is essential terminal-edge-case handling pinned by the 4 `*.repro.test.ts` files. The only other candidates (a clipboard-probe dedup and a submit-reset dedup) carry subtle behavioral asymmetries and were **discarded** per the issue's own "don't trade incidental complexity for a wrong abstraction" rule. This dead-code + doc cleanup is the last clean win.

## Verification

- `pnpm lint` clean (`tsc --noEmit`).
- `pnpm test src/cli/terminal-compositor src/cli/input/input-surface.test.ts` → **48 files, 391 tests green.**

Net: −7 LOC.

Closes #682.
